### PR TITLE
ci: remove feat/** from push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [develop, "feat/**"]
+    branches: [develop]
   pull_request:
     branches: [develop]
 


### PR DESCRIPTION
PR-based CI already covers feature branches via `pull_request` trigger on `develop`. The duplicate `push` trigger on `feat/**` wastes Actions minutes and causes confusing double CI runs.

### Changes
- Remove `feat/**` from `on.push.branches` in `.github/workflows/ci.yml`