### PR TITLE
fix(contract): propagate outbox.Write error + HTTP metadata + contract test rewrites

### DIFF
--- a/cells/access-core/slices/identitymanage/contract_test.go
+++ b/cells/access-core/slices/identitymanage/contract_test.go
@@ -268,11 +268,19 @@ func TestHttpAuthUserDeleteV1Serve_RejectsBodyOn204(t *testing.T) {
 	}
 }
 
-// capturingTB is a testing.TB implementation that captures whether Errorf was called.
+// capturingTB is a minimal testing.TB that captures whether an error method was called.
+// Methods beyond Helper/Errorf/Fatalf are implemented defensively to avoid nil-panic
+// if ValidateHTTPResponseRecorder's call-sites change.
 type capturingTB struct {
 	testing.TB
 	errored bool
 }
 
-func (c *capturingTB) Helper()                           {}
-func (c *capturingTB) Errorf(format string, args ...any) { c.errored = true }
+func (c *capturingTB) Helper()                            {}
+func (c *capturingTB) Errorf(format string, args ...any)  { c.errored = true }
+func (c *capturingTB) Fatalf(format string, args ...any)  { c.errored = true }
+func (c *capturingTB) Logf(format string, args ...any)    {}
+func (c *capturingTB) Name() string                       { return "capturingTB" }
+func (c *capturingTB) Log(args ...any)                    {}
+func (c *capturingTB) Error(args ...any)                  { c.errored = true }
+func (c *capturingTB) Fatal(args ...any)                  { c.errored = true }

--- a/cells/access-core/slices/identitymanage/contract_test.go
+++ b/cells/access-core/slices/identitymanage/contract_test.go
@@ -1,6 +1,7 @@
 package identitymanage
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -10,20 +11,58 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/stretchr/testify/require"
 )
 
 // testPassword is a deterministic credential used only in contract tests.
 // Extracted as a constant to satisfy S6437 (no hardcoded credentials).
 const testPassword = "contract-test-P@ssw0rd" //nolint:gosec
 
+// --- contract test doubles ---
+
+type contractRecordingWriter struct {
+	entries []outbox.Entry
+}
+
+func (w *contractRecordingWriter) Write(_ context.Context, e outbox.Entry) error {
+	w.entries = append(w.entries, e)
+	return nil
+}
+
+type contractTxRunner struct{}
+
+func (contractTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+var _ persistence.TxRunner = contractTxRunner{}
+
 func setupContractHandler() http.Handler {
 	svc := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default())
+	return buildMux(svc)
+}
+
+func setupContractHandlerWithOutbox() (http.Handler, *contractRecordingWriter) {
+	writer := &contractRecordingWriter{}
+	svc := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(contractTxRunner{}))
+	return buildMux(svc), writer
+}
+
+func buildMux(svc *Service) http.Handler {
 	mux := celltest.NewTestMux()
 	h := NewHandler(svc)
 	mux.Handle("POST /api/v1/access/users", http.HandlerFunc(h.handleCreate))
+	mux.Handle("GET /api/v1/access/users/{id}", http.HandlerFunc(h.handleGet))
+	mux.Handle("PUT /api/v1/access/users/{id}", http.HandlerFunc(h.handleUpdate))
+	mux.Handle("PATCH /api/v1/access/users/{id}", http.HandlerFunc(h.handlePatch))
 	mux.Handle("DELETE /api/v1/access/users/{id}", http.HandlerFunc(h.handleDelete))
+	mux.Handle("POST /api/v1/access/users/{id}/lock", http.HandlerFunc(h.handleLock))
+	mux.Handle("POST /api/v1/access/users/{id}/unlock", http.HandlerFunc(h.handleUnlock))
 	return mux
 }
 
@@ -67,27 +106,51 @@ func TestHttpAuthUserCreateV1Serve(t *testing.T) {
 
 func TestHttpAuthUserGetV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.get.v1")
+	handler := setupContractHandler()
 
-	c.ValidateResponse(t, []byte(`{"data":{"id":"u-1","username":"alice","email":"a@b.com","status":"active","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}}`))
+	userID := createUserForContractTest(t, handler, createContract)
+	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	handler.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }
 
 func TestHttpAuthUserUpdateV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.update.v1")
+	handler := setupContractHandler()
+
+	userID := createUserForContractTest(t, handler, createContract)
+	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"email":"new@b.com"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
 
 	c.ValidateRequest(t, []byte(`{"email":"new@b.com"}`))
-	c.ValidateResponse(t, []byte(`{"data":{"id":"u-1","username":"alice","email":"new@b.com","status":"active","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}}`))
 	c.MustRejectRequest(t, []byte(`{"email":"a","extra":"bad"}`))
 }
 
 func TestHttpAuthUserPatchV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.patch.v1")
+	handler := setupContractHandler()
 
-	c.ValidateRequest(t, []byte(`{"name":"Bob"}`))
-	c.ValidateResponse(t, []byte(`{"data":{"id":"u-1","username":"alice","email":"a@b.com","status":"active","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}}`))
+	userID := createUserForContractTest(t, handler, createContract)
+	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"name":"Bob"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
+
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }
 
@@ -110,38 +173,107 @@ func TestHttpAuthUserDeleteV1Serve(t *testing.T) {
 
 func TestHttpAuthUserLockV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.lock.v1")
+	handler := setupContractHandler()
 
-	c.ValidateResponse(t, []byte(`{"data":{"status":"locked"}}`))
+	userID := createUserForContractTest(t, handler, createContract)
+	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	handler.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }
 
 func TestHttpAuthUserUnlockV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
+	lockContract := contracttest.LoadByID(t, root, "http.auth.user.lock.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.unlock.v1")
+	handler := setupContractHandler()
 
-	c.ValidateResponse(t, []byte(`{"data":{"status":"active"}}`))
+	userID := createUserForContractTest(t, handler, createContract)
+	// Lock first
+	lockPath := strings.Replace(lockContract.HTTP.Path, "{id}", userID, 1)
+	httptest.NewRecorder()
+	lockReq := httptest.NewRequest(lockContract.HTTP.Method, lockPath, nil)
+	handler.ServeHTTP(httptest.NewRecorder(), lockReq)
+
+	// Unlock
+	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	handler.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }
 
+// --- Event contract tests with real handler output ---
+
 func TestEventUserCreatedV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "event.user.created.v1")
+	handler, writer := setupContractHandlerWithOutbox()
 
-	// Schema validation: payload requires user_id + username, headers requires event_id.
-	c.ValidatePayload(t, []byte(`{"user_id":"usr-1","username":"alice"}`))
-	c.ValidateHeaders(t, []byte(`{"event_id":"evt-123"}`))
+	_ = createUserForContractTest(t, handler, createContract)
+
+	require.Len(t, writer.entries, 1, "Create must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"user_id":"x"}`))
 	c.MustRejectHeaders(t, []byte(`{}`))
 }
 
 func TestEventUserLockedV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
+	lockContract := contracttest.LoadByID(t, root, "http.auth.user.lock.v1")
 	c := contracttest.LoadByID(t, root, "event.user.locked.v1")
+	handler, writer := setupContractHandlerWithOutbox()
 
-	// Schema validation: payload requires user_id, headers requires event_id.
-	c.ValidatePayload(t, []byte(`{"user_id":"usr-1"}`))
-	c.ValidateHeaders(t, []byte(`{"event_id":"evt-456"}`))
+	userID := createUserForContractTest(t, handler, createContract)
+	writer.entries = nil // reset after create event
+
+	lockPath := strings.Replace(lockContract.HTTP.Path, "{id}", userID, 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(lockContract.HTTP.Method, lockPath, nil)
+	handler.ServeHTTP(rec, req)
+	lockContract.ValidateHTTPResponseRecorder(t, rec)
+
+	require.Len(t, writer.entries, 1, "Lock must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{}`))
 	c.MustRejectHeaders(t, []byte(`{}`))
 }
+
+// --- #22 DELETE-NOCONTENT-01: 204 semantic negative test ---
+
+func TestHttpAuthUserDeleteV1Serve_RejectsBodyOn204(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.auth.user.delete.v1")
+
+	// Fabricate a buggy 204 response with a body to prove the contract catches it.
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(204)
+	_, _ = rec.Write([]byte(`{"error":"oops"}`))
+
+	mockT := &capturingTB{}
+	c.ValidateHTTPResponseRecorder(mockT, rec)
+	if !mockT.errored {
+		t.Fatal("204 contract must reject responses with non-empty body")
+	}
+}
+
+// capturingTB is a testing.TB implementation that captures whether Errorf was called.
+type capturingTB struct {
+	testing.TB
+	errored bool
+}
+
+func (c *capturingTB) Helper()                           {}
+func (c *capturingTB) Errorf(format string, args ...any) { c.errored = true }

--- a/cells/access-core/slices/identitymanage/contract_test.go
+++ b/cells/access-core/slices/identitymanage/contract_test.go
@@ -196,7 +196,6 @@ func TestHttpAuthUserUnlockV1Serve(t *testing.T) {
 	userID := createUserForContractTest(t, handler, createContract)
 	// Lock first
 	lockPath := strings.Replace(lockContract.HTTP.Path, "{id}", userID, 1)
-	httptest.NewRecorder()
 	lockReq := httptest.NewRequest(lockContract.HTTP.Method, lockPath, nil)
 	handler.ServeHTTP(httptest.NewRecorder(), lockReq)
 

--- a/cells/access-core/slices/identitymanage/outbox_test.go
+++ b/cells/access-core/slices/identitymanage/outbox_test.go
@@ -3,6 +3,7 @@ package identitymanage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -18,9 +19,15 @@ import (
 
 // --- stubs ---
 
-type stubOutboxWriter struct{ entries []outbox.Entry }
+type stubOutboxWriter struct {
+	entries []outbox.Entry
+	err     error // when set, Write returns this error
+}
 
 func (s *stubOutboxWriter) Write(_ context.Context, e outbox.Entry) error {
+	if s.err != nil {
+		return s.err
+	}
 	s.entries = append(s.entries, e)
 	return nil
 }
@@ -219,6 +226,40 @@ func TestService_Update_EmptyID(t *testing.T) {
 	svc := newTestService()
 	_, err := svc.Update(context.Background(), UpdateInput{})
 	assert.Error(t, err)
+}
+
+// --- #27d OUTBOX-WRITE-ERR-01: outbox.Write error must propagate ---
+
+func TestService_Create_OutboxWriteError(t *testing.T) {
+	ow := &stubOutboxWriter{err: errors.New("outbox unavailable")}
+	svc := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+		WithOutboxWriter(ow), WithTxManager(&stubTxRunner{}))
+
+	_, err := svc.Create(context.Background(), CreateInput{
+		Username: "alice", Email: "a@b.c", Password: "hash",
+	})
+	require.Error(t, err, "Create must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
+}
+
+func TestService_Lock_OutboxWriteError(t *testing.T) {
+	repo := mem.NewUserRepository()
+	// Create user with working outbox
+	svcCreate := NewService(repo, mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+		WithOutboxWriter(&stubOutboxWriter{}), WithTxManager(&stubTxRunner{}))
+	user, err := svcCreate.Create(context.Background(), CreateInput{
+		Username: "bob", Email: "b@c.d", Password: "hash",
+	})
+	require.NoError(t, err)
+
+	// Lock with failing outbox
+	failWriter := &stubOutboxWriter{err: errors.New("outbox unavailable")}
+	svcLock := NewService(repo, mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+		WithOutboxWriter(failWriter), WithTxManager(&stubTxRunner{}))
+
+	err = svcLock.Lock(context.Background(), user.ID)
+	require.Error(t, err, "Lock must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
 }
 
 // --- helpers ---

--- a/cells/access-core/slices/identitymanage/service.go
+++ b/cells/access-core/slices/identitymanage/service.go
@@ -218,7 +218,10 @@ func (s *Service) Unlock(ctx context.Context, id string) error {
 }
 
 func (s *Service) publish(ctx context.Context, topic string, payload map[string]any) error {
-	data, _ := json.Marshal(payload)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("identity-manage: marshal event payload: %w", err)
+	}
 	if s.outboxWriter != nil {
 		entry := outbox.Entry{
 			ID:        "evt" + "-" + uuid.NewString(),

--- a/cells/access-core/slices/identitymanage/service.go
+++ b/cells/access-core/slices/identitymanage/service.go
@@ -233,7 +233,7 @@ func (s *Service) publish(ctx context.Context, topic string, payload map[string]
 	// Demo mode: publisher failure is logged but not propagated since
 	// demo mode does not guarantee L2 atomicity.
 	if err := s.publisher.Publish(ctx, topic, data); err != nil {
-		s.logger.Error("identity-manage: failed to publish event",
+		s.logger.Warn("identity-manage: failed to publish event (demo mode)",
 			slog.Any("error", err), slog.String("topic", topic))
 	}
 	return nil

--- a/cells/access-core/slices/identitymanage/service.go
+++ b/cells/access-core/slices/identitymanage/service.go
@@ -87,7 +87,9 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.User, 
 		if err := s.repo.Create(txCtx, user); err != nil {
 			return fmt.Errorf("identity-manage: create: %w", err)
 		}
-		s.publish(txCtx, TopicUserCreated, eventPayload)
+		if err := s.publish(txCtx, TopicUserCreated, eventPayload); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return nil, err
@@ -183,7 +185,9 @@ func (s *Service) Lock(ctx context.Context, id string) error {
 			s.logger.Error("identity-manage: failed to revoke sessions on lock",
 				slog.Any("error", err), slog.String("user_id", id))
 		}
-		s.publish(txCtx, TopicUserLocked, map[string]any{"user_id": id})
+		if err := s.publish(txCtx, TopicUserLocked, map[string]any{"user_id": id}); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return err
@@ -213,7 +217,7 @@ func (s *Service) Unlock(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Service) publish(ctx context.Context, topic string, payload map[string]any) {
+func (s *Service) publish(ctx context.Context, topic string, payload map[string]any) error {
 	data, _ := json.Marshal(payload)
 	if s.outboxWriter != nil {
 		entry := outbox.Entry{
@@ -222,15 +226,17 @@ func (s *Service) publish(ctx context.Context, topic string, payload map[string]
 			Payload:   data,
 		}
 		if err := s.outboxWriter.Write(ctx, entry); err != nil {
-			s.logger.Error("identity-manage: failed to write outbox entry",
-				slog.Any("error", err), slog.String("topic", topic))
+			return fmt.Errorf("identity-manage: write outbox entry: %w", err)
 		}
-		return
+		return nil
 	}
+	// Demo mode: publisher failure is logged but not propagated since
+	// demo mode does not guarantee L2 atomicity.
 	if err := s.publisher.Publish(ctx, topic, data); err != nil {
 		s.logger.Error("identity-manage: failed to publish event",
 			slog.Any("error", err), slog.String("topic", topic))
 	}
+	return nil
 }
 
 // runInTx executes fn in a transaction if txRunner is configured, otherwise

--- a/cells/access-core/slices/session-logout/slice.yaml
+++ b/cells/access-core/slices/session-logout/slice.yaml
@@ -1,11 +1,14 @@
 id: session-logout
 belongsToCell: access-core
 contractUsages:
+  - contract: http.auth.session.delete.v1
+    role: serve
   - contract: event.session.revoked.v1
     role: publish
 verify:
   unit:
     - unit.session-logout.service
   contract:
+    - contract.http.auth.session.delete.v1.serve
     - contract.event.session.revoked.v1.publish
   waivers: []

--- a/cells/access-core/slices/sessionlogout/contract_test.go
+++ b/cells/access-core/slices/sessionlogout/contract_test.go
@@ -2,7 +2,11 @@ package sessionlogout
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,9 +24,13 @@ import (
 
 type recordingWriter struct {
 	entries []outbox.Entry
+	err     error
 }
 
 func (w *recordingWriter) Write(_ context.Context, e outbox.Entry) error {
+	if w.err != nil {
+		return w.err
+	}
 	w.entries = append(w.entries, e)
 	return nil
 }
@@ -34,6 +43,39 @@ func (noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error)
 
 var _ persistence.TxRunner = noopTxRunner{}
 
+func seedContractSession(repo *mem.SessionRepository) string {
+	sess, _ := domain.NewSession("usr-1", "at-1", "rt-1", time.Now().Add(time.Hour))
+	sess.ID = "sess-1"
+	_ = repo.Create(context.Background(), sess)
+	return sess.ID
+}
+
+// --- HTTP contract test (S1-F1) ---
+
+func TestHttpAuthSessionDeleteV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.auth.session.delete.v1")
+
+	sessionRepo := mem.NewSessionRepository()
+	sessID := seedContractSession(sessionRepo)
+	svc := NewService(sessionRepo, eventbus.New(), slog.Default(),
+		WithOutboxWriter(&recordingWriter{}), WithTxManager(noopTxRunner{}))
+
+	mux := http.NewServeMux()
+	mux.Handle("DELETE /api/v1/access/sessions/{id}", http.HandlerFunc(NewHandler(svc).HandleLogout))
+
+	c.ValidateRequest(t, []byte(`{}`))
+	c.MustRejectRequest(t, []byte(`{"unexpected":true}`))
+
+	path := strings.Replace(c.HTTP.Path, "{id}", sessID, 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	mux.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
+}
+
+// --- Event contract test ---
+
 func TestEventSessionRevokedV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.session.revoked.v1")
@@ -43,12 +85,9 @@ func TestEventSessionRevokedV1Publish(t *testing.T) {
 	svc := NewService(sessionRepo, eventbus.New(), slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(noopTxRunner{}))
 
-	// Seed a session to revoke.
-	sess, _ := domain.NewSession("usr-1", "at-1", "rt-1", time.Now().Add(time.Hour))
-	sess.ID = "sess-1"
-	_ = sessionRepo.Create(context.Background(), sess)
+	sessID := seedContractSession(sessionRepo)
 
-	err := svc.Logout(context.Background(), "sess-1")
+	err := svc.Logout(context.Background(), sessID)
 	require.NoError(t, err)
 
 	require.Len(t, writer.entries, 1, "Logout must emit one outbox entry")
@@ -57,4 +96,18 @@ func TestEventSessionRevokedV1Publish(t *testing.T) {
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"session_id":"s"}`))
 	c.MustRejectHeaders(t, []byte(`{}`))
+}
+
+// --- Outbox error propagation test (S3-F1) ---
+
+func TestService_Logout_OutboxWriteError(t *testing.T) {
+	sessionRepo := mem.NewSessionRepository()
+	seedContractSession(sessionRepo)
+	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
+	svc := NewService(sessionRepo, eventbus.New(), slog.Default(),
+		WithOutboxWriter(failWriter), WithTxManager(noopTxRunner{}))
+
+	err := svc.Logout(context.Background(), "sess-1")
+	require.Error(t, err, "Logout must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
 }

--- a/cells/access-core/slices/sessionlogout/contract_test.go
+++ b/cells/access-core/slices/sessionlogout/contract_test.go
@@ -1,18 +1,60 @@
 package sessionlogout
 
 import (
+	"context"
+	"log/slog"
 	"testing"
+	"time"
 
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/stretchr/testify/require"
 )
+
+// --- contract test doubles ---
+
+type recordingWriter struct {
+	entries []outbox.Entry
+}
+
+func (w *recordingWriter) Write(_ context.Context, e outbox.Entry) error {
+	w.entries = append(w.entries, e)
+	return nil
+}
+
+type noopTxRunner struct{}
+
+func (noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+var _ persistence.TxRunner = noopTxRunner{}
 
 func TestEventSessionRevokedV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.session.revoked.v1")
 
-	// Schema validation: payload requires session_id + user_id, headers requires event_id.
-	c.ValidatePayload(t, []byte(`{"session_id":"sess-1","user_id":"usr-1"}`))
-	c.ValidateHeaders(t, []byte(`{"event_id":"evt-789"}`))
+	sessionRepo := mem.NewSessionRepository()
+	writer := &recordingWriter{}
+	svc := NewService(sessionRepo, eventbus.New(), slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(noopTxRunner{}))
+
+	// Seed a session to revoke.
+	sess, _ := domain.NewSession("usr-1", "at-1", "rt-1", time.Now().Add(time.Hour))
+	sess.ID = "sess-1"
+	_ = sessionRepo.Create(context.Background(), sess)
+
+	err := svc.Logout(context.Background(), "sess-1")
+	require.NoError(t, err)
+
+	require.Len(t, writer.entries, 1, "Logout must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"session_id":"s"}`))
 	c.MustRejectHeaders(t, []byte(`{}`))
 }

--- a/cells/config-core/internal/domain/topics.go
+++ b/cells/config-core/internal/domain/topics.go
@@ -1,0 +1,8 @@
+package domain
+
+// Event topic constants for config-core. Shared across slices to prevent
+// duplicate declarations (configwrite, configpublish, configsubscribe).
+const (
+	TopicConfigChanged  = "event.config.changed.v1"
+	TopicConfigRollback = "event.config.rollback.v1"
+)

--- a/cells/config-core/slices/configpublish/contract_test.go
+++ b/cells/config-core/slices/configpublish/contract_test.go
@@ -1,24 +1,68 @@
 package configpublish
 
 import (
+	"context"
+	"log/slog"
 	"testing"
+	"time"
 
+	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/stretchr/testify/require"
 )
+
+func newContractService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+	repo := mem.NewConfigRepository()
+	writer := &recordingWriter{}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	return svc, repo, writer
+}
+
+func seedContractEntry(repo *mem.ConfigRepository, key, value string) {
+	now := time.Now()
+	_ = repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-" + key, Key: key, Value: value, Version: 1,
+		CreatedAt: now, UpdatedAt: now,
+	})
+}
 
 func TestEventConfigChangedV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
+	svc, repo, writer := newContractService()
+	seedContractEntry(repo, "app.name", "value")
 
-	c.ValidatePayload(t, []byte(`{"action":"published","key":"app.name","config_id":"cfg-1","version":2}`))
-	c.ValidateHeaders(t, []byte(`{"event_id":"evt-456"}`))
+	_, err := svc.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+
+	require.Len(t, writer.entries, 1, "Publish must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
+	c.MustRejectPayload(t, []byte(`{"action":"published","key":"app.name"}`))
+	c.MustRejectHeaders(t, []byte(`{}`))
 }
 
 func TestEventConfigRollbackV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.rollback.v1")
+	svc, repo, writer := newContractService()
+	seedContractEntry(repo, "app.name", "v1")
 
-	c.ValidatePayload(t, []byte(`{"action":"rollback","key":"app.name","target_version":1,"new_version":3}`))
-	c.ValidateHeaders(t, []byte(`{"event_id":"evt-789"}`))
+	// Publish first to create a version, then rollback
+	_, err := svc.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+	writer.entries = nil // reset
+
+	_, err = svc.Rollback(context.Background(), "app.name", 1)
+	require.NoError(t, err)
+
+	require.Len(t, writer.entries, 1, "Rollback must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"action":"rollback","key":"app.name"}`))
+	c.MustRejectHeaders(t, []byte(`{}`))
 }

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -17,11 +17,11 @@ import (
 	"github.com/google/uuid"
 )
 
+// Re-exported from domain for backward compatibility within this package's
+// tests and callers.
 const (
-	// TopicConfigChanged is the event topic for config changes.
-	TopicConfigChanged = "event.config.changed.v1"
-	// TopicConfigRollback is the event topic for config rollbacks.
-	TopicConfigRollback = "event.config.rollback.v1"
+	TopicConfigChanged  = domain.TopicConfigChanged
+	TopicConfigRollback = domain.TopicConfigRollback
 )
 
 // Option configures a config-publish Service.
@@ -175,7 +175,7 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 	// Demo mode: publisher failure is logged but not propagated since
 	// demo mode does not guarantee L2 atomicity.
 	if err := s.publisher.Publish(ctx, topic, payload); err != nil {
-		s.logger.Error("config-publish: failed to publish event",
+		s.logger.Warn("config-publish: failed to publish event (demo mode)",
 			slog.Any("error", err), slog.String("key", key))
 	}
 	return nil

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -79,12 +79,15 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 		PublishedAt: &now,
 	}
 
-	payload, _ := json.Marshal(map[string]any{
+	payload, err := json.Marshal(map[string]any{
 		"action":    "published",
 		"key":       key,
 		"config_id": entry.ID,
 		"version":   version.Version,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("config-publish: marshal event payload: %w", err)
+	}
 
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
 		if err := s.repo.PublishVersion(txCtx, version); err != nil {
@@ -127,12 +130,15 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 	entry.Version++
 	entry.UpdatedAt = time.Now()
 
-	payload, _ := json.Marshal(map[string]any{
+	payload, err := json.Marshal(map[string]any{
 		"action":         "rollback",
 		"key":            key,
 		"target_version": targetVersion,
 		"new_version":    entry.Version,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("config-publish: marshal event payload: %w", err)
+	}
 
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
 		if err := s.repo.Update(txCtx, entry); err != nil {

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -90,7 +90,9 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 		if err := s.repo.PublishVersion(txCtx, version); err != nil {
 			return fmt.Errorf("config-publish: publish version: %w", err)
 		}
-		s.publishEvent(txCtx, TopicConfigChanged, payload, key)
+		if err := s.publishEvent(txCtx, TopicConfigChanged, payload, key); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return nil, err
@@ -136,7 +138,9 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 		if err := s.repo.Update(txCtx, entry); err != nil {
 			return fmt.Errorf("config-publish: rollback update: %w", err)
 		}
-		s.publishEvent(txCtx, TopicConfigRollback, payload, key)
+		if err := s.publishEvent(txCtx, TopicConfigRollback, payload, key); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return nil, err
@@ -156,7 +160,7 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 	return fn(ctx)
 }
 
-func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte, key string) {
+func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte, key string) error {
 	if s.outboxWriter != nil {
 		entry := outbox.Entry{
 			ID:        "evt" + "-" + uuid.NewString(),
@@ -164,13 +168,15 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 			Payload:   payload,
 		}
 		if err := s.outboxWriter.Write(ctx, entry); err != nil {
-			s.logger.Error("config-publish: failed to write outbox entry",
-				slog.Any("error", err), slog.String("key", key))
+			return fmt.Errorf("config-publish: write outbox entry: %w", err)
 		}
-		return
+		return nil
 	}
+	// Demo mode: publisher failure is logged but not propagated since
+	// demo mode does not guarantee L2 atomicity.
 	if err := s.publisher.Publish(ctx, topic, payload); err != nil {
 		s.logger.Error("config-publish: failed to publish event",
 			slog.Any("error", err), slog.String("key", key))
 	}
+	return nil
 }

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -2,22 +2,65 @@ package configpublish
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// --- test doubles (ref: order-create/service_test.go) ---
+
+type recordingWriter struct {
+	entries []outbox.Entry
+	err     error
+}
+
+func (w *recordingWriter) Write(_ context.Context, entry outbox.Entry) error {
+	if w.err != nil {
+		return w.err
+	}
+	w.entries = append(w.entries, entry)
+	return nil
+}
+
+var _ outbox.Writer = (*recordingWriter)(nil)
+
+type noopTxRunner struct{ calls int }
+
+func (s *noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	s.calls++
+	return fn(ctx)
+}
+
+var _ persistence.TxRunner = (*noopTxRunner)(nil)
+
+type stubPublisher struct{}
+
+func (stubPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
+
+var _ outbox.Publisher = stubPublisher{}
 
 func newTestService() (*Service, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
 	eb := eventbus.New()
 	logger := slog.Default()
 	return NewService(repo, eb, logger), repo
+}
+
+func newDurableTestService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+	repo := mem.NewConfigRepository()
+	writer := &recordingWriter{}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	return svc, repo, writer
 }
 
 func seedEntry(t *testing.T, repo *mem.ConfigRepository, key, value string) {
@@ -105,4 +148,47 @@ func TestService_Rollback(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- #27d OUTBOX-WRITE-ERR-01: outbox.Write error must propagate ---
+
+func TestService_Publish_OutboxWriteError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	writer := &recordingWriter{err: errors.New("outbox unavailable")}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	mustSeedEntry(repo, "app.name", "value")
+
+	_, err := svc.Publish(context.Background(), "app.name")
+	require.Error(t, err, "Publish must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
+}
+
+func TestService_Rollback_OutboxWriteError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	writer := &recordingWriter{err: errors.New("outbox unavailable")}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	mustSeedEntry(repo, "app.name", "v1")
+	// Publish first (use a working writer), then swap to failing writer for rollback.
+	goodWriter := &recordingWriter{}
+	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(goodWriter), WithTxManager(&noopTxRunner{}))
+	_, err := svcGood.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+
+	_, err = svc.Rollback(context.Background(), "app.name", 1)
+	require.Error(t, err, "Rollback must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
+}
+
+func TestService_Publish_DurableMode_CapturesOutboxEntry(t *testing.T) {
+	svc, repo, writer := newDurableTestService()
+	mustSeedEntry(repo, "app.name", "value")
+
+	ver, err := svc.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+	assert.Equal(t, 1, ver.Version)
+	require.Len(t, writer.entries, 1)
+	assert.Equal(t, TopicConfigChanged, writer.entries[0].EventType)
 }

--- a/cells/config-core/slices/configread/contract_test.go
+++ b/cells/config-core/slices/configread/contract_test.go
@@ -1,47 +1,20 @@
 package configread
 
 import (
-	"context"
-	"log/slog"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
-	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
-	"github.com/ghbvf/gocell/pkg/query"
-	"github.com/stretchr/testify/require"
 )
-
-func newContractHandler() (http.Handler, *mem.ConfigRepository) {
-	repo := mem.NewConfigRepository()
-	codec, _ := query.NewCursorCodec([]byte("gocell-demo-cursor-key-32bytes!!"))
-	svc := NewService(repo, codec, slog.Default())
-	h := NewHandler(svc)
-	mux := http.NewServeMux()
-	mux.Handle("GET /api/v1/config/{key}", http.HandlerFunc(h.HandleGet))
-	return mux, repo
-}
 
 func TestHttpConfigGetV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.get.v1")
-	handler, repo := newContractHandler()
 
-	now := time.Now()
-	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
-		ID: "cfg-1", Key: "app.name", Value: "gocell", Version: 1,
-		CreatedAt: now, UpdatedAt: now,
-	}))
-
-	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(c.HTTP.Method, path, nil)
-	handler.ServeHTTP(rec, req)
-	c.ValidateHTTPResponseRecorder(t, rec)
-
+	// TODO(#8 Entity→DTO): handler outputs domain entity directly (PascalCase)
+	// and response.schema.json was written to match that PascalCase output.
+	// Both are wrong per API convention (JSON fields must be camelCase).
+	// Once #8 adds DTO mapping with json tags, fix BOTH the schema and test
+	// to use camelCase, then rewrite to invoke real handler via httptest.
+	c.ValidateResponse(t, []byte(`{"data":{"ID":"c-1","Key":"app.name","Value":"myapp","Version":1,"CreatedAt":"2026-01-01T00:00:00Z","UpdatedAt":"2026-01-01T00:00:00Z"}}`))
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }

--- a/cells/config-core/slices/configread/contract_test.go
+++ b/cells/config-core/slices/configread/contract_test.go
@@ -10,9 +10,9 @@ func TestHttpConfigGetV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.get.v1")
 
-	// TODO(CFG-JSON-01 #16): handler outputs PascalCase (domain entity) instead
-	// of camelCase. Invoking the real handler would fail schema validation.
-	// Once #16 adds json tags, rewrite this to invoke real handler via httptest.
+	// TODO(#8 Entity→DTO): handler outputs domain entity directly (PascalCase)
+	// instead of DTO (camelCase). Invoking the real handler would fail schema
+	// validation. Once #8 adds DTO mapping, rewrite to invoke real handler.
 	c.ValidateResponse(t, []byte(`{"data":{"ID":"c-1","Key":"app.name","Value":"myapp","Version":1,"CreatedAt":"2026-01-01T00:00:00Z","UpdatedAt":"2026-01-01T00:00:00Z"}}`))
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }

--- a/cells/config-core/slices/configread/contract_test.go
+++ b/cells/config-core/slices/configread/contract_test.go
@@ -1,18 +1,47 @@
 package configread
 
 import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/stretchr/testify/require"
 )
+
+func newContractHandler() (http.Handler, *mem.ConfigRepository) {
+	repo := mem.NewConfigRepository()
+	codec, _ := query.NewCursorCodec([]byte("gocell-demo-cursor-key-32bytes!!"))
+	svc := NewService(repo, codec, slog.Default())
+	h := NewHandler(svc)
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/config/{key}", http.HandlerFunc(h.HandleGet))
+	return mux, repo
+}
 
 func TestHttpConfigGetV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.get.v1")
+	handler, repo := newContractHandler()
 
-	// TODO(#8 Entity→DTO): handler outputs domain entity directly (PascalCase)
-	// instead of DTO (camelCase). Invoking the real handler would fail schema
-	// validation. Once #8 adds DTO mapping, rewrite to invoke real handler.
-	c.ValidateResponse(t, []byte(`{"data":{"ID":"c-1","Key":"app.name","Value":"myapp","Version":1,"CreatedAt":"2026-01-01T00:00:00Z","UpdatedAt":"2026-01-01T00:00:00Z"}}`))
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-1", Key: "app.name", Value: "gocell", Version: 1,
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	handler.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
+
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }

--- a/cells/config-core/slices/configread/contract_test.go
+++ b/cells/config-core/slices/configread/contract_test.go
@@ -10,7 +10,9 @@ func TestHttpConfigGetV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.get.v1")
 
-	// NOTE: config.get response schema uses PascalCase (known issue CFG-JSON-01).
+	// TODO(CFG-JSON-01 #16): handler outputs PascalCase (domain entity) instead
+	// of camelCase. Invoking the real handler would fail schema validation.
+	// Once #16 adds json tags, rewrite this to invoke real handler via httptest.
 	c.ValidateResponse(t, []byte(`{"data":{"ID":"c-1","Key":"app.name","Value":"myapp","Version":1,"CreatedAt":"2026-01-01T00:00:00Z","UpdatedAt":"2026-01-01T00:00:00Z"}}`))
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }

--- a/cells/config-core/slices/configsubscribe/service.go
+++ b/cells/config-core/slices/configsubscribe/service.go
@@ -9,13 +9,12 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
-const (
-	// TopicConfigChanged is the event topic consumed by this slice.
-	TopicConfigChanged = "event.config.changed.v1"
-)
+// TopicConfigChanged is re-exported from domain for this package's callers.
+const TopicConfigChanged = domain.TopicConfigChanged
 
 // Cache holds the latest config values observed from events.
 type Cache struct {

--- a/cells/config-core/slices/configwrite/contract_test.go
+++ b/cells/config-core/slices/configwrite/contract_test.go
@@ -1,17 +1,71 @@
 package configwrite
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 
+	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/stretchr/testify/require"
 )
 
-func TestEventConfigChangedV1Publish(t *testing.T) {
+func newContractService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+	repo := mem.NewConfigRepository()
+	writer := &recordingWriter{}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	return svc, repo, writer
+}
+
+func TestEventConfigChangedV1Publish_Create(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
+	svc, _, writer := newContractService()
 
-	c.ValidatePayload(t, []byte(`{"action":"created","key":"app.name","value":"myapp","version":1}`))
-	c.ValidateHeaders(t, []byte(`{"event_id":"evt-123"}`))
+	_, err := svc.Create(context.Background(), CreateInput{Key: "app.name", Value: "myapp"})
+	require.NoError(t, err)
+
+	require.Len(t, writer.entries, 1, "Create must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"action":"created","key":"app.name"}`))
 	c.MustRejectHeaders(t, []byte(`{}`))
+}
+
+func TestEventConfigChangedV1Publish_Update(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
+	svc, _, writer := newContractService()
+
+	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v1"})
+	require.NoError(t, err)
+	writer.entries = nil // reset
+
+	_, err = svc.Update(context.Background(), UpdateInput{Key: "k", Value: "v2"})
+	require.NoError(t, err)
+
+	require.Len(t, writer.entries, 1, "Update must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
+}
+
+func TestEventConfigChangedV1Publish_Delete(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
+	svc, _, writer := newContractService()
+
+	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
+	require.NoError(t, err)
+	writer.entries = nil // reset
+
+	err = svc.Delete(context.Background(), "k")
+	require.NoError(t, err)
+
+	require.Len(t, writer.entries, 1, "Delete must emit one outbox entry")
+	entry := writer.entries[0]
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 }

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -83,7 +83,9 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.Config
 		if err := s.repo.Create(txCtx, entry); err != nil {
 			return fmt.Errorf("config-write: create: %w", err)
 		}
-		s.publishChange(txCtx, "created", entry)
+		if err := s.publishChange(txCtx, "created", entry); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return nil, err
@@ -118,7 +120,9 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.Config
 		if err := s.repo.Update(txCtx, entry); err != nil {
 			return fmt.Errorf("config-write: update: %w", err)
 		}
-		s.publishChange(txCtx, "updated", entry)
+		if err := s.publishChange(txCtx, "updated", entry); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return nil, err
@@ -143,7 +147,9 @@ func (s *Service) Delete(ctx context.Context, key string) error {
 		if err := s.repo.Delete(txCtx, key); err != nil {
 			return fmt.Errorf("config-write: delete: %w", err)
 		}
-		s.publishChange(txCtx, "deleted", entry)
+		if err := s.publishChange(txCtx, "deleted", entry); err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		return err
@@ -162,7 +168,7 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 	return fn(ctx)
 }
 
-func (s *Service) publishChange(ctx context.Context, action string, entry *domain.ConfigEntry) {
+func (s *Service) publishChange(ctx context.Context, action string, entry *domain.ConfigEntry) error {
 	payload, _ := json.Marshal(map[string]any{
 		"action":  action,
 		"key":     entry.Key,
@@ -176,17 +182,17 @@ func (s *Service) publishChange(ctx context.Context, action string, entry *domai
 			Payload:   payload,
 		}
 		if err := s.outboxWriter.Write(ctx, outboxEntry); err != nil {
-			s.logger.Error("config-write: failed to write outbox entry",
-				slog.Any("error", err),
-				slog.String("key", entry.Key),
-			)
+			return fmt.Errorf("config-write: write outbox entry: %w", err)
 		}
-		return
+		return nil
 	}
+	// Demo mode: publisher failure is logged but not propagated since
+	// demo mode does not guarantee L2 atomicity.
 	if err := s.publisher.Publish(ctx, TopicConfigChanged, payload); err != nil {
 		s.logger.Error("config-write: failed to publish event",
 			slog.Any("error", err),
 			slog.String("key", entry.Key),
 		)
 	}
+	return nil
 }

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -17,10 +17,9 @@ import (
 	"github.com/google/uuid"
 )
 
-const (
-	// TopicConfigChanged is the event topic for config changes.
-	TopicConfigChanged = "event.config.changed.v1"
-)
+// TopicConfigChanged is re-exported from domain for backward compatibility
+// within this package's tests and callers.
+const TopicConfigChanged = domain.TopicConfigChanged
 
 // Option configures a config-write Service.
 type Option func(*Service)
@@ -189,7 +188,7 @@ func (s *Service) publishChange(ctx context.Context, action string, entry *domai
 	// Demo mode: publisher failure is logged but not propagated since
 	// demo mode does not guarantee L2 atomicity.
 	if err := s.publisher.Publish(ctx, TopicConfigChanged, payload); err != nil {
-		s.logger.Error("config-write: failed to publish event",
+		s.logger.Warn("config-write: failed to publish event (demo mode)",
 			slog.Any("error", err),
 			slog.String("key", entry.Key),
 		)

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -168,12 +168,15 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 }
 
 func (s *Service) publishChange(ctx context.Context, action string, entry *domain.ConfigEntry) error {
-	payload, _ := json.Marshal(map[string]any{
+	payload, err := json.Marshal(map[string]any{
 		"action":  action,
 		"key":     entry.Key,
 		"value":   entry.Value,
 		"version": entry.Version,
 	})
+	if err != nil {
+		return fmt.Errorf("config-write: marshal event payload: %w", err)
+	}
 	if s.outboxWriter != nil {
 		outboxEntry := outbox.Entry{
 			ID:        "evt" + "-" + uuid.NewString(),

--- a/cells/config-core/slices/configwrite/service_test.go
+++ b/cells/config-core/slices/configwrite/service_test.go
@@ -2,20 +2,63 @@ package configwrite
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// --- test doubles (ref: order-create/service_test.go) ---
+
+type recordingWriter struct {
+	entries []outbox.Entry
+	err     error
+}
+
+func (w *recordingWriter) Write(_ context.Context, entry outbox.Entry) error {
+	if w.err != nil {
+		return w.err
+	}
+	w.entries = append(w.entries, entry)
+	return nil
+}
+
+var _ outbox.Writer = (*recordingWriter)(nil)
+
+type noopTxRunner struct{ calls int }
+
+func (s *noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	s.calls++
+	return fn(ctx)
+}
+
+var _ persistence.TxRunner = (*noopTxRunner)(nil)
+
+type stubPublisher struct{}
+
+func (stubPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
+
+var _ outbox.Publisher = stubPublisher{}
 
 func newTestService() (*Service, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
 	eb := eventbus.New()
 	logger := slog.Default()
 	return NewService(repo, eb, logger), repo
+}
+
+func newDurableTestService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+	repo := mem.NewConfigRepository()
+	writer := &recordingWriter{}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	return svc, repo, writer
 }
 
 func TestService_Create(t *testing.T) {
@@ -155,4 +198,61 @@ func TestService_Delete(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- #27d OUTBOX-WRITE-ERR-01: outbox.Write error must propagate ---
+
+func TestService_Create_OutboxWriteError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	writer := &recordingWriter{err: errors.New("outbox unavailable")}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+
+	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
+	require.Error(t, err, "Create must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
+}
+
+func TestService_Update_OutboxWriteError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	goodWriter := &recordingWriter{}
+	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(goodWriter), WithTxManager(&noopTxRunner{}))
+	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v1"})
+	require.NoError(t, err)
+
+	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(failWriter), WithTxManager(&noopTxRunner{}))
+
+	_, err = svc.Update(context.Background(), UpdateInput{Key: "k", Value: "v2"})
+	require.Error(t, err, "Update must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
+}
+
+func TestService_Delete_OutboxWriteError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	goodWriter := &recordingWriter{}
+	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(goodWriter), WithTxManager(&noopTxRunner{}))
+	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
+	require.NoError(t, err)
+
+	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
+	svc := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(failWriter), WithTxManager(&noopTxRunner{}))
+
+	err = svc.Delete(context.Background(), "k")
+	require.Error(t, err, "Delete must propagate outbox.Write error to preserve L2 atomicity")
+	assert.Contains(t, err.Error(), "outbox")
+}
+
+func TestService_Create_DurableMode_CapturesOutboxEntry(t *testing.T) {
+	svc, _, writer := newDurableTestService()
+
+	entry, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
+	require.NoError(t, err)
+	assert.Equal(t, "k", entry.Key)
+	require.Len(t, writer.entries, 1)
+	assert.Equal(t, TopicConfigChanged, writer.entries[0].EventType)
 }

--- a/cells/config-core/slices/featureflag/contract_test.go
+++ b/cells/config-core/slices/featureflag/contract_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ghbvf/gocell/pkg/contracttest"
 )
 
-// TODO(CFG-JSON-01 #16): handler outputs domain entities with PascalCase fields
-// instead of camelCase DTO. Invoking the real handler would fail schema validation.
-// Once #16 adds json tags and DTO mapping, rewrite these to invoke real handler
+// TODO(#8 Entity→DTO): handler outputs domain entities directly (PascalCase)
+// instead of DTO (camelCase). Invoking the real handler would fail schema
+// validation. Once #8 adds DTO mapping, rewrite these to invoke real handler
 // via httptest + ValidateHTTPResponseRecorder.
 
 func TestHttpConfigFlagsListV1Serve(t *testing.T) {

--- a/cells/config-core/slices/featureflag/contract_test.go
+++ b/cells/config-core/slices/featureflag/contract_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 // TODO(#8 Entity→DTO): handler outputs domain entities directly (PascalCase)
-// instead of DTO (camelCase). Invoking the real handler would fail schema
-// validation. Once #8 adds DTO mapping, rewrite these to invoke real handler
-// via httptest + ValidateHTTPResponseRecorder.
+// and response.schema.json follows correct camelCase convention. The two don't
+// match. Once #8 adds DTO mapping with json tags, rewrite these to invoke real
+// handler via httptest + ValidateHTTPResponseRecorder.
 
 func TestHttpConfigFlagsListV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()

--- a/cells/config-core/slices/featureflag/contract_test.go
+++ b/cells/config-core/slices/featureflag/contract_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/ghbvf/gocell/pkg/contracttest"
 )
 
+// TODO(CFG-JSON-01 #16): handler outputs domain entities with PascalCase fields
+// instead of camelCase DTO. Invoking the real handler would fail schema validation.
+// Once #16 adds json tags and DTO mapping, rewrite these to invoke real handler
+// via httptest + ValidateHTTPResponseRecorder.
+
 func TestHttpConfigFlagsListV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.flags.list.v1")

--- a/cells/device-cell/slices/device-register/contract_test.go
+++ b/cells/device-cell/slices/device-register/contract_test.go
@@ -1,25 +1,75 @@
 package deviceregister
 
 import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/stretchr/testify/require"
 )
+
+// --- contract test doubles ---
+
+type recordingPublisher struct {
+	calls []publishCall
+}
+
+type publishCall struct {
+	topic   string
+	payload []byte
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, topic string, payload []byte) error {
+	p.calls = append(p.calls, publishCall{topic: topic, payload: payload})
+	return nil
+}
+
+var _ outbox.Publisher = (*recordingPublisher)(nil)
+
+func newContractHandler() (http.Handler, *recordingPublisher) {
+	repo := mem.NewDeviceRepository()
+	pub := &recordingPublisher{}
+	svc := NewService(repo, pub, slog.Default())
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/devices", http.HandlerFunc(NewHandler(svc).HandleRegister))
+	return mux, pub
+}
 
 func TestHttpDeviceRegisterV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.device.register.v1")
+	h, _ := newContractHandler()
 
 	c.ValidateRequest(t, []byte(`{"name":"sensor-01"}`))
-	c.ValidateResponse(t, []byte(`{"data":{"id":"d-1","name":"sensor-01","status":"registered"}}`))
 	c.MustRejectRequest(t, []byte(`{"name":"a","extra":"bad"}`))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(`{"name":"sensor-01"}`))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
 }
 
 func TestEventDeviceRegisteredV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
+	httpContract := contracttest.LoadByID(t, root, "http.device.register.v1")
 	c := contracttest.LoadByID(t, root, "event.device-registered.v1")
+	h, pub := newContractHandler()
 
-	c.ValidatePayload(t, []byte(`{"id":"d-1","name":"sensor-01","status":"registered"}`))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(httpContract.HTTP.Method, httpContract.HTTP.Path, strings.NewReader(`{"name":"sensor-01"}`))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+	httpContract.ValidateHTTPResponseRecorder(t, rec)
+
+	require.Len(t, pub.calls, 1, "Register must publish one event")
+	c.ValidatePayload(t, pub.calls[0].payload)
 	c.MustRejectPayload(t, []byte(`{"id":"d-1"}`))
 	// Headers validation skipped: device-cell uses publisher.Publish directly
 	// (L4, no outbox.Entry per KG-07), so event_id is not emitted at transport level.

--- a/cells/device-cell/slices/device-status/contract_test.go
+++ b/cells/device-cell/slices/device-status/contract_test.go
@@ -1,15 +1,54 @@
 package devicestatus
 
 import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
+	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/stretchr/testify/require"
 )
+
+func newContractHandler() http.Handler {
+	repo := mem.NewDeviceRepository()
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-1", Name: "sensor-01", Status: "online",
+		LastSeen: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	svc := NewService(repo, slog.Default())
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/devices/{id}/status", http.HandlerFunc(NewHandler(svc).HandleGetStatus))
+	return mux
+}
 
 func TestHttpDeviceStatusV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.device.status.v1")
+	h := newContractHandler()
 
-	c.ValidateResponse(t, []byte(`{"data":{"id":"d-1","name":"sensor-01","status":"online","lastSeen":"2026-01-01T00:00:00Z"}}`))
+	path := strings.Replace(c.HTTP.Path, "{id}", "dev-1", 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	h.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
+
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
+}
+
+func TestHttpDeviceStatusV1Serve_NotFound(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.device.status.v1")
+	h := newContractHandler()
+
+	path := strings.Replace(c.HTTP.Path, "{id}", "no-such-id", 1)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	h.ServeHTTP(rec, req)
+	require.NotEqual(t, c.HTTP.SuccessStatus, rec.Code, "non-existent device must not return success")
 }

--- a/contracts/http/auth/login/v1/contract.yaml
+++ b/contracts/http/auth/login/v1/contract.yaml
@@ -7,6 +7,11 @@ endpoints:
   server: access-core
   clients:
     - edge-bff
+  http:
+    method: POST
+    path: /api/v1/access/sessions/login
+    successStatus: 201
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/auth/refresh/v1/contract.yaml
+++ b/contracts/http/auth/refresh/v1/contract.yaml
@@ -6,6 +6,11 @@ lifecycle: active
 endpoints:
   server: access-core
   clients: []
+  http:
+    method: POST
+    path: /api/v1/access/sessions/refresh
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/auth/session/delete/v1/contract.yaml
+++ b/contracts/http/auth/session/delete/v1/contract.yaml
@@ -1,0 +1,16 @@
+id: http.auth.session.delete.v1
+kind: http
+ownerCell: access-core
+consistencyLevel: L2
+lifecycle: active
+endpoints:
+  server: access-core
+  clients:
+    - edge-bff
+  http:
+    method: DELETE
+    path: /api/v1/access/sessions/{id}
+    successStatus: 204
+    noContent: true
+schemaRefs:
+  request: request.schema.json

--- a/contracts/http/auth/session/delete/v1/contract.yaml
+++ b/contracts/http/auth/session/delete/v1/contract.yaml
@@ -1,7 +1,7 @@
 id: http.auth.session.delete.v1
 kind: http
 ownerCell: access-core
-consistencyLevel: L2
+consistencyLevel: L1
 lifecycle: active
 endpoints:
   server: access-core

--- a/contracts/http/auth/session/delete/v1/request.schema.json
+++ b/contracts/http/auth/session/delete/v1/request.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.session.delete.v1.request",
+  "description": "DELETE carries no JSON fields. The session ID is supplied by the HTTP path parameter.",
+  "type": "object",
+  "maxProperties": 0,
+  "additionalProperties": false
+}

--- a/contracts/http/auth/user/get/v1/contract.yaml
+++ b/contracts/http/auth/user/get/v1/contract.yaml
@@ -7,6 +7,11 @@ endpoints:
   server: access-core
   clients:
     - edge-bff
+  http:
+    method: GET
+    path: /api/v1/access/users/{id}
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/auth/user/lock/v1/contract.yaml
+++ b/contracts/http/auth/user/lock/v1/contract.yaml
@@ -7,6 +7,11 @@ endpoints:
   server: access-core
   clients:
     - edge-bff
+  http:
+    method: POST
+    path: /api/v1/access/users/{id}/lock
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/auth/user/patch/v1/contract.yaml
+++ b/contracts/http/auth/user/patch/v1/contract.yaml
@@ -7,6 +7,11 @@ endpoints:
   server: access-core
   clients:
     - edge-bff
+  http:
+    method: PATCH
+    path: /api/v1/access/users/{id}
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/auth/user/unlock/v1/contract.yaml
+++ b/contracts/http/auth/user/unlock/v1/contract.yaml
@@ -7,6 +7,11 @@ endpoints:
   server: access-core
   clients:
     - edge-bff
+  http:
+    method: POST
+    path: /api/v1/access/users/{id}/unlock
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/auth/user/update/v1/contract.yaml
+++ b/contracts/http/auth/user/update/v1/contract.yaml
@@ -7,6 +7,11 @@ endpoints:
   server: access-core
   clients:
     - edge-bff
+  http:
+    method: PUT
+    path: /api/v1/access/users/{id}
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/config/flags/evaluate/v1/contract.yaml
+++ b/contracts/http/config/flags/evaluate/v1/contract.yaml
@@ -6,6 +6,11 @@ lifecycle: active
 endpoints:
   server: config-core
   clients: []
+  http:
+    method: POST
+    path: /api/v1/flags/{key}/evaluate
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/config/flags/get/v1/contract.yaml
+++ b/contracts/http/config/flags/get/v1/contract.yaml
@@ -6,6 +6,11 @@ lifecycle: active
 endpoints:
   server: config-core
   clients: []
+  http:
+    method: GET
+    path: /api/v1/flags/{key}
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/config/flags/list/v1/contract.yaml
+++ b/contracts/http/config/flags/list/v1/contract.yaml
@@ -6,6 +6,11 @@ lifecycle: active
 endpoints:
   server: config-core
   clients: []
+  http:
+    method: GET
+    path: /api/v1/flags
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/config/get/v1/contract.yaml
+++ b/contracts/http/config/get/v1/contract.yaml
@@ -7,6 +7,11 @@ endpoints:
   server: config-core
   clients:
     - access-core
+  http:
+    method: GET
+    path: /api/v1/config/{key}
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/device/register/v1/contract.yaml
+++ b/contracts/http/device/register/v1/contract.yaml
@@ -6,6 +6,11 @@ lifecycle: active
 endpoints:
   server: device-cell
   clients: []
+  http:
+    method: POST
+    path: /api/v1/devices
+    successStatus: 201
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/contracts/http/device/status/v1/contract.yaml
+++ b/contracts/http/device/status/v1/contract.yaml
@@ -6,6 +6,11 @@ lifecycle: active
 endpoints:
   server: device-cell
   clients: []
+  http:
+    method: GET
+    path: /api/v1/devices/{id}/status
+    successStatus: 200
+    noContent: false
 schemaRefs:
   request: request.schema.json
   response: response.schema.json

--- a/docs/reviews/202604151200-225-contract-correctness-review.md
+++ b/docs/reviews/202604151200-225-contract-correctness-review.md
@@ -1,0 +1,235 @@
+# PR #125 Review: fix/225-contract-correctness
+
+**Review baseline commit**: `491227a7190bfe69d39e90e229953ce81054999e`
+**Branch**: `fix/225-contract-correctness`
+**Date**: 2026-04-15
+
+---
+
+## Summary
+
+PR #125 addresses four contract correctness issues:
+1. (#27d) Error propagation from `publishEvent`/`publishChange`/`publish` to preserve L2 atomicity
+2. (#3) Added `endpoints.http` metadata to all 19 HTTP contracts, plus a new `http.auth.session.delete.v1` contract
+3. (#4) Rewrote `contract_test.go` in 8 slices to invoke real handlers/services
+4. (#22) Added explicit 204 No Content negative test
+
+---
+
+## Findings
+
+### S1 Architecture Consistency
+
+**S1-F1 [C2] Missing `http.auth.session.delete.v1` contract test in sessionlogout slice**
+
+The new contract `http.auth.session.delete.v1` is declared in `cells/access-core/slices/session-logout/slice.yaml` (line 4) with `role: serve`, and `verify.contract` lists `contract.http.auth.session.delete.v1.serve` (line 12). However, `cells/access-core/slices/sessionlogout/contract_test.go` contains only `TestEventSessionRevokedV1Publish` -- there is no test function that loads `http.auth.session.delete.v1` and validates HTTP request/response via `ValidateHTTPResponseRecorder`.
+
+The handler exists (`sessionlogout/handler.go` `HandleLogout`) and returns 204, and there is a handler_test.go that tests 204/404, but this is not a contract test -- it does not load the contract YAML or validate against the schema.
+
+Evidence:
+- `cells/access-core/slices/session-logout/slice.yaml:12`: `contract.http.auth.session.delete.v1.serve`
+- `cells/access-core/slices/sessionlogout/contract_test.go`: no reference to `http.auth.session.delete`
+
+Suggestion: Add a contract test similar to `TestHttpAuthUserDeleteV1Serve` in identitymanage that:
+1. Seeds a session
+2. Sends `DELETE /api/v1/access/sessions/{id}` via httptest
+3. Calls `c.ValidateHTTPResponseRecorder(t, rec)` against the loaded contract
+4. Asserts `c.ValidateRequest(t, []byte('{}'))` and `c.MustRejectRequest(t, []byte('{"unexpected":true}'))`
+
+---
+
+**S1-F2 [C3] `endpoints.http.clients` is empty on 10 of 19 HTTP contracts**
+
+Several HTTP contracts (`http.auth.refresh.v1`, `http.config.flags.*.v1`, `http.order.*.v1`, `http.device.*.v1`) declare `clients: []`. While this is syntactically valid, empty client lists weaken contract governance -- a contract with no declared consumers cannot be validated for cross-cell coverage.
+
+Evidence:
+- `contracts/http/auth/refresh/v1/contract.yaml:9`: `clients: []`
+- `contracts/http/config/flags/list/v1/contract.yaml:9`: `clients: []`
+- (and 8 others)
+
+Suggestion: Declare at least the intended consumer (e.g. `edge-bff`) or add a `lifecycle: draft` annotation to signal that client mappings are deferred.
+
+---
+
+**S1-F3 [C3] Consistency level on session delete contract may need review**
+
+`contracts/http/auth/session/delete/v1/contract.yaml` declares `consistencyLevel: L2`, which is correct because session revocation writes to the outbox. However, the other session-related HTTP contracts (`http.auth.login.v1`, `http.auth.refresh.v1`) declare `L1`. This asymmetry is semantically correct (login does not use outbox), but worth documenting the rationale for future maintainers.
+
+Evidence:
+- `contracts/http/auth/session/delete/v1/contract.yaml:4`: `consistencyLevel: L2`
+- `contracts/http/auth/login/v1/contract.yaml:4`: `consistencyLevel: L1`
+
+---
+
+### S2 Security / Permissions
+
+**S2-F1 [C3] New DELETE endpoint is covered by auth middleware**
+
+The integration test `TestAuthWiring_RealAssembly_ProtectedRoutes401` at `cmd/core-bundle/auth_integration_test.go:129` includes `{http.MethodDelete, "/api/v1/access/sessions/some-id"}` in the protected routes list. This confirms the new session-delete endpoint is behind JWT auth. No security issue found.
+
+---
+
+### S3 Testing / Regression
+
+**S3-F1 [C2] Missing outbox write error propagation test for sessionlogout**
+
+All other L2 services that got #27d fixes have explicit `OUTBOX-WRITE-ERR-01` tests:
+- `identitymanage/outbox_test.go:TestService_Create_OutboxWriteError`
+- `identitymanage/outbox_test.go:TestService_Lock_OutboxWriteError`
+- `configwrite/service_test.go:TestService_Create_OutboxWriteError` (and Update, Delete)
+- `configpublish/service_test.go:TestService_Publish_OutboxWriteError` (and Rollback)
+
+But `sessionlogout` has no such test, even though its `Logout()` method (service.go lines 88-98) does propagate outbox write errors.
+
+Evidence:
+- `cells/access-core/slices/sessionlogout/outbox_test.go`: no `OutboxWriteError` test
+- `cells/access-core/slices/sessionlogout/service.go:95-97`: `if writeErr := s.outboxWriter.Write(txCtx, entry); writeErr != nil { return fmt.Errorf(...) }`
+
+Suggestion: Add:
+```go
+func TestService_Logout_OutboxWriteError(t *testing.T) {
+    repo := mem.NewSessionRepository()
+    seedSession(repo, "sess-1", "usr-1")
+    failWriter := &stubOutboxWriter{err: errors.New("outbox unavailable")}
+    // add an err field to stubOutboxWriter as in identitymanage
+    svc := NewService(repo, eventbus.New(), slog.Default(),
+        WithOutboxWriter(failWriter), WithTxManager(&stubTxRunner{}))
+    err := svc.Logout(context.Background(), "sess-1")
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "outbox")
+}
+```
+
+---
+
+**S3-F2 [C3] 8 contract tests still use hardcoded JSON instead of real handlers**
+
+The PR rewrote 8 slices, but 8 remain with hardcoded JSON validation:
+- `sessionlogin/contract_test.go` -- hardcoded JSON for login response/session.created event
+- `sessionrefresh/contract_test.go` -- hardcoded JSON for refresh response
+- `configsubscribe/contract_test.go` -- hardcoded JSON for event payloads
+- `configread/contract_test.go` -- hardcoded JSON (with TODO #16)
+- `featureflag/contract_test.go` -- hardcoded JSON (with TODO #16)
+- `auditappend/contract_test.go` -- hardcoded JSON for event payloads
+- `auditverify/contract_test.go` -- hardcoded JSON for event payloads
+- `device-command/contract_test.go` -- hardcoded JSON for command schemas
+
+Some of these have valid reasons (configread/featureflag have TODO #16 for PascalCase issue). The event subscriber tests (auditappend, configsubscribe) legitimately validate schema acceptance only. But `sessionlogin` and `sessionrefresh` could invoke real handlers.
+
+This is not blocking; just noting the remaining gap for tracking.
+
+---
+
+**S3-F3 [C3] `capturingTB` nil-panic risk**
+
+In `cells/access-core/slices/identitymanage/contract_test.go` lines 273-279, `capturingTB` embeds `testing.TB` as a nil interface. It only implements `Helper()` and `Errorf()`. If `ValidateHTTPResponseRecorder` calls any other `testing.TB` method (e.g., `Logf`, `Name`, `Cleanup`), it will panic with a nil pointer dereference.
+
+Currently this is safe because the code path only calls `Errorf`/`Helper`. But it is fragile if `contracttest.go` is later modified.
+
+Evidence:
+- `contract_test.go:273-279`: `type capturingTB struct { testing.TB; errored bool }`
+
+Suggestion: Consider adding a `Fatalf` method (since `contracttest.go` uses `t.Fatalf` in `Load` paths, though those are not reached in this test). Or use a more robust testing double.
+
+---
+
+**S3-F4 [C3] Unused `httptest.NewRecorder()` call in unlock test**
+
+In `cells/access-core/slices/identitymanage/contract_test.go` line 199:
+```go
+httptest.NewRecorder()  // return value discarded
+lockReq := httptest.NewRequest(lockContract.HTTP.Method, lockPath, nil)
+handler.ServeHTTP(httptest.NewRecorder(), lockReq)
+```
+Line 199 creates a recorder whose return value is discarded. This is a minor waste but does not affect correctness.
+
+---
+
+### S4 Operations / Deployment
+
+**S4-F1 [C3] No migration or infrastructure changes**
+
+This PR is purely code + metadata (contract YAML). No Dockerfile, docker-compose, CI, or migration changes. No findings.
+
+---
+
+### S5 DX / Maintainability
+
+**S5-F1 [C2] Duplicate test double types across packages**
+
+The following types are reimplemented in multiple packages:
+- `recordingWriter` / `contractRecordingWriter` / `stubOutboxWriter`: defined in identitymanage, sessionlogout, configwrite, configpublish, order-create
+- `noopTxRunner` / `stubTxRunner` / `contractTxRunner`: defined in identitymanage, sessionlogout, configwrite, configpublish
+
+Each is ~10 lines. Having 5+ copies increases maintenance burden.
+
+Evidence:
+- `identitymanage/outbox_test.go:22-33` (stubOutboxWriter)
+- `identitymanage/contract_test.go:27-42` (contractRecordingWriter, contractTxRunner)
+- `sessionlogout/outbox_test.go:17-22` (stubOutboxWriter)
+- `configwrite/service_test.go:19-32` (recordingWriter)
+- `configpublish/service_test.go:21-34` (recordingWriter)
+
+Suggestion: Extract to a shared test helper package (e.g., `kernel/outbox/outboxtest` or `pkg/testutil`).
+
+---
+
+**S5-F2 [C3] Topic constant `TopicConfigChanged` is declared twice**
+
+`TopicConfigChanged = "event.config.changed.v1"` is declared in both:
+- `cells/config-core/slices/configwrite/service.go:22`
+- `cells/config-core/slices/configpublish/service.go:23`
+
+This violates the "string used >= 3 times must be a constant" rule -- the constant exists, but is duplicated across packages.
+
+Evidence:
+- `configwrite/service.go:22`: `TopicConfigChanged = "event.config.changed.v1"`
+- `configpublish/service.go:23`: `TopicConfigChanged = "event.config.changed.v1"`
+
+Suggestion: Define once in a shared location (e.g., `cells/config-core/topics.go` or `cells/config-core/internal/domain/topics.go`).
+
+---
+
+**S5-F3 [C3] Demo-mode publisher error is logged but comment says "not propagated"**
+
+In `identitymanage/service.go:235-239`, `configwrite/service.go:191-196`, and `configpublish/service.go:177-180`, when outboxWriter is nil (demo mode), publisher errors are logged but not returned. The code comment says "demo mode does not guarantee L2 atomicity" which is correct. However, the logging uses `slog.Error` level -- per observability rules, `Error` level is for correctness-affecting failures. In demo mode, this is a degraded operation, so `Warn` may be more appropriate.
+
+Evidence:
+- `identitymanage/service.go:236`: `s.logger.Error("identity-manage: failed to publish event",...)`
+- `configwrite/service.go:191`: `s.logger.Error("config-write: failed to publish event",...)`
+- `configpublish/service.go:178`: `s.logger.Error("config-publish: failed to publish event",...)`
+
+Suggestion: Use `slog.Warn` for demo-mode publisher failures, reserving `slog.Error` for real L2 atomicity violations.
+
+---
+
+### S6 Product / User Experience
+
+**S6-F1 [C3] Lock/Unlock API returns `{"data":{"status":"locked"}}` -- no user context**
+
+`identitymanage/handler.go:167` returns `{"data": {"status": "locked"}}` for lock, and `{"data": {"status": "active"}}` for unlock. This provides minimal feedback -- the user ID, username, and timestamps are not included. While the PR does not change this behavior, the contract test now validates against it. Consider including the full `UserResponse` DTO in a future iteration to match the pattern used by create/get/update/patch.
+
+Evidence:
+- `identitymanage/handler.go:167`: `httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": map[string]string{"status": "locked"}})`
+
+---
+
+## Findings Summary
+
+| ID | Seat | Severity | Description |
+|----|------|----------|-------------|
+| S1-F1 | Architecture | C2 | Missing contract test for `http.auth.session.delete.v1` |
+| S1-F2 | Architecture | C3 | Empty `clients: []` on 10 HTTP contracts |
+| S1-F3 | Architecture | C3 | L2 vs L1 consistency level asymmetry worth documenting |
+| S3-F1 | Testing | C2 | Missing outbox write error test for sessionlogout |
+| S3-F2 | Testing | C3 | 8 contract tests still use hardcoded JSON |
+| S3-F3 | Testing | C3 | `capturingTB` nil-panic risk if contracttest.go changes |
+| S3-F4 | Testing | C3 | Unused `httptest.NewRecorder()` return value |
+| S5-F1 | DX | C2 | Duplicate test double types across 5 packages |
+| S5-F2 | DX | C3 | `TopicConfigChanged` constant declared twice |
+| S5-F3 | DX | C3 | Demo-mode publisher errors logged at Error instead of Warn |
+| S6-F1 | Product | C3 | Lock/Unlock returns minimal status, no user context |
+
+**Totals**: 0 C1 (must fix), 3 C2 (should fix), 8 C3 (nice to have)
+
+**Verdict**: No blocking issues. The C2 findings (S1-F1, S3-F1, S5-F1) should be addressed before or shortly after merge. The PR achieves its stated goals: L2 atomicity is preserved, HTTP contract metadata is complete, and 8 contract tests now invoke real handlers.


### PR DESCRIPTION
## Summary

- **#27d OUTBOX-WRITE-ERR-01**: `publishEvent`/`publishChange`/`publish` now return `error` and propagate `outbox.Write` failures within `runInTx`, preserving L2 atomicity. Affects `configpublish`, `configwrite`, `identitymanage`. Demo-mode publisher errors remain log-only. ref: Watermill — errors always propagate.
- **#3 CONTRACT-OP-01**: Added `endpoints.http` metadata (method, path, successStatus, noContent) to all 11 HTTP contracts missing it. Created new `http.auth.session.delete.v1` contract + updated `session-logout/slice.yaml`. ref: go-zero — HTTP metadata drives validation.
- **#4 CONTRACT-TEST-02**: Rewrote `contract_test.go` in 8 slices to invoke real handlers/services via httptest and validate actual output against contract schemas, eliminating false-positive tests. `configread`/`featureflag` deferred to #16 (CFG-JSON-01 PascalCase). ref: Pact-Go — validate real output.
- **#22 DELETE-NOCONTENT-01**: Added explicit negative 204 semantic test proving the contract rejects responses with non-empty body.

## Files changed (30)

**Error propagation** (3 services + 3 test files):
- `cells/config-core/slices/configpublish/service.go` — `publishEvent` returns error
- `cells/config-core/slices/configwrite/service.go` — `publishChange` returns error  
- `cells/access-core/slices/identitymanage/service.go` — `publish` returns error
- `*_test.go` — 7 new outbox error propagation tests + test doubles

**HTTP metadata** (13 contract.yaml + 1 new contract + 1 schema + 1 slice.yaml):
- 11 existing `contracts/http/**/contract.yaml` — added `endpoints.http`
- `contracts/http/auth/session/delete/v1/` — new 204 contract
- `cells/access-core/slices/session-logout/slice.yaml` — added HTTP serve usage

**Contract test rewrites** (8 contract_test.go):
- `configpublish`, `configwrite` — invoke real Service, capture outbox entries
- `device-register`, `device-status` — invoke real HTTP handler via httptest
- `identitymanage` — expanded to all 7 HTTP + 2 event contracts with real handler
- `sessionlogout` — invoke real Service.Logout, capture outbox

## Test plan

- [x] `go build ./...` passes
- [x] All 7 outbox error propagation tests pass (TDD: failed before fix, pass after)
- [x] All 8 rewritten contract tests pass with real handler invocation
- [x] 204 negative semantic test passes
- [x] All existing tests in affected packages pass (28 packages)
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)