### PR TITLE
fix(outbox): PR#145 review fixes + outbox cleanup

### DIFF
--- a/adapters/postgres/pool.go
+++ b/adapters/postgres/pool.go
@@ -153,18 +153,18 @@ func (p *Pool) Close() {
 // ref: pgxpool Stat() — adopted same field set for operational dashboards
 // and Prometheus/OTel metric collectors.
 type PoolStats struct {
-	AcquireCount            int64
-	AcquireDuration         time.Duration
-	AcquiredConns           int32
-	CanceledAcquireCount    int64
-	ConstructingConns       int32
-	EmptyAcquireCount       int64
-	IdleConns               int32
-	MaxConns                int32
-	TotalConns              int32
-	NewConnsCount           int64
-	MaxLifetimeDestroyCount int64
-	MaxIdleDestroyCount     int64
+	AcquireCount            int64         `json:"acquireCount"`
+	AcquireDuration         time.Duration `json:"acquireDuration"`
+	AcquiredConns           int32         `json:"acquiredConns"`
+	CanceledAcquireCount    int64         `json:"canceledAcquireCount"`
+	ConstructingConns       int32         `json:"constructingConns"`
+	EmptyAcquireCount       int64         `json:"emptyAcquireCount"`
+	IdleConns               int32         `json:"idleConns"`
+	MaxConns                int32         `json:"maxConns"`
+	TotalConns              int32         `json:"totalConns"`
+	NewConnsCount           int64         `json:"newConnsCount"`
+	MaxLifetimeDestroyCount int64         `json:"maxLifetimeDestroyCount"`
+	MaxIdleDestroyCount     int64         `json:"maxIdleDestroyCount"`
 }
 
 // PoolStats returns structured pool statistics suitable for metrics collection

--- a/adapters/postgres/pool_test.go
+++ b/adapters/postgres/pool_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -133,6 +134,16 @@ func TestPoolStats_ZeroValue(t *testing.T) {
 	assert.Equal(t, int64(0), stats.NewConnsCount)
 	assert.Equal(t, int64(0), stats.MaxLifetimeDestroyCount)
 	assert.Equal(t, int64(0), stats.MaxIdleDestroyCount)
+}
+
+func TestPoolStats_JSON_CamelCase(t *testing.T) {
+	stats := PoolStats{AcquireCount: 5, IdleConns: 2, TotalConns: 10}
+	b, err := json.Marshal(stats)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"acquireCount"`)
+	assert.Contains(t, s, `"idleConns"`)
+	assert.Contains(t, s, `"totalConns"`)
 }
 
 func TestPoolStats_NilInner(t *testing.T) {

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -70,6 +70,13 @@ func (s ConnectionState) String() string {
 	}
 }
 
+// MarshalText implements encoding.TextMarshaler so that JSON serialization
+// of PoolStats.State produces a human-readable string ("connected") instead
+// of a numeric uint8 value.
+func (s ConnectionState) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
 // isPermanentDialError returns true if the error from Dial indicates a
 // permanent condition that will not resolve by retrying.
 //

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -615,9 +615,9 @@ func (c *Connection) Health() error {
 // channels (open, confirm, publish, close) that bypass the pool entirely,
 // so IdleChannels does not reflect publisher channel activity.
 type PoolStats struct {
-	ChannelPoolSize int             // configured pool capacity (subscriber only)
-	IdleChannels    int             // channels currently idle in pool (subscriber only)
-	State           ConnectionState // current connection lifecycle state
+	ChannelPoolSize int             `json:"channelPoolSize"` // configured pool capacity (subscriber only)
+	IdleChannels    int             `json:"idleChannels"`    // channels currently idle in pool (subscriber only)
+	State           ConnectionState `json:"state"`           // current connection lifecycle state
 }
 
 // PoolStats returns structured pool statistics suitable for metrics collection

--- a/adapters/rabbitmq/consumer_base.go
+++ b/adapters/rabbitmq/consumer_base.go
@@ -20,6 +20,7 @@ const (
 )
 
 // ClaimPolicy controls ConsumerBase behavior when Claimer.Claim() fails.
+// The zero value (ClaimPolicyFailClosed) is the safe default.
 type ClaimPolicy uint8
 
 const (
@@ -33,7 +34,7 @@ const (
 	// processing during outage.
 	ClaimPolicyFailOpen
 
-	// claimPolicySentinel is the upper bound for validation. Not exported.
+	// claimPolicySentinel must remain last — add new values above this line.
 	claimPolicySentinel
 )
 
@@ -86,10 +87,6 @@ type ConsumerBaseConfig struct {
 }
 
 func (c *ConsumerBaseConfig) setDefaults() {
-	if !c.ClaimPolicy.Valid() {
-		panic(fmt.Sprintf("rabbitmq: invalid ClaimPolicy %d, must be ClaimPolicyFailClosed (%d) or ClaimPolicyFailOpen (%d)",
-			c.ClaimPolicy, ClaimPolicyFailClosed, ClaimPolicyFailOpen))
-	}
 	if c.RetryCount <= 0 {
 		c.RetryCount = 3
 	}
@@ -143,14 +140,22 @@ func logWithContext(ctx context.Context, level slog.Level, msg string, attrs ...
 }
 
 // NewConsumerBase creates a ConsumerBase using the two-phase Claimer interface.
-// The returned Receipt is threaded through HandleResult so that the Subscriber
-// can Commit/Release after broker Ack/Nack.
-func NewConsumerBase(claimer idempotency.Claimer, config ConsumerBaseConfig) *ConsumerBase {
+// Returns an error if ConsumerBaseConfig contains invalid values (e.g., unknown
+// ClaimPolicy). The returned Receipt is threaded through HandleResult so that
+// the Subscriber can Commit/Release after broker Ack/Nack.
+//
+// ref: nats-go Connect() (*Conn, error), watermill-amqp NewSubscriber() (*Subscriber, error)
+// — constructors return error, never panic.
+func NewConsumerBase(claimer idempotency.Claimer, config ConsumerBaseConfig) (*ConsumerBase, error) {
+	if !config.ClaimPolicy.Valid() {
+		return nil, fmt.Errorf("rabbitmq: invalid ClaimPolicy %d (valid range: 0..%d)",
+			config.ClaimPolicy, claimPolicySentinel-1)
+	}
 	config.setDefaults()
 	return &ConsumerBase{
 		claimer: claimer,
 		config:  config,
-	}
+	}, nil
 }
 
 // AsMiddleware returns a TopicHandlerMiddleware that applies this
@@ -238,7 +243,7 @@ func (cb *ConsumerBase) claimWithRetry(
 	topic string,
 	entry outbox.Entry,
 	idempotencyKey string,
-) (idempotency.ClaimState, idempotency.Receipt, error) {
+) (idempotency.ClaimState, outbox.Receipt, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < cb.config.ClaimRetryCount; attempt++ {
@@ -289,7 +294,7 @@ func (cb *ConsumerBase) handleClaimState(
 	entry outbox.Entry,
 	handler outbox.EntryHandler,
 	state idempotency.ClaimState,
-	receipt idempotency.Receipt,
+	receipt outbox.Receipt,
 ) outbox.HandleResult {
 	switch state {
 	case idempotency.ClaimDone:
@@ -317,7 +322,7 @@ func (cb *ConsumerBase) handleClaimState(
 }
 
 // requeueResult constructs a Requeue HandleResult with the given error and receipt.
-func requeueResult(err error, receipt idempotency.Receipt) outbox.HandleResult {
+func requeueResult(err error, receipt outbox.Receipt) outbox.HandleResult {
 	return outbox.HandleResult{
 		Disposition: outbox.DispositionRequeue,
 		Err:         err,
@@ -333,7 +338,7 @@ func (cb *ConsumerBase) retryLoop(
 	topic string,
 	entry outbox.Entry,
 	handler outbox.EntryHandler,
-	receipt idempotency.Receipt,
+	receipt outbox.Receipt,
 ) outbox.HandleResult {
 	var lastResult outbox.HandleResult
 	for attempt := range cb.config.RetryCount {

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -272,7 +272,7 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	conn.ReleaseChannel(rawCh)
 
 	// --- Create ConsumerBase with short retry ---
-	cb := NewConsumerBase(
+	cb, cbErr := NewConsumerBase(
 		&noopClaimer{},
 		ConsumerBaseConfig{
 			ConsumerGroup:  "test-retry-e2e",
@@ -281,6 +281,7 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 			IdempotencyTTL: time.Hour,
 		},
 	)
+	require.NoError(t, cbErr)
 
 	// --- Start main subscriber with ConsumerBase-wrapped handler ---
 	sub := NewSubscriber(conn, SubscriberConfig{
@@ -529,7 +530,7 @@ func TestIntegration_DLXBrokerNative(t *testing.T) {
 // returns ClaimAcquired with a noopReceipt.
 type noopClaimer struct{}
 
-func (n *noopClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (idempotency.ClaimState, idempotency.Receipt, error) {
+func (n *noopClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (idempotency.ClaimState, outbox.Receipt, error) {
 	return idempotency.ClaimAcquired, &noopReceipt{}, nil
 }
 

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -2127,9 +2127,10 @@ func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "mw-group",
 	})
+	require.NoError(t, cbErr)
 
 	mw := cb.AsMiddleware()
 
@@ -2153,9 +2154,10 @@ func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
 func TestConsumerBase_AsMiddleware_Idempotency_SkipsDuplicate(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimDone}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "mw-group",
 	})
+	require.NoError(t, cbErr)
 
 	mw := cb.AsMiddleware()
 
@@ -2175,11 +2177,12 @@ func TestConsumerBase_AsMiddleware_RejectOnPermanentError(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "mw-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	mw := cb.AsMiddleware()
 
@@ -2206,9 +2209,10 @@ func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 		{state: idempotency.ClaimDone},
 	}}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "integration-group",
 	})
+	require.NoError(t, cbErr)
 
 	// Use a simple recording subscriber to verify the chain works end-to-end.
 	var capturedHandler outbox.EntryHandler
@@ -2257,9 +2261,10 @@ func TestConsumerBase_AsMiddleware_WithObservabilityContextMiddleware(t *testing
 		receipt: receipt,
 	}}}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "integration-group",
 	})
+	require.NoError(t, cbErr)
 
 	var capturedHandler outbox.EntryHandler
 	innerSub := &stubSubscriber{
@@ -2323,9 +2328,10 @@ func TestConsumerBase_AsMiddleware_LogsRestoredContext(t *testing.T) {
 		receipt: receipt,
 	}}}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "integration-group",
 	})
+	require.NoError(t, cbErr)
 
 	var capturedHandler outbox.EntryHandler
 	innerSub := &stubSubscriber{
@@ -2470,17 +2476,17 @@ func (r *mockReceipt) Release(ctx context.Context) error {
 	return r.releaseErr
 }
 
-var _ idempotency.Receipt = (*mockReceipt)(nil)
+var _ outbox.Receipt = (*mockReceipt)(nil)
 
 type mockClaimer struct {
-	mu     sync.Mutex
-	state  idempotency.ClaimState
-	receipt idempotency.Receipt
-	err    error
-	claims []string
+	mu      sync.Mutex
+	state   idempotency.ClaimState
+	receipt outbox.Receipt
+	err     error
+	claims  []string
 }
 
-func (c *mockClaimer) Claim(_ context.Context, key string, _, _ time.Duration) (idempotency.ClaimState, idempotency.Receipt, error) {
+func (c *mockClaimer) Claim(_ context.Context, key string, _, _ time.Duration) (idempotency.ClaimState, outbox.Receipt, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.claims = append(c.claims, key)
@@ -2495,9 +2501,10 @@ func TestConsumerBase_WrapWithClaimer_Success_ReturnsReceipt(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
@@ -2521,9 +2528,10 @@ func TestConsumerBase_WrapWithClaimer_Success_ReturnsReceipt(t *testing.T) {
 func TestConsumerBase_WrapWithClaimer_ClaimDone_SkipsHandler(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimDone}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -2540,9 +2548,10 @@ func TestConsumerBase_WrapWithClaimer_ClaimDone_SkipsHandler(t *testing.T) {
 func TestConsumerBase_WrapWithClaimer_ClaimBusy_Requeues(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimBusy}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -2559,11 +2568,12 @@ func TestConsumerBase_WrapWithClaimer_Reject_ThreadsReceipt(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     1,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("fail")}
@@ -2584,11 +2594,12 @@ func TestConsumerBase_WrapWithClaimer_ExplicitReject_FirstRoundNoRetry(t *testin
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	handlerCallCount := 0
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCallCount++
@@ -2609,11 +2620,12 @@ func TestConsumerBase_WrapWithClaimer_WrappedPermanentError_FirstRoundReject(t *
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	handlerCallCount := 0
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCallCount++
@@ -2641,11 +2653,11 @@ type sequenceClaimer struct {
 
 type claimResponse struct {
 	state   idempotency.ClaimState
-	receipt idempotency.Receipt
+	receipt outbox.Receipt
 	err     error
 }
 
-func (c *sequenceClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (idempotency.ClaimState, idempotency.Receipt, error) {
+func (c *sequenceClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (idempotency.ClaimState, outbox.Receipt, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	idx := c.callCount
@@ -2671,11 +2683,12 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_LocalRetryThe
 		{state: idempotency.ClaimAcquired, receipt: receipt},                // attempt 2 — success
 	}}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:      "test-group",
 		ClaimRetryCount:    3,
 		ClaimRetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -2698,11 +2711,12 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_HasBackoff(t 
 
 	// ClaimRetryCount=3, ClaimRetryBaseDelay=20ms → sleeps between attempts.
 	// With jitter, we assert >= base delay only (not exact).
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:      "test-group",
 		ClaimRetryCount:    3,
 		ClaimRetryBaseDelay: 20 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -2726,11 +2740,12 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_HasBackoff(t 
 func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_CtxCancel(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:      "test-group",
 		ClaimRetryCount:    3,
 		ClaimRetryBaseDelay: 5 * time.Second, // long delay — ctx cancel must short-circuit
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
@@ -2754,11 +2769,12 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_RetryCount1(t
 	// S3-01: boundary — ClaimRetryCount=1 means exactly 1 attempt, no backoff sleep.
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:      "test-group",
 		ClaimRetryCount:    1,
 		ClaimRetryBaseDelay: 5 * time.Second,
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
@@ -2784,13 +2800,14 @@ func TestConsumerBase_WrapWithClaimer_ClaimRetryConfig_Independent(t *testing.T)
 		{state: idempotency.ClaimAcquired, receipt: receipt},                // attempt 1 — success
 	}}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:      "test-group",
 		RetryCount:         5,                   // handler retries — should not affect claim
 		RetryBaseDelay:     1 * time.Second,     // handler backoff — should not affect claim
 		ClaimRetryCount:    2,                   // claim retries
 		ClaimRetryBaseDelay: 10 * time.Millisecond, // claim backoff
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -2816,12 +2833,13 @@ func TestConsumerBase_MaxRetryDelay_Caps_ClaimBackoff(t *testing.T) {
 	// S4-02: MaxRetryDelay caps exponential growth.
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:      "test-group",
 		ClaimRetryCount:    3,
 		ClaimRetryBaseDelay: 100 * time.Millisecond,
 		MaxRetryDelay:      50 * time.Millisecond, // cap below base — forces all delays to 50ms
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
@@ -2840,11 +2858,12 @@ func TestConsumerBase_MaxRetryDelay_Caps_ClaimBackoff(t *testing.T) {
 func TestConsumerBase_NegativeClaimRetryBaseDelay_NoPanic(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     2,
 		ClaimRetryBaseDelay: -1 * time.Second, // negative — must not panic
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
@@ -2858,12 +2877,13 @@ func TestConsumerBase_NegativeClaimRetryBaseDelay_NoPanic(t *testing.T) {
 func TestConsumerBase_NegativeMaxRetryDelay_NoPanic(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     2,
 		ClaimRetryBaseDelay: 10 * time.Millisecond,
 		MaxRetryDelay:       -1 * time.Second, // negative — must not panic
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
@@ -3195,10 +3215,11 @@ func TestProcessDelivery_Reject_NoDLX_SubscribeReturnsError(t *testing.T) {
 func TestConsumerBase_WrapWithClaimer_ClaimBusy_HasBackoff(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimBusy}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryBaseDelay: 50 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		t.Fatal("handler should not be called for ClaimBusy")
@@ -3255,12 +3276,13 @@ func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
 func TestConsumerBase_WrapWithClaimer_ClaimError_FailClosed(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:       "test-group",
 		ClaimPolicy:         ClaimPolicyFailClosed,
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -3278,10 +3300,11 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_FailClosed(t *testing.T) {
 func TestConsumerBase_WrapWithClaimer_ClaimError_FailOpen_Explicit(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup: "test-group",
 		ClaimPolicy:   ClaimPolicyFailOpen,
 	})
+	require.NoError(t, cbErr)
 
 	handlerCalled := false
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -3301,13 +3324,43 @@ func TestClaimPolicy_Valid(t *testing.T) {
 	assert.False(t, ClaimPolicy(99).Valid(), "unknown ClaimPolicy must be invalid")
 }
 
-func TestConsumerBase_InvalidClaimPolicy_Panics(t *testing.T) {
-	assert.Panics(t, func() {
-		NewConsumerBase(&mockClaimer{}, ConsumerBaseConfig{
-			ConsumerGroup: "test",
-			ClaimPolicy:   ClaimPolicy(99),
+func TestNewConsumerBase_InvalidClaimPolicy_ReturnsError(t *testing.T) {
+	_, err := NewConsumerBase(&mockClaimer{}, ConsumerBaseConfig{
+		ConsumerGroup: "test",
+		ClaimPolicy:   ClaimPolicy(99),
+	})
+	require.Error(t, err, "NewConsumerBase must return error on invalid ClaimPolicy")
+	assert.Contains(t, err.Error(), "invalid ClaimPolicy 99")
+}
+
+func TestNewConsumerBase_ValidClaimPolicy_Succeeds(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy ClaimPolicy
+	}{
+		{"FailClosed", ClaimPolicyFailClosed},
+		{"FailOpen", ClaimPolicyFailOpen},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb, err := NewConsumerBase(&mockClaimer{}, ConsumerBaseConfig{
+				ConsumerGroup: "test",
+				ClaimPolicy:   tt.policy,
+			})
+			require.NoError(t, err)
+			assert.NotNil(t, cb)
 		})
-	}, "NewConsumerBase must panic on invalid ClaimPolicy")
+	}
+}
+
+func TestNewConsumerBase_ExplicitFailClosed_Preserved(t *testing.T) {
+	// Explicitly pass ClaimPolicyFailClosed (0) — must be preserved through setDefaults.
+	cb, err := NewConsumerBase(&mockClaimer{}, ConsumerBaseConfig{
+		ConsumerGroup: "test",
+		ClaimPolicy:   ClaimPolicyFailClosed,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ClaimPolicyFailClosed, cb.config.ClaimPolicy)
 }
 
 // =============================================================================
@@ -3320,11 +3373,12 @@ func TestConsumerBase_RetryLoop_CtxCancelledAfterFinalAttempt_Requeues(t *testin
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     1, // single attempt, no inter-attempt sleep
 		RetryBaseDelay: time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -3572,11 +3626,12 @@ func TestConsumerBase_WrapWithClaimer_TransientError_ThenSuccess(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	attempt := 0
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -3604,11 +3659,12 @@ func TestConsumerBase_WrapWithClaimer_ExplicitReject_NoRetry(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     5,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	callCount := 0
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -3633,11 +3689,12 @@ func TestConsumerBase_WrapWithClaimer_WrappedPermanentError_Detected(t *testing.
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(claimer, ConsumerBaseConfig{
+	cb, cbErr := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ConsumerGroup:  "test-group",
 		RetryCount:     5,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
+	require.NoError(t, cbErr)
 
 	callCount := 0
 	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -4379,7 +4436,7 @@ func TestConsumerBase_RetryExhaustion(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb := NewConsumerBase(
+	cb, cbErr := NewConsumerBase(
 		claimer,
 		ConsumerBaseConfig{
 			ConsumerGroup:  "test-retry-group",
@@ -4388,6 +4445,7 @@ func TestConsumerBase_RetryExhaustion(t *testing.T) {
 			IdempotencyTTL: time.Hour,
 		},
 	)
+	require.NoError(t, cbErr)
 
 	topic := "test.retry.unit"
 	callCount := 0
@@ -4476,8 +4534,19 @@ func TestPublisher_Publish_CloseError_DoesNotMaskResult(t *testing.T) {
 	ch := newMockChannel()
 	ch.closeErr = errors.New("channel already closed")
 
+	// Use context.WithTimeout to prevent goroutine leak if the test
+	// exits before the confirmation is sent (e.g., on early failure).
+	// Pattern ref: NATS channel+timeout, Sarama goleak.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
 	go func() {
 		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			ch.mu.Lock()
 			npc := ch.notifyPublishCh
 			confirmed := ch.confirmCalled

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -406,6 +406,16 @@ func TestConnection_PoolStats_Empty(t *testing.T) {
 	assert.Equal(t, StateConnected, stats.State)
 }
 
+func TestPoolStats_JSON_CamelCase(t *testing.T) {
+	stats := PoolStats{ChannelPoolSize: 10, IdleChannels: 3, State: StateConnected}
+	b, err := json.Marshal(stats)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"channelPoolSize"`)
+	assert.Contains(t, s, `"idleChannels"`)
+	assert.Contains(t, s, `"state":"connected"`) // MarshalText, not numeric
+}
+
 func TestConnection_Close_Idempotent(t *testing.T) {
 	conn, _ := newTestConnection(t)
 

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -4478,13 +4478,20 @@ func TestConsumerBase_RetryExhaustion(t *testing.T) {
 func TestPublisher_Publish_ClosesChannel(t *testing.T) {
 	ch := newMockChannel()
 
-	// Send confirmation asynchronously after NotifyPublish replaces the channel.
-	origNotify := ch.NotifyPublish
-	_ = origNotify
+	// Use context.WithTimeout to prevent goroutine leak if the test
+	// exits before the confirmation is sent (same fix as CloseError test).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
 	go func() {
 		// Wait until confirmCalled is set (Confirm was called), then the
 		// next NotifyPublish will install a new channel. Poll briefly.
 		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			ch.mu.Lock()
 			npc := ch.notifyPublishCh
 			confirmed := ch.confirmCalled

--- a/adapters/redis/client.go
+++ b/adapters/redis/client.go
@@ -115,12 +115,12 @@ type poolStatsProvider interface {
 //
 // ref: go-redis PoolStats / redisprometheus — adopted same field set.
 type PoolStats struct {
-	Hits       uint32 // times free connection was found in pool
-	Misses     uint32 // times free connection was NOT found in pool
-	Timeouts   uint32 // times a wait timeout occurred
-	TotalConns uint32 // total connections in pool
-	IdleConns  uint32 // idle connections in pool
-	StaleConns uint32 // stale connections removed from pool
+	Hits       uint32 `json:"hits"`       // times free connection was found in pool
+	Misses     uint32 `json:"misses"`     // times free connection was NOT found in pool
+	Timeouts   uint32 `json:"timeouts"`   // times a wait timeout occurred
+	TotalConns uint32 `json:"totalConns"` // total connections in pool
+	IdleConns  uint32 `json:"idleConns"`  // idle connections in pool
+	StaleConns uint32 `json:"staleConns"` // stale connections removed from pool
 }
 
 // Client wraps a go-redis universal client and provides health checking

--- a/adapters/redis/client_test.go
+++ b/adapters/redis/client_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -147,6 +148,17 @@ func TestClientPoolStats_WithProvider(t *testing.T) {
 	assert.Equal(t, uint32(10), stats.TotalConns)
 	assert.Equal(t, uint32(7), stats.IdleConns)
 	assert.Equal(t, uint32(2), stats.StaleConns)
+}
+
+func TestPoolStats_JSON_CamelCase(t *testing.T) {
+	stats := PoolStats{Hits: 10, Misses: 2, TotalConns: 5, IdleConns: 3}
+	b, err := json.Marshal(stats)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"hits"`)
+	assert.Contains(t, s, `"misses"`)
+	assert.Contains(t, s, `"totalConns"`)
+	assert.Contains(t, s, `"idleConns"`)
 }
 
 func TestNewClient_StandaloneEmptyAddr(t *testing.T) {

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -215,7 +215,7 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if c.outboxWriter == nil && c.txRunner == nil {
 		if c.publisher == nil {
 			return errcode.New(errcode.ErrCellMissingOutbox,
-				"access-core requires publisher or outbox writer; use WithPublisher(outbox.DiscardPublisher{}) for demo mode")
+				"access-core requires publisher or outbox writer; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
 		}
 		if c.ConsistencyLevel() >= cell.L2 {
 			c.logger.Warn("access-core: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",

--- a/cells/audit-core/cell.go
+++ b/cells/audit-core/cell.go
@@ -154,7 +154,7 @@ func (c *AuditCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if c.outboxWriter == nil && c.txRunner == nil {
 		if c.publisher == nil {
 			return errcode.New(errcode.ErrCellMissingOutbox,
-				"audit-core requires publisher or outbox writer; use WithPublisher(outbox.DiscardPublisher{}) for demo mode")
+				"audit-core requires publisher or outbox writer; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
 		}
 		if c.ConsistencyLevel() >= cell.L2 {
 			c.logger.Warn("audit-core: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",

--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -135,7 +135,7 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if c.outboxWriter == nil && c.txRunner == nil {
 		if c.publisher == nil {
 			return errcode.New(errcode.ErrCellMissingOutbox,
-				"config-core requires publisher or outbox writer; use WithPublisher(outbox.DiscardPublisher{}) for demo mode")
+				"config-core requires publisher or outbox writer; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
 		}
 		if c.ConsistencyLevel() >= cell.L2 {
 			c.logger.Warn("config-core: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",

--- a/cells/device-cell/cell.go
+++ b/cells/device-cell/cell.go
@@ -104,10 +104,10 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 		c.logger.Info("device-cell: using in-memory command repository (demo mode)")
 	}
 
-	// Publisher is required (NIL-PUB-P1). Use DiscardPublisher{} for demo mode.
+	// Publisher is required (NIL-PUB-P1). Use &DiscardPublisher{} for demo mode.
 	if c.publisher == nil {
 		return errcode.New(errcode.ErrCellMissingOutbox,
-			"device-cell requires publisher; use WithPublisher(outbox.DiscardPublisher{}) for demo mode")
+			"device-cell requires publisher; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
 	}
 
 	// Durable mode: reject noop publisher (#27c-2).

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -290,7 +290,13 @@ type DiscardPublisher struct {
 }
 
 // Publish logs a discard warning, increments the counter, and returns nil.
+// Safe to call on a nil receiver (typed nil defense).
 func (d *DiscardPublisher) Publish(_ context.Context, topic string, _ []byte) error {
+	if d == nil {
+		slog.Default().Warn("outbox: discard publisher dropping message (nil receiver)",
+			slog.String("topic", topic))
+		return nil
+	}
 	d.counter.Add(1)
 	l := d.Logger
 	if l == nil {
@@ -301,7 +307,11 @@ func (d *DiscardPublisher) Publish(_ context.Context, topic string, _ []byte) er
 }
 
 // DiscardCount returns the total number of messages discarded.
+// Returns 0 on a nil receiver.
 func (d *DiscardPublisher) DiscardCount() uint64 {
+	if d == nil {
+		return 0
+	}
 	return d.counter.Load()
 }
 

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/idempotency"
@@ -278,32 +279,44 @@ func (NoopWriter) Noop() bool { return true }
 //   - Unit testing Cells that require an outbox.Publisher dependency
 //   - Running demo/example code without a message broker
 //
-// Publish logs a structured warning via slog.Default() and discards the
-// payload. The warning ensures discard behavior is visible in logs.
-type DiscardPublisher struct{}
+// Publish logs a structured warning and discards the payload. The warning
+// ensures discard behavior is visible in logs.
+//
+// ref: go-logr zero-value safe (if sink == nil), slog DiscardHandler
+type DiscardPublisher struct {
+	// Logger is used for discard warnings. If nil, slog.Default() is used.
+	Logger  *slog.Logger
+	counter atomic.Uint64
+}
 
-// Publish logs a discard warning and returns nil.
-func (DiscardPublisher) Publish(_ context.Context, topic string, _ []byte) error {
-	slog.Warn("outbox: discard publisher dropping message", slog.String("topic", topic))
+// Publish logs a discard warning, increments the counter, and returns nil.
+func (d *DiscardPublisher) Publish(_ context.Context, topic string, _ []byte) error {
+	d.counter.Add(1)
+	l := d.Logger
+	if l == nil {
+		l = slog.Default()
+	}
+	l.Warn("outbox: discard publisher dropping message", slog.String("topic", topic))
 	return nil
 }
 
-var _ Publisher = DiscardPublisher{}
+// DiscardCount returns the total number of messages discarded.
+func (d *DiscardPublisher) DiscardCount() uint64 {
+	return d.counter.Load()
+}
+
+var _ Publisher = (*DiscardPublisher)(nil)
 
 // Noop implements cell.Nooper. CheckNotNoop rejects DiscardPublisher in durable mode.
-func (DiscardPublisher) Noop() bool { return true }
+func (*DiscardPublisher) Noop() bool { return true }
 
 // isDiscardPublisher reports whether p is the explicit discard sink.
 // Unexported: concrete-type detection should not leak into the public API.
 // Cell/runtime code that needs discard awareness should use cell metadata
 // or DurabilityMode instead of type-switching on Publisher implementations.
 func isDiscardPublisher(p Publisher) bool {
-	switch p.(type) {
-	case DiscardPublisher, *DiscardPublisher:
-		return true
-	default:
-		return false
-	}
+	_, ok := p.(*DiscardPublisher)
+	return ok
 }
 
 // ---------------------------------------------------------------------------
@@ -351,9 +364,12 @@ func (d Disposition) String() string {
 	}
 }
 
-// Deprecated: Use idempotency.Receipt directly. This alias will be removed
-// after all callers migrate (target: Sprint N+2, per project deprecation policy).
-// Canonical ownership now lives in kernel/idempotency.
+// Receipt is the canonical import path for consumer Receipt. Callers should use
+// outbox.Receipt rather than importing kernel/idempotency directly.
+//
+// Implementation note: this is a type alias to idempotency.Receipt so existing
+// code compiles during migration. Once all callers use outbox.Receipt, the alias
+// may be replaced with a standalone interface in a future version.
 type Receipt = idempotency.Receipt
 
 // HandleResult carries the business handler's processing outcome.

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -857,11 +857,13 @@ func TestDiscardPublisher_ZeroValue_Safe(t *testing.T) {
 func TestDiscardPublisher_TypedNil_NoPanic(t *testing.T) {
 	// Typed nil: interface is non-nil but underlying pointer is nil.
 	// Must not panic — this is the key regression from value→pointer migration.
-	var p *DiscardPublisher // typed nil
+	var p *DiscardPublisher //nolint:staticcheck // SA4023: typed nil used to verify interface-nil semantics below
 	var pub Publisher = p   // interface non-nil at Go level
 
 	// Go interface nil semantics: pub != nil because it carries type info.
-	if pub == nil {
+	// The comparison is tautologically false at compile time; staticcheck
+	// (SA4023) flags it but it documents the invariant the test guards.
+	if pub == nil { //nolint:staticcheck // SA4023: intentional — asserts typed-nil wrapped in interface is not == nil
 		t.Fatal("typed nil wrapped in interface should not be == nil")
 	}
 	assert.NotPanics(t, func() {

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -853,3 +853,19 @@ func TestDiscardPublisher_ZeroValue_Safe(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), dp.DiscardCount())
 }
+
+func TestDiscardPublisher_TypedNil_NoPanic(t *testing.T) {
+	// Typed nil: interface is non-nil but underlying pointer is nil.
+	// Must not panic — this is the key regression from value→pointer migration.
+	var p *DiscardPublisher // typed nil
+	var pub Publisher = p   // interface non-nil at Go level
+
+	// Go interface nil semantics: pub != nil because it carries type info.
+	if pub == nil {
+		t.Fatal("typed nil wrapped in interface should not be == nil")
+	}
+	assert.NotPanics(t, func() {
+		_ = pub.Publish(context.Background(), "test.topic", []byte(`{}`))
+	}, "Publish on typed nil must not panic")
+	assert.Equal(t, uint64(0), p.DiscardCount(), "DiscardCount on nil returns 0")
+}

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -1,9 +1,11 @@
 package outbox
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -74,11 +76,11 @@ func TestNoopWriter_Noop(t *testing.T) {
 }
 
 func TestDiscardPublisher_Noop(t *testing.T) {
-	assert.True(t, DiscardPublisher{}.Noop())
+	assert.True(t, (&DiscardPublisher{}).Noop())
 }
 
 func TestDiscardPublisher_IsExplicitDiscardSink(t *testing.T) {
-	var publisher Publisher = DiscardPublisher{}
+	var publisher Publisher = &DiscardPublisher{}
 	err := publisher.Publish(context.Background(), "orders.created", []byte(`{"ok":true}`))
 	assert.NoError(t, err)
 	assert.True(t, isDiscardPublisher(publisher))
@@ -820,4 +822,34 @@ func TestEntry_Validate_MetadataAtExactBoundary(t *testing.T) {
 	exactVal := strings.Repeat("v", MaxMetadataValueLen)
 	e3.Metadata = map[string]string{"k": exactVal}
 	assert.NoError(t, e3.Validate(), "value at exactly MaxMetadataValueLen should be valid")
+}
+
+// --- DiscardPublisher Logger + Counter Tests (DISCARD-OBS-01) ---
+
+func TestDiscardPublisher_Logger_Injection(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	logger := slog.New(handler)
+
+	dp := &DiscardPublisher{Logger: logger}
+	err := dp.Publish(context.Background(), "test.topic", []byte(`{}`))
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "test.topic", "injected logger must capture discard warning")
+}
+
+func TestDiscardPublisher_Counter_Increments(t *testing.T) {
+	dp := &DiscardPublisher{}
+	for range 3 {
+		err := dp.Publish(context.Background(), "t", []byte(`{}`))
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, uint64(3), dp.DiscardCount())
+}
+
+func TestDiscardPublisher_ZeroValue_Safe(t *testing.T) {
+	// Zero-value DiscardPublisher{} must work without panic.
+	var dp DiscardPublisher
+	err := dp.Publish(context.Background(), "t", []byte(`{}`))
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), dp.DiscardCount())
 }

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -303,6 +303,7 @@ func testMultipleSubscribers(t *testing.T, _ Features, constructor PubSubConstru
 // testCompetingConsumers verifies that when BroadcastSubscribe=false (e.g.,
 // RabbitMQ with a shared queue), a single message is delivered to exactly one
 // of multiple subscribers — not duplicated to all.
+// Features is unused here; the signature matches the test-registration interface.
 func testCompetingConsumers(t *testing.T, _ Features, constructor PubSubConstructor) {
 	pub, sub := constructor(t)
 	ctx := context.Background()
@@ -328,6 +329,10 @@ func testCompetingConsumers(t *testing.T, _ Features, constructor PubSubConstruc
 		}()
 	}
 
+	// One waitForSubscription is sufficient for shared-queue brokers: both
+	// competing subscribers consume from the same queue, and topology is
+	// created once. The sleep fallback covers in-memory subscribers where
+	// both goroutines need time to register.
 	waitForSubscription(t, ctx, sub, topic, "")
 
 	// Publish one message.
@@ -338,7 +343,10 @@ func testCompetingConsumers(t *testing.T, _ Features, constructor PubSubConstruc
 		return totalReceived.Load() >= 1
 	}, defaultTimeout, 10*time.Millisecond, "at least one subscriber should receive the message")
 
-	// Brief window for any duplicate delivery.
+	// Brief window for any duplicate delivery to surface. 200ms is sufficient
+	// for shared-queue brokers (RabbitMQ, in-memory) where redelivery, if any,
+	// happens within single-digit milliseconds. This is a pragmatic bound, not
+	// a guarantee — a flaky failure here indicates a real duplicate delivery bug.
 	time.Sleep(200 * time.Millisecond)
 
 	got := totalReceived.Load()

--- a/kernel/outbox/outboxtest/helpers_test.go
+++ b/kernel/outbox/outboxtest/helpers_test.go
@@ -184,6 +184,10 @@ func TestWaitForSubscription_UsesInitializerWhenAvailable(t *testing.T) {
 	}
 }
 
+// subscribeInitThreshold is 80% of subscribeInitDelay (50ms). Used as the
+// lower bound in sleep-fallback assertions to tolerate scheduling jitter.
+const subscribeInitThreshold = 40 * time.Millisecond
+
 func TestWaitForSubscription_FallsBackToSleep(t *testing.T) {
 	// fakePubSub does NOT implement SubscriberInitializer.
 	sub := &fakePubSub{}
@@ -194,7 +198,7 @@ func TestWaitForSubscription_FallsBackToSleep(t *testing.T) {
 	elapsed := time.Since(start)
 
 	// Should have slept at least subscribeInitDelay (50ms).
-	if elapsed < 40*time.Millisecond {
+	if elapsed < subscribeInitThreshold {
 		t.Fatalf("expected sleep fallback (~50ms), but returned in %v", elapsed)
 	}
 }
@@ -217,7 +221,7 @@ func TestWaitForSubscription_MiddlewareWrappedNonInitializer_FallsBack(t *testin
 	elapsed := time.Since(start)
 
 	// Must fall back to sleep, NOT return instantly.
-	if elapsed < 40*time.Millisecond {
+	if elapsed < subscribeInitThreshold {
 		t.Fatalf("middleware-wrapped non-initializer must fall back to sleep (~50ms), but returned in %v", elapsed)
 	}
 }

--- a/kernel/outbox/outboxtest/mock_receipt.go
+++ b/kernel/outbox/outboxtest/mock_receipt.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"sync/atomic"
 
-	"github.com/ghbvf/gocell/kernel/idempotency"
+	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
 // Compile-time check.
-var _ idempotency.Receipt = (*MockReceipt)(nil)
+var _ outbox.Receipt = (*MockReceipt)(nil)
 
 // MockReceipt records Commit/Release calls for assertion in tests.
 // Thread-safe via atomic.Bool.

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/google/uuid"
@@ -398,7 +397,7 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 
 // commitReceipt calls Receipt.Commit with a detached 5s-timeout context,
 // consistent with the RabbitMQ subscriber path.
-func commitReceipt(ctx context.Context, r idempotency.Receipt, topic, entryID string) {
+func commitReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string) {
 	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	if err := r.Commit(rctx); err != nil {
@@ -410,7 +409,7 @@ func commitReceipt(ctx context.Context, r idempotency.Receipt, topic, entryID st
 }
 
 // releaseReceipt calls Receipt.Release with a detached 5s-timeout context.
-func releaseReceipt(ctx context.Context, r idempotency.Receipt, topic, entryID string) {
+func releaseReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string) {
 	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	if err := r.Release(rctx); err != nil {


### PR DESCRIPTION
## Summary

- **PR#145 review findings A-K**: `NewConsumerBase` panic→error, goroutine leak fix, conformance doc, sentinel comment, ClaimPolicy zero-value doc
- **DISCARD-OBS-01**: DiscardPublisher Logger injection + atomic counter (`DiscardCount()`)
- **OUTBOX-RECEIPT-01**: `idempotency.Receipt` → `outbox.Receipt` migration (6 files)
- **POOLSTATS-JSON-01**: camelCase json tags for 3 PoolStats structs (postgres/redis/rabbitmq)

## Root Cause A: NewConsumerBase panic → error

```go
// Before
func NewConsumerBase(claimer Claimer, cfg ConsumerBaseConfig) *ConsumerBase

// After
func NewConsumerBase(claimer Claimer, cfg ConsumerBaseConfig) (*ConsumerBase, error)
```

ref: watermill-amqp `NewSubscriber`, nats-go `Connect`, sarama `NewConsumerGroup` — constructors return error, never panic

## Changes

| File | Change | Finding |
|------|--------|---------|
| `consumer_base.go` | `(*ConsumerBase, error)` + dynamic error msg + sentinel comment | A, C, J, K |
| `subscriber.go` | Caller adaptation (implicit via test) | A |
| `rabbitmq_test.go` | 3 new tests + goroutine leak fix + 28 call sites adapted | A, E, F |
| `outbox.go` | DiscardPublisher Logger/counter + Receipt comment | DISCARD-OBS, RECEIPT |
| `outbox_test.go` | 3 DiscardPublisher tests | DISCARD-OBS |
| `conformance.go` | waitForSubscription doc + Features doc + sleep doc | B, G, I |
| `helpers_test.go` | Extract `subscribeInitThreshold` constant | H |
| 6 files | `idempotency.Receipt` → `outbox.Receipt` | RECEIPT-01 |
| 3 files | PoolStats json tags (21 fields) | POOLSTATS-JSON |
| 4 cell files | `&outbox.DiscardPublisher{}` pointer receiver | DISCARD-OBS |

## Test plan

- [x] `go test ./adapters/rabbitmq/...` — 3 new + 28 adapted tests pass
- [x] `go test ./kernel/outbox/...` — 3 new DiscardPublisher tests pass
- [x] `go test ./adapters/postgres/... ./adapters/redis/... ./runtime/eventbus/...` — pass
- [x] `go test ./cells/...` — pass (DiscardPublisher pointer receiver)
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)