### PR TITLE
refactor(config-core): remove dead runMode fail-open from configpublish

### DIFF
--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -155,7 +155,7 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := c.initReadSlice(runMode); err != nil {
 		return err
 	}
-	c.initPublishSlice(runMode)
+	c.initPublishSlice()
 	c.initSubscribeSlice()
 	if err := c.initFlagSlice(runMode); err != nil {
 		return err
@@ -235,7 +235,7 @@ func (c *ConfigCore) initReadSlice(runMode query.RunMode) error {
 	return nil
 }
 
-func (c *ConfigCore) initPublishSlice(runMode query.RunMode) {
+func (c *ConfigCore) initPublishSlice() {
 	var opts []configpublish.Option
 	if c.outboxWriter != nil {
 		opts = append(opts, configpublish.WithOutboxWriter(c.outboxWriter))
@@ -243,10 +243,6 @@ func (c *ConfigCore) initPublishSlice(runMode query.RunMode) {
 	if c.txRunner != nil {
 		opts = append(opts, configpublish.WithTxManager(c.txRunner))
 	}
-	// Publisher fail-open is keyed off the same cell-level RunMode that config-read /
-	// feature-flag consume; durable stays fail-closed by construction (zero-value RunModeProd).
-	// Do not re-derive this from DurabilityMode here — call RunModeForDemo once in Init.
-	opts = append(opts, configpublish.WithRunMode(runMode))
 	publishSvc := configpublish.NewService(c.configRepo, c.publisher, c.logger, opts...)
 	c.publishHandler = configpublish.NewHandler(publishSvc)
 	c.AddSlice(cell.NewBaseSlice("config-publish", "config-core", cell.L2))

--- a/cells/config-core/cell_test.go
+++ b/cells/config-core/cell_test.go
@@ -371,65 +371,6 @@ func TestConfigCore_InitDurable_RejectsMissingCursorCodec(t *testing.T) {
 	assert.Contains(t, err.Error(), "cursor codec")
 }
 
-// TestConfigCore_Wiring_PublisherFailure_DemoVsDurable exercises the
-// ConfigCore.Init → WithRunMode(query.RunModeDemo/Prod) wiring end-to-end
-// through HTTP. A publisher-only path with a failing publisher must:
-//   - DurabilityDemo: swallow the publisher error (200 OK)
-//   - DurabilityDurable: propagate the error (500)
-//
-// This is the contract that PR#165 introduced but was previously only
-// covered at the service layer; the wiring in ConfigCore.Init toggling
-// the run mode was untested.
-func TestConfigCore_Wiring_PublisherFailure_DemoVsDurable(t *testing.T) {
-	t.Parallel()
-	productionKey := []byte("wiring-test-cfg-cursor-key-32b!!")
-
-	tests := []struct {
-		name       string
-		mode       cell.DurabilityMode
-		path       string
-		wantStatus int
-	}{
-		{"demo swallows publisher error on publish", cell.DurabilityDemo, "/api/v1/config/flag-wiring/publish", http.StatusOK},
-		{"demo swallows publisher error on rollback", cell.DurabilityDemo, "/api/v1/config/flag-wiring/rollback", http.StatusOK},
-	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			repo := mem.NewConfigRepository()
-			seedConfigEntry(t, repo, "flag-wiring", "v1")
-			// Pre-create a version for rollback path.
-			mustPublish(t, repo, "flag-wiring")
-
-			c := NewConfigCore(
-				WithConfigRepository(repo),
-				WithFlagRepository(mem.NewFlagRepository()),
-				WithPublisher(failingPub{err: fmt.Errorf("broker unavailable")}),
-				WithCursorCodec(mustNewCfgCodec(t, productionKey)),
-				// No outbox — exercises the publisher-only path.
-			)
-			require.NoError(t, c.Init(context.Background(), cell.Dependencies{
-				Config:         map[string]any{},
-				DurabilityMode: tc.mode,
-			}))
-
-			r := router.New()
-			c.RegisterRoutes(r)
-
-			rec := httptest.NewRecorder()
-			ctx := auth.TestContext("admin-user", []string{"admin"})
-			body := strings.NewReader(`{"version":1}`)
-			req := httptest.NewRequest(http.MethodPost, tc.path, body).WithContext(ctx)
-			req.Header.Set("Content-Type", "application/json")
-			r.ServeHTTP(rec, req)
-
-			assert.Equalf(t, tc.wantStatus, rec.Code,
-				"mode=%s body=%s", tc.mode, rec.Body.String())
-		})
-	}
-}
-
 // recordingConfigWriter is a minimal outbox.Writer test double that is not a
 // Nooper — durable mode requires a non-noop writer.
 type recordingConfigWriter struct{ entries []outbox.Entry }
@@ -439,31 +380,11 @@ func (w *recordingConfigWriter) Write(_ context.Context, entry outbox.Entry) err
 	return nil
 }
 
-type failingPub struct{ err error }
-
-func (p failingPub) Publish(_ context.Context, _ string, _ []byte) error { return p.err }
-
 func mustNewCfgCodec(t *testing.T, key []byte) *query.CursorCodec {
 	t.Helper()
 	codec, err := query.NewCursorCodec(key)
 	require.NoError(t, err)
 	return codec
-}
-
-func seedConfigEntry(t *testing.T, repo *mem.ConfigRepository, key, value string) {
-	t.Helper()
-	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
-		ID: "cfg-" + key, Key: key, Value: value, Version: 1,
-	}))
-}
-
-func mustPublish(t *testing.T, repo *mem.ConfigRepository, key string) {
-	t.Helper()
-	entry, err := repo.GetByKey(context.Background(), key)
-	require.NoError(t, err)
-	require.NoError(t, repo.PublishVersion(context.Background(), &domain.ConfigVersion{
-		ID: "ver-seed-" + key, ConfigID: entry.ID, Version: entry.Version, Value: entry.Value,
-	}))
 }
 
 // TestWithPostgresDefaults_ConfiguresRepoAndOutbox verifies that

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -168,7 +168,8 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 	return fn(ctx)
 }
 
-// publishEvent writes to the outbox (durable) or directly via publisher (demo).
+// publishEvent writes to the outbox (L2 durable) or directly via publisher
+// (fallback when outboxWriter is nil, e.g. demo assemblies using DiscardPublisher).
 // No RunMode fail-open needed: demo mode injects DiscardPublisher which never
 // errors by contract, so any publisher failure is a real infrastructure problem
 // that must surface. Read slices use RunMode to handle stale cursor tokens —

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/google/uuid"
 )
 
@@ -38,22 +37,6 @@ func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = tx }
 }
 
-// WithRunMode sets the service run mode. RunModeDemo allows publisher-only
-// failures to be logged and swallowed (matching the cell's demo-mode L2 relaxation
-// for deployments that inject outbox.DiscardPublisher{}); RunModeProd — the zero
-// value — keeps the service fail-closed so publisher errors propagate and L2
-// atomicity is preserved.
-//
-// This unifies the publisher fail-open decision with pkg/query.RunMode: the cell
-// translates kernel/cell.DurabilityMode → query.RunMode exactly once in Init()
-// via query.RunModeForDemo and passes the resulting mode to every slice that
-// needs it. Do not introduce slice-local bool flags that re-derive this signal.
-// ref: zeromicro/go-zero ServiceConf.Mode — one mode field, propagated, not re-sniffed.
-// ref: watermill/components/forwarder — publish failures always wrap+return.
-func WithRunMode(mode query.RunMode) Option {
-	return func(s *Service) { s.runMode = mode }
-}
-
 // Service implements config publish/rollback business logic.
 type Service struct {
 	repo         ports.ConfigRepository
@@ -61,12 +44,9 @@ type Service struct {
 	outboxWriter outbox.Writer
 	txRunner     persistence.TxRunner
 	logger       *slog.Logger
-	runMode      query.RunMode
 }
 
-// NewService creates a config-publish Service. By default (RunModeProd zero
-// value) publisher errors propagate to preserve L2 atomicity; demo assemblies
-// opt-in to Warn+swallow behavior via WithRunMode(query.RunModeDemo).
+// NewService creates a config-publish Service.
 func NewService(repo ports.ConfigRepository, pub outbox.Publisher, logger *slog.Logger, opts ...Option) *Service {
 	s := &Service{
 		repo:      repo,
@@ -114,10 +94,7 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 		if err := s.repo.PublishVersion(txCtx, version); err != nil {
 			return fmt.Errorf("config-publish: publish version: %w", err)
 		}
-		if err := s.publishEvent(txCtx, TopicConfigChanged, payload, key); err != nil {
-			return err
-		}
-		return nil
+		return s.publishEvent(txCtx, TopicConfigChanged, payload)
 	}); err != nil {
 		return nil, err
 	}
@@ -171,10 +148,7 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 		if err := s.repo.Update(txCtx, entry); err != nil {
 			return fmt.Errorf("config-publish: rollback update: %w", err)
 		}
-		if err := s.publishEvent(txCtx, TopicConfigRollback, payload, key); err != nil {
-			return err
-		}
-		return nil
+		return s.publishEvent(txCtx, TopicConfigRollback, payload)
 	}); err != nil {
 		return nil, err
 	}
@@ -194,7 +168,12 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 	return fn(ctx)
 }
 
-func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte, key string) error {
+// publishEvent writes to the outbox (durable) or directly via publisher (demo).
+// No RunMode fail-open needed: demo mode injects DiscardPublisher which never
+// errors by contract, so any publisher failure is a real infrastructure problem
+// that must surface. Read slices use RunMode to handle stale cursor tokens —
+// a concern that does not exist in write operations.
+func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte) error {
 	if s.outboxWriter != nil {
 		entry := outbox.Entry{
 			ID:        "evt" + "-" + uuid.NewString(),
@@ -206,14 +185,7 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 		}
 		return nil
 	}
-	// Publisher-only path (no outbox). Fail-closed by default to keep L2
-	// atomicity honest; demo assemblies opt-in via WithRunMode(query.RunModeDemo).
 	if err := s.publisher.Publish(ctx, topic, payload); err != nil {
-		if s.runMode.IsDemo() {
-			s.logger.Warn("config-publish: publisher failed (demo fail-open)",
-				slog.Any("error", err), slog.String("key", key), slog.String("topic", topic))
-			return nil
-		}
 		return fmt.Errorf("config-publish: publisher failed for topic %s: %w", topic, err)
 	}
 	return nil

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +59,7 @@ func newTestService() (*Service, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
 	eb := eventbus.New()
 	logger := slog.Default()
-	return NewService(repo, eb, logger, WithRunMode(query.RunModeDemo)), repo
+	return NewService(repo, eb, logger), repo
 }
 
 func newDurableTestService() (*Service, *mem.ConfigRepository, *recordingWriter) {
@@ -175,16 +174,6 @@ func TestService_Publish_PublisherError_ProdMode_PropagatesError(t *testing.T) {
 	_, err := svc.Publish(context.Background(), "k")
 	require.Error(t, err, "prod-mode publisher failure must propagate")
 	assert.Contains(t, err.Error(), "broker unavailable")
-}
-
-func TestService_Publish_PublisherError_DemoMode_SwallowsError(t *testing.T) {
-	repo := mem.NewConfigRepository()
-	pub := failingPublisher{err: errors.New("broker unavailable")}
-	svc := NewService(repo, pub, slog.Default(), WithRunMode(query.RunModeDemo))
-
-	mustSeedEntry(repo, "k", "v1")
-	_, err := svc.Publish(context.Background(), "k")
-	require.NoError(t, err, "demo fail-open must swallow publisher failure")
 }
 
 // --- #27d OUTBOX-WRITE-ERR-01: outbox.Write error must propagate ---

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -157,22 +157,21 @@ func TestService_Rollback(t *testing.T) {
 	}
 }
 
-// --- CONFIG-DEMO-FAILOPEN-01: publisher error must propagate in prod mode ---
+// --- publisher errors propagate (no fail-open on write path) ---
 
-// TestService_Publish_PublisherError_ProdMode_PropagatesError asserts that
-// when the service is wired without an outbox writer (publisher-only path)
-// and NOT configured for demo fail-open, a publisher failure surfaces as an
-// error. L2 cell declares transactional atomicity; silently swallowing the
-// error would violate that contract.
+// TestService_Publish_PublisherError_Propagates asserts that a publisher failure
+// on the publisher-only path (no outboxWriter) surfaces as an error.
+// L2 cell declares transactional atomicity; silently swallowing the error
+// would violate that contract.
 // ref: watermill/components/forwarder — publish failure wraps+returns.
-func TestService_Publish_PublisherError_ProdMode_PropagatesError(t *testing.T) {
+func TestService_Publish_PublisherError_Propagates(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := failingPublisher{err: errors.New("broker unavailable")}
-	svc := NewService(repo, pub, slog.Default()) // zero-value RunMode = RunModeProd → fail-closed
+	svc := NewService(repo, pub, slog.Default()) // no outboxWriter → publisher path; error propagates
 
 	mustSeedEntry(repo, "k", "v1")
 	_, err := svc.Publish(context.Background(), "k")
-	require.Error(t, err, "prod-mode publisher failure must propagate")
+	require.Error(t, err, "publisher failure must propagate")
 	assert.Contains(t, err.Error(), "broker unavailable")
 }
 

--- a/docs/architecture/202604180100-adr-runmode-translation.md
+++ b/docs/architecture/202604180100-adr-runmode-translation.md
@@ -16,7 +16,7 @@ GoCell 在两个抽象层上有"模式"（mode）概念：
 
 两个枚举互有对应关系（demo↔demo、durable↔prod），但**不是同一个概念**：
 - `DurabilityMode` 描述整个 Cell 的 L2 写路径；
-- `RunMode` 只描述 `pkg/query.ExecutePagedQuery` 与 `configpublish.WithRunMode` 消费者的"容错姿态"。
+- `RunMode` 只描述 `pkg/query.ExecutePagedQuery`（即 config-read / feature-flag cursor 降级）的"容错姿态"。
 
 问题：这两层在何处、由谁、如何做翻译？错误地散落到 slice/handler/repository 会让 demo 语义四处漂移，回归审查困难，也违反分层规则（`pkg/` 不能依赖 `kernel/`）。
 
@@ -45,7 +45,7 @@ pkg/       允许依赖: 标准库         禁止依赖: kernel/ cells/ runtime/
    - 重新观察 `DurabilityMode`（`pkg/` 本就无法感知）
    - 为 `bool` 参数额外加 `demoFailOpen`、`isDemo` 等并行旗标
 
-违反第 3 条会出现"两个真相源"，例如 PR#165 之前的 `configpublish.WithDemoFailOpen(bool)` 与 `RunMode` 重复表达同一信号。PR-P-QUERY 已合并为单一 `WithRunMode(query.RunMode)`。
+违反第 3 条会出现"两个真相源"，例如 PR#165 之前的 `configpublish.WithDemoFailOpen(bool)` 与 `RunMode` 重复表达同一信号。PR-P-QUERY 已合并为单一 `WithRunMode(query.RunMode)`；PR#175 进一步将 `configpublish.WithRunMode` 彻底删除（`DiscardPublisher` 永不报错，fail-open 为死代码），`RunMode` 消费方收窄为 config-read / feature-flag。
 
 ## 对标
 
@@ -65,8 +65,9 @@ pkg/       允许依赖: 标准库         禁止依赖: kernel/ cells/ runtime/
 
 - 引入：`pkg/query/runmode.go`（`RunModeForDemo` godoc 现含 "Do not extend" 警告）
 - 统一 configpublish：`WithDemoFailOpen` 删除，改用 `WithRunMode`（PR-P-QUERY）
+- PR#175：`configpublish.WithRunMode` 删除（死代码），write path 不再有 RunMode 消费
 - 调用点：
-  - `cells/config-core/cell.go::Init` — 单次翻译，下发给 config-read / feature-flag / config-publish
+  - `cells/config-core/cell.go::Init` — 单次翻译，下发给 config-read / feature-flag（config-publish 已移除）
   - `cells/audit-core/cell.go::Init`
   - `cells/order-cell/cell.go::Init`
   - `cells/device-cell/cell.go::Init`


### PR DESCRIPTION
## 问题

`configpublish.Service` 持有 `runMode query.RunMode` 字段，在 `publishEvent` 中通过 `if s.runMode.IsDemo() { swallow error }` 实现 demo fail-open。但这段代码是死代码：

- demo 模式注入 `DiscardPublisher`，其 `Publish()` 契约是**永远返回 nil**，错误分支永不触发
- durable 模式走 outbox 路径，根本不经过 publisher

## 根因

PR-X1（commit 5345d83）用显式 `RunMode` 替换了旧的隐式 nil-publisher 推断，原则正确。但没有追问 fail-open 本身是否必要。`DiscardPublisher` 引入后，被保护的失败场景不再存在，三次重构都在改"怎么 gate"，没人问"为什么 gate"。

## 变更

- 删除 `Service.runMode` 字段和 `WithRunMode` Option
- `publishEvent` 直接传播 publisher 错误，移除 fail-open 分支
- `cell.go initPublishSlice` 去掉 `WithRunMode(runMode)` 调用
- 删除覆盖 demo-swallows-error 行为的测试（service_test.go + cell_test.go）
- `publishEvent` 加注释说明为何不需要 RunMode（读 slice 用 RunMode 保护 cursor token 失效，写路径无外部状态验证）

Read slice（configread、featureflag）的 `RunMode` 不动，cursor decode 降级是合理的 DX concern。

## 测试

```
go test ./cells/config-core/... → all ok
golangci-lint run ./cells/config-core/... → 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)