### PR TITLE
feat(outbox): add Relay Prometheus metrics (RL-METRICS-01)

### DIFF
--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -124,6 +124,10 @@ type RelayConfig struct {
 	// cleanup. Separate from RetentionPeriod to give operators more time
 	// to investigate and manually retry failed entries. Default 30 days.
 	DeadRetentionPeriod time.Duration
+	// Metrics is the relay metrics collector for Prometheus integration.
+	// If nil, a NoopRelayCollector is used (zero overhead).
+	// ref: Temporal client.Options{MetricsHandler} — inject-at-construction pattern
+	Metrics outbox.RelayCollector
 }
 
 // DefaultRelayConfig returns a RelayConfig with sensible defaults.
@@ -229,6 +233,9 @@ func NewOutboxRelay(db relayDB, pub outbox.Publisher, cfg RelayConfig) *OutboxRe
 	}
 	if cfg.DeadRetentionPeriod <= 0 {
 		cfg.DeadRetentionPeriod = defaults.DeadRetentionPeriod
+	}
+	if cfg.Metrics == nil {
+		cfg.Metrics = outbox.NoopRelayCollector{}
 	}
 
 	// Guard: ClaimTTL must exceed 2x PollInterval to prevent reclaimStale
@@ -427,6 +434,10 @@ func (r *OutboxRelay) pollOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Record batch size even for empty batches (captures idle cycles).
+	r.config.Metrics.RecordBatchSize(len(entries))
+
 	if len(entries) == 0 {
 		return nil
 	}
@@ -444,10 +455,12 @@ func (r *OutboxRelay) pollOnce(ctx context.Context) error {
 	}
 
 	// Phase 3: WriteBack (short tx)
+	wbStart := time.Now()
 	stats, wbErr := r.writeBack(ctx, results)
+	wbDur := time.Since(wbStart)
 
-	// Log only after writeBack completes — if commit fails, stats are
-	// rolled back and logging them would be misleading.
+	// Log and record metrics only after writeBack completes — if commit
+	// fails, stats are rolled back and recording them would be misleading.
 	if wbErr == nil {
 		slog.Info("outbox relay: poll complete",
 			slog.Int("published", stats.published),
@@ -456,6 +469,10 @@ func (r *OutboxRelay) pollOnce(ctx context.Context) error {
 			slog.Int("skipped", stats.skipped),
 			slog.Duration("claim_dur", claimDur),
 			slog.Duration("publish_dur", pubDur),
+		)
+		r.config.Metrics.RecordPollCycle(
+			stats.published, stats.retried, stats.dead, stats.skipped,
+			claimDur, pubDur, wbDur,
 		)
 	}
 
@@ -680,6 +697,7 @@ func (r *OutboxRelay) reclaimStale(ctx context.Context) error {
 			slog.Int64("count", ct.RowsAffected()),
 		)
 	}
+	r.config.Metrics.RecordReclaim(ct.RowsAffected())
 	return nil
 }
 
@@ -776,5 +794,6 @@ func (r *OutboxRelay) deletePublishedBefore(ctx context.Context, before time.Tim
 		)
 	}
 
+	r.config.Metrics.RecordCleanup(totalPublished, totalDead)
 	return nil
 }

--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -802,6 +802,11 @@ func (r *OutboxRelay) deletePublishedBefore(ctx context.Context, before time.Tim
 		)
 	}
 
+	// NOTE: If an intermediate batch exec fails above, this function returns
+	// early and RecordCleanup is not called — already-deleted rows are not
+	// counted. This is intentionally conservative: under-counting cleanup is
+	// safer than over-counting. If more precise cleanup metrics are needed,
+	// consider accumulating inside the loop and reporting on each iteration.
 	if totalPublished > 0 || totalDead > 0 {
 		r.config.Metrics.RecordCleanup(totalPublished, totalDead)
 	}

--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -470,10 +470,15 @@ func (r *OutboxRelay) pollOnce(ctx context.Context) error {
 			slog.Duration("claim_dur", claimDur),
 			slog.Duration("publish_dur", pubDur),
 		)
-		r.config.Metrics.RecordPollCycle(
-			stats.published, stats.retried, stats.dead, stats.skipped,
-			claimDur, pubDur, wbDur,
-		)
+		r.config.Metrics.RecordPollCycle(outbox.PollCycleResult{
+			Published:    stats.published,
+			Retried:      stats.retried,
+			Dead:         stats.dead,
+			Skipped:      stats.skipped,
+			ClaimDur:     claimDur,
+			PublishDur:   pubDur,
+			WriteBackDur: wbDur,
+		})
 	}
 
 	return wbErr
@@ -696,8 +701,8 @@ func (r *OutboxRelay) reclaimStale(ctx context.Context) error {
 		slog.Warn("outbox relay: reclaimed stale entries",
 			slog.Int64("count", ct.RowsAffected()),
 		)
+		r.config.Metrics.RecordReclaim(ct.RowsAffected())
 	}
-	r.config.Metrics.RecordReclaim(ct.RowsAffected())
 	return nil
 }
 

--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -237,6 +237,9 @@ func NewOutboxRelay(db relayDB, pub outbox.Publisher, cfg RelayConfig) *OutboxRe
 	if cfg.Metrics == nil {
 		cfg.Metrics = outbox.NoopRelayCollector{}
 	}
+	// Wrap in safe adapter: collector panics must not crash relay goroutines.
+	// ref: runtime/http/middleware/safe_observe.go — same pattern for HTTP metrics.
+	cfg.Metrics = &safeRelayCollector{inner: cfg.Metrics}
 
 	// Guard: ClaimTTL must exceed 2x PollInterval to prevent reclaimStale
 	// from reclaiming entries still being processed.

--- a/src/adapters/postgres/outbox_relay.go
+++ b/src/adapters/postgres/outbox_relay.go
@@ -802,6 +802,8 @@ func (r *OutboxRelay) deletePublishedBefore(ctx context.Context, before time.Tim
 		)
 	}
 
-	r.config.Metrics.RecordCleanup(totalPublished, totalDead)
+	if totalPublished > 0 || totalDead > 0 {
+		r.config.Metrics.RecordCleanup(totalPublished, totalDead)
+	}
 	return nil
 }

--- a/src/adapters/postgres/outbox_relay_test.go
+++ b/src/adapters/postgres/outbox_relay_test.go
@@ -893,28 +893,20 @@ func (p *mockPublisher) Publish(_ context.Context, topic string, payload []byte)
 
 type mockRelayCollector struct {
 	mu             sync.Mutex
-	pollCycles     []mockPollCycle
+	pollCycles     []outbox.PollCycleResult
 	batchSizes     []int
 	reclaimCounts  []int64
 	cleanupCalls   []mockCleanupCall
-}
-
-type mockPollCycle struct {
-	published, retried, dead, skipped int
-	claimDur, publishDur, writeBackDur time.Duration
 }
 
 type mockCleanupCall struct {
 	publishedDeleted, deadDeleted int64
 }
 
-func (m *mockRelayCollector) RecordPollCycle(published, retried, dead, skipped int, claimDur, publishDur, writeBackDur time.Duration) {
+func (m *mockRelayCollector) RecordPollCycle(r outbox.PollCycleResult) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.pollCycles = append(m.pollCycles, mockPollCycle{
-		published: published, retried: retried, dead: dead, skipped: skipped,
-		claimDur: claimDur, publishDur: publishDur, writeBackDur: writeBackDur,
-	})
+	m.pollCycles = append(m.pollCycles, r)
 }
 
 func (m *mockRelayCollector) RecordBatchSize(size int) {
@@ -966,13 +958,13 @@ func TestRelay_ThreePhase_Success_RecordsMetrics(t *testing.T) {
 
 	// Poll cycle recorded with correct counts.
 	require.Len(t, mc.pollCycles, 1)
-	assert.Equal(t, 2, mc.pollCycles[0].published)
-	assert.Equal(t, 0, mc.pollCycles[0].retried)
-	assert.Equal(t, 0, mc.pollCycles[0].dead)
-	assert.Equal(t, 0, mc.pollCycles[0].skipped)
-	assert.Greater(t, mc.pollCycles[0].claimDur, time.Duration(0))
-	assert.Greater(t, mc.pollCycles[0].publishDur, time.Duration(0))
-	assert.Greater(t, mc.pollCycles[0].writeBackDur, time.Duration(0))
+	assert.Equal(t, 2, mc.pollCycles[0].Published)
+	assert.Equal(t, 0, mc.pollCycles[0].Retried)
+	assert.Equal(t, 0, mc.pollCycles[0].Dead)
+	assert.Equal(t, 0, mc.pollCycles[0].Skipped)
+	assert.Greater(t, mc.pollCycles[0].ClaimDur, time.Duration(0))
+	assert.Greater(t, mc.pollCycles[0].PublishDur, time.Duration(0))
+	assert.Greater(t, mc.pollCycles[0].WriteBackDur, time.Duration(0))
 }
 
 func TestRelay_EmptyBatch_RecordsBatchSizeZero(t *testing.T) {

--- a/src/adapters/postgres/outbox_relay_test.go
+++ b/src/adapters/postgres/outbox_relay_test.go
@@ -962,9 +962,9 @@ func TestRelay_ThreePhase_Success_RecordsMetrics(t *testing.T) {
 	assert.Equal(t, 0, mc.pollCycles[0].Retried)
 	assert.Equal(t, 0, mc.pollCycles[0].Dead)
 	assert.Equal(t, 0, mc.pollCycles[0].Skipped)
-	assert.Greater(t, mc.pollCycles[0].ClaimDur, time.Duration(0))
-	assert.Greater(t, mc.pollCycles[0].PublishDur, time.Duration(0))
-	assert.Greater(t, mc.pollCycles[0].WriteBackDur, time.Duration(0))
+	assert.GreaterOrEqual(t, mc.pollCycles[0].ClaimDur, time.Duration(0))
+	assert.GreaterOrEqual(t, mc.pollCycles[0].PublishDur, time.Duration(0))
+	assert.GreaterOrEqual(t, mc.pollCycles[0].WriteBackDur, time.Duration(0))
 }
 
 func TestRelay_EmptyBatch_RecordsBatchSizeZero(t *testing.T) {

--- a/src/adapters/postgres/outbox_relay_test.go
+++ b/src/adapters/postgres/outbox_relay_test.go
@@ -886,3 +886,166 @@ func (p *mockPublisher) Publish(_ context.Context, topic string, payload []byte)
 	p.published = append(p.published, publishCall{topic: topic, payload: payload})
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// Mock RelayCollector for metrics tests
+// ---------------------------------------------------------------------------
+
+type mockRelayCollector struct {
+	mu             sync.Mutex
+	pollCycles     []mockPollCycle
+	batchSizes     []int
+	reclaimCounts  []int64
+	cleanupCalls   []mockCleanupCall
+}
+
+type mockPollCycle struct {
+	published, retried, dead, skipped int
+	claimDur, publishDur, writeBackDur time.Duration
+}
+
+type mockCleanupCall struct {
+	publishedDeleted, deadDeleted int64
+}
+
+func (m *mockRelayCollector) RecordPollCycle(published, retried, dead, skipped int, claimDur, publishDur, writeBackDur time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pollCycles = append(m.pollCycles, mockPollCycle{
+		published: published, retried: retried, dead: dead, skipped: skipped,
+		claimDur: claimDur, publishDur: publishDur, writeBackDur: writeBackDur,
+	})
+}
+
+func (m *mockRelayCollector) RecordBatchSize(size int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.batchSizes = append(m.batchSizes, size)
+}
+
+func (m *mockRelayCollector) RecordReclaim(count int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reclaimCounts = append(m.reclaimCounts, count)
+}
+
+func (m *mockRelayCollector) RecordCleanup(publishedDeleted, deadDeleted int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanupCalls = append(m.cleanupCalls, mockCleanupCall{
+		publishedDeleted: publishedDeleted, deadDeleted: deadDeleted,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Metrics integration tests (RL-METRICS-01)
+// ---------------------------------------------------------------------------
+
+func TestRelay_ThreePhase_Success_RecordsMetrics(t *testing.T) {
+	e1 := makeRelayEntry("e-m1", "order.created", 0)
+	e2 := makeRelayEntry("e-m2", "order.updated", 0)
+
+	db := &mockDBTX{
+		queryRows: &mockRows{entries: []mockRowData{
+			makeMockRowData(e1),
+			makeMockRowData(e2),
+		}},
+	}
+	pub := &mockPublisher{}
+	mc := &mockRelayCollector{}
+	cfg := DefaultRelayConfig()
+	cfg.Metrics = mc
+	relay := NewOutboxRelay(db, pub, cfg)
+
+	err := relay.pollOnce(context.Background())
+	require.NoError(t, err)
+
+	// Batch size recorded (2 entries).
+	require.Len(t, mc.batchSizes, 1)
+	assert.Equal(t, 2, mc.batchSizes[0])
+
+	// Poll cycle recorded with correct counts.
+	require.Len(t, mc.pollCycles, 1)
+	assert.Equal(t, 2, mc.pollCycles[0].published)
+	assert.Equal(t, 0, mc.pollCycles[0].retried)
+	assert.Equal(t, 0, mc.pollCycles[0].dead)
+	assert.Equal(t, 0, mc.pollCycles[0].skipped)
+	assert.Greater(t, mc.pollCycles[0].claimDur, time.Duration(0))
+	assert.Greater(t, mc.pollCycles[0].publishDur, time.Duration(0))
+	assert.Greater(t, mc.pollCycles[0].writeBackDur, time.Duration(0))
+}
+
+func TestRelay_EmptyBatch_RecordsBatchSizeZero(t *testing.T) {
+	db := &mockDBTX{
+		queryRows: &mockRows{entries: nil}, // empty
+	}
+	pub := &mockPublisher{}
+	mc := &mockRelayCollector{}
+	cfg := DefaultRelayConfig()
+	cfg.Metrics = mc
+	relay := NewOutboxRelay(db, pub, cfg)
+
+	err := relay.pollOnce(context.Background())
+	require.NoError(t, err)
+
+	// Batch size 0 recorded.
+	require.Len(t, mc.batchSizes, 1)
+	assert.Equal(t, 0, mc.batchSizes[0])
+
+	// No poll cycle recorded for empty batch.
+	assert.Empty(t, mc.pollCycles)
+}
+
+func TestRelay_ReclaimStale_RecordsMetrics(t *testing.T) {
+	db := &mockDBTX{
+		execResult: pgconn.NewCommandTag("UPDATE 3"),
+	}
+	mc := &mockRelayCollector{}
+	cfg := DefaultRelayConfig()
+	cfg.Metrics = mc
+	relay := NewOutboxRelay(db, &mockPublisher{}, cfg)
+
+	err := relay.reclaimStale(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, mc.reclaimCounts, 1)
+	assert.Equal(t, int64(3), mc.reclaimCounts[0])
+}
+
+func TestRelay_DeletePublishedBefore_RecordsCleanupMetrics(t *testing.T) {
+	db := &mockDBTX{}
+	mc := &mockRelayCollector{}
+	cfg := DefaultRelayConfig()
+	cfg.Metrics = mc
+	relay := NewOutboxRelay(db, &mockPublisher{}, cfg)
+
+	cutoff := time.Now().Add(-72 * time.Hour)
+	err := relay.deletePublishedBefore(context.Background(), cutoff)
+	require.NoError(t, err)
+
+	require.Len(t, mc.cleanupCalls, 1)
+	// With default mock returning UPDATE 1, totalPublished=1 and totalDead=1.
+	assert.Equal(t, int64(1), mc.cleanupCalls[0].publishedDeleted)
+	assert.Equal(t, int64(1), mc.cleanupCalls[0].deadDeleted)
+}
+
+func TestRelay_NilMetrics_UsesNoop(t *testing.T) {
+	db := &mockDBTX{
+		queryRows: &mockRows{entries: []mockRowData{
+			makeMockRowData(makeRelayEntry("e-noop", "test.event", 0)),
+		}},
+	}
+	pub := &mockPublisher{}
+	// Explicitly pass nil Metrics — must not panic.
+	relay := NewOutboxRelay(db, pub, RelayConfig{})
+
+	err := relay.pollOnce(context.Background())
+	assert.NoError(t, err, "pollOnce with nil Metrics (noop) must not panic")
+
+	err = relay.reclaimStale(context.Background())
+	assert.NoError(t, err, "reclaimStale with nil Metrics (noop) must not panic")
+
+	cutoff := time.Now().Add(-72 * time.Hour)
+	err = relay.deletePublishedBefore(context.Background(), cutoff)
+	assert.NoError(t, err, "deletePublishedBefore with nil Metrics (noop) must not panic")
+}

--- a/src/adapters/postgres/safe_relay_collector.go
+++ b/src/adapters/postgres/safe_relay_collector.go
@@ -13,8 +13,9 @@ import (
 // This follows the same pattern as runtime/http/middleware/safe_observe.go
 // which protects HTTP metrics collection from crashing request handlers.
 //
-// It also handles typed-nil implementations (e.g. a nil *prometheus.RelayCollector
-// stored in an interface value) by checking the inner value before delegation.
+// Typed-nil implementations (e.g. a nil *prometheus.RelayCollector stored in
+// an interface value) are handled implicitly: the nil-pointer dereference
+// panic is caught by the deferred recover() in safeCall.
 type safeRelayCollector struct {
 	inner outbox.RelayCollector
 }

--- a/src/adapters/postgres/safe_relay_collector.go
+++ b/src/adapters/postgres/safe_relay_collector.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"log/slog"
+	"runtime/debug"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// safeRelayCollector wraps an outbox.RelayCollector and recovers from any
+// panic so that a misbehaving collector cannot crash relay worker goroutines.
+//
+// This follows the same pattern as runtime/http/middleware/safe_observe.go
+// which protects HTTP metrics collection from crashing request handlers.
+//
+// It also handles typed-nil implementations (e.g. a nil *prometheus.RelayCollector
+// stored in an interface value) by checking the inner value before delegation.
+type safeRelayCollector struct {
+	inner outbox.RelayCollector
+}
+
+func (s *safeRelayCollector) RecordPollCycle(r outbox.PollCycleResult) {
+	s.safeCall(func() { s.inner.RecordPollCycle(r) })
+}
+
+func (s *safeRelayCollector) RecordBatchSize(size int) {
+	s.safeCall(func() { s.inner.RecordBatchSize(size) })
+}
+
+func (s *safeRelayCollector) RecordReclaim(count int64) {
+	s.safeCall(func() { s.inner.RecordReclaim(count) })
+}
+
+func (s *safeRelayCollector) RecordCleanup(publishedDeleted, deadDeleted int64) {
+	s.safeCall(func() { s.inner.RecordCleanup(publishedDeleted, deadDeleted) })
+}
+
+// safeCall runs fn and recovers from any panic, logging it instead of
+// letting it propagate to the relay goroutine.
+func (s *safeRelayCollector) safeCall(fn func()) {
+	defer func() {
+		if v := recover(); v != nil {
+			slog.Error("outbox relay: metrics collector panic (dropped observation)",
+				slog.Any("panic", v),
+				slog.String("stack", string(debug.Stack())),
+			)
+		}
+	}()
+	fn()
+}

--- a/src/adapters/postgres/safe_relay_collector.go
+++ b/src/adapters/postgres/safe_relay_collector.go
@@ -19,6 +19,9 @@ type safeRelayCollector struct {
 	inner outbox.RelayCollector
 }
 
+// Compile-time interface check.
+var _ outbox.RelayCollector = (*safeRelayCollector)(nil)
+
 func (s *safeRelayCollector) RecordPollCycle(r outbox.PollCycleResult) {
 	s.safeCall(func() { s.inner.RecordPollCycle(r) })
 }

--- a/src/adapters/postgres/safe_relay_collector_test.go
+++ b/src/adapters/postgres/safe_relay_collector_test.go
@@ -1,0 +1,87 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/stretchr/testify/assert"
+)
+
+// panicRelayCollector is a test collector that panics on every call.
+type panicRelayCollector struct{}
+
+func (panicRelayCollector) RecordPollCycle(_ outbox.PollCycleResult) { panic("boom: poll cycle") }
+func (panicRelayCollector) RecordBatchSize(_ int)                    { panic("boom: batch size") }
+func (panicRelayCollector) RecordReclaim(_ int64)                    { panic("boom: reclaim") }
+func (panicRelayCollector) RecordCleanup(_, _ int64)                 { panic("boom: cleanup") }
+
+func TestSafeRelayCollector_PanickingCollector_DoesNotCrash(t *testing.T) {
+	s := &safeRelayCollector{inner: panicRelayCollector{}}
+
+	// None of these should panic — all should be silently recovered.
+	assert.NotPanics(t, func() {
+		s.RecordPollCycle(outbox.PollCycleResult{
+			Published: 1, ClaimDur: time.Millisecond,
+			PublishDur: time.Millisecond, WriteBackDur: time.Millisecond,
+		})
+	}, "RecordPollCycle panic must be recovered")
+
+	assert.NotPanics(t, func() {
+		s.RecordBatchSize(10)
+	}, "RecordBatchSize panic must be recovered")
+
+	assert.NotPanics(t, func() {
+		s.RecordReclaim(5)
+	}, "RecordReclaim panic must be recovered")
+
+	assert.NotPanics(t, func() {
+		s.RecordCleanup(10, 3)
+	}, "RecordCleanup panic must be recovered")
+}
+
+func TestSafeRelayCollector_TypedNil_DoesNotCrash(t *testing.T) {
+	// A typed nil: interface holds a nil *mockRelayCollector pointer.
+	// Calling methods on it will panic with nil pointer dereference.
+	var nilCollector *mockRelayCollector // typed nil
+	s := &safeRelayCollector{inner: nilCollector}
+
+	assert.NotPanics(t, func() {
+		s.RecordPollCycle(outbox.PollCycleResult{Published: 1})
+	}, "typed-nil collector must not crash")
+
+	assert.NotPanics(t, func() {
+		s.RecordBatchSize(5)
+	}, "typed-nil collector must not crash")
+
+	assert.NotPanics(t, func() {
+		s.RecordReclaim(1)
+	}, "typed-nil collector must not crash")
+
+	assert.NotPanics(t, func() {
+		s.RecordCleanup(1, 0)
+	}, "typed-nil collector must not crash")
+}
+
+func TestSafeRelayCollector_DelegatesCorrectly(t *testing.T) {
+	mc := &mockRelayCollector{}
+	s := &safeRelayCollector{inner: mc}
+
+	s.RecordPollCycle(outbox.PollCycleResult{Published: 3})
+	s.RecordBatchSize(42)
+	s.RecordReclaim(7)
+	s.RecordCleanup(10, 2)
+
+	assert.Len(t, mc.pollCycles, 1)
+	assert.Equal(t, 3, mc.pollCycles[0].Published)
+
+	assert.Len(t, mc.batchSizes, 1)
+	assert.Equal(t, 42, mc.batchSizes[0])
+
+	assert.Len(t, mc.reclaimCounts, 1)
+	assert.Equal(t, int64(7), mc.reclaimCounts[0])
+
+	assert.Len(t, mc.cleanupCalls, 1)
+	assert.Equal(t, int64(10), mc.cleanupCalls[0].publishedDeleted)
+	assert.Equal(t, int64(2), mc.cleanupCalls[0].deadDeleted)
+}

--- a/src/adapters/prometheus/relay_collector.go
+++ b/src/adapters/prometheus/relay_collector.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	prom "github.com/prometheus/client_golang/prometheus"
-	"time"
 )
 
 // Compile-time check: RelayCollector implements outbox.RelayCollector.
@@ -55,6 +54,9 @@ func (c *RelayCollectorConfig) defaults() {
 
 // RelayCollector implements outbox.RelayCollector using Prometheus metrics.
 //
+// All metrics use dynamic labels (no ConstLabels) for consistency and to
+// support multiple cells sharing a single registry without conflicts.
+//
 // Registered metrics:
 //   - gocell_outbox_relayed_total        (counter, labels: cell, outcome)
 //   - gocell_outbox_poll_duration_seconds (histogram, labels: cell, phase)
@@ -67,8 +69,8 @@ type RelayCollector struct {
 
 	relayed      *prom.CounterVec
 	pollDuration *prom.HistogramVec
-	batchSize    prom.Histogram
-	reclaimed    prom.Counter
+	batchSize    *prom.HistogramVec
+	reclaimed    *prom.CounterVec
 	cleaned      *prom.CounterVec
 }
 
@@ -97,22 +99,20 @@ func NewRelayCollector(cfg RelayCollectorConfig) (*RelayCollector, error) {
 		Buckets:   cfg.PollBuckets,
 	}, []string{"cell", "phase"})
 
-	batchSize := prom.NewHistogram(prom.HistogramOpts{
-		Namespace:   cfg.Namespace,
-		Subsystem:   "outbox",
-		Name:        "batch_size",
-		Help:        "Number of entries claimed per relay poll cycle.",
-		Buckets:     cfg.BatchBuckets,
-		ConstLabels: prom.Labels{"cell": cfg.CellID},
-	})
+	batchSize := prom.NewHistogramVec(prom.HistogramOpts{
+		Namespace: cfg.Namespace,
+		Subsystem: "outbox",
+		Name:      "batch_size",
+		Help:      "Number of entries claimed per relay poll cycle.",
+		Buckets:   cfg.BatchBuckets,
+	}, []string{"cell"})
 
-	reclaimed := prom.NewCounter(prom.CounterOpts{
-		Namespace:   cfg.Namespace,
-		Subsystem:   "outbox",
-		Name:        "reclaimed_total",
-		Help:        "Total number of stale entries reclaimed by the relay.",
-		ConstLabels: prom.Labels{"cell": cfg.CellID},
-	})
+	reclaimed := prom.NewCounterVec(prom.CounterOpts{
+		Namespace: cfg.Namespace,
+		Subsystem: "outbox",
+		Name:      "reclaimed_total",
+		Help:      "Total number of stale entries reclaimed by the relay.",
+	}, []string{"cell"})
 
 	cleaned := prom.NewCounterVec(prom.CounterOpts{
 		Namespace: cfg.Namespace,
@@ -139,37 +139,37 @@ func NewRelayCollector(cfg RelayCollectorConfig) (*RelayCollector, error) {
 }
 
 // RecordPollCycle records a completed poll cycle.
-func (c *RelayCollector) RecordPollCycle(published, retried, dead, skipped int, claimDur, publishDur, writeBackDur time.Duration) {
+func (c *RelayCollector) RecordPollCycle(r outbox.PollCycleResult) {
 	cell := c.cellID
 
-	if published > 0 {
-		c.relayed.With(prom.Labels{"cell": cell, "outcome": "published"}).Add(float64(published))
+	if r.Published > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "published"}).Add(float64(r.Published))
 	}
-	if retried > 0 {
-		c.relayed.With(prom.Labels{"cell": cell, "outcome": "retried"}).Add(float64(retried))
+	if r.Retried > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "retried"}).Add(float64(r.Retried))
 	}
-	if dead > 0 {
-		c.relayed.With(prom.Labels{"cell": cell, "outcome": "dead"}).Add(float64(dead))
+	if r.Dead > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "dead"}).Add(float64(r.Dead))
 	}
-	if skipped > 0 {
-		c.relayed.With(prom.Labels{"cell": cell, "outcome": "skipped"}).Add(float64(skipped))
+	if r.Skipped > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "skipped"}).Add(float64(r.Skipped))
 	}
 
-	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "claim"}).Observe(claimDur.Seconds())
-	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "publish"}).Observe(publishDur.Seconds())
-	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "write_back"}).Observe(writeBackDur.Seconds())
-	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "total"}).Observe((claimDur + publishDur + writeBackDur).Seconds())
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "claim"}).Observe(r.ClaimDur.Seconds())
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "publish"}).Observe(r.PublishDur.Seconds())
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "write_back"}).Observe(r.WriteBackDur.Seconds())
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "total"}).Observe((r.ClaimDur + r.PublishDur + r.WriteBackDur).Seconds())
 }
 
 // RecordBatchSize records the number of entries claimed.
 func (c *RelayCollector) RecordBatchSize(size int) {
-	c.batchSize.Observe(float64(size))
+	c.batchSize.With(prom.Labels{"cell": c.cellID}).Observe(float64(size))
 }
 
 // RecordReclaim records stale entries reclaimed.
 func (c *RelayCollector) RecordReclaim(count int64) {
 	if count > 0 {
-		c.reclaimed.Add(float64(count))
+		c.reclaimed.With(prom.Labels{"cell": c.cellID}).Add(float64(count))
 	}
 }
 
@@ -182,9 +182,4 @@ func (c *RelayCollector) RecordCleanup(publishedDeleted, deadDeleted int64) {
 	if deadDeleted > 0 {
 		c.cleaned.With(prom.Labels{"cell": cell, "status": "dead"}).Add(float64(deadDeleted))
 	}
-}
-
-// Registry returns the Prometheus registry, primarily for testing.
-func (c *RelayCollector) Registry() *prom.Registry {
-	return c.registry
 }

--- a/src/adapters/prometheus/relay_collector.go
+++ b/src/adapters/prometheus/relay_collector.go
@@ -1,0 +1,190 @@
+package prometheus
+
+import (
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+// Compile-time check: RelayCollector implements outbox.RelayCollector.
+var _ outbox.RelayCollector = (*RelayCollector)(nil)
+
+// DefaultPollBuckets are histogram buckets for poll phase duration (5ms–10s).
+var DefaultPollBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+// DefaultBatchBuckets are histogram buckets for batch size (1–500).
+var DefaultBatchBuckets = []float64{1, 5, 10, 25, 50, 100, 200, 500}
+
+// RelayCollectorConfig configures the Prometheus relay metrics collector.
+type RelayCollectorConfig struct {
+	// CellID identifies the cell that owns these metrics. Required.
+	CellID string
+
+	// Namespace is the Prometheus metric namespace prefix. Default: "gocell".
+	Namespace string
+
+	// Registry is the Prometheus registry to use. If nil, a new registry is
+	// created. Using an isolated registry avoids collisions with the global default.
+	Registry *prom.Registry
+
+	// PollBuckets configures histogram bucket boundaries for poll durations.
+	// Default: DefaultPollBuckets.
+	PollBuckets []float64
+
+	// BatchBuckets configures histogram bucket boundaries for batch sizes.
+	// Default: DefaultBatchBuckets.
+	BatchBuckets []float64
+}
+
+// defaults fills zero-valued fields with sensible defaults.
+func (c *RelayCollectorConfig) defaults() {
+	if c.Namespace == "" {
+		c.Namespace = "gocell"
+	}
+	if c.Registry == nil {
+		c.Registry = prom.NewRegistry()
+	}
+	if len(c.PollBuckets) == 0 {
+		c.PollBuckets = DefaultPollBuckets
+	}
+	if len(c.BatchBuckets) == 0 {
+		c.BatchBuckets = DefaultBatchBuckets
+	}
+}
+
+// RelayCollector implements outbox.RelayCollector using Prometheus metrics.
+//
+// Registered metrics:
+//   - gocell_outbox_relayed_total        (counter, labels: cell, outcome)
+//   - gocell_outbox_poll_duration_seconds (histogram, labels: cell, phase)
+//   - gocell_outbox_batch_size           (histogram, labels: cell)
+//   - gocell_outbox_reclaimed_total      (counter, labels: cell)
+//   - gocell_outbox_cleaned_total        (counter, labels: cell, status)
+type RelayCollector struct {
+	cellID   string
+	registry *prom.Registry
+
+	relayed      *prom.CounterVec
+	pollDuration *prom.HistogramVec
+	batchSize    prom.Histogram
+	reclaimed    prom.Counter
+	cleaned      *prom.CounterVec
+}
+
+// NewRelayCollector creates a Prometheus-backed relay metrics collector.
+// ref: Watermill PrometheusMetricsBuilder — register with AlreadyRegistered tolerance
+// ref: Temporal MetricsHandler — inject at construction
+func NewRelayCollector(cfg RelayCollectorConfig) (*RelayCollector, error) {
+	cfg.defaults()
+
+	if cfg.CellID == "" {
+		return nil, errcode.New(ErrAdapterPromConfig, "prometheus: relay CellID is required")
+	}
+
+	relayed := prom.NewCounterVec(prom.CounterOpts{
+		Namespace: cfg.Namespace,
+		Subsystem: "outbox",
+		Name:      "relayed_total",
+		Help:      "Total number of outbox entries processed by the relay, by outcome.",
+	}, []string{"cell", "outcome"})
+
+	pollDuration := prom.NewHistogramVec(prom.HistogramOpts{
+		Namespace: cfg.Namespace,
+		Subsystem: "outbox",
+		Name:      "poll_duration_seconds",
+		Help:      "Duration of each relay poll phase in seconds.",
+		Buckets:   cfg.PollBuckets,
+	}, []string{"cell", "phase"})
+
+	batchSize := prom.NewHistogram(prom.HistogramOpts{
+		Namespace:   cfg.Namespace,
+		Subsystem:   "outbox",
+		Name:        "batch_size",
+		Help:        "Number of entries claimed per relay poll cycle.",
+		Buckets:     cfg.BatchBuckets,
+		ConstLabels: prom.Labels{"cell": cfg.CellID},
+	})
+
+	reclaimed := prom.NewCounter(prom.CounterOpts{
+		Namespace:   cfg.Namespace,
+		Subsystem:   "outbox",
+		Name:        "reclaimed_total",
+		Help:        "Total number of stale entries reclaimed by the relay.",
+		ConstLabels: prom.Labels{"cell": cfg.CellID},
+	})
+
+	cleaned := prom.NewCounterVec(prom.CounterOpts{
+		Namespace: cfg.Namespace,
+		Subsystem: "outbox",
+		Name:      "cleaned_total",
+		Help:      "Total number of entries cleaned up (deleted) by the relay.",
+	}, []string{"cell", "status"})
+
+	for _, c := range []prom.Collector{relayed, pollDuration, batchSize, reclaimed, cleaned} {
+		if err := cfg.Registry.Register(c); err != nil {
+			return nil, errcode.Wrap(ErrAdapterPromRegister, "prometheus: relay metric registration failed", err)
+		}
+	}
+
+	return &RelayCollector{
+		cellID:       cfg.CellID,
+		registry:     cfg.Registry,
+		relayed:      relayed,
+		pollDuration: pollDuration,
+		batchSize:    batchSize,
+		reclaimed:    reclaimed,
+		cleaned:      cleaned,
+	}, nil
+}
+
+// RecordPollCycle records a completed poll cycle.
+func (c *RelayCollector) RecordPollCycle(published, retried, dead, skipped int, claimDur, publishDur, writeBackDur time.Duration) {
+	cell := c.cellID
+
+	if published > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "published"}).Add(float64(published))
+	}
+	if retried > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "retried"}).Add(float64(retried))
+	}
+	if dead > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "dead"}).Add(float64(dead))
+	}
+	if skipped > 0 {
+		c.relayed.With(prom.Labels{"cell": cell, "outcome": "skipped"}).Add(float64(skipped))
+	}
+
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "claim"}).Observe(claimDur.Seconds())
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "publish"}).Observe(publishDur.Seconds())
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "write_back"}).Observe(writeBackDur.Seconds())
+	c.pollDuration.With(prom.Labels{"cell": cell, "phase": "total"}).Observe((claimDur + publishDur + writeBackDur).Seconds())
+}
+
+// RecordBatchSize records the number of entries claimed.
+func (c *RelayCollector) RecordBatchSize(size int) {
+	c.batchSize.Observe(float64(size))
+}
+
+// RecordReclaim records stale entries reclaimed.
+func (c *RelayCollector) RecordReclaim(count int64) {
+	if count > 0 {
+		c.reclaimed.Add(float64(count))
+	}
+}
+
+// RecordCleanup records entries cleaned up.
+func (c *RelayCollector) RecordCleanup(publishedDeleted, deadDeleted int64) {
+	cell := c.cellID
+	if publishedDeleted > 0 {
+		c.cleaned.With(prom.Labels{"cell": cell, "status": "published"}).Add(float64(publishedDeleted))
+	}
+	if deadDeleted > 0 {
+		c.cleaned.With(prom.Labels{"cell": cell, "status": "dead"}).Add(float64(deadDeleted))
+	}
+}
+
+// Registry returns the Prometheus registry, primarily for testing.
+func (c *RelayCollector) Registry() *prom.Registry {
+	return c.registry
+}

--- a/src/adapters/prometheus/relay_collector.go
+++ b/src/adapters/prometheus/relay_collector.go
@@ -75,7 +75,7 @@ type RelayCollector struct {
 }
 
 // NewRelayCollector creates a Prometheus-backed relay metrics collector.
-// ref: Watermill PrometheusMetricsBuilder — register with AlreadyRegistered tolerance
+// Metrics are registered during construction; any registration failure is returned.
 // ref: Temporal MetricsHandler — inject at construction
 func NewRelayCollector(cfg RelayCollectorConfig) (*RelayCollector, error) {
 	cfg.defaults()

--- a/src/adapters/prometheus/relay_collector_test.go
+++ b/src/adapters/prometheus/relay_collector_test.go
@@ -46,38 +46,19 @@ func TestRelayCollector_RecordPollCycle(t *testing.T) {
 	families, err := registry.Gather()
 	require.NoError(t, err)
 
-	var foundRelayed, foundDuration bool
-	for _, f := range families {
-		switch f.GetName() {
-		case "gocell_outbox_relayed_total":
-			foundRelayed = true
-			// Should have metrics for published(3), retried(1), skipped(1).
-			// dead=0, so no metric emitted for dead.
-			metricCount := len(f.GetMetric())
-			assert.Equal(t, 3, metricCount,
-				"should have 3 label combinations (published, retried, skipped; dead=0 is skipped)")
-			// Verify published counter value.
-			for _, m := range f.GetMetric() {
-				labels := metricLabels(m)
-				if labels["outcome"] == "published" {
-					assert.Equal(t, 3.0, m.GetCounter().GetValue())
-				}
-				if labels["outcome"] == "retried" {
-					assert.Equal(t, 1.0, m.GetCounter().GetValue())
-				}
-				if labels["outcome"] == "skipped" {
-					assert.Equal(t, 1.0, m.GetCounter().GetValue())
-				}
-			}
-		case "gocell_outbox_poll_duration_seconds":
-			foundDuration = true
-			// 4 phases: claim, publish, write_back, total.
-			assert.Equal(t, 4, len(f.GetMetric()),
-				"should have 4 phase label combinations")
-		}
-	}
-	assert.True(t, foundRelayed, "should have relayed_total counter")
-	assert.True(t, foundDuration, "should have poll_duration_seconds histogram")
+	relayed := findFamily(families, "gocell_outbox_relayed_total")
+	require.NotNil(t, relayed, "should have relayed_total counter")
+	// 3 label combos: published(3), retried(1), skipped(1). dead=0 is skipped.
+	assert.Equal(t, 3, len(relayed.GetMetric()),
+		"should have 3 label combinations (published, retried, skipped; dead=0 is skipped)")
+	assertCounterValue(t, relayed, "outcome", "published", 3.0)
+	assertCounterValue(t, relayed, "outcome", "retried", 1.0)
+	assertCounterValue(t, relayed, "outcome", "skipped", 1.0)
+
+	duration := findFamily(families, "gocell_outbox_poll_duration_seconds")
+	require.NotNil(t, duration, "should have poll_duration_seconds histogram")
+	assert.Equal(t, 4, len(duration.GetMetric()),
+		"should have 4 phase label combinations")
 }
 
 func TestRelayCollector_RecordPollCycle_AllZero(t *testing.T) {
@@ -276,4 +257,28 @@ func metricLabels(m *prom_dto.Metric) map[string]string {
 		labels[lp.GetName()] = lp.GetValue()
 	}
 	return labels
+}
+
+// findFamily returns the metric family with the given name, or nil.
+func findFamily(families []*prom_dto.MetricFamily, name string) *prom_dto.MetricFamily {
+	for _, f := range families {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// assertCounterValue asserts that the metric family contains a counter with
+// the given label key=value and the expected counter value.
+func assertCounterValue(t *testing.T, family *prom_dto.MetricFamily, labelKey, labelValue string, expected float64) {
+	t.Helper()
+	for _, m := range family.GetMetric() {
+		if metricLabels(m)[labelKey] == labelValue {
+			assert.Equal(t, expected, m.GetCounter().GetValue(),
+				"counter %s=%s", labelKey, labelValue)
+			return
+		}
+	}
+	t.Errorf("no metric found with %s=%s", labelKey, labelValue)
 }

--- a/src/adapters/prometheus/relay_collector_test.go
+++ b/src/adapters/prometheus/relay_collector_test.go
@@ -1,0 +1,242 @@
+package prometheus
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	prom "github.com/prometheus/client_golang/prometheus"
+	prom_dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayCollector_ImplementsInterface(t *testing.T) {
+	var _ outbox.RelayCollector = (*RelayCollector)(nil)
+}
+
+func TestNewRelayCollector_MissingCellID(t *testing.T) {
+	_, err := NewRelayCollector(RelayCollectorConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CellID")
+}
+
+func TestNewRelayCollector_DefaultConfig(t *testing.T) {
+	c, err := NewRelayCollector(RelayCollectorConfig{CellID: "test-cell"})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "test-cell", c.cellID)
+	assert.NotNil(t, c.registry)
+}
+
+func TestRelayCollector_RecordPollCycle(t *testing.T) {
+	registry := prom.NewRegistry()
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	c.RecordPollCycle(3, 1, 0, 1,
+		10*time.Millisecond, 50*time.Millisecond, 5*time.Millisecond)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var foundRelayed, foundDuration bool
+	for _, f := range families {
+		switch f.GetName() {
+		case "gocell_outbox_relayed_total":
+			foundRelayed = true
+			// Should have metrics for published(3), retried(1), skipped(1).
+			// dead=0, so no metric emitted for dead.
+			metricCount := len(f.GetMetric())
+			assert.Equal(t, 3, metricCount,
+				"should have 3 label combinations (published, retried, skipped; dead=0 is skipped)")
+			// Verify published counter value.
+			for _, m := range f.GetMetric() {
+				labels := metricLabels(m)
+				if labels["outcome"] == "published" {
+					assert.Equal(t, 3.0, m.GetCounter().GetValue())
+				}
+				if labels["outcome"] == "retried" {
+					assert.Equal(t, 1.0, m.GetCounter().GetValue())
+				}
+				if labels["outcome"] == "skipped" {
+					assert.Equal(t, 1.0, m.GetCounter().GetValue())
+				}
+			}
+		case "gocell_outbox_poll_duration_seconds":
+			foundDuration = true
+			// 4 phases: claim, publish, write_back, total.
+			assert.Equal(t, 4, len(f.GetMetric()),
+				"should have 4 phase label combinations")
+		}
+	}
+	assert.True(t, foundRelayed, "should have relayed_total counter")
+	assert.True(t, foundDuration, "should have poll_duration_seconds histogram")
+}
+
+func TestRelayCollector_RecordBatchSize(t *testing.T) {
+	registry := prom.NewRegistry()
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	c.RecordBatchSize(0)
+	c.RecordBatchSize(50)
+	c.RecordBatchSize(100)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() == "gocell_outbox_batch_size" {
+			found = true
+			require.Len(t, f.GetMetric(), 1)
+			h := f.GetMetric()[0].GetHistogram()
+			assert.Equal(t, uint64(3), h.GetSampleCount())
+		}
+	}
+	assert.True(t, found, "should have batch_size histogram")
+}
+
+func TestRelayCollector_RecordReclaim(t *testing.T) {
+	registry := prom.NewRegistry()
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	c.RecordReclaim(0) // no-op
+	c.RecordReclaim(5)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() == "gocell_outbox_reclaimed_total" {
+			found = true
+			require.Len(t, f.GetMetric(), 1)
+			assert.Equal(t, 5.0, f.GetMetric()[0].GetCounter().GetValue())
+		}
+	}
+	assert.True(t, found, "should have reclaimed_total counter")
+}
+
+func TestRelayCollector_RecordCleanup(t *testing.T) {
+	registry := prom.NewRegistry()
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	c.RecordCleanup(100, 3)
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() == "gocell_outbox_cleaned_total" {
+			found = true
+			assert.Equal(t, 2, len(f.GetMetric()),
+				"should have 2 status label combinations (published, dead)")
+		}
+	}
+	assert.True(t, found, "should have cleaned_total counter")
+}
+
+func TestRelayCollector_RecordCleanup_ZeroSkipped(t *testing.T) {
+	registry := prom.NewRegistry()
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	c.RecordCleanup(0, 0) // both zero, no metrics emitted
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		assert.NotEqual(t, "gocell_outbox_cleaned_total", f.GetName(),
+			"zero cleanup should not emit any cleaned_total metrics")
+	}
+}
+
+func TestRelayCollector_ConcurrentSafety(t *testing.T) {
+	c, err := NewRelayCollector(RelayCollectorConfig{CellID: "test-cell"})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.RecordPollCycle(1, 0, 0, 0, time.Millisecond, time.Millisecond, time.Millisecond)
+			c.RecordBatchSize(10)
+			c.RecordReclaim(1)
+			c.RecordCleanup(1, 0)
+		}()
+	}
+	wg.Wait()
+
+	families, err := c.registry.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		if f.GetName() == "gocell_outbox_reclaimed_total" {
+			assert.Equal(t, 100.0, f.GetMetric()[0].GetCounter().GetValue())
+		}
+	}
+}
+
+func TestRelayCollector_CustomBuckets(t *testing.T) {
+	registry := prom.NewRegistry()
+	pollBuckets := []float64{0.001, 0.01, 0.1}
+	batchBuckets := []float64{1, 10, 100}
+
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:       "test-cell",
+		Registry:     registry,
+		PollBuckets:  pollBuckets,
+		BatchBuckets: batchBuckets,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}
+
+func TestRelayCollector_DuplicateRegister_Error(t *testing.T) {
+	registry := prom.NewRegistry()
+	_, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	// Second registration on the same registry should fail.
+	_, err = NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration")
+}
+
+// metricLabels extracts label name→value from a gathered Prometheus metric.
+func metricLabels(m *prom_dto.Metric) map[string]string {
+	labels := make(map[string]string)
+	for _, lp := range m.GetLabel() {
+		labels[lp.GetName()] = lp.GetValue()
+	}
+	return labels
+}

--- a/src/adapters/prometheus/relay_collector_test.go
+++ b/src/adapters/prometheus/relay_collector_test.go
@@ -38,8 +38,10 @@ func TestRelayCollector_RecordPollCycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	c.RecordPollCycle(3, 1, 0, 1,
-		10*time.Millisecond, 50*time.Millisecond, 5*time.Millisecond)
+	c.RecordPollCycle(outbox.PollCycleResult{
+		Published: 3, Retried: 1, Dead: 0, Skipped: 1,
+		ClaimDur: 10 * time.Millisecond, PublishDur: 50 * time.Millisecond, WriteBackDur: 5 * time.Millisecond,
+	})
 
 	families, err := registry.Gather()
 	require.NoError(t, err)
@@ -78,6 +80,26 @@ func TestRelayCollector_RecordPollCycle(t *testing.T) {
 	assert.True(t, foundDuration, "should have poll_duration_seconds histogram")
 }
 
+func TestRelayCollector_RecordPollCycle_AllZero(t *testing.T) {
+	registry := prom.NewRegistry()
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	c.RecordPollCycle(outbox.PollCycleResult{})
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		if f.GetName() == "gocell_outbox_relayed_total" {
+			t.Fatal("all-zero PollCycleResult should not emit any relayed_total counters")
+		}
+	}
+}
+
 func TestRelayCollector_RecordBatchSize(t *testing.T) {
 	registry := prom.NewRegistry()
 	c, err := NewRelayCollector(RelayCollectorConfig{
@@ -100,6 +122,9 @@ func TestRelayCollector_RecordBatchSize(t *testing.T) {
 			require.Len(t, f.GetMetric(), 1)
 			h := f.GetMetric()[0].GetHistogram()
 			assert.Equal(t, uint64(3), h.GetSampleCount())
+			// Verify cell label is dynamic (not ConstLabels).
+			labels := metricLabels(f.GetMetric()[0])
+			assert.Equal(t, "test-cell", labels["cell"])
 		}
 	}
 	assert.True(t, found, "should have batch_size histogram")
@@ -125,6 +150,9 @@ func TestRelayCollector_RecordReclaim(t *testing.T) {
 			found = true
 			require.Len(t, f.GetMetric(), 1)
 			assert.Equal(t, 5.0, f.GetMetric()[0].GetCounter().GetValue())
+			// Verify cell label is dynamic (not ConstLabels).
+			labels := metricLabels(f.GetMetric()[0])
+			assert.Equal(t, "test-cell", labels["cell"])
 		}
 	}
 	assert.True(t, found, "should have reclaimed_total counter")
@@ -174,7 +202,11 @@ func TestRelayCollector_RecordCleanup_ZeroSkipped(t *testing.T) {
 }
 
 func TestRelayCollector_ConcurrentSafety(t *testing.T) {
-	c, err := NewRelayCollector(RelayCollectorConfig{CellID: "test-cell"})
+	registry := prom.NewRegistry()
+	c, err := NewRelayCollector(RelayCollectorConfig{
+		CellID:   "test-cell",
+		Registry: registry,
+	})
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -182,7 +214,12 @@ func TestRelayCollector_ConcurrentSafety(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c.RecordPollCycle(1, 0, 0, 0, time.Millisecond, time.Millisecond, time.Millisecond)
+			c.RecordPollCycle(outbox.PollCycleResult{
+				Published: 1,
+				ClaimDur:  time.Millisecond,
+				PublishDur: time.Millisecond,
+				WriteBackDur: time.Millisecond,
+			})
 			c.RecordBatchSize(10)
 			c.RecordReclaim(1)
 			c.RecordCleanup(1, 0)
@@ -190,7 +227,7 @@ func TestRelayCollector_ConcurrentSafety(t *testing.T) {
 	}
 	wg.Wait()
 
-	families, err := c.registry.Gather()
+	families, err := registry.Gather()
 	require.NoError(t, err)
 
 	for _, f := range families {

--- a/src/kernel/outbox/relay_metrics.go
+++ b/src/kernel/outbox/relay_metrics.go
@@ -43,7 +43,7 @@ type RelayCollector interface {
 // Used when metrics collection is disabled (nil Metrics in RelayConfig).
 type NoopRelayCollector struct{}
 
-func (NoopRelayCollector) RecordPollCycle(_ PollCycleResult) {}
-func (NoopRelayCollector) RecordBatchSize(_ int)             {}
-func (NoopRelayCollector) RecordReclaim(_ int64)             {}
-func (NoopRelayCollector) RecordCleanup(_, _ int64)          {}
+func (NoopRelayCollector) RecordPollCycle(_ PollCycleResult) { /* no-op: metrics disabled */ }
+func (NoopRelayCollector) RecordBatchSize(_ int)             { /* no-op: metrics disabled */ }
+func (NoopRelayCollector) RecordReclaim(_ int64)             { /* no-op: metrics disabled */ }
+func (NoopRelayCollector) RecordCleanup(_, _ int64)          { /* no-op: metrics disabled */ }

--- a/src/kernel/outbox/relay_metrics.go
+++ b/src/kernel/outbox/relay_metrics.go
@@ -2,8 +2,18 @@ package outbox
 
 import "time"
 
+// PollCycleResult captures the outcome of a single relay poll cycle.
+// Used by RelayCollector.RecordPollCycle to avoid a long parameter list
+// and to support future extensions without breaking the interface.
+type PollCycleResult struct {
+	Published, Retried, Dead, Skipped int
+	ClaimDur, PublishDur, WriteBackDur time.Duration
+}
+
 // RelayCollector records outbox relay operational metrics.
 // Implementations must be safe for concurrent use.
+// Zero counts are valid inputs; implementations should handle them gracefully
+// (e.g. skip counter increments for zero values).
 //
 // The interface is intentionally in kernel/outbox (not runtime/) so that
 // adapters/postgres can depend on it without pulling in runtime/ packages.
@@ -14,7 +24,7 @@ import "time"
 type RelayCollector interface {
 	// RecordPollCycle records a completed poll cycle with outcome counts and
 	// per-phase durations. Called once per pollOnce invocation after writeBack.
-	RecordPollCycle(published, retried, dead, skipped int, claimDur, publishDur, writeBackDur time.Duration)
+	RecordPollCycle(result PollCycleResult)
 
 	// RecordBatchSize records the number of entries claimed in a poll cycle.
 	// Called even when the batch is empty (size=0) to capture idle cycles.
@@ -33,7 +43,7 @@ type RelayCollector interface {
 // Used when metrics collection is disabled (nil Metrics in RelayConfig).
 type NoopRelayCollector struct{}
 
-func (NoopRelayCollector) RecordPollCycle(_, _, _, _ int, _, _, _ time.Duration) {}
-func (NoopRelayCollector) RecordBatchSize(_ int)                                {}
-func (NoopRelayCollector) RecordReclaim(_ int64)                                {}
-func (NoopRelayCollector) RecordCleanup(_, _ int64)                             {}
+func (NoopRelayCollector) RecordPollCycle(_ PollCycleResult) {}
+func (NoopRelayCollector) RecordBatchSize(_ int)             {}
+func (NoopRelayCollector) RecordReclaim(_ int64)             {}
+func (NoopRelayCollector) RecordCleanup(_, _ int64)          {}

--- a/src/kernel/outbox/relay_metrics.go
+++ b/src/kernel/outbox/relay_metrics.go
@@ -1,0 +1,39 @@
+package outbox
+
+import "time"
+
+// RelayCollector records outbox relay operational metrics.
+// Implementations must be safe for concurrent use.
+//
+// The interface is intentionally in kernel/outbox (not runtime/) so that
+// adapters/postgres can depend on it without pulling in runtime/ packages.
+//
+// ref: Temporal client.Options{MetricsHandler} — inject-at-construction pattern
+// ref: Watermill components/metrics — publish_time_seconds, subscriber_messages_received_total
+// ref: Debezium JMX — MilliSecondsBehindSource, max.batch.size, DLQ count
+type RelayCollector interface {
+	// RecordPollCycle records a completed poll cycle with outcome counts and
+	// per-phase durations. Called once per pollOnce invocation after writeBack.
+	RecordPollCycle(published, retried, dead, skipped int, claimDur, publishDur, writeBackDur time.Duration)
+
+	// RecordBatchSize records the number of entries claimed in a poll cycle.
+	// Called even when the batch is empty (size=0) to capture idle cycles.
+	RecordBatchSize(size int)
+
+	// RecordReclaim records the number of stale entries reclaimed back to
+	// pending (or dead-lettered). Called once per reclaimStale invocation.
+	RecordReclaim(count int64)
+
+	// RecordCleanup records the number of entries removed during periodic
+	// cleanup, split by original status (published vs dead-lettered).
+	RecordCleanup(publishedDeleted, deadDeleted int64)
+}
+
+// NoopRelayCollector is a no-op implementation of RelayCollector.
+// Used when metrics collection is disabled (nil Metrics in RelayConfig).
+type NoopRelayCollector struct{}
+
+func (NoopRelayCollector) RecordPollCycle(_, _, _, _ int, _, _, _ time.Duration) {}
+func (NoopRelayCollector) RecordBatchSize(_ int)                                {}
+func (NoopRelayCollector) RecordReclaim(_ int64)                                {}
+func (NoopRelayCollector) RecordCleanup(_, _ int64)                             {}

--- a/src/kernel/outbox/relay_metrics_test.go
+++ b/src/kernel/outbox/relay_metrics_test.go
@@ -11,7 +11,10 @@ var _ RelayCollector = NoopRelayCollector{}
 func TestNoopRelayCollector_DoesNotPanic(t *testing.T) {
 	var c NoopRelayCollector
 	// All methods must be safe to call with any arguments.
-	c.RecordPollCycle(1, 2, 3, 4, time.Millisecond, time.Second, time.Microsecond)
+	c.RecordPollCycle(PollCycleResult{
+		Published: 1, Retried: 2, Dead: 3, Skipped: 4,
+		ClaimDur: time.Millisecond, PublishDur: time.Second, WriteBackDur: time.Microsecond,
+	})
 	c.RecordBatchSize(0)
 	c.RecordBatchSize(100)
 	c.RecordReclaim(0)
@@ -23,7 +26,7 @@ func TestNoopRelayCollector_DoesNotPanic(t *testing.T) {
 func TestNoopRelayCollector_ZeroValue_Safe(t *testing.T) {
 	// Zero value must be usable without initialization.
 	var c NoopRelayCollector
-	c.RecordPollCycle(0, 0, 0, 0, 0, 0, 0)
+	c.RecordPollCycle(PollCycleResult{})
 	c.RecordBatchSize(0)
 	c.RecordReclaim(0)
 	c.RecordCleanup(0, 0)

--- a/src/kernel/outbox/relay_metrics_test.go
+++ b/src/kernel/outbox/relay_metrics_test.go
@@ -1,0 +1,30 @@
+package outbox
+
+import (
+	"testing"
+	"time"
+)
+
+// Compile-time interface check.
+var _ RelayCollector = NoopRelayCollector{}
+
+func TestNoopRelayCollector_DoesNotPanic(t *testing.T) {
+	var c NoopRelayCollector
+	// All methods must be safe to call with any arguments.
+	c.RecordPollCycle(1, 2, 3, 4, time.Millisecond, time.Second, time.Microsecond)
+	c.RecordBatchSize(0)
+	c.RecordBatchSize(100)
+	c.RecordReclaim(0)
+	c.RecordReclaim(42)
+	c.RecordCleanup(0, 0)
+	c.RecordCleanup(100, 50)
+}
+
+func TestNoopRelayCollector_ZeroValue_Safe(t *testing.T) {
+	// Zero value must be usable without initialization.
+	var c NoopRelayCollector
+	c.RecordPollCycle(0, 0, 0, 0, 0, 0, 0)
+	c.RecordBatchSize(0)
+	c.RecordReclaim(0)
+	c.RecordCleanup(0, 0)
+}

--- a/src/templates/grafana-dashboard.json
+++ b/src/templates/grafana-dashboard.json
@@ -65,8 +65,8 @@
       }
     },
     {
-      "title": "Outbox Relay Lag (Messages Pending)",
-      "description": "Number of messages pending in the outbox relay. High values indicate the relay is falling behind.",
+      "title": "Outbox Relay Throughput",
+      "description": "Relay processing rates by outcome. Shows published, retried, and dead-lettered message rates.",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -81,14 +81,19 @@
       },
       "targets": [
         {
-          "expr": "sum(gocell_outbox_batch_size_sum{cell=\"${cell_id}\"}) - sum(gocell_outbox_relayed_total{cell=\"${cell_id}\"})",
-          "legendFormat": "throughput deficit",
+          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"published\"}[5m])",
+          "legendFormat": "published (msg/s)",
           "refId": "A"
         },
         {
-          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"published\"}[5m])",
-          "legendFormat": "relay rate (msg/s)",
+          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"retried\"}[5m])",
+          "legendFormat": "retried (msg/s)",
           "refId": "B"
+        },
+        {
+          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"dead\"}[5m])",
+          "legendFormat": "dead (msg/s)",
+          "refId": "C"
         }
       ],
       "fieldConfig": {
@@ -239,8 +244,8 @@
       }
     },
     {
-      "title": "Dead Letter Queue (DLQ) Count",
-      "description": "Messages routed to the dead letter queue. Non-zero values require investigation.",
+      "title": "Dead-Letter Event Volume",
+      "description": "Rate of messages entering the dead-letter state. Non-zero rates require investigation. Includes pollOnce failures only; reclaimStale dead transitions are tracked separately via gocell_outbox_reclaimed_total.",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -255,9 +260,14 @@
       },
       "targets": [
         {
-          "expr": "gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"dead\"}",
-          "legendFormat": "DLQ messages",
+          "expr": "increase(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"dead\"}[5m])",
+          "legendFormat": "dead events (5m)",
           "refId": "A"
+        },
+        {
+          "expr": "increase(gocell_outbox_reclaimed_total{cell=\"${cell_id}\"}[5m])",
+          "legendFormat": "reclaimed (5m, may include dead)",
+          "refId": "B"
         }
       ],
       "fieldConfig": {

--- a/src/templates/grafana-dashboard.json
+++ b/src/templates/grafana-dashboard.json
@@ -81,12 +81,12 @@
       },
       "targets": [
         {
-          "expr": "gocell_outbox_pending_messages{cell=\"${cell_id}\"}",
-          "legendFormat": "pending messages",
+          "expr": "sum(gocell_outbox_batch_size_count{cell=\"${cell_id}\"}) - sum(gocell_outbox_relayed_total{cell=\"${cell_id}\"})",
+          "legendFormat": "pending estimate",
           "refId": "A"
         },
         {
-          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\"}[5m])",
+          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"published\"}[5m])",
           "legendFormat": "relay rate (msg/s)",
           "refId": "B"
         }
@@ -255,7 +255,7 @@
       },
       "targets": [
         {
-          "expr": "gocell_dlq_messages_total{cell=\"${cell_id}\"}",
+          "expr": "gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"dead\"}",
           "legendFormat": "DLQ messages",
           "refId": "A"
         }

--- a/src/templates/grafana-dashboard.json
+++ b/src/templates/grafana-dashboard.json
@@ -81,8 +81,8 @@
       },
       "targets": [
         {
-          "expr": "sum(gocell_outbox_batch_size_count{cell=\"${cell_id}\"}) - sum(gocell_outbox_relayed_total{cell=\"${cell_id}\"})",
-          "legendFormat": "pending estimate",
+          "expr": "sum(gocell_outbox_batch_size_sum{cell=\"${cell_id}\"}) - sum(gocell_outbox_relayed_total{cell=\"${cell_id}\"})",
+          "legendFormat": "throughput deficit",
           "refId": "A"
         },
         {


### PR DESCRIPTION
## RL-METRICS-01: Outbox Relay Prometheus Metrics

### Summary
Add production observability for the PostgreSQL outbox relay with a kernel-level metrics interface, Prometheus implementation, panic-safe collector wrapper, and Grafana dashboard panels.

### Architecture
```
kernel/outbox/relay_metrics.go        → RelayCollector interface + PollCycleResult struct + NoopRelayCollector
adapters/prometheus/relay_collector.go → Prometheus *Vec implementation (5 metric families, all dynamic labels)
adapters/postgres/safe_relay_collector.go → Panic-safe wrapper (recover + log, follows safeObserve pattern)
adapters/postgres/outbox_relay.go      → Injection via RelayConfig.Metrics (nil→Noop→safe wrapper)
templates/grafana-dashboard.json       → Throughput + Dead-Letter Volume panels (rate/increase, no state metrics)
```

### Metrics Registered
| Metric | Type | Labels |
|--------|------|--------|
| `gocell_outbox_relayed_total` | CounterVec | cell, outcome |
| `gocell_outbox_poll_duration_seconds` | HistogramVec | cell, phase |
| `gocell_outbox_batch_size` | HistogramVec | cell |
| `gocell_outbox_reclaimed_total` | CounterVec | cell |
| `gocell_outbox_cleaned_total` | CounterVec | cell, status |

### Design Decisions
- **Flow metrics only** — no state gauges (pending/DLQ count). Dashboards use `rate()` and `increase()` for accurate visualization without lifecycle-point mismatch.
- **Dynamic labels only** — no ConstLabels, supports multi-cell single-registry.
- **PollCycleResult struct** — replaces 7-param method for readability and future extensibility.
- **Panic-safe wrapper** — `safeRelayCollector` at construction time, handles panicking + typed-nil collectors. Follows existing `runtime/http/middleware/safe_observe.go` pattern.
- **Conservative cleanup metrics** — partial cleanup on error is not recorded (under-count > over-count).

### Review Fixes Applied
- [x] P0: ConstLabels → dynamic labels
- [x] P1: Grafana pending panel → throughput rate panel
- [x] P1: Grafana DLQ counter → dead-letter event volume (increase + reclaimed)
- [x] P1: Panic isolation via safeRelayCollector
- [x] P1: RecordReclaim zero-guard at call site
- [x] P2: 7-param → PollCycleResult struct
- [x] P2: Import ordering (stdlib first)
- [x] P2: Remove unused Registry() method
- [x] Copilot: Fix registration comment (AlreadyRegistered → returns error)
- [x] Copilot: Fix flaky duration assertions (> 0 → >= 0)
- [x] Copilot: typed-nil protection via safe wrapper
- [x] SonarCloud: Cognitive complexity refactor (18→5)
- [x] SonarCloud: Empty function body comments ×4

### Test Coverage
- 10 tests in adapters/prometheus (interface, gather, all-zero, concurrent, custom buckets, duplicate register)
- 3 tests in adapters/postgres/safe_relay_collector (panic, typed-nil, delegation)
- 5 tests in adapters/postgres/outbox_relay (poll cycle, empty batch, reclaim, cleanup, nil-metrics)
- 2 tests in kernel/outbox (noop safety, zero-value)

ref: Watermill components/metrics
ref: Temporal client.Options{MetricsHandler}
ref: Debezium JMX monitoring