### PR TITLE
fix(auth): PR#170 follow-up — fail-fast audience + HTTP route tests + S9 observability

### DIFF
--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -53,7 +53,7 @@ func mustIssuer(ks *auth.KeySet) *auth.JWTIssuer {
 }
 
 func mustVerifier(ks *auth.KeySet) *auth.JWTVerifier {
-	v, err := auth.NewJWTVerifier(ks)
+	v, err := auth.NewJWTVerifier(ks, auth.WithExpectedAudiences("gocell"))
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -482,7 +482,7 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 
 	// Verify token through session-aware verifier — should succeed.
 	verifier := c.TokenVerifier()
-	claims, err := verifier.Verify(ctx, accessToken)
+	claims, err := verifier.VerifyIntent(ctx, accessToken, auth.TokenIntentAccess)
 	require.NoError(t, err, "token should be valid before revocation")
 
 	sid, ok := claims.Extra["sid"].(string)
@@ -496,7 +496,7 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	require.NoError(t, sessionRepo.Update(ctx, sess))
 
 	// Verify same token again — should be rejected.
-	_, err = verifier.Verify(ctx, accessToken)
+	_, err = verifier.VerifyIntent(ctx, accessToken, auth.TokenIntentAccess)
 	require.Error(t, err, "token should be rejected after session revocation")
 	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN", "error should be auth invalid token")
 }
@@ -566,7 +566,7 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 
 	// Validate refreshed token through session-aware verifier.
 	verifier := c.TokenVerifier()
-	claims, err := verifier.Verify(ctx, refreshedToken)
+	claims, err := verifier.VerifyIntent(ctx, refreshedToken, auth.TokenIntentAccess)
 	require.NoError(t, err, "refreshed token should be valid")
 
 	sid := claims.Extra["sid"].(string)
@@ -579,7 +579,7 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 	require.NoError(t, sessionRepo.Update(ctx, sess))
 
 	// Refreshed token should now be rejected.
-	_, err = verifier.Verify(ctx, refreshedToken)
+	_, err = verifier.VerifyIntent(ctx, refreshedToken, auth.TokenIntentAccess)
 	require.Error(t, err, "refreshed token should be rejected after session revocation")
 	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN")
 }

--- a/cells/access-core/slices/sessionlogin/intent_test.go
+++ b/cells/access-core/slices/sessionlogin/intent_test.go
@@ -20,7 +20,7 @@ func TestService_Login_IssuesDistinctIntents(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pair)
 
-	testVerifier, err := auth.NewJWTVerifier(testKeySet)
+	testVerifier, err := auth.NewJWTVerifier(testKeySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	accessClaims, err := testVerifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)

--- a/cells/access-core/slices/sessionlogin/service_test.go
+++ b/cells/access-core/slices/sessionlogin/service_test.go
@@ -121,14 +121,14 @@ func TestService_Login_TokensContainSessionID(t *testing.T) {
 	require.NoError(t, err)
 
 	// Access token must contain sid.
-	accessClaims, err := verifier.Verify(context.Background(), pair.AccessToken)
+	accessClaims, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)
 	require.NoError(t, err)
 	sid, ok := accessClaims.Extra["sid"].(string)
 	assert.True(t, ok, "access token must contain sid claim")
 	assert.True(t, strings.HasPrefix(sid, "sess-"), "sid must start with sess-")
 
 	// Refresh token must contain same sid.
-	refreshClaims, err := verifier.Verify(context.Background(), pair.RefreshToken)
+	refreshClaims, err := verifier.VerifyIntent(context.Background(), pair.RefreshToken, auth.TokenIntentRefresh)
 	require.NoError(t, err)
 	refreshSid, ok := refreshClaims.Extra["sid"].(string)
 	assert.True(t, ok, "refresh token must contain sid claim")

--- a/cells/access-core/slices/sessionlogin/service_test.go
+++ b/cells/access-core/slices/sessionlogin/service_test.go
@@ -114,7 +114,7 @@ func TestService_Login_TokensContainSessionID(t *testing.T) {
 	seedUser(userRepo, "sid-user", "pass123")
 
 	// Need a verifier to decode the tokens.
-	verifier, err := auth.NewJWTVerifier(testKeySet)
+	verifier, err := auth.NewJWTVerifier(testKeySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	pair, err := svc.Login(context.Background(), LoginInput{Username: "sid-user", Password: "pass123"})

--- a/cells/access-core/slices/sessionrefresh/intent_test.go
+++ b/cells/access-core/slices/sessionrefresh/intent_test.go
@@ -47,7 +47,7 @@ func TestService_Refresh_NewTokensCarryCorrectIntents(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pair)
 
-	verifier, err := auth.NewJWTVerifier(testKeySet)
+	verifier, err := auth.NewJWTVerifier(testKeySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	newAccess, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -210,11 +210,11 @@ func TestService_Refresh_NewTokensContainSessionID(t *testing.T) {
 	verifier, err := auth.NewJWTVerifier(testKeySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	accessClaims, err := verifier.Verify(context.Background(), pair.AccessToken)
+	accessClaims, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "sess-r1", accessClaims.Extra["sid"], "new access token must carry the session ID")
 
-	refreshClaims, err := verifier.Verify(context.Background(), pair.RefreshToken)
+	refreshClaims, err := verifier.VerifyIntent(context.Background(), pair.RefreshToken, auth.TokenIntentRefresh)
 	require.NoError(t, err)
 	assert.Equal(t, "sess-r1", refreshClaims.Extra["sid"], "new refresh token must carry the session ID")
 }

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -26,7 +26,7 @@ func init() {
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
-	testVerifier, err = auth.NewJWTVerifier(testKeySet)
+	testVerifier, err = auth.NewJWTVerifier(testKeySet, auth.WithExpectedAudiences("gocell"))
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
@@ -39,7 +39,7 @@ func newTestService() (*Service, *mem.SessionRepository) {
 }
 
 func issueTestToken(sub string) string {
-	tok, _ := testIssuer.Issue(auth.TokenIntentRefresh, sub, nil, nil, "")
+	tok, _ := testIssuer.Issue(auth.TokenIntentRefresh, sub, nil, []string{auth.DefaultJWTAudience}, "")
 	return tok
 }
 
@@ -207,7 +207,7 @@ func TestService_Refresh_NewTokensContainSessionID(t *testing.T) {
 	require.NoError(t, err)
 
 	// Decode the new access token to verify sid.
-	verifier, err := auth.NewJWTVerifier(testKeySet)
+	verifier, err := auth.NewJWTVerifier(testKeySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	accessClaims, err := verifier.Verify(context.Background(), pair.AccessToken)
@@ -233,7 +233,7 @@ func TestService_Refresh_SessionAwareVerifier(t *testing.T) {
 	svc := NewService(sessionRepo, roleRepo, testIssuer, testVerifier, slog.Default())
 
 	// Issue a token with sid claim to tie to a session.
-	rt, err := testIssuer.Issue(auth.TokenIntentRefresh, "usr-sa", nil, nil, "sess-sa")
+	rt, err := testIssuer.Issue(auth.TokenIntentRefresh, "usr-sa", nil, []string{auth.DefaultJWTAudience}, "sess-sa")
 	require.NoError(t, err)
 
 	sess, err := domain.NewSession("usr-sa", "at", rt, time.Now().Add(time.Hour))

--- a/cells/access-core/slices/sessionvalidate/intent_test.go
+++ b/cells/access-core/slices/sessionvalidate/intent_test.go
@@ -18,7 +18,7 @@ func TestService_Verify_RejectsRefreshIntentToken(t *testing.T) {
 	priv, pub := auth.MustGenerateTestKeyPair()
 	ks, err := auth.NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := auth.NewJWTVerifier(ks)
+	verifier, err := auth.NewJWTVerifier(ks, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	svc := NewService(verifier, nil, slog.Default())
@@ -37,7 +37,7 @@ func TestService_Verify_AcceptsAccessIntentToken(t *testing.T) {
 	priv, pub := auth.MustGenerateTestKeyPair()
 	ks, err := auth.NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := auth.NewJWTVerifier(ks)
+	verifier, err := auth.NewJWTVerifier(ks, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	svc := NewService(verifier, nil, slog.Default())

--- a/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/cells/access-core/slices/sessionvalidate/service_test.go
@@ -21,7 +21,7 @@ var (
 
 func init() {
 	var err error
-	testVerifier, err = auth.NewJWTVerifier(testKeySet)
+	testVerifier, err = auth.NewJWTVerifier(testKeySet, auth.WithExpectedAudiences("gocell"))
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cmd/core-bundle/auth_integration_test.go
+++ b/cmd/core-bundle/auth_integration_test.go
@@ -53,7 +53,7 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 	require.NoError(t, err)
 	jwtIssuer, err := auth.NewJWTIssuer(keySet, "test", 15*time.Minute)
 	require.NoError(t, err)
-	jwtVerifier, err := auth.NewJWTVerifier(keySet)
+	jwtVerifier, err := auth.NewJWTVerifier(keySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	eb := eventbus.New()

--- a/examples/sso-bff/main.go
+++ b/examples/sso-bff/main.go
@@ -62,7 +62,7 @@ func main() {
 		logger.Error("failed to create JWT issuer", slog.Any("error", err))
 		os.Exit(1)
 	}
-	jwtVerifier, err := auth.NewJWTVerifier(keySet)
+	jwtVerifier, err := auth.NewJWTVerifier(keySet, auth.WithExpectedAudiences(auth.DefaultJWTAudience))
 	if err != nil {
 		logger.Error("failed to create JWT verifier", slog.Any("error", err))
 		os.Exit(1)

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -40,8 +40,13 @@ const (
 	ErrCommandNotFound   Code = "ERR_COMMAND_NOT_FOUND"
 	ErrAdapterPGNoTx     Code = "ERR_ADAPTER_PG_NO_TX"
 	ErrAuthKeyInvalid    Code = "ERR_AUTH_KEY_INVALID"
-	ErrAuthTokenInvalid  Code = "ERR_AUTH_TOKEN_INVALID"
-	ErrAuthTokenExpired  Code = "ERR_AUTH_TOKEN_EXPIRED"
+	// ErrAuthVerifierConfig signals a JWT verifier construction error — e.g.
+	// required configuration (WithExpectedAudiences) was not provided.
+	// Distinct from ErrAuthKeyInvalid (key material) so operators can route
+	// verifier misconfiguration separately from cryptographic key failures.
+	ErrAuthVerifierConfig Code = "ERR_AUTH_VERIFIER_CONFIG"
+	ErrAuthTokenInvalid   Code = "ERR_AUTH_TOKEN_INVALID"
+	ErrAuthTokenExpired   Code = "ERR_AUTH_TOKEN_EXPIRED"
 	// ErrAuthInvalidTokenIntent signals that a JWT's token_use claim (and/or
 	// its JOSE typ header) does not match the expected intent for the current
 	// request scope — e.g., a refresh token presented at a business endpoint,

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -237,6 +237,7 @@ var codeToStatus = map[errcode.Code]int{
 	// --- 401 Unauthorized ---
 	errcode.ErrAuthUnauthorized:       http.StatusUnauthorized,
 	errcode.ErrAuthKeyInvalid:         http.StatusUnauthorized,
+	errcode.ErrAuthVerifierConfig:     http.StatusInternalServerError,
 	errcode.ErrAuthTokenInvalid:       http.StatusUnauthorized,
 	errcode.ErrAuthTokenExpired:       http.StatusUnauthorized,
 	errcode.ErrAuthLoginFailed:        http.StatusUnauthorized,

--- a/runtime/auth/auth.go
+++ b/runtime/auth/auth.go
@@ -14,6 +14,15 @@ import (
 // expected by JWTVerifier.VerifyIntent in production deployments. Centralised
 // here so issuer (sessionlogin/sessionrefresh) and verifier (buildJWTDeps) stay
 // in sync without drift.
+//
+// Design note: this is a single fixed string, which means audience validation is
+// a self-referential check in GoCell's single-tenant deployment — the issuer
+// always writes "gocell" and the verifier always expects "gocell". The primary
+// security boundary is the RS256 private key; audience prevents cross-service
+// token confusion in multi-service deployments (e.g., a token issued for
+// service-A cannot be accepted by service-B if each configures a distinct
+// expected audience). Multi-tenant or multi-service operators should override
+// this value per deployment rather than relying on the default.
 const DefaultJWTAudience = "gocell"
 
 // TokenIntent distinguishes how a JWT is meant to be used, preventing
@@ -61,22 +70,18 @@ type Claims struct {
 	Extra map[string]any
 }
 
-// TokenVerifier verifies an authentication token and returns the decoded claims.
-// Implementations live in cells/access-core (e.g., JWT, opaque token).
-type TokenVerifier interface {
-	// Verify validates the token string and returns claims on success.
-	Verify(ctx context.Context, token string) (Claims, error)
-}
-
-// IntentTokenVerifier extends TokenVerifier with intent-aware validation.
-// Callers that know the required token intent (e.g., HTTP middleware expecting
-// access tokens, /auth/refresh expecting refresh tokens) should use
-// VerifyIntent so the verifier can reject token-confusion attempts with a
-// distinct ErrAuthInvalidTokenIntent code.
+// IntentTokenVerifier verifies an authentication token, requiring both
+// cryptographic validity and a declared intent (token_use claim + typ header)
+// that matches the expected usage scope (access vs. refresh). Audience is
+// enforced when the verifier is configured with WithExpectedAudiences.
+//
+// This is the only verification interface in GoCell. The narrower TokenVerifier
+// interface (Verify without intent) was removed: every production verification
+// path must declare the expected intent to prevent token-confusion attacks
+// (RFC 8725 §3.11).
 type IntentTokenVerifier interface {
-	TokenVerifier
-	// VerifyIntent validates the token and additionally requires that its
-	// declared intent (token_use claim + typ header) matches expected.
+	// VerifyIntent validates the token and requires that its declared intent
+	// (token_use claim + typ header) matches expected.
 	// Returns ErrAuthInvalidTokenIntent when the intent does not match, is
 	// missing, or header/claim diverge.
 	VerifyIntent(ctx context.Context, token string, expected TokenIntent) (Claims, error)

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -126,7 +126,7 @@ func NewJWTVerifier(keys VerificationKeyStore, opts ...JWTVerifierOption) (*JWTV
 		o(v)
 	}
 	if len(v.expectedAudiences) == 0 {
-		return nil, errcode.New(errcode.ErrAuthKeyInvalid,
+		return nil, errcode.New(errcode.ErrAuthVerifierConfig,
 			"JWT verifier requires at least one expected audience (WithExpectedAudiences); RFC 8725 §3.3")
 	}
 	return v, nil

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"slices"
 	"time"
 
@@ -85,13 +84,12 @@ type JWTVerifierOption func(*JWTVerifier)
 
 // WithExpectedAudiences configures VerifyIntent to enforce that the token's
 // aud claim contains at least one of the given audience strings per RFC 8725
-// §3.3 ("recipients MUST validate the aud claim"). Production deployments MUST
-// supply at least one expected audience matching what JWTIssuer.Issue writes.
+// §3.3 ("recipients MUST validate the aud claim"). This option is REQUIRED:
+// NewJWTVerifier returns an error if no expected audiences are configured.
 //
 // The first argument is required (preventing zero-argument calls). Empty strings
 // are silently filtered. Duplicate values across multiple calls are deduplicated.
 //
-// When not configured (default), VerifyIntent skips the audience check.
 // Verify() is never affected — audience enforcement is intentionally scoped to
 // VerifyIntent only.
 //
@@ -128,7 +126,8 @@ func NewJWTVerifier(keys VerificationKeyStore, opts ...JWTVerifierOption) (*JWTV
 		o(v)
 	}
 	if len(v.expectedAudiences) == 0 {
-		slog.Warn("JWT verifier constructed without expected audiences; RFC 8725 §3.3 audience validation disabled (configure WithExpectedAudiences for production)")
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid,
+			"JWT verifier requires at least one expected audience (WithExpectedAudiences); RFC 8725 §3.3")
 	}
 	return v, nil
 }

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -132,19 +132,7 @@ func NewJWTVerifier(keys VerificationKeyStore, opts ...JWTVerifierOption) (*JWTV
 	return v, nil
 }
 
-// Verify validates the token string and returns Claims on success.
-// It rejects tokens that are not signed with RS256 or do not carry a valid kid.
-//
-// Verify DOES NOT enforce token intent (access vs. refresh) — callers that
-// need intent checks must use VerifyIntent instead.
-//
-// Note: Verify does NOT check audience. Use VerifyIntent for all production request paths.
-func (v *JWTVerifier) Verify(ctx context.Context, tokenStr string) (Claims, error) {
-	claims, _, err := v.parseAndVerify(ctx, tokenStr)
-	return claims, err
-}
-
-// VerifyIntent validates the token like Verify, and additionally requires the
+// VerifyIntent validates the token and additionally requires the
 // declared intent (JWT token_use claim + JOSE typ header) to equal expected.
 // Returns ErrAuthInvalidTokenIntent when:
 //   - expected is not a valid TokenIntent

--- a/runtime/auth/jwt_aud_test.go
+++ b/runtime/auth/jwt_aud_test.go
@@ -3,9 +3,9 @@
 // Covers RFC 8725 §3.3: "recipients MUST validate the aud claim to determine
 // that the JWT is indeed intended for the recipient."
 //
-// WithExpectedAudiences configures the verifier; when not set the check is
-// skipped (backward compatible). When set, at least one configured audience
-// must appear in the token's aud claim.
+// WithExpectedAudiences is required — NewJWTVerifier returns an error when no
+// expected audiences are configured (fail-fast per RFC 8725 §3.3). At least
+// one configured audience must appear in the token's aud claim.
 package auth
 
 import (

--- a/runtime/auth/jwt_aud_test.go
+++ b/runtime/auth/jwt_aud_test.go
@@ -10,12 +10,15 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // makeTokenWithAud issues a signed token carrying the given audience slice.
@@ -98,6 +101,10 @@ func TestNewJWTVerifier_NoAudiences_ReturnsError(t *testing.T) {
 	_, err := NewJWTVerifier(ks)
 	require.Error(t, err, "NewJWTVerifier without WithExpectedAudiences must return an error")
 	assert.Contains(t, err.Error(), "audience")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error")
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code,
+		"construction error must use ErrAuthVerifierConfig, not ErrAuthKeyInvalid")
 }
 
 // TestJWTVerifier_VerifyIntent_AcceptsMultipleAudiencesWhenOneMatches verifies

--- a/runtime/auth/jwt_aud_test.go
+++ b/runtime/auth/jwt_aud_test.go
@@ -157,18 +157,20 @@ func TestJWTVerifier_VerifyIntent_AudienceCheckAppliedAfterIntentCheck(t *testin
 		"intent check fires before audience check")
 }
 
-// TestJWTVerifier_Verify_UnaffectedByExpectedAudiences verifies that the plain
-// Verify() method is NOT affected by WithExpectedAudiences — audience validation
-// is intentionally scoped to VerifyIntent only.
-func TestJWTVerifier_Verify_UnaffectedByExpectedAudiences(t *testing.T) {
+// TestJWTVerifier_VerifyIntent_RejectsAudienceOnAccessPath confirms that
+// audience enforcement applies through the primary VerifyIntent call path —
+// the only verification API in GoCell (TokenVerifier.Verify was removed in
+// favour of a single intent-aware API to prevent accidental audience bypass).
+func TestJWTVerifier_VerifyIntent_RejectsAudienceOnAccessPath(t *testing.T) {
 	ks := mustTestKeySet(t)
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	// Token with mismatched aud — Verify should not check it.
+	// Mismatched audience on access path — rejected.
 	tok := makeTokenWithAud(t, ks, []string{"some-other-service"})
-	_, err = verifier.Verify(context.Background(), tok)
-	require.NoError(t, err, "Verify() must not enforce audience (only VerifyIntent does)")
+	_, err = verifier.VerifyIntent(context.Background(), tok, TokenIntentAccess)
+	require.Error(t, err, "VerifyIntent must reject a token with a wrong audience")
+	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN_INTENT")
 }
 
 // TestJWTVerifier_VerifyIntent_AcceptsSingleStringAud verifies RFC 7519 §4.1.3:

--- a/runtime/auth/jwt_aud_test.go
+++ b/runtime/auth/jwt_aud_test.go
@@ -89,30 +89,15 @@ func TestJWTVerifier_VerifyIntent_RejectsMissingAudience(t *testing.T) {
 		"token without aud claim must be rejected when expected audience is configured")
 }
 
-// TestJWTVerifier_VerifyIntent_AudienceCheckSkippedWhenNotConfigured verifies
-// backward compatibility: when WithExpectedAudiences is not called, VerifyIntent
-// skips the audience check and accepts tokens regardless of aud content.
-func TestJWTVerifier_VerifyIntent_AudienceCheckSkippedWhenNotConfigured(t *testing.T) {
+// TestNewJWTVerifier_NoAudiences_ReturnsError verifies that NewJWTVerifier fails
+// at construction time when no expected audiences are configured (RFC 8725 §3.3
+// fail-fast). Any composition root that forgets WithExpectedAudiences will get a
+// hard error instead of silently skipping audience validation.
+func TestNewJWTVerifier_NoAudiences_ReturnsError(t *testing.T) {
 	ks := mustTestKeySet(t)
-	verifier, err := NewJWTVerifier(ks) // no WithExpectedAudiences
-	require.NoError(t, err)
-
-	// Token with mismatched audience — should still pass when no expectation configured.
-	tok := makeTokenWithAud(t, ks, []string{"some-other-audience"})
-	_, err = verifier.VerifyIntent(context.Background(), tok, TokenIntentAccess)
-	require.NoError(t, err, "no expected audience configured → aud check skipped (backward compat)")
-}
-
-// TestJWTVerifier_VerifyIntent_NoAudSkippedWhenNotConfigured mirrors the above
-// but with a token that has no aud claim at all.
-func TestJWTVerifier_VerifyIntent_NoAudSkippedWhenNotConfigured(t *testing.T) {
-	ks := mustTestKeySet(t)
-	verifier, err := NewJWTVerifier(ks) // no WithExpectedAudiences
-	require.NoError(t, err)
-
-	tok := makeRawTokenWithoutAud(t, ks)
-	_, err = verifier.VerifyIntent(context.Background(), tok, TokenIntentAccess)
-	require.NoError(t, err, "no expected audience configured → aud check skipped")
+	_, err := NewJWTVerifier(ks)
+	require.Error(t, err, "NewJWTVerifier without WithExpectedAudiences must return an error")
+	assert.Contains(t, err.Error(), "audience")
 }
 
 // TestJWTVerifier_VerifyIntent_AcceptsMultipleAudiencesWhenOneMatches verifies

--- a/runtime/auth/jwt_intent_test.go
+++ b/runtime/auth/jwt_intent_test.go
@@ -90,7 +90,7 @@ func TestJWTVerifier_Verify_PopulatesTokenUseOnClaims(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
@@ -105,17 +105,17 @@ func TestJWTVerifier_VerifyIntent_AcceptsMatchingIntent(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	access, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, nil, "sid-1")
+	access, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, []string{"gocell"}, "sid-1")
 	require.NoError(t, err)
 	claims, err := verifier.VerifyIntent(context.Background(), access, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-1", claims.Subject)
 	assert.Equal(t, TokenIntentAccess, claims.TokenUse)
 
-	refresh, err := issuer.Issue(TokenIntentRefresh, "user-1", nil, nil, "sid-1")
+	refresh, err := issuer.Issue(TokenIntentRefresh, "user-1", nil, []string{"gocell"}, "sid-1")
 	require.NoError(t, err)
 	rc, err := verifier.VerifyIntent(context.Background(), refresh, TokenIntentRefresh)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestJWTVerifier_VerifyIntent_RejectsWrongIntent_Access(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	refresh, err := issuer.Issue(TokenIntentRefresh, "user-1", nil, nil, "")
@@ -141,7 +141,7 @@ func TestJWTVerifier_VerifyIntent_RejectsWrongIntent_Refresh(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	access, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
@@ -156,7 +156,7 @@ func TestJWTVerifier_VerifyIntent_RejectsMissingTokenUseClaim(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	// Manually forge a legacy-style token: valid signature + kid but no token_use claim.
@@ -181,7 +181,7 @@ func TestJWTVerifier_VerifyIntent_RejectsHeaderClaimMismatch(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	// Forge a token where typ header says "at+jwt" but token_use claim says "refresh".
@@ -209,7 +209,7 @@ func TestJWTVerifier_VerifyIntent_RejectsUnknownIntentArg(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tok, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
@@ -257,7 +257,7 @@ func TestJWTVerifier_VerifyIntent_RejectsLegacyTypHeader(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	// RFC 7519 legacy: typ="JWT" (upper-case) + token_use=access
@@ -286,7 +286,7 @@ func TestJWTVerifier_VerifyIntent_RejectsMissingTypHeader(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	claims := jwt.MapClaims{
@@ -318,7 +318,7 @@ func TestJWTVerifier_VerifyIntent_RejectsNonStringTypHeader(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	claims := jwt.MapClaims{

--- a/runtime/auth/jwt_intent_test.go
+++ b/runtime/auth/jwt_intent_test.go
@@ -86,17 +86,17 @@ func TestJWTIssuer_IssueWithIntent_InvalidIntent_Rejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN_INTENT")
 }
 
-func TestJWTVerifier_Verify_PopulatesTokenUseOnClaims(t *testing.T) {
+func TestJWTVerifier_VerifyIntent_PopulatesTokenUseOnClaims(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, TokenIntentAccess, claims.TokenUse)
 }

--- a/runtime/auth/jwt_test.go
+++ b/runtime/auth/jwt_test.go
@@ -84,7 +84,7 @@ func TestJWTVerifier_VerifiesByKID(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, []string{"api"}, "")
@@ -104,7 +104,7 @@ func TestJWTVerifier_RejectsUnknownKID(t *testing.T) {
 
 	issuer, err := NewJWTIssuer(ks1, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks2) // different key set
+	verifier, err := NewJWTVerifier(ks2, WithExpectedAudiences("gocell")) // different key set
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
@@ -119,7 +119,7 @@ func TestJWTVerifier_RejectsMissingKID(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	// Create a token WITHOUT kid header (legacy-style).
@@ -143,7 +143,7 @@ func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin", "user"}, []string{"api"}, "")
@@ -163,7 +163,7 @@ func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", -time.Hour) // already expired
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
@@ -176,7 +176,7 @@ func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
 
 func TestJWTVerifier_RejectsHS256(t *testing.T) {
 	ks := mustTestKeySet(t)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	hmacToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
@@ -193,7 +193,7 @@ func TestJWTVerifier_RejectsHS256(t *testing.T) {
 
 func TestJWTVerifier_RejectsAlgNone(t *testing.T) {
 	ks := mustTestKeySet(t)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	noneToken := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
@@ -212,7 +212,7 @@ func TestJWTVerifier_RejectsRS384(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	// Sign a valid token with RS384 instead of RS256.
@@ -233,7 +233,7 @@ func TestJWTVerifier_RejectsRS512(t *testing.T) {
 	priv, pub := generateTestKeyPair(t)
 	ks, err := NewKeySet(priv, pub)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS512, jwt.MapClaims{
@@ -255,7 +255,7 @@ func TestJWTVerifier_WrongKey(t *testing.T) {
 
 	issuer, err := NewJWTIssuer(ks1, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks2)
+	verifier, err := NewJWTVerifier(ks2, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
@@ -267,7 +267,7 @@ func TestJWTVerifier_WrongKey(t *testing.T) {
 
 func TestJWTVerifier_MalformedToken(t *testing.T) {
 	ks := mustTestKeySet(t)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	_, err = verifier.Verify(context.Background(), "not.a.jwt")
@@ -278,7 +278,7 @@ func TestJWTIssuer_RoundTrip(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "test-issuer", 30*time.Minute)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "svc-audit", []string{"service"}, []string{"internal"}, "")
@@ -296,7 +296,7 @@ func TestJWTIssuer_NoRolesNoAudience(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-2", nil, nil, "")
@@ -351,7 +351,7 @@ func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verifier using the new KeySet should still accept the old token.
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	claims, err := verifier.Verify(context.Background(), oldTokenStr)
@@ -455,7 +455,7 @@ func TestJWTVerifier_AcceptsVerificationKeyStore(t *testing.T) {
 
 	// Verify using a stub store with only the public key.
 	stub := &stubVerificationKeyStore{keys: map[string]*rsa.PublicKey{kid: pub}}
-	verifier, err := NewJWTVerifier(stub)
+	verifier, err := NewJWTVerifier(stub, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	claims, err := verifier.Verify(context.Background(), tokenStr)
@@ -558,7 +558,7 @@ func TestJWTIssuer_Issue_IncludesSessionID(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, []string{"api"}, "sess-abc123")
@@ -574,7 +574,7 @@ func TestJWTIssuer_Issue_EmptySessionID_OmitsSid(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
-	verifier, err := NewJWTVerifier(ks)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
 	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
@@ -619,7 +619,7 @@ func TestWithIssuerClock_NilIgnored(t *testing.T) {
 
 func TestWithVerifierClock_NilIgnored(t *testing.T) {
 	ks := mustTestKeySet(t)
-	verifier, err := NewJWTVerifier(ks, WithVerifierClock(nil))
+	verifier, err := NewJWTVerifier(ks, WithVerifierClock(nil), WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 	// Should not panic on construction.
 	assert.NotNil(t, verifier)

--- a/runtime/auth/jwt_test.go
+++ b/runtime/auth/jwt_test.go
@@ -87,15 +87,15 @@ func TestJWTVerifier_VerifiesByKID(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, []string{"api"}, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-1", claims.Subject)
 	assert.Equal(t, "gocell", claims.Issuer)
 	assert.Equal(t, []string{"admin"}, claims.Roles)
-	assert.Equal(t, []string{"api"}, claims.Audience)
+	assert.Equal(t, []string{"gocell"}, claims.Audience)
 }
 
 func TestJWTVerifier_RejectsUnknownKID(t *testing.T) {
@@ -107,10 +107,10 @@ func TestJWTVerifier_RejectsUnknownKID(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks2, WithExpectedAudiences("gocell")) // different key set
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
@@ -132,7 +132,7 @@ func TestJWTVerifier_RejectsMissingKID(t *testing.T) {
 	tokenStr, err := token.SignedString(priv)
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
@@ -146,15 +146,15 @@ func TestJWTVerifier_RS256_ValidToken(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin", "user"}, []string{"api"}, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin", "user"}, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-1", claims.Subject)
 	assert.Equal(t, "gocell", claims.Issuer)
 	assert.Equal(t, []string{"admin", "user"}, claims.Roles)
-	assert.Equal(t, []string{"api"}, claims.Audience)
+	assert.Equal(t, []string{"gocell"}, claims.Audience)
 	assert.False(t, claims.ExpiresAt.IsZero())
 	assert.False(t, claims.IssuedAt.IsZero())
 }
@@ -166,10 +166,10 @@ func TestJWTVerifier_RS256_ExpiredToken(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
@@ -186,7 +186,7 @@ func TestJWTVerifier_RejectsHS256(t *testing.T) {
 	tokenStr, err := hmacToken.SignedString([]byte("some-secret"))
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
@@ -203,7 +203,7 @@ func TestJWTVerifier_RejectsAlgNone(t *testing.T) {
 	tokenStr, err := noneToken.SignedString(jwt.UnsafeAllowNoneSignatureType)
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
@@ -224,7 +224,7 @@ func TestJWTVerifier_RejectsRS384(t *testing.T) {
 	tokenStr, err := token.SignedString(priv)
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
@@ -244,7 +244,7 @@ func TestJWTVerifier_RejectsRS512(t *testing.T) {
 	tokenStr, err := token.SignedString(priv)
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
@@ -258,10 +258,10 @@ func TestJWTVerifier_WrongKey(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks2, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), tokenStr)
+	_, err = verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.Error(t, err)
 }
 
@@ -270,7 +270,7 @@ func TestJWTVerifier_MalformedToken(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	_, err = verifier.Verify(context.Background(), "not.a.jwt")
+	_, err = verifier.VerifyIntent(context.Background(), "not.a.jwt", TokenIntentAccess)
 	require.Error(t, err)
 }
 
@@ -281,32 +281,32 @@ func TestJWTIssuer_RoundTrip(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "svc-audit", []string{"service"}, []string{"internal"}, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "svc-audit", []string{"service"}, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "svc-audit", claims.Subject)
 	assert.Equal(t, "test-issuer", claims.Issuer)
 	assert.Equal(t, []string{"service"}, claims.Roles)
-	assert.Equal(t, []string{"internal"}, claims.Audience)
+	assert.Equal(t, []string{"gocell"}, claims.Audience)
 }
 
-func TestJWTIssuer_NoRolesNoAudience(t *testing.T) {
+func TestJWTIssuer_NoRoles(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-2", nil, nil, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-2", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-2", claims.Subject)
 	assert.Empty(t, claims.Roles)
-	assert.Empty(t, claims.Audience)
+	assert.Equal(t, []string{"gocell"}, claims.Audience)
 }
 
 func TestNewJWTVerifier_NilKeySetReturnsError(t *testing.T) {
@@ -338,15 +338,18 @@ func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {
 	ks, err := NewKeySetWithVerificationKeys(priv2, pub2, []VerificationKey{vk})
 	require.NoError(t, err)
 
-	// Issue a token signed with the OLD key (key1), adding kid manually.
+	// Issue a token signed with the OLD key (key1), adding required intent fields.
 	oldClaims := jwt.MapClaims{
-		"sub": "user-old",
-		"iss": "gocell",
-		"exp": time.Now().Add(time.Hour).Unix(),
-		"iat": time.Now().Unix(),
+		"sub":       "user-old",
+		"iss":       "gocell",
+		"exp":       time.Now().Add(time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"token_use": string(TokenIntentAccess),
+		"aud":       "gocell",
 	}
 	oldToken := jwt.NewWithClaims(jwt.SigningMethodRS256, oldClaims)
 	oldToken.Header["kid"] = Thumbprint(pub1)
+	oldToken.Header["typ"] = TypHeaderForIntent(TokenIntentAccess)
 	oldTokenStr, err := oldToken.SignedString(priv1)
 	require.NoError(t, err)
 
@@ -354,7 +357,7 @@ func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), oldTokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), oldTokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-old", claims.Subject)
 
@@ -362,10 +365,10 @@ func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
 	require.NoError(t, err)
 
-	newTokenStr, err := issuer.Issue(TokenIntentAccess, "user-new", nil, nil, "")
+	newTokenStr, err := issuer.Issue(TokenIntentAccess, "user-new", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	claims, err = verifier.Verify(context.Background(), newTokenStr)
+	claims, err = verifier.VerifyIntent(context.Background(), newTokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-new", claims.Subject)
 }
@@ -450,7 +453,7 @@ func TestJWTVerifier_AcceptsVerificationKeyStore(t *testing.T) {
 	require.NoError(t, err)
 	issuer, err := NewJWTIssuer(ks, "gocell-test", time.Hour)
 	require.NoError(t, err)
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
 	// Verify using a stub store with only the public key.
@@ -458,7 +461,7 @@ func TestJWTVerifier_AcceptsVerificationKeyStore(t *testing.T) {
 	verifier, err := NewJWTVerifier(stub, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-1", claims.Subject)
 }
@@ -561,10 +564,10 @@ func TestJWTIssuer_Issue_IncludesSessionID(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, []string{"api"}, "sess-abc123")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", []string{"admin"}, []string{"gocell"}, "sess-abc123")
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "user-1", claims.Subject)
 	assert.Equal(t, "sess-abc123", claims.Extra["sid"])
@@ -577,10 +580,10 @@ func TestJWTIssuer_Issue_EmptySessionID_OmitsSid(t *testing.T) {
 	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, nil, "")
+	tokenStr, err := issuer.Issue(TokenIntentAccess, "user-1", nil, []string{"gocell"}, "")
 	require.NoError(t, err)
 
-	claims, err := verifier.Verify(context.Background(), tokenStr)
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
 	require.NoError(t, err)
 	_, hasSid := claims.Extra["sid"]
 	assert.False(t, hasSid, "empty sessionID should not produce a sid claim")

--- a/runtime/auth/middleware_aud_test.go
+++ b/runtime/auth/middleware_aud_test.go
@@ -1,0 +1,99 @@
+package auth
+
+// middleware_aud_test.go: HTTP route-level audience regression tests.
+// These tests exercise the full AuthMiddleware → JWTVerifier chain via
+// httptest.ResponseRecorder, ensuring that wrong-audience and missing-audience
+// bearer tokens are rejected BEFORE reaching any handler — not just at the
+// VerifyIntent helper level.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildAudTestPair returns an issuer and verifier pair for audience tests.
+// The verifier expects audience "gocell"; the issuer can produce any audience.
+func buildAudTestPair(t *testing.T) (*JWTIssuer, *JWTVerifier) {
+	t.Helper()
+	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "test", 15*time.Minute)
+	require.NoError(t, err)
+	verifier, err := NewJWTVerifier(ks, WithExpectedAudiences("gocell"))
+	require.NoError(t, err)
+	return issuer, verifier
+}
+
+// audProtectedHandler is a trivial handler that writes 200 when reached.
+var audProtectedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func TestAuthMiddleware_WrongAudience_Returns401(t *testing.T) {
+	issuer, verifier := buildAudTestPair(t)
+	// Issue token for "other-service", not "gocell"
+	token, err := issuer.Issue(TokenIntentAccess, "alice", nil, []string{"other-service"}, "")
+	require.NoError(t, err)
+
+	h := AuthMiddleware(verifier, nil)(audProtectedHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"wrong-audience access token must be rejected by AuthMiddleware before reaching handler")
+}
+
+func TestAuthMiddleware_MissingAudience_Returns401(t *testing.T) {
+	issuer, verifier := buildAudTestPair(t)
+	// Issue token with no audience at all
+	token, err := issuer.Issue(TokenIntentAccess, "alice", nil, nil, "")
+	require.NoError(t, err)
+
+	h := AuthMiddleware(verifier, nil)(audProtectedHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"missing-audience access token must be rejected by AuthMiddleware before reaching handler")
+}
+
+func TestAuthMiddleware_WrongAudience_RefreshPath_Returns401(t *testing.T) {
+	issuer, verifier := buildAudTestPair(t)
+	// Issue a refresh token (right intent) but wrong audience
+	token, err := issuer.Issue(TokenIntentRefresh, "alice", nil, []string{"other-service"}, "")
+	require.NoError(t, err)
+
+	// Simulate a refresh endpoint: uses VerifyIntent(refresh) directly.
+	// This tests that audience enforcement propagates into VerifyIntent when
+	// called by application code (not just by AuthMiddleware).
+	refreshHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bearer := r.Header.Get("Authorization")
+		if len(bearer) > 7 {
+			bearer = bearer[7:]
+		}
+		_, err := verifier.VerifyIntent(r.Context(), bearer, TokenIntentRefresh)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	refreshHandler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"wrong-audience refresh token must be rejected before reaching refresh handler")
+}

--- a/runtime/auth/middleware_aud_test.go
+++ b/runtime/auth/middleware_aud_test.go
@@ -1,10 +1,15 @@
 package auth
 
 // middleware_aud_test.go: HTTP route-level audience regression tests.
-// These tests exercise the full AuthMiddleware → JWTVerifier chain via
-// httptest.ResponseRecorder, ensuring that wrong-audience and missing-audience
-// bearer tokens are rejected BEFORE reaching any handler — not just at the
-// VerifyIntent helper level.
+//
+// TestAuthMiddleware_* (first two) exercise the full AuthMiddleware →
+// JWTVerifier chain via httptest.ResponseRecorder, ensuring that
+// wrong/missing-audience tokens are rejected before reaching any handler.
+//
+// TestAuthMiddleware_WrongAudience_RefreshPath_Returns401 tests the refresh
+// path pattern, where production code calls verifier.VerifyIntent directly
+// (refresh endpoints extract the bearer token and call VerifyIntent themselves,
+// rather than relying on AuthMiddleware).
 
 import (
 	"net/http"
@@ -73,9 +78,9 @@ func TestAuthMiddleware_WrongAudience_RefreshPath_Returns401(t *testing.T) {
 	token, err := issuer.Issue(TokenIntentRefresh, "alice", nil, []string{"other-service"}, "")
 	require.NoError(t, err)
 
-	// Simulate a refresh endpoint: uses VerifyIntent(refresh) directly.
-	// This tests that audience enforcement propagates into VerifyIntent when
-	// called by application code (not just by AuthMiddleware).
+	// Mirrors the production refresh-endpoint pattern: the handler extracts the
+	// bearer token and calls VerifyIntent directly (AuthMiddleware is not in the
+	// chain for refresh paths). Validates that audience enforcement holds there too.
 	refreshHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bearer := r.Header.Get("Authorization")
 		if len(bearer) > 7 {

--- a/runtime/auth/middleware_intent_test.go
+++ b/runtime/auth/middleware_intent_test.go
@@ -27,13 +27,6 @@ type intentMockVerifier struct {
 	refreshErr    error
 }
 
-// Verify is kept so intentMockVerifier also satisfies TokenVerifier; it is
-// never invoked by AuthMiddleware (which calls VerifyIntent directly) and
-// returns a sentinel error so accidental fallback is caught by tests.
-func (v *intentMockVerifier) Verify(_ context.Context, _ string) (Claims, error) {
-	return Claims{}, errcode.New(errcode.ErrAuthUnauthorized, "intentMockVerifier.Verify should not be called")
-}
-
 func (v *intentMockVerifier) VerifyIntent(_ context.Context, _ string, expected TokenIntent) (Claims, error) {
 	switch expected {
 	case TokenIntentAccess:
@@ -147,24 +140,12 @@ func TestAuthMiddleware_IntentMismatch_LogsInvalidIntentError(t *testing.T) {
 		"ERR_AUTH_INVALID_TOKEN_INTENT must appear in structured log output so ops can distinguish it via metrics reason=invalid_intent")
 }
 
-// TestAuthMiddleware_LegacyTokenVerifierIsCompileTimeRejected is a compile-time
-// invariant check: AuthMiddleware's parameter is IntentTokenVerifier, so a
-// plain TokenVerifier can no longer be plugged in. Any attempt to narrow the
-// parameter back to TokenVerifier will fail to build this test.
-func TestAuthMiddleware_LegacyTokenVerifierIsCompileTimeRejected(t *testing.T) {
+// TestAuthMiddleware_IntentVerifierIsRequiredAtCompileTime is a compile-time
+// invariant check: AuthMiddleware's parameter is IntentTokenVerifier.
+// Any regression that widens it to a plain verifier would allow callers
+// without VerifyIntent to be plugged in — this test pins the constraint.
+func TestAuthMiddleware_IntentVerifierIsRequiredAtCompileTime(t *testing.T) {
 	var v IntentTokenVerifier = &intentMockVerifier{}
-	// The following must compile — v is an IntentTokenVerifier.
 	_ = AuthMiddleware(v, nil)
-
-	// Documented negative case: a value that only implements TokenVerifier
-	// cannot be assigned to IntentTokenVerifier. We express that as a
-	// non-executing check via interface satisfaction so a future regression
-	// (widening the parameter back to TokenVerifier) would let a
-	// plain-TokenVerifier compile and this assertion would become
-	// redundant, surfacing the drift in review.
 	var _ IntentTokenVerifier = (*intentMockVerifier)(nil)
-	var _ TokenVerifier = (*mockVerifier)(nil)
-	// mockVerifier now also satisfies IntentTokenVerifier; we rely on the
-	// parameter type of AuthMiddleware (IntentTokenVerifier) to enforce the
-	// invariant. The comment above documents why narrowing is a regression.
 }

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -16,18 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockVerifier implements IntentTokenVerifier for testing. The tests in this
-// file exercise generic middleware behaviour (missing token, public endpoints,
-// path cleaning, etc.), so VerifyIntent returns the same canned result as
-// Verify regardless of the requested intent. Intent-specific behaviour is
-// tested in middleware_intent_test.go.
+// mockVerifier implements IntentTokenVerifier for testing. Intent-specific
+// behaviour is tested in middleware_intent_test.go.
 type mockVerifier struct {
 	claims Claims
 	err    error
-}
-
-func (v *mockVerifier) Verify(_ context.Context, _ string) (Claims, error) {
-	return v.claims, v.err
 }
 
 func (v *mockVerifier) VerifyIntent(_ context.Context, _ string, _ TokenIntent) (Claims, error) {

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -188,6 +188,17 @@ func handleServiceToken(cfg serviceTokenConfig, ring *HMACKeyRing, next http.Han
 	}
 
 	parts := strings.SplitN(token, ":", 3)
+	if len(parts) == 2 {
+		// 2-part legacy format ({timestamp}:{hex_hmac}) — no nonce, always rejected.
+		// Recorded separately so ops can observe residual legacy token traffic.
+		cfg.metrics.recordServiceVerify("failure", "legacy_format")
+		cfg.logger.WarnContext(r.Context(), "legacy service token format rejected",
+			slog.String("path", r.URL.Path),
+			slog.String("format", "2-part"),
+		)
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
+		return
+	}
 	if len(parts) != 3 {
 		cfg.metrics.recordServiceVerify("failure", "invalid_format")
 		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -19,6 +19,8 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
+const msgInvalidServiceTokenFormat = "invalid service token format"
+
 // WithServiceTokenLogger sets the logger for ServiceTokenMiddleware.
 func WithServiceTokenLogger(l *slog.Logger) ServiceTokenOption {
 	return func(c *serviceTokenConfig) {
@@ -196,12 +198,12 @@ func handleServiceToken(cfg serviceTokenConfig, ring *HMACKeyRing, next http.Han
 			slog.String("path", r.URL.Path),
 			slog.String("format", "2-part"),
 		)
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", msgInvalidServiceTokenFormat)
 		return
 	}
 	if len(parts) != 3 {
 		cfg.metrics.recordServiceVerify("failure", "invalid_format")
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", msgInvalidServiceTokenFormat)
 		return
 	}
 
@@ -231,7 +233,7 @@ func handleServiceToken(cfg serviceTokenConfig, ring *HMACKeyRing, next http.Han
 	providedMAC, err := hex.DecodeString(sigHex)
 	if err != nil {
 		cfg.metrics.recordServiceVerify("failure", "invalid_format")
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token format")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", msgInvalidServiceTokenFormat)
 		return
 	}
 

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -631,3 +631,94 @@ func TestCanonicalQuery_SortsKeys(t *testing.T) {
 	assert.Equal(t, "a=1&b=2", canonicalQuery("b=2&a=1"))
 	assert.Equal(t, "", canonicalQuery(""))
 }
+
+// spyCounterVec records each (result, reason) pair observed via Inc().
+type spyCounterVec struct {
+	labels   []string
+	recorded []spyRecord
+}
+
+type spyRecord struct {
+	result string
+	reason string
+}
+
+func (v *spyCounterVec) With(l metrics.Labels) metrics.Counter {
+	metrics.MustValidateLabels(v.labels, l)
+	return &spyCounter{vec: v, result: l["result"], reason: l["reason"]}
+}
+
+type spyCounter struct {
+	vec    *spyCounterVec
+	result string
+	reason string
+}
+
+func (c *spyCounter) Inc() {
+	c.vec.recorded = append(c.vec.recorded, spyRecord{result: c.result, reason: c.reason})
+}
+func (c *spyCounter) Add(_ float64) {}
+
+// spyProvider is a metrics.Provider that returns a spyCounterVec for the
+// service-token counter and no-ops for everything else.
+type spyProvider struct {
+	svcVec *spyCounterVec
+}
+
+func newSpyProvider() *spyProvider {
+	return &spyProvider{
+		svcVec: &spyCounterVec{labels: []string{"result", "reason"}},
+	}
+}
+
+func (p *spyProvider) CounterVec(opts metrics.CounterOpts) (metrics.CounterVec, error) {
+	if opts.Name == "auth_service_token_verify_total" {
+		return p.svcVec, nil
+	}
+	return metrics.NopProvider{}.CounterVec(opts)
+}
+
+func (p *spyProvider) HistogramVec(opts metrics.HistogramOpts) (metrics.HistogramVec, error) {
+	return metrics.NopProvider{}.HistogramVec(opts)
+}
+
+func (p *spyProvider) assertServiceVerify(t *testing.T, result, reason string) {
+	t.Helper()
+	for _, r := range p.svcVec.recorded {
+		if r.result == result && r.reason == reason {
+			return
+		}
+	}
+	t.Errorf("expected service verify record {result=%q reason=%q}, got %v",
+		result, reason, p.svcVec.recorded)
+}
+
+// TestServiceToken_LegacyTwoPart_MetricLabel verifies that a 2-part legacy token
+// ({timestamp}:{hex_hmac}, no nonce) is rejected with HTTP 401 AND records the
+// metric label "legacy_format" (not "invalid_format").
+func TestServiceToken_LegacyTwoPart_MetricLabel(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Unix(1700000000, 0)
+
+	spy := newSpyProvider()
+	am, err := NewAuthMetrics(spy)
+	require.NoError(t, err)
+
+	legacyToken := legacyTwoPartToken(testSecret, http.MethodGet, "/internal/v1/test", now)
+
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenMetrics(am),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not be called: 2-part token must be rejected")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/test", nil)
+	req.Header.Set("Authorization", "ServiceToken "+legacyToken)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assertErrorCode(t, rec, "ERR_AUTH_UNAUTHORIZED")
+	spy.assertServiceVerify(t, "failure", "legacy_format")
+}


### PR DESCRIPTION
## Summary

Follow-up to PR#170 (ca2dd30), addressing two review findings and one missing backlog item.

- **C1 (P1 blocker)**: `NewJWTVerifier` now returns an error when constructed without `WithExpectedAudiences`, replacing the previous `slog.Warn`-only path. RFC 8725 §3.3 audience compliance is enforced at construction time across all composition roots (`cmd/core-bundle`, `examples/sso-bff`) and test fixtures.
- **C2 (P1-1 completion)**: Added `runtime/auth/middleware_aud_test.go` with 3 `httptest.Server`-level regression tests covering wrong-audience and missing-audience bearer tokens on protected routes and the refresh path — verifying rejection at the middleware layer, not only at the `VerifyIntent` helper.
- **S9 (AUTH-LEGACY-TOKEN-STRICT-01)**: `handleServiceToken` now distinguishes legacy 2-part service token format `{timestamp}:{hex_hmac}` from generic invalid formats. The 2-part path records metric label `"legacy_format"` and emits `slog.WarnContext` with `path` and `format` fields, making residual legacy token traffic observable without changing rejection semantics (always fail-closed).

## Changed files

| File | Change |
|------|--------|
| `runtime/auth/jwt.go` | `NewJWTVerifier`: `slog.Warn` → `return nil, error`; remove `slog` import |
| `runtime/auth/jwt_aud_test.go` | Replace backward-compat tests with `TestNewJWTVerifier_NoAudiences_ReturnsError` |
| `runtime/auth/jwt_test.go` | Add `WithExpectedAudiences("gocell")` to all verifier constructions |
| `runtime/auth/jwt_intent_test.go` | Same |
| `runtime/auth/middleware_aud_test.go` | **New**: 3 HTTP route-level audience regression tests |
| `runtime/auth/servicetoken.go` | Split `invalid_format` path: `len==2` → `legacy_format` + `WarnContext` |
| `runtime/auth/servicetoken_test.go` | Add `TestServiceToken_LegacyTwoPart_MetricLabel` |
| `cells/access-core/cell_test.go` | `WithExpectedAudiences("gocell")` |
| `cells/access-core/slices/*/intent_test.go` | Same (sessionlogin, sessionrefresh, sessionvalidate) |
| `cells/access-core/slices/*/service_test.go` | Same |
| `cmd/core-bundle/auth_integration_test.go` | Same |
| `examples/sso-bff/main.go` | Composition root: `WithExpectedAudiences(auth.DefaultJWTAudience)` |

## Test plan

- [ ] `go test ./runtime/auth/...` — all green including 3 new middleware tests and S9 metric test
- [ ] `go test ./cells/access-core/...` — all green
- [ ] `go test ./cmd/core-bundle/...` — all green (sandbox TCP bind failure pre-existed)
- [ ] `golangci-lint run` — 0 issues on modified packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)