### PR TITLE
feat(adapters): structured pool stats + session health + config-drift readyz (#11 OPS-5 + #28b)

### DIFF
--- a/adapters/postgres/pool.go
+++ b/adapters/postgres/pool.go
@@ -148,6 +148,45 @@ func (p *Pool) Close() {
 	slog.Info("postgres pool closed")
 }
 
+// PoolStats holds structured connection pool statistics.
+//
+// ref: pgxpool Stat() — adopted same field set for operational dashboards
+// and Prometheus/OTel metric collectors.
+type PoolStats struct {
+	AcquireCount            int64
+	AcquireDuration         time.Duration
+	AcquiredConns           int32
+	CanceledAcquireCount    int64
+	ConstructingConns       int32
+	EmptyAcquireCount       int64
+	IdleConns               int32
+	MaxConns                int32
+	TotalConns              int32
+	NewConnsCount           int64
+	MaxLifetimeDestroyCount int64
+	MaxIdleDestroyCount     int64
+}
+
+// PoolStats returns structured pool statistics suitable for metrics collection
+// and operational dashboards.
+func (p *Pool) PoolStats() PoolStats {
+	s := p.inner.Stat()
+	return PoolStats{
+		AcquireCount:            s.AcquireCount(),
+		AcquireDuration:         s.AcquireDuration(),
+		AcquiredConns:           s.AcquiredConns(),
+		CanceledAcquireCount:    s.CanceledAcquireCount(),
+		ConstructingConns:       s.ConstructingConns(),
+		EmptyAcquireCount:       s.EmptyAcquireCount(),
+		IdleConns:               s.IdleConns(),
+		MaxConns:                s.MaxConns(),
+		TotalConns:              s.TotalConns(),
+		NewConnsCount:           s.NewConnsCount(),
+		MaxLifetimeDestroyCount: s.MaxLifetimeDestroyCount(),
+		MaxIdleDestroyCount:     s.MaxIdleDestroyCount(),
+	}
+}
+
 // Stats returns pool statistics as a formatted string for diagnostics.
 func (p *Pool) Stats() string {
 	s := p.inner.Stat()

--- a/adapters/postgres/pool.go
+++ b/adapters/postgres/pool.go
@@ -168,8 +168,12 @@ type PoolStats struct {
 }
 
 // PoolStats returns structured pool statistics suitable for metrics collection
-// and operational dashboards.
+// and operational dashboards. Returns zero-value PoolStats if the pool is not
+// initialized (defensive guard, consistent with Redis adapter pattern).
 func (p *Pool) PoolStats() PoolStats {
+	if p.inner == nil {
+		return PoolStats{}
+	}
 	s := p.inner.Stat()
 	return PoolStats{
 		AcquireCount:            s.AcquireCount(),

--- a/adapters/postgres/pool_test.go
+++ b/adapters/postgres/pool_test.go
@@ -135,6 +135,13 @@ func TestPoolStats_ZeroValue(t *testing.T) {
 	assert.Equal(t, int64(0), stats.MaxIdleDestroyCount)
 }
 
+func TestPoolStats_NilInner(t *testing.T) {
+	// Defensive: PoolStats on uninitialized Pool returns zero value, no panic.
+	p := &Pool{}
+	stats := p.PoolStats()
+	assert.Equal(t, PoolStats{}, stats)
+}
+
 func TestNewPool_UnreachableHost(t *testing.T) {
 	if os.Getenv("PG_INTEGRATION") == "" {
 		t.Skip("skipping integration test; set PG_INTEGRATION=1 to run")

--- a/adapters/postgres/pool_test.go
+++ b/adapters/postgres/pool_test.go
@@ -119,6 +119,22 @@ func TestNewPool_InvalidDSN(t *testing.T) {
 	assert.Contains(t, err.Error(), "parse DSN")
 }
 
+func TestPoolStats_ZeroValue(t *testing.T) {
+	var stats PoolStats
+	assert.Equal(t, int64(0), stats.AcquireCount)
+	assert.Equal(t, time.Duration(0), stats.AcquireDuration)
+	assert.Equal(t, int32(0), stats.AcquiredConns)
+	assert.Equal(t, int64(0), stats.CanceledAcquireCount)
+	assert.Equal(t, int32(0), stats.ConstructingConns)
+	assert.Equal(t, int64(0), stats.EmptyAcquireCount)
+	assert.Equal(t, int32(0), stats.IdleConns)
+	assert.Equal(t, int32(0), stats.MaxConns)
+	assert.Equal(t, int32(0), stats.TotalConns)
+	assert.Equal(t, int64(0), stats.NewConnsCount)
+	assert.Equal(t, int64(0), stats.MaxLifetimeDestroyCount)
+	assert.Equal(t, int64(0), stats.MaxIdleDestroyCount)
+}
+
 func TestNewPool_UnreachableHost(t *testing.T) {
 	if os.Getenv("PG_INTEGRATION") == "" {
 		t.Skip("skipping integration test; set PG_INTEGRATION=1 to run")

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -624,6 +624,26 @@ func (c *Connection) Health() error {
 	return nil
 }
 
+// PoolStats holds structured channel pool statistics.
+type PoolStats struct {
+	ChannelPoolSize int             // configured pool capacity
+	IdleChannels    int             // channels currently idle in pool
+	State           ConnectionState // current connection lifecycle state
+}
+
+// PoolStats returns structured pool statistics suitable for metrics collection
+// and operational dashboards.
+func (c *Connection) PoolStats() PoolStats {
+	c.mu.RLock()
+	state := c.state
+	c.mu.RUnlock()
+	return PoolStats{
+		ChannelPoolSize: cap(c.channelPool),
+		IdleChannels:    len(c.channelPool),
+		State:           state,
+	}
+}
+
 // ConnectionStatus returns the current lifecycle state of the connection.
 // Useful for dashboards, structured logging, and operational tooling.
 func (c *Connection) ConnectionStatus() ConnectionState {

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -376,6 +376,28 @@ func TestConnection_AcquireFromPool(t *testing.T) {
 	assert.Equal(t, pooledCh, ch)
 }
 
+func TestConnection_PoolStats_Connected(t *testing.T) {
+	conn, _ := newTestConnection(t)
+
+	// Put 2 channels in the pool.
+	conn.ReleaseChannel(newMockChannel())
+	conn.ReleaseChannel(newMockChannel())
+
+	stats := conn.PoolStats()
+	assert.Equal(t, conn.config.ChannelPoolSize, stats.ChannelPoolSize)
+	assert.Equal(t, 2, stats.IdleChannels)
+	assert.Equal(t, StateConnected, stats.State)
+}
+
+func TestConnection_PoolStats_Empty(t *testing.T) {
+	conn, _ := newTestConnection(t)
+
+	stats := conn.PoolStats()
+	assert.Equal(t, conn.config.ChannelPoolSize, stats.ChannelPoolSize)
+	assert.Equal(t, 0, stats.IdleChannels)
+	assert.Equal(t, StateConnected, stats.State)
+}
+
 func TestConnection_Close_Idempotent(t *testing.T) {
 	conn, _ := newTestConnection(t)
 

--- a/adapters/redis/client.go
+++ b/adapters/redis/client.go
@@ -105,11 +105,30 @@ type cmdable interface {
 	Eval(ctx context.Context, script string, keys []string, args ...any) *goredis.Cmd
 }
 
+// poolStatsProvider abstracts the PoolStats method available on concrete
+// go-redis clients (*Client, *FailoverClient) but not on the cmdable interface.
+type poolStatsProvider interface {
+	PoolStats() *goredis.PoolStats
+}
+
+// PoolStats holds structured connection pool statistics.
+//
+// ref: go-redis PoolStats / redisprometheus — adopted same field set.
+type PoolStats struct {
+	Hits       uint32 // times free connection was found in pool
+	Misses     uint32 // times free connection was NOT found in pool
+	Timeouts   uint32 // times a wait timeout occurred
+	TotalConns uint32 // total connections in pool
+	IdleConns  uint32 // idle connections in pool
+	StaleConns uint32 // stale connections removed from pool
+}
+
 // Client wraps a go-redis universal client and provides health checking
 // and lifecycle management.
 type Client struct {
-	rdb    cmdable
-	config Config
+	rdb           cmdable
+	config        Config
+	statsProvider poolStatsProvider // nil for test mocks
 }
 
 // NewClient creates a new Redis Client with the given configuration.
@@ -130,10 +149,13 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 			"redis: Config.SentinelMaster is required for sentinel mode")
 	}
 
-	var rdb cmdable
+	var (
+		rdb           cmdable
+		statsProvider poolStatsProvider
+	)
 	switch cfg.Mode {
 	case ModeSentinel:
-		rdb = goredis.NewFailoverClient(&goredis.FailoverOptions{
+		fc := goredis.NewFailoverClient(&goredis.FailoverOptions{
 			MasterName:    cfg.SentinelMaster,
 			SentinelAddrs: cfg.SentinelAddrs,
 			Password:      cfg.Password,
@@ -142,8 +164,10 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 			ReadTimeout:   cfg.ReadTimeout,
 			WriteTimeout:  cfg.WriteTimeout,
 		})
+		rdb = fc
+		statsProvider = fc
 	default:
-		rdb = goredis.NewClient(&goredis.Options{
+		rc := goredis.NewClient(&goredis.Options{
 			Addr:         cfg.Addr,
 			Password:     cfg.Password,
 			DB:           cfg.DB,
@@ -151,9 +175,11 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 			ReadTimeout:  cfg.ReadTimeout,
 			WriteTimeout: cfg.WriteTimeout,
 		})
+		rdb = rc
+		statsProvider = rc
 	}
 
-	c := &Client{rdb: rdb, config: cfg}
+	c := &Client{rdb: rdb, config: cfg, statsProvider: statsProvider}
 
 	if err := c.Health(ctx); err != nil {
 		// Close to avoid resource leak on failed initial connection.
@@ -201,6 +227,23 @@ func (c *Client) Close() error {
 // (DistLock, Cache, IdempotencyClaimer). Not exported.
 func (c *Client) cmdable() cmdable {
 	return c.rdb
+}
+
+// PoolStats returns structured pool statistics suitable for metrics collection.
+// Returns zero-value PoolStats for test mocks (no statsProvider).
+func (c *Client) PoolStats() PoolStats {
+	if c.statsProvider == nil {
+		return PoolStats{}
+	}
+	s := c.statsProvider.PoolStats()
+	return PoolStats{
+		Hits:       s.Hits,
+		Misses:     s.Misses,
+		Timeouts:   s.Timeouts,
+		TotalConns: s.TotalConns,
+		IdleConns:  s.IdleConns,
+		StaleConns: s.StaleConns,
+	}
 }
 
 // Config returns a copy of the client configuration.

--- a/adapters/redis/client_test.go
+++ b/adapters/redis/client_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -123,6 +124,29 @@ func TestClientPoolStats_NilProvider(t *testing.T) {
 
 	stats := client.PoolStats()
 	assert.Equal(t, PoolStats{}, stats, "mock client must return zero PoolStats")
+}
+
+func TestClientPoolStats_WithProvider(t *testing.T) {
+	mock := newMockCmdable()
+	client := newClientFromCmdable(mock, Config{})
+	client.statsProvider = &mockPoolStatsProvider{
+		stats: &goredis.PoolStats{
+			Hits:       100,
+			Misses:     5,
+			Timeouts:   1,
+			TotalConns: 10,
+			IdleConns:  7,
+			StaleConns: 2,
+		},
+	}
+
+	stats := client.PoolStats()
+	assert.Equal(t, uint32(100), stats.Hits)
+	assert.Equal(t, uint32(5), stats.Misses)
+	assert.Equal(t, uint32(1), stats.Timeouts)
+	assert.Equal(t, uint32(10), stats.TotalConns)
+	assert.Equal(t, uint32(7), stats.IdleConns)
+	assert.Equal(t, uint32(2), stats.StaleConns)
 }
 
 func TestNewClient_StandaloneEmptyAddr(t *testing.T) {

--- a/adapters/redis/client_test.go
+++ b/adapters/redis/client_test.go
@@ -117,6 +117,14 @@ func TestConfigLogValueRedactsPassword(t *testing.T) {
 	assert.NotContains(t, resolved, "s3cret", "LogValue must not contain password")
 }
 
+func TestClientPoolStats_NilProvider(t *testing.T) {
+	mock := newMockCmdable()
+	client := newClientFromCmdable(mock, Config{})
+
+	stats := client.PoolStats()
+	assert.Equal(t, PoolStats{}, stats, "mock client must return zero PoolStats")
+}
+
 func TestNewClient_StandaloneEmptyAddr(t *testing.T) {
 	_, err := NewClient(context.Background(), Config{Mode: ModeStandalone})
 	require.Error(t, err)

--- a/adapters/redis/mock_test.go
+++ b/adapters/redis/mock_test.go
@@ -207,6 +207,15 @@ func toInt64(v any) (int64, bool) {
 // errMock is a sentinel error used in tests.
 var errMock = errors.New("mock error")
 
+// mockPoolStatsProvider implements poolStatsProvider for testing.
+type mockPoolStatsProvider struct {
+	stats *goredis.PoolStats
+}
+
+func (m *mockPoolStatsProvider) PoolStats() *goredis.PoolStats {
+	return m.stats
+}
+
 // claimerMockCmdable extends mockCmdable with Eval behavior that simulates
 // the IdempotencyClaimer's Lua scripts (claim, commit, release).
 type claimerMockCmdable struct {

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -135,6 +135,19 @@ func NewAccessCore(opts ...Option) *AccessCore {
 	return c
 }
 
+// SessionHealthChecker returns a health check function for the session store,
+// or nil if the underlying repository does not support health checks (e.g. when
+// using a third-party implementation without a Health method).
+// Callers should register this with bootstrap.WithHealthChecker("session-store", fn)
+// when fn is non-nil.
+func (c *AccessCore) SessionHealthChecker() func() error {
+	type healthChecker interface{ Health() error }
+	if hc, ok := c.sessionRepo.(healthChecker); ok {
+		return hc.Health
+	}
+	return nil
+}
+
 // TokenVerifier returns the session-validate service (implements auth.TokenVerifier).
 func (c *AccessCore) TokenVerifier() auth.TokenVerifier {
 	if c.validateSvc == nil {

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -136,13 +136,19 @@ func NewAccessCore(opts ...Option) *AccessCore {
 }
 
 // SessionHealthChecker returns a health check function for the session store,
-// or nil if the underlying repository does not support health checks (e.g. when
-// using a third-party implementation without a Health method).
-// Callers should register this with bootstrap.WithHealthChecker("session-store", fn)
+// or nil if the underlying repository does not support health checks.
+//
+// Returns non-nil when the session repo implements ports.HealthCheckable.
+// Future real adapters (e.g. PG-backed session store) SHOULD implement
+// ports.HealthCheckable so that session store availability is reflected in
+// /readyz. If they don't, this method returns nil and bootstrap silently
+// skips the registration — a compile-time check is not possible since
+// HealthCheckable is intentionally separate from SessionRepository.
+//
+// Callers should register with bootstrap.WithHealthChecker("session-store", fn)
 // when fn is non-nil.
 func (c *AccessCore) SessionHealthChecker() func() error {
-	type healthChecker interface{ Health() error }
-	if hc, ok := c.sessionRepo.(healthChecker); ok {
+	if hc, ok := c.sessionRepo.(ports.HealthCheckable); ok {
 		return hc.Health
 	}
 	return nil

--- a/cells/access-core/internal/mem/repo_test.go
+++ b/cells/access-core/internal/mem/repo_test.go
@@ -55,6 +55,11 @@ func TestUserRepository_ConcurrentCreateAndGet(t *testing.T) {
 	wg.Wait()
 }
 
+func TestSessionRepository_Health(t *testing.T) {
+	repo := NewSessionRepository()
+	assert.NoError(t, repo.Health(), "in-memory session repo is always healthy")
+}
+
 // TestSessionRepository_ConcurrentCreateAndGet verifies that concurrent
 // Create and Get calls do not race. Run with -race to verify.
 func TestSessionRepository_ConcurrentCreateAndGet(t *testing.T) {

--- a/cells/access-core/internal/mem/session_repo.go
+++ b/cells/access-core/internal/mem/session_repo.go
@@ -29,6 +29,12 @@ func NewSessionRepository() *SessionRepository {
 	}
 }
 
+// Health returns nil for in-memory repositories (always available).
+// Future DB-backed implementations should check connection liveness.
+func (r *SessionRepository) Health() error {
+	return nil
+}
+
 func (r *SessionRepository) Create(_ context.Context, session *domain.Session) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/cells/access-core/internal/ports/health.go
+++ b/cells/access-core/internal/ports/health.go
@@ -1,0 +1,15 @@
+package ports
+
+// HealthCheckable is an optional interface for infrastructure components that
+// can report their health status. Repository implementations should implement
+// this when they depend on external resources (database, cache) whose
+// availability should be reflected in /readyz.
+//
+// This is intentionally separate from domain repository interfaces (e.g.
+// SessionRepository) because health checking is an infrastructure concern,
+// not a domain concern. However, keeping it in ports makes the expectation
+// explicit: future real adapters implementing SessionRepository SHOULD also
+// implement HealthCheckable so that session store availability is observable.
+type HealthCheckable interface {
+	Health() error
+}

--- a/cells/access-core/options_test.go
+++ b/cells/access-core/options_test.go
@@ -25,6 +25,19 @@ func TestWithInMemoryDefaults(t *testing.T) {
 	assert.NotNil(t, c.roleRepo)
 }
 
+func TestSessionHealthChecker_InMemory(t *testing.T) {
+	c := NewAccessCore(WithInMemoryDefaults())
+	fn := c.SessionHealthChecker()
+	require.NotNil(t, fn, "in-memory session repo implements Health()")
+	assert.NoError(t, fn())
+}
+
+func TestSessionHealthChecker_NilRepo(t *testing.T) {
+	c := NewAccessCore() // no repo set
+	fn := c.SessionHealthChecker()
+	assert.Nil(t, fn, "nil session repo has no health checker")
+}
+
 func TestRegisterSubscriptions(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -172,12 +172,20 @@ func main() {
 		"/api/v1/access/sessions/refresh",
 	}
 
-	app := bootstrap.New(
+	bootstrapOpts := []bootstrap.Option{
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithHTTPAddr(":8080"),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithPublicEndpoints(publicEndpoints),
-	)
+	}
+
+	// Register session store health checker if the repository supports it.
+	// In-memory: always healthy. Future PG-backed: checks DB connectivity.
+	if fn := accessCell.SessionHealthChecker(); fn != nil {
+		bootstrapOpts = append(bootstrapOpts, bootstrap.WithHealthChecker("session-store", fn))
+	}
+
+	app := bootstrap.New(bootstrapOpts...)
 
 	if err := app.Run(ctx); err != nil {
 		slog.Error("application failed", "error", err)

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -47,6 +47,7 @@ type Option func(*Bootstrap)
 
 const (
 	configWatcherCheckerName = "config-watcher"
+	configDriftCheckerName   = "config-drift"
 	eventRouterCheckerName   = "eventrouter"
 )
 
@@ -588,6 +589,23 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	if cfgWatcher != nil {
 		if err := registerHealthChecker(configWatcherCheckerName, cfgWatcher.Health); err != nil {
 			return rollback(err)
+		}
+	}
+	// Register config-drift checker when the config supports generation tracking.
+	// Returns unhealthy when desired generation (config reloaded) differs from
+	// observed generation (all cells applied). Transient drift during reload is
+	// absorbed by K8s failureThreshold (default 3 consecutive failures).
+	if g, gOK := cfg.(config.Generationer); gOK {
+		if og, ogOK := cfg.(config.ObservedGenerationer); ogOK {
+			if err := registerHealthChecker(configDriftCheckerName, func() error {
+				if g.Generation() != og.ObservedGeneration() {
+					return fmt.Errorf("config drift: generation %d, observed %d",
+						g.Generation(), og.ObservedGeneration())
+				}
+				return nil
+			}); err != nil {
+				return rollback(err)
+			}
 		}
 	}
 	// Framework health handler is applied LAST so user-supplied router options

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -592,13 +592,14 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		}
 	}
 	// Register config-drift checker when the config supports generation tracking.
+	// Reuses config.HasDrift to avoid duplicating the generation comparison logic.
 	// Returns unhealthy when desired generation (config reloaded) differs from
 	// observed generation (all cells applied). Transient drift during reload is
 	// absorbed by K8s failureThreshold (default 3 consecutive failures).
 	if g, gOK := cfg.(config.Generationer); gOK {
 		if og, ogOK := cfg.(config.ObservedGenerationer); ogOK {
 			if err := registerHealthChecker(configDriftCheckerName, func() error {
-				if g.Generation() != og.ObservedGeneration() {
+				if config.HasDrift(cfg) {
 					return fmt.Errorf("config drift: generation %d, observed %d",
 						g.Generation(), og.ObservedGeneration())
 				}

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -975,6 +975,78 @@ func TestBootstrap_ConfigDriftChecker_ErrorMessage(t *testing.T) {
 	assert.NoError(t, checker(), "drift resolved after cells apply")
 }
 
+func TestBootstrap_ConfigDriftReadyz_HTTP503OnDrift(t *testing.T) {
+	// Integration test: verify /readyz returns 503 when config drift exists.
+	// Uses a reloaderCell that always fails → observedGeneration never advances.
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: test\n"), 0o644))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	failCell := newReloaderCell("fail-cell")
+	failCell.err = fmt.Errorf("intentional reload failure")
+
+	asm := assembly.New(assembly.Config{ID: "test-drift-http-503"})
+	require.NoError(t, asm.Register(failCell))
+
+	b := New(
+		WithAssembly(asm),
+		WithConfig(cfgFile, ""),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	// Wait for server to be ready (healthy initially — no drift yet).
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz", addr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond, "server did not become ready")
+
+	// Trigger a config change → watcher fires OnChange → Reload → generation++
+	// → failCell.OnConfigReload returns error → observedGeneration stays → drift!
+	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: drifted\n"), 0o644))
+
+	// Poll /readyz?verbose until config-drift shows unhealthy.
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz?verbose", addr))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			return false
+		}
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return false
+		}
+		deps, ok := body["dependencies"].(map[string]any)
+		if !ok {
+			return false
+		}
+		return deps[configDriftCheckerName] == "unhealthy"
+	}, 5*time.Second, 100*time.Millisecond, "readyz should return 503 with config-drift unhealthy")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
 func TestBootstrap_ConfigWatcherInitFailure_FailsFast(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "config.yaml")

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -854,6 +854,87 @@ func TestBootstrap_ConfigWatcher_ReadyzVerboseIncludesWatcher(t *testing.T) {
 	}
 }
 
+func TestBootstrap_ConfigDriftReadyz_NoDrift(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: test\n"), 0o644))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	asm := assembly.New(assembly.Config{ID: "test-config-drift-no-drift"})
+	require.NoError(t, asm.Register(newTestCell("cell-1")))
+
+	b := New(
+		WithAssembly(asm),
+		WithConfig(cfgFile, ""),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz?verbose", addr))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return false
+		}
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return false
+		}
+		deps, ok := body["dependencies"].(map[string]any)
+		if !ok {
+			return false
+		}
+		// Config drift checker should be registered and healthy (no drift).
+		return deps[configDriftCheckerName] == "healthy"
+	}, 3*time.Second, 50*time.Millisecond, "config-drift checker not found or not healthy")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+func TestBootstrap_ConfigDriftChecker_ReportsUnhealthy(t *testing.T) {
+	// Unit test: verify the config-drift checker closure logic directly.
+	// Integration of HasDrift with generation/observedGeneration is covered
+	// by runtime/config/config_test.go (TestConfig_HasDrift).
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: test\n"), 0o644))
+
+	cfg, err := config.Load(cfgFile, "")
+	require.NoError(t, err)
+
+	// Initially: generation=0, observedGeneration=0 → no drift.
+	assert.False(t, config.HasDrift(cfg))
+
+	// Reload to bump generation to 1; observedGeneration stays 0 → drift.
+	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: updated\n"), 0o644))
+	r, ok := cfg.(config.Reloader)
+	require.True(t, ok)
+	require.NoError(t, r.Reload(cfgFile, ""))
+	assert.True(t, config.HasDrift(cfg), "generation 1 != observed 0 → drift")
+
+	// Simulate cells applying → set observed = generation → no drift.
+	og := cfg.(config.ObservedGenerationer)
+	g := cfg.(config.Generationer)
+	og.SetObservedGeneration(g.Generation())
+	assert.False(t, config.HasDrift(cfg), "after cells apply, drift resolved")
+}
+
 func TestBootstrap_ConfigWatcherInitFailure_FailsFast(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "config.yaml")

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -935,6 +935,46 @@ func TestBootstrap_ConfigDriftChecker_ReportsUnhealthy(t *testing.T) {
 	assert.False(t, config.HasDrift(cfg), "after cells apply, drift resolved")
 }
 
+func TestBootstrap_ConfigDriftChecker_ErrorMessage(t *testing.T) {
+	// Verify the drift checker closure returns a correctly formatted error
+	// containing both generation and observedGeneration values.
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: test\n"), 0o644))
+
+	cfg, err := config.Load(cfgFile, "")
+	require.NoError(t, err)
+
+	g := cfg.(config.Generationer)
+	og := cfg.(config.ObservedGenerationer)
+
+	// Construct the same checker closure that bootstrap.Run creates.
+	checker := func() error {
+		if g.Generation() != og.ObservedGeneration() {
+			return fmt.Errorf("config drift: generation %d, observed %d",
+				g.Generation(), og.ObservedGeneration())
+		}
+		return nil
+	}
+
+	// No drift initially.
+	assert.NoError(t, checker())
+
+	// Trigger drift via reload.
+	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: v2\n"), 0o644))
+	require.NoError(t, cfg.(config.Reloader).Reload(cfgFile, ""))
+
+	err = checker()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config drift")
+	assert.Contains(t, err.Error(), "generation 1")
+	assert.Contains(t, err.Error(), "observed 0")
+
+	// Resolve drift.
+	og.SetObservedGeneration(g.Generation())
+	assert.NoError(t, checker(), "drift resolved after cells apply")
+}
+
 func TestBootstrap_ConfigWatcherInitFailure_FailsFast(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
## Summary

- **OPS-5**: Add `PoolStats()` method to PG (12 fields from pgxpool.Stat), Redis (6 fields via poolStatsProvider), and RabbitMQ (channel pool size/idle/state) adapters
- **#28b AUTH-HEALTH-01**: Session store health check — `mem.SessionRepository.Health()` + `AccessCore.SessionHealthChecker()` + `WithHealthChecker("session-store", fn)` registration in main.go
- **#11 CFG-DRIFT-READYZ**: Auto-register `config-drift` readyz checker in bootstrap when config supports generation tracking — returns unhealthy when `generation != observedGeneration`

## Open-source references

| Project | Pattern adopted |
|---------|----------------|
| pgxpool `Pool.Stat()` | Structured stats struct with 12+ fields |
| go-redis `PoolStats()` | Type-assert `poolStatsProvider` interface for stats |
| IBM pgxpoolprometheus | Prometheus Collector wrapping stats struct |

## Test plan

- [x] `TestPoolStats_ZeroValue` — PG PoolStats struct fields
- [x] `TestClientPoolStats_NilProvider` — Redis mock returns zero stats
- [x] `TestConnection_PoolStats_Connected` / `_Empty` — RMQ channel pool stats
- [x] `TestSessionRepository_Health` — in-memory repo always healthy
- [x] `TestSessionHealthChecker_InMemory` / `_NilRepo` — type-assert health discovery
- [x] `TestBootstrap_ConfigDriftReadyz_NoDrift` — integration: checker registered + healthy
- [x] `TestBootstrap_ConfigDriftChecker_ReportsUnhealthy` — unit: drift detection logic
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] All existing tests pass (adapters + cells + bootstrap + cmd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)