### PR TITLE
fix(access-core): harden txRunner XOR + config event subscription + session TOCTOU

### DIFF
--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/cells/access-core/slices/authorizationdecide"
+	"github.com/ghbvf/gocell/cells/access-core/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/access-core/slices/identitymanage"
 	"github.com/ghbvf/gocell/cells/access-core/slices/rbaccheck"
 	"github.com/ghbvf/gocell/cells/access-core/slices/sessionlogin"
@@ -19,6 +20,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/slices/sessionvalidate"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -73,6 +75,11 @@ func WithOutboxWriter(w outbox.Writer) Option {
 	return func(c *AccessCore) { c.outboxWriter = w }
 }
 
+// WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
+func WithTxManager(tx persistence.TxRunner) Option {
+	return func(c *AccessCore) { c.txRunner = tx }
+}
+
 // WithInMemoryDefaults configures in-memory repositories for development
 // and testing. Not suitable for production use.
 func WithInMemoryDefaults() Option {
@@ -91,6 +98,7 @@ type AccessCore struct {
 	roleRepo     ports.RoleRepository
 	publisher    outbox.Publisher
 	outboxWriter outbox.Writer
+	txRunner     persistence.TxRunner
 	logger       *slog.Logger
 	jwtIssuer    *auth.JWTIssuer
 	jwtVerifier  *auth.JWTVerifier
@@ -102,9 +110,10 @@ type AccessCore struct {
 	logoutHandler   *sessionlogout.Handler
 
 	// Services exposed for composition (e.g. TokenVerifier, Authorizer).
-	validateSvc *sessionvalidate.Service
-	authzSvc    *authorizationdecide.Service
-	rbacHandler *rbaccheck.Handler
+	validateSvc      *sessionvalidate.Service
+	authzSvc         *authorizationdecide.Service
+	rbacHandler      *rbaccheck.Handler
+	configReceiveSvc *configreceive.Service
 }
 
 // NewAccessCore creates a new AccessCore Cell.
@@ -142,10 +151,11 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 		return err
 	}
 
-	// Fail-fast: L2+ Cell requires outboxWriter for transactional event publishing.
-	if c.ConsistencyLevel() >= cell.L2 && c.outboxWriter == nil {
-		slog.Warn("access-core: outboxWriter not injected, L2 consistency not guaranteed")
-		return errcode.New(errcode.ErrCellMissingOutbox, "access-core (L2) requires outboxWriter injection")
+	// Fail-fast: outboxWriter and txRunner must be both present or both absent (XOR constraint).
+	// Both present = durable mode (L2 atomicity). Both absent = demo/in-memory mode.
+	if (c.outboxWriter == nil) != (c.txRunner == nil) {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"access-core durable mode requires both outboxWriter and txRunner")
 	}
 
 	// Fail-fast: RS256 key pair required.
@@ -159,6 +169,9 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if c.outboxWriter != nil {
 		identityOpts = append(identityOpts, identitymanage.WithOutboxWriter(c.outboxWriter))
 	}
+	if c.txRunner != nil {
+		identityOpts = append(identityOpts, identitymanage.WithTxManager(c.txRunner))
+	}
 	identitySvc := identitymanage.NewService(c.userRepo, c.sessionRepo, c.publisher, c.logger, identityOpts...)
 	c.identityHandler = identitymanage.NewHandler(identitySvc)
 	c.AddSlice(cell.NewBaseSlice("identity-manage", "access-core", cell.L1))
@@ -167,6 +180,9 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	var loginOpts []sessionlogin.Option
 	if c.outboxWriter != nil {
 		loginOpts = append(loginOpts, sessionlogin.WithOutboxWriter(c.outboxWriter))
+	}
+	if c.txRunner != nil {
+		loginOpts = append(loginOpts, sessionlogin.WithTxManager(c.txRunner))
 	}
 	loginSvc := sessionlogin.NewService(c.userRepo, c.sessionRepo, c.roleRepo, c.publisher, c.jwtIssuer, c.logger, loginOpts...)
 	c.loginHandler = sessionlogin.NewHandler(loginSvc)
@@ -181,6 +197,9 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	var logoutOpts []sessionlogout.Option
 	if c.outboxWriter != nil {
 		logoutOpts = append(logoutOpts, sessionlogout.WithOutboxWriter(c.outboxWriter))
+	}
+	if c.txRunner != nil {
+		logoutOpts = append(logoutOpts, sessionlogout.WithTxManager(c.txRunner))
 	}
 	logoutSvc := sessionlogout.NewService(c.sessionRepo, c.publisher, c.logger, logoutOpts...)
 	c.logoutHandler = sessionlogout.NewHandler(logoutSvc)
@@ -198,6 +217,10 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	rbacSvc := rbaccheck.NewService(c.roleRepo, c.logger)
 	c.rbacHandler = rbaccheck.NewHandler(rbacSvc)
 	c.AddSlice(cell.NewBaseSlice("rbac-check", "access-core", cell.L0))
+
+	// config-receive: subscribes to config.changed events from config-core
+	c.configReceiveSvc = configreceive.NewService(c.logger)
+	c.AddSlice(cell.NewBaseSlice("config-receive", "access-core", cell.L3))
 
 	return nil
 }
@@ -220,8 +243,10 @@ func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
 	})
 }
 
-// RegisterSubscriptions is a no-op for access-core.
-// Future: subscribe to cross-cell events if needed.
-func (c *AccessCore) RegisterSubscriptions(_ cell.EventRouter) error {
+// RegisterSubscriptions declares event subscriptions for access-core.
+// The Router manages goroutine lifecycle and setup-error detection.
+func (c *AccessCore) RegisterSubscriptions(r cell.EventRouter) error {
+	handler := outbox.WrapLegacyHandler(c.configReceiveSvc.HandleEvent)
+	r.AddHandler(configreceive.TopicConfigChanged, handler, "access-core")
 	return nil
 }

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -11,12 +11,23 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// noopTxRunner is a test double that executes fn directly without a real transaction.
+type noopTxRunner struct{}
+
+func (noopTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) error {
+	return fn(context.Background())
+}
+
+var _ persistence.TxRunner = noopTxRunner{}
 
 var (
 	testKeySet, testPrivKey, _ = auth.MustNewTestKeySet()
@@ -49,6 +60,7 @@ func newTestCell() *AccessCore {
 		WithJWTIssuer(testIssuer),
 		WithJWTVerifier(testVerifier),
 		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
 	)
 }
 
@@ -60,6 +72,7 @@ func TestAccessCore_Init_RequiresJWTIssuer(t *testing.T) {
 		WithPublisher(eventbus.New()),
 		WithJWTVerifier(testVerifier), // issuer missing
 		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
 	require.Error(t, err)
@@ -74,10 +87,60 @@ func TestAccessCore_Init_RequiresJWTVerifier(t *testing.T) {
 		WithPublisher(eventbus.New()),
 		WithJWTIssuer(testIssuer), // verifier missing
 		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "WithJWTVerifier")
+}
+
+func TestInit_TxRunnerXOR_OutboxWithoutTx(t *testing.T) {
+	// outboxWriter present but txRunner missing → XOR mismatch → error
+	c := NewAccessCore(
+		WithUserRepository(mem.NewUserRepository()),
+		WithSessionRepository(mem.NewSessionRepository()),
+		WithRoleRepository(mem.NewRoleRepository()),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		// txRunner intentionally omitted
+	)
+	deps := cell.Dependencies{Config: make(map[string]any)}
+	err := c.Init(context.Background(), deps)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
+	assert.Contains(t, err.Error(), "txRunner")
+}
+
+func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
+	// txRunner present but outboxWriter missing → XOR mismatch → error
+	c := NewAccessCore(
+		WithUserRepository(mem.NewUserRepository()),
+		WithSessionRepository(mem.NewSessionRepository()),
+		WithRoleRepository(mem.NewRoleRepository()),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithTxManager(noopTxRunner{}),
+		// outboxWriter intentionally omitted
+	)
+	deps := cell.Dependencies{Config: make(map[string]any)}
+	err := c.Init(context.Background(), deps)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
+	assert.Contains(t, err.Error(), "txRunner")
+}
+
+func TestInit_TxRunnerXOR_BothPresent(t *testing.T) {
+	// Both outboxWriter and txRunner present → should succeed
+	c := newTestCell() // newTestCell includes both
+	deps := cell.Dependencies{Config: make(map[string]any)}
+	require.NoError(t, c.Init(context.Background(), deps))
 }
 
 func TestAccessCore_Lifecycle(t *testing.T) {
@@ -89,7 +152,7 @@ func TestAccessCore_Lifecycle(t *testing.T) {
 
 	// Init
 	require.NoError(t, c.Init(ctx, deps))
-	assert.Equal(t, 7, len(c.OwnedSlices()), "should have 7 slices")
+	assert.Equal(t, 8, len(c.OwnedSlices()), "should have 8 slices")
 
 	// Start
 	require.NoError(t, c.Start(ctx))

--- a/cells/access-core/internal/domain/session.go
+++ b/cells/access-core/internal/domain/session.go
@@ -17,6 +17,7 @@ type Session struct {
 	ExpiresAt            time.Time
 	RevokedAt            *time.Time // nil = not revoked
 	CreatedAt            time.Time
+	Version              int64      // optimistic lock version; incremented on each update
 }
 
 // NewSession creates a new session for the given user.
@@ -38,6 +39,7 @@ func NewSession(userID, accessToken, refreshToken string, expiresAt time.Time) (
 		RefreshToken: refreshToken,
 		ExpiresAt:    expiresAt,
 		CreatedAt:    time.Now(),
+		Version:      1,
 	}, nil
 }
 

--- a/cells/access-core/internal/mem/repo_test.go
+++ b/cells/access-core/internal/mem/repo_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestUserRepository_ConcurrentCreateAndGet verifies that concurrent
@@ -141,4 +143,156 @@ func TestRoleRepository_ConcurrentAssignAndGet(t *testing.T) {
 
 	wg.Wait()
 	assert.NotNil(t, repo) // ensure repo survived concurrent access
+}
+
+// TestSessionRepository_Update_VersionConflict verifies that updating a session
+// with a stale version returns ErrSessionConflict.
+func TestSessionRepository_Update_VersionConflict(t *testing.T) {
+	repo := NewSessionRepository()
+	ctx := context.Background()
+
+	sess := &domain.Session{
+		ID:           "sess-vc",
+		UserID:       "usr-1",
+		AccessToken:  "at-1",
+		RefreshToken: "rt-1",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		CreatedAt:    time.Now(),
+		Version:      1,
+	}
+	require.NoError(t, repo.Create(ctx, sess))
+
+	// Read twice — simulating two concurrent goroutines.
+	clone1, err := repo.GetByRefreshToken(ctx, "rt-1")
+	require.NoError(t, err)
+	clone2, err := repo.GetByRefreshToken(ctx, "rt-1")
+	require.NoError(t, err)
+
+	// First update succeeds.
+	clone1.RefreshToken = "rt-2"
+	clone1.PreviousRefreshToken = "rt-1"
+	require.NoError(t, repo.Update(ctx, clone1))
+
+	// Second update with stale version should fail.
+	clone2.RefreshToken = "rt-3"
+	clone2.PreviousRefreshToken = "rt-1"
+	err = repo.Update(ctx, clone2)
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrSessionConflict, ecErr.Code)
+}
+
+// TestSessionRepository_Update_VersionIncrement verifies that version is
+// incremented on each successful update.
+func TestSessionRepository_Update_VersionIncrement(t *testing.T) {
+	repo := NewSessionRepository()
+	ctx := context.Background()
+
+	sess := &domain.Session{
+		ID:           "sess-vi",
+		UserID:       "usr-1",
+		AccessToken:  "at-1",
+		RefreshToken: "rt-1",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		CreatedAt:    time.Now(),
+		Version:      1,
+	}
+	require.NoError(t, repo.Create(ctx, sess))
+
+	for i := 1; i <= 3; i++ {
+		s, err := repo.GetByID(ctx, "sess-vi")
+		require.NoError(t, err)
+		assert.Equal(t, int64(i), s.Version)
+
+		s.RefreshToken = fmt.Sprintf("rt-%d", i+1)
+		s.PreviousRefreshToken = fmt.Sprintf("rt-%d", i)
+		require.NoError(t, repo.Update(ctx, s))
+	}
+
+	final, err := repo.GetByID(ctx, "sess-vi")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), final.Version)
+}
+
+// TestSessionRepository_ConcurrentRefreshUpdate verifies that concurrent
+// updates to the same session result in exactly one success and the rest
+// returning ErrSessionConflict. Run with -race.
+func TestSessionRepository_ConcurrentRefreshUpdate(t *testing.T) {
+	repo := NewSessionRepository()
+	ctx := context.Background()
+
+	sess := &domain.Session{
+		ID:           "sess-cru",
+		UserID:       "usr-1",
+		AccessToken:  "at-1",
+		RefreshToken: "rt-1",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		CreatedAt:    time.Now(),
+		Version:      1,
+	}
+	require.NoError(t, repo.Create(ctx, sess))
+
+	const goroutines = 10
+	var (
+		wg        sync.WaitGroup
+		successes int64
+		conflicts int64
+		mu        sync.Mutex
+	)
+
+	// All goroutines read the same version, then try to update.
+	clones := make([]*domain.Session, goroutines)
+	for i := range goroutines {
+		clone, err := repo.GetByRefreshToken(ctx, "rt-1")
+		require.NoError(t, err)
+		clone.RefreshToken = fmt.Sprintf("rt-new-%d", i)
+		clone.PreviousRefreshToken = "rt-1"
+		clones[i] = clone
+	}
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			err := repo.Update(ctx, clones[idx])
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				successes++
+			} else {
+				var ecErr *errcode.Error
+				if assert.ErrorAs(t, err, &ecErr) {
+					assert.Equal(t, errcode.ErrSessionConflict, ecErr.Code)
+				}
+				conflicts++
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	assert.Equal(t, int64(1), successes, "exactly one goroutine should succeed")
+	assert.Equal(t, int64(goroutines-1), conflicts, "all others should get version conflict")
+}
+
+// TestSessionRepository_Create_SetsVersion verifies that Create initializes
+// Version to 1 even if the caller passes 0.
+func TestSessionRepository_Create_SetsVersion(t *testing.T) {
+	repo := NewSessionRepository()
+	ctx := context.Background()
+
+	sess := &domain.Session{
+		ID:           "sess-cv",
+		UserID:       "usr-1",
+		RefreshToken: "rt-1",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		CreatedAt:    time.Now(),
+		// Version intentionally omitted (zero value)
+	}
+	require.NoError(t, repo.Create(ctx, sess))
+
+	stored, err := repo.GetByID(ctx, "sess-cv")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stored.Version, "Version should be initialized to 1")
 }

--- a/cells/access-core/internal/mem/session_repo.go
+++ b/cells/access-core/internal/mem/session_repo.go
@@ -2,6 +2,7 @@ package mem
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
@@ -33,6 +34,9 @@ func (r *SessionRepository) Create(_ context.Context, session *domain.Session) e
 	defer r.mu.Unlock()
 
 	clone := *session
+	if clone.Version == 0 {
+		clone.Version = 1
+	}
 	r.byID[session.ID] = &clone
 	r.byRefresh[session.RefreshToken] = &clone
 	if session.PreviousRefreshToken != "" {
@@ -86,6 +90,12 @@ func (r *SessionRepository) Update(_ context.Context, session *domain.Session) e
 		return errcode.New(errcode.ErrSessionNotFound, "session not found: "+session.ID)
 	}
 
+	// Optimistic lock: reject if version mismatch.
+	if session.Version != old.Version {
+		return errcode.New(errcode.ErrSessionConflict,
+			fmt.Sprintf("session version conflict: expected %d, got %d", old.Version, session.Version))
+	}
+
 	// Remove old refresh-token index entry.
 	delete(r.byRefresh, old.RefreshToken)
 	// Remove old previous-refresh-token index entry.
@@ -93,6 +103,7 @@ func (r *SessionRepository) Update(_ context.Context, session *domain.Session) e
 		delete(r.byPrevRefresh, old.PreviousRefreshToken)
 	}
 
+	session.Version++
 	clone := *session
 	r.byID[session.ID] = &clone
 	r.byRefresh[session.RefreshToken] = &clone

--- a/cells/access-core/internal/mem/session_repo.go
+++ b/cells/access-core/internal/mem/session_repo.go
@@ -92,8 +92,9 @@ func (r *SessionRepository) Update(_ context.Context, session *domain.Session) e
 
 	// Optimistic lock: reject if version mismatch.
 	if session.Version != old.Version {
-		return errcode.New(errcode.ErrSessionConflict,
-			fmt.Sprintf("session version conflict: expected %d, got %d", old.Version, session.Version))
+		return errcode.Safe(errcode.ErrSessionConflict,
+			"session was modified by another request, please retry",
+			fmt.Sprintf("version conflict: expected %d, got %d", old.Version, session.Version))
 	}
 
 	// Remove old refresh-token index entry.

--- a/cells/access-core/options_test.go
+++ b/cells/access-core/options_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,25 +27,34 @@ func TestWithInMemoryDefaults(t *testing.T) {
 
 func TestRegisterSubscriptions(t *testing.T) {
 	c := newTestCell()
-	err := c.RegisterSubscriptions(nil)
-	require.NoError(t, err)
+	ctx := context.Background()
+	deps := cell.Dependencies{Config: make(map[string]any)}
+	require.NoError(t, c.Init(ctx, deps))
+
+	r := &celltest.StubEventRouter{}
+	require.NoError(t, c.RegisterSubscriptions(r))
+	assert.Equal(t, 1, r.HandlerCount(), "access-core should register 1 topic handler")
+	assert.Equal(t, "event.config.changed.v1", r.Topics[0])
+	assert.Equal(t, "access-core", r.ConsumerGroups[0])
 }
 
 func TestInit_MissingOutboxWriter(t *testing.T) {
-	// L2 cell without outboxWriter should fail.
+	// L2 cell without outboxWriter (but with txRunner) should fail via XOR check.
 	c := NewAccessCore(
 		WithJWTIssuer(testIssuer),
 		WithJWTVerifier(testVerifier),
+		WithTxManager(noopTxRunner{}),
 	)
 	deps := cell.Dependencies{Config: make(map[string]any)}
 	err := c.Init(context.Background(), deps)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "outboxWriter")
+	assert.Contains(t, err.Error(), "txRunner")
 }
 
 func TestInit_MissingJWTIssuerAndVerifier(t *testing.T) {
 	c := NewAccessCore(
 		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
 	)
 	deps := cell.Dependencies{Config: make(map[string]any)}
 	err := c.Init(context.Background(), deps)

--- a/cells/access-core/slices/config-receive/slice.yaml
+++ b/cells/access-core/slices/config-receive/slice.yaml
@@ -1,0 +1,10 @@
+id: config-receive
+belongsToCell: access-core
+contractUsages:
+  - contract: event.config.changed.v1
+    role: subscribe
+verify:
+  unit:
+    - unit.config-receive.service
+  contract:
+    - contract.event.config.changed.v1.subscribe

--- a/cells/access-core/slices/configreceive/service.go
+++ b/cells/access-core/slices/configreceive/service.go
@@ -17,11 +17,22 @@ const (
 	TopicConfigChanged = "event.config.changed.v1"
 )
 
+// ConfigChangedEvent is the payload for event.config.changed.v1.
+// Matches contracts/event/config/changed/v1/payload.schema.json.
+type ConfigChangedEvent struct {
+	Action   string `json:"action"`
+	Key      string `json:"key"`
+	Value    string `json:"value,omitempty"`
+	Version  int    `json:"version,omitempty"`
+	ConfigID string `json:"config_id,omitempty"`
+}
+
 // Service consumes config change events for access-core.
 //
 // Consumer: cg-access-core-config-changed
 // Idempotency: log-only (no side effects), inherently idempotent
 // Disposition: Ack on success / Reject on permanent unmarshal error
+// DLX: broker-native via DispositionReject → Nack(requeue=false)
 type Service struct {
 	logger *slog.Logger
 }
@@ -34,16 +45,12 @@ func NewService(logger *slog.Logger) *Service {
 // HandleEvent processes a config change event. This is the callback registered
 // with the event bus subscriber via outbox.WrapLegacyHandler.
 func (s *Service) HandleEvent(_ context.Context, entry outbox.Entry) error {
-	var event struct {
-		Action string `json:"action"`
-		Key    string `json:"key"`
-		Value  string `json:"value"`
-	}
+	var event ConfigChangedEvent
 
 	if err := json.Unmarshal(entry.Payload, &event); err != nil {
 		s.logger.Error("config-receive: failed to unmarshal event, routing to dead letter",
 			slog.Any("error", err), slog.String("entry_id", entry.ID))
-		return fmt.Errorf("config-receive: unmarshal payload: %w", err)
+		return outbox.NewPermanentError(fmt.Errorf("config-receive: unmarshal payload: %w", err))
 	}
 
 	switch event.Action {

--- a/cells/access-core/slices/configreceive/service.go
+++ b/cells/access-core/slices/configreceive/service.go
@@ -1,0 +1,65 @@
+// Package configreceive implements the config-receive slice: consumes
+// config change events from config-core. Currently logs changes for
+// observability; future use: refresh JWT TTL, key rotation intervals, etc.
+package configreceive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+const (
+	// TopicConfigChanged is the event topic consumed by this slice.
+	TopicConfigChanged = "event.config.changed.v1"
+)
+
+// Service consumes config change events for access-core.
+//
+// Consumer: cg-access-core-config-changed
+// Idempotency: log-only (no side effects), inherently idempotent
+// Disposition: Ack on success / Reject on permanent unmarshal error
+type Service struct {
+	logger *slog.Logger
+}
+
+// NewService creates a config-receive Service.
+func NewService(logger *slog.Logger) *Service {
+	return &Service{logger: logger}
+}
+
+// HandleEvent processes a config change event. This is the callback registered
+// with the event bus subscriber via outbox.WrapLegacyHandler.
+func (s *Service) HandleEvent(_ context.Context, entry outbox.Entry) error {
+	var event struct {
+		Action string `json:"action"`
+		Key    string `json:"key"`
+		Value  string `json:"value"`
+	}
+
+	if err := json.Unmarshal(entry.Payload, &event); err != nil {
+		s.logger.Error("config-receive: failed to unmarshal event, routing to dead letter",
+			slog.Any("error", err), slog.String("entry_id", entry.ID))
+		return fmt.Errorf("config-receive: unmarshal payload: %w", err)
+	}
+
+	switch event.Action {
+	case "created", "updated":
+		s.logger.Info("config-receive: config changed",
+			slog.String("key", event.Key), slog.String("action", event.Action))
+	case "deleted":
+		s.logger.Info("config-receive: config deleted",
+			slog.String("key", event.Key))
+	case "published":
+		s.logger.Info("config-receive: config published (no action)",
+			slog.String("key", event.Key))
+	default:
+		s.logger.Warn("config-receive: unknown action, skipping",
+			slog.String("key", event.Key), slog.String("action", event.Action))
+	}
+
+	return nil
+}

--- a/cells/access-core/slices/configreceive/service_test.go
+++ b/cells/access-core/slices/configreceive/service_test.go
@@ -1,0 +1,84 @@
+package configreceive
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleEvent_ValidPayload(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+	}{
+		{"created", "created"},
+		{"updated", "updated"},
+		{"deleted", "deleted"},
+		{"published", "published"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService(slog.Default())
+
+			payload, err := json.Marshal(map[string]string{
+				"action": tt.action,
+				"key":    "jwt.ttl",
+				"value":  "30m",
+			})
+			require.NoError(t, err)
+
+			entry := outbox.Entry{
+				ID:      "evt-1",
+				Topic:   TopicConfigChanged,
+				Payload: payload,
+			}
+
+			err = svc.HandleEvent(context.Background(), entry)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestHandleEvent_UnknownAction(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	payload, _ := json.Marshal(map[string]string{
+		"action": "unknown-action",
+		"key":    "some.key",
+	})
+
+	entry := outbox.Entry{
+		ID:      "evt-2",
+		Topic:   TopicConfigChanged,
+		Payload: payload,
+	}
+
+	// Unknown action is logged but not an error (no side effects to fail).
+	err := svc.HandleEvent(context.Background(), entry)
+	assert.NoError(t, err)
+}
+
+func TestHandleEvent_InvalidJSON(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	entry := outbox.Entry{
+		ID:      "evt-3",
+		Topic:   TopicConfigChanged,
+		Payload: []byte("not-json{"),
+	}
+
+	// Invalid JSON is a permanent error — should be rejected (not retried).
+	err := svc.HandleEvent(context.Background(), entry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestTopicConstant(t *testing.T) {
+	assert.Equal(t, "event.config.changed.v1", TopicConfigChanged)
+}

--- a/cells/access-core/slices/configreceive/service_test.go
+++ b/cells/access-core/slices/configreceive/service_test.go
@@ -77,6 +77,10 @@ func TestHandleEvent_InvalidJSON(t *testing.T) {
 	err := svc.HandleEvent(context.Background(), entry)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshal")
+
+	// Must be PermanentError so WrapLegacyHandler routes to DLX, not retry.
+	var permErr *outbox.PermanentError
+	assert.ErrorAs(t, err, &permErr)
 }
 
 func TestTopicConstant(t *testing.T) {

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -3,6 +3,7 @@ package sessionrefresh
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -145,4 +146,50 @@ func TestService_Refresh_SigningMethodCheck(t *testing.T) {
 
 	_, err = svc.Refresh(context.Background(), tokenStr)
 	assert.Error(t, err, "should reject token signed with a different key")
+}
+
+// TestService_Refresh_ConcurrentRefresh verifies that concurrent refresh
+// attempts on the same session result in at most one success. The remaining
+// goroutines either get a version conflict (409) or trigger reuse detection.
+// Run with -race to verify memory safety.
+func TestService_Refresh_ConcurrentRefresh(t *testing.T) {
+	svc, repo := newTestService()
+
+	rt := issueTestToken("usr-conc")
+	sess, err := domain.NewSession("usr-conc", "at", rt, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	sess.ID = "sess-conc"
+	require.NoError(t, repo.Create(context.Background(), sess))
+
+	const goroutines = 5
+	var (
+		wg        sync.WaitGroup
+		successes int64
+		failures  int64
+		mu        sync.Mutex
+	)
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, refreshErr := svc.Refresh(context.Background(), rt)
+			mu.Lock()
+			defer mu.Unlock()
+			if refreshErr == nil {
+				successes++
+			} else {
+				failures++
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// With optimistic locking, at most 1 goroutine succeeds.
+	// Others fail with version conflict or reuse detection.
+	assert.LessOrEqual(t, successes, int64(1),
+		"at most one concurrent refresh should succeed")
+	assert.GreaterOrEqual(t, failures, int64(goroutines-1),
+		"remaining goroutines should fail")
 }

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -186,10 +186,10 @@ func TestService_Refresh_ConcurrentRefresh(t *testing.T) {
 
 	wg.Wait()
 
-	// With optimistic locking, at most 1 goroutine succeeds.
+	// With optimistic locking, exactly 1 goroutine succeeds.
 	// Others fail with version conflict or reuse detection.
-	assert.LessOrEqual(t, successes, int64(1),
-		"at most one concurrent refresh should succeed")
-	assert.GreaterOrEqual(t, failures, int64(goroutines-1),
+	assert.Equal(t, int64(1), successes,
+		"exactly one concurrent refresh should succeed")
+	assert.Equal(t, int64(goroutines-1), failures,
 		"remaining goroutines should fail")
 }

--- a/cmd/core-bundle/auth_integration_test.go
+++ b/cmd/core-bundle/auth_integration_test.go
@@ -14,6 +14,7 @@ import (
 	configcore "github.com/ghbvf/gocell/cells/config-core"
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
@@ -21,6 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// noopTxRunner executes fn directly without a real transaction.
+type noopTxRunner struct{}
+
+func (noopTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) error {
+	return fn(context.Background())
+}
+
+var _ persistence.TxRunner = noopTxRunner{}
 
 var testHTTPClient = &http.Client{Timeout: 2 * time.Second}
 
@@ -59,6 +69,7 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 		accesscore.WithJWTIssuer(jwtIssuer),
 		accesscore.WithJWTVerifier(jwtVerifier),
 		accesscore.WithOutboxWriter(nw),
+		accesscore.WithTxManager(noopTxRunner{}),
 	)
 	cc := configcore.NewConfigCore(
 		configcore.WithInMemoryDefaults(),

--- a/examples/sso-bff/main.go
+++ b/examples/sso-bff/main.go
@@ -21,11 +21,21 @@ import (
 	configcore "github.com/ghbvf/gocell/cells/config-core"
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
+
+// noopTxRunner executes fn directly without a real transaction (demo mode).
+type noopTxRunner struct{}
+
+func (noopTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) error {
+	return fn(context.Background())
+}
+
+var _ persistence.TxRunner = noopTxRunner{}
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -67,6 +77,7 @@ func main() {
 		accesscore.WithJWTIssuer(jwtIssuer),
 		accesscore.WithJWTVerifier(jwtVerifier),
 		accesscore.WithOutboxWriter(nw),
+		accesscore.WithTxManager(noopTxRunner{}),
 		accesscore.WithLogger(logger),
 	)
 

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -33,6 +33,7 @@ const (
 	ErrBusClosed          Code = "ERR_BUS_CLOSED"
 	ErrCellMissingOutbox  Code = "ERR_CELL_MISSING_OUTBOX"
 	ErrSessionNotFound    Code = "ERR_SESSION_NOT_FOUND"
+	ErrSessionConflict    Code = "ERR_SESSION_CONFLICT"
 	ErrOrderNotFound      Code = "ERR_ORDER_NOT_FOUND"
 	ErrDeviceNotFound     Code = "ERR_DEVICE_NOT_FOUND"
 	ErrCommandNotFound    Code = "ERR_COMMAND_NOT_FOUND"

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -201,6 +201,7 @@ var codeToStatus = map[errcode.Code]int{
 	errcode.ErrAssemblyNotFound:   http.StatusNotFound,
 	errcode.ErrJourneyNotFound:    http.StatusNotFound,
 	errcode.ErrSessionNotFound:    http.StatusNotFound,
+	errcode.ErrSessionConflict:    http.StatusConflict,
 	errcode.ErrOrderNotFound:      http.StatusNotFound,
 	errcode.ErrDeviceNotFound:     http.StatusNotFound,
 	errcode.ErrCommandNotFound:    http.StatusNotFound,


### PR DESCRIPTION
## Summary

- **L2-TX-01**: Add `txRunner` field + `WithTxManager` Option with XOR constraint `(outboxWriter==nil)!=(txRunner==nil)` — matching order-cell pattern. Passes txRunner to identity-manage, session-login, session-logout services.
- **EVT-SUB-01**: New `configreceive` slice subscribes to `event.config.changed.v1`. `RegisterSubscriptions()` no longer no-op — aligns with contract.yaml + J-config-hot-reload journey.
- **Session TOCTOU**: `Version` field on Session domain + optimistic lock in in-memory repo `Update()`. Concurrent refresh returns `ErrSessionConflict` (409) instead of silently overwriting token rotation.

## Test plan

- [x] `TestInit_TxRunnerXOR_OutboxWithoutTx` — outboxWriter without txRunner → error
- [x] `TestInit_TxRunnerXOR_TxWithoutOutbox` — txRunner without outboxWriter → error
- [x] `TestInit_TxRunnerXOR_BothPresent` — both present → success
- [x] `TestHandleEvent_ValidPayload` — config event handler (created/updated/deleted/published)
- [x] `TestHandleEvent_InvalidJSON` — reject malformed payload
- [x] `TestRegisterSubscriptions` — StubEventRouter verifies 1 handler registered
- [x] `TestSessionRepository_Update_VersionConflict` — stale version rejected
- [x] `TestSessionRepository_Update_VersionIncrement` — version increments each update
- [x] `TestSessionRepository_ConcurrentRefreshUpdate` — 10 goroutines, exactly 1 wins
- [x] `TestSessionRepository_Create_SetsVersion` — Version initialized to 1
- [x] `TestService_Refresh_ConcurrentRefresh` — concurrent refresh, at most 1 succeeds
- [x] All tests pass with `-race -count=1`

ref: order-cell cell.go (XOR pattern), config-core configsubscribe (event handler pattern)

Backlog: #8a (access-core) + #8b + #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)