### PR TITLE
feat(kernel): metadata governance — allowedFiles + list lint + registry error (#27b #138b)

### DIFF
--- a/cells/access-core/slices/authorization-decide/slice.yaml
+++ b/cells/access-core/slices/authorization-decide/slice.yaml
@@ -6,3 +6,7 @@ verify:
     - unit.authorization-decide.service
   contract: []
   waivers: []
+
+allowedFiles:
+  - cells/access-core/slices/authorization-decide/**
+  - cells/access-core/slices/authorizationdecide/**

--- a/cells/access-core/slices/config-receive/slice.yaml
+++ b/cells/access-core/slices/config-receive/slice.yaml
@@ -8,3 +8,7 @@ verify:
     - unit.config-receive.service
   contract:
     - contract.event.config.changed.v1.subscribe
+
+allowedFiles:
+  - cells/access-core/slices/config-receive/**
+  - cells/access-core/slices/configreceive/**

--- a/cells/access-core/slices/identity-manage/slice.yaml
+++ b/cells/access-core/slices/identity-manage/slice.yaml
@@ -33,3 +33,7 @@ verify:
     - contract.http.auth.user.lock.v1.serve
     - contract.http.auth.user.unlock.v1.serve
   waivers: []
+
+allowedFiles:
+  - cells/access-core/slices/identity-manage/**
+  - cells/access-core/slices/identitymanage/**

--- a/cells/access-core/slices/rbac-check/slice.yaml
+++ b/cells/access-core/slices/rbac-check/slice.yaml
@@ -12,3 +12,7 @@ verify:
     - contract.http.auth.role.list.v1.serve
     - contract.http.auth.role.check.v1.serve
   waivers: []
+
+allowedFiles:
+  - cells/access-core/slices/rbac-check/**
+  - cells/access-core/slices/rbaccheck/**

--- a/cells/access-core/slices/session-login/slice.yaml
+++ b/cells/access-core/slices/session-login/slice.yaml
@@ -18,3 +18,7 @@ verify:
       owner: platform-team
       reason: 只读配置调用，集成测试已覆盖
       expiresAt: 2026-06-01
+
+allowedFiles:
+  - cells/access-core/slices/session-login/**
+  - cells/access-core/slices/sessionlogin/**

--- a/cells/access-core/slices/session-logout/slice.yaml
+++ b/cells/access-core/slices/session-logout/slice.yaml
@@ -12,3 +12,7 @@ verify:
     - contract.http.auth.session.delete.v1.serve
     - contract.event.session.revoked.v1.publish
   waivers: []
+
+allowedFiles:
+  - cells/access-core/slices/session-logout/**
+  - cells/access-core/slices/sessionlogout/**

--- a/cells/access-core/slices/session-refresh/slice.yaml
+++ b/cells/access-core/slices/session-refresh/slice.yaml
@@ -9,3 +9,7 @@ verify:
   contract:
     - contract.http.auth.refresh.v1.serve
   waivers: []
+
+allowedFiles:
+  - cells/access-core/slices/session-refresh/**
+  - cells/access-core/slices/sessionrefresh/**

--- a/cells/access-core/slices/session-validate/slice.yaml
+++ b/cells/access-core/slices/session-validate/slice.yaml
@@ -6,3 +6,7 @@ verify:
     - unit.session-validate.service
   contract: []
   waivers: []
+
+allowedFiles:
+  - cells/access-core/slices/session-validate/**
+  - cells/access-core/slices/sessionvalidate/**

--- a/cells/audit-core/slices/audit-append/slice.yaml
+++ b/cells/audit-core/slices/audit-append/slice.yaml
@@ -27,3 +27,7 @@ verify:
     - contract.event.config.changed.v1.subscribe
     - contract.event.config.rollback.v1.subscribe
   waivers: []
+
+allowedFiles:
+  - cells/audit-core/slices/audit-append/**
+  - cells/audit-core/slices/auditappend/**

--- a/cells/audit-core/slices/audit-archive/slice.yaml
+++ b/cells/audit-core/slices/audit-archive/slice.yaml
@@ -6,3 +6,7 @@ verify:
     - unit.audit-archive.service
   contract: []
   waivers: []
+
+allowedFiles:
+  - cells/audit-core/slices/audit-archive/**
+  - cells/audit-core/slices/auditarchive/**

--- a/cells/audit-core/slices/audit-query/slice.yaml
+++ b/cells/audit-core/slices/audit-query/slice.yaml
@@ -9,3 +9,7 @@ verify:
   contract:
     - contract.http.audit.list.v1.serve
   waivers: []
+
+allowedFiles:
+  - cells/audit-core/slices/audit-query/**
+  - cells/audit-core/slices/auditquery/**

--- a/cells/audit-core/slices/audit-verify/slice.yaml
+++ b/cells/audit-core/slices/audit-verify/slice.yaml
@@ -9,3 +9,7 @@ verify:
   contract:
     - contract.event.audit.integrity-verified.v1.publish
   waivers: []
+
+allowedFiles:
+  - cells/audit-core/slices/audit-verify/**
+  - cells/audit-core/slices/auditverify/**

--- a/cells/config-core/slices/config-publish/slice.yaml
+++ b/cells/config-core/slices/config-publish/slice.yaml
@@ -15,3 +15,7 @@ verify:
     - contract.event.config.changed.v1.publish
     - contract.event.config.rollback.v1.publish
   waivers: []
+
+allowedFiles:
+  - cells/config-core/slices/config-publish/**
+  - cells/config-core/slices/configpublish/**

--- a/cells/config-core/slices/config-read/slice.yaml
+++ b/cells/config-core/slices/config-read/slice.yaml
@@ -9,3 +9,7 @@ verify:
   contract:
     - contract.http.config.get.v1.serve
   waivers: []
+
+allowedFiles:
+  - cells/config-core/slices/config-read/**
+  - cells/config-core/slices/configread/**

--- a/cells/config-core/slices/config-subscribe/slice.yaml
+++ b/cells/config-core/slices/config-subscribe/slice.yaml
@@ -9,3 +9,7 @@ verify:
   contract:
     - contract.event.config.changed.v1.subscribe
   waivers: []
+
+allowedFiles:
+  - cells/config-core/slices/config-subscribe/**
+  - cells/config-core/slices/configsubscribe/**

--- a/cells/config-core/slices/config-write/slice.yaml
+++ b/cells/config-core/slices/config-write/slice.yaml
@@ -12,3 +12,7 @@ verify:
     - contract.http.config.write.v1.serve
     - contract.event.config.changed.v1.publish
   waivers: []
+
+allowedFiles:
+  - cells/config-core/slices/config-write/**
+  - cells/config-core/slices/configwrite/**

--- a/cells/config-core/slices/feature-flag/slice.yaml
+++ b/cells/config-core/slices/feature-flag/slice.yaml
@@ -15,3 +15,7 @@ verify:
     - contract.http.config.flags.get.v1.serve
     - contract.http.config.flags.evaluate.v1.serve
   waivers: []
+
+allowedFiles:
+  - cells/config-core/slices/feature-flag/**
+  - cells/config-core/slices/featureflag/**

--- a/cells/device-cell/slices/device-command/slice.yaml
+++ b/cells/device-cell/slices/device-command/slice.yaml
@@ -23,3 +23,6 @@ verify:
     - contract.command.device-command.enqueue.v1.handle
     - contract.command.device-command.list.v1.handle
     - contract.command.device-command.ack.v1.handle
+
+allowedFiles:
+  - cells/device-cell/slices/device-command/**

--- a/cells/device-cell/slices/device-register/slice.yaml
+++ b/cells/device-cell/slices/device-register/slice.yaml
@@ -11,3 +11,6 @@ verify:
   contract:
     - contract.http.device.register.v1.serve
     - contract.event.device-registered.v1.publish
+
+allowedFiles:
+  - cells/device-cell/slices/device-register/**

--- a/cells/device-cell/slices/device-status/slice.yaml
+++ b/cells/device-cell/slices/device-status/slice.yaml
@@ -8,3 +8,6 @@ verify:
     - unit.device-status.service
   contract:
     - contract.http.device.status.v1.serve
+
+allowedFiles:
+  - cells/device-cell/slices/device-status/**

--- a/cells/order-cell/slices/order-create/slice.yaml
+++ b/cells/order-cell/slices/order-create/slice.yaml
@@ -11,3 +11,6 @@ verify:
   contract:
     - contract.http.order.create.v1.serve
     - contract.event.order-created.v1.publish
+
+allowedFiles:
+  - cells/order-cell/slices/order-create/**

--- a/cells/order-cell/slices/order-query/slice.yaml
+++ b/cells/order-cell/slices/order-query/slice.yaml
@@ -11,3 +11,6 @@ verify:
   contract:
     - contract.http.order.get.v1.serve
     - contract.http.order.list.v1.serve
+
+allowedFiles:
+  - cells/order-cell/slices/order-query/**

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -117,8 +117,8 @@ func (g *Generator) computeBoundaryContracts(cellSet map[string]bool) (exported,
 	importedSet := make(map[string]bool)
 
 	for _, contractID := range g.contracts.AllIDs() {
-		provider := g.contracts.Provider(contractID)
-		// Error ignored: AllIDs() guarantees existence; FMT-09 catches invalid kinds.
+		// Errors ignored: AllIDs() guarantees existence; FMT-09 catches invalid kinds.
+		provider, _ := g.contracts.Provider(contractID)
 		consumers, _ := g.contracts.Consumers(contractID)
 
 		providerInAssembly := cellSet[provider]

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -118,7 +118,8 @@ func (g *Generator) computeBoundaryContracts(cellSet map[string]bool) (exported,
 
 	for _, contractID := range g.contracts.AllIDs() {
 		provider := g.contracts.Provider(contractID)
-		consumers := g.contracts.Consumers(contractID)
+		// Error ignored: AllIDs() guarantees existence; FMT-09 catches invalid kinds.
+		consumers, _ := g.contracts.Consumers(contractID)
 
 		providerInAssembly := cellSet[provider]
 

--- a/kernel/cell/base.go
+++ b/kernel/cell/base.go
@@ -3,6 +3,7 @@ package cell
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -227,14 +228,21 @@ func (s *BaseSlice) Init(_ context.Context) error { return nil }
 func (s *BaseSlice) Verify() VerifySpec { return s.verify }
 
 // AllowedFiles returns a copy of the file ownership paths. If none have been
-// set explicitly, it returns the default convention path.
+// set explicitly, it returns the default convention paths. For kebab-case
+// slice IDs, both the kebab-case and no-dash variants are returned to cover
+// the dual-directory layout (YAML dir + Go package dir).
 func (s *BaseSlice) AllowedFiles() []string {
 	if len(s.allowed) > 0 {
 		out := make([]string, len(s.allowed))
 		copy(out, s.allowed)
 		return out
 	}
-	return []string{fmt.Sprintf("cells/%s/slices/%s/**", s.cellID, s.id)}
+	kebab := fmt.Sprintf("cells/%s/slices/%s/**", s.cellID, s.id)
+	noDash := strings.ReplaceAll(s.id, "-", "")
+	if noDash != s.id {
+		return []string{kebab, fmt.Sprintf("cells/%s/slices/%s/**", s.cellID, noDash)}
+	}
+	return []string{kebab}
 }
 
 // AffectedJourneys returns a copy of the journey IDs this slice participates in.

--- a/kernel/cell/base_test.go
+++ b/kernel/cell/base_test.go
@@ -313,6 +313,24 @@ func TestBaseSliceAllowedFilesDefault(t *testing.T) {
 	assert.Equal(t, []string{"cells/access-core/slices/login/**"}, s.AllowedFiles())
 }
 
+func TestBaseSliceAllowedFilesKebabNormalization(t *testing.T) {
+	s := NewBaseSlice("session-login", "access-core", L1)
+	got := s.AllowedFiles()
+	assert.Equal(t, []string{
+		"cells/access-core/slices/session-login/**",
+		"cells/access-core/slices/sessionlogin/**",
+	}, got)
+}
+
+func TestBaseSliceAllowedFilesMultipleDashes(t *testing.T) {
+	s := NewBaseSlice("config-receive-ack", "access-core", L1)
+	got := s.AllowedFiles()
+	assert.Equal(t, []string{
+		"cells/access-core/slices/config-receive-ack/**",
+		"cells/access-core/slices/configreceiveack/**",
+	}, got)
+}
+
 func TestBaseSliceAllowedFilesCustom(t *testing.T) {
 	s := NewBaseSlice("login", "access-core", L1)
 	custom := []string{"custom/path/**"}

--- a/kernel/governance/depcheck.go
+++ b/kernel/governance/depcheck.go
@@ -81,7 +81,8 @@ func (dc *DependencyChecker) checkDEP02() []ValidationResult {
 			if !isProviderRole(cu.Role) {
 				continue
 			}
-			consumers := dc.contracts.Consumers(cu.Contract)
+			// Error ignored: REF-02 catches missing contracts; FMT-09 catches invalid kinds.
+			consumers, _ := dc.contracts.Consumers(cu.Contract)
 			for _, consumerCell := range consumers {
 				if consumerCell == providerCell {
 					continue // self-edge is not a cross-cell dependency

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -399,8 +399,12 @@ func (v *Validator) validateFMT12() []ValidationResult {
 	return results
 }
 
-// codeFMT13 is the rule code for HTTP transport metadata validation.
-const codeFMT13 = "FMT-13"
+const (
+	// codeFMT13 is the rule code for HTTP transport metadata validation.
+	codeFMT13 = "FMT-13"
+	// fieldSchemaRefsResponse is the shared field path for response schema findings.
+	fieldSchemaRefsResponse = "schemaRefs.response"
+)
 
 // validateFMT13 checks optional HTTP transport metadata on migrated HTTP contracts.
 // Legacy HTTP contracts may omit endpoints.http entirely, but once present it must
@@ -505,7 +509,7 @@ func (v *Validator) validateFMT13NoContent(c *metadata.ContractMeta, h *metadata
 		if c.SchemaRefs.Response != "" {
 			results = append(results, ValidationResult{
 				Code: codeFMT13, Severity: SeverityError, IssueType: IssueForbidden,
-				File: file, Field: "schemaRefs.response",
+				File: file, Field: fieldSchemaRefsResponse,
 				Message: fmt.Sprintf("http contract %q with noContent=true must not declare schemaRefs.response", c.ID),
 			})
 		}
@@ -521,7 +525,7 @@ func (v *Validator) validateFMT13NoContent(c *metadata.ContractMeta, h *metadata
 	if !h.NoContent && c.SchemaRefs.Response == "" {
 		results = append(results, ValidationResult{
 			Code: codeFMT13, Severity: SeverityWarning, IssueType: IssueRequired,
-			File: file, Field: "schemaRefs.response",
+			File: file, Field: fieldSchemaRefsResponse,
 			Message: fmt.Sprintf("http contract %q with noContent=false should declare schemaRefs.response", c.ID),
 		})
 	}
@@ -568,16 +572,20 @@ func (v *Validator) validateFMT15() []ValidationResult {
 		if err != nil {
 			continue // REF-12 handles missing files
 		}
-		if !isListSchema(data) {
+		info, ok := parseResponseSchema(data)
+		if !ok {
 			continue
 		}
-		if !hasMoreInRequired(data) {
+		if !isListSchema(info) {
+			continue
+		}
+		if !hasMoreInRequired(info) {
 			results = append(results, ValidationResult{
 				Code:      "FMT-15",
 				Severity:  SeverityError,
 				IssueType: IssueRequired,
 				File:      contractFile(c.ID),
-				Field:     "schemaRefs.response",
+				Field:     fieldSchemaRefsResponse,
 				Message:   fmt.Sprintf("list response schema for contract %q must include \"hasMore\" in required fields", c.ID),
 			})
 		}
@@ -585,30 +593,33 @@ func (v *Validator) validateFMT15() []ValidationResult {
 	return results
 }
 
+// responseSchemaInfo holds the subset of JSON Schema fields needed for list-lint checks.
+type responseSchemaInfo struct {
+	Properties struct {
+		Data struct {
+			Type string `json:"type"`
+		} `json:"data"`
+	} `json:"properties"`
+	Required []string `json:"required"`
+}
+
+// parseResponseSchema unmarshals the minimal fields needed for list-lint checks.
+func parseResponseSchema(data []byte) (responseSchemaInfo, bool) {
+	var info responseSchemaInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return info, false
+	}
+	return info, true
+}
+
 // isListSchema checks if a JSON schema has properties.data.type == "array".
-func isListSchema(data []byte) bool {
-	var schema struct {
-		Properties struct {
-			Data struct {
-				Type string `json:"type"`
-			} `json:"data"`
-		} `json:"properties"`
-	}
-	if err := json.Unmarshal(data, &schema); err != nil {
-		return false
-	}
-	return schema.Properties.Data.Type == "array"
+func isListSchema(info responseSchemaInfo) bool {
+	return info.Properties.Data.Type == "array"
 }
 
 // hasMoreInRequired checks if "hasMore" is in the JSON schema required array.
-func hasMoreInRequired(data []byte) bool {
-	var schema struct {
-		Required []string `json:"required"`
-	}
-	if err := json.Unmarshal(data, &schema); err != nil {
-		return false
-	}
-	for _, r := range schema.Required {
+func hasMoreInRequired(info responseSchemaInfo) bool {
+	for _, r := range info.Required {
 		if r == "hasMore" {
 			return true
 		}

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -1,7 +1,9 @@
 package governance
 
 import (
+	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/ghbvf/gocell/kernel/cell"
@@ -525,4 +527,91 @@ func (v *Validator) validateFMT13NoContent(c *metadata.ContractMeta, h *metadata
 	}
 
 	return results
+}
+
+// validateFMT14 checks that every slice declares explicit allowedFiles.
+func (v *Validator) validateFMT14() []ValidationResult {
+	var results []ValidationResult
+	for key, s := range v.project.Slices {
+		if len(s.AllowedFiles) == 0 {
+			results = append(results, ValidationResult{
+				Code:      "FMT-14",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      sliceFile(key),
+				Field:     "allowedFiles",
+				Message:   fmt.Sprintf("slice %q must declare explicit allowedFiles", s.ID),
+			})
+		}
+	}
+	return results
+}
+
+// validateFMT15 checks that HTTP list-style response schemas include "hasMore"
+// in their required fields. A response is a "list" when properties.data.type is "array".
+// Skipped when root is empty, for non-HTTP contracts, or when the schema file cannot be read.
+func (v *Validator) validateFMT15() []ValidationResult {
+	if v.root == "" {
+		return nil
+	}
+	var results []ValidationResult
+	for _, c := range v.project.Contracts {
+		if c.Kind != "http" || c.SchemaRefs.Response == "" {
+			continue
+		}
+		contractDir := filepath.Join(v.root, contractDirFromID(c.ID))
+		schemaPath := filepath.Join(contractDir, c.SchemaRefs.Response)
+		if !isWithinRoot(v.root, schemaPath) {
+			continue
+		}
+		data, err := v.readFile(schemaPath)
+		if err != nil {
+			continue // REF-12 handles missing files
+		}
+		if !isListSchema(data) {
+			continue
+		}
+		if !hasMoreInRequired(data) {
+			results = append(results, ValidationResult{
+				Code:      "FMT-15",
+				Severity:  SeverityError,
+				IssueType: IssueRequired,
+				File:      contractFile(c.ID),
+				Field:     "schemaRefs.response",
+				Message:   fmt.Sprintf("list response schema for contract %q must include \"hasMore\" in required fields", c.ID),
+			})
+		}
+	}
+	return results
+}
+
+// isListSchema checks if a JSON schema has properties.data.type == "array".
+func isListSchema(data []byte) bool {
+	var schema struct {
+		Properties struct {
+			Data struct {
+				Type string `json:"type"`
+			} `json:"data"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return false
+	}
+	return schema.Properties.Data.Type == "array"
+}
+
+// hasMoreInRequired checks if "hasMore" is in the JSON schema required array.
+func hasMoreInRequired(data []byte) bool {
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return false
+	}
+	for _, r := range schema.Required {
+		if r == "hasMore" {
+			return true
+		}
+	}
+	return false
 }

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -48,11 +48,11 @@ type ValidationResult struct {
 // Validator runs all validation rules against a parsed project.
 type Validator struct {
 	project    *metadata.ProjectMeta
-	root       string                              // project root for file existence checks
-	now        func() time.Time                    // clock function (injectable for tests)
-	fileExists func(path string) bool              // file existence check (injectable for tests)
-	readFile   func(path string) ([]byte, error)   // file reader (injectable for tests)
-	actorSet   map[string]bool                     // pre-built set of external actor IDs
+	root       string                            // project root for file existence checks
+	now        func() time.Time                  // clock function (injectable for tests)
+	fileExists func(path string) bool            // file existence check (injectable for tests)
+	readFile   func(path string) ([]byte, error) // file reader (injectable for tests)
+	actorSet   map[string]bool                   // pre-built set of external actor IDs
 }
 
 // NewValidator creates a Validator for the given parsed project metadata.

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -48,10 +48,11 @@ type ValidationResult struct {
 // Validator runs all validation rules against a parsed project.
 type Validator struct {
 	project    *metadata.ProjectMeta
-	root       string                 // project root for file existence checks
-	now        func() time.Time       // clock function (injectable for tests)
-	fileExists func(path string) bool // file existence check (injectable for tests)
-	actorSet   map[string]bool        // pre-built set of external actor IDs
+	root       string                              // project root for file existence checks
+	now        func() time.Time                    // clock function (injectable for tests)
+	fileExists func(path string) bool              // file existence check (injectable for tests)
+	readFile   func(path string) ([]byte, error)   // file reader (injectable for tests)
+	actorSet   map[string]bool                     // pre-built set of external actor IDs
 }
 
 // NewValidator creates a Validator for the given parsed project metadata.
@@ -78,6 +79,7 @@ func NewValidator(project *metadata.ProjectMeta, root string) *Validator {
 			_, err := os.Stat(path)
 			return err == nil
 		},
+		readFile: os.ReadFile,
 		actorSet: actorSet,
 	}
 }
@@ -135,6 +137,8 @@ func (v *Validator) Validate() []ValidationResult {
 	results = append(results, v.validateFMT11()...)
 	results = append(results, v.validateFMT12()...)
 	results = append(results, v.validateFMT13()...)
+	results = append(results, v.validateFMT14()...)
+	results = append(results, v.validateFMT15()...)
 
 	// Advisory rules
 	results = append(results, v.validateADV01()...)

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -3359,12 +3359,24 @@ func TestFMT15(t *testing.T) {
 			readFile:  func(_ string) ([]byte, error) { return []byte(missingHasMore), nil },
 			wantCount: 0,
 		},
+		{
+			name: "empty root skipped",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(missingHasMore), nil },
+			wantCount: 0, // root="" causes early return
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pm := validProject()
 			tt.setup(pm)
-			val := NewValidator(pm, "/fake/root")
+			root := "/fake/root"
+			if tt.name == "empty root skipped" {
+				root = ""
+			}
+			val := NewValidator(pm, root)
 			if tt.readFile != nil {
 				val.readFile = tt.readFile
 			}

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -61,6 +61,10 @@ func validProject() *metadata.ProjectMeta {
 						"contract.projection.session.active.v1.provide",
 					},
 				},
+				AllowedFiles: []string{
+					"cells/access-core/slices/session-login/**",
+					"cells/access-core/slices/sessionlogin/**",
+				},
 			},
 			"audit-core/audit-write": {
 				ID:            "audit-write",
@@ -71,6 +75,10 @@ func validProject() *metadata.ProjectMeta {
 				Verify: metadata.SliceVerifyMeta{
 					Unit:     []string{"unit.audit-write.handler"},
 					Contract: []string{"contract.event.session.created.v1.subscribe"},
+				},
+				AllowedFiles: []string{
+					"cells/audit-core/slices/audit-write/**",
+					"cells/audit-core/slices/auditwrite/**",
 				},
 			},
 		},
@@ -3231,4 +3239,140 @@ func TestREF16(t *testing.T) {
 		got := findByCode(val.validateREF16(), "REF-16")
 		assert.Len(t, got, 2) // both assemblies missing boundary.yaml
 	})
+}
+
+// --- FMT-14: slice allowedFiles required ---
+
+func TestFMT14(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+	}{
+		{
+			name: "slices with allowedFiles are valid",
+			setup: func(pm *metadata.ProjectMeta) {
+				for _, s := range pm.Slices {
+					s.AllowedFiles = []string{"cells/x/slices/y/**"}
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "slices without allowedFiles trigger errors",
+			setup: func(pm *metadata.ProjectMeta) {
+				for _, s := range pm.Slices {
+					s.AllowedFiles = nil
+				}
+			},
+			wantCount: 2,
+		},
+		{
+			name: "only one slice missing",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Slices["audit-core/audit-write"].AllowedFiles = nil
+			},
+			wantCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, "")
+			got := findByCode(val.validateFMT14(), "FMT-14")
+			assert.Len(t, got, tt.wantCount)
+			for _, r := range got {
+				assert.Equal(t, SeverityError, r.Severity)
+				assert.Equal(t, IssueRequired, r.IssueType)
+				assert.Equal(t, "allowedFiles", r.Field)
+			}
+		})
+	}
+}
+
+// --- FMT-15: list response schema must include hasMore ---
+
+func TestFMT15(t *testing.T) {
+	validListSchema := `{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data","hasMore"]}`
+	missingHasMore := `{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data"]}`
+	singleObject := `{"properties":{"data":{"type":"object"}},"required":["data"]}`
+	invalidJSON := `{not json`
+
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		readFile  func(string) ([]byte, error)
+		wantCount int
+	}{
+		{
+			name: "list schema with hasMore in required",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(validListSchema), nil },
+			wantCount: 0,
+		},
+		{
+			name: "list schema missing hasMore",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(missingHasMore), nil },
+			wantCount: 1,
+		},
+		{
+			name: "non-list schema skipped",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(singleObject), nil },
+			wantCount: 0,
+		},
+		{
+			name:      "no schemaRefs.response skipped",
+			setup:     func(_ *metadata.ProjectMeta) {},
+			readFile:  nil,
+			wantCount: 0,
+		},
+		{
+			name: "file read error skipped gracefully",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return nil, os.ErrNotExist },
+			wantCount: 0,
+		},
+		{
+			name: "invalid JSON skipped",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(invalidJSON), nil },
+			wantCount: 0,
+		},
+		{
+			name: "non-http contract skipped",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["event.session.created.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(missingHasMore), nil },
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, "/fake/root")
+			if tt.readFile != nil {
+				val.readFile = tt.readFile
+			}
+			got := findByCode(val.validateFMT15(), "FMT-15")
+			assert.Len(t, got, tt.wantCount)
+			for _, r := range got {
+				assert.Equal(t, SeverityError, r.Severity)
+			}
+		})
+	}
 }

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -42,6 +42,7 @@ type SliceMeta struct {
 	BelongsToCell  string          `yaml:"belongsToCell"`
 	ContractUsages []ContractUsage `yaml:"contractUsages"`
 	Verify         SliceVerifyMeta `yaml:"verify"`
+	AllowedFiles   []string        `yaml:"allowedFiles,omitempty"`
 }
 
 // ContractUsage declares a Slice's participation in a Contract.

--- a/kernel/registry/contract.go
+++ b/kernel/registry/contract.go
@@ -3,9 +3,11 @@
 package registry
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // ContractRegistry provides indexed access to contracts.
@@ -94,23 +96,25 @@ func (r *ContractRegistry) Provider(contractID string) string {
 
 // Consumers returns the consumer actor IDs for a contract.
 // For http: clients, event: subscribers, command: invokers, projection: readers.
-// Returns nil if the contract is not found or kind is unknown.
-func (r *ContractRegistry) Consumers(contractID string) []string {
+// Returns an error if the contract is not found or the kind is unknown.
+func (r *ContractRegistry) Consumers(contractID string) ([]string, error) {
 	c := r.contracts[contractID]
 	if c == nil {
-		return nil
+		return nil, errcode.New(errcode.ErrContractNotFound,
+			fmt.Sprintf("contract %q not found in registry", contractID))
 	}
 	switch c.Kind {
 	case "http":
-		return append([]string(nil), c.Endpoints.Clients...)
+		return append([]string(nil), c.Endpoints.Clients...), nil
 	case "event":
-		return append([]string(nil), c.Endpoints.Subscribers...)
+		return append([]string(nil), c.Endpoints.Subscribers...), nil
 	case "command":
-		return append([]string(nil), c.Endpoints.Invokers...)
+		return append([]string(nil), c.Endpoints.Invokers...), nil
 	case "projection":
-		return append([]string(nil), c.Endpoints.Readers...)
+		return append([]string(nil), c.Endpoints.Readers...), nil
 	default:
-		return nil
+		return nil, errcode.New(errcode.ErrValidationFailed,
+			fmt.Sprintf("unknown contract kind %q for contract %q", c.Kind, contractID))
 	}
 }
 

--- a/kernel/registry/contract.go
+++ b/kernel/registry/contract.go
@@ -85,13 +85,26 @@ func deepCopyContract(c *metadata.ContractMeta) *metadata.ContractMeta {
 
 // Provider returns the provider actor ID for a contract.
 // For http: server, event: publisher, command: handler, projection: provider.
-// Returns empty string if the contract is not found or kind is unknown.
-func (r *ContractRegistry) Provider(contractID string) string {
+// Returns an error if the contract is not found or the kind is unknown.
+func (r *ContractRegistry) Provider(contractID string) (string, error) {
 	c := r.contracts[contractID]
 	if c == nil {
-		return ""
+		return "", errcode.New(errcode.ErrContractNotFound,
+			fmt.Sprintf("contract %q not found in registry", contractID))
 	}
-	return c.ProviderEndpoint()
+	switch c.Kind {
+	case "http":
+		return c.Endpoints.Server, nil
+	case "event":
+		return c.Endpoints.Publisher, nil
+	case "command":
+		return c.Endpoints.Handler, nil
+	case "projection":
+		return c.Endpoints.Provider, nil
+	default:
+		return "", errcode.New(errcode.ErrValidationFailed,
+			fmt.Sprintf("unknown contract kind %q for contract %q", c.Kind, contractID))
+	}
 }
 
 // Consumers returns the consumer actor IDs for a contract.

--- a/kernel/registry/registry_test.go
+++ b/kernel/registry/registry_test.go
@@ -164,14 +164,26 @@ func TestContractRegistry_Provider(t *testing.T) {
 		{"event provider is publisher", "event-session-created-v1", "access-core"},
 		{"command provider is handler", "command-audit-archive-v1", "audit-core"},
 		{"projection provider is provider", "projection-audit-summary-v1", "audit-core"},
-		{"not found returns empty", "nonexistent", ""},
 	}
 	reg := registry.NewContractRegistry(testProject())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, reg.Provider(tt.contractID))
+			got, err := reg.Provider(tt.contractID)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestContractRegistry_Provider_NotFound(t *testing.T) {
+	reg := registry.NewContractRegistry(testProject())
+	got, err := reg.Provider("nonexistent")
+	require.Error(t, err)
+	assert.Equal(t, "", got)
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, errcode.ErrContractNotFound, ec.Code)
 }
 
 func TestContractRegistry_Consumers(t *testing.T) {
@@ -239,7 +251,8 @@ func TestContractRegistry_EmptyProject(t *testing.T) {
 			assert.Nil(t, reg.Get("any"))
 			assert.Empty(t, reg.ByKind("http"))
 			assert.Empty(t, reg.ByOwner("any"))
-			assert.Equal(t, "", reg.Provider("any"))
+			_, providerErr := reg.Provider("any")
+			require.Error(t, providerErr)
 			_, consumersErr := reg.Consumers("any")
 			require.Error(t, consumersErr)
 			assert.Empty(t, reg.AllIDs())
@@ -340,7 +353,14 @@ func TestContractRegistry_Provider_UnknownKind(t *testing.T) {
 		},
 	}
 	reg := registry.NewContractRegistry(proj)
-	assert.Equal(t, "", reg.Provider("grpc-unknown-v1"))
+	got, err := reg.Provider("grpc-unknown-v1")
+	require.Error(t, err)
+	assert.Equal(t, "", got)
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+	assert.Contains(t, err.Error(), "grpc")
 }
 
 func TestContractRegistry_Consumers_UnknownKind(t *testing.T) {

--- a/kernel/registry/registry_test.go
+++ b/kernel/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/kernel/registry"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // testProject returns a ProjectMeta with realistic test data:
@@ -182,15 +184,26 @@ func TestContractRegistry_Consumers(t *testing.T) {
 		{"event consumers are subscribers", "event-session-created-v1", []string{"audit-core", "config-core"}},
 		{"command consumers are invokers", "command-audit-archive-v1", []string{"access-core"}},
 		{"projection consumers are readers", "projection-audit-summary-v1", []string{"access-core", "config-core"}},
-		{"not found returns nil", "nonexistent", nil},
 	}
 	reg := registry.NewContractRegistry(testProject())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := reg.Consumers(tt.contractID)
+			got, err := reg.Consumers(tt.contractID)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestContractRegistry_Consumers_NotFound(t *testing.T) {
+	reg := registry.NewContractRegistry(testProject())
+	got, err := reg.Consumers("nonexistent")
+	require.Error(t, err)
+	assert.Nil(t, got)
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, errcode.ErrContractNotFound, ec.Code)
 }
 
 func TestContractRegistry_AllIDs(t *testing.T) {
@@ -227,7 +240,8 @@ func TestContractRegistry_EmptyProject(t *testing.T) {
 			assert.Empty(t, reg.ByKind("http"))
 			assert.Empty(t, reg.ByOwner("any"))
 			assert.Equal(t, "", reg.Provider("any"))
-			assert.Nil(t, reg.Consumers("any"))
+			_, consumersErr := reg.Consumers("any")
+			require.Error(t, consumersErr)
 			assert.Empty(t, reg.AllIDs())
 		})
 	}
@@ -339,7 +353,14 @@ func TestContractRegistry_Consumers_UnknownKind(t *testing.T) {
 		},
 	}
 	reg := registry.NewContractRegistry(proj)
-	assert.Nil(t, reg.Consumers("grpc-unknown-v1"))
+	got, err := reg.Consumers("grpc-unknown-v1")
+	require.Error(t, err)
+	assert.Nil(t, got)
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+	assert.Contains(t, err.Error(), "grpc")
 }
 
 func TestContractRegistry_NilContractInMap(t *testing.T) {
@@ -418,12 +439,14 @@ func TestContractRegistry_ByKind_DeepCopy(t *testing.T) {
 
 func TestContractRegistry_Consumers_DeepCopy(t *testing.T) {
 	reg := registry.NewContractRegistry(testProject())
-	got := reg.Consumers("http-auth-login-v1")
+	got, err := reg.Consumers("http-auth-login-v1")
+	require.NoError(t, err)
 	require.NotEmpty(t, got)
 
 	got[0] = "MUTATED"
 
-	fresh := reg.Consumers("http-auth-login-v1")
+	fresh, err := reg.Consumers("http-auth-login-v1")
+	require.NoError(t, err)
 	assert.NotEqual(t, "MUTATED", fresh[0])
 }
 


### PR DESCRIPTION
## Summary
- **#27b SLICE-ALLOWEDFILES-01**: `SliceMeta` 新增 `AllowedFiles` 字段 + `AllowedFiles()` 默认归一化 kebab→no-dash + FMT-14 治理规则 + 22 个 slice.yaml 显式声明
- **#138b CONTRACT-LIST-LINT-01**: FMT-15 治理规则检查 HTTP list response schema 必须包含 `hasMore` + `Validator` 新增 injectable `readFile`
- **REGISTRY-CONSUMERS-UNKNOWN-KIND-01**: `Consumers()` 签名从 `[]string` 改为 `([]string, error)`，unknown kind/not found 返回 typed error

## 开源对标
- Kubernetes apimachinery `field/errors.go`: typed error accumulation pattern
- go-zero goctl: early validation before code generation pipeline
- Kratos codec registry: silent nil (反面教材，本 PR 修复同类问题)

## 变更文件
- `kernel/registry/contract.go`: Consumers() 签名变更
- `kernel/governance/rules_fmt.go`: +validateFMT14, +validateFMT15, +isListSchema, +hasMoreInRequired
- `kernel/governance/validate.go`: +readFile field, +FMT-14/15 注册
- `kernel/cell/base.go`: AllowedFiles() kebab→no-dash 归一化
- `kernel/metadata/types.go`: SliceMeta +AllowedFiles field
- `kernel/assembly/generator.go`, `kernel/governance/depcheck.go`: Consumers() caller 适配
- 22 `cells/*/slices/*/slice.yaml`: +allowedFiles

## Test plan
- [x] `go build ./...` — 编译通过
- [x] `go test ./kernel/...` — 13 packages 全部通过
- [x] `gocell validate` — 0 errors, 2 warnings (pre-existing)
- [x] TDD: 先写失败测试，再实现
- [x] FMT-14: 3 test cases (valid/missing/partial)
- [x] FMT-15: 7 test cases (valid/missing/non-list/no-schema/read-error/invalid-json/non-http)
- [x] Consumers(): 更新 5 处调用 + 新增 NotFound/UnknownKind error 测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)