### PR TITLE
feat(query): generic cursor helper + log convergence + prod guard

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,118 @@
+---
+name: code-reviewer
+description: 轻量代码审查 - 单次 PR/diff 快速审查，每条 Finding 含复杂度分级，便于后续 /fix 处理
+tools:
+  - Read
+  - Glob
+  - Grep
+model: sonnet
+effort: high
+permissionMode: auto
+---
+
+# Code Reviewer Agent
+
+你是日常代码审查助手。与 6 席位 `reviewer`（Phase S5/S6 工作流）不同，你做单次、轻量的 PR/diff 审查，一次性覆盖多个维度，直接返回 Finding 清单，**每条 Finding 带复杂度分级**（对接 `/fix` 技能），不产出 Finding 文件、不做席位分工。
+
+## Reasoning Blindness
+
+只看代码本身。不参考提交者的 commit message、handoff note 或自我评价，不假设意图——只看实际变更是否正确、安全、符合规范。
+
+## 审查范围
+
+按用户指令确定范围：
+- 指定 PR → 调用方用 `gh pr diff <N>` 预取或用户粘贴 diff
+- 指定 commit 范围 → 实际 `Read` 文件
+- 未指定 → 询问用户目标
+
+## 审查维度（一次性全覆盖）
+
+### 1. 正确性
+- 逻辑错误、边界条件、空值处理
+- 并发安全（goroutine 泄漏、race、死锁）
+- 错误传播是否完整
+
+### 2. GoCell 分层合规（见 CLAUDE.md）
+- kernel/ 是否引入对 runtime/adapters/cells 的依赖
+- cells/ 是否直接 import adapters/
+- 跨 Cell 是否通过 contract 通信
+- 新增 CUD 操作是否标注一致性级别（L0-L4）
+
+### 3. 编码规范（见 CLAUDE.md + .claude/rules/gocell/）
+- 错误用 `pkg/errcode`，不裸 `errors.New` 对外
+- 日志用 `slog`（结构化），不 `fmt.Println` / `log.Printf`
+- DB `snake_case`，JSON/Query/Path `camelCase`
+- 函数认知复杂度 ≤ 15
+- 字符串常量 ≥ 3 次使用需抽取
+- EventBus consumer 声明注释是否完整
+- HTTP 错误响应格式 `{"error": {"code","message","details"}}`
+
+### 4. 测试覆盖
+- 新增/修改代码是否有对应测试
+- kernel/ ≥ 90%，其他 ≥ 80%
+- table-driven test
+- 边界用例（空值/极端值/并发）
+
+### 5. 安全
+- 输入校验、SQL 注入、XSS、敏感信息泄漏
+- JWT / 鉴权覆盖
+- Debug 日志是否 dump 敏感 body
+
+### 6. 可维护性
+- godoc 清晰度、命名规范
+- 不必要的抽象或过度设计
+- 删除过时代码而非注释保留
+
+## 复杂度分级（每条 Finding 必须判定）
+
+对接 `/fix` 技能的复杂度体系，用于判断后续修复路径：
+
+| 等级 | 判定标准 | 修复形态 |
+|------|---------|---------|
+| **Cx1 简单** | 改 1-2 个文件，不跨包，不改接口 | 可 `/fix` 自动修 |
+| **Cx2 中等** | 改 3-5 个文件，跨 1-2 个包，接口不变 | `/fix` 给最小+彻底方案 |
+| **Cx3 复杂** | 改 5+ 文件，跨 3+ 包，或需改 kernel 接口 | `/fix` 只出方案，需人工决策 |
+| **Cx4 架构级** | 新增/重构子模块，或改变数据流方向 | 只做方案设计，不执行 |
+
+判定依据（按顺序）：
+1. 修复涉及多少文件？（用 `Grep` 搜索所有受影响调用点）
+2. 是否需改 `kernel/` 接口或类型？
+3. 是否需改数据库 schema（migration）？
+4. 是否影响 wire/bootstrap 组装逻辑？
+5. 同类问题是否在其他模块重复（1 处=局部，3+=系统性）
+
+## Finding 格式
+
+```
+[P0/P1/P2] [Cx1-Cx4] [维度] 文件:行号
+问题: ...
+证据: `具体代码片段或引用`
+建议: ...
+```
+
+严重级别：
+- **P0** 阻塞合并：安全漏洞、分层违规、数据丢失、核心功能缺失
+- **P1** 应当修复：规范违反、测试缺失、性能风险
+- **P2** 建议改进：可读性、命名、文档
+
+## 输出形式
+
+对话中返回：
+1. **Finding 清单**（按 P0→P2 排序，同级内 Cx1→Cx4）
+2. **复杂度汇总**：`Cx1: N 条 / Cx2: N 条 / Cx3: N 条 / Cx4: N 条`
+3. **修复分流建议**（供主对话直接执行）：
+   - Cx1/Cx2 单条或批量 → 派发 `developer` agent（批量时把 Finding 清单或本报告路径作为输入）
+   - Cx3/Cx4 → 标注"需人工决策"，必要时派 `architect`
+4. **总体结论**：LGTM / 需修复 / 需讨论
+
+不写 finding 文件、**不改代码**。
+
+## 约束
+
+- 每条 Finding 必须有文件路径 + 行号
+- 不凭记忆推断，必须 `Read` / `Grep` 确认
+- 复杂度分级必须基于实际 `Grep` 同模式搜索，不凭感觉
+- 证据不足时标 **[需确认]** 而非直接判 P0
+- 不做架构裁决（转给 `architect`）
+- 不做 Phase 流程审查（那属于 6 席位 `reviewer`）
+- 不做根因追踪（那属于 `/fix` 阶段 2）

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,0 +1,126 @@
+---
+name: developer
+description: 开发者 - 简单任务开发、单条或批量 Cx1/Cx2 问题修复，遵循 GoCell 编码规范与分层约束
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Edit
+  - Write
+  - Bash
+model: sonnet
+effort: high
+permissionMode: auto
+---
+
+# Developer Agent
+
+你是开发者 agent，接收**边界清晰**的任务：小功能开发、bug 修复、单条或批量 Cx1/Cx2 Finding 处理。不负责诊断、不做架构决策、不做审查。
+
+## 适用范围
+
+| 场景 | 是否适用 |
+|------|---------|
+| 加字段、改参数默认值、补错误处理、补单元测试 | ✅ |
+| 单条 Cx1/Cx2 Finding（调用方已指定文件+行号+建议） | ✅ |
+| **批量 Cx1/Cx2 Finding**（调用方提供清单或 review 报告路径） | ✅ |
+| 小范围重构（不改接口、不跨 3+ 包） | ✅ |
+| 需要根因分析、复现测试、多方案对比 | ❌ 转 `/fix` 技能 |
+| 架构变更、kernel 接口修改、Cx3/Cx4 | ❌ 转 `architect` + 人工 |
+| PR / Phase 审查 | ❌ 转 `code-reviewer` 或 `reviewer` |
+
+## 输入要求（调用方必须提供）
+
+**单任务**:
+1. **任务描述** — 一句话说清做什么
+2. **目标文件路径** — 绝对路径或相对仓库根的路径
+3. **修改意图** — 改前/改后的预期行为，或引用 Finding 建议
+4. **验收标准** — 测试命令 / 构建命令 / 手动验证方式
+
+**批量任务**:
+1. **Finding 清单** — 内联列表或 review 报告文件路径
+2. 每条须含：文件:行号、Cx 分级、修复建议
+3. **验收命令** — 批量跑完后的统一验证方式
+
+缺少信息 → 第一轮反问调用方，不凭推断动手。
+
+## 执行流程
+
+### 1. 理解任务（必做）
+
+- `Read` 目标文件（批量时先 Read review 报告解析清单）
+- `Grep` 相关调用点确认影响范围
+- 如果单条实际影响超过 Cx2 范围（跨 3+ 包 / 需改接口） → 立即停止，回报调用方升级处理
+- 批量模式下：先全部判一遍复杂度，Cx3/Cx4 条目剔除并回报，只处理剩余 Cx1/Cx2
+
+### 2. 检查对标约束（kernel/cells/runtime/adapters 下修改时）
+
+按 CLAUDE.md 的"对标对比规则"：
+- 查 `docs/references/framework-comparison.md` 找当前模块对标
+- 不确定设计时停手，请调用方派发 `explorer` agent 先研究，再回来执行
+
+### 3. Edit-Test Loop（逐步改、逐步测）
+
+对每次改动（批量时逐条循环，按复杂度从低到高排序：先 Cx1 再 Cx2）：
+1. `Edit` 或 `Write` 修改代码
+2. `go build ./...` — 编译检查
+3. `go test ./修改的包/...` — 运行相关测试
+4. 涉及并发 → `go test -race ./...`
+5. 失败 → 在当前方案上迭代；3 轮修不好 → 回滚当前条目 + 标 ESCALATE，继续下一条（批量模式不因单条失败中断）
+
+### 4. 补/改测试
+
+- 新增代码必须有对应测试（kernel/ ≥ 90%，其他 ≥ 80%）
+- 修 bug 先写复现测试确认 FAIL，再改代码让测试 PASS
+- table-driven test 覆盖边界用例
+
+### 5. 验证与收尾
+
+- 最终一次完整 `go build ./... && go test ./修改的包/...`
+- 涉及 kernel/ → 额外跑 `go test ./kernel/...`
+- **单任务报告**：改了什么文件、测试结果、遗留项（如有）
+- **批量任务报告**：逐条列状态表（✅ FIXED / ⚠ ESCALATE / ⏭ SKIPPED-Cx3+），末尾给改动文件汇总与统一测试结果
+
+## 编码规范（必须遵守）
+
+- 错误用 `pkg/errcode`，不裸 `errors.New` 对外
+- 日志用 `slog`（结构化），不 `fmt.Println` / `log.Printf`
+- DB `snake_case`，JSON/Query/Path `camelCase`
+- 函数认知复杂度 ≤ 15
+- 字符串常量 ≥ 3 次使用需抽取
+- HTTP 错误响应格式 `{"error": {"code","message","details"}}`
+- EventBus consumer 必须有声明注释（见 `.claude/rules/gocell/eventbus.md`）
+
+## 分层约束（必须遵守）
+
+- kernel/ 不依赖 runtime/adapters/cells
+- cells/ 不直接 import adapters/
+- 跨 Cell 只通过 contract
+- 新增 CUD 操作标注一致性级别（L0-L4）
+
+## Git 约束
+
+- 不自动 commit（除非调用方明确授权）
+- 提示调用方 commit 时给出 Conventional Commits 格式建议：`fix(<scope>): ...` / `feat(<scope>): ...`
+- 不 `git add -A`，只 add 修改文件
+- 不 `--amend`，不 `--no-verify`
+- 不 push，不 force push
+
+## 停手条件
+
+**立即全停 + 回报调用方**（适用于单任务 / 批量模式的全局停手）:
+- 修改中发现更严重的相关 bug（超出 scope）
+- 遇到安全相关改动需人工确认（鉴权、密码学、token 处理）
+- 对标约束不清晰，需 `explorer` 先研究
+
+**单条跳过 + 继续下一条**（仅批量模式）:
+- 某条实际复杂度超出 Cx2（跨 3+ 包 / 需改 kernel 接口 / 需 migration） → 标 `⏭ SKIPPED-Cx3+`
+- 某条 3 轮 Edit-Test Loop 仍失败 → 回滚该条 + 标 `⚠ ESCALATE`
+
+## 约束
+
+- 只做被派发的任务，不顺手重构
+- 不引入新依赖（除非调用方授权）
+- 不删除未明确要求删除的代码
+- 不添加无关注释或 TODO
+- 简洁报告结果，不冗长自述

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -1,0 +1,78 @@
+---
+name: explorer
+description: 开源项目探索 - 对标框架源码研究、外部项目设计分析、接口签名与生命周期提取
+tools:
+  - Read
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
+model: sonnet
+effort: high
+permissionMode: auto
+---
+
+# Explorer Agent
+
+你是多角色工作流中的 **Explorer**。你负责探索开源项目和对标框架源码，为 GoCell 的设计决策提供外部参考。
+
+## 使用场景
+
+- 新建或重构 kernel/、cells/、runtime/、adapters/ 下的模块时，按 CLAUDE.md 的"对标对比规则"拉取对标源码
+- 研究某个开源项目的接口设计、生命周期、错误处理模式
+- 对比多个框架解决同一问题的方案
+- 为架构决策提供证据（源码引用 + 采纳/偏离理由）
+
+## 探索流程
+
+### 1. 确定对标目标
+
+- 查 `docs/references/framework-comparison.md` 找到当前模块对应的 primary/secondary 对标文件路径
+- 用户明确指定的外部项目 → 直接使用
+- 未指定 → 在 framework-comparison.md 中找同类模块的对标
+
+### 2. 拉取源码
+
+- 优先使用 `WebFetch` 拉 GitHub raw 源码：`https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}`
+- 需要搜索关键字或发现新路径时用 `WebSearch`
+- 拉取后在本地内联阅读；超长文件分段拉取
+
+### 3. 提取关键设计
+
+从源码中提取：
+- **接口签名** — 公开导出的类型、方法、函数签名
+- **生命周期钩子** — 初始化 / 启动 / 停止 / 清理的调用顺序
+- **错误处理** — 错误类型定义、包装方式、传播路径
+- **并发模型** — goroutine 启动时机、取消传播、资源清理
+- **扩展点** — 插件机制、中间件、回调
+
+### 4. 对标输出
+
+输出格式：
+
+```
+## 对标: {framework} {file}
+
+源码位置: https://github.com/{owner}/{repo}/blob/{ref}/{path}
+
+### 关键设计
+- 接口: `func Foo(ctx context.Context, ...) error`
+- 生命周期: New → Start → Stop
+- 错误处理: 包装为 `*FooError`，含 Code/Message
+
+### 对 GoCell 的启示
+- 可采纳: ...（理由）
+- 需偏离: ...（理由）
+- 不适用: ...（场景差异）
+
+### 引用（供 PR/commit 使用）
+ref: {framework} {path}@{ref}
+```
+
+## 约束
+
+- **必须实际拉取源码**，不凭记忆描述框架行为
+- 源码引用必须给出 **完整 URL + 行号范围**（如 `file.go:L42-L98`）
+- 不修改 GoCell 代码（只探索和汇报）
+- 不下载大文件（>500KB 的源码文件先用 `Grep` 定位行号再局部拉取）
+- 对比结论必须有 GoCell 侧的具体场景对应，禁止空泛建议

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tmp/
 
 # Claude Code
 worktrees/
+.claude/scheduled_tasks.lock
 
 # Build output (root-level binaries from `go build ./cmd/...`)
 /gocell

--- a/cells/access-core/slices/identitymanage/service.go
+++ b/cells/access-core/slices/identitymanage/service.go
@@ -243,7 +243,8 @@ func (s *Service) publish(ctx context.Context, topic string, payload map[string]
 }
 
 // runInTx executes fn in a transaction if txRunner is configured, otherwise
-// executes directly.
+// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
+// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
 	if s.txRunner != nil {
 		return s.txRunner.RunInTx(ctx, fn)

--- a/cells/access-core/slices/sessionlogin/service.go
+++ b/cells/access-core/slices/sessionlogin/service.go
@@ -159,6 +159,7 @@ func (s *Service) Login(ctx context.Context, input LoginInput) (*TokenPair, erro
 		return nil
 	}
 
+	// txRunner nil-safe: nil means no transaction support (query-only or demo mode).
 	if s.txRunner != nil {
 		if err := s.txRunner.RunInTx(ctx, persistAndPublish); err != nil {
 			return nil, err

--- a/cells/access-core/slices/sessionlogout/service.go
+++ b/cells/access-core/slices/sessionlogout/service.go
@@ -99,6 +99,7 @@ func (s *Service) Logout(ctx context.Context, sessionID string) error {
 		return nil
 	}
 
+	// txRunner nil-safe: nil means no transaction support (query-only or demo mode).
 	if s.txRunner != nil {
 		if err := s.txRunner.RunInTx(ctx, persistAndPublish); err != nil {
 			return err

--- a/cells/audit-core/slices/auditappend/service.go
+++ b/cells/audit-core/slices/auditappend/service.go
@@ -157,8 +157,9 @@ func (s *Service) buildPersistFn(auditEntry *domain.AuditEntry, appendedPayload 
 	}
 }
 
-// runPersist executes fn within a transaction if txRunner is configured,
-// otherwise calls fn directly.
+// runPersist executes fn in a transaction if txRunner is configured, otherwise
+// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
+// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runPersist(ctx context.Context, fn func(context.Context) error) error {
 	if s.txRunner != nil {
 		return s.txRunner.RunInTx(ctx, fn)

--- a/cells/audit-core/slices/auditquery/service.go
+++ b/cells/audit-core/slices/auditquery/service.go
@@ -55,5 +55,6 @@ func (s *Service) Query(ctx context.Context, filters ports.AuditFilters, pageReq
 			return []any{e.Timestamp.Format(time.RFC3339Nano), e.ID}
 		},
 		OnCursorErr: query.LogCursorError(s.logger, "auditquery"),
+		DemoMode:    s.codec.IsDemoKey(query.KnownDemoKeys()...),
 	})
 }

--- a/cells/audit-core/slices/auditquery/service.go
+++ b/cells/audit-core/slices/auditquery/service.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
@@ -34,64 +33,27 @@ func NewService(repo ports.AuditRepository, codec *query.CursorCodec, logger *sl
 
 // Query returns a paginated page of audit entries matching the given filters.
 func (s *Service) Query(ctx context.Context, filters ports.AuditFilters, pageReq query.PageRequest) (query.PageResult[*domain.AuditEntry], error) {
-	pageReq.Normalize()
-
 	qctx := query.QueryContext("endpoint", "audit-query",
 		"eventType", filters.EventType,
 		"actorId", filters.ActorID,
 		"from", filters.From.Format(time.RFC3339Nano),
 		"to", filters.To.Format(time.RFC3339Nano),
 	)
-
-	var cursorValues []any
-	if pageReq.Cursor != "" {
-		cur, err := s.codec.Decode(pageReq.Cursor)
-		if err != nil {
-			s.logInvalidCursor(ctx, "decode", err)
-			return query.PageResult[*domain.AuditEntry]{}, err
-		}
-		if err := query.ValidateCursorScope(cur, auditSort, qctx); err != nil {
-			s.logInvalidCursor(ctx, "scope", err)
-			return query.PageResult[*domain.AuditEntry]{}, err
-		}
-		cursorValues = cur.Values
-	}
-
-	params := query.ListParams{
-		Limit:        pageReq.Limit,
-		CursorValues: cursorValues,
-		Sort:         auditSort,
-	}
-
-	entries, err := s.repo.Query(ctx, filters, params)
-	if err != nil {
-		return query.PageResult[*domain.AuditEntry]{}, fmt.Errorf("audit-query: query: %w", err)
-	}
-
-	return query.BuildPageResult(entries, pageReq.Limit, s.codec, auditSort, qctx, func(e *domain.AuditEntry) []any {
-		return []any{e.Timestamp.Format(time.RFC3339Nano), e.ID}
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.AuditEntry]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     auditSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.AuditEntry, error) {
+			entries, err := s.repo.Query(ctx, filters, params)
+			if err != nil {
+				return nil, fmt.Errorf("audit-query: query: %w", err)
+			}
+			return entries, nil
+		},
+		Extract: func(e *domain.AuditEntry) []any {
+			return []any{e.Timestamp.Format(time.RFC3339Nano), e.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "auditquery"),
 	})
-}
-
-// logInvalidCursor emits a structured Info record for client-supplied cursor
-// failures. The raw cursor string is intentionally omitted — opaque base64
-// that may encode internal offsets; aligned with k8s apiserver / etcd / MinIO
-// practice (none log continuation-token values).
-//
-// Level is Info (not Warn) because cursor errors are client input failures,
-// not server-side degradation; operators tracking 4xx frequency should rely
-// on metrics rather than log-volume alerts. Cursor failures are logged —
-// rather than silently surfacing via HTTP 400 — because repeated occurrences
-// can indicate a client bug, a stale session, or enumeration probing worth
-// correlating with request IDs during triage.
-func (s *Service) logInvalidCursor(ctx context.Context, reason string, err error) {
-	attrs := []any{
-		"slice", "auditquery",
-		"reason", reason,
-		"error", err.Error(),
-	}
-	if rid, ok := ctxkeys.RequestIDFrom(ctx); ok && rid != "" {
-		attrs = append(attrs, "request_id", rid)
-	}
-	s.logger.Info("invalid cursor", attrs...)
 }

--- a/cells/audit-core/slices/auditverify/service.go
+++ b/cells/audit-core/slices/auditverify/service.go
@@ -129,8 +129,9 @@ func (s *Service) buildPersistFn(payload []byte) func(context.Context) error {
 	}
 }
 
-// runPersist executes fn within a transaction if txRunner is configured,
-// otherwise calls fn directly.
+// runPersist executes fn in a transaction if txRunner is configured, otherwise
+// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
+// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runPersist(ctx context.Context, fn func(context.Context) error) error {
 	if s.txRunner != nil {
 		return s.txRunner.RunInTx(ctx, fn)

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -165,7 +165,8 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 }
 
 // runInTx executes fn in a transaction if txRunner is configured, otherwise
-// executes directly.
+// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
+// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
 	if s.txRunner != nil {
 		return s.txRunner.RunInTx(ctx, fn)

--- a/cells/config-core/slices/configread/service.go
+++ b/cells/config-core/slices/configread/service.go
@@ -44,34 +44,22 @@ func (s *Service) GetByKey(ctx context.Context, key string) (*domain.ConfigEntry
 
 // List returns a paginated page of config entries.
 func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.PageResult[*domain.ConfigEntry], error) {
-	pageReq.Normalize()
-
 	qctx := query.QueryContext("endpoint", "config-read")
-
-	var cursorValues []any
-	if pageReq.Cursor != "" {
-		cur, err := s.codec.Decode(pageReq.Cursor)
-		if err != nil {
-			return query.PageResult[*domain.ConfigEntry]{}, err
-		}
-		if err := query.ValidateCursorScope(cur, configSort, qctx); err != nil {
-			return query.PageResult[*domain.ConfigEntry]{}, err
-		}
-		cursorValues = cur.Values
-	}
-
-	params := query.ListParams{
-		Limit:        pageReq.Limit,
-		CursorValues: cursorValues,
-		Sort:         configSort,
-	}
-
-	entries, err := s.repo.List(ctx, params)
-	if err != nil {
-		return query.PageResult[*domain.ConfigEntry]{}, fmt.Errorf("config-read: list: %w", err)
-	}
-
-	return query.BuildPageResult(entries, pageReq.Limit, s.codec, configSort, qctx, func(e *domain.ConfigEntry) []any {
-		return []any{e.Key, e.ID}
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.ConfigEntry]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     configSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.ConfigEntry, error) {
+			entries, err := s.repo.List(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("config-read: list: %w", err)
+			}
+			return entries, nil
+		},
+		Extract: func(e *domain.ConfigEntry) []any {
+			return []any{e.Key, e.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "configread"),
 	})
 }

--- a/cells/config-core/slices/configread/service.go
+++ b/cells/config-core/slices/configread/service.go
@@ -61,5 +61,6 @@ func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.Pa
 			return []any{e.Key, e.ID}
 		},
 		OnCursorErr: query.LogCursorError(s.logger, "configread"),
+		DemoMode:    s.codec.IsDemoKey(query.KnownDemoKeys()...),
 	})
 }

--- a/cells/config-core/slices/configread/service_test.go
+++ b/cells/config-core/slices/configread/service_test.go
@@ -127,6 +127,48 @@ func TestService_List_InvalidCursor(t *testing.T) {
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }
 
+func TestService_List_ScopeMismatch(t *testing.T) {
+	codec, _ := query.NewCursorCodec([]byte("gocell-demo-cursor-key-32bytes!!"))
+	differentSort := []query.SortColumn{
+		{Name: "created_at", Direction: query.SortDESC},
+		{Name: "id", Direction: query.SortASC},
+	}
+	cur := query.Cursor{
+		Values:  []any{"some-key", "some-id"},
+		Scope:   query.SortScope(differentSort),
+		Context: query.QueryContext("endpoint", "config-read"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	svc, _ := newTestService()
+	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "sort scope mismatch", ecErr.Details["reason"])
+}
+
+func TestService_List_ContextMismatch(t *testing.T) {
+	codec, _ := query.NewCursorCodec([]byte("gocell-demo-cursor-key-32bytes!!"))
+	cur := query.Cursor{
+		Values:  []any{"some-key", "some-id"},
+		Scope:   query.SortScope(configSort),
+		Context: query.QueryContext("endpoint", "wrong-endpoint"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	svc, _ := newTestService()
+	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "query context mismatch", ecErr.Details["reason"])
+}
+
 func TestService_List_LastPage(t *testing.T) {
 	svc, repo := newTestService()
 	seedEntry(t, repo, "key-a", "v")

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -161,7 +161,8 @@ func (s *Service) Delete(ctx context.Context, key string) error {
 }
 
 // runInTx executes fn in a transaction if txRunner is configured, otherwise
-// executes directly.
+// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
+// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
 	if s.txRunner != nil {
 		return s.txRunner.RunInTx(ctx, fn)

--- a/cells/config-core/slices/featureflag/service.go
+++ b/cells/config-core/slices/featureflag/service.go
@@ -69,6 +69,7 @@ func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.Pa
 			return []any{f.Key, f.ID}
 		},
 		OnCursorErr: query.LogCursorError(s.logger, "featureflag"),
+		DemoMode:    s.codec.IsDemoKey(query.KnownDemoKeys()...),
 	})
 }
 

--- a/cells/config-core/slices/featureflag/service.go
+++ b/cells/config-core/slices/featureflag/service.go
@@ -52,35 +52,23 @@ func (s *Service) GetByKey(ctx context.Context, key string) (*domain.FeatureFlag
 
 // List returns a paginated page of feature flags.
 func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.PageResult[*domain.FeatureFlag], error) {
-	pageReq.Normalize()
-
 	qctx := query.QueryContext("endpoint", "feature-flag")
-
-	var cursorValues []any
-	if pageReq.Cursor != "" {
-		cur, err := s.codec.Decode(pageReq.Cursor)
-		if err != nil {
-			return query.PageResult[*domain.FeatureFlag]{}, err
-		}
-		if err := query.ValidateCursorScope(cur, flagSort, qctx); err != nil {
-			return query.PageResult[*domain.FeatureFlag]{}, err
-		}
-		cursorValues = cur.Values
-	}
-
-	params := query.ListParams{
-		Limit:        pageReq.Limit,
-		CursorValues: cursorValues,
-		Sort:         flagSort,
-	}
-
-	flags, err := s.repo.List(ctx, params)
-	if err != nil {
-		return query.PageResult[*domain.FeatureFlag]{}, fmt.Errorf("feature-flag: list: %w", err)
-	}
-
-	return query.BuildPageResult(flags, pageReq.Limit, s.codec, flagSort, qctx, func(f *domain.FeatureFlag) []any {
-		return []any{f.Key, f.ID}
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.FeatureFlag]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     flagSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.FeatureFlag, error) {
+			flags, err := s.repo.List(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("feature-flag: list: %w", err)
+			}
+			return flags, nil
+		},
+		Extract: func(f *domain.FeatureFlag) []any {
+			return []any{f.Key, f.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "featureflag"),
 	})
 }
 

--- a/cells/config-core/slices/featureflag/service_test.go
+++ b/cells/config-core/slices/featureflag/service_test.go
@@ -110,6 +110,52 @@ func TestService_List_InvalidCursor(t *testing.T) {
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }
 
+func TestService_List_ScopeMismatch(t *testing.T) {
+	repo := mem.NewFlagRepository()
+	codec, _ := query.NewCursorCodec([]byte("test-featureflag-cursor-key-32b!"))
+	svc := NewService(repo, codec, slog.Default())
+
+	differentSort := []query.SortColumn{
+		{Name: "created_at", Direction: query.SortDESC},
+		{Name: "id", Direction: query.SortASC},
+	}
+	cur := query.Cursor{
+		Values:  []any{"some-key", "some-id"},
+		Scope:   query.SortScope(differentSort),
+		Context: query.QueryContext("endpoint", "feature-flag"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "sort scope mismatch", ecErr.Details["reason"])
+}
+
+func TestService_List_ContextMismatch(t *testing.T) {
+	repo := mem.NewFlagRepository()
+	codec, _ := query.NewCursorCodec([]byte("test-featureflag-cursor-key-32b!"))
+	svc := NewService(repo, codec, slog.Default())
+
+	cur := query.Cursor{
+		Values:  []any{"some-key", "some-id"},
+		Scope:   query.SortScope(flagSort),
+		Context: query.QueryContext("endpoint", "wrong-endpoint"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "query context mismatch", ecErr.Details["reason"])
+}
+
 func TestService_List_LastPage(t *testing.T) {
 	svc, repo := newTestService()
 	seedFlag(t, repo, "flag-a", domain.FlagBoolean, true, 0)

--- a/cells/device-cell/slices/device-command/service.go
+++ b/cells/device-cell/slices/device-command/service.go
@@ -74,40 +74,26 @@ func (s *Service) Enqueue(ctx context.Context, deviceID, payload string) (*domai
 // Sort: created_at ASC, id ASC (FIFO -- oldest pending commands first).
 // This is the poll endpoint used by devices in the L4 latent model.
 func (s *Service) ListPending(ctx context.Context, deviceID string, pageReq query.PageRequest) (query.PageResult[*domain.Command], error) {
-	// Verify device exists.
 	if _, err := s.deviceRepo.GetByID(ctx, deviceID); err != nil {
 		return query.PageResult[*domain.Command]{}, fmt.Errorf("device-command: lookup device: %w", err)
 	}
-
-	pageReq.Normalize()
-
 	qctx := query.QueryContext("endpoint", "device-command", "deviceId", deviceID)
-
-	var cursorValues []any
-	if pageReq.Cursor != "" {
-		cur, err := s.codec.Decode(pageReq.Cursor)
-		if err != nil {
-			return query.PageResult[*domain.Command]{}, err
-		}
-		if err := query.ValidateCursorScope(cur, pendingSort, qctx); err != nil {
-			return query.PageResult[*domain.Command]{}, err
-		}
-		cursorValues = cur.Values
-	}
-
-	params := query.ListParams{
-		Limit:        pageReq.Limit,
-		CursorValues: cursorValues,
-		Sort:         pendingSort,
-	}
-
-	cmds, err := s.cmdRepo.ListPending(ctx, deviceID, params)
-	if err != nil {
-		return query.PageResult[*domain.Command]{}, fmt.Errorf("device-command: list pending: %w", err)
-	}
-
-	return query.BuildPageResult(cmds, pageReq.Limit, s.codec, pendingSort, qctx, func(c *domain.Command) []any {
-		return []any{c.CreatedAt.Format(time.RFC3339Nano), c.ID}
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Command]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     pendingSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Command, error) {
+			cmds, err := s.cmdRepo.ListPending(ctx, deviceID, params)
+			if err != nil {
+				return nil, fmt.Errorf("device-command: list pending: %w", err)
+			}
+			return cmds, nil
+		},
+		Extract: func(c *domain.Command) []any {
+			return []any{c.CreatedAt.Format(time.RFC3339Nano), c.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "device-command"),
 	})
 }
 

--- a/cells/device-cell/slices/device-command/service.go
+++ b/cells/device-cell/slices/device-command/service.go
@@ -94,6 +94,7 @@ func (s *Service) ListPending(ctx context.Context, deviceID string, pageReq quer
 			return []any{c.CreatedAt.Format(time.RFC3339Nano), c.ID}
 		},
 		OnCursorErr: query.LogCursorError(s.logger, "device-command"),
+		DemoMode:    s.codec.IsDemoKey(query.KnownDemoKeys()...),
 	})
 }
 

--- a/cells/order-cell/slices/order-query/handler_test.go
+++ b/cells/order-cell/slices/order-query/handler_test.go
@@ -172,14 +172,37 @@ func TestHandleList_ExceedsMaxLimit(t *testing.T) {
 }
 
 func TestHandleList_InvalidCursor(t *testing.T) {
-	h, _ := newTestHandler(&domain.Order{ID: "ord-1", Item: "x", Status: "pending"})
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders?cursor=garbage", nil)
+	codec, _ := query.NewCursorCodec(bytes.Repeat([]byte("k"), 32))
 
-	h.HandleList(rec, req)
+	wrongSort := []query.SortColumn{{Name: "other", Direction: query.SortASC}, {Name: "x", Direction: query.SortASC}}
+	missingFieldsToken, _ := codec.Encode(query.Cursor{Values: []any{"v1", "v2"}})
+	crossContextToken, _ := codec.Encode(query.Cursor{
+		Values:  []any{"v1", "v2"},
+		Scope:   query.SortScope(wrongSort),
+		Context: query.QueryContext("endpoint", "wrong-endpoint"),
+	})
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "ERR_CURSOR_INVALID")
+	tests := []struct {
+		name   string
+		cursor string
+	}{
+		{"garbage token", "not-a-valid-cursor!!!"},
+		{"missing scope and context", missingFieldsToken},
+		{"cross-context replay", crossContextToken},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := newTestHandler(&domain.Order{ID: "ord-1", Item: "x", Status: "pending"})
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/orders?cursor="+tc.cursor, nil)
+
+			h.HandleList(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "ERR_CURSOR_INVALID")
+		})
+	}
 }
 
 func TestHandleList_Empty(t *testing.T) {

--- a/cells/order-cell/slices/order-query/service.go
+++ b/cells/order-cell/slices/order-query/service.go
@@ -52,5 +52,6 @@ func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.Pa
 			return []any{o.CreatedAt.Format(time.RFC3339Nano), o.ID}
 		},
 		OnCursorErr: query.LogCursorError(s.logger, "order-query"),
+		DemoMode:    s.codec.IsDemoKey(query.KnownDemoKeys()...),
 	})
 }

--- a/cells/order-cell/slices/order-query/service.go
+++ b/cells/order-cell/slices/order-query/service.go
@@ -39,34 +39,18 @@ func (s *Service) GetByID(ctx context.Context, id string) (*domain.Order, error)
 
 // List returns a paginated page of orders.
 func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.PageResult[*domain.Order], error) {
-	pageReq.Normalize()
-
 	qctx := query.QueryContext("endpoint", "order-query")
-
-	var cursorValues []any
-	if pageReq.Cursor != "" {
-		cur, err := s.codec.Decode(pageReq.Cursor)
-		if err != nil {
-			return query.PageResult[*domain.Order]{}, err
-		}
-		if err := query.ValidateCursorScope(cur, orderSort, qctx); err != nil {
-			return query.PageResult[*domain.Order]{}, err
-		}
-		cursorValues = cur.Values
-	}
-
-	params := query.ListParams{
-		Limit:        pageReq.Limit,
-		CursorValues: cursorValues,
-		Sort:         orderSort,
-	}
-
-	orders, err := s.repo.List(ctx, params)
-	if err != nil {
-		return query.PageResult[*domain.Order]{}, err
-	}
-
-	return query.BuildPageResult(orders, pageReq.Limit, s.codec, orderSort, qctx, func(o *domain.Order) []any {
-		return []any{o.CreatedAt.Format(time.RFC3339Nano), o.ID}
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Order]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     orderSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Order, error) {
+			return s.repo.List(ctx, params)
+		},
+		Extract: func(o *domain.Order) []any {
+			return []any{o.CreatedAt.Format(time.RFC3339Nano), o.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "order-query"),
 	})
 }

--- a/cells/order-cell/slices/order-query/service_test.go
+++ b/cells/order-cell/slices/order-query/service_test.go
@@ -190,3 +190,27 @@ func TestService_List_ScopeMismatch(t *testing.T) {
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 	assert.Equal(t, "sort scope mismatch", ecErr.Details["reason"])
 }
+
+func TestService_List_ContextMismatch(t *testing.T) {
+	codec := testCodec()
+	cur := query.Cursor{
+		Values:  []any{time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), "ord-1"},
+		Scope:   query.SortScope(orderSort),
+		Context: query.QueryContext("endpoint", "wrong-endpoint"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	repo := seedRepo(&domain.Order{
+		ID: "ord-1", Item: "a", Status: "pending",
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	svc := NewService(repo, codec, slog.Default())
+
+	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "query context mismatch", ecErr.Details["reason"])
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,25 +1,30 @@
 # GoCell Backlog
 
 > 只含待办事项。已完成项归档至 `docs/reviews/archive/`。
-> 更新日期: 2026-04-16
+> 更新日期: 2026-04-17
 > Batch 1-5: ✅ 全部完成 (PR#67-114, 48 PRs)
-> Wave 1 进行中: ✅ PR#116-138 (23 PRs 已合入)
+> Wave 1: ✅ 全部完成 (PR#116-142+146, Batch A-EF 全部合入)
+> Post-Wave 1: PR#141+143-148+150-157 已合入（TPUB+RMQ+RBAC closure+outbox fixes+kernel governance+rabbitmq conformance isolation+access-core 安全加固+validator 诊断定位+CI 并行化+hook 生命周期+config rollback 契约+OBS-B test determinism+OBS-A provider-neutral metrics）
+> PR#154 ✅ kernel hook 生命周期超时 + HookObserver + outbox metadata DX（WM17-F2-2/F4-3 + OBS-DX-01 + OBS-DOC-01）
+> PR#155 ✅ config-core rollback 契约 + publish redaction（H2-1 + H2-2 + AUTHZ-WRITE-CONFIG-01 + ERROR-MSG-SCRUB-01 + ROLLBACK-NEGPATH-TEST-01 + SCHEMA-SENSITIVE-DESC-01）
+> PR#156 ✅ PR-R-OBS-B: test determinism + cursor log（CONFORMANCE-SLEEP-01 + OBS-TABLE-01 + CURSOR-P2-02）
+> PR#157 ✅ PR-R-OBS-A: provider-neutral metrics + async hook dispatcher + pool statter（OBS-METRIC-01 + OTEL-COV-01 + HOOK-OBSERVER-ASYNC-01 + OBS-LEAK-02 + OBS-POOLSTATS-WAITCOUNT-01 + OBS-HOOK-DISPATCHER-CFG-01）
+> PR#149 已被 PR#151 取代（access-core 安全加固 + READYZ，已合入）
 > PR#129 (Sentinel DSN redaction) / PR#130 (Bolt journey catalog) — 外部 PR，未合入
 > 旧版备份: `docs/reviews/archive/20260415-backlog-pre-pr127-cleanup.md`
 
 ---
 
-## Wave 1: 待做
+## Wave 1: ✅ 全部完成
 
-> 已合入 PR#116-128。剩余按优先级分层：P1 正确性 → MUST（v1.0 阻塞项）→ SHOULD（建议 v1.0 前做）。
-> DEFER 项已移至 Batch 8。
+> 已合入 PR#116-142+146。DEFER 项已移至 Batch 8。
 
 ### P1 正确性
 
 | # | 任务 | 工时 | 文件 | 来源 |
 |---|------|------|------|------|
 | 5 | **AUTH-DX-01** README + seed 用户 + sso-bff walkthrough: auth 已拦截全部业务路由，README 失效；sso-bff README 缺 refresh/GET user/event 消费 demo (P4-P1-6)。具体漂移: refresh curl 发 `sessionId` 实际需 `refreshToken`；logout 204 空 body 管道 jq 失败；audit jq 用 `.createdAt` 实为 `.Timestamp` | 4h | `README.md` + `cells/access-core/internal/mem/` + `examples/sso-bff/README.md` | 6B + P4 review |
-| 6 | **TPUB-01** TestPubSub 真实 adapter 认证: conformance harness 替换 sleep + 接入 RabbitMQ adapter | 4h | `kernel/outbox/outboxtest/` + `adapters/rabbitmq/` | 6B |
+| 6 | ✅ **TPUB-01** TestPubSub 真实 adapter 认证: conformance harness 替换 sleep + 接入 RabbitMQ adapter | 4h | `kernel/outbox/outboxtest/` + `adapters/rabbitmq/` | 6B | PR#141 |
 
 ### 运维 + 基础设施
 
@@ -68,8 +73,8 @@
 | # | 任务 | 前置 | 工时 |
 |---|------|------|------|
 | 28 | **SOL-B-01** Claimer lease 续租 | L4 API ✅ | 4h |
-| 31 | **RabbitMQ 代码清理** backoff + FailOpen enum | RMQ ✅ | 3h |
-| 32 | **cursor 可观测** invalid 结构化日志 | cursor (#15 B8) | 1h |
+| 31 | ✅ **RabbitMQ 代码清理** backoff + FailOpen enum → ClaimPolicy typed enum | RMQ ✅ | 3h | PR#141 |
+| 32 | ✅ **cursor 可观测** invalid 结构化日志（CURSOR-P2-02）| cursor (#15 B8) | 1h | PR#156 |
 | 33 | **WM-35** BFF handler 接入 cookie session ★ | WM-2-F1 ✅ | **2d** |
 
 ## Wave 3: Auth 收尾
@@ -94,7 +99,7 @@
 ## 关键路径
 
 ```
-★ Auth 链: WM-2-F1 ✅ → WM-35 (2d) → WM-36 (1.5d) → Review (2d) = 剩余 5.5 工作日
+★ Auth 链: WM-2-F1 ✅ → WM-35 (2d) → WM-36 (1.5d) → H1(0.5d) → H2(0.5d) → FEAT(1d) → README(0.5d) → Review(2d) = 剩余 8 工作日
 ```
 
 ---
@@ -106,13 +111,18 @@
 
 | PR 组 | 任务 | 工时 |
 |-------|------|------|
-| **OBS 全家桶** | META-SIZE-01(Metadata key 数/大小上限) + ✅ OBS-TABLE-01 PR-R-OBS-B(kernel/metadata parser_test.go 合并 7 个 invalid-YAML 测试为 table-driven，删除 5 个被 EmptyStructFiles 覆盖的 EmptyID 测试) + OBS-METRIC-01(bridge counter/histogram) + OBS-DX-01(cloneMetadata 导出 + wrapper 清理 + godoc) + OBS-DOC-01(IsReservedMetadataKey usage example) + #23(OTel 覆盖率 OTEL-COV-01 testcontainers 集成测试, `adapters/otel/`) + ✅ CONFORMANCE-SLEEP-01 PR-R-OBS-B(conformance.go 5 处 time.Sleep+count → harness.assertNoMoreDeliveries pure select，对齐 Watermill; buffer=100 non-blocking send 避免干扰被测行为) + HOOK-OBSERVER-ASYNC-01(LifecycleHookObserver 独立超时 + 异步有界队列) | 7h → 5h |
-| **Outbox 治理** | OUTBOX-GUARD-01(NoopWriter/DiscardPublisher lint 约束) + DISCARD-OBS-01(DiscardPublisher Logger 注入 + counter) + OUTBOX-RECEIPT-01(`outbox.Receipt` alias 全仓迁移 `idempotency.Receipt`) | 4h |
+| **OBS 全家桶** | ~~META-SIZE-01~~ ✅ PR#147 + ✅ OBS-TABLE-01 PR#156(kernel/metadata parser_test.go 合并 7 个 invalid-YAML 测试为 table-driven，删除 5 个被 EmptyStructFiles 覆盖的 EmptyID 测试) + ✅ OBS-METRIC-01 PR#157(provider-neutral metrics.Provider + prom/otel adapter + HTTP/Relay collector 迁移 + bootstrap.WithMetricsProvider + default-assembly wiring) + ✅ OBS-DX-01 PR#154(CloneMetadata 导出 + godoc) + ✅ OBS-DOC-01 PR#154(ExampleIsReservedMetadataKey) + ✅ #23 OTEL-COV-01 PR#157(mock OTLP via ManualReader + tracetest.InMemoryExporter, 覆盖 metrics + trace) + ✅ CONFORMANCE-SLEEP-01 PR#156(conformance.go 5 处 time.Sleep+count → harness.assertNoMoreDeliveries pure select，对齐 Watermill; buffer=100 non-blocking send 避免干扰被测行为) + ✅ HOOK-OBSERVER-ASYNC-01 PR#157(kernel/assembly/hook_dispatcher.go: 异步有界队列 + per-sink timeout + drop counter via Provider + goleak + failed-start cleanup via bootstrap Shutdown teardown) | 7h → 0h |
+| **OBS 全家桶 follow-up** | ✅ OBS-LEAK-02 PR#157(`newTestAssembly(t, cfg)` helper + 51 sites 迁移，移除 goleak allowlist) + ✅ OBS-POOLSTATS-WAITCOUNT-01 PR#157(`db.client.connection.timeouts` ObservableCounter) + OBS-RELAY-REGISTER-ATOMIC-01(Cx3, P2): `outbox.NewProviderRelayCollector` 5 个 metric 顺序 register，3 失败则前 2 半注册；需 Provider.Unregister 支持或文档化契约 (discovered via PR#157 review S3-05) + ✅ OBS-HOOK-DISPATCHER-CFG-01 PR#157(`dispatcherConfig{}` 替代位置参数) + OBS-HTTP-COLLECTOR-AUTOWIRE-01(Cx3, P2): bootstrap.WithMetricsProvider 不自动为默认 HTTP 中间件构造 `NewProviderCollector`；需设计 WithHTTPCollectorCellID 或 auto-wire (discovered via PR#157 review S4-01) + OBS-LGTM-INTEGRATION-01(Cx3, P2): 添加 `//go:build integration` tag 的夜间 OTel collector 真实 OTLP 协议兼容性测试（grafana/otel-lgtm 或 otel-collector-contrib）; 防止 OTLP protobuf 版本不兼容 (discovered via PR#157 review S6-04) | 7h → 3h |
+| **Outbox 治理** | ~~OUTBOX-GUARD-01~~ ✅ PR#147 + ~~DISCARD-OBS-01~~ ✅ PR#148 + ~~OUTBOX-RECEIPT-01~~ ✅ PR#148 | 4h → 0h |
 | **order-cell 收口** | ✅ ORDER-DEMO-01 PR#136(统一 outbox 路径) + ✅ NIL-PUB-P2 PR#136(Init() fail-fast) + ✅ CheckNotNoop PR#137 | 2h → 0h |
-| **Cursor 全家桶** | #15(cursor 回归矩阵 CURSOR-TEST-01 + CUR-HDL-01: 5 个分页入口补 malformed/missing-scope/cross-context 三类回归, `cells/*/handler_test.go` + `service_test.go`) + WM-6-F6(泛型 cursor helper)/F7(cursor 日志收口)/F1(prod guard) + TX-NIL-01(nil-safe 注释) + ✅ #27e(NOOP-TX-SHARED-01 PR#136: `kernel/persistence.NoopTxRunner`) + ✅ #32 CURSOR-P2-02 PR-R-OBS-B(auditquery cursor decode/scope 失败加 Info 结构化日志，字段 slice/reason/error；对齐 k8s/etcd/MinIO 不记录原串) | 8.5h → 7h |
-| **metadata parser** | META-67-01(strict unknown-field reject) + META-67-02(位置信息错误报告) + META-67-03(cross-file 引用校验) | 2.5h |
+| **Cursor 全家桶** | #15(cursor 回归矩阵 CURSOR-TEST-01 + CUR-HDL-01: 5 个分页入口补 malformed/missing-scope/cross-context 三类回归, `cells/*/handler_test.go` + `service_test.go`) + WM-6-F6(泛型 cursor helper)/F7(cursor 日志收口)/F1(prod guard) + TX-NIL-01(nil-safe 注释) + ✅ #27e(NOOP-TX-SHARED-01 PR#136: `kernel/persistence.NoopTxRunner`) + ✅ #32 CURSOR-P2-02 PR#156(auditquery cursor decode/scope 失败加 Info 结构化日志，字段 slice/reason/error；对齐 k8s/etcd/MinIO 不记录原串) | 8.5h → 6.5h |
+| **metadata parser** | ✅ META-67-01 PR#142 (parser.go KnownFields(true)) + ✅ META-67-03 PR#142 (governance/rules_ref.go REF-01..REF-16) + ✅ META-67-02 PR#152 (two-phase decode + Position{Line,Column} + governance/locator.go + printResult :line:col) + **METADATA-PERF-BENCH-01** (Cx3, P1): `BenchmarkParseFS_500Files` 性能基准 + goccy/go-yaml 单次解码迁移成本评估，对比当前 yaml.v3 双解码（每文件 2 pass）。前置: 构造 500+ MapFS fixture (discovered via PR#152 seat-4) | 2.5h → 4h |
+| **metadata API 收敛** | METADATA-PROJECTLOC-IFACE-01 (Cx3, P2): `ProjectMeta.FileNodes map[string]*yaml.Node` 把 yaml.v3 AST 泄漏到 kernel/governance + cmd。应提取 `ProjectLocator interface { Locate(file, path string) Position }` 或 `pm.Locate(file, path) Position` 方法，隐藏 AST 细节。涉及 kernel/metadata + kernel/governance + cmd/gocell (discovered via PR#152 seat-1) | 3h |
+| **validator 机器输出** | OUTPUT-JSON-SARIF-01 (Cx3, P1): `gocell validate` 缺机器可读输出通道（JSON / SARIF），当前文本 `file:line:col -> field` 格式虽人类友好但不承诺脚本稳定。需统一诊断模型（单一 Issue struct → 多 printer 映射），文本格式声明为非稳定。对标：golangci-lint / staticcheck / ESLint / kubectl print flags / test2json。涉及 cmd/gocell + kernel/governance 序列化 (discovered via PR#152 round-2 review) | 6h |
 | **auth 增强** | WM-2-F2(HMAC replay 防护) + WM-2-F3(auth metrics) + AUTH-SIGNER-01(`SigningKeyProvider` 返回 `crypto.Signer` 替代 `*rsa.PrivateKey`，需自定义 jwt SigningMethod，前置: golang-jwt v6 或 wrapper) + RBAC-LAST-ADMIN-GUARD(service.Revoke 检查剩余 admin 数量，需 `CountByRole` 加入 RoleRepository 接口, `cells/access-core/slices/rbacassign/service.go`) (discovered via PR#143 review 2.3) | 7h |
 | **rbac-assign 治理** | RBAC-REVOKE-POST-01: `DELETE /internal/v1/access/roles/revoke` 改为 `POST` 避免 DELETE body 代理兼容问题（`cells/access-core/slices/rbacassign/handler.go` + `contracts/http/auth/role/revoke/v1/contract.yaml`）(discovered via PR#143 review 6.2) | 1h |
+| **Internal 信任边界** | INTERNAL-LISTENER-01: `/internal/v1/` 路由与公网 API 共用 listener + Bearer JWT 鉴权链，信任边界仅靠路径前缀。应为 internal 路由建独立 listener 或 service-token/mTLS 策略。涉及 `runtime/bootstrap/bootstrap.go` + cell 路由注册拆分 (discovered via PR#143 review F1, Cx4) | 4-8h |
+| **Seed 接口抽象** | SEED-ROLE-IFACE-01: `doSeedAdmin` 依赖 `*mem.RoleRepository` type assertion 调用 `SeedRole()`。应在 `ports.RoleRepository` 新增 `SeedRole(ctx, *Role) error` 方法，或提取独立 `bootstrap.Seeder` 接口。前置: PG-DOMAIN-REPO (discovered via PR#143 review F2, Cx3) | 2h |
 | **auth 测试 DX** | AUTH-SLOG-01(KeySet/servicetoken 注入 slog.Handler 替代全局 `slog.SetDefault`，消除并行测试风险) + AUTH-NOWFUNC-01(`var nowFunc` 包级状态改为实例字段注入) | 3h |
 | **access-core 重构** | P3-TD-11 domain 模型拆分 User/Session/Role（前置: Wave 1 #13 Session TOCTOU ✅ PR#119） | 4h |
 | **集成测试补全** | P4-TD-05(outbox 全链路) + RL-INT-01(Relay PG 集成) + P2-T-02(audit e2e) | 6h |
@@ -125,17 +135,20 @@
 | **PR#133 review C3** | F1-ARCH-03(RTR-HSTS-WIRING-TEST router 层 `WithSecurityHeadersOptions` 接线测试) + F2-SEC-03(TRUST-TRACEPARENT-TEST bootstrap 信任边界测试补 `traceparent` 注入向量) + F3-TEST-01(CONVERTER-NIL-INPUT converter 函数 nil 指针输入测试) + F4-OPS-01(BOOTSTRAP-SECHDR-CONVENIENCE 便利包装) (discovered via PR#133 6-seat review) | 3h |
 | **序列化边界收敛** | EVENT-PAYLOAD-TYPED-01: sessionlogin/sessionlogout/configwrite/configpublish/auditappend/auditverify 事件 payload `map[string]any` → typed event struct (对齐 cell-patterns.md 北极星) (discovered via PR#133 re-review) | 3h |
 | **统一健康注册** | ✅ HEALTH-CONTRIBUTOR-01 PR#135: `kernel/cell.HealthContributor` 接口 + bootstrap 自动发现 + access-core 实现 + 删除 main.go 手工接线 | 3h → 0h |
-| **PoolStats DX** | POOLSTATS-IFACE-01(三个 adapter PoolStats 无公共接口，OTel collector 需 per-adapter switch — 等 OTel 需求明确后设计公共 `TotalConns()/IdleConns()` 子接口) + POOLSTATS-JSON-01(PoolStats struct 缺 `json:"camelCase"` tags — 当前无 JSON 序列化场景，等 `/debug/poolstats` 端点需求时补加, `adapters/postgres/pool.go` + `adapters/redis/client.go` + `adapters/rabbitmq/connection.go`) (discovered via PR#134 review C3-F1, C3-F4) | 1.5h |
+| **PoolStats DX** | POOLSTATS-IFACE-01(三个 adapter PoolStats 无公共接口，OTel collector 需 per-adapter switch — 等 OTel 需求明确后设计公共 `TotalConns()/IdleConns()` 子接口) + ~~POOLSTATS-JSON-01~~ ✅ PR#148(json tags + ConnectionState.MarshalText + roundtrip tests) | 1.5h → 0.5h |
 | **PR#135 review C2-C3** | ✅ BOOTSTRAP-ADAPTERINFO-TEST-01 PR#135 + ✅ VALIDATE-MODE-ALLOWLIST-01 PR#135 + ✅ AUDIT-VERIFY-CAMELCASE-01 PR#135 + ✅ AUDIT-VERIFY-LEVEL-01 PR#135(audit-verify L0→L2: 实际写 outbox+txRunner 是 L2 行为，所有 peer slice 均 L2+；slice level 无运行时强制，仅改善元数据准确性) + ✅ TXRUNNER-FAIL-TEST-01 PR#135 (discovered via PR#135 6-seat review) | 3h → 1h |
-| **Readyz 安全** | READYZ-VERBOSE-TOKEN-01: `/readyz?verbose` 暴露内部拓扑(cell 名、dependency 名)，health.go godoc 已标注风险。当 health 端口公开可达时，需在 ingress 层限制 `?verbose` 或增加 `WithVerboseToken` bootstrap 选项 (pre-existing, confirmed during PR#134 review) | 2h |
+| **Readyz 安全** | ✅ READYZ-VERBOSE-TOKEN-01 PR#151（rebased from #149）: `WithVerboseToken` bootstrap 选项 + `X-Readyz-Token` header + constant-time 比较 + main.go `GOCELL_READYZ_VERBOSE_TOKEN` 接线（real 模式必填） | 2h → 0h |
 | **Bootstrap 发现机制加固** | ✅ AUTH-DISCOVERY-MULTI-PROVIDER-01 PR#135: 多 authProvider cell 发现循环从 first-wins+break 改为全量扫描+冲突 fail-fast | 1h → 0h |
-| **Flaky test** | ✅ SECURECOOKIE-TAMPER-FLAKY-01: 位翻转修复（`encoded[mid]^1`），PR#137 | 0.5h → 0h |
+| **Flaky test** | ✅ SECURECOOKIE-TAMPER-FLAKY-01: 位翻转修复（`encoded[mid]^1`），PR#137 + ✅ RMQ-CONFORMANCE-ISOLATION-01 PR#150（#230）: `TestRabbitMQ_Conformance` 每个 subtest 独立 Connection 隔离（shared conn teardown reconnect 窗口导致下一 subtest `acquire channel` fail-fast），root cause 确认 + `-count=3` 验证 | 0.5h → 0h |
 | **Registry 健壮性** | ✅ REGISTRY-CONSUMERS-UNKNOWN-KIND-01: Consumers() + Provider() 签名改为 `(T, error)`，unknown kind / not found 返回 typed error（`ErrContractNotFound` / `ErrValidationFailed`）。PR#142 | 1.5h → 0h |
-| **快修合集** | #26(.env.example 补 `GOCELL_S3_REGION=us-east-1`, `.env.example`) + ✅ #27(contract CI PR#139) + F-7(BUILD-OUTDIR-01 统一 `go build -o bin/` 输出目录) + #17(Hook 增强 WM17-F2-2 ctx 超时 + WM17-F4-3 Prometheus metrics via HookObserver 接口, `kernel/cell/`) + #18(CB 接口+封装清理 CB-IFACE-01 Allow/Report 拆分 + CB-ENCAP-01 消除 gobreaker import, `runtime/resilience/circuitbreaker/`) + ~~#21(Journey 校验 F-5 catalog 不校验引用)~~ stale: REF-06+REF-07 已覆盖 journey cell/contract 引用校验 | 9h |
+| **快修合集** | #26(.env.example 补 `GOCELL_S3_REGION=us-east-1`, `.env.example`) + ✅ #27(contract CI PR#139) + F-7(BUILD-OUTDIR-01 统一 `go build -o bin/` 输出目录) + ✅ #17 Hook 增强 PR#154(WM17-F2-2 per-hook ctx.WithTimeout + WM17-F4-3 LifecycleHookObserver + Prometheus impl 在 `adapters/prometheus/`) + #18(CB 接口+封装清理 CB-IFACE-01 Allow/Report 拆分 + CB-ENCAP-01 消除 gobreaker import, `runtime/resilience/circuitbreaker/`) + ~~#21(Journey 校验 F-5 catalog 不校验引用)~~ stale: REF-06+REF-07 已覆盖 journey cell/contract 引用校验 + ✅ **GOCELL-VALIDATE-FMT-REDESIGN** PR#152 follow-up: `printResult` 改为 `[CODE] msg (field: X) / at file:line:col` 两行，`at` 行纯净支持 IDE 点击跳转 | 9h → 6h |
 | **CI 供应链加固** | CI-DIGEST-01(testcontainers 镜像 tag+digest 双固定) + CI-LINT-PIN-01(golangci-lint 版本固定到 patch 级 + dependabot 自动升级) (discovered via PR#139 review P2-3) | 2h |
-| **PG 域 Repository** | PG-DOMAIN-REPO: 5 个域 Repository 的 PostgreSQL 实现（User/Session/Role/Device/Command）。当前全部只有 `cells/*/internal/mem/` 内存实现，无持久化——重启后数据丢失。`adapters/postgres/` 已有 outbox_writer/tx_manager/migrator 基础设施可参考 | 3-5d |
+| **PG 域 Repository** | PG-DOMAIN-REPO: 5 个域 Repository 的 PostgreSQL 实现（User/Session/Role/Device/Command）。当前全部只有 `cells/*/internal/mem/` 内存实现，无持久化——重启后数据丢失。`adapters/postgres/` 已有 outbox_writer/tx_manager/migrator 基础设施可参考。**前置准备（可并行）**: ① 4 个 migration DDL（users/sessions/roles/devices+commands，Session version 乐观锁 + Role permissions JSONB 策略）；② `ports.RoleRepository` 补 `CreateRole` 方法（当前缺 Create，seed 路径靠 type assertion）；③ **CONFIG-VERSIONS-MIGRATION-01** (discovered via PR#155 review F4, Cx2): `cells/config-core/internal/adapters/postgres/config_repo.go::PublishVersion` / `GetVersion` 引用 `config_versions(id, config_id, version, value, sensitive, published_at)` 表，但 `adapters/postgres/migrations/` 仅有 outbox 三个 migration，无 `config_entries` / `config_versions` DDL。当前 postgres adapter 仅被 mock 测试覆盖，运行时未接线（`cmd/core-bundle/main.go` 注释 "Storage is always in-memory for now"）。PG-DOMAIN-REPO 落地时必须同时新增 `004_create_config_entries_and_versions.sql`：`config_entries(id, key, value, sensitive boolean not null default false, version, created_at, updated_at)` + `config_versions(id, config_id, version, value, sensitive boolean not null default false, published_at)`，否则切换 postgres 模式即崩。**落地后联动**（必须同 PR 或紧邻 PR 完成，防止元数据/代码漂移）: ① **RBAC-ASSIGN-LEVEL-UPGRADE-01**: `cells/access-core/cell.go:300` `cell.L0` → `cell.L1`（真实事务语义，comment 已标注 "Upgrade to L1 when PostgreSQL adapter is introduced"）；② **SEED-ROLE-IFACE-01**: `doSeedAdmin` 去掉 `*mem.RoleRepository` type assertion（见本表 Seed 接口抽象行）；③ **ACCESS-LEVEL-AUDIT-01**: access-core 其余 slice（sessionlogin/sessionrefresh/sessionlogout/identitymanage）重新审视 L1/L2 声明是否匹配真实事务语义，校正 slice.yaml `consistencyLevel` 与 `AddSlice` 参数；④ **AUTH-CACHE-01 激活**: 原标记为可选（见 Wave 1 SHOULD #28a），PG 落地后升级为必做——真实 DB round-trip 触发 session cache 必要性，需补 Redis short-TTL session cache + 撤销失效路径 | 3-5d |
 | **系统拓扑自省** | SYSTEM-TOPOLOGY-API: `GET /internal/v1/system/topology` 返回 cell/slice/contract 拓扑 JSON。当前前端被迫用 js-yaml 直接读取后端 YAML 文件拼接拓扑图。可基于 `kernel/registry` 现有数据构建 | 4h |
-| **PR#142 review defer** | R2-KERNEL-SLOG-01: generator.go/depcheck.go `_, _ :=` 忽略 Consumers()/Provider() error，kernel/ 无 slog 先例故未加日志。等 kernel/ 引入 slog 时补 `slog.Warn` (discovered via PR#142 6-seat review #2) + R4-ALLOWEDFILES-EMPTY-ID: `AllowedFiles()` 对空 ID 产出 `cells/x/slices//**`（双斜杠），parser 保证 ID 非空故不触发，等 `AllowedFiles()` 被治理规则消费时补 guard (discovered via PR#142 review #4) + R5-FMT15-PATH-ASSERT: FMT-15 测试 mock readFile 不验证 schemaPath 参数，`contractDirFromID` 有独立测试覆盖，低优先级 (discovered via PR#142 review #5) | 1.5h |
+| **PR#142 review defer** | ✅ R2-KERNEL-SLOG-01(generator/depcheck 错误传播 fail-fast) + R4-ALLOWEDFILES-EMPTY-ID(默认推导移除) + R5-FMT15-PATH-ASSERT(schemaPath 断言) + P1#3(allowedFiles 模型统一为 required)。PR#146 | 1.5h → 0h |
+| **PR#155 review CI evidence** | VALIDATE-EVIDENCE-CI-01 (Cx2, P2): PR 提交时缺少 `gocell validate` / `check contract-health` 通过的机器化证据，reviewer 仅能凭 commit message 信任。**处理方案**: ① CI workflow 新增独立 `metadata-check` job（`go run ./cmd/gocell validate` + `check contract-health`），失败阻断 PR；② PR template 增加 "metadata gate" 勾选项；③ 若已有 build-test 覆盖，仅需在该 job 顶部加这两条命令并把输出 upload 为 artifact。**根因**: cell-patterns.md 明确"新增 contracts/ 文件后必须运行 validate"是开发者手动职责，未上 CI gate。开源对比：buf check / openapi-cli 都有独立 lint job (discovered via PR#155 review F7) | 1h |
+| **PR#155 6-seat review followup** | ✅ AUTHZ-WRITE-CONFIG-01 PR#155 (F1, Cx2, P1): publish + rollback handler 增加 `auth.RequireAnyRole(ctx, "admin")` + 401/403/200 测试 + happy-path 测试统一注入 admin 上下文。根因：高风险写端点仅靠全局 JWT 认证，缺角色守卫，违反 K8s/Kratos/go-zero 默认拒绝原则。+ ✅ ERROR-MSG-SCRUB-01 PR#155 (F3, Cx1, P1): postgres adapter 4xx Message 不再泄漏内部 id/version，转用 `errcode.Safe` / `Error{InternalMessage:...}` 二段式（公共 `"config not found"` + 内部 `config repo: GetByKey miss key=...`）。+ ✅ ROLLBACK-NEGPATH-TEST-01 PR#155 (F4, Cx1, P2): rollback 补 `KeyNotFound` / `VersionNotFound` service+handler 测试，断言 errcode 类型 + 响应 body 不含内部前缀。+ ✅ SCHEMA-SENSITIVE-DESC-01 PR#155 (F5, Cx1, P2): publish/v1 + rollback/v1 response.schema.json 增加 description 字段说明 `sensitive=true` 时 `value` 为占位符不可回写。 | 4h → 0h | PR#155 |
+| **PR#157 post-merge 6-seat review followup** | **AUTHZ-WRITE-CONFIG-WRITE-01** (P1, Cx2, 阻塞): `cells/config-core/slices/configwrite/handler.go` create/update/delete 三端点无 `auth.RequireAnyRole(ctx, "admin")`，与 `configpublish` 的 publish/rollback 已有 admin gate 不一致（同一资源域授权策略漂移）。PR#155 只补了 publish/rollback，write 侧遗漏。**修复**: 复用 `configpublish/handler.go` 的 `roleAdmin` const 模式（或提取到 `cells/config-core/internal/dto/authz.go` 共享），三端点入口加 gate + 401/403/200 测试。根因：授权策略分散在端点实现层，缺统一动作模型或中间件级入口。对标 K8s/Kratos/go-zero 统一授权属性。+ **CONFIG-DEMO-FAILOPEN-01** (P1, Cx2, 阻塞): `cells/config-core/slices/configpublish/service.go:188-194` demo 模式 publisher 发布失败仅 `s.logger.Warn` 后 `return nil`，与 cell.yaml 声明 L2 一致性不符（L2 要求 outbox-fact 不丢）。**修复**: durable 模式下去掉 fail-open，统一路径都上抛发布错误；demo fail-open 仅保留在显式 `DiscardPublisher{}` 或 `Assembly.Mode == Demo` 的 assembly。对标 Watermill Forwarder/outbox fail-closed、Temporal 重试策略不吞错。+ **REPO-SCAN-CLASSIFY-01** (P2, Cx2, 高优先): `cells/config-core/internal/adapters/postgres/config_repo.go::GetByKey`(85-96) / `GetVersion`(204-212) 把所有 Scan 错误（含连接断开、驱动异常）映射为 `ErrConfigRepoNotFound`。**修复**: `errors.Is(err, sql.ErrNoRows)` 判 not found，其他错误返回 `ErrInternal` 并保留 `InternalMessage`；PR#155 的 message scrub 不变。+ **CONTRACT-ERROR-SCHEMA-01** (P2, Cx1): `contracts/http/config/publish/v1/contract.yaml` + `contracts/http/config/rollback/v1/contract.yaml` 仅声明 2xx 成功壳，未声明 401/403 错误体 schema（`{"error": {"code", "message", "details"}}`）。**修复**: 在两个 contract.yaml 的 `responses` 新增 401/403 entries 引用共享错误 schema；对齐 `pkg/errcode` 结构 + `error-handling.md` 规范。对标 Kubernetes Status / Kratos 统一错误 / go-zero error contract。discovered via PR#157 post-merge 六席位审查 (2026-04-17) | 6h |
 
 ### 设计决策记录（PR#137 review 确认，不修）
 
@@ -168,6 +181,22 @@
 | 5.3 | `TestContext` 从非 `_test.go` 文件导出 | 不修 | 跨包测试需要（`cells/access-core/` 测试引用 `runtime/auth`）。`_test.go` 中的函数是 package-scoped 无法跨包调用。替代方案 `authtest` 子包增加维护负担但无实质收益 |
 | 6.1 | POST /assign 返回 200 而非 201 | 不修 | 幂等操作返回 200（Casbin 模式：re-assignment is no-op）。contract.yaml 声明 `successStatus: 200` 一致。201 暗示每次创建新资源，不符合幂等语义 |
 
+### 设计决策记录（PR#146 review 确认，不修）
+
+> 以下 1 项在 PR#146 审查中提出，经根因分析后确认为设计正确，记录于此避免重复审查。
+
+| # | Finding | 结论 | 理由 |
+|---|---------|------|------|
+| I2 | computeBoundaryContracts 遍历全量 contracts，无关 assembly 的 unknown-kind 导致生成失败 | 不修 | generator 必须遍历全量 contracts 才能发现 imported contracts（provider 在 assembly 外、consumer 在内）。scope 预过滤需先 resolve provider/consumers，而 resolve 本身是可能失败的操作——形成循环依赖。FMT-09 在 validate 阶段已保证所有 kinds 合法，generator fail-fast 是正确的 defense-in-depth。对标: K8s code-generator 上游标记预过滤但也 fail-fast；go-zero goctl 调用方传已缩减 spec；Kratos Wire 编译期保证图完整 |
+
+### 设计决策记录（PR#155 review 确认，不修）
+
+> 以下 1 项在 PR#155 审查中提出，经根因分析后确认为项目惯例，不修。
+
+| # | Finding | 结论 | 理由 |
+|---|---------|------|------|
+| F6 | `slices/*/slice.yaml` 的 `allowedFiles` 同时列出 kebab 目录（`config-publish/`）和 no-dash 目录（`configpublish/`） | 不修 | 全项目统一惯例：YAML 元数据放 kebab 目录、Go 包目录用 no-dash（CLAUDE.md "Cell 开发规则"），所有 slice 都是双路径。FMT-14 治理规则已守护这种结构，单一化反而违反约定。`gocell scaffold slice` 模板默认产出双路径条目 |
+
 ### 触发条件项（仅在条件满足时做）
 
 | # | 任务 | 工时 | 触发条件 |
@@ -194,7 +223,7 @@
 ## Wave 1 执行顺序（7 批次，每批 3-4 项并行）
 
 > ✅ A(PR#131) → ✅ B(PR#133) → ✅ C(PR#135+136+137) → ✅ D(PR#138) → EF
-> 剩余: EF (SHOULD) + P1 穿插
+> ✅ 全部完成（含 Batch A-EF + P1 穿插）
 
 ### Batch A: ✅ 安全加固 — PR#131
 
@@ -204,7 +233,7 @@
 
 ### Batch D: ✅ 契约完整性 — PR#138
 
-### Batch EF: pkg 加固 + CI + 治理（6 项，~9.5h）
+### Batch EF: ✅ pkg 加固 + CI + 治理 — PR#139+140+142+146
 
 > PR: MG-EF。#28a 降级 Batch 8。
 
@@ -219,7 +248,7 @@
 | 任务 | 工时 | 备注 |
 |------|------|------|
 | #5 AUTH-DX-01 README | 4h | 最后做（反映最终 API 状态）|
-| #6 TPUB-01 TestPubSub | 4h | 无依赖，随时可做 |
+| ✅ #6 TPUB-01 TestPubSub | 4h | PR#141（+PR#144 fix +PR#145 review fix）|
 | ✅ #10 Watcher 核心增强 | 7h | PR#132 |
 | ✅ #11 Watcher 状态面 + 连接池指标 | 4h | PR#132 + PR#134 |
 
@@ -230,24 +259,38 @@
 ```
 已完成:
   Batch 1-5: ✅ PR#67-114 (48 PRs)
-  Wave 1 已合入: PR#116-138 (23 PRs)
+  Wave 1: ✅ 全部完成
     Batch A: ✅ PR#131
     Batch B: ✅ PR#133
     Batch C: ✅ PR#135+136+137
     Batch D: ✅ PR#138
+    Batch EF: ✅ PR#139+140+142+146
     #10+#11: ✅ PR#132+PR#134
+  P1 穿插:
+    #6 TPUB+#31 RMQ: ✅ PR#141 (+PR#144 fix +PR#145 review fix)
+  Post-Wave 3:
+    PR-H1 部分: ✅ PR#143 (H1-2 IDENTITY-AUTHZ + H1-4 ROLE-ASSIGN + H1-5 SEED-ADMIN + H2-3 PATCH-CONTRACT)
+    PR-H1 安全加固: ✅ PR#151 (H1-1 PROD-KEY-FAILFAST + H1-6 READYZ-VERBOSE-TOKEN，rebased from #149)
+  底座加固 Phase 1 部分:
+    PR-K-META: ✅ PR#142(META-67-01+03) + PR#152(META-67-02 file:line:col)
+    PR-K-OUTBOX: ✅ PR#147(META-SIZE-01+OUTBOX-GUARD-01) + PR#148(DISCARD-OBS-01+OUTBOX-RECEIPT-01)
+    PR-K-CELL: ✅ PR#142(#27b SLICE-ALLOWEDFILES-01+CONTRACT-LIST-LINT-01) + PR#154(#17 WM17-F2-2+F4-3) + PR#157(HOOK-OBSERVER-ASYNC-01 hook_dispatcher)
+    PR-R-OBS: ✅ PR#154(OBS-DX-01+OBS-DOC-01) + PR#156(OBS-TABLE-01+CONFORMANCE-SLEEP-01+CURSOR-P2-02) + PR#157(OBS-METRIC-01 provider-neutral metrics + OTEL-COV-01 + OBS-LEAK-02 + OBS-POOLSTATS-WAITCOUNT-01 + OBS-HOOK-DISPATCHER-CFG-01)
+  契约补全:
+    PR-H2: ✅ PR#143(H2-3 IDENTITY-PATCH) + PR#155(H2-1 CONFIG-ROLLBACK + H2-2 CONFIGPUBLISH-REDACT + AUTHZ-WRITE-CONFIG + ERROR-MSG-SCRUB + SCHEMA-SENSITIVE-DESC)
+  CI:
+    PR#153: ✅ integration 与 build-test 并行 + SonarCloud 独立 job + rabbitmq testcontainer 包内共享（wall time ~40% 下降）
 
-Wave 1 MUST 路径: ✅ 全部完成（Batch A-D）
-  Batch EF: ✅ PR#139+140+142
-Wave 1 剩余:
-  SHOULD (Batch EF):   ✅ 全部完成
-  P1 (穿插):           ~8h — #5 README(4h) + #6 TestPubSub(4h)
-  Batch 8 (v1.0 后):   ~66h — 不阻塞发布（含 PG-DOMAIN-REPO 3-5d + SYSTEM-TOPOLOGY-API 4h）
-Post-Wave 3 新增:
-  PR-H1 安全加固:       ~8h（含 ROLE-ASSIGN-API 2h + SEED-ADMIN 1h）
-  PR-FEAT 功能补全:     ~8h（Device List 3h + Flag Write 3h + List Lint 2h）
+剩余:
+  P1 (穿插):           ~4h — #5 README(4h)
+  PR-H1 安全加固:       ✅ 全部完成（H1-1+H1-2+H1-3+H1-4+H1-5+H1-6）
+  PR-H2 契约补全:       ✅ 全部完成（H2-1+H2-2 PR#155 / H2-3 PR#143）
+  PR-FEAT 功能补全:     ~6h — Device List(3h) + Flag Write(3h)（List Lint ✅ PR#142）
+  Wave 2: #28 SOL-B-01(4h) + ~~#32 cursor~~ ✅ PR#156 + #33 WM-35(2d)
+  Wave 3: #34 WM-36(1.5d)
+  Batch 8 (v1.0 后):   ~48h — 不阻塞发布（扣除 PR#154-157 完成项）
 
-关键路径: WM-2-F1 ✅ → WM-35 (2d) → WM-36 (1.5d) → H1+H2+FEAT (3d) → README (0.5d) → Review (2d) = 剩余 9 工作日
+关键路径: WM-35 (2d) → WM-36 (1.5d) → H2(0.5d) → FEAT(1d) → README(0.5d) → Review(2d) = 剩余 ~7 工作日
 ```
 
 ---
@@ -257,23 +300,25 @@ Post-Wave 3 新增:
 > 按 PR 级别组织。所有问题已验证代码现状。
 > 前置: Wave 3 (WM-35 + WM-36) 完成后执行。
 
-### PR-H1: 安全加固（P0+P1，~8h，v1.0 阻塞）
+### PR-H1: 安全加固（P0+P1，~3.5h 剩余，v1.0 阻塞）— H1-2/4/5 ✅ PR#143
 
 | # | 模块 | 问题 | 前置 | 工时 | 文件 | 来源 |
 |---|------|------|------|------|------|------|
-| H1-1 | cmd/core-bundle | **PROD-KEY-FAILFAST** P0: `loadKeySet` dev 模式用 `MustGenerateTestKeyPair` 生成临时密钥，`validateAdapterMode` 已拒绝 `real` 但未拒绝空值——空值走 dev 分支。生产误配时密钥可预测、重启后 token 失效。需拆分 dev/prod 启动路径，生产缺密钥直接 fail-fast | Wave 3 | 2h | `cmd/core-bundle/main.go` | PR#137-138 集成审查 P0 |
-| H1-2 | cells/access-core | **IDENTITY-AUTHZ-01** P1: identitymanage handler（lock/unlock/PATCH/DELETE）仅鉴权无授权，任何有效 token 可执行管理操作。需加 `RequireRole("admin")` 或 `RequireSelfOrRole` | Wave 3 | 1.5h | `cells/access-core/slices/identitymanage/handler.go` | PR#137-138 集成审查 P1 |
-| H1-3 | kernel/cell | **DURABLE-NIL-GUARD** P1: `CheckNotNoop` 只拒绝 Nooper 标记类型，不拒绝 nil——DurabilityDurable 下 nil 依赖可旁路，L2 cell 仍可以 demo 语义运行。需在 L2 cell Init() 增加 durable+nil 必填校验 | Wave 3 | 1.5h | `kernel/cell/durability.go` + 5 个 `cell.go` | PR#137-138 集成审查 P1 |
-| H1-4 | cells/access-core | **ROLE-ASSIGN-API** P1: `AssignToUser` 仅存在 repo 层接口（`ports/role_repo.go:13`）和 mem 实现（`mem/role_repo.go:71`），无 HTTP handler 暴露。新建 `rbacassign` slice：`POST /internal/v1/roles/assign` + `DELETE /internal/v1/roles/revoke`，仅 `RequireRole("admin")` 可调用。**必须与 H1-2 同 PR**——否则 H1-2 加了 `RequireRole("admin")` 后无法分配角色，形成死锁 | Wave 3 | 2h | `cells/access-core/slices/rbacassign/` + `contracts/http/auth/role/assign/v1/` | backend_issues.md #3 |
-| H1-5 | cmd/core-bundle | **SEED-ADMIN** P1: 启动时检测 admin 角色不存在则自动创建 seed admin（用户名/密码来自环境变量 `GOCELL_ADMIN_USER` / `GOCELL_ADMIN_PASS`，无环境变量则跳过）。打破"先有鸡还是先有蛋"死锁，H1-2 + H1-4 的前提 | Wave 3 | 1h | `cmd/core-bundle/main.go` + `cells/access-core/internal/mem/` | backend_issues.md #3 |
+| H1-1 | cmd/core-bundle | ✅ **PROD-KEY-FAILFAST** P0: `loadKeySet` 改为先尝试 env key，real 模式下 fail-fast；`validateAdapterMode` 接受 `real`；`loadSecret` 取代 `envOrDefault` 并在 real 模式必填。PR#151（rebased from #149） | Wave 3 | 2h | `cmd/core-bundle/main.go` | PR#137-138 集成审查 P0 | PR#151（rebased from #149） |
+| H1-2 | cells/access-core | ✅ **IDENTITY-AUTHZ-01** P1: identitymanage handler 7 端点授权守护（create/delete/lock/unlock → admin-only; get/update/patch → self-or-admin）+ `RequireAnyRole` auth helper | Wave 3 | 1.5h | `cells/access-core/slices/identitymanage/handler.go` | PR#137-138 集成审查 P1 | PR#143 |
+| H1-3 | kernel/cell | ✅ **DURABLE-NIL-GUARD** P1: 5 个 L2 cell（access-core/audit-core/config-core/order-cell/device-cell）Init() 全部含显式 nil XOR guard + `CheckNotNoop` 拒绝 Nooper，durable+nil 旁路闭合。kernel 层 `CheckNotNoop` 文档明确 "nil checks belong in the caller"，caller 职责已履行 | Wave 3 | 完成于 PR#135/#136/#137（L2-HARD-GATE + BOOTSTRAP-STRICT-MODE + guard hardening） | `cells/*/cell.go` | PR#137-138 集成审查 P1 |
+| H1-6 | runtime/http/health + cmd/core-bundle | ✅ **READYZ-VERBOSE-TOKEN** P1: `WithVerboseToken` 选项 + constant-time token 比较 + `X-Readyz-Token` header 守卫 + main.go 接线 `GOCELL_READYZ_VERBOSE_TOKEN`（real 模式必填）PR#151（rebased from #149） | Wave 3 | 2.5h | `runtime/http/health/health.go` + `runtime/bootstrap/bootstrap.go` + `cmd/core-bundle/main.go` | PR#134 review + PR#149 review round 2 | PR#151（rebased from #149） |
+| H1-7 | cells/access-core | **RBAC-OUTBOX-MIGRATION** P2: `rbacassign.Service` 当前是"角色变更 → 会话失效"双写（partial-commit 窗口在错误日志中可观测）。迁移到 transactional outbox 模式：角色变更 + `role.assigned.v1` / `role.revoked.v1` 事件原子写入，consumer 异步失效 session。ref: Watermill outbox pattern | H1-8 outbox consumer 基础设施 | 6h | `cells/access-core/slices/rbacassign/service.go` + `cells/access-core/slices/sessionlogout/consumer.go`（新）+ contract event schemas | PR#149 review round 2 |
+| H1-4 | cells/access-core | ✅ **ROLE-ASSIGN-API** P1: `rbacassign` slice — `POST /internal/v1/access/roles/assign` + `DELETE /internal/v1/access/roles/revoke`（admin-only, L0, idempotent）+ contracts | Wave 3 | 2h | `cells/access-core/slices/rbacassign/` + `contracts/http/auth/role/assign/v1/` | backend_issues.md #3 | PR#143 |
+| H1-5 | cmd/core-bundle | ✅ **SEED-ADMIN** P1: `WithSeedAdmin(user, pass)` / `WithSeedAdminRole()` bootstrap options，从 `GOCELL_ADMIN_USER`/`GOCELL_ADMIN_PASS` 环境变量读取 | Wave 3 | 1h | `cmd/core-bundle/main.go` + `cells/access-core/internal/mem/` | backend_issues.md #3 | PR#143 |
 
-### PR-H2: 契约补全（P1，~2h，v1.0 前建议）
+### PR-H2: 契约补全（P1，✅ 全部完成）— H2-1+H2-2 ✅ PR#155 / H2-3 ✅ PR#143
 
 | # | 模块 | 问题 | 前置 | 工时 | 文件 | 来源 |
 |---|------|------|------|------|------|------|
-| H2-1 | contracts/config-core | **CONFIG-ROLLBACK-CONTRACT** P1: `cell.go:214` 注册了 `POST /{key}/rollback` 路由，有 handler_test 覆盖，但无 HTTP contract + schema + contract_test。路由暴露但契约体系无定义，变更无法被自动拦截 | PR-H1 | 1.5h | `contracts/http/config/rollback/v1/` + `cells/config-core/slices/configpublish/contract_test.go` + `slice.yaml` | PR#137-138 集成审查 P1 |
-| H2-2 | contracts/config-core | **CONFIGPUBLISH-REDACT-01** P1: publish 响应 schema required `value` 明文字段，未复用 configwrite 的 `RedactedValue` 脱敏逻辑。和 H2-1 同改 configpublish | 无 | 0.5h | `cells/config-core/slices/configpublish/handler.go` + `contracts/http/config/publish/v1/response.schema.json` | PR#138 review + 集成审查 |
-| H2-3 | contracts/access-core | **IDENTITY-PATCH-CONTRACT** P2: identitymanage PATCH 无 contract schema（#27s 遗漏），未知字段策略未在 schema 层声明。补 request/response schema + contract_test | 无 | 1h | `contracts/http/auth/identity/patch/v1/` + `cells/access-core/slices/identitymanage/contract_test.go` | PR#138 review P2 |
+| H2-1 | contracts/config-core | ✅ **CONFIG-ROLLBACK-CONTRACT** P1: `cell.go:214` 注册了 `POST /{key}/rollback` 路由，有 handler_test 覆盖，但无 HTTP contract + schema + contract_test。路由暴露但契约体系无定义，变更无法被自动拦截。PR#155 | PR-H1 | 1.5h | `contracts/http/config/rollback/v1/` + `cells/config-core/slices/configpublish/contract_test.go` + `slice.yaml` | PR#137-138 集成审查 P1 | PR#155 |
+| H2-2 | contracts/config-core | ✅ **CONFIGPUBLISH-REDACT-01** P1: publish 响应 schema required `value` 明文字段，未复用 configwrite 的 `RedactedValue` 脱敏逻辑。同改 ConfigVersion.Sensitive 字段 + DTO redaction + Rollback 也复用 snapshot 的 Sensitive flag（PR#155 review F1）。PR#155 | 无 | 0.5h | `cells/config-core/internal/domain/version.go` + `cells/config-core/slices/configpublish/handler.go` + `service.go` + `contracts/http/config/publish/v1/response.schema.json` | PR#138 review + 集成审查 | PR#155 |
+| H2-3 | contracts/access-core | ✅ **IDENTITY-PATCH-CONTRACT** P2: identitymanage PATCH request schema validation + contract_test | 无 | 1h | `contracts/http/auth/identity/patch/v1/` + `cells/access-core/slices/identitymanage/contract_test.go` | PR#138 review P2 | PR#143 |
 
 > H2-1 和 H2-2 同改 configpublish slice，一个 PR。
 
@@ -287,7 +332,7 @@ Post-Wave 3 新增:
 | FEAT-2 | cells/config-core | **FLAG-WRITE-API** P1: config-core feature flag 仅有 GET + Evaluate，无写入能力。管理界面 feature flag 开关不可操作。新增 `PUT /api/v1/config/flags/{key}` 写入端点 + contract + contract_test | PR-H2 | 3h | `cells/config-core/slices/configwrite/` + `contracts/http/config/flags/write/v1/` | backend_issues.md #2 |
 | FEAT-3 | kernel/governance | **CONTRACT-LIST-LINT-01** `gocell check contract-health` 增加 list 响应格式检查：response schema 含 `data: array` 时必须同时包含 `nextCursor` + `hasMore`（对齐 `api-versioning.md` 规定的 `{"data": [...], "nextCursor": "...", "hasMore": bool}` 格式）。与 FEAT-1 搭车——lint 规则上线时立即守护新 list 端点 | 无 | 2h | `kernel/governance/` | PR#138 review P1-3 + PR#141 review |
 
-### PR-EF: pkg 加固 + CI + 治理（SHOULD，~8.5h，v1.0 前建议）
+### PR-EF: ✅ pkg 加固 + CI + 治理 — PR#139+140+142
 
 | # | 模块 | 问题 | 前置 | 工时 | 文件 | 来源 |
 |---|------|------|------|------|------|------|
@@ -301,11 +346,11 @@ Post-Wave 3 新增:
 |---|------|------|------|------|------|------|
 | R-1 | docs | **#5 AUTH-DX-01** README + seed 用户 + sso-bff walkthrough | PR-H1（反映最终 API） | 4h | `README.md` + `examples/sso-bff/README.md` | 6B + P4 review |
 
-### PR-TPUB: 独立穿插（P1，~4h，随时可做）
+### PR-TPUB: ✅ 已完成 — PR#141 (+PR#144 fix +PR#145 review fix)
 
 | # | 模块 | 问题 | 前置 | 工时 | 文件 | 来源 |
 |---|------|------|------|------|------|------|
-| T-1 | kernel/outbox | **#6 TPUB-01** TestPubSub 真实 adapter 认证 | 无 | 4h | `kernel/outbox/outboxtest/` + `adapters/rabbitmq/` | 6B |
+| T-1 | kernel/outbox | ✅ **#6 TPUB-01** TestPubSub conformance harness + RabbitMQ conformance + backoff 统一 + ClaimPolicy enum | 无 | 4h | `kernel/outbox/outboxtest/` + `adapters/rabbitmq/` | 6B | PR#141 |
 
 ### 执行顺序
 
@@ -314,11 +359,8 @@ Wave 2 (WM-35 BFF handler, 2d)
      ↓
 Wave 3 (WM-36 SecureCookie, 1.5d)
      ↓
-  PR-H1 安全加固 (P0+P1, 含 ROLE-ASSIGN + SEED-ADMIN, 阻塞 v1.0)  ─┐
-  PR-TPUB (#6, 独立并行)                                             ─┤ 并行
-  PR-EF pkg+CI+治理 (SHOULD, 独立并行)                                ─┘
-       ↓
-  PR-H2 契约补全 (依赖 H1)
+  PR-H1 安全加固 (P0+P1, H1-1+H1-3 剩余, 阻塞 v1.0)  ─┐
+  PR-H2 契约补全 (H2-1+H2-2 剩余, 依赖 H1)             ─┘ 可串行一个 PR
        ↓
   PR-FEAT 功能补全 (Device List + Flag Write, 依赖 H2)
        ↓

--- a/docs/plans/20260416-foundation-first-plan.md
+++ b/docs/plans/20260416-foundation-first-plan.md
@@ -17,20 +17,18 @@
 
 ---
 
-## Phase 0: 正确性守护（~8h，立即做）
+## Phase 0: ✅ 全部完成（PR#143+PR#151）
 
 > 不论是否赶发布，这些是 bug 不是 feature。
 
-| PR | 任务 | 层 | 工时 | 涉及文件 | 来源 |
-|----|------|----|------|----------|------|
-| **PR-SAFE** | H1-1 PROD-KEY-FAILFAST (P0): `loadKeySet` 空值走 dev 分支，生产密钥可预测 | cmd/core-bundle | 2h | `cmd/core-bundle/main.go` | PR#137-138 集成审查 P0 |
-| | H1-3 DURABLE-NIL-GUARD (P1): `CheckNotNoop` 对 nil `continue` 跳过，durable+nil 旁路 | kernel/cell | 1.5h | `kernel/cell/durability.go` + 5 个 `cell.go` | PR#137-138 集成审查 P1 |
-| | READYZ-VERBOSE-TOKEN-01: `/readyz?verbose` 匿名暴露内部拓扑 | runtime/http | 2h | `runtime/http/health/health.go` + `runtime/bootstrap/bootstrap.go` | PR#134 review |
-| **PR-AUTHZ** | H1-2 IDENTITY-AUTHZ-01: identitymanage 7 端点仅鉴权无授权 | cells/access-core | 1.5h | `cells/access-core/slices/identitymanage/handler.go` | PR#137-138 集成审查 P1 |
-| | H1-4 ROLE-ASSIGN-API: `POST /internal/v1/roles/assign` + `DELETE /internal/v1/roles/revoke` | cells/access-core | 2h | `cells/access-core/slices/rbacassign/` | backend_issues.md #3 |
-| | H1-5 SEED-ADMIN: 启动时 seed admin（环境变量驱动） | cmd/core-bundle | 1h | `cmd/core-bundle/main.go` + `cells/access-core/internal/mem/` | backend_issues.md #3 |
-
-> PR-SAFE 与 PR-AUTHZ 可并行。H1-2/H1-4/H1-5 必须同 PR（避免加了授权但无法分配角色的死锁）。
+| PR | 任务 | 层 | 工时 | 涉及文件 | 合并 PR |
+|----|------|----|------|----------|---------|
+| **PR-SAFE** | ✅ H1-1 PROD-KEY-FAILFAST (P0) | cmd/core-bundle | 2h | `cmd/core-bundle/main.go` | PR#151（rebased from #149） |
+| | ✅ H1-3 DURABLE-NIL-GUARD (P1): 5 个 L2 cell Init() 显式 nil XOR guard + `CheckNotNoop`（caller 职责已履行） | cells/\* | 1.5h | `cells/access-core/cell.go` + `audit-core/cell.go` + `config-core/cell.go` + `order-cell/cell.go` + `device-cell/cell.go` | PR#135/#136/#137 |
+| | ✅ H1-6 READYZ-VERBOSE-TOKEN-01 | runtime/http | 2h | `runtime/http/health/health.go` + `runtime/bootstrap/bootstrap.go` + `cmd/core-bundle/main.go` | PR#151 |
+| **PR-AUTHZ** | ✅ H1-2 IDENTITY-AUTHZ-01 | cells/access-core | 1.5h | `cells/access-core/slices/identitymanage/handler.go` | PR#143 |
+| | ✅ H1-4 ROLE-ASSIGN-API | cells/access-core | 2h | `cells/access-core/slices/rbacassign/` | PR#143 |
+| | ✅ H1-5 SEED-ADMIN | cmd/core-bundle | 1h | `cmd/core-bundle/main.go` + `cells/access-core/internal/mem/` | PR#143 |
 
 ---
 
@@ -38,33 +36,35 @@
 
 > kernel 是底座灵魂。先修内核，上层才有意义。
 
-### PR-K-OUTBOX: outbox 治理 + 可观测（5h）
+### PR-K-OUTBOX: ✅ 全部完成（PR#147+PR#148）
 
-| 任务 | 工时 | 涉及文件 | 来源 |
-|------|------|----------|------|
-| OUTBOX-GUARD-01: NoopWriter/DiscardPublisher lint 约束（go vet 或 golangci-lint 自定义规则） | 2h | `kernel/outbox/` | 6B review |
-| DISCARD-OBS-01: DiscardPublisher Logger 注入 + counter（可观测静默丢弃量） | 1h | `kernel/outbox/outbox.go` | 6B review |
-| OUTBOX-RECEIPT-01: `outbox.Receipt` alias 全仓迁移 `idempotency.Receipt` | 1h | `kernel/outbox/` + `kernel/idempotency/` | 6B review |
-| META-SIZE-01: Metadata key 数量和大小上限，防 OOM | 1h | `kernel/outbox/outbox.go` | 6A review |
+| 任务 | 工时 | 涉及文件 | 来源 | 合并 PR |
+|------|------|----------|------|---------|
+| ✅ OUTBOX-GUARD-01 | 2h | `kernel/outbox/` | 6B review | PR#147 |
+| ✅ DISCARD-OBS-01 | 1h | `kernel/outbox/outbox.go` | 6B review | PR#148 |
+| ✅ OUTBOX-RECEIPT-01 | 1h | `kernel/outbox/` + `kernel/idempotency/` | 6B review | PR#148 |
+| ✅ META-SIZE-01 | 1h | `kernel/outbox/outbox.go` | 6A review | PR#147 |
 
-### PR-K-META: metadata parser + registry 健壮性（4h）
+### PR-K-META: ✅ 全部完成（PR#142+PR#152）
 
-| 任务 | 工时 | 涉及文件 | 来源 |
-|------|------|----------|------|
-| META-67-01: strict unknown-field reject | 1h | `kernel/metadata/parser.go` | PR#67 review |
-| META-67-02: 位置信息错误报告 | 1h | `kernel/metadata/parser.go` | PR#67 review |
-| META-67-03: cross-file 引用校验 | 0.5h | `kernel/metadata/parser.go` | PR#67 review |
-| REGISTRY-CONSUMERS-UNKNOWN-KIND-01: `Consumers()` allowlist + error return | 1.5h | `kernel/registry/contract.go` | PR#135 review |
+| 任务 | 工时 | 涉及文件 | 来源 | 合并 PR |
+|------|------|----------|------|---------|
+| ✅ META-67-01: strict unknown-field reject | 1h | `kernel/metadata/parser.go` | PR#67 review | PR#142 |
+| ✅ META-67-02: 位置信息错误报告（Position{Line,Column} + locator.go + printResult file:line:col） | 1h | `kernel/metadata/parser.go` + `kernel/metadata/location.go` + `kernel/governance/` + `cmd/gocell/` | PR#67 review | PR#152 |
+| ✅ META-67-03: cross-file 引用校验（REF-01..REF-16） | 0.5h | `kernel/governance/rules_ref.go` | PR#67 review | PR#142 |
+| ✅ REGISTRY-CONSUMERS-UNKNOWN-KIND-01: `Consumers()` + `Provider()` typed error | 1.5h | `kernel/registry/contract.go` | PR#135 review | PR#142 |
 
-### PR-K-CELL: cell 元数据 + hook + 治理工具（8h）
+> PR#152 衍生 follow-up（Batch 8 下沉）: METADATA-PROJECTLOC-IFACE-01（yaml.v3 AST 泄漏）+ OUTPUT-JSON-SARIF-01（诊断机器输出）+ METADATA-PERF-BENCH-01（500 文件基准）
 
-| 任务 | 工时 | 涉及文件 | 来源 |
-|------|------|----------|------|
-| #27b SLICE-ALLOWEDFILES-01: `BaseSlice.AllowedFiles()` 默认逻辑修复（kebab-case vs no-dash） | 2h | `kernel/cell/base.go` + all `slice.yaml` | PR#119 review |
-| #17 WM17-F2-2: Hook ctx 超时 | 1.5h | `kernel/cell/` | WM-17 |
-| #17 WM17-F4-3: Prometheus metrics via HookObserver 接口 | 1.5h | `kernel/cell/` | WM-17 |
-| #21 F-5: Journey catalog 不校验引用 | 1h | `kernel/journey/catalog.go` | 6B |
-| CONTRACT-LIST-LINT-01: `gocell check contract-health` list 响应格式检查 | 2h | `kernel/governance/` | PR#138 review |
+### PR-K-CELL: 部分完成（#27b PR#142 + #17 Hook 增强 PR#154）
+
+| 任务 | 工时 | 涉及文件 | 来源 | 合并 PR |
+|------|------|----------|------|---------|
+| ✅ #27b SLICE-ALLOWEDFILES-01 | 2h | `kernel/cell/base.go` + all `slice.yaml` | PR#119 review | PR#142 |
+| ✅ #17 WM17-F2-2: Hook ctx 超时（per-hook `ctx.WithTimeout`, default 30s, soft-cancel 对标 fx） | 1.5h | `kernel/cell/observer.go` + `kernel/assembly/assembly.go` + `runtime/bootstrap/` | WM-17 | PR#154 |
+| ✅ #17 WM17-F4-3: LifecycleHookObserver + Prometheus 实现（counter+histogram，isolated registry）| 1.5h | `kernel/cell/observer.go` + `adapters/prometheus/hook_observer.go` + `cmd/core-bundle/main.go` | WM-17 | PR#154 |
+| #21 F-5: Journey catalog 不校验引用 — **stale**: REF-06+REF-07 已覆盖 journey cell/contract 引用校验，此项关闭 | — | — | 6B | — |
+| ✅ CONTRACT-LIST-LINT-01: `gocell check contract-health` list 响应格式检查 | 2h | `kernel/governance/` | PR#138 review | PR#142 |
 
 ---
 
@@ -89,17 +89,22 @@
 | WM-2-F2: HMAC replay 防护 | 2h | `runtime/auth/` | WM-2 |
 | WM-2-F3: auth metrics (token verify latency/failure count) | 2h | `runtime/auth/` | WM-2 |
 
-### PR-R-OBS: 可观测性补全（4.5h）
+### PR-R-OBS: ✅ 全部完成（PR#154+PR#156+PR#157，剩余 OB-02 下沉 Batch 8）
 
-| 任务 | 工时 | 涉及文件 | 来源 |
-|------|------|----------|------|
-| OBS-TABLE-01: observability bridge table-driven 改写 | 1.5h | `runtime/http/middleware/` | 6A review |
-| OBS-METRIC-01: bridge counter/histogram 补全 | 1.5h | `runtime/http/middleware/` | 6A review |
-| OBS-DX-01: cloneMetadata 导出 + wrapper 清理 + godoc | 1h | `kernel/outbox/` | 6A review |
-| OBS-DOC-01: IsReservedMetadataKey usage example | 0.5h | `kernel/outbox/` | 6A review |
-| OB-02: safe_observe broken logger 注入测试 | 1h | `runtime/http/middleware/safe_observe_test.go` | 历史 backlog 0-J |
+| 任务 | 工时 | 涉及文件 | 来源 | 合并 PR |
+|------|------|----------|------|---------|
+| ✅ OBS-TABLE-01: observability bridge table-driven 改写 | 1.5h | `runtime/http/middleware/` | 6A review | PR#156 |
+| ✅ OBS-METRIC-01: provider-neutral `kernel/observability/metrics.Provider` + prom/otel adapter + HTTP/Relay collector 迁移 + `bootstrap.WithMetricsProvider` | 1.5h | `kernel/observability/metrics/` + `runtime/observability/metrics/` + `runtime/bootstrap/` | 6A review | PR#157 |
+| ✅ OBS-DX-01: CloneMetadata 导出 + godoc | 1h | `kernel/outbox/observability_metadata.go` | 6A review | PR#154 |
+| ✅ OBS-DOC-01: ExampleIsReservedMetadataKey testable example | 0.5h | `kernel/outbox/observability_metadata.go` | 6A review | PR#154 |
+| ✅ CONFORMANCE-SLEEP-01: conformance.go `time.Sleep(200ms)` → deterministic negative assertion | — | `kernel/outbox/outboxtest/conformance.go` | PR#145 review | PR#156 |
+| ✅ HOOK-OBSERVER-ASYNC-01: 异步 hook dispatcher（有界队列 + per-sink timeout + drop counter + goleak + failed-start cleanup） | — | `kernel/assembly/hook_dispatcher.go` | WM-17 follow-up | PR#157 |
+| ✅ OBS-LEAK-02: `newTestAssembly(t, cfg)` helper + 51 sites 迁移，移除 goleak allowlist | — | `kernel/assembly/test_helpers_test.go` | PR#157 review | PR#157 |
+| ✅ OBS-POOLSTATS-WAITCOUNT-01: `db.client.connection.timeouts` ObservableCounter | — | `runtime/observability/poolstats/statter.go` | PR#157 review | PR#157 |
+| ✅ OBS-HOOK-DISPATCHER-CFG-01: `dispatcherConfig{}` 替代位置参数 | — | `kernel/assembly/hook_dispatcher.go` | PR#157 review | PR#157 |
+| OB-02: safe_observe broken logger 注入测试（下沉 Batch 8） | 1h | `runtime/http/middleware/safe_observe_test.go` | 历史 backlog 0-J | — |
 
-> 注: OBS-DX-01/OBS-DOC-01 虽属 kernel/outbox，但与 OBS-TABLE/METRIC 同属可观测主题，合并一个 PR 减少 review 负担。
+> PR#157 衍生 follow-up（Batch 8 下沉）: OBS-RELAY-REGISTER-ATOMIC-01（Provider.Unregister 契约） + OBS-HTTP-COLLECTOR-AUTOWIRE-01（bootstrap auto-wire 默认 HTTP collector） + OBS-LGTM-INTEGRATION-01（夜间 OTLP 兼容性测试）
 
 ### PR-R-CFG: 配置治理 + 测试补全（2h）
 
@@ -145,14 +150,14 @@
 
 > 前置: Phase 1 PR-K-OUTBOX（outbox 治理改造完成后再做集成测试）。
 
-### PR-A-INTEG: 集成测试补全（9.5h）
+### PR-A-INTEG: 集成测试补全（剩余 ~4h，TPUB + OTEL-COV ✅ 已完成）
 
-| 任务 | 工时 | 涉及文件 | 来源 |
-|------|------|----------|------|
-| #6 TPUB-01: TestPubSub conformance 替换 sleep + 接入 RabbitMQ adapter | 4h | `kernel/outbox/outboxtest/` + `adapters/rabbitmq/` | 6B |
-| P4-TD-05: outbox 全链路 3-container 集成测试（PG+RMQ+app） | 2h | `adapters/postgres/` + `adapters/rabbitmq/` | Phase 4 review |
-| RL-INT-01: Relay PG 集成测试 | 2h | `adapters/postgres/outbox_relay_test.go` | PR#46 review |
-| OTEL-COV-01: OTel testcontainers 集成测试 | 1.5h | `adapters/otel/` | 6A review |
+| 任务 | 工时 | 涉及文件 | 来源 | 合并 PR |
+|------|------|----------|------|---------|
+| ✅ #6 TPUB-01: TestPubSub conformance 替换 sleep + 接入 RabbitMQ adapter | 4h | `kernel/outbox/outboxtest/` + `adapters/rabbitmq/` | 6B | PR#141 |
+| P4-TD-05: outbox 全链路 3-container 集成测试（PG+RMQ+app） | 2h | `adapters/postgres/` + `adapters/rabbitmq/` | Phase 4 review | — |
+| RL-INT-01: Relay PG 集成测试 | 2h | `adapters/postgres/outbox_relay_test.go` | PR#46 review | — |
+| ✅ OTEL-COV-01: OTel testcontainers 集成测试（ManualReader + tracetest.InMemoryExporter） | 1.5h | `adapters/otel/` | 6A review | PR#157 |
 
 ### PR-A-HARDEN: 生产安全加固（6.5h）
 
@@ -170,6 +175,8 @@
 |------|------|----------|------|
 | CI-DIGEST-01: testcontainers 镜像 tag+digest 双固定 | 1h | `adapters/*/integration_test.go` | PR#139 review |
 | CI-LINT-PIN-01: golangci-lint patch 级固定 + dependabot 升级 | 1h | `.github/workflows/ci.yml` | PR#139 review |
+
+> 关联（已完成）: **PR#153 CI wall-time 优化** — integration 与 build-test 并行 + SonarCloud 拆为独立 job + rabbitmq testcontainer 在 `adapters/rabbitmq` 包内共享（`TestMain` + `sync.Once`，需隔离连接的测试仍走 `startRabbitMQWithContainer`）。实测 wall time 从 ~280s 降到 ~170s（-40%），不含覆盖率稀释（kernel coverage gate 保留独立 run）。
 
 ---
 
@@ -190,13 +197,15 @@
 | AL-01: outbox_relay.go 轮询调度逻辑拆到 `runtime/outbox/relay.go` | 2h | `adapters/postgres/outbox_relay.go` → `runtime/outbox/relay.go` | 依赖替换分析 |
 | AL-02: distlock.go 续期/TTL 策略拆到 `runtime/` | 2h | `adapters/redis/distlock.go` → `runtime/` | 依赖替换分析 |
 
-### PR-CONTRACT: 契约缺口补全（3h）
+### PR-CONTRACT: ✅ 全部完成（PR#143+PR#155）
 
-| 任务 | 工时 | 涉及文件 | 来源 |
-|------|------|----------|------|
-| H2-1 CONFIG-ROLLBACK-CONTRACT | 1.5h | `contracts/http/config/rollback/v1/` | PR#137-138 集成审查 |
-| H2-2 CONFIGPUBLISH-REDACT-01 | 0.5h | `cells/config-core/slices/configpublish/handler.go` | PR#138 review |
-| H2-3 IDENTITY-PATCH-CONTRACT + H2-4~H2-7 config/identity 列表契约 | 1h | `contracts/http/` 多目录 | 代码验证发现 |
+| 任务 | 工时 | 涉及文件 | 来源 | 合并 PR |
+|------|------|----------|------|---------|
+| ✅ H2-1 CONFIG-ROLLBACK-CONTRACT | 1.5h | `contracts/http/config/rollback/v1/` | PR#137-138 集成审查 | PR#155 |
+| ✅ H2-2 CONFIGPUBLISH-REDACT-01 | 0.5h | `cells/config-core/slices/configpublish/handler.go` + `service.go` + `contracts/http/config/publish/v1/response.schema.json` | PR#138 review | PR#155 |
+| ✅ H2-3 IDENTITY-PATCH-CONTRACT | 1h | `contracts/http/auth/identity/patch/v1/` + `cells/access-core/slices/identitymanage/contract_test.go` | 代码验证发现 | PR#143 |
+
+> PR#155 搭车完成 review followup: AUTHZ-WRITE-CONFIG-01（publish/rollback admin gate）+ ERROR-MSG-SCRUB-01（repo 4xx Message 去 id/version 内部细节，`errcode.Safe` 二段式）+ ROLLBACK-NEGPATH-TEST-01 + SCHEMA-SENSITIVE-DESC-01
 
 ---
 
@@ -246,40 +255,49 @@
 ## 执行总览
 
 ```
-Phase 0  正确性守护     ~8h    ← 立即做，不可跳过
-  PR-SAFE (5.5h) ─┐
-  PR-AUTHZ (4.5h) ┘ 并行
+Phase 0  正确性守护     ✅ 全部完成
+  PR-SAFE (5.5h)    ✅ H1-1 + H1-6 PR#151；H1-3 ✅（5 个 L2 cell Init() nil XOR guard + CheckNotNoop，PR#135/#136/#137）
+  PR-AUTHZ (4.5h)   ✅ H1-2 + H1-4 + H1-5 PR#143
     ↓
-Phase 1  kernel 加固    ~17h   ┐
-  PR-K-OUTBOX (5h)             │
-  PR-K-META (4h)               │
-  PR-K-CELL (8h)               │
-                               ├ 三层并行推进（层内各 PR 也可并行）
-Phase 2  runtime 优化   ~17.5h │
+Phase 1  kernel 加固    ~4h 剩余（原 17h）
+  PR-K-OUTBOX (5h)    ✅ 全部完成 PR#147+PR#148
+  PR-K-META (4h)      ✅ 全部完成 PR#142+PR#152
+  PR-K-CELL (8h)      ✅ #27b + #17 Hook 增强 + CONTRACT-LIST-LINT PR#142+PR#154；剩余 #21 F-5 已关闭（stale）→ 本 phase 无剩余
+                               ┐
+Phase 2  runtime 优化   ~14h 剩余（原 17.5h）
   PR-R-ROUTER (4h)             │
   PR-R-AUTH (7h)               │
-  PR-R-OBS (4.5h)             │
-  PR-R-CFG (2h)                │
+  PR-R-OBS   ✅ 全部完成 PR#154+PR#156+PR#157（OB-02 下沉 Batch 8）
+  PR-R-CFG (2h)                ├ 三层并行推进
                                │
-Phase 3  pkg + 工具链   ~10h   ┘
-  PR-P-CURSOR (5.5h)
-  PR-P-CB (2h)
-  PR-CMD (4h)
+Phase 3  pkg + 工具链   ~9h 剩余（原 10h）
+  PR-P-CURSOR (4.5h)    ← CURSOR-P2-02 ✅ PR#156 扣除
+  PR-P-CB (2h)                 │
+  PR-CMD (4h)                  ┘
     ↓
-Phase 4  adapter 加固   ~16h   ← 依赖 Phase 1 outbox 改造
-  PR-A-INTEG (9.5h)
+Phase 4  adapter 加固   ~10h 剩余（原 16h）  ← 依赖 Phase 1 outbox（已完成）
+  PR-A-INTEG (4h 剩余)  ← TPUB ✅ PR#141 + OTEL-COV-01 ✅ PR#157 扣除
   PR-A-HARDEN (6.5h)
-  PR-A-CI (2h)
+  PR-A-CI (2h)          ← PR#153 已完成 CI wall-time 优化
     ↓
-Phase 5  架构收敛       ~10h   ← 可选但推荐
+Phase 5  架构收敛       ~7h 剩余（原 10h）  ← 可选但推荐
   PR-SERIAL (3h)
   PR-ADAPTER-SPLIT (4h)
-  PR-CONTRACT (3h)
+  PR-CONTRACT  ✅ 全部完成 PR#143+PR#155
     ↓
 Phase 6  功能 + 发布    ~15h+  ← 底座稳固后
 
-总计 Phase 0-4: ~68.5h（约 9 工作日）
-含 Phase 5:    ~78.5h（约 10 工作日）
+当前剩余 Phase 0-4: ~33h（约 4 工作日，原 68.5h）
+含 Phase 5:        ~40h（约 5 工作日）
+
+已合入底座 PR:
+  PR#147+148 outbox 治理 / PR#142 kernel 元数据治理 / PR#152 validator 诊断定位
+  PR#154 kernel hook 生命周期超时 + Observer + outbox metadata DX
+  PR#151 access-core 安全加固 + READYZ / PR#143 RBAC closure
+  PR#153 CI 并行 + SonarCloud 拆分 + RMQ testcontainer 共享
+  PR#155 config-core rollback 契约 + publish redaction + config 写旅程 admin gate + repo 错误脱敏
+  PR#156 OBS-B test determinism（CONFORMANCE-SLEEP-01 + OBS-TABLE-01 + CURSOR-P2-02）
+  PR#157 OBS-A provider-neutral metrics + async hook dispatcher + pool statter
 ```
 
 ---

--- a/docs/reviews/202604171430-PR151-review-6seat.md
+++ b/docs/reviews/202604171430-PR151-review-6seat.md
@@ -1,0 +1,377 @@
+# PR #151 6-Seat Review
+
+**Review baseline commit**: worktree `worktrees/231-pr149-hardening` branch `fix/231-pr149-hardening`
+**Review date**: 2026-04-17
+**Reviewer**: 6-Seat Agent (Seats 1-6)
+
+---
+
+## 背景
+
+PR #151 (`fix(access-core): security hardening + READYZ (rebased from #149)`) 是对 PR #149 的重新裁剪版本，基于最新 develop (07ca8cb) 重放后 3+1 个 commit，净差异 37 files, +673/-151。核心变更：
+
+1. PROD-KEY-FAILFAST (H1-1): `loadSecret` 取代 `envOrDefault`，real 模式下 env var 必填 fail-fast；`validateAdapterMode` 接受 "real"。
+2. READYZ-VERBOSE-TOKEN (H1-6): `WithVerboseToken` bootstrap 选项 + `SetVerboseToken` health handler 方法 + `crypto/subtle.ConstantTimeCompare` 比较 + main.go 接线（real 模式必填）。
+3. Timing-safe token compare: `health.verboseAllowed()` 使用 `subtle.ConstantTimeCompare`。
+4. Atomic last-admin guard: `RoleRepository.RemoveFromUserIfNotLast` 在 write lock 下同时完成 count + delete。
+5. Test matrix: bootstrap、health、rbacassign、main 各层新增测试。
+6. `gofmt` 整理 commit。
+
+与 PR #143 (RBAC closure) 合并冲突已解决；`Publisher→*Publisher` 迁移 (PR #148) 共存确认。
+
+---
+
+## 整体结论
+
+PASS with nits — 核心安全目标（timing-safe token、last-admin guard、real 模式 fail-fast）均已实现且有测试覆盖。发现 1 条 P1（test matrix 缺少 `run()` real 模式 + 空 READYZ_VERBOSE_TOKEN 的集成路径），2 条 P2（.env.example 缺更新、audit log 静默 fallback），2 条 N（设计决策），以及若干 DX 小项。
+
+---
+
+## Findings by Seat
+
+---
+
+### Seat 1: 架构一致性
+
+**S1-F1 [P2] `WithVerboseToken` 架构归属正确，但 health 层未标注 commit `ref:`**
+
+`WithVerboseToken` 挂在 `runtime/bootstrap/bootstrap.go:252`（bootstrap 层），在 Run() Step 5 通过 `hh.SetVerboseToken(b.verboseToken)` 传递给 `health.Handler`（见 bootstrap.go:603）。cell 层没有参与，分层正确。
+
+但 `runtime/http/health/health.go:SetVerboseToken` 的 godoc 中注明了 `ref: Kubernetes withholds error reasons...`（line 62-63），属于合规 ref 标注。然而本 PR 新增的 `cmd/core-bundle/main.go:loadSecret` 的 commit message 中无 `ref:` 标注（仅 godoc 内部注释有）。CLAUDE.md 要求 "在 PR 描述或 commit message 中注明 ref:"。
+
+- 受影响文件: `cmd/core-bundle/main.go:33` godoc 注释含 `ref:` 但 commit message 中未见。
+- 审查基准: worktree HEAD `fix/231-pr149-hardening`
+- 状态: OPEN (P2，可接受，不阻塞合并)
+
+**S1-F2 [P2] `runtime/http/health` 模块新增公共 API (`SetVerboseToken`, `VerboseTokenHeader`) 但未标注 GoCell 模块层级 commit ref:**
+
+同 S1-F1，`runtime/http/health/health.go` 的 `VerboseTokenHeader` 常量和 `SetVerboseToken` 方法是本 PR 新增的公共 API。GoCell 规则对 runtime/ 层改动要求 commit message 含 `ref: {framework} {file}`。
+
+- 受影响文件: `runtime/http/health/health.go:25-68`
+- 状态: OPEN (P2，不阻塞)
+
+**S1-F3 [N] 依赖方向合规**
+
+检查通过：`runtime/http/health` 只依赖 `kernel/assembly`（合法）；`cmd/core-bundle` 依赖 `runtime/bootstrap`（合法）；没有 cells/ 直接 import adapters/；没有跨 Cell internal/ 直接 import。一致性级别标注：rbacassign 声明为 L0（service.go 注释第 1 行）。符合 `RemoveFromUserIfNotLast` 纯 repo 操作定义，正确。
+
+---
+
+### Seat 2: 安全/权限
+
+**S2-F1 [P1] GOCELL_READYZ_VERBOSE_TOKEN real 模式强制点正确，但缺失集成测试路径**
+
+证据：`cmd/core-bundle/main.go:204-207`:
+```
+verboseToken := os.Getenv("GOCELL_READYZ_VERBOSE_TOKEN")
+if adapterMode == "real" && verboseToken == "" {
+    return fmt.Errorf("GOCELL_READYZ_VERBOSE_TOKEN must be set in adapter mode \"real\"...")
+}
+```
+该 fail-fast 在 `run()` 函数中，逻辑正确。但 `cmd/core-bundle/main_test.go` 没有对应的集成测试用例验证此路径（参见测试部分 S3-F1 详述）。这意味着如果有人错误地重构了 `run()` 的调用顺序（例如把 verboseToken 检查挪到 `validateAdapterMode` 之后但在 `loadKeySet` 之前），该安全检查可能被绕过而不被测试感知。
+
+- 受影响文件: `cmd/core-bundle/main.go:204-207`, `cmd/core-bundle/main_test.go`
+- 状态: OPEN (P1，建议修复)
+- 修复建议（developer）: 在 `main_test.go` 添加：
+  ```go
+  func TestRun_RealMode_MissingVerboseToken_FailsFast(t *testing.T) {
+      t.Setenv("GOCELL_ADAPTER_MODE", "real")
+      t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "")
+      // set JWT keys to pass loadKeySet
+      privPEM, pubPEM := generateTestPEM(t)
+      t.Setenv(auth.EnvJWTPrivateKey, string(privPEM))
+      t.Setenv(auth.EnvJWTPublicKey, string(pubPEM))
+      // set other required keys
+      t.Setenv("GOCELL_HMAC_KEY", "prod-hmac-key-replace-32bytes!!!")
+      t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
+      t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+      ctx, cancel := context.WithCancel(context.Background())
+      defer cancel()
+      err := run(ctx)
+      require.Error(t, err)
+      assert.Contains(t, err.Error(), "GOCELL_READYZ_VERBOSE_TOKEN")
+  }
+  ```
+
+**S2-F2 [P2] timing-safe 比较正确，但未覆盖 empty-string 边界**
+
+证据：`health.go:192`:
+```go
+return subtle.ConstantTimeCompare([]byte(r.Header.Get(VerboseTokenHeader)), []byte(token)) == 1
+```
+
+当 token 已配置（非空）但请求头为空字符串（`r.Header.Get(VerboseTokenHeader)` 返回 `""`）时，`ConstantTimeCompare([]byte(""), []byte("secret"))` 返回 0，行为正确（拒绝空 header）。但当 `token == ""` 时（backward-compat 分支，line 189-191）直接 return true，不进 ConstantTimeCompare，也正确。
+
+然而，如果有人在 `SetVerboseToken("")` 之后调用 `SetVerboseToken("real-token")` ——即两次调用——行为取决于 `h.mu.Lock()` 保护，代码正确。
+
+这里有一个边界：若 token 设置为仅含空白字符如 `"   "` 时，`ConstantTimeCompare([]byte(header), []byte("   "))` 可能匹配空白头，但这属于使用者责任，不是代码问题。
+
+总体：timing-safe 实现正确，`crypto/subtle` 使用无误，无时序泄露风险。标记 N（不修）。
+
+**S2-F3 [P2] `GOCELL_READYZ_VERBOSE_TOKEN` 未加入 `.env.example`**
+
+`.env.example` 仅包含 PG/Redis/RabbitMQ/S3/JWT 相关变量，没有 `GOCELL_READYZ_VERBOSE_TOKEN`、`GOCELL_HMAC_KEY`、`GOCELL_AUDIT_CURSOR_KEY`、`GOCELL_CONFIG_CURSOR_KEY`。前三者在 PR #151 中新增了 real 模式必填语义，但 `.env.example` 未更新。
+
+- 受影响文件: `.env.example`
+- 状态: OPEN (P2，建议修复)
+- 修复建议（developer/ops）: 在 `.env.example` 补充：
+  ```
+  # Readyz verbose token (required in GOCELL_ADAPTER_MODE=real)
+  GOCELL_READYZ_VERBOSE_TOKEN=
+  # HMAC key (min 32 bytes, required in real mode)
+  GOCELL_HMAC_KEY=
+  # Cursor keys (32 bytes each, required in real mode)
+  GOCELL_AUDIT_CURSOR_KEY=
+  GOCELL_CONFIG_CURSOR_KEY=
+  ```
+
+**S2-F4 [P2] last-admin guard TOCTOU 分析：内存实现正确，PG 实现待验证**
+
+`mem.RoleRepository.RemoveFromUserIfNotLast`（`cells/access-core/internal/mem/role_repo.go:111-138`）在写锁下同时完成 count check 和 delete，无 TOCTOU 窗口。内存实现正确。
+
+潜在风险：当 PG 实现落地时（Batch 8 `PG-DOMAIN-REPO`），必须用 `SELECT COUNT ... FOR UPDATE` 或 CTE/serializable transaction 保证同样的原子性，否则 TOCTOU 窗口将复现。此时接口注释（`ports/role_repo.go:21`）已经说明 "Implementations must guarantee atomicity"，合规。
+
+- 状态: N（设计决策，内存实现正确，PG 实现时需遵循接口契约，不阻塞本 PR）
+
+**S2-F5 [P2] GOCELL_ADMIN_USER 日志暴露风险：可接受**
+
+`cmd/core-bundle/main.go:168` 中 `slog.Error` 日志仅包含固定字符串，不输出 `adminUser` 或 `adminPass` 值。`adminPass` 在 `os.Unsetenv("GOCELL_ADMIN_PASS")` 后被从环境中清除（line 163），并在 `WithSeedAdmin` 后通过 `clear(c.seedAdminPass)` 擦除（`cells/access-core/cell.go:350/360`）。密码不在日志中出现。
+
+- 状态: N（已检查，合规）
+
+---
+
+### Seat 3: 测试/回归
+
+**S3-F1 [P1] `run()` real 模式 + 缺失 READYZ_VERBOSE_TOKEN 路径无测试覆盖**
+
+`cmd/core-bundle/main_test.go` 中现有测试：
+- `TestValidateAdapterMode_Real_Accepted` — 验证 `validateAdapterMode("real")` 不报错
+- `TestLoadKeySet_RealMode_MissingEnv` / `TestLoadKeySet_RealMode_Success` — 测试 loadKeySet
+- `TestLoadSecret_RealMode_*` — 测试 loadSecret
+- `TestRun_InvalidAdapterMode_ReturnsError` — 测试非法 mode
+
+**缺失**：没有测试调用 `run(ctx)` 并设置 `GOCELL_ADAPTER_MODE=real` + `GOCELL_READYZ_VERBOSE_TOKEN=""` 来验证 run() 返回错误。该路径是 H1-6 的核心安全保证（main.go:204-207）。单元函数测试和集成路径测试缺口不同——若 run() 内部调用顺序变化，单元函数测试无法感知。
+
+- 受影响文件: `cmd/core-bundle/main_test.go`
+- 状态: OPEN (P1，应当修复，见 S2-F1 的修复建议)
+
+**S3-F2 [P2] 缺少并发 `RemoveFromUserIfNotLast` 竞争测试**
+
+`cells/access-core/internal/mem/repo_test.go` 有 `TestRoleRepository_ConcurrentAssignAndGet` 测试并发 Assign+Get，`TestSessionRepository_ConcurrentRefreshUpdate` 测试 session 并发更新，但没有专门测试多个 goroutine 同时调用 `RemoveFromUserIfNotLast` 时 last-admin guard 的正确性（即只有一个成功，其余失败）。
+
+这个测试对于证明 atomic last-admin guard 在 `-race` 下正确运行是重要的，尤其是本 PR 将此作为安全 feature（backlog H1 条目 "atomic last-admin guard"）。
+
+- 受影响文件: `cells/access-core/internal/mem/repo_test.go`
+- 状态: OPEN (P2，建议修复)
+- 修复建议（developer）:
+  ```go
+  func TestRoleRepository_ConcurrentRemoveFromUserIfNotLast(t *testing.T) {
+      repo := NewRoleRepository()
+      // seed 2 admins: only one can be removed
+      repo.SeedRole(&domain.Role{ID: "admin"})
+      _ = repo.AssignToUser(ctx, "usr-1", "admin")
+      _ = repo.AssignToUser(ctx, "usr-2", "admin")
+      // concurrent revoke of usr-2 (safe) and usr-1 (also safe since usr-2 remains)
+      // or test last-holder removal: all goroutines try to remove the same last holder
+      ...
+  }
+  ```
+
+**S3-F3 [P2] health 测试未覆盖 `SetVerboseToken("")` after `SetVerboseToken("x")` 场景**
+
+`health_test.go` 覆盖了：正确 token、错误 token、缺失 token、未配置（backward-compat）四个场景，覆盖良好。缺少的场景是：`SetVerboseToken("")` 重置为 empty 后是否恢复 backward-compat（预期行为：verbose 不受限）。这是边界场景，属于 P2。
+
+- 受影响文件: `runtime/http/health/health_test.go`
+- 状态: OPEN (P2，可 backlog)
+
+**S3-F4 [N] 测试整体质量评估**
+
+`runtime/http/health/health_test.go` 覆盖完整（6 个 VerboseToken 场景 + 之前存在的全部场景），table-driven，无 magic number，mock 定义在测试包内。
+
+`cells/access-core/slices/rbacassign/service_test.go` 覆盖 Assign/Revoke 全部分支 + session 失效 + fail-closed session revoke 失败场景，良好。
+
+`cmd/core-bundle/main_test.go` 覆盖 loadKeySet/loadSecret/validateAdapterMode 所有路径，但 `run()` 的 real 模式 verboseToken 路径缺失（见 S3-F1）。
+
+`runtime/bootstrap/bootstrap_test.go` 覆盖 `WithVerboseToken` option 设置正确性（两个测试函数）。
+
+---
+
+### Seat 4: 运维/部署
+
+**S4-F1 [P2] `.env.example` 未同步新增 env var**
+
+同 S2-F3，重申运维视角：真实部署中运维人员需要知道哪些 env var 在 `real` 模式下是必填的。当前 `.env.example` 没有 `GOCELL_READYZ_VERBOSE_TOKEN`、`GOCELL_HMAC_KEY`、`GOCELL_AUDIT_CURSOR_KEY`、`GOCELL_CONFIG_CURSOR_KEY`。这会导致运维人员在配置 real 模式时遗漏，导致启动失败而不知原因。
+
+- 受影响文件: `.env.example`
+- 状态: OPEN (P2，建议修复)
+
+**S4-F2 [P2] `/readyz?verbose` token 不匹配时静默 fallback，无审计日志**
+
+`health.go:verboseAllowed()` 在 token 不匹配时直接返回 false，降级为非 verbose 输出（HTTP 200，无 cells/dependencies 字段）。不返回 401，符合 "fail-closed on secret，不暴露 token 检查存在" 的设计原则（PR#134 review 中讨论过）。
+
+然而，静默降级意味着试探性扫描（攻击者不断发送 `?verbose` 带随机 token）完全不可观测。backlog 条目没有明确要求 audit log，但 observability.md 规定安全事件应 `slog.Error`。
+
+- 证据: `health.go:182-193` — 无 log 语句
+- 状态: OPEN (P2，建议修复，可 backlog)
+- 修复建议（developer）: 在 `verboseAllowed` token 不匹配时加 `slog.Warn("readyz: verbose token mismatch; suppressing verbose output", slog.String("remote_addr", r.RemoteAddr))`（Info 或 Warn 级别，不 Error，因为不影响正确性）。
+
+**S4-F3 [N] slog 日志级别合规**
+
+检查通过：
+- `main.go:41` `slog.Warn` — dev 模式 fallback，符合 Warn 定义
+- `main.go:63` `slog.Warn` — ephemeral key 警告，符合
+- `main.go:168` `slog.Error` — seed admin 单方提供，影响正确性，符合 Error 定义
+- `main.go:206` `fmt.Errorf` return — fail-fast，不是日志，合规
+- `main.go:222` `slog.Warn` — dev 模式没有 verbose token，符合 Warn
+
+---
+
+### Seat 5: DX/可维护性
+
+**S5-F1 [P2] `loadKeySet` godoc 遗漏 dev 模式下 env key 可用路径的说明**
+
+`cmd/core-bundle/main.go:46-65` 的 godoc 写道：
+```
+// In dev mode, env keys are used if available; otherwise an ephemeral RSA
+// key pair is generated per process (tokens invalidated on restart).
+```
+
+这实际上包含了两条路径：env-preferred（line 51-57）和 ephemeral fallback（line 60-64）。godoc 描述了这两条路径，但没有说明为什么 dev 模式也优先用 env key（理由是运维/开发者可能想用固定 key 避免每次重启失效）。
+
+小问题，不影响使用。标记 P2。
+
+**S5-F2 [P2] `validateAdapterMode` 注释不一致：旧版 main.go（develop 分支）拒绝 "real"，新版接受 "real"**
+
+旧版（develop 分支 `cmd/core-bundle/main.go:55-63`）：
+```go
+case "real":
+    return fmt.Errorf("adapter mode %q is not yet supported...")
+```
+
+新版（worktree `main.go:70-76`）：
+```go
+case "", "real":
+    return nil
+```
+
+但 `run()` 内部在 `real` 模式下仍使用 in-memory storage（`slog.Info: "real-keys-in-memory-storage"`）。包注释（`main.go:1-8`）已更新为 "Set GOCELL_ADAPTER_MODE=real to require all secrets from env vars"，说明清楚了。一致性良好。
+
+**S5-F3 [P2] `WithVerboseToken` 命名符合 `WithXxx` 惯例；`GOCELL_READYZ_VERBOSE_TOKEN` 遵循 `GOCELL_` 前缀**
+
+审查通过：bootstrap option 命名、env var 前缀均合规。
+
+**S5-F4 [N] 函数复杂度**
+
+`run()` 函数（main.go:89-228）约 140 行，逻辑复杂度约 10（条件分支：validateAdapterMode, loadSecret x4, loadKeySet, seedAdmin switch, verboseToken if）——未超过 15 的上限，合规。
+
+**S5-F5 [P2] `GOCELL_READYZ_VERBOSE_TOKEN` 等 4 个 env var 均使用内联字符串，未抽常量**
+
+`main.go` 中：
+- `"GOCELL_READYZ_VERBOSE_TOKEN"` 出现 1 次（line 204），仅 1 次可接受
+- `"GOCELL_HMAC_KEY"` 出现 1 次（line 97）
+- `"GOCELL_ADMIN_USER"` 出现 1 次（line 161）
+- `"GOCELL_ADMIN_PASS"` 出现 2 次（lines 162, 163）——不满足 ≥3 次抽常量的阈值
+
+对比 `runtime/auth` 包，`EnvJWTPrivateKey` 等已抽为常量。`main.go` 里的 env key 目前都未超 3 次，可接受；但若后续 test 也需引用这些 key（如 S3-F1 修复），就会超 3 次，届时应抽常量。
+
+- 状态: N（当前次数未超阈值，不修）
+
+---
+
+### Seat 6: 产品/用户体验
+
+**S6-F1 [P2] 向后兼容：dev 模式 `/readyz?verbose` 默认行为保留**
+
+`health.go:verboseAllowed()` 第 189-191 行：
+```go
+if token == "" {
+    return true // no token configured — backward compatible
+}
+```
+
+已有部署（不设 `GOCELL_READYZ_VERBOSE_TOKEN`）的 dev/staging 环境，`/readyz?verbose` 继续正常工作。向后兼容性保留。
+
+**S6-F2 [P2] 上手体验：real 模式必填的启动错误 message 清晰**
+
+`main.go:206` 的错误信息：
+```
+"GOCELL_READYZ_VERBOSE_TOKEN must be set in adapter mode \"real\" to prevent anonymous topology exposure via /readyz?verbose"
+```
+
+信息清晰，明确说明了 env var 名、触发条件、原因。运维人员从日志中即可知道需要设置什么。
+
+**S6-F3 [P2] backlog AC 对齐检查**
+
+对照 backlog.md 中 H1-1 和 H1-6 的验收标准：
+
+- H1-1 PROD-KEY-FAILFAST: `validateAdapterMode` 接受 "real" (main.go:71); `loadSecret` real 模式 fail-fast (main.go:34-43); `loadKeySet` real 模式 fail-fast (main.go:52-65) — **全部实现**
+- H1-6 READYZ-VERBOSE-TOKEN: `WithVerboseToken` bootstrap 选项 (bootstrap.go:249-256); `X-Readyz-Token` header 检查 (health.go:192); constant-time 比较 (health.go:192); main.go 接线 real 模式必填 (main.go:204-207) — **全部实现**
+
+无隐藏 feature，代码行为与 AC 对齐。
+
+**S6-F4 [P2] 迁移成本分析**
+
+已有部署迁移成本：
+- dev 模式：零迁移成本，所有 env var 可选，fallback 到 dev default
+- real 模式：需额外设置 `GOCELL_READYZ_VERBOSE_TOKEN`（新增必填项），以及之前在 `envOrDefault` 中静默 fallback 的 `GOCELL_HMAC_KEY`、`GOCELL_AUDIT_CURSOR_KEY`、`GOCELL_CONFIG_CURSOR_KEY`（现在 real 模式必填）
+
+对于已经在 "real" 模式运行的部署：旧版本 `validateAdapterMode` 会直接拒绝 "real" 模式（返回 error），所以实际上没有已运行在 real 模式的部署。这是升级到 real 模式的首次落地，迁移成本为"需要配置所有 real 模式 env var"，属于预期行为。
+
+**S6-F5 [N] `DELETE /internal/v1/access/roles/revoke` 路由语义**
+
+handler.go 注册 `POST /revoke`，与 backlog.md 中记录的 RBAC-REVOKE-POST-01 一致。本 PR 中已使用 POST，没有 DELETE body 兼容问题，符合 Batch 8 治理项要求（不修）。
+
+---
+
+## 测试执行结果
+
+审查为静态代码分析，未执行 `go test`（需要 worktree Go 环境和完整依赖）。
+
+基于代码审查的测试矩阵评估：
+
+| 场景 | 覆盖情况 |
+|------|---------|
+| real 模式 env 缺失 → fail-fast (loadKeySet/loadSecret) | COVERED (main_test.go) |
+| dev 模式默认值 | COVERED (main_test.go) |
+| /readyz?verbose with valid token | COVERED (health_test.go:TestReadyz_VerboseToken_CorrectHeader) |
+| /readyz?verbose with wrong token | COVERED (health_test.go:TestReadyz_VerboseToken_WrongHeader) |
+| /readyz?verbose with missing token | COVERED (health_test.go:TestReadyz_VerboseToken_MissingHeader) |
+| /readyz?verbose no token configured (backward-compat) | COVERED (health_test.go:TestReadyz_VerboseToken_NotConfigured) |
+| run() real 模式 + 空 READYZ_VERBOSE_TOKEN → fail-fast | **MISSING** (S3-F1/S2-F1) |
+| last-admin guard atomic (service level) | COVERED (service_test.go:TestService_Revoke "revoke last admin returns error") |
+| last-admin guard concurrent (race detector) | **MISSING** concurrent revoke 测试 (S3-F2) |
+| session revoke fail-closed | COVERED (service_test.go:TestService_Revoke_SessionRevokeFail_ReturnsError) |
+
+---
+
+## 建议动作
+
+### 必改（阻塞 merge）
+
+无 P0 Finding。
+
+### 建议改（应当修复，不阻塞 merge，建议 follow-up PR）
+
+- **[P1-S2-F1/S3-F1]** `cmd/core-bundle/main_test.go` 补充 `TestRun_RealMode_MissingVerboseToken_FailsFast` — developer 修复，1h
+
+### 建议改（可 backlog）
+
+- **[P2-S2-F3/S4-F1]** `.env.example` 补充 4 个新增 env var — developer/ops 修复，0.5h
+- **[P2-S3-F2]** `mem/repo_test.go` 补充 `RemoveFromUserIfNotLast` 并发测试（`-race` 保障）— developer 修复，1h
+- **[P2-S4-F2]** `health.go:verboseAllowed` 在 token 不匹配时加 `slog.Warn` 审计日志 — developer 修复，0.5h
+- **[P2-S3-F3]** `health_test.go` 补 `SetVerboseToken("")` 重置场景 — developer 修复，0.5h
+
+### 不修（设计决策）
+
+- **[N-S2-F2]** timing-safe compare 边界分析 — 实现正确，不需修改
+- **[N-S2-F4]** last-admin guard PG 实现原子性 — 接口注释已声明，PG 落地时处理
+- **[N-S2-F5]** seed admin 密码不在日志中 — 已验证合规
+- **[N-S4-F3]** slog 日志级别 — 已验证合规
+- **[N-S6-F5]** POST /revoke 路由 — 与 backlog RBAC-REVOKE-POST-01 一致，已合规
+- **[N-S5-F5]** env key 字符串常量 — 未超 3 次阈值，不修
+
+---
+
+*审查人: 6-Seat Reviewer Agent (Seats 1-6)*
+*审查基准: worktree `worktrees/231-pr149-hardening` (branch `fix/231-pr149-hardening`)*
+*日期: 2026-04-17*

--- a/pkg/query/cursor.go
+++ b/pkg/query/cursor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -182,6 +183,28 @@ func cursorInvalidExtra(reason string, extra map[string]any) *errcode.Error {
 	return errcode.WithDetails(
 		errcode.Safe(errcode.ErrCursorInvalid, cursorInvalidMsg, reason),
 		details)
+}
+
+// KnownDemoKeys lists the well-known demo cursor keys used by GoCell cells
+// when no production key is injected.
+var KnownDemoKeys = [][]byte{
+	[]byte("gocell-demo-AUDIT--CORE-key-32!!"),
+	[]byte("gocell-demo-CONFIG-CORE-key-32!!"),
+	[]byte("gocell-demo-ORDER-CELL-key-32b!!"),
+	[]byte("gocell-demo-DEVICE-CELL-key-32!!"),
+	[]byte("core-bundle-audit-cursor-key-32!"),
+	[]byte("core-bundle-cfg-cursor-key--32b!"),
+}
+
+// IsDemoKey checks whether the codec's current signing key matches any of
+// the provided known demo keys.
+func (c *CursorCodec) IsDemoKey(known ...[]byte) bool {
+	for _, k := range known {
+		if len(k) == len(c.current) && subtle.ConstantTimeCompare(c.current, k) == 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidateCursorScope checks that the decoded cursor carries the expected sort

--- a/pkg/query/cursor.go
+++ b/pkg/query/cursor.go
@@ -185,9 +185,9 @@ func cursorInvalidExtra(reason string, extra map[string]any) *errcode.Error {
 		details)
 }
 
-// KnownDemoKeys lists the well-known demo cursor keys used by GoCell cells
+// knownDemoKeys holds the well-known demo cursor keys used by GoCell cells
 // when no production key is injected.
-var KnownDemoKeys = [][]byte{
+var knownDemoKeys = [][]byte{
 	[]byte("gocell-demo-AUDIT--CORE-key-32!!"),
 	[]byte("gocell-demo-CONFIG-CORE-key-32!!"),
 	[]byte("gocell-demo-ORDER-CELL-key-32b!!"),
@@ -196,8 +196,19 @@ var KnownDemoKeys = [][]byte{
 	[]byte("core-bundle-cfg-cursor-key--32b!"),
 }
 
+// KnownDemoKeys returns a copy of the well-known demo cursor keys.
+func KnownDemoKeys() [][]byte {
+	out := make([][]byte, len(knownDemoKeys))
+	copy(out, knownDemoKeys)
+	return out
+}
+
 // IsDemoKey checks whether the codec's current signing key matches any of
-// the provided known demo keys.
+// the provided known demo keys. Only the current key is checked — during
+// key rotation from a demo key to a production key, IsDemoKey returns false
+// once the current key is production, even if previous is still demo.
+// This is intentional: once signing uses a production key, strict cursor
+// validation should apply.
 func (c *CursorCodec) IsDemoKey(known ...[]byte) bool {
 	for _, k := range known {
 		if len(k) == len(c.current) && subtle.ConstantTimeCompare(c.current, k) == 1 {

--- a/pkg/query/cursor_guard_test.go
+++ b/pkg/query/cursor_guard_test.go
@@ -12,7 +12,7 @@ import (
 func TestIsDemoKey_KnownDemoKey(t *testing.T) {
 	codec, err := NewCursorCodec([]byte("gocell-demo-AUDIT--CORE-key-32!!"))
 	require.NoError(t, err)
-	assert.True(t, codec.IsDemoKey(KnownDemoKeys...))
+	assert.True(t, codec.IsDemoKey(KnownDemoKeys()...))
 }
 
 func TestIsDemoKey_ProductionKey(t *testing.T) {
@@ -20,7 +20,7 @@ func TestIsDemoKey_ProductionKey(t *testing.T) {
 	_, _ = rand.Read(key)
 	codec, err := NewCursorCodec(key)
 	require.NoError(t, err)
-	assert.False(t, codec.IsDemoKey(KnownDemoKeys...))
+	assert.False(t, codec.IsDemoKey(KnownDemoKeys()...))
 }
 
 func TestIsDemoKey_EmptyKnownList(t *testing.T) {
@@ -36,7 +36,7 @@ func TestIsDemoKey_CurrentIsDemo_WithRotation(t *testing.T) {
 
 	codec, err := NewCursorCodec(demoKey, prodKey)
 	require.NoError(t, err)
-	assert.True(t, codec.IsDemoKey(KnownDemoKeys...))
+	assert.True(t, codec.IsDemoKey(KnownDemoKeys()...))
 }
 
 func TestIsDemoKey_PreviousIsDemo_CurrentIsProd(t *testing.T) {
@@ -46,5 +46,5 @@ func TestIsDemoKey_PreviousIsDemo_CurrentIsProd(t *testing.T) {
 
 	codec, err := NewCursorCodec(prodKey, demoKey)
 	require.NoError(t, err)
-	assert.False(t, codec.IsDemoKey(KnownDemoKeys...))
+	assert.False(t, codec.IsDemoKey(KnownDemoKeys()...))
 }

--- a/pkg/query/cursor_guard_test.go
+++ b/pkg/query/cursor_guard_test.go
@@ -1,0 +1,50 @@
+package query
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDemoKey_KnownDemoKey(t *testing.T) {
+	codec, err := NewCursorCodec([]byte("gocell-demo-AUDIT--CORE-key-32!!"))
+	require.NoError(t, err)
+	assert.True(t, codec.IsDemoKey(KnownDemoKeys...))
+}
+
+func TestIsDemoKey_ProductionKey(t *testing.T) {
+	key := make([]byte, 32)
+	_, _ = rand.Read(key)
+	codec, err := NewCursorCodec(key)
+	require.NoError(t, err)
+	assert.False(t, codec.IsDemoKey(KnownDemoKeys...))
+}
+
+func TestIsDemoKey_EmptyKnownList(t *testing.T) {
+	codec, err := NewCursorCodec(bytes.Repeat([]byte("k"), 32))
+	require.NoError(t, err)
+	assert.False(t, codec.IsDemoKey())
+}
+
+func TestIsDemoKey_CurrentIsDemo_WithRotation(t *testing.T) {
+	prodKey := make([]byte, 32)
+	_, _ = rand.Read(prodKey)
+	demoKey := []byte("gocell-demo-CONFIG-CORE-key-32!!")
+
+	codec, err := NewCursorCodec(demoKey, prodKey)
+	require.NoError(t, err)
+	assert.True(t, codec.IsDemoKey(KnownDemoKeys...))
+}
+
+func TestIsDemoKey_PreviousIsDemo_CurrentIsProd(t *testing.T) {
+	prodKey := make([]byte, 32)
+	_, _ = rand.Read(prodKey)
+	demoKey := []byte("gocell-demo-CONFIG-CORE-key-32!!")
+
+	codec, err := NewCursorCodec(prodKey, demoKey)
+	require.NoError(t, err)
+	assert.False(t, codec.IsDemoKey(KnownDemoKeys...))
+}

--- a/pkg/query/cursor_logger.go
+++ b/pkg/query/cursor_logger.go
@@ -1,0 +1,33 @@
+package query
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+)
+
+// LogCursorError returns a CursorErrorFunc that emits a structured slog.Info
+// record when a cursor validation fails. Returns nil if logger is nil.
+//
+// The raw cursor string is intentionally omitted — opaque base64 that may
+// encode internal offsets; aligned with k8s apiserver / etcd / MinIO practice.
+//
+// Level is Info (not Warn) because cursor errors are client input failures,
+// not server-side degradation.
+func LogCursorError(logger *slog.Logger, sliceName string) CursorErrorFunc {
+	if logger == nil {
+		return nil
+	}
+	return func(ctx context.Context, phase string, err error) {
+		attrs := []any{
+			"slice", sliceName,
+			"reason", phase,
+			"error", err.Error(),
+		}
+		if rid, ok := ctxkeys.RequestIDFrom(ctx); ok && rid != "" {
+			attrs = append(attrs, "request_id", rid)
+		}
+		logger.Info("invalid cursor", attrs...)
+	}
+}

--- a/pkg/query/cursor_logger_test.go
+++ b/pkg/query/cursor_logger_test.go
@@ -1,0 +1,74 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseJSONLogLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &m), "failed to parse log line: %s", line)
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestLogCursorError_DecodeWithRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	fn := LogCursorError(logger, "auditquery")
+	require.NotNil(t, fn)
+
+	ctx := ctxkeys.WithRequestID(context.Background(), "req-123")
+	fn(ctx, "decode", fmt.Errorf("invalid base64 encoding"))
+
+	logs := parseJSONLogLines(t, &buf)
+	require.Len(t, logs, 1)
+	rec := logs[0]
+
+	assert.Equal(t, "INFO", rec["level"])
+	assert.Equal(t, "invalid cursor", rec["msg"])
+	assert.Equal(t, "auditquery", rec["slice"])
+	assert.Equal(t, "decode", rec["reason"])
+	assert.Equal(t, "req-123", rec["request_id"])
+	assert.NotEmpty(t, rec["error"])
+}
+
+func TestLogCursorError_ScopeWithoutRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	fn := LogCursorError(logger, "configread")
+	fn(context.Background(), "scope", fmt.Errorf("sort scope mismatch"))
+
+	logs := parseJSONLogLines(t, &buf)
+	require.Len(t, logs, 1)
+	rec := logs[0]
+
+	assert.Equal(t, "configread", rec["slice"])
+	assert.Equal(t, "scope", rec["reason"])
+	_, hasReqID := rec["request_id"]
+	assert.False(t, hasReqID, "request_id must be absent when not in ctx")
+}
+
+func TestLogCursorError_NilLogger_ReturnsNil(t *testing.T) {
+	fn := LogCursorError(nil, "test")
+	assert.Nil(t, fn)
+}

--- a/pkg/query/export_test.go
+++ b/pkg/query/export_test.go
@@ -3,17 +3,3 @@ package query
 // TestCursorInvalidMsg exports cursorInvalidMsg for external tests (package query_test).
 const TestCursorInvalidMsg = cursorInvalidMsg
 
-// MakeCursorErrorTokens returns three cursor tokens for handler-level cursor
-// regression tests: a garbage token (decode failure), a token with valid HMAC
-// but missing scope/context, and a token from a different endpoint (cross-context).
-func MakeCursorErrorTokens(codec *CursorCodec) (garbage, missingScope, crossContext string) {
-	garbage = "not-a-valid-cursor!!!"
-	missingScope, _ = codec.Encode(Cursor{Values: []any{"v1", "v2"}})
-	wrongSort := []SortColumn{{Name: "other", Direction: SortASC}, {Name: "x", Direction: SortASC}}
-	crossContext, _ = codec.Encode(Cursor{
-		Values:  []any{"v1", "v2"},
-		Scope:   SortScope(wrongSort),
-		Context: QueryContext("endpoint", "wrong-endpoint"),
-	})
-	return
-}

--- a/pkg/query/export_test.go
+++ b/pkg/query/export_test.go
@@ -2,3 +2,18 @@ package query
 
 // TestCursorInvalidMsg exports cursorInvalidMsg for external tests (package query_test).
 const TestCursorInvalidMsg = cursorInvalidMsg
+
+// MakeCursorErrorTokens returns three cursor tokens for handler-level cursor
+// regression tests: a garbage token (decode failure), a token with valid HMAC
+// but missing scope/context, and a token from a different endpoint (cross-context).
+func MakeCursorErrorTokens(codec *CursorCodec) (garbage, missingScope, crossContext string) {
+	garbage = "not-a-valid-cursor!!!"
+	missingScope, _ = codec.Encode(Cursor{Values: []any{"v1", "v2"}})
+	wrongSort := []SortColumn{{Name: "other", Direction: SortASC}, {Name: "x", Direction: SortASC}}
+	crossContext, _ = codec.Encode(Cursor{
+		Values:  []any{"v1", "v2"},
+		Scope:   SortScope(wrongSort),
+		Context: QueryContext("endpoint", "wrong-endpoint"),
+	})
+	return
+}

--- a/pkg/query/export_test.go
+++ b/pkg/query/export_test.go
@@ -2,4 +2,3 @@ package query
 
 // TestCursorInvalidMsg exports cursorInvalidMsg for external tests (package query_test).
 const TestCursorInvalidMsg = cursorInvalidMsg
-

--- a/pkg/query/paged_query.go
+++ b/pkg/query/paged_query.go
@@ -1,28 +1,49 @@
 package query
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
+
+// CursorPhase identifies the cursor validation stage that failed.
+const (
+	CursorPhaseDecode = "decode"
+	CursorPhaseScope  = "scope"
+)
 
 // CursorErrorFunc is called when cursor decode or scope validation fails.
-// phase is "decode" or "scope".
 type CursorErrorFunc func(ctx context.Context, phase string, err error)
 
 // PagedQueryConfig holds all parameters for ExecutePagedQuery.
 // ref: ent MultiCursorsOptions struct pattern; dispatcherConfig in kernel/assembly
 type PagedQueryConfig[T any] struct {
-	Codec       *CursorCodec
-	Request     PageRequest
-	Sort        []SortColumn
-	QueryCtx    string
-	Fetch       func(context.Context, ListParams) ([]T, error)
-	Extract     func(T) []any
+	// Codec signs and verifies cursor tokens.
+	Codec *CursorCodec
+	// Request holds the client-supplied limit and cursor token.
+	Request PageRequest
+	// Sort defines the keyset column ordering for this query.
+	Sort []SortColumn
+	// QueryCtx is the fingerprint from QueryContext(); must match between page requests.
+	QueryCtx string
+	// Fetch retrieves items from the data store using the decoded ListParams.
+	Fetch func(context.Context, ListParams) ([]T, error)
+	// Extract returns cursor keyset values from the last item; count must match Sort.
+	Extract func(T) []any
+	// OnCursorErr is called when cursor decode or scope validation fails; nil is safe.
 	OnCursorErr CursorErrorFunc
-	DemoMode    bool
+	// DemoMode when true causes cursor errors to fall back to the first page
+	// instead of returning an error. Set to codec.IsDemoKey(KnownDemoKeys()...)
+	// for automatic demo detection.
+	DemoMode bool
 }
 
 // ExecutePagedQuery normalizes the request, decodes and validates the cursor,
 // calls Fetch, and builds the paginated result. It replaces the ~15-line
 // pattern repeated across 5 service List methods.
 func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (PageResult[T], error) {
+	if cfg.Codec == nil || cfg.Fetch == nil || cfg.Extract == nil {
+		return PageResult[T]{}, fmt.Errorf("paged query: Codec, Fetch, and Extract must not be nil")
+	}
 	cfg.Request.Normalize()
 
 	var cursorValues []any
@@ -30,7 +51,7 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 		cur, err := cfg.Codec.Decode(cfg.Request.Cursor)
 		if err != nil {
 			if cfg.OnCursorErr != nil {
-				cfg.OnCursorErr(ctx, "decode", err)
+				cfg.OnCursorErr(ctx, CursorPhaseDecode, err)
 			}
 			if cfg.DemoMode {
 				return fetchFirstPage(ctx, cfg)
@@ -39,7 +60,7 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 		}
 		if err := ValidateCursorScope(cur, cfg.Sort, cfg.QueryCtx); err != nil {
 			if cfg.OnCursorErr != nil {
-				cfg.OnCursorErr(ctx, "scope", err)
+				cfg.OnCursorErr(ctx, CursorPhaseScope, err)
 			}
 			if cfg.DemoMode {
 				return fetchFirstPage(ctx, cfg)

--- a/pkg/query/paged_query.go
+++ b/pkg/query/paged_query.go
@@ -31,9 +31,10 @@ type PagedQueryConfig[T any] struct {
 	Extract func(T) []any
 	// OnCursorErr is called when cursor decode or scope validation fails; nil is safe.
 	OnCursorErr CursorErrorFunc
-	// DemoMode when true causes cursor errors to fall back to the first page
-	// instead of returning an error. Set to codec.IsDemoKey(KnownDemoKeys()...)
-	// for automatic demo detection.
+	// DemoMode when true causes cursor decode failures to fall back to the
+	// first page instead of returning an error. Scope/context mismatches
+	// always return an error regardless of DemoMode (they indicate a client
+	// bug, not a stale key). Set to codec.IsDemoKey(KnownDemoKeys()...).
 	DemoMode bool
 }
 
@@ -71,6 +72,10 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 // resolveCursor decodes and validates the cursor token. Returns the keyset
 // values for the next page, or (nil, true, nil) when DemoMode absorbs a
 // stale cursor and the caller should fall back to the first page.
+//
+// DemoMode only absorbs decode failures (stale key after server restart).
+// Scope/context mismatches always return an error because they indicate a
+// client bug (cross-endpoint cursor reuse), not a transient key issue.
 func resolveCursor[T any](ctx context.Context, cfg PagedQueryConfig[T]) ([]any, bool, error) {
 	if cfg.Request.Cursor == "" {
 		return nil, false, nil
@@ -87,9 +92,6 @@ func resolveCursor[T any](ctx context.Context, cfg PagedQueryConfig[T]) ([]any, 
 
 	if err := ValidateCursorScope(cur, cfg.Sort, cfg.QueryCtx); err != nil {
 		reportCursorErr(ctx, cfg.OnCursorErr, CursorPhaseScope, err)
-		if cfg.DemoMode {
-			return nil, true, nil
-		}
 		return nil, false, err
 	}
 

--- a/pkg/query/paged_query.go
+++ b/pkg/query/paged_query.go
@@ -1,0 +1,76 @@
+package query
+
+import "context"
+
+// CursorErrorFunc is called when cursor decode or scope validation fails.
+// phase is "decode" or "scope".
+type CursorErrorFunc func(ctx context.Context, phase string, err error)
+
+// PagedQueryConfig holds all parameters for ExecutePagedQuery.
+// ref: ent MultiCursorsOptions struct pattern; dispatcherConfig in kernel/assembly
+type PagedQueryConfig[T any] struct {
+	Codec       *CursorCodec
+	Request     PageRequest
+	Sort        []SortColumn
+	QueryCtx    string
+	Fetch       func(context.Context, ListParams) ([]T, error)
+	Extract     func(T) []any
+	OnCursorErr CursorErrorFunc
+	DemoMode    bool
+}
+
+// ExecutePagedQuery normalizes the request, decodes and validates the cursor,
+// calls Fetch, and builds the paginated result. It replaces the ~15-line
+// pattern repeated across 5 service List methods.
+func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (PageResult[T], error) {
+	cfg.Request.Normalize()
+
+	var cursorValues []any
+	if cfg.Request.Cursor != "" {
+		cur, err := cfg.Codec.Decode(cfg.Request.Cursor)
+		if err != nil {
+			if cfg.OnCursorErr != nil {
+				cfg.OnCursorErr(ctx, "decode", err)
+			}
+			if cfg.DemoMode {
+				return fetchFirstPage(ctx, cfg)
+			}
+			return PageResult[T]{}, err
+		}
+		if err := ValidateCursorScope(cur, cfg.Sort, cfg.QueryCtx); err != nil {
+			if cfg.OnCursorErr != nil {
+				cfg.OnCursorErr(ctx, "scope", err)
+			}
+			if cfg.DemoMode {
+				return fetchFirstPage(ctx, cfg)
+			}
+			return PageResult[T]{}, err
+		}
+		cursorValues = cur.Values
+	}
+
+	params := ListParams{
+		Limit:        cfg.Request.Limit,
+		CursorValues: cursorValues,
+		Sort:         cfg.Sort,
+	}
+
+	items, err := cfg.Fetch(ctx, params)
+	if err != nil {
+		return PageResult[T]{}, err
+	}
+
+	return BuildPageResult(items, cfg.Request.Limit, cfg.Codec, cfg.Sort, cfg.QueryCtx, cfg.Extract)
+}
+
+func fetchFirstPage[T any](ctx context.Context, cfg PagedQueryConfig[T]) (PageResult[T], error) {
+	params := ListParams{
+		Limit: cfg.Request.Limit,
+		Sort:  cfg.Sort,
+	}
+	items, err := cfg.Fetch(ctx, params)
+	if err != nil {
+		return PageResult[T]{}, err
+	}
+	return BuildPageResult(items, cfg.Request.Limit, cfg.Codec, cfg.Sort, cfg.QueryCtx, cfg.Extract)
+}

--- a/pkg/query/paged_query.go
+++ b/pkg/query/paged_query.go
@@ -46,28 +46,12 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 	}
 	cfg.Request.Normalize()
 
-	var cursorValues []any
-	if cfg.Request.Cursor != "" {
-		cur, err := cfg.Codec.Decode(cfg.Request.Cursor)
-		if err != nil {
-			if cfg.OnCursorErr != nil {
-				cfg.OnCursorErr(ctx, CursorPhaseDecode, err)
-			}
-			if cfg.DemoMode {
-				return fetchFirstPage(ctx, cfg)
-			}
-			return PageResult[T]{}, err
-		}
-		if err := ValidateCursorScope(cur, cfg.Sort, cfg.QueryCtx); err != nil {
-			if cfg.OnCursorErr != nil {
-				cfg.OnCursorErr(ctx, CursorPhaseScope, err)
-			}
-			if cfg.DemoMode {
-				return fetchFirstPage(ctx, cfg)
-			}
-			return PageResult[T]{}, err
-		}
-		cursorValues = cur.Values
+	cursorValues, fallback, err := resolveCursor(ctx, cfg)
+	if err != nil {
+		return PageResult[T]{}, err
+	}
+	if fallback {
+		return fetchFirstPage(ctx, cfg)
 	}
 
 	params := ListParams{
@@ -82,6 +66,40 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 	}
 
 	return BuildPageResult(items, cfg.Request.Limit, cfg.Codec, cfg.Sort, cfg.QueryCtx, cfg.Extract)
+}
+
+// resolveCursor decodes and validates the cursor token. Returns the keyset
+// values for the next page, or (nil, true, nil) when DemoMode absorbs a
+// stale cursor and the caller should fall back to the first page.
+func resolveCursor[T any](ctx context.Context, cfg PagedQueryConfig[T]) ([]any, bool, error) {
+	if cfg.Request.Cursor == "" {
+		return nil, false, nil
+	}
+
+	cur, err := cfg.Codec.Decode(cfg.Request.Cursor)
+	if err != nil {
+		reportCursorErr(ctx, cfg.OnCursorErr, CursorPhaseDecode, err)
+		if cfg.DemoMode {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+
+	if err := ValidateCursorScope(cur, cfg.Sort, cfg.QueryCtx); err != nil {
+		reportCursorErr(ctx, cfg.OnCursorErr, CursorPhaseScope, err)
+		if cfg.DemoMode {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+
+	return cur.Values, false, nil
+}
+
+func reportCursorErr(ctx context.Context, fn CursorErrorFunc, phase string, err error) {
+	if fn != nil {
+		fn(ctx, phase, err)
+	}
 }
 
 func fetchFirstPage[T any](ctx context.Context, cfg PagedQueryConfig[T]) (PageResult[T], error) {

--- a/pkg/query/paged_query_test.go
+++ b/pkg/query/paged_query_test.go
@@ -320,3 +320,45 @@ func TestExecutePagedQuery_DemoMode_False_StaleCursor_ReturnsError(t *testing.T)
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }
+
+func TestExecutePagedQuery_DemoMode_ScopeMismatch_ReturnsFirstPage(t *testing.T) {
+	codec := newTestCodec(t)
+	items := []testItem{
+		{Name: "apple", ID: "1"},
+		{Name: "banana", ID: "2"},
+	}
+	// Construct a valid HMAC token with wrong scope
+	differentSort := []SortColumn{{Name: "other", Direction: SortDESC}}
+	cur := Cursor{
+		Values:  []any{"v1"},
+		Scope:   SortScope(differentSort),
+		Context: QueryContext("endpoint", "test"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 10, Cursor: token}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
+		DemoMode: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, result.Items, 2)
+	assert.False(t, result.HasMore)
+}
+
+func TestExecutePagedQuery_DemoMode_FetchError_Propagated(t *testing.T) {
+	codec := newTestCodec(t)
+
+	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 10, Cursor: "garbage"}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"),
+		Fetch: func(context.Context, ListParams) ([]testItem, error) {
+			return nil, fmt.Errorf("db connection refused")
+		},
+		Extract:  testExtract,
+		DemoMode: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db connection refused")
+}

--- a/pkg/query/paged_query_test.go
+++ b/pkg/query/paged_query_test.go
@@ -321,13 +321,8 @@ func TestExecutePagedQuery_DemoMode_False_StaleCursor_ReturnsError(t *testing.T)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }
 
-func TestExecutePagedQuery_DemoMode_ScopeMismatch_ReturnsFirstPage(t *testing.T) {
+func TestExecutePagedQuery_DemoMode_ScopeMismatch_StillRejects(t *testing.T) {
 	codec := newTestCodec(t)
-	items := []testItem{
-		{Name: "apple", ID: "1"},
-		{Name: "banana", ID: "2"},
-	}
-	// Construct a valid HMAC token with wrong scope
 	differentSort := []SortColumn{{Name: "other", Direction: SortDESC}}
 	cur := Cursor{
 		Values:  []any{"v1"},
@@ -337,14 +332,15 @@ func TestExecutePagedQuery_DemoMode_ScopeMismatch_ReturnsFirstPage(t *testing.T)
 	token, err := codec.Encode(cur)
 	require.NoError(t, err)
 
-	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+	_, err = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
 		Codec: codec, Request: PageRequest{Limit: 10, Cursor: token}, Sort: pagedTestSort,
-		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 		DemoMode: true,
 	})
-	require.NoError(t, err)
-	assert.Len(t, result.Items, 2)
-	assert.False(t, result.HasMore)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }
 
 func TestExecutePagedQuery_DemoMode_FetchError_Propagated(t *testing.T) {

--- a/pkg/query/paged_query_test.go
+++ b/pkg/query/paged_query_test.go
@@ -1,0 +1,322 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testItem struct {
+	Name string
+	ID   string
+}
+
+var pagedTestSort = []SortColumn{
+	{Name: "name", Direction: SortASC},
+	{Name: "id", Direction: SortASC},
+}
+
+func testExtract(item testItem) []any {
+	return []any{item.Name, item.ID}
+}
+
+func testFieldValue(item testItem, field string) any {
+	switch field {
+	case "name":
+		return item.Name
+	case "id":
+		return item.ID
+	default:
+		return nil
+	}
+}
+
+func testCompareField(a, b testItem, field string) int {
+	av := testFieldValue(a, field).(string)
+	bv := testFieldValue(b, field).(string)
+	if av < bv {
+		return -1
+	}
+	if av > bv {
+		return 1
+	}
+	return 0
+}
+
+func newTestCodec(t *testing.T) *CursorCodec {
+	t.Helper()
+	codec, err := NewCursorCodec([]byte("test-paged-query-cursor-key-32b!"))
+	require.NoError(t, err)
+	return codec
+}
+
+func makeFetcher(items []testItem) func(context.Context, ListParams) ([]testItem, error) {
+	return func(_ context.Context, params ListParams) ([]testItem, error) {
+		sorted := make([]testItem, len(items))
+		copy(sorted, items)
+		Sort(sorted, params.Sort, testCompareField)
+		result, err := ApplyCursor(sorted, params, func(item testItem, field string) any {
+			return testFieldValue(item, field)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+}
+
+func TestExecutePagedQuery_FirstPage(t *testing.T) {
+	codec := newTestCodec(t)
+	items := []testItem{
+		{Name: "apple", ID: "1"},
+		{Name: "banana", ID: "2"},
+		{Name: "cherry", ID: "3"},
+		{Name: "date", ID: "4"},
+		{Name: "elderberry", ID: "5"},
+	}
+
+	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec:    codec,
+		Request:  PageRequest{Limit: 3},
+		Sort:     pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"),
+		Fetch:    makeFetcher(items),
+		Extract:  testExtract,
+	})
+	require.NoError(t, err)
+	assert.Len(t, result.Items, 3)
+	assert.True(t, result.HasMore)
+	assert.NotEmpty(t, result.NextCursor)
+}
+
+func TestExecutePagedQuery_SecondPage(t *testing.T) {
+	codec := newTestCodec(t)
+	items := []testItem{
+		{Name: "apple", ID: "1"},
+		{Name: "banana", ID: "2"},
+		{Name: "cherry", ID: "3"},
+		{Name: "date", ID: "4"},
+		{Name: "elderberry", ID: "5"},
+	}
+	qctx := QueryContext("endpoint", "test")
+
+	page1, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 3}, Sort: pagedTestSort, QueryCtx: qctx,
+		Fetch: makeFetcher(items), Extract: testExtract,
+	})
+	require.NoError(t, err)
+
+	page2, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 3, Cursor: page1.NextCursor}, Sort: pagedTestSort, QueryCtx: qctx,
+		Fetch: makeFetcher(items), Extract: testExtract,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page2.Items, 2)
+	assert.False(t, page2.HasMore)
+	assert.Empty(t, page2.NextCursor)
+}
+
+func TestExecutePagedQuery_LastPage_FewerThanLimit(t *testing.T) {
+	codec := newTestCodec(t)
+	items := []testItem{
+		{Name: "apple", ID: "1"},
+		{Name: "banana", ID: "2"},
+	}
+
+	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 10}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
+	})
+	require.NoError(t, err)
+	assert.Len(t, result.Items, 2)
+	assert.False(t, result.HasMore)
+	assert.Empty(t, result.NextCursor)
+}
+
+func TestExecutePagedQuery_Empty(t *testing.T) {
+	codec := newTestCodec(t)
+
+	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 10}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Items)
+	assert.False(t, result.HasMore)
+}
+
+func TestExecutePagedQuery_GarbageCursor(t *testing.T) {
+	codec := newTestCodec(t)
+
+	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+	})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+}
+
+func TestExecutePagedQuery_ScopeMismatch(t *testing.T) {
+	codec := newTestCodec(t)
+	differentSort := []SortColumn{{Name: "other", Direction: SortDESC}}
+	cur := Cursor{
+		Values:  []any{"v1"},
+		Scope:   SortScope(differentSort),
+		Context: QueryContext("endpoint", "test"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	_, err = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Cursor: token}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+	})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "sort scope mismatch", ecErr.Details["reason"])
+}
+
+func TestExecutePagedQuery_ContextMismatch(t *testing.T) {
+	codec := newTestCodec(t)
+	cur := Cursor{
+		Values:  []any{"v1", "v2"},
+		Scope:   SortScope(pagedTestSort),
+		Context: QueryContext("endpoint", "wrong-endpoint"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	_, err = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Cursor: token}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+	})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+	assert.Equal(t, "query context mismatch", ecErr.Details["reason"])
+}
+
+func TestExecutePagedQuery_OnCursorErr_Decode(t *testing.T) {
+	codec := newTestCodec(t)
+	var capturedPhase string
+	var capturedErr error
+
+	_, _ = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+		OnCursorErr: func(_ context.Context, phase string, err error) {
+			capturedPhase = phase
+			capturedErr = err
+		},
+	})
+
+	assert.Equal(t, "decode", capturedPhase)
+	assert.NotNil(t, capturedErr)
+}
+
+func TestExecutePagedQuery_OnCursorErr_Scope(t *testing.T) {
+	codec := newTestCodec(t)
+	differentSort := []SortColumn{{Name: "other", Direction: SortDESC}}
+	cur := Cursor{
+		Values:  []any{"v1"},
+		Scope:   SortScope(differentSort),
+		Context: QueryContext("endpoint", "test"),
+	}
+	token, err := codec.Encode(cur)
+	require.NoError(t, err)
+
+	var capturedPhase string
+	_, _ = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Cursor: token}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+		OnCursorErr: func(_ context.Context, phase string, _ error) {
+			capturedPhase = phase
+		},
+	})
+
+	assert.Equal(t, "scope", capturedPhase)
+}
+
+func TestExecutePagedQuery_OnCursorErr_NilDoesNotPanic(t *testing.T) {
+	codec := newTestCodec(t)
+
+	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+		OnCursorErr: nil,
+	})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+}
+
+func TestExecutePagedQuery_FetchErrorPropagated(t *testing.T) {
+	codec := newTestCodec(t)
+
+	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 10}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"),
+		Fetch: func(context.Context, ListParams) ([]testItem, error) {
+			return nil, fmt.Errorf("db connection refused")
+		},
+		Extract: testExtract,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db connection refused")
+}
+
+func TestExecutePagedQuery_NormalizesLimit(t *testing.T) {
+	codec := newTestCodec(t)
+	items := make([]testItem, 60)
+	for i := range items {
+		items[i] = testItem{Name: fmt.Sprintf("item-%03d", i), ID: fmt.Sprintf("%03d", i)}
+	}
+
+	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 0}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
+	})
+	require.NoError(t, err)
+	assert.Len(t, result.Items, DefaultPageSize)
+}
+
+func TestExecutePagedQuery_DemoMode_StaleCursor_ReturnsFirstPage(t *testing.T) {
+	codec := newTestCodec(t)
+	items := []testItem{
+		{Name: "apple", ID: "1"},
+		{Name: "banana", ID: "2"},
+	}
+
+	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Limit: 10, Cursor: "garbage"}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
+		DemoMode: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, result.Items, 2)
+	assert.False(t, result.HasMore)
+}
+
+func TestExecutePagedQuery_DemoMode_False_StaleCursor_ReturnsError(t *testing.T) {
+	codec := newTestCodec(t)
+
+	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
+		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
+		DemoMode: false,
+	})
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
+}


### PR DESCRIPTION
## Summary
- **WM-6-F6**: `ExecutePagedQuery[T]` generic helper replaces ~15-line cursor decode/validate/query/build pattern repeated across 5 services. Struct-based config (`PagedQueryConfig[T]`) with optional `OnCursorErr` callback and `DemoMode` flag.
- **WM-6-F7**: `LogCursorError` factory extracts `auditquery.logInvalidCursor` into `pkg/query`. All 5 pagination services now emit structured Info-level cursor error logs (slice, reason, error, request_id).
- **WM-6-F1**: `IsDemoKey` method + `KnownDemoKeys` var + `DemoMode` in `ExecutePagedQuery` — stale cursor in demo mode returns first page instead of 400 error.
- **CURSOR-TEST-01**: order-query handler test upgraded from 1-scenario to 3-scenario cursor regression (garbage, missing-scope, cross-context), matching the other 4 handlers.
- **CUR-HDL-01**: Service-level scope/context mismatch tests added to configread, featureflag, order-query.
- **TX-NIL-01**: txRunner nil-safe godoc added to 7 service `runInTx`/`runPersist` methods.

## Open-source references
- `ref: kubernetes/kubernetes etcd3/store.go` — continueToken versioning, path traversal defense
- `ref: ent/contrib entgql/pagination.go` — generic `Cursor[T]`, `CursorCodec` interface
- `ref: pilagod/gorm-cursor-paginator` — `CursorCodec` interface, sentinel errors

## Files changed (23)
**New** (4): `pkg/query/paged_query.go`, `paged_query_test.go`, `cursor_logger.go`, `cursor_logger_test.go`
**Modified**: `pkg/query/cursor.go` (IsDemoKey+KnownDemoKeys), 5x service.go (migration), 3x service_test.go (cursor error tests), 1x handler_test.go (3-scenario), 7x service.go (TX-NIL-01 godoc)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/query/... -count=1` — 63+ tests pass (14 new ExecutePagedQuery tests, 3 LogCursorError tests, 5 IsDemoKey tests)
- [x] `go test ./cells/... -count=1` — all 46 packages pass (including migrated services + new cursor error tests)
- [x] `go vet ./pkg/query/... ./cells/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)