### PR TITLE
fix(pkg/query): unify cursor decode errors to cursorInvalid helper

### DIFF
--- a/src/pkg/query/cursor.go
+++ b/src/pkg/query/cursor.go
@@ -55,7 +55,10 @@ func NewCursorCodec(current []byte, previous ...[]byte) (*CursorCodec, error) {
 func (c *CursorCodec) Encode(cur Cursor) (string, error) {
 	payload, err := json.Marshal(cur)
 	if err != nil {
-		return "", cursorInvalid("marshal failed")
+		// Marshal failure is a server-side programming error (un-serializable
+		// values in Cursor.Values), not a client-provided bad cursor. Use
+		// ErrInternal so it maps to HTTP 500, not 400.
+		return "", errcode.Wrap(errcode.ErrInternal, "cursor: marshal failed", err)
 	}
 
 	sig := c.signWith(c.current, payload)

--- a/src/pkg/query/cursor.go
+++ b/src/pkg/query/cursor.go
@@ -55,7 +55,7 @@ func NewCursorCodec(current []byte, previous ...[]byte) (*CursorCodec, error) {
 func (c *CursorCodec) Encode(cur Cursor) (string, error) {
 	payload, err := json.Marshal(cur)
 	if err != nil {
-		return "", errcode.Wrap(errcode.ErrCursorInvalid, "cursor: marshal failed", err)
+		return "", cursorInvalid("marshal failed")
 	}
 
 	sig := c.signWith(c.current, payload)

--- a/src/pkg/query/cursor.go
+++ b/src/pkg/query/cursor.go
@@ -71,17 +71,17 @@ func (c *CursorCodec) Encode(cur Cursor) (string, error) {
 // Returns ErrCursorInvalid on any failure (tamper, format, etc.).
 func (c *CursorCodec) Decode(token string) (Cursor, error) {
 	if token == "" {
-		return Cursor{}, errcode.New(errcode.ErrCursorInvalid, "cursor token is empty")
+		return Cursor{}, cursorInvalid("cursor token is empty")
 	}
 
 	raw, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
-		return Cursor{}, errcode.New(errcode.ErrCursorInvalid, "cursor: invalid base64 encoding")
+		return Cursor{}, cursorInvalid("invalid base64 encoding")
 	}
 
 	dotIdx := bytes.LastIndexByte(raw, '.')
 	if dotIdx < 0 || dotIdx >= len(raw)-1 {
-		return Cursor{}, errcode.New(errcode.ErrCursorInvalid, "cursor: missing signature separator")
+		return Cursor{}, cursorInvalid("missing signature separator")
 	}
 
 	payload := raw[:dotIdx]
@@ -102,12 +102,12 @@ func (c *CursorCodec) Decode(token string) (Cursor, error) {
 		}
 	}
 	if !verified {
-		return Cursor{}, errcode.New(errcode.ErrCursorInvalid, "cursor: signature verification failed")
+		return Cursor{}, cursorInvalid("signature verification failed")
 	}
 
 	var cur Cursor
 	if err := json.Unmarshal(payload, &cur); err != nil {
-		return Cursor{}, errcode.New(errcode.ErrCursorInvalid, "cursor: invalid payload")
+		return Cursor{}, cursorInvalid("invalid payload")
 	}
 
 	return cur, nil
@@ -157,35 +157,47 @@ func QueryContext(pairs ...string) string {
 // so they appear in the response "details" field without polluting "message".
 const cursorInvalidMsg = "invalid cursor; restart from first page"
 
+// cursorInvalid returns a standardized cursor error with a stable client-facing
+// message and diagnostic reason in the details field.
+func cursorInvalid(reason string) *errcode.Error {
+	return errcode.WithDetails(
+		errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
+		map[string]any{"reason": reason})
+}
+
+// cursorInvalidExtra returns a standardized cursor error with extra diagnostic
+// key-value pairs merged into the details alongside the reason.
+func cursorInvalidExtra(reason string, extra map[string]any) *errcode.Error {
+	details := map[string]any{"reason": reason}
+	for k, v := range extra {
+		details[k] = v
+	}
+	return errcode.WithDetails(
+		errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
+		details)
+}
+
 // ValidateCursorScope checks that the decoded cursor carries the expected sort
 // scope and query context, and that the value count matches. Both fields are
 // mandatory on both sides — empty scope/context is rejected regardless of
 // whether it comes from the cursor or from the caller.
 func ValidateCursorScope(cur Cursor, sort []SortColumn, queryCtx string) error {
 	if cur.Scope == "" {
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
-			map[string]any{"reason": "sort scope is required"})
+		return cursorInvalid("sort scope is required")
 	}
 	if expected := SortScope(sort); cur.Scope != expected {
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
-			map[string]any{"reason": "sort scope mismatch", "got": cur.Scope, "want": expected})
+		return cursorInvalidExtra("sort scope mismatch",
+			map[string]any{"got": cur.Scope, "want": expected})
 	}
 	if cur.Context == "" {
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
-			map[string]any{"reason": "query context is required"})
+		return cursorInvalid("query context is required")
 	}
 	if cur.Context != queryCtx {
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
-			map[string]any{"reason": "query context mismatch", "got": cur.Context, "want": queryCtx})
+		return cursorInvalidExtra("query context mismatch",
+			map[string]any{"got": cur.Context, "want": queryCtx})
 	}
 	if len(cur.Values) != len(sort) {
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
-			map[string]any{"reason": fmt.Sprintf("has %d values but expected %d sort columns", len(cur.Values), len(sort))})
+		return cursorInvalid(fmt.Sprintf("has %d values but expected %d sort columns", len(cur.Values), len(sort)))
 	}
 	return nil
 }

--- a/src/pkg/query/cursor.go
+++ b/src/pkg/query/cursor.go
@@ -161,22 +161,26 @@ func QueryContext(pairs ...string) string {
 const cursorInvalidMsg = "invalid cursor; restart from first page"
 
 // cursorInvalid returns a standardized cursor error with a stable client-facing
-// message and diagnostic reason in the details field.
+// message and diagnostic reason in the details field. The reason is also set as
+// InternalMessage so it appears in server-side logs via Error().
 func cursorInvalid(reason string) *errcode.Error {
 	return errcode.WithDetails(
-		errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
+		errcode.Safe(errcode.ErrCursorInvalid, cursorInvalidMsg, reason),
 		map[string]any{"reason": reason})
 }
 
 // cursorInvalidExtra returns a standardized cursor error with extra diagnostic
 // key-value pairs merged into the details alongside the reason.
+// The "reason" key is set after merging extra, so callers cannot accidentally
+// overwrite it.
 func cursorInvalidExtra(reason string, extra map[string]any) *errcode.Error {
-	details := map[string]any{"reason": reason}
+	details := make(map[string]any, len(extra)+1)
 	for k, v := range extra {
 		details[k] = v
 	}
+	details["reason"] = reason // set last — cannot be overwritten by extra
 	return errcode.WithDetails(
-		errcode.New(errcode.ErrCursorInvalid, cursorInvalidMsg),
+		errcode.Safe(errcode.ErrCursorInvalid, cursorInvalidMsg, reason),
 		details)
 }
 

--- a/src/pkg/query/cursor_test.go
+++ b/src/pkg/query/cursor_test.go
@@ -89,9 +89,15 @@ func TestCursorCodec_Encode_MarshalFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Cursor.Values is []any — a func value is not JSON-serializable.
+	// Encode failure is a server-side error (ErrInternal, not ErrCursorInvalid)
+	// because the client sent no cursor; the server failed to build nextCursor.
 	cur := Cursor{Values: []any{func() {}}}
 	_, err = codec.Encode(cur)
-	requireCursorInvalid(t, err, "marshal failed")
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrInternal, ecErr.Code)
+	assert.Equal(t, "cursor: marshal failed", ecErr.Message)
+	assert.NotNil(t, ecErr.Cause, "must preserve underlying json.Marshal error for diagnosis")
 }
 
 func TestCursorCodec_Decode_TamperedPayload(t *testing.T) {
@@ -273,6 +279,12 @@ func TestValidateCursorScope_Mismatch(t *testing.T) {
 	cur := Cursor{Values: []any{"v1", "v2"}, Scope: SortScope(sortA), Context: qctx}
 	err := ValidateCursorScope(cur, sortB, qctx)
 	requireCursorInvalid(t, err, "sort scope mismatch")
+
+	// Assert got/want diagnostics from cursorInvalidExtra.
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, SortScope(sortA), ecErr.Details["got"])
+	assert.Equal(t, SortScope(sortB), ecErr.Details["want"])
 }
 
 func TestValidateCursorScope_ValueCountMismatch(t *testing.T) {
@@ -321,6 +333,12 @@ func TestValidateCursorScope_ContextMismatch(t *testing.T) {
 	cur := Cursor{Values: []any{"v1"}, Scope: SortScope(sort), Context: ctxA}
 	err := ValidateCursorScope(cur, sort, ctxB)
 	requireCursorInvalid(t, err, "query context mismatch")
+
+	// Assert got/want diagnostics from cursorInvalidExtra.
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, ctxA, ecErr.Details["got"])
+	assert.Equal(t, ctxB, ecErr.Details["want"])
 }
 
 func TestValidateCursorScope_ContextMatch(t *testing.T) {

--- a/src/pkg/query/cursor_test.go
+++ b/src/pkg/query/cursor_test.go
@@ -2,8 +2,10 @@ package query
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/base64"
-	"errors"
+	"encoding/hex"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -95,10 +97,7 @@ func TestCursorCodec_Decode_TamperedPayload(t *testing.T) {
 	tampered := base64.RawURLEncoding.EncodeToString(raw)
 
 	_, err = codec.Decode(tampered)
-	assert.Error(t, err)
-	var ecErr *errcode.Error
-	assert.True(t, errors.As(err, &ecErr))
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalid(t, err, "signature verification failed")
 }
 
 func TestCursorCodec_Decode_TamperedSignature(t *testing.T) {
@@ -116,10 +115,7 @@ func TestCursorCodec_Decode_TamperedSignature(t *testing.T) {
 	tampered := base64.RawURLEncoding.EncodeToString(raw)
 
 	_, err = codec.Decode(tampered)
-	assert.Error(t, err)
-	var ecErr *errcode.Error
-	assert.True(t, errors.As(err, &ecErr))
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalid(t, err, "signature verification failed")
 }
 
 func TestCursorCodec_Decode_InvalidBase64(t *testing.T) {
@@ -127,10 +123,41 @@ func TestCursorCodec_Decode_InvalidBase64(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = codec.Decode("not-valid-base64!!!")
-	assert.Error(t, err)
-	var ecErr *errcode.Error
-	assert.True(t, errors.As(err, &ecErr))
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalid(t, err, "invalid base64 encoding")
+}
+
+func TestCursorCodec_Decode_MissingSeparator(t *testing.T) {
+	codec, err := NewCursorCodec(testKey())
+	require.NoError(t, err)
+
+	// Valid base64 but no '.' separator inside.
+	raw := []byte("nodothere")
+	token := base64.RawURLEncoding.EncodeToString(raw)
+
+	_, err = codec.Decode(token)
+	requireCursorInvalid(t, err, "missing signature separator")
+}
+
+func TestCursorCodec_Decode_InvalidPayload(t *testing.T) {
+	codec, err := NewCursorCodec(testKey())
+	require.NoError(t, err)
+
+	// Construct a properly signed token with invalid JSON payload.
+	payload := []byte("not-valid-json{{{")
+	mac := hmac.New(sha256.New, testKey())
+	mac.Write(payload)
+	sum := mac.Sum(nil)
+	sig := make([]byte, hex.EncodedLen(len(sum)))
+	hex.Encode(sig, sum)
+
+	raw := make([]byte, 0, len(payload)+1+len(sig))
+	raw = append(raw, payload...)
+	raw = append(raw, '.')
+	raw = append(raw, sig...)
+	token := base64.RawURLEncoding.EncodeToString(raw)
+
+	_, err = codec.Decode(token)
+	requireCursorInvalid(t, err, "invalid payload")
 }
 
 func TestCursorCodec_Decode_EmptyToken(t *testing.T) {
@@ -138,10 +165,7 @@ func TestCursorCodec_Decode_EmptyToken(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = codec.Decode("")
-	assert.Error(t, err)
-	var ecErr *errcode.Error
-	assert.True(t, errors.As(err, &ecErr))
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalid(t, err, "cursor token is empty")
 }
 
 func TestCursorCodec_DifferentKeysReject(t *testing.T) {
@@ -154,10 +178,7 @@ func TestCursorCodec_DifferentKeysReject(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = codecB.Decode(token)
-	assert.Error(t, err)
-	var ecErr *errcode.Error
-	assert.True(t, errors.As(err, &ecErr))
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalid(t, err, "signature verification failed")
 }
 
 func TestCursorCodec_RoundTrip_EmptyValues(t *testing.T) {
@@ -201,10 +222,7 @@ func TestCursorCodec_CrossCellRejection(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cellB.Decode(token)
-	assert.Error(t, err)
-	var ecErr *errcode.Error
-	assert.True(t, errors.As(err, &ecErr))
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalid(t, err, "signature verification failed")
 }
 
 // --- SortScope tests ---

--- a/src/pkg/query/cursor_test.go
+++ b/src/pkg/query/cursor_test.go
@@ -84,6 +84,16 @@ func TestCursorCodec_RoundTrip_NumericTypes(t *testing.T) {
 	assert.InDelta(t, 3.14, decoded.Values[1].(float64), 0.001)
 }
 
+func TestCursorCodec_Encode_MarshalFailure(t *testing.T) {
+	codec, err := NewCursorCodec(testKey())
+	require.NoError(t, err)
+
+	// Cursor.Values is []any — a func value is not JSON-serializable.
+	cur := Cursor{Values: []any{func() {}}}
+	_, err = codec.Encode(cur)
+	requireCursorInvalid(t, err, "marshal failed")
+}
+
 func TestCursorCodec_Decode_TamperedPayload(t *testing.T) {
 	codec, err := NewCursorCodec(testKey())
 	require.NoError(t, err)

--- a/src/pkg/query/export_test.go
+++ b/src/pkg/query/export_test.go
@@ -1,0 +1,4 @@
+package query
+
+// TestCursorInvalidMsg exports cursorInvalidMsg for external tests (package query_test).
+const TestCursorInvalidMsg = cursorInvalidMsg

--- a/src/pkg/query/keyset.go
+++ b/src/pkg/query/keyset.go
@@ -43,9 +43,8 @@ func AppendKeyset(b *Builder, params ListParams) error {
 
 	if params.CursorValues != nil {
 		if len(params.CursorValues) != len(params.Sort) {
-			return errcode.New(errcode.ErrCursorInvalid,
-				fmt.Sprintf("keyset: cursor has %d values but %d sort columns",
-					len(params.CursorValues), len(params.Sort)))
+			return cursorInvalid(fmt.Sprintf("cursor has %d values but %d sort columns",
+				len(params.CursorValues), len(params.Sort)))
 		}
 		if err := appendKeysetWhere(b, params.Sort, params.CursorValues); err != nil {
 			return err

--- a/src/pkg/query/keyset_test.go
+++ b/src/pkg/query/keyset_test.go
@@ -193,7 +193,7 @@ func TestKeyset_CursorValueCountMismatch(t *testing.T) {
 		},
 	}
 	err := AppendKeyset(b, params)
-	assert.Error(t, err)
+	requireCursorInvalid(t, err, "cursor has 1 values but 2 sort columns")
 }
 
 func TestKeyset_FullQuery(t *testing.T) {

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"time"
-
-	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // CompareFunc compares a single named field of two entities, returning -1/0/+1.
@@ -50,13 +48,11 @@ func Sort[T any](items []T, cols []SortColumn, compareField CompareFunc[T]) {
 func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) ([]T, error) {
 	if params.CursorValues != nil {
 		if len(params.Sort) == 0 {
-			return nil, errcode.New(errcode.ErrCursorInvalid,
-				"cursor values present but no sort columns defined")
+			return nil, cursorInvalid("cursor values present but no sort columns defined")
 		}
 		if len(params.CursorValues) != len(params.Sort) {
-			return nil, errcode.New(errcode.ErrCursorInvalid,
-				fmt.Sprintf("cursor values count %d does not match sort columns count %d",
-					len(params.CursorValues), len(params.Sort)))
+			return nil, cursorInvalid(fmt.Sprintf("cursor values count %d does not match sort columns count %d",
+				len(params.CursorValues), len(params.Sort)))
 		}
 	}
 
@@ -156,7 +152,7 @@ func CompareAny(a, b any) (int, error) {
 		}
 	}
 
-	return 0, errcode.New(errcode.ErrCursorInvalid, "invalid cursor value")
+	return 0, cursorInvalid("invalid cursor value")
 }
 
 // normalizeNumeric converts int to float64 for uniform numeric comparison.
@@ -172,7 +168,7 @@ func normalizeNumeric(v any) any {
 func parseTimeString(s string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
-		return time.Time{}, errcode.New(errcode.ErrCursorInvalid, "invalid cursor value")
+		return time.Time{}, cursorInvalid("invalid cursor value")
 	}
 	return t, nil
 }

--- a/src/pkg/query/mempage.go
+++ b/src/pkg/query/mempage.go
@@ -152,7 +152,7 @@ func CompareAny(a, b any) (int, error) {
 		}
 	}
 
-	return 0, cursorInvalid("invalid cursor value")
+	return 0, cursorInvalid("unsupported cursor value types")
 }
 
 // normalizeNumeric converts int to float64 for uniform numeric comparison.
@@ -168,7 +168,7 @@ func normalizeNumeric(v any) any {
 func parseTimeString(s string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
-		return time.Time{}, cursorInvalid("invalid cursor value")
+		return time.Time{}, cursorInvalid("invalid time format in cursor value")
 	}
 	return t, nil
 }

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -71,6 +71,7 @@ func cmpFloat(a, b float64) int {
 
 // requireCursorInvalidMsg asserts the error is a standardized cursor error
 // with unified message and the expected reason in details.
+// NOTE: the string literal must match query.cursorInvalidMsg (unexported).
 func requireCursorInvalidMsg(t *testing.T, err error, wantReason string) {
 	t.Helper()
 	var ecErr *errcode.Error
@@ -418,13 +419,13 @@ func TestCompareAny_Error(t *testing.T) {
 		a, b       any
 		wantReason string
 	}{
-		{"nil vs string", nil, "x", "invalid cursor value"},
-		{"string vs nil", "x", nil, "invalid cursor value"},
-		{"bool vs bool", true, false, "invalid cursor value"},
-		{"float64 vs string", 1.0, "str", "invalid cursor value"},
-		{"float64 vs time", 1.0, time.Now(), "invalid cursor value"},
-		{"time vs invalid string", time.Now(), "not-a-time", "invalid cursor value"},
-		{"invalid string vs time", "not-a-time", time.Now(), "invalid cursor value"},
+		{"nil vs string", nil, "x", "unsupported cursor value types"},
+		{"string vs nil", "x", nil, "unsupported cursor value types"},
+		{"bool vs bool", true, false, "unsupported cursor value types"},
+		{"float64 vs string", 1.0, "str", "unsupported cursor value types"},
+		{"float64 vs time", 1.0, time.Now(), "unsupported cursor value types"},
+		{"time vs invalid string", time.Now(), "not-a-time", "invalid time format in cursor value"},
+		{"invalid string vs time", "not-a-time", time.Now(), "invalid time format in cursor value"},
 	}
 
 	for _, tt := range tests {

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -71,13 +71,12 @@ func cmpFloat(a, b float64) int {
 
 // requireCursorInvalidMsg asserts the error is a standardized cursor error
 // with unified message and the expected reason in details.
-// NOTE: the string literal must match query.cursorInvalidMsg (unexported).
 func requireCursorInvalidMsg(t *testing.T, err error, wantReason string) {
 	t.Helper()
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	assert.Equal(t, "invalid cursor; restart from first page", ecErr.Message,
+	assert.Equal(t, query.TestCursorInvalidMsg, ecErr.Message,
 		"client-facing message must be stable across all cursor errors")
 	assert.Equal(t, wantReason, ecErr.Details["reason"])
 }

--- a/src/pkg/query/mempage_test.go
+++ b/src/pkg/query/mempage_test.go
@@ -69,6 +69,18 @@ func cmpFloat(a, b float64) int {
 	return 0
 }
 
+// requireCursorInvalidMsg asserts the error is a standardized cursor error
+// with unified message and the expected reason in details.
+func requireCursorInvalidMsg(t *testing.T, err error, wantReason string) {
+	t.Helper()
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "invalid cursor; restart from first page", ecErr.Message,
+		"client-facing message must be stable across all cursor errors")
+	assert.Equal(t, wantReason, ecErr.Details["reason"])
+}
+
 // --- Sort tests ---
 
 func TestSort_SingleColumn_ASC(t *testing.T) {
@@ -321,10 +333,7 @@ func TestApplyCursor_EmptySortWithCursor_ReturnsError(t *testing.T) {
 		Sort:         []query.SortColumn{},
 	}
 	_, err := query.ApplyCursor(items, params, testFieldValue)
-	require.Error(t, err)
-	var ecErr *errcode.Error
-	require.ErrorAs(t, err, &ecErr)
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalidMsg(t, err, "cursor values present but no sort columns defined")
 }
 
 func TestApplyCursor_MismatchedCursorValuesLength_ReturnsError(t *testing.T) {
@@ -339,10 +348,7 @@ func TestApplyCursor_MismatchedCursorValuesLength_ReturnsError(t *testing.T) {
 	}
 
 	_, err := query.ApplyCursor(items, params, testFieldValue)
-	require.Error(t, err)
-	var ecErr *errcode.Error
-	require.ErrorAs(t, err, &ecErr)
-	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	requireCursorInvalidMsg(t, err, "cursor values count 1 does not match sort columns count 2")
 }
 
 // --- CompareAny tests (table-driven) ---
@@ -408,23 +414,23 @@ func TestCompareAny(t *testing.T) {
 
 func TestCompareAny_Error(t *testing.T) {
 	tests := []struct {
-		name string
-		a, b any
+		name       string
+		a, b       any
+		wantReason string
 	}{
-		{"nil vs string", nil, "x"},
-		{"string vs nil", "x", nil},
-		{"bool vs bool", true, false},
-		{"float64 vs string", 1.0, "str"},
-		{"float64 vs time", 1.0, time.Now()},
+		{"nil vs string", nil, "x", "invalid cursor value"},
+		{"string vs nil", "x", nil, "invalid cursor value"},
+		{"bool vs bool", true, false, "invalid cursor value"},
+		{"float64 vs string", 1.0, "str", "invalid cursor value"},
+		{"float64 vs time", 1.0, time.Now(), "invalid cursor value"},
+		{"time vs invalid string", time.Now(), "not-a-time", "invalid cursor value"},
+		{"invalid string vs time", "not-a-time", time.Now(), "invalid cursor value"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := query.CompareAny(tt.a, tt.b)
-			require.Error(t, err)
-			var ecErr *errcode.Error
-			require.ErrorAs(t, err, &ecErr)
-			assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+			requireCursorInvalidMsg(t, err, tt.wantReason)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Extract `cursorInvalid()` / `cursorInvalidExtra()` helpers that produce a stable client-facing message (`"invalid cursor; restart from first page"`) with diagnostic info in `details.reason`
- Refactor 14 cursor error sites across `CursorCodec.Decode()` (5), `ValidateCursorScope()` (5), and `mempage.go` (4) to use the helpers
- `NewCursorCodec` key validation errors left as-is (config errors, not client request errors)

## Motivation

`CursorCodec.Decode()` exposed internal diagnostic messages (e.g. `"cursor: invalid base64 encoding"`, `"cursor: signature verification failed"`) directly to API clients. `ValidateCursorScope()` already had the correct pattern. This PR unifies all cursor errors to follow the same pattern.

ref: ent/entgql `errInvalidPagination` constant pattern
ref: Kratos `errors.BadRequest` typed constructor + reason code

## Files Changed

| File | Changes |
|------|---------|
| `src/pkg/query/cursor.go` | +`cursorInvalid`/`cursorInvalidExtra` helpers; refactor Decode() + ValidateCursorScope() |
| `src/pkg/query/mempage.go` | Refactor ApplyCursor/CompareAny/parseTimeString; remove unused errcode import |
| `src/pkg/query/cursor_test.go` | +MissingSeparator/InvalidPayload tests; strengthen all Decode tests to assert Message+Details |
| `src/pkg/query/mempage_test.go` | +`requireCursorInvalidMsg` helper; strengthen error tests; +time-vs-invalid-string cases |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/query/... -v -count=1` — 91 tests pass
- [x] `go vet ./pkg/query/...` clean
- [x] Handler-level cursor tests (`cells/*/handler_test.go`) still pass (only check error code)
- [x] TDD workflow: RED (wrote failing tests asserting new format) → GREEN (implemented helpers + refactored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)