### PR TITLE
fix(kernel): C2 batch — governance 语义修正 + metadata ownerCell + registry 防御性拷贝

### DIFF
--- a/src/kernel/assembly/assembly.go
+++ b/src/kernel/assembly/assembly.go
@@ -90,7 +90,7 @@ func (a *CoreAssembly) Start(ctx context.Context) error {
 }
 
 // Stop stops every registered Cell in reverse registration order. If multiple
-// Cells fail, Stop continues and returns the first error encountered.
+// Cells fail, Stop continues and returns all errors joined via errors.Join.
 // Stop is only allowed from the Started state; calling Stop in any other state
 // is a no-op.
 //

--- a/src/kernel/cell/base.go
+++ b/src/kernel/cell/base.go
@@ -248,10 +248,14 @@ func (s *BaseSlice) AffectedJourneys() []string {
 func (s *BaseSlice) SetVerify(v VerifySpec) { s.verify = v }
 
 // SetAllowedFiles overrides the default file ownership paths.
-func (s *BaseSlice) SetAllowedFiles(files []string) { s.allowed = files }
+func (s *BaseSlice) SetAllowedFiles(files []string) {
+	s.allowed = append([]string(nil), files...)
+}
 
 // SetAffectedJourneys sets the journey IDs.
-func (s *BaseSlice) SetAffectedJourneys(ids []string) { s.journeys = ids }
+func (s *BaseSlice) SetAffectedJourneys(ids []string) {
+	s.journeys = append([]string(nil), ids...)
+}
 
 // ---------------------------------------------------------------------------
 // BaseContract

--- a/src/kernel/governance/helpers.go
+++ b/src/kernel/governance/helpers.go
@@ -14,18 +14,7 @@ import (
 
 // contractProvider returns the provider cell/actor for a contract based on its kind.
 func contractProvider(c *metadata.ContractMeta) string {
-	switch cell.ContractKind(c.Kind) {
-	case cell.ContractHTTP:
-		return c.Endpoints.Server
-	case cell.ContractEvent:
-		return c.Endpoints.Publisher
-	case cell.ContractCommand:
-		return c.Endpoints.Handler
-	case cell.ContractProjection:
-		return c.Endpoints.Provider
-	default:
-		return ""
-	}
+	return c.ProviderEndpoint()
 }
 
 // contractConsumers returns the consumer cell/actor list for a contract based on its kind.

--- a/src/kernel/governance/rules_topo.go
+++ b/src/kernel/governance/rules_topo.go
@@ -100,10 +100,14 @@ func (v *Validator) validateTOPO03() []ValidationResult {
 func (v *Validator) validateTOPO04() []ValidationResult {
 	// Build actor lookup for external providers.
 	actorMaxLevel := make(map[string]cell.Level)
+	actorMalformed := make(map[string]bool)
 	for _, a := range v.project.Actors {
-		if lvl, err := cell.ParseLevel(a.MaxConsistencyLevel); err == nil {
-			actorMaxLevel[a.ID] = lvl
+		lvl, err := cell.ParseLevel(a.MaxConsistencyLevel)
+		if err != nil {
+			actorMalformed[a.ID] = true
+			continue
 		}
+		actorMaxLevel[a.ID] = lvl
 	}
 
 	var results []ValidationResult
@@ -140,7 +144,23 @@ func (v *Validator) validateTOPO04() []ValidationResult {
 			continue
 		}
 
-		// Check if provider is an external Actor.
+		// Check if provider is an external Actor with malformed level.
+		if actorMalformed[providerID] {
+			results = append(results, ValidationResult{
+				Code:      "TOPO-04",
+				Severity:  SeverityError,
+				IssueType: IssueInvalid,
+				File:      "actors.yaml",
+				Field:     "maxConsistencyLevel",
+				Message: fmt.Sprintf(
+					"cannot verify contract %q consistency: external actor %q has invalid maxConsistencyLevel",
+					c.ID, providerID,
+				),
+			})
+			continue
+		}
+
+		// Check if provider is an external Actor with valid level.
 		if maxLvl, ok := actorMaxLevel[providerID]; ok {
 			if contractLevel > maxLvl {
 				results = append(results, ValidationResult{

--- a/src/kernel/governance/rules_topo.go
+++ b/src/kernel/governance/rules_topo.go
@@ -94,35 +94,69 @@ func (v *Validator) validateTOPO03() []ValidationResult {
 	return results
 }
 
-// validateTOPO04 checks that contract.consistencyLevel does not exceed ownerCell's consistencyLevel.
+// validateTOPO04 checks that contract.consistencyLevel does not exceed the
+// actual provider's consistencyLevel. The provider is determined from
+// endpoints (not ownerCell, which is a governance field that may differ).
 func (v *Validator) validateTOPO04() []ValidationResult {
+	// Build actor lookup for external providers.
+	actorMaxLevel := make(map[string]cell.Level)
+	for _, a := range v.project.Actors {
+		if lvl, err := cell.ParseLevel(a.MaxConsistencyLevel); err == nil {
+			actorMaxLevel[a.ID] = lvl
+		}
+	}
+
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
-		ownerCell, ok := v.project.Cells[c.OwnerCell]
-		if !ok {
-			continue // REF-03 covers missing ownerCell
-		}
 		contractLevel, err := cell.ParseLevel(c.ConsistencyLevel)
 		if err != nil {
 			continue // FMT-03 covers invalid levels
 		}
-		cellLevel, err := cell.ParseLevel(ownerCell.ConsistencyLevel)
-		if err != nil {
+
+		providerID := contractProvider(c)
+		if providerID == "" {
+			continue // REF covers missing provider
+		}
+
+		// Check if provider is a Cell.
+		if providerCell, ok := v.project.Cells[providerID]; ok {
+			providerLevel, err := cell.ParseLevel(providerCell.ConsistencyLevel)
+			if err != nil {
+				continue
+			}
+			if contractLevel > providerLevel {
+				results = append(results, ValidationResult{
+					Code:      "TOPO-04",
+					Severity:  SeverityError,
+					IssueType: IssueMismatch,
+					File:      contractFile(c.ID),
+					Field:     "consistencyLevel",
+					Message: fmt.Sprintf(
+						"contract %q consistencyLevel %s exceeds provider cell %q level %s",
+						c.ID, c.ConsistencyLevel, providerID, providerCell.ConsistencyLevel,
+					),
+				})
+			}
 			continue
 		}
-		if contractLevel > cellLevel {
-			results = append(results, ValidationResult{
-				Code:      "TOPO-04",
-				Severity:  SeverityError,
-				IssueType: IssueMismatch,
-				File:      contractFile(c.ID),
-				Field:     "consistencyLevel",
-				Message: fmt.Sprintf(
-					"contract %q consistencyLevel %s exceeds ownerCell %q level %s",
-					c.ID, c.ConsistencyLevel, c.OwnerCell, ownerCell.ConsistencyLevel,
-				),
-			})
+
+		// Check if provider is an external Actor.
+		if maxLvl, ok := actorMaxLevel[providerID]; ok {
+			if contractLevel > maxLvl {
+				results = append(results, ValidationResult{
+					Code:      "TOPO-04",
+					Severity:  SeverityError,
+					IssueType: IssueMismatch,
+					File:      contractFile(c.ID),
+					Field:     "consistencyLevel",
+					Message: fmt.Sprintf(
+						"contract %q consistencyLevel %s exceeds external actor %q maxConsistencyLevel %s",
+						c.ID, c.ConsistencyLevel, providerID, maxLvl,
+					),
+				})
+			}
 		}
+		// If provider is neither a Cell nor an Actor, REF rules cover that.
 	}
 	return results
 }

--- a/src/kernel/governance/rules_verify.go
+++ b/src/kernel/governance/rules_verify.go
@@ -130,23 +130,28 @@ func (v *Validator) validateVERIFY02() []ValidationResult {
 	return results
 }
 
-// validateVERIFY04 checks that every active contract has at least one
-// provider-role slice in the provider cell. Without this, a contract is
+// validateVERIFY04 checks that every active contract whose provider is a
+// Cell has at least one provider-role slice. Without this, a contract is
 // "published but nobody provides it" — a ghost capability.
+// Contracts served by external actors are skipped (actors have no slices).
 func (v *Validator) validateVERIFY04() []ValidationResult {
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
 		if c.Lifecycle != "active" {
 			continue
 		}
-		providerCellID := contractProvider(c)
-		if providerCellID == "" {
+		providerID := contractProvider(c)
+		if providerID == "" {
 			continue // REF rules cover missing provider
+		}
+		// Only check cell-backed contracts; external actors have no slices.
+		if _, isCell := v.project.Cells[providerID]; !isCell {
+			continue
 		}
 
 		found := false
 		for _, s := range v.project.Slices {
-			if s.BelongsToCell != providerCellID {
+			if s.BelongsToCell != providerID {
 				continue
 			}
 			for _, cu := range s.ContractUsages {
@@ -169,7 +174,7 @@ func (v *Validator) validateVERIFY04() []ValidationResult {
 				Field:     "lifecycle",
 				Message: fmt.Sprintf(
 					"active contract %q has no provider-role slice in cell %q",
-					c.ID, providerCellID,
+					c.ID, providerID,
 				),
 			})
 		}

--- a/src/kernel/governance/rules_verify.go
+++ b/src/kernel/governance/rules_verify.go
@@ -130,6 +130,53 @@ func (v *Validator) validateVERIFY02() []ValidationResult {
 	return results
 }
 
+// validateVERIFY04 checks that every active contract has at least one
+// provider-role slice in the provider cell. Without this, a contract is
+// "published but nobody provides it" — a ghost capability.
+func (v *Validator) validateVERIFY04() []ValidationResult {
+	var results []ValidationResult
+	for _, c := range v.project.Contracts {
+		if c.Lifecycle != "active" {
+			continue
+		}
+		providerCellID := contractProvider(c)
+		if providerCellID == "" {
+			continue // REF rules cover missing provider
+		}
+
+		found := false
+		for _, s := range v.project.Slices {
+			if s.BelongsToCell != providerCellID {
+				continue
+			}
+			for _, cu := range s.ContractUsages {
+				if cu.Contract == c.ID && cell.IsProviderRole(cell.ContractRole(cu.Role)) {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+
+		if !found {
+			results = append(results, ValidationResult{
+				Code:      "VERIFY-04",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      contractFile(c.ID),
+				Field:     "lifecycle",
+				Message: fmt.Sprintf(
+					"active contract %q has no provider-role slice in cell %q",
+					c.ID, providerCellID,
+				),
+			})
+		}
+	}
+	return results
+}
+
 // validateVERIFY03 checks that l0Dependencies[].cell targets an L0-level cell.
 func (v *Validator) validateVERIFY03() []ValidationResult {
 	var results []ValidationResult

--- a/src/kernel/governance/validate.go
+++ b/src/kernel/governance/validate.go
@@ -115,6 +115,7 @@ func (v *Validator) Validate() []ValidationResult {
 	results = append(results, v.validateVERIFY01()...)
 	results = append(results, v.validateVERIFY02()...)
 	results = append(results, v.validateVERIFY03()...)
+	results = append(results, v.validateVERIFY04()...)
 
 	// Format compliance rules
 	results = append(results, v.validateFMT01()...)

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -636,6 +636,66 @@ func TestTOPO04(t *testing.T) {
 			},
 			wantCount: 1,
 		},
+		{
+			name: "contract level within external actor max level",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Actors = []metadata.ActorMeta{
+					{ID: "ext-gateway", Type: "external", MaxConsistencyLevel: "L3"},
+				}
+				pm.Contracts["http.ext.gw.v1"] = &metadata.ContractMeta{
+					ID:               "http.ext.gw.v1",
+					Kind:             "http",
+					OwnerCell:        "ext-gateway",
+					ConsistencyLevel: "L2",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Server:  "ext-gateway",
+						Clients: []string{"access-core"},
+					},
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "contract level exceeds external actor max level",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Actors = []metadata.ActorMeta{
+					{ID: "ext-gateway", Type: "external", MaxConsistencyLevel: "L1"},
+				}
+				pm.Contracts["http.ext.gw.v1"] = &metadata.ContractMeta{
+					ID:               "http.ext.gw.v1",
+					Kind:             "http",
+					OwnerCell:        "ext-gateway",
+					ConsistencyLevel: "L3",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Server:  "ext-gateway",
+						Clients: []string{"access-core"},
+					},
+				}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "external actor with malformed maxConsistencyLevel reports error",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Actors = []metadata.ActorMeta{
+					{ID: "ext-gateway", Type: "external", MaxConsistencyLevel: "INVALID"},
+				}
+				pm.Contracts["http.ext.gw.v1"] = &metadata.ContractMeta{
+					ID:               "http.ext.gw.v1",
+					Kind:             "http",
+					OwnerCell:        "ext-gateway",
+					ConsistencyLevel: "L2",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Server:  "ext-gateway",
+						Clients: []string{"access-core"},
+					},
+				}
+			},
+			wantCount: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1007,6 +1067,82 @@ func TestVERIFY03(t *testing.T) {
 			tt.setup(pm)
 			val := NewValidator(pm, ".")
 			got := findByCode(val.validateVERIFY03(), "VERIFY-03")
+			assert.Len(t, got, tt.wantCount)
+		})
+	}
+}
+
+func TestVERIFY04(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+	}{
+		{
+			name:      "active contract with provider-role slice passes",
+			setup:     func(_ *metadata.ProjectMeta) {},
+			wantCount: 0,
+		},
+		{
+			name: "active contract without provider-role slice fails",
+			setup: func(pm *metadata.ProjectMeta) {
+				// Remove the provide usage from the only slice that provides this contract.
+				s := pm.Slices["access-core/session-login"]
+				s.ContractUsages = []metadata.ContractUsage{
+					{Contract: "http.auth.login.v1", Role: "serve"},
+					{Contract: "event.session.created.v1", Role: "publish"},
+					// removed: projection.session.active.v1 provide
+				}
+				s.Verify.Contract = []string{
+					"contract.http.auth.login.v1.serve",
+					"contract.event.session.created.v1.publish",
+				}
+			},
+			wantCount: 1, // projection.session.active.v1 has no provider slice
+		},
+		{
+			name: "draft contract without provider-role slice is OK",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["projection.session.active.v1"].Lifecycle = "draft"
+				s := pm.Slices["access-core/session-login"]
+				s.ContractUsages = []metadata.ContractUsage{
+					{Contract: "http.auth.login.v1", Role: "serve"},
+					{Contract: "event.session.created.v1", Role: "publish"},
+				}
+				s.Verify.Contract = []string{
+					"contract.http.auth.login.v1.serve",
+					"contract.event.session.created.v1.publish",
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "active contract with external actor provider is skipped",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Actors = []metadata.ActorMeta{
+					{ID: "ext-gateway", Type: "external", MaxConsistencyLevel: "L3"},
+				}
+				pm.Contracts["http.ext.gateway.v1"] = &metadata.ContractMeta{
+					ID:               "http.ext.gateway.v1",
+					Kind:             "http",
+					OwnerCell:        "ext-gateway",
+					ConsistencyLevel: "L1",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Server:  "ext-gateway", // actor, not a cell
+						Clients: []string{"access-core"},
+					},
+				}
+			},
+			wantCount: 0, // actor-backed contracts are not checked
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, ".")
+			got := findByCode(val.validateVERIFY04(), "VERIFY-04")
 			assert.Len(t, got, tt.wantCount)
 		})
 	}

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -642,6 +642,7 @@ func TestTOPO04(t *testing.T) {
 				pm.Actors = []metadata.ActorMeta{
 					{ID: "ext-gateway", Type: "external", MaxConsistencyLevel: "L3"},
 				}
+				// OwnerCell is set for REF-03; TOPO-04 uses endpoints.server as provider.
 				pm.Contracts["http.ext.gw.v1"] = &metadata.ContractMeta{
 					ID:               "http.ext.gw.v1",
 					Kind:             "http",
@@ -662,6 +663,7 @@ func TestTOPO04(t *testing.T) {
 				pm.Actors = []metadata.ActorMeta{
 					{ID: "ext-gateway", Type: "external", MaxConsistencyLevel: "L1"},
 				}
+				// OwnerCell is set for REF-03; TOPO-04 uses endpoints.server as provider.
 				pm.Contracts["http.ext.gw.v1"] = &metadata.ContractMeta{
 					ID:               "http.ext.gw.v1",
 					Kind:             "http",
@@ -682,6 +684,7 @@ func TestTOPO04(t *testing.T) {
 				pm.Actors = []metadata.ActorMeta{
 					{ID: "ext-gateway", Type: "external", MaxConsistencyLevel: "INVALID"},
 				}
+				// OwnerCell is set for REF-03; TOPO-04 uses endpoints.server as provider.
 				pm.Contracts["http.ext.gw.v1"] = &metadata.ContractMeta{
 					ID:               "http.ext.gw.v1",
 					Kind:             "http",

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -51,12 +51,14 @@ func validProject() *metadata.ProjectMeta {
 				ContractUsages: []metadata.ContractUsage{
 					{Contract: "http.auth.login.v1", Role: "serve"},
 					{Contract: "event.session.created.v1", Role: "publish"},
+					{Contract: "projection.session.active.v1", Role: "provide"},
 				},
 				Verify: metadata.SliceVerifyMeta{
 					Unit: []string{"unit.session-login.service"},
 					Contract: []string{
 						"contract.http.auth.login.v1.serve",
 						"contract.event.session.created.v1.publish",
+						"contract.projection.session.active.v1.provide",
 					},
 				},
 			},
@@ -760,6 +762,7 @@ func TestVERIFY01(t *testing.T) {
 				pm.Slices["access-core/session-login"].Verify.Contract = []string{
 					// removed "contract.http.auth.login.v1.serve"
 					"contract.event.session.created.v1.publish",
+					"contract.projection.session.active.v1.provide",
 				}
 			},
 			wantCount: 1,
@@ -770,6 +773,7 @@ func TestVERIFY01(t *testing.T) {
 				pm.Slices["access-core/session-login"].Verify.Contract = []string{
 					// removed "contract.http.auth.login.v1.serve"
 					"contract.event.session.created.v1.publish",
+					"contract.projection.session.active.v1.provide",
 				}
 				pm.Slices["access-core/session-login"].Verify.Waivers = []metadata.WaiverMeta{
 					{
@@ -787,6 +791,7 @@ func TestVERIFY01(t *testing.T) {
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Slices["access-core/session-login"].Verify.Contract = []string{
 					"contract.event.session.created.v1.publish",
+					"contract.projection.session.active.v1.provide",
 				}
 				pm.Slices["access-core/session-login"].Verify.Waivers = []metadata.WaiverMeta{
 					{
@@ -804,6 +809,7 @@ func TestVERIFY01(t *testing.T) {
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Slices["access-core/session-login"].Verify.Contract = []string{
 					"contract.event.session.created.v1.publish",
+					"contract.projection.session.active.v1.provide",
 				}
 				pm.Slices["access-core/session-login"].Verify.Waivers = []metadata.WaiverMeta{
 					{
@@ -821,6 +827,7 @@ func TestVERIFY01(t *testing.T) {
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Slices["access-core/session-login"].Verify.Contract = []string{
 					"contract.event.session.created.v1.publish",
+					"contract.projection.session.active.v1.provide",
 				}
 				pm.Slices["access-core/session-login"].Verify.Waivers = []metadata.WaiverMeta{
 					{

--- a/src/kernel/metadata/parser.go
+++ b/src/kernel/metadata/parser.go
@@ -177,7 +177,7 @@ func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
 	}
 	// Infer ownerCell from provider endpoint if omitted (per contract.schema.json).
 	if m.OwnerCell == "" {
-		m.OwnerCell = inferContractOwner(&m)
+		m.OwnerCell = m.ProviderEndpoint()
 	}
 
 	if _, exists := pm.Contracts[m.ID]; exists {
@@ -186,22 +186,6 @@ func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
 	}
 	pm.Contracts[m.ID] = &m
 	return nil
-}
-
-// inferContractOwner returns the provider cell for a contract based on its kind.
-func inferContractOwner(c *ContractMeta) string {
-	switch c.Kind {
-	case "http":
-		return c.Endpoints.Server
-	case "event":
-		return c.Endpoints.Publisher
-	case "command":
-		return c.Endpoints.Handler
-	case "projection":
-		return c.Endpoints.Provider
-	default:
-		return ""
-	}
 }
 
 func (p *Parser) parseJourney(fsys fs.FS, path string, pm *ProjectMeta) error {

--- a/src/kernel/metadata/parser.go
+++ b/src/kernel/metadata/parser.go
@@ -175,12 +175,33 @@ func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
 		return errcode.New(errcode.ErrMetadataInvalid,
 			fmt.Sprintf("contract id is empty in %s", path))
 	}
+	// Infer ownerCell from provider endpoint if omitted (per contract.schema.json).
+	if m.OwnerCell == "" {
+		m.OwnerCell = inferContractOwner(&m)
+	}
+
 	if _, exists := pm.Contracts[m.ID]; exists {
 		return errcode.New(errcode.ErrMetadataInvalid,
 			fmt.Sprintf("duplicate contract ID %q: %s and previous", m.ID, path))
 	}
 	pm.Contracts[m.ID] = &m
 	return nil
+}
+
+// inferContractOwner returns the provider cell for a contract based on its kind.
+func inferContractOwner(c *ContractMeta) string {
+	switch c.Kind {
+	case "http":
+		return c.Endpoints.Server
+	case "event":
+		return c.Endpoints.Publisher
+	case "command":
+		return c.Endpoints.Handler
+	case "projection":
+		return c.Endpoints.Provider
+	default:
+		return ""
+	}
 }
 
 func (p *Parser) parseJourney(fsys fs.FS, path string, pm *ProjectMeta) error {

--- a/src/kernel/metadata/parser_test.go
+++ b/src/kernel/metadata/parser_test.go
@@ -770,3 +770,87 @@ build:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "assembly id is empty")
 }
+
+func TestParseFS_ContractOwnerCellInferred(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantOwner string
+	}{
+		{
+			name: "http infers ownerCell from server",
+			yaml: `id: http.test.v1
+kind: http
+consistencyLevel: L1
+lifecycle: active
+endpoints:
+  server: cell-a
+  clients: [cell-b]
+`,
+			wantOwner: "cell-a",
+		},
+		{
+			name: "event infers ownerCell from publisher",
+			yaml: `id: event.test.v1
+kind: event
+consistencyLevel: L2
+lifecycle: active
+endpoints:
+  publisher: cell-b
+  subscribers: [cell-a]
+`,
+			wantOwner: "cell-b",
+		},
+		{
+			name: "command infers ownerCell from handler",
+			yaml: `id: command.test.v1
+kind: command
+consistencyLevel: L1
+lifecycle: active
+endpoints:
+  handler: cell-c
+  invokers: [cell-a]
+`,
+			wantOwner: "cell-c",
+		},
+		{
+			name: "projection infers ownerCell from provider",
+			yaml: `id: projection.test.v1
+kind: projection
+consistencyLevel: L1
+lifecycle: active
+endpoints:
+  provider: cell-d
+  readers: [cell-a]
+`,
+			wantOwner: "cell-d",
+		},
+		{
+			name: "explicit ownerCell is preserved",
+			yaml: `id: http.explicit.v1
+kind: http
+ownerCell: explicit-cell
+consistencyLevel: L1
+lifecycle: active
+endpoints:
+  server: different-cell
+  clients: [cell-b]
+`,
+			wantOwner: "explicit-cell",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := fstest.MapFS{
+				"contracts/test/domain/v1/contract.yaml": &fstest.MapFile{Data: []byte(tt.yaml)},
+			}
+			p := NewParser("")
+			pm, err := p.ParseFS(fs)
+			require.NoError(t, err)
+			require.Len(t, pm.Contracts, 1)
+			for _, c := range pm.Contracts {
+				assert.Equal(t, tt.wantOwner, c.OwnerCell)
+			}
+		})
+	}
+}

--- a/src/kernel/metadata/types.go
+++ b/src/kernel/metadata/types.go
@@ -78,6 +78,23 @@ type ContractMeta struct {
 	DeliverySemantics string         `yaml:"deliverySemantics,omitempty"`
 }
 
+// ProviderEndpoint returns the provider cell/actor ID for this contract
+// based on its Kind. Returns "" if Kind is unknown or provider is unset.
+func (c *ContractMeta) ProviderEndpoint() string {
+	switch c.Kind {
+	case "http":
+		return c.Endpoints.Server
+	case "event":
+		return c.Endpoints.Publisher
+	case "command":
+		return c.Endpoints.Handler
+	case "projection":
+		return c.Endpoints.Provider
+	default:
+		return ""
+	}
+}
+
 // EndpointsMeta holds the kind-specific endpoint fields for a Contract.
 // Only the fields relevant to the contract's Kind are populated.
 type EndpointsMeta struct {

--- a/src/kernel/metadata/types_test.go
+++ b/src/kernel/metadata/types_test.go
@@ -285,6 +285,26 @@ func TestStatusBoardSliceRoundTrip(t *testing.T) {
 	assert.Equal(t, orig, got)
 }
 
+func TestContractMeta_ProviderEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		meta ContractMeta
+		want string
+	}{
+		{"http returns server", ContractMeta{Kind: "http", Endpoints: EndpointsMeta{Server: "cell-a"}}, "cell-a"},
+		{"event returns publisher", ContractMeta{Kind: "event", Endpoints: EndpointsMeta{Publisher: "cell-b"}}, "cell-b"},
+		{"command returns handler", ContractMeta{Kind: "command", Endpoints: EndpointsMeta{Handler: "cell-c"}}, "cell-c"},
+		{"projection returns provider", ContractMeta{Kind: "projection", Endpoints: EndpointsMeta{Provider: "cell-d"}}, "cell-d"},
+		{"unknown kind returns empty", ContractMeta{Kind: "grpc"}, ""},
+		{"empty kind returns empty", ContractMeta{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.meta.ProviderEndpoint())
+		})
+	}
+}
+
 func TestActorSliceRoundTrip(t *testing.T) {
 	orig := []ActorMeta{
 		{ID: "edge-bff", Type: "external", MaxConsistencyLevel: "L1"},

--- a/src/kernel/registry/cell.go
+++ b/src/kernel/registry/cell.go
@@ -45,17 +45,16 @@ func NewCellRegistry(project *metadata.ProjectMeta) *CellRegistry {
 	return r
 }
 
-// Get returns a shallow copy of a cell by ID, or nil if not found.
+// Get returns a deep copy of a cell by ID, or nil if not found.
 func (r *CellRegistry) Get(id string) *metadata.CellMeta {
 	c := r.cells[id]
 	if c == nil {
 		return nil
 	}
-	cp := *c
-	return &cp
+	return deepCopyCell(c)
 }
 
-// SlicesFor returns copies of all slices belonging to the given cell.
+// SlicesFor returns deep copies of all slices belonging to the given cell.
 func (r *CellRegistry) SlicesFor(cellID string) []*metadata.SliceMeta {
 	src := r.slices[cellID]
 	if len(src) == 0 {
@@ -63,10 +62,25 @@ func (r *CellRegistry) SlicesFor(cellID string) []*metadata.SliceMeta {
 	}
 	out := make([]*metadata.SliceMeta, len(src))
 	for i, s := range src {
-		cp := *s
-		out[i] = &cp
+		out[i] = deepCopySlice(s)
 	}
 	return out
+}
+
+func deepCopyCell(c *metadata.CellMeta) *metadata.CellMeta {
+	cp := *c
+	cp.Verify.Smoke = append([]string(nil), c.Verify.Smoke...)
+	cp.L0Dependencies = append([]metadata.L0DepMeta(nil), c.L0Dependencies...)
+	return &cp
+}
+
+func deepCopySlice(s *metadata.SliceMeta) *metadata.SliceMeta {
+	cp := *s
+	cp.ContractUsages = append([]metadata.ContractUsage(nil), s.ContractUsages...)
+	cp.Verify.Unit = append([]string(nil), s.Verify.Unit...)
+	cp.Verify.Contract = append([]string(nil), s.Verify.Contract...)
+	cp.Verify.Waivers = append([]metadata.WaiverMeta(nil), s.Verify.Waivers...)
+	return &cp
 }
 
 // AllIDs returns all cell IDs sorted alphabetically.

--- a/src/kernel/registry/cell.go
+++ b/src/kernel/registry/cell.go
@@ -45,14 +45,28 @@ func NewCellRegistry(project *metadata.ProjectMeta) *CellRegistry {
 	return r
 }
 
-// Get returns a cell by ID, or nil if not found.
+// Get returns a shallow copy of a cell by ID, or nil if not found.
 func (r *CellRegistry) Get(id string) *metadata.CellMeta {
-	return r.cells[id]
+	c := r.cells[id]
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	return &cp
 }
 
-// SlicesFor returns all slices belonging to the given cell.
+// SlicesFor returns copies of all slices belonging to the given cell.
 func (r *CellRegistry) SlicesFor(cellID string) []*metadata.SliceMeta {
-	return r.slices[cellID]
+	src := r.slices[cellID]
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]*metadata.SliceMeta, len(src))
+	for i, s := range src {
+		cp := *s
+		out[i] = &cp
+	}
+	return out
 }
 
 // AllIDs returns all cell IDs sorted alphabetically.

--- a/src/kernel/registry/contract.go
+++ b/src/kernel/registry/contract.go
@@ -36,19 +36,36 @@ func NewContractRegistry(project *metadata.ProjectMeta) *ContractRegistry {
 	return r
 }
 
-// Get returns a contract by ID, or nil if not found.
+// Get returns a shallow copy of a contract by ID, or nil if not found.
 func (r *ContractRegistry) Get(id string) *metadata.ContractMeta {
-	return r.contracts[id]
+	c := r.contracts[id]
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	return &cp
 }
 
-// ByKind returns all contracts of the given kind (http/event/command/projection).
+// ByKind returns copies of all contracts of the given kind.
 func (r *ContractRegistry) ByKind(kind string) []*metadata.ContractMeta {
-	return r.byKind[kind]
+	return copyContractSlice(r.byKind[kind])
 }
 
-// ByOwner returns all contracts owned by the given cell.
+// ByOwner returns copies of all contracts owned by the given cell.
 func (r *ContractRegistry) ByOwner(cellID string) []*metadata.ContractMeta {
-	return r.byOwner[cellID]
+	return copyContractSlice(r.byOwner[cellID])
+}
+
+func copyContractSlice(src []*metadata.ContractMeta) []*metadata.ContractMeta {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]*metadata.ContractMeta, len(src))
+	for i, c := range src {
+		cp := *c
+		out[i] = &cp
+	}
+	return out
 }
 
 // Provider returns the provider actor ID for a contract.
@@ -83,13 +100,13 @@ func (r *ContractRegistry) Consumers(contractID string) []string {
 	}
 	switch c.Kind {
 	case "http":
-		return c.Endpoints.Clients
+		return append([]string(nil), c.Endpoints.Clients...)
 	case "event":
-		return c.Endpoints.Subscribers
+		return append([]string(nil), c.Endpoints.Subscribers...)
 	case "command":
-		return c.Endpoints.Invokers
+		return append([]string(nil), c.Endpoints.Invokers...)
 	case "projection":
-		return c.Endpoints.Readers
+		return append([]string(nil), c.Endpoints.Readers...)
 	default:
 		return nil
 	}

--- a/src/kernel/registry/contract.go
+++ b/src/kernel/registry/contract.go
@@ -36,22 +36,21 @@ func NewContractRegistry(project *metadata.ProjectMeta) *ContractRegistry {
 	return r
 }
 
-// Get returns a shallow copy of a contract by ID, or nil if not found.
+// Get returns a deep copy of a contract by ID, or nil if not found.
 func (r *ContractRegistry) Get(id string) *metadata.ContractMeta {
 	c := r.contracts[id]
 	if c == nil {
 		return nil
 	}
-	cp := *c
-	return &cp
+	return deepCopyContract(c)
 }
 
-// ByKind returns copies of all contracts of the given kind.
+// ByKind returns deep copies of all contracts of the given kind.
 func (r *ContractRegistry) ByKind(kind string) []*metadata.ContractMeta {
 	return copyContractSlice(r.byKind[kind])
 }
 
-// ByOwner returns copies of all contracts owned by the given cell.
+// ByOwner returns deep copies of all contracts owned by the given cell.
 func (r *ContractRegistry) ByOwner(cellID string) []*metadata.ContractMeta {
 	return copyContractSlice(r.byOwner[cellID])
 }
@@ -62,10 +61,24 @@ func copyContractSlice(src []*metadata.ContractMeta) []*metadata.ContractMeta {
 	}
 	out := make([]*metadata.ContractMeta, len(src))
 	for i, c := range src {
-		cp := *c
-		out[i] = &cp
+		out[i] = deepCopyContract(c)
 	}
 	return out
+}
+
+func deepCopyContract(c *metadata.ContractMeta) *metadata.ContractMeta {
+	cp := *c
+	// Deep copy mutable Endpoints slices.
+	cp.Endpoints.Clients = append([]string(nil), c.Endpoints.Clients...)
+	cp.Endpoints.Subscribers = append([]string(nil), c.Endpoints.Subscribers...)
+	cp.Endpoints.Invokers = append([]string(nil), c.Endpoints.Invokers...)
+	cp.Endpoints.Readers = append([]string(nil), c.Endpoints.Readers...)
+	// Deep copy Replayable pointer.
+	if c.Replayable != nil {
+		v := *c.Replayable
+		cp.Replayable = &v
+	}
+	return &cp
 }
 
 // Provider returns the provider actor ID for a contract.

--- a/src/kernel/registry/contract.go
+++ b/src/kernel/registry/contract.go
@@ -89,18 +89,7 @@ func (r *ContractRegistry) Provider(contractID string) string {
 	if c == nil {
 		return ""
 	}
-	switch c.Kind {
-	case "http":
-		return c.Endpoints.Server
-	case "event":
-		return c.Endpoints.Publisher
-	case "command":
-		return c.Endpoints.Handler
-	case "projection":
-		return c.Endpoints.Provider
-	default:
-		return ""
-	}
+	return c.ProviderEndpoint()
 }
 
 // Consumers returns the consumer actor IDs for a contract.

--- a/src/kernel/registry/registry_test.go
+++ b/src/kernel/registry/registry_test.go
@@ -387,3 +387,86 @@ func TestCellRegistry_SliceFallbackCellID(t *testing.T) {
 	reg := registry.NewCellRegistry(proj)
 	assert.Len(t, reg.SlicesFor("fallback-cell"), 1)
 }
+
+// --- Deep-copy mutation tests ---
+
+func TestContractRegistry_Get_DeepCopy(t *testing.T) {
+	reg := registry.NewContractRegistry(testProject())
+	got := reg.Get("http-auth-login-v1")
+	require.NotNil(t, got)
+
+	// Mutate the returned copy.
+	got.Endpoints.Clients[0] = "MUTATED"
+	got.ID = "MUTATED"
+
+	// Original must be unchanged.
+	original := reg.Get("http-auth-login-v1")
+	assert.Equal(t, "http-auth-login-v1", original.ID)
+	assert.NotEqual(t, "MUTATED", original.Endpoints.Clients[0])
+}
+
+func TestContractRegistry_ByKind_DeepCopy(t *testing.T) {
+	reg := registry.NewContractRegistry(testProject())
+	got := reg.ByKind("http")
+	require.Len(t, got, 1)
+
+	got[0].Endpoints.Clients[0] = "MUTATED"
+
+	fresh := reg.ByKind("http")
+	assert.NotEqual(t, "MUTATED", fresh[0].Endpoints.Clients[0])
+}
+
+func TestContractRegistry_Consumers_DeepCopy(t *testing.T) {
+	reg := registry.NewContractRegistry(testProject())
+	got := reg.Consumers("http-auth-login-v1")
+	require.NotEmpty(t, got)
+
+	got[0] = "MUTATED"
+
+	fresh := reg.Consumers("http-auth-login-v1")
+	assert.NotEqual(t, "MUTATED", fresh[0])
+}
+
+func TestCellRegistry_Get_DeepCopy(t *testing.T) {
+	proj := testProject()
+	proj.Cells["access-core"].Verify.Smoke = []string{"smoke.startup"}
+	reg := registry.NewCellRegistry(proj)
+	got := reg.Get("access-core")
+	require.NotNil(t, got)
+
+	got.Verify.Smoke[0] = "MUTATED"
+	got.ID = "MUTATED"
+
+	original := reg.Get("access-core")
+	assert.Equal(t, "access-core", original.ID)
+	assert.NotEqual(t, "MUTATED", original.Verify.Smoke[0])
+}
+
+func TestCellRegistry_SlicesFor_DeepCopy(t *testing.T) {
+	proj := testProject()
+	proj.Slices["access-core/session-create"].ContractUsages = []metadata.ContractUsage{
+		{Contract: "http-auth-login-v1", Role: "serve"},
+	}
+	reg := registry.NewCellRegistry(proj)
+	got := reg.SlicesFor("access-core")
+	require.NotEmpty(t, got)
+
+	// Find the slice with contract usages.
+	var target *metadata.SliceMeta
+	for _, s := range got {
+		if len(s.ContractUsages) > 0 {
+			target = s
+			break
+		}
+	}
+	require.NotNil(t, target)
+
+	target.ContractUsages[0].Role = "MUTATED"
+
+	fresh := reg.SlicesFor("access-core")
+	for _, s := range fresh {
+		for _, cu := range s.ContractUsages {
+			assert.NotEqual(t, "MUTATED", cu.Role)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **metadata/parser**: `ownerCell` 为空时从 endpoints 按 kind 推导（MR-R02）
- **governance/TOPO-04**: 改为检查实际 provider 而非 ownerCell，支持 external actor（GOV-1）
- **governance/VERIFY-04**: 新规则 — active contract 必须有 provider-role slice（GOV-3）
- **registry**: Get/SlicesFor/ByKind/ByOwner/Consumers 全部返回防御性拷贝（MR-R05）

## Findings Addressed (4 C2 items)
| ID | 问题 |
|----|------|
| MR-R02 | schema 声称 ownerCell 可省略，实现未回填 |
| GOV-1 | TOPO-04 拿 ownerCell 当 provider 做一致性约束（误报+漏报） |
| GOV-3 | active contract 可零 provider 实现通过校验 |
| MR-R05 | registry 声称 read-only 但返回内部可变指针 |

## Test plan
- [x] `go test ./kernel/... -count=1` — 全部通过
- [x] governance TOPO-04 用 `contractProvider()` 替代 `ownerCell` 查找
- [x] VERIFY-04 测试 fixture 补齐 provider-role slice

来源: 2026-04-09 kernel 六角色深审 Phase B
剩余: B5 (GOV-5/6) + B6 (strict YAML) 将在后续 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)