### PR TITLE
fix(config-core): gate configwrite mutations behind admin role

### DIFF
--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -23,8 +23,8 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ cell.Cell          = (*ConfigCore)(nil)
-	_ cell.HTTPRegistrar = (*ConfigCore)(nil)
+	_ cell.Cell           = (*ConfigCore)(nil)
+	_ cell.HTTPRegistrar  = (*ConfigCore)(nil)
 	_ cell.EventRegistrar = (*ConfigCore)(nil)
 )
 
@@ -87,11 +87,11 @@ type ConfigCore struct {
 	logger       *slog.Logger
 
 	// Slice services and handlers.
-	writeHandler     *configwrite.Handler
-	readHandler      *configread.Handler
-	publishHandler   *configpublish.Handler
-	flagHandler      *featureflag.Handler
-	subscribeSvc     *configsubscribe.Service
+	writeHandler   *configwrite.Handler
+	readHandler    *configread.Handler
+	publishHandler *configpublish.Handler
+	flagHandler    *featureflag.Handler
+	subscribeSvc   *configsubscribe.Service
 }
 
 // NewConfigCore creates a new ConfigCore Cell.
@@ -114,6 +114,9 @@ func NewConfigCore(opts ...Option) *ConfigCore {
 }
 
 // Init constructs all 5 slices and registers them.
+// TODO(PR-R-BOOT-COGNIT): split into validateDeps / buildCursorCodec / per-slice builders.
+//
+//nolint:gocognit
 func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := c.BaseCell.Init(ctx, deps); err != nil {
 		return err

--- a/cells/config-core/cell_test.go
+++ b/cells/config-core/cell_test.go
@@ -196,8 +196,8 @@ func (m *stubMux) Route(_ string, fn func(cell.RouteMux)) {
 	m.handleCount++
 	fn(m)
 }
-func (m *stubMux) Mount(_ string, _ http.Handler)                   { m.handleCount++ }
-func (m *stubMux) Group(_ func(cell.RouteMux))                      { m.handleCount++ }
+func (m *stubMux) Mount(_ string, _ http.Handler)                          { m.handleCount++ }
+func (m *stubMux) Group(_ func(cell.RouteMux))                             { m.handleCount++ }
 func (m *stubMux) With(_ ...func(http.Handler) http.Handler) cell.RouteMux { return m }
 
 // initCellWithRouter creates an initialized ConfigCore with routes registered
@@ -275,6 +275,7 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/config/", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
+		req = req.WithContext(auth.TestContext("admin-test", []string{"admin"}))
 		r.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusCreated, rec.Code, "setup: create config entry %d", i)
 	}

--- a/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -333,5 +333,5 @@ func (r *mockRowSet) Scan(dest ...any) error {
 	return nil
 }
 
-func (r *mockRowSet) Close() {}
+func (r *mockRowSet) Close()     {}
 func (r *mockRowSet) Err() error { return nil }

--- a/cells/config-core/internal/dto/authz.go
+++ b/cells/config-core/internal/dto/authz.go
@@ -1,4 +1,9 @@
+// Package dto provides shared handler-level data transfer objects for config-core.
 package dto
 
-// RoleAdmin is the role name required to mutate config entries.
+// RoleAdmin is the role required to perform privileged config-core mutations.
+//
+// This is a cell-internal copy of access-core/internal/domain.RoleAdmin.
+// Direct cross-cell import is forbidden by GoCell cell-boundary rules; both
+// constants must be kept in sync manually whenever the role name changes.
 const RoleAdmin = "admin"

--- a/cells/config-core/internal/dto/authz.go
+++ b/cells/config-core/internal/dto/authz.go
@@ -1,0 +1,4 @@
+package dto
+
+// RoleAdmin is the role name required to mutate config entries.
+const RoleAdmin = "admin"

--- a/cells/config-core/internal/mem/config_repo.go
+++ b/cells/config-core/internal/mem/config_repo.go
@@ -14,14 +14,13 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
-
 // Compile-time check.
 var _ ports.ConfigRepository = (*ConfigRepository)(nil)
 
 // ConfigRepository is an in-memory implementation of ports.ConfigRepository.
 type ConfigRepository struct {
 	mu       sync.RWMutex
-	entries  map[string]*domain.ConfigEntry   // key -> entry
+	entries  map[string]*domain.ConfigEntry     // key -> entry
 	versions map[string][]*domain.ConfigVersion // configID -> versions
 }
 

--- a/cells/config-core/slices/configpublish/handler.go
+++ b/cells/config-core/slices/configpublish/handler.go
@@ -10,12 +10,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
-// roleAdmin is the role required to publish or rollback a config entry.
-// Mirrors access-core/internal/domain.RoleAdmin which cannot be imported
-// directly (cell-internal). Both must stay in sync — see CLAUDE.md "Cell 之间
-// 只通过 contract 通信".
-const roleAdmin = "admin"
-
 // ConfigVersionResponse is the public DTO for ConfigVersion.
 // Sensitive snapshots have Value redacted to dto.RedactedValue; the Sensitive
 // flag is always surfaced so clients can render appropriately (mirrors
@@ -58,7 +52,7 @@ func NewHandler(svc *Service) *Handler {
 // integrity-affecting operation. Default-deny per K8s/Kratos/go-zero
 // convention; authentication alone is not enough.
 func (h *Handler) HandlePublish(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), roleAdmin); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), dto.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
@@ -78,7 +72,7 @@ func (h *Handler) HandlePublish(w http.ResponseWriter, r *http.Request) {
 // Admin-only: rollback re-activates a prior snapshot and is at least as
 // privileged as publish. See HandlePublish for the rationale.
 func (h *Handler) HandleRollback(w http.ResponseWriter, r *http.Request) {
-	if err := auth.RequireAnyRole(r.Context(), roleAdmin); err != nil {
+	if err := auth.RequireAnyRole(r.Context(), dto.RoleAdmin); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}

--- a/cells/config-core/slices/configsubscribe/service.go
+++ b/cells/config-core/slices/configsubscribe/service.go
@@ -46,7 +46,7 @@ type Service struct {
 // NewService creates a config-subscribe Service.
 func NewService(logger *slog.Logger) *Service {
 	return &Service{
-		cache: &Cache{values: make(map[string]string)},
+		cache:  &Cache{values: make(map[string]string)},
 		logger: logger,
 	}
 }

--- a/cells/config-core/slices/configwrite/contract_test.go
+++ b/cells/config-core/slices/configwrite/contract_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +40,7 @@ func TestHttpConfigWriteV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(`{"key":"app.name","value":"myapp"}`))
 	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.TestContext("admin-test", []string{dto.RoleAdmin}))
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 

--- a/cells/config-core/slices/configwrite/contract_test.go
+++ b/cells/config-core/slices/configwrite/contract_test.go
@@ -40,7 +40,7 @@ func TestHttpConfigWriteV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(`{"key":"app.name","value":"myapp"}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(auth.TestContext("admin-test", []string{dto.RoleAdmin}))
+	req = req.WithContext(auth.TestContext(testAdminSubject, []string{dto.RoleAdmin}))
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 

--- a/cells/config-core/slices/configwrite/contract_test.go
+++ b/cells/config-core/slices/configwrite/contract_test.go
@@ -2,6 +2,7 @@ package configwrite
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,6 +47,49 @@ func TestHttpConfigWriteV1Serve(t *testing.T) {
 	c.ValidateHTTPResponseRecorder(t, rec)
 
 	c.MustRejectResponse(t, []byte(`{"data":{"id":"x"}}`))
+}
+
+// TestHttpConfigWriteV1_AuthzNegative validates the 401/403 failure semantics
+// that are part of the http.config.write.v1 interface contract. These paths
+// are tested here alongside the happy-path contract test so that auth-guard
+// regressions are caught at the contract boundary, not just in unit tests.
+func TestHttpConfigWriteV1_AuthzNegative(t *testing.T) {
+	svc, _, _ := newContractService()
+	h := NewHandler(svc)
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/config/", http.HandlerFunc(h.HandleCreate))
+	body := `{"key":"app.name","value":"myapp"}`
+
+	cases := []struct {
+		name        string
+		injectAuth  bool
+		subject     string
+		roles       []string
+		wantStatus  int
+		wantErrCode string
+	}{
+		{"no_auth", false, "", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", true, "user-1", []string{"viewer"}, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/config/", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.injectAuth {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			mux.ServeHTTP(rec, req)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			var resp struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tc.wantErrCode, resp.Error.Code)
+		})
+	}
 }
 
 // --- Event contract tests ---

--- a/cells/config-core/slices/configwrite/handler.go
+++ b/cells/config-core/slices/configwrite/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // Handler provides HTTP endpoints for config write operations.
@@ -19,6 +20,11 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleCreate handles POST / — creates a new config entry.
 func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), dto.RoleAdmin); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	var req struct {
 		Key       string `json:"key"`
 		Value     string `json:"value"`
@@ -40,6 +46,11 @@ func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 
 // HandleUpdate handles PUT /{key} — updates an existing config entry.
 func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), dto.RoleAdmin); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	key := r.PathValue("key")
 
 	var req struct {
@@ -61,6 +72,11 @@ func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 
 // HandleDelete handles DELETE /{key} — deletes a config entry.
 func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
+	if err := auth.RequireAnyRole(r.Context(), dto.RoleAdmin); err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
 	key := r.PathValue("key")
 
 	if err := h.svc.Delete(r.Context(), key); err != nil {

--- a/cells/config-core/slices/configwrite/handler_test.go
+++ b/cells/config-core/slices/configwrite/handler_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testAdminSubject = "admin-test"
+
 // --- stubs ---
 
 type stubOutboxWriter struct{ entries []outbox.Entry }
@@ -40,7 +42,7 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 // non-auth logic (e.g. validation, business errors) and need to pass the
 // auth guard.
 func withAdmin(req *http.Request) *http.Request {
-	return req.WithContext(auth.TestContext("admin-test", []string{dto.RoleAdmin}))
+	return req.WithContext(auth.TestContext(testAdminSubject, []string{dto.RoleAdmin}))
 }
 
 // --- handler tests ---
@@ -305,17 +307,6 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 
 // --- authz tests ---
 
-func setupHandlerMux() http.Handler {
-	repo := mem.NewConfigRepository()
-	svc := NewService(repo, eventbus.New(), slog.Default())
-	h := NewHandler(svc)
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST /", h.HandleCreate)
-	mux.HandleFunc("PUT /{key}", h.HandleUpdate)
-	mux.HandleFunc("DELETE /{key}", h.HandleDelete)
-	return mux
-}
-
 func TestHandler_Authz_Create(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -326,11 +317,11 @@ func TestHandler_Authz_Create(t *testing.T) {
 	}{
 		{"no_auth", "", nil, false, http.StatusUnauthorized},
 		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden},
-		{"admin", "admin-1", []string{dto.RoleAdmin}, true, http.StatusCreated},
+		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, http.StatusCreated},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			mux := setupHandlerMux()
+			mux, _ := setupHandler()
 			body := `{"key":"test.key","value":"v"}`
 			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
@@ -350,17 +341,28 @@ func TestHandler_Authz_Update(t *testing.T) {
 		subject    string
 		roles      []string
 		injectAuth bool
+		setup      func(*mem.ConfigRepository)
+		path       string
 		wantStatus int
 	}{
-		{"no_auth", "", nil, false, http.StatusUnauthorized},
-		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden},
-		{"admin", "admin-1", []string{dto.RoleAdmin}, true, http.StatusNotFound},
+		{"no_auth", "", nil, false, nil, "/nonexistent", http.StatusUnauthorized},
+		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent", http.StatusForbidden},
+		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, nil, "/nonexistent", http.StatusNotFound},
+		{"admin_success", testAdminSubject, []string{dto.RoleAdmin}, true, func(r *mem.ConfigRepository) {
+			now := time.Now()
+			_ = r.Create(context.Background(), &domain.ConfigEntry{
+				ID: "au-1", Key: "test.update", Value: "v", Version: 1, CreatedAt: now, UpdatedAt: now,
+			})
+		}, "/test.update", http.StatusOK},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			mux := setupHandlerMux()
+			mux, repo := setupHandler()
+			if tc.setup != nil {
+				tc.setup(repo)
+			}
 			body := `{"value":"new"}`
-			req := httptest.NewRequest(http.MethodPut, "/nonexistent", strings.NewReader(body))
+			req := httptest.NewRequest(http.MethodPut, tc.path, strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			if tc.injectAuth {
 				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
@@ -378,16 +380,27 @@ func TestHandler_Authz_Delete(t *testing.T) {
 		subject    string
 		roles      []string
 		injectAuth bool
+		setup      func(*mem.ConfigRepository)
+		path       string
 		wantStatus int
 	}{
-		{"no_auth", "", nil, false, http.StatusUnauthorized},
-		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden},
-		{"admin", "admin-1", []string{dto.RoleAdmin}, true, http.StatusNotFound},
+		{"no_auth", "", nil, false, nil, "/nonexistent", http.StatusUnauthorized},
+		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent", http.StatusForbidden},
+		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, nil, "/nonexistent", http.StatusNotFound},
+		{"admin_success", testAdminSubject, []string{dto.RoleAdmin}, true, func(r *mem.ConfigRepository) {
+			now := time.Now()
+			_ = r.Create(context.Background(), &domain.ConfigEntry{
+				ID: "ad-1", Key: "test.delete", Value: "v", Version: 1, CreatedAt: now, UpdatedAt: now,
+			})
+		}, "/test.delete", http.StatusNoContent},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			mux := setupHandlerMux()
-			req := httptest.NewRequest(http.MethodDelete, "/nonexistent", nil)
+			mux, repo := setupHandler()
+			if tc.setup != nil {
+				tc.setup(repo)
+			}
+			req := httptest.NewRequest(http.MethodDelete, tc.path, nil)
 			if tc.injectAuth {
 				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
 			}

--- a/cells/config-core/slices/configwrite/handler_test.go
+++ b/cells/config-core/slices/configwrite/handler_test.go
@@ -309,15 +309,16 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 
 func TestHandler_Authz_Create(t *testing.T) {
 	cases := []struct {
-		name       string
-		subject    string
-		roles      []string
-		injectAuth bool
-		wantStatus int
+		name        string
+		subject     string
+		roles       []string
+		injectAuth  bool
+		wantStatus  int
+		wantErrCode string
 	}{
-		{"no_auth", "", nil, false, http.StatusUnauthorized},
-		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden},
-		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, http.StatusCreated},
+		{"no_auth", "", nil, false, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, http.StatusCreated, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -331,29 +332,39 @@ func TestHandler_Authz_Create(t *testing.T) {
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantErrCode != "" {
+				var resp struct {
+					Error struct {
+						Code string `json:"code"`
+					} `json:"error"`
+				}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, tc.wantErrCode, resp.Error.Code)
+			}
 		})
 	}
 }
 
 func TestHandler_Authz_Update(t *testing.T) {
 	cases := []struct {
-		name       string
-		subject    string
-		roles      []string
-		injectAuth bool
-		setup      func(*mem.ConfigRepository)
-		path       string
-		wantStatus int
+		name        string
+		subject     string
+		roles       []string
+		injectAuth  bool
+		setup       func(*mem.ConfigRepository)
+		path        string
+		wantStatus  int
+		wantErrCode string
 	}{
-		{"no_auth", "", nil, false, nil, "/nonexistent", http.StatusUnauthorized},
-		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent", http.StatusForbidden},
-		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, nil, "/nonexistent", http.StatusNotFound},
+		{"no_auth", "", nil, false, nil, "/nonexistent", http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent", http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, nil, "/nonexistent", http.StatusNotFound, ""},
 		{"admin_success", testAdminSubject, []string{dto.RoleAdmin}, true, func(r *mem.ConfigRepository) {
 			now := time.Now()
 			_ = r.Create(context.Background(), &domain.ConfigEntry{
 				ID: "au-1", Key: "test.update", Value: "v", Version: 1, CreatedAt: now, UpdatedAt: now,
 			})
-		}, "/test.update", http.StatusOK},
+		}, "/test.update", http.StatusOK, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -370,29 +381,39 @@ func TestHandler_Authz_Update(t *testing.T) {
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantErrCode != "" {
+				var resp struct {
+					Error struct {
+						Code string `json:"code"`
+					} `json:"error"`
+				}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, tc.wantErrCode, resp.Error.Code)
+			}
 		})
 	}
 }
 
 func TestHandler_Authz_Delete(t *testing.T) {
 	cases := []struct {
-		name       string
-		subject    string
-		roles      []string
-		injectAuth bool
-		setup      func(*mem.ConfigRepository)
-		path       string
-		wantStatus int
+		name        string
+		subject     string
+		roles       []string
+		injectAuth  bool
+		setup       func(*mem.ConfigRepository)
+		path        string
+		wantStatus  int
+		wantErrCode string
 	}{
-		{"no_auth", "", nil, false, nil, "/nonexistent", http.StatusUnauthorized},
-		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent", http.StatusForbidden},
-		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, nil, "/nonexistent", http.StatusNotFound},
+		{"no_auth", "", nil, false, nil, "/nonexistent", http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent", http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"admin", testAdminSubject, []string{dto.RoleAdmin}, true, nil, "/nonexistent", http.StatusNotFound, ""},
 		{"admin_success", testAdminSubject, []string{dto.RoleAdmin}, true, func(r *mem.ConfigRepository) {
 			now := time.Now()
 			_ = r.Create(context.Background(), &domain.ConfigEntry{
 				ID: "ad-1", Key: "test.delete", Value: "v", Version: 1, CreatedAt: now, UpdatedAt: now,
 			})
-		}, "/test.delete", http.StatusNoContent},
+		}, "/test.delete", http.StatusNoContent, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -407,6 +428,15 @@ func TestHandler_Authz_Delete(t *testing.T) {
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantErrCode != "" {
+				var resp struct {
+					Error struct {
+						Code string `json:"code"`
+					} `json:"error"`
+				}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, tc.wantErrCode, resp.Error.Code)
+			}
 		})
 	}
 }

--- a/cells/config-core/slices/configwrite/handler_test.go
+++ b/cells/config-core/slices/configwrite/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,13 @@ type stubTxRunner struct{ calls int }
 func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) error {
 	s.calls++
 	return fn(context.Background())
+}
+
+// withAdmin injects an admin context into a request for tests that exercise
+// non-auth logic (e.g. validation, business errors) and need to pass the
+// auth guard.
+func withAdmin(req *http.Request) *http.Request {
+	return req.WithContext(auth.TestContext("admin-test", []string{dto.RoleAdmin}))
 }
 
 // --- handler tests ---
@@ -55,6 +63,7 @@ func TestHandler_HandleCreate_OK(t *testing.T) {
 	body := `{"key":"app.name","value":"gocell"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -67,6 +76,7 @@ func TestHandler_HandleCreate_BadJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -79,6 +89,7 @@ func TestHandler_HandleCreate_EmptyKey(t *testing.T) {
 	body := `{"key":"","value":"v"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -91,6 +102,7 @@ func TestHandler_HandleCreate_UnknownField(t *testing.T) {
 	body := `{"key":"app.name","value":"gocell","extra":"y"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -103,6 +115,7 @@ func TestHandler_HandleUpdate_UnknownField(t *testing.T) {
 	body := `{"value":"new","extra":"y"}`
 	req := httptest.NewRequest(http.MethodPut, "/k", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -120,6 +133,7 @@ func TestHandler_HandleUpdate_OK(t *testing.T) {
 	body := `{"value":"new"}`
 	req := httptest.NewRequest(http.MethodPut, "/app.name", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -133,6 +147,7 @@ func TestHandler_HandleUpdate_NotFound(t *testing.T) {
 	body := `{"value":"v"}`
 	req := httptest.NewRequest(http.MethodPut, "/missing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -144,6 +159,7 @@ func TestHandler_HandleUpdate_BadJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/k", strings.NewReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -159,6 +175,7 @@ func TestHandler_HandleDelete_OK(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodDelete, "/app.name", nil)
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNoContent, w.Code)
@@ -169,6 +186,7 @@ func TestHandler_HandleDelete_NotFound(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodDelete, "/missing", nil)
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -183,6 +201,7 @@ func TestHandler_HandleCreate_SensitiveRedacted(t *testing.T) {
 	body := `{"key":"db.password","value":"s3cret!","sensitive":true}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -207,6 +226,7 @@ func TestHandler_HandleUpdate_SensitiveRedacted(t *testing.T) {
 	body := `{"value":"new-secret"}`
 	req := httptest.NewRequest(http.MethodPut, "/api.key", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withAdmin(req)
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -281,4 +301,99 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 
 	assert.Equal(t, 3, tx.calls, "each op should use tx")
 	assert.Len(t, ow.entries, 3, "each op should write to outbox")
+}
+
+// --- authz tests ---
+
+func setupHandlerMux() http.Handler {
+	repo := mem.NewConfigRepository()
+	svc := NewService(repo, eventbus.New(), slog.Default())
+	h := NewHandler(svc)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /", h.HandleCreate)
+	mux.HandleFunc("PUT /{key}", h.HandleUpdate)
+	mux.HandleFunc("DELETE /{key}", h.HandleDelete)
+	return mux
+}
+
+func TestHandler_Authz_Create(t *testing.T) {
+	cases := []struct {
+		name       string
+		subject    string
+		roles      []string
+		injectAuth bool
+		wantStatus int
+	}{
+		{"no_auth", "", nil, false, http.StatusUnauthorized},
+		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden},
+		{"admin", "admin-1", []string{dto.RoleAdmin}, true, http.StatusCreated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := setupHandlerMux()
+			body := `{"key":"test.key","value":"v"}`
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.injectAuth {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestHandler_Authz_Update(t *testing.T) {
+	cases := []struct {
+		name       string
+		subject    string
+		roles      []string
+		injectAuth bool
+		wantStatus int
+	}{
+		{"no_auth", "", nil, false, http.StatusUnauthorized},
+		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden},
+		{"admin", "admin-1", []string{dto.RoleAdmin}, true, http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := setupHandlerMux()
+			body := `{"value":"new"}`
+			req := httptest.NewRequest(http.MethodPut, "/nonexistent", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			if tc.injectAuth {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestHandler_Authz_Delete(t *testing.T) {
+	cases := []struct {
+		name       string
+		subject    string
+		roles      []string
+		injectAuth bool
+		wantStatus int
+	}{
+		{"no_auth", "", nil, false, http.StatusUnauthorized},
+		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden},
+		{"admin", "admin-1", []string{dto.RoleAdmin}, true, http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := setupHandlerMux()
+			req := httptest.NewRequest(http.MethodDelete, "/nonexistent", nil)
+			if tc.injectAuth {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Add `auth.RequireAnyRole(ctx, dto.RoleAdmin)` guard to `HandleCreate`, `HandleUpdate`, `HandleDelete` — unauthenticated requests → 401, authenticated non-admin → 403
- Extract `RoleAdmin = "admin"` const to `cells/config-core/internal/dto/authz.go` for cross-slice reuse within config-core
- Update handler + contract tests to inject admin context; add table-driven `TestHandler_Authz_{Create,Update,Delete}` covering 401/403/200 paths (TDD)

## Scope

Closes **PR-P0-AUTHZ-CONFIGWRITE** from `docs/plans/20260418-bottom-up-implementation-plan.md`

## Test plan

- [x] `go test ./cells/config-core/slices/configwrite/...` — all pass
- [x] `golangci-lint run ./cells/config-core/slices/configwrite/... ./cells/config-core/internal/dto/...` — 0 issues
- [x] `TestHandler_Authz_Create/no_auth` → 401
- [x] `TestHandler_Authz_Create/non_admin` → 403
- [x] `TestHandler_Authz_Create/admin` → 201
- [x] Same 401/403/pass coverage for Update and Delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)