### PR TITLE
fix(pkg): WithDetails nil 防御 + mapCodeToStatus TOKEN_INVALID 漏匹配

### DIFF
--- a/src/pkg/errcode/errcode.go
+++ b/src/pkg/errcode/errcode.go
@@ -82,7 +82,11 @@ func Wrap(code Code, message string, cause error) *Error {
 // WithDetails returns a shallow copy of err with the provided details merged in.
 // If err.Details is nil a new map is allocated; existing keys are preserved
 // unless overwritten by the supplied details.
+// If err is nil, nil is returned.
 func WithDetails(err *Error, details map[string]any) *Error {
+	if err == nil {
+		return nil
+	}
 	merged := make(map[string]any, len(err.Details)+len(details))
 	for k, v := range err.Details {
 		merged[k] = v

--- a/src/pkg/errcode/errcode_test.go
+++ b/src/pkg/errcode/errcode_test.go
@@ -140,6 +140,11 @@ func TestWithDetails(t *testing.T) {
 	}
 }
 
+func TestWithDetails_NilError(t *testing.T) {
+	result := WithDetails(nil, map[string]any{"key": "val"})
+	assert.Nil(t, result)
+}
+
 func TestWithDetailsDDoesNotMutateOriginal(t *testing.T) {
 	original := WithDetails(New(ErrAssemblyNotFound, "not found"), map[string]any{"key": "val"})
 	_ = WithDetails(original, map[string]any{"extra": "data"})

--- a/src/pkg/httputil/response.go
+++ b/src/pkg/httputil/response.go
@@ -96,7 +96,7 @@ func mapCodeToStatus(code errcode.Code) int {
 		return http.StatusNotFound
 	case strings.Contains(c, "VALIDATION") || strings.Contains(c, "INVALID_INPUT"):
 		return http.StatusBadRequest
-	case strings.Contains(c, "UNAUTHORIZED") || strings.Contains(c, "LOGIN_FAILED") || strings.Contains(c, "REFRESH_FAILED") || strings.Contains(c, "INVALID_TOKEN") || strings.Contains(c, "TOKEN_EXPIRED") || strings.Contains(c, "KEY_INVALID"):
+	case strings.Contains(c, "UNAUTHORIZED") || strings.Contains(c, "LOGIN_FAILED") || strings.Contains(c, "REFRESH_FAILED") || strings.Contains(c, "INVALID_TOKEN") || strings.Contains(c, "TOKEN_INVALID") || strings.Contains(c, "TOKEN_EXPIRED") || strings.Contains(c, "KEY_INVALID"):
 		return http.StatusUnauthorized
 	case strings.Contains(c, "FORBIDDEN"):
 		return http.StatusForbidden

--- a/src/pkg/httputil/response_test.go
+++ b/src/pkg/httputil/response_test.go
@@ -27,6 +27,7 @@ func TestMapCodeToStatus(t *testing.T) {
 		{"ERR_AUTH_REFRESH_FAILED", http.StatusUnauthorized},
 		{"ERR_AUTH_TOKEN_EXPIRED", http.StatusUnauthorized},
 		{"ERR_AUTH_KEY_INVALID", http.StatusUnauthorized},
+		{"ERR_AUTH_TOKEN_INVALID", http.StatusUnauthorized},
 		{"ERR_AUTH_FORBIDDEN", http.StatusForbidden},
 		{"ERR_USER_LOCKED", http.StatusForbidden},
 		{"ERR_DUPLICATE_USER", http.StatusConflict},


### PR DESCRIPTION
## Summary

- **errcode.WithDetails**: 传入 nil `*Error` 时不再 panic，直接返回 nil，防止共享包的调用方失误导致服务崩溃
- **httputil.mapCodeToStatus**: 补充 `TOKEN_INVALID` 模式匹配，修复 `ErrAuthTokenInvalid`（`"ERR_AUTH_TOKEN_INVALID"`）被错误映射为 500 而非 401 的 bug
- 补充对应测试用例

## Test plan

- [x] `go test ./pkg/...` 全部通过（含新增 `TestWithDetails_NilError` 和 `ERR_AUTH_TOKEN_INVALID` 映射测试）
- [x] `go build ./pkg/...` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)