### PR TITLE
refactor(http): ctxkeys 测试补全 + middleware error envelope 统一

### DIFF
--- a/src/pkg/ctxkeys/keys_test.go
+++ b/src/pkg/ctxkeys/keys_test.go
@@ -115,6 +115,61 @@ func TestSpanIDRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRequestIDRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "uuid", value: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+		{name: "empty string", value: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithRequestID(context.Background(), tt.value)
+			got, ok := RequestIDFrom(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, tt.value, got)
+		})
+	}
+}
+
+func TestRealIPRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "ipv4", value: "192.168.1.100"},
+		{name: "ipv6", value: "::1"},
+		{name: "empty string", value: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithRealIP(context.Background(), tt.value)
+			got, ok := RealIPFrom(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, tt.value, got)
+		})
+	}
+}
+
+func TestSubjectRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "user id", value: "user-42"},
+		{name: "empty string", value: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithSubject(context.Background(), tt.value)
+			got, ok := SubjectFrom(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, tt.value, got)
+		})
+	}
+}
+
 func TestFromMissingKey(t *testing.T) {
 	ctx := context.Background()
 
@@ -128,6 +183,9 @@ func TestFromMissingKey(t *testing.T) {
 		{name: "JourneyID missing", fn: JourneyIDFrom},
 		{name: "TraceID missing", fn: TraceIDFrom},
 		{name: "SpanID missing", fn: SpanIDFrom},
+		{name: "RequestID missing", fn: RequestIDFrom},
+		{name: "RealIP missing", fn: RealIPFrom},
+		{name: "Subject missing", fn: SubjectFrom},
 	}
 
 	for _, tt := range tests {
@@ -147,6 +205,9 @@ func TestMultipleKeysInSameContext(t *testing.T) {
 	ctx = WithJourneyID(ctx, "J-SSO-001")
 	ctx = WithTraceID(ctx, "trace-abc")
 	ctx = WithSpanID(ctx, "span-xyz")
+	ctx = WithRequestID(ctx, "req-001")
+	ctx = WithRealIP(ctx, "10.0.0.1")
+	ctx = WithSubject(ctx, "admin")
 
 	cellID, ok := CellIDFrom(ctx)
 	assert.True(t, ok)
@@ -171,4 +232,16 @@ func TestMultipleKeysInSameContext(t *testing.T) {
 	spanID, ok := SpanIDFrom(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, "span-xyz", spanID)
+
+	reqID, ok := RequestIDFrom(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "req-001", reqID)
+
+	realIP, ok := RealIPFrom(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "10.0.0.1", realIP)
+
+	subject, ok := SubjectFrom(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "admin", subject)
 }

--- a/src/pkg/httputil/response.go
+++ b/src/pkg/httputil/response.go
@@ -23,6 +23,9 @@ func WriteJSON(w http.ResponseWriter, status int, v any) {
 // WriteError writes a structured error response in the canonical format:
 //
 //	{"error": {"code": "ERR_*", "message": "...", "details": {}}}
+//
+// Callers that need additional response headers (e.g. Retry-After) must set
+// them before calling WriteError, as it calls w.WriteHeader internally.
 func WriteError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/src/pkg/httputil/response_test.go
+++ b/src/pkg/httputil/response_test.go
@@ -59,7 +59,7 @@ func TestWriteError(t *testing.T) {
 	require.True(t, ok, "response must contain 'error' key")
 	assert.Equal(t, "ERR_VALIDATION_REQUIRED_FIELD", errObj["code"])
 	assert.Equal(t, "field is required", errObj["message"])
-	assert.NotNil(t, errObj["details"], "details must be present")
+	assert.Equal(t, map[string]any{}, errObj["details"], "canonical envelope must include empty details object")
 }
 
 func TestWriteJSON(t *testing.T) {
@@ -128,7 +128,7 @@ func TestWriteDomainError_ErrcodeError(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, tt.wantCode, errObj["code"])
 			assert.Equal(t, tt.wantMsg, errObj["message"])
-			assert.NotNil(t, errObj["details"])
+			assert.IsType(t, map[string]any{}, errObj["details"], "details must be a JSON object")
 		})
 	}
 }

--- a/src/runtime/http/middleware/body_limit.go
+++ b/src/runtime/http/middleware/body_limit.go
@@ -1,8 +1,9 @@
 package middleware
 
 import (
-	"encoding/json"
 	"net/http"
+
+	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
 // DefaultBodyLimit is the default maximum request body size (1 MB).
@@ -28,12 +29,5 @@ func BodyLimit(maxBytes int64) func(http.Handler) http.Handler {
 }
 
 func writeBodyTooLarge(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusRequestEntityTooLarge)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"error": map[string]any{
-			"code":    "ERR_BODY_TOO_LARGE",
-			"message": "request body too large",
-		},
-	})
+	httputil.WriteError(w, http.StatusRequestEntityTooLarge, "ERR_BODY_TOO_LARGE", "request body too large")
 }

--- a/src/runtime/http/middleware/body_limit_test.go
+++ b/src/runtime/http/middleware/body_limit_test.go
@@ -47,7 +47,7 @@ func TestBodyLimit_ExactContentLengthOverLimit(t *testing.T) {
 	require.NoError(t, err)
 	errObj := respBody["error"].(map[string]any)
 	assert.Equal(t, "ERR_BODY_TOO_LARGE", errObj["code"])
-	assert.NotNil(t, errObj["details"], "canonical envelope must include details")
+	assert.Equal(t, map[string]any{}, errObj["details"], "canonical envelope must include empty details object")
 }
 
 func TestBodyLimit_MaxBytesReaderTriggered(t *testing.T) {

--- a/src/runtime/http/middleware/body_limit_test.go
+++ b/src/runtime/http/middleware/body_limit_test.go
@@ -47,6 +47,7 @@ func TestBodyLimit_ExactContentLengthOverLimit(t *testing.T) {
 	require.NoError(t, err)
 	errObj := respBody["error"].(map[string]any)
 	assert.Equal(t, "ERR_BODY_TOO_LARGE", errObj["code"])
+	assert.NotNil(t, errObj["details"], "canonical envelope must include details")
 }
 
 func TestBodyLimit_MaxBytesReaderTriggered(t *testing.T) {

--- a/src/runtime/http/middleware/rate_limit.go
+++ b/src/runtime/http/middleware/rate_limit.go
@@ -1,13 +1,13 @@
 package middleware
 
 import (
-	"encoding/json"
 	"math"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
 // RateLimiter decides whether a request identified by key should be allowed.
@@ -37,15 +37,8 @@ func RateLimit(limiter RateLimiter) func(http.Handler) http.Handler {
 			ip := clientIP(r)
 			if !limiter.Allow(ip) {
 				retryAfter := computeRetryAfter(limiter)
-				w.Header().Set("Content-Type", "application/json")
 				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-				w.WriteHeader(http.StatusTooManyRequests)
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"error": map[string]any{
-						"code":    "ERR_RATE_LIMITED",
-						"message": "too many requests",
-					},
-				})
+				httputil.WriteError(w, http.StatusTooManyRequests, "ERR_RATE_LIMITED", "too many requests")
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/src/runtime/http/middleware/rate_limit_test.go
+++ b/src/runtime/http/middleware/rate_limit_test.go
@@ -77,7 +77,7 @@ func TestRateLimit_Rejected_DefaultRetryAfter(t *testing.T) {
 	require.NoError(t, err)
 	errObj := body["error"].(map[string]any)
 	assert.Equal(t, "ERR_RATE_LIMITED", errObj["code"])
-	assert.NotNil(t, errObj["details"], "canonical envelope must include details")
+	assert.Equal(t, map[string]any{}, errObj["details"], "canonical envelope must include empty details object")
 }
 
 func TestRateLimit_Rejected_DynamicRetryAfter(t *testing.T) {

--- a/src/runtime/http/middleware/rate_limit_test.go
+++ b/src/runtime/http/middleware/rate_limit_test.go
@@ -77,6 +77,7 @@ func TestRateLimit_Rejected_DefaultRetryAfter(t *testing.T) {
 	require.NoError(t, err)
 	errObj := body["error"].(map[string]any)
 	assert.Equal(t, "ERR_RATE_LIMITED", errObj["code"])
+	assert.NotNil(t, errObj["details"], "canonical envelope must include details")
 }
 
 func TestRateLimit_Rejected_DynamicRetryAfter(t *testing.T) {

--- a/src/runtime/http/middleware/recovery.go
+++ b/src/runtime/http/middleware/recovery.go
@@ -1,12 +1,12 @@
 package middleware
 
 import (
-	"encoding/json"
 	"log/slog"
 	"net/http"
 	"runtime/debug"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
 // ref: zeromicro/go-zero rest/handler/recoverhandler.go — RecoverHandler pattern
@@ -32,14 +32,7 @@ func Recovery(next http.Handler) http.Handler {
 				}
 				slog.Error("panic recovered", attrs...)
 
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"error": map[string]any{
-						"code":    "ERR_INTERNAL",
-						"message": "internal server error",
-					},
-				})
+				httputil.WriteError(w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
 			}
 		}()
 		next.ServeHTTP(w, r)

--- a/src/runtime/http/middleware/recovery_test.go
+++ b/src/runtime/http/middleware/recovery_test.go
@@ -44,7 +44,7 @@ func TestRecovery_PanicString(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "ERR_INTERNAL", errObj["code"])
 	assert.Equal(t, "internal server error", errObj["message"])
-	assert.NotNil(t, errObj["details"], "canonical envelope must include details")
+	assert.Equal(t, map[string]any{}, errObj["details"], "canonical envelope must include empty details object")
 }
 
 func TestRecovery_PanicError(t *testing.T) {

--- a/src/runtime/http/middleware/recovery_test.go
+++ b/src/runtime/http/middleware/recovery_test.go
@@ -44,6 +44,7 @@ func TestRecovery_PanicString(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "ERR_INTERNAL", errObj["code"])
 	assert.Equal(t, "internal server error", errObj["message"])
+	assert.NotNil(t, errObj["details"], "canonical envelope must include details")
 }
 
 func TestRecovery_PanicError(t *testing.T) {


### PR DESCRIPTION
## Summary

- **ctxkeys**: 补全 RequestID / RealIP / Subject 三组 RoundTrip 测试，扩展 FromMissing 和 MultipleKeys 覆盖全部 9 个 context key
- **middleware**: recovery / body_limit / rate_limit 改用 `httputil.WriteError` 替代手写 `json.Encode`，统一 error response 包含 `details:{}`（与 `WriteDomainError` 格式一致）

## Test plan

- [x] `go test ./pkg/ctxkeys/... -v` 全部通过（9 key RoundTrip + FromMissing + MultipleKeys）
- [x] `go test ./runtime/http/middleware/... -v` 全部通过（TDD Red→Green：先加 details 断言失败，再改产品代码通过）
- [x] `go build ./...` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)