### PR TITLE
feat(auth): injectable slog/clock/nonce/metrics (PR-R-AUTH)

### DIFF
--- a/runtime/auth/auth.go
+++ b/runtime/auth/auth.go
@@ -1,7 +1,3 @@
-// Package auth defines authentication and authorization interfaces for the
-// GoCell framework. Concrete implementations (e.g., JWT verification) live in
-// cells/access-core or adapters/.
-//
 // ref: go-kratos/kratos middleware/auth/auth.go — auth middleware pattern
 // Adopted: middleware wrapping pattern, Claims extraction from context.
 // Deviated: separate TokenVerifier and Authorizer interfaces (GoCell splits

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -24,8 +23,8 @@ func RequireSelfOrRole(ctx context.Context, targetID string, bypassRoles ...stri
 	}
 
 	if targetID == "" {
-		slog.Warn("authz: RequireSelfOrRole called with empty targetID",
-			slog.String("subject", subject))
+		loggerFrom(ctx).Warn("authz: RequireSelfOrRole called with empty targetID",
+			"subject", subject)
 	}
 
 	if targetID != "" && subject == targetID {

--- a/runtime/auth/authz_test.go
+++ b/runtime/auth/authz_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestRequireSelfOrRole(t *testing.T) {
 	tests := []struct {
-		name       string
-		ctx        context.Context
-		targetID   string
-		roles      []string
-		wantErr    bool
-		wantCode   errcode.Code
+		name     string
+		ctx      context.Context
+		targetID string
+		roles    []string
+		wantErr  bool
+		wantCode errcode.Code
 	}{
 		{
 			name:     "self-access allowed",

--- a/runtime/auth/authz_test.go
+++ b/runtime/auth/authz_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
@@ -160,6 +162,18 @@ func TestRequireAnyRole(t *testing.T) {
 			assert.Equal(t, tc.wantCode, ecErr.Code)
 		})
 	}
+}
+
+func TestRequireSelfOrRole_EmptyTargetID_LogsWarning(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := withLogger(context.Background(), logger)
+	ctx = ctxkeys.WithSubject(ctx, "user-1")
+	ctx = WithClaims(ctx, Claims{Subject: "user-1", Roles: []string{"admin"}})
+
+	err := RequireSelfOrRole(ctx, "", "admin")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "empty targetID")
 }
 
 func withSubjectAndClaims(subject string, roles []string) context.Context {

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -181,42 +181,63 @@ func mapClaimsToClaims(mc jwt.MapClaims) Claims {
 		c.Issuer = iss
 	}
 
-	// Parse audience (can be string or []interface{}).
-	switch aud := mc["aud"].(type) {
-	case string:
-		c.Audience = []string{aud}
-	case []any:
-		for _, a := range aud {
-			if s, ok := a.(string); ok {
-				c.Audience = append(c.Audience, s)
-			}
-		}
-	}
-
-	// Parse roles ([]interface{}).
-	if roles, ok := mc["roles"].([]any); ok {
-		for _, r := range roles {
-			if s, ok := r.(string); ok {
-				c.Roles = append(c.Roles, s)
-			}
-		}
-	}
-
-	// Parse timestamps.
-	if exp, ok := mc["exp"].(float64); ok {
-		c.ExpiresAt = time.Unix(int64(exp), 0)
-	}
-	if iat, ok := mc["iat"].(float64); ok {
-		c.IssuedAt = time.Unix(int64(iat), 0)
-	}
-
-	// Collect extra claims.
-	standard := map[string]bool{"sub": true, "iss": true, "aud": true, "exp": true, "iat": true, "nbf": true, "roles": true}
-	for k, v := range mc {
-		if !standard[k] {
-			c.Extra[k] = v
-		}
-	}
+	c.Audience = parseAudience(mc["aud"])
+	c.Roles = parseStringSlice(mc["roles"])
+	c.ExpiresAt = parseUnixTime(mc["exp"])
+	c.IssuedAt = parseUnixTime(mc["iat"])
+	c.Extra = collectExtraClaims(mc)
 
 	return c
+}
+
+func parseAudience(v any) []string {
+	switch aud := v.(type) {
+	case string:
+		return []string{aud}
+	case []any:
+		return filterStrings(aud)
+	default:
+		return nil
+	}
+}
+
+func parseStringSlice(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	return filterStrings(arr)
+}
+
+func filterStrings(arr []any) []string {
+	var out []string
+	for _, a := range arr {
+		if s, ok := a.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func parseUnixTime(v any) time.Time {
+	f, ok := v.(float64)
+	if !ok {
+		return time.Time{}
+	}
+	return time.Unix(int64(f), 0)
+}
+
+var standardClaims = map[string]bool{
+	"sub": true, "iss": true, "aud": true,
+	"exp": true, "iat": true, "nbf": true, "roles": true,
+}
+
+func collectExtraClaims(mc jwt.MapClaims) map[string]any {
+	extra := make(map[string]any)
+	for k, v := range mc {
+		if !standardClaims[k] {
+			extra[k] = v
+		}
+	}
+	return extra
 }

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -32,9 +32,12 @@ type JWTVerifierOption func(*JWTVerifier)
 
 // WithVerifierClock overrides the time source used for token expiry validation.
 // Delegates to golang-jwt/jwt v5's WithTimeFunc ParserOption.
+// A nil fn is ignored; the verifier uses time.Now by default.
 func WithVerifierClock(fn func() time.Time) JWTVerifierOption {
 	return func(v *JWTVerifier) {
-		v.parserOpts = append(v.parserOpts, jwt.WithTimeFunc(fn))
+		if fn != nil {
+			v.parserOpts = append(v.parserOpts, jwt.WithTimeFunc(fn))
+		}
 	}
 }
 
@@ -110,8 +113,13 @@ type JWTIssuer struct {
 type JWTIssuerOption func(*JWTIssuer)
 
 // WithIssuerClock overrides the time source used for iat/exp claim generation.
+// A nil fn is ignored; the issuer uses time.Now by default.
 func WithIssuerClock(fn func() time.Time) JWTIssuerOption {
-	return func(i *JWTIssuer) { i.now = fn }
+	return func(i *JWTIssuer) {
+		if fn != nil {
+			i.now = fn
+		}
+	}
 }
 
 // NewJWTIssuer creates a JWTIssuer using the active signing key from the provider.

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -20,17 +20,35 @@ const DefaultAccessTokenTTL = 15 * time.Minute
 // Adopted: KeyFunc-based verification, Claims extraction from context.
 // Deviated: RS256 pinned (no configurable signing method), refuses HS256/none.
 // Extended: kid-based key lookup from VerificationKeyStore (RFC 7638 thumbprint).
+//
+// ref: golang-jwt/jwt v5 parser_option.go -- WithTimeFunc for clock injection.
 type JWTVerifier struct {
-	keys VerificationKeyStore
+	keys       VerificationKeyStore
+	parserOpts []jwt.ParserOption
+}
+
+// JWTVerifierOption configures a JWTVerifier.
+type JWTVerifierOption func(*JWTVerifier)
+
+// WithVerifierClock overrides the time source used for token expiry validation.
+// Delegates to golang-jwt/jwt v5's WithTimeFunc ParserOption.
+func WithVerifierClock(fn func() time.Time) JWTVerifierOption {
+	return func(v *JWTVerifier) {
+		v.parserOpts = append(v.parserOpts, jwt.WithTimeFunc(fn))
+	}
 }
 
 // NewJWTVerifier creates a JWTVerifier that validates tokens by looking up the
 // signing key from the VerificationKeyStore using the token's kid header.
-func NewJWTVerifier(keys VerificationKeyStore) (*JWTVerifier, error) {
+func NewJWTVerifier(keys VerificationKeyStore, opts ...JWTVerifierOption) (*JWTVerifier, error) {
 	if keys == nil {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "verification key store must not be nil")
 	}
-	return &JWTVerifier{keys: keys}, nil
+	v := &JWTVerifier{keys: keys}
+	for _, o := range opts {
+		o(v)
+	}
+	return v, nil
 }
 
 // Verify validates the token string and returns Claims on success.
@@ -63,7 +81,7 @@ func (v *JWTVerifier) Verify(_ context.Context, tokenStr string) (Claims, error)
 			return nil, fmt.Errorf("key lookup failed for kid %s: %w", kid, err)
 		}
 		return pub, nil
-	})
+	}, v.parserOpts...)
 	if err != nil {
 		return Claims{}, errcode.Wrap(errcode.ErrAuthUnauthorized, "token verification failed", err)
 	}
@@ -85,18 +103,32 @@ type JWTIssuer struct {
 	keys   SigningKeyProvider
 	issuer string
 	ttl    time.Duration
+	now    func() time.Time
+}
+
+// JWTIssuerOption configures a JWTIssuer.
+type JWTIssuerOption func(*JWTIssuer)
+
+// WithIssuerClock overrides the time source used for iat/exp claim generation.
+func WithIssuerClock(fn func() time.Time) JWTIssuerOption {
+	return func(i *JWTIssuer) { i.now = fn }
 }
 
 // NewJWTIssuer creates a JWTIssuer using the active signing key from the provider.
-func NewJWTIssuer(keys SigningKeyProvider, issuer string, ttl time.Duration) (*JWTIssuer, error) {
+func NewJWTIssuer(keys SigningKeyProvider, issuer string, ttl time.Duration, opts ...JWTIssuerOption) (*JWTIssuer, error) {
 	if keys == nil {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "signing key provider must not be nil")
 	}
-	return &JWTIssuer{
+	i := &JWTIssuer{
 		keys:   keys,
 		issuer: issuer,
 		ttl:    ttl,
-	}, nil
+		now:    time.Now,
+	}
+	for _, o := range opts {
+		o(i)
+	}
+	return i, nil
 }
 
 // Issue creates a signed JWT token for the given subject and roles.
@@ -107,7 +139,7 @@ func (i *JWTIssuer) Issue(subject string, roles []string, audience []string, ses
 	if i.keys.SigningKey() == nil {
 		return "", errcode.New(errcode.ErrAuthKeyInvalid, "signing key is nil")
 	}
-	now := time.Now()
+	now := i.now()
 	claims := jwt.MapClaims{
 		"sub": subject,
 		"iss": i.issuer,

--- a/runtime/auth/jwt_test.go
+++ b/runtime/auth/jwt_test.go
@@ -596,3 +596,21 @@ func TestLoadKeysFromEnv_PKCS8(t *testing.T) {
 	assert.NotNil(t, priv)
 	assert.NotNil(t, pub)
 }
+
+func TestWithIssuerClock_NilIgnored(t *testing.T) {
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "test", time.Hour, WithIssuerClock(nil))
+	require.NoError(t, err)
+	// Should use time.Now (default), not panic.
+	token, err := issuer.Issue("user-1", nil, nil, "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+}
+
+func TestWithVerifierClock_NilIgnored(t *testing.T) {
+	ks := mustTestKeySet(t)
+	verifier, err := NewJWTVerifier(ks, WithVerifierClock(nil))
+	require.NoError(t, err)
+	// Should not panic on construction.
+	assert.NotNil(t, verifier)
+}

--- a/runtime/auth/keys.go
+++ b/runtime/auth/keys.go
@@ -82,6 +82,15 @@ func WithKeySetLogger(l *slog.Logger) KeySetOption {
 	}
 }
 
+// WithKeySetClock overrides the time source for key expiry checks.
+func WithKeySetClock(fn func() time.Time) KeySetOption {
+	return func(ks *KeySet) {
+		if fn != nil {
+			ks.now = fn
+		}
+	}
+}
+
 // NewKeySet creates a KeySet with a single active signing key pair.
 // The kid is derived deterministically from the public key using RFC 7638.
 func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey, opts ...KeySetOption) (*KeySet, error) {

--- a/runtime/auth/keys.go
+++ b/runtime/auth/keys.go
@@ -67,11 +67,24 @@ type KeySet struct {
 	keyIndex         map[string]*rsa.PublicKey // kid → public key
 	keyExpiry        map[string]time.Time      // kid → expiry (signing key absent = never expires)
 	now              func() time.Time          // injectable clock for testing; defaults to time.Now
+	logger           *slog.Logger
+}
+
+// KeySetOption configures KeySet behavior.
+type KeySetOption func(*KeySet)
+
+// WithKeySetLogger sets the logger for a KeySet.
+func WithKeySetLogger(l *slog.Logger) KeySetOption {
+	return func(ks *KeySet) {
+		if l != nil {
+			ks.logger = l
+		}
+	}
 }
 
 // NewKeySet creates a KeySet with a single active signing key pair.
 // The kid is derived deterministically from the public key using RFC 7638.
-func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey) (*KeySet, error) {
+func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey, opts ...KeySetOption) (*KeySet, error) {
 	if priv == nil || pub == nil {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "signing key pair must not be nil")
 	}
@@ -96,11 +109,15 @@ func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey) (*KeySet, error) {
 		keyIndex:     map[string]*rsa.PublicKey{kid: pub},
 		keyExpiry:    make(map[string]time.Time),
 		now:          time.Now,
+		logger:       slog.Default(),
+	}
+	for _, o := range opts {
+		o(ks)
 	}
 
-	slog.Info("key activated",
-		slog.String("kid", kid),
-		slog.String("transition", "activated"),
+	ks.logger.Info("key activated",
+		"kid", kid,
+		"transition", "activated",
 	)
 
 	return ks, nil
@@ -109,8 +126,8 @@ func NewKeySet(priv *rsa.PrivateKey, pub *rsa.PublicKey) (*KeySet, error) {
 // NewKeySetWithVerificationKeys creates a KeySet with an active signing key
 // and one or more verification-only keys. Keys that are already expired at
 // construction time are pruned immediately.
-func NewKeySetWithVerificationKeys(priv *rsa.PrivateKey, pub *rsa.PublicKey, vkeys []VerificationKey) (*KeySet, error) {
-	ks, err := NewKeySet(priv, pub)
+func NewKeySetWithVerificationKeys(priv *rsa.PrivateKey, pub *rsa.PublicKey, vkeys []VerificationKey, opts ...KeySetOption) (*KeySet, error) {
+	ks, err := NewKeySet(priv, pub, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -127,20 +144,20 @@ func NewKeySetWithVerificationKeys(priv *rsa.PrivateKey, pub *rsa.PublicKey, vke
 			return nil, err
 		}
 		if !now.Before(vk.ExpiresAt) {
-			slog.Info("key pruned",
-				slog.String("kid", vk.KeyID),
-				slog.String("transition", "pruned"),
-				slog.String("reason", "already expired at load time"),
+			ks.logger.Info("key pruned",
+				"kid", vk.KeyID,
+				"transition", "pruned",
+				"reason", "already expired at load time",
 			)
 			continue
 		}
 		ks.verificationKeys = append(ks.verificationKeys, vk)
 		ks.keyIndex[vk.KeyID] = vk.PublicKey
 		ks.keyExpiry[vk.KeyID] = vk.ExpiresAt
-		slog.Info("key demoted to verification-only",
-			slog.String("kid", vk.KeyID),
-			slog.String("transition", "verification-only"),
-			slog.Time("expiresAt", vk.ExpiresAt),
+		ks.logger.Info("key demoted to verification-only",
+			"kid", vk.KeyID,
+			"transition", "verification-only",
+			"expiresAt", vk.ExpiresAt,
 		)
 	}
 
@@ -203,9 +220,9 @@ func (ks *KeySet) PruneExpired() {
 		} else {
 			delete(ks.keyIndex, vk.KeyID)
 			delete(ks.keyExpiry, vk.KeyID)
-			slog.Info("key pruned",
-				slog.String("kid", vk.KeyID),
-				slog.String("transition", "pruned"),
+			ks.logger.Info("key pruned",
+				"kid", vk.KeyID,
+				"transition", "pruned",
 			)
 		}
 	}

--- a/runtime/auth/keys_test.go
+++ b/runtime/auth/keys_test.go
@@ -245,7 +245,7 @@ func TestKeySet_PruneExpired_AfterTimeAdvance(t *testing.T) {
 	assert.Equal(t, pub2, got)
 
 	// Advance clock past expiry using injectable now func.
-	ks.now = func() time.Time { return baseTime.Add(2 * time.Hour) }
+	WithKeySetClock(func() time.Time { return baseTime.Add(2 * time.Hour) })(ks)
 
 	// Key should be pruned now.
 	_, err = ks.PublicKeyByKID(vk.KeyID)
@@ -441,7 +441,7 @@ func TestKeySet_LifecycleLog_Pruning(t *testing.T) {
 	require.NoError(t, err)
 
 	// Advance clock past expiry.
-	ks.now = func() time.Time { return baseTime.Add(2 * time.Hour) }
+	WithKeySetClock(func() time.Time { return baseTime.Add(2 * time.Hour) })(ks)
 
 	// Reset buffer so only PruneExpired log is captured.
 	buf.Reset()

--- a/runtime/auth/keys_test.go
+++ b/runtime/auth/keys_test.go
@@ -392,12 +392,9 @@ func TestLoadKeySetFromEnv_InvalidExpiryFails(t *testing.T) {
 func TestKeySet_LifecycleLog_Activation(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
-	orig := slog.Default()
-	slog.SetDefault(logger)
-	defer slog.SetDefault(orig)
 
 	priv, pub := generateTestKeyPair(t)
-	_, err := NewKeySet(priv, pub)
+	_, err := NewKeySet(priv, pub, WithKeySetLogger(logger))
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -408,9 +405,6 @@ func TestKeySet_LifecycleLog_Activation(t *testing.T) {
 func TestKeySet_LifecycleLog_VerificationOnly(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
-	orig := slog.Default()
-	slog.SetDefault(logger)
-	defer slog.SetDefault(orig)
 
 	priv1, pub1 := generateTestKeyPair(t)
 	_, pub2 := generateTestKeyPair(t)
@@ -421,7 +415,7 @@ func TestKeySet_LifecycleLog_VerificationOnly(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	}
 
-	_, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	_, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk}, WithKeySetLogger(logger))
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -430,6 +424,9 @@ func TestKeySet_LifecycleLog_VerificationOnly(t *testing.T) {
 }
 
 func TestKeySet_LifecycleLog_Pruning(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
 	priv1, pub1 := generateTestKeyPair(t)
 	_, pub2 := generateTestKeyPair(t)
 
@@ -440,17 +437,14 @@ func TestKeySet_LifecycleLog_Pruning(t *testing.T) {
 		ExpiresAt: baseTime.Add(time.Hour),
 	}
 
-	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk})
+	ks, err := NewKeySetWithVerificationKeys(priv1, pub1, []VerificationKey{vk}, WithKeySetLogger(logger))
 	require.NoError(t, err)
 
 	// Advance clock past expiry.
 	ks.now = func() time.Time { return baseTime.Add(2 * time.Hour) }
 
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, nil))
-	orig := slog.Default()
-	slog.SetDefault(logger)
-	defer slog.SetDefault(orig)
+	// Reset buffer so only PruneExpired log is captured.
+	buf.Reset()
 
 	ks.PruneExpired()
 

--- a/runtime/auth/metrics.go
+++ b/runtime/auth/metrics.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
+)
+
+// AuthMetrics holds pre-registered metric instruments for auth operations.
+type AuthMetrics struct {
+	tokenVerifyTotal    metrics.CounterVec
+	tokenVerifyDuration metrics.HistogramVec
+	serviceVerifyTotal  metrics.CounterVec
+}
+
+// NewAuthMetrics registers auth metric instruments with the given provider.
+func NewAuthMetrics(p metrics.Provider) (*AuthMetrics, error) {
+	if p == nil {
+		return nil, fmt.Errorf("auth: metrics provider must not be nil")
+	}
+
+	tvt, err := p.CounterVec(metrics.CounterOpts{
+		Name:       "auth_token_verify_total",
+		Help:       "Total number of JWT token verifications.",
+		LabelNames: []string{"result", "reason"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("auth: register auth_token_verify_total: %w", err)
+	}
+
+	tvd, err := p.HistogramVec(metrics.HistogramOpts{
+		Name:       "auth_token_verify_duration_seconds",
+		Help:       "Duration of JWT token verification in seconds.",
+		LabelNames: []string{"result"},
+		Buckets:    []float64{.0001, .0005, .001, .005, .01, .025, .05, .1},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("auth: register auth_token_verify_duration_seconds: %w", err)
+	}
+
+	svt, err := p.CounterVec(metrics.CounterOpts{
+		Name:       "auth_service_token_verify_total",
+		Help:       "Total number of service token verifications.",
+		LabelNames: []string{"result", "reason"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("auth: register auth_service_token_verify_total: %w", err)
+	}
+
+	return &AuthMetrics{
+		tokenVerifyTotal:    tvt,
+		tokenVerifyDuration: tvd,
+		serviceVerifyTotal:  svt,
+	}, nil
+}
+
+func (m *AuthMetrics) recordTokenVerify(result, reason string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.tokenVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc()
+	m.tokenVerifyDuration.With(metrics.Labels{"result": result}).Observe(duration.Seconds())
+}
+
+func (m *AuthMetrics) recordServiceVerify(result, reason string) {
+	if m == nil {
+		return
+	}
+	m.serviceVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc()
+}
+
+// classifyTokenError maps a token verification error to a short reason label.
+func classifyTokenError(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "expired") || strings.Contains(msg, "not valid yet"):
+		return "expired"
+	case strings.Contains(msg, "kid"):
+		return "invalid_kid"
+	case strings.Contains(msg, "signing method"):
+		return "wrong_alg"
+	default:
+		return "invalid_signature"
+	}
+}

--- a/runtime/auth/metrics.go
+++ b/runtime/auth/metrics.go
@@ -12,6 +12,10 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// ref: go-kratos/kratos middleware/metrics/metrics.go — nil-guard fast-path pattern.
+// Adopted: counter+histogram with label-based classification.
+// Deviated: auth-specific reason labels (expired/invalid_kid/wrong_alg) vs generic code labels.
+
 // AuthMetrics holds pre-registered metric instruments for auth operations.
 type AuthMetrics struct {
 	tokenVerifyTotal    metrics.CounterVec

--- a/runtime/auth/metrics.go
+++ b/runtime/auth/metrics.go
@@ -1,11 +1,15 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // AuthMetrics holds pre-registered metric instruments for auth operations.
@@ -18,7 +22,7 @@ type AuthMetrics struct {
 // NewAuthMetrics registers auth metric instruments with the given provider.
 func NewAuthMetrics(p metrics.Provider) (*AuthMetrics, error) {
 	if p == nil {
-		return nil, fmt.Errorf("auth: metrics provider must not be nil")
+		return nil, errcode.New(errcode.ErrValidationFailed, "auth: metrics provider must not be nil")
 	}
 
 	tvt, err := p.CounterVec(metrics.CounterOpts{
@@ -76,15 +80,22 @@ func classifyTokenError(err error) string {
 	if err == nil {
 		return "ok"
 	}
-	msg := err.Error()
 	switch {
-	case strings.Contains(msg, "expired") || strings.Contains(msg, "not valid yet"):
+	case errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet):
 		return "expired"
-	case strings.Contains(msg, "kid"):
-		return "invalid_kid"
-	case strings.Contains(msg, "signing method"):
-		return "wrong_alg"
-	default:
+	case errors.Is(err, jwt.ErrTokenSignatureInvalid):
 		return "invalid_signature"
+	default:
+		// Covers invalid kid, wrong signing method, malformed tokens.
+		// jwt.ErrTokenMalformed, jwt.ErrTokenUnverifiable, and custom keyFunc errors.
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "kid"):
+			return "invalid_kid"
+		case strings.Contains(msg, "signing method"):
+			return "wrong_alg"
+		default:
+			return "invalid_token"
+		}
 	}
 }

--- a/runtime/auth/metrics.go
+++ b/runtime/auth/metrics.go
@@ -72,6 +72,16 @@ func (m *AuthMetrics) recordTokenVerify(result, reason string, duration time.Dur
 	m.tokenVerifyDuration.With(metrics.Labels{"result": result}).Observe(duration.Seconds())
 }
 
+// recordTokenVerifyCounter increments the token verify counter without recording
+// a duration. Used for early-exit paths (e.g. missing token) where no
+// verification work was performed and a 0 duration would pollute the histogram.
+func (m *AuthMetrics) recordTokenVerifyCounter(result, reason string) {
+	if m == nil {
+		return
+	}
+	m.tokenVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc()
+}
+
 func (m *AuthMetrics) recordServiceVerify(result, reason string) {
 	if m == nil {
 		return

--- a/runtime/auth/metrics_test.go
+++ b/runtime/auth/metrics_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/runtime/auth/metrics_test.go
+++ b/runtime/auth/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,24 +47,21 @@ func TestAuthMetrics_NilSafe(t *testing.T) {
 
 func TestClassifyTokenError(t *testing.T) {
 	tests := []struct {
-		name   string
-		errMsg string
-		want   string
+		name string
+		err  error
+		want string
 	}{
-		{"nil error", "", "ok"},
-		{"expired", "token is expired", "expired"},
-		{"not valid yet", "token is not valid yet", "expired"},
-		{"kid", "missing kid header", "invalid_kid"},
-		{"signing method", "unexpected signing method", "wrong_alg"},
-		{"other", "something else", "invalid_signature"},
+		{"nil", nil, "ok"},
+		{"jwt expired", jwt.ErrTokenExpired, "expired"},
+		{"jwt not valid yet", jwt.ErrTokenNotValidYet, "expired"},
+		{"jwt invalid signature", jwt.ErrTokenSignatureInvalid, "invalid_signature"},
+		{"kid error", fmt.Errorf("token verification failed: missing kid header"), "invalid_kid"},
+		{"wrong alg", fmt.Errorf("token verification failed: unexpected signing method: HS256"), "wrong_alg"},
+		{"other", fmt.Errorf("something unexpected"), "invalid_token"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var err error
-			if tt.errMsg != "" {
-				err = fmt.Errorf("%s", tt.errMsg)
-			}
-			assert.Equal(t, tt.want, classifyTokenError(err))
+			assert.Equal(t, tt.want, classifyTokenError(tt.err))
 		})
 	}
 }

--- a/runtime/auth/metrics_test.go
+++ b/runtime/auth/metrics_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAuthMetrics_NopProvider(t *testing.T) {
+	am, err := NewAuthMetrics(metrics.NopProvider{})
+	require.NoError(t, err)
+	require.NotNil(t, am)
+}
+
+func TestNewAuthMetrics_NilProvider(t *testing.T) {
+	_, err := NewAuthMetrics(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be nil")
+}
+
+func TestAuthMetrics_RecordTokenVerify_NoPanic(t *testing.T) {
+	am, err := NewAuthMetrics(metrics.NopProvider{})
+	require.NoError(t, err)
+	// Should not panic with valid labels.
+	am.recordTokenVerify("success", "ok", 5*time.Millisecond)
+	am.recordTokenVerify("failure", "expired", time.Millisecond)
+}
+
+func TestAuthMetrics_RecordServiceVerify_NoPanic(t *testing.T) {
+	am, err := NewAuthMetrics(metrics.NopProvider{})
+	require.NoError(t, err)
+	am.recordServiceVerify("success", "ok")
+	am.recordServiceVerify("failure", "expired")
+}
+
+func TestAuthMetrics_NilSafe(t *testing.T) {
+	// nil AuthMetrics should not panic.
+	var am *AuthMetrics
+	am.recordTokenVerify("success", "ok", time.Millisecond)
+	am.recordServiceVerify("success", "ok")
+}
+
+func TestClassifyTokenError(t *testing.T) {
+	tests := []struct {
+		name   string
+		errMsg string
+		want   string
+	}{
+		{"nil error", "", "ok"},
+		{"expired", "token is expired", "expired"},
+		{"not valid yet", "token is not valid yet", "expired"},
+		{"kid", "missing kid header", "invalid_kid"},
+		{"signing method", "unexpected signing method", "wrong_alg"},
+		{"other", "something else", "invalid_signature"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			if tt.errMsg != "" {
+				err = fmt.Errorf("%s", tt.errMsg)
+			}
+			assert.Equal(t, tt.want, classifyTokenError(err))
+		})
+	}
+}

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -91,43 +91,62 @@ func RequireRole(authorizer Authorizer, roles ...string) func(http.Handler) http
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			claims, ok := ClaimsFrom(r.Context())
-			if !ok {
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "authentication required")
-				return
-			}
-
-			// Check if any of the user's roles match the required roles.
-			for _, role := range claims.Roles {
-				if roleSet[role] {
-					next.ServeHTTP(w, r)
-					return
-				}
-			}
-
-			// If an Authorizer is provided, try policy-based authorization.
-			if authorizer != nil {
-				sub := claims.Subject
-				for _, role := range roles {
-					allowed, err := authorizer.Authorize(r.Context(), sub, r.URL.Path, role)
-					if err != nil {
-						loggerFrom(r.Context()).Error("authorization check failed",
-							"error", err,
-							"subject", sub,
-						)
-						httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
-						return
-					}
-					if allowed {
-						next.ServeHTTP(w, r)
-						return
-					}
-				}
-			}
-
-			httputil.WriteError(r.Context(), w, http.StatusForbidden, "ERR_AUTH_FORBIDDEN", "insufficient permissions")
+			handleRequireRole(authorizer, roles, roleSet, next, w, r)
 		})
 	}
+}
+
+func handleRequireRole(authorizer Authorizer, roles []string, roleSet map[string]bool, next http.Handler, w http.ResponseWriter, r *http.Request) {
+	claims, ok := ClaimsFrom(r.Context())
+	if !ok {
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "authentication required")
+		return
+	}
+
+	if hasMatchingRole(claims, roleSet) {
+		next.ServeHTTP(w, r)
+		return
+	}
+
+	if authorizer != nil {
+		allowed, err := checkAuthorizer(authorizer, r, claims.Subject, roles)
+		if err != nil {
+			loggerFrom(r.Context()).Error("authorization check failed",
+				"error", err,
+				"subject", claims.Subject,
+			)
+			httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
+			return
+		}
+		if allowed {
+			next.ServeHTTP(w, r)
+			return
+		}
+	}
+
+	httputil.WriteError(r.Context(), w, http.StatusForbidden, "ERR_AUTH_FORBIDDEN", "insufficient permissions")
+}
+
+func hasMatchingRole(claims Claims, roleSet map[string]bool) bool {
+	for _, role := range claims.Roles {
+		if roleSet[role] {
+			return true
+		}
+	}
+	return false
+}
+
+func checkAuthorizer(authorizer Authorizer, r *http.Request, subject string, roles []string) (bool, error) {
+	for _, role := range roles {
+		allowed, err := authorizer.Authorize(r.Context(), subject, r.URL.Path, role)
+		if err != nil {
+			return false, err
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func extractBearerToken(r *http.Request) string {

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -53,7 +53,7 @@ func AuthMiddleware(verifier TokenVerifier, publicEndpoints []string, opts ...Au
 
 			token := extractBearerToken(r)
 			if token == "" {
-				cfg.metrics.recordTokenVerify("failure", "missing", 0)
+				cfg.metrics.recordTokenVerifyCounter("failure", "missing")
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "missing or invalid authorization header")
 				return
 			}
@@ -141,4 +141,3 @@ func extractBearerToken(r *http.Request) string {
 	}
 	return strings.TrimSpace(parts[1])
 }
-

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -1,10 +1,10 @@
 package auth
 
 import (
-	"log/slog"
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -28,7 +28,12 @@ var DefaultPublicEndpoints = []string{}
 // publicEndpoints specifies paths that bypass authentication. If nil,
 // DefaultPublicEndpoints is used. Paths are normalized via path.Clean before
 // matching, consistent with other security middleware in this package.
-func AuthMiddleware(verifier TokenVerifier, publicEndpoints []string) func(http.Handler) http.Handler {
+func AuthMiddleware(verifier TokenVerifier, publicEndpoints []string, opts ...AuthOption) func(http.Handler) http.Handler {
+	cfg := defaultAuthConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	publicPaths := publicEndpoints
 	if publicPaths == nil {
 		publicPaths = DefaultPublicEndpoints
@@ -48,23 +53,28 @@ func AuthMiddleware(verifier TokenVerifier, publicEndpoints []string) func(http.
 
 			token := extractBearerToken(r)
 			if token == "" {
+				cfg.metrics.recordTokenVerify("failure", "missing", 0)
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "missing or invalid authorization header")
 				return
 			}
 
+			start := time.Now()
 			claims, err := verifier.Verify(r.Context(), token)
 			if err != nil {
-				slog.Error("token verification failed",
-					slog.Any("error", err),
-					slog.String("path", r.URL.Path),
-					slog.String("remote_addr", r.RemoteAddr),
+				cfg.metrics.recordTokenVerify("failure", classifyTokenError(err), time.Since(start))
+				cfg.logger.Error("token verification failed",
+					"error", err,
+					"path", r.URL.Path,
+					"remote_addr", r.RemoteAddr,
 				)
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid token")
 				return
 			}
+			cfg.metrics.recordTokenVerify("success", "ok", time.Since(start))
 
 			ctx := WithClaims(r.Context(), claims)
 			ctx = ctxkeys.WithSubject(ctx, claims.Subject)
+			ctx = withLogger(ctx, cfg.logger)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -101,9 +111,9 @@ func RequireRole(authorizer Authorizer, roles ...string) func(http.Handler) http
 				for _, role := range roles {
 					allowed, err := authorizer.Authorize(r.Context(), sub, r.URL.Path, role)
 					if err != nil {
-						slog.Error("authorization check failed",
-							slog.Any("error", err),
-							slog.String("subject", sub),
+						loggerFrom(r.Context()).Error("authorization check failed",
+							"error", err,
+							"subject", sub,
 						)
 						httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
 						return

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -1,9 +1,11 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -270,6 +272,25 @@ func TestRequireRole_AuthorizerError(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestAuthMiddleware_WithLogger_LogsToBuffer(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	verifier := &mockVerifier{err: errors.New("token expired")}
+	handler := AuthMiddleware(verifier, nil, WithLogger(logger))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("should not be called")
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, buf.String(), "token verification failed")
 }
 
 func assertErrorCode(t *testing.T, rec *httptest.ResponseRecorder, code string) {

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -291,6 +292,38 @@ func TestAuthMiddleware_WithLogger_LogsToBuffer(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Contains(t, buf.String(), "token verification failed")
+}
+
+func TestAuthMiddleware_WithMetrics_NoPanic(t *testing.T) {
+	am, err := NewAuthMetrics(metrics.NopProvider{})
+	require.NoError(t, err)
+
+	verifier := &mockVerifier{claims: Claims{Subject: "user-1"}}
+	handler := AuthMiddleware(verifier, nil, WithMetrics(am))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	// Success path.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Failure path.
+	failVerifier := &mockVerifier{err: errors.New("expired")}
+	failHandler := AuthMiddleware(failVerifier, nil, WithMetrics(am))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("should not be called")
+		}),
+	)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+	req2.Header.Set("Authorization", "Bearer bad-token")
+	rec2 := httptest.NewRecorder()
+	failHandler.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
 }
 
 func assertErrorCode(t *testing.T, rec *httptest.ResponseRecorder, code string) {

--- a/runtime/auth/nonce.go
+++ b/runtime/auth/nonce.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -54,7 +55,12 @@ func WithMaxNonceEntries(n int) InMemoryNonceOption {
 }
 
 // NewInMemoryNonceStore creates an InMemoryNonceStore with the given maxAge.
-func NewInMemoryNonceStore(maxAge time.Duration, opts ...InMemoryNonceOption) *InMemoryNonceStore {
+// maxAge must be positive; a zero or negative value makes replay protection
+// ineffective and is rejected with an error.
+func NewInMemoryNonceStore(maxAge time.Duration, opts ...InMemoryNonceOption) (*InMemoryNonceStore, error) {
+	if maxAge <= 0 {
+		return nil, fmt.Errorf("auth: nonce store maxAge must be positive, got %v", maxAge)
+	}
 	s := &InMemoryNonceStore{
 		seen:       make(map[string]time.Time),
 		maxAge:     maxAge,
@@ -64,7 +70,7 @@ func NewInMemoryNonceStore(maxAge time.Duration, opts ...InMemoryNonceOption) *I
 	for _, o := range opts {
 		o(s)
 	}
-	return s
+	return s, nil
 }
 
 // CheckAndMark checks whether nonce has been seen within its TTL window. If

--- a/runtime/auth/nonce.go
+++ b/runtime/auth/nonce.go
@@ -18,6 +18,9 @@ var ErrNonceReused = errors.New("auth: nonce already used")
 // forced prune is triggered in InMemoryNonceStore.CheckAndMark.
 const defaultMaxNonceEntries = 100000
 
+// ref: none — no direct framework analog for HMAC nonce store; adopted
+// standard sync.Mutex + map-with-TTL pattern (cf. gorilla/securecookie token store).
+
 // NonceStore tracks nonces for replay prevention. Implementations must be
 // safe for concurrent use. The store must retain nonces for at least
 // ServiceTokenMaxAge (5 minutes) to prevent replay within the token

--- a/runtime/auth/nonce.go
+++ b/runtime/auth/nonce.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrNonceReused is returned by NonceStore.CheckAndMark when a nonce has
+// already been consumed within its TTL window.
+var ErrNonceReused = errors.New("auth: nonce already used")
+
+// NonceStore tracks nonces for replay prevention. Implementations must be
+// safe for concurrent use.
+type NonceStore interface {
+	CheckAndMark(ctx context.Context, nonce string) error
+}
+
+// InMemoryNonceStore is a NonceStore backed by a map with lazy expiry pruning.
+// Suitable for single-instance deployments.
+type InMemoryNonceStore struct {
+	mu     sync.Mutex
+	seen   map[string]time.Time // nonce → expiry
+	maxAge time.Duration
+	now    func() time.Time
+}
+
+// InMemoryNonceOption configures an InMemoryNonceStore.
+type InMemoryNonceOption func(*InMemoryNonceStore)
+
+// WithNonceClock overrides the time source (for testing).
+func WithNonceClock(fn func() time.Time) InMemoryNonceOption {
+	return func(s *InMemoryNonceStore) { s.now = fn }
+}
+
+// NewInMemoryNonceStore creates an InMemoryNonceStore with the given maxAge.
+func NewInMemoryNonceStore(maxAge time.Duration, opts ...InMemoryNonceOption) *InMemoryNonceStore {
+	s := &InMemoryNonceStore{
+		seen:   make(map[string]time.Time),
+		maxAge: maxAge,
+		now:    time.Now,
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// CheckAndMark checks whether nonce has been seen within its TTL window. If
+// not, it records the nonce and returns nil. If the nonce is still live,
+// ErrNonceReused is returned.
+func (s *InMemoryNonceStore) CheckAndMark(_ context.Context, nonce string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+
+	// Lazy prune when map grows large.
+	if len(s.seen) > 1000 {
+		for k, exp := range s.seen {
+			if now.After(exp) {
+				delete(s.seen, k)
+			}
+		}
+	}
+
+	if exp, exists := s.seen[nonce]; exists && now.Before(exp) {
+		return ErrNonceReused
+	}
+
+	s.seen[nonce] = now.Add(s.maxAge)
+	return nil
+}

--- a/runtime/auth/nonce.go
+++ b/runtime/auth/nonce.go
@@ -9,10 +9,19 @@ import (
 
 // ErrNonceReused is returned by NonceStore.CheckAndMark when a nonce has
 // already been consumed within its TTL window.
+//
+// This uses errors.New (not errcode) because it is an internal sentinel
+// for errors.Is matching. The HTTP error code is set at the middleware layer.
 var ErrNonceReused = errors.New("auth: nonce already used")
 
+// defaultMaxNonceEntries is the maximum number of live nonce entries before a
+// forced prune is triggered in InMemoryNonceStore.CheckAndMark.
+const defaultMaxNonceEntries = 100000
+
 // NonceStore tracks nonces for replay prevention. Implementations must be
-// safe for concurrent use.
+// safe for concurrent use. The store must retain nonces for at least
+// ServiceTokenMaxAge (5 minutes) to prevent replay within the token
+// validity window; a shorter TTL creates a replay vulnerability.
 type NonceStore interface {
 	CheckAndMark(ctx context.Context, nonce string) error
 }
@@ -20,10 +29,11 @@ type NonceStore interface {
 // InMemoryNonceStore is a NonceStore backed by a map with lazy expiry pruning.
 // Suitable for single-instance deployments.
 type InMemoryNonceStore struct {
-	mu     sync.Mutex
-	seen   map[string]time.Time // nonce → expiry
-	maxAge time.Duration
-	now    func() time.Time
+	mu         sync.Mutex
+	seen       map[string]time.Time // nonce → expiry
+	maxAge     time.Duration
+	maxEntries int
+	now        func() time.Time
 }
 
 // InMemoryNonceOption configures an InMemoryNonceStore.
@@ -34,12 +44,19 @@ func WithNonceClock(fn func() time.Time) InMemoryNonceOption {
 	return func(s *InMemoryNonceStore) { s.now = fn }
 }
 
+// WithMaxNonceEntries overrides the maximum number of live nonce entries before
+// a forced prune is triggered. The default is defaultMaxNonceEntries.
+func WithMaxNonceEntries(n int) InMemoryNonceOption {
+	return func(s *InMemoryNonceStore) { s.maxEntries = n }
+}
+
 // NewInMemoryNonceStore creates an InMemoryNonceStore with the given maxAge.
 func NewInMemoryNonceStore(maxAge time.Duration, opts ...InMemoryNonceOption) *InMemoryNonceStore {
 	s := &InMemoryNonceStore{
-		seen:   make(map[string]time.Time),
-		maxAge: maxAge,
-		now:    time.Now,
+		seen:       make(map[string]time.Time),
+		maxAge:     maxAge,
+		maxEntries: defaultMaxNonceEntries,
+		now:        time.Now,
 	}
 	for _, o := range opts {
 		o(s)
@@ -56,8 +73,8 @@ func (s *InMemoryNonceStore) CheckAndMark(_ context.Context, nonce string) error
 
 	now := s.now()
 
-	// Lazy prune when map grows large.
-	if len(s.seen) > 1000 {
+	// Lazy prune when map grows past threshold.
+	if len(s.seen) >= s.maxEntries {
 		for k, exp := range s.seen {
 			if now.After(exp) {
 				delete(s.seen, k)

--- a/runtime/auth/nonce_test.go
+++ b/runtime/auth/nonce_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -69,20 +70,24 @@ func TestInMemoryNonceStore_ConcurrentAccess(t *testing.T) {
 
 func TestInMemoryNonceStore_LazyPrune(t *testing.T) {
 	now := time.Unix(1700000000, 0)
-	store := NewInMemoryNonceStore(1*time.Second, WithNonceClock(func() time.Time { return now }))
+	// Use a low maxEntries cap so the prune triggers after 10 entries.
+	store := NewInMemoryNonceStore(1*time.Second,
+		WithNonceClock(func() time.Time { return now }),
+		WithMaxNonceEntries(10),
+	)
 
-	// Insert 1001 entries; all will expire quickly.
-	for i := 0; i < 1001; i++ {
+	// Insert 10 entries; all will expire quickly.
+	for i := 0; i < 10; i++ {
 		err := store.CheckAndMark(context.Background(), fmt.Sprintf("prune-nonce-%d", i))
 		require.NoError(t, err)
 	}
 	initialLen := len(store.seen)
-	assert.GreaterOrEqual(t, initialLen, 1001)
+	assert.GreaterOrEqual(t, initialLen, 10)
 
 	// Advance clock past TTL so all existing entries are expired.
 	now = now.Add(2 * time.Second)
 
-	// Insert one more entry; this triggers the lazy prune because len > 1000.
+	// Insert one more entry; this triggers the lazy prune because len >= maxEntries.
 	err := store.CheckAndMark(context.Background(), "trigger-prune")
 	require.NoError(t, err)
 
@@ -93,4 +98,30 @@ func TestInMemoryNonceStore_LazyPrune(t *testing.T) {
 
 	assert.Less(t, finalLen, initialLen, "lazy prune should have reduced map size")
 	assert.Equal(t, 1, finalLen, "only the new entry should remain after prune")
+}
+
+func TestInMemoryNonceStore_ConcurrentSameNonce_ExactlyOneSucceeds(t *testing.T) {
+	store := NewInMemoryNonceStore(5 * time.Minute)
+	const goroutines = 50
+	var (
+		successes atomic.Int32
+		failures  atomic.Int32
+		wg        sync.WaitGroup
+	)
+	wg.Add(goroutines)
+	for i := range goroutines {
+		_ = i
+		go func() {
+			defer wg.Done()
+			err := store.CheckAndMark(context.Background(), "same-nonce")
+			if err == nil {
+				successes.Add(1)
+			} else {
+				failures.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), successes.Load(), "exactly one goroutine should succeed")
+	assert.Equal(t, int32(goroutines-1), failures.Load(), "all others should fail")
 }

--- a/runtime/auth/nonce_test.go
+++ b/runtime/auth/nonce_test.go
@@ -13,14 +13,16 @@ import (
 )
 
 func TestInMemoryNonceStore_FirstUseSucceeds(t *testing.T) {
-	store := NewInMemoryNonceStore(5 * time.Minute)
-	err := store.CheckAndMark(context.Background(), "nonce-abc")
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
+	err = store.CheckAndMark(context.Background(), "nonce-abc")
 	require.NoError(t, err)
 }
 
 func TestInMemoryNonceStore_ReplayRejected(t *testing.T) {
-	store := NewInMemoryNonceStore(5 * time.Minute)
-	err := store.CheckAndMark(context.Background(), "nonce-xyz")
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
+	err = store.CheckAndMark(context.Background(), "nonce-xyz")
 	require.NoError(t, err)
 
 	err = store.CheckAndMark(context.Background(), "nonce-xyz")
@@ -28,9 +30,10 @@ func TestInMemoryNonceStore_ReplayRejected(t *testing.T) {
 }
 
 func TestInMemoryNonceStore_DifferentNoncesSucceed(t *testing.T) {
-	store := NewInMemoryNonceStore(5 * time.Minute)
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
 
-	err := store.CheckAndMark(context.Background(), "nonce-1")
+	err = store.CheckAndMark(context.Background(), "nonce-1")
 	require.NoError(t, err)
 
 	err = store.CheckAndMark(context.Background(), "nonce-2")
@@ -39,9 +42,10 @@ func TestInMemoryNonceStore_DifferentNoncesSucceed(t *testing.T) {
 
 func TestInMemoryNonceStore_ExpiredNonceAllowsReuse(t *testing.T) {
 	now := time.Unix(1700000000, 0)
-	store := NewInMemoryNonceStore(5*time.Minute, WithNonceClock(func() time.Time { return now }))
+	store, err := NewInMemoryNonceStore(5*time.Minute, WithNonceClock(func() time.Time { return now }))
+	require.NoError(t, err)
 
-	err := store.CheckAndMark(context.Background(), "nonce-exp")
+	err = store.CheckAndMark(context.Background(), "nonce-exp")
 	require.NoError(t, err)
 
 	// Advance clock past maxAge.
@@ -52,7 +56,8 @@ func TestInMemoryNonceStore_ExpiredNonceAllowsReuse(t *testing.T) {
 }
 
 func TestInMemoryNonceStore_ConcurrentAccess(t *testing.T) {
-	store := NewInMemoryNonceStore(5 * time.Minute)
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
 	const n = 100
 	var wg sync.WaitGroup
 	wg.Add(n)
@@ -71,10 +76,11 @@ func TestInMemoryNonceStore_ConcurrentAccess(t *testing.T) {
 func TestInMemoryNonceStore_LazyPrune(t *testing.T) {
 	now := time.Unix(1700000000, 0)
 	// Use a low maxEntries cap so the prune triggers after 10 entries.
-	store := NewInMemoryNonceStore(1*time.Second,
+	store, err := NewInMemoryNonceStore(1*time.Second,
 		WithNonceClock(func() time.Time { return now }),
 		WithMaxNonceEntries(10),
 	)
+	require.NoError(t, err)
 
 	// Insert 10 entries; all will expire quickly.
 	for i := 0; i < 10; i++ {
@@ -88,7 +94,7 @@ func TestInMemoryNonceStore_LazyPrune(t *testing.T) {
 	now = now.Add(2 * time.Second)
 
 	// Insert one more entry; this triggers the lazy prune because len >= maxEntries.
-	err := store.CheckAndMark(context.Background(), "trigger-prune")
+	err = store.CheckAndMark(context.Background(), "trigger-prune")
 	require.NoError(t, err)
 
 	// Map should have shrunk: only the new entry remains.
@@ -101,7 +107,8 @@ func TestInMemoryNonceStore_LazyPrune(t *testing.T) {
 }
 
 func TestInMemoryNonceStore_ConcurrentSameNonce_ExactlyOneSucceeds(t *testing.T) {
-	store := NewInMemoryNonceStore(5 * time.Minute)
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
 	const goroutines = 50
 	var (
 		successes atomic.Int32
@@ -124,4 +131,15 @@ func TestInMemoryNonceStore_ConcurrentSameNonce_ExactlyOneSucceeds(t *testing.T)
 	wg.Wait()
 	assert.Equal(t, int32(1), successes.Load(), "exactly one goroutine should succeed")
 	assert.Equal(t, int32(goroutines-1), failures.Load(), "all others should fail")
+}
+
+func TestNewInMemoryNonceStore_ZeroMaxAge_Fails(t *testing.T) {
+	_, err := NewInMemoryNonceStore(0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "positive")
+}
+
+func TestNewInMemoryNonceStore_NegativeMaxAge_Fails(t *testing.T) {
+	_, err := NewInMemoryNonceStore(-time.Second)
+	require.Error(t, err)
 }

--- a/runtime/auth/nonce_test.go
+++ b/runtime/auth/nonce_test.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryNonceStore_FirstUseSucceeds(t *testing.T) {
+	store := NewInMemoryNonceStore(5 * time.Minute)
+	err := store.CheckAndMark(context.Background(), "nonce-abc")
+	require.NoError(t, err)
+}
+
+func TestInMemoryNonceStore_ReplayRejected(t *testing.T) {
+	store := NewInMemoryNonceStore(5 * time.Minute)
+	err := store.CheckAndMark(context.Background(), "nonce-xyz")
+	require.NoError(t, err)
+
+	err = store.CheckAndMark(context.Background(), "nonce-xyz")
+	assert.ErrorIs(t, err, ErrNonceReused)
+}
+
+func TestInMemoryNonceStore_DifferentNoncesSucceed(t *testing.T) {
+	store := NewInMemoryNonceStore(5 * time.Minute)
+
+	err := store.CheckAndMark(context.Background(), "nonce-1")
+	require.NoError(t, err)
+
+	err = store.CheckAndMark(context.Background(), "nonce-2")
+	require.NoError(t, err)
+}
+
+func TestInMemoryNonceStore_ExpiredNonceAllowsReuse(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	store := NewInMemoryNonceStore(5*time.Minute, WithNonceClock(func() time.Time { return now }))
+
+	err := store.CheckAndMark(context.Background(), "nonce-exp")
+	require.NoError(t, err)
+
+	// Advance clock past maxAge.
+	now = now.Add(6 * time.Minute)
+
+	err = store.CheckAndMark(context.Background(), "nonce-exp")
+	require.NoError(t, err, "expired nonce should be reusable after TTL")
+}
+
+func TestInMemoryNonceStore_ConcurrentAccess(t *testing.T) {
+	store := NewInMemoryNonceStore(5 * time.Minute)
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			nonce := fmt.Sprintf("unique-nonce-%d", i)
+			err := store.CheckAndMark(context.Background(), nonce)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestInMemoryNonceStore_LazyPrune(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	store := NewInMemoryNonceStore(1*time.Second, WithNonceClock(func() time.Time { return now }))
+
+	// Insert 1001 entries; all will expire quickly.
+	for i := 0; i < 1001; i++ {
+		err := store.CheckAndMark(context.Background(), fmt.Sprintf("prune-nonce-%d", i))
+		require.NoError(t, err)
+	}
+	initialLen := len(store.seen)
+	assert.GreaterOrEqual(t, initialLen, 1001)
+
+	// Advance clock past TTL so all existing entries are expired.
+	now = now.Add(2 * time.Second)
+
+	// Insert one more entry; this triggers the lazy prune because len > 1000.
+	err := store.CheckAndMark(context.Background(), "trigger-prune")
+	require.NoError(t, err)
+
+	// Map should have shrunk: only the new entry remains.
+	store.mu.Lock()
+	finalLen := len(store.seen)
+	store.mu.Unlock()
+
+	assert.Less(t, finalLen, initialLen, "lazy prune should have reduced map size")
+	assert.Equal(t, 1, finalLen, "only the new entry should remain after prune")
+}

--- a/runtime/auth/options.go
+++ b/runtime/auth/options.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+)
+
+// AuthOption configures auth middleware behavior.
+type AuthOption func(*authConfig)
+
+type authConfig struct {
+	logger  *slog.Logger
+	metrics *AuthMetrics
+}
+
+func defaultAuthConfig() authConfig {
+	return authConfig{logger: slog.Default()}
+}
+
+// WithLogger sets the logger for auth middleware.
+func WithLogger(l *slog.Logger) AuthOption {
+	return func(c *authConfig) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
+// WithMetrics sets the AuthMetrics for auth middleware.
+func WithMetrics(m *AuthMetrics) AuthOption {
+	return func(c *authConfig) { c.metrics = m }
+}
+
+type loggerCtxKey struct{}
+
+func withLogger(ctx context.Context, l *slog.Logger) context.Context {
+	return context.WithValue(ctx, loggerCtxKey{}, l)
+}
+
+func loggerFrom(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(loggerCtxKey{}).(*slog.Logger); ok && l != nil {
+		return l
+	}
+	return slog.Default()
+}

--- a/runtime/auth/provider.go
+++ b/runtime/auth/provider.go
@@ -6,6 +6,18 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// EnvKeyProviderOption configures EnvKeyProvider behavior.
+type EnvKeyProviderOption func(*EnvKeyProvider)
+
+// WithEnvKeyProviderLogger sets the logger for EnvKeyProvider.
+func WithEnvKeyProviderLogger(l *slog.Logger) EnvKeyProviderOption {
+	return func(p *EnvKeyProvider) {
+		if l != nil {
+			p.logger = l
+		}
+	}
+}
+
 // KeyProvider abstracts the source of cryptographic key material.
 // It is consumed at the composition root (main.go) to build JWTIssuer,
 // JWTVerifier, and service token infrastructure.
@@ -39,26 +51,31 @@ type EnvKeyProvider struct {
 	rsaErr    error
 	hmacRing  *HMACKeyRing
 	hmacErr   error
+	logger    *slog.Logger
 }
 
 // NewEnvKeyProvider loads all available key material from environment variables.
 // It returns a provider even if some key types are not configured — call
 // RSAKeySet() or HMACKeyRing() to check individual domain availability.
-func NewEnvKeyProvider() *EnvKeyProvider {
+func NewEnvKeyProvider(opts ...EnvKeyProviderOption) *EnvKeyProvider {
+	p := &EnvKeyProvider{logger: slog.Default()}
+	for _, o := range opts {
+		o(p)
+	}
+
 	ks, rsaErr := LoadKeySetFromEnv()
 	ring, hmacErr := LoadHMACKeyRingFromEnv()
 	if rsaErr != nil {
-		slog.Info("RSA key set not loaded from environment", slog.String("error", rsaErr.Error()))
+		p.logger.Info("RSA key set not loaded from environment", "error", rsaErr.Error())
 	}
 	if hmacErr != nil {
-		slog.Info("HMAC key ring not loaded from environment", slog.String("error", hmacErr.Error()))
+		p.logger.Info("HMAC key ring not loaded from environment", "error", hmacErr.Error())
 	}
-	return &EnvKeyProvider{
-		rsaKeySet: ks,
-		rsaErr:    rsaErr,
-		hmacRing:  ring,
-		hmacErr:   hmacErr,
-	}
+	p.rsaKeySet = ks
+	p.rsaErr = rsaErr
+	p.hmacRing = ring
+	p.hmacErr = hmacErr
+	return p
 }
 
 // RSAKeySet returns the cached RSA KeySet or the error from loading.

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -47,7 +49,11 @@ type ServiceTokenOption func(*serviceTokenConfig)
 
 // WithServiceTokenClock overrides the time source for timestamp validation.
 func WithServiceTokenClock(fn func() time.Time) ServiceTokenOption {
-	return func(c *serviceTokenConfig) { c.now = fn }
+	return func(c *serviceTokenConfig) {
+		if fn != nil {
+			c.now = fn
+		}
+	}
 }
 
 // WithNonceStore sets a NonceStore for replay prevention. When set, the
@@ -146,9 +152,9 @@ func LoadHMACKeyRingFromEnv() (*HMACKeyRing, error) {
 //	ServiceToken {unix_timestamp}:{nonce}:{hex_hmac}             (new, with replay protection)
 //
 // For the new 3-part format the HMAC is computed over
-// "{method} {path} {timestamp} {nonce}". For the legacy 2-part format the
-// HMAC is computed over "{method} {path} {timestamp}" and no nonce check is
-// performed, even when a NonceStore is configured.
+// "{method} {path}[?{canonicalQuery}] {timestamp} {nonce}". For the legacy
+// 2-part format the HMAC is computed over "{method} {path} {timestamp}" and no
+// nonce check is performed, even when a NonceStore is configured.
 //
 // Verification tries each secret in the key ring in order (current, then
 // previous). Tokens older than 5 minutes (exclusive boundary) are rejected.
@@ -169,101 +175,142 @@ func ServiceTokenMiddleware(ring *HMACKeyRing, opts ...ServiceTokenOption) func(
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			token := extractServiceToken(r)
-			if token == "" {
-				cfg.metrics.recordServiceVerify("failure", "missing")
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "missing service token")
-				return
-			}
-
-			// Accept both 2-part (legacy) and 3-part (new) formats.
-			parts := strings.SplitN(token, ":", 3)
-			if len(parts) < 2 {
-				cfg.metrics.recordServiceVerify("failure", "invalid_format")
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
-				return
-			}
-
-			tsStr := parts[0]
-			ts, err := strconv.ParseInt(tsStr, 10, 64)
-			if err != nil {
-				cfg.metrics.recordServiceVerify("failure", "invalid_format")
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token timestamp")
-				return
-			}
-
-			now := cfg.now()
-			tokenTime := time.Unix(ts, 0)
-			age := now.Sub(tokenTime)
-			if age < 0 {
-				age = -age
-			}
-			if age >= ServiceTokenMaxAge {
-				cfg.metrics.recordServiceVerify("failure", "expired")
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token expired")
-				return
-			}
-
-			var nonce, sigHex, message string
-			isNewFormat := len(parts) == 3
-			if isNewFormat {
-				nonce, sigHex = parts[1], parts[2]
-				message = fmt.Sprintf("%s %s %s %s", r.Method, r.URL.Path, tsStr, nonce)
-			} else {
-				sigHex = parts[1]
-				message = fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, tsStr)
-			}
-
-			providedMAC, err := hex.DecodeString(sigHex)
-			if err != nil {
-				cfg.metrics.recordServiceVerify("failure", "invalid_format")
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
-				return
-			}
-
-			verified := false
-			for _, secret := range ring.Secrets() {
-				mac := hmac.New(sha256.New, secret)
-				_, _ = mac.Write([]byte(message))
-				if hmac.Equal(providedMAC, mac.Sum(nil)) {
-					verified = true
-					break
-				}
-			}
-			if !verified {
-				cfg.metrics.recordServiceVerify("failure", "invalid_mac")
-				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
-				return
-			}
-
-			if !isNewFormat && cfg.nonceStore != nil {
-				cfg.logger.Warn("legacy 2-part service token accepted without replay check",
-					slog.String("path", r.URL.Path),
-					slog.String("method", r.Method),
-				)
-			}
-
-			// Replay check only for new 3-part tokens.
-			if isNewFormat && cfg.nonceStore != nil {
-				if err := cfg.nonceStore.CheckAndMark(r.Context(), nonce); err != nil {
-					cfg.metrics.recordServiceVerify("failure", "replay")
-					httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token replay detected")
-					return
-				}
-			}
-
-			cfg.metrics.recordServiceVerify("success", "ok")
-			next.ServeHTTP(w, r)
+			handleServiceToken(cfg, ring, next, w, r)
 		})
 	}
 }
 
+// handleServiceToken contains all request-handling logic extracted from
+// ServiceTokenMiddleware to reduce cognitive complexity.
+func handleServiceToken(cfg serviceTokenConfig, ring *HMACKeyRing, next http.Handler, w http.ResponseWriter, r *http.Request) {
+	token := extractServiceToken(r)
+	if token == "" {
+		cfg.metrics.recordServiceVerify("failure", "missing")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "missing service token")
+		return
+	}
+
+	// Accept both 2-part (legacy) and 3-part (new) formats.
+	parts := strings.SplitN(token, ":", 3)
+	if len(parts) < 2 {
+		cfg.metrics.recordServiceVerify("failure", "invalid_format")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
+		return
+	}
+
+	tsStr := parts[0]
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		cfg.metrics.recordServiceVerify("failure", "invalid_format")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token timestamp")
+		return
+	}
+
+	now := cfg.now()
+	tokenTime := time.Unix(ts, 0)
+	age := now.Sub(tokenTime)
+	if age < 0 {
+		age = -age
+	}
+	if age >= ServiceTokenMaxAge {
+		cfg.metrics.recordServiceVerify("failure", "expired")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token expired")
+		return
+	}
+
+	var nonce, sigHex, message string
+	isNewFormat := len(parts) == 3
+	if isNewFormat {
+		nonce, sigHex = parts[1], parts[2]
+		message = buildServiceTokenMessage(r.Method, r.URL.Path, r.URL.RawQuery, tsStr, nonce)
+	} else {
+		sigHex = parts[1]
+		message = fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, tsStr)
+	}
+
+	providedMAC, err := hex.DecodeString(sigHex)
+	if err != nil {
+		cfg.metrics.recordServiceVerify("failure", "invalid_format")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
+		return
+	}
+
+	if !verifyServiceTokenMAC(ring, message, providedMAC) {
+		cfg.metrics.recordServiceVerify("failure", "invalid_mac")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
+		return
+	}
+
+	if !isNewFormat && cfg.nonceStore != nil {
+		cfg.logger.Warn("legacy 2-part service token accepted without replay check",
+			slog.String("path", r.URL.Path),
+			slog.String("method", r.Method),
+		)
+	}
+
+	// Replay check only for new 3-part tokens.
+	if isNewFormat && cfg.nonceStore != nil {
+		if err := cfg.nonceStore.CheckAndMark(r.Context(), nonce); err != nil {
+			if errors.Is(err, ErrNonceReused) {
+				cfg.metrics.recordServiceVerify("failure", "replay")
+				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token replay detected")
+			} else {
+				cfg.metrics.recordServiceVerify("failure", "nonce_store_error")
+				cfg.logger.Error("nonce store check failed", slog.Any("error", err))
+				httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
+			}
+			return
+		}
+	}
+
+	cfg.metrics.recordServiceVerify("success", "ok")
+	next.ServeHTTP(w, r)
+}
+
+// verifyServiceTokenMAC checks whether the provided MAC is valid for message
+// under any of the secrets in the key ring.
+func verifyServiceTokenMAC(ring *HMACKeyRing, message string, providedMAC []byte) bool {
+	for _, secret := range ring.Secrets() {
+		mac := hmac.New(sha256.New, secret)
+		_, _ = mac.Write([]byte(message))
+		if hmac.Equal(providedMAC, mac.Sum(nil)) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildServiceTokenMessage constructs the canonical HMAC message for the new
+// 3-part token format. The query string is canonicalized (keys sorted) and
+// appended to the path when non-empty.
+func buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce string) string {
+	cq := canonicalQuery(rawQuery)
+	if cq != "" {
+		return fmt.Sprintf("%s %s?%s %s %s", method, path, cq, tsStr, nonce)
+	}
+	return fmt.Sprintf("%s %s %s %s", method, path, tsStr, nonce)
+}
+
+// canonicalQuery returns a deterministic encoding of rawQuery with keys sorted.
+// Returns empty string when rawQuery is empty. Falls back to rawQuery if
+// url.ParseQuery fails.
+func canonicalQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	params, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return rawQuery
+	}
+	return params.Encode() // url.Values.Encode() sorts keys alphabetically
+}
+
 // GenerateServiceToken creates a service token for the given method, path,
-// and timestamp using the current secret from the key ring.
+// optional rawQuery, and timestamp using the current secret from the key ring.
 // The token format is "{timestamp}:{nonce}:{hex_hmac}" where nonce is 16
 // cryptographically random bytes, hex-encoded. It returns an empty string if
 // ring is nil.
-func GenerateServiceToken(ring *HMACKeyRing, method, path string, ts time.Time) string {
+func GenerateServiceToken(ring *HMACKeyRing, method, path, rawQuery string, ts time.Time) string {
 	if ring == nil {
 		return ""
 	}
@@ -276,8 +323,9 @@ func GenerateServiceToken(ring *HMACKeyRing, method, path string, ts time.Time) 
 	}
 	nonce := hex.EncodeToString(nonceBytes)
 
+	message := buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce)
 	mac := hmac.New(sha256.New, ring.Current())
-	_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s %s", method, path, tsStr, nonce)))
+	fmt.Fprintf(mac, "%s", message)
 	return tsStr + ":" + nonce + ":" + hex.EncodeToString(mac.Sum(nil))
 }
 

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -236,6 +236,13 @@ func ServiceTokenMiddleware(ring *HMACKeyRing, opts ...ServiceTokenOption) func(
 				return
 			}
 
+			if !isNewFormat && cfg.nonceStore != nil {
+				cfg.logger.Warn("legacy 2-part service token accepted without replay check",
+					slog.String("path", r.URL.Path),
+					slog.String("method", r.Method),
+				)
+			}
+
 			// Replay check only for new 3-part tokens.
 			if isNewFormat && cfg.nonceStore != nil {
 				if err := cfg.nonceStore.CheckAndMark(r.Context(), nonce); err != nil {

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -16,16 +17,50 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
+// WithServiceTokenLogger sets the logger for ServiceTokenMiddleware.
+func WithServiceTokenLogger(l *slog.Logger) ServiceTokenOption {
+	return func(c *serviceTokenConfig) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
 // ServiceTokenMaxAge is the maximum age of a service token before it is
 // rejected. Tokens with timestamps at or beyond this window are refused.
 const ServiceTokenMaxAge = 5 * time.Minute
 
-// nowFunc is overridable for testing.
-var nowFunc = time.Now
-
 // MinHMACKeyBytes is the minimum HMAC secret length. NIST recommends 256-bit
 // (32-byte) keys for HMAC-SHA256; this constant enforces that minimum.
 const MinHMACKeyBytes = 32
+
+// serviceTokenConfig holds per-middleware options.
+type serviceTokenConfig struct {
+	now        func() time.Time
+	logger     *slog.Logger
+	nonceStore NonceStore
+	metrics    *AuthMetrics
+}
+
+// ServiceTokenOption configures ServiceTokenMiddleware behavior.
+type ServiceTokenOption func(*serviceTokenConfig)
+
+// WithServiceTokenClock overrides the time source for timestamp validation.
+func WithServiceTokenClock(fn func() time.Time) ServiceTokenOption {
+	return func(c *serviceTokenConfig) { c.now = fn }
+}
+
+// WithNonceStore sets a NonceStore for replay prevention. When set, the
+// middleware rejects tokens whose nonce has already been consumed within
+// the NonceStore's TTL window.
+func WithNonceStore(ns NonceStore) ServiceTokenOption {
+	return func(c *serviceTokenConfig) { c.nonceStore = ns }
+}
+
+// WithServiceTokenMetrics sets the AuthMetrics for ServiceTokenMiddleware.
+func WithServiceTokenMetrics(m *AuthMetrics) ServiceTokenOption {
+	return func(c *serviceTokenConfig) { c.metrics = m }
+}
 
 // HMACKeyRing holds an ordered pair of HMAC secrets for service token operations.
 // Position 0 (current) is used for signing; verification tries all secrets in order.
@@ -105,19 +140,29 @@ func LoadHMACKeyRingFromEnv() (*HMACKeyRing, error) {
 }
 
 // ServiceTokenMiddleware validates requests using HMAC-SHA256 service tokens.
-// The token is expected in the Authorization header as:
+// The token is expected in the Authorization header as one of:
 //
-//	ServiceToken {unix_timestamp}:{hex_hmac}
+//	ServiceToken {unix_timestamp}:{hex_hmac}                     (legacy)
+//	ServiceToken {unix_timestamp}:{nonce}:{hex_hmac}             (new, with replay protection)
 //
-// The HMAC is computed over "{method} {path} {timestamp}" using secrets from
-// the key ring. Verification tries each secret in order (current, then previous).
-// Tokens older than 5 minutes (exclusive boundary) are rejected.
-func ServiceTokenMiddleware(ring *HMACKeyRing) func(http.Handler) http.Handler {
+// For the new 3-part format the HMAC is computed over
+// "{method} {path} {timestamp} {nonce}". For the legacy 2-part format the
+// HMAC is computed over "{method} {path} {timestamp}" and no nonce check is
+// performed, even when a NonceStore is configured.
+//
+// Verification tries each secret in the key ring in order (current, then
+// previous). Tokens older than 5 minutes (exclusive boundary) are rejected.
+func ServiceTokenMiddleware(ring *HMACKeyRing, opts ...ServiceTokenOption) func(http.Handler) http.Handler {
+	cfg := serviceTokenConfig{now: time.Now, logger: slog.Default()}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	if ring == nil {
-		// Fail-fast: refuse to create middleware with nil key ring.
 		return func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				slog.Error("service token middleware called with nil key ring")
+				cfg.metrics.recordServiceVerify("failure", "internal")
+				cfg.logger.Error("service token middleware called with nil key ring")
 				httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
 			})
 		}
@@ -126,70 +171,107 @@ func ServiceTokenMiddleware(ring *HMACKeyRing) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := extractServiceToken(r)
 			if token == "" {
+				cfg.metrics.recordServiceVerify("failure", "missing")
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "missing service token")
 				return
 			}
 
-			// Parse "{timestamp}:{signature}".
-			parts := strings.SplitN(token, ":", 2)
-			if len(parts) != 2 {
+			// Accept both 2-part (legacy) and 3-part (new) formats.
+			parts := strings.SplitN(token, ":", 3)
+			if len(parts) < 2 {
+				cfg.metrics.recordServiceVerify("failure", "invalid_format")
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
 				return
 			}
 
-			tsStr, sigHex := parts[0], parts[1]
+			tsStr := parts[0]
 			ts, err := strconv.ParseInt(tsStr, 10, 64)
 			if err != nil {
+				cfg.metrics.recordServiceVerify("failure", "invalid_format")
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token timestamp")
 				return
 			}
 
-			// Check timestamp is within the allowed window.
-			// Boundary (exactly 5 minutes) is rejected (>=).
-			now := nowFunc()
+			now := cfg.now()
 			tokenTime := time.Unix(ts, 0)
 			age := now.Sub(tokenTime)
 			if age < 0 {
 				age = -age
 			}
 			if age >= ServiceTokenMaxAge {
+				cfg.metrics.recordServiceVerify("failure", "expired")
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token expired")
 				return
 			}
 
+			var nonce, sigHex, message string
+			isNewFormat := len(parts) == 3
+			if isNewFormat {
+				nonce, sigHex = parts[1], parts[2]
+				message = fmt.Sprintf("%s %s %s %s", r.Method, r.URL.Path, tsStr, nonce)
+			} else {
+				sigHex = parts[1]
+				message = fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, tsStr)
+			}
+
 			providedMAC, err := hex.DecodeString(sigHex)
 			if err != nil {
+				cfg.metrics.recordServiceVerify("failure", "invalid_format")
 				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
 				return
 			}
 
-			// Try all secrets in the key ring (current first, then previous).
-			message := fmt.Sprintf("%s %s %s", r.Method, r.URL.Path, tsStr)
+			verified := false
 			for _, secret := range ring.Secrets() {
 				mac := hmac.New(sha256.New, secret)
 				_, _ = mac.Write([]byte(message))
 				if hmac.Equal(providedMAC, mac.Sum(nil)) {
-					next.ServeHTTP(w, r)
+					verified = true
+					break
+				}
+			}
+			if !verified {
+				cfg.metrics.recordServiceVerify("failure", "invalid_mac")
+				httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
+				return
+			}
+
+			// Replay check only for new 3-part tokens.
+			if isNewFormat && cfg.nonceStore != nil {
+				if err := cfg.nonceStore.CheckAndMark(r.Context(), nonce); err != nil {
+					cfg.metrics.recordServiceVerify("failure", "replay")
+					httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token replay detected")
 					return
 				}
 			}
 
-			httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
+			cfg.metrics.recordServiceVerify("success", "ok")
+			next.ServeHTTP(w, r)
 		})
 	}
 }
 
 // GenerateServiceToken creates a service token for the given method, path,
 // and timestamp using the current secret from the key ring.
-// It returns an empty string if ring is nil.
+// The token format is "{timestamp}:{nonce}:{hex_hmac}" where nonce is 16
+// cryptographically random bytes, hex-encoded. It returns an empty string if
+// ring is nil.
 func GenerateServiceToken(ring *HMACKeyRing, method, path string, ts time.Time) string {
 	if ring == nil {
 		return ""
 	}
 	tsStr := strconv.FormatInt(ts.Unix(), 10)
+
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		// crypto/rand failure is not recoverable; return empty to signal error.
+		return ""
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+
 	mac := hmac.New(sha256.New, ring.Current())
-	_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s", method, path, tsStr)))
-	return tsStr + ":" + hex.EncodeToString(mac.Sum(nil))
+	_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s %s", method, path, tsStr, nonce)))
+	return tsStr + ":" + nonce + ":" + hex.EncodeToString(mac.Sum(nil))
 }
 
 func extractServiceToken(r *http.Request) string {

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -522,4 +523,33 @@ func TestServiceTokenMiddleware_LegacyTwoPartFormat_StillWorks(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code, "legacy 2-part token must still be accepted")
+}
+
+func TestServiceTokenMiddleware_WithMetrics_NoPanic(t *testing.T) {
+	am, err := NewAuthMetrics(metrics.NopProvider{})
+	require.NoError(t, err)
+
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenMetrics(am),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Success path.
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Failure path (missing token).
+	req2 := httptest.NewRequest(http.MethodGet, "/api", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
 }

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -72,7 +72,7 @@ func TestHMACKeyRing_Current_ReturnsCopy(t *testing.T) {
 func TestHMACKeyRing_SignWithCurrent(t *testing.T) {
 	ring := mustTestRing(t, testSecretNew, testSecretOld)
 	now := time.Now()
-	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", "", now)
 
 	singleRing := mustTestRing(t, testSecretNew, "")
 	handler := mustTestServiceHandler(t, singleRing, func() time.Time { return now })
@@ -89,7 +89,7 @@ func TestHMACKeyRing_VerifyWithPrevious(t *testing.T) {
 	now := time.Now()
 
 	oldRing := mustTestRing(t, testSecretOld, "")
-	token := GenerateServiceToken(oldRing, http.MethodGet, "/api", now)
+	token := GenerateServiceToken(oldRing, http.MethodGet, "/api", "", now)
 
 	newRing := mustTestRing(t, testSecretNew, testSecretOld)
 	handler := mustTestServiceHandler(t, newRing, func() time.Time { return now })
@@ -106,7 +106,7 @@ func TestHMACKeyRing_RejectUnknownSecret(t *testing.T) {
 	now := time.Now()
 
 	unknownRing := mustTestRing(t, testSecretUnk, "")
-	token := GenerateServiceToken(unknownRing, http.MethodGet, "/api", now)
+	token := GenerateServiceToken(unknownRing, http.MethodGet, "/api", "", now)
 
 	ring := mustTestRing(t, testSecretNew, testSecretOld)
 	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
@@ -123,7 +123,7 @@ func TestHMACKeyRing_SingleSecretMode(t *testing.T) {
 	now := time.Now()
 
 	ring := mustTestRing(t, testSecretOne, "")
-	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", "", now)
 	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
@@ -138,7 +138,7 @@ func TestHMACKeyRing_SameSecretBothPositions(t *testing.T) {
 	now := time.Now()
 
 	ring := mustTestRing(t, testSecretSam, testSecretSam)
-	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", "", now)
 	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
@@ -171,7 +171,7 @@ func TestNewHMACKeyRing_ShortPreviousFails(t *testing.T) {
 }
 
 func TestGenerateServiceToken_NilRing(t *testing.T) {
-	token := GenerateServiceToken(nil, "GET", "/api", time.Now())
+	token := GenerateServiceToken(nil, "GET", "/api", "", time.Now())
 	assert.Empty(t, token)
 }
 
@@ -225,7 +225,7 @@ func TestLoadHMACKeyRingFromEnv_MissingCurrentFails(t *testing.T) {
 func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", "", now)
 	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
@@ -276,7 +276,7 @@ func TestServiceTokenMiddleware_DifferentPath(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
 
-	token := GenerateServiceToken(ring, http.MethodGet, "/other", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/other", "", now)
 	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
@@ -305,7 +305,7 @@ func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
 	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	oldTime := now.Add(-6 * time.Minute)
-	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", oldTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", "", oldTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -320,7 +320,7 @@ func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
 	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	boundaryTime := now.Add(-ServiceTokenMaxAge)
-	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", boundaryTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", "", boundaryTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -335,7 +335,7 @@ func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
 	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
 	recentTime := now.Add(-4*time.Minute - 59*time.Second)
-	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", recentTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", "", recentTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -350,7 +350,7 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	futureTime := now.Add(6 * time.Minute)
-	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", futureTime)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", "", futureTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -379,8 +379,8 @@ func TestGenerateServiceToken_Deterministic(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	ts := time.Unix(1700000000, 0)
 
-	t1 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)
-	t2 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)
+	t1 := GenerateServiceToken(ring, http.MethodPost, "/api", "", ts)
+	t2 := GenerateServiceToken(ring, http.MethodPost, "/api", "", ts)
 
 	parts1 := strings.SplitN(t1, ":", 3)
 	parts2 := strings.SplitN(t2, ":", 3)
@@ -391,14 +391,14 @@ func TestGenerateServiceToken_Deterministic(t *testing.T) {
 	assert.NotEqual(t, parts1[1], parts2[1], "nonces must differ between calls")
 
 	// Different method produces a different HMAC (nonces also differ).
-	t3 := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
+	t3 := GenerateServiceToken(ring, http.MethodGet, "/api", "", ts)
 	assert.NotEqual(t, t1, t3)
 }
 
 func TestGenerateServiceToken_IncludesNonce(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	ts := time.Unix(1700000000, 0)
-	token := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", "", ts)
 
 	parts := strings.SplitN(token, ":", 3)
 	require.Len(t, parts, 3, "token must have 3 colon-separated parts")
@@ -410,8 +410,8 @@ func TestGenerateServiceToken_NonceUniqueness(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	ts := time.Unix(1700000000, 0)
 
-	t1 := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
-	t2 := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
+	t1 := GenerateServiceToken(ring, http.MethodGet, "/api", "", ts)
+	t2 := GenerateServiceToken(ring, http.MethodGet, "/api", "", ts)
 
 	parts1 := strings.SplitN(t1, ":", 3)
 	parts2 := strings.SplitN(t2, ":", 3)
@@ -425,7 +425,8 @@ func TestGenerateServiceToken_NonceUniqueness(t *testing.T) {
 func TestServiceTokenMiddleware_WithNonceStore_ReplayRejected(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	store := NewInMemoryNonceStore(5 * time.Minute)
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
 		WithNonceStore(store),
@@ -433,7 +434,7 @@ func TestServiceTokenMiddleware_WithNonceStore_ReplayRejected(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", "", now)
 
 	// First use — accepted.
 	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
@@ -453,7 +454,8 @@ func TestServiceTokenMiddleware_WithNonceStore_ReplayRejected(t *testing.T) {
 func TestServiceTokenMiddleware_WithNonceStore_UniqueTokensAccepted(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	store := NewInMemoryNonceStore(5 * time.Minute)
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
 		WithNonceStore(store),
@@ -461,8 +463,8 @@ func TestServiceTokenMiddleware_WithNonceStore_UniqueTokensAccepted(t *testing.T
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token1 := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
-	token2 := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
+	token1 := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", "", now)
+	token2 := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", "", now)
 
 	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
 	req1.Header.Set("Authorization", "ServiceToken "+token1)
@@ -483,7 +485,7 @@ func TestServiceTokenMiddleware_WithoutNonceStore_ReplayAllowed(t *testing.T) {
 	// No nonce store — backward-compat mode.
 	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
-	token := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", "", now)
 
 	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
 	req1.Header.Set("Authorization", "ServiceToken "+token)
@@ -506,10 +508,11 @@ func TestServiceTokenMiddleware_LegacyTwoPartFormat_StillWorks(t *testing.T) {
 	// Craft a legacy 2-part token manually.
 	tsStr := strconv.FormatInt(now.Unix(), 10)
 	mac := hmac.New(sha256.New, ring.Current())
-	_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s", http.MethodGet, "/legacy/path", tsStr)))
+	fmt.Fprintf(mac, "%s %s %s", http.MethodGet, "/legacy/path", tsStr)
 	legacyToken := tsStr + ":" + hex.EncodeToString(mac.Sum(nil))
 
-	store := NewInMemoryNonceStore(5 * time.Minute)
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	require.NoError(t, err)
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
 		WithNonceStore(store),
@@ -531,7 +534,7 @@ func TestServiceTokenMiddleware_WithMetrics_NoPanic(t *testing.T) {
 
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", "", now)
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
@@ -552,4 +555,32 @@ func TestServiceTokenMiddleware_WithMetrics_NoPanic(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
+}
+
+func TestServiceTokenMiddleware_QueryBoundInSignature(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+
+	// Sign with query=foo=bar
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", "foo=bar", now)
+	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
+
+	// Same path+query should succeed.
+	req := httptest.NewRequest(http.MethodGet, "/api?foo=bar", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Different query should fail.
+	req2 := httptest.NewRequest(http.MethodGet, "/api?foo=baz", nil)
+	req2.Header.Set("Authorization", "ServiceToken "+token)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
+}
+
+func TestCanonicalQuery_SortsKeys(t *testing.T) {
+	assert.Equal(t, "a=1&b=2", canonicalQuery("b=2&a=1"))
+	assert.Equal(t, "", canonicalQuery(""))
 }

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -1,9 +1,15 @@
 package auth
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,36 +39,42 @@ func mustTestRing(t *testing.T, current, previous string) *HMACKeyRing {
 	return ring
 }
 
+func mustTestServiceHandler(t *testing.T, ring *HMACKeyRing, clockFn func() time.Time) http.Handler {
+	t.Helper()
+	return ServiceTokenMiddleware(ring, WithServiceTokenClock(clockFn))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+}
+
+func mustTestServiceHandlerFatal(t *testing.T, ring *HMACKeyRing, clockFn func() time.Time) http.Handler {
+	t.Helper()
+	return ServiceTokenMiddleware(ring, WithServiceTokenClock(clockFn))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("should not be called")
+		}),
+	)
+}
+
 func TestHMACKeyRing_Current_ReturnsCopy(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	c := ring.Current()
 	original := make([]byte, len(c))
 	copy(original, c)
 
-	// Mutate the returned slice.
 	c[0] = 0xFF
 
-	// The ring's internal state must be unchanged.
 	assert.Equal(t, original, ring.Current(), "Current() must return a defensive copy")
 }
 
-// --- Phase 4: User Story 3 (T017-T025) ---
-
 func TestHMACKeyRing_SignWithCurrent(t *testing.T) {
 	ring := mustTestRing(t, testSecretNew, testSecretOld)
-
 	now := time.Now()
 	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
 
-	// Should be verifiable with current secret only.
 	singleRing := mustTestRing(t, testSecretNew, "")
-	handler := ServiceTokenMiddleware(singleRing)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
+	handler := mustTestServiceHandler(t, singleRing, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
@@ -74,19 +86,12 @@ func TestHMACKeyRing_SignWithCurrent(t *testing.T) {
 
 func TestHMACKeyRing_VerifyWithPrevious(t *testing.T) {
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
 
-	// Sign token with old secret.
 	oldRing := mustTestRing(t, testSecretOld, "")
 	token := GenerateServiceToken(oldRing, http.MethodGet, "/api", now)
 
-	// Create ring with new+old. Old token should still verify.
 	newRing := mustTestRing(t, testSecretNew, testSecretOld)
-	handler := ServiceTokenMiddleware(newRing)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	handler := mustTestServiceHandler(t, newRing, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
@@ -98,18 +103,12 @@ func TestHMACKeyRing_VerifyWithPrevious(t *testing.T) {
 
 func TestHMACKeyRing_RejectUnknownSecret(t *testing.T) {
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
 
-	// Sign with a secret that is NOT in the ring.
 	unknownRing := mustTestRing(t, testSecretUnk, "")
 	token := GenerateServiceToken(unknownRing, http.MethodGet, "/api", now)
 
 	ring := mustTestRing(t, testSecretNew, testSecretOld)
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
@@ -121,16 +120,10 @@ func TestHMACKeyRing_RejectUnknownSecret(t *testing.T) {
 
 func TestHMACKeyRing_SingleSecretMode(t *testing.T) {
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
 
 	ring := mustTestRing(t, testSecretOne, "")
 	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
-
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
@@ -142,16 +135,10 @@ func TestHMACKeyRing_SingleSecretMode(t *testing.T) {
 
 func TestHMACKeyRing_SameSecretBothPositions(t *testing.T) {
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
 
 	ring := mustTestRing(t, testSecretSam, testSecretSam)
 	token := GenerateServiceToken(ring, http.MethodGet, "/api", now)
-
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
@@ -234,23 +221,14 @@ func TestLoadHMACKeyRingFromEnv_MissingCurrentFails(t *testing.T) {
 	assert.Equal(t, errcode.ErrAuthKeyMissing, ecErr.Code)
 }
 
-// --- Updated existing tests ---
-
 func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-
 	now := time.Now()
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", now)
+	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
+
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
-
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
-
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -259,14 +237,8 @@ func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
 
 func TestServiceTokenMiddleware_InvalidToken(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
-
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
+	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken 12345:deadbeef")
@@ -278,9 +250,7 @@ func TestServiceTokenMiddleware_InvalidToken(t *testing.T) {
 
 func TestServiceTokenMiddleware_MissingToken(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	handler := mustTestServiceHandlerFatal(t, ring, time.Now)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -291,9 +261,7 @@ func TestServiceTokenMiddleware_MissingToken(t *testing.T) {
 
 func TestServiceTokenMiddleware_WrongScheme(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	handler := mustTestServiceHandlerFatal(t, ring, time.Now)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer some-jwt")
@@ -305,16 +273,11 @@ func TestServiceTokenMiddleware_WrongScheme(t *testing.T) {
 
 func TestServiceTokenMiddleware_DifferentPath(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
-
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
 
 	token := GenerateServiceToken(ring, http.MethodGet, "/other", now)
+	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
+
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -337,14 +300,8 @@ func TestServiceTokenMiddleware_NilRing(t *testing.T) {
 
 func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
-
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
+	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	oldTime := now.Add(-6 * time.Minute)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", oldTime)
@@ -358,14 +315,8 @@ func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
 
 func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
-
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
+	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	boundaryTime := now.Add(-ServiceTokenMaxAge)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", boundaryTime)
@@ -379,14 +330,8 @@ func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
 
 func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
+	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
 
 	recentTime := now.Add(-4*time.Minute - 59*time.Second)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", recentTime)
@@ -400,14 +345,8 @@ func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
 
 func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
-
 	now := time.Now()
-	origNow := nowFunc
-	nowFunc = func() time.Time { return now }
-	defer func() { nowFunc = origNow }()
+	handler := mustTestServiceHandlerFatal(t, ring, func() time.Time { return now })
 
 	futureTime := now.Add(6 * time.Minute)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/health", futureTime)
@@ -434,13 +373,153 @@ func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
 }
 
 func TestGenerateServiceToken_Deterministic(t *testing.T) {
+	// GenerateServiceToken now includes a random nonce, so two calls with the
+	// same parameters produce different tokens. We verify structure instead.
 	ring := mustTestRing(t, testSecret, "")
 	ts := time.Unix(1700000000, 0)
+
 	t1 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)
 	t2 := GenerateServiceToken(ring, http.MethodPost, "/api", ts)
-	assert.Equal(t, t1, t2)
 
-	// Different method should produce different token.
+	parts1 := strings.SplitN(t1, ":", 3)
+	parts2 := strings.SplitN(t2, ":", 3)
+	require.Len(t, parts1, 3, "token must have 3 colon-separated parts")
+	require.Len(t, parts2, 3, "token must have 3 colon-separated parts")
+
+	// Nonces differ between calls.
+	assert.NotEqual(t, parts1[1], parts2[1], "nonces must differ between calls")
+
+	// Different method produces a different HMAC (nonces also differ).
 	t3 := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
 	assert.NotEqual(t, t1, t3)
+}
+
+func TestGenerateServiceToken_IncludesNonce(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	ts := time.Unix(1700000000, 0)
+	token := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
+
+	parts := strings.SplitN(token, ":", 3)
+	require.Len(t, parts, 3, "token must have 3 colon-separated parts")
+	assert.NotEmpty(t, parts[1], "nonce must not be empty")
+	assert.Len(t, parts[1], 32, "nonce must be 32 hex chars (16 bytes)")
+}
+
+func TestGenerateServiceToken_NonceUniqueness(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	ts := time.Unix(1700000000, 0)
+
+	t1 := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
+	t2 := GenerateServiceToken(ring, http.MethodGet, "/api", ts)
+
+	parts1 := strings.SplitN(t1, ":", 3)
+	parts2 := strings.SplitN(t2, ":", 3)
+	require.Len(t, parts1, 3)
+	require.Len(t, parts2, 3)
+
+	assert.NotEqual(t, parts1[1], parts2[1], "consecutive calls must produce different nonces")
+	assert.NotEqual(t, t1, t2, "tokens with different nonces must differ")
+}
+
+func TestServiceTokenMiddleware_WithNonceStore_ReplayRejected(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	store := NewInMemoryNonceStore(5 * time.Minute)
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithNonceStore(store),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
+
+	// First use — accepted.
+	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+	req1.Header.Set("Authorization", "ServiceToken "+token)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	// Replay — rejected.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+	req2.Header.Set("Authorization", "ServiceToken "+token)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
+}
+
+func TestServiceTokenMiddleware_WithNonceStore_UniqueTokensAccepted(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	store := NewInMemoryNonceStore(5 * time.Minute)
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithNonceStore(store),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token1 := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
+	token2 := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
+
+	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+	req1.Header.Set("Authorization", "ServiceToken "+token1)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	assert.Equal(t, http.StatusOK, rec1.Code, "first unique token must be accepted")
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+	req2.Header.Set("Authorization", "ServiceToken "+token2)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code, "second unique token must be accepted")
+}
+
+func TestServiceTokenMiddleware_WithoutNonceStore_ReplayAllowed(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	// No nonce store — backward-compat mode.
+	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
+
+	token := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", now)
+
+	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+	req1.Header.Set("Authorization", "ServiceToken "+token)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	// Same token again — still accepted because no nonce store.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+	req2.Header.Set("Authorization", "ServiceToken "+token)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code, "replay must be allowed without a NonceStore")
+}
+
+func TestServiceTokenMiddleware_LegacyTwoPartFormat_StillWorks(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Unix(1700000000, 0)
+
+	// Craft a legacy 2-part token manually.
+	tsStr := strconv.FormatInt(now.Unix(), 10)
+	mac := hmac.New(sha256.New, ring.Current())
+	_, _ = mac.Write([]byte(fmt.Sprintf("%s %s %s", http.MethodGet, "/legacy/path", tsStr)))
+	legacyToken := tsStr + ":" + hex.EncodeToString(mac.Sum(nil))
+
+	store := NewInMemoryNonceStore(5 * time.Minute)
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithNonceStore(store),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/legacy/path", nil)
+	req.Header.Set("Authorization", "ServiceToken "+legacyToken)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "legacy 2-part token must still be accepted")
 }

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -797,6 +797,17 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 	}
 	if b.authVerifier != nil {
 		routerOpts = append(routerOpts, router.WithAuthMiddleware(b.authVerifier, b.authPublicEndpoints))
+		var authMetrics *auth.AuthMetrics
+		if b.metricsProvider != nil {
+			am, err := auth.NewAuthMetrics(b.metricsProvider)
+			if err != nil {
+				return rollback(fmt.Errorf("bootstrap: register auth metrics: %w", err))
+			}
+			authMetrics = am
+		}
+		if authMetrics != nil {
+			routerOpts = append(routerOpts, router.WithAuthMetrics(authMetrics))
+		}
 	}
 	routerOpts = append(routerOpts, router.WithHealthHandler(hh))
 	rtr, err := router.NewE(routerOpts...)

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -158,6 +158,13 @@ func WithAuthMiddleware(verifier auth.TokenVerifier, publicEndpoints []string) O
 	}
 }
 
+// WithAuthMetrics sets the AuthMetrics instance used by AuthMiddleware when wired
+// via WithAuthMiddleware. When provided, JWT verification outcomes are recorded
+// against the shared metrics backend.
+func WithAuthMetrics(m *auth.AuthMetrics) Option {
+	return func(r *Router) { r.authMetrics = m }
+}
+
 // WithSecurityHeadersOptions passes additional SecurityHeadersOption values to
 // the SecurityHeaders middleware. Use this to configure HSTS directives, e.g.:
 //
@@ -195,18 +202,19 @@ func WithTrustedProxies(proxies []string) Option {
 // infra endpoints (/healthz, /readyz, /metrics) bypass RL/CB while business
 // routes get the full protection chain.
 type Router struct {
-	outerMux            *chi.Mux
-	mux                 *chi.Mux
-	healthHandler       *health.Handler
-	metricsCollector    metrics.Collector
-	metricsHandler      http.Handler
-	tracer              tracing.Tracer
-	tracingOpts         []middleware.TracingOption
-	requestIDOpts       []middleware.RequestIDOption
-	rateLimiter         middleware.RateLimiter
-	circuitBreaker      middleware.CircuitBreakerPolicy
-	authVerifier        auth.TokenVerifier
+	outerMux             *chi.Mux
+	mux                  *chi.Mux
+	healthHandler        *health.Handler
+	metricsCollector     metrics.Collector
+	metricsHandler       http.Handler
+	tracer               tracing.Tracer
+	tracingOpts          []middleware.TracingOption
+	requestIDOpts        []middleware.RequestIDOption
+	rateLimiter          middleware.RateLimiter
+	circuitBreaker       middleware.CircuitBreakerPolicy
+	authVerifier         auth.TokenVerifier
 	authPublicEndpoints  []string
+	authMetrics          *auth.AuthMetrics
 	securityHeadersOpts  []middleware.SecurityHeadersOption
 	bodyLimit            int64
 	trustedProxies       []string
@@ -321,7 +329,11 @@ func NewE(opts ...Option) (*Router, error) {
 		r.mux.Use(middleware.CircuitBreaker(r.circuitBreaker))
 	}
 	if r.authVerifier != nil {
-		r.mux.Use(auth.AuthMiddleware(r.authVerifier, r.authPublicEndpoints))
+		var authOpts []auth.AuthOption
+		if r.authMetrics != nil {
+			authOpts = append(authOpts, auth.WithMetrics(r.authMetrics))
+		}
+		r.mux.Use(auth.AuthMiddleware(r.authVerifier, r.authPublicEndpoints, authOpts...))
 	}
 	r.mux.Use(middleware.BodyLimit(r.bodyLimit))
 

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -202,22 +202,22 @@ func WithTrustedProxies(proxies []string) Option {
 // infra endpoints (/healthz, /readyz, /metrics) bypass RL/CB while business
 // routes get the full protection chain.
 type Router struct {
-	outerMux             *chi.Mux
-	mux                  *chi.Mux
-	healthHandler        *health.Handler
-	metricsCollector     metrics.Collector
-	metricsHandler       http.Handler
-	tracer               tracing.Tracer
-	tracingOpts          []middleware.TracingOption
-	requestIDOpts        []middleware.RequestIDOption
-	rateLimiter          middleware.RateLimiter
-	circuitBreaker       middleware.CircuitBreakerPolicy
-	authVerifier         auth.TokenVerifier
-	authPublicEndpoints  []string
-	authMetrics          *auth.AuthMetrics
-	securityHeadersOpts  []middleware.SecurityHeadersOption
-	bodyLimit            int64
-	trustedProxies       []string
+	outerMux            *chi.Mux
+	mux                 *chi.Mux
+	healthHandler       *health.Handler
+	metricsCollector    metrics.Collector
+	metricsHandler      http.Handler
+	tracer              tracing.Tracer
+	tracingOpts         []middleware.TracingOption
+	requestIDOpts       []middleware.RequestIDOption
+	rateLimiter         middleware.RateLimiter
+	circuitBreaker      middleware.CircuitBreakerPolicy
+	authVerifier        auth.TokenVerifier
+	authPublicEndpoints []string
+	authMetrics         *auth.AuthMetrics
+	securityHeadersOpts []middleware.SecurityHeadersOption
+	bodyLimit           int64
+	trustedProxies      []string
 }
 
 // New creates a Router with default middleware and optional configuration.


### PR DESCRIPTION
## Summary

- **AUTH-NOWFUNC-01**: Remove package-level `var nowFunc`; inject time via `JWTIssuerOption`/`JWTVerifierOption`/`ServiceTokenOption`. Verifier delegates to golang-jwt v5's `WithTimeFunc`. All 10+ test overrides replaced with per-instance clock injection.
- **AUTH-SLOG-01**: Inject `*slog.Logger` via `AuthOption`/`KeySetOption`/`ServiceTokenOption`/`EnvKeyProviderOption`. AuthMiddleware stores logger in context; `RequireRole` and authz functions extract via `loggerFrom(ctx)` — 17 cells/ call sites unchanged. 3 `slog.SetDefault()` in tests replaced.
- **WM-2-F2**: HMAC replay protection via `NonceStore` interface + `InMemoryNonceStore`. Token format extended to `{ts}:{nonce}:{hmac}` with `crypto/rand` nonce; backward-compatible 2-part legacy parsing.
- **WM-2-F3**: Auth metrics via `kernel/observability/metrics.Provider`. `AuthMetrics` registers `auth_token_verify_total`, `auth_token_verify_duration_seconds`, `auth_service_token_verify_total`. Wired through `router.WithAuthMetrics` + bootstrap auto-registration.

## Framework References

| Framework | Pattern Adopted |
|-----------|----------------|
| golang-jwt v5 `parser_option.go` | `WithTimeFunc` for verifier clock injection |
| Kratos `middleware/auth/jwt` | Logger injected at construction, not global |
| Kratos `middleware/metrics` | Nil-guard fast-path for zero-overhead when uninjected |

## Files Changed

| Area | Files | Purpose |
|------|-------|---------|
| New | `options.go`, `nonce.go`, `nonce_test.go`, `metrics.go`, `metrics_test.go` | Auth options, nonce store, metrics |
| Auth core | `jwt.go`, `servicetoken.go`, `middleware.go`, `authz.go`, `keys.go`, `provider.go` | DI injection points |
| Tests | `*_test.go` (6 files) | Updated for DI, new coverage |
| Wiring | `router.go`, `bootstrap.go` | Metrics auto-wire |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./runtime/auth/... -race` — all pass (89.6% coverage)
- [x] `go test ./runtime/http/router/...` — all pass
- [x] Verify no `var nowFunc` or `slog.SetDefault` remain in runtime/auth/
- [ ] CI green (build + test + SonarCloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)