### PR TITLE
feat(governance): GOV-5 verify ref format validation + GOV-6 L0 dependency tracking

### DIFF
--- a/src/kernel/assembly/generator_test.go
+++ b/src/kernel/assembly/generator_test.go
@@ -38,7 +38,7 @@ func buildTestProject() *metadata.ProjectMeta {
 				ConsistencyLevel: "L1",
 				Owner:            metadata.OwnerMeta{Team: "identity", Role: "maintainer"},
 				Schema:           metadata.SchemaMeta{Primary: "users"},
-				Verify:           metadata.CellVerifyMeta{Smoke: []string{"test/smoke/auth_test.go", "test/smoke/session_test.go"}},
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.access-core.auth", "smoke.access-core.session"}},
 			},
 			"audit-core": {
 				ID:               "audit-core",
@@ -46,7 +46,7 @@ func buildTestProject() *metadata.ProjectMeta {
 				ConsistencyLevel: "L2",
 				Owner:            metadata.OwnerMeta{Team: "compliance", Role: "maintainer"},
 				Schema:           metadata.SchemaMeta{Primary: "audit_logs"},
-				Verify:           metadata.CellVerifyMeta{Smoke: []string{"test/smoke/audit_test.go"}},
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.audit-core.audit"}},
 			},
 			"config-core": {
 				ID:               "config-core",
@@ -54,7 +54,7 @@ func buildTestProject() *metadata.ProjectMeta {
 				ConsistencyLevel: "L1",
 				Owner:            metadata.OwnerMeta{Team: "platform", Role: "maintainer"},
 				Schema:           metadata.SchemaMeta{Primary: "config_entries"},
-				Verify:           metadata.CellVerifyMeta{Smoke: []string{"test/smoke/config_test.go"}},
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.config-core.config"}},
 			},
 		},
 		Slices:    make(map[string]*metadata.SliceMeta),
@@ -271,14 +271,14 @@ func TestGenerateBoundary_SmokeTargets(t *testing.T) {
 
 	content := string(out)
 
-	// access-core smoke: test/smoke/auth_test.go, test/smoke/session_test.go
-	// audit-core smoke: test/smoke/audit_test.go
-	assert.Contains(t, content, "test/smoke/auth_test.go")
-	assert.Contains(t, content, "test/smoke/session_test.go")
-	assert.Contains(t, content, "test/smoke/audit_test.go")
+	// access-core smoke: smoke.access-core.auth, smoke.access-core.session
+	// audit-core smoke: smoke.audit-core.audit
+	assert.Contains(t, content, "smoke.access-core.auth")
+	assert.Contains(t, content, "smoke.access-core.session")
+	assert.Contains(t, content, "smoke.audit-core.audit")
 
 	// config-core smoke should NOT appear (config-core is outside assembly)
-	assert.NotContains(t, content, "test/smoke/config_test.go")
+	assert.NotContains(t, content, "smoke.config-core.config")
 }
 
 func TestGenerateBoundary_FingerprintNonEmpty(t *testing.T) {

--- a/src/kernel/cell/interfaces.go
+++ b/src/kernel/cell/interfaces.go
@@ -46,7 +46,8 @@ type SchemaConfig struct {
 	Primary string
 }
 
-// CellVerify holds smoke-test paths for a Cell.
+// CellVerify holds structured verify refs for a Cell.
+// Smoke refs use the format: smoke.{cellID}.{suffix}
 type CellVerify struct {
 	Smoke []string
 }

--- a/src/kernel/governance/rules_verify.go
+++ b/src/kernel/governance/rules_verify.go
@@ -197,7 +197,7 @@ var validRefPrefixes = map[string]bool{
 func (v *Validator) validateVerifyRef(ref, file, field string) []ValidationResult {
 	var results []ValidationResult
 	parts := strings.SplitN(ref, ".", 3)
-	if len(parts) < 3 || parts[2] == "" {
+	if len(parts) < 3 || parts[1] == "" || parts[2] == "" {
 		results = append(results, ValidationResult{
 			Code:      "VERIFY-05",
 			Severity:  SeverityError,
@@ -205,7 +205,7 @@ func (v *Validator) validateVerifyRef(ref, file, field string) []ValidationResul
 			File:      file,
 			Field:     field,
 			Message: fmt.Sprintf(
-				"ref %q must have at least 3 dot-separated segments", ref,
+				"ref %q must have at least 3 non-empty dot-separated segments", ref,
 			),
 		})
 		return results

--- a/src/kernel/governance/rules_verify.go
+++ b/src/kernel/governance/rules_verify.go
@@ -131,6 +131,37 @@ func (v *Validator) validateVERIFY02() []ValidationResult {
 	return results
 }
 
+// validateVERIFY03 checks that l0Dependencies[].cell targets an L0-level cell.
+func (v *Validator) validateVERIFY03() []ValidationResult {
+	var results []ValidationResult
+	for _, c := range v.project.Cells {
+		for i, dep := range c.L0Dependencies {
+			target, ok := v.project.Cells[dep.Cell]
+			if !ok {
+				continue // REF-09 covers missing cells
+			}
+			targetLevel, parseErr := cell.ParseLevel(target.ConsistencyLevel)
+			if parseErr != nil {
+				continue // FMT-03 covers invalid levels
+			}
+			if targetLevel != cell.L0 {
+				results = append(results, ValidationResult{
+					Code:      "VERIFY-03",
+					Severity:  SeverityError,
+					IssueType: IssueMismatch,
+					File:      cellFile(c.ID),
+					Field:     fmt.Sprintf("l0Dependencies[%d].cell", i),
+					Message: fmt.Sprintf(
+						"cell %q declares l0Dependency on %q but target has consistencyLevel %s (expected L0)",
+						c.ID, dep.Cell, target.ConsistencyLevel,
+					),
+				})
+			}
+		}
+	}
+	return results
+}
+
 // validateVERIFY04 checks that every active contract whose provider is a
 // Cell has at least one provider-role slice. Without this, a contract is
 // "published but nobody provides it" — a ghost capability.
@@ -288,36 +319,5 @@ func (v *Validator) validateVERIFY05() []ValidationResult {
 		}
 	}
 
-	return results
-}
-
-// validateVERIFY03 checks that l0Dependencies[].cell targets an L0-level cell.
-func (v *Validator) validateVERIFY03() []ValidationResult {
-	var results []ValidationResult
-	for _, c := range v.project.Cells {
-		for i, dep := range c.L0Dependencies {
-			target, ok := v.project.Cells[dep.Cell]
-			if !ok {
-				continue // REF-09 covers missing cells
-			}
-			targetLevel, parseErr := cell.ParseLevel(target.ConsistencyLevel)
-			if parseErr != nil {
-				continue // FMT-03 covers invalid levels
-			}
-			if targetLevel != cell.L0 {
-				results = append(results, ValidationResult{
-					Code:      "VERIFY-03",
-					Severity:  SeverityError,
-					IssueType: IssueMismatch,
-					File:      cellFile(c.ID),
-					Field:     fmt.Sprintf("l0Dependencies[%d].cell", i),
-					Message: fmt.Sprintf(
-						"cell %q declares l0Dependency on %q but target has consistencyLevel %s (expected L0)",
-						c.ID, dep.Cell, target.ConsistencyLevel,
-					),
-				})
-			}
-		}
-	}
 	return results
 }

--- a/src/kernel/governance/rules_verify.go
+++ b/src/kernel/governance/rules_verify.go
@@ -228,7 +228,7 @@ var validRefPrefixes = map[string]bool{
 func (v *Validator) validateVerifyRef(ref, file, field string) []ValidationResult {
 	var results []ValidationResult
 	parts := strings.SplitN(ref, ".", 3)
-	if len(parts) < 3 || parts[1] == "" || parts[2] == "" {
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		results = append(results, ValidationResult{
 			Code:      "VERIFY-05",
 			Severity:  SeverityError,

--- a/src/kernel/governance/rules_verify.go
+++ b/src/kernel/governance/rules_verify.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/cell"
@@ -179,6 +180,114 @@ func (v *Validator) validateVERIFY04() []ValidationResult {
 			})
 		}
 	}
+	return results
+}
+
+// validRefPrefixes is the set of allowed first segments in a verify ref.
+var validRefPrefixes = map[string]bool{
+	"journey":  true,
+	"smoke":    true,
+	"unit":     true,
+	"contract": true,
+}
+
+// validateVerifyRef checks a single ref string for format compliance.
+// Rules: at least 3 dot-separated segments; first segment must be a known prefix.
+// For smoke refs, second segment must be a cellID present in the project.
+func (v *Validator) validateVerifyRef(ref, file, field string) []ValidationResult {
+	var results []ValidationResult
+	parts := strings.SplitN(ref, ".", 3)
+	if len(parts) < 3 || parts[2] == "" {
+		results = append(results, ValidationResult{
+			Code:      "VERIFY-05",
+			Severity:  SeverityError,
+			IssueType: IssueInvalid,
+			File:      file,
+			Field:     field,
+			Message: fmt.Sprintf(
+				"ref %q must have at least 3 dot-separated segments", ref,
+			),
+		})
+		return results
+	}
+
+	prefix := parts[0]
+	if !validRefPrefixes[prefix] {
+		results = append(results, ValidationResult{
+			Code:      "VERIFY-05",
+			Severity:  SeverityError,
+			IssueType: IssueInvalid,
+			File:      file,
+			Field:     field,
+			Message: fmt.Sprintf(
+				"ref %q has unknown prefix %q; expected journey, smoke, unit, or contract", ref, prefix,
+			),
+		})
+		return results
+	}
+
+	// For smoke refs, the second segment must be an existing cellID.
+	if prefix == "smoke" {
+		cellID := parts[1]
+		if _, ok := v.project.Cells[cellID]; !ok {
+			results = append(results, ValidationResult{
+				Code:      "VERIFY-05",
+				Severity:  SeverityError,
+				IssueType: IssueRefNotFound,
+				File:      file,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"smoke ref %q references non-existent cell %q", ref, cellID,
+				),
+			})
+		}
+	}
+
+	return results
+}
+
+// validateVERIFY05 checks that all verify refs (cell.verify.smoke,
+// slice.verify.unit, slice.verify.contract, journey.passCriteria[].checkRef)
+// use the structured ref format: {prefix}.{scope}.{suffix}, where prefix is
+// one of journey/smoke/unit/contract. For smoke refs the scope must be an
+// existing cellID.
+func (v *Validator) validateVERIFY05() []ValidationResult {
+	var results []ValidationResult
+
+	// cell.yaml verify.smoke refs
+	for _, c := range v.project.Cells {
+		file := cellFile(c.ID)
+		for i, ref := range c.Verify.Smoke {
+			field := fmt.Sprintf("verify.smoke[%d]", i)
+			results = append(results, v.validateVerifyRef(ref, file, field)...)
+		}
+	}
+
+	// slice.yaml verify.unit + verify.contract refs
+	for key, s := range v.project.Slices {
+		file := sliceFile(key)
+		for i, ref := range s.Verify.Unit {
+			field := fmt.Sprintf("verify.unit[%d]", i)
+			results = append(results, v.validateVerifyRef(ref, file, field)...)
+		}
+		for i, ref := range s.Verify.Contract {
+			field := fmt.Sprintf("verify.contract[%d]", i)
+			results = append(results, v.validateVerifyRef(ref, file, field)...)
+		}
+	}
+
+	// journey passCriteria[].checkRef
+	for _, j := range v.project.Journeys {
+		file := journeyFile(j.ID)
+		for i, pc := range j.PassCriteria {
+			if pc.CheckRef == "" {
+				continue
+			}
+			field := fmt.Sprintf("passCriteria[%d].checkRef", i)
+			results = append(results, v.validateVerifyRef(pc.CheckRef, file, field)...)
+		}
+	}
+
 	return results
 }
 

--- a/src/kernel/governance/targets.go
+++ b/src/kernel/governance/targets.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
@@ -288,7 +289,7 @@ func (ts *TargetSelector) expandL0Dependents(sliceSet map[string]struct{}, fileC
 		if !ok {
 			continue
 		}
-		if c.ConsistencyLevel == "L0" {
+		if lvl, err := cell.ParseLevel(c.ConsistencyLevel); err == nil && lvl == cell.L0 {
 			l0Cells[c.ID] = struct{}{}
 		}
 	}
@@ -299,7 +300,7 @@ func (ts *TargetSelector) expandL0Dependents(sliceSet map[string]struct{}, fileC
 		if !ok {
 			continue
 		}
-		if c.ConsistencyLevel == "L0" {
+		if lvl, err := cell.ParseLevel(c.ConsistencyLevel); err == nil && lvl == cell.L0 {
 			l0Cells[c.ID] = struct{}{}
 		}
 	}

--- a/src/kernel/governance/targets.go
+++ b/src/kernel/governance/targets.go
@@ -45,14 +45,15 @@ func NewTargetSelector(project *metadata.ProjectMeta) *TargetSelector {
 // ref: K8s kubectl diff — impact analysis across all resource types
 func (ts *TargetSelector) SelectFromFiles(files []string) *AffectedTargets {
 	sliceSet := make(map[string]struct{})
-	cellSet := make(map[string]struct{})
+	fileCellSet := make(map[string]struct{}) // cells directly hit by file paths (cells/**)
+	cellSet := make(map[string]struct{})     // cells from journey/assembly expansion
 	contractSet := make(map[string]struct{})
 
 	for _, f := range files {
 		// Normalize path separators and clean.
 		f = path.Clean(strings.ReplaceAll(f, "\\", "/"))
 
-		if ts.matchSliceFromCellsPath(f, sliceSet) {
+		if ts.matchSliceFromCellsPath(f, sliceSet, fileCellSet) {
 			continue
 		}
 		if ts.matchSlicesFromContractPath(f, sliceSet) {
@@ -64,16 +65,17 @@ func (ts *TargetSelector) SelectFromFiles(files []string) *AffectedTargets {
 		ts.matchFromAssemblyPath(f, cellSet)
 	}
 
+	// Expand L0 dependencies BEFORE journey/assembly expansion.
+	// Only file-path-derived cells trigger L0 propagation, not
+	// journey/assembly references (which would cause over-selection).
+	ts.expandL0Dependents(sliceSet, fileCellSet)
+
 	// Expand cells collected from journey/assembly paths into slices.
 	for key, s := range ts.project.Slices {
 		if _, ok := cellSet[s.BelongsToCell]; ok {
 			sliceSet[key] = struct{}{}
 		}
 	}
-
-	// Expand L0 dependencies: when an L0 cell's file is changed,
-	// all cells that declare it in l0Dependencies are also affected.
-	ts.expandL0Dependents(sliceSet)
 
 	result := ts.expandFromSlices(sliceSet)
 
@@ -105,7 +107,9 @@ func (ts *TargetSelector) SelectFromSlice(sliceKey string) *AffectedTargets {
 
 // matchSliceFromCellsPath handles paths under cells/.
 // Returns true if the path was consumed (matched cells/ prefix).
-func (ts *TargetSelector) matchSliceFromCellsPath(f string, sliceSet map[string]struct{}) bool {
+// fileCellSet tracks which cells are directly hit by file paths
+// (used for L0 dependency propagation).
+func (ts *TargetSelector) matchSliceFromCellsPath(f string, sliceSet, fileCellSet map[string]struct{}) bool {
 	// Expect: cells/{cellID}/...
 	if !strings.HasPrefix(f, "cells/") {
 		return false
@@ -122,6 +126,9 @@ func (ts *TargetSelector) matchSliceFromCellsPath(f string, sliceSet map[string]
 	if _, ok := ts.project.Cells[cellID]; !ok {
 		return true
 	}
+
+	// Track this cell as directly affected by a file change.
+	fileCellSet[cellID] = struct{}{}
 
 	// cells/{cellID}/slices/{sliceID}/**
 	if len(parts) >= 4 && parts[2] == "slices" {
@@ -263,12 +270,15 @@ func (ts *TargetSelector) contractIDFromPath(f string) string {
 	return strings.ReplaceAll(dir, "/", ".")
 }
 
-// expandL0Dependents checks whether any already-selected slice belongs to
-// an L0 cell, and if so, adds all slices of cells that declare that L0 cell
-// in their l0Dependencies. This propagates change impact through L0 edges.
-func (ts *TargetSelector) expandL0Dependents(sliceSet map[string]struct{}) {
-	// Collect L0 cell IDs that are already affected.
+// expandL0Dependents checks whether any file-change-affected cell is L0,
+// and if so, adds all slices of cells that declare that L0 cell in their
+// l0Dependencies. fileCellSet covers L0 cells that may have no slices
+// (and thus no entries in sliceSet).
+func (ts *TargetSelector) expandL0Dependents(sliceSet map[string]struct{}, fileCellSet map[string]struct{}) {
+	// Collect L0 cell IDs from file-path-derived sources.
 	l0Cells := make(map[string]struct{})
+
+	// From sliceSet: slice-level file changes.
 	for key := range sliceSet {
 		s, ok := ts.project.Slices[key]
 		if !ok {
@@ -282,6 +292,18 @@ func (ts *TargetSelector) expandL0Dependents(sliceSet map[string]struct{}) {
 			l0Cells[c.ID] = struct{}{}
 		}
 	}
+
+	// From fileCellSet: cell-level file changes (covers L0 cells with no slices).
+	for cellID := range fileCellSet {
+		c, ok := ts.project.Cells[cellID]
+		if !ok {
+			continue
+		}
+		if c.ConsistencyLevel == "L0" {
+			l0Cells[c.ID] = struct{}{}
+		}
+	}
+
 	if len(l0Cells) == 0 {
 		return
 	}

--- a/src/kernel/governance/targets.go
+++ b/src/kernel/governance/targets.go
@@ -71,6 +71,10 @@ func (ts *TargetSelector) SelectFromFiles(files []string) *AffectedTargets {
 		}
 	}
 
+	// Expand L0 dependencies: when an L0 cell's file is changed,
+	// all cells that declare it in l0Dependencies are also affected.
+	ts.expandL0Dependents(sliceSet)
+
 	result := ts.expandFromSlices(sliceSet)
 
 	// Merge extra contracts from journey paths that may not be referenced
@@ -257,6 +261,45 @@ func (ts *TargetSelector) contractIDFromPath(f string) string {
 
 	// Replace slashes with dots to form the contract ID.
 	return strings.ReplaceAll(dir, "/", ".")
+}
+
+// expandL0Dependents checks whether any already-selected slice belongs to
+// an L0 cell, and if so, adds all slices of cells that declare that L0 cell
+// in their l0Dependencies. This propagates change impact through L0 edges.
+func (ts *TargetSelector) expandL0Dependents(sliceSet map[string]struct{}) {
+	// Collect L0 cell IDs that are already affected.
+	l0Cells := make(map[string]struct{})
+	for key := range sliceSet {
+		s, ok := ts.project.Slices[key]
+		if !ok {
+			continue
+		}
+		c, ok := ts.project.Cells[s.BelongsToCell]
+		if !ok {
+			continue
+		}
+		if c.ConsistencyLevel == "L0" {
+			l0Cells[c.ID] = struct{}{}
+		}
+	}
+	if len(l0Cells) == 0 {
+		return
+	}
+
+	// Find all cells that depend on any affected L0 cell.
+	for _, c := range ts.project.Cells {
+		for _, dep := range c.L0Dependencies {
+			if _, ok := l0Cells[dep.Cell]; ok {
+				// Add all slices of the dependent cell.
+				for key, s := range ts.project.Slices {
+					if s.BelongsToCell == c.ID {
+						sliceSet[key] = struct{}{}
+					}
+				}
+				break // no need to check more deps for this cell
+			}
+		}
+	}
 }
 
 // expandFromSlices takes a set of slice keys and expands to the full

--- a/src/kernel/governance/targets_test.go
+++ b/src/kernel/governance/targets_test.go
@@ -359,6 +359,16 @@ func l0Project() *metadata.ProjectMeta {
 				ConsistencyLevel: "L2",
 				// no L0 dependencies
 			},
+			"billing-core": {
+				ID:               "billing-core",
+				Type:             "core",
+				ConsistencyLevel: "L2",
+				L0Dependencies: []metadata.L0DepMeta{
+					{Cell: "shared-crypto", Reason: "signature"},
+				},
+				// NOT referenced by J-l0-test journey — used to test
+				// that journey changes don't trigger L0 propagation.
+			},
 		},
 		Slices: map[string]*metadata.SliceMeta{
 			"shared-crypto/hasher": {
@@ -376,6 +386,10 @@ func l0Project() *metadata.ProjectMeta {
 			"audit-core/audit-write": {
 				ID:            "audit-write",
 				BelongsToCell: "audit-core",
+			},
+			"billing-core/payment": {
+				ID:            "payment",
+				BelongsToCell: "billing-core",
 			},
 		},
 		Contracts: map[string]*metadata.ContractMeta{
@@ -403,13 +417,13 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 		wantContracts []string
 	}{
 		{
-			name:  "L0 cell change propagates to dependent cell",
+			name:  "L0 cell change propagates to all dependent cells",
 			files: []string{"cells/shared-crypto/slices/hasher/hash.go"},
 			// shared-crypto/hasher is directly affected;
-			// access-core depends on shared-crypto via l0Dependencies,
-			// so access-core/session-login is also selected.
-			wantSlices:    []string{"access-core/session-login", "shared-crypto/hasher"},
-			wantCells:     []string{"access-core", "shared-crypto"},
+			// access-core AND billing-core both depend on shared-crypto,
+			// so their slices are also selected.
+			wantSlices:    []string{"access-core/session-login", "billing-core/payment", "shared-crypto/hasher"},
+			wantCells:     []string{"access-core", "billing-core", "shared-crypto"},
 			wantContracts: []string{"http.auth.login.v1"},
 		},
 		{
@@ -424,8 +438,9 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 			name:  "journey referencing L0 cell does NOT trigger L0 propagation",
 			files: []string{"journeys/J-l0-test.yaml"},
 			// Journey references shared-crypto (L0) and access-core.
-			// But journey changes should NOT trigger L0 dependency propagation —
-			// only file-path changes to cells/** should.
+			// billing-core depends on shared-crypto but is NOT in the journey.
+			// If L0 propagation fired from journey expansion, billing-core/payment
+			// would appear — its absence proves the guard works.
 			wantSlices:    []string{"access-core/session-login", "shared-crypto/hasher"},
 			wantCells:     []string{"access-core", "shared-crypto"},
 			wantContracts: []string{"http.auth.login.v1"},

--- a/src/kernel/governance/targets_test.go
+++ b/src/kernel/governance/targets_test.go
@@ -328,7 +328,8 @@ func TestSelectFromFiles_NonexistentJourney(t *testing.T) {
 
 // --- L0 dependency tracking (GOV-6) ---
 
-// l0Project returns a ProjectMeta with an L0 cell and a dependent cell.
+// l0Project returns a ProjectMeta with L0 cells (with and without slices)
+// and dependent cells, plus a journey referencing the L0 cell.
 func l0Project() *metadata.ProjectMeta {
 	return &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{
@@ -337,12 +338,19 @@ func l0Project() *metadata.ProjectMeta {
 				Type:             "support",
 				ConsistencyLevel: "L0",
 			},
+			"shared-validate": {
+				ID:               "shared-validate",
+				Type:             "support",
+				ConsistencyLevel: "L0",
+				// L0 cell with NO slices — tests propagation for slice-less cells.
+			},
 			"access-core": {
 				ID:               "access-core",
 				Type:             "core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
 					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "shared-validate", Reason: "input validation"},
 				},
 			},
 			"audit-core": {
@@ -357,6 +365,7 @@ func l0Project() *metadata.ProjectMeta {
 				ID:            "hasher",
 				BelongsToCell: "shared-crypto",
 			},
+			// shared-validate has NO slices (intentional).
 			"access-core/session-login": {
 				ID:            "session-login",
 				BelongsToCell: "access-core",
@@ -375,7 +384,12 @@ func l0Project() *metadata.ProjectMeta {
 				Kind: "http",
 			},
 		},
-		Journeys:   map[string]*metadata.JourneyMeta{},
+		Journeys: map[string]*metadata.JourneyMeta{
+			"J-l0-test": {
+				ID:    "J-l0-test",
+				Cells: []string{"shared-crypto", "access-core"},
+			},
+		},
 		Assemblies: map[string]*metadata.AssemblyMeta{},
 	}
 }
@@ -407,11 +421,22 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 			wantContracts: []string{"http.auth.login.v1"},
 		},
 		{
-			name:  "cell without l0Dependencies not affected by L0 change",
-			files: []string{"cells/shared-crypto/slices/hasher/hash.go"},
-			// audit-core has no l0Dependencies, so it is NOT selected.
+			name:  "journey referencing L0 cell does NOT trigger L0 propagation",
+			files: []string{"journeys/J-l0-test.yaml"},
+			// Journey references shared-crypto (L0) and access-core.
+			// But journey changes should NOT trigger L0 dependency propagation —
+			// only file-path changes to cells/** should.
 			wantSlices:    []string{"access-core/session-login", "shared-crypto/hasher"},
 			wantCells:     []string{"access-core", "shared-crypto"},
+			wantContracts: []string{"http.auth.login.v1"},
+		},
+		{
+			name:  "L0 cell without slices propagates to dependents",
+			files: []string{"cells/shared-validate/cell.yaml"},
+			// shared-validate is L0 with no slices. Changing its cell.yaml
+			// should still propagate to access-core (which depends on it).
+			wantSlices:    []string{"access-core/session-login"},
+			wantCells:     []string{"access-core"},
 			wantContracts: []string{"http.auth.login.v1"},
 		},
 	}

--- a/src/kernel/governance/targets_test.go
+++ b/src/kernel/governance/targets_test.go
@@ -325,3 +325,105 @@ func TestSelectFromFiles_NonexistentJourney(t *testing.T) {
 	assert.Nil(t, result.Journeys)
 	assert.Nil(t, result.Contracts)
 }
+
+// --- L0 dependency tracking (GOV-6) ---
+
+// l0Project returns a ProjectMeta with an L0 cell and a dependent cell.
+func l0Project() *metadata.ProjectMeta {
+	return &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			"shared-crypto": {
+				ID:               "shared-crypto",
+				Type:             "support",
+				ConsistencyLevel: "L0",
+			},
+			"access-core": {
+				ID:               "access-core",
+				Type:             "core",
+				ConsistencyLevel: "L2",
+				L0Dependencies: []metadata.L0DepMeta{
+					{Cell: "shared-crypto", Reason: "hashing"},
+				},
+			},
+			"audit-core": {
+				ID:               "audit-core",
+				Type:             "core",
+				ConsistencyLevel: "L2",
+				// no L0 dependencies
+			},
+		},
+		Slices: map[string]*metadata.SliceMeta{
+			"shared-crypto/hasher": {
+				ID:            "hasher",
+				BelongsToCell: "shared-crypto",
+			},
+			"access-core/session-login": {
+				ID:            "session-login",
+				BelongsToCell: "access-core",
+				ContractUsages: []metadata.ContractUsage{
+					{Contract: "http.auth.login.v1", Role: "serve"},
+				},
+			},
+			"audit-core/audit-write": {
+				ID:            "audit-write",
+				BelongsToCell: "audit-core",
+			},
+		},
+		Contracts: map[string]*metadata.ContractMeta{
+			"http.auth.login.v1": {
+				ID:   "http.auth.login.v1",
+				Kind: "http",
+			},
+		},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+}
+
+func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
+	tests := []struct {
+		name          string
+		files         []string
+		wantSlices    []string
+		wantCells     []string
+		wantContracts []string
+	}{
+		{
+			name:  "L0 cell change propagates to dependent cell",
+			files: []string{"cells/shared-crypto/slices/hasher/hash.go"},
+			// shared-crypto/hasher is directly affected;
+			// access-core depends on shared-crypto via l0Dependencies,
+			// so access-core/session-login is also selected.
+			wantSlices:    []string{"access-core/session-login", "shared-crypto/hasher"},
+			wantCells:     []string{"access-core", "shared-crypto"},
+			wantContracts: []string{"http.auth.login.v1"},
+		},
+		{
+			name:  "non-L0 cell change does not trigger L0 tracking",
+			files: []string{"cells/access-core/slices/session-login/handler.go"},
+			// access-core is L2, so no L0 propagation happens.
+			wantSlices:    []string{"access-core/session-login"},
+			wantCells:     []string{"access-core"},
+			wantContracts: []string{"http.auth.login.v1"},
+		},
+		{
+			name:  "cell without l0Dependencies not affected by L0 change",
+			files: []string{"cells/shared-crypto/slices/hasher/hash.go"},
+			// audit-core has no l0Dependencies, so it is NOT selected.
+			wantSlices:    []string{"access-core/session-login", "shared-crypto/hasher"},
+			wantCells:     []string{"access-core", "shared-crypto"},
+			wantContracts: []string{"http.auth.login.v1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := NewTargetSelector(l0Project())
+			result := ts.SelectFromFiles(tt.files)
+			assert.Equal(t, tt.wantSlices, result.Slices)
+			assert.Equal(t, tt.wantCells, result.Cells)
+			if tt.wantContracts != nil {
+				assert.Equal(t, tt.wantContracts, result.Contracts)
+			}
+		})
+	}
+}

--- a/src/kernel/governance/validate.go
+++ b/src/kernel/governance/validate.go
@@ -116,6 +116,7 @@ func (v *Validator) Validate() []ValidationResult {
 	results = append(results, v.validateVERIFY02()...)
 	results = append(results, v.validateVERIFY03()...)
 	results = append(results, v.validateVERIFY04()...)
+	results = append(results, v.validateVERIFY05()...)
 
 	// Format compliance rules
 	results = append(results, v.validateFMT01()...)

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -41,7 +41,7 @@ func validProject() *metadata.ProjectMeta {
 				Type:             "support",
 				ConsistencyLevel: "L0",
 				Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
-				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.shared-crypto"}},
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.shared-crypto.startup"}},
 			},
 		},
 		Slices: map[string]*metadata.SliceMeta{
@@ -122,6 +122,10 @@ func validProject() *metadata.ProjectMeta {
 				Contracts: []string{
 					"http.auth.login.v1",
 					"event.session.created.v1",
+				},
+				PassCriteria: []metadata.PassCriterion{
+					{Text: "login returns token", Mode: "auto", CheckRef: "journey.J-sso-login.login-returns-token"},
+					{Text: "manual review", Mode: "manual"},
 				},
 			},
 		},
@@ -1146,6 +1150,119 @@ func TestVERIFY04(t *testing.T) {
 			tt.setup(pm)
 			val := NewValidator(pm, ".")
 			got := findByCode(val.validateVERIFY04(), "VERIFY-04")
+			assert.Len(t, got, tt.wantCount)
+		})
+	}
+}
+
+func TestVERIFY05(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+	}{
+		{
+			name:      "all refs valid format",
+			setup:     func(_ *metadata.ProjectMeta) {},
+			wantCount: 0,
+		},
+		{
+			name: "smoke ref missing third segment",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Verify.Smoke = []string{"smoke.access-core"}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "unknown prefix",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Verify.Smoke = []string{"integration.access-core.startup"}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "smoke ref references non-existent cell",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Verify.Smoke = []string{"smoke.nonexistent-cell.startup"}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "unit ref valid format",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["access-core/session-login"].Verify.Unit = []string{"unit.session-login.service"}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "unit ref too few segments",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["access-core/session-login"].Verify.Unit = []string{"unit.service"}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "contract ref valid format",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["access-core/session-login"].Verify.Contract = []string{
+					"contract.http.auth.login.v1.serve",
+					"contract.event.session.created.v1.publish",
+					"contract.projection.session.active.v1.provide",
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "journey checkRef valid format",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-sso-login"].PassCriteria = []metadata.PassCriterion{
+					{Text: "login ok", Mode: "auto", CheckRef: "journey.J-sso-login.login-ok"},
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "journey checkRef invalid prefix",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-sso-login"].PassCriteria = []metadata.PassCriterion{
+					{Text: "login ok", Mode: "auto", CheckRef: "unknown.J-sso-login.login-ok"},
+				}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "journey checkRef too few segments",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-sso-login"].PassCriteria = []metadata.PassCriterion{
+					{Text: "login ok", Mode: "auto", CheckRef: "journey.login"},
+				}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "empty checkRef is skipped",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-sso-login"].PassCriteria = []metadata.PassCriterion{
+					{Text: "manual step", Mode: "manual", CheckRef: ""},
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "multiple invalid refs accumulate",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Verify.Smoke = []string{"bad.ref"}
+				pm.Slices["access-core/session-login"].Verify.Unit = []string{"also-bad"}
+			},
+			wantCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, ".")
+			got := findByCode(val.validateVERIFY05(), "VERIFY-05")
 			assert.Len(t, got, tt.wantCount)
 		})
 	}

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -1256,6 +1256,13 @@ func TestVERIFY05(t *testing.T) {
 			wantCount: 0,
 		},
 		{
+			name: "leading dot ref rejected as empty prefix",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Cells["access-core"].Verify.Smoke = []string{".foo.bar"}
+			},
+			wantCount: 1,
+		},
+		{
 			name: "multiple invalid refs accumulate",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Cells["access-core"].Verify.Smoke = []string{"bad.ref"}

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -1240,6 +1240,13 @@ func TestVERIFY05(t *testing.T) {
 			wantCount: 1,
 		},
 		{
+			name: "empty scope segment rejected",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["access-core/session-login"].Verify.Unit = []string{"unit..service"}
+			},
+			wantCount: 1,
+		},
+		{
 			name: "empty checkRef is skipped",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Journeys["J-sso-login"].PassCriteria = []metadata.PassCriterion{

--- a/src/kernel/metadata/types.go
+++ b/src/kernel/metadata/types.go
@@ -24,7 +24,8 @@ type SchemaMeta struct {
 	Primary string `yaml:"primary"`
 }
 
-// CellVerifyMeta holds smoke-test paths for a Cell.
+// CellVerifyMeta holds structured verify refs for a Cell.
+// Smoke refs use the format: smoke.{cellID}.{suffix}
 type CellVerifyMeta struct {
 	Smoke []string `yaml:"smoke"`
 }

--- a/src/kernel/verify/ref.go
+++ b/src/kernel/verify/ref.go
@@ -29,9 +29,9 @@ type resolvedRef struct {
 // ref: kubernetes pkg/apis validation — segment-level input validation.
 func resolveRef(ref string) (resolvedRef, error) {
 	parts := strings.SplitN(ref, ".", 3)
-	if len(parts) < 3 || parts[2] == "" {
+	if len(parts) < 3 || parts[1] == "" || parts[2] == "" {
 		return resolvedRef{}, errcode.New(errcode.ErrCheckRefInvalid,
-			fmt.Sprintf("ref %q must have at least 3 dot-separated segments", ref))
+			fmt.Sprintf("ref %q must have at least 3 non-empty dot-separated segments", ref))
 	}
 
 	prefix := parts[0]

--- a/src/kernel/verify/ref.go
+++ b/src/kernel/verify/ref.go
@@ -29,7 +29,7 @@ type resolvedRef struct {
 // ref: kubernetes pkg/apis validation — segment-level input validation.
 func resolveRef(ref string) (resolvedRef, error) {
 	parts := strings.SplitN(ref, ".", 3)
-	if len(parts) < 3 || parts[1] == "" || parts[2] == "" {
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return resolvedRef{}, errcode.New(errcode.ErrCheckRefInvalid,
 			fmt.Sprintf("ref %q must have at least 3 non-empty dot-separated segments", ref))
 	}

--- a/src/kernel/verify/ref_test.go
+++ b/src/kernel/verify/ref_test.go
@@ -60,6 +60,11 @@ func TestResolveRef(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "empty scope segment",
+			ref:     "unit..service",
+			wantErr: true,
+		},
+		{
 			name:    "empty string",
 			ref:     "",
 			wantErr: true,

--- a/src/kernel/verify/ref_test.go
+++ b/src/kernel/verify/ref_test.go
@@ -65,6 +65,11 @@ func TestResolveRef(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "leading dot empty prefix",
+			ref:     ".foo.bar",
+			wantErr: true,
+		},
+		{
 			name:    "empty string",
 			ref:     "",
 			wantErr: true,


### PR DESCRIPTION
## Summary

**GOV-5**: Validate all verify ref strings (`cell.verify.smoke`, `slice.verify.unit/contract`, `journey.passCriteria[].checkRef`) at `gocell validate` time. Enforces structured format `{prefix}.{scope}.{suffix}` with known prefix, non-empty segments, and for smoke refs validates scope is an existing cellID.

**GOV-6**: When an L0 cell's files change, `select-targets` propagates impact to all cells declaring it in `l0Dependencies`. Only file-path-derived changes trigger propagation (not journey/assembly references). Handles L0 cells with no slices.

## Review fixes (second commit)

- **P1**: Reject empty scope segment — `unit..service`, `journey..login` now caught by both static validation and runtime resolver
- **P2**: Move `expandL0Dependents` before journey/assembly expansion; introduce `fileCellSet` to prevent over-selection when journeys reference L0 cells
- **P2**: `expandL0Dependents` now checks `fileCellSet` in addition to `sliceSet`, so L0 cells without slices still propagate to dependents
- **Actionable**: Replace duplicate test case with two new targeted cases (journey over-selection + slice-less L0 propagation)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./kernel/governance/... -count=1` — all pass
- [x] `go test ./kernel/verify/... -count=1` — all pass
- [x] `TestVERIFY05/empty_scope_segment_rejected` — new case passes
- [x] `TestSelectFromFiles_L0DependencyTracking` — 4 cases (propagation, non-L0, journey no-propagation, no-slice L0)
- [x] Coverage 96%+ (kernel ≥ 90% requirement)

## Backlog refs

- GOV-5, GOV-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)