### PR TITLE
fix: resolve 7 Phase 2 tech-debt items before Phase 3

### DIFF
--- a/specs/feat/001-phase2-runtime-cells/tech-debt.md
+++ b/specs/feat/001-phase2-runtime-cells/tech-debt.md
@@ -102,9 +102,11 @@
 | 76 | [TECH] | C-P1 | mapCodeToStatus 用 strings.Contains 匹配 — 顺序敏感、歧义 | Phase 3 |
 | 77 | [TECH] | C-P2 | WriteJSON 忽略 json.Encode 错误 | Phase 3 |
 | 78 | [TECH] | C-P3 | CLI exit code 不区分（usage error / validation error 都是 1） | Phase 3 |
+| 79 | [TECH] | PR#4-A1 | cells/ 层 service.go 约 15 处 fmt.Errorf 跨边界暴露非结构化错误（sessionlogin 4 处、sessionrefresh 3 处、sessionlogout 2 处、identitymanage 2 处、configwrite 2 处、configpublish 2 处），应改为 errcode.Wrap。#27 仅修了 kernel/，cells/ 同类问题未清理 | Phase 3 |
+| 80 | [TECH] | PR#4-D2 | bootstrap config reload 仅更新 cfg 对象，不传播到 assembly/cells — Run() 在启动时将 cfg 快照为 cfgMap 传给 asm.StartWithConfig()，之后 watcher 触发的 Reload 只更新 cfg，cells 仍用初始快照值。完整链路（cfg 变更→通知 cells→cells 重读）属 J-config-hot-reload journey 范围 | Phase 3 |
 
 ## 统计
-- [TECH] 新增: 23 条 (S6) + 49 条 (review-031) = 72 条
+- [TECH] 新增: 23 条 (S6) + 49 条 (review-031) + 2 条 (PR#4 review) = 74 条
 - [PRODUCT] 新增: 3 条 (S6) + 1 条 (review-031) = 4 条
 - 本 PR 已修复: 路由 404 + logout persist + INVALID_TOKEN 映射 + JWT key 校验 + workerErrCh + ServiceToken nil secret
 - 上一 Phase 遗留已解决: 0 条（首次启用工作流）

--- a/src/cells/access-core/cell.go
+++ b/src/cells/access-core/cell.go
@@ -141,6 +141,9 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if len(c.signingKey) == 0 {
 		return errcode.New("ERR_AUTH_MISSING_KEY", "JWT signing key is required")
 	}
+	if len(c.signingKey) < 32 {
+		return errcode.New("ERR_AUTH_MISSING_KEY", "JWT signing key must be at least 32 bytes")
+	}
 
 	// identity-manage
 	identitySvc := identitymanage.NewService(c.userRepo, c.sessionRepo, c.publisher, c.logger)

--- a/src/cells/access-core/slices/identitymanage/handler_test.go
+++ b/src/cells/access-core/slices/identitymanage/handler_test.go
@@ -1,0 +1,107 @@
+package identitymanage
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+)
+
+func setup() http.Handler {
+	svc := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default())
+	return NewHandler(svc).Routes()
+}
+
+func TestHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		wantStatus int
+		checkBody  func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "POST / valid user returns 201",
+			method:     http.MethodPost,
+			path:       "/",
+			body:       `{"username":"alice","email":"a@b.com","password":"secret123"}`,
+			wantStatus: http.StatusCreated,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp map[string]json.RawMessage
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.Contains(t, string(resp["data"]), "alice")
+			},
+		},
+		{
+			name:       "POST / invalid body returns 400",
+			method:     http.MethodPost,
+			path:       "/",
+			body:       `{bad json`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "GET /{id} nonexistent returns 404",
+			method:     http.MethodGet,
+			path:       "/no-such-id",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := setup()
+			var req *http.Request
+			if tc.body != "" {
+				req = httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			} else {
+				req = httptest.NewRequest(tc.method, tc.path, nil)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.checkBody != nil {
+				tc.checkBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestHandler_CreateThenGetThenDelete(t *testing.T) {
+	r := setup()
+
+	// Create
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"bob","email":"b@c.com","password":"pass1234"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var created struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	id := created.Data.ID
+	require.NotEmpty(t, id)
+
+	// Get
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/"+id, nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Delete
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/"+id, nil))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}

--- a/src/cells/access-core/slices/identitymanage/service.go
+++ b/src/cells/access-core/slices/identitymanage/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/id"
 )
 
 const (
@@ -60,7 +61,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.User, 
 		return nil, err
 	}
 
-	user.ID = fmt.Sprintf("usr-%d", time.Now().UnixNano())
+	user.ID = id.New("usr")
 
 	if err := s.repo.Create(ctx, user); err != nil {
 		return nil, fmt.Errorf("identity-manage: create: %w", err)

--- a/src/cells/access-core/slices/rbaccheck/handler_test.go
+++ b/src/cells/access-core/slices/rbaccheck/handler_test.go
@@ -1,0 +1,100 @@
+package rbaccheck
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+)
+
+func setup() http.Handler {
+	roleRepo := mem.NewRoleRepository()
+	roleRepo.SeedRole(&domain.Role{ID: "r1", Name: "admin"})
+	_ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
+
+	svc := NewService(roleRepo, slog.Default())
+	return NewHandler(svc).Routes()
+}
+
+func TestHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+		checkBody  func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "GET /{userID} returns roles",
+			path:       "/user-1",
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Data  []json.RawMessage `json:"data"`
+					Total int               `json:"total"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, 1, resp.Total)
+			},
+		},
+		{
+			name:       "GET /{userID} no roles returns empty",
+			path:       "/unknown-user",
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Total int `json:"total"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, 0, resp.Total)
+			},
+		},
+		{
+			name:       "GET /{userID}/{roleName} has role",
+			path:       "/user-1/admin",
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Data struct {
+						HasRole bool `json:"hasRole"`
+					} `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.True(t, resp.Data.HasRole)
+			},
+		},
+		{
+			name:       "GET /{userID}/{roleName} missing role",
+			path:       "/user-1/viewer",
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Data struct {
+						HasRole bool `json:"hasRole"`
+					} `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.False(t, resp.Data.HasRole)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := setup()
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.checkBody != nil {
+				tc.checkBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}

--- a/src/cells/access-core/slices/sessionlogin/handler_test.go
+++ b/src/cells/access-core/slices/sessionlogin/handler_test.go
@@ -1,0 +1,87 @@
+package sessionlogin
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+)
+
+// testKey is declared in service_test.go
+
+func setup() http.Handler {
+	userRepo := mem.NewUserRepository()
+	hash, _ := bcrypt.GenerateFromPassword([]byte("correct-pass"), bcrypt.MinCost)
+	user := &domain.User{
+		ID: "usr-1", Username: "alice", Email: "a@b.com",
+		PasswordHash: string(hash), Status: domain.StatusActive,
+	}
+	_ = userRepo.Create(context.Background(), user)
+
+	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(), eventbus.New(), testKey, slog.Default())
+	r := chi.NewRouter()
+	r.Post("/login", NewHandler(svc).HandleLogin)
+	return r
+}
+
+func TestHandleLogin(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		checkBody  func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "valid credentials returns 201 with tokens",
+			body:       `{"username":"alice","password":"correct-pass"}`,
+			wantStatus: http.StatusCreated,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Data struct {
+						AccessToken  string `json:"accessToken"`
+						RefreshToken string `json:"refreshToken"`
+					} `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.NotEmpty(t, resp.Data.AccessToken)
+				assert.NotEmpty(t, resp.Data.RefreshToken)
+			},
+		},
+		{
+			name:       "invalid JSON returns 400",
+			body:       `{bad`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "wrong password returns 401",
+			body:       `{"username":"alice","password":"wrong"}`,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := setup()
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.checkBody != nil {
+				tc.checkBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}

--- a/src/cells/access-core/slices/sessionlogin/service.go
+++ b/src/cells/access-core/slices/sessionlogin/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/id"
 )
 
 const (
@@ -103,7 +104,7 @@ func (s *Service) Login(ctx context.Context, input LoginInput) (*TokenPair, erro
 	// Issue JWT.
 	now := time.Now()
 	expiresAt := now.Add(accessTokenTTL)
-	sessionID := fmt.Sprintf("sess-%d", now.UnixNano())
+	sessionID := id.New("sess")
 
 	accessToken, err := s.issueToken(user.ID, roleNames, expiresAt, sessionID)
 	if err != nil {
@@ -151,6 +152,7 @@ func (s *Service) issueToken(subject string, roles []string, expiresAt time.Time
 		"iat": jwt.NewNumericDate(time.Now()),
 		"exp": jwt.NewNumericDate(expiresAt),
 		"iss": "gocell-access-core",
+		"aud": jwt.ClaimStrings{"gocell"},
 	}
 	if len(roles) > 0 {
 		claims["roles"] = roles

--- a/src/cells/access-core/slices/sessionlogout/handler_test.go
+++ b/src/cells/access-core/slices/sessionlogout/handler_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
@@ -41,9 +40,9 @@ func TestHandleLogout(t *testing.T) {
 			wantStatus: http.StatusNoContent,
 		},
 		{
-			name:       "nonexistent session returns 500",
+			name:       "nonexistent session returns 404",
 			path:       "/no-such-sess",
-			wantStatus: http.StatusInternalServerError,
+			wantStatus: http.StatusNotFound,
 		},
 	}
 
@@ -52,13 +51,7 @@ func TestHandleLogout(t *testing.T) {
 			r := setup()
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, tc.path, nil))
-			if tc.wantStatus == http.StatusNoContent {
-				assert.Equal(t, tc.wantStatus, w.Code)
-			} else {
-				// The error wraps a non-errcode error (fmt.Errorf),
-				// so WriteDomainError maps it to 500.
-				require.GreaterOrEqual(t, w.Code, 400)
-			}
+			assert.Equal(t, tc.wantStatus, w.Code)
 		})
 	}
 }

--- a/src/cells/access-core/slices/sessionlogout/handler_test.go
+++ b/src/cells/access-core/slices/sessionlogout/handler_test.go
@@ -1,0 +1,64 @@
+package sessionlogout
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+)
+
+func setup() http.Handler {
+	sessionRepo := mem.NewSessionRepository()
+	sess, _ := domain.NewSession("usr-1", "access-tok", "refresh-tok", time.Now().Add(time.Hour))
+	sess.ID = "sess-1"
+	_ = sessionRepo.Create(context.Background(), sess)
+
+	svc := NewService(sessionRepo, eventbus.New(), slog.Default())
+	r := chi.NewRouter()
+	r.Delete("/{id}", NewHandler(svc).HandleLogout)
+	return r
+}
+
+func TestHandleLogout(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name:       "existing session returns 204",
+			path:       "/sess-1",
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "nonexistent session returns 500",
+			path:       "/no-such-sess",
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := setup()
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, tc.path, nil))
+			if tc.wantStatus == http.StatusNoContent {
+				assert.Equal(t, tc.wantStatus, w.Code)
+			} else {
+				// The error wraps a non-errcode error (fmt.Errorf),
+				// so WriteDomainError maps it to 500.
+				require.GreaterOrEqual(t, w.Code, 400)
+			}
+		})
+	}
+}

--- a/src/cells/access-core/slices/sessionlogout/service.go
+++ b/src/cells/access-core/slices/sessionlogout/service.go
@@ -47,7 +47,7 @@ func (s *Service) Logout(ctx context.Context, sessionID string) error {
 
 	session, err := s.sessionRepo.GetByID(ctx, sessionID)
 	if err != nil {
-		return fmt.Errorf("session-logout: get session: %w", err)
+		return errcode.New("ERR_SESSION_NOT_FOUND", "session not found")
 	}
 
 	if session.IsRevoked() {

--- a/src/cells/access-core/slices/sessionrefresh/handler_test.go
+++ b/src/cells/access-core/slices/sessionrefresh/handler_test.go
@@ -1,0 +1,99 @@
+package sessionrefresh
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+)
+
+// testKey is declared in service_test.go
+
+func issueRefreshToken(userID string) string {
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"exp": jwt.NewNumericDate(time.Now().Add(7 * 24 * time.Hour)),
+		"iat": jwt.NewNumericDate(time.Now()),
+		"iss": "gocell-access-core",
+		"aud": jwt.ClaimStrings{"gocell"},
+	}
+	tok, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(testKey)
+	return tok
+}
+
+func setup() (http.Handler, string) {
+	sessionRepo := mem.NewSessionRepository()
+	refreshTok := issueRefreshToken("usr-1")
+
+	sess, _ := domain.NewSession("usr-1", "access-tok", refreshTok, time.Now().Add(time.Hour))
+	sess.ID = "sess-1"
+	_ = sessionRepo.Create(context.Background(), sess)
+
+	svc := NewService(sessionRepo, mem.NewRoleRepository(), testKey, slog.Default())
+	r := chi.NewRouter()
+	r.Post("/refresh", NewHandler(svc).HandleRefresh)
+	return r, refreshTok
+}
+
+func TestHandleRefresh(t *testing.T) {
+	router, validToken := setup()
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		checkBody  func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "valid refresh token returns 200 with new tokens",
+			body:       `{"refreshToken":"` + validToken + `"}`,
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Data struct {
+						AccessToken  string `json:"accessToken"`
+						RefreshToken string `json:"refreshToken"`
+					} `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.NotEmpty(t, resp.Data.AccessToken)
+				assert.NotEmpty(t, resp.Data.RefreshToken)
+			},
+		},
+		{
+			name:       "invalid JSON returns 400",
+			body:       `{bad`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid token returns 401",
+			body:       `{"refreshToken":"not.a.jwt"}`,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/refresh", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.checkBody != nil {
+				tc.checkBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}

--- a/src/cells/access-core/slices/sessionrefresh/service.go
+++ b/src/cells/access-core/slices/sessionrefresh/service.go
@@ -124,6 +124,7 @@ func (s *Service) issueToken(subject string, roles []string, expiresAt time.Time
 		"iat": jwt.NewNumericDate(time.Now()),
 		"exp": jwt.NewNumericDate(expiresAt),
 		"iss": "gocell-access-core",
+		"aud": jwt.ClaimStrings{"gocell"},
 	}
 	if len(roles) > 0 {
 		claims["roles"] = roles

--- a/src/cells/access-core/slices/sessionvalidate/service.go
+++ b/src/cells/access-core/slices/sessionvalidate/service.go
@@ -66,6 +66,10 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 		claims.IssuedAt = iat.Time
 	}
 
+	if aud, err := mapClaims.GetAudience(); err == nil {
+		claims.Audience = aud
+	}
+
 	// Extract roles.
 	if rolesRaw, ok := mapClaims["roles"].([]any); ok {
 		for _, r := range rolesRaw {
@@ -105,6 +109,7 @@ func IssueTestToken(signingKey []byte, subject string, roles []string, ttl time.
 		"iat": jwt.NewNumericDate(now),
 		"exp": jwt.NewNumericDate(now.Add(ttl)),
 		"iss": "gocell-access-core",
+		"aud": jwt.ClaimStrings{"gocell"},
 	}
 	if len(roles) > 0 {
 		claims["roles"] = roles

--- a/src/cells/access-core/slices/sessionvalidate/service.go
+++ b/src/cells/access-core/slices/sessionvalidate/service.go
@@ -40,7 +40,7 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 			return nil, errcode.New(ErrValidateInvalidToken, "unexpected signing method")
 		}
 		return s.signingKey, nil
-	})
+	}, jwt.WithAudience("gocell"), jwt.WithIssuer("gocell-access-core"))
 	if err != nil {
 		return auth.Claims{}, errcode.New(ErrValidateInvalidToken, "invalid token")
 	}

--- a/src/cells/audit-core/slices/auditappend/service.go
+++ b/src/cells/audit-core/slices/auditappend/service.go
@@ -5,13 +5,13 @@ package auditappend
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/id"
 )
 
 const (
@@ -75,7 +75,7 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 
 	// Append to hash chain.
 	auditEntry := s.chain.Append(entry.ID, entry.EventType, actorID, entry.Payload)
-	auditEntry.ID = fmt.Sprintf("audit-%d", auditEntry.Timestamp.UnixNano())
+	auditEntry.ID = id.New("audit")
 
 	// Persist.
 	if err := s.repo.Append(ctx, auditEntry); err != nil {

--- a/src/cells/config-core/slices/configpublish/service.go
+++ b/src/cells/config-core/slices/configpublish/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/id"
 )
 
 const (
@@ -53,7 +54,7 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 
 	now := time.Now()
 	version := &domain.ConfigVersion{
-		ID:          fmt.Sprintf("ver-%d", now.UnixNano()),
+		ID:          id.New("ver"),
 		ConfigID:    entry.ID,
 		Version:     entry.Version,
 		Value:       entry.Value,

--- a/src/cells/config-core/slices/configwrite/service.go
+++ b/src/cells/config-core/slices/configwrite/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/id"
 )
 
 const (
@@ -52,7 +53,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.Config
 
 	now := time.Now()
 	entry := &domain.ConfigEntry{
-		ID:        fmt.Sprintf("cfg-%d", now.UnixNano()),
+		ID:        id.New("cfg"),
 		Key:       input.Key,
 		Value:     input.Value,
 		Version:   1,

--- a/src/cmd/core-bundle/main.go
+++ b/src/cmd/core-bundle/main.go
@@ -18,9 +18,20 @@ import (
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
+func envOrDefault(key, fallback string) []byte {
+	if v := os.Getenv(key); v != "" {
+		return []byte(v)
+	}
+	slog.Warn("using dev-only default key; set env var for production", slog.String("var", key))
+	return []byte(fallback)
+}
+
 func main() {
 	// Create shared event bus.
 	eb := eventbus.New()
+
+	signingKey := envOrDefault("GOCELL_SIGNING_KEY", "dev-signing-key-replace-in-prod!!")
+	hmacKey := envOrDefault("GOCELL_HMAC_KEY", "dev-hmac-key-replace-in-prod!!!!")
 
 	// Create cells with in-memory repositories.
 	configCell := configcore.NewConfigCore(
@@ -30,12 +41,12 @@ func main() {
 	accessCell := accesscore.NewAccessCore(
 		accesscore.WithInMemoryDefaults(),
 		accesscore.WithPublisher(eb),
-		accesscore.WithSigningKey([]byte("dev-signing-key-replace-in-prod!!")),
+		accesscore.WithSigningKey(signingKey),
 	)
 	auditCell := auditcore.NewAuditCore(
 		auditcore.WithInMemoryDefaults(),
 		auditcore.WithPublisher(eb),
-		auditcore.WithHMACKey([]byte("dev-hmac-key-replace-in-prod!!!!")),
+		auditcore.WithHMACKey(hmacKey),
 	)
 
 	// Create assembly and register cells in dependency order.

--- a/src/kernel/governance/rules_fmt.go
+++ b/src/kernel/governance/rules_fmt.go
@@ -103,42 +103,49 @@ func (v *Validator) validateFMT03() []ValidationResult {
 	return results
 }
 
-// validateFMT04 checks that event-type contracts include replayable, idempotencyKey, deliverySemantics.
+// validateFMT04 checks that event-type contracts include replayable, idempotencyKey, deliverySemantics,
+// and that projection-type contracts include replayable.
 func (v *Validator) validateFMT04() []ValidationResult {
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
-		if cell.ContractKind(c.Kind) != cell.ContractEvent {
-			continue
+		kind := cell.ContractKind(c.Kind)
+
+		// Both event and projection contracts require replayable.
+		if kind == cell.ContractEvent || kind == cell.ContractProjection {
+			if c.Replayable == nil {
+				results = append(results, ValidationResult{
+					Code:      "FMT-04",
+					Severity:  SeverityError,
+					IssueType: IssueRequired,
+					File:      contractFile(c.ID),
+					Field:     "replayable",
+					Message:   fmt.Sprintf("%s contract %q must specify replayable", c.Kind, c.ID),
+				})
+			}
 		}
-		if c.Replayable == nil {
-			results = append(results, ValidationResult{
-				Code:      "FMT-04",
-				Severity:  SeverityError,
-				IssueType: IssueRequired,
-				File:      contractFile(c.ID),
-				Field:     "replayable",
-				Message:   fmt.Sprintf("event contract %q must specify replayable", c.ID),
-			})
-		}
-		if c.IdempotencyKey == "" {
-			results = append(results, ValidationResult{
-				Code:      "FMT-04",
-				Severity:  SeverityError,
-				IssueType: IssueRequired,
-				File:      contractFile(c.ID),
-				Field:     "idempotencyKey",
-				Message:   fmt.Sprintf("event contract %q must specify idempotencyKey", c.ID),
-			})
-		}
-		if c.DeliverySemantics == "" {
-			results = append(results, ValidationResult{
-				Code:      "FMT-04",
-				Severity:  SeverityError,
-				IssueType: IssueRequired,
-				File:      contractFile(c.ID),
-				Field:     "deliverySemantics",
-				Message:   fmt.Sprintf("event contract %q must specify deliverySemantics", c.ID),
-			})
+
+		// Only event contracts require idempotencyKey and deliverySemantics.
+		if kind == cell.ContractEvent {
+			if c.IdempotencyKey == "" {
+				results = append(results, ValidationResult{
+					Code:      "FMT-04",
+					Severity:  SeverityError,
+					IssueType: IssueRequired,
+					File:      contractFile(c.ID),
+					Field:     "idempotencyKey",
+					Message:   fmt.Sprintf("event contract %q must specify idempotencyKey", c.ID),
+				})
+			}
+			if c.DeliverySemantics == "" {
+				results = append(results, ValidationResult{
+					Code:      "FMT-04",
+					Severity:  SeverityError,
+					IssueType: IssueRequired,
+					File:      contractFile(c.ID),
+					Field:     "deliverySemantics",
+					Message:   fmt.Sprintf("event contract %q must specify deliverySemantics", c.ID),
+				})
+			}
 		}
 	}
 	return results

--- a/src/kernel/governance/rules_verify.go
+++ b/src/kernel/governance/rules_verify.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 )
 
-// validateVERIFY01 checks that every provider-role contractUsage has a matching
+// validateVERIFY01 checks that every contractUsage has a matching
 // verify.contract entry or a valid waiver.
 //
 // verify.contract format: "contract.{contractID}.{role}"
@@ -37,9 +37,6 @@ func (v *Validator) validateVERIFY01() []ValidationResult {
 		}
 
 		for i, cu := range s.ContractUsages {
-			if !cell.IsProviderRole(cell.ContractRole(cu.Role)) {
-				continue
-			}
 			verifyKey := fmt.Sprintf("contract.%s.%s", cu.Contract, cu.Role)
 			if !verifySet[verifyKey] && !waiverSet[cu.Contract] {
 				results = append(results, ValidationResult{
@@ -49,7 +46,7 @@ func (v *Validator) validateVERIFY01() []ValidationResult {
 					File:      sliceFile(key),
 					Field:     fmt.Sprintf("contractUsages[%d]", i),
 					Message: fmt.Sprintf(
-						"provider-role usage of contract %q (role %q) in slice %q has no verify.contract entry or valid waiver",
+						"usage of contract %q (role %q) in slice %q has no verify.contract entry or valid waiver",
 						cu.Contract, cu.Role, s.ID,
 					),
 				})

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -67,7 +67,8 @@ func validProject() *metadata.ProjectMeta {
 					{Contract: "event.session.created.v1", Role: "subscribe"},
 				},
 				Verify: metadata.SliceVerifyMeta{
-					Unit: []string{"unit.audit-write.handler"},
+					Unit:     []string{"unit.audit-write.handler"},
+					Contract: []string{"contract.event.session.created.v1.subscribe"},
 				},
 			},
 		},
@@ -96,6 +97,18 @@ func validProject() *metadata.ProjectMeta {
 				Replayable:        &replayable,
 				IdempotencyKey:    "session-id",
 				DeliverySemantics: "at-least-once",
+			},
+			"projection.session.active.v1": {
+				ID:               "projection.session.active.v1",
+				Kind:             "projection",
+				OwnerCell:        "access-core",
+				ConsistencyLevel: "L1",
+				Lifecycle:        "active",
+				Endpoints: metadata.EndpointsMeta{
+					Provider: "access-core",
+					Readers:  []string{"audit-core"},
+				},
+				Replayable: &replayable,
 			},
 		},
 		Journeys: map[string]*metadata.JourneyMeta{
@@ -821,12 +834,11 @@ func TestVERIFY01(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name: "consumer role does not require verify entry",
+			name: "consumer role without verify entry triggers error",
 			setup: func(pm *metadata.ProjectMeta) {
-				// audit-core/audit-write has subscribe (consumer) role with no verify.contract entries
-				// This should NOT trigger VERIFY-01
+				pm.Slices["audit-core/audit-write"].Verify.Contract = nil
 			},
-			wantCount: 0,
+			wantCount: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -1144,6 +1156,20 @@ func TestFMT04(t *testing.T) {
 			name: "http contract does not require event fields",
 			setup: func(pm *metadata.ProjectMeta) {
 				// http contract has no replayable/idempotencyKey/deliverySemantics and that's fine
+			},
+			wantCount: 0,
+		},
+		{
+			name: "projection contract missing replayable",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["projection.session.active.v1"].Replayable = nil
+			},
+			wantCount: 1,
+		},
+		{
+			name: "projection contract with replayable set",
+			setup: func(pm *metadata.ProjectMeta) {
+				// projection contract already has replayable in validProject
 			},
 			wantCount: 0,
 		},

--- a/src/kernel/slice/verify.go
+++ b/src/kernel/slice/verify.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // TestResult represents the outcome of a single test target.
@@ -54,7 +55,7 @@ func (r *Runner) VerifySlice(ctx context.Context, sliceKey string) (*VerifyResul
 	}
 
 	if _, ok := r.project.Slices[sliceKey]; !ok {
-		return nil, fmt.Errorf("slice %q not found in project metadata", sliceKey)
+		return nil, errcode.New(errcode.ErrSliceNotFound, fmt.Sprintf("slice %q not found in project metadata", sliceKey))
 	}
 
 	pkg := fmt.Sprintf("./cells/%s/slices/%s/...", cellID, sliceID)
@@ -81,7 +82,7 @@ func (r *Runner) VerifySlice(ctx context.Context, sliceKey string) (*VerifyResul
 // It runs `go test ./cells/{cellID}/... -v -run Smoke` from the project root.
 func (r *Runner) VerifyCell(ctx context.Context, cellID string) (*VerifyResult, error) {
 	if r.project.Cells[cellID] == nil {
-		return nil, fmt.Errorf("cell %q not found in project metadata", cellID)
+		return nil, errcode.New(errcode.ErrCellNotFound, fmt.Sprintf("cell %q not found in project metadata", cellID))
 	}
 
 	pkg := fmt.Sprintf("./cells/%s/...", cellID)
@@ -110,7 +111,7 @@ func (r *Runner) VerifyCell(ctx context.Context, cellID string) (*VerifyResult, 
 func (r *Runner) RunJourney(ctx context.Context, journeyID string) (*VerifyResult, error) {
 	journey := r.project.Journeys[journeyID]
 	if journey == nil {
-		return nil, fmt.Errorf("journey %q not found in project metadata", journeyID)
+		return nil, errcode.New(errcode.ErrJourneyNotFound, fmt.Sprintf("journey %q not found in project metadata", journeyID))
 	}
 
 	result := &VerifyResult{
@@ -150,13 +151,13 @@ func (r *Runner) RunJourney(ctx context.Context, journeyID string) (*VerifyResul
 func parseSliceKey(key string) (cellID, sliceID string, err error) {
 	parts := strings.SplitN(key, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("invalid slice key %q: expected format \"cellID/sliceID\"", key)
+		return "", "", errcode.New(errcode.ErrValidationFailed, fmt.Sprintf("invalid slice key %q: expected format \"cellID/sliceID\"", key))
 	}
 	if strings.Contains(parts[0], "..") || strings.ContainsAny(parts[0], `/\`) {
-		return "", "", fmt.Errorf("invalid cellID: contains path separator or traversal")
+		return "", "", errcode.New(errcode.ErrValidationFailed, "invalid cellID: contains path separator or traversal")
 	}
 	if strings.Contains(parts[1], "..") || strings.ContainsAny(parts[1], `/\`) {
-		return "", "", fmt.Errorf("invalid sliceID: contains path separator or traversal")
+		return "", "", errcode.New(errcode.ErrValidationFailed, "invalid sliceID: contains path separator or traversal")
 	}
 	return parts[0], parts[1], nil
 }
@@ -212,7 +213,7 @@ func runGoTest(ctx context.Context, dir string, args []string) (output string, p
 	}
 
 	// Other error: command couldn't execute at all.
-	return output, false, fmt.Errorf("go test execution failed: %w", runErr)
+	return output, false, errcode.Wrap(errcode.ErrTestExecution, "go test execution failed", runErr)
 }
 
 // isExitError checks whether err (or any wrapped error in its chain) is an

--- a/src/pkg/errcode/errcode.go
+++ b/src/pkg/errcode/errcode.go
@@ -25,6 +25,8 @@ const (
 	ErrAuthForbidden    Code = "ERR_AUTH_FORBIDDEN"
 	ErrRateLimited      Code = "ERR_RATE_LIMITED"
 	ErrBodyTooLarge     Code = "ERR_BODY_TOO_LARGE"
+	ErrJourneyNotFound  Code = "ERR_JOURNEY_NOT_FOUND"
+	ErrTestExecution    Code = "ERR_TEST_EXECUTION"
 )
 
 // Error is a structured error that carries a machine-readable Code, a

--- a/src/pkg/id/id.go
+++ b/src/pkg/id/id.go
@@ -11,6 +11,8 @@ import (
 
 // New generates a random ID with the given prefix.
 // Format: "{prefix}-{16 hex chars}" (8 random bytes = 64 bits of entropy).
+// 64-bit entropy is sufficient for single-process in-memory use. For globally
+// unique IDs across distributed systems, consider UUID v4 (128 bits).
 // Example: New("usr") → "usr-a1b2c3d4e5f67890"
 func New(prefix string) string {
 	var b [8]byte

--- a/src/pkg/id/id.go
+++ b/src/pkg/id/id.go
@@ -1,0 +1,21 @@
+// Package id provides cryptographically random ID generation for the GoCell
+// framework. All entity IDs should use this package instead of time-based
+// approaches (e.g., UnixNano) to avoid collisions and predictability.
+package id
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// New generates a random ID with the given prefix.
+// Format: "{prefix}-{16 hex chars}" (8 random bytes = 64 bits of entropy).
+// Example: New("usr") → "usr-a1b2c3d4e5f67890"
+func New(prefix string) string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(fmt.Sprintf("id: crypto/rand failed: %v", err))
+	}
+	return prefix + "-" + hex.EncodeToString(b[:])
+}

--- a/src/pkg/id/id_test.go
+++ b/src/pkg/id/id_test.go
@@ -1,0 +1,33 @@
+package id
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("format", func(t *testing.T) {
+		got := New("usr")
+		require.True(t, strings.HasPrefix(got, "usr-"))
+		// prefix "usr-" (4) + 16 hex chars = 20
+		assert.Len(t, got, 20)
+	})
+
+	t.Run("uniqueness", func(t *testing.T) {
+		seen := make(map[string]bool, 1000)
+		for range 1000 {
+			id := New("test")
+			assert.False(t, seen[id], "duplicate ID generated: %s", id)
+			seen[id] = true
+		}
+	})
+
+	t.Run("different prefixes", func(t *testing.T) {
+		assert.True(t, strings.HasPrefix(New("sess"), "sess-"))
+		assert.True(t, strings.HasPrefix(New("cfg"), "cfg-"))
+		assert.True(t, strings.HasPrefix(New("audit"), "audit-"))
+	})
+}

--- a/src/runtime/bootstrap/bootstrap.go
+++ b/src/runtime/bootstrap/bootstrap.go
@@ -158,6 +158,29 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		cfg = config.NewFromMap(make(map[string]any))
 	}
 
+	// Step 1.5: Start config watcher (if config file provided).
+	if b.configPath != "" {
+		watcher, err := config.NewWatcher(b.configPath)
+		if err != nil {
+			slog.Warn("bootstrap: config watcher not available", slog.Any("error", err))
+		} else {
+			yamlPath, envPrefix := b.configPath, b.envPrefix
+			watcher.OnChange(func(evt config.WatchEvent) {
+				if rc, ok := cfg.(config.Reloader); ok {
+					if err := rc.Reload(yamlPath, envPrefix); err != nil {
+						slog.Error("bootstrap: config reload failed", slog.Any("error", err))
+					} else {
+						slog.Info("bootstrap: config reloaded", slog.String("path", evt.Path))
+					}
+				}
+			})
+			watcher.Start()
+			teardowns = append(teardowns, func(_ context.Context) error {
+				return watcher.Close()
+			})
+		}
+	}
+
 	// Step 2: Initialise eventbus.
 	eb := b.eventBus
 	if eb == nil {

--- a/src/runtime/config/config.go
+++ b/src/runtime/config/config.go
@@ -28,6 +28,12 @@ type Config interface {
 	Keys() []string
 }
 
+// Reloader is an optional interface for configs that support hot-reloading.
+// The concrete *config returned by Load implements this; NewFromMap does not.
+type Reloader interface {
+	Reload(yamlPath, envPrefix string) error
+}
+
 // config is the default in-memory implementation of Config.
 type config struct {
 	mu   sync.RWMutex

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/id"
 )
 
 const (
@@ -84,7 +85,7 @@ func (b *InMemoryEventBus) Publish(_ context.Context, topic string, payload []by
 	}
 
 	entry := outbox.Entry{
-		ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+		ID:        id.New("evt"),
 		EventType: topic,
 		Payload:   payload,
 		CreatedAt: time.Now(),


### PR DESCRIPTION
## Summary

- **#27** verify.go 7× `fmt.Errorf` → `pkg/errcode` 结构化错误
- **#28** VERIFY-01 扩展到检查所有角色（不再仅 provider）
- **#29** FMT-04 增加 projection contract `replayable` 必填校验
- **#5+#6** 密钥从环境变量读取 (`GOCELL_SIGNING_KEY`/`GOCELL_HMAC_KEY`) + JWT `aud` claim
- **#20** config watcher 接入 bootstrap 生命周期（启动+teardown）
- **#33** 6 处 `UnixNano` ID 生成 → `crypto/rand`（新增 `pkg/id`）
- **#32** 5 个 handler_test.go 补充（identitymanage/rbaccheck/sessionlogin/sessionlogout/sessionrefresh）

## Stats
- 23 files changed, +654 / -58
- 55 test packages PASS, 0 regressions

## Test plan
- [x] `go build ./...` 通过
- [x] `go test ./... -count=1` 全量通过（55 包）
- [x] kernel/ 覆盖率保持 ≥ 90%
- [x] 新增 `pkg/id` 包含 uniqueness + format 测试
- [ ] 验证 `GOCELL_SIGNING_KEY` / `GOCELL_HMAC_KEY` 环境变量设置后 dev 默认 key 不再使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)