### PR TITLE
feat(outbox): conformance harness ready-signal + RMQ conformance + backoff cleanup (#6 #31)

### DIFF
--- a/adapters/rabbitmq/backoff.go
+++ b/adapters/rabbitmq/backoff.go
@@ -1,0 +1,24 @@
+package rabbitmq
+
+import (
+	"math/bits"
+	"time"
+)
+
+// exponentialDelay computes base * 2^attempt with overflow protection, capped at maxDelay.
+// If base is zero or negative, it returns 0. The bits.Len64 technique determines
+// the maximum safe left-shift to avoid integer overflow before comparing against maxDelay.
+func exponentialDelay(base, maxDelay time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	maxSafeShift := 63 - bits.Len64(uint64(base))
+	if attempt > maxSafeShift {
+		return maxDelay
+	}
+	delay := base * (1 << uint(attempt))
+	if delay <= 0 || delay > maxDelay {
+		return maxDelay
+	}
+	return delay
+}

--- a/adapters/rabbitmq/backoff_test.go
+++ b/adapters/rabbitmq/backoff_test.go
@@ -1,0 +1,38 @@
+package rabbitmq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExponentialDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     time.Duration
+		maxDelay time.Duration
+		attempt  int
+		want     time.Duration
+	}{
+		// Normal progression: base=1s, max=30s.
+		{name: "attempt 0 returns base", base: time.Second, maxDelay: 30 * time.Second, attempt: 0, want: time.Second},
+		{name: "attempt 1 doubles", base: time.Second, maxDelay: 30 * time.Second, attempt: 1, want: 2 * time.Second},
+		{name: "attempt 2 quadruples", base: time.Second, maxDelay: 30 * time.Second, attempt: 2, want: 4 * time.Second},
+		{name: "attempt 10 exceeds max", base: time.Second, maxDelay: 30 * time.Second, attempt: 10, want: 30 * time.Second},
+		{name: "attempt 34 overflow guard", base: time.Second, maxDelay: 30 * time.Second, attempt: 34, want: 30 * time.Second},
+		{name: "attempt 100 far overflow", base: time.Second, maxDelay: 30 * time.Second, attempt: 100, want: 30 * time.Second},
+
+		// Edge cases.
+		{name: "base=0 returns 0", base: 0, maxDelay: 30 * time.Second, attempt: 5, want: 0},
+		{name: "negative base returns 0", base: -time.Second, maxDelay: 30 * time.Second, attempt: 3, want: 0},
+		{name: "large attempt returns maxDelay", base: time.Second, maxDelay: time.Minute, attempt: 200, want: time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := exponentialDelay(tt.base, tt.maxDelay, tt.attempt)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/adapters/rabbitmq/conformance_test.go
+++ b/adapters/rabbitmq/conformance_test.go
@@ -53,6 +53,11 @@ func (p *envelopingPublisher) Publish(ctx context.Context, topic string, payload
 //   - BlockingSubscribe:  true  — Subscribe blocks until ctx cancelled.
 //   - BroadcastSubscribe: false — same queue = competing consumers, not fan-out.
 func TestRabbitMQ_Conformance(t *testing.T) {
+	// A single Connection is shared across all sub-tests. Each sub-test creates
+	// its own Subscriber (with independent channels and lifecycle). This is safe
+	// because Subscriber.Close only closes that subscriber's tracked channels,
+	// not the shared Connection. Topic names are unique per test (TestTopic),
+	// so exchange/queue declarations do not collide across sub-tests.
 	conn, cleanup := startRabbitMQ(t)
 	t.Cleanup(cleanup)
 

--- a/adapters/rabbitmq/conformance_test.go
+++ b/adapters/rabbitmq/conformance_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package rabbitmq
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/outbox/outboxtest"
+)
+
+// envelopingPublisher wraps a raw Publisher to serialize payloads into the
+// outboxWireMessage envelope expected by the RabbitMQ subscriber's
+// unmarshalDelivery. Without this wrapper, the conformance harness publishes
+// bare JSON payloads (e.g., {"seq":0}), but the subscriber expects an envelope
+// with id, eventType, and an embedded payload field.
+//
+// This is NOT needed in production — the outbox relay serializes entries
+// into the wire format. It is only needed for conformance tests that bypass
+// the relay and test Publisher+Subscriber directly.
+type envelopingPublisher struct {
+	inner outbox.Publisher
+}
+
+func (p *envelopingPublisher) Publish(ctx context.Context, topic string, payload []byte) error {
+	entry := outboxtest.NewEntry(topic, payload)
+	wire := outboxWireMessage{
+		ID:        entry.ID,
+		EventType: entry.EventType,
+		Topic:     entry.Topic,
+		Payload:   json.RawMessage(payload),
+		CreatedAt: entry.CreatedAt,
+	}
+	body, err := json.Marshal(wire)
+	if err != nil {
+		return err
+	}
+	return p.inner.Publish(ctx, topic, body)
+}
+
+// TestRabbitMQ_Conformance runs the full outboxtest conformance suite against
+// a real RabbitMQ broker via testcontainers.
+//
+// Features:
+//   - GuaranteedOrder:    true  — single consumer on a single queue is FIFO.
+//   - SupportsRequeue:    true  — Nack(requeue=true) redelivers.
+//   - SupportsReject:     true  — Nack(requeue=false) routes to DLX.
+//   - SupportsReceipt:    false — raw Subscriber does not thread Receipt;
+//     ConsumerBase middleware handles that.
+//   - BlockingSubscribe:  true  — Subscribe blocks until ctx cancelled.
+//   - BroadcastSubscribe: false — same queue = competing consumers, not fan-out.
+func TestRabbitMQ_Conformance(t *testing.T) {
+	conn, cleanup := startRabbitMQ(t)
+	t.Cleanup(cleanup)
+
+	outboxtest.TestPubSub(t, outboxtest.Features{
+		GuaranteedOrder:    true,
+		SupportsRequeue:    true,
+		SupportsReject:     true,
+		SupportsReceipt:    false,
+		BlockingSubscribe:  true,
+		BroadcastSubscribe: false,
+	}, func(t *testing.T) (outbox.Publisher, outbox.Subscriber) {
+		pub := NewPublisher(conn)
+		sub := NewSubscriber(conn, SubscriberConfig{
+			DLXExchange:     "test.dlx",
+			PrefetchCount:   1,
+			ShutdownTimeout: 5 * time.Second,
+		})
+		t.Cleanup(func() { _ = sub.Close() })
+		return &envelopingPublisher{inner: pub}, sub
+	})
+}

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/bits"
 	"math/rand/v2"
 	"net"
 	"net/url"
@@ -472,31 +471,15 @@ func (c *Connection) reconnectWithBackoff() (bool, error) {
 // capped result is always in [0.75*max, max]. This prevents thundering-herd
 // at the cap while keeping ReconnectMaxBackoff as a true upper bound.
 func (c *Connection) backoffDelay(attempt int) time.Duration {
-	maxBackoff := c.config.ReconnectMaxBackoff
-	base := c.config.ReconnectBaseDelay
-
-	// Compute max safe exponent: 63 - bits needed to represent base.
-	// This adapts to any ReconnectBaseDelay (1ns → exp 62, 1s → exp 33).
-	maxSafeShift := 63 - bits.Len64(uint64(base))
-	if attempt > maxSafeShift {
-		return addDownJitter(maxBackoff)
-	}
-
-	delay := base * time.Duration(1<<uint(attempt))
-	if delay <= 0 { // overflow guard
-		return addDownJitter(maxBackoff)
-	}
-
-	if delay >= maxBackoff {
-		// Capped region: apply downward-only jitter [0.75*max, max] to prevent
-		// thundering-herd while keeping maxBackoff as a true upper bound.
-		return addDownJitter(maxBackoff)
+	delay := exponentialDelay(c.config.ReconnectBaseDelay, c.config.ReconnectMaxBackoff, attempt)
+	if delay >= c.config.ReconnectMaxBackoff {
+		return addDownJitter(c.config.ReconnectMaxBackoff)
 	}
 
 	// Uncapped region: jitter on actual delay. Cap any overshoot from +25%.
 	withJitter := addJitter(delay)
-	if withJitter > maxBackoff {
-		return maxBackoff
+	if withJitter > c.config.ReconnectMaxBackoff {
+		return c.config.ReconnectMaxBackoff
 	}
 	return withJitter
 }

--- a/adapters/rabbitmq/consumer_base.go
+++ b/adapters/rabbitmq/consumer_base.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/bits"
 	"math/rand/v2"
 	"time"
 
@@ -18,6 +17,21 @@ const (
 	logKeyEventID       = "event_id"
 	logKeyTopic         = "topic"
 	logKeyConsumerGroup = "consumer_group"
+)
+
+// ClaimPolicy controls ConsumerBase behavior when Claimer.Claim() fails.
+type ClaimPolicy uint8
+
+const (
+	// ClaimPolicyFailClosed (default zero-value): retry Claim with exponential
+	// backoff. Safe from duplicates, but consumption stops until the idempotency
+	// backend recovers.
+	ClaimPolicyFailClosed ClaimPolicy = iota
+
+	// ClaimPolicyFailOpen: single Claim attempt; on error, proceed without
+	// idempotency receipt. Avoids total consumer stall, but risks duplicate
+	// processing during outage.
+	ClaimPolicyFailOpen
 )
 
 // ConsumerBaseConfig configures ConsumerBase behavior.
@@ -43,14 +57,10 @@ type ConsumerBaseConfig struct {
 	// Default: 5m (idempotency.DefaultLeaseTTL). Only used with Claimer.
 	LeaseTTL time.Duration
 
-	// ClaimFailOpen controls behavior when Claimer.Claim() fails due to
-	// infrastructure errors (e.g., Redis down).
-	//   true:  proceed without idempotency — avoids total consumer
-	//          stall, but risks duplicate processing during outage.
-	//   false (default): return DispositionRequeue — safe from duplicates, but all
-	//          consumption stops until the idempotency backend recovers.
-	// Must be set explicitly; nil defaults to fail-closed for safety.
-	ClaimFailOpen *bool
+	// ClaimPolicy controls behavior when Claimer.Claim() fails due to
+	// infrastructure errors (e.g., Redis down). See ClaimPolicyFailClosed
+	// (default zero-value) and ClaimPolicyFailOpen for details.
+	ClaimPolicy ClaimPolicy
 
 	// ClaimRetryCount is the max number of Claim() attempts on the fail-closed
 	// path before returning DispositionRequeue to the broker.
@@ -92,21 +102,9 @@ func (c *ConsumerBaseConfig) setDefaults() {
 }
 
 // safeDelay computes base * 2^attempt with overflow protection, capped by maxDelay.
-// Uses bits.Len64 to determine the maximum safe shift, matching the strategy
-// in Connection.backoffDelay.
+// Delegates to the shared exponentialDelay helper.
 func safeDelay(base, maxDelay time.Duration, attempt int) time.Duration {
-	if base <= 0 {
-		return 0
-	}
-	maxSafeShift := 63 - bits.Len64(uint64(base))
-	if attempt > maxSafeShift {
-		return maxDelay
-	}
-	delay := base * (1 << uint(attempt))
-	if delay <= 0 || delay > maxDelay {
-		return maxDelay
-	}
-	return delay
+	return exponentialDelay(base, maxDelay, attempt)
 }
 
 // ConsumerBase wraps an outbox.EntryHandler with two-phase idempotency
@@ -159,12 +157,12 @@ func (cb *ConsumerBase) AsMiddleware() outbox.TopicHandlerMiddleware {
 // The Receipt is threaded through HandleResult — ConsumerBase never calls
 // Commit/Release itself; that is processDelivery's job after broker Ack/Nack.
 //
-// Fail-open (ClaimFailOpen=true): single Claim attempt; on error, proceed
+// Fail-open (ClaimPolicyFailOpen): single Claim attempt; on error, proceed
 // without idempotency — avoids total consumer stall, but risks duplicate
 // processing during outage.
 //
-// Fail-closed (ClaimFailOpen=false or nil, default): all Claim attempts go
-// through claimWithRetry (including the first), so every failure is followed
+// Fail-closed (ClaimPolicyFailClosed, default zero-value): all Claim attempts
+// go through claimWithRetry (including the first), so every failure is followed
 // by exponential backoff + jitter. Safe from duplicates, but all consumption
 // stops until the idempotency backend recovers.
 //
@@ -181,7 +179,7 @@ func (cb *ConsumerBase) Wrap(topic string, handler outbox.EntryHandler) outbox.E
 		idempotencyKey := fmt.Sprintf("%s:%s", cb.config.ConsumerGroup, entry.ID)
 
 		// Fail-open: single Claim attempt, proceed without idempotency on error.
-		if cb.config.ClaimFailOpen != nil && *cb.config.ClaimFailOpen {
+		if cb.config.ClaimPolicy == ClaimPolicyFailOpen {
 			state, receipt, err := cb.claimer.Claim(ctx, idempotencyKey, cb.config.LeaseTTL, cb.config.IdempotencyTTL)
 			if err != nil {
 				logWithContext(ctx, slog.LevelWarn, "rabbitmq: idempotency claim failed, proceeding without receipt (fail-open)",

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -1255,6 +1255,74 @@ func TestPublisher_Publish_TerminalState_ReturnsPermanentError(t *testing.T) {
 
 func TestSubscriber_InterfaceCompliance(t *testing.T) {
 	var _ outbox.Subscriber = (*Subscriber)(nil)
+	var _ outbox.SubscriberInitializer = (*Subscriber)(nil)
+}
+
+func TestSubscriber_InitializeSubscription_DeclaresTopology(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	err := sub.InitializeSubscription(context.Background(), "test.topic", "cg-1")
+	require.NoError(t, err)
+
+	// Verify topology was declared: 2 exchanges (main + DLX), 1 queue, 1 binding.
+	assert.Equal(t, []string{"test.topic", "test.dlx"}, ch.exchangesDeclared)
+	assert.Equal(t, []string{"cg-1.test.topic"}, ch.queuesDeclared)
+	assert.Equal(t, []string{"cg-1.test.topic->test.topic"}, ch.queueBindings)
+
+	// Verify DLX args on the queue.
+	require.Len(t, ch.queueDeclareArgs, 1)
+	assert.Equal(t, "test.dlx", ch.queueDeclareArgs[0]["x-dead-letter-exchange"])
+}
+
+func TestSubscriber_InitializeSubscription_EmptyDLX_ReturnsError(t *testing.T) {
+	conn, _ := newTestConnection(t)
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: ""})
+
+	err := sub.InitializeSubscription(context.Background(), "test.topic", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "DLXExchange is required")
+}
+
+func TestSubscriber_InitializeSubscription_AcquireChannelFailure(t *testing.T) {
+	conn, _ := newTestConnection(t)
+	// Close the connection to make AcquireChannel fail.
+	_ = conn.Close()
+
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	err := sub.InitializeSubscription(context.Background(), "test.topic", "")
+	assert.Error(t, err)
+}
+
+func TestSubscriber_InitializeSubscription_ExchangeDeclareFailure(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	ch.exchangeDeclareErr = errors.New("exchange declare failed")
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	err := sub.InitializeSubscription(context.Background(), "test.topic", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "declare exchange")
+}
+
+func TestSubscriber_InitializeSubscription_EmptyGroup_DefaultsToTopic(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	err := sub.InitializeSubscription(context.Background(), "my.topic", "")
+	require.NoError(t, err)
+
+	// Empty group → queue name = topic.
+	assert.Equal(t, []string{"my.topic"}, ch.queuesDeclared)
 }
 
 func TestSubscriberConfig_Defaults(t *testing.T) {

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -48,7 +48,9 @@ type mockChannel struct {
 	exchangeDeclareErr error
 	queuesDeclared     []string
 	queueDeclareArgs   []amqp.Table
+	queueDeclareErr    error
 	queueBindings      []string
+	queueBindErr       error
 
 	notifyPublishCh chan amqp.Confirmation
 
@@ -126,6 +128,9 @@ func (m *mockChannel) ExchangeDeclare(name, kind string, durable, autoDelete, in
 func (m *mockChannel) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.queueDeclareErr != nil {
+		return amqp.Queue{}, m.queueDeclareErr
+	}
 	m.queuesDeclared = append(m.queuesDeclared, name)
 	m.queueDeclareArgs = append(m.queueDeclareArgs, args)
 	return amqp.Queue{Name: name}, nil
@@ -134,6 +139,9 @@ func (m *mockChannel) QueueDeclare(name string, durable, autoDelete, exclusive, 
 func (m *mockChannel) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.queueBindErr != nil {
+		return m.queueBindErr
+	}
 	m.queueBindings = append(m.queueBindings, name+"->"+exchange)
 	return nil
 }
@@ -1309,6 +1317,32 @@ func TestSubscriber_InitializeSubscription_ExchangeDeclareFailure(t *testing.T) 
 	err := sub.InitializeSubscription(context.Background(), "test.topic", "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "declare exchange")
+}
+
+func TestSubscriber_InitializeSubscription_QueueDeclareFailure(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	ch.queueDeclareErr = errors.New("queue declare failed")
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	err := sub.InitializeSubscription(context.Background(), "test.topic", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "declare queue")
+}
+
+func TestSubscriber_InitializeSubscription_QueueBindFailure(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	ch.queueBindErr = errors.New("queue bind failed")
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	err := sub.InitializeSubscription(context.Background(), "test.topic", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bind queue")
 }
 
 func TestSubscriber_InitializeSubscription_EmptyGroup_DefaultsToTopic(t *testing.T) {

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -3147,18 +3147,16 @@ func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
 }
 
 // =============================================================================
-// ClaimFailOpen config tests
+// ClaimPolicy config tests
 // =============================================================================
-
-func boolPtr(b bool) *bool { return &b }
 
 func TestConsumerBase_WrapWithClaimer_ClaimError_FailClosed(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:      "test-group",
-		ClaimFailOpen:      boolPtr(false),
-		ClaimRetryCount:    3,
+		ConsumerGroup:       "test-group",
+		ClaimPolicy:         ClaimPolicyFailClosed,
+		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 10 * time.Millisecond,
 	})
 
@@ -3180,7 +3178,7 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_FailOpen_Explicit(t *testing.T)
 
 	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
-		ClaimFailOpen: boolPtr(true),
+		ClaimPolicy:   ClaimPolicyFailOpen,
 	})
 
 	handlerCalled := false

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -48,8 +48,11 @@ func isRecoverableAMQPError(err error) bool {
 	return false
 }
 
-// Compile-time interface check.
-var _ outbox.Subscriber = (*Subscriber)(nil)
+// Compile-time interface checks.
+var (
+	_ outbox.Subscriber            = (*Subscriber)(nil)
+	_ outbox.SubscriberInitializer = (*Subscriber)(nil)
+)
 
 // SubscriberConfig configures how a Subscriber consumes messages.
 type SubscriberConfig struct {
@@ -134,6 +137,63 @@ func (s *Subscriber) resolveQueueName(topic, consumerGroup string) string {
 		return s.config.ConsumerGroup + "." + topic
 	}
 	return topic
+}
+
+// declareTopology declares the exchange, DLX, queue, and binding on the given
+// channel. All operations are idempotent — safe to call multiple times.
+func (s *Subscriber) declareTopology(ch AMQPChannel, topic, queueName string) error {
+	// Declare exchange idempotently.
+	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {
+		return fmt.Errorf("rabbitmq: declare exchange: %w", err)
+	}
+
+	// Declare the dead-letter exchange to ensure it exists before binding.
+	// Uses "direct" type so rejected messages are routed by DLXRoutingKey.
+	if err := ch.ExchangeDeclare(s.config.DLXExchange, "direct", true, false, false, false, nil); err != nil {
+		return fmt.Errorf("rabbitmq: declare DLX exchange: %w", err)
+	}
+
+	// Build queue arguments for dead-letter routing.
+	queueArgs := amqp.Table{
+		"x-dead-letter-exchange": s.config.DLXExchange,
+	}
+	if s.config.DLXRoutingKey != "" {
+		queueArgs["x-dead-letter-routing-key"] = s.config.DLXRoutingKey
+	}
+
+	// Declare queue.
+	if _, err := ch.QueueDeclare(queueName, true, false, false, false, queueArgs); err != nil {
+		return fmt.Errorf("rabbitmq: declare queue: %w", err)
+	}
+
+	// Bind queue to exchange.
+	if err := ch.QueueBind(queueName, "", topic, false, nil); err != nil {
+		return fmt.Errorf("rabbitmq: bind queue: %w", err)
+	}
+
+	return nil
+}
+
+// InitializeSubscription pre-declares the AMQP topology (exchange, DLX, queue,
+// binding) for the given topic and consumer group. After this returns, messages
+// published to the topic are queued by the broker — even before Subscribe
+// starts consuming. This enables deterministic conformance testing without sleep.
+//
+// ref: Watermill message.SubscribeInitializer — synchronous topology pre-creation.
+func (s *Subscriber) InitializeSubscription(ctx context.Context, topic, consumerGroup string) error {
+	if s.config.DLXExchange == "" {
+		return errcode.New(ErrAdapterAMQPSubscribe,
+			"rabbitmq: DLXExchange is required for InitializeSubscription")
+	}
+
+	ch, err := s.conn.AcquireChannel()
+	if err != nil {
+		return fmt.Errorf("rabbitmq: acquire channel for init: %w", err)
+	}
+	defer s.conn.ReleaseChannel(ch)
+
+	queueName := s.resolveQueueName(topic, consumerGroup)
+	return s.declareTopology(ch, topic, queueName)
 }
 
 // Subscribe registers a handler for the given topic and blocks until ctx is
@@ -277,33 +337,9 @@ func (s *Subscriber) subscribeOnce(
 		return setupErr("rabbitmq: set qos", ErrAdapterAMQPSubscribe, err)
 	}
 
-	// Declare exchange idempotently.
-	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {
-		return setupErr("rabbitmq: declare exchange", ErrAdapterAMQPSubscribe, err)
-	}
-
-	// Declare the dead-letter exchange to ensure it exists before binding.
-	// Uses "direct" type so rejected messages are routed by DLXRoutingKey.
-	if err := ch.ExchangeDeclare(s.config.DLXExchange, "direct", true, false, false, false, nil); err != nil {
-		return setupErr("rabbitmq: declare DLX exchange", ErrAdapterAMQPSubscribe, err)
-	}
-
-	// Build queue arguments for dead-letter routing.
-	queueArgs := amqp.Table{
-		"x-dead-letter-exchange": s.config.DLXExchange,
-	}
-	if s.config.DLXRoutingKey != "" {
-		queueArgs["x-dead-letter-routing-key"] = s.config.DLXRoutingKey
-	}
-
-	// Declare queue.
-	if _, err = ch.QueueDeclare(queueName, true, false, false, false, queueArgs); err != nil {
-		return setupErr("rabbitmq: declare queue", ErrAdapterAMQPSubscribe, err)
-	}
-
-	// Bind queue to exchange.
-	if err := ch.QueueBind(queueName, "", topic, false, nil); err != nil {
-		return setupErr("rabbitmq: bind queue", ErrAdapterAMQPSubscribe, err)
+	// Declare topology (exchange, DLX, queue, binding) — idempotent.
+	if err := s.declareTopology(ch, topic, queueName); err != nil {
+		return setupErr("rabbitmq: declare topology", ErrAdapterAMQPSubscribe, err)
 	}
 
 	consumerTag := fmt.Sprintf("cg-%s-%s", queueName, topic)

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -141,7 +141,15 @@ func (s *Subscriber) resolveQueueName(topic, consumerGroup string) string {
 
 // declareTopology declares the exchange, DLX, queue, and binding on the given
 // channel. All operations are idempotent — safe to call multiple times.
+//
+// Precondition: s.config.DLXExchange must be non-empty. Both call sites
+// (Subscribe, InitializeSubscription) validate this, but the guard here
+// prevents accidental misuse from future code paths.
 func (s *Subscriber) declareTopology(ch AMQPChannel, topic, queueName string) error {
+	if s.config.DLXExchange == "" {
+		return fmt.Errorf("rabbitmq: declareTopology: DLXExchange must not be empty")
+	}
+
 	// Declare exchange idempotently.
 	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {
 		return fmt.Errorf("rabbitmq: declare exchange: %w", err)

--- a/docs/guides/adapter-config-reference.md
+++ b/docs/guides/adapter-config-reference.md
@@ -71,7 +71,7 @@ This document lists every adapter shipped with GoCell and its configuration surf
 | `RetryBaseDelay` | duration | no | 1s | Initial delay for exponential backoff retries |
 | `IdempotencyTTL` | duration | no | 24h | TTL for idempotency done-keys |
 | `LeaseTTL` | duration | no | 5m | Processing-lease TTL for Claimer backend |
-| `ClaimFailOpen` | *bool | no | nil (fail-closed) | `true`: proceed without idempotency on Claim failure; `false`/nil: requeue until backend recovers |
+| `ClaimPolicy` | ClaimPolicy | no | ClaimPolicyFailClosed (zero-value) | `ClaimPolicyFailOpen`: proceed without idempotency on Claim failure; `ClaimPolicyFailClosed`: requeue until backend recovers |
 | `ClaimRetryCount` | int | no | RetryCount | Max Claim() attempts on the fail-closed path |
 | `ClaimRetryBaseDelay` | duration | no | RetryBaseDelay | Initial backoff between Claim() retries |
 | `MaxRetryDelay` | duration | no | 30s | Cap for exponential backoff delay |

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -429,6 +429,16 @@ func (s *SubscriberWithMiddleware) Subscribe(ctx context.Context, topic string, 
 	return s.Inner.Subscribe(ctx, topic, wrapped, consumerGroup)
 }
 
+// InitializeSubscription delegates to Inner if it implements SubscriberInitializer.
+// This ensures the deterministic ready-signal is not silently lost when a
+// SubscriberInitializer-capable subscriber is wrapped with middleware.
+func (s *SubscriberWithMiddleware) InitializeSubscription(ctx context.Context, topic, consumerGroup string) error {
+	if init, ok := s.Inner.(SubscriberInitializer); ok {
+		return init.InitializeSubscription(ctx, topic, consumerGroup)
+	}
+	return nil
+}
+
 // Close delegates to the inner subscriber.
 func (s *SubscriberWithMiddleware) Close() error {
 	return s.Inner.Close()

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -391,6 +391,20 @@ type Subscriber interface {
 	Close() error
 }
 
+// SubscriberInitializer is optionally implemented by Subscriber to pre-declare
+// broker topology (exchanges, queues, bindings) before Subscribe is called.
+// This allows the conformance harness to publish messages deterministically —
+// with a persistent broker, messages are queued even before Subscribe starts
+// consuming.
+//
+// Implementations that do not support pre-initialization (e.g., in-memory)
+// need not implement this interface; the harness falls back to a brief sleep.
+//
+// ref: Watermill message.SubscribeInitializer — synchronous topology pre-creation.
+type SubscriberInitializer interface {
+	InitializeSubscription(ctx context.Context, topic, consumerGroup string) error
+}
+
 // TopicHandlerMiddleware transforms an EntryHandler, receiving the topic name.
 // It is the event-consumer analogue of HTTP middleware.
 type TopicHandlerMiddleware func(topic string, next EntryHandler) EntryHandler

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -31,6 +31,18 @@ func (m *mockPublisher) Publish(ctx context.Context, topic string, payload []byt
 
 var _ Publisher = (*mockPublisher)(nil)
 
+// plainSubscriber implements Subscriber but NOT SubscriberInitializer.
+type plainSubscriber struct{}
+
+func (m *plainSubscriber) Subscribe(context.Context, string, EntryHandler, string) error { return nil }
+func (m *plainSubscriber) Close() error                                                  { return nil }
+
+func TestSubscriberInitializer_IsOptional(t *testing.T) {
+	var sub Subscriber = &plainSubscriber{}
+	_, ok := sub.(SubscriberInitializer)
+	assert.False(t, ok, "plainSubscriber should not implement SubscriberInitializer")
+}
+
 func TestNoopWriter_Write(t *testing.T) {
 	writer := NoopWriter{}
 	err := writer.Write(context.Background(), validEntry("noop"))

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -305,6 +305,57 @@ func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
 	assert.False(t, handlerCalled)
 }
 
+// --- SubscriberWithMiddleware + SubscriberInitializer forwarding (F1-1) ---
+
+// initializerSubscriber implements both Subscriber and SubscriberInitializer.
+type initializerSubscriber struct {
+	recordingSubscriber
+	initCalled bool
+	initTopic  string
+	initGroup  string
+	initErr    error
+}
+
+func (s *initializerSubscriber) InitializeSubscription(_ context.Context, topic, consumerGroup string) error {
+	s.initCalled = true
+	s.initTopic = topic
+	s.initGroup = consumerGroup
+	return s.initErr
+}
+
+func TestSubscriberWithMiddleware_ForwardsSubscriberInitializer(t *testing.T) {
+	inner := &initializerSubscriber{}
+	sub := &SubscriberWithMiddleware{Inner: inner}
+
+	// SubscriberWithMiddleware must implement SubscriberInitializer.
+	init, ok := Subscriber(sub).(SubscriberInitializer)
+	assert.True(t, ok, "SubscriberWithMiddleware should implement SubscriberInitializer")
+
+	err := init.InitializeSubscription(context.Background(), "test.topic", "cg-1")
+	assert.NoError(t, err)
+	assert.True(t, inner.initCalled)
+	assert.Equal(t, "test.topic", inner.initTopic)
+	assert.Equal(t, "cg-1", inner.initGroup)
+}
+
+func TestSubscriberWithMiddleware_InitializeSubscription_PropagatesError(t *testing.T) {
+	inner := &initializerSubscriber{initErr: errors.New("init failed")}
+	sub := &SubscriberWithMiddleware{Inner: inner}
+
+	err := sub.InitializeSubscription(context.Background(), "t", "g")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "init failed")
+}
+
+func TestSubscriberWithMiddleware_InitializeSubscription_InnerNotInitializer(t *testing.T) {
+	// Inner does NOT implement SubscriberInitializer — should be a no-op.
+	inner := &recordingSubscriber{}
+	sub := &SubscriberWithMiddleware{Inner: inner}
+
+	err := sub.InitializeSubscription(context.Background(), "t", "g")
+	assert.NoError(t, err, "should return nil when inner does not support initialization")
+}
+
 func TestEntry_RoutingTopic(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -52,6 +52,9 @@ func TestPubSub(t *testing.T, features Features, constructor PubSubConstructor) 
 		testTopicIsolation(t, features, constructor)
 	})
 	t.Run("MultipleSubscribers", func(t *testing.T) {
+		if !features.BroadcastSubscribe {
+			t.Skip("implementation uses competing consumers, not broadcast fan-out")
+		}
 		testMultipleSubscribers(t, features, constructor)
 	})
 
@@ -220,7 +223,7 @@ func testTopicIsolation(t *testing.T, _ Features, constructor PubSubConstructor)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		}, "")
 	}()
-	time.Sleep(subscribeInitDelay)
+	waitForSubscription(t, ctx, sub, topicA, "")
 
 	// Publish to both topics.
 	assertNoError(t, pub.Publish(ctx, topicB, []byte(`{"topic":"B"}`)))
@@ -232,7 +235,7 @@ func testTopicIsolation(t *testing.T, _ Features, constructor PubSubConstructor)
 		t.Fatal("timed out waiting for message on topic A")
 	}
 
-	// Give a brief window for any leaked messages.
+	// Give a brief window for any leaked messages (negative assertion guard).
 	time.Sleep(100 * time.Millisecond)
 
 	cancel()
@@ -278,7 +281,7 @@ func testMultipleSubscribers(t *testing.T, _ Features, constructor PubSubConstru
 		}, "")
 	}()
 
-	time.Sleep(subscribeInitDelay)
+	waitForSubscription(t, ctx, sub, topic, "")
 
 	assertNoError(t, pub.Publish(ctx, topic, []byte(`{"test":"fan-out"}`)))
 
@@ -580,7 +583,7 @@ func testCloseTerminatesSubscribers(t *testing.T, _ Features, constructor PubSub
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		}, "")
 	}()
-	time.Sleep(subscribeInitDelay)
+	waitForSubscription(t, ctx, sub, topic, "")
 
 	assertNoError(t, sub.Close())
 

--- a/kernel/outbox/outboxtest/features.go
+++ b/kernel/outbox/outboxtest/features.go
@@ -27,6 +27,13 @@ type Features struct {
 	// BlockingSubscribe means Subscribe blocks until ctx is cancelled.
 	BlockingSubscribe bool
 
+	// BroadcastSubscribe indicates that multiple Subscribe calls on the same
+	// topic from the same Subscriber instance deliver a copy to EVERY handler
+	// (fan-out). When false, multiple subscribers on the same topic compete
+	// for messages (round-robin); testMultipleSubscribers is skipped.
+	// InMemoryEventBus: true. RabbitMQ (same queue without explicit group): false.
+	BroadcastSubscribe bool
+
 	// MessageCount is how many messages to use in bulk tests.
 	// Default: 100 (short mode: 10).
 	MessageCount int

--- a/kernel/outbox/outboxtest/helpers.go
+++ b/kernel/outbox/outboxtest/helpers.go
@@ -15,6 +15,26 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
+// waitForSubscription replaces time.Sleep(subscribeInitDelay) with a
+// deterministic readiness check when the subscriber implements
+// outbox.SubscriberInitializer. For persistent brokers (e.g., RabbitMQ),
+// InitializeSubscription pre-declares the topology so that published messages
+// are queued before Subscribe starts consuming — eliminating the race.
+// For in-memory implementations that lack InitializeSubscription, it falls
+// back to the brief sleep.
+//
+// ref: Watermill message.SubscribeInitializer — synchronous topology pre-creation.
+func waitForSubscription(t *testing.T, ctx context.Context, sub outbox.Subscriber, topic, consumerGroup string) {
+	t.Helper()
+	if init, ok := sub.(outbox.SubscriberInitializer); ok {
+		if err := init.InitializeSubscription(ctx, topic, consumerGroup); err != nil {
+			t.Fatalf("InitializeSubscription(%s, %s): %v", topic, consumerGroup, err)
+		}
+		return
+	}
+	time.Sleep(subscribeInitDelay)
+}
+
 // TestTopic returns a unique topic name scoped to the given test.
 // Prevents cross-test interference when implementations share state.
 func TestTopic(t *testing.T) string {
@@ -114,8 +134,9 @@ func CollectN(
 		_ = sub.Subscribe(subCtx, topic, handler, "")
 	}()
 
-	// Wait for subscription to register (InMemoryEventBus needs a brief delay).
-	time.Sleep(subscribeInitDelay)
+	// Wait for subscription to register. Uses SubscriberInitializer if available,
+	// otherwise falls back to a brief sleep.
+	waitForSubscription(t, ctx, sub, topic, "")
 
 	select {
 	case <-done:
@@ -188,10 +209,10 @@ func startCollecting(t *testing.T, ctx context.Context, sub outbox.Subscriber, t
 		}
 	}()
 	<-ready
-	// Brief yield to let Subscribe register internally. The ready channel
-	// guarantees the goroutine is running; this yield covers the window
-	// between goroutine start and the Subscribe call's internal registration.
-	time.Sleep(subscribeInitDelay)
+	// Wait for subscription to register. Uses SubscriberInitializer if available,
+	// otherwise falls back to a brief sleep to cover the window between goroutine
+	// start and Subscribe's internal registration.
+	waitForSubscription(t, ctx, sub, topic, "")
 	return c
 }
 
@@ -264,7 +285,7 @@ func (h *pubSubHarness) subscribe(handler outbox.EntryHandler) {
 		}
 	}()
 	<-ready
-	time.Sleep(subscribeInitDelay)
+	waitForSubscription(h.T, ctx, h.Sub, h.Topic, "")
 }
 
 // publishAndWait publishes payload and blocks until signalDone or timeout.

--- a/kernel/outbox/outboxtest/helpers_test.go
+++ b/kernel/outbox/outboxtest/helpers_test.go
@@ -149,6 +149,57 @@ func TestFeatures_SetDefaults_PreservesExplicit(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// waitForSubscription tests
+// ---------------------------------------------------------------------------
+
+// fakeInitializerSub implements both Subscriber and SubscriberInitializer.
+type fakeInitializerSub struct {
+	fakePubSub
+	initCalled bool
+	initTopic  string
+	initGroup  string
+}
+
+func (f *fakeInitializerSub) InitializeSubscription(_ context.Context, topic, group string) error {
+	f.initCalled = true
+	f.initTopic = topic
+	f.initGroup = group
+	return nil
+}
+
+func TestWaitForSubscription_UsesInitializerWhenAvailable(t *testing.T) {
+	sub := &fakeInitializerSub{}
+	ctx := context.Background()
+
+	waitForSubscription(t, ctx, sub, "my.topic", "cg-1")
+
+	if !sub.initCalled {
+		t.Fatal("expected InitializeSubscription to be called")
+	}
+	if sub.initTopic != "my.topic" {
+		t.Fatalf("want topic 'my.topic', got %q", sub.initTopic)
+	}
+	if sub.initGroup != "cg-1" {
+		t.Fatalf("want group 'cg-1', got %q", sub.initGroup)
+	}
+}
+
+func TestWaitForSubscription_FallsBackToSleep(t *testing.T) {
+	// fakePubSub does NOT implement SubscriberInitializer.
+	sub := &fakePubSub{}
+	ctx := context.Background()
+
+	start := time.Now()
+	waitForSubscription(t, ctx, sub, "any.topic", "")
+	elapsed := time.Since(start)
+
+	// Should have slept at least subscribeInitDelay (50ms).
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("expected sleep fallback (~50ms), but returned in %v", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // collector tests — uses a minimal in-test fake subscriber (no runtime/ import)
 // ---------------------------------------------------------------------------
 

--- a/runtime/eventbus/conformance_test.go
+++ b/runtime/eventbus/conformance_test.go
@@ -12,11 +12,12 @@ import (
 // against InMemoryEventBus, proving the test helpers work.
 func TestInMemoryEventBus_Conformance(t *testing.T) {
 	outboxtest.TestPubSub(t, outboxtest.Features{
-		GuaranteedOrder:   true,
-		SupportsRequeue:   true,
-		SupportsReject:    true,
-		SupportsReceipt:   true,
-		BlockingSubscribe: true,
+		GuaranteedOrder:    true,
+		SupportsRequeue:    true,
+		SupportsReject:     true,
+		SupportsReceipt:    true,
+		BlockingSubscribe:  true,
+		BroadcastSubscribe: true,
 	}, func(t *testing.T) (outbox.Publisher, outbox.Subscriber) {
 		bus := eventbus.New(eventbus.WithBufferSize(256))
 		t.Cleanup(func() { _ = bus.Close() })


### PR DESCRIPTION
## Summary

- **SubscriberInitializer 接口** (`kernel/outbox`): 可选接口，pre-declare broker topology，消除 conformance harness 中 6 处 `time.Sleep(subscribeInitDelay)` 竞态
- **RabbitMQ conformance test** (`adapters/rabbitmq`): 接入 `outboxtest.TestPubSub` 20 个子测试（`//go:build integration`，testcontainers）
- **Backoff 统一**: 提取共享 `exponentialDelay`，消除 `connection.backoffDelay` 和 `consumer_base.safeDelay` 重复
- **ClaimPolicy enum**: `ClaimFailOpen *bool` 三态反模式 → `ClaimPolicy` typed enum（零值 = FailClosed）

## 对标框架

- ref: Watermill `message.SubscribeInitializer` — 同步拓扑预创建（采纳）
- ref: Sarama `WaitForState` — 轮询 + atomic state enum（参考，未直接使用）
- ref: Redpanda Connect `require.Eventually` — dual-layer readiness（参考）

## 关键设计决策

| 决策 | 选择 | 理由 |
|------|------|------|
| `BroadcastSubscribe` Feature flag | 新增 | 区分 fan-out（in-memory）vs competing consumers（RabbitMQ），跳过语义不匹配的 `testMultipleSubscribers` |
| `envelopingPublisher` wrapper | conformance test 专用 | RabbitMQ subscriber 期望 wire envelope，harness 发裸 payload，wrapper 桥接 |
| `exponentialDelay` 位置 | `adapters/rabbitmq/backoff.go` | 仅 RMQ adapter 使用，不上升到 kernel |
| `ClaimPolicy` 零值 | `FailClosed` (iota=0) | 安全默认：零值 = fail-closed |

## 文件清单

| 文件 | 操作 |
|------|------|
| `kernel/outbox/outbox.go` | +`SubscriberInitializer` 接口 |
| `kernel/outbox/outboxtest/helpers.go` | +`waitForSubscription`，6 处 sleep 替换 |
| `kernel/outbox/outboxtest/features.go` | +`BroadcastSubscribe` |
| `kernel/outbox/outboxtest/conformance.go` | MultipleSubscribers 门禁 |
| `adapters/rabbitmq/subscriber.go` | +`declareTopology` + `InitializeSubscription` |
| `adapters/rabbitmq/conformance_test.go` | 新建：RMQ conformance test |
| `adapters/rabbitmq/backoff.go` | 新建：共享 `exponentialDelay` |
| `adapters/rabbitmq/consumer_base.go` | `ClaimPolicy` enum |

## Test plan

- [x] `go test ./kernel/outbox/...` — SubscriberInitializer 接口测试
- [x] `go test ./kernel/outbox/outboxtest/...` — harness helpers 单测
- [x] `go test ./runtime/eventbus/... -run Conformance` — InMemoryEventBus 全 22 子测试通过
- [x] `go test ./adapters/rabbitmq/... -short` — 单元测试通过（mock-based）
- [ ] `go test ./adapters/rabbitmq/... -tags integration` — RabbitMQ conformance（需 Docker）
- [x] `go build ./...` — 全量构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)