### PR TITLE
fix(kernel/outbox): HandleResult zero value must not silently ACK (SOL-B-04)

### DIFF
--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -89,14 +89,28 @@ type Publisher interface {
 type Disposition uint8
 
 const (
-	DispositionAck     Disposition = iota // ACK — success or safe-to-skip duplicate
-	DispositionRequeue                    // NACK+requeue — transient / shutdown
-	DispositionReject                     // NACK+no-requeue — permanent failure → DLX
+	// DispositionAck indicates the message was processed successfully (or is a
+	// safe-to-skip duplicate); broker may discard.
+	//
+	// IMPORTANT: iota+1 ensures the zero value (0) is NOT a valid Disposition.
+	// A forgotten/uninitialised HandleResult.Disposition will NOT silently ACK.
+	DispositionAck     Disposition = iota + 1 // = 1
+	DispositionRequeue                        // NACK+requeue — transient / shutdown
+	DispositionReject                         // NACK+no-requeue — permanent failure → DLX
 )
 
+// Valid reports whether d is a recognised Disposition value.
+// The zero value is deliberately invalid to catch forgotten/uninitialised fields.
+func (d Disposition) Valid() bool {
+	return d >= DispositionAck && d <= DispositionReject
+}
+
 // String returns a human-readable label for the Disposition.
+// The zero value returns "invalid" to surface forgotten/uninitialised fields.
 func (d Disposition) String() string {
 	switch d {
+	case 0:
+		return "invalid"
 	case DispositionAck:
 		return "ack"
 	case DispositionRequeue:

--- a/src/kernel/outbox/outbox_test.go
+++ b/src/kernel/outbox/outbox_test.go
@@ -297,6 +297,7 @@ func TestDisposition_String(t *testing.T) {
 		d    Disposition
 		want string
 	}{
+		{Disposition(0), "invalid"},
 		{DispositionAck, "ack"},
 		{DispositionRequeue, "requeue"},
 		{DispositionReject, "reject"},
@@ -307,6 +308,43 @@ func TestDisposition_String(t *testing.T) {
 			assert.Equal(t, tt.want, tt.d.String())
 		})
 	}
+}
+
+func TestDisposition_Valid(t *testing.T) {
+	tests := []struct {
+		d    Disposition
+		want bool
+	}{
+		{Disposition(0), false},
+		{DispositionAck, true},
+		{DispositionRequeue, true},
+		{DispositionReject, true},
+		{Disposition(99), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.d.String(), func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.d.Valid())
+		})
+	}
+}
+
+func TestDisposition_ZeroValueIsNotAck(t *testing.T) {
+	// R-1: The zero value of Disposition MUST NOT equal DispositionAck.
+	// A forgotten/uninitialised HandleResult.Disposition must not silently ACK.
+	var zero Disposition
+	assert.NotEqual(t, DispositionAck, zero,
+		"zero-value Disposition must differ from DispositionAck")
+	assert.Equal(t, "invalid", zero.String(),
+		"zero-value Disposition.String() must return \"invalid\"")
+	assert.False(t, zero.Valid(),
+		"zero-value Disposition must not be valid")
+}
+
+func TestHandleResult_ZeroValueDispositionIsInvalid(t *testing.T) {
+	// R-1: HandleResult{} (zero value) must have an invalid Disposition.
+	var res HandleResult
+	assert.NotEqual(t, DispositionAck, res.Disposition)
+	assert.False(t, res.Disposition.Valid())
 }
 
 // --- WrapLegacyHandler Tests ---

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -264,13 +264,22 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 			if res.Receipt != nil {
 				releaseReceipt(ctx, res.Receipt, topic, entry.ID)
 			}
+			lastErr = res.Err
+			jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
+			delay := baseRetryDelay*(1<<attempt) + jitter
 			slog.Error("eventbus: invalid disposition, treating as requeue",
 				slog.String("topic", topic),
 				slog.String("entry_id", entry.ID),
 				slog.String("disposition", res.Disposition.String()),
+				slog.Int("attempt", attempt+1),
+				slog.Duration("retry_delay", delay),
 			)
-			lastErr = res.Err
-			continue
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+				continue
+			}
 		}
 	}
 

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -258,6 +258,19 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 			case <-time.After(delay):
 				continue
 			}
+		default:
+			// Zero-value or unknown Disposition — treat as requeue (safe degradation)
+			// and log at Error level so the programming mistake is surfaced.
+			if res.Receipt != nil {
+				releaseReceipt(ctx, res.Receipt, topic, entry.ID)
+			}
+			slog.Error("eventbus: invalid disposition, treating as requeue",
+				slog.String("topic", topic),
+				slog.String("entry_id", entry.ID),
+				slog.String("disposition", res.Disposition.String()),
+			)
+			lastErr = res.Err
+			continue
 		}
 	}
 

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -470,6 +470,154 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 	<-done
 }
 
+func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	var attempts atomic.Int32
+	var receipts []*mockReceipt
+	var receiptsMu sync.Mutex
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "zero.disp", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			attempts.Add(1)
+			r := &mockReceipt{}
+			receiptsMu.Lock()
+			receipts = append(receipts, r)
+			receiptsMu.Unlock()
+			// Zero-value HandleResult — Disposition is 0 (invalid).
+			return outbox.HandleResult{
+				Err:     errors.New("forgot disposition"),
+				Receipt: r,
+			}
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	start := time.Now()
+	err := bus.Publish(context.Background(), "zero.disp", []byte("data"))
+	require.NoError(t, err)
+
+	// Should exhaust retries and land in dead letter.
+	assert.Eventually(t, func() bool {
+		return bus.DeadLetterLen() == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	elapsed := time.Since(start)
+
+	// Must have retried exactly maxRetries times.
+	assert.Equal(t, int32(maxRetries), attempts.Load(),
+		"zero-value disposition should retry exactly maxRetries times")
+
+	// Must have applied backoff (at least ~300ms for 3 attempts: 100+200ms minimum).
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(250),
+		"zero-value disposition must apply backoff like DispositionRequeue")
+
+	// All receipts must be released, none committed.
+	receiptsMu.Lock()
+	defer receiptsMu.Unlock()
+	require.Len(t, receipts, maxRetries)
+	for i, r := range receipts {
+		assert.True(t, r.released.Load(), "receipt %d should be released", i)
+		assert.False(t, r.committed.Load(), "receipt %d should not be committed", i)
+	}
+
+	// Dead letter should contain the error.
+	dl := bus.DrainDeadLetters()
+	require.Len(t, dl, 1)
+	assert.Equal(t, "zero.disp", dl[0].Topic)
+
+	cancel()
+	<-done
+}
+
+func TestSubscribe_UnknownDisposition_TreatedAsRequeue(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	var attempts atomic.Int32
+	testErr := errors.New("unknown disp error")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "unknown.disp", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			attempts.Add(1)
+			return outbox.HandleResult{
+				Disposition: outbox.Disposition(99), // not a valid Disposition
+				Err:         testErr,
+			}
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	start := time.Now()
+	err := bus.Publish(context.Background(), "unknown.disp", []byte("data"))
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return bus.DeadLetterLen() == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	elapsed := time.Since(start)
+
+	assert.Equal(t, int32(maxRetries), attempts.Load(),
+		"unknown disposition should retry exactly maxRetries times")
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(250),
+		"unknown disposition must apply backoff")
+
+	dl := bus.DrainDeadLetters()
+	require.Len(t, dl, 1)
+	assert.Equal(t, testErr, dl[0].LastErr)
+
+	cancel()
+	<-done
+}
+
+func TestSubscribe_InvalidDisposition_RespectsCtxCancel(t *testing.T) {
+	bus := New(WithBufferSize(16))
+	defer func() { _ = bus.Close() }()
+
+	var attempts atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "cancel.disp", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			n := attempts.Add(1)
+			if n == 1 {
+				// After first attempt with invalid disposition, cancel ctx
+				// during backoff to verify early exit.
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					cancel()
+				}()
+			}
+			return outbox.HandleResult{} // zero-value
+		})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	err := bus.Publish(context.Background(), "cancel.disp", []byte("data"))
+	require.NoError(t, err)
+
+	// Subscribe should return promptly after cancel.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not exit after ctx cancel during invalid disposition backoff")
+	}
+
+	// Should have been called only once — cancelled during backoff before retry.
+	assert.Equal(t, int32(1), attempts.Load(),
+		"should exit during backoff, not retry after cancel")
+}
+
 // Verify interface compliance at compile time.
 var (
 	_ outbox.Publisher  = (*InMemoryEventBus)(nil)


### PR DESCRIPTION
## Summary
- `DispositionAck` changed from `iota` (=0) to `iota + 1` (=1) so zero-value HandleResult has invalid Disposition
- Added `Disposition.Valid()` method
- `Disposition.String()` returns `"invalid"` for zero value
- `runtime/eventbus` default branch treats zero/unknown Disposition as Requeue + slog.Error
- RabbitMQ `processDelivery` already had a default branch (no change needed)

## Test plan
- [x] `TestDisposition_Valid` — all values
- [x] `TestDisposition_ZeroValueIsNotAck` — R-1 safety assertion
- [x] `TestHandleResult_ZeroValueDispositionIsInvalid`
- [x] `go build ./...` passes
- [x] All 87 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)