### PR TITLE
refactor(cells): 去 chi — URLParam→PathValue + Routes→RegisterRoutes

### DIFF
--- a/src/cells/access-core/cell.go
+++ b/src/cells/access-core/cell.go
@@ -229,7 +229,7 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
 	mux.Route("/api/v1/access", func(sub cell.RouteMux) {
 		// Identity management: /api/v1/access/users
-		sub.Mount("/users", c.identityHandler.Routes())
+		sub.Route("/users", c.identityHandler.RegisterRoutes)
 
 		// Session endpoints: /api/v1/access/sessions
 		sub.Route("/sessions", func(s cell.RouteMux) {
@@ -239,7 +239,7 @@ func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
 		})
 
 		// RBAC queries: /api/v1/access/roles
-		sub.Mount("/roles", c.rbacHandler.Routes())
+		sub.Route("/roles", c.rbacHandler.RegisterRoutes)
 	})
 }
 

--- a/src/cells/access-core/cell_test.go
+++ b/src/cells/access-core/cell_test.go
@@ -182,6 +182,34 @@ func TestAccessCore_RouteUserCreate(t *testing.T) {
 		"POST /api/v1/access/users/ should not return 404 (got %d)", rec.Code)
 }
 
+func TestAccessCore_RouteSessionLogout(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/access/sessions/sess-nonexistent", nil)
+	r.ServeHTTP(rec, req)
+
+	// 404 means handler was reached and session not found (correct routing).
+	// 405 or chi-level 404 (without JSON body) means routing is broken.
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"DELETE /api/v1/access/sessions/{id} should reach handler (got %d)", rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"),
+		"response should be JSON (handler reached, not chi 404)")
+}
+
+func TestAccessCore_RouteUserGet(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/users/usr-nonexistent", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"GET /api/v1/access/users/{id} should reach handler (got %d)", rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"),
+		"response should be JSON (handler reached, not chi 404)")
+}
+
 func TestAccessCore_RouteRolesList(t *testing.T) {
 	r := initCellWithRouter(t)
 

--- a/src/cells/access-core/slices/identitymanage/handler.go
+++ b/src/cells/access-core/slices/identitymanage/handler.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
+	kcell "github.com/ghbvf/gocell/kernel/cell"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -44,17 +44,15 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// Routes returns a chi.Router with identity-manage routes.
-func (h *Handler) Routes() chi.Router {
-	r := chi.NewRouter()
-	r.Post("/", h.handleCreate)
-	r.Get("/{id}", h.handleGet)
-	r.Put("/{id}", h.handleUpdate)
-	r.Patch("/{id}", h.handlePatch)
-	r.Delete("/{id}", h.handleDelete)
-	r.Post("/{id}/lock", h.handleLock)
-	r.Post("/{id}/unlock", h.handleUnlock)
-	return r
+// RegisterRoutes registers identity-manage routes on the given mux.
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
+	mux.Handle("POST /", http.HandlerFunc(h.handleCreate))
+	mux.Handle("GET /{id}", http.HandlerFunc(h.handleGet))
+	mux.Handle("PUT /{id}", http.HandlerFunc(h.handleUpdate))
+	mux.Handle("PATCH /{id}", http.HandlerFunc(h.handlePatch))
+	mux.Handle("DELETE /{id}", http.HandlerFunc(h.handleDelete))
+	mux.Handle("POST /{id}/lock", http.HandlerFunc(h.handleLock))
+	mux.Handle("POST /{id}/unlock", http.HandlerFunc(h.handleUnlock))
 }
 
 func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +78,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 	user, err := h.svc.GetByID(r.Context(), id)
 	if err != nil {
 		httputil.WriteDomainError(w, err)
@@ -90,7 +88,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 	var req struct {
 		Email string `json:"email"`
 	}
@@ -112,7 +110,7 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 
 	// JSON merge patch: only fields present in the JSON body are updated.
 	var raw map[string]json.RawMessage
@@ -150,7 +148,7 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 	if err := h.svc.Delete(r.Context(), id); err != nil {
 		httputil.WriteDomainError(w, err)
 		return
@@ -159,7 +157,7 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 	if err := h.svc.Lock(r.Context(), id); err != nil {
 		httputil.WriteDomainError(w, err)
 		return
@@ -168,7 +166,7 @@ func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleUnlock(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 	if err := h.svc.Unlock(r.Context(), id); err != nil {
 		httputil.WriteDomainError(w, err)
 		return

--- a/src/cells/access-core/slices/identitymanage/handler_test.go
+++ b/src/cells/access-core/slices/identitymanage/handler_test.go
@@ -12,12 +12,29 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
+// testMux adapts http.ServeMux to cell.RouteMux for testing.
+type testMux struct{ *http.ServeMux }
+
+func (m *testMux) Handle(pattern string, handler http.Handler) { m.ServeMux.Handle(pattern, handler) }
+func (m *testMux) Route(pattern string, fn func(cell.RouteMux)) {
+	sub := &testMux{http.NewServeMux()}
+	fn(sub)
+	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, sub.ServeMux))
+}
+func (m *testMux) Mount(pattern string, handler http.Handler) {
+	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, handler))
+}
+func (m *testMux) Group(fn func(cell.RouteMux)) { fn(m) }
+
 func setup() http.Handler {
 	svc := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default())
-	return NewHandler(svc).Routes()
+	mux := &testMux{http.NewServeMux()}
+	NewHandler(svc).RegisterRoutes(mux)
+	return mux
 }
 
 func TestHandler(t *testing.T) {

--- a/src/cells/access-core/slices/identitymanage/handler_test.go
+++ b/src/cells/access-core/slices/identitymanage/handler_test.go
@@ -12,27 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
-	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
-// testMux adapts http.ServeMux to cell.RouteMux for testing.
-type testMux struct{ *http.ServeMux }
-
-func (m *testMux) Handle(pattern string, handler http.Handler) { m.ServeMux.Handle(pattern, handler) }
-func (m *testMux) Route(pattern string, fn func(cell.RouteMux)) {
-	sub := &testMux{http.NewServeMux()}
-	fn(sub)
-	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, sub.ServeMux))
-}
-func (m *testMux) Mount(pattern string, handler http.Handler) {
-	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, handler))
-}
-func (m *testMux) Group(fn func(cell.RouteMux)) { fn(m) }
-
 func setup() http.Handler {
 	svc := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default())
-	mux := &testMux{http.NewServeMux()}
+	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux
 }

--- a/src/cells/access-core/slices/rbaccheck/handler.go
+++ b/src/cells/access-core/slices/rbaccheck/handler.go
@@ -3,8 +3,7 @@ package rbaccheck
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
+	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -18,16 +17,14 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// Routes returns a chi.Router with rbac-check routes.
-func (h *Handler) Routes() chi.Router {
-	r := chi.NewRouter()
-	r.Get("/{userID}", h.handleListRoles)
-	r.Get("/{userID}/{roleName}", h.handleHasRole)
-	return r
+// RegisterRoutes registers rbac-check routes on the given mux.
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
+	mux.Handle("GET /{userID}", http.HandlerFunc(h.handleListRoles))
+	mux.Handle("GET /{userID}/{roleName}", http.HandlerFunc(h.handleHasRole))
 }
 
 func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
-	userID := chi.URLParam(r, "userID")
+	userID := r.PathValue("userID")
 
 	roles, err := h.svc.ListRoles(r.Context(), userID)
 	if err != nil {
@@ -39,8 +36,8 @@ func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleHasRole(w http.ResponseWriter, r *http.Request) {
-	userID := chi.URLParam(r, "userID")
-	roleName := chi.URLParam(r, "roleName")
+	userID := r.PathValue("userID")
+	roleName := r.PathValue("roleName")
 
 	has, err := h.svc.HasRole(r.Context(), userID, roleName)
 	if err != nil {

--- a/src/cells/access-core/slices/rbaccheck/handler_test.go
+++ b/src/cells/access-core/slices/rbaccheck/handler_test.go
@@ -13,7 +13,22 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell"
 )
+
+// testMux adapts http.ServeMux to cell.RouteMux for testing.
+type testMux struct{ *http.ServeMux }
+
+func (m *testMux) Handle(pattern string, handler http.Handler) { m.ServeMux.Handle(pattern, handler) }
+func (m *testMux) Route(pattern string, fn func(cell.RouteMux)) {
+	sub := &testMux{http.NewServeMux()}
+	fn(sub)
+	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, sub.ServeMux))
+}
+func (m *testMux) Mount(pattern string, handler http.Handler) {
+	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, handler))
+}
+func (m *testMux) Group(fn func(cell.RouteMux)) { fn(m) }
 
 func setup() http.Handler {
 	roleRepo := mem.NewRoleRepository()
@@ -21,7 +36,9 @@ func setup() http.Handler {
 	_ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
 
 	svc := NewService(roleRepo, slog.Default())
-	return NewHandler(svc).Routes()
+	mux := &testMux{http.NewServeMux()}
+	NewHandler(svc).RegisterRoutes(mux)
+	return mux
 }
 
 func TestHandler(t *testing.T) {

--- a/src/cells/access-core/slices/rbaccheck/handler_test.go
+++ b/src/cells/access-core/slices/rbaccheck/handler_test.go
@@ -13,22 +13,8 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
-	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 )
-
-// testMux adapts http.ServeMux to cell.RouteMux for testing.
-type testMux struct{ *http.ServeMux }
-
-func (m *testMux) Handle(pattern string, handler http.Handler) { m.ServeMux.Handle(pattern, handler) }
-func (m *testMux) Route(pattern string, fn func(cell.RouteMux)) {
-	sub := &testMux{http.NewServeMux()}
-	fn(sub)
-	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, sub.ServeMux))
-}
-func (m *testMux) Mount(pattern string, handler http.Handler) {
-	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, handler))
-}
-func (m *testMux) Group(fn func(cell.RouteMux)) { fn(m) }
 
 func setup() http.Handler {
 	roleRepo := mem.NewRoleRepository()
@@ -36,7 +22,7 @@ func setup() http.Handler {
 	_ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
 
 	svc := NewService(roleRepo, slog.Default())
-	mux := &testMux{http.NewServeMux()}
+	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux
 }

--- a/src/cells/access-core/slices/sessionlogin/handler_test.go
+++ b/src/cells/access-core/slices/sessionlogin/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
@@ -21,7 +20,7 @@ import (
 
 // testIssuer is declared in service_test.go
 
-func setup() http.Handler {
+func setup() *Handler {
 	userRepo := mem.NewUserRepository()
 	hash, _ := bcrypt.GenerateFromPassword([]byte("correct-pass"), bcrypt.MinCost)
 	user := &domain.User{
@@ -31,9 +30,7 @@ func setup() http.Handler {
 	_ = userRepo.Create(context.Background(), user)
 
 	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(), eventbus.New(), testIssuer, slog.Default())
-	r := chi.NewRouter()
-	r.Post("/login", NewHandler(svc).HandleLogin)
-	return r
+	return NewHandler(svc)
 }
 
 func TestHandleLogin(t *testing.T) {
@@ -73,11 +70,11 @@ func TestHandleLogin(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := setup()
+			h := setup()
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(tc.body))
 			req.Header.Set("Content-Type", "application/json")
-			r.ServeHTTP(w, req)
+			h.HandleLogin(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.checkBody != nil {
 				tc.checkBody(t, w.Body.Bytes())

--- a/src/cells/access-core/slices/sessionlogout/handler.go
+++ b/src/cells/access-core/slices/sessionlogout/handler.go
@@ -3,7 +3,6 @@ package sessionlogout
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
@@ -20,7 +19,7 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleLogout handles DELETE /api/v1/access/sessions/{id}.
 func (h *Handler) HandleLogout(w http.ResponseWriter, r *http.Request) {
-	sessionID := chi.URLParam(r, "id")
+	sessionID := r.PathValue("id")
 
 	if err := h.svc.Logout(r.Context(), sessionID); err != nil {
 		httputil.WriteDomainError(w, err)

--- a/src/cells/access-core/slices/sessionlogout/handler.go
+++ b/src/cells/access-core/slices/sessionlogout/handler.go
@@ -3,7 +3,6 @@ package sessionlogout
 import (
 	"net/http"
 
-
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 

--- a/src/cells/access-core/slices/sessionlogout/handler_test.go
+++ b/src/cells/access-core/slices/sessionlogout/handler_test.go
@@ -16,14 +16,14 @@ import (
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
-func setup() (*Handler, func()) {
+func setup() *Handler {
 	sessionRepo := mem.NewSessionRepository()
 	sess, _ := domain.NewSession("usr-1", "access-tok", "refresh-tok", time.Now().Add(time.Hour))
 	sess.ID = "sess-1"
 	_ = sessionRepo.Create(context.Background(), sess)
 
 	svc := NewService(sessionRepo, eventbus.New(), slog.Default())
-	return NewHandler(svc), func() {}
+	return NewHandler(svc)
 }
 
 func TestHandleLogout(t *testing.T) {
@@ -46,7 +46,7 @@ func TestHandleLogout(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h, _ := setup()
+			h := setup()
 			w := httptest.NewRecorder()
 			sessionID := strings.TrimPrefix(tc.path, "/")
 			req := httptest.NewRequest(http.MethodDelete, tc.path, nil)

--- a/src/cells/access-core/slices/sessionlogout/handler_test.go
+++ b/src/cells/access-core/slices/sessionlogout/handler_test.go
@@ -5,10 +5,10 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
@@ -16,16 +16,14 @@ import (
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
-func setup() http.Handler {
+func setup() (*Handler, func()) {
 	sessionRepo := mem.NewSessionRepository()
 	sess, _ := domain.NewSession("usr-1", "access-tok", "refresh-tok", time.Now().Add(time.Hour))
 	sess.ID = "sess-1"
 	_ = sessionRepo.Create(context.Background(), sess)
 
 	svc := NewService(sessionRepo, eventbus.New(), slog.Default())
-	r := chi.NewRouter()
-	r.Delete("/{id}", NewHandler(svc).HandleLogout)
-	return r
+	return NewHandler(svc), func() {}
 }
 
 func TestHandleLogout(t *testing.T) {
@@ -48,9 +46,12 @@ func TestHandleLogout(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := setup()
+			h, _ := setup()
 			w := httptest.NewRecorder()
-			r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, tc.path, nil))
+			sessionID := strings.TrimPrefix(tc.path, "/")
+			req := httptest.NewRequest(http.MethodDelete, tc.path, nil)
+			req.SetPathValue("id", sessionID)
+			h.HandleLogout(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
 		})
 	}

--- a/src/cells/access-core/slices/sessionrefresh/handler_test.go
+++ b/src/cells/access-core/slices/sessionrefresh/handler_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,7 +24,7 @@ func issueRefreshToken(userID string) string {
 	return tok
 }
 
-func setup() (http.Handler, string) {
+func setup() (*Handler, string) {
 	sessionRepo := mem.NewSessionRepository()
 	refreshTok := issueRefreshToken("usr-1")
 
@@ -34,13 +33,11 @@ func setup() (http.Handler, string) {
 	_ = sessionRepo.Create(context.Background(), sess)
 
 	svc := NewService(sessionRepo, mem.NewRoleRepository(), testIssuer, testVerifier, slog.Default())
-	r := chi.NewRouter()
-	r.Post("/refresh", NewHandler(svc).HandleRefresh)
-	return r, refreshTok
+	return NewHandler(svc), refreshTok
 }
 
 func TestHandleRefresh(t *testing.T) {
-	router, validToken := setup()
+	h, validToken := setup()
 
 	tests := []struct {
 		name       string
@@ -81,7 +78,7 @@ func TestHandleRefresh(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/refresh", strings.NewReader(tc.body))
 			req.Header.Set("Content-Type", "application/json")
-			router.ServeHTTP(w, req)
+			h.HandleRefresh(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.checkBody != nil {
 				tc.checkBody(t, w.Body.Bytes())

--- a/src/cells/config-core/slices/configpublish/handler.go
+++ b/src/cells/config-core/slices/configpublish/handler.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -19,17 +17,9 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// Routes returns a chi.Router with config-publish routes.
-func (h *Handler) Routes() chi.Router {
-	r := chi.NewRouter()
-	r.Post("/{key}/publish", h.HandlePublish)
-	r.Post("/{key}/rollback", h.HandleRollback)
-	return r
-}
-
 // HandlePublish handles POST /{key}/publish — publishes a config entry.
 func (h *Handler) HandlePublish(w http.ResponseWriter, r *http.Request) {
-	key := chi.URLParam(r, "key")
+	key := r.PathValue("key")
 
 	version, err := h.svc.Publish(r.Context(), key)
 	if err != nil {
@@ -42,7 +32,7 @@ func (h *Handler) HandlePublish(w http.ResponseWriter, r *http.Request) {
 
 // HandleRollback handles POST /{key}/rollback — rolls back a config entry.
 func (h *Handler) HandleRollback(w http.ResponseWriter, r *http.Request) {
-	key := chi.URLParam(r, "key")
+	key := r.PathValue("key")
 
 	var req struct {
 		Version int `json:"version"`

--- a/src/cells/config-core/slices/configread/handler.go
+++ b/src/cells/config-core/slices/configread/handler.go
@@ -3,8 +3,6 @@ package configread
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -18,17 +16,9 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// Routes returns a chi.Router with config-read routes.
-func (h *Handler) Routes() chi.Router {
-	r := chi.NewRouter()
-	r.Get("/", h.HandleList)
-	r.Get("/{key}", h.HandleGet)
-	return r
-}
-
 // HandleGet handles GET /{key} — returns a single config entry.
 func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
-	key := chi.URLParam(r, "key")
+	key := r.PathValue("key")
 
 	entry, err := h.svc.GetByKey(r.Context(), key)
 	if err != nil {

--- a/src/cells/config-core/slices/configwrite/handler.go
+++ b/src/cells/config-core/slices/configwrite/handler.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -17,15 +15,6 @@ type Handler struct {
 // NewHandler creates a config-write Handler.
 func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
-}
-
-// Routes returns a chi.Router with config-write routes.
-func (h *Handler) Routes() chi.Router {
-	r := chi.NewRouter()
-	r.Post("/", h.HandleCreate)
-	r.Put("/{key}", h.HandleUpdate)
-	r.Delete("/{key}", h.HandleDelete)
-	return r
 }
 
 // HandleCreate handles POST / — creates a new config entry.
@@ -50,7 +39,7 @@ func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 
 // HandleUpdate handles PUT /{key} — updates an existing config entry.
 func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
-	key := chi.URLParam(r, "key")
+	key := r.PathValue("key")
 
 	var req struct {
 		Value string `json:"value"`
@@ -71,7 +60,7 @@ func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 
 // HandleDelete handles DELETE /{key} — deletes a config entry.
 func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
-	key := chi.URLParam(r, "key")
+	key := r.PathValue("key")
 
 	if err := h.svc.Delete(r.Context(), key); err != nil {
 		httputil.WriteDomainError(w, err)

--- a/src/cells/config-core/slices/featureflag/handler.go
+++ b/src/cells/config-core/slices/featureflag/handler.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -17,15 +15,6 @@ type Handler struct {
 // NewHandler creates a feature-flag Handler.
 func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
-}
-
-// Routes returns a chi.Router with feature-flag routes.
-func (h *Handler) Routes() chi.Router {
-	r := chi.NewRouter()
-	r.Get("/", h.HandleList)
-	r.Get("/{key}", h.HandleGet)
-	r.Post("/{key}/evaluate", h.HandleEvaluate)
-	return r
 }
 
 // HandleList handles GET / — returns all feature flags.
@@ -41,7 +30,7 @@ func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
 
 // HandleGet handles GET /{key} — returns a single feature flag.
 func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
-	key := chi.URLParam(r, "key")
+	key := r.PathValue("key")
 
 	flag, err := h.svc.GetByKey(r.Context(), key)
 	if err != nil {
@@ -54,7 +43,7 @@ func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleEvaluate handles POST /{key}/evaluate — evaluates a feature flag.
 func (h *Handler) HandleEvaluate(w http.ResponseWriter, r *http.Request) {
-	key := chi.URLParam(r, "key")
+	key := r.PathValue("key")
 
 	var req struct {
 		Subject string `json:"subject"`

--- a/src/cells/device-cell/slices/device-command/handler.go
+++ b/src/cells/device-cell/slices/device-command/handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )

--- a/src/cells/device-cell/slices/device-command/handler.go
+++ b/src/cells/device-cell/slices/device-command/handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -27,7 +26,7 @@ type enqueueRequest struct {
 
 // HandleEnqueue handles POST /api/v1/devices/{id}/commands.
 func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
-	deviceID := chi.URLParam(r, "id")
+	deviceID := r.PathValue("id")
 
 	var req enqueueRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -53,7 +52,7 @@ func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 // HandleListPending handles GET /api/v1/devices/{id}/commands.
 // Devices poll this endpoint to retrieve pending commands (L4 latent model).
 func (h *Handler) HandleListPending(w http.ResponseWriter, r *http.Request) {
-	deviceID := chi.URLParam(r, "id")
+	deviceID := r.PathValue("id")
 
 	cmds, err := h.svc.ListPending(r.Context(), deviceID)
 	if err != nil {
@@ -69,8 +68,8 @@ func (h *Handler) HandleListPending(w http.ResponseWriter, r *http.Request) {
 
 // HandleAck handles POST /api/v1/devices/{id}/commands/{cmdId}/ack.
 func (h *Handler) HandleAck(w http.ResponseWriter, r *http.Request) {
-	deviceID := chi.URLParam(r, "id")
-	cmdID := chi.URLParam(r, "cmdId")
+	deviceID := r.PathValue("id")
+	cmdID := r.PathValue("cmdId")
 
 	if err := h.svc.Ack(r.Context(), deviceID, cmdID); err != nil {
 		httputil.WriteDomainError(w, err)

--- a/src/cells/device-cell/slices/device-command/handler_test.go
+++ b/src/cells/device-cell/slices/device-command/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,23 +16,17 @@ import (
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 )
 
-// setupCommandRouter creates a chi router with all device-command endpoints.
-// It seeds a device so that command operations succeed.
-func setupCommandRouter() (http.Handler, *mem.DeviceRepository, *mem.CommandRepository) {
+// setupCommandHandler creates a Handler and seeds a device so that command operations succeed.
+func setupCommandHandler() (*Handler, *mem.DeviceRepository, *mem.CommandRepository) {
 	devRepo := mem.NewDeviceRepository()
 	cmdRepo := mem.NewCommandRepository()
 	svc := NewService(cmdRepo, devRepo, slog.Default())
-	h := NewHandler(svc)
 
 	_ = devRepo.Create(context.Background(), &domain.Device{
 		ID: "dev-1", Name: "sensor-a", Status: "online",
 	})
 
-	r := chi.NewRouter()
-	r.Post("/devices/{id}/commands", h.HandleEnqueue)
-	r.Get("/devices/{id}/commands", h.HandleListPending)
-	r.Post("/devices/{id}/commands/{cmdId}/ack", h.HandleAck)
-	return r, devRepo, cmdRepo
+	return NewHandler(svc), devRepo, cmdRepo
 }
 
 func TestHandleEnqueue(t *testing.T) {
@@ -80,11 +73,12 @@ func TestHandleEnqueue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r, _, _ := setupCommandRouter()
+			h, _, _ := setupCommandHandler()
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/devices/"+tc.deviceID+"/commands", strings.NewReader(tc.body))
 			req.Header.Set("Content-Type", "application/json")
-			r.ServeHTTP(w, req)
+			req.SetPathValue("id", tc.deviceID)
+			h.HandleEnqueue(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.checkBody != nil {
@@ -126,7 +120,7 @@ func TestHandleListPending(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r, _, cmdRepo := setupCommandRouter()
+			h, _, cmdRepo := setupCommandHandler()
 			ctx := context.Background()
 			for i := range tc.seedCmds {
 				_ = cmdRepo.Create(ctx, &domain.Command{
@@ -137,7 +131,8 @@ func TestHandleListPending(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/devices/"+tc.deviceID+"/commands", nil)
-			r.ServeHTTP(w, req)
+			req.SetPathValue("id", tc.deviceID)
+			h.HandleListPending(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.wantStatus == http.StatusOK {
@@ -175,7 +170,7 @@ func TestHandleAck(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r, _, cmdRepo := setupCommandRouter()
+			h, _, cmdRepo := setupCommandHandler()
 			if tc.seedCmd {
 				_ = cmdRepo.Create(context.Background(), &domain.Command{
 					ID: tc.cmdID, DeviceID: tc.deviceID, Payload: "reboot", Status: "pending",
@@ -184,7 +179,9 @@ func TestHandleAck(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/devices/"+tc.deviceID+"/commands/"+tc.cmdID+"/ack", nil)
-			r.ServeHTTP(w, req)
+			req.SetPathValue("id", tc.deviceID)
+			req.SetPathValue("cmdId", tc.cmdID)
+			h.HandleAck(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.wantStatus == http.StatusOK {

--- a/src/cells/device-cell/slices/device-status/handler.go
+++ b/src/cells/device-cell/slices/device-status/handler.go
@@ -3,7 +3,6 @@ package devicestatus
 import (
 	"net/http"
 
-
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 

--- a/src/cells/device-cell/slices/device-status/handler.go
+++ b/src/cells/device-cell/slices/device-status/handler.go
@@ -3,7 +3,6 @@ package devicestatus
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
@@ -20,7 +19,7 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleGetStatus handles GET /api/v1/devices/{id}/status.
 func (h *Handler) HandleGetStatus(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 
 	device, err := h.svc.GetStatus(r.Context(), id)
 	if err != nil {

--- a/src/cells/device-cell/slices/device-status/handler_test.go
+++ b/src/cells/device-cell/slices/device-status/handler_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,14 +15,10 @@ import (
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 )
 
-func setupStatusRouter() (http.Handler, *mem.DeviceRepository) {
+func setupStatusHandler() (*Handler, *mem.DeviceRepository) {
 	repo := mem.NewDeviceRepository()
 	svc := NewService(repo, slog.Default())
-	h := NewHandler(svc)
-
-	r := chi.NewRouter()
-	r.Get("/devices/{id}/status", h.HandleGetStatus)
-	return r, repo
+	return NewHandler(svc), repo
 }
 
 func TestHandleGetStatus(t *testing.T) {
@@ -63,12 +58,13 @@ func TestHandleGetStatus(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r, repo := setupStatusRouter()
+			h, repo := setupStatusHandler()
 			tc.setup(repo)
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/devices/"+tc.deviceID+"/status", nil)
-			r.ServeHTTP(w, req)
+			req.SetPathValue("id", tc.deviceID)
+			h.HandleGetStatus(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.checkBody != nil {

--- a/src/cells/order-cell/slices/order-query/handler.go
+++ b/src/cells/order-cell/slices/order-query/handler.go
@@ -3,7 +3,6 @@ package orderquery
 import (
 	"net/http"
 
-
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 

--- a/src/cells/order-cell/slices/order-query/handler.go
+++ b/src/cells/order-cell/slices/order-query/handler.go
@@ -3,7 +3,6 @@ package orderquery
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
@@ -20,7 +19,7 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleGet handles GET /api/v1/orders/{id}.
 func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := r.PathValue("id")
 
 	order, err := h.svc.GetByID(r.Context(), id)
 	if err != nil {

--- a/src/cells/order-cell/slices/order-query/handler_test.go
+++ b/src/cells/order-cell/slices/order-query/handler_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -22,13 +21,6 @@ func newTestHandler(orders ...*domain.Order) (*Handler, *mem.OrderRepository) {
 	}
 	svc := NewService(repo, slog.Default())
 	return NewHandler(svc), repo
-}
-
-// withChiURLParam creates a request with chi URL parameters set.
-func withChiURLParam(r *http.Request, key, val string) *http.Request {
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add(key, val)
-	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 }
 
 func TestHandleGet(t *testing.T) {
@@ -57,7 +49,7 @@ func TestHandleGet(t *testing.T) {
 			h, _ := newTestHandler(tt.seed...)
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/"+tt.id, nil)
-			req = withChiURLParam(req, "id", tt.id)
+			req.SetPathValue("id", tt.id)
 
 			h.HandleGet(rec, req)
 
@@ -71,7 +63,7 @@ func TestHandleGet_ResponseBody(t *testing.T) {
 	h, _ := newTestHandler(&domain.Order{ID: "ord-detail", Item: "laptop", Status: "confirmed"})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/ord-detail", nil)
-	req = withChiURLParam(req, "id", "ord-detail")
+	req.SetPathValue("id", "ord-detail")
 
 	h.HandleGet(rec, req)
 

--- a/src/kernel/cell/celltest/mux.go
+++ b/src/kernel/cell/celltest/mux.go
@@ -1,0 +1,45 @@
+// Package celltest provides test utilities for kernel/cell types.
+// It follows the net/http → net/http/httptest pattern.
+package celltest
+
+import (
+	"net/http"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+)
+
+// Compile-time check: TestMux implements cell.RouteMux.
+var _ cell.RouteMux = (*TestMux)(nil)
+
+// TestMux adapts http.ServeMux to cell.RouteMux for testing.
+// It uses Go 1.22+ ServeMux pattern matching ("GET /path/{param}").
+type TestMux struct {
+	*http.ServeMux
+}
+
+// NewTestMux creates a TestMux backed by a stdlib ServeMux.
+func NewTestMux() *TestMux {
+	return &TestMux{http.NewServeMux()}
+}
+
+// Handle registers a handler for the given pattern.
+func (m *TestMux) Handle(pattern string, handler http.Handler) {
+	m.ServeMux.Handle(pattern, handler)
+}
+
+// Route creates a sub-mux with prefix stripping.
+func (m *TestMux) Route(pattern string, fn func(cell.RouteMux)) {
+	sub := NewTestMux()
+	fn(sub)
+	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, sub.ServeMux))
+}
+
+// Mount attaches an http.Handler under the given prefix with stripping.
+func (m *TestMux) Mount(pattern string, handler http.Handler) {
+	m.ServeMux.Handle(pattern+"/", http.StripPrefix(pattern, handler))
+}
+
+// Group calls fn with the same mux (no prefix change).
+func (m *TestMux) Group(fn func(cell.RouteMux)) {
+	fn(m)
+}

--- a/src/kernel/cell/registrar.go
+++ b/src/kernel/cell/registrar.go
@@ -22,11 +22,34 @@ import (
 // RouteMux is a minimal route registration interface.
 // kernel/ does not import any specific router (chi, gorilla, etc.);
 // concrete implementations are provided by runtime/ or adapters/.
+//
+// For testing, use kernel/cell/celltest.TestMux.
 type RouteMux interface {
+	// Handle registers handler for the given pattern.
+	// Pattern follows Go 1.22+ enhanced ServeMux syntax: "METHOD /path/{param}".
+	// Path parameters are extracted by the underlying router implementation and
+	// accessible via r.PathValue("param") in the handler.
+	//
+	// Examples:
+	//   mux.Handle("GET /users/{id}", handler)
+	//   mux.Handle("POST /", handler)
+	//   mux.Handle("DELETE /sessions/{id}", handler)
 	Handle(pattern string, handler http.Handler)
-	Route(pattern string, fn func(sub RouteMux)) // sub-router with prefix stripping
-	Mount(pattern string, handler http.Handler)   // mount handler with prefix stripping
-	Group(fn func(RouteMux))                      // same-level grouping (no prefix change)
+
+	// Route creates a sub-router under pattern with prefix stripping.
+	// Use for GoCell native route registration — the sub-router participates
+	// in the framework's pattern matching, PathValue binding, and test model.
+	Route(pattern string, fn func(sub RouteMux))
+
+	// Mount attaches an opaque http.Handler sub-tree under pattern with prefix
+	// stripping. The mounted handler is a "black box" that does not need to
+	// follow GoCell routing conventions. Use Route + RegisterRoutes instead
+	// when the sub-tree is a GoCell cell/slice.
+	Mount(pattern string, handler http.Handler)
+
+	// Group creates a same-level scope sharing the parent prefix.
+	// Useful for applying middleware to a subset of routes.
+	Group(fn func(RouteMux))
 }
 
 // HTTPRegistrar is optionally implemented by Cells that expose HTTP endpoints.

--- a/src/runtime/http/router/router_test.go
+++ b/src/runtime/http/router/router_test.go
@@ -5,14 +5,19 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+	"nhooyr.io/websocket"
 
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
+	rtws "github.com/ghbvf/gocell/runtime/websocket"
+	ws "github.com/ghbvf/gocell/adapters/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -124,6 +129,29 @@ func TestMount(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/sub/hello", nil)
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRouterChain_WebSocketUpgrade(t *testing.T) {
+	hub := rtws.NewHub(rtws.HubConfig{ReadLimit: 4096}, func(_ context.Context, _ string, _ []byte) {})
+
+	go func() { _ = hub.Start(context.Background()) }()
+	require.Eventually(t, func() bool { return hub.IsRunning() }, 2*time.Second, time.Millisecond)
+	t.Cleanup(func() { _ = hub.Stop(context.Background()) })
+
+	r := New()
+	r.Mount("/ws", ws.UpgradeHandler(hub, ws.UpgradeConfig{}))
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	wsURL := strings.Replace(srv.URL, "http://", "ws://", 1) + "/ws"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(t, err, "WebSocket upgrade through router middleware chain must succeed")
+	conn.CloseNow()
 }
 
 func TestDefaultMiddlewareApplied(t *testing.T) {


### PR DESCRIPTION
## Summary

- **cells/ 产品代码零 chi import**：10 个 handler 的 `chi.URLParam` → `r.PathValue`（23 处），删除所有 `go-chi/chi/v5` import
- **Routes() → RegisterRoutes()**：identitymanage 和 rbaccheck 的 `Routes() chi.Router` 改为 `RegisterRoutes(mux cell.RouteMux)`，access-core cell.go 从 `Mount` 改为 `Route`
- **删除死代码**：config-core 4 个 handler 的 `Routes()` 方法从未被调用，直接删除
- **RouteMux 接口不变**：Group 保留，不加 HandleFunc
- **测试全部改造**：chi.NewRouter / chi.RouteCtxKey → 直接调 handler + `r.SetPathValue` / stdlib testMux adapter

## Test plan

- [x] `go build ./...` + `go vet ./...`
- [x] `go test ./cells/... -short -count=1` 全部通过（34 个包）
- [x] `grep -r '"github.com/go-chi/chi' src/cells/ --include='*.go' | grep -v _test.go` → 零结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)