### PR TITLE
feat(metadata): strict YAML parsing — reject unknown fields (F-META-01)

### DIFF
--- a/src/kernel/governance/rules_ref.go
+++ b/src/kernel/governance/rules_ref.go
@@ -268,6 +268,11 @@ func (v *Validator) validateREF12() []ValidationResult {
 			{"schemaRefs.response", c.SchemaRefs.Response},
 			{"schemaRefs.payload", c.SchemaRefs.Payload},
 		}
+		for key, val := range c.SchemaRefs.Extra {
+			refs = append(refs, refEntry{
+				fmt.Sprintf("schemaRefs.%s", key), val,
+			})
+		}
 		for _, ref := range refs {
 			if ref.value == "" {
 				continue

--- a/src/kernel/governance/validate_test.go
+++ b/src/kernel/governance/validate_test.go
@@ -2082,6 +2082,37 @@ func TestREF12(t *testing.T) {
 		assert.Len(t, got, 1)
 		assert.Contains(t, got[0].Field, "payload")
 	})
+
+	t.Run("extra schemaRef key missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		contractDir := filepath.Join(tmpDir, "contracts", "http", "auth", "login", "v1")
+		require.NoError(t, os.MkdirAll(contractDir, 0o755))
+
+		pm := validProject()
+		pm.Contracts["http.auth.login.v1"].SchemaRefs = metadata.SchemaRefsMeta{
+			Extra: map[string]string{"custom": "custom-schema.json"},
+		}
+		val := NewValidator(pm, tmpDir)
+		got := findByCode(val.validateREF12(), "REF-12")
+		require.Len(t, got, 1)
+		assert.Equal(t, "schemaRefs.custom", got[0].Field)
+		assert.Equal(t, IssueRefNotFound, got[0].IssueType)
+	})
+
+	t.Run("extra schemaRef key exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		contractDir := filepath.Join(tmpDir, "contracts", "http", "auth", "login", "v1")
+		require.NoError(t, os.MkdirAll(contractDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(contractDir, "custom-schema.json"), []byte("{}"), 0o644))
+
+		pm := validProject()
+		pm.Contracts["http.auth.login.v1"].SchemaRefs = metadata.SchemaRefsMeta{
+			Extra: map[string]string{"custom": "custom-schema.json"},
+		}
+		val := NewValidator(pm, tmpDir)
+		got := findByCode(val.validateREF12(), "REF-12")
+		assert.Empty(t, got)
+	})
 }
 
 // --- REF-13: contract provider actor exists ---

--- a/src/kernel/metadata/parser.go
+++ b/src/kernel/metadata/parser.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
@@ -240,15 +241,18 @@ func (p *Parser) parseActors(fsys fs.FS, path string, pm *ProjectMeta) error {
 	return nil
 }
 
-// unmarshalFile reads and decodes a YAML file from fsys.
-// Parse errors are wrapped with the file path and ErrMetadataInvalid.
+// unmarshalFile reads and decodes a YAML file from fsys with strict field
+// checking. Unknown YAML keys that don't map to struct fields are rejected,
+// preventing silent typos in metadata files (e.g., "ownerId" instead of "ownerCell").
 func unmarshalFile(fsys fs.FS, path string, out any) error {
 	data, err := fs.ReadFile(fsys, path)
 	if err != nil {
 		return errcode.Wrap(errcode.ErrMetadataInvalid,
 			fmt.Sprintf("read %s", path), err)
 	}
-	if err := yaml.Unmarshal(data, out); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(out); err != nil {
 		return errcode.Wrap(errcode.ErrMetadataInvalid,
 			fmt.Sprintf("parse %s", path), err)
 	}

--- a/src/kernel/metadata/parser.go
+++ b/src/kernel/metadata/parser.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -253,6 +254,13 @@ func unmarshalFile(fsys fs.FS, path string, out any) error {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(out); err != nil {
+		// yaml.Decoder returns io.EOF for empty/whitespace-only files, whereas
+		// yaml.Unmarshal silently leaves the target at its zero value. Preserve
+		// the old behaviour so that empty actors.yaml / status-board.yaml parse
+		// as empty slices instead of aborting.
+		if err == io.EOF {
+			return nil
+		}
 		return errcode.Wrap(errcode.ErrMetadataInvalid,
 			fmt.Sprintf("parse %s", path), err)
 	}

--- a/src/kernel/metadata/parser.go
+++ b/src/kernel/metadata/parser.go
@@ -264,5 +264,12 @@ func unmarshalFile(fsys fs.FS, path string, out any) error {
 		return errcode.Wrap(errcode.ErrMetadataInvalid,
 			fmt.Sprintf("parse %s", path), err)
 	}
+	// Reject multi-document YAML files. Metadata files must contain exactly
+	// one document; a second document after "---" would be silently ignored
+	// by a single Decode call.
+	if dec.Decode(new(any)) != io.EOF {
+		return errcode.New(errcode.ErrMetadataInvalid,
+			fmt.Sprintf("parse %s: unexpected multiple YAML documents", path))
+	}
 	return nil
 }

--- a/src/kernel/metadata/parser_test.go
+++ b/src/kernel/metadata/parser_test.go
@@ -1,9 +1,11 @@
 package metadata
 
 import (
+	"errors"
 	"testing"
 	"testing/fstest"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -910,14 +912,115 @@ bogus: 42
 			},
 			wantMsg: "bogus",
 		},
+		{
+			name: "unknown field in journey yaml",
+			fs: fstest.MapFS{
+				"journeys/J-test.yaml": &fstest.MapFile{Data: []byte(`id: J-test
+goal: test
+owner: {team: t, role: r}
+cells: []
+contracts: []
+passCriteria: []
+badField: oops
+`)},
+			},
+			wantMsg: "badField",
+		},
+		{
+			name: "unknown field in assembly yaml",
+			fs: fstest.MapFS{
+				"assemblies/a/assembly.yaml": &fstest.MapFile{Data: []byte(`id: a
+cells: []
+build: {entrypoint: main.go, binary: a, deployTemplate: t}
+nope: true
+`)},
+			},
+			wantMsg: "nope",
+		},
+		{
+			name: "unknown field in status-board entry",
+			fs: fstest.MapFS{
+				"journeys/status-board.yaml": &fstest.MapFile{Data: []byte(`- journeyId: J-x
+  state: green
+  risk: none
+  blocker: ""
+  updatedAt: "2026-01-01"
+  extra: bad
+`)},
+			},
+			wantMsg: "extra",
+		},
+		{
+			name: "unknown field in actors entry",
+			fs: fstest.MapFS{
+				"actors.yaml": &fstest.MapFile{Data: []byte(`- id: ext
+  type: external
+  maxConsistencyLevel: L2
+  phantom: yes
+`)},
+			},
+			wantMsg: "phantom",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewParser(".")
 			_, err := p.ParseFS(tt.fs)
 			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr), "expected *errcode.Error, got: %T", err)
+			assert.Equal(t, errcode.ErrMetadataInvalid, ecErr.Code)
 			assert.Contains(t, err.Error(), tt.wantMsg)
-			assert.Contains(t, err.Error(), "not found")
+		})
+	}
+}
+
+func TestParseFS_SchemaRefsExtraKeys(t *testing.T) {
+	fs := fstest.MapFS{
+		"contracts/http/test/v1/contract.yaml": &fstest.MapFile{Data: []byte(`id: http.test.v1
+kind: http
+lifecycle: active
+endpoints: {server: x}
+schemaRefs:
+  request: req.json
+  response: res.json
+  custom: extra.json
+`)},
+	}
+	p := NewParser(".")
+	pm, err := p.ParseFS(fs)
+	require.NoError(t, err)
+	c := pm.Contracts["http.test.v1"]
+	require.NotNil(t, c)
+	assert.Equal(t, "req.json", c.SchemaRefs.Request)
+	assert.Equal(t, "res.json", c.SchemaRefs.Response)
+	assert.Equal(t, "extra.json", c.SchemaRefs.Extra["custom"])
+}
+
+func TestParseFS_EmptyFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		fs   fstest.MapFS
+	}{
+		{
+			name: "empty actors.yaml",
+			fs: fstest.MapFS{
+				"actors.yaml": &fstest.MapFile{Data: []byte("")},
+			},
+		},
+		{
+			name: "whitespace-only status-board.yaml",
+			fs: fstest.MapFS{
+				"journeys/status-board.yaml": &fstest.MapFile{Data: []byte("  \n")},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(".")
+			pm, err := p.ParseFS(tt.fs)
+			require.NoError(t, err, "empty file should parse without error")
+			assert.NotNil(t, pm)
 		})
 	}
 }

--- a/src/kernel/metadata/parser_test.go
+++ b/src/kernel/metadata/parser_test.go
@@ -854,3 +854,70 @@ endpoints:
 		})
 	}
 }
+
+func TestParseFS_RejectsUnknownFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		fs      fstest.MapFS
+		wantMsg string
+	}{
+		{
+			name: "unknown field in cell.yaml",
+			fs: fstest.MapFS{
+				"cells/x/cell.yaml": &fstest.MapFile{Data: []byte(`id: x
+type: core
+consistencyLevel: L1
+owner:
+  team: t
+  role: r
+schema:
+  primary: tbl
+verify:
+  smoke: []
+unknownField: oops
+`)},
+			},
+			wantMsg: "unknownField",
+		},
+		{
+			name: "unknown field in slice.yaml",
+			fs: fstest.MapFS{
+				"cells/x/cell.yaml": &fstest.MapFile{Data: []byte(`id: x
+type: core
+consistencyLevel: L1
+owner: {team: t, role: r}
+schema: {primary: tbl}
+verify: {smoke: []}
+`)},
+				"cells/x/slices/s/slice.yaml": &fstest.MapFile{Data: []byte(`id: s
+belongsToCell: x
+contractUsages: []
+verify: {unit: [], contract: []}
+typo_field: bad
+`)},
+			},
+			wantMsg: "typo_field",
+		},
+		{
+			name: "unknown field in contract.yaml",
+			fs: fstest.MapFS{
+				"contracts/http/test/v1/contract.yaml": &fstest.MapFile{Data: []byte(`id: http.test.v1
+kind: http
+lifecycle: active
+endpoints: {server: x}
+bogus: 42
+`)},
+			},
+			wantMsg: "bogus",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(".")
+			_, err := p.ParseFS(tt.fs)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+			assert.Contains(t, err.Error(), "not found")
+		})
+	}
+}

--- a/src/kernel/metadata/parser_test.go
+++ b/src/kernel/metadata/parser_test.go
@@ -997,6 +997,43 @@ schemaRefs:
 	assert.Equal(t, "extra.json", c.SchemaRefs.Extra["custom"])
 }
 
+func TestParseFS_RejectsMultipleDocuments(t *testing.T) {
+	tests := []struct {
+		name string
+		fs   fstest.MapFS
+	}{
+		{
+			name: "multi-doc cell.yaml",
+			fs: fstest.MapFS{
+				"cells/x/cell.yaml": &fstest.MapFile{Data: []byte("id: x\ntype: core\nconsistencyLevel: L1\nowner: {team: t, role: r}\nschema: {primary: tbl}\nverify: {smoke: []}\n---\nid: y\ntype: edge\n")},
+			},
+		},
+		{
+			name: "multi-doc contract.yaml",
+			fs: fstest.MapFS{
+				"contracts/http/test/v1/contract.yaml": &fstest.MapFile{Data: []byte("id: http.test.v1\nkind: http\nlifecycle: active\nendpoints: {server: x}\n---\nid: injected\n")},
+			},
+		},
+		{
+			name: "multi-doc actors.yaml",
+			fs: fstest.MapFS{
+				"actors.yaml": &fstest.MapFile{Data: []byte("- id: a\n  type: external\n  maxConsistencyLevel: L2\n---\n- id: b\n  type: external\n  maxConsistencyLevel: L3\n")},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(".")
+			_, err := p.ParseFS(tt.fs)
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr))
+			assert.Equal(t, errcode.ErrMetadataInvalid, ecErr.Code)
+			assert.Contains(t, err.Error(), "multiple YAML documents")
+		})
+	}
+}
+
 func TestParseFS_EmptyFiles(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1021,6 +1058,58 @@ func TestParseFS_EmptyFiles(t *testing.T) {
 			pm, err := p.ParseFS(tt.fs)
 			require.NoError(t, err, "empty file should parse without error")
 			assert.NotNil(t, pm)
+		})
+	}
+}
+
+// TestParseFS_EmptyStructFiles verifies that empty files for struct-based
+// metadata types (cell, contract, journey, assembly) fail with "id is empty"
+// rather than silently succeeding. This documents the boundary: empty list
+// files (actors, status-board) are OK, but empty struct files must have an ID.
+func TestParseFS_EmptyStructFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		fs      fstest.MapFS
+		wantMsg string
+	}{
+		{
+			name: "empty cell.yaml",
+			fs: fstest.MapFS{
+				"cells/x/cell.yaml": &fstest.MapFile{Data: []byte("")},
+			},
+			wantMsg: "cell id is empty",
+		},
+		{
+			name: "empty contract.yaml",
+			fs: fstest.MapFS{
+				"contracts/http/test/v1/contract.yaml": &fstest.MapFile{Data: []byte("")},
+			},
+			wantMsg: "contract id is empty",
+		},
+		{
+			name: "empty journey yaml",
+			fs: fstest.MapFS{
+				"journeys/J-test.yaml": &fstest.MapFile{Data: []byte("")},
+			},
+			wantMsg: "journey id is empty",
+		},
+		{
+			name: "empty assembly yaml",
+			fs: fstest.MapFS{
+				"assemblies/a/assembly.yaml": &fstest.MapFile{Data: []byte("")},
+			},
+			wantMsg: "assembly id is empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(".")
+			_, err := p.ParseFS(tt.fs)
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr))
+			assert.Equal(t, errcode.ErrMetadataInvalid, ecErr.Code)
+			assert.Contains(t, err.Error(), tt.wantMsg)
 		})
 	}
 }

--- a/src/kernel/metadata/schemas/contract.schema.json
+++ b/src/kernel/metadata/schemas/contract.schema.json
@@ -54,6 +54,10 @@
       "type": "string",
       "description": "Delivery guarantee. Required for kind=event.",
       "enum": ["at-least-once", "exactly-once"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of the contract's purpose."
     }
   },
   "allOf": [

--- a/src/kernel/metadata/types.go
+++ b/src/kernel/metadata/types.go
@@ -77,6 +77,7 @@ type ContractMeta struct {
 	Replayable        *bool          `yaml:"replayable,omitempty"`
 	IdempotencyKey    string         `yaml:"idempotencyKey,omitempty"`
 	DeliverySemantics string         `yaml:"deliverySemantics,omitempty"`
+	Description       string         `yaml:"description,omitempty"`
 }
 
 // ProviderEndpoint returns the provider cell/actor ID for this contract

--- a/src/kernel/metadata/types.go
+++ b/src/kernel/metadata/types.go
@@ -115,10 +115,14 @@ type EndpointsMeta struct {
 }
 
 // SchemaRefsMeta holds JSON Schema file references relative to the contract directory.
+// Known keys are request, response, payload; additional string-valued keys are
+// captured in Extra to stay compatible with contract.schema.json's
+// additionalProperties: {"type":"string"}.
 type SchemaRefsMeta struct {
-	Request  string `yaml:"request,omitempty"`
-	Response string `yaml:"response,omitempty"`
-	Payload  string `yaml:"payload,omitempty"`
+	Request  string            `yaml:"request,omitempty"`
+	Response string            `yaml:"response,omitempty"`
+	Payload  string            `yaml:"payload,omitempty"`
+	Extra    map[string]string `yaml:",inline"`
 }
 
 // JourneyMeta maps to journeys/J-*.yaml.

--- a/src/kernel/metadata/types_test.go
+++ b/src/kernel/metadata/types_test.go
@@ -142,6 +142,42 @@ func TestContractMetaOmitEmptySchemaRefs(t *testing.T) {
 	assert.NotContains(t, string(data), "schemaRefs")
 }
 
+// TestSchemaRefsInlinePrecedence verifies that when a YAML schemaRefs block
+// contains both named keys (request, response, payload) and extra keys, the
+// decoder fills named struct fields first — Extra never shadows them.
+func TestSchemaRefsInlinePrecedence(t *testing.T) {
+	raw := `request: req.json
+response: res.json
+custom: extra.json
+`
+	var sr SchemaRefsMeta
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &sr))
+
+	// Named fields populated
+	assert.Equal(t, "req.json", sr.Request)
+	assert.Equal(t, "res.json", sr.Response)
+	assert.Empty(t, sr.Payload)
+
+	// Extra captures only the unknown key
+	assert.Equal(t, map[string]string{"custom": "extra.json"}, sr.Extra)
+
+	// Named key must NOT appear in Extra
+	_, hasRequest := sr.Extra["request"]
+	assert.False(t, hasRequest, "named field 'request' must not leak into Extra")
+}
+
+// TestSchemaRefsExtraRoundTrip verifies that Extra keys survive marshal→unmarshal.
+func TestSchemaRefsExtraRoundTrip(t *testing.T) {
+	orig := SchemaRefsMeta{
+		Request: "req.json",
+		Extra:   map[string]string{"custom": "extra.json"},
+	}
+	data, got := roundTrip(t, orig)
+	assert.Equal(t, "req.json", got.Request)
+	assert.Equal(t, "extra.json", got.Extra["custom"])
+	assert.Contains(t, string(data), "custom: extra.json")
+}
+
 func TestContractMetaNilReplayable(t *testing.T) {
 	orig := ContractMeta{
 		ID:               "http.test.v1",


### PR DESCRIPTION
## Summary

- Replace `yaml.Unmarshal` with `yaml.NewDecoder` + `KnownFields(true)` in `unmarshalFile`
- Typos in YAML metadata (e.g., `ownerId` instead of `ownerCell`) are now caught at parse time
- Add `ContractMeta.Description` field (existed in `command.device-command.v1/contract.yaml` but was missing from struct)

## Pre-check

Ran strict parser against all 6 cells, 21 slices, 16 contracts, 8 journeys, 1 assembly, 1 actors.yaml, 1 status-board.yaml — only `description` in one contract was unknown (now added to struct). All other YAML files are clean.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./kernel/metadata/...` — all pass
- [x] `go test -tags=integration ./kernel/metadata/... -run TestParseRealProject` — passes against real project YAML
- [x] `TestParseFS_RejectsUnknownFields` — 3 cases (cell, slice, contract) verify unknown fields are rejected

## Backlog ref

F-META-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)