### PR TITLE
⚡ Bolt: Optimize Journey Catalog queries to O(1) lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-04-12 - Postgres Batch Insertion Memory Optimization
 **Learning:** `strconv.Itoa` causes thousands of unnecessary allocations inside large batch generation loops, and `strings.Builder` dynamically resizing wastes time.
 **Action:** Use `sb.Grow` to pre-allocate capacity and `strconv.AppendInt` with a local buffer `[32]byte` to prevent allocations entirely during heavy string building operations.
+## 2024-05-15 - Journey Catalog Performance Bottleneck
+**Learning:** Found an O(N*M + N log N) bottleneck in `kernel/journey/catalog.go` where `CellJourneys`, `ContractJourneys`, and other read methods were re-scanning and sorting the entire map of journeys on every call.
+**Action:** When seeing maps being converted to slices and sorted inside read methods, pre-compute and sort those slice indexes at initialization time to achieve O(1) lookups.

--- a/kernel/journey/catalog.go
+++ b/kernel/journey/catalog.go
@@ -13,14 +13,22 @@ import (
 type Catalog struct {
 	journeys    map[string]*metadata.JourneyMeta
 	statusBoard map[string]*metadata.StatusBoardEntry // keyed by journeyId
+
+	// Pre-computed indexes for O(1) lookups
+	cellIndex      map[string][]*metadata.JourneyMeta
+	contractIndex  map[string][]*metadata.JourneyMeta
+	crossCellIndex []*metadata.JourneyMeta
+	listIndex      []*metadata.JourneyMeta
 }
 
 // NewCatalog creates a Catalog from parsed project metadata.
 // A nil or zero-value ProjectMeta produces an empty but usable Catalog.
 func NewCatalog(project *metadata.ProjectMeta) *Catalog {
 	c := &Catalog{
-		journeys:    make(map[string]*metadata.JourneyMeta),
-		statusBoard: make(map[string]*metadata.StatusBoardEntry),
+		journeys:      make(map[string]*metadata.JourneyMeta),
+		statusBoard:   make(map[string]*metadata.StatusBoardEntry),
+		cellIndex:     make(map[string][]*metadata.JourneyMeta),
+		contractIndex: make(map[string][]*metadata.JourneyMeta),
 	}
 	if project == nil {
 		return c
@@ -28,7 +36,37 @@ func NewCatalog(project *metadata.ProjectMeta) *Catalog {
 
 	for id, j := range project.Journeys {
 		c.journeys[id] = j
+		c.listIndex = append(c.listIndex, j)
+
+		for _, cell := range j.Cells {
+			c.cellIndex[cell] = append(c.cellIndex[cell], j)
+		}
+
+		for _, ctr := range j.Contracts {
+			c.contractIndex[ctr] = append(c.contractIndex[ctr], j)
+		}
+
+		if len(j.Cells) > 1 {
+			c.crossCellIndex = append(c.crossCellIndex, j)
+		}
 	}
+
+	// Sort indexes once to guarantee deterministic results
+	sortJourneys := func(list []*metadata.JourneyMeta) {
+		sort.Slice(list, func(i, k int) bool {
+			return list[i].ID < list[k].ID
+		})
+	}
+
+	sortJourneys(c.listIndex)
+	sortJourneys(c.crossCellIndex)
+	for _, list := range c.cellIndex {
+		sortJourneys(list)
+	}
+	for _, list := range c.contractIndex {
+		sortJourneys(list)
+	}
+
 	for i := range project.StatusBoard {
 		entry := &project.StatusBoard[i]
 		c.statusBoard[entry.JourneyID] = entry
@@ -82,49 +120,33 @@ func (c *Catalog) Get(id string) *metadata.JourneyMeta {
 
 // List returns deep copies of all journeys sorted by ID.
 func (c *Catalog) List() []*metadata.JourneyMeta {
-	result := make([]*metadata.JourneyMeta, 0, len(c.journeys))
-	for _, j := range c.journeys {
+	list := c.listIndex
+	result := make([]*metadata.JourneyMeta, 0, len(list))
+	for _, j := range list {
 		result = append(result, copyJourneyMeta(j))
 	}
-	sort.Slice(result, func(i, k int) bool {
-		return result[i].ID < result[k].ID
-	})
 	return result
 }
 
 // CellJourneys returns journeys that reference the given cell ID,
 // sorted by journey ID.
 func (c *Catalog) CellJourneys(cellID string) []*metadata.JourneyMeta {
-	var result []*metadata.JourneyMeta
-	for _, j := range c.journeys {
-		for _, cell := range j.Cells {
-			if cell == cellID {
-				result = append(result, copyJourneyMeta(j))
-				break
-			}
-		}
+	list := c.cellIndex[cellID]
+	result := make([]*metadata.JourneyMeta, 0, len(list))
+	for _, j := range list {
+		result = append(result, copyJourneyMeta(j))
 	}
-	sort.Slice(result, func(i, k int) bool {
-		return result[i].ID < result[k].ID
-	})
 	return result
 }
 
 // ContractJourneys returns journeys that reference the given contract ID,
 // sorted by journey ID.
 func (c *Catalog) ContractJourneys(contractID string) []*metadata.JourneyMeta {
-	var result []*metadata.JourneyMeta
-	for _, j := range c.journeys {
-		for _, ctr := range j.Contracts {
-			if ctr == contractID {
-				result = append(result, copyJourneyMeta(j))
-				break
-			}
-		}
+	list := c.contractIndex[contractID]
+	result := make([]*metadata.JourneyMeta, 0, len(list))
+	for _, j := range list {
+		result = append(result, copyJourneyMeta(j))
 	}
-	sort.Slice(result, func(i, k int) bool {
-		return result[i].ID < result[k].ID
-	})
 	return result
 }
 
@@ -141,15 +163,11 @@ func (c *Catalog) Status(journeyID string) *metadata.StatusBoardEntry {
 // CrossCellJourneys returns journeys that involve more than one cell,
 // sorted by journey ID.
 func (c *Catalog) CrossCellJourneys() []*metadata.JourneyMeta {
-	var result []*metadata.JourneyMeta
-	for _, j := range c.journeys {
-		if len(j.Cells) > 1 {
-			result = append(result, copyJourneyMeta(j))
-		}
+	list := c.crossCellIndex
+	result := make([]*metadata.JourneyMeta, 0, len(list))
+	for _, j := range list {
+		result = append(result, copyJourneyMeta(j))
 	}
-	sort.Slice(result, func(i, k int) bool {
-		return result[i].ID < result[k].ID
-	})
 	return result
 }
 


### PR DESCRIPTION
💡 **What:** 
Updated `kernel/journey/catalog.go` to pre-compute and pre-sort slice indexes (`cellIndex`, `contractIndex`, `crossCellIndex`, and `listIndex`) during the `NewCatalog` initialization rather than dynamically scanning maps and sorting slices on every read.

🎯 **Why:** 
The query methods (`CellJourneys`, `ContractJourneys`, `CrossCellJourneys`, `List`) were executing nested loops to scan all journeys (O(N*M)) and then sorting the resulting slice (O(N log N)) on every single invocation. This is an unnecessary bottleneck for a catalog that is static after creation.

📊 **Impact:** 
Read operations drop from O(N*M + N log N) to O(1) lookup + O(K) copy (where K is the number of matching elements). This will significantly speed up any operations relying on journey relationship queries, especially as the number of journeys grows.

🔬 **Measurement:** 
Run `make test` inside `kernel/journey/` to verify tests pass and functionality behaves identically. Benchmark tests would show dramatic CPU and allocation improvements for all read queries.

---
*PR created automatically by Jules for task [10541283851273493407](https://jules.google.com/task/10541283851273493407) started by @ghbvf*