### PR TITLE
🛡️ Sentinel: [security improvement] Add Content-Security-Policy header

### DIFF
--- a/src/runtime/http/middleware/security_headers.go
+++ b/src/runtime/http/middleware/security_headers.go
@@ -6,11 +6,13 @@ import "net/http"
 //   - X-Content-Type-Options: nosniff
 //   - X-Frame-Options: DENY
 //   - Strict-Transport-Security: max-age=31536000
+//   - Content-Security-Policy: default-src 'self'
 func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/src/runtime/http/middleware/security_headers_test.go
+++ b/src/runtime/http/middleware/security_headers_test.go
@@ -24,6 +24,7 @@ func TestSecurityHeaders(t *testing.T) {
 		{"X-Content-Type-Options", "nosniff"},
 		{"X-Frame-Options", "DENY"},
 		{"Strict-Transport-Security", "max-age=31536000"},
+		{"Content-Security-Policy", "default-src 'self'"},
 	}
 
 	for _, tt := range tests {

--- a/src/runtime/http/router/router_contract_test.go
+++ b/src/runtime/http/router/router_contract_test.go
@@ -116,6 +116,8 @@ func TestMount_MiddlewareInheritance(t *testing.T) {
 		"SecurityHeaders middleware must run for mounted handlers")
 	assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"),
 		"SecurityHeaders middleware must run for mounted handlers")
+	assert.Equal(t, "default-src 'self'", rec.Header().Get("Content-Security-Policy"),
+		"SecurityHeaders middleware must run for mounted handlers")
 }
 
 func TestWith_ScopedMiddleware(t *testing.T) {

--- a/src/runtime/http/router/router_test.go
+++ b/src/runtime/http/router/router_test.go
@@ -277,6 +277,7 @@ func TestDefaultMiddlewareApplied(t *testing.T) {
 	// Security headers should be set by default middleware.
 	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
 	assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "default-src 'self'", rec.Header().Get("Content-Security-Policy"))
 	// RequestID middleware should set X-Request-Id.
 	assert.NotEmpty(t, rec.Header().Get("X-Request-Id"))
 }


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: Missing Content-Security-Policy header, leaving the application potentially more vulnerable to XSS.
🎯 Impact: Reduces the risk of cross-site scripting (XSS) and data injection attacks by restricting the sources from which resources can be loaded.
🔧 Fix: Added `Content-Security-Policy: default-src 'self'` to the `SecurityHeaders` middleware. This enforces a secure-by-default posture.
✅ Verification: Run `cd src && go test ./runtime/http/...`. All tests pass, including the new assertions for the CSP header.

---
*PR created automatically by Jules for task [17252274612838483964](https://jules.google.com/task/17252274612838483964) started by @ghbvf*