### PR TITLE
ci: parallelize jobs + SonarCloud split + share rabbitmq testcontainer (#232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,60 @@ jobs:
           fi
           echo "PASS: no internal import violations"
 
+      # Kernel coverage gate: parse the coverage profile produced by Test above
+      # instead of re-running `go test -cover ./kernel/...` (which took ~4s and
+      # duplicated work already captured by -coverpkg=./...).
+      - name: Kernel coverage gate
+        run: |
+          awk '
+            NR == 1 { next }
+            index($1, "github.com/ghbvf/gocell/kernel/") != 1 { next }
+            index($1, "outboxtest") > 0 || index($1, "celltest") > 0 { next }
+            {
+              split($1, a, ":")
+              file = a[1]
+              n = split(file, parts, "/")
+              pkg = parts[1]
+              for (i = 2; i < n; i++) pkg = pkg "/" parts[i]
+              total[pkg] += $2
+              if ($3 > 0) covered[pkg] += $2
+            }
+            END {
+              fail = 0
+              for (pkg in total) {
+                pct = (covered[pkg] * 100.0) / total[pkg]
+                printf "%s: %.1f%%\n", pkg, pct
+                if (pct < 90) {
+                  printf "FAIL: %s coverage %.1f%% < 90%%\n", pkg, pct
+                  fail = 1
+                }
+              }
+              exit fail
+            }
+          ' coverage.out
+          echo "PASS: kernel coverage >= 90%"
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-profile
+          path: coverage.out
+          retention-days: 1
+
+  sonarcloud:
+    runs-on: ubuntu-latest
+    needs: build-test
+    # Split from build-test so the scan does not block integration-test or
+    # other gates; build-test still produces the coverage profile this job
+    # consumes via the coverage-profile artifact.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download coverage profile
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: coverage-profile
+
       - name: Cache SonarQube packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -67,34 +121,16 @@ jobs:
         with:
           projectBaseDir: .
 
-      - name: Kernel coverage gate
-        run: |
-          go test -cover ./kernel/... 2>&1 | tee /tmp/kernel-cov.txt
-          awk '
-            /coverage: \[no statements\]/ { next }
-            /outboxtest/ { next }
-            /celltest/ { next }
-            /coverage:/ {
-              cov = $0
-              sub(/^.*coverage: /, "", cov)
-              sub(/% of statements.*$/, "", cov)
-              if (cov == $0) {
-                print "FAIL: could not parse coverage line: " $0;
-                exit 1
-              }
-              if (cov + 0 < 90) {
-                print "FAIL: " $2 " coverage " cov "% < 90%";
-                exit 1
-              }
-            }
-          ' /tmp/kernel-cov.txt
-          echo "PASS: kernel coverage >= 90%"
-
   integration-test:
     runs-on: ubuntu-latest
-    needs: build-test
-    # No static services: testcontainers manages containers dynamically,
-    # avoiding port conflicts with host-bound services.
+    # No `needs: build-test` — integration-test is independent (its own
+    # checkout + go build inside `go test`). Running in parallel with
+    # build-test cuts ~2 min of wall time. Cost: a CI minute wasted on
+    # integration when unit tests break, which at current PR frequency is
+    # a worthwhile trade.
+    #
+    # testcontainers manages containers dynamically (no static services)
+    # to avoid port conflicts with host-bound services.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,37 +53,32 @@ jobs:
           fi
           echo "PASS: no internal import violations"
 
-      # Kernel coverage gate: parse the coverage profile produced by Test above
-      # instead of re-running `go test -cover ./kernel/...` (which took ~4s and
-      # duplicated work already captured by -coverpkg=./...).
+      # NOTE: Kernel coverage gate re-runs `go test -cover ./kernel/...`
+      # deliberately — it is not a duplicate of the Test step. The Test step
+      # uses `-coverpkg=./...` whose merged profile loses per-package fidelity
+      # (cells/adapters test binaries dilute kernel counts). The gate needs
+      # in-package kernel coverage, which requires a standalone run.
       - name: Kernel coverage gate
         run: |
+          go test -cover ./kernel/... 2>&1 | tee /tmp/kernel-cov.txt
           awk '
-            NR == 1 { next }
-            index($1, "github.com/ghbvf/gocell/kernel/") != 1 { next }
-            index($1, "outboxtest") > 0 || index($1, "celltest") > 0 { next }
-            {
-              split($1, a, ":")
-              file = a[1]
-              n = split(file, parts, "/")
-              pkg = parts[1]
-              for (i = 2; i < n; i++) pkg = pkg "/" parts[i]
-              total[pkg] += $2
-              if ($3 > 0) covered[pkg] += $2
-            }
-            END {
-              fail = 0
-              for (pkg in total) {
-                pct = (covered[pkg] * 100.0) / total[pkg]
-                printf "%s: %.1f%%\n", pkg, pct
-                if (pct < 90) {
-                  printf "FAIL: %s coverage %.1f%% < 90%%\n", pkg, pct
-                  fail = 1
-                }
+            /coverage: \[no statements\]/ { next }
+            /outboxtest/ { next }
+            /celltest/ { next }
+            /coverage:/ {
+              cov = $0
+              sub(/^.*coverage: /, "", cov)
+              sub(/% of statements.*$/, "", cov)
+              if (cov == $0) {
+                print "FAIL: could not parse coverage line: " $0;
+                exit 1
               }
-              exit fail
+              if (cov + 0 < 90) {
+                print "FAIL: " $2 " coverage " cov "% < 90%";
+                exit 1
+              }
             }
-          ' coverage.out
+          ' /tmp/kernel-cov.txt
           echo "PASS: kernel coverage >= 90%"
 
       - name: Upload coverage profile

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -51,30 +51,34 @@ func startRabbitMQWithContainer(t *testing.T, config Config) (*Connection, *tcra
 	return conn, container, cleanup
 }
 
-// startRabbitMQ is a convenience wrapper that discards the container reference.
+// startRabbitMQ returns a per-test Connection backed by the package-wide
+// shared broker (see testmain_integration_test.go). Only the Connection is
+// torn down via t.Cleanup; the container lives until TestMain exits.
+//
+// Tests that need an isolated broker (because they mutate broker-wide state
+// with rabbitmqctl or container.Exec) must call startRabbitMQWithContainer
+// instead.
 func startRabbitMQ(t *testing.T) (*Connection, func()) {
-	conn, _, cleanup := startRabbitMQWithContainer(t, Config{
+	t.Helper()
+	url := sharedBrokerURL(t)
+	conn, err := NewConnection(Config{
+		URL:                 url,
+		ChannelPoolSize:     5,
+		ConfirmTimeout:      10 * time.Second,
 		ReconnectMaxBackoff: 5 * time.Second,
 		ReconnectBaseDelay:  500 * time.Millisecond,
 	})
-	return conn, cleanup
+	require.NoError(t, err, "create connection against shared rabbitmq broker")
+	return conn, func() { _ = conn.Close() }
 }
 
-// startRabbitMQBroker starts a testcontainers RabbitMQ instance and returns the
-// broker AMQP URL and a cleanup function. Unlike startRabbitMQ it does NOT create
-// a Connection, allowing callers to create independent Connections per-subtest
-// while sharing the (expensive) container lifecycle.
+// startRabbitMQBroker returns the package-wide shared broker AMQP URL.
+// The cleanup function is a no-op: the shared container is torn down in
+// TestMain. Kept as a named helper so callers (conformance_test.go) can
+// pass the URL to per-subtest Connections via newIntegrationConnection.
 func startRabbitMQBroker(t *testing.T) (amqpURL string, cleanup func()) {
 	t.Helper()
-	ctx := context.Background()
-
-	container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
-	require.NoError(t, err, "start rabbitmq container")
-
-	u, err := container.AmqpURL(ctx)
-	require.NoError(t, err, "get rabbitmq amqp url")
-
-	return u, func() { _ = container.Terminate(ctx) }
+	return sharedBrokerURL(t), func() {}
 }
 
 // newIntegrationConnection creates a fresh Connection pointing at the given

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -19,18 +19,24 @@ import (
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
-// startRabbitMQWithContainer launches a testcontainers RabbitMQ instance and
-// returns the Connection, the container (for Exec/Stop operations), and a
-// cleanup function.
-func startRabbitMQWithContainer(t *testing.T, config Config) (*Connection, *tcrabbitmq.RabbitMQContainer, func()) {
+// startRabbitMQDedicatedContainer launches a NEW testcontainers RabbitMQ
+// instance used by a single test that must not share broker state with any
+// other test. Examples: rabbitmqctl close_all_connections, container.Exec,
+// container.Stop/Start — any operation that mutates broker-wide state.
+//
+// The returned cleanup terminates both the Connection and the container.
+// Tests that do not mutate broker state should use startRabbitMQ (shared
+// broker) — this helper starts its own container on every call, which is
+// ~5-7s more expensive.
+func startRabbitMQDedicatedContainer(t *testing.T, config Config) (*Connection, *tcrabbitmq.RabbitMQContainer, func()) {
 	t.Helper()
 	ctx := context.Background()
 
 	container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
-	require.NoError(t, err, "start rabbitmq container")
+	require.NoError(t, err, "start dedicated rabbitmq container")
 
 	amqpURL, err := container.AmqpURL(ctx)
-	require.NoError(t, err, "get rabbitmq amqp url")
+	require.NoError(t, err, "get dedicated rabbitmq amqp url")
 
 	config.URL = amqpURL
 	if config.ChannelPoolSize == 0 {
@@ -41,11 +47,13 @@ func startRabbitMQWithContainer(t *testing.T, config Config) (*Connection, *tcra
 	}
 
 	conn, err := NewConnection(config)
-	require.NoError(t, err, "create rabbitmq connection")
+	require.NoError(t, err, "create dedicated rabbitmq connection")
 
 	cleanup := func() {
 		_ = conn.Close()
-		_ = container.Terminate(ctx)
+		if err := container.Terminate(ctx); err != nil {
+			t.Logf("rabbitmq: dedicated container terminate failed: %v", err)
+		}
 	}
 
 	return conn, container, cleanup
@@ -53,11 +61,14 @@ func startRabbitMQWithContainer(t *testing.T, config Config) (*Connection, *tcra
 
 // startRabbitMQ returns a per-test Connection backed by the package-wide
 // shared broker (see testmain_integration_test.go). Only the Connection is
-// torn down via t.Cleanup; the container lives until TestMain exits.
+// torn down via the returned cleanup; the container lives until TestMain
+// exits.
 //
-// Tests that need an isolated broker (because they mutate broker-wide state
-// with rabbitmqctl or container.Exec) must call startRabbitMQWithContainer
-// instead.
+// Contract: callers MUST NOT mutate broker-wide state. That means no
+// rabbitmqctl, no container.Exec, no container.Stop/Start, no policy
+// changes that outlive the test. All exchange/queue/topic names must be
+// unique per test (use `test.<testname>.*` or TestTopic(t)). Tests that
+// need broker-level isolation must call startRabbitMQDedicatedContainer.
 func startRabbitMQ(t *testing.T) (*Connection, func()) {
 	t.Helper()
 	url := sharedBrokerURL(t)
@@ -72,10 +83,15 @@ func startRabbitMQ(t *testing.T) (*Connection, func()) {
 	return conn, func() { _ = conn.Close() }
 }
 
-// startRabbitMQBroker returns the package-wide shared broker AMQP URL.
-// The cleanup function is a no-op: the shared container is torn down in
-// TestMain. Kept as a named helper so callers (conformance_test.go) can
-// pass the URL to per-subtest Connections via newIntegrationConnection.
+// startRabbitMQBroker returns the package-wide shared broker AMQP URL
+// (see sharedBrokerURL in testmain_integration_test.go). The returned
+// cleanup is a no-op: the shared container is torn down in TestMain.
+//
+// Contract: same as startRabbitMQ — callers create their own Connections
+// against this URL (typically via newIntegrationConnection for the
+// per-subtest pattern used by conformance_test.go) and must not mutate
+// broker-wide state. For broker-level isolation, use
+// startRabbitMQDedicatedContainer instead.
 func startRabbitMQBroker(t *testing.T) (amqpURL string, cleanup func()) {
 	t.Helper()
 	return sharedBrokerURL(t), func() {}
@@ -365,7 +381,7 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 // Uses rabbitmqctl close_all_connections (not container stop/start) to avoid
 // port remapping issues — the broker stays on the same address.
 func TestIntegration_ConnectionRecovery(t *testing.T) {
-	conn, container, cleanup := startRabbitMQWithContainer(t, Config{
+	conn, container, cleanup := startRabbitMQDedicatedContainer(t, Config{
 		ReconnectBaseDelay:  200 * time.Millisecond,
 		ReconnectMaxBackoff: 2 * time.Second,
 	})

--- a/adapters/rabbitmq/testmain_integration_test.go
+++ b/adapters/rabbitmq/testmain_integration_test.go
@@ -8,8 +8,12 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/docker/go-connections/nat"
+	"github.com/testcontainers/testcontainers-go"
 	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/ghbvf/gocell/tests/testutil"
 )
@@ -41,7 +45,18 @@ func sharedBrokerURL(t *testing.T) string {
 	t.Helper()
 	sharedBrokerOnce.Do(func() {
 		ctx := context.Background()
-		container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
+		// tcrabbitmq.Run's default wait strategy only watches for the
+		// "Server startup complete" log pattern. On Docker Desktop for Mac
+		// the port forwarder can lag behind that signal, causing AmqpURL /
+		// PortEndpoint to return `port "5672/tcp" not found` for a brief
+		// window. Add an explicit port-listening wait so the container is
+		// not considered ready until the mapped port is actually reachable.
+		container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage,
+			testcontainers.WithAdditionalWaitStrategy(
+				wait.ForListeningPort(nat.Port(tcrabbitmq.DefaultAMQPPort)).
+					WithStartupTimeout(30*time.Second),
+			),
+		)
 		if err != nil {
 			sharedBrokerInitErr = fmt.Errorf("start shared rabbitmq container: %w", err)
 			return

--- a/adapters/rabbitmq/testmain_integration_test.go
+++ b/adapters/rabbitmq/testmain_integration_test.go
@@ -5,6 +5,7 @@ package rabbitmq
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"sync"
 	"testing"
@@ -30,7 +31,7 @@ import (
 //
 // Tests with broker-wide side effects (TestIntegration_ConnectionRecovery
 // calls rabbitmqctl close_all_connections) MUST continue using
-// startRabbitMQWithContainer to get a dedicated container.
+// startRabbitMQDedicatedContainer to get their own container.
 var (
 	sharedBrokerOnce     sync.Once
 	sharedBrokerInitErr  error
@@ -63,12 +64,22 @@ func sharedBrokerURL(t *testing.T) string {
 		}
 		u, err := container.AmqpURL(ctx)
 		if err != nil {
-			_ = container.Terminate(ctx)
+			if termErr := container.Terminate(ctx); termErr != nil {
+				log.Printf("rabbitmq: shared broker terminate after AmqpURL failure: %v", termErr)
+			}
 			sharedBrokerInitErr = fmt.Errorf("get shared rabbitmq url: %w", err)
 			return
 		}
 		sharedBrokerURLValue = u
-		sharedBrokerShutdown = func() { _ = container.Terminate(ctx) }
+		sharedBrokerShutdown = func() {
+			if err := container.Terminate(ctx); err != nil {
+				// TestMain runs outside any test context, so *testing.T is
+				// unavailable. Emit to stderr so CI log scrapers pick up
+				// cleanup failures (Ryuk fallback handles the actual reap,
+				// but a failure here usually hints at Docker-daemon trouble).
+				log.Printf("rabbitmq: shared broker terminate failed: %v", err)
+			}
+		}
 	})
 	if sharedBrokerInitErr != nil {
 		t.Fatalf("shared broker unavailable: %v", sharedBrokerInitErr)

--- a/adapters/rabbitmq/testmain_integration_test.go
+++ b/adapters/rabbitmq/testmain_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
+
+	"github.com/ghbvf/gocell/tests/testutil"
+)
+
+// Shared broker lifecycle for the rabbitmq integration package.
+//
+// All tests that do NOT mutate broker-wide state (rabbitmqctl, container
+// restart) reuse one testcontainers RabbitMQ via sharedBrokerURL. The
+// container is started lazily on first use and terminated from TestMain
+// after the whole package finishes, NOT via t.Cleanup.
+//
+// Previously, each test function that called startRabbitMQ paid a fresh
+// container startup (~5-7s each × 5 callers = 25-35s wall time).
+//
+// Tests with broker-wide side effects (TestIntegration_ConnectionRecovery
+// calls rabbitmqctl close_all_connections) MUST continue using
+// startRabbitMQWithContainer to get a dedicated container.
+var (
+	sharedBrokerOnce     sync.Once
+	sharedBrokerInitErr  error
+	sharedBrokerURLValue string
+	sharedBrokerShutdown func()
+)
+
+// sharedBrokerURL starts (once) and returns the amqp URL of the package-
+// wide shared broker. Tests use it with newIntegrationConnection to get a
+// per-test Connection with its own cleanup.
+func sharedBrokerURL(t *testing.T) string {
+	t.Helper()
+	sharedBrokerOnce.Do(func() {
+		ctx := context.Background()
+		container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
+		if err != nil {
+			sharedBrokerInitErr = fmt.Errorf("start shared rabbitmq container: %w", err)
+			return
+		}
+		u, err := container.AmqpURL(ctx)
+		if err != nil {
+			_ = container.Terminate(ctx)
+			sharedBrokerInitErr = fmt.Errorf("get shared rabbitmq url: %w", err)
+			return
+		}
+		sharedBrokerURLValue = u
+		sharedBrokerShutdown = func() { _ = container.Terminate(ctx) }
+	})
+	if sharedBrokerInitErr != nil {
+		t.Fatalf("shared broker unavailable: %v", sharedBrokerInitErr)
+	}
+	return sharedBrokerURLValue
+}
+
+// TestMain owns shared-broker teardown. It runs exactly once per test
+// binary invocation, after all tests in the package have completed.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedBrokerShutdown != nil {
+		sharedBrokerShutdown()
+	}
+	os.Exit(code)
+}

--- a/go.mod
+++ b/go.mod
@@ -14,16 +14,17 @@ require (
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/pressly/goose/v3 v3.27.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/contrib/propagators/b3 v1.41.0
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0
 	go.opentelemetry.io/otel/sdk v1.41.0
 	go.opentelemetry.io/otel/trace v1.41.0
-	go.opentelemetry.io/contrib/propagators/b3 v1.41.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.49.0
 	golang.org/x/oauth2 v0.36.0
@@ -49,7 +50,6 @@ require (
 	github.com/mdelapenya/tlscert v0.2.0 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
@@ -79,7 +79,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/go-connections v0.6.0
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4


### PR DESCRIPTION
## Summary

Three CI wall-time optimizations, no test coverage lost:

1. **integration-test no longer \`needs: build-test\`** — the two jobs are independent; parallelizing cuts ~2 min wall time per run. Cost: one wasted CI minute on integration-test when unit tests break.

2. **SonarQube scan extracted to its own \`sonarcloud\` job** — consumes build-test's coverage profile via artifact. Frees build-test from the ~50s external API wait; sonarcloud runs in parallel with integration-test.

3. **Shared rabbitmq testcontainer for integration tests** — each test function that called \`startRabbitMQ(t)\` previously spun up its own container (6 containers per run). New \`TestMain\` owns one package-wide broker via \`sync.Once\`; tests reuse it. Tests that need an isolated broker (\`TestIntegration_ConnectionRecovery\`) keep using \`startRabbitMQWithContainer\`. Local measurement: rabbitmq package drops from ~90s to ~26s (-65s).

Dropped from original plan: ~~merge kernel coverage gate into Test step~~ — the \`go test -coverpkg=./... ./...\` merged profile dilutes per-package kernel coverage (cells/adapters test binaries lower the numbers), so the standalone \`go test -cover ./kernel/...\` run stays. Added a comment noting it's intentional.

## Projected impact

Current wall time: ~280s (build-test 166s serial → integration 114s)
After: ~170s wall time (build-test 166s ‖ integration ~50s ‖ sonarcloud post-build 55s)

~40% wall-time reduction. \`-race\` stays; golangci-lint stays; all gates preserved.

## Test plan

- [ ] build-test passes (kernel coverage gate still blocks < 90%)
- [ ] sonarcloud job runs in parallel and ingests the artifact coverage profile
- [ ] integration-test passes in parallel with build-test
- [ ] rabbitmq package measurably faster (~26s vs ~90s)
- [ ] Total wall time drops vs previous runs on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)