### PR TITLE
fix(middleware,httputil): panic guard + MaxBytesError + error code

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -233,6 +233,19 @@
 | PROM-01 | `runtime/observability/metrics/metrics.go` + `adapters/prometheus/collector.go` | metrics Middleware 传入原始 URL path 作为 label，参数化路由（`/users/123`）会导致 Prometheus label 基数爆炸。需要在 middleware 层做路由模板归一化（`/users/{id}`），或由 collector 接受归一化后的 path |
 | TX-NIL-01 | 7 个 slice service (`cells/*/service.go`) | `txRunner` 字段 nil-safe 回退行为（`if s.txRunner != nil` → 顺序执行）未文档化。建议在各 service 的 `txRunner` 字段或 `runInTx` helper 上补注释 |
 
+### 0-H: DecodeJSON 严格模式 — DisallowUnknownFields opt-in（0.5d）
+
+> 来源: PR#54 review 讨论（2026-04-09）
+> 架构师意见: 校验策略属于 handler 层决策，不应在 pkg/ 基础设施强制；需独立 PR + migration guide
+> 产品意见: 内部项目 Fail Fast 收益大于成本；保留严格模式但需明确列出未知字段名
+
+| # | 任务 | 预估 | 状态 |
+|---|------|------|------|
+| SF-01 | `DecodeJSONStrict` 启用 DisallowUnknownFields，复用 classifyDecodeError（含 unknown field 分支） | 1h | TODO |
+| SF-02 | handler 逐个从 `DecodeJSON` 切到 `DecodeJSONStrict`（10 个 struct 目标） | 1h | TODO |
+| SF-03 | `WriteDecodeError` 适配：严格模式返回 ERR_VALIDATION_FAILED + unknown field details，宽松模式保持 ERR_VALIDATION_REQUIRED_FIELD | 0.5h | TODO |
+| SF-04 | CHANGELOG / API 文档标注 breaking change | 0.5h | TODO |
+
 ### 历史 Tech-Debt（合并保留）
 
 #### P1（5 条）

--- a/src/cells/access-core/internal/domain/session.go
+++ b/src/cells/access-core/internal/domain/session.go
@@ -6,10 +6,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-// Error codes for session domain.
-const (
-	ErrSessionInvalidInput errcode.Code = "ERR_AUTH_SESSION_INVALID_INPUT"
-)
 
 // Session represents an authenticated user session with tokens and expiry.
 type Session struct {
@@ -27,13 +23,13 @@ type Session struct {
 // Returns an errcode.Error if any required field is empty.
 func NewSession(userID, accessToken, refreshToken string, expiresAt time.Time) (*Session, error) {
 	if userID == "" {
-		return nil, errcode.New(ErrSessionInvalidInput, "userID is required")
+		return nil, errcode.New(errcode.ErrAuthSessionInvalidInput, "userID is required")
 	}
 	if accessToken == "" {
-		return nil, errcode.New(ErrSessionInvalidInput, "accessToken is required")
+		return nil, errcode.New(errcode.ErrAuthSessionInvalidInput, "accessToken is required")
 	}
 	if refreshToken == "" {
-		return nil, errcode.New(ErrSessionInvalidInput, "refreshToken is required")
+		return nil, errcode.New(errcode.ErrAuthSessionInvalidInput, "refreshToken is required")
 	}
 
 	return &Session{

--- a/src/cells/access-core/internal/domain/user.go
+++ b/src/cells/access-core/internal/domain/user.go
@@ -7,11 +7,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-// Error codes for access-core domain.
-const (
-	ErrUserInvalidInput errcode.Code = "ERR_AUTH_INVALID_INPUT"
-	ErrUserLocked       errcode.Code = "ERR_AUTH_USER_LOCKED"
-)
 
 // UserStatus represents the account state of a user.
 type UserStatus string
@@ -50,13 +45,13 @@ type User struct {
 // Returns an errcode.Error if any required field is empty.
 func NewUser(username, email, passwordHash string) (*User, error) {
 	if username == "" {
-		return nil, errcode.New(ErrUserInvalidInput, "username is required")
+		return nil, errcode.New(errcode.ErrAuthInvalidInput, "username is required")
 	}
 	if email == "" {
-		return nil, errcode.New(ErrUserInvalidInput, "email is required")
+		return nil, errcode.New(errcode.ErrAuthInvalidInput, "email is required")
 	}
 	if passwordHash == "" {
-		return nil, errcode.New(ErrUserInvalidInput, "passwordHash is required")
+		return nil, errcode.New(errcode.ErrAuthInvalidInput, "passwordHash is required")
 	}
 
 	now := time.Now()

--- a/src/cells/access-core/internal/mem/role_repo.go
+++ b/src/cells/access-core/internal/mem/role_repo.go
@@ -9,9 +9,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	ErrRoleNotFound errcode.Code = "ERR_AUTH_ROLE_NOT_FOUND"
-)
 
 var _ ports.RoleRepository = (*RoleRepository)(nil)
 
@@ -46,7 +43,7 @@ func (r *RoleRepository) GetByID(_ context.Context, id string) (*domain.Role, er
 
 	role, ok := r.roles[id]
 	if !ok {
-		return nil, errcode.New(ErrRoleNotFound, "role not found: "+id)
+		return nil, errcode.New(errcode.ErrAuthRoleNotFound, "role not found: "+id)
 	}
 	clone := *role
 	return &clone, nil
@@ -76,7 +73,7 @@ func (r *RoleRepository) AssignToUser(_ context.Context, userID, roleID string) 
 	defer r.mu.Unlock()
 
 	if _, ok := r.roles[roleID]; !ok {
-		return errcode.New(ErrRoleNotFound, "role not found: "+roleID)
+		return errcode.New(errcode.ErrAuthRoleNotFound, "role not found: "+roleID)
 	}
 
 	if r.userRoles[userID] == nil {

--- a/src/cells/access-core/internal/mem/user_repo.go
+++ b/src/cells/access-core/internal/mem/user_repo.go
@@ -10,10 +10,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	ErrUserNotFound  errcode.Code = "ERR_AUTH_USER_NOT_FOUND"
-	ErrUserDuplicate errcode.Code = "ERR_AUTH_USER_DUPLICATE"
-)
 
 var _ ports.UserRepository = (*UserRepository)(nil)
 
@@ -37,7 +33,7 @@ func (r *UserRepository) Create(_ context.Context, user *domain.User) error {
 	defer r.mu.Unlock()
 
 	if _, exists := r.byName[user.Username]; exists {
-		return errcode.New(ErrUserDuplicate, "username already exists: "+user.Username)
+		return errcode.New(errcode.ErrAuthUserDuplicate, "username already exists: "+user.Username)
 	}
 
 	c := cloneUser(user)
@@ -52,7 +48,7 @@ func (r *UserRepository) GetByID(_ context.Context, id string) (*domain.User, er
 
 	u, ok := r.byID[id]
 	if !ok {
-		return nil, errcode.New(ErrUserNotFound, "user not found: "+id)
+		return nil, errcode.New(errcode.ErrAuthUserNotFound, "user not found: "+id)
 	}
 	return cloneUser(u), nil
 }
@@ -63,7 +59,7 @@ func (r *UserRepository) GetByUsername(_ context.Context, username string) (*dom
 
 	u, ok := r.byName[username]
 	if !ok {
-		return nil, errcode.New(ErrUserNotFound, "user not found: "+username)
+		return nil, errcode.New(errcode.ErrAuthUserNotFound, "user not found: "+username)
 	}
 	return cloneUser(u), nil
 }
@@ -73,7 +69,7 @@ func (r *UserRepository) Update(_ context.Context, user *domain.User) error {
 	defer r.mu.Unlock()
 
 	if _, exists := r.byID[user.ID]; !exists {
-		return errcode.New(ErrUserNotFound, "user not found: "+user.ID)
+		return errcode.New(errcode.ErrAuthUserNotFound, "user not found: "+user.ID)
 	}
 
 	c := cloneUser(user)
@@ -101,7 +97,7 @@ func (r *UserRepository) Delete(_ context.Context, id string) error {
 
 	u, ok := r.byID[id]
 	if !ok {
-		return errcode.New(ErrUserNotFound, "user not found: "+id)
+		return errcode.New(errcode.ErrAuthUserNotFound, "user not found: "+id)
 	}
 	delete(r.byName, u.Username)
 	delete(r.byID, id)

--- a/src/cells/access-core/slices/identitymanage/handler.go
+++ b/src/cells/access-core/slices/identitymanage/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 
@@ -93,7 +93,7 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		Email string `json:"email"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 	// JSON merge patch: only fields present in the JSON body are updated.
 	var raw map[string]json.RawMessage
 	if err := httputil.DecodeJSON(r, &raw); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/access-core/slices/identitymanage/handler.go
+++ b/src/cells/access-core/slices/identitymanage/handler.go
@@ -61,8 +61,8 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Email    string `json:"email"`
 		Password string `json:"password"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 
@@ -92,8 +92,8 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Email string `json:"email"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 
@@ -114,8 +114,8 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 
 	// JSON merge patch: only fields present in the JSON body are updated.
 	var raw map[string]json.RawMessage
-	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &raw); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/access-core/slices/identitymanage/service.go
+++ b/src/cells/access-core/slices/identitymanage/service.go
@@ -22,7 +22,6 @@ import (
 const (
 	TopicUserCreated = "event.user.created.v1"
 	TopicUserLocked  = "event.user.locked.v1"
-	ErrIdentityInput errcode.Code = "ERR_AUTH_IDENTITY_INVALID_INPUT"
 )
 
 // Option configures an identity-manage Service.
@@ -68,7 +67,7 @@ type CreateInput struct {
 // The plain-text password is bcrypt-hashed before storage.
 func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.User, error) {
 	if input.Password == "" {
-		return nil, errcode.New(ErrIdentityInput, "password is required")
+		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput, "password is required")
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(input.Password), bcrypt.DefaultCost)
@@ -120,7 +119,7 @@ type UpdateInput struct {
 // only non-nil fields are applied; missing fields are left unchanged.
 func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.User, error) {
 	if input.ID == "" {
-		return nil, errcode.New(ErrIdentityInput, "id is required")
+		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput, "id is required")
 	}
 
 	user, err := s.repo.GetByID(ctx, input.ID)
@@ -137,7 +136,7 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.User, 
 	if input.Status != nil {
 		status := domain.UserStatus(*input.Status)
 		if *input.Status != string(domain.StatusActive) && *input.Status != string(domain.StatusSuspended) {
-			return nil, errcode.New(ErrIdentityInput, "status must be 'active' or 'suspended'")
+			return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput, "status must be 'active' or 'suspended'")
 		}
 		user.Status = status
 	}
@@ -154,7 +153,7 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.User, 
 // Delete removes a user.
 func (s *Service) Delete(ctx context.Context, id string) error {
 	if id == "" {
-		return errcode.New(ErrIdentityInput, "id is required")
+		return errcode.New(errcode.ErrAuthIdentityInvalidInput, "id is required")
 	}
 	if err := s.repo.Delete(ctx, id); err != nil {
 		return fmt.Errorf("identity-manage: delete: %w", err)
@@ -166,7 +165,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 // Lock locks a user account and publishes an event.
 func (s *Service) Lock(ctx context.Context, id string) error {
 	if id == "" {
-		return errcode.New(ErrIdentityInput, "id is required")
+		return errcode.New(errcode.ErrAuthIdentityInvalidInput, "id is required")
 	}
 
 	user, err := s.repo.GetByID(ctx, id)
@@ -197,7 +196,7 @@ func (s *Service) Lock(ctx context.Context, id string) error {
 // Unlock unlocks a user account.
 func (s *Service) Unlock(ctx context.Context, id string) error {
 	if id == "" {
-		return errcode.New(ErrIdentityInput, "id is required")
+		return errcode.New(errcode.ErrAuthIdentityInvalidInput, "id is required")
 	}
 
 	user, err := s.repo.GetByID(ctx, id)

--- a/src/cells/access-core/slices/rbaccheck/service.go
+++ b/src/cells/access-core/slices/rbaccheck/service.go
@@ -12,9 +12,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	ErrRBACInvalidInput errcode.Code = "ERR_AUTH_RBAC_INVALID_INPUT"
-)
 
 // Service implements RBAC query operations.
 type Service struct {
@@ -30,7 +27,7 @@ func NewService(roleRepo ports.RoleRepository, logger *slog.Logger) *Service {
 // HasRole checks if a user has the specified role.
 func (s *Service) HasRole(ctx context.Context, userID, roleName string) (bool, error) {
 	if userID == "" || roleName == "" {
-		return false, errcode.New(ErrRBACInvalidInput, "userID and roleName are required")
+		return false, errcode.New(errcode.ErrAuthRBACInvalidInput, "userID and roleName are required")
 	}
 
 	roles, err := s.roleRepo.GetByUserID(ctx, userID)
@@ -49,7 +46,7 @@ func (s *Service) HasRole(ctx context.Context, userID, roleName string) (bool, e
 // ListRoles returns all roles assigned to a user.
 func (s *Service) ListRoles(ctx context.Context, userID string) ([]*domain.Role, error) {
 	if userID == "" {
-		return nil, errcode.New(ErrRBACInvalidInput, "userID is required")
+		return nil, errcode.New(errcode.ErrAuthRBACInvalidInput, "userID is required")
 	}
 
 	roles, err := s.roleRepo.GetByUserID(ctx, userID)

--- a/src/cells/access-core/slices/sessionlogin/handler.go
+++ b/src/cells/access-core/slices/sessionlogin/handler.go
@@ -1,7 +1,6 @@
 package sessionlogin
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -23,8 +22,8 @@ func (h *Handler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		Username string `json:"username"`
 		Password string `json:"password"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/access-core/slices/sessionlogin/handler.go
+++ b/src/cells/access-core/slices/sessionlogin/handler.go
@@ -23,7 +23,7 @@ func (h *Handler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/access-core/slices/sessionlogin/service.go
+++ b/src/cells/access-core/slices/sessionlogin/service.go
@@ -23,9 +23,6 @@ import (
 const (
 	TopicSessionCreated = "event.session.created.v1"
 
-	ErrLoginInvalidInput errcode.Code = "ERR_AUTH_LOGIN_INVALID_INPUT"
-	ErrLoginFailed       errcode.Code = "ERR_AUTH_LOGIN_FAILED"
-
 	accessTokenTTL = 15 * time.Minute
 )
 
@@ -94,20 +91,20 @@ type LoginInput struct {
 // Login authenticates a user and returns a JWT token pair.
 func (s *Service) Login(ctx context.Context, input LoginInput) (*TokenPair, error) {
 	if input.Username == "" || input.Password == "" {
-		return nil, errcode.New(ErrLoginInvalidInput, "username and password are required")
+		return nil, errcode.New(errcode.ErrAuthLoginInvalidInput, "username and password are required")
 	}
 
 	user, err := s.userRepo.GetByUsername(ctx, input.Username)
 	if err != nil {
-		return nil, errcode.New(ErrLoginFailed, "invalid credentials")
+		return nil, errcode.New(errcode.ErrAuthLoginFailed, "invalid credentials")
 	}
 
 	if user.IsLocked() {
-		return nil, errcode.New(domain.ErrUserLocked, "account is locked")
+		return nil, errcode.New(errcode.ErrAuthUserLocked, "account is locked")
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(input.Password)); err != nil {
-		return nil, errcode.New(ErrLoginFailed, "invalid credentials")
+		return nil, errcode.New(errcode.ErrAuthLoginFailed, "invalid credentials")
 	}
 
 	// Fetch roles for JWT claims.

--- a/src/cells/access-core/slices/sessionlogout/service.go
+++ b/src/cells/access-core/slices/sessionlogout/service.go
@@ -17,8 +17,6 @@ import (
 
 const (
 	TopicSessionRevoked = "event.session.revoked.v1"
-
-	ErrLogoutInvalidInput errcode.Code = "ERR_AUTH_LOGOUT_INVALID_INPUT"
 )
 
 // Option configures a session-logout Service.
@@ -64,7 +62,7 @@ func NewService(
 // Logout revokes a session by its ID.
 func (s *Service) Logout(ctx context.Context, sessionID string) error {
 	if sessionID == "" {
-		return errcode.New(ErrLogoutInvalidInput, "session ID is required")
+		return errcode.New(errcode.ErrAuthLogoutInvalidInput, "session ID is required")
 	}
 
 	session, err := s.sessionRepo.GetByID(ctx, sessionID)
@@ -127,7 +125,7 @@ func (s *Service) Logout(ctx context.Context, sessionID string) error {
 // LogoutUser revokes all sessions for a user.
 func (s *Service) LogoutUser(ctx context.Context, userID string) error {
 	if userID == "" {
-		return errcode.New(ErrLogoutInvalidInput, "user ID is required")
+		return errcode.New(errcode.ErrAuthLogoutInvalidInput, "user ID is required")
 	}
 
 	if err := s.sessionRepo.RevokeByUserID(ctx, userID); err != nil {

--- a/src/cells/access-core/slices/sessionrefresh/handler.go
+++ b/src/cells/access-core/slices/sessionrefresh/handler.go
@@ -22,7 +22,7 @@ func (h *Handler) HandleRefresh(w http.ResponseWriter, r *http.Request) {
 		RefreshToken string `json:"refreshToken"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/access-core/slices/sessionrefresh/handler.go
+++ b/src/cells/access-core/slices/sessionrefresh/handler.go
@@ -1,7 +1,6 @@
 package sessionrefresh
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -22,8 +21,8 @@ func (h *Handler) HandleRefresh(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		RefreshToken string `json:"refreshToken"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/access-core/slices/sessionrefresh/service.go
+++ b/src/cells/access-core/slices/sessionrefresh/service.go
@@ -14,10 +14,6 @@ import (
 )
 
 const (
-	ErrRefreshInvalidInput errcode.Code = "ERR_AUTH_REFRESH_INVALID_INPUT"
-	ErrRefreshFailed       errcode.Code = "ERR_AUTH_REFRESH_FAILED"
-	ErrRefreshTokenReuse   errcode.Code = "ERR_AUTH_REFRESH_TOKEN_REUSE"
-
 	accessTokenTTL = 15 * time.Minute
 )
 
@@ -68,13 +64,13 @@ func NewService(
 // the entire session is revoked (reuse detection).
 func (s *Service) Refresh(ctx context.Context, refreshToken string) (*TokenPair, error) {
 	if refreshToken == "" {
-		return nil, errcode.New(ErrRefreshInvalidInput, "refresh token is required")
+		return nil, errcode.New(errcode.ErrAuthRefreshInvalidInput, "refresh token is required")
 	}
 
 	// Verify the refresh token JWT signature via RS256 verifier.
 	_, err := s.verifier.Verify(ctx, refreshToken)
 	if err != nil {
-		return nil, errcode.New(ErrRefreshFailed, "invalid refresh token")
+		return nil, errcode.New(errcode.ErrAuthRefreshFailed, "invalid refresh token")
 	}
 
 	// Look up the session by current refresh token.
@@ -93,13 +89,13 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*TokenPair,
 			s.logger.Error("session-refresh: refresh token reuse detected, session revoked",
 				slog.String("session_id", reuseSession.ID),
 				slog.String("user_id", reuseSession.UserID))
-			return nil, errcode.New(ErrRefreshTokenReuse, "refresh token reuse detected, session revoked")
+			return nil, errcode.New(errcode.ErrAuthRefreshTokenReuse, "refresh token reuse detected, session revoked")
 		}
-		return nil, errcode.New(ErrRefreshFailed, "session not found")
+		return nil, errcode.New(errcode.ErrAuthRefreshFailed, "session not found")
 	}
 
 	if session.IsRevoked() {
-		return nil, errcode.New(ErrRefreshFailed, "session has been revoked")
+		return nil, errcode.New(errcode.ErrAuthRefreshFailed, "session has been revoked")
 	}
 
 	// Fetch roles for new access token.

--- a/src/cells/access-core/slices/sessionvalidate/service.go
+++ b/src/cells/access-core/slices/sessionvalidate/service.go
@@ -15,9 +15,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
-const (
-	ErrValidateInvalidToken errcode.Code = "ERR_AUTH_INVALID_TOKEN"
-)
 
 // Compile-time check: Service implements auth.TokenVerifier.
 var _ auth.TokenVerifier = (*Service)(nil)
@@ -41,17 +38,17 @@ func NewService(verifier auth.TokenVerifier, sessionRepo ports.SessionRepository
 func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, error) {
 	claims, err := s.verifier.Verify(ctx, tokenStr)
 	if err != nil {
-		return auth.Claims{}, errcode.New(ErrValidateInvalidToken, "invalid token")
+		return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid token")
 	}
 
 	// Check session revocation if sid claim is present in Extra.
 	if sid, ok := claims.Extra["sid"].(string); ok && sid != "" && s.sessionRepo != nil {
 		session, err := s.sessionRepo.GetByID(ctx, sid)
 		if err != nil {
-			return auth.Claims{}, errcode.New(ErrValidateInvalidToken, "session not found")
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "session not found")
 		}
 		if session.IsRevoked() {
-			return auth.Claims{}, errcode.New(ErrValidateInvalidToken, "session has been revoked")
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "session has been revoked")
 		}
 	}
 

--- a/src/cells/audit-core/internal/adapters/postgres/audit_repo.go
+++ b/src/cells/audit-core/internal/adapters/postgres/audit_repo.go
@@ -13,11 +13,6 @@ import (
 )
 
 const (
-	// ErrAuditRepoQuery indicates a query execution failure.
-	ErrAuditRepoQuery errcode.Code = "ERR_AUDIT_REPO_QUERY"
-	// ErrAuditRepoNotFound indicates no records found.
-	ErrAuditRepoNotFound errcode.Code = "ERR_AUDIT_REPO_NOT_FOUND"
-
 	// listLimit is the safety-net row limit for unbounded queries.
 	listLimit = 1000
 )
@@ -78,7 +73,7 @@ func (r *AuditRepository) Append(ctx context.Context, entry *domain.AuditEntry) 
 		entry.Hash,
 	)
 	if err != nil {
-		return errcode.Wrap(ErrAuditRepoQuery, "audit repo: append failed", err)
+		return errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: append failed", err)
 	}
 
 	return nil
@@ -105,7 +100,7 @@ func (r *AuditRepository) GetRange(ctx context.Context, from, to int) ([]*domain
 
 	rows, err := r.db.Query(ctx, query, limit, from)
 	if err != nil {
-		return nil, errcode.Wrap(ErrAuditRepoQuery, "audit repo: get range failed", err)
+		return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: get range failed", err)
 	}
 	defer rows.Close()
 
@@ -146,7 +141,7 @@ func (r *AuditRepository) Query(ctx context.Context, filters ports.AuditFilters)
 
 	rows, err := r.db.Query(ctx, query, args...)
 	if err != nil {
-		return nil, errcode.Wrap(ErrAuditRepoQuery, "audit repo: query failed", err)
+		return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: query failed", err)
 	}
 	defer rows.Close()
 
@@ -162,12 +157,12 @@ func scanAuditEntries(rows Rows) ([]*domain.AuditEntry, error) {
 			&e.ID, &e.EventID, &e.EventType, &e.ActorID,
 			&e.Timestamp, &e.Payload, &e.PrevHash, &e.Hash,
 		); err != nil {
-			return nil, errcode.Wrap(ErrAuditRepoQuery, "audit repo: scan failed", err)
+			return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: scan failed", err)
 		}
 		entries = append(entries, &e)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, errcode.Wrap(ErrAuditRepoQuery, "audit repo: rows error", err)
+		return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: rows error", err)
 	}
 	return entries, nil
 }

--- a/src/cells/audit-core/internal/adapters/postgres/audit_repo_test.go
+++ b/src/cells/audit-core/internal/adapters/postgres/audit_repo_test.go
@@ -62,7 +62,7 @@ func TestAuditRepository_Append_Error(t *testing.T) {
 
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrAuditRepoQuery, ec.Code)
+	assert.Equal(t, errcode.ErrAuditRepoQuery, ec.Code)
 }
 
 func TestAuditRepository_GetRange(t *testing.T) {

--- a/src/cells/audit-core/internal/adapters/s3archive/archive.go
+++ b/src/cells/audit-core/internal/adapters/s3archive/archive.go
@@ -14,12 +14,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	// ErrArchiveUpload indicates a failure uploading the archive.
-	ErrArchiveUpload errcode.Code = "ERR_ARCHIVE_UPLOAD"
-	// ErrArchiveMarshal indicates a failure serializing entries.
-	ErrArchiveMarshal errcode.Code = "ERR_ARCHIVE_MARSHAL"
-)
 
 // ObjectUploader abstracts the upload operation for S3-compatible storage.
 // This interface decouples the ArchiveStore from the concrete s3.Client.
@@ -54,7 +48,7 @@ func (s *ArchiveStore) Archive(ctx context.Context, entries []*domain.AuditEntry
 
 	data, err := json.Marshal(entries)
 	if err != nil {
-		return errcode.Wrap(ErrArchiveMarshal, "s3archive: failed to marshal entries", err)
+		return errcode.Wrap(errcode.ErrArchiveMarshal, "s3archive: failed to marshal entries", err)
 	}
 
 	key := fmt.Sprintf("%s%s-%d.json",
@@ -64,7 +58,7 @@ func (s *ArchiveStore) Archive(ctx context.Context, entries []*domain.AuditEntry
 	)
 
 	if err := s.uploader.Upload(ctx, key, data, "application/json"); err != nil {
-		return errcode.Wrap(ErrArchiveUpload,
+		return errcode.Wrap(errcode.ErrArchiveUpload,
 			fmt.Sprintf("s3archive: upload failed for key %s", key), err)
 	}
 

--- a/src/cells/audit-core/internal/adapters/s3archive/archive_test.go
+++ b/src/cells/audit-core/internal/adapters/s3archive/archive_test.go
@@ -77,7 +77,7 @@ func TestArchiveStore_Archive_UploadError(t *testing.T) {
 
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrArchiveUpload, ec.Code)
+	assert.Equal(t, errcode.ErrArchiveUpload, ec.Code)
 }
 
 // --- mock ---

--- a/src/cells/audit-core/slices/auditarchive/service.go
+++ b/src/cells/audit-core/slices/auditarchive/service.go
@@ -8,9 +8,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	ErrNotImplemented errcode.Code = "ERR_NOT_IMPLEMENTED"
-)
 
 // Service is a stub implementation for the audit-archive slice.
 type Service struct{}
@@ -22,5 +19,5 @@ func NewService() *Service {
 
 // Archive is not available in Phase 2.
 func (s *Service) Archive(_ context.Context) error {
-	return errcode.New(ErrNotImplemented, "audit archive not available in Phase 2")
+	return errcode.New(errcode.ErrNotImplemented, "audit archive not available in Phase 2")
 }

--- a/src/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/src/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -14,13 +14,6 @@ import (
 )
 
 const (
-	// ErrConfigRepoQuery indicates a query execution failure.
-	ErrConfigRepoQuery errcode.Code = "ERR_CONFIG_REPO_QUERY"
-	// ErrConfigRepoNotFound indicates a record was not found.
-	ErrConfigRepoNotFound errcode.Code = "ERR_CONFIG_REPO_NOT_FOUND"
-	// ErrConfigRepoDuplicate indicates a duplicate key.
-	ErrConfigRepoDuplicate errcode.Code = "ERR_CONFIG_REPO_DUPLICATE"
-
 	// listLimit is the safety-net row limit for unbounded queries.
 	listLimit = 1000
 )
@@ -78,7 +71,7 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 		entry.CreatedAt, entry.UpdatedAt,
 	)
 	if err != nil {
-		return errcode.Wrap(ErrConfigRepoQuery,
+		return errcode.Wrap(errcode.ErrConfigRepoQuery,
 			fmt.Sprintf("config repo: create failed for key %s", entry.Key), err)
 	}
 
@@ -94,7 +87,7 @@ func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.Co
 
 	var e domain.ConfigEntry
 	if err := row.Scan(&e.ID, &e.Key, &e.Value, &e.Version, &e.CreatedAt, &e.UpdatedAt); err != nil {
-		return nil, errcode.Wrap(ErrConfigRepoNotFound,
+		return nil, errcode.Wrap(errcode.ErrConfigRepoNotFound,
 			fmt.Sprintf("config repo: key not found: %s", key), err)
 	}
 
@@ -115,11 +108,11 @@ func (r *ConfigRepository) Update(ctx context.Context, entry *domain.ConfigEntry
 		entry.Value, entry.Version, entry.UpdatedAt, entry.Key,
 	)
 	if err != nil {
-		return errcode.Wrap(ErrConfigRepoQuery,
+		return errcode.Wrap(errcode.ErrConfigRepoQuery,
 			fmt.Sprintf("config repo: update failed for key %s", entry.Key), err)
 	}
 	if affected == 0 {
-		return errcode.New(ErrConfigRepoNotFound,
+		return errcode.New(errcode.ErrConfigRepoNotFound,
 			fmt.Sprintf("config repo: key not found: %s", entry.Key))
 	}
 
@@ -132,11 +125,11 @@ func (r *ConfigRepository) Delete(ctx context.Context, key string) error {
 
 	affected, err := r.db.Exec(ctx, query, key)
 	if err != nil {
-		return errcode.Wrap(ErrConfigRepoQuery,
+		return errcode.Wrap(errcode.ErrConfigRepoQuery,
 			fmt.Sprintf("config repo: delete failed for key %s", key), err)
 	}
 	if affected == 0 {
-		return errcode.New(ErrConfigRepoNotFound,
+		return errcode.New(errcode.ErrConfigRepoNotFound,
 			fmt.Sprintf("config repo: key not found: %s", key))
 	}
 
@@ -150,7 +143,7 @@ func (r *ConfigRepository) List(ctx context.Context) ([]*domain.ConfigEntry, err
 
 	rows, err := r.db.Query(ctx, query)
 	if err != nil {
-		return nil, errcode.Wrap(ErrConfigRepoQuery, "config repo: list failed", err)
+		return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: list failed", err)
 	}
 	defer rows.Close()
 
@@ -158,12 +151,12 @@ func (r *ConfigRepository) List(ctx context.Context) ([]*domain.ConfigEntry, err
 	for rows.Next() {
 		var e domain.ConfigEntry
 		if err := rows.Scan(&e.ID, &e.Key, &e.Value, &e.Version, &e.CreatedAt, &e.UpdatedAt); err != nil {
-			return nil, errcode.Wrap(ErrConfigRepoQuery, "config repo: scan failed", err)
+			return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: scan failed", err)
 		}
 		entries = append(entries, &e)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, errcode.Wrap(ErrConfigRepoQuery, "config repo: rows error", err)
+		return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: rows error", err)
 	}
 
 	return entries, nil
@@ -180,7 +173,7 @@ func (r *ConfigRepository) PublishVersion(ctx context.Context, version *domain.C
 		version.Value, version.PublishedAt,
 	)
 	if err != nil {
-		return errcode.Wrap(ErrConfigRepoQuery,
+		return errcode.Wrap(errcode.ErrConfigRepoQuery,
 			fmt.Sprintf("config repo: publish version failed for config %s v%d",
 				version.ConfigID, version.Version), err)
 	}
@@ -197,7 +190,7 @@ func (r *ConfigRepository) GetVersion(ctx context.Context, configID string, vers
 
 	var v domain.ConfigVersion
 	if err := row.Scan(&v.ID, &v.ConfigID, &v.Version, &v.Value, &v.PublishedAt); err != nil {
-		return nil, errcode.Wrap(ErrConfigRepoNotFound,
+		return nil, errcode.Wrap(errcode.ErrConfigRepoNotFound,
 			fmt.Sprintf("config repo: version not found: %s v%d", configID, version), err)
 	}
 

--- a/src/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/src/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -39,7 +39,7 @@ func TestConfigRepository_Create_Error(t *testing.T) {
 
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrConfigRepoQuery, ec.Code)
+	assert.Equal(t, errcode.ErrConfigRepoQuery, ec.Code)
 }
 
 func TestConfigRepository_GetByKey(t *testing.T) {
@@ -70,7 +70,7 @@ func TestConfigRepository_GetByKey_NotFound(t *testing.T) {
 
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrConfigRepoNotFound, ec.Code)
+	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code)
 }
 
 func TestConfigRepository_Update(t *testing.T) {
@@ -99,7 +99,7 @@ func TestConfigRepository_Update_NotFound(t *testing.T) {
 
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrConfigRepoNotFound, ec.Code)
+	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code)
 }
 
 func TestConfigRepository_Delete(t *testing.T) {
@@ -122,7 +122,7 @@ func TestConfigRepository_Delete_NotFound(t *testing.T) {
 
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrConfigRepoNotFound, ec.Code)
+	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code)
 }
 
 func TestConfigRepository_List(t *testing.T) {
@@ -196,7 +196,7 @@ func TestConfigRepository_GetVersion_NotFound(t *testing.T) {
 
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrConfigRepoNotFound, ec.Code)
+	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code)
 }
 
 // --- mocks ---

--- a/src/cells/config-core/internal/mem/config_repo.go
+++ b/src/cells/config-core/internal/mem/config_repo.go
@@ -11,12 +11,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	// ErrConfigNotFound indicates the requested config key does not exist.
-	ErrConfigNotFound errcode.Code = "ERR_CONFIG_NOT_FOUND"
-	// ErrConfigDuplicate indicates a config key already exists.
-	ErrConfigDuplicate errcode.Code = "ERR_CONFIG_DUPLICATE"
-)
 
 // Compile-time check.
 var _ ports.ConfigRepository = (*ConfigRepository)(nil)
@@ -41,7 +35,7 @@ func (r *ConfigRepository) Create(_ context.Context, entry *domain.ConfigEntry) 
 	defer r.mu.Unlock()
 
 	if _, exists := r.entries[entry.Key]; exists {
-		return errcode.New(ErrConfigDuplicate, "config key already exists: "+entry.Key)
+		return errcode.New(errcode.ErrConfigDuplicate, "config key already exists: "+entry.Key)
 	}
 	clone := *entry
 	r.entries[entry.Key] = &clone
@@ -54,7 +48,7 @@ func (r *ConfigRepository) GetByKey(_ context.Context, key string) (*domain.Conf
 
 	entry, ok := r.entries[key]
 	if !ok {
-		return nil, errcode.New(ErrConfigNotFound, "config not found: "+key)
+		return nil, errcode.New(errcode.ErrConfigNotFound, "config not found: "+key)
 	}
 	clone := *entry
 	return &clone, nil
@@ -65,7 +59,7 @@ func (r *ConfigRepository) Update(_ context.Context, entry *domain.ConfigEntry) 
 	defer r.mu.Unlock()
 
 	if _, exists := r.entries[entry.Key]; !exists {
-		return errcode.New(ErrConfigNotFound, "config not found: "+entry.Key)
+		return errcode.New(errcode.ErrConfigNotFound, "config not found: "+entry.Key)
 	}
 	clone := *entry
 	r.entries[entry.Key] = &clone
@@ -77,7 +71,7 @@ func (r *ConfigRepository) Delete(_ context.Context, key string) error {
 	defer r.mu.Unlock()
 
 	if _, exists := r.entries[key]; !exists {
-		return errcode.New(ErrConfigNotFound, "config not found: "+key)
+		return errcode.New(errcode.ErrConfigNotFound, "config not found: "+key)
 	}
 	delete(r.entries, key)
 	return nil
@@ -115,5 +109,5 @@ func (r *ConfigRepository) GetVersion(_ context.Context, configID string, versio
 			return &clone, nil
 		}
 	}
-	return nil, errcode.New(ErrConfigNotFound, "version not found")
+	return nil, errcode.New(errcode.ErrConfigNotFound, "version not found")
 }

--- a/src/cells/config-core/internal/mem/flag_repo.go
+++ b/src/cells/config-core/internal/mem/flag_repo.go
@@ -9,12 +9,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	// ErrFlagNotFound indicates the requested flag key does not exist.
-	ErrFlagNotFound errcode.Code = "ERR_FLAG_NOT_FOUND"
-	// ErrFlagDuplicate indicates a flag key already exists.
-	ErrFlagDuplicate errcode.Code = "ERR_FLAG_DUPLICATE"
-)
 
 // Compile-time check.
 var _ ports.FlagRepository = (*FlagRepository)(nil)
@@ -37,7 +31,7 @@ func (r *FlagRepository) Create(_ context.Context, flag *domain.FeatureFlag) err
 	defer r.mu.Unlock()
 
 	if _, exists := r.flags[flag.Key]; exists {
-		return errcode.New(ErrFlagDuplicate, "flag key already exists: "+flag.Key)
+		return errcode.New(errcode.ErrFlagDuplicate, "flag key already exists: "+flag.Key)
 	}
 	clone := *flag
 	r.flags[flag.Key] = &clone
@@ -50,7 +44,7 @@ func (r *FlagRepository) GetByKey(_ context.Context, key string) (*domain.Featur
 
 	flag, ok := r.flags[key]
 	if !ok {
-		return nil, errcode.New(ErrFlagNotFound, "flag not found: "+key)
+		return nil, errcode.New(errcode.ErrFlagNotFound, "flag not found: "+key)
 	}
 	clone := *flag
 	return &clone, nil
@@ -61,7 +55,7 @@ func (r *FlagRepository) Update(_ context.Context, flag *domain.FeatureFlag) err
 	defer r.mu.Unlock()
 
 	if _, exists := r.flags[flag.Key]; !exists {
-		return errcode.New(ErrFlagNotFound, "flag not found: "+flag.Key)
+		return errcode.New(errcode.ErrFlagNotFound, "flag not found: "+flag.Key)
 	}
 	clone := *flag
 	r.flags[flag.Key] = &clone

--- a/src/cells/config-core/slices/configpublish/handler.go
+++ b/src/cells/config-core/slices/configpublish/handler.go
@@ -1,7 +1,6 @@
 package configpublish
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -37,8 +36,8 @@ func (h *Handler) HandleRollback(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Version int `json:"version"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/config-core/slices/configpublish/handler.go
+++ b/src/cells/config-core/slices/configpublish/handler.go
@@ -37,7 +37,7 @@ func (h *Handler) HandleRollback(w http.ResponseWriter, r *http.Request) {
 		Version int `json:"version"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/config-core/slices/configpublish/service.go
+++ b/src/cells/config-core/slices/configpublish/service.go
@@ -22,8 +22,6 @@ const (
 	TopicConfigChanged = "event.config.changed.v1"
 	// TopicConfigRollback is the event topic for config rollbacks.
 	TopicConfigRollback = "event.config.rollback.v1"
-	// ErrPublishInvalidInput indicates invalid input for a publish operation.
-	ErrPublishInvalidInput errcode.Code = "ERR_CONFIG_PUBLISH_INVALID_INPUT"
 )
 
 // Option configures a config-publish Service.
@@ -64,7 +62,7 @@ func NewService(repo ports.ConfigRepository, pub outbox.Publisher, logger *slog.
 // Publish creates a versioned snapshot of a config entry.
 func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersion, error) {
 	if key == "" {
-		return nil, errcode.New(ErrPublishInvalidInput, "key is required")
+		return nil, errcode.New(errcode.ErrConfigPublishInvalidInput, "key is required")
 	}
 
 	entry, err := s.repo.GetByKey(ctx, key)
@@ -106,7 +104,7 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 // Rollback reverts a config entry to a specific version.
 func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (*domain.ConfigEntry, error) {
 	if key == "" {
-		return nil, errcode.New(ErrPublishInvalidInput, "key is required")
+		return nil, errcode.New(errcode.ErrConfigPublishInvalidInput, "key is required")
 	}
 
 	entry, err := s.repo.GetByKey(ctx, key)

--- a/src/cells/config-core/slices/configwrite/handler.go
+++ b/src/cells/config-core/slices/configwrite/handler.go
@@ -1,7 +1,6 @@
 package configwrite
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -23,8 +22,8 @@ func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 		Key   string `json:"key"`
 		Value string `json:"value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 
@@ -44,8 +43,8 @@ func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Value string `json:"value"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/config-core/slices/configwrite/handler.go
+++ b/src/cells/config-core/slices/configwrite/handler.go
@@ -23,7 +23,7 @@ func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 		Value string `json:"value"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 
@@ -44,7 +44,7 @@ func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 		Value string `json:"value"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/config-core/slices/configwrite/service.go
+++ b/src/cells/config-core/slices/configwrite/service.go
@@ -20,8 +20,6 @@ import (
 const (
 	// TopicConfigChanged is the event topic for config changes.
 	TopicConfigChanged = "event.config.changed.v1"
-	// ErrConfigInvalidInput indicates invalid input for a config operation.
-	ErrConfigInvalidInput errcode.Code = "ERR_CONFIG_INVALID_INPUT"
 )
 
 // Option configures a config-write Service.
@@ -68,7 +66,7 @@ type CreateInput struct {
 // Create creates a new config entry and publishes a change event.
 func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.ConfigEntry, error) {
 	if input.Key == "" {
-		return nil, errcode.New(ErrConfigInvalidInput, "key is required")
+		return nil, errcode.New(errcode.ErrConfigInvalidInput, "key is required")
 	}
 
 	now := time.Now()
@@ -104,7 +102,7 @@ type UpdateInput struct {
 // Update modifies an existing config entry and publishes a change event.
 func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.ConfigEntry, error) {
 	if input.Key == "" {
-		return nil, errcode.New(ErrConfigInvalidInput, "key is required")
+		return nil, errcode.New(errcode.ErrConfigInvalidInput, "key is required")
 	}
 
 	entry, err := s.repo.GetByKey(ctx, input.Key)
@@ -133,7 +131,7 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.Config
 // Delete removes a config entry by key and publishes a change event.
 func (s *Service) Delete(ctx context.Context, key string) error {
 	if key == "" {
-		return errcode.New(ErrConfigInvalidInput, "key is required")
+		return errcode.New(errcode.ErrConfigInvalidInput, "key is required")
 	}
 
 	entry, err := s.repo.GetByKey(ctx, key)

--- a/src/cells/config-core/slices/featureflag/handler.go
+++ b/src/cells/config-core/slices/featureflag/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) HandleEvaluate(w http.ResponseWriter, r *http.Request) {
 		Subject string `json:"subject"`
 	}
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/config-core/slices/featureflag/handler.go
+++ b/src/cells/config-core/slices/featureflag/handler.go
@@ -1,7 +1,6 @@
 package featureflag
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -48,8 +47,8 @@ func (h *Handler) HandleEvaluate(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Subject string `json:"subject"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/config-core/slices/featureflag/service.go
+++ b/src/cells/config-core/slices/featureflag/service.go
@@ -12,10 +12,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-const (
-	// ErrFlagInvalidInput indicates invalid input for flag operations.
-	ErrFlagInvalidInput errcode.Code = "ERR_FLAG_INVALID_INPUT"
-)
 
 // EvaluateResult holds the result of a flag evaluation.
 type EvaluateResult struct {
@@ -58,10 +54,10 @@ func (s *Service) List(ctx context.Context) ([]*domain.FeatureFlag, error) {
 // Evaluate checks if a flag is enabled for the given subject.
 func (s *Service) Evaluate(ctx context.Context, key, subject string) (*EvaluateResult, error) {
 	if key == "" {
-		return nil, errcode.New(ErrFlagInvalidInput, "key is required")
+		return nil, errcode.New(errcode.ErrFlagInvalidInput, "key is required")
 	}
 	if subject == "" {
-		return nil, errcode.New(ErrFlagInvalidInput, "subject is required")
+		return nil, errcode.New(errcode.ErrFlagInvalidInput, "subject is required")
 	}
 
 	flag, err := s.repo.GetByKey(ctx, key)

--- a/src/cells/device-cell/slices/device-command/handler.go
+++ b/src/cells/device-cell/slices/device-command/handler.go
@@ -27,7 +27,7 @@ func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 
 	var req enqueueRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/device-cell/slices/device-command/handler.go
+++ b/src/cells/device-cell/slices/device-command/handler.go
@@ -1,10 +1,8 @@
 package devicecommand
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -28,9 +26,8 @@ func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 	deviceID := r.PathValue("id")
 
 	var req enqueueRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest,
-			string(errcode.ErrValidationFailed), "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/device-cell/slices/device-register/handler.go
+++ b/src/cells/device-cell/slices/device-register/handler.go
@@ -1,10 +1,8 @@
 package deviceregister
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -26,9 +24,8 @@ type registerRequest struct {
 // HandleRegister handles POST /api/v1/devices.
 func (h *Handler) HandleRegister(w http.ResponseWriter, r *http.Request) {
 	var req registerRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest,
-			string(errcode.ErrValidationFailed), "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/cells/device-cell/slices/device-register/handler.go
+++ b/src/cells/device-cell/slices/device-register/handler.go
@@ -25,7 +25,7 @@ type registerRequest struct {
 func (h *Handler) HandleRegister(w http.ResponseWriter, r *http.Request) {
 	var req registerRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/order-cell/slices/order-create/handler.go
+++ b/src/cells/order-cell/slices/order-create/handler.go
@@ -25,7 +25,7 @@ type createRequest struct {
 func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	var req createRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.WriteDomainError(w, err)
+		httputil.WriteDecodeError(w, err)
 		return
 	}
 

--- a/src/cells/order-cell/slices/order-create/handler.go
+++ b/src/cells/order-cell/slices/order-create/handler.go
@@ -1,10 +1,8 @@
 package ordercreate
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -26,9 +24,8 @@ type createRequest struct {
 // HandleCreate handles POST /api/v1/orders.
 func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	var req createRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest,
-			string(errcode.ErrValidationFailed), "invalid request body")
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.WriteDomainError(w, err)
 		return
 	}
 

--- a/src/pkg/errcode/errcode.go
+++ b/src/pkg/errcode/errcode.go
@@ -37,6 +37,51 @@ const (
 	ErrAuthKeyInvalid     Code = "ERR_AUTH_KEY_INVALID"
 	ErrAuthTokenInvalid   Code = "ERR_AUTH_TOKEN_INVALID"
 	ErrAuthTokenExpired   Code = "ERR_AUTH_TOKEN_EXPIRED"
+
+	// Access-core cell error codes.
+	ErrAuthUserNotFound         Code = "ERR_AUTH_USER_NOT_FOUND"
+	ErrAuthUserDuplicate        Code = "ERR_AUTH_USER_DUPLICATE"
+	ErrAuthRoleNotFound         Code = "ERR_AUTH_ROLE_NOT_FOUND"
+	ErrAuthInvalidInput         Code = "ERR_AUTH_INVALID_INPUT"
+	ErrAuthUserLocked           Code = "ERR_AUTH_USER_LOCKED"
+	ErrAuthSessionInvalidInput  Code = "ERR_AUTH_SESSION_INVALID_INPUT"
+	ErrAuthIdentityInvalidInput Code = "ERR_AUTH_IDENTITY_INVALID_INPUT"
+	ErrAuthLoginInvalidInput    Code = "ERR_AUTH_LOGIN_INVALID_INPUT"
+	ErrAuthLoginFailed          Code = "ERR_AUTH_LOGIN_FAILED"
+	ErrAuthLogoutInvalidInput   Code = "ERR_AUTH_LOGOUT_INVALID_INPUT"
+	ErrAuthRefreshInvalidInput  Code = "ERR_AUTH_REFRESH_INVALID_INPUT"
+	ErrAuthRefreshFailed        Code = "ERR_AUTH_REFRESH_FAILED"
+	ErrAuthRefreshTokenReuse    Code = "ERR_AUTH_REFRESH_TOKEN_REUSE"
+	ErrAuthInvalidToken         Code = "ERR_AUTH_INVALID_TOKEN"
+	ErrAuthRBACInvalidInput     Code = "ERR_AUTH_RBAC_INVALID_INPUT"
+	ErrAuthKeyMissing           Code = "ERR_AUTH_KEY_MISSING"
+
+	// Config-core cell error codes.
+	ErrConfigNotFound            Code = "ERR_CONFIG_NOT_FOUND"
+	ErrConfigDuplicate           Code = "ERR_CONFIG_DUPLICATE"
+	ErrConfigInvalidInput        Code = "ERR_CONFIG_INVALID_INPUT"
+	ErrConfigPublishInvalidInput Code = "ERR_CONFIG_PUBLISH_INVALID_INPUT"
+	ErrConfigRepoNotFound        Code = "ERR_CONFIG_REPO_NOT_FOUND"
+	ErrConfigRepoDuplicate       Code = "ERR_CONFIG_REPO_DUPLICATE"
+	ErrConfigRepoQuery           Code = "ERR_CONFIG_REPO_QUERY"
+	ErrFlagNotFound              Code = "ERR_FLAG_NOT_FOUND"
+	ErrFlagDuplicate             Code = "ERR_FLAG_DUPLICATE"
+	ErrFlagInvalidInput          Code = "ERR_FLAG_INVALID_INPUT"
+
+	// Audit-core cell error codes.
+	ErrAuditRepoNotFound Code = "ERR_AUDIT_REPO_NOT_FOUND"
+	ErrAuditRepoQuery    Code = "ERR_AUDIT_REPO_QUERY"
+	ErrArchiveUpload     Code = "ERR_ARCHIVE_UPLOAD"
+	ErrArchiveMarshal    Code = "ERR_ARCHIVE_MARSHAL"
+	ErrNotImplemented    Code = "ERR_NOT_IMPLEMENTED"
+
+	// WebSocket runtime error codes.
+	ErrWSConnNotFound   Code = "ERR_WS_CONN_NOT_FOUND"
+	ErrWSAlreadyStarted Code = "ERR_WS_ALREADY_STARTED"
+	ErrWSAlreadyStopped Code = "ERR_WS_ALREADY_STOPPED"
+	ErrWSHubStopping    Code = "ERR_WS_HUB_STOPPING"
+	ErrWSHubNotRunning  Code = "ERR_WS_HUB_NOT_RUNNING"
+	ErrWSMaxConns       Code = "ERR_WS_MAX_CONNS"
 )
 
 // Error is a structured error that carries a machine-readable Code, a

--- a/src/pkg/httputil/decode.go
+++ b/src/pkg/httputil/decode.go
@@ -30,6 +30,11 @@ func DecodeJSON(r *http.Request, dst any) error {
 	// dec.More() is insufficient — it returns false for stray '}' and ']',
 	// letting invalid input like `{"name":"ok"}}` pass silently.
 	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		// The second decode may hit the body size limit instead of trailing
+		// content — surface that as 413, not 400.
+		if isMaxBytesError(err) {
+			return errcode.New(errcode.ErrBodyTooLarge, "request body too large")
+		}
 		return errcode.WithDetails(
 			errcode.New(errcode.ErrValidationFailed, "invalid request body"),
 			map[string]any{"reason": "trailing content after JSON value"},

--- a/src/pkg/httputil/decode.go
+++ b/src/pkg/httputil/decode.go
@@ -15,17 +15,26 @@ import (
 // map targets accept any key regardless).
 //
 // Errors are returned as *errcode.Error:
-//   - empty body         -> ErrValidationFailed, details: {"reason": "empty body"}
-//   - syntax error       -> ErrValidationFailed, details: {"reason": "malformed JSON", ...}
-//   - type mismatch      -> ErrValidationFailed, details: {"reason": "type mismatch", "field": ...}
-//   - unknown field      -> ErrValidationFailed, details: {"reason": "unknown field", "field": ...}
-//   - body too large     -> ErrBodyTooLarge
-//   - other              -> ErrInternal (details not exposed)
+//   - empty body           -> ErrValidationFailed, details: {"reason": "empty body"}
+//   - truncated JSON       -> ErrValidationFailed, details: {"reason": "malformed JSON"}
+//   - syntax error         -> ErrValidationFailed, details: {"reason": "malformed JSON", ...}
+//   - type mismatch        -> ErrValidationFailed, details: {"reason": "type mismatch", "field": ...}
+//   - unknown field        -> ErrValidationFailed, details: {"reason": "unknown field", "field": ...}
+//   - trailing content     -> ErrValidationFailed, details: {"reason": "trailing content after JSON value"}
+//   - body too large       -> ErrBodyTooLarge
+//   - other                -> ErrInternal (details not exposed)
 func DecodeJSON(r *http.Request, dst any) error {
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(dst); err != nil {
 		return classifyDecodeError(err)
+	}
+	// Reject trailing content: body must contain exactly one JSON value.
+	if dec.More() {
+		return errcode.WithDetails(
+			errcode.New(errcode.ErrValidationFailed, "invalid request body"),
+			map[string]any{"reason": "trailing content after JSON value"},
+		)
 	}
 	return nil
 }
@@ -36,6 +45,11 @@ func classifyDecodeError(err error) *errcode.Error {
 		return errcode.WithDetails(
 			errcode.New(errcode.ErrValidationFailed, "invalid request body"),
 			map[string]any{"reason": "empty body"},
+		)
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return errcode.WithDetails(
+			errcode.New(errcode.ErrValidationFailed, "invalid request body"),
+			map[string]any{"reason": "malformed JSON"},
 		)
 	case isMaxBytesError(err):
 		return errcode.New(errcode.ErrBodyTooLarge, "request body too large")
@@ -54,8 +68,9 @@ func classifyDecodeError(err error) *errcode.Error {
 				map[string]any{"reason": "type mismatch", "field": typeErr.Field},
 			)
 		}
-		// DisallowUnknownFields produces a plain error with message starting with
-		// "json: unknown field"
+		// DisallowUnknownFields produces a plain error whose message starts with
+		// "json: unknown field". This is not a public API guarantee — verify on
+		// Go version upgrades. See https://github.com/golang/go/issues/29035.
 		if strings.HasPrefix(err.Error(), "json: unknown field") {
 			field := strings.TrimPrefix(err.Error(), "json: unknown field ")
 			field = strings.Trim(field, "\"")

--- a/src/pkg/httputil/decode.go
+++ b/src/pkg/httputil/decode.go
@@ -1,0 +1,74 @@
+package httputil
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// DecodeJSON reads the request body as JSON into dst.
+// It enables DisallowUnknownFields by default (only affects struct targets;
+// map targets accept any key regardless).
+//
+// Errors are returned as *errcode.Error:
+//   - empty body         -> ErrValidationFailed, details: {"reason": "empty body"}
+//   - syntax error       -> ErrValidationFailed, details: {"reason": "malformed JSON", ...}
+//   - type mismatch      -> ErrValidationFailed, details: {"reason": "type mismatch", "field": ...}
+//   - unknown field      -> ErrValidationFailed, details: {"reason": "unknown field", "field": ...}
+//   - body too large     -> ErrBodyTooLarge
+//   - other              -> ErrInternal (details not exposed)
+func DecodeJSON(r *http.Request, dst any) error {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return classifyDecodeError(err)
+	}
+	return nil
+}
+
+func classifyDecodeError(err error) *errcode.Error {
+	switch {
+	case errors.Is(err, io.EOF):
+		return errcode.WithDetails(
+			errcode.New(errcode.ErrValidationFailed, "invalid request body"),
+			map[string]any{"reason": "empty body"},
+		)
+	case isMaxBytesError(err):
+		return errcode.New(errcode.ErrBodyTooLarge, "request body too large")
+	default:
+		var syntaxErr *json.SyntaxError
+		if errors.As(err, &syntaxErr) {
+			return errcode.WithDetails(
+				errcode.New(errcode.ErrValidationFailed, "invalid request body"),
+				map[string]any{"reason": "malformed JSON", "offset": syntaxErr.Offset},
+			)
+		}
+		var typeErr *json.UnmarshalTypeError
+		if errors.As(err, &typeErr) {
+			return errcode.WithDetails(
+				errcode.New(errcode.ErrValidationFailed, "invalid request body"),
+				map[string]any{"reason": "type mismatch", "field": typeErr.Field},
+			)
+		}
+		// DisallowUnknownFields produces a plain error with message starting with
+		// "json: unknown field"
+		if strings.HasPrefix(err.Error(), "json: unknown field") {
+			field := strings.TrimPrefix(err.Error(), "json: unknown field ")
+			field = strings.Trim(field, "\"")
+			return errcode.WithDetails(
+				errcode.New(errcode.ErrValidationFailed, "invalid request body"),
+				map[string]any{"reason": "unknown field", "field": field},
+			)
+		}
+		return errcode.Wrap(errcode.ErrInternal, "internal server error", err)
+	}
+}
+
+func isMaxBytesError(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}

--- a/src/pkg/httputil/decode.go
+++ b/src/pkg/httputil/decode.go
@@ -5,32 +5,31 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // DecodeJSON reads the request body as JSON into dst.
-// It enables DisallowUnknownFields by default (only affects struct targets;
-// map targets accept any key regardless).
+// The body must contain exactly one JSON value; trailing content is rejected.
+// Unknown fields are silently ignored to maintain backward compatibility.
 //
 // Errors are returned as *errcode.Error:
 //   - empty body           -> ErrValidationFailed, details: {"reason": "empty body"}
 //   - truncated JSON       -> ErrValidationFailed, details: {"reason": "malformed JSON"}
 //   - syntax error         -> ErrValidationFailed, details: {"reason": "malformed JSON", ...}
 //   - type mismatch        -> ErrValidationFailed, details: {"reason": "type mismatch", "field": ...}
-//   - unknown field        -> ErrValidationFailed, details: {"reason": "unknown field", "field": ...}
 //   - trailing content     -> ErrValidationFailed, details: {"reason": "trailing content after JSON value"}
 //   - body too large       -> ErrBodyTooLarge
 //   - other                -> ErrInternal (details not exposed)
 func DecodeJSON(r *http.Request, dst any) error {
 	dec := json.NewDecoder(r.Body)
-	dec.DisallowUnknownFields()
 	if err := dec.Decode(dst); err != nil {
 		return classifyDecodeError(err)
 	}
-	// Reject trailing content: body must contain exactly one JSON value.
-	if dec.More() {
+	// Reject trailing content: a second Decode must return io.EOF.
+	// dec.More() is insufficient — it returns false for stray '}' and ']',
+	// letting invalid input like `{"name":"ok"}}` pass silently.
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
 		return errcode.WithDetails(
 			errcode.New(errcode.ErrValidationFailed, "invalid request body"),
 			map[string]any{"reason": "trailing content after JSON value"},
@@ -66,17 +65,6 @@ func classifyDecodeError(err error) *errcode.Error {
 			return errcode.WithDetails(
 				errcode.New(errcode.ErrValidationFailed, "invalid request body"),
 				map[string]any{"reason": "type mismatch", "field": typeErr.Field},
-			)
-		}
-		// DisallowUnknownFields produces a plain error whose message starts with
-		// "json: unknown field". This is not a public API guarantee — verify on
-		// Go version upgrades. See https://github.com/golang/go/issues/29035.
-		if strings.HasPrefix(err.Error(), "json: unknown field") {
-			field := strings.TrimPrefix(err.Error(), "json: unknown field ")
-			field = strings.Trim(field, "\"")
-			return errcode.WithDetails(
-				errcode.New(errcode.ErrValidationFailed, "invalid request body"),
-				map[string]any{"reason": "unknown field", "field": field},
 			)
 		}
 		return errcode.Wrap(errcode.ErrInternal, "internal server error", err)

--- a/src/pkg/httputil/decode_test.go
+++ b/src/pkg/httputil/decode_test.go
@@ -1,0 +1,107 @@
+package httputil
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeJSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		dst        func() any // factory to create fresh decode target
+		wantCode   errcode.Code
+		wantReason string // expected details["reason"]
+	}{
+		{
+			name:     "valid struct",
+			body:     `{"name":"test"}`,
+			dst:      func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode: "", // no error
+		},
+		{
+			name:     "valid map",
+			body:     `{"foo":"bar","extra":"ok"}`,
+			dst:      func() any { return &map[string]json.RawMessage{} },
+			wantCode: "", // maps accept any field
+		},
+		{
+			name:       "empty body",
+			body:       "",
+			dst:        func() any { return &struct{}{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "empty body",
+		},
+		{
+			name:       "malformed JSON",
+			body:       `{invalid`,
+			dst:        func() any { return &struct{}{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "malformed JSON",
+		},
+		{
+			name:       "type mismatch",
+			body:       `{"count":"notanumber"}`,
+			dst:        func() any { return &struct{ Count int `json:"count"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "type mismatch",
+		},
+		{
+			name:       "unknown field on struct",
+			body:       `{"name":"test","unknown":"value"}`,
+			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "unknown field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.body))
+			r.Header.Set("Content-Type", "application/json")
+
+			dst := tt.dst()
+			err := DecodeJSON(r, dst)
+
+			if tt.wantCode == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr), "error should be *errcode.Error")
+			assert.Equal(t, tt.wantCode, ecErr.Code)
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, ecErr.Details["reason"])
+			}
+		})
+	}
+}
+
+func TestDecodeJSON_MaxBytesExceeded(t *testing.T) {
+	// Create a request with a large body
+	bigBody := `{"data":"` + strings.Repeat("x", 1024) + `"}`
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(bigBody))
+	r.Header.Set("Content-Type", "application/json")
+	// Wrap body with MaxBytesReader to simulate a size limit
+	r.Body = http.MaxBytesReader(httptest.NewRecorder(), r.Body, 10)
+
+	var dst struct {
+		Data string `json:"data"`
+	}
+	err := DecodeJSON(r, &dst)
+
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error should be *errcode.Error")
+	assert.Equal(t, errcode.ErrBodyTooLarge, ecErr.Code)
+}

--- a/src/pkg/httputil/decode_test.go
+++ b/src/pkg/httputil/decode_test.go
@@ -146,3 +146,36 @@ func TestDecodeJSON_MaxBytesExceeded(t *testing.T) {
 	require.True(t, errors.As(err, &ecErr), "error should be *errcode.Error")
 	assert.Equal(t, errcode.ErrBodyTooLarge, ecErr.Code)
 }
+
+func TestDecodeJSON_MaxBytesExceeded_TrailingContent(t *testing.T) {
+	// Scenario: first JSON value fits within the limit, but the trailing
+	// content check (second dec.Decode) reads past it and hits MaxBytesReader.
+	//
+	// The trailing content is a JSON string literal ("bbb...") so the decoder
+	// keeps reading (looking for the closing ") instead of returning a syntax
+	// error from the buffer alone.
+	firstJSON := `{"n":"x"}`
+	largeTrailing := `"` + strings.Repeat("b", 2048) + `"`
+	body := firstJSON + largeTrailing
+
+	// Limit: covers the first JSON + some trailing, but not all of it.
+	// The decoder's internal buffer receives up to `limit` bytes. After the
+	// first decode, the remaining buffer holds a partial JSON string; the
+	// second decode exhausts it and calls Read → MaxBytesError.
+	limit := int64(len(firstJSON) + 200)
+
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Body = http.MaxBytesReader(httptest.NewRecorder(), r.Body, limit)
+
+	var dst struct {
+		N string `json:"n"`
+	}
+	err := DecodeJSON(r, &dst)
+
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error should be *errcode.Error")
+	assert.Equal(t, errcode.ErrBodyTooLarge, ecErr.Code,
+		"MaxBytesError during trailing-content check must return ErrBodyTooLarge, not ErrValidationFailed")
+}

--- a/src/pkg/httputil/decode_test.go
+++ b/src/pkg/httputil/decode_test.go
@@ -61,6 +61,27 @@ func TestDecodeJSON(t *testing.T) {
 			wantCode:   errcode.ErrValidationFailed,
 			wantReason: "unknown field",
 		},
+		{
+			name:       "truncated JSON",
+			body:       `{"username":`,
+			dst:        func() any { return &struct{ Username string `json:"username"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "malformed JSON",
+		},
+		{
+			name:       "trailing content",
+			body:       `{"name":"test"}garbage`,
+			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "trailing content after JSON value",
+		},
+		{
+			name:       "multiple JSON objects",
+			body:       `{"name":"test"}{"role":"admin"}`,
+			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "trailing content after JSON value",
+		},
 	}
 
 	for _, tt := range tests {

--- a/src/pkg/httputil/decode_test.go
+++ b/src/pkg/httputil/decode_test.go
@@ -55,11 +55,10 @@ func TestDecodeJSON(t *testing.T) {
 			wantReason: "type mismatch",
 		},
 		{
-			name:       "unknown field on struct",
-			body:       `{"name":"test","unknown":"value"}`,
-			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
-			wantCode:   errcode.ErrValidationFailed,
-			wantReason: "unknown field",
+			name:     "unknown fields accepted",
+			body:     `{"name":"test","unknown":"value"}`,
+			dst:      func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode: "", // backward compatible: unknown fields are silently ignored
 		},
 		{
 			name:       "truncated JSON",
@@ -78,6 +77,27 @@ func TestDecodeJSON(t *testing.T) {
 		{
 			name:       "multiple JSON objects",
 			body:       `{"name":"test"}{"role":"admin"}`,
+			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "trailing content after JSON value",
+		},
+		{
+			name:       "trailing close brace",
+			body:       `{"name":"ok"}}`,
+			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "trailing content after JSON value",
+		},
+		{
+			name:       "trailing close bracket",
+			body:       `{"name":"ok"}]`,
+			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
+			wantCode:   errcode.ErrValidationFailed,
+			wantReason: "trailing content after JSON value",
+		},
+		{
+			name:       "trailing close bracket with space",
+			body:       `{"name":"ok"} ]`,
 			dst:        func() any { return &struct{ Name string `json:"name"` }{} },
 			wantCode:   errcode.ErrValidationFailed,
 			wantReason: "trailing content after JSON value",

--- a/src/pkg/httputil/response.go
+++ b/src/pkg/httputil/response.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strings"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
@@ -72,27 +71,79 @@ func WriteDomainError(w http.ResponseWriter, err error) {
 	WriteError(w, http.StatusInternalServerError, string(errcode.ErrInternal), "internal server error")
 }
 
+// codeToStatus maps known error codes to HTTP status codes.
+// Codes from pkg/errcode use sentinel constants; cell-local codes that surface
+// through HTTP handlers are registered as literal Code values.
+var codeToStatus = map[errcode.Code]int{
+	// --- 404 Not Found ---
+	errcode.ErrMetadataNotFound:             http.StatusNotFound,
+	errcode.ErrCellNotFound:                 http.StatusNotFound,
+	errcode.ErrSliceNotFound:                http.StatusNotFound,
+	errcode.ErrContractNotFound:             http.StatusNotFound,
+	errcode.ErrAssemblyNotFound:             http.StatusNotFound,
+	errcode.ErrJourneyNotFound:              http.StatusNotFound,
+	errcode.ErrSessionNotFound:              http.StatusNotFound,
+	errcode.ErrOrderNotFound:                http.StatusNotFound,
+	errcode.ErrDeviceNotFound:               http.StatusNotFound,
+	errcode.ErrCommandNotFound:              http.StatusNotFound,
+	"ERR_AUTH_USER_NOT_FOUND":               http.StatusNotFound,
+	"ERR_AUTH_ROLE_NOT_FOUND":               http.StatusNotFound,
+	"ERR_CONFIG_NOT_FOUND":                  http.StatusNotFound,
+	"ERR_CONFIG_REPO_NOT_FOUND":             http.StatusNotFound,
+	"ERR_FLAG_NOT_FOUND":                    http.StatusNotFound,
+	"ERR_WS_CONN_NOT_FOUND":                http.StatusNotFound,
+	"ERR_AUDIT_REPO_NOT_FOUND":             http.StatusNotFound,
+
+	// --- 400 Bad Request ---
+	errcode.ErrValidationFailed:             http.StatusBadRequest,
+	errcode.ErrMetadataInvalid:              http.StatusBadRequest,
+	errcode.ErrLifecycleInvalid:             http.StatusBadRequest,
+	errcode.ErrReferenceBroken:              http.StatusBadRequest,
+	"ERR_AUTH_INVALID_INPUT":                http.StatusBadRequest,
+	"ERR_AUTH_IDENTITY_INVALID_INPUT":       http.StatusBadRequest,
+	"ERR_AUTH_LOGIN_INVALID_INPUT":          http.StatusBadRequest,
+	"ERR_AUTH_REFRESH_INVALID_INPUT":        http.StatusBadRequest,
+	"ERR_AUTH_SESSION_INVALID_INPUT":        http.StatusBadRequest,
+	"ERR_AUTH_LOGOUT_INVALID_INPUT":         http.StatusBadRequest,
+	"ERR_AUTH_RBAC_INVALID_INPUT":           http.StatusBadRequest,
+	"ERR_CONFIG_INVALID_INPUT":              http.StatusBadRequest,
+	"ERR_CONFIG_PUBLISH_INVALID_INPUT":      http.StatusBadRequest,
+	"ERR_FLAG_INVALID_INPUT":                http.StatusBadRequest,
+
+	// --- 401 Unauthorized ---
+	errcode.ErrAuthUnauthorized:             http.StatusUnauthorized,
+	errcode.ErrAuthKeyInvalid:               http.StatusUnauthorized,
+	errcode.ErrAuthTokenInvalid:             http.StatusUnauthorized,
+	errcode.ErrAuthTokenExpired:             http.StatusUnauthorized,
+	"ERR_AUTH_LOGIN_FAILED":                 http.StatusUnauthorized,
+	"ERR_AUTH_REFRESH_FAILED":               http.StatusUnauthorized,
+	"ERR_AUTH_REFRESH_TOKEN_REUSE":          http.StatusUnauthorized,
+	"ERR_AUTH_INVALID_TOKEN":                http.StatusUnauthorized,
+
+	// --- 403 Forbidden ---
+	errcode.ErrAuthForbidden:                http.StatusForbidden,
+	"ERR_AUTH_USER_LOCKED":                  http.StatusForbidden,
+
+	// --- 409 Conflict ---
+	"ERR_AUTH_USER_DUPLICATE":               http.StatusConflict,
+	"ERR_CONFIG_DUPLICATE":                  http.StatusConflict,
+	"ERR_CONFIG_REPO_DUPLICATE":             http.StatusConflict,
+	"ERR_FLAG_DUPLICATE":                    http.StatusConflict,
+
+	// --- 429 Too Many Requests ---
+	errcode.ErrRateLimited:                  http.StatusTooManyRequests,
+
+	// --- 413 Request Entity Too Large ---
+	errcode.ErrBodyTooLarge:                 http.StatusRequestEntityTooLarge,
+}
+
 // mapCodeToStatus maps an errcode.Code to the appropriate HTTP status code.
+// Known codes use an explicit lookup table. Unknown codes default to 500
+// and emit a warning log to prompt registration.
 func mapCodeToStatus(code errcode.Code) int {
-	c := string(code)
-	switch {
-	case strings.Contains(c, "NOT_FOUND"):
-		return http.StatusNotFound
-	case strings.Contains(c, "VALIDATION") || strings.Contains(c, "INVALID_INPUT"):
-		return http.StatusBadRequest
-	case strings.Contains(c, "UNAUTHORIZED") || strings.Contains(c, "LOGIN_FAILED") || strings.Contains(c, "REFRESH_FAILED") || strings.Contains(c, "INVALID_TOKEN") || strings.Contains(c, "TOKEN_INVALID") || strings.Contains(c, "TOKEN_EXPIRED") || strings.Contains(c, "KEY_INVALID"):
-		return http.StatusUnauthorized
-	case strings.Contains(c, "FORBIDDEN"):
-		return http.StatusForbidden
-	case strings.Contains(c, "DUPLICATE") || strings.Contains(c, "CONFLICT"):
-		return http.StatusConflict
-	case strings.Contains(c, "LOCKED"):
-		return http.StatusForbidden
-	case strings.Contains(c, "RATE_LIMITED"):
-		return http.StatusTooManyRequests
-	case strings.Contains(c, "TOO_LARGE"):
-		return http.StatusRequestEntityTooLarge
-	default:
-		return http.StatusInternalServerError
+	if status, ok := codeToStatus[code]; ok {
+		return status
 	}
+	slog.Warn("unmapped error code, defaulting to 500", slog.String("code", string(code)))
+	return http.StatusInternalServerError
 }

--- a/src/pkg/httputil/response.go
+++ b/src/pkg/httputil/response.go
@@ -72,69 +72,91 @@ func WriteDomainError(w http.ResponseWriter, err error) {
 }
 
 // codeToStatus maps known error codes to HTTP status codes.
-// Codes from pkg/errcode use sentinel constants; cell-local codes that surface
-// through HTTP handlers are registered as literal Code values.
+// All codes use errcode constants for compile-time checking.
 var codeToStatus = map[errcode.Code]int{
 	// --- 404 Not Found ---
-	errcode.ErrMetadataNotFound:             http.StatusNotFound,
-	errcode.ErrCellNotFound:                 http.StatusNotFound,
-	errcode.ErrSliceNotFound:                http.StatusNotFound,
-	errcode.ErrContractNotFound:             http.StatusNotFound,
-	errcode.ErrAssemblyNotFound:             http.StatusNotFound,
-	errcode.ErrJourneyNotFound:              http.StatusNotFound,
-	errcode.ErrSessionNotFound:              http.StatusNotFound,
-	errcode.ErrOrderNotFound:                http.StatusNotFound,
-	errcode.ErrDeviceNotFound:               http.StatusNotFound,
-	errcode.ErrCommandNotFound:              http.StatusNotFound,
-	"ERR_AUTH_USER_NOT_FOUND":               http.StatusNotFound,
-	"ERR_AUTH_ROLE_NOT_FOUND":               http.StatusNotFound,
-	"ERR_CONFIG_NOT_FOUND":                  http.StatusNotFound,
-	"ERR_CONFIG_REPO_NOT_FOUND":             http.StatusNotFound,
-	"ERR_FLAG_NOT_FOUND":                    http.StatusNotFound,
-	"ERR_WS_CONN_NOT_FOUND":                http.StatusNotFound,
-	"ERR_AUDIT_REPO_NOT_FOUND":             http.StatusNotFound,
+	errcode.ErrMetadataNotFound:   http.StatusNotFound,
+	errcode.ErrCellNotFound:       http.StatusNotFound,
+	errcode.ErrSliceNotFound:      http.StatusNotFound,
+	errcode.ErrContractNotFound:   http.StatusNotFound,
+	errcode.ErrAssemblyNotFound:   http.StatusNotFound,
+	errcode.ErrJourneyNotFound:    http.StatusNotFound,
+	errcode.ErrSessionNotFound:    http.StatusNotFound,
+	errcode.ErrOrderNotFound:      http.StatusNotFound,
+	errcode.ErrDeviceNotFound:     http.StatusNotFound,
+	errcode.ErrCommandNotFound:    http.StatusNotFound,
+	errcode.ErrAuthUserNotFound:   http.StatusNotFound,
+	errcode.ErrAuthRoleNotFound:   http.StatusNotFound,
+	errcode.ErrConfigNotFound:     http.StatusNotFound,
+	errcode.ErrConfigRepoNotFound: http.StatusNotFound,
+	errcode.ErrFlagNotFound:       http.StatusNotFound,
+	errcode.ErrWSConnNotFound:     http.StatusNotFound,
+	errcode.ErrAuditRepoNotFound:  http.StatusNotFound,
 
 	// --- 400 Bad Request ---
-	errcode.ErrValidationFailed:             http.StatusBadRequest,
-	errcode.ErrMetadataInvalid:              http.StatusBadRequest,
-	errcode.ErrLifecycleInvalid:             http.StatusBadRequest,
-	errcode.ErrReferenceBroken:              http.StatusBadRequest,
-	"ERR_AUTH_INVALID_INPUT":                http.StatusBadRequest,
-	"ERR_AUTH_IDENTITY_INVALID_INPUT":       http.StatusBadRequest,
-	"ERR_AUTH_LOGIN_INVALID_INPUT":          http.StatusBadRequest,
-	"ERR_AUTH_REFRESH_INVALID_INPUT":        http.StatusBadRequest,
-	"ERR_AUTH_SESSION_INVALID_INPUT":        http.StatusBadRequest,
-	"ERR_AUTH_LOGOUT_INVALID_INPUT":         http.StatusBadRequest,
-	"ERR_AUTH_RBAC_INVALID_INPUT":           http.StatusBadRequest,
-	"ERR_CONFIG_INVALID_INPUT":              http.StatusBadRequest,
-	"ERR_CONFIG_PUBLISH_INVALID_INPUT":      http.StatusBadRequest,
-	"ERR_FLAG_INVALID_INPUT":                http.StatusBadRequest,
+	errcode.ErrValidationFailed:          http.StatusBadRequest,
+	errcode.ErrMetadataInvalid:           http.StatusBadRequest,
+	errcode.ErrLifecycleInvalid:          http.StatusBadRequest,
+	errcode.ErrReferenceBroken:           http.StatusBadRequest,
+	errcode.ErrAuthInvalidInput:          http.StatusBadRequest,
+	errcode.ErrAuthIdentityInvalidInput:  http.StatusBadRequest,
+	errcode.ErrAuthLoginInvalidInput:     http.StatusBadRequest,
+	errcode.ErrAuthRefreshInvalidInput:   http.StatusBadRequest,
+	errcode.ErrAuthSessionInvalidInput:   http.StatusBadRequest,
+	errcode.ErrAuthLogoutInvalidInput:    http.StatusBadRequest,
+	errcode.ErrAuthRBACInvalidInput:      http.StatusBadRequest,
+	errcode.ErrConfigInvalidInput:        http.StatusBadRequest,
+	errcode.ErrConfigPublishInvalidInput: http.StatusBadRequest,
+	errcode.ErrFlagInvalidInput:          http.StatusBadRequest,
 
 	// --- 401 Unauthorized ---
-	errcode.ErrAuthUnauthorized:             http.StatusUnauthorized,
-	errcode.ErrAuthKeyInvalid:               http.StatusUnauthorized,
-	errcode.ErrAuthTokenInvalid:             http.StatusUnauthorized,
-	errcode.ErrAuthTokenExpired:             http.StatusUnauthorized,
-	"ERR_AUTH_LOGIN_FAILED":                 http.StatusUnauthorized,
-	"ERR_AUTH_REFRESH_FAILED":               http.StatusUnauthorized,
-	"ERR_AUTH_REFRESH_TOKEN_REUSE":          http.StatusUnauthorized,
-	"ERR_AUTH_INVALID_TOKEN":                http.StatusUnauthorized,
+	errcode.ErrAuthUnauthorized:      http.StatusUnauthorized,
+	errcode.ErrAuthKeyInvalid:        http.StatusUnauthorized,
+	errcode.ErrAuthTokenInvalid:      http.StatusUnauthorized,
+	errcode.ErrAuthTokenExpired:      http.StatusUnauthorized,
+	errcode.ErrAuthLoginFailed:       http.StatusUnauthorized,
+	errcode.ErrAuthRefreshFailed:     http.StatusUnauthorized,
+	errcode.ErrAuthRefreshTokenReuse: http.StatusUnauthorized,
+	errcode.ErrAuthInvalidToken:      http.StatusUnauthorized,
 
 	// --- 403 Forbidden ---
-	errcode.ErrAuthForbidden:                http.StatusForbidden,
-	"ERR_AUTH_USER_LOCKED":                  http.StatusForbidden,
+	errcode.ErrAuthForbidden:  http.StatusForbidden,
+	errcode.ErrAuthUserLocked: http.StatusForbidden,
 
 	// --- 409 Conflict ---
-	"ERR_AUTH_USER_DUPLICATE":               http.StatusConflict,
-	"ERR_CONFIG_DUPLICATE":                  http.StatusConflict,
-	"ERR_CONFIG_REPO_DUPLICATE":             http.StatusConflict,
-	"ERR_FLAG_DUPLICATE":                    http.StatusConflict,
+	errcode.ErrAuthUserDuplicate:  http.StatusConflict,
+	errcode.ErrConfigDuplicate:    http.StatusConflict,
+	errcode.ErrConfigRepoDuplicate: http.StatusConflict,
+	errcode.ErrFlagDuplicate:      http.StatusConflict,
 
 	// --- 429 Too Many Requests ---
-	errcode.ErrRateLimited:                  http.StatusTooManyRequests,
+	errcode.ErrRateLimited: http.StatusTooManyRequests,
 
 	// --- 413 Request Entity Too Large ---
-	errcode.ErrBodyTooLarge:                 http.StatusRequestEntityTooLarge,
+	errcode.ErrBodyTooLarge: http.StatusRequestEntityTooLarge,
+
+	// --- 503 Service Unavailable ---
+	errcode.ErrWSHubStopping:  http.StatusServiceUnavailable,
+	errcode.ErrWSHubNotRunning: http.StatusServiceUnavailable,
+	errcode.ErrWSMaxConns:     http.StatusServiceUnavailable,
+
+	// --- 500 Internal Server Error ---
+	errcode.ErrInternal:          http.StatusInternalServerError,
+	errcode.ErrDependencyCycle:   http.StatusInternalServerError,
+	errcode.ErrBusClosed:         http.StatusInternalServerError,
+	errcode.ErrAdapterPGNoTx:     http.StatusInternalServerError,
+	errcode.ErrTestExecution:     http.StatusInternalServerError,
+	errcode.ErrCellMissingOutbox: http.StatusInternalServerError,
+	errcode.ErrArchiveUpload:     http.StatusInternalServerError,
+	errcode.ErrArchiveMarshal:    http.StatusInternalServerError,
+	errcode.ErrAuditRepoQuery:   http.StatusInternalServerError,
+	errcode.ErrConfigRepoQuery:  http.StatusInternalServerError,
+	errcode.ErrAuthKeyMissing:   http.StatusInternalServerError,
+	errcode.ErrWSAlreadyStarted: http.StatusInternalServerError,
+	errcode.ErrWSAlreadyStopped: http.StatusInternalServerError,
+
+	// --- 501 Not Implemented ---
+	errcode.ErrNotImplemented: http.StatusNotImplemented,
 }
 
 // mapCodeToStatus maps an errcode.Code to the appropriate HTTP status code.

--- a/src/pkg/httputil/response.go
+++ b/src/pkg/httputil/response.go
@@ -40,16 +40,18 @@ func WriteError(w http.ResponseWriter, status int, code, message string) {
 }
 
 // WriteDecodeError writes the HTTP error response for a DecodeJSON failure.
-// It preserves the legacy API contract: body-too-large returns 413 with
-// ERR_BODY_TOO_LARGE; all other decode errors return 400 with
-// ERR_VALIDATION_REQUIRED_FIELD and message "invalid request body".
+// It maps the errcode embedded in the error to the correct HTTP status via
+// mapCodeToStatus, preserving each handler's existing external contract:
+//   - ErrValidationFailed  → 400
+//   - ErrBodyTooLarge      → 413
+//   - ErrInternal          → 500
 func WriteDecodeError(w http.ResponseWriter, err error) {
 	var ecErr *errcode.Error
-	if errors.As(err, &ecErr) && ecErr.Code == errcode.ErrBodyTooLarge {
-		WriteError(w, http.StatusRequestEntityTooLarge, string(errcode.ErrBodyTooLarge), ecErr.Message)
+	if errors.As(err, &ecErr) {
+		WriteError(w, mapCodeToStatus(ecErr.Code), string(ecErr.Code), ecErr.Message)
 		return
 	}
-	WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+	WriteError(w, http.StatusBadRequest, string(errcode.ErrValidationFailed), "invalid request body")
 }
 
 // WriteDomainError inspects err and writes the appropriate HTTP error response.

--- a/src/pkg/httputil/response.go
+++ b/src/pkg/httputil/response.go
@@ -39,6 +39,19 @@ func WriteError(w http.ResponseWriter, status int, code, message string) {
 	}
 }
 
+// WriteDecodeError writes the HTTP error response for a DecodeJSON failure.
+// It preserves the legacy API contract: body-too-large returns 413 with
+// ERR_BODY_TOO_LARGE; all other decode errors return 400 with
+// ERR_VALIDATION_REQUIRED_FIELD and message "invalid request body".
+func WriteDecodeError(w http.ResponseWriter, err error) {
+	var ecErr *errcode.Error
+	if errors.As(err, &ecErr) && ecErr.Code == errcode.ErrBodyTooLarge {
+		WriteError(w, http.StatusRequestEntityTooLarge, string(errcode.ErrBodyTooLarge), ecErr.Message)
+		return
+	}
+	WriteError(w, http.StatusBadRequest, "ERR_VALIDATION_REQUIRED_FIELD", "invalid request body")
+}
+
 // WriteDomainError inspects err and writes the appropriate HTTP error response.
 //   - If err is an *errcode.Error the error code is mapped to an HTTP status and
 //     the errcode Message is used as the response message.

--- a/src/pkg/httputil/response_test.go
+++ b/src/pkg/httputil/response_test.go
@@ -3,8 +3,14 @@ package httputil
 import (
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -51,30 +57,56 @@ func TestMapCodeToStatus_ExplicitMapping(t *testing.T) {
 		{errcode.ErrBodyTooLarge, http.StatusRequestEntityTooLarge},
 
 		// Cell-local NOT_FOUND codes -> 404
-		{"ERR_AUTH_USER_NOT_FOUND", http.StatusNotFound},
-		{"ERR_CONFIG_NOT_FOUND", http.StatusNotFound},
-		{"ERR_FLAG_NOT_FOUND", http.StatusNotFound},
+		{errcode.ErrAuthUserNotFound, http.StatusNotFound},
+		{errcode.ErrConfigNotFound, http.StatusNotFound},
+		{errcode.ErrFlagNotFound, http.StatusNotFound},
+		{errcode.ErrAuthRoleNotFound, http.StatusNotFound},
+		{errcode.ErrConfigRepoNotFound, http.StatusNotFound},
+		{errcode.ErrWSConnNotFound, http.StatusNotFound},
+		{errcode.ErrAuditRepoNotFound, http.StatusNotFound},
 
 		// Cell-local validation codes -> 400
-		{"ERR_AUTH_LOGIN_INVALID_INPUT", http.StatusBadRequest},
-		{"ERR_CONFIG_INVALID_INPUT", http.StatusBadRequest},
+		{errcode.ErrAuthLoginInvalidInput, http.StatusBadRequest},
+		{errcode.ErrConfigInvalidInput, http.StatusBadRequest},
+		{errcode.ErrAuthInvalidInput, http.StatusBadRequest},
+		{errcode.ErrAuthIdentityInvalidInput, http.StatusBadRequest},
+		{errcode.ErrAuthRefreshInvalidInput, http.StatusBadRequest},
+		{errcode.ErrAuthSessionInvalidInput, http.StatusBadRequest},
+		{errcode.ErrAuthLogoutInvalidInput, http.StatusBadRequest},
+		{errcode.ErrAuthRBACInvalidInput, http.StatusBadRequest},
+		{errcode.ErrConfigPublishInvalidInput, http.StatusBadRequest},
+		{errcode.ErrFlagInvalidInput, http.StatusBadRequest},
 
 		// Cell-local auth failure codes -> 401
-		{"ERR_AUTH_LOGIN_FAILED", http.StatusUnauthorized},
-		{"ERR_AUTH_REFRESH_FAILED", http.StatusUnauthorized},
+		{errcode.ErrAuthLoginFailed, http.StatusUnauthorized},
+		{errcode.ErrAuthRefreshFailed, http.StatusUnauthorized},
+		{errcode.ErrAuthRefreshTokenReuse, http.StatusUnauthorized},
+		{errcode.ErrAuthInvalidToken, http.StatusUnauthorized},
 
 		// Cell-local locked -> 403
-		{"ERR_AUTH_USER_LOCKED", http.StatusForbidden},
+		{errcode.ErrAuthUserLocked, http.StatusForbidden},
 
 		// Cell-local duplicate -> 409
-		{"ERR_AUTH_USER_DUPLICATE", http.StatusConflict},
-		{"ERR_CONFIG_DUPLICATE", http.StatusConflict},
+		{errcode.ErrAuthUserDuplicate, http.StatusConflict},
+		{errcode.ErrConfigDuplicate, http.StatusConflict},
+		{errcode.ErrConfigRepoDuplicate, http.StatusConflict},
+		{errcode.ErrFlagDuplicate, http.StatusConflict},
 
-		// Codes that should fallback to 500
+		// 500 Internal Server Error (explicit, not fallback)
 		{errcode.ErrInternal, http.StatusInternalServerError},
 		{errcode.ErrDependencyCycle, http.StatusInternalServerError},
 		{errcode.ErrBusClosed, http.StatusInternalServerError},
 		{errcode.ErrAdapterPGNoTx, http.StatusInternalServerError},
+		{errcode.ErrTestExecution, http.StatusInternalServerError},
+		{errcode.ErrCellMissingOutbox, http.StatusInternalServerError},
+
+		// 503 Service Unavailable
+		{errcode.ErrWSHubStopping, http.StatusServiceUnavailable},
+		{errcode.ErrWSHubNotRunning, http.StatusServiceUnavailable},
+		{errcode.ErrWSMaxConns, http.StatusServiceUnavailable},
+
+		// 501 Not Implemented
+		{errcode.ErrNotImplemented, http.StatusNotImplemented},
 	}
 
 	for _, tt := range tests {
@@ -213,4 +245,58 @@ func TestWriteDomainError_WithDetails(t *testing.T) {
 	errObj := body["error"].(map[string]any)
 	details := errObj["details"].(map[string]any)
 	assert.Equal(t, "email", details["field"])
+}
+
+// TestCodeToStatus_Exhaustive parses pkg/errcode/errcode.go with go/ast,
+// extracts every Code constant, and verifies it has an entry in codeToStatus.
+// This fails loudly when a new errcode.Code is added without registering an
+// HTTP status mapping, forcing the developer to make a conscious choice.
+func TestCodeToStatus_Exhaustive(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	errcodeFile := filepath.Join(filepath.Dir(thisFile), "..", "errcode", "errcode.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, errcodeFile, nil, 0)
+	require.NoError(t, err, "failed to parse errcode.go")
+
+	// Collect string values of all `const ... Code = "..."` declarations.
+	var codes []string
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok || vs.Type == nil {
+				continue
+			}
+			ident, ok := vs.Type.(*ast.Ident)
+			if !ok || ident.Name != "Code" {
+				continue
+			}
+			for _, val := range vs.Values {
+				lit, ok := val.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				s, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				codes = append(codes, s)
+			}
+		}
+	}
+
+	require.NotEmpty(t, codes, "should find Code constants in errcode.go")
+
+	for _, code := range codes {
+		t.Run(code, func(t *testing.T) {
+			_, registered := codeToStatus[errcode.Code(code)]
+			assert.True(t, registered,
+				"errcode.Code %q has no entry in codeToStatus — add it to the map in response.go", code)
+		})
+	}
 }

--- a/src/pkg/httputil/response_test.go
+++ b/src/pkg/httputil/response_test.go
@@ -12,37 +12,83 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMapCodeToStatus(t *testing.T) {
+func TestMapCodeToStatus_ExplicitMapping(t *testing.T) {
 	tests := []struct {
-		code   errcode.Code
-		want   int
+		code       errcode.Code
+		wantStatus int
 	}{
-		{"ERR_NOT_FOUND", http.StatusNotFound},
-		{"ERR_USER_NOT_FOUND", http.StatusNotFound},
-		{"ERR_VALIDATION_REQUIRED_FIELD", http.StatusBadRequest},
-		{"ERR_AUTH_LOGIN_INVALID_INPUT", http.StatusBadRequest},
+		// NOT_FOUND group -> 404
+		{errcode.ErrMetadataNotFound, http.StatusNotFound},
+		{errcode.ErrCellNotFound, http.StatusNotFound},
+		{errcode.ErrSliceNotFound, http.StatusNotFound},
+		{errcode.ErrContractNotFound, http.StatusNotFound},
+		{errcode.ErrAssemblyNotFound, http.StatusNotFound},
+		{errcode.ErrJourneyNotFound, http.StatusNotFound},
+		{errcode.ErrSessionNotFound, http.StatusNotFound},
+		{errcode.ErrOrderNotFound, http.StatusNotFound},
+		{errcode.ErrDeviceNotFound, http.StatusNotFound},
+		{errcode.ErrCommandNotFound, http.StatusNotFound},
+
+		// Validation group -> 400
+		{errcode.ErrValidationFailed, http.StatusBadRequest},
+		{errcode.ErrMetadataInvalid, http.StatusBadRequest},
+		{errcode.ErrLifecycleInvalid, http.StatusBadRequest},
+		{errcode.ErrReferenceBroken, http.StatusBadRequest},
+
+		// Auth group -> 401
 		{errcode.ErrAuthUnauthorized, http.StatusUnauthorized},
+		{errcode.ErrAuthKeyInvalid, http.StatusUnauthorized},
 		{errcode.ErrAuthTokenInvalid, http.StatusUnauthorized},
 		{errcode.ErrAuthTokenExpired, http.StatusUnauthorized},
-		{errcode.ErrAuthKeyInvalid, http.StatusUnauthorized},
+
+		// Forbidden -> 403
+		{errcode.ErrAuthForbidden, http.StatusForbidden},
+
+		// Rate limited -> 429
+		{errcode.ErrRateLimited, http.StatusTooManyRequests},
+
+		// Body too large -> 413
+		{errcode.ErrBodyTooLarge, http.StatusRequestEntityTooLarge},
+
+		// Cell-local NOT_FOUND codes -> 404
+		{"ERR_AUTH_USER_NOT_FOUND", http.StatusNotFound},
+		{"ERR_CONFIG_NOT_FOUND", http.StatusNotFound},
+		{"ERR_FLAG_NOT_FOUND", http.StatusNotFound},
+
+		// Cell-local validation codes -> 400
+		{"ERR_AUTH_LOGIN_INVALID_INPUT", http.StatusBadRequest},
+		{"ERR_CONFIG_INVALID_INPUT", http.StatusBadRequest},
+
+		// Cell-local auth failure codes -> 401
 		{"ERR_AUTH_LOGIN_FAILED", http.StatusUnauthorized},
 		{"ERR_AUTH_REFRESH_FAILED", http.StatusUnauthorized},
-		{"ERR_AUTH_FORBIDDEN", http.StatusForbidden},
-		{"ERR_USER_LOCKED", http.StatusForbidden},
-		{"ERR_DUPLICATE_USER", http.StatusConflict},
-		{"ERR_CONFLICT", http.StatusConflict},
-		{"ERR_RATE_LIMITED", http.StatusTooManyRequests},
-		{"ERR_TOO_LARGE", http.StatusRequestEntityTooLarge},
-		{"ERR_INTERNAL", http.StatusInternalServerError},
-		{"ERR_UNKNOWN_CODE", http.StatusInternalServerError},
+
+		// Cell-local locked -> 403
+		{"ERR_AUTH_USER_LOCKED", http.StatusForbidden},
+
+		// Cell-local duplicate -> 409
+		{"ERR_AUTH_USER_DUPLICATE", http.StatusConflict},
+		{"ERR_CONFIG_DUPLICATE", http.StatusConflict},
+
+		// Codes that should fallback to 500
+		{errcode.ErrInternal, http.StatusInternalServerError},
+		{errcode.ErrDependencyCycle, http.StatusInternalServerError},
+		{errcode.ErrBusClosed, http.StatusInternalServerError},
+		{errcode.ErrAdapterPGNoTx, http.StatusInternalServerError},
 	}
 
 	for _, tt := range tests {
 		t.Run(string(tt.code), func(t *testing.T) {
 			got := mapCodeToStatus(tt.code)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantStatus, got)
 		})
 	}
+}
+
+func TestMapCodeToStatus_UnknownCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteDomainError(rec, errcode.New("ERR_TOTALLY_NEW", "test"))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestWriteError(t *testing.T) {
@@ -85,30 +131,30 @@ func TestWriteDomainError_ErrcodeError(t *testing.T) {
 	}{
 		{
 			name:       "not found",
-			err:        errcode.New("ERR_USER_NOT_FOUND", "user not found"),
+			err:        errcode.New(errcode.ErrCellNotFound, "cell not found"),
 			wantStatus: http.StatusNotFound,
-			wantCode:   "ERR_USER_NOT_FOUND",
-			wantMsg:    "user not found",
+			wantCode:   string(errcode.ErrCellNotFound),
+			wantMsg:    "cell not found",
 		},
 		{
 			name:       "validation",
-			err:        errcode.New("ERR_VALIDATION_REQUIRED_FIELD", "field missing"),
+			err:        errcode.New(errcode.ErrValidationFailed, "field missing"),
 			wantStatus: http.StatusBadRequest,
-			wantCode:   "ERR_VALIDATION_REQUIRED_FIELD",
+			wantCode:   string(errcode.ErrValidationFailed),
 			wantMsg:    "field missing",
 		},
 		{
 			name:       "unauthorized",
-			err:        errcode.New("ERR_AUTH_UNAUTHORIZED", "bad creds"),
+			err:        errcode.New(errcode.ErrAuthUnauthorized, "bad creds"),
 			wantStatus: http.StatusUnauthorized,
-			wantCode:   "ERR_AUTH_UNAUTHORIZED",
+			wantCode:   string(errcode.ErrAuthUnauthorized),
 			wantMsg:    "bad creds",
 		},
 		{
 			name:       "forbidden",
-			err:        errcode.New("ERR_AUTH_FORBIDDEN", "no access"),
+			err:        errcode.New(errcode.ErrAuthForbidden, "no access"),
 			wantStatus: http.StatusForbidden,
-			wantCode:   "ERR_AUTH_FORBIDDEN",
+			wantCode:   string(errcode.ErrAuthForbidden),
 			wantMsg:    "no access",
 		},
 	}
@@ -152,7 +198,7 @@ func TestWriteDomainError_PlainError(t *testing.T) {
 
 func TestWriteDomainError_WithDetails(t *testing.T) {
 	ecErr := errcode.WithDetails(
-		errcode.New("ERR_VALIDATION_REQUIRED_FIELD", "field missing"),
+		errcode.New(errcode.ErrValidationFailed, "field missing"),
 		map[string]any{"field": "email"},
 	)
 

--- a/src/runtime/auth/keys.go
+++ b/src/runtime/auth/keys.go
@@ -57,7 +57,7 @@ const (
 )
 
 // ErrKeyMissing indicates a required JWT key environment variable is not set.
-var ErrKeyMissing = errcode.Code("ERR_AUTH_KEY_MISSING")
+var ErrKeyMissing = errcode.ErrAuthKeyMissing
 
 // LoadKeysFromEnv reads PEM-encoded RSA keys from environment variables
 // GOCELL_JWT_PRIVATE_KEY and GOCELL_JWT_PUBLIC_KEY. It returns an errcode

--- a/src/runtime/http/middleware/access_log.go
+++ b/src/runtime/http/middleware/access_log.go
@@ -11,8 +11,9 @@ import (
 // AccessLog logs structured request/response information via slog.Info.
 // Fields: method, path, status, duration_ms, request_id.
 //
-// If a RecorderState already exists in the context (set by Recovery),
-// AccessLog reuses it to avoid additional httpsnoop wrapping.
+// When a RecorderState exists in the context (created by the Recorder
+// middleware), AccessLog reuses it. Otherwise it creates its own to
+// remain usable as a standalone middleware.
 func AccessLog(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/src/runtime/http/middleware/access_log.go
+++ b/src/runtime/http/middleware/access_log.go
@@ -27,16 +27,18 @@ func AccessLog(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 
-		duration := time.Since(start)
-		attrs := []any{
-			slog.String("method", r.Method),
-			slog.String("path", r.URL.Path),
-			slog.Int("status", state.Status()),
-			slog.Int64("duration_ms", duration.Milliseconds()),
-		}
-		if reqID, ok := ctxkeys.RequestIDFrom(r.Context()); ok {
-			attrs = append(attrs, slog.String("request_id", reqID))
-		}
-		slog.Info("http request", attrs...)
+		safeObserve(func() {
+			duration := time.Since(start)
+			attrs := []any{
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", state.Status()),
+				slog.Int64("duration_ms", duration.Milliseconds()),
+			}
+			if reqID, ok := ctxkeys.RequestIDFrom(r.Context()); ok {
+				attrs = append(attrs, slog.String("request_id", reqID))
+			}
+			slog.Info("http request", attrs...)
+		})
 	})
 }

--- a/src/runtime/http/middleware/access_log_test.go
+++ b/src/runtime/http/middleware/access_log_test.go
@@ -16,13 +16,15 @@ import (
 func TestAccessLog_LogsFields(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	original := slog.Default()
 	slog.SetDefault(logger)
-	defer slog.SetDefault(slog.Default())
+	defer slog.SetDefault(original)
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
-	handler := AccessLog(inner)
+	// Recorder creates the shared RecorderState that AccessLog reads.
+	handler := Recorder(AccessLog(inner))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
 	// Simulate request_id already in context
@@ -45,17 +47,44 @@ func TestAccessLog_LogsFields(t *testing.T) {
 	assert.Equal(t, "req-123", logEntry["request_id"])
 }
 
+// TestAccessLog_Standalone verifies AccessLog works without Recorder middleware,
+// creating its own RecorderState.
+func TestAccessLog_Standalone(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	original := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(original)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	// No Recorder — AccessLog creates its own RecorderState.
+	handler := AccessLog(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var logEntry map[string]any
+	err := json.Unmarshal(buf.Bytes(), &logEntry)
+	require.NoError(t, err)
+	assert.Equal(t, float64(404), logEntry["status"])
+}
+
 func TestAccessLog_DefaultStatus200(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	original := slog.Default()
 	slog.SetDefault(logger)
-	defer slog.SetDefault(slog.Default())
+	defer slog.SetDefault(original)
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// No explicit WriteHeader → default 200
 		_, _ = w.Write([]byte("ok"))
 	})
-	handler := AccessLog(inner)
+	// Recorder creates the shared RecorderState that AccessLog reads.
+	handler := Recorder(AccessLog(inner))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()

--- a/src/runtime/http/middleware/metrics.go
+++ b/src/runtime/http/middleware/metrics.go
@@ -27,7 +27,9 @@ func Metrics(collector metrics.Collector) func(http.Handler) http.Handler {
 
 			next.ServeHTTP(w, r)
 
-			collector.RecordRequest(r.Method, r.URL.Path, state.Status(), time.Since(start).Seconds())
+			safeObserve(func() {
+				collector.RecordRequest(r.Method, r.URL.Path, state.Status(), time.Since(start).Seconds())
+			})
 		})
 	}
 }

--- a/src/runtime/http/middleware/metrics.go
+++ b/src/runtime/http/middleware/metrics.go
@@ -10,11 +10,9 @@ import (
 // Metrics returns an HTTP middleware that records request count and duration
 // using the provided Collector.
 //
-// If a RecorderState already exists in the context (set by Recovery),
-// Metrics reuses it to avoid additional httpsnoop wrapping.
-//
-// On panic, recording is skipped because the inner middleware's code after
-// ServeHTTP does not execute. Recovery logs the full panic context separately.
+// When a RecorderState exists in the context (created by the Recorder
+// middleware), Metrics reuses it. Otherwise it creates its own to
+// remain usable as a standalone middleware.
 func Metrics(collector metrics.Collector) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/runtime/http/middleware/metrics_test.go
+++ b/src/runtime/http/middleware/metrics_test.go
@@ -11,9 +11,10 @@ import (
 
 func TestMetrics_RecordsMetrics(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Recorder creates the shared RecorderState that Metrics reads.
+	handler := Recorder(Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-	}))
+	})))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
 	rec := httptest.NewRecorder()
@@ -28,9 +29,10 @@ func TestMetrics_RecordsMetrics(t *testing.T) {
 
 func TestMetrics_DefaultStatus200(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Recorder creates the shared RecorderState that Metrics reads.
+	handler := Recorder(Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("ok"))
-	}))
+	})))
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
@@ -41,12 +43,14 @@ func TestMetrics_DefaultStatus200(t *testing.T) {
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
-func TestMetrics_PanicSkipsRecord(t *testing.T) {
+func TestMetrics_PanicRecordsStatus500(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	// Recovery wraps Metrics — same as default router chain.
-	handler := Recovery(Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// New chain order: Recorder → Metrics → Recovery → handler.
+	// Recovery catches panic and writes 500; Metrics sees the 500 status
+	// because it shares the RecorderState created by Recorder.
+	handler := Recorder(Metrics(c)(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		panic("boom")
-	})))
+	}))))
 
 	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
 	rec := httptest.NewRecorder()
@@ -54,17 +58,37 @@ func TestMetrics_PanicSkipsRecord(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
-	// Panic request must NOT be recorded in metrics.
-	// Before this fix, defer caused it to record as 200.
 	snap := c.Snapshot()
-	assert.Empty(t, snap.RequestCounts, "panic request must not appear in metrics")
+	key := "GET /panic 500"
+	assert.Equal(t, int64(1), snap.RequestCounts[key], "panic request must be recorded as status 500 in metrics")
+}
+
+// TestMetrics_Standalone verifies Metrics works without Recorder middleware,
+// creating its own RecorderState.
+func TestMetrics_Standalone(t *testing.T) {
+	c := metrics.NewInMemoryCollector()
+	// No Recorder — Metrics creates its own RecorderState.
+	handler := Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/jobs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	snap := c.Snapshot()
+	key := "POST /jobs 202"
+	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
 func TestMetrics_MultipleRequests(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Recorder creates the shared RecorderState that Metrics reads.
+	handler := Recorder(Metrics(c)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
+	})))
 
 	for range 5 {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/src/runtime/http/middleware/recorder_middleware.go
+++ b/src/runtime/http/middleware/recorder_middleware.go
@@ -1,0 +1,19 @@
+package middleware
+
+import "net/http"
+
+// Recorder creates a shared RecorderState and stores it in the request
+// context so downstream middleware (AccessLog, Metrics, Recovery) can
+// reuse it without redundant httpsnoop wrapping.
+//
+// Place Recorder early in the middleware chain — before any middleware
+// that needs to observe the final response status (e.g. AccessLog,
+// Metrics) and before Recovery so that a panic-recovered 500 response
+// is visible to all observers.
+func Recorder(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		state, wrapped := NewRecorder(w)
+		ctx := WithRecorderState(r.Context(), state)
+		next.ServeHTTP(wrapped, r.WithContext(ctx))
+	})
+}

--- a/src/runtime/http/middleware/recorder_middleware_test.go
+++ b/src/runtime/http/middleware/recorder_middleware_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecorder_CreatesStateInContext(t *testing.T) {
+	var gotState *RecorderState
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotState = RecorderStateFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Recorder(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.NotNil(t, gotState, "Recorder middleware must store RecorderState in context")
+	assert.Equal(t, http.StatusOK, gotState.Status())
+}
+
+func TestRecorder_DownstreamSeesWrittenStatus(t *testing.T) {
+	var gotState *RecorderState
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotState = RecorderStateFrom(r.Context())
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	handler := Recorder(inner)
+	req := httptest.NewRequest(http.MethodPost, "/items", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.NotNil(t, gotState)
+	assert.Equal(t, http.StatusCreated, gotState.Status())
+	assert.True(t, gotState.Committed())
+}

--- a/src/runtime/http/middleware/recovery.go
+++ b/src/runtime/http/middleware/recovery.go
@@ -19,14 +19,21 @@ import (
 // If the response has already been committed (WriteHeader called), Recovery
 // only logs the panic and does not attempt to write an error response.
 //
-// Recovery creates the shared RecorderState and stores it in the context so
-// downstream middleware (AccessLog, Tracing, Metrics) can reuse it without
-// additional httpsnoop wrapping.
+// When a RecorderState exists in the context (created by the Recorder
+// middleware), Recovery reuses it so upstream middleware (AccessLog, Metrics)
+// can observe the 500 status. When used standalone without Recorder,
+// Recovery creates its own RecorderState and stores it in the context,
+// preserving committed-response detection.
 func Recovery(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		state, w := NewRecorder(w)
-		ctx := WithRecorderState(r.Context(), state)
-		r = r.WithContext(ctx)
+		state := RecorderStateFrom(r.Context())
+		if state == nil {
+			var wrapped http.ResponseWriter
+			state, wrapped = NewRecorder(w)
+			ctx := WithRecorderState(r.Context(), state)
+			r = r.WithContext(ctx)
+			w = wrapped
+		}
 
 		defer func() {
 			if v := recover(); v != nil {

--- a/src/runtime/http/middleware/recovery_test.go
+++ b/src/runtime/http/middleware/recovery_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 func TestRecovery_NoPanic(t *testing.T) {
-	handler := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Recorder creates the shared RecorderState that Recovery reads.
+	handler := Recorder(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
-	}))
+	})))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -25,9 +26,9 @@ func TestRecovery_NoPanic(t *testing.T) {
 }
 
 func TestRecovery_PanicString(t *testing.T) {
-	handler := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recorder(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		panic("test panic")
-	}))
+	})))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	rec := httptest.NewRecorder()
@@ -48,9 +49,9 @@ func TestRecovery_PanicString(t *testing.T) {
 }
 
 func TestRecovery_PanicError(t *testing.T) {
-	handler := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recorder(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		panic(42)
-	}))
+	})))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -59,12 +60,50 @@ func TestRecovery_PanicError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
-func TestRecovery_PanicAfterPartialWrite(t *testing.T) {
+// TestRecovery_Standalone verifies Recovery works without Recorder middleware,
+// creating its own RecorderState for committed-response detection.
+func TestRecovery_Standalone(t *testing.T) {
+	handler := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("standalone panic")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var body map[string]any
+	err := json.NewDecoder(rec.Body).Decode(&body)
+	require.NoError(t, err)
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ERR_INTERNAL", errObj["code"])
+}
+
+// TestRecovery_StandaloneCommitted verifies Recovery detects committed
+// responses even without Recorder middleware in the chain.
+func TestRecovery_StandaloneCommitted(t *testing.T) {
 	handler := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("partial"))
-		panic("late panic")
+		panic("late standalone panic")
 	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "status must remain 200 — already committed")
+	assert.Equal(t, "partial", rec.Body.String(), "body must not have JSON error appended")
+}
+
+func TestRecovery_PanicAfterPartialWrite(t *testing.T) {
+	handler := Recorder(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+		panic("late panic")
+	})))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()

--- a/src/runtime/http/middleware/safe_observe.go
+++ b/src/runtime/http/middleware/safe_observe.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"log/slog"
+	"runtime/debug"
+)
+
+// safeObserve runs fn and recovers from any panic, logging it via slog.Error
+// instead of letting it escape the request chain.
+//
+// Used by observability middleware (AccessLog, Metrics) whose post-ServeHTTP
+// code sits outside Recovery. A bug in the collector or logger must not crash
+// the process — at worst it drops one observation.
+//
+// ref: prometheus/client_golang promhttp — instrumentation handler panics are
+// silently dropped rather than propagated to the caller.
+func safeObserve(fn func()) {
+	defer func() {
+		if v := recover(); v != nil {
+			slog.Error("observability middleware panic",
+				slog.Any("panic", v),
+				slog.String("stack", string(debug.Stack())),
+			)
+		}
+	}()
+	fn()
+}

--- a/src/runtime/http/middleware/safe_observe_test.go
+++ b/src/runtime/http/middleware/safe_observe_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeObserve_PanicDoesNotPropagate(t *testing.T) {
+	assert.NotPanics(t, func() {
+		safeObserve(func() {
+			panic("kaboom")
+		})
+	})
+}
+
+func TestMetrics_CollectorPanicDoesNotCrash(t *testing.T) {
+	// A collector that panics in RecordRequest must not crash the request.
+	handler := Recorder(Metrics(&panicCollector{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	assert.NotPanics(t, func() {
+		handler.ServeHTTP(rec, req)
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestAccessLog_PanicDoesNotCrash(t *testing.T) {
+	// Even if slog panics (e.g. custom handler), the request must complete.
+	// We test via safeObserve directly since we cannot easily inject a panicking slog.
+	assert.NotPanics(t, func() {
+		safeObserve(func() {
+			panic("slog boom")
+		})
+	})
+}
+
+// panicCollector implements metrics.Collector but panics on RecordRequest.
+type panicCollector struct{}
+
+func (p *panicCollector) RecordRequest(_, _ string, _ int, _ float64) {
+	panic("collector panic in RecordRequest")
+}

--- a/src/runtime/http/middleware/tracing.go
+++ b/src/runtime/http/middleware/tracing.go
@@ -10,12 +10,9 @@ import (
 // The span name is "{method} {path}". Trace and span IDs are stored in the
 // request context via ctxkeys for logging correlation.
 //
-// If a RecorderState already exists in the context (set by Recovery),
-// Tracing reuses it to avoid additional httpsnoop wrapping.
-//
-// On panic, the span is ended (via defer) but status is not recorded because
-// the inner defer runs before Recovery catches the panic. Recovery logs the
-// full panic context separately.
+// When a RecorderState exists in the context (created by the Recorder
+// middleware), Tracing reuses it. Otherwise it creates its own to
+// capture http.status_code as a standalone middleware.
 func Tracing(tracer tracing.Tracer) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/runtime/http/router/router.go
+++ b/src/runtime/http/router/router.go
@@ -67,7 +67,12 @@ type Router struct {
 //
 // Default middleware chain (applied in order):
 //
-//	RequestID -> RealIP -> Recovery -> AccessLog -> SecurityHeaders -> BodyLimit
+//	RequestID → RealIP → Recorder → AccessLog → [Metrics] → Recovery → SecurityHeaders → BodyLimit
+//
+// Recorder creates the shared RecorderState at the chain head. AccessLog and
+// Metrics sit outside Recovery so their post-ServeHTTP code always executes —
+// even when Recovery catches a panic and writes a 500 response. This ensures
+// panic requests are visible in both logs and metrics.
 func New(opts ...Option) *Router {
 	r := &Router{
 		mux:       chi.NewRouter(),
@@ -77,20 +82,26 @@ func New(opts ...Option) *Router {
 		o(r)
 	}
 
-	// Default middleware chain.
+	// Default middleware chain — Recorder before AccessLog/Metrics,
+	// Recovery after them so panic-recovered 500s are observable.
 	r.mux.Use(
 		middleware.RequestID,
 		middleware.RealIP(nil),
-		middleware.Recovery,
+		middleware.Recorder,
 		middleware.AccessLog,
-		middleware.SecurityHeaders,
-		middleware.BodyLimit(r.bodyLimit),
 	)
 
-	// Add metrics middleware if collector provided.
+	// Metrics (if configured) — must be before Recovery so panic
+	// requests are recorded as status 500.
 	if r.metricsCollector != nil {
 		r.mux.Use(middleware.Metrics(r.metricsCollector))
 	}
+
+	r.mux.Use(
+		middleware.Recovery,
+		middleware.SecurityHeaders,
+		middleware.BodyLimit(r.bodyLimit),
+	)
 
 	// Auto-register infrastructure endpoints.
 	if r.healthHandler != nil {

--- a/src/runtime/http/router/router_test.go
+++ b/src/runtime/http/router/router_test.go
@@ -1,8 +1,10 @@
 package router
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -152,6 +154,106 @@ func TestRouterChain_WebSocketUpgrade(t *testing.T) {
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	require.NoError(t, err, "WebSocket upgrade through router middleware chain must succeed")
 	conn.CloseNow()
+}
+
+func TestPanicRequestRecordedInAccessLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	original := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(original)
+
+	r := New()
+	r.Handle("/boom", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		panic("access log panic test")
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// Parse all JSON log entries and find the access log (level=INFO, msg="http request").
+	var found bool
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry["msg"] == "http request" {
+			found = true
+			assert.Equal(t, float64(500), entry["status"], "access log must capture status 500 for panic requests")
+			break
+		}
+	}
+	assert.True(t, found, "access log entry must exist for panic request")
+}
+
+func TestPanicRequestRecordedInMetrics(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	r := New(WithMetricsCollector(mc))
+	r.Handle("/boom", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		panic("metrics panic test")
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	snap := mc.Snapshot()
+	key := "GET /boom 500"
+	assert.Equal(t, int64(1), snap.RequestCounts[key], "metrics must record panic request as status 500")
+}
+
+func TestNormalRequestUnchanged(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	original := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(original)
+
+	r := New(WithMetricsCollector(mc))
+	r.Handle("/ok", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":"ok"}`))
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, `{"data":"ok"}`, rec.Body.String())
+
+	// Verify access log has status 200.
+	var found bool
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry["msg"] == "http request" {
+			found = true
+			assert.Equal(t, float64(200), entry["status"])
+			break
+		}
+	}
+	assert.True(t, found, "access log entry must exist")
+
+	// Verify metrics recorded status 200.
+	snap := mc.Snapshot()
+	key := "GET /ok 200"
+	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
 func TestDefaultMiddlewareApplied(t *testing.T) {

--- a/src/runtime/websocket/errors.go
+++ b/src/runtime/websocket/errors.go
@@ -2,25 +2,12 @@ package websocket
 
 import "github.com/ghbvf/gocell/pkg/errcode"
 
-// Hub error codes.
-const (
-	// ErrWSConnNotFound indicates Send targeted a non-existent connection.
-	ErrWSConnNotFound errcode.Code = "ERR_WS_CONN_NOT_FOUND"
-
-	// ErrWSAlreadyStarted indicates Start was called on a running Hub.
-	ErrWSAlreadyStarted errcode.Code = "ERR_WS_ALREADY_STARTED"
-
-	// ErrWSAlreadyStopped indicates Start or Stop was called on a stopped Hub.
-	ErrWSAlreadyStopped errcode.Code = "ERR_WS_ALREADY_STOPPED"
-
-	// ErrWSHubStopping indicates Register was called during shutdown.
-	ErrWSHubStopping errcode.Code = "ERR_WS_HUB_STOPPING"
-
-	// ErrWSHubNotRunning indicates Register was called on a non-running Hub
-	// (idle or stopped).
-	ErrWSHubNotRunning errcode.Code = "ERR_WS_HUB_NOT_RUNNING"
-
-	// ErrWSMaxConns indicates Register was rejected because the Hub has
-	// reached its MaxConnections limit.
-	ErrWSMaxConns errcode.Code = "ERR_WS_MAX_CONNS"
+// Hub error codes — aliases to centralized errcode constants for local readability.
+var (
+	ErrWSConnNotFound   = errcode.ErrWSConnNotFound
+	ErrWSAlreadyStarted = errcode.ErrWSAlreadyStarted
+	ErrWSAlreadyStopped = errcode.ErrWSAlreadyStopped
+	ErrWSHubStopping    = errcode.ErrWSHubStopping
+	ErrWSHubNotRunning  = errcode.ErrWSHubNotRunning
+	ErrWSMaxConns       = errcode.ErrWSMaxConns
 )


### PR DESCRIPTION
## Summary
- **P1-1**: Add `safeObserve()` to AccessLog/Metrics — their post-ServeHTTP panics (e.g. broken Collector) are caught and logged instead of escaping the request chain
- **P2-1**: Fix `decode.go` trailing content check: `MaxBytesError` during second `dec.Decode` now returns 413/ErrBodyTooLarge instead of 400/ErrValidationFailed
- **P2-2**: `WriteDecodeError` uses errcode from `DecodeJSON` via `mapCodeToStatus` instead of hardcoding `ERR_VALIDATION_REQUIRED_FIELD` — restores `ERR_VALIDATION_FAILED` contract

## Changes
| File | Change |
|------|--------|
| `middleware/safe_observe.go` | NEW: `safeObserve()` — deferred recover for observability middleware |
| `middleware/safe_observe_test.go` | NEW: Tests for safeObserve + panicking collector |
| `middleware/access_log.go` | Wrap post-ServeHTTP slog.Info in safeObserve |
| `middleware/metrics.go` | Wrap post-ServeHTTP collector.RecordRequest in safeObserve |
| `httputil/decode.go` | Check isMaxBytesError before classifying as trailing content |
| `httputil/decode_test.go` | Add TestDecodeJSON_MaxBytesExceeded_TrailingContent |
| `httputil/response.go` | WriteDecodeError: use errcode from error, not hardcoded string |

## References
- `prometheus/client_golang promhttp` — instrumentation handler panics silently dropped
- Review findings from manual reproduction with `http.MaxBytesReader`

## Test plan
- [x] `go build ./...`
- [x] `go test ./runtime/http/middleware/...` — PASS
- [x] `go test ./pkg/httputil/...` — PASS
- [x] `go test ./runtime/http/router/...` — PASS (skip WebSocket sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/fix`