### PR TITLE
🛡️ Sentinel: [HIGH] Fix DSN Credential Leakage in postgres pool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-14 - Redacting Credentials in Parse Errors
+**Vulnerability:** Third-party libraries like `pgx` and standard libraries like `net/url` often embed raw inputs, including connection strings, into their error messages. This can lead to credential leakage in logs or HTTP responses when DSN parsing fails.
+**Learning:** Error redaction requires caution to ensure we don't accidentally leak the underlying error by wrapping it with `%w`. If the string is changed, flattening the error via `fmt.Errorf` is the correct security posture to prevent unwrapping.
+**Prevention:** Always inspect error strings returned by parsing functions before surfacing them. Use robust Regex patterns that handle both URI (`postgres://...`) and Key-Value (`password=...`) formats.

--- a/adapters/postgres/pool.go
+++ b/adapters/postgres/pool.go
@@ -5,11 +5,19 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strconv"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var (
+	// Matches `password=value` or `password='value'` in key-value DSNs.
+	kvPasswordRegex = regexp.MustCompile(`password=([^\s']+|'[^']*')`)
+	// Matches `postgres://user:password@` or `postgresql://...`
+	urlPasswordRegex = regexp.MustCompile(`(postgres(?:ql)?:\/\/[^:]+:)([^@]+)(@)`)
 )
 
 // Default pool configuration values.
@@ -89,6 +97,23 @@ type Pool struct {
 	config Config
 }
 
+// redactDSNError attempts to redact passwords from error messages related to DSN parsing.
+func redactDSNError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+	errMsg = kvPasswordRegex.ReplaceAllString(errMsg, "password=***")
+	errMsg = urlPasswordRegex.ReplaceAllString(errMsg, "${1}***${3}")
+
+	// If the string was changed, return a new error. Otherwise, return the original.
+	if errMsg != err.Error() {
+		return fmt.Errorf("%s", errMsg)
+	}
+	return err
+}
+
 // NewPool creates a new connection pool from the supplied Config.
 // It validates the DSN, applies defaults, and pings the database to confirm
 // connectivity.
@@ -101,7 +126,7 @@ func NewPool(ctx context.Context, cfg Config) (*Pool, error) {
 
 	poolCfg, err := pgxpool.ParseConfig(cfg.DSN)
 	if err != nil {
-		return nil, errcode.Wrap(ErrAdapterPGConnect, "postgres: parse DSN", err)
+		return nil, errcode.Wrap(ErrAdapterPGConnect, "postgres: parse DSN", redactDSNError(err))
 	}
 
 	poolCfg.MaxConns = cfg.MaxConns


### PR DESCRIPTION
🚨 Severity: HIGH (P1)
💡 Vulnerability: `pgxpool.ParseConfig` embeds the raw DSN (including credentials) in its error messages upon failure. If these errors are bubbled up, passwords can leak into application logs or API responses. (Identified as F-06 in security review).
🎯 Impact: Attackers or internal staff with log access could view plaintext database credentials.
🔧 Fix: Implemented `redactDSNError` which uses regex to scrub passwords from both URI (`postgres://user:pass@host`) and key-value (`password=secret`) DSN formats. The scrubbed string is returned as a flattened error to prevent unwrapping the original secret.
✅ Verification: Ran unit tests and verified via standard go test command `go test ./adapters/postgres/...`.

---
*PR created automatically by Jules for task [9081754250008391645](https://jules.google.com/task/9081754250008391645) started by @ghbvf*