### PR TITLE
feat(access-core): RBAC closure — role assign + identity authz + seed admin

### DIFF
--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -311,13 +311,12 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 func (c *AccessCore) doSeedAdmin(ctx context.Context) error {
 	memRoleRepo, ok := c.roleRepo.(*mem.RoleRepository)
 	if !ok {
-		c.logger.Warn("seed admin: roleRepo is not in-memory, skipping seed")
-		return nil
+		return fmt.Errorf("seed admin requires in-memory role repository; got %T", c.roleRepo)
 	}
 
 	memRoleRepo.SeedRole(&domain.Role{
-		ID:   "admin",
-		Name: "admin",
+		ID:   domain.RoleAdmin,
+		Name: domain.RoleAdmin,
 		Permissions: []domain.Permission{
 			{Resource: "*", Action: "*"},
 		},
@@ -350,7 +349,7 @@ func (c *AccessCore) doSeedAdmin(ctx context.Context) error {
 		return fmt.Errorf("persist user: %w", err)
 	}
 
-	if err := c.roleRepo.AssignToUser(ctx, user.ID, "admin"); err != nil {
+	if err := c.roleRepo.AssignToUser(ctx, user.ID, domain.RoleAdmin); err != nil {
 		return fmt.Errorf("assign role: %w", err)
 	}
 

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -293,7 +293,8 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	c.rbacHandler = rbaccheck.NewHandler(rbacSvc)
 	c.AddSlice(cell.NewBaseSlice("rbac-check", "access-core", cell.L0))
 
-	// rbac-assign (L0: pure repo operations, no events)
+	// rbac-assign — L0 is correct for in-memory repos (no transaction semantics).
+	// Upgrade to L1 when PostgreSQL adapter is introduced (needs real tx).
 	rbacAssignSvc := rbacassign.NewService(c.roleRepo, c.logger)
 	c.rbacAssignHandler = rbacassign.NewHandler(rbacAssignSvc)
 	c.AddSlice(cell.NewBaseSlice("rbac-assign", "access-core", cell.L0))

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -5,14 +5,19 @@ package accesscore
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/cells/access-core/slices/authorizationdecide"
 	"github.com/ghbvf/gocell/cells/access-core/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/access-core/slices/identitymanage"
+	"github.com/ghbvf/gocell/cells/access-core/slices/rbacassign"
 	"github.com/ghbvf/gocell/cells/access-core/slices/rbaccheck"
 	"github.com/ghbvf/gocell/cells/access-core/slices/sessionlogin"
 	"github.com/ghbvf/gocell/cells/access-core/slices/sessionlogout"
@@ -91,6 +96,23 @@ func WithInMemoryDefaults() Option {
 	}
 }
 
+// WithSeedAdminRole ensures the "admin" role exists in the role repository
+// during Init(). Idempotent: re-seeding is a no-op.
+func WithSeedAdminRole() Option {
+	return func(c *AccessCore) { c.seedAdminRole = true }
+}
+
+// WithSeedAdmin ensures the "admin" role exists and creates an admin user
+// with the given credentials during Init(). Idempotent: skips if the user
+// already exists.
+func WithSeedAdmin(username, password string) Option {
+	return func(c *AccessCore) {
+		c.seedAdminRole = true
+		c.seedAdminUser = username
+		c.seedAdminPass = password
+	}
+}
+
 // AccessCore is the access-core Cell implementation.
 type AccessCore struct {
 	*cell.BaseCell
@@ -104,6 +126,11 @@ type AccessCore struct {
 	jwtIssuer    *auth.JWTIssuer
 	jwtVerifier  *auth.JWTVerifier
 
+	// Seed admin configuration (set via WithSeedAdmin/WithSeedAdminRole).
+	seedAdminRole bool
+	seedAdminUser string
+	seedAdminPass string
+
 	// Slice handlers.
 	identityHandler *identitymanage.Handler
 	loginHandler    *sessionlogin.Handler
@@ -114,6 +141,7 @@ type AccessCore struct {
 	validateSvc      *sessionvalidate.Service
 	authzSvc         *authorizationdecide.Service
 	rbacHandler      *rbaccheck.Handler
+	rbacAssignHandler *rbacassign.Handler
 	configReceiveSvc *configreceive.Service
 }
 
@@ -165,7 +193,7 @@ func (c *AccessCore) Authorizer() auth.Authorizer {
 	return c.authzSvc
 }
 
-// Init constructs all 8 slices.
+// Init constructs all 9 slices.
 func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := c.BaseCell.Init(ctx, deps); err != nil {
 		return err
@@ -200,6 +228,13 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if c.jwtIssuer == nil || c.jwtVerifier == nil {
 		return errcode.New(errcode.ErrAuthKeyInvalid,
 			"RS256 key pair required: use WithJWTIssuer and WithJWTVerifier")
+	}
+
+	// Seed admin role and optional admin user.
+	if c.seedAdminRole {
+		if err := c.doSeedAdmin(ctx); err != nil {
+			return fmt.Errorf("access-core seed admin: %w", err)
+		}
 	}
 
 	// identity-manage
@@ -258,10 +293,70 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	c.rbacHandler = rbaccheck.NewHandler(rbacSvc)
 	c.AddSlice(cell.NewBaseSlice("rbac-check", "access-core", cell.L0))
 
+	// rbac-assign (L0: pure repo operations, no events)
+	rbacAssignSvc := rbacassign.NewService(c.roleRepo, c.logger)
+	c.rbacAssignHandler = rbacassign.NewHandler(rbacAssignSvc)
+	c.AddSlice(cell.NewBaseSlice("rbac-assign", "access-core", cell.L0))
+
 	// config-receive: subscribes to config.changed events from config-core
 	c.configReceiveSvc = configreceive.NewService(c.logger)
 	c.AddSlice(cell.NewBaseSlice("config-receive", "access-core", cell.L3))
 
+	return nil
+}
+
+// doSeedAdmin seeds the admin role and optionally creates an admin user.
+// Requires roleRepo to be a *mem.RoleRepository (for SeedRole access).
+// Idempotent: skips if user already exists.
+func (c *AccessCore) doSeedAdmin(ctx context.Context) error {
+	memRoleRepo, ok := c.roleRepo.(*mem.RoleRepository)
+	if !ok {
+		c.logger.Warn("seed admin: roleRepo is not in-memory, skipping seed")
+		return nil
+	}
+
+	memRoleRepo.SeedRole(&domain.Role{
+		ID:   "admin",
+		Name: "admin",
+		Permissions: []domain.Permission{
+			{Resource: "*", Action: "*"},
+		},
+	})
+	c.logger.Info("seed: admin role ensured")
+
+	if c.seedAdminUser == "" || c.seedAdminPass == "" {
+		return nil
+	}
+
+	// Check if user already exists (idempotent).
+	if _, err := c.userRepo.GetByUsername(ctx, c.seedAdminUser); err == nil {
+		c.logger.Info("seed: admin user already exists, skipping",
+			slog.String("username", c.seedAdminUser))
+		return nil
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(c.seedAdminPass), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("hash password: %w", err)
+	}
+
+	user, err := domain.NewUser(c.seedAdminUser, c.seedAdminUser+"@gocell.local", string(hash))
+	if err != nil {
+		return fmt.Errorf("create user: %w", err)
+	}
+	user.ID = "usr-admin-seed"
+
+	if err := c.userRepo.Create(ctx, user); err != nil {
+		return fmt.Errorf("persist user: %w", err)
+	}
+
+	if err := c.roleRepo.AssignToUser(ctx, user.ID, "admin"); err != nil {
+		return fmt.Errorf("assign role: %w", err)
+	}
+
+	c.logger.Info("seed: admin user created",
+		slog.String("username", c.seedAdminUser),
+		slog.String("user_id", user.ID))
 	return nil
 }
 
@@ -280,6 +375,11 @@ func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
 
 		// RBAC queries: /api/v1/access/roles
 		sub.Route("/roles", c.rbacHandler.RegisterRoutes)
+	})
+
+	// Internal admin endpoints: /internal/v1/access/roles
+	mux.Route("/internal/v1/access", func(sub cell.RouteMux) {
+		sub.Route("/roles", c.rbacAssignHandler.RegisterRoutes)
 	})
 }
 

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -295,7 +295,7 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 
 	// rbac-assign — L0 is correct for in-memory repos (no transaction semantics).
 	// Upgrade to L1 when PostgreSQL adapter is introduced (needs real tx).
-	rbacAssignSvc := rbacassign.NewService(c.roleRepo, c.logger)
+	rbacAssignSvc := rbacassign.NewService(c.roleRepo, c.sessionRepo, c.logger)
 	c.rbacAssignHandler = rbacassign.NewHandler(rbacAssignSvc)
 	c.AddSlice(cell.NewBaseSlice("rbac-assign", "access-core", cell.L0))
 

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 
 	"golang.org/x/crypto/bcrypt"
 	"github.com/ghbvf/gocell/kernel/cell"
@@ -616,4 +617,26 @@ func TestAccessCore_SeedAdmin_Idempotent(t *testing.T) {
 	require.NoError(t, makeCell().Init(ctx, deps))
 	// Second init should not error (idempotent).
 	require.NoError(t, makeCell().Init(ctx, deps))
+}
+
+// stubRoleRepo is a non-mem RoleRepository for testing doSeedAdmin type assertion.
+type stubRoleRepo struct{ ports.RoleRepository }
+
+func TestAccessCore_SeedAdmin_NonMemRepo_ReturnsError(t *testing.T) {
+	c := NewAccessCore(
+		WithUserRepository(mem.NewUserRepository()),
+		WithSessionRepository(mem.NewSessionRepository()),
+		WithRoleRepository(stubRoleRepo{}),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
+		WithSeedAdminRole(),
+	)
+	ctx := context.Background()
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	err := c.Init(ctx, deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "seed admin requires in-memory role repository")
 }

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -187,7 +187,7 @@ func TestAccessCore_Lifecycle(t *testing.T) {
 
 	// Init
 	require.NoError(t, c.Init(ctx, deps))
-	assert.Equal(t, 8, len(c.OwnedSlices()), "should have 8 slices")
+	assert.Equal(t, 9, len(c.OwnedSlices()), "should have 9 slices")
 
 	// Start
 	require.NoError(t, c.Start(ctx))
@@ -313,6 +313,7 @@ func TestAccessCore_RouteUserCreate(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/users/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	r.ServeHTTP(rec, req)
 
 	assert.NotEqual(t, http.StatusNotFound, rec.Code,
@@ -339,6 +340,7 @@ func TestAccessCore_RouteUserGet(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/users/usr-nonexistent", nil)
+	req = req.WithContext(auth.TestContext("usr-nonexistent", nil)) // self-access
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusNotFound, rec.Code,
@@ -347,11 +349,31 @@ func TestAccessCore_RouteUserGet(t *testing.T) {
 		"response should be JSON (handler reached, not chi 404)")
 }
 
+func TestAccessCore_RouteRoleAssign(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	// Verify route is reachable. Role "admin" is not seeded in newTestCell(),
+	// so we expect a domain-level 404 (role not found) — NOT a router-level 404.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/access/roles/assign",
+		strings.NewReader(`{"userId":"usr-1","roleId":"admin"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
+	r.ServeHTTP(rec, req)
+
+	// Domain-level 404 has JSON body with error code; router-level 404 doesn't.
+	if rec.Code == http.StatusNotFound {
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"),
+			"response should be JSON (handler reached, not router 404)")
+	}
+}
+
 func TestAccessCore_RouteRolesList(t *testing.T) {
 	r := initCellWithRouter(t)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/roles/user-1", nil)
+	req = req.WithContext(auth.TestContext("user-1", nil)) // self-access
 	r.ServeHTTP(rec, req)
 
 	assert.NotEqual(t, http.StatusNotFound, rec.Code,
@@ -510,4 +532,88 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 	_, err = verifier.Verify(ctx, refreshedToken)
 	require.Error(t, err, "refreshed token should be rejected after session revocation")
 	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN")
+}
+
+// --- Seed admin tests (H1-5) ---
+
+func TestAccessCore_SeedAdminRole_AlwaysSeeded(t *testing.T) {
+	roleRepo := mem.NewRoleRepository()
+	c := NewAccessCore(
+		WithUserRepository(mem.NewUserRepository()),
+		WithSessionRepository(mem.NewSessionRepository()),
+		WithRoleRepository(roleRepo),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
+		WithSeedAdminRole(),
+	)
+	ctx := context.Background()
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	require.NoError(t, c.Init(ctx, deps))
+
+	role, err := roleRepo.GetByID(ctx, "admin")
+	require.NoError(t, err, "admin role should be seeded")
+	assert.Equal(t, "admin", role.Name)
+}
+
+func TestAccessCore_SeedAdmin_CreatesUserAndAssignsRole(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	c := NewAccessCore(
+		WithUserRepository(userRepo),
+		WithSessionRepository(mem.NewSessionRepository()),
+		WithRoleRepository(roleRepo),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
+		WithSeedAdmin("admin", "admin-pass-123"),
+	)
+	ctx := context.Background()
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	require.NoError(t, c.Init(ctx, deps))
+
+	// Admin role exists.
+	role, err := roleRepo.GetByID(ctx, "admin")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", role.Name)
+
+	// Admin user exists.
+	user, err := userRepo.GetByUsername(ctx, "admin")
+	require.NoError(t, err)
+	assert.Equal(t, "usr-admin-seed", user.ID)
+
+	// Role assigned.
+	roles, err := roleRepo.GetByUserID(ctx, user.ID)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "admin", roles[0].Name)
+}
+
+func TestAccessCore_SeedAdmin_Idempotent(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	makeCell := func() *AccessCore {
+		return NewAccessCore(
+			WithUserRepository(userRepo),
+			WithSessionRepository(mem.NewSessionRepository()),
+			WithRoleRepository(roleRepo),
+			WithPublisher(eventbus.New()),
+			WithJWTIssuer(testIssuer),
+			WithJWTVerifier(testVerifier),
+			WithOutboxWriter(outbox.NoopWriter{}),
+			WithTxManager(noopTxRunner{}),
+			WithSeedAdmin("admin", "admin-pass-123"),
+		)
+	}
+	ctx := context.Background()
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+
+	// First init seeds admin.
+	require.NoError(t, makeCell().Init(ctx, deps))
+	// Second init should not error (idempotent).
+	require.NoError(t, makeCell().Init(ctx, deps))
 }

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -310,15 +310,41 @@ func TestAccessCore_RouteSessionRefresh(t *testing.T) {
 func TestAccessCore_RouteUserCreate(t *testing.T) {
 	r := initCellWithRouter(t)
 
+	// Admin creates user → 201.
 	body := `{"username":"bob","email":"bob@example.com","password":"secret123"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/users/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code,
+		"POST /api/v1/access/users/ with admin should return 201 (got %d)", rec.Code)
+}
 
-	assert.NotEqual(t, http.StatusNotFound, rec.Code,
-		"POST /api/v1/access/users/ should not return 404 (got %d)", rec.Code)
+func TestAccessCore_RouteUserCreate_NoAuth_Returns401(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/users/",
+		strings.NewReader(`{"username":"x","email":"x@y.com","password":"pass1234"}`))
+	req.Header.Set("Content-Type", "application/json")
+	// No auth context.
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ERR_AUTH_UNAUTHORIZED")
+}
+
+func TestAccessCore_RouteUserCreate_NonAdmin_Returns403(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/users/",
+		strings.NewReader(`{"username":"x","email":"x@y.com","password":"pass1234"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("user-1", []string{"viewer"}))
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ERR_AUTH_FORBIDDEN")
 }
 
 func TestAccessCore_RouteSessionLogout(t *testing.T) {
@@ -353,8 +379,7 @@ func TestAccessCore_RouteUserGet(t *testing.T) {
 func TestAccessCore_RouteRoleAssign(t *testing.T) {
 	r := initCellWithRouter(t)
 
-	// Verify route is reachable. Role "admin" is not seeded in newTestCell(),
-	// so we expect a domain-level 404 (role not found) — NOT a router-level 404.
+	// Role "admin" is not seeded in newTestCell() → domain-level 404 (role not found).
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/internal/v1/access/roles/assign",
 		strings.NewReader(`{"userId":"usr-1","roleId":"admin"}`))
@@ -362,11 +387,36 @@ func TestAccessCore_RouteRoleAssign(t *testing.T) {
 	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	r.ServeHTTP(rec, req)
 
-	// Domain-level 404 has JSON body with error code; router-level 404 doesn't.
-	if rec.Code == http.StatusNotFound {
-		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"),
-			"response should be JSON (handler reached, not router 404)")
-	}
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"),
+		"response should be JSON (handler reached, not router 404)")
+	assert.Contains(t, rec.Body.String(), "ERR_AUTH_ROLE_NOT_FOUND")
+}
+
+func TestAccessCore_RouteRoleAssign_NoAuth_Returns401(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/access/roles/assign",
+		strings.NewReader(`{"userId":"usr-1","roleId":"admin"}`))
+	req.Header.Set("Content-Type", "application/json")
+	// No auth context.
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ERR_AUTH_UNAUTHORIZED")
+}
+
+func TestAccessCore_RouteRoleAssign_NonAdmin_Returns403(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/access/roles/assign",
+		strings.NewReader(`{"userId":"usr-1","roleId":"admin"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("user-1", []string{"viewer"}))
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ERR_AUTH_FORBIDDEN")
 }
 
 func TestAccessCore_RouteRolesList(t *testing.T) {

--- a/cells/access-core/internal/domain/role.go
+++ b/cells/access-core/internal/domain/role.go
@@ -1,5 +1,8 @@
 package domain
 
+// RoleAdmin is the well-known admin role name used across access-core.
+const RoleAdmin = "admin"
+
 // Permission represents a single allowed action on a resource.
 type Permission struct {
 	Resource string

--- a/cells/access-core/slices/identitymanage/contract_test.go
+++ b/cells/access-core/slices/identitymanage/contract_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/require"
 )
@@ -71,6 +72,7 @@ func createUserForContractTest(t *testing.T, handler http.Handler, contract *con
 	body := `{"username":"alice","email":"a@b.com","password":"` + testPassword + `"}`
 	req := httptest.NewRequest(contract.HTTP.Method, contract.HTTP.Path, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 	contract.ValidateHTTPResponseRecorder(t, recorder)
@@ -99,6 +101,7 @@ func TestHttpAuthUserCreateV1Serve(t *testing.T) {
 
 	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(`{"username":"alice","email":"a@b.com","password":"`+testPassword+`"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 	c.ValidateHTTPResponseRecorder(t, recorder)
@@ -114,6 +117,7 @@ func TestHttpAuthUserGetV1Serve(t *testing.T) {
 	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	handler.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
@@ -130,6 +134,7 @@ func TestHttpAuthUserUpdateV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"email":"new@b.com"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	handler.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 
@@ -148,8 +153,14 @@ func TestHttpAuthUserPatchV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"name":"Bob"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	handler.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
+
+	// H2-3: validate request schema for PATCH (JSON merge patch).
+	c.ValidateRequest(t, []byte(`{"name":"Bob"}`))
+	c.ValidateRequest(t, []byte(`{"email":"new@b.com"}`))
+	c.ValidateRequest(t, []byte(`{"name":"Bob","email":"new@b.com","status":"active"}`))
 
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }
@@ -166,6 +177,7 @@ func TestHttpAuthUserDeleteV1Serve(t *testing.T) {
 	userID := createUserForContractTest(t, handler, createContract)
 	deletePath := strings.Replace(deleteContract.HTTP.Path, "{id}", userID, 1)
 	req := httptest.NewRequest(deleteContract.HTTP.Method, deletePath, nil)
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 	deleteContract.ValidateHTTPResponseRecorder(t, recorder)
@@ -181,6 +193,7 @@ func TestHttpAuthUserLockV1Serve(t *testing.T) {
 	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	handler.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
@@ -197,12 +210,14 @@ func TestHttpAuthUserUnlockV1Serve(t *testing.T) {
 	// Lock first
 	lockPath := strings.Replace(lockContract.HTTP.Path, "{id}", userID, 1)
 	lockReq := httptest.NewRequest(lockContract.HTTP.Method, lockPath, nil)
+	lockReq = lockReq.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	handler.ServeHTTP(httptest.NewRecorder(), lockReq)
 
 	// Unlock
 	path := strings.Replace(c.HTTP.Path, "{id}", userID, 1)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	handler.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
@@ -239,6 +254,7 @@ func TestEventUserLockedV1Publish(t *testing.T) {
 	lockPath := strings.Replace(lockContract.HTTP.Path, "{id}", userID, 1)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(lockContract.HTTP.Method, lockPath, nil)
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
 	handler.ServeHTTP(rec, req)
 	lockContract.ValidateHTTPResponseRecorder(t, rec)
 

--- a/cells/access-core/slices/identitymanage/handler.go
+++ b/cells/access-core/slices/identitymanage/handler.go
@@ -64,7 +64,7 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 }
 
 func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -92,7 +92,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	if err := auth.RequireSelfOrRole(r.Context(), id, "admin"); err != nil {
+	if err := auth.RequireSelfOrRole(r.Context(), id, domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -107,7 +107,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	if err := auth.RequireSelfOrRole(r.Context(), id, "admin"); err != nil {
+	if err := auth.RequireSelfOrRole(r.Context(), id, domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -134,7 +134,7 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	if err := auth.RequireSelfOrRole(r.Context(), id, "admin"); err != nil {
+	if err := auth.RequireSelfOrRole(r.Context(), id, domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -186,7 +186,7 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -200,7 +200,7 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -214,7 +214,7 @@ func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleUnlock(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}

--- a/cells/access-core/slices/identitymanage/handler.go
+++ b/cells/access-core/slices/identitymanage/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // StatusResponse is a single-field DTO for lock/unlock responses.
@@ -63,6 +64,11 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 }
 
 func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	var req struct {
 		Username string `json:"username"`
 		Email    string `json:"email"`
@@ -86,6 +92,11 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if err := auth.RequireSelfOrRole(r.Context(), id, "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	user, err := h.svc.GetByID(r.Context(), id)
 	if err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
@@ -96,6 +107,11 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if err := auth.RequireSelfOrRole(r.Context(), id, "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	var req struct {
 		Email string `json:"email"`
 	}
@@ -118,6 +134,10 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if err := auth.RequireSelfOrRole(r.Context(), id, "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
 
 	// JSON merge patch: only fields present in the JSON body are updated.
 	// Patchable fields: name, email, status. Other fields are silently ignored.
@@ -166,6 +186,11 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	id := r.PathValue("id")
 	if err := h.svc.Delete(r.Context(), id); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
@@ -175,6 +200,11 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	id := r.PathValue("id")
 	if err := h.svc.Lock(r.Context(), id); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
@@ -184,6 +214,11 @@ func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleUnlock(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	id := r.PathValue("id")
 	if err := h.svc.Unlock(r.Context(), id); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)

--- a/cells/access-core/slices/identitymanage/handler_test.go
+++ b/cells/access-core/slices/identitymanage/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
@@ -23,6 +24,13 @@ func setup() http.Handler {
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux
+}
+
+// adminCtx returns a context carrying admin credentials for test requests.
+func adminCtx() func(*http.Request) *http.Request {
+	return func(req *http.Request) *http.Request {
+		return req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
+	}
 }
 
 func TestUserResponse_ExcludesSensitiveFields(t *testing.T) {
@@ -63,6 +71,8 @@ func TestHandler(t *testing.T) {
 		method     string
 		path       string
 		body       string
+		subject    string
+		roles      []string
 		wantStatus int
 		checkBody  func(t *testing.T, body []byte)
 	}{
@@ -71,6 +81,8 @@ func TestHandler(t *testing.T) {
 			method:     http.MethodPost,
 			path:       "/",
 			body:       `{"username":"alice","email":"a@b.com","password":"secret123"}`,
+			subject:    "admin-user",
+			roles:      []string{"admin"},
 			wantStatus: http.StatusCreated,
 			checkBody: func(t *testing.T, body []byte) {
 				var resp map[string]json.RawMessage
@@ -93,12 +105,15 @@ func TestHandler(t *testing.T) {
 			method:     http.MethodPost,
 			path:       "/",
 			body:       `{bad json`,
+			subject:    "admin-user",
+			roles:      []string{"admin"},
 			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "GET /{id} nonexistent returns 404",
 			method:     http.MethodGet,
 			path:       "/no-such-id",
+			subject:    "no-such-id", // self-access
 			wantStatus: http.StatusNotFound,
 		},
 		{
@@ -106,7 +121,70 @@ func TestHandler(t *testing.T) {
 			method:     http.MethodPost,
 			path:       "/",
 			body:       `{"username":"alice","email":"a@b.com","password":"secret123","extra":"y"}`,
+			subject:    "admin-user",
+			roles:      []string{"admin"},
 			wantStatus: http.StatusBadRequest,
+		},
+		// Authorization tests (H1-2).
+		{
+			name:       "POST / no auth returns 401",
+			method:     http.MethodPost,
+			path:       "/",
+			body:       `{"username":"alice","email":"a@b.com","password":"secret123"}`,
+			subject:    "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "POST / non-admin returns 403",
+			method:     http.MethodPost,
+			path:       "/",
+			body:       `{"username":"alice","email":"a@b.com","password":"secret123"}`,
+			subject:    "user-1",
+			roles:      []string{"viewer"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "GET /{id} self-access authz passes (user not found)",
+			method:     http.MethodGet,
+			path:       "/self-access-test",
+			subject:    "self-access-test",
+			wantStatus: http.StatusNotFound, // authz passes (self), service returns 404
+		},
+		{
+			name:       "GET /{id} different user non-admin returns 403",
+			method:     http.MethodGet,
+			path:       "/user-1",
+			subject:    "user-2",
+			roles:      []string{"viewer"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "GET /{id} no auth returns 401",
+			method:     http.MethodGet,
+			path:       "/user-1",
+			subject:    "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "DELETE /{id} non-admin returns 403",
+			method:     http.MethodDelete,
+			path:       "/user-1",
+			subject:    "user-1", // even self cannot delete
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "POST /{id}/lock non-admin returns 403",
+			method:     http.MethodPost,
+			path:       "/user-1/lock",
+			subject:    "user-1",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "POST /{id}/unlock non-admin returns 403",
+			method:     http.MethodPost,
+			path:       "/user-1/unlock",
+			subject:    "user-1",
+			wantStatus: http.StatusForbidden,
 		},
 	}
 
@@ -120,6 +198,9 @@ func TestHandler(t *testing.T) {
 				req = httptest.NewRequest(tc.method, tc.path, nil)
 			}
 			req.Header.Set("Content-Type", "application/json")
+			if tc.subject != "" {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -133,10 +214,11 @@ func TestHandler(t *testing.T) {
 func TestHandler_UpdateUnknownField(t *testing.T) {
 	r := setup()
 
-	// Create a user first
+	// Create a user first (as admin).
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"bob","email":"b@c.com","password":"pass1234"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = adminCtx()(req)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
@@ -147,11 +229,12 @@ func TestHandler_UpdateUnknownField(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
 
-	// PUT with unknown field should return 400
+	// PUT with unknown field should return 400 (self-access).
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPut, "/"+created.Data.ID,
 		strings.NewReader(`{"email":"new@b.com","extra":"y"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext(created.Data.ID, nil)) // self-access
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -159,10 +242,11 @@ func TestHandler_UpdateUnknownField(t *testing.T) {
 func TestHandler_PatchAcceptsUnknownFields(t *testing.T) {
 	r := setup()
 
-	// Create a user first
+	// Create a user first (as admin).
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"eve","email":"e@f.com","password":"pass1234"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = adminCtx()(req)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
@@ -173,11 +257,12 @@ func TestHandler_PatchAcceptsUnknownFields(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
 
-	// PATCH with unknown field should succeed (merge patch accepts any key)
+	// PATCH with unknown field should succeed (merge patch accepts any key, self-access).
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPatch, "/"+created.Data.ID,
 		strings.NewReader(`{"email":"new@f.com","extra":"ignored"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext(created.Data.ID, nil)) // self-access
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code, "PATCH uses DecodeJSON (not strict); unknown fields must be accepted for merge patch semantics")
 }
@@ -185,10 +270,11 @@ func TestHandler_PatchAcceptsUnknownFields(t *testing.T) {
 func TestHandler_CreateThenGetThenDelete(t *testing.T) {
 	r := setup()
 
-	// Create
+	// Create (admin).
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"bob","email":"b@c.com","password":"pass1234"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = adminCtx()(req)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
@@ -201,24 +287,31 @@ func TestHandler_CreateThenGetThenDelete(t *testing.T) {
 	id := created.Data.ID
 	require.NotEmpty(t, id)
 
-	// Get
+	// Get (self-access).
 	w = httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/"+id, nil))
+	getReq := httptest.NewRequest(http.MethodGet, "/"+id, nil)
+	getReq = getReq.WithContext(auth.TestContext(id, nil))
+	r.ServeHTTP(w, getReq)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	// Delete
+	// Delete (admin).
 	w = httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/"+id, nil))
+	delReq := httptest.NewRequest(http.MethodDelete, "/"+id, nil)
+	delReq = adminCtx()(delReq)
+	r.ServeHTTP(w, delReq)
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
 func TestHandlePatch_TypeValidation(t *testing.T) {
 	r := setup()
 
-	// Create a user first.
+	// Create a user first (admin).
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/",
-		strings.NewReader(`{"username":"patchuser","email":"p@b.com","password":"Secret123!"}`)))
+	createReq := httptest.NewRequest(http.MethodPost, "/",
+		strings.NewReader(`{"username":"patchuser","email":"p@b.com","password":"Secret123!"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq = adminCtx()(createReq)
+	r.ServeHTTP(w, createReq)
 	require.Equal(t, http.StatusCreated, w.Code)
 	var created struct {
 		Data struct {
@@ -264,6 +357,7 @@ func TestHandlePatch_TypeValidation(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPatch, "/"+id, strings.NewReader(tc.body))
 			req.Header.Set("Content-Type", "application/json")
+			req = req.WithContext(auth.TestContext(id, nil)) // self-access
 			r.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
 			if tc.wantCode != "" {

--- a/cells/access-core/slices/identitymanage/outbox_test.go
+++ b/cells/access-core/slices/identitymanage/outbox_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,21 +42,23 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 
 // --- additional handler tests ---
 
+func withAdmin(req *http.Request) *http.Request {
+	return req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
+}
+
 func TestHandler_UpdatePUT(t *testing.T) {
 	r := setup()
-	// Create a user first.
 	w := httptest.NewRecorder()
 	body := `{"username":"upd","email":"u@b.com","password":"pass1234"}`
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
 	id := extractID(t, w.Body.Bytes())
 
-	// PUT update
 	w = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPut, "/"+id, strings.NewReader(`{"email":"new@b.com"}`))
+	req = withAdmin(httptest.NewRequest(http.MethodPut, "/"+id, strings.NewReader(`{"email":"new@b.com"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -65,7 +68,7 @@ func TestHandler_UpdatePUT(t *testing.T) {
 func TestHandler_UpdatePUT_BadJSON(t *testing.T) {
 	r := setup()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/some-id", strings.NewReader("{bad"))
+	req := withAdmin(httptest.NewRequest(http.MethodPut, "/some-id", strings.NewReader("{bad")))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -73,18 +76,16 @@ func TestHandler_UpdatePUT_BadJSON(t *testing.T) {
 
 func TestHandler_PatchUser(t *testing.T) {
 	r := setup()
-	// Create a user.
 	w := httptest.NewRecorder()
 	body := `{"username":"patch","email":"p@b.com","password":"pass1234"}`
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 	id := extractID(t, w.Body.Bytes())
 
-	// PATCH name only
 	w = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPatch, "/"+id, strings.NewReader(`{"name":"newname"}`))
+	req = withAdmin(httptest.NewRequest(http.MethodPatch, "/"+id, strings.NewReader(`{"name":"newname"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -94,7 +95,7 @@ func TestHandler_PatchUser(t *testing.T) {
 func TestHandler_PatchUser_BadJSON(t *testing.T) {
 	r := setup()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPatch, "/some-id", strings.NewReader("{bad"))
+	req := withAdmin(httptest.NewRequest(http.MethodPatch, "/some-id", strings.NewReader("{bad")))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -102,16 +103,15 @@ func TestHandler_PatchUser_BadJSON(t *testing.T) {
 
 func TestHandler_PatchUser_Status(t *testing.T) {
 	r := setup()
-	// Create + PATCH status
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"st","email":"s@b.com","password":"pass1234"}`))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"st","email":"s@b.com","password":"pass1234"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 	id := extractID(t, w.Body.Bytes())
 
 	w = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPatch, "/"+id, strings.NewReader(`{"status":"suspended"}`))
+	req = withAdmin(httptest.NewRequest(http.MethodPatch, "/"+id, strings.NewReader(`{"status":"suspended"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -119,24 +119,21 @@ func TestHandler_PatchUser_Status(t *testing.T) {
 
 func TestHandler_LockUnlock(t *testing.T) {
 	r := setup()
-	// Create
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"lock","email":"l@b.com","password":"pass1234"}`))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"lock","email":"l@b.com","password":"pass1234"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 	id := extractID(t, w.Body.Bytes())
 
-	// Lock
 	w = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/"+id+"/lock", nil)
+	req = withAdmin(httptest.NewRequest(http.MethodPost, "/"+id+"/lock", nil))
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "locked")
 
-	// Unlock
 	w = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/"+id+"/unlock", nil)
+	req = withAdmin(httptest.NewRequest(http.MethodPost, "/"+id+"/unlock", nil))
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "active")
@@ -145,7 +142,7 @@ func TestHandler_LockUnlock(t *testing.T) {
 func TestHandler_Lock_NotFound(t *testing.T) {
 	r := setup()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/no-such-id/lock", nil)
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/no-such-id/lock", nil))
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -153,7 +150,7 @@ func TestHandler_Lock_NotFound(t *testing.T) {
 func TestHandler_Unlock_NotFound(t *testing.T) {
 	r := setup()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/no-such-id/unlock", nil)
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/no-such-id/unlock", nil))
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/cells/access-core/slices/rbac-assign/slice.yaml
+++ b/cells/access-core/slices/rbac-assign/slice.yaml
@@ -1,0 +1,14 @@
+id: rbac-assign
+belongsToCell: access-core
+contractUsages:
+  - contract: http.auth.role.assign.v1
+    role: serve
+  - contract: http.auth.role.revoke.v1
+    role: serve
+verify:
+  unit:
+    - unit.rbac-assign.service
+  contract:
+    - contract.http.auth.role.assign.v1.serve
+    - contract.http.auth.role.revoke.v1.serve
+  waivers: []

--- a/cells/access-core/slices/rbac-assign/slice.yaml
+++ b/cells/access-core/slices/rbac-assign/slice.yaml
@@ -12,3 +12,7 @@ verify:
     - contract.http.auth.role.assign.v1.serve
     - contract.http.auth.role.revoke.v1.serve
   waivers: []
+
+allowedFiles:
+  - cells/access-core/slices/rbac-assign/**
+  - cells/access-core/slices/rbacassign/**

--- a/cells/access-core/slices/rbacassign/contract_test.go
+++ b/cells/access-core/slices/rbacassign/contract_test.go
@@ -25,7 +25,7 @@ func newContractHandler() http.Handler {
 	})
 	_ = roleRepo.AssignToUser(context.Background(), "usr-seed", "admin")
 
-	svc := NewService(roleRepo, slog.Default())
+	svc := NewService(roleRepo, mem.NewSessionRepository(), slog.Default())
 	inner := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(inner)
 

--- a/cells/access-core/slices/rbacassign/contract_test.go
+++ b/cells/access-core/slices/rbacassign/contract_test.go
@@ -1,0 +1,81 @@
+package rbacassign
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+func newContractHandler() http.Handler {
+	roleRepo := mem.NewRoleRepository()
+	roleRepo.SeedRole(&domain.Role{
+		ID: "admin", Name: "admin",
+		Permissions: []domain.Permission{{Resource: "*", Action: "*"}},
+	})
+	_ = roleRepo.AssignToUser(context.Background(), "usr-seed", "admin")
+
+	svc := NewService(roleRepo, slog.Default())
+	inner := celltest.NewTestMux()
+	NewHandler(svc).RegisterRoutes(inner)
+
+	outer := http.NewServeMux()
+	outer.Handle("/internal/v1/access/roles/", http.StripPrefix("/internal/v1/access/roles", inner))
+	return outer
+}
+
+func TestHttpAuthRoleAssignV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.auth.role.assign.v1")
+	handler := newContractHandler()
+
+	// Validate request schema.
+	c.ValidateRequest(t, []byte(`{"userId":"usr-2","roleId":"admin"}`))
+	c.MustRejectRequest(t, []byte(`{"userId":"usr-2"}`))
+	c.MustRejectRequest(t, []byte(`{"userId":"usr-2","roleId":"admin","extra":"bad"}`))
+
+	// Execute real handler.
+	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(`{"userId":"usr-2","roleId":"admin"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("usr-seed", []string{"admin"}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	c.ValidateHTTPResponseRecorder(t, rec)
+	require.Equal(t, 200, rec.Code)
+
+	// Reject invalid response shape.
+	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
+}
+
+func TestHttpAuthRoleRevokeV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.auth.role.revoke.v1")
+	handler := newContractHandler()
+
+	// Validate request schema.
+	c.ValidateRequest(t, []byte(`{"userId":"usr-seed","roleId":"admin"}`))
+	c.MustRejectRequest(t, []byte(`{"userId":"usr-seed"}`))
+
+	// Execute real handler.
+	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(`{"userId":"usr-seed","roleId":"admin"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("usr-seed", []string{"admin"}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	c.ValidateHTTPResponseRecorder(t, rec)
+	require.Equal(t, 200, rec.Code)
+
+	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
+}

--- a/cells/access-core/slices/rbacassign/handler.go
+++ b/cells/access-core/slices/rbacassign/handler.go
@@ -1,0 +1,97 @@
+package rbacassign
+
+import (
+	"net/http"
+
+	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// AssignRequest is the request DTO for role assignment.
+type AssignRequest struct {
+	UserID string `json:"userId"`
+	RoleID string `json:"roleId"`
+}
+
+// AssignResponse is the response DTO for role assignment.
+type AssignResponse struct {
+	UserID   string `json:"userId"`
+	RoleID   string `json:"roleId"`
+	Assigned bool   `json:"assigned"`
+}
+
+// RevokeResponse is the response DTO for role revocation.
+type RevokeResponse struct {
+	UserID  string `json:"userId"`
+	RoleID  string `json:"roleId"`
+	Revoked bool   `json:"revoked"`
+}
+
+// Handler provides HTTP endpoints for RBAC role assignment/revocation.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates an rbac-assign Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterRoutes registers rbac-assign routes on the given mux.
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
+	mux.Handle("POST /assign", http.HandlerFunc(h.handleAssign))
+	mux.Handle("DELETE /revoke", http.HandlerFunc(h.handleRevoke))
+}
+
+func (h *Handler) handleAssign(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
+	var req AssignRequest
+	if err := httputil.DecodeJSONStrict(r, &req); err != nil {
+		httputil.WriteDecodeError(r.Context(), w, err)
+		return
+	}
+
+	if err := h.svc.Assign(r.Context(), req.UserID, req.RoleID); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{
+		"data": AssignResponse{
+			UserID:   req.UserID,
+			RoleID:   req.RoleID,
+			Assigned: true,
+		},
+	})
+}
+
+func (h *Handler) handleRevoke(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
+	var req AssignRequest
+	if err := httputil.DecodeJSONStrict(r, &req); err != nil {
+		httputil.WriteDecodeError(r.Context(), w, err)
+		return
+	}
+
+	if err := h.svc.Revoke(r.Context(), req.UserID, req.RoleID); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{
+		"data": RevokeResponse{
+			UserID:  req.UserID,
+			RoleID:  req.RoleID,
+			Revoked: true,
+		},
+	})
+}

--- a/cells/access-core/slices/rbacassign/handler.go
+++ b/cells/access-core/slices/rbacassign/handler.go
@@ -3,6 +3,7 @@ package rbacassign
 import (
 	"net/http"
 
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -45,7 +46,7 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 }
 
 func (h *Handler) handleAssign(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -71,7 +72,7 @@ func (h *Handler) handleAssign(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleRevoke(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), "admin"); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), domain.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}

--- a/cells/access-core/slices/rbacassign/handler_test.go
+++ b/cells/access-core/slices/rbacassign/handler_test.go
@@ -1,0 +1,178 @@
+package rbacassign
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+func setupHandler() (http.Handler, *mem.RoleRepository) {
+	roleRepo := mem.NewRoleRepository()
+	roleRepo.SeedRole(&domain.Role{
+		ID: "admin", Name: "admin",
+		Permissions: []domain.Permission{{Resource: "*", Action: "*"}},
+	})
+	_ = roleRepo.AssignToUser(context.Background(), "usr-1", "admin")
+
+	svc := NewService(roleRepo, slog.Default())
+	mux := celltest.NewTestMux()
+	NewHandler(svc).RegisterRoutes(mux)
+	return mux, roleRepo
+}
+
+func TestHandler_Assign(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		subject    string
+		roles      []string
+		wantStatus int
+		checkBody  func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "admin assigns role returns 200",
+			body:       `{"userId":"usr-2","roleId":"admin"}`,
+			subject:    "usr-1",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Data struct {
+						UserID   string `json:"userId"`
+						RoleID   string `json:"roleId"`
+						Assigned bool   `json:"assigned"`
+					} `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, "usr-2", resp.Data.UserID)
+				assert.Equal(t, "admin", resp.Data.RoleID)
+				assert.True(t, resp.Data.Assigned)
+			},
+		},
+		{
+			name:       "non-admin returns 403",
+			body:       `{"userId":"usr-2","roleId":"admin"}`,
+			subject:    "usr-2",
+			roles:      []string{"viewer"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no auth returns 401",
+			body:       `{"userId":"usr-2","roleId":"admin"}`,
+			subject:    "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "invalid body returns 400",
+			body:       `{bad json`,
+			subject:    "usr-1",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty userId returns 400",
+			body:       `{"userId":"","roleId":"admin"}`,
+			subject:    "usr-1",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "role not found returns 404",
+			body:       `{"userId":"usr-2","roleId":"nonexistent"}`,
+			subject:    "usr-1",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := setupHandler()
+			req := httptest.NewRequest(http.MethodPost, "/assign", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.subject != "" {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.checkBody != nil {
+				tc.checkBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestHandler_Revoke(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		subject    string
+		roles      []string
+		wantStatus int
+		checkBody  func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "admin revokes role returns 200",
+			body:       `{"userId":"usr-1","roleId":"admin"}`,
+			subject:    "usr-1",
+			roles:      []string{"admin"},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Data struct {
+						UserID  string `json:"userId"`
+						RoleID  string `json:"roleId"`
+						Revoked bool   `json:"revoked"`
+					} `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, "usr-1", resp.Data.UserID)
+				assert.Equal(t, "admin", resp.Data.RoleID)
+				assert.True(t, resp.Data.Revoked)
+			},
+		},
+		{
+			name:       "non-admin returns 403",
+			body:       `{"userId":"usr-1","roleId":"admin"}`,
+			subject:    "usr-2",
+			roles:      []string{"viewer"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no auth returns 401",
+			body:       `{"userId":"usr-1","roleId":"admin"}`,
+			subject:    "",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := setupHandler()
+			req := httptest.NewRequest(http.MethodDelete, "/revoke", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.subject != "" {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.checkBody != nil {
+				tc.checkBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}

--- a/cells/access-core/slices/rbacassign/handler_test.go
+++ b/cells/access-core/slices/rbacassign/handler_test.go
@@ -26,7 +26,7 @@ func setupHandler() (http.Handler, *mem.RoleRepository) {
 	})
 	_ = roleRepo.AssignToUser(context.Background(), "usr-1", "admin")
 
-	svc := NewService(roleRepo, slog.Default())
+	svc := NewService(roleRepo, mem.NewSessionRepository(), slog.Default())
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux, roleRepo

--- a/cells/access-core/slices/rbacassign/service.go
+++ b/cells/access-core/slices/rbacassign/service.go
@@ -1,0 +1,53 @@
+package rbacassign
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// Service handles RBAC role assignment and revocation (L0 — pure repo operations).
+type Service struct {
+	roleRepo ports.RoleRepository
+	logger   *slog.Logger
+}
+
+// NewService creates a new rbac-assign service.
+func NewService(roleRepo ports.RoleRepository, logger *slog.Logger) *Service {
+	return &Service{roleRepo: roleRepo, logger: logger}
+}
+
+// Assign assigns a role to a user. Idempotent: re-assignment is a no-op.
+func (s *Service) Assign(ctx context.Context, userID, roleID string) error {
+	if userID == "" || roleID == "" {
+		return errcode.New(errcode.ErrAuthRBACInvalidInput, "userId and roleId are required")
+	}
+
+	if err := s.roleRepo.AssignToUser(ctx, userID, roleID); err != nil {
+		return fmt.Errorf("rbac-assign: assign: %w", err)
+	}
+
+	s.logger.Info("role assigned",
+		slog.String("user_id", userID),
+		slog.String("role_id", roleID))
+	return nil
+}
+
+// Revoke removes a role from a user. Idempotent: revoking a non-assigned role is a no-op.
+func (s *Service) Revoke(ctx context.Context, userID, roleID string) error {
+	if userID == "" || roleID == "" {
+		return errcode.New(errcode.ErrAuthRBACInvalidInput, "userId and roleId are required")
+	}
+
+	if err := s.roleRepo.RemoveFromUser(ctx, userID, roleID); err != nil {
+		return fmt.Errorf("rbac-assign: revoke: %w", err)
+	}
+
+	s.logger.Info("role revoked",
+		slog.String("user_id", userID),
+		slog.String("role_id", roleID))
+	return nil
+}

--- a/cells/access-core/slices/rbacassign/service.go
+++ b/cells/access-core/slices/rbacassign/service.go
@@ -34,9 +34,10 @@ func (s *Service) Assign(ctx context.Context, userID, roleID string) error {
 	}
 
 	// Revoke active sessions so user must re-login to get updated JWT roles.
+	// Fail-closed: if session revocation fails, the role change is not reported
+	// as successful to prevent stale-role window.
 	if err := s.sessionRepo.RevokeByUserID(ctx, userID); err != nil {
-		s.logger.Error("rbac-assign: failed to revoke sessions after role assign",
-			slog.Any("error", err), slog.String("user_id", userID))
+		return fmt.Errorf("rbac-assign: assign succeeded but session revoke failed: %w", err)
 	}
 
 	s.logger.Info("role assigned",
@@ -57,9 +58,10 @@ func (s *Service) Revoke(ctx context.Context, userID, roleID string) error {
 	}
 
 	// Revoke active sessions so user must re-login to get updated JWT roles.
+	// Fail-closed: if session revocation fails, the role change is not reported
+	// as successful to prevent stale-role window.
 	if err := s.sessionRepo.RevokeByUserID(ctx, userID); err != nil {
-		s.logger.Error("rbac-assign: failed to revoke sessions after role revoke",
-			slog.Any("error", err), slog.String("user_id", userID))
+		return fmt.Errorf("rbac-assign: revoke succeeded but session revoke failed: %w", err)
 	}
 
 	s.logger.Info("role revoked",

--- a/cells/access-core/slices/rbacassign/service.go
+++ b/cells/access-core/slices/rbacassign/service.go
@@ -11,13 +11,16 @@ import (
 
 // Service handles RBAC role assignment and revocation (L0 — pure repo operations).
 type Service struct {
-	roleRepo ports.RoleRepository
-	logger   *slog.Logger
+	roleRepo    ports.RoleRepository
+	sessionRepo ports.SessionRepository
+	logger      *slog.Logger
 }
 
 // NewService creates a new rbac-assign service.
-func NewService(roleRepo ports.RoleRepository, logger *slog.Logger) *Service {
-	return &Service{roleRepo: roleRepo, logger: logger}
+// sessionRepo is used to revoke active sessions on role change so that
+// the JWT (which embeds roles) is forced to refresh.
+func NewService(roleRepo ports.RoleRepository, sessionRepo ports.SessionRepository, logger *slog.Logger) *Service {
+	return &Service{roleRepo: roleRepo, sessionRepo: sessionRepo, logger: logger}
 }
 
 // Assign assigns a role to a user. Idempotent: re-assignment is a no-op.
@@ -30,6 +33,12 @@ func (s *Service) Assign(ctx context.Context, userID, roleID string) error {
 		return fmt.Errorf("rbac-assign: assign: %w", err)
 	}
 
+	// Revoke active sessions so user must re-login to get updated JWT roles.
+	if err := s.sessionRepo.RevokeByUserID(ctx, userID); err != nil {
+		s.logger.Error("rbac-assign: failed to revoke sessions after role assign",
+			slog.Any("error", err), slog.String("user_id", userID))
+	}
+
 	s.logger.Info("role assigned",
 		slog.String("user_id", userID),
 		slog.String("role_id", roleID))
@@ -37,6 +46,7 @@ func (s *Service) Assign(ctx context.Context, userID, roleID string) error {
 }
 
 // Revoke removes a role from a user. Idempotent: revoking a non-assigned role is a no-op.
+// Active sessions are revoked to force re-login with updated JWT roles.
 func (s *Service) Revoke(ctx context.Context, userID, roleID string) error {
 	if userID == "" || roleID == "" {
 		return errcode.New(errcode.ErrAuthRBACInvalidInput, "userId and roleId are required")
@@ -44,6 +54,12 @@ func (s *Service) Revoke(ctx context.Context, userID, roleID string) error {
 
 	if err := s.roleRepo.RemoveFromUser(ctx, userID, roleID); err != nil {
 		return fmt.Errorf("rbac-assign: revoke: %w", err)
+	}
+
+	// Revoke active sessions so user must re-login to get updated JWT roles.
+	if err := s.sessionRepo.RevokeByUserID(ctx, userID); err != nil {
+		s.logger.Error("rbac-assign: failed to revoke sessions after role revoke",
+			slog.Any("error", err), slog.String("user_id", userID))
 	}
 
 	s.logger.Info("role revoked",

--- a/cells/access-core/slices/rbacassign/service_test.go
+++ b/cells/access-core/slices/rbacassign/service_test.go
@@ -1,0 +1,168 @@
+package rbacassign
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+func newTestService() (*Service, *mem.RoleRepository) {
+	repo := mem.NewRoleRepository()
+	repo.SeedRole(&domain.Role{
+		ID:   "admin",
+		Name: "admin",
+		Permissions: []domain.Permission{
+			{Resource: "*", Action: "*"},
+		},
+	})
+	return NewService(repo, slog.Default()), repo
+}
+
+func TestService_Assign(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*mem.RoleRepository)
+		userID   string
+		roleID   string
+		wantErr  bool
+		wantCode errcode.Code
+	}{
+		{
+			name:    "assign role to user",
+			userID:  "usr-1",
+			roleID:  "admin",
+			wantErr: false,
+		},
+		{
+			name:   "assign same role twice is idempotent",
+			userID: "usr-1",
+			roleID: "admin",
+			setup: func(r *mem.RoleRepository) {
+				_ = r.AssignToUser(context.Background(), "usr-1", "admin")
+			},
+			wantErr: false,
+		},
+		{
+			name:     "empty userId returns error",
+			userID:   "",
+			roleID:   "admin",
+			wantErr:  true,
+			wantCode: errcode.ErrAuthRBACInvalidInput,
+		},
+		{
+			name:     "empty roleId returns error",
+			userID:   "usr-1",
+			roleID:   "",
+			wantErr:  true,
+			wantCode: errcode.ErrAuthRBACInvalidInput,
+		},
+		{
+			name:     "role not found returns error",
+			userID:   "usr-1",
+			roleID:   "nonexistent",
+			wantErr:  true,
+			wantCode: errcode.ErrAuthRoleNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, repo := newTestService()
+			if tc.setup != nil {
+				tc.setup(repo)
+			}
+
+			err := svc.Assign(context.Background(), tc.userID, tc.roleID)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				// Verify assignment persisted.
+				roles, _ := repo.GetByUserID(context.Background(), tc.userID)
+				var found bool
+				for _, r := range roles {
+					if r.ID == tc.roleID {
+						found = true
+					}
+				}
+				assert.True(t, found, "role %s should be assigned to user %s", tc.roleID, tc.userID)
+				return
+			}
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr))
+			assert.Equal(t, tc.wantCode, ecErr.Code)
+		})
+	}
+}
+
+func TestService_Revoke(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*mem.RoleRepository)
+		userID   string
+		roleID   string
+		wantErr  bool
+		wantCode errcode.Code
+	}{
+		{
+			name:   "revoke assigned role",
+			userID: "usr-1",
+			roleID: "admin",
+			setup: func(r *mem.RoleRepository) {
+				_ = r.AssignToUser(context.Background(), "usr-1", "admin")
+			},
+			wantErr: false,
+		},
+		{
+			name:    "revoke unassigned role is idempotent",
+			userID:  "usr-1",
+			roleID:  "admin",
+			wantErr: false,
+		},
+		{
+			name:     "empty userId returns error",
+			userID:   "",
+			roleID:   "admin",
+			wantErr:  true,
+			wantCode: errcode.ErrAuthRBACInvalidInput,
+		},
+		{
+			name:     "empty roleId returns error",
+			userID:   "usr-1",
+			roleID:   "",
+			wantErr:  true,
+			wantCode: errcode.ErrAuthRBACInvalidInput,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, repo := newTestService()
+			if tc.setup != nil {
+				tc.setup(repo)
+			}
+
+			err := svc.Revoke(context.Background(), tc.userID, tc.roleID)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				// Verify removal persisted.
+				roles, _ := repo.GetByUserID(context.Background(), tc.userID)
+				for _, r := range roles {
+					assert.NotEqual(t, tc.roleID, r.ID, "role %s should not be assigned to user %s after revoke", tc.roleID, tc.userID)
+				}
+				return
+			}
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr))
+			assert.Equal(t, tc.wantCode, ecErr.Code)
+		})
+	}
+}

--- a/cells/access-core/slices/rbacassign/service_test.go
+++ b/cells/access-core/slices/rbacassign/service_test.go
@@ -14,16 +14,17 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-func newTestService() (*Service, *mem.RoleRepository) {
-	repo := mem.NewRoleRepository()
-	repo.SeedRole(&domain.Role{
+func newTestService() (*Service, *mem.RoleRepository, *mem.SessionRepository) {
+	roleRepo := mem.NewRoleRepository()
+	roleRepo.SeedRole(&domain.Role{
 		ID:   "admin",
 		Name: "admin",
 		Permissions: []domain.Permission{
 			{Resource: "*", Action: "*"},
 		},
 	})
-	return NewService(repo, slog.Default()), repo
+	sessionRepo := mem.NewSessionRepository()
+	return NewService(roleRepo, sessionRepo, slog.Default()), roleRepo, sessionRepo
 }
 
 func TestService_Assign(t *testing.T) {
@@ -75,7 +76,7 @@ func TestService_Assign(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			svc, repo := newTestService()
+			svc, repo, _ := newTestService()
 			if tc.setup != nil {
 				tc.setup(repo)
 			}
@@ -144,7 +145,7 @@ func TestService_Revoke(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			svc, repo := newTestService()
+			svc, repo, _ := newTestService()
 			if tc.setup != nil {
 				tc.setup(repo)
 			}
@@ -165,4 +166,33 @@ func TestService_Revoke(t *testing.T) {
 			assert.Equal(t, tc.wantCode, ecErr.Code)
 		})
 	}
+}
+
+func TestService_Revoke_InvalidatesSessions(t *testing.T) {
+	svc, roleRepo, sessionRepo := newTestService()
+	ctx := context.Background()
+
+	_ = roleRepo.AssignToUser(ctx, "usr-1", "admin")
+	sess := &domain.Session{ID: "sess-1", UserID: "usr-1"}
+	require.NoError(t, sessionRepo.Create(ctx, sess))
+
+	require.NoError(t, svc.Revoke(ctx, "usr-1", "admin"))
+
+	s, err := sessionRepo.GetByID(ctx, "sess-1")
+	require.NoError(t, err)
+	assert.True(t, s.IsRevoked(), "session must be revoked after role change")
+}
+
+func TestService_Assign_InvalidatesSessions(t *testing.T) {
+	svc, _, sessionRepo := newTestService()
+	ctx := context.Background()
+
+	sess := &domain.Session{ID: "sess-2", UserID: "usr-2"}
+	require.NoError(t, sessionRepo.Create(ctx, sess))
+
+	require.NoError(t, svc.Assign(ctx, "usr-2", "admin"))
+
+	s, err := sessionRepo.GetByID(ctx, "sess-2")
+	require.NoError(t, err)
+	assert.True(t, s.IsRevoked(), "session must be revoked after role assignment")
 }

--- a/cells/access-core/slices/rbacassign/service_test.go
+++ b/cells/access-core/slices/rbacassign/service_test.go
@@ -3,6 +3,7 @@ package rbacassign
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
@@ -195,4 +197,32 @@ func TestService_Assign_InvalidatesSessions(t *testing.T) {
 	s, err := sessionRepo.GetByID(ctx, "sess-2")
 	require.NoError(t, err)
 	assert.True(t, s.IsRevoked(), "session must be revoked after role assignment")
+}
+
+// failingSessionRepo returns an error on RevokeByUserID to test fail-closed behavior.
+type failingSessionRepo struct{ ports.SessionRepository }
+
+func (failingSessionRepo) RevokeByUserID(_ context.Context, _ string) error {
+	return fmt.Errorf("session store unavailable")
+}
+
+func TestService_Revoke_SessionRevokeFail_ReturnsError(t *testing.T) {
+	roleRepo := mem.NewRoleRepository()
+	roleRepo.SeedRole(&domain.Role{ID: "admin", Name: "admin"})
+	_ = roleRepo.AssignToUser(context.Background(), "usr-1", "admin")
+
+	svc := NewService(roleRepo, failingSessionRepo{}, slog.Default())
+	err := svc.Revoke(context.Background(), "usr-1", "admin")
+	require.Error(t, err, "revoke must fail-closed when session revocation fails")
+	assert.Contains(t, err.Error(), "session revoke failed")
+}
+
+func TestService_Assign_SessionRevokeFail_ReturnsError(t *testing.T) {
+	roleRepo := mem.NewRoleRepository()
+	roleRepo.SeedRole(&domain.Role{ID: "admin", Name: "admin"})
+
+	svc := NewService(roleRepo, failingSessionRepo{}, slog.Default())
+	err := svc.Assign(context.Background(), "usr-1", "admin")
+	require.Error(t, err, "assign must fail-closed when session revocation fails")
+	assert.Contains(t, err.Error(), "session revoke failed")
 }

--- a/cmd/core-bundle/auth_integration_test.go
+++ b/cmd/core-bundle/auth_integration_test.go
@@ -137,6 +137,9 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 		{http.MethodPost, "/api/v1/config/some-key/rollback"},
 		{http.MethodGet, "/api/v1/audit/entries"},
 		{http.MethodGet, "/api/v1/flags/"},
+		// Internal admin endpoints (PR-A RBAC closure).
+		{http.MethodPost, "/internal/v1/access/roles/assign"},
+		{http.MethodDelete, "/internal/v1/access/roles/revoke"},
 	}
 
 	for _, tc := range protectedRoutes {

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -120,12 +120,24 @@ func run(ctx context.Context) error {
 		configcore.WithPublisher(eb),
 		configcore.WithCursorCodec(configCursorCodec),
 	)
-	accessCell := accesscore.NewAccessCore(
+
+	accessOpts := []accesscore.Option{
 		accesscore.WithInMemoryDefaults(),
 		accesscore.WithPublisher(eb),
 		accesscore.WithJWTIssuer(jwtIssuer),
 		accesscore.WithJWTVerifier(jwtVerifier),
-	)
+	}
+
+	// Seed admin role + optional admin user from env vars.
+	adminUser := os.Getenv("GOCELL_ADMIN_USER")
+	adminPass := os.Getenv("GOCELL_ADMIN_PASS")
+	if adminUser != "" && adminPass != "" {
+		accessOpts = append(accessOpts, accesscore.WithSeedAdmin(adminUser, adminPass))
+	} else {
+		accessOpts = append(accessOpts, accesscore.WithSeedAdminRole())
+	}
+
+	accessCell := accesscore.NewAccessCore(accessOpts...)
 	auditCell := auditcore.NewAuditCore(
 		auditcore.WithInMemoryDefaults(),
 		auditcore.WithPublisher(eb),

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -131,9 +131,13 @@ func run(ctx context.Context) error {
 	// Seed admin role + optional admin user from env vars.
 	adminUser := os.Getenv("GOCELL_ADMIN_USER")
 	adminPass := os.Getenv("GOCELL_ADMIN_PASS")
-	if adminUser != "" && adminPass != "" {
+	switch {
+	case adminUser != "" && adminPass != "":
 		accessOpts = append(accessOpts, accesscore.WithSeedAdmin(adminUser, adminPass))
-	} else {
+	case adminUser != "" || adminPass != "":
+		slog.Error("seed admin: both GOCELL_ADMIN_USER and GOCELL_ADMIN_PASS must be set; got only one, skipping admin user creation")
+		accessOpts = append(accessOpts, accesscore.WithSeedAdminRole())
+	default:
 		accessOpts = append(accessOpts, accesscore.WithSeedAdminRole())
 	}
 

--- a/contracts/http/auth/role/assign/v1/contract.yaml
+++ b/contracts/http/auth/role/assign/v1/contract.yaml
@@ -1,0 +1,16 @@
+id: http.auth.role.assign.v1
+kind: http
+ownerCell: access-core
+consistencyLevel: L0
+lifecycle: active
+endpoints:
+  server: access-core
+  clients:
+    - edge-bff
+  http:
+    method: POST
+    path: /internal/v1/access/roles/assign
+    successStatus: 200
+schemaRefs:
+  request: request.schema.json
+  response: response.schema.json

--- a/contracts/http/auth/role/assign/v1/request.schema.json
+++ b/contracts/http/auth/role/assign/v1/request.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.role.assign.v1.request",
+  "type": "object",
+  "properties": {
+    "userId": { "type": "string", "minLength": 1 },
+    "roleId": { "type": "string", "minLength": 1 }
+  },
+  "required": ["userId", "roleId"],
+  "additionalProperties": false
+}

--- a/contracts/http/auth/role/assign/v1/response.schema.json
+++ b/contracts/http/auth/role/assign/v1/response.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.role.assign.v1.response",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "userId": { "type": "string" },
+        "roleId": { "type": "string" },
+        "assigned": { "type": "boolean" }
+      },
+      "required": ["userId", "roleId", "assigned"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["data"],
+  "additionalProperties": false
+}

--- a/contracts/http/auth/role/revoke/v1/contract.yaml
+++ b/contracts/http/auth/role/revoke/v1/contract.yaml
@@ -1,0 +1,16 @@
+id: http.auth.role.revoke.v1
+kind: http
+ownerCell: access-core
+consistencyLevel: L0
+lifecycle: active
+endpoints:
+  server: access-core
+  clients:
+    - edge-bff
+  http:
+    method: DELETE
+    path: /internal/v1/access/roles/revoke
+    successStatus: 200
+schemaRefs:
+  request: request.schema.json
+  response: response.schema.json

--- a/contracts/http/auth/role/revoke/v1/request.schema.json
+++ b/contracts/http/auth/role/revoke/v1/request.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.role.revoke.v1.request",
+  "type": "object",
+  "properties": {
+    "userId": { "type": "string", "minLength": 1 },
+    "roleId": { "type": "string", "minLength": 1 }
+  },
+  "required": ["userId", "roleId"],
+  "additionalProperties": false
+}

--- a/contracts/http/auth/role/revoke/v1/response.schema.json
+++ b/contracts/http/auth/role/revoke/v1/response.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.role.revoke.v1.response",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "userId": { "type": "string" },
+        "roleId": { "type": "string" },
+        "revoked": { "type": "boolean" }
+      },
+      "required": ["userId", "roleId", "revoked"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["data"],
+  "additionalProperties": false
+}

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -68,6 +68,8 @@ func hasAnyRole(ctx context.Context, roles []string) bool {
 // Use this instead of RequireSelfOrRole for admin-only endpoints where there
 // is no target resource owner to compare against.
 //
+// Calling with zero roles always returns ErrAuthForbidden (no role can match).
+//
 // Errors:
 //   - ErrAuthUnauthorized: no subject in context (auth middleware did not run)
 //   - ErrAuthForbidden: subject does not hold any of the required roles

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -62,6 +62,28 @@ func hasAnyRole(ctx context.Context, roles []string) bool {
 	return false
 }
 
+// RequireAnyRole checks that the authenticated subject holds at least one of
+// the specified roles. Returns nil on success.
+//
+// Use this instead of RequireSelfOrRole for admin-only endpoints where there
+// is no target resource owner to compare against.
+//
+// Errors:
+//   - ErrAuthUnauthorized: no subject in context (auth middleware did not run)
+//   - ErrAuthForbidden: subject does not hold any of the required roles
+func RequireAnyRole(ctx context.Context, roles ...string) error {
+	subject, ok := ctxkeys.SubjectFrom(ctx)
+	if !ok || subject == "" {
+		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
+	}
+
+	if hasAnyRole(ctx, roles) {
+		return nil
+	}
+
+	return errcode.New(errcode.ErrAuthForbidden, "access denied")
+}
+
 // TestContext creates a context carrying the given subject and roles for use
 // in handler tests across cells/. Follows the net/http/httptest naming pattern.
 func TestContext(subject string, roles []string) context.Context {

--- a/runtime/auth/authz_test.go
+++ b/runtime/auth/authz_test.go
@@ -90,6 +90,71 @@ func TestRequireSelfOrRole(t *testing.T) {
 	}
 }
 
+func TestRequireAnyRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		roles    []string
+		wantErr  bool
+		wantCode errcode.Code
+	}{
+		{
+			name:    "admin role allowed",
+			ctx:     withSubjectAndClaims("user-1", []string{"admin"}),
+			roles:   []string{"admin"},
+			wantErr: false,
+		},
+		{
+			name:    "second role matches",
+			ctx:     withSubjectAndClaims("user-1", []string{"operator"}),
+			roles:   []string{"admin", "operator"},
+			wantErr: false,
+		},
+		{
+			name:     "no matching role denied",
+			ctx:      withSubjectAndClaims("user-1", []string{"viewer"}),
+			roles:    []string{"admin"},
+			wantErr:  true,
+			wantCode: errcode.ErrAuthForbidden,
+		},
+		{
+			name:     "no roles in claims denied",
+			ctx:      withSubjectAndClaims("user-1", nil),
+			roles:    []string{"admin"},
+			wantErr:  true,
+			wantCode: errcode.ErrAuthForbidden,
+		},
+		{
+			name:     "missing subject denied",
+			ctx:      context.Background(),
+			roles:    []string{"admin"},
+			wantErr:  true,
+			wantCode: errcode.ErrAuthUnauthorized,
+		},
+		{
+			name:     "empty required roles denied",
+			ctx:      withSubjectAndClaims("user-1", []string{"admin"}),
+			roles:    nil,
+			wantErr:  true,
+			wantCode: errcode.ErrAuthForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireAnyRole(tc.ctx, tc.roles...)
+			if !tc.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr))
+			assert.Equal(t, tc.wantCode, ecErr.Code)
+		})
+	}
+}
+
 func withSubjectAndClaims(subject string, roles []string) context.Context {
 	ctx := ctxkeys.WithSubject(context.Background(), subject)
 	ctx = WithClaims(ctx, Claims{Subject: subject, Roles: roles})

--- a/runtime/auth/authz_test.go
+++ b/runtime/auth/authz_test.go
@@ -132,6 +132,13 @@ func TestRequireAnyRole(t *testing.T) {
 			wantCode: errcode.ErrAuthUnauthorized,
 		},
 		{
+			name:     "empty string subject denied",
+			ctx:      withSubjectAndClaims("", nil),
+			roles:    []string{"admin"},
+			wantErr:  true,
+			wantCode: errcode.ErrAuthUnauthorized,
+		},
+		{
 			name:     "empty required roles denied",
 			ctx:      withSubjectAndClaims("user-1", []string{"admin"}),
 			roles:    nil,


### PR DESCRIPTION
## Summary

- **H1-4 ROLE-ASSIGN-API**: New `rbacassign` slice with `POST /internal/v1/access/roles/assign` + `DELETE /internal/v1/access/roles/revoke` (admin-only, L0, idempotent)
- **H1-2 IDENTITY-AUTHZ-01**: Authorization guards on all 7 identitymanage handlers (create/delete/lock/unlock → admin-only; get/update/patch → self-or-admin)
- **H1-5 SEED-ADMIN**: `WithSeedAdmin(user, pass)` / `WithSeedAdminRole()` options bootstrap admin role + optional user during Init(); wired from `GOCELL_ADMIN_USER`/`GOCELL_ADMIN_PASS` env vars
- **H2-3 IDENTITY-PATCH-CONTRACT**: Added request schema validation for PATCH endpoint contract test
- New `RequireAnyRole(ctx, roles...)` auth helper for admin-only endpoints
- New contracts: `http.auth.role.assign.v1`, `http.auth.role.revoke.v1`

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` all green (0 failures)
- [x] `gocell validate` — 0 errors, 2 pre-existing warnings
- [x] RequireAnyRole: 6 table-driven test cases (admin/non-admin/no-auth/empty roles)
- [x] rbacassign service: assign/revoke + idempotent + validation + role-not-found
- [x] rbacassign handler: admin 200, non-admin 403, no-auth 401, invalid body 400
- [x] rbacassign contract: schema validation for both assign and revoke
- [x] identitymanage authz: 401/403 for all admin-only + self-or-admin endpoints
- [x] seedAdmin: role always seeded + user creation + idempotent re-init
- [x] All existing tests updated with auth context (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)