### PR TITLE
feat(runtime/eventrouter): EventRouter — separate declaration from execution (Phase 2)

### DIFF
--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -51,6 +51,19 @@ func handleEvent(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 - **零值 HandleResult{} 的 Disposition 是 invalid**（不等于 Ack），会被安全降级为 Requeue
 - `PermanentError` 包装的错误即使返回 Requeue 也会被 ConsumerBase 升级为 Reject
 
+### Cell 订阅注册（EventRouter 模式）
+
+Cell 在 `RegisterSubscriptions` 中通过 `r.AddHandler(topic, handler)` 声明订阅意图，
+**禁止手动启动 goroutine 或调用 sub.Subscribe**——Router 管理所有 goroutine 生命周期。
+
+```go
+func (c *MyCell) RegisterSubscriptions(r cell.EventRouter) error {
+    handler := outbox.WrapLegacyHandler(c.svc.HandleEvent)
+    r.AddHandler("my.topic.v1", handler)
+    return nil
+}
+```
+
 ### 旧 handler 迁移
 
 使用 `outbox.WrapLegacyHandler` 适配旧签名：
@@ -58,7 +71,7 @@ func handleEvent(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 ```go
 legacy := func(ctx context.Context, entry outbox.Entry) error { ... }
 handler := outbox.WrapLegacyHandler(legacy)
-// nil error → Ack, non-nil → Requeue
+// nil error → Ack, PermanentError → Reject, other error → Requeue
 ```
 
 WrapLegacyHandler 检测 PermanentError 并返回 DispositionReject，无需 ConsumerBase 包装即可路由到 DLX。

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -125,8 +125,8 @@
 | ER-P2-04 | `runtime/bootstrap/bootstrap_test.go` | ~~缺 Router 正路径集成测试~~ PR#76 ✅ | ~~1h~~ |
 | CLEANUP-01 | `runtime/bootstrap/bootstrap.go` | 删除 `WithEventBus` deprecated wrapper，调用方改用 `WithPublisher` + `WithSubscriber` | 30min |
 | CLEANUP-02 | `cells/access-core/cell.go` | 删除 `WithSigningKey` + `signingKey` backward compat 字段，统一用 `WithJWTIssuer`/`WithJWTVerifier` | 1h |
-| ER-ARCH-01 | `runtime/eventrouter/router.go`, `kernel/outbox/outbox.go` | **Readiness heuristic**: Router startup detection 仍用 time.After(500ms)，RabbitMQ Subscribe 的 topology setup (Qos+Declare+Bind+Consume) 可能超过此超时。彻底修复需 Subscriber 接口拆分 Setup()+Run()，**C4 架构级** | Phase 2 后评估 |
-| ER-ARCH-02 | `kernel/cell/registrar.go`, `runtime/eventrouter/router.go` | **Competing consumers**: EventRouter.AddHandler 只有 topic+handler，无 consumer group identity。同 topic 多 handler（如 audit-core + config-core 都订阅 event.config.changed.v1）在 RabbitMQ 下退化为 competing consumers 而非 fan-out。需 AddHandler 增加 ConsumerGroup 参数或 AddHandlerWithOptions，**C3** | Phase 2 后评估 |
+| ER-ARCH-01 | `runtime/eventrouter/router.go`, `kernel/outbox/outbox.go` | **Readiness heuristic**: Router startup detection 仍用 time.After(500ms)，RabbitMQ Subscribe 的 topology setup (Qos+Declare+Bind+Consume) 可能超过此超时。彻底修复需 Subscriber 接口拆分 Setup()+Run()，**C4 架构级**。当前 500ms 对本地 broker 足够（InMemory 即时，RabbitMQ local declare < 50ms），仅跨网络集群场景才会触发 | **v1.1** |
+| ER-ARCH-02 | `kernel/cell/registrar.go`, `runtime/eventrouter/router.go` | **Competing consumers**: EventRouter.AddHandler 只有 topic+handler，无 consumer group identity。audit-core + config-core 都订阅 event.config.changed.v1，RabbitMQ 下退化为 competing consumers 而非 fan-out。方案：`AddHandler(topic, handler, ...HandlerOption)` + `WithConsumerGroup(cg)`，**C3** | **Batch 5**（与 WM-17 lifecycle hooks 同期改 kernel/cell 接口），2h |
 
 ### winmdm Accept P1
 
@@ -402,6 +402,7 @@
 | A | WM-33b 熔断器 | 0.5d | `adapters/` sony/gobreaker 包装 |
 | B | WM-17 生命周期钩子（BeforeStart/AfterStart/BeforeStop/AfterStop） | 1d | `kernel/cell` 可选接口（type assertion） |
 | B | WM-15 L4 队列状态机 | 1.5d | `kernel/outbox` 合入 0-B2，状态 enum + 超时检测 |
+| B | ER-ARCH-02 EventRouter ConsumerGroup 支持 | 2h | `AddHandler(...HandlerOption)` + `WithConsumerGroup`，修复 competing consumers |
 
 **安全底线**: 熔断器防级联故障；AfterStop 清理敏感资源
 **测试策略**: TestPubSub 标准套件 12 场景；lifecycle hooks 回归验证（不注册钩子时行为不变）

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -119,6 +119,10 @@
 | TX-NIL-01 | `cells/*/service.go` | txRunner nil-safe 未文档化 | 1h |
 | OTEL-COV-01 | `adapters/otel/` | 覆盖率 67.3%（PR#72 删除了依赖内部 API 的旧测试后回升，但仍 < 80%；成功路径需 gRPC OTLP endpoint，需 testcontainers 集成测试） | 2h |
 | SUB-SETUP-01 | `kernel/outbox`, `cells/*/cell.go` | RegisterSubscriptions 用 100ms 启发式区分 setup 失败与正常阻塞消费。**已被 Phase 2 EventRouter 解决**——Router.Run() 同步返回 setup error，消除启发式 | ~~4h~~ → Phase 2 |
+| ER-P2-01 | `runtime/eventrouter/router.go` | Close() 正常关停缺 elapsed 日志（超时路径已有 slog.Warn） | 15min |
+| ER-P2-02 | `cells/audit-core/cell_test.go`, `cells/config-core/cell_test.go` | stubEventRouter 重复定义 → 提取到 `kernel/cell/celltest` | 30min |
+| ER-P2-03 | `runtime/eventrouter/router.go`, `runtime/bootstrap/bootstrap.go` | Running() 是一次性信号，无持续 health check 集成（OPS-3 readiness 探针可复用） | 1h |
+| ER-P2-04 | `runtime/bootstrap/bootstrap_test.go` | 缺 Router 正路径集成测试（HandlerCount > 0 成功启动 + 关停） | 1h |
 
 ### winmdm Accept P1
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -119,10 +119,12 @@
 | TX-NIL-01 | `cells/*/service.go` | txRunner nil-safe 未文档化 | 1h |
 | OTEL-COV-01 | `adapters/otel/` | 覆盖率 67.3%（PR#72 删除了依赖内部 API 的旧测试后回升，但仍 < 80%；成功路径需 gRPC OTLP endpoint，需 testcontainers 集成测试） | 2h |
 | SUB-SETUP-01 | `kernel/outbox`, `cells/*/cell.go` | RegisterSubscriptions 用 100ms 启发式区分 setup 失败与正常阻塞消费。**已被 Phase 2 EventRouter 解决**——Router.Run() 同步返回 setup error，消除启发式 | ~~4h~~ → Phase 2 |
-| ER-P2-01 | `runtime/eventrouter/router.go` | Close() 正常关停缺 elapsed 日志（超时路径已有 slog.Warn） | 15min |
-| ER-P2-02 | `cells/audit-core/cell_test.go`, `cells/config-core/cell_test.go` | stubEventRouter 重复定义 → 提取到 `kernel/cell/celltest` | 30min |
+| ER-P2-01 | `runtime/eventrouter/router.go` | ~~Close() 正常关停缺 elapsed 日志~~ PR#76 ✅ | ~~15min~~ |
+| ER-P2-02 | `kernel/cell/celltest/eventrouter.go` | ~~stubEventRouter 重复 → 提取到 celltest~~ PR#76 ✅ | ~~30min~~ |
 | ER-P2-03 | `runtime/eventrouter/router.go`, `runtime/bootstrap/bootstrap.go` | Running() 是一次性信号，无持续 health check 集成（OPS-3 readiness 探针可复用） | 1h |
-| ER-P2-04 | `runtime/bootstrap/bootstrap_test.go` | 缺 Router 正路径集成测试（HandlerCount > 0 成功启动 + 关停） | 1h |
+| ER-P2-04 | `runtime/bootstrap/bootstrap_test.go` | ~~缺 Router 正路径集成测试~~ PR#76 ✅ | ~~1h~~ |
+| CLEANUP-01 | `runtime/bootstrap/bootstrap.go` | 删除 `WithEventBus` deprecated wrapper，调用方改用 `WithPublisher` + `WithSubscriber` | 30min |
+| CLEANUP-02 | `cells/access-core/cell.go` | 删除 `WithSigningKey` + `signingKey` backward compat 字段，统一用 `WithJWTIssuer`/`WithJWTVerifier` | 1h |
 
 ### winmdm Accept P1
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -125,6 +125,8 @@
 | ER-P2-04 | `runtime/bootstrap/bootstrap_test.go` | ~~缺 Router 正路径集成测试~~ PR#76 ✅ | ~~1h~~ |
 | CLEANUP-01 | `runtime/bootstrap/bootstrap.go` | 删除 `WithEventBus` deprecated wrapper，调用方改用 `WithPublisher` + `WithSubscriber` | 30min |
 | CLEANUP-02 | `cells/access-core/cell.go` | 删除 `WithSigningKey` + `signingKey` backward compat 字段，统一用 `WithJWTIssuer`/`WithJWTVerifier` | 1h |
+| ER-ARCH-01 | `runtime/eventrouter/router.go`, `kernel/outbox/outbox.go` | **Readiness heuristic**: Router startup detection 仍用 time.After(500ms)，RabbitMQ Subscribe 的 topology setup (Qos+Declare+Bind+Consume) 可能超过此超时。彻底修复需 Subscriber 接口拆分 Setup()+Run()，**C4 架构级** | Phase 2 后评估 |
+| ER-ARCH-02 | `kernel/cell/registrar.go`, `runtime/eventrouter/router.go` | **Competing consumers**: EventRouter.AddHandler 只有 topic+handler，无 consumer group identity。同 topic 多 handler（如 audit-core + config-core 都订阅 event.config.changed.v1）在 RabbitMQ 下退化为 competing consumers 而非 fan-out。需 AddHandler 增加 ConsumerGroup 参数或 AddHandlerWithOptions，**C3** | Phase 2 后评估 |
 
 ### winmdm Accept P1
 

--- a/src/cells/access-core/cell.go
+++ b/src/cells/access-core/cell.go
@@ -243,8 +243,8 @@ func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
 	})
 }
 
-// RegisterSubscriptions is a no-op for access-core in Phase 2.
+// RegisterSubscriptions is a no-op for access-core.
 // Future: subscribe to cross-cell events if needed.
-func (c *AccessCore) RegisterSubscriptions(_ outbox.Subscriber) error {
+func (c *AccessCore) RegisterSubscriptions(_ cell.EventRouter) error {
 	return nil
 }

--- a/src/cells/audit-core/cell.go
+++ b/src/cells/audit-core/cell.go
@@ -4,10 +4,8 @@ package auditcore
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
@@ -168,30 +166,12 @@ func (c *AuditCore) RegisterRoutes(mux cell.RouteMux) {
 	})
 }
 
-// RegisterSubscriptions registers event subscriptions for all 6 topics.
-// Returns an error if any subscription fails during setup (e.g., missing DLX).
-// Long-running consumption loops are started in background goroutines.
-func (c *AuditCore) RegisterSubscriptions(sub outbox.Subscriber) error {
+// RegisterSubscriptions declares event subscriptions for all audit topics.
+// The Router manages goroutine lifecycle and setup-error detection.
+func (c *AuditCore) RegisterSubscriptions(r cell.EventRouter) error {
 	handler := outbox.WrapLegacyHandler(c.appendSvc.HandleEvent)
 	for _, topic := range auditappend.Topics {
-		topic := topic
-		errCh := make(chan error, 1)
-		go func() {
-			ctx := context.Background()
-			errCh <- sub.Subscribe(ctx, topic, handler)
-		}()
-
-		// Subscribe returns immediately on config errors (DLX missing, closed).
-		// On success it blocks — a short wait distinguishes the two.
-		select {
-		case err := <-errCh:
-			if err != nil {
-				return fmt.Errorf("audit-core: subscription setup failed for topic %s: %w", topic, err)
-			}
-			// Subscribe returned nil without blocking — clean shutdown, not an error.
-		case <-time.After(100 * time.Millisecond):
-			// Subscribe is blocking (consuming) — setup succeeded.
-		}
+		r.AddHandler(topic, handler)
 	}
 	return nil
 }

--- a/src/cells/audit-core/cell_test.go
+++ b/src/cells/audit-core/cell_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
@@ -132,17 +133,10 @@ func TestAuditCore_RegisterSubscriptions(t *testing.T) {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	r := &stubEventRouter{}
+	r := &celltest.StubEventRouter{}
 	require.NoError(t, c.RegisterSubscriptions(r))
-	assert.Equal(t, 6, r.count, "audit-core should register 6 topic handlers")
+	assert.Equal(t, 6, r.HandlerCount(), "audit-core should register 6 topic handlers")
 }
-
-// stubEventRouter implements cell.EventRouter for testing.
-type stubEventRouter struct {
-	count int
-}
-
-func (r *stubEventRouter) AddHandler(_ string, _ outbox.EntryHandler) { r.count++ }
 
 // stubMux implements cell.RouteMux for testing.
 type stubMux struct {

--- a/src/cells/audit-core/cell_test.go
+++ b/src/cells/audit-core/cell_test.go
@@ -132,10 +132,17 @@ func TestAuditCore_RegisterSubscriptions(t *testing.T) {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	eb := eventbus.New()
-	require.NoError(t, c.RegisterSubscriptions(eb))
-	_ = eb.Close()
+	r := &stubEventRouter{}
+	require.NoError(t, c.RegisterSubscriptions(r))
+	assert.Equal(t, 6, r.count, "audit-core should register 6 topic handlers")
 }
+
+// stubEventRouter implements cell.EventRouter for testing.
+type stubEventRouter struct {
+	count int
+}
+
+func (r *stubEventRouter) AddHandler(_ string, _ outbox.EntryHandler) { r.count++ }
 
 // stubMux implements cell.RouteMux for testing.
 type stubMux struct {

--- a/src/cells/config-core/cell.go
+++ b/src/cells/config-core/cell.go
@@ -4,10 +4,8 @@ package configcore
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
@@ -174,23 +172,10 @@ func (c *ConfigCore) RegisterRoutes(mux cell.RouteMux) {
 	})
 }
 
-// RegisterSubscriptions registers event subscriptions for config-core.
-// Returns an error if subscription setup fails (e.g., missing DLX).
-func (c *ConfigCore) RegisterSubscriptions(sub outbox.Subscriber) error {
+// RegisterSubscriptions declares event subscriptions for config-core.
+// The Router manages goroutine lifecycle and setup-error detection.
+func (c *ConfigCore) RegisterSubscriptions(r cell.EventRouter) error {
 	handler := outbox.WrapLegacyHandler(c.subscribeSvc.HandleEvent)
-	errCh := make(chan error, 1)
-	go func() {
-		ctx := context.Background()
-		errCh <- sub.Subscribe(ctx, configsubscribe.TopicConfigChanged, handler)
-	}()
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return fmt.Errorf("config-subscribe: subscription setup failed: %w", err)
-		}
-		return nil
-	case <-time.After(100 * time.Millisecond):
-		return nil // Subscribe is blocking (consuming) — setup succeeded.
-	}
+	r.AddHandler(configsubscribe.TopicConfigChanged, handler)
+	return nil
 }

--- a/src/cells/config-core/cell_test.go
+++ b/src/cells/config-core/cell_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
@@ -99,17 +100,10 @@ func TestConfigCore_RegisterSubscriptions(t *testing.T) {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	r := &stubEventRouter{}
+	r := &celltest.StubEventRouter{}
 	require.NoError(t, c.RegisterSubscriptions(r))
-	assert.Equal(t, 1, r.count, "config-core should register 1 topic handler")
+	assert.Equal(t, 1, r.HandlerCount(), "config-core should register 1 topic handler")
 }
-
-// stubEventRouter implements cell.EventRouter for testing.
-type stubEventRouter struct {
-	count int
-}
-
-func (r *stubEventRouter) AddHandler(_ string, _ outbox.EntryHandler) { r.count++ }
 
 // stubMux implements cell.RouteMux for testing.
 type stubMux struct {

--- a/src/cells/config-core/cell_test.go
+++ b/src/cells/config-core/cell_test.go
@@ -99,10 +99,17 @@ func TestConfigCore_RegisterSubscriptions(t *testing.T) {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	eb := eventbus.New()
-	require.NoError(t, c.RegisterSubscriptions(eb))
-	_ = eb.Close()
+	r := &stubEventRouter{}
+	require.NoError(t, c.RegisterSubscriptions(r))
+	assert.Equal(t, 1, r.count, "config-core should register 1 topic handler")
 }
+
+// stubEventRouter implements cell.EventRouter for testing.
+type stubEventRouter struct {
+	count int
+}
+
+func (r *stubEventRouter) AddHandler(_ string, _ outbox.EntryHandler) { r.count++ }
 
 // stubMux implements cell.RouteMux for testing.
 type stubMux struct {

--- a/src/kernel/cell/celltest/eventrouter.go
+++ b/src/kernel/cell/celltest/eventrouter.go
@@ -1,0 +1,26 @@
+package celltest
+
+import (
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// Compile-time check: StubEventRouter implements cell.EventRouter.
+var _ cell.EventRouter = (*StubEventRouter)(nil)
+
+// StubEventRouter records AddHandler calls for testing.
+type StubEventRouter struct {
+	Topics   []string
+	Handlers []outbox.EntryHandler
+}
+
+// AddHandler records the topic and handler.
+func (r *StubEventRouter) AddHandler(topic string, handler outbox.EntryHandler) {
+	r.Topics = append(r.Topics, topic)
+	r.Handlers = append(r.Handlers, handler)
+}
+
+// HandlerCount returns the number of registered handlers.
+func (r *StubEventRouter) HandlerCount() int {
+	return len(r.Topics)
+}

--- a/src/kernel/cell/registrar.go
+++ b/src/kernel/cell/registrar.go
@@ -65,11 +65,25 @@ type HTTPRegistrar interface {
 	RegisterRoutes(mux RouteMux)
 }
 
+// EventRouter declares event subscriptions. Cells call AddHandler during
+// RegisterSubscriptions to declare intent; the caller (bootstrap/Router)
+// is responsible for starting consumption.
+//
+// The minimal interface lives in kernel/cell so Cells can depend on it
+// without importing runtime/. The concrete implementation is in
+// runtime/eventrouter.
+//
+// ref: ThreeDotsLabs/watermill message/router.go — AddHandler registers
+// intent; Router.Run starts consumption. GoCell simplifies to topic+handler
+// (no publish side in the same call).
+type EventRouter interface {
+	AddHandler(topic string, handler outbox.EntryHandler)
+}
+
 // EventRegistrar is optionally implemented by Cells that subscribe to events.
-// RegisterSubscriptions MUST validate subscription setup (e.g., DLX config)
-// synchronously and return an error if any subscription cannot be established.
-// Long-running consumption loops should be started in background goroutines
-// only after validation succeeds.
+// RegisterSubscriptions declares subscriptions by calling r.AddHandler for
+// each topic. It MUST NOT start goroutines or block — the Router manages
+// the subscription lifecycle.
 type EventRegistrar interface {
-	RegisterSubscriptions(sub outbox.Subscriber) error
+	RegisterSubscriptions(r EventRouter) error
 }

--- a/src/kernel/cell/registrar_test.go
+++ b/src/kernel/cell/registrar_test.go
@@ -58,20 +58,17 @@ func (h *httpCell) RegisterRoutes(mux RouteMux) {
 // Compile-time check.
 var _ HTTPRegistrar = (*httpCell)(nil)
 
-// mockSubscriber implements outbox.Subscriber for testing.
-type mockSubscriber struct {
+// mockEventRouter implements EventRouter for testing.
+type mockEventRouter struct {
 	topics []string
 }
 
-func (m *mockSubscriber) Subscribe(_ context.Context, topic string, _ outbox.EntryHandler) error {
+func (m *mockEventRouter) AddHandler(topic string, _ outbox.EntryHandler) {
 	m.topics = append(m.topics, topic)
-	return nil
 }
 
-func (m *mockSubscriber) Close() error { return nil }
-
 // Compile-time check.
-var _ outbox.Subscriber = (*mockSubscriber)(nil)
+var _ EventRouter = (*mockEventRouter)(nil)
 
 // eventCell is a Cell that also implements EventRegistrar.
 type eventCell struct {
@@ -79,9 +76,9 @@ type eventCell struct {
 	registered bool
 }
 
-func (e *eventCell) RegisterSubscriptions(sub outbox.Subscriber) error {
+func (e *eventCell) RegisterSubscriptions(r EventRouter) error {
 	e.registered = true
-	_ = sub.Subscribe(context.Background(), "session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	r.AddHandler("session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 	return nil
@@ -102,9 +99,9 @@ func (d *dualCell) RegisterRoutes(mux RouteMux) {
 	mux.Handle("/api/v1/devices", http.NotFoundHandler())
 }
 
-func (d *dualCell) RegisterSubscriptions(sub outbox.Subscriber) error {
+func (d *dualCell) RegisterSubscriptions(r EventRouter) error {
 	d.eventRegistered = true
-	_ = sub.Subscribe(context.Background(), "device.enrolled", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	r.AddHandler("device.enrolled", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 	return nil
@@ -150,12 +147,12 @@ func TestEventRegistrar_TypeAssertion(t *testing.T) {
 	r, ok := c.(EventRegistrar)
 	assert.True(t, ok, "eventCell should satisfy EventRegistrar")
 
-	sub := &mockSubscriber{}
-	err := r.RegisterSubscriptions(sub)
+	router := &mockEventRouter{}
+	err := r.RegisterSubscriptions(router)
 	assert.NoError(t, err)
 
 	assert.True(t, ec.registered)
-	assert.Equal(t, []string{"session.created"}, sub.topics)
+	assert.Equal(t, []string{"session.created"}, router.topics)
 }
 
 func TestEventRegistrar_NegativeTypeAssertion(t *testing.T) {
@@ -182,11 +179,11 @@ func TestDualRegistrar_BothInterfaces(t *testing.T) {
 	// Event
 	er, ok := c.(EventRegistrar)
 	assert.True(t, ok)
-	sub := &mockSubscriber{}
-	err := er.RegisterSubscriptions(sub)
+	router := &mockEventRouter{}
+	err := er.RegisterSubscriptions(router)
 	assert.NoError(t, err)
 	assert.True(t, dc.eventRegistered)
-	assert.Equal(t, []string{"device.enrolled"}, sub.topics)
+	assert.Equal(t, []string{"device.enrolled"}, router.topics)
 }
 
 func TestRouteMux_Group(t *testing.T) {

--- a/src/runtime/bootstrap/bootstrap.go
+++ b/src/runtime/bootstrap/bootstrap.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/config"
 	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/ghbvf/gocell/runtime/eventrouter"
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	"github.com/ghbvf/gocell/runtime/shutdown"
@@ -262,16 +263,35 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		}
 	}
 
-	// Step 6: Register event subscriptions for cells implementing EventRegistrar.
-	// Subscription setup errors (e.g., missing DLX) abort startup.
+	// Step 6: Register event subscriptions via EventRouter.
+	// Cells declare handlers (non-blocking), then Router.Run starts consumption.
+	// Setup errors (e.g., missing DLX) abort startup.
+	var evtRouter *eventrouter.Router
 	if sub != nil {
+		evtRouter = eventrouter.New(sub)
 		for _, id := range asm.CellIDs() {
 			c := asm.Cell(id)
 			if er, ok := c.(cell.EventRegistrar); ok {
-				if err := er.RegisterSubscriptions(sub); err != nil {
+				if err := er.RegisterSubscriptions(evtRouter); err != nil {
 					return rollback(fmt.Errorf("bootstrap: cell %s subscription setup failed: %w", id, err))
 				}
 			}
+		}
+		if evtRouter.HandlerCount() > 0 {
+			routerErrCh := make(chan error, 1)
+			go func() {
+				routerErrCh <- evtRouter.Run(ctx)
+			}()
+			// Wait for all subscriptions to start or a setup error.
+			select {
+			case err := <-routerErrCh:
+				return rollback(fmt.Errorf("bootstrap: event router: %w", err))
+			case <-evtRouter.Running():
+				// All subscriptions consuming.
+			}
+			teardowns = append(teardowns, func(_ context.Context) error {
+				return evtRouter.Close()
+			})
 		}
 	}
 

--- a/src/runtime/bootstrap/bootstrap.go
+++ b/src/runtime/bootstrap/bootstrap.go
@@ -266,9 +266,9 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	// Step 6: Register event subscriptions via EventRouter.
 	// Cells declare handlers (non-blocking), then Router.Run starts consumption.
 	// Setup errors (e.g., missing DLX) abort startup.
-	var evtRouter *eventrouter.Router
+	var routerErrCh chan error // hoisted for Step 9 monitoring
 	if sub != nil {
-		evtRouter = eventrouter.New(sub)
+		evtRouter := eventrouter.New(sub)
 		for _, id := range asm.CellIDs() {
 			c := asm.Cell(id)
 			if er, ok := c.(cell.EventRegistrar); ok {
@@ -278,7 +278,9 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 			}
 		}
 		if evtRouter.HandlerCount() > 0 {
-			routerErrCh := make(chan error, 1)
+			slog.Info("bootstrap: starting event router",
+				slog.Int("handler_count", evtRouter.HandlerCount()))
+			routerErrCh = make(chan error, 1)
 			go func() {
 				routerErrCh <- evtRouter.Run(ctx)
 			}()
@@ -289,8 +291,8 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 			case <-evtRouter.Running():
 				// All subscriptions consuming.
 			}
-			teardowns = append(teardowns, func(_ context.Context) error {
-				return evtRouter.Close()
+			teardowns = append(teardowns, func(c context.Context) error {
+				return evtRouter.Close(c)
 			})
 		}
 	}
@@ -346,6 +348,7 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	}
 
 	// Step 9: Wait for shutdown signal or error.
+	// Monitor all background components: HTTP, workers, and event router.
 	slog.Info("bootstrap: application started successfully")
 	select {
 	case <-ctx.Done():
@@ -358,6 +361,11 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		if err != nil {
 			slog.Error("bootstrap: worker failed, initiating shutdown", slog.Any("error", err))
 			return rollback(fmt.Errorf("bootstrap: worker: %w", err))
+		}
+	case err := <-routerErrCh:
+		if err != nil {
+			slog.Error("bootstrap: event router failed, initiating shutdown", slog.Any("error", err))
+			return rollback(fmt.Errorf("bootstrap: event router: %w", err))
 		}
 	}
 

--- a/src/runtime/bootstrap/bootstrap_test.go
+++ b/src/runtime/bootstrap/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -151,8 +152,14 @@ func newEventCell(id string, subErr error) *eventCell {
 	}
 }
 
-func (c *eventCell) RegisterSubscriptions(_ cell.EventRouter) error {
-	return c.subErr
+func (c *eventCell) RegisterSubscriptions(r cell.EventRouter) error {
+	if c.subErr != nil {
+		return c.subErr
+	}
+	r.AddHandler("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+	return nil
 }
 
 func TestBootstrap_SubscriptionFailure_TriggersRollback(t *testing.T) {
@@ -178,6 +185,37 @@ func TestBootstrap_SubscriptionFailure_TriggersRollback(t *testing.T) {
 	assert.Contains(t, err.Error(), "DLX not configured")
 	// After rollback, assembly should be stopped (health returns empty or degraded).
 	// The key assertion is that Run returns the error instead of hanging.
+}
+
+func TestBootstrap_EventRouter_HappyPath(t *testing.T) {
+	// Cell registers a handler → Router starts → bootstrap serves → ctx cancel → clean shutdown.
+	asm := assembly.New(assembly.Config{ID: "test-router-ok"})
+	ec := newEventCell("ok-cell", nil) // nil error → registers 1 handler
+	require.NoError(t, asm.Register(ec))
+
+	eb := eventbus.New()
+	b := New(
+		WithAssembly(asm),
+		WithSubscriber(eb),
+		WithPublisher(eb),
+		WithHTTPAddr("127.0.0.1:0"),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	// Give bootstrap time to start (Router + HTTP).
+	time.Sleep(time.Second)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "clean shutdown should not produce an error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
 }
 
 func TestBootstrap_RunContextCancel(t *testing.T) {

--- a/src/runtime/bootstrap/bootstrap_test.go
+++ b/src/runtime/bootstrap/bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/cell"
-	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -152,7 +151,7 @@ func newEventCell(id string, subErr error) *eventCell {
 	}
 }
 
-func (c *eventCell) RegisterSubscriptions(_ outbox.Subscriber) error {
+func (c *eventCell) RegisterSubscriptions(_ cell.EventRouter) error {
 	return c.subErr
 }
 

--- a/src/runtime/bootstrap/doc.go
+++ b/src/runtime/bootstrap/doc.go
@@ -8,7 +8,8 @@
 //	app := bootstrap.New(
 //	    bootstrap.WithAssembly(asm),
 //	    bootstrap.WithHTTPAddr(":8080"),
-//	    bootstrap.WithEventBus(eb),
+//	    bootstrap.WithPublisher(pub),
+//	    bootstrap.WithSubscriber(sub),
 //	)
 //	if err := app.Run(ctx); err != nil { ... }
 package bootstrap

--- a/src/runtime/eventrouter/router.go
+++ b/src/runtime/eventrouter/router.go
@@ -1,0 +1,183 @@
+// Package eventrouter provides a Router that separates event subscription
+// declaration from execution. Cells declare handlers via AddHandler; the
+// Router owns goroutine lifecycle, setup-error detection, and graceful shutdown.
+//
+// ref: ThreeDotsLabs/watermill message/router.go — AddHandler/Run/Close pattern.
+// Adopted: declaration-then-run split, Running() readiness signal, WaitGroup goroutine tracking.
+// Deviated: no publish-side in AddHandler (GoCell publishes via outbox.Writer, not Router);
+// startup detection uses a configurable timeout because outbox.Subscriber.Subscribe blocks
+// without a separate setup/run split.
+package eventrouter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// DefaultStartupTimeout is the duration Run waits for Subscribe calls to
+// either return an error (setup failure) or remain blocking (consuming).
+// If no error arrives within this window, all subscriptions are assumed ready.
+const DefaultStartupTimeout = 500 * time.Millisecond
+
+// Option configures a Router.
+type Option func(*Router)
+
+// WithStartupTimeout overrides the default startup detection timeout.
+func WithStartupTimeout(d time.Duration) Option {
+	return func(r *Router) {
+		if d > 0 {
+			r.startupTimeout = d
+		}
+	}
+}
+
+type handlerConfig struct {
+	topic   string
+	handler outbox.EntryHandler
+}
+
+// Router manages event subscription lifecycle. It implements cell.EventRouter
+// for the declaration phase (AddHandler) and provides Run/Close for the
+// execution phase.
+type Router struct {
+	subscriber     outbox.Subscriber
+	handlers       []handlerConfig
+	mu             sync.Mutex
+	startupTimeout time.Duration
+	running        chan struct{}
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+}
+
+// Compile-time interface check.
+var _ cell.EventRouter = (*Router)(nil)
+
+// New creates a Router that will use the given Subscriber for all subscriptions.
+func New(sub outbox.Subscriber, opts ...Option) *Router {
+	r := &Router{
+		subscriber:     sub,
+		startupTimeout: DefaultStartupTimeout,
+		running:        make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// AddHandler registers a subscription intent. It MUST be called before Run.
+// Not safe for concurrent use — intended to be called sequentially during
+// bootstrap's RegisterSubscriptions phase.
+func (r *Router) AddHandler(topic string, handler outbox.EntryHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handlers = append(r.handlers, handlerConfig{topic: topic, handler: handler})
+}
+
+// Run starts all registered subscriptions and blocks until ctx is cancelled
+// or an unrecoverable subscription error occurs.
+//
+// Setup-error detection: each Subscribe call is launched in a goroutine.
+// If any returns an error within the startup timeout, Run cancels all
+// goroutines and returns the error. If no error arrives within the timeout,
+// all subscriptions are assumed to be consuming and Running() is closed.
+//
+// On context cancellation, Run waits for all goroutines to finish before
+// returning.
+func (r *Router) Run(ctx context.Context) error {
+	r.mu.Lock()
+	handlers := make([]handlerConfig, len(r.handlers))
+	copy(handlers, r.handlers)
+	r.mu.Unlock()
+
+	if len(handlers) == 0 {
+		close(r.running)
+		<-ctx.Done()
+		return nil
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+
+	// setupErr receives the first subscription setup error.
+	// Buffer size = len(handlers) to avoid goroutine leaks if multiple fail.
+	setupErr := make(chan error, len(handlers))
+
+	for _, h := range handlers {
+		h := h
+		r.wg.Add(1)
+		go func() {
+			defer r.wg.Done()
+			slog.Info("eventrouter: starting subscription",
+				slog.String("topic", h.topic))
+			err := r.subscriber.Subscribe(runCtx, h.topic, h.handler)
+			if err != nil && runCtx.Err() == nil {
+				// Real setup/runtime error, not a cancellation side-effect.
+				setupErr <- fmt.Errorf("eventrouter: topic %s: %w", h.topic, err)
+			}
+		}()
+	}
+
+	// Wait for setup phase: either an error arrives or startup timeout passes.
+	select {
+	case err := <-setupErr:
+		slog.Error("eventrouter: subscription setup failed, shutting down",
+			slog.Any("error", err))
+		cancel()
+		r.wg.Wait()
+		return err
+	case <-time.After(r.startupTimeout):
+		// No errors within timeout — all handlers are consuming.
+		slog.Info("eventrouter: all subscriptions started",
+			slog.Int("count", len(handlers)))
+		close(r.running)
+	case <-runCtx.Done():
+		// Context cancelled during startup.
+		r.wg.Wait()
+		return runCtx.Err()
+	}
+
+	// Block until context cancelled or a runtime error surfaces.
+	select {
+	case <-runCtx.Done():
+	case err := <-setupErr:
+		// A subscription failed after the startup window.
+		slog.Error("eventrouter: subscription failed at runtime",
+			slog.Any("error", err))
+		cancel()
+		r.wg.Wait()
+		return err
+	}
+
+	r.wg.Wait()
+	return nil
+}
+
+// Running returns a channel that is closed when all subscriptions have
+// successfully started consuming. Callers can use this to wait for the
+// Router to be ready (e.g., in bootstrap).
+func (r *Router) Running() <-chan struct{} {
+	return r.running
+}
+
+// Close cancels all subscriptions and waits for goroutines to finish.
+func (r *Router) Close() error {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.wg.Wait()
+	return nil
+}
+
+// HandlerCount returns the number of registered handlers.
+func (r *Router) HandlerCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.handlers)
+}

--- a/src/runtime/eventrouter/router.go
+++ b/src/runtime/eventrouter/router.go
@@ -23,6 +23,12 @@ import (
 // DefaultStartupTimeout is the duration Run waits for Subscribe calls to
 // either return an error (setup failure) or remain blocking (consuming).
 // If no error arrives within this window, all subscriptions are assumed ready.
+//
+// Note: this is a heuristic. If broker topology setup (e.g., RabbitMQ
+// ExchangeDeclare + QueueBind) takes longer than this timeout, bootstrap
+// will proceed before subscriptions are actually ready. The timeout is
+// configurable via WithStartupTimeout. A future Subscriber interface split
+// (Setup + Run) would eliminate this heuristic entirely.
 const DefaultStartupTimeout = 500 * time.Millisecond
 
 // Option configures a Router.
@@ -45,12 +51,16 @@ type handlerConfig struct {
 // Router manages event subscription lifecycle. It implements cell.EventRouter
 // for the declaration phase (AddHandler) and provides Run/Close for the
 // execution phase.
+//
+// Run MUST be called at most once. Calling Run a second time returns an error.
 type Router struct {
 	subscriber     outbox.Subscriber
 	handlers       []handlerConfig
 	mu             sync.Mutex
 	startupTimeout time.Duration
 	running        chan struct{}
+	runGuard       sync.Once // ensures Run is called at most once
+	runningOnce    sync.Once // ensures close(r.running) is called at most once
 	cancel         context.CancelFunc
 	wg             sync.WaitGroup
 }
@@ -72,16 +82,26 @@ func New(sub outbox.Subscriber, opts ...Option) *Router {
 }
 
 // AddHandler registers a subscription intent. It MUST be called before Run.
-// Not safe for concurrent use — intended to be called sequentially during
-// bootstrap's RegisterSubscriptions phase.
+// Panics if topic is empty or handler is nil.
 func (r *Router) AddHandler(topic string, handler outbox.EntryHandler) {
+	if topic == "" {
+		panic("eventrouter: AddHandler called with empty topic")
+	}
+	if handler == nil {
+		panic("eventrouter: AddHandler called with nil handler")
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.handlers = append(r.handlers, handlerConfig{topic: topic, handler: handler})
 }
 
+// errAlreadyRunning is returned if Run is called more than once.
+var errAlreadyRunning = fmt.Errorf("eventrouter: Run called more than once")
+
 // Run starts all registered subscriptions and blocks until ctx is cancelled
 // or an unrecoverable subscription error occurs.
+//
+// Run MUST be called at most once; a second call returns errAlreadyRunning.
 //
 // Setup-error detection: each Subscribe call is launched in a goroutine.
 // If any returns an error within the startup timeout, Run cancels all
@@ -91,19 +111,28 @@ func (r *Router) AddHandler(topic string, handler outbox.EntryHandler) {
 // On context cancellation, Run waits for all goroutines to finish before
 // returning.
 func (r *Router) Run(ctx context.Context) error {
+	var firstRun bool
+	r.runGuard.Do(func() { firstRun = true })
+	if !firstRun {
+		return errAlreadyRunning
+	}
+
 	r.mu.Lock()
 	handlers := make([]handlerConfig, len(r.handlers))
 	copy(handlers, r.handlers)
 	r.mu.Unlock()
 
+	runCtx, cancel := context.WithCancel(ctx)
+
+	r.mu.Lock()
+	r.cancel = cancel
+	r.mu.Unlock()
+
 	if len(handlers) == 0 {
-		close(r.running)
-		<-ctx.Done()
+		r.closeRunning()
+		<-runCtx.Done()
 		return nil
 	}
-
-	runCtx, cancel := context.WithCancel(ctx)
-	r.cancel = cancel
 
 	// setupErr receives the first subscription setup error.
 	// Buffer size = len(handlers) to avoid goroutine leaks if multiple fail.
@@ -114,11 +143,15 @@ func (r *Router) Run(ctx context.Context) error {
 		r.wg.Add(1)
 		go func() {
 			defer r.wg.Done()
+			defer func() {
+				if rv := recover(); rv != nil {
+					setupErr <- fmt.Errorf("eventrouter: topic %s panicked: %v", h.topic, rv)
+				}
+			}()
 			slog.Info("eventrouter: starting subscription",
 				slog.String("topic", h.topic))
 			err := r.subscriber.Subscribe(runCtx, h.topic, h.handler)
 			if err != nil && runCtx.Err() == nil {
-				// Real setup/runtime error, not a cancellation side-effect.
 				setupErr <- fmt.Errorf("eventrouter: topic %s: %w", h.topic, err)
 			}
 		}()
@@ -136,7 +169,7 @@ func (r *Router) Run(ctx context.Context) error {
 		// No errors within timeout — all handlers are consuming.
 		slog.Info("eventrouter: all subscriptions started",
 			slog.Int("count", len(handlers)))
-		close(r.running)
+		r.closeRunning()
 	case <-runCtx.Done():
 		// Context cancelled during startup.
 		r.wg.Wait()
@@ -147,7 +180,6 @@ func (r *Router) Run(ctx context.Context) error {
 	select {
 	case <-runCtx.Done():
 	case err := <-setupErr:
-		// A subscription failed after the startup window.
 		slog.Error("eventrouter: subscription failed at runtime",
 			slog.Any("error", err))
 		cancel()
@@ -159,20 +191,46 @@ func (r *Router) Run(ctx context.Context) error {
 	return nil
 }
 
+// closeRunning safely closes the running channel exactly once.
+func (r *Router) closeRunning() {
+	r.runningOnce.Do(func() { close(r.running) })
+}
+
 // Running returns a channel that is closed when all subscriptions have
 // successfully started consuming. Callers can use this to wait for the
 // Router to be ready (e.g., in bootstrap).
+//
+// Note: if Run returns a setup error, Running() is never closed. Callers
+// should also monitor the error from Run.
 func (r *Router) Running() <-chan struct{} {
 	return r.running
 }
 
 // Close cancels all subscriptions and waits for goroutines to finish.
-func (r *Router) Close() error {
-	if r.cancel != nil {
-		r.cancel()
+// The provided context controls the maximum wait time for goroutines to
+// drain; if the context expires, Close returns the context error.
+func (r *Router) Close(ctx context.Context) error {
+	r.mu.Lock()
+	cancel := r.cancel
+	r.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
 	}
-	r.wg.Wait()
-	return nil
+
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		slog.Warn("eventrouter: close timed out, some goroutines may still be running")
+		return ctx.Err()
+	}
 }
 
 // HandlerCount returns the number of registered handlers.

--- a/src/runtime/eventrouter/router.go
+++ b/src/runtime/eventrouter/router.go
@@ -210,6 +210,8 @@ func (r *Router) Running() <-chan struct{} {
 // The provided context controls the maximum wait time for goroutines to
 // drain; if the context expires, Close returns the context error.
 func (r *Router) Close(ctx context.Context) error {
+	start := time.Now()
+
 	r.mu.Lock()
 	cancel := r.cancel
 	r.mu.Unlock()
@@ -226,9 +228,11 @@ func (r *Router) Close(ctx context.Context) error {
 
 	select {
 	case <-done:
+		slog.Info("eventrouter: closed", slog.Duration("elapsed", time.Since(start)))
 		return nil
 	case <-ctx.Done():
-		slog.Warn("eventrouter: close timed out, some goroutines may still be running")
+		slog.Warn("eventrouter: close timed out, some goroutines may still be running",
+			slog.Duration("elapsed", time.Since(start)))
 		return ctx.Err()
 	}
 }

--- a/src/runtime/eventrouter/router_test.go
+++ b/src/runtime/eventrouter/router_test.go
@@ -1,0 +1,400 @@
+package eventrouter
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time interface check.
+var _ cell.EventRouter = (*Router)(nil)
+
+// --- Mock Subscriber ---
+
+// blockingSubscriber blocks until ctx is cancelled, simulating a healthy broker.
+type blockingSubscriber struct {
+	mu     sync.Mutex
+	topics []string
+}
+
+func (s *blockingSubscriber) Subscribe(ctx context.Context, topic string, _ outbox.EntryHandler) error {
+	s.mu.Lock()
+	s.topics = append(s.topics, topic)
+	s.mu.Unlock()
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *blockingSubscriber) Close() error { return nil }
+
+func (s *blockingSubscriber) Topics() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]string, len(s.topics))
+	copy(cp, s.topics)
+	return cp
+}
+
+// failingSubscriber returns an error immediately, simulating setup failure.
+type failingSubscriber struct {
+	err error
+}
+
+func (s *failingSubscriber) Subscribe(_ context.Context, _ string, _ outbox.EntryHandler) error {
+	return s.err
+}
+
+func (s *failingSubscriber) Close() error { return nil }
+
+// delayedFailSubscriber blocks briefly then returns an error (simulates
+// runtime failure after startup).
+type delayedFailSubscriber struct {
+	delay time.Duration
+	err   error
+}
+
+func (s *delayedFailSubscriber) Subscribe(ctx context.Context, _ string, _ outbox.EntryHandler) error {
+	select {
+	case <-time.After(s.delay):
+		return s.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *delayedFailSubscriber) Close() error { return nil }
+
+// --- Tests ---
+
+func TestRouter_AddHandler_RegistersTopics(t *testing.T) {
+	sub := &blockingSubscriber{}
+	r := New(sub)
+
+	r.AddHandler("topic.a", noopHandler)
+	r.AddHandler("topic.b", noopHandler)
+
+	assert.Equal(t, 2, r.HandlerCount())
+}
+
+func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
+	sub := &blockingSubscriber{}
+	r := New(sub, WithStartupTimeout(200*time.Millisecond))
+
+	r.AddHandler("topic.a", noopHandler)
+	r.AddHandler("topic.b", noopHandler)
+	r.AddHandler("topic.c", noopHandler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	// Wait for Running signal.
+	select {
+	case <-r.Running():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Router did not become ready")
+	}
+
+	// Verify all 3 topics subscribed.
+	topics := sub.Topics()
+	assert.Len(t, topics, 3)
+	assert.Contains(t, topics, "topic.a")
+	assert.Contains(t, topics, "topic.b")
+	assert.Contains(t, topics, "topic.c")
+
+	cancel()
+	assert.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func TestRouter_Run_SetupError_ReturnsImmediately(t *testing.T) {
+	setupErr := errcode.New(errcode.ErrBusClosed, "bus closed")
+	sub := &failingSubscriber{err: setupErr}
+	r := New(sub, WithStartupTimeout(500*time.Millisecond))
+
+	r.AddHandler("topic.fail", noopHandler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := r.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "topic.fail")
+
+	// Running() should NOT be closed on setup failure.
+	select {
+	case <-r.Running():
+		t.Fatal("Running() should not be closed on setup failure")
+	default:
+		// expected
+	}
+}
+
+func TestRouter_Run_NoHandlers_BlocksUntilCancel(t *testing.T) {
+	sub := &blockingSubscriber{}
+	r := New(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	// Running should be closed immediately.
+	select {
+	case <-r.Running():
+	case <-time.After(time.Second):
+		t.Fatal("Running() should close immediately with no handlers")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after cancel")
+	}
+}
+
+func TestRouter_Close_CancelsSubscriptions(t *testing.T) {
+	sub := &blockingSubscriber{}
+	r := New(sub, WithStartupTimeout(200*time.Millisecond))
+
+	r.AddHandler("topic.a", noopHandler)
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	<-r.Running()
+
+	err := r.Close()
+	assert.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after Close")
+	}
+}
+
+func TestRouter_Run_HandlerReceivesMessages(t *testing.T) {
+	// Use InMemoryEventBus to verify end-to-end message flow.
+	bus := newTestEventBus(t)
+
+	var received atomic.Int32
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		received.Add(1)
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}
+
+	r := New(bus, WithStartupTimeout(200*time.Millisecond))
+	r.AddHandler("test.topic", handler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	<-r.Running()
+
+	// Publish a message.
+	err := bus.Publish(context.Background(), "test.topic", []byte(`{"key":"value"}`))
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return received.Load() >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+func TestRouter_Run_MultipleHandlersSameSubscriber(t *testing.T) {
+	bus := newTestEventBus(t)
+
+	var countA, countB atomic.Int32
+
+	r := New(bus, WithStartupTimeout(200*time.Millisecond))
+	r.AddHandler("topic.a", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		countA.Add(1)
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+	r.AddHandler("topic.b", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		countB.Add(1)
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	<-r.Running()
+
+	require.NoError(t, bus.Publish(context.Background(), "topic.a", []byte(`{}`)))
+	require.NoError(t, bus.Publish(context.Background(), "topic.b", []byte(`{}`)))
+
+	assert.Eventually(t, func() bool {
+		return countA.Load() >= 1 && countB.Load() >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+func TestRouter_EventRegistrar_Integration(t *testing.T) {
+	// Simulate the bootstrap pattern: cell declares handlers, router runs them.
+	bus := newTestEventBus(t)
+	r := New(bus, WithStartupTimeout(200*time.Millisecond))
+
+	var received atomic.Int32
+
+	// Simulate a cell's RegisterSubscriptions.
+	var registrar cell.EventRegistrar = &mockCell{handler: func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		received.Add(1)
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}}
+
+	err := registrar.RegisterSubscriptions(r)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.HandlerCount())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	<-r.Running()
+
+	require.NoError(t, bus.Publish(context.Background(), "mock.topic", []byte(`{}`)))
+
+	assert.Eventually(t, func() bool {
+		return received.Load() >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+func TestRouter_Run_RuntimeError_AfterStartup(t *testing.T) {
+	// Subscribe blocks for 300ms (past startup timeout), then fails.
+	sub := &delayedFailSubscriber{
+		delay: 300 * time.Millisecond,
+		err:   errors.New("connection lost"),
+	}
+	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r.AddHandler("topic.a", noopHandler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := r.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection lost")
+}
+
+// --- Helpers ---
+
+var noopHandler = func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	return outbox.HandleResult{Disposition: outbox.DispositionAck}
+}
+
+// mockCell implements cell.EventRegistrar for testing.
+type mockCell struct {
+	handler outbox.EntryHandler
+}
+
+func (m *mockCell) RegisterSubscriptions(r cell.EventRouter) error {
+	r.AddHandler("mock.topic", m.handler)
+	return nil
+}
+
+// newTestEventBus creates an InMemoryEventBus for testing, registered for cleanup.
+func newTestEventBus(t *testing.T) *testBus {
+	t.Helper()
+	b := &testBus{
+		subs:    make(map[string][]*testSub),
+		bufSize: 256,
+	}
+	t.Cleanup(func() { _ = b.Close() })
+	return b
+}
+
+// testBus is a minimal in-memory pub/sub for Router tests, avoiding import
+// of runtime/eventbus (same package layer). Mirrors eventbus.InMemoryEventBus
+// but without retry/dead-letter logic.
+type testBus struct {
+	mu      sync.RWMutex
+	subs    map[string][]*testSub
+	bufSize int
+	closed  bool
+}
+
+type testSub struct {
+	ch     chan outbox.Entry
+	cancel context.CancelFunc
+}
+
+func (b *testBus) Publish(_ context.Context, topic string, payload []byte) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.closed {
+		return errcode.New(errcode.ErrBusClosed, "closed")
+	}
+	entry := outbox.Entry{ID: "evt-test", EventType: topic, Payload: payload}
+	for _, s := range b.subs[topic] {
+		select {
+		case s.ch <- entry:
+		default:
+		}
+	}
+	return nil
+}
+
+func (b *testBus) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler) error {
+	subCtx, cancel := context.WithCancel(ctx)
+	s := &testSub{ch: make(chan outbox.Entry, b.bufSize), cancel: cancel}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		cancel()
+		return errcode.New(errcode.ErrBusClosed, "closed")
+	}
+	b.subs[topic] = append(b.subs[topic], s)
+	b.mu.Unlock()
+
+	for {
+		select {
+		case <-subCtx.Done():
+			return subCtx.Err()
+		case entry := <-s.ch:
+			handler(subCtx, entry)
+		}
+	}
+}
+
+func (b *testBus) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	for _, subs := range b.subs {
+		for _, s := range subs {
+			s.cancel()
+		}
+	}
+	return nil
+}

--- a/src/runtime/eventrouter/router_test.go
+++ b/src/runtime/eventrouter/router_test.go
@@ -180,7 +180,7 @@ func TestRouter_Close_CancelsSubscriptions(t *testing.T) {
 
 	<-r.Running()
 
-	err := r.Close()
+	err := r.Close(context.Background())
 	assert.NoError(t, err)
 
 	select {
@@ -302,6 +302,115 @@ func TestRouter_Run_RuntimeError_AfterStartup(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection lost")
 }
+
+func TestRouter_Run_DoubleRun_ReturnsError(t *testing.T) {
+	sub := &blockingSubscriber{}
+	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r.AddHandler("topic.a", noopHandler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	<-r.Running()
+
+	// Second Run should return error, not panic.
+	err := r.Run(ctx)
+	assert.ErrorIs(t, err, errAlreadyRunning)
+
+	cancel()
+	<-done
+}
+
+func TestRouter_Close_ZeroHandlers(t *testing.T) {
+	sub := &blockingSubscriber{}
+	r := New(sub)
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	<-r.Running()
+
+	// Close should terminate Run even with zero handlers.
+	err := r.Close(context.Background())
+	assert.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after Close with zero handlers")
+	}
+}
+
+func TestRouter_Close_Timeout(t *testing.T) {
+	// Subscriber that ignores context cancellation (simulates stuck goroutine).
+	stuck := make(chan struct{})
+	sub := &stuckSubscriber{block: stuck}
+	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r.AddHandler("topic.stuck", noopHandler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = r.Run(ctx) }()
+
+	<-r.Running()
+
+	// Close with a very short timeout — should return context deadline error.
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer closeCancel()
+	err := r.Close(closeCtx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	close(stuck) // unblock the subscriber so test cleanup works
+}
+
+func TestRouter_AddHandler_PanicsOnEmptyTopic(t *testing.T) {
+	r := New(&blockingSubscriber{})
+	assert.Panics(t, func() {
+		r.AddHandler("", noopHandler)
+	})
+}
+
+func TestRouter_AddHandler_PanicsOnNilHandler(t *testing.T) {
+	r := New(&blockingSubscriber{})
+	assert.Panics(t, func() {
+		r.AddHandler("topic", nil)
+	})
+}
+
+func TestRouter_Run_PanicInSubscriber_CapturedAsError(t *testing.T) {
+	// A subscriber whose Subscribe panics.
+	panickySub := &panickingSubscriber{}
+	r := New(panickySub, WithStartupTimeout(500*time.Millisecond))
+	r.AddHandler("topic.panic", noopHandler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := r.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panicked")
+}
+
+// stuckSubscriber blocks on an external channel, ignoring context cancellation.
+type stuckSubscriber struct {
+	block chan struct{}
+}
+
+func (s *stuckSubscriber) Subscribe(_ context.Context, _ string, _ outbox.EntryHandler) error {
+	<-s.block // ignores ctx — simulates unresponsive subscriber
+	return nil
+}
+func (s *stuckSubscriber) Close() error { return nil }
+
+// panickingSubscriber panics on Subscribe.
+type panickingSubscriber struct{}
+
+func (s *panickingSubscriber) Subscribe(_ context.Context, _ string, _ outbox.EntryHandler) error {
+	panic("boom")
+}
+func (s *panickingSubscriber) Close() error { return nil }
 
 // --- Helpers ---
 


### PR DESCRIPTION
## Summary
- Introduces `cell.EventRouter` interface and `runtime/eventrouter.Router` to separate event subscription **declaration** from **execution**
- Eliminates per-cell 100ms heuristic timer boilerplate in audit-core and config-core
- Centralizes subscription lifecycle and error supervision in Router (goroutine tracking via WaitGroup, panic recovery, runtime error propagation to bootstrap)
- **Does NOT fully resolve**: P5 (InMemoryEventBus behavioral divergence — competing consumers on same topic still differ between in-memory fan-out and RabbitMQ queue sharing); readiness detection (`Running()`) remains a configurable timeout heuristic, not a true setup-complete signal

## What this PR achieves
- Cells go from ~20 lines of goroutine+timer boilerplate to `r.AddHandler(topic, handler)`
- Bootstrap monitors Router runtime errors (routerErrCh in Step 9 select) — subscription failures no longer silently lost
- Router lifecycle is safe: sync.Once double-Run guard, mutex-protected cancel, Close(ctx) with timeout, panic recovery in subscription goroutines

## Known limitations (tracked in backlog)
- **ER-ARCH-01 (v1.1)**: `Running()` still uses `time.After(startupTimeout)` — RabbitMQ topology setup (Qos+Declare+Bind+Consume) could exceed 500ms on slow networks. True fix requires `Subscriber` interface split into `Setup()+Run()`
- **ER-ARCH-02 (Batch 5)**: `AddHandler` has no consumer group identity — audit-core and config-core both subscribe to `event.config.changed.v1`, which in RabbitMQ becomes competing consumers instead of fan-out. Fix: `AddHandler(...HandlerOption)` + `WithConsumerGroup(cg)`

## Key Design (ref: Watermill Router)
- `AddHandler(topic, handler)` — non-blocking declaration (Cells call this)
- `Run(ctx) error` — starts all Subscribe goroutines, detects setup errors within configurable timeout, blocks until cancelled
- `Running() <-chan struct{}` — closes when no setup error within timeout (heuristic readiness)
- `Close(ctx) error` — cancel + timeout-bounded WaitGroup drain

## Files Changed (15 files across 6 commits)
| File | Change |
|------|--------|
| `kernel/cell/registrar.go` | New `EventRouter` interface, updated `EventRegistrar` signature |
| `kernel/cell/celltest/eventrouter.go` | New `StubEventRouter` test helper |
| `runtime/eventrouter/router.go` | New package: Router with Run/Running/Close lifecycle |
| `runtime/eventrouter/router_test.go` | 15 tests: startup, setup error, runtime error, close, timeout, panic, double-run, message flow, e2e |
| `cells/audit-core/cell.go` | 28→6 lines: remove goroutine + 100ms heuristic |
| `cells/config-core/cell.go` | 20→4 lines: same simplification |
| `cells/access-core/cell.go` | Signature update (still no-op) |
| `runtime/bootstrap/bootstrap.go` | Router integration + routerErrCh in Step 9 |
| `runtime/bootstrap/doc.go` | Fix deprecated WithEventBus example |
| `.claude/rules/gocell/eventbus.md` | Update consumer docs with EventRouter pattern |
| `docs/backlog.md` | Record ER-ARCH-01/02 + cleanup items |
| `*_test.go` (4 files) | Updated mocks, bootstrap happy-path test |

## Breaking Change
`cell.EventRegistrar.RegisterSubscriptions` signature changed from `(outbox.Subscriber)` to `(cell.EventRouter)`. All 3 in-tree implementations updated atomically.

## Test plan
- [x] `go build ./...`
- [x] `runtime/eventrouter` — 15 tests including race detector
- [x] `kernel/cell` — registrar tests updated
- [x] `cells/*` — all 3 cells passing
- [x] `runtime/bootstrap` — subscription failure rollback + happy-path Router integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)