### PR TITLE
review: R1C+R1H runtime review + naming audit + 24 P1 fixes (Wave 1+2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       run:
         working-directory: src
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.22"
+          go-version: "1.25"
           cache-dependency-path: src/go.sum
 
       - name: Build
@@ -48,14 +48,14 @@ jobs:
           echo "PASS: no internal import violations"
 
       - name: Cache SonarQube packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -82,11 +82,11 @@ jobs:
     # No static services: testcontainers manages containers dynamically,
     # avoiding port conflicts with host-bound services.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.22"
+          go-version: "1.25"
           cache-dependency-path: src/go.sum
 
       - name: Integration tests (testcontainers)

--- a/docs/reviews/202604060830-R0/R1C-1-runtime-auth.md
+++ b/docs/reviews/202604060830-R0/R1C-1-runtime-auth.md
@@ -1,0 +1,280 @@
+# R1C-1: runtime/auth Module Review
+
+| Field | Value |
+|-------|-------|
+| Reviewer | R1C-1 (Security + Architecture + Test combined) |
+| Scope | `src/runtime/auth/` -- 569 LOC prod, 736 LOC test (11 files) |
+| Baseline commit | `ce03ba1` (develop HEAD) |
+| Date | 2026-04-06 |
+
+---
+
+## Summary
+
+The `runtime/auth` module provides RS256 JWT issuing/verification, HMAC-SHA256 service tokens, and HTTP auth middleware. Post-PR#16 hardening, RS256 is correctly pinned as the only signing method. The module is well-structured with clear separation of interfaces (`auth.go`) from implementations (`jwt.go`, `servicetoken.go`, `middleware.go`, `keys.go`). Test coverage is strong with 25 test functions covering happy paths and attack vectors.
+
+**Overall risk: LOW-MEDIUM.** No P0 blockers found. Several P1 items related to error code duplication, missing key-size validation, and a minor security hardening gap.
+
+---
+
+## Findings
+
+### F-01: Duplicate ErrAuthUnauthorized definition (P1 -- Code Quality)
+
+| Field | Value |
+|-------|-------|
+| Seat | S1 Architecture + S5 DX |
+| Severity | P1 |
+| Category | Code duplication / naming collision |
+| File | `src/runtime/auth/jwt.go:54`, `src/pkg/errcode/errcode.go:24` |
+| Status | OPEN |
+
+**Evidence:**
+
+`jwt.go:54` defines:
+```go
+var ErrAuthUnauthorized = errcode.Code("ERR_AUTH_UNAUTHORIZED")
+```
+
+`errcode.go:24` defines:
+```go
+ErrAuthUnauthorized Code = "ERR_AUTH_UNAUTHORIZED"
+```
+
+Two distinct Go symbols (`auth.ErrAuthUnauthorized` and `errcode.ErrAuthUnauthorized`) hold the same string value. This is confusing for consumers who may import the wrong one, and violates the single-source-of-truth principle for error codes.
+
+**Fix:** Remove the local `var ErrAuthUnauthorized` in `jwt.go` and import `errcode.ErrAuthUnauthorized` instead. The same applies if `ErrKeyMissing` in `keys.go:46` has no counterpart in errcode (it currently does not -- `ERR_AUTH_KEY_MISSING` vs `ERR_AUTH_KEY_INVALID`), which is a separate naming inconsistency.
+
+---
+
+### F-02: No minimum RSA key size validation (P1 -- Security)
+
+| Field | Value |
+|-------|-------|
+| Seat | S2 Security |
+| Severity | P1 |
+| Category | Key management |
+| File | `src/runtime/auth/keys.go:26-36`, `src/runtime/auth/jwt.go:24-26` |
+| Status | OPEN |
+
+**Evidence:**
+
+`NewJWTVerifier` and `NewJWTIssuer` accept any `*rsa.PublicKey`/`*rsa.PrivateKey` without checking key size. `LoadRSAKeyPairFromPEM` and `LoadKeysFromEnv` also perform no minimum-bits check. A 512-bit or 1024-bit RSA key would be accepted silently, which is cryptographically weak.
+
+**Fix:** Add a guard in `NewJWTVerifier`, `NewJWTIssuer`, and/or `LoadRSAKeyPairFromPEM` that rejects keys with `key.N.BitLen() < 2048`. Return an `errcode` error.
+
+---
+
+### F-03: Bare `fmt.Errorf` in internal key parsing functions (P1 -- Error Handling)
+
+| Field | Value |
+|-------|-------|
+| Seat | S5 DX / S2 Security |
+| Severity | P1 |
+| Category | Error handling convention violation |
+| File | `src/runtime/auth/keys.go:82,90,101,109` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// keys.go:82
+return nil, fmt.Errorf("no PEM block found")
+// keys.go:90
+return nil, fmt.Errorf("PKCS#8 key is not RSA")
+// keys.go:101
+return nil, fmt.Errorf("no PEM block found")
+// keys.go:109
+return nil, fmt.Errorf("PKIX key is not RSA")
+```
+
+Project convention (CLAUDE.md): "errors exposed across package boundaries must use `pkg/errcode`". While `parseRSAPrivateKey`/`parseRSAPublicKey` are unexported, their errors propagate through `LoadRSAKeyPairFromPEM` (exported) and `LoadKeysFromEnv` (which wraps them via `errcode.Wrap`). The wrapping in `LoadKeysFromEnv` mitigates this, but `LoadRSAKeyPairFromPEM` exposes bare `fmt.Errorf` errors directly to callers.
+
+**Fix:** Wrap errors in `LoadRSAKeyPairFromPEM` with `errcode.Wrap(ErrKeyMissing, ...)` or define an appropriate error code for key parsing failures.
+
+---
+
+### F-04: `writeAuthError` ignores JSON encoding error (P2 -- Error Handling)
+
+| Field | Value |
+|-------|-------|
+| Seat | S5 DX |
+| Severity | P2 |
+| Category | Error handling |
+| File | `src/runtime/auth/middleware.go:133` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+_ = json.NewEncoder(w).Encode(map[string]any{...})
+```
+
+The blank identifier discards the encoding error. Per CLAUDE.md: "Prohibit `_ = someFunc()` ignoring errors". While this is an HTTP response write (failure typically means the client disconnected), it should at minimum be logged at Debug level per observability convention.
+
+**Fix:** Replace `_ =` with `if err := json.NewEncoder(w).Encode(...); err != nil { slog.Debug("failed to write auth error response", slog.Any("error", err)) }`.
+
+---
+
+### F-05: Public endpoint whitelist uses exact path match only (P2 -- Security)
+
+| Field | Value |
+|-------|-------|
+| Seat | S2 Security |
+| Severity | P2 |
+| Category | Auth bypass surface |
+| File | `src/runtime/auth/middleware.go:40` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+if publicSet[r.URL.Path] {
+```
+
+This is an exact-match lookup. It correctly handles query strings (`r.URL.Path` does not include the query string in Go's `net/http`). However, it does not handle trailing-slash variants (e.g., `/healthz/` would NOT match `/healthz`). This is generally safe (fail-closed: unmatched paths require auth), but could surprise users when reverse proxies normalize trailing slashes.
+
+Additionally, there is no prefix-matching support for versioned API paths (e.g., `/api/v1/auth/` subtree). This is a design choice, not a bug, but should be documented.
+
+**Fix:** Add a godoc note on `AuthMiddleware` clarifying exact-match semantics and trailing-slash behavior. Consider offering an optional prefix-match mode in a future iteration.
+
+---
+
+### F-06: `nowFunc` package-level mutable var is not concurrency-safe for tests (P2 -- Test Quality)
+
+| Field | Value |
+|-------|-------|
+| Seat | S3 Test |
+| Severity | P2 |
+| Category | Test isolation / concurrency |
+| File | `src/runtime/auth/servicetoken.go:19` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+var nowFunc = time.Now
+```
+
+This exported-scope mutable variable is overridden in tests without synchronization. If `go test -parallel` or `-count=N` runs servicetoken tests concurrently, data races on `nowFunc` are possible. Current tests use `defer` cleanup but no mutex.
+
+**Fix:** Either (a) use `sync.Mutex` around `nowFunc` access, (b) inject a `Clock` interface via `ServiceTokenMiddleware` options instead of a package-level var, or (c) mark all servicetoken tests with `t.Parallel()` removed (they already are not parallel, so this is low-risk in practice -- downgrade to advisory).
+
+---
+
+### F-07: No token revocation / JTI support (P2 -- Security Design)
+
+| Field | Value |
+|-------|-------|
+| Seat | S2 Security |
+| Severity | P2 |
+| Category | JWT lifecycle |
+| File | `src/runtime/auth/jwt.go` (entire file) |
+| Status | OPEN |
+
+**Evidence:**
+
+The `JWTIssuer.Issue` method does not emit a `jti` (JWT ID) claim. The `JWTVerifier.Verify` method does not check for revoked tokens. There is no revocation interface or token blocklist mechanism anywhere in the module.
+
+For short-lived tokens (the `ttl` parameter controls this), revocation is less critical. However, there is no enforcement of a maximum TTL, and callers could pass `24 * time.Hour` or longer, making stolen tokens dangerous.
+
+**Fix:** (1) Add `jti` claim generation (UUID) in `Issue`. (2) Consider adding a `TokenBlacklist` interface that `JWTVerifier` can optionally check. (3) Document recommended TTL ranges in godoc. These are design improvements, not urgent for current scope.
+
+---
+
+### F-08: `ErrKeyMissing` vs `ErrAuthKeyInvalid` naming inconsistency (P2 -- DX)
+
+| Field | Value |
+|-------|-------|
+| Seat | S5 DX |
+| Severity | P2 |
+| Category | Naming consistency |
+| File | `src/runtime/auth/keys.go:46` vs `src/pkg/errcode/errcode.go:37` |
+| Status | OPEN |
+
+**Evidence:**
+
+`keys.go:46`:
+```go
+var ErrKeyMissing = errcode.Code("ERR_AUTH_KEY_MISSING")
+```
+
+`errcode.go:37-39` defines:
+```go
+ErrAuthKeyInvalid   Code = "ERR_AUTH_KEY_INVALID"
+ErrAuthTokenInvalid Code = "ERR_AUTH_TOKEN_INVALID"
+ErrAuthTokenExpired Code = "ERR_AUTH_TOKEN_EXPIRED"
+```
+
+The string `"ERR_AUTH_KEY_MISSING"` does not appear in the central errcode registry. Meanwhile `"ERR_AUTH_KEY_INVALID"` exists in errcode but is not used by the auth module. This creates two separate code families for auth key errors.
+
+**Fix:** Consolidate: use `errcode.ErrAuthKeyInvalid` for invalid key data and add `ErrAuthKeyMissing` to the central errcode package if the distinction is needed.
+
+---
+
+### F-09: RS256 algorithm pinning is correct -- confirmed (No Finding)
+
+Positive confirmation: `JWTVerifier.Verify` at `jwt.go:33` checks `token.Method.(*jwt.SigningMethodRSA)` before returning the public key. This correctly rejects HS256, `none`, and all non-RSA algorithms. Tests confirm rejection of HS256 (`TestJWTVerifier_RejectsHS256`) and `none` (`TestJWTVerifier_RejectsAlgNone`). The PR#16 fix is properly in place.
+
+---
+
+### F-10: HMAC comparison uses constant-time `hmac.Equal` -- confirmed (No Finding)
+
+Positive confirmation: `servicetoken.go:83` uses `hmac.Equal(providedMAC, expectedMAC)` which is constant-time, preventing timing attacks. The empty-secret fail-fast at `servicetoken.go:29-36` is also correct.
+
+---
+
+## Layering Compliance Check
+
+| Check | Result |
+|-------|--------|
+| kernel/ imports runtime/auth? | N/A (not applicable -- this IS runtime/) |
+| runtime/auth imports cells/? | PASS -- no cell imports |
+| runtime/auth imports adapters/? | PASS -- no adapter imports |
+| runtime/auth imports only pkg/ + stdlib + golang-jwt | PASS |
+| Cross-Cell communication via contract? | N/A |
+| CUD operations with consistency level? | N/A (no CUD -- pure auth logic) |
+
+---
+
+## Test Coverage Assessment
+
+| File | Test File | Test Count | Assessment |
+|------|-----------|------------|------------|
+| auth.go (61 LOC) | auth_test.go | 2 | Good -- context round-trip covered |
+| jwt.go (142 LOC) | jwt_test.go | 8 | Strong -- RS256 valid, expired, HS256 reject, none reject, wrong key, malformed, round-trip, no-roles |
+| keys.go (115 LOC) | keys_test.go + jwt_test.go | 5 | Good -- PKCS#1, PKCS#8, missing env, invalid PEM, valid keys |
+| middleware.go (139 LOC) | middleware_test.go | 11 | Strong -- valid, missing, invalid, non-bearer, public endpoints (default+custom), require-role (has/missing/no-claims/authorizer-fallback/authorizer-error) |
+| servicetoken.go (112 LOC) | servicetoken_test.go | 11 | Strong -- valid, invalid, missing, wrong scheme, different path, empty secret, expired, exact boundary, within window, future timestamp, deterministic |
+
+Estimated coverage: ~85-90% (above 80% threshold). Missing edge cases: empty-string subject in Issue, very large Extra claims map, concurrent Verify calls (though the implementation is stateless and safe).
+
+---
+
+## Risk Matrix
+
+| Risk | Level | Mitigation |
+|------|-------|------------|
+| Algorithm confusion (HS256/none) | LOW | RS256 pinned, tested |
+| Timing attack on HMAC | LOW | `hmac.Equal` used |
+| Weak RSA key accepted | MEDIUM | No min-key-size check (F-02) |
+| Token revocation gap | LOW-MEDIUM | Short TTL recommended but not enforced (F-07) |
+| Error code duplication | LOW | Functional but confusing (F-01) |
+| Layering violation | NONE | Clean dependency graph |
+
+---
+
+## Findings Summary
+
+| ID | Severity | Category | File | Description |
+|----|----------|----------|------|-------------|
+| F-01 | P1 | Code quality | jwt.go:54, errcode.go:24 | Duplicate ErrAuthUnauthorized definition |
+| F-02 | P1 | Security | keys.go, jwt.go | No minimum RSA key size validation |
+| F-03 | P1 | Error handling | keys.go:82,90,101,109 | Bare fmt.Errorf in exported-path functions |
+| F-04 | P2 | Error handling | middleware.go:133 | writeAuthError ignores JSON encode error |
+| F-05 | P2 | Security | middleware.go:40 | Exact-match whitelist not documented |
+| F-06 | P2 | Test quality | servicetoken.go:19 | Package-level mutable nowFunc |
+| F-07 | P2 | Security design | jwt.go | No JTI / revocation support |
+| F-08 | P2 | DX/naming | keys.go:46, errcode.go:37 | ErrKeyMissing vs ErrAuthKeyInvalid inconsistency |
+
+**P0: 0 | P1: 3 | P2: 5 | Total: 8**

--- a/docs/reviews/202604060830-R0/R1C-2-runtime-eventbus-worker.md
+++ b/docs/reviews/202604060830-R0/R1C-2-runtime-eventbus-worker.md
@@ -1,0 +1,362 @@
+# R1C-2: runtime/eventbus + runtime/worker Review Report
+
+- **Reviewer agent**: R1C-2 (runtime/eventbus, runtime/worker)
+- **Review baseline commit**: `ce03ba1` (HEAD of develop at review time)
+- **Review date**: 2026-04-06
+- **Seats exercised**: S1 (Architecture), S3 (Test/Regression), S5 (DX/Maintainability)
+
+---
+
+## Review Scope
+
+| Package | Source files | LOC (source) | Test files | LOC (test) |
+|---------|-------------|-------------|------------|------------|
+| `runtime/eventbus` | `eventbus.go`, `doc.go` | 237 | `eventbus_test.go` | 226 |
+| `runtime/worker` | `worker.go`, `periodic.go`, `doc.go` | 96 | `worker_test.go` | 204 |
+| **Total** | **5 source** | **~333** | **2 test** | **~430** |
+
+### Downstream consumers examined
+
+- `adapters/postgres/outbox_relay.go` -- implements both `outbox.Relay` and `worker.Worker`
+- `runtime/bootstrap/bootstrap.go` -- orchestrates `worker.WorkerGroup` and `eventbus.InMemoryEventBus`
+- All `cells/*/cell_test.go` and `cells/*/slices/*/service_test.go` -- use `eventbus.New()` as test double
+
+---
+
+## Dependency Direction Check
+
+| Check | Result | Evidence |
+|-------|--------|----------|
+| `runtime/eventbus` imports kernel/ or pkg/ only | PASS | Imports: `kernel/outbox`, `pkg/errcode`, `pkg/uid`, stdlib (`context`, `log/slog`, `sync`, `time`) |
+| `runtime/eventbus` does NOT import cells/ or adapters/ | PASS | No such imports |
+| `runtime/worker` imports only stdlib | PASS | Imports: `context`, `log/slog`, `sync`, `time` -- no kernel/ or pkg/ deps at all |
+| `runtime/worker` does NOT import cells/ or adapters/ | PASS | No such imports |
+| Cells depend on `outbox.Publisher` interface, not concrete `InMemoryEventBus` | PASS | All cell production code uses `outbox.Publisher`; `eventbus.New()` appears only in `_test.go` files |
+| `adapters/postgres/outbox_relay.go` depends on `runtime/worker.Worker` (interface) | PASS | Compile-time check at line 20: `_ worker.Worker = (*OutboxRelay)(nil)` |
+
+---
+
+## Findings
+
+### R1C2-F01 | P1 | eventbus: Close() + Subscribe() race on channel read after close
+
+- **Seat**: S1 (Architecture), S3 (Test)
+- **File**: `src/runtime/eventbus/eventbus.go:138-148`, `src/runtime/eventbus/eventbus.go:152-168`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: In `Close()` (line 152-168), the bus cancels each subscription's context and then closes its channel in the same loop iteration. Meanwhile, in `Subscribe()` (line 138-148), the select statement reads from `sub.ch`. There is a timing window where:
+
+1. `Close()` calls `sub.cancel()` -- this triggers `subCtx.Done()` to become ready.
+2. `Close()` calls `close(sub.ch)` -- this makes `sub.ch` readable (yields zero value).
+3. In `Subscribe`, the `select` at line 139-148 non-deterministically picks between `<-subCtx.Done()` and `<-sub.ch`. If `<-sub.ch` wins after close, `ok` is `false` and the goroutine returns cleanly (line 143-145). This path is fine.
+
+However, the real risk is subtler: if a **new message** is sent to `sub.ch` by `Publish()` concurrently with `Close()`, the RWMutex protects `Publish` from writing to the map after `closed=true`, but `Publish()` may already be inside the `RLock` section iterating subscribers at line 99-108 when `Close()` acquires the write lock. Because `Close()` holds `mu.Lock()` while closing channels, and `Publish()` holds `mu.RLock()` while sending to channels, the `RLock` in `Publish` blocks `Close()` from acquiring `Lock` -- so `close(sub.ch)` cannot execute while `Publish` is in-flight. This means the mutex correctly prevents sending to a closed channel.
+
+**After deeper analysis**: The RWMutex discipline is actually sound. `Publish` holds `RLock` during the send, and `Close` acquires `Lock` before closing channels. This prevents the "send on closed channel" panic. The concern is mitigated by the existing locking. **Downgrading this to P2** -- the code is correct but the lack of an explicit comment explaining this invariant makes it a maintenance hazard.
+
+**Revised severity**: P2
+
+**Suggested fix**: Add a comment above the `Close()` method explaining why the RWMutex prevents send-on-closed-channel panics:
+
+```go
+// Close terminates all subscriber goroutines and prevents new publishes.
+// Safety: Close holds mu.Lock(), which excludes all Publish() calls (which
+// hold mu.RLock()), so no goroutine can send to sub.ch while Close is
+// executing close(sub.ch).
+```
+
+---
+
+### R1C2-F02 | P1 | eventbus: Subscribe leaks subscription from subs map on exit
+
+- **Seat**: S1 (Architecture)
+- **File**: `src/runtime/eventbus/eventbus.go:118-149`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: When `Subscribe()` returns (either by context cancellation at line 140-141 or channel close at line 143-145), the `subscription` struct remains in `b.subs[topic]`. This means:
+
+1. If a caller subscribes and then cancels, the stale `*subscription` stays in the slice.
+2. Subsequent `Publish()` calls iterate over the stale subscription and attempt to send to its channel. The channel is not closed by `Subscribe()` on exit (only `Close()` closes channels). Sending to the channel will succeed (the message is buffered or dropped) but no goroutine is reading from it, so messages are silently lost.
+3. Over time, repeated subscribe/cancel cycles accumulate stale subscriptions, leaking memory (the channel buffer) and masking message drops.
+
+This is particularly relevant for long-running services that dynamically subscribe/unsubscribe to topics (e.g., during config reload or cell restart).
+
+**Suggested fix**: On `Subscribe()` return, remove the subscription from `b.subs[topic]` and close the channel:
+
+```go
+defer func() {
+    b.mu.Lock()
+    subs := b.subs[topic]
+    for i, s := range subs {
+        if s == sub {
+            b.subs[topic] = append(subs[:i], subs[i+1:]...)
+            break
+        }
+    }
+    b.mu.Unlock()
+    close(sub.done)
+}()
+```
+
+---
+
+### R1C2-F03 | P1 | worker: WorkerGroup.Start does not cancel remaining workers on first failure
+
+- **Seat**: S1 (Architecture)
+- **File**: `src/runtime/worker/worker.go:47-72`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: `WorkerGroup.Start()` launches all workers concurrently and waits for all of them to finish (`wg.Wait()`). If one worker returns an error, the error is recorded (line 65) but the other workers continue running until they independently exit. The caller's context (`ctx`) is not cancelled.
+
+In `bootstrap.go` (line 310-323), the pattern is:
+
+```go
+workerCtx, workerCancel := context.WithCancel(ctx)
+go func() { workerErrCh <- wg.Start(workerCtx) }()
+```
+
+If one worker fails, `workerErrCh` only receives the error **after all workers have exited** (`wg.Wait()` at line 71). This means the bootstrap shutdown is delayed until all workers happen to exit on their own. If a worker blocks indefinitely (which is the `Worker.Start` contract: "block until ctx is cancelled"), then a single worker failure does not trigger shutdown of sibling workers.
+
+The go-zero `ServiceGroup` reference implementation cancels all services on any single failure.
+
+**Suggested fix**: Accept a cancellable context and cancel sibling workers on first error:
+
+```go
+func (g *WorkerGroup) Start(ctx context.Context) error {
+    ctx, cancel := context.WithCancel(ctx)
+    defer cancel()
+    // ... launch workers with this derived ctx ...
+    // On first error, call cancel() to signal siblings.
+}
+```
+
+Alternatively, add a `CancelOnError bool` field to `WorkerGroup` to make this opt-in.
+
+---
+
+### R1C2-F04 | P1 | worker: PeriodicWorker missing compile-time interface check
+
+- **Seat**: S3 (Test), S5 (DX)
+- **File**: `src/runtime/worker/periodic.go`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: `PeriodicWorker` implements the `Worker` interface (`Start(ctx) error`, `Stop(ctx) error`), but there is no compile-time assertion `var _ Worker = (*PeriodicWorker)(nil)` in the package. The `adapters/postgres/outbox_relay.go` correctly has `var _ worker.Worker = (*OutboxRelay)(nil)` (line 20), and `eventbus_test.go` has `var _ outbox.Publisher = (*InMemoryEventBus)(nil)` (line 223). `PeriodicWorker` should follow the same pattern.
+
+If the `Worker` interface evolves (e.g., adding a `Name() string` method), the breakage in `PeriodicWorker` will only be caught when a test constructs and uses it, not at compile time.
+
+**Suggested fix**: Add to `periodic.go` or `worker.go`:
+
+```go
+// Compile-time interface check.
+var _ Worker = (*PeriodicWorker)(nil)
+```
+
+---
+
+### R1C2-F05 | P1 | worker: PeriodicWorker.Stop is not safe against double-Start
+
+- **Seat**: S1 (Architecture)
+- **File**: `src/runtime/worker/periodic.go:18-52`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: `PeriodicWorker` creates the `done` channel once in the constructor (line 20: `done: make(chan struct{})`). If `Start()` is called twice (either concurrently or sequentially after a stop), both goroutines share the same `done` channel. After the first `Stop()` closes `done`, the second `Start()` will immediately exit because `<-p.done` is ready.
+
+There is no guard against double-start or restart. While the `WorkerGroup` only calls `Start` once, a standalone usage of `PeriodicWorker` could hit this.
+
+**Suggested fix**: Either (a) document that `PeriodicWorker` is single-use, or (b) recreate the `done` channel in `Start()`:
+
+```go
+func (p *PeriodicWorker) Start(ctx context.Context) error {
+    p.done = make(chan struct{}) // fresh channel per Start
+    // ... rest of logic
+}
+```
+
+Option (b) introduces its own race if `Stop()` is called concurrently with `Start()` assigning a new channel. A `sync.Once` or `atomic` state flag is safer.
+
+---
+
+### R1C2-F06 | P1 | eventbus: handleWithRetry uses time.After without jitter
+
+- **Seat**: S5 (DX/Maintainability)
+- **File**: `src/runtime/eventbus/eventbus.go:197-231`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: The retry delay at line 202 uses pure exponential backoff (`baseRetryDelay * (1 << attempt)`) without jitter. When multiple subscribers fail simultaneously on the same topic, they all retry at the exact same intervals (100ms, 200ms, 400ms), causing a "thundering herd" effect. The Watermill reference implementation uses randomized backoff.
+
+For an in-memory dev/test bus this is unlikely to cause real issues, but since this code is referenced as the pattern for production consumer implementations (per the `eventbus.md` rule), it sets a bad precedent.
+
+**Suggested fix**: Add random jitter (e.g., +/- 25%):
+
+```go
+jitter := time.Duration(rand.Int63n(int64(delay) / 2))
+delay = delay + jitter - delay/4
+```
+
+Or document clearly that production implementations must add jitter.
+
+---
+
+### R1C2-F07 | P2 | worker: WorkerGroup does not prevent Add after Start
+
+- **Seat**: S5 (DX/Maintainability)
+- **File**: `src/runtime/worker/worker.go:38-42`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: `Add()` can be called after `Start()` has already launched workers. The newly added worker will not be started (since `Start` already copied the slice and is running). This is a silent misconfiguration. The go-zero `ServiceGroup` prevents adds after start.
+
+**Suggested fix**: Add a `started bool` field; `Add()` should return an error (or panic) if called after `Start()`.
+
+---
+
+### R1C2-F08 | P2 | eventbus: doc.go and eventbus.go have different package doc comments
+
+- **Seat**: S5 (DX)
+- **File**: `src/runtime/eventbus/doc.go:1-4`, `src/runtime/eventbus/eventbus.go:1-8`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: `doc.go` says "delivers messages synchronously and is not suitable for production use", while `eventbus.go` says "in-memory implementation of kernel/outbox.Publisher and kernel/outbox.Subscriber for development and testing". Both are package-level doc comments. Go tooling picks one (typically alphabetically first file, which is `doc.go`). The `eventbus.go` comment is more detailed and includes the Watermill reference. Having two competing comments is confusing.
+
+**Suggested fix**: Remove the package comment from `eventbus.go` (keep only the `doc.go` one, but merge the Watermill reference and design notes into it).
+
+---
+
+### R1C2-F09 | P2 | worker: doc.go and worker.go have different package doc comments
+
+- **Seat**: S5 (DX)
+- **File**: `src/runtime/worker/doc.go:1-3`, `src/runtime/worker/worker.go:1-8`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: Same issue as F08. `doc.go` says "Worker interface and WorkerGroup for managing concurrent background workers with graceful lifecycle control." while `worker.go` has a longer comment including the go-zero reference. Only one survives in `go doc`.
+
+**Suggested fix**: Consolidate into `doc.go`, remove the package comment from `worker.go`.
+
+---
+
+### R1C2-F10 | P2 | eventbus: DeadLetterLen uses Mutex instead of RWMutex for read-only operation
+
+- **Seat**: S5 (DX/Maintainability)
+- **File**: `src/runtime/eventbus/eventbus.go:182-186`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: `DeadLetterLen()` and `DrainDeadLetters()` both use `deadLettersMu.Lock()` (exclusive lock). `DeadLetterLen()` is a read-only operation and could use `RLock()` if `deadLettersMu` were a `sync.RWMutex`. This is a minor performance concern (read contention on the dead letter count) but more importantly a code clarity issue -- readers seeing `Lock()` for a read-only function may wonder if there's a hidden mutation.
+
+**Suggested fix**: Change `deadLettersMu` to `sync.RWMutex` and use `RLock()` in `DeadLetterLen()`.
+
+---
+
+### R1C2-F11 | P2 | worker: WorkerGroup error handling loses context from multiple failures
+
+- **Seat**: S5 (DX)
+- **File**: `src/runtime/worker/worker.go:53-72`
+- **Commit**: `ce03ba1`
+- **Status**: OPEN
+
+**Description**: `Start()` captures only the first error via `errOnce.Do` (line 65). If multiple workers fail, only the first error is returned; subsequent errors are logged but discarded from the return value. For debugging, it would be useful to aggregate all errors (e.g., via `errors.Join` from Go 1.20+).
+
+Similarly, `Stop()` (line 76-93) also returns only the first error.
+
+**Suggested fix**: Use `errors.Join(firstErr, err)` to aggregate all worker errors into the return value.
+
+---
+
+## Test Coverage Assessment
+
+### eventbus test coverage
+
+| Test case | What it covers |
+|-----------|---------------|
+| `TestPublishSubscribe` | Happy path: 2 messages delivered to 1 subscriber |
+| `TestPublish_NoSubscribers` | Publish to topic with no subscribers (no-op, no error) |
+| `TestSubscribe_RetryAndDeadLetter` | All 3 retries fail -> dead letter queue |
+| `TestClose_PreventsFurtherPublish` | Publish after Close returns error |
+| `TestClose_Idempotent` | Double-close is safe |
+| `TestSubscribe_ClosedBus` | Subscribe to closed bus returns error |
+| `TestMultipleSubscribers` | Fan-out: 1 message delivered to 2 subscribers |
+| `TestSubscribe_SuccessAfterRetry` | Handler succeeds on 3rd attempt -> no dead letter |
+| `TestHealth` | Health reports "healthy" / "closed" |
+| `TestTopicConfigChangedConstant` | Constant value assertion |
+| Compile-time checks | `var _ outbox.Publisher = (*InMemoryEventBus)(nil)` and `Subscriber` |
+
+**Missing test scenarios**:
+- Buffer-full message drop (subscriber buffer is full, publish should log warning and not block) -- the `WithBufferSize` option is tested implicitly but the drop path is not exercised.
+- Concurrent publish/subscribe stress test (race detector).
+- Subscribe context cancellation during retry backoff (the `time.After` select in `handleWithRetry` line 207-210 covers this but is not tested explicitly).
+- Unsubscribe / re-subscribe lifecycle (related to F02).
+
+### worker test coverage
+
+| Test case | What it covers |
+|-----------|---------------|
+| `TestWorkerGroup_StartStop` | Start 2 workers, cancel context, verify Canceled error |
+| `TestWorkerGroup_StartError` | Worker returns immediate error |
+| `TestWorkerGroup_Stop` | Stop directly (without Start) |
+| `TestWorkerGroup_StopSerialReverseOrder` | Reverse-order stop verification |
+| `TestPeriodicWorker_ExecutesFunction` | Function called >= 3 times |
+| `TestPeriodicWorker_PanicIsolation` | Panic on 1st call, continues on subsequent |
+| `TestPeriodicWorker_Stop` | Stop via `Stop()` method (not context) |
+
+**Missing test scenarios**:
+- `PeriodicWorker` compile-time interface check (F04).
+- `PeriodicWorker` double-start behavior (F05).
+- `WorkerGroup.Add` after `Start` (F07).
+- `WorkerGroup` with zero workers (edge case -- `Start` should return immediately).
+- Stop with context timeout (verify behavior when `Stop(ctx)` context expires).
+
+---
+
+## Architecture Notes
+
+### Should Worker interface move to kernel/?
+
+The `Worker` interface is currently in `runtime/worker`. It is consumed by `adapters/postgres/outbox_relay.go` and `runtime/bootstrap/bootstrap.go`. The kernel `outbox.Relay` interface already defines `Start(ctx) error` and `Stop(ctx) error` with the same signature as `Worker`.
+
+**Assessment**: `Worker` is a generic runtime concern (background task lifecycle), not a domain/governance concept. Keeping it in `runtime/` is correct per the GoCell layering rules. The `outbox.Relay` interface in `kernel/` is domain-specific (outbox relay semantics). The fact that `OutboxRelay` implements both is appropriate -- it IS both a worker and a relay. No change needed.
+
+### RunConfig
+
+No `RunConfig` type exists in the codebase. The worker package uses a simple `Worker` interface + `WorkerGroup` pattern. The `PeriodicWorker` accepts its configuration (interval + function) via constructor parameters. This is clean and sufficient for the current scope.
+
+### eventbus as test double vs. production component
+
+The `InMemoryEventBus` is documented as "for development and testing" (doc.go). However, all three example applications (`sso-bff`, `todo-order`, `iot-device`) and the `cmd/core-bundle` main use it as their **only** event bus. There is no production event bus adapter (e.g., RabbitMQ, Kafka). This is noted but not a finding -- it is an expected gap for the current project stage.
+
+---
+
+## Findings Summary
+
+| ID | Severity | Category | File | Description |
+|----|----------|----------|------|-------------|
+| R1C2-F01 | ~~P1~~ P2 | Thread safety | `eventbus.go:152-168` | Close/Publish RWMutex invariant undocumented (code is correct) |
+| R1C2-F02 | **P1** | Resource leak | `eventbus.go:118-149` | Subscribe leaks subscription from subs map on exit |
+| R1C2-F03 | **P1** | Lifecycle | `worker.go:47-72` | WorkerGroup.Start does not cancel siblings on first failure |
+| R1C2-F04 | **P1** | Interface | `periodic.go` | PeriodicWorker missing compile-time Worker interface check |
+| R1C2-F05 | **P1** | Lifecycle | `periodic.go:18-52` | PeriodicWorker not safe against double-Start |
+| R1C2-F06 | **P1** | Retry | `eventbus.go:197-231` | handleWithRetry uses pure exponential backoff without jitter |
+| R1C2-F07 | P2 | DX | `worker.go:38-42` | WorkerGroup.Add after Start silently ignored |
+| R1C2-F08 | P2 | DX | `eventbus doc.go + eventbus.go` | Duplicate package doc comments |
+| R1C2-F09 | P2 | DX | `worker doc.go + worker.go` | Duplicate package doc comments |
+| R1C2-F10 | P2 | DX | `eventbus.go:182-186` | DeadLetterLen uses Mutex for read-only op |
+| R1C2-F11 | P2 | DX | `worker.go:53-72` | Multiple worker errors lost (only first returned) |
+
+**Totals**: 0 P0, 5 P1, 6 P2
+
+---
+
+## Highlights
+
+1. **Clean dependency direction**: Both packages strictly follow the GoCell layering rules. `eventbus` depends only on `kernel/outbox` + `pkg/`. `worker` depends only on stdlib. No reverse dependencies.
+2. **Good interface discipline**: Cells consume `outbox.Publisher` (kernel interface), not the concrete `InMemoryEventBus`. The `adapters/postgres/outbox_relay.go` correctly verifies both `outbox.Relay` and `worker.Worker` interface compliance at compile time.
+3. **Solid test coverage**: Both packages have comprehensive test suites covering happy paths, error paths, concurrency, panic isolation, and idempotent close. The eventbus tests use proper synchronization (`sync.Mutex`, `atomic.Int32`, `Eventually`).
+4. **Reference traceability**: Both packages cite their reference frameworks (Watermill for eventbus, go-zero for worker) in package-level comments with adopted/deviated notes, per project convention.
+5. **Error handling**: `eventbus` uses `pkg/errcode` for all returned errors (`ErrBusClosed`). `worker` does not return domain errors (only propagates worker errors or `ctx.Err()`), which is appropriate.

--- a/docs/reviews/202604060830-R0/R1C-3-runtime-config-shutdown.md
+++ b/docs/reviews/202604060830-R0/R1C-3-runtime-config-shutdown.md
@@ -1,0 +1,461 @@
+# R1C-3: runtime/config + runtime/shutdown Review
+
+| Field | Value |
+|-------|-------|
+| Reviewer | R1C-3 (multi-seat: S1 Architecture, S3 Test, S4 Ops, S5 DX) |
+| Scope | `src/runtime/config/` (~342 LOC), `src/runtime/shutdown/` (~99 LOC) |
+| Baseline commit | ce03ba1 (develop HEAD) |
+| Date | 2026-04-06 |
+
+---
+
+## Files Reviewed
+
+| File | LOC (approx) | Purpose |
+|------|-------------|---------|
+| `src/runtime/config/config.go` | 216 | Config interface, YAML+env loading, Reload, flatten/setNested |
+| `src/runtime/config/watcher.go` | 114 | fsnotify file watcher with callback dispatch |
+| `src/runtime/config/doc.go` | 14 | Package godoc |
+| `src/runtime/config/config_test.go` | 189 | Tests for Load/Scan/Keys/Reload |
+| `src/runtime/config/watcher_test.go` | 90 | Tests for Watcher lifecycle |
+| `src/runtime/shutdown/shutdown.go` | 97 | Graceful shutdown Manager with LIFO hooks |
+| `src/runtime/shutdown/shutdown_test.go` | 137 | Tests for LIFO, error continuation, signal, timeout |
+| `src/runtime/shutdown/doc.go` | 3 | Package godoc |
+
+---
+
+## Summary
+
+Both modules are well-structured and compact. `runtime/config` provides a clean Config interface with YAML+env loading, hot-reload via fsnotify, and proper RWMutex protection for concurrent reads/writes. `runtime/shutdown` implements LIFO hook execution with signal handling and timeout. The integration with `runtime/bootstrap` is coherent.
+
+Key strengths:
+- Config uses `sync.RWMutex` correctly for concurrent access
+- Reload is atomic: new data prepared in local vars, then swapped under write lock
+- Watcher copies callback slice before invoking, avoiding lock-during-callback
+- Watcher recovers panics in callbacks
+- Shutdown LIFO order is correct and tested
+- All hooks execute even if one fails
+- Double-close safety on Watcher
+- `ref:` tag present in config.go header (go-micro reference)
+
+---
+
+## Findings
+
+### F01 -- [S1 Architecture] P2 -- Watcher.Close() calls fsnotify.Close() on every invocation
+
+**File:** `src/runtime/config/watcher.go:105-113`
+
+**Evidence:**
+```go
+func (w *Watcher) Close() error {
+    select {
+    case <-w.done:
+        // Already closed.
+    default:
+        close(w.done)
+    }
+    return w.watcher.Close() // called EVERY time, even after done is already closed
+}
+```
+
+**Description:** The `done` channel is properly guarded against double-close, but `w.watcher.Close()` is called unconditionally on every `Close()` invocation. While `fsnotify.Watcher.Close()` is documented as safe to call multiple times (it returns nil), this is relying on an implementation detail. Logically, the second branch should return early.
+
+**Severity:** P2
+
+**Suggestion:**
+```go
+func (w *Watcher) Close() error {
+    select {
+    case <-w.done:
+        return nil // Already closed
+    default:
+        close(w.done)
+    }
+    return w.watcher.Close()
+}
+```
+
+**Status:** OPEN
+
+---
+
+### F02 -- [S1 Architecture] P2 -- Close() has TOCTOU race on `done` channel
+
+**File:** `src/runtime/config/watcher.go:105-113`
+
+**Evidence:**
+```go
+func (w *Watcher) Close() error {
+    select {
+    case <-w.done:
+        // Already closed.
+    default:
+        close(w.done)   // Two goroutines can both reach this line concurrently
+    }
+    ...
+```
+
+**Description:** If two goroutines call `Close()` concurrently, both could enter the `default` branch and both attempt `close(w.done)`, causing a panic on double-close of a channel. The `select` on a closed channel is not atomic with the `close()` call. This is plausible in practice: `StartWithContext` launches a goroutine that calls `Close()` on context cancellation, while the caller may also call `Close()` directly.
+
+**Severity:** P1
+
+**Suggestion:** Use `sync.Once`:
+```go
+type Watcher struct {
+    // ...
+    closeOnce sync.Once
+    closeErr  error
+}
+
+func (w *Watcher) Close() error {
+    w.closeOnce.Do(func() {
+        close(w.done)
+        w.closeErr = w.watcher.Close()
+    })
+    return w.closeErr
+}
+```
+
+**Status:** OPEN
+
+---
+
+### F03 -- [S3 Test] P1 -- No concurrent read/write test for Config
+
+**File:** `src/runtime/config/config_test.go`
+
+**Evidence:** All test functions run sequentially. No test calls `Get()` from multiple goroutines while `Reload()` runs.
+
+**Description:** The `config` struct uses `sync.RWMutex` to protect concurrent access, but there is no test exercising this under the race detector. A concurrent test with `-race` would validate the correctness of the locking. Given that `Reload` is designed to be called from watcher callbacks (different goroutine), this is a real usage scenario.
+
+**Severity:** P1
+
+**Suggestion:** Add a test like:
+```go
+func TestConfig_ConcurrentReadReload(t *testing.T) {
+    // Create config, then spawn N goroutines doing Get()
+    // while main goroutine calls Reload() in a loop
+    // Run with -race flag
+}
+```
+
+**Status:** OPEN
+
+---
+
+### F04 -- [S3 Test] P2 -- No test for Watcher callback panic recovery
+
+**File:** `src/runtime/config/watcher_test.go`
+
+**Evidence:** `watcher.go:83-87` has panic recovery, but no test triggers a panicking callback.
+
+**Description:** The watcher has a `defer recover()` guard in the callback dispatch loop (line 83-87), which is good defensive programming. However, there is no test verifying that (a) a panicking callback does not crash the watcher loop, and (b) subsequent callbacks still fire.
+
+**Severity:** P2
+
+**Suggestion:** Add a test with a panicking first callback and a normal second callback, assert both are dispatched.
+
+**Status:** OPEN
+
+---
+
+### F05 -- [S5 DX] P2 -- Scan() does not reflect env overrides in structured output
+
+**File:** `src/runtime/config/config.go:80-93`
+
+**Evidence:**
+```go
+func (c *config) Scan(dest interface{}) error {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    b, err := yaml.Marshal(c.raw)
+    // ...
+    if err := yaml.Unmarshal(b, dest); err != nil {
+```
+
+The `raw` map is updated by `applyEnv` via `setNested`, so env overrides ARE reflected in Scan. However, the type is always `string` from env vars (line 175: `data[key] = v` where `v` is a string), while YAML parsing may produce `int`, `bool`, etc.
+
+**Description:** When an env var overrides a YAML key like `server.port: 8080`, the `raw` map will contain the string `"9090"` instead of the integer `9090`. `Scan` then marshals this to YAML and unmarshals it into a struct. Since YAML unmarshaling handles string-to-int conversion, this works in most cases. However, it can produce unexpected behavior for boolean fields: `"true"` (string) vs `true` (bool) may not always round-trip identically depending on the struct tag and YAML library version.
+
+The `Get()` return type also changes from `int` to `string` after env override, which is a semantic surprise for callers (see `TestLoad_EnvOverridesYAML` where the assertion checks for string `"9090"` not int `9090`).
+
+**Severity:** P2
+
+**Suggestion:** Document this type coercion behavior clearly in the Config interface godoc, or consider type-aware env parsing (detect numeric/bool strings).
+
+**Status:** OPEN
+
+---
+
+### F06 -- [S1 Architecture] P2 -- shutdown.Manager.Register is not goroutine-safe
+
+**File:** `src/runtime/shutdown/shutdown.go:48-49`
+
+**Evidence:**
+```go
+func (m *Manager) Register(h Hook) {
+    m.hooks = append(m.hooks, h)
+}
+```
+
+**Description:** `Register` directly appends to the `hooks` slice without any synchronization. If `Register` is called from multiple goroutines (e.g., during parallel cell initialization), this is a data race. In practice, the current bootstrap code registers hooks sequentially, so this is not an active bug, but it violates the principle of making concurrent-use types safe by default.
+
+**Severity:** P2
+
+**Suggestion:** Add a `sync.Mutex` to protect `Register` and `runHooks`, or document clearly that `Register` must not be called concurrently or after `Wait`/`Shutdown`.
+
+**Status:** OPEN
+
+---
+
+### F07 -- [S3 Test] P2 -- shutdown.Manager timeout test does not assert DeadlineExceeded
+
+**File:** `src/runtime/shutdown/shutdown_test.go:59-70`
+
+**Evidence:**
+```go
+func TestManager_Shutdown_Timeout(t *testing.T) {
+    m := New(WithTimeout(50 * time.Millisecond))
+    m.Register(func(ctx context.Context) error {
+        <-ctx.Done()
+        return ctx.Err()
+    })
+    err := m.Shutdown()
+    assert.Error(t, err)  // only checks non-nil, not the specific error
+}
+```
+
+**Description:** The test only asserts `err != nil` but does not verify that the error is `context.DeadlineExceeded`. This weakens the test -- it would pass even if the error source changed to something unrelated.
+
+**Severity:** P2
+
+**Suggestion:** `assert.ErrorIs(t, err, context.DeadlineExceeded)`
+
+**Status:** OPEN
+
+---
+
+### F08 -- [S5 DX] P2 -- Config.Get returns `any` with no type helper
+
+**File:** `src/runtime/config/config.go:24-26`
+
+**Evidence:**
+```go
+type Config interface {
+    Get(key string) any
+    Scan(dest interface{}) error
+    Keys() []string
+}
+```
+
+**Description:** `Get` returns `any`, requiring callers to type-assert every value. The go-micro reference (primary framework) provides typed helpers like `config.Get("key").String("")`, `config.Get("key").Int(0)`. For DX, a `GetString(key, default)` / `GetInt(key, default)` pattern would reduce boilerplate and prevent runtime panics from bad assertions.
+
+**Severity:** P2
+
+**Suggestion:** Add typed convenience methods (at least `GetString`, `GetInt`, `GetBool`, `GetDuration`) that return the value or a default, matching the go-micro pattern referenced in the file header.
+
+**Status:** OPEN
+
+---
+
+### F09 -- [S1 Architecture] P2 -- No validation hook in Reload path
+
+**File:** `src/runtime/config/config.go:109-129`
+
+**Evidence:**
+```go
+func (c *config) Reload(yamlPath string, envPrefix string) error {
+    newData := make(map[string]any)
+    newRaw := make(map[string]any)
+    if yamlPath != "" {
+        raw, err := readYAML(yamlPath)
+        // ...
+        newRaw = raw
+        flatten("", raw, newData)
+    }
+    applyEnv(envPrefix, newData, newRaw)
+    c.mu.Lock()
+    c.data = newData
+    c.raw = newRaw
+    c.mu.Unlock()
+    return nil
+}
+```
+
+**Description:** `Reload` applies the new configuration unconditionally as long as the YAML is syntactically valid. There is no validation callback to reject semantically invalid configurations (e.g., port out of range, missing required keys). The CLAUDE.md and framework comparison reference go-micro which supports validation on reload. An invalid config file change on disk would be silently applied.
+
+**Severity:** P2
+
+**Suggestion:** Add an optional `ValidateFunc(map[string]any) error` field to `config` (or a `WithValidator` option for `Load`). If validation fails on reload, log an error and keep the old config. This is especially important for hot-reload scenarios.
+
+**Status:** OPEN
+
+---
+
+### F10 -- [S4 Ops] P2 -- No debounce on file watcher events
+
+**File:** `src/runtime/config/watcher.go:68-101`
+
+**Evidence:**
+```go
+func (w *Watcher) loop() {
+    for {
+        select {
+        case event, ok := <-w.watcher.Events:
+            if !ok { return }
+            if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+                // immediately invoke all callbacks
+```
+
+**Description:** File editors (vim, VS Code) often produce multiple rapid write events for a single save operation (write temp file, rename, etc.). The watcher fires callbacks on every `Write` or `Create` event without any debounce, which can trigger multiple rapid Reload calls. In the bootstrap integration, each event triggers a full YAML re-parse and map swap, which is wasteful and could cause log spam.
+
+**Severity:** P2
+
+**Suggestion:** Add a configurable debounce interval (e.g., 100ms default) using a `time.Timer` that resets on each event, only firing the callbacks when the timer expires.
+
+**Status:** OPEN
+
+---
+
+### F11 -- [S3 Test] P1 -- Watcher test relies on timing with `time.Sleep`
+
+**File:** `src/runtime/config/watcher_test.go:33-42`
+
+**Evidence:**
+```go
+w.Start()
+
+// Give the watcher time to start.
+time.Sleep(50 * time.Millisecond)
+
+// Modify the file.
+require.NoError(t, os.WriteFile(file, []byte("key: val2"), 0o644))
+
+// Wait for callback.
+assert.Eventually(t, func() bool {
+    return called.Load() >= 1
+}, 2*time.Second, 50*time.Millisecond, ...)
+```
+
+**Description:** The 50ms sleep before file modification is a race-prone pattern. On slow CI machines, the watcher goroutine may not have started its `select` loop yet, causing the test to miss the write event. The `Eventually` timeout of 2 seconds provides a safety net, but the initial sleep is fragile. This has been a known flaky-test pattern with fsnotify.
+
+**Severity:** P1
+
+**Suggestion:** Use a "ready" signal from the watcher (e.g., a channel that closes once the loop starts its first `select`) instead of a fixed sleep. Alternatively, write the file in a retry loop until the callback fires.
+
+**Status:** OPEN
+
+---
+
+### F12 -- [S1 Architecture] P2 -- shutdown.runHooks returns ctx.Err() even on success
+
+**File:** `src/runtime/shutdown/shutdown.go:77-96`
+
+**Evidence:**
+```go
+func (m *Manager) runHooks(ctx context.Context) error {
+    var firstErr error
+    for i := len(m.hooks) - 1; i >= 0; i-- {
+        if err := m.hooks[i](ctx); err != nil {
+            // ...
+            if firstErr == nil { firstErr = err }
+        }
+    }
+    if firstErr != nil {
+        return firstErr
+    }
+    return ctx.Err()  // <--- returns context error even if all hooks succeeded
+}
+```
+
+**Description:** When all hooks succeed, `runHooks` returns `ctx.Err()`. If hooks complete quickly but the context happens to expire between the last hook and this line (possible with very short timeouts), the method returns `context.DeadlineExceeded` even though all hooks completed successfully. The `TestManager_NoHooks` test passes only because the 100ms timeout has not expired yet.
+
+More practically: looking at `Wait()` -- after running all hooks successfully, `ctx.Err()` will be nil because the context has not yet been cancelled (the timeout is 30s by default). So this is a theoretical concern but a correctness smell.
+
+**Severity:** P2
+
+**Suggestion:** Return `nil` when all hooks succeed:
+```go
+if firstErr != nil {
+    return firstErr
+}
+return nil
+```
+
+**Status:** OPEN
+
+---
+
+### F13 -- [S5 DX] P2 -- doc.go example in config uses incorrect NewFromMap key format
+
+**File:** `src/runtime/config/doc.go:12-13`
+
+**Evidence:**
+```go
+// For testing, use NewFromMap to create a Config from an existing map:
+//
+//	cfg := config.NewFromMap(map[string]any{"server.port": 8080})
+```
+
+**Description:** `NewFromMap` passes the map through `flatten()`, which expects nested maps. A flat key like `"server.port"` is treated as a single key (not split on dot), so `cfg.Get("server.port")` would return `8080` but `cfg.Scan()` would produce `{"server.port": 8080}` as a top-level key, not a nested `server.port` structure. The example is misleading because it suggests dot-separated keys work as input, but they are only meaningful for the flattened `data` map, not the `raw` map used by `Scan`.
+
+**Severity:** P2
+
+**Suggestion:** Update the example to use nested maps:
+```go
+//	cfg := config.NewFromMap(map[string]any{
+//	    "server": map[string]any{"port": 8080},
+//	})
+```
+
+**Status:** OPEN
+
+---
+
+## Dependency Compliance Check (All Seats)
+
+| Check | Result |
+|-------|--------|
+| `runtime/config` imports `cells/` | NO -- Clean |
+| `runtime/config` imports `adapters/` | NO -- Clean |
+| `runtime/shutdown` imports `cells/` | NO -- Clean |
+| `runtime/shutdown` imports `adapters/` | NO -- Clean |
+| `runtime/config` imports `kernel/` | NO -- Clean (only std lib + gopkg.in/yaml.v3 + fsnotify) |
+| `runtime/shutdown` imports `kernel/` | NO -- Clean (only std lib) |
+| Cross-Cell direct import | N/A (these are runtime packages) |
+| `ref:` tag present | YES -- config.go header has `ref: go-micro` |
+
+---
+
+## Findings Ledger Summary
+
+| ID | Severity | Seat | Category | File | Status |
+|----|----------|------|----------|------|--------|
+| F01 | P2 | S1 | Redundant fsnotify.Close call | watcher.go:105-113 | OPEN |
+| F02 | P1 | S1 | TOCTOU race in Watcher.Close | watcher.go:105-113 | OPEN |
+| F03 | P1 | S3 | Missing concurrent read/reload test | config_test.go | OPEN |
+| F04 | P2 | S3 | Missing panic-recovery test for watcher | watcher_test.go | OPEN |
+| F05 | P2 | S5 | Env override type coercion undocumented | config.go:175 | OPEN |
+| F06 | P2 | S1 | shutdown.Register not goroutine-safe | shutdown.go:48-49 | OPEN |
+| F07 | P2 | S3 | Timeout test does not assert DeadlineExceeded | shutdown_test.go:59-70 | OPEN |
+| F08 | P2 | S5 | No typed Get helpers (DX gap vs go-micro ref) | config.go:24-26 | OPEN |
+| F09 | P2 | S1 | No validation hook in Reload path | config.go:109-129 | OPEN |
+| F10 | P2 | S4 | No debounce on watcher events | watcher.go:68-101 | OPEN |
+| F11 | P1 | S3 | Watcher test timing-dependent (flaky risk) | watcher_test.go:33-42 | OPEN |
+| F12 | P2 | S1 | runHooks returns ctx.Err() on full success | shutdown.go:94 | OPEN |
+| F13 | P2 | S5 | doc.go example misleading for NewFromMap | doc.go:12-13 | OPEN |
+
+**Totals:** 0 P0, 3 P1, 10 P2
+
+---
+
+## Verdict
+
+**No P0 blockers.** Three P1 findings (F02, F03, F11) should be addressed before the next milestone:
+
+- **F02** is a real race condition that can cause a panic in production when `StartWithContext` cancellation and explicit `Close()` overlap. Fix with `sync.Once`.
+- **F03** is a test gap for a concurrency-critical code path. The mutex is there but unexercised under `-race`.
+- **F11** is a CI flakiness risk that will cause spurious failures.
+
+The P2 findings are quality improvements that should be tracked in the backlog.

--- a/docs/reviews/202604060830-R0/R1C-4-runtime-http.md
+++ b/docs/reviews/202604060830-R0/R1C-4-runtime-http.md
@@ -1,0 +1,626 @@
+# R1C-4: runtime/http Module Review
+
+| Field | Value |
+|---|---|
+| Reviewer Seat | S1 Architecture + S2 Security + S3 Test + S5 DX (combined full-module review) |
+| Scope | `src/runtime/http/` (middleware/, health/, router/) ~650 LOC |
+| Review basis commit | `ce03ba1` (HEAD of develop) |
+| Date | 2026-04-06 |
+
+---
+
+## Inventory
+
+| File | LOC | Test file | Test LOC |
+|---|---|---|---|
+| middleware/access_log.go | 43 | middleware/access_log_test.go | 68 |
+| middleware/body_limit.go | 39 | middleware/body_limit_test.go | 78 |
+| middleware/rate_limit.go | 76 | middleware/rate_limit_test.go | 166 |
+| middleware/real_ip.go | 60 | middleware/real_ip_test.go | 116 |
+| middleware/recovery.go | 47 | middleware/recovery_test.go | 59 |
+| middleware/request_id.go | 52 | middleware/request_id_test.go | 89 |
+| middleware/security_headers.go | 16 | middleware/security_headers_test.go | 34 |
+| middleware/doc.go | 24 | -- | -- |
+| health/health.go | 121 | health/health_test.go | 151 |
+| health/doc.go | 5 | -- | -- |
+| router/router.go | 165 | router/router_test.go | 142 |
+| router/doc.go | 4 | -- | -- |
+
+---
+
+## F-01: RealIP middleware does not support CIDR-based trustedProxies
+
+| Field | Value |
+|---|---|
+| Seat | S2 Security |
+| Severity | **P1** |
+| Category | Security / Configuration |
+| File | `src/runtime/http/middleware/real_ip.go:16-18` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// real_ip.go:16-18
+trusted := make(map[string]bool, len(trustedProxies))
+for _, p := range trustedProxies {
+    trusted[p] = true
+}
+```
+
+The `trustedProxies` parameter only accepts exact IP addresses. In production deployments behind cloud load balancers (AWS ALB, GCP LB, Kubernetes ingress), proxies often present from a CIDR range (e.g., `10.0.0.0/8`). Without CIDR matching, operators must enumerate every individual proxy IP, which is impractical and error-prone. If the list is incomplete, the middleware falls back to RemoteAddr (the proxy IP), which breaks per-IP rate limiting accuracy.
+
+**Recommendation:**
+Parse each entry via `net.ParseCIDR()`; if that fails, treat as a single IP. Match incoming RemoteAddr host against the `[]*net.IPNet` list. This is the standard pattern used by Gin's `SetTrustedProxies` and Echo's `TrustLoopback/TrustPrivateNet`.
+
+---
+
+## F-02: Default router passes `nil` to RealIP -- all forwarding headers ignored in production
+
+| Field | Value |
+|---|---|
+| Seat | S1 Architecture |
+| Severity | **P1** |
+| Category | Configuration / Middleware Chain |
+| File | `src/runtime/http/router/router.go:73` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// router.go:72-79
+r.mux.Use(
+    middleware.RequestID,
+    middleware.RealIP(nil),   // <-- always nil
+    middleware.Recovery,
+    middleware.AccessLog,
+    middleware.SecurityHeaders,
+    middleware.BodyLimit(r.bodyLimit),
+)
+```
+
+`RealIP(nil)` means no proxy is trusted, so `X-Forwarded-For` and `X-Real-Ip` are always ignored. Behind any reverse proxy (nginx, envoy, cloud LB), every request will see the proxy IP as the client IP. This cascades to:
+- Rate limiting (F-07) keys all requests to the same proxy IP.
+- Access logs record incorrect client IPs.
+- Audit trails are inaccurate.
+
+There is no `WithTrustedProxies(...)` router Option to configure this.
+
+**Recommendation:**
+Add a `WithTrustedProxies(proxies []string) Option` to the router. The bootstrap layer should read trusted proxies from configuration (e.g., `http.trustedProxies` in YAML). Until configured, warn at startup that RealIP spoofing protection is active but forwarding headers are not trusted.
+
+---
+
+## F-03: No CORS middleware
+
+| Field | Value |
+|---|---|
+| Seat | S2 Security |
+| Severity | **P1** |
+| Category | Security / Cross-Origin |
+| File | `src/runtime/http/middleware/` (missing) |
+| Status | OPEN |
+
+**Evidence:**
+Searched for "CORS" or "cors" across `src/runtime/` -- zero matches. No `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, or `Access-Control-Allow-Headers` are set anywhere in the middleware package.
+
+Any browser-based client (SPA, BFF) calling the GoCell API from a different origin will be blocked by the browser's same-origin policy. This is a fundamental gap for the `sso-bff` example and any real frontend integration.
+
+**Recommendation:**
+Add a `CORS` middleware with configurable `AllowedOrigins`, `AllowedMethods`, `AllowedHeaders`, `MaxAge`. Do NOT default to `*` for AllowedOrigins -- require explicit configuration. Consider wrapping `rs/cors` or implementing a lightweight version.
+
+---
+
+## F-04: Missing Content-Security-Policy and Referrer-Policy security headers
+
+| Field | Value |
+|---|---|
+| Seat | S2 Security |
+| Severity | **P2** |
+| Category | Security Headers |
+| File | `src/runtime/http/middleware/security_headers.go:9-16` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// security_headers.go:9-16
+func SecurityHeaders(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("X-Content-Type-Options", "nosniff")
+        w.Header().Set("X-Frame-Options", "DENY")
+        w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+The following standard security headers are missing:
+- `Content-Security-Policy: default-src 'none'` (for API-only service)
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `X-Permitted-Cross-Domain-Policies: none`
+- `Permissions-Policy: (empty/restrictive)` for API endpoints
+
+The `Strict-Transport-Security` header should include `includeSubDomains` for defence-in-depth.
+
+**Recommendation:**
+Add these headers with sensible API defaults. Make CSP configurable via an option for services that also serve HTML.
+
+---
+
+## F-05: statusRecorder in access_log.go duplicates httputil.StatusRecorder
+
+| Field | Value |
+|---|---|
+| Seat | S5 DX / Maintainability |
+| Severity | **P2** |
+| Category | Code Duplication |
+| Files | `src/runtime/http/middleware/access_log.go:12-20`, `src/pkg/httputil/response.go:66-83` |
+| Status | OPEN |
+
+**Evidence:**
+
+`access_log.go` defines a private `statusRecorder`:
+```go
+// access_log.go:12-20
+type statusRecorder struct {
+    http.ResponseWriter
+    status int
+}
+func (sr *statusRecorder) WriteHeader(code int) {
+    sr.status = code
+    sr.ResponseWriter.WriteHeader(code)
+}
+```
+
+`httputil/response.go` defines a public `StatusRecorder` with the same logic:
+```go
+// response.go:66-83
+type StatusRecorder struct {
+    http.ResponseWriter
+    Status int
+}
+```
+
+The `runtime/observability/tracing/tracing.go` already uses `httputil.NewStatusRecorder(w)`. The middleware package should reuse the shared type.
+
+**Recommendation:**
+Replace the private `statusRecorder` with `httputil.StatusRecorder` / `httputil.NewStatusRecorder()`.
+
+---
+
+## F-06: statusRecorder does not implement Flusher/Hijacker -- breaks SSE and WebSocket upgrade
+
+| Field | Value |
+|---|---|
+| Seat | S1 Architecture |
+| Severity | **P1** |
+| Category | Interface Compatibility |
+| Files | `src/runtime/http/middleware/access_log.go:12-20`, `src/pkg/httputil/response.go:66-83` |
+| Status | OPEN |
+
+**Evidence:**
+
+Both `statusRecorder` (middleware) and `StatusRecorder` (httputil) embed `http.ResponseWriter` and override `WriteHeader`, but neither checks for or delegates `http.Flusher`, `http.Hijacker`, or `http.CloseNotifier`.
+
+When the access log middleware wraps the response writer, any downstream handler that type-asserts `w.(http.Flusher)` to flush SSE events will get `false` -- silently breaking Server-Sent Events. Similarly, WebSocket upgrade via `w.(http.Hijacker)` will fail.
+
+This is a known pattern issue documented in the Go standard library.
+
+**Recommendation:**
+Implement optional interface delegation. The standard pattern:
+```go
+func (sr *statusRecorder) Flush() {
+    if f, ok := sr.ResponseWriter.(http.Flusher); ok {
+        f.Flush()
+    }
+}
+func (sr *statusRecorder) Unwrap() http.ResponseWriter {
+    return sr.ResponseWriter
+}
+```
+Go 1.20+ supports `http.ResponseController` which uses `Unwrap()`.
+
+---
+
+## F-07: Rate limiter is per-IP only -- no per-user/per-tenant differentiation
+
+| Field | Value |
+|---|---|
+| Seat | S2 Security |
+| Severity | **P2** |
+| Category | Rate Limiting Design |
+| File | `src/runtime/http/middleware/rate_limit.go:37-38` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// rate_limit.go:37-38
+ip := clientIP(r)
+if !limiter.Allow(ip) {
+```
+
+The rate limiter key is always the client IP. There is no support for per-user or per-tenant rate limiting (using the authenticated subject from context). In multi-tenant deployments or behind NAT, all users from the same IP share the same rate limit bucket. Conversely, an authenticated abuser can rotate IPs to bypass limits.
+
+The `RateLimiter` interface itself (`Allow(key string)`) is flexible enough, but the middleware always passes `clientIP(r)`.
+
+**Recommendation:**
+After auth middleware has run, compose a key like `"user:" + subject` when a subject is available, falling back to `"ip:" + clientIP(r)` for unauthenticated requests. This requires rate limiting middleware to be placed after auth in the chain, or to accept a key-extraction function.
+
+---
+
+## F-08: Auth middleware NOT in default router chain -- Cells must manually add it
+
+| Field | Value |
+|---|---|
+| Seat | S1 Architecture |
+| Severity | **P1** |
+| Category | Middleware Chain / Security Default |
+| File | `src/runtime/http/router/router.go:72-79` |
+| Status | OPEN |
+
+**Evidence:**
+
+The default middleware chain in `router.New()`:
+```go
+// router.go:72-79
+r.mux.Use(
+    middleware.RequestID,
+    middleware.RealIP(nil),
+    middleware.Recovery,
+    middleware.AccessLog,
+    middleware.SecurityHeaders,
+    middleware.BodyLimit(r.bodyLimit),
+)
+```
+
+Auth middleware (`runtime/auth.AuthMiddleware`) is NOT included. Rate limiting (`middleware.RateLimit`) is also not included by default. The documented expected chain order from the review checklist -- `recovery -> logging -> auth -> rate_limit` -- is not followed.
+
+The current chain order is: `RequestID -> RealIP -> Recovery -> AccessLog -> SecurityHeaders -> BodyLimit`.
+
+While auth is intentionally not in the default chain (it requires a `TokenVerifier` dependency), there is no `WithAuthMiddleware(...)` router option, and the doc.go example in middleware/doc.go shows a chain of `RequestID -> Recovery -> AccessLog` without auth.
+
+**Recommendation:**
+1. Add `WithAuthMiddleware(verifier TokenVerifier, publicEndpoints []string) Option` to the router.
+2. Add `WithRateLimiter(limiter RateLimiter) Option` to the router.
+3. When auth is provided, insert it after AccessLog and before route matching.
+4. When rate limiter is provided, insert after RealIP.
+5. Document the canonical chain order clearly in doc.go.
+
+---
+
+## F-09: Recovery middleware may write to already-written response
+
+| Field | Value |
+|---|---|
+| Seat | S1 Architecture |
+| Severity | **P2** |
+| Category | Correctness |
+| File | `src/runtime/http/middleware/recovery.go:21-46` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// recovery.go:21-46
+defer func() {
+    if rec := recover(); rec != nil {
+        // ...
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusInternalServerError)
+        _ = json.NewEncoder(w).Encode(...)
+    }
+}()
+next.ServeHTTP(w, r)
+```
+
+If the downstream handler has already written partial response headers or body bytes before panicking, the recovery middleware's `WriteHeader(500)` call will:
+1. Log a superfluous `http: superfluous response.WriteHeader call` warning.
+2. Not actually change the status code (first WriteHeader wins).
+3. Append JSON error body after whatever was already written, producing malformed output.
+
+**Recommendation:**
+Wrap `w` in a `statusRecorder` that tracks whether `WriteHeader` or `Write` has been called. If already written, only log the panic without attempting to write a response body.
+
+---
+
+## F-10: Health check runs readiness checkers sequentially -- no timeout per checker
+
+| Field | Value |
+|---|---|
+| Seat | S1 Architecture |
+| Severity | **P2** |
+| Category | Resilience |
+| File | `src/runtime/http/health/health.go:93-99` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// health.go:93-99
+for name, fn := range checkersCopy {
+    if err := fn(); err != nil {
+        checks[name] = "unhealthy"
+        allHealthy = false
+    } else {
+        checks[name] = "healthy"
+    }
+}
+```
+
+Readiness checkers run sequentially with no timeout. A slow database ping or external service check can block the `/readyz` endpoint indefinitely. Load balancers will mark the instance as unhealthy due to timeout, not due to actual unhealthiness.
+
+Additionally, the `Checker` function signature is `func() error` -- it does not accept a `context.Context`, so callers cannot propagate cancellation or deadlines.
+
+**Recommendation:**
+1. Change `Checker` to `func(ctx context.Context) error`.
+2. Run checkers with `context.WithTimeout` (e.g., 5 seconds per checker).
+3. Consider running checkers concurrently with `errgroup` for latency reduction.
+
+---
+
+## F-11: Middleware error responses do not use `pkg/errcode` or `pkg/httputil`
+
+| Field | Value |
+|---|---|
+| Seat | S5 DX / Maintainability |
+| Severity | **P2** |
+| Category | Error Handling Consistency |
+| Files | `src/runtime/http/middleware/rate_limit.go:42-49`, `body_limit.go:31-38`, `recovery.go:35-43` |
+| Status | OPEN |
+
+**Evidence:**
+
+Three middleware files construct JSON error responses inline:
+```go
+// rate_limit.go:42-49
+_ = json.NewEncoder(w).Encode(map[string]any{
+    "error": map[string]any{
+        "code":    "ERR_RATE_LIMITED",
+        "message": "too many requests",
+    },
+})
+```
+
+The `auth/middleware.go:130-138` has the same pattern via `writeAuthError()`.
+
+The project has `pkg/httputil.WriteError()` which produces the canonical format with a `details` field:
+```go
+{"error": {"code": "ERR_*", "message": "...", "details": {}}}
+```
+
+The middleware error responses omit the `details` field, creating an inconsistency with the documented error response format in `.claude/rules/gocell/error-handling.md`.
+
+**Recommendation:**
+Use `httputil.WriteError(w, status, code, message)` in all middleware error paths. This ensures the `details: {}` field is always present and the format is maintained centrally.
+
+---
+
+## F-12: Error code strings are hardcoded -- not using `pkg/errcode` constants
+
+| Field | Value |
+|---|---|
+| Seat | S5 DX / Maintainability |
+| Severity | **P2** |
+| Category | Constant Management |
+| Files | `src/runtime/http/middleware/rate_limit.go:45`, `body_limit.go:35`, `recovery.go:39` |
+| Status | OPEN |
+
+**Evidence:**
+
+Error codes are string literals:
+- `"ERR_RATE_LIMITED"` (rate_limit.go:45)
+- `"ERR_BODY_TOO_LARGE"` (body_limit.go:35)
+- `"ERR_INTERNAL"` (recovery.go:39)
+- `"ERR_AUTH_UNAUTHORIZED"` (auth/middleware.go:47, 57)
+- `"ERR_AUTH_FORBIDDEN"` (auth/middleware.go:113)
+
+The project has a `pkg/errcode` package that should be the single source of truth for error codes. Hardcoded strings risk typos and drift.
+
+**Recommendation:**
+Define these codes as `errcode.Code` constants in `pkg/errcode` (e.g., `errcode.ErrRateLimited`, `errcode.ErrBodyTooLarge`) and reference them in middleware.
+
+---
+
+## F-13: `chiRouterAdapter` does not expose `Use()` method
+
+| Field | Value |
+|---|---|
+| Seat | S1 Architecture |
+| Severity | **P2** |
+| Category | API Completeness |
+| File | `src/runtime/http/router/router.go:139-165` |
+| Status | OPEN |
+
+**Evidence:**
+
+The `Router` type has a `Use()` method (line 125-127) but the `chiRouterAdapter` (used for Group/Route sub-routers) does not. The `RouteMux` kernel interface also does not include `Use()`.
+
+This means Cells calling `mux.Route("/api/v1", func(sub RouteMux) { ... })` cannot add group-level middleware within the sub-router callback. They must cast to a concrete type or use chi directly, which couples Cells to the router implementation.
+
+**Recommendation:**
+Consider adding `Use(mw ...func(http.Handler) http.Handler)` to the `RouteMux` interface (kernel). If that is too broad, at minimum add it to `chiRouterAdapter` and create an extended interface `RouteMuxWithMiddleware` that the router can expose.
+
+---
+
+## F-14: `doc.go` example shows incorrect middleware chain order
+
+| Field | Value |
+|---|---|
+| Seat | S5 DX |
+| Severity | **P2** |
+| Category | Documentation |
+| File | `src/runtime/http/middleware/doc.go:17-23` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// doc.go:17-23
+//  handler := middleware.RequestID(
+//      middleware.Recovery(
+//          middleware.AccessLog(
+//              myHandler,
+//          ),
+//      ),
+//  )
+```
+
+This shows manual nesting (inside-out), but the actual `router.New()` uses `r.mux.Use()` which applies middleware in declaration order (outside-in). The doc.go example also omits `RealIP`, `SecurityHeaders`, and `BodyLimit`, suggesting an incomplete chain.
+
+Furthermore, the nesting approach shown in doc.go applies middleware in the opposite order from `chi.Use()`. A developer reading doc.go and then looking at router.go will be confused.
+
+**Recommendation:**
+Update doc.go to show the chi `Use()` pattern or clearly document both patterns with correct ordering.
+
+---
+
+## F-15: Health endpoint response format does not match API envelope convention
+
+| Field | Value |
+|---|---|
+| Seat | S6 Product/UX |
+| Severity | **P2** |
+| Category | API Consistency |
+| File | `src/runtime/http/health/health.go:64-68, 109-113` |
+| Status | OPEN |
+
+**Evidence:**
+
+Health endpoints return:
+```json
+{"status": "healthy", "checks": {"cell-1": "healthy"}}
+```
+
+The project API convention (from `.claude/rules/gocell/api-versioning.md`) specifies:
+```json
+{"data": ..., "total": ..., "page": ...}
+```
+
+Health/infrastructure endpoints are commonly exempted from the data envelope, but this should be explicitly documented. Also, when unhealthy, the response includes no error details about *why* a checker failed -- just `"unhealthy"`.
+
+**Recommendation:**
+1. Document that `/healthz` and `/readyz` are infrastructure endpoints exempt from the data envelope.
+2. When a checker returns an error, include the error message in a `reason` field for operational debugging (ensure no sensitive information is leaked).
+
+---
+
+## F-16: Health check `Checker` errors are discarded -- no observability on failure reason
+
+| Field | Value |
+|---|---|
+| Seat | S5 DX |
+| Severity | **P2** |
+| Category | Observability |
+| File | `src/runtime/http/health/health.go:93-99` |
+| Status | OPEN |
+
+**Evidence:**
+
+```go
+// health.go:93-99
+for name, fn := range checkersCopy {
+    if err := fn(); err != nil {
+        checks[name] = "unhealthy"
+        allHealthy = false
+    } else {
+        checks[name] = "healthy"
+    }
+}
+```
+
+When a checker returns an error, the error value is completely discarded. There is no `slog` logging of the error, no metric emission, and no inclusion in the response. Operators will know a component is unhealthy but not why.
+
+**Recommendation:**
+At minimum, log the error: `slog.Warn("readiness check failed", slog.String("checker", name), slog.Any("error", err))`. Optionally include a sanitized reason in the JSON response.
+
+---
+
+## F-17: `json.NewEncoder(w).Encode()` errors silently ignored in multiple locations
+
+| Field | Value |
+|---|---|
+| Seat | S5 DX |
+| Severity | **P2** |
+| Category | Error Handling |
+| Files | `middleware/rate_limit.go:43`, `body_limit.go:33`, `recovery.go:37`, `health/health.go:119` |
+| Status | OPEN |
+
+**Evidence:**
+
+All error response writes use `_ = json.NewEncoder(w).Encode(...)`. If the client disconnects mid-write, the error is silently discarded. While this is generally acceptable for HTTP middleware (the connection is already broken), the pattern violates the project's rule in `error-handling.md`:
+
+> Prohibit `_ = someFunc()` ignoring errors; must explicitly handle or log.
+
+**Recommendation:**
+At minimum, log the write error at Debug level for the middleware paths (since it's expected for broken connections). For the health endpoint, consider logging at Warn.
+
+---
+
+## F-18: No request timeout middleware
+
+| Field | Value |
+|---|---|
+| Seat | S2 Security |
+| Severity | **P2** |
+| Category | Denial of Service |
+| File | `src/runtime/http/middleware/` (missing) |
+| Status | OPEN |
+
+**Evidence:**
+
+The bootstrap sets `ReadHeaderTimeout: 10 * time.Second` on the HTTP server (bootstrap.go:279), but there is no request body read timeout or handler execution timeout middleware. A slow-loris attack on the request body or a handler that hangs indefinitely will hold the goroutine forever.
+
+The `http.TimeoutHandler` from the standard library or a custom middleware can enforce per-request execution deadlines.
+
+**Recommendation:**
+Add an optional `Timeout(duration time.Duration)` middleware that wraps `http.TimeoutHandler`. Apply it before business handlers in the chain. Set a sensible default (e.g., 30 seconds) with configurability.
+
+---
+
+## GoCell Layer Dependency Check
+
+| Rule | Status | Notes |
+|---|---|---|
+| kernel/ must not import runtime/adapters/cells/ | PASS | `kernel/cell/registrar.go` defines `RouteMux` with only `net/http` + `kernel/outbox` imports |
+| cells/ must not import adapters/ | N/A | No cells/ code in scope |
+| runtime/ must not import cells/ or adapters/ | PASS | `router/router.go` imports `kernel/cell`, `runtime/http/*`, `runtime/observability/*` -- all allowed |
+| Cross-Cell import prohibition | N/A | No cross-cell imports in scope |
+
+---
+
+## Test Coverage Assessment
+
+| Component | Test Exists | Edge Cases Covered | Assessment |
+|---|---|---|---|
+| access_log | Yes | Default status, request_id propagation | Adequate |
+| body_limit | Yes | Under/over limit, unknown content-length, default | Good |
+| rate_limit | Yes | Allow/reject, windowed/non-windowed, fallback IP, ceil rounding | Good |
+| real_ip | Yes | Trusted/untrusted, XFF chain, X-Real-Ip, fallback | Good |
+| recovery | Yes | No panic, string panic, int panic | Missing: panic after partial write |
+| request_id | Yes | Existing header, generation, too-long, control chars, uniqueness | Good |
+| security_headers | Yes | All three headers verified | Adequate |
+| health | Yes | Healthy, unhealthy cell, unhealthy checker, empty assembly | Missing: concurrent checker registration |
+| router | Yes | RouteMux interface, health, metrics, Handle, Route, Group, Mount, default middleware | Missing: auth integration, body limit trigger |
+
+**Overall:** Test coverage appears solid for happy paths and basic error cases. The main gaps are:
+- No test for recovery middleware behavior when response is already partially written (relates to F-09).
+- No test for health checker timeout behavior (relates to F-10).
+- No concurrent safety test for `health.RegisterChecker` during serving.
+
+---
+
+## Summary
+
+| Severity | Count | Finding IDs |
+|---|---|---|
+| P0 | 0 | -- |
+| P1 | 4 | F-01, F-02, F-03, F-06, F-08 |
+| P2 | 13 | F-04, F-05, F-07, F-09, F-10, F-11, F-12, F-13, F-14, F-15, F-16, F-17, F-18 |
+
+**Note:** P1 count is 5 (F-01, F-02, F-03, F-06, F-08). No P0 blockers found.
+
+The runtime/http module is well-structured with clean separation of concerns. Each middleware follows the standard `func(http.Handler) http.Handler` pattern and the router correctly implements the `kernel/cell.RouteMux` interface. Test coverage is thorough for the code that exists.
+
+The primary gaps are in production-readiness configuration: the RealIP middleware cannot be properly configured via router options (F-02), CIDR matching is missing (F-01), CORS is absent (F-03), and auth/rate-limit are not wired into the default chain (F-08). The `statusRecorder` interface compatibility issue (F-06) will surface as soon as SSE or WebSocket endpoints are added.

--- a/docs/reviews/202604060830-R0/R1C-5-runtime-observability-bootstrap.md
+++ b/docs/reviews/202604060830-R0/R1C-5-runtime-observability-bootstrap.md
@@ -1,0 +1,292 @@
+# R1C-5: runtime/observability + runtime/bootstrap Review
+
+| Field | Value |
+|---|---|
+| Reviewer | R1C-5 Agent (Seats 1/3/4/5 composite) |
+| Scope | `src/runtime/observability/{logging,metrics,tracing}/`, `src/runtime/bootstrap/` |
+| Baseline commit | ce03ba1 (develop HEAD) |
+| Date | 2026-04-06 |
+| LOC reviewed | ~780 (bootstrap 357, logging 105, metrics 177, tracing 116, tests ~370) |
+
+---
+
+## Summary
+
+The observability and bootstrap modules form the lifecycle backbone of GoCell. The code is generally well-structured with clean interfaces, proper slog usage, and good test coverage for the observability sub-packages. However, the bootstrap `Run()` function has high cognitive complexity and several integration gaps. The metrics package contains a duplicated ResponseWriter wrapper and dead code. Tracing middleware exists but is never wired into the default middleware chain.
+
+---
+
+## Findings
+
+### F-01 [Seat 5: DX/Maintainability] P1 -- bootstrap.Run() cognitive complexity exceeds limit
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/bootstrap/bootstrap.go` lines 158-356
+
+**Evidence:** The `Run()` function is 198 lines long with 10 sequential lifecycle steps, nested closures (rollback, watcher callback), multiple select branches, and inline teardown registration. SonarCloud flags CC=57 against a limit of 15.
+
+**Description:** The function handles config loading, config watcher setup, publisher/subscriber init, assembly start, router build, HTTP route registration, event subscription registration, HTTP server start, worker start, signal wait, and orderly shutdown -- all in a single function body. This makes it difficult to test individual phases and hard to reason about.
+
+**Recommendation:** Extract sub-functions for each lifecycle phase:
+- `loadConfig() (config.Config, []teardownFn, error)`
+- `initEventBus() (outbox.Publisher, outbox.Subscriber, []teardownFn)`
+- `startAssembly(ctx, cfg) (*assembly.CoreAssembly, []teardownFn, error)`
+- `buildAndServeHTTP(asm) (*http.Server, []teardownFn, error)`
+- `startWorkers(ctx) ([]teardownFn, error)`
+- `awaitShutdown(ctx, teardowns) error`
+
+Each function returns its own teardown closures. This would reduce Run() to ~30 lines of sequential calls and bring CC well below 15.
+
+---
+
+### F-02 [Seat 3: Test/Regression] P1 -- No integration test for bootstrap.Run() happy path
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/bootstrap/bootstrap_test.go`
+
+**Evidence:** The test file has 11 test functions. `TestBootstrap_RunContextCancel` (line 137) immediately cancels the context and does not assert on the result (`_ = err`). The remaining tests only exercise option setters and assembly internals -- they never test a complete Run() that successfully starts and shuts down.
+
+**Description:** `WithListener` exists precisely for test-friendly port allocation, but no test uses it. A minimal integration test should: (1) create a net.Listener on `:0`, (2) register a test cell, (3) Run() with a context that cancels after a short delay, (4) assert no error. Without this, regressions in the startup/shutdown sequence are invisible.
+
+**Recommendation:** Add a `TestBootstrap_RunHappyPath` test:
+```go
+func TestBootstrap_RunHappyPath(t *testing.T) {
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    require.NoError(t, err)
+    
+    asm := assembly.New(assembly.Config{ID: "test"})
+    require.NoError(t, asm.Register(newTestCell("cell-1")))
+    
+    ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+    defer cancel()
+    
+    b := New(
+        WithAssembly(asm),
+        WithListener(ln),
+        WithShutdownTimeout(time.Second),
+    )
+    err = b.Run(ctx)
+    require.NoError(t, err)
+}
+```
+
+---
+
+### F-03 [Seat 5: DX/Maintainability] P1 -- metrics.metricsRecorder duplicates pkg/httputil.StatusRecorder
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/metrics/metrics.go` lines 148-169
+
+**Evidence:** `metricsRecorder` (lines 148-169) implements `WriteHeader` and `Write` to capture status codes -- the exact same responsibility as `pkg/httputil.StatusRecorder` (lines 66-83 in `response.go`). The tracing middleware already uses `httputil.NewStatusRecorder`.
+
+**Description:** Two independent ResponseWriter wrappers that do the same thing create a maintenance burden: a bug fix in one will not propagate to the other. The metrics `Write` method also sets `wroteHeader = true` but `StatusRecorder` does not, which means their behaviors subtly diverge.
+
+**Recommendation:** Replace `metricsRecorder` with `httputil.StatusRecorder` in the metrics `Middleware` function:
+```go
+rec := httputil.NewStatusRecorder(w)
+next.ServeHTTP(rec, r)
+collector.RecordRequest(r.Method, r.URL.Path, rec.Status, duration)
+```
+
+---
+
+### F-04 [Seat 1: Architecture] P1 -- Tracing middleware exists but is never wired into router or bootstrap
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/tracing/tracing.go` lines 92-108
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/http/router/router.go` lines 71-79
+
+**Evidence:** `tracing.Middleware(tracer)` is a fully implemented HTTP middleware (line 95). However, `router.New()` (line 62) only wires `RequestID, RealIP, Recovery, AccessLog, SecurityHeaders, BodyLimit` and optionally metrics middleware. There is no `WithTracer` option on the router. A grep for `tracing.Middleware` or `tracing.NewTracer` across all of `src/runtime/` returns zero results.
+
+**Description:** Without tracing middleware in the default chain, trace_id and span_id are never injected into the request context for production traffic. The logging handler (`contextHandler`) correctly extracts these from context, but they will always be empty. This renders the entire tracing package effectively dead in production.
+
+**Recommendation:** Add a `WithTracer(t tracing.Tracer)` option to `router.Router` and wire `tracing.Middleware(tracer)` early in the default middleware chain (before AccessLog, so logs include trace_id).
+
+---
+
+### F-05 [Seat 5: DX/Maintainability] P2 -- Dead code: `metricsText` function never called
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/metrics/metrics.go` lines 173-176
+
+**Evidence:** `metricsText` is an unexported function. A project-wide grep for `metricsText` returns only its definition (line 173) and its doc comment (line 171). It is never called from any code or test.
+
+**Description:** Dead code increases cognitive load and suggests incomplete implementation. The comment says "debugging/testing" but no test uses it.
+
+**Recommendation:** Remove the function, or if the intent is to provide a debug helper, export it as `MetricsText` and add a test.
+
+---
+
+### F-06 [Seat 5: DX/Maintainability] P2 -- metrics.Handler() uses fragile Sscanf to reverse-parse composite key
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/metrics/metrics.go` line 114
+
+**Evidence:**
+```go
+_, _ = fmt.Sscanf(k, "%s %s %d", &method, &path, &status)
+```
+The key format is `"METHOD /path STATUS"` (built by `metricKey` on line 47). The Sscanf return values (count and error) are both discarded. If a path contained a space (e.g., encoded incorrectly), parsing would silently produce wrong values.
+
+**Description:** The code constructs a composite string key and then parses it back, which is fragile. The error from Sscanf is silenced, violating the project rule "must explicitly handle or record errors."
+
+**Recommendation:** Use a struct key (`metricEntry{Method, Path, Status}`) as the map key (requires a string representation for map key, e.g., via a helper). Alternatively, store entries as a slice of structs and remove the need for parsing entirely. At minimum, check the Sscanf return value and log on failure.
+
+---
+
+### F-07 [Seat 3: Test/Regression] P2 -- metrics.Handler() JSON encoding error silenced
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/metrics/metrics.go` line 125
+
+**Evidence:**
+```go
+_ = json.NewEncoder(w).Encode(map[string]any{
+```
+
+**Description:** The JSON encode error is discarded. While unlikely to fail for simple map structures, silencing the error prevents detection of writer failures (e.g., client disconnect). The project rule says "must explicitly handle or record errors."
+
+**Recommendation:** Log the error at Debug level if non-nil:
+```go
+if err := json.NewEncoder(w).Encode(...); err != nil {
+    slog.Debug("metrics: failed to encode response", slog.Any("error", err))
+}
+```
+
+---
+
+### F-08 [Seat 3: Test/Regression] P2 -- tracing.generateID silences rand.Read error
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/tracing/tracing.go` line 113
+
+**Evidence:**
+```go
+_, _ = rand.Read(buf)
+```
+
+**Description:** `crypto/rand.Read` returns an error when the OS entropy source fails. On Go 1.24+ `rand.Read` never returns an error (the function panics instead), so this is technically safe for the current Go version (1.25 per go.mod). However, the double underscore suppression pattern is a code smell and could mislead future readers.
+
+**Recommendation:** Since Go 1.25 guarantees no error from `crypto/rand.Read`, simplify to:
+```go
+rand.Read(buf) // Go 1.25: guaranteed no error (panics on failure)
+```
+Or equivalently use `crypto/rand.Read` with a comment explaining the guarantee.
+
+---
+
+### F-09 [Seat 1: Architecture] P2 -- bootstrap imports runtime/eventbus concrete type in WithEventBus
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/bootstrap/bootstrap.go` lines 87-92
+
+**Evidence:**
+```go
+func WithEventBus(eb *eventbus.InMemoryEventBus) Option {
+```
+This option accepts a concrete `*eventbus.InMemoryEventBus`, creating a hard coupling to the in-memory implementation. The newer `WithPublisher` and `WithSubscriber` correctly accept interfaces (`outbox.Publisher` and `outbox.Subscriber`).
+
+**Description:** The function is marked `Deprecated` (line 83), which is correct. However, it is still used in `bootstrap_test.go` line 39. Since the Deprecated annotation exists, the priority is low, but the test should migrate to the interface-based options to validate the recommended path.
+
+**Recommendation:** Update `TestNew_WithOptions` to use `WithPublisher(eb)` and `WithSubscriber(eb)` instead of `WithEventBus(eb)`. Consider removing `WithEventBus` in the next breaking change window.
+
+---
+
+### F-10 [Seat 5: DX/Maintainability] P2 -- Snapshot field name DurationSumsMs stores microseconds, displays milliseconds
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/metrics/metrics.go` lines 28, 89
+
+**Evidence:**
+```go
+// line 28
+DurationSumsMs   map[string]int64
+// line 89
+snap.DurationSumsMs[k] = v.Load() / 1000 // microseconds -> milliseconds
+```
+Internally, `durations` stores microseconds (line 73: `int64(durationSeconds * 1e6)`). The `Snapshot()` method converts to milliseconds on read. The field name `DurationSumsMs` correctly indicates milliseconds, but the internal storage in microseconds and the integer division truncation means values under 1ms are silently rounded to 0.
+
+**Description:** For sub-millisecond request durations (common in health checks), the reported duration will be 0. This could mislead users into thinking a request took no time.
+
+**Recommendation:** Either store and report microseconds (`DurationSumsUs`) for precision, or use `float64` milliseconds to preserve sub-ms detail. Document the unit explicitly.
+
+---
+
+### F-11 [Seat 1: Architecture] P2 -- router.WithMetricsCollector accepts concrete InMemoryCollector, not Collector interface
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/http/router/router.go` line 36
+
+**Evidence:**
+```go
+func WithMetricsCollector(c *metrics.InMemoryCollector) Option {
+```
+The `Collector` interface exists (metrics.go line 18) but `WithMetricsCollector` requires the concrete `*InMemoryCollector`. This prevents passing a production Prometheus adapter without also wrapping it.
+
+**Description:** The pattern violates the GoCell principle of interface-based decoupling. The middleware `metrics.Middleware(collector Collector)` (line 133) correctly takes the interface, but the router's option does not.
+
+**Recommendation:** Split into two concerns: (1) `WithMetricsMiddleware(c metrics.Collector)` for the middleware, (2) `WithMetricsHandler(h http.Handler)` for the `/metrics` endpoint. This allows production adapters (e.g., promhttp.Handler) to be passed without depending on `InMemoryCollector`.
+
+---
+
+### F-12 [Seat 3: Test/Regression] P2 -- logging tests do not cover WithGroup
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/logging/logging_test.go`
+
+**Evidence:** The `contextHandler.WithGroup` method is implemented (logging.go line 84) but no test covers it. The existing tests cover `WithAttrs` (line 100) but not `WithGroup`.
+
+**Description:** `WithGroup` is part of the `slog.Handler` interface contract. Without a test, a regression in group namespace propagation would go undetected.
+
+**Recommendation:** Add a `TestContextHandler_WithGroup` test that verifies context attributes appear correctly under a named group.
+
+---
+
+### F-13 [Seat 3: Test/Regression] P2 -- No concurrency test for InMemoryCollector
+
+**File:** `/Users/shengming/Documents/code/gocell/src/runtime/observability/metrics/metrics_test.go`
+
+**Evidence:** The `InMemoryCollector` uses `sync.RWMutex` with a double-check locking pattern and `atomic.Int64` (metrics.go lines 51-74), indicating it is designed for concurrent use. However, no test exercises concurrent access (e.g., `t.Parallel()` with multiple goroutines calling `RecordRequest`).
+
+**Description:** The double-check locking pattern (RLock, check, RUnlock, Lock, re-check) is a common source of subtle bugs. Without a race-detected concurrent test, data races may exist undetected.
+
+**Recommendation:** Add a `TestInMemoryCollector_Concurrent` test using `sync.WaitGroup` with multiple goroutines and run with `-race`.
+
+---
+
+## Findings Summary
+
+| ID | Seat | Severity | Category | File(s) |
+|---|---|---|---|---|
+| F-01 | S5 DX | P1 | Cognitive complexity | bootstrap.go |
+| F-02 | S3 Test | P1 | Missing integration test | bootstrap_test.go |
+| F-03 | S5 DX | P1 | Code duplication | metrics.go, httputil/response.go |
+| F-04 | S1 Arch | P1 | Dead integration | tracing.go, router.go |
+| F-05 | S5 DX | P2 | Dead code | metrics.go |
+| F-06 | S5 DX | P2 | Fragile parsing | metrics.go |
+| F-07 | S3 Test | P2 | Error silencing | metrics.go |
+| F-08 | S3 Test | P2 | Error silencing | tracing.go |
+| F-09 | S1 Arch | P2 | Concrete coupling | bootstrap.go |
+| F-10 | S5 DX | P2 | Misleading precision | metrics.go |
+| F-11 | S1 Arch | P2 | Concrete coupling | router.go |
+| F-12 | S3 Test | P2 | Missing test | logging_test.go |
+| F-13 | S3 Test | P2 | Missing test | metrics_test.go |
+
+**P0: 0 | P1: 4 | P2: 9 | Total: 13**
+
+---
+
+## Compliance Checklist
+
+| Check | Status | Notes |
+|---|---|---|
+| kernel/ imports from runtime/adapters/cells | PASS | No violations |
+| cells/ imports adapters/ | N/A | Not in scope |
+| Cross-cell direct import | N/A | Not in scope |
+| CUD consistency level annotations | N/A | No CUD operations in these modules |
+| runtime/ imports cells/ or adapters/ | PASS | Only imports kernel/ and pkg/ |
+| bare errors.New | PASS | None found |
+| fmt.Println / log.Printf | PASS | None found |
+| slog structured fields | PASS | All slog calls include structured fields |
+| Bare slog.Error("failed") | PASS | All Error calls include slog.Any("error", ...) |
+| Debug dump of request body | PASS | No Debug-level logging in these modules |
+| ref: tag in commit messages | INFO | bootstrap.go has ref: comments inline (lines 6-8, 66-67, 144); no commit grep performed |
+
+---
+
+## Positive Observations
+
+1. **Clean interface design**: `Tracer`, `Span`, and `Collector` interfaces are well-defined and follow Go idioms (small, single-purpose).
+2. **Context propagation**: The `contextHandler` correctly enriches every log record with trace/span/request/cell IDs from context -- excellent correlation design.
+3. **LIFO teardown**: Bootstrap's rollback and shutdown both use reverse-order teardown, matching the uber-go/fx reference pattern.
+4. **Option pattern consistency**: All constructors use functional options, consistent across bootstrap, router, and shutdown.
+5. **Double-close prevention**: Bootstrap correctly checks `any(pub) != any(sub)` before registering a separate publisher teardown (line 227).
+6. **ReadHeaderTimeout**: HTTP server sets `ReadHeaderTimeout: 10 * time.Second` (line 279), preventing Slowloris attacks.

--- a/docs/reviews/202604060830-R0/R1H-1-yaml-naming.md
+++ b/docs/reviews/202604060830-R0/R1H-1-yaml-naming.md
@@ -1,0 +1,197 @@
+# R1H-1: YAML Metadata Naming Compliance Review
+
+- **Auditor**: Kernel Guardian
+- **Date**: 2026-04-06
+- **Baseline**: `docs/architecture/naming-baseline.md`
+- **Scope**: All YAML metadata files under `src/`
+
+## Files Audited
+
+| Category | Count | Files |
+|----------|-------|-------|
+| cell.yaml | 6 | access-core, audit-core, config-core, demo, device-cell, order-cell |
+| slice.yaml | 21 | (all slices across 6 cells) |
+| contract.yaml | 18 | (all contracts under src/contracts/) |
+| assembly.yaml | 1 | core-bundle |
+| journey YAML | 9 | J-sso-login, J-session-refresh, J-session-logout, J-user-onboarding, J-account-lockout, J-audit-login-trail, J-config-hot-reload, J-config-rollback, J-order-create |
+| status-board.yaml | 1 | journeys/status-board.yaml |
+| actors.yaml | 1 | src/actors.yaml |
+| generated/boundary.yaml | 0 | Does not exist (OK -- no multi-assembly scenario yet) |
+| **Total** | **57** | |
+
+---
+
+## Check 1: Prohibited Old Field Names (11 fields)
+
+Searched all 57 YAML files for: `cellId`, `sliceId`, `contractId`, `assemblyId`, `ownedSlices`, `authoritativeData`, `producer`, `consumers`, `callsContracts`, `publishes`, `consumes`.
+
+**Result: PASS -- zero occurrences found.**
+
+---
+
+## Check 2: Entity ID Format
+
+### Cell IDs (expect kebab-case)
+
+| File | ID Value | Verdict |
+|------|----------|---------|
+| src/cells/access-core/cell.yaml | `access-core` | PASS |
+| src/cells/audit-core/cell.yaml | `audit-core` | PASS |
+| src/cells/config-core/cell.yaml | `config-core` | PASS |
+| src/cells/demo/cell.yaml | `demo` | PASS |
+| src/cells/device-cell/cell.yaml | `device-cell` | PASS |
+| src/cells/order-cell/cell.yaml | `order-cell` | PASS |
+
+### Slice IDs (expect kebab-case)
+
+All 21 slice IDs verified -- all kebab-case. No violations.
+
+<details><summary>Full slice ID list</summary>
+
+session-login, rbac-check, session-validate, session-logout, authorization-decide, identity-manage, session-refresh, audit-query, audit-verify, audit-archive, audit-append, config-read, config-write, config-publish, feature-flag, config-subscribe, device-command, device-register, device-status, order-create, order-query
+
+</details>
+
+### Assembly ID (expect kebab-case)
+
+| File | ID Value | Verdict |
+|------|----------|---------|
+| src/assemblies/core-bundle/assembly.yaml | `core-bundle` | PASS |
+
+### Contract IDs (expect lowercase dot-separated)
+
+All 18 contract IDs verified. No violations.
+
+<details><summary>Full contract ID list</summary>
+
+- `http.auth.login.v1`
+- `http.config.get.v1`
+- `event.session.created.v1`
+- `event.audit.appended.v1`
+- `event.session.revoked.v1`
+- `event.user.created.v1`
+- `event.user.locked.v1`
+- `event.audit.integrity-verified.v1`
+- `event.config.rollback.v1`
+- `http.auth.me.v1`
+- `http.config.flags.v1`
+- `event.config.changed.v1`
+- `http.auth.refresh.v1`
+- `command.device-command.v1`
+- `event.device-registered.v1`
+- `event.order-created.v1`
+- `http.device.v1`
+- `http.order.v1`
+
+</details>
+
+### Journey IDs (expect J-{kebab-case})
+
+All 9 journey IDs verified -- all match `J-{kebab-case}`. No violations.
+
+### Actor IDs (expect kebab-case)
+
+| File | ID Value | Verdict |
+|------|----------|---------|
+| src/actors.yaml | `edge-bff` | PASS |
+
+**Result: PASS -- all entity IDs conform to naming-baseline.md section 1.1.**
+
+---
+
+## Check 3: YAML Field Names (camelCase)
+
+Searched all 57 YAML files for snake_case multi-word field names (`[a-z]+_[a-z]+:` as a YAML key).
+
+**Result: PASS -- zero snake_case field names found.**
+
+Spot-check of camelCase fields across files:
+- `belongsToCell` -- used in all 21 slice.yaml files, correct
+- `contractUsages` -- used in all 21 slice.yaml files, correct
+- `consistencyLevel` -- used in all 6 cell.yaml + all 18 contract.yaml, correct
+- `journeyId` -- used in status-board.yaml, correct
+- `updatedAt` -- used in status-board.yaml, correct
+- `ownerCell` -- used in all contract.yaml, correct
+- `deliverySemantics` -- used in event contracts, correct
+- `idempotencyKey` -- used in event contracts, correct
+- `schemaRefs` -- used in HTTP contracts, correct
+- `l0Dependencies` -- used in core cell.yaml files, correct
+- `passCriteria` -- used in journey YAML, correct
+- `checkRef` -- used in journey YAML, correct
+- `expiresAt` -- used in waiver, correct
+- `maxConsistencyLevel` -- used in actors.yaml, correct
+- `deployTemplate` -- used in assembly.yaml, correct
+
+---
+
+## Check 4: Contract Directory Structure
+
+Expected: `src/contracts/{kind}/{domain-path}/{version}/contract.yaml`
+
+| Contract ID | Directory Path | Match | Verdict |
+|-------------|---------------|-------|---------|
+| http.auth.login.v1 | http/auth/login/v1/ | YES | PASS |
+| http.config.get.v1 | http/config/get/v1/ | YES | PASS |
+| event.session.created.v1 | event/session/created/v1/ | YES | PASS |
+| event.audit.appended.v1 | event/audit/appended/v1/ | YES | PASS |
+| event.session.revoked.v1 | event/session/revoked/v1/ | YES | PASS |
+| event.user.created.v1 | event/user/created/v1/ | YES | PASS |
+| event.user.locked.v1 | event/user/locked/v1/ | YES | PASS |
+| event.audit.integrity-verified.v1 | event/audit/integrity-verified/v1/ | YES | PASS |
+| event.config.rollback.v1 | event/config/rollback/v1/ | YES | PASS |
+| http.auth.me.v1 | http/auth/me/v1/ | YES | PASS |
+| http.config.flags.v1 | http/config/flags/v1/ | YES | PASS |
+| event.config.changed.v1 | event/config/changed/v1/ | YES | PASS |
+| http.auth.refresh.v1 | http/auth/refresh/v1/ | YES | PASS |
+| command.device-command.v1 | command/device-command/v1/ | YES | PASS |
+| event.device-registered.v1 | event/device-registered/v1/ | YES | PASS |
+| event.order-created.v1 | event/order-created/v1/ | YES | PASS |
+| http.device.v1 | http/device/v1/ | YES | PASS |
+| http.order.v1 | http/order/v1/ | YES | PASS |
+
+**Result: PASS -- all 18 contracts have correct directory structure matching their IDs.**
+
+### SchemaRef File Existence (HTTP contracts only)
+
+Six HTTP contracts declare `schemaRefs` with `request.schema.json` and `response.schema.json`. All 12 files verified to exist on disk:
+- http/auth/login/v1/ -- request.schema.json, response.schema.json
+- http/config/get/v1/ -- request.schema.json, response.schema.json
+- http/auth/me/v1/ -- request.schema.json, response.schema.json
+- http/config/flags/v1/ -- request.schema.json, response.schema.json
+- http/auth/refresh/v1/ -- request.schema.json, response.schema.json
+
+Note: `http.device.v1` and `http.order.v1` do not declare `schemaRefs`, so no files to check.
+
+---
+
+## Check 5: generated/boundary.yaml
+
+File does not exist. Per naming-baseline.md section 1.5, when it is eventually generated, it must not contain the `assemblyId` field.
+
+**Result: N/A -- file not yet generated.**
+
+---
+
+## Violations Summary
+
+| # | File:Line | Violation Type | Severity | Suggested Fix |
+|---|-----------|---------------|----------|---------------|
+| (none) | -- | -- | -- | -- |
+
+**Total violations: 0**
+
+---
+
+## Observations (non-blocking, for future consideration)
+
+1. **device-cell and order-cell cell.yaml lack `l0Dependencies`**: The three core cells (access-core, audit-core, config-core) all declare `l0Dependencies: []`, but device-cell and order-cell omit this field entirely. While not a naming violation, this is a metadata consistency gap.
+
+2. **status-board.yaml missing J-order-create**: The status-board lists 8 journeys but `J-order-create` is not tracked. This is not a naming issue but a metadata completeness gap.
+
+3. **event.config.rollback.v1 lists access-core as subscriber**: No access-core slice declares a `contractUsage` for `event.config.rollback.v1` as a subscriber. This is a referential integrity concern, not a naming issue, and belongs in a separate audit (R1H-2 or similar).
+
+---
+
+## Conclusion
+
+All 57 YAML metadata files in the repository pass the naming compliance checks defined in `docs/architecture/naming-baseline.md`. No prohibited field names, no snake_case YAML keys, no malformed entity IDs, and all contract directories match their IDs correctly.

--- a/docs/reviews/202604060830-R0/R1H-2-go-naming-lower.md
+++ b/docs/reviews/202604060830-R0/R1H-2-go-naming-lower.md
@@ -1,0 +1,120 @@
+# R1H-2 Go Naming Convention Review
+
+Reviewer: R1H-2 (Go Naming)
+Scope: `src/pkg/**/*.go`, `src/kernel/**/*.go`, `src/runtime/**/*.go` (excluding `_test.go`)
+Baseline: `docs/architecture/naming-baseline.md` section 1.6 + section 2.2
+Commit: ce03ba1 (HEAD of develop at review time)
+Date: 2026-04-06
+
+## Summary
+
+Total production .go files reviewed: 62
+Total lines scanned: ~6500 LOC (excluding test files)
+
+### Verdict: PASS with 1 P2 finding
+
+The codebase demonstrates excellent adherence to Go naming conventions.
+All 13 abbreviation checklist items are clean in Go identifiers.
+
+---
+
+## Checklist Results
+
+### 1. Go Abbreviation Casing
+
+| Abbreviation | Incorrect pattern searched | Violations found |
+|---|---|---|
+| `Id` (should be `ID`) | `[A-Z][a-z]*Id[^e]`, `[a-z]Id[^e]` | 0 in Go identifiers |
+| `Url` (should be `URL`) | `[A-Z][a-z]*Url` | 0 |
+| `Http` (should be `HTTP`) | `[A-Z][a-z]*Http`, `Http[A-Z]` | 0 |
+| `Jwt` (should be `JWT`) | `[A-Z][a-z]*Jwt`, `Jwt[A-Z]` | 0 |
+| `Oidc` (should be `OIDC`) | `[A-Z][a-z]*Oidc`, `Oidc[A-Z]` | 0 |
+| `Rbac` (should be `RBAC`) | `[A-Z][a-z]*Rbac`, `Rbac[A-Z]` | 0 |
+| `Json` (should be `JSON`) | `[A-Z][a-z]*Json`, `Json[A-Z]` | 0 |
+| `Yaml` (should be `YAML`) | `[A-Z][a-z]*Yaml`, `Yaml[A-Z]` | 0 |
+| `Sql` (should be `SQL`) | `[A-Z][a-z]*Sql`, `Sql[A-Z]` | 0 |
+| `Ip` (should be `IP`) | `[A-Z][a-z]*Ip` | 0 |
+| `Ttl` (should be `TTL`) | `[A-Z][a-z]*Ttl`, `Ttl[A-Z]` | 0 |
+| `Hmac` (should be `HMAC`) | `[A-Z][a-z]*Hmac`, `Hmac[A-Z]` | 0 |
+| `Jwks` (should be `JWKS`) | `[A-Z][a-z]*Jwks`, `Jwks[A-Z]` | 0 |
+| `Uri` (should be `URI`) | `[A-Z][a-z]*Uri` | 0 |
+
+Exemplary usages found:
+- `ctxkeys.RequestID`, `ctxkeys.CellID`, `ctxkeys.RealIP` (pkg/ctxkeys/keys.go)
+- `JWTVerifier`, `JWTIssuer`, `JWKSURI` naming (runtime/auth/jwt.go)
+- `EnvJWTPrivateKey`, `EnvJWTPublicKey` (runtime/auth/keys.go)
+- `headerRequestID` (runtime/http/middleware/request_id.go)
+- `JourneyID string` struct field with `yaml:"journeyId"` tag (kernel/metadata/types.go:138)
+
+Note: All `journeyId`, `cellId`, `sliceId`, `assemblyId` matches are in YAML struct tags, string literals (map keys for banned-field detection), comments, or test data -- not Go identifiers. These are correct per naming-baseline.md section 1.2 which mandates `camelCase` for YAML field names.
+
+### 2. errcode Constant Format
+
+All errcode constants follow `ERR_*` + `SCREAMING_SNAKE_CASE`:
+- `pkg/errcode/errcode.go`: 27 constants, all conforming
+- `kernel/scaffold/scaffold.go`: 5 constants, all conforming
+- `runtime/auth/jwt.go`: 1 var, conforming (`ERR_AUTH_UNAUTHORIZED`)
+- `runtime/auth/keys.go`: 1 var, conforming (`ERR_AUTH_KEY_MISSING`)
+
+No violations found.
+
+### 3. Exported/Non-exported Identifiers
+
+Spot-checked all 62 files:
+- All exported types, functions, methods, and constants use PascalCase
+- All non-exported identifiers use camelCase
+- No violations found
+
+### 4. Go Package Names
+
+All packages use lowercase continuous words:
+- `errcode`, `ctxkeys`, `httputil`, `uid`, `id` (pkg/)
+- `cell`, `metadata`, `governance`, `assembly`, `gentpl`, `registry`, `scaffold`, `journey`, `idempotency`, `outbox`, `slice` (kernel/)
+- `auth`, `bootstrap`, `config`, `eventbus`, `health`, `middleware`, `router`, `logging`, `metrics`, `tracing`, `shutdown`, `worker` (runtime/)
+
+No underscores, hyphens, or mixed case. All conforming.
+
+### 5. Go File Names
+
+All 62 files use `lower_snake_case.go` or single-word names:
+- Multi-word examples: `access_log.go`, `body_limit.go`, `rate_limit.go`, `real_ip.go`, `request_id.go`, `security_headers.go`, `rules_advisory.go`, `rules_fmt.go`, `rules_ref.go`, `rules_topo.go`, `rules_verify.go`, `parser_integration_test.go`
+
+No violations found.
+
+---
+
+## Findings
+
+### F-001 [P2] Template generates banned YAML field `assemblyId`
+
+| Field | Value |
+|---|---|
+| Seat | R1H-2 Go Naming |
+| Severity | P2 |
+| Category | Naming / banned field |
+| File | `src/kernel/assembly/gentpl/boundary.yaml.tpl:4` |
+| Evidence | `assemblyId: {{.AssemblyID}}` |
+| Commit | ce03ba1 |
+| Status | OPEN |
+
+The `boundary.yaml.tpl` template outputs `assemblyId:` as a YAML field name. Per `naming-baseline.md` section 1.3, `assemblyId` is a banned field name -- the replacement is `id`. Per section 1.5, `generated/boundary.yaml` should not contain the `assemblyId` field.
+
+The `governance/rules_fmt.go` bannedFieldNames map already lists `assemblyId` as banned with replacement `id`, and `naming-baseline.md` section 1.5 explicitly enumerates the allowed generated fields (`generatedAt`, `sourceFingerprint`, `exportedContracts`, `importedContracts`, `smokeTargets`) -- `assemblyId` is not among them.
+
+This violation is also locked in by test assertions:
+- `generator_test.go:313`: `assert.Contains(t, content, "assemblyId: sso-bff")`
+- `generator_test.go:345`: `assert.Contains(t, content, "assemblyId: empty")`
+
+**Fix suggestion**: Change the template field from `assemblyId` to `id` (or remove it entirely since it duplicates the assembly directory name), and update the corresponding test assertions.
+
+---
+
+## Non-findings (noted but not violations)
+
+### N-001 Duplicate errcode definition (informational)
+
+`runtime/auth/jwt.go:54` declares `var ErrAuthUnauthorized = errcode.Code("ERR_AUTH_UNAUTHORIZED")` which duplicates `errcode.ErrAuthUnauthorized` in `pkg/errcode/errcode.go:24`. Both have the same string value. This is not a naming convention violation but creates a maintenance risk -- the runtime/auth package uses its own local variable while the centralized constant exists. Recommend consolidating to use `errcode.ErrAuthUnauthorized` directly.
+
+### N-002 Comment uses YAML field name (informational)
+
+`kernel/journey/catalog.go:13`: comment says `// keyed by journeyId` -- this refers to the YAML field name, not a Go identifier. Acceptable per naming-baseline.md scope rules.

--- a/docs/reviews/202604060830-R0/R1H-3-go-naming-upper.md
+++ b/docs/reviews/202604060830-R0/R1H-3-go-naming-upper.md
@@ -1,0 +1,220 @@
+# R1H-3: Go Naming Convention Review (adapters/ + cells/ + examples/ + cmd/)
+
+Reviewer: R1H-3 Agent (Seat 5 DX/Maintainability focus)
+Scope: `src/adapters/**/*.go`, `src/cells/**/*.go`, `src/examples/**/*.go`, `src/cmd/**/*.go` (non-test)
+Baseline: `docs/architecture/naming-baseline.md`
+Date: 2026-04-06
+
+---
+
+## 1. Go Abbreviation Violations (Id -> ID)
+
+### 1.1 URL Path Parameter `{cmdId}` (should be `{cmdID}`)
+
+This is a chi URL path parameter. While chi does not enforce casing, project consistency requires `ID` form.
+
+| # | File | Line | Current | Should Be |
+|---|------|------|---------|-----------|
+| 1 | `src/cells/device-cell/cell.go` | 129 | `{cmdId}` | `{cmdID}` |
+| 2 | `src/cells/device-cell/slices/device-command/handler.go` | 70 | `{cmdId}` (comment) | `{cmdID}` |
+| 3 | `src/cells/device-cell/slices/device-command/handler.go` | 73 | `chi.URLParam(r, "cmdId")` | `chi.URLParam(r, "cmdID")` |
+
+Severity: P2 (URL path params are external API surface but chi params are internal routing keys)
+
+Note: If `cmdId` is changed in the route pattern, all `chi.URLParam(r, "cmdId")` calls and tests must be updated together.
+
+### 1.2 JSON Response Map Key `"deviceId"` (should be `"deviceID"`)
+
+Per naming-baseline 2.1, JSON fields should be camelCase. However, the Go abbreviation rule (`ID` not `Id`) applies to Go identifiers, not JSON field names. The JSON convention is `"deviceId"` (camelCase) which is actually the standard JSON convention -- `"deviceID"` would be unusual in JSON.
+
+**Decision: NOT a violation.** JSON field `"deviceId"` follows standard JSON camelCase convention. The Go struct field `DeviceID` correctly uses `ID`, and the JSON tag maps it to `"deviceId"` which is correct. No action needed.
+
+Affected locations (all COMPLIANT):
+- `src/cells/device-cell/internal/domain/device.go:23` -- `DeviceID string \`json:"deviceId"\``
+- `src/cells/device-cell/slices/device-command/handler.go:47` -- `"deviceId": cmd.DeviceID`
+
+---
+
+## 2. JSON Tag snake_case Violations
+
+### 2.1 OIDC Adapter -- External Protocol (EXEMPT)
+
+The following use snake_case in JSON tags because they map to the OIDC/OAuth2 protocol specification (RFC 6749, OpenID Connect Discovery 1.0). These are NOT violations.
+
+| File | Line | Tag | Reason |
+|------|------|-----|--------|
+| `src/adapters/oidc/token.go` | 18 | `json:"access_token"` | OAuth2 RFC 6749 |
+| `src/adapters/oidc/token.go` | 19 | `json:"token_type"` | OAuth2 RFC 6749 |
+| `src/adapters/oidc/token.go` | 20 | `json:"expires_in"` | OAuth2 RFC 6749 |
+| `src/adapters/oidc/token.go` | 21 | `json:"refresh_token"` | OAuth2 RFC 6749 |
+| `src/adapters/oidc/token.go` | 22 | `json:"id_token"` | OIDC Core |
+| `src/adapters/oidc/provider.go` | 20 | `json:"authorization_endpoint"` | OIDC Discovery |
+| `src/adapters/oidc/provider.go` | 21 | `json:"token_endpoint"` | OIDC Discovery |
+| `src/adapters/oidc/provider.go` | 22 | `json:"userinfo_endpoint"` | OIDC Discovery |
+| `src/adapters/oidc/provider.go` | 23 | `json:"jwks_uri"` | OIDC Discovery |
+| `src/adapters/oidc/provider.go` | 24 | `json:"scopes_supported"` | OIDC Discovery |
+| `src/adapters/oidc/provider.go` | 25 | `json:"id_token_signing_alg_values_supported"` | OIDC Discovery |
+| `src/adapters/oidc/userinfo.go` | 19 | `json:"email_verified"` | OIDC UserInfo |
+
+**Status: EXEMPT** -- External protocol fields, naming-baseline 2.1 allows external protocol overrides.
+
+### 2.2 Audit Append -- Internal Payload Struct
+
+| # | File | Line | Current | Should Be |
+|---|------|------|---------|-----------|
+| 1 | `src/cells/audit-core/slices/auditappend/service.go` | 93 | `json:"user_id"` | `json:"userId"` |
+
+Severity: P2 (this struct unmarshals event payloads; the JSON field name is part of the internal event schema)
+
+Note: This struct reads from event payloads produced by `identitymanage/service.go:91` (`"user_id"`) and `sessionlogin/service.go:153` (`"user_id"`). All producers and consumers must change together if this is fixed.
+
+---
+
+## 3. Event Payload JSON Keys (snake_case)
+
+Event payloads use `map[string]any` with snake_case keys. Per naming-baseline 2.1, JSON fields should prefer camelCase. However, event payloads are internal protocol between producers and consumers, not external API. This is a borderline area.
+
+**Listing for completeness (all P2 -- suggestion, not blocking):**
+
+| # | File | Line | Key(s) |
+|---|------|------|--------|
+| 1 | `src/cells/access-core/slices/identitymanage/service.go` | 91 | `"user_id"`, `"username"` |
+| 2 | `src/cells/access-core/slices/identitymanage/service.go` | 192 | `"user_id"` |
+| 3 | `src/cells/access-core/slices/sessionlogin/service.go` | 153 | `"session_id"`, `"user_id"` |
+| 4 | `src/cells/access-core/slices/sessionlogout/service.go` | 88 | `"session_id"`, `"user_id"` |
+| 5 | `src/cells/audit-core/slices/auditappend/service.go` | 108-109 | `"audit_entry_id"`, `"event_type"` |
+| 6 | `src/cells/audit-core/slices/auditverify/service.go` | 95-96 | `"first_invalid_index"`, `"entries_checked"` |
+| 7 | `src/cells/config-core/slices/configpublish/service.go` | 92 | `"config_id"` |
+| 8 | `src/cells/config-core/slices/configpublish/service.go` | 134-135 | `"target_version"`, `"new_version"` |
+
+Severity: P2 (event payloads are internal, but naming-baseline says JSON should prefer camelCase)
+
+---
+
+## 4. Query Parameter Naming (snake_case -> camelCase)
+
+Per naming-baseline 2.1: "JSON / Query / Path fields should use camelCase".
+
+| # | File | Line | Current | Should Be |
+|---|------|------|---------|-----------|
+| 1 | `src/cells/audit-core/slices/auditquery/handler.go` | 29 | `r.URL.Query().Get("event_type")` | `"eventType"` |
+| 2 | `src/cells/audit-core/slices/auditquery/handler.go` | 30 | `r.URL.Query().Get("actor_id")` | `"actorId"` |
+
+Severity: P1 (external API surface, directly affects client integration)
+
+---
+
+## 5. DB Field Naming
+
+All SQL queries use snake_case for column names. Verified in:
+- `src/adapters/postgres/migrator.go` -- `version`, `applied_at`, `name`
+- `src/adapters/postgres/outbox_writer.go` -- `aggregate_id`, `aggregate_type`, `event_type`, `payload`, `metadata`
+- `src/adapters/postgres/outbox_relay.go` -- `id`, `aggregate_id`, `aggregate_type`, `event_type`, `payload`, `metadata`, `published`, `published_at`, `created_at`
+- `src/cells/config-core/internal/adapters/postgres/config_repo.go` -- `id`, `key`, `value`, `version`, `created_at`, `updated_at`, `config_id`, `published_at`
+- `src/cells/audit-core/internal/adapters/postgres/audit_repo.go` -- `id`, `event_id`, `event_type`, `actor_id`, `timestamp`, `payload`, `prev_hash`, `hash`
+
+**Status: COMPLIANT** -- All DB column names use snake_case as required.
+
+---
+
+## 6. Environment Variable Naming
+
+| # | File | Line | Variable | Status |
+|---|------|------|----------|--------|
+| 1 | `src/adapters/postgres/pool.go` | 49 | `GOCELL_PG_DSN` | COMPLIANT |
+| 2 | `src/adapters/postgres/pool.go` | 55 | `GOCELL_PG_MAX_CONNS` | COMPLIANT |
+| 3 | `src/adapters/postgres/pool.go` | 60 | `GOCELL_PG_IDLE_TIMEOUT` | COMPLIANT |
+| 4 | `src/adapters/postgres/pool.go` | 65 | `GOCELL_PG_MAX_LIFETIME` | COMPLIANT |
+| 5 | `src/cmd/core-bundle/main.go` | 33 | `GOCELL_SIGNING_KEY` | COMPLIANT |
+| 6 | `src/cmd/core-bundle/main.go` | 34 | `GOCELL_HMAC_KEY` | COMPLIANT |
+| 7 | `src/cmd/core-bundle/main.go` | 37 | `GOCELL_ADAPTER_MODE` | COMPLIANT |
+| 8 | `src/adapters/s3/client.go` | 48 | `GOCELL_S3_ENDPOINT` | COMPLIANT |
+| 9 | `src/adapters/s3/client.go` | 49 | `GOCELL_S3_REGION` | COMPLIANT |
+| 10 | `src/adapters/s3/client.go` | 50 | `GOCELL_S3_BUCKET` | COMPLIANT |
+| 11 | `src/adapters/s3/client.go` | 51 | `GOCELL_S3_ACCESS_KEY` | COMPLIANT |
+| 12 | `src/adapters/s3/client.go` | 52 | `GOCELL_S3_SECRET_KEY` | COMPLIANT |
+| 13 | `src/adapters/s3/client.go` | 53 | `GOCELL_S3_USE_PATH_STYLE` | COMPLIANT |
+
+Legacy S3_* fallback variables are documented as deprecated with slog.Warn -- acceptable.
+
+**Note (test file only, out of scope):** `src/adapters/postgres/pool_test.go:123` uses `PG_INTEGRATION` (no `GOCELL_` prefix). This is a test-only gate variable, not a production config. Not counted as a violation but noted for awareness.
+
+**Status: COMPLIANT** -- All production env vars use `GOCELL_*` prefix with SCREAMING_SNAKE_CASE.
+
+---
+
+## 7. Slice Dual-Directory Violations
+
+Naming-baseline 1.4 states: "Not allowed to have parallel sibling directories, e.g. `session-login/` and `sessionlogin/` coexisting."
+
+The following dual-directory pairs exist:
+
+| # | Cell | kebab-case dir (slice.yaml) | Go package dir (code) | Violation? |
+|---|------|-----------------------------|-----------------------|------------|
+| 1 | access-core | `slices/session-login/` | `slices/sessionlogin/` | YES |
+| 2 | access-core | `slices/session-logout/` | `slices/sessionlogout/` | (inferred) |
+| 3 | access-core | `slices/session-refresh/` | `slices/sessionrefresh/` | (inferred) |
+| 4 | access-core | `slices/session-validate/` | `slices/sessionvalidate/` | (inferred from code path) |
+| 5 | access-core | `slices/identity-manage/` | `slices/identitymanage/` | YES |
+| 6 | access-core | `slices/rbac-check/` | `slices/rbaccheck/` | YES |
+| 7 | access-core | `slices/authorization-decide/` | `slices/authorizationdecide/` | YES |
+| 8 | audit-core | `slices/audit-append/` | `slices/auditappend/` | YES |
+| 9 | audit-core | `slices/audit-query/` | `slices/auditquery/` | YES |
+| 10 | audit-core | `slices/audit-verify/` | `slices/auditverify/` | YES |
+| 11 | audit-core | `slices/audit-archive/` | `slices/auditarchive/` | YES |
+| 12 | config-core | `slices/config-read/` | `slices/configread/` | YES |
+| 13 | config-core | `slices/config-write/` | `slices/configwrite/` | YES |
+| 14 | config-core | `slices/config-publish/` | `slices/configpublish/` | YES |
+| 15 | config-core | `slices/config-subscribe/` | `slices/configsubscribe/` | YES |
+| 16 | config-core | `slices/feature-flag/` | `slices/featureflag/` | YES |
+
+Evidence: `src/cells/access-core/slices/` contains both `session-login/slice.yaml` and `sessionlogin/handler.go` as separate directories. Same pattern repeats across all three core Cells.
+
+Severity: P1 (naming-baseline 1.4 explicitly prohibits this; section 3 lists it as a required migration item)
+
+Note: `device-cell` and `order-cell` do NOT have this problem -- they use a single kebab-case directory for both slice.yaml and Go code, with the Go package name derived from the directory. This is the correct pattern.
+
+---
+
+## 8. errcode Format
+
+All error codes in scope follow `ERR_*` + SCREAMING_SNAKE_CASE format.
+
+Verified across:
+- `src/adapters/postgres/errors.go` -- `ERR_ADAPTER_PG_*`
+- `src/adapters/redis/client.go` -- `ERR_ADAPTER_REDIS_*`
+- `src/adapters/rabbitmq/connection.go` -- `ERR_ADAPTER_AMQP_*`
+- `src/adapters/s3/errors.go` -- `ERR_ADAPTER_S3_*`
+- `src/adapters/websocket/errors.go` -- `ERR_ADAPTER_WS_*`
+- `src/adapters/oidc/errors.go` -- `ERR_ADAPTER_OIDC_*`
+- `src/cells/access-core/` -- `ERR_AUTH_*`
+- `src/cells/audit-core/` -- `ERR_AUDIT_*`, `ERR_NOT_IMPLEMENTED`, `ERR_ARCHIVE_*`
+- `src/cells/config-core/` -- `ERR_CONFIG_*`, `ERR_FLAG_*`
+
+**Status: COMPLIANT**
+
+---
+
+## Summary
+
+| Category | Findings | Severity |
+|----------|----------|----------|
+| Go abbreviations (URL param `cmdId`) | 3 locations | P2 |
+| JSON tag snake_case (internal struct) | 1 location | P2 |
+| Event payload JSON keys (snake_case) | 8 code sites | P2 |
+| Query param snake_case (external API) | 2 locations | P1 |
+| DB field naming | 0 | COMPLIANT |
+| Environment variables | 0 | COMPLIANT |
+| Slice dual-directory | 16 pairs | P1 |
+| errcode format | 0 | COMPLIANT |
+
+### Action Items
+
+**P1 (should fix):**
+1. **Query parameters**: Change `event_type` -> `eventType` and `actor_id` -> `actorId` in `src/cells/audit-core/slices/auditquery/handler.go:29-30`. Update corresponding tests in `handler_test.go`.
+2. **Slice dual-directory consolidation**: Merge 16 dual-directory pairs so each slice has one canonical directory. Go code and slice.yaml must coexist in the kebab-case directory. The Go package name inside a `session-login/` directory should be `sessionlogin` (Go does not allow hyphens in package names, but the *directory* should be kebab-case). This is tracked in naming-baseline section 3 as a migration item.
+
+**P2 (suggestion):**
+3. **URL path param `cmdId`**: Consider renaming to `cmdID` in route pattern and all `chi.URLParam` calls. Low priority since it is an internal routing key.
+4. **Event payload keys**: Consider migrating internal event payload JSON keys from snake_case to camelCase for consistency with the naming baseline. This requires coordinated changes across all producers and consumers.
+5. **JSON tag `"user_id"`**: In `auditappend/service.go:93`, consider changing to `"userId"` if event producers are also updated.

--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -193,10 +193,10 @@ func (r *OutboxRelay) pollOnce(ctx context.Context) error {
 			continue
 		}
 
-		if err := r.pub.Publish(ctx, e.EventType, payload); err != nil {
+		if err := r.pub.Publish(ctx, e.RoutingTopic(), payload); err != nil {
 			slog.Error("outbox relay: publish failed",
 				slog.String("entry_id", e.ID),
-				slog.String("event_type", e.EventType),
+				slog.String("topic", e.RoutingTopic()),
 				slog.Any("error", err),
 			)
 			// Do NOT mark as published; will retry on next poll.

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -103,16 +103,18 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 	return func(ctx context.Context, entry outbox.Entry) error {
 		idempotencyKey := fmt.Sprintf("%s:%s", cb.config.ConsumerGroup, entry.ID)
 
-		// Check idempotency.
-		processed, err := cb.checker.IsProcessed(ctx, idempotencyKey)
+		// Atomic idempotency check-and-mark via TryProcess (eliminates TOCTOU race).
+		shouldProcess, err := cb.checker.TryProcess(ctx, idempotencyKey, cb.config.IdempotencyTTL)
 		if err != nil {
 			slog.Warn("rabbitmq: idempotency check failed, proceeding with handler",
 				slog.String("event_id", entry.ID),
 				slog.String("topic", topic),
 				slog.String("consumer_group", cb.config.ConsumerGroup),
 				slog.String("error", err.Error()))
+			// On error, default to processing (fail-open) to avoid dropping messages.
+			shouldProcess = true
 		}
-		if processed {
+		if !shouldProcess {
 			slog.Debug("rabbitmq: event already processed, skipping",
 				slog.String("event_id", entry.ID),
 				slog.String("topic", topic),
@@ -125,14 +127,6 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 		for attempt := range cb.config.RetryCount {
 			lastErr = handler(ctx, entry)
 			if lastErr == nil {
-				// Handler succeeded — mark as processed.
-				if markErr := cb.checker.MarkProcessed(ctx, idempotencyKey, cb.config.IdempotencyTTL); markErr != nil {
-					slog.Error("rabbitmq: failed to mark event as processed",
-						slog.String("event_id", entry.ID),
-						slog.String("topic", topic),
-						slog.String("consumer_group", cb.config.ConsumerGroup),
-						slog.String("error", markErr.Error()))
-				}
 				return nil
 			}
 

--- a/src/adapters/rabbitmq/integration_test.go
+++ b/src/adapters/rabbitmq/integration_test.go
@@ -260,3 +260,7 @@ func (n *noopChecker) IsProcessed(_ context.Context, _ string) (bool, error) {
 func (n *noopChecker) MarkProcessed(_ context.Context, _ string, _ time.Duration) error {
 	return nil
 }
+
+func (n *noopChecker) TryProcess(_ context.Context, _ string, _ time.Duration) (bool, error) {
+	return true, nil
+}

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -204,10 +204,11 @@ func (m *mockConnection) Close() error {
 // --- Mock Idempotency Checker ---
 
 type mockIdempotencyChecker struct {
-	mu        sync.Mutex
-	processed map[string]bool
-	checkErr  error
-	markErr   error
+	mu          sync.Mutex
+	processed   map[string]bool
+	checkErr    error
+	markErr     error
+	tryProcErr  error
 }
 
 func newMockIdempotencyChecker() *mockIdempotencyChecker {
@@ -233,6 +234,19 @@ func (m *mockIdempotencyChecker) MarkProcessed(_ context.Context, key string, _ 
 	}
 	m.processed[key] = true
 	return nil
+}
+
+func (m *mockIdempotencyChecker) TryProcess(_ context.Context, key string, _ time.Duration) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.tryProcErr != nil {
+		return false, m.tryProcErr
+	}
+	if m.processed[key] {
+		return false, nil
+	}
+	m.processed[key] = true
+	return true, nil
 }
 
 // Compile-time interface checks.
@@ -955,9 +969,11 @@ func TestConsumerBase_Wrap_RetryExhausted_DLQ(t *testing.T) {
 	assert.Equal(t, "2", dlqEntry.Metadata["x-death-retry-count"])
 	pub.mu.Unlock()
 
-	// Should NOT be marked as processed.
+	// With TryProcess, the key is claimed atomically before the handler runs.
+	// Even though the handler failed and exhausted retries, the key remains marked
+	// to prevent duplicate processing by other consumers (message goes to DLQ).
 	checker.mu.Lock()
-	assert.False(t, checker.processed["test-group:evt-003"])
+	assert.True(t, checker.processed["test-group:evt-003"])
 	checker.mu.Unlock()
 }
 
@@ -1013,7 +1029,7 @@ func TestConsumerBase_Wrap_CustomDLQTopic(t *testing.T) {
 
 func TestConsumerBase_Wrap_IdempotencyCheckError_StillProcesses(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	checker.checkErr = errors.New("redis down")
+	checker.tryProcErr = errors.New("redis down")
 	pub := newMockPublisher()
 
 	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{

--- a/src/adapters/redis/idempotency.go
+++ b/src/adapters/redis/idempotency.go
@@ -57,3 +57,16 @@ func (ic *IdempotencyChecker) MarkProcessed(ctx context.Context, key string, ttl
 	}
 	return nil
 }
+
+// TryProcess atomically checks whether key has been processed and marks it if not.
+// Returns true if the caller should process (key was not previously seen).
+// Returns false if already processed (another consumer got there first).
+// Uses Redis SetNX which is inherently atomic, eliminating the TOCTOU race.
+func (ic *IdempotencyChecker) TryProcess(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+	set, err := ic.rdb.SetNX(ctx, key, "1", ttl).Result()
+	if err != nil {
+		return false, errcode.Wrap(ErrAdapterRedisSet,
+			fmt.Sprintf("redis: idempotency try-process failed (key=%s)", key), err)
+	}
+	return set, nil
+}

--- a/src/adapters/redis/idempotency_test.go
+++ b/src/adapters/redis/idempotency_test.go
@@ -69,6 +69,50 @@ func TestIdempotencyChecker_MarkProcessed_SetNXError(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_REDIS_SET")
 }
 
+func TestIdempotencyChecker_TryProcess_FirstCall(t *testing.T) {
+	mock := newMockCmdable()
+	ic := newIdempotencyCheckerFromCmdable(mock)
+	ctx := context.Background()
+
+	// First call: key does not exist, should return true (caller should process).
+	shouldProcess, err := ic.TryProcess(ctx, "idem:test:try:1", 24*time.Hour)
+	require.NoError(t, err)
+	assert.True(t, shouldProcess, "first TryProcess should return true")
+
+	// Verify key is now marked as processed via IsProcessed.
+	ok, err := ic.IsProcessed(ctx, "idem:test:try:1")
+	require.NoError(t, err)
+	assert.True(t, ok, "key should be processed after TryProcess")
+}
+
+func TestIdempotencyChecker_TryProcess_Duplicate(t *testing.T) {
+	mock := newMockCmdable()
+	ic := newIdempotencyCheckerFromCmdable(mock)
+	ctx := context.Background()
+
+	// First call succeeds.
+	shouldProcess, err := ic.TryProcess(ctx, "idem:test:try:2", 24*time.Hour)
+	require.NoError(t, err)
+	assert.True(t, shouldProcess)
+
+	// Second call: key already exists, should return false.
+	shouldProcess, err = ic.TryProcess(ctx, "idem:test:try:2", 24*time.Hour)
+	require.NoError(t, err)
+	assert.False(t, shouldProcess, "duplicate TryProcess should return false")
+}
+
+func TestIdempotencyChecker_TryProcess_SetNXError(t *testing.T) {
+	mock := newMockCmdable()
+	mock.setNXErr = errMock
+	ic := newIdempotencyCheckerFromCmdable(mock)
+	ctx := context.Background()
+
+	shouldProcess, err := ic.TryProcess(ctx, "idem:test:try:err", 24*time.Hour)
+	require.Error(t, err)
+	assert.False(t, shouldProcess)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_REDIS_SET")
+}
+
 func TestIdempotencyChecker_ViaClientConstructor(t *testing.T) {
 	mock := newMockCmdable()
 	client := newClientFromCmdable(mock, Config{})

--- a/src/cells/access-core/cell_test.go
+++ b/src/cells/access-core/cell_test.go
@@ -20,9 +20,21 @@ import (
 
 var (
 	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
-	testIssuer              = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
-	testVerifier            = auth.NewJWTVerifier(testPubKey)
+	testIssuer              *auth.JWTIssuer
+	testVerifier            *auth.JWTVerifier
 )
+
+func init() {
+	var err error
+	testIssuer, err = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+	testVerifier, err = auth.NewJWTVerifier(testPubKey)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+}
 
 // noopWriter is a no-op outbox.Writer for testing.
 type noopWriter struct{}

--- a/src/cells/access-core/slices/sessionlogin/service_test.go
+++ b/src/cells/access-core/slices/sessionlogin/service_test.go
@@ -18,8 +18,16 @@ import (
 
 var (
 	testPrivKey, _ = auth.MustGenerateTestKeyPair()
-	testIssuer     = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
+	testIssuer     *auth.JWTIssuer
 )
+
+func init() {
+	var err error
+	testIssuer, err = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+}
 
 func newTestService() (*Service, *mem.UserRepository) {
 	userRepo := mem.NewUserRepository()

--- a/src/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/src/cells/access-core/slices/sessionrefresh/service_test.go
@@ -15,9 +15,21 @@ import (
 
 var (
 	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
-	testIssuer              = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
-	testVerifier            = auth.NewJWTVerifier(testPubKey)
+	testIssuer              *auth.JWTIssuer
+	testVerifier            *auth.JWTVerifier
 )
+
+func init() {
+	var err error
+	testIssuer, err = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+	testVerifier, err = auth.NewJWTVerifier(testPubKey)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+}
 
 func newTestService() (*Service, *mem.SessionRepository) {
 	sessionRepo := mem.NewSessionRepository()
@@ -125,9 +137,10 @@ func TestService_Refresh_SigningMethodCheck(t *testing.T) {
 
 	// Tokens signed with a different key should be rejected by the verifier.
 	otherPriv, _ := auth.MustGenerateTestKeyPair()
-	otherIssuer := auth.NewJWTIssuer(otherPriv, "gocell-access-core", time.Hour)
+	otherIssuer, err := auth.NewJWTIssuer(otherPriv, "gocell-access-core", time.Hour)
+	require.NoError(t, err)
 	tokenStr, _ := otherIssuer.Issue("usr-1", nil, nil)
 
-	_, err := svc.Refresh(context.Background(), tokenStr)
+	_, err = svc.Refresh(context.Background(), tokenStr)
 	assert.Error(t, err, "should reject token signed with a different key")
 }

--- a/src/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/src/cells/access-core/slices/sessionvalidate/service_test.go
@@ -15,8 +15,16 @@ import (
 
 var (
 	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
-	testVerifier            = auth.NewJWTVerifier(testPubKey)
+	testVerifier            *auth.JWTVerifier
 )
+
+func init() {
+	var err error
+	testVerifier, err = auth.NewJWTVerifier(testPubKey)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+}
 
 func TestService_Verify(t *testing.T) {
 	sessionRepo := mem.NewSessionRepository()

--- a/src/cells/audit-core/slices/auditquery/handler.go
+++ b/src/cells/audit-core/slices/auditquery/handler.go
@@ -23,11 +23,11 @@ func NewHandler(svc *Service) *Handler {
 }
 
 // HandleQuery handles GET /api/v1/audit/entries.
-// Query parameters: event_type, actor_id, from, to (RFC3339).
+// Query parameters: eventType, actorId, from, to (RFC3339).
 func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	filters := ports.AuditFilters{
-		EventType: r.URL.Query().Get("event_type"),
-		ActorID:   r.URL.Query().Get("actor_id"),
+		EventType: r.URL.Query().Get("eventType"),
+		ActorID:   r.URL.Query().Get("actorId"),
 	}
 
 	if fromStr := r.URL.Query().Get("from"); fromStr != "" {

--- a/src/examples/sso-bff/main.go
+++ b/src/examples/sso-bff/main.go
@@ -44,8 +44,16 @@ func main() {
 
 	// RSA key pair for JWT signing/verification (development only).
 	privKey, pubKey := auth.MustGenerateTestKeyPair()
-	jwtIssuer := auth.NewJWTIssuer(privKey, "sso-bff-dev", 15*time.Minute)
-	jwtVerifier := auth.NewJWTVerifier(pubKey)
+	jwtIssuer, err := auth.NewJWTIssuer(privKey, "sso-bff-dev", 15*time.Minute)
+	if err != nil {
+		logger.Error("failed to create JWT issuer", slog.Any("error", err))
+		os.Exit(1)
+	}
+	jwtVerifier, err := auth.NewJWTVerifier(pubKey)
+	if err != nil {
+		logger.Error("failed to create JWT verifier", slog.Any("error", err))
+		os.Exit(1)
+	}
 
 	// Shared noop outbox writer for all L2+ Cells.
 	var nw outbox.Writer = noopWriter{}

--- a/src/kernel/assembly/assembly.go
+++ b/src/kernel/assembly/assembly.go
@@ -81,54 +81,7 @@ func (a *CoreAssembly) Register(c cell.Cell) error {
 //
 // ref: uber-go/fx app.go — Start 出错后自动 rollback 已启动的 Cell（LIFO Stop）。
 func (a *CoreAssembly) Start(ctx context.Context) error {
-	a.mu.Lock()
-	if a.state != stateStopped {
-		a.mu.Unlock()
-		return errcode.New(errcode.ErrValidationFailed,
-			fmt.Sprintf("assembly %q: cannot start in state %d", a.id, a.state))
-	}
-	a.state = stateStarting
-	a.mu.Unlock()
-
-	deps := cell.Dependencies{
-		Cells:     a.cellMap,
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
-	}
-
-	// Phase 1: Init all cells. If any fails, no cell has been Start'd yet.
-	for _, c := range a.cells {
-		if err := c.Init(ctx, deps); err != nil {
-			a.mu.Lock()
-			a.state = stateStopped
-			a.mu.Unlock()
-			return errcode.Wrap(errcode.ErrValidationFailed,
-				fmt.Sprintf("assembly: init cell %q", c.ID()), err)
-		}
-	}
-
-	// Phase 2: Start cells in order. On failure, rollback already-started cells.
-	for i, c := range a.cells {
-		if err := c.Start(ctx); err != nil {
-			// Rollback: stop cells [0..i-1] in reverse order.
-			for j := i - 1; j >= 0; j-- {
-				if stopErr := a.cells[j].Stop(ctx); stopErr != nil {
-					slog.Warn("rollback: failed to stop cell",
-						"cell", a.cells[j].ID(), "error", stopErr)
-				}
-			}
-			a.mu.Lock()
-			a.state = stateStopped
-			a.mu.Unlock()
-			return errcode.Wrap(errcode.ErrLifecycleInvalid,
-				fmt.Sprintf("assembly: start cell %q", c.ID()), err)
-		}
-	}
-
-	a.mu.Lock()
-	a.state = stateStarted
-	a.mu.Unlock()
-	return nil
+	return a.startInternal(ctx, nil)
 }
 
 // Stop stops every registered Cell in reverse registration order. If multiple
@@ -179,6 +132,14 @@ func (a *CoreAssembly) Health() map[string]cell.HealthStatus {
 // StartWithConfig is like Start but injects the given config map into
 // Dependencies.Config before initialising cells.
 func (a *CoreAssembly) StartWithConfig(ctx context.Context, cfgMap map[string]any) error {
+	return a.startInternal(ctx, cfgMap)
+}
+
+// startInternal is the shared implementation for Start and StartWithConfig.
+// If cfgMap is nil an empty map is used for Dependencies.Config.
+//
+// ref: uber-go/fx app.go — Start 出错后自动 rollback 已启动的 Cell（LIFO Stop）。
+func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any) error {
 	a.mu.Lock()
 	if a.state != stateStopped {
 		a.mu.Unlock()
@@ -188,12 +149,17 @@ func (a *CoreAssembly) StartWithConfig(ctx context.Context, cfgMap map[string]an
 	a.state = stateStarting
 	a.mu.Unlock()
 
+	if cfgMap == nil {
+		cfgMap = make(map[string]any)
+	}
+
 	deps := cell.Dependencies{
 		Cells:     a.cellMap,
 		Contracts: make(map[string]cell.Contract),
 		Config:    cfgMap,
 	}
 
+	// Phase 1: Init all cells. If any fails, no cell has been Start'd yet.
 	for _, c := range a.cells {
 		if err := c.Init(ctx, deps); err != nil {
 			a.mu.Lock()
@@ -204,8 +170,10 @@ func (a *CoreAssembly) StartWithConfig(ctx context.Context, cfgMap map[string]an
 		}
 	}
 
+	// Phase 2: Start cells in order. On failure, rollback already-started cells.
 	for i, c := range a.cells {
 		if err := c.Start(ctx); err != nil {
+			// Rollback: stop cells [0..i-1] in reverse order.
 			for j := i - 1; j >= 0; j-- {
 				if stopErr := a.cells[j].Stop(ctx); stopErr != nil {
 					slog.Warn("rollback: failed to stop cell",

--- a/src/kernel/assembly/doc.go
+++ b/src/kernel/assembly/doc.go
@@ -1,4 +1,4 @@
 // Package assembly provides the CoreAssembly that orchestrates Cell lifecycle
-// (register, init, start, stop, health). It resolves Cell dependency order and
-// manages graceful shutdown sequencing.
+// (register, init, start, stop, health). Cells are started in registration
+// order (FIFO) and stopped in reverse registration order (LIFO).
 package assembly

--- a/src/kernel/cell/base.go
+++ b/src/kernel/cell/base.go
@@ -62,6 +62,8 @@ func (b *BaseCell) Metadata() CellMetadata { return b.meta }
 
 // OwnedSlices returns a copy of the owned slice list.
 func (b *BaseCell) OwnedSlices() []Slice {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	out := make([]Slice, len(b.slices))
 	copy(out, b.slices)
 	return out
@@ -69,6 +71,8 @@ func (b *BaseCell) OwnedSlices() []Slice {
 
 // ProducedContracts returns a copy of the produced contract list.
 func (b *BaseCell) ProducedContracts() []Contract {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	out := make([]Contract, len(b.produced))
 	copy(out, b.produced)
 	return out
@@ -76,6 +80,8 @@ func (b *BaseCell) ProducedContracts() []Contract {
 
 // ConsumedContracts returns a copy of the consumed contract list.
 func (b *BaseCell) ConsumedContracts() []Contract {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	out := make([]Contract, len(b.consumed))
 	copy(out, b.consumed)
 	return out
@@ -162,13 +168,25 @@ func (b *BaseCell) ShutdownCtx() context.Context {
 }
 
 // AddSlice appends a Slice to this cell's owned slice list.
-func (b *BaseCell) AddSlice(s Slice) { b.slices = append(b.slices, s) }
+func (b *BaseCell) AddSlice(s Slice) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.slices = append(b.slices, s)
+}
 
 // AddProducedContract appends a Contract this cell produces.
-func (b *BaseCell) AddProducedContract(c Contract) { b.produced = append(b.produced, c) }
+func (b *BaseCell) AddProducedContract(c Contract) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.produced = append(b.produced, c)
+}
 
 // AddConsumedContract appends a Contract this cell consumes.
-func (b *BaseCell) AddConsumedContract(c Contract) { b.consumed = append(b.consumed, c) }
+func (b *BaseCell) AddConsumedContract(c Contract) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.consumed = append(b.consumed, c)
+}
 
 // ---------------------------------------------------------------------------
 // BaseSlice

--- a/src/kernel/cell/base_test.go
+++ b/src/kernel/cell/base_test.go
@@ -245,6 +245,35 @@ func TestBaseCellConcurrentHealthReady(t *testing.T) {
 	require.NoError(t, c.Stop(context.Background()))
 }
 
+func TestBaseCellConcurrentAddAndRead(t *testing.T) {
+	c := NewBaseCell(CellMetadata{ID: "race-add"})
+
+	const n = 100
+	done := make(chan struct{})
+
+	// Writer goroutine: adds slices, produced, and consumed contracts.
+	go func() {
+		defer close(done)
+		for i := 0; i < n; i++ {
+			c.AddSlice(NewBaseSlice("s", "race-add", L0))
+			c.AddProducedContract(NewBaseContract("pc", ContractHTTP, "race-add", L1))
+			c.AddConsumedContract(NewBaseContract("cc", ContractEvent, "other", L2))
+		}
+	}()
+
+	// Reader goroutine (main): reads all three lists concurrently.
+	for i := 0; i < n; i++ {
+		_ = c.OwnedSlices()
+		_ = c.ProducedContracts()
+		_ = c.ConsumedContracts()
+	}
+	<-done
+
+	assert.Len(t, c.OwnedSlices(), n)
+	assert.Len(t, c.ProducedContracts(), n)
+	assert.Len(t, c.ConsumedContracts(), n)
+}
+
 // ---------------------------------------------------------------------------
 // BaseSlice
 // ---------------------------------------------------------------------------

--- a/src/kernel/governance/rules_fmt.go
+++ b/src/kernel/governance/rules_fmt.go
@@ -329,3 +329,62 @@ func (v *Validator) validateFMT08() []ValidationResult {
 	}
 	return results
 }
+
+// validateFMT11 checks that every cell has required owner and verify fields:
+// owner.team, owner.role, and verify.smoke must be non-empty.
+// CLAUDE.md mandates: cell.yaml must have owner{team,role} and verify.smoke.
+func (v *Validator) validateFMT11() []ValidationResult {
+	var results []ValidationResult
+	for _, c := range v.project.Cells {
+		if c.Owner.Team == "" {
+			results = append(results, ValidationResult{
+				Code:      "FMT-11",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      cellFile(c.ID),
+				Field:     "owner.team",
+				Message:   fmt.Sprintf("cell %q must have owner.team", c.ID),
+			})
+		}
+		if c.Owner.Role == "" {
+			results = append(results, ValidationResult{
+				Code:      "FMT-11",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      cellFile(c.ID),
+				Field:     "owner.role",
+				Message:   fmt.Sprintf("cell %q must have owner.role", c.ID),
+			})
+		}
+		if len(c.Verify.Smoke) == 0 {
+			results = append(results, ValidationResult{
+				Code:      "FMT-11",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      cellFile(c.ID),
+				Field:     "verify.smoke",
+				Message:   fmt.Sprintf("cell %q must have at least one verify.smoke entry", c.ID),
+			})
+		}
+	}
+	return results
+}
+
+// validateFMT12 checks that every slice has at least one verify.unit entry.
+// CLAUDE.md mandates: slice.yaml must have verify.unit.
+func (v *Validator) validateFMT12() []ValidationResult {
+	var results []ValidationResult
+	for key, s := range v.project.Slices {
+		if len(s.Verify.Unit) == 0 {
+			results = append(results, ValidationResult{
+				Code:      "FMT-12",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      sliceFile(key),
+				Field:     "verify.unit",
+				Message:   fmt.Sprintf("slice %q must have at least one verify.unit entry", s.ID),
+			})
+		}
+	}
+	return results
+}

--- a/src/kernel/governance/validate.go
+++ b/src/kernel/governance/validate.go
@@ -127,6 +127,8 @@ func (v *Validator) Validate() []ValidationResult {
 	results = append(results, v.validateFMT08()...)
 	results = append(results, v.validateFMT09()...)
 	results = append(results, v.validateFMT10()...)
+	results = append(results, v.validateFMT11()...)
+	results = append(results, v.validateFMT12()...)
 
 	// Advisory rules
 	results = append(results, v.validateADV01()...)

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -2229,3 +2229,137 @@ func TestFMT10(t *testing.T) {
 		})
 	}
 }
+
+// --- FMT-11: cell.yaml required owner and verify.smoke fields ---
+
+func TestFMT11(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+		wantField string // if non-empty, first result must match this field
+	}{
+		{
+			name:      "all cells have owner.team, owner.role, verify.smoke",
+			setup:     func(_ *metadata.ProjectMeta) {},
+			wantCount: 0,
+		},
+		{
+			name: "cell missing owner.team",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Owner.Team = ""
+			},
+			wantCount: 1,
+			wantField: "owner.team",
+		},
+		{
+			name: "cell missing owner.role",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Owner.Role = ""
+			},
+			wantCount: 1,
+			wantField: "owner.role",
+		},
+		{
+			name: "cell missing verify.smoke",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Verify.Smoke = nil
+			},
+			wantCount: 1,
+			wantField: "verify.smoke",
+		},
+		{
+			name: "cell with empty verify.smoke slice",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Verify.Smoke = []string{}
+			},
+			wantCount: 1,
+			wantField: "verify.smoke",
+		},
+		{
+			name: "cell missing all three fields",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Owner.Team = ""
+				pm.Cells["access-core"].Owner.Role = ""
+				pm.Cells["access-core"].Verify.Smoke = nil
+			},
+			wantCount: 3,
+		},
+		{
+			name: "multiple cells with missing fields",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Owner.Team = ""
+				pm.Cells["audit-core"].Owner.Role = ""
+			},
+			wantCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, "")
+			got := findByCode(val.validateFMT11(), "FMT-11")
+			assert.Len(t, got, tt.wantCount)
+			for _, r := range got {
+				assert.Equal(t, SeverityError, r.Severity)
+				assert.Equal(t, IssueRequired, r.IssueType)
+			}
+			if tt.wantField != "" && len(got) > 0 {
+				assert.Equal(t, tt.wantField, got[0].Field)
+			}
+		})
+	}
+}
+
+// --- FMT-12: slice.yaml required verify.unit field ---
+
+func TestFMT12(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+	}{
+		{
+			name:      "all slices have verify.unit",
+			setup:     func(_ *metadata.ProjectMeta) {},
+			wantCount: 0,
+		},
+		{
+			name: "slice missing verify.unit (nil)",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["access-core/session-login"].Verify.Unit = nil
+			},
+			wantCount: 1,
+		},
+		{
+			name: "slice with empty verify.unit slice",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["access-core/session-login"].Verify.Unit = []string{}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "multiple slices missing verify.unit",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["access-core/session-login"].Verify.Unit = nil
+				pm.Slices["audit-core/audit-write"].Verify.Unit = nil
+			},
+			wantCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, "")
+			got := findByCode(val.validateFMT12(), "FMT-12")
+			assert.Len(t, got, tt.wantCount)
+			for _, r := range got {
+				assert.Equal(t, SeverityError, r.Severity)
+				assert.Equal(t, IssueRequired, r.IssueType)
+				assert.Equal(t, "verify.unit", r.Field)
+			}
+		})
+	}
+}

--- a/src/kernel/idempotency/idempotency.go
+++ b/src/kernel/idempotency/idempotency.go
@@ -18,4 +18,10 @@ type Checker interface {
 
 	// MarkProcessed marks the key as processed with the given TTL.
 	MarkProcessed(ctx context.Context, key string, ttl time.Duration) error
+
+	// TryProcess atomically checks whether key has been processed and marks it if not.
+	// Returns true if the caller should process (key was not previously seen).
+	// Returns false if already processed (another consumer got there first).
+	// This eliminates the TOCTOU race between separate IsProcessed + MarkProcessed calls.
+	TryProcess(ctx context.Context, key string, ttl time.Duration) (bool, error)
 }

--- a/src/kernel/idempotency/idempotency_test.go
+++ b/src/kernel/idempotency/idempotency_test.go
@@ -10,21 +10,50 @@ import (
 
 // Compile-time interface check.
 
-type mockChecker struct{}
-
-func (m *mockChecker) IsProcessed(ctx context.Context, key string) (bool, error) {
-	return false, nil
+type mockChecker struct {
+	processed map[string]bool
 }
 
-func (m *mockChecker) MarkProcessed(ctx context.Context, key string, ttl time.Duration) error {
+func newMockChecker() *mockChecker {
+	return &mockChecker{processed: make(map[string]bool)}
+}
+
+func (m *mockChecker) IsProcessed(_ context.Context, key string) (bool, error) {
+	return m.processed[key], nil
+}
+
+func (m *mockChecker) MarkProcessed(_ context.Context, key string, _ time.Duration) error {
+	m.processed[key] = true
 	return nil
+}
+
+func (m *mockChecker) TryProcess(_ context.Context, key string, _ time.Duration) (bool, error) {
+	if m.processed[key] {
+		return false, nil
+	}
+	m.processed[key] = true
+	return true, nil
 }
 
 var _ Checker = (*mockChecker)(nil)
 
 func TestCheckerInterface(t *testing.T) {
-	var c Checker = &mockChecker{}
+	var c Checker = newMockChecker()
 	ok, err := c.IsProcessed(context.Background(), "test-key")
 	assert.NoError(t, err)
 	assert.False(t, ok)
+}
+
+func TestCheckerInterface_TryProcess(t *testing.T) {
+	var c Checker = newMockChecker()
+
+	// First call should return true (caller should process).
+	shouldProcess, err := c.TryProcess(context.Background(), "test-key", DefaultTTL)
+	assert.NoError(t, err)
+	assert.True(t, shouldProcess)
+
+	// Second call should return false (already processed).
+	shouldProcess, err = c.TryProcess(context.Background(), "test-key", DefaultTTL)
+	assert.NoError(t, err)
+	assert.False(t, shouldProcess)
 }

--- a/src/kernel/journey/catalog.go
+++ b/src/kernel/journey/catalog.go
@@ -2,9 +2,11 @@
 package journey
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // Catalog provides query access to all journeys and their status.
@@ -32,6 +34,41 @@ func NewCatalog(project *metadata.ProjectMeta) *Catalog {
 		c.statusBoard[entry.JourneyID] = entry
 	}
 	return c
+}
+
+// Validate checks that every cell and contract referenced by journeys in this
+// catalog actually exists in the provided sets. It returns an error (with code
+// ErrReferenceBroken) listing all broken references, or nil if all references
+// are valid.
+//
+// cellIDs and contractIDs are the known-good identifiers from the project
+// registry. Passing nil sets is equivalent to passing empty sets.
+func (c *Catalog) Validate(cellIDs, contractIDs map[string]struct{}) error {
+	var msgs []string
+	for _, j := range c.journeys {
+		for _, cellRef := range j.Cells {
+			if _, ok := cellIDs[cellRef]; !ok {
+				msgs = append(msgs, fmt.Sprintf(
+					"journey %q references unknown cell %q", j.ID, cellRef))
+			}
+		}
+		for _, ctrRef := range j.Contracts {
+			if _, ok := contractIDs[ctrRef]; !ok {
+				msgs = append(msgs, fmt.Sprintf(
+					"journey %q references unknown contract %q", j.ID, ctrRef))
+			}
+		}
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+	// Sort for deterministic output.
+	sort.Strings(msgs)
+	combined := msgs[0]
+	for _, m := range msgs[1:] {
+		combined += "; " + m
+	}
+	return errcode.New(errcode.ErrReferenceBroken, combined)
 }
 
 // Get returns a journey by ID, or nil if not found.

--- a/src/kernel/journey/catalog_test.go
+++ b/src/kernel/journey/catalog_test.go
@@ -1,9 +1,11 @@
 package journey
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	ecErr "github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -391,5 +393,105 @@ func TestEmptyProjectMeta_NoPanic(t *testing.T) {
 		assert.Empty(t, c.CellJourneys("any"), "case %d", i)
 		assert.Empty(t, c.ContractJourneys("any"), "case %d", i)
 		assert.Empty(t, c.CrossCellJourneys(), "case %d", i)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	allCells := map[string]struct{}{
+		"access-core": {},
+		"audit-core":  {},
+		"config-core": {},
+	}
+	allContracts := map[string]struct{}{
+		"event.user.created.v1":            {},
+		"http.auth.login.v1":               {},
+		"event.session.created.v1":         {},
+		"event.audit.integrity-verified.v1": {},
+	}
+
+	tests := []struct {
+		name        string
+		project     *metadata.ProjectMeta
+		cellIDs     map[string]struct{}
+		contractIDs map[string]struct{}
+		wantErr     bool
+		wantCode    ecErr.Code
+		wantContain []string // substrings expected in error message
+	}{
+		{
+			name:        "all references valid",
+			project:     buildTestProject(),
+			cellIDs:     allCells,
+			contractIDs: allContracts,
+			wantErr:     false,
+		},
+		{
+			name:    "missing cell reference",
+			project: buildTestProject(),
+			cellIDs: map[string]struct{}{
+				"access-core": {},
+				"audit-core":  {},
+				// config-core missing
+			},
+			contractIDs: allContracts,
+			wantErr:     true,
+			wantCode:    ecErr.ErrReferenceBroken,
+			wantContain: []string{"config-core", "unknown cell"},
+		},
+		{
+			name:    "missing contract reference",
+			project: buildTestProject(),
+			cellIDs: allCells,
+			contractIDs: map[string]struct{}{
+				"event.user.created.v1":    {},
+				"http.auth.login.v1":       {},
+				"event.session.created.v1": {},
+				// event.audit.integrity-verified.v1 missing
+			},
+			wantErr:     true,
+			wantCode:    ecErr.ErrReferenceBroken,
+			wantContain: []string{"event.audit.integrity-verified.v1", "unknown contract"},
+		},
+		{
+			name:        "empty catalog validates successfully",
+			project:     nil,
+			cellIDs:     nil,
+			contractIDs: nil,
+			wantErr:     false,
+		},
+		{
+			name:        "nil sets treat all references as broken",
+			project:     buildTestProject(),
+			cellIDs:     nil,
+			contractIDs: nil,
+			wantErr:     true,
+			wantCode:    ecErr.ErrReferenceBroken,
+		},
+		{
+			name:        "empty sets treat all references as broken",
+			project:     buildTestProject(),
+			cellIDs:     map[string]struct{}{},
+			contractIDs: map[string]struct{}{},
+			wantErr:     true,
+			wantCode:    ecErr.ErrReferenceBroken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCatalog(tt.project)
+			err := c.Validate(tt.cellIDs, tt.contractIDs)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var ec *ecErr.Error
+			require.True(t, errors.As(err, &ec))
+			assert.Equal(t, tt.wantCode, ec.Code)
+			for _, sub := range tt.wantContain {
+				assert.Contains(t, err.Error(), sub)
+			}
+		})
 	}
 }

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -17,9 +17,19 @@ type Entry struct {
 	AggregateID   string
 	AggregateType string
 	EventType     string
+	Topic         string // broker routing key; falls back to EventType if empty
 	Payload       []byte
 	CreatedAt     time.Time
 	Metadata      map[string]string // optional metadata (ref: Watermill Message.Metadata)
+}
+
+// RoutingTopic returns the broker routing key for the entry.
+// If Topic is set, it is returned; otherwise EventType is used as fallback.
+func (e Entry) RoutingTopic() string {
+	if e.Topic != "" {
+		return e.Topic
+	}
+	return e.EventType
 }
 
 // Writer writes outbox entries within a transaction.

--- a/src/kernel/outbox/outbox_test.go
+++ b/src/kernel/outbox/outbox_test.go
@@ -71,3 +71,45 @@ func TestEntryFields(t *testing.T) {
 	assert.NotEmpty(t, e.Payload)
 	assert.False(t, e.CreatedAt.IsZero())
 }
+
+func TestEntry_RoutingTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		entry     Entry
+		wantTopic string
+	}{
+		{
+			name: "Topic set — returns Topic",
+			entry: Entry{
+				EventType: "order.created",
+				Topic:     "orders.v2",
+			},
+			wantTopic: "orders.v2",
+		},
+		{
+			name: "Topic empty — falls back to EventType",
+			entry: Entry{
+				EventType: "order.created",
+				Topic:     "",
+			},
+			wantTopic: "order.created",
+		},
+		{
+			name: "Topic zero value (not set) — falls back to EventType",
+			entry: Entry{
+				EventType: "session.created",
+			},
+			wantTopic: "session.created",
+		},
+		{
+			name: "Both empty — returns empty string",
+			entry: Entry{},
+			wantTopic: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantTopic, tt.entry.RoutingTopic())
+		})
+	}
+}

--- a/src/pkg/httputil/response.go
+++ b/src/pkg/httputil/response.go
@@ -15,7 +15,9 @@ import (
 func WriteJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("httputil: encode response", slog.Any("error", err))
+	}
 }
 
 // WriteError writes a structured error response in the canonical format:
@@ -24,13 +26,15 @@ func WriteJSON(w http.ResponseWriter, status int, v any) {
 func WriteError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]any{
+	if err := json.NewEncoder(w).Encode(map[string]any{
 		"error": map[string]any{
 			"code":    code,
 			"message": message,
 			"details": map[string]any{},
 		},
-	})
+	}); err != nil {
+		slog.Error("httputil: encode error response", slog.Any("error", err))
+	}
 }
 
 // WriteDomainError inspects err and writes the appropriate HTTP error response.
@@ -48,13 +52,15 @@ func WriteDomainError(w http.ResponseWriter, err error) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		if encErr := json.NewEncoder(w).Encode(map[string]any{
 			"error": map[string]any{
 				"code":    string(ecErr.Code),
 				"message": ecErr.Message,
 				"details": details,
 			},
-		})
+		}); encErr != nil {
+			slog.Error("httputil: encode domain error response", slog.Any("error", encErr))
+		}
 		return
 	}
 
@@ -90,7 +96,7 @@ func mapCodeToStatus(code errcode.Code) int {
 		return http.StatusNotFound
 	case strings.Contains(c, "VALIDATION") || strings.Contains(c, "INVALID_INPUT"):
 		return http.StatusBadRequest
-	case strings.Contains(c, "UNAUTHORIZED") || strings.Contains(c, "LOGIN_FAILED") || strings.Contains(c, "REFRESH_FAILED") || strings.Contains(c, "INVALID_TOKEN"):
+	case strings.Contains(c, "UNAUTHORIZED") || strings.Contains(c, "LOGIN_FAILED") || strings.Contains(c, "REFRESH_FAILED") || strings.Contains(c, "INVALID_TOKEN") || strings.Contains(c, "TOKEN_EXPIRED") || strings.Contains(c, "KEY_INVALID"):
 		return http.StatusUnauthorized
 	case strings.Contains(c, "FORBIDDEN"):
 		return http.StatusForbidden

--- a/src/pkg/httputil/response_test.go
+++ b/src/pkg/httputil/response_test.go
@@ -25,6 +25,8 @@ func TestMapCodeToStatus(t *testing.T) {
 		{"ERR_AUTH_INVALID_TOKEN", http.StatusUnauthorized},
 		{"ERR_AUTH_LOGIN_FAILED", http.StatusUnauthorized},
 		{"ERR_AUTH_REFRESH_FAILED", http.StatusUnauthorized},
+		{"ERR_AUTH_TOKEN_EXPIRED", http.StatusUnauthorized},
+		{"ERR_AUTH_KEY_INVALID", http.StatusUnauthorized},
 		{"ERR_AUTH_FORBIDDEN", http.StatusForbidden},
 		{"ERR_USER_LOCKED", http.StatusForbidden},
 		{"ERR_DUPLICATE_USER", http.StatusConflict},

--- a/src/runtime/auth/jwt.go
+++ b/src/runtime/auth/jwt.go
@@ -21,8 +21,12 @@ type JWTVerifier struct {
 
 // NewJWTVerifier creates a JWTVerifier that validates tokens using the given
 // RSA public key with RS256 algorithm pinning.
-func NewJWTVerifier(publicKey *rsa.PublicKey) *JWTVerifier {
-	return &JWTVerifier{publicKey: publicKey}
+// It returns an error if the public key is smaller than MinRSAKeyBits (2048).
+func NewJWTVerifier(publicKey *rsa.PublicKey) (*JWTVerifier, error) {
+	if err := validateRSAKeySize(publicKey.N.BitLen(), "public"); err != nil {
+		return nil, err
+	}
+	return &JWTVerifier{publicKey: publicKey}, nil
 }
 
 // Verify validates the token string and returns Claims on success.
@@ -36,22 +40,19 @@ func (v *JWTVerifier) Verify(_ context.Context, tokenStr string) (Claims, error)
 		return v.publicKey, nil
 	})
 	if err != nil {
-		return Claims{}, errcode.Wrap(ErrAuthUnauthorized, "token verification failed", err)
+		return Claims{}, errcode.Wrap(errcode.ErrAuthUnauthorized, "token verification failed", err)
 	}
 	if !token.Valid {
-		return Claims{}, errcode.New(ErrAuthUnauthorized, "invalid token")
+		return Claims{}, errcode.New(errcode.ErrAuthUnauthorized, "invalid token")
 	}
 
 	mapClaims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return Claims{}, errcode.New(ErrAuthUnauthorized, "invalid token claims")
+		return Claims{}, errcode.New(errcode.ErrAuthUnauthorized, "invalid token claims")
 	}
 
 	return mapClaimsToClaims(mapClaims), nil
 }
-
-// ErrAuthUnauthorized is the error code for authentication failures.
-var ErrAuthUnauthorized = errcode.Code("ERR_AUTH_UNAUTHORIZED")
 
 // JWTIssuer signs JWT tokens with RS256 using an RSA private key.
 type JWTIssuer struct {
@@ -61,12 +62,16 @@ type JWTIssuer struct {
 }
 
 // NewJWTIssuer creates a JWTIssuer.
-func NewJWTIssuer(privateKey *rsa.PrivateKey, issuer string, ttl time.Duration) *JWTIssuer {
+// It returns an error if the private key is smaller than MinRSAKeyBits (2048).
+func NewJWTIssuer(privateKey *rsa.PrivateKey, issuer string, ttl time.Duration) (*JWTIssuer, error) {
+	if err := validateRSAKeySize(privateKey.N.BitLen(), "private"); err != nil {
+		return nil, err
+	}
 	return &JWTIssuer{
 		privateKey: privateKey,
 		issuer:     issuer,
 		ttl:        ttl,
-	}
+	}, nil
 }
 
 // Issue creates a signed JWT token for the given subject and roles.

--- a/src/runtime/auth/jwt_test.go
+++ b/src/runtime/auth/jwt_test.go
@@ -23,8 +23,10 @@ func generateTestKeyPair(t *testing.T) (*rsa.PrivateKey, *rsa.PublicKey) {
 
 func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
-	issuer := NewJWTIssuer(priv, "gocell", time.Hour)
-	verifier := NewJWTVerifier(pub)
+	issuer, err := NewJWTIssuer(priv, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(pub)
+	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-1", []string{"admin", "user"}, []string{"api"})
 	require.NoError(t, err)
@@ -41,8 +43,10 @@ func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
 
 func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
-	issuer := NewJWTIssuer(priv, "gocell", -time.Hour) // already expired
-	verifier := NewJWTVerifier(pub)
+	issuer, err := NewJWTIssuer(priv, "gocell", -time.Hour) // already expired
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(pub)
+	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-1", nil, nil)
 	require.NoError(t, err)
@@ -55,7 +59,8 @@ func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
 func TestJWTVerifier_RejectsHS256(t *testing.T) {
 	// Create HS256 token and verify it is rejected by RS256 verifier.
 	_, pub := generateTestKeyPair(t)
-	verifier := NewJWTVerifier(pub)
+	verifier, err := NewJWTVerifier(pub)
+	require.NoError(t, err)
 
 	hmacToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub": "attacker",
@@ -71,7 +76,8 @@ func TestJWTVerifier_RejectsHS256(t *testing.T) {
 
 func TestJWTVerifier_RejectsAlgNone(t *testing.T) {
 	_, pub := generateTestKeyPair(t)
-	verifier := NewJWTVerifier(pub)
+	verifier, err := NewJWTVerifier(pub)
+	require.NoError(t, err)
 
 	// Create an unsigned token with alg=none.
 	noneToken := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
@@ -89,8 +95,10 @@ func TestJWTVerifier_RejectsAlgNone(t *testing.T) {
 func TestJWTVerifier_WrongKey(t *testing.T) {
 	priv1, _ := generateTestKeyPair(t)
 	_, pub2 := generateTestKeyPair(t) // different key pair
-	issuer := NewJWTIssuer(priv1, "gocell", time.Hour)
-	verifier := NewJWTVerifier(pub2)
+	issuer, err := NewJWTIssuer(priv1, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(pub2)
+	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-1", nil, nil)
 	require.NoError(t, err)
@@ -101,16 +109,19 @@ func TestJWTVerifier_WrongKey(t *testing.T) {
 
 func TestJWTVerifier_MalformedToken(t *testing.T) {
 	_, pub := generateTestKeyPair(t)
-	verifier := NewJWTVerifier(pub)
+	verifier, err := NewJWTVerifier(pub)
+	require.NoError(t, err)
 
-	_, err := verifier.Verify(context.Background(), "not.a.jwt")
+	_, err = verifier.Verify(context.Background(), "not.a.jwt")
 	require.Error(t, err)
 }
 
 func TestJWTIssuer_RoundTrip(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
-	issuer := NewJWTIssuer(priv, "test-issuer", 30*time.Minute)
-	verifier := NewJWTVerifier(pub)
+	issuer, err := NewJWTIssuer(priv, "test-issuer", 30*time.Minute)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(pub)
+	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("svc-audit", []string{"service"}, []string{"internal"})
 	require.NoError(t, err)
@@ -125,8 +136,10 @@ func TestJWTIssuer_RoundTrip(t *testing.T) {
 
 func TestJWTIssuer_NoRolesNoAudience(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
-	issuer := NewJWTIssuer(priv, "gocell", time.Hour)
-	verifier := NewJWTVerifier(pub)
+	issuer, err := NewJWTIssuer(priv, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(pub)
+	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-2", nil, nil)
 	require.NoError(t, err)
@@ -136,6 +149,28 @@ func TestJWTIssuer_NoRolesNoAudience(t *testing.T) {
 	assert.Equal(t, "user-2", claims.Subject)
 	assert.Empty(t, claims.Roles)
 	assert.Empty(t, claims.Audience)
+}
+
+func TestNewJWTVerifier_RejectsWeakKey(t *testing.T) {
+	// Generate a 1024-bit RSA key (below MinRSAKeyBits).
+	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	_, err = NewJWTVerifier(&weakKey.PublicKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
+	assert.Contains(t, err.Error(), "1024")
+}
+
+func TestNewJWTIssuer_RejectsWeakKey(t *testing.T) {
+	// Generate a 1024-bit RSA key (below MinRSAKeyBits).
+	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	_, err = NewJWTIssuer(weakKey, "gocell", time.Hour)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
+	assert.Contains(t, err.Error(), "1024")
 }
 
 func TestLoadKeysFromEnv_PKCS8(t *testing.T) {

--- a/src/runtime/auth/keys.go
+++ b/src/runtime/auth/keys.go
@@ -11,6 +11,20 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// MinRSAKeyBits is the minimum RSA key size accepted by the auth package.
+// Keys smaller than 2048 bits (e.g. 512 or 1024) are considered insecure and
+// will be rejected during parsing and verifier/issuer construction.
+const MinRSAKeyBits = 2048
+
+// validateRSAKeySize checks that the RSA key modulus is at least MinRSAKeyBits.
+func validateRSAKeySize(n int, keyKind string) error {
+	if n < MinRSAKeyBits {
+		return errcode.New(errcode.ErrAuthKeyInvalid,
+			fmt.Sprintf("RSA %s key size %d bits is below the minimum %d bits", keyKind, n, MinRSAKeyBits))
+	}
+	return nil
+}
+
 // MustGenerateTestKeyPair generates a 2048-bit RSA key pair for testing.
 // It panics on error, following the Go test helper convention (e.g., template.Must).
 // Do NOT use in production code.
@@ -79,7 +93,7 @@ func LoadKeysFromEnv() (privateKey *rsa.PrivateKey, publicKey *rsa.PublicKey, er
 func parseRSAPrivateKey(pemData []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(pemData)
 	if block == nil {
-		return nil, fmt.Errorf("no PEM block found")
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "no PEM block found in private key data")
 	}
 
 	// Try PKCS#8 first, then PKCS#1.
@@ -87,18 +101,28 @@ func parseRSAPrivateKey(pemData []byte) (*rsa.PrivateKey, error) {
 	if err == nil {
 		rsaKey, ok := key.(*rsa.PrivateKey)
 		if !ok {
-			return nil, fmt.Errorf("PKCS#8 key is not RSA")
+			return nil, errcode.New(errcode.ErrAuthKeyInvalid, "PKCS#8 key is not RSA")
+		}
+		if err := validateRSAKeySize(rsaKey.N.BitLen(), "private"); err != nil {
+			return nil, err
 		}
 		return rsaKey, nil
 	}
 
-	return x509.ParsePKCS1PrivateKey(block.Bytes)
+	rsaKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.ErrAuthKeyInvalid, "failed to parse RSA private key", err)
+	}
+	if err := validateRSAKeySize(rsaKey.N.BitLen(), "private"); err != nil {
+		return nil, err
+	}
+	return rsaKey, nil
 }
 
 func parseRSAPublicKey(pemData []byte) (*rsa.PublicKey, error) {
 	block, _ := pem.Decode(pemData)
 	if block == nil {
-		return nil, fmt.Errorf("no PEM block found")
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "no PEM block found in public key data")
 	}
 
 	// Try PKIX first, then PKCS#1.
@@ -106,10 +130,20 @@ func parseRSAPublicKey(pemData []byte) (*rsa.PublicKey, error) {
 	if err == nil {
 		rsaKey, ok := pub.(*rsa.PublicKey)
 		if !ok {
-			return nil, fmt.Errorf("PKIX key is not RSA")
+			return nil, errcode.New(errcode.ErrAuthKeyInvalid, "PKIX key is not RSA")
+		}
+		if err := validateRSAKeySize(rsaKey.N.BitLen(), "public"); err != nil {
+			return nil, err
 		}
 		return rsaKey, nil
 	}
 
-	return x509.ParsePKCS1PublicKey(block.Bytes)
+	rsaKey, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.ErrAuthKeyInvalid, "failed to parse RSA public key", err)
+	}
+	if err := validateRSAKeySize(rsaKey.N.BitLen(), "public"); err != nil {
+		return nil, err
+	}
+	return rsaKey, nil
 }

--- a/src/runtime/auth/keys_test.go
+++ b/src/runtime/auth/keys_test.go
@@ -69,6 +69,32 @@ func TestLoadKeysFromEnv_ValidKeys(t *testing.T) {
 	assert.NotNil(t, pub)
 }
 
+func TestLoadRSAKeyPairFromPEM_RejectsWeakKey(t *testing.T) {
+	// Generate a 1024-bit RSA key (below MinRSAKeyBits).
+	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	privPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(weakKey),
+	})
+	pubBytes, err := x509.MarshalPKIXPublicKey(&weakKey.PublicKey)
+	require.NoError(t, err)
+	pubPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubBytes,
+	})
+
+	// Private key parse should fail due to weak key.
+	_, _, err = LoadRSAKeyPairFromPEM(privPEM, pubPEM)
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code)
+	assert.Contains(t, ecErr.Message, "1024")
+}
+
 func generateTestKeyPairPEM(t *testing.T) (privPEM, pubPEM []byte) {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/src/runtime/config/config_test.go
+++ b/src/runtime/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -185,4 +186,60 @@ func TestConfig_SetNested_OverwriteNonMap(t *testing.T) {
 	cfg, err := Load(yamlFile, "SN")
 	require.NoError(t, err)
 	assert.Equal(t, "nested-val", cfg.Get("flat.deep"))
+}
+
+// TestConfig_ConcurrentGetAndReload verifies that concurrent Get() and Reload()
+// calls do not race. Run with -race to verify.
+func TestConfig_ConcurrentGetAndReload(t *testing.T) {
+	dir := t.TempDir()
+	yamlFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(yamlFile, []byte("key: initial\ncount: 1\n"), 0o644))
+
+	cfg, err := Load(yamlFile, "")
+	require.NoError(t, err)
+
+	c := cfg.(*config)
+
+	const readers = 10
+	const iterations = 100
+
+	var wg sync.WaitGroup
+
+	// Multiple goroutines reading concurrently.
+	for i := range readers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := range iterations {
+				_ = cfg.Get("key")
+				_ = cfg.Get("count")
+				_ = cfg.Keys()
+				if j%10 == 0 {
+					var dest map[string]any
+					_ = cfg.Scan(&dest)
+				}
+				_ = id // prevent unused variable warning
+			}
+		}(i)
+	}
+
+	// One goroutine reloading concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			// Alternate between two config versions to exercise the swap.
+			require.NoError(t, os.WriteFile(yamlFile, []byte("key: version_a\ncount: 2\n"), 0o644))
+			_ = c.Reload(yamlFile, "")
+
+			require.NoError(t, os.WriteFile(yamlFile, []byte("key: version_b\ncount: 3\n"), 0o644))
+			_ = c.Reload(yamlFile, "")
+		}
+	}()
+
+	wg.Wait()
+
+	// After all reloads, config should still be readable without error.
+	val := cfg.Get("key")
+	assert.NotNil(t, val, "key should be present after concurrent reloads")
 }

--- a/src/runtime/config/watcher.go
+++ b/src/runtime/config/watcher.go
@@ -21,6 +21,9 @@ type Watcher struct {
 	callbacks []func(WatchEvent)
 	mu        sync.Mutex
 	done      chan struct{}
+	ready     chan struct{} // closed when the event loop starts
+	closeOnce sync.Once
+	readyOnce sync.Once
 }
 
 // NewWatcher creates a Watcher for the given file path. The watcher does not
@@ -38,6 +41,7 @@ func NewWatcher(path string) (*Watcher, error) {
 		path:    path,
 		watcher: fw,
 		done:    make(chan struct{}),
+		ready:   make(chan struct{}),
 	}, nil
 }
 
@@ -65,7 +69,14 @@ func (w *Watcher) StartWithContext(ctx context.Context) {
 	go w.loop()
 }
 
+// Ready returns a channel that is closed when the event loop has started and is
+// ready to process file-system events. Useful in tests to avoid time.Sleep.
+func (w *Watcher) Ready() <-chan struct{} {
+	return w.ready
+}
+
 func (w *Watcher) loop() {
+	w.readyOnce.Do(func() { close(w.ready) })
 	for {
 		select {
 		case event, ok := <-w.watcher.Events:
@@ -101,13 +112,11 @@ func (w *Watcher) loop() {
 	}
 }
 
-// Close stops the watcher and releases resources.
+// Close stops the watcher and releases resources. It is safe to call
+// concurrently from multiple goroutines.
 func (w *Watcher) Close() error {
-	select {
-	case <-w.done:
-		// Already closed.
-	default:
+	w.closeOnce.Do(func() {
 		close(w.done)
-	}
+	})
 	return w.watcher.Close()
 }

--- a/src/runtime/config/watcher_test.go
+++ b/src/runtime/config/watcher_test.go
@@ -30,8 +30,12 @@ func TestWatcher_OnChange(t *testing.T) {
 
 	w.Start()
 
-	// Give the watcher time to start.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for the event loop to be ready instead of sleeping.
+	select {
+	case <-w.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not become ready in time")
+	}
 
 	// Modify the file.
 	require.NoError(t, os.WriteFile(file, []byte("key: val2"), 0o644))

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -10,6 +10,7 @@ package eventbus
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -134,7 +135,10 @@ func (b *InMemoryEventBus) Subscribe(ctx context.Context, topic string, handler 
 	b.mu.Unlock()
 
 	// Process messages in the current goroutine (Subscribe blocks per interface contract).
-	defer close(sub.done)
+	defer func() {
+		close(sub.done)
+		b.removeSub(topic, sub)
+	}()
 	for {
 		select {
 		case <-subCtx.Done():
@@ -194,12 +198,26 @@ func (b *InMemoryEventBus) DrainDeadLetters() []DeadLetter {
 	return dl
 }
 
+// removeSub removes a specific subscription from the topic's subscriber list.
+func (b *InMemoryEventBus) removeSub(topic string, target *subscription) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	subs := b.subs[topic]
+	for i, s := range subs {
+		if s == target {
+			b.subs[topic] = append(subs[:i], subs[i+1:]...)
+			return
+		}
+	}
+}
+
 func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, entry outbox.Entry, handler func(context.Context, outbox.Entry) error) {
 	var lastErr error
 	for attempt := range maxRetries {
 		if err := handler(ctx, entry); err != nil {
 			lastErr = err
-			delay := baseRetryDelay * (1 << attempt) // 100ms, 200ms, 400ms
+			jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
+			delay := baseRetryDelay*(1<<attempt) + jitter // e.g. 100-200ms, 200-300ms, 400-500ms
 			slog.Warn("eventbus: handler error, retrying",
 				slog.String("topic", topic),
 				slog.Int("attempt", attempt+1),

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -218,6 +218,37 @@ func TestTopicConfigChangedConstant(t *testing.T) {
 	assert.Equal(t, "event.config.changed.v1", TopicConfigChanged)
 }
 
+func TestSubscribe_CleansUpOnExit(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "cleanup.topic", func(_ context.Context, e outbox.Entry) error {
+			return nil
+		})
+	}()
+
+	// Wait for subscriber to register.
+	time.Sleep(20 * time.Millisecond)
+
+	bus.mu.RLock()
+	subsBefore := len(bus.subs["cleanup.topic"])
+	bus.mu.RUnlock()
+	assert.Equal(t, 1, subsBefore, "subscriber should be registered")
+
+	// Cancel the subscriber.
+	cancel()
+	<-done
+
+	// After exit, the subscription should be removed.
+	bus.mu.RLock()
+	subsAfter := len(bus.subs["cleanup.topic"])
+	bus.mu.RUnlock()
+	assert.Equal(t, 0, subsAfter, "subscriber should be cleaned up after exit")
+}
+
 // Verify interface compliance at compile time.
 var (
 	_ outbox.Publisher  = (*InMemoryEventBus)(nil)

--- a/src/runtime/observability/metrics/metrics.go
+++ b/src/runtime/observability/metrics/metrics.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
 // Collector records HTTP request metrics.
@@ -129,43 +131,20 @@ func (c *InMemoryCollector) Handler() http.Handler {
 }
 
 // Middleware returns an HTTP middleware that records request count and duration
-// using the provided Collector.
+// using the provided Collector. It uses httputil.StatusRecorder to capture the
+// response status code, avoiding a duplicate recorder definition.
 func Middleware(collector Collector) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			rec := &metricsRecorder{ResponseWriter: w, status: http.StatusOK}
+			rec := httputil.NewStatusRecorder(w)
 
 			next.ServeHTTP(rec, r)
 
 			duration := time.Since(start).Seconds()
-			collector.RecordRequest(r.Method, r.URL.Path, rec.status, duration)
+			collector.RecordRequest(r.Method, r.URL.Path, rec.Status, duration)
 		})
 	}
-}
-
-// metricsRecorder captures the response status code.
-type metricsRecorder struct {
-	http.ResponseWriter
-	status      int
-	wroteHeader bool
-}
-
-func (r *metricsRecorder) WriteHeader(code int) {
-	if !r.wroteHeader {
-		r.status = code
-		r.wroteHeader = true
-	}
-	r.ResponseWriter.WriteHeader(code)
-}
-
-// Write captures the default 200 status if WriteHeader hasn't been called.
-func (r *metricsRecorder) Write(b []byte) (int, error) {
-	if !r.wroteHeader {
-		r.status = http.StatusOK
-		r.wroteHeader = true
-	}
-	return r.ResponseWriter.Write(b)
 }
 
 // metricsText formats the counter as a Prometheus-like text line for

--- a/src/runtime/worker/periodic.go
+++ b/src/runtime/worker/periodic.go
@@ -3,12 +3,17 @@ package worker
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 )
+
+// Compile-time interface check.
+var _ Worker = (*PeriodicWorker)(nil)
 
 // PeriodicWorker runs a function at a fixed interval. Panics in the function
 // are isolated and logged, not propagated.
 type PeriodicWorker struct {
+	mu       sync.Mutex
 	interval time.Duration
 	fn       func(ctx context.Context)
 	done     chan struct{}
@@ -24,7 +29,14 @@ func NewPeriodicWorker(interval time.Duration, fn func(ctx context.Context)) *Pe
 }
 
 // Start runs the periodic function until ctx is cancelled or Stop is called.
+// Each call to Start creates a fresh done channel, so a PeriodicWorker can be
+// restarted after Stop.
 func (p *PeriodicWorker) Start(ctx context.Context) error {
+	p.mu.Lock()
+	p.done = make(chan struct{})
+	done := p.done
+	p.mu.Unlock()
+
 	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
 
@@ -32,7 +44,7 @@ func (p *PeriodicWorker) Start(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-p.done:
+		case <-done:
 			return nil
 		case <-ticker.C:
 			p.runSafe(ctx)
@@ -42,6 +54,8 @@ func (p *PeriodicWorker) Start(ctx context.Context) error {
 
 // Stop signals the worker to exit.
 func (p *PeriodicWorker) Stop(_ context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	select {
 	case <-p.done:
 		// Already stopped.

--- a/src/runtime/worker/worker.go
+++ b/src/runtime/worker/worker.go
@@ -42,17 +42,20 @@ func (g *WorkerGroup) Add(w Worker) {
 }
 
 // Start launches all workers concurrently. It blocks until all workers
-// return. If any worker returns an error, it is logged. The first error
-// encountered is returned.
+// return. If any worker returns a non-context error, all sibling workers are
+// cancelled via a shared context. The first error encountered is returned.
 func (g *WorkerGroup) Start(ctx context.Context) error {
 	g.mu.Lock()
 	workers := make([]Worker, len(g.workers))
 	copy(workers, g.workers)
 	g.mu.Unlock()
 
+	groupCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var (
-		wg      sync.WaitGroup
-		errOnce sync.Once
+		wg       sync.WaitGroup
+		errOnce  sync.Once
 		firstErr error
 	)
 
@@ -60,9 +63,10 @@ func (g *WorkerGroup) Start(ctx context.Context) error {
 		wg.Add(1)
 		go func(w Worker) {
 			defer wg.Done()
-			if err := w.Start(ctx); err != nil {
+			if err := w.Start(groupCtx); err != nil {
 				slog.Error("worker exited with error", slog.Any("error", err))
 				errOnce.Do(func() { firstErr = err })
+				cancel() // cancel sibling workers
 			}
 		}(w)
 	}

--- a/src/runtime/worker/worker_test.go
+++ b/src/runtime/worker/worker_test.go
@@ -201,3 +201,72 @@ func TestPeriodicWorker_Stop(t *testing.T) {
 		t.Fatal("periodic worker did not stop in time")
 	}
 }
+
+func TestPeriodicWorker_RestartAfterStop(t *testing.T) {
+	var count atomic.Int32
+	pw := NewPeriodicWorker(10*time.Millisecond, func(ctx context.Context) {
+		count.Add(1)
+	})
+
+	// First run.
+	done := make(chan error, 1)
+	go func() {
+		done <- pw.Start(context.Background())
+	}()
+
+	assert.Eventually(t, func() bool {
+		return count.Load() >= 2
+	}, time.Second, 5*time.Millisecond)
+
+	err := pw.Stop(context.Background())
+	require.NoError(t, err)
+	<-done
+
+	// Record count after first stop.
+	countAfterFirstStop := count.Load()
+
+	// Second run — should work without error.
+	done2 := make(chan error, 1)
+	go func() {
+		done2 <- pw.Start(context.Background())
+	}()
+
+	assert.Eventually(t, func() bool {
+		return count.Load() >= countAfterFirstStop+2
+	}, time.Second, 5*time.Millisecond)
+
+	err = pw.Stop(context.Background())
+	require.NoError(t, err)
+	<-done2
+}
+
+func TestWorkerGroup_CancelsSiblingsOnError(t *testing.T) {
+	g := NewWorkerGroup()
+
+	// failWorker returns an error immediately.
+	fail := newTestWorker()
+	fail.startErr = errors.New("boom")
+
+	// longWorker blocks until context is cancelled.
+	long := newTestWorker()
+
+	g.Add(long)
+	g.Add(fail)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- g.Start(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		// The group should have returned with the fail worker's error.
+		assert.Error(t, err)
+		assert.Equal(t, "boom", err.Error())
+	case <-time.After(3 * time.Second):
+		t.Fatal("WorkerGroup.Start did not return after sibling failure — sibling was not cancelled")
+	}
+}
+
+// Verify compile-time interface check (Fix #9).
+var _ Worker = (*PeriodicWorker)(nil)


### PR DESCRIPTION
## Summary

Full code review Round 1C (runtime, 5 modules) + R1H (naming audit, 3 scans) + 24 P1 fixes across 2 waves.

**Review reports (8 files):**
- R1C-1: runtime/auth — 3 P1, RS256 pinning confirmed correct
- R1C-2: runtime/eventbus+worker — 5 P1 (Subscribe leak, WorkerGroup cancel, etc.)
- R1C-3: runtime/config+shutdown — 3 P1 (Watcher double-close, concurrent test, Sleep)
- R1C-4: runtime/http — 5 P1 (RealIP CIDR, no CORS, statusRecorder, auth/rate unwired)
- R1C-5: runtime/observability+bootstrap — 4 P1 (CC=57, tracing unwired, metrics dup)
- R1H-1: YAML naming — zero violations (57 files)
- R1H-2: Go naming lower layers — 1 P2 (boundary.yaml.tpl assemblyId)
- R1H-3: Go naming upper layers — 2 P1 (query snake_case, 16 slice dual-directories)

**24 P1 fixes in 2 waves (41 files changed):**

Wave 1 (21 fixes, no Wavefront):
- pkg/httputil: mapCodeToStatus + json.Encode error handling
- kernel/cell: mutex protection for Add*/read accessors
- kernel/governance: FMT-11/FMT-12 required field validation
- kernel/assembly: Start/StartWithConfig dedup + journey Validate + doc.go
- runtime/auth: remove dup errcode + errcode.Wrap + RSA min 2048-bit
- runtime/eventbus+worker: Subscribe cleanup + cancel siblings + restart + jitter
- runtime/config: sync.Once + concurrent test + ready signal + metrics dedup

Wave 2 (3 fixes, 1 Wavefront):
- kernel/idempotency: atomic TryProcess → redis SetNX + rabbitmq ConsumerBase
- kernel/outbox: Topic field + RoutingTopic() fallback
- cells/audit-core: query param camelCase

**CI hardening:** GitHub Actions pinned to commit SHA + go-version 1.22→1.25

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all packages, 0 failures)
- [x] `go test -race ./kernel/... ./runtime/...` passes
- [x] Wavefront: auth NewJWTIssuer/NewJWTVerifier error return propagated to all callers
- [x] Wavefront: idempotency TryProcess propagated to redis/rabbitmq + test assertions updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)