### PR TITLE
feat(runtime/auth): JWT kid rotation + HMAC key ring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,14 @@ GOCELL_S3_SECRET_KEY=gocell_dev_secret
 GOCELL_S3_BUCKET=gocell-dev
 GOCELL_S3_USE_SSL=false
 
-# JWT
+# JWT (active signing key pair)
 GOCELL_JWT_PRIVATE_KEY=
 GOCELL_JWT_PUBLIC_KEY=
+
+# JWT key rotation (optional — set during rotation window)
+# GOCELL_JWT_PREV_PUBLIC_KEY=
+# GOCELL_JWT_PREV_KEY_EXPIRES=2026-04-12T00:00:00Z
+
+# Service token HMAC (min 32 bytes)
+GOCELL_SERVICE_SECRET=
+# GOCELL_SERVICE_SECRET_PREVIOUS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,10 @@ actors.yaml   — 外部 Actor 注册（参与 contract 但不属于 Cell 模型
 格式：`yyyyMMddHHmm-编号-实际功能或问题.md`（ date "+%Y%m%d%H%M" 后缀按内容选择，不限 `.md`）
 示例：`202603281443-022-compliance-api-review.md`
 
+
+## Active Technologies
+- Go (latest stable) + `github.com/golang-jwt/jwt/v5` (existing), `crypto/*` stdlib (201-wm2-key-rotation)
+- N/A (in-memory key set, loaded from static config) (201-wm2-key-rotation)
+
+## Recent Changes
+- 201-wm2-key-rotation: Added Go (latest stable) + `github.com/golang-jwt/jwt/v5` (existing), `crypto/*` stdlib

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -207,6 +207,17 @@
 | WM-2-F3 | runtime/auth 无 Prometheus metrics（key lifecycle counters/gauges），需通过接口注入避免 runtime→adapters 依赖 | 2h (discovered via PR#81 review P2-11，前置 WM-34) |
 | P3-TD-11 | access-core domain 模型重构 | 4h（高风险） |
 | P3-TD-12 | configpublish.Rollback version 校验 | 2h |
+
+### WM-2 Review Accept（PR#81 六席位审查，不修理由）
+
+| ID | Finding | Accept 理由 |
+|----|---------|-------------|
+| P2-3 | 缺 RFC 7638 external known-good test vector | Thumbprint 仅 3 行无分支（base64url + SHA-256）。已有 determinism + length(43) + encoding 测试。引入 RFC 附录固定密钥收益低。 |
+| P2-4 | kid 未截断，log flooding 风险 | kid = base64url(SHA-256) = 固定 43 chars，由 Thumbprint 产生，不受外部输入控制。无任意长度 flooding 场景。 |
+| P2-8 | 缺 non-RSA key type 拒绝路径测试 | `parseRSAPublicKey` 的 "PKIX key is not RSA" 分支在 develop 上已存在，非本 PR 引入。预存 tech debt。 |
+| P2-9 | Lifecycle log 测试未用 table-driven | 3 个测试验证不同生命周期事件（激活/降级/修剪），场景差异大。table-driven 反而降低可读性。风格偏好。 |
+| P2-10 | init() 模式有 package-level 副作用风险 | cell_test.go 已消除 init()。剩余 3 个 slice test 的 init 仅做 NewJWTIssuer/NewJWTVerifier（需 error 处理，无法用 var 替代）。Go 测试标准做法。 |
+| P2-16 | env loader 仅支持 1 个 prev key | By design — spec FR-005 明确 "env loader 0-1"。KeySet API 支持 0-N。列表型 env 配置属 WM-34 scope。 |
 | P4-TD-12 | demo cell `TestDemo_Startup` t.Skip 占位 | 30min |
 
 ### metadata parser follow-up（PR#67）

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -23,7 +23,9 @@
 
 ## 进行中
 
-无
+| 任务 | PR | 说明 |
+|------|-----|------|
+| WM-2 密钥轮换 — JWT kid + HMAC key ring | PR#81 | 待合并，4 commits，所有 P0/P1 已修 |
 
 ### PR 队列（跨框架分析后修订，PR#70-77 已全部合并）
 
@@ -59,13 +61,13 @@
 
 | 序号 | ID | 任务 | 文件 | 预估 | 依赖 |
 |------|-----|------|------|------|------|
-| K-1 | CS-AR-2 | Dependencies 精简 + 冻结注释 | `kernel/cell/interfaces.go`, `kernel/assembly/assembly.go`, ~20 test files | 1h | ~~Phase 2~~ ✅ 无阻塞 |
-| K-2 | CS-AR-3 | net/http ADR 注释 | `kernel/cell/registrar.go` | 15min | 无 |
-| K-3 | F-OB-01 | BatchWriter 接口 + WriteBatchFallback | `kernel/outbox/outbox.go`, `adapters/postgres/outbox_writer.go` | 3h | 无 |
+| ~~K-1~~ | CS-AR-2 | ~~Dependencies 精简 + 冻结注释~~ | — | — | ✅ PR#79 |
+| ~~K-2~~ | CS-AR-3 | ~~net/http ADR 注释~~ | — | — | ✅ PR#79 |
+| ~~K-3~~ | F-OB-01 | ~~BatchWriter 接口 + WriteBatchFallback~~ | — | — | ✅ PR#79 |
 | K-4 | SOL-B-02 | Receipt 移回 idempotency 包 | `kernel/idempotency/idempotency.go`, `kernel/outbox/outbox.go`, adapters + tests | 3h | Phase 3 |
-| K-5 | — | 三角色审查 mandatory actions | Dependencies 冻结 + registrar ADR + WriteBatchFallback godoc | 含在 K-1/K-2/K-3 |
+| ~~K-5~~ | — | ~~三角色审查 mandatory actions~~ | — | — | ✅ 含在 PR#79 |
 
-> K-1/K-2/K-3 全程无阻塞可并行（Phase 2 已合并）；K-4 依赖 Phase 3
+> ~~K-1/K-2/K-3~~ ✅ 已合并（PR#79）；K-4 依赖 Phase 3
 
 ---
 
@@ -119,7 +121,7 @@
 | F-5 | `kernel/journey/catalog.go` | Journey catalog 不校验引用 | 2h |
 | R1C2-F01 | `runtime/eventbus/eventbus.go` | Close()+Subscribe() 竞态 | 2h |
 | R1C2-F03 | `runtime/worker/worker.go` | WorkerGroup.Start 首个失败不取消其余 worker | 2h |
-| F-OB-01 | `kernel/outbox/outbox.go` | 无批量写支持 | 2h |
+| ~~F-OB-01~~ | `kernel/outbox/outbox.go` | ~~无批量写支持~~ PR#79 ✅ | ~~2h~~ |
 | TX-NIL-01 | `cells/*/service.go` | txRunner nil-safe 未文档化 | 1h |
 | OTEL-COV-01 | `adapters/otel/` | 覆盖率 67.3%（PR#72 删除了依赖内部 API 的旧测试后回升，但仍 < 80%；成功路径需 gRPC OTLP endpoint，需 testcontainers 集成测试） | 2h |
 | SUB-SETUP-01 | `kernel/outbox`, `cells/*/cell.go` | RegisterSubscriptions 用 100ms 启发式区分 setup 失败与正常阻塞消费。**已被 Phase 2 EventRouter 解决**——Router.Run() 同步返回 setup error，消除启发式 | ~~4h~~ → Phase 2 |
@@ -136,6 +138,11 @@
 | RMQ-75-03 | `adapters/rabbitmq/connection.go` | 命名改善：`failed→terminalCh`, `safeExp→maxSafeShift`, `permanentDialKeywords→permanentDialSubstrings` | 15min |
 | RMQ-75-04 | `adapters/rabbitmq/connection.go` | `WaitConnected` godoc 缺调用方指引（permanent vs transient 区分） | 15min |
 | RMQ-75-05 | `runtime/bootstrap/bootstrap.go` | `RegisterChecker("rabbitmq", conn.Health)` 未接入 readiness — permanent error 后 Pod 继续接流量 | 30min |
+| P3-DEFER-01 | `adapters/rabbitmq/consumer_base.go`, `connection.go` | safeDelay 与 backoffDelay 核心逻辑重复（bits.Len64 overflow guard），应提取到 pkg/backoff | 2h |
+| P3-DEFER-02 | `adapters/rabbitmq/consumer_base.go` | ClaimFailOpen `*bool` 不符合 Go 习惯，应改为 enum (`ClaimFailMode`) | 1h |
+| P3-DEFER-03 | `examples/` | 新 API（WithHealthChecker、NewConsumerBase(Claimer)、MaxReconnectAttempts）无示例项目演示 | 2h |
+| P3-DEFER-04 | `kernel/idempotency/idempotency.go`, `kernel/outbox/outbox.go` | Receipt 定义在 outbox 包造成 idempotency→outbox 耦合，考虑移到 idempotency 包 | 3h（C3 kernel 接口） |
+| P3-DEFER-05 | `adapters/rabbitmq/connection.go` | Health() 在 reconnecting 和 terminal 状态下返回相同 error code，运维无法区分 | 3h（C3 状态机设计） |
 
 ### winmdm Accept P1
 
@@ -145,8 +152,9 @@
 | WM-35 | BFF handler 接入 — login/refresh/logout 接 SessionCookieWriter + BFF 模式不返回 token body | `cells/access-core/slices/session*` | 2d | WM-1 |
 | WM-36 | SecureCookie key rotation — active+previous 双 key ring，灰度轮换 | `pkg/securecookie` | 1.5d | WM-1 |
 | WM-6 | 游标分页 — keyset pagination | `pkg/query` | 1.5d | 无 |
-| WM-2 | 密钥轮换 — JWT kid 轮换 + HMAC（范围限定，扩展 keys.go） | `runtime/auth` | 2d | 无 |
+| ~~WM-2~~ | ~~密钥轮换 — JWT kid 轮换 + HMAC（范围限定，扩展 keys.go）~~ | `runtime/auth` | ~~2d~~ | PR#81 🔄 |
 | WM-34 | 配置热更新回调 — Cell 级 OnConfigReload | `runtime/config` | 1d | 无 |
+| WM-2-F1 | KeyProvider 接口抽象 — JWTIssuer/JWTVerifier 解耦 *KeySet，为 auto-rotation/JWKS 预留接缝 | `runtime/auth` | 1d | WM-34 (discovered via PR#81 review P1-4) |
 | WM-20 | TestPubSub 测试套件 — TestPublisher/TestSubscriber 标准套件 | `kernel/outbox/outboxtest/` | 1.5d | PR#68 |
 | WM-17 | 生命周期钩子 — BeforeStart/AfterStart/BeforeStop/AfterStop 可选接口 | `kernel/cell` | 1d | 无 |
 | WM-15 | L4 队列状态机 — 合入 0-B2 | `kernel/outbox` | 1.5d | 0-B2 |
@@ -169,7 +177,7 @@
 | SOL-B-01 | Claimer lease 续租 — handler/retryLoop 超 LeaseTTL 后 Commit stale，需 Receipt.Renew 或后台续租（参考 distlock.go renewLoop） | 4h（C3，改 kernel 接口） | R-4 |
 | SOL-B-02 | `idempotency → outbox` 依赖方向反转 — Receipt 移到 idempotency 包，outbox 反向依赖 idempotency | 3h（C3，10+ 文件） | K-4 |
 | SOL-B-06 | `claimWithRetry` / `retryLoop` 的指数退避在超大重试次数下仍可能先发生 `time.Duration` 溢出；需改为饱和计算并补极值边界测试 | 1h | Phase 3 附近 |
-| P4-TD-03 | `IssueTestToken` HS256 死代码（测试陷阱） | 30min | — |
+| ~~P4-TD-03~~ | ~~`IssueTestToken` HS256 死代码（测试陷阱）~~ | ~~30min~~ | PR#81 ✅ (移到 helpers_test.go，删除 HS256 分支) |
 | P4-TD-04 | order-cell 声明 L2 但无 outboxWriter enforce — order-create/service.go:50-71 + device-register/service.go:50-71 直接 Publish 违反 outbox 规则 | 2h | — |
 | P4-TD-05 | 缺少 outbox 全链路 3-container 集成测试 | 2h | — |
 | P3-TD-10 | Session refresh TOCTOU 竞态 | 4h（高风险） | — |
@@ -195,6 +203,8 @@
 | P4-TD-11 | in-memory repository 缺并发测试 | 1h |
 | P4-TD-13 | Entity 直接作为 API 响应（order-query / configread / configwrite / featureflag / configpublish / device-status / device-register / device-command），需 DTO 转换 | 4h |
 | P4-TD-14 | audit-core/auditappend/service.go:90 `_ = json.Unmarshal` 静默忽略错误，需显式处理或记录日志 | 30min |
+| WM-2-F2 | ServiceToken HMAC message 不含 query string，可跨参数 replay | 2h (discovered via PR#81 review P2-1) |
+| WM-2-F3 | runtime/auth 无 Prometheus metrics（key lifecycle counters/gauges），需通过接口注入避免 runtime→adapters 依赖 | 2h (discovered via PR#81 review P2-11，前置 WM-34) |
 | P3-TD-11 | access-core domain 模型重构 | 4h（高风险） |
 | P3-TD-12 | configpublish.Rollback version 校验 | 2h |
 | P4-TD-12 | demo cell `TestDemo_Startup` t.Skip 占位 | 30min |
@@ -273,9 +283,9 @@
 
 | ID | 问题 | 归属 PR | 状态 |
 |----|------|---------|------|
-| CS-AR-2 | Dependencies 精简 — 移除 `Cells`/`Contracts` 字段（零 caller），加冻结注释 | PR-Cleanup | 设计完成，三角色 PASS |
-| CS-AR-3 | kernel/cell net/http 决策 — 确认 net/http 为 stdlib 允许依赖，registrar.go 加 ADR 注释 | PR-Cleanup | 设计完成，文档化即可 |
-| F-OB-01 | BatchWriter 接口 + WriteBatchFallback helper — 独立接口，向后兼容 | PR-Cleanup | 设计完成，三角色 PASS |
+| ~~CS-AR-2~~ | ~~Dependencies 精简~~ — 移除 `Cells`/`Contracts` 字段（零 caller），加冻结注释 | PR#79 | ✅ |
+| ~~CS-AR-3~~ | ~~kernel/cell net/http 决策~~ — ADR 注释已存在于 registrar.go | PR#79 | ✅ |
+| ~~F-OB-01~~ | ~~BatchWriter 接口 + WriteBatchFallback helper~~ — 独立接口，向后兼容 | PR#79 | ✅ |
 | Cell 接口 | 12 个方法，考虑拆分为 Cell + CellLifecycle + CellMetadata | — | 暂缓（assembly 需全部 facet） |
 | adapter 测试 | 15 个 t.Skip 集成测试待补全 | — | TODO |
 
@@ -355,7 +365,8 @@
 | A | Phase 1: PermanentError → kernel | PR#74 | ✅ |
 | A | Phase 2: EventRouter 引入 | PR#76 | ✅ |
 | B | 0-G B-03 RabbitMQ 重连 backoff | PR#75 | ✅ |
-| B | K-2 net/http ADR 注释 | — | 待做 |
+| B | K-1/K-2/K-3/K-5 Kernel 架构整理 | PR#79 | ✅ |
+| — | device-cell 测试对齐 data 信封 + celltest 覆盖率 | PR#78 | ✅ |
 
 ### Batch 3: Tier 0 收尾 + 基础稳定（2d，Batch 2 后）
 
@@ -420,8 +431,12 @@
 | F-5 Journey catalog 校验 | 2h | kernel/journey |
 | R1C2-F01 eventbus Close+Subscribe 竞态 | 2h | runtime/eventbus（需 -race 验证） |
 | R1C2-F03 WorkerGroup 首个失败 | 2h | runtime/worker |
-| F-OB-01 outbox 批量写 | 2h | kernel/outbox |
+| ~~F-OB-01 outbox 批量写~~ | ~~2h~~ | ~~kernel/outbox~~ PR#79 ✅ |
 | TX-NIL-01 txRunner nil-safe 文档 | 1h | cells/ |
+| F-OB-02 outbox UUID nil guard | 30min | adapters/postgres — 拒绝全零 UUID 防幂等碰撞 (discovered via PR#79 review) |
+| P4-TD-01 noopWriter 去重 | 1h | cells/*/cell_test.go → 提取到 kernel/outbox/outboxtest (discovered via PR#79 review) |
+| CI-01 integration job 补 tests/integration/ | 30min | .github/workflows/ci.yml 只跑 ./adapters/...，漏掉 tests/integration/ (discovered via PR#79 review) |
+| OB-UUID-01 cells evt-\<uuid\> 与 Writer UUID 校验冲突 | 2h | cells 生成 `evt-<uuid>` 前缀 ID，但 outbox_writer.go 只接受 canonical UUID (discovered via PR#79 review) |
 | P3-TD-10 Session refresh TOCTOU | 4h | 高风险，乐观锁方案 |
 | P4-TD-03 IssueTestToken 死代码 | 30min | runtime/auth |
 | OPS-3 readiness 探针接 postgres/redis | 2h | 实现 Health() + 注册 HealthChecker（rabbitmq 已提前至 Batch 3） |

--- a/docs/reviews/20260411-wm2-key-rotation-research.md
+++ b/docs/reviews/20260411-wm2-key-rotation-research.md
@@ -1,0 +1,195 @@
+# WM-2 密钥轮换 — 开源研究报告
+
+> 日期: 2026-04-11
+> 范围: JWT kid 轮换 + HMAC 密钥轮换（`runtime/auth/`）
+> 方法: 4 角色并行分析 12+ 开源项目
+
+---
+
+## 一、JWT kid 轮换 — 行业共识
+
+### 研究项目
+
+| 项目 | 类型 | kid 来源 | 轮换模型 | 多密钥 |
+|------|------|---------|---------|-------|
+| **go-jose/v4** | JOSE 库 | 调用方设置 `JSONWebKey.KeyID` + RFC 7638 Thumbprint | 无（纯库） | `JSONWebKeySet` 任意数量 |
+| **Dex** | OIDC Provider | 随机 20-byte hex | 3 态：Active → Verification-only(带 Expiry) → Pruned | 1 签名 + N 验证 |
+| **Authelia** | Auth Gateway | 配置文件静态 kid | 无自动轮换，运维手动 | 多算法多 kid，按 token 类型选 |
+| **Casdoor** | IAM | cert.Name | 无自动轮换，DB 存储证书 | 每 app 绑定 1 cert |
+
+### 关键发现
+
+| 维度 | 行业共识 | 最佳参考 |
+|------|---------|---------|
+| **kid 来源** | SHA-256 thumbprint (RFC 7638) 或 UUID | Kubernetes (thumbprint), Hydra (UUID) |
+| **签发** | `token.Header["kid"] = activeKey.ID` | Dex, Casdoor, Hydra, Zitadel 全部设置 |
+| **验证** | KeyFunc 按 kid 查找密钥，非遍历 | Kratos `jwt.Keyfunc`, Hydra `GetPublicKey(kid)` |
+| **轮换状态** | 3 态：Active → Verification-only(带 Expiry) → Pruned | Dex 最简洁 |
+| **多密钥** | 1 签名 + N 验证（N 通常 1-2） | Dex, Zitadel |
+| **JWKS** | 暴露 `/.well-known/jwks.json` | Hydra, Zitadel, Casdoor 全部暴露 |
+
+### Dex 轮换模型详解（推荐参考）
+
+Dex 的 `Keys` struct 持有 1 个 `SigningKey`（私钥）+ `SigningKeyPub`（公钥）。轮换时：
+1. 生成新密钥对，分配随机 20-byte hex 作为 KeyID
+2. 旧 `SigningKeyPub` 降级为 `VerificationKeys`，设置 `Expiry = now + idTokenValidFor`
+3. 新密钥成为 `SigningKey`，签发所有新 token
+4. 过期的 VerificationKey 在下次轮换时被清除
+
+轮换由定时器触发：`now > NextRotation` 时在 `Storage.UpdateKeys()` 内原子执行。
+
+ref: dexidp/dex `server/rotation.go`, `storage/storage.go`
+
+---
+
+## 二、HMAC 密钥轮换 — 行业共识
+
+### 研究项目
+
+| 项目 | 密钥选择 | 签名策略 | 验证策略 | 轮换方式 | Ring 大小 |
+|------|---------|---------|---------|---------|----------|
+| **gorilla/securecookie** | 位置式 (index 0 = 当前) | 第一个 codec | 依次尝试全部 `DecodeMulti` | 配置 + 重启 | 无限制 |
+| **gorilla/sessions** | 委托 securecookie | 第一个 codec | 依次尝试全部 | 配置 + 重启 | 无限制 |
+| **golang-jwt** | 标签式 (`kid` header) | 调用方指定 | `Keyfunc` 按 kid 查找 | JWKS 轮询或代码 | 无限制 |
+| **Rails ActiveSupport** | 标签式 (`rotate` 调用) | 仅 primary | 先 primary 再 rotations + `on_rotation` 回调 | 代码调用 | 无限制 |
+| **Django signing** | 角色式 (`SECRET_KEY` + `FALLBACKS`) | 仅 primary | 依次尝试 `[key, *fallbacks]` | 配置变更 | 无限（有性能警告） |
+| **go-zero** | 双密钥窗口 (`secret` + `prevSecret`) | 当前 secret | 尝试两个，按使用频率优先 | 配置变更 | 固定 2 |
+
+### 关键发现
+
+| 维度 | 行业共识 | 最佳参考 |
+|------|---------|---------|
+| **密钥选择** | 位置式（index 0 = 当前） | gorilla, Django, Rails 全部位置式 |
+| **签名** | 始终用 `keys[0]` | 全部一致 |
+| **验证** | Try-all-keys 依次尝试 | gorilla `DecodeMulti`, Django `unsign()` |
+| **Ring 大小** | 2（current + previous） | go-zero `PrevSecret`, Django 推荐 |
+| **轮换触发** | 配置驱动（非定时） | Django `SECRET_KEY_FALLBACKS` |
+| **回调** | 旧密钥解码成功时 emit metric | Rails `on_rotation` |
+
+---
+
+## 三、密钥生命周期 — 行业共识
+
+### 研究项目
+
+| 项目 | 版本模型 | 轮换状态机 | 并发控制 | Grace period |
+|------|---------|-----------|---------|-------------|
+| **Kubernetes apiserver** | SHA-256 thumbprint | 无显式状态机，多密钥验证器 | 不可变集合，原子替换 | `GetCacheAgeMaxSeconds()` = 3600s |
+| **Vault Transit** | 递增整数版本 | 即时原子轮换 + Min/Max Version 滑动窗口 | `sync.RWMutex` | MinDecryptionVersion 控制 |
+| **cert-manager** | revision 整数 | 条件触发 → 签发 → 原子交换 | K8s 工作队列串行化 | 剩余 1/3 有效期 |
+| **Teleport** | UUID (CurrentID) | 5 阶段: Standby→Init→UpdateClients→UpdateServers→Standby | Clone + 后端 CAS | 可配置 GracePeriod |
+
+### Vault Transit 详解（推荐参考）
+
+Vault 使用两个滑动窗口控制密钥生命周期：
+- `MinDecryptionVersion`: 允许解密/验证的最旧版本
+- `MinEncryptionVersion`: 允许加密/签名的最旧版本（0 = 仅最新版本）
+- `AutoRotatePeriod`: 自动轮换间隔（最小 1h）
+
+密文前缀 `vault:v{version}:` 使版本始终可见。旧密钥保留到管理员推进 MinDecryptionVersion。
+
+ref: hashicorp/vault `builtin/logical/transit/policy.go`
+
+### Teleport 5 阶段轮换详解
+
+```
+Standby → Init → UpdateClients → UpdateServers → Standby (complete)
+              |                  |                 |
+              +→ Rollback ←------+→ Rollback ←-----+
+                    |
+                    +→ Standby (abort)
+```
+
+- **Init**: 新 CA 生成为 AdditionalTrustedKeys，旧 CA 继续签名
+- **UpdateClients**: 密钥交换 — 新 CA 签名，旧 CA 仍受信
+- **UpdateServers**: 新旧 CA 同时受信，旧 CA 逐步淘汰
+- **Rollback**: 任何阶段可回退
+
+ref: gravitational/teleport `lib/auth/rotate.go`
+
+---
+
+## 四、Go 框架集成 — 行业共识
+
+### 研究项目
+
+| 项目 | 密钥配置 | kid 支持 | 轮换 | JWKS | DI 集成 |
+|------|---------|---------|------|------|---------|
+| **go-zero** | 静态 HMAC string + `PrevSecret` | 无 | 双密钥窗口 + 使用频率优先 | 无 | 无 |
+| **Kratos** | `jwt.Keyfunc` 回调 | 完全委托用户 | 无内建 | 无 | Middleware 注册 |
+| **Casdoor** | DB 存储证书 | cert.Name 作为 kid | 手动（管理员操作） | 有 | ORM 绑定 |
+| **Ory Hydra** | SQL DB + AES-GCM 加密 | UUID | 删除 + 自动重建 | 有 | `InternalRegistry` DI |
+| **Zitadel** | Event-sourced + 加密存储 | 事件 ID | 自动（基于 expiry） | 有 | 深度 DI + 背景清理 |
+
+### 关键发现
+
+| 维度 | 行业共识 | 最佳参考 |
+|------|---------|---------|
+| **验证器抽象** | `KeyFunc(token) → key` 而非单密钥 | Kratos, golang-jwt/v5 原生模式 |
+| **密钥存储接口** | `GetSigningKey()` + `GetPublicKey(kid)` | Hydra `Manager` |
+| **HMAC 双密钥** | `secret` + `prevSecret` 两阶段窗口 | go-zero `TokenParser` |
+| **生命周期** | DI 注入 + config watcher 热更新 | Zitadel (background purge goroutine) |
+| **JWKS endpoint** | 暴露公钥供跨服务验证 | Hydra, Zitadel, Casdoor |
+
+---
+
+## 五、GoCell 现状差距
+
+### 当前 `src/runtime/auth/` 代码
+
+| 文件 | 现状 | 差距 |
+|------|------|------|
+| `keys.go` | 单 RSA 密钥对，`LoadKeysFromEnv()` 从 env 加载 | 无 kid、无 key ring、无多密钥 |
+| `jwt.go` | `JWTIssuer` 无 kid header；`JWTVerifier` 单密钥 KeyFunc | 签发不带 kid，验证无法按 kid 选密钥 |
+| `servicetoken.go` | 单 HMAC secret (`[]byte`) | 无轮换、无 try-all-keys |
+| `auth.go` | `TokenVerifier` / `Authorizer` 接口 + `Claims` | Claims 无 kid 字段 |
+| `middleware.go` | Bearer → verify → context | 接口层 OK，不需要改 |
+
+### 框架对标确认
+
+`docs/references/framework-comparison.md:98-104`:
+- Primary: **go-micro auth** (JWT + Rules + Account)
+- Secondary: **go-kratos middleware/auth**
+- Goal: **RS256 pinned + kid rotation + Claims context injection**
+
+---
+
+## 六、推荐方案（WM-2 范围限定）
+
+### Layer 1: JWT kid 轮换（采纳 Dex 模型 + Kratos 抽象）
+
+```
+签发: JWTIssuer.Issue() → token.Header["kid"] = SHA256Thumbprint(publicKey)
+验证: JWTVerifier.Verify() → KeyFunc 从 KeySet 按 kid 查找
+数据: KeySet { SigningKey, VerificationKeys []VerificationKey }
+状态: Active → VerificationOnly(ExpiresAt=now+tokenTTL) → Pruned
+```
+
+关键设计决策：
+- kid = RFC 7638 thumbprint（确定性，无需额外存储，K8s 同款）
+- `KeyFunc` 模式替代单密钥（Kratos 验证的最小正确抽象）
+- WM-2 阶段：静态配置加载，不含自动轮换调度器
+
+### Layer 2: HMAC 密钥轮换（采纳 gorilla + go-zero 模型）
+
+```
+签名: 始终用 secrets[0]
+验证: 依次尝试 secrets[0], secrets[1]
+Ring:  [active, previous] 固定大小 2
+触发: 配置变更（与 WM-34 热更新对接）
+```
+
+关键设计决策：
+- 位置式而非标签式（HMAC 签名值无法嵌入 kid）
+- Ring 大小 = 2（go-zero `PrevSecret` 验证的工业实践）
+- WM-2 阶段：静态配置，WM-34 后对接热更新
+
+### 范围排除
+
+| 排除项 | 原因 | 留给哪个后续任务 |
+|--------|------|----------------|
+| 自动轮换调度器 | 需要 worker 基础设施 | WM-34 热更新后 |
+| JWKS endpoint | 需要 router 注册 | 独立任务 |
+| DB 密钥存储 | 当前单进程足够 | 扩展时 |
+| 多算法支持 | RS256 pinned 不变 | 无计划 |
+| SecureCookie 集成 | WM-36 专项 | WM-36 |

--- a/specs/201-wm2-key-rotation/checklists/requirements.md
+++ b/specs/201-wm2-key-rotation/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: JWT kid Rotation & HMAC Key Ring
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation.
+- Scope explicitly excludes: auto-rotation scheduler (WM-34), JWKS endpoint, DB key storage, multi-algorithm support, SecureCookie integration (WM-36).
+- Research document provides thorough industry analysis backing all design decisions referenced in assumptions.

--- a/specs/201-wm2-key-rotation/data-model.md
+++ b/specs/201-wm2-key-rotation/data-model.md
@@ -15,7 +15,7 @@ The central key management entity for JWT operations. Holds the currently active
 | --- | --- | --- |
 | SigningKey | The active key pair used to sign new tokens | Exactly one; MUST have both private and public key |
 | SigningKeyID | kid of the signing key (RFC 7638 thumbprint) | Derived deterministically from public key material |
-| VerificationKeys | List of demoted public keys still trusted for validation | Zero or more; each has an expiry |
+| VerificationKeys | List of demoted public keys still trusted for validation | Zero or more; each has an expiry. Env loader supports 0-1; programmatic API supports 0-N. |
 
 **State transitions**:
 

--- a/specs/201-wm2-key-rotation/data-model.md
+++ b/specs/201-wm2-key-rotation/data-model.md
@@ -1,0 +1,99 @@
+# Data Model: JWT kid Rotation & HMAC Key Ring
+
+**Feature**: 201-wm2-key-rotation  
+**Date**: 2026-04-11
+
+## Entities
+
+### KeySet
+
+The central key management entity for JWT operations. Holds the currently active signing key and zero or more verification-only keys retained for validating previously-issued tokens.
+
+**Attributes**:
+
+| Attribute | Description | Constraints |
+| --- | --- | --- |
+| SigningKey | The active key pair used to sign new tokens | Exactly one; MUST have both private and public key |
+| SigningKeyID | kid of the signing key (RFC 7638 thumbprint) | Derived deterministically from public key material |
+| VerificationKeys | List of demoted public keys still trusted for validation | Zero or more; each has an expiry |
+
+**State transitions**:
+
+```
+[New Key Loaded] → Active (signs new tokens)
+                      │
+                      ▼  (new key replaces it)
+                 Verification-only (validates existing tokens)
+                      │
+                      ▼  (expiry passed)
+                    Pruned (removed from set)
+```
+
+**Invariants**:
+- Exactly one signing key at any time
+- kid is unique across all keys in the set (signing + verification)
+- A verification-only key whose expiry has passed MUST be pruned on next access
+- Adding a new verification-only key when one already exists replaces the oldest
+
+**Relationships**:
+- Used by JWTIssuer (reads SigningKey for token creation)
+- Used by JWTVerifier (reads all keys for kid-based lookup)
+
+---
+
+### VerificationKey
+
+A previously active signing key that has been demoted. Retains only the public key for token validation during the grace period.
+
+**Attributes**:
+
+| Attribute | Description | Constraints |
+| --- | --- | --- |
+| PublicKey | RSA public key material | MUST meet MinRSAKeyBits (2048) |
+| KeyID | kid (RFC 7638 thumbprint) | Immutable once assigned |
+| ExpiresAt | Time after which this key is pruned | Typically set to demotion time + token TTL |
+
+**Invariants**:
+- Read-only after creation (no mutation of public key or kid)
+- ExpiresAt MUST be in the future at creation time
+
+---
+
+### HMACKeyRing
+
+An ordered pair of symmetric secrets for HMAC-based service token operations. Enables graceful secret rotation without invalidating in-flight tokens.
+
+**Attributes**:
+
+| Attribute | Description | Constraints |
+| --- | --- | --- |
+| Current | The active secret used for signing new tokens | Position 0; MUST NOT be empty |
+| Previous | The previous secret retained for verification | Position 1; MAY be nil (single-key mode) |
+
+**Invariants**:
+- Current (position 0) is always used for signing
+- Verification tries Current first, then Previous
+- Ring size is fixed at 2 (no growth beyond [current, previous])
+- When Previous is nil, verification uses only Current
+
+**Relationships**:
+- Used by ServiceTokenMiddleware (verification)
+- Used by GenerateServiceToken (signing)
+
+---
+
+## Validation Rules
+
+| Entity | Rule | Source |
+| --- | --- | --- |
+| KeySet | MUST have exactly one signing key at startup | FR-015 |
+| KeySet | MUST reject tokens with unknown kid | FR-004 |
+| KeySet | MUST prune expired verification keys | FR-008 |
+| VerificationKey | Public key MUST be ≥ 2048 bits RSA | Existing MinRSAKeyBits |
+| VerificationKey | ExpiresAt MUST be set at creation | FR-008 |
+| HMACKeyRing | Current secret MUST NOT be empty | FR-015 |
+| HMACKeyRing | Previous MAY be nil | FR-013 |
+
+## No Database Changes
+
+This feature operates entirely in-memory. Key material is loaded from static configuration (environment variables or PEM files) at startup. No database tables, migrations, or schema changes are required.

--- a/specs/201-wm2-key-rotation/plan.md
+++ b/specs/201-wm2-key-rotation/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: JWT kid Rotation & HMAC Key Ring
+
+**Branch**: `201-wm2-key-rotation` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/201-wm2-key-rotation/spec.md`
+
+## Summary
+
+Extend `src/runtime/auth/` to support JWT key rotation via kid (key identifier) headers and HMAC secret rotation via a 2-position key ring. Currently, the module uses a single RSA key pair (no kid) and a single HMAC secret (no rotation). This plan adds:
+
+1. **KeySet** — holds 1 active signing key + N verification-only keys, with kid derived from RFC 7638 SHA-256 thumbprint. Adopts Dex's 3-state lifecycle (Active → Verification-only → Pruned).
+2. **HMACKeyRing** — ordered pair of secrets `[current, previous]` with try-all-keys verification. Adopts gorilla/go-zero positional model.
+3. **Updated JWTIssuer/JWTVerifier** — issue tokens with kid header, verify by kid-based key lookup.
+4. **Updated ServiceTokenMiddleware** — verify against key ring instead of single secret.
+
+All changes are in `src/runtime/auth/`. No new dependencies, no database changes, no new contracts.
+
+## Technical Context
+
+**Language/Version**: Go (latest stable)  
+**Primary Dependencies**: `github.com/golang-jwt/jwt/v5` (existing), `crypto/*` stdlib  
+**Storage**: N/A (in-memory key set, loaded from static config)  
+**Testing**: `go test`, `testify` assertions, table-driven tests  
+**Target Platform**: Linux server  
+**Project Type**: Library (runtime layer)  
+**Performance Goals**: kid-based key lookup within 1ms per verification (O(1) map lookup vs current single-key)  
+**Constraints**: No new external dependencies to `runtime/`; `runtime/` MUST NOT depend on `cells/` or `adapters/`  
+**Scale/Scope**: Single-service key management; multi-service JWKS discovery is out of scope
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --- | --- | --- |
+| I. Cell-Native Layering | PASS | Changes in `runtime/auth/` — depends only on `pkg/` and stdlib. No `cells/` or `adapters/` imports. |
+| II. Cell Governance | N/A | No Cell/Slice metadata changes. |
+| III. Contract Boundary | N/A | No new contracts. Internal runtime module. |
+| IV. TDD First | GATE | Must write tests first (Red → Green → Refactor). Coverage ≥ 80% for new code. |
+| V. Cell Data Sovereignty | N/A | No database changes. |
+| VI. Event-Driven | N/A | No events involved. This is L0 (pure computation). |
+| VII. Journey Acceptance | N/A | Runtime library, not a user journey. |
+| VIII. Security Built-in | GATE | Key operations MUST produce audit logs (slog). Secrets MUST NOT appear in logs. kid values are safe to log. |
+| IX. Simplicity & Incremental | PASS | Scope explicitly bounded: no auto-rotation, no JWKS, no DB storage, no multi-algorithm. |
+
+**Six-Question Checklist (Principle VI)**: Not applicable — this feature is L0 (pure in-memory computation, no state persistence, no events). Key material is loaded from static configuration and managed in memory.
+
+**Red Line Check**:
+- RL-14 (no noop fallback): `LoadKeySetFromEnv()` and `LoadHMACKeyRingFromEnv()` fail-fast on missing keys. No silent degradation.
+- RL-13 (no t.Skip abuse): All new tests will be active; no skips.
+- All other red lines: not triggered by this feature.
+
+### Post-Phase-1 Re-check
+
+| Principle | Status | Notes |
+| --- | --- | --- |
+| I. Cell-Native Layering | PASS | Confirmed: all new types (`KeySet`, `VerificationKey`, `HMACKeyRing`) in `runtime/auth/`. No cross-layer imports. |
+| IV. TDD First | GATE | Remains: implementation phase must follow Red → Green → Refactor. |
+| VIII. Security Built-in | PASS | Design includes structured slog for lifecycle transitions. kid (thumbprint) is non-sensitive — safe to log. Secret values never logged. |
+| IX. Simplicity | PASS | 3 new types, ~6 new/modified functions. No abstractions beyond what the feature requires. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/201-wm2-key-rotation/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0: consolidated research decisions
+├── data-model.md        # Phase 1: entity definitions and invariants
+├── quickstart.md        # Phase 1: usage examples before/after
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+src/runtime/auth/
+├── auth.go              # (existing) Claims, TokenVerifier, Authorizer interfaces — no changes
+├── middleware.go         # (existing) AuthMiddleware, RequireRole — no changes
+├── keys.go              # (modify) Add KeySet, VerificationKey, LoadKeySetFromEnv, kid computation
+├── jwt.go               # (modify) JWTIssuer adds kid header; JWTVerifier uses KeySet for kid lookup
+├── servicetoken.go      # (modify) HMACKeyRing, try-all-keys verification, LoadHMACKeyRingFromEnv
+├── keys_test.go         # (modify) Tests for KeySet lifecycle, kid generation, pruning
+├── jwt_test.go          # (modify) Tests for kid in issued tokens, kid-based verification
+└── servicetoken_test.go # (modify) Tests for key ring verification, rotation scenarios
+```
+
+**Structure Decision**: All changes are within the existing `src/runtime/auth/` package. No new packages, directories, or files beyond what exists. The feature extends existing types and functions.
+
+## Complexity Tracking
+
+No constitution violations to justify. All changes stay within existing package boundaries, use existing dependencies, and add no new abstractions beyond the three entities defined in the data model.
+
+## Framework References
+
+| GoCell Component | Reference Framework | Source File | Adoption |
+| --- | --- | --- | --- |
+| KeySet lifecycle | Dex | `server/rotation.go` | Adopted: 3-state model (Active → Verification-only → Pruned). Deviated: kid is SHA-256 thumbprint (not random hex); no rotation timer (static config). |
+| KeyFunc verification | Kratos | `middleware/auth/jwt/jwt.go` | Adopted: `KeyFunc(token) → key` pattern, context injection. Already in use by GoCell's `JWTVerifier`. |
+| HMAC key ring | go-zero | `rest/token/tokenparser.go` | Adopted: dual-key [current, previous] model. Deviated: simple ordered try (not frequency-based priority). |
+| HMAC try-all-keys | gorilla/securecookie | `securecookie.go` | Adopted: `DecodeMulti` pattern — try current, fallback to previous. |

--- a/specs/201-wm2-key-rotation/quickstart.md
+++ b/specs/201-wm2-key-rotation/quickstart.md
@@ -1,0 +1,83 @@
+# Quickstart: JWT kid Rotation & HMAC Key Ring
+
+**Feature**: 201-wm2-key-rotation
+
+## JWT Key Rotation
+
+### Before (current — single key, no kid)
+
+```go
+priv, pub, err := auth.LoadKeysFromEnv()
+issuer, _ := auth.NewJWTIssuer(priv, "gocell", 1*time.Hour)
+verifier, _ := auth.NewJWTVerifier(pub)
+
+token, _ := issuer.Issue("user-123", []string{"admin"}, nil)
+// Token header: {"alg": "RS256", "typ": "JWT"} — no kid
+```
+
+### After (key set with kid)
+
+```go
+// Load key set with active signing key + optional verification-only keys
+keySet, err := auth.LoadKeySetFromEnv()
+// keySet contains: 1 signing key (with kid) + 0-N verification keys
+
+issuer, _ := auth.NewJWTIssuer(keySet, "gocell", 1*time.Hour)
+verifier, _ := auth.NewJWTVerifier(keySet)
+
+token, _ := issuer.Issue("user-123", []string{"admin"}, nil)
+// Token header: {"alg": "RS256", "typ": "JWT", "kid": "<sha256-thumbprint>"}
+
+// Verification: KeyFunc looks up key by kid from the key set
+claims, err := verifier.Verify(ctx, token)
+```
+
+### Key Rotation (operator workflow)
+
+1. Generate a new RSA key pair
+2. Update environment: set new key as active, move old key to verification-only with expiry
+3. Restart the service — the new key set is loaded, old tokens remain valid until expiry
+
+## HMAC Service Token Rotation
+
+### Before (current — single secret)
+
+```go
+secret := []byte(os.Getenv("GOCELL_SERVICE_SECRET"))
+mw := auth.ServiceTokenMiddleware(secret)
+token := auth.GenerateServiceToken(secret, "GET", "/internal/v1/sessions", time.Now())
+```
+
+### After (key ring with rotation)
+
+```go
+// Load key ring: current + optional previous secret
+ring, err := auth.LoadHMACKeyRingFromEnv()
+
+mw := auth.ServiceTokenMiddleware(ring)
+// Verification: tries current secret first, then previous
+
+token := auth.GenerateServiceToken(ring, "GET", "/internal/v1/sessions", time.Now())
+// Always signs with current secret (position 0)
+```
+
+### Secret Rotation (operator workflow)
+
+1. Set the new secret as `GOCELL_SERVICE_SECRET`
+2. Set the old secret as `GOCELL_SERVICE_SECRET_PREVIOUS`
+3. Restart the service — in-flight tokens signed with the old secret are still accepted
+
+## Environment Variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `GOCELL_JWT_PRIVATE_KEY` | Yes | PEM-encoded RSA private key (active signing key) |
+| `GOCELL_JWT_PUBLIC_KEY` | Yes | PEM-encoded RSA public key (active signing key) |
+| `GOCELL_JWT_PREV_PUBLIC_KEY` | No | PEM-encoded RSA public key (verification-only, recently rotated) |
+| `GOCELL_JWT_PREV_KEY_EXPIRES` | No | Expiry for the verification-only key (RFC 3339, e.g. `2026-04-12T00:00:00Z`) |
+| `GOCELL_SERVICE_SECRET` | Yes | Current HMAC secret for service tokens |
+| `GOCELL_SERVICE_SECRET_PREVIOUS` | No | Previous HMAC secret (retained during rotation) |
+
+## Middleware Integration (unchanged)
+
+The existing `AuthMiddleware` and `ServiceTokenMiddleware` signatures remain compatible. The key set and key ring integrate behind the existing `TokenVerifier` interface — no changes to middleware.go or route registration are needed.

--- a/specs/201-wm2-key-rotation/quickstart.md
+++ b/specs/201-wm2-key-rotation/quickstart.md
@@ -78,6 +78,68 @@ token := auth.GenerateServiceToken(ring, "GET", "/internal/v1/sessions", time.No
 | `GOCELL_SERVICE_SECRET` | Yes | Current HMAC secret for service tokens |
 | `GOCELL_SERVICE_SECRET_PREVIOUS` | No | Previous HMAC secret (retained during rotation) |
 
+## PEM Encoding in Environment Variables
+
+PEM keys contain newlines. Depending on your deployment platform:
+
+| Platform | How to set multi-line env var |
+| --- | --- |
+| Shell (bash/zsh) | `export GOCELL_JWT_PRIVATE_KEY="$(cat private.pem)"` |
+| Docker Compose | Use YAML literal block: <code>GOCELL_JWT_PRIVATE_KEY: \|</code> followed by indented PEM content |
+| Kubernetes | Use a Secret with `stringData:` and literal PEM, or mount as a file |
+| `.env` file | Replace newlines with `\n`: `GOCELL_JWT_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIE...` |
+
+If you see `"no PEM block found"` errors at startup, the newlines are likely stripped or escaped incorrectly.
+
+## PREV_KEY_EXPIRES Recommended Value
+
+Set `GOCELL_JWT_PREV_KEY_EXPIRES` to the latest possible expiry of any token signed with the old key:
+
+```
+PREV_KEY_EXPIRES = rotation_time + token_TTL
+```
+
+For example, if your JWT TTL is 15 minutes, set the expiry to 15 minutes after the rotation timestamp. This ensures all in-flight tokens naturally expire before the old key is pruned.
+
+## Initial Deployment (Migration from Legacy Tokens)
+
+This feature requires all tokens to carry a `kid` header. Tokens issued before this deployment (without kid) will be rejected.
+
+**Recommended deployment strategy:**
+
+1. Deploy the new code — all *new* tokens will include `kid`
+2. Wait one full token TTL (e.g. 15 minutes) for all old tokens to expire
+3. No further action needed — after the TTL window, all active tokens carry `kid`
+
+Since GoCell is pre-production, there are no external consumers holding legacy tokens. If you have long-lived tokens in an external system, coordinate the deployment with those consumers.
+
+## JWT Key Rotation Runbook
+
+### Rotation steps
+
+1. **Generate** a new RSA key pair (>= 2048 bits)
+2. **Set environment variables:**
+   - `GOCELL_JWT_PRIVATE_KEY` = new private key PEM
+   - `GOCELL_JWT_PUBLIC_KEY` = new public key PEM
+   - `GOCELL_JWT_PREV_PUBLIC_KEY` = old public key PEM
+   - `GOCELL_JWT_PREV_KEY_EXPIRES` = `now + token_TTL` (RFC 3339, e.g. `2026-04-12T00:15:00Z`)
+3. **Rolling restart** the service — new tokens use the new key; old tokens remain valid
+4. **After PREV_KEY_EXPIRES passes**, remove the `PREV` env vars (optional cleanup)
+
+### Rollback
+
+If the new key is compromised or causes issues:
+1. Revert `GOCELL_JWT_PRIVATE_KEY` / `GOCELL_JWT_PUBLIC_KEY` to the old key
+2. Remove `GOCELL_JWT_PREV_*` vars
+3. Restart — service reverts to the old key, all new tokens use the old key again
+
+### Verification
+
+After rotation, confirm:
+- New tokens contain the new kid: decode a token header and check `kid` field
+- Old tokens still verify: test with a token issued before the restart
+- Logs show "key activated" for the new kid and "key demoted to verification-only" for the old kid
+
 ## Middleware Integration (unchanged)
 
 The existing `AuthMiddleware` and `ServiceTokenMiddleware` signatures remain compatible. The key set and key ring integrate behind the existing `TokenVerifier` interface — no changes to middleware.go or route registration are needed.

--- a/specs/201-wm2-key-rotation/research.md
+++ b/specs/201-wm2-key-rotation/research.md
@@ -1,0 +1,84 @@
+# Research: JWT kid Rotation & HMAC Key Ring
+
+**Feature**: 201-wm2-key-rotation  
+**Date**: 2026-04-11  
+**Source**: `docs/reviews/20260411-wm2-key-rotation-research.md` (4-role parallel analysis of 12+ open source projects)
+
+## R-001: JWT kid Generation Strategy
+
+**Decision**: RFC 7638 SHA-256 thumbprint of the public key.
+
+**Rationale**: Deterministic — same key always yields the same kid, no extra storage needed. Used by Kubernetes apiserver. The research found two prevalent patterns (thumbprint vs. random UUID); thumbprint is preferred because it eliminates the need for a separate kid→key mapping during initial key loading.
+
+**Alternatives considered**:
+- Random 20-byte hex (Dex) — simpler but non-deterministic; requires storing kid alongside key material.
+- UUID (Ory Hydra) — same problem as random hex.
+- cert.Name (Casdoor) — too coupled to certificate lifecycle.
+
+ref: dexidp/dex `server/rotation.go`, Kubernetes apiserver thumbprint pattern
+
+## R-002: JWT Key Set Model
+
+**Decision**: Adopt Dex's 3-state model: Active → Verification-only (with expiry) → Pruned. KeySet holds 1 signing key + N verification-only keys.
+
+**Rationale**: Dex's model is the simplest that correctly handles zero-downtime rotation. One signing key issues all new tokens; demoted keys remain trusted until their expiry (set to `now + tokenTTL` at demotion time). Pruning happens lazily on next key set access. This matches GoCell's "simplicity first" constitution principle.
+
+**Alternatives considered**:
+- Vault Transit sliding window (MinDecryptionVersion / MinEncryptionVersion) — more powerful but requires versioned ciphertext prefixes; overkill for JWT where kid is in the header.
+- Teleport 5-phase rotation — designed for CA rotation with rollback, far too complex for single-service JWT.
+- Authelia static kid — no rotation capability.
+
+ref: dexidp/dex `storage/storage.go` Keys struct
+
+## R-003: JWT Verification Strategy
+
+**Decision**: `KeyFunc(token) → key` pattern — select key by kid from the key set, not try-all-keys.
+
+**Rationale**: Industry standard (Kratos, golang-jwt/v5 native pattern). O(1) key lookup vs. O(N) trial. The existing GoCell `JWTVerifier` already uses `jwt.Parse` with a `KeyFunc` callback; extending it to look up by kid is a minimal change.
+
+**Alternatives considered**:
+- Try-all-keys (gorilla/securecookie style) — only appropriate for HMAC where kid cannot be embedded; wrong model for JWT.
+
+ref: go-kratos/kratos `middleware/auth/jwt/jwt.go` — KeyFunc pattern with context injection
+
+## R-004: HMAC Key Ring Model
+
+**Decision**: Position-based ring of size 2 (`[current, previous]`). Sign with `secrets[0]`, verify by trying `secrets[0]` then `secrets[1]`.
+
+**Rationale**: Industry consensus across gorilla/securecookie, Django, Rails, go-zero. HMAC signatures cannot embed a kid, so position-based try-all is the correct model. Ring size 2 is sufficient because rotation replaces the previous key; go-zero's `PrevSecret` validates this as industrial practice.
+
+**Alternatives considered**:
+- Unlimited ring (gorilla) — unnecessary; 2 covers the rotation window.
+- Tagged/kid-based (golang-jwt) — not applicable for HMAC service tokens where the signature format doesn't carry metadata.
+- Frequency-based priority (go-zero) — optimization not needed at GoCell's scale; simple ordered try is clearer.
+
+ref: zeromicro/go-zero `rest/token/tokenparser.go`, gorilla/securecookie `DecodeMulti`
+
+## R-005: Key Lifecycle Observability
+
+**Decision**: Structured slog entries for all lifecycle transitions (activation, demotion, pruning). No metrics in WM-2 scope.
+
+**Rationale**: Constitution Principle VIII requires audit logging for key operations. Structured log fields (`kid`, `transition`, `timestamp`) are sufficient for WM-2; Prometheus metrics can be layered on later without API changes.
+
+**Alternatives considered**:
+- Rails `on_rotation` callback — useful pattern, but GoCell's static config model doesn't trigger runtime rotation events. When WM-34 adds hot-reload, callbacks can be added.
+- Metrics-first — premature; slog is the universal observability primitive in GoCell.
+
+## R-006: Configuration Loading Strategy
+
+**Decision**: Static configuration at startup (env vars or PEM files). No auto-rotation scheduler in WM-2.
+
+**Rationale**: The current `LoadKeysFromEnv()` pattern works. WM-2 extends it to load multiple keys (active + verification-only for JWT, current + previous for HMAC). Auto-rotation requires worker infrastructure (WM-34 dependency). The research found that Dex uses a timer goroutine, Vault uses `AutoRotatePeriod`, and cert-manager uses condition-based triggers — all require background scheduling that GoCell doesn't have yet.
+
+**Alternatives considered**:
+- File watcher (fsnotify) — adds external dependency to runtime/; deferred to WM-34.
+- Config-hot-reload — WM-34 scope.
+
+## R-007: Backward Compatibility with Existing Tokens
+
+**Decision**: Tokens without a `kid` header are rejected.
+
+**Rationale**: GoCell is pre-production; no external consumers hold tokens issued by the current system. The research doc confirms the system currently has no kid in tokens. A clean break (reject kidless tokens) avoids dual-path verification complexity. Constitution Principle IX (YAGNI) supports this.
+
+**Alternatives considered**:
+- Fallback to single-key verification for kidless tokens — adds permanent legacy code path for a pre-production system.

--- a/specs/201-wm2-key-rotation/spec.md
+++ b/specs/201-wm2-key-rotation/spec.md
@@ -1,0 +1,132 @@
+# Feature Specification: JWT kid Rotation & HMAC Key Ring
+
+**Feature Branch**: `201-wm2-key-rotation`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "JWT kid rotation + HMAC key rotation for runtime/auth, based on Dex/gorilla/go-zero models"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - JWT Tokens Include Key Identifier (Priority: P1)
+
+When the authentication module issues a JWT token, it must include a key identifier (kid) in the token header so that verifiers can deterministically select the correct public key for validation. Today, the system signs tokens without a kid, which means verification can only work with a single known key — making key rotation impossible without downtime.
+
+**Why this priority**: This is the foundational building block. Without kid in tokens, no rotation scheme can work. Every downstream story depends on this capability.
+
+**Independent Test**: Can be fully tested by issuing a token and inspecting the header to confirm the kid is present and matches the signing key's identity. Delivers the ability to identify which key signed any given token.
+
+**Acceptance Scenarios**:
+
+1. **Given** the system has a configured signing key, **When** a JWT token is issued, **Then** the token header contains a `kid` field that uniquely identifies the signing key.
+2. **Given** a token with a `kid` header, **When** the verifier receives the token, **Then** it uses the kid to select the matching public key from the key set rather than using a single hardcoded key.
+3. **Given** a token with a `kid` that does not match any known key, **When** the verifier attempts validation, **Then** the token is rejected with an appropriate error.
+
+---
+
+### User Story 2 - JWT Key Set Supports Multiple Verification Keys (Priority: P1)
+
+The system must support holding multiple public keys simultaneously — one active signing key and one or more verification-only keys (recently rotated out). This enables zero-downtime key rotation: tokens signed with the previous key remain valid until they naturally expire, while all new tokens are signed with the current key.
+
+**Why this priority**: Equal priority with Story 1 because together they form the minimum viable key rotation capability. A kid without multi-key support, or multi-key without kid, are both incomplete.
+
+**Independent Test**: Can be tested by configuring two key pairs, signing a token with the older key, and verifying that the system accepts it via the verification key set while only using the newer key for new signatures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key set with one active signing key and one verification-only key, **When** a token signed by the verification-only key is presented, **Then** the verifier accepts the token (the key is still trusted).
+2. **Given** a key set with one active signing key, **When** a new token is issued, **Then** it is always signed by the active key (never by a verification-only key).
+3. **Given** a verification-only key has passed its expiry time, **When** the key set is refreshed, **Then** the expired key is removed (pruned) and tokens signed by it are no longer accepted.
+
+---
+
+### User Story 3 - HMAC Secrets Support Graceful Rotation (Priority: P2)
+
+For service-to-service tokens (service tokens signed with HMAC), the system must support a key ring of two secrets: the current signing secret and the previous secret. This allows operators to rotate the HMAC secret without invalidating in-flight tokens signed with the old secret.
+
+**Why this priority**: Service tokens are critical for internal communication, but the HMAC rotation pattern is simpler than JWT kid rotation and has fewer moving parts. It builds on the same mental model but is independently valuable.
+
+**Independent Test**: Can be tested by signing a token with the old secret, rotating to a new secret, and verifying that the token signed with the old secret is still accepted while new tokens use the new secret.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key ring with two secrets [current, previous], **When** a new service token is signed, **Then** the current secret (position 0) is always used.
+2. **Given** a key ring with two secrets, **When** a token signed with the previous secret is verified, **Then** the system accepts it by trying both secrets in order.
+3. **Given** a key ring with two secrets, **When** a token signed with an unknown secret (not in the ring) is verified, **Then** the system rejects it.
+4. **Given** a key ring with only one secret (no previous), **When** a token is verified, **Then** the system uses only the single secret and does not error due to the absent previous secret.
+
+---
+
+### User Story 4 - Key Lifecycle Transitions (Priority: P2)
+
+Operators must be able to understand the state of each key in the system. Each JWT key progresses through a clear lifecycle: Active (signs new tokens) to Verification-only (validates existing tokens for a grace period) to Pruned (removed). Each HMAC secret is either Current (signs) or Previous (verifies only). The system logs lifecycle transitions for operational visibility.
+
+**Why this priority**: Without observable lifecycle state, operators cannot confidently rotate keys or diagnose authentication failures during rotation windows.
+
+**Independent Test**: Can be tested by triggering a key rotation and observing that the system correctly transitions the old key to verification-only status and logs the event.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active JWT signing key, **When** a new key is loaded as the active key, **Then** the previous key transitions to verification-only status with an expiry time.
+2. **Given** a verification-only key whose expiry has passed, **When** the system checks key state, **Then** the expired key is pruned from the key set.
+3. **Given** any key lifecycle transition occurs, **When** the transition completes, **Then** a structured log entry records the transition type, key identifier, and timestamp.
+
+---
+
+### Edge Cases
+
+- What happens when the system starts with no keys configured? The system must fail to start with a clear error message indicating missing key configuration.
+- What happens when a JWT token has no `kid` header (legacy token)? The system must reject it, since all valid tokens in the new scheme carry a kid.
+- What happens when the HMAC key ring is reconfigured with the same secret in both positions? The system should accept this gracefully (degenerate case, functionally equivalent to a single key).
+- What happens when the verification-only key expiry is set to zero or negative? The key should be pruned immediately, effectively disabling the grace period.
+- What happens when multiple key rotations occur in quick succession before the first grace period expires? The system should support at most one verification-only key; the oldest is pruned when a new one is added.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST include a `kid` (key identifier) in the header of every JWT token it issues.
+- **FR-002**: System MUST derive the `kid` deterministically from the public key material so that the same key always produces the same kid.
+- **FR-003**: System MUST verify JWT tokens by selecting the matching key from the key set using the token's `kid` header, not by trying all keys.
+- **FR-004**: System MUST reject JWT tokens whose `kid` does not match any key in the current key set.
+- **FR-005**: System MUST support a key set containing one active signing key and zero or more verification-only keys.
+- **FR-006**: System MUST only use the active signing key for issuing new JWT tokens.
+- **FR-007**: System MUST accept JWT tokens signed by any non-expired verification-only key in the key set.
+- **FR-008**: System MUST prune verification-only keys whose expiry time has passed.
+- **FR-009**: System MUST support an HMAC key ring of exactly two positions: current (index 0) and previous (index 1).
+- **FR-010**: System MUST sign all new HMAC-based tokens using the current secret (index 0).
+- **FR-011**: System MUST verify HMAC-based tokens by trying secrets in order: current first, then previous.
+- **FR-012**: System MUST reject HMAC-based tokens that do not match any secret in the ring.
+- **FR-013**: System MUST operate correctly when the HMAC key ring contains only one secret (no previous secret configured).
+- **FR-014**: System MUST log all key lifecycle transitions (activation, demotion to verification-only, pruning) with structured fields including key identifier and timestamp.
+- **FR-015**: System MUST fail to start if no signing key is configured, with a clear error message.
+- **FR-016**: System MUST reject JWT tokens that do not contain a `kid` header.
+- **FR-017**: System MUST load key configuration at startup from static configuration (environment or file); automatic rotation scheduling is out of scope.
+
+### Key Entities
+
+- **KeySet**: A collection of cryptographic keys for JWT operations. Contains exactly one active signing key and zero or more verification-only keys. Responsible for key lookup by identifier and lifecycle management (promotion, demotion, pruning).
+- **Signing Key**: The currently active asymmetric key pair used to sign new JWT tokens. Has an associated key identifier. Only one signing key is active at any time.
+- **Verification Key**: A previously active signing key that has been demoted. Retains the public key and key identifier. Has an expiry time after which it is pruned. Used only for validating existing tokens.
+- **HMAC Key Ring**: An ordered pair of symmetric secrets for service token operations. Position 0 is the current signing secret; position 1 is the previous secret retained for verification during rotation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All newly issued JWT tokens contain a valid key identifier that matches the signing key, verified by inspecting 100% of tokens in test scenarios.
+- **SC-002**: Token verification using kid-based key lookup succeeds for valid tokens within 1 millisecond per verification (no performance regression from multi-key support).
+- **SC-003**: Key rotation completes with zero rejected valid tokens — tokens signed by the previous key continue to be accepted during the grace period.
+- **SC-004**: HMAC secret rotation causes zero authentication failures for in-flight service tokens signed with the previous secret.
+- **SC-005**: All key lifecycle transitions produce observable structured log entries that operators can query.
+- **SC-006**: System startup fails deterministically when no signing key is configured, preventing silent misconfiguration.
+
+## Assumptions
+
+- The system currently uses a single RSA key pair and a single HMAC secret; this feature extends (not replaces) the existing authentication flow.
+- RS256 is the only JWT signing algorithm in scope; multi-algorithm support is not planned and not needed.
+- Key material is loaded from static configuration (environment variables or files) at startup. Dynamic/hot-reload configuration will be addressed in a future task (WM-34).
+- Automatic rotation scheduling (timer-based key generation) is out of scope; operators trigger rotation by updating configuration and restarting.
+- The HMAC key ring is fixed at size 2 (current + previous); larger rings are not required.
+- A JWKS (JSON Web Key Set) public endpoint for cross-service key discovery is out of scope and will be addressed as an independent task.
+- The existing middleware layer (`middleware.go`) and interfaces (`TokenVerifier`, `Authorizer`) do not need structural changes; the new key management integrates behind these interfaces.
+- The verification-only key grace period defaults to the JWT token TTL (tokens signed before rotation remain valid until they naturally expire).

--- a/specs/201-wm2-key-rotation/spec.md
+++ b/specs/201-wm2-key-rotation/spec.md
@@ -78,7 +78,7 @@ Operators must be able to understand the state of each key in the system. Each J
 - What happens when a JWT token has no `kid` header (legacy token)? The system must reject it, since all valid tokens in the new scheme carry a kid.
 - What happens when the HMAC key ring is reconfigured with the same secret in both positions? The system should accept this gracefully (degenerate case, functionally equivalent to a single key).
 - What happens when the verification-only key expiry is set to zero or negative? The key should be pruned immediately, effectively disabling the grace period.
-- What happens when multiple key rotations occur in quick succession before the first grace period expires? The system should support at most one verification-only key; the oldest is pruned when a new one is added.
+- What happens when multiple key rotations occur in quick succession before the first grace period expires? The KeySet API supports multiple verification-only keys simultaneously. However, the environment variable-based loader (`LoadKeySetFromEnv`) supports at most one previous key. For rapid consecutive rotations via env vars, each rotation replaces the previous key.
 
 ## Requirements *(mandatory)*
 
@@ -88,7 +88,7 @@ Operators must be able to understand the state of each key in the system. Each J
 - **FR-002**: System MUST derive the `kid` deterministically from the public key material so that the same key always produces the same kid.
 - **FR-003**: System MUST verify JWT tokens by selecting the matching key from the key set using the token's `kid` header, not by trying all keys.
 - **FR-004**: System MUST reject JWT tokens whose `kid` does not match any key in the current key set.
-- **FR-005**: System MUST support a key set containing one active signing key and zero or more verification-only keys.
+- **FR-005**: System MUST support a key set containing one active signing key and zero or more verification-only keys. The `LoadKeySetFromEnv` loader supports at most one previous key; programmatic construction via `NewKeySetWithVerificationKeys` supports N.
 - **FR-006**: System MUST only use the active signing key for issuing new JWT tokens.
 - **FR-007**: System MUST accept JWT tokens signed by any non-expired verification-only key in the key set.
 - **FR-008**: System MUST prune verification-only keys whose expiry time has passed.

--- a/specs/201-wm2-key-rotation/tasks.md
+++ b/specs/201-wm2-key-rotation/tasks.md
@@ -130,8 +130,9 @@
 - [x] T033 Run `go build ./...` — verify zero compilation errors across entire codebase
 - [x] T034 Run `go test ./src/runtime/auth/...` — verify all tests pass, coverage ≥ 80%
 - [x] T035 Run `go vet ./src/runtime/auth/...` — verify no vet warnings
+- [x] T036 Run `go test -race ./runtime/auth/...` — **mandatory** race detection gate for auth package
 
-**Checkpoint**: Full codebase compiles. All auth tests pass. Coverage meets threshold.
+**Checkpoint**: Full codebase compiles. All auth tests pass with `-race`. Coverage meets threshold.
 
 ---
 

--- a/specs/201-wm2-key-rotation/tasks.md
+++ b/specs/201-wm2-key-rotation/tasks.md
@@ -1,0 +1,242 @@
+# Tasks: JWT kid Rotation & HMAC Key Ring
+
+**Input**: Design documents from `/specs/201-wm2-key-rotation/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md  
+**TDD**: Required by Constitution Principle IV — all tests written first (RED), then implementation (GREEN)
+
+**Organization**: Tasks grouped by user story. US1+US2 (both P1) are in separate phases but share foundational types. US3+US4 (both P2) are independent of each other.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story (US1, US2, US3, US4)
+- All paths relative to repository root
+
+---
+
+## Phase 1: Foundational (Types + kid Computation)
+
+**Purpose**: Core types and utility functions that ALL user stories depend on. No user story work can begin until this phase is complete.
+
+**Covers**: KeySet, VerificationKey, HMACKeyRing types; RFC 7638 thumbprint function.
+
+- [x] T001 Write table-driven tests for RFC 7638 SHA-256 thumbprint computation (determinism, different key sizes, consistency) in src/runtime/auth/keys_test.go (TDD: RED)
+- [x] T002 Implement `Thumbprint(pub *rsa.PublicKey) string` — RFC 7638 SHA-256 thumbprint that derives kid from public key material — in src/runtime/auth/keys.go (TDD: GREEN for T001)
+- [x] T003 Write tests for KeySet constructor: single signing key, kid matches thumbprint, PublicKeyByKID returns correct key, PublicKeyByKID returns error for unknown kid in src/runtime/auth/keys_test.go (TDD: RED)
+- [x] T004 Implement `VerificationKey` struct and `KeySet` struct with `NewKeySet(privateKey, publicKey)` constructor and `PublicKeyByKID(kid) (*rsa.PublicKey, error)` method in src/runtime/auth/keys.go (TDD: GREEN for T003)
+
+**Checkpoint**: Foundational types compile and pass tests. `go test ./src/runtime/auth/... -run TestThumbprint` and `go test ./src/runtime/auth/... -run TestKeySet` both GREEN.
+
+---
+
+## Phase 2: User Story 1 — JWT Tokens Include Key Identifier (Priority: P1) MVP
+
+**Goal**: Every issued JWT token carries a `kid` header; verification selects the matching key from KeySet by kid, not by single hardcoded key.
+
+**Independent Test**: Issue a token, decode the header, confirm `kid` is present and matches the signing key's thumbprint. Verify round-trip: issue → verify succeeds. Verify unknown/missing kid → rejection.
+
+### Tests for User Story 1
+
+> **TDD: Write these tests FIRST. They MUST FAIL before implementation.**
+
+- [x] T005 [P] [US1] Write tests for JWTIssuer: issued token header contains `kid` field matching signing key thumbprint in src/runtime/auth/jwt_test.go (TDD: RED)
+- [x] T006 [P] [US1] Write tests for JWTVerifier: verifies token by looking up public key from KeySet using token's `kid` header in src/runtime/auth/jwt_test.go (TDD: RED)
+- [x] T007 [P] [US1] Write tests for JWTVerifier rejection: unknown kid returns error; missing kid header returns error in src/runtime/auth/jwt_test.go (TDD: RED)
+
+### Implementation for User Story 1
+
+- [x] T008 [US1] Update `NewJWTIssuer` to accept `*KeySet` instead of `*rsa.PrivateKey`; update `Issue()` to set `token.Header["kid"] = keySet.SigningKeyID()` in src/runtime/auth/jwt.go (TDD: GREEN for T005)
+- [x] T009 [US1] Update `NewJWTVerifier` to accept `*KeySet` instead of `*rsa.PublicKey`; update `Verify()` KeyFunc to extract `kid` from token header and call `keySet.PublicKeyByKID(kid)` in src/runtime/auth/jwt.go (TDD: GREEN for T006, T007)
+- [x] T010 [US1] Update existing tests in src/runtime/auth/jwt_test.go and src/runtime/auth/middleware_test.go to use KeySet-based constructors (fix compilation)
+
+**Checkpoint**: `go test ./src/runtime/auth/... -run TestJWT` all GREEN. Tokens have kid. Verification works by kid lookup.
+
+---
+
+## Phase 3: User Story 2 — JWT Key Set Supports Multiple Verification Keys (Priority: P1)
+
+**Goal**: KeySet holds one active signing key + zero or more verification-only keys with expiry. Tokens signed by non-expired verification keys are accepted. Expired keys are pruned.
+
+**Independent Test**: Create KeySet with signing key + verification key. Issue token with old key's kid. Verify it succeeds. Advance time past expiry. Verify it fails (key pruned).
+
+### Tests for User Story 2
+
+- [x] T011 [P] [US2] Write tests for KeySet multi-key: verification-only key lookup by kid succeeds; signing always uses active key only in src/runtime/auth/keys_test.go (TDD: RED)
+- [x] T012 [P] [US2] Write tests for KeySet pruning: expired verification key is removed on PruneExpired(); lookup by pruned kid fails in src/runtime/auth/keys_test.go (TDD: RED)
+- [x] T013 [P] [US2] Write tests for KeySet edge cases: rapid rotation replaces oldest verification key; zero/negative expiry prunes immediately in src/runtime/auth/keys_test.go (TDD: RED)
+
+### Implementation for User Story 2
+
+- [x] T014 [US2] Implement `NewKeySetWithVerificationKeys(privateKey, publicKey, verificationKeys []VerificationKey)` constructor and `PruneExpired()` method in src/runtime/auth/keys.go (TDD: GREEN for T011, T012, T013)
+- [x] T015 [US2] Implement `LoadKeySetFromEnv()` — load active key pair from existing env vars + optional `GOCELL_JWT_PREV_PUBLIC_KEY` and `GOCELL_JWT_PREV_KEY_EXPIRES` for verification-only key in src/runtime/auth/keys.go
+- [x] T016 [US2] Write tests for `LoadKeySetFromEnv`: active-only, active+verification, missing active fails, invalid expiry fails in src/runtime/auth/keys_test.go
+
+**Checkpoint**: `go test ./src/runtime/auth/... -run TestKeySet` all GREEN. Multi-key verification works. Pruning works. LoadKeySetFromEnv works.
+
+---
+
+## Phase 4: User Story 3 — HMAC Secrets Support Graceful Rotation (Priority: P2)
+
+**Goal**: HMACKeyRing holds `[current, previous]` secrets. Signing always uses current. Verification tries current then previous. Unknown secrets rejected. Single-secret mode works.
+
+**Independent Test**: Generate token with old secret. Create ring with new+old. Verify old token succeeds. Verify completely unknown secret fails.
+
+### Tests for User Story 3
+
+- [x] T017 [P] [US3] Write tests for HMACKeyRing: sign with current (position 0), verify succeeds with current, verify succeeds with previous in src/runtime/auth/servicetoken_test.go (TDD: RED)
+- [x] T018 [P] [US3] Write tests for HMACKeyRing: reject unknown secret; single-secret mode (nil previous) works correctly in src/runtime/auth/servicetoken_test.go (TDD: RED)
+- [x] T019 [P] [US3] Write tests for HMACKeyRing edge case: same secret in both positions works (degenerate case) in src/runtime/auth/servicetoken_test.go (TDD: RED)
+
+### Implementation for User Story 3
+
+- [x] T020 [US3] Implement `HMACKeyRing` struct with `Current() []byte` and `Secrets() [][]byte` methods in src/runtime/auth/servicetoken.go (TDD: GREEN for T017, T018, T019)
+- [x] T021 [US3] Update `ServiceTokenMiddleware` to accept `*HMACKeyRing` — try-all-keys verification (current first, then previous) in src/runtime/auth/servicetoken.go
+- [x] T022 [US3] Update `GenerateServiceToken` to accept `*HMACKeyRing` — always sign with Current() in src/runtime/auth/servicetoken.go
+- [x] T023 [US3] Implement `LoadHMACKeyRingFromEnv()` — load `GOCELL_SERVICE_SECRET` + optional `GOCELL_SERVICE_SECRET_PREVIOUS` in src/runtime/auth/servicetoken.go
+- [x] T024 [US3] Write tests for `LoadHMACKeyRingFromEnv`: current-only, current+previous, missing current fails in src/runtime/auth/servicetoken_test.go
+- [x] T025 [US3] Update existing ServiceToken tests in src/runtime/auth/servicetoken_test.go to use HMACKeyRing-based API (fix compilation)
+
+**Checkpoint**: `go test ./src/runtime/auth/... -run TestServiceToken` and `go test ./src/runtime/auth/... -run TestHMAC` all GREEN. Key ring rotation works.
+
+---
+
+## Phase 5: User Story 4 — Key Lifecycle Transitions (Priority: P2)
+
+**Goal**: All key lifecycle transitions (activation, demotion to verification-only, pruning) produce structured slog entries. System fails fast on missing signing key configuration.
+
+**Independent Test**: Create KeySet, trigger lifecycle transitions, capture slog output, verify structured fields (kid, transition type, timestamp) are present.
+
+### Tests for User Story 4
+
+- [x] T026 [P] [US4] Write tests for slog output on KeySet creation (key activation log), verification key addition (demotion log), and pruning (pruning log) in src/runtime/auth/keys_test.go (TDD: RED)
+- [x] T027 [P] [US4] Write tests for fail-fast: NewKeySet with nil key panics or returns error; LoadKeySetFromEnv with missing env var returns clear error in src/runtime/auth/keys_test.go (TDD: RED)
+
+### Implementation for User Story 4
+
+- [x] T028 [US4] Add structured slog.Info logging to KeySet constructor (activation), AddVerificationKey/NewKeySetWithVerificationKeys (demotion), and PruneExpired (pruning) with fields: kid, transition, timestamp in src/runtime/auth/keys.go (TDD: GREEN for T026)
+- [x] T029 [US4] Add fail-fast validation: NewKeySet returns error on nil/invalid key; LoadKeySetFromEnv returns errcode error on missing GOCELL_JWT_PRIVATE_KEY or GOCELL_JWT_PUBLIC_KEY in src/runtime/auth/keys.go (TDD: GREEN for T027)
+
+**Checkpoint**: `go test ./src/runtime/auth/... -run TestLifecycle` and `go test ./src/runtime/auth/... -run TestFailFast` all GREEN. Lifecycle events observable in logs.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update callers, verify full build, ensure coverage.
+
+- [x] T030 [P] Update callers in src/cells/access-core/ to use KeySet-based JWTIssuer/JWTVerifier API
+- [x] T031 [P] Update callers in src/examples/sso-bff/main.go to use KeySet and HMACKeyRing API
+- [x] T032 [P] Update src/adapters/oidc/oidc.go if it references old JWTVerifier constructor
+- [x] T033 Run `go build ./...` — verify zero compilation errors across entire codebase
+- [x] T034 Run `go test ./src/runtime/auth/...` — verify all tests pass, coverage ≥ 80%
+- [x] T035 Run `go vet ./src/runtime/auth/...` — verify no vet warnings
+
+**Checkpoint**: Full codebase compiles. All auth tests pass. Coverage meets threshold.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (Foundational)    ← No dependencies, start immediately
+    │
+    ▼
+Phase 2 (US1: kid in tokens) ← Depends on Phase 1 complete
+    │
+    ▼
+Phase 3 (US2: multi-key)     ← Depends on Phase 2 (US1 introduces KeySet API)
+    │
+    ├──→ Phase 4 (US3: HMAC ring)       ← Independent of US2, depends on Phase 1 only
+    │
+    └──→ Phase 5 (US4: lifecycle logs)   ← Depends on Phase 3 (needs KeySet lifecycle methods)
+              │
+              ▼
+         Phase 6 (Polish)               ← Depends on all user stories complete
+```
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational (Phase 1). No dependency on other stories.
+- **US2 (P1)**: Depends on US1 (Phase 2) — extends the KeySet API introduced by US1.
+- **US3 (P2)**: Depends on Foundational (Phase 1) only. Can run in **parallel** with US1/US2.
+- **US4 (P2)**: Depends on US2 (Phase 3) — logs lifecycle events from KeySet methods.
+
+### Within Each User Story
+
+1. Tests MUST be written first and FAIL (TDD: RED)
+2. Implementation makes tests pass (TDD: GREEN)
+3. Type changes before function changes
+4. Internal API before public API (LoadFromEnv)
+5. Existing test fixup after API changes
+
+### Parallel Opportunities
+
+- **Phase 1**: T001→T002 sequential, T003→T004 sequential, but T001+T003 can start in parallel (different test functions)
+- **Phase 2 (US1)**: T005, T006, T007 can run in parallel (different test functions in same file)
+- **Phase 3 (US2)**: T011, T012, T013 can run in parallel
+- **Phase 4 (US3)**: T017, T018, T019 can run in parallel. **US3 can run in parallel with US1/US2** (different files entirely)
+- **Phase 5 (US4)**: T026, T027 can run in parallel
+- **Phase 6**: T030, T031, T032 can all run in parallel (different files)
+
+---
+
+## Parallel Example: US1 + US3 Concurrent
+
+```text
+# These two stories touch different files and can be worked on simultaneously:
+
+# Developer A: US1 (JWT kid)
+T005: Test JWTIssuer kid header in jwt_test.go
+T006: Test JWTVerifier kid lookup in jwt_test.go
+T007: Test rejection in jwt_test.go
+T008: Update JWTIssuer in jwt.go
+T009: Update JWTVerifier in jwt.go
+
+# Developer B: US3 (HMAC ring) — can start after Phase 1, no dependency on US1
+T017: Test HMACKeyRing sign/verify in servicetoken_test.go
+T018: Test rejection/single-secret in servicetoken_test.go
+T019: Test edge cases in servicetoken_test.go
+T020: Implement HMACKeyRing in servicetoken.go
+T021: Update ServiceTokenMiddleware in servicetoken.go
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Foundational types (T001-T004)
+2. Complete Phase 2: US1 — JWT kid in tokens (T005-T010)
+3. **STOP and VALIDATE**: Issue a token, verify kid is present, round-trip works
+4. This alone enables kid-based key identification — the foundation for all rotation
+
+### Incremental Delivery
+
+1. Phase 1 (Foundational) → Types ready
+2. Phase 2 (US1) → Tokens carry kid → **MVP deployable**
+3. Phase 3 (US2) → Multi-key verification → **Zero-downtime JWT rotation**
+4. Phase 4 (US3) → HMAC key ring → **Zero-downtime service token rotation**
+5. Phase 5 (US4) → Lifecycle logging → **Operational visibility**
+6. Phase 6 (Polish) → Full integration → **Feature complete**
+
+### Test Coverage Target
+
+| File | Target | Method |
+| --- | --- | --- |
+| keys.go | ≥ 85% | Table-driven tests for Thumbprint, KeySet, VerificationKey, LoadKeySetFromEnv |
+| jwt.go | ≥ 80% | Tests for kid header, kid-based verification, rejection paths |
+| servicetoken.go | ≥ 80% | Tests for HMACKeyRing sign/verify, LoadHMACKeyRingFromEnv |
+
+---
+
+## Notes
+
+- All changes are within `src/runtime/auth/` — no new packages or directories
+- No new external dependencies — uses existing `github.com/golang-jwt/jwt/v5` + stdlib `crypto/*`
+- Constitution requires TDD: every test task (RED) must FAIL before its matching implementation task (GREEN)
+- `auth.go` and `middleware.go` are NOT modified — new types integrate behind existing interfaces
+- kid values (SHA-256 thumbprints) are safe to log; secret values MUST NOT appear in logs
+- Commit after each phase checkpoint with Conventional Commits format

--- a/src/cells/access-core/cell_test.go
+++ b/src/cells/access-core/cell_test.go
@@ -19,26 +19,25 @@ import (
 )
 
 var (
-	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
-	testKeySet              *auth.KeySet
-	testIssuer              *auth.JWTIssuer
-	testVerifier            *auth.JWTVerifier
+	testKeySet, testPrivKey, _ = auth.MustNewTestKeySet()
+	testIssuer                 = mustIssuer(testKeySet)
+	testVerifier               = mustVerifier(testKeySet)
 )
 
-func init() {
-	var err error
-	testKeySet, err = auth.NewKeySet(testPrivKey, testPubKey)
+func mustIssuer(ks *auth.KeySet) *auth.JWTIssuer {
+	i, err := auth.NewJWTIssuer(ks, "gocell-access-core", 15*time.Minute)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
-	testIssuer, err = auth.NewJWTIssuer(testKeySet, "gocell-access-core", 15*time.Minute)
+	return i
+}
+
+func mustVerifier(ks *auth.KeySet) *auth.JWTVerifier {
+	v, err := auth.NewJWTVerifier(ks)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
-	testVerifier, err = auth.NewJWTVerifier(testKeySet)
-	if err != nil {
-		panic("test setup: " + err.Error())
-	}
+	return v
 }
 
 // noopWriter is a no-op outbox.Writer for testing.

--- a/src/cells/access-core/cell_test.go
+++ b/src/cells/access-core/cell_test.go
@@ -20,17 +20,22 @@ import (
 
 var (
 	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
+	testKeySet              *auth.KeySet
 	testIssuer              *auth.JWTIssuer
 	testVerifier            *auth.JWTVerifier
 )
 
 func init() {
 	var err error
-	testIssuer, err = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
+	testKeySet, err = auth.NewKeySet(testPrivKey, testPubKey)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
-	testVerifier, err = auth.NewJWTVerifier(testPubKey)
+	testIssuer, err = auth.NewJWTIssuer(testKeySet, "gocell-access-core", 15*time.Minute)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+	testVerifier, err = auth.NewJWTVerifier(testKeySet)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/src/cells/access-core/slices/sessionlogin/service_test.go
+++ b/src/cells/access-core/slices/sessionlogin/service_test.go
@@ -17,13 +17,18 @@ import (
 )
 
 var (
-	testPrivKey, _ = auth.MustGenerateTestKeyPair()
-	testIssuer     *auth.JWTIssuer
+	testPrivKey, testPubKey_ = auth.MustGenerateTestKeyPair()
+	testKeySet_              *auth.KeySet
+	testIssuer               *auth.JWTIssuer
 )
 
 func init() {
 	var err error
-	testIssuer, err = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
+	testKeySet_, err = auth.NewKeySet(testPrivKey, testPubKey_)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+	testIssuer, err = auth.NewJWTIssuer(testKeySet_, "gocell-access-core", 15*time.Minute)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/src/cells/access-core/slices/sessionlogin/service_test.go
+++ b/src/cells/access-core/slices/sessionlogin/service_test.go
@@ -17,18 +17,13 @@ import (
 )
 
 var (
-	testPrivKey, testPubKey_ = auth.MustGenerateTestKeyPair()
-	testKeySet_              *auth.KeySet
-	testIssuer               *auth.JWTIssuer
+	testKeySet, testPrivKey, _ = auth.MustNewTestKeySet()
+	testIssuer                 *auth.JWTIssuer
 )
 
 func init() {
 	var err error
-	testKeySet_, err = auth.NewKeySet(testPrivKey, testPubKey_)
-	if err != nil {
-		panic("test setup: " + err.Error())
-	}
-	testIssuer, err = auth.NewJWTIssuer(testKeySet_, "gocell-access-core", 15*time.Minute)
+	testIssuer, err = auth.NewJWTIssuer(testKeySet, "gocell-access-core", 15*time.Minute)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/src/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/src/cells/access-core/slices/sessionrefresh/service_test.go
@@ -15,17 +15,22 @@ import (
 
 var (
 	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
+	testKeySet              *auth.KeySet
 	testIssuer              *auth.JWTIssuer
 	testVerifier            *auth.JWTVerifier
 )
 
 func init() {
 	var err error
-	testIssuer, err = auth.NewJWTIssuer(testPrivKey, "gocell-access-core", 15*time.Minute)
+	testKeySet, err = auth.NewKeySet(testPrivKey, testPubKey)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
-	testVerifier, err = auth.NewJWTVerifier(testPubKey)
+	testIssuer, err = auth.NewJWTIssuer(testKeySet, "gocell-access-core", 15*time.Minute)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+	testVerifier, err = auth.NewJWTVerifier(testKeySet)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
@@ -136,8 +141,10 @@ func TestService_Refresh_SigningMethodCheck(t *testing.T) {
 	svc, _ := newTestService()
 
 	// Tokens signed with a different key should be rejected by the verifier.
-	otherPriv, _ := auth.MustGenerateTestKeyPair()
-	otherIssuer, err := auth.NewJWTIssuer(otherPriv, "gocell-access-core", time.Hour)
+	otherPriv, otherPub := auth.MustGenerateTestKeyPair()
+	otherKS, err := auth.NewKeySet(otherPriv, otherPub)
+	require.NoError(t, err)
+	otherIssuer, err := auth.NewJWTIssuer(otherKS, "gocell-access-core", time.Hour)
 	require.NoError(t, err)
 	tokenStr, _ := otherIssuer.Issue("usr-1", nil, nil)
 

--- a/src/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/src/cells/access-core/slices/sessionrefresh/service_test.go
@@ -14,18 +14,13 @@ import (
 )
 
 var (
-	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
-	testKeySet              *auth.KeySet
-	testIssuer              *auth.JWTIssuer
-	testVerifier            *auth.JWTVerifier
+	testKeySet, testPrivKey, _ = auth.MustNewTestKeySet()
+	testIssuer                 *auth.JWTIssuer
+	testVerifier               *auth.JWTVerifier
 )
 
 func init() {
 	var err error
-	testKeySet, err = auth.NewKeySet(testPrivKey, testPubKey)
-	if err != nil {
-		panic("test setup: " + err.Error())
-	}
 	testIssuer, err = auth.NewJWTIssuer(testKeySet, "gocell-access-core", 15*time.Minute)
 	if err != nil {
 		panic("test setup: " + err.Error())

--- a/src/cells/access-core/slices/sessionvalidate/helpers_test.go
+++ b/src/cells/access-core/slices/sessionvalidate/helpers_test.go
@@ -1,0 +1,35 @@
+package sessionvalidate
+
+import (
+	"crypto/rsa"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// IssueTestToken creates a signed JWT for testing purposes.
+// An optional sessionID can be provided to include the "sid" claim.
+// signingKey must be *rsa.PrivateKey (RS256). The token includes a kid header
+// derived from the public key via RFC 7638 thumbprint.
+func IssueTestToken(signingKey *rsa.PrivateKey, subject string, roles []string, ttl time.Duration, sessionID ...string) (string, error) {
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"sub": subject,
+		"iat": jwt.NewNumericDate(now),
+		"exp": jwt.NewNumericDate(now.Add(ttl)),
+		"iss": "gocell-access-core",
+		"aud": jwt.ClaimStrings{"gocell"},
+	}
+	if len(roles) > 0 {
+		claims["roles"] = roles
+	}
+	if len(sessionID) > 0 && sessionID[0] != "" {
+		claims["sid"] = sessionID[0]
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = auth.Thumbprint(&signingKey.PublicKey)
+	return token.SignedString(signingKey)
+}

--- a/src/cells/access-core/slices/sessionvalidate/service.go
+++ b/src/cells/access-core/slices/sessionvalidate/service.go
@@ -4,11 +4,7 @@ package sessionvalidate
 
 import (
 	"context"
-	"crypto/rsa"
 	"log/slog"
-	"time"
-
-	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -55,35 +51,3 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 	return claims, nil
 }
 
-// IssueTestToken creates a signed JWT for testing purposes.
-// An optional sessionID can be provided to include the "sid" claim.
-// signingKey can be []byte (HS256) or *rsa.PrivateKey (RS256).
-func IssueTestToken(signingKey any, subject string, roles []string, ttl time.Duration, sessionID ...string) (string, error) {
-	now := time.Now()
-	claims := jwt.MapClaims{
-		"sub": subject,
-		"iat": jwt.NewNumericDate(now),
-		"exp": jwt.NewNumericDate(now.Add(ttl)),
-		"iss": "gocell-access-core",
-		"aud": jwt.ClaimStrings{"gocell"},
-	}
-	if len(roles) > 0 {
-		claims["roles"] = roles
-	}
-	if len(sessionID) > 0 && sessionID[0] != "" {
-		claims["sid"] = sessionID[0]
-	}
-
-	switch k := signingKey.(type) {
-	case *rsa.PrivateKey:
-		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-		token.Header["kid"] = auth.Thumbprint(&k.PublicKey)
-		return token.SignedString(k)
-	case []byte:
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-		return token.SignedString(k)
-	default:
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-		return token.SignedString(signingKey)
-	}
-}

--- a/src/cells/access-core/slices/sessionvalidate/service.go
+++ b/src/cells/access-core/slices/sessionvalidate/service.go
@@ -77,6 +77,7 @@ func IssueTestToken(signingKey any, subject string, roles []string, ttl time.Dur
 	switch k := signingKey.(type) {
 	case *rsa.PrivateKey:
 		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		token.Header["kid"] = auth.Thumbprint(&k.PublicKey)
 		return token.SignedString(k)
 	case []byte:
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/src/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/src/cells/access-core/slices/sessionvalidate/service_test.go
@@ -14,17 +14,12 @@ import (
 )
 
 var (
-	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
-	testKeySet              *auth.KeySet
-	testVerifier            *auth.JWTVerifier
+	testKeySet, testPrivKey, _ = auth.MustNewTestKeySet()
+	testVerifier               *auth.JWTVerifier
 )
 
 func init() {
 	var err error
-	testKeySet, err = auth.NewKeySet(testPrivKey, testPubKey)
-	if err != nil {
-		panic("test setup: " + err.Error())
-	}
 	testVerifier, err = auth.NewJWTVerifier(testKeySet)
 	if err != nil {
 		panic("test setup: " + err.Error())

--- a/src/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/src/cells/access-core/slices/sessionvalidate/service_test.go
@@ -15,12 +15,17 @@ import (
 
 var (
 	testPrivKey, testPubKey = auth.MustGenerateTestKeyPair()
+	testKeySet              *auth.KeySet
 	testVerifier            *auth.JWTVerifier
 )
 
 func init() {
 	var err error
-	testVerifier, err = auth.NewJWTVerifier(testPubKey)
+	testKeySet, err = auth.NewKeySet(testPrivKey, testPubKey)
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+	testVerifier, err = auth.NewJWTVerifier(testKeySet)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/src/examples/sso-bff/main.go
+++ b/src/examples/sso-bff/main.go
@@ -43,6 +43,8 @@ func main() {
 	eb := eventbus.New()
 
 	// RSA key pair for JWT signing/verification (development only).
+	// Production: use auth.LoadKeySetFromEnv() which reads from env vars and
+	// supports key rotation via GOCELL_JWT_PREV_PUBLIC_KEY + GOCELL_JWT_PREV_KEY_EXPIRES.
 	privKey, pubKey := auth.MustGenerateTestKeyPair()
 	keySet, err := auth.NewKeySet(privKey, pubKey)
 	if err != nil {

--- a/src/examples/sso-bff/main.go
+++ b/src/examples/sso-bff/main.go
@@ -44,12 +44,17 @@ func main() {
 
 	// RSA key pair for JWT signing/verification (development only).
 	privKey, pubKey := auth.MustGenerateTestKeyPair()
-	jwtIssuer, err := auth.NewJWTIssuer(privKey, "sso-bff-dev", 15*time.Minute)
+	keySet, err := auth.NewKeySet(privKey, pubKey)
+	if err != nil {
+		logger.Error("failed to create key set", slog.Any("error", err))
+		os.Exit(1)
+	}
+	jwtIssuer, err := auth.NewJWTIssuer(keySet, "sso-bff-dev", 15*time.Minute)
 	if err != nil {
 		logger.Error("failed to create JWT issuer", slog.Any("error", err))
 		os.Exit(1)
 	}
-	jwtVerifier, err := auth.NewJWTVerifier(pubKey)
+	jwtVerifier, err := auth.NewJWTVerifier(keySet)
 	if err != nil {
 		logger.Error("failed to create JWT verifier", slog.Any("error", err))
 		os.Exit(1)

--- a/src/runtime/auth/jwt.go
+++ b/src/runtime/auth/jwt.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"crypto/rsa"
 	"fmt"
 	"time"
 
@@ -15,29 +14,44 @@ import (
 // ref: go-kratos/kratos middleware/auth/jwt/jwt.go -- JWT middleware pattern
 // Adopted: KeyFunc-based verification, Claims extraction from context.
 // Deviated: RS256 pinned (no configurable signing method), refuses HS256/none.
+// Extended: kid-based key lookup from KeySet (RFC 7638 thumbprint).
 type JWTVerifier struct {
-	publicKey *rsa.PublicKey
+	keySet *KeySet
 }
 
-// NewJWTVerifier creates a JWTVerifier that validates tokens using the given
-// RSA public key with RS256 algorithm pinning.
-// It returns an error if the public key is smaller than MinRSAKeyBits (2048).
-func NewJWTVerifier(publicKey *rsa.PublicKey) (*JWTVerifier, error) {
-	if err := validateRSAKeySize(publicKey.N.BitLen(), "public"); err != nil {
-		return nil, err
+// NewJWTVerifier creates a JWTVerifier that validates tokens by looking up the
+// signing key from the KeySet using the token's kid header.
+func NewJWTVerifier(keySet *KeySet) (*JWTVerifier, error) {
+	if keySet == nil {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "key set must not be nil")
 	}
-	return &JWTVerifier{publicKey: publicKey}, nil
+	return &JWTVerifier{keySet: keySet}, nil
 }
 
 // Verify validates the token string and returns Claims on success.
-// It rejects tokens that are not signed with RS256.
+// It rejects tokens that are not signed with RS256 or do not carry a valid kid.
 func (v *JWTVerifier) Verify(_ context.Context, tokenStr string) (Claims, error) {
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (any, error) {
 		// Pin to RS256 only -- reject HS256, none, and all other algorithms.
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
-		return v.publicKey, nil
+
+		// Extract kid from token header.
+		kidRaw, ok := token.Header["kid"]
+		if !ok {
+			return nil, fmt.Errorf("missing kid header")
+		}
+		kid, ok := kidRaw.(string)
+		if !ok || kid == "" {
+			return nil, fmt.Errorf("invalid kid header")
+		}
+
+		pub, err := v.keySet.PublicKeyByKID(kid)
+		if err != nil {
+			return nil, fmt.Errorf("unknown kid: %s", kid)
+		}
+		return pub, nil
 	})
 	if err != nil {
 		return Claims{}, errcode.Wrap(errcode.ErrAuthUnauthorized, "token verification failed", err)
@@ -54,27 +68,28 @@ func (v *JWTVerifier) Verify(_ context.Context, tokenStr string) (Claims, error)
 	return mapClaimsToClaims(mapClaims), nil
 }
 
-// JWTIssuer signs JWT tokens with RS256 using an RSA private key.
+// JWTIssuer signs JWT tokens with RS256 using the active key from a KeySet.
+// Each issued token carries a kid header derived from the signing key.
 type JWTIssuer struct {
-	privateKey *rsa.PrivateKey
-	issuer     string
-	ttl        time.Duration
+	keySet *KeySet
+	issuer string
+	ttl    time.Duration
 }
 
-// NewJWTIssuer creates a JWTIssuer.
-// It returns an error if the private key is smaller than MinRSAKeyBits (2048).
-func NewJWTIssuer(privateKey *rsa.PrivateKey, issuer string, ttl time.Duration) (*JWTIssuer, error) {
-	if err := validateRSAKeySize(privateKey.N.BitLen(), "private"); err != nil {
-		return nil, err
+// NewJWTIssuer creates a JWTIssuer using the active signing key from the KeySet.
+func NewJWTIssuer(keySet *KeySet, issuer string, ttl time.Duration) (*JWTIssuer, error) {
+	if keySet == nil {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "key set must not be nil")
 	}
 	return &JWTIssuer{
-		privateKey: privateKey,
-		issuer:     issuer,
-		ttl:        ttl,
+		keySet: keySet,
+		issuer: issuer,
+		ttl:    ttl,
 	}, nil
 }
 
 // Issue creates a signed JWT token for the given subject and roles.
+// The token header includes the kid of the active signing key.
 func (i *JWTIssuer) Issue(subject string, roles []string, audience []string) (string, error) {
 	now := time.Now()
 	claims := jwt.MapClaims{
@@ -91,7 +106,8 @@ func (i *JWTIssuer) Issue(subject string, roles []string, audience []string) (st
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	return token.SignedString(i.privateKey)
+	token.Header["kid"] = i.keySet.SigningKeyID()
+	return token.SignedString(i.keySet.SigningKey())
 }
 
 func mapClaimsToClaims(mc jwt.MapClaims) Claims {

--- a/src/runtime/auth/jwt_test.go
+++ b/src/runtime/auth/jwt_test.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,11 +23,119 @@ func generateTestKeyPair(t *testing.T) (*rsa.PrivateKey, *rsa.PublicKey) {
 	return key, &key.PublicKey
 }
 
-func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
+func mustTestKeySet(t *testing.T) *KeySet {
+	t.Helper()
 	priv, pub := generateTestKeyPair(t)
-	issuer, err := NewJWTIssuer(priv, "gocell", time.Hour)
+	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(pub)
+	return ks
+}
+
+// --- Phase 2: User Story 1 (T005-T010) ---
+
+func TestJWTIssuer_TokenHasKID(t *testing.T) {
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.NoError(t, err)
+
+	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	require.NoError(t, err)
+
+	// Decode the token header to check kid.
+	parts := strings.SplitN(tokenStr, ".", 3)
+	require.Len(t, parts, 3)
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(headerJSON), `"kid"`)
+	assert.Contains(t, string(headerJSON), ks.SigningKeyID())
+}
+
+func TestJWTIssuer_KIDMatchesThumbprint(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	ks, err := NewKeySet(priv, pub)
+	require.NoError(t, err)
+
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.NoError(t, err)
+
+	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	require.NoError(t, err)
+
+	// Parse without verification to inspect header.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+	require.NoError(t, err)
+
+	kid, ok := token.Header["kid"].(string)
+	require.True(t, ok)
+	assert.Equal(t, Thumbprint(pub), kid)
+}
+
+func TestJWTVerifier_VerifiesByKID(t *testing.T) {
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(ks)
+	require.NoError(t, err)
+
+	tokenStr, err := issuer.Issue("user-1", []string{"admin"}, []string{"api"})
+	require.NoError(t, err)
+
+	claims, err := verifier.Verify(context.Background(), tokenStr)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims.Subject)
+	assert.Equal(t, "gocell", claims.Issuer)
+	assert.Equal(t, []string{"admin"}, claims.Roles)
+	assert.Equal(t, []string{"api"}, claims.Audience)
+}
+
+func TestJWTVerifier_RejectsUnknownKID(t *testing.T) {
+	ks1 := mustTestKeySet(t)
+	ks2 := mustTestKeySet(t)
+
+	issuer, err := NewJWTIssuer(ks1, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(ks2) // different key set
+	require.NoError(t, err)
+
+	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	require.NoError(t, err)
+
+	_, err = verifier.Verify(context.Background(), tokenStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
+}
+
+func TestJWTVerifier_RejectsMissingKID(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	ks, err := NewKeySet(priv, pub)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(ks)
+	require.NoError(t, err)
+
+	// Create a token WITHOUT kid header (legacy-style).
+	claims := jwt.MapClaims{
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	// Deliberately do NOT set token.Header["kid"]
+	tokenStr, err := token.SignedString(priv)
+	require.NoError(t, err)
+
+	_, err = verifier.Verify(context.Background(), tokenStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
+}
+
+// --- Updated existing tests ---
+
+func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-1", []string{"admin", "user"}, []string{"api"})
@@ -42,10 +152,10 @@ func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
 }
 
 func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
-	priv, pub := generateTestKeyPair(t)
-	issuer, err := NewJWTIssuer(priv, "gocell", -time.Hour) // already expired
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", -time.Hour) // already expired
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(pub)
+	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-1", nil, nil)
@@ -57,9 +167,8 @@ func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
 }
 
 func TestJWTVerifier_RejectsHS256(t *testing.T) {
-	// Create HS256 token and verify it is rejected by RS256 verifier.
-	_, pub := generateTestKeyPair(t)
-	verifier, err := NewJWTVerifier(pub)
+	ks := mustTestKeySet(t)
+	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
 	hmacToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
@@ -75,11 +184,10 @@ func TestJWTVerifier_RejectsHS256(t *testing.T) {
 }
 
 func TestJWTVerifier_RejectsAlgNone(t *testing.T) {
-	_, pub := generateTestKeyPair(t)
-	verifier, err := NewJWTVerifier(pub)
+	ks := mustTestKeySet(t)
+	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
-	// Create an unsigned token with alg=none.
 	noneToken := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
 		"sub": "attacker",
 		"exp": time.Now().Add(time.Hour).Unix(),
@@ -93,11 +201,12 @@ func TestJWTVerifier_RejectsAlgNone(t *testing.T) {
 }
 
 func TestJWTVerifier_WrongKey(t *testing.T) {
-	priv1, _ := generateTestKeyPair(t)
-	_, pub2 := generateTestKeyPair(t) // different key pair
-	issuer, err := NewJWTIssuer(priv1, "gocell", time.Hour)
+	ks1 := mustTestKeySet(t)
+	ks2 := mustTestKeySet(t)
+
+	issuer, err := NewJWTIssuer(ks1, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(pub2)
+	verifier, err := NewJWTVerifier(ks2)
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-1", nil, nil)
@@ -108,8 +217,8 @@ func TestJWTVerifier_WrongKey(t *testing.T) {
 }
 
 func TestJWTVerifier_MalformedToken(t *testing.T) {
-	_, pub := generateTestKeyPair(t)
-	verifier, err := NewJWTVerifier(pub)
+	ks := mustTestKeySet(t)
+	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
 	_, err = verifier.Verify(context.Background(), "not.a.jwt")
@@ -117,10 +226,10 @@ func TestJWTVerifier_MalformedToken(t *testing.T) {
 }
 
 func TestJWTIssuer_RoundTrip(t *testing.T) {
-	priv, pub := generateTestKeyPair(t)
-	issuer, err := NewJWTIssuer(priv, "test-issuer", 30*time.Minute)
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "test-issuer", 30*time.Minute)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(pub)
+	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("svc-audit", []string{"service"}, []string{"internal"})
@@ -135,10 +244,10 @@ func TestJWTIssuer_RoundTrip(t *testing.T) {
 }
 
 func TestJWTIssuer_NoRolesNoAudience(t *testing.T) {
-	priv, pub := generateTestKeyPair(t)
-	issuer, err := NewJWTIssuer(priv, "gocell", time.Hour)
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(pub)
+	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue("user-2", nil, nil)
@@ -151,26 +260,65 @@ func TestJWTIssuer_NoRolesNoAudience(t *testing.T) {
 	assert.Empty(t, claims.Audience)
 }
 
-func TestNewJWTVerifier_RejectsWeakKey(t *testing.T) {
-	// Generate a 1024-bit RSA key (below MinRSAKeyBits).
-	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
-	require.NoError(t, err)
-
-	_, err = NewJWTVerifier(&weakKey.PublicKey)
+func TestNewJWTVerifier_NilKeySetReturnsError(t *testing.T) {
+	_, err := NewJWTVerifier(nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
-	assert.Contains(t, err.Error(), "1024")
 }
 
-func TestNewJWTIssuer_RejectsWeakKey(t *testing.T) {
-	// Generate a 1024-bit RSA key (below MinRSAKeyBits).
-	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
-	require.NoError(t, err)
-
-	_, err = NewJWTIssuer(weakKey, "gocell", time.Hour)
+func TestNewJWTIssuer_NilKeySetReturnsError(t *testing.T) {
+	_, err := NewJWTIssuer(nil, "gocell", time.Hour)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
-	assert.Contains(t, err.Error(), "1024")
+}
+
+// --- Multi-key verification (US2 via JWT) ---
+
+func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {
+	// Key pair 1: the OLD key (will become verification-only).
+	priv1, pub1 := generateTestKeyPair(t)
+	// Key pair 2: the NEW active key.
+	priv2, pub2 := generateTestKeyPair(t)
+
+	// Build a KeySet with key2 as active, key1 as verification-only.
+	vk := VerificationKey{
+		PublicKey: pub1,
+		KeyID:     Thumbprint(pub1),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	ks, err := NewKeySetWithVerificationKeys(priv2, pub2, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	// Issue a token signed with the OLD key (key1), adding kid manually.
+	oldClaims := jwt.MapClaims{
+		"sub": "user-old",
+		"iss": "gocell",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	}
+	oldToken := jwt.NewWithClaims(jwt.SigningMethodRS256, oldClaims)
+	oldToken.Header["kid"] = Thumbprint(pub1)
+	oldTokenStr, err := oldToken.SignedString(priv1)
+	require.NoError(t, err)
+
+	// Verifier using the new KeySet should still accept the old token.
+	verifier, err := NewJWTVerifier(ks)
+	require.NoError(t, err)
+
+	claims, err := verifier.Verify(context.Background(), oldTokenStr)
+	require.NoError(t, err)
+	assert.Equal(t, "user-old", claims.Subject)
+
+	// New tokens use the new key.
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.NoError(t, err)
+
+	newTokenStr, err := issuer.Issue("user-new", nil, nil)
+	require.NoError(t, err)
+
+	claims, err = verifier.Verify(context.Background(), newTokenStr)
+	require.NoError(t, err)
+	assert.Equal(t, "user-new", claims.Subject)
 }
 
 func TestLoadKeysFromEnv_PKCS8(t *testing.T) {

--- a/src/runtime/auth/keys.go
+++ b/src/runtime/auth/keys.go
@@ -189,6 +189,17 @@ func MustGenerateTestKeyPair() (*rsa.PrivateKey, *rsa.PublicKey) {
 	return priv, &priv.PublicKey
 }
 
+// MustNewTestKeySet creates a KeySet from a freshly generated 2048-bit RSA
+// key pair. It panics on error. Intended for test setup and examples only.
+func MustNewTestKeySet() (*KeySet, *rsa.PrivateKey, *rsa.PublicKey) {
+	priv, pub := MustGenerateTestKeyPair()
+	ks, err := NewKeySet(priv, pub)
+	if err != nil {
+		panic(fmt.Sprintf("auth: failed to create test key set: %v", err))
+	}
+	return ks, priv, pub
+}
+
 // LoadRSAKeyPairFromPEM parses PEM-encoded RSA private and public keys.
 func LoadRSAKeyPairFromPEM(privPEM, pubPEM []byte) (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	priv, err := parseRSAPrivateKey(privPEM)
@@ -280,7 +291,7 @@ func LoadKeySetFromEnv() (*KeySet, error) {
 	expiresAt, err := time.Parse(time.RFC3339, expiresStr)
 	if err != nil {
 		return nil, errcode.Wrap(errcode.ErrAuthKeyInvalid,
-			fmt.Sprintf("failed to parse %s as RFC 3339", EnvJWTPrevKeyExpires), err)
+			fmt.Sprintf("failed to parse %s as RFC 3339 (example: 2026-04-12T00:00:00Z)", EnvJWTPrevKeyExpires), err)
 	}
 
 	vk := VerificationKey{

--- a/src/runtime/auth/keys.go
+++ b/src/runtime/auth/keys.go
@@ -59,13 +59,14 @@ type VerificationKey struct {
 //
 // ref: dexidp/dex server/rotation.go — 3-state model (Active → Verification-only → Pruned)
 type KeySet struct {
-	mu               sync.Mutex
+	mu               sync.RWMutex
 	signingKey       *rsa.PrivateKey
 	signingPub       *rsa.PublicKey
 	signingKeyID     string
 	verificationKeys []VerificationKey
 	keyIndex         map[string]*rsa.PublicKey // kid → public key
-	now              func() time.Time         // injectable clock for testing; defaults to time.Now
+	keyExpiry        map[string]time.Time      // kid → expiry (signing key absent = never expires)
+	now              func() time.Time          // injectable clock for testing; defaults to time.Now
 }
 
 // NewKeySet creates a KeySet with a single active signing key pair.
@@ -78,12 +79,22 @@ func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey) (*KeySet, error) {
 		return nil, err
 	}
 
+	// Verify that private and public keys form a valid pair.
+	// Without this check, misconfigured key pairs would silently issue
+	// tokens that can never be verified — violating the fail-fast invariant.
+	derivedPub := &priv.PublicKey
+	if derivedPub.N.Cmp(pub.N) != 0 || derivedPub.E != pub.E {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid,
+			"private and public keys do not form a valid pair")
+	}
+
 	kid := Thumbprint(pub)
 	ks := &KeySet{
 		signingKey:   priv,
 		signingPub:   pub,
 		signingKeyID: kid,
 		keyIndex:     map[string]*rsa.PublicKey{kid: pub},
+		keyExpiry:    make(map[string]time.Time),
 		now:          time.Now,
 	}
 
@@ -116,6 +127,7 @@ func NewKeySetWithVerificationKeys(priv *rsa.PrivateKey, pub *rsa.PublicKey, vke
 		}
 		ks.verificationKeys = append(ks.verificationKeys, vk)
 		ks.keyIndex[vk.KeyID] = vk.PublicKey
+		ks.keyExpiry[vk.KeyID] = vk.ExpiresAt
 		slog.Info("key demoted to verification-only",
 			slog.String("kid", vk.KeyID),
 			slog.String("transition", "verification-only"),
@@ -136,32 +148,41 @@ func (ks *KeySet) SigningKey() *rsa.PrivateKey {
 	return ks.signingKey
 }
 
-// PublicKeyByKID looks up a public key by its kid. It lazily prunes expired
-// verification keys before lookup (write side-effect: expired keys are removed
-// from the key set). Returns an error if the kid is unknown or expired.
-// This method is safe for concurrent use.
+// PublicKeyByKID looks up a public key by its kid. For verification-only keys,
+// it checks the expiry time and rejects expired keys. This method is a pure-read
+// operation — it does not mutate internal state. Safe for concurrent use.
+//
+// ref: dexidp/dex, hashicorp/vault, gravitational/teleport — all keep the
+// verification/lookup path read-only; lifecycle mutations happen at the
+// rotation/loading boundary, not on every request.
 func (ks *KeySet) PublicKeyByKID(kid string) (*rsa.PublicKey, error) {
-	ks.mu.Lock()
-	defer ks.mu.Unlock()
-	ks.pruneExpiredLocked()
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
 	pub, ok := ks.keyIndex[kid]
 	if !ok {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, fmt.Sprintf("unknown kid: %s", kid))
 	}
+
+	// Signing key has no entry in keyExpiry — it never expires.
+	// Verification keys are checked against their expiry.
+	if exp, isVerification := ks.keyExpiry[kid]; isVerification {
+		if !ks.now().Before(exp) {
+			return nil, errcode.New(errcode.ErrAuthKeyInvalid, fmt.Sprintf("kid %s has expired", kid))
+		}
+	}
+
 	return pub, nil
 }
 
-// PruneExpired removes verification-only keys whose expiry time has passed.
-// This method is safe for concurrent use.
+// PruneExpired removes verification-only keys whose expiry time has passed
+// from the internal maps. This is an explicit cleanup operation — call it at
+// rotation boundaries or during maintenance, not on the request path.
+// Safe for concurrent use.
 func (ks *KeySet) PruneExpired() {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
-	ks.pruneExpiredLocked()
-}
 
-// pruneExpiredLocked is the lock-free inner implementation of PruneExpired.
-// Caller must hold ks.mu.
-func (ks *KeySet) pruneExpiredLocked() {
 	now := ks.now()
 	remaining := ks.verificationKeys[:0]
 	for _, vk := range ks.verificationKeys {
@@ -169,6 +190,7 @@ func (ks *KeySet) pruneExpiredLocked() {
 			remaining = append(remaining, vk)
 		} else {
 			delete(ks.keyIndex, vk.KeyID)
+			delete(ks.keyExpiry, vk.KeyID)
 			slog.Info("key pruned",
 				slog.String("kid", vk.KeyID),
 				slog.String("transition", "pruned"),

--- a/src/runtime/auth/keys.go
+++ b/src/runtime/auth/keys.go
@@ -3,10 +3,15 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
+	"math/big"
 	"os"
+	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
@@ -23,6 +28,136 @@ func validateRSAKeySize(n int, keyKind string) error {
 			fmt.Sprintf("RSA %s key size %d bits is below the minimum %d bits", keyKind, n, MinRSAKeyBits))
 	}
 	return nil
+}
+
+// Thumbprint computes the RFC 7638 JSON Web Key (JWK) Thumbprint of an RSA
+// public key using SHA-256. The result is a base64url-encoded (no padding)
+// hash that serves as a deterministic key identifier (kid).
+//
+// ref: RFC 7638 §3.2 — required members for RSA in lexicographic order: "e", "kty", "n"
+func Thumbprint(pub *rsa.PublicKey) string {
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	canonical := fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s"}`, e, n)
+	hash := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// VerificationKey is a previously active signing key that has been demoted.
+// It retains the public key for token validation during the grace period.
+type VerificationKey struct {
+	PublicKey *rsa.PublicKey
+	KeyID     string
+	ExpiresAt time.Time
+}
+
+// KeySet holds a set of cryptographic keys for JWT operations: one active
+// signing key and zero or more verification-only keys. It provides O(1)
+// key lookup by kid (key identifier).
+//
+// ref: dexidp/dex server/rotation.go — 3-state model (Active → Verification-only → Pruned)
+type KeySet struct {
+	signingKey       *rsa.PrivateKey
+	signingPub       *rsa.PublicKey
+	signingKeyID     string
+	verificationKeys []VerificationKey
+	keyIndex         map[string]*rsa.PublicKey // kid → public key
+}
+
+// NewKeySet creates a KeySet with a single active signing key pair.
+// The kid is derived deterministically from the public key using RFC 7638.
+func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey) (*KeySet, error) {
+	if priv == nil || pub == nil {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "signing key pair must not be nil")
+	}
+	if err := validateRSAKeySize(pub.N.BitLen(), "public"); err != nil {
+		return nil, err
+	}
+
+	kid := Thumbprint(pub)
+	ks := &KeySet{
+		signingKey:   priv,
+		signingPub:   pub,
+		signingKeyID: kid,
+		keyIndex:     map[string]*rsa.PublicKey{kid: pub},
+	}
+
+	slog.Info("key activated",
+		slog.String("kid", kid),
+		slog.String("transition", "activated"),
+	)
+
+	return ks, nil
+}
+
+// NewKeySetWithVerificationKeys creates a KeySet with an active signing key
+// and one or more verification-only keys. Keys that are already expired at
+// construction time are pruned immediately.
+func NewKeySetWithVerificationKeys(priv *rsa.PrivateKey, pub *rsa.PublicKey, vkeys []VerificationKey) (*KeySet, error) {
+	ks, err := NewKeySet(priv, pub)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	for _, vk := range vkeys {
+		if !now.Before(vk.ExpiresAt) {
+			slog.Info("key pruned",
+				slog.String("kid", vk.KeyID),
+				slog.String("transition", "pruned"),
+				slog.String("reason", "already expired at load time"),
+			)
+			continue
+		}
+		ks.verificationKeys = append(ks.verificationKeys, vk)
+		ks.keyIndex[vk.KeyID] = vk.PublicKey
+		slog.Info("key demoted to verification-only",
+			slog.String("kid", vk.KeyID),
+			slog.String("transition", "verification-only"),
+			slog.Time("expiresAt", vk.ExpiresAt),
+		)
+	}
+
+	return ks, nil
+}
+
+// SigningKeyID returns the kid of the active signing key.
+func (ks *KeySet) SigningKeyID() string {
+	return ks.signingKeyID
+}
+
+// SigningKey returns the active private key for signing.
+func (ks *KeySet) SigningKey() *rsa.PrivateKey {
+	return ks.signingKey
+}
+
+// PublicKeyByKID looks up a public key by its kid. It prunes expired
+// verification keys before lookup. Returns an error if the kid is unknown.
+func (ks *KeySet) PublicKeyByKID(kid string) (*rsa.PublicKey, error) {
+	ks.PruneExpired()
+	pub, ok := ks.keyIndex[kid]
+	if !ok {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, fmt.Sprintf("unknown kid: %s", kid))
+	}
+	return pub, nil
+}
+
+// PruneExpired removes verification-only keys whose expiry time has passed.
+func (ks *KeySet) PruneExpired() {
+	now := time.Now()
+	remaining := ks.verificationKeys[:0]
+	for _, vk := range ks.verificationKeys {
+		if now.Before(vk.ExpiresAt) {
+			remaining = append(remaining, vk)
+		} else {
+			delete(ks.keyIndex, vk.KeyID)
+			slog.Info("key pruned",
+				slog.String("kid", vk.KeyID),
+				slog.String("transition", "pruned"),
+			)
+		}
+	}
+	ks.verificationKeys = remaining
 }
 
 // MustGenerateTestKeyPair generates a 2048-bit RSA key pair for testing.
@@ -54,6 +189,10 @@ const (
 	EnvJWTPrivateKey = "GOCELL_JWT_PRIVATE_KEY"
 	// EnvJWTPublicKey is the environment variable for the PEM-encoded RSA public key.
 	EnvJWTPublicKey = "GOCELL_JWT_PUBLIC_KEY"
+	// EnvJWTPrevPublicKey is the environment variable for the previous (verification-only) public key.
+	EnvJWTPrevPublicKey = "GOCELL_JWT_PREV_PUBLIC_KEY"
+	// EnvJWTPrevKeyExpires is the environment variable for the expiry of the previous key (RFC 3339).
+	EnvJWTPrevKeyExpires = "GOCELL_JWT_PREV_KEY_EXPIRES"
 )
 
 // ErrKeyMissing indicates a required JWT key environment variable is not set.
@@ -88,6 +227,48 @@ func LoadKeysFromEnv() (privateKey *rsa.PrivateKey, publicKey *rsa.PublicKey, er
 	}
 
 	return privateKey, publicKey, nil
+}
+
+// LoadKeySetFromEnv loads a KeySet from environment variables. It reads the
+// active key pair from GOCELL_JWT_PRIVATE_KEY / GOCELL_JWT_PUBLIC_KEY, and
+// optionally loads a verification-only key from GOCELL_JWT_PREV_PUBLIC_KEY
+// with expiry from GOCELL_JWT_PREV_KEY_EXPIRES (RFC 3339).
+func LoadKeySetFromEnv() (*KeySet, error) {
+	priv, pub, err := LoadKeysFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	prevPubPEM := os.Getenv(EnvJWTPrevPublicKey)
+	if prevPubPEM == "" {
+		return NewKeySet(priv, pub)
+	}
+
+	prevPub, err := parseRSAPublicKey([]byte(prevPubPEM))
+	if err != nil {
+		return nil, errcode.Wrap(errcode.ErrAuthKeyInvalid,
+			fmt.Sprintf("failed to parse %s", EnvJWTPrevPublicKey), err)
+	}
+
+	expiresStr := os.Getenv(EnvJWTPrevKeyExpires)
+	if expiresStr == "" {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid,
+			fmt.Sprintf("%s is set but %s is missing", EnvJWTPrevPublicKey, EnvJWTPrevKeyExpires))
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, expiresStr)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.ErrAuthKeyInvalid,
+			fmt.Sprintf("failed to parse %s as RFC 3339", EnvJWTPrevKeyExpires), err)
+	}
+
+	vk := VerificationKey{
+		PublicKey: prevPub,
+		KeyID:     Thumbprint(prevPub),
+		ExpiresAt: expiresAt,
+	}
+
+	return NewKeySetWithVerificationKeys(priv, pub, []VerificationKey{vk})
 }
 
 func parseRSAPrivateKey(pemData []byte) (*rsa.PrivateKey, error) {

--- a/src/runtime/auth/keys.go
+++ b/src/runtime/auth/keys.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"math/big"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -31,8 +32,9 @@ func validateRSAKeySize(n int, keyKind string) error {
 }
 
 // Thumbprint computes the RFC 7638 JSON Web Key (JWK) Thumbprint of an RSA
-// public key using SHA-256. The result is a base64url-encoded (no padding)
-// hash that serves as a deterministic key identifier (kid).
+// public key using SHA-256. The result is a 43-character base64url-encoded
+// (no padding) string derived from the SHA-256 hash of the canonical JWK
+// representation. The same key always produces the same thumbprint.
 //
 // ref: RFC 7638 §3.2 — required members for RSA in lexicographic order: "e", "kty", "n"
 func Thumbprint(pub *rsa.PublicKey) string {
@@ -53,15 +55,17 @@ type VerificationKey struct {
 
 // KeySet holds a set of cryptographic keys for JWT operations: one active
 // signing key and zero or more verification-only keys. It provides O(1)
-// key lookup by kid (key identifier).
+// key lookup by kid (key identifier). All methods are safe for concurrent use.
 //
 // ref: dexidp/dex server/rotation.go — 3-state model (Active → Verification-only → Pruned)
 type KeySet struct {
+	mu               sync.Mutex
 	signingKey       *rsa.PrivateKey
 	signingPub       *rsa.PublicKey
 	signingKeyID     string
 	verificationKeys []VerificationKey
 	keyIndex         map[string]*rsa.PublicKey // kid → public key
+	now              func() time.Time         // injectable clock for testing; defaults to time.Now
 }
 
 // NewKeySet creates a KeySet with a single active signing key pair.
@@ -80,6 +84,7 @@ func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey) (*KeySet, error) {
 		signingPub:   pub,
 		signingKeyID: kid,
 		keyIndex:     map[string]*rsa.PublicKey{kid: pub},
+		now:          time.Now,
 	}
 
 	slog.Info("key activated",
@@ -99,7 +104,7 @@ func NewKeySetWithVerificationKeys(priv *rsa.PrivateKey, pub *rsa.PublicKey, vke
 		return nil, err
 	}
 
-	now := time.Now()
+	now := ks.now()
 	for _, vk := range vkeys {
 		if !now.Before(vk.ExpiresAt) {
 			slog.Info("key pruned",
@@ -131,10 +136,14 @@ func (ks *KeySet) SigningKey() *rsa.PrivateKey {
 	return ks.signingKey
 }
 
-// PublicKeyByKID looks up a public key by its kid. It prunes expired
-// verification keys before lookup. Returns an error if the kid is unknown.
+// PublicKeyByKID looks up a public key by its kid. It lazily prunes expired
+// verification keys before lookup (write side-effect: expired keys are removed
+// from the key set). Returns an error if the kid is unknown or expired.
+// This method is safe for concurrent use.
 func (ks *KeySet) PublicKeyByKID(kid string) (*rsa.PublicKey, error) {
-	ks.PruneExpired()
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	ks.pruneExpiredLocked()
 	pub, ok := ks.keyIndex[kid]
 	if !ok {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, fmt.Sprintf("unknown kid: %s", kid))
@@ -143,8 +152,17 @@ func (ks *KeySet) PublicKeyByKID(kid string) (*rsa.PublicKey, error) {
 }
 
 // PruneExpired removes verification-only keys whose expiry time has passed.
+// This method is safe for concurrent use.
 func (ks *KeySet) PruneExpired() {
-	now := time.Now()
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	ks.pruneExpiredLocked()
+}
+
+// pruneExpiredLocked is the lock-free inner implementation of PruneExpired.
+// Caller must hold ks.mu.
+func (ks *KeySet) pruneExpiredLocked() {
+	now := ks.now()
 	remaining := ks.verificationKeys[:0]
 	for _, vk := range ks.verificationKeys {
 		if now.Before(vk.ExpiresAt) {
@@ -160,9 +178,9 @@ func (ks *KeySet) PruneExpired() {
 	ks.verificationKeys = remaining
 }
 
-// MustGenerateTestKeyPair generates a 2048-bit RSA key pair for testing.
-// It panics on error, following the Go test helper convention (e.g., template.Must).
-// Do NOT use in production code.
+// MustGenerateTestKeyPair generates a 2048-bit RSA key pair for testing and
+// examples. It panics on error, following the Go test helper convention.
+// Production code should use LoadKeySetFromEnv to load keys from configuration.
 func MustGenerateTestKeyPair() (*rsa.PrivateKey, *rsa.PublicKey) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -198,6 +216,9 @@ const (
 // ErrKeyMissing indicates a required JWT key environment variable is not set.
 var ErrKeyMissing = errcode.ErrAuthKeyMissing
 
+// Deprecated: Use LoadKeySetFromEnv instead, which returns a KeySet with
+// kid support and optional verification-only key loading.
+//
 // LoadKeysFromEnv reads PEM-encoded RSA keys from environment variables
 // GOCELL_JWT_PRIVATE_KEY and GOCELL_JWT_PUBLIC_KEY. It returns an errcode
 // error if either variable is missing or contains invalid PEM/key data.

--- a/src/runtime/auth/keys_test.go
+++ b/src/runtime/auth/keys_test.go
@@ -1,17 +1,385 @@
 package auth
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// --- Phase 1: Foundational (T001-T004) ---
+
+func TestThumbprint_Deterministic(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	_ = priv
+
+	kid1 := Thumbprint(pub)
+	kid2 := Thumbprint(pub)
+	assert.Equal(t, kid1, kid2, "same key must produce same thumbprint")
+	assert.NotEmpty(t, kid1)
+}
+
+func TestThumbprint_DifferentKeys(t *testing.T) {
+	_, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	kid1 := Thumbprint(pub1)
+	kid2 := Thumbprint(pub2)
+	assert.NotEqual(t, kid1, kid2, "different keys must produce different thumbprints")
+}
+
+func TestThumbprint_Base64URLEncoded(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	kid := Thumbprint(pub)
+
+	// Base64url uses no padding and only URL-safe characters.
+	assert.NotContains(t, kid, "+")
+	assert.NotContains(t, kid, "/")
+	assert.NotContains(t, kid, "=")
+}
+
+func TestNewKeySet_SingleKey(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+
+	ks, err := NewKeySet(priv, pub)
+	require.NoError(t, err)
+	assert.NotNil(t, ks)
+	assert.Equal(t, Thumbprint(pub), ks.SigningKeyID())
+	assert.Equal(t, priv, ks.SigningKey())
+}
+
+func TestNewKeySet_PublicKeyByKID(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+
+	ks, err := NewKeySet(priv, pub)
+	require.NoError(t, err)
+
+	got, err := ks.PublicKeyByKID(ks.SigningKeyID())
+	require.NoError(t, err)
+	assert.Equal(t, pub, got)
+}
+
+func TestNewKeySet_UnknownKID(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+
+	ks, err := NewKeySet(priv, pub)
+	require.NoError(t, err)
+
+	_, err = ks.PublicKeyByKID("nonexistent-kid")
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code)
+}
+
+func TestNewKeySet_NilKeyReturnsError(t *testing.T) {
+	_, err := NewKeySet(nil, nil)
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code)
+}
+
+func TestNewKeySet_WeakKeyReturnsError(t *testing.T) {
+	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	_, err = NewKeySet(weakKey, &weakKey.PublicKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1024")
+}
+
+// --- Phase 3: User Story 2 (T011-T016) ---
+
+func TestKeySet_VerificationKeyLookup(t *testing.T) {
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	// Can look up verification key by kid.
+	got, err := ks.PublicKeyByKID(vk.KeyID)
+	require.NoError(t, err)
+	assert.Equal(t, pub2, got)
+
+	// Can still look up signing key.
+	got, err = ks.PublicKeyByKID(ks.SigningKeyID())
+	require.NoError(t, err)
+	assert.Equal(t, pub1, got)
+}
+
+func TestKeySet_OnlySignsWithActiveKey(t *testing.T) {
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	// SigningKeyID must be the active key, not the verification key.
+	assert.Equal(t, Thumbprint(pub1), ks.SigningKeyID())
+	assert.NotEqual(t, vk.KeyID, ks.SigningKeyID())
+}
+
+func TestKeySet_PruneExpiredKeys(t *testing.T) {
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	// Create verification key that is already expired.
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(-time.Second),
+	}
+
+	// Already-expired keys are pruned at construction time.
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	_, err = ks.PublicKeyByKID(vk.KeyID)
+	require.Error(t, err, "expired key should have been pruned")
+}
+
+func TestKeySet_PruneExpired_AfterTimeAdvance(t *testing.T) {
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	// Verification key expires in 1 millisecond.
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(100 * time.Millisecond),
+	}
+
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	// Key should be accessible before expiry.
+	got, err := ks.PublicKeyByKID(vk.KeyID)
+	require.NoError(t, err)
+	assert.Equal(t, pub2, got)
+
+	// Wait for expiry.
+	time.Sleep(150 * time.Millisecond)
+
+	// Key should be pruned now.
+	_, err = ks.PublicKeyByKID(vk.KeyID)
+	require.Error(t, err, "key should be pruned after expiry")
+}
+
+func TestKeySet_ZeroExpiryPrunesImmediately(t *testing.T) {
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Time{}, // zero value
+	}
+
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	_, err = ks.PublicKeyByKID(vk.KeyID)
+	require.Error(t, err, "zero-expiry key should be pruned immediately")
+}
+
+func TestKeySet_RapidRotationReplacesOldest(t *testing.T) {
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+	_, pub3 := generateTestKeyPair(t)
+
+	vk1 := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	vk2 := VerificationKey{
+		PublicKey: pub3,
+		KeyID:     Thumbprint(pub3),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	// Both verification keys should be present.
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk1, vk2})
+	require.NoError(t, err)
+
+	got1, err := ks.PublicKeyByKID(vk1.KeyID)
+	require.NoError(t, err)
+	assert.Equal(t, pub2, got1)
+
+	got2, err := ks.PublicKeyByKID(vk2.KeyID)
+	require.NoError(t, err)
+	assert.Equal(t, pub3, got2)
+}
+
+func TestLoadKeySetFromEnv_ActiveOnly(t *testing.T) {
+	privPEM, pubPEM := generateTestKeyPairPEM(t)
+
+	t.Setenv(EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(EnvJWTPublicKey, string(pubPEM))
+	t.Setenv(EnvJWTPrevPublicKey, "")
+	t.Setenv(EnvJWTPrevKeyExpires, "")
+
+	ks, err := LoadKeySetFromEnv()
+	require.NoError(t, err)
+	assert.NotEmpty(t, ks.SigningKeyID())
+}
+
+func TestLoadKeySetFromEnv_WithVerificationKey(t *testing.T) {
+	privPEM, pubPEM := generateTestKeyPairPEM(t)
+	_, prevPubPEM := generateTestKeyPairPEM(t)
+
+	t.Setenv(EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(EnvJWTPublicKey, string(pubPEM))
+	t.Setenv(EnvJWTPrevPublicKey, string(prevPubPEM))
+	t.Setenv(EnvJWTPrevKeyExpires, time.Now().Add(time.Hour).Format(time.RFC3339))
+
+	ks, err := LoadKeySetFromEnv()
+	require.NoError(t, err)
+	assert.NotEmpty(t, ks.SigningKeyID())
+
+	// Verification key should be accessible.
+	prevPub, err := parseRSAPublicKey(prevPubPEM)
+	require.NoError(t, err)
+	prevKID := Thumbprint(prevPub)
+
+	got, err := ks.PublicKeyByKID(prevKID)
+	require.NoError(t, err)
+	assert.Equal(t, prevPub, got)
+}
+
+func TestLoadKeySetFromEnv_MissingActiveFails(t *testing.T) {
+	t.Setenv(EnvJWTPrivateKey, "")
+	t.Setenv(EnvJWTPublicKey, "")
+
+	_, err := LoadKeySetFromEnv()
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, ErrKeyMissing, ecErr.Code)
+}
+
+func TestLoadKeySetFromEnv_PrevKeyMissingExpiryFails(t *testing.T) {
+	privPEM, pubPEM := generateTestKeyPairPEM(t)
+	_, prevPubPEM := generateTestKeyPairPEM(t)
+
+	t.Setenv(EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(EnvJWTPublicKey, string(pubPEM))
+	t.Setenv(EnvJWTPrevPublicKey, string(prevPubPEM))
+	t.Setenv(EnvJWTPrevKeyExpires, "") // missing
+
+	_, err := LoadKeySetFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), EnvJWTPrevKeyExpires)
+}
+
+func TestLoadKeySetFromEnv_InvalidExpiryFails(t *testing.T) {
+	privPEM, pubPEM := generateTestKeyPairPEM(t)
+	_, prevPubPEM := generateTestKeyPairPEM(t)
+
+	t.Setenv(EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(EnvJWTPublicKey, string(pubPEM))
+	t.Setenv(EnvJWTPrevPublicKey, string(prevPubPEM))
+	t.Setenv(EnvJWTPrevKeyExpires, "not-a-date")
+
+	_, err := LoadKeySetFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RFC 3339")
+}
+
+// --- Phase 5: User Story 4 (T026-T029) ---
+
+func TestKeySet_LifecycleLog_Activation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	slog.SetDefault(logger)
+	defer slog.SetDefault(slog.Default())
+
+	priv, pub := generateTestKeyPair(t)
+	_, err := NewKeySet(priv, pub)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "key activated")
+	assert.Contains(t, output, Thumbprint(pub))
+}
+
+func TestKeySet_LifecycleLog_VerificationOnly(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	slog.SetDefault(logger)
+	defer slog.SetDefault(slog.Default())
+
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	_, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "verification-only")
+	assert.Contains(t, output, Thumbprint(pub2))
+}
+
+func TestKeySet_LifecycleLog_Pruning(t *testing.T) {
+	priv1, pub1 := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(50 * time.Millisecond),
+	}
+
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	slog.SetDefault(logger)
+	defer slog.SetDefault(slog.Default())
+
+	ks.PruneExpired()
+
+	output := buf.String()
+	assert.Contains(t, output, "key pruned")
+	assert.Contains(t, output, Thumbprint(pub2))
+}
+
+// --- Existing tests (preserved) ---
 
 func TestLoadKeysFromEnv_BothMissing(t *testing.T) {
 	t.Setenv(EnvJWTPrivateKey, "")

--- a/src/runtime/auth/keys_test.go
+++ b/src/runtime/auth/keys_test.go
@@ -37,6 +37,13 @@ func TestThumbprint_DifferentKeys(t *testing.T) {
 	assert.NotEqual(t, kid1, kid2, "different keys must produce different thumbprints")
 }
 
+func TestThumbprint_OutputLength(t *testing.T) {
+	// RFC 7638 SHA-256 thumbprint: 32 bytes → 43 chars base64url (no padding).
+	_, pub := generateTestKeyPair(t)
+	kid := Thumbprint(pub)
+	assert.Len(t, kid, 43, "SHA-256 base64url-encoded without padding is always 43 chars")
+}
+
 func TestThumbprint_Base64URLEncoded(t *testing.T) {
 	_, pub := generateTestKeyPair(t)
 	kid := Thumbprint(pub)
@@ -296,6 +303,19 @@ func TestLoadKeySetFromEnv_PrevKeyMissingExpiryFails(t *testing.T) {
 	_, err := LoadKeySetFromEnv()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), EnvJWTPrevKeyExpires)
+}
+
+func TestLoadKeySetFromEnv_InvalidPrevPEMFails(t *testing.T) {
+	privPEM, pubPEM := generateTestKeyPairPEM(t)
+
+	t.Setenv(EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(EnvJWTPublicKey, string(pubPEM))
+	t.Setenv(EnvJWTPrevPublicKey, "not-valid-pem")
+	t.Setenv(EnvJWTPrevKeyExpires, time.Now().Add(time.Hour).Format(time.RFC3339))
+
+	_, err := LoadKeySetFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no PEM block")
 }
 
 func TestLoadKeySetFromEnv_InvalidExpiryFails(t *testing.T) {

--- a/src/runtime/auth/keys_test.go
+++ b/src/runtime/auth/keys_test.go
@@ -98,6 +98,15 @@ func TestNewKeySet_NilKeyReturnsError(t *testing.T) {
 	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code)
 }
 
+func TestNewKeySet_MismatchedKeyPairReturnsError(t *testing.T) {
+	priv1, _ := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	_, err := NewKeySet(priv1, pub2) // private from pair 1, public from pair 2
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "do not form a valid pair")
+}
+
 func TestNewKeySet_WeakKeyReturnsError(t *testing.T) {
 	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)

--- a/src/runtime/auth/keys_test.go
+++ b/src/runtime/auth/keys_test.go
@@ -108,7 +108,7 @@ func TestNewKeySet_MismatchedKeyPairReturnsError(t *testing.T) {
 }
 
 func TestNewKeySet_WeakKeyReturnsError(t *testing.T) {
-	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	weakKey, err := rsa.GenerateKey(rand.Reader, 1024) //NOSONAR — intentional weak key to test rejection
 	require.NoError(t, err)
 
 	_, err = NewKeySet(weakKey, &weakKey.PublicKey)
@@ -505,7 +505,7 @@ func TestLoadKeysFromEnv_ValidKeys(t *testing.T) {
 
 func TestLoadRSAKeyPairFromPEM_RejectsWeakKey(t *testing.T) {
 	// Generate a 1024-bit RSA key (below MinRSAKeyBits).
-	weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	weakKey, err := rsa.GenerateKey(rand.Reader, 1024) //NOSONAR — intentional weak key to test rejection
 	require.NoError(t, err)
 
 	privPEM := pem.EncodeToMemory(&pem.Block{

--- a/src/runtime/auth/keys_test.go
+++ b/src/runtime/auth/keys_test.go
@@ -167,11 +167,11 @@ func TestKeySet_PruneExpired_AfterTimeAdvance(t *testing.T) {
 	priv1, pub1 := generateTestKeyPair(t)
 	_, pub2 := generateTestKeyPair(t)
 
-	// Verification key expires in 1 millisecond.
+	baseTime := time.Now()
 	vk := VerificationKey{
 		PublicKey: pub2,
 		KeyID:     Thumbprint(pub2),
-		ExpiresAt: time.Now().Add(100 * time.Millisecond),
+		ExpiresAt: baseTime.Add(time.Hour),
 	}
 
 	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
@@ -182,8 +182,8 @@ func TestKeySet_PruneExpired_AfterTimeAdvance(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pub2, got)
 
-	// Wait for expiry.
-	time.Sleep(150 * time.Millisecond)
+	// Advance clock past expiry using injectable now func.
+	ks.now = func() time.Time { return baseTime.Add(2 * time.Hour) }
 
 	// Key should be pruned now.
 	_, err = ks.PublicKeyByKID(vk.KeyID)
@@ -317,8 +317,9 @@ func TestLoadKeySetFromEnv_InvalidExpiryFails(t *testing.T) {
 func TestKeySet_LifecycleLog_Activation(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	orig := slog.Default()
 	slog.SetDefault(logger)
-	defer slog.SetDefault(slog.Default())
+	defer slog.SetDefault(orig)
 
 	priv, pub := generateTestKeyPair(t)
 	_, err := NewKeySet(priv, pub)
@@ -332,8 +333,9 @@ func TestKeySet_LifecycleLog_Activation(t *testing.T) {
 func TestKeySet_LifecycleLog_VerificationOnly(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	orig := slog.Default()
 	slog.SetDefault(logger)
-	defer slog.SetDefault(slog.Default())
+	defer slog.SetDefault(orig)
 
 	priv1, pub1 := generateTestKeyPair(t)
 	_, pub2 := generateTestKeyPair(t)
@@ -356,27 +358,62 @@ func TestKeySet_LifecycleLog_Pruning(t *testing.T) {
 	priv1, pub1 := generateTestKeyPair(t)
 	_, pub2 := generateTestKeyPair(t)
 
+	baseTime := time.Now()
 	vk := VerificationKey{
 		PublicKey: pub2,
 		KeyID:     Thumbprint(pub2),
-		ExpiresAt: time.Now().Add(50 * time.Millisecond),
+		ExpiresAt: baseTime.Add(time.Hour),
 	}
 
 	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
+	// Advance clock past expiry.
+	ks.now = func() time.Time { return baseTime.Add(2 * time.Hour) }
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	orig := slog.Default()
 	slog.SetDefault(logger)
-	defer slog.SetDefault(slog.Default())
+	defer slog.SetDefault(orig)
 
 	ks.PruneExpired()
 
 	output := buf.String()
 	assert.Contains(t, output, "key pruned")
 	assert.Contains(t, output, Thumbprint(pub2))
+}
+
+// --- Concurrency (F1.4 + F3.1) ---
+
+func TestKeySet_ConcurrentPublicKeyByKID(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	_, pub2 := generateTestKeyPair(t)
+
+	vk := VerificationKey{
+		PublicKey: pub2,
+		KeyID:     Thumbprint(pub2),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	ks, err := NewKeySetWithVerificationKeys(priv, pub, []VerificationKey{vk})
+	require.NoError(t, err)
+
+	// Run concurrent lookups — go test -race will detect data races.
+	const goroutines = 50
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 100; j++ {
+				_, _ = ks.PublicKeyByKID(ks.SigningKeyID())
+				_, _ = ks.PublicKeyByKID(vk.KeyID)
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
 }
 
 // --- Existing tests (preserved) ---

--- a/src/runtime/auth/servicetoken.go
+++ b/src/runtime/auth/servicetoken.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
@@ -21,19 +23,80 @@ const ServiceTokenMaxAge = 5 * time.Minute
 // nowFunc is overridable for testing.
 var nowFunc = time.Now
 
+// HMACKeyRing holds an ordered pair of HMAC secrets for service token operations.
+// Position 0 (current) is used for signing; verification tries all secrets in order.
+//
+// ref: zeromicro/go-zero rest/token/tokenparser.go — dual-key [current, previous] model
+// ref: gorilla/securecookie — DecodeMulti try-all-keys pattern
+type HMACKeyRing struct {
+	current  []byte
+	previous []byte
+}
+
+// NewHMACKeyRing creates an HMACKeyRing. current must not be empty.
+// previous may be nil for single-secret mode.
+func NewHMACKeyRing(current []byte, previous []byte) (*HMACKeyRing, error) {
+	if len(current) == 0 {
+		return nil, errcode.New(errcode.ErrAuthKeyMissing, "current HMAC secret must not be empty")
+	}
+	return &HMACKeyRing{
+		current:  current,
+		previous: previous,
+	}, nil
+}
+
+// Current returns the active signing secret.
+func (r *HMACKeyRing) Current() []byte {
+	return r.current
+}
+
+// Secrets returns all secrets in try-order: current first, then previous (if set).
+func (r *HMACKeyRing) Secrets() [][]byte {
+	if len(r.previous) == 0 {
+		return [][]byte{r.current}
+	}
+	return [][]byte{r.current, r.previous}
+}
+
+const (
+	// EnvServiceSecret is the environment variable for the current HMAC secret.
+	EnvServiceSecret = "GOCELL_SERVICE_SECRET"
+	// EnvServiceSecretPrevious is the environment variable for the previous HMAC secret.
+	EnvServiceSecretPrevious = "GOCELL_SERVICE_SECRET_PREVIOUS"
+)
+
+// LoadHMACKeyRingFromEnv loads an HMACKeyRing from environment variables.
+// GOCELL_SERVICE_SECRET is required; GOCELL_SERVICE_SECRET_PREVIOUS is optional.
+func LoadHMACKeyRingFromEnv() (*HMACKeyRing, error) {
+	current := os.Getenv(EnvServiceSecret)
+	if current == "" {
+		return nil, errcode.New(errcode.ErrAuthKeyMissing,
+			fmt.Sprintf("environment variable %s is not set", EnvServiceSecret))
+	}
+
+	previous := os.Getenv(EnvServiceSecretPrevious)
+	var prevBytes []byte
+	if previous != "" {
+		prevBytes = []byte(previous)
+	}
+
+	return NewHMACKeyRing([]byte(current), prevBytes)
+}
+
 // ServiceTokenMiddleware validates requests using HMAC-SHA256 service tokens.
 // The token is expected in the Authorization header as:
 //
 //	ServiceToken {unix_timestamp}:{hex_hmac}
 //
-// The HMAC is computed over "{method} {path} {timestamp}" using the shared
-// secret. Tokens older than 5 minutes (exclusive boundary) are rejected.
-func ServiceTokenMiddleware(secret []byte) func(http.Handler) http.Handler {
-	if len(secret) == 0 {
-		// Fail-fast: refuse to create middleware with empty secret.
+// The HMAC is computed over "{method} {path} {timestamp}" using secrets from
+// the key ring. Verification tries each secret in order (current, then previous).
+// Tokens older than 5 minutes (exclusive boundary) are rejected.
+func ServiceTokenMiddleware(ring *HMACKeyRing) func(http.Handler) http.Handler {
+	if ring == nil {
+		// Fail-fast: refuse to create middleware with nil key ring.
 		return func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				slog.Error("service token middleware called with empty secret")
+				slog.Error("service token middleware called with nil key ring")
 				httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
 			})
 		}
@@ -79,26 +142,27 @@ func ServiceTokenMiddleware(secret []byte) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Compute expected HMAC over "METHOD PATH TIMESTAMP".
-			mac := hmac.New(sha256.New, secret)
-			_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, tsStr)))
-			expectedMAC := mac.Sum(nil)
-
-			if !hmac.Equal(providedMAC, expectedMAC) {
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
-				return
+			// Try all secrets in the key ring (current first, then previous).
+			message := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, tsStr)
+			for _, secret := range ring.Secrets() {
+				mac := hmac.New(sha256.New, secret)
+				_, _ = mac.Write([]byte(message))
+				if hmac.Equal(providedMAC, mac.Sum(nil)) {
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
 
-			next.ServeHTTP(w, r)
+			httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
 		})
 	}
 }
 
 // GenerateServiceToken creates a service token for the given method, path,
-// and timestamp using the shared secret.
-func GenerateServiceToken(secret []byte, method, path string, ts time.Time) string {
+// and timestamp using the current secret from the key ring.
+func GenerateServiceToken(ring *HMACKeyRing, method, path string, ts time.Time) string {
 	tsStr := strconv.FormatInt(ts.Unix(), 10)
-	mac := hmac.New(sha256.New, secret)
+	mac := hmac.New(sha256.New, ring.Current())
 	_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s", method, path, tsStr)))
 	return tsStr + ":" + hex.EncodeToString(mac.Sum(nil))
 }

--- a/src/runtime/auth/servicetoken.go
+++ b/src/runtime/auth/servicetoken.go
@@ -63,12 +63,16 @@ func (r *HMACKeyRing) Current() []byte {
 	return r.current
 }
 
-// Secrets returns all secrets in try-order: current first, then previous (if set).
+// Secrets returns a copy of all secrets in try-order: current first, then previous (if set).
+// The returned slice is a fresh allocation; callers cannot mutate the ring's internal state.
 func (r *HMACKeyRing) Secrets() [][]byte {
 	if len(r.previous) == 0 {
-		return [][]byte{r.current}
+		return [][]byte{append([]byte(nil), r.current...)}
 	}
-	return [][]byte{r.current, r.previous}
+	return [][]byte{
+		append([]byte(nil), r.current...),
+		append([]byte(nil), r.previous...),
+	}
 }
 
 const (

--- a/src/runtime/auth/servicetoken.go
+++ b/src/runtime/auth/servicetoken.go
@@ -23,6 +23,10 @@ const ServiceTokenMaxAge = 5 * time.Minute
 // nowFunc is overridable for testing.
 var nowFunc = time.Now
 
+// MinHMACKeyBytes is the minimum HMAC secret length. NIST recommends 256-bit
+// (32-byte) keys for HMAC-SHA256; this constant enforces that minimum.
+const MinHMACKeyBytes = 32
+
 // HMACKeyRing holds an ordered pair of HMAC secrets for service token operations.
 // Position 0 (current) is used for signing; verification tries all secrets in order.
 //
@@ -33,11 +37,20 @@ type HMACKeyRing struct {
 	previous []byte
 }
 
-// NewHMACKeyRing creates an HMACKeyRing. current must not be empty.
-// previous may be nil for single-secret mode.
+// NewHMACKeyRing creates an HMACKeyRing. current must be at least MinHMACKeyBytes
+// (32 bytes). previous may be nil for single-secret mode; if set, it must also
+// meet the minimum length.
 func NewHMACKeyRing(current []byte, previous []byte) (*HMACKeyRing, error) {
 	if len(current) == 0 {
 		return nil, errcode.New(errcode.ErrAuthKeyMissing, "current HMAC secret must not be empty")
+	}
+	if len(current) < MinHMACKeyBytes {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid,
+			fmt.Sprintf("current HMAC secret is %d bytes, minimum is %d", len(current), MinHMACKeyBytes))
+	}
+	if len(previous) > 0 && len(previous) < MinHMACKeyBytes {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid,
+			fmt.Sprintf("previous HMAC secret is %d bytes, minimum is %d", len(previous), MinHMACKeyBytes))
 	}
 	return &HMACKeyRing{
 		current:  current,
@@ -160,7 +173,11 @@ func ServiceTokenMiddleware(ring *HMACKeyRing) func(http.Handler) http.Handler {
 
 // GenerateServiceToken creates a service token for the given method, path,
 // and timestamp using the current secret from the key ring.
+// It returns an empty string if ring is nil.
 func GenerateServiceToken(ring *HMACKeyRing, method, path string, ts time.Time) string {
+	if ring == nil {
+		return ""
+	}
 	tsStr := strconv.FormatInt(ts.Unix(), 10)
 	mac := hmac.New(sha256.New, ring.Current())
 	_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s", method, path, tsStr)))

--- a/src/runtime/auth/servicetoken_test.go
+++ b/src/runtime/auth/servicetoken_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// test secrets — each exactly 32 bytes (>= MinHMACKeyBytes).
+const (
+	testSecret    = "test-secret-padding-to-32bytes!!" // len=32
+	testSecretOld = "old--secret-padding-to-32bytes!!" // len=32
+	testSecretNew = "new--secret-padding-to-32bytes!!" // len=32
+	testSecretUnk = "unkn-secret-padding-to-32bytes!!" // len=32
+	testSecretOne = "only-secret-padding-to-32bytes!!" // len=32
+	testSecretSam = "same-secret-padding-to-32bytes!!" // len=32
+)
+
 func mustTestRing(t *testing.T, current, previous string) *HMACKeyRing {
 	t.Helper()
 	var prev []byte
@@ -26,13 +36,13 @@ func mustTestRing(t *testing.T, current, previous string) *HMACKeyRing {
 // --- Phase 4: User Story 3 (T017-T025) ---
 
 func TestHMACKeyRing_SignWithCurrent(t *testing.T) {
-	ring := mustTestRing(t, "new-secret", "old-secret")
+	ring := mustTestRing(t, testSecretNew, testSecretOld)
 
 	now := time.Now()
 	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
 
 	// Should be verifiable with current secret only.
-	singleRing := mustTestRing(t, "new-secret", "")
+	singleRing := mustTestRing(t, testSecretNew, "")
 	handler := ServiceTokenMiddleware(singleRing)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -56,11 +66,11 @@ func TestHMACKeyRing_VerifyWithPrevious(t *testing.T) {
 	defer func() { nowFunc = origNow }()
 
 	// Sign token with old secret.
-	oldRing := mustTestRing(t, "old-secret", "")
+	oldRing := mustTestRing(t, testSecretOld, "")
 	token := GenerateServiceToken(oldRing, http.MethodGet, "/api", now)
 
 	// Create ring with new+old. Old token should still verify.
-	newRing := mustTestRing(t, "new-secret", "old-secret")
+	newRing := mustTestRing(t, testSecretNew, testSecretOld)
 	handler := ServiceTokenMiddleware(newRing)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -80,10 +90,10 @@ func TestHMACKeyRing_RejectUnknownSecret(t *testing.T) {
 	defer func() { nowFunc = origNow }()
 
 	// Sign with a secret that is NOT in the ring.
-	unknownRing := mustTestRing(t, "unknown-secret", "")
+	unknownRing := mustTestRing(t, testSecretUnk, "")
 	token := GenerateServiceToken(unknownRing, http.MethodGet, "/api", now)
 
-	ring := mustTestRing(t, "new-secret", "old-secret")
+	ring := mustTestRing(t, testSecretNew, testSecretOld)
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -102,7 +112,7 @@ func TestHMACKeyRing_SingleSecretMode(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
 
-	ring := mustTestRing(t, "only-secret", "")
+	ring := mustTestRing(t, testSecretOne, "")
 	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
 
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +133,7 @@ func TestHMACKeyRing_SameSecretBothPositions(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
 
-	ring := mustTestRing(t, "same-secret", "same-secret")
+	ring := mustTestRing(t, testSecretSam, testSecretSam)
 	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
 
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -147,38 +157,55 @@ func TestNewHMACKeyRing_EmptyCurrentFails(t *testing.T) {
 	assert.Equal(t, errcode.ErrAuthKeyMissing, ecErr.Code)
 }
 
+func TestNewHMACKeyRing_ShortCurrentFails(t *testing.T) {
+	_, err := NewHMACKeyRing([]byte("too-short"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "minimum is 32")
+}
+
+func TestNewHMACKeyRing_ShortPreviousFails(t *testing.T) {
+	_, err := NewHMACKeyRing([]byte(testSecret), []byte("too-short"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "previous HMAC secret")
+}
+
+func TestGenerateServiceToken_NilRing(t *testing.T) {
+	token := GenerateServiceToken(nil, "GET", "/api", time.Now())
+	assert.Empty(t, token)
+}
+
 func TestHMACKeyRing_Secrets_SingleKey(t *testing.T) {
-	ring := mustTestRing(t, "secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	secrets := ring.Secrets()
 	assert.Len(t, secrets, 1)
-	assert.Equal(t, []byte("secret"), secrets[0])
+	assert.Equal(t, []byte(testSecret), secrets[0])
 }
 
 func TestHMACKeyRing_Secrets_DualKey(t *testing.T) {
-	ring := mustTestRing(t, "new", "old")
+	ring := mustTestRing(t, testSecretNew, testSecretOld)
 	secrets := ring.Secrets()
 	assert.Len(t, secrets, 2)
-	assert.Equal(t, []byte("new"), secrets[0])
-	assert.Equal(t, []byte("old"), secrets[1])
+	assert.Equal(t, []byte(testSecretNew), secrets[0])
+	assert.Equal(t, []byte(testSecretOld), secrets[1])
 }
 
 func TestLoadHMACKeyRingFromEnv_CurrentOnly(t *testing.T) {
-	t.Setenv(EnvServiceSecret, "my-secret")
+	t.Setenv(EnvServiceSecret, testSecret)
 	t.Setenv(EnvServiceSecretPrevious, "")
 
 	ring, err := LoadHMACKeyRingFromEnv()
 	require.NoError(t, err)
-	assert.Equal(t, []byte("my-secret"), ring.Current())
+	assert.Equal(t, []byte(testSecret), ring.Current())
 	assert.Len(t, ring.Secrets(), 1)
 }
 
 func TestLoadHMACKeyRingFromEnv_CurrentAndPrevious(t *testing.T) {
-	t.Setenv(EnvServiceSecret, "new-secret")
-	t.Setenv(EnvServiceSecretPrevious, "old-secret")
+	t.Setenv(EnvServiceSecret, testSecretNew)
+	t.Setenv(EnvServiceSecretPrevious, testSecretOld)
 
 	ring, err := LoadHMACKeyRingFromEnv()
 	require.NoError(t, err)
-	assert.Equal(t, []byte("new-secret"), ring.Current())
+	assert.Equal(t, []byte(testSecretNew), ring.Current())
 	assert.Len(t, ring.Secrets(), 2)
 }
 
@@ -197,7 +224,7 @@ func TestLoadHMACKeyRingFromEnv_MissingCurrentFails(t *testing.T) {
 // --- Updated existing tests ---
 
 func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -218,7 +245,7 @@ func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_InvalidToken(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -237,7 +264,7 @@ func TestServiceTokenMiddleware_InvalidToken(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_MissingToken(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -250,7 +277,7 @@ func TestServiceTokenMiddleware_MissingToken(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_WrongScheme(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -264,7 +291,7 @@ func TestServiceTokenMiddleware_WrongScheme(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_DifferentPath(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -296,7 +323,7 @@ func TestServiceTokenMiddleware_NilRing(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -317,7 +344,7 @@ func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -338,7 +365,7 @@ func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -359,7 +386,7 @@ func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -380,7 +407,7 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -394,7 +421,7 @@ func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
 }
 
 func TestGenerateServiceToken_Deterministic(t *testing.T) {
-	ring := mustTestRing(t, "test-secret", "")
+	ring := mustTestRing(t, testSecret, "")
 	ts := time.Unix(1700000000, 0)
 	t1 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)
 	t2 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)

--- a/src/runtime/auth/servicetoken_test.go
+++ b/src/runtime/auth/servicetoken_test.go
@@ -1,26 +1,212 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func mustTestRing(t *testing.T, current, previous string) *HMACKeyRing {
+	t.Helper()
+	var prev []byte
+	if previous != "" {
+		prev = []byte(previous)
+	}
+	ring, err := NewHMACKeyRing([]byte(current), prev)
+	require.NoError(t, err)
+	return ring
+}
+
+// --- Phase 4: User Story 3 (T017-T025) ---
+
+func TestHMACKeyRing_SignWithCurrent(t *testing.T) {
+	ring := mustTestRing(t, "new-secret", "old-secret")
+
+	now := time.Now()
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+
+	// Should be verifiable with current secret only.
+	singleRing := mustTestRing(t, "new-secret", "")
+	handler := ServiceTokenMiddleware(singleRing)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	origNow := nowFunc
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = origNow }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHMACKeyRing_VerifyWithPrevious(t *testing.T) {
+	now := time.Now()
+	origNow := nowFunc
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = origNow }()
+
+	// Sign token with old secret.
+	oldRing := mustTestRing(t, "old-secret", "")
+	token := GenerateServiceToken(oldRing, http.MethodGet, "/api", now)
+
+	// Create ring with new+old. Old token should still verify.
+	newRing := mustTestRing(t, "new-secret", "old-secret")
+	handler := ServiceTokenMiddleware(newRing)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHMACKeyRing_RejectUnknownSecret(t *testing.T) {
+	now := time.Now()
+	origNow := nowFunc
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = origNow }()
+
+	// Sign with a secret that is NOT in the ring.
+	unknownRing := mustTestRing(t, "unknown-secret", "")
+	token := GenerateServiceToken(unknownRing, http.MethodGet, "/api", now)
+
+	ring := mustTestRing(t, "new-secret", "old-secret")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHMACKeyRing_SingleSecretMode(t *testing.T) {
+	now := time.Now()
+	origNow := nowFunc
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = origNow }()
+
+	ring := mustTestRing(t, "only-secret", "")
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHMACKeyRing_SameSecretBothPositions(t *testing.T) {
+	now := time.Now()
+	origNow := nowFunc
+	nowFunc = func() time.Time { return now }
+	defer func() { nowFunc = origNow }()
+
+	ring := mustTestRing(t, "same-secret", "same-secret")
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestNewHMACKeyRing_EmptyCurrentFails(t *testing.T) {
+	_, err := NewHMACKeyRing(nil, nil)
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthKeyMissing, ecErr.Code)
+}
+
+func TestHMACKeyRing_Secrets_SingleKey(t *testing.T) {
+	ring := mustTestRing(t, "secret", "")
+	secrets := ring.Secrets()
+	assert.Len(t, secrets, 1)
+	assert.Equal(t, []byte("secret"), secrets[0])
+}
+
+func TestHMACKeyRing_Secrets_DualKey(t *testing.T) {
+	ring := mustTestRing(t, "new", "old")
+	secrets := ring.Secrets()
+	assert.Len(t, secrets, 2)
+	assert.Equal(t, []byte("new"), secrets[0])
+	assert.Equal(t, []byte("old"), secrets[1])
+}
+
+func TestLoadHMACKeyRingFromEnv_CurrentOnly(t *testing.T) {
+	t.Setenv(EnvServiceSecret, "my-secret")
+	t.Setenv(EnvServiceSecretPrevious, "")
+
+	ring, err := LoadHMACKeyRingFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("my-secret"), ring.Current())
+	assert.Len(t, ring.Secrets(), 1)
+}
+
+func TestLoadHMACKeyRingFromEnv_CurrentAndPrevious(t *testing.T) {
+	t.Setenv(EnvServiceSecret, "new-secret")
+	t.Setenv(EnvServiceSecretPrevious, "old-secret")
+
+	ring, err := LoadHMACKeyRingFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new-secret"), ring.Current())
+	assert.Len(t, ring.Secrets(), 2)
+}
+
+func TestLoadHMACKeyRingFromEnv_MissingCurrentFails(t *testing.T) {
+	t.Setenv(EnvServiceSecret, "")
+	t.Setenv(EnvServiceSecretPrevious, "")
+
+	_, err := LoadHMACKeyRingFromEnv()
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthKeyMissing, ecErr.Code)
+}
+
+// --- Updated existing tests ---
+
 func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	now := time.Now()
-	token := GenerateServiceToken(secret, http.MethodGet, "/internal/v1/health", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", now)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 
-	// Override nowFunc so it matches the token timestamp.
 	origNow := nowFunc
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
@@ -32,8 +218,8 @@ func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_InvalidToken(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -51,8 +237,8 @@ func TestServiceTokenMiddleware_InvalidToken(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_MissingToken(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -64,8 +250,8 @@ func TestServiceTokenMiddleware_MissingToken(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_WrongScheme(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -78,8 +264,8 @@ func TestServiceTokenMiddleware_WrongScheme(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_DifferentPath(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -88,8 +274,7 @@ func TestServiceTokenMiddleware_DifferentPath(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
 
-	// Token computed for different path.
-	token := GenerateServiceToken(secret, http.MethodGet, "/other", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/other", now)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -98,7 +283,7 @@ func TestServiceTokenMiddleware_DifferentPath(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
-func TestServiceTokenMiddleware_EmptySecret(t *testing.T) {
+func TestServiceTokenMiddleware_NilRing(t *testing.T) {
 	handler := ServiceTokenMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -111,8 +296,8 @@ func TestServiceTokenMiddleware_EmptySecret(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -121,9 +306,8 @@ func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
 
-	// Token with timestamp 6 minutes ago (exceeds 5 min window).
 	oldTime := now.Add(-6 * time.Minute)
-	token := GenerateServiceToken(secret, http.MethodGet, "/internal/v1/health", oldTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", oldTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -133,8 +317,8 @@ func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -143,9 +327,8 @@ func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
 
-	// Token with timestamp exactly 5 minutes ago (boundary = rejected).
 	boundaryTime := now.Add(-ServiceTokenMaxAge)
-	token := GenerateServiceToken(secret, http.MethodGet, "/internal/v1/health", boundaryTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", boundaryTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -155,8 +338,8 @@ func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -165,9 +348,8 @@ func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
 
-	// Token with timestamp 4 minutes 59 seconds ago (within window).
 	recentTime := now.Add(-4*time.Minute - 59*time.Second)
-	token := GenerateServiceToken(secret, http.MethodGet, "/internal/v1/health", recentTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", recentTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -177,8 +359,8 @@ func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -187,9 +369,8 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 	nowFunc = func() time.Time { return now }
 	defer func() { nowFunc = origNow }()
 
-	// Token with timestamp 6 minutes in the future.
 	futureTime := now.Add(6 * time.Minute)
-	token := GenerateServiceToken(secret, http.MethodGet, "/internal/v1/health", futureTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", futureTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -199,8 +380,8 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 }
 
 func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
-	secret := []byte("test-secret")
-	handler := ServiceTokenMiddleware(secret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ring := mustTestRing(t, "test-secret", "")
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -213,13 +394,13 @@ func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
 }
 
 func TestGenerateServiceToken_Deterministic(t *testing.T) {
-	secret := []byte("test-secret")
+	ring := mustTestRing(t, "test-secret", "")
 	ts := time.Unix(1700000000, 0)
-	t1 := GenerateServiceToken(secret, http.MethodPost, "/api", ts)
-	t2 := GenerateServiceToken(secret, http.MethodPost, "/api", ts)
+	t1 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)
+	t2 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)
 	assert.Equal(t, t1, t2)
 
 	// Different method should produce different token.
-	t3 := GenerateServiceToken(secret, http.MethodGet, "/api", ts)
+	t3 := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
 	assert.NotEqual(t, t1, t3)
 }


### PR DESCRIPTION
## Summary

- **JWT kid rotation**: All issued tokens carry a `kid` header (RFC 7638 SHA-256 thumbprint). Verification uses O(1) kid-based key lookup from `KeySet`. Supports 1 active signing key + 0-N verification-only keys with expiry.
- **HMAC key ring**: `HMACKeyRing` holds `[current, previous]` secrets (min 32 bytes) with try-all-keys verification for zero-downtime service token rotation.
- **Pure-read lookup**: `PublicKeyByKID` is a read-only operation (`RWMutex.RLock`). Lifecycle mutations (prune) happen only at construction/explicit call, not on the request path. Aligned with Dex/Vault/Teleport patterns.
- **Fail-fast**: Key pair mismatch detected at startup. Missing keys rejected deterministically. HMAC minimum 32 bytes enforced.
- **Lifecycle observability**: Structured `slog.Info` on key activation, demotion, and pruning.

### Commits (7)

| # | Commit | Description |
|---|--------|-------------|
| 1 | `3781269` | feat: initial implementation — KeySet, HMACKeyRing, kid headers |
| 2 | `2506008` | fix: concurrency (Mutex), HMAC min length, slog defer, injectable clock |
| 3 | `5f32b25` | fix: .env.example, MustNewTestKeySet, runbook, PEM docs, defensive copies |
| 4 | `7443543` | fix: pure-read lookup (RWMutex), key pair validation, contract alignment |
| 5 | `71963fe` | docs: backlog DEFER items (KeyProvider, HMAC query, metrics) |
| 6 | `2c3b167` | docs: backlog ACCEPT items with rationale |
| 7 | `454cfd9` | fix: suppress SonarCloud S4426 false positive on weak key tests |

### Review findings resolved

- **P0**: KeySet concurrency — pure-read lookup with RWMutex (no mutation in hot path)
- **P0**: .env.example — 6 new env vars documented
- **P1**: IssueTestToken — moved to helpers_test.go, HS256 branch removed
- **P1**: slog defer restore — fixed with `orig := slog.Default()` pattern
- **P1**: time.Sleep flaky — replaced with injectable `KeySet.now` clock
- **P1**: Key pair mismatch — NewKeySet validates priv/pub form a valid pair
- **P1**: Retained-key contract — unified across spec/data-model/quickstart (API 0-N, env 0-1)
- **P1**: Runbook/PEM docs/migration — added to quickstart.md
- **P1**: MustNewTestKeySet — exported helper, 4 callers simplified

### Metrics

- 72 tests, all pass with `-race`
- 89.7% statement coverage on `runtime/auth/`
- `go vet` clean

### Deferred (recorded in backlog)

- WM-2-F1: KeyProvider interface → WM-34 (YAGNI, 2 consumers)
- WM-2-F2: HMAC query string replay → separate fix
- WM-2-F3: Prometheus metrics → WM-34

## Test plan

- [x] `go build ./...` — zero errors
- [x] `go test -race ./runtime/auth/...` — 72 tests pass
- [x] `go test ./cells/access-core/...` — all downstream pass
- [x] `go vet ./runtime/auth/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)