### PR TITLE
fix(security): trust boundary hardening (#24+#27o+#27p+#27q+#27r)

### DIFF
--- a/cells/access-core/slices/rbaccheck/handler.go
+++ b/cells/access-core/slices/rbaccheck/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // RoleResponse is the public DTO for Role, isolating the API contract from the
@@ -49,6 +50,11 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("userID")
 
+	if err := auth.RequireSelfOrRole(r.Context(), userID, "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	roles, err := h.svc.ListRoles(r.Context(), userID)
 	if err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
@@ -64,6 +70,12 @@ func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleHasRole(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("userID")
+
+	if err := auth.RequireSelfOrRole(r.Context(), userID, "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	roleName := r.PathValue("roleName")
 
 	has, err := h.svc.HasRole(r.Context(), userID, roleName)

--- a/cells/access-core/slices/rbaccheck/handler_test.go
+++ b/cells/access-core/slices/rbaccheck/handler_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 func setup() http.Handler {
@@ -33,16 +35,26 @@ func setup() http.Handler {
 	return mux
 }
 
+// authCtx creates a context with the given subject and roles for auth testing.
+func authCtx(subject string, roles []string) context.Context {
+	ctx := ctxkeys.WithSubject(context.Background(), subject)
+	return auth.WithClaims(ctx, auth.Claims{Subject: subject, Roles: roles})
+}
+
 func TestHandler(t *testing.T) {
 	tests := []struct {
 		name       string
 		path       string
+		subject    string
+		roles      []string
 		wantStatus int
 		checkBody  func(t *testing.T, body []byte)
 	}{
 		{
-			name:       "GET /{userID} returns roles with permissions",
+			name:       "GET /{userID} self-access returns roles with permissions",
 			path:       "/user-1",
+			subject:    "user-1",
+			roles:      nil,
 			wantStatus: http.StatusOK,
 			checkBody: func(t *testing.T, body []byte) {
 				var resp struct {
@@ -64,8 +76,9 @@ func TestHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "GET /{userID} no roles returns empty",
+			name:       "GET /{userID} self-access no roles returns empty",
 			path:       "/unknown-user",
+			subject:    "unknown-user",
 			wantStatus: http.StatusOK,
 			checkBody: func(t *testing.T, body []byte) {
 				var resp struct {
@@ -76,8 +89,9 @@ func TestHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "GET /{userID}/{roleName} has role",
+			name:       "GET /{userID}/{roleName} self-access has role",
 			path:       "/user-1/admin",
+			subject:    "user-1",
 			wantStatus: http.StatusOK,
 			checkBody: func(t *testing.T, body []byte) {
 				var resp struct {
@@ -90,8 +104,9 @@ func TestHandler(t *testing.T) {
 			},
 		},
 		{
-			name:       "GET /{userID}/{roleName} missing role",
+			name:       "GET /{userID}/{roleName} self-access missing role",
 			path:       "/user-1/viewer",
+			subject:    "user-1",
 			wantStatus: http.StatusOK,
 			checkBody: func(t *testing.T, body []byte) {
 				var resp struct {
@@ -103,13 +118,45 @@ func TestHandler(t *testing.T) {
 				assert.False(t, resp.Data.HasRole)
 			},
 		},
+		// Trust boundary tests (#27r)
+		{
+			name:       "GET /{userID} admin bypass allowed",
+			path:       "/user-1",
+			subject:    "admin-user",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "GET /{userID} different user no admin returns 403",
+			path:       "/user-1",
+			subject:    "user-2",
+			roles:      []string{"viewer"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "GET /{userID}/{roleName} different user no admin returns 403",
+			path:       "/user-1/admin",
+			subject:    "user-2",
+			roles:      []string{"viewer"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "GET /{userID} no subject returns 401",
+			path:       "/user-1",
+			subject:    "", // no auth context
+			wantStatus: http.StatusUnauthorized,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			r := setup()
 			w := httptest.NewRecorder()
-			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.subject != "" {
+				req = req.WithContext(authCtx(tc.subject, tc.roles))
+			}
+			r.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.checkBody != nil {
 				tc.checkBody(t, w.Body.Bytes())

--- a/cells/access-core/slices/rbaccheck/handler_test.go
+++ b/cells/access-core/slices/rbaccheck/handler_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -33,12 +32,6 @@ func setup() http.Handler {
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux
-}
-
-// authCtx creates a context with the given subject and roles for auth testing.
-func authCtx(subject string, roles []string) context.Context {
-	ctx := ctxkeys.WithSubject(context.Background(), subject)
-	return auth.WithClaims(ctx, auth.Claims{Subject: subject, Roles: roles})
 }
 
 func TestHandler(t *testing.T) {
@@ -154,7 +147,7 @@ func TestHandler(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			if tc.subject != "" {
-				req = req.WithContext(authCtx(tc.subject, tc.roles))
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
 			}
 			r.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // AuditEntryResponse is the public DTO for AuditEntry, excluding internal
@@ -44,10 +46,32 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleQuery handles GET /api/v1/audit/entries.
 // Query parameters: eventType, actorId, from, to (RFC3339), limit, cursor.
+//
+// Trust boundary: non-admin users can only query their own audit entries.
+// If actorId is omitted, it defaults to the authenticated subject.
+// If actorId differs from subject, admin role is required.
 func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
+	subject, ok := ctxkeys.SubjectFrom(r.Context())
+	if !ok {
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized,
+			string(errcode.ErrAuthUnauthorized), "authentication required")
+		return
+	}
+
+	actorID := r.URL.Query().Get("actorId")
+	if actorID == "" {
+		actorID = subject
+	}
+	if actorID != subject {
+		if err := auth.RequireSelfOrRole(r.Context(), actorID, "admin"); err != nil {
+			httputil.WriteDomainError(r.Context(), w, err)
+			return
+		}
+	}
+
 	filters := ports.AuditFilters{
 		EventType: r.URL.Query().Get("eventType"),
-		ActorID:   r.URL.Query().Get("actorId"),
+		ActorID:   actorID,
 	}
 
 	if fromStr := r.URL.Query().Get("from"); fromStr != "" {

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -67,6 +67,10 @@ func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 			httputil.WriteDomainError(r.Context(), w, err)
 			return
 		}
+		slog.Info("audit: admin querying other user",
+			slog.String("admin", subject),
+			slog.String("target_actor", actorID),
+		)
 	}
 
 	filters := ports.AuditFilters{

--- a/cells/audit-core/slices/auditquery/handler_test.go
+++ b/cells/audit-core/slices/auditquery/handler_test.go
@@ -12,18 +12,11 @@ import (
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/mem"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// authCtx creates a context with the given subject and roles for auth testing.
-func authCtx(subject string, roles []string) context.Context {
-	ctx := ctxkeys.WithSubject(context.Background(), subject)
-	return auth.WithClaims(ctx, auth.Claims{Subject: subject, Roles: roles})
-}
 
 func TestHandleQuery_InvalidTimeFormat(t *testing.T) {
 	repo := mem.NewAuditRepository()
@@ -65,7 +58,7 @@ func TestHandleQuery_InvalidTimeFormat(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries"+tc.query, nil)
 			// Inject auth context so the handler doesn't reject with 401.
-			req = req.WithContext(authCtx("usr-1", []string{"admin"}))
+			req = req.WithContext(auth.TestContext("usr-1", []string{"admin"}))
 			h.HandleQuery(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -89,7 +82,7 @@ func TestHandleQuery_InvalidLimit(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries?limit=abc", nil)
-	req = req.WithContext(authCtx("usr-1", []string{"admin"}))
+	req = req.WithContext(auth.TestContext("usr-1", []string{"admin"}))
 	h.HandleQuery(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -103,7 +96,7 @@ func TestHandleQuery_ExceedsMaxLimit(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries?limit=501", nil)
-	req = req.WithContext(authCtx("usr-1", []string{"admin"}))
+	req = req.WithContext(auth.TestContext("usr-1", []string{"admin"}))
 	h.HandleQuery(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -138,7 +131,7 @@ func TestHandleQuery_Pagination_FullTraversal(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, url, nil)
 		// Self-access: subject matches actorId in data.
-		req = req.WithContext(authCtx("usr-1", nil))
+		req = req.WithContext(auth.TestContext("usr-1", nil))
 		h.HandleQuery(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
@@ -197,7 +190,7 @@ func TestHandleQuery_InvalidCursor(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries?cursor="+tc.cursor, nil)
-			req = req.WithContext(authCtx("usr-1", []string{"admin"}))
+			req = req.WithContext(auth.TestContext("usr-1", []string{"admin"}))
 			h.HandleQuery(w, req)
 
 			assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -298,7 +291,7 @@ func TestHandleQuery_ActorBinding(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries"+tc.query, nil)
 			if tc.subject != "" {
-				req = req.WithContext(authCtx(tc.subject, tc.roles))
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
 			}
 			h.HandleQuery(w, req)
 

--- a/cells/audit-core/slices/auditquery/handler_test.go
+++ b/cells/audit-core/slices/auditquery/handler_test.go
@@ -12,10 +12,18 @@ import (
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/mem"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// authCtx creates a context with the given subject and roles for auth testing.
+func authCtx(subject string, roles []string) context.Context {
+	ctx := ctxkeys.WithSubject(context.Background(), subject)
+	return auth.WithClaims(ctx, auth.Claims{Subject: subject, Roles: roles})
+}
 
 func TestHandleQuery_InvalidTimeFormat(t *testing.T) {
 	repo := mem.NewAuditRepository()
@@ -56,6 +64,8 @@ func TestHandleQuery_InvalidTimeFormat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries"+tc.query, nil)
+			// Inject auth context so the handler doesn't reject with 401.
+			req = req.WithContext(authCtx("usr-1", []string{"admin"}))
 			h.HandleQuery(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -79,6 +89,7 @@ func TestHandleQuery_InvalidLimit(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries?limit=abc", nil)
+	req = req.WithContext(authCtx("usr-1", []string{"admin"}))
 	h.HandleQuery(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -92,6 +103,7 @@ func TestHandleQuery_ExceedsMaxLimit(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries?limit=501", nil)
+	req = req.WithContext(authCtx("usr-1", []string{"admin"}))
 	h.HandleQuery(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -125,6 +137,8 @@ func TestHandleQuery_Pagination_FullTraversal(t *testing.T) {
 		}
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, url, nil)
+		// Self-access: subject matches actorId in data.
+		req = req.WithContext(authCtx("usr-1", nil))
 		h.HandleQuery(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
@@ -134,8 +148,8 @@ func TestHandleQuery_Pagination_FullTraversal(t *testing.T) {
 		for _, item := range data {
 			m := item.(map[string]any)
 			id, ok := m["id"].(string)
-				require.True(t, ok, "response item should have string 'id' field")
-				allIDs = append(allIDs, id)
+			require.True(t, ok, "response item should have string 'id' field")
+			allIDs = append(allIDs, id)
 		}
 
 		hasMore := resp["hasMore"].(bool)
@@ -183,6 +197,7 @@ func TestHandleQuery_InvalidCursor(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries?cursor="+tc.cursor, nil)
+			req = req.WithContext(authCtx("usr-1", []string{"admin"}))
 			h.HandleQuery(w, req)
 
 			assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -212,4 +227,88 @@ func TestAuditEntryResponse_ExcludesInternalFields(t *testing.T) {
 
 	assert.NotContains(t, body, `"prevHash"`)
 	assert.NotContains(t, body, `"hash"`)
+}
+
+// Trust boundary tests (#27q)
+func TestHandleQuery_ActorBinding(t *testing.T) {
+	repo := mem.NewAuditRepository()
+	svc := NewService(repo, testCodec(), slog.Default())
+	h := NewHandler(svc)
+
+	// Seed entries for two actors
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, repo.Append(context.Background(), &domain.AuditEntry{
+		ID: "ae-1", EventID: "evt-1", EventType: "event.test.v1",
+		ActorID: "usr-1", Timestamp: base, Payload: []byte("{}"),
+	}))
+	require.NoError(t, repo.Append(context.Background(), &domain.AuditEntry{
+		ID: "ae-2", EventID: "evt-2", EventType: "event.test.v1",
+		ActorID: "usr-2", Timestamp: base.Add(time.Hour), Payload: []byte("{}"),
+	}))
+
+	tests := []struct {
+		name       string
+		query      string
+		subject    string
+		roles      []string
+		wantStatus int
+		wantCount  int // -1 = don't check
+	}{
+		{
+			name:       "self actorId matches subject",
+			query:      "?actorId=usr-1",
+			subject:    "usr-1",
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name:       "no actorId defaults to subject",
+			query:      "",
+			subject:    "usr-1",
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name:       "other actorId without admin returns 403",
+			query:      "?actorId=usr-2",
+			subject:    "usr-1",
+			roles:      []string{"viewer"},
+			wantStatus: http.StatusForbidden,
+			wantCount:  -1,
+		},
+		{
+			name:       "other actorId with admin allowed",
+			query:      "?actorId=usr-2",
+			subject:    "admin-user",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name:       "no subject returns 401",
+			query:      "",
+			subject:    "",
+			wantStatus: http.StatusUnauthorized,
+			wantCount:  -1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries"+tc.query, nil)
+			if tc.subject != "" {
+				req = req.WithContext(authCtx(tc.subject, tc.roles))
+			}
+			h.HandleQuery(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantCount >= 0 {
+				var resp map[string]any
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				data := resp["data"].([]any)
+				assert.Len(t, data, tc.wantCount)
+			}
+		})
+	}
 }

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -51,8 +51,8 @@ func NewConfigRepository(db DBTX) *ConfigRepository {
 // Create inserts a new config entry.
 func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry) error {
 	const query = `INSERT INTO config_entries
-		(id, key, value, version, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6)`
+		(id, key, value, sensitive, version, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`
 
 	now := time.Now()
 	if entry.CreatedAt.IsZero() {
@@ -63,7 +63,7 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 	}
 
 	_, err := r.db.Exec(ctx, query,
-		entry.ID, entry.Key, entry.Value, entry.Version,
+		entry.ID, entry.Key, entry.Value, entry.Sensitive, entry.Version,
 		entry.CreatedAt, entry.UpdatedAt,
 	)
 	if err != nil {
@@ -76,13 +76,13 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 
 // GetByKey retrieves a config entry by key.
 func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.ConfigEntry, error) {
-	const query = `SELECT id, key, value, version, created_at, updated_at
+	const query = `SELECT id, key, value, sensitive, version, created_at, updated_at
 		FROM config_entries WHERE key = $1`
 
 	row := r.db.QueryRow(ctx, query, key)
 
 	var e domain.ConfigEntry
-	if err := row.Scan(&e.ID, &e.Key, &e.Value, &e.Version, &e.CreatedAt, &e.UpdatedAt); err != nil {
+	if err := row.Scan(&e.ID, &e.Key, &e.Value, &e.Sensitive, &e.Version, &e.CreatedAt, &e.UpdatedAt); err != nil {
 		return nil, errcode.Wrap(errcode.ErrConfigRepoNotFound,
 			fmt.Sprintf("config repo: key not found: %s", key), err)
 	}
@@ -93,15 +93,15 @@ func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.Co
 // Update updates an existing config entry.
 func (r *ConfigRepository) Update(ctx context.Context, entry *domain.ConfigEntry) error {
 	const query = `UPDATE config_entries
-		SET value = $1, version = $2, updated_at = $3
-		WHERE key = $4`
+		SET value = $1, sensitive = $2, version = $3, updated_at = $4
+		WHERE key = $5`
 
 	if entry.UpdatedAt.IsZero() {
 		entry.UpdatedAt = time.Now()
 	}
 
 	affected, err := r.db.Exec(ctx, query,
-		entry.Value, entry.Version, entry.UpdatedAt, entry.Key,
+		entry.Value, entry.Sensitive, entry.Version, entry.UpdatedAt, entry.Key,
 	)
 	if err != nil {
 		return errcode.Wrap(errcode.ErrConfigRepoQuery,
@@ -136,7 +136,7 @@ func (r *ConfigRepository) Delete(ctx context.Context, key string) error {
 // Requires composite index: CREATE INDEX idx_config_entries_key_id ON config_entries (key ASC, id ASC)
 func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([]*domain.ConfigEntry, error) {
 	b := query.NewBuilder()
-	b.Append("SELECT id, key, value, version, created_at, updated_at FROM config_entries WHERE 1=1")
+	b.Append("SELECT id, key, value, sensitive, version, created_at, updated_at FROM config_entries WHERE 1=1")
 
 	if err := query.AppendKeyset(b, params); err != nil {
 		return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: keyset build failed", err)
@@ -152,7 +152,7 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 	var entries []*domain.ConfigEntry
 	for rows.Next() {
 		var e domain.ConfigEntry
-		if err := rows.Scan(&e.ID, &e.Key, &e.Value, &e.Version, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.Key, &e.Value, &e.Sensitive, &e.Version, &e.CreatedAt, &e.UpdatedAt); err != nil {
 			return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: scan failed", err)
 		}
 		entries = append(entries, &e)

--- a/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -47,7 +47,7 @@ func TestConfigRepository_GetByKey(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "app.name", "GoCell", 1, now, now},
+			values: []any{"cfg-1", "app.name", "GoCell", false, 1, now, now},
 		},
 	}
 	repo := NewConfigRepository(db)
@@ -131,8 +131,8 @@ func TestConfigRepository_List(t *testing.T) {
 	db := &mockDB{
 		queryRows: &mockRowSet{
 			entries: []mockRowValues{
-				{values: []any{"cfg-1", "a.key", "val1", 1, now, now}},
-				{values: []any{"cfg-2", "b.key", "val2", 1, now, now}},
+				{values: []any{"cfg-1", "a.key", "val1", false, 1, now, now}},
+				{values: []any{"cfg-2", "b.key", "val2", false, 1, now, now}},
 			},
 		},
 	}
@@ -265,6 +265,8 @@ func (r *mockRow) Scan(dest ...any) error {
 			*d = v.(string)
 		case *int:
 			*d = v.(int)
+		case *bool:
+			*d = v.(bool)
 		case *[]byte:
 			*d = v.([]byte)
 		case *time.Time:
@@ -298,6 +300,8 @@ func (r *mockRowSet) Scan(dest ...any) error {
 			*d = v.(string)
 		case *int:
 			*d = v.(int)
+		case *bool:
+			*d = v.(bool)
 		case *[]byte:
 			*d = v.([]byte)
 		case *time.Time:

--- a/cells/config-core/internal/domain/config_entry.go
+++ b/cells/config-core/internal/domain/config_entry.go
@@ -8,6 +8,7 @@ type ConfigEntry struct {
 	ID        string
 	Key       string
 	Value     string
+	Sensitive bool // marks value as containing secrets (API keys, passwords, etc.)
 	Version   int
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/cells/config-core/internal/dto/config_entry.go
+++ b/cells/config-core/internal/dto/config_entry.go
@@ -8,21 +8,30 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 )
 
+// RedactedValue is the placeholder shown in API responses for sensitive config values.
+const RedactedValue = "******"
+
 // ConfigEntryResponse is the public DTO for ConfigEntry, isolating the API
-// contract from the domain model.
+// contract from the domain model. Sensitive values are redacted.
 type ConfigEntryResponse struct {
 	ID        string    `json:"id"`
 	Key       string    `json:"key"`
 	Value     string    `json:"value"`
+	Sensitive bool      `json:"sensitive"`
 	Version   int       `json:"version"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // ToConfigEntryResponse converts a domain.ConfigEntry to its API response DTO.
+// Sensitive values are replaced with RedactedValue.
 func ToConfigEntryResponse(e *domain.ConfigEntry) ConfigEntryResponse {
+	value := e.Value
+	if e.Sensitive {
+		value = RedactedValue
+	}
 	return ConfigEntryResponse{
-		ID: e.ID, Key: e.Key, Value: e.Value, Version: e.Version,
-		CreatedAt: e.CreatedAt, UpdatedAt: e.UpdatedAt,
+		ID: e.ID, Key: e.Key, Value: value, Sensitive: e.Sensitive,
+		Version: e.Version, CreatedAt: e.CreatedAt, UpdatedAt: e.UpdatedAt,
 	}
 }

--- a/cells/config-core/slices/configread/handler_test.go
+++ b/cells/config-core/slices/configread/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
@@ -191,4 +192,71 @@ func TestHandler_HandleList_InvalidCursor(t *testing.T) {
 			assert.Contains(t, w.Body.String(), "ERR_CURSOR_INVALID")
 		})
 	}
+}
+
+// Sensitive value redaction tests (#27o)
+func TestHandler_HandleGet_SensitiveRedacted(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-s1", Key: "db.password", Value: "s3cret!", Sensitive: true,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/db.password", nil)
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Data dto.ConfigEntryResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, dto.RedactedValue, resp.Data.Value)
+	assert.True(t, resp.Data.Sensitive)
+	assert.NotContains(t, w.Body.String(), "s3cret!")
+}
+
+func TestHandler_HandleGet_NonSensitiveVisible(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-n1", Key: "app.name", Value: "gocell", Sensitive: false,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/app.name", nil)
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Data dto.ConfigEntryResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "gocell", resp.Data.Value)
+	assert.False(t, resp.Data.Sensitive)
+}
+
+func TestHandler_HandleList_SensitiveRedacted(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-1", Key: "app.name", Value: "gocell", Sensitive: false,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-2", Key: "api.key", Value: "sk-secret-key-123", Sensitive: true,
+		Version: 1, CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "gocell")
+	assert.NotContains(t, body, "sk-secret-key-123")
+	assert.Contains(t, body, dto.RedactedValue)
 }

--- a/cells/config-core/slices/configwrite/handler.go
+++ b/cells/config-core/slices/configwrite/handler.go
@@ -20,15 +20,16 @@ func NewHandler(svc *Service) *Handler {
 // HandleCreate handles POST / — creates a new config entry.
 func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
+		Key       string `json:"key"`
+		Value     string `json:"value"`
+		Sensitive bool   `json:"sensitive"`
 	}
 	if err := httputil.DecodeJSONStrict(r, &req); err != nil {
 		httputil.WriteDecodeError(r.Context(), w, err)
 		return
 	}
 
-	entry, err := h.svc.Create(r.Context(), CreateInput{Key: req.Key, Value: req.Value})
+	entry, err := h.svc.Create(r.Context(), CreateInput{Key: req.Key, Value: req.Value, Sensitive: req.Sensitive})
 	if err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return

--- a/cells/config-core/slices/configwrite/handler_test.go
+++ b/cells/config-core/slices/configwrite/handler_test.go
@@ -2,6 +2,7 @@ package configwrite
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -170,6 +172,67 @@ func TestHandler_HandleDelete_NotFound(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- sensitive value redaction tests (#27o) ---
+
+func TestHandler_HandleCreate_SensitiveRedacted(t *testing.T) {
+	handler, _ := setupHandler()
+
+	w := httptest.NewRecorder()
+	body := `{"key":"db.password","value":"s3cret!","sensitive":true}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var resp struct {
+		Data dto.ConfigEntryResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, dto.RedactedValue, resp.Data.Value, "sensitive value must be redacted in response")
+	assert.True(t, resp.Data.Sensitive)
+	assert.NotContains(t, w.Body.String(), "s3cret!")
+}
+
+func TestHandler_HandleUpdate_SensitiveRedacted(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-s1", Key: "api.key", Value: "old-secret", Sensitive: true,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	w := httptest.NewRecorder()
+	body := `{"value":"new-secret"}`
+	req := httptest.NewRequest(http.MethodPut, "/api.key", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Data dto.ConfigEntryResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, dto.RedactedValue, resp.Data.Value, "sensitive value must be redacted in update response")
+	assert.NotContains(t, w.Body.String(), "new-secret")
+}
+
+func TestService_Create_SensitiveEventPayloadRedacted(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	ow := &stubOutboxWriter{}
+	svc := NewService(repo, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+
+	_, err := svc.Create(context.Background(), CreateInput{
+		Key: "db.password", Value: "s3cret!", Sensitive: true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, ow.entries, 1)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(ow.entries[0].Payload, &payload))
+	assert.Equal(t, "******", payload["value"], "sensitive value must be redacted in event payload")
+	assert.NotEqual(t, "s3cret!", payload["value"])
 }
 
 // --- outbox/tx service tests ---

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -58,8 +58,9 @@ func NewService(repo ports.ConfigRepository, pub outbox.Publisher, logger *slog.
 
 // CreateInput holds parameters for creating a config entry.
 type CreateInput struct {
-	Key   string
-	Value string
+	Key       string
+	Value     string
+	Sensitive bool
 }
 
 // Create creates a new config entry and publishes a change event.
@@ -73,6 +74,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.Config
 		ID:        "cfg" + "-" + uuid.NewString(),
 		Key:       input.Key,
 		Value:     input.Value,
+		Sensitive: input.Sensitive,
 		Version:   1,
 		CreatedAt: now,
 		UpdatedAt: now,

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -170,10 +170,14 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 }
 
 func (s *Service) publishChange(ctx context.Context, action string, entry *domain.ConfigEntry) error {
+	eventValue := entry.Value
+	if entry.Sensitive {
+		eventValue = "******"
+	}
 	payload, err := json.Marshal(map[string]any{
 		"action":  action,
 		"key":     entry.Key,
-		"value":   entry.Value,
+		"value":   eventValue,
 		"version": entry.Version,
 	})
 	if err != nil {

--- a/cells/device-cell/cell_test.go
+++ b/cells/device-cell/cell_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	"github.com/stretchr/testify/assert"
@@ -216,9 +218,12 @@ func TestDeviceCell_RouteListPendingCommands(t *testing.T) {
 	data := extractData(t, rec.Body.Bytes())
 	deviceID := data["id"].(string)
 
-	// List pending (should be empty).
+	// List pending (should be empty). Inject auth context: device authenticates as itself.
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/devices/"+deviceID+"/commands", nil)
+	ctx := ctxkeys.WithSubject(context.Background(), deviceID)
+	ctx = auth.WithClaims(ctx, auth.Claims{Subject: deviceID})
+	req = req.WithContext(ctx)
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -247,9 +252,12 @@ func TestDeviceCell_RouteAckCommand(t *testing.T) {
 	cmdData := extractData(t, rec.Body.Bytes())
 	cmdID := cmdData["id"].(string)
 
-	// Ack.
+	// Ack. Inject auth context: device authenticates as itself.
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/v1/devices/"+deviceID+"/commands/"+cmdID+"/ack", nil)
+	ackCtx := ctxkeys.WithSubject(context.Background(), deviceID)
+	ackCtx = auth.WithClaims(ackCtx, auth.Claims{Subject: deviceID})
+	req = req.WithContext(ackCtx)
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)

--- a/cells/device-cell/cell_test.go
+++ b/cells/device-cell/cell_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
@@ -221,9 +220,7 @@ func TestDeviceCell_RouteListPendingCommands(t *testing.T) {
 	// List pending (should be empty). Inject auth context: device authenticates as itself.
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/devices/"+deviceID+"/commands", nil)
-	ctx := ctxkeys.WithSubject(context.Background(), deviceID)
-	ctx = auth.WithClaims(ctx, auth.Claims{Subject: deviceID})
-	req = req.WithContext(ctx)
+	req = req.WithContext(auth.TestContext(deviceID, nil))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -255,9 +252,7 @@ func TestDeviceCell_RouteAckCommand(t *testing.T) {
 	// Ack. Inject auth context: device authenticates as itself.
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/v1/devices/"+deviceID+"/commands/"+cmdID+"/ack", nil)
-	ackCtx := ctxkeys.WithSubject(context.Background(), deviceID)
-	ackCtx = auth.WithClaims(ackCtx, auth.Claims{Subject: deviceID})
-	req = req.WithContext(ackCtx)
+	req = req.WithContext(auth.TestContext(deviceID, nil))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)

--- a/cells/device-cell/slices/device-command/handler.go
+++ b/cells/device-cell/slices/device-command/handler.go
@@ -45,6 +45,9 @@ type enqueueRequest struct {
 }
 
 // HandleEnqueue handles POST /api/v1/devices/{id}/commands.
+// No subject-deviceID check: this is an operator/management endpoint where
+// authenticated operators enqueue commands for any device they manage.
+// ListPending and Ack are device-facing (subject == deviceID).
 func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 	deviceID := r.PathValue("id")
 

--- a/cells/device-cell/slices/device-command/handler.go
+++ b/cells/device-cell/slices/device-command/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // CommandResponse is the public DTO for Command, isolating the API contract
@@ -64,8 +65,16 @@ func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 
 // HandleListPending handles GET /api/v1/devices/{id}/commands?limit=N&cursor=TOKEN.
 // Devices poll this endpoint to retrieve pending commands (L4 latent model).
+//
+// Trust boundary: subject must match deviceID (device authenticates as itself)
+// or hold admin role.
 func (h *Handler) HandleListPending(w http.ResponseWriter, r *http.Request) {
 	deviceID := r.PathValue("id")
+
+	if err := auth.RequireSelfOrRole(r.Context(), deviceID, "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
 
 	pageReq, err := httputil.ParsePageRequest(r)
 	if err != nil {
@@ -90,8 +99,16 @@ func (h *Handler) HandleListPending(w http.ResponseWriter, r *http.Request) {
 // Returns a status-only response (not a full CommandResponse) because
 // Ack is a fire-and-forget action — the service does not return the
 // updated entity.
+//
+// Trust boundary: subject must match deviceID or hold admin role.
 func (h *Handler) HandleAck(w http.ResponseWriter, r *http.Request) {
 	deviceID := r.PathValue("id")
+
+	if err := auth.RequireSelfOrRole(r.Context(), deviceID, "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	cmdID := r.PathValue("cmdId")
 
 	if err := h.svc.Ack(r.Context(), deviceID, cmdID); err != nil {

--- a/cells/device-cell/slices/device-command/handler_test.go
+++ b/cells/device-cell/slices/device-command/handler_test.go
@@ -428,11 +428,23 @@ func TestHandleAck_DeviceIDOR(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
+			name:       "admin bypass allowed",
+			subject:    "operator-1",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusOK,
+		},
+		{
 			name:       "different device returns 403",
 			subject:    "dev-2",
 			roles:      []string{"device"},
 			wantStatus: http.StatusForbidden,
 			wantCode:   "ERR_AUTH_FORBIDDEN",
+		},
+		{
+			name:       "no subject returns 401",
+			subject:    "",
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "ERR_AUTH_UNAUTHORIZED",
 		},
 	}
 
@@ -447,7 +459,9 @@ func TestHandleAck_DeviceIDOR(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/devices/dev-1/commands/cmd-idor/ack", nil)
 			req.SetPathValue("id", "dev-1")
 			req.SetPathValue("cmdId", "cmd-idor")
-			req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			if tc.subject != "" {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
 			h.HandleAck(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)

--- a/cells/device-cell/slices/device-command/handler_test.go
+++ b/cells/device-cell/slices/device-command/handler_test.go
@@ -370,6 +370,7 @@ func TestHandleListPending_DeviceIDOR(t *testing.T) {
 		subject    string
 		roles      []string
 		wantStatus int
+		wantCode   string
 	}{
 		{
 			name:       "self-access allowed",
@@ -390,12 +391,14 @@ func TestHandleListPending_DeviceIDOR(t *testing.T) {
 			subject:    "dev-2",
 			roles:      []string{"device"},
 			wantStatus: http.StatusForbidden,
+			wantCode:   "ERR_AUTH_FORBIDDEN",
 		},
 		{
 			name:       "no subject returns 401",
 			deviceID:   "dev-1",
 			subject:    "",
 			wantStatus: http.StatusUnauthorized,
+			wantCode:   "ERR_AUTH_UNAUTHORIZED",
 		},
 	}
 
@@ -411,6 +414,9 @@ func TestHandleListPending_DeviceIDOR(t *testing.T) {
 			h.HandleListPending(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantCode != "" {
+				assert.Contains(t, w.Body.String(), tc.wantCode)
+			}
 		})
 	}
 }
@@ -421,6 +427,7 @@ func TestHandleAck_DeviceIDOR(t *testing.T) {
 		subject    string
 		roles      []string
 		wantStatus int
+		wantCode   string
 	}{
 		{
 			name:       "self-access allowed",
@@ -432,6 +439,7 @@ func TestHandleAck_DeviceIDOR(t *testing.T) {
 			subject:    "dev-2",
 			roles:      []string{"device"},
 			wantStatus: http.StatusForbidden,
+			wantCode:   "ERR_AUTH_FORBIDDEN",
 		},
 	}
 
@@ -450,6 +458,9 @@ func TestHandleAck_DeviceIDOR(t *testing.T) {
 			h.HandleAck(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantCode != "" {
+				assert.Contains(t, w.Body.String(), tc.wantCode)
+			}
 		})
 	}
 }

--- a/cells/device-cell/slices/device-command/handler_test.go
+++ b/cells/device-cell/slices/device-command/handler_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -33,12 +32,6 @@ func setupCommandHandler() (*Handler, *mem.DeviceRepository, *mem.CommandReposit
 	})
 
 	return NewHandler(svc), devRepo, cmdRepo
-}
-
-// authCtx creates a context with the given subject and roles for auth testing.
-func authCtx(subject string, roles []string) context.Context {
-	ctx := ctxkeys.WithSubject(context.Background(), subject)
-	return auth.WithClaims(ctx, auth.Claims{Subject: subject, Roles: roles})
 }
 
 func TestHandleEnqueue(t *testing.T) {
@@ -113,7 +106,7 @@ func TestHandleListPending_InvalidLimit(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/devices/dev-1/commands?limit=abc", nil)
 	req.SetPathValue("id", "dev-1")
-	req = req.WithContext(authCtx("dev-1", nil))
+	req = req.WithContext(auth.TestContext("dev-1", nil))
 	h.HandleListPending(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -125,7 +118,7 @@ func TestHandleListPending_ExceedsMaxLimit(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/devices/dev-1/commands?limit=501", nil)
 	req.SetPathValue("id", "dev-1")
-	req = req.WithContext(authCtx("dev-1", nil))
+	req = req.WithContext(auth.TestContext("dev-1", nil))
 	h.HandleListPending(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -177,7 +170,7 @@ func TestHandleListPending(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/devices/"+tc.deviceID+"/commands", nil)
 			req.SetPathValue("id", tc.deviceID)
 			// Device authenticates as itself (self-access).
-			req = req.WithContext(authCtx(tc.deviceID, nil))
+			req = req.WithContext(auth.TestContext(tc.deviceID, nil))
 			h.HandleListPending(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -218,7 +211,7 @@ func TestHandleListPending_Pagination_FullTraversal(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, url, nil)
 		req.SetPathValue("id", "dev-1")
-		req = req.WithContext(authCtx("dev-1", nil))
+		req = req.WithContext(auth.TestContext("dev-1", nil))
 		h.HandleListPending(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
@@ -275,7 +268,7 @@ func TestHandleListPending_InvalidCursor(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/devices/dev-1/commands?cursor="+tc.cursor, nil)
 			req.SetPathValue("id", "dev-1")
-			req = req.WithContext(authCtx("dev-1", nil))
+			req = req.WithContext(auth.TestContext("dev-1", nil))
 			h.HandleListPending(w, req)
 
 			assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -322,7 +315,7 @@ func TestHandleAck(t *testing.T) {
 			req.SetPathValue("id", tc.deviceID)
 			req.SetPathValue("cmdId", tc.cmdID)
 			// Device authenticates as itself.
-			req = req.WithContext(authCtx(tc.deviceID, nil))
+			req = req.WithContext(auth.TestContext(tc.deviceID, nil))
 			h.HandleAck(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -409,7 +402,7 @@ func TestHandleListPending_DeviceIDOR(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/devices/"+tc.deviceID+"/commands", nil)
 			req.SetPathValue("id", tc.deviceID)
 			if tc.subject != "" {
-				req = req.WithContext(authCtx(tc.subject, tc.roles))
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
 			}
 			h.HandleListPending(w, req)
 
@@ -454,7 +447,7 @@ func TestHandleAck_DeviceIDOR(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/devices/dev-1/commands/cmd-idor/ack", nil)
 			req.SetPathValue("id", "dev-1")
 			req.SetPathValue("cmdId", "cmd-idor")
-			req = req.WithContext(authCtx(tc.subject, tc.roles))
+			req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
 			h.HandleAck(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)

--- a/cells/device-cell/slices/device-command/handler_test.go
+++ b/cells/device-cell/slices/device-command/handler_test.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // setupCommandHandler creates a Handler and seeds a device so that command operations succeed.
@@ -31,6 +33,12 @@ func setupCommandHandler() (*Handler, *mem.DeviceRepository, *mem.CommandReposit
 	})
 
 	return NewHandler(svc), devRepo, cmdRepo
+}
+
+// authCtx creates a context with the given subject and roles for auth testing.
+func authCtx(subject string, roles []string) context.Context {
+	ctx := ctxkeys.WithSubject(context.Background(), subject)
+	return auth.WithClaims(ctx, auth.Claims{Subject: subject, Roles: roles})
 }
 
 func TestHandleEnqueue(t *testing.T) {
@@ -105,6 +113,7 @@ func TestHandleListPending_InvalidLimit(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/devices/dev-1/commands?limit=abc", nil)
 	req.SetPathValue("id", "dev-1")
+	req = req.WithContext(authCtx("dev-1", nil))
 	h.HandleListPending(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -116,6 +125,7 @@ func TestHandleListPending_ExceedsMaxLimit(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/devices/dev-1/commands?limit=501", nil)
 	req.SetPathValue("id", "dev-1")
+	req = req.WithContext(authCtx("dev-1", nil))
 	h.HandleListPending(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -166,6 +176,8 @@ func TestHandleListPending(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/devices/"+tc.deviceID+"/commands", nil)
 			req.SetPathValue("id", tc.deviceID)
+			// Device authenticates as itself (self-access).
+			req = req.WithContext(authCtx(tc.deviceID, nil))
 			h.HandleListPending(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -206,6 +218,7 @@ func TestHandleListPending_Pagination_FullTraversal(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, url, nil)
 		req.SetPathValue("id", "dev-1")
+		req = req.WithContext(authCtx("dev-1", nil))
 		h.HandleListPending(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
@@ -215,8 +228,8 @@ func TestHandleListPending_Pagination_FullTraversal(t *testing.T) {
 		for _, item := range data {
 			m := item.(map[string]any)
 			id, ok := m["id"].(string)
-				require.True(t, ok, "response item should have string 'id' field")
-				allIDs = append(allIDs, id)
+			require.True(t, ok, "response item should have string 'id' field")
+			allIDs = append(allIDs, id)
 		}
 
 		hasMore := resp["hasMore"].(bool)
@@ -262,6 +275,7 @@ func TestHandleListPending_InvalidCursor(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/devices/dev-1/commands?cursor="+tc.cursor, nil)
 			req.SetPathValue("id", "dev-1")
+			req = req.WithContext(authCtx("dev-1", nil))
 			h.HandleListPending(w, req)
 
 			assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -307,6 +321,8 @@ func TestHandleAck(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/devices/"+tc.deviceID+"/commands/"+tc.cmdID+"/ack", nil)
 			req.SetPathValue("id", tc.deviceID)
 			req.SetPathValue("cmdId", tc.cmdID)
+			// Device authenticates as itself.
+			req = req.WithContext(authCtx(tc.deviceID, nil))
 			h.HandleAck(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -344,4 +360,96 @@ func TestCommandResponse_AckedAt_Serialization(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(b), `"ackedAt"`)
 	})
+}
+
+// Trust boundary tests (#27p)
+func TestHandleListPending_DeviceIDOR(t *testing.T) {
+	tests := []struct {
+		name       string
+		deviceID   string
+		subject    string
+		roles      []string
+		wantStatus int
+	}{
+		{
+			name:       "self-access allowed",
+			deviceID:   "dev-1",
+			subject:    "dev-1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "admin bypass allowed",
+			deviceID:   "dev-1",
+			subject:    "operator-1",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "different device returns 403",
+			deviceID:   "dev-1",
+			subject:    "dev-2",
+			roles:      []string{"device"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no subject returns 401",
+			deviceID:   "dev-1",
+			subject:    "",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, _ := setupCommandHandler()
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/devices/"+tc.deviceID+"/commands", nil)
+			req.SetPathValue("id", tc.deviceID)
+			if tc.subject != "" {
+				req = req.WithContext(authCtx(tc.subject, tc.roles))
+			}
+			h.HandleListPending(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestHandleAck_DeviceIDOR(t *testing.T) {
+	tests := []struct {
+		name       string
+		subject    string
+		roles      []string
+		wantStatus int
+	}{
+		{
+			name:       "self-access allowed",
+			subject:    "dev-1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "different device returns 403",
+			subject:    "dev-2",
+			roles:      []string{"device"},
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, cmdRepo := setupCommandHandler()
+			_ = cmdRepo.Create(context.Background(), &domain.Command{
+				ID: "cmd-idor", DeviceID: "dev-1", Payload: "reboot", Status: "pending",
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/devices/dev-1/commands/cmd-idor/ack", nil)
+			req.SetPathValue("id", "dev-1")
+			req.SetPathValue("cmdId", "cmd-idor")
+			req = req.WithContext(authCtx(tc.subject, tc.roles))
+			h.HandleAck(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -74,7 +74,7 @@
 | 21 | **Journey 校验** F-5 catalog 不校验引用 | 2h | `kernel/journey/catalog.go` | 6B |
 | 22 | **DELETE 无 body** DELETE-NOCONTENT-01: 204 + body=0 语义测试 | 1.5h | `contracts/http/auth/user/delete/v1/` | 6B |
 | 23 | **OTel 覆盖率** OTEL-COV-01 testcontainers 集成测试 | 1h | `adapters/otel/` | 6B |
-| 24 | **Trace trust policy** TRUST-POLICY-01: public-facing endpoint trust-boundary 策略（参考 otelhttp `WithPublicEndpoint`：new root + link），当前默认 trusted-upstream + **OBS-REQID-TRUST**: request_id middleware 无条件信任外部 `X-Request-Id`，需信任边界校验 | 4h | `runtime/http/middleware/tracing.go` + `request_id.go` | 5B PR#112 review + 217 tech-debt |
+| 24 | **Trace trust policy** TRUST-POLICY-01: public-facing endpoint trust-boundary 策略（参考 otelhttp `WithPublicEndpoint`：new root + link），当前默认 trusted-upstream + **OBS-REQID-TRUST**: request_id middleware 无条件信任外部 `X-Request-Id`，需信任边界校验 | 4h | `runtime/http/middleware/tracing.go` + `request_id.go` | 5B PR#112 review + 217 tech-debt | ✅ PR#127 |
 | 25 | **HSTS 加固** C-H4: `security_headers.go` 补 `includeSubDomains` | 0.5h | `runtime/http/middleware/security_headers.go` | P2 tech-debt |
 | 26 | **.env.example 补全** ENV-S3: 补 `GOCELL_S3_REGION=us-east-1` — `s3.Config.Validate()` 必填但示例缺失 | 0.5h | `.env.example` | P4 review |
 | 27 | **examples contract CI** INT-2: order-cell/device-cell contract YAML 存在且被 slice.yaml 引用，但 CI 未校验 | 1h | `.github/workflows/ci.yml` | P4 review |

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -10,6 +10,9 @@ import (
 // RequireSelfOrRole checks that the authenticated subject matches targetID
 // or holds one of the specified bypass roles. Returns nil on success.
 //
+// ref: go-kratos/kratos middleware/auth/auth.go — adopted: subject-from-context
+// pattern; deviated: combined self+role check instead of separate authz middleware.
+//
 // Errors:
 //   - ErrAuthUnauthorized: no subject in context (auth middleware did not run)
 //   - ErrAuthForbidden: subject does not match targetID and lacks bypass roles

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// RequireSelfOrRole checks that the authenticated subject matches targetID
+// or holds one of the specified bypass roles. Returns nil on success.
+//
+// Errors:
+//   - ErrAuthUnauthorized: no subject in context (auth middleware did not run)
+//   - ErrAuthForbidden: subject does not match targetID and lacks bypass roles
+func RequireSelfOrRole(ctx context.Context, targetID string, bypassRoles ...string) error {
+	subject, ok := ctxkeys.SubjectFrom(ctx)
+	if !ok || subject == "" {
+		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
+	}
+
+	if targetID != "" && subject == targetID {
+		return nil
+	}
+
+	if len(bypassRoles) > 0 {
+		claims, hasClaims := ClaimsFrom(ctx)
+		if hasClaims {
+			roleSet := make(map[string]bool, len(bypassRoles))
+			for _, r := range bypassRoles {
+				roleSet[r] = true
+			}
+			for _, r := range claims.Roles {
+				if roleSet[r] {
+					return nil
+				}
+			}
+		}
+	}
+
+	return errcode.New(errcode.ErrAuthForbidden, "access denied")
+}

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -22,24 +23,48 @@ func RequireSelfOrRole(ctx context.Context, targetID string, bypassRoles ...stri
 		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
 	}
 
+	if targetID == "" {
+		slog.Warn("authz: RequireSelfOrRole called with empty targetID",
+			slog.String("subject", subject))
+	}
+
 	if targetID != "" && subject == targetID {
 		return nil
 	}
 
-	if len(bypassRoles) > 0 {
-		claims, hasClaims := ClaimsFrom(ctx)
-		if hasClaims {
-			roleSet := make(map[string]bool, len(bypassRoles))
-			for _, r := range bypassRoles {
-				roleSet[r] = true
-			}
-			for _, r := range claims.Roles {
-				if roleSet[r] {
-					return nil
-				}
-			}
-		}
+	if hasAnyRole(ctx, bypassRoles) {
+		return nil
 	}
 
 	return errcode.New(errcode.ErrAuthForbidden, "access denied")
+}
+
+// hasAnyRole checks whether the authenticated Claims in ctx carry at least
+// one of the specified roles. Returns false when roles is empty, Claims are
+// absent, or no role matches.
+func hasAnyRole(ctx context.Context, roles []string) bool {
+	if len(roles) == 0 {
+		return false
+	}
+	claims, ok := ClaimsFrom(ctx)
+	if !ok {
+		return false
+	}
+	roleSet := make(map[string]bool, len(roles))
+	for _, r := range roles {
+		roleSet[r] = true
+	}
+	for _, r := range claims.Roles {
+		if roleSet[r] {
+			return true
+		}
+	}
+	return false
+}
+
+// TestContext creates a context carrying the given subject and roles for use
+// in handler tests across cells/. Follows the net/http/httptest naming pattern.
+func TestContext(subject string, roles []string) context.Context {
+	ctx := ctxkeys.WithSubject(context.Background(), subject)
+	return WithClaims(ctx, Claims{Subject: subject, Roles: roles})
 }

--- a/runtime/auth/authz_test.go
+++ b/runtime/auth/authz_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireSelfOrRole(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		targetID   string
+		roles      []string
+		wantErr    bool
+		wantCode   errcode.Code
+	}{
+		{
+			name:     "self-access allowed",
+			ctx:      withSubjectAndClaims("user-1", nil),
+			targetID: "user-1",
+			roles:    []string{"admin"},
+			wantErr:  false,
+		},
+		{
+			name:     "admin bypass allowed",
+			ctx:      withSubjectAndClaims("user-2", []string{"admin"}),
+			targetID: "user-1",
+			roles:    []string{"admin"},
+			wantErr:  false,
+		},
+		{
+			name:     "different user no admin denied",
+			ctx:      withSubjectAndClaims("user-2", []string{"viewer"}),
+			targetID: "user-1",
+			roles:    []string{"admin"},
+			wantErr:  true,
+			wantCode: errcode.ErrAuthForbidden,
+		},
+		{
+			name:     "missing subject denied",
+			ctx:      context.Background(),
+			targetID: "user-1",
+			roles:    []string{"admin"},
+			wantErr:  true,
+			wantCode: errcode.ErrAuthUnauthorized,
+		},
+		{
+			name:     "empty targetID denied",
+			ctx:      withSubjectAndClaims("user-1", nil),
+			targetID: "",
+			roles:    []string{"admin"},
+			wantErr:  true,
+			wantCode: errcode.ErrAuthForbidden,
+		},
+		{
+			name:     "multiple bypass roles second matches",
+			ctx:      withSubjectAndClaims("user-2", []string{"operator"}),
+			targetID: "user-1",
+			roles:    []string{"admin", "operator"},
+			wantErr:  false,
+		},
+		{
+			name:     "no bypass roles specified only self allowed",
+			ctx:      withSubjectAndClaims("user-2", []string{"admin"}),
+			targetID: "user-1",
+			roles:    nil,
+			wantErr:  true,
+			wantCode: errcode.ErrAuthForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireSelfOrRole(tc.ctx, tc.targetID, tc.roles...)
+			if !tc.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr))
+			assert.Equal(t, tc.wantCode, ecErr.Code)
+		})
+	}
+}
+
+func withSubjectAndClaims(subject string, roles []string) context.Context {
+	ctx := ctxkeys.WithSubject(context.Background(), subject)
+	ctx = WithClaims(ctx, Claims{Subject: subject, Roles: roles})
+	return ctx
+}

--- a/runtime/http/middleware/tracing.go
+++ b/runtime/http/middleware/tracing.go
@@ -4,7 +4,25 @@ import (
 	"net/http"
 
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
+
+// TracingOption configures the Tracing middleware.
+type TracingOption func(*tracingConfig)
+
+type tracingConfig struct {
+	publicEndpointFn func(*http.Request) bool
+}
+
+// WithPublicEndpointFn sets a per-request function that determines whether an
+// endpoint is public-facing (untrusted upstream). When it returns true, the
+// middleware creates a new root trace instead of continuing the upstream trace.
+// The remote span context is recorded as linked attributes for correlation.
+//
+// ref: otelhttp WithPublicEndpointFn — new root + trace.Link to remote context
+func WithPublicEndpointFn(fn func(*http.Request) bool) TracingOption {
+	return func(c *tracingConfig) { c.publicEndpointFn = fn }
+}
 
 // Tracing creates an HTTP middleware that starts a span for each request.
 // The span is initially named "{method} {path}" and renamed to
@@ -25,18 +43,45 @@ import (
 // used only as a fallback. Invalid headers are ignored and result in a new
 // root span.
 //
+// For public-facing endpoints (determined by WithPublicEndpointFn), inbound
+// trace context is NOT inherited. A new root trace is created and the remote
+// context is recorded as linked attributes (linked.trace_id, linked.span_id).
+//
 // When a RecorderState exists in the context (created by the Recorder
 // middleware), Tracing reuses it. Otherwise it creates its own to
 // capture http.status_code as a standalone middleware.
-func Tracing(tracer tracing.Tracer) func(http.Handler) http.Handler {
+func Tracing(tracer tracing.Tracer, opts ...TracingOption) func(http.Handler) http.Handler {
+	var cfg tracingConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := extractTraceContext(r.Context(), r.Header)
+			ctx := r.Context()
+
+			isPublic := cfg.publicEndpointFn != nil && cfg.publicEndpointFn(r)
+
+			// Extract remote span context for linking (before deciding to use it).
+			extractedCtx := extractTraceContext(ctx, r.Header)
+			remoteSpanCtx := oteltrace.SpanContextFromContext(extractedCtx)
+
+			if !isPublic {
+				// Trusted upstream: continue the upstream trace.
+				ctx = extractedCtx
+			}
+			// Public endpoint: ctx stays clean → tracer creates new root.
 
 			// Start span with tentative name using raw path.
 			// After routing, the span is renamed to use the route pattern.
 			ctx, span := tracer.Start(ctx, r.Method+" "+r.URL.Path)
 			defer span.End()
+
+			// Record linked remote context for public endpoints.
+			if isPublic && remoteSpanCtx.IsValid() && remoteSpanCtx.IsRemote() {
+				span.SetAttribute("linked.trace_id", remoteSpanCtx.TraceID().String())
+				span.SetAttribute("linked.span_id", remoteSpanCtx.SpanID().String())
+			}
 
 			state := RecorderStateFrom(ctx)
 			if state == nil {

--- a/runtime/http/middleware/tracing_test.go
+++ b/runtime/http/middleware/tracing_test.go
@@ -315,3 +315,87 @@ func TestTracing_2xxDoesNotSetErrorSpanStatus(t *testing.T) {
 	assert.Nil(t, spans[0].Attr("_status_error"),
 		"2xx must not set span status to error")
 }
+
+// --- Public endpoint trust boundary tests (#24 TRUST-POLICY-01) ---
+
+func TestTracing_PublicEndpoint_NewRootTrace(t *testing.T) {
+	spy := &spyTracer{}
+
+	handler := Tracing(spy, WithPublicEndpointFn(func(r *http.Request) bool {
+		return true // all endpoints are public
+	}))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	spans := spy.Spans()
+	require.Len(t, spans, 1)
+
+	// Span should record the linked remote context as attributes.
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spans[0].Attr("linked.trace_id"),
+		"public endpoint must record incoming trace_id as linked attribute")
+	assert.Equal(t, "00f067aa0ba902b7", spans[0].Attr("linked.span_id"),
+		"public endpoint must record incoming span_id as linked attribute")
+}
+
+func TestTracing_NonPublicEndpoint_InheritsTrace(t *testing.T) {
+	tracer := tracing.NewTracer("test-tracer")
+
+	var gotTraceID string
+	handler := Tracing(tracer, WithPublicEndpointFn(func(r *http.Request) bool {
+		return false // not public
+	}))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/internal", nil)
+	req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", gotTraceID,
+		"non-public endpoint must inherit upstream trace")
+}
+
+func TestTracing_PublicEndpoint_NoInboundHeaders(t *testing.T) {
+	tracer := tracing.NewTracer("test-tracer")
+
+	var gotTraceID string
+	handler := Tracing(tracer, WithPublicEndpointFn(func(r *http.Request) bool {
+		return true
+	}))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/public-no-headers", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.NotEmpty(t, gotTraceID, "new root span should still generate trace ID")
+	assert.Len(t, gotTraceID, 32)
+}
+
+func TestTracing_NilPublicEndpointFn_AllTrusted(t *testing.T) {
+	tracer := tracing.NewTracer("test-tracer")
+
+	var gotTraceID string
+	// No WithPublicEndpointFn option → all endpoints trusted (backward compat)
+	handler := Tracing(tracer)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/default", nil)
+	req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", gotTraceID,
+		"nil publicEndpointFn must default to trusted upstream (backward compat)")
+}

--- a/runtime/http/middleware/tracing_test.go
+++ b/runtime/http/middleware/tracing_test.go
@@ -319,10 +319,35 @@ func TestTracing_2xxDoesNotSetErrorSpanStatus(t *testing.T) {
 // --- Public endpoint trust boundary tests (#24 TRUST-POLICY-01) ---
 
 func TestTracing_PublicEndpoint_NewRootTrace(t *testing.T) {
+	tracer := tracing.NewTracer("public-test")
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+
+	var gotTraceID string
+	handler := Tracing(tracer, WithPublicEndpointFn(func(r *http.Request) bool {
+		return true // all endpoints are public
+	}))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.Header.Set("traceparent", "00-"+upstreamTraceID+"-00f067aa0ba902b7-01")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Core semantic: public endpoint must NOT inherit upstream trace.
+	assert.NotEqual(t, upstreamTraceID, gotTraceID,
+		"public endpoint must create new root trace, not inherit upstream")
+	assert.Len(t, gotTraceID, 32, "new root trace ID must be a valid 32-char hex")
+}
+
+func TestTracing_PublicEndpoint_LinkedAttributes(t *testing.T) {
 	spy := &spyTracer{}
 
 	handler := Tracing(spy, WithPublicEndpointFn(func(r *http.Request) bool {
-		return true // all endpoints are public
+		return true
 	}))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -335,7 +360,7 @@ func TestTracing_PublicEndpoint_NewRootTrace(t *testing.T) {
 	spans := spy.Spans()
 	require.Len(t, spans, 1)
 
-	// Span should record the linked remote context as attributes.
+	// Linked attributes record the remote context for correlation.
 	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spans[0].Attr("linked.trace_id"),
 		"public endpoint must record incoming trace_id as linked attribute")
 	assert.Equal(t, "00f067aa0ba902b7", spans[0].Attr("linked.span_id"),

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -67,12 +67,10 @@ func WithBodyLimit(maxBytes int64) Option {
 // middleware is placed after Recorder and before AccessLog so trace IDs appear
 // in access logs.
 //
-// Trust model: the current implementation unconditionally continues upstream
-// traces from valid inbound headers. This assumes a trusted-upstream
-// deployment (service-to-service behind a gateway). For public-facing
-// endpoints exposed directly to untrusted clients, consider adding a
-// trust-boundary middleware or gateway-level header sanitization to prevent
-// external callers from injecting arbitrary trace identities.
+// Trust model: by default the tracer continues upstream traces from valid
+// inbound headers (trusted-upstream assumption). Use WithTracingOptions to
+// configure WithPublicEndpointFn for public-facing endpoints that should
+// create new root traces instead of inheriting from untrusted callers.
 //
 // ref: go-zero — observability wired by default when configured
 // ref: otelchi — chi middleware for OpenTelemetry trace propagation
@@ -80,6 +78,18 @@ func WithBodyLimit(maxBytes int64) Option {
 func WithTracer(t tracing.Tracer) Option {
 	return func(r *Router) {
 		r.tracer = t
+	}
+}
+
+// WithTracingOptions passes additional TracingOption values to the Tracing
+// middleware. Use this to configure trust-boundary behavior, e.g.:
+//
+//	WithTracingOptions(middleware.WithPublicEndpointFn(func(r *http.Request) bool {
+//	    return isPublicPath(r.URL.Path)
+//	}))
+func WithTracingOptions(opts ...middleware.TracingOption) Option {
+	return func(r *Router) {
+		r.tracingOpts = append(r.tracingOpts, opts...)
 	}
 }
 
@@ -164,6 +174,7 @@ type Router struct {
 	metricsCollector    metrics.Collector
 	metricsHandler      http.Handler
 	tracer              tracing.Tracer
+	tracingOpts         []middleware.TracingOption
 	rateLimiter         middleware.RateLimiter
 	circuitBreaker      middleware.CircuitBreakerPolicy
 	authVerifier        auth.TokenVerifier
@@ -242,7 +253,7 @@ func NewE(opts ...Option) (*Router, error) {
 		middleware.Recorder,
 	)
 	if r.tracer != nil {
-		r.outerMux.Use(middleware.Tracing(r.tracer))
+		r.outerMux.Use(middleware.Tracing(r.tracer, r.tracingOpts...))
 	}
 	r.outerMux.Use(middleware.AccessLog)
 	if r.metricsCollector != nil {

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/http/health"
+	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
 	"github.com/stretchr/testify/assert"
@@ -376,6 +377,46 @@ func TestWithTracer_ExtractsUpstreamTraceparent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", gotTraceID,
 		"router tracing chain should preserve upstream trace continuity")
+}
+
+func TestWithTracingOptions_PublicEndpointNewRoot(t *testing.T) {
+	tracer := tracing.NewTracer("test-public")
+	r := New(
+		WithTracer(tracer),
+		WithTracingOptions(middleware.WithPublicEndpointFn(func(req *http.Request) bool {
+			return req.URL.Path == "/public"
+		})),
+	)
+
+	var publicTraceID, internalTraceID string
+	r.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		publicTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	r.Handle("/internal", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		internalTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+
+	// Public endpoint: should NOT inherit upstream trace.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.Header.Set("traceparent", "00-"+upstreamTraceID+"-00f067aa0ba902b7-01")
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotEqual(t, upstreamTraceID, publicTraceID,
+		"public endpoint must NOT inherit upstream trace (new root)")
+
+	// Internal endpoint: should inherit upstream trace.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/internal", nil)
+	req.Header.Set("traceparent", "00-"+upstreamTraceID+"-00f067aa0ba902b7-01")
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, upstreamTraceID, internalTraceID,
+		"internal endpoint must inherit upstream trace")
 }
 
 func TestNoTracer_NoTraceID(t *testing.T) {


### PR DESCRIPTION
## Summary

- **#24 TRUST-POLICY-01**: Add `WithPublicEndpointFn` option to tracing middleware. Public endpoints get new root traces (not inherited from untrusted upstream) with linked attributes for correlation. Ref: otelhttp `WithPublicEndpointFn` pattern. Request ID trust boundary already enforced by existing `isSafeID()` validation.
- **#27o CONFIG-VALUE-SENSITIVE**: Add `Sensitive bool` field to `ConfigEntry` domain model. DTO redacts value to `"******"` when sensitive. Configwrite accepts `sensitive` flag on create.
- **#27p DEVICE-IDOR**: Add `RequireSelfOrRole` check to `HandleListPending` and `HandleAck` — device subject must match path `{id}` or hold admin role.
- **#27q AUDIT-ACTOR-BIND**: Bind `actorId` query parameter to JWT subject. Omitted `actorId` defaults to self. Cross-user queries require admin role.
- **#27r RBAC-ENUMERATE**: Add `RequireSelfOrRole` check to `handleListRoles` and `handleHasRole` — subject must match path `{userID}` or hold admin role.

### Shared infrastructure

- `runtime/auth/authz.go`: New `RequireSelfOrRole(ctx, targetID, bypassRoles...)` helper — extracts subject from context, checks self-access or role bypass, returns `ErrAuthForbidden`/`ErrAuthUnauthorized`.

### Research references

| Project | Pattern | Applied to |
|---------|---------|------------|
| otelhttp `WithPublicEndpointFn` | New root span + link to remote context | #24 tracing |
| K8s apiserver `Authorizer` | Subject-resource-action model | #27p/q/r auth checks |
| K8s Secrets / struct-sensitive | Sensitive field marking + DTO redaction | #27o config masking |

## Test plan

- [x] `RequireSelfOrRole` — 7 table-driven tests (self, admin, denied, missing subject, empty target, multi-role, no-role)
- [x] rbaccheck — 8 handler tests (4 existing + 4 trust boundary: self-access, admin bypass, 403 cross-user, 401 no subject)
- [x] auditquery — 5 new trust boundary tests (self actorId, default to self, 403 cross-user, admin bypass, 401)
- [x] device-command — 6 new IDOR tests (self ListPending, admin bypass, 403 cross-device, self Ack, 403 cross-device Ack, 401)
- [x] configread — 3 new sensitive tests (redacted GET, visible non-sensitive GET, redacted in list)
- [x] tracing — 4 new trust policy tests (public new root + linked attrs, non-public inherits, public no headers, nil fn backward compat)
- [x] All existing tests updated with auth context injection (cell-level integration tests)
- [x] `go build ./...` — zero errors
- [x] `go test ./cells/... ./runtime/auth/ ./runtime/http/middleware/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)