### PR TITLE
fix(kernel): C1 batch — scaffold 安全 + assembly 守卫 + cell/base 生命周期 + 防御性拷贝

### DIFF
--- a/src/kernel/assembly/assembly.go
+++ b/src/kernel/assembly/assembly.go
@@ -10,6 +10,7 @@ package assembly
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -63,6 +64,10 @@ func (a *CoreAssembly) Register(c cell.Cell) error {
 			fmt.Sprintf("assembly %q: cannot register in state %d", a.id, a.state))
 	}
 
+	if c == nil {
+		return errcode.New(errcode.ErrValidationFailed, "cell must not be nil")
+	}
+
 	id := c.ID()
 	if id == "" {
 		return errcode.New(errcode.ErrValidationFailed, "cell ID must not be empty")
@@ -99,20 +104,18 @@ func (a *CoreAssembly) Stop(ctx context.Context) error {
 	a.state = stateStopping
 	a.mu.Unlock()
 
-	var firstErr error
+	var errs []error
 	for i := len(a.cells) - 1; i >= 0; i-- {
 		if err := a.cells[i].Stop(ctx); err != nil {
-			if firstErr == nil {
-				firstErr = errcode.Wrap(errcode.ErrLifecycleInvalid,
-					fmt.Sprintf("assembly: stop cell %q", a.cells[i].ID()), err)
-			}
+			errs = append(errs, errcode.Wrap(errcode.ErrLifecycleInvalid,
+				fmt.Sprintf("assembly: stop cell %q", a.cells[i].ID()), err))
 		}
 	}
 
 	a.mu.Lock()
 	a.state = stateStopped
 	a.mu.Unlock()
-	return firstErr
+	return errors.Join(errs...)
 }
 
 // Health returns the HealthStatus of every registered Cell, keyed by Cell ID.

--- a/src/kernel/assembly/generator.go
+++ b/src/kernel/assembly/generator.go
@@ -177,16 +177,20 @@ func (g *Generator) sourceFingerprint(assemblyID string) string {
 	}
 
 	h := sha256.New()
+	cells := sortedCopy(asm.Cells)
 
 	// Hash assembly identity.
 	fmt.Fprintf(h, "assembly:%s\n", asm.ID)
-	fmt.Fprintf(h, "cells:%v\n", asm.Cells)
+	for _, c := range cells {
+		fmt.Fprintf(h, "cells:%s\n", c)
+	}
 	fmt.Fprintf(h, "build.entrypoint:%s\n", asm.Build.Entrypoint)
 	fmt.Fprintf(h, "build.binary:%s\n", asm.Build.Binary)
 
 	// Hash cell metadata in sorted order for determinism.
-	cells := sortedCopy(asm.Cells)
+	cellSet := make(map[string]bool, len(asm.Cells))
 	for _, cellID := range cells {
+		cellSet[cellID] = true
 		cellMeta := g.cells.Get(cellID)
 		if cellMeta == nil {
 			fmt.Fprintf(h, "cell:%s:missing\n", cellID)
@@ -199,6 +203,15 @@ func (g *Generator) sourceFingerprint(assemblyID string) string {
 		for _, s := range cellMeta.Verify.Smoke {
 			fmt.Fprintf(h, "cell:%s:smoke:%s\n", cellID, s)
 		}
+	}
+
+	// Hash boundary contracts so that endpoint changes invalidate the fingerprint.
+	exported, imported := g.computeBoundaryContracts(cellSet)
+	for _, cID := range exported {
+		fmt.Fprintf(h, "export:%s\n", cID)
+	}
+	for _, cID := range imported {
+		fmt.Fprintf(h, "import:%s\n", cID)
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil))

--- a/src/kernel/cell/base.go
+++ b/src/kernel/cell/base.go
@@ -36,7 +36,7 @@ const (
 // Embed or compose it to get a working Cell with minimal boilerplate.
 // All state-accessing methods are protected by a mutex for safe concurrent use.
 type BaseCell struct {
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	meta     CellMetadata
 	slices   []Slice
 	produced []Contract
@@ -62,8 +62,8 @@ func (b *BaseCell) Metadata() CellMetadata { return b.meta }
 
 // OwnedSlices returns a copy of the owned slice list.
 func (b *BaseCell) OwnedSlices() []Slice {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	out := make([]Slice, len(b.slices))
 	copy(out, b.slices)
 	return out
@@ -71,8 +71,8 @@ func (b *BaseCell) OwnedSlices() []Slice {
 
 // ProducedContracts returns a copy of the produced contract list.
 func (b *BaseCell) ProducedContracts() []Contract {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	out := make([]Contract, len(b.produced))
 	copy(out, b.produced)
 	return out
@@ -80,8 +80,8 @@ func (b *BaseCell) ProducedContracts() []Contract {
 
 // ConsumedContracts returns a copy of the consumed contract list.
 func (b *BaseCell) ConsumedContracts() []Contract {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	out := make([]Contract, len(b.consumed))
 	copy(out, b.consumed)
 	return out
@@ -95,6 +95,11 @@ func (b *BaseCell) Init(_ context.Context, _ Dependencies) error {
 		return errcode.New(errcode.ErrLifecycleInvalid,
 			fmt.Sprintf("cell %q: Init requires state new or stopped, current state: %d", b.meta.ID, b.state))
 	}
+	// Reset shutdown context from previous lifecycle to avoid stale cancellation.
+	if b.shutdownCancel != nil {
+		b.shutdownCancel()
+	}
+	b.shutdownCtx, b.shutdownCancel = nil, nil
 	b.state = cellStateInitialized
 	return nil
 }
@@ -103,14 +108,14 @@ func (b *BaseCell) Init(_ context.Context, _ Dependencies) error {
 // the initialized state. A shutdownCtx is created that will be cancelled
 // when Stop is called — goroutines should use ShutdownCtx() instead of
 // context.Background().
-func (b *BaseCell) Start(_ context.Context) error {
+func (b *BaseCell) Start(ctx context.Context) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.state != cellStateInitialized {
 		return errcode.New(errcode.ErrLifecycleInvalid,
 			fmt.Sprintf("cell %q: Start requires state initialized, current state: %d", b.meta.ID, b.state))
 	}
-	b.shutdownCtx, b.shutdownCancel = context.WithCancel(context.Background())
+	b.shutdownCtx, b.shutdownCancel = context.WithCancel(ctx)
 	b.state = cellStateStarted
 	return nil
 }
@@ -221,17 +226,23 @@ func (s *BaseSlice) Init(_ context.Context) error { return nil }
 // Verify returns the verification spec for this slice.
 func (s *BaseSlice) Verify() VerifySpec { return s.verify }
 
-// AllowedFiles returns the file ownership paths. If none have been set
-// explicitly, it returns the default convention path.
+// AllowedFiles returns a copy of the file ownership paths. If none have been
+// set explicitly, it returns the default convention path.
 func (s *BaseSlice) AllowedFiles() []string {
 	if len(s.allowed) > 0 {
-		return s.allowed
+		out := make([]string, len(s.allowed))
+		copy(out, s.allowed)
+		return out
 	}
 	return []string{fmt.Sprintf("cells/%s/slices/%s/**", s.cellID, s.id)}
 }
 
-// AffectedJourneys returns the journey IDs this slice participates in.
-func (s *BaseSlice) AffectedJourneys() []string { return s.journeys }
+// AffectedJourneys returns a copy of the journey IDs this slice participates in.
+func (s *BaseSlice) AffectedJourneys() []string {
+	out := make([]string, len(s.journeys))
+	copy(out, s.journeys)
+	return out
+}
 
 // SetVerify sets the verification spec.
 func (s *BaseSlice) SetVerify(v VerifySpec) { s.verify = v }

--- a/src/kernel/cell/base.go
+++ b/src/kernel/cell/base.go
@@ -144,8 +144,8 @@ func (b *BaseCell) Stop(_ context.Context) error {
 
 // Health returns the current HealthStatus.
 func (b *BaseCell) Health() HealthStatus {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	if b.state == cellStateStarted {
 		return HealthStatus{Status: "healthy"}
 	}
@@ -154,8 +154,8 @@ func (b *BaseCell) Health() HealthStatus {
 
 // Ready returns true when the cell is in the started state.
 func (b *BaseCell) Ready() bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.state == cellStateStarted
 }
 
@@ -164,8 +164,8 @@ func (b *BaseCell) Ready() bool {
 // context.Background(). Returns context.Background() if the cell has
 // not been started.
 func (b *BaseCell) ShutdownCtx() context.Context {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	if b.shutdownCtx != nil {
 		return b.shutdownCtx
 	}

--- a/src/kernel/cell/base.go
+++ b/src/kernel/cell/base.go
@@ -115,7 +115,7 @@ func (b *BaseCell) Start(ctx context.Context) error {
 		return errcode.New(errcode.ErrLifecycleInvalid,
 			fmt.Sprintf("cell %q: Start requires state initialized, current state: %d", b.meta.ID, b.state))
 	}
-	b.shutdownCtx, b.shutdownCancel = context.WithCancel(ctx)
+	b.shutdownCtx, b.shutdownCancel = context.WithCancel(context.WithoutCancel(ctx))
 	b.state = cellStateStarted
 	return nil
 }

--- a/src/kernel/governance/depcheck.go
+++ b/src/kernel/governance/depcheck.go
@@ -189,10 +189,40 @@ func (dc *DependencyChecker) checkDEP03() []ValidationResult {
 
 	var results []ValidationResult
 	for _, c := range dc.project.Cells {
+		if len(c.L0Dependencies) == 0 {
+			continue
+		}
 		assemblyID := cellToAssembly[c.ID]
+		if assemblyID == "" {
+			// Cell with L0 dependencies must be assigned to an assembly.
+			results = append(results, ValidationResult{
+				Code:      "DEP-03",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      cellFile(c.ID),
+				Field:     "l0Dependencies",
+				Message: fmt.Sprintf(
+					"cell %q has L0 dependencies but is not assigned to any assembly",
+					c.ID,
+				),
+			})
+			continue
+		}
 		for i, dep := range c.L0Dependencies {
 			depAssembly := cellToAssembly[dep.Cell]
-			if assemblyID != depAssembly {
+			if depAssembly == "" {
+				results = append(results, ValidationResult{
+					Code:      "DEP-03",
+					Severity:  SeverityError,
+					IssueType: IssueRequired,
+					File:      cellFile(c.ID),
+					Field:     fmt.Sprintf("l0Dependencies[%d].cell", i),
+					Message: fmt.Sprintf(
+						"cell %q (assembly %q) has L0 dependency on %q which is not in any assembly",
+						c.ID, assemblyID, dep.Cell,
+					),
+				})
+			} else if assemblyID != depAssembly {
 				results = append(results, ValidationResult{
 					Code:      "DEP-03",
 					Severity:  SeverityError,

--- a/src/kernel/journey/catalog.go
+++ b/src/kernel/journey/catalog.go
@@ -71,22 +71,20 @@ func (c *Catalog) Validate(cellIDs, contractIDs map[string]struct{}) error {
 	return errcode.New(errcode.ErrReferenceBroken, combined)
 }
 
-// Get returns a shallow copy of a journey by ID, or nil if not found.
+// Get returns a deep copy of a journey by ID, or nil if not found.
 func (c *Catalog) Get(id string) *metadata.JourneyMeta {
 	j := c.journeys[id]
 	if j == nil {
 		return nil
 	}
-	cp := *j
-	return &cp
+	return copyJourneyMeta(j)
 }
 
-// List returns shallow copies of all journeys sorted by ID.
+// List returns deep copies of all journeys sorted by ID.
 func (c *Catalog) List() []*metadata.JourneyMeta {
 	result := make([]*metadata.JourneyMeta, 0, len(c.journeys))
 	for _, j := range c.journeys {
-		cp := *j
-		result = append(result, &cp)
+		result = append(result, copyJourneyMeta(j))
 	}
 	sort.Slice(result, func(i, k int) bool {
 		return result[i].ID < result[k].ID
@@ -101,8 +99,7 @@ func (c *Catalog) CellJourneys(cellID string) []*metadata.JourneyMeta {
 	for _, j := range c.journeys {
 		for _, cell := range j.Cells {
 			if cell == cellID {
-				cp := *j
-				result = append(result, &cp)
+				result = append(result, copyJourneyMeta(j))
 				break
 			}
 		}
@@ -120,8 +117,7 @@ func (c *Catalog) ContractJourneys(contractID string) []*metadata.JourneyMeta {
 	for _, j := range c.journeys {
 		for _, ctr := range j.Contracts {
 			if ctr == contractID {
-				cp := *j
-				result = append(result, &cp)
+				result = append(result, copyJourneyMeta(j))
 				break
 			}
 		}
@@ -132,7 +128,7 @@ func (c *Catalog) ContractJourneys(contractID string) []*metadata.JourneyMeta {
 	return result
 }
 
-// Status returns a shallow copy of the status-board entry, or nil if not found.
+// Status returns a copy of the status-board entry, or nil if not found.
 func (c *Catalog) Status(journeyID string) *metadata.StatusBoardEntry {
 	s := c.statusBoard[journeyID]
 	if s == nil {
@@ -148,14 +144,22 @@ func (c *Catalog) CrossCellJourneys() []*metadata.JourneyMeta {
 	var result []*metadata.JourneyMeta
 	for _, j := range c.journeys {
 		if len(j.Cells) > 1 {
-			cp := *j
-			result = append(result, &cp)
+			result = append(result, copyJourneyMeta(j))
 		}
 	}
 	sort.Slice(result, func(i, k int) bool {
 		return result[i].ID < result[k].ID
 	})
 	return result
+}
+
+// copyJourneyMeta returns a deep copy of a JourneyMeta, including its slice fields.
+func copyJourneyMeta(j *metadata.JourneyMeta) *metadata.JourneyMeta {
+	cp := *j
+	cp.Cells = append([]string(nil), j.Cells...)
+	cp.Contracts = append([]string(nil), j.Contracts...)
+	cp.PassCriteria = append([]metadata.PassCriterion(nil), j.PassCriteria...)
+	return &cp
 }
 
 // Count returns the total number of journeys.

--- a/src/kernel/journey/catalog.go
+++ b/src/kernel/journey/catalog.go
@@ -71,16 +71,22 @@ func (c *Catalog) Validate(cellIDs, contractIDs map[string]struct{}) error {
 	return errcode.New(errcode.ErrReferenceBroken, combined)
 }
 
-// Get returns a journey by ID, or nil if not found.
+// Get returns a shallow copy of a journey by ID, or nil if not found.
 func (c *Catalog) Get(id string) *metadata.JourneyMeta {
-	return c.journeys[id]
+	j := c.journeys[id]
+	if j == nil {
+		return nil
+	}
+	cp := *j
+	return &cp
 }
 
-// List returns all journeys sorted by ID.
+// List returns shallow copies of all journeys sorted by ID.
 func (c *Catalog) List() []*metadata.JourneyMeta {
 	result := make([]*metadata.JourneyMeta, 0, len(c.journeys))
 	for _, j := range c.journeys {
-		result = append(result, j)
+		cp := *j
+		result = append(result, &cp)
 	}
 	sort.Slice(result, func(i, k int) bool {
 		return result[i].ID < result[k].ID
@@ -95,7 +101,8 @@ func (c *Catalog) CellJourneys(cellID string) []*metadata.JourneyMeta {
 	for _, j := range c.journeys {
 		for _, cell := range j.Cells {
 			if cell == cellID {
-				result = append(result, j)
+				cp := *j
+				result = append(result, &cp)
 				break
 			}
 		}
@@ -113,7 +120,8 @@ func (c *Catalog) ContractJourneys(contractID string) []*metadata.JourneyMeta {
 	for _, j := range c.journeys {
 		for _, ctr := range j.Contracts {
 			if ctr == contractID {
-				result = append(result, j)
+				cp := *j
+				result = append(result, &cp)
 				break
 			}
 		}
@@ -124,9 +132,14 @@ func (c *Catalog) ContractJourneys(contractID string) []*metadata.JourneyMeta {
 	return result
 }
 
-// Status returns the status-board entry for a journey, or nil if not found.
+// Status returns a shallow copy of the status-board entry, or nil if not found.
 func (c *Catalog) Status(journeyID string) *metadata.StatusBoardEntry {
-	return c.statusBoard[journeyID]
+	s := c.statusBoard[journeyID]
+	if s == nil {
+		return nil
+	}
+	cp := *s
+	return &cp
 }
 
 // CrossCellJourneys returns journeys that involve more than one cell,
@@ -135,7 +148,8 @@ func (c *Catalog) CrossCellJourneys() []*metadata.JourneyMeta {
 	var result []*metadata.JourneyMeta
 	for _, j := range c.journeys {
 		if len(j.Cells) > 1 {
-			result = append(result, j)
+			cp := *j
+			result = append(result, &cp)
 		}
 	}
 	sort.Slice(result, func(i, k int) bool {

--- a/src/kernel/metadata/parser.go
+++ b/src/kernel/metadata/parser.go
@@ -151,6 +151,10 @@ func (p *Parser) parseSlice(fsys fs.FS, path string, pm *ProjectMeta) error {
 
 	if m.BelongsToCell == "" {
 		m.BelongsToCell = cellID
+	} else if m.BelongsToCell != cellID {
+		return errcode.New(errcode.ErrMetadataInvalid,
+			fmt.Sprintf("slice %q: belongsToCell %q does not match directory cell %q in %s",
+				m.ID, m.BelongsToCell, cellID, path))
 	}
 
 	key := cellID + "/" + m.ID

--- a/src/kernel/metadata/parser_integration_test.go
+++ b/src/kernel/metadata/parser_integration_test.go
@@ -27,14 +27,16 @@ func TestParseRealProject(t *testing.T) {
 	pm, err := p.Parse()
 	require.NoError(t, err, "Parse should succeed on real project files")
 
-	// --- Cells: at least the 3 original cells ---
+	// --- Cells: at least the 3 original cells (upper bound catches over-parse) ---
 	assert.GreaterOrEqual(t, len(pm.Cells), 3, "expected at least 3 cells")
+	assert.LessOrEqual(t, len(pm.Cells), 6, "unexpected extra cells parsed — update this bound if new cells were added intentionally")
 	for _, id := range []string{"access-core", "audit-core", "config-core"} {
 		assert.Contains(t, pm.Cells, id, "missing cell %s", id)
 	}
 
-	// --- Slices: at least the 16 original slices ---
+	// --- Slices: at least the 16 original slices (upper bound catches over-parse) ---
 	assert.GreaterOrEqual(t, len(pm.Slices), 16, "expected at least 16 slices")
+	assert.LessOrEqual(t, len(pm.Slices), 24, "unexpected extra slices parsed — update this bound if new slices were added intentionally")
 	expectedSlices := []string{
 		"access-core/session-login",
 		"access-core/session-validate",
@@ -57,8 +59,9 @@ func TestParseRealProject(t *testing.T) {
 		assert.Contains(t, pm.Slices, key, "missing slice %s", key)
 	}
 
-	// --- Contracts: at least the 12 original contracts ---
+	// --- Contracts: at least the 12 original contracts (upper bound catches over-parse) ---
 	assert.GreaterOrEqual(t, len(pm.Contracts), 12, "expected at least 12 contracts")
+	assert.LessOrEqual(t, len(pm.Contracts), 18, "unexpected extra contracts parsed — update this bound if new contracts were added intentionally")
 	expectedContracts := []string{
 		"http.auth.login.v1",
 		"http.config.get.v1",
@@ -77,8 +80,9 @@ func TestParseRealProject(t *testing.T) {
 		assert.Contains(t, pm.Contracts, id, "missing contract %s", id)
 	}
 
-	// --- Journeys: at least the 8 original journeys ---
+	// --- Journeys: at least the 8 original journeys (upper bound catches over-parse) ---
 	assert.GreaterOrEqual(t, len(pm.Journeys), 8, "expected at least 8 journeys")
+	assert.LessOrEqual(t, len(pm.Journeys), 12, "unexpected extra journeys parsed — update this bound if new journeys were added intentionally")
 	expectedJourneys := []string{
 		"J-sso-login",
 		"J-session-refresh",
@@ -93,12 +97,14 @@ func TestParseRealProject(t *testing.T) {
 		assert.Contains(t, pm.Journeys, id, "missing journey %s", id)
 	}
 
-	// --- Assemblies: at least the 1 original assembly ---
+	// --- Assemblies: at least the 1 original assembly (upper bound catches over-parse) ---
 	assert.GreaterOrEqual(t, len(pm.Assemblies), 1, "expected at least 1 assembly")
+	assert.LessOrEqual(t, len(pm.Assemblies), 3, "unexpected extra assemblies parsed — update this bound if new assemblies were added intentionally")
 	assert.Contains(t, pm.Assemblies, "core-bundle")
 
-	// --- Status Board: at least the 8 original entries ---
+	// --- Status Board: at least the 8 original entries (upper bound catches over-parse) ---
 	assert.GreaterOrEqual(t, len(pm.StatusBoard), 8, "expected at least 8 status-board entries")
+	assert.LessOrEqual(t, len(pm.StatusBoard), 12, "unexpected extra status-board entries parsed — update this bound if new entries were added intentionally")
 
 	// --- Actors: 1 ---
 	assert.Len(t, pm.Actors, 1, "expected 1 actor")

--- a/src/kernel/metadata/parser_integration_test.go
+++ b/src/kernel/metadata/parser_integration_test.go
@@ -27,14 +27,14 @@ func TestParseRealProject(t *testing.T) {
 	pm, err := p.Parse()
 	require.NoError(t, err, "Parse should succeed on real project files")
 
-	// --- Cells: 3 ---
-	assert.Len(t, pm.Cells, 3, "expected 3 cells")
+	// --- Cells: at least the 3 original cells ---
+	assert.GreaterOrEqual(t, len(pm.Cells), 3, "expected at least 3 cells")
 	for _, id := range []string{"access-core", "audit-core", "config-core"} {
 		assert.Contains(t, pm.Cells, id, "missing cell %s", id)
 	}
 
-	// --- Slices: 16 ---
-	assert.Len(t, pm.Slices, 16, "expected 16 slices")
+	// --- Slices: at least the 16 original slices ---
+	assert.GreaterOrEqual(t, len(pm.Slices), 16, "expected at least 16 slices")
 	expectedSlices := []string{
 		"access-core/session-login",
 		"access-core/session-validate",
@@ -57,8 +57,8 @@ func TestParseRealProject(t *testing.T) {
 		assert.Contains(t, pm.Slices, key, "missing slice %s", key)
 	}
 
-	// --- Contracts: 12 ---
-	assert.Len(t, pm.Contracts, 12, "expected 12 contracts")
+	// --- Contracts: at least the 12 original contracts ---
+	assert.GreaterOrEqual(t, len(pm.Contracts), 12, "expected at least 12 contracts")
 	expectedContracts := []string{
 		"http.auth.login.v1",
 		"http.config.get.v1",
@@ -77,8 +77,8 @@ func TestParseRealProject(t *testing.T) {
 		assert.Contains(t, pm.Contracts, id, "missing contract %s", id)
 	}
 
-	// --- Journeys: 8 ---
-	assert.Len(t, pm.Journeys, 8, "expected 8 journeys")
+	// --- Journeys: at least the 8 original journeys ---
+	assert.GreaterOrEqual(t, len(pm.Journeys), 8, "expected at least 8 journeys")
 	expectedJourneys := []string{
 		"J-sso-login",
 		"J-session-refresh",
@@ -93,12 +93,12 @@ func TestParseRealProject(t *testing.T) {
 		assert.Contains(t, pm.Journeys, id, "missing journey %s", id)
 	}
 
-	// --- Assemblies: 1 ---
-	assert.Len(t, pm.Assemblies, 1, "expected 1 assembly")
+	// --- Assemblies: at least the 1 original assembly ---
+	assert.GreaterOrEqual(t, len(pm.Assemblies), 1, "expected at least 1 assembly")
 	assert.Contains(t, pm.Assemblies, "core-bundle")
 
-	// --- Status Board: 8 entries ---
-	assert.Len(t, pm.StatusBoard, 8, "expected 8 status-board entries")
+	// --- Status Board: at least the 8 original entries ---
+	assert.GreaterOrEqual(t, len(pm.StatusBoard), 8, "expected at least 8 status-board entries")
 
 	// --- Actors: 1 ---
 	assert.Len(t, pm.Actors, 1, "expected 1 actor")

--- a/src/kernel/scaffold/scaffold.go
+++ b/src/kernel/scaffold/scaffold.go
@@ -26,7 +26,7 @@ func validatePathComponent(value, field string) error {
 	if value == "" {
 		return errcode.New(ErrScaffoldInvalidOpts, field+" is required")
 	}
-	if strings.Contains(value, "..") || strings.ContainsAny(value, `/\`) {
+	if value == "." || strings.Contains(value, "..") || strings.ContainsAny(value, `/\`) {
 		return errcode.New(ErrScaffoldInvalidOpts, field+" contains path traversal or separator")
 	}
 	return nil

--- a/src/kernel/scaffold/scaffold.go
+++ b/src/kernel/scaffold/scaffold.go
@@ -20,6 +20,18 @@ const (
 	ErrScaffoldIO          errcode.Code = "ERR_SCAFFOLD_IO"
 )
 
+// validatePathComponent rejects identifiers that contain path traversal
+// sequences or separators, preventing writes outside the project root.
+func validatePathComponent(value, field string) error {
+	if value == "" {
+		return errcode.New(ErrScaffoldInvalidOpts, field+" is required")
+	}
+	if strings.Contains(value, "..") || strings.ContainsAny(value, `/\`) {
+		return errcode.New(ErrScaffoldInvalidOpts, field+" contains path traversal or separator")
+	}
+	return nil
+}
+
 // CellOpts defines options for scaffolding a new cell.
 type CellOpts struct {
 	ID               string
@@ -62,8 +74,8 @@ func New(root string) *Scaffolder {
 // CreateCell creates cells/{id}/cell.yaml with directory.
 // Returns an error if the cell directory already exists (skip-on-conflict).
 func (s *Scaffolder) CreateCell(opts CellOpts) error {
-	if opts.ID == "" {
-		return errcode.New(ErrScaffoldInvalidOpts, "cell ID is required")
+	if err := validatePathComponent(opts.ID, "cell ID"); err != nil {
+		return err
 	}
 	if opts.OwnerTeam == "" {
 		return errcode.New(ErrScaffoldInvalidOpts, "cell owner team is required")
@@ -86,11 +98,11 @@ func (s *Scaffolder) CreateCell(opts CellOpts) error {
 // CreateSlice creates cells/{cellID}/slices/{id}/slice.yaml.
 // Returns an error if the cell doesn't exist or the slice directory already exists.
 func (s *Scaffolder) CreateSlice(opts SliceOpts) error {
-	if opts.ID == "" {
-		return errcode.New(ErrScaffoldInvalidOpts, "slice ID is required")
+	if err := validatePathComponent(opts.ID, "slice ID"); err != nil {
+		return err
 	}
-	if opts.CellID == "" {
-		return errcode.New(ErrScaffoldInvalidOpts, "slice cell ID is required")
+	if err := validatePathComponent(opts.CellID, "slice cell ID"); err != nil {
+		return err
 	}
 
 	// Verify the parent cell exists.
@@ -113,11 +125,17 @@ func (s *Scaffolder) CreateContract(opts ContractOpts) error {
 	if opts.ID == "" {
 		return errcode.New(ErrScaffoldInvalidOpts, "contract ID is required")
 	}
-	if opts.Kind == "" {
-		return errcode.New(ErrScaffoldInvalidOpts, "contract kind is required")
+	if err := validatePathComponent(opts.Kind, "contract kind"); err != nil {
+		return err
 	}
-	if opts.OwnerCell == "" {
-		return errcode.New(ErrScaffoldInvalidOpts, "contract owner cell is required")
+	if err := validatePathComponent(opts.OwnerCell, "contract owner cell"); err != nil {
+		return err
+	}
+	// Validate each dot-segment of the ID for path traversal.
+	for _, seg := range strings.Split(opts.ID, ".") {
+		if err := validatePathComponent(seg, "contract ID segment"); err != nil {
+			return err
+		}
 	}
 
 	validKinds := map[string]bool{"http": true, "event": true, "command": true, "projection": true}
@@ -149,8 +167,8 @@ func (s *Scaffolder) CreateContract(opts ContractOpts) error {
 
 // CreateJourney creates journeys/J-{name}.yaml (or journeys/{id}.yaml if id starts with "J-").
 func (s *Scaffolder) CreateJourney(opts JourneyOpts) error {
-	if opts.ID == "" {
-		return errcode.New(ErrScaffoldInvalidOpts, "journey ID is required")
+	if err := validatePathComponent(opts.ID, "journey ID"); err != nil {
+		return err
 	}
 	if opts.Goal == "" {
 		return errcode.New(ErrScaffoldInvalidOpts, "journey goal is required")
@@ -162,10 +180,11 @@ func (s *Scaffolder) CreateJourney(opts JourneyOpts) error {
 		return errcode.New(ErrScaffoldInvalidOpts, "journey must reference at least one cell")
 	}
 
-	filename := opts.ID + ".yaml"
+	// Normalize: ensure ID carries the J- prefix for both filename and template.
 	if !strings.HasPrefix(opts.ID, "J-") {
-		filename = "J-" + opts.ID + ".yaml"
+		opts.ID = "J-" + opts.ID
 	}
+	filename := opts.ID + ".yaml"
 
 	dir := filepath.Join(s.root, "journeys")
 	outPath := filepath.Join(dir, filename)

--- a/src/kernel/scaffold/scaffold_test.go
+++ b/src/kernel/scaffold/scaffold_test.go
@@ -543,6 +543,12 @@ func TestPathTraversal(t *testing.T) {
 		{"journey ../admin", func() error {
 			return s.CreateJourney(JourneyOpts{ID: "../admin", Goal: "g", OwnerTeam: "t", Cells: []string{"c"}})
 		}},
+		{"cell dot", func() error {
+			return s.CreateCell(CellOpts{ID: ".", OwnerTeam: "t"})
+		}},
+		{"slice cellID dot", func() error {
+			return s.CreateSlice(SliceOpts{ID: "s", CellID: "."})
+		}},
 	}
 
 	for _, tc := range cases {

--- a/src/kernel/scaffold/scaffold_test.go
+++ b/src/kernel/scaffold/scaffold_test.go
@@ -437,7 +437,7 @@ func TestCreateJourney(t *testing.T) {
 
 	outPath := filepath.Join(root, "journeys", "J-sso-login.yaml")
 	content := readGenerated(t, outPath)
-	assert.Contains(t, content, "id: sso-login")
+	assert.Contains(t, content, "id: J-sso-login")
 	assert.Contains(t, content, `goal: "User completes SSO login and obtains a valid session"`)
 	assert.Contains(t, content, "team: platform")
 	assert.Contains(t, content, "role: journey-owner")
@@ -505,6 +505,52 @@ func TestCreateJourney_NoCells(t *testing.T) {
 	s := New(root)
 	err := s.CreateJourney(JourneyOpts{ID: "j", Goal: "g", OwnerTeam: "t"})
 	requireErrCode(t, err, ErrScaffoldInvalidOpts)
+}
+
+// ---------------------------------------------------------------------------
+// Path traversal prevention
+// ---------------------------------------------------------------------------
+
+func TestPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"cell ../etc", func() error {
+			return s.CreateCell(CellOpts{ID: "../etc", OwnerTeam: "t"})
+		}},
+		{"cell foo/bar", func() error {
+			return s.CreateCell(CellOpts{ID: "foo/bar", OwnerTeam: "t"})
+		}},
+		{`cell foo\bar`, func() error {
+			return s.CreateCell(CellOpts{ID: `foo\bar`, OwnerTeam: "t"})
+		}},
+		{"slice ../x", func() error {
+			return s.CreateSlice(SliceOpts{ID: "../x", CellID: "c"})
+		}},
+		{"slice cellID ../c", func() error {
+			return s.CreateSlice(SliceOpts{ID: "s", CellID: "../c"})
+		}},
+		{"contract ownerCell ../c", func() error {
+			return s.CreateContract(ContractOpts{ID: "http.a.v1", Kind: "http", OwnerCell: "../c"})
+		}},
+		{"contract ID segment ..", func() error {
+			return s.CreateContract(ContractOpts{ID: "http..exploit.v1", Kind: "http", OwnerCell: "c"})
+		}},
+		{"journey ../admin", func() error {
+			return s.CreateJourney(JourneyOpts{ID: "../admin", Goal: "g", OwnerTeam: "t", Cells: []string{"c"}})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			requireErrCode(t, err, ErrScaffoldInvalidOpts)
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **scaffold**: 路径穿越防护 `validatePathComponent` + 8 个测试用例 + journey id J- 前缀修复
- **assembly**: `Register(nil)` 守卫 + `Stop()` 改用 `errors.Join` + `sourceFingerprint` 含 boundary contracts
- **cell/base**: `sync.RWMutex` + `Init` 重置 ctx + `Start(ctx)` 传播 + `BaseSlice` 防御性拷贝
- **journey/catalog**: 6 个 getter 方法返回浅拷贝
- **metadata/parser**: `belongsToCell` 与路径一致性校验 + integration test 去硬编码
- **governance/depcheck**: DEP-03 空 assembly 守卫

## Findings Addressed (13 C1 items)
| ID | 问题 |
|----|------|
| ASJ-2 | scaffold 路径穿越 |
| ASJ-1 | CreateJourney schema 不合规 |
| ASJ-3 | Register(nil) panic |
| F-3 | assembly Stop 只返回首个错误 |
| ASJ-5 | sourceFingerprint 缺 contract metadata |
| R1B1-03 | Init 不重置 shutdownCtx |
| R1B1-04 | sync.Mutex → sync.RWMutex |
| CS-AR-1 | Start 忽略传入 ctx |
| CS-F5 | BaseSlice 暴露可变切片 |
| ASJ-4 | Catalog 返回可变指针 |
| MR-R03 | integration test 硬编码已过期 |
| MR-R01 | belongsToCell 路径不一致 |
| GOV-2 | DEP-03 空 assembly 绕过 |

## Test plan
- [x] `go test ./kernel/... -count=1 -race` — 全部通过
- [x] scaffold 路径穿越测试 (`TestPathTraversal` 8 cases)
- [x] journey id 前缀测试 (`TestCreateJourney` 验证 `id: J-sso-login`)

来源: 2026-04-09 kernel 六角色深审
修复计划: `tools/docs/20260408-fix-order-plan.md` Phase A

🤖 Generated with [Claude Code](https://claude.com/claude-code)