### PR TITLE
fix(cursor): correctness + repo hardening

### DIFF
--- a/src/cells/access-core/internal/mem/repo_test.go
+++ b/src/cells/access-core/internal/mem/repo_test.go
@@ -1,0 +1,144 @@
+package mem
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUserRepository_ConcurrentCreateAndGet verifies that concurrent
+// Create and Get calls do not race. Run with -race to verify.
+func TestUserRepository_ConcurrentCreateAndGet(t *testing.T) {
+	repo := NewUserRepository()
+	ctx := context.Background()
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				_ = repo.Create(ctx, &domain.User{
+					ID:       fmt.Sprintf("uid-w%d-i%d", id, i),
+					Username: fmt.Sprintf("user-w%d-i%d", id, i),
+					Email:    fmt.Sprintf("u%d-%d@test.com", id, i),
+					Status:   domain.StatusActive,
+				})
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_, _ = repo.GetByID(ctx, "uid-w0-i0")
+				_, _ = repo.GetByUsername(ctx, "user-w0-i0")
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSessionRepository_ConcurrentCreateAndGet verifies that concurrent
+// Create and Get calls do not race. Run with -race to verify.
+func TestSessionRepository_ConcurrentCreateAndGet(t *testing.T) {
+	repo := NewSessionRepository()
+	ctx := context.Background()
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				_ = repo.Create(ctx, &domain.Session{
+					ID:           fmt.Sprintf("sid-w%d-i%d", id, i),
+					UserID:       fmt.Sprintf("uid-%d", id),
+					RefreshToken: fmt.Sprintf("rt-w%d-i%d", id, i),
+					ExpiresAt:    time.Now().Add(time.Hour),
+					CreatedAt:    time.Now(),
+				})
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_, _ = repo.GetByID(ctx, "sid-w0-i0")
+				_, _ = repo.GetByRefreshToken(ctx, "rt-w0-i0")
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestRoleRepository_ConcurrentAssignAndGet verifies that concurrent
+// Assign and Get calls do not race. Run with -race to verify.
+func TestRoleRepository_ConcurrentAssignAndGet(t *testing.T) {
+	repo := NewRoleRepository()
+	ctx := context.Background()
+
+	// Seed roles.
+	for i := range 5 {
+		repo.SeedRole(&domain.Role{
+			ID:   fmt.Sprintf("role-%d", i),
+			Name: fmt.Sprintf("Role %d", i),
+		})
+	}
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				userID := fmt.Sprintf("uid-w%d-i%d", id, i)
+				_ = repo.AssignToUser(ctx, userID, fmt.Sprintf("role-%d", id%5))
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_, _ = repo.GetByID(ctx, "role-0")
+				_, _ = repo.GetByUserID(ctx, "uid-w0-i0")
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
+	assert.NotNil(t, repo) // ensure repo survived concurrent access
+}

--- a/src/cells/audit-core/internal/mem/audit_repo.go
+++ b/src/cells/audit-core/internal/mem/audit_repo.go
@@ -63,7 +63,7 @@ func (r *AuditRepository) Query(_ context.Context, filters ports.AuditFilters, p
 
 	filtered := filterEntries(r.entries, filters)
 	query.Sort(filtered, params.Sort, compareAuditField)
-	return query.ApplyCursor(filtered, params, auditFieldValue), nil
+	return query.ApplyCursor(filtered, params, auditFieldValue)
 }
 
 // filterEntries returns clones of entries matching the given filters.

--- a/src/cells/audit-core/internal/mem/audit_repo.go
+++ b/src/cells/audit-core/internal/mem/audit_repo.go
@@ -4,6 +4,7 @@ package mem
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
@@ -63,7 +64,11 @@ func (r *AuditRepository) Query(_ context.Context, filters ports.AuditFilters, p
 
 	filtered := filterEntries(r.entries, filters)
 	query.Sort(filtered, params.Sort, compareAuditField)
-	return query.ApplyCursor(filtered, params, auditFieldValue)
+	result, err := query.ApplyCursor(filtered, params, auditFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("audit-repo: query: %w", err)
+	}
+	return result, nil
 }
 
 // filterEntries returns clones of entries matching the given filters.

--- a/src/cells/audit-core/internal/mem/audit_repo.go
+++ b/src/cells/audit-core/internal/mem/audit_repo.go
@@ -4,7 +4,6 @@ package mem
 import (
 	"cmp"
 	"context"
-	"slices"
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
@@ -63,8 +62,8 @@ func (r *AuditRepository) Query(_ context.Context, filters ports.AuditFilters, p
 	defer r.mu.RUnlock()
 
 	filtered := filterEntries(r.entries, filters)
-	sortAuditEntries(filtered, params.Sort)
-	return applyAuditCursor(filtered, params), nil
+	query.Sort(filtered, params.Sort, compareAuditField)
+	return query.ApplyCursor(filtered, params, auditFieldValue), nil
 }
 
 // filterEntries returns clones of entries matching the given filters.
@@ -89,56 +88,28 @@ func filterEntries(entries []*domain.AuditEntry, filters ports.AuditFilters) []*
 	return out
 }
 
-// sortAuditEntries sorts entries in-place by the given sort columns.
-func sortAuditEntries(entries []*domain.AuditEntry, cols []query.SortColumn) {
-	if len(cols) == 0 {
-		return
-	}
-	slices.SortFunc(entries, func(a, b *domain.AuditEntry) int {
-		for _, col := range cols {
-			var c int
-			switch col.Name {
-			case "timestamp":
-				c = a.Timestamp.Compare(b.Timestamp)
-			case "id":
-				c = cmp.Compare(a.ID, b.ID)
-			}
-			if col.Direction == query.SortDESC {
-				c = -c
-			}
-			if c != 0 {
-				return c
-			}
-		}
+// compareAuditField compares a single field of two audit entries.
+func compareAuditField(a, b *domain.AuditEntry, field string) int {
+	switch field {
+	case "timestamp":
+		return a.Timestamp.Compare(b.Timestamp)
+	case "id":
+		return cmp.Compare(a.ID, b.ID)
+	default:
 		return 0
-	})
+	}
 }
 
-// applyAuditCursor skips entries at or before the cursor position, then limits.
-func applyAuditCursor(entries []*domain.AuditEntry, params query.ListParams) []*domain.AuditEntry {
-	if len(params.CursorValues) >= 2 {
-		cursorTS, _ := params.CursorValues[0].(string)
-		cursorID, _ := params.CursorValues[1].(string)
-		var after []*domain.AuditEntry
-		for _, e := range entries {
-			ts := e.Timestamp.Format("2006-01-02T15:04:05.999999999Z07:00")
-			// Sort is timestamp DESC, id ASC: skip while (ts > cursorTS) or (ts == cursorTS && id <= cursorID)
-			if ts > cursorTS {
-				continue
-			}
-			if ts == cursorTS && e.ID <= cursorID {
-				continue
-			}
-			after = append(after, e)
-		}
-		entries = after
+// auditFieldValue extracts a cursor-comparable value from an audit entry.
+func auditFieldValue(e *domain.AuditEntry, field string) any {
+	switch field {
+	case "timestamp":
+		return e.Timestamp
+	case "id":
+		return e.ID
+	default:
+		return ""
 	}
-
-	limit := params.FetchLimit()
-	if limit > 0 && len(entries) > limit {
-		entries = entries[:limit]
-	}
-	return entries
 }
 
 // Len returns the number of entries (for testing).

--- a/src/cells/audit-core/internal/mem/audit_repo_test.go
+++ b/src/cells/audit-core/internal/mem/audit_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -421,6 +422,7 @@ func TestAuditRepository_ConcurrentAppendAndQuery(t *testing.T) {
 		}(w)
 	}
 
+	var readErrors atomic.Int64
 	for r := range readers {
 		wg.Add(1)
 		go func() {
@@ -433,7 +435,17 @@ func TestAuditRepository_ConcurrentAppendAndQuery(t *testing.T) {
 				},
 			}
 			for range iterations {
-				_, _ = repo.Query(ctx, ports.AuditFilters{}, params)
+				items, err := repo.Query(ctx, ports.AuditFilters{}, params)
+				if err != nil {
+					readErrors.Add(1)
+					continue
+				}
+				// Semantic invariant: results must be DESC-sorted by timestamp.
+				for j := 1; j < len(items); j++ {
+					if items[j].Timestamp.After(items[j-1].Timestamp) {
+						t.Errorf("query results not DESC-sorted by timestamp")
+					}
+				}
 				_, _ = repo.GetRange(ctx, 0, 10)
 				_ = repo.Len()
 			}
@@ -443,4 +455,5 @@ func TestAuditRepository_ConcurrentAppendAndQuery(t *testing.T) {
 
 	wg.Wait()
 	assert.Equal(t, writers*iterations, repo.Len())
+	assert.Zero(t, readErrors.Load(), "concurrent reads should not error")
 }

--- a/src/cells/audit-core/internal/mem/audit_repo_test.go
+++ b/src/cells/audit-core/internal/mem/audit_repo_test.go
@@ -3,6 +3,7 @@ package mem
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -331,6 +332,42 @@ func TestAuditRepository_Query_UnknownSortField(t *testing.T) {
 	assert.Len(t, result, 2)
 }
 
+func TestAuditRepository_Query_Cursor_SubsecondPrecision(t *testing.T) {
+	repo := NewAuditRepository()
+	ctx := context.Background()
+
+	// Two entries at the same second but different nanoseconds.
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, repo.Append(ctx, &domain.AuditEntry{
+		ID: "ae-01", EventType: "login", ActorID: "usr-1",
+		Timestamp: base.Add(100 * time.Nanosecond),
+	}))
+	require.NoError(t, repo.Append(ctx, &domain.AuditEntry{
+		ID: "ae-02", EventType: "login", ActorID: "usr-1",
+		Timestamp: base.Add(200 * time.Nanosecond),
+	}))
+	require.NoError(t, repo.Append(ctx, &domain.AuditEntry{
+		ID: "ae-03", EventType: "login", ActorID: "usr-1",
+		Timestamp: base.Add(300 * time.Nanosecond),
+	}))
+
+	// Sort DESC by timestamp, cursor at ae-02.
+	cursorTS := base.Add(200 * time.Nanosecond).Format(time.RFC3339Nano)
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{cursorTS, "ae-02"},
+		Sort: []query.SortColumn{
+			{Name: "timestamp", Direction: query.SortDESC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+	result, err := repo.Query(ctx, ports.AuditFilters{}, params)
+	require.NoError(t, err)
+	// After ae-02 in DESC order: ae-01 (100ns)
+	require.Len(t, result, 1)
+	assert.Equal(t, "ae-01", result[0].ID)
+}
+
 func TestAuditRepository_Query_SortByID(t *testing.T) {
 	repo := NewAuditRepository()
 	ctx := context.Background()
@@ -354,4 +391,56 @@ func TestAuditRepository_Query_SortByID(t *testing.T) {
 	require.Len(t, result, 2)
 	assert.Equal(t, "ae-a", result[0].ID)
 	assert.Equal(t, "ae-z", result[1].ID)
+}
+
+// TestAuditRepository_ConcurrentAppendAndQuery verifies that concurrent
+// Append and Query calls do not race. Run with -race to verify.
+func TestAuditRepository_ConcurrentAppendAndQuery(t *testing.T) {
+	repo := NewAuditRepository()
+	ctx := context.Background()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				_ = repo.Append(ctx, &domain.AuditEntry{
+					ID:        fmt.Sprintf("ae-w%d-i%d", id, i),
+					EventType: "login",
+					ActorID:   fmt.Sprintf("usr-%d", id),
+					Timestamp: base.Add(time.Duration(id*iterations+i) * time.Millisecond),
+				})
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			params := query.ListParams{
+				Limit: 10,
+				Sort: []query.SortColumn{
+					{Name: "timestamp", Direction: query.SortDESC},
+					{Name: "id", Direction: query.SortASC},
+				},
+			}
+			for range iterations {
+				_, _ = repo.Query(ctx, ports.AuditFilters{}, params)
+				_, _ = repo.GetRange(ctx, 0, 10)
+				_ = repo.Len()
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, writers*iterations, repo.Len())
 }

--- a/src/cells/audit-core/slices/auditappend/service.go
+++ b/src/cells/audit-core/slices/auditappend/service.go
@@ -87,7 +87,12 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 	var payload struct {
 		UserID string `json:"user_id"`
 	}
-	_ = json.Unmarshal(entry.Payload, &payload)
+	if err := json.Unmarshal(entry.Payload, &payload); err != nil {
+		s.logger.Warn("audit-append: failed to extract actor from payload",
+			slog.Any("error", err),
+			slog.String("event_id", entry.ID),
+			slog.String("event_type", entry.EventType))
+	}
 
 	actorID := payload.UserID
 	if actorID == "" {

--- a/src/cells/audit-core/slices/auditappend/service.go
+++ b/src/cells/audit-core/slices/auditappend/service.go
@@ -104,10 +104,16 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 	auditEntry.ID = "audit" + "-" + uuid.NewString()
 
 	// Publish audit.appended event.
-	appendedPayload, _ := json.Marshal(map[string]any{
+	appendedPayload, err := json.Marshal(map[string]any{
 		"audit_entry_id": auditEntry.ID,
 		"event_type":     entry.EventType,
 	})
+	if err != nil {
+		s.logger.Error("audit-append: failed to marshal appended event payload",
+			slog.Any("error", err),
+			slog.String("event_id", entry.ID))
+		return err
+	}
 
 	// Wrap persist + outbox write in a transaction for L2 atomicity.
 	persistAndPublish := func(txCtx context.Context) error {

--- a/src/cells/audit-core/slices/auditappend/service.go
+++ b/src/cells/audit-core/slices/auditappend/service.go
@@ -115,30 +115,9 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 		return err
 	}
 
-	// Wrap persist + outbox write in a transaction for L2 atomicity.
-	persistAndPublish := func(txCtx context.Context) error {
-		if err := s.repo.Append(txCtx, auditEntry); err != nil {
-			return err // transient, will be retried
-		}
-		if s.outboxWriter != nil {
-			outboxEntry := outbox.Entry{
-				ID:        "evt" + "-" + uuid.NewString(),
-				EventType: TopicAuditAppended,
-				Payload:   appendedPayload,
-			}
-			if writeErr := s.outboxWriter.Write(txCtx, outboxEntry); writeErr != nil {
-				return writeErr
-			}
-		}
-		return nil
-	}
-
-	var persistErr error
-	if s.txRunner != nil {
-		persistErr = s.txRunner.RunInTx(ctx, persistAndPublish)
-	} else {
-		persistErr = persistAndPublish(ctx)
-	}
+	// Persist + outbox write in a transaction for L2 atomicity.
+	persistFn := s.buildPersistFn(auditEntry, appendedPayload)
+	persistErr := s.runPersist(ctx, persistFn)
 	if persistErr != nil {
 		s.logger.Error("audit-append: failed to persist entry",
 			slog.Any("error", persistErr), slog.String("event_id", entry.ID))
@@ -157,6 +136,33 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 		slog.String("entry_id", auditEntry.ID),
 		slog.String("event_type", entry.EventType))
 	return nil
+}
+
+// buildPersistFn returns a transaction function that persists the audit entry
+// and writes the outbox event.
+func (s *Service) buildPersistFn(auditEntry *domain.AuditEntry, appendedPayload []byte) func(context.Context) error {
+	return func(txCtx context.Context) error {
+		if err := s.repo.Append(txCtx, auditEntry); err != nil {
+			return err
+		}
+		if s.outboxWriter == nil {
+			return nil
+		}
+		return s.outboxWriter.Write(txCtx, outbox.Entry{
+			ID:        "evt" + "-" + uuid.NewString(),
+			EventType: TopicAuditAppended,
+			Payload:   appendedPayload,
+		})
+	}
+}
+
+// runPersist executes fn within a transaction if txRunner is configured,
+// otherwise calls fn directly.
+func (s *Service) runPersist(ctx context.Context, fn func(context.Context) error) error {
+	if s.txRunner != nil {
+		return s.txRunner.RunInTx(ctx, fn)
+	}
+	return fn(ctx)
 }
 
 // ChainLen returns the number of entries in the chain (for testing).

--- a/src/cells/audit-core/slices/auditappend/service_test.go
+++ b/src/cells/audit-core/slices/auditappend/service_test.go
@@ -1,6 +1,7 @@
 package auditappend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -87,6 +88,34 @@ func TestService_HandleEvent_ChainGrows(t *testing.T) {
 
 	assert.Equal(t, 5, svc.ChainLen())
 	assert.Equal(t, 5, repo.Len())
+}
+
+func TestService_HandleEvent_InvalidPayload_LogsWarning(t *testing.T) {
+	repo := mem.NewAuditRepository()
+	eb := eventbus.New()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	svc := NewService(repo, testHMACKey, eb, logger)
+
+	entry := outbox.Entry{
+		ID:        "evt-bad-json",
+		EventType: "event.user.created.v1",
+		Payload:   []byte("{invalid json}"),
+	}
+
+	err := svc.HandleEvent(context.Background(), entry)
+	require.NoError(t, err, "invalid payload should not cause HandleEvent to fail")
+
+	// Verify audit entry was created with fallback actorID.
+	entries, getErr := repo.GetRange(context.Background(), 0, 1)
+	require.NoError(t, getErr)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "system", entries[0].ActorID, "should fallback to system actor")
+
+	// Verify warning was logged.
+	logOutput := logBuf.String()
+	assert.Contains(t, logOutput, "failed to extract actor from payload")
+	assert.Contains(t, logOutput, "evt-bad-json")
 }
 
 func mustJSON(v any) []byte {

--- a/src/cells/audit-core/slices/auditquery/handler.go
+++ b/src/cells/audit-core/slices/auditquery/handler.go
@@ -29,7 +29,7 @@ func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if fromStr := r.URL.Query().Get("from"); fromStr != "" {
-		t, err := time.Parse(time.RFC3339, fromStr)
+		t, err := time.Parse(time.RFC3339Nano, fromStr)
 		if err != nil {
 			httputil.WriteError(r.Context(), w, http.StatusBadRequest, string(errcode.ErrInvalidTimeFormat),
 				"invalid 'from' parameter: expected RFC3339 format")
@@ -38,7 +38,7 @@ func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		filters.From = t
 	}
 	if toStr := r.URL.Query().Get("to"); toStr != "" {
-		t, err := time.Parse(time.RFC3339, toStr)
+		t, err := time.Parse(time.RFC3339Nano, toStr)
 		if err != nil {
 			httputil.WriteError(r.Context(), w, http.StatusBadRequest, string(errcode.ErrInvalidTimeFormat),
 				"invalid 'to' parameter: expected RFC3339 format")

--- a/src/cells/audit-core/slices/auditquery/service.go
+++ b/src/cells/audit-core/slices/auditquery/service.go
@@ -38,8 +38,8 @@ func (s *Service) Query(ctx context.Context, filters ports.AuditFilters, pageReq
 	qctx := query.QueryContext("endpoint", "audit-query",
 		"eventType", filters.EventType,
 		"actorId", filters.ActorID,
-		"from", filters.From.Format(time.RFC3339),
-		"to", filters.To.Format(time.RFC3339),
+		"from", filters.From.Format(time.RFC3339Nano),
+		"to", filters.To.Format(time.RFC3339Nano),
 	)
 
 	var cursorValues []any

--- a/src/cells/audit-core/slices/auditquery/service_test.go
+++ b/src/cells/audit-core/slices/auditquery/service_test.go
@@ -191,3 +191,32 @@ func TestService_Query_CursorContextMismatch(t *testing.T) {
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 	assert.Contains(t, ecErr.Message, "context mismatch")
 }
+
+func TestService_Query_SubsecondFilterContext(t *testing.T) {
+	// Two queries with from/to at the same second but different nanoseconds
+	// must produce different QueryContext fingerprints, so a cursor from one
+	// is rejected by the other.
+	base := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	svc, repo := newTestService()
+	for i := range 10 {
+		seedEntry(repo, fmt.Sprintf("ae-%02d", i), "event.test.v1", "usr-1",
+			base.Add(time.Duration(i)*time.Millisecond))
+	}
+
+	// Query A: from = base+100ns
+	filtersA := ports.AuditFilters{From: base.Add(100 * time.Nanosecond)}
+	pageA, err := svc.Query(context.Background(), filtersA, query.PageRequest{Limit: 3})
+	require.NoError(t, err)
+	require.True(t, pageA.HasMore)
+
+	// Query B: from = base+200ns (same second, different nanosecond)
+	filtersB := ports.AuditFilters{From: base.Add(200 * time.Nanosecond)}
+	_, err = svc.Query(context.Background(), filtersB, query.PageRequest{
+		Limit:  3,
+		Cursor: pageA.NextCursor,
+	})
+	require.Error(t, err, "cursor from query A must be rejected by query B with different sub-second from filter")
+	var ecErr2 *errcode.Error
+	require.ErrorAs(t, err, &ecErr2)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr2.Code)
+}

--- a/src/cells/config-core/cell_test.go
+++ b/src/cells/config-core/cell_test.go
@@ -2,6 +2,8 @@ package configcore
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -177,4 +179,41 @@ func TestConfigCore_RouteFlagsList(t *testing.T) {
 
 	assert.NotEqual(t, http.StatusNotFound, rec.Code,
 		"GET /api/v1/flags/ should not return 404 (got %d)", rec.Code)
+}
+
+func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	// Seed enough config entries to produce a nextCursor.
+	for i := range 3 {
+		body := fmt.Sprintf(`{"key":"cfg-%d","value":"val-%d"}`, i, i)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/config/", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusCreated, rec.Code, "setup: create config entry %d", i)
+	}
+
+	// Get config-read page with limit=1 to obtain a cursor.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/?limit=1", nil)
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var configPage struct {
+		NextCursor string `json:"nextCursor"`
+		HasMore    bool   `json:"hasMore"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&configPage))
+	require.True(t, configPage.HasMore, "need hasMore to get a cursor")
+	require.NotEmpty(t, configPage.NextCursor)
+
+	// Use config-read cursor on feature-flag list endpoint — must be rejected.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet,
+		"/api/v1/flags/?cursor="+configPage.NextCursor, nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"config-read cursor must be rejected by feature-flag endpoint")
 }

--- a/src/cells/config-core/cell_test.go
+++ b/src/cells/config-core/cell_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
@@ -216,4 +217,47 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code,
 		"config-read cursor must be rejected by feature-flag endpoint")
+
+}
+
+func TestConfigCore_CrossSliceCursorRejection_Reverse(t *testing.T) {
+	c := newTestCell()
+	ctx := context.Background()
+	deps := cell.Dependencies{Config: make(map[string]any)}
+	require.NoError(t, c.Init(ctx, deps))
+
+	r := router.New()
+	c.RegisterRoutes(r)
+
+	// Seed flags directly via repository (no HTTP create endpoint for flags).
+	for i := range 3 {
+		require.NoError(t, c.flagRepo.Create(ctx, &domain.FeatureFlag{
+			ID:      fmt.Sprintf("id-%d", i),
+			Key:     fmt.Sprintf("flag-%d", i),
+			Type:    domain.FlagBoolean,
+			Enabled: true,
+		}))
+	}
+
+	// Get flag page with limit=1 to obtain a cursor.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flags/?limit=1", nil)
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var flagPage struct {
+		NextCursor string `json:"nextCursor"`
+		HasMore    bool   `json:"hasMore"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&flagPage))
+	require.True(t, flagPage.HasMore, "need hasMore to get a flag cursor")
+
+	// Use flag cursor on config-read endpoint — must be rejected.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet,
+		"/api/v1/config/?cursor="+flagPage.NextCursor, nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"feature-flag cursor must be rejected by config-read endpoint")
 }

--- a/src/cells/config-core/internal/mem/config_repo.go
+++ b/src/cells/config-core/internal/mem/config_repo.go
@@ -5,10 +5,7 @@ package mem
 import (
 	"cmp"
 	"context"
-	"fmt"
-	"slices"
 	"sync"
-	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
@@ -95,49 +92,8 @@ func (r *ConfigRepository) List(_ context.Context, params query.ListParams) ([]*
 		all = append(all, &clone)
 	}
 
-	sortConfigEntries(all, params.Sort)
-	return applyConfigCursor(all, params), nil
-}
-
-// sortConfigEntries sorts config entries in-place by the given sort columns.
-func sortConfigEntries(entries []*domain.ConfigEntry, cols []query.SortColumn) {
-	if len(cols) == 0 {
-		return
-	}
-	slices.SortFunc(entries, func(a, b *domain.ConfigEntry) int {
-		for _, col := range cols {
-			v := compareConfigField(a, b, col.Name)
-			if col.Direction == query.SortDESC {
-				v = -v
-			}
-			if v != 0 {
-				return v
-			}
-		}
-		return 0
-	})
-}
-
-// applyConfigCursor skips rows until past the cursor position, then limits.
-func applyConfigCursor(entries []*domain.ConfigEntry, params query.ListParams) []*domain.ConfigEntry {
-	start := 0
-	if params.CursorValues != nil {
-		for i, e := range entries {
-			if configAfterCursor(e, params.Sort, params.CursorValues) {
-				start = i
-				break
-			}
-			if i == len(entries)-1 {
-				start = len(entries) // cursor past all rows
-			}
-		}
-	}
-
-	end := start + params.FetchLimit()
-	if end > len(entries) {
-		end = len(entries)
-	}
-	return entries[start:end]
+	query.Sort(all, params.Sort, compareConfigField)
+	return query.ApplyCursor(all, params, configFieldValue), nil
 }
 
 // compareConfigField compares a single field of two config entries.
@@ -160,32 +116,7 @@ func compareConfigField(a, b *domain.ConfigEntry, field string) int {
 	}
 }
 
-// configAfterCursor returns true if the entry is strictly after the cursor
-// position according to the sort columns and their directions.
-func configAfterCursor(e *domain.ConfigEntry, cols []query.SortColumn, cursorValues []any) bool {
-	for level := 0; level < len(cols); level++ {
-		val := configFieldValue(e, cols[level].Name)
-		curVal := cursorValues[level]
-		c := configCompareAny(val, curVal)
-
-		if level < len(cols)-1 {
-			if c != 0 {
-				if cols[level].Direction == query.SortDESC {
-					return c < 0
-				}
-				return c > 0
-			}
-			continue
-		}
-		// Last column: strict inequality.
-		if cols[level].Direction == query.SortDESC {
-			return c < 0
-		}
-		return c > 0
-	}
-	return false
-}
-
+// configFieldValue extracts a cursor-comparable value from a config entry.
 func configFieldValue(e *domain.ConfigEntry, field string) any {
 	switch field {
 	case "key":
@@ -197,27 +128,12 @@ func configFieldValue(e *domain.ConfigEntry, field string) any {
 	case "version":
 		return float64(e.Version)
 	case "created_at":
-		return e.CreatedAt.Format(time.RFC3339Nano)
+		return e.CreatedAt
 	case "updated_at":
-		return e.UpdatedAt.Format(time.RFC3339Nano)
+		return e.UpdatedAt
 	default:
 		return ""
 	}
-}
-
-// configCompareAny compares two values that are either string or float64.
-func configCompareAny(a, b any) int {
-	aStr, aOk := a.(string)
-	bStr, bOk := b.(string)
-	if aOk && bOk {
-		return cmp.Compare(aStr, bStr)
-	}
-	aFloat, aOk := a.(float64)
-	bFloat, bOk := b.(float64)
-	if aOk && bOk {
-		return cmp.Compare(aFloat, bFloat)
-	}
-	panic(fmt.Sprintf("configCompareAny: unsupported type combination %T vs %T", a, b))
 }
 
 func (r *ConfigRepository) PublishVersion(_ context.Context, version *domain.ConfigVersion) error {

--- a/src/cells/config-core/internal/mem/config_repo.go
+++ b/src/cells/config-core/internal/mem/config_repo.go
@@ -5,6 +5,7 @@ package mem
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
@@ -93,7 +94,11 @@ func (r *ConfigRepository) List(_ context.Context, params query.ListParams) ([]*
 	}
 
 	query.Sort(all, params.Sort, compareConfigField)
-	return query.ApplyCursor(all, params, configFieldValue)
+	result, err := query.ApplyCursor(all, params, configFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("config-repo: list: %w", err)
+	}
+	return result, nil
 }
 
 // compareConfigField compares a single field of two config entries.

--- a/src/cells/config-core/internal/mem/config_repo.go
+++ b/src/cells/config-core/internal/mem/config_repo.go
@@ -93,7 +93,7 @@ func (r *ConfigRepository) List(_ context.Context, params query.ListParams) ([]*
 	}
 
 	query.Sort(all, params.Sort, compareConfigField)
-	return query.ApplyCursor(all, params, configFieldValue), nil
+	return query.ApplyCursor(all, params, configFieldValue)
 }
 
 // compareConfigField compares a single field of two config entries.

--- a/src/cells/config-core/internal/mem/config_repo_test.go
+++ b/src/cells/config-core/internal/mem/config_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -483,8 +484,65 @@ func TestConfigRepository_PublishVersion_And_GetVersion(t *testing.T) {
 	})
 }
 
+func TestConfigRepository_List_SubsecondPrecision_CreatedAt(t *testing.T) {
+	repo := NewConfigRepository()
+	ctx := context.Background()
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	for i := range 3 {
+		now := base.Add(time.Duration(i*100) * time.Nanosecond)
+		require.NoError(t, repo.Create(ctx, &domain.ConfigEntry{
+			ID: fmt.Sprintf("id-%d", i), Key: fmt.Sprintf("key-%d", i),
+			Value: "v", Version: 1, CreatedAt: now, UpdatedAt: now,
+		}))
+	}
+
+	cursorTS := base.Add(100 * time.Nanosecond).Format(time.RFC3339Nano)
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{cursorTS, "id-1"},
+		Sort: []query.SortColumn{
+			{Name: "created_at", Direction: query.SortASC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+	result, err := repo.List(ctx, params)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "id-2", result[0].ID)
+}
+
+func TestConfigRepository_List_SubsecondPrecision_UpdatedAt(t *testing.T) {
+	repo := NewConfigRepository()
+	ctx := context.Background()
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	for i := range 3 {
+		now := base.Add(time.Duration(i*100) * time.Nanosecond)
+		require.NoError(t, repo.Create(ctx, &domain.ConfigEntry{
+			ID: fmt.Sprintf("id-%d", i), Key: fmt.Sprintf("key-%d", i),
+			Value: "v", Version: 1, CreatedAt: base, UpdatedAt: now,
+		}))
+	}
+
+	// DESC sort by updated_at, cursor at entry 1 (100ns).
+	cursorTS := base.Add(100 * time.Nanosecond).Format(time.RFC3339Nano)
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{cursorTS, "id-1"},
+		Sort: []query.SortColumn{
+			{Name: "updated_at", Direction: query.SortDESC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+	result, err := repo.List(ctx, params)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "id-0", result[0].ID)
+}
+
 // TestConfigRepository_ConcurrentCRUDAndList verifies that concurrent
-// CRUD and List calls do not race. Run with -race to verify.
+// CRUD and List calls do not race and maintain semantic invariants.
 func TestConfigRepository_ConcurrentCRUDAndList(t *testing.T) {
 	repo := NewConfigRepository()
 	ctx := context.Background()
@@ -494,6 +552,7 @@ func TestConfigRepository_ConcurrentCRUDAndList(t *testing.T) {
 	const iterations = 50
 
 	var wg sync.WaitGroup
+	var writeErrors, readErrors atomic.Int64
 
 	for w := range writers {
 		wg.Add(1)
@@ -501,14 +560,16 @@ func TestConfigRepository_ConcurrentCRUDAndList(t *testing.T) {
 			defer wg.Done()
 			for i := range iterations {
 				now := time.Now()
-				_ = repo.Create(ctx, &domain.ConfigEntry{
+				if err := repo.Create(ctx, &domain.ConfigEntry{
 					ID:        fmt.Sprintf("id-w%d-i%d", id, i),
 					Key:       fmt.Sprintf("key-w%d-i%d", id, i),
 					Value:     "val",
 					Version:   1,
 					CreatedAt: now,
 					UpdatedAt: now,
-				})
+				}); err != nil {
+					writeErrors.Add(1)
+				}
 			}
 		}(w)
 	}
@@ -525,12 +586,23 @@ func TestConfigRepository_ConcurrentCRUDAndList(t *testing.T) {
 				},
 			}
 			for range iterations {
-				_, _ = repo.List(ctx, params)
-				_, _ = repo.GetByKey(ctx, "key-w0-i0")
+				items, err := repo.List(ctx, params)
+				if err != nil {
+					readErrors.Add(1)
+					continue
+				}
+				// Semantic invariant: results must be sorted.
+				for j := 1; j < len(items); j++ {
+					if items[j].Key < items[j-1].Key {
+						t.Errorf("list results not sorted: %s < %s", items[j].Key, items[j-1].Key)
+					}
+				}
 			}
 			_ = r
 		}()
 	}
 
 	wg.Wait()
+	assert.Zero(t, writeErrors.Load(), "concurrent writes should not error (unique keys)")
+	assert.Zero(t, readErrors.Load(), "concurrent reads should not error")
 }

--- a/src/cells/config-core/internal/mem/config_repo_test.go
+++ b/src/cells/config-core/internal/mem/config_repo_test.go
@@ -2,6 +2,8 @@ package mem
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -479,4 +481,56 @@ func TestConfigRepository_PublishVersion_And_GetVersion(t *testing.T) {
 		_, err := repo.GetVersion(ctx, "cfg-1", 99)
 		require.Error(t, err)
 	})
+}
+
+// TestConfigRepository_ConcurrentCRUDAndList verifies that concurrent
+// CRUD and List calls do not race. Run with -race to verify.
+func TestConfigRepository_ConcurrentCRUDAndList(t *testing.T) {
+	repo := NewConfigRepository()
+	ctx := context.Background()
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				now := time.Now()
+				_ = repo.Create(ctx, &domain.ConfigEntry{
+					ID:        fmt.Sprintf("id-w%d-i%d", id, i),
+					Key:       fmt.Sprintf("key-w%d-i%d", id, i),
+					Value:     "val",
+					Version:   1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				})
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			params := query.ListParams{
+				Limit: 10,
+				Sort: []query.SortColumn{
+					{Name: "key", Direction: query.SortASC},
+					{Name: "id", Direction: query.SortASC},
+				},
+			}
+			for range iterations {
+				_, _ = repo.List(ctx, params)
+				_, _ = repo.GetByKey(ctx, "key-w0-i0")
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
 }

--- a/src/cells/config-core/internal/mem/flag_repo.go
+++ b/src/cells/config-core/internal/mem/flag_repo.go
@@ -77,7 +77,7 @@ func (r *FlagRepository) List(_ context.Context, params query.ListParams) ([]*do
 	}
 
 	query.Sort(all, params.Sort, compareFlagField)
-	return query.ApplyCursor(all, params, flagFieldValue), nil
+	return query.ApplyCursor(all, params, flagFieldValue)
 }
 
 // compareFlagField compares a single field of two feature flags.

--- a/src/cells/config-core/internal/mem/flag_repo.go
+++ b/src/cells/config-core/internal/mem/flag_repo.go
@@ -3,8 +3,6 @@ package mem
 import (
 	"cmp"
 	"context"
-	"fmt"
-	"slices"
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
@@ -12,7 +10,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 )
-
 
 // Compile-time check.
 var _ ports.FlagRepository = (*FlagRepository)(nil)
@@ -79,49 +76,8 @@ func (r *FlagRepository) List(_ context.Context, params query.ListParams) ([]*do
 		all = append(all, &clone)
 	}
 
-	sortFlags(all, params.Sort)
-	return applyFlagCursor(all, params), nil
-}
-
-// sortFlags sorts feature flags in-place by the given sort columns.
-func sortFlags(flags []*domain.FeatureFlag, cols []query.SortColumn) {
-	if len(cols) == 0 {
-		return
-	}
-	slices.SortFunc(flags, func(a, b *domain.FeatureFlag) int {
-		for _, col := range cols {
-			v := compareFlagField(a, b, col.Name)
-			if col.Direction == query.SortDESC {
-				v = -v
-			}
-			if v != 0 {
-				return v
-			}
-		}
-		return 0
-	})
-}
-
-// applyFlagCursor skips rows until past the cursor position, then limits.
-func applyFlagCursor(flags []*domain.FeatureFlag, params query.ListParams) []*domain.FeatureFlag {
-	start := 0
-	if params.CursorValues != nil {
-		for i, f := range flags {
-			if flagAfterCursor(f, params.Sort, params.CursorValues) {
-				start = i
-				break
-			}
-			if i == len(flags)-1 {
-				start = len(flags) // cursor past all rows
-			}
-		}
-	}
-
-	end := start + params.FetchLimit()
-	if end > len(flags) {
-		end = len(flags)
-	}
-	return flags[start:end]
+	query.Sort(all, params.Sort, compareFlagField)
+	return query.ApplyCursor(all, params, flagFieldValue), nil
 }
 
 // compareFlagField compares a single field of two feature flags.
@@ -136,32 +92,7 @@ func compareFlagField(a, b *domain.FeatureFlag, field string) int {
 	}
 }
 
-// flagAfterCursor returns true if the flag is strictly after the cursor
-// position according to the sort columns and their directions.
-func flagAfterCursor(f *domain.FeatureFlag, cols []query.SortColumn, cursorValues []any) bool {
-	for level := 0; level < len(cols); level++ {
-		val := flagFieldValue(f, cols[level].Name)
-		curVal := cursorValues[level]
-		c := compareFlagAny(val, curVal)
-
-		if level < len(cols)-1 {
-			if c != 0 {
-				if cols[level].Direction == query.SortDESC {
-					return c < 0
-				}
-				return c > 0
-			}
-			continue
-		}
-		// Last column: strict inequality.
-		if cols[level].Direction == query.SortDESC {
-			return c < 0
-		}
-		return c > 0
-	}
-	return false
-}
-
+// flagFieldValue extracts a cursor-comparable value from a feature flag.
 func flagFieldValue(f *domain.FeatureFlag, field string) any {
 	switch field {
 	case "key":
@@ -171,19 +102,4 @@ func flagFieldValue(f *domain.FeatureFlag, field string) any {
 	default:
 		return ""
 	}
-}
-
-// compareFlagAny compares two values that are either string or float64.
-func compareFlagAny(a, b any) int {
-	aStr, aOk := a.(string)
-	bStr, bOk := b.(string)
-	if aOk && bOk {
-		return cmp.Compare(aStr, bStr)
-	}
-	aFloat, aOk := a.(float64)
-	bFloat, bOk := b.(float64)
-	if aOk && bOk {
-		return cmp.Compare(aFloat, bFloat)
-	}
-	panic(fmt.Sprintf("compareFlagAny: unsupported type combination %T vs %T", a, b))
 }

--- a/src/cells/config-core/internal/mem/flag_repo.go
+++ b/src/cells/config-core/internal/mem/flag_repo.go
@@ -3,6 +3,7 @@ package mem
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
@@ -77,7 +78,11 @@ func (r *FlagRepository) List(_ context.Context, params query.ListParams) ([]*do
 	}
 
 	query.Sort(all, params.Sort, compareFlagField)
-	return query.ApplyCursor(all, params, flagFieldValue)
+	result, err := query.ApplyCursor(all, params, flagFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("flag-repo: list: %w", err)
+	}
+	return result, nil
 }
 
 // compareFlagField compares a single field of two feature flags.

--- a/src/cells/config-core/internal/mem/flag_repo_test.go
+++ b/src/cells/config-core/internal/mem/flag_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -332,6 +333,7 @@ func TestFlagRepository_ConcurrentCRUDAndList(t *testing.T) {
 		}(w)
 	}
 
+	var readErrors atomic.Int64
 	for r := range readers {
 		wg.Add(1)
 		go func() {
@@ -344,12 +346,22 @@ func TestFlagRepository_ConcurrentCRUDAndList(t *testing.T) {
 				},
 			}
 			for range iterations {
-				_, _ = repo.List(ctx, params)
-				_, _ = repo.GetByKey(ctx, "flag-w0-i0")
+				items, err := repo.List(ctx, params)
+				if err != nil {
+					readErrors.Add(1)
+					continue
+				}
+				// Semantic invariant: results sorted by key.
+				for j := 1; j < len(items); j++ {
+					if items[j].Key < items[j-1].Key {
+						t.Errorf("flag list not sorted: %s < %s", items[j].Key, items[j-1].Key)
+					}
+				}
 			}
 			_ = r
 		}()
 	}
 
 	wg.Wait()
+	assert.Zero(t, readErrors.Load(), "concurrent reads should not error")
 }

--- a/src/cells/config-core/internal/mem/flag_repo_test.go
+++ b/src/cells/config-core/internal/mem/flag_repo_test.go
@@ -2,6 +2,8 @@ package mem
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -303,4 +305,51 @@ func TestFlagRepository_List_Empty(t *testing.T) {
 	result, err := repo.List(context.Background(), params)
 	require.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+// TestFlagRepository_ConcurrentCRUDAndList verifies that concurrent
+// CRUD and List calls do not race. Run with -race to verify.
+func TestFlagRepository_ConcurrentCRUDAndList(t *testing.T) {
+	repo := NewFlagRepository()
+	ctx := context.Background()
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				_ = repo.Create(ctx, &domain.FeatureFlag{
+					ID:  fmt.Sprintf("id-w%d-i%d", id, i),
+					Key: fmt.Sprintf("flag-w%d-i%d", id, i),
+				})
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			params := query.ListParams{
+				Limit: 10,
+				Sort: []query.SortColumn{
+					{Name: "key", Direction: query.SortASC},
+					{Name: "id", Direction: query.SortASC},
+				},
+			}
+			for range iterations {
+				_, _ = repo.List(ctx, params)
+				_, _ = repo.GetByKey(ctx, "flag-w0-i0")
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
 }

--- a/src/cells/device-cell/internal/mem/repository.go
+++ b/src/cells/device-cell/internal/mem/repository.go
@@ -100,7 +100,7 @@ func (r *CommandRepository) ListPending(_ context.Context, deviceID string, para
 	}
 
 	query.Sort(filtered, params.Sort, compareCommandField)
-	return query.ApplyCursor(filtered, params, commandFieldValue), nil
+	return query.ApplyCursor(filtered, params, commandFieldValue)
 }
 
 // compareCommandField compares a single field of two commands.

--- a/src/cells/device-cell/internal/mem/repository.go
+++ b/src/cells/device-cell/internal/mem/repository.go
@@ -100,7 +100,11 @@ func (r *CommandRepository) ListPending(_ context.Context, deviceID string, para
 	}
 
 	query.Sort(filtered, params.Sort, compareCommandField)
-	return query.ApplyCursor(filtered, params, commandFieldValue)
+	result, err := query.ApplyCursor(filtered, params, commandFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("command-repo: list-pending: %w", err)
+	}
+	return result, nil
 }
 
 // compareCommandField compares a single field of two commands.

--- a/src/cells/device-cell/internal/mem/repository.go
+++ b/src/cells/device-cell/internal/mem/repository.go
@@ -5,7 +5,6 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -100,49 +99,8 @@ func (r *CommandRepository) ListPending(_ context.Context, deviceID string, para
 		}
 	}
 
-	sortCommands(filtered, params.Sort)
-	return applyCommandCursor(filtered, params), nil
-}
-
-// sortCommands sorts commands in-place by the given sort columns.
-func sortCommands(cmds []*domain.Command, cols []query.SortColumn) {
-	if len(cols) == 0 {
-		return
-	}
-	slices.SortFunc(cmds, func(a, b *domain.Command) int {
-		for _, col := range cols {
-			v := compareCommandField(a, b, col.Name)
-			if col.Direction == query.SortDESC {
-				v = -v
-			}
-			if v != 0 {
-				return v
-			}
-		}
-		return 0
-	})
-}
-
-// applyCommandCursor skips rows until past the cursor position, then limits.
-func applyCommandCursor(cmds []*domain.Command, params query.ListParams) []*domain.Command {
-	start := 0
-	if params.CursorValues != nil {
-		for i, cmd := range cmds {
-			if commandAfterCursor(cmd, params.Sort, params.CursorValues) {
-				start = i
-				break
-			}
-			if i == len(cmds)-1 {
-				start = len(cmds) // cursor past all rows
-			}
-		}
-	}
-
-	end := start + params.FetchLimit()
-	if end > len(cmds) {
-		end = len(cmds)
-	}
-	return cmds[start:end]
+	query.Sort(filtered, params.Sort, compareCommandField)
+	return query.ApplyCursor(filtered, params, commandFieldValue), nil
 }
 
 // compareCommandField compares a single field of two commands.
@@ -163,36 +121,11 @@ func compareCommandField(a, b *domain.Command, field string) int {
 	}
 }
 
-// commandAfterCursor returns true if the command is strictly after the cursor
-// position according to the sort columns and their directions.
-func commandAfterCursor(cmd *domain.Command, cols []query.SortColumn, cursorValues []any) bool {
-	for level := 0; level < len(cols); level++ {
-		val := commandFieldValue(cmd, cols[level].Name)
-		curVal := cursorValues[level]
-		c := compareAny(val, curVal)
-
-		if level < len(cols)-1 {
-			if c != 0 {
-				if cols[level].Direction == query.SortDESC {
-					return c < 0
-				}
-				return c > 0
-			}
-			continue
-		}
-		// Last column: strict inequality.
-		if cols[level].Direction == query.SortDESC {
-			return c < 0
-		}
-		return c > 0
-	}
-	return false
-}
-
+// commandFieldValue extracts a cursor-comparable value from a command.
 func commandFieldValue(cmd *domain.Command, field string) any {
 	switch field {
 	case "created_at":
-		return cmd.CreatedAt.Format(time.RFC3339Nano)
+		return cmd.CreatedAt
 	case "id":
 		return cmd.ID
 	case "device_id":
@@ -204,21 +137,6 @@ func commandFieldValue(cmd *domain.Command, field string) any {
 	default:
 		return ""
 	}
-}
-
-// compareAny compares two values that are either string or float64.
-func compareAny(a, b any) int {
-	aStr, aOk := a.(string)
-	bStr, bOk := b.(string)
-	if aOk && bOk {
-		return cmp.Compare(aStr, bStr)
-	}
-	aFloat, aOk := a.(float64)
-	bFloat, bOk := b.(float64)
-	if aOk && bOk {
-		return cmp.Compare(aFloat, bFloat)
-	}
-	panic(fmt.Sprintf("compareAny: unsupported type combination %T vs %T", a, b))
 }
 
 // Ack marks a command as acknowledged.

--- a/src/cells/device-cell/internal/mem/repository_test.go
+++ b/src/cells/device-cell/internal/mem/repository_test.go
@@ -2,6 +2,8 @@ package mem
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -522,4 +524,74 @@ func TestCommandRepository_ListPending_CursorDESC(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cmds, 1)
 	assert.Equal(t, "c1", cmds[0].ID)
+}
+
+func TestCommandRepository_ListPending_SubsecondPrecision(t *testing.T) {
+	repo := NewCommandRepository()
+	ctx := context.Background()
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	_ = repo.Create(ctx, &domain.Command{ID: "c1", DeviceID: "dev-1", Status: "pending", CreatedAt: base.Add(100 * time.Nanosecond)})
+	_ = repo.Create(ctx, &domain.Command{ID: "c2", DeviceID: "dev-1", Status: "pending", CreatedAt: base.Add(200 * time.Nanosecond)})
+	_ = repo.Create(ctx, &domain.Command{ID: "c3", DeviceID: "dev-1", Status: "pending", CreatedAt: base.Add(300 * time.Nanosecond)})
+
+	// Cursor at c2 (200ns), ASC → should return c3 only.
+	cursorTS := base.Add(200 * time.Nanosecond).Format(time.RFC3339Nano)
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{cursorTS, "c2"},
+		Sort: []query.SortColumn{
+			{Name: "created_at", Direction: query.SortASC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+	cmds, err := repo.ListPending(ctx, "dev-1", params)
+	require.NoError(t, err)
+	require.Len(t, cmds, 1)
+	assert.Equal(t, "c3", cmds[0].ID)
+}
+
+// TestCommandRepository_ConcurrentCreateAndListPending verifies that concurrent
+// Create and ListPending calls do not race. Run with -race to verify.
+func TestCommandRepository_ConcurrentCreateAndListPending(t *testing.T) {
+	repo := NewCommandRepository()
+	ctx := context.Background()
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				_ = repo.Create(ctx, &domain.Command{
+					ID:        fmt.Sprintf("cmd-w%d-i%d", id, i),
+					DeviceID:  "dev-1",
+					Status:    "pending",
+					CreatedAt: time.Now(),
+				})
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			params := query.ListParams{
+				Limit: 10,
+				Sort:  defaultCmdSort,
+			}
+			for range iterations {
+				_, _ = repo.ListPending(ctx, "dev-1", params)
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
 }

--- a/src/cells/device-cell/internal/mem/repository_test.go
+++ b/src/cells/device-cell/internal/mem/repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -578,6 +579,7 @@ func TestCommandRepository_ConcurrentCreateAndListPending(t *testing.T) {
 		}(w)
 	}
 
+	var readErrors atomic.Int64
 	for r := range readers {
 		wg.Add(1)
 		go func() {
@@ -587,11 +589,15 @@ func TestCommandRepository_ConcurrentCreateAndListPending(t *testing.T) {
 				Sort:  defaultCmdSort,
 			}
 			for range iterations {
-				_, _ = repo.ListPending(ctx, "dev-1", params)
+				_, err := repo.ListPending(ctx, "dev-1", params)
+				if err != nil {
+					readErrors.Add(1)
+				}
 			}
 			_ = r
 		}()
 	}
 
 	wg.Wait()
+	assert.Zero(t, readErrors.Load(), "concurrent reads should not error")
 }

--- a/src/cells/order-cell/internal/mem/repository.go
+++ b/src/cells/order-cell/internal/mem/repository.go
@@ -70,7 +70,11 @@ func (r *OrderRepository) List(_ context.Context, params query.ListParams) ([]*d
 	}
 
 	query.Sort(all, params.Sort, compareOrderField)
-	return query.ApplyCursor(all, params, orderFieldValue)
+	result, err := query.ApplyCursor(all, params, orderFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("order-repo: list: %w", err)
+	}
+	return result, nil
 }
 
 // compareOrderField compares a single field of two orders.

--- a/src/cells/order-cell/internal/mem/repository.go
+++ b/src/cells/order-cell/internal/mem/repository.go
@@ -70,7 +70,7 @@ func (r *OrderRepository) List(_ context.Context, params query.ListParams) ([]*d
 	}
 
 	query.Sort(all, params.Sort, compareOrderField)
-	return query.ApplyCursor(all, params, orderFieldValue), nil
+	return query.ApplyCursor(all, params, orderFieldValue)
 }
 
 // compareOrderField compares a single field of two orders.

--- a/src/cells/order-cell/internal/mem/repository.go
+++ b/src/cells/order-cell/internal/mem/repository.go
@@ -5,9 +5,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"slices"
 	"sync"
-	"time"
 
 	"github.com/ghbvf/gocell/cells/order-cell/internal/domain"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -71,49 +69,8 @@ func (r *OrderRepository) List(_ context.Context, params query.ListParams) ([]*d
 		all = append(all, &cp)
 	}
 
-	sortOrders(all, params.Sort)
-	return applyOrderCursor(all, params), nil
-}
-
-// sortOrders sorts orders in-place by the given sort columns.
-func sortOrders(orders []*domain.Order, cols []query.SortColumn) {
-	if len(cols) == 0 {
-		return
-	}
-	slices.SortFunc(orders, func(a, b *domain.Order) int {
-		for _, col := range cols {
-			v := compareOrderField(a, b, col.Name)
-			if col.Direction == query.SortDESC {
-				v = -v
-			}
-			if v != 0 {
-				return v
-			}
-		}
-		return 0
-	})
-}
-
-// applyOrderCursor skips rows until past the cursor position, then limits.
-func applyOrderCursor(orders []*domain.Order, params query.ListParams) []*domain.Order {
-	start := 0
-	if params.CursorValues != nil {
-		for i, o := range orders {
-			if orderAfterCursor(o, params.Sort, params.CursorValues) {
-				start = i
-				break
-			}
-			if i == len(orders)-1 {
-				start = len(orders) // cursor past all rows
-			}
-		}
-	}
-
-	end := start + params.FetchLimit()
-	if end > len(orders) {
-		end = len(orders)
-	}
-	return orders[start:end]
+	query.Sort(all, params.Sort, compareOrderField)
+	return query.ApplyCursor(all, params, orderFieldValue), nil
 }
 
 // compareOrderField compares a single field of two orders.
@@ -132,36 +89,11 @@ func compareOrderField(a, b *domain.Order, field string) int {
 	}
 }
 
-// orderAfterCursor returns true if the order is strictly after the cursor
-// position according to the sort columns and their directions.
-func orderAfterCursor(o *domain.Order, cols []query.SortColumn, cursorValues []any) bool {
-	for level := 0; level < len(cols); level++ {
-		val := orderFieldValue(o, cols[level].Name)
-		curVal := cursorValues[level]
-		c := compareAny(val, curVal)
-
-		if level < len(cols)-1 {
-			if c != 0 {
-				if cols[level].Direction == query.SortDESC {
-					return c < 0
-				}
-				return c > 0
-			}
-			continue
-		}
-		// Last column: strict inequality.
-		if cols[level].Direction == query.SortDESC {
-			return c < 0
-		}
-		return c > 0
-	}
-	return false
-}
-
+// orderFieldValue extracts a cursor-comparable value from an order.
 func orderFieldValue(o *domain.Order, field string) any {
 	switch field {
 	case "created_at":
-		return o.CreatedAt.Format(time.RFC3339Nano)
+		return o.CreatedAt
 	case "id":
 		return o.ID
 	case "item":
@@ -171,19 +103,4 @@ func orderFieldValue(o *domain.Order, field string) any {
 	default:
 		return ""
 	}
-}
-
-// compareAny compares two values that are either string or float64.
-func compareAny(a, b any) int {
-	aStr, aOk := a.(string)
-	bStr, bOk := b.(string)
-	if aOk && bOk {
-		return cmp.Compare(aStr, bStr)
-	}
-	aFloat, aOk := a.(float64)
-	bFloat, bOk := b.(float64)
-	if aOk && bOk {
-		return cmp.Compare(aFloat, bFloat)
-	}
-	panic(fmt.Sprintf("compareAny: unsupported type combination %T vs %T", a, b))
 }

--- a/src/cells/order-cell/internal/mem/repository_test.go
+++ b/src/cells/order-cell/internal/mem/repository_test.go
@@ -3,6 +3,7 @@ package mem
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -405,4 +406,78 @@ func TestOrderRepository_ListPaged_CursorStatusField(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 	assert.Equal(t, "pending", orders[0].Status)
+}
+
+func TestOrderRepository_ListPaged_SubsecondPrecision(t *testing.T) {
+	repo := NewOrderRepository()
+	ctx := context.Background()
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	_ = repo.Create(ctx, &domain.Order{ID: "1", Item: "a", CreatedAt: base.Add(100 * time.Nanosecond)})
+	_ = repo.Create(ctx, &domain.Order{ID: "2", Item: "b", CreatedAt: base.Add(200 * time.Nanosecond)})
+	_ = repo.Create(ctx, &domain.Order{ID: "3", Item: "c", CreatedAt: base.Add(300 * time.Nanosecond)})
+
+	// Cursor at order 2 (200ns), ASC → should return order 3 only.
+	cursorTS := base.Add(200 * time.Nanosecond).Format(time.RFC3339Nano)
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{cursorTS, "2"},
+		Sort: []query.SortColumn{
+			{Name: "created_at", Direction: query.SortASC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+	orders, err := repo.List(ctx, params)
+	require.NoError(t, err)
+	require.Len(t, orders, 1)
+	assert.Equal(t, "3", orders[0].ID)
+}
+
+// TestOrderRepository_ConcurrentCreateAndList verifies that concurrent
+// Create and List calls do not race. Run with -race to verify.
+func TestOrderRepository_ConcurrentCreateAndList(t *testing.T) {
+	repo := NewOrderRepository()
+	ctx := context.Background()
+
+	const writers = 5
+	const readers = 10
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				_ = repo.Create(ctx, &domain.Order{
+					ID:        fmt.Sprintf("ord-w%d-i%d", id, i),
+					Item:      "item",
+					Status:    "pending",
+					CreatedAt: time.Now(),
+				})
+			}
+		}(w)
+	}
+
+	for r := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			params := query.ListParams{
+				Limit: 10,
+				Sort: []query.SortColumn{
+					{Name: "created_at", Direction: query.SortDESC},
+					{Name: "id", Direction: query.SortASC},
+				},
+			}
+			for range iterations {
+				_, _ = repo.List(ctx, params)
+				_, _ = repo.GetByID(ctx, "ord-w0-i0")
+			}
+			_ = r
+		}()
+	}
+
+	wg.Wait()
 }

--- a/src/cells/order-cell/internal/mem/repository_test.go
+++ b/src/cells/order-cell/internal/mem/repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -460,6 +461,7 @@ func TestOrderRepository_ConcurrentCreateAndList(t *testing.T) {
 		}(w)
 	}
 
+	var readErrors atomic.Int64
 	for r := range readers {
 		wg.Add(1)
 		go func() {
@@ -472,12 +474,24 @@ func TestOrderRepository_ConcurrentCreateAndList(t *testing.T) {
 				},
 			}
 			for range iterations {
-				_, _ = repo.List(ctx, params)
-				_, _ = repo.GetByID(ctx, "ord-w0-i0")
+				items, err := repo.List(ctx, params)
+				if err != nil {
+					readErrors.Add(1)
+					continue
+				}
+				// Semantic invariant: no duplicate IDs in a page.
+				seen := make(map[string]bool, len(items))
+				for _, o := range items {
+					if seen[o.ID] {
+						t.Errorf("duplicate order ID in list results: %s", o.ID)
+					}
+					seen[o.ID] = true
+				}
 			}
 			_ = r
 		}()
 	}
 
 	wg.Wait()
+	assert.Zero(t, readErrors.Load(), "concurrent reads should not error")
 }

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -122,12 +122,7 @@ func CompareAny(a, b any) (int, error) {
 			return cmp.Compare(av, bv), nil
 		}
 		if bt, ok := b.(time.Time); ok {
-			at, err := time.Parse(time.RFC3339Nano, av)
-			if err != nil {
-				return 0, errcode.New(errcode.ErrCursorInvalid,
-					fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", av, err))
-			}
-			return at.Compare(bt), nil
+			return compareStringWithTime(av, bt)
 		}
 	case float64:
 		if bv, ok := b.(float64); ok {
@@ -138,15 +133,30 @@ func CompareAny(a, b any) (int, error) {
 			return av.Compare(bt), nil
 		}
 		if bs, ok := b.(string); ok {
-			bt, err := time.Parse(time.RFC3339Nano, bs)
-			if err != nil {
-				return 0, errcode.New(errcode.ErrCursorInvalid,
-					fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", bs, err))
-			}
-			return av.Compare(bt), nil
+			return compareTimeWithString(av, bs)
 		}
 	}
 
 	return 0, errcode.New(errcode.ErrCursorInvalid,
 		fmt.Sprintf("unsupported cursor value type combination %T vs %T", a, b))
+}
+
+// compareStringWithTime parses s as RFC3339Nano and compares with t.
+func compareStringWithTime(s string, t time.Time) (int, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return 0, errcode.New(errcode.ErrCursorInvalid,
+			fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", s, err))
+	}
+	return parsed.Compare(t), nil
+}
+
+// compareTimeWithString parses s as RFC3339Nano and compares t with the result.
+func compareTimeWithString(t time.Time, s string) (int, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return 0, errcode.New(errcode.ErrCursorInvalid,
+			fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", s, err))
+	}
+	return t.Compare(parsed), nil
 }

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // CompareFunc compares a single named field of two entities, returning -1/0/+1.
@@ -12,8 +14,8 @@ type CompareFunc[T any] func(a, b T, field string) int
 
 // FieldFunc extracts a cursor-comparable value from an entity by field name.
 // Returned values must be string, float64, or time.Time — other types will
-// cause CompareAny to panic. Time fields should return time.Time (not a
-// formatted string) so that CompareAny uses temporal comparison.
+// cause CompareAny to return an error. Time fields should return time.Time
+// (not a formatted string) so that CompareAny uses temporal comparison.
 type FieldFunc[T any] func(item T, field string) any
 
 // Sort sorts items in-place by the given sort columns using compareField.
@@ -37,11 +39,26 @@ func Sort[T any](items []T, cols []SortColumn, compareField CompareFunc[T]) {
 
 // ApplyCursor skips items at or before the cursor position, then limits to
 // FetchLimit() (Limit+1 for N+1 hasMore detection).
-func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) []T {
+//
+// Returns ErrCursorInvalid if CursorValues length does not match Sort columns
+// or if cursor value types are incompatible.
+func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) ([]T, error) {
+	if params.CursorValues != nil {
+		if len(params.CursorValues) != len(params.Sort) {
+			return nil, errcode.New(errcode.ErrCursorInvalid,
+				fmt.Sprintf("cursor values count %d does not match sort columns count %d",
+					len(params.CursorValues), len(params.Sort)))
+		}
+	}
+
 	start := 0
 	if params.CursorValues != nil {
 		for i, item := range items {
-			if afterCursor(item, params.Sort, params.CursorValues, fieldValue) {
+			after, err := afterCursor(item, params.Sort, params.CursorValues, fieldValue)
+			if err != nil {
+				return nil, err
+			}
+			if after {
 				start = i
 				break
 			}
@@ -52,7 +69,7 @@ func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) [
 	}
 
 	end := min(start+params.FetchLimit(), len(items))
-	return items[start:end]
+	return items[start:end], nil
 }
 
 // afterCursor returns true if item is strictly after the cursor position
@@ -63,28 +80,31 @@ func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) [
 // - Non-last column, values differ: result determined by direction (ASC→positive, DESC→negative).
 // - Non-last column, values equal: continue to next column.
 // - Last column: strict inequality required (excludes the cursor item itself).
-func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValue FieldFunc[T]) bool {
+func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValue FieldFunc[T]) (bool, error) {
 	for level := range len(cols) {
 		val := fieldValue(item, cols[level].Name)
 		curVal := cursorValues[level]
-		c := CompareAny(val, curVal)
+		c, err := CompareAny(val, curVal)
+		if err != nil {
+			return false, err
+		}
 
 		if level < len(cols)-1 {
 			if c != 0 {
 				if cols[level].Direction == SortDESC {
-					return c < 0
+					return c < 0, nil
 				}
-				return c > 0
+				return c > 0, nil
 			}
 			continue
 		}
 		// Last column: strict inequality.
 		if cols[level].Direction == SortDESC {
-			return c < 0
+			return c < 0, nil
 		}
-		return c > 0
+		return c > 0, nil
 	}
-	return false
+	return false, nil
 }
 
 // CompareAny compares two values that may be string, float64, or time.Time.
@@ -93,40 +113,40 @@ func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValu
 // from JSON decode.
 //
 // Supported type pairs: string↔string, float64↔float64, time.Time↔time.Time,
-// time.Time↔string (parsed as RFC3339Nano). All other combinations panic.
-// This is safe because inputs come from HMAC-validated cursor values (JSON
-// decode produces only string/float64) and FieldFunc callbacks (returning
-// string/float64/time.Time).
-func CompareAny(a, b any) int {
-	// Fast path: both same concrete type.
+// time.Time↔string (parsed as RFC3339Nano). All other combinations return
+// ErrCursorInvalid.
+func CompareAny(a, b any) (int, error) {
 	switch av := a.(type) {
 	case string:
 		if bv, ok := b.(string); ok {
-			return cmp.Compare(av, bv)
+			return cmp.Compare(av, bv), nil
 		}
 		if bt, ok := b.(time.Time); ok {
 			at, err := time.Parse(time.RFC3339Nano, av)
 			if err != nil {
-				panic(fmt.Sprintf("CompareAny: cannot parse string %q as RFC3339Nano: %v", av, err))
+				return 0, errcode.New(errcode.ErrCursorInvalid,
+					fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", av, err))
 			}
-			return at.Compare(bt)
+			return at.Compare(bt), nil
 		}
 	case float64:
 		if bv, ok := b.(float64); ok {
-			return cmp.Compare(av, bv)
+			return cmp.Compare(av, bv), nil
 		}
 	case time.Time:
 		if bt, ok := b.(time.Time); ok {
-			return av.Compare(bt)
+			return av.Compare(bt), nil
 		}
 		if bs, ok := b.(string); ok {
 			bt, err := time.Parse(time.RFC3339Nano, bs)
 			if err != nil {
-				panic(fmt.Sprintf("CompareAny: cannot parse string %q as RFC3339Nano: %v", bs, err))
+				return 0, errcode.New(errcode.ErrCursorInvalid,
+					fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", bs, err))
 			}
-			return av.Compare(bt)
+			return av.Compare(bt), nil
 		}
 	}
 
-	panic(fmt.Sprintf("CompareAny: unsupported type combination %T vs %T", a, b))
+	return 0, errcode.New(errcode.ErrCursorInvalid,
+		fmt.Sprintf("unsupported cursor value type combination %T vs %T", a, b))
 }

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -13,9 +13,10 @@ import (
 type CompareFunc[T any] func(a, b T, field string) int
 
 // FieldFunc extracts a cursor-comparable value from an entity by field name.
-// Returned values must be string, float64, or time.Time — other types will
-// cause CompareAny to return an error. Time fields should return time.Time
-// (not a formatted string) so that CompareAny uses temporal comparison.
+// Returned values must be string, int, float64, or time.Time — other types
+// will cause CompareAny to return an error. Time fields should return
+// time.Time (not a formatted string) so that CompareAny uses temporal
+// comparison.
 type FieldFunc[T any] func(item T, field string) any
 
 // Sort sorts items in-place by the given sort columns using compareField.
@@ -40,10 +41,18 @@ func Sort[T any](items []T, cols []SortColumn, compareField CompareFunc[T]) {
 // ApplyCursor skips items at or before the cursor position, then limits to
 // FetchLimit() (Limit+1 for N+1 hasMore detection).
 //
-// Returns ErrCursorInvalid if CursorValues length does not match Sort columns
-// or if cursor value types are incompatible.
+// Precondition: items must already be sorted by params.Sort columns (via Sort).
+// Behavior is undefined on unsorted input.
+//
+// Returns ErrCursorInvalid if CursorValues length does not match Sort columns,
+// if Sort is empty when CursorValues is present, or if cursor value types are
+// incompatible.
 func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) ([]T, error) {
 	if params.CursorValues != nil {
+		if len(params.Sort) == 0 {
+			return nil, errcode.New(errcode.ErrCursorInvalid,
+				"cursor values present but no sort columns defined")
+		}
 		if len(params.CursorValues) != len(params.Sort) {
 			return nil, errcode.New(errcode.ErrCursorInvalid,
 				fmt.Sprintf("cursor values count %d does not match sort columns count %d",
@@ -112,9 +121,9 @@ func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValu
 // which occurs when fieldValue returns time.Time but cursor values are strings
 // from JSON decode.
 //
-// Supported type pairs: string↔string, float64↔float64, time.Time↔time.Time,
-// time.Time↔string (parsed as RFC3339Nano). All other combinations return
-// ErrCursorInvalid.
+// Supported type pairs: string↔string, float64↔float64, int↔float64,
+// time.Time↔time.Time, time.Time↔string (parsed as RFC3339Nano).
+// All other combinations return ErrCursorInvalid.
 func CompareAny(a, b any) (int, error) {
 	switch av := a.(type) {
 	case string:
@@ -128,6 +137,16 @@ func CompareAny(a, b any) (int, error) {
 		if bv, ok := b.(float64); ok {
 			return cmp.Compare(av, bv), nil
 		}
+		if bv, ok := b.(int); ok {
+			return cmp.Compare(av, float64(bv)), nil
+		}
+	case int:
+		if bv, ok := b.(float64); ok {
+			return cmp.Compare(float64(av), bv), nil
+		}
+		if bv, ok := b.(int); ok {
+			return cmp.Compare(av, bv), nil
+		}
 	case time.Time:
 		if bt, ok := b.(time.Time); ok {
 			return av.Compare(bt), nil
@@ -137,8 +156,7 @@ func CompareAny(a, b any) (int, error) {
 		}
 	}
 
-	return 0, errcode.New(errcode.ErrCursorInvalid,
-		fmt.Sprintf("unsupported cursor value type combination %T vs %T", a, b))
+	return 0, errcode.New(errcode.ErrCursorInvalid, "invalid cursor value")
 }
 
 // compareStringWithTime parses s as RFC3339Nano and compares with t.

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -83,6 +83,12 @@ func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValu
 // It handles cross-type comparison between time.Time and RFC3339Nano strings,
 // which occurs when fieldValue returns time.Time but cursor values are strings
 // from JSON decode.
+//
+// Supported type pairs: string↔string, float64↔float64, time.Time↔time.Time,
+// time.Time↔string (parsed as RFC3339Nano). All other combinations panic.
+// This is safe because inputs come from HMAC-validated cursor values (JSON
+// decode produces only string/float64) and FieldFunc callbacks (returning
+// string/float64/time.Time).
 func CompareAny(a, b any) int {
 	// Fast path: both same concrete type.
 	switch av := a.(type) {

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -125,26 +125,22 @@ func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValu
 // time.Time↔time.Time, time.Time↔string (parsed as RFC3339Nano).
 // All other combinations return ErrCursorInvalid.
 func CompareAny(a, b any) (int, error) {
+	a, b = normalizeNumeric(a), normalizeNumeric(b)
+
 	switch av := a.(type) {
 	case string:
 		if bv, ok := b.(string); ok {
 			return cmp.Compare(av, bv), nil
 		}
 		if bt, ok := b.(time.Time); ok {
-			return compareStringWithTime(av, bt)
+			at, err := parseTimeString(av)
+			if err != nil {
+				return 0, err
+			}
+			return at.Compare(bt), nil
 		}
 	case float64:
 		if bv, ok := b.(float64); ok {
-			return cmp.Compare(av, bv), nil
-		}
-		if bv, ok := b.(int); ok {
-			return cmp.Compare(av, float64(bv)), nil
-		}
-	case int:
-		if bv, ok := b.(float64); ok {
-			return cmp.Compare(float64(av), bv), nil
-		}
-		if bv, ok := b.(int); ok {
 			return cmp.Compare(av, bv), nil
 		}
 	case time.Time:
@@ -152,29 +148,32 @@ func CompareAny(a, b any) (int, error) {
 			return av.Compare(bt), nil
 		}
 		if bs, ok := b.(string); ok {
-			return compareTimeWithString(av, bs)
+			bt, err := parseTimeString(bs)
+			if err != nil {
+				return 0, err
+			}
+			return av.Compare(bt), nil
 		}
 	}
 
 	return 0, errcode.New(errcode.ErrCursorInvalid, "invalid cursor value")
 }
 
-// compareStringWithTime parses s as RFC3339Nano and compares with t.
-func compareStringWithTime(s string, t time.Time) (int, error) {
-	parsed, err := time.Parse(time.RFC3339Nano, s)
-	if err != nil {
-		return 0, errcode.New(errcode.ErrCursorInvalid,
-			fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", s, err))
+// normalizeNumeric converts int to float64 for uniform numeric comparison.
+// JSON decode produces float64, but Go struct fields often use int.
+func normalizeNumeric(v any) any {
+	if i, ok := v.(int); ok {
+		return float64(i)
 	}
-	return parsed.Compare(t), nil
+	return v
 }
 
-// compareTimeWithString parses s as RFC3339Nano and compares t with the result.
-func compareTimeWithString(t time.Time, s string) (int, error) {
-	parsed, err := time.Parse(time.RFC3339Nano, s)
+// parseTimeString parses s as RFC3339Nano, returning ErrCursorInvalid on failure.
+func parseTimeString(s string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
-		return 0, errcode.New(errcode.ErrCursorInvalid,
+		return time.Time{}, errcode.New(errcode.ErrCursorInvalid,
 			fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", s, err))
 	}
-	return t.Compare(parsed), nil
+	return t, nil
 }

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -172,8 +172,7 @@ func normalizeNumeric(v any) any {
 func parseTimeString(s string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
-		return time.Time{}, errcode.New(errcode.ErrCursorInvalid,
-			fmt.Sprintf("cannot parse cursor value %q as timestamp: %v", s, err))
+		return time.Time{}, errcode.New(errcode.ErrCursorInvalid, "invalid cursor value")
 	}
 	return t, nil
 }

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -11,7 +11,9 @@ import (
 type CompareFunc[T any] func(a, b T, field string) int
 
 // FieldFunc extracts a cursor-comparable value from an entity by field name.
-// Returned values must be string, float64, or time.Time.
+// Returned values must be string, float64, or time.Time — other types will
+// cause CompareAny to panic. Time fields should return time.Time (not a
+// formatted string) so that CompareAny uses temporal comparison.
 type FieldFunc[T any] func(item T, field string) any
 
 // Sort sorts items in-place by the given sort columns using compareField.
@@ -55,6 +57,12 @@ func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) [
 
 // afterCursor returns true if item is strictly after the cursor position
 // according to the sort columns and their directions.
+//
+// Algorithm: multi-column lexicographic comparison with direction-awareness.
+// For each column from first to last: compare item value vs cursor value.
+// - Non-last column, values differ: result determined by direction (ASC→positive, DESC→negative).
+// - Non-last column, values equal: continue to next column.
+// - Last column: strict inequality required (excludes the cursor item itself).
 func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValue FieldFunc[T]) bool {
 	for level := range len(cols) {
 		val := fieldValue(item, cols[level].Name)

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -1,0 +1,118 @@
+package query
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"time"
+)
+
+// CompareFunc compares a single named field of two entities, returning -1/0/+1.
+type CompareFunc[T any] func(a, b T, field string) int
+
+// FieldFunc extracts a cursor-comparable value from an entity by field name.
+// Returned values must be string, float64, or time.Time.
+type FieldFunc[T any] func(item T, field string) any
+
+// Sort sorts items in-place by the given sort columns using compareField.
+func Sort[T any](items []T, cols []SortColumn, compareField CompareFunc[T]) {
+	if len(cols) == 0 {
+		return
+	}
+	slices.SortFunc(items, func(a, b T) int {
+		for _, col := range cols {
+			v := compareField(a, b, col.Name)
+			if col.Direction == SortDESC {
+				v = -v
+			}
+			if v != 0 {
+				return v
+			}
+		}
+		return 0
+	})
+}
+
+// ApplyCursor skips items at or before the cursor position, then limits to
+// FetchLimit() (Limit+1 for N+1 hasMore detection).
+func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) []T {
+	start := 0
+	if params.CursorValues != nil {
+		for i, item := range items {
+			if afterCursor(item, params.Sort, params.CursorValues, fieldValue) {
+				start = i
+				break
+			}
+			if i == len(items)-1 {
+				start = len(items) // cursor past all rows
+			}
+		}
+	}
+
+	end := min(start+params.FetchLimit(), len(items))
+	return items[start:end]
+}
+
+// afterCursor returns true if item is strictly after the cursor position
+// according to the sort columns and their directions.
+func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValue FieldFunc[T]) bool {
+	for level := range len(cols) {
+		val := fieldValue(item, cols[level].Name)
+		curVal := cursorValues[level]
+		c := CompareAny(val, curVal)
+
+		if level < len(cols)-1 {
+			if c != 0 {
+				if cols[level].Direction == SortDESC {
+					return c < 0
+				}
+				return c > 0
+			}
+			continue
+		}
+		// Last column: strict inequality.
+		if cols[level].Direction == SortDESC {
+			return c < 0
+		}
+		return c > 0
+	}
+	return false
+}
+
+// CompareAny compares two values that may be string, float64, or time.Time.
+// It handles cross-type comparison between time.Time and RFC3339Nano strings,
+// which occurs when fieldValue returns time.Time but cursor values are strings
+// from JSON decode.
+func CompareAny(a, b any) int {
+	// Fast path: both same concrete type.
+	switch av := a.(type) {
+	case string:
+		if bv, ok := b.(string); ok {
+			return cmp.Compare(av, bv)
+		}
+		if bt, ok := b.(time.Time); ok {
+			at, err := time.Parse(time.RFC3339Nano, av)
+			if err != nil {
+				panic(fmt.Sprintf("CompareAny: cannot parse string %q as RFC3339Nano: %v", av, err))
+			}
+			return at.Compare(bt)
+		}
+	case float64:
+		if bv, ok := b.(float64); ok {
+			return cmp.Compare(av, bv)
+		}
+	case time.Time:
+		if bt, ok := b.(time.Time); ok {
+			return av.Compare(bt)
+		}
+		if bs, ok := b.(string); ok {
+			bt, err := time.Parse(time.RFC3339Nano, bs)
+			if err != nil {
+				panic(fmt.Sprintf("CompareAny: cannot parse string %q as RFC3339Nano: %v", bs, err))
+			}
+			return av.Compare(bt)
+		}
+	}
+
+	panic(fmt.Sprintf("CompareAny: unsupported type combination %T vs %T", a, b))
+}

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -124,6 +124,13 @@ func TestSort_MultiColumn(t *testing.T) {
 	assert.Equal(t, "bob", items[2].Name)
 }
 
+func TestSort_EmptyItems(t *testing.T) {
+	var items []testItem
+	cols := []query.SortColumn{{Name: "id", Direction: query.SortASC}}
+	query.Sort(items, cols, compareTestField)
+	assert.Empty(t, items)
+}
+
 func TestSort_EmptyColumns(t *testing.T) {
 	items := []testItem{{ID: "b"}, {ID: "a"}}
 	query.Sort(items, nil, compareTestField)
@@ -260,6 +267,73 @@ func TestApplyCursor_TimeVsString_CrossType(t *testing.T) {
 	assert.Equal(t, "3", result[1].ID)
 }
 
+func TestApplyCursor_EmptyItems_WithCursor(t *testing.T) {
+	var items []testItem
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{"x"},
+		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortASC}},
+	}
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestApplyCursor_MultiColumn_MixedDirection(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	items := []testItem{
+		{ID: "1", CreatedAt: base.Add(2 * time.Second)},
+		{ID: "2", CreatedAt: base.Add(2 * time.Second)},
+		{ID: "3", CreatedAt: base.Add(time.Second)},
+		{ID: "4", CreatedAt: base.Add(time.Second)},
+		{ID: "5", CreatedAt: base},
+	}
+	// Sort: created_at DESC, id ASC. Cursor at (base+2s, "1").
+	// After cursor: items with same timestamp and id > "1", or earlier timestamps.
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{base.Add(2 * time.Second), "1"},
+		Sort: []query.SortColumn{
+			{Name: "created_at", Direction: query.SortDESC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
+	require.Len(t, result, 4)
+	assert.Equal(t, "2", result[0].ID) // same second, id > "1"
+	assert.Equal(t, "3", result[1].ID)
+	assert.Equal(t, "4", result[2].ID)
+	assert.Equal(t, "5", result[3].ID)
+}
+
+func TestApplyCursor_AllItemsEqualCursor(t *testing.T) {
+	items := []testItem{{ID: "a"}, {ID: "a"}, {ID: "a"}}
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{"a"},
+		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortASC}},
+	}
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
+	assert.Empty(t, result, "all items at cursor position should be skipped")
+}
+
+func TestApplyCursor_EmptySortWithCursor_ReturnsError(t *testing.T) {
+	items := []testItem{{ID: "a"}}
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{"a"},
+		Sort:         []query.SortColumn{},
+	}
+	_, err := query.ApplyCursor(items, params, testFieldValue)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+}
+
 func TestApplyCursor_MismatchedCursorValuesLength_ReturnsError(t *testing.T) {
 	items := []testItem{{ID: "a"}, {ID: "b"}}
 	params := query.ListParams{
@@ -326,11 +400,34 @@ func TestCompareAny_StringVsTime(t *testing.T) {
 	assert.Equal(t, 1, mustCompare(t, s, t1.Add(-time.Second)))
 }
 
-func TestCompareAny_UnsupportedType_ReturnsError(t *testing.T) {
-	_, err := query.CompareAny(42, "str")
+func TestCompareAny_IntVsFloat64(t *testing.T) {
+	assert.Equal(t, -1, mustCompare(t, 1, 2.0))
+	assert.Equal(t, 0, mustCompare(t, 3, 3.0))
+	assert.Equal(t, 1, mustCompare(t, 5, 2.0))
+}
+
+func TestCompareAny_Float64VsInt(t *testing.T) {
+	assert.Equal(t, -1, mustCompare(t, 1.0, 2))
+	assert.Equal(t, 0, mustCompare(t, 3.0, 3))
+	assert.Equal(t, 1, mustCompare(t, 5.0, 2))
+}
+
+func TestCompareAny_IntVsInt(t *testing.T) {
+	assert.Equal(t, -1, mustCompare(t, 1, 2))
+	assert.Equal(t, 0, mustCompare(t, 3, 3))
+	assert.Equal(t, 1, mustCompare(t, 5, 2))
+}
+
+func TestCompareAny_NilValue_ReturnsError(t *testing.T) {
+	_, err := query.CompareAny(nil, "x")
 	require.Error(t, err)
 
-	_, err = query.CompareAny(true, false)
+	_, err = query.CompareAny("x", nil)
+	require.Error(t, err)
+}
+
+func TestCompareAny_UnsupportedType_ReturnsError(t *testing.T) {
+	_, err := query.CompareAny(true, false)
 	require.Error(t, err)
 
 	_, err = query.CompareAny(1.0, "str")

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -302,4 +302,28 @@ func TestCompareAny_UnsupportedType_Panics(t *testing.T) {
 	assert.Panics(t, func() {
 		query.CompareAny(true, false)
 	})
+	assert.Panics(t, func() {
+		query.CompareAny(1.0, "str")
+	})
+	assert.Panics(t, func() {
+		query.CompareAny(1.0, time.Now())
+	})
+}
+
+func TestApplyCursor_MismatchedCursorValuesLength_Panics(t *testing.T) {
+	items := []testItem{{ID: "a"}, {ID: "b"}}
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{"a"}, // 1 value but 2 sort columns
+		Sort: []query.SortColumn{
+			{Name: "id", Direction: query.SortASC},
+			{Name: "name", Direction: query.SortASC},
+		},
+	}
+
+	// ApplyCursor does not validate length — this is enforced upstream by
+	// ValidateCursorScope. If bypass occurs, it panics with index out of range.
+	assert.Panics(t, func() {
+		query.ApplyCursor(items, params, testFieldValue)
+	})
 }

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -1,0 +1,305 @@
+package query_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers ---
+
+type testItem struct {
+	ID        string
+	Name      string
+	Score     float64
+	CreatedAt time.Time
+}
+
+func compareTestField(a, b testItem, field string) int {
+	switch field {
+	case "id":
+		return cmpStr(a.ID, b.ID)
+	case "name":
+		return cmpStr(a.Name, b.Name)
+	case "score":
+		return cmpFloat(a.Score, b.Score)
+	case "created_at":
+		return a.CreatedAt.Compare(b.CreatedAt)
+	default:
+		return 0
+	}
+}
+
+func testFieldValue(item testItem, field string) any {
+	switch field {
+	case "id":
+		return item.ID
+	case "name":
+		return item.Name
+	case "score":
+		return item.Score
+	case "created_at":
+		return item.CreatedAt
+	default:
+		return ""
+	}
+}
+
+func cmpStr(a, b string) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+func cmpFloat(a, b float64) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+// --- Sort tests ---
+
+func TestSort_SingleColumn_ASC(t *testing.T) {
+	items := []testItem{
+		{ID: "c"}, {ID: "a"}, {ID: "b"},
+	}
+	cols := []query.SortColumn{{Name: "id", Direction: query.SortASC}}
+
+	query.Sort(items, cols, compareTestField)
+
+	assert.Equal(t, "a", items[0].ID)
+	assert.Equal(t, "b", items[1].ID)
+	assert.Equal(t, "c", items[2].ID)
+}
+
+func TestSort_SingleColumn_DESC(t *testing.T) {
+	items := []testItem{
+		{ID: "a"}, {ID: "c"}, {ID: "b"},
+	}
+	cols := []query.SortColumn{{Name: "id", Direction: query.SortDESC}}
+
+	query.Sort(items, cols, compareTestField)
+
+	assert.Equal(t, "c", items[0].ID)
+	assert.Equal(t, "b", items[1].ID)
+	assert.Equal(t, "a", items[2].ID)
+}
+
+func TestSort_MultiColumn(t *testing.T) {
+	items := []testItem{
+		{Name: "bob", ID: "2"},
+		{Name: "alice", ID: "3"},
+		{Name: "alice", ID: "1"},
+	}
+	cols := []query.SortColumn{
+		{Name: "name", Direction: query.SortASC},
+		{Name: "id", Direction: query.SortASC},
+	}
+
+	query.Sort(items, cols, compareTestField)
+
+	assert.Equal(t, "alice", items[0].Name)
+	assert.Equal(t, "1", items[0].ID)
+	assert.Equal(t, "alice", items[1].Name)
+	assert.Equal(t, "3", items[1].ID)
+	assert.Equal(t, "bob", items[2].Name)
+}
+
+func TestSort_EmptyColumns(t *testing.T) {
+	items := []testItem{{ID: "b"}, {ID: "a"}}
+	query.Sort(items, nil, compareTestField)
+	// order unchanged
+	assert.Equal(t, "b", items[0].ID)
+	assert.Equal(t, "a", items[1].ID)
+}
+
+// --- ApplyCursor tests ---
+
+func TestApplyCursor_FirstPage(t *testing.T) {
+	items := []testItem{
+		{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"},
+	}
+	params := query.ListParams{
+		Limit: 2,
+		Sort:  []query.SortColumn{{Name: "id", Direction: query.SortASC}},
+	}
+
+	result := query.ApplyCursor(items, params, testFieldValue)
+
+	// FetchLimit = 3, so we get 3 items (for hasMore detection)
+	require.Len(t, result, 3)
+	assert.Equal(t, "a", result[0].ID)
+	assert.Equal(t, "b", result[1].ID)
+	assert.Equal(t, "c", result[2].ID)
+}
+
+func TestApplyCursor_WithCursor(t *testing.T) {
+	items := []testItem{
+		{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"},
+	}
+	params := query.ListParams{
+		Limit:        2,
+		CursorValues: []any{"b"},
+		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortASC}},
+	}
+
+	result := query.ApplyCursor(items, params, testFieldValue)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "c", result[0].ID)
+	assert.Equal(t, "d", result[1].ID)
+}
+
+func TestApplyCursor_CursorPastEnd(t *testing.T) {
+	items := []testItem{
+		{ID: "a"}, {ID: "b"},
+	}
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{"z"},
+		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortASC}},
+	}
+
+	result := query.ApplyCursor(items, params, testFieldValue)
+
+	assert.Empty(t, result)
+}
+
+func TestApplyCursor_MultiColumnCursor(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	items := []testItem{
+		{ID: "1", CreatedAt: base},
+		{ID: "2", CreatedAt: base},
+		{ID: "3", CreatedAt: base.Add(time.Second)},
+		{ID: "4", CreatedAt: base.Add(time.Second)},
+	}
+	// Sort: created_at ASC, id ASC. Cursor at (base, "1") → skip item 1.
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{base, "1"},
+		Sort: []query.SortColumn{
+			{Name: "created_at", Direction: query.SortASC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+
+	result := query.ApplyCursor(items, params, testFieldValue)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "2", result[0].ID)
+	assert.Equal(t, "3", result[1].ID)
+	assert.Equal(t, "4", result[2].ID)
+}
+
+func TestApplyCursor_DESC_Direction(t *testing.T) {
+	items := []testItem{
+		{ID: "d"}, {ID: "c"}, {ID: "b"}, {ID: "a"},
+	}
+	// Sorted DESC. Cursor at "c" → next items are b, a.
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{"c"},
+		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortDESC}},
+	}
+
+	result := query.ApplyCursor(items, params, testFieldValue)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "b", result[0].ID)
+	assert.Equal(t, "a", result[1].ID)
+}
+
+func TestApplyCursor_TimeVsString_CrossType(t *testing.T) {
+	// This is the core CURSOR-P1-02 fix scenario:
+	// fieldValue returns time.Time, cursor values contain RFC3339Nano strings.
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	items := []testItem{
+		{ID: "1", CreatedAt: base},
+		{ID: "2", CreatedAt: base.Add(100 * time.Nanosecond)},
+		{ID: "3", CreatedAt: base.Add(200 * time.Nanosecond)},
+	}
+
+	// Cursor value is a string (as it would be after JSON decode from cursor token).
+	params := query.ListParams{
+		Limit:        10,
+		CursorValues: []any{base.Format(time.RFC3339Nano), "1"},
+		Sort: []query.SortColumn{
+			{Name: "created_at", Direction: query.SortASC},
+			{Name: "id", Direction: query.SortASC},
+		},
+	}
+
+	result := query.ApplyCursor(items, params, testFieldValue)
+
+	require.Len(t, result, 2, "should skip item at cursor position")
+	assert.Equal(t, "2", result[0].ID)
+	assert.Equal(t, "3", result[1].ID)
+}
+
+// --- CompareAny tests ---
+
+func TestCompareAny_StringVsString(t *testing.T) {
+	assert.Equal(t, -1, query.CompareAny("a", "b"))
+	assert.Equal(t, 0, query.CompareAny("x", "x"))
+	assert.Equal(t, 1, query.CompareAny("z", "a"))
+}
+
+func TestCompareAny_Float64VsFloat64(t *testing.T) {
+	assert.Equal(t, -1, query.CompareAny(1.0, 2.0))
+	assert.Equal(t, 0, query.CompareAny(3.14, 3.14))
+	assert.Equal(t, 1, query.CompareAny(9.9, 1.1))
+}
+
+func TestCompareAny_TimeVsTime(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Nanosecond)
+
+	assert.Equal(t, -1, query.CompareAny(t1, t2))
+	assert.Equal(t, 0, query.CompareAny(t1, t1))
+	assert.Equal(t, 1, query.CompareAny(t2, t1))
+}
+
+func TestCompareAny_TimeVsString(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 12, 0, 0, 100, time.UTC)
+	s := t1.Format(time.RFC3339Nano)
+
+	// time.Time vs string(RFC3339Nano) — should compare equal
+	assert.Equal(t, 0, query.CompareAny(t1, s))
+
+	// time.Time earlier than string
+	earlier := t1.Add(-time.Second)
+	assert.Equal(t, -1, query.CompareAny(earlier, s))
+
+	// time.Time later than string
+	later := t1.Add(time.Second)
+	assert.Equal(t, 1, query.CompareAny(later, s))
+}
+
+func TestCompareAny_StringVsTime(t *testing.T) {
+	t1 := time.Date(2026, 6, 15, 8, 30, 0, 500, time.UTC)
+	s := t1.Format(time.RFC3339Nano)
+
+	assert.Equal(t, 0, query.CompareAny(s, t1))
+	assert.Equal(t, -1, query.CompareAny(s, t1.Add(time.Second)))
+	assert.Equal(t, 1, query.CompareAny(s, t1.Add(-time.Second)))
+}
+
+func TestCompareAny_UnsupportedType_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		query.CompareAny(42, "str")
+	})
+	assert.Panics(t, func() {
+		query.CompareAny(true, false)
+	})
+}

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -69,13 +69,6 @@ func cmpFloat(a, b float64) int {
 	return 0
 }
 
-func mustCompare(t *testing.T, a, b any) int {
-	t.Helper()
-	v, err := query.CompareAny(a, b)
-	require.NoError(t, err)
-	return v
-}
-
 // --- Sort tests ---
 
 func TestSort_SingleColumn_ASC(t *testing.T) {
@@ -352,87 +345,86 @@ func TestApplyCursor_MismatchedCursorValuesLength_ReturnsError(t *testing.T) {
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }
 
-// --- CompareAny tests ---
+// --- CompareAny tests (table-driven) ---
 
-func TestCompareAny_StringVsString(t *testing.T) {
-	assert.Equal(t, -1, mustCompare(t, "a", "b"))
-	assert.Equal(t, 0, mustCompare(t, "x", "x"))
-	assert.Equal(t, 1, mustCompare(t, "z", "a"))
-}
-
-func TestCompareAny_Float64VsFloat64(t *testing.T) {
-	assert.Equal(t, -1, mustCompare(t, 1.0, 2.0))
-	assert.Equal(t, 0, mustCompare(t, 3.14, 3.14))
-	assert.Equal(t, 1, mustCompare(t, 9.9, 1.1))
-}
-
-func TestCompareAny_TimeVsTime(t *testing.T) {
-	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	t2 := t1.Add(time.Nanosecond)
-
-	assert.Equal(t, -1, mustCompare(t, t1, t2))
-	assert.Equal(t, 0, mustCompare(t, t1, t1))
-	assert.Equal(t, 1, mustCompare(t, t2, t1))
-}
-
-func TestCompareAny_TimeVsString(t *testing.T) {
+func TestCompareAny(t *testing.T) {
 	t1 := time.Date(2026, 1, 1, 12, 0, 0, 100, time.UTC)
-	s := t1.Format(time.RFC3339Nano)
+	t2 := time.Date(2026, 6, 15, 8, 30, 0, 500, time.UTC)
 
-	// time.Time vs string(RFC3339Nano) — should compare equal
-	assert.Equal(t, 0, mustCompare(t, t1, s))
+	tests := []struct {
+		name string
+		a, b any
+		want int
+	}{
+		// string vs string
+		{"string < string", "a", "b", -1},
+		{"string == string", "x", "x", 0},
+		{"string > string", "z", "a", 1},
 
-	// time.Time earlier than string
-	earlier := t1.Add(-time.Second)
-	assert.Equal(t, -1, mustCompare(t, earlier, s))
+		// float64 vs float64
+		{"float64 < float64", 1.0, 2.0, -1},
+		{"float64 == float64", 3.14, 3.14, 0},
+		{"float64 > float64", 9.9, 1.1, 1},
 
-	// time.Time later than string
-	later := t1.Add(time.Second)
-	assert.Equal(t, 1, mustCompare(t, later, s))
+		// time vs time
+		{"time < time", t1, t1.Add(time.Nanosecond), -1},
+		{"time == time", t1, t1, 0},
+		{"time > time", t1.Add(time.Nanosecond), t1, 1},
+
+		// time vs string (cross-type)
+		{"time == string", t1, t1.Format(time.RFC3339Nano), 0},
+		{"time < string", t1.Add(-time.Second), t1.Format(time.RFC3339Nano), -1},
+		{"time > string", t1.Add(time.Second), t1.Format(time.RFC3339Nano), 1},
+
+		// string vs time (cross-type, reverse)
+		{"string == time", t2.Format(time.RFC3339Nano), t2, 0},
+		{"string < time", t2.Format(time.RFC3339Nano), t2.Add(time.Second), -1},
+		{"string > time", t2.Format(time.RFC3339Nano), t2.Add(-time.Second), 1},
+
+		// int vs float64 (normalized)
+		{"int < float64", 1, 2.0, -1},
+		{"int == float64", 3, 3.0, 0},
+		{"int > float64", 5, 2.0, 1},
+
+		// float64 vs int (normalized)
+		{"float64 < int", 1.0, 2, -1},
+		{"float64 == int", 3.0, 3, 0},
+		{"float64 > int", 5.0, 2, 1},
+
+		// int vs int (both normalized to float64)
+		{"int < int", 1, 2, -1},
+		{"int == int", 3, 3, 0},
+		{"int > int", 5, 2, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := query.CompareAny(tt.a, tt.b)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
-func TestCompareAny_StringVsTime(t *testing.T) {
-	t1 := time.Date(2026, 6, 15, 8, 30, 0, 500, time.UTC)
-	s := t1.Format(time.RFC3339Nano)
+func TestCompareAny_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b any
+	}{
+		{"nil vs string", nil, "x"},
+		{"string vs nil", "x", nil},
+		{"bool vs bool", true, false},
+		{"float64 vs string", 1.0, "str"},
+		{"float64 vs time", 1.0, time.Now()},
+	}
 
-	assert.Equal(t, 0, mustCompare(t, s, t1))
-	assert.Equal(t, -1, mustCompare(t, s, t1.Add(time.Second)))
-	assert.Equal(t, 1, mustCompare(t, s, t1.Add(-time.Second)))
-}
-
-func TestCompareAny_IntVsFloat64(t *testing.T) {
-	assert.Equal(t, -1, mustCompare(t, 1, 2.0))
-	assert.Equal(t, 0, mustCompare(t, 3, 3.0))
-	assert.Equal(t, 1, mustCompare(t, 5, 2.0))
-}
-
-func TestCompareAny_Float64VsInt(t *testing.T) {
-	assert.Equal(t, -1, mustCompare(t, 1.0, 2))
-	assert.Equal(t, 0, mustCompare(t, 3.0, 3))
-	assert.Equal(t, 1, mustCompare(t, 5.0, 2))
-}
-
-func TestCompareAny_IntVsInt(t *testing.T) {
-	assert.Equal(t, -1, mustCompare(t, 1, 2))
-	assert.Equal(t, 0, mustCompare(t, 3, 3))
-	assert.Equal(t, 1, mustCompare(t, 5, 2))
-}
-
-func TestCompareAny_NilValue_ReturnsError(t *testing.T) {
-	_, err := query.CompareAny(nil, "x")
-	require.Error(t, err)
-
-	_, err = query.CompareAny("x", nil)
-	require.Error(t, err)
-}
-
-func TestCompareAny_UnsupportedType_ReturnsError(t *testing.T) {
-	_, err := query.CompareAny(true, false)
-	require.Error(t, err)
-
-	_, err = query.CompareAny(1.0, "str")
-	require.Error(t, err)
-
-	_, err = query.CompareAny(1.0, time.Now())
-	require.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := query.CompareAny(tt.a, tt.b)
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.ErrorAs(t, err, &ecErr)
+			assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+		})
+	}
 }

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,13 @@ func cmpFloat(a, b float64) int {
 		return 1
 	}
 	return 0
+}
+
+func mustCompare(t *testing.T, a, b any) int {
+	t.Helper()
+	v, err := query.CompareAny(a, b)
+	require.NoError(t, err)
+	return v
 }
 
 // --- Sort tests ---
@@ -135,7 +143,8 @@ func TestApplyCursor_FirstPage(t *testing.T) {
 		Sort:  []query.SortColumn{{Name: "id", Direction: query.SortASC}},
 	}
 
-	result := query.ApplyCursor(items, params, testFieldValue)
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
 
 	// FetchLimit = 3, so we get 3 items (for hasMore detection)
 	require.Len(t, result, 3)
@@ -154,7 +163,8 @@ func TestApplyCursor_WithCursor(t *testing.T) {
 		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortASC}},
 	}
 
-	result := query.ApplyCursor(items, params, testFieldValue)
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
 
 	require.Len(t, result, 2)
 	assert.Equal(t, "c", result[0].ID)
@@ -171,8 +181,8 @@ func TestApplyCursor_CursorPastEnd(t *testing.T) {
 		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortASC}},
 	}
 
-	result := query.ApplyCursor(items, params, testFieldValue)
-
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
 	assert.Empty(t, result)
 }
 
@@ -194,7 +204,8 @@ func TestApplyCursor_MultiColumnCursor(t *testing.T) {
 		},
 	}
 
-	result := query.ApplyCursor(items, params, testFieldValue)
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
 
 	require.Len(t, result, 3)
 	assert.Equal(t, "2", result[0].ID)
@@ -213,7 +224,8 @@ func TestApplyCursor_DESC_Direction(t *testing.T) {
 		Sort:         []query.SortColumn{{Name: "id", Direction: query.SortDESC}},
 	}
 
-	result := query.ApplyCursor(items, params, testFieldValue)
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
 
 	require.Len(t, result, 2)
 	assert.Equal(t, "b", result[0].ID)
@@ -240,77 +252,15 @@ func TestApplyCursor_TimeVsString_CrossType(t *testing.T) {
 		},
 	}
 
-	result := query.ApplyCursor(items, params, testFieldValue)
+	result, err := query.ApplyCursor(items, params, testFieldValue)
+	require.NoError(t, err)
 
 	require.Len(t, result, 2, "should skip item at cursor position")
 	assert.Equal(t, "2", result[0].ID)
 	assert.Equal(t, "3", result[1].ID)
 }
 
-// --- CompareAny tests ---
-
-func TestCompareAny_StringVsString(t *testing.T) {
-	assert.Equal(t, -1, query.CompareAny("a", "b"))
-	assert.Equal(t, 0, query.CompareAny("x", "x"))
-	assert.Equal(t, 1, query.CompareAny("z", "a"))
-}
-
-func TestCompareAny_Float64VsFloat64(t *testing.T) {
-	assert.Equal(t, -1, query.CompareAny(1.0, 2.0))
-	assert.Equal(t, 0, query.CompareAny(3.14, 3.14))
-	assert.Equal(t, 1, query.CompareAny(9.9, 1.1))
-}
-
-func TestCompareAny_TimeVsTime(t *testing.T) {
-	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	t2 := t1.Add(time.Nanosecond)
-
-	assert.Equal(t, -1, query.CompareAny(t1, t2))
-	assert.Equal(t, 0, query.CompareAny(t1, t1))
-	assert.Equal(t, 1, query.CompareAny(t2, t1))
-}
-
-func TestCompareAny_TimeVsString(t *testing.T) {
-	t1 := time.Date(2026, 1, 1, 12, 0, 0, 100, time.UTC)
-	s := t1.Format(time.RFC3339Nano)
-
-	// time.Time vs string(RFC3339Nano) — should compare equal
-	assert.Equal(t, 0, query.CompareAny(t1, s))
-
-	// time.Time earlier than string
-	earlier := t1.Add(-time.Second)
-	assert.Equal(t, -1, query.CompareAny(earlier, s))
-
-	// time.Time later than string
-	later := t1.Add(time.Second)
-	assert.Equal(t, 1, query.CompareAny(later, s))
-}
-
-func TestCompareAny_StringVsTime(t *testing.T) {
-	t1 := time.Date(2026, 6, 15, 8, 30, 0, 500, time.UTC)
-	s := t1.Format(time.RFC3339Nano)
-
-	assert.Equal(t, 0, query.CompareAny(s, t1))
-	assert.Equal(t, -1, query.CompareAny(s, t1.Add(time.Second)))
-	assert.Equal(t, 1, query.CompareAny(s, t1.Add(-time.Second)))
-}
-
-func TestCompareAny_UnsupportedType_Panics(t *testing.T) {
-	assert.Panics(t, func() {
-		query.CompareAny(42, "str")
-	})
-	assert.Panics(t, func() {
-		query.CompareAny(true, false)
-	})
-	assert.Panics(t, func() {
-		query.CompareAny(1.0, "str")
-	})
-	assert.Panics(t, func() {
-		query.CompareAny(1.0, time.Now())
-	})
-}
-
-func TestApplyCursor_MismatchedCursorValuesLength_Panics(t *testing.T) {
+func TestApplyCursor_MismatchedCursorValuesLength_ReturnsError(t *testing.T) {
 	items := []testItem{{ID: "a"}, {ID: "b"}}
 	params := query.ListParams{
 		Limit:        10,
@@ -321,9 +271,71 @@ func TestApplyCursor_MismatchedCursorValuesLength_Panics(t *testing.T) {
 		},
 	}
 
-	// ApplyCursor does not validate length — this is enforced upstream by
-	// ValidateCursorScope. If bypass occurs, it panics with index out of range.
-	assert.Panics(t, func() {
-		query.ApplyCursor(items, params, testFieldValue)
-	})
+	_, err := query.ApplyCursor(items, params, testFieldValue)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+}
+
+// --- CompareAny tests ---
+
+func TestCompareAny_StringVsString(t *testing.T) {
+	assert.Equal(t, -1, mustCompare(t, "a", "b"))
+	assert.Equal(t, 0, mustCompare(t, "x", "x"))
+	assert.Equal(t, 1, mustCompare(t, "z", "a"))
+}
+
+func TestCompareAny_Float64VsFloat64(t *testing.T) {
+	assert.Equal(t, -1, mustCompare(t, 1.0, 2.0))
+	assert.Equal(t, 0, mustCompare(t, 3.14, 3.14))
+	assert.Equal(t, 1, mustCompare(t, 9.9, 1.1))
+}
+
+func TestCompareAny_TimeVsTime(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Nanosecond)
+
+	assert.Equal(t, -1, mustCompare(t, t1, t2))
+	assert.Equal(t, 0, mustCompare(t, t1, t1))
+	assert.Equal(t, 1, mustCompare(t, t2, t1))
+}
+
+func TestCompareAny_TimeVsString(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 12, 0, 0, 100, time.UTC)
+	s := t1.Format(time.RFC3339Nano)
+
+	// time.Time vs string(RFC3339Nano) — should compare equal
+	assert.Equal(t, 0, mustCompare(t, t1, s))
+
+	// time.Time earlier than string
+	earlier := t1.Add(-time.Second)
+	assert.Equal(t, -1, mustCompare(t, earlier, s))
+
+	// time.Time later than string
+	later := t1.Add(time.Second)
+	assert.Equal(t, 1, mustCompare(t, later, s))
+}
+
+func TestCompareAny_StringVsTime(t *testing.T) {
+	t1 := time.Date(2026, 6, 15, 8, 30, 0, 500, time.UTC)
+	s := t1.Format(time.RFC3339Nano)
+
+	assert.Equal(t, 0, mustCompare(t, s, t1))
+	assert.Equal(t, -1, mustCompare(t, s, t1.Add(time.Second)))
+	assert.Equal(t, 1, mustCompare(t, s, t1.Add(-time.Second)))
+}
+
+func TestCompareAny_UnsupportedType_ReturnsError(t *testing.T) {
+	_, err := query.CompareAny(42, "str")
+	require.Error(t, err)
+
+	_, err = query.CompareAny(true, false)
+	require.Error(t, err)
+
+	_, err = query.CompareAny(1.0, "str")
+	require.Error(t, err)
+
+	_, err = query.CompareAny(1.0, time.Now())
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

- **CURSOR-P1-01**: audit-query QueryContext from/to precision → RFC3339Nano (prevents same-second sub-second queries sharing cursor fingerprint)
- **CURSOR-P1-02**: All 4 in-memory repos unified to `time.Compare` via generic `query.CompareAny` (fixes audit repo string comparison drift)
- **WM-6-F2**: Extracted `pkg/query/mempage.go` — generic `Sort[T]`, `ApplyCursor[T]`, `CompareAny` with time.Time↔string cross-type support, eliminating ~400 lines of duplicate pagination code across 5 repos
- **CURSOR-P2-01**: Cross-slice cursor rejection test (config-read cursor rejected by feature-flag endpoint)
- **P4-TD-11**: 5 concurrent `-race` tests for all in-memory repos (audit, order, device, config, flag)
- **P4-TD-14**: `_ = json.Unmarshal` → `slog.Warn` in audit-append (observable graceful degradation)

## Stats

17 files changed, +903 / -401 (net: ~400 lines of deduplication removed)

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./pkg/query/... ./cells/... -count=1` — all 28 packages pass
- [x] `go test -race -run Concurrent` — all 5 concurrent tests pass under race detector
- [x] Subsecond precision tests verify cursor advancement at nanosecond granularity
- [x] Cross-slice cursor rejection verified via HTTP round-trip integration test
- [x] All existing cursor/pagination tests pass as regression guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)