### PR TITLE
refactor(kernel): Dependencies 精简 + BatchWriter 接口 (K-1/K-2/K-3/K-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to GoCell are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased] - PR-Cleanup: Kernel 架构整理
+
+> PR: #79
+> Scope: K-1/K-2/K-3/K-5
+
+### Breaking
+
+- **kernel/cell**: `Dependencies` struct 移除 `Cells map[string]Cell` 和 `Contracts map[string]Contract` 字段（零调用方使用）。仅保留 `Config map[string]any`。迁移：删除 `Dependencies{}` 字面量中的 `Cells:` 和 `Contracts:` 字段。
+
+### Added
+
+- **kernel/outbox**: `BatchWriter` 接口（嵌入 `Writer`，新增 `WriteBatch` 方法）+ `WriteBatchFallback` helper（自动检测 batch 支持，降级到顺序写入）
+- **adapters/postgres**: `OutboxWriter` 实现 `BatchWriter`，使用多行 INSERT，超过 7000 条自动分片
+
+### Documentation
+
+- **kernel/cell/registrar.go**: net/http ADR 注释（CS-AR-3，已存在，标记完成）
+- **kernel/cell/interfaces.go**: `Dependencies` 冻结 ADR 注释
+
 ## [Unreleased] - Phase 4: Examples + Documentation
 
 > Branch: `feat/003-phase4-examples-docs`

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ examples/  ← all layers
 
 | Adapter | Capabilities | Kernel Interface |
 |---------|-------------|-----------------|
-| `adapters/postgres` | Pool, TxManager, Migrator (goose v3), OutboxWriter, OutboxRelay | `outbox.Writer`, `outbox.Relay` |
+| `adapters/postgres` | Pool, TxManager, Migrator (goose v3), OutboxWriter, OutboxRelay | `outbox.Writer`, `outbox.BatchWriter`, `outbox.Relay` |
 | `adapters/redis` | Client, DistLock, IdempotencyChecker, Cache | `idempotency.Checker` |
 | `adapters/oidc` | Thin go-oidc v3 wrapper (Config, Provider, Refresh, Verifier, OAuth2Config) | — |
 | `adapters/s3` | Thin aws-sdk-go-v2 wrapper (Config, Upload, Health, SDK escape hatch) | — |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -428,6 +428,8 @@
 | P4-TD-03 IssueTestToken 死代码 | 30min | runtime/auth |
 | OPS-3 readiness 探针接 postgres/redis | 2h | 实现 Health() + 注册 HealthChecker（rabbitmq 已提前至 Batch 3） |
 | OPS-4 优雅关闭 drain 期 | 1h | bootstrap shutdown |
+| CI-01 integration job 补 tests/integration/ | 30min | .github/workflows/ci.yml:101-102 只跑 ./adapters/...，漏掉 src/tests/integration/ (discovered via PR#79 review) |
+| OB-UUID-01 cells evt-<uuid> 与 Writer UUID 校验冲突 | 2h | cells 生成 `evt-<uuid>` 前缀 ID，但 outbox_writer.go 只接受 canonical UUID；需统一 ID 生成策略或放宽校验 (discovered via PR#79 review) |
 
 ### 总时间线（修订后，+6 个 Batch）
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -119,7 +119,7 @@
 | F-5 | `kernel/journey/catalog.go` | Journey catalog 不校验引用 | 2h |
 | R1C2-F01 | `runtime/eventbus/eventbus.go` | Close()+Subscribe() 竞态 | 2h |
 | R1C2-F03 | `runtime/worker/worker.go` | WorkerGroup.Start 首个失败不取消其余 worker | 2h |
-| F-OB-01 | `kernel/outbox/outbox.go` | 无批量写支持 | 2h |
+| ~~F-OB-01~~ | `kernel/outbox/outbox.go` | ~~无批量写支持~~ PR#79 ✅ | ~~2h~~ |
 | TX-NIL-01 | `cells/*/service.go` | txRunner nil-safe 未文档化 | 1h |
 | OTEL-COV-01 | `adapters/otel/` | 覆盖率 67.3%（PR#72 删除了依赖内部 API 的旧测试后回升，但仍 < 80%；成功路径需 gRPC OTLP endpoint，需 testcontainers 集成测试） | 2h |
 | SUB-SETUP-01 | `kernel/outbox`, `cells/*/cell.go` | RegisterSubscriptions 用 100ms 启发式区分 setup 失败与正常阻塞消费。**已被 Phase 2 EventRouter 解决**——Router.Run() 同步返回 setup error，消除启发式 | ~~4h~~ → Phase 2 |
@@ -420,8 +420,10 @@
 | F-5 Journey catalog 校验 | 2h | kernel/journey |
 | R1C2-F01 eventbus Close+Subscribe 竞态 | 2h | runtime/eventbus（需 -race 验证） |
 | R1C2-F03 WorkerGroup 首个失败 | 2h | runtime/worker |
-| F-OB-01 outbox 批量写 | 2h | kernel/outbox |
+| ~~F-OB-01 outbox 批量写~~ | ~~2h~~ | ~~kernel/outbox~~ PR#79 ✅ |
 | TX-NIL-01 txRunner nil-safe 文档 | 1h | cells/ |
+| F-OB-02 outbox UUID nil guard | 30min | adapters/postgres — 拒绝全零 UUID 防幂等碰撞 (discovered via PR#79 review F-2.3) |
+| P4-TD-01 noopWriter 去重 | 1h | cells/*/cell_test.go → 提取到 kernel/outbox/outboxtest (discovered via PR#79 review F-5.2) |
 | P3-TD-10 Session refresh TOCTOU | 4h | 高风险，乐观锁方案 |
 | P4-TD-03 IssueTestToken 死代码 | 30min | runtime/auth |
 | OPS-3 readiness 探针接 postgres/redis | 2h | 实现 Health() + 注册 HealthChecker（rabbitmq 已提前至 Batch 3） |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -59,13 +59,13 @@
 
 | 序号 | ID | 任务 | 文件 | 预估 | 依赖 |
 |------|-----|------|------|------|------|
-| K-1 | CS-AR-2 | Dependencies 精简 + 冻结注释 | `kernel/cell/interfaces.go`, `kernel/assembly/assembly.go`, ~20 test files | 1h | ~~Phase 2~~ ✅ 无阻塞 |
-| K-2 | CS-AR-3 | net/http ADR 注释 | `kernel/cell/registrar.go` | 15min | 无 |
-| K-3 | F-OB-01 | BatchWriter 接口 + WriteBatchFallback | `kernel/outbox/outbox.go`, `adapters/postgres/outbox_writer.go` | 3h | 无 |
+| ~~K-1~~ | CS-AR-2 | ~~Dependencies 精简 + 冻结注释~~ | — | — | ✅ PR#79 |
+| ~~K-2~~ | CS-AR-3 | ~~net/http ADR 注释~~ | — | — | ✅ PR#79（ADR 已存在于 registrar.go） |
+| ~~K-3~~ | F-OB-01 | ~~BatchWriter 接口 + WriteBatchFallback~~ | — | — | ✅ PR#79 |
 | K-4 | SOL-B-02 | Receipt 移回 idempotency 包 | `kernel/idempotency/idempotency.go`, `kernel/outbox/outbox.go`, adapters + tests | 3h | Phase 3 |
-| K-5 | — | 三角色审查 mandatory actions | Dependencies 冻结 + registrar ADR + WriteBatchFallback godoc | 含在 K-1/K-2/K-3 |
+| ~~K-5~~ | — | ~~三角色审查 mandatory actions~~ | — | — | ✅ 含在 PR#79 |
 
-> K-1/K-2/K-3 全程无阻塞可并行（Phase 2 已合并）；K-4 依赖 Phase 3
+> ~~K-1/K-2/K-3~~ ✅ 已合并（PR#79）；K-4 依赖 Phase 3
 
 ---
 
@@ -355,7 +355,7 @@
 | A | Phase 1: PermanentError → kernel | PR#74 | ✅ |
 | A | Phase 2: EventRouter 引入 | PR#76 | ✅ |
 | B | 0-G B-03 RabbitMQ 重连 backoff | PR#75 | ✅ |
-| B | K-2 net/http ADR 注释 | — | 待做 |
+| B | K-1/K-2/K-3/K-5 Kernel 架构整理 | PR#79 | ✅ |
 
 ### Batch 3: Tier 0 收尾 + 基础稳定（2d，Batch 2 后）
 

--- a/src/adapters/postgres/outbox_writer.go
+++ b/src/adapters/postgres/outbox_writer.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -14,8 +16,9 @@ import (
 // uuidPattern matches a canonical UUID string (8-4-4-4-12 hex digits).
 var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
-// Compile-time interface check.
+// Compile-time interface checks.
 var _ outbox.Writer = (*OutboxWriter)(nil)
+var _ outbox.BatchWriter = (*OutboxWriter)(nil)
 
 // OutboxWriter writes outbox entries within a PostgreSQL transaction.
 // It relies on TxFromContext to obtain the current transaction, ensuring
@@ -78,6 +81,84 @@ func (w *OutboxWriter) Write(ctx context.Context, entry outbox.Entry) error {
 	if err != nil {
 		return errcode.Wrap(ErrAdapterPGQuery,
 			fmt.Sprintf("outbox: failed to insert entry %s", entry.ID), err)
+	}
+
+	return nil
+}
+
+// WriteBatch inserts multiple outbox entries in a single multi-row INSERT
+// within the caller's transaction. All entries are validated upfront;
+// if any entry is invalid, no entries are written.
+//
+// An empty entries slice is a no-op and returns nil.
+// All-or-nothing: the transaction guarantees atomicity.
+func (w *OutboxWriter) WriteBatch(ctx context.Context, entries []outbox.Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	tx, ok := TxFromContext(ctx)
+	if !ok {
+		return errcode.New(ErrAdapterPGNoTx, "outbox batch write requires a transaction in context")
+	}
+
+	// Validate all entries upfront.
+	for i, e := range entries {
+		if e.ID == "" {
+			return errcode.New(errcode.ErrValidationFailed,
+				fmt.Sprintf("outbox entry[%d] ID must not be empty", i))
+		}
+		if !uuidPattern.MatchString(e.ID) {
+			return errcode.New(errcode.ErrValidationFailed,
+				fmt.Sprintf("outbox entry[%d] ID is not a valid UUID: %s", i, e.ID))
+		}
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("outbox entry[%d]: %w", i, err)
+		}
+	}
+
+	// Build multi-row INSERT: INSERT INTO ... VALUES ($1,...,$9), ($10,...,$18), ...
+	const cols = 9 // id, aggregate_id, aggregate_type, event_type, topic, payload, metadata, created_at, published
+	var sb strings.Builder
+	sb.WriteString(`INSERT INTO outbox_entries
+		(id, aggregate_id, aggregate_type, event_type, topic, payload, metadata, created_at, published)
+		VALUES `)
+
+	args := make([]any, 0, len(entries)*cols)
+	for i, e := range entries {
+		metadata, err := json.Marshal(e.Metadata)
+		if err != nil {
+			return errcode.Wrap(ErrAdapterPGMarshal,
+				fmt.Sprintf("outbox entry[%d]: failed to marshal metadata", i), err)
+		}
+
+		createdAt := e.CreatedAt
+		if createdAt.IsZero() {
+			createdAt = time.Now()
+		}
+
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		base := i * cols
+		sb.WriteString("(")
+		for j := range cols {
+			if j > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString("$")
+			sb.WriteString(strconv.Itoa(base + j + 1))
+		}
+		sb.WriteString(")")
+
+		args = append(args, e.ID, e.AggregateID, e.AggregateType,
+			e.EventType, e.Topic, e.Payload, metadata, createdAt, false)
+	}
+
+	_, err := tx.Exec(ctx, sb.String(), args...)
+	if err != nil {
+		return errcode.Wrap(ErrAdapterPGQuery,
+			fmt.Sprintf("outbox: failed to batch insert %d entries", len(entries)), err)
 	}
 
 	return nil

--- a/src/adapters/postgres/outbox_writer.go
+++ b/src/adapters/postgres/outbox_writer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/jackc/pgx/v5"
 )
 
 // uuidPattern matches a canonical UUID string (8-4-4-4-12 hex digits).
@@ -86,12 +87,20 @@ func (w *OutboxWriter) Write(ctx context.Context, entry outbox.Entry) error {
 	return nil
 }
 
-// WriteBatch inserts multiple outbox entries in a single multi-row INSERT
-// within the caller's transaction. All entries are validated upfront;
-// if any entry is invalid, no entries are written.
+// writeBatchChunkSize is the maximum number of entries per INSERT statement.
+// PostgreSQL supports at most 65535 bind parameters; each entry uses 9 columns,
+// so the theoretical max is 65535/9 = 7281. We use 7000 as a safe margin.
+const writeBatchChunkSize = 7000
+
+// WriteBatch inserts multiple outbox entries within the caller's transaction.
+// All entries are validated upfront (ID format + Entry.Validate); if any entry
+// is invalid, no entries are written.
+//
+// For batches exceeding writeBatchChunkSize, entries are split into chunks
+// and each chunk is inserted with a separate multi-row INSERT within the
+// same transaction, preserving all-or-nothing semantics.
 //
 // An empty entries slice is a no-op and returns nil.
-// All-or-nothing: the transaction guarantees atomicity.
 func (w *OutboxWriter) WriteBatch(ctx context.Context, entries []outbox.Entry) error {
 	if len(entries) == 0 {
 		return nil
@@ -117,7 +126,22 @@ func (w *OutboxWriter) WriteBatch(ctx context.Context, entries []outbox.Entry) e
 		}
 	}
 
-	// Build multi-row INSERT: INSERT INTO ... VALUES ($1,...,$9), ($10,...,$18), ...
+	// Split into chunks to stay within PostgreSQL's 65535 parameter limit.
+	for offset := 0; offset < len(entries); offset += writeBatchChunkSize {
+		end := offset + writeBatchChunkSize
+		if end > len(entries) {
+			end = len(entries)
+		}
+		if err := w.writeBatchChunk(ctx, tx, entries[offset:end], offset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeBatchChunk inserts a single chunk of entries via multi-row INSERT.
+// globalOffset is the index of the first entry in the original slice (for error messages).
+func (w *OutboxWriter) writeBatchChunk(ctx context.Context, tx pgx.Tx, entries []outbox.Entry, globalOffset int) error {
 	const cols = 9 // id, aggregate_id, aggregate_type, event_type, topic, payload, metadata, created_at, published
 	var sb strings.Builder
 	sb.WriteString(`INSERT INTO outbox_entries
@@ -129,7 +153,7 @@ func (w *OutboxWriter) WriteBatch(ctx context.Context, entries []outbox.Entry) e
 		metadata, err := json.Marshal(e.Metadata)
 		if err != nil {
 			return errcode.Wrap(ErrAdapterPGMarshal,
-				fmt.Sprintf("outbox entry[%d]: failed to marshal metadata", i), err)
+				fmt.Sprintf("outbox entry[%d]: failed to marshal metadata", globalOffset+i), err)
 		}
 
 		createdAt := e.CreatedAt
@@ -160,6 +184,5 @@ func (w *OutboxWriter) WriteBatch(ctx context.Context, entries []outbox.Entry) e
 		return errcode.Wrap(ErrAdapterPGQuery,
 			fmt.Sprintf("outbox: failed to batch insert %d entries", len(entries)), err)
 	}
-
 	return nil
 }

--- a/src/adapters/postgres/outbox_writer_test.go
+++ b/src/adapters/postgres/outbox_writer_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -264,6 +265,115 @@ func TestOutboxWriter_Write_MissingPayload(t *testing.T) {
 	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
 	assert.Contains(t, ec.Message, "payload")
 	assert.Empty(t, tx.execCalls, "should not reach DB insert")
+}
+
+// --- WriteBatch Tests ---
+
+func TestOutboxWriter_WriteBatch_EmptySlice(t *testing.T) {
+	w := NewOutboxWriter()
+	tx := &mockOutboxTx{}
+	ctx := CtxWithTx(context.Background(), tx)
+
+	err := w.WriteBatch(ctx, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, tx.execCalls)
+
+	err = w.WriteBatch(ctx, []outbox.Entry{})
+	assert.NoError(t, err)
+	assert.Empty(t, tx.execCalls)
+}
+
+func TestOutboxWriter_WriteBatch_NoTx(t *testing.T) {
+	w := NewOutboxWriter()
+	entries := []outbox.Entry{{
+		ID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", Topic: "t", Payload: []byte("{}"),
+	}}
+
+	err := w.WriteBatch(context.Background(), entries)
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, ErrAdapterPGNoTx, ec.Code)
+}
+
+func TestOutboxWriter_WriteBatch_Success(t *testing.T) {
+	w := NewOutboxWriter()
+	tx := &mockOutboxTx{}
+	ctx := CtxWithTx(context.Background(), tx)
+
+	entries := []outbox.Entry{
+		{ID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", Topic: "t1", Payload: []byte(`{"a":1}`), CreatedAt: time.Now()},
+		{ID: "b2c3d4e5-f6a7-8901-bcde-f12345678901", Topic: "t2", Payload: []byte(`{"b":2}`), CreatedAt: time.Now()},
+	}
+
+	err := w.WriteBatch(ctx, entries)
+	require.NoError(t, err)
+	require.Len(t, tx.execCalls, 1)
+
+	call := tx.execCalls[0]
+	assert.Contains(t, call.sql, "INSERT INTO outbox_entries")
+	// 2 entries × 9 cols = 18 args
+	assert.Len(t, call.args, 18)
+	assert.Equal(t, "a1b2c3d4-e5f6-7890-abcd-ef1234567890", call.args[0])
+	assert.Equal(t, "b2c3d4e5-f6a7-8901-bcde-f12345678901", call.args[9])
+}
+
+func TestOutboxWriter_WriteBatch_InvalidEntry(t *testing.T) {
+	w := NewOutboxWriter()
+	tx := &mockOutboxTx{}
+	ctx := CtxWithTx(context.Background(), tx)
+
+	entries := []outbox.Entry{
+		{ID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", Topic: "t", Payload: []byte("{}")},
+		{ID: "not-a-uuid", Topic: "t", Payload: []byte("{}")},
+	}
+
+	err := w.WriteBatch(ctx, entries)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entry[1]")
+	assert.Empty(t, tx.execCalls, "no INSERT should execute on validation failure")
+}
+
+func TestOutboxWriter_WriteBatch_ExecError(t *testing.T) {
+	w := NewOutboxWriter()
+	tx := &mockOutboxTx{execErr: errcode.New(ErrAdapterPGQuery, "batch exec failed")}
+	ctx := CtxWithTx(context.Background(), tx)
+
+	entries := []outbox.Entry{
+		{ID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", Topic: "t", Payload: []byte("{}"), CreatedAt: time.Now()},
+	}
+
+	err := w.WriteBatch(ctx, entries)
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, ErrAdapterPGQuery, ec.Code)
+}
+
+func TestOutboxWriter_WriteBatch_ChunksLargeBatch(t *testing.T) {
+	w := NewOutboxWriter()
+	tx := &mockOutboxTx{}
+	ctx := CtxWithTx(context.Background(), tx)
+
+	// Create writeBatchChunkSize + 1 entries to force 2 chunks.
+	n := writeBatchChunkSize + 1
+	entries := make([]outbox.Entry, n)
+	for i := range n {
+		entries[i] = outbox.Entry{
+			ID:        fmt.Sprintf("00000000-0000-0000-0000-%012d", i),
+			Topic:     "t",
+			Payload:   []byte("{}"),
+			CreatedAt: time.Now(),
+		}
+	}
+
+	err := w.WriteBatch(ctx, entries)
+	require.NoError(t, err)
+	require.Len(t, tx.execCalls, 2, "should split into 2 chunks")
+	assert.Len(t, tx.execCalls[0].args, writeBatchChunkSize*9)
+	assert.Len(t, tx.execCalls[1].args, 1*9)
 }
 
 // mockOutboxTx records exec calls for assertion.

--- a/src/adapters/rabbitmq/rabbitmq_test.go
+++ b/src/adapters/rabbitmq/rabbitmq_test.go
@@ -2438,6 +2438,58 @@ func TestConsumerBase_WrapWithClaimer_Reject_ThreadsReceipt(t *testing.T) {
 	receipt.mu.Unlock()
 }
 
+func TestConsumerBase_WrapWithClaimer_ExplicitReject_FirstRoundNoRetry(t *testing.T) {
+	receipt := &mockReceipt{}
+	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	handlerCallCount := 0
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryCount:     3,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		handlerCallCount++
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionReject,
+			Err:         errors.New("bad payload"),
+		}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-reject-direct"})
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+	assert.Equal(t, 1, handlerCallCount, "DispositionReject must skip retry loop — handler called exactly once")
+	assert.Same(t, receipt, res.Receipt)
+}
+
+func TestConsumerBase_WrapWithClaimer_WrappedPermanentError_FirstRoundReject(t *testing.T) {
+	receipt := &mockReceipt{}
+	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	handlerCallCount := 0
+	cb := NewConsumerBaseWithClaimer(claimer, ConsumerBaseConfig{
+		ConsumerGroup:  "test-group",
+		RetryCount:     3,
+		RetryBaseDelay: 10 * time.Millisecond,
+	})
+
+	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		handlerCallCount++
+		// Wrapped PermanentError — must be detected by errors.As through fmt.Errorf wrapping.
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionRequeue,
+			Err:         fmt.Errorf("handler context: %w", outbox.NewPermanentError(errors.New("unmarshal failed"))),
+		}
+	})
+
+	res := handler(context.Background(), outbox.Entry{ID: "evt-perm-wrapped"})
+	assert.Equal(t, outbox.DispositionReject, res.Disposition,
+		"wrapped PermanentError must be detected and upgraded to Reject")
+	assert.Equal(t, 1, handlerCallCount, "PermanentError must skip retry loop — handler called exactly once")
+	assert.Same(t, receipt, res.Receipt)
+}
+
 // sequenceClaimer returns different results on successive Claim calls.
 // Used to test claimWithRetry: first N calls fail, then succeed.
 type sequenceClaimer struct {

--- a/src/cells/access-core/cell_test.go
+++ b/src/cells/access-core/cell_test.go
@@ -57,9 +57,7 @@ func TestAccessCore_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 
 	// Init
@@ -88,7 +86,6 @@ func TestAccessCore_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -101,7 +98,6 @@ func TestAccessCore_TokenVerifierAndAuthorizer(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -114,7 +110,6 @@ func TestAccessCore_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -145,7 +140,6 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))

--- a/src/cells/audit-core/cell_test.go
+++ b/src/cells/audit-core/cell_test.go
@@ -37,9 +37,7 @@ func TestAuditCore_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 
 	// Init
@@ -68,7 +66,6 @@ func TestAuditCore_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -86,7 +83,6 @@ func TestAuditCore_MissingHMACKey(t *testing.T) {
 	)
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 
@@ -103,7 +99,6 @@ func TestAuditCore_HMACKeyFromConfig(t *testing.T) {
 	)
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: map[string]any{"audit.hmac_key": "config-provided-key-32bytes!!!!!"},
 	}
 
@@ -114,7 +109,6 @@ func TestAuditCore_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -128,7 +122,6 @@ func TestAuditCore_RegisterSubscriptions(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -156,7 +149,6 @@ func TestAuditCore_RouteQueryEntries(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))

--- a/src/cells/config-core/cell_test.go
+++ b/src/cells/config-core/cell_test.go
@@ -35,9 +35,7 @@ func TestConfigCore_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 
 	// Init
@@ -68,7 +66,6 @@ func TestConfigCore_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -81,7 +78,6 @@ func TestConfigCore_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -95,7 +91,6 @@ func TestConfigCore_RegisterSubscriptions(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -126,7 +121,6 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))

--- a/src/cells/device-cell/cell_test.go
+++ b/src/cells/device-cell/cell_test.go
@@ -28,9 +28,7 @@ func TestDeviceCell_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 
 	// Init
@@ -59,7 +57,6 @@ func TestDeviceCell_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells: make(map[string]cell.Cell), Contracts: make(map[string]cell.Contract),
 		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
@@ -73,9 +70,7 @@ func TestDeviceCell_InitDefaultsRepositories(t *testing.T) {
 	c := NewDeviceCell(WithPublisher(eventbus.New()))
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
 	assert.Len(t, c.OwnedSlices(), 3)
@@ -89,9 +84,7 @@ func TestDeviceCell_InitNoPublisher(t *testing.T) {
 	)
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
 	assert.Len(t, c.OwnedSlices(), 3)
@@ -101,9 +94,7 @@ func TestDeviceCell_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -143,9 +134,7 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 	require.NoError(t, c.Init(ctx, deps))
 

--- a/src/cells/order-cell/cell_test.go
+++ b/src/cells/order-cell/cell_test.go
@@ -28,9 +28,7 @@ var _ outbox.Publisher = noopPublisher{}
 
 func newTestDeps() cell.Dependencies {
 	return cell.Dependencies{
-		Cells:     make(map[string]cell.Cell),
-		Contracts: make(map[string]cell.Contract),
-		Config:    make(map[string]any),
+		Config: make(map[string]any),
 	}
 }
 

--- a/src/kernel/assembly/assembly.go
+++ b/src/kernel/assembly/assembly.go
@@ -157,9 +157,7 @@ func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any)
 	}
 
 	deps := cell.Dependencies{
-		Cells:     a.cellMap,
-		Contracts: make(map[string]cell.Contract),
-		Config:    cfgMap,
+		Config: cfgMap,
 	}
 
 	// Phase 1: Init all cells. If any fails, no cell has been Start'd yet.

--- a/src/kernel/cell/interfaces.go
+++ b/src/kernel/cell/interfaces.go
@@ -16,6 +16,10 @@ import "context"
 // Previously this struct also carried Cells map[string]Cell and
 // Contracts map[string]Contract. Analysis showed zero callers read
 // either field — exposing the full cell graph violated least-privilege.
+//
+// The struct wrapper is retained (rather than passing map[string]any
+// directly) for forward compatibility: future fields (e.g. Secrets,
+// ServiceLocator) can be added without changing the Cell.Init signature.
 type Dependencies struct {
 	Config map[string]any
 }

--- a/src/kernel/cell/interfaces.go
+++ b/src/kernel/cell/interfaces.go
@@ -3,10 +3,21 @@ package cell
 import "context"
 
 // Dependencies is the set of collaborators injected into a Cell during Init.
+//
+// ADR: Frozen — fields intentionally minimal.
+//
+// Status: Accepted (2026-04-11, CS-AR-2)
+//
+// Decision: Dependencies carries only Config. Cross-cell access MUST go
+// through contracts, not through a shared cell graph. All concrete
+// dependencies (repos, outbox writers, publishers) are injected via
+// functional options at cell construction time, not via Dependencies.
+//
+// Previously this struct also carried Cells map[string]Cell and
+// Contracts map[string]Contract. Analysis showed zero callers read
+// either field — exposing the full cell graph violated least-privilege.
 type Dependencies struct {
-	Cells     map[string]Cell
-	Contracts map[string]Contract
-	Config    map[string]any
+	Config map[string]any
 }
 
 // VerifySpec describes the verification requirements for a Slice.

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -82,9 +82,10 @@ type Writer interface {
 type BatchWriter interface {
 	Writer
 	// WriteBatch persists multiple outbox entries atomically within the
-	// caller's transaction scope. All entries MUST be validated before any
-	// write occurs. If validation fails for any entry, no entries are
-	// written and the first validation error is returned.
+	// caller's transaction scope. Implementations MUST validate entries
+	// independently (defense-in-depth) even when called via
+	// WriteBatchFallback, which only runs Entry.Validate(). If validation
+	// fails for any entry, no entries are written.
 	//
 	// An empty entries slice is a no-op and returns nil.
 	//
@@ -97,7 +98,12 @@ type BatchWriter interface {
 
 // WriteBatchFallback writes entries using the Writer interface, falling
 // back to sequential Write calls if the writer does not implement
-// BatchWriter. All entries are validated upfront before any write occurs.
+// BatchWriter.
+//
+// Validation scope: WriteBatchFallback runs Entry.Validate() on all
+// entries upfront (topic + payload checks). Writer-specific validation
+// (e.g. UUID format, transaction presence) is the responsibility of
+// the Writer/BatchWriter implementation and may run independently.
 //
 // The caller MUST ensure ctx carries an active transaction. Atomicity
 // depends on the transaction scope: if all writes happen within the

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -65,6 +66,70 @@ type Writer interface {
 	// context-embedded transaction pattern (e.g., extract tx from context via
 	// TxFromContext(ctx)) to participate in the caller's transaction scope.
 	Write(ctx context.Context, entry Entry) error
+}
+
+// BatchWriter extends Writer with batch write support.
+// Implementations that support batch operations SHOULD implement this
+// interface for atomic multi-entry writes within a single transaction.
+//
+// If an implementation does not support BatchWriter, callers can use
+// WriteBatchFallback which auto-detects batch support and falls back
+// to sequential Write calls.
+//
+// ref: ThreeDotsLabs/watermill message/pubsub.go — Publish(topic, ...msgs)
+// variadic pattern. GoCell uses a separate interface instead to preserve
+// the existing Writer contract and enable optimized multi-row INSERT.
+type BatchWriter interface {
+	Writer
+	// WriteBatch persists multiple outbox entries atomically within the
+	// caller's transaction scope. All entries MUST be validated before any
+	// write occurs. If validation fails for any entry, no entries are
+	// written and the first validation error is returned.
+	//
+	// An empty entries slice is a no-op and returns nil.
+	//
+	// Implementations SHOULD use a single batch INSERT for efficiency.
+	// The context MUST carry the caller's transaction (same requirement
+	// as Writer.Write). All-or-nothing: either all entries are written
+	// or none are (transaction rollback on failure).
+	WriteBatch(ctx context.Context, entries []Entry) error
+}
+
+// WriteBatchFallback writes entries using the Writer interface, falling
+// back to sequential Write calls if the writer does not implement
+// BatchWriter. All entries are validated upfront before any write occurs.
+//
+// The caller MUST ensure ctx carries an active transaction. Atomicity
+// depends on the transaction scope: if all writes happen within the
+// same transaction, a failure rolls back everything. WriteBatchFallback
+// itself does not manage transactions.
+//
+// An empty entries slice is a no-op and returns nil.
+func WriteBatchFallback(ctx context.Context, w Writer, entries []Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Phase 1: Validate all entries upfront.
+	for i, e := range entries {
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("outbox: entry[%d]: %w", i, err)
+		}
+	}
+
+	// Phase 2: Use batch if available, otherwise sequential.
+	if bw, ok := w.(BatchWriter); ok {
+		return bw.WriteBatch(ctx, entries)
+	}
+
+	slog.Debug("outbox: WriteBatchFallback using sequential writes (writer does not implement BatchWriter)",
+		slog.Int("count", len(entries)))
+	for i, e := range entries {
+		if err := w.Write(ctx, e); err != nil {
+			return fmt.Errorf("outbox: write entry[%d]: %w", i, err)
+		}
+	}
+	return nil
 }
 
 // Relay polls unpublished outbox entries and publishes them.

--- a/src/kernel/outbox/outbox.go
+++ b/src/kernel/outbox/outbox.go
@@ -132,7 +132,7 @@ func WriteBatchFallback(ctx context.Context, w Writer, entries []Entry) error {
 		slog.Int("count", len(entries)))
 	for i, e := range entries {
 		if err := w.Write(ctx, e); err != nil {
-			return fmt.Errorf("outbox: write entry[%d]: %w", i, err)
+			return fmt.Errorf("outbox: write entry[%d] (id=%s): %w", i, e.ID, err)
 		}
 	}
 	return nil

--- a/src/kernel/outbox/outbox_test.go
+++ b/src/kernel/outbox/outbox_test.go
@@ -537,6 +537,7 @@ func TestWriteBatchFallback_ValidationFailure(t *testing.T) {
 	err := WriteBatchFallback(context.Background(), w, entries)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "entry[1]")
+	assert.Contains(t, err.Error(), "ERR_VALIDATION_FAILED")
 	assert.Nil(t, w.batchEntries, "no writes should occur on validation failure")
 	assert.Nil(t, w.writeEntries)
 }
@@ -579,6 +580,7 @@ func TestWriteBatchFallback_SequentialFallbackError(t *testing.T) {
 	err := WriteBatchFallback(context.Background(), w, entries)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "entry[1]")
+	assert.Contains(t, err.Error(), "id=e2")
 	assert.Contains(t, err.Error(), "db write failed")
 	assert.Len(t, w.entries, 1, "only the first entry should have been written")
 }

--- a/src/kernel/outbox/outbox_test.go
+++ b/src/kernel/outbox/outbox_test.go
@@ -472,6 +472,117 @@ func TestEntry_Validate(t *testing.T) {
 	}
 }
 
+// --- WriteBatchFallback Tests (F-OB-01) ---
+
+// batchRecorder implements BatchWriter and records calls.
+type batchRecorder struct {
+	writeEntries []Entry
+	batchEntries []Entry
+	writeErr     error
+	batchErr     error
+}
+
+func (r *batchRecorder) Write(ctx context.Context, entry Entry) error {
+	r.writeEntries = append(r.writeEntries, entry)
+	return r.writeErr
+}
+
+func (r *batchRecorder) WriteBatch(ctx context.Context, entries []Entry) error {
+	r.batchEntries = entries
+	return r.batchErr
+}
+
+var _ BatchWriter = (*batchRecorder)(nil)
+
+// sequentialRecorder implements only Writer (no BatchWriter).
+type sequentialRecorder struct {
+	entries  []Entry
+	writeErr error
+	failAt   int // fail on the Nth write (0-based); -1 = never fail
+}
+
+func (r *sequentialRecorder) Write(_ context.Context, entry Entry) error {
+	if r.failAt >= 0 && len(r.entries) == r.failAt {
+		return r.writeErr
+	}
+	r.entries = append(r.entries, entry)
+	return nil
+}
+
+var _ Writer = (*sequentialRecorder)(nil)
+
+func validEntry(id string) Entry {
+	return Entry{ID: id, Topic: "test.topic", Payload: []byte("{}")}
+}
+
+func TestWriteBatchFallback_EmptySlice(t *testing.T) {
+	w := &batchRecorder{}
+	err := WriteBatchFallback(context.Background(), w, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, w.batchEntries)
+	assert.Nil(t, w.writeEntries)
+
+	err = WriteBatchFallback(context.Background(), w, []Entry{})
+	assert.NoError(t, err)
+}
+
+func TestWriteBatchFallback_ValidationFailure(t *testing.T) {
+	w := &batchRecorder{}
+	entries := []Entry{
+		validEntry("e1"),
+		{ID: "e2", Payload: []byte("{}")}, // missing topic
+		validEntry("e3"),
+	}
+
+	err := WriteBatchFallback(context.Background(), w, entries)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "entry[1]")
+	assert.Nil(t, w.batchEntries, "no writes should occur on validation failure")
+	assert.Nil(t, w.writeEntries)
+}
+
+func TestWriteBatchFallback_UsesBatchWriter(t *testing.T) {
+	w := &batchRecorder{}
+	entries := []Entry{validEntry("e1"), validEntry("e2")}
+
+	err := WriteBatchFallback(context.Background(), w, entries)
+	assert.NoError(t, err)
+	assert.Len(t, w.batchEntries, 2)
+	assert.Nil(t, w.writeEntries, "should not use sequential Write when BatchWriter is available")
+}
+
+func TestWriteBatchFallback_BatchWriterError(t *testing.T) {
+	w := &batchRecorder{batchErr: errors.New("batch insert failed")}
+	entries := []Entry{validEntry("e1")}
+
+	err := WriteBatchFallback(context.Background(), w, entries)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "batch insert failed")
+}
+
+func TestWriteBatchFallback_SequentialFallback(t *testing.T) {
+	w := &sequentialRecorder{failAt: -1}
+	entries := []Entry{validEntry("e1"), validEntry("e2"), validEntry("e3")}
+
+	err := WriteBatchFallback(context.Background(), w, entries)
+	assert.NoError(t, err)
+	assert.Len(t, w.entries, 3)
+}
+
+func TestWriteBatchFallback_SequentialFallbackError(t *testing.T) {
+	w := &sequentialRecorder{
+		failAt:   1,
+		writeErr: errors.New("db write failed"),
+	}
+	entries := []Entry{validEntry("e1"), validEntry("e2"), validEntry("e3")}
+
+	err := WriteBatchFallback(context.Background(), w, entries)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "entry[1]")
+	assert.Contains(t, err.Error(), "db write failed")
+	assert.Len(t, w.entries, 1, "only the first entry should have been written")
+}
+
 // --- HandleResult tests ---
 
 func TestHandleResult_Fields(t *testing.T) {


### PR DESCRIPTION
## Summary
- **K-1 (CS-AR-2)**: `Dependencies` struct 移除 `Cells` 和 `Contracts` 字段（零调用方使用），仅保留 `Config`。消除 full cell graph 暴露的最小权限违规。更新 assembly 和 5 个 cell 测试文件
- **K-2 (CS-AR-3)**: net/http ADR 注释已存在于 `registrar.go`，标记完成
- **K-3 (F-OB-01)**: 新增 `BatchWriter` 接口（嵌入 `Writer`）+ `WriteBatchFallback` helper（自动检测 batch 支持，降级到顺序写入并记录 debug 日志）。Postgres `OutboxWriter` 实现多行 INSERT
- **K-5**: 三角色审查收尾 — Dependencies 冻结注释、registrar ADR、WriteBatchFallback godoc 均已验证

ref: watermill message/pubsub.go — variadic Publish pattern
ref: docs/designs/20260411-wave-c-architecture-design.md

## Test plan
- [x] `go build ./...` 编译通过
- [x] `go test ./kernel/...` 全部通过，覆盖率 ≥ 90%（outbox 100%, cell 99.3%, celltest 100%）
- [x] `go test ./cells/...` 全部通过（Dependencies 字面量更新无回归）
- [x] WriteBatchFallback 6 个测试：空 slice / validation-first / batch path / fallback / error propagation
- [ ] CI pipeline 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)