### PR TITLE
feat(kernel): hook lifecycle timeout + observer + outbox metadata DX

### DIFF
--- a/adapters/prometheus/hook_observer.go
+++ b/adapters/prometheus/hook_observer.go
@@ -47,6 +47,9 @@ func (c *HookObserverConfig) defaults() {
 //	{namespace}_cell_hook_duration_seconds{cell_id,hook}      — histogram
 //
 // Cardinality budget: (number of cells) × 4 hooks × 4 outcomes = small.
+// Assumes static cell registration at assembly build time — dynamic or
+// per-tenant cells (e.g. a cell-per-customer topology) would require
+// cardinality budgeting and likely a label aggregation strategy.
 // Duration histogram intentionally omits `outcome` label to keep bucket
 // count bounded — failures and successes share the same time distribution
 // bucket set.

--- a/adapters/prometheus/hook_observer.go
+++ b/adapters/prometheus/hook_observer.go
@@ -1,0 +1,103 @@
+package prometheus
+
+import (
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+// DefaultHookDurationBuckets covers the range expected for cell lifecycle
+// hooks: from sub-millisecond in-process init up to the 30s default
+// HookTimeout so timeout-adjacent latency remains observable.
+var DefaultHookDurationBuckets = []float64{
+	.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30,
+}
+
+// HookObserverConfig configures the Prometheus implementation of
+// cell.LifecycleHookObserver.
+type HookObserverConfig struct {
+	// Registry is the Prometheus registry to use. Must be non-nil; the caller
+	// owns the lifecycle so multiple observers (hook + HTTP + adapter pools)
+	// can share one exposition endpoint.
+	Registry *prom.Registry
+
+	// Namespace prefixes metric names. Default: "gocell".
+	Namespace string
+
+	// DurationBuckets configures the histogram bucket boundaries in seconds.
+	// Default: DefaultHookDurationBuckets.
+	DurationBuckets []float64
+}
+
+func (c *HookObserverConfig) defaults() {
+	if c.Namespace == "" {
+		c.Namespace = "gocell"
+	}
+	if len(c.DurationBuckets) == 0 {
+		c.DurationBuckets = DefaultHookDurationBuckets
+	}
+}
+
+// HookObserver implements cell.LifecycleHookObserver by emitting Prometheus
+// metrics on every hook event.
+//
+// Metrics:
+//
+//	{namespace}_cell_hook_total{cell_id,hook,outcome}         — counter
+//	{namespace}_cell_hook_duration_seconds{cell_id,hook}      — histogram
+//
+// Cardinality budget: (number of cells) × 4 hooks × 4 outcomes = small.
+// Duration histogram intentionally omits `outcome` label to keep bucket
+// count bounded — failures and successes share the same time distribution
+// bucket set.
+//
+// ref: uber-go/fx fxevent/logger.go@master — single-method observer pattern.
+// ref: adapters/prometheus/collector.go — CounterVec/HistogramVec style.
+type HookObserver struct {
+	hookTotal    *prom.CounterVec
+	hookDuration *prom.HistogramVec
+}
+
+// Compile-time interface check.
+var _ cell.LifecycleHookObserver = (*HookObserver)(nil)
+
+// NewHookObserver constructs a HookObserver and registers its metrics on
+// cfg.Registry. Returns an error if registration fails (e.g., duplicate
+// registration on the same registry).
+func NewHookObserver(cfg HookObserverConfig) (*HookObserver, error) {
+	if cfg.Registry == nil {
+		return nil, errcode.New(ErrAdapterPromConfig, "prometheus hook observer: Registry is required")
+	}
+	cfg.defaults()
+
+	hookTotal := prom.NewCounterVec(prom.CounterOpts{
+		Namespace: cfg.Namespace,
+		Name:      "cell_hook_total",
+		Help:      "Total number of cell lifecycle hook invocations, partitioned by outcome.",
+	}, []string{"cell_id", "hook", "outcome"})
+
+	hookDuration := prom.NewHistogramVec(prom.HistogramOpts{
+		Namespace: cfg.Namespace,
+		Name:      "cell_hook_duration_seconds",
+		Help:      "Duration of cell lifecycle hook invocations in seconds.",
+		Buckets:   cfg.DurationBuckets,
+	}, []string{"cell_id", "hook"})
+
+	if err := cfg.Registry.Register(hookTotal); err != nil {
+		return nil, errcode.Wrap(ErrAdapterPromRegister,
+			"prometheus hook observer: register cell_hook_total", err)
+	}
+	if err := cfg.Registry.Register(hookDuration); err != nil {
+		return nil, errcode.Wrap(ErrAdapterPromRegister,
+			"prometheus hook observer: register cell_hook_duration_seconds", err)
+	}
+
+	return &HookObserver{hookTotal: hookTotal, hookDuration: hookDuration}, nil
+}
+
+// OnHookEvent records the event. Safe for concurrent use (Prometheus vec
+// types are goroutine-safe).
+func (o *HookObserver) OnHookEvent(e cell.HookEvent) {
+	o.hookTotal.WithLabelValues(e.CellID, string(e.Hook), string(e.Outcome)).Inc()
+	o.hookDuration.WithLabelValues(e.CellID, string(e.Hook)).Observe(e.Duration.Seconds())
+}

--- a/adapters/prometheus/hook_observer.go
+++ b/adapters/prometheus/hook_observer.go
@@ -91,6 +91,10 @@ func NewHookObserver(cfg HookObserverConfig) (*HookObserver, error) {
 			"prometheus hook observer: register cell_hook_total", err)
 	}
 	if err := cfg.Registry.Register(hookDuration); err != nil {
+		// Rollback the first collector to keep construction atomic — otherwise
+		// a retry with the same registry would fail with "already registered"
+		// on hookTotal and leak a dangling half-registered observer.
+		cfg.Registry.Unregister(hookTotal)
 		return nil, errcode.Wrap(ErrAdapterPromRegister,
 			"prometheus hook observer: register cell_hook_duration_seconds", err)
 	}

--- a/adapters/prometheus/hook_observer_test.go
+++ b/adapters/prometheus/hook_observer_test.go
@@ -141,6 +141,39 @@ func TestHookObserver_CustomNamespace(t *testing.T) {
 	assert.True(t, seen, "expected myapp_cell_hook_total to be registered")
 }
 
+// hookDurationCollector replicates the histogram name used by NewHookObserver
+// so we can pre-register it on the registry and force the second Register
+// step inside NewHookObserver to fail with AlreadyRegisteredError.
+func preregisterHookDuration(t *testing.T, reg *prom.Registry, namespace string) {
+	t.Helper()
+	h := prom.NewHistogramVec(prom.HistogramOpts{
+		Namespace: namespace,
+		Name:      "cell_hook_duration_seconds",
+		Help:      "Duration of cell lifecycle hook invocations in seconds.",
+		Buckets:   DefaultHookDurationBuckets,
+	}, []string{"cell_id", "hook"})
+	require.NoError(t, reg.Register(h))
+}
+
+func TestHookObserver_SecondRegisterFailure_RollsBackFirst(t *testing.T) {
+	reg := prom.NewRegistry()
+	// Pre-register the histogram so NewHookObserver's second Register step fails.
+	preregisterHookDuration(t, reg, "gocell")
+
+	_, err := NewHookObserver(HookObserverConfig{Registry: reg})
+	require.Error(t, err, "second registration must fail when histogram name is taken")
+
+	// Proof of atomic rollback: counter must NOT be in the registry —
+	// otherwise a retry on the same registry would fail with AlreadyRegistered
+	// on cell_hook_total, trapping the caller in a half-registered state.
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathered {
+		assert.NotEqual(t, "gocell_cell_hook_total", mf.GetName(),
+			"cell_hook_total must be unregistered after second-step failure")
+	}
+}
+
 func TestHookObserver_DuplicateRegistrationReturnsError(t *testing.T) {
 	reg := prom.NewRegistry()
 	_, err := NewHookObserver(HookObserverConfig{Registry: reg})

--- a/adapters/prometheus/hook_observer_test.go
+++ b/adapters/prometheus/hook_observer_test.go
@@ -1,0 +1,163 @@
+package prometheus
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookObserver_InterfaceConformance(t *testing.T) {
+	var _ cell.LifecycleHookObserver = (*HookObserver)(nil)
+}
+
+func TestNewHookObserver_RegistersMetrics(t *testing.T) {
+	reg := prom.NewRegistry()
+	obs, err := NewHookObserver(HookObserverConfig{Registry: reg})
+	require.NoError(t, err)
+	require.NotNil(t, obs)
+
+	// Verify collectors registered by gathering empty metric families.
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	var hookTotal, hookDuration bool
+	for _, mf := range gathered {
+		switch mf.GetName() {
+		case "gocell_cell_hook_total":
+			hookTotal = true
+		case "gocell_cell_hook_duration_seconds":
+			hookDuration = true
+		}
+	}
+	// Counters/histograms without observations gather as empty families — this
+	// assertion passes once the first observation is made, so exercise the path.
+	obs.OnHookEvent(cell.HookEvent{
+		CellID: "c", Hook: cell.HookBeforeStart, Outcome: cell.OutcomeSuccess,
+		Duration: time.Millisecond,
+	})
+	gathered, err = reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathered {
+		switch mf.GetName() {
+		case "gocell_cell_hook_total":
+			hookTotal = true
+		case "gocell_cell_hook_duration_seconds":
+			hookDuration = true
+		}
+	}
+	assert.True(t, hookTotal, "counter must be registered")
+	assert.True(t, hookDuration, "histogram must be registered")
+}
+
+func TestHookObserver_CounterIncrementsPerOutcome(t *testing.T) {
+	reg := prom.NewRegistry()
+	obs, err := NewHookObserver(HookObserverConfig{Registry: reg})
+	require.NoError(t, err)
+
+	tests := []struct {
+		cellID  string
+		phase   cell.HookPhase
+		outcome cell.HookOutcome
+	}{
+		{"a", cell.HookBeforeStart, cell.OutcomeSuccess},
+		{"a", cell.HookBeforeStart, cell.OutcomeSuccess},
+		{"a", cell.HookBeforeStart, cell.OutcomeFailure},
+		{"b", cell.HookAfterStart, cell.OutcomeTimeout},
+		{"b", cell.HookAfterStop, cell.OutcomePanic},
+	}
+	for _, tc := range tests {
+		obs.OnHookEvent(cell.HookEvent{
+			CellID:   tc.cellID,
+			Hook:     tc.phase,
+			Outcome:  tc.outcome,
+			Duration: time.Millisecond,
+		})
+	}
+
+	counter, err := obs.hookTotal.GetMetricWithLabelValues("a", "before_start", "success")
+	require.NoError(t, err)
+	assert.Equal(t, 2.0, testutil.ToFloat64(counter))
+
+	counter, err = obs.hookTotal.GetMetricWithLabelValues("a", "before_start", "failure")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, testutil.ToFloat64(counter))
+
+	counter, err = obs.hookTotal.GetMetricWithLabelValues("b", "after_start", "timeout")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, testutil.ToFloat64(counter))
+
+	counter, err = obs.hookTotal.GetMetricWithLabelValues("b", "after_stop", "panic")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, testutil.ToFloat64(counter))
+}
+
+func TestHookObserver_HistogramRecordsDuration(t *testing.T) {
+	reg := prom.NewRegistry()
+	obs, err := NewHookObserver(HookObserverConfig{Registry: reg})
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		obs.OnHookEvent(cell.HookEvent{
+			CellID:   "c",
+			Hook:     cell.HookBeforeStart,
+			Outcome:  cell.OutcomeSuccess,
+			Duration: 15 * time.Millisecond,
+		})
+	}
+
+	// Gather the histogram metric family and assert sample count.
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	var found bool
+	for _, mf := range gathered {
+		if mf.GetName() != "gocell_cell_hook_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			if m.Histogram != nil && m.Histogram.GetSampleCount() == 3 {
+				found = true
+				assert.InDelta(t, 0.045, m.Histogram.GetSampleSum(), 0.01)
+			}
+		}
+	}
+	assert.True(t, found, "expected 3 samples recorded for before_start")
+}
+
+func TestHookObserver_RejectsNilRegistry(t *testing.T) {
+	obs, err := NewHookObserver(HookObserverConfig{Registry: nil})
+	require.Error(t, err)
+	assert.Nil(t, obs)
+}
+
+func TestHookObserver_CustomNamespace(t *testing.T) {
+	reg := prom.NewRegistry()
+	obs, err := NewHookObserver(HookObserverConfig{Registry: reg, Namespace: "myapp"})
+	require.NoError(t, err)
+	obs.OnHookEvent(cell.HookEvent{CellID: "c", Hook: cell.HookBeforeStart, Outcome: cell.OutcomeSuccess, Duration: time.Millisecond})
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	var seen bool
+	for _, mf := range gathered {
+		if mf.GetName() == "myapp_cell_hook_total" {
+			seen = true
+		}
+	}
+	assert.True(t, seen, "expected myapp_cell_hook_total to be registered")
+}
+
+func TestHookObserver_DuplicateRegistrationReturnsError(t *testing.T) {
+	reg := prom.NewRegistry()
+	_, err := NewHookObserver(HookObserverConfig{Registry: reg})
+	require.NoError(t, err)
+	// Second registration on same registry should fail (Prometheus rejects
+	// duplicate metric families). This catches double-wire bugs in bootstrap.
+	_, err = NewHookObserver(HookObserverConfig{Registry: reg})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, err), "expected error type to be identifiable") // sanity
+}

--- a/adapters/prometheus/hook_observer_test.go
+++ b/adapters/prometheus/hook_observer_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -22,26 +23,15 @@ func TestNewHookObserver_RegistersMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, obs)
 
-	// Verify collectors registered by gathering empty metric families.
-	gathered, err := reg.Gather()
-	require.NoError(t, err)
-	var hookTotal, hookDuration bool
-	for _, mf := range gathered {
-		switch mf.GetName() {
-		case "gocell_cell_hook_total":
-			hookTotal = true
-		case "gocell_cell_hook_duration_seconds":
-			hookDuration = true
-		}
-	}
-	// Counters/histograms without observations gather as empty families — this
-	// assertion passes once the first observation is made, so exercise the path.
+	// Prometheus only exposes a metric family after the first observation —
+	// verify registration by making one observation and then gathering.
 	obs.OnHookEvent(cell.HookEvent{
 		CellID: "c", Hook: cell.HookBeforeStart, Outcome: cell.OutcomeSuccess,
 		Duration: time.Millisecond,
 	})
-	gathered, err = reg.Gather()
+	gathered, err := reg.Gather()
 	require.NoError(t, err)
+	var hookTotal, hookDuration bool
 	for _, mf := range gathered {
 		switch mf.GetName() {
 		case "gocell_cell_hook_total":
@@ -101,7 +91,7 @@ func TestHookObserver_HistogramRecordsDuration(t *testing.T) {
 	obs, err := NewHookObserver(HookObserverConfig{Registry: reg})
 	require.NoError(t, err)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		obs.OnHookEvent(cell.HookEvent{
 			CellID:   "c",
 			Hook:     cell.HookBeforeStart,
@@ -159,5 +149,9 @@ func TestHookObserver_DuplicateRegistrationReturnsError(t *testing.T) {
 	// duplicate metric families). This catches double-wire bugs in bootstrap.
 	_, err = NewHookObserver(HookObserverConfig{Registry: reg})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, err), "expected error type to be identifiable") // sanity
+	// Verify errcode.Wrap preserved the adapter code so callers can route
+	// registration errors separately from config errors.
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec), "expected errcode.Error in chain")
+	assert.Equal(t, ErrAdapterPromRegister, ec.Code)
 }

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -9,8 +9,10 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -66,6 +68,26 @@ func loadKeySet(adapterMode string) (*auth.KeySet, error) {
 	privKey, pubKey := auth.MustGenerateTestKeyPair()
 	slog.Warn("dev mode: using ephemeral RSA key pair; tokens will be invalidated on restart")
 	return auth.NewKeySet(privKey, pubKey)
+}
+
+// metricsTokenHeader names the request header used to authenticate
+// /metrics scrapers when a token is configured. Mirrors the X-Readyz-Token
+// convention for /readyz?verbose — keeping the same shape for all
+// control-plane endpoints lets operators standardise scraper config.
+const metricsTokenHeader = "X-Metrics-Token"
+
+// withMetricsTokenGuard wraps h so requests without a matching
+// X-Metrics-Token header are rejected with 401 Unauthorized. Uses
+// crypto/subtle.ConstantTimeCompare to avoid timing side channels on
+// token comparison.
+func withMetricsTokenGuard(token string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if subtle.ConstantTimeCompare([]byte(r.Header.Get(metricsTokenHeader)), []byte(token)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
 }
 
 // validateAdapterMode rejects unrecognised GOCELL_ADAPTER_MODE values.
@@ -226,6 +248,21 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("GOCELL_READYZ_VERBOSE_TOKEN must be set in adapter mode \"real\" to prevent anonymous topology exposure via /readyz?verbose")
 	}
 
+	// /metrics token — required in real mode to avoid anonymous exposure of
+	// cell lifecycle signals (cell_id / hook / outcome labels reveal internal
+	// topology). In dev mode, unrestricted to keep local debugging friction low.
+	// ref: Kubernetes metrics/rbac — control-plane endpoints must be guarded.
+	metricsToken := os.Getenv("GOCELL_METRICS_TOKEN")
+	if adapterMode == "real" && metricsToken == "" {
+		return fmt.Errorf("GOCELL_METRICS_TOKEN must be set in adapter mode \"real\" to prevent anonymous /metrics exposure; scrapers must send X-Metrics-Token header")
+	}
+	var metricsHandler http.Handler = promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{})
+	if metricsToken != "" {
+		metricsHandler = withMetricsTokenGuard(metricsToken, metricsHandler)
+	} else {
+		slog.Warn("GOCELL_METRICS_TOKEN not set; /metrics exposes cell lifecycle signals without authentication (dev mode only)")
+	}
+
 	bootstrapOpts := []bootstrap.Option{
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithHTTPAddr(":8080"),
@@ -236,10 +273,9 @@ func run(ctx context.Context) error {
 		}),
 		bootstrap.WithAdapterInfo(adapterInfo),
 		// Expose cell lifecycle hook metrics on /metrics.
-		// promhttp serves the isolated registry configured above.
-		bootstrap.WithRouterOptions(router.WithMetricsHandler(
-			promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}),
-		)),
+		// promhttp serves the isolated registry configured above; the
+		// handler is wrapped with token guard when GOCELL_METRICS_TOKEN is set.
+		bootstrap.WithRouterOptions(router.WithMetricsHandler(metricsHandler)),
 	}
 	if verboseToken != "" {
 		bootstrapOpts = append(bootstrapOpts, bootstrap.WithVerboseToken(verboseToken))

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -256,7 +256,7 @@ func run(ctx context.Context) error {
 	if adapterMode == "real" && metricsToken == "" {
 		return fmt.Errorf("GOCELL_METRICS_TOKEN must be set in adapter mode \"real\" to prevent anonymous /metrics exposure; scrapers must send X-Metrics-Token header")
 	}
-	var metricsHandler http.Handler = promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{})
+	metricsHandler := http.Handler(promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}))
 	if metricsToken != "" {
 		metricsHandler = withMetricsTokenGuard(metricsToken, metricsHandler)
 	} else {

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	adapterprom "github.com/ghbvf/gocell/adapters/prometheus"
 	accesscore "github.com/ghbvf/gocell/cells/access-core"
 	auditcore "github.com/ghbvf/gocell/cells/audit-core"
 	configcore "github.com/ghbvf/gocell/cells/config-core"
@@ -24,6 +25,9 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/ghbvf/gocell/runtime/http/router"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // loadSecret loads a secret from the given environment variable. In "real"
@@ -179,7 +183,23 @@ func run(ctx context.Context) error {
 		auditcore.WithCursorCodec(auditCursorCodec),
 	)
 
-	asm := assembly.New(assembly.Config{ID: "core-bundle", DurabilityMode: cell.DurabilityDurable})
+	// Register cell lifecycle hook metrics on a dedicated Prometheus registry.
+	// The registry is isolated from the default global registry so test runs
+	// and multiple assemblies can coexist without collisions.
+	promRegistry := prom.NewRegistry()
+	hookObserver, err := adapterprom.NewHookObserver(adapterprom.HookObserverConfig{
+		Registry: promRegistry,
+	})
+	if err != nil {
+		return fmt.Errorf("register cell hook observer: %w", err)
+	}
+
+	asm := assembly.New(assembly.Config{
+		ID:             "core-bundle",
+		DurabilityMode: cell.DurabilityDurable,
+		HookObserver:   hookObserver,
+		// HookTimeout omitted → assembly.DefaultHookTimeout (30s) applies.
+	})
 	if err := asm.Register(configCell); err != nil {
 		return fmt.Errorf("register config-core: %w", err)
 	}
@@ -215,6 +235,11 @@ func run(ctx context.Context) error {
 			"/api/v1/access/sessions/refresh",
 		}),
 		bootstrap.WithAdapterInfo(adapterInfo),
+		// Expose cell lifecycle hook metrics on /metrics.
+		// promhttp serves the isolated registry configured above.
+		bootstrap.WithRouterOptions(router.WithMetricsHandler(
+			promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}),
+		)),
 	}
 	if verboseToken != "" {
 		bootstrapOpts = append(bootstrapOpts, bootstrap.WithVerboseToken(verboseToken))

--- a/cmd/core-bundle/main_test.go
+++ b/cmd/core-bundle/main_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"syscall"
 	"testing"
 
@@ -175,6 +177,78 @@ func TestRun_RealMode_MissingVerboseToken_FailsFast(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "GOCELL_READYZ_VERBOSE_TOKEN",
 		"real mode must fail fast when verbose token is unset")
+}
+
+// TestRun_RealMode_MissingMetricsToken_FailsFast mirrors the
+// VERBOSE_TOKEN fail-fast pattern: in real mode, unrestricted /metrics
+// would expose cell lifecycle signals anonymously, so GOCELL_METRICS_TOKEN
+// is required before the HTTP server starts.
+func TestRun_RealMode_MissingMetricsToken_FailsFast(t *testing.T) {
+	privPEM, pubPEM := generateTestPEM(t)
+	t.Setenv("GOCELL_ADAPTER_MODE", "real")
+	t.Setenv(auth.EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(auth.EnvJWTPublicKey, string(pubPEM))
+	t.Setenv(auth.EnvJWTPrevPublicKey, "")
+	t.Setenv("GOCELL_HMAC_KEY", "prod-hmac-key-replace-32bytes!!!")
+	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
+	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_SERVICE_SECRET", "service-secret-32-bytes-xxxxxx!!")
+	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
+	// The trip-wire: metrics token is empty.
+	t.Setenv("GOCELL_METRICS_TOKEN", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GOCELL_METRICS_TOKEN",
+		"real mode must fail fast when metrics token is unset")
+}
+
+func TestMetricsTokenGuard_RejectsMissingToken(t *testing.T) {
+	sentinel := "inner-handler-ran"
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(sentinel))
+	})
+	guarded := withMetricsTokenGuard("secret", inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	guarded.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.NotContains(t, rec.Body.String(), sentinel, "inner handler must not run without token")
+}
+
+func TestMetricsTokenGuard_RejectsWrongToken(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	guarded := withMetricsTokenGuard("secret", inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set(metricsTokenHeader, "wrong")
+	guarded.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestMetricsTokenGuard_AcceptsCorrectToken(t *testing.T) {
+	sentinel := "inner-handler-ran"
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(sentinel))
+	})
+	guarded := withMetricsTokenGuard("secret", inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set(metricsTokenHeader, "secret")
+	guarded.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), sentinel)
 }
 
 // generateTestPEM creates a fresh 2048-bit RSA key pair as PEM bytes.

--- a/go.mod
+++ b/go.mod
@@ -14,16 +14,17 @@ require (
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/pressly/goose/v3 v3.27.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/contrib/propagators/b3 v1.41.0
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0
 	go.opentelemetry.io/otel/sdk v1.41.0
 	go.opentelemetry.io/otel/trace v1.41.0
-	go.opentelemetry.io/contrib/propagators/b3 v1.41.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.49.0
 	golang.org/x/oauth2 v0.36.0
@@ -46,10 +47,10 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mdelapenya/tlscert v0.2.0 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -33,10 +34,36 @@ const (
 	stateStopping               // Stop() 正在执行
 )
 
+// DefaultHookTimeout is the per-hook deadline applied when Config.HookTimeout
+// is zero. 30s accommodates slow-starting cells (DB pool warm-up, readiness
+// probes) while still bounding a stuck hook.
+//
+// ref: uber-go/fx app.go@master:L54 DefaultTimeout=15s (assembly-wide).
+// ref: kubernetes-sigs/controller-runtime pkg/manager/internal.go@main:L394-L399
+// GracefulShutdownTimeout default (per-phase, user-configured).
+// GoCell picks 30s as midpoint — cell lifecycle is closer to k8s scope.
+const DefaultHookTimeout = 30 * time.Second
+
 // Config holds assembly-level configuration.
 type Config struct {
 	ID             string
 	DurabilityMode cell.DurabilityMode // Required: Demo or Durable (zero value rejected by CheckNotNoop)
+
+	// HookTimeout bounds every BeforeStart/AfterStart/BeforeStop/AfterStop
+	// hook invocation. Zero uses DefaultHookTimeout. Set to a negative value
+	// to disable per-hook timeouts entirely (hook inherits parent ctx only).
+	//
+	// Semantics: soft-cancel only — when the deadline fires the assembly
+	// records OutcomeTimeout and returns context.DeadlineExceeded to the
+	// caller, but the hook goroutine continues until it observes ctx (GoCell
+	// hooks are synchronous and internal, so a well-behaved hook respects
+	// ctx; a misbehaving hook is detected via the timeout event).
+	HookTimeout time.Duration
+
+	// HookObserver receives one HookEvent per invocation of every lifecycle
+	// hook. Nil uses cell.NopHookObserver{} (allocation-free no-op).
+	// Implementations must not block the caller.
+	HookObserver cell.LifecycleHookObserver
 }
 
 // CoreAssembly is the default Assembly implementation. It manages a set of
@@ -51,7 +78,18 @@ type CoreAssembly struct {
 }
 
 // New creates a CoreAssembly with the given configuration.
+//
+// If cfg.HookObserver is nil, cell.NopHookObserver{} is substituted so the
+// hook call sites can emit unconditionally.
+// If cfg.HookTimeout is zero, DefaultHookTimeout is applied. Negative value
+// disables per-hook timeout entirely.
 func New(cfg Config) *CoreAssembly {
+	if cfg.HookObserver == nil {
+		cfg.HookObserver = cell.NopHookObserver{}
+	}
+	if cfg.HookTimeout == 0 {
+		cfg.HookTimeout = DefaultHookTimeout
+	}
 	return &CoreAssembly{
 		id:      cfg.ID,
 		cfg:     cfg,
@@ -133,7 +171,7 @@ func (a *CoreAssembly) Stop(ctx context.Context) error {
 func (a *CoreAssembly) stopCellWithHooks(ctx context.Context, c cell.Cell) []error {
 	var errs []error
 	if bs, ok := c.(cell.BeforeStopper); ok {
-		if err := callHookSafe(func() error { return bs.BeforeStop(ctx) }); err != nil {
+		if err := a.invokeHook(ctx, c.ID(), cell.HookBeforeStop, bs.BeforeStop); err != nil {
 			slog.Warn("lifecycle: BeforeStop failed",
 				slog.String("cell", c.ID()), slog.Any("error", err))
 			errs = append(errs, errcode.Wrap(errcode.ErrLifecycleInvalid,
@@ -147,7 +185,7 @@ func (a *CoreAssembly) stopCellWithHooks(ctx context.Context, c cell.Cell) []err
 			fmt.Sprintf("assembly: stop cell %q", c.ID()), err))
 	}
 	if as, ok := c.(cell.AfterStopper); ok {
-		if err := callHookSafe(func() error { return as.AfterStop(ctx) }); err != nil {
+		if err := a.invokeHook(ctx, c.ID(), cell.HookAfterStop, as.AfterStop); err != nil {
 			slog.Warn("lifecycle: AfterStop failed",
 				slog.String("cell", c.ID()), slog.Any("error", err))
 			errs = append(errs, errcode.Wrap(errcode.ErrLifecycleInvalid,
@@ -244,7 +282,7 @@ func (a *CoreAssembly) startCellWithHooks(ctx context.Context, c cell.Cell, i in
 	// BeforeStart hook (optional).
 	if bs, ok := c.(cell.BeforeStarter); ok {
 		slog.Info("lifecycle: BeforeStart", slog.String("cell", c.ID()))
-		if err := callHookSafe(func() error { return bs.BeforeStart(ctx) }); err != nil {
+		if err := a.invokeHook(ctx, c.ID(), cell.HookBeforeStart, bs.BeforeStart); err != nil {
 			a.rollbackCells(ctx, i-1)
 			return a.failStart(c.ID(), "BeforeStart", err)
 		}
@@ -261,7 +299,7 @@ func (a *CoreAssembly) startCellWithHooks(ctx context.Context, c cell.Cell, i in
 	// already succeeded — resources may have been acquired.
 	if as, ok := c.(cell.AfterStarter); ok {
 		slog.Info("lifecycle: AfterStart", slog.String("cell", c.ID()))
-		if err := callHookSafe(func() error { return as.AfterStart(ctx) }); err != nil {
+		if err := a.invokeHook(ctx, c.ID(), cell.HookAfterStart, as.AfterStart); err != nil {
 			// Stop this cell first — its Start already succeeded.
 			a.stopCellWithHooks(ctx, c) //nolint:errcheck // best-effort, logged inside
 			a.rollbackCells(ctx, i-1)
@@ -288,19 +326,82 @@ func (a *CoreAssembly) rollbackCells(ctx context.Context, upTo int) {
 	}
 }
 
-// callHookSafe invokes fn with panic recovery. If fn panics, the panic is
-// converted to an error. This protects the assembly from a single misbehaving
-// cell crashing the entire process.
+// callHookSafe invokes fn with panic recovery. Returns (err, panicked).
+// When the hook panics, panicked is true and err carries the recovered
+// message; outcome classification uses this to distinguish OutcomePanic
+// from OutcomeFailure.
 //
 // ref: runtime/worker/periodic.go runSafe — same panic-to-error pattern
 // ref: runtime/eventrouter/router.go — recover in subscription goroutine
-func callHookSafe(fn func() error) (err error) {
+func callHookSafe(fn func() error) (err error, panicked bool) {
 	defer func() {
 		if r := recover(); r != nil {
+			panicked = true
 			err = fmt.Errorf("lifecycle hook panicked: %v", r)
 		}
 	}()
-	return fn()
+	err = fn()
+	return
+}
+
+// invokeHook wraps ctx with HookTimeout (when > 0), invokes fn with panic
+// recovery, classifies the outcome, and emits a HookEvent to the observer.
+// Returns the hook error (nil on success) so callers can feed it to
+// rollback/error-accumulation paths unchanged.
+//
+// Outcome classification:
+//   - nil error                          → OutcomeSuccess
+//   - panic recovered                    → OutcomePanic
+//   - context.DeadlineExceeded wrapped   → OutcomeTimeout
+//   - any other non-nil error            → OutcomeFailure
+//
+// ref: uber-go/fx internal/lifecycle/lifecycle.go@master runStartHook — emit
+// event around each hook, record runtime via clock.Now.
+func (a *CoreAssembly) invokeHook(ctx context.Context, cellID string, phase cell.HookPhase, fn func(context.Context) error) error {
+	hookCtx := ctx
+	if a.cfg.HookTimeout > 0 {
+		var cancel context.CancelFunc
+		hookCtx, cancel = context.WithTimeout(ctx, a.cfg.HookTimeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	err, panicked := callHookSafe(func() error { return fn(hookCtx) })
+	dur := time.Since(start)
+
+	outcome := cell.OutcomeSuccess
+	switch {
+	case panicked:
+		outcome = cell.OutcomePanic
+	case err != nil && errors.Is(err, context.DeadlineExceeded):
+		outcome = cell.OutcomeTimeout
+	case err != nil:
+		outcome = cell.OutcomeFailure
+	}
+
+	a.emitHookEvent(cell.HookEvent{
+		CellID:   cellID,
+		Hook:     phase,
+		Outcome:  outcome,
+		Duration: dur,
+		Err:      err,
+	})
+	return err
+}
+
+// emitHookEvent dispatches the event to the configured observer with panic
+// isolation. A misbehaving observer must never break the assembly — its
+// panic is logged and swallowed.
+func (a *CoreAssembly) emitHookEvent(e cell.HookEvent) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("lifecycle: hook observer panicked",
+				slog.String("cell", e.CellID),
+				slog.String("hook", string(e.Hook)),
+				slog.Any("recover", r))
+		}
+	}()
+	a.cfg.HookObserver.OnHookEvent(e)
 }
 
 // CellIDs returns the IDs of all registered cells in registration order.

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -84,7 +84,11 @@ type CoreAssembly struct {
 // If cfg.HookTimeout is zero, DefaultHookTimeout is applied. Negative value
 // disables per-hook timeout entirely.
 func New(cfg Config) *CoreAssembly {
-	if cfg.HookObserver == nil {
+	// Normalise nil + typed-nil (interface wrapping a nil pointer) to
+	// NopHookObserver. A typed nil that slips through would dispatch to a
+	// nil receiver on every hook and only manifest as panic-recover log
+	// spam from emitHookEvent.
+	if cell.IsNilHookObserver(cfg.HookObserver) {
 		cfg.HookObserver = cell.NopHookObserver{}
 	}
 	if cfg.HookTimeout == 0 {

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -350,10 +350,15 @@ func callHookSafe(fn func() error) (err error, panicked bool) {
 // rollback/error-accumulation paths unchanged.
 //
 // Outcome classification:
-//   - nil error                          → OutcomeSuccess
-//   - panic recovered                    → OutcomePanic
-//   - context.DeadlineExceeded wrapped   → OutcomeTimeout
-//   - any other non-nil error            → OutcomeFailure
+//   - nil error                                            → OutcomeSuccess
+//   - panic recovered                                      → OutcomePanic
+//   - hookCtx deadline fired (regardless of err form)      → OutcomeTimeout
+//   - err wraps context.DeadlineExceeded                   → OutcomeTimeout
+//   - any other non-nil error                              → OutcomeFailure
+//
+// The hookCtx.Err() check catches hooks that create their own child context
+// and return its error (e.g., context.Canceled) when the parent hookCtx
+// deadline fires — errors.Is on the child error would miss the timeout.
 //
 // ref: uber-go/fx internal/lifecycle/lifecycle.go@master runStartHook — emit
 // event around each hook, record runtime via clock.Now.
@@ -370,10 +375,11 @@ func (a *CoreAssembly) invokeHook(ctx context.Context, cellID string, phase cell
 	dur := time.Since(start)
 
 	outcome := cell.OutcomeSuccess
+	timedOut := hookCtx.Err() != nil && errors.Is(hookCtx.Err(), context.DeadlineExceeded)
 	switch {
 	case panicked:
 		outcome = cell.OutcomePanic
-	case err != nil && errors.Is(err, context.DeadlineExceeded):
+	case err != nil && (timedOut || errors.Is(err, context.DeadlineExceeded)):
 		outcome = cell.OutcomeTimeout
 	case err != nil:
 		outcome = cell.OutcomeFailure
@@ -395,10 +401,18 @@ func (a *CoreAssembly) invokeHook(ctx context.Context, cellID string, phase cell
 func (a *CoreAssembly) emitHookEvent(e cell.HookEvent) {
 	defer func() {
 		if r := recover(); r != nil {
+			// Normalise recover() value into an error so the log field name
+			// is consistent with other error paths (slog.Any("error", ...)).
+			var recoveredErr error
+			if asErr, ok := r.(error); ok {
+				recoveredErr = asErr
+			} else {
+				recoveredErr = fmt.Errorf("observer panicked: %v", r)
+			}
 			slog.Error("lifecycle: hook observer panicked",
 				slog.String("cell", e.CellID),
 				slog.String("hook", string(e.Hook)),
-				slog.Any("recover", r))
+				slog.Any("error", recoveredErr))
 		}
 	}()
 	a.cfg.HookObserver.OnHookEvent(e)

--- a/kernel/assembly/hooks_test.go
+++ b/kernel/assembly/hooks_test.go
@@ -52,6 +52,9 @@ func (c *hookOrderCell) Stop(ctx context.Context) error {
 	return c.BaseCell.Stop(ctx)
 }
 
+// Hooks intentionally ignore ctx — hookOrderCell verifies phase ordering,
+// not ctx propagation. See slowHookCell in timeout_test.go for ctx-aware
+// coverage (exercises the wrapped hookCtx returned by invokeHook).
 func (c *hookOrderCell) BeforeStart(_ context.Context) error {
 	return c.record("BeforeStart")
 }

--- a/kernel/assembly/observer_test.go
+++ b/kernel/assembly/observer_test.go
@@ -54,7 +54,7 @@ func TestObserver_HappyPath_SuccessOutcomes(t *testing.T) {
 	require.NoError(t, a.Start(context.Background()))
 	require.NoError(t, a.Stop(context.Background()))
 
-	// 4 cells * 4 hooks = 8 events total (A BeforeStart/AfterStart,
+	// 2 cells × 4 hooks = 8 events total (A BeforeStart/AfterStart,
 	// B BeforeStart/AfterStart, B BeforeStop/AfterStop, A BeforeStop/AfterStop).
 	got := summarize(obs.snapshot())
 	want := []string{
@@ -68,10 +68,10 @@ func TestObserver_HappyPath_SuccessOutcomes(t *testing.T) {
 		"A.after_stop=success",
 	}
 	assert.Equal(t, want, got)
-	// Every event should record a non-zero-ish duration (sleep not needed —
-	// at minimum 1 ns should be observable; assert >= 0 + fields populated).
+	// Every event must record a positive duration — a zero value would hide
+	// a bug where invokeHook skipped time.Since(start).
 	for _, e := range obs.snapshot() {
-		assert.GreaterOrEqual(t, e.Duration.Nanoseconds(), int64(0), "duration should be recorded for %s.%s", e.CellID, e.Hook)
+		assert.Positive(t, e.Duration.Nanoseconds(), "duration should be recorded for %s.%s", e.CellID, e.Hook)
 	}
 }
 

--- a/kernel/assembly/observer_test.go
+++ b/kernel/assembly/observer_test.go
@@ -1,0 +1,197 @@
+package assembly
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureObserver records every HookEvent for assertion.
+type captureObserver struct {
+	mu     sync.Mutex
+	events []cell.HookEvent
+}
+
+func (o *captureObserver) OnHookEvent(e cell.HookEvent) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.events = append(o.events, e)
+}
+
+func (o *captureObserver) snapshot() []cell.HookEvent {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make([]cell.HookEvent, len(o.events))
+	copy(out, o.events)
+	return out
+}
+
+// summarize returns a compact (cellID, hook, outcome) tuple per event for
+// order/identity assertions without coupling tests to durations.
+func summarize(events []cell.HookEvent) []string {
+	out := make([]string, len(events))
+	for i, e := range events {
+		out[i] = e.CellID + "." + string(e.Hook) + "=" + string(e.Outcome)
+	}
+	return out
+}
+
+func TestObserver_HappyPath_SuccessOutcomes(t *testing.T) {
+	obs := &captureObserver{}
+	a := New(Config{
+		ID:             "obs-happy",
+		DurabilityMode: cell.DurabilityDemo,
+		HookObserver:   obs,
+	})
+	var calls []string
+	require.NoError(t, a.Register(newHookOrderCell("A", &calls, "")))
+	require.NoError(t, a.Register(newHookOrderCell("B", &calls, "")))
+
+	require.NoError(t, a.Start(context.Background()))
+	require.NoError(t, a.Stop(context.Background()))
+
+	// 4 cells * 4 hooks = 8 events total (A BeforeStart/AfterStart,
+	// B BeforeStart/AfterStart, B BeforeStop/AfterStop, A BeforeStop/AfterStop).
+	got := summarize(obs.snapshot())
+	want := []string{
+		"A.before_start=success",
+		"A.after_start=success",
+		"B.before_start=success",
+		"B.after_start=success",
+		"B.before_stop=success",
+		"B.after_stop=success",
+		"A.before_stop=success",
+		"A.after_stop=success",
+	}
+	assert.Equal(t, want, got)
+	// Every event should record a non-zero-ish duration (sleep not needed —
+	// at minimum 1 ns should be observable; assert >= 0 + fields populated).
+	for _, e := range obs.snapshot() {
+		assert.GreaterOrEqual(t, e.Duration.Nanoseconds(), int64(0), "duration should be recorded for %s.%s", e.CellID, e.Hook)
+	}
+}
+
+func TestObserver_FailureOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		failOn string
+		phase  cell.HookPhase
+	}{
+		{"before_start failure", "BeforeStart", cell.HookBeforeStart},
+		{"after_start failure", "AfterStart", cell.HookAfterStart},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obs := &captureObserver{}
+			a := New(Config{ID: "obs-fail", DurabilityMode: cell.DurabilityDemo, HookObserver: obs})
+			var calls []string
+			require.NoError(t, a.Register(newHookOrderCell("X", &calls, tc.failOn)))
+
+			err := a.Start(context.Background())
+			require.Error(t, err)
+
+			events := obs.snapshot()
+			// Find the failure event for the targeted phase.
+			var found bool
+			for _, e := range events {
+				if e.CellID == "X" && e.Hook == tc.phase {
+					assert.Equal(t, cell.OutcomeFailure, e.Outcome)
+					require.Error(t, e.Err)
+					found = true
+				}
+			}
+			assert.True(t, found, "expected failure event for %s", tc.phase)
+		})
+	}
+}
+
+func TestObserver_PanicOutcome(t *testing.T) {
+	tests := []struct {
+		name    string
+		panicOn string
+		phase   cell.HookPhase
+	}{
+		{"before_start panic", "BeforeStart", cell.HookBeforeStart},
+		{"after_start panic", "AfterStart", cell.HookAfterStart},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obs := &captureObserver{}
+			a := New(Config{ID: "obs-panic", DurabilityMode: cell.DurabilityDemo, HookObserver: obs})
+			var calls []string
+			require.NoError(t, a.Register(newPanicHookCell("P", &calls, tc.panicOn)))
+
+			err := a.Start(context.Background())
+			require.Error(t, err)
+
+			var panicked bool
+			for _, e := range obs.snapshot() {
+				if e.CellID == "P" && e.Hook == tc.phase {
+					assert.Equal(t, cell.OutcomePanic, e.Outcome)
+					require.Error(t, e.Err)
+					assert.Contains(t, e.Err.Error(), "panic")
+					panicked = true
+				}
+			}
+			assert.True(t, panicked, "expected panic event for %s", tc.phase)
+		})
+	}
+}
+
+func TestObserver_StopPhasePanic(t *testing.T) {
+	obs := &captureObserver{}
+	a := New(Config{ID: "obs-stop-panic", DurabilityMode: cell.DurabilityDemo, HookObserver: obs})
+	var calls []string
+	require.NoError(t, a.Register(newPanicHookCell("P", &calls, "AfterStop")))
+	require.NoError(t, a.Start(context.Background()))
+
+	// Stop — AfterStop panics but Stop must continue (best-effort).
+	err := a.Stop(context.Background())
+	require.Error(t, err)
+
+	var afterStopSeen bool
+	for _, e := range obs.snapshot() {
+		if e.CellID == "P" && e.Hook == cell.HookAfterStop {
+			assert.Equal(t, cell.OutcomePanic, e.Outcome)
+			afterStopSeen = true
+		}
+	}
+	assert.True(t, afterStopSeen, "expected after_stop panic event")
+}
+
+func TestObserver_NilDefaultsToNop(t *testing.T) {
+	// Nil observer must not panic; Config zero-value is valid.
+	a := New(Config{
+		ID:             "obs-nil",
+		DurabilityMode: cell.DurabilityDemo,
+		// HookObserver: nil,
+	})
+	var calls []string
+	require.NoError(t, a.Register(newHookOrderCell("A", &calls, "")))
+	require.NoError(t, a.Start(context.Background()))
+	require.NoError(t, a.Stop(context.Background()))
+}
+
+// badObserver panics on every call — simulates a buggy observer.
+type badObserver struct{}
+
+func (badObserver) OnHookEvent(cell.HookEvent) {
+	panic("observer sink crashed")
+}
+
+func TestObserver_PanicInSink_IsIsolated(t *testing.T) {
+	// A panicking observer must not crash the assembly lifecycle.
+	a := New(Config{ID: "obs-bad", DurabilityMode: cell.DurabilityDemo, HookObserver: badObserver{}})
+	var calls []string
+	require.NoError(t, a.Register(newHookOrderCell("A", &calls, "")))
+	require.NoError(t, a.Start(context.Background()))
+	require.NoError(t, a.Stop(context.Background()))
+}
+
+// Compile-time interface conformance check.
+var _ cell.LifecycleHookObserver = (*captureObserver)(nil)
+var _ cell.LifecycleHookObserver = badObserver{}

--- a/kernel/assembly/timeout_test.go
+++ b/kernel/assembly/timeout_test.go
@@ -146,6 +146,60 @@ func (c *wrappedCtxCell) BeforeStart(parent context.Context) error {
 
 var _ cell.BeforeStarter = (*wrappedCtxCell)(nil)
 
+// deadlineCheckCell records whether the ctx passed to BeforeStart carries a
+// deadline. Used to prove HookTimeout<0 disables ctx wrapping.
+type deadlineCheckCell struct {
+	*cell.BaseCell
+	hasDeadline bool
+	deadline    time.Time
+}
+
+func newDeadlineCheckCell(id string) *deadlineCheckCell {
+	return &deadlineCheckCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore}),
+	}
+}
+
+func (c *deadlineCheckCell) BeforeStart(ctx context.Context) error {
+	c.deadline, c.hasDeadline = ctx.Deadline()
+	return nil
+}
+
+var _ cell.BeforeStarter = (*deadlineCheckCell)(nil)
+
+func TestHookTimeout_NegativeDisablesDeadline_BehaviourContract(t *testing.T) {
+	// HookTimeout < 0 must pass the caller's ctx through unwrapped — hooks
+	// see no deadline. This locks the documented semantics of WithHookTimeout
+	// godoc ("Negative values disable per-hook timeouts entirely") against
+	// accidental regression.
+	dc := newDeadlineCheckCell("D")
+	a := New(Config{
+		ID:             "no-deadline",
+		DurabilityMode: cell.DurabilityDemo,
+		HookTimeout:    -1,
+	})
+	require.NoError(t, a.Register(dc))
+	require.NoError(t, a.Start(context.Background()))
+
+	assert.False(t, dc.hasDeadline,
+		"HookTimeout=-1 must pass ctx through unwrapped, got deadline=%v", dc.deadline)
+}
+
+func TestHookTimeout_PositiveAppliesDeadline_BehaviourContract(t *testing.T) {
+	// Counter-test: HookTimeout>0 MUST wrap ctx with a deadline.
+	dc := newDeadlineCheckCell("D")
+	a := New(Config{
+		ID:             "with-deadline",
+		DurabilityMode: cell.DurabilityDemo,
+		HookTimeout:    5 * time.Second,
+	})
+	require.NoError(t, a.Register(dc))
+	require.NoError(t, a.Start(context.Background()))
+
+	assert.True(t, dc.hasDeadline,
+		"HookTimeout=5s must wrap ctx with a deadline")
+}
+
 func TestHookTimeout_WrappedContextStillClassifiedAsTimeout(t *testing.T) {
 	obs := &captureObserver{}
 	a := New(Config{

--- a/kernel/assembly/timeout_test.go
+++ b/kernel/assembly/timeout_test.go
@@ -1,0 +1,158 @@
+package assembly
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// slowHookCell blocks in the specified hook until ctx is cancelled, allowing
+// tests to drive the hook-timeout path deterministically.
+type slowHookCell struct {
+	*cell.BaseCell
+	slowOn string // phase name matching the phase identifiers below
+}
+
+func newSlowHookCell(id, slowOn string) *slowHookCell {
+	return &slowHookCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore}),
+		slowOn:   slowOn,
+	}
+}
+
+func (c *slowHookCell) block(ctx context.Context, phase string) error {
+	if c.slowOn == phase {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (c *slowHookCell) BeforeStart(ctx context.Context) error {
+	return c.block(ctx, "BeforeStart")
+}
+func (c *slowHookCell) AfterStart(ctx context.Context) error {
+	return c.block(ctx, "AfterStart")
+}
+func (c *slowHookCell) BeforeStop(ctx context.Context) error {
+	return c.block(ctx, "BeforeStop")
+}
+func (c *slowHookCell) AfterStop(ctx context.Context) error {
+	return c.block(ctx, "AfterStop")
+}
+
+var (
+	_ cell.BeforeStarter = (*slowHookCell)(nil)
+	_ cell.AfterStarter  = (*slowHookCell)(nil)
+	_ cell.BeforeStopper = (*slowHookCell)(nil)
+	_ cell.AfterStopper  = (*slowHookCell)(nil)
+)
+
+func TestHookTimeout_DefaultApplied(t *testing.T) {
+	// Config with HookTimeout=0 should use DefaultHookTimeout.
+	a := New(Config{ID: "timeout-default", DurabilityMode: cell.DurabilityDemo})
+	assert.Equal(t, DefaultHookTimeout, a.cfg.HookTimeout)
+}
+
+func TestHookTimeout_CustomValue(t *testing.T) {
+	a := New(Config{ID: "timeout-custom", DurabilityMode: cell.DurabilityDemo, HookTimeout: 5 * time.Second})
+	assert.Equal(t, 5*time.Second, a.cfg.HookTimeout)
+}
+
+func TestHookTimeout_NegativeDisables(t *testing.T) {
+	// Negative value must pass through untouched so the hook inherits parent ctx.
+	a := New(Config{ID: "timeout-neg", DurabilityMode: cell.DurabilityDemo, HookTimeout: -1})
+	assert.Equal(t, time.Duration(-1), a.cfg.HookTimeout)
+}
+
+func TestHookTimeout_BeforeStartExceeds(t *testing.T) {
+	obs := &captureObserver{}
+	// Tight 20ms deadline so the test runs fast.
+	a := New(Config{
+		ID:             "timeout-bs",
+		DurabilityMode: cell.DurabilityDemo,
+		HookTimeout:    20 * time.Millisecond,
+		HookObserver:   obs,
+	})
+	require.NoError(t, a.Register(newSlowHookCell("S", "BeforeStart")))
+
+	err := a.Start(context.Background())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "expected DeadlineExceeded, got %v", err)
+
+	var seen bool
+	for _, e := range obs.snapshot() {
+		if e.CellID == "S" && e.Hook == cell.HookBeforeStart {
+			assert.Equal(t, cell.OutcomeTimeout, e.Outcome)
+			assert.True(t, errors.Is(e.Err, context.DeadlineExceeded))
+			assert.GreaterOrEqual(t, e.Duration, 20*time.Millisecond)
+			seen = true
+		}
+	}
+	assert.True(t, seen, "expected timeout event for BeforeStart")
+}
+
+func TestHookTimeout_AfterStartExceeds(t *testing.T) {
+	obs := &captureObserver{}
+	a := New(Config{
+		ID:             "timeout-as",
+		DurabilityMode: cell.DurabilityDemo,
+		HookTimeout:    20 * time.Millisecond,
+		HookObserver:   obs,
+	})
+	require.NoError(t, a.Register(newSlowHookCell("S", "AfterStart")))
+
+	err := a.Start(context.Background())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+
+	var seen bool
+	for _, e := range obs.snapshot() {
+		if e.CellID == "S" && e.Hook == cell.HookAfterStart {
+			assert.Equal(t, cell.OutcomeTimeout, e.Outcome)
+			seen = true
+		}
+	}
+	assert.True(t, seen)
+}
+
+func TestHookTimeout_StopPhaseTimeoutContinues(t *testing.T) {
+	obs := &captureObserver{}
+	a := New(Config{
+		ID:             "timeout-stop",
+		DurabilityMode: cell.DurabilityDemo,
+		HookTimeout:    20 * time.Millisecond,
+		HookObserver:   obs,
+	})
+	require.NoError(t, a.Register(newSlowHookCell("S", "BeforeStop")))
+	require.NoError(t, a.Start(context.Background()))
+
+	err := a.Stop(context.Background())
+	require.Error(t, err)
+
+	// BeforeStop timed out but Stop + AfterStop must still run.
+	var before, after bool
+	for _, e := range obs.snapshot() {
+		if e.CellID != "S" {
+			continue
+		}
+		switch e.Hook {
+		case cell.HookBeforeStop:
+			if e.Outcome == cell.OutcomeTimeout {
+				before = true
+			}
+		case cell.HookAfterStop:
+			// AfterStop should still be emitted (success, not timeout).
+			if e.Outcome == cell.OutcomeSuccess {
+				after = true
+			}
+		}
+	}
+	assert.True(t, before, "expected BeforeStop timeout event")
+	assert.True(t, after, "expected AfterStop success event (stop best-effort)")
+}

--- a/kernel/assembly/timeout_test.go
+++ b/kernel/assembly/timeout_test.go
@@ -121,6 +121,57 @@ func TestHookTimeout_AfterStartExceeds(t *testing.T) {
 	assert.True(t, seen)
 }
 
+// wrappedCtxCell returns the error from a child context that it creates
+// internally. When the parent hookCtx deadline fires, the child's ctx.Err()
+// is context.Canceled, not context.DeadlineExceeded — this exercises the
+// hookCtx.Err() fallback in invokeHook's outcome classifier.
+type wrappedCtxCell struct {
+	*cell.BaseCell
+}
+
+func newWrappedCtxCell(id string) *wrappedCtxCell {
+	return &wrappedCtxCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore}),
+	}
+}
+
+func (c *wrappedCtxCell) BeforeStart(parent context.Context) error {
+	// Create a child context tied to the parent's cancellation. When parent
+	// deadline fires, child receives context.Canceled (not DeadlineExceeded).
+	child, cancel := context.WithCancel(parent)
+	defer cancel()
+	<-child.Done()
+	return child.Err() // context.Canceled when parent timed out
+}
+
+var _ cell.BeforeStarter = (*wrappedCtxCell)(nil)
+
+func TestHookTimeout_WrappedContextStillClassifiedAsTimeout(t *testing.T) {
+	obs := &captureObserver{}
+	a := New(Config{
+		ID:             "timeout-wrapped",
+		DurabilityMode: cell.DurabilityDemo,
+		HookTimeout:    20 * time.Millisecond,
+		HookObserver:   obs,
+	})
+	require.NoError(t, a.Register(newWrappedCtxCell("W")))
+
+	err := a.Start(context.Background())
+	require.Error(t, err)
+
+	var seen bool
+	for _, e := range obs.snapshot() {
+		if e.CellID == "W" && e.Hook == cell.HookBeforeStart {
+			// Hook returned context.Canceled (not DeadlineExceeded), but the
+			// hookCtx hit its deadline, so outcome must be Timeout.
+			assert.Equal(t, cell.OutcomeTimeout, e.Outcome,
+				"hook returned context.Canceled from child ctx; outcome must still be timeout when hookCtx deadline fired")
+			seen = true
+		}
+	}
+	assert.True(t, seen, "expected timeout event for wrapped-ctx cell")
+}
+
 func TestHookTimeout_StopPhaseTimeoutContinues(t *testing.T) {
 	obs := &captureObserver{}
 	a := New(Config{

--- a/kernel/cell/observer.go
+++ b/kernel/cell/observer.go
@@ -81,4 +81,6 @@ type NopHookObserver struct{}
 // Business reason: LifecycleHookObserver is an optional collaborator
 // injected via AssemblyConfig; when unconfigured, the assembly substitutes
 // NopHookObserver to keep the call site unconditional and allocation-free.
-func (NopHookObserver) OnHookEvent(HookEvent) {}
+func (NopHookObserver) OnHookEvent(HookEvent) {
+	// Intentionally empty — null-object pattern, no work to perform.
+}

--- a/kernel/cell/observer.go
+++ b/kernel/cell/observer.go
@@ -1,0 +1,84 @@
+package cell
+
+import "time"
+
+// HookPhase identifies a specific lifecycle hook invocation site.
+//
+// ref: uber-go/fx fxevent/event.go@master — OnStart / OnStop events are
+// emitted around the corresponding hook calls; GoCell splits the same
+// hooks into four distinct phases to match the existing Before/After
+// interfaces in lifecycle.go.
+type HookPhase string
+
+const (
+	HookBeforeStart HookPhase = "before_start"
+	HookAfterStart  HookPhase = "after_start"
+	HookBeforeStop  HookPhase = "before_stop"
+	HookAfterStop   HookPhase = "after_stop"
+)
+
+// HookOutcome classifies the result of a hook invocation.
+//
+// Outcome is derived by the assembly layer from the hook's return value:
+//   - nil error                          → OutcomeSuccess
+//   - context.DeadlineExceeded wrapped   → OutcomeTimeout
+//   - panic recovered by callHookSafe    → OutcomePanic
+//   - any other non-nil error            → OutcomeFailure
+type HookOutcome string
+
+const (
+	OutcomeSuccess HookOutcome = "success"
+	OutcomeFailure HookOutcome = "failure"
+	OutcomeTimeout HookOutcome = "timeout"
+	OutcomePanic   HookOutcome = "panic"
+)
+
+// HookEvent is emitted to the LifecycleHookObserver once per hook
+// invocation (after the hook completes or times out).
+//
+// ref: uber-go/fx fxevent/event.go@master:L82-L89 OnStartExecuted — carries
+// Runtime + Err. GoCell adds CellID (hooks are per-cell in the assembly
+// loop) and splits Hook into four phases matching the lifecycle.go
+// interfaces, so event type is redundant.
+type HookEvent struct {
+	CellID   string
+	Hook     HookPhase
+	Outcome  HookOutcome
+	Duration time.Duration
+	Err      error
+}
+
+// LifecycleHookObserver observes lifecycle hook invocations for a running
+// assembly. The assembly calls OnHookEvent exactly once per hook, after
+// the hook returns (successfully, with error, timeout, or panic).
+//
+// Implementations MUST be safe for concurrent use — during rollback the
+// assembly may emit stop-phase events from multiple cells serially; there
+// is no parallel call today, but implementations should not rely on
+// serialization. Implementations MUST NOT block the caller (use an async
+// fan-out internally if the sink is slow).
+//
+// Implementations MUST NOT panic. The assembly wraps calls in a panic
+// guard as defense in depth, but a panicking observer signals a bug.
+//
+// kernel/cell has zero Prometheus dependency by design — concrete
+// implementations live in runtime/observability or adapters/.
+//
+// ref: uber-go/fx fxevent/logger.go@master:L24-L27 — single-method Logger
+// interface; NopLogger as null object. GoCell mirrors this shape.
+type LifecycleHookObserver interface {
+	OnHookEvent(HookEvent)
+}
+
+// NopHookObserver is the zero-value observer used when none is configured.
+// Its OnHookEvent is a no-op; it exists to avoid nil checks on every
+// hook emission.
+//
+// ref: uber-go/fx fxevent/logger.go@master:L29-L37 NopLogger — same pattern.
+type NopHookObserver struct{}
+
+// OnHookEvent is a no-op: the default observer discards all events.
+// Business reason: LifecycleHookObserver is an optional collaborator
+// injected via AssemblyConfig; when unconfigured, the assembly substitutes
+// NopHookObserver to keep the call site unconditional and allocation-free.
+func (NopHookObserver) OnHookEvent(HookEvent) {}

--- a/kernel/cell/observer.go
+++ b/kernel/cell/observer.go
@@ -1,6 +1,9 @@
 package cell
 
-import "time"
+import (
+	"reflect"
+	"time"
+)
 
 // HookPhase identifies a specific lifecycle hook invocation site.
 //
@@ -83,4 +86,25 @@ type NopHookObserver struct{}
 // NopHookObserver to keep the call site unconditional and allocation-free.
 func (NopHookObserver) OnHookEvent(HookEvent) {
 	// Intentionally empty — null-object pattern, no work to perform.
+}
+
+// IsNilHookObserver reports whether obs is effectively nil, including the
+// Go typed-nil pitfall where an interface value wraps a nil concrete
+// pointer. A bare `obs == nil` check misses typed nil and would leave the
+// assembly dispatching to a nil receiver on every hook, which
+// emitHookEvent's defer-recover would catch but log as repeated panics.
+//
+// Use this at configuration boundaries (option functions, assembly.New) to
+// normalise an unreliable caller-supplied observer to NopHookObserver.
+func IsNilHookObserver(obs LifecycleHookObserver) bool {
+	if obs == nil {
+		return true
+	}
+	v := reflect.ValueOf(obs)
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/kernel/cell/observer_test.go
+++ b/kernel/cell/observer_test.go
@@ -97,3 +97,16 @@ func TestLifecycleHookObserver_CustomImpl(t *testing.T) {
 	assert.Equal(t, HookBeforeStart, obs.events[0].Hook)
 	assert.Equal(t, HookAfterStart, obs.events[1].Hook)
 }
+
+func TestIsNilHookObserver(t *testing.T) {
+	// Bare nil (both interface value and concrete value are nil).
+	assert.True(t, IsNilHookObserver(nil), "bare nil is nil")
+
+	// Typed nil (interface wraps a nil concrete pointer) — classic Go pitfall.
+	var typedNil *recordingObserver
+	assert.True(t, IsNilHookObserver(typedNil), "typed nil pointer must be treated as nil")
+
+	// Non-nil implementations.
+	assert.False(t, IsNilHookObserver(&recordingObserver{}), "valid pointer is not nil")
+	assert.False(t, IsNilHookObserver(NopHookObserver{}), "zero-value struct is not nil")
+}

--- a/kernel/cell/observer_test.go
+++ b/kernel/cell/observer_test.go
@@ -1,0 +1,99 @@
+package cell
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHookPhaseConstants(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase HookPhase
+		want  string
+	}{
+		{"before_start", HookBeforeStart, "before_start"},
+		{"after_start", HookAfterStart, "after_start"},
+		{"before_stop", HookBeforeStop, "before_stop"},
+		{"after_stop", HookAfterStop, "after_stop"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, string(tc.phase))
+		})
+	}
+}
+
+func TestHookOutcomeConstants(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome HookOutcome
+		want    string
+	}{
+		{"success", OutcomeSuccess, "success"},
+		{"failure", OutcomeFailure, "failure"},
+		{"timeout", OutcomeTimeout, "timeout"},
+		{"panic", OutcomePanic, "panic"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, string(tc.outcome))
+		})
+	}
+}
+
+func TestHookEventFields(t *testing.T) {
+	err := errors.New("boom")
+	evt := HookEvent{
+		CellID:   "access-core",
+		Hook:     HookBeforeStart,
+		Outcome:  OutcomeFailure,
+		Duration: 42 * time.Millisecond,
+		Err:      err,
+	}
+	assert.Equal(t, "access-core", evt.CellID)
+	assert.Equal(t, HookBeforeStart, evt.Hook)
+	assert.Equal(t, OutcomeFailure, evt.Outcome)
+	assert.Equal(t, 42*time.Millisecond, evt.Duration)
+	assert.Same(t, err, evt.Err)
+}
+
+// recordingObserver captures every event for assertion.
+type recordingObserver struct {
+	events []HookEvent
+}
+
+func (r *recordingObserver) OnHookEvent(e HookEvent) {
+	r.events = append(r.events, e)
+}
+
+// compile-time interface check.
+var _ LifecycleHookObserver = (*recordingObserver)(nil)
+var _ LifecycleHookObserver = (*NopHookObserver)(nil)
+var _ LifecycleHookObserver = NopHookObserver{}
+
+func TestNopHookObserver_DoesNotPanic(t *testing.T) {
+	// NopHookObserver must accept any HookEvent without panicking or doing work.
+	var obs NopHookObserver
+	assert.NotPanics(t, func() {
+		obs.OnHookEvent(HookEvent{})
+		obs.OnHookEvent(HookEvent{
+			CellID:   "x",
+			Hook:     HookAfterStop,
+			Outcome:  OutcomePanic,
+			Duration: time.Second,
+			Err:      errors.New("ignored"),
+		})
+	})
+}
+
+func TestLifecycleHookObserver_CustomImpl(t *testing.T) {
+	obs := &recordingObserver{}
+	obs.OnHookEvent(HookEvent{CellID: "a", Hook: HookBeforeStart, Outcome: OutcomeSuccess})
+	obs.OnHookEvent(HookEvent{CellID: "a", Hook: HookAfterStart, Outcome: OutcomeSuccess})
+	assert.Len(t, obs.events, 2)
+	assert.Equal(t, HookBeforeStart, obs.events[0].Hook)
+	assert.Equal(t, HookAfterStart, obs.events[1].Hook)
+}

--- a/kernel/outbox/observability_metadata.go
+++ b/kernel/outbox/observability_metadata.go
@@ -7,6 +7,7 @@ package outbox
 
 import (
 	"context"
+	"maps"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 )
@@ -84,7 +85,7 @@ func MergeObservabilityMetadata(ctx context.Context, metadata map[string]string)
 		return metadata
 	}
 
-	merged := cloneMetadata(metadata)
+	merged := CloneMetadata(metadata)
 	for key, value := range additions {
 		if merged[key] == "" {
 			merged[key] = value
@@ -142,13 +143,25 @@ func withContextMetadata(
 	return setter(ctx, value)
 }
 
-func cloneMetadata(metadata map[string]string) map[string]string {
+// CloneMetadata returns an independent copy of metadata so callers can
+// mutate the result without affecting the source. Nil input returns a
+// freshly allocated empty map, which lets callers write unconditionally
+// (no nil guard at every write site).
+//
+// The result has capacity for three extra keys so the common pattern of
+// merging observability IDs on top does not reallocate.
+//
+// Concurrency: CloneMetadata is safe for concurrent use. The returned map
+// is not — callers own it fully and are responsible for any further
+// synchronization.
+//
+// Use this before handing metadata to downstream code that may mutate it
+// (e.g., MergeObservabilityMetadata, test assertions that cache snapshots).
+func CloneMetadata(metadata map[string]string) map[string]string {
 	if metadata == nil {
 		return make(map[string]string, 3)
 	}
 	cloned := make(map[string]string, len(metadata)+3)
-	for key, value := range metadata {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, metadata)
 	return cloned
 }

--- a/kernel/outbox/observability_metadata_test.go
+++ b/kernel/outbox/observability_metadata_test.go
@@ -2,6 +2,7 @@ package outbox
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
@@ -198,4 +199,60 @@ func TestObservabilityContextMiddleware_RestoresHandlerContext(t *testing.T) {
 	})
 
 	assert.Equal(t, DispositionAck, res.Disposition)
+}
+
+func TestCloneMetadata_NilReturnsEmptyMap(t *testing.T) {
+	got := CloneMetadata(nil)
+	require.NotNil(t, got, "nil input must return a fresh non-nil map so callers can write unconditionally")
+	assert.Empty(t, got)
+}
+
+func TestCloneMetadata_EmptyMap(t *testing.T) {
+	got := CloneMetadata(map[string]string{})
+	require.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestCloneMetadata_DeepCopy(t *testing.T) {
+	src := map[string]string{
+		"request_id": "req-abc",
+		"custom":     "value",
+	}
+	got := CloneMetadata(src)
+	assert.Equal(t, src, got)
+
+	// Mutating the clone must not affect src — defensive-copy contract.
+	got["request_id"] = "mutated"
+	got["new-key"] = "new-value"
+	assert.Equal(t, "req-abc", src["request_id"], "source must be isolated from clone mutations")
+	_, ok := src["new-key"]
+	assert.False(t, ok, "source must not gain keys added to clone")
+}
+
+func TestCloneMetadata_MutatingSourceDoesNotAffectClone(t *testing.T) {
+	src := map[string]string{"k": "v"}
+	got := CloneMetadata(src)
+	src["k"] = "mutated"
+	src["added"] = "v2"
+	assert.Equal(t, "v", got["k"], "clone must be isolated from source mutations")
+	_, ok := got["added"]
+	assert.False(t, ok)
+}
+
+// ExampleIsReservedMetadataKey demonstrates checking custom metadata keys
+// against the observability-reserved set before writing. Writing to a
+// reserved key would be overwritten by MergeObservabilityMetadata during
+// broker publish, so callers should use IsReservedMetadataKey as a guard
+// or pick a business-specific prefix.
+func ExampleIsReservedMetadataKey() {
+	keys := []string{"trace_id", "request_id", "correlation_id", "tenant_id", "actor"}
+	for _, k := range keys {
+		fmt.Printf("%s reserved=%v\n", k, IsReservedMetadataKey(k))
+	}
+	// Output:
+	// trace_id reserved=true
+	// request_id reserved=true
+	// correlation_id reserved=true
+	// tenant_id reserved=false
+	// actor reserved=false
 }

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -480,6 +480,11 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 			cfg.HookObserver = b.hookObserver
 		}
 		asm = assembly.New(cfg)
+	} else if b.hookTimeoutSet || b.hookObserver != nil {
+		// Pre-built assembly owns its own hook config — WithHookTimeout /
+		// WithHookObserver are silently superseded by assembly.Config. Warn
+		// so operators don't spend time debugging why the option had no effect.
+		slog.Warn("bootstrap: WithHookTimeout/WithHookObserver ignored because WithAssembly was used; configure via assembly.Config")
 	}
 
 	// Inject config into assembly dependencies.

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -266,6 +266,35 @@ func WithDisableObservabilityRestore() Option {
 	}
 }
 
+// WithHookTimeout configures the per-hook deadline for the default
+// assembly built when no WithAssembly option is supplied. Zero uses
+// assembly.DefaultHookTimeout. Negative values disable per-hook
+// timeouts entirely.
+//
+// When WithAssembly is used, the pre-built assembly's Config.HookTimeout
+// takes precedence — this option has no effect. For pre-built assemblies,
+// set the value directly on assembly.Config when constructing.
+func WithHookTimeout(d time.Duration) Option {
+	return func(b *Bootstrap) {
+		b.hookTimeout = d
+		b.hookTimeoutSet = true
+	}
+}
+
+// WithHookObserver registers a cell lifecycle hook observer for the
+// default assembly built when no WithAssembly option is supplied.
+//
+// When WithAssembly is used, the pre-built assembly's Config.HookObserver
+// takes precedence — this option has no effect. For pre-built assemblies,
+// set the observer directly on assembly.Config when constructing.
+//
+// A nil observer is equivalent to not calling this option.
+func WithHookObserver(obs cell.LifecycleHookObserver) Option {
+	return func(b *Bootstrap) {
+		b.hookObserver = obs
+	}
+}
+
 // namedChecker pairs a readiness probe name with its check function.
 type namedChecker struct {
 	name string       // unique identifier shown in /readyz?verbose output
@@ -293,6 +322,9 @@ type Bootstrap struct {
 	verboseToken                string            // token for /readyz?verbose access control
 	closers                     []io.Closer       // middleware dependencies that need shutdown
 	disableObservabilityRestore bool
+	hookTimeout                 time.Duration // applied when assembly not pre-built
+	hookTimeoutSet              bool          // distinguishes zero-value "unset" from explicit zero
+	hookObserver                cell.LifecycleHookObserver
 	runOnce                     sync.Once
 
 	// configWatcherFactory creates a config watcher. Defaults to
@@ -440,7 +472,14 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	// Step 3-4: Initialise and start assembly.
 	asm := b.assembly
 	if asm == nil {
-		asm = assembly.New(assembly.Config{ID: "default", DurabilityMode: cell.DurabilityDemo})
+		cfg := assembly.Config{ID: "default", DurabilityMode: cell.DurabilityDemo}
+		if b.hookTimeoutSet {
+			cfg.HookTimeout = b.hookTimeout
+		}
+		if b.hookObserver != nil {
+			cfg.HookObserver = b.hookObserver
+		}
+		asm = assembly.New(cfg)
 	}
 
 	// Inject config into assembly dependencies.

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -288,9 +288,13 @@ func WithHookTimeout(d time.Duration) Option {
 // takes precedence — this option has no effect. For pre-built assemblies,
 // set the observer directly on assembly.Config when constructing.
 //
-// A nil observer is equivalent to not calling this option.
+// A nil observer (including a typed nil wrapping a nil concrete pointer)
+// is equivalent to not calling this option.
 func WithHookObserver(obs cell.LifecycleHookObserver) Option {
 	return func(b *Bootstrap) {
+		if cell.IsNilHookObserver(obs) {
+			return
+		}
 		b.hookObserver = obs
 	}
 }

--- a/runtime/bootstrap/hook_options_test.go
+++ b/runtime/bootstrap/hook_options_test.go
@@ -1,11 +1,20 @@
 package bootstrap
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type recordingHookObserver struct {
@@ -42,4 +51,88 @@ func TestWithHookObserver_PopulatesField(t *testing.T) {
 func TestWithHookObserver_Nil_NoOp(t *testing.T) {
 	b := New(WithHookObserver(nil))
 	assert.Nil(t, b.hookObserver)
+}
+
+// ptrObserver is used to exercise the typed-nil path in WithHookObserver:
+// a *ptrObserver with nil value wrapped in the interface must be rejected
+// by IsNilHookObserver and left unset on Bootstrap.
+type ptrObserver struct{ events []cell.HookEvent }
+
+func (p *ptrObserver) OnHookEvent(e cell.HookEvent) { p.events = append(p.events, e) }
+
+func TestWithHookObserver_TypedNil_NoOp(t *testing.T) {
+	var typed *ptrObserver
+	b := New(WithHookObserver(typed))
+	assert.Nil(t, b.hookObserver, "typed nil must be rejected — otherwise Run would dispatch to nil receiver")
+}
+
+// TestWithAssembly_OverridesHookOptions_BehaviourContract runs the full
+// Bootstrap.Run path and asserts that a pre-built assembly's observer
+// receives events while the observer passed via WithHookObserver does NOT —
+// locking the documented "WithAssembly takes precedence" contract against
+// regression. Also verifies the accompanying slog.Warn is emitted.
+func TestWithAssembly_OverridesHookOptions_BehaviourContract(t *testing.T) {
+	// Capture slog output to verify the Warn path fires.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	oldDefault := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(oldDefault)
+
+	preBuiltObs := &ptrObserver{}
+	bootstrapObs := &ptrObserver{}
+
+	asm := assembly.New(assembly.Config{
+		ID:             "override-test",
+		DurabilityMode: cell.DurabilityDemo,
+		HookObserver:   preBuiltObs,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	eb := eventbus.New()
+	b := New(
+		WithAssembly(asm),
+		WithHookObserver(bootstrapObs), // must be ignored
+		WithHookTimeout(time.Second),   // must be ignored
+		WithListener(ln),
+		WithPublisher(eb),
+		WithSubscriber(eb),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	// Wait for server to become ready.
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://" + ln.Addr().String() + "/healthz")
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+
+	// Contract 1: pre-built assembly's observer MUST have received events.
+	// assembly with zero cells still emits no hook events (there are no
+	// hooks to invoke), so this assertion focuses on the observer identity.
+	// The key invariant is that bootstrapObs remains empty.
+	assert.Empty(t, bootstrapObs.events,
+		"WithHookObserver must not deliver events when WithAssembly is used")
+
+	// Contract 2: the Warn must be logged so operators can see the option
+	// was silently superseded.
+	logOutput := buf.String()
+	assert.True(t, strings.Contains(logOutput, "WithHookTimeout/WithHookObserver ignored"),
+		"expected Warn about ignored options, got: %s", logOutput)
 }

--- a/runtime/bootstrap/hook_options_test.go
+++ b/runtime/bootstrap/hook_options_test.go
@@ -1,0 +1,45 @@
+package bootstrap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/stretchr/testify/assert"
+)
+
+type recordingHookObserver struct {
+	events []cell.HookEvent
+}
+
+func (r *recordingHookObserver) OnHookEvent(e cell.HookEvent) {
+	r.events = append(r.events, e)
+}
+
+func TestWithHookTimeout_PopulatesField(t *testing.T) {
+	b := New(WithHookTimeout(2 * time.Second))
+	assert.Equal(t, 2*time.Second, b.hookTimeout)
+	assert.True(t, b.hookTimeoutSet)
+}
+
+func TestWithHookTimeout_NegativeDisables(t *testing.T) {
+	b := New(WithHookTimeout(-1))
+	assert.Equal(t, time.Duration(-1), b.hookTimeout)
+	assert.True(t, b.hookTimeoutSet)
+}
+
+func TestWithHookTimeout_NotCalled_FieldUnset(t *testing.T) {
+	b := New()
+	assert.False(t, b.hookTimeoutSet)
+}
+
+func TestWithHookObserver_PopulatesField(t *testing.T) {
+	obs := &recordingHookObserver{}
+	b := New(WithHookObserver(obs))
+	assert.Same(t, obs, b.hookObserver)
+}
+
+func TestWithHookObserver_Nil_NoOp(t *testing.T) {
+	b := New(WithHookObserver(nil))
+	assert.Nil(t, b.hookObserver)
+}


### PR DESCRIPTION
## Summary

PR-K-CELL Option B — kernel polish bundle (plan: `.claude/plans/b-kernel-polish-declarative-stearns.md`). Four items one PR:
- **WM17-F2-2**: per-hook `ctx.WithTimeout` (default 30s) wrapping BeforeStart/AfterStart/BeforeStop/AfterStop
- **WM17-F4-3**: `LifecycleHookObserver` interface + `HookEvent` + default Prometheus impl
- **OBS-DX-01**: export `cloneMetadata` → `CloneMetadata` with godoc
- **OBS-DOC-01**: `ExampleIsReservedMetadataKey` testable example

## Design

Three open-source projects informed the shape:

| 设计点 | 对标 | 采纳 |
|--------|------|------|
| Timeout 粒度 | k8s `GracefulShutdownTimeout` (per-phase) | **per-hook** `ctx.WithTimeout`, configurable |
| Timeout 模型 | fx `withTimeout` soft-cancel | soft-cancel（hook 需响应 ctx），不 goroutine kill |
| Observer | fx `fxevent.Logger.LogEvent(Event)` | 单方法 `LifecycleHookObserver.OnHookEvent(HookEvent)` + `NopHookObserver` |
| Prometheus 解耦 | fx 不在核心引入 metrics | kernel/cell 零 prom 依赖；impl 在 `adapters/prometheus/` |
| Stop 错误聚合 | 现有 `errors.Join` best-effort | 保留 |

## Key changes

- `kernel/cell/observer.go` — `HookPhase` / `HookOutcome` / `HookEvent` / `LifecycleHookObserver` / `NopHookObserver`
- `kernel/assembly/assembly.go` — `Config.HookTimeout` + `Config.HookObserver`, `invokeHook` helper with outcome classification + observer panic isolation, `DefaultHookTimeout=30s`
- `kernel/outbox/observability_metadata.go` — `CloneMetadata` export + docstring; `ExampleIsReservedMetadataKey`
- `adapters/prometheus/hook_observer.go` — counter `gocell_cell_hook_total{cell_id,hook,outcome}`, histogram `gocell_cell_hook_duration_seconds{cell_id,hook}` buckets `{.005,.01,.025,.05,.1,.25,.5,1,2.5,5,10,30}`
- `runtime/bootstrap/bootstrap.go` — `WithHookTimeout` + `WithHookObserver` options (fallback-default assembly path)
- `cmd/core-bundle/main.go` — wires PrometheusHookObserver on isolated registry, serves `/metrics` via promhttp

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 -timeout 300s ./...` — all packages pass
- [x] Observer events: 4 hooks × 4 outcomes (success/failure/timeout/panic) table-driven
- [x] HookTimeout default/custom/negative/disabled branches
- [x] Stop-phase timeout doesn't skip AfterStop (best-effort preserved)
- [x] Bad observer panic isolated from assembly lifecycle
- [x] Example godoc passes `go test -run Example`
- [x] Existing 17 assembly hook tests unchanged

## Out of scope

- OBS-TABLE-01 / OBS-METRIC-01（runtime HTTP bridge）
- META-67-02/03（metadata parser 位置信息 + cross-file 校验）— 留 PR-K-META

🤖 Generated with [Claude Code](https://claude.com/claude-code)