### PR TITLE
refactor(cmd): PR-CMD CLI 工具链优化 (app 包提取 + fail-fast/dry-run + bin/ 输出)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,13 +41,6 @@ tmp/
 worktrees/
 .claude/scheduled_tasks.lock
 
-# Build output (root-level binaries from `go build ./cmd/...`)
-/gocell
-/core-bundle
-/iot-device
-/sso-bff
-/todo-order
-
 # Legacy src/ directory (flattened in PR#116, may contain stale build artifacts)
 src/
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ cover:
 clean:
 	rm -rf bin/
 	rm -f coverage.out
+	rm -f gocell core-bundle iot-device sso-bff todo-order
 
 # ---------------------------------------------------------------------------
 # Docker Compose lifecycle

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test validate generate cover clean \
+.PHONY: build check-build test validate generate cover clean \
         up down \
         test-integration \
         healthcheck-verify
@@ -7,9 +7,15 @@
 # Go targets
 # ---------------------------------------------------------------------------
 
+# build produces shippable binaries into bin/. Use `make check-build` when the
+# goal is a full-repo compile check (no artefacts) — mirrors the
+# Kubernetes/kratos/go-zero split between `verify` and `build`.
 build:
 	mkdir -p bin
 	go build -o bin/ ./cmd/... ./examples/...
+
+check-build:
+	go build ./...
 
 test:
 	go test ./... -count=1

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
 # ---------------------------------------------------------------------------
 
 build:
-	go build ./...
+	mkdir -p bin
+	go build -o bin/ ./cmd/... ./examples/...
 
 test:
 	go test ./... -count=1
@@ -24,8 +25,8 @@ cover:
 	go tool cover -func=coverage.out | tail -1
 
 clean:
+	rm -rf bin/
 	rm -f coverage.out
-	rm -f core-bundle gocell iot-device sso-bff todo-order
 
 # ---------------------------------------------------------------------------
 # Docker Compose lifecycle

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"flag"

--- a/cmd/gocell/app/check_test.go
+++ b/cmd/gocell/app/check_test.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"strings"

--- a/cmd/gocell/app/dispatch.go
+++ b/cmd/gocell/app/dispatch.go
@@ -13,6 +13,8 @@ import (
 // commands maps sub-command names to their run functions. It is kept
 // unexported so callers go through Dispatch, which enforces the error/usage
 // contract; tests in this package may reference it directly.
+// Black-box tests in the app_test package must go through Dispatch; direct
+// map mutation is not supported.
 var commands = map[string]func(args []string) error{
 	"validate": runValidate,
 	"scaffold": runScaffold,
@@ -24,6 +26,9 @@ var commands = map[string]func(args []string) error{
 // Dispatch runs the gocell sub-command identified by args[0] and returns a
 // process exit code (0 on success, 1 on usage / execution errors). Writes
 // errors to stderr; does not call os.Exit so callers keep control.
+//
+// Stability: internal. Used by cmd/gocell/main.go and in-tree smoke tests;
+// signature may change without notice.
 func Dispatch(args []string) int {
 	if len(args) < 1 {
 		PrintUsage()
@@ -43,6 +48,9 @@ func Dispatch(args []string) int {
 }
 
 // PrintUsage writes the top-level gocell usage summary to stdout.
+//
+// Stability: internal. Used by cmd/gocell/main.go and in-tree smoke tests;
+// signature may change without notice.
 func PrintUsage() {
 	fmt.Println("Usage: gocell <command> [args]")
 	fmt.Println()

--- a/cmd/gocell/app/dispatch.go
+++ b/cmd/gocell/app/dispatch.go
@@ -23,31 +23,45 @@ var commands = map[string]func(args []string) error{
 	"verify":   runVerify,
 }
 
+// Exit codes. Follows the common POSIX convention used by tools like go
+// itself: usage/misuse errors are distinct from runtime failures so CI
+// scripts can tell "CLI was invoked wrong" apart from "validation failed".
+const (
+	ExitOK      = 0 // success
+	ExitRuntime = 1 // sub-command returned an error (validation failure, IO, etc.)
+	ExitUsage   = 2 // caller passed wrong / unknown / missing arguments
+)
+
 // Dispatch runs the gocell sub-command identified by args[0] and returns a
-// process exit code (0 on success, 1 on usage / execution errors). Writes
-// errors to stderr; does not call os.Exit so callers keep control.
+// process exit code: ExitOK (0) on success, ExitUsage (2) when the caller
+// invokes gocell incorrectly, ExitRuntime (1) when the sub-command itself
+// returns an error. Writes errors to stderr; does not call os.Exit so
+// callers keep control.
 //
 // Stability: internal. Used by cmd/gocell/main.go and in-tree smoke tests;
 // signature may change without notice.
 func Dispatch(args []string) int {
 	if len(args) < 1 {
 		PrintUsage()
-		return 1
+		return ExitUsage
 	}
 	cmd, ok := commands[args[0]]
 	if !ok {
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
 		PrintUsage()
-		return 1
+		return ExitUsage
 	}
 	if err := cmd(args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
+		return ExitRuntime
 	}
-	return 0
+	return ExitOK
 }
 
-// PrintUsage writes the top-level gocell usage summary to stdout.
+// PrintUsage writes the top-level gocell usage summary to stdout, including a
+// one-line hint of the most-used flag per sub-command so `gocell` with no args
+// gives discoverable output. Full per-sub-command flag help is available via
+// `gocell <sub> -h`.
 //
 // Stability: internal. Used by cmd/gocell/main.go and in-tree smoke tests;
 // signature may change without notice.
@@ -55,9 +69,11 @@ func PrintUsage() {
 	fmt.Println("Usage: gocell <command> [args]")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  validate    Validate all metadata (blocking)")
-	fmt.Println("  scaffold    Generate new cell/slice/contract/journey")
-	fmt.Println("  generate    Generate assembly code and derived files")
-	fmt.Println("  check       Run targeted architecture analysis")
-	fmt.Println("  verify      Run tests (slice/cell/journey)")
+	fmt.Println("  validate    Validate all metadata (blocking)         [--root, --fail-fast]")
+	fmt.Println("  scaffold    Generate new cell/slice/contract/journey [--dry-run]")
+	fmt.Println("  generate    Generate assembly code and derived files [--id, --module]")
+	fmt.Println("  check       Run targeted architecture analysis        [contract-health | slice-coverage | ...]")
+	fmt.Println("  verify      Run tests (slice/cell/journey)           [--id, --files]")
+	fmt.Println()
+	fmt.Println("Run 'gocell <command> -h' for full flag help on a sub-command.")
 }

--- a/cmd/gocell/app/dispatch.go
+++ b/cmd/gocell/app/dispatch.go
@@ -1,0 +1,55 @@
+// Package app implements the gocell CLI command dispatch.
+//
+// It is importable from test packages so that assembly smoke tests and
+// higher-level integration drivers can exercise the full command pipeline
+// without shelling out to the built binary.
+package app
+
+import (
+	"fmt"
+	"os"
+)
+
+// commands maps sub-command names to their run functions. It is kept
+// unexported so callers go through Dispatch, which enforces the error/usage
+// contract; tests in this package may reference it directly.
+var commands = map[string]func(args []string) error{
+	"validate": runValidate,
+	"scaffold": runScaffold,
+	"generate": runGenerate,
+	"check":    runCheck,
+	"verify":   runVerify,
+}
+
+// Dispatch runs the gocell sub-command identified by args[0] and returns a
+// process exit code (0 on success, 1 on usage / execution errors). Writes
+// errors to stderr; does not call os.Exit so callers keep control.
+func Dispatch(args []string) int {
+	if len(args) < 1 {
+		PrintUsage()
+		return 1
+	}
+	cmd, ok := commands[args[0]]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+		PrintUsage()
+		return 1
+	}
+	if err := cmd(args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// PrintUsage writes the top-level gocell usage summary to stdout.
+func PrintUsage() {
+	fmt.Println("Usage: gocell <command> [args]")
+	fmt.Println()
+	fmt.Println("Commands:")
+	fmt.Println("  validate    Validate all metadata (blocking)")
+	fmt.Println("  scaffold    Generate new cell/slice/contract/journey")
+	fmt.Println("  generate    Generate assembly code and derived files")
+	fmt.Println("  check       Run targeted architecture analysis")
+	fmt.Println("  verify      Run tests (slice/cell/journey)")
+}

--- a/cmd/gocell/app/dispatch_test.go
+++ b/cmd/gocell/app/dispatch_test.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// captureDispatch runs Dispatch with args while capturing stdout and stderr
+// separately, so contract tests can assert which stream each message lands on.
+func captureDispatch(t *testing.T, args []string) (exit int, stdout, stderr string) {
+	t.Helper()
+
+	origOut, origErr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
+
+	doneOut, doneErr := make(chan struct{}), make(chan struct{})
+	var bufOut, bufErr bytes.Buffer
+	go func() { _, _ = io.Copy(&bufOut, rOut); close(doneOut) }()
+	go func() { _, _ = io.Copy(&bufErr, rErr); close(doneErr) }()
+
+	exit = Dispatch(args)
+	_ = wOut.Close()
+	_ = wErr.Close()
+	<-doneOut
+	<-doneErr
+	return exit, bufOut.String(), bufErr.String()
+}
+
+// TestDispatch_Contract pins the exit-code and stream-split behaviour of the
+// top-level entry point. Regressions here would otherwise only surface through
+// shell-level flake after merge; we want a fast CI guard. Kept table-driven
+// so new edge cases (e.g. `--help`) can be added without new test fns.
+func TestDispatch_Contract(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantExit     int
+		stdoutSub    []string // substrings expected on stdout
+		stderrSub    []string // substrings expected on stderr
+		stdoutNotSub []string // substrings that must NOT appear on stdout
+	}{
+		{
+			name:      "no args prints usage to stdout and returns 1",
+			args:      []string{},
+			wantExit:  1,
+			stdoutSub: []string{"Usage: gocell", "validate", "scaffold"},
+			// Usage itself is not an error condition, so nothing on stderr.
+		},
+		{
+			name:      "unknown command goes to stderr, usage to stdout, returns 1",
+			args:      []string{"bogus-command"},
+			wantExit:  1,
+			stdoutSub: []string{"Usage: gocell"},
+			stderrSub: []string{"unknown command: bogus-command"},
+		},
+		{
+			name:         "sub-command error goes to stderr, NOT stdout, returns 1",
+			args:         []string{"scaffold"}, // missing sub-kind → runScaffold returns error
+			wantExit:     1,
+			stderrSub:    []string{"error:", "usage: gocell scaffold"},
+			stdoutNotSub: []string{"error:"},
+		},
+		{
+			name:     "scaffold unknown kind returns 1 via sub-command error path",
+			args:     []string{"scaffold", "not-a-kind"},
+			wantExit: 1,
+			stderrSub: []string{
+				"error:",
+				"unknown scaffold type",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exit, stdout, stderr := captureDispatch(t, tt.args)
+			assert.Equal(t, tt.wantExit, exit,
+				"exit code mismatch\nstdout=%q\nstderr=%q", stdout, stderr)
+			for _, s := range tt.stdoutSub {
+				assert.Contains(t, stdout, s, "expected %q on stdout", s)
+			}
+			for _, s := range tt.stderrSub {
+				assert.Contains(t, stderr, s, "expected %q on stderr", s)
+			}
+			for _, s := range tt.stdoutNotSub {
+				assert.NotContains(t, stdout, s, "unexpected %q on stdout", s)
+			}
+		})
+	}
+}
+
+// TestDispatch_SuccessPath_ExitZero ensures the success branch (exit 0,
+// nothing on stderr) is also pinned. We drive it through `validate` against
+// a temp project with no metadata — it produces a clean pass and returns 0.
+func TestDispatch_SuccessPath_ExitZero(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/go.mod",
+		[]byte("module example.com/empty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exit, stdout, stderr := captureDispatch(t, []string{"validate", "--root", dir})
+	assert.Equal(t, 0, exit, "stderr=%q", stderr)
+	assert.Empty(t, strings.TrimSpace(stderr), "nothing on stderr for success")
+	assert.Contains(t, stdout, "Validation complete:", "summary line expected")
+}

--- a/cmd/gocell/app/dispatch_test.go
+++ b/cmd/gocell/app/dispatch_test.go
@@ -48,30 +48,30 @@ func TestDispatch_Contract(t *testing.T) {
 		stdoutNotSub []string // substrings that must NOT appear on stdout
 	}{
 		{
-			name:      "no args prints usage to stdout and returns 1",
+			name:      "no args prints usage to stdout and returns ExitUsage",
 			args:      []string{},
-			wantExit:  1,
+			wantExit:  ExitUsage,
 			stdoutSub: []string{"Usage: gocell", "validate", "scaffold"},
 			// Usage itself is not an error condition, so nothing on stderr.
 		},
 		{
-			name:      "unknown command goes to stderr, usage to stdout, returns 1",
+			name:      "unknown command returns ExitUsage (distinct from runtime error)",
 			args:      []string{"bogus-command"},
-			wantExit:  1,
+			wantExit:  ExitUsage,
 			stdoutSub: []string{"Usage: gocell"},
 			stderrSub: []string{"unknown command: bogus-command"},
 		},
 		{
-			name:         "sub-command error goes to stderr, NOT stdout, returns 1",
+			name:         "sub-command error returns ExitRuntime, stderr carries error",
 			args:         []string{"scaffold"}, // missing sub-kind → runScaffold returns error
-			wantExit:     1,
+			wantExit:     ExitRuntime,
 			stderrSub:    []string{"error:", "usage: gocell scaffold"},
 			stdoutNotSub: []string{"error:"},
 		},
 		{
-			name:     "scaffold unknown kind returns 1 via sub-command error path",
+			name:     "scaffold unknown kind returns ExitRuntime via sub-command error path",
 			args:     []string{"scaffold", "not-a-kind"},
-			wantExit: 1,
+			wantExit: ExitRuntime,
 			stderrSub: []string{
 				"error:",
 				"unknown scaffold type",
@@ -107,7 +107,7 @@ func TestDispatch_SuccessPath_ExitZero(t *testing.T) {
 		t.Fatal(err)
 	}
 	exit, stdout, stderr := captureDispatch(t, []string{"validate", "--root", dir})
-	assert.Equal(t, 0, exit, "stderr=%q", stderr)
+	assert.Equal(t, ExitOK, exit, "stderr=%q", stderr)
 	assert.Empty(t, strings.TrimSpace(stderr), "nothing on stderr for success")
 	assert.Contains(t, stdout, "Validation complete:", "summary line expected")
 }

--- a/cmd/gocell/app/generate.go
+++ b/cmd/gocell/app/generate.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"flag"
@@ -82,40 +82,37 @@ func generateAssembly(args []string) error {
 		return fmt.Errorf("generate boundary: %w", err)
 	}
 
-	// Determine entrypoint path from assembly metadata.
 	// ref: go-zero goctl — generated file paths driven by configuration
 	asm := project.Assemblies[*id]
 	entrypointRel := asm.Build.Entrypoint
 	if entrypointRel == "" {
 		entrypointRel = filepath.Join("cmd", *id, "main.go")
 	}
-	// The entrypoint path in assembly.yaml is relative to the project root.
-
 	entrypointPath := filepath.Join(root, entrypointRel)
-	if !isWithinRoot(root, entrypointPath) {
-		return fmt.Errorf("assembly %q build.entrypoint %q: path escapes project root", *id, entrypointRel)
+	if err := writeGeneratedFile(root, entrypointPath, entrypoint,
+		fmt.Sprintf("assembly %q build.entrypoint %q", *id, entrypointRel)); err != nil {
+		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(entrypointPath), 0o755); err != nil {
-		return fmt.Errorf("create entrypoint dir: %w", err)
-	}
-	if err := os.WriteFile(entrypointPath, entrypoint, 0o644); err != nil {
-		return fmt.Errorf("write entrypoint: %w", err)
-	}
-	fmt.Printf("Generated: %s\n", entrypointPath)
 
-	// Boundary goes into assemblies/{id}/generated/ (generated artifacts directory).
-	generatedDir := filepath.Join(root, "assemblies", *id, "generated")
-	if !isWithinRoot(root, generatedDir) {
-		return fmt.Errorf("assembly %q: generated dir escapes project root", *id)
-	}
-	if err := os.MkdirAll(generatedDir, 0o755); err != nil {
-		return fmt.Errorf("create generated dir: %w", err)
-	}
-	boundaryPath := filepath.Join(generatedDir, "boundary.yaml")
-	if err := os.WriteFile(boundaryPath, boundary, 0o644); err != nil {
-		return fmt.Errorf("write boundary: %w", err)
-	}
-	fmt.Printf("Generated: %s\n", boundaryPath)
+	// Boundary goes into assemblies/{id}/generated/.
+	boundaryPath := filepath.Join(root, "assemblies", *id, "generated", "boundary.yaml")
+	return writeGeneratedFile(root, boundaryPath, boundary,
+		fmt.Sprintf("assembly %q generated dir", *id))
+}
 
+// writeGeneratedFile creates parent dirs and writes content to outPath, after
+// verifying the path stays within root. label is used to identify the caller
+// in error messages (e.g. "assembly X build.entrypoint Y").
+func writeGeneratedFile(root, outPath string, content []byte, label string) error {
+	if !isWithinRoot(root, outPath) {
+		return fmt.Errorf("%s: path escapes project root", label)
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("%s: create dir: %w", label, err)
+	}
+	if err := os.WriteFile(outPath, content, 0o644); err != nil {
+		return fmt.Errorf("%s: write file: %w", label, err)
+	}
+	fmt.Printf("Generated: %s\n", outPath)
 	return nil
 }

--- a/cmd/gocell/app/generate.go
+++ b/cmd/gocell/app/generate.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/governance"
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
@@ -104,7 +105,7 @@ func generateAssembly(args []string) error {
 // verifying the path stays within root. label is used to identify the caller
 // in error messages (e.g. "assembly X build.entrypoint Y").
 func writeGeneratedFile(root, outPath string, content []byte, label string) error {
-	if !isWithinRoot(root, outPath) {
+	if !governance.IsWithinRoot(root, outPath) {
 		return fmt.Errorf("%s: path escapes project root", label)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {

--- a/cmd/gocell/app/helpers.go
+++ b/cmd/gocell/app/helpers.go
@@ -99,47 +99,6 @@ func formatResults(results []governance.ValidationResult) {
 	}
 }
 
-// isWithinRoot checks that target resolves to a path inside root.
-// Both sides are normalized to absolute paths, and symlinks are resolved
-// when possible, to prevent both relative-path and symlink-based bypasses.
-// SYNC: kernel/governance/helpers.go:isWithinRoot — keep in sync.
-func isWithinRoot(root, target string) bool {
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		return false
-	}
-	absTarget, err := filepath.Abs(target)
-	if err != nil {
-		return false
-	}
-	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
-		absRoot = resolved
-	}
-	if resolved, err := filepath.EvalSymlinks(absTarget); err == nil {
-		absTarget = resolved
-	} else {
-		// Resolve longest existing ancestor for non-existent paths.
-		absTarget = evalExistingPrefix(absTarget)
-	}
-	cleanRoot := absRoot + string(os.PathSeparator)
-	return strings.HasPrefix(absTarget, cleanRoot) || absTarget == absRoot
-}
-
-// evalExistingPrefix resolves symlinks on the longest existing ancestor of p,
-// then appends the non-existent suffix. This handles platforms where
-// intermediate directories are symlinks (e.g., macOS /tmp → /private/tmp).
-// SYNC: kernel/governance/helpers.go:evalExistingPrefix — keep in sync.
-func evalExistingPrefix(p string) string {
-	if resolved, err := filepath.EvalSymlinks(p); err == nil {
-		return resolved
-	}
-	parent := filepath.Dir(p)
-	if parent == p {
-		return p
-	}
-	return filepath.Join(evalExistingPrefix(parent), filepath.Base(p))
-}
-
 // printResult prints a single validation result in human-readable format.
 //
 // Output shape differs by what the finding is anchored to:

--- a/cmd/gocell/app/helpers.go
+++ b/cmd/gocell/app/helpers.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bufio"
@@ -41,8 +41,8 @@ func readModule(root string) (string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "module ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(rest), nil
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -50,6 +50,18 @@ func readModule(root string) (string, error) {
 	}
 
 	return "", fmt.Errorf("module directive not found in go.mod")
+}
+
+// formatResultsFailFast prints only the first error found and returns. It
+// emits no banner, no warnings, and no summary — giving CI a single, loud
+// signal. A caller that needs rich output should use formatResults instead.
+func formatResultsFailFast(results []governance.ValidationResult) {
+	for i := range results {
+		if results[i].Severity == governance.SeverityError {
+			printResult(results[i])
+			return
+		}
+	}
 }
 
 // formatResults prints validation results grouped by severity.

--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -397,55 +397,10 @@ func TestPrintTargetList(t *testing.T) {
 	printTargetList("Test", []string{"a", "b"})
 }
 
-func TestIsWithinRoot(t *testing.T) {
-	root := t.TempDir()
-
-	// Create a symlink inside root that points outside it.
-	outsideDir := t.TempDir()
-	symlink := filepath.Join(root, "escape-link")
-	if err := os.Symlink(outsideDir, symlink); err != nil {
-		t.Skipf("cannot create symlink: %v", err)
-	}
-
-	tests := []struct {
-		name   string
-		target string
-		want   bool
-	}{
-		{"child path", filepath.Join(root, "cmd", "main.go"), true},
-		{"root itself", root, true},
-		{"parent escape", filepath.Join(root, "..", "etc", "passwd"), false},
-		{"double escape", filepath.Join(root, "..", "..", "tmp"), false},
-		{"symlink escape", filepath.Join(symlink, "secret.txt"), false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isWithinRoot(root, tt.target)
-			if got != tt.want {
-				t.Errorf("isWithinRoot(%q, %q) = %v, want %v", root, tt.target, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestEvalExistingPrefix(t *testing.T) {
-	root := t.TempDir()
-
-	// Multi-level non-existent path: root exists, a/b/c does not.
-	deep := filepath.Join(root, "a", "b", "c")
-	got := evalExistingPrefix(deep)
-
-	// Result should start with the resolved root (handles macOS /tmp symlink).
-	resolved, err := filepath.EvalSymlinks(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(resolved, "a", "b", "c")
-	if got != want {
-		t.Errorf("evalExistingPrefix(%q) = %q, want %q", deep, got, want)
-	}
-}
+// TestIsWithinRoot / TestEvalExistingPrefix previously lived here as a copy
+// of kernel/governance's tests. Now that cmd/gocell/app delegates to the
+// exported governance.IsWithinRoot / EvalExistingPrefix, coverage lives in
+// kernel/governance/validate_test.go — no duplication here.
 
 func TestPrintResult(t *testing.T) {
 	// Should not panic.

--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"bytes"
@@ -13,7 +13,7 @@ import (
 
 func TestPrintUsage(t *testing.T) {
 	// Should not panic.
-	printUsage()
+	PrintUsage()
 }
 
 func TestFindRoot(t *testing.T) {

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -82,6 +82,7 @@ func TestRunScaffoldCell_DryRun_NoFileWritten(t *testing.T) {
 	assert.Contains(t, out, "dry-run", "output must mark dry-run mode")
 	assert.Contains(t, out, "cells/dry-cell/cell.yaml",
 		"dry-run must report the path that would be written")
+	assert.NotContains(t, out, "Created cell:", "dry-run must not emit a 'Created cell:' line")
 }
 
 func TestRunScaffoldSlice_DryRun_NoFileWritten(t *testing.T) {
@@ -96,11 +97,14 @@ func TestRunScaffoldSlice_DryRun_NoFileWritten(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(orig) })
 	require.NoError(t, os.Chdir(dir))
 
-	err := runScaffold([]string{"slice", "--id=dry-slice", "--cell=parent-cell", "--dry-run"})
-	require.NoError(t, err)
+	out := captureStdout(t, func() {
+		err := runScaffold([]string{"slice", "--id=dry-slice", "--cell=parent-cell", "--dry-run"})
+		require.NoError(t, err)
+	})
 
 	_, statErr := os.Stat(filepath.Join(dir, "cells", "parent-cell", "slices", "dry-slice", "slice.yaml"))
 	assert.True(t, os.IsNotExist(statErr), "dry-run must not create slice.yaml")
+	assert.NotContains(t, out, "Created slice:", "dry-run must not emit a 'Created slice:' line")
 }
 
 func TestRunScaffoldContract_DryRun_NoFileWritten(t *testing.T) {
@@ -113,12 +117,15 @@ func TestRunScaffoldContract_DryRun_NoFileWritten(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(orig) })
 	require.NoError(t, os.Chdir(dir))
 
-	err := runScaffold([]string{"contract",
-		"--id=http.dry.test.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
-	require.NoError(t, err)
+	out := captureStdout(t, func() {
+		err := runScaffold([]string{"contract",
+			"--id=http.dry.test.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
+		require.NoError(t, err)
+	})
 
 	_, statErr := os.Stat(filepath.Join(dir, "contracts", "http", "dry", "test", "v1", "contract.yaml"))
 	assert.True(t, os.IsNotExist(statErr), "dry-run must not create contract.yaml")
+	assert.NotContains(t, out, "Created contract:", "dry-run must not emit a 'Created contract:' line")
 }
 
 func TestRunScaffoldJourney_DryRun_NoFileWritten(t *testing.T) {
@@ -131,12 +138,39 @@ func TestRunScaffoldJourney_DryRun_NoFileWritten(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(orig) })
 	require.NoError(t, os.Chdir(dir))
 
-	err := runScaffold([]string{"journey",
-		"--id=J-dry", "--goal=test goal", "--team=squad", "--cells=a,b", "--dry-run"})
-	require.NoError(t, err)
+	out := captureStdout(t, func() {
+		err := runScaffold([]string{"journey",
+			"--id=J-dry", "--goal=test goal", "--team=squad", "--cells=a,b", "--dry-run"})
+		require.NoError(t, err)
+	})
 
 	_, statErr := os.Stat(filepath.Join(dir, "journeys", "J-dry.yaml"))
 	assert.True(t, os.IsNotExist(statErr), "dry-run must not create journey file")
+	assert.NotContains(t, out, "Created journey:", "dry-run must not emit a 'Created journey:' line")
+}
+
+// TestRunValidate_FailFast_ReturnsError checks that runValidate with --fail-fast
+// returns a non-nil error whose message contains "validation failed:" when there
+// are governance-rule violations. We build a minimal temp project with a cell.yaml
+// that parses successfully but triggers an FMT-02 error (invalid cell type).
+func TestRunValidate_FailFast_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	// Minimal go.mod so findRoot succeeds when --root is explicit.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+	// A cell.yaml with a valid id but an invalid type — triggers FMT-02 (SeverityError).
+	cellDir := filepath.Join(dir, "cells", "bad-cell")
+	require.NoError(t, os.MkdirAll(cellDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cellDir, "cell.yaml"),
+		[]byte("id: bad-cell\ntype: INVALID\nconsistencyLevel: L2\nowner:\n  team: squad\n  role: cell-owner\n"), 0o644))
+
+	var gotErr error
+	_ = captureStdout(t, func() {
+		gotErr = runValidate([]string{"--root", dir, "--fail-fast"})
+	})
+	require.Error(t, gotErr, "runValidate with --fail-fast must return error when validation errors exist")
+	assert.Contains(t, gotErr.Error(), "validation failed:",
+		"error message must contain 'validation failed:'")
 }
 
 // Dry-run must still fail-fast on invalid opts — this is the whole point: CI
@@ -174,4 +208,67 @@ func TestRunScaffoldCell_DryRun_DetectsConflict(t *testing.T) {
 	err := runScaffold([]string{"cell",
 		"--id=conflict-cell", "--team=squad", "--dry-run"})
 	require.Error(t, err, "dry-run must still surface conflicts")
+}
+
+// TestRunScaffoldSlice_DryRun_DetectsConflict mirrors the cell conflict test
+// for slice scaffolding.
+func TestRunScaffoldSlice_DryRun_DetectsConflict(t *testing.T) {
+	dir := t.TempDir()
+	// Create parent cell and a pre-existing slice target.
+	sliceDir := filepath.Join(dir, "cells", "my-cell", "slices", "conflict-slice")
+	require.NoError(t, os.MkdirAll(sliceDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "my-cell", "cell.yaml"),
+		[]byte("id: my-cell\ntype: core\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sliceDir, "slice.yaml"),
+		[]byte("id: conflict-slice\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"slice",
+		"--id=conflict-slice", "--cell=my-cell", "--dry-run"})
+	require.Error(t, err, "dry-run must still surface slice conflicts")
+}
+
+// TestRunScaffoldContract_DryRun_DetectsConflict mirrors the cell conflict test
+// for contract scaffolding.
+func TestRunScaffoldContract_DryRun_DetectsConflict(t *testing.T) {
+	dir := t.TempDir()
+	contractDir := filepath.Join(dir, "contracts", "http", "conflict", "api", "v1")
+	require.NoError(t, os.MkdirAll(contractDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(contractDir, "contract.yaml"),
+		[]byte("id: http.conflict.api.v1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"contract",
+		"--id=http.conflict.api.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
+	require.Error(t, err, "dry-run must still surface contract conflicts")
+}
+
+// TestRunScaffoldJourney_DryRun_DetectsConflict mirrors the cell conflict test
+// for journey scaffolding.
+func TestRunScaffoldJourney_DryRun_DetectsConflict(t *testing.T) {
+	dir := t.TempDir()
+	journeyDir := filepath.Join(dir, "journeys")
+	require.NoError(t, os.MkdirAll(journeyDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(journeyDir, "J-conflict.yaml"),
+		[]byte("id: J-conflict\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"journey",
+		"--id=conflict", "--goal=test goal", "--team=squad", "--cells=a", "--dry-run"})
+	require.Error(t, err, "dry-run must still surface journey conflicts")
 }

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -77,106 +77,14 @@ func TestRunValidate_FailFast_NoErrors_PrintsOK(t *testing.T) {
 		"fail-fast success output is the single-line ack")
 }
 
-// --- scaffold --dry-run ---
-
-func TestRunScaffoldCell_DryRun_NoFileWritten(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
-
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	out := captureStdout(t, func() {
-		err := runScaffold([]string{"cell", "--id=dry-cell", "--team=squad", "--dry-run"})
-		require.NoError(t, err)
-	})
-
-	_, statErr := os.Stat(filepath.Join(dir, "cells", "dry-cell", "cell.yaml"))
-	assert.True(t, os.IsNotExist(statErr), "dry-run must not create cell.yaml")
-
-	assert.Contains(t, out, "dry-run", "output must mark dry-run mode")
-	assert.Contains(t, out, "cells/dry-cell/cell.yaml",
-		"dry-run must report the path that would be written")
-	assert.NotContains(t, out, "Created cell:", "dry-run must not emit a 'Created cell:' line")
-}
-
-func TestRunScaffoldSlice_DryRun_NoFileWritten(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells", "parent-cell", "slices"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "parent-cell", "cell.yaml"),
-		[]byte("id: parent-cell\ntype: core\n"), 0o644))
-
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	out := captureStdout(t, func() {
-		err := runScaffold([]string{"slice", "--id=dry-slice", "--cell=parent-cell", "--dry-run"})
-		require.NoError(t, err)
-	})
-
-	_, statErr := os.Stat(filepath.Join(dir, "cells", "parent-cell", "slices", "dry-slice", "slice.yaml"))
-	assert.True(t, os.IsNotExist(statErr), "dry-run must not create slice.yaml")
-	assert.NotContains(t, out, "Created slice:", "dry-run must not emit a 'Created slice:' line")
-}
-
-func TestRunScaffoldContract_DryRun_NoFileWritten(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "contracts"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
-
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	out := captureStdout(t, func() {
-		err := runScaffold([]string{"contract",
-			"--id=http.dry.test.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
-		require.NoError(t, err)
-	})
-
-	_, statErr := os.Stat(filepath.Join(dir, "contracts", "http", "dry", "test", "v1", "contract.yaml"))
-	assert.True(t, os.IsNotExist(statErr), "dry-run must not create contract.yaml")
-	assert.NotContains(t, out, "Created contract:", "dry-run must not emit a 'Created contract:' line")
-}
-
-func TestRunScaffoldJourney_DryRun_NoFileWritten(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "journeys"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
-
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	out := captureStdout(t, func() {
-		err := runScaffold([]string{"journey",
-			"--id=J-dry", "--goal=test goal", "--team=squad", "--cells=a,b", "--dry-run"})
-		require.NoError(t, err)
-	})
-
-	_, statErr := os.Stat(filepath.Join(dir, "journeys", "J-dry.yaml"))
-	assert.True(t, os.IsNotExist(statErr), "dry-run must not create journey file")
-	assert.NotContains(t, out, "Created journey:", "dry-run must not emit a 'Created journey:' line")
-}
-
 // TestRunValidate_FailFast_ReturnsError checks that runValidate with --fail-fast
 // returns a non-nil error whose message contains "validation failed:" when there
 // are governance-rule violations. We build a minimal temp project with a cell.yaml
 // that parses successfully but triggers an FMT-02 error (invalid cell type).
 func TestRunValidate_FailFast_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	// Minimal go.mod so findRoot succeeds when --root is explicit.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
 		[]byte("module example.com/test\n"), 0o644))
-	// A cell.yaml with a valid id but an invalid type — triggers FMT-02 (SeverityError).
 	cellDir := filepath.Join(dir, "cells", "bad-cell")
 	require.NoError(t, os.MkdirAll(cellDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(cellDir, "cell.yaml"),
@@ -191,102 +99,147 @@ func TestRunValidate_FailFast_ReturnsError(t *testing.T) {
 		"error message must contain 'validation failed:'")
 }
 
+// --- scaffold --dry-run ---
+//
+// These tests drive runScaffoldWithRoot directly, bypassing runScaffold's
+// findRoot() / cwd dependency. Previously each test did os.Chdir(tempDir),
+// which serialises the whole test binary (F-SEC-03). With an explicit root
+// parameter, t.TempDir() is isolated by design.
+
+// setupProject writes go.mod and any extra subdirs inside a fresh tempdir,
+// returning the dir. Keeps the boilerplate out of each test body.
+func setupProject(t *testing.T, extraDirs ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+	for _, d := range extraDirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, d), 0o755))
+	}
+	return dir
+}
+
+func TestRunScaffoldCell_DryRun_NoFileWritten(t *testing.T) {
+	dir := setupProject(t, "cells")
+
+	out := captureStdout(t, func() {
+		err := runScaffoldWithRoot(dir,
+			[]string{"cell", "--id=dry-cell", "--team=squad", "--dry-run"})
+		require.NoError(t, err)
+	})
+
+	_, statErr := os.Stat(filepath.Join(dir, "cells", "dry-cell", "cell.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create cell.yaml")
+
+	assert.Contains(t, out, "dry-run", "output must mark dry-run mode")
+	assert.Contains(t, out, "cells/dry-cell/cell.yaml",
+		"dry-run must report the path that would be written")
+	assert.NotContains(t, out, "Created cell", "dry-run must not emit a 'Created cell' line")
+}
+
+func TestRunScaffoldSlice_DryRun_NoFileWritten(t *testing.T) {
+	dir := setupProject(t, "cells/parent-cell/slices")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "parent-cell", "cell.yaml"),
+		[]byte("id: parent-cell\ntype: core\n"), 0o644))
+
+	out := captureStdout(t, func() {
+		err := runScaffoldWithRoot(dir,
+			[]string{"slice", "--id=dry-slice", "--cell=parent-cell", "--dry-run"})
+		require.NoError(t, err)
+	})
+
+	_, statErr := os.Stat(filepath.Join(dir,
+		"cells", "parent-cell", "slices", "dry-slice", "slice.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create slice.yaml")
+	assert.NotContains(t, out, "Created slice", "dry-run must not emit a 'Created slice' line")
+}
+
+func TestRunScaffoldContract_DryRun_NoFileWritten(t *testing.T) {
+	dir := setupProject(t, "contracts")
+
+	out := captureStdout(t, func() {
+		err := runScaffoldWithRoot(dir, []string{"contract",
+			"--id=http.dry.test.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
+		require.NoError(t, err)
+	})
+
+	_, statErr := os.Stat(filepath.Join(dir,
+		"contracts", "http", "dry", "test", "v1", "contract.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create contract.yaml")
+	assert.NotContains(t, out, "Created contract", "dry-run must not emit a 'Created contract' line")
+}
+
+func TestRunScaffoldJourney_DryRun_NoFileWritten(t *testing.T) {
+	dir := setupProject(t, "journeys")
+
+	out := captureStdout(t, func() {
+		err := runScaffoldWithRoot(dir, []string{"journey",
+			"--id=J-dry", "--goal=test goal", "--team=squad", "--cells=a,b", "--dry-run"})
+		require.NoError(t, err)
+	})
+
+	_, statErr := os.Stat(filepath.Join(dir, "journeys", "J-dry.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create journey file")
+	assert.NotContains(t, out, "Created journey", "dry-run must not emit a 'Created journey' line")
+}
+
 // Dry-run must still fail-fast on invalid opts — this is the whole point: CI
 // pre-commit hooks can call `scaffold ... --dry-run` and stop on bad inputs
 // without leaving partial files behind.
 func TestRunScaffoldCell_DryRun_StillValidatesOpts(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
+	dir := setupProject(t, "cells")
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"cell", "--id=no-team", "--dry-run"})
+	err := runScaffoldWithRoot(dir,
+		[]string{"cell", "--id=no-team", "--dry-run"})
 	require.Error(t, err, "missing --team must fail even in dry-run")
 }
 
 // Dry-run must still detect existing target path — reporting "would create"
 // silently over an existing file would be misleading.
 func TestRunScaffoldCell_DryRun_DetectsConflict(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupProject(t)
 	target := filepath.Join(dir, "cells", "conflict-cell")
 	require.NoError(t, os.MkdirAll(target, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(target, "cell.yaml"),
 		[]byte("id: conflict-cell\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"cell",
+	err := runScaffoldWithRoot(dir, []string{"cell",
 		"--id=conflict-cell", "--team=squad", "--dry-run"})
 	require.Error(t, err, "dry-run must still surface conflicts")
 }
 
-// TestRunScaffoldSlice_DryRun_DetectsConflict mirrors the cell conflict test
-// for slice scaffolding.
 func TestRunScaffoldSlice_DryRun_DetectsConflict(t *testing.T) {
-	dir := t.TempDir()
-	// Create parent cell and a pre-existing slice target.
+	dir := setupProject(t)
 	sliceDir := filepath.Join(dir, "cells", "my-cell", "slices", "conflict-slice")
 	require.NoError(t, os.MkdirAll(sliceDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "my-cell", "cell.yaml"),
 		[]byte("id: my-cell\ntype: core\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(sliceDir, "slice.yaml"),
 		[]byte("id: conflict-slice\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"slice",
+	err := runScaffoldWithRoot(dir, []string{"slice",
 		"--id=conflict-slice", "--cell=my-cell", "--dry-run"})
 	require.Error(t, err, "dry-run must still surface slice conflicts")
 }
 
-// TestRunScaffoldContract_DryRun_DetectsConflict mirrors the cell conflict test
-// for contract scaffolding.
 func TestRunScaffoldContract_DryRun_DetectsConflict(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupProject(t)
 	contractDir := filepath.Join(dir, "contracts", "http", "conflict", "api", "v1")
 	require.NoError(t, os.MkdirAll(contractDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(contractDir, "contract.yaml"),
 		[]byte("id: http.conflict.api.v1\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"contract",
+	err := runScaffoldWithRoot(dir, []string{"contract",
 		"--id=http.conflict.api.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
 	require.Error(t, err, "dry-run must still surface contract conflicts")
 }
 
-// TestRunScaffoldJourney_DryRun_DetectsConflict mirrors the cell conflict test
-// for journey scaffolding.
 func TestRunScaffoldJourney_DryRun_DetectsConflict(t *testing.T) {
-	dir := t.TempDir()
-	journeyDir := filepath.Join(dir, "journeys")
-	require.NoError(t, os.MkdirAll(journeyDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(journeyDir, "J-conflict.yaml"),
+	dir := setupProject(t, "journeys")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "J-conflict.yaml"),
 		[]byte("id: J-conflict\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
-		[]byte("module example.com/test\n"), 0o644))
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"journey",
+	err := runScaffoldWithRoot(dir, []string{"journey",
 		"--id=conflict", "--goal=test goal", "--team=squad", "--cells=a", "--dry-run"})
 	require.Error(t, err, "dry-run must still surface journey conflicts")
 }

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/governance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- validate --fail-fast ---
+
+// formatResultsFailFast must print only the first error encountered, and then
+// stop — no "ERRORS (N):" banner, no warnings, no trailing summary. Errors
+// win over warnings regardless of slice order.
+func TestFormatResultsFailFast_FirstError(t *testing.T) {
+	results := []governance.ValidationResult{
+		{Code: "ADV-01", Severity: governance.SeverityWarning, Message: "warn first"},
+		{Code: "REF-01", Severity: governance.SeverityError, Message: "first error"},
+		{Code: "REF-02", Severity: governance.SeverityError, Message: "second error"},
+	}
+	out := captureStdout(t, func() { formatResultsFailFast(results) })
+	assert.Contains(t, out, "REF-01")
+	assert.Contains(t, out, "first error")
+	assert.NotContains(t, out, "REF-02", "second error must not be printed")
+	assert.NotContains(t, out, "second error")
+	assert.NotContains(t, out, "warn first", "warnings must not be printed in fail-fast")
+	assert.NotContains(t, out, "ERRORS (", "fail-fast mode skips the banner")
+}
+
+// When no errors exist, fail-fast acts as a no-op (no spurious output). The
+// caller is responsible for deciding success; formatResultsFailFast itself
+// only prints when an error is present.
+func TestFormatResultsFailFast_NoErrors(t *testing.T) {
+	results := []governance.ValidationResult{
+		{Code: "ADV-01", Severity: governance.SeverityWarning, Message: "just a warning"},
+	}
+	out := captureStdout(t, func() { formatResultsFailFast(results) })
+	assert.Empty(t, strings.TrimSpace(out), "no output expected when no errors: %q", out)
+}
+
+// runValidate --fail-fast on the live project: if errors exist it returns
+// error; the printed output must not include a "Validation complete:" summary
+// or a "WARNINGS (" banner. We only assert format invariants here — whether
+// there are errors or not depends on the repo state at test time.
+func TestRunValidate_FailFast_FormatInvariants(t *testing.T) {
+	root, err := findRoot()
+	require.NoError(t, err)
+
+	out := captureStdout(t, func() {
+		_ = runValidate([]string{"--root", root, "--fail-fast"})
+	})
+	assert.NotContains(t, out, "Validation complete:",
+		"fail-fast must not emit summary line")
+	assert.NotContains(t, out, "WARNINGS (",
+		"fail-fast must not emit warnings banner")
+}
+
+// --- scaffold --dry-run ---
+
+func TestRunScaffoldCell_DryRun_NoFileWritten(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	out := captureStdout(t, func() {
+		err := runScaffold([]string{"cell", "--id=dry-cell", "--team=squad", "--dry-run"})
+		require.NoError(t, err)
+	})
+
+	_, statErr := os.Stat(filepath.Join(dir, "cells", "dry-cell", "cell.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create cell.yaml")
+
+	assert.Contains(t, out, "dry-run", "output must mark dry-run mode")
+	assert.Contains(t, out, "cells/dry-cell/cell.yaml",
+		"dry-run must report the path that would be written")
+}
+
+func TestRunScaffoldSlice_DryRun_NoFileWritten(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells", "parent-cell", "slices"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "parent-cell", "cell.yaml"),
+		[]byte("id: parent-cell\ntype: core\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"slice", "--id=dry-slice", "--cell=parent-cell", "--dry-run"})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(dir, "cells", "parent-cell", "slices", "dry-slice", "slice.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create slice.yaml")
+}
+
+func TestRunScaffoldContract_DryRun_NoFileWritten(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "contracts"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"contract",
+		"--id=http.dry.test.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(dir, "contracts", "http", "dry", "test", "v1", "contract.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create contract.yaml")
+}
+
+func TestRunScaffoldJourney_DryRun_NoFileWritten(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "journeys"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"journey",
+		"--id=J-dry", "--goal=test goal", "--team=squad", "--cells=a,b", "--dry-run"})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(dir, "journeys", "J-dry.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not create journey file")
+}
+
+// Dry-run must still fail-fast on invalid opts — this is the whole point: CI
+// pre-commit hooks can call `scaffold ... --dry-run` and stop on bad inputs
+// without leaving partial files behind.
+func TestRunScaffoldCell_DryRun_StillValidatesOpts(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"cell", "--id=no-team", "--dry-run"})
+	require.Error(t, err, "missing --team must fail even in dry-run")
+}
+
+// Dry-run must still detect existing target path — reporting "would create"
+// silently over an existing file would be misleading.
+func TestRunScaffoldCell_DryRun_DetectsConflict(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "cells", "conflict-cell")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "cell.yaml"),
+		[]byte("id: conflict-cell\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	require.NoError(t, os.Chdir(dir))
+
+	err := runScaffold([]string{"cell",
+		"--id=conflict-cell", "--team=squad", "--dry-run"})
+	require.Error(t, err, "dry-run must still surface conflicts")
+}

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -59,6 +59,24 @@ func TestRunValidate_FailFast_FormatInvariants(t *testing.T) {
 		"fail-fast must not emit warnings banner")
 }
 
+// Output contract for --fail-fast on a clean project: prints exactly
+// "OK: no errors." and returns nil. Locking this in so that future refactors
+// (e.g. "make fail-fast silent for scripting") become an explicit decision
+// rather than an accidental behaviour drift.
+func TestRunValidate_FailFast_NoErrors_PrintsOK(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/empty\n"), 0o644))
+
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runValidate([]string{"--root", dir, "--fail-fast"})
+	})
+	require.NoError(t, gotErr, "empty project must validate cleanly in fail-fast")
+	assert.Equal(t, "OK: no errors.\n", out,
+		"fail-fast success output is the single-line ack")
+}
+
 // --- scaffold --dry-run ---
 
 func TestRunScaffoldCell_DryRun_NoFileWritten(t *testing.T) {

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -28,17 +28,28 @@ const (
 // --dry-run validates opts and detects path conflicts without writing files;
 // CI pre-commit hooks can use it to fail fast on bad inputs.
 func runScaffold(args []string) error {
+	// Check args shape before resolving project root — lets callers
+	// (and tests) hit the usage error path without a valid cwd/go.mod.
+	if len(args) < 1 {
+		return fmt.Errorf("usage: gocell scaffold <cell|slice|contract|journey> [flags]")
+	}
+	root, err := findRoot()
+	if err != nil {
+		return fmt.Errorf("cannot find project root: %w", err)
+	}
+	return runScaffoldWithRoot(root, args)
+}
+
+// runScaffoldWithRoot dispatches a scaffold sub-command against an explicit
+// project root — decoupling the dispatch from process cwd so tests can drive
+// a temp directory without os.Chdir (which serialises the whole test binary).
+func runScaffoldWithRoot(root string, args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: gocell scaffold <cell|slice|contract|journey> [flags]")
 	}
 
 	subtype := args[0]
 	subArgs := args[1:]
-
-	root, err := findRoot()
-	if err != nil {
-		return fmt.Errorf("cannot find project root: %w", err)
-	}
 
 	switch subtype {
 	case "cell":
@@ -54,13 +65,23 @@ func runScaffold(args []string) error {
 	}
 }
 
+// scaffoldReport carries everything reportScaffold needs. Using a struct
+// instead of positional params makes call sites self-describing and safer
+// against future additions (e.g. a template-version field).
+type scaffoldReport struct {
+	DryRun bool
+	Kind   string // "cell" | "slice" | "contract" | "journey"
+	ID     string // user-visible identifier
+	Target string // path that was or would have been written
+}
+
 // reportScaffold prints the standard success line, switching prefix in dry-run.
-func reportScaffold(dryRun bool, kind, id, target string) {
-	if dryRun {
-		fmt.Printf("(dry-run) Would create %s %s at %s\n", kind, id, target)
+func reportScaffold(r scaffoldReport) {
+	if r.DryRun {
+		fmt.Printf("(dry-run) Would create %s %s at %s\n", r.Kind, r.ID, r.Target)
 		return
 	}
-	fmt.Printf("Created %s %s at %s\n", kind, id, target)
+	fmt.Printf("Created %s %s at %s\n", r.Kind, r.ID, r.Target)
 }
 
 func scaffoldCell(root string, args []string) error {
@@ -91,8 +112,12 @@ func scaffoldCell(root string, args []string) error {
 		return err
 	}
 
-	target := filepath.Join("cells", *id, "cell.yaml")
-	reportScaffold(*dryRun, "cell", *id, target)
+	reportScaffold(scaffoldReport{
+		DryRun: *dryRun,
+		Kind:   "cell",
+		ID:     *id,
+		Target: filepath.Join("cells", *id, "cell.yaml"),
+	})
 	return nil
 }
 
@@ -120,8 +145,12 @@ func scaffoldSlice(root string, args []string) error {
 		return err
 	}
 
-	target := filepath.Join("cells", *cellID, "slices", *id, "slice.yaml")
-	reportScaffold(*dryRun, "slice", *cellID+"/"+*id, target)
+	reportScaffold(scaffoldReport{
+		DryRun: *dryRun,
+		Kind:   "slice",
+		ID:     *cellID + "/" + *id,
+		Target: filepath.Join("cells", *cellID, "slices", *id, "slice.yaml"),
+	})
 	return nil
 }
 
@@ -157,8 +186,12 @@ func scaffoldContract(root string, args []string) error {
 	// Contract ID format: {kind}.{domain...}.{version}
 	pathParts := append([]string{"contracts"}, strings.Split(*id, ".")...)
 	pathParts = append(pathParts, "contract.yaml")
-	target := filepath.Join(pathParts...)
-	reportScaffold(*dryRun, "contract", *id, target)
+	reportScaffold(scaffoldReport{
+		DryRun: *dryRun,
+		Kind:   "contract",
+		ID:     *id,
+		Target: filepath.Join(pathParts...),
+	})
 	return nil
 }
 
@@ -206,7 +239,11 @@ func scaffoldJourney(root string, args []string) error {
 	if !strings.HasPrefix(fileID, "J-") {
 		fileID = "J-" + fileID
 	}
-	target := filepath.Join("journeys", fileID+".yaml")
-	reportScaffold(*dryRun, "journey", *id, target)
+	reportScaffold(scaffoldReport{
+		DryRun: *dryRun,
+		Kind:   "journey",
+		ID:     *id,
+		Target: filepath.Join("journeys", fileID+".yaml"),
+	})
 	return nil
 }

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -51,7 +51,7 @@ func reportScaffold(dryRun bool, kind, id, target string) {
 		fmt.Printf("(dry-run) Would create %s %s at %s\n", kind, id, target)
 		return
 	}
-	fmt.Printf("Created %s: %s\n", kind, id)
+	fmt.Printf("Created %s %s at %s\n", kind, id, target)
 }
 
 func scaffoldCell(root string, args []string) error {

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -9,6 +9,15 @@ import (
 	"github.com/ghbvf/gocell/kernel/scaffold"
 )
 
+// Shared flag name + usage for scaffold sub-commands. Constants avoid the
+// "magic string" duplication SonarCloud flags across scaffoldCell/Slice/
+// Contract/Journey; also makes it safe to rename in one place if the CLI
+// convention evolves.
+const (
+	dryRunFlag  = "dry-run"
+	dryRunUsage = "validate inputs and path conflict; do not write files"
+)
+
 // runScaffold implements:
 //
 //	gocell scaffold cell --id=<id> [--type=core] [--level=L2] [--team=<team>] [--dry-run]
@@ -60,7 +69,7 @@ func scaffoldCell(root string, args []string) error {
 	cellType := fs.String("type", "core", "cell type")
 	level := fs.String("level", "L2", "consistency level")
 	team := fs.String("team", "", "owner team (required)")
-	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
+	dryRun := fs.Bool(dryRunFlag, false, dryRunUsage)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -91,7 +100,7 @@ func scaffoldSlice(root string, args []string) error {
 	fs := flag.NewFlagSet("scaffold slice", flag.ContinueOnError)
 	id := fs.String("id", "", "slice ID (required)")
 	cellID := fs.String("cell", "", "parent cell ID (required)")
-	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
+	dryRun := fs.Bool(dryRunFlag, false, dryRunUsage)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -121,7 +130,7 @@ func scaffoldContract(root string, args []string) error {
 	id := fs.String("id", "", "contract ID (required)")
 	kind := fs.String("kind", "", "contract kind: http|event|command|projection (required)")
 	owner := fs.String("owner", "", "owner cell ID (required)")
-	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
+	dryRun := fs.Bool(dryRunFlag, false, dryRunUsage)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -159,7 +168,7 @@ func scaffoldJourney(root string, args []string) error {
 	goal := fs.String("goal", "", "journey goal (required)")
 	team := fs.String("team", "", "owner team (required)")
 	cells := fs.String("cells", "", "comma-separated cell IDs (required)")
-	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
+	dryRun := fs.Bool(dryRunFlag, false, dryRunUsage)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -1,8 +1,9 @@
-package main
+package app
 
 import (
 	"flag"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/ghbvf/gocell/kernel/scaffold"
@@ -10,10 +11,13 @@ import (
 
 // runScaffold implements:
 //
-//	gocell scaffold cell --id=<id> [--type=core] [--level=L2] [--team=<team>]
-//	gocell scaffold slice --id=<id> --cell=<cellID>
-//	gocell scaffold contract --id=<id> --kind=<kind> --owner=<cellID>
-//	gocell scaffold journey --id=<id> --goal=<goal> [--team=<team>] [--cells=<a,b>]
+//	gocell scaffold cell --id=<id> [--type=core] [--level=L2] [--team=<team>] [--dry-run]
+//	gocell scaffold slice --id=<id> --cell=<cellID> [--dry-run]
+//	gocell scaffold contract --id=<id> --kind=<kind> --owner=<cellID> [--dry-run]
+//	gocell scaffold journey --id=<id> --goal=<goal> [--team=<team>] [--cells=<a,b>] [--dry-run]
+//
+// --dry-run validates opts and detects path conflicts without writing files;
+// CI pre-commit hooks can use it to fail fast on bad inputs.
 func runScaffold(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: gocell scaffold <cell|slice|contract|journey> [flags]")
@@ -26,28 +30,37 @@ func runScaffold(args []string) error {
 	if err != nil {
 		return fmt.Errorf("cannot find project root: %w", err)
 	}
-	s := scaffold.New(root)
 
 	switch subtype {
 	case "cell":
-		return scaffoldCell(s, subArgs)
+		return scaffoldCell(root, subArgs)
 	case "slice":
-		return scaffoldSlice(s, subArgs)
+		return scaffoldSlice(root, subArgs)
 	case "contract":
-		return scaffoldContract(s, subArgs)
+		return scaffoldContract(root, subArgs)
 	case "journey":
-		return scaffoldJourney(s, subArgs)
+		return scaffoldJourney(root, subArgs)
 	default:
 		return fmt.Errorf("unknown scaffold type: %s (expected cell, slice, contract, or journey)", subtype)
 	}
 }
 
-func scaffoldCell(s *scaffold.Scaffolder, args []string) error {
+// reportScaffold prints the standard success line, switching prefix in dry-run.
+func reportScaffold(dryRun bool, kind, id, target string) {
+	if dryRun {
+		fmt.Printf("(dry-run) Would create %s %s at %s\n", kind, id, target)
+		return
+	}
+	fmt.Printf("Created %s: %s\n", kind, id)
+}
+
+func scaffoldCell(root string, args []string) error {
 	fs := flag.NewFlagSet("scaffold cell", flag.ContinueOnError)
 	id := fs.String("id", "", "cell ID (required)")
 	cellType := fs.String("type", "core", "cell type")
 	level := fs.String("level", "L2", "consistency level")
 	team := fs.String("team", "", "owner team (required)")
+	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -59,6 +72,7 @@ func scaffoldCell(s *scaffold.Scaffolder, args []string) error {
 		return fmt.Errorf("--team is required")
 	}
 
+	s := scaffold.New(root).WithDryRun(*dryRun)
 	if err := s.CreateCell(scaffold.CellOpts{
 		ID:               *id,
 		Type:             *cellType,
@@ -68,14 +82,16 @@ func scaffoldCell(s *scaffold.Scaffolder, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Created cell: %s\n", *id)
+	target := filepath.Join("cells", *id, "cell.yaml")
+	reportScaffold(*dryRun, "cell", *id, target)
 	return nil
 }
 
-func scaffoldSlice(s *scaffold.Scaffolder, args []string) error {
+func scaffoldSlice(root string, args []string) error {
 	fs := flag.NewFlagSet("scaffold slice", flag.ContinueOnError)
 	id := fs.String("id", "", "slice ID (required)")
 	cellID := fs.String("cell", "", "parent cell ID (required)")
+	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -87,6 +103,7 @@ func scaffoldSlice(s *scaffold.Scaffolder, args []string) error {
 		return fmt.Errorf("--cell is required")
 	}
 
+	s := scaffold.New(root).WithDryRun(*dryRun)
 	if err := s.CreateSlice(scaffold.SliceOpts{
 		ID:     *id,
 		CellID: *cellID,
@@ -94,15 +111,17 @@ func scaffoldSlice(s *scaffold.Scaffolder, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Created slice: %s/%s\n", *cellID, *id)
+	target := filepath.Join("cells", *cellID, "slices", *id, "slice.yaml")
+	reportScaffold(*dryRun, "slice", *cellID+"/"+*id, target)
 	return nil
 }
 
-func scaffoldContract(s *scaffold.Scaffolder, args []string) error {
+func scaffoldContract(root string, args []string) error {
 	fs := flag.NewFlagSet("scaffold contract", flag.ContinueOnError)
 	id := fs.String("id", "", "contract ID (required)")
 	kind := fs.String("kind", "", "contract kind: http|event|command|projection (required)")
 	owner := fs.String("owner", "", "owner cell ID (required)")
+	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -117,6 +136,7 @@ func scaffoldContract(s *scaffold.Scaffolder, args []string) error {
 		return fmt.Errorf("--owner is required")
 	}
 
+	s := scaffold.New(root).WithDryRun(*dryRun)
 	if err := s.CreateContract(scaffold.ContractOpts{
 		ID:        *id,
 		Kind:      *kind,
@@ -125,16 +145,21 @@ func scaffoldContract(s *scaffold.Scaffolder, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Created contract: %s\n", *id)
+	// Contract ID format: {kind}.{domain...}.{version}
+	pathParts := append([]string{"contracts"}, strings.Split(*id, ".")...)
+	pathParts = append(pathParts, "contract.yaml")
+	target := filepath.Join(pathParts...)
+	reportScaffold(*dryRun, "contract", *id, target)
 	return nil
 }
 
-func scaffoldJourney(s *scaffold.Scaffolder, args []string) error {
+func scaffoldJourney(root string, args []string) error {
 	fs := flag.NewFlagSet("scaffold journey", flag.ContinueOnError)
 	id := fs.String("id", "", "journey ID (required)")
 	goal := fs.String("goal", "", "journey goal (required)")
 	team := fs.String("team", "", "owner team (required)")
 	cells := fs.String("cells", "", "comma-separated cell IDs (required)")
+	dryRun := fs.Bool("dry-run", false, "validate inputs and path conflict; do not write files")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -157,6 +182,7 @@ func scaffoldJourney(s *scaffold.Scaffolder, args []string) error {
 		cellList[i] = strings.TrimSpace(cellList[i])
 	}
 
+	s := scaffold.New(root).WithDryRun(*dryRun)
 	if err := s.CreateJourney(scaffold.JourneyOpts{
 		ID:        *id,
 		Goal:      *goal,
@@ -166,6 +192,12 @@ func scaffoldJourney(s *scaffold.Scaffolder, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Created journey: %s\n", *id)
+	// Kernel scaffold normalizes ID to carry J- prefix for the filename.
+	fileID := *id
+	if !strings.HasPrefix(fileID, "J-") {
+		fileID = "J-" + fileID
+	}
+	target := filepath.Join("journeys", fileID+".yaml")
+	reportScaffold(*dryRun, "journey", *id, target)
 	return nil
 }

--- a/cmd/gocell/app/scaffold_verify_test.go
+++ b/cmd/gocell/app/scaffold_verify_test.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"os"

--- a/cmd/gocell/app/scaffold_verify_test.go
+++ b/cmd/gocell/app/scaffold_verify_test.go
@@ -10,21 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// These happy-path tests now go through runScaffoldWithRoot so they can run
+// against t.TempDir without needing os.Chdir — see F-SEC-03 in review PR#164.
+
 func TestRunScaffoldCell_Success(t *testing.T) {
 	dir := t.TempDir()
-	// Create minimal project structure for scaffolder.
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
 
-	// Save and restore cwd.
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"cell", "--id=test-cell", "--team=squad"})
+	err := runScaffoldWithRoot(dir,
+		[]string{"cell", "--id=test-cell", "--team=squad"})
 	require.NoError(t, err)
 
-	// Verify cell.yaml was created.
 	_, statErr := os.Stat(filepath.Join(dir, "cells", "test-cell", "cell.yaml"))
 	assert.NoError(t, statErr)
 }
@@ -32,41 +30,35 @@ func TestRunScaffoldCell_Success(t *testing.T) {
 func TestRunScaffoldSlice_Success(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cells", "test-cell", "slices"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "test-cell", "cell.yaml"),
 		[]byte("id: test-cell\ntype: core\n"), 0o644))
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"slice", "--id=my-slice", "--cell=test-cell"})
+	err := runScaffoldWithRoot(dir,
+		[]string{"slice", "--id=my-slice", "--cell=test-cell"})
 	require.NoError(t, err)
 }
 
 func TestRunScaffoldContract_Success(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "contracts"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"contract", "--id=http.test.v1", "--kind=http", "--owner=test-cell"})
+	err := runScaffoldWithRoot(dir,
+		[]string{"contract", "--id=http.test.v1", "--kind=http", "--owner=test-cell"})
 	require.NoError(t, err)
 }
 
 func TestRunScaffoldJourney_Success(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "journeys"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n"), 0o644))
 
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { os.Chdir(orig) })
-	require.NoError(t, os.Chdir(dir))
-
-	err := runScaffold([]string{"journey", "--id=J-test", "--goal=test goal", "--team=squad", "--cells=a,b"})
+	err := runScaffoldWithRoot(dir,
+		[]string{"journey", "--id=J-test", "--goal=test goal", "--team=squad", "--cells=a,b"})
 	require.NoError(t, err)
 }
 

--- a/cmd/gocell/app/validate.go
+++ b/cmd/gocell/app/validate.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"flag"
@@ -14,6 +14,8 @@ import (
 func runValidate(args []string) error {
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
 	root := fs.String("root", "", "project root directory (default: auto-detect from go.mod)")
+	failFast := fs.Bool("fail-fast", false,
+		"print only the first error and exit; skip warnings and summary (CI-friendly)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -45,6 +47,14 @@ func runValidate(args []string) error {
 	// Merge all results.
 	allResults := append(valResults, depResults...)
 
+	if *failFast {
+		if firstErr := firstError(allResults); firstErr != nil {
+			formatResultsFailFast(allResults)
+			return fmt.Errorf("validation failed: %s", firstErr.Code)
+		}
+		return nil
+	}
+
 	// Output results.
 	formatResults(allResults)
 
@@ -63,6 +73,16 @@ func runValidate(args []string) error {
 
 	if errCount > 0 {
 		return fmt.Errorf("validation failed with %d error(s)", errCount)
+	}
+	return nil
+}
+
+// firstError returns the first result whose severity is error, or nil.
+func firstError(results []governance.ValidationResult) *governance.ValidationResult {
+	for i := range results {
+		if results[i].Severity == governance.SeverityError {
+			return &results[i]
+		}
 	}
 	return nil
 }

--- a/cmd/gocell/app/validate.go
+++ b/cmd/gocell/app/validate.go
@@ -12,14 +12,15 @@ import (
 // Parses all metadata, runs validate-meta and depcheck.
 // exit 0 = pass, exit 1 = errors found.
 //
-// --fail-fast controls output, not traversal: the validator always evaluates all
-// rules; only the printed output is short-circuited. With the flag set, only the
-// first error encountered is printed and banners/summary are suppressed.
+// --fail-fast: true short-circuit. The validator and the dependency checker
+// stop at the first rule that produces a SeverityError — subsequent rules do
+// not run, which is the point of the flag for CI pipelines over large repos.
+// Output is also trimmed to a single error line.
 func runValidate(args []string) error {
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
 	root := fs.String("root", "", "project root directory (default: auto-detect from go.mod)")
 	failFast := fs.Bool("fail-fast", false,
-		"print only the first error encountered and skip banners/summary; the validator still evaluates all rules (this flag controls output, not traversal)")
+		"stop at the first error and skip remaining rules; trims output to that error (CI-friendly)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -40,27 +41,30 @@ func runValidate(args []string) error {
 		return fmt.Errorf("metadata parse: %w", err)
 	}
 
-	// Run validation rules.
 	validator := governance.NewValidator(project, rootDir)
-	valResults := validator.Validate()
-
-	// Run dependency checks.
 	depChecker := governance.NewDependencyChecker(project)
-	depResults := depChecker.Check()
-
-	// Merge all results.
-	allResults := append(valResults, depResults...)
 
 	if *failFast {
-		if firstErr := firstError(allResults); firstErr != nil {
-			formatResultsFailFast(allResults)
+		// True bailout: validator first (most errors originate there); if it
+		// already flagged an error, depcheck is skipped entirely.
+		valResults := validator.ValidateFailFast()
+		if firstErr := firstError(valResults); firstErr != nil {
+			formatResultsFailFast(valResults)
+			return fmt.Errorf("validation failed: %s", firstErr.Code)
+		}
+		depResults := depChecker.CheckFailFast()
+		if firstErr := firstError(depResults); firstErr != nil {
+			formatResultsFailFast(depResults)
 			return fmt.Errorf("validation failed: %s", firstErr.Code)
 		}
 		fmt.Println("OK: no errors.")
 		return nil
 	}
 
-	// Output results.
+	valResults := validator.Validate()
+	depResults := depChecker.Check()
+	allResults := append(valResults, depResults...)
+
 	formatResults(allResults)
 
 	// Summary.

--- a/cmd/gocell/app/validate.go
+++ b/cmd/gocell/app/validate.go
@@ -11,11 +11,15 @@ import (
 // runValidate implements: gocell validate [--root <path>]
 // Parses all metadata, runs validate-meta and depcheck.
 // exit 0 = pass, exit 1 = errors found.
+//
+// --fail-fast controls output, not traversal: the validator always evaluates all
+// rules; only the printed output is short-circuited. With the flag set, only the
+// first error encountered is printed and banners/summary are suppressed.
 func runValidate(args []string) error {
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
 	root := fs.String("root", "", "project root directory (default: auto-detect from go.mod)")
 	failFast := fs.Bool("fail-fast", false,
-		"print only the first error and exit; skip warnings and summary (CI-friendly)")
+		"print only the first error encountered and skip banners/summary; the validator still evaluates all rules (this flag controls output, not traversal)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -52,6 +56,7 @@ func runValidate(args []string) error {
 			formatResultsFailFast(allResults)
 			return fmt.Errorf("validation failed: %s", firstErr.Code)
 		}
+		fmt.Println("OK: no errors.")
 		return nil
 	}
 

--- a/cmd/gocell/app/verify.go
+++ b/cmd/gocell/app/verify.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"context"

--- a/cmd/gocell/main.go
+++ b/cmd/gocell/main.go
@@ -1,42 +1,15 @@
+// Command gocell is the GoCell metadata / scaffolding CLI entry point.
+//
+// All command logic lives in the importable cmd/gocell/app package so that
+// smoke tests and higher-level drivers can invoke the dispatcher directly.
 package main
 
 import (
-	"fmt"
 	"os"
+
+	"github.com/ghbvf/gocell/cmd/gocell/app"
 )
 
-var commands = map[string]func(args []string) error{
-	"validate": runValidate,
-	"scaffold": runScaffold,
-	"generate": runGenerate,
-	"check":    runCheck,
-	"verify":   runVerify,
-}
-
 func main() {
-	if len(os.Args) < 2 {
-		printUsage()
-		os.Exit(1)
-	}
-	cmd, ok := commands[os.Args[1]]
-	if !ok {
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
-		printUsage()
-		os.Exit(1)
-	}
-	if err := cmd(os.Args[2:]); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-}
-
-func printUsage() {
-	fmt.Println("Usage: gocell <command> [args]")
-	fmt.Println()
-	fmt.Println("Commands:")
-	fmt.Println("  validate    Validate all metadata (blocking)")
-	fmt.Println("  scaffold    Generate new cell/slice/contract/journey")
-	fmt.Println("  generate    Generate assembly code and derived files")
-	fmt.Println("  check       Run targeted architecture analysis")
-	fmt.Println("  verify      Run tests (slice/cell/journey)")
+	os.Exit(app.Dispatch(os.Args[1:]))
 }

--- a/kernel/governance/depcheck.go
+++ b/kernel/governance/depcheck.go
@@ -28,15 +28,36 @@ func NewDependencyChecker(project *metadata.ProjectMeta) *DependencyChecker {
 
 // Check runs all dependency checks and returns findings.
 func (dc *DependencyChecker) Check() []ValidationResult {
+	var results []ValidationResult
+	for _, check := range dc.checks() {
+		results = append(results, check()...)
+	}
+	return results
+}
+
+// CheckFailFast runs the same checks as Check but returns as soon as any
+// produces a SeverityError. Warnings do not trigger the bailout.
+func (dc *DependencyChecker) CheckFailFast() []ValidationResult {
+	var results []ValidationResult
+	for _, check := range dc.checks() {
+		r := check()
+		results = append(results, r...)
+		if HasErrors(r) {
+			return results
+		}
+	}
+	return results
+}
+
+// checks returns the list of check methods in execution order. Shared by
+// Check and CheckFailFast so they stay provably in sync.
+func (dc *DependencyChecker) checks() []func() []ValidationResult {
 	if dc.project == nil {
 		return nil
 	}
-
-	var results []ValidationResult
-	results = append(results, dc.checkDEP01()...)
-	results = append(results, dc.checkDEP02()...)
-	results = append(results, dc.checkDEP03()...)
-	return results
+	return []func() []ValidationResult{
+		dc.checkDEP01, dc.checkDEP02, dc.checkDEP03,
+	}
 }
 
 // checkDEP01 verifies that each slice's belongsToCell matches the cellID

--- a/kernel/governance/helpers.go
+++ b/kernel/governance/helpers.go
@@ -132,10 +132,13 @@ func repositoryRoot(root string) string {
 	return absRoot
 }
 
-// isWithinRoot checks that target resolves to a path inside root.
+// IsWithinRoot checks that target resolves to a path inside root.
 // Both sides are normalized to absolute paths, and symlinks are resolved
 // when possible, to prevent both relative-path and symlink-based bypasses.
-func isWithinRoot(root, target string) bool {
+//
+// Exported so cmd/gocell and other callers share a single implementation
+// rather than carrying a duplicate with a hand-maintained `// SYNC:` note.
+func IsWithinRoot(root, target string) bool {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return false
@@ -155,16 +158,16 @@ func isWithinRoot(root, target string) bool {
 	if resolved, err := filepath.EvalSymlinks(absTarget); err == nil {
 		absTarget = resolved
 	} else {
-		absTarget = evalExistingPrefix(absTarget)
+		absTarget = EvalExistingPrefix(absTarget)
 	}
 	cleanRoot := absRoot + string(os.PathSeparator)
 	return strings.HasPrefix(absTarget, cleanRoot) || absTarget == absRoot
 }
 
-// evalExistingPrefix resolves symlinks on the longest existing ancestor of p,
+// EvalExistingPrefix resolves symlinks on the longest existing ancestor of p,
 // then appends the non-existent suffix. This handles platforms where
 // intermediate directories are symlinks (e.g., macOS /tmp → /private/tmp).
-func evalExistingPrefix(p string) string {
+func EvalExistingPrefix(p string) string {
 	if resolved, err := filepath.EvalSymlinks(p); err == nil {
 		return resolved
 	}
@@ -172,7 +175,7 @@ func evalExistingPrefix(p string) string {
 	if parent == p {
 		return p // filesystem root, stop recursion
 	}
-	return filepath.Join(evalExistingPrefix(parent), filepath.Base(p))
+	return filepath.Join(EvalExistingPrefix(parent), filepath.Base(p))
 }
 
 // --- actor helpers ---

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -539,7 +539,7 @@ func (v *Validator) validateFMT15() []ValidationResult {
 		}
 		contractDir := filepath.Join(v.root, contractDirFromID(c.ID))
 		schemaPath := filepath.Join(contractDir, c.SchemaRefs.Response)
-		if !isWithinRoot(v.root, schemaPath) {
+		if !IsWithinRoot(v.root, schemaPath) {
 			continue
 		}
 		data, err := v.readFile(schemaPath)

--- a/kernel/governance/rules_ref.go
+++ b/kernel/governance/rules_ref.go
@@ -201,7 +201,7 @@ func (v *Validator) validateREF11() []ValidationResult {
 		// The entrypoint path is relative to the repository root (parent of go.mod directory).
 		repoRoot := repositoryRoot(v.root)
 		fullPath := filepath.Join(repoRoot, a.Build.Entrypoint)
-		if !isWithinRoot(repoRoot, fullPath) {
+		if !IsWithinRoot(repoRoot, fullPath) {
 			results = append(results, v.newResult(
 				"REF-11", SeverityError, IssueInvalid,
 				assemblyFile(a.ID),
@@ -255,7 +255,7 @@ func (v *Validator) validateREF12() []ValidationResult {
 				continue
 			}
 			fullPath := filepath.Join(contractDir, ref.value)
-			if !isWithinRoot(contractDir, fullPath) {
+			if !IsWithinRoot(contractDir, fullPath) {
 				results = append(results, v.newResult(
 					"REF-12", SeverityError, IssueInvalid,
 					contractFile(c.ID),
@@ -353,7 +353,7 @@ func (v *Validator) validateREF16() []ValidationResult {
 	var results []ValidationResult
 	for _, a := range v.project.Assemblies {
 		boundaryPath := filepath.Join(v.root, "assemblies", a.ID, "generated", "boundary.yaml")
-		if !isWithinRoot(v.root, boundaryPath) {
+		if !IsWithinRoot(v.root, boundaryPath) {
 			results = append(results, v.newResult(
 				"REF-16", SeverityError, IssueInvalid,
 				assemblyFile(a.ID),

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -106,68 +106,52 @@ func NewValidator(project *metadata.ProjectMeta, root string) *Validator {
 // Validate runs all rules and returns all findings.
 func (v *Validator) Validate() []ValidationResult {
 	var results []ValidationResult
-
-	// Reference integrity rules
-	results = append(results, v.validateREF01()...)
-	results = append(results, v.validateREF02()...)
-	results = append(results, v.validateREF03()...)
-	results = append(results, v.validateREF04()...)
-	results = append(results, v.validateREF05()...)
-	results = append(results, v.validateREF06()...)
-	results = append(results, v.validateREF07()...)
-	results = append(results, v.validateREF08()...)
-	results = append(results, v.validateREF09()...)
-	results = append(results, v.validateREF10()...)
-	results = append(results, v.validateREF11()...)
-	results = append(results, v.validateREF12()...)
-	results = append(results, v.validateREF13()...)
-	results = append(results, v.validateREF14()...)
-	results = append(results, v.validateREF15()...)
-	results = append(results, v.validateREF16()...)
-
-	// Topological rules
-	results = append(results, v.validateTOPO01()...)
-	results = append(results, v.validateTOPO02()...)
-	results = append(results, v.validateTOPO03()...)
-	results = append(results, v.validateTOPO04()...)
-	results = append(results, v.validateTOPO05()...)
-	results = append(results, v.validateTOPO06()...)
-	results = append(results, v.validateTOPO07()...)
-	results = append(results, v.validateTOPO08()...)
-
-	// Verify closure rules
-	results = append(results, v.validateVERIFY01()...)
-	results = append(results, v.validateVERIFY02()...)
-	results = append(results, v.validateVERIFY03()...)
-	results = append(results, v.validateVERIFY04()...)
-	results = append(results, v.validateVERIFY05()...)
-
-	// Format compliance rules
-	results = append(results, v.validateFMT01()...)
-	results = append(results, v.validateFMT02()...)
-	results = append(results, v.validateFMT03()...)
-	results = append(results, v.validateFMT04()...)
-	results = append(results, v.validateFMT05()...)
-	results = append(results, v.validateFMT06()...)
-	results = append(results, v.validateFMT07()...)
-	results = append(results, v.validateFMT08()...)
-	results = append(results, v.validateFMT09()...)
-	results = append(results, v.validateFMT10()...)
-	results = append(results, v.validateFMT11()...)
-	results = append(results, v.validateFMT12()...)
-	results = append(results, v.validateFMT13()...)
-	results = append(results, v.validateFMT14()...)
-	results = append(results, v.validateFMT15()...)
-
-	// Advisory rules
-	results = append(results, v.validateADV01()...)
-	results = append(results, v.validateADV03()...)
-	results = append(results, v.validateADV04()...)
-
-	// Outbox governance rules
-	results = append(results, v.validateOUTGUARD01()...)
-
+	for _, rule := range v.rules() {
+		results = append(results, rule()...)
+	}
 	return results
+}
+
+// ValidateFailFast runs the same rules as Validate but returns as soon as
+// any rule produces a SeverityError result. Warnings do not trigger the
+// bailout. This is the true short-circuit path for CI pipelines — unlike
+// a Validate() caller that filters downstream, no subsequent rule runs.
+//
+// When no errors are found, the return value contains every rule's warnings
+// in the same order as Validate() would.
+func (v *Validator) ValidateFailFast() []ValidationResult {
+	var results []ValidationResult
+	for _, rule := range v.rules() {
+		r := rule()
+		results = append(results, r...)
+		if HasErrors(r) {
+			return results
+		}
+	}
+	return results
+}
+
+// rules returns the list of rule methods in the same order Validate runs
+// them. Used by both Validate (for full evaluation) and ValidateFailFast
+// (for short-circuit). Keeping this list in one place is what makes the
+// two entry points provably equivalent on the happy path.
+func (v *Validator) rules() []func() []ValidationResult {
+	return []func() []ValidationResult{
+		v.validateREF01, v.validateREF02, v.validateREF03, v.validateREF04,
+		v.validateREF05, v.validateREF06, v.validateREF07, v.validateREF08,
+		v.validateREF09, v.validateREF10, v.validateREF11, v.validateREF12,
+		v.validateREF13, v.validateREF14, v.validateREF15, v.validateREF16,
+		v.validateTOPO01, v.validateTOPO02, v.validateTOPO03, v.validateTOPO04,
+		v.validateTOPO05, v.validateTOPO06, v.validateTOPO07, v.validateTOPO08,
+		v.validateVERIFY01, v.validateVERIFY02, v.validateVERIFY03,
+		v.validateVERIFY04, v.validateVERIFY05,
+		v.validateFMT01, v.validateFMT02, v.validateFMT03, v.validateFMT04,
+		v.validateFMT05, v.validateFMT06, v.validateFMT07, v.validateFMT08,
+		v.validateFMT09, v.validateFMT10, v.validateFMT11, v.validateFMT12,
+		v.validateFMT13, v.validateFMT14, v.validateFMT15,
+		v.validateADV01, v.validateADV03, v.validateADV04,
+		v.validateOUTGUARD01,
+	}
 }
 
 // HasErrors returns true if any result has SeverityError.

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -2433,7 +2433,7 @@ func TestActorExists(t *testing.T) {
 	assert.False(t, val.actorExists("nonexistent"), "unknown ID should not exist")
 }
 
-// --- S1: isWithinRoot path traversal guard ---
+// --- S1: IsWithinRoot path traversal guard ---
 
 func TestIsWithinRoot(t *testing.T) {
 	tests := []struct {
@@ -2448,7 +2448,7 @@ func TestIsWithinRoot(t *testing.T) {
 		{"dot-dot escapes", "/project/src", "/project/src/../etc/passwd", false},
 		{"different tree", "/project/src", "/other/place", false},
 	}
-	// Also test relative paths (P1 fix: isWithinRoot must handle relative root).
+	// Also test relative paths (P1 fix: IsWithinRoot must handle relative root).
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	tests = append(tests, struct {
@@ -2464,7 +2464,7 @@ func TestIsWithinRoot(t *testing.T) {
 	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isWithinRoot(tt.root, tt.target)
+			got := IsWithinRoot(tt.root, tt.target)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -2483,7 +2483,7 @@ func TestIsWithinRoot_Symlink(t *testing.T) {
 	require.NoError(t, os.Symlink(outside, symlink))
 
 	target := filepath.Join(symlink, "secret.yaml")
-	assert.False(t, isWithinRoot(root, target), "symlink target outside root should be rejected")
+	assert.False(t, IsWithinRoot(root, target), "symlink target outside root should be rejected")
 }
 
 // --- S1: REF-11 path traversal ---

--- a/kernel/scaffold/scaffold.go
+++ b/kernel/scaffold/scaffold.go
@@ -63,12 +63,21 @@ type JourneyOpts struct {
 
 // Scaffolder generates directory structures and YAML templates.
 type Scaffolder struct {
-	root string // project root containing go.mod
+	root   string // project root containing go.mod
+	dryRun bool   // if true, skip filesystem writes while still validating opts and detecting conflicts
 }
 
 // New creates a Scaffolder rooted at the given directory.
 func New(root string) *Scaffolder {
 	return &Scaffolder{root: root}
+}
+
+// WithDryRun returns the receiver after flipping its dry-run mode: opts
+// validation, conflict detection, and template rendering still run, but no
+// directories or files are written. Fluent to pair with New.
+func (s *Scaffolder) WithDryRun(dry bool) *Scaffolder {
+	s.dryRun = dry
+	return s
 }
 
 // CreateCell creates cells/{id}/cell.yaml with directory.
@@ -229,6 +238,12 @@ func (s *Scaffolder) renderToFile(tplPath, outPath string, data any) error {
 	if err := tmpl.Execute(&buf, data); err != nil {
 		return errcode.Wrap(ErrScaffoldTemplate,
 			fmt.Sprintf("scaffold: failed to execute template %s", tplPath), err)
+	}
+
+	// Dry-run: conflict + render are enough to catch CI-pre-commit mistakes.
+	// Stop before touching the filesystem so partial writes never linger.
+	if s.dryRun {
+		return nil
 	}
 
 	// Create directories and write file.

--- a/kernel/scaffold/scaffold.go
+++ b/kernel/scaffold/scaffold.go
@@ -62,6 +62,15 @@ type JourneyOpts struct {
 }
 
 // Scaffolder generates directory structures and YAML templates.
+//
+// Design note — deviated from runtime/bootstrap Option pattern:
+// Scaffolder intentionally uses a fluent/chained API rather than the variadic-
+// option (WithX ...Option) pattern used by runtime/bootstrap/bootstrap.go. The
+// two patterns are equivalent in power, but Scaffolder has only two state fields
+// (root + dryRun), is always single-use (created, called once, discarded), and
+// is wired in CLI one-liners where chaining reads more naturally than a variadic
+// options slice. The Option pattern would not add safety or extensibility here.
+// ref: runtime/bootstrap/bootstrap.go Option — comparison group.
 type Scaffolder struct {
 	root   string // project root containing go.mod
 	dryRun bool   // if true, skip filesystem writes while still validating opts and detecting conflicts
@@ -72,9 +81,17 @@ func New(root string) *Scaffolder {
 	return &Scaffolder{root: root}
 }
 
-// WithDryRun returns the receiver after flipping its dry-run mode: opts
-// validation, conflict detection, and template rendering still run, but no
-// directories or files are written. Fluent to pair with New.
+// WithDryRun returns the receiver after setting its dry-run flag. When dry is
+// true, opts validation, conflict detection, and template rendering still run,
+// but no directories or files are written to disk. Fluent — designed to chain
+// directly with New:
+//
+//	err := scaffold.New(root).WithDryRun(true).CreateCell(opts)
+//
+// Conflict detection relies on os.Stat for the target path, so an existing file
+// will still cause ErrScaffoldConflict even in dry-run mode.
+//
+// Deviated from runtime/bootstrap Option pattern: see Scaffolder type godoc.
 func (s *Scaffolder) WithDryRun(dry bool) *Scaffolder {
 	s.dryRun = dry
 	return s

--- a/kernel/scaffold/scaffold_test.go
+++ b/kernel/scaffold/scaffold_test.go
@@ -560,6 +560,49 @@ func TestPathTraversal(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// WithDryRun
+// ---------------------------------------------------------------------------
+
+// TestScaffolder_WithDryRun_NoFileWritten verifies that dry-run mode skips
+// all filesystem writes while still returning nil on valid opts.
+func TestScaffolder_WithDryRun_NoFileWritten(t *testing.T) {
+	root := t.TempDir()
+	s := New(root).WithDryRun(true)
+
+	require.NoError(t, s.CreateCell(CellOpts{ID: "dry-cell", OwnerTeam: "squad"}))
+
+	_, err := os.Stat(filepath.Join(root, "cells", "dry-cell", "cell.yaml"))
+	assert.True(t, os.IsNotExist(err), "dry-run must not write cell.yaml")
+}
+
+// TestScaffolder_WithDryRun_StillReportsConflict verifies that a pre-existing
+// target path causes ErrScaffoldConflict even when dryRun is true.
+func TestScaffolder_WithDryRun_StillReportsConflict(t *testing.T) {
+	root := t.TempDir()
+
+	// Create the target that would conflict.
+	cellDir := filepath.Join(root, "cells", "exists-cell")
+	require.NoError(t, os.MkdirAll(cellDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cellDir, "cell.yaml"),
+		[]byte("id: exists-cell\n"), 0o644))
+
+	s := New(root).WithDryRun(true)
+	err := s.CreateCell(CellOpts{ID: "exists-cell", OwnerTeam: "squad"})
+	requireErrCode(t, err, ErrScaffoldConflict)
+}
+
+// TestScaffolder_WithDryRun_StillValidatesOpts verifies that invalid opts
+// (missing required fields) are still rejected in dry-run mode before any I/O.
+func TestScaffolder_WithDryRun_StillValidatesOpts(t *testing.T) {
+	root := t.TempDir()
+	s := New(root).WithDryRun(true)
+
+	// Missing OwnerTeam — must fail regardless of dryRun.
+	err := s.CreateCell(CellOpts{ID: "no-team"})
+	requireErrCode(t, err, ErrScaffoldInvalidOpts)
+}
+
+// ---------------------------------------------------------------------------
 // Template embedding
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

PR-CMD（foundation-first plan Phase 3）一次性落地三项:

- **CMD-REFACTOR-01**: `cmd/gocell/*` 命令实现迁入 `cmd/gocell/app/`；`main.go` 只保留 `app.Dispatch()` 调度；`app` 包可被外部 smoke test 直接 import
- **CMD-MODE-01**:
  - `gocell validate --fail-fast`: 首个 error 即退出；跳过 warnings 与 summary
  - `gocell scaffold <kind> --dry-run`: 校验/冲突/模板全跑，不落盘
- **F-7 BUILD-OUTDIR-01**: `Makefile` 统一 `go build -o bin/`；`clean` 改 `rm -rf bin/`

一并吃掉 backlog L134 **CMD 重构** + L151 **快修合集 F-7**。

## Scope

- `cmd/gocell/app/` 新包（9 文件 + 2 新增）
- `cmd/gocell/main.go` 瘦身到 13 行
- `kernel/scaffold/scaffold.go` 加 `Scaffolder.WithDryRun` + `renderToFile` 分支
- `Makefile` build/clean 两条命令
- 新测试 `cmd/gocell/app/mode_test.go`（9 个用例覆盖 fail-fast + dry-run）

## Test plan

- [x] `go build ./...` 绿
- [x] `go test ./...` 全绿（cmd/gocell/app + kernel/scaffold 重点验证）
- [x] `golangci-lint run ./cmd/gocell/... ./kernel/scaffold/...` 0 issues
- [x] 手测 `gocell validate --fail-fast` 正确返回（当前仓库无 error）
- [x] 手测 `gocell scaffold cell --dry-run` 输出 `(dry-run) Would create ...` 且无文件落盘
- [x] `make build` 产物全部落在 `bin/`；`make clean` 干净清理

## References

- foundation-first plan: `docs/plans/20260416-foundation-first-plan.md` Phase 3 PR-CMD
- ref: go-zero goctl — 生成产物路径由 metadata 驱动
- ref: K8s kubectl `--dry-run` — 预览式校验模式语义来源

🤖 Generated with [Claude Code](https://claude.com/claude-code)