### PR TITLE
fix(outbox): review fixes — ClaimPolicy validation + competing consumers test + doc

### DIFF
--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -156,7 +156,8 @@ type Config struct {
 	// Default: 1s.
 	ReconnectBaseDelay time.Duration
 
-	// ChannelPoolSize is the maximum number of channels in the pool.
+	// ChannelPoolSize is the maximum number of idle channels in the subscriber
+	// pool. Publisher uses ephemeral channels (not pooled).
 	// Default: 10.
 	ChannelPoolSize int
 

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -609,14 +609,18 @@ func (c *Connection) Health() error {
 }
 
 // PoolStats holds structured channel pool statistics.
+//
+// The channel pool is used by Subscriber only. Publisher uses ephemeral
+// channels (open, confirm, publish, close) that bypass the pool entirely,
+// so IdleChannels does not reflect publisher channel activity.
 type PoolStats struct {
-	ChannelPoolSize int             // configured pool capacity
-	IdleChannels    int             // channels currently idle in pool
+	ChannelPoolSize int             // configured pool capacity (subscriber only)
+	IdleChannels    int             // channels currently idle in pool (subscriber only)
 	State           ConnectionState // current connection lifecycle state
 }
 
 // PoolStats returns structured pool statistics suitable for metrics collection
-// and operational dashboards.
+// and operational dashboards. See PoolStats type doc for scope limitations.
 func (c *Connection) PoolStats() PoolStats {
 	c.mu.RLock()
 	state := c.state

--- a/adapters/rabbitmq/consumer_base.go
+++ b/adapters/rabbitmq/consumer_base.go
@@ -32,7 +32,15 @@ const (
 	// idempotency receipt. Avoids total consumer stall, but risks duplicate
 	// processing during outage.
 	ClaimPolicyFailOpen
+
+	// claimPolicySentinel is the upper bound for validation. Not exported.
+	claimPolicySentinel
 )
+
+// Valid returns true if the ClaimPolicy is a recognized enum value.
+func (p ClaimPolicy) Valid() bool {
+	return p < claimPolicySentinel
+}
 
 // ConsumerBaseConfig configures ConsumerBase behavior.
 type ConsumerBaseConfig struct {
@@ -78,6 +86,10 @@ type ConsumerBaseConfig struct {
 }
 
 func (c *ConsumerBaseConfig) setDefaults() {
+	if !c.ClaimPolicy.Valid() {
+		panic(fmt.Sprintf("rabbitmq: invalid ClaimPolicy %d, must be ClaimPolicyFailClosed (%d) or ClaimPolicyFailOpen (%d)",
+			c.ClaimPolicy, ClaimPolicyFailClosed, ClaimPolicyFailOpen))
+	}
 	if c.RetryCount <= 0 {
 		c.RetryCount = 3
 	}

--- a/adapters/rabbitmq/doc.go
+++ b/adapters/rabbitmq/doc.go
@@ -1,8 +1,14 @@
 // Package rabbitmq provides a RabbitMQ adapter for the GoCell event bus.
 //
 // It implements outbox.Publisher and outbox.Subscriber using amqp091-go,
-// with auto-reconnect (exponential backoff), channel pooling, publisher
-// confirm mode, and consumer-side ConsumerBase (idempotency + retry + DLQ).
+// with auto-reconnect (exponential backoff), subscriber channel pooling,
+// publisher confirm mode (ephemeral channel per publish), and consumer-side
+// ConsumerBase (idempotency + retry + DLQ).
 //
-// ref: Watermill watermill-amqp subscriber.go — reconnect + ACK/NACK pattern
+// Publisher uses a fresh channel per Publish call (open, confirm, publish,
+// close) to avoid confirm-mode channels polluting the shared pool. For
+// high-throughput scenarios, a dedicated long-lived confirm channel is a
+// future optimization (see Watermill pooledChannelProvider).
+//
+// ref: Watermill watermill-amqp — reconnect + ACK/NACK + channel lifecycle
 package rabbitmq

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -3295,6 +3295,21 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_FailOpen_Explicit(t *testing.T)
 	assert.Nil(t, res.Receipt, "no Receipt when claim fails")
 }
 
+func TestClaimPolicy_Valid(t *testing.T) {
+	assert.True(t, ClaimPolicyFailClosed.Valid())
+	assert.True(t, ClaimPolicyFailOpen.Valid())
+	assert.False(t, ClaimPolicy(99).Valid(), "unknown ClaimPolicy must be invalid")
+}
+
+func TestConsumerBase_InvalidClaimPolicy_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		NewConsumerBase(&mockClaimer{}, ConsumerBaseConfig{
+			ConsumerGroup: "test",
+			ClaimPolicy:   ClaimPolicy(99),
+		})
+	}, "NewConsumerBase must panic on invalid ClaimPolicy")
+}
+
 // =============================================================================
 // retryLoop post-loop ctx.Err() test (S3-02)
 // =============================================================================
@@ -4455,4 +4470,41 @@ func TestPublisher_Publish_ClosesChannel(t *testing.T) {
 	default:
 		// Good — pool is empty.
 	}
+}
+
+func TestPublisher_Publish_CloseError_DoesNotMaskResult(t *testing.T) {
+	ch := newMockChannel()
+	ch.closeErr = errors.New("channel already closed")
+
+	go func() {
+		for {
+			ch.mu.Lock()
+			npc := ch.notifyPublishCh
+			confirmed := ch.confirmCalled
+			ch.mu.Unlock()
+			if confirmed && npc != nil {
+				select {
+				case npc <- amqp.Confirmation{Ack: true}:
+					return
+				default:
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	mc := &mockConnection{nextCh: ch}
+	conn := &Connection{
+		config:      Config{URL: "amqp://test@localhost/", ConfirmTimeout: 5 * time.Second},
+		channelPool: make(chan AMQPChannel, 5),
+		closeCh:     make(chan struct{}),
+		connected:   make(chan struct{}),
+		terminalCh:  make(chan struct{}),
+		state:       StateConnected,
+		conn:        mc,
+	}
+
+	pub := NewPublisher(conn)
+	err := pub.Publish(context.Background(), "test.topic", []byte(`{"test":true}`))
+	assert.NoError(t, err, "close error must not mask successful publish result")
 }

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -391,9 +391,10 @@ type Subscriber interface {
 	Close() error
 }
 
-// ErrInitializerNotSupported is returned by SubscriberWithMiddleware.InitializeSubscription
-// when the inner subscriber does not implement SubscriberInitializer. Callers
-// should fall back to sleep-based waiting on this error.
+// ErrInitializerNotSupported is returned by InitializeSubscription when the
+// underlying subscriber does not support topology pre-declaration. Callers
+// that receive this error should use an alternative readiness mechanism
+// (e.g., polling or timed delay) instead of assuming initialization succeeded.
 var ErrInitializerNotSupported = errors.New("subscriber does not implement SubscriberInitializer")
 
 // SubscriberInitializer is optionally implemented by Subscriber to pre-declare

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -57,6 +57,12 @@ func TestPubSub(t *testing.T, features Features, constructor PubSubConstructor) 
 		}
 		testMultipleSubscribers(t, features, constructor)
 	})
+	t.Run("CompetingConsumers", func(t *testing.T) {
+		if features.BroadcastSubscribe {
+			t.Skip("implementation uses broadcast fan-out, not competing consumers")
+		}
+		testCompetingConsumers(t, features, constructor)
+	})
 
 	// Batch 2: Disposition lifecycle
 	t.Run("DispositionAck", func(t *testing.T) {
@@ -289,6 +295,55 @@ func testMultipleSubscribers(t *testing.T, _ Features, constructor PubSubConstru
 	assertEventually(t, func() bool {
 		return sub1Received.Load() >= 1 && sub2Received.Load() >= 1
 	}, defaultTimeout, 10*time.Millisecond, "both subscribers should receive the message")
+
+	cancel()
+	wg.Wait()
+}
+
+// testCompetingConsumers verifies that when BroadcastSubscribe=false (e.g.,
+// RabbitMQ with a shared queue), a single message is delivered to exactly one
+// of multiple subscribers — not duplicated to all.
+func testCompetingConsumers(t *testing.T, _ Features, constructor PubSubConstructor) {
+	pub, sub := constructor(t)
+	ctx := context.Background()
+	topic := TestTopic(t)
+
+	var (
+		totalReceived atomic.Int32
+		wg            sync.WaitGroup
+	)
+
+	subCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	// Start two competing subscribers on the same topic.
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = sub.Subscribe(subCtx, topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+				totalReceived.Add(1)
+				return outbox.HandleResult{Disposition: outbox.DispositionAck}
+			}, "")
+		}()
+	}
+
+	waitForSubscription(t, ctx, sub, topic, "")
+
+	// Publish one message.
+	assertNoError(t, pub.Publish(ctx, topic, []byte(`{"test":"competing"}`)))
+
+	// Wait for at least one delivery.
+	assertEventually(t, func() bool {
+		return totalReceived.Load() >= 1
+	}, defaultTimeout, 10*time.Millisecond, "at least one subscriber should receive the message")
+
+	// Brief window for any duplicate delivery.
+	time.Sleep(200 * time.Millisecond)
+
+	got := totalReceived.Load()
+	assertEqual(t, int32(1), got,
+		fmt.Sprintf("competing consumers: message should be delivered to exactly 1 subscriber, got %d", got))
 
 	cancel()
 	wg.Wait()

--- a/kernel/outbox/outboxtest/helpers_test.go
+++ b/kernel/outbox/outboxtest/helpers_test.go
@@ -199,6 +199,29 @@ func TestWaitForSubscription_FallsBackToSleep(t *testing.T) {
 	}
 }
 
+func TestWaitForSubscription_MiddlewareWrappedNonInitializer_FallsBack(t *testing.T) {
+	// This is the exact regression path from PR#141 CI failure:
+	// SubscriberWithMiddleware wraps a non-SubscriberInitializer (e.g.,
+	// InMemoryEventBus). Before the fix, InitializeSubscription returned nil
+	// (false success), skipping the sleep fallback → publish before subscribe
+	// registers → message lost → test timeout.
+	inner := &fakePubSub{} // does NOT implement SubscriberInitializer
+	wrapped := &outbox.SubscriberWithMiddleware{
+		Inner:      inner,
+		Middleware: nil,
+	}
+	ctx := context.Background()
+
+	start := time.Now()
+	waitForSubscription(t, ctx, wrapped, "test.topic", "")
+	elapsed := time.Since(start)
+
+	// Must fall back to sleep, NOT return instantly.
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("middleware-wrapped non-initializer must fall back to sleep (~50ms), but returned in %v", elapsed)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // collector tests — uses a minimal in-test fake subscriber (no runtime/ import)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Review fixes for PR#141/PR#144 findings. PR#144 was merged before this commit landed.

- **R6 ClaimPolicy allowlist**: `ClaimPolicy.Valid()` + `setDefaults()` panic on invalid enum (fail-fast at construction)
- **R7 CompetingConsumers test**: when `BroadcastSubscribe=false`, verify single message delivered to exactly 1 of 2 subscribers
- **R1+R4 doc.go**: clarify subscriber-only pool, publisher ephemeral channels, performance note
- **R2 close error test**: `TestPublisher_Publish_CloseError_DoesNotMaskResult`
- **R5 godoc**: `ErrInitializerNotSupported` — remove specific caller reference

## Test plan

- [x] `go build ./...`
- [x] `go test ./kernel/outbox/... ./runtime/eventbus/... ./adapters/rabbitmq/... -race`
- [x] `TestClaimPolicy_Valid` + `TestConsumerBase_InvalidClaimPolicy_Panics`
- [x] `TestPublisher_Publish_CloseError_DoesNotMaskResult`
- [x] InMemoryEventBus conformance (incl. new CompetingConsumers) — 3x pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)