### PR TITLE
fix(rabbitmq): isolate Connection per conformance subtest (#230)

### DIFF
--- a/adapters/rabbitmq/conformance_test.go
+++ b/adapters/rabbitmq/conformance_test.go
@@ -53,13 +53,14 @@ func (p *envelopingPublisher) Publish(ctx context.Context, topic string, payload
 //   - BlockingSubscribe:  true  — Subscribe blocks until ctx cancelled.
 //   - BroadcastSubscribe: false — same queue = competing consumers, not fan-out.
 func TestRabbitMQ_Conformance(t *testing.T) {
-	// A single Connection is shared across all sub-tests. Each sub-test creates
-	// its own Subscriber (with independent channels and lifecycle). This is safe
-	// because Subscriber.Close only closes that subscriber's tracked channels,
-	// not the shared Connection. Topic names are unique per test (TestTopic),
-	// so exchange/queue declarations do not collide across sub-tests.
-	conn, cleanup := startRabbitMQ(t)
-	t.Cleanup(cleanup)
+	// One testcontainer is shared (it is expensive to start) but each subtest
+	// receives its own independent Connection. This prevents a prior subtest's
+	// teardown (e.g. SubscribeBlocksUntilCancel) from leaving the shared
+	// Connection in a reconnecting state that causes the next subtest's
+	// InitializeSubscription → acquireChannel call to fail with
+	// ERR_ADAPTER_AMQP_CONNECT "connection not available".
+	brokerURL, containerCleanup := startRabbitMQBroker(t)
+	t.Cleanup(containerCleanup)
 
 	outboxtest.TestPubSub(t, outboxtest.Features{
 		GuaranteedOrder:    true,
@@ -69,6 +70,10 @@ func TestRabbitMQ_Conformance(t *testing.T) {
 		BlockingSubscribe:  true,
 		BroadcastSubscribe: false,
 	}, func(t *testing.T) (outbox.Publisher, outbox.Subscriber) {
+		// Fresh Connection per subtest: isolates connection state so one
+		// subtest's teardown cannot bleed into the next.
+		conn := newIntegrationConnection(t, brokerURL)
+
 		pub := NewPublisher(conn)
 		sub := NewSubscriber(conn, SubscriberConfig{
 			DLXExchange:     "test.dlx",

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -60,6 +60,40 @@ func startRabbitMQ(t *testing.T) (*Connection, func()) {
 	return conn, cleanup
 }
 
+// startRabbitMQBroker starts a testcontainers RabbitMQ instance and returns the
+// broker AMQP URL and a cleanup function. Unlike startRabbitMQ it does NOT create
+// a Connection, allowing callers to create independent Connections per-subtest
+// while sharing the (expensive) container lifecycle.
+func startRabbitMQBroker(t *testing.T) (amqpURL string, cleanup func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
+	require.NoError(t, err, "start rabbitmq container")
+
+	u, err := container.AmqpURL(ctx)
+	require.NoError(t, err, "get rabbitmq amqp url")
+
+	return u, func() { _ = container.Terminate(ctx) }
+}
+
+// newIntegrationConnection creates a fresh Connection pointing at the given
+// broker URL. The connection is registered for cleanup with t.Cleanup.
+// Use this when a per-subtest Connection is needed against a shared container.
+func newIntegrationConnection(t *testing.T, amqpURL string) *Connection {
+	t.Helper()
+	conn, err := NewConnection(Config{
+		URL:                 amqpURL,
+		ChannelPoolSize:     5,
+		ConfirmTimeout:      10 * time.Second,
+		ReconnectMaxBackoff: 5 * time.Second,
+		ReconnectBaseDelay:  500 * time.Millisecond,
+	})
+	require.NoError(t, err, "create per-subtest rabbitmq connection")
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
 type queueInspector interface {
 	QueueInspect(name string) (amqp.Queue, error)
 }


### PR DESCRIPTION
## Problem

`TestRabbitMQ_Conformance` flaked intermittently in CI with:

```
conformance.go:686: InitializeSubscription(...): rabbitmq: acquire channel for init: [ERR_ADAPTER_AMQP_CONNECT] rabbitmq: connection not available
conformance.go:734: InitializeSubscription(...): rabbitmq: acquire channel for init: [ERR_ADAPTER_AMQP_CONNECT] rabbitmq: connection not available
```

Subtests affected: `ConcurrentPublish`, `SubscriberWithMiddleware`.

## Root cause

A single `*Connection` was shared across all subtests. A prior subtest's teardown (notably `SubscribeBlocksUntilCancel`, which cancels the subscriber context and calls `sub.Close()`) could leave the shared Connection briefly in `StateDisconnected` (reconnecting). The next subtest's `InitializeSubscription → AcquireChannel` hits the fail-fast guard (`conn.IsClosed()`) and returns `ERR_ADAPTER_AMQP_CONNECT "connection not available"`. Race between teardown reconnect timing and the next subtest's setup makes it non-deterministic.

## Fix

- Add `startRabbitMQBroker(t)`: starts the testcontainer, returns `(amqpURL string, cleanup func())` only — no Connection created. The expensive container is still shared.
- Add `newIntegrationConnection(t, amqpURL string)`: dials a fresh `*Connection`, registers `t.Cleanup(conn.Close)` automatically.
- Refactor `TestRabbitMQ_Conformance`: call `startRabbitMQBroker` once, then inside the `outboxtest.TestPubSub` constructor closure call `newIntegrationConnection` per subtest.

Each subtest now owns its Connection; teardown of one cannot bleed into the next. No sleeps or retries added — isolation is the correct fix.

## Verification

- `go build ./...` — clean
- `go vet ./adapters/rabbitmq/...` — clean
- `gofmt -l` — empty (no formatting issues)
- `-count=3` locally: all 23 subtests passed across all 3 runs, including the two previously flaking subtests

Unblocks future PRs from hitting the same flake (e.g. PR #147 needed a rerun due to this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)