### PR TITLE
review: R1D-3 rabbitmq six-role review — 3 P0 fixes + errors.As

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,22 @@ jobs:
       - name: Kernel coverage gate
         run: |
           go test -cover ./kernel/... 2>&1 | tee /tmp/kernel-cov.txt
-          awk '/coverage:/ {
-            split($NF, a, "%");
-            if (a[1]+0 < 90) {
-              print "FAIL: " $1 " coverage " $NF " < 90%";
-              exit 1
+          awk '
+            /coverage: \[no statements\]/ { next }
+            /coverage:/ {
+              cov = $0
+              sub(/^.*coverage: /, "", cov)
+              sub(/% of statements.*$/, "", cov)
+              if (cov == $0) {
+                print "FAIL: could not parse coverage line: " $0;
+                exit 1
+              }
+              if (cov + 0 < 90) {
+                print "FAIL: " $2 " coverage " cov "% < 90%";
+                exit 1
+              }
             }
-          }' /tmp/kernel-cov.txt
+          ' /tmp/kernel-cov.txt
           echo "PASS: kernel coverage >= 90%"
 
   integration-test:

--- a/docs/reviews/202604060830-R0/R1D-3-rabbitmq-architect.md
+++ b/docs/reviews/202604060830-R0/R1D-3-rabbitmq-architect.md
@@ -1,0 +1,519 @@
+# R1D-3: adapters/rabbitmq Architect Review
+
+**Reviewer**: Architect  
+**Date**: 2026-04-06  
+**Scope**: `src/adapters/rabbitmq/` -- 7 files (~950 LOC prod, ~1080 LOC test)  
+**Files**: connection.go (380L), publisher.go (81L), subscriber.go (257L), consumer_base.go (224L), doc.go (8L), rabbitmq_test.go (1081L), integration_test.go (267L)
+
+---
+
+## 1. Executive Summary
+
+The RabbitMQ adapter is a well-structured implementation of `outbox.Publisher` and `outbox.Subscriber` with reconnect, channel pooling, ConsumerBase (idempotency + retry + DLQ), and comprehensive tests. Dependency direction is fully compliant. The TryProcess TOCTOU fix (Issue #18) is correctly implemented. However, the review surfaces **3 P0 findings** (DLQ-publish-then-ACK violation, reconnect subscriber invalidation, PermanentError detection fragility), **4 P1 findings**, and **3 P2 findings**.
+
+| Severity | Count | Key Issue |
+|----------|-------|-----------|
+| P0 | 3 | DLQ publish failure silently ACKs, Subscriber channel invalidation on reconnect, PermanentError type assertion bypass |
+| P1 | 4 | sanitizeURL credential leak, no TLS support, serial processDelivery, confirm mode per-publish overhead |
+| P2 | 3 | No MessageId on published messages, no metrics/tracing hooks, ConsumerBase retry blocks Subscriber goroutine |
+
+---
+
+## 2. Dependency Compliance (GREEN)
+
+### Import analysis (all 5 production files)
+
+| File | Imports from gocell | Verdict |
+|------|---------------------|---------|
+| connection.go | `pkg/errcode` | GREEN |
+| publisher.go | `kernel/outbox`, `pkg/errcode` | GREEN |
+| subscriber.go | `kernel/outbox`, `pkg/errcode` | GREEN |
+| consumer_base.go | `kernel/idempotency`, `kernel/outbox` | GREEN |
+| doc.go | (none) | GREEN |
+
+**Verified absence**: Zero imports of `runtime/`, `cells/`, or other `adapters/` packages in any production file. Confirmed by running:
+
+```
+grep -r "runtime/\|cells/\|adapters/" src/adapters/rabbitmq/*.go
+# (no matches in non-test files)
+```
+
+**Dependency direction**: adapters/rabbitmq --> kernel/outbox, kernel/idempotency, pkg/errcode. This is the correct direction (adapters implement kernel-defined interfaces). The only external dependency is `github.com/rabbitmq/amqp091-go`.
+
+**Verdict**: Fully compliant with the layering constraint "adapters/ implements kernel/ or runtime/ defined interfaces".
+
+---
+
+## 3. Interface Implementation Compliance
+
+### 3.1 outbox.Publisher
+
+**Compile-time check**: `src/adapters/rabbitmq/publisher.go:15`
+```go
+var _ outbox.Publisher = (*Publisher)(nil)
+```
+
+**Kernel interface** (`src/kernel/outbox/outbox.go:53-55`):
+```go
+type Publisher interface {
+    Publish(ctx context.Context, topic string, payload []byte) error
+}
+```
+
+**Implementation**: `Publisher.Publish` at publisher.go:31-80 -- correct signature, correct semantics. Uses publisher confirm mode for delivery guarantees. PASS.
+
+### 3.2 outbox.Subscriber
+
+**Compile-time check**: `src/adapters/rabbitmq/subscriber.go:19`
+```go
+var _ outbox.Subscriber = (*Subscriber)(nil)
+```
+
+**Kernel interface** (`src/kernel/outbox/outbox.go:63-74`):
+```go
+type Subscriber interface {
+    Subscribe(ctx context.Context, topic string, handler func(context.Context, Entry) error) error
+    Close() error
+}
+```
+
+**Implementation**: `Subscriber.Subscribe` at subscriber.go:80-133, `Subscriber.Close` at subscriber.go:221-256 -- correct signatures, correct semantics. PASS.
+
+### 3.3 idempotency.Checker (consumed, not implemented)
+
+ConsumerBase consumes `idempotency.Checker` via dependency injection (consumer_base.go:73-76). The adapter does **not** implement `Checker` -- that is the responsibility of `adapters/redis`. This is architecturally correct: each adapter implements one kernel interface, avoiding cross-adapter coupling.
+
+---
+
+## 4. P0 Findings
+
+### P0-F1: DLQ publish failure silently ACKs original message [Issue #26 CONFIRMED]
+
+**Dimension**: [Consistency Level] -- L2 OutboxFact data loss
+
+**Location**: `src/adapters/rabbitmq/consumer_base.go:170-173`
+```go
+// Exhausted all retries -- route to DLQ.
+cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount)
+// Return nil to ACK the original message (it's been DLQ'd).
+return nil
+```
+
+And in `deadLetter()` at consumer_base.go:205-213:
+```go
+if err := cb.publisher.Publish(ctx, dlqTopic, payload); err != nil {
+    slog.Error("rabbitmq: failed to publish to DLQ",
+        slog.String("event_id", entry.ID),
+        // ...
+    )
+    return  // <-- SILENT RETURN, no error propagated
+}
+```
+
+**Problem**: When `deadLetter()` fails to publish to the DLQ (broker down, DLQ exchange not declared, network error), the method returns without error. The caller (the `Wrap` closure) then returns `nil`, which tells the `Subscriber` to ACK the original message. The message is permanently lost -- neither processed, nor in the DLQ, nor requeued.
+
+**Impact**: HIGH. This violates L2 (OutboxFact) consistency guarantees. Any transient DLQ publish failure causes silent data loss.
+
+**Fix**: `deadLetter()` must return an error. When DLQ publish fails, the `Wrap` closure must return the error (triggering NACK+requeue in Subscriber) rather than ACK. Proposed change:
+
+```go
+func (cb *ConsumerBase) deadLetter(...) error {
+    // ... marshal + publish ...
+    if err := cb.publisher.Publish(ctx, dlqTopic, payload); err != nil {
+        return fmt.Errorf("dead letter publish to %s: %w", dlqTopic, err)
+    }
+    return nil
+}
+
+// In Wrap():
+if err := cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount); err != nil {
+    return err  // NACK+requeue, preserving the message
+}
+return nil  // ACK only after successful DLQ publish
+```
+
+**Same pattern applies to the PermanentError DLQ path** at consumer_base.go:141:
+```go
+cb.deadLetter(ctx, topic, entry, lastErr, attempt+1)
+return nil // Return nil to ACK the original message.
+```
+
+Both call sites must propagate DLQ publish failure.
+
+---
+
+### P0-F2: Subscriber channel invalidation on reconnect [Issue #25 CONFIRMED]
+
+**Dimension**: [Cell Aggregation / Reconnect Strategy] -- silent consumer death
+
+**Location**: `src/adapters/rabbitmq/connection.go:213` and `subscriber.go:91-132`
+
+**Problem**: When the AMQP connection drops and `reconnectLoop()` runs:
+
+1. `drainChannelPool()` closes all pooled channels (connection.go:213)
+2. A new connection is established (connection.go:220-224)
+
+However, `Subscriber.Subscribe()` holds a **dedicated channel** (subscriber.go:91) that is NOT in the channel pool. It was acquired at subscribe-time and stored in `s.channels` (subscriber.go:96-97). When the underlying AMQP connection is severed:
+
+- The dedicated channel becomes invalid
+- The `deliveries` channel returned by `ch.Consume()` (subscriber.go:121) will be closed by the AMQP library
+- The `consumeLoop` detects this at subscriber.go:155-159 and returns `ErrAdapterAMQPConsume`
+- **But the subscriber does not automatically re-subscribe**. It exits permanently.
+
+The reconnect loop restores the *connection*, but all active subscriptions are dead. The caller receives an error from `Subscribe()` and must manually re-invoke `Subscribe()` -- but there is no mechanism or documentation for this.
+
+**Evidence**: `reconnectLoop()` at connection.go:187-226 only drains the channel pool and re-establishes the connection. It has no callback mechanism to notify subscribers that they need to re-acquire channels and re-consume.
+
+**Impact**: HIGH. After any network blip, all consumers silently stop receiving messages. In production with transient network issues, this leads to complete message processing stall.
+
+**Fix options** (architectural decision required):
+
+1. **Subscriber-level reconnect loop**: Subscriber wraps `consumeLoop` in a retry loop that re-acquires a channel and re-subscribes after channel closure. This is the Watermill pattern.
+2. **Connection notification callback**: Connection exposes a `OnReconnect(func())` hook that Subscriber registers to re-setup its channel.
+3. **Document-and-delegate**: Document that callers must re-invoke Subscribe in a loop. (Least desirable -- pushes complexity to every consumer.)
+
+Recommendation: Option 1 is the most robust and aligns with the Watermill reference architecture.
+
+---
+
+### P0-F3: PermanentError detection via direct type assertion bypasses wrapping
+
+**Dimension**: [Interface Stability] -- API contract fragility
+
+**Location**: `src/adapters/rabbitmq/consumer_base.go:134`
+```go
+if _, ok := lastErr.(*PermanentError); ok {
+```
+
+**Problem**: This uses a direct type assertion (`*PermanentError`) instead of `errors.As()`. If a handler wraps a `PermanentError` with `fmt.Errorf("context: %w", NewPermanentError(err))`, the type assertion fails, and the error is treated as transient -- retried up to `RetryCount` times before going to DLQ anyway.
+
+This is a correctness issue because:
+1. The `PermanentError` type implements `Unwrap()` (consumer_base.go:57-59), signaling intent to participate in error chains
+2. Go error handling best practices require `errors.As()` for type-switched errors
+3. Any middleware or handler that wraps errors (which is standard per the project's error-handling.md rule "errors must wrap context") will bypass the permanent error detection
+
+**Evidence**: `PermanentError` has `Unwrap() error` at consumer_base.go:57, but the detection at line 134 does not use the unwrap chain.
+
+**Impact**: HIGH. Any handler following the project's own error wrapping convention (`fmt.Errorf("enrollment: %w", err)`) will cause PermanentErrors to be retried instead of immediately routed to DLQ, wasting retry budget and delaying dead-lettering.
+
+**Fix**:
+```go
+var permErr *PermanentError
+if errors.As(lastErr, &permErr) {
+```
+
+---
+
+## 5. P1 Findings
+
+### P1-F1: sanitizeURL leaks AMQP credentials [Prior P0-F12S01]
+
+**Dimension**: [Interface Stability / Security]
+
+**Location**: `src/adapters/rabbitmq/connection.go:372-379`
+```go
+func sanitizeURL(url string) string {
+    if len(url) > 10 {
+        return url[:10] + "***"
+    }
+    return "***"
+}
+```
+
+**Problem**: For a typical AMQP URL `amqp://user:password@host:5672/`, the first 10 characters are `amqp://use` which leaks the username prefix. For URLs with short usernames (e.g., `amqp://a:secret@host`), it leaks `amqp://a:s` -- the start of the password.
+
+**Recommendation**: Use `net/url.Parse` to properly redact credentials:
+```go
+func sanitizeURL(rawURL string) string {
+    u, err := url.Parse(rawURL)
+    if err != nil {
+        return "***"
+    }
+    u.User = url.UserPassword("***", "***")
+    return u.String()
+}
+```
+
+**Impact**: Medium. Credentials in slog output may reach log aggregation systems.
+
+---
+
+### P1-F2: No TLS configuration support [Prior P1-M5]
+
+**Dimension**: [Extensibility]
+
+**Location**: `src/adapters/rabbitmq/connection.go:25-44` (Config struct) and `connection.go:110-116` (DefaultDial)
+
+**Problem**: `Config` has no `TLSConfig *tls.Config` field. `DefaultDial` uses `amqp.Dial` which does not support TLS. Production RabbitMQ deployments almost universally require TLS (`amqps://`). The `amqp091-go` library provides `amqp.DialTLS(url, tlsConfig)` for this purpose.
+
+**Recommendation**: Add optional `TLSConfig *tls.Config` to `Config`. In `DefaultDial`, check if TLSConfig is non-nil and use `amqp.DialTLS` accordingly. This is a backward-compatible, additive change.
+
+**Impact**: Medium. Blocks production deployment without TLS.
+
+---
+
+### P1-F3: processDelivery is synchronous, PrefetchCount is underutilized [Prior P1-M7]
+
+**Dimension**: [Performance / Scalability]
+
+**Location**: `src/adapters/rabbitmq/subscriber.go:161-162`
+```go
+s.wg.Add(1)
+s.processDelivery(ctx, ch, delivery, topic, handler)
+```
+
+**Problem**: `processDelivery` is called synchronously in the `consumeLoop` select. Despite setting `Qos(prefetchCount, ...)`, only one message is processed at a time because the loop blocks on each delivery. The prefetch buffer fills up at the broker, but the consumer cannot process them concurrently.
+
+**Recommendation**: Change to `go s.processDelivery(...)` to enable concurrent processing up to `PrefetchCount`. The `sync.WaitGroup` already tracks in-flight messages for graceful shutdown.
+
+**Caveat**: If made concurrent, the `ch.Ack`/`ch.Nack` calls in `processDelivery` need to be thread-safe. The AMQP library's channel operations are NOT concurrency-safe. Two options:
+1. Use a dedicated channel per goroutine (expensive)
+2. Serialize ACK/NACK through a channel or mutex
+
+This is a design decision that should be made carefully. Track as P1, not P0, because the current serial approach is correct, just suboptimal.
+
+**Impact**: Medium. Throughput limited to 1 message at a time per subscription.
+
+---
+
+### P1-F4: Publisher enables confirm mode on every publish call
+
+**Dimension**: [Performance]
+
+**Location**: `src/adapters/rabbitmq/publisher.go:43-46`
+```go
+// Enable confirm mode.
+if err := ch.Confirm(false); err != nil {
+    return errcode.Wrap(ErrAdapterAMQPPublish, "rabbitmq: enable confirm mode", err)
+}
+```
+
+**Problem**: `ch.Confirm(false)` is called on every `Publish` invocation. AMQP confirm mode is a per-channel setting -- once enabled, it persists for the channel's lifetime. Re-enabling it on every publish is redundant and adds a round-trip to the broker.
+
+Furthermore, since `AcquireChannel` may return a channel from the pool that already has confirm mode enabled, the redundant `Confirm` call is a no-op but still incurs network overhead.
+
+**Recommendation**: Enable confirm mode once when the channel is created (in `AcquireChannel` or via a confirm-aware channel wrapper), not on every publish.
+
+**Impact**: Medium. Adds one unnecessary AMQP round-trip per publish.
+
+---
+
+## 6. P2 Findings
+
+### P2-F1: Published messages lack AMQP MessageId [Prior P1-M6]
+
+**Dimension**: [Observability / Traceability]
+
+**Location**: `src/adapters/rabbitmq/publisher.go:50-55`
+```go
+msg := amqp.Publishing{
+    ContentType:  "application/octet-stream",
+    DeliveryMode: amqp.Persistent,
+    Timestamp:    time.Now().UTC(),
+    Body:         payload,
+}
+```
+
+**Problem**: The `amqp.Publishing` does not set `MessageId`. Without a MessageId, broker-level tracing (RabbitMQ Management UI, Firehose, Shovel) cannot correlate messages. The outbox `Entry.ID` is the natural candidate for `MessageId`.
+
+**Recommendation**: The publisher receives raw `[]byte` payload (not an `Entry`), so it cannot extract `Entry.ID` without unmarshalling. Two options:
+1. Add an optional `MessageId string` parameter to `Publish` (breaking interface change -- avoid)
+2. Set `MessageId` to a UUID generated per-publish (provides broker traceability but not domain correlation)
+3. Accept the Entry.ID as a header via the AMQP `Headers` table (best option: relay can set `x-event-id` header)
+
+**Impact**: Low. Mainly affects debugging and monitoring.
+
+---
+
+### P2-F2: No metrics or tracing hooks [Prior P1-M4]
+
+**Dimension**: [Observability]
+
+**Location**: All files.
+
+**Problem**: DLQ routing, publish confirmations, reconnect events, and consumer processing are all logged via `slog` but have no metrics counters or OpenTelemetry span integration. The observability spec (`.claude/rules/gocell/observability.md`) and the `runtime/observability` package exist, but the adapter does not integrate with them.
+
+Key metrics missing:
+- `rabbitmq_messages_published_total` (with topic label)
+- `rabbitmq_messages_consumed_total` (with topic, status=ack/nack/dlq labels)
+- `rabbitmq_dlq_routed_total` (with topic, consumer_group labels)
+- `rabbitmq_reconnect_total`
+- `rabbitmq_publish_confirm_latency_seconds`
+
+**Impact**: Low. The adapter functions correctly; observability is a production-readiness concern.
+
+---
+
+### P2-F3: ConsumerBase retry blocks the Subscriber goroutine
+
+**Dimension**: [Performance]
+
+**Location**: `src/adapters/rabbitmq/consumer_base.go:155-159`
+```go
+select {
+case <-time.After(delay):
+case <-ctx.Done():
+    return ctx.Err()
+}
+```
+
+**Problem**: The `Wrap` closure performs retry with backoff using `time.After` delays. Since `processDelivery` calls the handler synchronously (see P1-F3), the retry backoff blocks the entire consume loop. If `RetryCount=3` and `RetryBaseDelay=1s`, a failing message blocks all other messages on that subscription for up to 1s + 2s + 4s = 7 seconds.
+
+**Impact**: Low (given P1-F3 serial processing, this is a secondary concern). If P1-F3 is fixed to enable concurrent processing, this becomes moot per message but still wastes a goroutine during backoff.
+
+---
+
+## 7. TryProcess / Issue #18 Verification
+
+The TOCTOU fix is correctly implemented. Evidence:
+
+**consumer_base.go:107**:
+```go
+shouldProcess, err := cb.checker.TryProcess(ctx, idempotencyKey, cb.config.IdempotencyTTL)
+```
+
+This replaces the old two-step `IsProcessed` + `MarkProcessed` pattern with a single atomic call. The `TryProcess` method was added to the `idempotency.Checker` interface (`src/kernel/idempotency/idempotency.go:23-27`) and the mock implementation in tests correctly simulates atomic check-and-mark semantics (`rabbitmq_test.go:239-250`).
+
+**Architect verdict**: Issue #18 fix is **ACCEPTED**. The atomic TryProcess eliminates the TOCTOU race. The fail-open behavior (line 113: `shouldProcess = true` when TryProcess errors) is a reasonable design choice for availability, with appropriate warning-level logging.
+
+---
+
+## 8. Publisher/Subscriber Decoupling Assessment
+
+**Can Publisher and Subscriber be used independently?** YES.
+
+- `Publisher` depends only on `*Connection` (publisher.go:18-20)
+- `Subscriber` depends only on `*Connection` (subscriber.go:49-50)
+- `ConsumerBase` depends on `idempotency.Checker` and `outbox.Publisher` (consumer_base.go:73-76) -- it does NOT depend on `Subscriber`
+- `Connection` is shared infrastructure but does not force publisher or subscriber creation
+
+A caller can create `NewConnection(...)` + `NewPublisher(conn)` without ever creating a Subscriber, and vice versa. This is correct for the adapter pattern -- producers and consumers may live in different assemblies.
+
+**ConsumerBase** is also independently usable. It wraps any `func(context.Context, outbox.Entry) error` handler and can be combined with any `outbox.Subscriber` implementation, not just the RabbitMQ one. This is good design.
+
+---
+
+## 9. DLQ Architecture Assessment
+
+### Routing Strategy
+
+DLQ topic defaults to `{topic}.dlq` (consumer_base.go:181-183), configurable via `ConsumerBaseConfig.DLQTopic`. Messages are enriched with `x-death-*` metadata (consumer_base.go:190-194):
+- `x-death-reason`: original error message
+- `x-death-topic`: source topic
+- `x-death-consumer-group`: consumer group identifier
+- `x-death-retry-count`: number of attempts
+- `x-death-time`: ISO 8601 timestamp
+
+This metadata is sufficient for manual inspection and automated reprocessing.
+
+### Reflow Mechanism
+
+**No reflow mechanism exists.** There is no DLQ consumer, no replay tool, and no API to move messages from DLQ back to the source topic. This is acceptable for v1.0 -- DLQ reflow is typically an operational tool, not a framework feature. However, it should be tracked as a post-v1.0 item.
+
+### DLQ Exchange Declaration
+
+The DLQ topic exchange is declared implicitly by `Publisher.Publish` (publisher.go:39) when `deadLetter()` calls `publisher.Publish(ctx, dlqTopic, payload)`. This means the DLQ exchange is created on first failure, which is correct for the fanout exchange pattern used here. A DLQ subscriber must bind to this exchange to receive dead-lettered messages.
+
+---
+
+## 10. Reconnect Strategy Assessment
+
+### Connection Level
+
+The reconnect loop (connection.go:187-226) is well-designed:
+- Exponential backoff with configurable base delay and max cap (connection.go:262-268)
+- Graceful shutdown via `closeCh` (connection.go:232-234)
+- Channel pool drain on disconnect (connection.go:213)
+- `WaitConnected()` for callers to block until reconnection (connection.go:358-369)
+- `connected` channel re-creation for reconnect signaling (connection.go:216-218, 222-224)
+
+### Channel Pool Recovery
+
+The channel pool is drained on disconnect (connection.go:213 calls `drainChannelPool()`). After reconnection, `AcquireChannel()` creates fresh channels from the new connection. This is correct -- pooled channels from the old connection would be invalid.
+
+### Subscriber Recovery (P0-F2)
+
+As detailed in P0-F2, subscriber-held channels are NOT recovered. This is the primary gap in the reconnect strategy.
+
+---
+
+## 11. Architectural Recommendations Summary
+
+```
+1. [Consistency Level] P0-F1: deadLetter must return error; Wrap must propagate DLQ
+   publish failure as NACK+requeue -- Reason: Silent data loss on DLQ failure
+   violates L2 OutboxFact guarantees -- Impact: HIGH
+
+2. [Reconnect Strategy] P0-F2: Subscriber must implement reconnect-aware consume
+   loop that re-acquires channel and re-subscribes after connection loss
+   -- Reason: All consumers silently die after any network disruption
+   -- Impact: HIGH
+
+3. [Interface Stability] P0-F3: Replace direct type assertion `lastErr.(*PermanentError)`
+   with `errors.As(lastErr, &permErr)` -- Reason: Wrapped PermanentErrors bypass
+   DLQ routing, violating the documented API contract -- Impact: HIGH
+
+4. [Security] P1-F1: Replace fixed-offset sanitizeURL with net/url.Parse credential
+   redaction -- Reason: Current implementation leaks username and potentially
+   password prefix to log aggregation -- Impact: MEDIUM
+
+5. [Extensibility] P1-F2: Add optional TLSConfig to Config struct
+   -- Reason: Production RabbitMQ requires TLS; current adapter cannot connect
+   to amqps:// endpoints -- Impact: MEDIUM
+
+6. [Performance] P1-F3: Consider async processDelivery with channel-safe ACK/NACK
+   -- Reason: Serial processing underutilizes PrefetchCount, limiting throughput
+   -- Impact: MEDIUM
+
+7. [Performance] P1-F4: Move confirm mode enablement from per-publish to
+   per-channel-creation -- Reason: Redundant broker round-trip on every publish
+   -- Impact: MEDIUM
+
+8. [Observability] P2-F1: Set AMQP MessageId on published messages
+   -- Reason: Enables broker-level tracing and correlation -- Impact: LOW
+
+9. [Observability] P2-F2: Add metrics counters for publish/consume/DLQ/reconnect
+   -- Reason: Production observability requirement -- Impact: LOW
+
+10. [Performance] P2-F3: ConsumerBase retry backoff blocks consume loop
+    -- Reason: Failing messages stall all other messages on the subscription
+    -- Impact: LOW
+```
+
+---
+
+## 12. Architectural Verdict on Prior Findings
+
+| Finding ID | Original Severity | Verdict | Rationale |
+|-----------|-------------------|---------|-----------|
+| Issue #18 (TOCTOU) | P0 | **ACCEPTED as RESOLVED** | TryProcess atomic method correctly eliminates the race |
+| Issue #25 (reconnect subscriber) | P0 | **ACCEPTED as P0** | Subscribers do not recover after reconnect; confirmed in code |
+| Issue #26 (DLQ publish + ACK) | P0 | **ACCEPTED as P0** | deadLetter() silently swallows publish errors; confirmed in code |
+| P0-F12S01 (sanitizeURL) | P0 | **DOWNGRADED to P1** | Credential leak is real but limited (10-char prefix in structured logs); net/url.Parse fix is straightforward |
+| P0-F12D01 (ctx cancel requeue) | P0 | **DOWNGRADED to P1** | ctx cancellation returning error -> NACK+requeue is by-design in the Subscriber (transient). The ConsumerBase Wrap handles ctx.Done by returning ctx.Err() which triggers NACK+requeue -- appropriate for graceful shutdown. Not a data loss vector. |
+| P1-M7 (serial processDelivery) | P1 | **ACCEPTED as P1** | Correct behavior but suboptimal performance |
+| P1-M5 (no TLS) | P1 | **ACCEPTED as P1** | Blocks production deployment |
+| P1-M6 (no MessageId) | P1 | **DOWNGRADED to P2** | Observability nicety, not a correctness issue |
+| P1-L8 (reconnect test coverage) | P1 | **ACCEPTED as P1** | reconnectLoop/reconnectWithBackoff have zero unit test coverage |
+| P1-L9 (concurrent consume coverage) | P1 | **ACCEPTED as P1** | No concurrent consumer tests exist |
+
+---
+
+## 13. Dependency Compliance Matrix
+
+| Package | stdlib | pkg/ | kernel/ | runtime/ | adapters/ | cells/ | Verdict |
+|---------|--------|------|---------|----------|-----------|--------|---------|
+| adapters/rabbitmq | context, encoding/json, fmt, log/slog, math, sync, sync/atomic, time | errcode | outbox, idempotency | -- | -- | -- | **GREEN** |
+
+---
+
+## 14. Dimension Scores
+
+| Dimension | Score | Evidence |
+|-----------|-------|----------|
+| Layer compliance | **GREEN** | Only depends on kernel/ + pkg/ + stdlib + amqp091-go |
+| Cell aggregation boundary | **GREEN** | Adapter is self-contained; no cross-adapter coupling |
+| Interface stability | **YELLOW** | PermanentError type assertion (P0-F3) bypasses error chain; Publisher interface adequate |
+| Consistency level | **RED** | DLQ publish failure silently ACKs (P0-F1); subscriber death on reconnect (P0-F2) |
+| Performance / scalability | **YELLOW** | Serial processDelivery (P1-F3); per-publish confirm mode (P1-F4) |
+| Dependency direction | **GREEN** | No reverse dependencies confirmed |

--- a/docs/reviews/202604060830-R0/R1D-3-rabbitmq-codestyle.md
+++ b/docs/reviews/202604060830-R0/R1D-3-rabbitmq-codestyle.md
@@ -1,0 +1,202 @@
+# R1D-3 RabbitMQ Adapter Code Style Review
+
+| Field | Value |
+|---|---|
+| Reviewer Seat | S5 DX/Maintainability |
+| Scope | `src/adapters/rabbitmq/*.go` (7 files: doc.go, connection.go, publisher.go, subscriber.go, consumer_base.go, rabbitmq_test.go, integration_test.go) |
+| Review Basis Commit | `ce03ba1` (develop HEAD) |
+| Date | 2026-04-06 |
+
+---
+
+## Summary
+
+The rabbitmq adapter is a well-structured implementation of `outbox.Publisher` / `outbox.Subscriber` with auto-reconnect, channel pooling, publisher confirms, and a `ConsumerBase` providing idempotency + retry + DLQ. Overall code quality is high: errcode is used consistently for production code, slog is used with structured fields throughout, and the Watermill `ref:` tag is present in both doc.go and subscriber.go. Six findings identified below, with one P1.
+
+---
+
+## Findings
+
+### F-01 | P1 | errcode | consumer_base.go:134 | PermanentError check uses direct type assertion instead of errors.As
+
+**Evidence:**
+
+```go
+// consumer_base.go:134
+if _, ok := lastErr.(*PermanentError); ok {
+```
+
+**Problem:** The check uses a direct type assertion `lastErr.(*PermanentError)`. If a caller wraps a `PermanentError` inside another error (e.g., `fmt.Errorf("handler: %w", NewPermanentError(err))`), the type assertion will fail and the permanent error will be retried instead of routed to DLQ. The Go idiomatic approach is `errors.As`.
+
+**Fix:**
+
+```go
+var permErr *PermanentError
+if errors.As(lastErr, &permErr) {
+```
+
+This requires adding `"errors"` to the import block. Since `ConsumerBase` is a framework-level building block used by all consumers, this incorrect unwrapping behavior will silently cause wrapped permanent errors to exhaust retries and reach DLQ via the retry-exhaustion path instead of the immediate-DLQ path, leading to unnecessary retry delays and misleading log messages.
+
+**Status:** OPEN
+
+---
+
+### F-02 | P2 | slog-level | consumer_base.go:216 | DLQ success routing logged at Error level
+
+**Evidence:**
+
+```go
+// consumer_base.go:216
+slog.Error("rabbitmq: message routed to dead letter queue",
+    slog.String("event_id", entry.ID),
+    ...
+```
+
+**Problem:** After the DLQ publish succeeds (line 205 returned nil), the "message routed to dead letter queue" log at line 216 uses `slog.Error`. Per the observability spec, Error is for events "affecting correctness" (DB write failures, ACK failures). A successful DLQ routing is a degraded-but-expected code path -- it should be `slog.Warn`. The `slog.Error` at lines 198 and 206 (marshal failure / publish failure) are correct since those represent actual failures.
+
+**Fix:** Change `slog.Error` to `slog.Warn` on line 216.
+
+**Status:** OPEN
+
+---
+
+### F-03 | P2 | sanitize | connection.go:372-379 | sanitizeURL is incomplete -- may leak credentials
+
+**Evidence:**
+
+```go
+// connection.go:372-379
+func sanitizeURL(url string) string {
+    // Simple approach: just indicate the host portion.
+    // In production, parse the URL and redact credentials.
+    if len(url) > 10 {
+        return url[:10] + "***"
+    }
+    return "***"
+}
+```
+
+**Problem:** The function truncates to 10 characters, but depending on the URL format, the first 10 characters may include parts of the username (e.g., `amqp://use***` for `amqp://user:pass@host`). The comment acknowledges this is incomplete ("In production, parse the URL and redact credentials") but the TODO was never resolved. For a connection module that logs the URL on every connection/reconnection event (lines 182-183, 256), this needs a proper implementation.
+
+**Fix:** Use `net/url.Parse` to properly redact the userinfo component:
+
+```go
+func sanitizeURL(raw string) string {
+    u, err := url.Parse(raw)
+    if err != nil {
+        return "***"
+    }
+    u.User = nil
+    return u.String()
+}
+```
+
+**Status:** OPEN
+
+---
+
+### F-04 | P2 | ref-tag | connection.go, publisher.go, consumer_base.go | Missing ref: tag on connection.go, publisher.go, consumer_base.go
+
+**Evidence:**
+
+The `ref:` Watermill tag appears in:
+- `doc.go:7` -- `ref: Watermill watermill-amqp subscriber.go`
+- `subscriber.go:46` -- `ref: Watermill watermill-amqp subscriber.go`
+
+But is absent from:
+- `connection.go` -- reconnect loop with exponential backoff is a core Watermill pattern (`watermill-amqp/connection.go`)
+- `publisher.go` -- publisher confirm mode aligns with Watermill's publisher
+- `consumer_base.go` -- idempotency + retry + DLQ pattern
+
+Per CLAUDE.md: "编码时在 PR 描述或 commit message 中注明: `ref: {framework} {file}` + 采纳/偏离理由". The `connection.go` reconnect pattern and `consumer_base.go` DLQ routing are the most architecturally significant pieces and should carry `ref:` annotations documenting design decisions.
+
+**Fix:** Add `ref:` comments to:
+- `connection.go` Connection type godoc: `ref: Watermill watermill-amqp connection.go -- reconnect backoff pattern`
+- `publisher.go` Publisher type godoc: `ref: Watermill watermill-amqp publisher.go -- confirm mode pattern`
+- `consumer_base.go` ConsumerBase type godoc: `ref: Watermill middleware/ -- retry + poison queue pattern`
+
+**Status:** OPEN
+
+---
+
+### F-05 | P2 | CC/complexity | consumer_base.go:102-175 | Wrap method cognitive complexity is borderline
+
+**Evidence:**
+
+Manual CC count for `Wrap` closure (consumer_base.go lines 102-175):
+
+| Element | +CC |
+|---|---|
+| `if err != nil` (idempotency check) | +1 |
+| nested `if` (shouldProcess = true) | +1 (nesting) |
+| `if !shouldProcess` | +1 |
+| `for attempt := range` | +1 |
+| `if lastErr == nil` | +1 (nesting +1) |
+| `if _, ok := ... PermanentError` | +1 (nesting +2) |
+| `if attempt < RetryCount-1` | +1 (nesting +1) |
+| `select` (time.After / ctx.Done) | +1 (nesting +2) |
+| Total | ~12 |
+
+**Problem:** CC is approximately 12, within the <= 15 limit but close. The method handles four distinct concerns in one closure: idempotency check, retry loop, permanent error detection, and DLQ routing. While technically compliant, extracting the retry loop into a private `executeWithRetry` method would improve readability and testability.
+
+**Fix:** Optional refactor -- extract retry logic into:
+
+```go
+func (cb *ConsumerBase) executeWithRetry(ctx context.Context, entry outbox.Entry, topic string, handler func(context.Context, outbox.Entry) error) error
+```
+
+**Status:** OPEN (advisory)
+
+---
+
+### F-06 | P2 | naming | consumer_base.go:53 | PermanentError.Error() uses fmt.Sprintf unnecessarily
+
+**Evidence:**
+
+```go
+// consumer_base.go:53
+func (e *PermanentError) Error() string {
+    return fmt.Sprintf("permanent: %s", e.Err.Error())
+}
+```
+
+**Problem:** Minor -- `fmt.Sprintf` with a single `%s` and `.Error()` call can be simplified to string concatenation: `"permanent: " + e.Err.Error()`. More importantly, the conventional Go pattern is `fmt.Sprintf("permanent: %v", e.Err)` (using `%v` on the error itself rather than calling `.Error()` explicitly). This is a cosmetic nit.
+
+**Status:** OPEN (advisory)
+
+---
+
+## Positive Observations
+
+1. **errcode discipline:** All production `.go` files use `errcode.New` / `errcode.Wrap` exclusively. Zero `errors.New` in production code. The `errors.New` calls in `rabbitmq_test.go` are appropriate for test stubs.
+
+2. **slog structure:** Every slog call includes structured key-value fields (`topic`, `event_id`, `consumer_group`, `error`, `attempt`, etc.). No bare `slog.Error("failed")` anywhere. Log levels are correct for connection lifecycle (Info), degraded states (Warn), and failures (Error) -- with the one exception noted in F-02.
+
+3. **No fmt.Println / log.Printf:** Zero occurrences in the entire module.
+
+4. **AMQP abbreviation:** Correctly uppercased in type names: `AMQPConnection`, `AMQPChannel`, `ErrAdapterAMQP*`. The `DLQ` abbreviation is correctly uppercased in `DLQTopic`, `DLQEntry` metadata keys.
+
+5. **Consumer declaration comment:** `ConsumerBase` at line 68-72 and `Subscriber.Subscribe` at line 76-79 both carry the required EventBus consumer declaration format (Consumer tag, Idempotency key, ACK timing, Retry strategy).
+
+6. **Compile-time interface checks:** Both `publisher.go:15` and `subscriber.go:19` have `var _ outbox.Publisher = (*Publisher)(nil)` / `var _ outbox.Subscriber = (*Subscriber)(nil)`.
+
+7. **Layer compliance:** adapters/rabbitmq imports only `kernel/outbox`, `kernel/idempotency`, and `pkg/errcode`. No imports from `runtime/`, `cells/`, or other adapters. Fully compliant with the dependency rules.
+
+8. **Test coverage breadth:** 30+ unit tests covering success paths, error paths, edge cases (closed subscriber, pool full, idempotent replay, context cancellation, permanent vs transient errors, DLQ routing). Integration tests use testcontainers for real RabbitMQ validation.
+
+---
+
+## Findings Ledger
+
+| ID | Sev | File | Category | Status |
+|---|---|---|---|---|
+| F-01 | P1 | consumer_base.go:134 | errcode/errors.As | OPEN |
+| F-02 | P2 | consumer_base.go:216 | slog-level | OPEN |
+| F-03 | P2 | connection.go:372-379 | sanitize/security | OPEN |
+| F-04 | P2 | connection.go, publisher.go, consumer_base.go | ref-tag | OPEN |
+| F-05 | P2 | consumer_base.go:102-175 | CC/complexity | OPEN (advisory) |
+| F-06 | P2 | consumer_base.go:53 | naming/style | OPEN (advisory) |
+
+**Totals:** 0 P0 | 1 P1 | 5 P2
+
+**Verdict:** No P0 blockers. One P1 (F-01 `errors.As`) should be fixed before the next release to prevent silent misbehavior with wrapped permanent errors. P2 items are recommended improvements.

--- a/docs/reviews/202604060830-R0/R1D-3-rabbitmq-kg.md
+++ b/docs/reviews/202604060830-R0/R1D-3-rabbitmq-kg.md
@@ -1,0 +1,323 @@
+# R1D-3: adapters/rabbitmq -- Kernel Guardian Review
+
+**Reviewer role**: Kernel Guardian
+**Scope**: `src/adapters/rabbitmq/` (7 .go files)
+**Date**: 2026-04-06
+
+---
+
+## 1. File Inventory
+
+| File | LOC (approx) | Purpose |
+|------|-------------|---------|
+| doc.go | 8 | Package doc; declares Publisher/Subscriber/ConsumerBase scope |
+| connection.go | 380 | AMQP connection manager: auto-reconnect, exponential backoff, channel pool |
+| publisher.go | 81 | `outbox.Publisher` implementation with confirm mode |
+| subscriber.go | 257 | `outbox.Subscriber` implementation with ACK/NACK, graceful shutdown |
+| consumer_base.go | 224 | ConsumerBase wrapper: idempotency + retry + DLQ routing |
+| rabbitmq_test.go | 1081 | Unit tests (mocks, Connection, Publisher, Subscriber, ConsumerBase) |
+| integration_test.go | 267 | Testcontainers-based integration tests (build tag `integration`) |
+
+---
+
+## 2. Layer Isolation Check
+
+### 2.1 Production Imports (non-test .go files)
+
+| File | Internal Imports | External Imports |
+|------|-----------------|------------------|
+| connection.go | `pkg/errcode` | `amqp091-go`, stdlib |
+| publisher.go | `kernel/outbox`, `pkg/errcode` | `amqp091-go`, stdlib |
+| subscriber.go | `kernel/outbox`, `pkg/errcode` | `amqp091-go`, stdlib |
+| consumer_base.go | `kernel/idempotency`, `kernel/outbox` | stdlib only |
+
+**Verdict: GREEN** -- Zero imports from `runtime/`, `cells/`, or other `adapters/` packages. The adapter depends only on `kernel/` and `pkg/`, which is the correct dependency direction per CLAUDE.md: "adapters/ implements kernel/ or runtime/ defined interfaces."
+
+### 2.2 Test Imports
+
+| File | Internal Imports | External Imports |
+|------|-----------------|------------------|
+| rabbitmq_test.go | `kernel/idempotency`, `kernel/outbox` | `amqp091-go`, `testify` |
+| integration_test.go | `kernel/outbox` | `testify`, `testcontainers-go` |
+
+**Verdict: GREEN** -- Test imports are clean; mock implementations reside within the test file.
+
+---
+
+## 3. Interface Contract Compliance
+
+### 3.1 outbox.Publisher
+
+**Kernel interface** (`kernel/outbox/outbox.go`):
+```go
+type Publisher interface {
+    Publish(ctx context.Context, topic string, payload []byte) error
+}
+```
+
+**Adapter implementation** (`publisher.go`):
+- Compile-time check: `var _ outbox.Publisher = (*Publisher)(nil)` -- present on line 15.
+- Signature match: `func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) error` -- exact match.
+- Behavior:
+  - Declares exchange idempotently (fanout, durable).
+  - Enables publisher confirm mode per channel acquisition.
+  - Uses `DeliveryMode: amqp.Persistent` for durability.
+  - Waits for broker confirm with configurable timeout.
+  - Respects context cancellation.
+
+**Verdict: GREEN** -- Full compliance with `outbox.Publisher`.
+
+### 3.2 outbox.Subscriber
+
+**Kernel interface** (`kernel/outbox/outbox.go`):
+```go
+type Subscriber interface {
+    Subscribe(ctx context.Context, topic string, handler func(context.Context, Entry) error) error
+    Close() error
+}
+```
+
+**Adapter implementation** (`subscriber.go`):
+- Compile-time check: `var _ outbox.Subscriber = (*Subscriber)(nil)` -- present on line 19.
+- Signature match: both `Subscribe` and `Close` match exactly.
+- Behavior:
+  - Declares exchange + queue idempotently.
+  - Binds queue to exchange.
+  - Sets QoS prefetch for flow control.
+  - Blocks until ctx cancellation or close signal.
+  - Unmarshal failure: NACK without requeue (permanent error).
+  - Handler error: NACK with requeue (transient error).
+  - Handler success: ACK.
+  - Graceful shutdown with WaitGroup + timeout.
+
+**Verdict: GREEN** -- Full compliance with `outbox.Subscriber`.
+
+### 3.3 idempotency.Checker Usage
+
+**Kernel interface** (`kernel/idempotency/idempotency.go`):
+```go
+type Checker interface {
+    IsProcessed(ctx context.Context, key string) (bool, error)
+    MarkProcessed(ctx context.Context, key string, ttl time.Duration) error
+    TryProcess(ctx context.Context, key string, ttl time.Duration) (bool, error)
+}
+```
+
+**ConsumerBase usage** (`consumer_base.go`):
+- Uses `TryProcess` (the atomic check-and-mark method) -- eliminates TOCTOU race. Correct.
+- Does NOT use the older `IsProcessed` + `MarkProcessed` two-step pattern. Correct.
+- Idempotency key format: `{ConsumerGroup}:{entry.ID}` -- matches EventBus spec `{prefix}:{group}:{event-id}` pattern (using ConsumerGroup as the combined prefix:group).
+- Default TTL: `idempotency.DefaultTTL` (24h) -- matches EventBus spec.
+
+**Verdict: GREEN** -- Correct usage of the atomic `TryProcess` method.
+
+---
+
+## 4. Fail-Open Semantics Analysis
+
+**Location**: `consumer_base.go` lines 107-116.
+
+When `TryProcess` returns an error (e.g., Redis down), ConsumerBase sets `shouldProcess = true` and proceeds. This is **fail-open** behavior.
+
+**Assessment**:
+- **Correct for at-least-once semantics**: Dropping messages when the idempotency store is unavailable would silently lose events, which is worse than potential duplicate processing.
+- **Risk is bounded**: The handler itself should be idempotent at the business level (domain invariant), so temporary duplicate processing during Redis downtime is recoverable.
+- **Observability**: The `slog.Warn` log includes `event_id`, `topic`, `consumer_group`, and the error, which satisfies the observability spec.
+
+**Verdict: GREEN** -- Fail-open is the right choice for at-least-once messaging. Documented in code comments.
+
+---
+
+## 5. Consistency Level Support
+
+### 5.1 L2 (OutboxFact) Support
+
+The L2 chain is: business write + outbox write in same DB tx (postgres/OutboxWriter) -> relay polls and publishes via Publisher -> subscriber consumes.
+
+| Component | Role | Status |
+|-----------|------|--------|
+| `postgres.OutboxWriter` | Atomic write in tx | Exists, implements `outbox.Writer` |
+| `postgres.OutboxRelay` | Poll + publish | Exists, uses `outbox.Publisher` |
+| `rabbitmq.Publisher` | Broker delivery with confirms | Exists, implements `outbox.Publisher` |
+| `rabbitmq.Subscriber` | Consume from broker | Exists, implements `outbox.Subscriber` |
+| `rabbitmq.ConsumerBase` | Idempotency + retry + DLQ | Exists, uses `idempotency.Checker` |
+
+**Verdict: GREEN** -- The full L2 chain is wired: `Writer -> Relay -> Publisher -> Broker -> Subscriber -> ConsumerBase -> Handler`. All interfaces are kernel-defined and adapter-implemented.
+
+### 5.2 L3 (WorkflowEventual) Support
+
+L3 extends L2 with cross-cell eventual consistency. The RabbitMQ adapter provides the transport layer. Saga/workflow orchestration is out of scope for this adapter but the transport primitives (publish, subscribe, DLQ) are sufficient.
+
+**Verdict: GREEN** -- Transport primitives present. Saga orchestration is a runtime/cells concern, not adapter.
+
+---
+
+## 6. Message Semantics
+
+### 6.1 Delivery Guarantee: At-Least-Once
+
+| Mechanism | Evidence |
+|-----------|----------|
+| Publisher confirms | `ch.Confirm(false)` + `NotifyPublish` channel wait (publisher.go:44-48) |
+| Persistent messages | `DeliveryMode: amqp.Persistent` (publisher.go:53) |
+| Manual ACK | `autoAck=false` in `ch.Consume` (subscriber.go:121) |
+| ACK after handler | `ch.Ack` only after `handler()` returns nil (subscriber.go:212) |
+| NACK+requeue on error | `ch.Nack(tag, false, true)` on handler error (subscriber.go:204) |
+| NACK without requeue on unmarshal | `ch.Nack(tag, false, false)` on bad payload (subscriber.go:183) |
+
+**Verdict: GREEN** -- At-least-once is correctly implemented. ACK timing is after business logic completes, which is the correct pattern per EventBus spec.
+
+### 6.2 Not Exactly-Once
+
+The adapter provides at-least-once delivery. Exactly-once is achieved at the application layer via ConsumerBase's `TryProcess` idempotency check. This is the correct architectural split:
+- Transport layer: at-least-once (adapter responsibility)
+- Application layer: effectively-once via idempotency (ConsumerBase + redis Checker)
+
+---
+
+## 7. EventBus Specification Compliance
+
+### 7.1 Consumer Declaration Format
+
+**Spec requirement** (CLAUDE.md EventBus):
+```go
+// Consumer: cg-{service}-{event-type}
+// Idempotency key: {prefix}:{group}:{event-id}, TTL 24h
+// ACK timing: after business logic + idempotency key written
+// Retry: transient errors -> NACK+backoff / permanent errors -> dead letter
+```
+
+**Subscriber** (`subscriber.go` lines 76-79):
+```go
+// Consumer: cg-{QueueName}-{topic}
+// Idempotency key: handled by ConsumerBase (not in Subscriber)
+// ACK timing: after handler returns nil
+// Retry: transient errors -> NACK+requeue / permanent errors -> handled by ConsumerBase DLQ
+```
+
+**ConsumerBase** (`consumer_base.go` lines 69-72):
+```go
+// Consumer: cg-{ConsumerGroup}-{topic}
+// Idempotency key: {ConsumerGroup}:{event-id}, TTL 24h
+// ACK timing: after business logic + idempotency key written
+// Retry: transient errors -> NACK+backoff / permanent errors -> dead letter
+```
+
+**Verdict: GREEN** -- Both Subscriber and ConsumerBase carry the declaration block.
+
+### 7.2 Dead-Letter Routing
+
+| Requirement | Status |
+|-------------|--------|
+| L2 consumer must have DLQ | ConsumerBase routes to `{topic}.dlq` or custom DLQTopic |
+| DLQ messages must be observable | `slog.Error` on every dead-letter routing (line 216) with event_id, topic, dlq_topic, consumer_group, error, retry_count |
+| PermanentError -> DLQ immediately | Yes, no retry (line 133-142) |
+| Retry exhausted -> DLQ | Yes (lines 163-174) |
+| Unmarshal failure -> NACK without requeue | Handled at Subscriber level (line 183), not by ConsumerBase |
+
+**Verdict: YELLOW** -- The unmarshal failure path in Subscriber NACKs without requeue but does NOT route to a DLQ topic. The EventBus spec says `unmarshal failure -> deadLetter(ctx, msg, err)`. Currently, these messages are simply rejected by the broker. If the queue has no RabbitMQ-native DLX (dead-letter exchange) configured, these messages are lost.
+
+### 7.3 Stream Naming
+
+- Exchange names are user-supplied topic strings.
+- Queue names default to topic name or are user-configured.
+- Consumer tags follow `cg-{queue}-{topic}` pattern.
+- No hardcoded stream/exchange names observed; constants are deferred to callers.
+
+**Verdict: GREEN** -- Naming conventions are consistent and configurable.
+
+### 7.4 Event Payload
+
+- `entry.ID` is used as the canonical idempotency identifier (per kernel/outbox/outbox.go doc).
+- Payload changes are transparent ([]byte pass-through).
+- Metadata is a `map[string]string` with x-death enrichment on DLQ.
+
+**Verdict: GREEN**
+
+---
+
+## 8. Code Quality from Guardian Perspective
+
+### 8.1 Error Handling
+
+| Check | Status |
+|-------|--------|
+| Uses `pkg/errcode` (not bare `errors.New`) | All 5 error codes use `errcode.Code` constants |
+| Error wrapping with context | All errors wrapped via `errcode.Wrap` with descriptive messages |
+| No `_ = someFunc()` for errors | No suppressed errors in production code |
+| Structured logging on errors | All slog calls include structured fields |
+
+**Verdict: GREEN**
+
+### 8.2 Test Coverage
+
+Overall: **78.7%** (unit tests only, excluding integration).
+
+| Component | Coverage | Comment |
+|-----------|----------|---------|
+| ConsumerBase.Wrap | 100% | All paths: success, duplicate, transient retry, permanent error, DLQ, idempotency failure, context cancel |
+| Publisher.Publish | 85.7% | Missing: context deadline branch when confirm and cancel race |
+| Subscriber.Subscribe | 76.0% | Missing: consume error path |
+| connection.reconnectWithBackoff | 0% | Reconnect is tested only at integration level |
+| connection.reconnectLoop | 38.1% | Partial coverage of reconnect state machine |
+
+The 78.7% is below the 80% minimum specified in CLAUDE.md. The gap is primarily in `connection.go` reconnect logic (0% on `reconnectWithBackoff`).
+
+**Verdict: YELLOW** -- 78.7% < 80% threshold. The gap is in reconnect code paths which are inherently hard to unit test, but a mock-based reconnect scenario could push it over 80%.
+
+### 8.3 Confirm Mode Re-enablement
+
+**Finding (P2)**: Publisher calls `ch.Confirm(false)` on every `Publish()` call. When a channel is returned from the pool and reused, confirm mode is re-enabled unnecessarily. While RabbitMQ tolerates repeated `Confirm(false)` calls, this is an efficiency concern.
+
+**Impact**: Minor performance overhead on high-throughput publish paths. Not a correctness issue because `Confirm(false)` is idempotent on AMQP channels.
+
+---
+
+## 9. Findings Summary
+
+### P1 -- Must Fix (0 items)
+
+None.
+
+### P2 -- Should Fix (2 items)
+
+| ID | Finding | Location | Recommendation |
+|----|---------|----------|----------------|
+| KG-RMQ-01 | Unmarshal failure not routed to DLQ | subscriber.go:177-188 | When unmarshal fails, publish the raw delivery body to `{topic}.dlq` with `x-death-reason: unmarshal_failure` metadata instead of NACK-without-requeue. This aligns with the EventBus spec's `deadLetter(ctx, msg, err)` pattern and prevents message loss when no native RabbitMQ DLX is configured. |
+| KG-RMQ-02 | Unit test coverage 78.7% < 80% | rabbitmq_test.go | Add a mock-based reconnect test scenario targeting `reconnectWithBackoff` to push coverage above 80%. |
+
+### P3 -- Advisory (3 items)
+
+| ID | Finding | Location | Recommendation |
+|----|---------|----------|----------------|
+| KG-RMQ-03 | Confirm mode re-enabled per Publish | publisher.go:44 | Consider enabling confirm mode once at channel creation and caching it, or track confirm state in a wrapper. Low priority since `Confirm(false)` is idempotent. |
+| KG-RMQ-04 | TryProcess marks key before handler succeeds | consumer_base.go:107 | If the handler fails all retries and goes to DLQ, the idempotency key remains claimed. This is correct for DLQ semantics (prevents reprocessing the same failed message by other consumers), but should be explicitly documented. Currently documented only in test comments (rabbitmq_test.go:972-975). |
+| KG-RMQ-05 | DLQ publish failure is silently swallowed | consumer_base.go:205-213 | If DLQ publish fails, the error is logged but the original message is still ACKed (ConsumerBase.Wrap returns nil). Consider returning an error to trigger NACK+requeue, or add a DLQ failure metric counter. |
+
+---
+
+## 10. Constraint Checklist
+
+| Constraint | Status | Evidence |
+|------------|--------|----------|
+| Layer isolation: no upward dependency | GREEN | Zero imports from `runtime/`, `cells/`, or `adapters/` (Grep verified) |
+| Adapter implements kernel interface | GREEN | `outbox.Publisher`, `outbox.Subscriber` compile-time checks present |
+| `pkg/errcode` usage (no bare `errors.New`) | GREEN | All 5 error codes defined as `errcode.Code` constants |
+| Structured `slog` logging | GREEN | All log calls use structured fields (topic, event_id, error, etc.) |
+| At-least-once delivery | GREEN | Publisher confirms + manual ACK after handler |
+| Idempotency via `TryProcess` (atomic) | GREEN | Eliminates TOCTOU race vs. separate IsProcessed/MarkProcessed |
+| DLQ for L2 consumers | YELLOW | ConsumerBase routes to DLQ; Subscriber unmarshal path does not |
+| EventBus consumer declaration format | GREEN | Both Subscriber and ConsumerBase carry declaration blocks |
+| Coverage >= 80% | YELLOW | 78.7% (1.3% gap, primarily reconnect code) |
+
+---
+
+## 11. Verdict
+
+The `adapters/rabbitmq` module is architecturally sound with correct layer isolation, full kernel interface compliance, and well-implemented at-least-once delivery semantics. The ConsumerBase correctly uses the atomic `TryProcess` method and implements proper retry+DLQ routing with observability.
+
+Two P2 items require attention:
+1. The unmarshal failure path should route to DLQ rather than relying on broker-native DLX configuration.
+2. Unit test coverage should be pushed above the 80% threshold.
+
+No P1 (blocker) findings. The module is fit for purpose as the L2/L3 transport adapter.

--- a/docs/reviews/202604060830-R0/R1D-3-rabbitmq-product.md
+++ b/docs/reviews/202604060830-R0/R1D-3-rabbitmq-product.md
@@ -1,0 +1,316 @@
+# R1D-3: adapters/rabbitmq -- Product Review
+
+| Field | Value |
+|-------|-------|
+| Module | `adapters/rabbitmq` |
+| Reviewer Role | Product Manager |
+| Date | 2026-04-06 |
+| Source PR | #12 (introduced), #14 (idempotency evolution), #31 (integration), #35 (TryProcess) |
+| Persona | Go developer integrating GoCell event-driven messaging via `go get` |
+
+---
+
+## 1. Executive Summary
+
+The `adapters/rabbitmq` module delivers a functionally complete RabbitMQ adapter covering the five core components (Connection, Publisher, Subscriber, ConsumerBase, DLQ). The API surface is clean and idiomatic Go, with proper `outbox.Publisher` and `outbox.Subscriber` interface compliance verified at compile time. However, several product-level gaps prevent a "green" verdict: (a) documentation drift between `adapter-config-reference.md` and actual code, (b) zero example code showing RabbitMQ usage, (c) missing observability metrics, and (d) two known correctness findings that degrade at-least-once delivery guarantees.
+
+**Overall Verdict: CONDITIONAL PASS** -- P1 core features implemented, but 2 red and 2 yellow dimensions require follow-up.
+
+---
+
+## 2. Verification Scope -- Files Reviewed
+
+| File | Lines | Role |
+|------|-------|------|
+| `doc.go` | 8 | Package documentation |
+| `connection.go` | 380 | Connection lifecycle, auto-reconnect, channel pool |
+| `publisher.go` | 81 | Publish with confirm mode |
+| `subscriber.go` | 257 | Subscribe with ACK/NACK, graceful shutdown |
+| `consumer_base.go` | 224 | Idempotency + retry + DLQ wrapper |
+| `rabbitmq_test.go` | 1081 | Unit tests (mock-based) |
+| `integration_test.go` | 267 | Integration tests (testcontainers) |
+| `kernel/outbox/outbox.go` | 75 | Publisher/Subscriber interfaces |
+| `kernel/idempotency/idempotency.go` | 28 | Checker interface |
+| `docs/guides/adapter-config-reference.md` | 126 | Configuration reference |
+
+---
+
+## 3. Persona Assessment: "Go Developer Integrating RabbitMQ"
+
+### 3.1 Can they discover the API via godoc?
+
+`doc.go` is minimal (8 lines) but accurately describes scope: outbox.Publisher, outbox.Subscriber, auto-reconnect, channel pooling, publisher confirms, ConsumerBase. The Watermill reference is appropriate.
+
+**Verdict**: Adequate for discovery. Missing: usage example in doc.go package comment.
+
+### 3.2 Can they understand configuration?
+
+`Config`, `SubscriberConfig`, and `ConsumerBaseConfig` structs have field-level godoc with defaults documented inline. `setDefaults()` methods ensure zero-value configs produce sensible behavior.
+
+**Verdict**: Good. Developer can use zero-value structs and override only what matters.
+
+### 3.3 Can they write a consumer in under 30 minutes?
+
+The happy path requires:
+1. `NewConnection(Config{URL: "amqp://..."})` -- straightforward
+2. `NewPublisher(conn)` -- one-liner
+3. `NewSubscriber(conn, SubscriberConfig{QueueName: "..."})` -- clear
+4. `NewConsumerBase(checker, pub, ConsumerBaseConfig{...})` -- requires idempotency.Checker and outbox.Publisher
+
+The ConsumerBase.Wrap() pattern is well-documented with inline comments explaining return semantics.
+
+**Verdict**: Achievable for an experienced Go developer. However, no runnable example exists in `examples/` -- all three examples (sso-bff, todo-order, iot-device) use `eventbus.New()` (in-memory) instead.
+
+### 3.4 Can they diagnose failures?
+
+Error messages follow `"rabbitmq: {action}"` pattern with structured slog fields. Error codes (`ERR_ADAPTER_AMQP_*`) are module-specific and searchable. The `PermanentError` type provides a clear signal for DLQ routing.
+
+**Verdict**: Good error diagnostics. One gap: `sanitizeURL` uses naive fixed-length truncation (first 10 chars), which can leak credential fragments for short URLs (known finding P0-F12S01).
+
+---
+
+## 4. Acceptance Criteria Assessment
+
+### P1 -- Core Functionality
+
+| ID | Criterion | Status | Evidence |
+|----|-----------|--------|----------|
+| AC-1 | Publisher implements `outbox.Publisher` | PASS | Compile-time check `var _ outbox.Publisher = (*Publisher)(nil)` in publisher.go:15 |
+| AC-2 | Subscriber implements `outbox.Subscriber` | PASS | Compile-time check `var _ outbox.Subscriber = (*Subscriber)(nil)` in subscriber.go:19 |
+| AC-3 | Publisher uses confirm mode for delivery guarantee | PASS | `ch.Confirm(false)` + `NotifyPublish` + timeout/nack handling in publisher.go:44-79 |
+| AC-4 | Subscriber ACKs on handler success, NACKs on error | PASS | processDelivery: handler nil -> ACK (line 212), handler error -> NACK+requeue (line 203), unmarshal fail -> NACK no requeue (line 183) |
+| AC-5 | Connection auto-reconnects on broker failure | PASS | `reconnectLoop()` with exponential backoff, tested in rabbitmq_test.go (backoff delay tests) |
+| AC-6 | ConsumerBase provides idempotency check | PASS | `TryProcess` call in consumer_base.go:107. Uses atomic check-and-mark. |
+| AC-7 | ConsumerBase routes exhausted retries to DLQ | PASS | Retry loop + deadLetter() call at line 170. Tested in TestConsumerBase_Wrap_RetryExhausted_DLQ |
+| AC-8 | ConsumerBase routes PermanentError to DLQ immediately | PASS | Type assertion at line 134, tested in TestConsumerBase_Wrap_PermanentError_DLQ |
+| AC-9 | Graceful shutdown waits for in-flight messages | PASS | Subscriber.Close() uses WaitGroup + ShutdownTimeout (subscriber.go:221-256) |
+| AC-10 | Channel pool recycles connections | PASS | AcquireChannel/ReleaseChannel with buffered channel, tested in TestConnection_AcquireFromPool and TestConnection_ReleaseChannel_PoolFull |
+
+**P1 Result: 10/10 PASS**
+
+### P2 -- Enhanced Functionality
+
+| ID | Criterion | Status | Evidence / Reason |
+|----|-----------|--------|-------------------|
+| AC-11 | Idempotency key follows `{group}:{event-id}` format per EventBus spec | PASS | consumer_base.go:104: `fmt.Sprintf("%s:%s", cb.config.ConsumerGroup, entry.ID)` |
+| AC-12 | DLQ messages carry x-death metadata for debugging | PASS | deadLetter() enriches: x-death-reason, x-death-topic, x-death-consumer-group, x-death-retry-count, x-death-time |
+| AC-13 | DLQ topic is configurable (default: `{topic}.dlq`) | PASS | ConsumerBaseConfig.DLQTopic with fallback, tested in TestConsumerBase_Wrap_CustomDLQTopic |
+| AC-14 | RetryCount and RetryBaseDelay are configurable | PASS | ConsumerBaseConfig fields with defaults (3, 1s) |
+| AC-15 | PrefetchCount is configurable per subscriber | PASS | SubscriberConfig.PrefetchCount, set via ch.Qos() |
+| AC-16 | Idempotency fail-open preserves at-least-once semantics | FAIL | [P0-F12D01] TryProcess marks key before handler runs. If handler fails after mark, redelivered message is silently skipped. See PR35-noncompat-findings.md Finding #1. |
+| AC-17 | Examples demonstrate RabbitMQ adapter usage | SKIP | All 3 examples use in-memory eventbus. Docker-compose files provision RabbitMQ but no Go code uses it. Reason: project stage (examples show dev-mode flow). |
+| AC-18 | Metrics/counters for publish, consume, retry, DLQ events | SKIP | No metrics integration exists. DLQ events are logged only (slog.Error). Known finding P1-M4. |
+
+**P2 Result: 6 PASS, 1 FAIL, 2 SKIP (with reasons)**
+
+### P3 -- Infrastructure
+
+| ID | Criterion | Status | Evidence / Reason |
+|----|-----------|--------|-------------------|
+| AC-19 | Unit tests cover happy path + error paths | PASS | 30+ test cases: connection, publisher (success/nack/timeout/cancel/error), subscriber (process/unmarshal/handler-error/close/default-queue), consumer base (success/already-processed/retry/dlq/permanent/custom-dlq/idempotency-error/context-cancel) |
+| AC-20 | Integration tests with real RabbitMQ | PASS | 5 tests using testcontainers: health, publish-consume, publish-only, consumer-base-retry, connection-recovery |
+| AC-21 | Consumer declaration comment per EventBus spec | PASS | Subscriber.Subscribe godoc (subscriber.go:79) and ConsumerBase type comment (consumer_base.go:69-72) include Consumer/Idempotency/ACK/Retry declarations |
+| AC-22 | TLS configuration support | SKIP | No TLS Config extension point. Known finding P1-M5. Acceptable at current project stage. |
+
+**P3 Result: 3 PASS, 1 SKIP**
+
+---
+
+## 5. Product Review -- 7 Dimensions
+
+### A. Acceptance Criteria Coverage -- YELLOW
+
+- P1: 10/10 = 100% PASS
+- P2: 1 FAIL (AC-16 idempotency correctness), 2 SKIP with reasons
+- P3: 1 SKIP with reason
+
+The P2 FAIL on AC-16 is the primary concern. It represents a semantic correctness issue documented in PR35-noncompat-findings.md (Finding #1: "TryProcess can silently lose requeued messages"). While the code functions correctly in the happy path, the edge case degrades at-least-once to at-most-once.
+
+### B. UI Compliance Check (API Surface) -- GREEN
+
+| Check | Status |
+|-------|--------|
+| Empty/nil state handling | Config.setDefaults() handles all zero values; nil metadata initialized in processDelivery and deadLetter |
+| Error responses | All errors use errcode package with structured codes (ERR_ADAPTER_AMQP_*) |
+| Loading/waiting state | WaitConnected(ctx) provides blocking wait with context cancellation |
+| Navigation (API discoverability) | Types are logically grouped: Connection -> Publisher/Subscriber -> ConsumerBase |
+
+### C. Error Path Coverage -- YELLOW
+
+| Error Scenario | Designed | Tested |
+|----------------|----------|--------|
+| Dial failure | Yes | Yes (TestNewConnection_DialFails) |
+| Connection closed mid-operation | Yes | Yes (TestConnection_Health_Closed, AcquireChannel_ConnectionClosed) |
+| Publish NACK from broker | Yes | Yes (TestPublisher_Publish_Nacked) |
+| Publish confirm timeout | Yes | Yes (TestPublisher_Publish_ConfirmTimeout) |
+| Context cancellation during publish | Yes | Yes (TestPublisher_Publish_ContextCancelled) |
+| Channel error during publish | Yes | Yes (TestPublisher_Publish_PublishError) |
+| Confirm mode enable failure | Yes | Yes (TestPublisher_Publish_ConfirmModeError) |
+| Unmarshal failure in subscriber | Yes | Yes (TestSubscriber_Subscribe_UnmarshalFailure_Nack) |
+| Handler transient error | Yes | Yes (TestSubscriber_Subscribe_HandlerError_NackWithRequeue) |
+| Delivery channel closed | Yes | Yes (TestSubscriber_DeliveryChannelClosed) |
+| Subscribe after close | Yes | Yes (TestSubscriber_Subscribe_AfterClose) |
+| Idempotency check failure (fail-open) | Yes | Yes (TestConsumerBase_Wrap_IdempotencyCheckError_StillProcesses) |
+| Context cancel during retry backoff | Yes | Yes (TestConsumerBase_Wrap_ContextCancelled_DuringRetry) |
+| Reconnect after broker restart | Designed | Partial (connection recovery test only checks Health, not re-subscribe) |
+| Concurrent consumer processing | Designed (PrefetchCount) | NOT TESTED (known P1-L9) |
+| DLQ publish failure | Designed (logged) | NOT TESTED |
+
+Coverage: 13/16 scenarios tested = ~81%.
+
+Gap: reconnect + re-subscribe end-to-end flow, concurrent consumption under PrefetchCount, and DLQ publish failure path are untested.
+
+### D. Documentation Link Completeness -- RED
+
+| Document | Status | Issue |
+|----------|--------|-------|
+| doc.go | Exists | Accurate but minimal. No usage example. |
+| adapter-config-reference.md | Drift | **Significant mismatch** -- see Section 6 below |
+| examples/ Go code | Missing | No example uses `adapters/rabbitmq` |
+| examples/ docker-compose | Exists | sso-bff and todo-order provision RabbitMQ containers |
+| Consumer declaration comments | Present | Matches EventBus spec format |
+
+### E. Functionality Completeness -- GREEN
+
+All five core components are implemented:
+1. **Connection** -- lifecycle, auto-reconnect, channel pool, health check, WaitConnected
+2. **Publisher** -- confirm mode, exchange declaration, context-aware
+3. **Subscriber** -- QoS, exchange/queue/binding declaration, graceful shutdown
+4. **ConsumerBase** -- idempotency, retry with backoff, PermanentError, DLQ routing
+5. **DLQ** -- metadata enrichment (x-death-*), configurable topic
+
+### F. Success Criteria Achievement -- YELLOW
+
+| Criterion | Status |
+|-----------|--------|
+| RabbitMQ adapter implements outbox.Publisher + outbox.Subscriber | Met |
+| ConsumerBase provides built-in retry + DLQ + idempotency | Met (with correctness caveat on TryProcess) |
+| Adapter follows dependency rules (no cells/ or runtime/ imports) | Met -- depends only on kernel/outbox, kernel/idempotency, pkg/errcode |
+| Developer can configure all knobs (retry, backoff, DLQ, prefetch) | Met |
+| Production-ready observability (metrics) | NOT Met -- log-only |
+
+### G. Product Tech Debt -- 5 items
+
+| ID | Category | Description | Impact |
+|----|----------|-------------|--------|
+| [PRODUCT] PTD-1 | Correctness | TryProcess marks idempotency key before handler succeeds; redelivered messages silently lost | At-least-once guarantee broken in edge cases |
+| [PRODUCT] PTD-2 | Documentation | adapter-config-reference.md describes fields that do not exist in code (see Section 6) | Developer confusion on first integration |
+| [PRODUCT] PTD-3 | DX | No runnable example using RabbitMQ adapter in examples/ | Adoption friction |
+| [PRODUCT] PTD-4 | Observability | No metrics (publish count, consume count, retry count, DLQ count) | Ops blind spot in production |
+| [PRODUCT] PTD-5 | Security | sanitizeURL uses naive 10-char truncation, can leak credential fragments | Security hygiene |
+
+---
+
+## 6. Specific Findings
+
+### 6.1 [验收标准缺失] AC-16: TryProcess Idempotency Correctness
+
+**Severity**: P1 (impacts at-least-once guarantee -- core delivery semantics)
+
+The `ConsumerBase.Wrap()` method calls `TryProcess()` (consumer_base.go:107) which atomically marks the idempotency key before the business handler executes. If the handler subsequently fails:
+- ConsumerBase retries within its own retry budget -- this works correctly.
+- But if the entire `Wrap()` function returns an error (e.g., context cancellation at line 158), the Subscriber NACKs and requeues.
+- On redelivery, `TryProcess` returns `shouldProcess=false` and the message is silently ACKed without processing.
+
+**Given** a message is delivered and TryProcess succeeds
+**When** the handler returns a context.Cancelled error during retry backoff
+**Then** the message is NACKed, requeued, redelivered, and silently dropped
+
+This is documented in PR35-noncompat-findings.md (Finding #1) but remains unresolved.
+
+**Recommendation**: Either (a) defer TryProcess to after handler success, reverting to IsProcessed pre-check + MarkProcessed post-success with a note about the TOCTOU trade-off, or (b) add a `ReleaseProcess(key)` method to idempotency.Checker for cleanup on non-permanent failures.
+
+### 6.2 [开发者体验] Documentation Drift in adapter-config-reference.md
+
+**Severity**: P2
+
+The config reference document at `/Users/shengming/Documents/code/gocell/docs/guides/adapter-config-reference.md` (lines 52-78) describes a RabbitMQ configuration surface that does not match the actual code:
+
+| Reference Doc Field | Actual Code Field | Mismatch |
+|---------------------|-------------------|----------|
+| `reconnectDelay` (duration) | `ReconnectBaseDelay` + `ReconnectMaxBackoff` (two fields) | Name and cardinality differ |
+| `maxReconnect` (int, 0=unlimited) | Does not exist | Code always retries unlimited |
+| `exchange` (required on Publisher) | Not a Publisher config field; topic passed per-call to Publish() | Architectural mismatch |
+| `exchangeType` (default "topic") | Hardcoded "fanout" in publisher.go:39 | Type mismatch |
+| `confirmMode` (bool, default true) | Always enabled, not configurable | Missing toggle |
+| `queue` (required on ConsumerBase) | QueueName on SubscriberConfig, not ConsumerBaseConfig | Wrong struct |
+| `consumerTag` (auto) | Generated as `cg-{queue}-{topic}`, not configurable | Correct default but doc implies configurability |
+| `dlqExchange` (string) | `DLQTopic` (string on ConsumerBaseConfig) | Name mismatch |
+| `idempotencyStore` (idempotency.Store) | `idempotency.Checker` interface, passed to NewConsumerBase() | Type name mismatch |
+
+A developer reading this guide before looking at code will build incorrect mental models.
+
+### 6.3 [开发者体验] No RabbitMQ Usage in Examples
+
+**Severity**: P2
+
+All three example applications (sso-bff, todo-order, iot-device) use `eventbus.New()` for in-memory pub/sub despite having `docker-compose.yml` files that provision RabbitMQ containers. A Go developer looking for "how do I actually wire RabbitMQ into my GoCell assembly" has no reference code.
+
+**Recommendation**: Add a `// +build rabbitmq` variant in at least one example, or add a standalone `examples/rabbitmq-demo/main.go`.
+
+### 6.4 [验收标准缺失] Missing Observability Metrics
+
+**Severity**: P2
+
+The EventBus specification (`.claude/rules/gocell/eventbus.md`) requires: "dead-letter messages must be observable (counting metrics or logs)." Currently DLQ events are logged via `slog.Error` (consumer_base.go:216-222), satisfying the "or logs" portion. However, there are no metrics for:
+- Messages published (count, latency)
+- Messages consumed (count, latency)
+- Retry attempts (count by topic)
+- DLQ routings (count by topic and consumer group)
+
+The `runtime/observability/metrics` package exists in the codebase but is not integrated with the RabbitMQ adapter.
+
+### 6.5 [范围偏移] processDelivery is Serial Despite PrefetchCount
+
+**Severity**: P2 (known finding P1-M7)
+
+`subscriber.go:162` calls `s.processDelivery()` synchronously within the select loop. Even with `PrefetchCount=10`, only one message is processed at a time. The WaitGroup (`s.wg`) exists but is never leveraged for concurrent processing.
+
+A developer setting `PrefetchCount: 50` would expect concurrent consumption but get serial behavior, which is misleading.
+
+### 6.6 [开发者体验] sanitizeURL Leaks Credential Fragments
+
+**Severity**: P1 (security)
+
+`connection.go:372-379`: `sanitizeURL` takes the first 10 characters of the URL. For `amqp://guest:guest@localhost:5672/`, the output is `amqp://gue***` -- this leaks the beginning of the username. For shorter URLs with passwords, more sensitive information could be exposed.
+
+**Recommendation**: Use `net/url.Parse()` to properly redact the userinfo component, or replace with a fixed string like `amqp://***@{host}`.
+
+---
+
+## 7. Dimension Summary
+
+| Dimension | Rating | Key Rationale |
+|-----------|--------|---------------|
+| A. Acceptance Criteria Coverage | YELLOW | P1 100%, but P2 has 1 FAIL (AC-16 idempotency) |
+| B. API Surface Compliance | GREEN | Clean types, proper defaults, structured errors |
+| C. Error Path Coverage | YELLOW | ~81% (13/16). Reconnect flow, concurrent consume, DLQ-publish-fail untested |
+| D. Documentation Completeness | RED | adapter-config-reference.md severely drifted; no example code |
+| E. Functionality Completeness | GREEN | All 5 components delivered |
+| F. Success Criteria Achievement | YELLOW | 4/5 met; metrics gap |
+| G. Product Tech Debt | RED | 5 items including P1 correctness issue |
+
+---
+
+## 8. Confirmation Checklist
+
+| Check | Status |
+|-------|--------|
+| Product context defined (persona + success criteria) | DONE (Section 3 + F) |
+| Acceptance criteria graded (P1/P2/P3) | DONE (Section 4) |
+| P1 acceptance criteria = 100% PASS | PASS (10/10) |
+| P2 no FAIL (SKIP must have reason) | FAIL -- AC-16 is FAIL |
+| Product review report has no RED dimensions | FAIL -- D and G are RED |
+| Consumer sign-off | CONDITIONAL |
+
+**Final Verdict: CONDITIONAL PASS**
+
+The module is functionally complete for all P1 criteria. The two blocking items for full PASS are:
+
+1. **Must-fix (blocks production use)**: Resolve TryProcess idempotency race (PTD-1 / AC-16). Either revert to IsProcessed + MarkProcessed or add ReleaseProcess cleanup path.
+2. **Must-fix (blocks developer adoption)**: Update adapter-config-reference.md to match actual Config/SubscriberConfig/ConsumerBaseConfig fields (PTD-2).
+
+Three additional items recommended for next phase:
+3. Add RabbitMQ example in examples/ (PTD-3)
+4. Integrate runtime/observability/metrics for publish/consume/retry/DLQ counters (PTD-4)
+5. Fix sanitizeURL to use net/url.Parse (PTD-5)

--- a/docs/reviews/202604060830-R0/R1D-3-rabbitmq-security.md
+++ b/docs/reviews/202604060830-R0/R1D-3-rabbitmq-security.md
@@ -1,0 +1,423 @@
+# R1D-3: adapters/rabbitmq Security Review
+
+- **Reviewer Seat**: S2 (Security / Permissions)
+- **Scope**: `src/adapters/rabbitmq/` all .go files (~950 LOC on develop)
+- **Review Baseline**: commit `ce03ba1` (develop HEAD)
+- **Date**: 2026-04-06
+
+---
+
+## Summary
+
+The `adapters/rabbitmq` package implements `outbox.Publisher` and `outbox.Subscriber` with auto-reconnect, channel pooling, publisher confirm mode, and a `ConsumerBase` providing idempotency + retry + DLQ routing. The security review focused on six core concerns raised from prior PR#7-12 reviews. **3 P0 findings** remain open or partially mitigated, **3 P1 findings** identified, and **2 P2 findings** noted.
+
+---
+
+## Findings
+
+### P0-R1D3-01: sanitizeURL Still Leaks AMQP Credentials (CONFIRMED -- NOT FIXED)
+
+- **Seat**: S2 Security
+- **Severity**: P0
+- **Category**: Credential Leakage
+- **Affected File**: `src/adapters/rabbitmq/connection.go` lines 372-379
+- **Prior Finding**: P0-F12S01
+
+**Evidence**:
+
+```go
+// connection.go:372-379
+func sanitizeURL(url string) string {
+    // Simple approach: just indicate the host portion.
+    // In production, parse the URL and redact credentials.
+    if len(url) > 10 {
+        return url[:10] + "***"
+    }
+    return "***"
+}
+```
+
+The function truncates the URL to its first 10 characters. For a typical AMQP URL like `amqp://admin:SuperSecret@broker.internal:5672/vhost`, the first 10 characters are `amqp://adm`, which leaks the username prefix. For short usernames (e.g., `amqp://a:b@host`), significant credential material is exposed.
+
+The unit test at `rabbitmq_test.go:478` confirms the broken behavior:
+```go
+{name: "long URL", url: "amqp://guest:guest@localhost:5672/", expected: "amqp://gue***"},
+```
+The test shows `amqp://gue***` as the expected output -- meaning 3 characters of the username `guest` are leaked. The test codifies the vulnerability rather than catching it.
+
+The code's own comment says `"In production, parse the URL and redact credentials"` -- this was never implemented.
+
+**Callers**: `connect()` at line 183 logs the result via `slog.Info`, meaning credentials leak to structured logs in every connection establishment and every reconnect.
+
+**Fix Recommendation**: Replace with proper URL parsing:
+
+```go
+import "net/url"
+
+func sanitizeURL(rawURL string) string {
+    u, err := url.Parse(rawURL)
+    if err != nil {
+        return "***"
+    }
+    u.User = nil
+    return u.String()
+}
+```
+
+**Status**: OPEN
+
+---
+
+### P0-R1D3-02: DLQ Publish Failure Silently ACKs Original Message (Issue #26)
+
+- **Seat**: S2 Security
+- **Severity**: P0
+- **Category**: Message Loss / Data Integrity
+- **Affected File**: `src/adapters/rabbitmq/consumer_base.go` lines 170-174, 196-213
+- **Prior Finding**: Issue #26
+
+**Evidence**:
+
+In `ConsumerBase.Wrap()`, after retry exhaustion (line 170-174):
+```go
+// consumer_base.go:170-174
+cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount)
+
+// Return nil to ACK the original message (it's been DLQ'd).
+return nil
+```
+
+But inside `deadLetter()` (lines 205-212):
+```go
+// consumer_base.go:205-212
+if err := cb.publisher.Publish(ctx, dlqTopic, payload); err != nil {
+    slog.Error("rabbitmq: failed to publish to DLQ",
+        slog.String("event_id", entry.ID),
+        ...
+    return  // <-- returns without any indication of failure
+}
+```
+
+When `cb.publisher.Publish()` fails, `deadLetter()` returns (void), and then `Wrap()` returns `nil`, causing the Subscriber to ACK the original delivery. The message is permanently lost: it was not successfully processed, not in the DLQ, and not requeued.
+
+The same pattern applies to the permanent error path (line 141):
+```go
+// consumer_base.go:139-141
+cb.deadLetter(ctx, topic, entry, lastErr, attempt+1)
+return nil // Return nil to ACK the original message.
+```
+
+And the marshal failure path (lines 196-203):
+```go
+// consumer_base.go:196-203
+payload, err := json.Marshal(dlqEntry)
+if err != nil {
+    slog.Error("rabbitmq: failed to marshal DLQ entry", ...)
+    return  // <-- silent return, caller ACKs
+}
+```
+
+**Impact**: Any DLQ publish failure (broker down, network partition, exchange not declared) causes silent, permanent message loss. This is a data integrity violation for L2+ consistency levels.
+
+**Fix Recommendation**: `deadLetter()` must return an `error`. When it fails, `Wrap()` must return a non-nil error so the Subscriber NACKs the original message (with requeue). Example:
+
+```go
+func (cb *ConsumerBase) deadLetter(...) error {
+    // ...
+    if err := cb.publisher.Publish(ctx, dlqTopic, payload); err != nil {
+        slog.Error(...)
+        return fmt.Errorf("deadLetter publish: %w", err)
+    }
+    return nil
+}
+
+// In Wrap():
+if err := cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount); err != nil {
+    return err  // Non-nil -> Subscriber NACKs with requeue
+}
+return nil
+```
+
+**Status**: OPEN
+
+---
+
+### P0-R1D3-03: Context Cancellation During Retry Causes Uncontrolled Requeue
+
+- **Seat**: S2 Security
+- **Severity**: P0
+- **Category**: Message Safety / Requeue Storm
+- **Affected File**: `src/adapters/rabbitmq/consumer_base.go` lines 155-159, `src/adapters/rabbitmq/subscriber.go` lines 197-208
+- **Prior Finding**: P0-F12D01
+
+**Evidence**:
+
+In `ConsumerBase.Wrap()` retry backoff (lines 155-159):
+```go
+// consumer_base.go:155-159
+select {
+case <-time.After(delay):
+case <-ctx.Done():
+    return ctx.Err()
+}
+```
+
+When context is cancelled during retry backoff, `Wrap()` returns `ctx.Err()` (non-nil). This flows to `Subscriber.processDelivery()` line 197:
+
+```go
+// subscriber.go:197-208
+if err := handler(ctx, entry); err != nil {
+    // Handler error is a transient failure -- NACK with requeue.
+    slog.Warn("rabbitmq: handler returned error, nacking with requeue", ...)
+    if nackErr := ch.Nack(delivery.DeliveryTag, false, true); nackErr != nil {
+        ...
+    }
+    return
+}
+```
+
+The Subscriber treats ALL handler errors as transient and NACKs with `requeue=true`. So context cancellation (shutdown) causes every in-flight message to be requeued. On restart, these messages are re-delivered, potentially hitting the same ctx cancellation and requeuing again -- creating a requeue storm.
+
+The test at `rabbitmq_test.go:1051-1071` (`TestConsumerBase_Wrap_ContextCancelled_DuringRetry`) verifies that `ctx.Err()` is returned, but no test validates the Subscriber's NACK behavior on ctx cancellation.
+
+**Fix Recommendation**: The Subscriber should distinguish context cancellation from handler errors:
+
+```go
+func (s *Subscriber) processDelivery(...) {
+    defer s.wg.Done()
+    // ...
+    if err := handler(ctx, entry); err != nil {
+        if ctx.Err() != nil {
+            // Context cancelled (shutdown) -- NACK without requeue.
+            // Message will be re-delivered when consumer reconnects normally.
+            ch.Nack(delivery.DeliveryTag, false, false)
+            return
+        }
+        // Transient error -- NACK with requeue.
+        ch.Nack(delivery.DeliveryTag, false, true)
+        return
+    }
+    // ...
+}
+```
+
+Alternatively, consider routing to DLQ instead of requeue on shutdown, depending on business requirements.
+
+**Status**: OPEN
+
+---
+
+### P1-R1D3-04: No TLS Support -- Credentials and Messages Transmitted in Plaintext
+
+- **Seat**: S2 Security
+- **Severity**: P1
+- **Category**: Transport Security
+- **Affected Files**: `src/adapters/rabbitmq/connection.go` lines 25-44, 110-116
+
+**Evidence**:
+
+The `Config` struct (lines 25-44) has no TLS configuration field:
+```go
+type Config struct {
+    URL string
+    ReconnectMaxBackoff time.Duration
+    ReconnectBaseDelay  time.Duration
+    ChannelPoolSize     int
+    ConfirmTimeout      time.Duration
+}
+```
+
+The `DefaultDial` function (lines 110-116) uses `amqp.Dial(url)` which does NOT support TLS:
+```go
+func DefaultDial(url string) (AMQPConnection, error) {
+    conn, err := amqp.Dial(url)
+    // ...
+}
+```
+
+The `amqp091-go` library provides `amqp.DialTLS(url, tlsConfig)` for TLS connections, but the adapter has no mechanism to use it. Users can work around this via `WithDialFunc()`, but there is no documented guidance, no `TLSConfig` field, and no validation that production URLs use `amqps://`.
+
+**Impact**: AMQP credentials (in the URL) and all message payloads are transmitted in plaintext. In any non-localhost deployment, this is a significant security risk.
+
+**Fix Recommendation**:
+1. Add a `TLSConfig *tls.Config` field to `Config`.
+2. When `TLSConfig` is non-nil, use `amqp.DialTLS()` in `DefaultDial`.
+3. Log a warning if the URL scheme is `amqp://` (not `amqps://`) and `TLSConfig` is nil.
+4. Document the TLS configuration in godoc.
+
+**Status**: OPEN
+
+---
+
+### P1-R1D3-05: TryProcess Fail-Open Risks Duplicate Processing
+
+- **Seat**: S2 Security
+- **Severity**: P1
+- **Category**: Data Integrity / Idempotency
+- **Affected File**: `src/adapters/rabbitmq/consumer_base.go` lines 107-115
+
+**Evidence**:
+
+```go
+// consumer_base.go:107-115
+shouldProcess, err := cb.checker.TryProcess(ctx, idempotencyKey, cb.config.IdempotencyTTL)
+if err != nil {
+    slog.Warn("rabbitmq: idempotency check failed, proceeding with handler",
+        slog.String("event_id", entry.ID),
+        ...
+    // On error, default to processing (fail-open) to avoid dropping messages.
+    shouldProcess = true
+}
+```
+
+When the idempotency store (e.g., Redis) is unavailable, the system falls back to processing every message. This is a deliberate fail-open design. The rationale ("avoid dropping messages") is valid for availability, but it means:
+
+1. During Redis outage, ALL messages are processed regardless of deduplication. If the same message is delivered N times (e.g., due to requeue or consumer rebalancing), it will be processed N times.
+2. There is no rate limiting, circuit breaker, or metric emission on this fallback path. A sustained Redis outage will cause silent mass duplication with only a `Warn`-level log.
+3. For non-idempotent handlers (side effects like sending emails, charging payments), this can cause real damage.
+
+The test at `rabbitmq_test.go:1030-1049` confirms this behavior explicitly.
+
+**Fix Recommendation**:
+1. Emit a metric counter (e.g., `rabbitmq_idempotency_fallback_total`) so monitoring can alert on degraded dedup.
+2. Document clearly in godoc that handlers wrapped by `ConsumerBase` MUST be idempotent at the business level, because the infrastructure-level dedup is best-effort.
+3. Consider adding a `FailClosed bool` config option for critical handlers that should NACK when idempotency is unavailable.
+
+**Status**: OPEN
+
+---
+
+### P1-R1D3-06: Reconnect Leaves Stale Channel References in Subscriber
+
+- **Seat**: S2 Security
+- **Severity**: P1
+- **Category**: Message Safety / Reconnect
+- **Affected Files**: `src/adapters/rabbitmq/subscriber.go` lines 90-132, `src/adapters/rabbitmq/connection.go` lines 187-226
+
+**Evidence**:
+
+When the AMQP connection drops, `Connection.reconnectLoop()` (connection.go:213) calls `drainChannelPool()` which only drains the pool. However, channels already acquired by `Subscriber.Subscribe()` (stored in `s.channels` at line 96-97) are NOT invalidated.
+
+```go
+// subscriber.go:90-97
+ch, err := s.conn.AcquireChannel()
+if err != nil {
+    return errcode.Wrap(...)
+}
+s.mu.Lock()
+s.channels = append(s.channels, ch)
+s.mu.Unlock()
+```
+
+When the connection drops, the AMQP library closes the delivery channel (the `<-chan amqp.Delivery` returned by `ch.Consume`), which causes `consumeLoop` to exit with an error at line 156-159:
+
+```go
+// subscriber.go:154-159
+case delivery, ok := <-deliveries:
+    if !ok {
+        slog.Warn("rabbitmq: delivery channel closed, subscriber exiting", ...)
+        return errcode.New(ErrAdapterAMQPConsume, "rabbitmq: delivery channel closed")
+    }
+```
+
+The subscriber exits but does NOT re-subscribe. The caller (the goroutine that called `Subscribe`) must handle the reconnect. There is no built-in reconnect loop in the Subscriber. Any messages published between the connection drop and the caller re-subscribing are lost from this consumer's perspective (they accumulate in the queue but are not consumed).
+
+Furthermore, there is a window between reconnect and the delivery channel closing where the old channel may have outstanding unacknowledged deliveries. ACK/NACK on these deliveries will fail because the underlying AMQP channel is closed, but the errors are only logged (subscriber.go:213, 203, 186).
+
+**Fix Recommendation**:
+1. Document clearly that `Subscribe()` exits on connection loss and callers must implement a reconnect loop (or add a reconnect loop to Subscriber).
+2. Consider tracking the connection generation/epoch to detect stale channels.
+
+**Status**: OPEN
+
+---
+
+### P2-R1D3-07: Pooled Channels Re-enter Confirm Mode on Every Publish
+
+- **Seat**: S2 Security
+- **Severity**: P2
+- **Category**: Correctness / Performance
+- **Affected File**: `src/adapters/rabbitmq/publisher.go` lines 43-48
+
+**Evidence**:
+
+```go
+// publisher.go:43-48
+// Enable confirm mode.
+if err := ch.Confirm(false); err != nil {
+    return errcode.Wrap(ErrAdapterAMQPPublish, "rabbitmq: enable confirm mode", err)
+}
+confirmCh := ch.NotifyPublish(make(chan amqp.Confirmation, 1))
+```
+
+Every `Publish()` call acquires a channel from the pool and calls `ch.Confirm(false)` again. Per the AMQP spec, calling `confirm` on an already-confirmed channel is a no-op (the method is idempotent), but `NotifyPublish` creates a new notification channel each time. Previous notification channels from earlier publishes on the same pooled channel are orphaned, leaking goroutines if any are blocked.
+
+**Fix Recommendation**: Either mark channels as confirmed when first created (and skip re-confirmation), or do not pool channels used for confirms.
+
+**Status**: OPEN
+
+---
+
+### P2-R1D3-08: No Input Validation on Topic/QueueName Parameters
+
+- **Seat**: S2 Security
+- **Severity**: P2
+- **Category**: Input Validation
+- **Affected Files**: `src/adapters/rabbitmq/publisher.go` line 31, `src/adapters/rabbitmq/subscriber.go` line 80
+
+**Evidence**:
+
+Both `Publisher.Publish()` and `Subscriber.Subscribe()` accept arbitrary `topic` strings that are used directly as AMQP exchange names:
+
+```go
+// publisher.go:39
+ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil)
+
+// subscriber.go:105
+ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil)
+```
+
+There is no validation on the topic string. While RabbitMQ itself rejects invalid exchange names (max 255 bytes, no null characters), passing empty strings or strings with special AMQP characters could cause confusing errors. More importantly, if topic values are derived from user input anywhere in the call chain, this could allow an attacker to declare arbitrary exchanges on the broker.
+
+**Fix Recommendation**: Add basic validation (non-empty, max length, alphanumeric + dots/hyphens/underscores) on topic and queue name inputs.
+
+**Status**: OPEN
+
+---
+
+## GoCell Layering Check (S2 cross-check)
+
+| Check | Result |
+|-------|--------|
+| kernel/ imports runtime/adapters/cells? | NO -- kernel/idempotency and kernel/outbox have no such imports |
+| cells/ imports adapters/? | N/A -- adapters/rabbitmq has no cells/ dependency |
+| adapters/rabbitmq imports | `kernel/idempotency`, `kernel/outbox`, `pkg/errcode` -- CORRECT direction |
+| Cross-Cell import? | N/A |
+| CUD operations have consistency level? | NOT ANNOTATED -- consumer_base.go handles L2 events but no consistency level annotation in code |
+
+---
+
+## Prior Finding Resolution Status
+
+| Prior Finding ID | Description | Status in This Review |
+|------------------|-------------|----------------------|
+| P0-F12S01 | sanitizeURL fixed truncation leaks AMQP credentials | **CONFIRMED NOT FIXED** -- see P0-R1D3-01 |
+| P0-F12D01 | ctx cancel causes NACK+requeue on shutdown | **CONFIRMED NOT FIXED** -- see P0-R1D3-03 |
+| Issue #26 | DLQ publish failure silently ACKs original message | **CONFIRMED NOT FIXED** -- see P0-R1D3-02 |
+
+---
+
+## Findings Summary
+
+| ID | Severity | Category | File | Status |
+|----|----------|----------|------|--------|
+| P0-R1D3-01 | P0 | Credential Leakage | connection.go:372-379 | OPEN |
+| P0-R1D3-02 | P0 | Message Loss (DLQ fail -> ACK) | consumer_base.go:170-174,205-212 | OPEN |
+| P0-R1D3-03 | P0 | Requeue Storm on ctx cancel | consumer_base.go:155-159, subscriber.go:197-208 | OPEN |
+| P1-R1D3-04 | P1 | No TLS Support | connection.go:25-44,110-116 | OPEN |
+| P1-R1D3-05 | P1 | Fail-Open Idempotency | consumer_base.go:107-115 | OPEN |
+| P1-R1D3-06 | P1 | Stale Channels on Reconnect | subscriber.go:90-132, connection.go:187-226 | OPEN |
+| P2-R1D3-07 | P2 | Repeated Confirm Mode | publisher.go:43-48 | OPEN |
+| P2-R1D3-08 | P2 | No Topic/Queue Validation | publisher.go:31, subscriber.go:80 | OPEN |
+
+**Verdict**: 3 P0 findings block merge for any security-sensitive deployment. P0-R1D3-02 (DLQ publish failure -> silent ACK) is the most critical as it causes permanent, silent message loss.

--- a/docs/reviews/202604060830-R0/R1D-3-rabbitmq-testing.md
+++ b/docs/reviews/202604060830-R0/R1D-3-rabbitmq-testing.md
@@ -1,0 +1,185 @@
+# R1D-3: adapters/rabbitmq Testing Review
+
+| Field | Value |
+|---|---|
+| Reviewer Seat | S3 Test / QA |
+| Scope | `src/adapters/rabbitmq/` unit + integration tests |
+| Review basis commit | `5096d4f` |
+| Date | 2026-04-06 |
+| Verification mode | Unit tests executed via `/opt/homebrew/bin/go`; integration-tag suite not executed |
+
+---
+
+## Summary
+
+The module has broad unit-test coverage and real-broker integration tests, but the highest-risk failure paths are still unproven. In particular, the test suite does not protect the two delivery-safety regressions currently visible in code: DLQ publish failure still ACKs the original message, and shutdown/requeue behavior is not tested end to end.
+
+Observed local verification:
+- `/opt/homebrew/bin/go test ./adapters/rabbitmq/...` -> pass
+- `/opt/homebrew/bin/go test -cover ./adapters/rabbitmq/...` -> `78.7%` statement coverage
+- `-tags integration` not run in this review window
+
+**Verdict**: `BLOCKED`
+
+| Severity | Count | Notes |
+|---|---|---|
+| P0 | 2 | Message-loss and shutdown semantics are not covered |
+| P1 | 2 | Reconnect and subscribe-setup failures are largely untested |
+| P2 | 1 | Several tests overclaim coverage and rely on fixed sleeps |
+
+---
+
+## Findings
+
+### F-01 [P0] No test proves DLQ publish failure preserves the original message
+
+**Files**:
+- `src/adapters/rabbitmq/consumer_base.go:163-173`
+- `src/adapters/rabbitmq/consumer_base.go:205-212`
+- `src/adapters/rabbitmq/rabbitmq_test.go:940-1002`
+- `src/adapters/rabbitmq/integration_test.go:147-234`
+
+**Evidence**:
+
+`Wrap()` always returns `nil` after calling `deadLetter()`:
+
+```go
+cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount)
+return nil
+```
+
+But `deadLetter()` swallows publish failure:
+
+```go
+if err := cb.publisher.Publish(ctx, dlqTopic, payload); err != nil {
+    slog.Error("rabbitmq: failed to publish to DLQ", ...)
+    return
+}
+```
+
+Current tests only cover the success path where DLQ publish succeeds. There is no unit or integration case where `publisher.Publish()` fails and the caller must decide whether to ACK or NACK the original delivery.
+
+**Why it matters**:
+This is a silent message-loss path. If DLQ publish fails and the wrapper still returns `nil`, `Subscriber.processDelivery()` will ACK the original RabbitMQ delivery.
+
+**Recommendation**:
+Add one unit test with a failing mock publisher and one integration-style test that asserts the wrapper returns non-nil when DLQ publish fails, so the original message is not ACKed.
+
+**Status**: Confirmed historical plan item `#26`
+
+---
+
+### F-02 [P0] No end-to-end test covers `ConsumerBase + Subscriber` shutdown/cancel interaction
+
+**Files**:
+- `src/adapters/rabbitmq/consumer_base.go:155-159`
+- `src/adapters/rabbitmq/subscriber.go:197-208`
+- `src/adapters/rabbitmq/rabbitmq_test.go:741-781`
+- `src/adapters/rabbitmq/rabbitmq_test.go:1051-1071`
+
+**Evidence**:
+
+`ConsumerBase.Wrap()` returns `ctx.Err()` when retry backoff is interrupted:
+
+```go
+case <-ctx.Done():
+    return ctx.Err()
+```
+
+`Subscriber.processDelivery()` treats any handler error as transient and requeues:
+
+```go
+if err := handler(ctx, entry); err != nil {
+    if nackErr := ch.Nack(delivery.DeliveryTag, false, true); nackErr != nil {
+        ...
+    }
+    return
+}
+```
+
+The current suite tests these behaviors separately, but not together. There is no end-to-end case that invokes `Subscriber` with a wrapped `ConsumerBase` handler and then cancels the context during backoff.
+
+**Why it matters**:
+This is the exact path where shutdown safety, duplicate delivery, and idempotency semantics interact. Without an end-to-end test, the suite cannot prove the adapter behaves correctly during real shutdown.
+
+**Recommendation**:
+Add an integration-style unit test that wires `Subscriber.processDelivery()` to a `ConsumerBase.Wrap()` handler, cancels context during retry backoff, and asserts the final ACK/NACK decision explicitly.
+
+**Status**: Confirms the earlier `ctx cancel -> NACK+requeue` risk remains unverified
+
+---
+
+### F-03 [P1] Reconnect logic is barely tested
+
+**Files**:
+- `src/adapters/rabbitmq/connection.go:187-259`
+- `src/adapters/rabbitmq/rabbitmq_test.go:315-438`
+- `src/adapters/rabbitmq/integration_test.go:236-250`
+
+**Evidence**:
+
+`reconnectLoop()` and `reconnectWithBackoff()` are the core reliability path, but the current tests do not simulate:
+- a `NotifyClose` event
+- repeated dial failures
+- `WaitConnected()` during disconnect/reconnect
+- a live subscriber or publisher surviving a reconnect
+
+The so-called `TestIntegration_ConnectionRecovery` only checks `Health()` and a channel acquire/release cycle. It never forces a disconnect.
+
+**Why it matters**:
+Reconnect is one of the module's core promises. An untested reconnect path is effectively unsupported in production.
+
+**Recommendation**:
+Add mock-dial tests for disconnect and re-dial behavior, then add one real-broker recovery test that forces a disconnect and verifies publish/subscribe resumes afterward.
+
+**Status**: Confirmed historical reconnect test gap
+
+---
+
+### F-04 [P1] Subscribe setup failure matrix is uncovered
+
+**Files**:
+- `src/adapters/rabbitmq/subscriber.go:90-123`
+- `src/adapters/rabbitmq/rabbitmq_test.go:639-848`
+
+**Evidence**:
+
+After `AcquireChannel()`, `Subscribe()` can fail at five setup steps:
+- `Qos`
+- `ExchangeDeclare`
+- `QueueDeclare`
+- `QueueBind`
+- `Consume`
+
+The current tests cover success, unmarshal failure, handler failure, default queue name, closed subscriber, and closed delivery channel, but none of those setup failures.
+
+**Why it matters**:
+Consumer bootstrap failures are the path most likely to leak channels, return the wrong error code, or leave the subscriber in a partially initialized state.
+
+**Recommendation**:
+Extend `mockChannel` with failure injection for each setup call and add table-driven tests for all five branches.
+
+**Status**: New
+
+---
+
+### F-05 [P2] Some tests overstate their coverage and rely on fixed sleeps
+
+**Files**:
+- `src/adapters/rabbitmq/integration_test.go:147-234`
+- `src/adapters/rabbitmq/integration_test.go:183-184`
+- `src/adapters/rabbitmq/rabbitmq_test.go:675-677`
+- `src/adapters/rabbitmq/rabbitmq_test.go:726-727`
+- `src/adapters/rabbitmq/rabbitmq_test.go:769-770`
+
+**Evidence**:
+
+`TestIntegration_ConsumerBaseRetry` claims to validate retry + DLQ with real infrastructure, but it calls the wrapped handler directly and bypasses the RabbitMQ ACK/NACK path entirely. Several tests also rely on `time.Sleep(50ms)` / `time.Sleep(500ms)` for synchronization.
+
+**Why it matters**:
+These tests create a false sense of safety around the hardest delivery paths and may become flaky under load.
+
+**Recommendation**:
+Rename tests to match their real scope or extend them to cover the broker-driven path, and replace fixed sleeps with ready channels or polling assertions.
+
+**Status**: New

--- a/src/adapters/postgres/integration_test.go
+++ b/src/adapters/postgres/integration_test.go
@@ -14,9 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // setupPostgres starts a PostgreSQL container via testcontainers and returns a
@@ -31,10 +29,7 @@ func setupPostgres(t *testing.T) (*Pool, func()) {
 		tcpostgres.WithDatabase("test"),
 		tcpostgres.WithUsername("test"),
 		tcpostgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).WithStartupTimeout(30*time.Second),
-		),
+		tcpostgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err, "failed to start postgres container")
 

--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -54,9 +54,12 @@ type OutboxRelay struct {
 	pub    outbox.Publisher
 	config RelayConfig
 
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
-	once   sync.Once
+	// mu protects lifecycle state shared by Start and Stop.
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	running bool
+	wg      sync.WaitGroup
 }
 
 // NewOutboxRelay creates an OutboxRelay that polls from db and publishes via pub.
@@ -84,9 +87,31 @@ func NewOutboxRelay(db relayDB, pub outbox.Publisher, cfg RelayConfig) *OutboxRe
 // Start begins the relay polling loop and cleanup goroutine. It blocks until
 // ctx is cancelled or Stop is called.
 func (r *OutboxRelay) Start(ctx context.Context) error {
-	ctx, r.cancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
 
+	r.mu.Lock()
+	if r.running {
+		r.mu.Unlock()
+		cancel()
+		return errcode.New(ErrAdapterPGConnect, "outbox relay already started")
+	}
+	r.running = true
+	r.cancel = cancel
+	r.done = done
 	r.wg.Add(2)
+	r.mu.Unlock()
+
+	defer func() {
+		r.wg.Wait()
+
+		r.mu.Lock()
+		r.cancel = nil
+		r.done = nil
+		r.running = false
+		close(done)
+		r.mu.Unlock()
+	}()
 
 	go func() {
 		defer r.wg.Done()
@@ -113,17 +138,18 @@ func (r *OutboxRelay) Start(ctx context.Context) error {
 // It respects the caller's context deadline: if ctx expires before goroutines
 // finish, Stop returns an error instead of blocking indefinitely.
 func (r *OutboxRelay) Stop(ctx context.Context) error {
-	r.once.Do(func() {
-		if r.cancel != nil {
-			r.cancel()
-		}
-	})
+	r.mu.Lock()
+	cancel := r.cancel
+	done := r.done
+	r.cancel = nil
+	r.mu.Unlock()
 
-	done := make(chan struct{})
-	go func() {
-		r.wg.Wait()
-		close(done)
-	}()
+	if cancel != nil {
+		cancel()
+	}
+	if done == nil {
+		return nil
+	}
 
 	select {
 	case <-done:

--- a/src/adapters/postgres/outbox_relay_test.go
+++ b/src/adapters/postgres/outbox_relay_test.go
@@ -14,6 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func waitForRelayRunning(t *testing.T, relay *OutboxRelay) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		relay.mu.Lock()
+		defer relay.mu.Unlock()
+		return relay.running && relay.cancel != nil && relay.done != nil
+	}, time.Second, 5*time.Millisecond)
+}
+
 func TestOutboxRelay_StartStop(t *testing.T) {
 	db := &mockDBTX{}
 	pub := &mockPublisher{}
@@ -22,21 +32,78 @@ func TestOutboxRelay_StartStop(t *testing.T) {
 
 	relay := NewOutboxRelay(db, pub, cfg)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
+	startCtx, startCancel := context.WithCancel(context.Background())
+	defer startCancel()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- relay.Start(ctx)
+		errCh <- relay.Start(startCtx)
 	}()
 
-	// Wait for context to expire, then stop.
-	<-ctx.Done()
-	err := relay.Stop(context.Background())
+	waitForRelayRunning(t, relay)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+	defer stopCancel()
+
+	err := relay.Stop(stopCtx)
 	require.NoError(t, err)
 
 	startErr := <-errCh
 	assert.NoError(t, startErr, "Start should return nil on graceful stop per worker.Worker contract")
+}
+
+func TestOutboxRelay_StartStop_RaceRegression(t *testing.T) {
+	for i := 0; i < 25; i++ {
+		db := &mockDBTX{}
+		pub := &mockPublisher{}
+		cfg := DefaultRelayConfig()
+		cfg.PollInterval = 10 * time.Millisecond
+
+		relay := NewOutboxRelay(db, pub, cfg)
+
+		startCtx, startCancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- relay.Start(startCtx)
+		}()
+
+		waitForRelayRunning(t, relay)
+
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+		err := relay.Stop(stopCtx)
+		stopCancel()
+		startCancel()
+
+		require.NoErrorf(t, err, "iteration %d", i)
+		require.NoErrorf(t, <-errCh, "iteration %d", i)
+	}
+}
+
+func TestOutboxRelay_CanRestartAfterStop(t *testing.T) {
+	db := &mockDBTX{}
+	pub := &mockPublisher{}
+	cfg := DefaultRelayConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+
+	relay := NewOutboxRelay(db, pub, cfg)
+
+	for i := 0; i < 2; i++ {
+		startCtx, startCancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- relay.Start(startCtx)
+		}()
+
+		waitForRelayRunning(t, relay)
+
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+		err := relay.Stop(stopCtx)
+		stopCancel()
+		startCancel()
+
+		require.NoErrorf(t, err, "iteration %d", i)
+		require.NoErrorf(t, <-errCh, "iteration %d", i)
+	}
 }
 
 func TestOutboxRelay_PollOnce_NoEntries(t *testing.T) {
@@ -251,8 +318,7 @@ func TestOutboxRelay_Stop_RespectsCallerTimeout(t *testing.T) {
 		errCh <- relay.Start(startCtx)
 	}()
 
-	// Give the relay time to start.
-	time.Sleep(100 * time.Millisecond)
+	waitForRelayRunning(t, relay)
 
 	// Cancel start context to trigger shutdown of loops.
 	startCancel()
@@ -286,7 +352,7 @@ func TestOutboxRelay_Stop_SucceedsWithAmpleTimeout(t *testing.T) {
 		errCh <- relay.Start(startCtx)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	waitForRelayRunning(t, relay)
 	startCancel()
 
 	// Give plenty of time to stop.
@@ -338,9 +404,9 @@ type mockRelayTx struct {
 	db *mockDBTX
 }
 
-func (t *mockRelayTx) Begin(_ context.Context) (pgx.Tx, error)   { return t, nil }
-func (t *mockRelayTx) Commit(_ context.Context) error             { return nil }
-func (t *mockRelayTx) Rollback(_ context.Context) error           { return nil }
+func (t *mockRelayTx) Begin(_ context.Context) (pgx.Tx, error) { return t, nil }
+func (t *mockRelayTx) Commit(_ context.Context) error          { return nil }
+func (t *mockRelayTx) Rollback(_ context.Context) error        { return nil }
 func (t *mockRelayTx) CopyFrom(_ context.Context, _ pgx.Identifier, _ []string, _ pgx.CopyFromSource) (int64, error) {
 	return 0, nil
 }
@@ -388,13 +454,13 @@ func (r *mockRows) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *mockRows) Close()                                         {}
-func (r *mockRows) Err() error                                     { return nil }
-func (r *mockRows) CommandTag() pgconn.CommandTag                   { return pgconn.NewCommandTag("") }
-func (r *mockRows) FieldDescriptions() []pgconn.FieldDescription    { return nil }
-func (r *mockRows) Values() ([]any, error)                         { return nil, nil }
-func (r *mockRows) RawValues() [][]byte                            { return nil }
-func (r *mockRows) Conn() *pgx.Conn                                { return nil }
+func (r *mockRows) Close()                                       {}
+func (r *mockRows) Err() error                                   { return nil }
+func (r *mockRows) CommandTag() pgconn.CommandTag                { return pgconn.NewCommandTag("") }
+func (r *mockRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *mockRows) Values() ([]any, error)                       { return nil, nil }
+func (r *mockRows) RawValues() [][]byte                          { return nil }
+func (r *mockRows) Conn() *pgx.Conn                              { return nil }
 
 type publishCall struct {
 	topic   string

--- a/src/adapters/rabbitmq/connection.go
+++ b/src/adapters/rabbitmq/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"math"
+	"net/url"
 	"sync"
 	"time"
 
@@ -368,12 +369,18 @@ func (c *Connection) WaitConnected(ctx context.Context) error {
 	}
 }
 
-// sanitizeURL redacts the password from the AMQP URL for logging.
-func sanitizeURL(url string) string {
-	// Simple approach: just indicate the host portion.
-	// In production, parse the URL and redact credentials.
-	if len(url) > 10 {
-		return url[:10] + "***"
+// sanitizeURL redacts credentials from the AMQP URL for safe logging.
+func sanitizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "amqp://***"
 	}
-	return "***"
+	if u.User != nil {
+		u.User = nil
+		// Rebuild with redacted placeholder to avoid URL-encoding of special chars.
+		host := u.Host
+		u.Host = ""
+		return u.Scheme + "://***:***@" + host + u.RequestURI()
+	}
+	return u.String()
 }

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -131,18 +132,27 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 			}
 
 			// Check if this is a permanent error.
-			if _, ok := lastErr.(*PermanentError); ok {
+			var permErr *PermanentError
+			if errors.As(lastErr, &permErr) {
 				slog.Warn("rabbitmq: permanent error, routing to DLQ",
 					slog.String("event_id", entry.ID),
 					slog.String("topic", topic),
 					slog.String("consumer_group", cb.config.ConsumerGroup),
 					slog.String("error", lastErr.Error()))
-				cb.deadLetter(ctx, topic, entry, lastErr, attempt+1)
+				if dlqErr := cb.deadLetter(ctx, topic, entry, lastErr, attempt+1); dlqErr != nil {
+					// DLQ publish failed — return error so Subscriber NACKs with requeue.
+					return fmt.Errorf("rabbitmq: DLQ publish failed for permanent error: %w", dlqErr)
+				}
 				return nil // Return nil to ACK the original message.
 			}
 
 			// Transient error — backoff before retry.
 			if attempt < cb.config.RetryCount-1 {
+				// Early exit on shutdown to avoid blocking during backoff.
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
 				delay := cb.config.RetryBaseDelay * (1 << attempt)
 				slog.Warn("rabbitmq: transient error, retrying",
 					slog.String("event_id", entry.ID),
@@ -167,7 +177,10 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 			slog.String("consumer_group", cb.config.ConsumerGroup),
 			slog.Int("retry_count", cb.config.RetryCount),
 			slog.String("error", lastErr.Error()))
-		cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount)
+		if dlqErr := cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount); dlqErr != nil {
+			// DLQ publish failed — return error so Subscriber NACKs with requeue.
+			return fmt.Errorf("rabbitmq: DLQ publish failed after retry exhaustion: %w", dlqErr)
+		}
 
 		// Return nil to ACK the original message (it's been DLQ'd).
 		return nil
@@ -176,7 +189,9 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 
 // deadLetter routes a failed message to the dead-letter queue.
 // It publishes the original entry with x-death metadata to the DLQ topic.
-func (cb *ConsumerBase) deadLetter(ctx context.Context, topic string, entry outbox.Entry, originalErr error, retryCount int) {
+// Returns an error if the DLQ publish fails, so the caller can NACK with requeue
+// instead of silently ACKing and losing the message.
+func (cb *ConsumerBase) deadLetter(ctx context.Context, topic string, entry outbox.Entry, originalErr error, retryCount int) error {
 	dlqTopic := cb.config.DLQTopic
 	if dlqTopic == "" {
 		dlqTopic = topic + ".dlq"
@@ -199,7 +214,7 @@ func (cb *ConsumerBase) deadLetter(ctx context.Context, topic string, entry outb
 			slog.String("event_id", entry.ID),
 			slog.String("topic", topic),
 			slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("marshal DLQ entry: %w", err)
 	}
 
 	if err := cb.publisher.Publish(ctx, dlqTopic, payload); err != nil {
@@ -209,7 +224,7 @@ func (cb *ConsumerBase) deadLetter(ctx context.Context, topic string, entry outb
 			slog.String("dlq_topic", dlqTopic),
 			slog.String("error", err.Error()),
 			slog.Int("retry_count", retryCount))
-		return
+		return fmt.Errorf("publish to DLQ topic %s: %w", dlqTopic, err)
 	}
 
 	// T25: DLQ observability — log every dead-letter routing.
@@ -220,4 +235,5 @@ func (cb *ConsumerBase) deadLetter(ctx context.Context, topic string, entry outb
 		slog.String("consumer_group", cb.config.ConsumerGroup),
 		slog.String("error", originalErr.Error()),
 		slog.Int("retry_count", retryCount))
+	return nil
 }

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -90,6 +90,16 @@ func NewConsumerBase(checker idempotency.Checker, publisher outbox.Publisher, co
 	}
 }
 
+// AsMiddleware returns a TopicHandlerMiddleware that applies this
+// ConsumerBase's idempotency/retry/DLQ wrapping to any handler.
+// It can be used with SubscriberWithMiddleware to transparently inject
+// ConsumerBase behavior into a raw Subscriber pipeline.
+func (cb *ConsumerBase) AsMiddleware() outbox.TopicHandlerMiddleware {
+	return func(topic string, next func(context.Context, outbox.Entry) error) func(context.Context, outbox.Entry) error {
+		return cb.Wrap(topic, next)
+	}
+}
+
 // Wrap returns a handler function that wraps the given business handler with
 // idempotency checking, retry with exponential backoff, and DLQ routing.
 //
@@ -228,7 +238,8 @@ func (cb *ConsumerBase) deadLetter(ctx context.Context, topic string, entry outb
 	}
 
 	// T25: DLQ observability — log every dead-letter routing.
-	slog.Error("rabbitmq: message routed to dead letter queue",
+	// Warn (not Error): successful DLQ routing is expected behavior for permanent/exhausted errors.
+	slog.Warn("rabbitmq: message routed to dead letter queue",
 		slog.String("event_id", entry.ID),
 		slog.String("topic", topic),
 		slog.String("dlq_topic", dlqTopic),

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -150,7 +150,14 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 					slog.String("consumer_group", cb.config.ConsumerGroup),
 					slog.String("error", lastErr.Error()))
 				if dlqErr := cb.deadLetter(ctx, topic, entry, lastErr, attempt+1); dlqErr != nil {
-					// DLQ publish failed — return error so Subscriber NACKs with requeue.
+					// DLQ publish failed — release idempotency key so redelivery
+					// can re-enter business logic, then return error for NACK+requeue.
+					if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
+						slog.Error("rabbitmq: failed to release idempotency key",
+							slog.String("event_id", entry.ID),
+							slog.String("key", idempotencyKey),
+							slog.String("error", relErr.Error()))
+					}
 					return fmt.Errorf("rabbitmq: DLQ publish failed for permanent error: %w", dlqErr)
 				}
 				return nil // Return nil to ACK the original message.
@@ -159,7 +166,9 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 			// Transient error — backoff before retry.
 			if attempt < cb.config.RetryCount-1 {
 				// Early exit on shutdown to avoid blocking during backoff.
+				// Release idempotency key so redelivery can re-process.
 				if ctx.Err() != nil {
+					_ = cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey)
 					return ctx.Err()
 				}
 
@@ -175,6 +184,7 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 				select {
 				case <-time.After(delay):
 				case <-ctx.Done():
+					_ = cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey)
 					return ctx.Err()
 				}
 			}
@@ -188,7 +198,14 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 			slog.Int("retry_count", cb.config.RetryCount),
 			slog.String("error", lastErr.Error()))
 		if dlqErr := cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount); dlqErr != nil {
-			// DLQ publish failed — return error so Subscriber NACKs with requeue.
+			// DLQ publish failed — release idempotency key so redelivery
+			// can re-enter business logic, then return error for NACK+requeue.
+			if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
+				slog.Error("rabbitmq: failed to release idempotency key",
+					slog.String("event_id", entry.ID),
+					slog.String("key", idempotencyKey),
+					slog.String("error", relErr.Error()))
+			}
 			return fmt.Errorf("rabbitmq: DLQ publish failed after retry exhaustion: %w", dlqErr)
 		}
 

--- a/src/adapters/rabbitmq/integration_test.go
+++ b/src/adapters/rabbitmq/integration_test.go
@@ -264,3 +264,7 @@ func (n *noopChecker) MarkProcessed(_ context.Context, _ string, _ time.Duration
 func (n *noopChecker) TryProcess(_ context.Context, _ string, _ time.Duration) (bool, error) {
 	return true, nil
 }
+
+func (n *noopChecker) Release(_ context.Context, _ string) error {
+	return nil
+}

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -475,14 +476,47 @@ func TestSanitizeURL(t *testing.T) {
 		url      string
 		expected string
 	}{
-		{name: "long URL", url: "amqp://guest:guest@localhost:5672/", expected: "amqp://gue***"},
-		{name: "short URL", url: "amqp://x", expected: "***"},
+		{
+			name:     "full credentials redacted",
+			url:      "amqp://guest:guest@localhost:5672/",
+			expected: "amqp://***:***@localhost:5672/",
+		},
+		{
+			name:     "username only redacted",
+			url:      "amqp://admin@localhost:5672/",
+			expected: "amqp://***:***@localhost:5672/",
+		},
+		{
+			name:     "no credentials unchanged",
+			url:      "amqp://localhost:5672/",
+			expected: "amqp://localhost:5672/",
+		},
+		{
+			name:     "with vhost",
+			url:      "amqp://user:pass@rabbit.example.com:5672/production",
+			expected: "amqp://***:***@rabbit.example.com:5672/production",
+		},
+		{
+			name:     "empty string returns empty",
+			url:      "",
+			expected: "",
+		},
+		{
+			name:     "amqps scheme with credentials",
+			url:      "amqps://user:secret@secure.host:5671/",
+			expected: "amqps://***:***@secure.host:5671/",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := sanitizeURL(tt.url)
 			assert.Equal(t, tt.expected, result)
+			// Verify no real credentials appear in sanitized output.
+			assert.NotContains(t, result, "guest")
+			assert.NotContains(t, result, "admin")
+			assert.NotContains(t, result, "secret")
+			assert.NotContains(t, result, ":pass@")
 		})
 	}
 }
@@ -1077,4 +1111,134 @@ func TestPermanentError(t *testing.T) {
 	assert.Contains(t, pe.Error(), "permanent")
 	assert.Contains(t, pe.Error(), "bad data")
 	assert.Equal(t, inner, pe.Unwrap())
+}
+
+// --- P0 #5: DLQ publish failure must propagate error (not silently ACK) ---
+
+func TestConsumerBase_Wrap_DLQPublishFails_RetryExhausted_ReturnsError(t *testing.T) {
+	checker := newMockIdempotencyChecker()
+	pub := newMockPublisher()
+	pub.err = errors.New("DLQ broker down")
+
+	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryCount:     1,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+		return errors.New("always fails")
+	})
+
+	entry := outbox.Entry{ID: "evt-dlq-fail-001", EventType: "test.fail"}
+	err := handler(context.Background(), entry)
+	// When DLQ publish fails, Wrap must return an error so subscriber NACKs with requeue.
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "DLQ publish failed after retry exhaustion")
+	assert.Contains(t, err.Error(), "DLQ broker down")
+}
+
+func TestConsumerBase_Wrap_DLQPublishFails_PermanentError_ReturnsError(t *testing.T) {
+	checker := newMockIdempotencyChecker()
+	pub := newMockPublisher()
+	pub.err = errors.New("DLQ broker down")
+
+	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryCount:     3,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+		return NewPermanentError(errors.New("bad payload"))
+	})
+
+	entry := outbox.Entry{ID: "evt-dlq-fail-002", EventType: "test.permanent"}
+	err := handler(context.Background(), entry)
+	// When DLQ publish fails for a permanent error, Wrap must return an error.
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "DLQ publish failed for permanent error")
+	assert.Contains(t, err.Error(), "DLQ broker down")
+}
+
+// --- Extra fix: wrapped PermanentError detected via errors.As ---
+
+func TestConsumerBase_Wrap_WrappedPermanentError_DetectedByErrorsAs(t *testing.T) {
+	checker := newMockIdempotencyChecker()
+	pub := newMockPublisher()
+
+	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryCount:     3,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	callCount := 0
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+		callCount++
+		// Wrap PermanentError inside fmt.Errorf — the old type assertion would miss this.
+		return fmt.Errorf("handler context: %w", NewPermanentError(errors.New("unmarshal failed")))
+	})
+
+	entry := outbox.Entry{ID: "evt-wrapped-perm", EventType: "test.wrapped"}
+	err := handler(context.Background(), entry)
+	assert.NoError(t, err) // Should return nil because message was DLQ'd.
+	assert.Equal(t, 1, callCount) // Should not retry — permanent error detected on first attempt.
+
+	// Verify DLQ message was published.
+	pub.mu.Lock()
+	require.Len(t, pub.messages, 1)
+	assert.Equal(t, "test.topic.dlq", pub.messages[0].topic)
+	pub.mu.Unlock()
+}
+
+// --- P0 #7: ctx cancel → NACK without requeue (no requeue storm) ---
+
+func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithoutRequeue(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	entry := outbox.Entry{ID: "evt-ctx-cancel", EventType: "test.cancel"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	handler := func(_ context.Context, e outbox.Entry) error {
+		// Simulate ctx cancel happening before/during handler.
+		cancel()
+		return errors.New("transient error during shutdown")
+	}
+
+	go func() {
+		ch.consumeDeliveries <- amqp.Delivery{
+			DeliveryTag: 42,
+			Body:        entryBytes,
+		}
+		// Give time for processing then close deliveries to exit.
+		time.Sleep(100 * time.Millisecond)
+		close(ch.consumeDeliveries)
+	}()
+
+	_ = sub.Subscribe(ctx, "test.topic", handler)
+
+	// Wait briefly for async processing.
+	time.Sleep(50 * time.Millisecond)
+
+	ch.mu.Lock()
+	assert.True(t, ch.nackCalled, "should NACK the delivery")
+	assert.False(t, ch.nackRequeue, "should NACK without requeue when ctx is cancelled")
+	assert.Equal(t, uint64(42), ch.nackTag)
+	ch.mu.Unlock()
+
+	_ = sub.Close()
 }

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -221,11 +221,13 @@ func (m *mockConnection) Close() error {
 // --- Mock Idempotency Checker ---
 
 type mockIdempotencyChecker struct {
-	mu          sync.Mutex
-	processed   map[string]bool
-	checkErr    error
-	markErr     error
-	tryProcErr  error
+	mu           sync.Mutex
+	processed    map[string]bool
+	checkErr     error
+	markErr      error
+	tryProcErr   error
+	releaseErr   error
+	releaseCalls []string
 }
 
 func newMockIdempotencyChecker() *mockIdempotencyChecker {
@@ -264,6 +266,17 @@ func (m *mockIdempotencyChecker) TryProcess(_ context.Context, key string, _ tim
 	}
 	m.processed[key] = true
 	return true, nil
+}
+
+func (m *mockIdempotencyChecker) Release(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseCalls = append(m.releaseCalls, key)
+	if m.releaseErr != nil {
+		return m.releaseErr
+	}
+	delete(m.processed, key)
+	return nil
 }
 
 // Compile-time interface checks.

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -1628,9 +1628,9 @@ func TestConsumerBase_Wrap_WrappedPermanentError_DetectedByErrorsAs(t *testing.T
 	pub.mu.Unlock()
 }
 
-// --- P0 #7: ctx cancel → NACK without requeue (no requeue storm) ---
+// --- P0 #7: ctx cancel → NACK with requeue (conservative shutdown) ---
 
-func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithoutRequeue(t *testing.T) {
+func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithRequeue(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 
 	ch := newMockChannel()
@@ -1672,7 +1672,7 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithoutRequeue(t *testing.T
 
 	ch.mu.Lock()
 	assert.True(t, ch.nackCalled, "should NACK the delivery")
-	assert.False(t, ch.nackRequeue, "should NACK without requeue when ctx is cancelled")
+	assert.True(t, ch.nackRequeue, "should NACK with requeue when ctx is cancelled — without DLX, requeue=false would discard the message")
 	assert.Equal(t, uint64(42), ch.nackTag)
 	ch.mu.Unlock()
 

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -35,9 +35,11 @@ type mockChannel struct {
 	confirmCalled bool
 	confirmErr    error
 
-	exchangesDeclared []string
-	queuesDeclared    []string
-	queueBindings     []string
+	exchangesDeclared  []string
+	exchangeDeclareErr error
+	queuesDeclared     []string
+	queueDeclareArgs   []amqp.Table
+	queueBindings      []string
 
 	notifyPublishCh chan amqp.Confirmation
 
@@ -105,6 +107,9 @@ func (m *mockChannel) NotifyPublish(confirm chan amqp.Confirmation) chan amqp.Co
 func (m *mockChannel) ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.exchangeDeclareErr != nil {
+		return m.exchangeDeclareErr
+	}
 	m.exchangesDeclared = append(m.exchangesDeclared, name)
 	return nil
 }
@@ -113,6 +118,7 @@ func (m *mockChannel) QueueDeclare(name string, durable, autoDelete, exclusive, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.queuesDeclared = append(m.queuesDeclared, name)
+	m.queueDeclareArgs = append(m.queueDeclareArgs, args)
 	return amqp.Queue{Name: name}, nil
 }
 
@@ -155,6 +161,10 @@ type mockConnection struct {
 	nextCh   *mockChannel
 	chanErr  error
 
+	// channelQueue provides channels in FIFO order. When non-nil and non-empty,
+	// Channel() pops from the front. Falls back to nextCh / newMockChannel.
+	channelQueue []*mockChannel
+
 	notifyCloseCh chan *amqp.Error
 	isClosed      bool
 	closeErr      error
@@ -171,6 +181,12 @@ func (m *mockConnection) Channel() (AMQPChannel, error) {
 	defer m.mu.Unlock()
 	if m.chanErr != nil {
 		return nil, m.chanErr
+	}
+	if len(m.channelQueue) > 0 {
+		ch := m.channelQueue[0]
+		m.channelQueue = m.channelQueue[1:]
+		m.channels = append(m.channels, ch)
+		return ch, nil
 	}
 	if m.nextCh != nil {
 		ch := m.nextCh
@@ -858,7 +874,425 @@ func TestSubscriber_Subscribe_AfterClose(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_SUBSCRIBE")
 }
 
-func TestSubscriber_DeliveryChannelClosed(t *testing.T) {
+func TestSubscriber_DeliveryChannelClosed_TriggersReconnect(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	// First channel — will be closed to simulate connection loss.
+	ch1 := newMockChannel()
+	// Second channel — will be used after reconnect.
+	ch2 := newMockChannel()
+
+	// Use channelQueue for deterministic FIFO ordering: ch1 first, then ch2.
+	mockConn.mu.Lock()
+	mockConn.channelQueue = []*mockChannel{ch1, ch2}
+	mockConn.nextCh = nil
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// The subscribe loop will:
+	// 1. subscribeOnce with ch1 -> delivery channel closes -> error
+	// 2. WaitConnected (already connected) -> subscribeOnce with ch2
+	// 3. Handler processes message, then we cancel ctx to exit cleanly.
+	go func() {
+		// Close ch1's delivery channel to simulate connection loss.
+		time.Sleep(20 * time.Millisecond)
+		close(ch1.consumeDeliveries)
+
+		// Let ch2 process one message, then cancel.
+		entry := outbox.Entry{ID: "reconnect-001", EventType: "test.reconnected"}
+		entryBytes, _ := json.Marshal(entry)
+		time.Sleep(100 * time.Millisecond)
+		ch2.consumeDeliveries <- amqp.Delivery{
+			DeliveryTag: 1,
+			Body:        entryBytes,
+		}
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	handled := make(chan string, 1)
+	handler := func(_ context.Context, e outbox.Entry) error {
+		handled <- e.ID
+		return nil
+	}
+
+	err := sub.Subscribe(ctx, "test.topic", handler)
+	assert.NoError(t, err) // Clean exit via ctx cancel.
+
+	// Verify the handler was called after reconnect.
+	select {
+	case id := <-handled:
+		assert.Equal(t, "reconnect-001", id)
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not called after reconnect")
+	}
+
+	assert.NoError(t, sub.Close())
+}
+
+func TestSubscriber_ReconnectLoop_CtxCancelledDuringWait(t *testing.T) {
+	// Test that cancelling ctx during reconnect wait exits cleanly.
+	mockConn := newMockConnection()
+	dialFunc := func(url string) (AMQPConnection, error) {
+		return mockConn, nil
+	}
+
+	c := &Connection{
+		config:      Config{URL: "amqp://test@localhost/"},
+		dial:        dialFunc,
+		channelPool: make(chan AMQPChannel, 5),
+		closeCh:     make(chan struct{}),
+		connected:   make(chan struct{}), // Never closed = never connected.
+	}
+
+	// Make AcquireChannel fail so subscribeOnce returns error, entering reconnect wait.
+	mockConn.mu.Lock()
+	mockConn.chanErr = errors.New("no connection")
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(c, SubscriberConfig{
+		QueueName:       "test-queue",
+		ShutdownTimeout: 1 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		// Cancel ctx after a short delay to unblock WaitConnected.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.NoError(t, err) // Clean exit via ctx cancel during WaitConnected.
+}
+
+func TestSubscriber_ResolveQueueName(t *testing.T) {
+	tests := []struct {
+		name          string
+		queueName     string
+		consumerGroup string
+		topic         string
+		expected      string
+	}{
+		{
+			name:      "explicit queue name takes precedence",
+			queueName: "my-queue",
+			topic:     "my.topic",
+			expected:  "my-queue",
+		},
+		{
+			name:          "consumer group derives queue name",
+			consumerGroup: "audit-cell",
+			topic:         "session.created",
+			expected:      "audit-cell.session.created",
+		},
+		{
+			name:     "fallback to topic",
+			topic:    "my.topic",
+			expected: "my.topic",
+		},
+		{
+			name:          "queue name takes precedence over consumer group",
+			queueName:     "override-queue",
+			consumerGroup: "audit-cell",
+			topic:         "session.created",
+			expected:      "override-queue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub := &Subscriber{
+				config: SubscriberConfig{
+					QueueName:     tt.queueName,
+					ConsumerGroup: tt.consumerGroup,
+				},
+			}
+			assert.Equal(t, tt.expected, sub.resolveQueueName(tt.topic))
+		})
+	}
+}
+
+func TestSubscriber_TrackUntrackChannel(t *testing.T) {
+	sub := &Subscriber{
+		closeCh: make(chan struct{}),
+	}
+
+	ch1 := newMockChannel()
+	ch2 := newMockChannel()
+	ch3 := newMockChannel()
+
+	sub.trackChannel(ch1)
+	sub.trackChannel(ch2)
+	sub.trackChannel(ch3)
+
+	sub.mu.Lock()
+	assert.Len(t, sub.channels, 3)
+	sub.mu.Unlock()
+
+	sub.untrackChannel(ch2)
+
+	sub.mu.Lock()
+	assert.Len(t, sub.channels, 2)
+	// ch2 should be removed, ch1 and ch3 should remain.
+	assert.Contains(t, sub.channels, AMQPChannel(ch1))
+	assert.Contains(t, sub.channels, AMQPChannel(ch3))
+	sub.mu.Unlock()
+
+	// Untrack a channel that is not tracked — should be a no-op.
+	sub.untrackChannel(newMockChannel())
+
+	sub.mu.Lock()
+	assert.Len(t, sub.channels, 2)
+	sub.mu.Unlock()
+}
+
+func TestSubscriber_SubscribeOnce_AcquireChannelFails(t *testing.T) {
+	mockConn := newMockConnection()
+
+	dialFunc := func(url string) (AMQPConnection, error) {
+		return mockConn, nil
+	}
+
+	conn, err := NewConnection(Config{
+		URL:             "amqp://test@localhost/",
+		ChannelPoolSize: 5,
+	}, WithDialFunc(dialFunc))
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	// Now make channel acquisition fail.
+	mockConn.mu.Lock()
+	mockConn.chanErr = errors.New("connection dead")
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		ShutdownTimeout: 1 * time.Second,
+	})
+
+	// subscribeOnce should return an error (channel acquisition failure).
+	err = sub.subscribeOnce(context.Background(), "test.topic", "test-queue",
+		func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP")
+
+	// Verify no channels are tracked (it was cleaned up).
+	sub.mu.Lock()
+	assert.Empty(t, sub.channels)
+	sub.mu.Unlock()
+}
+
+func TestSubscriber_Subscribe_ClosedDuringReconnect(t *testing.T) {
+	// Use a connection whose "connected" channel is recreated after disconnect,
+	// so WaitConnected blocks until the subscriber is closed.
+	mockConn := newMockConnection()
+	dialFunc := func(url string) (AMQPConnection, error) {
+		return mockConn, nil
+	}
+
+	// Build Connection manually so we can control the "connected" channel.
+	c := &Connection{
+		config:      Config{URL: "amqp://test@localhost/"},
+		dial:        dialFunc,
+		channelPool: make(chan AMQPChannel, 5),
+		closeCh:     make(chan struct{}),
+		connected:   make(chan struct{}),
+	}
+	// Mark as initially connected.
+	close(c.connected)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(c, SubscriberConfig{
+		QueueName:       "test-queue",
+		ShutdownTimeout: 1 * time.Second,
+	})
+
+	subscribeDone := make(chan error, 1)
+
+	go func() {
+		// Close delivery channel to trigger reconnect.
+		time.Sleep(20 * time.Millisecond)
+		close(ch.consumeDeliveries)
+
+		// Simulate disconnection: re-create the connected channel so WaitConnected blocks.
+		time.Sleep(10 * time.Millisecond)
+		c.mu.Lock()
+		c.connected = make(chan struct{})
+		c.mu.Unlock()
+
+		// Close subscriber while WaitConnected is blocking.
+		// The derived context in Subscribe should be cancelled by closeCh, unblocking WaitConnected.
+		time.Sleep(30 * time.Millisecond)
+		_ = sub.Close()
+	}()
+
+	go func() {
+		subscribeDone <- sub.Subscribe(context.Background(), "test.topic",
+			func(_ context.Context, _ outbox.Entry) error { return nil })
+	}()
+
+	select {
+	case err := <-subscribeDone:
+		assert.NoError(t, err) // Clean exit via subscriber close.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not exit after subscriber close")
+	}
+}
+
+// --- P0-4: ConsumerGroup-based queue naming ---
+
+func TestSubscriber_Subscribe_ConsumerGroupQueueName(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		// QueueName deliberately left empty; ConsumerGroup is set.
+		ConsumerGroup:   "audit-core",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately so Subscribe exits after setup.
+
+	err := sub.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	// Queue name should be "{ConsumerGroup}.{topic}".
+	assert.Contains(t, ch.queuesDeclared, "audit-core.session.created")
+	// Binding should reference the derived queue name.
+	assert.Contains(t, ch.queueBindings, "audit-core.session.created->session.created")
+	ch.mu.Unlock()
+}
+
+func TestSubscriber_Subscribe_ExplicitQueueName_OverridesConsumerGroup(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "my-explicit-queue",
+		ConsumerGroup:   "audit-core", // Should be ignored when QueueName is set.
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sub.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	// Explicit QueueName takes precedence over ConsumerGroup derivation.
+	assert.Contains(t, ch.queuesDeclared, "my-explicit-queue")
+	assert.NotContains(t, ch.queuesDeclared, "audit-core.session.created")
+	ch.mu.Unlock()
+}
+
+func TestSubscriber_Subscribe_NoConsumerGroup_FallsBackToTopic(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		// Both QueueName and ConsumerGroup empty — backward compat.
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sub.Subscribe(ctx, "my.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	assert.Contains(t, ch.queuesDeclared, "my.topic") // Falls back to topic name.
+	ch.mu.Unlock()
+}
+
+// --- P0-3: DLX configuration for broker-side dead letter ---
+
+func TestSubscriber_Subscribe_DLXExchange_SetsQueueArgs(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "my-dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	require.Len(t, ch.queueDeclareArgs, 1)
+	args := ch.queueDeclareArgs[0]
+	assert.Equal(t, "my-dlx", args["x-dead-letter-exchange"])
+	_, hasRoutingKey := args["x-dead-letter-routing-key"]
+	assert.False(t, hasRoutingKey, "routing key should not be set when DLXRoutingKey is empty")
+	ch.mu.Unlock()
+}
+
+func TestSubscriber_Subscribe_DLXExchangeWithRoutingKey(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "my-dlx",
+		DLXRoutingKey:   "dead-letter-key",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	require.Len(t, ch.queueDeclareArgs, 1)
+	args := ch.queueDeclareArgs[0]
+	assert.Equal(t, "my-dlx", args["x-dead-letter-exchange"])
+	assert.Equal(t, "dead-letter-key", args["x-dead-letter-routing-key"])
+	ch.mu.Unlock()
+}
+
+func TestSubscriber_Subscribe_NoDLX_NilArgs(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 
 	ch := newMockChannel()
@@ -871,14 +1305,16 @@ func TestSubscriber_DeliveryChannelClosed(t *testing.T) {
 		ShutdownTimeout: 2 * time.Second,
 	})
 
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		close(ch.consumeDeliveries)
-	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	err := sub.Subscribe(context.Background(), "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_CONSUME")
+	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	require.Len(t, ch.queueDeclareArgs, 1)
+	assert.Nil(t, ch.queueDeclareArgs[0], "queue args should be nil when DLX is not configured")
+	ch.mu.Unlock()
 }
 
 // =============================================================================
@@ -1241,4 +1677,210 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithoutRequeue(t *testing.T
 	ch.mu.Unlock()
 
 	_ = sub.Close()
+}
+
+// =============================================================================
+// ConsumerBase.AsMiddleware Tests
+// =============================================================================
+
+func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
+	checker := newMockIdempotencyChecker()
+	pub := newMockPublisher()
+
+	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+		ConsumerGroup: "mw-group",
+	})
+
+	mw := cb.AsMiddleware()
+
+	// mw should be a valid TopicHandlerMiddleware.
+	var _ outbox.TopicHandlerMiddleware = mw
+
+	handlerCalled := false
+	wrapped := mw("test.topic", func(_ context.Context, e outbox.Entry) error {
+		handlerCalled = true
+		assert.Equal(t, "evt-mw-001", e.ID)
+		return nil
+	})
+
+	entry := outbox.Entry{ID: "evt-mw-001", EventType: "test.middleware"}
+	err := wrapped(context.Background(), entry)
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled)
+
+	// Verify idempotency key was marked (ConsumerBase wrapping is active).
+	checker.mu.Lock()
+	assert.True(t, checker.processed["mw-group:evt-mw-001"])
+	checker.mu.Unlock()
+}
+
+func TestConsumerBase_AsMiddleware_Idempotency_SkipsDuplicate(t *testing.T) {
+	checker := newMockIdempotencyChecker()
+	checker.processed["mw-group:evt-mw-dup"] = true
+	pub := newMockPublisher()
+
+	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+		ConsumerGroup: "mw-group",
+	})
+
+	mw := cb.AsMiddleware()
+
+	handlerCalled := false
+	wrapped := mw("test.topic", func(_ context.Context, _ outbox.Entry) error {
+		handlerCalled = true
+		return nil
+	})
+
+	entry := outbox.Entry{ID: "evt-mw-dup"}
+	err := wrapped(context.Background(), entry)
+	assert.NoError(t, err)
+	assert.False(t, handlerCalled, "handler should be skipped for duplicate event")
+}
+
+func TestConsumerBase_AsMiddleware_RoutesToDLQ_OnPermanentError(t *testing.T) {
+	checker := newMockIdempotencyChecker()
+	pub := newMockPublisher()
+
+	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+		ConsumerGroup:  "mw-group",
+		RetryCount:     3,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	mw := cb.AsMiddleware()
+
+	wrapped := mw("orders.created", func(_ context.Context, _ outbox.Entry) error {
+		return NewPermanentError(errors.New("corrupted payload"))
+	})
+
+	entry := outbox.Entry{ID: "evt-mw-perm", EventType: "orders.created"}
+	err := wrapped(context.Background(), entry)
+	assert.NoError(t, err) // DLQ'd, returns nil.
+
+	pub.mu.Lock()
+	require.Len(t, pub.messages, 1)
+	assert.Equal(t, "orders.created.dlq", pub.messages[0].topic)
+	pub.mu.Unlock()
+}
+
+func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
+	// Integration-style test: wire AsMiddleware into SubscriberWithMiddleware.
+	checker := newMockIdempotencyChecker()
+	pub := newMockPublisher()
+
+	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+		ConsumerGroup: "integration-group",
+	})
+
+	// Use a simple recording subscriber to verify the chain works end-to-end.
+	var capturedHandler func(context.Context, outbox.Entry) error
+	innerSub := &stubSubscriber{
+		onSubscribe: func(_ context.Context, _ string, h func(context.Context, outbox.Entry) error) error {
+			capturedHandler = h
+			return nil
+		},
+	}
+
+	wrappedSub := &outbox.SubscriberWithMiddleware{
+		Inner:      innerSub,
+		Middleware: []outbox.TopicHandlerMiddleware{cb.AsMiddleware()},
+	}
+
+	var receivedEntry outbox.Entry
+	handlerCalled := false
+	handler := func(_ context.Context, e outbox.Entry) error {
+		handlerCalled = true
+		receivedEntry = e
+		return nil
+	}
+
+	err := wrappedSub.Subscribe(context.Background(), "events.test", handler)
+	assert.NoError(t, err)
+	require.NotNil(t, capturedHandler)
+
+	// Simulate an incoming entry.
+	entry := outbox.Entry{ID: "evt-integration-001", EventType: "events.test"}
+	err = capturedHandler(context.Background(), entry)
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled)
+	assert.Equal(t, "evt-integration-001", receivedEntry.ID)
+
+	// Verify idempotency was applied.
+	checker.mu.Lock()
+	assert.True(t, checker.processed["integration-group:evt-integration-001"])
+	checker.mu.Unlock()
+
+	// Calling again with the same event should be skipped.
+	handlerCalled = false
+	err = capturedHandler(context.Background(), entry)
+	assert.NoError(t, err)
+	assert.False(t, handlerCalled, "duplicate should be skipped by ConsumerBase middleware")
+}
+
+// stubSubscriber is a minimal Subscriber for integration tests.
+type stubSubscriber struct {
+	onSubscribe func(context.Context, string, func(context.Context, outbox.Entry) error) error
+}
+
+func (s *stubSubscriber) Subscribe(ctx context.Context, topic string, handler func(context.Context, outbox.Entry) error) error {
+	if s.onSubscribe != nil {
+		return s.onSubscribe(ctx, topic, handler)
+	}
+	return nil
+}
+
+func (s *stubSubscriber) Close() error { return nil }
+
+var _ outbox.Subscriber = (*stubSubscriber)(nil)
+
+// =============================================================================
+// Publisher Error Branch Tests (P1-5)
+// =============================================================================
+
+func TestPublisher_Publish_ExchangeDeclareFails(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	ch.exchangeDeclareErr = errors.New("exchange declare failed: access refused")
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	pub := NewPublisher(conn)
+
+	err := pub.Publish(context.Background(), "test.topic", []byte(`{"data":"value"}`))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_PUBLISH")
+	assert.Contains(t, err.Error(), "declare exchange")
+
+	// Verify publish was never called since exchange declare failed first.
+	ch.mu.Lock()
+	assert.False(t, ch.publishCalled)
+	ch.mu.Unlock()
+}
+
+func TestPublisher_Publish_ConfirmChannelClosed(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	pub := NewPublisher(conn)
+
+	// Close the notifyPublishCh without sending any value to simulate
+	// the confirm channel being closed (e.g., broker disconnected after publish).
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ch.mu.Lock()
+		notifyCh := ch.notifyPublishCh
+		ch.mu.Unlock()
+		close(notifyCh)
+	}()
+
+	err := pub.Publish(context.Background(), "test.topic", []byte(`{"data":"value"}`))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_CONFIRM_TIMEOUT")
+	assert.Contains(t, err.Error(), "confirm channel closed")
 }

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -22,6 +22,32 @@ import (
 // permissions) are returned to the caller immediately.
 var errSubscriptionLost = errors.New("rabbitmq: subscription lost")
 
+// isRecoverableAMQPError returns true if the error indicates a transient
+// connection/channel loss that can be recovered via reconnect. Permanent errors
+// (ACCESS_REFUSED, PRECONDITION_FAILED, channel_max exhausted) return false.
+func isRecoverableAMQPError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// amqp.ErrClosed: connection or channel was closed.
+	if errors.Is(err, amqp.ErrClosed) {
+		return true
+	}
+	// ErrAdapterAMQPConnect from AcquireChannel means the connection is nil or
+	// IsClosed — this is transient and should trigger reconnect.
+	var ecErr *errcode.Error
+	if errors.As(err, &ecErr) && ecErr.Code == ErrAdapterAMQPConnect {
+		return true
+	}
+	// AMQP protocol errors: Recover=true means the broker will restart the
+	// channel; Recover=false (ACCESS_REFUSED, PRECONDITION_FAILED) is permanent.
+	var amqpErr *amqp.Error
+	if errors.As(err, &amqpErr) {
+		return amqpErr.Recover
+	}
+	return false
+}
+
 // Compile-time interface check.
 var _ outbox.Subscriber = (*Subscriber)(nil)
 
@@ -192,9 +218,10 @@ func (s *Subscriber) subscribeOnce(
 ) error {
 	ch, err := s.conn.AcquireChannel()
 	if err != nil {
-		// Channel acquisition failure is transient (connection down) — wrap as
-		// subscription lost so the outer loop reconnects.
-		return fmt.Errorf("%w: acquire channel: %v", errSubscriptionLost, err)
+		if isRecoverableAMQPError(err) {
+			return fmt.Errorf("%w: acquire channel: %v", errSubscriptionLost, err)
+		}
+		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: acquire channel for subscribe", err)
 	}
 
 	s.trackChannel(ch)
@@ -206,16 +233,26 @@ func (s *Subscriber) subscribeOnce(
 		_ = ch.Close()
 	}
 
+	// setupErr wraps a setup-stage error. If the underlying AMQP error is
+	// recoverable (connection/channel closed mid-setup), it wraps as
+	// errSubscriptionLost so the outer loop can reconnect and re-run the
+	// full setup. Otherwise it returns a permanent error to the caller.
+	setupErr := func(msg string, code errcode.Code, err error) error {
+		cleanupCh()
+		if isRecoverableAMQPError(err) {
+			return fmt.Errorf("%w: %s: %v", errSubscriptionLost, msg, err)
+		}
+		return errcode.Wrap(code, msg, err)
+	}
+
 	// Set QoS.
 	if err := ch.Qos(s.config.PrefetchCount, 0, false); err != nil {
-		cleanupCh()
-		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: set qos", err)
+		return setupErr("rabbitmq: set qos", ErrAdapterAMQPSubscribe, err)
 	}
 
 	// Declare exchange idempotently.
 	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {
-		cleanupCh()
-		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: declare exchange", err)
+		return setupErr("rabbitmq: declare exchange", ErrAdapterAMQPSubscribe, err)
 	}
 
 	// Build queue arguments for dead-letter routing.
@@ -231,22 +268,19 @@ func (s *Subscriber) subscribeOnce(
 
 	// Declare queue.
 	if _, err = ch.QueueDeclare(queueName, true, false, false, false, queueArgs); err != nil {
-		cleanupCh()
-		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: declare queue", err)
+		return setupErr("rabbitmq: declare queue", ErrAdapterAMQPSubscribe, err)
 	}
 
 	// Bind queue to exchange.
 	if err := ch.QueueBind(queueName, "", topic, false, nil); err != nil {
-		cleanupCh()
-		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: bind queue", err)
+		return setupErr("rabbitmq: bind queue", ErrAdapterAMQPSubscribe, err)
 	}
 
 	consumerTag := fmt.Sprintf("cg-%s-%s", queueName, topic)
 
 	deliveries, err := ch.Consume(queueName, consumerTag, false, false, false, false, nil)
 	if err != nil {
-		cleanupCh()
-		return errcode.Wrap(ErrAdapterAMQPConsume, "rabbitmq: start consuming", err)
+		return setupErr("rabbitmq: start consuming", ErrAdapterAMQPConsume, err)
 	}
 
 	slog.Info("rabbitmq: subscriber started",

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -14,6 +15,12 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
+
+// errSubscriptionLost is a sentinel error returned by subscribeOnce when the
+// delivery channel is closed (broker restart, network partition). The outer
+// Subscribe loop only reconnects on this error; all other errors (topology,
+// permissions) are returned to the caller immediately.
+var errSubscriptionLost = errors.New("rabbitmq: subscription lost")
 
 // Compile-time interface check.
 var _ outbox.Subscriber = (*Subscriber)(nil)
@@ -138,6 +145,13 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler func(c
 			return nil
 		}
 
+		// Only reconnect on delivery channel lost. Topology/permission errors
+		// (ExchangeDeclare, QueueDeclare, QueueBind) are permanent — return
+		// immediately so the caller can handle them.
+		if !errors.Is(err, errSubscriptionLost) {
+			return err
+		}
+
 		// Check if we should stop retrying.
 		select {
 		case <-subCtx.Done():
@@ -178,20 +192,29 @@ func (s *Subscriber) subscribeOnce(
 ) error {
 	ch, err := s.conn.AcquireChannel()
 	if err != nil {
-		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: acquire channel for subscribe", err)
+		// Channel acquisition failure is transient (connection down) — wrap as
+		// subscription lost so the outer loop reconnects.
+		return fmt.Errorf("%w: acquire channel: %v", errSubscriptionLost, err)
 	}
 
 	s.trackChannel(ch)
 
+	// cleanupCh closes and untracks the channel. Used on early-return error
+	// paths to prevent channel leaks.
+	cleanupCh := func() {
+		s.untrackChannel(ch)
+		_ = ch.Close()
+	}
+
 	// Set QoS.
 	if err := ch.Qos(s.config.PrefetchCount, 0, false); err != nil {
-		s.untrackChannel(ch)
+		cleanupCh()
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: set qos", err)
 	}
 
 	// Declare exchange idempotently.
 	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {
-		s.untrackChannel(ch)
+		cleanupCh()
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: declare exchange", err)
 	}
 
@@ -208,13 +231,13 @@ func (s *Subscriber) subscribeOnce(
 
 	// Declare queue.
 	if _, err = ch.QueueDeclare(queueName, true, false, false, false, queueArgs); err != nil {
-		s.untrackChannel(ch)
+		cleanupCh()
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: declare queue", err)
 	}
 
 	// Bind queue to exchange.
 	if err := ch.QueueBind(queueName, "", topic, false, nil); err != nil {
-		s.untrackChannel(ch)
+		cleanupCh()
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: bind queue", err)
 	}
 
@@ -222,7 +245,7 @@ func (s *Subscriber) subscribeOnce(
 
 	deliveries, err := ch.Consume(queueName, consumerTag, false, false, false, false, nil)
 	if err != nil {
-		s.untrackChannel(ch)
+		cleanupCh()
 		return errcode.Wrap(ErrAdapterAMQPConsume, "rabbitmq: start consuming", err)
 	}
 
@@ -283,7 +306,7 @@ func (s *Subscriber) consumeLoop(
 			if !ok {
 				slog.Warn("rabbitmq: delivery channel closed, subscriber exiting",
 					slog.String("topic", topic))
-				return errcode.New(ErrAdapterAMQPConsume, "rabbitmq: delivery channel closed")
+				return fmt.Errorf("%w: delivery channel closed", errSubscriptionLost)
 			}
 
 			s.wg.Add(1)
@@ -323,15 +346,15 @@ func (s *Subscriber) processDelivery(
 	entry.Metadata["topic"] = topic
 
 	if err := handler(ctx, entry); err != nil {
-		// If the context is cancelled (shutdown), NACK without requeue to avoid
-		// requeue storm. The message will be picked up by another consumer or
-		// redelivered after the consumer reconnects.
+		// If the context is cancelled (shutdown), NACK with requeue so the broker
+		// redelivers the message to another consumer. Without DLX configured,
+		// requeue=false would silently discard the message.
 		if ctx.Err() != nil {
-			slog.Info("rabbitmq: context cancelled during handler, nacking without requeue",
+			slog.Info("rabbitmq: context cancelled during handler, nacking with requeue",
 				slog.String("topic", topic),
 				slog.String("event_id", entry.ID),
 				slog.String("error", err.Error()))
-			if nackErr := ch.Nack(delivery.DeliveryTag, false, false); nackErr != nil {
+			if nackErr := ch.Nack(delivery.DeliveryTag, false, true); nackErr != nil {
 				slog.Error("rabbitmq: nack failed",
 					slog.String("topic", topic),
 					slog.String("error", nackErr.Error()))

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -20,8 +20,25 @@ var _ outbox.Subscriber = (*Subscriber)(nil)
 
 // SubscriberConfig configures how a Subscriber consumes messages.
 type SubscriberConfig struct {
-	// QueueName is the queue to consume from. If empty, defaults to the topic name.
+	// QueueName is the queue to consume from. If set, it takes precedence over
+	// ConsumerGroup-based naming. If both QueueName and ConsumerGroup are empty,
+	// the queue name defaults to the topic name (backward compatible).
 	QueueName string
+
+	// ConsumerGroup identifies the logical consumer group. When QueueName is empty
+	// and ConsumerGroup is set, the queue name is derived as "{ConsumerGroup}.{topic}".
+	// This ensures that multiple cells subscribing to the same fanout exchange each
+	// get their own queue (fanout semantics) instead of competing on a single queue.
+	ConsumerGroup string
+
+	// DLXExchange is the dead-letter exchange name. When set, the queue is declared
+	// with x-dead-letter-exchange so that NACK(requeue=false) messages are routed
+	// to the DLX instead of being silently discarded by the broker.
+	DLXExchange string
+
+	// DLXRoutingKey is an optional routing key for dead-lettered messages.
+	// Only effective when DLXExchange is set.
+	DLXRoutingKey string
 
 	// PrefetchCount limits the number of unacknowledged messages per consumer.
 	// Default: 10.
@@ -67,8 +84,25 @@ func NewSubscriber(conn *Connection, config SubscriberConfig) *Subscriber {
 	}
 }
 
+// resolveQueueName derives the queue name from config and topic.
+// Priority: QueueName > ConsumerGroup.topic > topic (backward compat).
+func (s *Subscriber) resolveQueueName(topic string) string {
+	if s.config.QueueName != "" {
+		return s.config.QueueName
+	}
+	if s.config.ConsumerGroup != "" {
+		return s.config.ConsumerGroup + "." + topic
+	}
+	return topic
+}
+
 // Subscribe registers a handler for the given topic and blocks until ctx is
-// cancelled, the subscriber is closed, or an unrecoverable error occurs.
+// cancelled or the subscriber is closed.
+//
+// Subscribe automatically reconnects when the underlying AMQP channel is lost
+// (e.g., due to a broker restart or network partition). It waits for the
+// Connection to re-establish via WaitConnected, then re-declares the exchange,
+// queue, and binding on a fresh channel.
 //
 // The topic is used as a fanout exchange name. A queue (from SubscriberConfig
 // or defaulting to the topic) is declared and bound to the exchange.
@@ -82,37 +116,105 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler func(c
 		return errcode.New(ErrAdapterAMQPSubscribe, "rabbitmq: subscriber is closed")
 	}
 
-	queueName := s.config.QueueName
-	if queueName == "" {
-		queueName = topic
-	}
+	// Derive a context that is cancelled when either the parent ctx is done or
+	// the subscriber is closed. This ensures WaitConnected unblocks promptly on
+	// subscriber shutdown even if the parent ctx has no deadline.
+	subCtx, subCancel := context.WithCancelCause(ctx)
+	defer subCancel(nil)
+	go func() {
+		select {
+		case <-s.closeCh:
+			subCancel(fmt.Errorf("subscriber closed"))
+		case <-subCtx.Done():
+		}
+	}()
 
+	queueName := s.resolveQueueName(topic)
+
+	for {
+		err := s.subscribeOnce(subCtx, topic, queueName, handler)
+		if err == nil {
+			// Clean exit: ctx cancelled or subscriber closed.
+			return nil
+		}
+
+		// Check if we should stop retrying.
+		select {
+		case <-subCtx.Done():
+			return nil
+		default:
+		}
+		if s.closed.Load() {
+			return nil
+		}
+
+		slog.Warn("rabbitmq: subscription lost, waiting for reconnect",
+			slog.String("topic", topic),
+			slog.String("queue", queueName),
+			slog.String("error", err.Error()))
+
+		// Wait for connection recovery before re-subscribing.
+		if waitErr := s.conn.WaitConnected(subCtx); waitErr != nil {
+			// ctx cancelled or subscriber closed during wait — clean exit.
+			return nil
+		}
+
+		slog.Info("rabbitmq: resubscribing after reconnect",
+			slog.String("topic", topic),
+			slog.String("queue", queueName))
+	}
+}
+
+// subscribeOnce performs a single subscription lifecycle: acquire channel,
+// declare topology, consume, and run the consume loop.
+//
+// Returns nil for a clean exit (ctx cancelled or subscriber closed).
+// Returns a non-nil error when the delivery channel is lost (triggers reconnect
+// in the outer Subscribe loop).
+func (s *Subscriber) subscribeOnce(
+	ctx context.Context,
+	topic, queueName string,
+	handler func(context.Context, outbox.Entry) error,
+) error {
 	ch, err := s.conn.AcquireChannel()
 	if err != nil {
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: acquire channel for subscribe", err)
 	}
 
-	s.mu.Lock()
-	s.channels = append(s.channels, ch)
-	s.mu.Unlock()
+	s.trackChannel(ch)
 
 	// Set QoS.
 	if err := ch.Qos(s.config.PrefetchCount, 0, false); err != nil {
+		s.untrackChannel(ch)
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: set qos", err)
 	}
 
 	// Declare exchange idempotently.
 	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {
+		s.untrackChannel(ch)
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: declare exchange", err)
 	}
 
+	// Build queue arguments for dead-letter routing.
+	var queueArgs amqp.Table
+	if s.config.DLXExchange != "" {
+		queueArgs = amqp.Table{
+			"x-dead-letter-exchange": s.config.DLXExchange,
+		}
+		if s.config.DLXRoutingKey != "" {
+			queueArgs["x-dead-letter-routing-key"] = s.config.DLXRoutingKey
+		}
+	}
+
 	// Declare queue.
-	if _, err = ch.QueueDeclare(queueName, true, false, false, false, nil); err != nil {
+	if _, err = ch.QueueDeclare(queueName, true, false, false, false, queueArgs); err != nil {
+		s.untrackChannel(ch)
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: declare queue", err)
 	}
 
 	// Bind queue to exchange.
 	if err := ch.QueueBind(queueName, "", topic, false, nil); err != nil {
+		s.untrackChannel(ch)
 		return errcode.Wrap(ErrAdapterAMQPSubscribe, "rabbitmq: bind queue", err)
 	}
 
@@ -120,6 +222,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler func(c
 
 	deliveries, err := ch.Consume(queueName, consumerTag, false, false, false, false, nil)
 	if err != nil {
+		s.untrackChannel(ch)
 		return errcode.Wrap(ErrAdapterAMQPConsume, "rabbitmq: start consuming", err)
 	}
 
@@ -129,7 +232,32 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler func(c
 		slog.String("consumer", consumerTag),
 		slog.Int("prefetch", s.config.PrefetchCount))
 
-	return s.consumeLoop(ctx, ch, deliveries, topic, handler)
+	loopErr := s.consumeLoop(ctx, ch, deliveries, topic, handler)
+
+	// Clean up the dead channel after consumeLoop exits.
+	s.untrackChannel(ch)
+	_ = ch.Close() // Best-effort close; channel is likely already dead.
+
+	return loopErr
+}
+
+// trackChannel adds a channel to the tracked list for cleanup on Close().
+func (s *Subscriber) trackChannel(ch AMQPChannel) {
+	s.mu.Lock()
+	s.channels = append(s.channels, ch)
+	s.mu.Unlock()
+}
+
+// untrackChannel removes a channel from the tracked list.
+func (s *Subscriber) untrackChannel(ch AMQPChannel) {
+	s.mu.Lock()
+	for i, tracked := range s.channels {
+		if tracked == ch {
+			s.channels = append(s.channels[:i], s.channels[i+1:]...)
+			break
+		}
+	}
+	s.mu.Unlock()
 }
 
 func (s *Subscriber) consumeLoop(

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -195,6 +195,22 @@ func (s *Subscriber) processDelivery(
 	entry.Metadata["topic"] = topic
 
 	if err := handler(ctx, entry); err != nil {
+		// If the context is cancelled (shutdown), NACK without requeue to avoid
+		// requeue storm. The message will be picked up by another consumer or
+		// redelivered after the consumer reconnects.
+		if ctx.Err() != nil {
+			slog.Info("rabbitmq: context cancelled during handler, nacking without requeue",
+				slog.String("topic", topic),
+				slog.String("event_id", entry.ID),
+				slog.String("error", err.Error()))
+			if nackErr := ch.Nack(delivery.DeliveryTag, false, false); nackErr != nil {
+				slog.Error("rabbitmq: nack failed",
+					slog.String("topic", topic),
+					slog.String("error", nackErr.Error()))
+			}
+			return
+		}
+
 		// Handler error is a transient failure — NACK with requeue.
 		slog.Warn("rabbitmq: handler returned error, nacking with requeue",
 			slog.String("topic", topic),

--- a/src/adapters/redis/idempotency.go
+++ b/src/adapters/redis/idempotency.go
@@ -78,3 +78,15 @@ func (ic *IdempotencyChecker) TryProcess(ctx context.Context, key string, ttl ti
 	}
 	return set, nil
 }
+
+// Release removes the idempotency key so a redelivered message can be processed
+// again. This must be called when a message is requeued after TryProcess already
+// claimed the key (e.g., DLQ publish failure, shutdown).
+func (ic *IdempotencyChecker) Release(ctx context.Context, key string) error {
+	_, err := ic.rdb.Del(ctx, key).Result()
+	if err != nil {
+		return errcode.Wrap(ErrAdapterRedisDelete,
+			fmt.Sprintf("redis: idempotency release failed (key=%s)", key), err)
+	}
+	return nil
+}

--- a/src/kernel/idempotency/idempotency.go
+++ b/src/kernel/idempotency/idempotency.go
@@ -24,4 +24,9 @@ type Checker interface {
 	// Returns false if already processed (another consumer got there first).
 	// This eliminates the TOCTOU race between separate IsProcessed + MarkProcessed calls.
 	TryProcess(ctx context.Context, key string, ttl time.Duration) (bool, error)
+
+	// Release removes the idempotency key so that a redelivered message can be
+	// processed again. Must be called on requeue/shutdown paths where TryProcess
+	// already claimed the key but business logic did not complete.
+	Release(ctx context.Context, key string) error
 }

--- a/src/kernel/idempotency/idempotency_test.go
+++ b/src/kernel/idempotency/idempotency_test.go
@@ -35,6 +35,11 @@ func (m *mockChecker) TryProcess(_ context.Context, key string, _ time.Duration)
 	return true, nil
 }
 
+func (m *mockChecker) Release(_ context.Context, key string) error {
+	delete(m.processed, key)
+	return nil
+}
+
 var _ Checker = (*mockChecker)(nil)
 
 func TestCheckerInterface(t *testing.T) {

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -72,3 +72,32 @@ type Subscriber interface {
 	// Close terminates all active subscriptions and releases resources.
 	Close() error
 }
+
+// TopicHandlerMiddleware transforms an entry handler, receiving the topic name.
+// It is the event-consumer analogue of HTTP middleware.
+type TopicHandlerMiddleware func(topic string, next func(context.Context, Entry) error) func(context.Context, Entry) error
+
+// SubscriberWithMiddleware wraps a Subscriber so that every handler passed
+// to Subscribe is first wrapped by the given middleware chain.
+// Middleware is applied in order: [0] is outermost, [len-1] is innermost.
+type SubscriberWithMiddleware struct {
+	Inner      Subscriber
+	Middleware []TopicHandlerMiddleware
+}
+
+// Compile-time interface check.
+var _ Subscriber = (*SubscriberWithMiddleware)(nil)
+
+// Subscribe wraps the handler with the middleware chain, then delegates to Inner.
+func (s *SubscriberWithMiddleware) Subscribe(ctx context.Context, topic string, handler func(context.Context, Entry) error) error {
+	wrapped := handler
+	for i := len(s.Middleware) - 1; i >= 0; i-- {
+		wrapped = s.Middleware[i](topic, wrapped)
+	}
+	return s.Inner.Subscribe(ctx, topic, wrapped)
+}
+
+// Close delegates to the inner subscriber.
+func (s *SubscriberWithMiddleware) Close() error {
+	return s.Inner.Close()
+}

--- a/src/kernel/outbox/outbox_test.go
+++ b/src/kernel/outbox/outbox_test.go
@@ -72,6 +72,179 @@ func TestEntryFields(t *testing.T) {
 	assert.False(t, e.CreatedAt.IsZero())
 }
 
+// --- SubscriberWithMiddleware Tests ---
+
+// recordingSubscriber captures the handler passed to Subscribe so tests can inspect it.
+type recordingSubscriber struct {
+	subscribeCalled bool
+	subscribeTopic  string
+	capturedHandler func(context.Context, Entry) error
+	closeErr        error
+}
+
+func (r *recordingSubscriber) Subscribe(_ context.Context, topic string, handler func(context.Context, Entry) error) error {
+	r.subscribeCalled = true
+	r.subscribeTopic = topic
+	r.capturedHandler = handler
+	return nil
+}
+
+func (r *recordingSubscriber) Close() error {
+	return r.closeErr
+}
+
+var _ Subscriber = (*recordingSubscriber)(nil)
+
+func TestSubscriberWithMiddleware_InterfaceCompliance(t *testing.T) {
+	var _ Subscriber = (*SubscriberWithMiddleware)(nil)
+}
+
+func TestSubscriberWithMiddleware_NoMiddleware(t *testing.T) {
+	inner := &recordingSubscriber{}
+	sub := &SubscriberWithMiddleware{Inner: inner}
+
+	called := false
+	handler := func(_ context.Context, _ Entry) error {
+		called = true
+		return nil
+	}
+
+	err := sub.Subscribe(context.Background(), "test.topic", handler)
+	assert.NoError(t, err)
+	assert.True(t, inner.subscribeCalled)
+	assert.Equal(t, "test.topic", inner.subscribeTopic)
+
+	// Call the captured handler to verify it's the original.
+	err = inner.capturedHandler(context.Background(), Entry{})
+	assert.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestSubscriberWithMiddleware_SingleMiddleware(t *testing.T) {
+	inner := &recordingSubscriber{}
+
+	var middlewareTopic string
+	middleware := func(topic string, next func(context.Context, Entry) error) func(context.Context, Entry) error {
+		middlewareTopic = topic
+		return func(ctx context.Context, e Entry) error {
+			e.Metadata = map[string]string{"wrapped": "true"}
+			return next(ctx, e)
+		}
+	}
+
+	sub := &SubscriberWithMiddleware{
+		Inner:      inner,
+		Middleware: []TopicHandlerMiddleware{middleware},
+	}
+
+	var receivedEntry Entry
+	handler := func(_ context.Context, e Entry) error {
+		receivedEntry = e
+		return nil
+	}
+
+	err := sub.Subscribe(context.Background(), "orders.created", handler)
+	assert.NoError(t, err)
+	assert.Equal(t, "orders.created", middlewareTopic)
+
+	// Call captured handler to verify middleware was applied.
+	err = inner.capturedHandler(context.Background(), Entry{ID: "evt-1"})
+	assert.NoError(t, err)
+	assert.Equal(t, "evt-1", receivedEntry.ID)
+	assert.Equal(t, "true", receivedEntry.Metadata["wrapped"])
+}
+
+func TestSubscriberWithMiddleware_MultipleMiddleware_OrderCorrect(t *testing.T) {
+	inner := &recordingSubscriber{}
+
+	var order []string
+
+	makeMiddleware := func(name string) TopicHandlerMiddleware {
+		return func(topic string, next func(context.Context, Entry) error) func(context.Context, Entry) error {
+			return func(ctx context.Context, e Entry) error {
+				order = append(order, name+"-before")
+				err := next(ctx, e)
+				order = append(order, name+"-after")
+				return err
+			}
+		}
+	}
+
+	sub := &SubscriberWithMiddleware{
+		Inner: inner,
+		Middleware: []TopicHandlerMiddleware{
+			makeMiddleware("outer"),
+			makeMiddleware("inner"),
+		},
+	}
+
+	handler := func(_ context.Context, _ Entry) error {
+		order = append(order, "handler")
+		return nil
+	}
+
+	err := sub.Subscribe(context.Background(), "test.topic", handler)
+	assert.NoError(t, err)
+
+	err = inner.capturedHandler(context.Background(), Entry{})
+	assert.NoError(t, err)
+
+	// [0] is outermost, [len-1] is innermost.
+	assert.Equal(t, []string{
+		"outer-before",
+		"inner-before",
+		"handler",
+		"inner-after",
+		"outer-after",
+	}, order)
+}
+
+func TestSubscriberWithMiddleware_Close_DelegatesToInner(t *testing.T) {
+	inner := &recordingSubscriber{}
+	sub := &SubscriberWithMiddleware{Inner: inner}
+
+	err := sub.Close()
+	assert.NoError(t, err)
+}
+
+func TestSubscriberWithMiddleware_Close_PropagatesError(t *testing.T) {
+	inner := &recordingSubscriber{closeErr: assert.AnError}
+	sub := &SubscriberWithMiddleware{Inner: inner}
+
+	err := sub.Close()
+	assert.Error(t, err)
+	assert.Equal(t, assert.AnError, err)
+}
+
+func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
+	inner := &recordingSubscriber{}
+
+	shortCircuit := func(_ string, _ func(context.Context, Entry) error) func(context.Context, Entry) error {
+		return func(_ context.Context, _ Entry) error {
+			return assert.AnError
+		}
+	}
+
+	sub := &SubscriberWithMiddleware{
+		Inner:      inner,
+		Middleware: []TopicHandlerMiddleware{shortCircuit},
+	}
+
+	handlerCalled := false
+	handler := func(_ context.Context, _ Entry) error {
+		handlerCalled = true
+		return nil
+	}
+
+	err := sub.Subscribe(context.Background(), "test.topic", handler)
+	assert.NoError(t, err)
+
+	// Call captured handler — middleware should short-circuit.
+	err = inner.capturedHandler(context.Background(), Entry{})
+	assert.Error(t, err)
+	assert.False(t, handlerCalled)
+}
+
 func TestEntry_RoutingTopic(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

Six-role deep review of `adapters/rabbitmq` — P0/P1 fixes across 3 rounds.

**6 review reports:** architect, security, testing, kernel-guardian, codestyle, product

### Round 1 — 3 P0 fixes + bonus (`fe1aeb9`)
1. DLQ publish failure silently ACKs → `deadLetter` returns error, Wrap propagates (Issue #26)
2. sanitizeURL leaks credentials → `net/url.Parse` proper redaction
3. ctx cancel requeue storm → NACK(requeue=false) on shutdown
4. **Bonus:** PermanentError detection via `errors.As` (not direct type assertion)

### Round 2 — 3 follow-up fixes (`f6fab05`)
1. **Shutdown requeue=true**: `Nack(requeue=false)` → `Nack(requeue=true)`. Without DLX, requeue=false silently discards. ref: Watermill subscriber.go
2. **Reconnect error classification**: `errSubscriptionLost` sentinel — only reconnect on delivery channel closed, not topology/permission errors. ref: Benthos amqp09 input.go
3. **Channel leak fix**: early-return paths in `subscribeOnce` now close channels via `cleanupCh()`

### Round 3 — P0 idempotency + P1 error classification (`e079e77`)
1. **P0 idempotency release**: DLQ publish failure left idempotency key claimed → redelivered messages short-circuited as "already processed". Added `Release(ctx, key)` to `idempotency.Checker`, implemented in redis, called on all requeue/shutdown paths in consumer_base.
2. **P1 AMQP error classification**: `isRecoverableAMQPError()` helper — checks `amqp.ErrClosed`, `ErrAdapterAMQPConnect`, `amqp.Error.Recover`. Setup errors (Qos/ExchangeDeclare/QueueDeclare/QueueBind/Consume) now reconnect if recoverable, return to caller if permanent.

### CI fix (`d75819e`)
Kernel coverage gate awk parser: skip `[no statements]` lines, robust parsing.

### Supplemental postgres fix (`12bbc52`)
OutboxRelay Start/Stop lifecycle race fix + integration test stabilization.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./adapters/rabbitmq/ -count=1` passes
- [x] `go test ./adapters/redis/ -count=1` passes
- [x] `go test ./kernel/idempotency/ -count=1` passes
- [x] `go test -race ./adapters/rabbitmq/ ./adapters/redis/ ./kernel/idempotency/ -count=1` passes
- [x] `go test -count=1 -race ./adapters/postgres`

🤖 Generated with [Claude Code](https://claude.com/claude-code)