### PR TITLE
fix: outbox relay fail-fast + startedCh handshake (R-01/R-02)

### DIFF
--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -55,11 +55,12 @@ type OutboxRelay struct {
 	config RelayConfig
 
 	// mu protects lifecycle state shared by Start and Stop.
-	mu      sync.Mutex
-	cancel  context.CancelFunc
-	done    chan struct{}
-	running bool
-	wg      sync.WaitGroup
+	mu        sync.Mutex
+	cancel    context.CancelFunc
+	done      chan struct{}
+	startedCh chan struct{} // closed once Start() has published lifecycle fields
+	running   bool
+	wg        sync.WaitGroup
 }
 
 // NewOutboxRelay creates an OutboxRelay that polls from db and publishes via pub.
@@ -78,9 +79,10 @@ func NewOutboxRelay(db relayDB, pub outbox.Publisher, cfg RelayConfig) *OutboxRe
 		cfg.RetentionPeriod = defaults.RetentionPeriod
 	}
 	return &OutboxRelay{
-		db:     db,
-		pub:    pub,
-		config: cfg,
+		db:        db,
+		pub:       pub,
+		config:    cfg,
+		startedCh: make(chan struct{}),
 	}
 }
 
@@ -99,7 +101,9 @@ func (r *OutboxRelay) Start(ctx context.Context) error {
 	r.running = true
 	r.cancel = cancel
 	r.done = done
+	r.startedCh = make(chan struct{}) // reset for re-start
 	r.wg.Add(2)
+	close(r.startedCh) // signal that lifecycle fields are published
 	r.mu.Unlock()
 
 	defer func() {
@@ -138,6 +142,18 @@ func (r *OutboxRelay) Start(ctx context.Context) error {
 // It respects the caller's context deadline: if ctx expires before goroutines
 // finish, Stop returns an error instead of blocking indefinitely.
 func (r *OutboxRelay) Stop(ctx context.Context) error {
+	// Wait for Start() to finish publishing lifecycle fields. This prevents
+	// a race where Stop() reads nil cancel/done before Start() writes them.
+	r.mu.Lock()
+	started := r.startedCh
+	r.mu.Unlock()
+
+	select {
+	case <-started:
+	case <-ctx.Done():
+		return errcode.Wrap(ErrAdapterPGConnect, "relay stop: timed out waiting for start", ctx.Err())
+	}
+
 	r.mu.Lock()
 	cancel := r.cancel
 	done := r.done
@@ -260,10 +276,10 @@ func (r *OutboxRelay) pollOnce(ctx context.Context) error {
 
 		const markQuery = `UPDATE outbox_entries SET published = true, published_at = now() WHERE id = $1`
 		if _, err := tx.Exec(ctx, markQuery, e.ID); err != nil {
-			slog.Error("outbox relay: mark published failed",
-				slog.String("entry_id", e.ID),
-				slog.Any("error", err),
-			)
+			// Fail-fast: abort the entire batch so the deferred rollback
+			// undoes all marks. Already-published entries will be re-delivered
+			// on next poll (at-least-once is the expected semantic).
+			return errcode.Wrap(ErrAdapterPGQuery, "outbox relay: mark published failed, aborting batch", err)
 		}
 	}
 

--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -79,10 +79,11 @@ func NewOutboxRelay(db relayDB, pub outbox.Publisher, cfg RelayConfig) *OutboxRe
 		cfg.RetentionPeriod = defaults.RetentionPeriod
 	}
 	return &OutboxRelay{
-		db:        db,
-		pub:       pub,
-		config:    cfg,
-		startedCh: make(chan struct{}),
+		db:     db,
+		pub:    pub,
+		config: cfg,
+		// startedCh intentionally nil — Start() creates and closes it.
+		// Stop() treats nil as "never started" and returns immediately.
 	}
 }
 
@@ -101,10 +102,14 @@ func (r *OutboxRelay) Start(ctx context.Context) error {
 	r.running = true
 	r.cancel = cancel
 	r.done = done
-	r.startedCh = make(chan struct{}) // reset for re-start
+	started := make(chan struct{})
+	r.startedCh = started
 	r.wg.Add(2)
-	close(r.startedCh) // signal that lifecycle fields are published
 	r.mu.Unlock()
+
+	// Signal after unlock: any Stop() that acquired the lock after us will
+	// read the same channel we are about to close.
+	close(started)
 
 	defer func() {
 		r.wg.Wait()
@@ -144,9 +149,15 @@ func (r *OutboxRelay) Start(ctx context.Context) error {
 func (r *OutboxRelay) Stop(ctx context.Context) error {
 	// Wait for Start() to finish publishing lifecycle fields. This prevents
 	// a race where Stop() reads nil cancel/done before Start() writes them.
+	// If Start() was never called, startedCh is nil and we return immediately
+	// (no-op, consistent with worker.Worker contract).
 	r.mu.Lock()
 	started := r.startedCh
 	r.mu.Unlock()
+
+	if started == nil {
+		return nil
+	}
 
 	select {
 	case <-started:

--- a/src/adapters/postgres/outbox_relay_test.go
+++ b/src/adapters/postgres/outbox_relay_test.go
@@ -366,6 +366,51 @@ func TestOutboxRelay_Stop_SucceedsWithAmpleTimeout(t *testing.T) {
 	assert.NoError(t, startErr, "Start should return nil on graceful stop")
 }
 
+func TestOutboxRelay_StopBeforeStart_IsNoop(t *testing.T) {
+	db := &mockDBTX{}
+	pub := &mockPublisher{}
+	relay := NewOutboxRelay(db, pub, DefaultRelayConfig())
+
+	// Stop on a never-started relay must return nil immediately,
+	// consistent with the worker.Worker contract.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := relay.Stop(ctx)
+	assert.NoError(t, err, "Stop on never-started relay must be a no-op")
+}
+
+func TestOutboxRelay_ConcurrentStartStop_NoStaleChannel(t *testing.T) {
+	db := &mockDBTX{}
+	pub := &mockPublisher{}
+	cfg := DefaultRelayConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+
+	relay := NewOutboxRelay(db, pub, cfg)
+
+	// Launch Start and Stop concurrently to exercise the race window
+	// where Stop() could snapshot a stale startedCh.
+	startCtx, startCancel := context.WithCancel(context.Background())
+	defer startCancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- relay.Start(startCtx)
+	}()
+
+	// Don't wait for running — call Stop immediately to hit the race window.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+
+	err := relay.Stop(stopCtx)
+	// Either Stop returns nil (completed) or nil because start hasn't run yet.
+	// It must NOT timeout — that would indicate the stale channel bug.
+	assert.NoError(t, err, "Stop must not timeout due to stale startedCh")
+
+	startCancel() // ensure Start exits
+	<-errCh
+}
+
 // --- mocks ---
 
 type mockDBTX struct {


### PR DESCRIPTION
## Summary
- **R-01**: `pollOnce()` now returns error on mark failure (fail-fast) instead of log-and-continue. Deferred rollback undoes the batch; entries re-deliver on next poll (at-least-once semantic preserved).
- **R-02**: New `startedCh` channel prevents `Stop()` from racing `Start()`. Stop waits for Start to publish lifecycle fields before reading cancel/done.

**Why:** R-01 fixes a correctness bug where continuing after mark failure amplifies duplicate delivery. R-02 fixes a race where Stop() could see nil cancel/done if called before Start() finishes initialization.

ref: `docs/reviews/202604061401-pr39-six-role/PR39-postgres-outbox-followup.md`

## Test plan
- [x] `go build ./...` passes
- [x] 14 relay tests pass including race regression and restart tests
- [x] `TestOutboxRelay_StartStop_RaceRegression` (25 rapid start/stop cycles)
- [x] `TestOutboxRelay_CanRestartAfterStop` (validates startedCh reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)