### PR TITLE
fix(kernel): DurabilityMode guard hardening + noop protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to GoCell are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased] - DurabilityMode 守护加固
+
+> PR: #284
+> Scope: A2/D2/C1/D1/NIL-PUB-P2/SECURECOOKIE-FLAKY
+
+### Breaking
+
+- **kernel/cell**: `DurabilityMode` zero value is now invalid (unset). All `assembly.Config{}` and `cell.Dependencies{}` must explicitly set `DurabilityMode: cell.DurabilityDemo` or `cell.DurabilityDurable`. Previously, zero-value defaulted to `DurabilityDemo` silently. ref: Vault `StoredKeysInvalid=0`, gRPC `InvalidSecurityLevel=0`.
+
+### Added
+
+- **kernel/cell**: `CheckNotNoop` now rejects zero-value `DurabilityMode` with `ErrValidationFailed`.
+- **cells**: access-core, audit-core, config-core now call `CheckNotNoop` in `Init()`, aligning with order-cell and device-cell.
+- **kernel/persistence**: `NoopTxRunner.RunInTx` panics with descriptive message on nil fn (ref: `net/http.HandleFunc`).
+
+### Fixed
+
+- **cells/order-cell**: outbox log distinguishes noop path (`Debug`) from real write (`Info`).
+- **pkg/securecookie**: `TestSecureCookie_TamperedValue` flaky (1/64 probability) fixed via bit-flip instead of literal "X" replacement.
+
 ## [Unreleased] - Decode 严格化 + 回归锁定
 
 > PR: #89

--- a/README.md
+++ b/README.md
@@ -204,6 +204,23 @@ curl http://localhost:8080/api/v1/hello
 | [sso-bff](examples/sso-bff/) | Medium-High | 3 built-in Cells composition (access + audit + config) |
 | [iot-device](examples/iot-device/) | High | L4 DeviceLatent: command queue, ack, high-latency loop |
 
+## Runtime Modes
+
+GoCell assemblies must declare a `DurabilityMode` explicitly (zero value is rejected):
+
+| Mode | Value | Noop Allowed | Use Case |
+|------|-------|-------------|----------|
+| `DurabilityDemo` | 1 | Yes — `NoopWriter`, `NoopTxRunner`, `DiscardPublisher` accepted | Development, unit tests, examples |
+| `DurabilityDurable` | 2 | No — `CheckNotNoop` rejects at `Init()` | Production (`cmd/core-bundle`) |
+
+```go
+// Production
+asm := assembly.New(assembly.Config{ID: "prod", DurabilityMode: cell.DurabilityDurable})
+
+// Development / tests
+asm := assembly.New(assembly.Config{ID: "dev", DurabilityMode: cell.DurabilityDemo})
+```
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ func main() {
     ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
     defer cancel()
 
-    asm := assembly.New(assembly.Config{ID: "my-app"})
+    asm := assembly.New(assembly.Config{ID: "my-app", DurabilityMode: cell.DurabilityDemo})
     asm.Register(mycell.New())
 
     app := bootstrap.New(

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -178,6 +178,11 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 			"access-core durable mode requires both outboxWriter and txRunner")
 	}
 
+	// Durable mode: reject noop implementations.
+	if err := cell.CheckNotNoop(deps.DurabilityMode, "access-core", c.outboxWriter, c.txRunner, c.publisher); err != nil {
+		return err
+	}
+
 	// Demo mode: both nil → require publisher for degraded event delivery.
 	if c.outboxWriter == nil && c.txRunner == nil {
 		if c.publisher == nil {

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -83,7 +83,7 @@ func TestAccessCore_Init_RequiresJWTIssuer(t *testing.T) {
 		WithOutboxWriter(outbox.NoopWriter{}),
 		WithTxManager(noopTxRunner{}),
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "WithJWTIssuer")
 }
@@ -98,7 +98,7 @@ func TestAccessCore_Init_RequiresJWTVerifier(t *testing.T) {
 		WithOutboxWriter(outbox.NoopWriter{}),
 		WithTxManager(noopTxRunner{}),
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "WithJWTVerifier")
 }
@@ -115,7 +115,7 @@ func TestInit_TxRunnerXOR_OutboxWithoutTx(t *testing.T) {
 		WithOutboxWriter(outbox.NoopWriter{}),
 		// txRunner intentionally omitted
 	)
-	deps := cell.Dependencies{Config: make(map[string]any)}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
 	require.Error(t, err)
 	var ecErr *errcode.Error
@@ -136,7 +136,7 @@ func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
 		WithTxManager(noopTxRunner{}),
 		// outboxWriter intentionally omitted
 	)
-	deps := cell.Dependencies{Config: make(map[string]any)}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
 	require.Error(t, err)
 	var ecErr *errcode.Error
@@ -148,7 +148,7 @@ func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
 func TestInit_TxRunnerXOR_BothPresent(t *testing.T) {
 	// Both outboxWriter and txRunner present → should succeed
 	c := newTestCell() // newTestCell includes both
-	deps := cell.Dependencies{Config: make(map[string]any)}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	require.NoError(t, c.Init(context.Background(), deps))
 }
 
@@ -160,7 +160,7 @@ func TestInit_DemoMode_RequiresPublisher(t *testing.T) {
 		WithJWTVerifier(testVerifier),
 		// no publisher, no outbox, no tx
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "publisher")
 }
@@ -173,7 +173,7 @@ func TestInit_DemoMode_WithPublisher_Succeeds(t *testing.T) {
 		WithJWTIssuer(testIssuer),
 		WithJWTVerifier(testVerifier),
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, err)
 }
 
@@ -181,7 +181,8 @@ func TestAccessCore_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 
 	// Init
@@ -210,7 +211,8 @@ func TestAccessCore_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 	require.NoError(t, c.Start(ctx))
@@ -222,7 +224,8 @@ func TestAccessCore_TokenVerifierAndAuthorizer(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -234,7 +237,8 @@ func TestAccessCore_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -264,7 +268,8 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -372,7 +377,7 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 		WithTxManager(noopTxRunner{}),
 	)
 	ctx := context.Background()
-	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any)}))
+	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}))
 
 	// Seed a user.
 	hash, _ := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
@@ -442,7 +447,7 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 		WithTxManager(noopTxRunner{}),
 	)
 	ctx := context.Background()
-	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any)}))
+	require.NoError(t, c.Init(ctx, cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}))
 
 	// Seed a user.
 	hash, _ := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)

--- a/cells/access-core/options_test.go
+++ b/cells/access-core/options_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +43,7 @@ func TestHealthCheckers_NilRepo(t *testing.T) {
 func TestRegisterSubscriptions(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
-	deps := cell.Dependencies{Config: make(map[string]any)}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	require.NoError(t, c.Init(ctx, deps))
 
 	r := &celltest.StubEventRouter{}
@@ -58,10 +60,30 @@ func TestInit_MissingOutboxWriter(t *testing.T) {
 		WithJWTVerifier(testVerifier),
 		WithTxManager(noopTxRunner{}),
 	)
-	deps := cell.Dependencies{Config: make(map[string]any)}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "txRunner")
+}
+
+func TestInit_DurableMode_RejectsNoopWriter(t *testing.T) {
+	c := NewAccessCore(
+		WithInMemoryDefaults(),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(persistence.NoopTxRunner{}),
+	)
+	deps := cell.Dependencies{
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDurable,
+	}
+	err := c.Init(context.Background(), deps)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
+	assert.Contains(t, err.Error(), "durable mode")
 }
 
 func TestInit_MissingJWTIssuerAndVerifier(t *testing.T) {
@@ -69,7 +91,7 @@ func TestInit_MissingJWTIssuerAndVerifier(t *testing.T) {
 		WithOutboxWriter(outbox.NoopWriter{}),
 		WithTxManager(noopTxRunner{}),
 	)
-	deps := cell.Dependencies{Config: make(map[string]any)}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "WithJWTIssuer")

--- a/cells/audit-core/cell.go
+++ b/cells/audit-core/cell.go
@@ -145,6 +145,11 @@ func (c *AuditCore) Init(ctx context.Context, deps cell.Dependencies) error {
 			"audit-core durable mode requires both outboxWriter and txRunner")
 	}
 
+	// Durable mode: reject noop implementations.
+	if err := cell.CheckNotNoop(deps.DurabilityMode, "audit-core", c.outboxWriter, c.txRunner, c.publisher); err != nil {
+		return err
+	}
+
 	// Demo mode: both nil → require publisher for degraded event delivery.
 	if c.outboxWriter == nil && c.txRunner == nil {
 		if c.publisher == nil {

--- a/cells/audit-core/cell_test.go
+++ b/cells/audit-core/cell_test.go
@@ -44,7 +44,8 @@ func TestAuditCore_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 
 	// Init
@@ -73,7 +74,8 @@ func TestAuditCore_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 	require.NoError(t, c.Start(ctx))
@@ -90,7 +92,8 @@ func TestAuditCore_MissingHMACKey(t *testing.T) {
 	)
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 
 	err := c.Init(ctx, deps)
@@ -107,7 +110,8 @@ func TestAuditCore_HMACKeyFromConfig(t *testing.T) {
 	)
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: map[string]any{"audit.hmac_key": "config-provided-key-32bytes!!!!!"},
+		Config:         map[string]any{"audit.hmac_key": "config-provided-key-32bytes!!!!!"},
+		DurabilityMode: cell.DurabilityDemo,
 	}
 
 	require.NoError(t, c.Init(ctx, deps))
@@ -125,7 +129,7 @@ func TestInit_TxRunnerXOR_OutboxWithoutTx(t *testing.T) {
 		WithOutboxWriter(outbox.NoopWriter{}),
 		// txRunner intentionally omitted
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}})
+	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -143,7 +147,7 @@ func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
 		WithTxManager(noopTxRunner{}),
 		// outboxWriter intentionally omitted
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}})
+	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -158,12 +162,32 @@ func TestInit_DemoMode_RequiresPublisher(t *testing.T) {
 		WithHMACKey(testHMACKey),
 		// No outboxWriter, no txRunner, no publisher.
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}})
+	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
 	assert.Contains(t, err.Error(), "publisher")
+}
+
+func TestInit_DurableMode_RejectsNoopWriter(t *testing.T) {
+	c := NewAuditCore(
+		WithAuditRepository(mem.NewAuditRepository()),
+		WithArchiveStore(mem.NewArchiveStore()),
+		WithHMACKey(testHMACKey),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(persistence.NoopTxRunner{}),
+	)
+	deps := cell.Dependencies{
+		Config:         map[string]any{},
+		DurabilityMode: cell.DurabilityDurable,
+	}
+	err := c.Init(context.Background(), deps)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
+	assert.Contains(t, err.Error(), "durable mode")
 }
 
 func TestInit_DemoMode_WithPublisher_Succeeds(t *testing.T) {
@@ -174,7 +198,7 @@ func TestInit_DemoMode_WithPublisher_Succeeds(t *testing.T) {
 		WithHMACKey(testHMACKey),
 		// No outboxWriter, no txRunner — demo mode with publisher.
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}})
+	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, err, "demo mode with publisher should succeed")
 }
 
@@ -182,7 +206,8 @@ func TestAuditCore_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -195,7 +220,8 @@ func TestAuditCore_RegisterSubscriptions(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -222,7 +248,8 @@ func TestAuditCore_RouteQueryEntries(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 

--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -126,6 +126,11 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 			"config-core durable mode requires both outboxWriter and txRunner")
 	}
 
+	// Durable mode: reject noop implementations.
+	if err := cell.CheckNotNoop(deps.DurabilityMode, "config-core", c.outboxWriter, c.txRunner, c.publisher); err != nil {
+		return err
+	}
+
 	// Demo mode: both nil → require publisher for degraded event delivery.
 	if c.outboxWriter == nil && c.txRunner == nil {
 		if c.publisher == nil {

--- a/cells/config-core/cell_test.go
+++ b/cells/config-core/cell_test.go
@@ -45,7 +45,8 @@ func TestConfigCore_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 
 	// Init
@@ -76,7 +77,8 @@ func TestConfigCore_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 	require.NoError(t, c.Start(ctx))
@@ -110,7 +112,7 @@ func TestConfigCore_InitRejectsHalfConfiguredDurablePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewConfigCore(tt.opts...)
-			err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
+			err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 			require.Error(t, err)
 			var ecErr *errcode.Error
 			require.ErrorAs(t, err, &ecErr)
@@ -119,9 +121,28 @@ func TestConfigCore_InitRejectsHalfConfiguredDurablePath(t *testing.T) {
 	}
 }
 
+func TestConfigCore_InitDurableMode_RejectsNoopWriter(t *testing.T) {
+	c := NewConfigCore(
+		WithInMemoryDefaults(),
+		WithPublisher(eventbus.New()),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(persistence.NoopTxRunner{}),
+	)
+	deps := cell.Dependencies{
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDurable,
+	}
+	err := c.Init(context.Background(), deps)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
+	assert.Contains(t, err.Error(), "durable mode")
+}
+
 func TestConfigCore_InitDemoMode_RequiresPublisher(t *testing.T) {
 	c := NewConfigCore(WithInMemoryDefaults())
-	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "publisher")
 }
@@ -131,7 +152,7 @@ func TestConfigCore_InitDemoMode_WithPublisher_Succeeds(t *testing.T) {
 		WithInMemoryDefaults(),
 		WithPublisher(eventbus.New()),
 	)
-	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any)})
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, err)
 }
 
@@ -139,7 +160,8 @@ func TestConfigCore_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -152,7 +174,8 @@ func TestConfigCore_RegisterSubscriptions(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -182,7 +205,8 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -281,7 +305,7 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 func TestConfigCore_CrossSliceCursorRejection_Reverse(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
-	deps := cell.Dependencies{Config: make(map[string]any)}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	require.NoError(t, c.Init(ctx, deps))
 
 	r := router.New()

--- a/cells/device-cell/cell_test.go
+++ b/cells/device-cell/cell_test.go
@@ -29,7 +29,8 @@ func TestDeviceCell_Lifecycle(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 
 	// Init
@@ -58,7 +59,8 @@ func TestDeviceCell_Startup(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 	require.NoError(t, c.Start(ctx))
@@ -71,7 +73,8 @@ func TestDeviceCell_InitDefaultsRepositories(t *testing.T) {
 	c := NewDeviceCell(WithPublisher(eventbus.New()))
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 	assert.Len(t, c.OwnedSlices(), 3)
@@ -85,7 +88,8 @@ func TestDeviceCell_InitNoPublisher(t *testing.T) {
 	)
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	err := c.Init(ctx, deps)
 	require.Error(t, err)
@@ -97,7 +101,8 @@ func TestDeviceCell_RegisterRoutes(t *testing.T) {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
@@ -137,7 +142,8 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	c := newTestCell()
 	ctx := context.Background()
 	deps := cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
 

--- a/cells/order-cell/cell_test.go
+++ b/cells/order-cell/cell_test.go
@@ -21,7 +21,8 @@ import (
 
 func newTestDeps() cell.Dependencies {
 	return cell.Dependencies{
-		Config: make(map[string]any),
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
 	}
 }
 

--- a/cells/order-cell/slices/order-create/service.go
+++ b/cells/order-cell/slices/order-create/service.go
@@ -105,11 +105,19 @@ func (s *Service) Create(ctx context.Context, item string) (*domain.Order, error
 		return nil, err
 	}
 
-	s.logger.Info("order-create: outbox entry written",
-		slog.String("order_id", order.ID),
-		slog.String("entry_id", entry.ID),
-		slog.String("topic", entry.RoutingTopic()),
-	)
+	if n, ok := s.outboxWriter.(interface{ Noop() bool }); ok && n.Noop() {
+		s.logger.Debug("order-create: outbox entry processed (noop: not persisted)",
+			slog.String("order_id", order.ID),
+			slog.String("entry_id", entry.ID),
+			slog.String("topic", entry.RoutingTopic()),
+		)
+	} else {
+		s.logger.Info("order-create: outbox entry written",
+			slog.String("order_id", order.ID),
+			slog.String("entry_id", entry.ID),
+			slog.String("topic", entry.RoutingTopic()),
+		)
+	}
 	return order, nil
 }
 

--- a/cells/order-cell/slices/order-create/service_test.go
+++ b/cells/order-cell/slices/order-create/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 )
 
 // --- test doubles ---
@@ -117,6 +118,15 @@ func TestService_Create_OutboxWriterFailureReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, order)
 	assert.Equal(t, 1, txRunner.calls)
+
+	// Document known limitation: stubTxRunner has no rollback, so the order
+	// persists in-memory even though the outbox write failed. With a real
+	// postgres TxManager, the entire transaction (including repo.Create)
+	// would be rolled back. This assertion captures the current demo-mode
+	// behavior and will fail-safe if stubTxRunner gains rollback semantics.
+	orders, listErr := repo.List(context.Background(), query.ListParams{Limit: 10})
+	require.NoError(t, listErr)
+	assert.Len(t, orders, 1, "stubTxRunner: order persists despite outbox failure (no rollback in demo mode)")
 }
 
 func TestService_Create_NoopWriterDemoPath(t *testing.T) {

--- a/cmd/core-bundle/auth_integration_test.go
+++ b/cmd/core-bundle/auth_integration_test.go
@@ -13,6 +13,7 @@ import (
 	auditcore "github.com/ghbvf/gocell/cells/audit-core"
 	configcore "github.com/ghbvf/gocell/cells/config-core"
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -87,7 +88,7 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 		auditcore.WithCursorCodec(auditCursorCodec),
 	)
 
-	asm := assembly.New(assembly.Config{ID: "auth-test"})
+	asm := assembly.New(assembly.Config{ID: "auth-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(ac))
 	require.NoError(t, asm.Register(cc))
 	require.NoError(t, asm.Register(auc))

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -103,13 +103,13 @@ func run(ctx context.Context) error {
 		slog.String("effective", "in-memory"))
 
 	auditCursorCodec, err := query.NewCursorCodec(
-		envOrDefault("GOCELL_AUDIT_CURSOR_KEY", "core-bundle-audit-cursor-key32!"),
+		envOrDefault("GOCELL_AUDIT_CURSOR_KEY", "core-bundle-audit-cursor-key-32!"),
 	)
 	if err != nil {
 		return fmt.Errorf("create audit cursor codec: %w", err)
 	}
 	configCursorCodec, err := query.NewCursorCodec(
-		envOrDefault("GOCELL_CONFIG_CURSOR_KEY", "core-bundle-cfg-cursor-key-32b!"),
+		envOrDefault("GOCELL_CONFIG_CURSOR_KEY", "core-bundle-cfg-cursor-key--32b!"),
 	)
 	if err != nil {
 		return fmt.Errorf("create config cursor codec: %w", err)

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -2,8 +2,9 @@
 // It bootstraps config-core, access-core, and audit-core with in-memory
 // repositories by default, suitable for development and integration testing.
 //
-// Set GOCELL_ADAPTER_MODE=real to enable real adapter wiring (requires
-// GOCELL_POSTGRES_DSN, GOCELL_REDIS_ADDR, GOCELL_RABBITMQ_URL).
+// DurabilityDurable is set to reject noop placeholders (NoopWriter,
+// NoopTxRunner, DiscardPublisher) even in dev mode. Real adapter wiring
+// (GOCELL_ADAPTER_MODE=real) is not yet implemented.
 package main
 
 import (

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -18,6 +18,7 @@ import (
 	auditcore "github.com/ghbvf/gocell/cells/audit-core"
 	configcore "github.com/ghbvf/gocell/cells/config-core"
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
@@ -131,7 +132,7 @@ func run(ctx context.Context) error {
 		auditcore.WithCursorCodec(auditCursorCodec),
 	)
 
-	asm := assembly.New(assembly.Config{ID: "core-bundle"})
+	asm := assembly.New(assembly.Config{ID: "core-bundle", DurabilityMode: cell.DurabilityDurable})
 	if err := asm.Register(configCell); err != nil {
 		return fmt.Errorf("register config-core: %w", err)
 	}

--- a/cmd/core-bundle/main_test.go
+++ b/cmd/core-bundle/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"strings"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -39,8 +40,11 @@ func TestLoadKeySet_RealMode_Success(t *testing.T) {
 	assert.NotNil(t, ks)
 }
 
-func TestLoadKeySet_UnknownMode_FallsDev(t *testing.T) {
-	// Typo or unknown value should still work (dev fallback) but logs a warning.
+func TestLoadKeySet_UnknownMode_StillGeneratesEphemeral(t *testing.T) {
+	// loadKeySet treats any non-"real" mode as dev (ephemeral key pair).
+	// In practice, validateAdapterMode rejects unknown values before
+	// loadKeySet is called, so this path is only reachable if a new
+	// valid mode is added without updating loadKeySet.
 	ks, err := loadKeySet("reall") // deliberate typo
 	require.NoError(t, err)
 	assert.NotNil(t, ks)
@@ -81,10 +85,18 @@ func TestRun_DevMode_StartsAndCancels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately — run() should exit cleanly
 
-	// run() may fail with "context canceled" or a listen error (sandbox);
-	// both are acceptable — we're testing that assembly + bootstrap wiring
-	// completes without crashing.
-	_ = run(ctx)
+	err := run(ctx)
+	// Only context.Canceled and listen/sandbox errors are acceptable.
+	// Any other error signals a real startup regression.
+	if err != nil {
+		msg := err.Error()
+		acceptable := strings.Contains(msg, "context canceled") ||
+			strings.Contains(msg, "operation not permitted") ||
+			strings.Contains(msg, "bind:")
+		if !acceptable {
+			t.Fatalf("unexpected startup error (not context-canceled or sandbox): %v", err)
+		}
+	}
 }
 
 func TestRun_InvalidAdapterMode_ReturnsError(t *testing.T) {

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -122,7 +122,7 @@ func (c *MyCell) RegisterSubscriptions(sub outbox.Subscriber) {
 ### 6. 注册到 Assembly
 
 ```go
-asm := assembly.New(assembly.Config{ID: "my-app"})
+asm := assembly.New(assembly.Config{ID: "my-app", DurabilityMode: cell.DurabilityDemo})
 asm.Register(mycell.NewMyCell(...))
 ```
 
@@ -166,9 +166,8 @@ func TestMyCell_Lifecycle(t *testing.T) {
     c := NewMyCell(WithInMemoryDefaults())
     ctx := context.Background()
     deps := cell.Dependencies{
-        Cells:     make(map[string]cell.Cell),
-        Contracts: make(map[string]cell.Contract),
-        Config:    make(map[string]any),
+        Config:         make(map[string]any),
+        DurabilityMode: cell.DurabilityDemo,
     }
 
     require.NoError(t, c.Init(ctx, deps))

--- a/docs/product/phase/phase0-interface-skeleton.md
+++ b/docs/product/phase/phase0-interface-skeleton.md
@@ -379,7 +379,10 @@ func (a *CoreAssembly) Health() map[string]cell.HealthStatus
 // gocell.go
 package gocell
 
-import "github.com/ghbvf/gocell/kernel/assembly"
+import (
+    "github.com/ghbvf/gocell/kernel/assembly"
+    "github.com/ghbvf/gocell/kernel/cell"
+)
 
 func NewAssembly(id string) *assembly.CoreAssembly {
     return assembly.New(assembly.Config{ID: id, DurabilityMode: cell.DurabilityDemo})

--- a/docs/product/phase/phase0-interface-skeleton.md
+++ b/docs/product/phase/phase0-interface-skeleton.md
@@ -382,7 +382,7 @@ package gocell
 import "github.com/ghbvf/gocell/kernel/assembly"
 
 func NewAssembly(id string) *assembly.CoreAssembly {
-    return assembly.New(assembly.Config{ID: id})
+    return assembly.New(assembly.Config{ID: id, DurabilityMode: cell.DurabilityDemo})
 }
 ```
 

--- a/docs/reviews/archive/202604060830-R0/R1C-5-runtime-observability-bootstrap.md
+++ b/docs/reviews/archive/202604060830-R0/R1C-5-runtime-observability-bootstrap.md
@@ -52,7 +52,7 @@ func TestBootstrap_RunHappyPath(t *testing.T) {
     ln, err := net.Listen("tcp", "127.0.0.1:0")
     require.NoError(t, err)
     
-    asm := assembly.New(assembly.Config{ID: "test"})
+    asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
     require.NoError(t, asm.Register(newTestCell("cell-1")))
     
     ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)

--- a/examples/iot-device/main.go
+++ b/examples/iot-device/main.go
@@ -16,6 +16,7 @@ import (
 
 	devicecell "github.com/ghbvf/gocell/cells/device-cell"
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -45,7 +46,7 @@ func main() {
 	)
 
 	// Build assembly and register the cell.
-	asm := assembly.New(assembly.Config{ID: "iot-device"})
+	asm := assembly.New(assembly.Config{ID: "iot-device", DurabilityMode: cell.DurabilityDemo})
 	if err := asm.Register(dc); err != nil {
 		logger.Error("failed to register device-cell", slog.Any("error", err))
 		os.Exit(1)

--- a/examples/sso-bff/main.go
+++ b/examples/sso-bff/main.go
@@ -20,6 +20,7 @@ import (
 	auditcore "github.com/ghbvf/gocell/cells/audit-core"
 	configcore "github.com/ghbvf/gocell/cells/config-core"
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -114,7 +115,7 @@ func main() {
 	)
 
 	// Build assembly and register all three Cells.
-	asm := assembly.New(assembly.Config{ID: "sso-bff"})
+	asm := assembly.New(assembly.Config{ID: "sso-bff", DurabilityMode: cell.DurabilityDemo})
 	for _, err := range []error{
 		asm.Register(ac),
 		asm.Register(auc),

--- a/examples/todo-order/main.go
+++ b/examples/todo-order/main.go
@@ -20,6 +20,7 @@ import (
 
 	ordercell "github.com/ghbvf/gocell/cells/order-cell"
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -52,7 +53,7 @@ func main() {
 	)
 
 	// Build assembly and register the cell.
-	asm := assembly.New(assembly.Config{ID: "todo-order"})
+	asm := assembly.New(assembly.Config{ID: "todo-order", DurabilityMode: cell.DurabilityDemo})
 	if err := asm.Register(oc); err != nil {
 		logger.Error("failed to register order-cell", slog.Any("error", err))
 		os.Exit(1)

--- a/gocell.go
+++ b/gocell.go
@@ -1,9 +1,12 @@
 // Package gocell provides the top-level entry point for the GoCell framework.
 package gocell
 
-import "github.com/ghbvf/gocell/kernel/assembly"
+import (
+	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
+)
 
 // NewAssembly creates a new CoreAssembly with the given identifier.
 func NewAssembly(id string) *assembly.CoreAssembly {
-	return assembly.New(assembly.Config{ID: id})
+	return assembly.New(assembly.Config{ID: id, DurabilityMode: cell.DurabilityDemo})
 }

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -36,7 +36,7 @@ const (
 // Config holds assembly-level configuration.
 type Config struct {
 	ID             string
-	DurabilityMode cell.DurabilityMode // Demo (default) or Durable
+	DurabilityMode cell.DurabilityMode // Required: Demo or Durable (zero value rejected by CheckNotNoop)
 }
 
 // CoreAssembly is the default Assembly implementation. It manages a set of

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -195,6 +195,14 @@ func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any)
 		cfgMap = make(map[string]any)
 	}
 
+	if err := cell.ValidateMode(a.cfg.DurabilityMode); err != nil {
+		a.mu.Lock()
+		a.state = stateStopped
+		a.mu.Unlock()
+		return errcode.Wrap(errcode.ErrValidationFailed,
+			fmt.Sprintf("assembly %q", a.id), err)
+	}
+
 	deps := cell.Dependencies{
 		Config:         cfgMap,
 		DurabilityMode: a.cfg.DurabilityMode,

--- a/kernel/assembly/assembly_test.go
+++ b/kernel/assembly/assembly_test.go
@@ -61,24 +61,6 @@ func newEmptyIDCell() *emptyIDCell {
 	}
 }
 
-// durabilityCheckCell calls CheckNotNoop in Init (like real L2 cells do).
-type durabilityCheckCell struct {
-	*cell.BaseCell
-}
-
-func newDurabilityCheckCell(id string) *durabilityCheckCell {
-	return &durabilityCheckCell{
-		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore, ConsistencyLevel: cell.L2}),
-	}
-}
-
-func (c *durabilityCheckCell) Init(ctx context.Context, deps cell.Dependencies) error {
-	if err := c.BaseCell.Init(ctx, deps); err != nil {
-		return err
-	}
-	return cell.CheckNotNoop(deps.DurabilityMode, c.ID())
-}
-
 // failStartCell passes Init but fails on Start.
 type failStartCell struct {
 	*cell.BaseCell
@@ -412,13 +394,25 @@ func TestAssemblyCellLookup(t *testing.T) {
 	assert.Nil(t, a.Cell("nonexistent"))
 }
 
-func TestAssemblyStart_ZeroDurabilityMode_FailsOnCellThatChecks(t *testing.T) {
-	// Integration: assembly with zero DurabilityMode + cell that calls CheckNotNoop → Start fails.
+func TestAssemblyStart_ZeroDurabilityMode_FailsAtAssemblyLevel(t *testing.T) {
+	// Zero DurabilityMode is rejected at assembly.Start — before any cell.Init runs.
 	a := New(Config{ID: "test-zero-durability"}) // zero DurabilityMode (unset)
-	c := newDurabilityCheckCell("durability-cell")
+	c := cell.NewBaseCell(cell.CellMetadata{ID: "any-cell", Type: cell.CellTypeCore})
 	require.NoError(t, a.Register(c))
 
 	err := a.Start(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "DurabilityMode not set")
+	assert.Contains(t, err.Error(), "invalid DurabilityMode 0")
+}
+
+func TestAssemblyStart_InvalidDurabilityMode_Rejects(t *testing.T) {
+	// Non-zero, non-valid mode (e.g., 99) rejected at assembly level.
+	// ref: Kubernetes allowlist validation, Uber fx fail-fast
+	a := New(Config{ID: "test-invalid-mode", DurabilityMode: cell.DurabilityMode(99)})
+	c := cell.NewBaseCell(cell.CellMetadata{ID: "any-cell", Type: cell.CellTypeCore})
+	require.NoError(t, a.Register(c))
+
+	err := a.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid DurabilityMode 99")
 }

--- a/kernel/assembly/assembly_test.go
+++ b/kernel/assembly/assembly_test.go
@@ -61,6 +61,24 @@ func newEmptyIDCell() *emptyIDCell {
 	}
 }
 
+// durabilityCheckCell calls CheckNotNoop in Init (like real L2 cells do).
+type durabilityCheckCell struct {
+	*cell.BaseCell
+}
+
+func newDurabilityCheckCell(id string) *durabilityCheckCell {
+	return &durabilityCheckCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore, ConsistencyLevel: cell.L2}),
+	}
+}
+
+func (c *durabilityCheckCell) Init(ctx context.Context, deps cell.Dependencies) error {
+	if err := c.BaseCell.Init(ctx, deps); err != nil {
+		return err
+	}
+	return cell.CheckNotNoop(deps.DurabilityMode, c.ID())
+}
+
 // failStartCell passes Init but fails on Start.
 type failStartCell struct {
 	*cell.BaseCell
@@ -98,7 +116,7 @@ func (c *failStopCell) Stop(_ context.Context) error {
 // ---------------------------------------------------------------------------
 
 func TestAssemblyStartStopHealthy(t *testing.T) {
-	a := New(Config{ID: "test-assembly"})
+	a := New(Config{ID: "test-assembly", DurabilityMode: cell.DurabilityDemo})
 
 	c1 := cell.NewBaseCell(cell.CellMetadata{ID: "c1", Type: cell.CellTypeCore, ConsistencyLevel: cell.L1})
 	c2 := cell.NewBaseCell(cell.CellMetadata{ID: "c2", Type: cell.CellTypeEdge, ConsistencyLevel: cell.L2})
@@ -120,7 +138,7 @@ func TestAssemblyStartStopHealthy(t *testing.T) {
 }
 
 func TestAssemblyStopReverseOrder(t *testing.T) {
-	a := New(Config{ID: "order-test"})
+	a := New(Config{ID: "order-test", DurabilityMode: cell.DurabilityDemo})
 
 	var order []string
 	c1 := newOrderCell("first", &order)
@@ -137,7 +155,7 @@ func TestAssemblyStopReverseOrder(t *testing.T) {
 }
 
 func TestAssemblyDuplicateCellID(t *testing.T) {
-	a := New(Config{ID: "dup-test"})
+	a := New(Config{ID: "dup-test", DurabilityMode: cell.DurabilityDemo})
 	c1 := cell.NewBaseCell(cell.CellMetadata{ID: "same", Type: cell.CellTypeCore})
 	c2 := cell.NewBaseCell(cell.CellMetadata{ID: "same", Type: cell.CellTypeCore})
 
@@ -151,7 +169,7 @@ func TestAssemblyDuplicateCellID(t *testing.T) {
 }
 
 func TestAssemblyEmptyCellID(t *testing.T) {
-	a := New(Config{ID: "empty-id-test"})
+	a := New(Config{ID: "empty-id-test", DurabilityMode: cell.DurabilityDemo})
 
 	err := a.Register(newEmptyIDCell())
 	require.Error(t, err)
@@ -161,7 +179,7 @@ func TestAssemblyEmptyCellID(t *testing.T) {
 }
 
 func TestAssemblyInitFailure(t *testing.T) {
-	a := New(Config{ID: "init-fail"})
+	a := New(Config{ID: "init-fail", DurabilityMode: cell.DurabilityDemo})
 
 	good := cell.NewBaseCell(cell.CellMetadata{ID: "good", Type: cell.CellTypeCore})
 	bad := newFailInitCell("bad")
@@ -183,7 +201,7 @@ func TestAssemblyInitFailure(t *testing.T) {
 }
 
 func TestAssemblyStopWithoutStart(t *testing.T) {
-	a := New(Config{ID: "no-start"})
+	a := New(Config{ID: "no-start", DurabilityMode: cell.DurabilityDemo})
 	c := cell.NewBaseCell(cell.CellMetadata{ID: "c", Type: cell.CellTypeCore})
 	require.NoError(t, a.Register(c))
 
@@ -192,7 +210,7 @@ func TestAssemblyStopWithoutStart(t *testing.T) {
 }
 
 func TestAssemblyStopOnlyFromStarted(t *testing.T) {
-	a := New(Config{ID: "guard-test"})
+	a := New(Config{ID: "guard-test", DurabilityMode: cell.DurabilityDemo})
 	var order []string
 	c := newOrderCell("c1", &order)
 	require.NoError(t, a.Register(c))
@@ -213,13 +231,13 @@ func TestAssemblyStopOnlyFromStarted(t *testing.T) {
 }
 
 func TestAssemblyStopEmpty(t *testing.T) {
-	a := New(Config{ID: "empty"})
+	a := New(Config{ID: "empty", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, a.Stop(context.Background()))
 }
 
 func TestAssemblyStartFailureRollback(t *testing.T) {
 	// ref: uber-go/fx — Start 失败自动 rollback 已启动的 Cell
-	a := New(Config{ID: "start-fail"})
+	a := New(Config{ID: "start-fail", DurabilityMode: cell.DurabilityDemo})
 
 	var order []string
 	good := newOrderCell("good", &order)
@@ -246,7 +264,7 @@ func TestAssemblyStartFailureRollback(t *testing.T) {
 
 func TestAssemblyDoubleStartPrevented(t *testing.T) {
 	// ref: uber-go/fx lifecycle.go — 状态机防止重入
-	a := New(Config{ID: "double-start"})
+	a := New(Config{ID: "double-start", DurabilityMode: cell.DurabilityDemo})
 	c := cell.NewBaseCell(cell.CellMetadata{ID: "c", Type: cell.CellTypeCore})
 	require.NoError(t, a.Register(c))
 	require.NoError(t, a.Start(context.Background()))
@@ -256,7 +274,7 @@ func TestAssemblyDoubleStartPrevented(t *testing.T) {
 }
 
 func TestAssemblyRegisterAfterStartRejected(t *testing.T) {
-	a := New(Config{ID: "reg-after-start"})
+	a := New(Config{ID: "reg-after-start", DurabilityMode: cell.DurabilityDemo})
 	c1 := cell.NewBaseCell(cell.CellMetadata{ID: "c1", Type: cell.CellTypeCore})
 	require.NoError(t, a.Register(c1))
 	require.NoError(t, a.Start(context.Background()))
@@ -273,7 +291,7 @@ func TestAssemblyRegisterAfterStartRejected(t *testing.T) {
 }
 
 func TestAssemblyStopContinuesOnError(t *testing.T) {
-	a := New(Config{ID: "stop-err"})
+	a := New(Config{ID: "stop-err", DurabilityMode: cell.DurabilityDemo})
 
 	good := cell.NewBaseCell(cell.CellMetadata{ID: "good", Type: cell.CellTypeCore})
 	bad1 := newFailStopCell("bad1")
@@ -299,7 +317,7 @@ func TestAssemblyStopContinuesOnError(t *testing.T) {
 }
 
 func TestAssemblyStartWithConfig(t *testing.T) {
-	a := New(Config{ID: "config-test"})
+	a := New(Config{ID: "config-test", DurabilityMode: cell.DurabilityDemo})
 	c := cell.NewBaseCell(cell.CellMetadata{ID: "c1", Type: cell.CellTypeCore})
 	require.NoError(t, a.Register(c))
 
@@ -312,7 +330,7 @@ func TestAssemblyStartWithConfig(t *testing.T) {
 }
 
 func TestAssemblyStartWithConfigDoubleStart(t *testing.T) {
-	a := New(Config{ID: "double-cfg"})
+	a := New(Config{ID: "double-cfg", DurabilityMode: cell.DurabilityDemo})
 	c := cell.NewBaseCell(cell.CellMetadata{ID: "c1", Type: cell.CellTypeCore})
 	require.NoError(t, a.Register(c))
 	require.NoError(t, a.StartWithConfig(context.Background(), nil))
@@ -323,7 +341,7 @@ func TestAssemblyStartWithConfigDoubleStart(t *testing.T) {
 }
 
 func TestAssemblyStartWithConfigInitFailure(t *testing.T) {
-	a := New(Config{ID: "init-fail-cfg"})
+	a := New(Config{ID: "init-fail-cfg", DurabilityMode: cell.DurabilityDemo})
 	bad := newFailInitCell("bad")
 	require.NoError(t, a.Register(bad))
 
@@ -332,7 +350,7 @@ func TestAssemblyStartWithConfigInitFailure(t *testing.T) {
 }
 
 func TestAssemblyStartWithConfigStartFailureRollback(t *testing.T) {
-	a := New(Config{ID: "start-fail-cfg"})
+	a := New(Config{ID: "start-fail-cfg", DurabilityMode: cell.DurabilityDemo})
 
 	var order []string
 	good := newOrderCell("good", &order)
@@ -346,7 +364,7 @@ func TestAssemblyStartWithConfigStartFailureRollback(t *testing.T) {
 }
 
 func TestAssemblyCellIDs(t *testing.T) {
-	a := New(Config{ID: "ids-test"})
+	a := New(Config{ID: "ids-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, a.Register(cell.NewBaseCell(cell.CellMetadata{ID: "a", Type: cell.CellTypeCore})))
 	require.NoError(t, a.Register(cell.NewBaseCell(cell.CellMetadata{ID: "b", Type: cell.CellTypeCore})))
 
@@ -355,7 +373,7 @@ func TestAssemblyCellIDs(t *testing.T) {
 }
 
 func TestAssemblyHealthConcurrentWithRegister(t *testing.T) {
-	a := New(Config{ID: "concurrent-health"})
+	a := New(Config{ID: "concurrent-health", DurabilityMode: cell.DurabilityDemo})
 
 	// Pre-register some cells.
 	for i := range 5 {
@@ -383,7 +401,7 @@ func TestAssemblyHealthConcurrentWithRegister(t *testing.T) {
 }
 
 func TestAssemblyCellLookup(t *testing.T) {
-	a := New(Config{ID: "lookup-test"})
+	a := New(Config{ID: "lookup-test", DurabilityMode: cell.DurabilityDemo})
 	c := cell.NewBaseCell(cell.CellMetadata{ID: "x", Type: cell.CellTypeCore})
 	require.NoError(t, a.Register(c))
 
@@ -392,4 +410,15 @@ func TestAssemblyCellLookup(t *testing.T) {
 	assert.Equal(t, "x", found.ID())
 
 	assert.Nil(t, a.Cell("nonexistent"))
+}
+
+func TestAssemblyStart_ZeroDurabilityMode_FailsOnCellThatChecks(t *testing.T) {
+	// Integration: assembly with zero DurabilityMode + cell that calls CheckNotNoop → Start fails.
+	a := New(Config{ID: "test-zero-durability"}) // zero DurabilityMode (unset)
+	c := newDurabilityCheckCell("durability-cell")
+	require.NoError(t, a.Register(c))
+
+	err := a.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DurabilityMode not set")
 }

--- a/kernel/assembly/generator_test.go
+++ b/kernel/assembly/generator_test.go
@@ -125,7 +125,7 @@ func TestGenerateEntrypoint_ContainsAssemblyID(t *testing.T) {
 	require.NoError(t, err)
 
 	content := string(out)
-	assert.Contains(t, content, `assembly.Config{ID: "sso-bff"}`)
+	assert.Contains(t, content, `assembly.Config{ID: "sso-bff", DurabilityMode: cell.DurabilityDemo}`)
 }
 
 func TestGenerateEntrypoint_ContainsCellComments(t *testing.T) {
@@ -362,7 +362,7 @@ func TestGenerateEntrypoint_EmptyAssembly(t *testing.T) {
 	require.NoError(t, err)
 
 	content := string(out)
-	assert.Contains(t, content, `assembly.Config{ID: "empty"}`)
+	assert.Contains(t, content, `assembly.Config{ID: "empty", DurabilityMode: cell.DurabilityDemo}`)
 	// No cell comments expected
 	assert.NotContains(t, content, "access-core")
 }

--- a/kernel/assembly/gentpl/main.go.tpl
+++ b/kernel/assembly/gentpl/main.go.tpl
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"{{.Module}}/kernel/assembly"
+	"{{.Module}}/kernel/cell"
 	// Cell imports
 {{- range .Cells}}
 	// TODO: import {{.}} cell package
@@ -16,7 +17,7 @@ import (
 )
 
 func main() {
-	app := assembly.New(assembly.Config{ID: "{{.AssemblyID}}"})
+	app := assembly.New(assembly.Config{ID: "{{.AssemblyID}}", DurabilityMode: cell.DurabilityDemo})
 
 	// Register cells
 {{- range .Cells}}

--- a/kernel/assembly/hooks_test.go
+++ b/kernel/assembly/hooks_test.go
@@ -163,7 +163,7 @@ var _ cell.BeforeStarter = (*onlyBeforeStartCell)(nil)
 // ---------------------------------------------------------------------------
 
 func TestAssemblyHooks_HappyPath(t *testing.T) {
-	a := New(Config{ID: "hooks-happy"})
+	a := New(Config{ID: "hooks-happy", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	a1 := newHookOrderCell("A", &calls, "")
@@ -188,7 +188,7 @@ func TestAssemblyHooks_HappyPath(t *testing.T) {
 }
 
 func TestAssemblyHooks_BeforeStartFailure(t *testing.T) {
-	a := New(Config{ID: "hooks-bs-fail"})
+	a := New(Config{ID: "hooks-bs-fail", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -214,7 +214,7 @@ func TestAssemblyHooks_BeforeStartFailure(t *testing.T) {
 }
 
 func TestAssemblyHooks_AfterStartFailure_RollbackIncludesFailedCell(t *testing.T) {
-	a := New(Config{ID: "hooks-as-fail"})
+	a := New(Config{ID: "hooks-as-fail", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -239,7 +239,7 @@ func TestAssemblyHooks_AfterStartFailure_RollbackIncludesFailedCell(t *testing.T
 }
 
 func TestAssemblyHooks_BeforeStopError_ContinuesAnyway(t *testing.T) {
-	a := New(Config{ID: "hooks-bstop-err"})
+	a := New(Config{ID: "hooks-bstop-err", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -265,7 +265,7 @@ func TestAssemblyHooks_BeforeStopError_ContinuesAnyway(t *testing.T) {
 }
 
 func TestAssemblyHooks_AfterStopError_ContinuesAnyway(t *testing.T) {
-	a := New(Config{ID: "hooks-astop-err"})
+	a := New(Config{ID: "hooks-astop-err", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -289,7 +289,7 @@ func TestAssemblyHooks_AfterStopError_ContinuesAnyway(t *testing.T) {
 }
 
 func TestAssemblyHooks_MixedCells(t *testing.T) {
-	a := New(Config{ID: "hooks-mixed"})
+	a := New(Config{ID: "hooks-mixed", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	hooked1 := newHookOrderCell("H1", &calls, "")
@@ -320,7 +320,7 @@ func TestAssemblyHooks_MixedCells(t *testing.T) {
 }
 
 func TestAssemblyHooks_PartialImplementation(t *testing.T) {
-	a := New(Config{ID: "hooks-partial"})
+	a := New(Config{ID: "hooks-partial", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	partial := newOnlyBeforeStartCell("P", &calls)
@@ -337,7 +337,7 @@ func TestAssemblyHooks_PartialImplementation(t *testing.T) {
 }
 
 func TestAssemblyHooks_StartWithConfig(t *testing.T) {
-	a := New(Config{ID: "hooks-cfg"})
+	a := New(Config{ID: "hooks-cfg", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	h := newHookOrderCell("A", &calls, "")
@@ -358,7 +358,7 @@ func TestAssemblyHooks_StartWithConfig(t *testing.T) {
 }
 
 func TestAssemblyHooks_RollbackHooksBestEffort(t *testing.T) {
-	a := New(Config{ID: "hooks-rb-best"})
+	a := New(Config{ID: "hooks-rb-best", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	// A has BeforeStop that fails — during rollback this should not abort.
@@ -384,7 +384,7 @@ func TestAssemblyHooks_RollbackHooksBestEffort(t *testing.T) {
 
 // F3-2: Start failure (not hook) triggers LIFO rollback with hooks on previously-started cells.
 func TestAssemblyHooks_StartFailure_RollbackUsesHooks(t *testing.T) {
-	a := New(Config{ID: "hooks-start-fail"})
+	a := New(Config{ID: "hooks-start-fail", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -408,7 +408,7 @@ func TestAssemblyHooks_StartFailure_RollbackUsesHooks(t *testing.T) {
 
 // F3-3: Context cancellation is respected by hooks.
 func TestAssemblyHooks_ContextCancellation(t *testing.T) {
-	a := New(Config{ID: "hooks-ctx-cancel"})
+	a := New(Config{ID: "hooks-ctx-cancel", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	// Cell whose BeforeStart checks context.
@@ -436,7 +436,7 @@ func TestAssemblyHooks_ContextCancellation(t *testing.T) {
 
 // F2-1: Panic in hook is recovered and treated as error, not crash.
 func TestAssemblyHooks_PanicRecovery_BeforeStart(t *testing.T) {
-	a := New(Config{ID: "hooks-panic-bs"})
+	a := New(Config{ID: "hooks-panic-bs", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -459,7 +459,7 @@ func TestAssemblyHooks_PanicRecovery_BeforeStart(t *testing.T) {
 }
 
 func TestAssemblyHooks_PanicRecovery_AfterStart(t *testing.T) {
-	a := New(Config{ID: "hooks-panic-as"})
+	a := New(Config{ID: "hooks-panic-as", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -482,7 +482,7 @@ func TestAssemblyHooks_PanicRecovery_AfterStart(t *testing.T) {
 }
 
 func TestAssemblyHooks_PanicRecovery_BeforeStop(t *testing.T) {
-	a := New(Config{ID: "hooks-panic-bstop"})
+	a := New(Config{ID: "hooks-panic-bstop", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")
@@ -506,7 +506,7 @@ func TestAssemblyHooks_PanicRecovery_BeforeStop(t *testing.T) {
 }
 
 func TestAssemblyHooks_PanicRecovery_AfterStop(t *testing.T) {
-	a := New(Config{ID: "hooks-panic-astop"})
+	a := New(Config{ID: "hooks-panic-astop", DurabilityMode: cell.DurabilityDemo})
 	var calls []string
 
 	good := newHookOrderCell("A", &calls, "")

--- a/kernel/cell/durability.go
+++ b/kernel/cell/durability.go
@@ -10,26 +10,31 @@ import (
 // Cells use this to reject noop/test implementations at Init() time,
 // preventing "pseudo-success" assemblies in production.
 //
-// ref: Spring @Profile (advisory) / Uber fx (no equivalent) / Watermill (no equivalent).
-// GoCell's fail-fast approach is stricter than all three reference frameworks.
+// The zero value is intentionally invalid (unset), forcing callers to
+// explicitly choose DurabilityDemo or DurabilityDurable.
+// ref: Vault StoredKeysInvalid=0, gRPC InvalidSecurityLevel=0, net/http SameSite iota+1
 type DurabilityMode int
 
 const (
 	// DurabilityDemo allows noop implementations (NoopWriter, NoopTxRunner,
 	// DiscardPublisher). Used by examples/ and unit tests.
-	DurabilityDemo DurabilityMode = iota
+	DurabilityDemo DurabilityMode = iota + 1
 
 	// DurabilityDurable rejects noop implementations at Init() time.
 	// Used by production assemblies (e.g., cmd/core-bundle).
 	DurabilityDurable
 )
 
-// String returns "demo" or "durable".
+// String returns "demo", "durable", or "unset".
 func (m DurabilityMode) String() string {
-	if m == DurabilityDurable {
+	switch m {
+	case DurabilityDemo:
+		return "demo"
+	case DurabilityDurable:
 		return "durable"
+	default:
+		return "unset"
 	}
-	return "demo"
 }
 
 // Nooper is a marker interface for test/demo-only implementations.
@@ -42,10 +47,15 @@ type Nooper interface {
 	Noop() bool
 }
 
-// CheckNotNoop returns an error if any dep implements Nooper and mode is
-// DurabilityDurable. In DurabilityDemo mode, all deps are accepted.
-// nil deps are silently skipped (nil checks belong in the caller).
+// CheckNotNoop returns an error if mode is unset (zero value), or if any dep
+// implements Nooper and mode is DurabilityDurable. In DurabilityDemo mode,
+// all deps are accepted. nil deps are silently skipped (nil checks belong
+// in the caller).
 func CheckNotNoop(mode DurabilityMode, cellID string, deps ...any) error {
+	if mode == 0 {
+		return errcode.New(errcode.ErrValidationFailed,
+			fmt.Sprintf("%s: DurabilityMode not set; explicitly choose DurabilityDemo or DurabilityDurable", cellID))
+	}
 	if mode != DurabilityDurable {
 		return nil
 	}

--- a/kernel/cell/durability.go
+++ b/kernel/cell/durability.go
@@ -47,16 +47,27 @@ type Nooper interface {
 	Noop() bool
 }
 
-// CheckNotNoop returns an error if mode is unset (zero value), or if any dep
-// implements Nooper and mode is DurabilityDurable. In DurabilityDemo mode,
-// all deps are accepted. nil deps are silently skipped (nil checks belong
-// in the caller).
-func CheckNotNoop(mode DurabilityMode, cellID string, deps ...any) error {
-	if mode == 0 {
+// ValidateMode returns an error if mode is not a known DurabilityMode.
+// Use at assembly-start boundaries to reject misconfiguration early.
+func ValidateMode(mode DurabilityMode) error {
+	switch mode {
+	case DurabilityDemo, DurabilityDurable:
+		return nil
+	default:
 		return errcode.New(errcode.ErrValidationFailed,
-			fmt.Sprintf("%s: DurabilityMode not set; explicitly choose DurabilityDemo or DurabilityDurable", cellID))
+			fmt.Sprintf("invalid DurabilityMode %d; explicitly choose DurabilityDemo or DurabilityDurable", int(mode)))
 	}
-	if mode != DurabilityDurable {
+}
+
+// CheckNotNoop returns an error if mode is invalid, or if any dep implements
+// Nooper and mode is DurabilityDurable. In DurabilityDemo mode, all deps are
+// accepted. nil deps are silently skipped (nil checks belong in the caller).
+func CheckNotNoop(mode DurabilityMode, cellID string, deps ...any) error {
+	if err := ValidateMode(mode); err != nil {
+		return errcode.Wrap(errcode.ErrValidationFailed,
+			fmt.Sprintf("%s: DurabilityMode check", cellID), err)
+	}
+	if mode == DurabilityDemo {
 		return nil
 	}
 	for _, dep := range deps {

--- a/kernel/cell/durability_test.go
+++ b/kernel/cell/durability_test.go
@@ -32,13 +32,13 @@ func TestCheckNotNoop_UnsetMode_RejectsAll(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrValidationFailed, ecErr.Code)
-	assert.Contains(t, err.Error(), "DurabilityMode not set")
+	assert.Contains(t, err.Error(), "invalid DurabilityMode 0")
 }
 
 func TestCheckNotNoop_UnsetMode_RejectsEvenWithNoDeps(t *testing.T) {
 	err := CheckNotNoop(DurabilityMode(0), "test-cell")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "DurabilityMode not set")
+	assert.Contains(t, err.Error(), "invalid DurabilityMode 0")
 }
 
 func TestCheckNotNoop_DemoMode_AllowsNoop(t *testing.T) {
@@ -75,4 +75,20 @@ func TestCheckNotNoop_MultipleDeps_RejectsFirstNoop(t *testing.T) {
 func TestCheckNotNoop_MultipleDeps_AllReal(t *testing.T) {
 	err := CheckNotNoop(DurabilityDurable, "test-cell", stubReal{}, stubReal{})
 	require.NoError(t, err)
+}
+
+func TestCheckNotNoop_InvalidMode_Rejects(t *testing.T) {
+	// Non-zero, non-valid mode (e.g., 99) must be rejected, not silently treated as demo.
+	// ref: Kubernetes allowlist validation, Uber fx fail-fast
+	err := CheckNotNoop(DurabilityMode(99), "test-cell", stubReal{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid DurabilityMode 99")
+}
+
+func TestValidateMode(t *testing.T) {
+	assert.NoError(t, ValidateMode(DurabilityDemo))
+	assert.NoError(t, ValidateMode(DurabilityDurable))
+	assert.Error(t, ValidateMode(DurabilityMode(0)))
+	assert.Error(t, ValidateMode(DurabilityMode(99)))
+	assert.Error(t, ValidateMode(DurabilityMode(-1)))
 }

--- a/kernel/cell/durability_test.go
+++ b/kernel/cell/durability_test.go
@@ -20,6 +20,25 @@ type stubReal struct{}
 func TestDurabilityMode_String(t *testing.T) {
 	assert.Equal(t, "demo", DurabilityDemo.String())
 	assert.Equal(t, "durable", DurabilityDurable.String())
+	assert.Equal(t, "unset", DurabilityMode(0).String())
+}
+
+func TestCheckNotNoop_UnsetMode_RejectsAll(t *testing.T) {
+	// Zero-value DurabilityMode (unset) must be rejected regardless of deps,
+	// forcing callers to explicitly choose Demo or Durable.
+	// ref: Vault StoredKeysInvalid=0, gRPC InvalidSecurityLevel=0
+	err := CheckNotNoop(DurabilityMode(0), "test-cell", stubReal{})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrValidationFailed, ecErr.Code)
+	assert.Contains(t, err.Error(), "DurabilityMode not set")
+}
+
+func TestCheckNotNoop_UnsetMode_RejectsEvenWithNoDeps(t *testing.T) {
+	err := CheckNotNoop(DurabilityMode(0), "test-cell")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DurabilityMode not set")
 }
 
 func TestCheckNotNoop_DemoMode_AllowsNoop(t *testing.T) {

--- a/kernel/cell/interfaces.go
+++ b/kernel/cell/interfaces.go
@@ -22,7 +22,7 @@ import "context"
 // ServiceLocator) can be added without changing the Cell.Init signature.
 type Dependencies struct {
 	Config         map[string]any
-	DurabilityMode DurabilityMode // Demo (default) or Durable; see durability.go
+	DurabilityMode DurabilityMode // Required: Demo or Durable (zero value rejected); see durability.go
 }
 
 // VerifySpec describes the verification requirements for a Slice.

--- a/kernel/persistence/tx.go
+++ b/kernel/persistence/tx.go
@@ -20,7 +20,11 @@ type TxRunner interface {
 type NoopTxRunner struct{}
 
 // RunInTx calls fn with the provided context (no transaction wrapping).
+// Panics if fn is nil (programming error, ref: net/http.HandleFunc, database/sql.Register).
 func (NoopTxRunner) RunInTx(ctx context.Context, fn func(ctx context.Context) error) error {
+	if fn == nil {
+		panic("persistence: nil fn passed to RunInTx")
+	}
 	return fn(ctx)
 }
 

--- a/kernel/persistence/tx_test.go
+++ b/kernel/persistence/tx_test.go
@@ -32,7 +32,7 @@ func TestNoopTxRunner_PropagatesError(t *testing.T) {
 }
 
 func TestNoopTxRunner_NilFnPanics(t *testing.T) {
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "persistence: nil fn passed to RunInTx", func() {
 		_ = NoopTxRunner{}.RunInTx(context.Background(), nil)
 	})
 }

--- a/pkg/securecookie/securecookie_test.go
+++ b/pkg/securecookie/securecookie_test.go
@@ -56,7 +56,8 @@ func TestSecureCookie_TamperedValue(t *testing.T) {
 	require.NoError(t, err)
 
 	mid := len(encoded) / 2
-	tampered := encoded[:mid] + "X" + encoded[mid+1:]
+	// Bit-flip guarantees the byte always changes (fixes 1/64 flaky when encoded[mid] was already 'X').
+	tampered := encoded[:mid] + string(encoded[mid]^1) + encoded[mid+1:]
 
 	_, err = sc.Decode("test", tampered)
 	assert.Error(t, err, "tampered value should fail decode")

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -430,7 +430,7 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	// Step 3-4: Initialise and start assembly.
 	asm := b.assembly
 	if asm == nil {
-		asm = assembly.New(assembly.Config{ID: "default"})
+		asm = assembly.New(assembly.Config{ID: "default", DurabilityMode: cell.DurabilityDemo})
 	}
 
 	// Inject config into assembly dependencies.

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -86,7 +86,7 @@ func TestNew_Defaults(t *testing.T) {
 }
 
 func TestNew_WithOptions(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	eb := eventbus.New()
 
 	b := New(
@@ -113,7 +113,7 @@ func TestNew_WithTracer(t *testing.T) {
 func TestBootstrap_InvalidTrustedProxies_ReturnsError(t *testing.T) {
 	// Invalid trusted proxies must return error (not panic), allowing
 	// Bootstrap.Run to roll back already-started components.
-	asm := assembly.New(assembly.Config{ID: "test-proxy-err"})
+	asm := assembly.New(assembly.Config{ID: "test-proxy-err", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -157,7 +157,7 @@ func TestBootstrap_RunWithInvalidConfig(t *testing.T) {
 
 func TestBootstrap_AssemblyStartWithConfig(t *testing.T) {
 	// Test that StartWithConfig works correctly with the assembly.
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	tc := newTestCell("cell-1")
 	require.NoError(t, asm.Register(tc))
 
@@ -173,7 +173,7 @@ func TestBootstrap_AssemblyStartWithConfig(t *testing.T) {
 }
 
 func TestBootstrap_CellIDs(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("a")))
 	require.NoError(t, asm.Register(newTestCell("b")))
 
@@ -182,7 +182,7 @@ func TestBootstrap_CellIDs(t *testing.T) {
 }
 
 func TestBootstrap_CellLookup(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	tc := newTestCell("lookup")
 	require.NoError(t, asm.Register(tc))
 
@@ -294,7 +294,7 @@ func (c *eventCell) RegisterSubscriptions(r cell.EventRouter) error {
 func TestBootstrap_MissingSubscriber_WithEventRegistrar_Fails(t *testing.T) {
 	// When a cell implements EventRegistrar but no subscriber is configured,
 	// bootstrap must fail at startup instead of silently skipping all subscriptions.
-	asm := assembly.New(assembly.Config{ID: "test-no-sub"})
+	asm := assembly.New(assembly.Config{ID: "test-no-sub", DurabilityMode: cell.DurabilityDemo})
 	ec := newEventCell("needs-sub", nil) // registers a handler
 	require.NoError(t, asm.Register(ec))
 
@@ -315,7 +315,7 @@ func TestBootstrap_MissingSubscriber_WithEventRegistrar_Fails(t *testing.T) {
 func TestBootstrap_SubscriptionFailure_TriggersRollback(t *testing.T) {
 	// S3-03: When RegisterSubscriptions fails, Run must rollback previously
 	// started components (assembly) and return an error wrapping the cause.
-	asm := assembly.New(assembly.Config{ID: "test-rollback"})
+	asm := assembly.New(assembly.Config{ID: "test-rollback", DurabilityMode: cell.DurabilityDemo})
 	ec := newEventCell("fail-cell", errors.New("DLX not configured"))
 	require.NoError(t, asm.Register(ec))
 
@@ -342,7 +342,7 @@ func TestBootstrap_EventRouter_HappyPath(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-router-ok"})
+	asm := assembly.New(assembly.Config{ID: "test-router-ok", DurabilityMode: cell.DurabilityDemo})
 	ec := newEventCell("ok-cell", nil) // nil error → registers 1 handler
 	require.NoError(t, asm.Register(ec))
 
@@ -383,7 +383,7 @@ func TestBootstrap_EventSubscriptions_RestoreObservabilityContext(t *testing.T) 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-router-context"})
+	asm := assembly.New(assembly.Config{ID: "test-router-context", DurabilityMode: cell.DurabilityDemo})
 	got := make(chan map[string]string, 1)
 	require.NoError(t, asm.Register(newContextCaptureCell("capture-cell", got)))
 
@@ -440,7 +440,7 @@ func TestBootstrap_EventSubscriptions_DisableObservabilityRestore(t *testing.T) 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-kill-switch"})
+	asm := assembly.New(assembly.Config{ID: "test-kill-switch", DurabilityMode: cell.DurabilityDemo})
 	got := make(chan map[string]string, 1)
 	require.NoError(t, asm.Register(newContextCaptureCell("capture-cell", got)))
 
@@ -532,7 +532,7 @@ func TestBootstrap_WithHealthChecker_Healthy(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-hc-healthy"})
+	asm := assembly.New(assembly.Config{ID: "test-hc-healthy", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -583,7 +583,7 @@ func TestBootstrap_WithHealthChecker_Unhealthy(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-hc-unhealthy"})
+	asm := assembly.New(assembly.Config{ID: "test-hc-unhealthy", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -636,7 +636,7 @@ func TestBootstrap_WithAdapterInfo_AppearsInReadyz(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-adapter-info"})
+	asm := assembly.New(assembly.Config{ID: "test-adapter-info", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -708,7 +708,7 @@ func TestBootstrap_HealthContributor_Discovery_AppearsInReadyz(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-hc-contrib"})
+	asm := assembly.New(assembly.Config{ID: "test-hc-contrib", DurabilityMode: cell.DurabilityDemo})
 	hcc := newHealthContribCell("access-core", map[string]func() error{
 		"session-store": func() error { return nil },
 	})
@@ -760,7 +760,7 @@ func TestBootstrap_HealthContributor_DuplicateName_FailsFast(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-hc-dup"})
+	asm := assembly.New(assembly.Config{ID: "test-hc-dup", DurabilityMode: cell.DurabilityDemo})
 	// Two cells both return "session-store" probe — should conflict.
 	require.NoError(t, asm.Register(newHealthContribCell("cell-a", map[string]func() error{
 		"session-store": func() error { return nil },
@@ -827,7 +827,7 @@ func TestBootstrap_WithMultipleHealthCheckers_OneUnhealthy(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-multi-hc"})
+	asm := assembly.New(assembly.Config{ID: "test-multi-hc", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -881,7 +881,7 @@ func TestBootstrap_WithHealthChecker_DynamicStateTransition(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-dynamic-hc"})
+	asm := assembly.New(assembly.Config{ID: "test-dynamic-hc", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	// Atomic flag to simulate connection health transitions at runtime.
@@ -953,7 +953,7 @@ func TestBootstrap_ConfigWatcher_ReadyzVerboseIncludesWatcher(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-config-watcher-readyz"})
+	asm := assembly.New(assembly.Config{ID: "test-config-watcher-readyz", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -1014,7 +1014,7 @@ func TestBootstrap_ConfigDriftReadyz_NoDrift(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-config-drift-no-drift"})
+	asm := assembly.New(assembly.Config{ID: "test-config-drift-no-drift", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -1140,7 +1140,7 @@ func TestBootstrap_ConfigDriftReadyz_HTTP503OnDrift(t *testing.T) {
 	failCell := newReloaderCell("fail-cell")
 	failCell.err = fmt.Errorf("intentional reload failure")
 
-	asm := assembly.New(assembly.Config{ID: "test-drift-http-503"})
+	asm := assembly.New(assembly.Config{ID: "test-drift-http-503", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(failCell))
 
 	b := New(
@@ -1204,7 +1204,7 @@ func TestBootstrap_ConfigWatcherInitFailure_FailsFast(t *testing.T) {
 	cfgFile := filepath.Join(dir, "config.yaml")
 	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: test\n"), 0o644))
 
-	asm := assembly.New(assembly.Config{ID: "test-config-watcher-fail-fast"})
+	asm := assembly.New(assembly.Config{ID: "test-config-watcher-fail-fast", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -1228,7 +1228,7 @@ func TestBootstrap_WithHealthChecker_ReservedNameConflict_ReturnsError(t *testin
 	cfgFile := filepath.Join(dir, "config.yaml")
 	require.NoError(t, os.WriteFile(cfgFile, []byte("app:\n  name: test\n"), 0o644))
 
-	asm := assembly.New(assembly.Config{ID: "test-reserved-health-checker"})
+	asm := assembly.New(assembly.Config{ID: "test-reserved-health-checker", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	b := New(
@@ -1250,7 +1250,7 @@ func TestBootstrap_EventRouter_ReadyzVerboseIncludesEventRouter(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-eventrouter-readyz"})
+	asm := assembly.New(assembly.Config{ID: "test-eventrouter-readyz", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newEventCell("ok-cell", nil)))
 
 	eb := eventbus.New()
@@ -1458,7 +1458,7 @@ func TestBootstrap_ShutdownDrainsInflightReload(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-drain"})
+	asm := assembly.New(assembly.Config{ID: "test-drain", DurabilityMode: cell.DurabilityDemo})
 	slow := newSlowReloaderCell("slow-cell", 300*time.Millisecond)
 	require.NoError(t, asm.Register(slow))
 
@@ -1515,7 +1515,7 @@ func TestBootstrap_ConfigReload_NotifiesCells(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-reload"})
+	asm := assembly.New(assembly.Config{ID: "test-reload", DurabilityMode: cell.DurabilityDemo})
 	rc := newReloaderCell("auth-core")
 	require.NoError(t, asm.Register(rc))
 
@@ -1573,7 +1573,7 @@ func TestBootstrap_ConfigReload_ErrorDoesNotCrash(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-reload-err"})
+	asm := assembly.New(assembly.Config{ID: "test-reload-err", DurabilityMode: cell.DurabilityDemo})
 	rc := newReloaderCell("fail-cell")
 	rc.err = errors.New("reload callback failed")
 	require.NoError(t, asm.Register(rc))
@@ -1626,7 +1626,7 @@ func TestBootstrap_ConfigReload_PanicDoesNotCrash(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-reload-panic"})
+	asm := assembly.New(assembly.Config{ID: "test-reload-panic", DurabilityMode: cell.DurabilityDemo})
 	rc := newReloaderCell("panic-cell")
 	rc.doPanic = true
 	require.NoError(t, asm.Register(rc))
@@ -1679,7 +1679,7 @@ func TestBootstrap_ConfigReload_FIFO(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-reload-fifo"})
+	asm := assembly.New(assembly.Config{ID: "test-reload-fifo", DurabilityMode: cell.DurabilityDemo})
 	callOrder := make([]string, 0, 3)
 	cells := make([]*reloaderCell, 3)
 	for i, id := range []string{"first", "second", "third"} {
@@ -1738,7 +1738,7 @@ func TestBootstrap_ConfigReload_NonReloaderSkipped(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-reload-skip"})
+	asm := assembly.New(assembly.Config{ID: "test-reload-skip", DurabilityMode: cell.DurabilityDemo})
 	plain := newTestCell("plain-cell") // does NOT implement ConfigReloader
 	rc := newReloaderCell("reloader-cell")
 	require.NoError(t, asm.Register(plain))
@@ -1795,7 +1795,7 @@ func TestBootstrap_ConfigReload_NoChangeNoCallback(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-reload-noop"})
+	asm := assembly.New(assembly.Config{ID: "test-reload-noop", DurabilityMode: cell.DurabilityDemo})
 	rc := newReloaderCell("noop-cell")
 	require.NoError(t, asm.Register(rc))
 
@@ -1887,7 +1887,7 @@ func TestBootstrap_ConfigReload_EventIsolation(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-isolation"})
+	asm := assembly.New(assembly.Config{ID: "test-isolation", DurabilityMode: cell.DurabilityDemo})
 	mutator := newMutatingReloaderCell("mutator")
 	observer := newReloaderCell("observer")
 	// Register mutator first — it tries to corrupt the event.
@@ -1950,7 +1950,7 @@ func TestBootstrap_ShutdownNoPostStopReload(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-shutdown-race"})
+	asm := assembly.New(assembly.Config{ID: "test-shutdown-race", DurabilityMode: cell.DurabilityDemo})
 	rc := newReloaderCell("shutdown-race-cell")
 	require.NoError(t, asm.Register(rc))
 
@@ -2009,7 +2009,7 @@ func TestBootstrap_ShutdownRejectsReloadDuringDrain(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-shutdown-drain-reject"})
+	asm := assembly.New(assembly.Config{ID: "test-shutdown-drain-reject", DurabilityMode: cell.DurabilityDemo})
 	rc := newReloaderCell("shutdown-drain-cell")
 	require.NoError(t, asm.Register(rc))
 
@@ -2073,7 +2073,7 @@ func TestBootstrap_ConfigReload_GenerationTracking(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-generation"})
+	asm := assembly.New(assembly.Config{ID: "test-generation", DurabilityMode: cell.DurabilityDemo})
 	rc := newReloaderCell("gen-cell")
 	require.NoError(t, asm.Register(rc))
 
@@ -2205,7 +2205,7 @@ func TestBootstrap_WithAuthMiddleware_ProtectedRoute_Returns401(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-auth-401"})
+	asm := assembly.New(assembly.Config{ID: "test-auth-401", DurabilityMode: cell.DurabilityDemo})
 	hc := newHTTPCell("auth-test-cell")
 	require.NoError(t, asm.Register(hc))
 
@@ -2260,7 +2260,7 @@ func TestBootstrap_WithAuthMiddleware_PublicRoute_Passes(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-auth-public"})
+	asm := assembly.New(assembly.Config{ID: "test-auth-public", DurabilityMode: cell.DurabilityDemo})
 	hc := newHTTPCell("auth-public-cell")
 	require.NoError(t, asm.Register(hc))
 
@@ -2317,13 +2317,13 @@ func TestBootstrap_UserRouterOpts_CannotOverrideFrameworkHealth(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-health-override"})
+	asm := assembly.New(assembly.Config{ID: "test-health-override", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	// Create a custom health handler backed by an un-started assembly (unhealthy).
 	// If the user's handler wins, /readyz would return 503 because the custom
 	// assembly was never started.
-	customAsm := assembly.New(assembly.Config{ID: "custom-unstartled"})
+	customAsm := assembly.New(assembly.Config{ID: "custom-unstartled", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, customAsm.Register(newTestCell("custom-cell")))
 	customHandler := health.New(customAsm) // un-started → always unhealthy
 
@@ -2441,7 +2441,7 @@ func TestBootstrap_TracingE2E_BusinessRoute(t *testing.T) {
 		}))
 	})
 
-	asm := assembly.New(assembly.Config{ID: "trace-e2e"})
+	asm := assembly.New(assembly.Config{ID: "trace-e2e", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(tc))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2479,7 +2479,7 @@ func TestBootstrap_TracingE2E_UpstreamPropagation(t *testing.T) {
 		}))
 	})
 
-	asm := assembly.New(assembly.Config{ID: "trace-upstream"})
+	asm := assembly.New(assembly.Config{ID: "trace-upstream", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(tc))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2521,7 +2521,7 @@ func TestBootstrap_TracingE2E_PanicRoute(t *testing.T) {
 		}))
 	})
 
-	asm := assembly.New(assembly.Config{ID: "trace-panic"})
+	asm := assembly.New(assembly.Config{ID: "trace-panic", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(tc))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2619,7 +2619,7 @@ func TestBootstrap_AuthDiscovery_ProtectedRoute_Returns401(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-auth-discovery-401"})
+	asm := assembly.New(assembly.Config{ID: "test-auth-discovery-401", DurabilityMode: cell.DurabilityDemo})
 	verifier := &bootstrapTestVerifier{
 		err: fmt.Errorf("no token provided"),
 	}
@@ -2666,7 +2666,7 @@ func TestBootstrap_AuthDiscovery_PublicRoute_Passes(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-auth-discovery-public"})
+	asm := assembly.New(assembly.Config{ID: "test-auth-discovery-public", DurabilityMode: cell.DurabilityDemo})
 	verifier := &bootstrapTestVerifier{
 		err: fmt.Errorf("should not verify for public route"),
 	}
@@ -2713,7 +2713,7 @@ func TestBootstrap_WithAuthMiddleware_Precedence(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-auth-precedence"})
+	asm := assembly.New(assembly.Config{ID: "test-auth-precedence", DurabilityMode: cell.DurabilityDemo})
 
 	cellVerifier := &bootstrapTestVerifier{
 		err: fmt.Errorf("cell-verifier: should not be called"),
@@ -2769,7 +2769,7 @@ func TestBootstrap_AuthDiscovery_NoProvider_FailsClosed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Register a plain cell with no TokenVerifier method.
-	asm := assembly.New(assembly.Config{ID: "test-no-auth-provider"})
+	asm := assembly.New(assembly.Config{ID: "test-no-auth-provider", DurabilityMode: cell.DurabilityDemo})
 	hc := newHTTPCell("plain-cell")
 	require.NoError(t, asm.Register(hc))
 
@@ -2801,7 +2801,7 @@ func TestBootstrap_AuthDiscovery_MultipleProviders_FailsFast(t *testing.T) {
 		claims: auth.Claims{Subject: "user-2", Roles: []string{"admin"}},
 	}
 
-	asm := assembly.New(assembly.Config{ID: "test-multi-auth"})
+	asm := assembly.New(assembly.Config{ID: "test-multi-auth", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newAuthProviderCell("access-core", verifier1)))
 	require.NoError(t, asm.Register(newAuthProviderCell("identity-core", verifier2)))
 
@@ -2831,7 +2831,7 @@ func TestBootstrap_TrustBoundary_PublicEndpoint_IgnoresClientIDs(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-trust-boundary"})
+	asm := assembly.New(assembly.Config{ID: "test-trust-boundary", DurabilityMode: cell.DurabilityDemo})
 	verifier := &bootstrapTestVerifier{
 		claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}},
 	}

--- a/runtime/bootstrap/workers_test.go
+++ b/runtime/bootstrap/workers_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	"github.com/ghbvf/gocell/runtime/worker"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestRun_WithWorkers_Shutdown(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	asm := assembly.New(assembly.Config{ID: "test-workers"})
+	asm := assembly.New(assembly.Config{ID: "test-workers", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(newTestCell("cell-1")))
 
 	w := &countWorker{}

--- a/runtime/http/health/health_test.go
+++ b/runtime/http/health/health_test.go
@@ -51,7 +51,7 @@ func TestLivezHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			asm := assembly.New(assembly.Config{ID: "test"})
+			asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 			c := newStubCell("cell-1")
 			require.NoError(t, asm.Register(c))
 
@@ -109,7 +109,7 @@ func TestReadyzHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			asm := assembly.New(assembly.Config{ID: "test"})
+			asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 			c := newStubCell("cell-1")
 			require.NoError(t, asm.Register(c))
 
@@ -146,7 +146,7 @@ func TestReadyzHandler(t *testing.T) {
 }
 
 func TestReadyzHandler_MultipleCheckers(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -173,7 +173,7 @@ func TestReadyzHandler_MultipleCheckers(t *testing.T) {
 }
 
 func TestLivezHandler_IsProcessLivenessOnly(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 
@@ -196,7 +196,7 @@ func TestLivezHandler_IsProcessLivenessOnly(t *testing.T) {
 }
 
 func TestReadyzHandler_DefaultOutputIsAggregateOnly(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -221,7 +221,7 @@ func TestReadyzHandler_DefaultOutputIsAggregateOnly(t *testing.T) {
 }
 
 func TestReadyzHandler_VerboseOutputIncludesDetails(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -248,7 +248,7 @@ func TestReadyzHandler_VerboseOutputIncludesDetails(t *testing.T) {
 }
 
 func TestReadyzHandler_VerboseOutput_IncludesAdapterInfo(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -275,7 +275,7 @@ func TestReadyzHandler_VerboseOutput_IncludesAdapterInfo(t *testing.T) {
 }
 
 func TestReadyzHandler_VerboseOutput_OmitsAdapterInfo_WhenNotSet(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -295,7 +295,7 @@ func TestReadyzHandler_VerboseOutput_OmitsAdapterInfo_WhenNotSet(t *testing.T) {
 }
 
 func TestReadyzHandler_DefaultOutput_UnhealthyAggregate(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -347,7 +347,7 @@ func TestReadyzVerboseQueryParsing(t *testing.T) {
 }
 
 func TestRegisterChecker_DuplicatePanics(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	h := New(asm)
 	h.RegisterChecker("db", func() error { return nil })
 
@@ -357,7 +357,7 @@ func TestRegisterChecker_DuplicatePanics(t *testing.T) {
 }
 
 func TestReadyz_ShuttingDown_Returns503(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Start(context.Background()))
 	defer func() { _ = asm.Stop(context.Background()) }()
 
@@ -381,7 +381,7 @@ func TestReadyz_ShuttingDown_Returns503(t *testing.T) {
 }
 
 func TestSetShuttingDown_Idempotent(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Start(context.Background()))
 	defer func() { _ = asm.Stop(context.Background()) }()
 
@@ -396,7 +396,7 @@ func TestSetShuttingDown_Idempotent(t *testing.T) {
 }
 
 func TestEmptyAssembly(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "empty"})
+	asm := assembly.New(assembly.Config{ID: "empty", DurabilityMode: cell.DurabilityDemo})
 	h := New(asm)
 
 	rec := httptest.NewRecorder()

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -40,7 +40,7 @@ func TestRouterImplementsRouteMux(t *testing.T) {
 }
 
 func TestHealthEndpoints(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -646,7 +646,7 @@ func TestWithCircuitBreaker_Open_Returns503(t *testing.T) {
 // --- Infra endpoints bypass RL/CB ---
 
 func TestInfraEndpoints_BypassRateLimiter(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -666,7 +666,7 @@ func TestInfraEndpoints_BypassRateLimiter(t *testing.T) {
 }
 
 func TestInfraEndpoints_BypassCircuitBreaker(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
@@ -802,7 +802,7 @@ func TestWithAuthMiddleware_PublicEndpoint_SkipsAuth(t *testing.T) {
 func TestWithAuthMiddleware_InfraEndpoints_BypassAuth(t *testing.T) {
 	// Auth middleware is on mux (business routes). Infra endpoints (/healthz, /readyz)
 	// are on outerMux and naturally bypass mux-level auth.
-	asm := assembly.New(assembly.Config{ID: "test"})
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	c := newStubCell("cell-1")
 	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))


### PR DESCRIPTION
## Summary

- **DurabilityMode zero-value sentinel** (A2): `iota+1` makes zero value invalid, forcing callers to explicitly choose `DurabilityDemo` or `DurabilityDurable`. ref: Vault `StoredKeysInvalid=0`, gRPC `InvalidSecurityLevel=0`
- **CheckNotNoop extended** to access-core, audit-core, config-core (NIL-PUB-P2): all L2 cells now reject noop implementations in durable mode
- **NoopTxRunner explicit panic** (D2): descriptive panic on nil fn, ref: `net/http.HandleFunc`
- **Outbox log noop-aware** (C1): `order-create` logs at `Debug` for NoopWriter, `Info` for real writes
- **OutboxWriterFailure rollback assertion** (D1): test documents demo-mode limitation
- **Securecookie flaky fix**: bit-flip tamper eliminates 1/64 failure probability
- **Docs**: CHANGELOG Breaking section + README Runtime Modes table

## Backlog items closed

- A2 (DurabilityMode zero-value)
- D2 (NoopTxRunner nil fn)
- C1 (outbox log misleading)
- D1 (rollback test gap)
- B2 (CHANGELOG + README docs)
- NIL-PUB-P2 (3 cells missing CheckNotNoop)
- SECURECOOKIE-TAMPER-FLAKY-01

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass (33 files changed, 0 failures)
- [x] `TestCheckNotNoop_UnsetMode_RejectsAll` — zero DurabilityMode rejected
- [x] `TestInit_DurableMode_RejectsNoopWriter` — all 5 L2 cells reject noop in durable mode
- [x] `TestNoopTxRunner_NilFnPanics` — explicit panic message verified
- [x] `TestSecureCookie_TamperedValue` — 100 runs, 0 flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)