### PR TITLE
fix(auth): enforce session-bound JWT verification (P0-1)

### DIFF
--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -137,6 +137,9 @@ func NewAccessCore(opts ...Option) *AccessCore {
 
 // TokenVerifier returns the session-validate service (implements auth.TokenVerifier).
 func (c *AccessCore) TokenVerifier() auth.TokenVerifier {
+	if c.validateSvc == nil {
+		return nil
+	}
 	return c.validateSvc
 }
 

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -3,6 +3,7 @@ package accesscore
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -417,4 +418,87 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	_, err = verifier.Verify(ctx, accessToken)
 	require.Error(t, err, "token should be rejected after session revocation")
 	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN", "error should be auth invalid token")
+}
+
+// TestAccessCore_RefreshTokenRevocation_E2E verifies the refresh→validate→revoke
+// chain: login → refresh → validate refreshed token → revoke → verify rejected.
+func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	sessionRepo := mem.NewSessionRepository()
+	roleRepo := mem.NewRoleRepository()
+
+	c := NewAccessCore(
+		WithUserRepository(userRepo),
+		WithSessionRepository(sessionRepo),
+		WithRoleRepository(roleRepo),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
+	)
+	ctx := context.Background()
+	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any)}))
+
+	// Seed a user.
+	hash, _ := bcrypt.GenerateFromPassword([]byte("secret123"), bcrypt.DefaultCost)
+	user, err := domain.NewUser("refresh-user", "refresh@test.com", string(hash))
+	require.NoError(t, err)
+	user.ID = "usr-refresh"
+	require.NoError(t, userRepo.Create(ctx, user))
+
+	// Login via HTTP.
+	r := router.New()
+	c.RegisterRoutes(r)
+
+	loginBody := `{"username":"refresh-user","password":"secret123"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/sessions/login", strings.NewReader(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var loginResp struct {
+		Data struct {
+			AccessToken  string `json:"AccessToken"`
+			RefreshToken string `json:"RefreshToken"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &loginResp))
+
+	// Refresh via HTTP.
+	refreshBody := fmt.Sprintf(`{"refreshToken":%q}`, loginResp.Data.RefreshToken)
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/access/sessions/refresh", strings.NewReader(refreshBody))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "refresh should succeed: %s", rec.Body.String())
+
+	var refreshResp struct {
+		Data struct {
+			AccessToken string `json:"AccessToken"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &refreshResp))
+	refreshedToken := refreshResp.Data.AccessToken
+	require.NotEmpty(t, refreshedToken)
+
+	// Validate refreshed token through session-aware verifier.
+	verifier := c.TokenVerifier()
+	claims, err := verifier.Verify(ctx, refreshedToken)
+	require.NoError(t, err, "refreshed token should be valid")
+
+	sid := claims.Extra["sid"].(string)
+	require.NotEmpty(t, sid)
+
+	// Revoke the session.
+	sess, err := sessionRepo.GetByID(ctx, sid)
+	require.NoError(t, err)
+	sess.Revoke()
+	require.NoError(t, sessionRepo.Update(ctx, sess))
+
+	// Refreshed token should now be rejected.
+	_, err = verifier.Verify(ctx, refreshedToken)
+	require.Error(t, err, "refreshed token should be rejected after session revocation")
+	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN")
 }

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -34,6 +34,10 @@ func (noopTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) e
 
 var _ persistence.TxRunner = noopTxRunner{}
 
+// testPassword is a fixed test-only credential used to seed users in E2E tests.
+// Not a real secret — safe to appear in test source code.
+const testPassword = "secret123" //nolint:gosec // test-only credential
+
 var (
 	testKeySet, testPrivKey, _ = auth.MustNewTestKeySet()
 	testIssuer                 = mustIssuer(testKeySet)
@@ -371,7 +375,7 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any)}))
 
 	// Seed a user.
-	hash, _ := bcrypt.GenerateFromPassword([]byte("secret123"), bcrypt.DefaultCost)
+	hash, _ := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
 	user, err := domain.NewUser("e2e-user", "e2e@test.com", string(hash))
 	require.NoError(t, err)
 	user.ID = "usr-e2e"
@@ -381,7 +385,7 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	r := router.New()
 	c.RegisterRoutes(r)
 
-	body := `{"username":"e2e-user","password":"secret123"}`
+	body := fmt.Sprintf(`{"username":"e2e-user","password":%q}`, testPassword)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/sessions/login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -441,7 +445,7 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any)}))
 
 	// Seed a user.
-	hash, _ := bcrypt.GenerateFromPassword([]byte("secret123"), bcrypt.DefaultCost)
+	hash, _ := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
 	user, err := domain.NewUser("refresh-user", "refresh@test.com", string(hash))
 	require.NoError(t, err)
 	user.ID = "usr-refresh"
@@ -451,7 +455,7 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 	r := router.New()
 	c.RegisterRoutes(r)
 
-	loginBody := `{"username":"refresh-user","password":"secret123"}`
+	loginBody := fmt.Sprintf(`{"username":"refresh-user","password":%q}`, testPassword)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/sessions/login", strings.NewReader(loginBody))
 	req.Header.Set("Content-Type", "application/json")

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+
+	"golang.org/x/crypto/bcrypt"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
@@ -342,4 +345,76 @@ func TestAccessCore_RouteRolesList(t *testing.T) {
 
 	assert.NotEqual(t, http.StatusNotFound, rec.Code,
 		"GET /api/v1/access/roles/{userID} should not return 404 (got %d)", rec.Code)
+}
+
+// TestAccessCore_SessionRevocation_E2E verifies the complete session revocation
+// chain: login → token has sid → verify ok → revoke → verify rejected.
+func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
+	// Use separate repos so we can manipulate session state.
+	userRepo := mem.NewUserRepository()
+	sessionRepo := mem.NewSessionRepository()
+	roleRepo := mem.NewRoleRepository()
+
+	c := NewAccessCore(
+		WithUserRepository(userRepo),
+		WithSessionRepository(sessionRepo),
+		WithRoleRepository(roleRepo),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
+	)
+	ctx := context.Background()
+	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any)}))
+
+	// Seed a user.
+	hash, _ := bcrypt.GenerateFromPassword([]byte("secret123"), bcrypt.DefaultCost)
+	user, err := domain.NewUser("e2e-user", "e2e@test.com", string(hash))
+	require.NoError(t, err)
+	user.ID = "usr-e2e"
+	require.NoError(t, userRepo.Create(ctx, user))
+
+	// Login via HTTP handler to simulate real flow.
+	r := router.New()
+	c.RegisterRoutes(r)
+
+	body := `{"username":"e2e-user","password":"secret123"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/sessions/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code, "login should succeed: %s", rec.Body.String())
+
+	// Extract access token from response.
+	respBody := rec.Body.String()
+	// Parse JSON to extract accessToken — using simple string search.
+	var accessToken string
+	for _, part := range strings.Split(respBody, `"`) {
+		if strings.HasPrefix(part, "eyJ") {
+			accessToken = part
+			break
+		}
+	}
+	require.NotEmpty(t, accessToken, "should find JWT in login response")
+
+	// Verify token through session-aware verifier — should succeed.
+	verifier := c.TokenVerifier()
+	claims, err := verifier.Verify(ctx, accessToken)
+	require.NoError(t, err, "token should be valid before revocation")
+
+	sid, ok := claims.Extra["sid"].(string)
+	require.True(t, ok, "token must contain sid claim")
+	require.True(t, strings.HasPrefix(sid, "sess-"), "sid must start with sess-")
+
+	// Revoke the session.
+	sess, err := sessionRepo.GetByID(ctx, sid)
+	require.NoError(t, err)
+	sess.Revoke()
+	require.NoError(t, sessionRepo.Update(ctx, sess))
+
+	// Verify same token again — should be rejected.
+	_, err = verifier.Verify(ctx, accessToken)
+	require.Error(t, err, "token should be rejected after session revocation")
+	assert.Contains(t, err.Error(), "revoked", "error should mention revocation")
 }

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -2,6 +2,7 @@ package accesscore
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -386,17 +387,16 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code, "login should succeed: %s", rec.Body.String())
 
-	// Extract access token from response.
-	respBody := rec.Body.String()
-	// Parse JSON to extract accessToken — using simple string search.
-	var accessToken string
-	for _, part := range strings.Split(respBody, `"`) {
-		if strings.HasPrefix(part, "eyJ") {
-			accessToken = part
-			break
-		}
+	// Extract access token from response via structured JSON parsing.
+	var loginResp struct {
+		Data struct {
+			AccessToken  string `json:"AccessToken"`
+			RefreshToken string `json:"RefreshToken"`
+		} `json:"data"`
 	}
-	require.NotEmpty(t, accessToken, "should find JWT in login response")
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &loginResp), "should parse login response JSON")
+	accessToken := loginResp.Data.AccessToken
+	require.NotEmpty(t, accessToken, "login response must contain access token")
 
 	// Verify token through session-aware verifier — should succeed.
 	verifier := c.TokenVerifier()
@@ -416,5 +416,5 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	// Verify same token again — should be rejected.
 	_, err = verifier.Verify(ctx, accessToken)
 	require.Error(t, err, "token should be rejected after session revocation")
-	assert.Contains(t, err.Error(), "revoked", "error should mention revocation")
+	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN", "error should be auth invalid token")
 }

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -391,8 +391,8 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	// Extract access token from response via structured JSON parsing.
 	var loginResp struct {
 		Data struct {
-			AccessToken  string `json:"AccessToken"`
-			RefreshToken string `json:"RefreshToken"`
+			AccessToken  string `json:"accessToken"`
+			RefreshToken string `json:"refreshToken"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &loginResp), "should parse login response JSON")
@@ -460,8 +460,8 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 
 	var loginResp struct {
 		Data struct {
-			AccessToken  string `json:"AccessToken"`
-			RefreshToken string `json:"RefreshToken"`
+			AccessToken  string `json:"accessToken"`
+			RefreshToken string `json:"refreshToken"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &loginResp))
@@ -476,7 +476,7 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 
 	var refreshResp struct {
 		Data struct {
-			AccessToken string `json:"AccessToken"`
+			AccessToken string `json:"accessToken"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &refreshResp))

--- a/cells/access-core/slices/sessionlogin/service.go
+++ b/cells/access-core/slices/sessionlogin/service.go
@@ -123,12 +123,12 @@ func (s *Service) Login(ctx context.Context, input LoginInput) (*TokenPair, erro
 	expiresAt := now.Add(accessTokenTTL)
 	sessionID := "sess" + "-" + uuid.NewString()
 
-	accessToken, err := s.issueToken(user.ID, roleNames)
+	accessToken, err := s.issueToken(user.ID, roleNames, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("session-login: issue access token: %w", err)
 	}
 
-	refreshToken, err := s.issueToken(user.ID, nil)
+	refreshToken, err := s.issueToken(user.ID, nil, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("session-login: issue refresh token: %w", err)
 	}
@@ -190,6 +190,6 @@ func (s *Service) Login(ctx context.Context, input LoginInput) (*TokenPair, erro
 	}, nil
 }
 
-func (s *Service) issueToken(subject string, roles []string) (string, error) {
-	return s.issuer.Issue(subject, roles, []string{"gocell"})
+func (s *Service) issueToken(subject string, roles []string, sessionID string) (string, error) {
+	return s.issuer.Issue(subject, roles, []string{"gocell"}, sessionID)
 }

--- a/cells/access-core/slices/sessionlogin/service_test.go
+++ b/cells/access-core/slices/sessionlogin/service_test.go
@@ -3,6 +3,7 @@ package sessionlogin
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,4 +107,30 @@ func TestService_Login(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestService_Login_TokensContainSessionID(t *testing.T) {
+	svc, userRepo := newTestService()
+	seedUser(userRepo, "sid-user", "pass123")
+
+	// Need a verifier to decode the tokens.
+	verifier, err := auth.NewJWTVerifier(testKeySet)
+	require.NoError(t, err)
+
+	pair, err := svc.Login(context.Background(), LoginInput{Username: "sid-user", Password: "pass123"})
+	require.NoError(t, err)
+
+	// Access token must contain sid.
+	accessClaims, err := verifier.Verify(context.Background(), pair.AccessToken)
+	require.NoError(t, err)
+	sid, ok := accessClaims.Extra["sid"].(string)
+	assert.True(t, ok, "access token must contain sid claim")
+	assert.True(t, strings.HasPrefix(sid, "sess-"), "sid must start with sess-")
+
+	// Refresh token must contain same sid.
+	refreshClaims, err := verifier.Verify(context.Background(), pair.RefreshToken)
+	require.NoError(t, err)
+	refreshSid, ok := refreshClaims.Extra["sid"].(string)
+	assert.True(t, ok, "refresh token must contain sid claim")
+	assert.Equal(t, sid, refreshSid, "both tokens must share the same session ID")
 }

--- a/cells/access-core/slices/sessionrefresh/handler_test.go
+++ b/cells/access-core/slices/sessionrefresh/handler_test.go
@@ -20,7 +20,7 @@ import (
 // testIssuer/testVerifier are declared in service_test.go
 
 func issueRefreshToken(userID string) string {
-	tok, _ := testIssuer.Issue(userID, nil, []string{"gocell"}, "")
+	tok, _ := testIssuer.Issue(userID, nil, []string{"gocell"}, "sess-handler-test")
 	return tok
 }
 

--- a/cells/access-core/slices/sessionrefresh/handler_test.go
+++ b/cells/access-core/slices/sessionrefresh/handler_test.go
@@ -20,7 +20,7 @@ import (
 // testIssuer/testVerifier are declared in service_test.go
 
 func issueRefreshToken(userID string) string {
-	tok, _ := testIssuer.Issue(userID, nil, []string{"gocell"})
+	tok, _ := testIssuer.Issue(userID, nil, []string{"gocell"}, "")
 	return tok
 }
 

--- a/cells/access-core/slices/sessionrefresh/service.go
+++ b/cells/access-core/slices/sessionrefresh/service.go
@@ -108,12 +108,12 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*TokenPair,
 	now := time.Now()
 	expiresAt := now.Add(accessTokenTTL)
 
-	accessToken, err := s.issueToken(session.UserID, roleNames)
+	accessToken, err := s.issueToken(session.UserID, roleNames, session.ID)
 	if err != nil {
 		return nil, fmt.Errorf("session-refresh: issue access token: %w", err)
 	}
 
-	newRefreshToken, err := s.issueToken(session.UserID, nil)
+	newRefreshToken, err := s.issueToken(session.UserID, nil, session.ID)
 	if err != nil {
 		return nil, fmt.Errorf("session-refresh: issue refresh token: %w", err)
 	}
@@ -137,6 +137,6 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*TokenPair,
 	}, nil
 }
 
-func (s *Service) issueToken(subject string, roles []string) (string, error) {
-	return s.issuer.Issue(subject, roles, []string{"gocell"})
+func (s *Service) issueToken(subject string, roles []string, sessionID string) (string, error) {
+	return s.issuer.Issue(subject, roles, []string{"gocell"}, sessionID)
 }

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -39,7 +39,7 @@ func newTestService() (*Service, *mem.SessionRepository) {
 }
 
 func issueTestToken(sub string) string {
-	tok, _ := testIssuer.Issue(sub, nil, nil)
+	tok, _ := testIssuer.Issue(sub, nil, nil, "")
 	return tok
 }
 
@@ -142,7 +142,7 @@ func TestService_Refresh_SigningMethodCheck(t *testing.T) {
 	require.NoError(t, err)
 	otherIssuer, err := auth.NewJWTIssuer(otherKS, "gocell-access-core", time.Hour)
 	require.NoError(t, err)
-	tokenStr, _ := otherIssuer.Issue("usr-1", nil, nil)
+	tokenStr, _ := otherIssuer.Issue("usr-1", nil, nil, "")
 
 	_, err = svc.Refresh(context.Background(), tokenStr)
 	assert.Error(t, err, "should reject token signed with a different key")
@@ -192,4 +192,29 @@ func TestService_Refresh_ConcurrentRefresh(t *testing.T) {
 		"exactly one concurrent refresh should succeed")
 	assert.Equal(t, int64(goroutines-1), failures,
 		"remaining goroutines should fail")
+}
+
+func TestService_Refresh_NewTokensContainSessionID(t *testing.T) {
+	svc, repo := newTestService()
+
+	rt := issueTestToken("usr-sid")
+	sess, err := domain.NewSession("usr-sid", "at", rt, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	sess.ID = "sess-r1"
+	require.NoError(t, repo.Create(context.Background(), sess))
+
+	pair, err := svc.Refresh(context.Background(), rt)
+	require.NoError(t, err)
+
+	// Decode the new access token to verify sid.
+	verifier, err := auth.NewJWTVerifier(testKeySet)
+	require.NoError(t, err)
+
+	accessClaims, err := verifier.Verify(context.Background(), pair.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "sess-r1", accessClaims.Extra["sid"], "new access token must carry the session ID")
+
+	refreshClaims, err := verifier.Verify(context.Background(), pair.RefreshToken)
+	require.NoError(t, err)
+	assert.Equal(t, "sess-r1", refreshClaims.Extra["sid"], "new refresh token must carry the session ID")
 }

--- a/cells/access-core/slices/sessionvalidate/service.go
+++ b/cells/access-core/slices/sessionvalidate/service.go
@@ -37,8 +37,12 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 		return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid token")
 	}
 
-	// Check session revocation if sid claim is present in Extra.
-	if sid, ok := claims.Extra["sid"].(string); ok && sid != "" && s.sessionRepo != nil {
+	// Fail-closed: when sessionRepo is configured, tokens MUST carry sid.
+	if s.sessionRepo != nil {
+		sid, ok := claims.Extra["sid"].(string)
+		if !ok || sid == "" {
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "missing session binding (sid)")
+		}
 		session, err := s.sessionRepo.GetByID(ctx, sid)
 		if err != nil {
 			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "session not found")

--- a/cells/access-core/slices/sessionvalidate/service.go
+++ b/cells/access-core/slices/sessionvalidate/service.go
@@ -13,6 +13,10 @@ import (
 )
 
 
+// errMsgAuthFailed is the uniform error message for all session validation
+// failures. Using a single message prevents session-state enumeration attacks.
+const errMsgAuthFailed = "invalid or expired authentication token"
+
 // Compile-time check: Service implements auth.TokenVerifier.
 var _ auth.TokenVerifier = (*Service)(nil)
 
@@ -46,7 +50,7 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 		if !ok || sid == "" {
 			s.logger.Warn("session-validate: token missing sid",
 				slog.String("subject", claims.Subject))
-			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, errMsgAuthFailed)
 		}
 		session, err := s.sessionRepo.GetByID(ctx, sid)
 		if err != nil {
@@ -61,19 +65,19 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 					slog.String("subject", claims.Subject),
 					slog.Any("error", err))
 			}
-			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, errMsgAuthFailed)
 		}
 		if session.IsRevoked() {
 			s.logger.Warn("session-validate: revoked session used",
 				slog.String("sid", sid),
 				slog.String("subject", claims.Subject))
-			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, errMsgAuthFailed)
 		}
 		if session.IsExpired() {
 			s.logger.Warn("session-validate: expired session used",
 				slog.String("sid", sid),
 				slog.String("subject", claims.Subject))
-			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, errMsgAuthFailed)
 		}
 	}
 

--- a/cells/access-core/slices/sessionvalidate/service.go
+++ b/cells/access-core/slices/sessionvalidate/service.go
@@ -41,14 +41,28 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 	if s.sessionRepo != nil {
 		sid, ok := claims.Extra["sid"].(string)
 		if !ok || sid == "" {
-			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "missing session binding (sid)")
+			s.logger.Warn("session-validate: token missing sid",
+				slog.String("subject", claims.Subject))
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
 		}
 		session, err := s.sessionRepo.GetByID(ctx, sid)
 		if err != nil {
-			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "session not found")
+			s.logger.Warn("session-validate: session not found",
+				slog.String("sid", sid),
+				slog.String("subject", claims.Subject))
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
 		}
 		if session.IsRevoked() {
-			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "session has been revoked")
+			s.logger.Warn("session-validate: revoked session used",
+				slog.String("sid", sid),
+				slog.String("subject", claims.Subject))
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
+		}
+		if session.IsExpired() {
+			s.logger.Warn("session-validate: expired session used",
+				slog.String("sid", sid),
+				slog.String("subject", claims.Subject))
+			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
 		}
 	}
 

--- a/cells/access-core/slices/sessionvalidate/service.go
+++ b/cells/access-core/slices/sessionvalidate/service.go
@@ -4,6 +4,7 @@ package sessionvalidate
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
@@ -34,7 +35,9 @@ func NewService(verifier auth.TokenVerifier, sessionRepo ports.SessionRepository
 func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, error) {
 	claims, err := s.verifier.Verify(ctx, tokenStr)
 	if err != nil {
-		return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid token")
+		s.logger.Warn("session-validate: JWT verification failed",
+			slog.Any("error", err))
+		return auth.Claims{}, errcode.Wrap(errcode.ErrAuthInvalidToken, "invalid token", err)
 	}
 
 	// Fail-closed: when sessionRepo is configured, tokens MUST carry sid.
@@ -47,9 +50,17 @@ func (s *Service) Verify(ctx context.Context, tokenStr string) (auth.Claims, err
 		}
 		session, err := s.sessionRepo.GetByID(ctx, sid)
 		if err != nil {
-			s.logger.Warn("session-validate: session not found",
-				slog.String("sid", sid),
-				slog.String("subject", claims.Subject))
+			var ec *errcode.Error
+			if errors.As(err, &ec) {
+				s.logger.Warn("session-validate: session not found",
+					slog.String("sid", sid),
+					slog.String("subject", claims.Subject))
+			} else {
+				s.logger.Error("session-validate: session repo unavailable",
+					slog.String("sid", sid),
+					slog.String("subject", claims.Subject),
+					slog.Any("error", err))
+			}
 			return auth.Claims{}, errcode.New(errcode.ErrAuthInvalidToken, "invalid or expired authentication token")
 		}
 		if session.IsRevoked() {

--- a/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/cells/access-core/slices/sessionvalidate/service_test.go
@@ -53,6 +53,17 @@ func TestService_Verify(t *testing.T) {
 	revokedSession.Revoke()
 	require.NoError(t, sessionRepo.Create(context.Background(), revokedSession))
 
+	// Seed an expired session.
+	expiredSession := &domain.Session{
+		ID:           "sess-expired",
+		UserID:       "usr-3",
+		AccessToken:  "dummy3",
+		RefreshToken: "dummy-refresh3",
+		ExpiresAt:    time.Now().Add(-time.Hour), // already expired
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	require.NoError(t, sessionRepo.Create(context.Background(), expiredSession))
+
 	tests := []struct {
 		name    string
 		token   func() string
@@ -89,6 +100,14 @@ func TestService_Verify(t *testing.T) {
 			name: "token with non-existent session",
 			token: func() string {
 				tok, _ := IssueTestToken(testPrivKey, "usr-1", nil, time.Hour, "sess-nonexistent")
+				return tok
+			},
+			wantErr: true,
+		},
+		{
+			name: "token with expired session",
+			token: func() string {
+				tok, _ := IssueTestToken(testPrivKey, "usr-3", nil, time.Hour, "sess-expired")
 				return tok
 			},
 			wantErr: true,

--- a/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/cells/access-core/slices/sessionvalidate/service_test.go
@@ -65,7 +65,7 @@ func TestService_Verify(t *testing.T) {
 				return tok
 			},
 			wantSub: "usr-1",
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "valid token with active session",
@@ -131,7 +131,7 @@ func TestService_Verify(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantSub, claims.Subject)
-				if tt.name == "valid token without sid" || tt.name == "valid token with active session" {
+				if tt.name == "valid token with active session" {
 					assert.Contains(t, claims.Roles, "admin")
 				}
 				assert.Equal(t, "gocell-access-core", claims.Issuer)
@@ -145,6 +145,18 @@ func TestService_Verify_NilSessionRepo(t *testing.T) {
 	svc := NewService(testVerifier, nil, slog.Default())
 
 	tok, err := IssueTestToken(testPrivKey, "usr-1", nil, time.Hour, "sess-any")
+	require.NoError(t, err)
+
+	claims, err := svc.Verify(context.Background(), tok)
+	require.NoError(t, err)
+	assert.Equal(t, "usr-1", claims.Subject)
+}
+
+func TestService_Verify_NilSessionRepo_NoSid(t *testing.T) {
+	// When sessionRepo is nil (demo mode), tokens without sid are accepted.
+	svc := NewService(testVerifier, nil, slog.Default())
+
+	tok, err := IssueTestToken(testPrivKey, "usr-1", nil, time.Hour)
 	require.NoError(t, err)
 
 	claims, err := svc.Verify(context.Background(), tok)

--- a/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/cells/access-core/slices/sessionvalidate/service_test.go
@@ -2,6 +2,7 @@ package sessionvalidate
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -150,6 +151,35 @@ func TestService_Verify_NilSessionRepo(t *testing.T) {
 	claims, err := svc.Verify(context.Background(), tok)
 	require.NoError(t, err)
 	assert.Equal(t, "usr-1", claims.Subject)
+}
+
+// errorSessionRepo simulates infrastructure failures (DB timeout, connection reset).
+type errorSessionRepo struct{}
+
+func (errorSessionRepo) Create(_ context.Context, _ *domain.Session) error   { return nil }
+func (errorSessionRepo) GetByID(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, fmt.Errorf("db connection timeout")
+}
+func (errorSessionRepo) GetByRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, nil
+}
+func (errorSessionRepo) GetByPreviousRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, nil
+}
+func (errorSessionRepo) Update(_ context.Context, _ *domain.Session) error { return nil }
+func (errorSessionRepo) Delete(_ context.Context, _ string) error          { return nil }
+func (errorSessionRepo) RevokeByUserID(_ context.Context, _ string) error  { return nil }
+
+func TestService_Verify_DBError_FailsClosed(t *testing.T) {
+	// Infrastructure errors (not just "not found") must also fail-closed.
+	svc := NewService(testVerifier, errorSessionRepo{}, slog.Default())
+
+	tok, err := IssueTestToken(testPrivKey, "usr-1", nil, time.Hour, "sess-db-fail")
+	require.NoError(t, err)
+
+	_, err = svc.Verify(context.Background(), tok)
+	require.Error(t, err, "DB errors must cause verification failure (fail-closed)")
+	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN")
 }
 
 func TestService_Verify_NilSessionRepo_NoSid(t *testing.T) {

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -177,7 +177,7 @@ func main() {
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithHTTPAddr(":8080"),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
-		bootstrap.WithAuthMiddleware(jwtVerifier, publicEndpoints),
+		bootstrap.WithPublicEndpoints(publicEndpoints),
 	)
 
 	if err := app.Run(ctx); err != nil {

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -96,7 +96,9 @@ func NewJWTIssuer(keys SigningKeyProvider, issuer string, ttl time.Duration) (*J
 
 // Issue creates a signed JWT token for the given subject and roles.
 // The token header includes the kid of the active signing key.
-func (i *JWTIssuer) Issue(subject string, roles []string, audience []string) (string, error) {
+// When sessionID is non-empty, a "sid" claim is included to bind the token
+// to a specific session for revocation support.
+func (i *JWTIssuer) Issue(subject string, roles []string, audience []string, sessionID string) (string, error) {
 	if i.keys.SigningKey() == nil {
 		return "", errcode.New(errcode.ErrAuthKeyInvalid, "signing key is nil")
 	}
@@ -112,6 +114,9 @@ func (i *JWTIssuer) Issue(subject string, roles []string, audience []string) (st
 	}
 	if len(roles) > 0 {
 		claims["roles"] = roles
+	}
+	if sessionID != "" {
+		claims["sid"] = sessionID
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)

--- a/runtime/auth/jwt_test.go
+++ b/runtime/auth/jwt_test.go
@@ -39,7 +39,7 @@ func TestJWTIssuer_TokenHasKID(t *testing.T) {
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
 	require.NoError(t, err)
 
 	// Decode the token header to check kid.
@@ -60,7 +60,7 @@ func TestJWTIssuer_KIDMatchesThumbprint(t *testing.T) {
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
 	require.NoError(t, err)
 
 	// Parse without verification to inspect header.
@@ -80,7 +80,7 @@ func TestJWTVerifier_VerifiesByKID(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", []string{"admin"}, []string{"api"})
+	tokenStr, err := issuer.Issue("user-1", []string{"admin"}, []string{"api"}, "")
 	require.NoError(t, err)
 
 	claims, err := verifier.Verify(context.Background(), tokenStr)
@@ -100,7 +100,7 @@ func TestJWTVerifier_RejectsUnknownKID(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks2) // different key set
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = verifier.Verify(context.Background(), tokenStr)
@@ -139,7 +139,7 @@ func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", []string{"admin", "user"}, []string{"api"})
+	tokenStr, err := issuer.Issue("user-1", []string{"admin", "user"}, []string{"api"}, "")
 	require.NoError(t, err)
 
 	claims, err := verifier.Verify(context.Background(), tokenStr)
@@ -159,7 +159,7 @@ func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = verifier.Verify(context.Background(), tokenStr)
@@ -251,7 +251,7 @@ func TestJWTVerifier_WrongKey(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks2)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = verifier.Verify(context.Background(), tokenStr)
@@ -274,7 +274,7 @@ func TestJWTIssuer_RoundTrip(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("svc-audit", []string{"service"}, []string{"internal"})
+	tokenStr, err := issuer.Issue("svc-audit", []string{"service"}, []string{"internal"}, "")
 	require.NoError(t, err)
 
 	claims, err := verifier.Verify(context.Background(), tokenStr)
@@ -292,7 +292,7 @@ func TestJWTIssuer_NoRolesNoAudience(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-2", nil, nil)
+	tokenStr, err := issuer.Issue("user-2", nil, nil, "")
 	require.NoError(t, err)
 
 	claims, err := verifier.Verify(context.Background(), tokenStr)
@@ -355,7 +355,7 @@ func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
 
-	newTokenStr, err := issuer.Issue("user-new", nil, nil)
+	newTokenStr, err := issuer.Issue("user-new", nil, nil, "")
 	require.NoError(t, err)
 
 	claims, err = verifier.Verify(context.Background(), newTokenStr)
@@ -398,7 +398,7 @@ func TestJWTIssuer_AcceptsSigningKeyProvider(t *testing.T) {
 	issuer, err := NewJWTIssuer(stub, "gocell-test", time.Hour)
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue("user-1", []string{"admin"}, nil)
+	tokenStr, err := issuer.Issue("user-1", []string{"admin"}, nil, "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, tokenStr)
 
@@ -418,7 +418,7 @@ func TestJWTIssuer_EmptyKID_ProducesTokenWithEmptyKID(t *testing.T) {
 	require.NoError(t, err)
 
 	// Issue succeeds but produces a token with empty kid — verifier would reject it.
-	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, tokenStr)
 }
@@ -430,7 +430,7 @@ func TestJWTIssuer_NilKey_FailsToSign(t *testing.T) {
 	require.NoError(t, err)
 
 	// Sign should fail because the key is nil.
-	_, err = issuer.Issue("user-1", nil, nil)
+	_, err = issuer.Issue("user-1", nil, nil, "")
 	require.Error(t, err)
 }
 
@@ -443,7 +443,7 @@ func TestJWTVerifier_AcceptsVerificationKeyStore(t *testing.T) {
 	require.NoError(t, err)
 	issuer, err := NewJWTIssuer(ks, "gocell-test", time.Hour)
 	require.NoError(t, err)
-	tokenStr, err := issuer.Issue("user-1", nil, nil)
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
 	require.NoError(t, err)
 
 	// Verify using a stub store with only the public key.
@@ -533,6 +533,40 @@ func TestMapClaimsToClaims_EdgeCases(t *testing.T) {
 			tt.check(t, c)
 		})
 	}
+}
+
+// --- Session ID claim tests (P0-1 fix) ---
+
+func TestJWTIssuer_Issue_IncludesSessionID(t *testing.T) {
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(ks)
+	require.NoError(t, err)
+
+	tokenStr, err := issuer.Issue("user-1", []string{"admin"}, []string{"api"}, "sess-abc123")
+	require.NoError(t, err)
+
+	claims, err := verifier.Verify(context.Background(), tokenStr)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims.Subject)
+	assert.Equal(t, "sess-abc123", claims.Extra["sid"])
+}
+
+func TestJWTIssuer_Issue_EmptySessionID_OmitsSid(t *testing.T) {
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(ks)
+	require.NoError(t, err)
+
+	tokenStr, err := issuer.Issue("user-1", nil, nil, "")
+	require.NoError(t, err)
+
+	claims, err := verifier.Verify(context.Background(), tokenStr)
+	require.NoError(t, err)
+	_, hasSid := claims.Extra["sid"]
+	assert.False(t, hasSid, "empty sessionID should not produce a sid claim")
 }
 
 func TestLoadKeysFromEnv_PKCS8(t *testing.T) {

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -174,8 +174,14 @@ func WithAuthMiddleware(verifier auth.TokenVerifier, publicEndpoints []string) O
 // AuthProvider cell is discovered post-Init. Unlike WithAuthMiddleware
 // (which provides the verifier explicitly), this option defers verifier
 // resolution to Run() time.
+// WithPublicEndpoints must not be combined with WithAuthMiddleware —
+// use one or the other. If both are called, the last one wins for
+// publicEndpoints and a warning is logged at startup.
 func WithPublicEndpoints(endpoints []string) Option {
 	return func(b *Bootstrap) {
+		if b.authVerifier != nil {
+			slog.Warn("bootstrap: WithPublicEndpoints called after WithAuthMiddleware; publicEndpoints will be overwritten")
+		}
 		b.authPublicEndpoints = endpoints
 		b.authDiscovery = true
 	}
@@ -435,7 +441,7 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		return asm.Stop(c)
 	})
 
-	// Step 4.7: Discover auth verifier from cells (post-Init).
+	// Step 4.5a: Discover auth verifier from cells (post-Init).
 	// When no explicit verifier was provided via WithAuthMiddleware but
 	// publicEndpoints are configured via WithPublicEndpoints, discover a
 	// cell implementing authProvider and use its TokenVerifier.
@@ -455,7 +461,7 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		}
 	}
 
-	// Step 4.5: Register config watcher OnChange callback (now that asm is started).
+	// Step 4.5b: Register config watcher OnChange callback (now that asm is started).
 	// Snapshot → Reload → Diff → notify ConfigReloader cells.
 	if cfgWatcher != nil {
 		yamlPath, envPrefix := b.configPath, b.envPrefix

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -35,6 +35,12 @@ import (
 	"github.com/ghbvf/gocell/runtime/worker"
 )
 
+// authProvider is discovered post-Init from cells that provide a
+// session-aware TokenVerifier (e.g. access-core's TokenVerifier()).
+type authProvider interface {
+	TokenVerifier() auth.TokenVerifier
+}
+
 // Option configures a Bootstrap instance.
 type Option func(*Bootstrap)
 
@@ -143,7 +149,7 @@ func WithCircuitBreaker(cb middleware.CircuitBreakerPolicy) Option {
 }
 
 // WithAuthMiddleware enables authentication for HTTP business routes. The
-// verifier is forwarded to the router's middleware chain via
+// verifier is applied to the router's middleware chain at Run() time via
 // router.WithAuthMiddleware.
 //
 // publicEndpoints specifies business-route paths that bypass authentication.
@@ -159,7 +165,19 @@ func WithCircuitBreaker(cb middleware.CircuitBreakerPolicy) Option {
 // ref: go-zero — per-route WithJwt() opt-in auth
 func WithAuthMiddleware(verifier auth.TokenVerifier, publicEndpoints []string) Option {
 	return func(b *Bootstrap) {
-		b.routerOpts = append(b.routerOpts, router.WithAuthMiddleware(verifier, publicEndpoints))
+		b.authVerifier = verifier
+		b.authPublicEndpoints = publicEndpoints
+	}
+}
+
+// WithPublicEndpoints sets paths that bypass authentication when an
+// AuthProvider cell is discovered post-Init. Unlike WithAuthMiddleware
+// (which provides the verifier explicitly), this option defers verifier
+// resolution to Run() time.
+func WithPublicEndpoints(endpoints []string) Option {
+	return func(b *Bootstrap) {
+		b.authPublicEndpoints = endpoints
+		b.authDiscovery = true
 	}
 }
 
@@ -233,8 +251,11 @@ type Bootstrap struct {
 	workers         []worker.Worker
 	publisher       outbox.Publisher
 	subscriber      outbox.Subscriber
-	routerOpts      []router.Option
-	shutdownTimeout  time.Duration
+	routerOpts          []router.Option
+	authVerifier        auth.TokenVerifier
+	authPublicEndpoints []string
+	authDiscovery       bool // true when WithPublicEndpoints was called
+	shutdownTimeout     time.Duration
 	preShutdownDelay time.Duration
 	listener         net.Listener
 	healthCheckers             []namedChecker
@@ -414,6 +435,23 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		return asm.Stop(c)
 	})
 
+	// Step 4.7: Discover auth verifier from cells (post-Init).
+	// When no explicit verifier was provided via WithAuthMiddleware but
+	// publicEndpoints are configured via WithPublicEndpoints, discover a
+	// cell implementing authProvider and use its TokenVerifier.
+	if b.authVerifier == nil && b.authDiscovery {
+		for _, id := range asm.CellIDs() {
+			if ap, ok := asm.Cell(id).(authProvider); ok {
+				if v := ap.TokenVerifier(); v != nil {
+					b.authVerifier = v
+					slog.Info("bootstrap: auth verifier discovered from cell",
+						slog.String("cell", id))
+					break
+				}
+			}
+		}
+	}
+
 	// Step 4.5: Register config watcher OnChange callback (now that asm is started).
 	// Snapshot → Reload → Diff → notify ConfigReloader cells.
 	if cfgWatcher != nil {
@@ -527,9 +565,12 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	// the last call wins, so placing the framework handler after user options
 	// guarantees the bootstrap-managed handler is always used.
 	// Copy to avoid mutating b.routerOpts' backing array.
-	routerOpts := make([]router.Option, len(b.routerOpts)+1)
-	copy(routerOpts, b.routerOpts)
-	routerOpts[len(b.routerOpts)] = router.WithHealthHandler(hh)
+	routerOpts := make([]router.Option, 0, len(b.routerOpts)+2)
+	routerOpts = append(routerOpts, b.routerOpts...)
+	if b.authVerifier != nil {
+		routerOpts = append(routerOpts, router.WithAuthMiddleware(b.authVerifier, b.authPublicEndpoints))
+	}
+	routerOpts = append(routerOpts, router.WithHealthHandler(hh))
 	rtr, err := router.NewE(routerOpts...)
 	if err != nil {
 		return rollback(fmt.Errorf("bootstrap: %w", err))

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -450,6 +450,9 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 				}
 			}
 		}
+		if b.authVerifier == nil {
+			return rollback(fmt.Errorf("bootstrap: WithPublicEndpoints requires an auth provider cell, but none was discovered"))
+		}
 	}
 
 	// Step 4.5: Register config watcher OnChange callback (now that asm is started).

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -2418,3 +2418,29 @@ func TestBootstrap_WithAuthMiddleware_Precedence(t *testing.T) {
 		t.Fatal("bootstrap did not shut down in time")
 	}
 }
+
+func TestBootstrap_AuthDiscovery_NoProvider_FailsClosed(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Register a plain cell with no TokenVerifier method.
+	asm := assembly.New(assembly.Config{ID: "test-no-auth-provider"})
+	hc := newHTTPCell("plain-cell")
+	require.NoError(t, asm.Register(hc))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithPublicEndpoints([]string{"/api/v1/access/sessions/login"}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run should fail because no auth provider cell was discovered.
+	err = b.Run(ctx)
+	require.Error(t, err, "bootstrap should fail when no auth provider cell is discovered")
+	assert.Contains(t, err.Error(), "auth provider cell",
+		"error should mention missing auth provider")
+}

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -2239,3 +2239,182 @@ func TestBootstrap_TracingE2E_InfraEndpoints(t *testing.T) {
 	assert.Contains(t, logOutput, "trace_id",
 		"infra endpoint /healthz must have trace_id in access log when tracing is enabled")
 }
+
+// --- Auth Provider discovery (post-Init cell discovery) ---
+
+// authProviderCell implements HTTPRegistrar and exposes a TokenVerifier.
+type authProviderCell struct {
+	*cell.BaseCell
+	verifier auth.TokenVerifier
+}
+
+func newAuthProviderCell(id string, verifier auth.TokenVerifier) *authProviderCell {
+	return &authProviderCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore}),
+		verifier: verifier,
+	}
+}
+
+func (c *authProviderCell) TokenVerifier() auth.TokenVerifier {
+	return c.verifier
+}
+
+func (c *authProviderCell) RegisterRoutes(mux cell.RouteMux) {
+	mux.Handle("GET /api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":"ok"}`))
+	}))
+	mux.Handle("POST /api/v1/access/sessions/login", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":"login-ok"}`))
+	}))
+}
+
+func TestBootstrap_AuthDiscovery_ProtectedRoute_Returns401(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	asm := assembly.New(assembly.Config{ID: "test-auth-discovery-401"})
+	verifier := &bootstrapTestVerifier{
+		err: fmt.Errorf("no token provided"),
+	}
+	hc := newAuthProviderCell("access-core", verifier)
+	require.NoError(t, asm.Register(hc))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithPublicEndpoints(nil),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// Protected route without token -> 401.
+	resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/api/v1/data", addr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"discovered auth verifier must protect business routes")
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "ERR_AUTH_UNAUTHORIZED", errObj["code"])
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+func TestBootstrap_AuthDiscovery_PublicRoute_Passes(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	asm := assembly.New(assembly.Config{ID: "test-auth-discovery-public"})
+	verifier := &bootstrapTestVerifier{
+		err: fmt.Errorf("should not verify for public route"),
+	}
+	hc := newAuthProviderCell("access-core", verifier)
+	require.NoError(t, asm.Register(hc))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithPublicEndpoints([]string{"/api/v1/access/sessions/login"}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// Public login route without token -> should pass auth.
+	resp, err := testHTTPClient.Post(
+		fmt.Sprintf("http://%s/api/v1/access/sessions/login", addr),
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"public endpoint must be accessible without auth token via discovered verifier")
+	assert.Equal(t, int32(0), verifier.callCount.Load(),
+		"verifier must not be called for public endpoint")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+func TestBootstrap_WithAuthMiddleware_Precedence(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	asm := assembly.New(assembly.Config{ID: "test-auth-precedence"})
+
+	cellVerifier := &bootstrapTestVerifier{
+		err: fmt.Errorf("cell-verifier: should not be called"),
+	}
+	hc := newAuthProviderCell("access-core", cellVerifier)
+	require.NoError(t, asm.Register(hc))
+
+	explicitVerifier := &bootstrapTestVerifier{
+		claims: auth.Claims{Subject: "explicit-user", Roles: []string{"admin"}},
+	}
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithAuthMiddleware(explicitVerifier, nil),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// Send request WITH Authorization header — explicit verifier should handle it.
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/api/v1/data", addr), nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer test-token")
+
+	resp, err := testHTTPClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"explicit verifier should authenticate successfully")
+	assert.Equal(t, int32(1), explicitVerifier.callCount.Load(),
+		"explicit verifier must be called")
+	assert.Equal(t, int32(0), cellVerifier.callCount.Load(),
+		"cell verifier must NOT be called when explicit verifier is provided")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}


### PR DESCRIPTION
## Summary

- **JWTIssuer.Issue()** gains `sessionID` parameter → tokens carry `sid` claim bound to session
- **sessionvalidate.Service** switches to fail-closed: tokens without `sid` rejected when `sessionRepo` is configured; revoked/expired sessions cause 401
- **Bootstrap** discovers session-aware `TokenVerifier` from cells post-Init via `authProvider` interface (same pattern as `HTTPRegistrar`/`EventRegistrar`); new `WithPublicEndpoints` option replaces explicit `WithAuthMiddleware` in `main.go`

Fixes P0-1: session revocation bypass — logout had no effect because auth middleware used pure JWT signature verification without session state check.

ref: go-kratos/kratos middleware/auth/jwt — deferred keyFunc execution
ref: uber-go/fx — lifecycle OnStart phase ordering

## Commits (5)

1. **b5dfc43** — Core fix: Issue() + sid claim + sessionvalidate fail-closed + bootstrap discovery + WithPublicEndpoints
2. **16e1ec5** — Review R1: bootstrap fail-closed on no provider, security logging, IsExpired(), unified error messages, discovery failure test, json.Unmarshal in E2E
3. **91c6001** — Review R1: DB error branch test + refresh→validate→revoke E2E test
4. **405ff21** — Review R2: json tag fix, handler_test sid, DB error log levels, typed-nil guard, errcode.Wrap, step comments, option overlap warning
5. **b9154fa** — SonarCloud: extract errMsgAuthFailed + testPassword constants

## Files changed (15)

| Layer | File | Change |
|-------|------|--------|
| runtime/auth | jwt.go | Issue() +sessionID param, sid claim injection |
| runtime/auth | jwt_test.go | 2 new tests + 19 callers updated |
| cells/access-core | sessionvalidate/service.go | fail-closed sid enforcement + security logging + IsExpired + DB error分级 |
| cells/access-core | sessionvalidate/service_test.go | 4 new tests (no-sid, nil-repo, DB-error, expired-session) |
| cells/access-core | sessionlogin/service.go | issueToken passes sessionID |
| cells/access-core | sessionlogin/service_test.go | sid presence test |
| cells/access-core | sessionrefresh/service.go | issueToken passes session.ID |
| cells/access-core | sessionrefresh/service_test.go | sid presence test |
| cells/access-core | sessionrefresh/handler_test.go | Issue() call with real sid |
| cells/access-core | cell.go | TokenVerifier() typed-nil guard |
| cells/access-core | cell_test.go | 2 E2E tests (login+revoke, refresh+revoke) |
| runtime/bootstrap | bootstrap.go | authProvider interface + WithPublicEndpoints + cell discovery + fail-closed + step comments |
| runtime/bootstrap | bootstrap_test.go | 4 discovery tests |
| cmd/core-bundle | main.go | WithAuthMiddleware → WithPublicEndpoints |

## Test plan

- [x] `go test ./runtime/auth/...` — sid claim round-trip
- [x] `go test ./cells/access-core/slices/sessionvalidate/...` — fail-closed + expired + DB error
- [x] `go test ./cells/access-core/slices/sessionlogin/...` — login tokens carry sid
- [x] `go test ./cells/access-core/slices/sessionrefresh/...` — refreshed tokens carry sid
- [x] `go test ./runtime/bootstrap/...` — auth discovery + precedence + no-provider fail
- [x] `go test ./cells/access-core` — E2E: login→revoke + refresh→revoke
- [x] `go build ./...` — clean
- [x] `go test ./...` — full suite, zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)