### PR TITLE
refactor(outbox)!: Subscription as first-class + lease hard fence + explicit ready

### DIFF
--- a/adapters/rabbitmq/backoff.go
+++ b/adapters/rabbitmq/backoff.go
@@ -1,13 +1,1 @@
 package rabbitmq
-
-import (
-	"time"
-
-	"github.com/ghbvf/gocell/kernel/outbox"
-)
-
-// safeDelay is an alias for outbox.ExponentialDelay retained so existing
-// rabbitmq tests can reference the helper without churn.
-func safeDelay(base, maxDelay time.Duration, attempt int) time.Duration {
-	return outbox.ExponentialDelay(base, maxDelay, attempt)
-}

--- a/adapters/rabbitmq/backoff.go
+++ b/adapters/rabbitmq/backoff.go
@@ -1,30 +1,13 @@
 package rabbitmq
 
 import (
-	"math/bits"
 	"time"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
-// safeDelay is an alias for exponentialDelay retained so existing rabbitmq
-// tests can reference the helper without churn.
+// safeDelay is an alias for outbox.ExponentialDelay retained so existing
+// rabbitmq tests can reference the helper without churn.
 func safeDelay(base, maxDelay time.Duration, attempt int) time.Duration {
-	return exponentialDelay(base, maxDelay, attempt)
-}
-
-// exponentialDelay computes base * 2^attempt with overflow protection, capped at maxDelay.
-// If base is zero or negative, it returns 0. The bits.Len64 technique determines
-// the maximum safe left-shift to avoid integer overflow before comparing against maxDelay.
-func exponentialDelay(base, maxDelay time.Duration, attempt int) time.Duration {
-	if base <= 0 {
-		return 0
-	}
-	maxSafeShift := 63 - bits.Len64(uint64(base))
-	if attempt > maxSafeShift {
-		return maxDelay
-	}
-	delay := base * (1 << uint(attempt))
-	if delay <= 0 || delay > maxDelay {
-		return maxDelay
-	}
-	return delay
+	return outbox.ExponentialDelay(base, maxDelay, attempt)
 }

--- a/adapters/rabbitmq/backoff_test.go
+++ b/adapters/rabbitmq/backoff_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
 func TestExponentialDelay(t *testing.T) {
@@ -31,13 +33,13 @@ func TestExponentialDelay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := exponentialDelay(tt.base, tt.maxDelay, tt.attempt)
+			got := outbox.ExponentialDelay(tt.base, tt.maxDelay, tt.attempt)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-// TestExponentialDelay_DoublesEachAttempt verifies that exponentialDelay
+// TestExponentialDelay_DoublesEachAttempt verifies that ExponentialDelay
 // produces exactly 2x growth per attempt: base * 2^attempt.
 func TestExponentialDelay_DoublesEachAttempt(t *testing.T) {
 	const base = 100 * time.Millisecond
@@ -53,7 +55,7 @@ func TestExponentialDelay_DoublesEachAttempt(t *testing.T) {
 		{3, 800 * time.Millisecond},
 	}
 	for _, c := range cases {
-		got := exponentialDelay(base, maxDelay, c.attempt)
+		got := outbox.ExponentialDelay(base, maxDelay, c.attempt)
 		assert.Equal(t, c.want, got, "attempt=%d", c.attempt)
 	}
 }

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -28,6 +28,7 @@ const (
 	ErrAdapterAMQPConsume            errcode.Code = "ERR_ADAPTER_AMQP_CONSUME"
 	ErrAdapterAMQPReconnectExhausted errcode.Code = "ERR_ADAPTER_AMQP_RECONNECT_EXHAUSTED"
 	ErrAdapterAMQPReconnecting       errcode.Code = "ERR_ADAPTER_AMQP_RECONNECTING"
+	ErrAdapterAMQPCloseTimeout       errcode.Code = "ERR_ADAPTER_AMQP_CLOSE_TIMEOUT"
 )
 
 // Pre-allocated Health() errors to avoid per-call allocation.

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -14,6 +14,7 @@ import (
 
 	amqp "github.com/rabbitmq/amqp091-go"
 
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
@@ -469,7 +470,7 @@ func (c *Connection) reconnectWithBackoff() bool {
 // capped result is always in [0.75*max, max]. This prevents thundering-herd
 // at the cap while keeping ReconnectMaxBackoff as a true upper bound.
 func (c *Connection) backoffDelay(attempt int) time.Duration {
-	delay := exponentialDelay(c.config.ReconnectBaseDelay, c.config.ReconnectMaxBackoff, attempt)
+	delay := outbox.ExponentialDelay(c.config.ReconnectBaseDelay, c.config.ReconnectMaxBackoff, attempt)
 	if delay >= c.config.ReconnectMaxBackoff {
 		return addDownJitter(c.config.ReconnectMaxBackoff)
 	}

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -185,10 +185,10 @@ func TestIntegration_PublishConsume(t *testing.T) {
 	// Run subscriber in a goroutine since Subscribe blocks.
 	subErrCh := make(chan error, 1)
 	go func() {
-		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		subErrCh <- sub.Subscribe(subCtx, outbox.Subscription{Topic: topic, ConsumerGroup: "integration-test"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			received <- e
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "integration-test")
+		})
 	}()
 
 	// Wait until Subscribe has declared, bound, and started consuming from the queue.
@@ -295,7 +295,6 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	cb, cbErr := outbox.NewConsumerBase(
 		&noopClaimer{},
 		outbox.ConsumerBaseConfig{
-			ConsumerGroup:  "test-retry-e2e",
 			RetryCount:     2,
 			RetryBaseDelay: 50 * time.Millisecond,
 			IdempotencyTTL: time.Hour,
@@ -315,14 +314,14 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	subCtx, subCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer subCancel()
 
-	wrappedHandler := cb.Wrap(topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	wrappedHandler := cb.Wrap(outbox.Subscription{Topic: topic, ConsumerGroup: "test-retry-e2e"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		callCount.Add(1)
 		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: assert.AnError}
 	})
 
 	subErrCh := make(chan error, 1)
 	go func() {
-		subErrCh <- sub.Subscribe(subCtx, topic, wrappedHandler, "test-retry-e2e")
+		subErrCh <- sub.Subscribe(subCtx, outbox.Subscription{Topic: topic, ConsumerGroup: "test-retry-e2e"}, wrappedHandler)
 	}()
 
 	waitForSubscriberReady(t, conn, mainQueue, subErrCh, 5*time.Second)
@@ -485,14 +484,14 @@ func TestIntegration_DLXBrokerNative(t *testing.T) {
 	handlerCalled := make(chan struct{}, 1)
 	subErrCh := make(chan error, 1)
 	go func() {
-		subErrCh <- sub.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		subErrCh <- sub.Subscribe(subCtx, outbox.Subscription{Topic: topic, ConsumerGroup: "integration-test-dlx"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			handlerCalled <- struct{}{}
 			// Permanent rejection — broker should route to DLX.
 			return outbox.HandleResult{
 				Disposition: outbox.DispositionReject,
 				Err:         assert.AnError,
 			}
-		}, "integration-test-dlx")
+		})
 	}()
 
 	waitForSubscriberReady(t, conn, mainQueue, subErrCh, 5*time.Second)

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -555,6 +555,6 @@ func (n *noopClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (id
 
 type noopReceipt struct{}
 
-func (n *noopReceipt) Commit(_ context.Context) error                    { return nil }
-func (n *noopReceipt) Release(_ context.Context) error                   { return nil }
-func (n *noopReceipt) Extend(_ context.Context, _ time.Duration) error   { return nil }
+func (n *noopReceipt) Commit(_ context.Context) error                  { return nil }
+func (n *noopReceipt) Release(_ context.Context) error                 { return nil }
+func (n *noopReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -3553,27 +3553,27 @@ func TestProcessDelivery_UnknownDisposition_NackWithRequeue(t *testing.T) {
 }
 
 func TestSafeDelay_LargeAttempt_NoPanic(t *testing.T) {
-	result := safeDelay(time.Second, 30*time.Second, 100)
+	result := outbox.ExponentialDelay(time.Second, 30*time.Second, 100)
 	assert.Equal(t, 30*time.Second, result)
 }
 
 func TestSafeDelay_ZeroBase(t *testing.T) {
-	result := safeDelay(0, 30*time.Second, 5)
+	result := outbox.ExponentialDelay(0, 30*time.Second, 5)
 	assert.Equal(t, time.Duration(0), result)
 }
 
 func TestSafeDelay_NormalRange(t *testing.T) {
-	result := safeDelay(time.Second, 30*time.Second, 3)
+	result := outbox.ExponentialDelay(time.Second, 30*time.Second, 3)
 	assert.Equal(t, 8*time.Second, result)
 }
 
 func TestSafeDelay_ExceedsMax(t *testing.T) {
-	result := safeDelay(time.Second, 30*time.Second, 10)
+	result := outbox.ExponentialDelay(time.Second, 30*time.Second, 10)
 	assert.Equal(t, 30*time.Second, result) // 1024s > 30s → capped
 }
 
 func TestSafeDelay_NegativeBase(t *testing.T) {
-	result := safeDelay(-time.Second, 30*time.Second, 3)
+	result := outbox.ExponentialDelay(-time.Second, 30*time.Second, 3)
 	assert.Equal(t, time.Duration(0), result)
 }
 
@@ -3676,11 +3676,11 @@ func TestConsumerBase_WrapWithClaimer_WrappedPermanentError_Detected(t *testing.
 // TestConnection_ReconnectWithBackoff_TransientError_ContinuesIndefinitely.
 
 // =============================================================================
-// safeDelay boundary tests (S3 P2)
+// ExponentialDelay boundary tests (S3 P2)
 // =============================================================================
 
 func TestSafeDelay_AttemptZero(t *testing.T) {
-	result := safeDelay(time.Second, 30*time.Second, 0)
+	result := outbox.ExponentialDelay(time.Second, 30*time.Second, 0)
 	assert.Equal(t, time.Second, result) // base * 2^0 = base
 }
 
@@ -3688,10 +3688,10 @@ func TestSafeDelay_ExactMaxSafeShift(t *testing.T) {
 	base := time.Second
 	maxSafeShift := 63 - bits.Len64(uint64(base))
 	// At maxSafeShift, result should still be capped to maxDelay.
-	result := safeDelay(base, 30*time.Second, maxSafeShift)
+	result := outbox.ExponentialDelay(base, 30*time.Second, maxSafeShift)
 	assert.Equal(t, 30*time.Second, result)
 	// At maxSafeShift+1, also capped (overflow guard).
-	result2 := safeDelay(base, 30*time.Second, maxSafeShift+1)
+	result2 := outbox.ExponentialDelay(base, 30*time.Second, maxSafeShift+1)
 	assert.Equal(t, 30*time.Second, result2)
 }
 

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -1192,6 +1192,7 @@ func TestPublisher_Publish_TerminalState_ReturnsPermanentError(t *testing.T) {
 
 func TestSubscriber_InterfaceCompliance(t *testing.T) {
 	var _ outbox.Subscriber = (*Subscriber)(nil)
+	//nolint:staticcheck // SubscriberInitializer is deprecated but Subscriber implements it for backward compat.
 	var _ outbox.SubscriberInitializer = (*Subscriber)(nil)
 }
 
@@ -1331,7 +1332,7 @@ func TestSubscriber_Subscribe_ProcessesDelivery(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 1, Body: entryBytes}
 
 	subDone := make(chan error, 1)
-	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
 
 	// Deterministic wait: poll until Ack is recorded instead of time.Sleep.
 	require.Eventually(t, func() bool {
@@ -1385,7 +1386,7 @@ func TestSubscriber_Subscribe_UnmarshalFailure_Nack(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 1, Body: []byte("not valid json{{{")}
 
 	subDone := make(chan error, 1)
-	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
 
 	require.Eventually(t, func() bool {
 		ch.mu.Lock()
@@ -1480,7 +1481,7 @@ func TestSubscriber_Subscribe_HandlerError_NackWithRequeue(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 1, Body: entryBytes}
 
 	subDone := make(chan error, 1)
-	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
 
 	require.Eventually(t, func() bool {
 		ch.mu.Lock()
@@ -1515,7 +1516,7 @@ func TestSubscriber_Subscribe_DefaultQueueName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately so Subscribe exits.
 
-	err := sub.Subscribe(ctx, "my.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "my.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1537,7 +1538,7 @@ func TestSubscriber_Subscribe_AfterClose(t *testing.T) {
 
 	assert.NoError(t, sub.Close())
 
-	err := sub.Subscribe(context.Background(), "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(context.Background(), outbox.Subscription{Topic: "test.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_AMQP_SUBSCRIBE")
 }
@@ -1580,7 +1581,7 @@ func TestSubscriber_DeliveryChannelClosed_TriggersReconnect(t *testing.T) {
 	// from the main test goroutine (t.FailNow must not be called from a helper goroutine).
 	subscribeDone := make(chan error, 1)
 	go func() {
-		subscribeDone <- sub.Subscribe(ctx, "test.topic", handler, "")
+		subscribeDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler)
 	}()
 
 	// Drive the reconnect sequence from the main goroutine (safe for require).
@@ -1658,7 +1659,7 @@ func TestSubscriber_ReconnectLoop_CtxCancelledDuringWait(t *testing.T) {
 		cancel()
 	}()
 
-	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err) // Clean exit via ctx cancel during WaitConnected.
 }
 
@@ -1836,8 +1837,8 @@ func TestSubscriber_Subscribe_ClosedDuringReconnect(t *testing.T) {
 	// reach Y" sleeps are needed.
 	subscribeDone := make(chan error, 1)
 	go func() {
-		subscribeDone <- sub.Subscribe(context.Background(), "test.topic",
-			outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+		subscribeDone <- sub.Subscribe(context.Background(), outbox.Subscription{Topic: "test.topic"},
+			outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	}()
 
 	// Let the subscriber enter the reconnect hot-loop. The loop iterates in
@@ -1883,7 +1884,7 @@ func TestSubscriber_Subscribe_ConsumerGroupQueueName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately so Subscribe exits after setup.
 
-	err := sub.Subscribe(ctx, "session.created", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "session.created"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1912,7 +1913,7 @@ func TestSubscriber_Subscribe_ExplicitQueueName_OverridesConsumerGroup(t *testin
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "session.created", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "session.created"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1939,7 +1940,7 @@ func TestSubscriber_Subscribe_NoConsumerGroup_FallsBackToTopic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "my.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "my.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1966,7 +1967,7 @@ func TestSubscriber_Subscribe_DLXExchange_SetsQueueArgs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -1996,7 +1997,7 @@ func TestSubscriber_Subscribe_DLXExchangeWithRoutingKey(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	assert.NoError(t, err)
 
 	ch.mu.Lock()
@@ -2016,7 +2017,7 @@ func TestSubscriber_Subscribe_NoDLX_ReturnsError(t *testing.T) {
 		// DLXExchange deliberately left empty.
 	})
 
-	err := sub.Subscribe(context.Background(), "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(context.Background(), outbox.Subscription{Topic: "test.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "DLXExchange is required")
 }
@@ -2082,7 +2083,7 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithRequeue(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 42, Body: entryBytes}
 
 	subDone := make(chan error, 1)
-	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
 
 	// Deterministic wait for NACK instead of fixed sleep — handler cancels
 	// ctx synchronously, so Subscribe will exit shortly after processDelivery
@@ -2115,17 +2116,15 @@ func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "mw-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
-	// AsMiddleware's return type is outbox.TopicHandlerMiddleware — compile
+	// AsMiddleware's return type is outbox.SubscriptionMiddleware — compile
 	// enforces the test name's contract.
 	mw := cb.AsMiddleware()
 
 	handlerCalled := false
-	wrapped := mw("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+	wrapped := mw(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "mw-group"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		assert.Equal(t, "evt-mw-001", e.ID)
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
@@ -2141,15 +2140,13 @@ func TestConsumerBase_AsMiddleware_ReturnsTopicHandlerMiddleware(t *testing.T) {
 func TestConsumerBase_AsMiddleware_Idempotency_SkipsDuplicate(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimDone}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "mw-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
 	mw := cb.AsMiddleware()
 
 	handlerCalled := false
-	wrapped := mw("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	wrapped := mw(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "mw-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -2165,7 +2162,6 @@ func TestConsumerBase_AsMiddleware_RejectOnPermanentError(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "mw-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
@@ -2173,7 +2169,7 @@ func TestConsumerBase_AsMiddleware_RejectOnPermanentError(t *testing.T) {
 
 	mw := cb.AsMiddleware()
 
-	wrapped := mw("orders.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	wrapped := mw(outbox.Subscription{Topic: "orders.created", ConsumerGroup: "mw-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{
 			Disposition: outbox.DispositionRequeue,
 			Err:         outbox.NewPermanentError(errors.New("corrupted payload")),
@@ -2196,9 +2192,7 @@ func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 		{state: idempotency.ClaimDone},
 	}}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "integration-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
 	// Use a simple recording subscriber to verify the chain works end-to-end.
@@ -2212,7 +2206,7 @@ func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 
 	wrappedSub := &outbox.SubscriberWithMiddleware{
 		Inner:      innerSub,
-		Middleware: []outbox.TopicHandlerMiddleware{cb.AsMiddleware()},
+		Middleware: []outbox.SubscriptionMiddleware{cb.AsMiddleware()},
 	}
 
 	var receivedEntry outbox.Entry
@@ -2223,7 +2217,7 @@ func TestConsumerBase_AsMiddleware_WithSubscriberWithMiddleware(t *testing.T) {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
-	err := wrappedSub.Subscribe(context.Background(), "events.test", handler, "")
+	err := wrappedSub.Subscribe(context.Background(), outbox.Subscription{Topic: "events.test"}, handler)
 	assert.NoError(t, err)
 	require.NotNil(t, capturedHandler)
 
@@ -2248,9 +2242,7 @@ func TestConsumerBase_AsMiddleware_WithObservabilityContextMiddleware(t *testing
 		receipt: receipt,
 	}}}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "integration-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
 	var capturedHandler outbox.EntryHandler
@@ -2263,7 +2255,7 @@ func TestConsumerBase_AsMiddleware_WithObservabilityContextMiddleware(t *testing
 
 	wrappedSub := &outbox.SubscriberWithMiddleware{
 		Inner: innerSub,
-		Middleware: []outbox.TopicHandlerMiddleware{
+		Middleware: []outbox.SubscriptionMiddleware{
 			outbox.ObservabilityContextMiddleware(),
 			cb.AsMiddleware(),
 		},
@@ -2277,7 +2269,7 @@ func TestConsumerBase_AsMiddleware_WithObservabilityContextMiddleware(t *testing
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
-	err := wrappedSub.Subscribe(context.Background(), "events.test", handler, "")
+	err := wrappedSub.Subscribe(context.Background(), outbox.Subscription{Topic: "events.test"}, handler)
 	assert.NoError(t, err)
 	require.NotNil(t, capturedHandler)
 
@@ -2315,9 +2307,7 @@ func TestConsumerBase_AsMiddleware_LogsRestoredContext(t *testing.T) {
 		receipt: receipt,
 	}}}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "integration-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
 	var capturedHandler outbox.EntryHandler
@@ -2330,7 +2320,7 @@ func TestConsumerBase_AsMiddleware_LogsRestoredContext(t *testing.T) {
 
 	wrappedSub := &outbox.SubscriberWithMiddleware{
 		Inner: innerSub,
-		Middleware: []outbox.TopicHandlerMiddleware{
+		Middleware: []outbox.SubscriptionMiddleware{
 			outbox.ObservabilityContextMiddleware(),
 			cb.AsMiddleware(),
 		},
@@ -2343,7 +2333,7 @@ func TestConsumerBase_AsMiddleware_LogsRestoredContext(t *testing.T) {
 		}
 	}
 
-	err := wrappedSub.Subscribe(context.Background(), "events.test", handler, "")
+	err := wrappedSub.Subscribe(context.Background(), outbox.Subscription{Topic: "events.test"}, handler)
 	assert.NoError(t, err)
 	require.NotNil(t, capturedHandler)
 
@@ -2370,13 +2360,18 @@ type stubSubscriber struct {
 	onSubscribe func(context.Context, string, outbox.EntryHandler) error
 }
 
-func (s *stubSubscriber) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler, _ string) error {
+func (s *stubSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *stubSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *stubSubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.EntryHandler) error {
 	if s.onSubscribe != nil {
-		return s.onSubscribe(ctx, topic, handler)
+		return s.onSubscribe(ctx, sub.Topic, handler)
 	}
 	return nil
 }
-
 func (s *stubSubscriber) Close() error { return nil }
 
 var _ outbox.Subscriber = (*stubSubscriber)(nil)
@@ -2490,13 +2485,11 @@ func TestConsumerBase_WrapWithClaimer_Success_ReturnsReceipt(t *testing.T) {
 	receipt := &mockReceipt{}
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "test-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -2517,13 +2510,11 @@ func TestConsumerBase_WrapWithClaimer_Success_ReturnsReceipt(t *testing.T) {
 func TestConsumerBase_WrapWithClaimer_ClaimDone_SkipsHandler(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimDone}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "test-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -2537,13 +2528,11 @@ func TestConsumerBase_WrapWithClaimer_ClaimDone_SkipsHandler(t *testing.T) {
 func TestConsumerBase_WrapWithClaimer_ClaimBusy_Requeues(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimBusy}
 
-	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "test-group",
-	})
+	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{})
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -2558,13 +2547,12 @@ func TestConsumerBase_WrapWithClaimer_Reject_ThreadsReceipt(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryCount:     1,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("fail")}
 	})
 
@@ -2584,13 +2572,12 @@ func TestConsumerBase_WrapWithClaimer_ExplicitReject_FirstRoundNoRetry(t *testin
 
 	handlerCallCount := 0
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCallCount++
 		return outbox.HandleResult{
 			Disposition: outbox.DispositionReject,
@@ -2610,13 +2597,12 @@ func TestConsumerBase_WrapWithClaimer_WrappedPermanentError_FirstRoundReject(t *
 
 	handlerCallCount := 0
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCallCount++
 		// Wrapped PermanentError — must be detected by errors.As through fmt.Errorf wrapping.
 		return outbox.HandleResult{
@@ -2673,14 +2659,13 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_LocalRetryThe
 	}}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 10 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -2701,14 +2686,13 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_HasBackoff(t 
 	// ClaimRetryCount=3, ClaimRetryBaseDelay=20ms → sleeps between attempts.
 	// With jitter, we assert >= base delay only (not exact).
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 20 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -2730,13 +2714,12 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_CtxCancel(t *
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 5 * time.Second, // long delay — ctx cancel must short-circuit
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
@@ -2759,13 +2742,12 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_DefaultFailClosed_RetryCount1(t
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     1,
 		ClaimRetryBaseDelay: 5 * time.Second,
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
@@ -2790,7 +2772,6 @@ func TestConsumerBase_WrapWithClaimer_ClaimRetryConfig_Independent(t *testing.T)
 	}}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		RetryCount:          5,                     // handler retries — should not affect claim
 		RetryBaseDelay:      1 * time.Second,       // handler backoff — should not affect claim
 		ClaimRetryCount:     2,                     // claim retries
@@ -2799,7 +2780,7 @@ func TestConsumerBase_WrapWithClaimer_ClaimRetryConfig_Independent(t *testing.T)
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -2823,14 +2804,13 @@ func TestConsumerBase_MaxRetryDelay_Caps_ClaimBackoff(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 100 * time.Millisecond,
 		MaxRetryDelay:       50 * time.Millisecond, // cap below base — forces all delays to 50ms
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
@@ -2848,13 +2828,12 @@ func TestConsumerBase_NegativeClaimRetryBaseDelay_NoPanic(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     2,
 		ClaimRetryBaseDelay: -1 * time.Second, // negative — must not panic
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
@@ -2867,14 +2846,13 @@ func TestConsumerBase_NegativeMaxRetryDelay_NoPanic(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimRetryCount:     2,
 		ClaimRetryBaseDelay: 10 * time.Millisecond,
 		MaxRetryDelay:       -1 * time.Second, // negative — must not panic
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
@@ -3189,7 +3167,7 @@ func TestProcessDelivery_Reject_NoDLX_SubscribeReturnsError(t *testing.T) {
 		// DLXExchange deliberately left empty.
 	})
 
-	err := sub.Subscribe(context.Background(), "test.topic", outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }), "")
+	err := sub.Subscribe(context.Background(), outbox.Subscription{Topic: "test.topic"}, outbox.WrapLegacyHandler(func(_ context.Context, _ outbox.Entry) error { return nil }))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "DLXExchange is required")
 }
@@ -3198,12 +3176,11 @@ func TestConsumerBase_WrapWithClaimer_ClaimBusy_HasBackoff(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimBusy}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryBaseDelay: 50 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		t.Fatal("handler should not be called for ClaimBusy")
 		return outbox.HandleResult{}
 	})
@@ -3258,7 +3235,6 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_FailClosed(t *testing.T) {
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:       "test-group",
 		ClaimPolicy:         outbox.ClaimPolicyFailClosed,
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 10 * time.Millisecond,
@@ -3266,7 +3242,7 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_FailClosed(t *testing.T) {
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -3282,13 +3258,12 @@ func TestConsumerBase_WrapWithClaimer_ClaimError_FailOpen_Explicit(t *testing.T)
 	claimer := &mockClaimer{err: errors.New("redis down")}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "test-group",
-		ClaimPolicy:   outbox.ClaimPolicyFailOpen,
+		ClaimPolicy: outbox.ClaimPolicyFailOpen,
 	})
 	require.NoError(t, cbErr)
 
 	handlerCalled := false
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		handlerCalled = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
@@ -3307,8 +3282,7 @@ func TestClaimPolicy_Valid(t *testing.T) {
 
 func TestNewConsumerBase_InvalidClaimPolicy_ReturnsError(t *testing.T) {
 	_, err := outbox.NewConsumerBase(&mockClaimer{}, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "test",
-		ClaimPolicy:   outbox.ClaimPolicy(99),
+		ClaimPolicy: outbox.ClaimPolicy(99),
 	})
 	require.Error(t, err, "NewConsumerBase must return error on invalid ClaimPolicy")
 	assert.Contains(t, err.Error(), "invalid ClaimPolicy 99")
@@ -3325,8 +3299,7 @@ func TestNewConsumerBase_ValidClaimPolicy_Succeeds(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cb, err := outbox.NewConsumerBase(&mockClaimer{}, outbox.ConsumerBaseConfig{
-				ConsumerGroup: "test",
-				ClaimPolicy:   tt.policy,
+				ClaimPolicy: tt.policy,
 			})
 			require.NoError(t, err)
 			assert.NotNil(t, cb)
@@ -3340,8 +3313,7 @@ func TestNewConsumerBase_ExplicitFailClosed_Preserved(t *testing.T) {
 	// confirm fail-closed semantics (single Claim attempt returns a wrapped result
 	// that is_NOT_ fail-open's proceed-without-receipt path).
 	cb, err := outbox.NewConsumerBase(&mockClaimer{}, outbox.ConsumerBaseConfig{
-		ConsumerGroup: "test",
-		ClaimPolicy:   outbox.ClaimPolicyFailClosed,
+		ClaimPolicy: outbox.ClaimPolicyFailClosed,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, cb)
@@ -3358,7 +3330,6 @@ func TestConsumerBase_RetryLoop_CtxCancelledAfterFinalAttempt_Requeues(t *testin
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryCount:     1, // single attempt, no inter-attempt sleep
 		RetryBaseDelay: time.Millisecond,
 	})
@@ -3366,7 +3337,7 @@ func TestConsumerBase_RetryLoop_CtxCancelledAfterFinalAttempt_Requeues(t *testin
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		// Cancel context during the handler — simulates shutdown mid-processing.
 		cancel()
 		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
@@ -3608,14 +3579,13 @@ func TestConsumerBase_WrapWithClaimer_TransientError_ThenSuccess(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryCount:     3,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
 	attempt := 0
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		n := attempt
 		attempt++
 		if n == 0 {
@@ -3641,14 +3611,13 @@ func TestConsumerBase_WrapWithClaimer_ExplicitReject_NoRetry(t *testing.T) {
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryCount:     5,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
 	callCount := 0
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		callCount++
 		return outbox.HandleResult{
 			Disposition: outbox.DispositionReject,
@@ -3671,14 +3640,13 @@ func TestConsumerBase_WrapWithClaimer_WrappedPermanentError_Detected(t *testing.
 	claimer := &mockClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, cbErr := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{
-		ConsumerGroup:  "test-group",
 		RetryCount:     5,
 		RetryBaseDelay: 10 * time.Millisecond,
 	})
 	require.NoError(t, cbErr)
 
 	callCount := 0
-	handler := cb.Wrap("test.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	handler := cb.Wrap(outbox.Subscription{Topic: "test.topic", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		callCount++
 		return outbox.HandleResult{
 			Disposition: outbox.DispositionRequeue,
@@ -4278,7 +4246,6 @@ func TestConsumerBase_RetryExhaustion(t *testing.T) {
 	cb, cbErr := outbox.NewConsumerBase(
 		claimer,
 		outbox.ConsumerBaseConfig{
-			ConsumerGroup:  "test-retry-group",
 			RetryCount:     2,
 			RetryBaseDelay: 10 * time.Millisecond,
 			IdempotencyTTL: time.Hour,
@@ -4286,9 +4253,8 @@ func TestConsumerBase_RetryExhaustion(t *testing.T) {
 	)
 	require.NoError(t, cbErr)
 
-	topic := "test.retry.unit"
 	callCount := 0
-	wrappedHandler := cb.Wrap(topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	wrappedHandler := cb.Wrap(outbox.Subscription{Topic: "test.retry.unit", ConsumerGroup: "test-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		callCount++
 		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: assert.AnError}
 	})

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -3193,7 +3193,13 @@ func TestConsumerBase_WrapWithClaimer_ClaimBusy_HasBackoff(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond, "ClaimBusy should backoff before requeue")
 }
 
-func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
+// TestProcessDelivery_BrokerAckFails_CommitAlreadyDone verifies the new
+// Commit→Ack ordering: if broker Ack fails after a successful Commit, the
+// Receipt is already committed (idempotency key is marked done). The message
+// will be redelivered, but the ClaimDone state ensures redelivery is a no-op.
+// We do NOT Release after a committed receipt — the idempotency key protects
+// against duplicate processing on redelivery.
+func TestProcessDelivery_BrokerAckFails_CommitAlreadyDone(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 	ch := newMockChannel()
 	ch.ackErr = errors.New("channel closed")
@@ -3206,7 +3212,7 @@ func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
 		ShutdownTimeout: 2 * time.Second,
 	})
 
-	receipt := &mockReceipt{}
+	receipt := &mockReceipt{} // commitErr = nil → Commit succeeds
 	entry := outbox.Entry{ID: "evt-broker-fail", EventType: "test.brokerfail"}
 	entryBytes := makeDeliveryBody(t, entry)
 
@@ -3222,8 +3228,10 @@ func TestProcessDelivery_BrokerAckFails_ReleasesReceipt(t *testing.T) {
 	}, "test.topic", handler)
 
 	receipt.mu.Lock()
-	assert.False(t, receipt.commitCalled, "should not Commit when broker Ack fails")
-	assert.True(t, receipt.releaseCalled, "should Release when broker Ack fails")
+	// With Commit→Ack ordering, Commit is called before Ack.
+	// Commit succeeds, then Ack fails. Receipt is already committed.
+	assert.True(t, receipt.commitCalled, "Commit must be called before Ack attempt")
+	assert.False(t, receipt.releaseCalled, "must NOT Release after committed receipt — idempotency key is already done")
 	receipt.mu.Unlock()
 }
 

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -542,42 +542,7 @@ func (s *Subscriber) processDelivery(
 	// Solution B: handler returns HandleResult with explicit Disposition + Receipt.
 	res := handler(deliveryCtx, entry)
 
-	// Execute broker-level disposition.
-	var brokerErr error
-	switch res.Disposition {
-	case outbox.DispositionAck:
-		brokerErr = ch.Ack(delivery.DeliveryTag, false)
-		if brokerErr != nil {
-			slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: ack failed",
-				slog.String(logKeyTopic, topic),
-				slog.String(logKeyEventID, entry.ID),
-				slog.String("error", brokerErr.Error()))
-		}
-	case outbox.DispositionReject:
-		brokerErr = ch.Nack(delivery.DeliveryTag, false, false)
-		if brokerErr != nil {
-			slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: nack(reject) failed",
-				slog.String(logKeyTopic, topic),
-				slog.String(logKeyEventID, entry.ID),
-				slog.String("error", brokerErr.Error()))
-		}
-	case outbox.DispositionRequeue:
-		brokerErr = ch.Nack(delivery.DeliveryTag, false, true)
-		if brokerErr != nil {
-			slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: nack(requeue) failed",
-				slog.String(logKeyTopic, topic),
-				slog.String(logKeyEventID, entry.ID),
-				slog.String("error", brokerErr.Error()))
-		}
-	default:
-		slog.LogAttrs(deliveryCtx, slog.LevelError, "rabbitmq: unknown disposition, nacking with requeue",
-			slog.String(logKeyTopic, topic),
-			slog.String(logKeyEventID, entry.ID),
-			slog.String("disposition", res.Disposition.String()))
-		brokerErr = ch.Nack(delivery.DeliveryTag, false, true)
-	}
-
-	// Log handler-level error if present (separate from broker error).
+	// Log handler-level error if present (separate from broker disposition).
 	if res.Err != nil {
 		slog.LogAttrs(deliveryCtx, slog.LevelWarn, "rabbitmq: handler reported error",
 			slog.String(logKeyTopic, topic),
@@ -586,50 +551,115 @@ func (s *Subscriber) processDelivery(
 			slog.String("error", res.Err.Error()))
 	}
 
-	s.settleReceipt(deliveryCtx, res, topic, entry.ID, brokerErr)
+	s.dispatchDisposition(deliveryCtx, ch, delivery.DeliveryTag, res, topic, entry.ID)
 }
 
-// settleReceipt commits or releases the idempotency receipt after the broker
-// Ack/Nack outcome is known. Uses a detached context with a 5s timeout so
-// the operation completes even during graceful shutdown.
-func (s *Subscriber) settleReceipt(
+// dispatchDisposition executes the broker-level disposition and settles the
+// idempotency receipt.
+//
+// DispositionAck: Commit FIRST (token-guarded), then broker Ack. If Commit
+// fails (lease expired, Redis Lua token mismatch), Nack(requeue=true) so
+// another holder retries. The previous Ack→Commit order could not roll back
+// a broker delivery after Commit failure.
+// ref: Temporal task-token validation (commit-time fencing)
+// ref: MassTransit ValidateLockStatus (Ack 前最后一道门)
+//
+// DispositionReject/Requeue: broker Nack first, then Release the receipt so
+// DLQ replay or redelivery can re-enter the Claim/Commit cycle cleanly.
+func (s *Subscriber) dispatchDisposition(
 	ctx context.Context,
+	ch AMQPChannel,
+	tag uint64,
 	res outbox.HandleResult,
 	topic, eventID string,
-	brokerErr error,
 ) {
-	if res.Receipt == nil {
+	switch res.Disposition {
+	case outbox.DispositionAck:
+		s.dispatchAck(ctx, ch, tag, res, topic, eventID)
+	case outbox.DispositionReject:
+		if nackErr := ch.Nack(tag, false, false); nackErr != nil {
+			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(reject) failed",
+				slog.String(logKeyTopic, topic),
+				slog.String(logKeyEventID, eventID),
+				slog.String("error", nackErr.Error()))
+		}
+		releaseReceipt(ctx, res.Receipt, topic, eventID, "reject")
+	case outbox.DispositionRequeue:
+		if nackErr := ch.Nack(tag, false, true); nackErr != nil {
+			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(requeue) failed",
+				slog.String(logKeyTopic, topic),
+				slog.String(logKeyEventID, eventID),
+				slog.String("error", nackErr.Error()))
+		}
+		releaseReceipt(ctx, res.Receipt, topic, eventID, "requeue")
+	default:
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: unknown disposition, nacking with requeue",
+			slog.String(logKeyTopic, topic),
+			slog.String(logKeyEventID, eventID),
+			slog.String("disposition", res.Disposition.String()))
+		if nackErr := ch.Nack(tag, false, true); nackErr != nil {
+			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(requeue) failed for unknown disposition",
+				slog.String(logKeyTopic, topic),
+				slog.String(logKeyEventID, eventID),
+				slog.String("error", nackErr.Error()))
+		}
+		releaseReceipt(ctx, res.Receipt, topic, eventID, "unknown")
+	}
+}
+
+// dispatchAck handles the Commit→Ack path for DispositionAck.
+// If Commit fails, Nack(requeue=true) is issued instead of Ack.
+func (s *Subscriber) dispatchAck(
+	ctx context.Context,
+	ch AMQPChannel,
+	tag uint64,
+	res outbox.HandleResult,
+	topic, eventID string,
+) {
+	if res.Receipt != nil {
+		rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		commitErr := res.Receipt.Commit(rctx)
+		cancel()
+		if commitErr != nil {
+			slog.LogAttrs(ctx, slog.LevelWarn, "rabbitmq: receipt commit failed (lease may have expired); requeuing instead of acking",
+				slog.String(logKeyTopic, topic),
+				slog.String(logKeyEventID, eventID),
+				slog.String("error", commitErr.Error()))
+			if nackErr := ch.Nack(tag, false, true); nackErr != nil {
+				slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(requeue) failed after commit failure",
+					slog.String(logKeyTopic, topic),
+					slog.String(logKeyEventID, eventID),
+					slog.String("error", nackErr.Error()))
+			}
+			return
+		}
+	}
+	if ackErr := ch.Ack(tag, false); ackErr != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: ack failed",
+			slog.String(logKeyTopic, topic),
+			slog.String(logKeyEventID, eventID),
+			slog.String("error", ackErr.Error()))
+		// Receipt already committed; broker ack failure means the message will
+		// be redelivered, but the idempotency key (ClaimDone) prevents double
+		// processing on the next delivery.
+	}
+}
+
+// releaseReceipt releases the idempotency receipt with a 5s detached timeout.
+// Uses context.WithoutCancel so the operation completes even during graceful shutdown.
+// reason is used for structured log fields.
+func releaseReceipt(ctx context.Context, receipt outbox.Receipt, topic, eventID, reason string) {
+	if receipt == nil {
 		return
 	}
 	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
-
-	if brokerErr != nil {
-		if relErr := res.Receipt.Release(rctx); relErr != nil {
-			slog.LogAttrs(rctx, slog.LevelError, "rabbitmq: receipt release failed after broker error",
-				slog.String(logKeyTopic, topic),
-				slog.String(logKeyEventID, eventID),
-				slog.String("error", relErr.Error()))
-		}
-		return
-	}
-
-	switch res.Disposition {
-	case outbox.DispositionAck:
-		if err := res.Receipt.Commit(rctx); err != nil {
-			slog.LogAttrs(rctx, slog.LevelError, "rabbitmq: receipt commit failed",
-				slog.String(logKeyTopic, topic),
-				slog.String(logKeyEventID, eventID),
-				slog.String("error", err.Error()))
-		}
-	default:
-		// Reject/Requeue/unknown — release so DLQ replay or redelivery can re-enter.
-		if err := res.Receipt.Release(rctx); err != nil {
-			slog.LogAttrs(rctx, slog.LevelError, "rabbitmq: receipt release failed",
-				slog.String(logKeyTopic, topic),
-				slog.String(logKeyEventID, eventID),
-				slog.String("error", err.Error()))
-		}
+	if relErr := receipt.Release(rctx); relErr != nil {
+		slog.LogAttrs(rctx, slog.LevelError, "rabbitmq: receipt release failed",
+			slog.String(logKeyTopic, topic),
+			slog.String(logKeyEventID, eventID),
+			slog.String("reason", reason),
+			slog.String("error", relErr.Error()))
 	}
 }
 

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -56,7 +56,8 @@ func isRecoverableAMQPError(err error) bool {
 
 // Compile-time interface checks.
 var (
-	_ outbox.Subscriber            = (*Subscriber)(nil)
+	_ outbox.Subscriber = (*Subscriber)(nil)
+	//nolint:staticcheck // SubscriberInitializer is deprecated but Subscriber implements it for backward compat.
 	_ outbox.SubscriberInitializer = (*Subscriber)(nil)
 )
 
@@ -188,44 +189,63 @@ func (s *Subscriber) declareTopology(ch AMQPChannel, topic, queueName string) er
 	return nil
 }
 
-// InitializeSubscription pre-declares the AMQP topology (exchange, DLX, queue,
-// binding) for the given topic and consumer group. After this returns, messages
-// published to the topic are queued by the broker — even before Subscribe
+// Setup implements outbox.Subscriber by pre-declaring AMQP topology (exchange,
+// DLX, queue, binding) for the given subscription. After this returns, messages
+// published to the topic are queued by the broker -- even before Subscribe
 // starts consuming. This enables deterministic conformance testing without sleep.
 //
-// ref: Watermill message.SubscribeInitializer — synchronous topology pre-creation.
-func (s *Subscriber) InitializeSubscription(ctx context.Context, topic, consumerGroup string) error {
+// ref: Watermill message.SubscribeInitializer -- synchronous topology pre-creation.
+func (s *Subscriber) Setup(ctx context.Context, sub outbox.Subscription) error {
 	if s.config.DLXExchange == "" {
 		return errcode.New(ErrAdapterAMQPSubscribe,
-			"rabbitmq: DLXExchange is required for InitializeSubscription")
+			"rabbitmq: DLXExchange is required for Setup")
 	}
 
 	ch, err := s.conn.AcquireChannel()
 	if err != nil {
-		return fmt.Errorf("rabbitmq: acquire channel for init: %w", err)
+		return fmt.Errorf("rabbitmq: acquire channel for setup: %w", err)
 	}
 	defer s.conn.ReleaseChannel(ch)
 
-	queueName := s.resolveQueueName(topic, consumerGroup)
-	return s.declareTopology(ch, topic, queueName)
+	queueName := s.resolveQueueName(sub.Topic, sub.ConsumerGroup)
+	return s.declareTopology(ch, sub.Topic, queueName)
 }
 
-// Subscribe registers a handler for the given topic and blocks until ctx is
-// cancelled or the subscriber is closed.
+// Ready implements outbox.Subscriber. RabbitMQ topology is declared synchronously
+// in Setup; once Setup returns, the subscription is immediately ready. Returns an
+// already-closed channel so callers do not block.
+func (s *Subscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+// InitializeSubscription implements outbox.SubscriberInitializer for backward
+// compatibility. Delegates to Setup.
+//
+// Deprecated: callers should use Setup directly.
+func (s *Subscriber) InitializeSubscription(ctx context.Context, topic, consumerGroup string) error {
+	return s.Setup(ctx, outbox.Subscription{Topic: topic, ConsumerGroup: consumerGroup})
+}
+
+// Subscribe registers a handler for the given subscription and blocks until ctx
+// is cancelled or the subscriber is closed.
 //
 // Subscribe automatically reconnects when the underlying AMQP channel is lost
 // (e.g., due to a broker restart or network partition). It waits for the
 // Connection to re-establish via WaitConnected, then re-declares the exchange,
 // queue, and binding on a fresh channel.
 //
-// The topic is used as a fanout exchange name. A queue (from SubscriberConfig
+// sub.Topic is used as a fanout exchange name. A queue (from SubscriberConfig
 // or defaulting to the topic) is declared and bound to the exchange.
 //
-// Consumer: cg-{QueueName}-{topic}
+// Consumer: cg-{QueueName}-{sub.Topic}
 // Idempotency key: handled by ConsumerBase middleware (not in Subscriber)
 // ACK timing: after handler returns DispositionAck
-// Retry: DispositionRequeue -> NACK+requeue / DispositionReject -> NACK(no-requeue) → DLX
-func (s *Subscriber) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler, consumerGroup string) error {
+// Retry: DispositionRequeue -> NACK+requeue / DispositionReject -> NACK(no-requeue) -> DLX
+func (s *Subscriber) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.EntryHandler) error {
+	topic := sub.Topic
+	consumerGroup := sub.ConsumerGroup
 	if s.closed.Load() {
 		return errcode.New(ErrAdapterAMQPSubscribe, "rabbitmq: subscriber is closed")
 	}

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -490,16 +490,11 @@ func (s *Subscriber) nackPermanent(ch AMQPChannel, tag uint64, topic string) {
 	}
 }
 
-// validateEntryID returns the reason string if entry.ID is invalid ("empty" or
-// "too_long"), or empty string if the ID is acceptable.
-func validateEntryID(id string) string {
-	if id == "" {
-		return "empty"
-	}
-	if len(id) > maxEntryIDLength {
-		return "too_long"
-	}
-	return ""
+// validateEntryIDLength returns true if entry.ID exceeds the AMQP shortstr
+// limit. Kept separate so that the too-long branch can log the truncated
+// length for diagnostics; outbox.Entry.Validate covers the empty-ID case.
+func validateEntryIDLength(id string) bool {
+	return len(id) > maxEntryIDLength
 }
 
 func (s *Subscriber) processDelivery(
@@ -522,21 +517,27 @@ func (s *Subscriber) processDelivery(
 		return
 	}
 
-	// Guard: reject entries with invalid ID before touching metadata or invoking handler.
-	// Defense-in-depth — valid WireMessage envelopes always have a non-empty ID, but
-	// the legacy fallback path and future format changes could produce invalid IDs.
-	if reason := validateEntryID(entry.ID); reason != "" {
-		attrs := []slog.Attr{
+	// AMQP shortstr cap: too-long IDs cannot survive a broker round-trip, so
+	// reject before touching metadata. Logged with capped length to indicate
+	// overflow magnitude without exposing the full byte count.
+	if validateEntryIDLength(entry.ID) {
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: entry.ID exceeds AMQP shortstr limit, nacking without requeue",
 			slog.String(logKeyTopic, topic),
 			slog.Uint64("delivery_tag", delivery.DeliveryTag),
-			slog.String("reason", reason),
-		}
-		if reason == "too_long" {
-			// Cap the logged length to 2× maxEntryIDLength (510) to indicate
-			// overflow magnitude without exposing the full byte count.
-			attrs = append(attrs, slog.Int("len_capped", min(len(entry.ID), maxEntryIDLength*2)))
-		}
-		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: invalid entry.ID, nacking without requeue", attrs...)
+			slog.Int("len_capped", min(len(entry.ID), maxEntryIDLength*2)))
+		s.nackPermanent(ch, delivery.DeliveryTag, topic)
+		return
+	}
+
+	// Unified Entry validation at consumer entry: covers empty ID, missing
+	// Topic+EventType, empty Payload, and metadata size limits in one place.
+	// Defense-in-depth — production senders satisfy these invariants, but a
+	// malformed broker delivery (e.g. tampered payload) must not reach handlers.
+	if err := entry.Validate(); err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: invalid entry, nacking without requeue",
+			slog.String(logKeyTopic, topic),
+			slog.Uint64("delivery_tag", delivery.DeliveryTag),
+			slog.String("error", err.Error()))
 		s.nackPermanent(ch, delivery.DeliveryTag, topic)
 		return
 	}
@@ -714,7 +715,12 @@ func (s *Subscriber) Close() error {
 		slog.Warn("rabbitmq: subscriber shutdown timed out, channels not force-closed",
 			slog.Duration("timeout", s.config.ShutdownTimeout),
 			slog.Int("remaining_channels", remaining))
-		return nil
+		// Surface the timeout to the caller so bootstrap teardown does not
+		// report success when in-flight handlers are still holding channels.
+		// Channels are deferred to process exit (see Two-phase shutdown above).
+		return errcode.New(ErrAdapterAMQPCloseTimeout,
+			fmt.Sprintf("rabbitmq: subscriber Close timed out after %s with %d channel(s) still in use",
+				s.config.ShutdownTimeout, remaining))
 	}
 
 	// All goroutines have exited — safe to close the AMQP channels.

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -433,6 +433,21 @@ func (s *Subscriber) untrackChannel(ch AMQPChannel) {
 	s.mu.Unlock()
 }
 
+// consumeLoop drains the deliveries channel and dispatches each delivery in a
+// dedicated goroutine, honouring PrefetchCount as real concurrency.
+//
+// Concurrent safety audit:
+//   - ch.Ack/Nack: guarded by amqp091-go's internal channel mutex; safe to call
+//     from multiple goroutines simultaneously.
+//     ref: rabbitmq/amqp091-go channel.go (sendMethod holds ch.m.Lock).
+//   - Receipt: per-delivery local variable passed into processDelivery — no
+//     sharing across goroutines.
+//   - dispatchAck/releaseReceipt/dispatchDisposition: use only the per-delivery
+//     ch, tag, and Receipt; no Subscriber-level mutable state.
+//   - s.wg: sync.WaitGroup — concurrency-safe by design.
+//   - topic/handler: immutable after Subscribe call.
+//
+// ref: ThreeDotsLabs/watermill message/router.go h.run — per-message goroutine
 func (s *Subscriber) consumeLoop(
 	ctx context.Context,
 	ch AMQPChannel,
@@ -460,7 +475,7 @@ func (s *Subscriber) consumeLoop(
 			}
 
 			s.wg.Add(1)
-			s.processDelivery(ctx, ch, delivery, topic, handler)
+			go s.processDelivery(ctx, ch, delivery, topic, handler)
 		}
 	}
 }

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -679,6 +679,15 @@ func releaseReceipt(ctx context.Context, receipt outbox.Receipt, topic, eventID,
 }
 
 // Close terminates all active subscriptions and waits for in-flight messages.
+//
+// Two-phase shutdown:
+//  1. Signal all goroutines to stop via closeCh, then wait up to ShutdownTimeout
+//     for processDelivery goroutines to complete (WaitGroup).
+//  2. Only close tracked AMQP channels when ALL goroutines have exited cleanly.
+//     If the timeout expires, channels are NOT force-closed (they may still be
+//     held by in-flight processDelivery goroutines); a warning is logged instead
+//     and cleanup is deferred to process exit. This prevents a closed-channel
+//     panic inside processDelivery after the consumer is drained by subscribeOnce.
 func (s *Subscriber) Close() error {
 	if !s.closed.CompareAndSwap(false, true) {
 		return nil
@@ -696,11 +705,19 @@ func (s *Subscriber) Close() error {
 	case <-done:
 		slog.Info("rabbitmq: subscriber closed gracefully")
 	case <-time.After(s.config.ShutdownTimeout):
-		slog.Warn("rabbitmq: subscriber shutdown timed out",
-			slog.Duration("timeout", s.config.ShutdownTimeout))
+		// Do not force-close AMQP channels here — processDelivery goroutines may
+		// still hold references and a close would cause a panic on the next send.
+		// Log the goroutine count and let the OS clean up on process exit.
+		s.mu.Lock()
+		remaining := len(s.channels)
+		s.mu.Unlock()
+		slog.Warn("rabbitmq: subscriber shutdown timed out, channels not force-closed",
+			slog.Duration("timeout", s.config.ShutdownTimeout),
+			slog.Int("remaining_channels", remaining))
+		return nil
 	}
 
-	// Close all channels.
+	// All goroutines have exited — safe to close the AMQP channels.
 	s.mu.Lock()
 	channels := s.channels
 	s.channels = nil

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -59,7 +59,7 @@ func TestProcessDelivery_EmptyEntryID_RejectsToDLX(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 7, Body: body}
 
 	subDone := make(chan error, 1)
-	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
 
 	require.Eventually(t, func() bool {
 		ch.mu.Lock()
@@ -113,7 +113,7 @@ func TestProcessDelivery_TooLongEntryID_RejectsToDLX(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 8, Body: body}
 
 	subDone := make(chan error, 1)
-	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
 
 	require.Eventually(t, func() bool {
 		ch.mu.Lock()
@@ -167,7 +167,7 @@ func TestProcessDelivery_ValidEntryID_PassesToHandler(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 9, Body: body}
 
 	subDone := make(chan error, 1)
-	go func() { subDone <- sub.Subscribe(ctx, "test.topic", handler, "") }()
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
 
 	require.Eventually(t, func() bool {
 		ch.mu.Lock()

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -3,13 +3,17 @@ package rabbitmq
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
@@ -264,6 +268,237 @@ func TestProcessDelivery_CommitSuccess_AcksAndDoesNotRelease(t *testing.T) {
 
 	assert.True(t, commitCalled, "Receipt.Commit must be called on DispositionAck")
 	assert.False(t, releaseCalled, "Receipt.Release must NOT be called on successful Commit+Ack")
+}
+
+// ---------------------------------------------------------------------------
+// Commit 5: real concurrency tests (A13)
+// ---------------------------------------------------------------------------
+
+// TestSubscriber_PrefetchCount10_RealConcurrency verifies that consumeLoop
+// launches processDelivery in goroutines, allowing PrefetchCount deliveries to
+// be processed concurrently. Under the old serial dispatch the WaitGroup barrier
+// below would never be reached within the 500ms budget → the test would timeout.
+//
+// ref: ThreeDotsLabs/watermill message/router.go h.run — per-message goroutine
+func TestSubscriber_PrefetchCount10_RealConcurrency(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	// Provide 11 channels: 1 for AcquireChannel in subscribeOnce, then any extras
+	// that may be needed. Using channelQueue so each call gets a distinct channel.
+	ch := newMockChannel()
+	// Increase buffer so all 10 deliveries fit without blocking the send loop.
+	ch.consumeDeliveries = make(chan amqp.Delivery, 10)
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	const numDeliveries = 10
+	const barrierTimeout = 500 * time.Millisecond
+
+	// barrier: each goroutine calls wg.Done() when it enters the handler.
+	// The test thread calls wg.Wait() to verify all 10 are concurrent.
+	var barrier sync.WaitGroup
+	barrier.Add(numDeliveries)
+
+	// blockCh allows handlers to proceed after the barrier is reached.
+	blockCh := make(chan struct{})
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		barrier.Done() // signal arrival
+		<-blockCh      // wait until all have arrived
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Enqueue 10 deliveries before starting subscriber so they're all ready.
+	for i := range numDeliveries {
+		body := makeDeliveryBody(t, outbox.Entry{
+			ID:        fmt.Sprintf("evt-concurrent-%d", i),
+			EventType: "test.concurrent",
+			Payload:   []byte(`{}`),
+		})
+		ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: uint64(i + 1), Body: body}
+	}
+
+	subDone := make(chan error, 1)
+	go func() {
+		subDone <- NewSubscriber(conn, SubscriberConfig{
+			QueueName:       "test-queue",
+			DLXExchange:     "test.dlx",
+			PrefetchCount:   numDeliveries,
+			ShutdownTimeout: 2 * time.Second,
+		}).Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler)
+	}()
+
+	// If concurrent: all 10 handlers reach the barrier within barrierTimeout.
+	// If serial: only 1 reaches the barrier (blocked by blockCh), test times out.
+	barrierDone := make(chan struct{})
+	go func() {
+		barrier.Wait()
+		close(barrierDone)
+	}()
+
+	select {
+	case <-barrierDone:
+		// All 10 goroutines entered the handler concurrently — pass.
+	case <-time.After(barrierTimeout):
+		t.Fatal("consumeLoop is serial: not all 10 deliveries reached handler concurrently within 500ms")
+	}
+
+	close(blockCh) // unblock handlers
+	cancel()
+	assert.NoError(t, <-subDone)
+}
+
+// TestSubscriber_ConcurrentReceiptCommitSafety verifies that when 10
+// deliveries are processed concurrently, every Receipt.Commit is called
+// exactly once (no loss, no duplicate).
+//
+// ref: rabbitmq/amqp091-go channel.go — ch.Ack/Nack guarded by internal mutex
+func TestSubscriber_ConcurrentReceiptCommitSafety(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	const numDeliveries = 10
+
+	var commitCount atomic.Int64
+
+	ch := newMockChannel()
+	ch.consumeDeliveries = make(chan amqp.Delivery, numDeliveries)
+
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		receipt := &countingReceipt{counter: &commitCount}
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionAck,
+			Receipt:     receipt,
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := range numDeliveries {
+		body := makeDeliveryBody(t, outbox.Entry{
+			ID:        fmt.Sprintf("evt-safety-%d", i),
+			EventType: "test.safety",
+			Payload:   []byte(`{}`),
+		})
+		ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: uint64(i + 1), Body: body}
+	}
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
+		PrefetchCount:   numDeliveries,
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	subDone := make(chan error, 1)
+	go func() {
+		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler)
+	}()
+
+	// Wait until all 10 commits have been recorded.
+	require.Eventually(t, func() bool {
+		return commitCount.Load() == int64(numDeliveries)
+	}, 3*time.Second, 5*time.Millisecond, "expected %d Receipt.Commit calls", numDeliveries)
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	// Assert Commit count == numDeliveries (no loss, no double-commit).
+	assert.Equal(t, int64(numDeliveries), commitCount.Load(),
+		"each delivery must have Receipt.Commit called exactly once")
+}
+
+// countingReceipt is a Receipt that increments an atomic counter on Commit.
+type countingReceipt struct {
+	counter *atomic.Int64
+}
+
+func (r *countingReceipt) Commit(_ context.Context) error {
+	r.counter.Add(1)
+	return nil
+}
+
+func (r *countingReceipt) Release(_ context.Context) error                 { return nil }
+func (r *countingReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
+
+var _ outbox.Receipt = (*countingReceipt)(nil)
+
+// TestSubscriber_GoroutineLeakOnClose verifies that Close() properly waits
+// for all in-flight processDelivery goroutines and leaves no residual goroutines
+// owned by the Subscriber itself.
+//
+// The Connection's reconnectLoop is a known background goroutine managed by
+// the Connection lifecycle; it is excluded via goleak.IgnoreTopFunction so
+// the test focuses only on Subscriber-owned goroutines.
+//
+// ref: go.uber.org/goleak — goroutine leak detection
+func TestSubscriber_GoroutineLeakOnClose(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	ch.consumeDeliveries = make(chan amqp.Delivery, 5)
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	// Handler returns immediately so processDelivery goroutines finish quickly.
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{Disposition: outbox.DispositionAck}
+	}
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	subDone := make(chan error, 1)
+	go func() {
+		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler)
+	}()
+
+	// Enqueue a delivery so at least one goroutine runs.
+	body := makeDeliveryBody(t, outbox.Entry{
+		ID:        "evt-leak-1",
+		EventType: "test.leak",
+		Payload:   []byte(`{}`),
+	})
+	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 1, Body: body}
+
+	// Wait for the delivery to be processed.
+	require.Eventually(t, func() bool {
+		ch.mu.Lock()
+		defer ch.mu.Unlock()
+		return ch.ackCalled
+	}, 2*time.Second, 5*time.Millisecond)
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	// Close subscriber.
+	assert.NoError(t, sub.Close())
+
+	// Close the Connection explicitly so its reconnectLoop goroutine exits
+	// before goleak.VerifyNone runs.
+	assert.NoError(t, conn.Close())
+
+	// Verify no goroutines were leaked by the Subscriber.
+	// The Connection.reconnectLoop is already stopped above (conn.Close),
+	// but goleak.IgnoreTopFunction is added as a belt-and-suspenders guard
+	// in case the event loop hasn't fully unwound yet.
+	goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("github.com/ghbvf/gocell/adapters/rabbitmq.(*Connection).reconnectLoop"),
+	)
 }
 
 // TestProcessDelivery_ValidEntryID_PassesToHandler verifies that an entry with

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -2,6 +2,7 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -132,6 +133,137 @@ func TestProcessDelivery_TooLongEntryID_RejectsToDLX(t *testing.T) {
 	assert.False(t, nackRequeue, "too-long entry.ID must Nack without requeue")
 	assert.Equal(t, uint64(8), nackTag)
 	assert.False(t, handlerCalled, "handler must not be called for too-long entry.ID")
+}
+
+// ---------------------------------------------------------------------------
+// Commit→Ack ordering tests (Commit 2, Layer 2 hard fence)
+// ---------------------------------------------------------------------------
+
+// TestProcessDelivery_CommitFailsAfterLeaseLost_NacksRequeue verifies Layer 2
+// hard fence: if Receipt.Commit fails (e.g., lease expired, token mismatch),
+// processDelivery must Nack(requeue=true) and NOT call ch.Ack.
+func TestProcessDelivery_CommitFailsAfterLeaseLost_NacksRequeue(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{commitErr: errors.New("lease expired: token mismatch")}
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionAck,
+			Receipt:     receipt,
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body := makeDeliveryBody(t, outbox.Entry{
+		ID:        "evt-commit-fail-1",
+		EventType: "test.event",
+		Payload:   []byte(`{}`),
+	})
+	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 10, Body: body}
+
+	subDone := make(chan error, 1)
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
+
+	// Wait for Nack to be called (Commit fails → Nack requeue=true).
+	require.Eventually(t, func() bool {
+		ch.mu.Lock()
+		defer ch.mu.Unlock()
+		return ch.nackCalled
+	}, 2*time.Second, 5*time.Millisecond, "Nack was not called after Commit failure")
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	ch.mu.Lock()
+	ackCalled := ch.ackCalled
+	nackRequeue := ch.nackRequeue
+	nackTag := ch.nackTag
+	ch.mu.Unlock()
+
+	assert.False(t, ackCalled, "ch.Ack must NOT be called when Commit fails")
+	assert.True(t, nackRequeue, "Nack must requeue=true when Commit fails")
+	assert.Equal(t, uint64(10), nackTag)
+
+	receipt.mu.Lock()
+	commitCalled := receipt.commitCalled
+	receipt.mu.Unlock()
+	assert.True(t, commitCalled, "Receipt.Commit must be called before broker Ack attempt")
+}
+
+// TestProcessDelivery_CommitSuccess_AcksAndDoesNotRelease verifies that when
+// Receipt.Commit succeeds, ch.Ack is called and Receipt.Release is NOT called.
+func TestProcessDelivery_CommitSuccess_AcksAndDoesNotRelease(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(conn, SubscriberConfig{
+		QueueName:       "test-queue",
+		DLXExchange:     "test.dlx",
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	receipt := &mockReceipt{} // commitErr = nil → success
+
+	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionAck,
+			Receipt:     receipt,
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body := makeDeliveryBody(t, outbox.Entry{
+		ID:        "evt-commit-ok-1",
+		EventType: "test.event",
+		Payload:   []byte(`{}`),
+	})
+	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 11, Body: body}
+
+	subDone := make(chan error, 1)
+	go func() { subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, handler) }()
+
+	require.Eventually(t, func() bool {
+		ch.mu.Lock()
+		defer ch.mu.Unlock()
+		return ch.ackCalled
+	}, 2*time.Second, 5*time.Millisecond, "Ack was not called after successful Commit")
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	ch.mu.Lock()
+	ackTag := ch.ackTag
+	ch.mu.Unlock()
+
+	assert.Equal(t, uint64(11), ackTag)
+
+	receipt.mu.Lock()
+	commitCalled := receipt.commitCalled
+	releaseCalled := receipt.releaseCalled
+	receipt.mu.Unlock()
+
+	assert.True(t, commitCalled, "Receipt.Commit must be called on DispositionAck")
+	assert.False(t, releaseCalled, "Receipt.Release must NOT be called on successful Commit+Ack")
 }
 
 // TestProcessDelivery_ValidEntryID_PassesToHandler verifies that an entry with

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -498,6 +498,10 @@ func TestSubscriber_GoroutineLeakOnClose(t *testing.T) {
 	// in case the event loop hasn't fully unwound yet.
 	goleak.VerifyNone(t,
 		goleak.IgnoreTopFunction("github.com/ghbvf/gocell/adapters/rabbitmq.(*Connection).reconnectLoop"),
+		// testcontainers Reaper goroutine survives the parent test's lifetime by
+		// design (it cleans up containers post-process); excluded so this test
+		// is stable when the suite is run with -tags=integration.
+		goleak.IgnoreTopFunction("github.com/testcontainers/testcontainers-go.(*Reaper).connect.func1"),
 	)
 }
 

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -578,38 +578,66 @@ func run(ctx context.Context) error {
 	//
 	// ref: runtime-api.md WithConsumerMiddleware — middleware order is
 	// observability-restore (prepended by bootstrap) then ConsumerBase.
-	consumerBase, err := outbox.NewConsumerBase(idempotency.NewInMemClaimer(), outbox.ConsumerBaseConfig{
-		ConsumerGroup: "core-bundle",
-	})
+	// ConsumerGroup is no longer set here; each subscription's ConsumerGroup is
+	// provided by the Cell via EventRouter.AddHandler and flows through
+	// Subscription.ConsumerGroup into the idempotency key namespace.
+	consumerBase, err := outbox.NewConsumerBase(idempotency.NewInMemClaimer(), outbox.ConsumerBaseConfig{})
 	if err != nil {
 		return fmt.Errorf("construct ConsumerBase: %w", err)
 	}
 
-	bootstrapOpts := append([]bootstrap.Option{
-		bootstrap.WithAssembly(asm),
+	app := bootstrap.New(assembleBootstrapOpts(bootstrapDeps{
+		assembly:        asm,
+		eventBus:        eb,
+		consumerBase:    consumerBase,
+		adapterInfo:     adapterInfo,
+		metricsHandler:  metricsHandler,
+		metricsProvider: ps.metricProvider,
+		verboseOpts:     verboseOpts,
+		pgPool:          pgPool,
+		relayWorker:     relayWorker,
+	})...)
+	return app.Run(ctx)
+}
+
+// bootstrapDeps groups the inputs to assembleBootstrapOpts so the call site in
+// run() stays under the cognitive-complexity ceiling.
+type bootstrapDeps struct {
+	assembly        *assembly.CoreAssembly
+	eventBus        *eventbus.InMemoryEventBus
+	consumerBase    *outbox.ConsumerBase
+	adapterInfo     map[string]string
+	metricsHandler  http.Handler
+	metricsProvider *adapterprom.MetricProvider
+	verboseOpts     []bootstrap.Option
+	pgPool          *adapterpg.Pool
+	relayWorker     worker.Worker
+}
+
+// assembleBootstrapOpts builds the ordered bootstrap.Option slice. Extracted
+// from run() to keep run cognitive complexity ≤ 15. Conditional appends
+// (verboseOpts, pgHealthChecker, relayWorker) live here so run() stays linear.
+//
+// ref: Uber fx OnStart non-blocking + goroutine + OnStop blocking pattern.
+// GoCell WorkerGroup already implements this contract; OutboxRelay satisfies
+// worker.Worker — wiring is conditional on PG mode (A11).
+func assembleBootstrapOpts(d bootstrapDeps) []bootstrap.Option {
+	opts := append([]bootstrap.Option{
+		bootstrap.WithAssembly(d.assembly),
 		bootstrap.WithHTTPAddr(":8080"),
-		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
-		bootstrap.WithConsumerMiddleware(consumerBase.AsMiddleware()),
+		bootstrap.WithPublisher(d.eventBus), bootstrap.WithSubscriber(d.eventBus),
+		bootstrap.WithConsumerMiddleware(d.consumerBase.AsMiddleware()),
 		bootstrap.WithPublicEndpoints([]string{
 			"/api/v1/access/sessions/login",
 			"/api/v1/access/sessions/refresh",
 		}),
-		bootstrap.WithAdapterInfo(adapterInfo),
-		bootstrap.WithRouterOptions(router.WithMetricsHandler(metricsHandler)),
-		bootstrap.WithMetricsProvider(ps.metricProvider),
-	}, verboseOpts...)
-	bootstrapOpts = append(bootstrapOpts, pgHealthCheckerOpts(pgPool)...)
-	// Wire outbox relay worker: PG mode only. relayWorker is nil in memory mode;
-	// bootstrap.WithWorkers with a nil worker is safe (it appends, but WorkerGroup
-	// skips nil — however we guard here to be explicit and avoid log noise).
-	//
-	// ref: Uber fx OnStart non-blocking + goroutine + OnStop blocking pattern.
-	// GoCell WorkerGroup already implements this contract; OutboxRelay already
-	// satisfies worker.Worker — only the wiring was missing (A11 fix).
-	if relayWorker != nil {
-		bootstrapOpts = append(bootstrapOpts, bootstrap.WithWorkers(relayWorker))
+		bootstrap.WithAdapterInfo(d.adapterInfo),
+		bootstrap.WithRouterOptions(router.WithMetricsHandler(d.metricsHandler)),
+		bootstrap.WithMetricsProvider(d.metricsProvider),
+	}, d.verboseOpts...)
+	opts = append(opts, pgHealthCheckerOpts(d.pgPool)...)
+	if d.relayWorker != nil {
+		opts = append(opts, bootstrap.WithWorkers(d.relayWorker))
 	}
-
-	app := bootstrap.New(bootstrapOpts...)
-	return app.Run(ctx)
+	return opts
 }

--- a/cmd/core-bundle/outbox_e2e_integration_test.go
+++ b/cmd/core-bundle/outbox_e2e_integration_test.go
@@ -134,14 +134,14 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 	subCtx, subCancel := context.WithCancel(ctx)
 	defer subCancel()
 	go func() {
-		_ = eb.Subscribe(subCtx, topic, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		_ = eb.Subscribe(subCtx, outbox.Subscription{Topic: topic, ConsumerGroup: "e2e-test"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			var p configChangedBusinessPayload
 			err := json.Unmarshal(e.Payload, &p)
 			recvMu.Lock()
 			recvs = append(recvs, received{entry: e, payload: p, parsed: err == nil})
 			recvMu.Unlock()
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "e2e-test")
+		})
 	}()
 	// Give subscriber goroutine a moment to register before first publish.
 	time.Sleep(50 * time.Millisecond)

--- a/cmd/core-bundle/outbox_wiring_test.go
+++ b/cmd/core-bundle/outbox_wiring_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -179,4 +182,74 @@ func TestValidateModeCoupling_Matrix(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestOutboxE2E_CrossCellFanout is the P0 regression guard for the cross-cell
+// fanout bug: before Commit 1, all cells in core-bundle shared a single
+// ConsumerGroup ("core-bundle"), causing the idempotency key to be the same for
+// every cell. The second cell to process an event saw ClaimDone and silently
+// Acked without calling its handler.
+//
+// This test uses the in-memory eventbus (no Docker required) to verify that
+// two subscribers with DIFFERENT ConsumerGroups on the same topic both receive
+// and process the published event independently.
+//
+// Chain: eventbus.Publish → fanout dispatch → access-group handler called +
+//
+//	audit-group handler called (both independently, no shared idempotency namespace)
+func TestOutboxE2E_CrossCellFanout(t *testing.T) {
+	const topic = "test.fanout.cross-cg.v1"
+
+	eb := eventbus.New()
+	t.Cleanup(func() { _ = eb.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Two counters — one per consumer group.
+	var accessCalls, auditCalls atomic.Int64
+
+	// Subscribe with ConsumerGroup "access-core" (simulates cells/access-core).
+	accessSub := outbox.Subscription{Topic: topic, ConsumerGroup: "access-core"}
+	go func() {
+		_ = eb.Subscribe(ctx, accessSub, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+			accessCalls.Add(1)
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
+		})
+	}()
+
+	// Subscribe with ConsumerGroup "audit-core" (simulates cells/audit-core).
+	auditSub := outbox.Subscription{Topic: topic, ConsumerGroup: "audit-core"}
+	go func() {
+		_ = eb.Subscribe(ctx, auditSub, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+			auditCalls.Add(1)
+			return outbox.HandleResult{Disposition: outbox.DispositionAck}
+		})
+	}()
+
+	// Give both goroutines time to call eb.Subscribe and acquire the mutex.
+	// eb.Subscribe registers under eb.mu.Lock before entering the blocking receive
+	// loop, so a 50ms sleep (matching the existing e2e test) is sufficient on
+	// any modern scheduler. This is a deliberate small sleep, not a busy-poll,
+	// because there is no external signal from the subscribe goroutine that fires
+	// after its mutex section completes.
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish exactly 1 event.
+	payload := []byte(`{"action":"fanout_test","key":"cross-cg","value":"ok"}`)
+	require.NoError(t, eb.Publish(ctx, topic, payload))
+
+	// Assert both handlers are called exactly once.
+	// Before the Subscription-first-class refactor (Commit 1), the shared
+	// "core-bundle" ConsumerGroup caused the second cell to see ClaimDone and
+	// silently Ack without calling its handler — one of the two counts would
+	// stay at 0.
+	require.Eventually(t, func() bool {
+		return accessCalls.Load() == 1 && auditCalls.Load() == 1
+	}, 3*time.Second, 5*time.Millisecond,
+		"P0 regression: both consumer groups must receive the event; "+
+			"access=%d audit=%d", accessCalls.Load(), auditCalls.Load())
+
+	assert.Equal(t, int64(1), accessCalls.Load(), "access-core handler must be called exactly once")
+	assert.Equal(t, int64(1), auditCalls.Load(), "audit-core handler must be called exactly once")
 }

--- a/cmd/core-bundle/outbox_wiring_test.go
+++ b/cmd/core-bundle/outbox_wiring_test.go
@@ -227,13 +227,18 @@ func TestOutboxE2E_CrossCellFanout(t *testing.T) {
 		})
 	}()
 
-	// Give both goroutines time to call eb.Subscribe and acquire the mutex.
-	// eb.Subscribe registers under eb.mu.Lock before entering the blocking receive
-	// loop, so a 50ms sleep (matching the existing e2e test) is sufficient on
-	// any modern scheduler. This is a deliberate small sleep, not a busy-poll,
-	// because there is no external signal from the subscribe goroutine that fires
-	// after its mutex section completes.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until both subscribe goroutines have registered (Finding F5: replace
+	// fixed sleep with explicit ready signal from eb.Ready).
+	select {
+	case <-eb.Ready(accessSub):
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for access-core subscription to be ready")
+	}
+	select {
+	case <-eb.Ready(auditSub):
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for audit-core subscription to be ready")
+	}
 
 	// Publish exactly 1 event.
 	payload := []byte(`{"action":"fanout_test","key":"cross-cg","value":"ok"}`)

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -104,20 +104,35 @@ func (c *MyCell) RegisterRoutes(mux cell.RouteMux) {
 
 ### 5. 注册事件订阅（可选）
 
-实现 `cell.EventRegistrar` 接口：
+实现 `cell.EventRegistrar` 接口，**通过 EventRouter 声明订阅意图**——
+禁止手动启动 goroutine 或直接调 `Subscriber.Subscribe`，goroutine 生命周期、
+错误收敛、Setup/Ready 阶段一律由 Router 统一接管。
 
 ```go
 var _ cell.EventRegistrar = (*MyCell)(nil)
 
-func (c *MyCell) RegisterSubscriptions(sub outbox.Subscriber) {
-    go func() {
-        ctx := context.Background()
-        if err := sub.Subscribe(ctx, "my.topic", c.svc.HandleEvent); err != nil {
-            c.logger.Error("subscription ended", slog.Any("error", err))
-        }
-    }()
+// RegisterSubscriptions 在启动阶段被框架调用一次。每次 AddHandler 注册
+// 一个 (topic, handler, consumerGroup) 三元组：
+//   - topic         : broker 路由键
+//   - handler       : outbox.EntryHandler 业务处理函数
+//   - consumerGroup : 通常等于 cell.ID()，作为幂等键命名空间；同 group 竞争消费，
+//                     不同 group 各自一份（fanout）
+//
+// 框架会包装 ConsumerBase（两阶段 Claim/Commit/Release + 退避重试 + DLX 路由），
+// 业务 handler 只需返回 outbox.HandleResult{Disposition: Ack/Requeue/Reject}。
+func (c *MyCell) RegisterSubscriptions(r cell.EventRouter) error {
+    handler := outbox.WrapLegacyHandler(c.svc.HandleEvent) // 旧签名 → EntryHandler
+    r.AddHandler("my.topic.v1", handler, c.ID())
+    return nil
 }
 ```
+
+EventRouter 在所有 cell 注册完成后按四阶段生命周期启动：
+1. **Setup**：串行调 `Subscriber.Setup(sub)` 声明 broker topology；任一失败立即终止
+2. **Subscribe**：每个 handler 起一个 goroutine 调 `Subscribe(ctx, sub, handler)`
+3. **Ready**：等所有 `Subscriber.Ready(sub)` channel close（默认 30s 超时；
+   `bootstrap.WithEventRouterReadyTimeout` 可调），任何未就绪的订阅会出现在错误信息中
+4. **Block**：阻塞至 ctx cancel 或运行时错误
 
 ### 6. 注册到 Assembly
 

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -141,9 +141,13 @@ func (c *ConsumerBaseConfig) SetDefaults() {
 	}
 }
 
-// exponentialDelay computes base * 2^attempt with overflow protection,
+// ExponentialDelay computes base * 2^attempt with overflow protection,
 // capped at maxDelay. Used by both claimWithRetry and retryLoop.
-func exponentialDelay(base, maxDelay time.Duration, attempt int) time.Duration {
+//
+// This is the single source of truth for exponential-backoff delay
+// computation; adapters (e.g., rabbitmq) should call this function
+// instead of maintaining their own copies.
+func ExponentialDelay(base, maxDelay time.Duration, attempt int) time.Duration {
 	if base <= 0 {
 		return 0
 	}
@@ -317,7 +321,7 @@ func (cb *ConsumerBase) claimWithRetry(
 			return 0, nil, ctx.Err()
 		}
 		if attempt < cb.config.ClaimRetryCount-1 {
-			base := exponentialDelay(cb.config.ClaimRetryBaseDelay, cb.config.MaxRetryDelay, attempt)
+			base := ExponentialDelay(cb.config.ClaimRetryBaseDelay, cb.config.MaxRetryDelay, attempt)
 			var jitter time.Duration
 			if base > 0 {
 				jitter = time.Duration(rand.Int64N(int64(base/backoffJitterDivisor) + 1))
@@ -405,7 +409,7 @@ func (cb *ConsumerBase) waitBackoff(ctx context.Context, topic string, entry Ent
 	if ctx.Err() != nil {
 		return true
 	}
-	delay := exponentialDelay(cb.config.RetryBaseDelay, cb.config.MaxRetryDelay, attempt)
+	delay := ExponentialDelay(cb.config.RetryBaseDelay, cb.config.MaxRetryDelay, attempt)
 	logWithContext(ctx, slog.LevelWarn, "outbox: transient error, retrying",
 		slog.String(logKeyEventID, entry.ID),
 		slog.String(logKeyTopic, topic),

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math/bits"
 	"math/rand/v2"
+	"sync/atomic"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/idempotency"
@@ -486,6 +487,12 @@ func (cb *ConsumerBase) retryLoop(
 // retryLoop with a cancellable context. If Extend returns ErrLeaseExpired the
 // context is cancelled so the handler can detect it via ctx.Done().
 //
+// Hard fence (Layer 1): an atomic.Bool latch tracks whether the lease was lost
+// during processing. After retryLoop returns, if leaseLost is set AND the
+// handler returned DispositionAck, the result is force-downgraded to
+// DispositionRequeue. This prevents a stale handler that ignores ctx.Done()
+// from successfully committing after losing its lease.
+//
 // The renewal goroutine exits after retryLoop returns (via cancel + done channel).
 // context.WithoutCancel wraps the Extend ctx so a shutdown-triggered cancellation
 // of the outer ctx does not prevent the last renewal/log from completing.
@@ -504,13 +511,18 @@ func (cb *ConsumerBase) runWithRenewal(
 		return cb.retryLoop(ctx, topic, entry, handler, receipt)
 	}
 
+	var leaseLost atomic.Bool
+
 	renewCtx, cancelRenew := context.WithCancel(ctx)
 	defer cancelRenew()
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		cb.leaseRenewalLoop(renewCtx, topic, entry, receipt, interval, cancelRenew)
+		cb.leaseRenewalLoop(renewCtx, topic, entry, receipt, interval, func() {
+			leaseLost.Store(true)
+			cancelRenew()
+		})
 	}()
 
 	result := cb.retryLoop(renewCtx, topic, entry, handler, receipt)
@@ -519,11 +531,22 @@ func (cb *ConsumerBase) runWithRenewal(
 	cancelRenew()
 	<-done
 
+	// Hard fence: if the lease was lost during processing and the handler
+	// still returned Ack (e.g., it ignored ctx.Done()), force-downgrade to
+	// Requeue so a stale holder cannot commit a dead lease.
+	if leaseLost.Load() && result.Disposition == DispositionAck {
+		logWithContext(ctx, slog.LevelWarn, "outbox: lease lost during processing, downgrading Ack to Requeue (hard fence)",
+			slog.String(logKeyEventID, entry.ID),
+			slog.String(logKeyTopic, topic))
+		return HandleResult{Disposition: DispositionRequeue, Receipt: receipt, Err: idempotency.ErrLeaseExpired}
+	}
+
 	return result
 }
 
 // leaseRenewalLoop ticks every interval and extends the processing lease.
-// It cancels cancelFn if Extend returns ErrLeaseExpired (fencing failure).
+// It calls onLeaseLost (which sets the leaseLost latch and cancels the handler
+// context) if Extend returns ErrLeaseExpired (fencing failure).
 // Exits when ctx is cancelled (handler finished or lease lost).
 func (cb *ConsumerBase) leaseRenewalLoop(
 	ctx context.Context,
@@ -531,7 +554,7 @@ func (cb *ConsumerBase) leaseRenewalLoop(
 	entry Entry,
 	receipt Receipt,
 	interval time.Duration,
-	cancelFn context.CancelFunc,
+	onLeaseLost func(),
 ) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -547,7 +570,7 @@ func (cb *ConsumerBase) leaseRenewalLoop(
 					logWithContext(ctx, slog.LevelError, "outbox: lease lost during processing, cancelling handler",
 						slog.String(logKeyEventID, entry.ID),
 						slog.String(logKeyTopic, topic))
-					cancelFn()
+					onLeaseLost()
 					return
 				}
 				logWithContext(ctx, slog.LevelWarn, "outbox: lease extend failed (transient), will retry",

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -65,9 +65,6 @@ func (p ClaimPolicy) String() string {
 
 // ConsumerBaseConfig configures ConsumerBase behavior.
 type ConsumerBaseConfig struct {
-	// ConsumerGroup identifies this consumer group for idempotency keys.
-	ConsumerGroup string
-
 	// RetryCount is the maximum number of retries for transient errors.
 	// Default: 3.
 	RetryCount int
@@ -212,24 +209,28 @@ func NewConsumerBase(claimer idempotency.Claimer, config ConsumerBaseConfig) (*C
 	}, nil
 }
 
-// AsMiddleware returns a TopicHandlerMiddleware that applies this
+// AsMiddleware returns a SubscriptionMiddleware that applies this
 // ConsumerBase's idempotency/retry wrapping to any EntryHandler.
 // It can be used with SubscriberWithMiddleware to transparently inject
 // ConsumerBase behavior into a raw Subscriber pipeline.
-func (cb *ConsumerBase) AsMiddleware() TopicHandlerMiddleware {
-	return func(topic string, next EntryHandler) EntryHandler {
-		return cb.Wrap(topic, next)
+func (cb *ConsumerBase) AsMiddleware() SubscriptionMiddleware {
+	return func(sub Subscription, next EntryHandler) EntryHandler {
+		return cb.Wrap(sub, next)
 	}
 }
 
 // Wrap returns an EntryHandler that wraps the given business handler with
 // two-phase Claim/Commit/Release idempotency and retry with exponential backoff.
 //
-// The Receipt is threaded through HandleResult — ConsumerBase never calls
+// The idempotency key is constructed as "{sub.ConsumerGroup}:{entry.ID}",
+// ensuring cross-cell fanout correctness: each cell's ConsumerGroup forms a
+// separate namespace so ClaimDone in one cell does not silence another.
+//
+// The Receipt is threaded through HandleResult -- ConsumerBase never calls
 // Commit/Release itself; that is the delivery loop's job after broker Ack/Nack.
 //
 // Fail-open (ClaimPolicyFailOpen): single Claim attempt; on error, proceed
-// without idempotency — avoids total consumer stall, but risks duplicate
+// without idempotency -- avoids total consumer stall, but risks duplicate
 // processing during outage.
 //
 // Fail-closed (ClaimPolicyFailClosed, default zero-value): all Claim attempts
@@ -238,16 +239,18 @@ func (cb *ConsumerBase) AsMiddleware() TopicHandlerMiddleware {
 // stops until the idempotency backend recovers.
 //
 // Rules:
-//   - handler returns DispositionAck → pass through as Ack
-//   - handler returns DispositionRequeue → pass through as Requeue
-//   - handler returns DispositionReject → pass through as Reject
-//   - handler returns error with non-Ack disposition → retry with backoff
-//   - PermanentError → Reject (broker routes to DLX)
-//   - retry budget exhausted → Reject
-//   - ctx cancelled / shutdown → Requeue
-func (cb *ConsumerBase) Wrap(topic string, handler EntryHandler) EntryHandler {
+//   - handler returns DispositionAck -> pass through as Ack
+//   - handler returns DispositionRequeue -> pass through as Requeue
+//   - handler returns DispositionReject -> pass through as Reject
+//   - handler returns error with non-Ack disposition -> retry with backoff
+//   - PermanentError -> Reject (broker routes to DLX)
+//   - retry budget exhausted -> Reject
+//   - ctx cancelled / shutdown -> Requeue
+func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) EntryHandler {
+	topic := sub.Topic
+	consumerGroup := sub.ConsumerGroup
 	return func(ctx context.Context, entry Entry) HandleResult {
-		idempotencyKey := fmt.Sprintf("%s:%s", cb.config.ConsumerGroup, entry.ID)
+		idempotencyKey := fmt.Sprintf("%s:%s", consumerGroup, entry.ID)
 
 		// Fail-open: single Claim attempt, proceed without idempotency on error.
 		if cb.config.ClaimPolicy == ClaimPolicyFailOpen {
@@ -256,7 +259,7 @@ func (cb *ConsumerBase) Wrap(topic string, handler EntryHandler) EntryHandler {
 				logWithContext(ctx, slog.LevelWarn, "outbox: idempotency claim failed, proceeding without receipt (fail-open)",
 					slog.String(logKeyEventID, entry.ID),
 					slog.String(logKeyTopic, topic),
-					slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup),
+					slog.String(logKeyConsumerGroup, consumerGroup),
 					slog.String("error", err.Error()))
 				return cb.retryLoop(ctx, topic, entry, handler, nil)
 			}
@@ -264,12 +267,12 @@ func (cb *ConsumerBase) Wrap(topic string, handler EntryHandler) EntryHandler {
 		}
 
 		// Fail-closed: claimWithRetry handles all attempts with backoff + jitter.
-		state, receipt, err := cb.claimWithRetry(ctx, topic, entry, idempotencyKey)
+		state, receipt, err := cb.claimWithRetry(ctx, topic, entry, idempotencyKey, consumerGroup)
 		if err != nil {
 			logWithContext(ctx, slog.LevelError, "outbox: idempotency claim exhausted, requeuing (fail-closed)",
 				slog.String(logKeyEventID, entry.ID),
 				slog.String(logKeyTopic, topic),
-				slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup),
+				slog.String(logKeyConsumerGroup, consumerGroup),
 				slog.Int("claim_retry_count", cb.config.ClaimRetryCount),
 				slog.String("error", err.Error()))
 			return HandleResult{Disposition: DispositionRequeue, Err: err}
@@ -293,6 +296,7 @@ func (cb *ConsumerBase) claimWithRetry(
 	topic string,
 	entry Entry,
 	idempotencyKey string,
+	consumerGroup string,
 ) (idempotency.ClaimState, Receipt, error) {
 	var lastErr error
 
@@ -321,6 +325,7 @@ func (cb *ConsumerBase) claimWithRetry(
 			logWithContext(ctx, slog.LevelWarn, "outbox: idempotency claim failed, retrying locally",
 				slog.String(logKeyEventID, entry.ID),
 				slog.String(logKeyTopic, topic),
+				slog.String(logKeyConsumerGroup, consumerGroup),
 				slog.Int("attempt", attempt+1),
 				slog.Int("max_retries", cb.config.ClaimRetryCount),
 				slog.Duration("backoff", delay),
@@ -350,15 +355,13 @@ func (cb *ConsumerBase) handleClaimState(
 	case idempotency.ClaimDone:
 		logWithContext(ctx, slog.LevelDebug, "outbox: event already processed, skipping",
 			slog.String(logKeyEventID, entry.ID),
-			slog.String(logKeyTopic, topic),
-			slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup))
+			slog.String(logKeyTopic, topic))
 		return HandleResult{Disposition: DispositionAck}
 	case idempotency.ClaimBusy:
 		delay := cb.config.RetryBaseDelay
 		logWithContext(ctx, slog.LevelDebug, "outbox: event being processed by another consumer, requeuing after backoff",
 			slog.String(logKeyEventID, entry.ID),
 			slog.String(logKeyTopic, topic),
-			slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup),
 			slog.Duration("backoff", delay))
 		select {
 		case <-time.After(delay):
@@ -366,7 +369,7 @@ func (cb *ConsumerBase) handleClaimState(
 		}
 		return HandleResult{Disposition: DispositionRequeue}
 	default:
-		// ClaimAcquired — start lease-renewal goroutine before invoking handler.
+		// ClaimAcquired -- start lease-renewal goroutine before invoking handler.
 		return cb.runWithRenewal(ctx, topic, entry, handler, receipt)
 	}
 }
@@ -442,7 +445,6 @@ func (cb *ConsumerBase) retryLoop(
 			logWithContext(ctx, slog.LevelWarn, "outbox: permanent error, rejecting to DLX",
 				slog.String(logKeyEventID, entry.ID),
 				slog.String(logKeyTopic, topic),
-				slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup),
 				slog.Any("error", lastResult.Err))
 			return HandleResult{
 				Disposition: DispositionReject,
@@ -467,11 +469,10 @@ func (cb *ConsumerBase) retryLoop(
 		return requeueResult(ctx.Err(), receipt)
 	}
 
-	// Exhausted all retries — reject so broker routes to DLX.
+	// Exhausted all retries -- reject so broker routes to DLX.
 	logWithContext(ctx, slog.LevelError, "outbox: retry budget exhausted, rejecting to DLX",
 		slog.String(logKeyEventID, entry.ID),
 		slog.String(logKeyTopic, topic),
-		slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup),
 		slog.Int("retry_count", cb.config.RetryCount),
 		slog.Any("error", lastResult.Err))
 	return HandleResult{
@@ -545,8 +546,7 @@ func (cb *ConsumerBase) leaseRenewalLoop(
 				if errors.Is(err, idempotency.ErrLeaseExpired) {
 					logWithContext(ctx, slog.LevelError, "outbox: lease lost during processing, cancelling handler",
 						slog.String(logKeyEventID, entry.ID),
-						slog.String(logKeyTopic, topic),
-						slog.String(logKeyConsumerGroup, cb.config.ConsumerGroup))
+						slog.String(logKeyTopic, topic))
 					cancelFn()
 					return
 				}

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -808,3 +808,131 @@ func TestWrap_LeaseRenewal_DisabledWhenIntervalZeroAndTTLZero(t *testing.T) {
 	// With very fast handler, no Extend should have been called.
 	assert.Equal(t, int32(0), receipt.extendCalls.Load())
 }
+
+// =============================================================================
+// Lease-lost hard fence tests (Commit 2)
+// =============================================================================
+
+// TestConsumerBase_LeaseLost_ForceRequeue_EvenWhenHandlerReturnsAck verifies
+// Layer 1 hard fence: if the lease expires (ErrLeaseExpired during Extend) and
+// the handler ignores ctx.Done() returning DispositionAck, runWithRenewal must
+// force-downgrade the result to DispositionRequeue.
+func TestConsumerBase_LeaseLost_ForceRequeue_EvenWhenHandlerReturnsAck(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	interval := 20 * time.Millisecond
+	callCount := atomic.Int32{}
+	baseReceipt := &fakeReceipt{}
+
+	// Fail on 2nd Extend call with ErrLeaseExpired.
+	spyR := &spyExtendReceipt{
+		receipt: baseReceipt,
+		failOn:  2,
+		err:     idempotency.ErrLeaseExpired,
+		calls:   &callCount,
+	}
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: spyR}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		LeaseTTL:             200 * time.Millisecond,
+		LeaseRenewalInterval: interval,
+		RetryCount:           1,
+		RetryBaseDelay:       time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	// Handler deliberately ignores ctx.Done() and returns Ack — simulates a
+	// stale holder that is not ctx-aware. It blocks for several intervals so
+	// the renewal goroutine can fire and detect the expired lease.
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(ctx context.Context, _ Entry) HandleResult {
+		// Block to allow renewal goroutine to fire and set leaseLost.
+		// The handler deliberately does NOT check ctx.Done() to simulate a
+		// stale handler that ignores cancellation.
+		time.Sleep(5 * interval)
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	res := handler(context.Background(), Entry{ID: "evt-lease-lost-ack"})
+
+	// The hard fence must downgrade Ack → Requeue.
+	assert.Equal(t, DispositionRequeue, res.Disposition,
+		"lease-lost hard fence must downgrade DispositionAck to DispositionRequeue")
+}
+
+// TestConsumerBase_LeaseLost_HandlerCancellation_StillRequeue verifies that
+// when the lease is lost AND the handler is ctx-aware (returns Requeue on
+// ctx.Done()), the final result is still Requeue — the same safe path.
+func TestConsumerBase_LeaseLost_HandlerCancellation_StillRequeue(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	interval := 20 * time.Millisecond
+	callCount := atomic.Int32{}
+	baseReceipt := &fakeReceipt{}
+
+	spyR := &spyExtendReceipt{
+		receipt: baseReceipt,
+		failOn:  2,
+		err:     idempotency.ErrLeaseExpired,
+		calls:   &callCount,
+	}
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: spyR}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		LeaseTTL:             200 * time.Millisecond,
+		LeaseRenewalInterval: interval,
+		RetryCount:           1,
+		RetryBaseDelay:       time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctxCancelSeen := make(chan struct{}, 1)
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(ctx context.Context, _ Entry) HandleResult {
+		select {
+		case <-ctx.Done():
+			ctxCancelSeen <- struct{}{}
+			return HandleResult{Disposition: DispositionRequeue, Err: ctx.Err()}
+		case <-time.After(5 * time.Second):
+			t.Error("handler blocked without ctx cancellation")
+			return HandleResult{Disposition: DispositionAck}
+		}
+	})
+
+	res := handler(context.Background(), Entry{ID: "evt-lease-lost-requeue"})
+
+	select {
+	case <-ctxCancelSeen:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler context was not cancelled after ErrLeaseExpired")
+	}
+
+	assert.Equal(t, DispositionRequeue, res.Disposition,
+		"ctx-aware handler returning Requeue after lease-lost must remain Requeue")
+}
+
+// TestConsumerBase_LeaseHeld_NormalAck verifies that the hard fence does NOT
+// interfere with the normal path where the lease is always valid and the
+// handler returns DispositionAck.
+func TestConsumerBase_LeaseHeld_NormalAck(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	receipt := &fakeReceipt{} // extendErr defaults to nil → always succeeds
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		LeaseTTL:             200 * time.Millisecond,
+		LeaseRenewalInterval: 20 * time.Millisecond,
+		RetryCount:           1,
+		RetryBaseDelay:       time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	res := handler(context.Background(), Entry{ID: "evt-normal-ack"})
+	assert.Equal(t, DispositionAck, res.Disposition,
+		"hard fence must not downgrade Ack when lease is always held")
+	assert.Same(t, receipt, res.Receipt,
+		"receipt must be threaded through on normal Ack path")
+}

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -215,23 +215,21 @@ func TestExponentialDelay_ExactMaxSafeShift(t *testing.T) {
 
 func TestNewConsumerBase_InvalidClaimPolicy(t *testing.T) {
 	_, err := NewConsumerBase(&fakeClaimer{}, ConsumerBaseConfig{
-		ConsumerGroup: "g",
-		ClaimPolicy:   ClaimPolicy(99),
+		ClaimPolicy: ClaimPolicy(99),
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid ClaimPolicy")
 }
 
 func TestNewConsumerBase_DefaultClaimPolicyFailClosed(t *testing.T) {
-	cb, err := NewConsumerBase(&fakeClaimer{}, ConsumerBaseConfig{ConsumerGroup: "g"})
+	cb, err := NewConsumerBase(&fakeClaimer{}, ConsumerBaseConfig{})
 	require.NoError(t, err)
 	assert.Equal(t, ClaimPolicyFailClosed, cb.config.ClaimPolicy)
 }
 
 func TestNewConsumerBase_ExplicitFailOpenPreserved(t *testing.T) {
 	cb, err := NewConsumerBase(&fakeClaimer{}, ConsumerBaseConfig{
-		ConsumerGroup: "g",
-		ClaimPolicy:   ClaimPolicyFailOpen,
+		ClaimPolicy: ClaimPolicyFailOpen,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, ClaimPolicyFailOpen, cb.config.ClaimPolicy)
@@ -243,11 +241,11 @@ func TestConsumerBase_Wrap_ClaimAcquired_Ack_ThreadsReceipt(t *testing.T) {
 	receipt := &fakeReceipt{}
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
-	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{ConsumerGroup: "cg"})
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{})
 	require.NoError(t, err)
 
 	called := false
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		called = true
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -267,11 +265,11 @@ func TestConsumerBase_Wrap_ClaimAcquired_Ack_ThreadsReceipt(t *testing.T) {
 func TestConsumerBase_Wrap_ClaimDone_SkipsHandler(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimDone}
 
-	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{ConsumerGroup: "cg"})
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{})
 	require.NoError(t, err)
 
 	called := false
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		called = true
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -286,13 +284,12 @@ func TestConsumerBase_Wrap_ClaimBusy_Requeues(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimBusy}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:  "cg",
 		RetryBaseDelay: 5 * time.Millisecond, // short backoff for test
 	})
 	require.NoError(t, err)
 
 	called := false
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		called = true
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -309,14 +306,13 @@ func TestConsumerBase_Wrap_TransientError_RetriesUntilAck(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:  "cg",
 		RetryCount:     3,
 		RetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 
 	attempts := 0
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		attempts++
 		if attempts == 1 {
 			return HandleResult{Disposition: DispositionRequeue, Err: errors.New("transient")}
@@ -335,14 +331,13 @@ func TestConsumerBase_Wrap_RetryBudgetExhausted_RejectsToDLX(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:  "cg",
 		RetryCount:     2,
 		RetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 
 	attempts := 0
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		attempts++
 		return HandleResult{Disposition: DispositionRequeue, Err: errors.New("always fail")}
 	})
@@ -358,14 +353,13 @@ func TestConsumerBase_Wrap_ExplicitReject_NoRetry(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:  "cg",
 		RetryCount:     5,
 		RetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 
 	attempts := 0
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		attempts++
 		return HandleResult{Disposition: DispositionReject, Err: errors.New("bad payload")}
 	})
@@ -381,14 +375,13 @@ func TestConsumerBase_Wrap_WrappedPermanentError_DetectedAndRejected(t *testing.
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:  "cg",
 		RetryCount:     5,
 		RetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 
 	attempts := 0
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		attempts++
 		return HandleResult{
 			Disposition: DispositionRequeue,
@@ -405,13 +398,12 @@ func TestConsumerBase_Wrap_CtxCancelled_DuringRetry_Requeues(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:  "cg",
 		RetryCount:     5,
 		RetryBaseDelay: 5 * time.Second, // long enough that ctx cancel wins
 	})
 	require.NoError(t, err)
 
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		return HandleResult{Disposition: DispositionRequeue, Err: errors.New("transient")}
 	})
 
@@ -440,14 +432,13 @@ func TestConsumerBase_Wrap_ClaimError_FailClosed_LocalRetryThenSuccess(t *testin
 	}}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:       "cg",
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 
 	called := false
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		called = true
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -466,14 +457,13 @@ func TestConsumerBase_Wrap_ClaimError_FailClosed_ExhaustedRequeues(t *testing.T)
 	claimer := &fakeClaimer{err: errors.New("redis down")}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:       "cg",
 		ClaimRetryCount:     2,
 		ClaimRetryBaseDelay: time.Millisecond,
 	})
 	require.NoError(t, err)
 
 	called := false
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		called = true
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -488,13 +478,12 @@ func TestConsumerBase_Wrap_ClaimError_FailClosed_CtxCancel(t *testing.T) {
 	claimer := &fakeClaimer{err: errors.New("redis down")}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:       "cg",
 		ClaimRetryCount:     5,
 		ClaimRetryBaseDelay: 5 * time.Second,
 	})
 	require.NoError(t, err)
 
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		return HandleResult{Disposition: DispositionAck}
 	})
 
@@ -516,13 +505,12 @@ func TestConsumerBase_Wrap_ClaimError_FailOpen_ProceedsWithoutReceipt(t *testing
 	claimer := &fakeClaimer{err: errors.New("redis down")}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup: "cg",
-		ClaimPolicy:   ClaimPolicyFailOpen,
+		ClaimPolicy: ClaimPolicyFailOpen,
 	})
 	require.NoError(t, err)
 
 	called := false
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		called = true
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -537,14 +525,13 @@ func TestConsumerBase_Wrap_MaxRetryDelay_CapsClaimBackoff(t *testing.T) {
 	claimer := &fakeClaimer{err: errors.New("redis down")}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:       "cg",
 		ClaimRetryCount:     3,
 		ClaimRetryBaseDelay: 200 * time.Millisecond,
 		MaxRetryDelay:       20 * time.Millisecond, // clamp well below base
 	})
 	require.NoError(t, err)
 
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		return HandleResult{Disposition: DispositionAck}
 	})
 
@@ -562,14 +549,14 @@ func TestConsumerBase_AsMiddleware_AppliesWrap(t *testing.T) {
 	receipt := &fakeReceipt{}
 	claimer := &fakeClaimer{state: idempotency.ClaimDone, receipt: receipt}
 
-	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{ConsumerGroup: "cg"})
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{})
 	require.NoError(t, err)
 
 	mw := cb.AsMiddleware()
 	require.NotNil(t, mw)
 
 	called := false
-	wrapped := mw("topic", func(_ context.Context, _ Entry) HandleResult {
+	wrapped := mw(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		called = true
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -594,14 +581,13 @@ func TestWrap_LeaseRenewal_ExtendsAtInterval(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:        "cg",
 		LeaseTTL:             200 * time.Millisecond,
 		LeaseRenewalInterval: interval,
 	})
 	require.NoError(t, err)
 
 	handlerDone := make(chan struct{})
-	handler := cb.Wrap("topic", func(ctx context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(ctx context.Context, _ Entry) HandleResult {
 		// Block for ~3 intervals so renewal fires at least twice.
 		select {
 		case <-time.After(3 * interval):
@@ -634,7 +620,6 @@ func TestWrap_LeaseRenewal_ExtendFailure_CancelsHandler(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:        "cg",
 		LeaseTTL:             200 * time.Millisecond,
 		LeaseRenewalInterval: interval,
 		RetryCount:           1,
@@ -643,7 +628,7 @@ func TestWrap_LeaseRenewal_ExtendFailure_CancelsHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	ctxCancelSeen := make(chan struct{}, 1)
-	handler := cb.Wrap("topic", func(ctx context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(ctx context.Context, _ Entry) HandleResult {
 		// Block until context is cancelled or timeout.
 		select {
 		case <-ctx.Done():
@@ -695,6 +680,59 @@ func (s *spyExtendReceipt) Extend(ctx context.Context, ttl time.Duration) error 
 
 var _ Receipt = (*spyExtendReceipt)(nil)
 
+// TestConsumerBase_DifferentConsumerGroupsNoCollision verifies that two distinct
+// ConsumerGroups processing the same entry.ID each reach ClaimAcquired independently
+// — they use different idempotency keys so neither sees ClaimDone from the other.
+// This is the critical regression test for PR#180 P0.
+func TestConsumerBase_DifferentConsumerGroupsNoCollision(t *testing.T) {
+	receipt1 := &fakeReceipt{}
+	claimer1 := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt1}
+	receipt2 := &fakeReceipt{}
+	claimer2 := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt2}
+
+	sub1 := Subscription{Topic: "session.created.v1", ConsumerGroup: "cg-audit-core"}
+	sub2 := Subscription{Topic: "session.created.v1", ConsumerGroup: "cg-config-core"}
+
+	cb1, err := NewConsumerBase(claimer1, ConsumerBaseConfig{})
+	require.NoError(t, err)
+	cb2, err := NewConsumerBase(claimer2, ConsumerBaseConfig{})
+	require.NoError(t, err)
+
+	calls1 := 0
+	handler1 := cb1.Wrap(sub1, func(_ context.Context, _ Entry) HandleResult {
+		calls1++
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	calls2 := 0
+	handler2 := cb2.Wrap(sub2, func(_ context.Context, _ Entry) HandleResult {
+		calls2++
+		return HandleResult{Disposition: DispositionAck}
+	})
+
+	entry := Entry{ID: "shared-event-id-001"}
+	res1 := handler1(context.Background(), entry)
+	res2 := handler2(context.Background(), entry)
+
+	assert.Equal(t, DispositionAck, res1.Disposition, "handler1 must reach ClaimAcquired")
+	assert.Equal(t, DispositionAck, res2.Disposition, "handler2 must reach ClaimAcquired")
+	assert.Equal(t, 1, calls1, "handler1 must be invoked")
+	assert.Equal(t, 1, calls2, "handler2 must be invoked — different namespace, no collision")
+
+	// Verify the idempotency keys differ — each claimer was called with its own namespace.
+	claimer1.mu.Lock()
+	key1 := claimer1.calls[0]
+	claimer1.mu.Unlock()
+
+	claimer2.mu.Lock()
+	key2 := claimer2.calls[0]
+	claimer2.mu.Unlock()
+
+	assert.Equal(t, "cg-audit-core:shared-event-id-001", key1)
+	assert.Equal(t, "cg-config-core:shared-event-id-001", key2)
+	assert.NotEqual(t, key1, key2, "idempotency keys must differ across ConsumerGroups")
+}
+
 // TestWrap_LeaseRenewal_HandlerComplete_StopsGoroutine verifies that when the
 // handler completes normally, the lease renewal goroutine exits cleanly (no
 // goroutine leak).
@@ -705,13 +743,12 @@ func TestWrap_LeaseRenewal_HandlerComplete_StopsGoroutine(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:        "cg",
 		LeaseTTL:             1 * time.Second,
 		LeaseRenewalInterval: 50 * time.Millisecond,
 	})
 	require.NoError(t, err)
 
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		// Return immediately — renewal goroutine must exit.
 		return HandleResult{Disposition: DispositionAck}
 	})
@@ -732,13 +769,12 @@ func TestWrap_LeaseRenewal_DisabledWhenIntervalNegative(t *testing.T) {
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:        "cg",
 		LeaseTTL:             idempotency.DefaultLeaseTTL,
 		LeaseRenewalInterval: -1, // negative disables renewal
 	})
 	require.NoError(t, err)
 
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		return HandleResult{Disposition: DispositionAck}
 	})
 
@@ -758,13 +794,12 @@ func TestWrap_LeaseRenewal_DisabledWhenIntervalZeroAndTTLZero(t *testing.T) {
 
 	// Use a very large interval that will never fire during the test.
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
-		ConsumerGroup:        "cg",
 		LeaseTTL:             idempotency.DefaultLeaseTTL,
 		LeaseRenewalInterval: 0, // should default to LeaseTTL/3
 	})
 	require.NoError(t, err)
 
-	handler := cb.Wrap("topic", func(_ context.Context, _ Entry) HandleResult {
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		return HandleResult{Disposition: DispositionAck}
 	})
 

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -177,7 +177,38 @@ func TestConsumerBaseConfig_SetDefaults_PositiveValuesPreserved(t *testing.T) {
 	assert.Equal(t, 5*time.Second, cfg.MaxRetryDelay)
 }
 
-// --- exponentialDelay ------------------------------------------------------
+// --- exponentialDelay / ExponentialDelay -----------------------------------
+
+// TestExponentialDelay_PublicAPI verifies the exported ExponentialDelay
+// function that adapters should use instead of maintaining their own copies.
+func TestExponentialDelay_PublicAPI(t *testing.T) {
+	base := 100 * time.Millisecond
+	maxDelay := 5 * time.Second
+	cases := []struct {
+		name     string
+		base     time.Duration
+		maxDelay time.Duration
+		attempt  int
+		want     time.Duration
+	}{
+		{"zero_base_returns_zero", 0, maxDelay, 3, 0},
+		{"attempt_0_equals_base", base, maxDelay, 0, base},
+		{"attempt_1_double", base, maxDelay, 1, 2 * base},
+		{"attempt_5_capped_by_base_shift", base, maxDelay, 5, 3200 * time.Millisecond},
+		{"capped_at_max", base, maxDelay, 10, maxDelay},
+		{"overflow_protection_63", base, maxDelay, 63, maxDelay},
+		{"overflow_protection_65", base, maxDelay, 65, maxDelay},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExponentialDelay(tc.base, tc.maxDelay, tc.attempt)
+			if got != tc.want {
+				t.Errorf("ExponentialDelay(%v, %v, %d) = %v, want %v",
+					tc.base, tc.maxDelay, tc.attempt, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestExponentialDelay_Table(t *testing.T) {
 	tests := []struct {
@@ -198,7 +229,7 @@ func TestExponentialDelay_Table(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := exponentialDelay(tt.base, tt.maxDelay, tt.attempt)
+			got := ExponentialDelay(tt.base, tt.maxDelay, tt.attempt)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -207,8 +238,8 @@ func TestExponentialDelay_Table(t *testing.T) {
 func TestExponentialDelay_ExactMaxSafeShift(t *testing.T) {
 	base := time.Second
 	maxSafeShift := 63 - bits.Len64(uint64(base))
-	assert.Equal(t, 30*time.Second, exponentialDelay(base, 30*time.Second, maxSafeShift))
-	assert.Equal(t, 30*time.Second, exponentialDelay(base, 30*time.Second, maxSafeShift+1))
+	assert.Equal(t, 30*time.Second, ExponentialDelay(base, 30*time.Second, maxSafeShift))
+	assert.Equal(t, 30*time.Second, ExponentialDelay(base, 30*time.Second, maxSafeShift+1))
 }
 
 // --- NewConsumerBase -------------------------------------------------------

--- a/kernel/outbox/observability_metadata.go
+++ b/kernel/outbox/observability_metadata.go
@@ -114,8 +114,8 @@ func ContextWithObservabilityMetadata(ctx context.Context, metadata map[string]s
 // ObservabilityContextMiddleware restores observability metadata into the
 // handler context before calling the next handler. This is the canonical
 // injection point; the subscriber adapter does not perform restoration.
-func ObservabilityContextMiddleware() TopicHandlerMiddleware {
-	return func(_ string, next EntryHandler) EntryHandler {
+func ObservabilityContextMiddleware() SubscriptionMiddleware {
+	return func(_ Subscription, next EntryHandler) EntryHandler {
 		return func(ctx context.Context, entry Entry) HandleResult {
 			return next(ContextWithObservabilityMetadata(ctx, entry.Metadata), entry)
 		}

--- a/kernel/outbox/observability_metadata_test.go
+++ b/kernel/outbox/observability_metadata_test.go
@@ -173,7 +173,7 @@ func TestIsReservedMetadataKey(t *testing.T) {
 func TestObservabilityContextMiddleware_RestoresHandlerContext(t *testing.T) {
 	mw := ObservabilityContextMiddleware()
 
-	wrapped := mw("event.test.v1", func(ctx context.Context, _ Entry) HandleResult {
+	wrapped := mw(Subscription{Topic: "event.test.v1"}, func(ctx context.Context, _ Entry) HandleResult {
 		requestID, ok := ctxkeys.RequestIDFrom(ctx)
 		require.True(t, ok)
 		assert.Equal(t, "req-789", requestID)

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -1,7 +1,7 @@
 // Package outbox defines interfaces for the transactional outbox pattern.
 // Implementations live in adapters/ (e.g., adapters/postgres).
 //
-// ref: ThreeDotsLabs/watermill message/ — Message 統一模型, Publisher/Subscriber 接口
+// ref: ThreeDotsLabs/watermill message/ -- Message unified model, Publisher/Subscriber interfaces
 package outbox
 
 import (
@@ -22,10 +22,10 @@ import (
 // These constants prevent unbounded metadata from degrading broker throughput
 // or exceeding transport-level control-line limits.
 //
-// ref: OTel sdk/trace/span_limits.go — 128 attributes/span (GoCell uses 64
+// ref: OTel sdk/trace/span_limits.go -- 128 attributes/span (GoCell uses 64
 //      as a tighter balance between overhead prevention and practical use)
-// ref: NATS server/const.go — MAX_CONTROL_LINE_SIZE = 4096 bytes
-// ref: RabbitMQ — no hard header-size limit, but 64 KB total is a pragmatic
+// ref: NATS server/const.go -- MAX_CONTROL_LINE_SIZE = 4096 bytes
+// ref: RabbitMQ -- no hard header-size limit, but 64 KB total is a pragmatic
 //      ceiling aligned with most broker implementations
 // ---------------------------------------------------------------------------
 
@@ -37,7 +37,7 @@ const (
 	MaxMetadataKeys = 64
 
 	// MaxMetadataKeyLen is the maximum byte length of a single metadata key.
-	// Measured in bytes (len()), not runes — multi-byte UTF-8 keys are counted
+	// Measured in bytes (len()), not runes -- multi-byte UTF-8 keys are counted
 	// by their wire size, consistent with transport-level limits.
 	MaxMetadataKeyLen = 256
 
@@ -166,7 +166,7 @@ type Writer interface {
 // WriteBatchFallback which auto-detects batch support and falls back
 // to sequential Write calls.
 //
-// ref: ThreeDotsLabs/watermill message/pubsub.go — Publish(topic, ...msgs)
+// ref: ThreeDotsLabs/watermill message/pubsub.go -- Publish(topic, ...msgs)
 // variadic pattern. GoCell uses a separate interface instead to preserve
 // the existing Writer contract and enable optimized multi-row INSERT.
 type BatchWriter interface {
@@ -330,7 +330,7 @@ func isDiscardPublisher(p Publisher) bool {
 }
 
 // ---------------------------------------------------------------------------
-// Disposition / Receipt / HandleResult — Solution B types
+// Disposition / Receipt / HandleResult -- Solution B types
 // ---------------------------------------------------------------------------
 
 // Disposition describes the broker-level action for a consumed message.
@@ -347,8 +347,8 @@ const (
 	// IMPORTANT: iota+1 ensures the zero value (0) is NOT a valid Disposition.
 	// A forgotten/uninitialised HandleResult.Disposition will NOT silently ACK.
 	DispositionAck     Disposition = iota + 1 // = 1
-	DispositionRequeue                        // NACK+requeue — transient / shutdown
-	DispositionReject                         // NACK+no-requeue — permanent failure → DLX
+	DispositionRequeue                        // NACK+requeue -- transient / shutdown
+	DispositionReject                         // NACK+no-requeue -- permanent failure -> DLX
 )
 
 // Valid reports whether d is a recognised Disposition value.
@@ -397,7 +397,7 @@ type HandleResult struct {
 type EntryHandler func(context.Context, Entry) HandleResult
 
 // ---------------------------------------------------------------------------
-// PermanentError — error classification (domain concept)
+// PermanentError -- error classification (domain concept)
 // ---------------------------------------------------------------------------
 
 // PermanentError wraps an error to indicate it should not be retried
@@ -405,7 +405,7 @@ type EntryHandler func(context.Context, Entry) HandleResult
 // alongside Disposition and HandleResult.
 //
 // ref: Temporal SDK temporal.ApplicationError (NonRetryable flag in SDK core);
-// Watermill delegates error classification to middleware — GoCell makes it
+// Watermill delegates error classification to middleware -- GoCell makes it
 // explicit at the kernel level so WrapLegacyHandler and InMemoryEventBus
 // can detect it without depending on adapter-layer types.
 type PermanentError struct {
@@ -437,9 +437,9 @@ func NewPermanentError(err error) *PermanentError {
 type LegacyHandler = func(context.Context, Entry) error
 
 // WrapLegacyHandler adapts a LegacyHandler to the new EntryHandler contract:
-//   - nil error         → DispositionAck
-//   - PermanentError    → DispositionReject (routed to DLX)
-//   - other non-nil err → DispositionRequeue (transient by default)
+//   - nil error         -> DispositionAck
+//   - PermanentError    -> DispositionReject (routed to DLX)
+//   - other non-nil err -> DispositionRequeue (transient by default)
 //
 // This allows existing cell handlers to compile against the new Subscriber
 // interface without immediate rewrite.
@@ -466,85 +466,92 @@ func WrapLegacyHandler(fn LegacyHandler) EntryHandler {
 // Adopted: Close() for clean shutdown; topic-based subscription model.
 // Deviated: callback-based EntryHandler instead of channel-based (<-chan *Message)
 // to align with GoCell's ConsumerBase pattern and simplify consumer lifecycle.
+// Extended: Setup/Ready split mirrors Watermill Router's setup-before-run pattern,
+// eliminating the 500ms startup-timeout heuristic in eventrouter (Commit 3).
 //
-// ref: Kafka sarama ConsumerGroup — consumerGroup isolates consumption; same group
+// ref: Kafka sarama ConsumerGroup -- consumerGroup isolates consumption; same group
 // competes, different groups each get a full copy (fanout).
-// ref: go-micro broker.SubscribeOptions.Queue — same concept, different name.
+// ref: go-micro broker.SubscribeOptions.Queue -- same concept, different name.
 type Subscriber interface {
-	// Subscribe registers a handler for the given topic. The handler is called
-	// for each incoming entry and returns a HandleResult that declares the
-	// intended broker disposition.
+	// Setup pre-declares broker topology (exchanges, queues, bindings) for the
+	// given subscription before Subscribe is called. Callers SHOULD await Ready
+	// before publishing to ensure messages are queued deterministically.
+	// In-memory implementations MUST return nil immediately.
+	Setup(ctx context.Context, sub Subscription) error
+
+	// Ready returns a channel that is closed when the subscription is ready to
+	// consume. In-memory implementations SHOULD return an already-closed channel.
+	Ready(sub Subscription) <-chan struct{}
+
+	// Subscribe registers a handler for the given subscription and blocks until
+	// ctx is cancelled or an unrecoverable error occurs.
 	//
-	// consumerGroup identifies the logical consumer group. Subscribers in
-	// the same group compete for messages (load-balanced); different groups
-	// each receive a full copy (fanout).
-	//
-	// Empty consumerGroup is accepted for backward compatibility but its
-	// semantics are backend-specific and NOT portable:
-	//   - InMemoryEventBus: broadcast to all subscribers (fanout)
-	//   - RabbitMQ: falls back to topic-named queue (competing)
-	// Cell code SHOULD always pass a non-empty group via EventRouter.AddHandler.
-	//
-	// Subscribe blocks until ctx is cancelled or an unrecoverable error occurs.
-	Subscribe(ctx context.Context, topic string, handler EntryHandler, consumerGroup string) error
+	// Subscription.ConsumerGroup identifies the logical consumer group.
+	// Subscribers sharing the same group compete for messages (load-balanced);
+	// different groups each receive a full copy (fanout).
+	Subscribe(ctx context.Context, sub Subscription, handler EntryHandler) error
 
 	// Close terminates all active subscriptions and releases resources.
 	Close() error
 }
 
-// ErrInitializerNotSupported is returned by InitializeSubscription when the
-// underlying subscriber does not support topology pre-declaration. Callers
-// that receive this error should use an alternative readiness mechanism
-// (e.g., polling or timed delay) instead of assuming initialization succeeded.
+// ErrInitializerNotSupported is kept for backward-compatible callers that still
+// perform SubscriberInitializer detection. Deprecated: use Subscriber.Setup.
 var ErrInitializerNotSupported = errors.New("subscriber does not implement SubscriberInitializer")
 
-// SubscriberInitializer is optionally implemented by Subscriber to pre-declare
-// broker topology (exchanges, queues, bindings) before Subscribe is called.
-// This allows the conformance harness to publish messages deterministically —
-// with a persistent broker, messages are queued even before Subscribe starts
-// consuming.
+// SubscriberInitializer is deprecated. Topology pre-declaration is now part of
+// the Subscriber interface (Setup method). Kept so existing callers compile
+// during migration.
 //
-// Implementations that do not support pre-initialization (e.g., in-memory)
-// need not implement this interface; the harness falls back to a brief sleep.
-//
-// ref: Watermill message.SubscribeInitializer — synchronous topology pre-creation.
+// Deprecated: implement Subscriber.Setup instead.
 type SubscriberInitializer interface {
 	InitializeSubscription(ctx context.Context, topic, consumerGroup string) error
 }
 
-// TopicHandlerMiddleware transforms an EntryHandler, receiving the topic name.
-// It is the event-consumer analogue of HTTP middleware.
+// TopicHandlerMiddleware is kept for backward compatibility with existing code
+// that uses ObservabilityContextMiddleware and bootstrap wiring.
+//
+// Deprecated: new code should use SubscriptionMiddleware (subscription.go)
+// which carries the full Subscription identity.
 type TopicHandlerMiddleware func(topic string, next EntryHandler) EntryHandler
 
-// SubscriberWithMiddleware wraps a Subscriber so that every handler passed
-// to Subscribe is first wrapped by the given middleware chain.
+// SubscriberWithMiddleware wraps a Subscriber so that every handler passed to
+// Subscribe is first wrapped by the SubscriptionMiddleware chain.
 // Middleware is applied in order: [0] is outermost, [len-1] is innermost.
 type SubscriberWithMiddleware struct {
 	Inner      Subscriber
-	Middleware []TopicHandlerMiddleware
+	Middleware []SubscriptionMiddleware
 }
 
 // Compile-time interface check.
 var _ Subscriber = (*SubscriberWithMiddleware)(nil)
 
-// Subscribe wraps the handler with the middleware chain, then delegates to Inner.
-func (s *SubscriberWithMiddleware) Subscribe(ctx context.Context, topic string, handler EntryHandler, consumerGroup string) error {
-	wrapped := handler
-	for i := len(s.Middleware) - 1; i >= 0; i-- {
-		wrapped = s.Middleware[i](topic, wrapped)
-	}
-	return s.Inner.Subscribe(ctx, topic, wrapped, consumerGroup)
+// Setup delegates topology pre-declaration to Inner.
+func (s *SubscriberWithMiddleware) Setup(ctx context.Context, sub Subscription) error {
+	return s.Inner.Setup(ctx, sub)
 }
 
-// InitializeSubscription delegates to Inner if it implements SubscriberInitializer.
-// Returns ErrInitializerNotSupported when Inner does not implement the interface,
-// so callers (e.g., outboxtest.waitForSubscription) can fall back to sleep-based
-// waiting instead of assuming initialization succeeded.
-func (s *SubscriberWithMiddleware) InitializeSubscription(ctx context.Context, topic, consumerGroup string) error {
-	if init, ok := s.Inner.(SubscriberInitializer); ok {
-		return init.InitializeSubscription(ctx, topic, consumerGroup)
+// Ready delegates to Inner.
+func (s *SubscriberWithMiddleware) Ready(sub Subscription) <-chan struct{} {
+	return s.Inner.Ready(sub)
+}
+
+// Subscribe wraps the handler with the middleware chain, passing the full
+// Subscription to each middleware, then delegates to Inner.
+func (s *SubscriberWithMiddleware) Subscribe(ctx context.Context, sub Subscription, handler EntryHandler) error {
+	wrapped := handler
+	for i := len(s.Middleware) - 1; i >= 0; i-- {
+		wrapped = s.Middleware[i](sub, wrapped)
 	}
-	return ErrInitializerNotSupported
+	return s.Inner.Subscribe(ctx, sub, wrapped)
+}
+
+// InitializeSubscription implements SubscriberInitializer for backward
+// compatibility. Delegates to Inner.Setup using a synthetic Subscription.
+//
+// Deprecated: callers should use Setup directly.
+func (s *SubscriberWithMiddleware) InitializeSubscription(ctx context.Context, topic, consumerGroup string) error {
+	return s.Inner.Setup(ctx, Subscription{Topic: topic, ConsumerGroup: consumerGroup})
 }
 
 // Close delegates to the inner subscriber.

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -37,13 +37,23 @@ var _ Publisher = (*mockPublisher)(nil)
 // plainSubscriber implements Subscriber but NOT SubscriberInitializer.
 type plainSubscriber struct{}
 
-func (m *plainSubscriber) Subscribe(context.Context, string, EntryHandler, string) error { return nil }
-func (m *plainSubscriber) Close() error                                                  { return nil }
+func (m *plainSubscriber) Setup(_ context.Context, _ Subscription) error { return nil }
+func (m *plainSubscriber) Ready(_ Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (m *plainSubscriber) Subscribe(_ context.Context, _ Subscription, _ EntryHandler) error {
+	return nil
+}
+func (m *plainSubscriber) Close() error { return nil }
 
 func TestSubscriberInitializer_IsOptional(t *testing.T) {
+	// SubscriberInitializer is deprecated; all Subscribers now implement Setup.
+	// plainSubscriber does not separately implement the deprecated interface.
 	var sub Subscriber = &plainSubscriber{}
 	_, ok := sub.(SubscriberInitializer)
-	assert.False(t, ok, "plainSubscriber should not implement SubscriberInitializer")
+	assert.False(t, ok, "plainSubscriber should not separately implement deprecated SubscriberInitializer")
 }
 
 func TestNoopWriter_Write(t *testing.T) {
@@ -91,7 +101,13 @@ func TestDiscardPublisher_IsExplicitDiscardSink(t *testing.T) {
 
 type mockSubscriber struct{}
 
-func (m *mockSubscriber) Subscribe(ctx context.Context, topic string, handler EntryHandler, _ string) error {
+func (m *mockSubscriber) Setup(_ context.Context, _ Subscription) error { return nil }
+func (m *mockSubscriber) Ready(_ Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (m *mockSubscriber) Subscribe(_ context.Context, _ Subscription, _ EntryHandler) error {
 	return nil
 }
 func (m *mockSubscriber) Close() error { return nil }
@@ -105,7 +121,7 @@ func TestSubscriberInterface(t *testing.T) {
 		handler := func(ctx context.Context, entry Entry) HandleResult {
 			return HandleResult{Disposition: DispositionAck}
 		}
-		err := sub.Subscribe(context.Background(), "test.topic", handler, "")
+		err := sub.Subscribe(context.Background(), Subscription{Topic: "test.topic"}, handler)
 		assert.NoError(t, err)
 	})
 
@@ -142,9 +158,15 @@ type recordingSubscriber struct {
 	closeErr        error
 }
 
-func (r *recordingSubscriber) Subscribe(_ context.Context, topic string, handler EntryHandler, _ string) error {
+func (r *recordingSubscriber) Setup(_ context.Context, _ Subscription) error { return nil }
+func (r *recordingSubscriber) Ready(_ Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (r *recordingSubscriber) Subscribe(_ context.Context, sub Subscription, handler EntryHandler) error {
 	r.subscribeCalled = true
-	r.subscribeTopic = topic
+	r.subscribeTopic = sub.Topic
 	r.capturedHandler = handler
 	return nil
 }
@@ -169,7 +191,7 @@ func TestSubscriberWithMiddleware_NoMiddleware(t *testing.T) {
 		return HandleResult{Disposition: DispositionAck}
 	}
 
-	err := sub.Subscribe(context.Background(), "test.topic", handler, "")
+	err := sub.Subscribe(context.Background(), Subscription{Topic: "test.topic"}, handler)
 	assert.NoError(t, err)
 	assert.True(t, inner.subscribeCalled)
 	assert.Equal(t, "test.topic", inner.subscribeTopic)
@@ -184,8 +206,8 @@ func TestSubscriberWithMiddleware_SingleMiddleware(t *testing.T) {
 	inner := &recordingSubscriber{}
 
 	var middlewareTopic string
-	middleware := func(topic string, next EntryHandler) EntryHandler {
-		middlewareTopic = topic
+	middleware := func(sub Subscription, next EntryHandler) EntryHandler {
+		middlewareTopic = sub.Topic
 		return func(ctx context.Context, e Entry) HandleResult {
 			e.Metadata = map[string]string{"wrapped": "true"}
 			return next(ctx, e)
@@ -194,7 +216,7 @@ func TestSubscriberWithMiddleware_SingleMiddleware(t *testing.T) {
 
 	sub := &SubscriberWithMiddleware{
 		Inner:      inner,
-		Middleware: []TopicHandlerMiddleware{middleware},
+		Middleware: []SubscriptionMiddleware{middleware},
 	}
 
 	var receivedEntry Entry
@@ -203,7 +225,7 @@ func TestSubscriberWithMiddleware_SingleMiddleware(t *testing.T) {
 		return HandleResult{Disposition: DispositionAck}
 	}
 
-	err := sub.Subscribe(context.Background(), "orders.created", handler, "")
+	err := sub.Subscribe(context.Background(), Subscription{Topic: "orders.created"}, handler)
 	assert.NoError(t, err)
 	assert.Equal(t, "orders.created", middlewareTopic)
 
@@ -219,8 +241,8 @@ func TestSubscriberWithMiddleware_MultipleMiddleware_OrderCorrect(t *testing.T) 
 
 	var order []string
 
-	makeMiddleware := func(name string) TopicHandlerMiddleware {
-		return func(topic string, next EntryHandler) EntryHandler {
+	makeMiddleware := func(name string) SubscriptionMiddleware {
+		return func(_ Subscription, next EntryHandler) EntryHandler {
 			return func(ctx context.Context, e Entry) HandleResult {
 				order = append(order, name+"-before")
 				res := next(ctx, e)
@@ -232,7 +254,7 @@ func TestSubscriberWithMiddleware_MultipleMiddleware_OrderCorrect(t *testing.T) 
 
 	sub := &SubscriberWithMiddleware{
 		Inner: inner,
-		Middleware: []TopicHandlerMiddleware{
+		Middleware: []SubscriptionMiddleware{
 			makeMiddleware("outer"),
 			makeMiddleware("inner"),
 		},
@@ -243,7 +265,7 @@ func TestSubscriberWithMiddleware_MultipleMiddleware_OrderCorrect(t *testing.T) 
 		return HandleResult{Disposition: DispositionAck}
 	}
 
-	err := sub.Subscribe(context.Background(), "test.topic", handler, "")
+	err := sub.Subscribe(context.Background(), Subscription{Topic: "test.topic"}, handler)
 	assert.NoError(t, err)
 
 	_ = inner.capturedHandler(context.Background(), Entry{})
@@ -278,7 +300,7 @@ func TestSubscriberWithMiddleware_Close_PropagatesError(t *testing.T) {
 func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
 	inner := &recordingSubscriber{}
 
-	shortCircuit := func(_ string, _ EntryHandler) EntryHandler {
+	shortCircuit := func(_ Subscription, _ EntryHandler) EntryHandler {
 		return func(_ context.Context, _ Entry) HandleResult {
 			return HandleResult{
 				Disposition: DispositionReject,
@@ -289,7 +311,7 @@ func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
 
 	sub := &SubscriberWithMiddleware{
 		Inner:      inner,
-		Middleware: []TopicHandlerMiddleware{shortCircuit},
+		Middleware: []SubscriptionMiddleware{shortCircuit},
 	}
 
 	handlerCalled := false
@@ -298,7 +320,7 @@ func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
 		return HandleResult{Disposition: DispositionAck}
 	}
 
-	err := sub.Subscribe(context.Background(), "test.topic", handler, "")
+	err := sub.Subscribe(context.Background(), Subscription{Topic: "test.topic"}, handler)
 	assert.NoError(t, err)
 
 	// Call captured handler — middleware should short-circuit.
@@ -308,41 +330,40 @@ func TestSubscriberWithMiddleware_MiddlewareCanShortCircuit(t *testing.T) {
 	assert.False(t, handlerCalled)
 }
 
-// --- SubscriberWithMiddleware + SubscriberInitializer forwarding (F1-1) ---
+// --- SubscriberWithMiddleware backward-compat InitializeSubscription (F1-1) ---
 
-// initializerSubscriber implements both Subscriber and SubscriberInitializer.
-type initializerSubscriber struct {
+// setupSubscriber tracks Setup calls for tests.
+type setupSubscriber struct {
 	recordingSubscriber
-	initCalled bool
-	initTopic  string
-	initGroup  string
-	initErr    error
+	setupCalled bool
+	setupSub    Subscription
+	setupErr    error
 }
 
-func (s *initializerSubscriber) InitializeSubscription(_ context.Context, topic, consumerGroup string) error {
-	s.initCalled = true
-	s.initTopic = topic
-	s.initGroup = consumerGroup
-	return s.initErr
+func (s *setupSubscriber) Setup(_ context.Context, sub Subscription) error {
+	s.setupCalled = true
+	s.setupSub = sub
+	return s.setupErr
 }
 
 func TestSubscriberWithMiddleware_ForwardsSubscriberInitializer(t *testing.T) {
-	inner := &initializerSubscriber{}
+	inner := &setupSubscriber{}
 	sub := &SubscriberWithMiddleware{Inner: inner}
 
-	// SubscriberWithMiddleware must implement SubscriberInitializer.
+	// SubscriberWithMiddleware must implement SubscriberInitializer for backward compat.
 	init, ok := Subscriber(sub).(SubscriberInitializer)
 	assert.True(t, ok, "SubscriberWithMiddleware should implement SubscriberInitializer")
 
+	// InitializeSubscription delegates to Inner.Setup.
 	err := init.InitializeSubscription(context.Background(), "test.topic", "cg-1")
 	assert.NoError(t, err)
-	assert.True(t, inner.initCalled)
-	assert.Equal(t, "test.topic", inner.initTopic)
-	assert.Equal(t, "cg-1", inner.initGroup)
+	assert.True(t, inner.setupCalled)
+	assert.Equal(t, "test.topic", inner.setupSub.Topic)
+	assert.Equal(t, "cg-1", inner.setupSub.ConsumerGroup)
 }
 
 func TestSubscriberWithMiddleware_InitializeSubscription_PropagatesError(t *testing.T) {
-	inner := &initializerSubscriber{initErr: errors.New("init failed")}
+	inner := &setupSubscriber{setupErr: errors.New("init failed")}
 	sub := &SubscriberWithMiddleware{Inner: inner}
 
 	err := sub.InitializeSubscription(context.Background(), "t", "g")
@@ -351,15 +372,14 @@ func TestSubscriberWithMiddleware_InitializeSubscription_PropagatesError(t *test
 }
 
 func TestSubscriberWithMiddleware_InitializeSubscription_InnerNotInitializer(t *testing.T) {
-	// Inner does NOT implement SubscriberInitializer — must return
-	// ErrInitializerNotSupported so callers (e.g., waitForSubscription)
-	// can fall back to sleep-based waiting instead of assuming success.
+	// All Subscribers now implement Setup, so InitializeSubscription always delegates
+	// to Setup. ErrInitializerNotSupported is no longer returned.
 	inner := &recordingSubscriber{}
 	sub := &SubscriberWithMiddleware{Inner: inner}
 
 	err := sub.InitializeSubscription(context.Background(), "t", "g")
-	assert.ErrorIs(t, err, ErrInitializerNotSupported,
-		"must return ErrInitializerNotSupported when inner does not implement SubscriberInitializer")
+	assert.NoError(t, err,
+		"InitializeSubscription must delegate to Setup which returns nil for recordingSubscriber")
 }
 
 func TestEntry_RoutingTopic(t *testing.T) {
@@ -853,6 +873,51 @@ func TestDiscardPublisher_ZeroValue_Safe(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), dp.DiscardCount())
 }
+
+// TestSubscriberWithMiddleware_PassesFullSubscription asserts that when Subscribe
+// is called with a Subscription, the middleware receives the *full* Subscription
+// (both Topic and ConsumerGroup), not only the topic string.
+// This test will fail until SubscriptionMiddleware replaces TopicHandlerMiddleware.
+func TestSubscriberWithMiddleware_PassesFullSubscription(t *testing.T) {
+	inner := &recordingSubscriberFull{}
+
+	var capturedSub Subscription
+	mw := func(sub Subscription, next EntryHandler) EntryHandler {
+		capturedSub = sub
+		return next
+	}
+
+	swm := &SubscriberWithMiddleware{
+		Inner:      inner,
+		Middleware: []SubscriptionMiddleware{mw},
+	}
+
+	wantSub := Subscription{Topic: "orders.created.v1", ConsumerGroup: "cg-audit-core", CellID: "audit-core"}
+	err := swm.Subscribe(context.Background(), wantSub, func(_ context.Context, _ Entry) HandleResult {
+		return HandleResult{Disposition: DispositionAck}
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, wantSub.Topic, capturedSub.Topic, "middleware must receive Topic")
+	assert.Equal(t, wantSub.ConsumerGroup, capturedSub.ConsumerGroup, "middleware must receive ConsumerGroup")
+	assert.Equal(t, wantSub.CellID, capturedSub.CellID, "middleware must receive CellID")
+}
+
+// recordingSubscriberFull implements the new Subscriber interface (Subscribe takes Subscription).
+type recordingSubscriberFull struct {
+	subscribedSub Subscription
+}
+
+func (r *recordingSubscriberFull) Setup(_ context.Context, _ Subscription) error { return nil }
+func (r *recordingSubscriberFull) Ready(_ Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (r *recordingSubscriberFull) Subscribe(_ context.Context, sub Subscription, _ EntryHandler) error {
+	r.subscribedSub = sub
+	return nil
+}
+func (r *recordingSubscriberFull) Close() error { return nil }
 
 func TestDiscardPublisher_TypedNil_NoPanic(t *testing.T) {
 	// Typed nil: interface is non-nil but underlying pointer is nil.

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -113,6 +113,9 @@ func TestPubSub(t *testing.T, features Features, constructor PubSubConstructor) 
 	t.Run("ReceiptReleasedOnRequeue", func(t *testing.T) {
 		testReceiptReleasedOnRequeue(t, features, constructor)
 	})
+	t.Run("ReceiptCommitFailureDoesNotAck", func(t *testing.T) {
+		testReceiptCommitFailureDoesNotAck(t, features, constructor)
+	})
 
 	// Batch 5: Lifecycle
 	t.Run("SubscribeBlocksUntilCancel", func(t *testing.T) {
@@ -648,6 +651,48 @@ func testReceiptReleasedOnRequeue(t *testing.T, features Features, constructor P
 	h.publishAndWait([]byte(`{"test":"receipt-requeue"}`))
 	assertEventually(t, func() bool { return receipt.Released() },
 		5*time.Second, 10*time.Millisecond, "Receipt.Release should be called on Requeue")
+	h.teardown()
+}
+
+// testReceiptCommitFailureDoesNotAck guards the cross-transport invariant
+// added in the F2 fix (PR #184): when handler returns DispositionAck but
+// Receipt.Commit fails (lease lost / token mismatch / backend error), the
+// adapter must NOT treat the message as successfully acknowledged. RabbitMQ
+// translates this to Nack(requeue=true); InMemoryEventBus retries via its
+// internal retry loop. Either way the handler must be re-invoked, evidenced
+// by an additional Receipt.Commit attempt or a redelivery.
+//
+// Without this guard, regression to the pre-F2 semantics (eventbus silently
+// promoting Commit failure to success) would cause stale lease holders to
+// "succeed" — see PR #184 review F2 / commit 87475b9.
+func testReceiptCommitFailureDoesNotAck(t *testing.T, features Features, constructor PubSubConstructor) {
+	if !features.SupportsReceipt {
+		t.Skip(skipNoReceipt)
+	}
+
+	h := newHarness(t, constructor)
+	// Receipt whose Commit always returns an error — emulates lease-lost /
+	// token-mismatch backend response.
+	receipt := NewMockReceiptWithErrors(errors.New("commit fails (test)"), nil)
+
+	var deliveries atomic.Int32
+	h.subscribe(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		n := deliveries.Add(1)
+		if n == 1 {
+			h.signalDone() // wake publisher after first delivery
+		}
+		return outbox.HandleResult{Disposition: outbox.DispositionAck, Receipt: receipt}
+	})
+
+	h.publishAndWait([]byte(`{"test":"commit-fail"}`))
+	// Adapter must retry / redeliver after Commit failure. We assert at least
+	// one extra Commit attempt OR an extra delivery within a generous window.
+	// Both rabbitmq (Nack→requeue→re-consume) and eventbus (handleWithRetry
+	// loop) satisfy "Commit was tried more than once" within retry budget.
+	assertEventually(t, func() bool {
+		return receipt.CommitCount() >= 2 || deliveries.Load() >= 2
+	}, 5*time.Second, 20*time.Millisecond,
+		"adapter must NOT promote Commit failure to success — expected retry/redelivery")
 	h.teardown()
 }
 

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -289,32 +289,47 @@ func testMultipleSubscribers(t *testing.T, _ Features, constructor PubSubConstru
 		sub1Received atomic.Int32
 		sub2Received atomic.Int32
 		wg           sync.WaitGroup
+		sub1Ready    = make(chan struct{})
+		sub2Ready    = make(chan struct{})
 	)
 
 	subCtx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	// Subscriber 1.
+	// Per-sub readiness signals: Subscribe is blocking, and the bus-level
+	// Ready() channel only synchronizes the FIRST Subscribe call for a given
+	// (consumerGroup, topic) pair. With two broadcast subscribers we need each
+	// goroutine to confirm its own registration before the test publishes,
+	// otherwise the second sub may miss the event.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		close(sub1Ready)
 		_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topic}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub1Received.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 
-	// Subscriber 2.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		close(sub2Ready)
 		_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topic}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub2Received.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})
 	}()
 
+	<-sub1Ready
+	<-sub2Ready
 	waitForSubscription(t, ctx, sub, topic, "")
+	// In-memory bus signals Ready after the FIRST Subscribe registration; the
+	// second broadcast sub may still be entering its Subscribe call. A brief
+	// sleep covers the tail registration window without coupling the test to
+	// bus internals. Persistent brokers (RabbitMQ) skip this path entirely
+	// (BroadcastSubscribe=false → testCompetingConsumers).
+	time.Sleep(subscribeInitDelay)
 
 	assertNoError(t, pub.Publish(ctx, topic, []byte(`{"test":"fan-out"}`)))
 

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -233,7 +233,7 @@ func testTopicIsolation(t *testing.T, _ Features, constructor PubSubConstructor)
 	subDone := make(chan struct{})
 	go func() {
 		defer close(subDone)
-		_ = sub.Subscribe(subCtx, topicA, func(_ context.Context, entry outbox.Entry) outbox.HandleResult {
+		_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topicA}, func(_ context.Context, entry outbox.Entry) outbox.HandleResult {
 			select {
 			case deliveryA <- struct{}{}:
 			default:
@@ -245,7 +245,7 @@ func testTopicIsolation(t *testing.T, _ Features, constructor PubSubConstructor)
 			}
 			mu.Unlock()
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 	waitForSubscription(t, ctx, sub, topicA, "")
 
@@ -298,20 +298,20 @@ func testMultipleSubscribers(t *testing.T, _ Features, constructor PubSubConstru
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = sub.Subscribe(subCtx, topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topic}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub1Received.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	// Subscriber 2.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = sub.Subscribe(subCtx, topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topic}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub2Received.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	waitForSubscription(t, ctx, sub, topic, "")
@@ -352,14 +352,14 @@ func testCompetingConsumers(t *testing.T, _ Features, constructor PubSubConstruc
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = sub.Subscribe(subCtx, topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+			_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topic}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 				select {
 				case delivery <- struct{}{}:
 				default:
 				}
 				totalReceived.Add(1)
 				return outbox.HandleResult{Disposition: outbox.DispositionAck}
-			}, "")
+			})
 		}()
 	}
 
@@ -650,9 +650,9 @@ func testSubscribeBlocksUntilCancel(t *testing.T, features Features, constructor
 
 	subscribeReturned := make(chan error, 1)
 	go func() {
-		err := sub.Subscribe(ctx, TestTopic(t), func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		err := sub.Subscribe(ctx, outbox.Subscription{Topic: TestTopic(t)}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 		subscribeReturned <- err
 	}()
 
@@ -682,9 +682,9 @@ func testCloseTerminatesSubscribers(t *testing.T, _ Features, constructor PubSub
 	subscribeReturned := make(chan struct{})
 	go func() {
 		defer close(subscribeReturned)
-		_ = sub.Subscribe(ctx, topic, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = sub.Subscribe(ctx, outbox.Subscription{Topic: topic}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 	waitForSubscription(t, ctx, sub, topic, "")
 
@@ -766,7 +766,7 @@ func testSubscriberWithMiddleware(t *testing.T, _ Features, constructor PubSubCo
 	h := newHarness(t, constructor)
 
 	var middlewareCalled atomic.Bool
-	middleware := func(_ string, next outbox.EntryHandler) outbox.EntryHandler {
+	middleware := func(_ outbox.Subscription, next outbox.EntryHandler) outbox.EntryHandler {
 		return func(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 			middlewareCalled.Store(true)
 			return next(ctx, entry)
@@ -776,7 +776,7 @@ func testSubscriberWithMiddleware(t *testing.T, _ Features, constructor PubSubCo
 	// Wrap inner subscriber with middleware.
 	h.Sub = &outbox.SubscriberWithMiddleware{
 		Inner:      h.Sub,
-		Middleware: []outbox.TopicHandlerMiddleware{middleware},
+		Middleware: []outbox.SubscriptionMiddleware{middleware},
 	}
 
 	h.subscribe(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {

--- a/kernel/outbox/outboxtest/helpers.go
+++ b/kernel/outbox/outboxtest/helpers.go
@@ -15,28 +15,30 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
-// waitForSubscription replaces time.Sleep(subscribeInitDelay) with a
-// deterministic readiness check when the subscriber implements
-// outbox.SubscriberInitializer. For persistent brokers (e.g., RabbitMQ),
-// InitializeSubscription pre-declares the topology so that published messages
-// are queued before Subscribe starts consuming — eliminating the race.
-// For in-memory implementations that lack InitializeSubscription, it falls
-// back to the brief sleep.
+// waitForSubscription waits until the subscriber is ready to receive messages
+// for the given topic. It calls Setup to declare topology, then waits for the
+// Ready channel to close. For persistent brokers, Setup pre-declares queues so
+// messages are durably queued before Subscribe starts consuming. For in-memory
+// implementations, Ready blocks until the goroutine calls Subscribe.
 //
 // ref: Watermill message.SubscribeInitializer — synchronous topology pre-creation.
 func waitForSubscription(t *testing.T, ctx context.Context, sub outbox.Subscriber, topic, consumerGroup string) {
 	t.Helper()
-	if init, ok := sub.(outbox.SubscriberInitializer); ok {
-		err := init.InitializeSubscription(ctx, topic, consumerGroup)
-		if err == nil {
-			return // deterministic initialization succeeded
-		}
-		if !errors.Is(err, outbox.ErrInitializerNotSupported) {
-			t.Fatalf("InitializeSubscription(%s, %s): %v", topic, consumerGroup, err)
-		}
-		// Inner does not support initialization — fall through to sleep.
+	subSpec := outbox.Subscription{Topic: topic, ConsumerGroup: consumerGroup}
+	if err := sub.Setup(ctx, subSpec); err != nil {
+		t.Fatalf("waitForSubscription: Setup(%s): %v", topic, err)
 	}
-	time.Sleep(subscribeInitDelay)
+	select {
+	case <-sub.Ready(subSpec):
+	case <-ctx.Done():
+		t.Fatalf("waitForSubscription: context cancelled before subscriber ready: %v", ctx.Err())
+	case <-time.After(subscribeInitDelay):
+		// Fallback: subscriber did not signal Ready within init delay. This is
+		// acceptable for implementations that return a never-closing Ready channel
+		// (e.g., persistent brokers where setup is fire-and-forget). The caller
+		// may experience delivery loss on the first message; that is acceptable
+		// for non-persistent test setups.
+	}
 }
 
 // TestTopic returns a unique topic name scoped to the given test.
@@ -131,11 +133,11 @@ func CollectN(
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
-	// Subscribe blocks — run in goroutine.
+	// Subscribe blocks -- run in goroutine.
 	subDone := make(chan struct{})
 	go func() {
 		defer close(subDone)
-		_ = sub.Subscribe(subCtx, topic, handler, "")
+		_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topic}, handler)
 	}()
 
 	// Wait for subscription to register. Uses SubscriberInitializer if available,
@@ -198,7 +200,7 @@ func startCollecting(t *testing.T, ctx context.Context, sub outbox.Subscriber, t
 	go func() {
 		defer close(c.subDone)
 		close(ready) // signal: goroutine is running, Subscribe call is imminent
-		err := sub.Subscribe(subCtx, topic, func(_ context.Context, entry outbox.Entry) outbox.HandleResult {
+		err := sub.Subscribe(subCtx, outbox.Subscription{Topic: topic}, func(_ context.Context, entry outbox.Entry) outbox.HandleResult {
 			c.mu.Lock()
 			c.collected = append(c.collected, entry)
 			count := len(c.collected)
@@ -207,7 +209,7 @@ func startCollecting(t *testing.T, ctx context.Context, sub outbox.Subscriber, t
 				c.closeOnce.Do(func() { close(c.done) })
 			}
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 		if err != nil && !errors.Is(err, context.Canceled) {
 			c.t.Errorf("unexpected Subscribe error: %v", err)
 		}
@@ -315,7 +317,7 @@ func (h *pubSubHarness) subscribe(handler outbox.EntryHandler) {
 	go func() {
 		defer close(h.subDone)
 		close(ready)
-		err := h.Sub.Subscribe(ctx, h.Topic, wrapped, "")
+		err := h.Sub.Subscribe(ctx, outbox.Subscription{Topic: h.Topic}, wrapped)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			h.T.Errorf("unexpected Subscribe error: %v", err)
 		}

--- a/kernel/outbox/outboxtest/helpers_test.go
+++ b/kernel/outbox/outboxtest/helpers_test.go
@@ -155,64 +155,75 @@ func TestFeatures_SetDefaults_PreservesExplicit(t *testing.T) {
 // waitForSubscription tests
 // ---------------------------------------------------------------------------
 
-// fakeInitializerSub implements both Subscriber and SubscriberInitializer.
-type fakeInitializerSub struct {
-	fakePubSub
-	initCalled bool
-	initTopic  string
-	initGroup  string
+// recordingSubscriber records Setup/Ready calls to verify waitForSubscription
+// uses the new Subscriber interface. Embeds immediateReadySub so Ready() returns
+// a pre-closed channel and waitForSubscription exits immediately.
+type recordingSubscriber struct {
+	immediateReadySub
+	mu          sync.Mutex
+	setupCalled bool
+	setupSub    outbox.Subscription
 }
 
-func (f *fakeInitializerSub) InitializeSubscription(_ context.Context, topic, group string) error {
-	f.initCalled = true
-	f.initTopic = topic
-	f.initGroup = group
+func (r *recordingSubscriber) Setup(_ context.Context, sub outbox.Subscription) error {
+	r.mu.Lock()
+	r.setupCalled = true
+	r.setupSub = sub
+	r.mu.Unlock()
 	return nil
 }
 
-func TestWaitForSubscription_UsesInitializerWhenAvailable(t *testing.T) {
-	sub := &fakeInitializerSub{}
+func TestWaitForSubscription_CallsSetupWithSubscription(t *testing.T) {
+	// waitForSubscription must call Setup with the correct Subscription.
+	sub := &recordingSubscriber{}
 	ctx := context.Background()
 
 	waitForSubscription(t, ctx, sub, "my.topic", "cg-1")
 
-	if !sub.initCalled {
-		t.Fatal("expected InitializeSubscription to be called")
+	sub.mu.Lock()
+	defer sub.mu.Unlock()
+	if !sub.setupCalled {
+		t.Fatal("expected Setup to be called")
 	}
-	if sub.initTopic != "my.topic" {
-		t.Fatalf("want topic 'my.topic', got %q", sub.initTopic)
+	if sub.setupSub.Topic != "my.topic" {
+		t.Fatalf("want topic 'my.topic', got %q", sub.setupSub.Topic)
 	}
-	if sub.initGroup != "cg-1" {
-		t.Fatalf("want group 'cg-1', got %q", sub.initGroup)
+	if sub.setupSub.ConsumerGroup != "cg-1" {
+		t.Fatalf("want group 'cg-1', got %q", sub.setupSub.ConsumerGroup)
 	}
 }
 
-// subscribeInitThreshold is 80% of subscribeInitDelay (50ms). Used as the
-// lower bound in sleep-fallback assertions to tolerate scheduling jitter.
-const subscribeInitThreshold = 40 * time.Millisecond
+// immediateReadySub is a subscriber whose Ready channel is always pre-closed.
+// Used to verify that waitForSubscription returns immediately when Ready is done.
+type immediateReadySub struct {
+	fakePubSub
+}
 
-func TestWaitForSubscription_FallsBackToSleep(t *testing.T) {
-	// fakePubSub does NOT implement SubscriberInitializer.
-	sub := &fakePubSub{}
+func (s *immediateReadySub) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func TestWaitForSubscription_WaitsForReadyChannel(t *testing.T) {
+	// When Ready returns a pre-closed channel, waitForSubscription returns fast.
+	sub := &immediateReadySub{}
 	ctx := context.Background()
 
 	start := time.Now()
 	waitForSubscription(t, ctx, sub, "any.topic", "")
 	elapsed := time.Since(start)
 
-	// Should have slept at least subscribeInitDelay (50ms).
-	if elapsed < subscribeInitThreshold {
-		t.Fatalf("expected sleep fallback (~50ms), but returned in %v", elapsed)
+	// Should return quickly since Ready() is already closed (pre-closed channel).
+	if elapsed >= subscribeInitDelay {
+		t.Fatalf("expected fast return (pre-closed Ready channel), but took %v", elapsed)
 	}
 }
 
-func TestWaitForSubscription_MiddlewareWrappedNonInitializer_FallsBack(t *testing.T) {
-	// This is the exact regression path from PR#141 CI failure:
-	// SubscriberWithMiddleware wraps a non-SubscriberInitializer (e.g.,
-	// InMemoryEventBus). Before the fix, InitializeSubscription returned nil
-	// (false success), skipping the sleep fallback → publish before subscribe
-	// registers → message lost → test timeout.
-	inner := &fakePubSub{} // does NOT implement SubscriberInitializer
+func TestWaitForSubscription_MiddlewareWrappedSubscriber_UsesSetup(t *testing.T) {
+	// SubscriberWithMiddleware uses Subscriber.Setup/Ready via Inner.
+	// When Inner.Ready returns a pre-closed channel, the fast path is taken.
+	inner := &immediateReadySub{} // Ready() returns pre-closed channel
 	wrapped := &outbox.SubscriberWithMiddleware{
 		Inner:      inner,
 		Middleware: nil,
@@ -223,9 +234,10 @@ func TestWaitForSubscription_MiddlewareWrappedNonInitializer_FallsBack(t *testin
 	waitForSubscription(t, ctx, wrapped, "test.topic", "")
 	elapsed := time.Since(start)
 
-	// Must fall back to sleep, NOT return instantly.
-	if elapsed < subscribeInitThreshold {
-		t.Fatalf("middleware-wrapped non-initializer must fall back to sleep (~50ms), but returned in %v", elapsed)
+	// Must NOT fall back to sleep -- Setup returns nil immediately and
+	// Inner.Ready returns a pre-closed channel.
+	if elapsed >= subscribeInitDelay {
+		t.Fatalf("middleware-wrapped subscriber must not sleep (Setup+Ready fast path), but took %v", elapsed)
 	}
 }
 
@@ -236,8 +248,19 @@ func TestWaitForSubscription_MiddlewareWrappedNonInitializer_FallsBack(t *testin
 // fakePubSub is a minimal channel-based Publisher+Subscriber for testing
 // the collector helper without importing runtime/eventbus.
 type fakePubSub struct {
-	mu   sync.Mutex
-	subs []chan outbox.Entry
+	mu      sync.Mutex
+	subs    []chan outbox.Entry
+	readyCh chan struct{} // closed on first Subscribe call
+	once    sync.Once
+}
+
+func (f *fakePubSub) readyChannel() chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.readyCh == nil {
+		f.readyCh = make(chan struct{})
+	}
+	return f.readyCh
 }
 
 func (f *fakePubSub) Publish(_ context.Context, topic string, payload []byte) error {
@@ -255,11 +278,28 @@ func (f *fakePubSub) Publish(_ context.Context, topic string, payload []byte) er
 	return nil
 }
 
-func (f *fakePubSub) Subscribe(ctx context.Context, _ string, handler outbox.EntryHandler, _ string) error {
+func (f *fakePubSub) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+
+// Ready returns a channel that closes once the first Subscribe call has
+// registered its handler. This prevents publish-before-subscribe races in
+// the test harness when waitForSubscription is used.
+func (f *fakePubSub) Ready(_ outbox.Subscription) <-chan struct{} {
+	return f.readyChannel()
+}
+
+func (f *fakePubSub) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.EntryHandler) error {
 	ch := make(chan outbox.Entry, 64)
 	f.mu.Lock()
 	f.subs = append(f.subs, ch)
+	rch := f.readyCh
+	if rch == nil {
+		f.readyCh = make(chan struct{})
+		rch = f.readyCh
+	}
 	f.mu.Unlock()
+
+	// Signal readiness after registering the subscription.
+	f.once.Do(func() { close(rch) })
 
 	for {
 		select {

--- a/kernel/outbox/outboxtest/mock_receipt.go
+++ b/kernel/outbox/outboxtest/mock_receipt.go
@@ -12,12 +12,13 @@ import (
 var _ outbox.Receipt = (*MockReceipt)(nil)
 
 // MockReceipt records Commit/Release calls for assertion in tests.
-// Thread-safe via atomic.Bool.
+// Thread-safe via atomic counters.
 type MockReceipt struct {
-	committed  atomic.Bool
-	released   atomic.Bool
-	commitErr  error
-	releaseErr error
+	committed   atomic.Bool
+	released    atomic.Bool
+	commitCalls atomic.Int32
+	commitErr   error
+	releaseErr  error
 }
 
 // NewMockReceipt creates a MockReceipt that succeeds on Commit/Release.
@@ -33,7 +34,14 @@ func NewMockReceiptWithErrors(commitErr, releaseErr error) *MockReceipt {
 // Commit marks the receipt as committed.
 func (r *MockReceipt) Commit(_ context.Context) error {
 	r.committed.Store(true)
+	r.commitCalls.Add(1)
 	return r.commitErr
+}
+
+// CommitCount returns the number of times Commit was called. Used by
+// regression tests that need to verify retries on Commit failure.
+func (r *MockReceipt) CommitCount() int32 {
+	return r.commitCalls.Load()
 }
 
 // Release marks the receipt as released.

--- a/kernel/outbox/subscription.go
+++ b/kernel/outbox/subscription.go
@@ -1,0 +1,58 @@
+package outbox
+
+import "github.com/ghbvf/gocell/pkg/errcode"
+
+// Subscription describes the full identity of a single subscription intent.
+// It is the first-class object passed through the middleware chain, ensuring
+// every layer (idempotency, observability, retry) sees Topic, ConsumerGroup,
+// and CellID without information loss at middleware boundaries.
+//
+// ref: ThreeDotsLabs/watermill message/router.go handler context injection
+// ref: MassTransit ConsumeContext — full identity traverses the entire pipeline
+type Subscription struct {
+	// Topic is the broker routing key. Required.
+	Topic string
+
+	// ConsumerGroup is the logical consumer group identity. Required.
+	// It forms the idempotency key namespace: "{ConsumerGroup}:{entry.ID}".
+	// Subscribers sharing the same ConsumerGroup compete for messages;
+	// different groups each receive a full copy (fanout).
+	ConsumerGroup string
+
+	// CellID is an optional observability label. When set it is used in log
+	// fields and metrics labels; falls back to ConsumerGroup when empty.
+	CellID string
+}
+
+// Validate returns an error when required fields are missing.
+func (s Subscription) Validate() error {
+	if s.Topic == "" {
+		return errcode.New(errcode.ErrValidationFailed, "outbox: subscription Topic must not be empty")
+	}
+	if s.ConsumerGroup == "" {
+		return errcode.New(errcode.ErrValidationFailed, "outbox: subscription ConsumerGroup must not be empty")
+	}
+	return nil
+}
+
+// IdempotencyNamespace returns the namespace prefix for idempotency keys.
+// Keys are constructed as "{IdempotencyNamespace}:{entry.ID}".
+func (s Subscription) IdempotencyNamespace() string {
+	return s.ConsumerGroup
+}
+
+// ObservabilityID returns the human-readable identifier used in logs and metrics.
+// Prefers CellID when set; falls back to ConsumerGroup.
+func (s Subscription) ObservabilityID() string {
+	if s.CellID != "" {
+		return s.CellID
+	}
+	return s.ConsumerGroup
+}
+
+// SubscriptionMiddleware is the event-consumer middleware type that carries
+// the full Subscription identity. It replaces TopicHandlerMiddleware, which
+// only passed the topic string and lost ConsumerGroup at middleware boundaries.
+//
+// Apply in order: [0] is outermost, [len-1] is innermost.
+type SubscriptionMiddleware func(sub Subscription, next EntryHandler) EntryHandler

--- a/kernel/outbox/subscription_test.go
+++ b/kernel/outbox/subscription_test.go
@@ -1,0 +1,67 @@
+package outbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscription_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		sub         Subscription
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "topic empty",
+			sub:         Subscription{Topic: "", ConsumerGroup: "cg-audit"},
+			wantErr:     true,
+			errContains: "Topic",
+		},
+		{
+			name:        "consumerGroup empty",
+			sub:         Subscription{Topic: "session.created.v1", ConsumerGroup: ""},
+			wantErr:     true,
+			errContains: "ConsumerGroup",
+		},
+		{
+			name:        "both empty",
+			sub:         Subscription{},
+			wantErr:     true,
+			errContains: "Topic",
+		},
+		{
+			name:    "valid",
+			sub:     Subscription{Topic: "session.created.v1", ConsumerGroup: "cg-audit"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.sub.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSubscription_IdempotencyNamespace(t *testing.T) {
+	sub := Subscription{Topic: "t", ConsumerGroup: "cg-audit-core"}
+	assert.Equal(t, "cg-audit-core", sub.IdempotencyNamespace())
+}
+
+func TestSubscription_ObservabilityID_UsesCellID(t *testing.T) {
+	sub := Subscription{Topic: "t", ConsumerGroup: "cg-audit", CellID: "audit-core"}
+	assert.Equal(t, "audit-core", sub.ObservabilityID())
+}
+
+func TestSubscription_ObservabilityID_FallsBackToConsumerGroup(t *testing.T) {
+	sub := Subscription{Topic: "t", ConsumerGroup: "cg-audit"}
+	assert.Equal(t, "cg-audit", sub.ObservabilityID())
+}

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -357,6 +357,19 @@ func WithDisableObservabilityRestore() Option {
 	}
 }
 
+// WithEventRouterReadyTimeout overrides the EventRouter Phase-3 ready-wait
+// budget. A non-positive value disables the bound (router waits indefinitely
+// until ctx cancel). Default: eventrouter.DefaultReadyTimeout (30s).
+//
+// On timeout, Bootstrap.Run returns an error listing not-ready
+// "consumerGroup/topic" pairs so operators can pinpoint the stuck subscription.
+func WithEventRouterReadyTimeout(d time.Duration) Option {
+	return func(b *Bootstrap) {
+		b.eventRouterReadyTimeoutSet = true
+		b.eventRouterReadyTimeout = d
+	}
+}
+
 // WithConsumerMiddleware registers subscriber-side middleware applied to every
 // topic handler before it is passed to the underlying Subscriber.Subscribe call.
 // Middleware is applied in registration order; each entry wraps the next, so the
@@ -459,6 +472,8 @@ type Bootstrap struct {
 	verboseToken                string            // token for /readyz?verbose access control
 	closers                     []io.Closer       // middleware dependencies that need shutdown
 	disableObservabilityRestore bool
+	eventRouterReadyTimeout     time.Duration
+	eventRouterReadyTimeoutSet  bool
 	consumerMiddleware          []outbox.SubscriptionMiddleware
 	hookTimeout                 time.Duration // applied when assembly not pre-built
 	hookTimeoutSet              bool          // distinguishes zero-value "unset" from explicit zero
@@ -1003,10 +1018,14 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		// that any log lines or metrics emitted by ConsumerBase / custom middleware
 		// see the restored request_id / correlation_id / trace_id fields.
 		mws = append(mws, b.consumerMiddleware...)
+		var routerOpts []eventrouter.Option
+		if b.eventRouterReadyTimeoutSet {
+			routerOpts = append(routerOpts, eventrouter.WithReadyTimeout(b.eventRouterReadyTimeout))
+		}
 		evtRouter := eventrouter.New(&outbox.SubscriberWithMiddleware{
 			Inner:      sub,
 			Middleware: mws,
-		})
+		}, routerOpts...)
 		for _, id := range asm.CellIDs() {
 			c := asm.Cell(id)
 			if er, ok := c.(cell.EventRegistrar); ok {

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -372,7 +372,7 @@ func WithDisableObservabilityRestore() Option {
 // ref: ThreeDotsLabs/watermill message/router.go — AddMiddleware wraps handlers
 // at router level; MassTransit UseMessageRetry — pipeline middleware at
 // receive-endpoint configuration.
-func WithConsumerMiddleware(mw ...outbox.TopicHandlerMiddleware) Option {
+func WithConsumerMiddleware(mw ...outbox.SubscriptionMiddleware) Option {
 	return func(b *Bootstrap) {
 		b.consumerMiddleware = append(b.consumerMiddleware, mw...)
 	}
@@ -459,7 +459,7 @@ type Bootstrap struct {
 	verboseToken                string            // token for /readyz?verbose access control
 	closers                     []io.Closer       // middleware dependencies that need shutdown
 	disableObservabilityRestore bool
-	consumerMiddleware          []outbox.TopicHandlerMiddleware
+	consumerMiddleware          []outbox.SubscriptionMiddleware
 	hookTimeout                 time.Duration // applied when assembly not pre-built
 	hookTimeoutSet              bool          // distinguishes zero-value "unset" from explicit zero
 	hookObserver                cell.LifecycleHookObserver
@@ -995,7 +995,7 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		}
 	}
 	if sub != nil {
-		var mws []outbox.TopicHandlerMiddleware
+		var mws []outbox.SubscriptionMiddleware
 		if !b.disableObservabilityRestore {
 			mws = append(mws, outbox.ObservabilityContextMiddleware())
 		}

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -274,7 +274,13 @@ type invokeOnceSubscriber struct {
 	once  sync.Once
 }
 
-func (s *invokeOnceSubscriber) Subscribe(ctx context.Context, _ string, handler outbox.EntryHandler, _ string) error {
+func (s *invokeOnceSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *invokeOnceSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *invokeOnceSubscriber) Subscribe(ctx context.Context, _ outbox.Subscription, handler outbox.EntryHandler) error {
 	s.once.Do(func() {
 		handler(ctx, s.entry)
 	})

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -24,6 +24,7 @@ import (
 const (
 	maxRetries     = 3
 	baseRetryDelay = 100 * time.Millisecond
+	maxRetryDelay  = 30 * time.Second
 
 	// TopicConfigChanged is the canonical event topic for config change
 	// events. Cells that publish or subscribe to config changes should
@@ -64,6 +65,10 @@ type InMemoryEventBus struct {
 	closed        bool
 	deadLettersMu sync.Mutex
 	deadLetters   []DeadLetter
+
+	// readyMu guards readyChans. Separate from mu to avoid lock ordering issues.
+	readyMu    sync.Mutex
+	readyChans map[string]chan struct{} // key: consumerGroup + "|" + topic
 }
 
 // groupState tracks subscribers and round-robin index for a consumer group.
@@ -87,8 +92,9 @@ func WithBufferSize(size int) Option {
 // New creates an InMemoryEventBus.
 func New(opts ...Option) *InMemoryEventBus {
 	b := &InMemoryEventBus{
-		groupSubs: make(map[string]map[string]*groupState),
-		bufSize:   256,
+		groupSubs:  make(map[string]map[string]*groupState),
+		readyChans: make(map[string]chan struct{}),
+		bufSize:    256,
 	}
 	for _, o := range opts {
 		o(b)
@@ -178,31 +184,23 @@ func (b *InMemoryEventBus) Setup(_ context.Context, _ outbox.Subscription) error
 	return nil
 }
 
-// Ready implements outbox.Subscriber. Returns a channel that closes once at
-// least one goroutine has called Subscribe for sub.Topic (i.e., the subscription
-// is actually registered and ready to receive messages). This prevents the
+// Ready implements outbox.Subscriber. Returns a channel that closes once
+// Subscribe has been called for the given subscription (i.e., the subscription
+// is registered and ready to receive messages). This prevents the
 // publish-before-subscribe race in tests that use waitForSubscription.
+//
+// The key is sub.ConsumerGroup + "|" + sub.Topic so that different consumer
+// groups on the same topic each get an independent ready signal.
 func (b *InMemoryEventBus) Ready(sub outbox.Subscription) <-chan struct{} {
+	key := sub.ConsumerGroup + "|" + sub.Topic
+	b.readyMu.Lock()
+	defer b.readyMu.Unlock()
+	if ch, ok := b.readyChans[key]; ok {
+		return ch
+	}
+	// No Subscribe call yet — create an open channel that Subscribe will close.
 	ch := make(chan struct{})
-	go func() {
-		for {
-			b.mu.RLock()
-			groups := b.groupSubs[sub.Topic]
-			registered := false
-			for _, gs := range groups {
-				if len(gs.subs) > 0 {
-					registered = true
-					break
-				}
-			}
-			b.mu.RUnlock()
-			if registered {
-				close(ch)
-				return
-			}
-			time.Sleep(time.Millisecond)
-		}
-	}()
+	b.readyChans[key] = ch
 	return ch
 }
 
@@ -245,6 +243,9 @@ func (b *InMemoryEventBus) Subscribe(ctx context.Context, sub outbox.Subscriptio
 	}
 	gs.subs = append(gs.subs, s)
 	b.mu.Unlock()
+
+	// Signal readiness: close (or create+close) the per-subscription ready channel.
+	b.signalReady(consumerGroup, topic)
 
 	// Process messages in the current goroutine (Subscribe blocks per interface contract).
 	defer func() {
@@ -313,6 +314,31 @@ func (b *InMemoryEventBus) DrainDeadLetters() []DeadLetter {
 	dl := b.deadLetters
 	b.deadLetters = nil
 	return dl
+}
+
+// signalReady closes the per-subscription ready channel for the given
+// consumerGroup + topic key. Safe to call multiple times (idempotent via sync.Once
+// semantics implemented with the closed channel check).
+func (b *InMemoryEventBus) signalReady(consumerGroup, topic string) {
+	key := consumerGroup + "|" + topic
+	b.readyMu.Lock()
+	defer b.readyMu.Unlock()
+	ch, ok := b.readyChans[key]
+	if !ok {
+		// Ready was never called; create an already-closed channel so future
+		// calls to Ready(sub) return an immediately-closed channel.
+		ch = make(chan struct{})
+		b.readyChans[key] = ch
+		close(ch)
+		return
+	}
+	// Only close if still open (guard against double-close on re-subscribe).
+	select {
+	case <-ch:
+		// already closed
+	default:
+		close(ch)
+	}
 }
 
 // removeSub removes a specific subscription from the group's subscriber list.
@@ -422,9 +448,9 @@ func (b *InMemoryEventBus) handleRequeue(ctx context.Context, topic string, entr
 
 // handleInvalidDisposition treats zero-value or unknown Disposition as Requeue
 // with an Error-level log so the programming mistake is surfaced.
-func (b *InMemoryEventBus) handleInvalidDisposition(_ context.Context, topic string, entry outbox.Entry, res outbox.HandleResult, attempt int) (done bool, lastErr error) {
+func (b *InMemoryEventBus) handleInvalidDisposition(ctx context.Context, topic string, entry outbox.Entry, res outbox.HandleResult, attempt int) (done bool, lastErr error) {
 	if res.Receipt != nil {
-		releaseReceipt(context.Background(), res.Receipt, topic, entry.ID)
+		releaseReceipt(ctx, res.Receipt, topic, entry.ID)
 	}
 	delay := retryDelay(attempt)
 	slog.Error("eventbus: invalid disposition, treating as requeue",
@@ -438,9 +464,11 @@ func (b *InMemoryEventBus) handleInvalidDisposition(_ context.Context, topic str
 }
 
 // retryDelay calculates exponential backoff with jitter for the given attempt.
+// Delegates to outbox.ExponentialDelay for overflow-safe computation, capped at maxRetryDelay.
 func retryDelay(attempt int) time.Duration {
+	base := outbox.ExponentialDelay(baseRetryDelay, maxRetryDelay, attempt)
 	jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
-	return baseRetryDelay*(1<<attempt) + jitter
+	return base + jitter
 }
 
 // awaitRetry sleeps for the retry delay then returns true, or returns false

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -131,6 +131,19 @@ func (b *InMemoryEventBus) Publish(_ context.Context, topic string, payload []by
 	}
 
 	entry := unmarshalInboundEntry(topic, payload)
+
+	// Defense-in-depth: reject malformed entries at the consumer entry, before
+	// any subscriber sees them. Mirrors adapters/rabbitmq.processDelivery —
+	// production senders satisfy these invariants, but a tampered payload or
+	// adapter regression must not propagate to handlers.
+	if err := entry.Validate(); err != nil {
+		slog.Warn("eventbus: dropping invalid entry at consumer entry",
+			slog.String("topic", topic),
+			slog.String("entry_id", entry.ID),
+			slog.String("error", err.Error()))
+		return errcode.Wrap(errcode.ErrValidationFailed, "eventbus: invalid inbound entry", err)
+	}
+
 	for group, gs := range b.groupSubs[topic] {
 		if len(gs.subs) == 0 {
 			continue
@@ -399,7 +412,16 @@ func (b *InMemoryEventBus) processResult(ctx context.Context, topic string, entr
 	switch res.Disposition {
 	case outbox.DispositionAck:
 		if res.Receipt != nil {
-			commitReceipt(ctx, res.Receipt, topic, entry.ID)
+			if commitErr := commitReceipt(ctx, res.Receipt, topic, entry.ID); commitErr != nil {
+				// Mirror rabbitmq.dispatchAck: Commit failure (lease lost,
+				// token mismatch, backend error) MUST NOT be silently
+				// promoted to success. Treat as transient → retry path.
+				slog.Warn("eventbus: receipt commit failed, downgrading Ack to Requeue",
+					slog.String("topic", topic),
+					slog.String("entry_id", entry.ID),
+					slog.String("error", commitErr.Error()))
+				return false, commitErr
+			}
 		}
 		return true, nil
 	case outbox.DispositionReject:
@@ -495,8 +517,12 @@ func (b *InMemoryEventBus) appendDeadLetter(topic string, entry outbox.Entry, er
 }
 
 // commitReceipt calls Receipt.Commit with a detached 5s-timeout context,
-// consistent with the RabbitMQ subscriber path.
-func commitReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string) {
+// consistent with the RabbitMQ subscriber path. Returns the Commit error so
+// the caller can downgrade Ack to Requeue on lease-loss / token-mismatch /
+// backend failure (matches rabbitmq.dispatchAck Commit→Ack ordering — Commit
+// failure must NOT be silently swallowed, otherwise stale holders could
+// "succeed" after losing the lease).
+func commitReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string) error {
 	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	if err := r.Commit(rctx); err != nil {
@@ -504,7 +530,9 @@ func commitReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string)
 			slog.String("topic", topic),
 			slog.String("entry_id", entryID),
 			slog.String("error", err.Error()))
+		return err
 	}
+	return nil
 }
 
 // releaseReceipt calls Receipt.Release with a detached 5s-timeout context.

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -125,56 +125,105 @@ func (b *InMemoryEventBus) Publish(_ context.Context, topic string, payload []by
 	}
 
 	entry := unmarshalInboundEntry(topic, payload)
-
-	groups := b.groupSubs[topic]
-	for group, gs := range groups {
+	for group, gs := range b.groupSubs[topic] {
 		if len(gs.subs) == 0 {
 			continue
 		}
-		if group == "" {
-			// Empty group → broadcast to all subscribers (backward compatible).
-			for _, sub := range gs.subs {
-				select {
-				case sub.ch <- entry:
-				default:
-					slog.Warn("eventbus: subscriber buffer full, message dropped",
-						slog.String("topic", topic),
-					)
-				}
-			}
-		} else {
-			// Named group → round-robin to one subscriber (competing).
-			rrVal := gs.rrIdx.Add(1) - 1 // atomic increment, use previous value
-			idx := rrVal % uint64(len(gs.subs))
-			sub := gs.subs[idx]
-			select {
-			case sub.ch <- entry:
-			default:
-				slog.Warn("eventbus: subscriber buffer full, message dropped",
-					slog.String("topic", topic),
-					slog.String("consumer_group", group),
-				)
-			}
-		}
+		b.dispatchToGroup(topic, group, gs, entry)
 	}
 	return nil
 }
 
-// Subscribe registers an EntryHandler for the given topic. It blocks until ctx
-// is cancelled or the bus is closed.
+// dispatchToGroup delivers entry to the appropriate subscriber(s) in gs.
+// Empty group: broadcast to all. Named group: round-robin to one.
+func (b *InMemoryEventBus) dispatchToGroup(topic, group string, gs *groupState, entry outbox.Entry) {
+	if group == "" {
+		b.broadcast(topic, gs, entry)
+	} else {
+		b.roundRobin(topic, group, gs, entry)
+	}
+}
+
+// broadcast delivers entry to every subscriber in gs (empty-group fanout).
+func (b *InMemoryEventBus) broadcast(topic string, gs *groupState, entry outbox.Entry) {
+	for _, sub := range gs.subs {
+		select {
+		case sub.ch <- entry:
+		default:
+			slog.Warn("eventbus: subscriber buffer full, message dropped",
+				slog.String("topic", topic),
+			)
+		}
+	}
+}
+
+// roundRobin delivers entry to one subscriber in gs via atomic round-robin.
+func (b *InMemoryEventBus) roundRobin(topic, group string, gs *groupState, entry outbox.Entry) {
+	rrVal := gs.rrIdx.Add(1) - 1 // atomic increment, use previous value
+	idx := rrVal % uint64(len(gs.subs))
+	sub := gs.subs[idx]
+	select {
+	case sub.ch <- entry:
+	default:
+		slog.Warn("eventbus: subscriber buffer full, message dropped",
+			slog.String("topic", topic),
+			slog.String("consumer_group", group),
+		)
+	}
+}
+
+// Setup implements outbox.Subscriber. InMemoryEventBus requires no topology
+// pre-declaration; returns nil immediately.
+func (b *InMemoryEventBus) Setup(_ context.Context, _ outbox.Subscription) error {
+	return nil
+}
+
+// Ready implements outbox.Subscriber. Returns a channel that closes once at
+// least one goroutine has called Subscribe for sub.Topic (i.e., the subscription
+// is actually registered and ready to receive messages). This prevents the
+// publish-before-subscribe race in tests that use waitForSubscription.
+func (b *InMemoryEventBus) Ready(sub outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		for {
+			b.mu.RLock()
+			groups := b.groupSubs[sub.Topic]
+			registered := false
+			for _, gs := range groups {
+				if len(gs.subs) > 0 {
+					registered = true
+					break
+				}
+			}
+			b.mu.RUnlock()
+			if registered {
+				close(ch)
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	return ch
+}
+
+// Subscribe registers an EntryHandler for the given subscription. It blocks
+// until ctx is cancelled or the bus is closed.
 //
-// Consumer: cg-eventbus-{consumerGroup}-{topic}
+// Consumer: cg-eventbus-{sub.ConsumerGroup}-{sub.Topic}
 // Idempotency key: N/A (in-memory, no persistence)
 // ACK timing: after handler returns DispositionAck
 // Retry: transient errors -> retry 3x with exponential backoff / permanent -> dead letter
 //
-// consumerGroup selects the dispatch mode:
+// sub.ConsumerGroup selects the dispatch mode:
 //   - non-empty: messages are load-balanced among subscribers in the same group
 //   - empty: each subscriber receives every message (broadcast / fanout)
-func (b *InMemoryEventBus) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler, consumerGroup string) error {
+func (b *InMemoryEventBus) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.EntryHandler) error {
+	topic := sub.Topic
+	consumerGroup := sub.ConsumerGroup
+
 	subCtx, cancel := context.WithCancel(ctx)
 
-	sub := &subscription{
+	s := &subscription{
 		ch:     make(chan outbox.Entry, b.bufSize),
 		cancel: cancel,
 		done:   make(chan struct{}),
@@ -194,19 +243,19 @@ func (b *InMemoryEventBus) Subscribe(ctx context.Context, topic string, handler 
 		gs = &groupState{}
 		b.groupSubs[topic][consumerGroup] = gs
 	}
-	gs.subs = append(gs.subs, sub)
+	gs.subs = append(gs.subs, s)
 	b.mu.Unlock()
 
 	// Process messages in the current goroutine (Subscribe blocks per interface contract).
 	defer func() {
-		close(sub.done)
-		b.removeSub(topic, consumerGroup, sub)
+		close(s.done)
+		b.removeSub(topic, consumerGroup, s)
 	}()
 	for {
 		select {
 		case <-subCtx.Done():
 			return subCtx.Err()
-		case entry, ok := <-sub.ch:
+		case entry, ok := <-s.ch:
 			if !ok {
 				return nil
 			}
@@ -299,105 +348,120 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 	var lastErr error
 	for attempt := range maxRetries {
 		res := handler(ctx, entry)
-		switch res.Disposition {
-		case outbox.DispositionAck:
-			if res.Receipt != nil {
-				commitReceipt(ctx, res.Receipt, topic, entry.ID)
-			}
-			return // success or safe duplicate
-		case outbox.DispositionReject:
-			if res.Receipt != nil {
-				releaseReceipt(ctx, res.Receipt, topic, entry.ID)
-			}
-			// Permanent failure — route directly to dead letter.
-			slog.Warn("eventbus: handler rejected message, routing to dead letter",
-				slog.String("topic", topic),
-				slog.String("entry_id", entry.ID),
-				slog.Any("error", res.Err),
-			)
-			b.deadLettersMu.Lock()
-			b.deadLetters = append(b.deadLetters, DeadLetter{
-				Topic:   topic,
-				Entry:   entry,
-				LastErr: res.Err,
-			})
-			b.deadLettersMu.Unlock()
+		done, err := b.processResult(ctx, topic, entry, res, attempt)
+		if done {
 			return
-		case outbox.DispositionRequeue:
-			if res.Receipt != nil {
-				releaseReceipt(ctx, res.Receipt, topic, entry.ID)
-			}
-			// PermanentError in Requeue → upgrade to dead letter (no retry).
-			// Mirrors ConsumerBase behavior: PermanentError takes precedence
-			// over the Disposition, ensuring consistent routing regardless of
-			// whether the handler or WrapLegacyHandler set the Disposition.
-			var permErr *outbox.PermanentError
-			if res.Err != nil && errors.As(res.Err, &permErr) {
-				slog.Warn("eventbus: permanent error in requeue, routing to dead letter",
-					slog.String("topic", topic),
-					slog.String("entry_id", entry.ID),
-					slog.Any("error", res.Err),
-				)
-				b.deadLettersMu.Lock()
-				b.deadLetters = append(b.deadLetters, DeadLetter{
-					Topic:   topic,
-					Entry:   entry,
-					LastErr: res.Err,
-				})
-				b.deadLettersMu.Unlock()
-				return
-			}
-			lastErr = res.Err
-			jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
-			delay := baseRetryDelay*(1<<attempt) + jitter // e.g. 100-200ms, 200-300ms, 400-500ms
-			slog.Warn("eventbus: handler requested requeue, retrying",
-				slog.String("topic", topic),
-				slog.Int("attempt", attempt+1),
-				slog.Any("error", res.Err),
-				slog.Duration("retry_delay", delay),
-			)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(delay):
-				continue
-			}
-		default:
-			// Zero-value or unknown Disposition — treat as requeue (safe degradation)
-			// and log at Error level so the programming mistake is surfaced.
-			if res.Receipt != nil {
-				releaseReceipt(ctx, res.Receipt, topic, entry.ID)
-			}
-			lastErr = res.Err
-			jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
-			delay := baseRetryDelay*(1<<attempt) + jitter
-			slog.Error("eventbus: invalid disposition, treating as requeue",
-				slog.String("topic", topic),
-				slog.String("entry_id", entry.ID),
-				slog.String("disposition", res.Disposition.String()),
-				slog.Int("attempt", attempt+1),
-				slog.Duration("retry_delay", delay),
-			)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(delay):
-				continue
-			}
+		}
+		lastErr = err
+		// Wait for retry delay or ctx cancellation.
+		if !awaitRetry(ctx, res.Disposition, attempt) {
+			return
 		}
 	}
-
-	// Exhausted retries → dead letter.
+	b.appendDeadLetter(topic, entry, lastErr)
 	slog.Error("eventbus: retries exhausted, routing to dead letter",
 		slog.String("topic", topic),
 		slog.String("entry_id", entry.ID),
 		slog.Any("error", lastErr),
 	)
+}
+
+// processResult handles a single handler result. Returns (done=true) when
+// no further retry is needed (Ack, Reject, or permanent error in Requeue).
+// Returns the error to propagate as lastErr when done=false.
+func (b *InMemoryEventBus) processResult(ctx context.Context, topic string, entry outbox.Entry, res outbox.HandleResult, attempt int) (done bool, lastErr error) {
+	switch res.Disposition {
+	case outbox.DispositionAck:
+		if res.Receipt != nil {
+			commitReceipt(ctx, res.Receipt, topic, entry.ID)
+		}
+		return true, nil
+	case outbox.DispositionReject:
+		if res.Receipt != nil {
+			releaseReceipt(ctx, res.Receipt, topic, entry.ID)
+		}
+		slog.Warn("eventbus: handler rejected message, routing to dead letter",
+			slog.String("topic", topic),
+			slog.String("entry_id", entry.ID),
+			slog.Any("error", res.Err),
+		)
+		b.appendDeadLetter(topic, entry, res.Err)
+		return true, nil
+	case outbox.DispositionRequeue:
+		return b.handleRequeue(ctx, topic, entry, res, attempt)
+	default:
+		return b.handleInvalidDisposition(ctx, topic, entry, res, attempt)
+	}
+}
+
+// handleRequeue processes DispositionRequeue: upgrades to dead letter on
+// PermanentError, otherwise schedules retry with backoff.
+func (b *InMemoryEventBus) handleRequeue(ctx context.Context, topic string, entry outbox.Entry, res outbox.HandleResult, attempt int) (done bool, lastErr error) {
+	if res.Receipt != nil {
+		releaseReceipt(ctx, res.Receipt, topic, entry.ID)
+	}
+	var permErr *outbox.PermanentError
+	if res.Err != nil && errors.As(res.Err, &permErr) {
+		slog.Warn("eventbus: permanent error in requeue, routing to dead letter",
+			slog.String("topic", topic),
+			slog.String("entry_id", entry.ID),
+			slog.Any("error", res.Err),
+		)
+		b.appendDeadLetter(topic, entry, res.Err)
+		return true, nil
+	}
+	delay := retryDelay(attempt)
+	slog.Warn("eventbus: handler requested requeue, retrying",
+		slog.String("topic", topic),
+		slog.Int("attempt", attempt+1),
+		slog.Any("error", res.Err),
+		slog.Duration("retry_delay", delay),
+	)
+	return false, res.Err
+}
+
+// handleInvalidDisposition treats zero-value or unknown Disposition as Requeue
+// with an Error-level log so the programming mistake is surfaced.
+func (b *InMemoryEventBus) handleInvalidDisposition(_ context.Context, topic string, entry outbox.Entry, res outbox.HandleResult, attempt int) (done bool, lastErr error) {
+	if res.Receipt != nil {
+		releaseReceipt(context.Background(), res.Receipt, topic, entry.ID)
+	}
+	delay := retryDelay(attempt)
+	slog.Error("eventbus: invalid disposition, treating as requeue",
+		slog.String("topic", topic),
+		slog.String("entry_id", entry.ID),
+		slog.String("disposition", res.Disposition.String()),
+		slog.Int("attempt", attempt+1),
+		slog.Duration("retry_delay", delay),
+	)
+	return false, res.Err
+}
+
+// retryDelay calculates exponential backoff with jitter for the given attempt.
+func retryDelay(attempt int) time.Duration {
+	jitter := time.Duration(rand.Int64N(int64(baseRetryDelay)))
+	return baseRetryDelay*(1<<attempt) + jitter
+}
+
+// awaitRetry sleeps for the retry delay then returns true, or returns false
+// if ctx is cancelled. For invalid disposition, uses the same delay logic.
+func awaitRetry(ctx context.Context, _ outbox.Disposition, attempt int) bool {
+	delay := retryDelay(attempt)
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(delay):
+		return true
+	}
+}
+
+// appendDeadLetter records an entry in the dead letter queue.
+func (b *InMemoryEventBus) appendDeadLetter(topic string, entry outbox.Entry, err error) {
 	b.deadLettersMu.Lock()
 	b.deadLetters = append(b.deadLetters, DeadLetter{
 		Topic:   topic,
 		Entry:   entry,
-		LastErr: lastErr,
+		LastErr: err,
 	})
 	b.deadLettersMu.Unlock()
 }

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -32,13 +32,13 @@ func TestPublish_EnvelopePayload_UnwrappedBeforeDelivery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "test.envelope.topic",
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "test.envelope.topic"},
 			func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 				mu.Lock()
 				got = e
 				mu.Unlock()
 				return outbox.HandleResult{Disposition: outbox.DispositionAck}
-			}, "")
+			})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -93,13 +93,13 @@ func TestPublish_NonEnvelopePayload_ForwardedUnchanged(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "test.direct.topic",
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "test.direct.topic"},
 			func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 				mu.Lock()
 				got = e
 				mu.Unlock()
 				return outbox.HandleResult{Disposition: outbox.DispositionAck}
-			}, "")
+			})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -134,12 +134,12 @@ func TestPublishSubscribe(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "test.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "test.topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			mu.Lock()
 			received = append(received, e)
 			mu.Unlock()
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	// Give subscriber time to register.
@@ -186,10 +186,10 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "retry.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "retry.topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			attempts.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: testErr}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -229,10 +229,10 @@ func TestSubscribe_RejectGoesDirectlyToDeadLetter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "reject.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "reject.topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			attempts.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionReject, Err: testErr}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -264,7 +264,7 @@ func TestSubscribe_PermanentErrorInRequeue_RoutesToDeadLetter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "perm.requeue", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "perm.requeue"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			attempts.Add(1)
 			// Return Requeue with PermanentError — eventbus should detect
 			// the PermanentError and route directly to dead letter.
@@ -272,7 +272,7 @@ func TestSubscribe_PermanentErrorInRequeue_RoutesToDeadLetter(t *testing.T) {
 				Disposition: outbox.DispositionRequeue,
 				Err:         outbox.NewPermanentError(errors.New("unmarshal failed")),
 			}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -319,9 +319,9 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "race.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "race.topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	require.Eventually(t, func() bool {
@@ -378,9 +378,9 @@ func TestSubscribe_ClosedBus(t *testing.T) {
 	bus := New()
 	_ = bus.Close()
 
-	err := bus.Subscribe(context.Background(), "topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+	err := bus.Subscribe(context.Background(), outbox.Subscription{Topic: "topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
-	}, "")
+	})
 	assert.Error(t, err)
 }
 
@@ -396,17 +396,17 @@ func TestMultipleSubscribers(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "multi.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "multi.topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			count1.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "multi.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "multi.topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			count2.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -431,13 +431,13 @@ func TestSubscribe_SuccessAfterRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "partial.fail", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "partial.fail"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			n := attempts.Add(1)
 			if n < 3 {
 				return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("not yet")}
 			}
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -476,9 +476,9 @@ func TestSubscribe_CleansUpOnExit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "cleanup.topic", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "cleanup.topic"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	// Wait for subscriber to register.
@@ -537,12 +537,12 @@ func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "receipt.ack", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.ack"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{
 				Disposition: outbox.DispositionAck,
 				Receipt:     receipt,
 			}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -569,13 +569,13 @@ func TestSubscribe_ReceiptReleasedOnReject(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "receipt.reject", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.reject"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{
 				Disposition: outbox.DispositionReject,
 				Err:         errors.New("permanent"),
 				Receipt:     receipt,
 			}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -603,7 +603,7 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "receipt.requeue", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.requeue"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			r := &mockReceipt{}
 			receiptsMu.Lock()
 			receipts = append(receipts, r)
@@ -613,7 +613,7 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 				Err:         errors.New("transient"),
 				Receipt:     r,
 			}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -654,7 +654,7 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "receipt.exhaust", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.exhaust"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			r := &mockReceipt{}
 			receiptsMu.Lock()
 			receipts = append(receipts, r)
@@ -664,7 +664,7 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 				Err:         testErr,
 				Receipt:     r,
 			}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -708,7 +708,7 @@ func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "zero.disp", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "zero.disp"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			attempts.Add(1)
 			r := &mockReceipt{}
 			receiptsMu.Lock()
@@ -719,7 +719,7 @@ func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
 				Err:     errors.New("forgot disposition"),
 				Receipt: r,
 			}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -771,13 +771,13 @@ func TestSubscribe_UnknownDisposition_TreatedAsRequeue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "unknown.disp", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "unknown.disp"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			attempts.Add(1)
 			return outbox.HandleResult{
 				Disposition: outbox.Disposition(99), // not a valid Disposition
 				Err:         testErr,
 			}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -814,7 +814,7 @@ func TestSubscribe_InvalidDisposition_RespectsCtxCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, "cancel.disp", func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "cancel.disp"}, func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			n := attempts.Add(1)
 			if n == 1 {
 				// After first attempt with invalid disposition, cancel ctx
@@ -825,7 +825,7 @@ func TestSubscribe_InvalidDisposition_RespectsCtxCancel(t *testing.T) {
 				}()
 			}
 			return outbox.HandleResult{} // zero-value
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -869,17 +869,17 @@ func TestConsumerGroup_SameGroup_CompetingConsumption(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "session.created", ConsumerGroup: "audit-core"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub1Count.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "audit-core")
+		})
 	}()
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "session.created", ConsumerGroup: "audit-core"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub2Count.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "audit-core")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond) // let subscriptions register
@@ -925,17 +925,17 @@ func TestConsumerGroup_DifferentGroups_Fanout(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "session.created", ConsumerGroup: "audit-core"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			auditCount.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "audit-core")
+		})
 	}()
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "session.created", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "session.created", ConsumerGroup: "config-core"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			configCount.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "config-core")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -976,17 +976,17 @@ func TestConsumerGroup_EmptyGroup_BackwardCompatible(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "events.v1", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "events.v1"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub1Count.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 	go func() {
 		defer wg.Done()
-		_ = bus.Subscribe(ctx, "events.v1", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "events.v1"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			sub2Count.Add(1)
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "")
+		})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -1029,10 +1029,10 @@ func TestConsumerGroup_ConcurrentPublish_NoRace(t *testing.T) {
 	for range numSubs {
 		go func() {
 			defer wg.Done()
-			_ = bus.Subscribe(ctx, "race.topic", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+			_ = bus.Subscribe(ctx, outbox.Subscription{Topic: "race.topic", ConsumerGroup: "race-group"}, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 				totalReceived.Add(1)
 				return outbox.HandleResult{Disposition: outbox.DispositionAck}
-			}, "race-group")
+			})
 		}()
 	}
 

--- a/runtime/eventrouter/router.go
+++ b/runtime/eventrouter/router.go
@@ -164,9 +164,15 @@ func (r *Router) Run(ctx context.Context) error {
 					setupErr <- fmt.Errorf("eventrouter: topic %s panicked: %v", h.topic, rv)
 				}
 			}()
+			sub := outbox.Subscription{
+				Topic:         h.topic,
+				ConsumerGroup: h.consumerGroup,
+				CellID:        h.consumerGroup,
+			}
 			slog.Info("eventrouter: starting subscription",
-				slog.String("topic", h.topic))
-			err := r.subscriber.Subscribe(runCtx, h.topic, h.handler, h.consumerGroup)
+				slog.String("topic", h.topic),
+				slog.String("consumer_group", h.consumerGroup))
+			err := r.subscriber.Subscribe(runCtx, sub, h.handler)
 			if err != nil && runCtx.Err() == nil {
 				setupErr <- fmt.Errorf("eventrouter: topic %s: %w", h.topic, err)
 			}

--- a/runtime/eventrouter/router.go
+++ b/runtime/eventrouter/router.go
@@ -5,8 +5,15 @@
 // ref: ThreeDotsLabs/watermill message/router.go — AddHandler/Run/Close pattern.
 // Adopted: declaration-then-run split, Running() readiness signal, WaitGroup goroutine tracking.
 // Deviated: no publish-side in AddHandler (GoCell publishes via outbox.Writer, not Router);
-// startup detection uses a configurable timeout because outbox.Subscriber.Subscribe blocks
-// without a separate setup/run split.
+// startup readiness uses an explicit Ready signal from the Subscriber interface rather
+// than a timeout heuristic — aligned with Uber fx OnStart synchronous return semantics.
+//
+// Run lifecycle (4 phases):
+//
+//	Phase 1: serially call Subscriber.Setup(sub) for each handler — blocking topology declaration.
+//	Phase 2: launch one Subscribe goroutine per handler concurrently.
+//	Phase 3: wait on Subscriber.Ready(sub) for every handler (explicit signal, no timeout).
+//	Phase 4: block until ctx cancel or a runtime subscription error.
 package eventrouter
 
 import (
@@ -20,28 +27,8 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
-// DefaultStartupTimeout is the duration Run waits for Subscribe calls to
-// either return an error (setup failure) or remain blocking (consuming).
-// If no error arrives within this window, all subscriptions are assumed ready.
-//
-// Note: this is a heuristic. If broker topology setup (e.g., RabbitMQ
-// ExchangeDeclare + QueueBind) takes longer than this timeout, bootstrap
-// will proceed before subscriptions are actually ready. The timeout is
-// configurable via WithStartupTimeout. A future Subscriber interface split
-// (Setup + Run) would eliminate this heuristic entirely.
-const DefaultStartupTimeout = 500 * time.Millisecond
-
-// Option configures a Router.
+// Option configures a Router. The Option type is retained for future extensibility.
 type Option func(*Router)
-
-// WithStartupTimeout overrides the default startup detection timeout.
-func WithStartupTimeout(d time.Duration) Option {
-	return func(r *Router) {
-		if d > 0 {
-			r.startupTimeout = d
-		}
-	}
-}
 
 type handlerConfig struct {
 	topic         string
@@ -55,19 +42,18 @@ type handlerConfig struct {
 //
 // Run MUST be called at most once. Calling Run a second time returns an error.
 type Router struct {
-	subscriber     outbox.Subscriber
-	handlers       []handlerConfig
-	mu             sync.Mutex
-	startupTimeout time.Duration
-	running        chan struct{}
-	runGuard       sync.Once // ensures Run is called at most once
-	runningOnce    sync.Once // ensures close(r.running) is called at most once
-	cancel         context.CancelFunc
-	wg             sync.WaitGroup
-	statusMu       sync.RWMutex
-	started        bool
-	shutdown       bool
-	healthErr      error
+	subscriber  outbox.Subscriber
+	handlers    []handlerConfig
+	mu          sync.Mutex
+	running     chan struct{}
+	runGuard    sync.Once // ensures Run is called at most once
+	runningOnce sync.Once // ensures close(r.running) is called at most once
+	cancel      context.CancelFunc
+	wg          sync.WaitGroup
+	statusMu    sync.RWMutex
+	started     bool
+	shutdown    bool
+	healthErr   error
 }
 
 // Compile-time interface check.
@@ -76,9 +62,8 @@ var _ cell.EventRouter = (*Router)(nil)
 // New creates a Router that will use the given Subscriber for all subscriptions.
 func New(sub outbox.Subscriber, opts ...Option) *Router {
 	r := &Router{
-		subscriber:     sub,
-		startupTimeout: DefaultStartupTimeout,
-		running:        make(chan struct{}),
+		subscriber: sub,
+		running:    make(chan struct{}),
 	}
 	for _, o := range opts {
 		o(r)
@@ -118,13 +103,16 @@ var errAlreadyRunning = fmt.Errorf("eventrouter: Run called more than once")
 //
 // Run MUST be called at most once; a second call returns errAlreadyRunning.
 //
-// Setup-error detection: each Subscribe call is launched in a goroutine.
-// If any returns an error within the startup timeout, Run cancels all
-// goroutines and returns the error. If no error arrives within the timeout,
-// all subscriptions are assumed to be consuming and Running() is closed.
+// Lifecycle (4 phases):
 //
-// On context cancellation, Run waits for all goroutines to finish before
-// returning.
+//	Phase 1: serially call Subscriber.Setup(sub) — blocking topology declaration.
+//	         Any Setup error causes Run to return immediately without starting subscriptions.
+//	Phase 2: launch one Subscribe goroutine per handler concurrently.
+//	Phase 3: wait on Subscriber.Ready(sub) for every handler.
+//	         Running() is closed only after ALL Ready channels close.
+//	Phase 4: block until ctx cancel or a runtime subscription error.
+//
+// On context cancellation, Run waits for all goroutines to finish before returning.
 func (r *Router) Run(ctx context.Context) error {
 	var firstRun bool
 	r.runGuard.Do(func() { firstRun = true })
@@ -147,60 +135,33 @@ func (r *Router) Run(ctx context.Context) error {
 		r.markRunning()
 		r.closeRunning()
 		<-runCtx.Done()
+		cancel()
 		return nil
 	}
 
-	// setupErr receives the first subscription setup error.
+	// Phase 1: serially Setup each subscription (topology declaration).
+	if err := r.runSetup(runCtx, cancel, handlers); err != nil {
+		return err
+	}
+
+	// setupErr receives the first subscription runtime error.
 	// Buffer size = len(handlers) to avoid goroutine leaks if multiple fail.
 	setupErr := make(chan error, len(handlers))
 
-	for _, h := range handlers {
-		h := h
-		r.wg.Add(1)
-		go func() {
-			defer r.wg.Done()
-			defer func() {
-				if rv := recover(); rv != nil {
-					setupErr <- fmt.Errorf("eventrouter: topic %s panicked: %v", h.topic, rv)
-				}
-			}()
-			sub := outbox.Subscription{
-				Topic:         h.topic,
-				ConsumerGroup: h.consumerGroup,
-				CellID:        h.consumerGroup,
-			}
-			slog.Info("eventrouter: starting subscription",
-				slog.String("topic", h.topic),
-				slog.String("consumer_group", h.consumerGroup))
-			err := r.subscriber.Subscribe(runCtx, sub, h.handler)
-			if err != nil && runCtx.Err() == nil {
-				setupErr <- fmt.Errorf("eventrouter: topic %s: %w", h.topic, err)
-			}
-		}()
-	}
+	// Phase 2: launch Subscribe goroutines concurrently.
+	r.runSubscribe(runCtx, handlers, setupErr)
 
-	// Wait for setup phase: either an error arrives or startup timeout passes.
-	select {
-	case err := <-setupErr:
-		r.markHealthError(err)
-		slog.Error("eventrouter: subscription setup failed, shutting down",
-			slog.Any("error", err))
-		cancel()
-		r.wg.Wait()
+	// Phase 3: wait for all Ready signals before marking Running.
+	if err := r.runAwaitReady(runCtx, cancel, handlers, setupErr); err != nil {
 		return err
-	case <-time.After(r.startupTimeout):
-		// No errors within timeout — all handlers are consuming.
-		r.markRunning()
-		slog.Info("eventrouter: all subscriptions started",
-			slog.Int("count", len(handlers)))
-		r.closeRunning()
-	case <-runCtx.Done():
-		// Context cancelled during startup.
-		r.wg.Wait()
-		return runCtx.Err()
 	}
 
-	// Block until context cancelled or a runtime error surfaces.
+	r.markRunning()
+	slog.Info("eventrouter: all subscriptions ready (explicit Ready signal)",
+		slog.Int("count", len(handlers)))
+	r.closeRunning()
+
+	// Phase 4: block until context cancelled or a runtime error surfaces.
 	select {
 	case <-runCtx.Done():
 		r.markShutdown()
@@ -214,6 +175,86 @@ func (r *Router) Run(ctx context.Context) error {
 	}
 
 	r.wg.Wait()
+	return nil
+}
+
+// runSetup calls Subscriber.Setup for each handler sequentially (Phase 1).
+// On error, it cancels the context and returns the wrapped error.
+func (r *Router) runSetup(ctx context.Context, cancel context.CancelFunc, handlers []handlerConfig) error {
+	for _, h := range handlers {
+		sub := outbox.Subscription{
+			Topic:         h.topic,
+			ConsumerGroup: h.consumerGroup,
+			CellID:        h.consumerGroup,
+		}
+		if err := r.subscriber.Setup(ctx, sub); err != nil {
+			wrapped := fmt.Errorf("eventrouter: setup %s: %w", sub.Topic, err)
+			r.markHealthError(wrapped)
+			slog.Error("eventrouter: subscription setup failed, aborting",
+				slog.String("topic", sub.Topic),
+				slog.Any("error", err))
+			cancel()
+			return wrapped
+		}
+	}
+	return nil
+}
+
+// runSubscribe starts one goroutine per handler that calls Subscriber.Subscribe
+// (Phase 2). Errors are sent to setupErr.
+func (r *Router) runSubscribe(ctx context.Context, handlers []handlerConfig, setupErr chan<- error) {
+	for _, h := range handlers {
+		h := h
+		sub := outbox.Subscription{
+			Topic:         h.topic,
+			ConsumerGroup: h.consumerGroup,
+			CellID:        h.consumerGroup,
+		}
+		r.wg.Add(1)
+		go func() {
+			defer r.wg.Done()
+			defer func() {
+				if rv := recover(); rv != nil {
+					setupErr <- fmt.Errorf("eventrouter: topic %s panicked: %v", sub.Topic, rv)
+				}
+			}()
+			slog.Info("eventrouter: starting subscription",
+				slog.String("topic", sub.Topic),
+				slog.String("consumer_group", sub.ConsumerGroup))
+			err := r.subscriber.Subscribe(ctx, sub, h.handler)
+			if err != nil && ctx.Err() == nil {
+				setupErr <- fmt.Errorf("eventrouter: topic %s: %w", sub.Topic, err)
+			}
+		}()
+	}
+}
+
+// runAwaitReady waits for Subscriber.Ready(sub) for each handler sequentially
+// (Phase 3). It also monitors setupErr and ctx cancellation.
+// On error, it cancels the context, waits for goroutines, and returns the error.
+func (r *Router) runAwaitReady(ctx context.Context, cancel context.CancelFunc, handlers []handlerConfig, setupErr <-chan error) error {
+	for _, h := range handlers {
+		sub := outbox.Subscription{
+			Topic:         h.topic,
+			ConsumerGroup: h.consumerGroup,
+			CellID:        h.consumerGroup,
+		}
+		readyCh := r.subscriber.Ready(sub)
+		select {
+		case <-readyCh:
+			// subscription is ready
+		case err := <-setupErr:
+			r.markHealthError(err)
+			slog.Error("eventrouter: subscription error during ready wait, shutting down",
+				slog.Any("error", err))
+			cancel()
+			r.wg.Wait()
+			return err
+		case <-ctx.Done():
+			r.wg.Wait()
+			return ctx.Err()
+		}
+	}
 	return nil
 }
 

--- a/runtime/eventrouter/router.go
+++ b/runtime/eventrouter/router.go
@@ -229,33 +229,65 @@ func (r *Router) runSubscribe(ctx context.Context, handlers []handlerConfig, set
 	}
 }
 
-// runAwaitReady waits for Subscriber.Ready(sub) for each handler sequentially
-// (Phase 3). It also monitors setupErr and ctx cancellation.
-// On error, it cancels the context, waits for goroutines, and returns the error.
+// runAwaitReady waits for Subscriber.Ready(sub) for ALL handlers concurrently
+// (Phase 3). Concurrent fan-out avoids goroutine-schedule coupling where a
+// serial wait on handler[0] would block if handler[1]'s goroutine happened to
+// register first with the in-memory bus.
+//
+// It also monitors setupErr and ctx cancellation. On error, it cancels the
+// context, waits for goroutines, and returns the error.
 func (r *Router) runAwaitReady(ctx context.Context, cancel context.CancelFunc, handlers []handlerConfig, setupErr <-chan error) error {
+	allReady := r.awaitAllReady(ctx, handlers)
+
+	select {
+	case <-allReady:
+		// All subscriptions are ready.
+		return nil
+	case err := <-setupErr:
+		r.markHealthError(err)
+		slog.Error("eventrouter: subscription error during ready wait, shutting down",
+			slog.Any("error", err))
+		cancel()
+		r.wg.Wait()
+		// Drain setupErr to prevent goroutine leak in runSubscribe goroutines
+		// that may still be trying to send after ctx cancellation.
+		go func() {
+			for range setupErr { //nolint:revive
+			}
+		}()
+		return err
+	case <-ctx.Done():
+		r.wg.Wait()
+		return ctx.Err()
+	}
+}
+
+// awaitAllReady launches one goroutine per handler that waits on Ready, then
+// returns a channel that closes when all goroutines complete (or ctx cancels).
+func (r *Router) awaitAllReady(ctx context.Context, handlers []handlerConfig) <-chan struct{} {
+	doneCh := make(chan struct{})
+	var wg sync.WaitGroup
 	for _, h := range handlers {
+		h := h
 		sub := outbox.Subscription{
 			Topic:         h.topic,
 			ConsumerGroup: h.consumerGroup,
 			CellID:        h.consumerGroup,
 		}
-		readyCh := r.subscriber.Ready(sub)
-		select {
-		case <-readyCh:
-			// subscription is ready
-		case err := <-setupErr:
-			r.markHealthError(err)
-			slog.Error("eventrouter: subscription error during ready wait, shutting down",
-				slog.Any("error", err))
-			cancel()
-			r.wg.Wait()
-			return err
-		case <-ctx.Done():
-			r.wg.Wait()
-			return ctx.Err()
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-r.subscriber.Ready(sub):
+			case <-ctx.Done():
+			}
+		}()
 	}
-	return nil
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+	return doneCh
 }
 
 // closeRunning safely closes the running channel exactly once.

--- a/runtime/eventrouter/router.go
+++ b/runtime/eventrouter/router.go
@@ -27,8 +27,20 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
-// Option configures a Router. The Option type is retained for future extensibility.
+// DefaultReadyTimeout bounds Phase 3 of Run() so a subscriber that never
+// signals Ready (broker reconnect storm, mis-configured topology) does not
+// block bootstrap indefinitely. 30s aligns with Uber fx StartTimeout default.
+// Set to a non-positive value via WithReadyTimeout to disable the bound.
+const DefaultReadyTimeout = 30 * time.Second
+
+// Option configures a Router.
 type Option func(*Router)
+
+// WithReadyTimeout overrides the default ready-wait budget. A value <= 0
+// disables the timeout (waits indefinitely on Ready channels and ctx).
+func WithReadyTimeout(d time.Duration) Option {
+	return func(r *Router) { r.readyTimeout = d }
+}
 
 type handlerConfig struct {
 	topic         string
@@ -42,18 +54,19 @@ type handlerConfig struct {
 //
 // Run MUST be called at most once. Calling Run a second time returns an error.
 type Router struct {
-	subscriber  outbox.Subscriber
-	handlers    []handlerConfig
-	mu          sync.Mutex
-	running     chan struct{}
-	runGuard    sync.Once // ensures Run is called at most once
-	runningOnce sync.Once // ensures close(r.running) is called at most once
-	cancel      context.CancelFunc
-	wg          sync.WaitGroup
-	statusMu    sync.RWMutex
-	started     bool
-	shutdown    bool
-	healthErr   error
+	subscriber   outbox.Subscriber
+	handlers     []handlerConfig
+	mu           sync.Mutex
+	readyTimeout time.Duration
+	running      chan struct{}
+	runGuard     sync.Once // ensures Run is called at most once
+	runningOnce  sync.Once // ensures close(r.running) is called at most once
+	cancel       context.CancelFunc
+	wg           sync.WaitGroup
+	statusMu     sync.RWMutex
+	started      bool
+	shutdown     bool
+	healthErr    error
 }
 
 // Compile-time interface check.
@@ -62,8 +75,9 @@ var _ cell.EventRouter = (*Router)(nil)
 // New creates a Router that will use the given Subscriber for all subscriptions.
 func New(sub outbox.Subscriber, opts ...Option) *Router {
 	r := &Router{
-		subscriber: sub,
-		running:    make(chan struct{}),
+		subscriber:   sub,
+		readyTimeout: DefaultReadyTimeout,
+		running:      make(chan struct{}),
 	}
 	for _, o := range opts {
 		o(r)
@@ -239,6 +253,13 @@ func (r *Router) runSubscribe(ctx context.Context, handlers []handlerConfig, set
 func (r *Router) runAwaitReady(ctx context.Context, cancel context.CancelFunc, handlers []handlerConfig, setupErr <-chan error) error {
 	allReady := r.awaitAllReady(ctx, handlers)
 
+	var deadlineCh <-chan time.Time
+	if r.readyTimeout > 0 {
+		timer := time.NewTimer(r.readyTimeout)
+		defer timer.Stop()
+		deadlineCh = timer.C
+	}
+
 	select {
 	case <-allReady:
 		// All subscriptions are ready.
@@ -249,17 +270,48 @@ func (r *Router) runAwaitReady(ctx context.Context, cancel context.CancelFunc, h
 			slog.Any("error", err))
 		cancel()
 		r.wg.Wait()
-		// Drain setupErr to prevent goroutine leak in runSubscribe goroutines
-		// that may still be trying to send after ctx cancellation.
-		go func() {
-			for range setupErr { //nolint:revive
-			}
-		}()
+		// No drain needed: setupErr buffer == len(handlers) guarantees every
+		// runSubscribe goroutine can send once without blocking. ctx cancel
+		// stops further sends; remaining buffered errors are GC'd with the
+		// channel when Run returns.
+		return err
+	case <-deadlineCh:
+		notReady := r.diagnoseNotReady(handlers)
+		err := fmt.Errorf("eventrouter: %d/%d subscriptions not ready after %s: %v",
+			len(notReady), len(handlers), r.readyTimeout, notReady)
+		r.markHealthError(err)
+		slog.Error("eventrouter: ready timeout exceeded, shutting down",
+			slog.Duration("timeout", r.readyTimeout),
+			slog.Int("not_ready_count", len(notReady)),
+			slog.Any("not_ready", notReady))
+		cancel()
+		r.wg.Wait()
 		return err
 	case <-ctx.Done():
 		r.wg.Wait()
 		return ctx.Err()
 	}
+}
+
+// diagnoseNotReady returns "consumerGroup/topic" identifiers for subscriptions
+// whose Ready channel has not closed. Used by ready-timeout error reporting
+// so operators can see which subscription is stuck without trawling logs.
+func (r *Router) diagnoseNotReady(handlers []handlerConfig) []string {
+	var notReady []string
+	for _, h := range handlers {
+		sub := outbox.Subscription{
+			Topic:         h.topic,
+			ConsumerGroup: h.consumerGroup,
+			CellID:        h.consumerGroup,
+		}
+		select {
+		case <-r.subscriber.Ready(sub):
+			// ready
+		default:
+			notReady = append(notReady, fmt.Sprintf("%s/%s", h.consumerGroup, h.topic))
+		}
+	}
+	return notReady
 }
 
 // awaitAllReady launches one goroutine per handler that waits on Ready, then

--- a/runtime/eventrouter/router_test.go
+++ b/runtime/eventrouter/router_test.go
@@ -26,14 +26,19 @@ type blockingSubscriber struct {
 	topics []string
 }
 
-func (s *blockingSubscriber) Subscribe(ctx context.Context, topic string, _ outbox.EntryHandler, _ string) error {
+func (s *blockingSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *blockingSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *blockingSubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, _ outbox.EntryHandler) error {
 	s.mu.Lock()
-	s.topics = append(s.topics, topic)
+	s.topics = append(s.topics, sub.Topic)
 	s.mu.Unlock()
 	<-ctx.Done()
 	return ctx.Err()
 }
-
 func (s *blockingSubscriber) Close() error { return nil }
 
 func (s *blockingSubscriber) Topics() []string {
@@ -49,10 +54,15 @@ type failingSubscriber struct {
 	err error
 }
 
-func (s *failingSubscriber) Subscribe(_ context.Context, _ string, _ outbox.EntryHandler, _ string) error {
+func (s *failingSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *failingSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *failingSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.EntryHandler) error {
 	return s.err
 }
-
 func (s *failingSubscriber) Close() error { return nil }
 
 // delayedFailSubscriber blocks briefly then returns an error (simulates
@@ -62,7 +72,13 @@ type delayedFailSubscriber struct {
 	err   error
 }
 
-func (s *delayedFailSubscriber) Subscribe(ctx context.Context, _ string, _ outbox.EntryHandler, _ string) error {
+func (s *delayedFailSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *delayedFailSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *delayedFailSubscriber) Subscribe(ctx context.Context, _ outbox.Subscription, _ outbox.EntryHandler) error {
 	select {
 	case <-time.After(s.delay):
 		return s.err
@@ -70,7 +86,6 @@ func (s *delayedFailSubscriber) Subscribe(ctx context.Context, _ string, _ outbo
 		return ctx.Err()
 	}
 }
-
 func (s *delayedFailSubscriber) Close() error { return nil }
 
 // --- Tests ---
@@ -459,8 +474,14 @@ type stuckSubscriber struct {
 	block chan struct{}
 }
 
-func (s *stuckSubscriber) Subscribe(_ context.Context, _ string, _ outbox.EntryHandler, _ string) error {
-	<-s.block // ignores ctx — simulates unresponsive subscriber
+func (s *stuckSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *stuckSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *stuckSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.EntryHandler) error {
+	<-s.block // ignores ctx -- simulates unresponsive subscriber
 	return nil
 }
 func (s *stuckSubscriber) Close() error { return nil }
@@ -468,7 +489,13 @@ func (s *stuckSubscriber) Close() error { return nil }
 // panickingSubscriber panics on Subscribe.
 type panickingSubscriber struct{}
 
-func (s *panickingSubscriber) Subscribe(_ context.Context, _ string, _ outbox.EntryHandler, _ string) error {
+func (s *panickingSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *panickingSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *panickingSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.EntryHandler) error {
 	panic("boom")
 }
 func (s *panickingSubscriber) Close() error { return nil }
@@ -489,7 +516,7 @@ func (m *mockCell) RegisterSubscriptions(r cell.EventRouter) error {
 	return nil
 }
 
-// newTestEventBus creates an InMemoryEventBus for testing, registered for cleanup.
+// newTestEventBus creates an in-memory pub/sub for Router tests, registered for cleanup.
 func newTestEventBus(t *testing.T) *testBus {
 	t.Helper()
 	b := &testBus{
@@ -531,7 +558,15 @@ func (b *testBus) Publish(_ context.Context, topic string, payload []byte) error
 	return nil
 }
 
-func (b *testBus) Subscribe(ctx context.Context, topic string, handler outbox.EntryHandler, _ string) error {
+func (b *testBus) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+
+func (b *testBus) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func (b *testBus) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.EntryHandler) error {
 	subCtx, cancel := context.WithCancel(ctx)
 	s := &testSub{ch: make(chan outbox.Entry, b.bufSize), cancel: cancel}
 
@@ -541,7 +576,7 @@ func (b *testBus) Subscribe(ctx context.Context, topic string, handler outbox.En
 		cancel()
 		return errcode.New(errcode.ErrBusClosed, "closed")
 	}
-	b.subs[topic] = append(b.subs[topic], s)
+	b.subs[sub.Topic] = append(b.subs[sub.Topic], s)
 	b.mu.Unlock()
 
 	for {
@@ -575,8 +610,8 @@ func (b *testBus) Close() error {
 
 // recordingGroupSubscriber records which consumerGroup was passed to Subscribe.
 type recordingGroupSubscriber struct {
-	mu     sync.Mutex
-	calls  []groupSubscribeCall
+	mu    sync.Mutex
+	calls []groupSubscribeCall
 }
 
 type groupSubscribeCall struct {
@@ -584,14 +619,19 @@ type groupSubscribeCall struct {
 	ConsumerGroup string
 }
 
-func (s *recordingGroupSubscriber) Subscribe(ctx context.Context, topic string, _ outbox.EntryHandler, consumerGroup string) error {
+func (s *recordingGroupSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+func (s *recordingGroupSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *recordingGroupSubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, _ outbox.EntryHandler) error {
 	s.mu.Lock()
-	s.calls = append(s.calls, groupSubscribeCall{Topic: topic, ConsumerGroup: consumerGroup})
+	s.calls = append(s.calls, groupSubscribeCall{Topic: sub.Topic, ConsumerGroup: sub.ConsumerGroup})
 	s.mu.Unlock()
 	<-ctx.Done()
 	return ctx.Err()
 }
-
 func (s *recordingGroupSubscriber) Close() error { return nil }
 
 func (s *recordingGroupSubscriber) Calls() []groupSubscribeCall {
@@ -603,7 +643,7 @@ func (s *recordingGroupSubscriber) Calls() []groupSubscribeCall {
 }
 
 // TestRouter_ConsumerGroup_PropagatesToSubscriber verifies that the consumerGroup
-// passed to AddHandler is forwarded verbatim to Subscriber.Subscribe.
+// passed to AddHandler is forwarded verbatim to Subscriber.Subscribe via Subscription.
 func TestRouter_ConsumerGroup_PropagatesToSubscriber(t *testing.T) {
 	sub := &recordingGroupSubscriber{}
 	r := New(sub, WithStartupTimeout(200*time.Millisecond))

--- a/runtime/eventrouter/router_test.go
+++ b/runtime/eventrouter/router_test.go
@@ -857,6 +857,106 @@ func TestRouter_SetupErrorAborts(t *testing.T) {
 	}
 }
 
+// mixedReadySubscriber covers the concurrent failure mode tested by
+// TestRouter_ReadyError_PartialNotReady_NoLeak: per-topic dispatch where
+// some topics close Ready immediately, one topic returns a Subscribe error,
+// and another topic delays Ready beyond the test window. Used to validate
+// that runAwaitReady's setupErr branch (1) returns the error promptly,
+// (2) does NOT close Running(), and (3) does not leak goroutines.
+type mixedReadySubscriber struct {
+	subscribeErrTopic string
+	subscribeErr      error
+	slowReadyTopic    string
+	slowReadyDelay    time.Duration
+	subscribeCalls    atomic.Int32
+}
+
+func (s *mixedReadySubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+
+func (s *mixedReadySubscriber) Ready(sub outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	if sub.Topic == s.subscribeErrTopic {
+		// Subscribe will fail before Ready can fire; leave channel open.
+		return ch
+	}
+	if sub.Topic == s.slowReadyTopic {
+		go func() {
+			time.Sleep(s.slowReadyDelay)
+			close(ch)
+		}()
+		return ch
+	}
+	close(ch)
+	return ch
+}
+
+func (s *mixedReadySubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, _ outbox.EntryHandler) error {
+	s.subscribeCalls.Add(1)
+	if sub.Topic == s.subscribeErrTopic {
+		return s.subscribeErr
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (s *mixedReadySubscriber) Close() error { return nil }
+
+// TestRouter_ReadyError_PartialNotReady_NoLeak verifies the runAwaitReady
+// failure path (six-seat review F1): when one Subscribe goroutine sends
+// to setupErr while other handlers are still waiting on Ready, Run must:
+//  1. Return the Subscribe error promptly (within ~100ms, not block on
+//     the slow Ready).
+//  2. NOT close Running() — Health remains "not running".
+//  3. Cancel the runCtx so all goroutines (including the slow-Ready waiter
+//     and the still-running Subscribe goroutines) exit cleanly via wg.Wait.
+//  4. Not leak the setupErr drain goroutine — proven by no extra background
+//     goroutine surviving the test (no drain since the F1 fix removed it).
+func TestRouter_ReadyError_PartialNotReady_NoLeak(t *testing.T) {
+	subErr := errors.New("subscribe failed mid-ready")
+	sub := &mixedReadySubscriber{
+		subscribeErrTopic: "topic.subscribe-error",
+		subscribeErr:      subErr,
+		slowReadyTopic:    "topic.slow-ready",
+		slowReadyDelay:    5 * time.Second, // would block test if Run waited
+	}
+
+	r := New(sub, WithReadyTimeout(0)) // disable timeout to isolate setupErr path
+
+	r.AddHandler("topic.fast", noopHandler, "test")
+	r.AddHandler(sub.subscribeErrTopic, noopHandler, "test")
+	r.AddHandler(sub.slowReadyTopic, noopHandler, "test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runDone := make(chan error, 1)
+	start := time.Now()
+	go func() { runDone <- r.Run(ctx) }()
+
+	select {
+	case err := <-runDone:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, subErr, "Run should propagate the Subscribe error")
+		elapsed := time.Since(start)
+		assert.Less(t, elapsed, 1*time.Second,
+			"Run should return promptly on Subscribe error, not wait for slow Ready (5s)")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s after Subscribe error — possible block on slow Ready")
+	}
+
+	// Running() must NOT be closed.
+	select {
+	case <-r.Running():
+		t.Fatal("Running() must not close when a Subscribe goroutine errors during ready wait")
+	default:
+	}
+	assert.Error(t, r.Health(), "Health must report not-running after setup error")
+
+	// All three Subscribe goroutines were dispatched (Phase 2 launches all
+	// before Phase 3 select); error path cancels them via runCtx.
+	assert.Equal(t, int32(3), sub.subscribeCalls.Load(),
+		"all 3 Subscribe goroutines should have been launched in Phase 2")
+}
+
 // TestRouter_PartialReady_BlocksUntilAll verifies that with 3 handlers where
 // topic-C Ready closes after 200ms, Router.Running() only closes after all
 // three Ready channels are closed (i.e., at or after 200ms).

--- a/runtime/eventrouter/router_test.go
+++ b/runtime/eventrouter/router_test.go
@@ -49,7 +49,8 @@ func (s *blockingSubscriber) Topics() []string {
 	return cp
 }
 
-// failingSubscriber returns an error immediately, simulating setup failure.
+// failingSubscriber returns an error immediately from Subscribe, simulating
+// a Subscribe-level failure (e.g. broker connection refused).
 type failingSubscriber struct {
 	err error
 }
@@ -102,7 +103,7 @@ func TestRouter_AddHandler_RegistersTopics(t *testing.T) {
 
 func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 	sub := &blockingSubscriber{}
-	r := New(sub, WithStartupTimeout(200*time.Millisecond))
+	r := New(sub)
 
 	r.AddHandler("topic.a", noopHandler, "test")
 	r.AddHandler("topic.b", noopHandler, "test")
@@ -119,9 +120,14 @@ func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 		t.Fatal("Router did not become ready")
 	}
 
-	// Verify all 3 topics subscribed.
+	// Subscribe goroutines are launched concurrently; give them a moment to
+	// register their topics (they run after Phase 3 Ready signals close).
+	assert.Eventually(t, func() bool {
+		topics := sub.Topics()
+		return len(topics) == 3
+	}, 2*time.Second, 10*time.Millisecond, "all 3 topics should be subscribed")
+
 	topics := sub.Topics()
-	assert.Len(t, topics, 3)
 	assert.Contains(t, topics, "topic.a")
 	assert.Contains(t, topics, "topic.b")
 	assert.Contains(t, topics, "topic.c")
@@ -137,10 +143,15 @@ func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond)
 }
 
-func TestRouter_Run_SetupError_ReturnsImmediately(t *testing.T) {
-	setupErr := errcode.New(errcode.ErrBusClosed, "bus closed")
-	sub := &failingSubscriber{err: setupErr}
-	r := New(sub, WithStartupTimeout(500*time.Millisecond))
+// TestRouter_Run_SubscribeError_ReturnsError verifies that when
+// Subscriber.Subscribe returns an error immediately (after Ready fires),
+// Run returns the error. Running() is closed first (Phase 3 completes), then
+// the runtime error is detected in Phase 4 and returned from Run.
+// For Setup-level failures (before any subscription starts), see TestRouter_SetupErrorAborts.
+func TestRouter_Run_SubscribeError_ReturnsError(t *testing.T) {
+	subscribeErr := errcode.New(errcode.ErrBusClosed, "bus closed")
+	sub := &failingSubscriber{err: subscribeErr}
+	r := New(sub)
 
 	r.AddHandler("topic.fail", noopHandler, "test")
 
@@ -150,14 +161,6 @@ func TestRouter_Run_SetupError_ReturnsImmediately(t *testing.T) {
 	err := r.Run(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "topic.fail")
-
-	// Running() should NOT be closed on setup failure.
-	select {
-	case <-r.Running():
-		t.Fatal("Running() should not be closed on setup failure")
-	default:
-		// expected
-	}
 }
 
 func TestRouter_Run_NoHandlers_BlocksUntilCancel(t *testing.T) {
@@ -185,7 +188,7 @@ func TestRouter_Run_NoHandlers_BlocksUntilCancel(t *testing.T) {
 
 func TestRouter_Close_CancelsSubscriptions(t *testing.T) {
 	sub := &blockingSubscriber{}
-	r := New(sub, WithStartupTimeout(200*time.Millisecond))
+	r := New(sub)
 
 	r.AddHandler("topic.a", noopHandler, "test")
 
@@ -215,7 +218,7 @@ func TestRouter_Run_HandlerReceivesMessages(t *testing.T) {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
 
-	r := New(bus, WithStartupTimeout(200*time.Millisecond))
+	r := New(bus)
 	r.AddHandler("test.topic", handler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -241,7 +244,7 @@ func TestRouter_Run_MultipleHandlersSameSubscriber(t *testing.T) {
 
 	var countA, countB atomic.Int32
 
-	r := New(bus, WithStartupTimeout(200*time.Millisecond))
+	r := New(bus)
 	r.AddHandler("topic.a", func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		countA.Add(1)
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
@@ -271,7 +274,7 @@ func TestRouter_Run_MultipleHandlersSameSubscriber(t *testing.T) {
 func TestRouter_EventRegistrar_Integration(t *testing.T) {
 	// Simulate the bootstrap pattern: cell declares handlers, router runs them.
 	bus := newTestEventBus(t)
-	r := New(bus, WithStartupTimeout(200*time.Millisecond))
+	r := New(bus)
 
 	var received atomic.Int32
 
@@ -302,12 +305,13 @@ func TestRouter_EventRegistrar_Integration(t *testing.T) {
 }
 
 func TestRouter_Run_RuntimeError_AfterStartup(t *testing.T) {
-	// Subscribe blocks for 300ms (past startup timeout), then fails.
+	// delayedFailSubscriber: Ready returns immediately-closed channel (so Router
+	// marks itself Running fast), then Subscribe returns an error after the delay.
 	sub := &delayedFailSubscriber{
-		delay: 300 * time.Millisecond,
+		delay: 100 * time.Millisecond,
 		err:   errors.New("connection lost"),
 	}
-	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r := New(sub)
 	r.AddHandler("topic.a", noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -319,11 +323,12 @@ func TestRouter_Run_RuntimeError_AfterStartup(t *testing.T) {
 }
 
 func TestRouter_HealthLifecycle(t *testing.T) {
+	// subscriber that is ready immediately but fails after 300ms.
 	sub := &delayedFailSubscriber{
-		delay: 600 * time.Millisecond,
+		delay: 300 * time.Millisecond,
 		err:   errors.New("connection lost"),
 	}
-	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r := New(sub)
 	r.AddHandler("topic.a", noopHandler, "test")
 
 	require.Error(t, r.Health(), "router must be unhealthy before Run")
@@ -352,7 +357,7 @@ func TestRouter_HealthLifecycle(t *testing.T) {
 
 func TestRouter_Health_AfterGracefulShutdown(t *testing.T) {
 	sub := &blockingSubscriber{}
-	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r := New(sub)
 	r.AddHandler("topic.a", noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -381,7 +386,7 @@ func TestRouter_Health_AfterGracefulShutdown(t *testing.T) {
 
 func TestRouter_Run_DoubleRun_ReturnsError(t *testing.T) {
 	sub := &blockingSubscriber{}
-	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r := New(sub)
 	r.AddHandler("topic.a", noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -423,7 +428,7 @@ func TestRouter_Close_Timeout(t *testing.T) {
 	// Subscriber that ignores context cancellation (simulates stuck goroutine).
 	stuck := make(chan struct{})
 	sub := &stuckSubscriber{block: stuck}
-	r := New(sub, WithStartupTimeout(100*time.Millisecond))
+	r := New(sub)
 	r.AddHandler("topic.stuck", noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -458,7 +463,7 @@ func TestRouter_AddHandler_PanicsOnNilHandler(t *testing.T) {
 func TestRouter_Run_PanicInSubscriber_CapturedAsError(t *testing.T) {
 	// A subscriber whose Subscribe panics.
 	panickySub := &panickingSubscriber{}
-	r := New(panickySub, WithStartupTimeout(500*time.Millisecond))
+	r := New(panickySub)
 	r.AddHandler("topic.panic", noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -560,9 +565,21 @@ func (b *testBus) Publish(_ context.Context, topic string, payload []byte) error
 
 func (b *testBus) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
 
-func (b *testBus) Ready(_ outbox.Subscription) <-chan struct{} {
+func (b *testBus) Ready(sub outbox.Subscription) <-chan struct{} {
 	ch := make(chan struct{})
-	close(ch)
+	// Close once a subscriber for this topic has actually registered.
+	go func() {
+		for {
+			b.mu.RLock()
+			_, exists := b.subs[sub.Topic]
+			b.mu.RUnlock()
+			if exists {
+				close(ch)
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
 	return ch
 }
 
@@ -646,7 +663,7 @@ func (s *recordingGroupSubscriber) Calls() []groupSubscribeCall {
 // passed to AddHandler is forwarded verbatim to Subscriber.Subscribe via Subscription.
 func TestRouter_ConsumerGroup_PropagatesToSubscriber(t *testing.T) {
 	sub := &recordingGroupSubscriber{}
-	r := New(sub, WithStartupTimeout(200*time.Millisecond))
+	r := New(sub)
 
 	r.AddHandler("session.created", noopHandler, "audit-core")
 	r.AddHandler("config.changed", noopHandler, "config-core")
@@ -685,4 +702,192 @@ func TestRouter_AddHandler_PanicsOnEmptyConsumerGroup(t *testing.T) {
 		func() {
 			r.AddHandler("topic", noopHandler, "")
 		})
+}
+
+// ---------------------------------------------------------------------------
+// Commit 3: Explicit Ready signal tests
+// ---------------------------------------------------------------------------
+
+// delayedReadySubscriber is a mock Subscriber whose Ready channel closes after
+// the configured delay. Subscribe blocks until ctx cancellation.
+type delayedReadySubscriber struct {
+	delay time.Duration
+
+	mu       sync.Mutex
+	readyChs map[string]chan struct{} // key = topic
+}
+
+func newDelayedReadySubscriber(delay time.Duration) *delayedReadySubscriber {
+	return &delayedReadySubscriber{
+		delay:    delay,
+		readyChs: make(map[string]chan struct{}),
+	}
+}
+
+func (s *delayedReadySubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+
+func (s *delayedReadySubscriber) Ready(sub outbox.Subscription) <-chan struct{} {
+	s.mu.Lock()
+	if _, ok := s.readyChs[sub.Topic]; !ok {
+		s.readyChs[sub.Topic] = make(chan struct{})
+	}
+	ch := s.readyChs[sub.Topic]
+	s.mu.Unlock()
+
+	go func() {
+		time.Sleep(s.delay)
+		// Safe to close multiple times? No — we create one per topic so it's fine.
+		select {
+		case <-ch:
+			// already closed
+		default:
+			close(ch)
+		}
+	}()
+	return ch
+}
+
+func (s *delayedReadySubscriber) Subscribe(ctx context.Context, _ outbox.Subscription, _ outbox.EntryHandler) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (s *delayedReadySubscriber) Close() error { return nil }
+
+// setupFailSubscriber returns an error from Setup, never calling Subscribe.
+type setupFailSubscriber struct {
+	err          error
+	subscribeCnt atomic.Int32
+}
+
+func (s *setupFailSubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return s.err }
+func (s *setupFailSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (s *setupFailSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.EntryHandler) error {
+	s.subscribeCnt.Add(1)
+	return nil
+}
+func (s *setupFailSubscriber) Close() error { return nil }
+
+// partialReadySubscriber: topics A and B have immediately-closed Ready channels;
+// topic C closes its Ready channel after the configured delay.
+type partialReadySubscriber struct {
+	slowTopic string
+	slowDelay time.Duration
+}
+
+func (s *partialReadySubscriber) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+
+func (s *partialReadySubscriber) Ready(sub outbox.Subscription) <-chan struct{} {
+	ch := make(chan struct{})
+	if sub.Topic == s.slowTopic {
+		go func() {
+			time.Sleep(s.slowDelay)
+			close(ch)
+		}()
+	} else {
+		close(ch)
+	}
+	return ch
+}
+
+func (s *partialReadySubscriber) Subscribe(ctx context.Context, _ outbox.Subscription, _ outbox.EntryHandler) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (s *partialReadySubscriber) Close() error { return nil }
+
+// TestRouter_RunBlocksUntilReady_NoTimeout verifies that Router.Running() is
+// NOT closed until the Subscriber.Ready signal fires. The Ready channel closes
+// after 100ms; Running() must close within that window (not at 500ms).
+func TestRouter_RunBlocksUntilReady_NoTimeout(t *testing.T) {
+	const readyDelay = 100 * time.Millisecond
+	sub := newDelayedReadySubscriber(readyDelay)
+
+	r := New(sub)
+	r.AddHandler("topic.a", noopHandler, "test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	start := time.Now()
+	go func() { _ = r.Run(ctx) }()
+
+	select {
+	case <-r.Running():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Router did not become ready within 2s")
+	}
+
+	elapsed := time.Since(start)
+	// Ready fires at ~100ms. Allow ±50ms tolerance.
+	assert.GreaterOrEqual(t, elapsed, readyDelay-10*time.Millisecond,
+		"Router became ready too early (before Ready signal fired)")
+	assert.Less(t, elapsed, readyDelay+50*time.Millisecond,
+		"Router took too long after Ready signal (should not wait 500ms)")
+}
+
+// TestRouter_SetupErrorAborts verifies that when Subscriber.Setup returns an
+// error, Run returns that error immediately and Subscribe is never called.
+func TestRouter_SetupErrorAborts(t *testing.T) {
+	setupErr := errors.New("topology declaration failed")
+	sub := &setupFailSubscriber{err: setupErr}
+
+	r := New(sub)
+	r.AddHandler("topic.fail", noopHandler, "test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := r.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "topic.fail")
+
+	// Subscribe must never have been called.
+	assert.Equal(t, int32(0), sub.subscribeCnt.Load(),
+		"Subscribe should not be called when Setup fails")
+
+	// Running() should NOT be closed on setup failure.
+	select {
+	case <-r.Running():
+		t.Fatal("Running() should not be closed when Setup fails")
+	default:
+	}
+}
+
+// TestRouter_PartialReady_BlocksUntilAll verifies that with 3 handlers where
+// topic-C Ready closes after 200ms, Router.Running() only closes after all
+// three Ready channels are closed (i.e., at or after 200ms).
+func TestRouter_PartialReady_BlocksUntilAll(t *testing.T) {
+	const slowDelay = 200 * time.Millisecond
+	sub := &partialReadySubscriber{
+		slowTopic: "topic.c",
+		slowDelay: slowDelay,
+	}
+
+	r := New(sub)
+	r.AddHandler("topic.a", noopHandler, "test")
+	r.AddHandler("topic.b", noopHandler, "test")
+	r.AddHandler("topic.c", noopHandler, "test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	start := time.Now()
+	go func() { _ = r.Run(ctx) }()
+
+	select {
+	case <-r.Running():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Router did not become ready within 2s")
+	}
+
+	elapsed := time.Since(start)
+	// All three Ready channels must close; the last is at ~200ms.
+	assert.GreaterOrEqual(t, elapsed, slowDelay-10*time.Millisecond,
+		"Router became ready before all Ready channels closed")
+	assert.Less(t, elapsed, slowDelay+100*time.Millisecond,
+		"Router took too long after all Ready signals fired")
 }

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -296,12 +296,12 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 
 	wrappedSub := &outbox.SubscriberWithMiddleware{
 		Inner:      sub,
-		Middleware: []outbox.TopicHandlerMiddleware{outbox.ObservabilityContextMiddleware()},
+		Middleware: []outbox.SubscriptionMiddleware{outbox.ObservabilityContextMiddleware()},
 	}
 
 	subErrCh := make(chan error, 1)
 	go func() {
-		subErrCh <- wrappedSub.Subscribe(subCtx, topic, func(handlerCtx context.Context, e outbox.Entry) outbox.HandleResult {
+		subErrCh <- wrappedSub.Subscribe(subCtx, outbox.Subscription{Topic: topic, ConsumerGroup: "fullchain-test"}, func(handlerCtx context.Context, e outbox.Entry) outbox.HandleResult {
 			requestID, _ := ctxkeys.RequestIDFrom(handlerCtx)
 			correlationID, _ := ctxkeys.CorrelationIDFrom(handlerCtx)
 			traceID, _ := ctxkeys.TraceIDFrom(handlerCtx)
@@ -312,7 +312,7 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 				traceID:       traceID,
 			}
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "fullchain-test")
+		})
 	}()
 
 	waitForSubscriberReady(t, rmqConn, "outbox.fullchain.queue", subErrCh, 5*time.Second)
@@ -539,12 +539,12 @@ func TestIntegration_OutboxFullChain_NoTrace(t *testing.T) {
 
 	wrappedSub := &outbox.SubscriberWithMiddleware{
 		Inner:      sub,
-		Middleware: []outbox.TopicHandlerMiddleware{outbox.ObservabilityContextMiddleware()},
+		Middleware: []outbox.SubscriptionMiddleware{outbox.ObservabilityContextMiddleware()},
 	}
 
 	subErrCh := make(chan error, 1)
 	go func() {
-		subErrCh <- wrappedSub.Subscribe(subCtx, topic, func(handlerCtx context.Context, e outbox.Entry) outbox.HandleResult {
+		subErrCh <- wrappedSub.Subscribe(subCtx, outbox.Subscription{Topic: topic, ConsumerGroup: "fullchain-notrace-test"}, func(handlerCtx context.Context, e outbox.Entry) outbox.HandleResult {
 			requestID, _ := ctxkeys.RequestIDFrom(handlerCtx)
 			correlationID, _ := ctxkeys.CorrelationIDFrom(handlerCtx)
 			traceID, traceOK := ctxkeys.TraceIDFrom(handlerCtx)
@@ -556,7 +556,7 @@ func TestIntegration_OutboxFullChain_NoTrace(t *testing.T) {
 				traceOK:       traceOK,
 			}
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
-		}, "fullchain-notrace-test")
+		})
 	}()
 
 	waitForSubscriberReady(t, rmqConn, "outbox.fullchain.notrace.queue", subErrCh, 5*time.Second)


### PR DESCRIPTION
## Summary

PR#180 review 暴露 5 个相互依赖的问题（P0 + 2×P1 + A13 + A14），全部围绕 `outbox.Subscriber` + `kernel/outbox.ConsumerBase` + `runtime/eventrouter.Router` 三层耦合。本 PR 以 5 个 commit 一次性彻底加固，按依赖顺序 commit-by-commit 可 review：

1. **`cab0dd3` refactor(outbox)!: hoist Subscription to first-class object** [P0]
   - 替换 topic-only `TopicHandlerMiddleware` → `SubscriptionMiddleware` 携带完整身份（Topic/ConsumerGroup/CellID）
   - `ConsumerBase` 用 `sub.ConsumerGroup` 作为幂等命名空间，删 `ConsumerBaseConfig.ConsumerGroup` 字段
   - `Subscriber` 接口拆 Setup/Ready/Subscribe/Close（删 SubscriberInitializer）
   - **修复**: 跨 cell fanout 串扰 — 之前所有 cell 共享 `core-bundle:{event-id}` 命名空间，后到 cell 看到 ClaimDone 静默 Ack 丢事件

2. **`0aad4a7` fix(outbox): lease-lost hard fence + Commit→Ack ordering** [P1]
   - Layer 1: ConsumerBase atomic.Bool 闩锁，失租后 handler 即使返回 Ack 也强制降级 Requeue
   - Layer 2: rabbitmq processDelivery 重排为 Receipt.Commit → broker.Ack，Commit 失败 → Nack(requeue)
   - settleReceipt helper 删除（逻辑内联）
   - **修复**: stale holder Ack 破坏两阶段幂等

3. **`6274fff` refactor(eventrouter)!: explicit Setup/Ready/Subscribe lifecycle** [P1]
   - 删除 `DefaultStartupTimeout` 常量与 `WithStartupTimeout` Option
   - Run 拆 Phase 1-4：Setup loop → Subscribe goroutines → Ready select → 阻塞循环
   - **修复**: readyz 假阳性窗口（之前 500ms 时间窗猜测）

4. **`c3d63e7` refactor(outbox): export ExponentialDelay as single source of truth** [A14]
   - `kernel/outbox.ExponentialDelay` 公开
   - 删除 `adapters/rabbitmq/backoff.go` 本地副本，调用点改为 kernel 版本

5. **`9cf79f9` feat(rabbitmq): concurrent processDelivery + cross-cell fanout e2e** [A13]
   - `consumeLoop` 改 `go s.processDelivery(...)` 兑现 PrefetchCount=10 真并发
   - 并发安全审计：amqp091-go channel mutex / per-delivery Receipt / sync.WaitGroup
   - cmd/core-bundle e2e `TestOutboxE2E_CrossCellFanout` 端到端验证 P0 修复

## Breaking changes

- `outbox.Subscriber` 接口契约重写（4 方法 Setup/Ready/Subscribe/Close）
- `outbox.SubscriptionMiddleware` 替换 `TopicHandlerMiddleware`
- `outbox.SubscriberInitializer` 删除（能力被 Setup 吸收）
- `outbox.ConsumerBaseConfig.ConsumerGroup` 字段删除
- `eventrouter.DefaultStartupTimeout` / `WithStartupTimeout` 删除

项目尚无外部消费方，破坏性变更影响仅限本仓库。

## Test plan

- [x] `go test -race ./...` 0 failures across all 50+ packages
- [x] `golangci-lint run` 0 new issues on modified files
- [x] 新增 TDD 测试：跨 cg 不串扰、lease-lost 闩锁、Commit→Ack 顺序、Ready signal 替代 timeout、ExponentialDelay 公开 API、PrefetchCount 真并发、goleak、cross-cell fanout e2e
- [x] cmd/core-bundle e2e `TestOutboxE2E_CrossCellFanout` 通过

## Framework refs

- ThreeDotsLabs/watermill router (handler context injection + per-message goroutine)
- MassTransit ConsumeContext (一等对象贯穿中间件)
- Temporal Server task token fencing (Commit 边界硬约束)
- Uber fx OnStart (显式 ready 而非 timeout 推断)

🤖 Generated with [Claude Code](https://claude.com/claude-code)