### PR TITLE
feat(config-core): rollback contract + publish redaction (PR-H2)

### DIFF
--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -83,8 +83,16 @@ func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.Co
 
 	var e domain.ConfigEntry
 	if err := row.Scan(&e.ID, &e.Key, &e.Value, &e.Sensitive, &e.Version, &e.CreatedAt, &e.UpdatedAt); err != nil {
-		return nil, errcode.Wrap(errcode.ErrConfigRepoNotFound,
-			fmt.Sprintf("config repo: key not found: %s", key), err)
+		// PR#155 followup F3: Message is the externally visible string for 4xx
+		// (writeErrcodeError pass-through). Keep it identifier-free; the key
+		// goes into InternalMessage which is logged but never written to the
+		// HTTP response. ref: pkg/errcode.Safe.
+		return nil, &errcode.Error{
+			Code:            errcode.ErrConfigRepoNotFound,
+			Message:         "config not found",
+			InternalMessage: fmt.Sprintf("config repo: GetByKey miss key=%s", key),
+			Cause:           err,
+		}
 	}
 
 	return &e, nil
@@ -108,8 +116,9 @@ func (r *ConfigRepository) Update(ctx context.Context, entry *domain.ConfigEntry
 			fmt.Sprintf("config repo: update failed for key %s", entry.Key), err)
 	}
 	if affected == 0 {
-		return errcode.New(errcode.ErrConfigRepoNotFound,
-			fmt.Sprintf("config repo: key not found: %s", entry.Key))
+		return errcode.Safe(errcode.ErrConfigRepoNotFound,
+			"config not found",
+			fmt.Sprintf("config repo: Update miss key=%s", entry.Key))
 	}
 
 	return nil
@@ -125,8 +134,9 @@ func (r *ConfigRepository) Delete(ctx context.Context, key string) error {
 			fmt.Sprintf("config repo: delete failed for key %s", key), err)
 	}
 	if affected == 0 {
-		return errcode.New(errcode.ErrConfigRepoNotFound,
-			fmt.Sprintf("config repo: key not found: %s", key))
+		return errcode.Safe(errcode.ErrConfigRepoNotFound,
+			"config not found",
+			fmt.Sprintf("config repo: Delete miss key=%s", key))
 	}
 
 	return nil
@@ -192,8 +202,15 @@ func (r *ConfigRepository) GetVersion(ctx context.Context, configID string, vers
 
 	var v domain.ConfigVersion
 	if err := row.Scan(&v.ID, &v.ConfigID, &v.Version, &v.Value, &v.Sensitive, &v.PublishedAt); err != nil {
-		return nil, errcode.Wrap(errcode.ErrConfigRepoNotFound,
-			fmt.Sprintf("config repo: version not found: %s v%d", configID, version), err)
+		// PR#155 followup F3: external Message must not leak the internal config_id
+		// or the requested version (would help an attacker enumerate). Identifiers
+		// stay in InternalMessage + Cause for logs/diagnostics only.
+		return nil, &errcode.Error{
+			Code:            errcode.ErrConfigRepoNotFound,
+			Message:         "config version not found",
+			InternalMessage: fmt.Sprintf("config repo: GetVersion miss config_id=%s version=%d", configID, version),
+			Cause:           err,
+		}
 	}
 
 	return &v, nil

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -167,12 +167,12 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 // PublishVersion inserts a config version record.
 func (r *ConfigRepository) PublishVersion(ctx context.Context, version *domain.ConfigVersion) error {
 	const query = `INSERT INTO config_versions
-		(id, config_id, version, value, published_at)
-		VALUES ($1, $2, $3, $4, $5)`
+		(id, config_id, version, value, sensitive, published_at)
+		VALUES ($1, $2, $3, $4, $5, $6)`
 
 	_, err := r.db.Exec(ctx, query,
 		version.ID, version.ConfigID, version.Version,
-		version.Value, version.PublishedAt,
+		version.Value, version.Sensitive, version.PublishedAt,
 	)
 	if err != nil {
 		return errcode.Wrap(errcode.ErrConfigRepoQuery,
@@ -185,13 +185,13 @@ func (r *ConfigRepository) PublishVersion(ctx context.Context, version *domain.C
 
 // GetVersion retrieves a specific config version.
 func (r *ConfigRepository) GetVersion(ctx context.Context, configID string, version int) (*domain.ConfigVersion, error) {
-	const query = `SELECT id, config_id, version, value, published_at
+	const query = `SELECT id, config_id, version, value, sensitive, published_at
 		FROM config_versions WHERE config_id = $1 AND version = $2`
 
 	row := r.db.QueryRow(ctx, query, configID, version)
 
 	var v domain.ConfigVersion
-	if err := row.Scan(&v.ID, &v.ConfigID, &v.Version, &v.Value, &v.PublishedAt); err != nil {
+	if err := row.Scan(&v.ID, &v.ConfigID, &v.Version, &v.Value, &v.Sensitive, &v.PublishedAt); err != nil {
 		return nil, errcode.Wrap(errcode.ErrConfigRepoNotFound,
 			fmt.Sprintf("config repo: version not found: %s v%d", configID, version), err)
 	}

--- a/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -180,7 +180,7 @@ func TestConfigRepository_GetVersion(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cv-1", "cfg-1", 1, "value", &now},
+			values: []any{"cv-1", "cfg-1", 1, "value", true, &now},
 		},
 	}
 	repo := NewConfigRepository(db)
@@ -191,6 +191,7 @@ func TestConfigRepository_GetVersion(t *testing.T) {
 	assert.Equal(t, "cfg-1", version.ConfigID)
 	assert.Equal(t, 1, version.Version)
 	assert.Equal(t, "value", version.Value)
+	assert.True(t, version.Sensitive)
 }
 
 func TestConfigRepository_GetVersion_NotFound(t *testing.T) {

--- a/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -157,23 +157,42 @@ func TestConfigRepository_List(t *testing.T) {
 }
 
 func TestConfigRepository_PublishVersion(t *testing.T) {
-	db := &mockDB{}
-	repo := NewConfigRepository(db)
-
-	now := time.Now()
-	version := &domain.ConfigVersion{
-		ID:          "cv-1",
-		ConfigID:    "cfg-1",
-		Version:     1,
-		Value:       "published value",
-		PublishedAt: &now,
+	// PR#155 review F5: assert the sensitive flag is actually bound as the 5th
+	// positional argument so a future drop of that arg from r.db.Exec would fail.
+	tests := []struct {
+		name      string
+		sensitive bool
+	}{
+		{name: "non-sensitive", sensitive: false},
+		{name: "sensitive", sensitive: true},
 	}
 
-	err := repo.PublishVersion(context.Background(), version)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &mockDB{}
+			repo := NewConfigRepository(db)
 
-	require.Len(t, db.execCalls, 1)
-	assert.Contains(t, db.execCalls[0].sql, "INSERT INTO config_versions")
+			now := time.Now()
+			version := &domain.ConfigVersion{
+				ID:          "cv-1",
+				ConfigID:    "cfg-1",
+				Version:     1,
+				Value:       "published value",
+				Sensitive:   tt.sensitive,
+				PublishedAt: &now,
+			}
+
+			err := repo.PublishVersion(context.Background(), version)
+			require.NoError(t, err)
+
+			require.Len(t, db.execCalls, 1)
+			assert.Contains(t, db.execCalls[0].sql, "INSERT INTO config_versions")
+			require.GreaterOrEqual(t, len(db.execCalls[0].args), 6,
+				"PublishVersion must bind 6 args: id, configId, version, value, sensitive, publishedAt")
+			assert.Equal(t, tt.sensitive, db.execCalls[0].args[4],
+				"5th positional arg must be ConfigVersion.Sensitive")
+		})
+	}
 }
 
 func TestConfigRepository_GetVersion(t *testing.T) {

--- a/cells/config-core/internal/domain/version.go
+++ b/cells/config-core/internal/domain/version.go
@@ -8,5 +8,6 @@ type ConfigVersion struct {
 	ConfigID    string
 	Version     int
 	Value       string
+	Sensitive   bool       // inherits ConfigEntry.Sensitive at publish time; drives DTO redaction.
 	PublishedAt *time.Time // nil = not published
 }

--- a/cells/config-core/slices/config-publish/slice.yaml
+++ b/cells/config-core/slices/config-publish/slice.yaml
@@ -3,6 +3,8 @@ belongsToCell: config-core
 contractUsages:
   - contract: http.config.publish.v1
     role: serve
+  - contract: http.config.rollback.v1
+    role: serve
   - contract: event.config.changed.v1
     role: publish
   - contract: event.config.rollback.v1
@@ -12,6 +14,7 @@ verify:
     - unit.config-publish.service
   contract:
     - contract.http.config.publish.v1.serve
+    - contract.http.config.rollback.v1.serve
     - contract.event.config.changed.v1.publish
     - contract.event.config.rollback.v1.publish
   waivers: []

--- a/cells/config-core/slices/configpublish/contract_test.go
+++ b/cells/config-core/slices/configpublish/contract_test.go
@@ -50,6 +50,41 @@ func TestHttpConfigPublishV1Serve(t *testing.T) {
 	c.ValidateHTTPResponseRecorder(t, rec)
 
 	c.MustRejectResponse(t, []byte(`{"data":{"id":"x"}}`))
+	// H2-2 redaction guard: response missing the `sensitive` flag must be rejected
+	// once the schema requires it (lock-in for redaction-aware contract).
+	c.MustRejectResponse(t, []byte(`{"data":{"id":"v","configId":"c","version":1,"value":"plain"}}`))
+}
+
+func TestHttpConfigRollbackV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.config.rollback.v1")
+	svc, repo, _ := newContractService()
+	seedContractEntry(repo, "app.name", "value")
+
+	// Publish first to create version 1 so rollback target exists.
+	_, err := svc.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+
+	h := NewHandler(svc)
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/config/{key}/rollback", http.HandlerFunc(h.HandleRollback))
+
+	// Request schema acceptance + rejection.
+	c.ValidateRequest(t, []byte(`{"version":1}`))
+	c.MustRejectRequest(t, []byte(`{"version":0}`))
+	c.MustRejectRequest(t, []byte(`{"version":"1"}`))
+	c.MustRejectRequest(t, []byte(`{}`))
+	c.MustRejectRequest(t, []byte(`{"version":1,"extra":"x"}`))
+
+	// Real-handler exercise: 200 OK + response schema.
+	rec := httptest.NewRecorder()
+	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
+	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
+
+	c.MustRejectResponse(t, []byte(`{"data":{"id":"x"}}`))
 }
 
 // --- Event contract tests ---

--- a/cells/config-core/slices/configpublish/contract_test.go
+++ b/cells/config-core/slices/configpublish/contract_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +46,8 @@ func TestHttpConfigPublishV1Serve(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
-	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	req := httptest.NewRequest(c.HTTP.Method, path, nil).
+		WithContext(auth.TestContext("contract-admin", []string{"admin"}))
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 
@@ -79,7 +81,8 @@ func TestHttpConfigRollbackV1Serve(t *testing.T) {
 	// Real-handler exercise: 200 OK + response schema.
 	rec := httptest.NewRecorder()
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
-	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1}`))
+	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1}`)).
+		WithContext(auth.TestContext("contract-admin", []string{"admin"}))
 	req.Header.Set("Content-Type", "application/json")
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)

--- a/cells/config-core/slices/configpublish/handler.go
+++ b/cells/config-core/slices/configpublish/handler.go
@@ -7,7 +7,14 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
+
+// roleAdmin is the role required to publish or rollback a config entry.
+// Mirrors access-core/internal/domain.RoleAdmin which cannot be imported
+// directly (cell-internal). Both must stay in sync — see CLAUDE.md "Cell 之间
+// 只通过 contract 通信".
+const roleAdmin = "admin"
 
 // ConfigVersionResponse is the public DTO for ConfigVersion.
 // Sensitive snapshots have Value redacted to dto.RedactedValue; the Sensitive
@@ -44,7 +51,15 @@ func NewHandler(svc *Service) *Handler {
 }
 
 // HandlePublish handles POST /{key}/publish — publishes a config entry.
+// Admin-only: publishing changes the active config version, a high-risk
+// integrity-affecting operation. Default-deny per K8s/Kratos/go-zero
+// convention; authentication alone is not enough.
 func (h *Handler) HandlePublish(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), roleAdmin); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	key := r.PathValue("key")
 
 	version, err := h.svc.Publish(r.Context(), key)
@@ -57,7 +72,14 @@ func (h *Handler) HandlePublish(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleRollback handles POST /{key}/rollback — rolls back a config entry.
+// Admin-only: rollback re-activates a prior snapshot and is at least as
+// privileged as publish. See HandlePublish for the rationale.
 func (h *Handler) HandleRollback(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), roleAdmin); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	key := r.PathValue("key")
 
 	var req struct {

--- a/cells/config-core/slices/configpublish/handler.go
+++ b/cells/config-core/slices/configpublish/handler.go
@@ -10,18 +10,26 @@ import (
 )
 
 // ConfigVersionResponse is the public DTO for ConfigVersion.
+// Sensitive snapshots have Value redacted to dto.RedactedValue; the Sensitive
+// flag is always surfaced so clients can render appropriately (mirrors
+// dto.ToConfigEntryResponse — see H2-2 CONFIGPUBLISH-REDACT-01).
 type ConfigVersionResponse struct {
 	ID          string     `json:"id"`
 	ConfigID    string     `json:"configId"`
 	Version     int        `json:"version"`
 	Value       string     `json:"value"`
+	Sensitive   bool       `json:"sensitive"`
 	PublishedAt *time.Time `json:"publishedAt,omitempty"`
 }
 
 func toConfigVersionResponse(v *domain.ConfigVersion) ConfigVersionResponse {
+	value := v.Value
+	if v.Sensitive {
+		value = dto.RedactedValue
+	}
 	return ConfigVersionResponse{
 		ID: v.ID, ConfigID: v.ConfigID, Version: v.Version,
-		Value: v.Value, PublishedAt: v.PublishedAt,
+		Value: value, Sensitive: v.Sensitive, PublishedAt: v.PublishedAt,
 	}
 }
 

--- a/cells/config-core/slices/configpublish/handler_test.go
+++ b/cells/config-core/slices/configpublish/handler_test.go
@@ -14,10 +14,22 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// adminCtx returns a request context carrying an admin subject + role for
+// authorized handler tests. Mirrors the identitymanage handler test pattern.
+func adminCtx() context.Context {
+	return auth.TestContext("test-admin", []string{"admin"})
+}
+
+// withAdmin clones req with the admin auth context attached.
+func withAdmin(req *http.Request) *http.Request {
+	return req.WithContext(adminCtx())
+}
 
 // --- stubs ---
 
@@ -102,7 +114,7 @@ func TestHandler_HandlePublish_OK(t *testing.T) {
 	seedForPublish(t, repo, "app.name", "v1")
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/app.name/publish", nil)
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/app.name/publish", nil))
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -115,10 +127,63 @@ func TestHandler_HandlePublish_NotFound(t *testing.T) {
 	handler, _ := setupHandler()
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/missing/publish", nil)
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/missing/publish", nil))
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// PR#155 followup F1 (Cx2, P1): publish + rollback are high-risk write operations
+// that must require an explicit admin role. Authentication alone (any logged-in
+// subject) is not enough — fail-closed at the handler layer mirrors
+// identitymanage/handler.go and matches the K8s/Kratos/go-zero default-deny convention.
+func TestHandler_HandlePublish_RequiresAuth(t *testing.T) {
+	handler, repo := setupHandler()
+	seedForPublish(t, repo, "app.name", "v1")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/app.name/publish", nil) // no auth
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "publish without subject must be 401")
+}
+
+func TestHandler_HandlePublish_RequiresAdminRole(t *testing.T) {
+	handler, repo := setupHandler()
+	seedForPublish(t, repo, "app.name", "v1")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/app.name/publish", nil).
+		WithContext(auth.TestContext("user-1", []string{"viewer"}))
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "non-admin subject must be 403")
+}
+
+func TestHandler_HandleRollback_RequiresAuth(t *testing.T) {
+	handler, _ := setupHandler()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/app.name/rollback",
+		strings.NewReader(`{"version":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "rollback without subject must be 401")
+}
+
+func TestHandler_HandleRollback_RequiresAdminRole(t *testing.T) {
+	handler, repo := setupHandler()
+	seedForPublish(t, repo, "app.name", "v1")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/app.name/rollback",
+		strings.NewReader(`{"version":1}`)).
+		WithContext(auth.TestContext("user-1", []string{"viewer"}))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "non-admin subject must be 403")
 }
 
 // H2-2 CONFIGPUBLISH-REDACT-01: sensitive entries must redact `value` and expose
@@ -132,7 +197,7 @@ func TestHandler_HandlePublish_SensitiveRedacted(t *testing.T) {
 	}))
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/db.password/publish", nil)
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/db.password/publish", nil))
 	handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
@@ -157,7 +222,7 @@ func TestHandler_HandlePublish_NonSensitiveVisible(t *testing.T) {
 	}))
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/app.name/publish", nil)
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/app.name/publish", nil))
 	handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
@@ -182,11 +247,48 @@ func TestHandler_HandleRollback_OK(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	body := `{"version":1}`
-	req := httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader(body))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// PR#155 followup F4 (Cx1, P2): rollback negative-path coverage. Locks 404
+// for both missing-key and missing-version inputs so future error-mapping
+// regressions surface in CI rather than at runtime.
+func TestHandler_HandleRollback_KeyNotFound(t *testing.T) {
+	handler, _ := setupHandler()
+
+	w := httptest.NewRecorder()
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/missing/rollback",
+		strings.NewReader(`{"version":1}`)))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"code"`)
+	// PR#155 followup F3: external 404 must not leak repo-internal identifiers.
+	assert.NotContains(t, body, "config repo")
+}
+
+func TestHandler_HandleRollback_VersionNotFound(t *testing.T) {
+	handler, repo := setupHandler()
+	seedForPublish(t, repo, "app.name", "v1") // entry exists, but no version published yet
+
+	w := httptest.NewRecorder()
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/app.name/rollback",
+		strings.NewReader(`{"version":42}`)))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	body := w.Body.String()
+	// PR#155 followup F3: external 404 must not leak the internal config_id or
+	// the requested version number (which would help an attacker enumerate).
+	assert.NotContains(t, body, "cfg-app.name", "internal config id must not leak in 404")
+	assert.NotContains(t, body, "config repo", "internal repo prefix must not leak")
 }
 
 // PR#155 review F2: rollback response must redact the value when the snapshot
@@ -204,8 +306,8 @@ func TestHandler_HandleRollback_SensitiveRedacted(t *testing.T) {
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/db.password/rollback",
-		strings.NewReader(`{"version":1}`))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/db.password/rollback",
+		strings.NewReader(`{"version":1}`)))
 	req.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
@@ -227,7 +329,7 @@ func TestHandler_HandleRollback_UnknownField(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	body := `{"version":1,"extra":"y"}`
-	req := httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader(body))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(w, req)
 
@@ -238,7 +340,7 @@ func TestHandler_HandleRollback_BadJSON(t *testing.T) {
 	handler, _ := setupHandler()
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader("{bad"))
+	req := withAdmin(httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader("{bad")))
 	req.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(w, req)
 
@@ -261,7 +363,7 @@ func TestHandler_HandleRollback_InvalidVersion(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			body := fmt.Sprintf(`{"version":%d}`, tt.version)
-			req := httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader(body))
+			req := withAdmin(httptest.NewRequest(http.MethodPost, "/app.name/rollback", strings.NewReader(body)))
 			req.Header.Set("Content-Type", "application/json")
 			handler.ServeHTTP(w, req)
 

--- a/cells/config-core/slices/configpublish/handler_test.go
+++ b/cells/config-core/slices/configpublish/handler_test.go
@@ -119,6 +119,57 @@ func TestHandler_HandlePublish_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+// H2-2 CONFIGPUBLISH-REDACT-01: sensitive entries must redact `value` and expose
+// the `sensitive` flag in the publish response so downstream logs/UI cannot leak the secret.
+func TestHandler_HandlePublish_SensitiveRedacted(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-secret", Key: "db.password", Value: "s3cret!", Sensitive: true,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/db.password/publish", nil)
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			Value     string `json:"value"`
+			Sensitive bool   `json:"sensitive"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "******", resp.Data.Value, "sensitive value must be redacted in publish response")
+	assert.True(t, resp.Data.Sensitive, "publish response must surface the sensitive flag")
+	assert.NotContains(t, w.Body.String(), "s3cret!", "raw secret must not appear anywhere in the body")
+}
+
+func TestHandler_HandlePublish_NonSensitiveVisible(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-plain", Key: "app.name", Value: "gocell", Sensitive: false,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/app.name/publish", nil)
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			Value     string `json:"value"`
+			Sensitive bool   `json:"sensitive"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "gocell", resp.Data.Value, "non-sensitive value must be returned plaintext")
+	assert.False(t, resp.Data.Sensitive)
+}
+
 func TestHandler_HandleRollback_OK(t *testing.T) {
 	handler, repo := setupHandler()
 	seedForPublish(t, repo, "app.name", "v1")

--- a/cells/config-core/slices/configpublish/handler_test.go
+++ b/cells/config-core/slices/configpublish/handler_test.go
@@ -58,6 +58,8 @@ func TestConfigVersionResponse_Fields(t *testing.T) {
 	assert.Contains(t, s, `"configId"`)
 	assert.Contains(t, s, `"version"`)
 	assert.Contains(t, s, `"value"`)
+	// PR#155 review F3: lock the sensitive JSON tag so removing it would fail here.
+	assert.Contains(t, s, `"sensitive"`)
 	assert.Contains(t, s, `"publishedAt"`)
 }
 
@@ -185,6 +187,39 @@ func TestHandler_HandleRollback_OK(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// PR#155 review F2: rollback response must redact the value when the snapshot
+// was sensitive, mirroring the publish response guarantee.
+func TestHandler_HandleRollback_SensitiveRedacted(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-secret", Key: "db.password", Value: "s3cret!", Sensitive: true,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+	// Publish v1 carries Sensitive=true into the snapshot.
+	svc := NewService(repo, eventbus.New(), slog.Default())
+	_, err := svc.Publish(context.Background(), "db.password")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/db.password/rollback",
+		strings.NewReader(`{"version":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			Value     string `json:"value"`
+			Sensitive bool   `json:"sensitive"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "******", resp.Data.Value, "rollback response must redact sensitive snapshot value")
+	assert.True(t, resp.Data.Sensitive)
+	assert.NotContains(t, w.Body.String(), "s3cret!", "raw secret must not appear anywhere in the rollback body")
 }
 
 func TestHandler_HandleRollback_UnknownField(t *testing.T) {

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -76,6 +76,7 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 		ConfigID:    entry.ID,
 		Version:     entry.Version,
 		Value:       entry.Value,
+		Sensitive:   entry.Sensitive,
 		PublishedAt: &now,
 	}
 

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -128,6 +128,12 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 	}
 
 	entry.Value = ver.Value
+	// Restore the snapshot's sensitivity so a rolled-back entry inherits the
+	// redaction policy that was in force at the snapshot time. Otherwise a
+	// sensitivity flip between the target version and the live entry would
+	// either leak a secret (entry was sensitive, snapshot was plain) or
+	// over-redact a public value (snapshot was sensitive, entry is now plain).
+	entry.Sensitive = ver.Sensitive
 	entry.Version++
 	entry.UpdatedAt = time.Now()
 

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -219,3 +219,49 @@ func TestService_Publish_NonSensitiveEntry_VersionFlagFalse(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ver.Sensitive)
 }
+
+// PR#155 review F1: rollback must restore the snapshot's Sensitive flag onto
+// the live entry so a sensitivity flip between target version and current
+// state cannot leak (sensitive→plain) or over-redact (plain→sensitive).
+func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
+	tests := []struct {
+		name              string
+		seedSensitive     bool
+		flipToSensitiveAt int // 0 = no flip
+		wantSensitive     bool
+	}{
+		{name: "snapshot sensitive, live plain → entry becomes sensitive", seedSensitive: true, flipToSensitiveAt: 0, wantSensitive: true},
+		{name: "snapshot plain, live sensitive → entry becomes plain", seedSensitive: false, flipToSensitiveAt: 1, wantSensitive: false},
+		{name: "snapshot plain, live plain → stays plain", seedSensitive: false, flipToSensitiveAt: 0, wantSensitive: false},
+		{name: "snapshot sensitive, live sensitive → stays sensitive", seedSensitive: true, flipToSensitiveAt: 1, wantSensitive: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := mem.NewConfigRepository()
+			svc := NewService(repo, stubPublisher{}, slog.Default())
+			now := time.Now()
+			require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+				ID: "cfg-x", Key: "app.x", Value: "v1", Sensitive: tt.seedSensitive,
+				Version: 1, CreatedAt: now, UpdatedAt: now,
+			}))
+			// Snapshot v1 with the seeded sensitivity.
+			_, err := svc.Publish(context.Background(), "app.x")
+			require.NoError(t, err)
+
+			// Optionally flip the live entry's sensitivity to differ from the snapshot.
+			if tt.flipToSensitiveAt > 0 {
+				live, err := repo.GetByKey(context.Background(), "app.x")
+				require.NoError(t, err)
+				live.Sensitive = !tt.seedSensitive
+				live.Value = "v-live"
+				require.NoError(t, repo.Update(context.Background(), live))
+			}
+
+			rolled, err := svc.Rollback(context.Background(), "app.x", 1)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSensitive, rolled.Sensitive,
+				"rollback must inherit the snapshot's Sensitive flag, not the live entry's")
+		})
+	}
+}

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -192,3 +192,30 @@ func TestService_Publish_DurableMode_CapturesOutboxEntry(t *testing.T) {
 	require.Len(t, writer.entries, 1)
 	assert.Equal(t, TopicConfigChanged, writer.entries[0].EventType)
 }
+
+// H2-2 CONFIGPUBLISH-REDACT-01: domain.ConfigVersion must carry the source entry's
+// Sensitive flag so downstream consumers (handler, postgres replay) can redact uniformly.
+func TestService_Publish_SensitiveEntry_VersionCarriesFlag(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	svc := NewService(repo, stubPublisher{}, slog.Default())
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-secret", Key: "db.password", Value: "s3cret!", Sensitive: true,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	ver, err := svc.Publish(context.Background(), "db.password")
+	require.NoError(t, err)
+	assert.True(t, ver.Sensitive, "snapshot must inherit the source entry's Sensitive flag")
+	assert.Equal(t, "s3cret!", ver.Value, "domain snapshot keeps the raw value; redaction is a DTO concern")
+}
+
+func TestService_Publish_NonSensitiveEntry_VersionFlagFalse(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	svc := NewService(repo, stubPublisher{}, slog.Default())
+	mustSeedEntry(repo, "app.name", "gocell")
+
+	ver, err := svc.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+	assert.False(t, ver.Sensitive)
+}

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,6 +209,32 @@ func TestService_Publish_SensitiveEntry_VersionCarriesFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ver.Sensitive, "snapshot must inherit the source entry's Sensitive flag")
 	assert.Equal(t, "s3cret!", ver.Value, "domain snapshot keeps the raw value; redaction is a DTO concern")
+}
+
+// PR#155 followup F4 (Cx1, P2): service-level rollback NotFound coverage.
+// Asserts the typed error code so handler→HTTP status mapping cannot drift.
+func TestService_Rollback_KeyNotFound(t *testing.T) {
+	svc, _ := newTestService()
+	_, err := svc.Rollback(context.Background(), "missing-key", 1)
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec, "rollback must return a typed errcode.Error")
+	assert.Equal(t, errcode.ErrConfigNotFound, ec.Code,
+		"missing key must return ErrConfigNotFound (mem repo) for 404 mapping")
+}
+
+func TestService_Rollback_VersionNotFound(t *testing.T) {
+	svc, repo := newTestService()
+	mustSeedEntry(repo, "app.name", "v1") // entry exists; no version published
+
+	_, err := svc.Rollback(context.Background(), "app.name", 99)
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrConfigNotFound, ec.Code,
+		"missing version must return ErrConfigNotFound (mem repo) for 404 mapping")
 }
 
 func TestService_Publish_NonSensitiveEntry_VersionFlagFalse(t *testing.T) {

--- a/contracts/http/config/publish/v1/response.schema.json
+++ b/contracts/http/config/publish/v1/response.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "http.config.publish.v1.response",
+  "description": "Snapshot of the published config version. When sensitive=true, value is replaced with the literal placeholder \"******\" (dto.RedactedValue) and MUST NOT be reused as input on any write path — fetch the original value via configwrite if you need to round-trip.",
   "type": "object",
   "properties": {
     "data": {
@@ -9,8 +10,14 @@
         "id": { "type": "string" },
         "configId": { "type": "string" },
         "version": { "type": "integer" },
-        "value": { "type": "string" },
-        "sensitive": { "type": "boolean" },
+        "value": {
+          "type": "string",
+          "description": "Snapshot value. If sensitive=true, this is the redaction placeholder \"******\", not the real secret."
+        },
+        "sensitive": {
+          "type": "boolean",
+          "description": "True iff the source ConfigEntry is sensitive. When true, value is redacted in this response and clients must NOT echo it back as input."
+        },
         "publishedAt": { "type": "string", "format": "date-time" }
       },
       "required": ["id", "configId", "version", "value", "sensitive"],

--- a/contracts/http/config/rollback/v1/contract.yaml
+++ b/contracts/http/config/rollback/v1/contract.yaml
@@ -1,0 +1,17 @@
+id: http.config.rollback.v1
+kind: http
+ownerCell: config-core
+consistencyLevel: L2
+lifecycle: active
+endpoints:
+  server: config-core
+  clients:
+    - edge-bff
+  http:
+    method: POST
+    path: /api/v1/config/{key}/rollback
+    successStatus: 200
+    noContent: false
+schemaRefs:
+  request: request.schema.json
+  response: response.schema.json

--- a/contracts/http/config/rollback/v1/request.schema.json
+++ b/contracts/http/config/rollback/v1/request.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.config.rollback.v1.request",
+  "type": "object",
+  "properties": {
+    "version": { "type": "integer", "minimum": 1 }
+  },
+  "required": ["version"],
+  "additionalProperties": false
+}

--- a/contracts/http/config/rollback/v1/response.schema.json
+++ b/contracts/http/config/rollback/v1/response.schema.json
@@ -1,19 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "http.config.publish.v1.response",
+  "title": "http.config.rollback.v1.response",
   "type": "object",
   "properties": {
     "data": {
       "type": "object",
       "properties": {
         "id": { "type": "string" },
-        "configId": { "type": "string" },
-        "version": { "type": "integer" },
+        "key": { "type": "string" },
         "value": { "type": "string" },
         "sensitive": { "type": "boolean" },
-        "publishedAt": { "type": "string", "format": "date-time" }
+        "version": { "type": "integer" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
       },
-      "required": ["id", "configId", "version", "value", "sensitive"],
+      "required": ["id", "key", "value", "sensitive", "version", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },

--- a/contracts/http/config/rollback/v1/response.schema.json
+++ b/contracts/http/config/rollback/v1/response.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "http.config.rollback.v1.response",
+  "description": "Live ConfigEntry after rollback restored a prior snapshot. When sensitive=true, value is replaced with the literal placeholder \"******\" (dto.RedactedValue) and MUST NOT be reused as input on any write path. The Sensitive flag itself is also restored from the snapshot — if the live entry's sensitivity differs from the snapshot, this response reflects the snapshot's sensitivity.",
   "type": "object",
   "properties": {
     "data": {
@@ -8,8 +9,14 @@
       "properties": {
         "id": { "type": "string" },
         "key": { "type": "string" },
-        "value": { "type": "string" },
-        "sensitive": { "type": "boolean" },
+        "value": {
+          "type": "string",
+          "description": "Live value after rollback. If sensitive=true, this is the redaction placeholder \"******\", not the real secret."
+        },
+        "sensitive": {
+          "type": "boolean",
+          "description": "True iff the rolled-back snapshot was marked sensitive. When true, value is redacted and clients must NOT echo it back as input."
+        },
         "version": { "type": "integer" },
         "createdAt": { "type": "string", "format": "date-time" },
         "updatedAt": { "type": "string", "format": "date-time" }


### PR DESCRIPTION
## Summary

Closes the remaining PR-H2 items from `docs/backlog.md` line 298–306:

- **H2-1 CONFIG-ROLLBACK-CONTRACT** — `POST /api/v1/config/{key}/rollback` route was wired (`cells/config-core/cell.go:214`) and unit-tested but had **no HTTP contract YAML, no JSON schemas, no contract_test**. Adds the missing artefacts so contract changes are gated by `gocell validate` and `check contract-health`.
- **H2-2 CONFIGPUBLISH-REDACT-01** — publishing a sensitive config entry returned the raw value in the HTTP response (and in any consumer that logged the body). The publish response now mirrors the existing `dto.ConfigEntryResponse` redaction model (value → `"******"`, `sensitive` flag surfaced) used by `configwrite` / `configread`.

H2-3 (`IDENTITY-PATCH-CONTRACT`) was already done in PR#143 — out of scope.

## Approach (TDD)

1. **Failing rollback contract test** — `TestHttpConfigRollbackV1Serve` referencing `http.config.rollback.v1`.
2. **Failing publish-redaction tests** — handler asserts `value=="******"` + `sensitive==true`; service asserts `domain.ConfigVersion.Sensitive == entry.Sensitive`; publish contract test `MustRejectResponse` for response missing `sensitive`.
3. **Implement minimum to make each test green**:
   - `contracts/http/config/rollback/v1/{contract.yaml,request.schema.json,response.schema.json}` (response shape mirrors `write/v1`).
   - `cells/config-core/slices/config-publish/slice.yaml` adds `contractUsages` + `verify.contract` for the new rollback contract.
   - `domain.ConfigVersion.Sensitive` field; service carries it from the source entry.
   - `ConfigVersionResponse` adds `sensitive` JSON field; `toConfigVersionResponse` redacts via `dto.RedactedValue` when sensitive.
   - `contracts/http/config/publish/v1/response.schema.json` adds `sensitive` (required, boolean).
   - `internal/adapters/postgres/config_repo.go` (and its mock-based test) updated to round-trip the new column. Postgres adapter remains a stub (no migration exists for `config_versions`); when PG-DOMAIN-REPO lands the migration must include `sensitive boolean not null default false`.

## Reference research

- **Vault KV v2** — rollback = read-old + write-new returning the new live record (200 OK). Confirms our existing service shape.
- **OWASP secrets management cheatsheet** — never return plaintext secrets in mutation responses; mask + expose a sensitivity flag for client UX. Matches the existing `dto.ConfigEntryResponse` pattern, now extended to `ConfigVersionResponse`.

## Out of scope (recorded as future work)

- No new audit metadata fields (`rolledBackBy/At`) — defer until access-core principal threading reaches configpublish.
- No HTTP-level If-Match precondition — current optimistic version increment is unchanged.
- No `?include_value=true` debug bypass — redaction is unconditional, mirrors configread/configwrite.
- `config_versions` Postgres migration — defer to PG-DOMAIN-REPO (Batch 8); SQL queries are updated and ready to use once the migration lands.

## Test plan

- [x] `go run ./cmd/gocell validate` — 0 errors (2 pre-existing warnings).
- [x] `go run ./cmd/gocell check contract-health` — PASS, `http.config.rollback.v1` registered.
- [x] `go build ./...` — clean.
- [x] `go test ./cells/config-core/...` — all green.
- [x] `go test ./...` — all green (1 sandbox-only IPv6 bind failure in `TestRouterChain_WebSocketUpgrade` confirmed pre-existing, passes outside sandbox).

## Manual smoke

```bash
curl -X POST http://localhost:8080/api/v1/config/ \
  -H 'Content-Type: application/json' \
  -d '{"key":"db.password","value":"top-secret","sensitive":true}'
curl -X POST http://localhost:8080/api/v1/config/db.password/publish
# → {"data":{"id":"...","configId":"...","version":1,"value":"******","sensitive":true,"publishedAt":"..."}}
curl -X POST http://localhost:8080/api/v1/config/db.password/rollback \
  -H 'Content-Type: application/json' -d '{"version":1}'
# → {"data":{"id":"...","key":"db.password","value":"******","sensitive":true,"version":2,...}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)