### PR TITLE
[codex] Fix CI failures in RabbitMQ integration and kernel celltest coverage

### DIFF
--- a/src/adapters/rabbitmq/integration_test.go
+++ b/src/adapters/rabbitmq/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
@@ -44,6 +45,40 @@ func startRabbitMQ(t *testing.T) (*Connection, func()) {
 	return conn, cleanup
 }
 
+type queueInspector interface {
+	QueueInspect(name string) (amqp.Queue, error)
+}
+
+func waitForSubscriberReady(t *testing.T, conn *Connection, queueName string, subErrCh <-chan error, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-subErrCh:
+			require.NoError(t, err, "subscriber exited before becoming ready")
+			t.Fatal("subscriber exited before becoming ready")
+		default:
+		}
+
+		ch, err := conn.AcquireChannel()
+		require.NoError(t, err, "AcquireChannel should succeed while waiting for subscriber readiness")
+
+		inspector, ok := ch.(queueInspector)
+		require.True(t, ok, "AMQPChannel should support QueueInspect in integration tests")
+
+		queue, inspectErr := inspector.QueueInspect(queueName)
+		_ = ch.Close()
+		if inspectErr == nil && queue.Consumers > 0 {
+			return
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for subscriber queue %q to become ready", queueName)
+}
+
 // TestIntegration_ConnectionHealth verifies the Connection is alive after
 // connecting to a real RabbitMQ broker.
 func TestIntegration_ConnectionHealth(t *testing.T) {
@@ -62,6 +97,31 @@ func TestIntegration_PublishConsume(t *testing.T) {
 
 	pub := NewPublisher(conn)
 	topic := "test.integration.events"
+	queueName := "test.integration.queue"
+
+	// Subscribe and receive.
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       queueName,
+		PrefetchCount:   1,
+		ShutdownTimeout: 5 * time.Second,
+	})
+
+	ctx := context.Background()
+	received := make(chan outbox.Entry, 1)
+	subCtx, subCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer subCancel()
+
+	// Run subscriber in a goroutine since Subscribe blocks.
+	subErrCh := make(chan error, 1)
+	go func() {
+		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) error {
+			received <- e
+			return nil
+		})
+	}()
+
+	// Wait until Subscribe has declared, bound, and started consuming from the queue.
+	waitForSubscriberReady(t, conn, queueName, subErrCh, 5*time.Second)
 
 	// Prepare an outbox.Entry as the message payload.
 	entry := outbox.Entry{
@@ -77,30 +137,9 @@ func TestIntegration_PublishConsume(t *testing.T) {
 	payload, err := json.Marshal(entry)
 	require.NoError(t, err, "marshal entry")
 
-	// Publish the message.
-	ctx := context.Background()
+	// Publish the message after the subscriber is ready.
 	err = pub.Publish(ctx, topic, payload)
 	require.NoError(t, err, "Publish should succeed")
-
-	// Subscribe and receive.
-	sub := NewSubscriber(conn, SubscriberConfig{
-		QueueName:       "test.integration.queue",
-		PrefetchCount:   1,
-		ShutdownTimeout: 5 * time.Second,
-	})
-
-	received := make(chan outbox.Entry, 1)
-	subCtx, subCancel := context.WithTimeout(ctx, 15*time.Second)
-	defer subCancel()
-
-	// Run subscriber in a goroutine since Subscribe blocks.
-	subErrCh := make(chan error, 1)
-	go func() {
-		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) error {
-			received <- e
-			return nil
-		})
-	}()
 
 	// Wait for the message.
 	select {

--- a/src/kernel/cell/celltest/mux_test.go
+++ b/src/kernel/cell/celltest/mux_test.go
@@ -1,0 +1,89 @@
+package celltest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+)
+
+func TestTestMux_HandleGroupAndWith(t *testing.T) {
+	mux := NewTestMux()
+	require.NotNil(t, mux)
+
+	groupCalled := false
+	mux.Group(func(group cell.RouteMux) {
+		groupCalled = true
+
+		group.Handle("GET /health", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+
+		wrapped := group.With(func(next http.Handler) http.Handler { return next })
+		require.NotNil(t, wrapped)
+
+		wrapped.Handle("GET /ready", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		}))
+	})
+
+	assert.True(t, groupCalled)
+
+	t.Run("group-registered route is reachable", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+	})
+
+	t.Run("with-registered route is reachable", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+		rec := httptest.NewRecorder()
+
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusAccepted, rec.Code)
+	})
+}
+
+func TestTestMux_RouteAndMountStripPrefix(t *testing.T) {
+	mux := NewTestMux()
+
+	mux.Route("/api", func(sub cell.RouteMux) {
+		sub.Handle("GET /items/{id}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(r.PathValue("id")))
+		}))
+	})
+
+	mounted := http.NewServeMux()
+	mounted.Handle("GET /status", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(r.URL.Path))
+	}))
+	mux.Mount("/internal", mounted)
+
+	t.Run("route strips prefix and preserves path values", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/items/42", nil)
+		rec := httptest.NewRecorder()
+
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "42", rec.Body.String())
+	})
+
+	t.Run("mount strips prefix before handing off to the mounted handler", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/internal/status", nil)
+		rec := httptest.NewRecorder()
+
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "/status", rec.Body.String())
+	})
+}


### PR DESCRIPTION
## Summary

This PR fixes the two reproducible CI blockers found while running the workflow locally:

- stabilizes `adapters/rabbitmq` integration by waiting for the subscriber to finish queue setup before publishing the test message
- adds `kernel/cell/celltest` coverage tests so the kernel coverage gate no longer fails on the helper package

## Root Cause

The RabbitMQ integration test published to a fanout exchange before the subscriber had completed `QueueDeclare + QueueBind + Consume`, so the message could be dropped before any queue was attached.

Separately, the CI kernel coverage gate evaluates every `kernel/...` package, and `kernel/cell/celltest` had executable code but no tests, so the helper package showed `0.0%` coverage and tripped the threshold.

## What Changed

- replaced the flaky publish-before-subscribe timing in `TestIntegration_PublishConsume` with a readiness wait that observes the subscriber's queue becoming active before publishing
- added behavioral tests for `celltest.TestMux` covering `Handle`, `Group`, `With`, `Route`, and `Mount`

## Validation

- `go test ./kernel/cell/... -count=1`
- `go test ./kernel/cell/celltest -count=1 -cover`
- `go test -tags=integration ./adapters/rabbitmq -run TestIntegration_PublishConsume -count=3`
- `go test -tags=integration ./adapters/... -count=1 -timeout 5m`
- `go build ./...`
- `go vet ./...`
- `go run ./cmd/gocell validate`
- kernel coverage gate passes locally

## Notes

- SonarQube scan was not run locally because this environment does not have `SONAR_TOKEN` configured.
