### PR TITLE
fix(outbox): SubscriberWithMiddleware ready-signal + Publisher channel pool deadlock

### DIFF
--- a/adapters/rabbitmq/publisher.go
+++ b/adapters/rabbitmq/publisher.go
@@ -38,7 +38,19 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 		}
 		return errcode.Wrap(ErrAdapterAMQPPublish, "rabbitmq: acquire channel for publish", err)
 	}
-	defer p.conn.ReleaseChannel(ch)
+	// Close the channel after use instead of returning it to the shared pool.
+	// Confirm-mode channels pollute the pool: amqp091-go's connection reader
+	// blocks on confirms.One() if the registered NotifyPublish listener is
+	// full, deadlocking ALL channels on the connection. Watermill uses the
+	// same strategy (ephemeral channel per publish) as the default.
+	//
+	// ref: Watermill defaultChannelProvider — open, use, close per publish.
+	defer func() {
+		if closeErr := ch.Close(); closeErr != nil {
+			slog.Debug("rabbitmq: error closing publish channel",
+				slog.String("error", closeErr.Error()))
+		}
+	}()
 
 	// Declare exchange idempotently.
 	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -4394,3 +4394,65 @@ func TestConsumerBase_RetryExhaustion(t *testing.T) {
 	assert.Equal(t, 2, callCount,
 		"handler should be called exactly RetryCount times")
 }
+
+// TestPublisher_Publish_ClosesChannel verifies that Publisher.Publish closes
+// the channel after use instead of returning it to the shared pool.
+// Confirm-mode channels returned to the pool can deadlock the connection
+// reader when reused by subscribers (see PR#141 CI failure analysis).
+//
+// ref: Watermill — publisher and subscriber use completely separate channels,
+// never sharing a pool. Default publisher strategy: open, use, close per publish.
+func TestPublisher_Publish_ClosesChannel(t *testing.T) {
+	ch := newMockChannel()
+
+	// Send confirmation asynchronously after NotifyPublish replaces the channel.
+	origNotify := ch.NotifyPublish
+	_ = origNotify
+	go func() {
+		// Wait until confirmCalled is set (Confirm was called), then the
+		// next NotifyPublish will install a new channel. Poll briefly.
+		for {
+			ch.mu.Lock()
+			npc := ch.notifyPublishCh
+			confirmed := ch.confirmCalled
+			ch.mu.Unlock()
+			if confirmed && npc != nil {
+				select {
+				case npc <- amqp.Confirmation{Ack: true}:
+					return
+				default:
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	mc := &mockConnection{nextCh: ch}
+	conn := &Connection{
+		config:      Config{URL: "amqp://test@localhost/", ConfirmTimeout: 5 * time.Second},
+		channelPool: make(chan AMQPChannel, 5),
+		closeCh:     make(chan struct{}),
+		connected:   make(chan struct{}),
+		terminalCh:  make(chan struct{}),
+		state:       StateConnected,
+		conn:        mc,
+	}
+
+	pub := NewPublisher(conn)
+	err := pub.Publish(context.Background(), "test.topic", []byte(`{"test":true}`))
+	require.NoError(t, err)
+
+	// Channel must be closed, NOT returned to pool.
+	ch.mu.Lock()
+	closed := ch.closeCalled
+	ch.mu.Unlock()
+	assert.True(t, closed, "Publisher must close the channel after use, not return to shared pool")
+
+	// Pool must be empty — channel was not released back.
+	select {
+	case <-conn.channelPool:
+		t.Fatal("channel was returned to pool; Publisher must close confirm-mode channels")
+	default:
+		// Good — pool is empty.
+	}
+}

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -391,6 +391,11 @@ type Subscriber interface {
 	Close() error
 }
 
+// ErrInitializerNotSupported is returned by SubscriberWithMiddleware.InitializeSubscription
+// when the inner subscriber does not implement SubscriberInitializer. Callers
+// should fall back to sleep-based waiting on this error.
+var ErrInitializerNotSupported = errors.New("subscriber does not implement SubscriberInitializer")
+
 // SubscriberInitializer is optionally implemented by Subscriber to pre-declare
 // broker topology (exchanges, queues, bindings) before Subscribe is called.
 // This allows the conformance harness to publish messages deterministically —
@@ -430,13 +435,14 @@ func (s *SubscriberWithMiddleware) Subscribe(ctx context.Context, topic string, 
 }
 
 // InitializeSubscription delegates to Inner if it implements SubscriberInitializer.
-// This ensures the deterministic ready-signal is not silently lost when a
-// SubscriberInitializer-capable subscriber is wrapped with middleware.
+// Returns ErrInitializerNotSupported when Inner does not implement the interface,
+// so callers (e.g., outboxtest.waitForSubscription) can fall back to sleep-based
+// waiting instead of assuming initialization succeeded.
 func (s *SubscriberWithMiddleware) InitializeSubscription(ctx context.Context, topic, consumerGroup string) error {
 	if init, ok := s.Inner.(SubscriberInitializer); ok {
 		return init.InitializeSubscription(ctx, topic, consumerGroup)
 	}
-	return nil
+	return ErrInitializerNotSupported
 }
 
 // Close delegates to the inner subscriber.

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -348,12 +348,15 @@ func TestSubscriberWithMiddleware_InitializeSubscription_PropagatesError(t *test
 }
 
 func TestSubscriberWithMiddleware_InitializeSubscription_InnerNotInitializer(t *testing.T) {
-	// Inner does NOT implement SubscriberInitializer — should be a no-op.
+	// Inner does NOT implement SubscriberInitializer — must return
+	// ErrInitializerNotSupported so callers (e.g., waitForSubscription)
+	// can fall back to sleep-based waiting instead of assuming success.
 	inner := &recordingSubscriber{}
 	sub := &SubscriberWithMiddleware{Inner: inner}
 
 	err := sub.InitializeSubscription(context.Background(), "t", "g")
-	assert.NoError(t, err, "should return nil when inner does not support initialization")
+	assert.ErrorIs(t, err, ErrInitializerNotSupported,
+		"must return ErrInitializerNotSupported when inner does not implement SubscriberInitializer")
 }
 
 func TestEntry_RoutingTopic(t *testing.T) {

--- a/kernel/outbox/outboxtest/helpers.go
+++ b/kernel/outbox/outboxtest/helpers.go
@@ -27,10 +27,14 @@ import (
 func waitForSubscription(t *testing.T, ctx context.Context, sub outbox.Subscriber, topic, consumerGroup string) {
 	t.Helper()
 	if init, ok := sub.(outbox.SubscriberInitializer); ok {
-		if err := init.InitializeSubscription(ctx, topic, consumerGroup); err != nil {
+		err := init.InitializeSubscription(ctx, topic, consumerGroup)
+		if err == nil {
+			return // deterministic initialization succeeded
+		}
+		if !errors.Is(err, outbox.ErrInitializerNotSupported) {
 			t.Fatalf("InitializeSubscription(%s, %s): %v", topic, consumerGroup, err)
 		}
-		return
+		// Inner does not support initialization — fall through to sleep.
 	}
 	time.Sleep(subscribeInitDelay)
 }


### PR DESCRIPTION
## Summary

Two CI-blocking regressions from PR#141:

- **SubscriberWithMiddleware ready-signal**: `InitializeSubscription` returned `nil` when Inner doesn't implement `SubscriberInitializer`, causing `waitForSubscription` to skip the sleep fallback. 100% reproducible `SubscriberWithMiddleware` conformance test timeout on every CI run (build-test).
- **Publisher channel pool deadlock**: `Publish` returned confirm-mode channels to the shared `Connection` pool. Subscribers acquiring these channels triggered amqp091-go connection reader deadlock via `confirms.One()` blocking on a full listener channel. RabbitMQ conformance integration test timeout (integration-test).

## Changes

| File | Change |
|------|--------|
| `kernel/outbox/outbox.go` | +`ErrInitializerNotSupported` sentinel; `InitializeSubscription` returns it when Inner doesn't support |
| `kernel/outbox/outboxtest/helpers.go` | `waitForSubscription` falls back to sleep on `ErrInitializerNotSupported` |
| `adapters/rabbitmq/publisher.go` | `defer ch.Close()` replaces `defer conn.ReleaseChannel(ch)` |
| `kernel/outbox/outbox_test.go` | Updated test expectation for sentinel error |
| `adapters/rabbitmq/rabbitmq_test.go` | +`TestPublisher_Publish_ClosesChannel` |

## Framework references

- ref: Watermill `message.SubscribeInitializer` — ready-signal pattern (adopted)
- ref: Watermill `defaultChannelProvider` — ephemeral channel per publish (adopted)
- ref: amqp091-go `NotifyPublish` godoc — documents the exact deadlock scenario

## Test plan

- [x] TDD: wrote failing tests first, then implemented fixes
- [x] `go build ./...` — full build passes
- [x] `go test ./kernel/outbox/... -race` — passes
- [x] `go test ./runtime/eventbus/... -race -count=3` — 3x pass (was 100% fail before)
- [x] `go test ./adapters/rabbitmq/... -race` — passes
- [x] `TestPublisher_Publish_ClosesChannel` — verifies channel closed, not pooled

🤖 Generated with [Claude Code](https://claude.com/claude-code)