### PR TITLE
fix(adapters/rabbitmq): B-03 reconnect backoff + K-2 net/http ADR

### DIFF
--- a/src/adapters/rabbitmq/connection.go
+++ b/src/adapters/rabbitmq/connection.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"math"
 	"math/rand/v2"
 	"net"
 	"net/url"
@@ -82,10 +81,10 @@ type Config struct {
 }
 
 func (c *Config) setDefaults() {
-	if c.ReconnectMaxBackoff == 0 {
+	if c.ReconnectMaxBackoff <= 0 {
 		c.ReconnectMaxBackoff = 30 * time.Second
 	}
-	if c.ReconnectBaseDelay == 0 {
+	if c.ReconnectBaseDelay <= 0 {
 		c.ReconnectBaseDelay = 1 * time.Second
 	}
 	if c.ChannelPoolSize <= 0 {
@@ -255,31 +254,35 @@ func (c *Connection) reconnectLoop() {
 		c.connected = make(chan struct{})
 		c.mu.Unlock()
 
-		c.reconnectWithBackoff()
-
-		c.mu.Lock()
-		close(c.connected)
-		c.mu.Unlock()
+		if c.reconnectWithBackoff() {
+			c.mu.Lock()
+			close(c.connected)
+			c.mu.Unlock()
+		}
+		// On permanent failure, connected stays open (never signalled).
+		// Callers blocked on WaitConnected will unblock when ctx is cancelled.
 	}
 }
 
-func (c *Connection) reconnectWithBackoff() {
+// reconnectWithBackoff attempts to re-establish the connection with exponential
+// backoff. Returns true if reconnected, false if gave up (permanent error or closed).
+func (c *Connection) reconnectWithBackoff() bool {
 	attempt := 0
 	for {
 		select {
 		case <-c.closeCh:
-			return
+			return false
 		default:
 		}
 
 		delay := c.backoffDelay(attempt)
-		slog.Info("rabbitmq: reconnect attempt",
+		slog.Warn("rabbitmq: reconnect attempt",
 			slog.Int("attempt", attempt+1),
 			slog.Duration("delay", delay))
 
 		select {
 		case <-c.closeCh:
-			return
+			return false
 		case <-time.After(delay):
 		}
 
@@ -295,7 +298,7 @@ func (c *Connection) reconnectWithBackoff() {
 				slog.Error("rabbitmq: permanent connection error, giving up",
 					slog.Int("attempt", attempt+1),
 					slog.String("error", err.Error()))
-				return
+				return false
 			}
 
 			slog.Warn("rabbitmq: reconnect failed (recoverable), will retry",
@@ -307,19 +310,30 @@ func (c *Connection) reconnectWithBackoff() {
 
 		slog.Info("rabbitmq: reconnected successfully",
 			slog.Int("attempts", attempt+1))
-		return
+		return true
 	}
 }
 
 // backoffDelay calculates the reconnect delay for the given attempt using
-// exponential backoff (base * 2^attempt) capped at ReconnectMaxBackoff,
-// with +-25% jitter to prevent thundering-herd reconnects.
+// exponential backoff (base * 2^attempt) with +-25% jitter, hard-capped at
+// ReconnectMaxBackoff. The jitter is applied before the cap so that
+// ReconnectMaxBackoff remains a true upper bound.
 func (c *Connection) backoffDelay(attempt int) time.Duration {
-	base := c.config.ReconnectBaseDelay * time.Duration(math.Pow(2, float64(attempt)))
-	if base > c.config.ReconnectMaxBackoff {
-		base = c.config.ReconnectMaxBackoff
+	// Cap the exponent to prevent int64 overflow in the bit-shift.
+	// 2^30 * 1s = ~34 years — well beyond any reasonable max backoff.
+	const maxExp = 30
+	if attempt > maxExp {
+		return c.config.ReconnectMaxBackoff
 	}
-	return addJitter(base)
+	base := c.config.ReconnectBaseDelay * time.Duration(1<<uint(attempt))
+	if base <= 0 { // overflow guard
+		return c.config.ReconnectMaxBackoff
+	}
+	withJitter := addJitter(base)
+	if withJitter > c.config.ReconnectMaxBackoff {
+		return c.config.ReconnectMaxBackoff
+	}
+	return withJitter
 }
 
 // addJitter applies +-25% random jitter to a duration.
@@ -439,6 +453,9 @@ func (c *Connection) WaitConnected(ctx context.Context) error {
 
 // sanitizeURL redacts credentials from the AMQP URL for safe logging.
 func sanitizeURL(raw string) string {
+	if raw == "" {
+		return "amqp://***"
+	}
 	u, err := url.Parse(raw)
 	if err != nil {
 		return "amqp://***"

--- a/src/adapters/rabbitmq/connection.go
+++ b/src/adapters/rabbitmq/connection.go
@@ -455,17 +455,25 @@ func (c *Connection) drainChannelPool() {
 }
 
 // AcquireChannel gets a channel from the pool or creates a new one.
+// Returns the permanent error if the connection is in terminal state.
 func (c *Connection) AcquireChannel() (AMQPChannel, error) {
+	c.mu.RLock()
+	permErr := c.permanentErr
+	conn := c.conn
+	c.mu.RUnlock()
+
+	// Terminal state: return permanent error so callers (Publisher, Subscriber)
+	// get a consistent error code instead of generic "connection not available".
+	if permErr != nil {
+		return nil, permErr
+	}
+
 	// Try to get from pool first.
 	select {
 	case ch := <-c.channelPool:
 		return ch, nil
 	default:
 	}
-
-	c.mu.RLock()
-	conn := c.conn
-	c.mu.RUnlock()
 
 	if conn == nil || conn.IsClosed() {
 		return nil, errcode.New(ErrAdapterAMQPConnect, "rabbitmq: connection not available")

--- a/src/adapters/rabbitmq/connection.go
+++ b/src/adapters/rabbitmq/connection.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math/bits"
 	"math/rand/v2"
 	"net"
+	"strings"
 	"net/url"
 	"sync"
 	"time"
@@ -27,12 +29,14 @@ const (
 
 // isPermanentDialError returns true if the error from Dial indicates a
 // permanent condition that will not resolve by retrying (e.g., authentication
-// failure, vhost not found). Network-level errors (timeout, connection refused,
-// DNS resolution) are considered recoverable and return false.
+// failure, vhost not found, bad URI, TLS misconfiguration).
 //
 // ref: rabbitmq/amqp091-go README — reconnection is delegated to the caller;
 // the library surfaces amqp.Error with Recover=false for auth/vhost/protocol
-// issues during the AMQP handshake.
+// issues during the AMQP handshake. However, amqp091-go also returns plain
+// errors (not *amqp.Error) for pre-handshake failures: URI parse errors,
+// unsupported auth_mechanism, TLS config/handshake failures. These are
+// permanent configuration errors that should not be retried.
 func isPermanentDialError(err error) bool {
 	if err == nil {
 		return false
@@ -54,8 +58,29 @@ func isPermanentDialError(err error) bool {
 		return false
 	}
 
+	// Pre-handshake permanent errors from amqp091-go that are plain errors
+	// (not *amqp.Error, not net.Error): URI parse failure, unsupported
+	// auth_mechanism, TLS config generation, TLS handshake failure.
+	// These are configuration errors that will never self-resolve.
+	msg := err.Error()
+	for _, keyword := range permanentDialKeywords {
+		if strings.Contains(msg, keyword) {
+			return true
+		}
+	}
+
 	// Unknown errors default to recoverable to avoid false-positive abort.
 	return false
+}
+
+// permanentDialKeywords are substrings found in amqp091-go plain-error messages
+// that indicate permanent (non-retryable) dial failures. Sourced from
+// amqp091-go v1.10.0: uri.go, connection.go, tls.go.
+var permanentDialKeywords = []string{
+	"AMQP URI",          // amqp.ParseURI → malformed URI
+	"auth mechanism",    // connection.go → unsupported SASL mechanism
+	"x509:",             // crypto/tls → certificate validation failure
+	"tls: ",             // crypto/tls → handshake / protocol error
 }
 
 // Config holds configuration for the RabbitMQ connection.
@@ -90,7 +115,7 @@ func (c *Config) setDefaults() {
 	if c.ChannelPoolSize <= 0 {
 		c.ChannelPoolSize = 10
 	}
-	if c.ConfirmTimeout == 0 {
+	if c.ConfirmTimeout <= 0 {
 		c.ConfirmTimeout = 5 * time.Second
 	}
 }
@@ -258,9 +283,14 @@ func (c *Connection) reconnectLoop() {
 			c.mu.Lock()
 			close(c.connected)
 			c.mu.Unlock()
+		} else {
+			// Permanent failure — stop reconnect loop.
+			// TODO(Phase2-EventRouter): connected stays open, so WaitConnected callers
+			// block until ctx is cancelled. This means permanent dial failures (credential
+			// revocation, vhost removal) cause silent consumer stall. Phase 2 EventRouter
+			// will propagate permanent errors to subscribers via Router.Run return value.
+			return
 		}
-		// On permanent failure, connected stays open (never signalled).
-		// Callers blocked on WaitConnected will unblock when ctx is cancelled.
 	}
 }
 
@@ -315,25 +345,52 @@ func (c *Connection) reconnectWithBackoff() bool {
 }
 
 // backoffDelay calculates the reconnect delay for the given attempt using
-// exponential backoff (base * 2^attempt) with +-25% jitter, hard-capped at
-// ReconnectMaxBackoff. The jitter is applied before the cap so that
-// ReconnectMaxBackoff remains a true upper bound.
+// exponential backoff (base * 2^attempt) with +-25% jitter.
+//
+// When the exponential value reaches or exceeds ReconnectMaxBackoff, jitter
+// is applied to ReconnectMaxBackoff itself (not the uncapped value), so the
+// capped result is always in [0.75*max, max]. This prevents thundering-herd
+// at the cap while keeping ReconnectMaxBackoff as a true upper bound.
 func (c *Connection) backoffDelay(attempt int) time.Duration {
-	// Cap the exponent to prevent int64 overflow in the bit-shift.
-	// 2^30 * 1s = ~34 years — well beyond any reasonable max backoff.
-	const maxExp = 30
-	if attempt > maxExp {
-		return c.config.ReconnectMaxBackoff
+	maxBackoff := c.config.ReconnectMaxBackoff
+	base := c.config.ReconnectBaseDelay
+
+	// Compute max safe exponent: 63 - bits needed to represent base.
+	// This adapts to any ReconnectBaseDelay (1ns → exp 62, 1s → exp 33).
+	safeExp := 63 - bits.Len64(uint64(base))
+	if attempt > safeExp {
+		return addDownJitter(maxBackoff)
 	}
-	base := c.config.ReconnectBaseDelay * time.Duration(1<<uint(attempt))
-	if base <= 0 { // overflow guard
-		return c.config.ReconnectMaxBackoff
+
+	delay := base * time.Duration(1<<uint(attempt))
+	if delay <= 0 { // overflow guard
+		return addDownJitter(maxBackoff)
 	}
-	withJitter := addJitter(base)
-	if withJitter > c.config.ReconnectMaxBackoff {
-		return c.config.ReconnectMaxBackoff
+
+	if delay >= maxBackoff {
+		// Capped region: apply downward-only jitter [0.75*max, max] to prevent
+		// thundering-herd while keeping maxBackoff as a true upper bound.
+		return addDownJitter(maxBackoff)
+	}
+
+	// Uncapped region: jitter on actual delay. Cap any overshoot from +25%.
+	withJitter := addJitter(delay)
+	if withJitter > maxBackoff {
+		return maxBackoff
 	}
 	return withJitter
+}
+
+// addDownJitter applies 0-25% downward jitter to a duration.
+// The result is in the range [0.75*d, d]. Used when d is already at the
+// maximum allowed value so the result never exceeds the cap.
+func addDownJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	// Remove up to 25% of d.
+	reduction := rand.Int64N(int64(d)/4 + 1)
+	return d - time.Duration(reduction)
 }
 
 // addJitter applies +-25% random jitter to a duration.

--- a/src/adapters/rabbitmq/connection.go
+++ b/src/adapters/rabbitmq/connection.go
@@ -2,8 +2,11 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"math"
+	"math/rand/v2"
+	"net"
 	"net/url"
 	"sync"
 	"time"
@@ -15,12 +18,46 @@ import (
 
 // Error codes for the RabbitMQ adapter.
 const (
-	ErrAdapterAMQPConnect        errcode.Code = "ERR_ADAPTER_AMQP_CONNECT"
-	ErrAdapterAMQPPublish        errcode.Code = "ERR_ADAPTER_AMQP_PUBLISH"
-	ErrAdapterAMQPConfirmTimeout errcode.Code = "ERR_ADAPTER_AMQP_CONFIRM_TIMEOUT"
-	ErrAdapterAMQPSubscribe      errcode.Code = "ERR_ADAPTER_AMQP_SUBSCRIBE"
-	ErrAdapterAMQPConsume        errcode.Code = "ERR_ADAPTER_AMQP_CONSUME"
+	ErrAdapterAMQPConnect          errcode.Code = "ERR_ADAPTER_AMQP_CONNECT"
+	ErrAdapterAMQPConnectPermanent errcode.Code = "ERR_ADAPTER_AMQP_CONNECT_PERMANENT"
+	ErrAdapterAMQPPublish          errcode.Code = "ERR_ADAPTER_AMQP_PUBLISH"
+	ErrAdapterAMQPConfirmTimeout   errcode.Code = "ERR_ADAPTER_AMQP_CONFIRM_TIMEOUT"
+	ErrAdapterAMQPSubscribe        errcode.Code = "ERR_ADAPTER_AMQP_SUBSCRIBE"
+	ErrAdapterAMQPConsume          errcode.Code = "ERR_ADAPTER_AMQP_CONSUME"
 )
+
+// isPermanentDialError returns true if the error from Dial indicates a
+// permanent condition that will not resolve by retrying (e.g., authentication
+// failure, vhost not found). Network-level errors (timeout, connection refused,
+// DNS resolution) are considered recoverable and return false.
+//
+// ref: rabbitmq/amqp091-go README — reconnection is delegated to the caller;
+// the library surfaces amqp.Error with Recover=false for auth/vhost/protocol
+// issues during the AMQP handshake.
+func isPermanentDialError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// AMQP protocol errors from the broker handshake.
+	// Recover=false means the broker will not recover the connection:
+	//   403 ACCESS_REFUSED  — bad credentials or no permission
+	//   404 NOT_FOUND       — vhost does not exist
+	//   530 NOT_ALLOWED     — connection not allowed (policy)
+	var amqpErr *amqp.Error
+	if errors.As(err, &amqpErr) {
+		return !amqpErr.Recover
+	}
+
+	// Network-level errors are recoverable (timeout, refused, DNS).
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return false
+	}
+
+	// Unknown errors default to recoverable to avoid false-positive abort.
+	return false
+}
 
 // Config holds configuration for the RabbitMQ connection.
 type Config struct {
@@ -247,7 +284,21 @@ func (c *Connection) reconnectWithBackoff() {
 		}
 
 		if err := c.connect(); err != nil {
-			slog.Warn("rabbitmq: reconnect failed",
+			// Unwrap the errcode wrapper to inspect the underlying dial error.
+			var ecErr *errcode.Error
+			dialErr := err
+			if errors.As(err, &ecErr) && ecErr.Unwrap() != nil {
+				dialErr = ecErr.Unwrap()
+			}
+
+			if isPermanentDialError(dialErr) {
+				slog.Error("rabbitmq: permanent connection error, giving up",
+					slog.Int("attempt", attempt+1),
+					slog.String("error", err.Error()))
+				return
+			}
+
+			slog.Warn("rabbitmq: reconnect failed (recoverable), will retry",
 				slog.Int("attempt", attempt+1),
 				slog.String("error", err.Error()))
 			attempt++
@@ -260,12 +311,29 @@ func (c *Connection) reconnectWithBackoff() {
 	}
 }
 
+// backoffDelay calculates the reconnect delay for the given attempt using
+// exponential backoff (base * 2^attempt) capped at ReconnectMaxBackoff,
+// with +-25% jitter to prevent thundering-herd reconnects.
 func (c *Connection) backoffDelay(attempt int) time.Duration {
-	delay := c.config.ReconnectBaseDelay * time.Duration(math.Pow(2, float64(attempt)))
-	if delay > c.config.ReconnectMaxBackoff {
-		delay = c.config.ReconnectMaxBackoff
+	base := c.config.ReconnectBaseDelay * time.Duration(math.Pow(2, float64(attempt)))
+	if base > c.config.ReconnectMaxBackoff {
+		base = c.config.ReconnectMaxBackoff
 	}
-	return delay
+	return addJitter(base)
+}
+
+// addJitter applies +-25% random jitter to a duration.
+// The result is in the range [0.75*d, 1.25*d].
+func addJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	// jitter range: 50% of d (from -25% to +25%)
+	jitterRange := int64(d) / 2
+	// offset: random value in [0, jitterRange]
+	offset := rand.Int64N(jitterRange + 1)
+	// shift to [-25%, +25%]: subtract 25% of d
+	return time.Duration(int64(d) - jitterRange/2 + offset)
 }
 
 func (c *Connection) drainChannelPool() {

--- a/src/adapters/rabbitmq/connection.go
+++ b/src/adapters/rabbitmq/connection.go
@@ -28,40 +28,45 @@ const (
 )
 
 // isPermanentDialError returns true if the error from Dial indicates a
-// permanent condition that will not resolve by retrying (e.g., authentication
-// failure, vhost not found, bad URI, TLS misconfiguration).
+// permanent condition that will not resolve by retrying.
+//
+// Classification strategy (structured first, string fallback):
+//  1. *amqp.Error with Recover=false → permanent (broker handshake rejection)
+//  2. net.Error → recoverable (network-level: timeout, refused, DNS)
+//  3. *url.Error → permanent (URI parse failure, structural)
+//  4. String keyword fallback → permanent for known amqp091-go plain errors
+//  5. Default → recoverable (avoid false-positive abort)
 //
 // ref: rabbitmq/amqp091-go README — reconnection is delegated to the caller;
-// the library surfaces amqp.Error with Recover=false for auth/vhost/protocol
-// issues during the AMQP handshake. However, amqp091-go also returns plain
-// errors (not *amqp.Error) for pre-handshake failures: URI parse errors,
-// unsupported auth_mechanism, TLS config/handshake failures. These are
-// permanent configuration errors that should not be retried.
+// amqp091-go surfaces *amqp.Error for handshake issues and plain errors for
+// pre-handshake failures (URI parse, auth mechanism, TLS).
 func isPermanentDialError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	// AMQP protocol errors from the broker handshake.
-	// Recover=false means the broker will not recover the connection:
-	//   403 ACCESS_REFUSED  — bad credentials or no permission
-	//   404 NOT_FOUND       — vhost does not exist
-	//   530 NOT_ALLOWED     — connection not allowed (policy)
+	// 1. AMQP protocol errors from the broker handshake.
+	// Recover=false: 403 ACCESS_REFUSED, 404 NOT_FOUND, 530 NOT_ALLOWED.
 	var amqpErr *amqp.Error
 	if errors.As(err, &amqpErr) {
 		return !amqpErr.Recover
 	}
 
-	// Network-level errors are recoverable (timeout, refused, DNS).
+	// 2. Network-level errors are recoverable (timeout, refused, DNS).
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		return false
 	}
 
-	// Pre-handshake permanent errors from amqp091-go that are plain errors
-	// (not *amqp.Error, not net.Error): URI parse failure, unsupported
-	// auth_mechanism, TLS config generation, TLS handshake failure.
-	// These are configuration errors that will never self-resolve.
+	// 3. URL parse errors are structural/permanent.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+
+	// 4. String keyword fallback for amqp091-go plain errors that don't
+	// implement a typed error. These are pre-handshake configuration errors
+	// (sourced from amqp091-go v1.10.0: uri.go, connection.go, tls.go).
 	msg := err.Error()
 	for _, keyword := range permanentDialKeywords {
 		if strings.Contains(msg, keyword) {
@@ -69,18 +74,18 @@ func isPermanentDialError(err error) bool {
 		}
 	}
 
-	// Unknown errors default to recoverable to avoid false-positive abort.
+	// 5. Unknown errors default to recoverable to avoid false-positive abort.
 	return false
 }
 
-// permanentDialKeywords are substrings found in amqp091-go plain-error messages
-// that indicate permanent (non-retryable) dial failures. Sourced from
-// amqp091-go v1.10.0: uri.go, connection.go, tls.go.
+// permanentDialKeywords are substrings in amqp091-go plain-error messages
+// that indicate permanent dial failures. String matching is the last resort —
+// structural checks (amqp.Error, net.Error, url.Error) are tried first.
 var permanentDialKeywords = []string{
-	"AMQP URI",          // amqp.ParseURI → malformed URI
-	"auth mechanism",    // connection.go → unsupported SASL mechanism
-	"x509:",             // crypto/tls → certificate validation failure
-	"tls: ",             // crypto/tls → handshake / protocol error
+	"AMQP URI",       // amqp.ParseURI → malformed URI
+	"auth mechanism", // connection.go → unsupported SASL mechanism
+	"x509:",          // crypto/tls → certificate validation failure
+	"tls: ",          // crypto/tls → handshake / protocol error
 }
 
 // Config holds configuration for the RabbitMQ connection.
@@ -178,6 +183,11 @@ func DefaultDial(url string) (AMQPConnection, error) {
 }
 
 // Connection manages an AMQP connection with auto-reconnect and channel pooling.
+//
+// Connection has three states:
+//   - connected:    ready for use (connected channel is closed)
+//   - reconnecting: lost connection, attempting backoff reconnect
+//   - terminal:     permanent error, will not reconnect (failed channel is closed)
 type Connection struct {
 	config Config
 	dial   DialFunc
@@ -192,6 +202,11 @@ type Connection struct {
 
 	// connected is closed when a connection is established, re-created on disconnect.
 	connected chan struct{}
+
+	// failed is closed when a permanent dial error is encountered.
+	// permanentErr holds the error for callers to inspect.
+	failed       chan struct{}
+	permanentErr error
 }
 
 // NewConnection creates a new Connection with the given config.
@@ -205,6 +220,7 @@ func NewConnection(config Config, opts ...ConnectionOption) (*Connection, error)
 		channelPool: make(chan AMQPChannel, config.ChannelPoolSize),
 		closeCh:     make(chan struct{}),
 		connected:   make(chan struct{}),
+		failed:      make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -212,6 +228,16 @@ func NewConnection(config Config, opts ...ConnectionOption) (*Connection, error)
 	}
 
 	if err := c.connect(); err != nil {
+		// Classify initial connection failure: permanent errors get a distinct code
+		// so callers can fail-fast on bad credentials, bad URI, TLS misconfiguration.
+		var ecErr *errcode.Error
+		dialErr := err
+		if errors.As(err, &ecErr) && ecErr.Unwrap() != nil {
+			dialErr = ecErr.Unwrap()
+		}
+		if isPermanentDialError(dialErr) {
+			return nil, errcode.Wrap(ErrAdapterAMQPConnectPermanent, "rabbitmq: initial connection failed (permanent)", err)
+		}
 		return nil, errcode.Wrap(ErrAdapterAMQPConnect, "rabbitmq: initial connection failed", err)
 	}
 
@@ -279,29 +305,34 @@ func (c *Connection) reconnectLoop() {
 		c.connected = make(chan struct{})
 		c.mu.Unlock()
 
-		if c.reconnectWithBackoff() {
+		ok, permErr := c.reconnectWithBackoff()
+		if ok {
 			c.mu.Lock()
 			close(c.connected)
 			c.mu.Unlock()
+		} else if permErr != nil {
+			// Terminal state: permanent dial error. Signal all WaitConnected callers.
+			c.mu.Lock()
+			c.permanentErr = permErr
+			close(c.failed)
+			c.mu.Unlock()
+			return
 		} else {
-			// Permanent failure — stop reconnect loop.
-			// TODO(Phase2-EventRouter): connected stays open, so WaitConnected callers
-			// block until ctx is cancelled. This means permanent dial failures (credential
-			// revocation, vhost removal) cause silent consumer stall. Phase 2 EventRouter
-			// will propagate permanent errors to subscribers via Router.Run return value.
+			// closeCh fired — clean shutdown, no terminal error.
 			return
 		}
 	}
 }
 
 // reconnectWithBackoff attempts to re-establish the connection with exponential
-// backoff. Returns true if reconnected, false if gave up (permanent error or closed).
-func (c *Connection) reconnectWithBackoff() bool {
+// backoff. Returns (true, nil) on success, (false, err) on permanent failure,
+// or (false, nil) if closeCh fired (clean shutdown).
+func (c *Connection) reconnectWithBackoff() (bool, error) {
 	attempt := 0
 	for {
 		select {
 		case <-c.closeCh:
-			return false
+			return false, nil
 		default:
 		}
 
@@ -312,7 +343,7 @@ func (c *Connection) reconnectWithBackoff() bool {
 
 		select {
 		case <-c.closeCh:
-			return false
+			return false, nil
 		case <-time.After(delay):
 		}
 
@@ -325,10 +356,12 @@ func (c *Connection) reconnectWithBackoff() bool {
 			}
 
 			if isPermanentDialError(dialErr) {
+				permErr := errcode.Wrap(ErrAdapterAMQPConnectPermanent,
+					"rabbitmq: permanent connection error, giving up", err)
 				slog.Error("rabbitmq: permanent connection error, giving up",
 					slog.Int("attempt", attempt+1),
 					slog.String("error", err.Error()))
-				return false
+				return false, permErr
 			}
 
 			slog.Warn("rabbitmq: reconnect failed (recoverable), will retry",
@@ -340,7 +373,7 @@ func (c *Connection) reconnectWithBackoff() bool {
 
 		slog.Info("rabbitmq: reconnected successfully",
 			slog.Int("attempts", attempt+1))
-		return true
+		return true, nil
 	}
 }
 
@@ -458,12 +491,17 @@ func (c *Connection) ReleaseChannel(ch AMQPChannel) {
 	}
 }
 
-// Health checks if the connection is alive.
+// Health checks if the connection is alive. Returns a permanent error if the
+// connection entered terminal state (e.g., credential revocation).
 func (c *Connection) Health() error {
 	c.mu.RLock()
 	conn := c.conn
+	permErr := c.permanentErr
 	c.mu.RUnlock()
 
+	if permErr != nil {
+		return permErr
+	}
 	if conn == nil || conn.IsClosed() {
 		return errcode.New(ErrAdapterAMQPConnect, "rabbitmq: connection is closed")
 	}
@@ -494,15 +532,23 @@ func (c *Connection) Close() error {
 	return nil
 }
 
-// WaitConnected blocks until the connection is established or ctx is cancelled.
+// WaitConnected blocks until the connection is established, a permanent error
+// occurs, or ctx is cancelled. Returns the permanent error if the connection
+// entered terminal state.
 func (c *Connection) WaitConnected(ctx context.Context) error {
 	c.mu.RLock()
 	connected := c.connected
+	failed := c.failed
 	c.mu.RUnlock()
 
 	select {
 	case <-connected:
 		return nil
+	case <-failed:
+		c.mu.RLock()
+		err := c.permanentErr
+		c.mu.RUnlock()
+		return err
 	case <-ctx.Done():
 		return errcode.Wrap(ErrAdapterAMQPConnect, "rabbitmq: wait for connection cancelled", ctx.Err())
 	}

--- a/src/adapters/rabbitmq/publisher.go
+++ b/src/adapters/rabbitmq/publisher.go
@@ -2,6 +2,7 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -31,6 +32,12 @@ func NewPublisher(conn *Connection) *Publisher {
 func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) error {
 	ch, err := p.conn.AcquireChannel()
 	if err != nil {
+		// Preserve permanent error code from Connection terminal state so callers
+		// can distinguish "permanent config failure" from "transient publish failure".
+		var ecErr *errcode.Error
+		if errors.As(err, &ecErr) && ecErr.Code == ErrAdapterAMQPConnectPermanent {
+			return err
+		}
 		return errcode.Wrap(ErrAdapterAMQPPublish, "rabbitmq: acquire channel for publish", err)
 	}
 	defer p.conn.ReleaseChannel(ch)

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -459,26 +459,33 @@ func TestConnection_BackoffDelay(t *testing.T) {
 	conn, _ := newTestConnection(t)
 
 	tests := []struct {
-		name    string
-		attempt int
-		// baseDelay is the expected delay before jitter (+-25%).
-		baseDelay time.Duration
+		name     string
+		attempt  int
+		minDelay time.Duration
+		maxDelay time.Duration // hard cap: never exceeds ReconnectMaxBackoff (30s)
 	}{
-		{name: "attempt 0", attempt: 0, baseDelay: 1 * time.Second},
-		{name: "attempt 1", attempt: 1, baseDelay: 2 * time.Second},
-		{name: "attempt 2", attempt: 2, baseDelay: 4 * time.Second},
-		{name: "attempt 10 (capped)", attempt: 10, baseDelay: 30 * time.Second},
+		{name: "attempt 0", attempt: 0,
+			minDelay: 750 * time.Millisecond, maxDelay: 1250 * time.Millisecond},
+		{name: "attempt 1", attempt: 1,
+			minDelay: 1500 * time.Millisecond, maxDelay: 2500 * time.Millisecond},
+		{name: "attempt 2", attempt: 2,
+			minDelay: 3 * time.Second, maxDelay: 5 * time.Second},
+		// Capped at MaxBackoff (30s) — jitter may reduce but never exceed.
+		{name: "attempt 10 (capped)", attempt: 10,
+			minDelay: 1 * time.Millisecond, maxDelay: 30 * time.Second},
+		{name: "attempt 34 (overflow guard)", attempt: 34,
+			minDelay: 30 * time.Second, maxDelay: 30 * time.Second},
+		{name: "attempt 100 (far overflow)", attempt: 100,
+			minDelay: 30 * time.Second, maxDelay: 30 * time.Second},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			delay := conn.backoffDelay(tt.attempt)
-			minDelay := time.Duration(float64(tt.baseDelay) * 0.75)
-			maxDelay := time.Duration(float64(tt.baseDelay) * 1.25)
-			assert.GreaterOrEqual(t, delay, minDelay,
-				"delay %v should be >= 75%% of base %v", delay, tt.baseDelay)
-			assert.LessOrEqual(t, delay, maxDelay,
-				"delay %v should be <= 125%% of base %v", delay, tt.baseDelay)
+			assert.GreaterOrEqual(t, delay, tt.minDelay,
+				"delay %v should be >= %v", delay, tt.minDelay)
+			assert.LessOrEqual(t, delay, tt.maxDelay,
+				"delay %v should be <= %v (hard cap)", delay, tt.maxDelay)
 		})
 	}
 }
@@ -600,9 +607,9 @@ func TestSanitizeURL(t *testing.T) {
 			expected: "amqp://***:***@rabbit.example.com:5672/production",
 		},
 		{
-			name:     "empty string returns empty",
+			name:     "empty string returns redacted placeholder",
 			url:      "",
-			expected: "",
+			expected: "amqp://***",
 		},
 		{
 			name:     "amqps scheme with credentials",
@@ -622,6 +629,68 @@ func TestSanitizeURL(t *testing.T) {
 			assert.NotContains(t, result, ":pass@")
 		})
 	}
+}
+
+func TestConnection_ReconnectWithBackoff_PermanentError_ReturnsFalse(t *testing.T) {
+	// reconnectWithBackoff should return false when dial returns a permanent error,
+	// so reconnectLoop does NOT close(connected) — preventing false "connected" signal.
+	permanentErr := &amqp.Error{Code: 403, Reason: "ACCESS_REFUSED", Recover: false}
+
+	conn := &Connection{
+		config: Config{
+			URL:                 "amqp://test:test@localhost:5672/",
+			ReconnectBaseDelay:  1 * time.Millisecond,
+			ReconnectMaxBackoff: 5 * time.Millisecond,
+		},
+		dial: func(url string) (AMQPConnection, error) {
+			return nil, permanentErr
+		},
+		closeCh:   make(chan struct{}),
+		connected: make(chan struct{}),
+	}
+
+	result := conn.reconnectWithBackoff()
+	assert.False(t, result, "reconnectWithBackoff must return false on permanent dial error")
+
+	// connected channel must NOT be closed — WaitConnected should block.
+	select {
+	case <-conn.connected:
+		t.Fatal("connected channel was closed after permanent error — WaitConnected would falsely succeed")
+	default:
+		// Good: channel is still open.
+	}
+}
+
+func TestConnection_ReconnectWithBackoff_RecoverableError_ThenSuccess(t *testing.T) {
+	// reconnectWithBackoff should return true after recovering from a transient error.
+	var mu sync.Mutex
+	dialCount := 0
+	conn := &Connection{
+		config: Config{
+			URL:                 "amqp://test:test@localhost:5672/",
+			ReconnectBaseDelay:  1 * time.Millisecond,
+			ReconnectMaxBackoff: 5 * time.Millisecond,
+		},
+		dial: func(url string) (AMQPConnection, error) {
+			mu.Lock()
+			dialCount++
+			n := dialCount
+			mu.Unlock()
+			if n <= 2 {
+				return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+			}
+			return newMockConnection(), nil
+		},
+		closeCh:   make(chan struct{}),
+		connected: make(chan struct{}),
+	}
+
+	result := conn.reconnectWithBackoff()
+	assert.True(t, result, "reconnectWithBackoff must return true after successful reconnect")
+
+	mu.Lock()
+	assert.Equal(t, 3, dialCount, "should have tried 3 times (2 failures + 1 success)")
+	mu.Unlock()
 }
 
 // =============================================================================

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -455,6 +455,21 @@ func TestConfig_Defaults(t *testing.T) {
 	assert.Equal(t, 5*time.Second, cfg.ConfirmTimeout)
 }
 
+func TestConfig_Defaults_NegativeValues(t *testing.T) {
+	cfg := Config{
+		ReconnectMaxBackoff: -1 * time.Second,
+		ReconnectBaseDelay:  -500 * time.Millisecond,
+		ChannelPoolSize:     -5,
+		ConfirmTimeout:      -3 * time.Second,
+	}
+	cfg.setDefaults()
+
+	assert.Equal(t, 30*time.Second, cfg.ReconnectMaxBackoff, "negative MaxBackoff should reset to default")
+	assert.Equal(t, 1*time.Second, cfg.ReconnectBaseDelay, "negative BaseDelay should reset to default")
+	assert.Equal(t, 10, cfg.ChannelPoolSize, "negative ChannelPoolSize should reset to default")
+	assert.Equal(t, 5*time.Second, cfg.ConfirmTimeout, "negative ConfirmTimeout should reset to default")
+}
+
 func TestConnection_BackoffDelay(t *testing.T) {
 	conn, _ := newTestConnection(t)
 
@@ -470,13 +485,13 @@ func TestConnection_BackoffDelay(t *testing.T) {
 			minDelay: 1500 * time.Millisecond, maxDelay: 2500 * time.Millisecond},
 		{name: "attempt 2", attempt: 2,
 			minDelay: 3 * time.Second, maxDelay: 5 * time.Second},
-		// Capped at MaxBackoff (30s) — jitter may reduce but never exceed.
+		// Capped region: jitter on MaxBackoff → [0.75*30s, 30s] = [22.5s, 30s].
 		{name: "attempt 10 (capped)", attempt: 10,
-			minDelay: 1 * time.Millisecond, maxDelay: 30 * time.Second},
+			minDelay: 22500 * time.Millisecond, maxDelay: 30 * time.Second},
 		{name: "attempt 34 (overflow guard)", attempt: 34,
-			minDelay: 30 * time.Second, maxDelay: 30 * time.Second},
+			minDelay: 22500 * time.Millisecond, maxDelay: 30 * time.Second},
 		{name: "attempt 100 (far overflow)", attempt: 100,
-			minDelay: 30 * time.Second, maxDelay: 30 * time.Second},
+			minDelay: 22500 * time.Millisecond, maxDelay: 30 * time.Second},
 	}
 
 	for _, tt := range tests {
@@ -569,6 +584,37 @@ func TestIsPermanentDialError(t *testing.T) {
 			name: "wrapped AMQP permanent error",
 			err:  fmt.Errorf("dial: %w", &amqp.Error{Code: 403, Reason: "ACCESS_REFUSED", Server: true, Recover: false}),
 			want: true,
+		},
+		// Plain errors from amqp091-go pre-handshake failures (U2).
+		{
+			name: "URI parse failure — permanent",
+			err:  errors.New("AMQP URI must start with amqp:// or amqps://"),
+			want: true,
+		},
+		{
+			name: "unsupported auth mechanism — permanent",
+			err:  errors.New("unsupported auth mechanism EXTERNAL: no credentials provided"),
+			want: true,
+		},
+		{
+			name: "x509 certificate error — permanent",
+			err:  errors.New("x509: certificate signed by unknown authority"),
+			want: true,
+		},
+		{
+			name: "TLS handshake error — permanent",
+			err:  errors.New("tls: first record does not look like a TLS handshake"),
+			want: true,
+		},
+		{
+			name: "wrapped URI parse failure — permanent",
+			err:  fmt.Errorf("dial: %w", errors.New("AMQP URI scheme must be amqp:// or amqps://")),
+			want: true,
+		},
+		{
+			name: "generic unknown error — recoverable",
+			err:  errors.New("some transient hiccup"),
+			want: false,
 		},
 	}
 
@@ -691,6 +737,40 @@ func TestConnection_ReconnectWithBackoff_RecoverableError_ThenSuccess(t *testing
 	mu.Lock()
 	assert.Equal(t, 3, dialCount, "should have tried 3 times (2 failures + 1 success)")
 	mu.Unlock()
+}
+
+func TestConnection_ReconnectWithBackoff_CloseCh_ReturnsFalse(t *testing.T) {
+	// When closeCh is closed during backoff wait, reconnectWithBackoff should
+	// return false promptly without waiting for the full delay.
+	closeCh := make(chan struct{})
+	conn := &Connection{
+		config: Config{
+			URL:                 "amqp://test:test@localhost:5672/",
+			ReconnectBaseDelay:  10 * time.Second, // long delay to ensure we'd block
+			ReconnectMaxBackoff: 30 * time.Second,
+		},
+		dial: func(url string) (AMQPConnection, error) {
+			return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		},
+		closeCh:   closeCh,
+		connected: make(chan struct{}),
+	}
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- conn.reconnectWithBackoff()
+	}()
+
+	// Close after a short delay — should interrupt the backoff wait.
+	time.Sleep(50 * time.Millisecond)
+	close(closeCh)
+
+	select {
+	case result := <-done:
+		assert.False(t, result, "reconnectWithBackoff must return false when closeCh fires")
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnectWithBackoff did not return after closeCh was closed")
+	}
 }
 
 // =============================================================================

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -167,16 +167,13 @@ type mockConnection struct {
 	// Channel() pops from the front. Falls back to nextCh / newMockChannel.
 	channelQueue []*mockChannel
 
-	notifyCloseCh    chan *amqp.Error
-	notifyCloseCalls int // number of times NotifyClose was called
-	isClosed         bool
+	notifyCloseCh chan *amqp.Error
+	isClosed      bool
 	closeErr         error
 }
 
 func newMockConnection() *mockConnection {
-	return &mockConnection{
-		notifyCloseCh: make(chan *amqp.Error, 1),
-	}
+	return &mockConnection{}
 }
 
 func (m *mockConnection) Channel() (AMQPChannel, error) {
@@ -205,7 +202,6 @@ func (m *mockConnection) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.notifyCloseCh = receiver
-	m.notifyCloseCalls++
 	return receiver
 }
 
@@ -612,13 +608,11 @@ func TestConnection_ReconnectLoop_DisconnectAndReconnect(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// Wait for reconnectLoop to call NotifyClose (not just check the initial channel
-	// from newMockConnection — we need notifyCloseCalls > 0 to confirm reconnectLoop
-	// has registered its own channel).
+	// Wait for reconnectLoop to call NotifyClose.
 	require.Eventually(t, func() bool {
 		mocks[0].mu.Lock()
 		defer mocks[0].mu.Unlock()
-		return mocks[0].notifyCloseCalls > 0
+		return mocks[0].notifyCloseCh != nil
 	}, time.Second, time.Millisecond, "reconnectLoop did not call NotifyClose")
 
 	// Now send on the channel that reconnectLoop is actually selecting on.
@@ -667,7 +661,7 @@ func TestConnection_ReconnectLoop_PermanentError_ExitsLoop(t *testing.T) {
 	require.Eventually(t, func() bool {
 		mock.mu.Lock()
 		defer mock.mu.Unlock()
-		return mock.notifyCloseCalls > 0
+		return mock.notifyCloseCh != nil
 	}, time.Second, time.Millisecond)
 
 	// Trigger disconnect.

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -678,13 +678,25 @@ func TestConnection_ReconnectLoop_PermanentError_ExitsLoop(t *testing.T) {
 		return dialCount >= 2
 	}, 2*time.Second, 10*time.Millisecond, "reconnect should have attempted dial")
 
-	// After permanent error, WaitConnected should NOT return success.
-	time.Sleep(20 * time.Millisecond) // let reconnectLoop process the return
+	// After permanent error, WaitConnected should return the permanent error
+	// immediately (not block until ctx timeout).
+	time.Sleep(20 * time.Millisecond) // let reconnectLoop process the terminal state
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	waitErr := conn.WaitConnected(ctx)
-	assert.Error(t, waitErr, "WaitConnected should timeout after permanent reconnect failure")
+	require.Error(t, waitErr, "WaitConnected must return error after permanent failure")
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(waitErr, &ecErr), "error should be errcode.Error")
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code,
+		"WaitConnected should return permanent error code, not generic connect error")
+
+	// Health should also reflect terminal state.
+	healthErr := conn.Health()
+	require.Error(t, healthErr)
+	require.True(t, errors.As(healthErr, &ecErr))
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code)
 }
 
 func TestIsPermanentDialError(t *testing.T) {
@@ -830,9 +842,7 @@ func TestSanitizeURL(t *testing.T) {
 	}
 }
 
-func TestConnection_ReconnectWithBackoff_PermanentError_ReturnsFalse(t *testing.T) {
-	// reconnectWithBackoff should return false when dial returns a permanent error,
-	// so reconnectLoop does NOT close(connected) — preventing false "connected" signal.
+func TestConnection_ReconnectWithBackoff_PermanentError(t *testing.T) {
 	permanentErr := &amqp.Error{Code: 403, Reason: "ACCESS_REFUSED", Recover: false}
 
 	conn := &Connection{
@@ -846,22 +856,19 @@ func TestConnection_ReconnectWithBackoff_PermanentError_ReturnsFalse(t *testing.
 		},
 		closeCh:   make(chan struct{}),
 		connected: make(chan struct{}),
+		failed:    make(chan struct{}),
 	}
 
-	result := conn.reconnectWithBackoff()
-	assert.False(t, result, "reconnectWithBackoff must return false on permanent dial error")
+	ok, err := conn.reconnectWithBackoff()
+	assert.False(t, ok, "must return false on permanent dial error")
+	assert.Error(t, err, "must return the permanent error")
 
-	// connected channel must NOT be closed — WaitConnected should block.
-	select {
-	case <-conn.connected:
-		t.Fatal("connected channel was closed after permanent error — WaitConnected would falsely succeed")
-	default:
-		// Good: channel is still open.
-	}
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code)
 }
 
 func TestConnection_ReconnectWithBackoff_RecoverableError_ThenSuccess(t *testing.T) {
-	// reconnectWithBackoff should return true after recovering from a transient error.
 	var mu sync.Mutex
 	dialCount := 0
 	conn := &Connection{
@@ -882,24 +889,24 @@ func TestConnection_ReconnectWithBackoff_RecoverableError_ThenSuccess(t *testing
 		},
 		closeCh:   make(chan struct{}),
 		connected: make(chan struct{}),
+		failed:    make(chan struct{}),
 	}
 
-	result := conn.reconnectWithBackoff()
-	assert.True(t, result, "reconnectWithBackoff must return true after successful reconnect")
+	ok, err := conn.reconnectWithBackoff()
+	assert.True(t, ok, "must return true after successful reconnect")
+	assert.NoError(t, err)
 
 	mu.Lock()
 	assert.Equal(t, 3, dialCount, "should have tried 3 times (2 failures + 1 success)")
 	mu.Unlock()
 }
 
-func TestConnection_ReconnectWithBackoff_CloseCh_ReturnsFalse(t *testing.T) {
-	// When closeCh is closed during backoff wait, reconnectWithBackoff should
-	// return false promptly without waiting for the full delay.
+func TestConnection_ReconnectWithBackoff_CloseCh(t *testing.T) {
 	closeCh := make(chan struct{})
 	conn := &Connection{
 		config: Config{
 			URL:                 "amqp://test:test@localhost:5672/",
-			ReconnectBaseDelay:  10 * time.Second, // long delay to ensure we'd block
+			ReconnectBaseDelay:  10 * time.Second,
 			ReconnectMaxBackoff: 30 * time.Second,
 		},
 		dial: func(url string) (AMQPConnection, error) {
@@ -907,20 +914,26 @@ func TestConnection_ReconnectWithBackoff_CloseCh_ReturnsFalse(t *testing.T) {
 		},
 		closeCh:   closeCh,
 		connected: make(chan struct{}),
+		failed:    make(chan struct{}),
 	}
 
-	done := make(chan bool, 1)
+	type result struct {
+		ok  bool
+		err error
+	}
+	done := make(chan result, 1)
 	go func() {
-		done <- conn.reconnectWithBackoff()
+		ok, err := conn.reconnectWithBackoff()
+		done <- result{ok, err}
 	}()
 
-	// Close after a short delay — should interrupt the backoff wait.
 	time.Sleep(50 * time.Millisecond)
 	close(closeCh)
 
 	select {
-	case result := <-done:
-		assert.False(t, result, "reconnectWithBackoff must return false when closeCh fires")
+	case r := <-done:
+		assert.False(t, r.ok, "must return false when closeCh fires")
+		assert.NoError(t, r.err, "clean shutdown, no permanent error")
 	case <-time.After(2 * time.Second):
 		t.Fatal("reconnectWithBackoff did not return after closeCh was closed")
 	}

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -534,6 +534,62 @@ func TestAddJitter(t *testing.T) {
 	}
 }
 
+func TestAddDownJitter(t *testing.T) {
+	t.Run("zero returns zero", func(t *testing.T) {
+		assert.Equal(t, time.Duration(0), addDownJitter(0))
+	})
+	t.Run("negative returns zero", func(t *testing.T) {
+		assert.Equal(t, time.Duration(0), addDownJitter(-1*time.Second))
+	})
+	t.Run("positive in [0.75*d, d]", func(t *testing.T) {
+		d := 30 * time.Second
+		for range 100 {
+			got := addDownJitter(d)
+			assert.GreaterOrEqual(t, got, time.Duration(float64(d)*0.75))
+			assert.LessOrEqual(t, got, d)
+		}
+	})
+}
+
+func TestConnection_BackoffDelay_SmallBase(t *testing.T) {
+	// U4: verify small base delay (1ms) doesn't prematurely jump to max.
+	conn := &Connection{
+		config: Config{
+			ReconnectBaseDelay:  1 * time.Millisecond,
+			ReconnectMaxBackoff: 1 * time.Hour,
+		},
+	}
+	// attempt 10: 1ms * 2^10 = 1.024s — well below 1h, jitter should be around 1s.
+	delay := conn.backoffDelay(10)
+	assert.GreaterOrEqual(t, delay, 750*time.Millisecond)
+	assert.LessOrEqual(t, delay, 1300*time.Millisecond)
+
+	// attempt 30: 1ms * 2^30 ≈ 1073s ≈ 17.9min — still below 1h.
+	delay30 := conn.backoffDelay(30)
+	assert.Less(t, delay30, 1*time.Hour, "attempt 30 with 1ms base should NOT hit 1h cap")
+}
+
+func TestConnection_ReconnectLoop_CloseExits(t *testing.T) {
+	// reconnectLoop should exit when closeCh is closed (via Connection.Close).
+	conn, _ := newTestConnection(t)
+
+	// reconnectLoop is already running from NewConnection. Close should stop it.
+	err := conn.Close()
+	assert.NoError(t, err)
+
+	// After Close, WaitConnected with a short timeout should fail (closeCh closed).
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	// connected was already closed by NewConnection, so this returns nil.
+	// This test verifies Close doesn't panic and exits cleanly.
+	_ = conn.WaitConnected(ctx)
+}
+
+// NOTE: reconnectLoop full-cycle test (disconnect → reconnect) requires real amqp
+// connection lifecycle and is covered by integration tests (go test -tags=integration).
+// The individual functions (reconnectWithBackoff, backoffDelay, isPermanentDialError)
+// are thoroughly unit-tested above.
+
 func TestIsPermanentDialError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -167,9 +167,10 @@ type mockConnection struct {
 	// Channel() pops from the front. Falls back to nextCh / newMockChannel.
 	channelQueue []*mockChannel
 
-	notifyCloseCh chan *amqp.Error
-	isClosed      bool
-	closeErr      error
+	notifyCloseCh    chan *amqp.Error
+	notifyCloseCalls int // number of times NotifyClose was called
+	isClosed         bool
+	closeErr         error
 }
 
 func newMockConnection() *mockConnection {
@@ -204,6 +205,7 @@ func (m *mockConnection) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.notifyCloseCh = receiver
+	m.notifyCloseCalls++
 	return receiver
 }
 
@@ -585,10 +587,111 @@ func TestConnection_ReconnectLoop_CloseExits(t *testing.T) {
 	_ = conn.WaitConnected(ctx)
 }
 
-// NOTE: reconnectLoop full-cycle test (disconnect → reconnect) requires real amqp
-// connection lifecycle and is covered by integration tests (go test -tags=integration).
-// The individual functions (reconnectWithBackoff, backoffDelay, isPermanentDialError)
-// are thoroughly unit-tested above.
+func TestConnection_ReconnectLoop_DisconnectAndReconnect(t *testing.T) {
+	// Full cycle: connect → disconnect → backoff → reconnect.
+	var mu sync.Mutex
+	dialCount := 0
+	mocks := []*mockConnection{newMockConnection(), newMockConnection()}
+	dialFunc := func(url string) (AMQPConnection, error) {
+		mu.Lock()
+		dialCount++
+		n := dialCount
+		mu.Unlock()
+		if n <= len(mocks) {
+			return mocks[n-1], nil
+		}
+		return newMockConnection(), nil
+	}
+
+	conn, err := NewConnection(Config{
+		URL:                 "amqp://test:test@localhost:5672/",
+		ChannelPoolSize:     2,
+		ReconnectBaseDelay:  1 * time.Millisecond,
+		ReconnectMaxBackoff: 5 * time.Millisecond,
+	}, WithDialFunc(dialFunc))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Wait for reconnectLoop to call NotifyClose (not just check the initial channel
+	// from newMockConnection — we need notifyCloseCalls > 0 to confirm reconnectLoop
+	// has registered its own channel).
+	require.Eventually(t, func() bool {
+		mocks[0].mu.Lock()
+		defer mocks[0].mu.Unlock()
+		return mocks[0].notifyCloseCalls > 0
+	}, time.Second, time.Millisecond, "reconnectLoop did not call NotifyClose")
+
+	// Now send on the channel that reconnectLoop is actually selecting on.
+	mocks[0].mu.Lock()
+	ch := mocks[0].notifyCloseCh
+	mocks[0].isClosed = true
+	mocks[0].mu.Unlock()
+	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+
+	// reconnectLoop should reconnect. Verify dial was called again.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return dialCount >= 2
+	}, 2*time.Second, 10*time.Millisecond, "reconnectLoop should have reconnected")
+}
+
+func TestConnection_ReconnectLoop_PermanentError_ExitsLoop(t *testing.T) {
+	// Full cycle: connect → disconnect → permanent error → loop exits.
+	var mu sync.Mutex
+	dialCount := 0
+	mock := newMockConnection()
+	permanentErr := &amqp.Error{Code: 403, Reason: "ACCESS_REFUSED", Recover: false}
+
+	dialFunc := func(url string) (AMQPConnection, error) {
+		mu.Lock()
+		dialCount++
+		n := dialCount
+		mu.Unlock()
+		if n == 1 {
+			return mock, nil
+		}
+		return nil, permanentErr
+	}
+
+	conn, err := NewConnection(Config{
+		URL:                 "amqp://test:test@localhost:5672/",
+		ChannelPoolSize:     2,
+		ReconnectBaseDelay:  1 * time.Millisecond,
+		ReconnectMaxBackoff: 5 * time.Millisecond,
+	}, WithDialFunc(dialFunc))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Wait for reconnectLoop to register NotifyClose.
+	require.Eventually(t, func() bool {
+		mock.mu.Lock()
+		defer mock.mu.Unlock()
+		return mock.notifyCloseCalls > 0
+	}, time.Second, time.Millisecond)
+
+	// Trigger disconnect.
+	mock.mu.Lock()
+	ch := mock.notifyCloseCh
+	mock.isClosed = true
+	mock.mu.Unlock()
+	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+
+	// Wait for permanent error to be hit.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return dialCount >= 2
+	}, 2*time.Second, 10*time.Millisecond, "reconnect should have attempted dial")
+
+	// After permanent error, WaitConnected should NOT return success.
+	time.Sleep(20 * time.Millisecond) // let reconnectLoop process the return
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	waitErr := conn.WaitConnected(ctx)
+	assert.Error(t, waitErr, "WaitConnected should timeout after permanent reconnect failure")
+}
 
 func TestIsPermanentDialError(t *testing.T) {
 	tests := []struct {

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -458,20 +459,116 @@ func TestConnection_BackoffDelay(t *testing.T) {
 	conn, _ := newTestConnection(t)
 
 	tests := []struct {
-		name     string
-		attempt  int
-		expected time.Duration
+		name    string
+		attempt int
+		// baseDelay is the expected delay before jitter (+-25%).
+		baseDelay time.Duration
 	}{
-		{name: "attempt 0", attempt: 0, expected: 1 * time.Second},
-		{name: "attempt 1", attempt: 1, expected: 2 * time.Second},
-		{name: "attempt 2", attempt: 2, expected: 4 * time.Second},
-		{name: "attempt 10 (capped)", attempt: 10, expected: 30 * time.Second},
+		{name: "attempt 0", attempt: 0, baseDelay: 1 * time.Second},
+		{name: "attempt 1", attempt: 1, baseDelay: 2 * time.Second},
+		{name: "attempt 2", attempt: 2, baseDelay: 4 * time.Second},
+		{name: "attempt 10 (capped)", attempt: 10, baseDelay: 30 * time.Second},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			delay := conn.backoffDelay(tt.attempt)
-			assert.Equal(t, tt.expected, delay)
+			minDelay := time.Duration(float64(tt.baseDelay) * 0.75)
+			maxDelay := time.Duration(float64(tt.baseDelay) * 1.25)
+			assert.GreaterOrEqual(t, delay, minDelay,
+				"delay %v should be >= 75%% of base %v", delay, tt.baseDelay)
+			assert.LessOrEqual(t, delay, maxDelay,
+				"delay %v should be <= 125%% of base %v", delay, tt.baseDelay)
+		})
+	}
+}
+
+func TestAddJitter(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+	}{
+		{name: "zero", d: 0},
+		{name: "1s", d: 1 * time.Second},
+		{name: "30s", d: 30 * time.Second},
+		{name: "100ms", d: 100 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.d == 0 {
+				assert.Equal(t, time.Duration(0), addJitter(tt.d))
+				return
+			}
+			// Run multiple times to check range.
+			for range 100 {
+				got := addJitter(tt.d)
+				minD := time.Duration(float64(tt.d) * 0.75)
+				maxD := time.Duration(float64(tt.d) * 1.25)
+				assert.GreaterOrEqual(t, got, minD)
+				assert.LessOrEqual(t, got, maxD)
+			}
+		})
+	}
+}
+
+func TestIsPermanentDialError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "AMQP ACCESS_REFUSED (403) — auth failure",
+			err:  &amqp.Error{Code: 403, Reason: "ACCESS_REFUSED", Server: true, Recover: false},
+			want: true,
+		},
+		{
+			name: "AMQP NOT_FOUND (404) — vhost does not exist",
+			err:  &amqp.Error{Code: 404, Reason: "NOT_FOUND", Server: true, Recover: false},
+			want: true,
+		},
+		{
+			name: "AMQP NOT_ALLOWED (530) — connection not allowed",
+			err:  &amqp.Error{Code: 530, Reason: "NOT_ALLOWED", Server: true, Recover: false},
+			want: true,
+		},
+		{
+			name: "AMQP connection.forced (320) — recoverable",
+			err:  &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Server: true, Recover: true},
+			want: false,
+		},
+		{
+			name: "AMQP frame error (501) — recoverable",
+			err:  &amqp.Error{Code: 501, Reason: "FRAME_ERROR", Server: true, Recover: true},
+			want: false,
+		},
+		{
+			name: "net.OpError (connection refused) — recoverable",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")},
+			want: false,
+		},
+		{
+			name: "generic error — defaults to recoverable",
+			err:  errors.New("some unknown error"),
+			want: false,
+		},
+		{
+			name: "wrapped AMQP permanent error",
+			err:  fmt.Errorf("dial: %w", &amqp.Error{Code: 403, Reason: "ACCESS_REFUSED", Server: true, Recover: false}),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPermanentDialError(tt.err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -1112,6 +1112,33 @@ func TestPublisher_Publish_ConfirmModeError(t *testing.T) {
 	assert.Contains(t, err.Error(), "confirm mode")
 }
 
+func TestPublisher_Publish_TerminalState_ReturnsPermanentError(t *testing.T) {
+	// When Connection is in terminal state, Publish should return
+	// ErrAdapterAMQPConnectPermanent (not generic publish error).
+	conn := &Connection{
+		config: Config{
+			URL:            "amqp://test:test@localhost:5672/",
+			ChannelPoolSize: 2,
+			ConfirmTimeout: 5 * time.Second,
+		},
+		channelPool:  make(chan AMQPChannel, 2),
+		closeCh:      make(chan struct{}),
+		connected:    make(chan struct{}),
+		failed:       make(chan struct{}),
+		permanentErr: errcode.New(ErrAdapterAMQPConnectPermanent, "access refused"),
+	}
+	close(conn.failed)
+
+	pub := NewPublisher(conn)
+	err := pub.Publish(context.Background(), "test.topic", []byte("payload"))
+
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code,
+		"Publish in terminal state should return permanent error, not generic publish error")
+}
+
 // =============================================================================
 // Subscriber Tests
 // =============================================================================

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -336,6 +336,40 @@ func TestNewConnection_DialFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_CONNECT")
 }
 
+func TestNewConnection_PermanentDialError(t *testing.T) {
+	// Initial connection with permanent error should return ErrAdapterAMQPConnectPermanent.
+	dialFunc := func(url string) (AMQPConnection, error) {
+		return nil, &amqp.Error{Code: 403, Reason: "ACCESS_REFUSED", Recover: false}
+	}
+
+	_, err := NewConnection(Config{
+		URL: "amqp://bad:bad@localhost:5672/",
+	}, WithDialFunc(dialFunc))
+
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code,
+		"initial permanent dial error should return ErrAdapterAMQPConnectPermanent")
+}
+
+func TestNewConnection_RecoverableDialError(t *testing.T) {
+	// Initial connection with recoverable error should return generic ErrAdapterAMQPConnect.
+	dialFunc := func(url string) (AMQPConnection, error) {
+		return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	}
+
+	_, err := NewConnection(Config{
+		URL: "amqp://test:test@localhost:5672/",
+	}, WithDialFunc(dialFunc))
+
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, ErrAdapterAMQPConnect, ecErr.Code,
+		"recoverable dial error should return generic ErrAdapterAMQPConnect")
+}
+
 func TestConnection_Health_Closed(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 
@@ -696,6 +730,12 @@ func TestConnection_ReconnectLoop_PermanentError_ExitsLoop(t *testing.T) {
 	healthErr := conn.Health()
 	require.Error(t, healthErr)
 	require.True(t, errors.As(healthErr, &ecErr))
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code)
+
+	// AcquireChannel should also return permanent error (not generic connect error).
+	_, acqErr := conn.AcquireChannel()
+	require.Error(t, acqErr)
+	require.True(t, errors.As(acqErr, &ecErr))
 	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code)
 }
 

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -242,7 +242,10 @@ func (s *Subscriber) subscribeOnce(
 	// paths to prevent channel leaks.
 	cleanupCh := func() {
 		s.untrackChannel(ch)
-		_ = ch.Close()
+		if err := ch.Close(); err != nil {
+			slog.Debug("rabbitmq: error closing channel during cleanup",
+				slog.String("error", err.Error()))
+		}
 	}
 
 	// setupErr wraps a setup-stage error. If the underlying AMQP error is
@@ -308,7 +311,10 @@ func (s *Subscriber) subscribeOnce(
 
 	// Clean up the dead channel after consumeLoop exits.
 	s.untrackChannel(ch)
-	_ = ch.Close() // Best-effort close; channel is likely already dead.
+	if closeErr := ch.Close(); closeErr != nil {
+		slog.Debug("rabbitmq: error closing consumed channel",
+			slog.String("error", closeErr.Error()))
+	}
 
 	return loopErr
 }

--- a/src/adapters/rabbitmq/subscriber.go
+++ b/src/adapters/rabbitmq/subscriber.go
@@ -201,6 +201,12 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler outbox
 
 		// Wait for connection recovery before re-subscribing.
 		if waitErr := s.conn.WaitConnected(subCtx); waitErr != nil {
+			// Permanent connection error — propagate to caller so upstream
+			// (EventRouter/Bootstrap) can detect and handle terminal failure.
+			var ecErr *errcode.Error
+			if errors.As(waitErr, &ecErr) && ecErr.Code == ErrAdapterAMQPConnectPermanent {
+				return waitErr
+			}
 			// ctx cancelled or subscriber closed during wait — clean exit.
 			return nil
 		}

--- a/src/kernel/cell/registrar.go
+++ b/src/kernel/cell/registrar.go
@@ -1,5 +1,29 @@
 package cell
 
+// ADR: kernel/cell depends on net/http (standard library)
+//
+// Status: Accepted
+//
+// Decision: kernel/cell uses net/http types (http.Handler, http.ResponseWriter,
+// http.Request) in the RouteMux and HTTPRegistrar interfaces.
+//
+// Rationale: net/http is part of the Go standard library. The project's
+// layering rules (CLAUDE.md) state "kernel/ only depends on stdlib + pkg/",
+// so net/http is an allowed dependency. The Go 1.22+ enhanced ServeMux
+// pattern syntax ("METHOD /path/{param}") gives kernel a powerful routing
+// abstraction without importing any third-party router.
+//
+// Alternatives considered:
+//   - Define custom Handler/ResponseWriter/Request interfaces to abstract
+//     away net/http entirely. Rejected: this would add complexity (type
+//     conversions, adapter layers) for no practical benefit, since net/http
+//     is guaranteed stable by the Go compatibility promise.
+//
+// Consequences: Any Cell implementing HTTPRegistrar receives an http.Handler-
+// compatible interface. Concrete routers (chi, gorilla) are provided by
+// runtime/ or adapters/ and implement RouteMux, keeping kernel free of
+// third-party dependencies.
+
 import (
 	"net/http"
 


### PR DESCRIPTION
## Summary

- **B-03 RabbitMQ reconnect backoff**: Add anti-hot-loop protection to the reconnect path. `isPermanentDialError` classifies dial errors as permanent (auth failure, vhost not found) vs recoverable (network timeout, connection refused). Permanent errors abort reconnect immediately. `backoffDelay` now applies +-25% random jitter (initial 1s, max 30s) to prevent thundering-herd reconnects.
- **K-2 net/http ADR**: Add Architecture Decision Record comment to `kernel/cell/registrar.go` documenting why kernel/cell depends on net/http (stdlib, no layering violation).

ref: rabbitmq/amqp091-go README — reconnection delegated to caller, no built-in reconnect
ref: GoCell ConsumerBase jitter pattern (consumer_base.go)

## Test plan

- [x] `TestIsPermanentDialError` — table-driven: nil, AMQP permanent (403/404/530), AMQP recoverable (320/501), net.OpError, generic error, wrapped permanent
- [x] `TestAddJitter` — zero duration returns 0; non-zero values stay within [0.75d, 1.25d] over 100 iterations
- [x] `TestConnection_BackoffDelay` — updated to verify range bounds instead of exact values
- [x] `go test ./adapters/rabbitmq/...` — all 45+ tests pass
- [x] `go test ./kernel/cell/...` — all tests pass
- [x] `go build ./...` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)