### PR TITLE
fix(cells/device-cell): align tests with data envelope response format

### DIFF
--- a/src/cells/device-cell/cell_test.go
+++ b/src/cells/device-cell/cell_test.go
@@ -126,6 +126,16 @@ func (m *stubMux) Mount(_ string, _ http.Handler)                   { m.handleCo
 func (m *stubMux) Group(_ func(cell.RouteMux))                      { m.handleCount++ }
 func (m *stubMux) With(_ ...func(http.Handler) http.Handler) cell.RouteMux { return m }
 
+// extractData unmarshals a JSON response and returns the "data" envelope.
+func extractData(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	data, ok := envelope["data"].(map[string]any)
+	require.True(t, ok, "response should have data envelope")
+	return data
+}
+
 // initCellWithRouter creates an initialized DeviceCell with routes registered
 // on a real chi-based router, ready for HTTP testing.
 func initCellWithRouter(t *testing.T) *router.Router {
@@ -156,9 +166,8 @@ func TestDeviceCell_RouteRegisterDevice(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, rec.Code,
 		"POST /api/v1/devices/ should return 201")
 
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.NotEmpty(t, resp["id"])
+	data := extractData(t, rec.Body.Bytes())
+	assert.NotEmpty(t, data["id"])
 }
 
 func TestDeviceCell_RouteGetStatus(t *testing.T) {
@@ -172,9 +181,8 @@ func TestDeviceCell_RouteGetStatus(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
-	var created map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
-	deviceID := created["id"].(string)
+	data := extractData(t, rec.Body.Bytes())
+	deviceID := data["id"].(string)
 
 	// Now get status.
 	rec = httptest.NewRecorder()
@@ -194,9 +202,8 @@ func TestDeviceCell_RouteEnqueueCommand(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
-	var created map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
-	deviceID := created["id"].(string)
+	data := extractData(t, rec.Body.Bytes())
+	deviceID := data["id"].(string)
 
 	// Enqueue command.
 	rec = httptest.NewRecorder()
@@ -217,9 +224,8 @@ func TestDeviceCell_RouteListPendingCommands(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
-	var created map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
-	deviceID := created["id"].(string)
+	data := extractData(t, rec.Body.Bytes())
+	deviceID := data["id"].(string)
 
 	// List pending (should be empty).
 	rec = httptest.NewRecorder()
@@ -239,9 +245,8 @@ func TestDeviceCell_RouteAckCommand(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
-	var created map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
-	deviceID := created["id"].(string)
+	data := extractData(t, rec.Body.Bytes())
+	deviceID := data["id"].(string)
 
 	// Enqueue command.
 	rec = httptest.NewRecorder()
@@ -250,9 +255,8 @@ func TestDeviceCell_RouteAckCommand(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
-	var cmdResp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &cmdResp))
-	cmdID := cmdResp["id"].(string)
+	cmdData := extractData(t, rec.Body.Bytes())
+	cmdID := cmdData["id"].(string)
 
 	// Ack.
 	rec = httptest.NewRecorder()

--- a/src/cells/device-cell/slices/device-command/handler_test.go
+++ b/src/cells/device-cell/slices/device-command/handler_test.go
@@ -43,12 +43,14 @@ func TestHandleEnqueue(t *testing.T) {
 			body:       `{"payload":"reboot"}`,
 			wantStatus: http.StatusCreated,
 			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]any
-				require.NoError(t, json.Unmarshal(body, &resp))
-				assert.NotEmpty(t, resp["id"])
-				assert.Equal(t, "dev-1", resp["deviceId"])
-				assert.Equal(t, "reboot", resp["payload"])
-				assert.Equal(t, "pending", resp["status"])
+				var envelope map[string]any
+				require.NoError(t, json.Unmarshal(body, &envelope))
+				data, ok := envelope["data"].(map[string]any)
+				require.True(t, ok, "response should have data envelope")
+				assert.NotEmpty(t, data["id"])
+				assert.Equal(t, "dev-1", data["deviceId"])
+				assert.Equal(t, "reboot", data["payload"])
+				assert.Equal(t, "pending", data["status"])
 			},
 		},
 		{
@@ -185,9 +187,11 @@ func TestHandleAck(t *testing.T) {
 
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.wantStatus == http.StatusOK {
-				var resp map[string]any
-				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-				assert.Equal(t, "acked", resp["status"])
+				var envelope map[string]any
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+				data, ok := envelope["data"].(map[string]any)
+				require.True(t, ok, "response should have data envelope")
+				assert.Equal(t, "acked", data["status"])
 			}
 		})
 	}

--- a/src/cells/device-cell/slices/device-register/handler_test.go
+++ b/src/cells/device-cell/slices/device-register/handler_test.go
@@ -33,11 +33,13 @@ func TestHandleRegister(t *testing.T) {
 			body:       `{"name":"sensor-a"}`,
 			wantStatus: http.StatusCreated,
 			checkBody: func(t *testing.T, body []byte) {
-				var resp map[string]any
-				require.NoError(t, json.Unmarshal(body, &resp))
-				assert.NotEmpty(t, resp["id"])
-				assert.Equal(t, "sensor-a", resp["name"])
-				assert.Equal(t, "online", resp["status"])
+				var envelope map[string]any
+				require.NoError(t, json.Unmarshal(body, &envelope))
+				data, ok := envelope["data"].(map[string]any)
+				require.True(t, ok, "response should have data envelope")
+				assert.NotEmpty(t, data["id"])
+				assert.Equal(t, "sensor-a", data["name"])
+				assert.Equal(t, "online", data["status"])
 			},
 		},
 		{

--- a/src/kernel/cell/celltest/eventrouter_test.go
+++ b/src/kernel/cell/celltest/eventrouter_test.go
@@ -1,0 +1,27 @@
+package celltest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func TestStubEventRouter_AddHandler(t *testing.T) {
+	r := &StubEventRouter{}
+	assert.Equal(t, 0, r.HandlerCount())
+
+	handler := outbox.EntryHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	})
+
+	r.AddHandler("topic.a.v1", handler)
+	assert.Equal(t, 1, r.HandlerCount())
+	assert.Equal(t, "topic.a.v1", r.Topics[0])
+
+	r.AddHandler("topic.b.v1", handler)
+	assert.Equal(t, 2, r.HandlerCount())
+	assert.Equal(t, "topic.b.v1", r.Topics[1])
+}


### PR DESCRIPTION
## Summary
- device-cell handler 响应已改为 `{"data": {...}}` 信封格式（符合 API 版本约定），但 3 个测试文件仍直接访问顶层字段（`resp["id"]`），导致 nil 断言失败和 panic
- 更新 `cell_test.go`、`device-register/handler_test.go`、`device-command/handler_test.go` 中所有断言，通过 `data` 信封提取实际字段
- 添加 `extractData` helper 消除 cell_test.go 中重复的信封解析代码

## Test plan
- [x] `go test ./cells/device-cell/...` 全部通过
- [x] `go build ./...` 编译通过
- [ ] CI pipeline 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)