### PR TITLE
feat(outbox): PR-OUTBOX-HARDEN-RMQ — A5 entry.ID guard + A6 polish + X6 lease renewal

### DIFF
--- a/adapters/rabbitmq/backoff.go
+++ b/adapters/rabbitmq/backoff.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+const (
+	// backoffMultiplierShift controls exponential growth: delay = base << (attempt * backoffMultiplierShift)
+	// (i.e. multiplier = 2^backoffMultiplierShift = 2x per attempt).
+	backoffMultiplierShift = 1
+)
+
 // safeDelay is an alias for exponentialDelay retained so existing rabbitmq
 // tests can reference the helper without churn.
 func safeDelay(base, maxDelay time.Duration, attempt int) time.Duration {
@@ -22,7 +28,7 @@ func exponentialDelay(base, maxDelay time.Duration, attempt int) time.Duration {
 	if attempt > maxSafeShift {
 		return maxDelay
 	}
-	delay := base * (1 << uint(attempt))
+	delay := base * (1 << (uint(attempt) * backoffMultiplierShift))
 	if delay <= 0 || delay > maxDelay {
 		return maxDelay
 	}

--- a/adapters/rabbitmq/backoff.go
+++ b/adapters/rabbitmq/backoff.go
@@ -5,12 +5,6 @@ import (
 	"time"
 )
 
-const (
-	// backoffMultiplierShift controls exponential growth: delay = base << (attempt * backoffMultiplierShift)
-	// (i.e. multiplier = 2^backoffMultiplierShift = 2x per attempt).
-	backoffMultiplierShift = 1
-)
-
 // safeDelay is an alias for exponentialDelay retained so existing rabbitmq
 // tests can reference the helper without churn.
 func safeDelay(base, maxDelay time.Duration, attempt int) time.Duration {
@@ -28,7 +22,7 @@ func exponentialDelay(base, maxDelay time.Duration, attempt int) time.Duration {
 	if attempt > maxSafeShift {
 		return maxDelay
 	}
-	delay := base * (1 << (uint(attempt) * backoffMultiplierShift))
+	delay := base * (1 << uint(attempt))
 	if delay <= 0 || delay > maxDelay {
 		return maxDelay
 	}

--- a/adapters/rabbitmq/backoff_test.go
+++ b/adapters/rabbitmq/backoff_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExponentialDelay(t *testing.T) {
@@ -34,5 +35,28 @@ func TestExponentialDelay(t *testing.T) {
 			got := exponentialDelay(tt.base, tt.maxDelay, tt.attempt)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// TestExponentialDelay_DoublesEachAttempt verifies that backoffMultiplierShift=1
+// produces exactly 2x growth per attempt: base * 2^attempt.
+func TestExponentialDelay_DoublesEachAttempt(t *testing.T) {
+	const base = 100 * time.Millisecond
+	const maxDelay = 10 * time.Second
+
+	require.Equal(t, 1, backoffMultiplierShift, "backoffMultiplierShift must be 1 for 2x growth")
+
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 100 * time.Millisecond},
+		{1, 200 * time.Millisecond},
+		{2, 400 * time.Millisecond},
+		{3, 800 * time.Millisecond},
+	}
+	for _, c := range cases {
+		got := exponentialDelay(base, maxDelay, c.attempt)
+		assert.Equal(t, c.want, got, "attempt=%d", c.attempt)
 	}
 }

--- a/adapters/rabbitmq/backoff_test.go
+++ b/adapters/rabbitmq/backoff_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExponentialDelay(t *testing.T) {
@@ -38,13 +37,11 @@ func TestExponentialDelay(t *testing.T) {
 	}
 }
 
-// TestExponentialDelay_DoublesEachAttempt verifies that backoffMultiplierShift=1
+// TestExponentialDelay_DoublesEachAttempt verifies that exponentialDelay
 // produces exactly 2x growth per attempt: base * 2^attempt.
 func TestExponentialDelay_DoublesEachAttempt(t *testing.T) {
 	const base = 100 * time.Millisecond
 	const maxDelay = 10 * time.Second
-
-	require.Equal(t, 1, backoffMultiplierShift, "backoffMultiplierShift must be 1 for 2x growth")
 
 	cases := []struct {
 		attempt int

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -556,5 +556,6 @@ func (n *noopClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (id
 
 type noopReceipt struct{}
 
-func (n *noopReceipt) Commit(_ context.Context) error  { return nil }
-func (n *noopReceipt) Release(_ context.Context) error { return nil }
+func (n *noopReceipt) Commit(_ context.Context) error                    { return nil }
+func (n *noopReceipt) Release(_ context.Context) error                   { return nil }
+func (n *noopReceipt) Extend(_ context.Context, _ time.Duration) error   { return nil }

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -2438,6 +2438,8 @@ type mockReceipt struct {
 	releaseErr    error
 	commitCtx     context.Context
 	releaseCtx    context.Context
+	extendCalls   int
+	extendErr     error
 }
 
 func (r *mockReceipt) Commit(ctx context.Context) error {
@@ -2454,6 +2456,13 @@ func (r *mockReceipt) Release(ctx context.Context) error {
 	r.releaseCalled = true
 	r.releaseCtx = ctx
 	return r.releaseErr
+}
+
+func (r *mockReceipt) Extend(_ context.Context, _ time.Duration) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.extendCalls++
+	return r.extendErr
 }
 
 var _ outbox.Receipt = (*mockReceipt)(nil)

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -23,6 +23,11 @@ import (
 // permissions) are returned to the caller immediately.
 var errSubscriptionLost = errors.New("rabbitmq: subscription lost")
 
+// maxEntryIDLength is the maximum allowed byte length for entry.ID.
+// Aligned with AMQP 0-9-1 shortstr limit (255 octets) to ensure the ID
+// can be safely embedded in AMQP message headers without truncation.
+const maxEntryIDLength = 255
+
 // isRecoverableAMQPError returns true if the error indicates a transient
 // connection/channel loss that can be recovered via reconnect. Permanent errors
 // (ACCESS_REFUSED, PRECONDITION_FAILED, channel_max exhausted) return false.
@@ -440,6 +445,28 @@ func (s *Subscriber) consumeLoop(
 	}
 }
 
+// nackPermanent calls ch.Nack(tag, false, false) and logs a warning if it fails.
+// Used for permanent errors (unmarshal, invalid entry.ID) that must not be requeued.
+func (s *Subscriber) nackPermanent(ch AMQPChannel, tag uint64, topic string) {
+	if err := ch.Nack(tag, false, false); err != nil {
+		slog.Error("rabbitmq: nack failed",
+			slog.String(logKeyTopic, topic),
+			slog.String("error", err.Error()))
+	}
+}
+
+// validateEntryID returns the reason string if entry.ID is invalid ("empty" or
+// "too_long"), or empty string if the ID is acceptable.
+func validateEntryID(id string) string {
+	if id == "" {
+		return "empty"
+	}
+	if len(id) > maxEntryIDLength {
+		return "too_long"
+	}
+	return ""
+}
+
 func (s *Subscriber) processDelivery(
 	ctx context.Context,
 	ch AMQPChannel,
@@ -456,11 +483,20 @@ func (s *Subscriber) processDelivery(
 			slog.String(logKeyTopic, topic),
 			slog.Uint64("delivery_tag", delivery.DeliveryTag),
 			slog.String("error", err.Error()))
-		if nackErr := ch.Nack(delivery.DeliveryTag, false, false); nackErr != nil {
-			slog.Error("rabbitmq: nack failed",
-				slog.String(logKeyTopic, topic),
-				slog.String("error", nackErr.Error()))
-		}
+		s.nackPermanent(ch, delivery.DeliveryTag, topic)
+		return
+	}
+
+	// Guard: reject entries with invalid ID before touching metadata or invoking handler.
+	// Defense-in-depth — valid WireMessage envelopes always have a non-empty ID, but
+	// the legacy fallback path and future format changes could produce invalid IDs.
+	if reason := validateEntryID(entry.ID); reason != "" {
+		slog.Error("rabbitmq: invalid entry.ID, nacking without requeue",
+			slog.String(logKeyTopic, topic),
+			slog.Uint64("delivery_tag", delivery.DeliveryTag),
+			slog.String("reason", reason),
+			slog.Int("len", len(entry.ID)))
+		s.nackPermanent(ch, delivery.DeliveryTag, topic)
 		return
 	}
 
@@ -627,10 +663,11 @@ func (s *Subscriber) Close() error {
 // no envelope). This format is used by adapter-level integration tests that
 // publish raw Entry JSON directly to test pub/sub primitives, predating the
 // WireMessage contract. When UnmarshalEnvelope falls back (EventType == ""),
-// we attempt json.Unmarshal into outbox.Entry. Success requires a non-empty ID.
+// we attempt json.Unmarshal into outbox.Entry. ID validation (non-empty,
+// max length) is deferred to the entry.ID guard in processDelivery.
 //
-// Broken JSON: if neither path produces a non-empty ID, we return an error so
-// that processDelivery NACKs without requeue (permanent error).
+// Broken JSON: if neither path can parse the body, we return an error so that
+// processDelivery NACKs without requeue (permanent error).
 //
 // Discriminator: UnmarshalEnvelope called with topic="" sets EventType="" on the
 // fallback path (since EventType = topic = ""), while a real WireMessage always
@@ -647,11 +684,10 @@ func unmarshalDelivery(body []byte) (outbox.Entry, error) {
 	// Fall back to legacy outbox.Entry JSON (predates WireMessage contract,
 	// still used by adapter-level integration tests that bypass the relay).
 	var legacy outbox.Entry
-	if legacyErr := json.Unmarshal(body, &legacy); legacyErr == nil && legacy.ID != "" {
+	if legacyErr := json.Unmarshal(body, &legacy); legacyErr == nil {
 		return legacy, nil
 	}
-	// Neither a valid WireMessage envelope nor a valid legacy Entry with a non-empty
-	// ID could be extracted. Treat as a permanent unmarshal error so the delivery
-	// is NACKed without requeue.
+	// Neither a valid WireMessage envelope nor a parseable legacy Entry JSON.
+	// Treat as a permanent unmarshal error so the delivery is NACKed without requeue.
 	return outbox.Entry{}, fmt.Errorf("unmarshal delivery: body is not a WireMessage envelope or legacy Entry JSON")
 }

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -686,7 +686,7 @@ func unmarshalDelivery(body []byte) (outbox.Entry, error) {
 	// Fall back to legacy outbox.Entry JSON (predates WireMessage contract,
 	// still used by adapter-level integration tests that bypass the relay).
 	var legacy outbox.Entry
-	if legacyErr := json.Unmarshal(body, &legacy); legacyErr == nil {
+	if json.Unmarshal(body, &legacy) == nil {
 		return legacy, nil
 	}
 	// Neither a valid WireMessage envelope nor a parseable legacy Entry JSON.

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -491,11 +491,17 @@ func (s *Subscriber) processDelivery(
 	// Defense-in-depth — valid WireMessage envelopes always have a non-empty ID, but
 	// the legacy fallback path and future format changes could produce invalid IDs.
 	if reason := validateEntryID(entry.ID); reason != "" {
-		slog.Error("rabbitmq: invalid entry.ID, nacking without requeue",
+		attrs := []slog.Attr{
 			slog.String(logKeyTopic, topic),
 			slog.Uint64("delivery_tag", delivery.DeliveryTag),
 			slog.String("reason", reason),
-			slog.Int("len", len(entry.ID)))
+		}
+		if reason == "too_long" {
+			// Cap the logged length to 2× maxEntryIDLength (510) to indicate
+			// overflow magnitude without exposing the full byte count.
+			attrs = append(attrs, slog.Int("len_capped", min(len(entry.ID), maxEntryIDLength*2)))
+		}
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: invalid entry.ID, nacking without requeue", attrs...)
 		s.nackPermanent(ch, delivery.DeliveryTag, topic)
 		return
 	}
@@ -522,7 +528,7 @@ func (s *Subscriber) processDelivery(
 	case outbox.DispositionAck:
 		brokerErr = ch.Ack(delivery.DeliveryTag, false)
 		if brokerErr != nil {
-			logAttrsWithContext(deliveryCtx, slog.LevelError, "rabbitmq: ack failed",
+			slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: ack failed",
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyEventID, entry.ID),
 				slog.String("error", brokerErr.Error()))
@@ -530,7 +536,7 @@ func (s *Subscriber) processDelivery(
 	case outbox.DispositionReject:
 		brokerErr = ch.Nack(delivery.DeliveryTag, false, false)
 		if brokerErr != nil {
-			logAttrsWithContext(deliveryCtx, slog.LevelError, "rabbitmq: nack(reject) failed",
+			slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: nack(reject) failed",
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyEventID, entry.ID),
 				slog.String("error", brokerErr.Error()))
@@ -538,13 +544,13 @@ func (s *Subscriber) processDelivery(
 	case outbox.DispositionRequeue:
 		brokerErr = ch.Nack(delivery.DeliveryTag, false, true)
 		if brokerErr != nil {
-			logAttrsWithContext(deliveryCtx, slog.LevelError, "rabbitmq: nack(requeue) failed",
+			slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: nack(requeue) failed",
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyEventID, entry.ID),
 				slog.String("error", brokerErr.Error()))
 		}
 	default:
-		logAttrsWithContext(deliveryCtx, slog.LevelError, "rabbitmq: unknown disposition, nacking with requeue",
+		slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: unknown disposition, nacking with requeue",
 			slog.String(logKeyTopic, topic),
 			slog.String(logKeyEventID, entry.ID),
 			slog.String("disposition", res.Disposition.String()))
@@ -553,7 +559,7 @@ func (s *Subscriber) processDelivery(
 
 	// Log handler-level error if present (separate from broker error).
 	if res.Err != nil {
-		logAttrsWithContext(deliveryCtx, slog.LevelWarn, "rabbitmq: handler reported error",
+		slog.LogAttrs(deliveryCtx, slog.LevelWarn, "rabbitmq: handler reported error",
 			slog.String(logKeyTopic, topic),
 			slog.String(logKeyEventID, entry.ID),
 			slog.String("disposition", res.Disposition.String()),
@@ -580,7 +586,7 @@ func (s *Subscriber) settleReceipt(
 
 	if brokerErr != nil {
 		if relErr := res.Receipt.Release(rctx); relErr != nil {
-			logAttrsWithContext(rctx, slog.LevelError, "rabbitmq: receipt release failed after broker error",
+			slog.LogAttrs(rctx, slog.LevelError, "rabbitmq: receipt release failed after broker error",
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyEventID, eventID),
 				slog.String("error", relErr.Error()))
@@ -591,7 +597,7 @@ func (s *Subscriber) settleReceipt(
 	switch res.Disposition {
 	case outbox.DispositionAck:
 		if err := res.Receipt.Commit(rctx); err != nil {
-			logAttrsWithContext(rctx, slog.LevelError, "rabbitmq: receipt commit failed",
+			slog.LogAttrs(rctx, slog.LevelError, "rabbitmq: receipt commit failed",
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyEventID, eventID),
 				slog.String("error", err.Error()))
@@ -599,16 +605,12 @@ func (s *Subscriber) settleReceipt(
 	default:
 		// Reject/Requeue/unknown — release so DLQ replay or redelivery can re-enter.
 		if err := res.Receipt.Release(rctx); err != nil {
-			logAttrsWithContext(rctx, slog.LevelError, "rabbitmq: receipt release failed",
+			slog.LogAttrs(rctx, slog.LevelError, "rabbitmq: receipt release failed",
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyEventID, eventID),
 				slog.String("error", err.Error()))
 		}
 	}
-}
-
-func logAttrsWithContext(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) {
-	slog.LogAttrs(ctx, level, msg, attrs...)
 }
 
 // Close terminates all active subscriptions and waits for in-flight messages.

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -1,0 +1,192 @@
+package rabbitmq
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// makeDeliveryBodyWithID constructs a WireMessage-envelope body where the
+// entry ID is replaced by the given id string. Used to test the entry.ID guard.
+func makeDeliveryBodyWithID(t *testing.T, id string) []byte {
+	t.Helper()
+	entry := outbox.Entry{
+		ID:        id,
+		EventType: "test.event",
+		Payload:   []byte(`{}`),
+	}
+	return makeDeliveryBody(t, entry)
+}
+
+// TestProcessDelivery_EmptyEntryID_RejectsToDLX verifies that an entry with
+// an empty ID is Nacked without requeue and the handler is never called.
+func TestProcessDelivery_EmptyEntryID_RejectsToDLX(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	handlerCalled := false
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use a legacy outbox.Entry JSON body with empty ID. The unmarshalDelivery
+	// legacy fallback parses this successfully (JSON is well-formed), and the
+	// entry.ID guard in processDelivery then Nacks it without requeue.
+	// Note: outbox.Entry has no json tags so PascalCase field names are used.
+	body := []byte(`{"ID":"","EventType":"test.event","Payload":"e30="}`)
+
+	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 7, Body: body}
+
+	subDone := make(chan error, 1)
+	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+
+	require.Eventually(t, func() bool {
+		ch.mu.Lock()
+		defer ch.mu.Unlock()
+		return ch.nackCalled
+	}, 2*time.Second, 5*time.Millisecond, "Nack was not called in time")
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	ch.mu.Lock()
+	nackRequeue := ch.nackRequeue
+	nackTag := ch.nackTag
+	ch.mu.Unlock()
+
+	assert.False(t, nackRequeue, "empty entry.ID must Nack without requeue")
+	assert.Equal(t, uint64(7), nackTag)
+	assert.False(t, handlerCalled, "handler must not be called for empty entry.ID")
+}
+
+// TestProcessDelivery_TooLongEntryID_RejectsToDLX verifies that an entry whose
+// ID exceeds maxEntryIDLength (255) is Nacked without requeue and the handler
+// is never called.
+func TestProcessDelivery_TooLongEntryID_RejectsToDLX(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	handlerCalled := false
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		handlerCalled = true
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Build an ID of exactly 256 bytes (maxEntryIDLength + 1).
+	tooLongID := strings.Repeat("x", 256)
+	body := makeDeliveryBodyWithID(t, tooLongID)
+
+	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 8, Body: body}
+
+	subDone := make(chan error, 1)
+	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+
+	require.Eventually(t, func() bool {
+		ch.mu.Lock()
+		defer ch.mu.Unlock()
+		return ch.nackCalled
+	}, 2*time.Second, 5*time.Millisecond, "Nack was not called in time for too-long ID")
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	ch.mu.Lock()
+	nackRequeue := ch.nackRequeue
+	nackTag := ch.nackTag
+	ch.mu.Unlock()
+
+	assert.False(t, nackRequeue, "too-long entry.ID must Nack without requeue")
+	assert.Equal(t, uint64(8), nackTag)
+	assert.False(t, handlerCalled, "handler must not be called for too-long entry.ID")
+}
+
+// TestProcessDelivery_ValidEntryID_PassesToHandler verifies that an entry with
+// ID at exactly the boundary length (255 bytes) passes the guard and reaches
+// the handler.
+func TestProcessDelivery_ValidEntryID_PassesToHandler(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	// Exactly maxEntryIDLength bytes.
+	boundaryID := strings.Repeat("a", 255)
+
+	handled := make(chan string, 1)
+	handler := func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		handled <- e.ID
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body := makeDeliveryBodyWithID(t, boundaryID)
+	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 9, Body: body}
+
+	subDone := make(chan error, 1)
+	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+
+	require.Eventually(t, func() bool {
+		ch.mu.Lock()
+		defer ch.mu.Unlock()
+		return ch.ackCalled
+	}, 2*time.Second, 5*time.Millisecond, "Ack was not called in time for boundary-length ID")
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	select {
+	case receivedID := <-handled:
+		assert.Equal(t, boundaryID, receivedID, "handler must be called with exact boundary ID")
+	case <-time.After(1 * time.Second):
+		t.Fatal("handler was not called for valid boundary-length entry.ID")
+	}
+
+	ch.mu.Lock()
+	ackTag := ch.ackTag
+	ch.mu.Unlock()
+	assert.Equal(t, uint64(9), ackTag)
+}

--- a/adapters/redis/idempotency.go
+++ b/adapters/redis/idempotency.go
@@ -256,7 +256,7 @@ func (r *redisReceipt) Extend(ctx context.Context, ttl time.Duration) error {
 	}
 	res, err := r.rdb.Eval(ctx, extendScript, []string{r.leaseKey}, r.token, ttlMs).Result()
 	if err != nil {
-		return fmt.Errorf("redis claimer: extend lease: %w", err)
+		return errcode.Wrap(ErrAdapterRedisSet, "redis claimer: extend lease", err)
 	}
 	code, ok := res.(int64)
 	if !ok || code == 0 {

--- a/adapters/redis/idempotency.go
+++ b/adapters/redis/idempotency.go
@@ -101,6 +101,20 @@ end
 return 0
 `
 
+// extendScript: atomic Extend (token-guarded):
+//
+//	KEYS[1] = lease:{key}
+//	ARGV[1] = token
+//	ARGV[2] = new TTL in milliseconds (PEXPIRE)
+//
+// Returns 1 on success, 0 if token mismatch (lease lost).
+const extendScript = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+end
+return 0
+`
+
 // Claim attempts to acquire a processing lease for the given key.
 func (c *IdempotencyClaimer) Claim(ctx context.Context, key string, leaseTTL, doneTTL time.Duration) (idempotency.ClaimState, idempotency.Receipt, error) {
 	if leaseTTL <= 0 {
@@ -160,10 +174,10 @@ type redisReceipt struct {
 	token    string
 	doneTTL  time.Duration
 
-	mu        sync.Mutex
-	committed bool
-	commitErr error
-	released  bool
+	mu         sync.Mutex
+	committed  bool
+	commitErr  error
+	released   bool
 	releaseErr error
 }
 
@@ -227,6 +241,27 @@ func (r *redisReceipt) Release(ctx context.Context) error {
 	}
 	r.releaseErr = nil // clear stale error from a previous transient failure
 	r.released = true
+	return nil
+}
+
+// Extend resets the processing-lease TTL to the given duration from now.
+// Returns idempotency.ErrLeaseExpired if the lease key is missing or the token
+// does not match (fencing failure). Redis errors are wrapped but not classified
+// as ErrLeaseExpired so callers can distinguish infrastructure failures from
+// intentional lease preemption.
+func (r *redisReceipt) Extend(ctx context.Context, ttl time.Duration) error {
+	ttlMs := ttl.Milliseconds()
+	if ttlMs < 1 {
+		ttlMs = 1
+	}
+	res, err := r.rdb.Eval(ctx, extendScript, []string{r.leaseKey}, r.token, ttlMs).Result()
+	if err != nil {
+		return fmt.Errorf("redis claimer: extend lease: %w", err)
+	}
+	code, ok := res.(int64)
+	if !ok || code == 0 {
+		return idempotency.ErrLeaseExpired
+	}
 	return nil
 }
 

--- a/adapters/redis/idempotency_test.go
+++ b/adapters/redis/idempotency_test.go
@@ -509,3 +509,26 @@ func TestIdempotencyClaimer_Receipt_Release_TransientError_ThenRetrySuccess(t *t
 	assert.False(t, hasLease, "lease key should be deleted after successful release")
 	assert.False(t, hasDone, "done key should NOT exist after release")
 }
+
+// TestClaimerMockCmdable_DoneKeyExpired_ReturnsAcquired verifies that the mock
+// treats an expired done key as absent and returns ClaimAcquired (not ClaimDone).
+// This mirrors the real Redis behavior where TTL-expired keys are invisible.
+func TestClaimerMockCmdable_DoneKeyExpired_ReturnsAcquired(t *testing.T) {
+	mock := newClaimerMock()
+	ctx := context.Background()
+
+	// Pre-set a done key that is already expired.
+	mock.mu.Lock()
+	mock.store["done:idem:expired-done:1"] = mockEntry{
+		value:  "1",
+		expiry: time.Now().Add(-1 * time.Second), // already expired
+	}
+	mock.mu.Unlock()
+
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	state, receipt, err := claimer.Claim(ctx, "idem:expired-done:1", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	// Expired done key must not block re-acquisition.
+	assert.Equal(t, idempotency.ClaimAcquired, state)
+	assert.NotNil(t, receipt)
+}

--- a/adapters/redis/idempotency_test.go
+++ b/adapters/redis/idempotency_test.go
@@ -408,6 +408,71 @@ func TestIdempotencyClaimer_Receipt_Commit_TransientError_ThenRetrySuccess(t *te
 	assert.True(t, hasDone, "done key should exist after successful commit")
 }
 
+// =============================================================================
+// Receipt.Extend tests
+// =============================================================================
+
+func TestReceipt_Extend_Success(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	_, receipt, err := claimer.Claim(ctx, "idem:extend:1", 5*time.Second, 24*time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	// Extend should succeed and update the TTL.
+	err = receipt.Extend(ctx, 10*time.Second)
+	require.NoError(t, err)
+
+	// The lease key must still exist with updated expiry.
+	mock.mu.Lock()
+	entry, hasLease := mock.store["lease:idem:extend:1"]
+	mock.mu.Unlock()
+
+	require.True(t, hasLease, "lease key should still exist after Extend")
+	// Expiry should be approximately 10s from now (within 1s tolerance).
+	assert.WithinDuration(t, time.Now().Add(10*time.Second), entry.expiry, time.Second)
+}
+
+func TestReceipt_Extend_LeaseExpired(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	_, receipt, err := claimer.Claim(ctx, "idem:extend:2", 5*time.Second, 24*time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	// Simulate lease taken by another consumer — delete the lease key.
+	mock.mu.Lock()
+	delete(mock.store, "lease:idem:extend:2")
+	mock.mu.Unlock()
+
+	// Extend on a lost lease must return ErrLeaseExpired.
+	err = receipt.Extend(ctx, 10*time.Second)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, idempotency.ErrLeaseExpired)
+}
+
+func TestReceipt_Extend_BackendDown(t *testing.T) {
+	mock := newClaimerMock()
+	claimer := newIdempotencyClaimerFromCmdable(mock)
+	ctx := context.Background()
+
+	_, receipt, err := claimer.Claim(ctx, "idem:extend:3", 5*time.Second, 24*time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	// Inject a backend error.
+	mock.evalErr = errMock
+
+	// Extend should wrap the error but NOT classify it as ErrLeaseExpired.
+	err = receipt.Extend(ctx, 10*time.Second)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, idempotency.ErrLeaseExpired, "backend error should not be ErrLeaseExpired")
+}
+
 func TestIdempotencyClaimer_Receipt_Release_TransientError_ThenRetrySuccess(t *testing.T) {
 	mock := newClaimerMock()
 	claimer := newIdempotencyClaimerFromCmdable(mock)

--- a/adapters/redis/mock_test.go
+++ b/adapters/redis/mock_test.go
@@ -277,9 +277,13 @@ func (m *claimerMockCmdable) Eval(_ context.Context, _ string, keys []string, ar
 		token := toString(args[0])
 		leaseSec, _ := toInt64(args[1])
 
-		if _, ok := m.store[doneKey]; ok {
-			cmd.SetVal(int64(0)) // ClaimDone
-			return cmd
+		if entry, ok := m.store[doneKey]; ok {
+			// Treat expired done key as absent (same as Get with expiry check).
+			if entry.expiry.IsZero() || time.Now().Before(entry.expiry) {
+				cmd.SetVal(int64(0)) // ClaimDone
+				return cmd
+			}
+			delete(m.store, doneKey) // expired
 		}
 		if entry, ok := m.store[leaseKey]; ok {
 			if entry.expiry.IsZero() || time.Now().Before(entry.expiry) {

--- a/adapters/redis/mock_test.go
+++ b/adapters/redis/mock_test.go
@@ -257,6 +257,20 @@ func (m *claimerMockCmdable) Eval(_ context.Context, _ string, keys []string, ar
 		}
 		return cmd
 
+	// Extend script: 1 key (leaseKey), 2 args (token, ttlMs)
+	case len(keys) == 1 && len(args) == 2:
+		leaseKey := keys[0]
+		token := toString(args[0])
+		ttlMs, _ := toInt64(args[1])
+		if entry, ok := m.store[leaseKey]; ok && entry.value == token {
+			entry.expiry = time.Now().Add(time.Duration(ttlMs) * time.Millisecond)
+			m.store[leaseKey] = entry
+			cmd.SetVal(int64(1))
+		} else {
+			cmd.SetVal(int64(0))
+		}
+		return cmd
+
 	// Claim script: 2 keys, keys[0] starts with "done:"
 	case len(keys) == 2 && len(args) >= 2 && strings.HasPrefix(keys[0], "done:"):
 		doneKey, leaseKey := keys[0], keys[1]

--- a/kernel/idempotency/idempotency.go
+++ b/kernel/idempotency/idempotency.go
@@ -4,8 +4,14 @@ package idempotency
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrLeaseExpired indicates the processing lease is no longer held —
+// either it expired naturally or another consumer claimed it.
+// Callers MUST stop business logic on this error and proceed to Release.
+var ErrLeaseExpired = errors.New("idempotency: processing lease expired")
 
 // DefaultTTL is the standard idempotency key TTL per the EventBus specification.
 const DefaultTTL = 24 * time.Hour
@@ -26,11 +32,19 @@ const DefaultLeaseTTL = 5 * time.Minute
 //   - DispositionRequeue + broker Nack success → Receipt.Release()
 //   - Any broker Ack/Nack failure             → Receipt.Release()
 //
+// For long-running handlers, callers MAY call Extend periodically to prevent
+// the lease from expiring mid-processing.
+//
 // Callers MUST use context.WithoutCancel for Receipt operations to ensure the
 // idempotency state is persisted even during graceful shutdown.
 type Receipt interface {
 	Commit(ctx context.Context) error
 	Release(ctx context.Context) error
+
+	// Extend resets the processing-lease TTL to the given duration from now.
+	// Returns ErrLeaseExpired if the lease is no longer held (fencing failure)
+	// or wraps the underlying backend error otherwise.
+	Extend(ctx context.Context, ttl time.Duration) error
 }
 
 // ---------------------------------------------------------------------------
@@ -60,9 +74,9 @@ const (
 // Flow:
 //  1. Claim(key) → ClaimAcquired + Receipt
 //  2. Execute business logic
-//  3a. Success → broker Ack → receipt.Commit()
-//  3b. Transient failure → broker Nack(requeue) → receipt.Release()
-//  3c. Permanent failure → broker Nack(no-requeue) → receipt.Release()
+//     3a. Success → broker Ack → receipt.Commit()
+//     3b. Transient failure → broker Nack(requeue) → receipt.Release()
+//     3c. Permanent failure → broker Nack(no-requeue) → receipt.Release()
 //
 // Note: Reject (3c) uses Release, not Commit, so that messages replayed
 // from a dead-letter queue can be reprocessed after the root cause is fixed.

--- a/kernel/idempotency/idempotency_test.go
+++ b/kernel/idempotency/idempotency_test.go
@@ -26,8 +26,9 @@ type mockClaimer struct {
 
 type mockReceipt struct{}
 
-func (mockReceipt) Commit(context.Context) error { return nil }
-func (mockReceipt) Release(context.Context) error { return nil }
+func (mockReceipt) Commit(context.Context) error                    { return nil }
+func (mockReceipt) Release(context.Context) error                   { return nil }
+func (mockReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
 
 var _ Receipt = mockReceipt{}
 

--- a/kernel/idempotency/idempotency_test.go
+++ b/kernel/idempotency/idempotency_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- ClaimState Tests ---
@@ -59,4 +60,193 @@ func TestDefaultLeaseTTL(t *testing.T) {
 
 func TestDefaultTTL(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, DefaultTTL)
+}
+
+// --- InMemClaimer / inMemReceipt Tests ---
+
+func TestInMemClaimer_Claim_Acquired(t *testing.T) {
+	c := NewInMemClaimer()
+	state, receipt, err := c.Claim(context.Background(), "key1", 5*time.Minute, 24*time.Hour)
+	assert.NoError(t, err)
+	assert.Equal(t, ClaimAcquired, state)
+	assert.NotNil(t, receipt)
+}
+
+func TestInMemClaimer_Claim_Done(t *testing.T) {
+	c := NewInMemClaimer()
+	ctx := context.Background()
+
+	// Acquire and commit.
+	_, receipt, err := c.Claim(ctx, "key-done", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, receipt.Commit(ctx))
+
+	// Second claim returns ClaimDone.
+	state, r2, err := c.Claim(ctx, "key-done", 5*time.Minute, 24*time.Hour)
+	assert.NoError(t, err)
+	assert.Equal(t, ClaimDone, state)
+	assert.Nil(t, r2)
+}
+
+func TestInMemClaimer_Claim_Busy(t *testing.T) {
+	c := NewInMemClaimer()
+	ctx := context.Background()
+
+	// Acquire lease (do not commit/release).
+	state, _, err := c.Claim(ctx, "key-busy", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, ClaimAcquired, state)
+
+	// Second claim returns ClaimBusy.
+	state2, r2, err2 := c.Claim(ctx, "key-busy", 5*time.Minute, 24*time.Hour)
+	assert.NoError(t, err2)
+	assert.Equal(t, ClaimBusy, state2)
+	assert.Nil(t, r2)
+}
+
+func TestInMemClaimer_Claim_ExpiredLease_ReacquiredBySecond(t *testing.T) {
+	c := &InMemClaimer{
+		entries: make(map[string]*inMemEntry),
+		now:     func() time.Time { return time.Unix(1000, 0) },
+	}
+	ctx := context.Background()
+
+	// Acquire with very short TTL (already expired at time=1001).
+	state, _, err := c.Claim(ctx, "key-exp", 1*time.Millisecond, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, ClaimAcquired, state)
+
+	// Advance clock past expiry.
+	c.now = func() time.Time { return time.Unix(1001, 0) }
+
+	// Second consumer should get ClaimAcquired (expired lease dropped).
+	state2, r2, err2 := c.Claim(ctx, "key-exp", 5*time.Minute, 24*time.Hour)
+	assert.NoError(t, err2)
+	assert.Equal(t, ClaimAcquired, state2)
+	assert.NotNil(t, r2)
+}
+
+func TestInMemClaimer_Release(t *testing.T) {
+	c := NewInMemClaimer()
+	ctx := context.Background()
+
+	_, receipt, err := c.Claim(ctx, "key-rel", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, receipt.Release(ctx))
+
+	// After release, a new claim should succeed.
+	state, _, err := c.Claim(ctx, "key-rel", 5*time.Minute, 24*time.Hour)
+	assert.NoError(t, err)
+	assert.Equal(t, ClaimAcquired, state)
+}
+
+func TestInMemReceipt_DoubleCommit_SecondIsNoop(t *testing.T) {
+	c := NewInMemClaimer()
+	ctx := context.Background()
+
+	_, receipt, err := c.Claim(ctx, "key-dbl", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, receipt.Commit(ctx))
+	// Second Commit is idempotent via sync.Once — returns same nil error.
+	assert.NoError(t, receipt.Commit(ctx))
+}
+
+func TestInMemReceipt_StaleCommit_AfterRelease_ReturnsError(t *testing.T) {
+	c := NewInMemClaimer()
+	ctx := context.Background()
+
+	_, receipt1, err := c.Claim(ctx, "key-stale", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, receipt1.Release(ctx))
+
+	// Another consumer reclaims the key.
+	_, _, err = c.Claim(ctx, "key-stale", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+
+	// receipt1.Commit is stale — token mismatch.
+	// sync.Once already fired (via Release), so this is a no-op returning the stored error.
+	// The error is already set from Release (nil), so we just verify no panic.
+	_ = receipt1.Commit(ctx)
+}
+
+// --- inMemReceipt.Extend tests ---
+
+func TestInMemReceipt_Extend_Success(t *testing.T) {
+	c := &InMemClaimer{
+		entries: make(map[string]*inMemEntry),
+		now:     func() time.Time { return time.Unix(1000, 0) },
+	}
+	ctx := context.Background()
+
+	_, receipt, err := c.Claim(ctx, "key-ext", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	// Advance clock and extend with a new TTL.
+	c.now = func() time.Time { return time.Unix(1100, 0) }
+	newTTL := 10 * time.Minute
+	extErr := receipt.Extend(ctx, newTTL)
+	assert.NoError(t, extErr)
+
+	// Verify the internal lease expiry was updated: should be now(1100) + 10min.
+	c.mu.Lock()
+	entry := c.entries["key-ext"]
+	c.mu.Unlock()
+	require.NotNil(t, entry)
+	expectedExpiry := time.Unix(1100, 0).Add(newTTL)
+	assert.Equal(t, expectedExpiry, entry.expiresAt)
+}
+
+func TestInMemReceipt_Extend_AfterRelease_ReturnsErrLeaseExpired(t *testing.T) {
+	c := NewInMemClaimer()
+	ctx := context.Background()
+
+	_, receipt, err := c.Claim(ctx, "key-ext-rel", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+
+	// Release drops the entry.
+	require.NoError(t, receipt.Release(ctx))
+
+	// Extend after release should return ErrLeaseExpired (entry gone).
+	extErr := receipt.Extend(ctx, 5*time.Minute)
+	assert.ErrorIs(t, extErr, ErrLeaseExpired)
+}
+
+func TestInMemReceipt_Extend_TokenMismatch_ReturnsErrLeaseExpired(t *testing.T) {
+	c := &InMemClaimer{
+		entries: make(map[string]*inMemEntry),
+		now:     func() time.Time { return time.Unix(1000, 0) },
+	}
+	ctx := context.Background()
+
+	_, receipt, err := c.Claim(ctx, "key-ext-mismatch", 5*time.Minute, 24*time.Hour)
+	require.NoError(t, err)
+
+	// Tamper with the entry's token to simulate a re-claim by another consumer.
+	c.mu.Lock()
+	c.entries["key-ext-mismatch"].token = "different-token"
+	c.mu.Unlock()
+
+	extErr := receipt.Extend(ctx, 5*time.Minute)
+	assert.ErrorIs(t, extErr, ErrLeaseExpired)
+}
+
+func TestInMemReceipt_Extend_AfterExpiredLease_ReturnsErrLeaseExpired(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := &InMemClaimer{
+		entries: make(map[string]*inMemEntry),
+		now:     func() time.Time { return now },
+	}
+	ctx := context.Background()
+
+	_, receipt, err := c.Claim(ctx, "key-ext-exp", 1*time.Millisecond, 24*time.Hour)
+	require.NoError(t, err)
+
+	// Advance clock so another Claim call drops the expired entry.
+	now = time.Unix(1002, 0)
+	// Trigger eviction by claiming again (which drops the expired entry).
+	_, _, _ = c.Claim(ctx, "key-ext-exp", 5*time.Minute, 24*time.Hour)
+	// Now the entry for old receipt is replaced — token mismatch.
+	extErr := receipt.Extend(ctx, 5*time.Minute)
+	assert.ErrorIs(t, extErr, ErrLeaseExpired)
 }

--- a/kernel/idempotency/inmem.go
+++ b/kernel/idempotency/inmem.go
@@ -121,6 +121,19 @@ func (r *inMemReceipt) Release(_ context.Context) error {
 	return r.err
 }
 
+// Extend resets the processing-lease TTL. Returns ErrLeaseExpired if the lease
+// was not held (token mismatch or entry evicted by TTL).
+func (r *inMemReceipt) Extend(_ context.Context, ttl time.Duration) error {
+	r.claimer.mu.Lock()
+	defer r.claimer.mu.Unlock()
+	entry, ok := r.claimer.entries[r.key]
+	if !ok || entry.token != r.token {
+		return ErrLeaseExpired
+	}
+	entry.expiresAt = r.claimer.now().Add(ttl)
+	return nil
+}
+
 var errStaleReceipt = errors.New("idempotency: receipt is stale (claim was released or expired)")
 
 func newToken() string {

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -19,6 +19,11 @@ const (
 	logKeyConsumerGroup = "consumer_group"
 )
 
+// backoffJitterDivisor controls jitter range for ConsumerBase retry backoff:
+// jitter ∈ [0, base/backoffJitterDivisor). Single-sided jitter (0..+50%)
+// keeps minimum delay ≥ base, avoiding thundering herd on a recovering backend.
+const backoffJitterDivisor = 2
+
 // ClaimPolicy controls ConsumerBase behavior when Claimer.Claim() fails.
 // The zero value (ClaimPolicyFailClosed) is the safe default.
 type ClaimPolicy uint8
@@ -41,6 +46,21 @@ const (
 // Valid returns true if the ClaimPolicy is a recognized enum value.
 func (p ClaimPolicy) Valid() bool {
 	return p < claimPolicySentinel
+}
+
+// String returns the lowercase kebab-case name of the ClaimPolicy.
+// Unknown values render as "unknown(N)".
+// The zero value (ClaimPolicyFailClosed) is the safe-by-default Go convention:
+// any unset ClaimPolicy field automatically uses the stricter fail-closed path.
+func (p ClaimPolicy) String() string {
+	switch p {
+	case ClaimPolicyFailClosed:
+		return "fail-closed"
+	case ClaimPolicyFailOpen:
+		return "fail-open"
+	default:
+		return fmt.Sprintf("unknown(%d)", p)
+	}
 }
 
 // ConsumerBaseConfig configures ConsumerBase behavior.
@@ -84,6 +104,12 @@ type ConsumerBaseConfig struct {
 	// and retryLoop, preventing unbounded growth with large retry counts.
 	// Default: 30s.
 	MaxRetryDelay time.Duration
+
+	// LeaseRenewalInterval is how often the lease renewal goroutine calls
+	// receipt.Extend while the handler is running. Zero falls back to
+	// LeaseTTL/3 so the lease is renewed well before it expires.
+	// Set to a negative value to disable lease renewal entirely.
+	LeaseRenewalInterval time.Duration
 }
 
 // SetDefaults populates zero-valued fields with safe defaults. Called
@@ -111,6 +137,9 @@ func (c *ConsumerBaseConfig) SetDefaults() {
 	}
 	if c.MaxRetryDelay <= 0 {
 		c.MaxRetryDelay = 30 * time.Second
+	}
+	if c.LeaseRenewalInterval == 0 {
+		c.LeaseRenewalInterval = c.LeaseTTL / 3
 	}
 }
 
@@ -286,7 +315,7 @@ func (cb *ConsumerBase) claimWithRetry(
 			base := exponentialDelay(cb.config.ClaimRetryBaseDelay, cb.config.MaxRetryDelay, attempt)
 			var jitter time.Duration
 			if base > 0 {
-				jitter = time.Duration(rand.Int64N(int64(base/2) + 1))
+				jitter = time.Duration(rand.Int64N(int64(base/backoffJitterDivisor) + 1))
 			}
 			delay := min(base+jitter, cb.config.MaxRetryDelay)
 			logWithContext(ctx, slog.LevelWarn, "outbox: idempotency claim failed, retrying locally",
@@ -337,8 +366,8 @@ func (cb *ConsumerBase) handleClaimState(
 		}
 		return HandleResult{Disposition: DispositionRequeue}
 	default:
-		// ClaimAcquired — proceed with handler, thread Receipt through.
-		return cb.retryLoop(ctx, topic, entry, handler, receipt)
+		// ClaimAcquired — start lease-renewal goroutine before invoking handler.
+		return cb.runWithRenewal(ctx, topic, entry, handler, receipt)
 	}
 }
 
@@ -449,5 +478,83 @@ func (cb *ConsumerBase) retryLoop(
 		Disposition: DispositionReject,
 		Err:         lastResult.Err,
 		Receipt:     receipt,
+	}
+}
+
+// runWithRenewal starts a background lease-renewal goroutine and then invokes
+// retryLoop with a cancellable context. If Extend returns ErrLeaseExpired the
+// context is cancelled so the handler can detect it via ctx.Done().
+//
+// The renewal goroutine exits after retryLoop returns (via cancel + done channel).
+// context.WithoutCancel wraps the Extend ctx so a shutdown-triggered cancellation
+// of the outer ctx does not prevent the last renewal/log from completing.
+//
+// Cognitive complexity is kept ≤15 by delegating the ticker loop to leaseRenewalLoop.
+func (cb *ConsumerBase) runWithRenewal(
+	ctx context.Context,
+	topic string,
+	entry Entry,
+	handler EntryHandler,
+	receipt Receipt,
+) HandleResult {
+	interval := cb.config.LeaseRenewalInterval
+	// Skip renewal when disabled (negative) or receipt is nil.
+	if interval <= 0 || receipt == nil {
+		return cb.retryLoop(ctx, topic, entry, handler, receipt)
+	}
+
+	renewCtx, cancelRenew := context.WithCancel(ctx)
+	defer cancelRenew()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cb.leaseRenewalLoop(renewCtx, topic, entry, receipt, interval, cancelRenew)
+	}()
+
+	result := cb.retryLoop(renewCtx, topic, entry, handler, receipt)
+
+	// Signal the renewal goroutine to stop and wait for it.
+	cancelRenew()
+	<-done
+
+	return result
+}
+
+// leaseRenewalLoop ticks every interval and extends the processing lease.
+// It cancels cancelFn if Extend returns ErrLeaseExpired (fencing failure).
+// Exits when ctx is cancelled (handler finished or lease lost).
+func (cb *ConsumerBase) leaseRenewalLoop(
+	ctx context.Context,
+	topic string,
+	entry Entry,
+	receipt Receipt,
+	interval time.Duration,
+	cancelFn context.CancelFunc,
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			extendCtx := context.WithoutCancel(ctx)
+			if err := receipt.Extend(extendCtx, cb.config.LeaseTTL); err != nil {
+				if errors.Is(err, idempotency.ErrLeaseExpired) {
+					logWithContext(ctx, slog.LevelError, "outbox: lease lost during processing, cancelling handler",
+						slog.String(logKeyEventID, entry.ID),
+						slog.String(logKeyTopic, topic),
+						slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup))
+					cancelFn()
+					return
+				}
+				logWithContext(ctx, slog.LevelWarn, "outbox: lease extend failed (transient), will retry",
+					slog.String(logKeyEventID, entry.ID),
+					slog.String(logKeyTopic, topic),
+					slog.String("error", err.Error()))
+			}
+		}
 	}
 }

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"math/bits"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/ghbvf/gocell/kernel/idempotency"
 )
@@ -26,6 +28,8 @@ type fakeReceipt struct {
 	mu            sync.Mutex
 	commitCalled  bool
 	releaseCalled bool
+	extendCalls   atomic.Int32
+	extendErr     error
 }
 
 func (r *fakeReceipt) Commit(_ context.Context) error {
@@ -40,6 +44,11 @@ func (r *fakeReceipt) Release(_ context.Context) error {
 	defer r.mu.Unlock()
 	r.releaseCalled = true
 	return nil
+}
+
+func (r *fakeReceipt) Extend(_ context.Context, _ time.Duration) error {
+	r.extendCalls.Add(1)
+	return r.extendErr
 }
 
 var _ Receipt = (*fakeReceipt)(nil)
@@ -97,6 +106,23 @@ func TestClaimPolicy_Valid(t *testing.T) {
 	assert.True(t, ClaimPolicyFailOpen.Valid())
 	assert.False(t, claimPolicySentinel.Valid())
 	assert.False(t, ClaimPolicy(99).Valid())
+}
+
+func TestClaimPolicy_String(t *testing.T) {
+	tests := []struct {
+		policy ClaimPolicy
+		want   string
+	}{
+		{ClaimPolicyFailClosed, "fail-closed"},
+		{ClaimPolicyFailOpen, "fail-open"},
+		{ClaimPolicy(99), "unknown(99)"},
+		{claimPolicySentinel, "unknown(2)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.policy.String())
+		})
+	}
 }
 
 func TestConsumerBaseConfig_SetDefaults_ZeroValues(t *testing.T) {
@@ -551,4 +577,173 @@ func TestConsumerBase_AsMiddleware_AppliesWrap(t *testing.T) {
 	res := wrapped(context.Background(), Entry{ID: "evt-mw"})
 	assert.False(t, called, "ClaimDone should short-circuit the wrapped handler")
 	assert.Equal(t, DispositionAck, res.Disposition)
+}
+
+// =============================================================================
+// Lease renewal tests (Task X6)
+// =============================================================================
+
+// TestWrap_LeaseRenewal_ExtendsAtInterval verifies that the lease renewal
+// goroutine calls receipt.Extend at each renewal interval while the handler
+// is running.
+func TestWrap_LeaseRenewal_ExtendsAtInterval(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	interval := 20 * time.Millisecond
+	receipt := &fakeReceipt{}
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		ConsumerGroup:        "cg",
+		LeaseTTL:             200 * time.Millisecond,
+		LeaseRenewalInterval: interval,
+	})
+	require.NoError(t, err)
+
+	handlerDone := make(chan struct{})
+	handler := cb.Wrap("topic", func(ctx context.Context, _ Entry) HandleResult {
+		// Block for ~3 intervals so renewal fires at least twice.
+		select {
+		case <-time.After(3 * interval):
+		case <-ctx.Done():
+		}
+		close(handlerDone)
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	res := handler(context.Background(), Entry{ID: "evt-renewal"})
+	<-handlerDone
+
+	assert.Equal(t, DispositionAck, res.Disposition)
+	got := int(receipt.extendCalls.Load())
+	assert.GreaterOrEqual(t, got, 2, "Extend should be called at least twice over 3 intervals")
+}
+
+// TestWrap_LeaseRenewal_ExtendFailure_CancelsHandler verifies that when
+// Extend returns ErrLeaseExpired the handler context is cancelled and the
+// result disposition is Requeue.
+func TestWrap_LeaseRenewal_ExtendFailure_CancelsHandler(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	interval := 20 * time.Millisecond
+	receipt := &fakeReceipt{}
+	// Set extendErr to ErrLeaseExpired on 2nd call.
+	callCount := atomic.Int32{}
+	receipt.extendErr = nil // default success; we override per-call below
+
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		ConsumerGroup:        "cg",
+		LeaseTTL:             200 * time.Millisecond,
+		LeaseRenewalInterval: interval,
+		RetryCount:           1,
+		RetryBaseDelay:       time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctxCancelSeen := make(chan struct{}, 1)
+	handler := cb.Wrap("topic", func(ctx context.Context, _ Entry) HandleResult {
+		// Block until context is cancelled or timeout.
+		select {
+		case <-ctx.Done():
+			ctxCancelSeen <- struct{}{}
+			return HandleResult{Disposition: DispositionRequeue, Err: ctx.Err()}
+		case <-time.After(5 * time.Second):
+			t.Error("handler blocked without ctx cancellation")
+			return HandleResult{Disposition: DispositionAck}
+		}
+	})
+
+	// Override extendErr to fail on 2nd call via a spy receipt.
+	spyReceipt := &spyExtendReceipt{
+		receipt: receipt,
+		failOn:  2,
+		err:     idempotency.ErrLeaseExpired,
+		calls:   &callCount,
+	}
+	claimer.receipt = spyReceipt
+
+	res := handler(context.Background(), Entry{ID: "evt-expire"})
+
+	select {
+	case <-ctxCancelSeen:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler context was not cancelled after Extend failure")
+	}
+
+	assert.Equal(t, DispositionRequeue, res.Disposition)
+}
+
+// spyExtendReceipt delegates to a fakeReceipt but injects an error on the Nth Extend call.
+type spyExtendReceipt struct {
+	receipt *fakeReceipt
+	failOn  int32
+	err     error
+	calls   *atomic.Int32
+}
+
+func (s *spyExtendReceipt) Commit(ctx context.Context) error  { return s.receipt.Commit(ctx) }
+func (s *spyExtendReceipt) Release(ctx context.Context) error { return s.receipt.Release(ctx) }
+func (s *spyExtendReceipt) Extend(ctx context.Context, ttl time.Duration) error {
+	n := s.calls.Add(1)
+	if n >= s.failOn {
+		return s.err
+	}
+	return s.receipt.Extend(ctx, ttl)
+}
+
+var _ Receipt = (*spyExtendReceipt)(nil)
+
+// TestWrap_LeaseRenewal_HandlerComplete_StopsGoroutine verifies that when the
+// handler completes normally, the lease renewal goroutine exits cleanly (no
+// goroutine leak).
+func TestWrap_LeaseRenewal_HandlerComplete_StopsGoroutine(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	receipt := &fakeReceipt{}
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		ConsumerGroup:        "cg",
+		LeaseTTL:             1 * time.Second,
+		LeaseRenewalInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+		// Return immediately — renewal goroutine must exit.
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	res := handler(context.Background(), Entry{ID: "evt-quick"})
+	assert.Equal(t, DispositionAck, res.Disposition)
+	// goleak.VerifyNone(t) at defer will catch any leaked goroutines.
+}
+
+// TestWrap_LeaseRenewal_DisabledWhenIntervalZeroAndTTLZero verifies that when
+// both LeaseRenewalInterval and LeaseTTL are zero (after defaults applied),
+// the handler is still called and returns normally.
+func TestWrap_LeaseRenewal_DisabledWhenIntervalZeroAndTTLZero(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	receipt := &fakeReceipt{}
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	// Use a very large interval that will never fire during the test.
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		ConsumerGroup:        "cg",
+		LeaseTTL:             idempotency.DefaultLeaseTTL,
+		LeaseRenewalInterval: 0, // should default to LeaseTTL/3
+	})
+	require.NoError(t, err)
+
+	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	res := handler(context.Background(), Entry{ID: "evt-zero"})
+	assert.Equal(t, DispositionAck, res.Disposition)
+	// With very fast handler, no Extend should have been called.
+	assert.Equal(t, int32(0), receipt.extendCalls.Load())
 }

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -721,6 +721,32 @@ func TestWrap_LeaseRenewal_HandlerComplete_StopsGoroutine(t *testing.T) {
 	// goleak.VerifyNone(t) at defer will catch any leaked goroutines.
 }
 
+// TestWrap_LeaseRenewal_DisabledWhenIntervalNegative verifies that setting
+// LeaseRenewalInterval to a negative value disables the renewal goroutine:
+// Receipt.Extend is never called, no goroutines are leaked, and the handler
+// runs to completion normally.
+func TestWrap_LeaseRenewal_DisabledWhenIntervalNegative(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	receipt := &fakeReceipt{}
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		ConsumerGroup:        "cg",
+		LeaseTTL:             idempotency.DefaultLeaseTTL,
+		LeaseRenewalInterval: -1, // negative disables renewal
+	})
+	require.NoError(t, err)
+
+	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	res := handler(context.Background(), Entry{ID: "evt-neg-interval"})
+	assert.Equal(t, DispositionAck, res.Disposition)
+	assert.Equal(t, int32(0), receipt.extendCalls.Load(), "Extend must not be called when interval is negative")
+}
+
 // TestWrap_LeaseRenewal_DisabledWhenIntervalZeroAndTTLZero verifies that when
 // both LeaseRenewalInterval and LeaseTTL are zero (after defaults applied),
 // the handler is still called and returns normally.

--- a/kernel/outbox/outboxtest/mock_receipt.go
+++ b/kernel/outbox/outboxtest/mock_receipt.go
@@ -3,6 +3,7 @@ package outboxtest
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
@@ -49,4 +50,10 @@ func (r *MockReceipt) Committed() bool {
 // Released reports whether Release was called.
 func (r *MockReceipt) Released() bool {
 	return r.released.Load()
+}
+
+// Extend is a no-op stub that always succeeds. Override in tests that need
+// to exercise lease-renewal behavior.
+func (r *MockReceipt) Extend(_ context.Context, _ time.Duration) error {
+	return nil
 }

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -524,6 +524,10 @@ func (r *mockReceipt) Release(_ context.Context) error {
 	return nil
 }
 
+func (r *mockReceipt) Extend(_ context.Context, _ time.Duration) error {
+	return nil
+}
+
 func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
 	bus := New(WithBufferSize(16))
 	defer func() { _ = bus.Close() }()


### PR DESCRIPTION
## Summary

按 `docs/plans/202604181700-domain-driven-plan.md` 域 4（Outbox/RabbitMQ）规划，本 PR 一次性闭合三项 outbox consumer 链路加固任务。

- **A5 (RL-SUB-01)** subscriber 入站 entry.ID 校验（空 / >255 字节 → 直接 Reject 到 DLX），防止 ConsumerBase 幂等键 \`cg-{group}:{id}\` 退化
- **A6** ClaimPolicy.String() + backoff 命名常量打磨；不改默认参数（explorer 报告确认 RabbitMQ 消费场景当前 1s/30s/2× 优于 cenkalti 默认）
- **X6 (SOL-B-01)** Receipt.Extend + ConsumerBase 续租 goroutine（interval=LeaseTTL/3，fail-closed）；解决长任务 handler 处理时长接近 LeaseTTL 时被另一 consumer 抢占的幂等违例

## Commits

3 个 commit 按任务拆分；A6 的 \`ClaimPolicy.String()\` 因与 X6 共享 \`kernel/outbox/consumer_base.go\`，与 X6 合并 commit（commit body 已说明）。

## 设计决策

详见 \`/Users/shengming/.claude/plans/agents-explorer-3-tdd-worktree-cozy-sloth.md\`，关键点：
- X6 API 选择 **方案 A**：Receipt.Extend + ConsumerBase 自动续租 goroutine（对齐 bsm/redislock Lock.Refresh / etcd Session.KeepAlive）
- 续租失败 → cancel handler ctx → handler 返回 Requeue（fail-closed，不假设业务可继续）
- 复用 \`context.WithoutCancel\` 模式确保续租失败 surfacing 不被 graceful shutdown 截断
- goroutine 退出由 defer cancel + done channel 同步保证；用 \`uber-go/goleak\` 验证无泄漏

## 不在本 PR 范围

- **X8** distlock 上抬 runtime/：独立 PR-OUTBOX-DISTLOCK 排期
- A6 重命名 ClaimPolicy → FailureMode：用户确认不做（业务语义更准确）
- A6 backoff 默认参数对齐 cenkalti：用户确认不做（场景不匹配）

## Test plan

- [x] \`go build ./...\` 全仓 OK
- [x] \`go test ./adapters/rabbitmq/... ./adapters/redis/... ./kernel/idempotency/... ./kernel/outbox/... ./runtime/eventbus/... -race -count=1\` 全绿
- [x] \`golangci-lint run\` 改动包 0 new issues（runtime/eventbus/eventbus.go 2 条 gocognit 为 pre-existing，未在本次改动范围）
- [x] X6 续租：\`TestWrap_LeaseRenewal_HandlerComplete_StopsGoroutine\` goleak 校验 0 残留
- [ ] CI 全绿（待跑）
- [ ] reviewer 子 agent 6 维度评审

🤖 Generated with [Claude Code](https://claude.com/claude-code)