### PR TITLE
feat(kernel): 0-F Solution B interfaces + infrastructure

### DIFF
--- a/src/adapters/postgres/outbox_writer.go
+++ b/src/adapters/postgres/outbox_writer.go
@@ -47,6 +47,10 @@ func (w *OutboxWriter) Write(ctx context.Context, entry outbox.Entry) error {
 		return errcode.New(errcode.ErrValidationFailed, "outbox entry ID is not a valid UUID: "+entry.ID)
 	}
 
+	if err := entry.Validate(); err != nil {
+		return err
+	}
+
 	metadata, err := json.Marshal(entry.Metadata)
 	if err != nil {
 		return errcode.Wrap(ErrAdapterPGMarshal, "outbox: failed to marshal metadata", err)

--- a/src/adapters/postgres/outbox_writer_test.go
+++ b/src/adapters/postgres/outbox_writer_test.go
@@ -224,6 +224,48 @@ func TestOutboxWriter_Write_ValidUUIDs(t *testing.T) {
 	}
 }
 
+func TestOutboxWriter_Write_MissingTopic(t *testing.T) {
+	w := NewOutboxWriter()
+	tx := &mockOutboxTx{}
+	ctx := CtxWithTx(context.Background(), tx)
+
+	entry := outbox.Entry{
+		ID:      "f6a7b8c9-d0e1-2345-faba-456789012345",
+		Payload: []byte(`{"data":true}`),
+		// Topic and EventType are both empty → Validate should fail
+	}
+
+	err := w.Write(ctx, entry)
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+	assert.Contains(t, ec.Message, "topic")
+	assert.Empty(t, tx.execCalls, "should not reach DB insert")
+}
+
+func TestOutboxWriter_Write_MissingPayload(t *testing.T) {
+	w := NewOutboxWriter()
+	tx := &mockOutboxTx{}
+	ctx := CtxWithTx(context.Background(), tx)
+
+	entry := outbox.Entry{
+		ID:    "a7b8c9d0-e1f2-3456-abcd-567890123456",
+		Topic: "some.topic",
+		// Payload is nil → Validate should fail
+	}
+
+	err := w.Write(ctx, entry)
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+	assert.Contains(t, ec.Message, "payload")
+	assert.Empty(t, tx.execCalls, "should not reach DB insert")
+}
+
 // mockOutboxTx records exec calls for assertion.
 // Embeds pgx.Tx to satisfy the full interface; only Exec/Commit/Rollback are overridden.
 type mockOutboxTx struct {

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -183,7 +183,7 @@ func (cb *ConsumerBase) wrapWithClaimer(topic string, handler outbox.EntryHandle
 
 		state, receipt, err := cb.claimer.Claim(ctx, idempotencyKey, cb.config.LeaseTTL, cb.config.IdempotencyTTL)
 		if err != nil {
-			slog.Warn("rabbitmq: idempotency claim failed, proceeding without receipt",
+			slog.Error("rabbitmq: idempotency claim failed, proceeding without receipt (fail-open)",
 				slog.String("event_id", entry.ID),
 				slog.String("topic", topic),
 				slog.String("consumer_group", cb.config.ConsumerGroup),
@@ -200,10 +200,18 @@ func (cb *ConsumerBase) wrapWithClaimer(topic string, handler outbox.EntryHandle
 				slog.String("consumer_group", cb.config.ConsumerGroup))
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		case idempotency.ClaimBusy:
-			slog.Debug("rabbitmq: event being processed by another consumer, requeuing",
+			// Backoff before requeue to prevent busy loop: RabbitMQ's
+			// Nack(requeue=true) redelivers immediately with no delay.
+			delay := cb.config.RetryBaseDelay
+			slog.Debug("rabbitmq: event being processed by another consumer, requeuing after backoff",
 				slog.String("event_id", entry.ID),
 				slog.String("topic", topic),
-				slog.String("consumer_group", cb.config.ConsumerGroup))
+				slog.String("consumer_group", cb.config.ConsumerGroup),
+				slog.Duration("backoff", delay))
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+			}
 			return outbox.HandleResult{Disposition: outbox.DispositionRequeue}
 		default:
 			// ClaimAcquired — proceed with handler, thread Receipt through.

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -2,7 +2,6 @@ package rabbitmq
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -28,9 +27,6 @@ type ConsumerBaseConfig struct {
 	// IdempotencyTTL is the TTL for idempotency keys.
 	// Default: 24h (idempotency.DefaultTTL).
 	IdempotencyTTL time.Duration
-
-	// DLQTopic is the dead-letter topic name. If empty, defaults to "{topic}.dlq".
-	DLQTopic string
 }
 
 func (c *ConsumerBaseConfig) setDefaults() {
@@ -64,54 +60,58 @@ func NewPermanentError(err error) *PermanentError {
 	return &PermanentError{Err: err}
 }
 
-// ConsumerBase wraps an outbox.Entry handler with idempotency checking,
-// exponential backoff retry, and dead-letter queue routing.
+// ConsumerBase wraps an outbox.EntryHandler with idempotency checking and
+// exponential backoff retry. DLQ routing is now handled by the broker via
+// DLX (DispositionReject triggers Nack requeue=false).
 //
 // Consumer: cg-{ConsumerGroup}-{topic}
 // Idempotency key: {ConsumerGroup}:{event-id}, TTL 24h
-// ACK timing: after business logic + idempotency key written
-// Retry: transient errors -> NACK+backoff / permanent errors -> dead letter
+// ACK timing: after business logic returns DispositionAck
+// Retry: transient errors -> retry+backoff / permanent errors -> DispositionReject → DLX
 type ConsumerBase struct {
-	checker   idempotency.Checker
-	publisher outbox.Publisher
-	config    ConsumerBaseConfig
+	checker idempotency.Checker
+	config  ConsumerBaseConfig
 }
 
 // NewConsumerBase creates a ConsumerBase.
 //
 // checker: idempotency.Checker implementation (e.g., from redis adapter).
-// publisher: outbox.Publisher for routing dead-letter messages.
-func NewConsumerBase(checker idempotency.Checker, publisher outbox.Publisher, config ConsumerBaseConfig) *ConsumerBase {
+func NewConsumerBase(checker idempotency.Checker, config ConsumerBaseConfig) *ConsumerBase {
 	config.setDefaults()
 	return &ConsumerBase{
-		checker:   checker,
-		publisher: publisher,
-		config:    config,
+		checker: checker,
+		config:  config,
 	}
 }
 
 // AsMiddleware returns a TopicHandlerMiddleware that applies this
-// ConsumerBase's idempotency/retry/DLQ wrapping to any handler.
+// ConsumerBase's idempotency/retry wrapping to any EntryHandler.
 // It can be used with SubscriberWithMiddleware to transparently inject
 // ConsumerBase behavior into a raw Subscriber pipeline.
 func (cb *ConsumerBase) AsMiddleware() outbox.TopicHandlerMiddleware {
-	return func(topic string, next func(context.Context, outbox.Entry) error) func(context.Context, outbox.Entry) error {
+	return func(topic string, next outbox.EntryHandler) outbox.EntryHandler {
 		return cb.Wrap(topic, next)
 	}
 }
 
-// Wrap returns a handler function that wraps the given business handler with
-// idempotency checking, retry with exponential backoff, and DLQ routing.
+// Wrap returns an EntryHandler that wraps the given business handler with
+// idempotency checking and retry with exponential backoff.
 //
-// The returned handler is suitable for use with Subscriber.Subscribe().
+// Solution B semantics:
+//   - ConsumerBase only determines the "business intent" (Ack/Reject/Requeue).
+//   - The broker-layer Subscriber performs the actual Ack/Nack and Receipt lifecycle.
+//   - DLQ routing is now broker-native via DLX (Nack requeue=false), not application-side publish.
 //
 // Rules:
-//   - return nil -> ACK (business logic succeeded, idempotency key written)
-//   - return error -> NACK + exponential backoff retry (transient error)
-//   - return PermanentError -> dead letter (no retry)
-//   - unmarshal failure in Subscriber -> dead letter (see subscriber.go)
-func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.Entry) error) func(context.Context, outbox.Entry) error {
-	return func(ctx context.Context, entry outbox.Entry) error {
+//   - handler returns DispositionAck → pass through as Ack
+//   - handler returns DispositionRequeue → pass through as Requeue
+//   - handler returns DispositionReject → pass through as Reject
+//   - handler returns error with non-Ack disposition → retry with backoff
+//   - PermanentError → Reject (broker routes to DLX)
+//   - retry budget exhausted → Reject
+//   - ctx cancelled / shutdown → Requeue (release lease)
+func (cb *ConsumerBase) Wrap(topic string, handler outbox.EntryHandler) outbox.EntryHandler {
+	return func(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 		idempotencyKey := fmt.Sprintf("%s:%s", cb.config.ConsumerGroup, entry.ID)
 
 		// Atomic idempotency check-and-mark via TryProcess (eliminates TOCTOU race).
@@ -130,46 +130,54 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 				slog.String("event_id", entry.ID),
 				slog.String("topic", topic),
 				slog.String("consumer_group", cb.config.ConsumerGroup))
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		}
 
 		// Execute handler with retry.
-		var lastErr error
+		var lastResult outbox.HandleResult
 		for attempt := range cb.config.RetryCount {
-			lastErr = handler(ctx, entry)
-			if lastErr == nil {
-				return nil
+			lastResult = handler(ctx, entry)
+			if lastResult.Disposition == outbox.DispositionAck {
+				return lastResult
 			}
 
-			// Check if this is a permanent error.
+			// Check if this is a permanent error / explicit rejection.
 			var permErr *PermanentError
-			if errors.As(lastErr, &permErr) {
-				slog.Warn("rabbitmq: permanent error, routing to DLQ",
+			if lastResult.Disposition == outbox.DispositionReject ||
+				(lastResult.Err != nil && errors.As(lastResult.Err, &permErr)) {
+				slog.Warn("rabbitmq: permanent error, rejecting to DLX",
 					slog.String("event_id", entry.ID),
 					slog.String("topic", topic),
 					slog.String("consumer_group", cb.config.ConsumerGroup),
-					slog.String("error", lastErr.Error()))
-				if dlqErr := cb.deadLetter(ctx, topic, entry, lastErr, attempt+1); dlqErr != nil {
-					// DLQ publish failed — release idempotency key so redelivery
-					// can re-enter business logic, then return error for NACK+requeue.
-					if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
-						slog.Error("rabbitmq: failed to release idempotency key",
-							slog.String("event_id", entry.ID),
-							slog.String("key", idempotencyKey),
-							slog.String("error", relErr.Error()))
-					}
-					return fmt.Errorf("rabbitmq: DLQ publish failed for permanent error: %w", dlqErr)
+					slog.Any("error", lastResult.Err))
+				// Release idempotency key so future reprocessing is possible if
+				// the message is manually republished from DLQ.
+				if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
+					slog.Error("rabbitmq: failed to release idempotency key",
+						slog.String("event_id", entry.ID),
+						slog.String("key", idempotencyKey),
+						slog.String("error", relErr.Error()))
 				}
-				return nil // Return nil to ACK the original message.
+				return outbox.HandleResult{
+					Disposition: outbox.DispositionReject,
+					Err:         lastResult.Err,
+				}
 			}
 
 			// Transient error — backoff before retry.
 			if attempt < cb.config.RetryCount-1 {
 				// Early exit on shutdown to avoid blocking during backoff.
-				// Release idempotency key so redelivery can re-process.
 				if ctx.Err() != nil {
-					_ = cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey)
-					return ctx.Err()
+					if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
+						slog.Error("rabbitmq: failed to release idempotency key on shutdown",
+							slog.String("event_id", entry.ID),
+							slog.String("key", idempotencyKey),
+							slog.String("error", relErr.Error()))
+					}
+					return outbox.HandleResult{
+						Disposition: outbox.DispositionRequeue,
+						Err:         ctx.Err(),
+					}
 				}
 
 				delay := cb.config.RetryBaseDelay * (1 << attempt)
@@ -179,89 +187,41 @@ func (cb *ConsumerBase) Wrap(topic string, handler func(context.Context, outbox.
 					slog.Int("attempt", attempt+1),
 					slog.Int("max_retries", cb.config.RetryCount),
 					slog.Duration("backoff", delay),
-					slog.String("error", lastErr.Error()))
+					slog.Any("error", lastResult.Err))
 
 				select {
 				case <-time.After(delay):
 				case <-ctx.Done():
-					_ = cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey)
-					return ctx.Err()
+					if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
+						slog.Error("rabbitmq: failed to release idempotency key on shutdown",
+							slog.String("event_id", entry.ID),
+							slog.String("key", idempotencyKey),
+							slog.String("error", relErr.Error()))
+					}
+					return outbox.HandleResult{
+						Disposition: outbox.DispositionRequeue,
+						Err:         ctx.Err(),
+					}
 				}
 			}
 		}
 
-		// Exhausted all retries — route to DLQ.
-		slog.Error("rabbitmq: retry budget exhausted, routing to DLQ",
+		// Exhausted all retries — reject so broker routes to DLX.
+		slog.Error("rabbitmq: retry budget exhausted, rejecting to DLX",
 			slog.String("event_id", entry.ID),
 			slog.String("topic", topic),
 			slog.String("consumer_group", cb.config.ConsumerGroup),
 			slog.Int("retry_count", cb.config.RetryCount),
-			slog.String("error", lastErr.Error()))
-		if dlqErr := cb.deadLetter(ctx, topic, entry, lastErr, cb.config.RetryCount); dlqErr != nil {
-			// DLQ publish failed — release idempotency key so redelivery
-			// can re-enter business logic, then return error for NACK+requeue.
-			if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
-				slog.Error("rabbitmq: failed to release idempotency key",
-					slog.String("event_id", entry.ID),
-					slog.String("key", idempotencyKey),
-					slog.String("error", relErr.Error()))
-			}
-			return fmt.Errorf("rabbitmq: DLQ publish failed after retry exhaustion: %w", dlqErr)
+			slog.Any("error", lastResult.Err))
+		if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
+			slog.Error("rabbitmq: failed to release idempotency key",
+				slog.String("event_id", entry.ID),
+				slog.String("key", idempotencyKey),
+				slog.String("error", relErr.Error()))
 		}
-
-		// Return nil to ACK the original message (it's been DLQ'd).
-		return nil
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionReject,
+			Err:         lastResult.Err,
+		}
 	}
-}
-
-// deadLetter routes a failed message to the dead-letter queue.
-// It publishes the original entry with x-death metadata to the DLQ topic.
-// Returns an error if the DLQ publish fails, so the caller can NACK with requeue
-// instead of silently ACKing and losing the message.
-func (cb *ConsumerBase) deadLetter(ctx context.Context, topic string, entry outbox.Entry, originalErr error, retryCount int) error {
-	dlqTopic := cb.config.DLQTopic
-	if dlqTopic == "" {
-		dlqTopic = topic + ".dlq"
-	}
-
-	// Enrich metadata with death info.
-	dlqEntry := entry
-	if dlqEntry.Metadata == nil {
-		dlqEntry.Metadata = make(map[string]string)
-	}
-	dlqEntry.Metadata["x-death-reason"] = originalErr.Error()
-	dlqEntry.Metadata["x-death-topic"] = topic
-	dlqEntry.Metadata["x-death-consumer-group"] = cb.config.ConsumerGroup
-	dlqEntry.Metadata["x-death-retry-count"] = fmt.Sprintf("%d", retryCount)
-	dlqEntry.Metadata["x-death-time"] = time.Now().UTC().Format(time.RFC3339)
-
-	payload, err := json.Marshal(dlqEntry)
-	if err != nil {
-		slog.Error("rabbitmq: failed to marshal DLQ entry",
-			slog.String("event_id", entry.ID),
-			slog.String("topic", topic),
-			slog.String("error", err.Error()))
-		return fmt.Errorf("marshal DLQ entry: %w", err)
-	}
-
-	if err := cb.publisher.Publish(ctx, dlqTopic, payload); err != nil {
-		slog.Error("rabbitmq: failed to publish to DLQ",
-			slog.String("event_id", entry.ID),
-			slog.String("topic", topic),
-			slog.String("dlq_topic", dlqTopic),
-			slog.String("error", err.Error()),
-			slog.Int("retry_count", retryCount))
-		return fmt.Errorf("publish to DLQ topic %s: %w", dlqTopic, err)
-	}
-
-	// T25: DLQ observability — log every dead-letter routing.
-	// Warn (not Error): successful DLQ routing is expected behavior for permanent/exhausted errors.
-	slog.Warn("rabbitmq: message routed to dead letter queue",
-		slog.String("event_id", entry.ID),
-		slog.String("topic", topic),
-		slog.String("dlq_topic", dlqTopic),
-		slog.String("consumer_group", cb.config.ConsumerGroup),
-		slog.String("error", originalErr.Error()),
-		slog.Int("retry_count", retryCount))
-	return nil
 }

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -333,7 +333,9 @@ func (cb *ConsumerBase) releaseChecker(ctx context.Context, key, eventID string)
 	if cb.checker == nil {
 		return
 	}
-	if relErr := cb.checker.Release(context.WithoutCancel(ctx), key); relErr != nil {
+	releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer releaseCancel()
+	if relErr := cb.checker.Release(releaseCtx, key); relErr != nil {
 		slog.Error("rabbitmq: failed to release idempotency key",
 			slog.String("event_id", eventID),
 			slog.String("key", key),

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -179,7 +179,11 @@ func (cb *ConsumerBase) wrapWithChecker(topic string, handler outbox.EntryHandle
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		}
 
-		return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, nil)
+		// Wrap legacy Checker as a Receipt so processDelivery can Release
+		// after broker Ack/Nack, not before. This prevents the race where
+		// releaseChecker runs before Nack, opening a duplicate-processing window.
+		receipt := &checkerReceipt{checker: cb.checker, key: idempotencyKey}
+		return cb.retryLoop(ctx, topic, entry, handler, receipt)
 	}
 }
 
@@ -198,7 +202,7 @@ func (cb *ConsumerBase) wrapWithClaimer(topic string, handler outbox.EntryHandle
 					slog.String("topic", topic),
 					slog.String("consumer_group", cb.config.ConsumerGroup),
 					slog.String("error", err.Error()))
-				return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, nil)
+				return cb.retryLoop(ctx, topic, entry, handler, nil)
 			}
 			slog.Error("rabbitmq: idempotency claim failed, requeuing (fail-closed)",
 				slog.String("event_id", entry.ID),
@@ -231,21 +235,19 @@ func (cb *ConsumerBase) wrapWithClaimer(topic string, handler outbox.EntryHandle
 			return outbox.HandleResult{Disposition: outbox.DispositionRequeue}
 		default:
 			// ClaimAcquired — proceed with handler, thread Receipt through.
-			return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, receipt)
+			return cb.retryLoop(ctx, topic, entry, handler, receipt)
 		}
 	}
 }
 
 // retryLoop executes the handler with exponential backoff retries.
-// When using the legacy Checker path, receipt is nil and idempotency cleanup
-// is done via checker.Release. When using Claimer, receipt is non-nil and
-// threaded through HandleResult for processDelivery to manage.
+// Receipt (from Claimer or checkerReceipt) is threaded through HandleResult
+// for processDelivery to Commit/Release after broker Ack/Nack.
 func (cb *ConsumerBase) retryLoop(
 	ctx context.Context,
 	topic string,
 	entry outbox.Entry,
 	handler outbox.EntryHandler,
-	idempotencyKey string,
 	receipt outbox.Receipt,
 ) outbox.HandleResult {
 	var lastResult outbox.HandleResult
@@ -271,7 +273,6 @@ func (cb *ConsumerBase) retryLoop(
 				slog.String("topic", topic),
 				slog.String("consumer_group", cb.config.ConsumerGroup),
 				slog.Any("error", lastResult.Err))
-			cb.releaseChecker(ctx, idempotencyKey, entry.ID)
 			return outbox.HandleResult{
 				Disposition: outbox.DispositionReject,
 				Err:         lastResult.Err,
@@ -282,7 +283,7 @@ func (cb *ConsumerBase) retryLoop(
 		// Transient error — backoff before retry.
 		if attempt < cb.config.RetryCount-1 {
 			if ctx.Err() != nil {
-				cb.releaseChecker(ctx, idempotencyKey, entry.ID)
+				// Receipt.Release is deferred to processDelivery after broker Ack/Nack.
 				return outbox.HandleResult{
 					Disposition: outbox.DispositionRequeue,
 					Err:         ctx.Err(),
@@ -302,7 +303,7 @@ func (cb *ConsumerBase) retryLoop(
 			select {
 			case <-time.After(delay):
 			case <-ctx.Done():
-				cb.releaseChecker(ctx, idempotencyKey, entry.ID)
+				// Receipt.Release is deferred to processDelivery after broker Ack/Nack.
 				return outbox.HandleResult{
 					Disposition: outbox.DispositionRequeue,
 					Err:         ctx.Err(),
@@ -319,7 +320,6 @@ func (cb *ConsumerBase) retryLoop(
 		slog.String("consumer_group", cb.config.ConsumerGroup),
 		slog.Int("retry_count", cb.config.RetryCount),
 		slog.Any("error", lastResult.Err))
-	cb.releaseChecker(ctx, idempotencyKey, entry.ID)
 	return outbox.HandleResult{
 		Disposition: outbox.DispositionReject,
 		Err:         lastResult.Err,
@@ -327,18 +327,24 @@ func (cb *ConsumerBase) retryLoop(
 	}
 }
 
-// releaseChecker releases the idempotency key via the legacy Checker.
-// No-op when using Claimer (Receipt lifecycle is managed by processDelivery).
-func (cb *ConsumerBase) releaseChecker(ctx context.Context, key, eventID string) {
-	if cb.checker == nil {
-		return
-	}
-	releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer releaseCancel()
-	if relErr := cb.checker.Release(releaseCtx, key); relErr != nil {
-		slog.Error("rabbitmq: failed to release idempotency key",
-			slog.String("event_id", eventID),
-			slog.String("key", key),
-			slog.String("error", relErr.Error()))
-	}
+// checkerReceipt adapts the legacy Checker to the Receipt interface so that
+// processDelivery can manage idempotency state uniformly after broker Ack/Nack.
+//
+//   - Commit: no-op — TryProcess already marked the key as done.
+//   - Release: calls checker.Release to allow redelivery.
+type checkerReceipt struct {
+	checker idempotency.Checker
+	key     string
+}
+
+// Compile-time interface check.
+var _ outbox.Receipt = (*checkerReceipt)(nil)
+
+func (r *checkerReceipt) Commit(_ context.Context) error {
+	// TryProcess already marked the key; nothing more to do.
+	return nil
+}
+
+func (r *checkerReceipt) Release(ctx context.Context) error {
+	return r.checker.Release(ctx, r.key)
 }

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -24,9 +24,15 @@ type ConsumerBaseConfig struct {
 	// Default: 1s.
 	RetryBaseDelay time.Duration
 
-	// IdempotencyTTL is the TTL for idempotency keys.
+	// IdempotencyTTL is the TTL for idempotency keys (done-key TTL for Claimer).
 	// Default: 24h (idempotency.DefaultTTL).
 	IdempotencyTTL time.Duration
+
+	// LeaseTTL is the processing-lease TTL for the Claimer backend.
+	// If a consumer crashes mid-processing, the lease expires after this
+	// duration, allowing another consumer to re-claim.
+	// Default: 5m (idempotency.DefaultLeaseTTL). Only used with Claimer.
+	LeaseTTL time.Duration
 }
 
 func (c *ConsumerBaseConfig) setDefaults() {
@@ -38,6 +44,9 @@ func (c *ConsumerBaseConfig) setDefaults() {
 	}
 	if c.IdempotencyTTL == 0 {
 		c.IdempotencyTTL = idempotency.DefaultTTL
+	}
+	if c.LeaseTTL == 0 {
+		c.LeaseTTL = idempotency.DefaultLeaseTTL
 	}
 }
 
@@ -64,22 +73,43 @@ func NewPermanentError(err error) *PermanentError {
 // exponential backoff retry. DLQ routing is now handled by the broker via
 // DLX (DispositionReject triggers Nack requeue=false).
 //
+// ConsumerBase supports two idempotency backends:
+//   - Legacy Checker (via NewConsumerBase): single-phase TryProcess. Has a race
+//     condition where the key is marked done before broker Ack. Retained for
+//     backward compatibility.
+//   - Claimer (via NewConsumerBaseWithClaimer): two-phase Claim/Commit/Release.
+//     Receipt is threaded through HandleResult so processDelivery can Commit
+//     only after broker Ack succeeds.
+//
 // Consumer: cg-{ConsumerGroup}-{topic}
 // Idempotency key: {ConsumerGroup}:{event-id}, TTL 24h
 // ACK timing: after business logic returns DispositionAck
 // Retry: transient errors -> retry+backoff / permanent errors -> DispositionReject → DLX
 type ConsumerBase struct {
-	checker idempotency.Checker
+	checker idempotency.Checker  // legacy, nil when using Claimer
+	claimer idempotency.Claimer  // Solution B, nil when using legacy Checker
 	config  ConsumerBaseConfig
 }
 
-// NewConsumerBase creates a ConsumerBase.
+// NewConsumerBase creates a ConsumerBase using the legacy Checker interface.
 //
-// checker: idempotency.Checker implementation (e.g., from redis adapter).
+// Deprecated: Use NewConsumerBaseWithClaimer for correct two-phase idempotency
+// that aligns idempotency state with broker acknowledgement.
 func NewConsumerBase(checker idempotency.Checker, config ConsumerBaseConfig) *ConsumerBase {
 	config.setDefaults()
 	return &ConsumerBase{
 		checker: checker,
+		config:  config,
+	}
+}
+
+// NewConsumerBaseWithClaimer creates a ConsumerBase using the two-phase
+// Claimer interface. The returned Receipt is threaded through HandleResult
+// so that the Subscriber can Commit/Release after broker Ack/Nack.
+func NewConsumerBaseWithClaimer(claimer idempotency.Claimer, config ConsumerBaseConfig) *ConsumerBase {
+	config.setDefaults()
+	return &ConsumerBase{
+		claimer: claimer,
 		config:  config,
 	}
 }
@@ -97,10 +127,10 @@ func (cb *ConsumerBase) AsMiddleware() outbox.TopicHandlerMiddleware {
 // Wrap returns an EntryHandler that wraps the given business handler with
 // idempotency checking and retry with exponential backoff.
 //
-// Solution B semantics:
-//   - ConsumerBase only determines the "business intent" (Ack/Reject/Requeue).
-//   - The broker-layer Subscriber performs the actual Ack/Nack and Receipt lifecycle.
-//   - DLQ routing is now broker-native via DLX (Nack requeue=false), not application-side publish.
+// When constructed with NewConsumerBaseWithClaimer, Wrap uses two-phase
+// idempotency: the Receipt is attached to HandleResult so processDelivery
+// can Commit/Release after broker Ack/Nack. When constructed with
+// NewConsumerBase (legacy), Wrap uses the single-phase TryProcess path.
 //
 // Rules:
 //   - handler returns DispositionAck → pass through as Ack
@@ -109,12 +139,20 @@ func (cb *ConsumerBase) AsMiddleware() outbox.TopicHandlerMiddleware {
 //   - handler returns error with non-Ack disposition → retry with backoff
 //   - PermanentError → Reject (broker routes to DLX)
 //   - retry budget exhausted → Reject
-//   - ctx cancelled / shutdown → Requeue (release lease)
+//   - ctx cancelled / shutdown → Requeue
 func (cb *ConsumerBase) Wrap(topic string, handler outbox.EntryHandler) outbox.EntryHandler {
+	if cb.claimer != nil {
+		return cb.wrapWithClaimer(topic, handler)
+	}
+	return cb.wrapWithChecker(topic, handler)
+}
+
+// wrapWithChecker is the legacy path using single-phase TryProcess.
+// Deprecated: has a race condition where the key is marked done before broker Ack.
+func (cb *ConsumerBase) wrapWithChecker(topic string, handler outbox.EntryHandler) outbox.EntryHandler {
 	return func(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 		idempotencyKey := fmt.Sprintf("%s:%s", cb.config.ConsumerGroup, entry.ID)
 
-		// Atomic idempotency check-and-mark via TryProcess (eliminates TOCTOU race).
 		shouldProcess, err := cb.checker.TryProcess(ctx, idempotencyKey, cb.config.IdempotencyTTL)
 		if err != nil {
 			slog.Warn("rabbitmq: idempotency check failed, proceeding with handler",
@@ -122,7 +160,6 @@ func (cb *ConsumerBase) Wrap(topic string, handler outbox.EntryHandler) outbox.E
 				slog.String("topic", topic),
 				slog.String("consumer_group", cb.config.ConsumerGroup),
 				slog.String("error", err.Error()))
-			// On error, default to processing (fail-open) to avoid dropping messages.
 			shouldProcess = true
 		}
 		if !shouldProcess {
@@ -133,95 +170,145 @@ func (cb *ConsumerBase) Wrap(topic string, handler outbox.EntryHandler) outbox.E
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		}
 
-		// Execute handler with retry.
-		var lastResult outbox.HandleResult
-		for attempt := range cb.config.RetryCount {
-			lastResult = handler(ctx, entry)
-			if lastResult.Disposition == outbox.DispositionAck {
-				return lastResult
-			}
+		return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, nil)
+	}
+}
 
-			// Check if this is a permanent error / explicit rejection.
-			var permErr *PermanentError
-			if lastResult.Disposition == outbox.DispositionReject ||
-				(lastResult.Err != nil && errors.As(lastResult.Err, &permErr)) {
-				slog.Warn("rabbitmq: permanent error, rejecting to DLX",
-					slog.String("event_id", entry.ID),
-					slog.String("topic", topic),
-					slog.String("consumer_group", cb.config.ConsumerGroup),
-					slog.Any("error", lastResult.Err))
-				// Release idempotency key so future reprocessing is possible if
-				// the message is manually republished from DLQ.
-				if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
-					slog.Error("rabbitmq: failed to release idempotency key",
-						slog.String("event_id", entry.ID),
-						slog.String("key", idempotencyKey),
-						slog.String("error", relErr.Error()))
-				}
-				return outbox.HandleResult{
-					Disposition: outbox.DispositionReject,
-					Err:         lastResult.Err,
-				}
-			}
+// wrapWithClaimer is the Solution B path using two-phase Claim/Commit/Release.
+// The Receipt is threaded through HandleResult — ConsumerBase never calls
+// Commit/Release itself; that is processDelivery's job after broker Ack/Nack.
+func (cb *ConsumerBase) wrapWithClaimer(topic string, handler outbox.EntryHandler) outbox.EntryHandler {
+	return func(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
+		idempotencyKey := fmt.Sprintf("%s:%s", cb.config.ConsumerGroup, entry.ID)
 
-			// Transient error — backoff before retry.
-			if attempt < cb.config.RetryCount-1 {
-				// Early exit on shutdown to avoid blocking during backoff.
-				if ctx.Err() != nil {
-					if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
-						slog.Error("rabbitmq: failed to release idempotency key on shutdown",
-							slog.String("event_id", entry.ID),
-							slog.String("key", idempotencyKey),
-							slog.String("error", relErr.Error()))
-					}
-					return outbox.HandleResult{
-						Disposition: outbox.DispositionRequeue,
-						Err:         ctx.Err(),
-					}
-				}
-
-				delay := cb.config.RetryBaseDelay * (1 << attempt)
-				slog.Warn("rabbitmq: transient error, retrying",
-					slog.String("event_id", entry.ID),
-					slog.String("topic", topic),
-					slog.Int("attempt", attempt+1),
-					slog.Int("max_retries", cb.config.RetryCount),
-					slog.Duration("backoff", delay),
-					slog.Any("error", lastResult.Err))
-
-				select {
-				case <-time.After(delay):
-				case <-ctx.Done():
-					if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
-						slog.Error("rabbitmq: failed to release idempotency key on shutdown",
-							slog.String("event_id", entry.ID),
-							slog.String("key", idempotencyKey),
-							slog.String("error", relErr.Error()))
-					}
-					return outbox.HandleResult{
-						Disposition: outbox.DispositionRequeue,
-						Err:         ctx.Err(),
-					}
-				}
-			}
-		}
-
-		// Exhausted all retries — reject so broker routes to DLX.
-		slog.Error("rabbitmq: retry budget exhausted, rejecting to DLX",
-			slog.String("event_id", entry.ID),
-			slog.String("topic", topic),
-			slog.String("consumer_group", cb.config.ConsumerGroup),
-			slog.Int("retry_count", cb.config.RetryCount),
-			slog.Any("error", lastResult.Err))
-		if relErr := cb.checker.Release(context.WithoutCancel(ctx), idempotencyKey); relErr != nil {
-			slog.Error("rabbitmq: failed to release idempotency key",
+		state, receipt, err := cb.claimer.Claim(ctx, idempotencyKey, cb.config.LeaseTTL, cb.config.IdempotencyTTL)
+		if err != nil {
+			slog.Warn("rabbitmq: idempotency claim failed, proceeding without receipt",
 				slog.String("event_id", entry.ID),
-				slog.String("key", idempotencyKey),
-				slog.String("error", relErr.Error()))
+				slog.String("topic", topic),
+				slog.String("consumer_group", cb.config.ConsumerGroup),
+				slog.String("error", err.Error()))
+			// Fail-open: proceed without Receipt (legacy behavior).
+			return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, nil)
 		}
-		return outbox.HandleResult{
-			Disposition: outbox.DispositionReject,
-			Err:         lastResult.Err,
+
+		switch state {
+		case idempotency.ClaimDone:
+			slog.Debug("rabbitmq: event already processed, skipping",
+				slog.String("event_id", entry.ID),
+				slog.String("topic", topic),
+				slog.String("consumer_group", cb.config.ConsumerGroup))
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
+		case idempotency.ClaimBusy:
+			slog.Debug("rabbitmq: event being processed by another consumer, requeuing",
+				slog.String("event_id", entry.ID),
+				slog.String("topic", topic),
+				slog.String("consumer_group", cb.config.ConsumerGroup))
+			return outbox.HandleResult{Disposition: outbox.DispositionRequeue}
+		default:
+			// ClaimAcquired — proceed with handler, thread Receipt through.
+			return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, receipt)
 		}
+	}
+}
+
+// retryLoop executes the handler with exponential backoff retries.
+// When using the legacy Checker path, receipt is nil and idempotency cleanup
+// is done via checker.Release. When using Claimer, receipt is non-nil and
+// threaded through HandleResult for processDelivery to manage.
+func (cb *ConsumerBase) retryLoop(
+	ctx context.Context,
+	topic string,
+	entry outbox.Entry,
+	handler outbox.EntryHandler,
+	idempotencyKey string,
+	receipt outbox.Receipt,
+) outbox.HandleResult {
+	var lastResult outbox.HandleResult
+	for attempt := range cb.config.RetryCount {
+		lastResult = handler(ctx, entry)
+		if lastResult.Disposition == outbox.DispositionAck {
+			return outbox.HandleResult{
+				Disposition: outbox.DispositionAck,
+				Receipt:     receipt,
+			}
+		}
+
+		// Check if this is a permanent error / explicit rejection.
+		var permErr *PermanentError
+		if lastResult.Disposition == outbox.DispositionReject ||
+			(lastResult.Err != nil && errors.As(lastResult.Err, &permErr)) {
+			slog.Warn("rabbitmq: permanent error, rejecting to DLX",
+				slog.String("event_id", entry.ID),
+				slog.String("topic", topic),
+				slog.String("consumer_group", cb.config.ConsumerGroup),
+				slog.Any("error", lastResult.Err))
+			cb.releaseChecker(ctx, idempotencyKey, entry.ID)
+			return outbox.HandleResult{
+				Disposition: outbox.DispositionReject,
+				Err:         lastResult.Err,
+				Receipt:     receipt,
+			}
+		}
+
+		// Transient error — backoff before retry.
+		if attempt < cb.config.RetryCount-1 {
+			if ctx.Err() != nil {
+				cb.releaseChecker(ctx, idempotencyKey, entry.ID)
+				return outbox.HandleResult{
+					Disposition: outbox.DispositionRequeue,
+					Err:         ctx.Err(),
+					Receipt:     receipt,
+				}
+			}
+
+			delay := cb.config.RetryBaseDelay * (1 << attempt)
+			slog.Warn("rabbitmq: transient error, retrying",
+				slog.String("event_id", entry.ID),
+				slog.String("topic", topic),
+				slog.Int("attempt", attempt+1),
+				slog.Int("max_retries", cb.config.RetryCount),
+				slog.Duration("backoff", delay),
+				slog.Any("error", lastResult.Err))
+
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				cb.releaseChecker(ctx, idempotencyKey, entry.ID)
+				return outbox.HandleResult{
+					Disposition: outbox.DispositionRequeue,
+					Err:         ctx.Err(),
+					Receipt:     receipt,
+				}
+			}
+		}
+	}
+
+	// Exhausted all retries — reject so broker routes to DLX.
+	slog.Error("rabbitmq: retry budget exhausted, rejecting to DLX",
+		slog.String("event_id", entry.ID),
+		slog.String("topic", topic),
+		slog.String("consumer_group", cb.config.ConsumerGroup),
+		slog.Int("retry_count", cb.config.RetryCount),
+		slog.Any("error", lastResult.Err))
+	cb.releaseChecker(ctx, idempotencyKey, entry.ID)
+	return outbox.HandleResult{
+		Disposition: outbox.DispositionReject,
+		Err:         lastResult.Err,
+		Receipt:     receipt,
+	}
+}
+
+// releaseChecker releases the idempotency key via the legacy Checker.
+// No-op when using Claimer (Receipt lifecycle is managed by processDelivery).
+func (cb *ConsumerBase) releaseChecker(ctx context.Context, key, eventID string) {
+	if cb.checker == nil {
+		return
+	}
+	if relErr := cb.checker.Release(context.WithoutCancel(ctx), key); relErr != nil {
+		slog.Error("rabbitmq: failed to release idempotency key",
+			slog.String("event_id", eventID),
+			slog.String("key", key),
+			slog.String("error", relErr.Error()))
 	}
 }

--- a/src/adapters/rabbitmq/consumer_base.go
+++ b/src/adapters/rabbitmq/consumer_base.go
@@ -33,6 +33,14 @@ type ConsumerBaseConfig struct {
 	// duration, allowing another consumer to re-claim.
 	// Default: 5m (idempotency.DefaultLeaseTTL). Only used with Claimer.
 	LeaseTTL time.Duration
+
+	// ClaimFailOpen controls behavior when Claimer.Claim() fails due to
+	// infrastructure errors (e.g., Redis down).
+	//   true  (default): proceed without idempotency — avoids total consumer
+	//          stall, but risks duplicate processing during outage.
+	//   false: return DispositionRequeue — safe from duplicates, but all
+	//          consumption stops until the idempotency backend recovers.
+	ClaimFailOpen *bool
 }
 
 func (c *ConsumerBaseConfig) setDefaults() {
@@ -95,6 +103,7 @@ type ConsumerBase struct {
 //
 // Deprecated: Use NewConsumerBaseWithClaimer for correct two-phase idempotency
 // that aligns idempotency state with broker acknowledgement.
+// Scheduled for removal after all cells migrate to Claimer (target: Phase 3).
 func NewConsumerBase(checker idempotency.Checker, config ConsumerBaseConfig) *ConsumerBase {
 	config.setDefaults()
 	return &ConsumerBase{
@@ -183,13 +192,20 @@ func (cb *ConsumerBase) wrapWithClaimer(topic string, handler outbox.EntryHandle
 
 		state, receipt, err := cb.claimer.Claim(ctx, idempotencyKey, cb.config.LeaseTTL, cb.config.IdempotencyTTL)
 		if err != nil {
-			slog.Error("rabbitmq: idempotency claim failed, proceeding without receipt (fail-open)",
+			if cb.config.ClaimFailOpen == nil || *cb.config.ClaimFailOpen {
+				slog.Error("rabbitmq: idempotency claim failed, proceeding without receipt (fail-open)",
+					slog.String("event_id", entry.ID),
+					slog.String("topic", topic),
+					slog.String("consumer_group", cb.config.ConsumerGroup),
+					slog.String("error", err.Error()))
+				return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, nil)
+			}
+			slog.Error("rabbitmq: idempotency claim failed, requeuing (fail-closed)",
 				slog.String("event_id", entry.ID),
 				slog.String("topic", topic),
 				slog.String("consumer_group", cb.config.ConsumerGroup),
 				slog.String("error", err.Error()))
-			// Fail-open: proceed without Receipt (legacy behavior).
-			return cb.retryLoop(ctx, topic, entry, handler, idempotencyKey, nil)
+			return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: err}
 		}
 
 		switch state {
@@ -243,6 +259,10 @@ func (cb *ConsumerBase) retryLoop(
 		}
 
 		// Check if this is a permanent error / explicit rejection.
+		// Note: if handler returns DispositionRequeue with a PermanentError,
+		// the PermanentError takes precedence and upgrades to Reject (no retry).
+		// This allows WrapLegacyHandler (which always returns Requeue) to still
+		// have PermanentError detected and routed to DLX by ConsumerBase.
 		var permErr *PermanentError
 		if lastResult.Disposition == outbox.DispositionReject ||
 			(lastResult.Err != nil && errors.As(lastResult.Err, &permErr)) {

--- a/src/adapters/rabbitmq/integration_test.go
+++ b/src/adapters/rabbitmq/integration_test.go
@@ -114,9 +114,9 @@ func TestIntegration_PublishConsume(t *testing.T) {
 	// Run subscriber in a goroutine since Subscribe blocks.
 	subErrCh := make(chan error, 1)
 	go func() {
-		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) error {
+		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			received <- e
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 
@@ -213,9 +213,9 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 
 	// Start DLQ subscriber first.
 	go func() {
-		_ = dlqSub.Subscribe(dlqCtx, dlqTopic, func(_ context.Context, e outbox.Entry) error {
+		_ = dlqSub.Subscribe(dlqCtx, dlqTopic, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			dlqReceived <- e
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 
@@ -225,21 +225,19 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	// Create a ConsumerBase with RetryCount=2 and very short delays.
 	cb := NewConsumerBase(
 		&noopChecker{},
-		pub,
 		ConsumerBaseConfig{
 			ConsumerGroup:  "test-retry-group",
 			RetryCount:     2,
 			RetryBaseDelay: 100 * time.Millisecond,
 			IdempotencyTTL: time.Hour,
-			DLQTopic:       dlqTopic,
 		},
 	)
 
 	// Wrap a handler that always fails with a transient error.
 	callCount := 0
-	wrappedHandler := cb.Wrap(topic, func(_ context.Context, _ outbox.Entry) error {
+	wrappedHandler := cb.Wrap(topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		callCount++
-		return assert.AnError
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: assert.AnError}
 	})
 
 	// Publish a message.
@@ -251,21 +249,10 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	}
 
 	// Invoke the wrapped handler directly (simulates what Subscriber does).
-	err := wrappedHandler(ctx, entry)
-	assert.NoError(t, err, "wrapped handler should return nil (message is DLQ'd)")
+	res := wrappedHandler(ctx, entry)
+	// In Solution B, exhausted retries return Reject (broker routes to DLX).
+	assert.Equal(t, outbox.DispositionReject, res.Disposition, "exhausted retries should reject")
 	assert.Equal(t, 2, callCount, "handler should be called RetryCount times")
-
-	// Wait for the DLQ message.
-	select {
-	case dlqEntry := <-dlqReceived:
-		assert.Equal(t, entry.ID, dlqEntry.ID, "DLQ entry should have same event ID")
-		assert.Contains(t, dlqEntry.Metadata["x-death-reason"], "assert.AnError",
-			"DLQ metadata should contain the error reason")
-		assert.Equal(t, "test-retry-group", dlqEntry.Metadata["x-death-consumer-group"],
-			"DLQ metadata should contain consumer group")
-	case <-dlqCtx.Done():
-		t.Fatal("timed out waiting for DLQ message")
-	}
 
 	// Clean up.
 	dlqCancel()

--- a/src/adapters/rabbitmq/integration_test.go
+++ b/src/adapters/rabbitmq/integration_test.go
@@ -196,7 +196,6 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	pub := NewPublisher(conn)
 	topic := "test.integration.retry"
 
 	// Track DLQ messages via a separate subscriber on the DLQ topic.

--- a/src/adapters/rabbitmq/integration_test.go
+++ b/src/adapters/rabbitmq/integration_test.go
@@ -276,6 +276,119 @@ func TestIntegration_ConnectionRecovery(t *testing.T) {
 	conn.ReleaseChannel(ch)
 }
 
+// TestIntegration_DLXBrokerNative verifies the full broker-native DLX path:
+//
+//	handler → DispositionReject → Subscriber.processDelivery Nack(requeue=false)
+//	→ RabbitMQ routes to DLX exchange → dead-letter queue receives message
+//
+// This test uses raw AMQP channels to set up the DLX infrastructure and
+// directly consume from the dead-letter queue, proving the broker actually
+// routes rejected messages end-to-end.
+func TestIntegration_DLXBrokerNative(t *testing.T) {
+	conn, cleanup := startRabbitMQ(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pub := NewPublisher(conn)
+
+	const (
+		topic       = "test.dlx.e2e"
+		dlxExchange = "test.dlx.e2e.dlx"
+		dlxQueue    = "test.dlx.e2e.dlq"
+		mainQueue   = "test.dlx.e2e.main"
+	)
+
+	// --- Set up DLX infrastructure via raw AMQP channel ---
+	rawCh, err := conn.AcquireChannel()
+	require.NoError(t, err)
+
+	// Declare the DLX exchange (direct type, durable).
+	err = rawCh.ExchangeDeclare(dlxExchange, "direct", true, false, false, false, nil)
+	require.NoError(t, err, "declare DLX exchange")
+
+	// Declare the dead-letter queue and bind it to the DLX exchange.
+	_, err = rawCh.QueueDeclare(dlxQueue, true, false, false, false, nil)
+	require.NoError(t, err, "declare DLQ queue")
+
+	err = rawCh.QueueBind(dlxQueue, "", dlxExchange, false, nil)
+	require.NoError(t, err, "bind DLQ to DLX exchange")
+
+	conn.ReleaseChannel(rawCh)
+
+	// --- Start the main subscriber with DLX configured ---
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       mainQueue,
+		PrefetchCount:   1,
+		DLXExchange:     dlxExchange,
+		ShutdownTimeout: 5 * time.Second,
+	})
+
+	subCtx, subCancel := context.WithTimeout(ctx, 20*time.Second)
+	defer subCancel()
+
+	handlerCalled := make(chan struct{}, 1)
+	subErrCh := make(chan error, 1)
+	go func() {
+		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			handlerCalled <- struct{}{}
+			// Permanent rejection — broker should route to DLX.
+			return outbox.HandleResult{
+				Disposition: outbox.DispositionReject,
+				Err:         assert.AnError,
+			}
+		})
+	}()
+
+	waitForSubscriberReady(t, conn, mainQueue, subErrCh, 5*time.Second)
+
+	// --- Publish a message ---
+	entry := outbox.Entry{
+		ID:        "evt-dlx-e2e-001",
+		EventType: "test.dlx.rejected",
+		Payload:   []byte(`{"dlx":"end-to-end"}`),
+		CreatedAt: time.Now().UTC(),
+	}
+	payload, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	err = pub.Publish(ctx, topic, payload)
+	require.NoError(t, err, "publish should succeed")
+
+	// Wait for handler to be called (message consumed → Reject).
+	select {
+	case <-handlerCalled:
+		// Handler was called and returned DispositionReject.
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for handler to be called")
+	}
+
+	// --- Consume from the dead-letter queue via raw AMQP ---
+	// Give broker a moment to route the rejected message to DLX.
+	time.Sleep(500 * time.Millisecond)
+
+	dlxCh, err := conn.AcquireChannel()
+	require.NoError(t, err)
+	defer conn.ReleaseChannel(dlxCh)
+
+	msgs, err := dlxCh.Consume(dlxQueue, "dlx-test-consumer", true, false, false, false, nil)
+	require.NoError(t, err, "consume from DLQ")
+
+	select {
+	case msg := <-msgs:
+		// Unmarshal and verify the dead-lettered message.
+		var dlEntry outbox.Entry
+		require.NoError(t, json.Unmarshal(msg.Body, &dlEntry))
+		assert.Equal(t, "evt-dlx-e2e-001", dlEntry.ID, "dead-lettered entry ID should match")
+		assert.JSONEq(t, `{"dlx":"end-to-end"}`, string(dlEntry.Payload), "payload should match")
+		t.Logf("DLX end-to-end verified: message %s arrived in dead-letter queue", dlEntry.ID)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for message in dead-letter queue — DLX routing failed")
+	}
+
+	subCancel()
+	_ = sub.Close()
+}
+
 // noopChecker is a minimal idempotency.Checker for testing that always
 // reports keys as not-yet-processed.
 type noopChecker struct{}

--- a/src/adapters/rabbitmq/integration_test.go
+++ b/src/adapters/rabbitmq/integration_test.go
@@ -103,6 +103,7 @@ func TestIntegration_PublishConsume(t *testing.T) {
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       queueName,
 		PrefetchCount:   1,
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 5 * time.Second,
 	})
 
@@ -205,6 +206,7 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	dlqSub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test.integration.retry.dlq.queue",
 		PrefetchCount:   1,
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 5 * time.Second,
 	})
 

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // --- Mock AMQP Channel ---
@@ -2372,5 +2373,136 @@ func TestProcessDelivery_Requeue_BrokerNackFails_ReleasesReceipt(t *testing.T) {
 	receipt.mu.Lock()
 	assert.False(t, receipt.commitCalled, "should not Commit when broker Nack fails")
 	assert.True(t, receipt.releaseCalled, "should Release when broker Nack fails, so redelivery can re-enter")
+	receipt.mu.Unlock()
+}
+
+func TestIsRecoverableAMQPError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "non-AMQP error",
+			err:  errors.New("some random error"),
+			want: false,
+		},
+		{
+			name: "AMQP error with Recover=true",
+			err:  &amqp.Error{Code: 501, Reason: "frame error", Server: true, Recover: true},
+			want: true,
+		},
+		{
+			name: "AMQP error with Recover=false",
+			err:  &amqp.Error{Code: 403, Reason: "access refused", Server: true, Recover: false},
+			want: false,
+		},
+		{
+			name: "connection error Code 320 (connection forced) with Recover=true",
+			err:  &amqp.Error{Code: 320, Reason: "connection forced", Server: true, Recover: true},
+			want: true,
+		},
+		{
+			name: "channel error Code 404 (not found) with Recover=false",
+			err:  &amqp.Error{Code: 404, Reason: "not found", Server: true, Recover: false},
+			want: false,
+		},
+		{
+			name: "amqp.ErrClosed",
+			err:  amqp.ErrClosed,
+			want: true,
+		},
+		{
+			name: "wrapped amqp.ErrClosed",
+			err:  fmt.Errorf("channel: %w", amqp.ErrClosed),
+			want: true,
+		},
+		{
+			name: "ErrAdapterAMQPConnect errcode",
+			err:  errcode.New(ErrAdapterAMQPConnect, "connection not available"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRecoverableAMQPError(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConsumerBase_Wrap_ReleaseCheckerError_Logged(t *testing.T) {
+	checker := newMockIdempotencyChecker()
+	checker.releaseErr = errors.New("redis timeout")
+
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryCount:     1,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+	})
+
+	entry := outbox.Entry{ID: "evt-release-err", EventType: "test.release.err"}
+	res := handler(context.Background(), entry)
+
+	// Retry exhausted (RetryCount=1) → DispositionReject.
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+
+	// Release was attempted even though it returned an error.
+	checker.mu.Lock()
+	assert.Contains(t, checker.releaseCalls, "test-group:evt-release-err",
+		"Release should have been called with the idempotency key")
+	checker.mu.Unlock()
+}
+
+func TestProcessDelivery_UnknownDisposition_NackWithRequeue(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{}
+	entry := outbox.Entry{ID: "evt-unknown-disp", EventType: "test.unknown"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.Disposition(99),
+			Receipt:     receipt,
+		}
+	}
+
+	sub.wg.Add(1)
+	sub.processDelivery(context.Background(), ch, amqp.Delivery{
+		DeliveryTag: 42,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	// Unknown disposition should Nack with requeue=true.
+	ch.mu.Lock()
+	assert.True(t, ch.nackCalled, "unknown disposition should trigger Nack")
+	assert.True(t, ch.nackRequeue, "unknown disposition should requeue")
+	ch.mu.Unlock()
+
+	// Receipt should be Released (not Committed) for unknown disposition.
+	receipt.mu.Lock()
+	assert.True(t, receipt.releaseCalled, "unknown disposition should Release Receipt")
+	assert.False(t, receipt.commitCalled, "unknown disposition should not Commit Receipt")
 	receipt.mu.Unlock()
 }

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -2122,11 +2122,11 @@ func TestProcessDelivery_Receipt_UsesDetachedCtx(t *testing.T) {
 	}, "test.topic", handler)
 
 	// Receipt should still be committed because processDelivery uses
-	// context.WithoutCancel for Receipt operations.
+	// context.WithoutCancel for Receipt operations. The parent ctx is
+	// cancelled but the receipt ctx is detached, so Commit succeeds.
 	receipt.mu.Lock()
-	assert.True(t, receipt.commitCalled, "Receipt should be committed even with cancelled ctx")
-	assert.NotNil(t, receipt.commitCtx, "Commit ctx should be non-nil")
-	assert.NoError(t, receipt.commitCtx.Err(), "Commit ctx should NOT be cancelled (WithoutCancel)")
+	assert.True(t, receipt.commitCalled, "Receipt should be committed even with cancelled parent ctx")
+	assert.False(t, receipt.releaseCalled, "Should Commit, not Release")
 	receipt.mu.Unlock()
 }
 
@@ -2239,5 +2239,138 @@ func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
 	receipt.mu.Lock()
 	assert.False(t, receipt.commitCalled, "should not Commit when broker Ack fails")
 	assert.True(t, receipt.releaseCalled, "should Release when broker Ack fails")
+	receipt.mu.Unlock()
+}
+
+// =============================================================================
+// ClaimFailOpen config tests
+// =============================================================================
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestConsumerBase_WrapWithClaimer_ClaimError_FailClosed(t *testing.T) {
+	claimer := &mockClaimer{err: errors.New("redis down")}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup: "test-group",
+		ClaimFailOpen: boolPtr(false),
+	})
+
+	handlerCalled := false
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-fail-closed"})
+	assert.False(t, handlerCalled, "handler must NOT be called when fail-closed")
+	assert.Equal(t, outbox.DispositionRequeue, res.Disposition)
+	assert.Error(t, res.Err)
+	assert.Contains(t, res.Err.Error(), "redis down")
+}
+
+func TestConsumerBase_WrapWithClaimer_ClaimError_FailOpen_Explicit(t *testing.T) {
+	claimer := &mockClaimer{err: errors.New("redis down")}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup: "test-group",
+		ClaimFailOpen: boolPtr(true),
+	})
+
+	handlerCalled := false
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-fail-open-explicit"})
+	assert.True(t, handlerCalled, "handler must be called when fail-open is explicit")
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
+	assert.Nil(t, res.Receipt, "no Receipt when claim fails")
+}
+
+// =============================================================================
+// processDelivery uncovered branch tests
+// =============================================================================
+
+func TestProcessDelivery_HandlerError_Logged(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	entry := outbox.Entry{ID: "evt-ack-with-err", EventType: "test.ackwitherr"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	// Handler returns DispositionAck but also an error (e.g., a warning).
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionAck,
+			Err:         errors.New("warning: partial data"),
+		}
+	}
+
+	sub.wg.Add(1)
+	sub.processDelivery(context.Background(), ch, amqp.Delivery{
+		DeliveryTag: 20,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	// Ack should still be called (error does not affect disposition).
+	ch.mu.Lock()
+	assert.True(t, ch.ackCalled, "Ack should be called even when handler reports an error")
+	assert.Equal(t, uint64(20), ch.ackTag)
+	assert.False(t, ch.nackCalled, "Nack should NOT be called for DispositionAck")
+	ch.mu.Unlock()
+}
+
+func TestProcessDelivery_Requeue_BrokerNackFails_ReleasesReceipt(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	ch.nackErr = errors.New("channel closed")
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{}
+	entry := outbox.Entry{ID: "evt-requeue-nack-fail", EventType: "test.requeue.nackfail"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionRequeue,
+			Err:         errors.New("transient"),
+			Receipt:     receipt,
+		}
+	}
+
+	sub.wg.Add(1)
+	sub.processDelivery(context.Background(), ch, amqp.Delivery{
+		DeliveryTag: 30,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	// Nack was attempted (requeue=true) but failed.
+	ch.mu.Lock()
+	assert.True(t, ch.nackCalled)
+	ch.mu.Unlock()
+
+	// Receipt should be Released because broker nack failed (brokerErr != nil path).
+	receipt.mu.Lock()
+	assert.False(t, receipt.commitCalled, "should not Commit when broker Nack fails")
+	assert.True(t, receipt.releaseCalled, "should Release when broker Nack fails, so redelivery can re-enter")
 	receipt.mu.Unlock()
 }

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -1816,3 +1816,345 @@ func TestPublisher_Publish_ConfirmChannelClosed(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_CONFIRM_TIMEOUT")
 	assert.Contains(t, err.Error(), "confirm channel closed")
 }
+
+// =============================================================================
+// Mock Claimer / Receipt for Solution B tests
+// =============================================================================
+
+type mockReceipt struct {
+	mu           sync.Mutex
+	commitCalled bool
+	commitErr    error
+	releaseCalled bool
+	releaseErr   error
+	commitCtx    context.Context
+	releaseCtx   context.Context
+}
+
+func (r *mockReceipt) Commit(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.commitCalled = true
+	r.commitCtx = ctx
+	return r.commitErr
+}
+
+func (r *mockReceipt) Release(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.releaseCalled = true
+	r.releaseCtx = ctx
+	return r.releaseErr
+}
+
+var _ outbox.Receipt = (*mockReceipt)(nil)
+
+type mockClaimer struct {
+	mu     sync.Mutex
+	state  idempotency.ClaimState
+	receipt outbox.Receipt
+	err    error
+	claims []string
+}
+
+func (c *mockClaimer) Claim(_ context.Context, key string, _, _ time.Duration) (idempotency.ClaimState, outbox.Receipt, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.claims = append(c.claims, key)
+	return c.state, c.receipt, c.err
+}
+
+var _ idempotency.Claimer = (*mockClaimer)(nil)
+
+// --- ConsumerBase with Claimer tests ---
+
+func TestConsumerBase_WrapWithClaimer_Success_ReturnsReceipt(t *testing.T) {
+	receipt := &mockReceipt{}
+	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup: "test-group",
+	})
+
+	handlerCalled := false
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	entry := outbox.Entry{ID: "evt-claimer-001"}
+	res := handler(context.Background(), entry)
+
+	assert.True(t, handlerCalled)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
+	assert.Same(t, receipt, res.Receipt, "Receipt should be threaded through HandleResult")
+	// ConsumerBase must NOT call Commit/Release — that's processDelivery's job.
+	receipt.mu.Lock()
+	assert.False(t, receipt.commitCalled)
+	assert.False(t, receipt.releaseCalled)
+	receipt.mu.Unlock()
+}
+
+func TestConsumerBase_WrapWithClaimer_ClaimDone_SkipsHandler(t *testing.T) {
+	claimer := &mockClaimer{state: idempotency.ClaimDone}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup: "test-group",
+	})
+
+	handlerCalled := false
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-done"})
+	assert.False(t, handlerCalled)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
+	assert.Nil(t, res.Receipt, "ClaimDone should not return a Receipt")
+}
+
+func TestConsumerBase_WrapWithClaimer_ClaimBusy_Requeues(t *testing.T) {
+	claimer := &mockClaimer{state: idempotency.ClaimBusy}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup: "test-group",
+	})
+
+	handlerCalled := false
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-busy"})
+	assert.False(t, handlerCalled)
+	assert.Equal(t, outbox.DispositionRequeue, res.Disposition)
+}
+
+func TestConsumerBase_WrapWithClaimer_Reject_ThreadsReceipt(t *testing.T) {
+	receipt := &mockReceipt{}
+	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryCount:     1,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("fail")}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-reject"})
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+	assert.Same(t, receipt, res.Receipt, "Reject should thread Receipt for processDelivery to Release")
+	// ConsumerBase must NOT call Commit/Release on Receipt.
+	receipt.mu.Lock()
+	assert.False(t, receipt.commitCalled)
+	assert.False(t, receipt.releaseCalled)
+	receipt.mu.Unlock()
+}
+
+func TestConsumerBase_WrapWithClaimer_ClaimError_FailOpen(t *testing.T) {
+	claimer := &mockClaimer{err: errors.New("redis down")}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup: "test-group",
+	})
+
+	handlerCalled := false
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-claim-err"})
+	assert.True(t, handlerCalled, "should still process on claim error (fail-open)")
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
+	assert.Nil(t, res.Receipt, "no Receipt on claim error")
+}
+
+// --- processDelivery Receipt lifecycle tests ---
+
+func TestProcessDelivery_Ack_CommitsReceipt(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{}
+	entry := outbox.Entry{ID: "evt-ack-receipt", EventType: "test.ack"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck, Receipt: receipt}
+	}
+
+	ctx := context.Background()
+	sub.wg.Add(1)
+	sub.processDelivery(ctx, ch, amqp.Delivery{
+		DeliveryTag: 1,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	ch.mu.Lock()
+	assert.True(t, ch.ackCalled)
+	ch.mu.Unlock()
+
+	receipt.mu.Lock()
+	assert.True(t, receipt.commitCalled, "Ack should Commit Receipt")
+	assert.False(t, receipt.releaseCalled, "Ack should not Release Receipt")
+	receipt.mu.Unlock()
+}
+
+func TestProcessDelivery_Reject_ReleasesReceipt(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{}
+	entry := outbox.Entry{ID: "evt-reject-receipt", EventType: "test.reject"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionReject,
+			Err:         errors.New("permanent"),
+			Receipt:     receipt,
+		}
+	}
+
+	ctx := context.Background()
+	sub.wg.Add(1)
+	sub.processDelivery(ctx, ch, amqp.Delivery{
+		DeliveryTag: 2,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	ch.mu.Lock()
+	assert.True(t, ch.nackCalled)
+	assert.False(t, ch.nackRequeue, "Reject should Nack without requeue")
+	ch.mu.Unlock()
+
+	receipt.mu.Lock()
+	assert.False(t, receipt.commitCalled, "Reject should NOT Commit Receipt")
+	assert.True(t, receipt.releaseCalled, "Reject should Release Receipt (allows DLQ replay)")
+	receipt.mu.Unlock()
+}
+
+func TestProcessDelivery_NilReceipt_NoPanic(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	entry := outbox.Entry{ID: "evt-nil-receipt", EventType: "test.nil"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}
+
+	ctx := context.Background()
+	sub.wg.Add(1)
+	// Should not panic even though Receipt is nil.
+	assert.NotPanics(t, func() {
+		sub.processDelivery(ctx, ch, amqp.Delivery{
+			DeliveryTag: 3,
+			Body:        entryBytes,
+		}, "test.topic", handler)
+	})
+}
+
+func TestProcessDelivery_Receipt_UsesDetachedCtx(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{}
+	entry := outbox.Entry{ID: "evt-detached-ctx", EventType: "test.ctx"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck, Receipt: receipt}
+	}
+
+	// Use a cancelled context to simulate shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sub.wg.Add(1)
+	sub.processDelivery(ctx, ch, amqp.Delivery{
+		DeliveryTag: 4,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	// Receipt should still be committed because processDelivery uses
+	// context.WithoutCancel for Receipt operations.
+	receipt.mu.Lock()
+	assert.True(t, receipt.commitCalled, "Receipt should be committed even with cancelled ctx")
+	assert.NotNil(t, receipt.commitCtx, "Commit ctx should be non-nil")
+	assert.NoError(t, receipt.commitCtx.Err(), "Commit ctx should NOT be cancelled (WithoutCancel)")
+	receipt.mu.Unlock()
+}
+
+func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	ch.ackErr = errors.New("channel closed")
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{}
+	entry := outbox.Entry{ID: "evt-broker-fail", EventType: "test.brokerfail"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck, Receipt: receipt}
+	}
+
+	ctx := context.Background()
+	sub.wg.Add(1)
+	sub.processDelivery(ctx, ch, amqp.Delivery{
+		DeliveryTag: 5,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	receipt.mu.Lock()
+	assert.False(t, receipt.commitCalled, "should not Commit when broker Ack fails")
+	assert.True(t, receipt.releaseCalled, "should Release when broker Ack fails")
+	receipt.mu.Unlock()
+}

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -1413,9 +1413,17 @@ func TestConsumerBase_Wrap_RetryExhausted_Reject(t *testing.T) {
 	assert.Equal(t, outbox.DispositionReject, res.Disposition)
 	assert.Error(t, res.Err)
 
-	// Idempotency key should be released so DLQ replay can re-process.
+	// Receipt should be a checkerReceipt — Release is deferred to processDelivery.
+	require.NotNil(t, res.Receipt, "legacy Checker path should return a checkerReceipt")
+	// Key is still marked (TryProcess set it); Release happens in processDelivery.
 	checker.mu.Lock()
-	assert.False(t, checker.processed["test-group:evt-003"])
+	assert.True(t, checker.processed["test-group:evt-003"], "key still marked before processDelivery Release")
+	checker.mu.Unlock()
+
+	// Simulate processDelivery calling Release after broker Nack.
+	require.NoError(t, res.Receipt.Release(context.Background()))
+	checker.mu.Lock()
+	assert.False(t, checker.processed["test-group:evt-003"], "key released after Receipt.Release")
 	checker.mu.Unlock()
 }
 
@@ -1534,7 +1542,9 @@ func TestConsumerBase_Wrap_RetryExhausted_ReleasesIdempotencyKey(t *testing.T) {
 	res := handler(context.Background(), entry)
 	assert.Equal(t, outbox.DispositionReject, res.Disposition)
 
-	// Idempotency key should be released so DLQ replay can re-enter.
+	// Receipt is deferred to processDelivery; simulate Release.
+	require.NotNil(t, res.Receipt)
+	require.NoError(t, res.Receipt.Release(context.Background()))
 	checker.mu.Lock()
 	assert.False(t, checker.processed["test-group:evt-dlq-001"])
 	checker.mu.Unlock()
@@ -2457,7 +2467,12 @@ func TestConsumerBase_Wrap_ReleaseCheckerError_Logged(t *testing.T) {
 	// Retry exhausted (RetryCount=1) → DispositionReject.
 	assert.Equal(t, outbox.DispositionReject, res.Disposition)
 
-	// Release was attempted even though it returned an error.
+	// Receipt defers Release to processDelivery. Simulate it.
+	require.NotNil(t, res.Receipt)
+	err := res.Receipt.Release(context.Background())
+	assert.Error(t, err, "Release should propagate checker error")
+	assert.Contains(t, err.Error(), "redis timeout")
+
 	checker.mu.Lock()
 	assert.Contains(t, checker.releaseCalls, "test-group:evt-release-err",
 		"Release should have been called with the idempotency key")

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -284,32 +284,8 @@ var _ idempotency.Checker = (*mockIdempotencyChecker)(nil)
 
 // --- Mock Publisher (for DLQ) ---
 
-type mockPublisher struct {
-	mu       sync.Mutex
-	messages []publishedMsg
-	err      error
-}
-
-type publishedMsg struct {
-	topic   string
-	payload []byte
-}
-
-func newMockPublisher() *mockPublisher {
-	return &mockPublisher{}
-}
-
-func (m *mockPublisher) Publish(_ context.Context, topic string, payload []byte) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.err != nil {
-		return m.err
-	}
-	m.messages = append(m.messages, publishedMsg{topic: topic, payload: payload})
-	return nil
-}
-
-var _ outbox.Publisher = (*mockPublisher)(nil)
+// mockPublisher was removed: ConsumerBase no longer uses application-side
+// DLQ publish. Dead-letter routing is now handled by broker-native DLX.
 
 // --- Helper to create a test connection ---
 
@@ -722,9 +698,9 @@ func TestSubscriber_Subscribe_ProcessesDelivery(t *testing.T) {
 	require.NoError(t, err)
 
 	handled := make(chan outbox.Entry, 1)
-	handler := func(_ context.Context, e outbox.Entry) error {
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handled <- e
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -774,9 +750,9 @@ func TestSubscriber_Subscribe_UnmarshalFailure_Nack(t *testing.T) {
 		ShutdownTimeout: 2 * time.Second,
 	})
 
-	handler := func(_ context.Context, e outbox.Entry) error {
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		t.Fatal("handler should not be called for unmarshal failure")
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -818,8 +794,8 @@ func TestSubscriber_Subscribe_HandlerError_NackWithRequeue(t *testing.T) {
 	entryBytes, err := json.Marshal(entry)
 	require.NoError(t, err)
 
-	handler := func(_ context.Context, e outbox.Entry) error {
-		return errors.New("transient error")
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("transient error")}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -838,7 +814,7 @@ func TestSubscriber_Subscribe_HandlerError_NackWithRequeue(t *testing.T) {
 
 	ch.mu.Lock()
 	assert.True(t, ch.nackCalled)
-	assert.True(t, ch.nackRequeue) // Transient error should requeue.
+	assert.True(t, ch.nackRequeue) // Requeue disposition should requeue.
 	ch.mu.Unlock()
 
 	assert.NoError(t, sub.Close())
@@ -860,7 +836,7 @@ func TestSubscriber_Subscribe_DefaultQueueName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately so Subscribe exits.
 
-	err := sub.Subscribe(ctx, "my.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "my.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -882,7 +858,7 @@ func TestSubscriber_Subscribe_AfterClose(t *testing.T) {
 
 	assert.NoError(t, sub.Close())
 
-	err := sub.Subscribe(context.Background(), "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(context.Background(), "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_SUBSCRIBE")
 }
@@ -930,9 +906,9 @@ func TestSubscriber_DeliveryChannelClosed_TriggersReconnect(t *testing.T) {
 	}()
 
 	handled := make(chan string, 1)
-	handler := func(_ context.Context, e outbox.Entry) error {
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handled <- e.ID
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
 	err := sub.Subscribe(ctx, "test.topic", handler)
@@ -982,7 +958,7 @@ func TestSubscriber_ReconnectLoop_CtxCancelledDuringWait(t *testing.T) {
 		cancel()
 	}()
 
-	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err) // Clean exit via ctx cancel during WaitConnected.
 }
 
@@ -1093,7 +1069,7 @@ func TestSubscriber_SubscribeOnce_AcquireChannelFails(t *testing.T) {
 
 	// subscribeOnce should return an error (channel acquisition failure).
 	err = sub.subscribeOnce(context.Background(), "test.topic", "test-queue",
-		func(_ context.Context, _ outbox.Entry) error { return nil })
+		outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP")
 
@@ -1153,7 +1129,7 @@ func TestSubscriber_Subscribe_ClosedDuringReconnect(t *testing.T) {
 
 	go func() {
 		subscribeDone <- sub.Subscribe(context.Background(), "test.topic",
-			func(_ context.Context, _ outbox.Entry) error { return nil })
+			outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	}()
 
 	select {
@@ -1183,7 +1159,7 @@ func TestSubscriber_Subscribe_ConsumerGroupQueueName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately so Subscribe exits after setup.
 
-	err := sub.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "session.created", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1211,7 +1187,7 @@ func TestSubscriber_Subscribe_ExplicitQueueName_OverridesConsumerGroup(t *testin
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "session.created", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1237,7 +1213,7 @@ func TestSubscriber_Subscribe_NoConsumerGroup_FallsBackToTopic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "my.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "my.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1264,7 +1240,7 @@ func TestSubscriber_Subscribe_DLXExchange_SetsQueueArgs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1294,7 +1270,7 @@ func TestSubscriber_Subscribe_DLXExchangeWithRoutingKey(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1321,7 +1297,7 @@ func TestSubscriber_Subscribe_NoDLX_NilArgs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "test.topic", func(_ context.Context, _ outbox.Entry) error { return nil })
+	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1345,22 +1321,21 @@ func TestConsumerBaseConfig_Defaults(t *testing.T) {
 
 func TestConsumerBase_Wrap_Success(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
 	})
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		assert.Equal(t, "evt-001", e.ID)
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
 	entry := outbox.Entry{ID: "evt-001", EventType: "test.created"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err)
+	res := handler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.True(t, handlerCalled)
 
 	// Verify idempotency key was marked.
@@ -1372,46 +1347,44 @@ func TestConsumerBase_Wrap_Success(t *testing.T) {
 func TestConsumerBase_Wrap_AlreadyProcessed(t *testing.T) {
 	checker := newMockIdempotencyChecker()
 	checker.processed["test-group:evt-001"] = true
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
 	})
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
 	entry := outbox.Entry{ID: "evt-001"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err)
+	res := handler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.False(t, handlerCalled) // Should skip because already processed.
 }
 
 func TestConsumerBase_Wrap_TransientError_Retry(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond, // Fast for test.
 	})
 
 	callCount := 0
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		callCount++
 		if callCount < 3 {
-			return errors.New("transient error")
+			return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("transient error")}
 		}
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
 	entry := outbox.Entry{ID: "evt-002"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err)
+	res := handler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.Equal(t, 3, callCount) // Should retry 3 times total.
 
 	// Should be marked processed on success.
@@ -1420,122 +1393,101 @@ func TestConsumerBase_Wrap_TransientError_Retry(t *testing.T) {
 	checker.mu.Unlock()
 }
 
-func TestConsumerBase_Wrap_RetryExhausted_DLQ(t *testing.T) {
+func TestConsumerBase_Wrap_RetryExhausted_Reject(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     2,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
-		return errors.New("always fails")
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("always fails")}
 	})
 
 	entry := outbox.Entry{ID: "evt-003", EventType: "test.fail"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err) // Returns nil because message was DLQ'd.
+	res := handler(context.Background(), entry)
+	// Exhausted retries now return DispositionReject (broker routes to DLX).
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+	assert.Error(t, res.Err)
 
-	// Verify DLQ message was published.
-	pub.mu.Lock()
-	require.Len(t, pub.messages, 1)
-	assert.Equal(t, "test.topic.dlq", pub.messages[0].topic)
-
-	var dlqEntry outbox.Entry
-	require.NoError(t, json.Unmarshal(pub.messages[0].payload, &dlqEntry))
-	assert.Equal(t, "evt-003", dlqEntry.ID)
-	assert.Equal(t, "always fails", dlqEntry.Metadata["x-death-reason"])
-	assert.Equal(t, "test.topic", dlqEntry.Metadata["x-death-topic"])
-	assert.Equal(t, "test-group", dlqEntry.Metadata["x-death-consumer-group"])
-	assert.Equal(t, "2", dlqEntry.Metadata["x-death-retry-count"])
-	pub.mu.Unlock()
-
-	// With TryProcess, the key is claimed atomically before the handler runs.
-	// Even though the handler failed and exhausted retries, the key remains marked
-	// to prevent duplicate processing by other consumers (message goes to DLQ).
+	// Idempotency key should be released so DLQ replay can re-process.
 	checker.mu.Lock()
-	assert.True(t, checker.processed["test-group:evt-003"])
+	assert.False(t, checker.processed["test-group:evt-003"])
 	checker.mu.Unlock()
 }
 
-func TestConsumerBase_Wrap_PermanentError_DLQ(t *testing.T) {
+func TestConsumerBase_Wrap_PermanentError_Reject(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
-		return NewPermanentError(errors.New("bad payload"))
+	callCount := 0
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		callCount++
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionRequeue,
+			Err:         NewPermanentError(errors.New("bad payload")),
+		}
 	})
 
 	entry := outbox.Entry{ID: "evt-004", EventType: "test.permanent"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err) // Returns nil because message was DLQ'd.
-
-	// Verify DLQ message was published — should only be called once (no retry).
-	pub.mu.Lock()
-	require.Len(t, pub.messages, 1)
-	assert.Equal(t, "test.topic.dlq", pub.messages[0].topic)
-	pub.mu.Unlock()
+	res := handler(context.Background(), entry)
+	// PermanentError → DispositionReject (no retry, broker routes to DLX).
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+	assert.Equal(t, 1, callCount) // Should not retry.
 }
 
-func TestConsumerBase_Wrap_CustomDLQTopic(t *testing.T) {
+func TestConsumerBase_Wrap_ExplicitReject_NoRetry(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
-		RetryCount:     1,
+		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
-		DLQTopic:       "custom-dlq",
 	})
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
-		return errors.New("fail")
+	callCount := 0
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		callCount++
+		return outbox.HandleResult{Disposition: outbox.DispositionReject, Err: errors.New("reject this")}
 	})
 
-	entry := outbox.Entry{ID: "evt-005"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err)
-
-	pub.mu.Lock()
-	require.Len(t, pub.messages, 1)
-	assert.Equal(t, "custom-dlq", pub.messages[0].topic)
-	pub.mu.Unlock()
+	entry := outbox.Entry{ID: "evt-explicit-reject"}
+	res := handler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+	assert.Equal(t, 1, callCount)
 }
 
 func TestConsumerBase_Wrap_IdempotencyCheckError_StillProcesses(t *testing.T) {
 	checker := newMockIdempotencyChecker()
 	checker.tryProcErr = errors.New("redis down")
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
 	})
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
 	entry := outbox.Entry{ID: "evt-006"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err)
+	res := handler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.True(t, handlerCalled) // Should still process when idempotency check fails.
 }
 
 func TestConsumerBase_Wrap_ContextCancelled_DuringRetry(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 500 * time.Millisecond,
@@ -1543,14 +1495,14 @@ func TestConsumerBase_Wrap_ContextCancelled_DuringRetry(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		cancel() // Cancel context during first handler call.
-		return errors.New("transient error")
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("transient error")}
 	})
 
 	entry := outbox.Entry{ID: "evt-007"}
-	err := handler(ctx, entry)
-	assert.Error(t, err) // Should return context error.
+	res := handler(ctx, entry)
+	assert.Equal(t, outbox.DispositionRequeue, res.Disposition) // Should requeue on shutdown.
 }
 
 func TestPermanentError(t *testing.T) {
@@ -1562,83 +1514,56 @@ func TestPermanentError(t *testing.T) {
 	assert.Equal(t, inner, pe.Unwrap())
 }
 
-// --- P0 #5: DLQ publish failure must propagate error (not silently ACK) ---
+// --- Solution B: Reject goes to broker DLX, not application-side DLQ ---
 
-func TestConsumerBase_Wrap_DLQPublishFails_RetryExhausted_ReturnsError(t *testing.T) {
+func TestConsumerBase_Wrap_RetryExhausted_ReleasesIdempotencyKey(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
-	pub.err = errors.New("DLQ broker down")
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     1,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
-		return errors.New("always fails")
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("always fails")}
 	})
 
-	entry := outbox.Entry{ID: "evt-dlq-fail-001", EventType: "test.fail"}
-	err := handler(context.Background(), entry)
-	// When DLQ publish fails, Wrap must return an error so subscriber NACKs with requeue.
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "DLQ publish failed after retry exhaustion")
-	assert.Contains(t, err.Error(), "DLQ broker down")
-}
+	entry := outbox.Entry{ID: "evt-dlq-001", EventType: "test.fail"}
+	res := handler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
 
-func TestConsumerBase_Wrap_DLQPublishFails_PermanentError_ReturnsError(t *testing.T) {
-	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
-	pub.err = errors.New("DLQ broker down")
-
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
-		RetryCount:     3,
-		RetryBaseDelay: 10 * time.Millisecond,
-	})
-
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
-		return NewPermanentError(errors.New("bad payload"))
-	})
-
-	entry := outbox.Entry{ID: "evt-dlq-fail-002", EventType: "test.permanent"}
-	err := handler(context.Background(), entry)
-	// When DLQ publish fails for a permanent error, Wrap must return an error.
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "DLQ publish failed for permanent error")
-	assert.Contains(t, err.Error(), "DLQ broker down")
+	// Idempotency key should be released so DLQ replay can re-enter.
+	checker.mu.Lock()
+	assert.False(t, checker.processed["test-group:evt-dlq-001"])
+	checker.mu.Unlock()
 }
 
 // --- Extra fix: wrapped PermanentError detected via errors.As ---
 
 func TestConsumerBase_Wrap_WrappedPermanentError_DetectedByErrorsAs(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 
 	callCount := 0
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) error {
+	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		callCount++
-		// Wrap PermanentError inside fmt.Errorf — the old type assertion would miss this.
-		return fmt.Errorf("handler context: %w", NewPermanentError(errors.New("unmarshal failed")))
+		// Wrap PermanentError inside fmt.Errorf — errors.As should still detect it.
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionRequeue,
+			Err:         fmt.Errorf("handler context: %w", NewPermanentError(errors.New("unmarshal failed"))),
+		}
 	})
 
 	entry := outbox.Entry{ID: "evt-wrapped-perm", EventType: "test.wrapped"}
-	err := handler(context.Background(), entry)
-	assert.NoError(t, err) // Should return nil because message was DLQ'd.
-	assert.Equal(t, 1, callCount) // Should not retry — permanent error detected on first attempt.
-
-	// Verify DLQ message was published.
-	pub.mu.Lock()
-	require.Len(t, pub.messages, 1)
-	assert.Equal(t, "test.topic.dlq", pub.messages[0].topic)
-	pub.mu.Unlock()
+	res := handler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionReject, res.Disposition) // PermanentError → Reject.
+	assert.Equal(t, 1, callCount)                               // Should not retry.
 }
 
 // --- P0 #7: ctx cancel → NACK with requeue (conservative shutdown) ---
@@ -1662,10 +1587,10 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithRequeue(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	handler := func(_ context.Context, e outbox.Entry) error {
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		// Simulate ctx cancel happening before/during handler.
 		cancel()
-		return errors.New("transient error during shutdown")
+		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("transient error during shutdown")}
 	}
 
 	go func() {
@@ -1685,7 +1610,7 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithRequeue(t *testing.T) {
 
 	ch.mu.Lock()
 	assert.True(t, ch.nackCalled, "should NACK the delivery")
-	assert.True(t, ch.nackRequeue, "should NACK with requeue when ctx is cancelled — without DLX, requeue=false would discard the message")
+	assert.True(t, ch.nackRequeue, "should NACK with requeue when disposition is Requeue")
 	assert.Equal(t, uint64(42), ch.nackTag)
 	ch.mu.Unlock()
 
@@ -1698,9 +1623,8 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithRequeue(t *testing.T) {
 
 func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup: "mw-group",
 	})
 
@@ -1710,15 +1634,15 @@ func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
 	var _ outbox.TopicHandlerMiddleware = mw
 
 	handlerCalled := false
-	wrapped := mw("test.topic", func(_ context.Context, e outbox.Entry) error {
+	wrapped := mw("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		assert.Equal(t, "evt-mw-001", e.ID)
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
 	entry := outbox.Entry{ID: "evt-mw-001", EventType: "test.middleware"}
-	err := wrapped(context.Background(), entry)
-	assert.NoError(t, err)
+	res := wrapped(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.True(t, handlerCalled)
 
 	// Verify idempotency key was marked (ConsumerBase wrapping is active).
@@ -1730,31 +1654,29 @@ func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
 func TestConsumerBase_AsMiddleware_Idempotency_SkipsDuplicate(t *testing.T) {
 	checker := newMockIdempotencyChecker()
 	checker.processed["mw-group:evt-mw-dup"] = true
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup: "mw-group",
 	})
 
 	mw := cb.AsMiddleware()
 
 	handlerCalled := false
-	wrapped := mw("test.topic", func(_ context.Context, _ outbox.Entry) error {
+	wrapped := mw("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
 	entry := outbox.Entry{ID: "evt-mw-dup"}
-	err := wrapped(context.Background(), entry)
-	assert.NoError(t, err)
+	res := wrapped(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.False(t, handlerCalled, "handler should be skipped for duplicate event")
 }
 
-func TestConsumerBase_AsMiddleware_RoutesToDLQ_OnPermanentError(t *testing.T) {
+func TestConsumerBase_AsMiddleware_RejectOnPermanentError(t *testing.T) {
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup:  "mw-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
@@ -1762,33 +1684,30 @@ func TestConsumerBase_AsMiddleware_RoutesToDLQ_OnPermanentError(t *testing.T) {
 
 	mw := cb.AsMiddleware()
 
-	wrapped := mw("orders.created", func(_ context.Context, _ outbox.Entry) error {
-		return NewPermanentError(errors.New("corrupted payload"))
+	wrapped := mw("orders.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionRequeue,
+			Err:         NewPermanentError(errors.New("corrupted payload")),
+		}
 	})
 
 	entry := outbox.Entry{ID: "evt-mw-perm", EventType: "orders.created"}
-	err := wrapped(context.Background(), entry)
-	assert.NoError(t, err) // DLQ'd, returns nil.
-
-	pub.mu.Lock()
-	require.Len(t, pub.messages, 1)
-	assert.Equal(t, "orders.created.dlq", pub.messages[0].topic)
-	pub.mu.Unlock()
+	res := wrapped(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionReject, res.Disposition) // Reject → DLX.
 }
 
 func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 	// Integration-style test: wire AsMiddleware into SubscriberWithMiddleware.
 	checker := newMockIdempotencyChecker()
-	pub := newMockPublisher()
 
-	cb := NewConsumerBase(checker, pub, ConsumerBaseConfig{
+	cb := NewConsumerBase(checker, ConsumerBaseConfig{
 		ConsumerGroup: "integration-group",
 	})
 
 	// Use a simple recording subscriber to verify the chain works end-to-end.
-	var capturedHandler func(context.Context, outbox.Entry) error
+	var capturedHandler outbox.EntryHandler
 	innerSub := &stubSubscriber{
-		onSubscribe: func(_ context.Context, _ string, h func(context.Context, outbox.Entry) error) error {
+		onSubscribe: func(_ context.Context, _ string, h outbox.EntryHandler) error {
 			capturedHandler = h
 			return nil
 		},
@@ -1801,10 +1720,10 @@ func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 
 	var receivedEntry outbox.Entry
 	handlerCalled := false
-	handler := func(_ context.Context, e outbox.Entry) error {
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		receivedEntry = e
-		return nil
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
 	err := wrappedSub.Subscribe(context.Background(), "events.test", handler)
@@ -1813,8 +1732,8 @@ func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 
 	// Simulate an incoming entry.
 	entry := outbox.Entry{ID: "evt-integration-001", EventType: "events.test"}
-	err = capturedHandler(context.Background(), entry)
-	assert.NoError(t, err)
+	res := capturedHandler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.True(t, handlerCalled)
 	assert.Equal(t, "evt-integration-001", receivedEntry.ID)
 
@@ -1825,17 +1744,17 @@ func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 
 	// Calling again with the same event should be skipped.
 	handlerCalled = false
-	err = capturedHandler(context.Background(), entry)
-	assert.NoError(t, err)
+	res = capturedHandler(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.False(t, handlerCalled, "duplicate should be skipped by ConsumerBase middleware")
 }
 
 // stubSubscriber is a minimal Subscriber for integration tests.
 type stubSubscriber struct {
-	onSubscribe func(context.Context, string, func(context.Context, outbox.Entry) error) error
+	onSubscribe func(context.Context, string, outbox.EntryHandler) error
 }
 
-func (s *stubSubscriber) Subscribe(ctx context.Context, topic string, handler func(context.Context, outbox.Entry) error) error {
+func (s *stubSubscriber) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler) error {
 	if s.onSubscribe != nil {
 		return s.onSubscribe(ctx, topic, handler)
 	}

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -686,6 +686,7 @@ func TestSubscriber_Subscribe_ProcessesDelivery(t *testing.T) {
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test-queue",
 		PrefetchCount:   5,
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -747,6 +748,7 @@ func TestSubscriber_Subscribe_UnmarshalFailure_Nack(t *testing.T) {
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -787,6 +789,7 @@ func TestSubscriber_Subscribe_HandlerError_NackWithRequeue(t *testing.T) {
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -830,6 +833,7 @@ func TestSubscriber_Subscribe_DefaultQueueName(t *testing.T) {
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		// QueueName deliberately left empty.
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -846,7 +850,7 @@ func TestSubscriber_Subscribe_DefaultQueueName(t *testing.T) {
 
 func TestSubscriber_Close_Idempotent(t *testing.T) {
 	conn, _ := newTestConnection(t)
-	sub := NewSubscriber(conn, SubscriberConfig{})
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
 
 	assert.NoError(t, sub.Close())
 	assert.NoError(t, sub.Close()) // Second close is no-op.
@@ -854,7 +858,7 @@ func TestSubscriber_Close_Idempotent(t *testing.T) {
 
 func TestSubscriber_Subscribe_AfterClose(t *testing.T) {
 	conn, _ := newTestConnection(t)
-	sub := NewSubscriber(conn, SubscriberConfig{})
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
 
 	assert.NoError(t, sub.Close())
 
@@ -879,6 +883,7 @@ func TestSubscriber_DeliveryChannelClosed_TriggersReconnect(t *testing.T) {
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -947,6 +952,7 @@ func TestSubscriber_ReconnectLoop_CtxCancelledDuringWait(t *testing.T) {
 
 	sub := NewSubscriber(c, SubscriberConfig{
 		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 1 * time.Second,
 	})
 
@@ -1064,6 +1070,7 @@ func TestSubscriber_SubscribeOnce_AcquireChannelFails(t *testing.T) {
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 1 * time.Second,
 	})
 
@@ -1105,6 +1112,7 @@ func TestSubscriber_Subscribe_ClosedDuringReconnect(t *testing.T) {
 
 	sub := NewSubscriber(c, SubscriberConfig{
 		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 1 * time.Second,
 	})
 
@@ -1153,6 +1161,7 @@ func TestSubscriber_Subscribe_ConsumerGroupQueueName(t *testing.T) {
 	sub := NewSubscriber(conn, SubscriberConfig{
 		// QueueName deliberately left empty; ConsumerGroup is set.
 		ConsumerGroup:   "audit-core",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -1181,6 +1190,7 @@ func TestSubscriber_Subscribe_ExplicitQueueName_OverridesConsumerGroup(t *testin
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "my-explicit-queue",
 		ConsumerGroup:   "audit-core", // Should be ignored when QueueName is set.
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -1207,6 +1217,7 @@ func TestSubscriber_Subscribe_NoConsumerGroup_FallsBackToTopic(t *testing.T) {
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		// Both QueueName and ConsumerGroup empty — backward compat.
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -1281,29 +1292,18 @@ func TestSubscriber_Subscribe_DLXExchangeWithRoutingKey(t *testing.T) {
 	ch.mu.Unlock()
 }
 
-func TestSubscriber_Subscribe_NoDLX_NilArgs(t *testing.T) {
-	conn, mockConn := newTestConnection(t)
-
-	ch := newMockChannel()
-	mockConn.mu.Lock()
-	mockConn.nextCh = ch
-	mockConn.mu.Unlock()
+func TestSubscriber_Subscribe_NoDLX_ReturnsError(t *testing.T) {
+	conn, _ := newTestConnection(t)
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test-queue",
 		ShutdownTimeout: 2 * time.Second,
+		// DLXExchange deliberately left empty.
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
-	assert.NoError(t, err)
-
-	ch.mu.Lock()
-	require.Len(t, ch.queueDeclareArgs, 1)
-	assert.Nil(t, ch.queueDeclareArgs[0], "queue args should be nil when DLX is not configured")
-	ch.mu.Unlock()
+	err := sub.Subscribe(context.Background(), "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DLXExchange is required")
 }
 
 // =============================================================================
@@ -1578,6 +1578,7 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithRequeue(t *testing.T) {
 
 	sub := NewSubscriber(conn, SubscriberConfig{
 		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -1985,6 +1986,7 @@ func TestProcessDelivery_Ack_CommitsReceipt(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -2022,6 +2024,7 @@ func TestProcessDelivery_Reject_ReleasesReceipt(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -2064,6 +2067,7 @@ func TestProcessDelivery_NilReceipt_NoPanic(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -2094,6 +2098,7 @@ func TestProcessDelivery_Receipt_UsesDetachedCtx(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -2133,6 +2138,7 @@ func TestProcessDelivery_Requeue_ReleasesReceipt(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 
@@ -2166,37 +2172,18 @@ func TestProcessDelivery_Requeue_ReleasesReceipt(t *testing.T) {
 	receipt.mu.Unlock()
 }
 
-func TestProcessDelivery_Reject_NoDLX_LogsError(t *testing.T) {
-	conn, mockConn := newTestConnection(t)
-	ch := newMockChannel()
-	mockConn.mu.Lock()
-	mockConn.nextCh = ch
-	mockConn.mu.Unlock()
+func TestProcessDelivery_Reject_NoDLX_SubscribeReturnsError(t *testing.T) {
+	conn, _ := newTestConnection(t)
 
-	// No DLXExchange configured.
+	// No DLXExchange configured — Subscribe should fail before any delivery processing.
 	sub := NewSubscriber(conn, SubscriberConfig{
 		ShutdownTimeout: 2 * time.Second,
+		// DLXExchange deliberately left empty.
 	})
 
-	entry := outbox.Entry{ID: "evt-no-dlx", EventType: "test.nodlx"}
-	entryBytes, err := json.Marshal(entry)
-	require.NoError(t, err)
-
-	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-		return outbox.HandleResult{Disposition: outbox.DispositionReject, Err: errors.New("permanent")}
-	}
-
-	sub.wg.Add(1)
-	sub.processDelivery(context.Background(), ch, amqp.Delivery{
-		DeliveryTag: 11,
-		Body:        entryBytes,
-	}, "test.topic", handler)
-
-	// Verify Nack without requeue was called (message will be discarded since no DLX).
-	ch.mu.Lock()
-	assert.True(t, ch.nackCalled)
-	assert.False(t, ch.nackRequeue)
-	ch.mu.Unlock()
+	err := sub.Subscribe(context.Background(), "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DLXExchange is required")
 }
 
 func TestConsumerBase_WrapWithClaimer_ClaimBusy_HasBackoff(t *testing.T) {
@@ -2229,6 +2216,7 @@ func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	sub := NewSubscriber(conn, SubscriberConfig{
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 2 * time.Second,
 	})
 

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -2125,6 +2125,101 @@ func TestProcessDelivery_Receipt_UsesDetachedCtx(t *testing.T) {
 	receipt.mu.Unlock()
 }
 
+func TestProcessDelivery_Requeue_ReleasesReceipt(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{}
+	entry := outbox.Entry{ID: "evt-requeue-receipt", EventType: "test.requeue"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionRequeue,
+			Err:         errors.New("transient"),
+			Receipt:     receipt,
+		}
+	}
+
+	sub.wg.Add(1)
+	sub.processDelivery(context.Background(), ch, amqp.Delivery{
+		DeliveryTag: 10,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	ch.mu.Lock()
+	assert.True(t, ch.nackCalled)
+	assert.True(t, ch.nackRequeue)
+	ch.mu.Unlock()
+
+	receipt.mu.Lock()
+	assert.False(t, receipt.commitCalled, "Requeue should not Commit")
+	assert.True(t, receipt.releaseCalled, "Requeue should Release Receipt")
+	receipt.mu.Unlock()
+}
+
+func TestProcessDelivery_Reject_NoDLX_LogsError(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	// No DLXExchange configured.
+	sub := NewSubscriber(conn, SubscriberConfig{
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	entry := outbox.Entry{ID: "evt-no-dlx", EventType: "test.nodlx"}
+	entryBytes, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionReject, Err: errors.New("permanent")}
+	}
+
+	sub.wg.Add(1)
+	sub.processDelivery(context.Background(), ch, amqp.Delivery{
+		DeliveryTag: 11,
+		Body:        entryBytes,
+	}, "test.topic", handler)
+
+	// Verify Nack without requeue was called (message will be discarded since no DLX).
+	ch.mu.Lock()
+	assert.True(t, ch.nackCalled)
+	assert.False(t, ch.nackRequeue)
+	ch.mu.Unlock()
+}
+
+func TestConsumerBase_WrapWithClaimer_ClaimBusy_HasBackoff(t *testing.T) {
+	claimer := &mockClaimer{state: idempotency.ClaimBusy}
+
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryBaseDelay: 50 * time.Millisecond,
+	})
+
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		t.Fatal("handler should not be called for ClaimBusy")
+		return outbox.HandleResult{}
+	})
+
+	start := time.Now()
+	res := handler(context.Background(), outbox.Entry{ID: "evt-busy-backoff"})
+	elapsed := time.Since(start)
+
+	assert.Equal(t, outbox.DispositionRequeue, res.Disposition)
+	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond, "ClaimBusy should backoff before requeue")
+}
+
 func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 	ch := newMockChannel()

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -262,15 +262,12 @@ func (s *Subscriber) subscribeOnce(
 	}
 
 	// Build queue arguments for dead-letter routing.
-	// DLXExchange is guaranteed non-empty here (validated in Subscribe).
-	var queueArgs amqp.Table
-	if s.config.DLXExchange != "" {
-		queueArgs = amqp.Table{
-			"x-dead-letter-exchange": s.config.DLXExchange,
-		}
-		if s.config.DLXRoutingKey != "" {
-			queueArgs["x-dead-letter-routing-key"] = s.config.DLXRoutingKey
-		}
+	// DLXExchange is guaranteed non-empty (validated in Subscribe).
+	queueArgs := amqp.Table{
+		"x-dead-letter-exchange": s.config.DLXExchange,
+	}
+	if s.config.DLXRoutingKey != "" {
+		queueArgs["x-dead-letter-routing-key"] = s.config.DLXRoutingKey
 	}
 
 	// Declare queue.
@@ -434,12 +431,14 @@ func (s *Subscriber) processDelivery(
 	}
 
 	// Commit or release the idempotency receipt based on broker outcome.
-	// Use WithoutCancel: broker Ack/Nack already succeeded, idempotency
-	// state must be persisted even during graceful shutdown.
+	// Use WithoutCancel + timeout: broker Ack/Nack already succeeded,
+	// idempotency state must be persisted even during graceful shutdown,
+	// but must not block indefinitely on network partitions.
 	if res.Receipt == nil {
 		return
 	}
-	receiptCtx := context.WithoutCancel(ctx)
+	receiptCtx, receiptCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer receiptCancel()
 	if brokerErr != nil {
 		// Broker disposition failed — release so redelivery can re-enter.
 		if relErr := res.Receipt.Release(receiptCtx); relErr != nil {

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -141,10 +141,10 @@ func (s *Subscriber) resolveQueueName(topic string) string {
 // or defaulting to the topic) is declared and bound to the exchange.
 //
 // Consumer: cg-{QueueName}-{topic}
-// Idempotency key: handled by ConsumerBase (not in Subscriber)
-// ACK timing: after handler returns nil
-// Retry: transient errors -> NACK+requeue / permanent errors -> handled by ConsumerBase DLQ
-func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler func(context.Context, outbox.Entry) error) error {
+// Idempotency key: handled by ConsumerBase middleware (not in Subscriber)
+// ACK timing: after handler returns DispositionAck
+// Retry: DispositionRequeue -> NACK+requeue / DispositionReject -> NACK(no-requeue) → DLX
+func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler) error {
 	if s.closed.Load() {
 		return errcode.New(ErrAdapterAMQPSubscribe, "rabbitmq: subscriber is closed")
 	}
@@ -214,7 +214,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler func(c
 func (s *Subscriber) subscribeOnce(
 	ctx context.Context,
 	topic, queueName string,
-	handler func(context.Context, outbox.Entry) error,
+	handler outbox.EntryHandler,
 ) error {
 	ch, err := s.conn.AcquireChannel()
 	if err != nil {
@@ -322,7 +322,7 @@ func (s *Subscriber) consumeLoop(
 	ch AMQPChannel,
 	deliveries <-chan amqp.Delivery,
 	topic string,
-	handler func(context.Context, outbox.Entry) error,
+	handler outbox.EntryHandler,
 ) error {
 	for {
 		select {
@@ -354,7 +354,7 @@ func (s *Subscriber) processDelivery(
 	ch AMQPChannel,
 	delivery amqp.Delivery,
 	topic string,
-	handler func(context.Context, outbox.Entry) error,
+	handler outbox.EntryHandler,
 ) {
 	defer s.wg.Done()
 
@@ -379,42 +379,76 @@ func (s *Subscriber) processDelivery(
 	}
 	entry.Metadata["topic"] = topic
 
-	if err := handler(ctx, entry); err != nil {
-		// If the context is cancelled (shutdown), NACK with requeue so the broker
-		// redelivers the message to another consumer. Without DLX configured,
-		// requeue=false would silently discard the message.
-		if ctx.Err() != nil {
-			slog.Info("rabbitmq: context cancelled during handler, nacking with requeue",
+	// Solution B: handler returns HandleResult with explicit Disposition + Receipt.
+	res := handler(ctx, entry)
+
+	// Execute broker-level disposition.
+	var brokerErr error
+	switch res.Disposition {
+	case outbox.DispositionAck:
+		brokerErr = ch.Ack(delivery.DeliveryTag, false)
+		if brokerErr != nil {
+			slog.Error("rabbitmq: ack failed",
 				slog.String("topic", topic),
 				slog.String("event_id", entry.ID),
-				slog.String("error", err.Error()))
-			if nackErr := ch.Nack(delivery.DeliveryTag, false, true); nackErr != nil {
-				slog.Error("rabbitmq: nack failed",
-					slog.String("topic", topic),
-					slog.String("error", nackErr.Error()))
-			}
-			return
+				slog.String("error", brokerErr.Error()))
 		}
+	case outbox.DispositionReject:
+		brokerErr = ch.Nack(delivery.DeliveryTag, false, false)
+		if brokerErr != nil {
+			slog.Error("rabbitmq: nack(reject) failed",
+				slog.String("topic", topic),
+				slog.String("event_id", entry.ID),
+				slog.String("error", brokerErr.Error()))
+		}
+	case outbox.DispositionRequeue:
+		brokerErr = ch.Nack(delivery.DeliveryTag, false, true)
+		if brokerErr != nil {
+			slog.Error("rabbitmq: nack(requeue) failed",
+				slog.String("topic", topic),
+				slog.String("event_id", entry.ID),
+				slog.String("error", brokerErr.Error()))
+		}
+	}
 
-		// Handler error is a transient failure — NACK with requeue.
-		slog.Warn("rabbitmq: handler returned error, nacking with requeue",
+	// Log handler-level error if present (separate from broker error).
+	if res.Err != nil {
+		slog.Warn("rabbitmq: handler reported error",
 			slog.String("topic", topic),
 			slog.String("event_id", entry.ID),
-			slog.String("error", err.Error()))
-		if nackErr := ch.Nack(delivery.DeliveryTag, false, true); nackErr != nil {
-			slog.Error("rabbitmq: nack failed",
+			slog.String("disposition", res.Disposition.String()),
+			slog.String("error", res.Err.Error()))
+	}
+
+	// Commit or release the idempotency receipt based on broker outcome.
+	if res.Receipt == nil {
+		return
+	}
+	if brokerErr != nil {
+		// Broker disposition failed — release so redelivery can re-enter.
+		if relErr := res.Receipt.Release(ctx); relErr != nil {
+			slog.Error("rabbitmq: receipt release failed after broker error",
 				slog.String("topic", topic),
-				slog.String("error", nackErr.Error()))
+				slog.String("event_id", entry.ID),
+				slog.String("error", relErr.Error()))
 		}
 		return
 	}
-
-	// Handler succeeded — ACK.
-	if err := ch.Ack(delivery.DeliveryTag, false); err != nil {
-		slog.Error("rabbitmq: ack failed",
-			slog.String("topic", topic),
-			slog.String("event_id", entry.ID),
-			slog.String("error", err.Error()))
+	switch res.Disposition {
+	case outbox.DispositionAck, outbox.DispositionReject:
+		if commitErr := res.Receipt.Commit(ctx); commitErr != nil {
+			slog.Error("rabbitmq: receipt commit failed",
+				slog.String("topic", topic),
+				slog.String("event_id", entry.ID),
+				slog.String("error", commitErr.Error()))
+		}
+	case outbox.DispositionRequeue:
+		if relErr := res.Receipt.Release(ctx); relErr != nil {
+			slog.Error("rabbitmq: receipt release failed",
+				slog.String("topic", topic),
+				slog.String("event_id", entry.ID),
+				slog.String("error", relErr.Error()))
+		}
 	}
 }
 

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -256,6 +256,11 @@ func (s *Subscriber) subscribeOnce(
 	}
 
 	// Build queue arguments for dead-letter routing.
+	if s.config.DLXExchange == "" {
+		slog.Warn("rabbitmq: subscribing without DLX configured — Nack(requeue=false) will discard messages",
+			slog.String("topic", topic),
+			slog.String("queue", queueName))
+	}
 	var queueArgs amqp.Table
 	if s.config.DLXExchange != "" {
 		queueArgs = amqp.Table{
@@ -394,6 +399,11 @@ func (s *Subscriber) processDelivery(
 				slog.String("error", brokerErr.Error()))
 		}
 	case outbox.DispositionReject:
+		if s.config.DLXExchange == "" {
+			slog.Error("rabbitmq: rejecting message without DLX configured — message will be discarded by broker",
+				slog.String("topic", topic),
+				slog.String("event_id", entry.ID))
+		}
 		brokerErr = ch.Nack(delivery.DeliveryTag, false, false)
 		if brokerErr != nil {
 			slog.Error("rabbitmq: nack(reject) failed",
@@ -409,6 +419,12 @@ func (s *Subscriber) processDelivery(
 				slog.String("event_id", entry.ID),
 				slog.String("error", brokerErr.Error()))
 		}
+	default:
+		slog.Error("rabbitmq: unknown disposition, nacking with requeue",
+			slog.String("topic", topic),
+			slog.String("event_id", entry.ID),
+			slog.String("disposition", res.Disposition.String()))
+		brokerErr = ch.Nack(delivery.DeliveryTag, false, true)
 	}
 
 	// Log handler-level error if present (separate from broker error).
@@ -421,12 +437,15 @@ func (s *Subscriber) processDelivery(
 	}
 
 	// Commit or release the idempotency receipt based on broker outcome.
+	// Use WithoutCancel: broker Ack/Nack already succeeded, idempotency
+	// state must be persisted even during graceful shutdown.
 	if res.Receipt == nil {
 		return
 	}
+	receiptCtx := context.WithoutCancel(ctx)
 	if brokerErr != nil {
 		// Broker disposition failed — release so redelivery can re-enter.
-		if relErr := res.Receipt.Release(ctx); relErr != nil {
+		if relErr := res.Receipt.Release(receiptCtx); relErr != nil {
 			slog.Error("rabbitmq: receipt release failed after broker error",
 				slog.String("topic", topic),
 				slog.String("event_id", entry.ID),
@@ -435,16 +454,24 @@ func (s *Subscriber) processDelivery(
 		return
 	}
 	switch res.Disposition {
-	case outbox.DispositionAck, outbox.DispositionReject:
-		if commitErr := res.Receipt.Commit(ctx); commitErr != nil {
+	case outbox.DispositionAck:
+		if commitErr := res.Receipt.Commit(receiptCtx); commitErr != nil {
 			slog.Error("rabbitmq: receipt commit failed",
 				slog.String("topic", topic),
 				slog.String("event_id", entry.ID),
 				slog.String("error", commitErr.Error()))
 		}
-	case outbox.DispositionRequeue:
-		if relErr := res.Receipt.Release(ctx); relErr != nil {
+	case outbox.DispositionReject, outbox.DispositionRequeue:
+		// Reject releases (not commits) so DLQ replay can reprocess.
+		if relErr := res.Receipt.Release(receiptCtx); relErr != nil {
 			slog.Error("rabbitmq: receipt release failed",
+				slog.String("topic", topic),
+				slog.String("event_id", entry.ID),
+				slog.String("error", relErr.Error()))
+		}
+	default:
+		if relErr := res.Receipt.Release(receiptCtx); relErr != nil {
+			slog.Error("rabbitmq: receipt release failed (unknown disposition)",
 				slog.String("topic", topic),
 				slog.String("event_id", entry.ID),
 				slog.String("error", relErr.Error()))

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -261,8 +261,13 @@ func (s *Subscriber) subscribeOnce(
 		return setupErr("rabbitmq: declare exchange", ErrAdapterAMQPSubscribe, err)
 	}
 
+	// Declare the dead-letter exchange to ensure it exists before binding.
+	// Uses "direct" type so rejected messages are routed by DLXRoutingKey.
+	if err := ch.ExchangeDeclare(s.config.DLXExchange, "direct", true, false, false, false, nil); err != nil {
+		return setupErr("rabbitmq: declare DLX exchange", ErrAdapterAMQPSubscribe, err)
+	}
+
 	// Build queue arguments for dead-letter routing.
-	// DLXExchange is guaranteed non-empty (validated in Subscribe).
 	queueArgs := amqp.Table{
 		"x-dead-letter-exchange": s.config.DLXExchange,
 	}

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -148,6 +148,12 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler outbox
 	if s.closed.Load() {
 		return errcode.New(ErrAdapterAMQPSubscribe, "rabbitmq: subscriber is closed")
 	}
+	if s.config.DLXExchange == "" {
+		return errcode.New(ErrAdapterAMQPSubscribe,
+			"rabbitmq: DLXExchange is required — without a dead-letter exchange, "+
+				"Nack(requeue=false) silently discards messages. "+
+				"Set SubscriberConfig.DLXExchange to a valid DLX name")
+	}
 
 	// Derive a context that is cancelled when either the parent ctx is done or
 	// the subscriber is closed. This ensures WaitConnected unblocks promptly on
@@ -256,11 +262,7 @@ func (s *Subscriber) subscribeOnce(
 	}
 
 	// Build queue arguments for dead-letter routing.
-	if s.config.DLXExchange == "" {
-		slog.Warn("rabbitmq: subscribing without DLX configured — Nack(requeue=false) will discard messages",
-			slog.String("topic", topic),
-			slog.String("queue", queueName))
-	}
+	// DLXExchange is guaranteed non-empty here (validated in Subscribe).
 	var queueArgs amqp.Table
 	if s.config.DLXExchange != "" {
 		queueArgs = amqp.Table{
@@ -399,11 +401,6 @@ func (s *Subscriber) processDelivery(
 				slog.String("error", brokerErr.Error()))
 		}
 	case outbox.DispositionReject:
-		if s.config.DLXExchange == "" {
-			slog.Error("rabbitmq: rejecting message without DLX configured — message will be discarded by broker",
-				slog.String("topic", topic),
-				slog.String("event_id", entry.ID))
-		}
 		brokerErr = ch.Nack(delivery.DeliveryTag, false, false)
 		if brokerErr != nil {
 			slog.Error("rabbitmq: nack(reject) failed",

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -435,47 +435,49 @@ func (s *Subscriber) processDelivery(
 			slog.String("error", res.Err.Error()))
 	}
 
-	// Commit or release the idempotency receipt based on broker outcome.
-	// Use WithoutCancel + timeout: broker Ack/Nack already succeeded,
-	// idempotency state must be persisted even during graceful shutdown,
-	// but must not block indefinitely on network partitions.
+	s.settleReceipt(ctx, res, topic, entry.ID, brokerErr)
+}
+
+// settleReceipt commits or releases the idempotency receipt after the broker
+// Ack/Nack outcome is known. Uses a detached context with a 5s timeout so
+// the operation completes even during graceful shutdown.
+func (s *Subscriber) settleReceipt(
+	ctx context.Context,
+	res outbox.HandleResult,
+	topic, eventID string,
+	brokerErr error,
+) {
 	if res.Receipt == nil {
 		return
 	}
-	receiptCtx, receiptCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer receiptCancel()
+	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
 	if brokerErr != nil {
-		// Broker disposition failed — release so redelivery can re-enter.
-		if relErr := res.Receipt.Release(receiptCtx); relErr != nil {
+		if relErr := res.Receipt.Release(rctx); relErr != nil {
 			slog.Error("rabbitmq: receipt release failed after broker error",
 				slog.String("topic", topic),
-				slog.String("event_id", entry.ID),
+				slog.String("event_id", eventID),
 				slog.String("error", relErr.Error()))
 		}
 		return
 	}
+
 	switch res.Disposition {
 	case outbox.DispositionAck:
-		if commitErr := res.Receipt.Commit(receiptCtx); commitErr != nil {
+		if err := res.Receipt.Commit(rctx); err != nil {
 			slog.Error("rabbitmq: receipt commit failed",
 				slog.String("topic", topic),
-				slog.String("event_id", entry.ID),
-				slog.String("error", commitErr.Error()))
-		}
-	case outbox.DispositionReject, outbox.DispositionRequeue:
-		// Reject releases (not commits) so DLQ replay can reprocess.
-		if relErr := res.Receipt.Release(receiptCtx); relErr != nil {
-			slog.Error("rabbitmq: receipt release failed",
-				slog.String("topic", topic),
-				slog.String("event_id", entry.ID),
-				slog.String("error", relErr.Error()))
+				slog.String("event_id", eventID),
+				slog.String("error", err.Error()))
 		}
 	default:
-		if relErr := res.Receipt.Release(receiptCtx); relErr != nil {
-			slog.Error("rabbitmq: receipt release failed (unknown disposition)",
+		// Reject/Requeue/unknown — release so DLQ replay or redelivery can re-enter.
+		if err := res.Receipt.Release(rctx); err != nil {
+			slog.Error("rabbitmq: receipt release failed",
 				slog.String("topic", topic),
-				slog.String("event_id", entry.ID),
-				slog.String("error", relErr.Error()))
+				slog.String("event_id", eventID),
+				slog.String("error", err.Error()))
 		}
 	}
 }

--- a/src/adapters/redis/idempotency.go
+++ b/src/adapters/redis/idempotency.go
@@ -2,20 +2,27 @@ package redis
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/idempotency"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	goredis "github.com/redis/go-redis/v9"
 )
 
+// ---------------------------------------------------------------------------
+// IdempotencyChecker — legacy (Deprecated, retained for Checker interface)
+// ---------------------------------------------------------------------------
+
 // Compile-time interface check.
 var _ idempotency.Checker = (*IdempotencyChecker)(nil)
 
-// IdempotencyChecker implements kernel/idempotency.Checker using Redis
-// SET NX + TTL for atomic check-and-mark semantics.
+// Deprecated: IdempotencyChecker implements the legacy idempotency.Checker.
+// New code should use IdempotencyClaimer (two-phase Claim/Commit/Release).
 type IdempotencyChecker struct {
 	rdb cmdable
 }
@@ -89,4 +96,188 @@ func (ic *IdempotencyChecker) Release(ctx context.Context, key string) error {
 			fmt.Sprintf("redis: idempotency release failed (key=%s)", key), err)
 	}
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// IdempotencyClaimer — two-phase model (Solution B)
+// ---------------------------------------------------------------------------
+
+// Compile-time interface check.
+var _ idempotency.Claimer = (*IdempotencyClaimer)(nil)
+
+// IdempotencyClaimer implements idempotency.Claimer using a dual-key Lua
+// script model:
+//
+//   - lease:{key} — SET NX with leaseTTL, value = random token. Indicates "processing".
+//   - done:{key}  — SET with doneTTL, value = "1". Indicates "completed".
+//
+// Claim checks done first (ClaimDone), then attempts lease (ClaimAcquired or ClaimBusy).
+// Commit sets done + deletes lease. Release deletes lease (token-guarded).
+type IdempotencyClaimer struct {
+	rdb cmdable
+}
+
+// NewIdempotencyClaimer creates an IdempotencyClaimer using the given Client.
+func NewIdempotencyClaimer(client *Client) *IdempotencyClaimer {
+	return &IdempotencyClaimer{rdb: client.cmdable()}
+}
+
+// newIdempotencyClaimerFromCmdable creates an IdempotencyClaimer with a
+// pre-built cmdable for testing.
+func newIdempotencyClaimerFromCmdable(rdb cmdable) *IdempotencyClaimer {
+	return &IdempotencyClaimer{rdb: rdb}
+}
+
+// claimScript is the Lua script for atomic Claim:
+//
+//	KEYS[1] = done:{key}
+//	KEYS[2] = lease:{key}
+//	ARGV[1] = token
+//	ARGV[2] = leaseTTL (seconds)
+//	ARGV[3] = doneTTL  (seconds, used only for reference — not set here)
+//
+// Returns:
+//
+//	0 = ClaimDone     (done key exists)
+//	1 = ClaimAcquired (lease key set successfully)
+//	2 = ClaimBusy     (lease key already held by another consumer)
+const claimScript = `
+local done = redis.call('EXISTS', KEYS[1])
+if done == 1 then
+  return 0
+end
+local ok = redis.call('SET', KEYS[2], ARGV[1], 'NX', 'EX', ARGV[2])
+if ok then
+  return 1
+end
+return 2
+`
+
+// commitScript: atomic Commit (token-guarded):
+//
+//	KEYS[1] = lease:{key}
+//	KEYS[2] = done:{key}
+//	ARGV[1] = token
+//	ARGV[2] = doneTTL (seconds)
+//
+// Returns 1 on success, 0 if token mismatch (stale lease).
+const commitScript = `
+local val = redis.call('GET', KEYS[1])
+if val == ARGV[1] then
+  redis.call('DEL', KEYS[1])
+  redis.call('SET', KEYS[2], '1', 'EX', ARGV[2])
+  return 1
+end
+return 0
+`
+
+// releaseScript: atomic Release (token-guarded):
+//
+//	KEYS[1] = lease:{key}
+//	ARGV[1] = token
+//
+// Returns 1 on success, 0 if token mismatch.
+const releaseScript = `
+local val = redis.call('GET', KEYS[1])
+if val == ARGV[1] then
+  redis.call('DEL', KEYS[1])
+  return 1
+end
+return 0
+`
+
+// Claim attempts to acquire a processing lease for the given key.
+func (c *IdempotencyClaimer) Claim(ctx context.Context, key string, leaseTTL, doneTTL time.Duration) (idempotency.ClaimState, outbox.Receipt, error) {
+	if leaseTTL <= 0 {
+		leaseTTL = idempotency.DefaultLeaseTTL
+	}
+	if doneTTL <= 0 {
+		doneTTL = idempotency.DefaultTTL
+	}
+
+	token, err := claimToken()
+	if err != nil {
+		return 0, nil, errcode.Wrap(ErrAdapterRedisSet,
+			fmt.Sprintf("redis: idempotency claim token generation failed (key=%s)", key), err)
+	}
+
+	leaseKey := "lease:" + key
+	doneKey := "done:" + key
+	leaseSec := int64(leaseTTL.Seconds())
+	if leaseSec < 1 {
+		leaseSec = 1
+	}
+
+	res, err := c.rdb.Eval(ctx, claimScript, []string{doneKey, leaseKey}, token, leaseSec).Result()
+	if err != nil {
+		return 0, nil, errcode.Wrap(ErrAdapterRedisSet,
+			fmt.Sprintf("redis: idempotency claim failed (key=%s)", key), err)
+	}
+
+	code, ok := res.(int64)
+	if !ok {
+		return 0, nil, errcode.New(ErrAdapterRedisGet,
+			fmt.Sprintf("redis: idempotency claim unexpected result type (key=%s)", key))
+	}
+
+	switch code {
+	case 0:
+		return idempotency.ClaimDone, nil, nil
+	case 1:
+		r := &redisReceipt{
+			rdb:      c.rdb,
+			leaseKey: leaseKey,
+			doneKey:  doneKey,
+			token:    token,
+			doneTTL:  doneTTL,
+		}
+		return idempotency.ClaimAcquired, r, nil
+	default:
+		return idempotency.ClaimBusy, nil, nil
+	}
+}
+
+// redisReceipt implements outbox.Receipt for the two-phase idempotency model.
+type redisReceipt struct {
+	rdb      cmdable
+	leaseKey string
+	doneKey  string
+	token    string
+	doneTTL  time.Duration
+}
+
+// Compile-time interface check.
+var _ outbox.Receipt = (*redisReceipt)(nil)
+
+// Commit marks the key as permanently done and removes the lease.
+func (r *redisReceipt) Commit(ctx context.Context) error {
+	doneSec := int64(r.doneTTL.Seconds())
+	if doneSec < 1 {
+		doneSec = 1
+	}
+	_, err := r.rdb.Eval(ctx, commitScript, []string{r.leaseKey, r.doneKey}, r.token, doneSec).Result()
+	if err != nil {
+		return errcode.Wrap(ErrAdapterRedisSet,
+			fmt.Sprintf("redis: idempotency commit failed (lease=%s)", r.leaseKey), err)
+	}
+	return nil
+}
+
+// Release removes the processing lease so a redelivered message can re-enter.
+func (r *redisReceipt) Release(ctx context.Context) error {
+	_, err := r.rdb.Eval(ctx, releaseScript, []string{r.leaseKey}, r.token).Result()
+	if err != nil {
+		return errcode.Wrap(ErrAdapterRedisDelete,
+			fmt.Sprintf("redis: idempotency release failed (lease=%s)", r.leaseKey), err)
+	}
+	return nil
+}
+
+// claimToken generates a 16-byte hex-encoded token for lease ownership.
+func claimToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }

--- a/src/adapters/redis/idempotency.go
+++ b/src/adapters/redis/idempotency.go
@@ -255,20 +255,30 @@ func (r *redisReceipt) Commit(ctx context.Context) error {
 	if doneSec < 1 {
 		doneSec = 1
 	}
-	_, err := r.rdb.Eval(ctx, commitScript, []string{r.leaseKey, r.doneKey}, r.token, doneSec).Result()
+	res, err := r.rdb.Eval(ctx, commitScript, []string{r.leaseKey, r.doneKey}, r.token, doneSec).Result()
 	if err != nil {
 		return errcode.Wrap(ErrAdapterRedisSet,
 			fmt.Sprintf("redis: idempotency commit failed (lease=%s)", r.leaseKey), err)
+	}
+	code, ok := res.(int64)
+	if !ok || code == 0 {
+		return errcode.New(ErrAdapterRedisSet,
+			fmt.Sprintf("redis: idempotency commit token mismatch (stale lease, key=%s)", r.leaseKey))
 	}
 	return nil
 }
 
 // Release removes the processing lease so a redelivered message can re-enter.
 func (r *redisReceipt) Release(ctx context.Context) error {
-	_, err := r.rdb.Eval(ctx, releaseScript, []string{r.leaseKey}, r.token).Result()
+	res, err := r.rdb.Eval(ctx, releaseScript, []string{r.leaseKey}, r.token).Result()
 	if err != nil {
 		return errcode.Wrap(ErrAdapterRedisDelete,
 			fmt.Sprintf("redis: idempotency release failed (lease=%s)", r.leaseKey), err)
+	}
+	code, ok := res.(int64)
+	if !ok || code == 0 {
+		return errcode.New(ErrAdapterRedisDelete,
+			fmt.Sprintf("redis: idempotency release token mismatch (stale lease, key=%s)", r.leaseKey))
 	}
 	return nil
 }

--- a/src/adapters/redis/idempotency.go
+++ b/src/adapters/redis/idempotency.go
@@ -134,7 +134,6 @@ func newIdempotencyClaimerFromCmdable(rdb cmdable) *IdempotencyClaimer {
 //	KEYS[2] = lease:{key}
 //	ARGV[1] = token
 //	ARGV[2] = leaseTTL (seconds)
-//	ARGV[3] = doneTTL  (seconds, used only for reference — not set here)
 //
 // Returns:
 //

--- a/src/adapters/redis/idempotency_test.go
+++ b/src/adapters/redis/idempotency_test.go
@@ -173,6 +173,36 @@ func TestIdempotencyChecker_NegativeTTLUsesDefault(t *testing.T) {
 	assert.False(t, entry.expiry.IsZero(), "negative TTL should use DefaultTTL")
 }
 
+func TestIdempotencyChecker_Release_Success(t *testing.T) {
+	mock := newMockCmdable()
+	ic := newIdempotencyCheckerFromCmdable(mock)
+	ctx := context.Background()
+
+	// Mark a key as processed.
+	err := ic.MarkProcessed(ctx, "idem:test:release:1", 24*time.Hour)
+	require.NoError(t, err)
+
+	// Release the key.
+	err = ic.Release(ctx, "idem:test:release:1")
+	require.NoError(t, err)
+
+	// After release, IsProcessed should return false.
+	ok, err := ic.IsProcessed(ctx, "idem:test:release:1")
+	require.NoError(t, err)
+	assert.False(t, ok, "key should not be processed after Release")
+}
+
+func TestIdempotencyChecker_Release_DelError(t *testing.T) {
+	mock := newMockCmdable()
+	mock.delErr = errMock
+	ic := newIdempotencyCheckerFromCmdable(mock)
+	ctx := context.Background()
+
+	err := ic.Release(ctx, "idem:test:release:err")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_REDIS_DELETE")
+}
+
 // =============================================================================
 // IdempotencyClaimer Tests (Solution B two-phase model)
 // =============================================================================

--- a/src/adapters/redis/idempotency_test.go
+++ b/src/adapters/redis/idempotency_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -395,4 +396,49 @@ func TestIdempotencyClaimer_ViaClientConstructor(t *testing.T) {
 	state, _, err := claimer.Claim(ctx, "idem:client:1", 5*time.Minute, 24*time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimAcquired, state)
+}
+
+func TestIdempotencyClaimer_Claim_Concurrent_OneAcquiredOneBusy(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	type result struct {
+		state   idempotency.ClaimState
+		receipt interface{} // non-nil check only
+		err     error
+	}
+
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			state, receipt, err := claimer.Claim(ctx, "idem:concurrent:1", 5*time.Minute, 24*time.Hour)
+			results <- result{state: state, receipt: receipt, err: err}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	var acquired, busy int
+	for r := range results {
+		require.NoError(t, r.err)
+		switch r.state {
+		case idempotency.ClaimAcquired:
+			acquired++
+			assert.NotNil(t, r.receipt, "ClaimAcquired must return a non-nil receipt")
+		case idempotency.ClaimBusy:
+			busy++
+			assert.Nil(t, r.receipt, "ClaimBusy must return nil receipt")
+		default:
+			t.Fatalf("unexpected ClaimState %d", r.state)
+		}
+	}
+
+	assert.Equal(t, 1, acquired, "exactly one goroutine should acquire the lease")
+	assert.Equal(t, 1, busy, "exactly one goroutine should get ClaimBusy")
 }

--- a/src/adapters/redis/idempotency_test.go
+++ b/src/adapters/redis/idempotency_test.go
@@ -171,3 +171,184 @@ func TestIdempotencyChecker_NegativeTTLUsesDefault(t *testing.T) {
 	require.True(t, ok)
 	assert.False(t, entry.expiry.IsZero(), "negative TTL should use DefaultTTL")
 }
+
+// =============================================================================
+// IdempotencyClaimer Tests (Solution B two-phase model)
+// =============================================================================
+
+// Compile-time interface check for the new Claimer.
+var _ idempotency.Claimer = (*IdempotencyClaimer)(nil)
+
+func TestIdempotencyClaimer_Claim_Acquired(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	state, receipt, err := claimer.Claim(ctx, "idem:claim:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, idempotency.ClaimAcquired, state)
+	assert.NotNil(t, receipt)
+
+	// Verify the lease key was set.
+	mock.mu.Lock()
+	_, hasLease := mock.store["lease:idem:claim:1"]
+	mock.mu.Unlock()
+	assert.True(t, hasLease)
+}
+
+func TestIdempotencyClaimer_Claim_Done(t *testing.T) {
+	mock := newClaimerMock()
+	ctx := context.Background()
+
+	// Pre-set the done key to simulate a previously completed processing.
+	mock.mu.Lock()
+	mock.store["done:idem:claim:2"] = mockEntry{value: "1"}
+	mock.mu.Unlock()
+
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	state, receipt, err := claimer.Claim(ctx, "idem:claim:2", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, idempotency.ClaimDone, state)
+	assert.Nil(t, receipt)
+}
+
+func TestIdempotencyClaimer_Claim_Busy(t *testing.T) {
+	mock := newClaimerMock()
+	ctx := context.Background()
+
+	// Pre-set the lease key to simulate another consumer processing.
+	mock.mu.Lock()
+	mock.store["lease:idem:claim:3"] = mockEntry{value: "other-token", expiry: time.Now().Add(5 * time.Minute)}
+	mock.mu.Unlock()
+
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	state, receipt, err := claimer.Claim(ctx, "idem:claim:3", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, idempotency.ClaimBusy, state)
+	assert.Nil(t, receipt)
+}
+
+func TestIdempotencyClaimer_Receipt_Commit(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	state, receipt, err := claimer.Claim(ctx, "idem:commit:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, idempotency.ClaimAcquired, state)
+	require.NotNil(t, receipt)
+
+	// Commit should set done key and remove lease key.
+	err = receipt.Commit(ctx)
+	require.NoError(t, err)
+
+	mock.mu.Lock()
+	_, hasLease := mock.store["lease:idem:commit:1"]
+	doneEntry, hasDone := mock.store["done:idem:commit:1"]
+	mock.mu.Unlock()
+
+	assert.False(t, hasLease, "lease key should be deleted after commit")
+	assert.True(t, hasDone, "done key should exist after commit")
+	assert.Equal(t, "1", doneEntry.value)
+}
+
+func TestIdempotencyClaimer_Receipt_Release(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	state, receipt, err := claimer.Claim(ctx, "idem:release:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, idempotency.ClaimAcquired, state)
+	require.NotNil(t, receipt)
+
+	// Release should remove lease key without setting done.
+	err = receipt.Release(ctx)
+	require.NoError(t, err)
+
+	mock.mu.Lock()
+	_, hasLease := mock.store["lease:idem:release:1"]
+	_, hasDone := mock.store["done:idem:release:1"]
+	mock.mu.Unlock()
+
+	assert.False(t, hasLease, "lease key should be deleted after release")
+	assert.False(t, hasDone, "done key should NOT exist after release")
+}
+
+func TestIdempotencyClaimer_After_Commit_Claim_Returns_Done(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	// First claim.
+	state, receipt, err := claimer.Claim(ctx, "idem:full:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, idempotency.ClaimAcquired, state)
+
+	// Commit.
+	err = receipt.Commit(ctx)
+	require.NoError(t, err)
+
+	// Second claim should return ClaimDone.
+	state, receipt2, err := claimer.Claim(ctx, "idem:full:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, idempotency.ClaimDone, state)
+	assert.Nil(t, receipt2)
+}
+
+func TestIdempotencyClaimer_After_Release_Claim_Reacquires(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	// First claim.
+	state, receipt, err := claimer.Claim(ctx, "idem:reacq:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, idempotency.ClaimAcquired, state)
+
+	// Release.
+	err = receipt.Release(ctx)
+	require.NoError(t, err)
+
+	// Second claim should re-acquire (not Done or Busy).
+	state, receipt2, err := claimer.Claim(ctx, "idem:reacq:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, idempotency.ClaimAcquired, state)
+	assert.NotNil(t, receipt2)
+}
+
+func TestIdempotencyClaimer_Claim_DefaultTTL(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	// Pass zero TTLs — should use defaults.
+	state, receipt, err := claimer.Claim(ctx, "idem:default-ttl:1", 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, idempotency.ClaimAcquired, state)
+	assert.NotNil(t, receipt)
+}
+
+func TestIdempotencyClaimer_Claim_EvalError(t *testing.T) {
+	mock := newClaimerMock()
+	mock.evalErr = errMock
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	state, receipt, err := claimer.Claim(ctx, "idem:err:1", 5*time.Minute, 24*time.Hour)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_REDIS_SET")
+	assert.Equal(t, idempotency.ClaimState(0), state)
+	assert.Nil(t, receipt)
+}
+
+func TestIdempotencyClaimer_ViaClientConstructor(t *testing.T) {
+	mock := newClaimerMock()
+	client := newClientFromCmdable(mock, Config{})
+	claimer := NewIdempotencyClaimer(client)
+	ctx := context.Background()
+
+	state, _, err := claimer.Claim(ctx, "idem:client:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, idempotency.ClaimAcquired, state)
+}

--- a/src/adapters/redis/idempotency_test.go
+++ b/src/adapters/redis/idempotency_test.go
@@ -342,6 +342,50 @@ func TestIdempotencyClaimer_Claim_EvalError(t *testing.T) {
 	assert.Nil(t, receipt)
 }
 
+func TestIdempotencyClaimer_Receipt_Commit_StaleToken(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	state, receipt, err := claimer.Claim(ctx, "idem:stale-commit:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, idempotency.ClaimAcquired, state)
+	require.NotNil(t, receipt)
+
+	// Simulate lease expiry by deleting the lease key from the store.
+	mock.mu.Lock()
+	delete(mock.store, "lease:idem:stale-commit:1")
+	mock.mu.Unlock()
+
+	// Commit should fail with stale lease error.
+	err = receipt.Commit(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_REDIS_SET")
+	assert.Contains(t, err.Error(), "stale lease")
+}
+
+func TestIdempotencyClaimer_Receipt_Release_StaleToken(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	state, receipt, err := claimer.Claim(ctx, "idem:stale-release:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, idempotency.ClaimAcquired, state)
+	require.NotNil(t, receipt)
+
+	// Simulate lease expiry by deleting the lease key from the store.
+	mock.mu.Lock()
+	delete(mock.store, "lease:idem:stale-release:1")
+	mock.mu.Unlock()
+
+	// Release should fail with stale lease error.
+	err = receipt.Release(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_ADAPTER_REDIS_DELETE")
+	assert.Contains(t, err.Error(), "stale lease")
+}
+
 func TestIdempotencyClaimer_ViaClientConstructor(t *testing.T) {
 	mock := newClaimerMock()
 	client := newClientFromCmdable(mock, Config{})

--- a/src/adapters/redis/mock_test.go
+++ b/src/adapters/redis/mock_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -205,3 +206,92 @@ func toInt64(v any) (int64, bool) {
 
 // errMock is a sentinel error used in tests.
 var errMock = errors.New("mock error")
+
+// claimerMockCmdable extends mockCmdable with Eval behavior that simulates
+// the IdempotencyClaimer's Lua scripts (claim, commit, release).
+type claimerMockCmdable struct {
+	mockCmdable
+}
+
+func newClaimerMock() *claimerMockCmdable {
+	return &claimerMockCmdable{
+		mockCmdable: mockCmdable{
+			store: make(map[string]mockEntry),
+		},
+	}
+}
+
+// Eval overrides the base mock to simulate the claimer Lua scripts.
+// Distinguishes claim vs commit by key order:
+//   - Claim:   keys=[done:{k}, lease:{k}]  (keys[0] starts with "done:")
+//   - Commit:  keys=[lease:{k}, done:{k}]  (keys[0] starts with "lease:")
+//   - Release: keys=[lease:{k}]            (single key)
+func (m *claimerMockCmdable) Eval(_ context.Context, _ string, keys []string, args ...any) *goredis.Cmd {
+	cmd := goredis.NewCmd(context.Background())
+	if m.evalErr != nil {
+		cmd.SetErr(m.evalErr)
+		return cmd
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch {
+	// Release script: 1 key (leaseKey), 1 arg (token)
+	case len(keys) == 1 && len(args) == 1:
+		leaseKey := keys[0]
+		token := toString(args[0])
+		if entry, ok := m.store[leaseKey]; ok && entry.value == token {
+			delete(m.store, leaseKey)
+			cmd.SetVal(int64(1))
+		} else {
+			cmd.SetVal(int64(0))
+		}
+		return cmd
+
+	// Claim script: 2 keys, keys[0] starts with "done:"
+	case len(keys) == 2 && len(args) >= 2 && strings.HasPrefix(keys[0], "done:"):
+		doneKey, leaseKey := keys[0], keys[1]
+		token := toString(args[0])
+		leaseSec, _ := toInt64(args[1])
+
+		if _, ok := m.store[doneKey]; ok {
+			cmd.SetVal(int64(0)) // ClaimDone
+			return cmd
+		}
+		if entry, ok := m.store[leaseKey]; ok {
+			if entry.expiry.IsZero() || time.Now().Before(entry.expiry) {
+				cmd.SetVal(int64(2)) // ClaimBusy
+				return cmd
+			}
+			delete(m.store, leaseKey) // expired
+		}
+		m.store[leaseKey] = mockEntry{
+			value:  token,
+			expiry: time.Now().Add(time.Duration(leaseSec) * time.Second),
+		}
+		cmd.SetVal(int64(1)) // ClaimAcquired
+		return cmd
+
+	// Commit script: 2 keys, keys[0] starts with "lease:"
+	case len(keys) == 2 && len(args) == 2 && strings.HasPrefix(keys[0], "lease:"):
+		leaseKey, doneKey := keys[0], keys[1]
+		token := toString(args[0])
+		doneSec, _ := toInt64(args[1])
+
+		if entry, ok := m.store[leaseKey]; ok && entry.value == token {
+			delete(m.store, leaseKey)
+			m.store[doneKey] = mockEntry{
+				value:  "1",
+				expiry: time.Now().Add(time.Duration(doneSec) * time.Second),
+			}
+			cmd.SetVal(int64(1))
+		} else {
+			cmd.SetVal(int64(0))
+		}
+		return cmd
+
+	default:
+		cmd.SetVal(int64(0))
+		return cmd
+	}
+}

--- a/src/cells/access-core/cell.go
+++ b/src/cells/access-core/cell.go
@@ -245,6 +245,6 @@ func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
 
 // RegisterSubscriptions is a no-op for access-core in Phase 2.
 // Future: subscribe to cross-cell events if needed.
-func (c *AccessCore) RegisterSubscriptions(_ outbox.Subscriber) {
-	// No subscriptions in Phase 2.
+func (c *AccessCore) RegisterSubscriptions(_ outbox.Subscriber) error {
+	return nil
 }

--- a/src/cells/audit-core/cell.go
+++ b/src/cells/audit-core/cell.go
@@ -4,8 +4,10 @@ package auditcore
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
@@ -167,16 +169,29 @@ func (c *AuditCore) RegisterRoutes(mux cell.RouteMux) {
 }
 
 // RegisterSubscriptions registers event subscriptions for all 6 topics.
-func (c *AuditCore) RegisterSubscriptions(sub outbox.Subscriber) {
+// Returns an error if any subscription fails during setup (e.g., missing DLX).
+// Long-running consumption loops are started in background goroutines.
+func (c *AuditCore) RegisterSubscriptions(sub outbox.Subscriber) error {
 	handler := outbox.WrapLegacyHandler(c.appendSvc.HandleEvent)
 	for _, topic := range auditappend.Topics {
 		topic := topic
+		errCh := make(chan error, 1)
 		go func() {
 			ctx := context.Background()
-			if err := sub.Subscribe(ctx, topic, handler); err != nil {
-				c.logger.Error("audit-core: subscription failed — consumer NOT running for this topic",
-					slog.Any("error", err), slog.String("topic", topic))
-			}
+			errCh <- sub.Subscribe(ctx, topic, handler)
 		}()
+
+		// Subscribe returns immediately on config errors (DLX missing, closed).
+		// On success it blocks — a short wait distinguishes the two.
+		select {
+		case err := <-errCh:
+			if err != nil {
+				return fmt.Errorf("audit-core: subscription setup failed for topic %s: %w", topic, err)
+			}
+			// Subscribe returned nil without blocking — clean shutdown, not an error.
+		case <-time.After(100 * time.Millisecond):
+			// Subscribe is blocking (consuming) — setup succeeded.
+		}
 	}
+	return nil
 }

--- a/src/cells/audit-core/cell.go
+++ b/src/cells/audit-core/cell.go
@@ -174,7 +174,7 @@ func (c *AuditCore) RegisterSubscriptions(sub outbox.Subscriber) {
 		go func() {
 			ctx := context.Background()
 			if err := sub.Subscribe(ctx, topic, handler); err != nil {
-				c.logger.Error("audit-core: subscription ended",
+				c.logger.Error("audit-core: subscription failed — consumer NOT running for this topic",
 					slog.Any("error", err), slog.String("topic", topic))
 			}
 		}()

--- a/src/cells/audit-core/cell.go
+++ b/src/cells/audit-core/cell.go
@@ -168,11 +168,12 @@ func (c *AuditCore) RegisterRoutes(mux cell.RouteMux) {
 
 // RegisterSubscriptions registers event subscriptions for all 6 topics.
 func (c *AuditCore) RegisterSubscriptions(sub outbox.Subscriber) {
+	handler := outbox.WrapLegacyHandler(c.appendSvc.HandleEvent)
 	for _, topic := range auditappend.Topics {
 		topic := topic
 		go func() {
 			ctx := context.Background()
-			if err := sub.Subscribe(ctx, topic, c.appendSvc.HandleEvent); err != nil {
+			if err := sub.Subscribe(ctx, topic, handler); err != nil {
 				c.logger.Error("audit-core: subscription ended",
 					slog.Any("error", err), slog.String("topic", topic))
 			}

--- a/src/cells/config-core/cell.go
+++ b/src/cells/config-core/cell.go
@@ -178,7 +178,7 @@ func (c *ConfigCore) RegisterSubscriptions(sub outbox.Subscriber) {
 		ctx := context.Background()
 		handler := outbox.WrapLegacyHandler(c.subscribeSvc.HandleEvent)
 		if err := sub.Subscribe(ctx, configsubscribe.TopicConfigChanged, handler); err != nil {
-			c.logger.Error("config-subscribe: subscription ended",
+			c.logger.Error("config-subscribe: subscription failed — consumer NOT running",
 				slog.Any("error", err))
 		}
 	}()

--- a/src/cells/config-core/cell.go
+++ b/src/cells/config-core/cell.go
@@ -4,8 +4,10 @@ package configcore
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
@@ -173,13 +175,22 @@ func (c *ConfigCore) RegisterRoutes(mux cell.RouteMux) {
 }
 
 // RegisterSubscriptions registers event subscriptions for config-core.
-func (c *ConfigCore) RegisterSubscriptions(sub outbox.Subscriber) {
+// Returns an error if subscription setup fails (e.g., missing DLX).
+func (c *ConfigCore) RegisterSubscriptions(sub outbox.Subscriber) error {
+	handler := outbox.WrapLegacyHandler(c.subscribeSvc.HandleEvent)
+	errCh := make(chan error, 1)
 	go func() {
 		ctx := context.Background()
-		handler := outbox.WrapLegacyHandler(c.subscribeSvc.HandleEvent)
-		if err := sub.Subscribe(ctx, configsubscribe.TopicConfigChanged, handler); err != nil {
-			c.logger.Error("config-subscribe: subscription failed — consumer NOT running",
-				slog.Any("error", err))
-		}
+		errCh <- sub.Subscribe(ctx, configsubscribe.TopicConfigChanged, handler)
 	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("config-subscribe: subscription setup failed: %w", err)
+		}
+		return nil
+	case <-time.After(100 * time.Millisecond):
+		return nil // Subscribe is blocking (consuming) — setup succeeded.
+	}
 }

--- a/src/cells/config-core/cell.go
+++ b/src/cells/config-core/cell.go
@@ -176,7 +176,8 @@ func (c *ConfigCore) RegisterRoutes(mux cell.RouteMux) {
 func (c *ConfigCore) RegisterSubscriptions(sub outbox.Subscriber) {
 	go func() {
 		ctx := context.Background()
-		if err := sub.Subscribe(ctx, configsubscribe.TopicConfigChanged, c.subscribeSvc.HandleEvent); err != nil {
+		handler := outbox.WrapLegacyHandler(c.subscribeSvc.HandleEvent)
+		if err := sub.Subscribe(ctx, configsubscribe.TopicConfigChanged, handler); err != nil {
 			c.logger.Error("config-subscribe: subscription ended",
 				slog.Any("error", err))
 		}

--- a/src/kernel/cell/registrar.go
+++ b/src/kernel/cell/registrar.go
@@ -66,6 +66,10 @@ type HTTPRegistrar interface {
 }
 
 // EventRegistrar is optionally implemented by Cells that subscribe to events.
+// RegisterSubscriptions MUST validate subscription setup (e.g., DLX config)
+// synchronously and return an error if any subscription cannot be established.
+// Long-running consumption loops should be started in background goroutines
+// only after validation succeeds.
 type EventRegistrar interface {
-	RegisterSubscriptions(sub outbox.Subscriber)
+	RegisterSubscriptions(sub outbox.Subscriber) error
 }

--- a/src/kernel/cell/registrar_test.go
+++ b/src/kernel/cell/registrar_test.go
@@ -63,7 +63,7 @@ type mockSubscriber struct {
 	topics []string
 }
 
-func (m *mockSubscriber) Subscribe(_ context.Context, topic string, _ func(context.Context, outbox.Entry) error) error {
+func (m *mockSubscriber) Subscribe(_ context.Context, topic string, _ outbox.EntryHandler) error {
 	m.topics = append(m.topics, topic)
 	return nil
 }
@@ -81,8 +81,8 @@ type eventCell struct {
 
 func (e *eventCell) RegisterSubscriptions(sub outbox.Subscriber) {
 	e.registered = true
-	_ = sub.Subscribe(context.Background(), "session.created", func(_ context.Context, _ outbox.Entry) error {
-		return nil
+	_ = sub.Subscribe(context.Background(), "session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 }
 
@@ -103,8 +103,8 @@ func (d *dualCell) RegisterRoutes(mux RouteMux) {
 
 func (d *dualCell) RegisterSubscriptions(sub outbox.Subscriber) {
 	d.eventRegistered = true
-	_ = sub.Subscribe(context.Background(), "device.enrolled", func(_ context.Context, _ outbox.Entry) error {
-		return nil
+	_ = sub.Subscribe(context.Background(), "device.enrolled", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 }
 

--- a/src/kernel/cell/registrar_test.go
+++ b/src/kernel/cell/registrar_test.go
@@ -79,11 +79,12 @@ type eventCell struct {
 	registered bool
 }
 
-func (e *eventCell) RegisterSubscriptions(sub outbox.Subscriber) {
+func (e *eventCell) RegisterSubscriptions(sub outbox.Subscriber) error {
 	e.registered = true
 	_ = sub.Subscribe(context.Background(), "session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
+	return nil
 }
 
 // Compile-time check.
@@ -101,11 +102,12 @@ func (d *dualCell) RegisterRoutes(mux RouteMux) {
 	mux.Handle("/api/v1/devices", http.NotFoundHandler())
 }
 
-func (d *dualCell) RegisterSubscriptions(sub outbox.Subscriber) {
+func (d *dualCell) RegisterSubscriptions(sub outbox.Subscriber) error {
 	d.eventRegistered = true
 	_ = sub.Subscribe(context.Background(), "device.enrolled", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
+	return nil
 }
 
 // Compile-time checks.
@@ -149,7 +151,8 @@ func TestEventRegistrar_TypeAssertion(t *testing.T) {
 	assert.True(t, ok, "eventCell should satisfy EventRegistrar")
 
 	sub := &mockSubscriber{}
-	r.RegisterSubscriptions(sub)
+	err := r.RegisterSubscriptions(sub)
+	assert.NoError(t, err)
 
 	assert.True(t, ec.registered)
 	assert.Equal(t, []string{"session.created"}, sub.topics)
@@ -180,7 +183,8 @@ func TestDualRegistrar_BothInterfaces(t *testing.T) {
 	er, ok := c.(EventRegistrar)
 	assert.True(t, ok)
 	sub := &mockSubscriber{}
-	er.RegisterSubscriptions(sub)
+	err := er.RegisterSubscriptions(sub)
+	assert.NoError(t, err)
 	assert.True(t, dc.eventRegistered)
 	assert.Equal(t, []string{"device.enrolled"}, sub.topics)
 }

--- a/src/kernel/idempotency/idempotency.go
+++ b/src/kernel/idempotency/idempotency.go
@@ -45,7 +45,11 @@ const (
 //  1. Claim(key) → ClaimAcquired + Receipt
 //  2. Execute business logic
 //  3a. Success → broker Ack → receipt.Commit()
-//  3b. Failure → broker Nack(requeue) → receipt.Release()
+//  3b. Transient failure → broker Nack(requeue) → receipt.Release()
+//  3c. Permanent failure → broker Nack(no-requeue) → receipt.Release()
+//
+// Note: Reject (3c) uses Release, not Commit, so that messages replayed
+// from a dead-letter queue can be reprocessed after the root cause is fixed.
 //
 // This eliminates the race condition where TryProcess marks a key as done
 // before the broker has acknowledged the message.

--- a/src/kernel/idempotency/idempotency.go
+++ b/src/kernel/idempotency/idempotency.go
@@ -5,13 +5,70 @@ package idempotency
 import (
 	"context"
 	"time"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
 // DefaultTTL is the standard idempotency key TTL per the EventBus specification.
 const DefaultTTL = 24 * time.Hour
 
-// Checker provides idempotency checking for event consumers.
-// The standard TTL is 24 hours per the EventBus specification.
+// DefaultLeaseTTL is the default processing-lease TTL.
+// If a consumer crashes mid-processing, the lease expires after this duration,
+// allowing another consumer to re-claim the message.
+const DefaultLeaseTTL = 5 * time.Minute
+
+// ---------------------------------------------------------------------------
+// ClaimState — two-phase idempotency model (Solution B)
+// ---------------------------------------------------------------------------
+
+// ClaimState is the result of a Claim attempt.
+type ClaimState uint8
+
+const (
+	// ClaimAcquired means the caller obtained the processing lease and should
+	// execute business logic. The returned Receipt MUST be Committed on success
+	// or Released on failure/requeue.
+	ClaimAcquired ClaimState = iota
+
+	// ClaimDone means a previous consumer already completed processing.
+	// The caller should Ack without running business logic.
+	ClaimDone
+
+	// ClaimBusy means another consumer currently holds the processing lease.
+	// The caller should Requeue so the broker redelivers later.
+	ClaimBusy
+)
+
+// Claimer provides two-phase idempotency for event consumers (Solution B).
+//
+// Flow:
+//  1. Claim(key) → ClaimAcquired + Receipt
+//  2. Execute business logic
+//  3a. Success → broker Ack → receipt.Commit()
+//  3b. Failure → broker Nack(requeue) → receipt.Release()
+//
+// This eliminates the race condition where TryProcess marks a key as done
+// before the broker has acknowledged the message.
+type Claimer interface {
+	// Claim attempts to acquire a processing lease for the given key.
+	//
+	// Returns:
+	//   - (ClaimAcquired, receipt, nil) — caller should process, then Commit or Release.
+	//   - (ClaimDone, nil, nil) — already processed; caller should Ack.
+	//   - (ClaimBusy, nil, nil) — another consumer is processing; caller should Requeue.
+	//   - (_, nil, err) — infrastructure error.
+	Claim(ctx context.Context, key string, leaseTTL, doneTTL time.Duration) (ClaimState, outbox.Receipt, error)
+}
+
+// ---------------------------------------------------------------------------
+// Checker — legacy interface (deprecated)
+// ---------------------------------------------------------------------------
+
+// Deprecated: Checker is the pre-Solution-B idempotency interface. New code
+// should use Claimer which provides two-phase Claim/Commit/Release semantics
+// that correctly align idempotency state with broker acknowledgement. (F-ID-01)
+//
+// Checker will be removed in a future release.
 type Checker interface {
 	// IsProcessed returns true if the given key has already been processed.
 	IsProcessed(ctx context.Context, key string) (bool, error)

--- a/src/kernel/idempotency/idempotency_test.go
+++ b/src/kernel/idempotency/idempotency_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -61,4 +62,43 @@ func TestCheckerInterface_TryProcess(t *testing.T) {
 	shouldProcess, err = c.TryProcess(context.Background(), "test-key", DefaultTTL)
 	assert.NoError(t, err)
 	assert.False(t, shouldProcess)
+}
+
+// --- ClaimState Tests ---
+
+func TestClaimState_Values(t *testing.T) {
+	assert.Equal(t, ClaimState(0), ClaimAcquired)
+	assert.Equal(t, ClaimState(1), ClaimDone)
+	assert.Equal(t, ClaimState(2), ClaimBusy)
+}
+
+// --- Claimer Interface Test ---
+
+type mockClaimer struct {
+	state   ClaimState
+	receipt outbox.Receipt
+	err     error
+}
+
+func (m *mockClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (ClaimState, outbox.Receipt, error) {
+	return m.state, m.receipt, m.err
+}
+
+var _ Claimer = (*mockClaimer)(nil)
+
+func TestClaimerInterface(t *testing.T) {
+	var c Claimer = &mockClaimer{state: ClaimAcquired}
+	state, _, err := c.Claim(context.Background(), "test-key", DefaultLeaseTTL, DefaultTTL)
+	assert.NoError(t, err)
+	assert.Equal(t, ClaimAcquired, state)
+}
+
+// --- DefaultLeaseTTL Test ---
+
+func TestDefaultLeaseTTL(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, DefaultLeaseTTL)
+}
+
+func TestDefaultTTL(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, DefaultTTL)
 }

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // ---------------------------------------------------------------------------
@@ -41,10 +43,10 @@ func (e Entry) RoutingTopic() string {
 // present. Writers SHOULD call Validate before persisting. (F-OB-03)
 func (e Entry) Validate() error {
 	if e.RoutingTopic() == "" {
-		return fmt.Errorf("outbox: entry missing topic (Topic and EventType are both empty)")
+		return errcode.New(errcode.ErrValidationFailed, "outbox: entry missing topic (Topic and EventType are both empty)")
 	}
 	if len(e.Payload) == 0 {
-		return fmt.Errorf("outbox: entry missing payload")
+		return errcode.New(errcode.ErrValidationFailed, "outbox: entry missing payload")
 	}
 	return nil
 }
@@ -107,12 +109,22 @@ func (d Disposition) String() string {
 }
 
 // Receipt represents a claimable idempotency token attached to a single
-// message processing attempt. The broker-layer (Subscriber) calls Commit
-// after a successful Ack/Reject, or Release after a Requeue or broker error.
+// message processing attempt. The broker-layer (Subscriber) manages the
+// Receipt lifecycle AFTER executing the broker Ack/Nack:
+//
+//   - DispositionAck    + broker Ack success  → Receipt.Commit()
+//   - DispositionReject + broker Nack success → Receipt.Release()  (allows DLQ replay)
+//   - DispositionRequeue + broker Nack success → Receipt.Release()
+//   - Any broker Ack/Nack failure             → Receipt.Release()
+//
+// Callers MUST use context.WithoutCancel for Receipt operations to ensure
+// idempotency state is persisted even during graceful shutdown.
 type Receipt interface {
 	// Commit marks the idempotency key as permanently done.
+	// Only called after DispositionAck + successful broker Ack.
 	Commit(ctx context.Context) error
 	// Release removes the processing lease so redelivery can re-enter.
+	// Called for Reject (allows DLQ replay), Requeue, and broker errors.
 	Release(ctx context.Context) error
 }
 

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -6,8 +6,13 @@ package outbox
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
+
+// ---------------------------------------------------------------------------
+// Entry
+// ---------------------------------------------------------------------------
 
 // Entry represents a single outbox record to be published.
 type Entry struct {
@@ -32,6 +37,22 @@ func (e Entry) RoutingTopic() string {
 	return e.EventType
 }
 
+// Validate checks that required fields (Topic or EventType, and Payload) are
+// present. Writers SHOULD call Validate before persisting. (F-OB-03)
+func (e Entry) Validate() error {
+	if e.RoutingTopic() == "" {
+		return fmt.Errorf("outbox: entry missing topic (Topic and EventType are both empty)")
+	}
+	if len(e.Payload) == 0 {
+		return fmt.Errorf("outbox: entry missing payload")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Writer / Relay / Publisher
+// ---------------------------------------------------------------------------
+
 // Writer writes outbox entries within a transaction.
 // The implementation must ensure the outbox write is atomic with the
 // business state write (same DB transaction).
@@ -54,28 +75,109 @@ type Publisher interface {
 	Publish(ctx context.Context, topic string, payload []byte) error
 }
 
+// ---------------------------------------------------------------------------
+// Disposition / Receipt / HandleResult — Solution B types
+// ---------------------------------------------------------------------------
+
+// Disposition describes the broker-level action for a consumed message.
+//
+//   - DispositionAck:     message processed successfully (or duplicate); broker may discard.
+//   - DispositionRequeue: temporary failure / shutdown; broker should redeliver.
+//   - DispositionReject:  permanent failure; broker routes to dead-letter exchange.
+type Disposition uint8
+
+const (
+	DispositionAck     Disposition = iota // ACK — success or safe-to-skip duplicate
+	DispositionRequeue                    // NACK+requeue — transient / shutdown
+	DispositionReject                     // NACK+no-requeue — permanent failure → DLX
+)
+
+// String returns a human-readable label for the Disposition.
+func (d Disposition) String() string {
+	switch d {
+	case DispositionAck:
+		return "ack"
+	case DispositionRequeue:
+		return "requeue"
+	case DispositionReject:
+		return "reject"
+	default:
+		return fmt.Sprintf("disposition(%d)", d)
+	}
+}
+
+// Receipt represents a claimable idempotency token attached to a single
+// message processing attempt. The broker-layer (Subscriber) calls Commit
+// after a successful Ack/Reject, or Release after a Requeue or broker error.
+type Receipt interface {
+	// Commit marks the idempotency key as permanently done.
+	Commit(ctx context.Context) error
+	// Release removes the processing lease so redelivery can re-enter.
+	Release(ctx context.Context) error
+}
+
+// HandleResult carries the business handler's processing outcome.
+// The Subscriber inspects Disposition to decide Ack/Nack, then calls
+// Receipt.Commit or Receipt.Release based on the broker outcome.
+type HandleResult struct {
+	Disposition Disposition
+	Err         error   // optional: logged/observed; nil for success
+	Receipt     Receipt // nil when idempotency is not in use
+}
+
+// EntryHandler is the Solution B handler signature. Business handlers return
+// a HandleResult that declares the intended broker disposition and carries an
+// optional idempotency Receipt.
+type EntryHandler func(context.Context, Entry) HandleResult
+
+// ---------------------------------------------------------------------------
+// Legacy compatibility
+// ---------------------------------------------------------------------------
+
+// LegacyHandler is the pre-Solution-B handler signature kept for reference.
+// New code should use EntryHandler.
+type LegacyHandler = func(context.Context, Entry) error
+
+// WrapLegacyHandler adapts a LegacyHandler to the new EntryHandler contract:
+//   - nil error  → DispositionAck
+//   - non-nil error → DispositionRequeue (transient by default)
+//
+// This allows existing cell handlers to compile against the new Subscriber
+// interface without immediate rewrite.
+func WrapLegacyHandler(fn LegacyHandler) EntryHandler {
+	return func(ctx context.Context, entry Entry) HandleResult {
+		if err := fn(ctx, entry); err != nil {
+			return HandleResult{Disposition: DispositionRequeue, Err: err}
+		}
+		return HandleResult{Disposition: DispositionAck}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscriber
+// ---------------------------------------------------------------------------
+
 // Subscriber consumes events from a topic.
 //
 // ref: ThreeDotsLabs/watermill message/pubsub.go Subscriber interface
 // Adopted: Close() for clean shutdown; topic-based subscription model.
-// Deviated: callback-based handler instead of channel-based (<-chan *Message)
+// Deviated: callback-based EntryHandler instead of channel-based (<-chan *Message)
 // to align with GoCell's ConsumerBase pattern and simplify consumer lifecycle.
 type Subscriber interface {
 	// Subscribe registers a handler for the given topic. The handler is called
-	// for each incoming entry. Returning a non-nil error from the handler
-	// signals a transient failure (retry/NACK); permanent failures should be
-	// routed to a dead-letter queue by the implementation.
+	// for each incoming entry and returns a HandleResult that declares the
+	// intended broker disposition.
 	//
 	// Subscribe blocks until ctx is cancelled or an unrecoverable error occurs.
-	Subscribe(ctx context.Context, topic string, handler func(context.Context, Entry) error) error
+	Subscribe(ctx context.Context, topic string, handler EntryHandler) error
 
 	// Close terminates all active subscriptions and releases resources.
 	Close() error
 }
 
-// TopicHandlerMiddleware transforms an entry handler, receiving the topic name.
+// TopicHandlerMiddleware transforms an EntryHandler, receiving the topic name.
 // It is the event-consumer analogue of HTTP middleware.
-type TopicHandlerMiddleware func(topic string, next func(context.Context, Entry) error) func(context.Context, Entry) error
+type TopicHandlerMiddleware func(topic string, next EntryHandler) EntryHandler
 
 // SubscriberWithMiddleware wraps a Subscriber so that every handler passed
 // to Subscribe is first wrapped by the given middleware chain.
@@ -89,7 +191,7 @@ type SubscriberWithMiddleware struct {
 var _ Subscriber = (*SubscriberWithMiddleware)(nil)
 
 // Subscribe wraps the handler with the middleware chain, then delegates to Inner.
-func (s *SubscriberWithMiddleware) Subscribe(ctx context.Context, topic string, handler func(context.Context, Entry) error) error {
+func (s *SubscriberWithMiddleware) Subscribe(ctx context.Context, topic string, handler EntryHandler) error {
 	wrapped := handler
 	for i := len(s.Middleware) - 1; i >= 0; i-- {
 		wrapped = s.Middleware[i](topic, wrapped)

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -154,6 +154,11 @@ type LegacyHandler = func(context.Context, Entry) error
 //   - nil error  → DispositionAck
 //   - non-nil error → DispositionRequeue (transient by default)
 //
+// Note: PermanentError is mapped to DispositionRequeue, not DispositionReject.
+// ConsumerBase.Wrap detects PermanentError via errors.As and upgrades to Reject.
+// Without ConsumerBase wrapping, PermanentError will be retried like any other
+// error. Direct Subscribe callers needing Reject should use EntryHandler directly.
+//
 // This allows existing cell handlers to compile against the new Subscriber
 // interface without immediate rewrite.
 func WrapLegacyHandler(fn LegacyHandler) EntryHandler {

--- a/src/kernel/outbox/outbox_test.go
+++ b/src/kernel/outbox/outbox_test.go
@@ -31,7 +31,7 @@ var _ Publisher = (*mockPublisher)(nil)
 
 type mockSubscriber struct{}
 
-func (m *mockSubscriber) Subscribe(ctx context.Context, topic string, handler func(context.Context, Entry) error) error {
+func (m *mockSubscriber) Subscribe(ctx context.Context, topic string, handler EntryHandler) error {
 	return nil
 }
 func (m *mockSubscriber) Close() error { return nil }
@@ -42,8 +42,8 @@ func TestSubscriberInterface(t *testing.T) {
 	var sub Subscriber = &mockSubscriber{}
 
 	t.Run("Subscribe returns nil on success", func(t *testing.T) {
-		handler := func(ctx context.Context, entry Entry) error {
-			return nil
+		handler := func(ctx context.Context, entry Entry) HandleResult {
+			return HandleResult{Disposition: DispositionAck}
 		}
 		err := sub.Subscribe(context.Background(), "test.topic", handler)
 		assert.NoError(t, err)
@@ -78,11 +78,11 @@ func TestEntryFields(t *testing.T) {
 type recordingSubscriber struct {
 	subscribeCalled bool
 	subscribeTopic  string
-	capturedHandler func(context.Context, Entry) error
+	capturedHandler EntryHandler
 	closeErr        error
 }
 
-func (r *recordingSubscriber) Subscribe(_ context.Context, topic string, handler func(context.Context, Entry) error) error {
+func (r *recordingSubscriber) Subscribe(_ context.Context, topic string, handler EntryHandler) error {
 	r.subscribeCalled = true
 	r.subscribeTopic = topic
 	r.capturedHandler = handler
@@ -104,9 +104,9 @@ func TestSubscriberWithMiddleware_NoMiddleware(t *testing.T) {
 	sub := &SubscriberWithMiddleware{Inner: inner}
 
 	called := false
-	handler := func(_ context.Context, _ Entry) error {
+	handler := func(_ context.Context, _ Entry) HandleResult {
 		called = true
-		return nil
+		return HandleResult{Disposition: DispositionAck}
 	}
 
 	err := sub.Subscribe(context.Background(), "test.topic", handler)
@@ -115,8 +115,8 @@ func TestSubscriberWithMiddleware_NoMiddleware(t *testing.T) {
 	assert.Equal(t, "test.topic", inner.subscribeTopic)
 
 	// Call the captured handler to verify it's the original.
-	err = inner.capturedHandler(context.Background(), Entry{})
-	assert.NoError(t, err)
+	res := inner.capturedHandler(context.Background(), Entry{})
+	assert.Equal(t, DispositionAck, res.Disposition)
 	assert.True(t, called)
 }
 
@@ -124,9 +124,9 @@ func TestSubscriberWithMiddleware_SingleMiddleware(t *testing.T) {
 	inner := &recordingSubscriber{}
 
 	var middlewareTopic string
-	middleware := func(topic string, next func(context.Context, Entry) error) func(context.Context, Entry) error {
+	middleware := func(topic string, next EntryHandler) EntryHandler {
 		middlewareTopic = topic
-		return func(ctx context.Context, e Entry) error {
+		return func(ctx context.Context, e Entry) HandleResult {
 			e.Metadata = map[string]string{"wrapped": "true"}
 			return next(ctx, e)
 		}
@@ -138,9 +138,9 @@ func TestSubscriberWithMiddleware_SingleMiddleware(t *testing.T) {
 	}
 
 	var receivedEntry Entry
-	handler := func(_ context.Context, e Entry) error {
+	handler := func(_ context.Context, e Entry) HandleResult {
 		receivedEntry = e
-		return nil
+		return HandleResult{Disposition: DispositionAck}
 	}
 
 	err := sub.Subscribe(context.Background(), "orders.created", handler)
@@ -148,8 +148,8 @@ func TestSubscriberWithMiddleware_SingleMiddleware(t *testing.T) {
 	assert.Equal(t, "orders.created", middlewareTopic)
 
 	// Call captured handler to verify middleware was applied.
-	err = inner.capturedHandler(context.Background(), Entry{ID: "evt-1"})
-	assert.NoError(t, err)
+	res := inner.capturedHandler(context.Background(), Entry{ID: "evt-1"})
+	assert.Equal(t, DispositionAck, res.Disposition)
 	assert.Equal(t, "evt-1", receivedEntry.ID)
 	assert.Equal(t, "true", receivedEntry.Metadata["wrapped"])
 }
@@ -160,12 +160,12 @@ func TestSubscriberWithMiddleware_MultipleMiddleware_OrderCorrect(t *testing.T) 
 	var order []string
 
 	makeMiddleware := func(name string) TopicHandlerMiddleware {
-		return func(topic string, next func(context.Context, Entry) error) func(context.Context, Entry) error {
-			return func(ctx context.Context, e Entry) error {
+		return func(topic string, next EntryHandler) EntryHandler {
+			return func(ctx context.Context, e Entry) HandleResult {
 				order = append(order, name+"-before")
-				err := next(ctx, e)
+				res := next(ctx, e)
 				order = append(order, name+"-after")
-				return err
+				return res
 			}
 		}
 	}
@@ -178,16 +178,15 @@ func TestSubscriberWithMiddleware_MultipleMiddleware_OrderCorrect(t *testing.T) 
 		},
 	}
 
-	handler := func(_ context.Context, _ Entry) error {
+	handler := func(_ context.Context, _ Entry) HandleResult {
 		order = append(order, "handler")
-		return nil
+		return HandleResult{Disposition: DispositionAck}
 	}
 
 	err := sub.Subscribe(context.Background(), "test.topic", handler)
 	assert.NoError(t, err)
 
-	err = inner.capturedHandler(context.Background(), Entry{})
-	assert.NoError(t, err)
+	_ = inner.capturedHandler(context.Background(), Entry{})
 
 	// [0] is outermost, [len-1] is innermost.
 	assert.Equal(t, []string{
@@ -219,9 +218,12 @@ func TestSubscriberWithMiddleware_Close_PropagatesError(t *testing.T) {
 func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
 	inner := &recordingSubscriber{}
 
-	shortCircuit := func(_ string, _ func(context.Context, Entry) error) func(context.Context, Entry) error {
-		return func(_ context.Context, _ Entry) error {
-			return assert.AnError
+	shortCircuit := func(_ string, _ EntryHandler) EntryHandler {
+		return func(_ context.Context, _ Entry) HandleResult {
+			return HandleResult{
+				Disposition: DispositionReject,
+				Err:         assert.AnError,
+			}
 		}
 	}
 
@@ -231,17 +233,18 @@ func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
 	}
 
 	handlerCalled := false
-	handler := func(_ context.Context, _ Entry) error {
+	handler := func(_ context.Context, _ Entry) HandleResult {
 		handlerCalled = true
-		return nil
+		return HandleResult{Disposition: DispositionAck}
 	}
 
 	err := sub.Subscribe(context.Background(), "test.topic", handler)
 	assert.NoError(t, err)
 
 	// Call captured handler — middleware should short-circuit.
-	err = inner.capturedHandler(context.Background(), Entry{})
-	assert.Error(t, err)
+	res := inner.capturedHandler(context.Background(), Entry{})
+	assert.Equal(t, DispositionReject, res.Disposition)
+	assert.Error(t, res.Err)
 	assert.False(t, handlerCalled)
 }
 
@@ -275,8 +278,8 @@ func TestEntry_RoutingTopic(t *testing.T) {
 			wantTopic: "session.created",
 		},
 		{
-			name: "Both empty — returns empty string",
-			entry: Entry{},
+			name:      "Both empty — returns empty string",
+			entry:     Entry{},
 			wantTopic: "",
 		},
 	}
@@ -285,4 +288,102 @@ func TestEntry_RoutingTopic(t *testing.T) {
 			assert.Equal(t, tt.wantTopic, tt.entry.RoutingTopic())
 		})
 	}
+}
+
+// --- Disposition Tests ---
+
+func TestDisposition_String(t *testing.T) {
+	tests := []struct {
+		d    Disposition
+		want string
+	}{
+		{DispositionAck, "ack"},
+		{DispositionRequeue, "requeue"},
+		{DispositionReject, "reject"},
+		{Disposition(99), "disposition(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.d.String())
+		})
+	}
+}
+
+// --- WrapLegacyHandler Tests ---
+
+func TestWrapLegacyHandler_Success(t *testing.T) {
+	legacy := func(_ context.Context, _ Entry) error { return nil }
+	handler := WrapLegacyHandler(legacy)
+
+	res := handler(context.Background(), Entry{ID: "1"})
+	assert.Equal(t, DispositionAck, res.Disposition)
+	assert.NoError(t, res.Err)
+}
+
+func TestWrapLegacyHandler_Error(t *testing.T) {
+	legacy := func(_ context.Context, _ Entry) error { return assert.AnError }
+	handler := WrapLegacyHandler(legacy)
+
+	res := handler(context.Background(), Entry{ID: "1"})
+	assert.Equal(t, DispositionRequeue, res.Disposition)
+	assert.Equal(t, assert.AnError, res.Err)
+}
+
+// --- Entry.Validate Tests (F-OB-03) ---
+
+func TestEntry_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   Entry
+		wantErr bool
+	}{
+		{
+			name:    "valid with Topic",
+			entry:   Entry{Topic: "t", Payload: []byte("{}")},
+			wantErr: false,
+		},
+		{
+			name:    "valid with EventType fallback",
+			entry:   Entry{EventType: "e", Payload: []byte("{}")},
+			wantErr: false,
+		},
+		{
+			name:    "missing topic and EventType",
+			entry:   Entry{Payload: []byte("{}")},
+			wantErr: true,
+		},
+		{
+			name:    "missing payload",
+			entry:   Entry{Topic: "t"},
+			wantErr: true,
+		},
+		{
+			name:    "completely empty",
+			entry:   Entry{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.entry.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- HandleResult tests ---
+
+func TestHandleResult_Fields(t *testing.T) {
+	res := HandleResult{
+		Disposition: DispositionReject,
+		Err:         assert.AnError,
+		Receipt:     nil,
+	}
+	assert.Equal(t, DispositionReject, res.Disposition)
+	assert.Error(t, res.Err)
+	assert.Nil(t, res.Receipt)
 }

--- a/src/kernel/outbox/outbox_test.go
+++ b/src/kernel/outbox/outbox_test.go
@@ -368,6 +368,7 @@ func TestEntry_Validate(t *testing.T) {
 			err := tt.entry.Validate()
 			if tt.wantErr {
 				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "ERR_VALIDATION_FAILED")
 			} else {
 				assert.NoError(t, err)
 			}

--- a/src/runtime/bootstrap/bootstrap.go
+++ b/src/runtime/bootstrap/bootstrap.go
@@ -263,11 +263,14 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	}
 
 	// Step 6: Register event subscriptions for cells implementing EventRegistrar.
+	// Subscription setup errors (e.g., missing DLX) abort startup.
 	if sub != nil {
 		for _, id := range asm.CellIDs() {
 			c := asm.Cell(id)
 			if er, ok := c.(cell.EventRegistrar); ok {
-				er.RegisterSubscriptions(sub)
+				if err := er.RegisterSubscriptions(sub); err != nil {
+					return fmt.Errorf("bootstrap: cell %s subscription setup failed: %w", id, err)
+				}
 			}
 		}
 	}

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -109,14 +109,14 @@ func (b *InMemoryEventBus) Publish(_ context.Context, topic string, payload []by
 	return nil
 }
 
-// Subscribe registers a handler for the given topic. It blocks until ctx is
-// cancelled or the bus is closed.
+// Subscribe registers an EntryHandler for the given topic. It blocks until ctx
+// is cancelled or the bus is closed.
 //
 // Consumer: cg-eventbus-{topic}
 // Idempotency key: N/A (in-memory, no persistence)
-// ACK timing: after handler returns nil
+// ACK timing: after handler returns DispositionAck
 // Retry: transient errors -> retry 3x with exponential backoff / permanent -> dead letter
-func (b *InMemoryEventBus) Subscribe(ctx context.Context, topic string, handler func(context.Context, outbox.Entry) error) error {
+func (b *InMemoryEventBus) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler) error {
 	subCtx, cancel := context.WithCancel(ctx)
 
 	sub := &subscription{
@@ -211,17 +211,36 @@ func (b *InMemoryEventBus) removeSub(topic string, target *subscription) {
 	}
 }
 
-func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, entry outbox.Entry, handler func(context.Context, outbox.Entry) error) {
+func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, entry outbox.Entry, handler outbox.EntryHandler) {
 	var lastErr error
 	for attempt := range maxRetries {
-		if err := handler(ctx, entry); err != nil {
-			lastErr = err
+		res := handler(ctx, entry)
+		switch res.Disposition {
+		case outbox.DispositionAck:
+			return // success or safe duplicate
+		case outbox.DispositionReject:
+			// Permanent failure — route directly to dead letter.
+			slog.Warn("eventbus: handler rejected message, routing to dead letter",
+				slog.String("topic", topic),
+				slog.String("entry_id", entry.ID),
+				slog.Any("error", res.Err),
+			)
+			b.deadLettersMu.Lock()
+			b.deadLetters = append(b.deadLetters, DeadLetter{
+				Topic:   topic,
+				Entry:   entry,
+				LastErr: res.Err,
+			})
+			b.deadLettersMu.Unlock()
+			return
+		case outbox.DispositionRequeue:
+			lastErr = res.Err
 			jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
 			delay := baseRetryDelay*(1<<attempt) + jitter // e.g. 100-200ms, 200-300ms, 400-500ms
-			slog.Warn("eventbus: handler error, retrying",
+			slog.Warn("eventbus: handler requested requeue, retrying",
 				slog.String("topic", topic),
 				slog.Int("attempt", attempt+1),
-				slog.Any("error", err),
+				slog.Any("error", res.Err),
 				slog.Duration("retry_delay", delay),
 			)
 			select {
@@ -231,7 +250,6 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 				continue
 			}
 		}
-		return // success
 	}
 
 	// Exhausted retries → dead letter.

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -217,8 +217,26 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 		res := handler(ctx, entry)
 		switch res.Disposition {
 		case outbox.DispositionAck:
+			if res.Receipt != nil {
+				if err := res.Receipt.Commit(ctx); err != nil {
+					slog.Error("eventbus: receipt commit failed",
+						slog.String("topic", topic),
+						slog.String("entry_id", entry.ID),
+						slog.String("error", err.Error()),
+					)
+				}
+			}
 			return // success or safe duplicate
 		case outbox.DispositionReject:
+			if res.Receipt != nil {
+				if err := res.Receipt.Release(ctx); err != nil {
+					slog.Error("eventbus: receipt release failed",
+						slog.String("topic", topic),
+						slog.String("entry_id", entry.ID),
+						slog.String("error", err.Error()),
+					)
+				}
+			}
 			// Permanent failure — route directly to dead letter.
 			slog.Warn("eventbus: handler rejected message, routing to dead letter",
 				slog.String("topic", topic),
@@ -234,6 +252,15 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 			b.deadLettersMu.Unlock()
 			return
 		case outbox.DispositionRequeue:
+			if res.Receipt != nil {
+				if err := res.Receipt.Release(ctx); err != nil {
+					slog.Error("eventbus: receipt release failed",
+						slog.String("topic", topic),
+						slog.String("entry_id", entry.ID),
+						slog.String("error", err.Error()),
+					)
+				}
+			}
 			lastErr = res.Err
 			jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
 			delay := baseRetryDelay*(1<<attempt) + jitter // e.g. 100-200ms, 200-300ms, 400-500ms

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -218,24 +218,12 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 		switch res.Disposition {
 		case outbox.DispositionAck:
 			if res.Receipt != nil {
-				if err := res.Receipt.Commit(context.WithoutCancel(ctx)); err != nil {
-					slog.Error("eventbus: receipt commit failed",
-						slog.String("topic", topic),
-						slog.String("entry_id", entry.ID),
-						slog.String("error", err.Error()),
-					)
-				}
+				commitReceipt(ctx, res.Receipt, topic, entry.ID)
 			}
 			return // success or safe duplicate
 		case outbox.DispositionReject:
 			if res.Receipt != nil {
-				if err := res.Receipt.Release(context.WithoutCancel(ctx)); err != nil {
-					slog.Error("eventbus: receipt release failed",
-						slog.String("topic", topic),
-						slog.String("entry_id", entry.ID),
-						slog.String("error", err.Error()),
-					)
-				}
+				releaseReceipt(ctx, res.Receipt, topic, entry.ID)
 			}
 			// Permanent failure — route directly to dead letter.
 			slog.Warn("eventbus: handler rejected message, routing to dead letter",
@@ -253,13 +241,7 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 			return
 		case outbox.DispositionRequeue:
 			if res.Receipt != nil {
-				if err := res.Receipt.Release(context.WithoutCancel(ctx)); err != nil {
-					slog.Error("eventbus: receipt release failed",
-						slog.String("topic", topic),
-						slog.String("entry_id", entry.ID),
-						slog.String("error", err.Error()),
-					)
-				}
+				releaseReceipt(ctx, res.Receipt, topic, entry.ID)
 			}
 			lastErr = res.Err
 			jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
@@ -292,4 +274,29 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 		LastErr: lastErr,
 	})
 	b.deadLettersMu.Unlock()
+}
+
+// commitReceipt calls Receipt.Commit with a detached 5s-timeout context,
+// consistent with the RabbitMQ subscriber path.
+func commitReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string) {
+	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := r.Commit(rctx); err != nil {
+		slog.Error("eventbus: receipt commit failed",
+			slog.String("topic", topic),
+			slog.String("entry_id", entryID),
+			slog.String("error", err.Error()))
+	}
+}
+
+// releaseReceipt calls Receipt.Release with a detached 5s-timeout context.
+func releaseReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string) {
+	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := r.Release(rctx); err != nil {
+		slog.Error("eventbus: receipt release failed",
+			slog.String("topic", topic),
+			slog.String("entry_id", entryID),
+			slog.String("error", err.Error()))
+	}
 }

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -218,7 +218,7 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 		switch res.Disposition {
 		case outbox.DispositionAck:
 			if res.Receipt != nil {
-				if err := res.Receipt.Commit(ctx); err != nil {
+				if err := res.Receipt.Commit(context.WithoutCancel(ctx)); err != nil {
 					slog.Error("eventbus: receipt commit failed",
 						slog.String("topic", topic),
 						slog.String("entry_id", entry.ID),
@@ -229,7 +229,7 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 			return // success or safe duplicate
 		case outbox.DispositionReject:
 			if res.Receipt != nil {
-				if err := res.Receipt.Release(ctx); err != nil {
+				if err := res.Receipt.Release(context.WithoutCancel(ctx)); err != nil {
 					slog.Error("eventbus: receipt release failed",
 						slog.String("topic", topic),
 						slog.String("entry_id", entry.ID),
@@ -253,7 +253,7 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 			return
 		case outbox.DispositionRequeue:
 			if res.Receipt != nil {
-				if err := res.Receipt.Release(ctx); err != nil {
+				if err := res.Receipt.Release(context.WithoutCancel(ctx)); err != nil {
 					slog.Error("eventbus: receipt release failed",
 						slog.String("topic", topic),
 						slog.String("entry_id", entry.ID),

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -23,11 +23,11 @@ func TestPublishSubscribe(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "test.topic", func(_ context.Context, e outbox.Entry) error {
+		done <- bus.Subscribe(ctx, "test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			mu.Lock()
 			received = append(received, e)
 			mu.Unlock()
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 
@@ -75,9 +75,9 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "retry.topic", func(_ context.Context, e outbox.Entry) error {
+		done <- bus.Subscribe(ctx, "retry.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			attempts.Add(1)
-			return testErr
+			return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: testErr}
 		})
 	}()
 
@@ -108,6 +108,42 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 	<-done
 }
 
+func TestSubscribe_RejectGoesDirectlyToDeadLetter(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	var attempts atomic.Int32
+	testErr := errors.New("permanent error")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "reject.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			attempts.Add(1)
+			return outbox.HandleResult{Disposition: outbox.DispositionReject, Err: testErr}
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	err := bus.Publish(context.Background(), "reject.topic", []byte("perm-fail"))
+	require.NoError(t, err)
+
+	// Should go directly to dead letter on first attempt (no retries).
+	assert.Eventually(t, func() bool {
+		return bus.DeadLetterLen() == 1
+	}, time.Second, 50*time.Millisecond)
+
+	assert.Equal(t, int32(1), attempts.Load(), "reject should not trigger retries")
+
+	dl := bus.DrainDeadLetters()
+	require.Len(t, dl, 1)
+	assert.Equal(t, testErr, dl[0].LastErr)
+
+	cancel()
+	<-done
+}
+
 func TestClose_PreventsFurtherPublish(t *testing.T) {
 	bus := New()
 	err := bus.Close()
@@ -127,8 +163,8 @@ func TestSubscribe_ClosedBus(t *testing.T) {
 	bus := New()
 	_ = bus.Close()
 
-	err := bus.Subscribe(context.Background(), "topic", func(_ context.Context, e outbox.Entry) error {
-		return nil
+	err := bus.Subscribe(context.Background(), "topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 	assert.Error(t, err)
 }
@@ -145,16 +181,16 @@ func TestMultipleSubscribers(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "multi.topic", func(_ context.Context, e outbox.Entry) error {
+		_ = bus.Subscribe(ctx, "multi.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			count1.Add(1)
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "multi.topic", func(_ context.Context, e outbox.Entry) error {
+		_ = bus.Subscribe(ctx, "multi.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			count2.Add(1)
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 
@@ -180,12 +216,12 @@ func TestSubscribe_SuccessAfterRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "partial.fail", func(_ context.Context, e outbox.Entry) error {
+		done <- bus.Subscribe(ctx, "partial.fail", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			n := attempts.Add(1)
 			if n < 3 {
-				return errors.New("not yet")
+				return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("not yet")}
 			}
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 
@@ -225,8 +261,8 @@ func TestSubscribe_CleansUpOnExit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "cleanup.topic", func(_ context.Context, e outbox.Entry) error {
-			return nil
+		done <- bus.Subscribe(ctx, "cleanup.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -285,6 +285,134 @@ func TestSubscribe_CleansUpOnExit(t *testing.T) {
 	assert.Equal(t, 0, subsAfter, "subscriber should be cleaned up after exit")
 }
 
+// mockReceipt records Commit/Release calls for testing.
+type mockReceipt struct {
+	committed atomic.Bool
+	released  atomic.Bool
+}
+
+func (r *mockReceipt) Commit(_ context.Context) error {
+	r.committed.Store(true)
+	return nil
+}
+
+func (r *mockReceipt) Release(_ context.Context) error {
+	r.released.Store(true)
+	return nil
+}
+
+func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	receipt := &mockReceipt{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "receipt.ack", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			return outbox.HandleResult{
+				Disposition: outbox.DispositionAck,
+				Receipt:     receipt,
+			}
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	err := bus.Publish(context.Background(), "receipt.ack", []byte("data"))
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return receipt.committed.Load()
+	}, time.Second, 10*time.Millisecond, "receipt should be committed on Ack")
+
+	assert.False(t, receipt.released.Load(), "receipt should not be released on Ack")
+
+	cancel()
+	<-done
+}
+
+func TestSubscribe_ReceiptReleasedOnReject(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	receipt := &mockReceipt{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "receipt.reject", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			return outbox.HandleResult{
+				Disposition: outbox.DispositionReject,
+				Err:         errors.New("permanent"),
+				Receipt:     receipt,
+			}
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	err := bus.Publish(context.Background(), "receipt.reject", []byte("data"))
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return receipt.released.Load()
+	}, time.Second, 10*time.Millisecond, "receipt should be released on Reject")
+
+	assert.False(t, receipt.committed.Load(), "receipt should not be committed on Reject")
+
+	cancel()
+	<-done
+}
+
+func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	var receipts []*mockReceipt
+	var receiptsMu sync.Mutex
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "receipt.requeue", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			r := &mockReceipt{}
+			receiptsMu.Lock()
+			receipts = append(receipts, r)
+			receiptsMu.Unlock()
+			return outbox.HandleResult{
+				Disposition: outbox.DispositionRequeue,
+				Err:         errors.New("transient"),
+				Receipt:     r,
+			}
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	err := bus.Publish(context.Background(), "receipt.requeue", []byte("data"))
+	require.NoError(t, err)
+
+	// Wait for all retries to exhaust.
+	assert.Eventually(t, func() bool {
+		return bus.DeadLetterLen() == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	receiptsMu.Lock()
+	defer receiptsMu.Unlock()
+
+	require.Len(t, receipts, maxRetries, "should have one receipt per retry attempt")
+
+	for i, r := range receipts {
+		assert.True(t, r.released.Load(), "receipt %d should be released on Requeue", i)
+		assert.False(t, r.committed.Load(), "receipt %d should not be committed on Requeue", i)
+	}
+
+	cancel()
+	<-done
+}
+
 // Verify interface compliance at compile time.
 var (
 	_ outbox.Publisher  = (*InMemoryEventBus)(nil)

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -413,6 +413,63 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 	<-done
 }
 
+func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	// Track all receipts across retry attempts to verify each is released
+	// and none is committed when retries exhaust.
+	var receipts []*mockReceipt
+	var receiptsMu sync.Mutex
+
+	testErr := errors.New("persistent transient error")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "receipt.exhaust", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			r := &mockReceipt{}
+			receiptsMu.Lock()
+			receipts = append(receipts, r)
+			receiptsMu.Unlock()
+			return outbox.HandleResult{
+				Disposition: outbox.DispositionRequeue,
+				Err:         testErr,
+				Receipt:     r,
+			}
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	err := bus.Publish(context.Background(), "receipt.exhaust", []byte("exhaust-data"))
+	require.NoError(t, err)
+
+	// Wait for retries to exhaust and message to land in dead letter.
+	assert.Eventually(t, func() bool {
+		return bus.DeadLetterLen() == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	receiptsMu.Lock()
+	defer receiptsMu.Unlock()
+
+	require.Equal(t, maxRetries, len(receipts), "handler should be called exactly maxRetries times")
+
+	for i, r := range receipts {
+		assert.True(t, r.released.Load(), "receipt %d should be released after requeue", i)
+		assert.False(t, r.committed.Load(), "receipt %d must never be committed on retry exhaustion", i)
+	}
+
+	// Verify dead letter contains the correct error.
+	dl := bus.DrainDeadLetters()
+	require.Len(t, dl, 1)
+	assert.Equal(t, testErr, dl[0].LastErr)
+	assert.Equal(t, "receipt.exhaust", dl[0].Topic)
+
+	cancel()
+	<-done
+}
+
 // Verify interface compliance at compile time.
 var (
 	_ outbox.Publisher  = (*InMemoryEventBus)(nil)

--- a/src/tests/integration/outbox_fullchain_test.go
+++ b/src/tests/integration/outbox_fullchain_test.go
@@ -166,6 +166,7 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 	sub := rabbitmq.NewSubscriber(rmqConn, rabbitmq.SubscriberConfig{
 		QueueName:       "outbox.fullchain.queue",
 		PrefetchCount:   1,
+		DLXExchange:     "test.dlx",
 		ShutdownTimeout: 5 * time.Second,
 	})
 	checker := redis.NewIdempotencyChecker(redisClient)

--- a/src/tests/integration/outbox_fullchain_test.go
+++ b/src/tests/integration/outbox_fullchain_test.go
@@ -236,9 +236,9 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 
 	subErrCh := make(chan error, 1)
 	go func() {
-		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) error {
+		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			received <- e
-			return nil
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 


### PR DESCRIPTION
## Summary
- **A3-01**: kernel/outbox — `Disposition`, `Receipt`, `HandleResult`, `EntryHandler`, `WrapLegacyHandler`, `Entry.Validate()`
- **A3-02**: kernel/idempotency — `ClaimState`, `Claimer` (Claim/Commit/Release 两阶段), 旧 `Checker` 标记 Deprecated (F-ID-01)
- **A3-03**: adapters/redis — `IdempotencyClaimer` 双 key Lua 脚本 (`lease:{k}` + `done:{k}`)
- **A3-04**: adapters/rabbitmq — `processDelivery` 重写为 Disposition 驱动, `ConsumerBase` 去掉应用侧 DLQ
- **A3-05**: runtime/eventbus — `InMemoryEventBus` 适配 `EntryHandler`
- **A3-06**: cells — audit-core/config-core 用 `WrapLegacyHandler` 适配
- **A3-07**: 全链路测试更新 + 新接口测试
- **F-OB-03**: `Entry.Validate()` 必填校验 (Topic/Payload)

## Review fixes (4173ee3)

Review 发现 8 个问题，已全部修复：

| 级别 | ID | 修复 |
|------|-----|------|
| P0 | DLX-OPT | subscribe 时 slog.Warn + Reject 时 slog.Error 告警无 DLX 配置 |
| P1 | CHECKER-RACE | `NewConsumerBaseWithClaimer` 走两阶段 Claim→Receipt→processDelivery Commit/Release |
| P1 | LUA-RETURN | `redisReceipt.Commit/Release` 检查 Lua 返回值，stale lease 返回 error |
| P1 | CTX-CANCEL | Receipt 操作改用 `context.WithoutCancel`，关停时仍写入幂等状态 |
| P2 | REJECT-SEM | processDelivery: Ack→Commit, Reject/Requeue→Release（允许 DLQ replay） |
| P2 | EVENTBUS-RECEIPT | `handleWithRetry` 每个 disposition 分支处理 Receipt Commit/Release |
| P2 | VALIDATE-DEAD | `OutboxWriter.Write` 调用 `entry.Validate()`；Validate 改用 errcode |
| P3 | TEST-GAP | 15 个新测试覆盖 Claimer、Receipt 生命周期、stale lease、detached ctx |

## Key design decisions
- 幂等状态只在 broker Ack 成功后才 Commit，Requeue/Reject 时 Release 租约
- Reject → Release（非 Commit），允许 DLQ replay 重新处理
- Receipt 操作使用 `context.WithoutCancel`，确保关停时幂等状态不丢失
- ConsumerBase 双模：`NewConsumerBase`（旧 Checker）+ `NewConsumerBaseWithClaimer`（新 Claimer）
- DLQ 路由改为 broker-native (DLX)，去掉应用侧 publisher 依赖
- `WrapLegacyHandler` 保持 cell handler 向后兼容，无需重写业务逻辑

## Test plan
- [x] `go build ./...` 通过
- [x] `go vet ./...` 通过
- [x] kernel/outbox 测试通过 (Disposition, HandleResult, WrapLegacyHandler, Entry.Validate errcode)
- [x] kernel/idempotency 测试通过 (ClaimState, Claimer doc)
- [x] adapters/redis IdempotencyClaimer 测试通过 (Claim/Commit/Release + stale-lease)
- [x] adapters/rabbitmq 测试通过 (processDelivery Receipt lifecycle + ConsumerBase Claimer path)
- [x] runtime/eventbus 测试通过 (Receipt Commit/Release)
- [x] adapters/postgres 测试通过 (OutboxWriter Validate integration)
- [x] 集成测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>