### PR TITLE
feat(runtime): trust boundary convergence + config key filter + PR#133 C3 closure

### DIFF
--- a/cells/access-core/slices/identitymanage/handler.go
+++ b/cells/access-core/slices/identitymanage/handler.go
@@ -33,6 +33,9 @@ type UserResponse struct {
 
 // toUserResponse converts a domain.User to a UserResponse DTO.
 func toUserResponse(u *domain.User) UserResponse {
+	if u == nil {
+		return UserResponse{}
+	}
 	return UserResponse{
 		ID:        u.ID,
 		Username:  u.Username,

--- a/cells/access-core/slices/identitymanage/handler_test.go
+++ b/cells/access-core/slices/identitymanage/handler_test.go
@@ -34,7 +34,9 @@ func adminCtx() func(*http.Request) *http.Request {
 }
 
 func TestToUserResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toUserResponse(nil) })
+	var got UserResponse
+	assert.NotPanics(t, func() { got = toUserResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestUserResponse_ExcludesSensitiveFields(t *testing.T) {

--- a/cells/access-core/slices/identitymanage/handler_test.go
+++ b/cells/access-core/slices/identitymanage/handler_test.go
@@ -33,6 +33,10 @@ func adminCtx() func(*http.Request) *http.Request {
 	}
 }
 
+func TestToUserResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toUserResponse(nil) })
+}
+
 func TestUserResponse_ExcludesSensitiveFields(t *testing.T) {
 	now := time.Now()
 	user := &domain.User{

--- a/cells/access-core/slices/sessionlogin/handler.go
+++ b/cells/access-core/slices/sessionlogin/handler.go
@@ -8,6 +8,9 @@ import (
 )
 
 func toTokenPairResponse(p *TokenPair) dto.TokenPairResponse {
+	if p == nil {
+		return dto.TokenPairResponse{}
+	}
 	return dto.TokenPairResponse{
 		AccessToken:  p.AccessToken,
 		RefreshToken: p.RefreshToken,

--- a/cells/access-core/slices/sessionlogin/handler_test.go
+++ b/cells/access-core/slices/sessionlogin/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/dto"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
@@ -35,7 +36,9 @@ func setup() *Handler {
 }
 
 func TestToTokenPairResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toTokenPairResponse(nil) })
+	var got dto.TokenPairResponse
+	assert.NotPanics(t, func() { got = toTokenPairResponse(nil) })
+	assert.Empty(t, got.AccessToken)
 }
 
 func TestTokenPairResponse_Fields(t *testing.T) {

--- a/cells/access-core/slices/sessionlogin/handler_test.go
+++ b/cells/access-core/slices/sessionlogin/handler_test.go
@@ -34,6 +34,10 @@ func setup() *Handler {
 	return NewHandler(svc)
 }
 
+func TestToTokenPairResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toTokenPairResponse(nil) })
+}
+
 func TestTokenPairResponse_Fields(t *testing.T) {
 	now := time.Now()
 	pair := &TokenPair{

--- a/cells/access-core/slices/sessionrefresh/handler.go
+++ b/cells/access-core/slices/sessionrefresh/handler.go
@@ -8,6 +8,9 @@ import (
 )
 
 func toTokenPairResponse(p *TokenPair) dto.TokenPairResponse {
+	if p == nil {
+		return dto.TokenPairResponse{}
+	}
 	return dto.TokenPairResponse{
 		AccessToken:  p.AccessToken,
 		RefreshToken: p.RefreshToken,

--- a/cells/access-core/slices/sessionrefresh/handler_test.go
+++ b/cells/access-core/slices/sessionrefresh/handler_test.go
@@ -36,6 +36,10 @@ func setup() (*Handler, string) {
 	return NewHandler(svc), refreshTok
 }
 
+func TestToTokenPairResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toTokenPairResponse(nil) })
+}
+
 func TestTokenPairResponse_Fields(t *testing.T) {
 	now := time.Now()
 	pair := &TokenPair{

--- a/cells/access-core/slices/sessionrefresh/handler_test.go
+++ b/cells/access-core/slices/sessionrefresh/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/cells/access-core/internal/dto"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 )
 
@@ -37,7 +38,9 @@ func setup() (*Handler, string) {
 }
 
 func TestToTokenPairResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toTokenPairResponse(nil) })
+	var got dto.TokenPairResponse
+	assert.NotPanics(t, func() { got = toTokenPairResponse(nil) })
+	assert.Empty(t, got.AccessToken)
 }
 
 func TestTokenPairResponse_Fields(t *testing.T) {

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -28,6 +28,9 @@ type AuditEntryResponse struct {
 }
 
 func toAuditEntryResponse(e *domain.AuditEntry) AuditEntryResponse {
+	if e == nil {
+		return AuditEntryResponse{}
+	}
 	return AuditEntryResponse{
 		ID: e.ID, EventID: e.EventID, EventType: e.EventType,
 		ActorID: e.ActorID, Timestamp: e.Timestamp, Payload: e.Payload,

--- a/cells/audit-core/slices/auditquery/handler_test.go
+++ b/cells/audit-core/slices/auditquery/handler_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestToAuditEntryResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toAuditEntryResponse(nil) })
+}
+
 func TestHandleQuery_InvalidTimeFormat(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	svc := NewService(repo, testCodec(), slog.Default())

--- a/cells/audit-core/slices/auditquery/handler_test.go
+++ b/cells/audit-core/slices/auditquery/handler_test.go
@@ -19,7 +19,9 @@ import (
 )
 
 func TestToAuditEntryResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toAuditEntryResponse(nil) })
+	var got AuditEntryResponse
+	assert.NotPanics(t, func() { got = toAuditEntryResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestHandleQuery_InvalidTimeFormat(t *testing.T) {

--- a/cells/config-core/slices/configpublish/handler.go
+++ b/cells/config-core/slices/configpublish/handler.go
@@ -30,6 +30,9 @@ type ConfigVersionResponse struct {
 }
 
 func toConfigVersionResponse(v *domain.ConfigVersion) ConfigVersionResponse {
+	if v == nil {
+		return ConfigVersionResponse{}
+	}
 	value := v.Value
 	if v.Sensitive {
 		value = dto.RedactedValue

--- a/cells/config-core/slices/configpublish/handler_test.go
+++ b/cells/config-core/slices/configpublish/handler_test.go
@@ -48,7 +48,9 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 }
 
 func TestToConfigVersionResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toConfigVersionResponse(nil) })
+	var got ConfigVersionResponse
+	assert.NotPanics(t, func() { got = toConfigVersionResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestConfigVersionResponse_Fields(t *testing.T) {

--- a/cells/config-core/slices/configpublish/handler_test.go
+++ b/cells/config-core/slices/configpublish/handler_test.go
@@ -47,6 +47,10 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 	return fn(context.Background())
 }
 
+func TestToConfigVersionResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toConfigVersionResponse(nil) })
+}
+
 func TestConfigVersionResponse_Fields(t *testing.T) {
 	now := time.Now()
 	version := &domain.ConfigVersion{

--- a/cells/config-core/slices/featureflag/handler.go
+++ b/cells/config-core/slices/featureflag/handler.go
@@ -20,6 +20,9 @@ type FeatureFlagResponse struct {
 }
 
 func toFeatureFlagResponse(f *domain.FeatureFlag) FeatureFlagResponse {
+	if f == nil {
+		return FeatureFlagResponse{}
+	}
 	return FeatureFlagResponse{
 		ID: f.ID, Key: f.Key, Type: string(f.Type),
 		Enabled: f.Enabled, RolloutPercentage: f.RolloutPercentage,
@@ -34,6 +37,9 @@ type EvaluateResultResponse struct {
 }
 
 func toEvaluateResultResponse(r *EvaluateResult) EvaluateResultResponse {
+	if r == nil {
+		return EvaluateResultResponse{}
+	}
 	return EvaluateResultResponse{Key: r.Key, Enabled: r.Enabled}
 }
 

--- a/cells/config-core/slices/featureflag/handler_test.go
+++ b/cells/config-core/slices/featureflag/handler_test.go
@@ -19,6 +19,14 @@ import (
 
 var flagHandlerTestKey = bytes.Repeat([]byte("f"), 32)
 
+func TestToFeatureFlagResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toFeatureFlagResponse(nil) })
+}
+
+func TestToEvaluateResultResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toEvaluateResultResponse(nil) })
+}
+
 func TestFeatureFlagResponse_Fields(t *testing.T) {
 	flag := &domain.FeatureFlag{
 		ID: "ff-1", Key: "dark-mode", Type: domain.FlagBoolean,

--- a/cells/config-core/slices/featureflag/handler_test.go
+++ b/cells/config-core/slices/featureflag/handler_test.go
@@ -20,11 +20,15 @@ import (
 var flagHandlerTestKey = bytes.Repeat([]byte("f"), 32)
 
 func TestToFeatureFlagResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toFeatureFlagResponse(nil) })
+	var got FeatureFlagResponse
+	assert.NotPanics(t, func() { got = toFeatureFlagResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestToEvaluateResultResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toEvaluateResultResponse(nil) })
+	var got EvaluateResultResponse
+	assert.NotPanics(t, func() { got = toEvaluateResultResponse(nil) })
+	assert.Zero(t, got.Key)
 }
 
 func TestFeatureFlagResponse_Fields(t *testing.T) {

--- a/cells/device-cell/slices/device-command/handler.go
+++ b/cells/device-cell/slices/device-command/handler.go
@@ -23,6 +23,9 @@ type CommandResponse struct {
 }
 
 func toCommandResponse(c *domain.Command) CommandResponse {
+	if c == nil {
+		return CommandResponse{}
+	}
 	return CommandResponse{
 		ID: c.ID, DeviceID: c.DeviceID, Payload: c.Payload,
 		Status: c.Status, CreatedAt: c.CreatedAt, AckedAt: c.AckedAt,

--- a/cells/device-cell/slices/device-command/handler_test.go
+++ b/cells/device-cell/slices/device-command/handler_test.go
@@ -21,7 +21,9 @@ import (
 )
 
 func TestToCommandResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toCommandResponse(nil) })
+	var got CommandResponse
+	assert.NotPanics(t, func() { got = toCommandResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 // setupCommandHandler creates a Handler and seeds a device so that command operations succeed.

--- a/cells/device-cell/slices/device-command/handler_test.go
+++ b/cells/device-cell/slices/device-command/handler_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
+func TestToCommandResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toCommandResponse(nil) })
+}
+
 // setupCommandHandler creates a Handler and seeds a device so that command operations succeed.
 func setupCommandHandler() (*Handler, *mem.DeviceRepository, *mem.CommandRepository) {
 	devRepo := mem.NewDeviceRepository()

--- a/cells/device-cell/slices/device-register/handler.go
+++ b/cells/device-cell/slices/device-register/handler.go
@@ -15,6 +15,9 @@ type DeviceRegisterResponse struct {
 }
 
 func toDeviceRegisterResponse(d *domain.Device) DeviceRegisterResponse {
+	if d == nil {
+		return DeviceRegisterResponse{}
+	}
 	return DeviceRegisterResponse{
 		ID:     d.ID,
 		Name:   d.Name,

--- a/cells/device-cell/slices/device-register/handler_test.go
+++ b/cells/device-cell/slices/device-register/handler_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestToDeviceRegisterResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toDeviceRegisterResponse(nil) })
+}
+
 func TestDeviceRegisterResponse_Fields(t *testing.T) {
 	device := &domain.Device{ID: "dev-1", Name: "sensor-a", Status: "online"}
 	resp := toDeviceRegisterResponse(device)

--- a/cells/device-cell/slices/device-register/handler_test.go
+++ b/cells/device-cell/slices/device-register/handler_test.go
@@ -16,7 +16,9 @@ import (
 )
 
 func TestToDeviceRegisterResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toDeviceRegisterResponse(nil) })
+	var got DeviceRegisterResponse
+	assert.NotPanics(t, func() { got = toDeviceRegisterResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestDeviceRegisterResponse_Fields(t *testing.T) {

--- a/cells/device-cell/slices/device-status/handler.go
+++ b/cells/device-cell/slices/device-status/handler.go
@@ -17,6 +17,9 @@ type DeviceStatusResponse struct {
 }
 
 func toDeviceStatusResponse(d *domain.Device) DeviceStatusResponse {
+	if d == nil {
+		return DeviceStatusResponse{}
+	}
 	return DeviceStatusResponse{
 		ID:       d.ID,
 		Name:     d.Name,

--- a/cells/device-cell/slices/device-status/handler_test.go
+++ b/cells/device-cell/slices/device-status/handler_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestToDeviceStatusResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toDeviceStatusResponse(nil) })
+	var got DeviceStatusResponse
+	assert.NotPanics(t, func() { got = toDeviceStatusResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestDeviceStatusResponse_Fields(t *testing.T) {

--- a/cells/device-cell/slices/device-status/handler_test.go
+++ b/cells/device-cell/slices/device-status/handler_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 )
 
+func TestToDeviceStatusResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toDeviceStatusResponse(nil) })
+}
+
 func TestDeviceStatusResponse_Fields(t *testing.T) {
 	now := time.Now()
 	device := &domain.Device{ID: "dev-1", Name: "sensor-a", Status: "online", LastSeen: now}

--- a/cells/order-cell/slices/order-create/handler.go
+++ b/cells/order-cell/slices/order-create/handler.go
@@ -15,6 +15,9 @@ type OrderCreateResponse struct {
 }
 
 func toOrderCreateResponse(o *domain.Order) OrderCreateResponse {
+	if o == nil {
+		return OrderCreateResponse{}
+	}
 	return OrderCreateResponse{
 		ID:     o.ID,
 		Item:   o.Item,

--- a/cells/order-cell/slices/order-create/handler_test.go
+++ b/cells/order-cell/slices/order-create/handler_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestToOrderCreateResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toOrderCreateResponse(nil) })
+	var got OrderCreateResponse
+	assert.NotPanics(t, func() { got = toOrderCreateResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestOrderCreateResponse_Fields(t *testing.T) {

--- a/cells/order-cell/slices/order-create/handler_test.go
+++ b/cells/order-cell/slices/order-create/handler_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 )
 
+func TestToOrderCreateResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toOrderCreateResponse(nil) })
+}
+
 func TestOrderCreateResponse_Fields(t *testing.T) {
 	order := &domain.Order{ID: "ord-1", Item: "laptop", Status: "pending"}
 	resp := toOrderCreateResponse(order)

--- a/cells/order-cell/slices/order-query/handler.go
+++ b/cells/order-cell/slices/order-query/handler.go
@@ -20,6 +20,9 @@ type OrderResponse struct {
 }
 
 func toOrderResponse(o *domain.Order) OrderResponse {
+	if o == nil {
+		return OrderResponse{}
+	}
 	return OrderResponse{
 		ID: o.ID, Item: o.Item, Status: o.Status, CreatedAt: o.CreatedAt,
 	}

--- a/cells/order-cell/slices/order-query/handler_test.go
+++ b/cells/order-cell/slices/order-query/handler_test.go
@@ -19,7 +19,9 @@ import (
 )
 
 func TestToOrderResponse_NilInput(t *testing.T) {
-	assert.NotPanics(t, func() { toOrderResponse(nil) })
+	var got OrderResponse
+	assert.NotPanics(t, func() { got = toOrderResponse(nil) })
+	assert.Zero(t, got.ID)
 }
 
 func TestOrderResponse_Fields(t *testing.T) {

--- a/cells/order-cell/slices/order-query/handler_test.go
+++ b/cells/order-cell/slices/order-query/handler_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
+func TestToOrderResponse_NilInput(t *testing.T) {
+	assert.NotPanics(t, func() { toOrderResponse(nil) })
+}
+
 func TestOrderResponse_Fields(t *testing.T) {
 	now := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
 	order := &domain.Order{

--- a/kernel/cell/registrar.go
+++ b/kernel/cell/registrar.go
@@ -194,3 +194,15 @@ type HealthContributor interface {
 type ConfigReloader interface {
 	OnConfigReload(event ConfigChangeEvent) error
 }
+
+// ConfigKeyFilterer is optionally implemented by ConfigReloader cells that
+// want notifications only for specific config key prefixes. If the changed
+// keys don't match any prefix, the cell is skipped.
+//
+// An empty return (nil or []string{}) means receive ALL notifications (default).
+//
+// ref: kratos config/config.go — Watch(key, Observer) single-key registration
+// ref: go-micro config/default.go — Watch(path...) key-scoped observation
+type ConfigKeyFilterer interface {
+	ConfigKeyPrefixes() []string
+}

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -17,7 +17,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"path"
 	"sync"
 	"time"
 
@@ -148,6 +147,17 @@ func WithCircuitBreaker(cb middleware.CircuitBreakerPolicy) Option {
 		if cl, ok := cb.(io.Closer); ok {
 			b.closers = append(b.closers, cl)
 		}
+	}
+}
+
+// WithSecurityHeadersOptions configures HSTS and other security header
+// directives. This is a convenience wrapper around
+// WithRouterOptions(router.WithSecurityHeadersOptions(...)).
+//
+// ref: unrolled/secure — configurable HSTS directives via struct fields
+func WithSecurityHeadersOptions(opts ...middleware.SecurityHeadersOption) Option {
+	return func(b *Bootstrap) {
+		b.routerOpts = append(b.routerOpts, router.WithSecurityHeadersOptions(opts...))
 	}
 }
 
@@ -657,6 +667,18 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 				if !ok {
 					continue
 				}
+				if kf, ok := c.(cell.ConfigKeyFilterer); ok {
+					prefixes := kf.ConfigKeyPrefixes()
+					if len(prefixes) > 0 {
+						changedKeys := make([]string, 0, len(added)+len(updated)+len(removed))
+						changedKeys = append(changedKeys, added...)
+						changedKeys = append(changedKeys, updated...)
+						changedKeys = append(changedKeys, removed...)
+						if !config.NewKeyFilter(prefixes...).Matches(changedKeys) {
+							continue
+						}
+					}
+				}
 				// Clone per cell to guarantee isolation: a misbehaving handler
 				// cannot mutate slices/map seen by subsequent handlers.
 				event := cell.ConfigChangeEvent{
@@ -778,22 +800,10 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	// Copy to avoid mutating b.routerOpts' backing array.
 	routerOpts := make([]router.Option, 0, len(b.routerOpts)+4)
 	routerOpts = append(routerOpts, b.routerOpts...)
-	// Wire trust-boundary policy for tracing and request_id from public endpoints.
-	// Public endpoints (e.g., login, refresh) ignore client-supplied trace context
-	// and X-Request-Id headers, preventing untrusted callers from injecting
-	// arbitrary observability identifiers.
+	// Wire trust-boundary policy via router.WithPublicEndpoints which configures
+	// auth bypass + tracing new-root + request_id rejection in a single option.
 	if len(b.authPublicEndpoints) > 0 {
-		publicSet := make(map[string]bool, len(b.authPublicEndpoints))
-		for _, p := range b.authPublicEndpoints {
-			publicSet[path.Clean(p)] = true
-		}
-		isPublic := func(r *http.Request) bool {
-			return publicSet[path.Clean(r.URL.Path)]
-		}
-		routerOpts = append(routerOpts,
-			router.WithTracingOptions(middleware.WithPublicEndpointFn(isPublic)),
-			router.WithRequestIDOptions(middleware.WithReqIDPublicEndpointFn(isPublic)),
-		)
+		routerOpts = append(routerOpts, router.WithPublicEndpoints(b.authPublicEndpoints))
 	}
 	if b.authVerifier != nil {
 		routerOpts = append(routerOpts, router.WithAuthMiddleware(b.authVerifier, b.authPublicEndpoints))

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -165,9 +165,10 @@ func WithSecurityHeadersOptions(opts ...middleware.SecurityHeadersOption) Option
 // verifier is applied to the router's middleware chain at Run() time via
 // router.WithAuthMiddleware.
 //
-// Deprecated: Use WithPublicEndpoints instead. WithPublicEndpoints discovers
-// the auth verifier automatically from cells implementing authProvider,
-// eliminating the need for explicit verifier injection at the composition root.
+// Deprecated: Use bootstrap.WithPublicEndpoints instead, which discovers the
+// auth verifier automatically and delegates trust boundary policy to
+// router.WithPublicEndpoints (auth bypass + tracing new-root + request_id
+// rejection in a single configuration point).
 //
 // publicEndpoints specifies business-route paths that bypass authentication.
 // If nil, no business routes are public (fail-closed). Callers must

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -435,6 +436,15 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		}
 	}
 
+	// Fail-fast: WithAuthMiddleware and WithPublicEndpoints are mutually
+	// exclusive. Both set authPublicEndpoints but with different semantics
+	// (explicit verifier vs. discovery). Allowing both silently creates
+	// order-dependent behavior.
+	if b.authVerifier != nil && b.authDiscovery {
+		return fmt.Errorf("bootstrap: WithAuthMiddleware and WithPublicEndpoints " +
+			"are mutually exclusive; use WithPublicEndpoints (recommended)")
+	}
+
 	// Track teardown functions for rollback (LIFO order).
 	var teardowns []func(context.Context) error
 
@@ -668,25 +678,32 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 				if !ok {
 					continue
 				}
+				var filteredPrefixes []string
 				if kf, ok := c.(cell.ConfigKeyFilterer); ok {
-					prefixes := kf.ConfigKeyPrefixes()
-					if len(prefixes) > 0 {
+					filteredPrefixes = kf.ConfigKeyPrefixes()
+					if len(filteredPrefixes) > 0 {
 						changedKeys := make([]string, 0, len(added)+len(updated)+len(removed))
 						changedKeys = append(changedKeys, added...)
 						changedKeys = append(changedKeys, updated...)
 						changedKeys = append(changedKeys, removed...)
-						if !config.NewKeyFilter(prefixes...).Matches(changedKeys) {
+						if !config.NewKeyFilter(filteredPrefixes...).Matches(changedKeys) {
 							continue
 						}
 					}
 				}
 				// Clone per cell to guarantee isolation: a misbehaving handler
 				// cannot mutate slices/map seen by subsequent handlers.
+				// When the cell declares key prefixes, trim the config snapshot
+				// to only matching keys (minimal exposure principle).
+				cfgSnap := cloneMap(newSnap)
+				if len(filteredPrefixes) > 0 {
+					cfgSnap = filterMapByPrefixes(cfgSnap, filteredPrefixes)
+				}
 				event := cell.ConfigChangeEvent{
 					Added:      cloneStrings(added),
 					Updated:    cloneStrings(updated),
 					Removed:    cloneStrings(removed),
-					Config:     cloneMap(newSnap),
+					Config:     cfgSnap,
 					Generation: gen,
 				}
 				func() {
@@ -999,6 +1016,19 @@ func cloneStrings(src []string) []string {
 // cloneMap returns a deep copy of a map[string]any. Values that are slices
 // or nested maps are recursively cloned so that mutations by one consumer
 // cannot affect another.
+func filterMapByPrefixes(src map[string]any, prefixes []string) map[string]any {
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		for _, p := range prefixes {
+			if strings.HasPrefix(k, p) {
+				dst[k] = v
+				break
+			}
+		}
+	}
+	return dst
+}
+
 func cloneMap(src map[string]any) map[string]any {
 	if src == nil {
 		return nil

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -3061,12 +3061,18 @@ func TestBootstrap_ConfigReload_KeyFilter_NotifiesMatched(t *testing.T) {
 	waitForHealthy(t, addr)
 
 	// Change a server.* key — server. cell MUST be notified.
-	require.NoError(t, os.WriteFile(cfgFile, []byte("server:\n  port: 9090\n"), 0o644))
+	require.NoError(t, os.WriteFile(cfgFile, []byte("server:\n  port: 9090\ndb:\n  host: localhost\n"), 0o644))
 
 	select {
 	case evt := <-kfc.reloaded:
 		assert.Contains(t, evt.Updated, "server.port",
 			"event must contain the matched key")
+		// Minimal exposure: Config snapshot only contains keys matching the
+		// cell's registered prefixes, not the full config.
+		_, hasServer := evt.Config["server.port"]
+		_, hasDB := evt.Config["db.host"]
+		assert.True(t, hasServer, "Config must contain matched prefix keys")
+		assert.False(t, hasDB, "Config must NOT contain keys outside registered prefixes (minimal exposure)")
 	case <-time.After(3 * time.Second):
 		t.Fatal("cell was not notified after matching key change")
 	}
@@ -3249,4 +3255,40 @@ func TestBootstrap_TrustBoundary_PublicEndpoint_TraceparentIgnored(t *testing.T)
 	case <-time.After(5 * time.Second):
 		t.Fatal("bootstrap did not shut down in time")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth option conflict detection (P1 fail-fast)
+// ---------------------------------------------------------------------------
+
+func TestBootstrap_ConflictingAuthOptions_ReturnsError(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "conflict-test", DurabilityMode: cell.DurabilityDemo})
+	tc := newTestCell("conflict-cell")
+	require.NoError(t, asm.Register(tc))
+
+	verifier := &bootstrapTestVerifier{
+		claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}},
+	}
+
+	t.Run("WithAuthMiddleware then WithPublicEndpoints", func(t *testing.T) {
+		b := New(
+			WithAssembly(asm),
+			WithAuthMiddleware(verifier, []string{"/login"}),
+			WithPublicEndpoints([]string{"/login"}),
+		)
+		err := b.Run(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("WithPublicEndpoints then WithAuthMiddleware", func(t *testing.T) {
+		b := New(
+			WithAssembly(asm),
+			WithPublicEndpoints([]string{"/login"}),
+			WithAuthMiddleware(verifier, []string{"/login"}),
+		)
+		err := b.Run(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
 }

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ghbvf/gocell/runtime/config"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/health"
+	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
 	"github.com/stretchr/testify/assert"
@@ -2897,6 +2898,348 @@ func TestBootstrap_TrustBoundary_PublicEndpoint_IgnoresClientIDs(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "trusted-upstream-id", resp.Header.Get("X-Request-Id"),
 			"protected endpoint must accept trusted upstream X-Request-Id")
+	})
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+func TestBootstrap_WithSecurityHeadersOptions_CustomHSTS(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	asm := assembly.New(assembly.Config{ID: "test-sechdr", DurabilityMode: cell.DurabilityDemo})
+	tc := newTestCell("hsts-cell")
+	require.NoError(t, asm.Register(tc))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithSecurityHeadersOptions(
+			middleware.WithHSTSIncludeSubDomains(),
+			middleware.WithHSTSPreload(),
+		),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	resp, reqErr := testHTTPClient.Get("http://" + addr + "/healthz")
+	require.NoError(t, reqErr)
+	_ = resp.Body.Close()
+
+	hsts := resp.Header.Get("Strict-Transport-Security")
+	assert.Contains(t, hsts, "includeSubDomains",
+		"WithSecurityHeadersOptions must propagate HSTS subdomain directive")
+	assert.Contains(t, hsts, "preload",
+		"WithSecurityHeadersOptions must propagate HSTS preload directive")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ConfigKeyFilterer integration tests (CFG-KEYFILTER-WIRE-01)
+// ---------------------------------------------------------------------------
+
+// keyFilterReloaderCell implements ConfigReloader + ConfigKeyFilterer for testing.
+type keyFilterReloaderCell struct {
+	*cell.BaseCell
+	prefixes []string
+	reloaded chan cell.ConfigChangeEvent
+}
+
+func newKeyFilterReloaderCell(id string, prefixes []string) *keyFilterReloaderCell {
+	return &keyFilterReloaderCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{
+			ID:   id,
+			Type: cell.CellTypeCore,
+		}),
+		prefixes: prefixes,
+		reloaded: make(chan cell.ConfigChangeEvent, 4),
+	}
+}
+
+func (c *keyFilterReloaderCell) OnConfigReload(event cell.ConfigChangeEvent) error {
+	c.reloaded <- event
+	return nil
+}
+
+func (c *keyFilterReloaderCell) ConfigKeyPrefixes() []string {
+	return c.prefixes
+}
+
+// TestBootstrap_ConfigReload_KeyFilter_SkipsUnmatched verifies that a cell with
+// ConfigKeyPrefixes()=["server."] is NOT notified when only "db.host" changes.
+func TestBootstrap_ConfigReload_KeyFilter_SkipsUnmatched(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("db:\n  host: localhost\n"), 0o644))
+
+	ln := newLocalListener(t)
+
+	asm := assembly.New(assembly.Config{ID: "test-keyfilter-skip", DurabilityMode: cell.DurabilityDemo})
+	kfc := newKeyFilterReloaderCell("server-cell", []string{"server."})
+	require.NoError(t, asm.Register(kfc))
+
+	b := New(
+		WithAssembly(asm),
+		WithConfig(cfgFile, ""),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// Change only a db.* key — server. cell must NOT be notified.
+	require.NoError(t, os.WriteFile(cfgFile, []byte("db:\n  host: db-primary\n"), 0o644))
+
+	// Wait long enough for any spurious notification to arrive.
+	select {
+	case evt := <-kfc.reloaded:
+		t.Fatalf("cell must NOT be notified when keys don't match prefix: got event %+v", evt)
+	case <-time.After(500 * time.Millisecond):
+		// expected: no notification
+	}
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// TestBootstrap_ConfigReload_KeyFilter_NotifiesMatched verifies that a cell with
+// ConfigKeyPrefixes()=["server."] IS notified when "server.port" changes.
+func TestBootstrap_ConfigReload_KeyFilter_NotifiesMatched(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("server:\n  port: 8080\n"), 0o644))
+
+	ln := newLocalListener(t)
+
+	asm := assembly.New(assembly.Config{ID: "test-keyfilter-match", DurabilityMode: cell.DurabilityDemo})
+	kfc := newKeyFilterReloaderCell("server-cell", []string{"server."})
+	require.NoError(t, asm.Register(kfc))
+
+	b := New(
+		WithAssembly(asm),
+		WithConfig(cfgFile, ""),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// Change a server.* key — server. cell MUST be notified.
+	require.NoError(t, os.WriteFile(cfgFile, []byte("server:\n  port: 9090\n"), 0o644))
+
+	select {
+	case evt := <-kfc.reloaded:
+		assert.Contains(t, evt.Updated, "server.port",
+			"event must contain the matched key")
+	case <-time.After(3 * time.Second):
+		t.Fatal("cell was not notified after matching key change")
+	}
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// TestBootstrap_ConfigReload_NoKeyFilter_ReceivesAll verifies backward
+// compatibility: a cell implementing only ConfigReloader (no ConfigKeyFilterer)
+// receives all config change notifications regardless of which keys changed.
+func TestBootstrap_ConfigReload_NoKeyFilter_ReceivesAll(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("db:\n  host: localhost\n"), 0o644))
+
+	ln := newLocalListener(t)
+
+	asm := assembly.New(assembly.Config{ID: "test-keyfilter-nofilter", DurabilityMode: cell.DurabilityDemo})
+	rc := newReloaderCell("plain-reloader")
+	require.NoError(t, asm.Register(rc))
+
+	b := New(
+		WithAssembly(asm),
+		WithConfig(cfgFile, ""),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// Change any key — plain reloader must receive notification.
+	require.NoError(t, os.WriteFile(cfgFile, []byte("db:\n  host: db-primary\n"), 0o644))
+
+	require.Eventually(t, func() bool {
+		return rc.eventCount() >= 1
+	}, 3*time.Second, 50*time.Millisecond, "plain ConfigReloader must receive all notifications")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Trust boundary: traceparent header injection (F2-SEC-03)
+// ---------------------------------------------------------------------------
+
+// traceCapturingCell registers routes that capture the trace_id from context.
+type traceCapturingCell struct {
+	*cell.BaseCell
+	verifier     auth.TokenVerifier
+	gotPublic    chan string
+	gotProtected chan string
+}
+
+func newTraceCapturingCell(id string, verifier auth.TokenVerifier) *traceCapturingCell {
+	return &traceCapturingCell{
+		BaseCell:     cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore}),
+		verifier:     verifier,
+		gotPublic:    make(chan string, 4),
+		gotProtected: make(chan string, 4),
+	}
+}
+
+func (c *traceCapturingCell) TokenVerifier() auth.TokenVerifier {
+	return c.verifier
+}
+
+func (c *traceCapturingCell) RegisterRoutes(mux cell.RouteMux) {
+	mux.Handle("GET /api/v1/public/ping", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tid, _ := ctxkeys.TraceIDFrom(r.Context())
+		c.gotPublic <- tid
+		w.WriteHeader(http.StatusOK)
+	}))
+	mux.Handle("GET /api/v1/protected/ping", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tid, _ := ctxkeys.TraceIDFrom(r.Context())
+		c.gotProtected <- tid
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// TestBootstrap_TrustBoundary_PublicEndpoint_TraceparentIgnored verifies the
+// trust boundary for traceparent headers:
+//   - Public endpoints must NOT propagate a client-supplied traceparent (new root trace).
+//   - Protected endpoints with a valid auth token MUST propagate the upstream traceparent.
+func TestBootstrap_TrustBoundary_PublicEndpoint_TraceparentIgnored(t *testing.T) {
+	ln := newLocalListener(t)
+	tracer := tracing.NewTracer("trust-test")
+
+	verifier := &bootstrapTestVerifier{
+		claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}},
+	}
+	tc := newTraceCapturingCell("trace-boundary-cell", verifier)
+
+	asm := assembly.New(assembly.Config{ID: "test-traceparent-boundary", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(tc))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithTracer(tracer),
+		WithShutdownTimeout(2*time.Second),
+		WithPublicEndpoints([]string{"/api/v1/public/ping"}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	upstreamTraceID := "aabbccddeeff00112233445566778899"
+	traceparentHeader := "00-" + upstreamTraceID + "-b7ad6b7169203331-01"
+
+	t.Run("public endpoint creates new root trace", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet,
+			fmt.Sprintf("http://%s/api/v1/public/ping", addr), nil)
+		require.NoError(t, err)
+		req.Header.Set("traceparent", traceparentHeader)
+
+		resp, err := testHTTPClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var gotTraceID string
+		select {
+		case gotTraceID = <-tc.gotPublic:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handler did not capture trace_id")
+		}
+		assert.NotEmpty(t, gotTraceID, "trace_id must be set in handler context")
+		assert.NotEqual(t, upstreamTraceID, gotTraceID,
+			"public endpoint must create a new root trace, not propagate client-supplied traceparent")
+	})
+
+	t.Run("protected endpoint continues upstream trace", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet,
+			fmt.Sprintf("http://%s/api/v1/protected/ping", addr), nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer test-token")
+		req.Header.Set("traceparent", traceparentHeader)
+
+		resp, err := testHTTPClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var gotTraceID string
+		select {
+		case gotTraceID = <-tc.gotProtected:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handler did not capture trace_id")
+		}
+		assert.Equal(t, upstreamTraceID, gotTraceID,
+			"protected endpoint must propagate upstream trace_id from traceparent header")
 	})
 
 	cancel()

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -281,28 +281,7 @@ func NewE(opts ...Option) (*Router, error) {
 		o(r)
 	}
 
-	// Derive trust-boundary policy from WithPublicEndpoints: build a single
-	// isPublic function and auto-wire tracing, request_id, and auth middleware.
-	//
-	// ref: go-zero rest/server.go — single-point route group auth config
-	// ref: otelhttp config.go — WithPublicEndpointFn per-request detection
-	if len(r.publicEndpoints) > 0 {
-		if len(r.tracingOpts) > 0 {
-			slog.Warn("router: WithPublicEndpoints overrides existing TracingOptions publicEndpointFn (last-write-wins)")
-		}
-		publicSet := make(map[string]bool, len(r.publicEndpoints))
-		for _, p := range r.publicEndpoints {
-			publicSet[path.Clean(p)] = true
-		}
-		isPublic := func(req *http.Request) bool {
-			return publicSet[path.Clean(req.URL.Path)]
-		}
-		r.tracingOpts = append(r.tracingOpts, middleware.WithPublicEndpointFn(isPublic))
-		r.requestIDOpts = append(r.requestIDOpts, middleware.WithReqIDPublicEndpointFn(isPublic))
-		if len(r.authPublicEndpoints) == 0 {
-			r.authPublicEndpoints = r.publicEndpoints
-		}
-	}
+	r.applyPublicEndpoints()
 
 	// Fail-fast: validate and construct the proxy checker once. The validated
 	// checker is passed to RealIPFromChecker so proxies are only parsed once.
@@ -378,6 +357,35 @@ func NewE(opts ...Option) (*Router, error) {
 	r.outerMux.Mount("/", r.mux)
 
 	return r, nil
+}
+
+// applyPublicEndpoints derives trust-boundary policy from WithPublicEndpoints:
+// builds isPublic function and auto-wires tracing, request_id, and auth.
+//
+// ref: go-zero rest/server.go — single-point route group auth config
+// ref: otelhttp config.go — WithPublicEndpointFn per-request detection
+func (r *Router) applyPublicEndpoints() {
+	if len(r.publicEndpoints) == 0 {
+		return
+	}
+	if len(r.tracingOpts) > 0 {
+		slog.Warn("router: WithPublicEndpoints overrides existing TracingOptions publicEndpointFn (last-write-wins)")
+	}
+	publicSet := make(map[string]bool, len(r.publicEndpoints))
+	for _, p := range r.publicEndpoints {
+		publicSet[path.Clean(p)] = true
+	}
+	isPublic := func(req *http.Request) bool {
+		return publicSet[path.Clean(req.URL.Path)]
+	}
+	r.tracingOpts = append(r.tracingOpts, middleware.WithPublicEndpointFn(isPublic))
+	r.requestIDOpts = append(r.requestIDOpts, middleware.WithReqIDPublicEndpointFn(isPublic))
+	// Standalone callers using WithPublicEndpoints without WithAuthMiddleware
+	// need authPublicEndpoints populated for the auth middleware. When bootstrap
+	// calls both, WithAuthMiddleware already sets this — the guard is a no-op.
+	if len(r.authPublicEndpoints) == 0 {
+		r.authPublicEndpoints = r.publicEndpoints
+	}
 }
 
 // Handle registers a handler for the given pattern, implementing cell.RouteMux.

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -10,6 +10,7 @@ package router
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"path"
 
@@ -115,6 +116,10 @@ func WithRequestIDOptions(opts ...middleware.RequestIDOption) Option {
 // For asymmetric policies (e.g., auth bypass without trace root), use the
 // individual WithTracingOptions / WithRequestIDOptions / WithAuthMiddleware
 // options instead.
+//
+// Note: bootstrap.WithPublicEndpoints wraps this option with auth-provider
+// discovery logic. Use this router-level option for standalone router usage
+// outside bootstrap (e.g., in tests or custom server setups).
 //
 // ref: go-zero rest/server.go — single-point route group auth config
 // ref: otelhttp config.go — WithPublicEndpointFn per-request detection
@@ -282,6 +287,9 @@ func NewE(opts ...Option) (*Router, error) {
 	// ref: go-zero rest/server.go — single-point route group auth config
 	// ref: otelhttp config.go — WithPublicEndpointFn per-request detection
 	if len(r.publicEndpoints) > 0 {
+		if len(r.tracingOpts) > 0 {
+			slog.Warn("router: WithPublicEndpoints overrides existing TracingOptions publicEndpointFn (last-write-wins)")
+		}
 		publicSet := make(map[string]bool, len(r.publicEndpoints))
 		for _, p := range r.publicEndpoints {
 			publicSet[path.Clean(p)] = true

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -11,6 +11,7 @@ package router
 import (
 	"fmt"
 	"net/http"
+	"path"
 
 	"github.com/go-chi/chi/v5"
 
@@ -102,6 +103,24 @@ func WithTracingOptions(opts ...middleware.TracingOption) Option {
 func WithRequestIDOptions(opts ...middleware.RequestIDOption) Option {
 	return func(r *Router) {
 		r.requestIDOpts = append(r.requestIDOpts, opts...)
+	}
+}
+
+// WithPublicEndpoints declares paths that are public-facing. This is the
+// recommended single-point configuration for trust boundary policy:
+//   - Auth: these paths bypass JWT verification
+//   - Tracing: these paths create new trace roots (ignore upstream traceparent)
+//   - RequestID: these paths reject client-supplied X-Request-Id headers
+//
+// For asymmetric policies (e.g., auth bypass without trace root), use the
+// individual WithTracingOptions / WithRequestIDOptions / WithAuthMiddleware
+// options instead.
+//
+// ref: go-zero rest/server.go — single-point route group auth config
+// ref: otelhttp config.go — WithPublicEndpointFn per-request detection
+func WithPublicEndpoints(paths []string) Option {
+	return func(r *Router) {
+		r.publicEndpoints = paths
 	}
 }
 
@@ -207,6 +226,7 @@ type Router struct {
 	circuitBreaker      middleware.CircuitBreakerPolicy
 	authVerifier        auth.TokenVerifier
 	authPublicEndpoints  []string
+	publicEndpoints      []string
 	securityHeadersOpts  []middleware.SecurityHeadersOption
 	bodyLimit            int64
 	trustedProxies       []string
@@ -254,6 +274,26 @@ func NewE(opts ...Option) (*Router, error) {
 	}
 	for _, o := range opts {
 		o(r)
+	}
+
+	// Derive trust-boundary policy from WithPublicEndpoints: build a single
+	// isPublic function and auto-wire tracing, request_id, and auth middleware.
+	//
+	// ref: go-zero rest/server.go — single-point route group auth config
+	// ref: otelhttp config.go — WithPublicEndpointFn per-request detection
+	if len(r.publicEndpoints) > 0 {
+		publicSet := make(map[string]bool, len(r.publicEndpoints))
+		for _, p := range r.publicEndpoints {
+			publicSet[path.Clean(p)] = true
+		}
+		isPublic := func(req *http.Request) bool {
+			return publicSet[path.Clean(req.URL.Path)]
+		}
+		r.tracingOpts = append(r.tracingOpts, middleware.WithPublicEndpointFn(isPublic))
+		r.requestIDOpts = append(r.requestIDOpts, middleware.WithReqIDPublicEndpointFn(isPublic))
+		if len(r.authPublicEndpoints) == 0 {
+			r.authPublicEndpoints = r.publicEndpoints
+		}
 	}
 
 	// Fail-fast: validate and construct the proxy checker once. The validated

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -1100,3 +1100,50 @@ func TestWithSecurityHeadersOptions_DefaultHSTS(t *testing.T) {
 	assert.NotContains(t, hsts, "preload",
 		"default HSTS must not include preload unless opted in")
 }
+
+// ---------------------------------------------------------------------------
+// WithPublicEndpoints edge cases (F3-TEST-01, F3-TEST-02)
+// ---------------------------------------------------------------------------
+
+func TestWithPublicEndpoints_EmptySlice_IsNoop(t *testing.T) {
+	tracer := tracing.NewTracer("test-empty")
+	r := New(
+		WithTracer(tracer),
+		WithPublicEndpoints([]string{}),
+	)
+
+	var traceID string
+	r.Handle("/test", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		traceID, _ = ctxkeys.TraceIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("traceparent", "00-"+upstreamTraceID+"-00f067aa0ba902b7-01")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, upstreamTraceID, traceID,
+		"empty WithPublicEndpoints must not alter tracing behavior (no-op)")
+}
+
+func TestWithPublicEndpoints_PathNormalization(t *testing.T) {
+	r := New(
+		WithPublicEndpoints([]string{"//api/v1//login"}),
+	)
+
+	var gotID string
+	r.Handle("/api/v1/login", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotID, _ = ctxkeys.RequestIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/login", nil)
+	req.Header.Set("X-Request-Id", "attacker-id")
+	r.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, "attacker-id", gotID,
+		"path.Clean must normalize //api/v1//login to /api/v1/login for matching")
+}

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -904,3 +904,199 @@ func TestWithRequestIDOptions_PublicEndpoint(t *testing.T) {
 	assert.Equal(t, "trusted-upstream-id", internalID,
 		"non-public endpoint must accept trusted upstream X-Request-Id")
 }
+
+// ---------------------------------------------------------------------------
+// WithPublicEndpoints combined trust-boundary option
+// ---------------------------------------------------------------------------
+
+func TestWithPublicEndpoints_AuthBypass(t *testing.T) {
+	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}}}
+	r := New(
+		WithPublicEndpoints([]string{"/api/v1/auth/login"}),
+		WithAuthMiddleware(verifier, nil),
+	)
+
+	var reached bool
+	r.Handle("/api/v1/auth/login", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/login", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.True(t, reached, "public endpoint must bypass auth and reach handler")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestWithPublicEndpoints_TracingNewRoot(t *testing.T) {
+	tracer := tracing.NewTracer("test-combined")
+	r := New(
+		WithTracer(tracer),
+		WithPublicEndpoints([]string{"/public"}),
+	)
+
+	var publicTraceID, internalTraceID string
+	r.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		publicTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	r.Handle("/internal", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		internalTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	tp := "00-" + upstreamTraceID + "-00f067aa0ba902b7-01"
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.Header.Set("traceparent", tp)
+	r.ServeHTTP(rec, req)
+	assert.NotEqual(t, upstreamTraceID, publicTraceID,
+		"WithPublicEndpoints: public endpoint must create new trace root")
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/internal", nil)
+	req.Header.Set("traceparent", tp)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, upstreamTraceID, internalTraceID,
+		"WithPublicEndpoints: non-public endpoint must inherit upstream trace")
+}
+
+func TestWithPublicEndpoints_RequestIDRejectsClient(t *testing.T) {
+	r := New(
+		WithPublicEndpoints([]string{"/public"}),
+	)
+
+	var publicID, internalID string
+	r.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		publicID, _ = ctxkeys.RequestIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	r.Handle("/internal", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		internalID, _ = ctxkeys.RequestIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.Header.Set("X-Request-Id", "attacker-id")
+	r.ServeHTTP(rec, req)
+	assert.NotEqual(t, "attacker-id", publicID,
+		"WithPublicEndpoints: public endpoint must reject client-supplied request ID")
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/internal", nil)
+	req.Header.Set("X-Request-Id", "trusted-upstream-id")
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, "trusted-upstream-id", internalID,
+		"WithPublicEndpoints: non-public endpoint must accept trusted upstream ID")
+}
+
+func TestWithPublicEndpoints_ProtectedStillRequiresAuth(t *testing.T) {
+	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}}}
+	r := New(
+		WithPublicEndpoints([]string{"/api/v1/auth/login"}),
+		WithAuthMiddleware(verifier, nil),
+	)
+
+	r.Handle("/api/v1/auth/login", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	r.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Protected endpoint without token → 401.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"WithPublicEndpoints: non-public endpoint must still require auth")
+}
+
+func TestWithPublicEndpoints_OverridesFineGrained(t *testing.T) {
+	tracer := tracing.NewTracer("test-combined-fine")
+	r := New(
+		WithTracer(tracer),
+		WithTracingOptions(middleware.WithPublicEndpointFn(func(req *http.Request) bool {
+			return req.URL.Path == "/fine-grained-public"
+		})),
+		WithPublicEndpoints([]string{"/public"}),
+	)
+
+	var publicTraceID, fineTraceID string
+	r.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		publicTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	r.Handle("/fine-grained-public", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		fineTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	tp := "00-" + upstreamTraceID + "-00f067aa0ba902b7-01"
+
+	// WithPublicEndpoints (last write) takes effect for /public.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.Header.Set("traceparent", tp)
+	r.ServeHTTP(rec, req)
+	assert.NotEqual(t, upstreamTraceID, publicTraceID,
+		"WithPublicEndpoints list path must create new trace root")
+
+	// Fine-grained path is NOT in WithPublicEndpoints → last-write-wins
+	// means WithPublicEndpoints' function is used, /fine-grained-public
+	// inherits upstream trace (not in public list).
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/fine-grained-public", nil)
+	req.Header.Set("traceparent", tp)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, upstreamTraceID, fineTraceID,
+		"WithPublicEndpoints overrides fine-grained option (last-write-wins)")
+}
+
+// ---------------------------------------------------------------------------
+// WithSecurityHeadersOptions wiring test (F1-ARCH-03)
+// ---------------------------------------------------------------------------
+
+func TestWithSecurityHeadersOptions_CustomHSTS(t *testing.T) {
+	r := New(
+		WithSecurityHeadersOptions(
+			middleware.WithHSTSIncludeSubDomains(),
+			middleware.WithHSTSPreload(),
+		),
+	)
+	r.Handle("/hsts-test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/hsts-test", nil)
+	r.ServeHTTP(rec, req)
+
+	hsts := rec.Header().Get("Strict-Transport-Security")
+	assert.Contains(t, hsts, "includeSubDomains",
+		"custom HSTS option must reach SecurityHeaders middleware")
+	assert.Contains(t, hsts, "preload",
+		"custom HSTS option must reach SecurityHeaders middleware")
+}
+
+func TestWithSecurityHeadersOptions_DefaultHSTS(t *testing.T) {
+	r := New()
+	r.Handle("/default-hsts", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/default-hsts", nil)
+	r.ServeHTTP(rec, req)
+
+	hsts := rec.Header().Get("Strict-Transport-Security")
+	assert.NotEmpty(t, hsts, "default SecurityHeaders must set HSTS")
+	assert.NotContains(t, hsts, "preload",
+		"default HSTS must not include preload unless opted in")
+}


### PR DESCRIPTION
## Summary
- **Router**: `WithPublicEndpoints(paths)` single-point trust boundary config (auth bypass + tracing new-root + request_id reject in one option)
- **Bootstrap**: simplified from 12-line manual wiring to 1-line `router.WithPublicEndpoints` call
- **Bootstrap**: `WithSecurityHeadersOptions()` convenience wrapper (F4-OPS-01)
- **Config**: `ConfigKeyFilterer` interface for selective reload notification (CFG-KEYFILTER-WIRE-01)
- **DTO**: nil-input guards for 12 converter functions across all cells (F3-TEST-01)
- **Tests**: SecurityHeaders wiring test (F1-ARCH-03), traceparent injection test (F2-SEC-03)
- **Assessment**: runtime/config keeps `fmt.Errorf` (infrastructure layer convention) (CFG-ERRCODE-01)

Closes PR#133 review C3 cluster (F1-ARCH-03, F2-SEC-03, F3-TEST-01, F4-OPS-01).
Phase 2 runtime layer optimization of 底座优先实施方案.

## Open source references
- go-zero `rest/server.go` — single-point route group auth config
- otelhttp `config.go` — `WithPublicEndpointFn` per-request detection
- kratos `middleware/selector` — positive-match (deviated: GoCell uses inverse/public-list)
- go-micro `config/default.go` — `Watch(path...)` key-scoped observation
- kratos `config/config.go` — `Watch(key, Observer)` single-key registration

## Test plan
- [x] `go build ./...` — 0 errors
- [x] `go test ./runtime/http/router/...` — all pass including 5 new WithPublicEndpoints tests
- [x] `go test ./runtime/bootstrap/...` — all pass including 4 new tests (SecurityHeaders, KeyFilter×2, Traceparent)
- [x] `go test ./kernel/cell/...` — ConfigKeyFilterer interface compiles
- [x] `go test ./cells/...` — 45 packages pass, 12 new nil-input tests
- [x] `go test -race ./runtime/...` — no races
- [x] `go run ./cmd/gocell validate` — 0 errors, 2 warnings (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)