### PR TITLE
fix(runtime): close runtime race gaps

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -46,7 +46,7 @@
 | PR | 任务合并 | 工时 | 文件 |
 |----|----------|------|------|
 | 运维健康体系 | OPS-3(pg/redis Health) + OPS-4(drain期) + ER-P2-03(Router health) + SEC-READYZ-01(/readyz隔离) + CFG-P2-01(watcher readyz) + READYZ-ROOT + R97-02(debounce) + R97-F1(symlink-pivot) + **BOOT-PANIC-01(bootstrap panic漏口: duplicate checker校验+registrar safe-call)** + **BOOT-OPTION-01(WithRouterOptions覆盖框架能力: 拒绝冲突option或固定优先级)** + **INFRA-EXPOSE-01(infra端点过度暴露: /metrics opt-in + health公开/内部分离或独立mux)** | 14h | `runtime/http/health/` + `runtime/bootstrap/` + `router/` + `config/` + `auth/middleware.go` **(+3 P1 from PR#96 复核)** |
-| runtime 竞态修复 | R1C2-F01(eventbus race) + R1C2-F03(WorkerGroup首失败) + **R97-R3-01(reload WaitGroup Add-after-Wait edge, 改用 channel+select 或 singleflight 消除理论竞态)** (PR#97 round3 review) | 5h | `runtime/eventbus/` + `runtime/worker/` + `runtime/bootstrap/` |
+| ~~runtime 竞态修复~~ | ~~R1C2-F01(eventbus 并发回归测试 + Close/Publish 锁序注释) + R1C2-F03(已验证: WorkerGroup cancel-on-error 已覆盖) + R97-R3-01(reload gate 替换 WaitGroup Add-after-Wait 窗口)~~ | ✅ done | `runtime/eventbus/` + `runtime/worker/` + `runtime/bootstrap/` |
 | RabbitMQ 连接正确性 | RMQ-RACE-01(WaitConnected竞态) + P3-DEFER-05(Health状态区分) | 4h | `adapters/rabbitmq/connection.go` |
 | kernel outbox 清理 | P4-TD-01(NoopOutboxWriter) + P3-DEFER-04(Receipt移包) | 4h | `kernel/outbox/` + `kernel/idempotency/` |
 | **L4 API 收敛** | **L4-API-01**: Validate 改名 ValidateNew（create-only 语义）+ AdvanceCommand 统一 timestamps/attempt 副作用 + CommandStateAdvancer 暴露完整迁移契约。adapter 不应需要绕过状态机语义 | 4h | `kernel/outbox/l4.go` **(P1, discovered via PR#93 六席位复核)** |

--- a/specs/217-runtime-race/plan.md
+++ b/specs/217-runtime-race/plan.md
@@ -79,11 +79,12 @@ Update `docs/backlog.md` so the runtime race row reflects what this branch actua
 ## Validation Plan
 
 1. `go test ./runtime/bootstrap ./runtime/eventbus ./runtime/worker`
-2. `go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap`
-3. `go build ./...`
+2. `cd src && go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap`
+3. `cd src && go build ./...`
 
 ## Risk Notes
 
 - The bootstrap change touches shutdown ordering; regressions would show up as hung shutdown, post-stop reloads, or dropped in-flight reloads.
+- Shutdown drain is bounded by `shutdownTimeout`; if a reload callback never leaves, `Run` returns the timeout error and later teardown steps are not guaranteed.
 - The eventbus test must avoid flaky timing and only assert invariants that the lock ordering guarantees.
 - The worker item should not be "fixed again" unless a new failing case is proven; otherwise we risk reopening already-correct code.

--- a/specs/217-runtime-race/plan.md
+++ b/specs/217-runtime-race/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Runtime Race Closure
+
+**Branch**: `217-runtime-race`  
+**Date**: 2026-04-13  
+**Spec**: `specs/217-runtime-race/spec.md`
+
+## Summary
+
+Close the Batch 6A runtime race backlog row by separating stale findings from the live defect:
+
+- `runtime/eventbus`: add proof, not a behavior rewrite.
+- `runtime/worker`: confirm the bug is already fixed in current code and preserve that guarantee.
+- `runtime/bootstrap`: replace the reload shutdown coordination with an explicit gate that prevents new callbacks from entering once shutdown begins.
+
+This is a TDD-first change set. Tests will land before implementation changes.
+
+## Root Cause
+
+### Eventbus
+
+The original concern came from `Close()` cancelling subscribers and closing channels while `Publish()` might still be sending. Current code already serializes those operations with `RWMutex`, so the remaining gap is documentation and regression coverage.
+
+### WorkerGroup
+
+The historical bug was "first worker failure does not cancel siblings". Current code already derives `groupCtx` and invokes `cancel()` on first error. The backlog entry drifted after the fix landed.
+
+### Bootstrap reload pipeline
+
+The reload callback uses a guard-then-`WaitGroup.Add(1)` pattern:
+
+1. callback reads the shutdown guard,
+2. shutdown starts and calls `Wait()`,
+3. callback still executes `Add(1)`.
+
+That sequence is a `WaitGroup` misuse window even if the callback exits immediately on the second guard check.
+
+## Planned Changes
+
+### 1. Add an internal reload gate
+
+Introduce an unexported helper in `src/runtime/bootstrap/` that provides:
+
+- `TryEnter() bool`: admit a reload callback only while shutdown has not started.
+- `Leave()`: mark callback completion.
+- `BeginShutdown() <-chan struct{}`: reject new callbacks and return a drained signal for in-flight work.
+
+Design constraints:
+
+- mutex-protected state,
+- no `WaitGroup` for the shutdown gate,
+- idempotent shutdown entry,
+- deterministic tests.
+
+### 2. Wire bootstrap to the new gate
+
+- Replace `assemblyStopped` and `reloadWG` with the new reload gate.
+- In the config watcher callback, call `TryEnter()` before any reload work and `Leave()` on exit.
+- In teardown, call `BeginShutdown()` and `select` on the drained channel or teardown context before `asm.Stop(c)`.
+
+### 3. Add regression coverage
+
+- `runtime/bootstrap`: unit tests for the gate itself and keep the existing integration tests green.
+- `runtime/eventbus`: concurrency regression test covering overlapping `Publish` and `Close`.
+- `runtime/worker`: keep the current cancellation test as proof that the backlog sub-item is already closed.
+
+### 4. Update backlog state
+
+Update `docs/backlog.md` so the runtime race row reflects what this branch actually closes.
+
+## Files Expected To Change
+
+- `src/runtime/bootstrap/bootstrap.go`
+- `src/runtime/bootstrap/bootstrap_test.go`
+- `src/runtime/bootstrap/reload_gate.go` (new)
+- `src/runtime/eventbus/eventbus.go`
+- `src/runtime/eventbus/eventbus_test.go`
+- `docs/backlog.md`
+
+## Validation Plan
+
+1. `go test ./runtime/bootstrap ./runtime/eventbus ./runtime/worker`
+2. `go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap`
+3. `go build ./...`
+
+## Risk Notes
+
+- The bootstrap change touches shutdown ordering; regressions would show up as hung shutdown, post-stop reloads, or dropped in-flight reloads.
+- The eventbus test must avoid flaky timing and only assert invariants that the lock ordering guarantees.
+- The worker item should not be "fixed again" unless a new failing case is proven; otherwise we risk reopening already-correct code.

--- a/specs/217-runtime-race/pr-plan.md
+++ b/specs/217-runtime-race/pr-plan.md
@@ -2,4 +2,4 @@
 
 | PR | Scope | Tasks | Depends | Verify | Branch |
 | --- | --- | --- | --- | --- | --- |
-| PR-1 | runtime bootstrap reload gate + eventbus regression closure | T001-T010 | none | `go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap && go build ./...` | `fix/217-runtime-race` |
+| PR-1 | runtime bootstrap reload gate + eventbus regression closure | T001-T010 | none | `cd src && go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap && go build ./...` | `fix/217-runtime-race` |

--- a/specs/217-runtime-race/pr-plan.md
+++ b/specs/217-runtime-race/pr-plan.md
@@ -1,0 +1,5 @@
+# PR Plan: Runtime Race Closure
+
+| PR | Scope | Tasks | Depends | Verify | Branch |
+| --- | --- | --- | --- | --- | --- |
+| PR-1 | runtime bootstrap reload gate + eventbus regression closure | T001-T010 | none | `go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap && go build ./...` | `fix/217-runtime-race` |

--- a/specs/217-runtime-race/research.md
+++ b/specs/217-runtime-race/research.md
@@ -1,0 +1,45 @@
+# Research: Runtime Race Closure
+
+## Upstream Comparison
+
+| Project | Files checked | Relevant pattern | Takeaway for GoCell |
+| --- | --- | --- | --- |
+| Uber fx | `app.go`, `internal/lifecycle/lifecycle.go`, `signal.go` | Gate new work before draining in-flight work; use explicit state instead of relying on `WaitGroup` alone | Bootstrap shutdown should use a first-class reload gate, then `select` on a drained signal before calling `asm.Stop` |
+| go-zero | `core/service/servicegroup.go`, `core/threading/routinegroup.go` | Parallel worker start/stop orchestration, but no stronger first-error policy than the caller provides | GoCell already goes further by propagating cancellation through context; the worker backlog item is already implemented in current code |
+| Viper | `viper.go` `WatchConfig()` | Directory-level watch, filtered event handling, explicit event-loop readiness | Keep the current directory watch approach; the missing piece is not file watching, but shutdown gating around reload callbacks |
+| Kratos | `config/config.go` watcher loop | Watcher lifecycle tied to explicit stop signals | Use an explicit stop/drain primitive instead of relying on a bare `WaitGroup` window |
+
+## Diagnosis Summary
+
+### `runtime/eventbus`
+
+- Current `Publish` holds `mu.RLock()` while sending to subscriber channels.
+- Current `Close` holds `mu.Lock()` before closing any subscriber channel.
+- That lock ordering prevents `send on closed channel` panics.
+- Remaining action: make the invariant explicit and keep it protected with a concurrency regression test.
+
+### `runtime/worker`
+
+- `WorkerGroup.Start` already derives a child context and calls `cancel()` on first error.
+- `TestWorkerGroup_CancelsSiblingsOnError` already verifies that the long-running sibling does not hang the group after a failing worker returns.
+- Remaining action: treat this backlog sub-item as already closed and reflect that in planning/backlog state.
+
+### `runtime/bootstrap`
+
+- The reload callback still uses `assemblyStopped.Load()` plus `reloadWG.Add(1)`.
+- Even with the double-check, shutdown can call `Wait()` while a callback races to `Add(1)` after observing the old state.
+- This is exactly the `Add-after-Wait` misuse window called out in the backlog.
+- Required fix: replace the implicit `WaitGroup` gate with an explicit reload gate that owns three things:
+  - admission of new reload callbacks,
+  - tracking of in-flight callbacks,
+  - a drained channel for shutdown to await with `select`.
+
+## Design Choice
+
+Use a small internal `reloadGate` with mutex-protected state and a drained channel.
+
+Why this is the best fit here:
+
+- It matches the backlog guidance to prefer `channel+select` over a theoretical `WaitGroup` misuse window.
+- It mirrors fx's `stop accepting -> drain active -> continue shutdown` lifecycle shape.
+- It keeps the fix local to `runtime/bootstrap`, without changing public APIs or introducing new dependencies.

--- a/specs/217-runtime-race/spec.md
+++ b/specs/217-runtime-race/spec.md
@@ -40,4 +40,10 @@ The remaining real implementation gap is `runtime/bootstrap`: config reload shut
 2. Reload drain logic is covered by deterministic unit tests, not just timing-dependent integration behavior.
 3. Concurrent `Publish` and `Close` on the in-memory event bus are covered by a regression test and do not panic under `go test -race`.
 4. The worker item is explicitly revalidated against current behavior so the backlog row does not claim an unfixed bug.
-5. `go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap` passes.
+5. `cd src && go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap` passes.
+
+## Shutdown Contract
+
+- Graceful shutdown closes the reload admission gate before teardown begins.
+- In-flight reload callbacks are allowed to finish until `shutdownTimeout` expires.
+- If reload drain does not finish before the shutdown context expires, `Run` returns the timeout error and later teardown steps are not guaranteed to run.

--- a/specs/217-runtime-race/spec.md
+++ b/specs/217-runtime-race/spec.md
@@ -1,0 +1,43 @@
+# Spec: Runtime Race Closure
+
+**Branch**: `217-runtime-race`  
+**Backlog Source**: `docs/backlog.md` Batch 6A `runtime 竞态修复`  
+**Date**: 2026-04-13
+
+## Problem
+
+The Batch 6A runtime race item currently mixes three concerns under one backlog row:
+
+1. `R1C2-F01` in `runtime/eventbus`.
+2. `R1C2-F03` in `runtime/worker`.
+3. `R97-R3-01` in `runtime/bootstrap`.
+
+Current code inspection shows that the backlog row is stale in two places:
+
+- `runtime/worker` already cancels sibling workers on first error and has a regression test.
+- `runtime/eventbus` already avoids `send on closed channel` via `RWMutex` ordering, but lacks an explicit regression test and lock-order comment to close the concern cleanly.
+
+The remaining real implementation gap is `runtime/bootstrap`: config reload shutdown still uses a `WaitGroup` pattern that allows a theoretical `Add-after-Wait` misuse window during shutdown.
+
+## Scope
+
+- `src/runtime/bootstrap/`: replace the reload shutdown coordination with an explicit gate that stops new reload callbacks before draining in-flight work.
+- `src/runtime/bootstrap/*_test.go`: add unit and integration coverage for the new reload gate semantics.
+- `src/runtime/eventbus/*`: add a concurrency regression test and document the publish/close lock invariant.
+- `src/runtime/worker/*`: revalidate the existing first-error cancellation behavior and keep the backlog item accurate.
+- `docs/backlog.md`: update the runtime race item to reflect the actual closure state.
+
+## Out Of Scope
+
+- `runtime/config` watcher redesign beyond the reload shutdown gate.
+- `runtime/worker` API redesign, restart semantics, or periodic worker follow-up items.
+- Retry policy changes such as eventbus jitter.
+- Any unrelated backlog items in Batch 6A or 6B.
+
+## Acceptance Criteria
+
+1. Shutdown starts by rejecting new config reload callbacks and only then waits for in-flight reload work to finish.
+2. Reload drain logic is covered by deterministic unit tests, not just timing-dependent integration behavior.
+3. Concurrent `Publish` and `Close` on the in-memory event bus are covered by a regression test and do not panic under `go test -race`.
+4. The worker item is explicitly revalidated against current behavior so the backlog row does not claim an unfixed bug.
+5. `go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap` passes.

--- a/specs/217-runtime-race/tasks.md
+++ b/specs/217-runtime-race/tasks.md
@@ -11,8 +11,8 @@
 - [x] T004 Implement the internal bootstrap reload gate using channel-plus-select drain signaling.
 - [x] T005 Replace the bootstrap `reloadWG` shutdown coordination with the new gate.
 - [x] T006 Add an explicit eventbus lock-order comment so the concurrency guarantee is maintained by future edits.
-- [x] T007 Run targeted package tests and race tests for `runtime/eventbus`, `runtime/worker`, and `runtime/bootstrap`.
-- [x] T008 Run `go build ./...`.
+- [x] T007 Run targeted package tests and race tests for `runtime/eventbus`, `runtime/worker`, and `runtime/bootstrap` from `src/`.
+- [x] T008 Run `go build ./...` from `src/`.
 - [x] T009 Update `docs/backlog.md` to reflect the closure state of the runtime race row.
 - [ ] T010 Create the PR and launch six-role review after verification passes.
 

--- a/specs/217-runtime-race/tasks.md
+++ b/specs/217-runtime-race/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Runtime Race Closure
+
+**Input**: `specs/217-runtime-race/spec.md`, `specs/217-runtime-race/research.md`, `specs/217-runtime-race/plan.md`  
+**TDD**: required
+
+## Task List
+
+- [x] T001 Add bootstrap reload-gate tests that define the required shutdown semantics before implementation.
+- [x] T002 Add an eventbus concurrent `Publish`/`Close` regression test that proves the lock invariant under `-race`.
+- [x] T003 Revalidate the existing worker cancellation behavior and keep it unchanged unless a new failing case is proven.
+- [x] T004 Implement the internal bootstrap reload gate using channel-plus-select drain signaling.
+- [x] T005 Replace the bootstrap `reloadWG` shutdown coordination with the new gate.
+- [x] T006 Add an explicit eventbus lock-order comment so the concurrency guarantee is maintained by future edits.
+- [x] T007 Run targeted package tests and race tests for `runtime/eventbus`, `runtime/worker`, and `runtime/bootstrap`.
+- [x] T008 Run `go build ./...`.
+- [x] T009 Update `docs/backlog.md` to reflect the closure state of the runtime race row.
+- [ ] T010 Create the PR and launch six-role review after verification passes.
+
+## Execution Order
+
+1. T001-T003
+2. T004-T006
+3. T007-T008
+4. T009-T010
+
+## Notes
+
+- `T003` is a validation task, not automatically a code change.
+- `T004` and `T005` are the only required behavior changes.
+- `T006` is intentionally small: the concurrency contract already exists in code and must be made obvious.

--- a/src/runtime/bootstrap/bootstrap.go
+++ b/src/runtime/bootstrap/bootstrap.go
@@ -331,6 +331,8 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		yamlPath, envPrefix := b.configPath, b.envPrefix
 		cfgWatcher.OnChange(func(evt config.WatchEvent) {
 			if !reloads.TryEnter() {
+				slog.Warn("bootstrap: config reload rejected during shutdown",
+					slog.String("path", evt.Path))
 				return
 			}
 			defer reloads.Leave()
@@ -546,6 +548,7 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 
 	// Step 10: Orderly shutdown.
 	slog.Info("bootstrap: initiating graceful shutdown")
+	reloads.BeginShutdown()
 	shutCtx, shutCancel := context.WithTimeout(context.Background(), b.shutdownTimeout)
 	defer shutCancel()
 

--- a/src/runtime/bootstrap/bootstrap.go
+++ b/src/runtime/bootstrap/bootstrap.go
@@ -17,8 +17,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/assembly"
@@ -309,21 +307,21 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	if err := asm.StartWithConfig(ctx, cfgMap); err != nil {
 		return rollback(fmt.Errorf("bootstrap: assembly start: %w", err))
 	}
-	// assemblyStopped + reloadWG together ensure clean shutdown of the reload
-	// pipeline. The guard prevents new callbacks from entering after shutdown
-	// begins; the WaitGroup drains any in-flight callback that passed the
-	// guard before assemblyStopped was set. Teardown sequence:
-	//   1. assemblyStopped.Store(true) — stop new callbacks
-	//   2. reloadWG.Wait()             — drain in-flight callbacks
-	//   3. asm.Stop(c)                 — safe: no concurrent OnConfigReload
+	// reloads ensures shutdown follows a strict gate-before-drain order:
+	//   1. reject new callbacks,
+	//   2. wait for in-flight callbacks to leave,
+	//   3. stop the assembly.
 	//
 	// ref: net/http Server.Shutdown — stop accepting + drain active + close.
-	var assemblyStopped atomic.Bool
-	var reloadWG sync.WaitGroup
+	reloads := newReloadGate()
 
 	teardowns = append(teardowns, func(c context.Context) error {
-		assemblyStopped.Store(true)
-		reloadWG.Wait()
+		drained := reloads.BeginShutdown()
+		select {
+		case <-drained:
+		case <-c.Done():
+			return c.Err()
+		}
 		return asm.Stop(c)
 	})
 
@@ -332,16 +330,10 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	if cfgWatcher != nil {
 		yamlPath, envPrefix := b.configPath, b.envPrefix
 		cfgWatcher.OnChange(func(evt config.WatchEvent) {
-			if assemblyStopped.Load() {
+			if !reloads.TryEnter() {
 				return
 			}
-			reloadWG.Add(1)
-			defer reloadWG.Done()
-			// Double-check after Add: if shutdown raced between the Load above
-			// and Add, we must not proceed.
-			if assemblyStopped.Load() {
-				return
-			}
+			defer reloads.Leave()
 
 			rc, ok := cfg.(config.Reloader)
 			if !ok {

--- a/src/runtime/bootstrap/bootstrap_test.go
+++ b/src/runtime/bootstrap/bootstrap_test.go
@@ -572,8 +572,8 @@ type plainConfig struct {
 	data map[string]any
 }
 
-func (c *plainConfig) Get(key string) any        { return c.data[key] }
-func (c *plainConfig) Scan(_ interface{}) error   { return nil }
+func (c *plainConfig) Get(key string) any       { return c.data[key] }
+func (c *plainConfig) Scan(_ interface{}) error { return nil }
 func (c *plainConfig) Keys() []string {
 	keys := make([]string, 0, len(c.data))
 	for k := range c.data {
@@ -604,9 +604,9 @@ func TestSnapshotConfig_Fallback(t *testing.T) {
 // reloaderCell is a Cell that implements cell.ConfigReloader for testing.
 type reloaderCell struct {
 	*cell.BaseCell
-	mu        sync.Mutex
-	events    []cell.ConfigChangeEvent
-	callOrder *[]string // shared slice to track call order across cells
+	mu         sync.Mutex
+	events     []cell.ConfigChangeEvent
+	callOrder  *[]string // shared slice to track call order across cells
 	err        error     // configurable error to return
 	doPanic    bool      // if true, panic instead of returning
 	panicCount atomic.Int32
@@ -685,7 +685,7 @@ func (w *blockingStopWorker) Stop(_ context.Context) error {
 	}
 	<-w.releaseStop
 	return nil
-	}
+}
 
 func newSlowReloaderCell(id string, delay time.Duration) *slowReloaderCell {
 	return &slowReloaderCell{

--- a/src/runtime/bootstrap/bootstrap_test.go
+++ b/src/runtime/bootstrap/bootstrap_test.go
@@ -660,6 +660,33 @@ type slowReloaderCell struct {
 	completed atomic.Int32
 }
 
+type blockingStopWorker struct {
+	stopStarted chan struct{}
+	releaseStop chan struct{}
+}
+
+func newBlockingStopWorker() *blockingStopWorker {
+	return &blockingStopWorker{
+		stopStarted: make(chan struct{}),
+		releaseStop: make(chan struct{}),
+	}
+}
+
+func (w *blockingStopWorker) Start(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (w *blockingStopWorker) Stop(_ context.Context) error {
+	select {
+	case <-w.stopStarted:
+	default:
+		close(w.stopStarted)
+	}
+	<-w.releaseStop
+	return nil
+	}
+
 func newSlowReloaderCell(id string, delay time.Duration) *slowReloaderCell {
 	return &slowReloaderCell{
 		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore}),
@@ -1225,6 +1252,71 @@ func TestBootstrap_ShutdownNoPostStopReload(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	assert.Equal(t, countBefore, rc.eventCount(),
 		"no config reload callback should fire after shutdown")
+}
+
+// TestBootstrap_ShutdownRejectsReloadDuringDrain verifies that shutdown starts
+// rejecting new reload callbacks before earlier teardown steps (such as worker
+// shutdown) have finished.
+func TestBootstrap_ShutdownRejectsReloadDuringDrain(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val1\n"), 0o644))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	asm := assembly.New(assembly.Config{ID: "test-shutdown-drain-reject"})
+	rc := newReloaderCell("shutdown-drain-cell")
+	require.NoError(t, asm.Register(rc))
+
+	blocker := newBlockingStopWorker()
+	b := New(
+		WithAssembly(asm),
+		WithConfig(cfgFile, ""),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithWorkers(blocker),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
+		if e != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-blocker.stopStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("shutdown did not reach worker stop")
+	}
+
+	countBefore := rc.eventCount()
+	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val_during_shutdown\n"), 0o644))
+
+	assert.Never(t, func() bool {
+		return rc.eventCount() > countBefore
+	}, 500*time.Millisecond, 20*time.Millisecond,
+		"shutdown must reject config reloads once graceful shutdown begins")
+
+	close(blocker.releaseStop)
+
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown timeout")
+	}
 }
 
 // TestBootstrap_ConfigReload_GenerationTracking verifies that the Generation

--- a/src/runtime/bootstrap/reload_gate.go
+++ b/src/runtime/bootstrap/reload_gate.go
@@ -1,6 +1,9 @@
 package bootstrap
 
-import "sync"
+import (
+	"log/slog"
+	"sync"
+)
 
 // reloadGate prevents new config reload callbacks from entering once shutdown
 // begins and exposes a drained signal for in-flight callbacks.
@@ -33,6 +36,7 @@ func (g *reloadGate) Leave() {
 	defer g.mu.Unlock()
 
 	if g.inFlight == 0 {
+		slog.Debug("reloadGate: Leave called with no in-flight reloads (unbalanced TryEnter/Leave)")
 		return
 	}
 

--- a/src/runtime/bootstrap/reload_gate.go
+++ b/src/runtime/bootstrap/reload_gate.go
@@ -1,0 +1,64 @@
+package bootstrap
+
+import "sync"
+
+// reloadGate prevents new config reload callbacks from entering once shutdown
+// begins and exposes a drained signal for in-flight callbacks.
+type reloadGate struct {
+	mu            sync.Mutex
+	shuttingDown  bool
+	inFlight      int
+	drained       chan struct{}
+	drainedClosed bool
+}
+
+func newReloadGate() *reloadGate {
+	return &reloadGate{drained: make(chan struct{})}
+}
+
+func (g *reloadGate) TryEnter() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.shuttingDown {
+		return false
+	}
+
+	g.inFlight++
+	return true
+}
+
+func (g *reloadGate) Leave() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.inFlight == 0 {
+		return
+	}
+
+	g.inFlight--
+	if g.shuttingDown && g.inFlight == 0 {
+		g.closeDrainedLocked()
+	}
+}
+
+func (g *reloadGate) BeginShutdown() <-chan struct{} {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.shuttingDown = true
+	if g.inFlight == 0 {
+		g.closeDrainedLocked()
+	}
+
+	return g.drained
+}
+
+func (g *reloadGate) closeDrainedLocked() {
+	if g.drainedClosed {
+		return
+	}
+
+	close(g.drained)
+	g.drainedClosed = true
+}

--- a/src/runtime/bootstrap/reload_gate_test.go
+++ b/src/runtime/bootstrap/reload_gate_test.go
@@ -1,0 +1,56 @@
+package bootstrap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReloadGate_BeginShutdownDrainsInflight(t *testing.T) {
+	gate := newReloadGate()
+	require.True(t, gate.TryEnter())
+
+	drained := gate.BeginShutdown()
+
+	select {
+	case <-drained:
+		t.Fatal("drained channel closed before the in-flight reload left")
+	default:
+	}
+
+	assert.False(t, gate.TryEnter(), "shutdown must reject new reload callbacks")
+
+	gate.Leave()
+
+	select {
+	case <-drained:
+	case <-time.After(time.Second):
+		t.Fatal("drained channel did not close after the in-flight reload completed")
+	}
+}
+
+func TestReloadGate_BeginShutdownWithoutInflightIsImmediate(t *testing.T) {
+	gate := newReloadGate()
+
+	select {
+	case <-gate.BeginShutdown():
+	case <-time.After(time.Second):
+		t.Fatal("shutdown without in-flight reloads should drain immediately")
+	}
+}
+
+func TestReloadGate_BeginShutdownIsIdempotent(t *testing.T) {
+	gate := newReloadGate()
+	first := gate.BeginShutdown()
+	second := gate.BeginShutdown()
+
+	assert.True(t, first == second)
+	assert.False(t, gate.TryEnter())
+	select {
+	case <-first:
+	case <-time.After(time.Second):
+		t.Fatal("drained channel should remain closed after repeated shutdown calls")
+	}
+}

--- a/src/runtime/eventbus/eventbus.go
+++ b/src/runtime/eventbus/eventbus.go
@@ -209,6 +209,9 @@ func (b *InMemoryEventBus) Subscribe(ctx context.Context, topic string, handler 
 }
 
 // Close terminates all subscriber goroutines and prevents new publishes.
+// Safety: Close holds mu.Lock() for the full channel-closing loop, while
+// Publish holds mu.RLock() while sending to subscriber channels. That lock
+// ordering prevents Publish from sending to a closed subscriber channel.
 func (b *InMemoryEventBus) Close() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -211,13 +211,14 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 	go func() {
 		done <- bus.Subscribe(ctx, "race.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		})
+		}, "")
 	}()
 
 	require.Eventually(t, func() bool {
 		bus.mu.RLock()
 		defer bus.mu.RUnlock()
-		return len(bus.subs["race.topic"]) == 1
+		gs := bus.groupSubs["race.topic"][""]
+		return gs != nil && len(gs.subs) == 1
 	}, time.Second, 10*time.Millisecond)
 
 	var stop atomic.Bool
@@ -238,6 +239,9 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 			}()
 
 			for !stop.Load() {
+				// CAS ensures exactly one 0→1 transition; the Eventually check
+				// below only needs proof that at least one publisher is actively
+				// calling Publish before we race Close against them.
 				publishStarted.CompareAndSwap(0, 1)
 				_ = bus.Publish(context.Background(), "race.topic", []byte("payload"))
 			}

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -221,6 +221,7 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	var stop atomic.Bool
+	var publishStarted atomic.Int32
 	panicCh := make(chan any, 1)
 	var publishers sync.WaitGroup
 	for i := 0; i < 4; i++ {
@@ -237,12 +238,15 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 			}()
 
 			for !stop.Load() {
+				publishStarted.CompareAndSwap(0, 1)
 				_ = bus.Publish(context.Background(), "race.topic", []byte("payload"))
 			}
 		}(i)
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return publishStarted.Load() == 1
+	}, time.Second, 10*time.Millisecond)
 	require.NoError(t, bus.Close())
 	stop.Store(true)
 	publishers.Wait()

--- a/src/runtime/eventbus/eventbus_test.go
+++ b/src/runtime/eventbus/eventbus_test.go
@@ -3,6 +3,7 @@ package eventbus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -200,6 +201,59 @@ func TestClose_Idempotent(t *testing.T) {
 	bus := New()
 	assert.NoError(t, bus.Close())
 	assert.NoError(t, bus.Close())
+}
+
+func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
+	bus := New(WithBufferSize(32))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, "race.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		bus.mu.RLock()
+		defer bus.mu.RUnlock()
+		return len(bus.subs["race.topic"]) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	var stop atomic.Bool
+	panicCh := make(chan any, 1)
+	var publishers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		publishers.Add(1)
+		go func(workerID int) {
+			defer publishers.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					select {
+					case panicCh <- fmt.Sprintf("publisher %d panicked: %v", workerID, r):
+					default:
+					}
+				}
+			}()
+
+			for !stop.Load() {
+				_ = bus.Publish(context.Background(), "race.topic", []byte("payload"))
+			}
+		}(i)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, bus.Close())
+	stop.Store(true)
+	publishers.Wait()
+	cancel()
+	<-done
+
+	select {
+	case panicValue := <-panicCh:
+		t.Fatalf("publish panicked during concurrent close: %v", panicValue)
+	default:
+	}
 }
 
 func TestSubscribe_ClosedBus(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace bootstrap config reload shutdown coordination with an explicit reload gate
- add eventbus concurrent Publish/Close regression coverage and document the lock invariant
- add spec/research/plan/tasks artifacts for the runtime race backlog item and close the backlog row

## Validation
- go test ./runtime/bootstrap ./runtime/eventbus ./runtime/worker
- go test -race ./runtime/eventbus ./runtime/worker ./runtime/bootstrap
- go build ./...
- go test ./...

## Notes
- R1C2-F03 is already implemented in current WorkerGroup and was revalidated rather than changed
- ref: uber-go/fx app.go
- ref: zeromicro/go-zero core/service/servicegroup.go
- ref: spf13/viper viper.go