### PR TITLE
fix(outbox): P1-14 envelope fail-closed + eventbus test sleep cleanup

### DIFF
--- a/adapters/rabbitmq/conformance_test.go
+++ b/adapters/rabbitmq/conformance_test.go
@@ -29,11 +29,12 @@ type envelopingPublisher struct {
 func (p *envelopingPublisher) Publish(ctx context.Context, topic string, payload []byte) error {
 	entry := outboxtest.NewEntry(topic, payload)
 	wire := outboxrt.WireMessage{
-		ID:        entry.ID,
-		EventType: entry.EventType,
-		Topic:     entry.Topic,
-		Payload:   json.RawMessage(payload),
-		CreatedAt: entry.CreatedAt,
+		SchemaVersion: outboxrt.EnvelopeSchemaV1,
+		ID:            entry.ID,
+		EventType:     entry.EventType,
+		Topic:         entry.Topic,
+		Payload:       json.RawMessage(payload),
+		CreatedAt:     entry.CreatedAt,
 	}
 	body, err := json.Marshal(wire)
 	if err != nil {

--- a/adapters/rabbitmq/conformance_test.go
+++ b/adapters/rabbitmq/conformance_test.go
@@ -3,45 +3,12 @@
 package rabbitmq
 
 import (
-	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/outbox/outboxtest"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 )
-
-// envelopingPublisher wraps a raw Publisher to serialize payloads into the
-// outboxrt.WireMessage envelope expected by the RabbitMQ subscriber's
-// unmarshalDelivery. Without this wrapper, the conformance harness publishes
-// bare JSON payloads (e.g., {"seq":0}), but the subscriber expects an envelope
-// with id, eventType, and an embedded payload field.
-//
-// This is NOT needed in production — the outbox relay serializes entries
-// into the wire format. It is only needed for conformance tests that bypass
-// the relay and test Publisher+Subscriber directly.
-type envelopingPublisher struct {
-	inner outbox.Publisher
-}
-
-func (p *envelopingPublisher) Publish(ctx context.Context, topic string, payload []byte) error {
-	entry := outboxtest.NewEntry(topic, payload)
-	wire := outboxrt.WireMessage{
-		SchemaVersion: outboxrt.EnvelopeSchemaV1,
-		ID:            entry.ID,
-		EventType:     entry.EventType,
-		Topic:         entry.Topic,
-		Payload:       json.RawMessage(payload),
-		CreatedAt:     entry.CreatedAt,
-	}
-	body, err := json.Marshal(wire)
-	if err != nil {
-		return err
-	}
-	return p.inner.Publish(ctx, topic, body)
-}
 
 // TestRabbitMQ_Conformance runs the full outboxtest conformance suite against
 // a real RabbitMQ broker via testcontainers.
@@ -83,6 +50,9 @@ func TestRabbitMQ_Conformance(t *testing.T) {
 			ShutdownTimeout: 5 * time.Second,
 		})
 		t.Cleanup(func() { _ = sub.Close() })
-		return &envelopingPublisher{inner: pub}, sub
+		// outboxtest.PublishN wraps payloads in a v1 wire envelope, matching
+		// the RabbitMQ subscriber's unmarshalDelivery contract — no additional
+		// envelope wrapper is needed here.
+		return pub, sub
 	})
 }

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -4,7 +4,6 @@ package rabbitmq
 
 import (
 	"context"
-	"encoding/json"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -194,7 +194,9 @@ func TestIntegration_PublishConsume(t *testing.T) {
 	// Wait until Subscribe has declared, bound, and started consuming from the queue.
 	waitForSubscriberReady(t, conn, queueName, subErrCh, 5*time.Second)
 
-	// Prepare an outbox.Entry as the message payload.
+	// Prepare an outbox.Entry as the message payload, wrapped in a v1 wire
+	// envelope so the subscriber's unmarshalDelivery (fail-closed since P1-14)
+	// accepts it.
 	entry := outbox.Entry{
 		ID:            "evt-001",
 		AggregateID:   "agg-001",
@@ -205,8 +207,8 @@ func TestIntegration_PublishConsume(t *testing.T) {
 		Metadata:      map[string]string{"source": "integration-test"},
 	}
 
-	payload, err := json.Marshal(entry)
-	require.NoError(t, err, "marshal entry")
+	payload, err := outboxrt.MarshalEnvelope(outboxrt.ClaimedEntry{Entry: entry})
+	require.NoError(t, err, "marshal envelope")
 
 	// Publish the message after the subscriber is ready.
 	err = pub.Publish(ctx, topic, payload)
@@ -244,7 +246,7 @@ func TestIntegration_PublishOnly(t *testing.T) {
 		CreatedAt: time.Now().UTC(),
 	}
 
-	payload, err := json.Marshal(entry)
+	payload, err := outboxrt.MarshalEnvelope(outboxrt.ClaimedEntry{Entry: entry})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -333,7 +335,7 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 		Payload:   []byte(`{"retry":"e2e"}`),
 		CreatedAt: time.Now().UTC(),
 	}
-	payload, err := json.Marshal(entry)
+	payload, err := outboxrt.MarshalEnvelope(outboxrt.ClaimedEntry{Entry: entry})
 	require.NoError(t, err)
 
 	err = pub.Publish(ctx, topic, payload)
@@ -354,7 +356,12 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	require.Eventually(t, func() bool {
 		select {
 		case msg := <-dlxMsgs:
-			return json.Unmarshal(msg.Body, &dlEntry) == nil
+			decoded, decodeErr := outboxrt.UnmarshalEnvelope("", msg.Body)
+			if decodeErr != nil {
+				return false
+			}
+			dlEntry = decoded
+			return true
 		default:
 			return false
 		}
@@ -503,7 +510,7 @@ func TestIntegration_DLXBrokerNative(t *testing.T) {
 		Payload:   []byte(`{"dlx":"end-to-end"}`),
 		CreatedAt: time.Now().UTC(),
 	}
-	payload, err := json.Marshal(entry)
+	payload, err := outboxrt.MarshalEnvelope(outboxrt.ClaimedEntry{Entry: entry})
 	require.NoError(t, err)
 
 	err = pub.Publish(ctx, topic, payload)
@@ -530,7 +537,12 @@ func TestIntegration_DLXBrokerNative(t *testing.T) {
 	require.Eventually(t, func() bool {
 		select {
 		case msg := <-dlxMsgs:
-			return json.Unmarshal(msg.Body, &dlEntry) == nil
+			decoded, decodeErr := outboxrt.UnmarshalEnvelope("", msg.Body)
+			if decodeErr != nil {
+				return false
+			}
+			dlEntry = decoded
+			return true
 		default:
 			return false
 		}

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -296,6 +296,7 @@ func makeDeliveryBody(t *testing.T, entry outbox.Entry) []byte {
 		payload = []byte(`{}`)
 	}
 	wire := outboxrt.WireMessage{
+		SchemaVersion: outboxrt.EnvelopeSchemaV1, // required since P1-14 A1 (fail-closed envelope schema)
 		ID:            entry.ID,
 		AggregateID:   entry.AggregateID,
 		AggregateType: entry.AggregateType,
@@ -1404,10 +1405,12 @@ func TestSubscriber_Subscribe_UnmarshalFailure_Nack(t *testing.T) {
 	assert.NoError(t, sub.Close())
 }
 
-// TestUnmarshalDelivery covers the three discriminator paths in unmarshalDelivery:
-//  1. WireMessage envelope (primary relay path) — EventType is decoded from JSON.
-//  2. Legacy outbox.Entry JSON (pre-envelope format, used by integration tests).
-//  3. Broken JSON (neither path yields a valid entry) — returns an error.
+// TestUnmarshalDelivery covers the discriminator paths in unmarshalDelivery
+// after P1-14 A2 (fail-closed envelope schema, legacy fallback removed):
+//  1. v1 WireMessage envelope (primary relay path) — succeeds.
+//  2. Legacy outbox.Entry JSON (no schemaVersion) — rejected with ErrUnknownEnvelopeVersion.
+//  3. Broken JSON — returns a wrapped parse error (not ErrUnknownEnvelopeVersion).
+//  4. Empty body — returns error.
 func TestUnmarshalDelivery(t *testing.T) {
 	t.Run("wire_message_envelope", func(t *testing.T) {
 		entry := outbox.Entry{
@@ -1415,7 +1418,7 @@ func TestUnmarshalDelivery(t *testing.T) {
 			EventType: "test.created",
 			Payload:   []byte(`{"x":1}`),
 		}
-		body := makeDeliveryBody(t, entry)
+		body := makeDeliveryBody(t, entry) // includes schemaVersion:"v1" since P1-14 A1
 
 		got, err := unmarshalDelivery(body)
 		require.NoError(t, err)
@@ -1425,8 +1428,8 @@ func TestUnmarshalDelivery(t *testing.T) {
 	})
 
 	t.Run("legacy_entry_json", func(t *testing.T) {
-		// Publish raw outbox.Entry JSON (PascalCase, no WireMessage envelope).
-		// This is the format used by the three failing integration tests.
+		// Legacy outbox.Entry JSON (PascalCase, missing schemaVersion) is now
+		// rejected with ErrUnknownEnvelopeVersion (fail-closed, no fallback).
 		entry := outbox.Entry{
 			ID:        "evt-legacy-001",
 			EventType: "test.legacy",
@@ -1435,17 +1438,16 @@ func TestUnmarshalDelivery(t *testing.T) {
 		body, err := json.Marshal(entry)
 		require.NoError(t, err)
 
-		got, legacyErr := unmarshalDelivery(body)
-		require.NoError(t, legacyErr)
-		assert.Equal(t, "evt-legacy-001", got.ID)
-		assert.Equal(t, "test.legacy", got.EventType)
-		assert.JSONEq(t, `{"legacy":true}`, string(got.Payload))
+		_, legacyErr := unmarshalDelivery(body)
+		require.Error(t, legacyErr, "legacy entry JSON must be rejected (no schemaVersion)")
+		assert.ErrorIs(t, legacyErr, outboxrt.ErrUnknownEnvelopeVersion)
 	})
 
 	t.Run("broken_json_returns_error", func(t *testing.T) {
 		_, err := unmarshalDelivery([]byte("not valid json{{{"))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unmarshal delivery")
+		// Must NOT be ErrUnknownEnvelopeVersion — it's a parse error.
+		assert.NotErrorIs(t, err, outboxrt.ErrUnknownEnvelopeVersion)
 	})
 
 	t.Run("empty_body_returns_error", func(t *testing.T) {

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -2,7 +2,6 @@ package rabbitmq
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -745,39 +744,16 @@ func (s *Subscriber) Close() error {
 
 // unmarshalDelivery deserializes a broker message body into an outbox.Entry.
 //
-// Primary path: the body is a WireMessage envelope produced by MarshalEnvelope
-// (relay path). Detected by calling UnmarshalEnvelope with topic="" — a real
-// WireMessage always has EventType set, so the returned entry has EventType != "".
+// Requires a valid v1 WireMessage envelope (schemaVersion:"v1", non-empty id and
+// eventType). Any other payload — legacy Entry JSON, raw bytes, unknown schema
+// versions — is rejected with an error so processDelivery NACKs without requeue
+// (permanent error, routes to DLX).
 //
-// Fallback path: the body is a legacy outbox.Entry JSON (PascalCase field names,
-// no envelope). This format is used by adapter-level integration tests that
-// publish raw Entry JSON directly to test pub/sub primitives, predating the
-// WireMessage contract. When UnmarshalEnvelope falls back (EventType == ""),
-// we attempt json.Unmarshal into outbox.Entry. ID validation (non-empty,
-// max length) is deferred to the entry.ID guard in processDelivery.
+// Fail-closed semantics: legacy fallback has been removed. All relay producers
+// MUST emit v1 envelopes via MarshalEnvelope.
 //
-// Broken JSON: if neither path can parse the body, we return an error so that
-// processDelivery NACKs without requeue (permanent error).
-//
-// Discriminator: UnmarshalEnvelope called with topic="" sets EventType="" on the
-// fallback path (since EventType = topic = ""), while a real WireMessage always
-// has EventType set by the relay producer. This replaces the previous "evt-"
-// ID-prefix heuristic, which collided with outboxtest.NewEntry IDs.
-//
+// ref: Watermill message/router.go handleMessage (unknown type → Nack, no retry)
 // ref: runtime/outbox/envelope.go UnmarshalEnvelope
 func unmarshalDelivery(body []byte) (outbox.Entry, error) {
-	entry, _ := outboxrt.UnmarshalEnvelope("", body)
-	if entry.EventType != "" {
-		// WireMessage envelope decoded successfully.
-		return entry, nil
-	}
-	// Fall back to legacy outbox.Entry JSON (predates WireMessage contract,
-	// still used by adapter-level integration tests that bypass the relay).
-	var legacy outbox.Entry
-	if json.Unmarshal(body, &legacy) == nil {
-		return legacy, nil
-	}
-	// Neither a valid WireMessage envelope nor a parseable legacy Entry JSON.
-	// Treat as a permanent unmarshal error so the delivery is NACKed without requeue.
-	return outbox.Entry{}, fmt.Errorf("unmarshal delivery: body is not a WireMessage envelope or legacy Entry JSON")
+	return outboxrt.UnmarshalEnvelope("", body)
 }

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -30,9 +30,11 @@ func makeDeliveryBodyWithID(t *testing.T, id string) []byte {
 	return makeDeliveryBody(t, entry)
 }
 
-// TestProcessDelivery_EmptyEntryID_RejectsToDLX verifies that an entry with
-// an empty ID is Nacked without requeue and the handler is never called.
-func TestProcessDelivery_EmptyEntryID_RejectsToDLX(t *testing.T) {
+// TestProcessDelivery_LegacyEnvelopeFormat_RejectsToDLX verifies that a legacy
+// (non-v1 envelope) delivery is Nacked without requeue and the handler is
+// never called. After P1-14 (A2), unmarshalDelivery rejects any body that is
+// not a v1 envelope — ErrUnknownEnvelopeVersion routes to DLX, not retry.
+func TestProcessDelivery_LegacyEnvelopeFormat_RejectsToDLX(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 
 	ch := newMockChannel()

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -55,9 +55,11 @@ func TestProcessDelivery_EmptyEntryID_RejectsToDLX(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Use a legacy outbox.Entry JSON body with empty ID. The unmarshalDelivery
-	// legacy fallback parses this successfully (JSON is well-formed), and the
-	// entry.ID guard in processDelivery then Nacks it without requeue.
+	// Use a non-v1 body (legacy outbox.Entry JSON format, missing schemaVersion).
+	// After P1-14 (A2), unmarshalDelivery rejects any body that is not a v1
+	// envelope — ErrUnknownEnvelopeVersion is returned and processDelivery
+	// NACKs without requeue. The empty-ID case is now subsumed by the schema
+	// version check, but the behavior (NACK, no handler call) is unchanged.
 	// Note: outbox.Entry has no json tags so PascalCase field names are used.
 	body := []byte(`{"ID":"","EventType":"test.event","Payload":"e30="}`)
 

--- a/cells/access-core/slices/configreceive/service.go
+++ b/cells/access-core/slices/configreceive/service.go
@@ -64,8 +64,14 @@ func (s *Service) HandleEvent(_ context.Context, entry outbox.Entry) error {
 		s.logger.Info("config-receive: config published (no action)",
 			slog.String("key", event.Key))
 	default:
-		s.logger.Warn("config-receive: unknown action, skipping",
-			slog.String("key", event.Key), slog.String("action", event.Action))
+		// Fail-closed: unknown actions are permanent errors routed to DLX.
+		//
+		// ref: K8s workqueue fail-closed semantics; Watermill Nack on unknown type
+		s.logger.Warn("config-receive: unknown action, routing to dead letter",
+			slog.String("action", event.Action), slog.String("key", event.Key))
+		return outbox.NewPermanentError(
+			fmt.Errorf("unknown action %q for key %q", event.Action, event.Key),
+		)
 	}
 
 	return nil

--- a/cells/access-core/slices/configreceive/service_test.go
+++ b/cells/access-core/slices/configreceive/service_test.go
@@ -45,11 +45,13 @@ func TestHandleEvent_ValidPayload(t *testing.T) {
 	}
 }
 
-func TestHandleEvent_UnknownAction(t *testing.T) {
+// TestHandleEvent_UnknownAction_PermanentError verifies that an unknown action
+// returns a PermanentError (fail-closed, P1-14 A3).
+func TestHandleEvent_UnknownAction_PermanentError(t *testing.T) {
 	svc := NewService(slog.Default())
 
 	payload, _ := json.Marshal(map[string]string{
-		"action": "unknown-action",
+		"action": "bogus",
 		"key":    "some.key",
 	})
 
@@ -59,9 +61,13 @@ func TestHandleEvent_UnknownAction(t *testing.T) {
 		Payload: payload,
 	}
 
-	// Unknown action is logged but not an error (no side effects to fail).
 	err := svc.HandleEvent(context.Background(), entry)
-	assert.NoError(t, err)
+	require.Error(t, err, "unknown action must return error")
+
+	// Must be PermanentError so WrapLegacyHandler routes to DLX, not retry.
+	var permErr *outbox.PermanentError
+	require.ErrorAs(t, err, &permErr, "unknown action must be PermanentError")
+	assert.Contains(t, err.Error(), "bogus", "error message should include the unknown action name")
 }
 
 func TestHandleEvent_InvalidJSON(t *testing.T) {
@@ -115,16 +121,19 @@ func TestWrapLegacyHandler_InvalidJSON_Reject(t *testing.T) {
 	assert.Error(t, result.Err)
 }
 
-func TestWrapLegacyHandler_UnknownAction_Ack(t *testing.T) {
+// TestWrapLegacyHandler_UnknownAction_Reject verifies that unknown actions
+// produce DispositionReject via WrapLegacyHandler (P1-14 A3).
+func TestWrapLegacyHandler_UnknownAction_Reject(t *testing.T) {
 	svc := NewService(slog.Default())
 	handler := outbox.WrapLegacyHandler(svc.HandleEvent)
 
-	payload, err := json.Marshal(ConfigChangedEvent{Action: "unknown-future-action", Key: "x"})
+	payload, err := json.Marshal(ConfigChangedEvent{Action: "bogus-action", Key: "x"})
 	require.NoError(t, err)
 
 	entry := outbox.Entry{ID: "evt-wrap-3", Topic: TopicConfigChanged, Payload: payload}
 	result := handler(context.Background(), entry)
 
-	assert.Equal(t, outbox.DispositionAck, result.Disposition)
-	assert.NoError(t, result.Err)
+	assert.Equal(t, outbox.DispositionReject, result.Disposition,
+		"unknown action via WrapLegacyHandler must produce DispositionReject → DLX")
+	assert.Error(t, result.Err)
 }

--- a/cells/access-core/slices/identitymanage/service.go
+++ b/cells/access-core/slices/identitymanage/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -352,8 +353,15 @@ func (s *Service) publish(ctx context.Context, topic string, payload map[string]
 		return nil
 	}
 	// Demo mode: publisher failure is logged but not propagated since
-	// demo mode does not guarantee L2 atomicity.
-	if err := s.publisher.Publish(ctx, topic, data); err != nil {
+	// demo mode does not guarantee L2 atomicity. Wrap in v1 wire envelope so
+	// the eventbus fail-closed schema check (P1-14) accepts the message.
+	envelope, envErr := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), data)
+	if envErr != nil {
+		s.logger.Warn("identity-manage: failed to marshal event envelope (demo mode)",
+			slog.Any("error", envErr), slog.String("topic", topic))
+		return nil
+	}
+	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
 		s.logger.Warn("identity-manage: failed to publish event (demo mode)",
 			slog.Any("error", err), slog.String("topic", topic))
 	}

--- a/cells/access-core/slices/identitymanage/service.go
+++ b/cells/access-core/slices/identitymanage/service.go
@@ -355,12 +355,7 @@ func (s *Service) publish(ctx context.Context, topic string, payload map[string]
 	// Demo mode: publisher failure is logged but not propagated since
 	// demo mode does not guarantee L2 atomicity. Wrap in v1 wire envelope so
 	// the eventbus fail-closed schema check (P1-14) accepts the message.
-	envelope, envErr := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), data)
-	if envErr != nil {
-		s.logger.Warn("identity-manage: failed to marshal event envelope (demo mode)",
-			slog.Any("error", envErr), slog.String("topic", topic))
-		return nil
-	}
+	envelope := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), data)
 	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
 		s.logger.Warn("identity-manage: failed to publish event (demo mode)",
 			slog.Any("error", err), slog.String("topic", topic))

--- a/cells/access-core/slices/identitymanage/service_test.go
+++ b/cells/access-core/slices/identitymanage/service_test.go
@@ -484,3 +484,26 @@ func TestService_Update_OmittedFieldNoChange(t *testing.T) {
 	assert.True(t, updated.PasswordResetRequired, "omitted field must not change existing flag")
 	assert.Equal(t, "new@omit.com", updated.Email)
 }
+
+// failingPublisher returns an error on every Publish call, used to drive the
+// publisher-error warn-log branch in Service.publish (demo mode).
+type failingPublisher struct{ err error }
+
+func (f failingPublisher) Publish(_ context.Context, _ string, _ []byte) error { return f.err }
+
+// TestService_Create_PublishError_DoesNotFailCreate verifies that demo-mode
+// publisher failure in Service.publish is logged but does not propagate as an
+// error — covering the else-branch warn log introduced when the direct publish
+// path was wrapped in a v1 envelope (P1-14 follow-up).
+func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	sessionRepo := mem.NewSessionRepository()
+	fp := failingPublisher{err: errors.New("broker unavailable")}
+	svc := NewService(userRepo, sessionRepo, fp, slog.Default())
+
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "pub-err-user", Email: "pub@err.com", Password: "hash",
+	})
+	require.NoError(t, err, "publish failure in demo mode must not fail Create")
+	assert.NotEmpty(t, user.ID)
+}

--- a/cells/access-core/slices/sessionlogin/service.go
+++ b/cells/access-core/slices/sessionlogin/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -198,11 +199,20 @@ func (s *Service) writeOutboxEntry(ctx context.Context, payload []byte) error {
 }
 
 // maybePublishDirect publishes directly when outbox is not in use (demo mode).
+// Wraps the business payload in a v1 wire envelope so the eventbus fail-closed
+// schema check (P1-14) accepts the message and subscribers receive it.
 func (s *Service) maybePublishDirect(ctx context.Context, payload []byte) {
 	if s.outboxWriter != nil {
 		return
 	}
-	if pubErr := s.publisher.Publish(ctx, TopicSessionCreated, payload); pubErr != nil {
+	envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicSessionCreated, TopicSessionCreated, outbox.NewEntryID(), payload)
+	if envErr != nil {
+		s.logger.Warn("session-login: failed to marshal event envelope (demo mode)",
+			slog.Any("error", envErr),
+			slog.String("topic", TopicSessionCreated))
+		return
+	}
+	if pubErr := s.publisher.Publish(ctx, TopicSessionCreated, envelope); pubErr != nil {
 		s.logger.Warn("session-login: failed to publish event (demo mode)",
 			slog.Any("error", pubErr),
 			slog.String("topic", TopicSessionCreated))

--- a/cells/access-core/slices/sessionlogin/service.go
+++ b/cells/access-core/slices/sessionlogin/service.go
@@ -205,13 +205,7 @@ func (s *Service) maybePublishDirect(ctx context.Context, payload []byte) {
 	if s.outboxWriter != nil {
 		return
 	}
-	envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicSessionCreated, TopicSessionCreated, outbox.NewEntryID(), payload)
-	if envErr != nil {
-		s.logger.Warn("session-login: failed to marshal event envelope (demo mode)",
-			slog.Any("error", envErr),
-			slog.String("topic", TopicSessionCreated))
-		return
-	}
+	envelope := outboxrt.MarshalDirectEnvelope(TopicSessionCreated, TopicSessionCreated, outbox.NewEntryID(), payload)
 	if pubErr := s.publisher.Publish(ctx, TopicSessionCreated, envelope); pubErr != nil {
 		s.logger.Warn("session-login: failed to publish event (demo mode)",
 			slog.Any("error", pubErr),

--- a/cells/access-core/slices/sessionlogout/service.go
+++ b/cells/access-core/slices/sessionlogout/service.go
@@ -116,12 +116,8 @@ func (s *Service) Logout(ctx context.Context, sessionID, callerUserID string) er
 	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
 	// so the eventbus fail-closed schema check (P1-14) accepts the message.
 	if s.outboxWriter == nil {
-		envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicSessionRevoked, TopicSessionRevoked, outbox.NewEntryID(), payload)
-		if envErr != nil {
-			s.logger.Warn("session-logout: failed to marshal event envelope (demo mode)",
-				slog.Any("error", envErr),
-				slog.String("topic", TopicSessionRevoked))
-		} else if pubErr := s.publisher.Publish(ctx, TopicSessionRevoked, envelope); pubErr != nil {
+		envelope := outboxrt.MarshalDirectEnvelope(TopicSessionRevoked, TopicSessionRevoked, outbox.NewEntryID(), payload)
+		if pubErr := s.publisher.Publish(ctx, TopicSessionRevoked, envelope); pubErr != nil {
 			s.logger.Warn("session-logout: failed to publish event (demo mode)",
 				slog.Any("error", pubErr),
 				slog.String("topic", TopicSessionRevoked))

--- a/cells/access-core/slices/sessionlogout/service.go
+++ b/cells/access-core/slices/sessionlogout/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 )
 
 const (
@@ -112,9 +113,15 @@ func (s *Service) Logout(ctx context.Context, sessionID, callerUserID string) er
 		return err
 	}
 
-	// Fallback direct publish when outbox is not in use.
+	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
+	// so the eventbus fail-closed schema check (P1-14) accepts the message.
 	if s.outboxWriter == nil {
-		if pubErr := s.publisher.Publish(ctx, TopicSessionRevoked, payload); pubErr != nil {
+		envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicSessionRevoked, TopicSessionRevoked, outbox.NewEntryID(), payload)
+		if envErr != nil {
+			s.logger.Warn("session-logout: failed to marshal event envelope (demo mode)",
+				slog.Any("error", envErr),
+				slog.String("topic", TopicSessionRevoked))
+		} else if pubErr := s.publisher.Publish(ctx, TopicSessionRevoked, envelope); pubErr != nil {
 			s.logger.Warn("session-logout: failed to publish event (demo mode)",
 				slog.Any("error", pubErr),
 				slog.String("topic", TopicSessionRevoked))

--- a/cells/audit-core/slices/auditappend/service.go
+++ b/cells/audit-core/slices/auditappend/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -136,9 +137,15 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 		return persistErr
 	}
 
-	// Fallback direct publish when outbox is not in use.
+	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
+	// so the eventbus fail-closed schema check (P1-14) accepts the message.
 	if s.outboxWriter == nil {
-		if pubErr := s.publisher.Publish(ctx, TopicAuditAppended, appendedPayload); pubErr != nil {
+		envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicAuditAppended, TopicAuditAppended, outbox.NewEntryID(), appendedPayload)
+		if envErr != nil {
+			s.logger.Warn("audit-append: failed to marshal appended event envelope (demo mode)",
+				slog.Any("error", envErr),
+				slog.String("topic", TopicAuditAppended))
+		} else if pubErr := s.publisher.Publish(ctx, TopicAuditAppended, envelope); pubErr != nil {
 			s.logger.Warn("audit-append: failed to publish appended event (demo mode)",
 				slog.Any("error", pubErr),
 				slog.String("topic", TopicAuditAppended))

--- a/cells/audit-core/slices/auditappend/service.go
+++ b/cells/audit-core/slices/auditappend/service.go
@@ -140,12 +140,8 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
 	// so the eventbus fail-closed schema check (P1-14) accepts the message.
 	if s.outboxWriter == nil {
-		envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicAuditAppended, TopicAuditAppended, outbox.NewEntryID(), appendedPayload)
-		if envErr != nil {
-			s.logger.Warn("audit-append: failed to marshal appended event envelope (demo mode)",
-				slog.Any("error", envErr),
-				slog.String("topic", TopicAuditAppended))
-		} else if pubErr := s.publisher.Publish(ctx, TopicAuditAppended, envelope); pubErr != nil {
+		envelope := outboxrt.MarshalDirectEnvelope(TopicAuditAppended, TopicAuditAppended, outbox.NewEntryID(), appendedPayload)
+		if pubErr := s.publisher.Publish(ctx, TopicAuditAppended, envelope); pubErr != nil {
 			s.logger.Warn("audit-append: failed to publish appended event (demo mode)",
 				slog.Any("error", pubErr),
 				slog.String("topic", TopicAuditAppended))

--- a/cells/audit-core/slices/auditverify/service.go
+++ b/cells/audit-core/slices/auditverify/service.go
@@ -103,12 +103,8 @@ func (s *Service) VerifyChain(ctx context.Context, from, to int) (*VerifyResult,
 	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
 	// so the eventbus fail-closed schema check (P1-14) accepts the message.
 	if s.outboxWriter == nil {
-		envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicIntegrityVerified, TopicIntegrityVerified, outbox.NewEntryID(), payload)
-		if envErr != nil {
-			s.logger.Warn("audit-verify: failed to marshal event envelope (demo mode)",
-				slog.Any("error", envErr),
-				slog.String("topic", TopicIntegrityVerified))
-		} else if pubErr := s.publisher.Publish(ctx, TopicIntegrityVerified, envelope); pubErr != nil {
+		envelope := outboxrt.MarshalDirectEnvelope(TopicIntegrityVerified, TopicIntegrityVerified, outbox.NewEntryID(), payload)
+		if pubErr := s.publisher.Publish(ctx, TopicIntegrityVerified, envelope); pubErr != nil {
 			s.logger.Warn("audit-verify: failed to publish event (demo mode)",
 				slog.Any("error", pubErr),
 				slog.String("topic", TopicIntegrityVerified))

--- a/cells/audit-core/slices/auditverify/service.go
+++ b/cells/audit-core/slices/auditverify/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 )
 
 const (
@@ -99,9 +100,15 @@ func (s *Service) VerifyChain(ctx context.Context, from, to int) (*VerifyResult,
 		return result, fmt.Errorf("audit-verify: persist: %w", persistErr)
 	}
 
-	// Fallback direct publish when outbox is not in use.
+	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
+	// so the eventbus fail-closed schema check (P1-14) accepts the message.
 	if s.outboxWriter == nil {
-		if pubErr := s.publisher.Publish(ctx, TopicIntegrityVerified, payload); pubErr != nil {
+		envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicIntegrityVerified, TopicIntegrityVerified, outbox.NewEntryID(), payload)
+		if envErr != nil {
+			s.logger.Warn("audit-verify: failed to marshal event envelope (demo mode)",
+				slog.Any("error", envErr),
+				slog.String("topic", TopicIntegrityVerified))
+		} else if pubErr := s.publisher.Publish(ctx, TopicIntegrityVerified, envelope); pubErr != nil {
 			s.logger.Warn("audit-verify: failed to publish event (demo mode)",
 				slog.Any("error", pubErr),
 				slog.String("topic", TopicIntegrityVerified))

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -189,10 +189,7 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 	}
 	// Wrap in v1 wire envelope so the eventbus fail-closed schema check (P1-14)
 	// accepts the message.
-	envelope, envErr := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), payload)
-	if envErr != nil {
-		return fmt.Errorf("config-publish: marshal envelope for topic %s: %w", topic, envErr)
-	}
+	envelope := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), payload)
 	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
 		return fmt.Errorf("config-publish: publisher failed for topic %s: %w", topic, err)
 	}

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -186,7 +187,13 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 		}
 		return nil
 	}
-	if err := s.publisher.Publish(ctx, topic, payload); err != nil {
+	// Wrap in v1 wire envelope so the eventbus fail-closed schema check (P1-14)
+	// accepts the message.
+	envelope, envErr := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), payload)
+	if envErr != nil {
+		return fmt.Errorf("config-publish: marshal envelope for topic %s: %w", topic, envErr)
+	}
+	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
 		return fmt.Errorf("config-publish: publisher failed for topic %s: %w", topic, err)
 	}
 	return nil

--- a/cells/config-core/slices/configsubscribe/service.go
+++ b/cells/config-core/slices/configsubscribe/service.go
@@ -73,9 +73,11 @@ func (s *Service) HandleEvent(_ context.Context, entry outbox.Entry) error {
 	if err := json.Unmarshal(entry.Payload, &event); err != nil {
 		s.logger.Error("config-subscribe: failed to unmarshal event, routing to dead letter",
 			slog.Any("error", err), slog.String("entry_id", entry.ID))
-		// Permanent error: return error so ConsumerBase routes to dead letter
-		// after exhausting retries.
-		return fmt.Errorf("config-subscribe: unmarshal payload: %w", err)
+		// Permanent error: malformed payload must not be retried.
+		// WrapLegacyHandler detects PermanentError and returns DispositionReject.
+		//
+		// ref: configreceive/service.go:53 — same pattern
+		return outbox.NewPermanentError(fmt.Errorf("config-subscribe: unmarshal payload: %w", err))
 	}
 
 	switch event.Action {

--- a/cells/config-core/slices/configsubscribe/service.go
+++ b/cells/config-core/slices/configsubscribe/service.go
@@ -78,16 +78,17 @@ func (s *Service) HandleEvent(_ context.Context, entry outbox.Entry) error {
 		return fmt.Errorf("config-subscribe: unmarshal payload: %w", err)
 	}
 
-	s.cache.mu.Lock()
-	defer s.cache.mu.Unlock()
-
 	switch event.Action {
 	case "deleted":
+		s.cache.mu.Lock()
 		delete(s.cache.values, event.Key)
+		s.cache.mu.Unlock()
 		s.logger.Info("config-subscribe: key deleted from cache",
 			slog.String("key", event.Key))
 	case "created", "updated":
+		s.cache.mu.Lock()
 		s.cache.values[event.Key] = event.Value
+		s.cache.mu.Unlock()
 		s.logger.Info("config-subscribe: cache updated",
 			slog.String("key", event.Key), slog.String("action", event.Action))
 	case "published":
@@ -97,8 +98,15 @@ func (s *Service) HandleEvent(_ context.Context, entry outbox.Entry) error {
 		s.logger.Info("config-subscribe: published event (no cache update)",
 			slog.String("key", event.Key))
 	default:
-		s.logger.Warn("config-subscribe: unknown action, skipping",
-			slog.String("key", event.Key), slog.String("action", event.Action))
+		// Fail-closed: unknown actions are permanent errors routed to DLX.
+		// The cache is NOT modified.
+		//
+		// ref: K8s workqueue fail-closed semantics; Watermill Nack on unknown type
+		s.logger.Warn("config-subscribe: unknown action, routing to dead letter",
+			slog.String("action", event.Action), slog.String("key", event.Key))
+		return outbox.NewPermanentError(
+			fmt.Errorf("unknown action %q for key %q", event.Action, event.Key),
+		)
 	}
 
 	return nil

--- a/cells/config-core/slices/configsubscribe/service_test.go
+++ b/cells/config-core/slices/configsubscribe/service_test.go
@@ -73,10 +73,27 @@ func TestService_HandleEvent_InvalidPayload(t *testing.T) {
 	svc := NewService(slog.Default())
 	entry := outbox.Entry{ID: "bad", Payload: []byte("not-json")}
 
-	// Should return error so ConsumerBase routes to dead letter after retries.
+	// Should return PermanentError so WrapLegacyHandler routes to DLX, not retry.
 	err := svc.HandleEvent(context.Background(), entry)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, 0, svc.Cache().Len())
+
+	var permErr *outbox.PermanentError
+	require.ErrorAs(t, err, &permErr, "invalid payload must be PermanentError")
+}
+
+// TestWrapLegacyHandler_InvalidPayload_Reject verifies the full disposition
+// chain: invalid payload → PermanentError → WrapLegacyHandler → DispositionReject.
+func TestWrapLegacyHandler_InvalidPayload_Reject(t *testing.T) {
+	svc := NewService(slog.Default())
+	handler := outbox.WrapLegacyHandler(svc.HandleEvent)
+
+	entry := outbox.Entry{ID: "bad", Payload: []byte("not-json")}
+	result := handler(context.Background(), entry)
+
+	assert.Equal(t, outbox.DispositionReject, result.Disposition,
+		"invalid payload via WrapLegacyHandler must produce DispositionReject")
+	assert.Error(t, result.Err)
 }
 
 // TestHandleEvent_UnknownAction_PermanentError verifies that an unknown action

--- a/cells/config-core/slices/configsubscribe/service_test.go
+++ b/cells/config-core/slices/configsubscribe/service_test.go
@@ -78,3 +78,41 @@ func TestService_HandleEvent_InvalidPayload(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, 0, svc.Cache().Len())
 }
+
+// TestHandleEvent_UnknownAction_PermanentError verifies that an unknown action
+// returns a PermanentError (fail-closed, P1-14 A3). The cache must not be modified.
+func TestHandleEvent_UnknownAction_PermanentError(t *testing.T) {
+	svc := NewService(slog.Default())
+	// Pre-populate cache so we can verify it stays unchanged.
+	_ = svc.HandleEvent(context.Background(), makeEntry("created", "existing.key", "existing-value"))
+
+	entry := makeEntry("bogus", "some.key", "")
+	err := svc.HandleEvent(context.Background(), entry)
+
+	require.Error(t, err, "unknown action must return error")
+
+	// Must be a PermanentError so WrapLegacyHandler routes to DLX, not retry.
+	var permErr *outbox.PermanentError
+	require.ErrorAs(t, err, &permErr, "unknown action must be PermanentError")
+	assert.Contains(t, err.Error(), "bogus", "error message should include the unknown action name")
+
+	// Cache must not be modified.
+	assert.Equal(t, 1, svc.Cache().Len(), "cache must be unchanged after unknown action")
+	v, ok := svc.Cache().Get("existing.key")
+	assert.True(t, ok)
+	assert.Equal(t, "existing-value", v)
+}
+
+// TestHandleEvent_UnknownAction_WrapLegacyHandler_Reject verifies the full
+// disposition chain: unknown action → PermanentError → WrapLegacyHandler → DispositionReject.
+func TestHandleEvent_UnknownAction_WrapLegacyHandler_Reject(t *testing.T) {
+	svc := NewService(slog.Default())
+	handler := outbox.WrapLegacyHandler(svc.HandleEvent)
+
+	entry := makeEntry("bogus", "some.key", "")
+	result := handler(context.Background(), entry)
+
+	assert.Equal(t, outbox.DispositionReject, result.Disposition,
+		"unknown action via WrapLegacyHandler must produce DispositionReject")
+	assert.Error(t, result.Err)
+}

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -196,8 +197,17 @@ func (s *Service) publishChange(ctx context.Context, action string, entry *domai
 		return nil
 	}
 	// Demo mode: publisher failure is logged but not propagated since
-	// demo mode does not guarantee L2 atomicity.
-	if err := s.publisher.Publish(ctx, TopicConfigChanged, payload); err != nil {
+	// demo mode does not guarantee L2 atomicity. Wrap in v1 wire envelope so
+	// the eventbus fail-closed schema check (P1-14) accepts the message.
+	envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicConfigChanged, TopicConfigChanged, outbox.NewEntryID(), payload)
+	if envErr != nil {
+		s.logger.Warn("config-write: failed to marshal event envelope (demo mode)",
+			slog.Any("error", envErr),
+			slog.String("key", entry.Key),
+		)
+		return nil
+	}
+	if err := s.publisher.Publish(ctx, TopicConfigChanged, envelope); err != nil {
 		s.logger.Warn("config-write: failed to publish event (demo mode)",
 			slog.Any("error", err),
 			slog.String("key", entry.Key),

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -199,14 +199,7 @@ func (s *Service) publishChange(ctx context.Context, action string, entry *domai
 	// Demo mode: publisher failure is logged but not propagated since
 	// demo mode does not guarantee L2 atomicity. Wrap in v1 wire envelope so
 	// the eventbus fail-closed schema check (P1-14) accepts the message.
-	envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicConfigChanged, TopicConfigChanged, outbox.NewEntryID(), payload)
-	if envErr != nil {
-		s.logger.Warn("config-write: failed to marshal event envelope (demo mode)",
-			slog.Any("error", envErr),
-			slog.String("key", entry.Key),
-		)
-		return nil
-	}
+	envelope := outboxrt.MarshalDirectEnvelope(TopicConfigChanged, TopicConfigChanged, outbox.NewEntryID(), payload)
 	if err := s.publisher.Publish(ctx, TopicConfigChanged, envelope); err != nil {
 		s.logger.Warn("config-write: failed to publish event (demo mode)",
 			slog.Any("error", err),

--- a/cells/config-core/slices/configwrite/service_test.go
+++ b/cells/config-core/slices/configwrite/service_test.go
@@ -309,3 +309,25 @@ func TestDelete_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, tx.calls, "Delete must call RunInTx exactly once")
 }
+
+// failingPublisher returns an error on every Publish call, used to drive the
+// publisher-error warn-log branch in Service.publishChange (demo mode).
+type failingPublisher struct{ err error }
+
+func (f failingPublisher) Publish(_ context.Context, _ string, _ []byte) error { return f.err }
+
+var _ outbox.Publisher = failingPublisher{}
+
+// TestService_Create_PublishError_DoesNotFailCreate verifies that demo-mode
+// publisher failure in Service.publishChange is logged but does not propagate
+// as an error — covering the warn-log branch introduced when the direct
+// publish path was wrapped in a v1 envelope (P1-14 follow-up).
+func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	fp := failingPublisher{err: errors.New("broker unavailable")}
+	svc := NewService(repo, fp, slog.Default())
+
+	entry, err := svc.Create(context.Background(), CreateInput{Key: "pub-err", Value: "v"})
+	require.NoError(t, err, "publish failure in demo mode must not fail Create")
+	assert.Equal(t, "pub-err", entry.Key)
+}

--- a/cells/device-cell/slices/device-register/contract_test.go
+++ b/cells/device-cell/slices/device-register/contract_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +70,12 @@ func TestEventDeviceRegisteredV1Publish(t *testing.T) {
 	httpContract.ValidateHTTPResponseRecorder(t, rec)
 
 	require.Len(t, pub.calls, 1, "Register must publish one event")
-	c.ValidatePayload(t, pub.calls[0].payload)
+	// The cell wraps the business payload in a v1 wire envelope before publishing
+	// so the eventbus fail-closed schema check (P1-14) accepts the message.
+	// Unwrap here to validate against the business-payload contract schema.
+	entry, err := outboxrt.UnmarshalEnvelope(pub.calls[0].topic, pub.calls[0].payload)
+	require.NoError(t, err, "published payload must be a valid v1 envelope")
+	c.ValidatePayload(t, entry.Payload)
 	c.MustRejectPayload(t, []byte(`{"id":"d-1"}`))
 	// Headers validation skipped: device-cell uses publisher.Publish directly
 	// (L4, no outbox.Entry per KG-07), so event_id is not emitted at transport level.

--- a/cells/device-cell/slices/device-register/service.go
+++ b/cells/device-cell/slices/device-register/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -67,13 +68,23 @@ func (s *Service) Register(ctx context.Context, name string) (*domain.Device, er
 	}
 
 	// L4 Cell uses publisher.Publish directly (no outboxWriter per KG-07).
+	// Payload is wrapped in a v1 wire envelope so the eventbus fail-closed
+	// schema check (P1-14) accepts the message.
 	payload, err := json.Marshal(toDeviceRegisteredEvent(device))
 	if err != nil {
 		s.logger.Error("device-register: marshal event failed", slog.Any("error", err))
 		return device, nil
 	}
+	envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicDeviceRegistered, TopicDeviceRegistered, outbox.NewEntryID(), payload)
+	if envErr != nil {
+		s.logger.Error("device-register: marshal envelope failed",
+			slog.String("device_id", device.ID),
+			slog.Any("error", envErr),
+		)
+		return device, nil
+	}
 
-	if err := s.publisher.Publish(ctx, TopicDeviceRegistered, payload); err != nil {
+	if err := s.publisher.Publish(ctx, TopicDeviceRegistered, envelope); err != nil {
 		s.logger.Error("device-register: publish event failed",
 			slog.String("device_id", device.ID),
 			slog.Any("error", err),

--- a/cells/device-cell/slices/device-register/service.go
+++ b/cells/device-cell/slices/device-register/service.go
@@ -75,14 +75,7 @@ func (s *Service) Register(ctx context.Context, name string) (*domain.Device, er
 		s.logger.Error("device-register: marshal event failed", slog.Any("error", err))
 		return device, nil
 	}
-	envelope, envErr := outboxrt.MarshalDirectEnvelope(TopicDeviceRegistered, TopicDeviceRegistered, outbox.NewEntryID(), payload)
-	if envErr != nil {
-		s.logger.Error("device-register: marshal envelope failed",
-			slog.String("device_id", device.ID),
-			slog.Any("error", envErr),
-		)
-		return device, nil
-	}
+	envelope := outboxrt.MarshalDirectEnvelope(TopicDeviceRegistered, TopicDeviceRegistered, outbox.NewEntryID(), payload)
 
 	if err := s.publisher.Publish(ctx, TopicDeviceRegistered, envelope); err != nil {
 		s.logger.Error("device-register: publish event failed",

--- a/cmd/core-bundle/outbox_wiring_test.go
+++ b/cmd/core-bundle/outbox_wiring_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/eventbus"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -240,9 +241,19 @@ func TestOutboxE2E_CrossCellFanout(t *testing.T) {
 		t.Fatal("timed out waiting for audit-core subscription to be ready")
 	}
 
-	// Publish exactly 1 event.
-	payload := []byte(`{"action":"fanout_test","key":"cross-cg","value":"ok"}`)
-	require.NoError(t, eb.Publish(ctx, topic, payload))
+	// Publish exactly 1 event wrapped in a v1 envelope so the bus envelope
+	// schema check (fail-closed, P1-14 A1/A2) accepts it.
+	entry := outboxrt.ClaimedEntry{
+		Entry: outbox.Entry{
+			ID:        "e2e-fanout-1",
+			EventType: topic,
+			Topic:     topic,
+			Payload:   []byte(`{"action":"fanout_test","key":"cross-cg","value":"ok"}`),
+		},
+	}
+	envelope, err := outboxrt.MarshalEnvelope(entry)
+	require.NoError(t, err, "MarshalEnvelope must not fail")
+	require.NoError(t, eb.Publish(ctx, topic, envelope))
 
 	// Assert both handlers are called exactly once.
 	// Before the Subscription-first-class refactor (Commit 1), the shared

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -201,7 +201,7 @@ func testPublishSubscribeInOrder(t *testing.T, features Features, constructor Pu
 	c := startCollecting(t, ctx, sub, topic, n)
 
 	for i := range n {
-		assertNoError(t, pub.Publish(ctx, topic, testPayload(i)))
+		assertNoError(t, pub.Publish(ctx, topic, wrapV1Envelope(t, topic, testPayload(i))))
 	}
 
 	collected := c.waitAndGet(defaultTimeout)
@@ -253,8 +253,8 @@ func testTopicIsolation(t *testing.T, _ Features, constructor PubSubConstructor)
 	waitForSubscription(t, ctx, sub, topicA, "")
 
 	// Publish to both topics.
-	assertNoError(t, pub.Publish(ctx, topicB, []byte(`{"topic":"B"}`)))
-	assertNoError(t, pub.Publish(ctx, topicA, []byte(`{"topic":"A"}`)))
+	assertNoError(t, pub.Publish(ctx, topicB, wrapV1Envelope(t, topicB, []byte(`{"topic":"B"}`))))
+	assertNoError(t, pub.Publish(ctx, topicA, wrapV1Envelope(t, topicA, []byte(`{"topic":"A"}`))))
 
 	select {
 	case <-doneA:
@@ -334,7 +334,7 @@ func testMultipleSubscribers(t *testing.T, _ Features, constructor PubSubConstru
 	// (BroadcastSubscribe=false → testCompetingConsumers).
 	time.Sleep(subscribeInitDelay)
 
-	assertNoError(t, pub.Publish(ctx, topic, []byte(`{"test":"fan-out"}`)))
+	assertNoError(t, pub.Publish(ctx, topic, wrapV1Envelope(t, topic, []byte(`{"test":"fan-out"}`))))
 
 	// Wait for both subscribers to receive.
 	assertEventually(t, func() bool {
@@ -388,7 +388,7 @@ func testCompetingConsumers(t *testing.T, _ Features, constructor PubSubConstruc
 	waitForSubscription(t, ctx, sub, topic, "")
 
 	// Publish one message.
-	assertNoError(t, pub.Publish(ctx, topic, []byte(`{"test":"competing"}`)))
+	assertNoError(t, pub.Publish(ctx, topic, wrapV1Envelope(t, topic, []byte(`{"test":"competing"}`))))
 
 	// Wait for exactly one delivery (bounded — if nothing arrives within
 	// defaultTimeout the test fails fast rather than hanging until the global
@@ -776,7 +776,7 @@ func testPublishAfterClose(t *testing.T, constructor PubSubConstructor) {
 
 	// Publishing after close should not panic.
 	assertNotPanics(t, func() {
-		_ = pub.Publish(context.Background(), "any-topic", []byte(`{}`))
+		_ = pub.Publish(context.Background(), "any-topic", wrapV1Envelope(t, "any-topic", []byte(`{}`)))
 	})
 }
 
@@ -803,7 +803,7 @@ func testConcurrentPublish(t *testing.T, features Features, constructor PubSubCo
 		wg.Add(1)
 		go func(seq int) {
 			defer wg.Done()
-			if err := pub.Publish(ctx, topic, testPayload(seq)); err != nil {
+			if err := pub.Publish(ctx, topic, wrapV1Envelope(t, topic, testPayload(seq))); err != nil {
 				pubMu.Lock()
 				pubErrs = append(pubErrs, err)
 				pubMu.Unlock()

--- a/kernel/outbox/outboxtest/helpers.go
+++ b/kernel/outbox/outboxtest/helpers.go
@@ -79,13 +79,16 @@ func testPayload(seq int) []byte {
 }
 
 // PublishN publishes n messages to the given topic and returns the entries published.
+// Messages are wrapped in v1 wire envelopes so relay-aware implementations
+// (e.g. InMemoryEventBus after P1-14) can receive them. Subscribers receive
+// the unwrapped business payload.
 func PublishN(t *testing.T, ctx context.Context, pub outbox.Publisher, topic string, n int) []outbox.Entry {
 	t.Helper()
 	entries := make([]outbox.Entry, 0, n)
 	for i := range n {
 		payload := testPayload(i)
 		entry := NewEntry(topic, payload)
-		if err := pub.Publish(ctx, topic, payload); err != nil {
+		if err := pub.Publish(ctx, topic, wrapV1Envelope(t, topic, payload)); err != nil {
 			t.Fatalf("publish message %d: %v", i, err)
 		}
 		entries = append(entries, entry)
@@ -326,15 +329,54 @@ func (h *pubSubHarness) subscribe(handler outbox.EntryHandler) {
 	waitForSubscription(h.T, ctx, h.Sub, h.Topic, "")
 }
 
-// publishAndWait publishes payload and blocks until signalDone or timeout.
+// publishAndWait wraps payload in a v1 wire envelope and publishes it, then
+// blocks until signalDone or timeout. Wrapping is required because relay-aware
+// implementations (e.g. InMemoryEventBus after P1-14) reject non-v1 payloads
+// at the consumer entry point — they dead-letter the message instead of
+// delivering it to subscribers.
 func (h *pubSubHarness) publishAndWait(payload []byte) {
 	h.T.Helper()
-	assertNoError(h.T, h.Pub.Publish(context.Background(), h.Topic, payload))
+	assertNoError(h.T, h.Pub.Publish(context.Background(), h.Topic, wrapV1Envelope(h.T, h.Topic, payload)))
 	select {
 	case <-h.done:
 	case <-time.After(defaultTimeout):
 		h.T.Fatal("timed out")
 	}
+}
+
+// wrapV1Envelope constructs a minimal v1 wire envelope JSON for the given topic
+// and business payload. Used by conformance helpers so implementations that
+// enforce schemaVersion:"v1" (e.g. InMemoryEventBus after P1-14) can receive
+// test messages. The subscriber will receive the unwrapped business payload.
+//
+// Constructed manually to avoid importing runtime/outbox from the kernel layer.
+func wrapV1Envelope(t testing.TB, topic string, payload []byte) []byte {
+	t.Helper()
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	id := "conf-" + hex.EncodeToString(b)
+
+	type wireMsg struct {
+		SchemaVersion string          `json:"schemaVersion"`
+		ID            string          `json:"id"`
+		EventType     string          `json:"eventType"`
+		Topic         string          `json:"topic"`
+		Payload       json.RawMessage `json:"payload"`
+		CreatedAt     string          `json:"createdAt"`
+	}
+	msg := wireMsg{
+		SchemaVersion: "v1",
+		ID:            id,
+		EventType:     topic,
+		Topic:         topic,
+		Payload:       json.RawMessage(payload),
+		CreatedAt:     "2024-01-01T00:00:00Z",
+	}
+	out, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("wrapV1Envelope: %v", err)
+	}
+	return out
 }
 
 // signalDone closes the done channel (safe for concurrent calls via sync.Once).

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -128,6 +128,12 @@ const (
 	ErrWSHubStopping    Code = "ERR_WS_HUB_STOPPING"
 	ErrWSHubNotRunning  Code = "ERR_WS_HUB_NOT_RUNNING"
 	ErrWSMaxConns       Code = "ERR_WS_MAX_CONNS"
+
+	// Outbox envelope error codes.
+	// ErrEnvelopeSchema signals that an inbound wire message does not conform
+	// to the expected envelope schema — unknown schemaVersion, missing required
+	// fields, or corrupt JSON. Consumers must Reject (not retry) on this error.
+	ErrEnvelopeSchema Code = "ERR_ENVELOPE_SCHEMA"
 )
 
 // Error is a structured error that carries a machine-readable Code, a

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -249,6 +249,7 @@ var codeToStatus = map[errcode.Code]int{
 	errcode.ErrZeroTestMatch:      http.StatusNotFound,
 
 	// --- 400 Bad Request ---
+	errcode.ErrEnvelopeSchema:            http.StatusBadRequest,
 	errcode.ErrCursorInvalid:             http.StatusBadRequest,
 	errcode.ErrPageSizeExceeded:          http.StatusBadRequest,
 	errcode.ErrValidationFailed:          http.StatusBadRequest,

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -104,6 +104,11 @@ func New(opts ...Option) *InMemoryEventBus {
 
 // Publish sends payload to subscribers of the given topic.
 //
+// Contract (P1-14 follow-up): payload MUST be a v1 wire envelope (produced by
+// outbox.MarshalEnvelope for relay-driven paths, or outbox.MarshalDirectEnvelope
+// for direct-publish paths such as demo-mode L2 cells and L4 cells without
+// outbox writer). Raw business payloads are rejected fail-closed.
+//
 // ConsumerGroup dispatch:
 //   - For each named consumer group: pick ONE subscriber via round-robin
 //   - For the empty-group ("") bucket: send to ALL subscribers (broadcast)
@@ -111,17 +116,19 @@ func New(opts ...Option) *InMemoryEventBus {
 // Non-blocking: if a subscriber's buffer is full, the message is dropped
 // (logged as warning).
 //
-// Envelope handling: when Publish is invoked by an outbox relay, payload is
-// a JSON-encoded wire envelope (outbox.WireEnvelope) wrapping the business
-// payload. The bus unwraps it so subscribers always see the business payload
+// The bus unwraps the envelope so subscribers always see the business payload
 // in Entry.Payload, matching the semantics of the RabbitMQ subscriber path.
-// Non-envelope payloads (direct publish from cells) are forwarded unchanged.
 //
-// Regression guard: before this unwrap, the PG mode (relay → in-memory bus)
-// silently delivered the envelope as-is; subscribers parsed the envelope
-// fields as business fields (empty Action, etc.) and ACKed unknown-action
-// events, causing complete event loss. Kept symmetric with
-// adapters/rabbitmq.unmarshalDelivery.
+// Regression guard: before this contract, demo-mode and L4 direct publishes
+// sent raw business bytes; with envelope enforcement added in P1-14 A1/A2 such
+// bytes were silently dead-lettered + nil returned, causing complete event
+// loss (symptom: sso-bff walkthrough audit-entries assertion fails because
+// audit-core never received session.created / user.created events). Returning
+// an explicit error makes producer-side contract violations loud instead of
+// silent; the dead-letter slice is retained as a diagnostic trail.
+//
+// ref: Watermill poison-queue middleware — undecodable messages → DLX,
+// main route cleared; K8s workqueue fail-closed semantics.
 func (b *InMemoryEventBus) Publish(_ context.Context, topic string, payload []byte) error {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -132,18 +139,11 @@ func (b *InMemoryEventBus) Publish(_ context.Context, topic string, payload []by
 
 	entry, unmarshalErr := unmarshalInboundEntry(topic, payload)
 	if unmarshalErr != nil {
-		// Fail-closed: invalid/non-v1 envelopes are routed to dead letter and
-		// never delivered to subscribers. Return nil so the caller (relay) does
-		// not treat this as a transport error — the message has been permanently
-		// disposed of via dead letter.
-		//
-		// ref: Watermill poison-queue middleware — undecodable messages → DLX,
-		//      main route cleared; K8s workqueue fail-closed semantics
-		slog.Warn("eventbus: dropping invalid envelope, routing to dead letter",
+		slog.Warn("eventbus: rejecting invalid envelope, routing to dead letter",
 			slog.String("topic", topic),
 			slog.String("error", unmarshalErr.Error()))
 		b.appendDeadLetter(topic, outbox.Entry{Topic: topic}, unmarshalErr)
-		return nil
+		return unmarshalErr
 	}
 
 	for group, gs := range b.groupSubs[topic] {

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -130,18 +130,20 @@ func (b *InMemoryEventBus) Publish(_ context.Context, topic string, payload []by
 		return errcode.New(errcode.ErrBusClosed, "eventbus: bus is closed")
 	}
 
-	entry := unmarshalInboundEntry(topic, payload)
-
-	// Defense-in-depth: reject malformed entries at the consumer entry, before
-	// any subscriber sees them. Mirrors adapters/rabbitmq.processDelivery —
-	// production senders satisfy these invariants, but a tampered payload or
-	// adapter regression must not propagate to handlers.
-	if err := entry.Validate(); err != nil {
-		slog.Warn("eventbus: dropping invalid entry at consumer entry",
+	entry, unmarshalErr := unmarshalInboundEntry(topic, payload)
+	if unmarshalErr != nil {
+		// Fail-closed: invalid/non-v1 envelopes are routed to dead letter and
+		// never delivered to subscribers. Return nil so the caller (relay) does
+		// not treat this as a transport error — the message has been permanently
+		// disposed of via dead letter.
+		//
+		// ref: Watermill poison-queue middleware — undecodable messages → DLX,
+		//      main route cleared; K8s workqueue fail-closed semantics
+		slog.Warn("eventbus: dropping invalid envelope, routing to dead letter",
 			slog.String("topic", topic),
-			slog.String("entry_id", entry.ID),
-			slog.String("error", err.Error()))
-		return errcode.Wrap(errcode.ErrValidationFailed, "eventbus: invalid inbound entry", err)
+			slog.String("error", unmarshalErr.Error()))
+		b.appendDeadLetter(topic, outbox.Entry{Topic: topic}, unmarshalErr)
+		return nil
 	}
 
 	for group, gs := range b.groupSubs[topic] {
@@ -551,10 +553,14 @@ func releaseReceipt(ctx context.Context, r outbox.Receipt, topic, entryID string
 // Wire envelope unwrap
 // ---------------------------------------------------------------------------
 
-// unmarshalInboundEntry constructs an outbox.Entry for delivery to subscribers.
-// Delegates to outboxrt.UnmarshalEnvelope which handles both relay wire envelopes
-// and the raw-payload fallback (direct-publish semantics).
-func unmarshalInboundEntry(topic string, payload []byte) outbox.Entry {
-	entry, _ := outboxrt.UnmarshalEnvelope(topic, payload)
-	return entry
+// unmarshalInboundEntry decodes a v1 wire envelope from payload into an outbox.Entry.
+// Returns (entry, nil) on success, or (zero, error) when the payload is not a
+// valid v1 envelope (missing/wrong schemaVersion, broken JSON, missing required fields).
+//
+// Callers must treat a non-nil error as a permanent failure and route to dead
+// letter without delivering to subscribers.
+//
+// ref: Watermill message/router.go handleMessage — handler error → Nack, no skip
+func unmarshalInboundEntry(topic string, payload []byte) (outbox.Entry, error) {
+	return outboxrt.UnmarshalEnvelope(topic, payload)
 }

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -2,6 +2,7 @@ package eventbus
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -10,9 +11,36 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
+	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// makeTestEnvelope wraps payload bytes in a valid v1 wire envelope for topic.
+// All test Publish calls must use this helper to satisfy the fail-closed
+// envelope schema check introduced in P1-14 (A1/A2).
+func makeTestEnvelope(t testing.TB, topic string, payload []byte, id string) []byte {
+	t.Helper()
+	entry := outboxrt.ClaimedEntry{
+		Entry: outbox.Entry{
+			ID:        id,
+			EventType: topic,
+			Topic:     topic,
+			Payload:   payload,
+		},
+	}
+	b, err := outboxrt.MarshalEnvelope(entry)
+	if err != nil {
+		t.Fatalf("makeTestEnvelope: %v", err)
+	}
+	return b
+}
+
+// makeSimpleEnvelope wraps payload in a v1 envelope with a fixed test ID.
+func makeSimpleEnvelope(t testing.TB, topic string) []byte {
+	t.Helper()
+	return makeTestEnvelope(t, topic, json.RawMessage(`{"test":true}`), "test-id-"+topic)
+}
 
 // TestPublish_EnvelopePayload_UnwrappedBeforeDelivery guards the F1 fix:
 // when a relay publishes an outboxMessage envelope (JSON object with id,
@@ -45,7 +73,9 @@ func TestPublish_EnvelopePayload_UnwrappedBeforeDelivery(t *testing.T) {
 
 	// Envelope wrapping a business payload (action/key/value), mirroring the
 	// shape produced by adapters/postgres/outbox_relay.go publishAll.
+	// schemaVersion:"v1" is required since P1-14 A1 (fail-closed envelope schema).
 	envelope := []byte(`{
+		"schemaVersion": "v1",
 		"id": "ent-123",
 		"aggregateId": "agg-1",
 		"aggregateType": "config",
@@ -79,49 +109,46 @@ func TestPublish_EnvelopePayload_UnwrappedBeforeDelivery(t *testing.T) {
 	assert.Equal(t, map[string]string{"request_id": "req-42"}, got.Metadata)
 }
 
-// TestPublish_NonEnvelopePayload_ForwardedUnchanged documents the fallback:
-// direct publish paths (cells calling bus.Publish with a business payload)
-// keep their pre-F1 semantics — the bus stamps an evt-{uuid} ID and forwards
-// the payload byte-for-byte.
-func TestPublish_NonEnvelopePayload_ForwardedUnchanged(t *testing.T) {
+// TestPublish_InvalidEnvelope_Dropped verifies fail-closed semantics (P1-14 A2):
+// when Publish receives a payload that is not a valid v1 envelope, the message
+// is routed to dead letter and NO subscriber handler is invoked.
+//
+// ref: Watermill poison-queue middleware — undecodable → DLX, main route cleared
+func TestPublish_InvalidEnvelope_Dropped(t *testing.T) {
 	bus := New(WithBufferSize(16))
 	defer func() { _ = bus.Close() }()
 
-	var got outbox.Entry
-	var mu sync.Mutex
+	var handlerCalled atomic.Bool
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "test.direct.topic"},
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "test.invalid.topic"},
 			func(_ context.Context, e outbox.Entry) outbox.HandleResult {
-				mu.Lock()
-				got = e
-				mu.Unlock()
+				handlerCalled.Store(true)
 				return outbox.HandleResult{Disposition: outbox.DispositionAck}
 			})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
 
-	// Business payload without id/eventType — must NOT be treated as envelope.
-	direct := []byte(`{"action":"updated","key":"k2","value":"v2"}`)
-	require.NoError(t, bus.Publish(context.Background(), "test.direct.topic", direct))
+	// Non-v1 payload: missing schemaVersion — must be dead-lettered, not delivered.
+	nonEnvelope := []byte(`{"action":"updated","key":"k2","value":"v2"}`)
+	require.NoError(t, bus.Publish(context.Background(), "test.invalid.topic", nonEnvelope))
 
-	assert.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return got.ID != ""
-	}, time.Second, 10*time.Millisecond)
+	// Dead letter should record the dropped message.
+	require.Eventually(t, func() bool {
+		return bus.DeadLetterLen() > 0
+	}, time.Second, 5*time.Millisecond, "invalid envelope must be routed to dead letter")
+
+	assert.False(t, handlerCalled.Load(), "subscriber handler must not be called for invalid envelope")
+
+	dl := bus.DrainDeadLetters()
+	require.Len(t, dl, 1)
+	assert.Equal(t, "test.invalid.topic", dl[0].Topic)
 
 	cancel()
 	<-done
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Equal(t, direct, got.Payload, "non-envelope payload must be forwarded unchanged")
-	assert.Contains(t, got.ID, "evt-", "bus stamps evt-{uuid} id for direct publish")
-	assert.Equal(t, "test.direct.topic", got.EventType, "event type defaults to topic for direct publish")
 }
 
 func TestPublishSubscribe(t *testing.T) {
@@ -145,10 +172,12 @@ func TestPublishSubscribe(t *testing.T) {
 	// Give subscriber time to register.
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "test.topic", []byte(`{"key":"value"}`))
+	msg1 := makeTestEnvelope(t, "test.topic", []byte(`{"key":"value"}`), "msg-1")
+	err := bus.Publish(context.Background(), "test.topic", msg1)
 	require.NoError(t, err)
 
-	err = bus.Publish(context.Background(), "test.topic", []byte(`{"key":"value2"}`))
+	msg2 := makeTestEnvelope(t, "test.topic", []byte(`{"key":"value2"}`), "msg-2")
+	err = bus.Publish(context.Background(), "test.topic", msg2)
 	require.NoError(t, err)
 
 	// Wait for processing.
@@ -172,7 +201,7 @@ func TestPublish_NoSubscribers(t *testing.T) {
 	bus := New()
 	defer func() { _ = bus.Close() }()
 
-	err := bus.Publish(context.Background(), "no.subs", []byte("data"))
+	err := bus.Publish(context.Background(), "no.subs", makeSimpleEnvelope(t, "no.subs"))
 	assert.NoError(t, err)
 }
 
@@ -194,7 +223,7 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "retry.topic", []byte("fail"))
+	err := bus.Publish(context.Background(), "retry.topic", makeSimpleEnvelope(t, "retry.topic"))
 	require.NoError(t, err)
 
 	// Wait for all retries to complete (3 attempts with delays: 100+200+400 = 700ms).
@@ -237,7 +266,7 @@ func TestSubscribe_RejectGoesDirectlyToDeadLetter(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "reject.topic", []byte("perm-fail"))
+	err := bus.Publish(context.Background(), "reject.topic", makeSimpleEnvelope(t, "reject.topic"))
 	require.NoError(t, err)
 
 	// Should go directly to dead letter on first attempt (no retries).
@@ -277,7 +306,7 @@ func TestSubscribe_PermanentErrorInRequeue_RoutesToDeadLetter(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "perm.requeue", []byte("bad-payload"))
+	err := bus.Publish(context.Background(), "perm.requeue", makeSimpleEnvelope(t, "perm.requeue"))
 	require.NoError(t, err)
 
 	// Should go directly to dead letter on first attempt (no retries).
@@ -353,7 +382,7 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 				// below only needs proof that at least one publisher is actively
 				// calling Publish before we race Close against them.
 				publishStarted.CompareAndSwap(0, 1)
-				_ = bus.Publish(context.Background(), "race.topic", []byte("payload"))
+				_ = bus.Publish(context.Background(), "race.topic", makeSimpleEnvelope(t, "race.topic"))
 			}
 		}(i)
 	}
@@ -411,7 +440,7 @@ func TestMultipleSubscribers(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "multi.topic", []byte("hello"))
+	err := bus.Publish(context.Background(), "multi.topic", makeSimpleEnvelope(t, "multi.topic"))
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
@@ -442,7 +471,7 @@ func TestSubscribe_SuccessAfterRetry(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "partial.fail", []byte("data"))
+	err := bus.Publish(context.Background(), "partial.fail", makeSimpleEnvelope(t, "partial.fail"))
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
@@ -547,7 +576,7 @@ func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "receipt.ack", []byte("data"))
+	err := bus.Publish(context.Background(), "receipt.ack", makeSimpleEnvelope(t, "receipt.ack"))
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
@@ -580,7 +609,7 @@ func TestSubscribe_ReceiptReleasedOnReject(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "receipt.reject", []byte("data"))
+	err := bus.Publish(context.Background(), "receipt.reject", makeSimpleEnvelope(t, "receipt.reject"))
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
@@ -618,7 +647,7 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "receipt.requeue", []byte("data"))
+	err := bus.Publish(context.Background(), "receipt.requeue", makeSimpleEnvelope(t, "receipt.requeue"))
 	require.NoError(t, err)
 
 	// Wait for all retries to exhaust.
@@ -669,7 +698,7 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "receipt.exhaust", []byte("exhaust-data"))
+	err := bus.Publish(context.Background(), "receipt.exhaust", makeSimpleEnvelope(t, "receipt.exhaust"))
 	require.NoError(t, err)
 
 	// Wait for retries to exhaust and message to land in dead letter.
@@ -725,7 +754,7 @@ func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	start := time.Now()
-	err := bus.Publish(context.Background(), "zero.disp", []byte("data"))
+	err := bus.Publish(context.Background(), "zero.disp", makeSimpleEnvelope(t, "zero.disp"))
 	require.NoError(t, err)
 
 	// Should exhaust retries and land in dead letter.
@@ -783,7 +812,7 @@ func TestSubscribe_UnknownDisposition_TreatedAsRequeue(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	start := time.Now()
-	err := bus.Publish(context.Background(), "unknown.disp", []byte("data"))
+	err := bus.Publish(context.Background(), "unknown.disp", makeSimpleEnvelope(t, "unknown.disp"))
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
@@ -830,7 +859,7 @@ func TestSubscribe_InvalidDisposition_RespectsCtxCancel(t *testing.T) {
 
 	time.Sleep(20 * time.Millisecond)
 
-	err := bus.Publish(context.Background(), "cancel.disp", []byte("data"))
+	err := bus.Publish(context.Background(), "cancel.disp", makeSimpleEnvelope(t, "cancel.disp"))
 	require.NoError(t, err)
 
 	// Subscribe should return promptly after cancel.
@@ -886,8 +915,9 @@ func TestConsumerGroup_SameGroup_CompetingConsumption(t *testing.T) {
 
 	// Publish 10 messages.
 	n := 10
-	for range n {
-		require.NoError(t, bus.Publish(ctx, "session.created", []byte(`{"event":"test"}`)))
+	for i := range n {
+		env := makeTestEnvelope(t, "session.created", []byte(`{"event":"test"}`), fmt.Sprintf("cg-same-msg-%d", i))
+		require.NoError(t, bus.Publish(ctx, "session.created", env))
 	}
 
 	// Wait for all messages to be handled.
@@ -941,8 +971,9 @@ func TestConsumerGroup_DifferentGroups_Fanout(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	n := 5
-	for range n {
-		require.NoError(t, bus.Publish(ctx, "session.created", []byte(`{"event":"test"}`)))
+	for i := range n {
+		env := makeTestEnvelope(t, "session.created", []byte(`{"event":"test"}`), fmt.Sprintf("cg-diff-msg-%d", i))
+		require.NoError(t, bus.Publish(ctx, "session.created", env))
 	}
 
 	require.Eventually(t, func() bool {
@@ -992,8 +1023,9 @@ func TestConsumerGroup_EmptyGroup_BackwardCompatible(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	n := 5
-	for range n {
-		require.NoError(t, bus.Publish(ctx, "events.v1", []byte(`{"event":"test"}`)))
+	for i := range n {
+		env := makeTestEnvelope(t, "events.v1", []byte(`{"event":"test"}`), fmt.Sprintf("cg-empty-msg-%d", i))
+		require.NoError(t, bus.Publish(ctx, "events.v1", env))
 	}
 
 	require.Eventually(t, func() bool {
@@ -1039,15 +1071,21 @@ func TestConsumerGroup_ConcurrentPublish_NoRace(t *testing.T) {
 	time.Sleep(20 * time.Millisecond) // let subscriptions register
 
 	// Concurrent publishers hammering the same topic+group.
+	// Use shared counter for unique envelope IDs across goroutines.
 	const numPublishers = 8
 	const msgsPerPublisher = 50
-	var pubWg sync.WaitGroup
+	var (
+		pubWg  sync.WaitGroup
+		msgSeq atomic.Int64
+	)
 	pubWg.Add(numPublishers)
 	for range numPublishers {
 		go func() {
 			defer pubWg.Done()
 			for range msgsPerPublisher {
-				_ = bus.Publish(ctx, "race.topic", []byte(`{"race":"test"}`))
+				id := fmt.Sprintf("race-msg-%d", msgSeq.Add(1))
+				env := makeTestEnvelope(t, "race.topic", []byte(`{"race":"test"}`), id)
+				_ = bus.Publish(ctx, "race.topic", env)
 			}
 		}()
 	}

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,12 +110,14 @@ func TestPublish_EnvelopePayload_UnwrappedBeforeDelivery(t *testing.T) {
 	assert.Equal(t, map[string]string{"request_id": "req-42"}, got.Metadata)
 }
 
-// TestPublish_InvalidEnvelope_Dropped verifies fail-closed semantics (P1-14 A2):
-// when Publish receives a payload that is not a valid v1 envelope, the message
-// is routed to dead letter and NO subscriber handler is invoked.
+// TestPublish_InvalidEnvelope_Rejected verifies the P1-14 follow-up
+// fail-closed contract: Publish returns an ErrEnvelopeSchema error AND routes
+// the payload to dead letter. NO subscriber handler is invoked. Returning the
+// error (rather than nil) makes producer-side contract violations loud so they
+// surface in tests and CI rather than leaking out as silent event loss.
 //
 // ref: Watermill poison-queue middleware — undecodable → DLX, main route cleared
-func TestPublish_InvalidEnvelope_Dropped(t *testing.T) {
+func TestPublish_InvalidEnvelope_Rejected(t *testing.T) {
 	bus := New(WithBufferSize(16))
 	defer func() { _ = bus.Close() }()
 
@@ -124,7 +127,7 @@ func TestPublish_InvalidEnvelope_Dropped(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "test.invalid.topic"},
-			func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+			func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 				handlerCalled.Store(true)
 				return outbox.HandleResult{Disposition: outbox.DispositionAck}
 			})
@@ -132,11 +135,16 @@ func TestPublish_InvalidEnvelope_Dropped(t *testing.T) {
 
 	<-bus.Ready(outbox.Subscription{Topic: "test.invalid.topic"})
 
-	// Non-v1 payload: missing schemaVersion — must be dead-lettered, not delivered.
+	// Non-v1 payload: missing schemaVersion — must return ErrEnvelopeSchema
+	// AND be recorded in dead letter, not delivered.
 	nonEnvelope := []byte(`{"action":"updated","key":"k2","value":"v2"}`)
-	require.NoError(t, bus.Publish(context.Background(), "test.invalid.topic", nonEnvelope))
+	err := bus.Publish(context.Background(), "test.invalid.topic", nonEnvelope)
+	require.Error(t, err, "Publish must return an error for non-v1 payload")
+	var ce *errcode.Error
+	require.True(t, errors.As(err, &ce), "error must be *errcode.Error")
+	require.Equal(t, errcode.ErrEnvelopeSchema, ce.Code)
 
-	// Dead letter should record the dropped message.
+	// Dead letter should also record the dropped message for diagnostics.
 	require.Eventually(t, func() bool {
 		return bus.DeadLetterLen() > 0
 	}, time.Second, 5*time.Millisecond, "invalid envelope must be routed to dead letter")

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -69,7 +69,7 @@ func TestPublish_EnvelopePayload_UnwrappedBeforeDelivery(t *testing.T) {
 			})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "test.envelope.topic"})
 
 	// Envelope wrapping a business payload (action/key/value), mirroring the
 	// shape produced by adapters/postgres/outbox_relay.go publishAll.
@@ -130,7 +130,7 @@ func TestPublish_InvalidEnvelope_Dropped(t *testing.T) {
 			})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "test.invalid.topic"})
 
 	// Non-v1 payload: missing schemaVersion — must be dead-lettered, not delivered.
 	nonEnvelope := []byte(`{"action":"updated","key":"k2","value":"v2"}`)
@@ -169,8 +169,8 @@ func TestPublishSubscribe(t *testing.T) {
 		})
 	}()
 
-	// Give subscriber time to register.
-	time.Sleep(20 * time.Millisecond)
+	// Wait for subscriber to register.
+	<-bus.Ready(outbox.Subscription{Topic: "test.topic"})
 
 	msg1 := makeTestEnvelope(t, "test.topic", []byte(`{"key":"value"}`), "msg-1")
 	err := bus.Publish(context.Background(), "test.topic", msg1)
@@ -221,7 +221,7 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "retry.topic"})
 
 	err := bus.Publish(context.Background(), "retry.topic", makeSimpleEnvelope(t, "retry.topic"))
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestSubscribe_RejectGoesDirectlyToDeadLetter(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "reject.topic"})
 
 	err := bus.Publish(context.Background(), "reject.topic", makeSimpleEnvelope(t, "reject.topic"))
 	require.NoError(t, err)
@@ -304,7 +304,7 @@ func TestSubscribe_PermanentErrorInRequeue_RoutesToDeadLetter(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "perm.requeue"})
 
 	err := bus.Publish(context.Background(), "perm.requeue", makeSimpleEnvelope(t, "perm.requeue"))
 	require.NoError(t, err)
@@ -438,7 +438,13 @@ func TestMultipleSubscribers(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	// Wait for both broadcast subscribers to be registered before publishing.
+	require.Eventually(t, func() bool {
+		bus.mu.RLock()
+		defer bus.mu.RUnlock()
+		gs := bus.groupSubs["multi.topic"][""]
+		return gs != nil && len(gs.subs) == 2
+	}, time.Second, 5*time.Millisecond)
 
 	err := bus.Publish(context.Background(), "multi.topic", makeSimpleEnvelope(t, "multi.topic"))
 	require.NoError(t, err)
@@ -469,7 +475,7 @@ func TestSubscribe_SuccessAfterRetry(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "partial.fail"})
 
 	err := bus.Publish(context.Background(), "partial.fail", makeSimpleEnvelope(t, "partial.fail"))
 	require.NoError(t, err)
@@ -479,8 +485,7 @@ func TestSubscribe_SuccessAfterRetry(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond)
 
 	// Should NOT be in dead letter (succeeded on 3rd attempt).
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 0, bus.DeadLetterLen())
+	assert.Equal(t, 0, bus.DeadLetterLen(), "message must not land in dead letter after successful retry")
 
 	cancel()
 	<-done
@@ -511,7 +516,7 @@ func TestSubscribe_CleansUpOnExit(t *testing.T) {
 	}()
 
 	// Wait for subscriber to register.
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "cleanup.topic"})
 
 	bus.mu.RLock()
 	gs := bus.groupSubs["cleanup.topic"][""]
@@ -574,7 +579,7 @@ func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "receipt.ack"})
 
 	err := bus.Publish(context.Background(), "receipt.ack", makeSimpleEnvelope(t, "receipt.ack"))
 	require.NoError(t, err)
@@ -607,7 +612,7 @@ func TestSubscribe_ReceiptReleasedOnReject(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "receipt.reject"})
 
 	err := bus.Publish(context.Background(), "receipt.reject", makeSimpleEnvelope(t, "receipt.reject"))
 	require.NoError(t, err)
@@ -645,7 +650,7 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "receipt.requeue"})
 
 	err := bus.Publish(context.Background(), "receipt.requeue", makeSimpleEnvelope(t, "receipt.requeue"))
 	require.NoError(t, err)
@@ -696,7 +701,7 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "receipt.exhaust"})
 
 	err := bus.Publish(context.Background(), "receipt.exhaust", makeSimpleEnvelope(t, "receipt.exhaust"))
 	require.NoError(t, err)
@@ -751,7 +756,7 @@ func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "zero.disp"})
 
 	start := time.Now()
 	err := bus.Publish(context.Background(), "zero.disp", makeSimpleEnvelope(t, "zero.disp"))
@@ -809,7 +814,7 @@ func TestSubscribe_UnknownDisposition_TreatedAsRequeue(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "unknown.disp"})
 
 	start := time.Now()
 	err := bus.Publish(context.Background(), "unknown.disp", makeSimpleEnvelope(t, "unknown.disp"))
@@ -857,7 +862,7 @@ func TestSubscribe_InvalidDisposition_RespectsCtxCancel(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "cancel.disp"})
 
 	err := bus.Publish(context.Background(), "cancel.disp", makeSimpleEnvelope(t, "cancel.disp"))
 	require.NoError(t, err)

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -353,12 +353,7 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 		})
 	}()
 
-	require.Eventually(t, func() bool {
-		bus.mu.RLock()
-		defer bus.mu.RUnlock()
-		gs := bus.groupSubs["race.topic"][""]
-		return gs != nil && len(gs.subs) == 1
-	}, time.Second, 10*time.Millisecond)
+	<-bus.Ready(outbox.Subscription{Topic: "race.topic"})
 
 	var stop atomic.Bool
 	var publishStarted atomic.Int32
@@ -916,7 +911,12 @@ func TestConsumerGroup_SameGroup_CompetingConsumption(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond) // let subscriptions register
+	require.Eventually(t, func() bool {
+		bus.mu.RLock()
+		defer bus.mu.RUnlock()
+		gs := bus.groupSubs["session.created"]["audit-core"]
+		return gs != nil && len(gs.subs) == 2
+	}, time.Second, 10*time.Millisecond, "both audit-core subscribers must register")
 
 	// Publish 10 messages.
 	n := 10
@@ -973,7 +973,14 @@ func TestConsumerGroup_DifferentGroups_Fanout(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		bus.mu.RLock()
+		defer bus.mu.RUnlock()
+		gsAudit := bus.groupSubs["session.created"]["audit-core"]
+		gsConfig := bus.groupSubs["session.created"]["config-core"]
+		return gsAudit != nil && len(gsAudit.subs) == 1 &&
+			gsConfig != nil && len(gsConfig.subs) == 1
+	}, time.Second, 10*time.Millisecond, "both group subscribers must register")
 
 	n := 5
 	for i := range n {
@@ -1025,7 +1032,12 @@ func TestConsumerGroup_EmptyGroup_BackwardCompatible(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		bus.mu.RLock()
+		defer bus.mu.RUnlock()
+		gs := bus.groupSubs["events.v1"][""]
+		return gs != nil && len(gs.subs) == 2
+	}, time.Second, 10*time.Millisecond, "both empty-group subscribers must register")
 
 	n := 5
 	for i := range n {
@@ -1073,7 +1085,12 @@ func TestConsumerGroup_ConcurrentPublish_NoRace(t *testing.T) {
 		}()
 	}
 
-	time.Sleep(20 * time.Millisecond) // let subscriptions register
+	require.Eventually(t, func() bool {
+		bus.mu.RLock()
+		defer bus.mu.RUnlock()
+		gs := bus.groupSubs["race.topic"]["race-group"]
+		return gs != nil && len(gs.subs) == numSubs
+	}, time.Second, 10*time.Millisecond, "all race-group subscribers must register")
 
 	// Concurrent publishers hammering the same topic+group.
 	// Use shared counter for unique envelope IDs across goroutines.

--- a/runtime/outbox/envelope.go
+++ b/runtime/outbox/envelope.go
@@ -6,8 +6,21 @@ import (
 	"time"
 
 	kout "github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/google/uuid"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
+
+// EnvelopeSchemaV1 is the canonical schema version for outbox wire envelopes.
+// All envelopes produced by MarshalEnvelope carry this version; UnmarshalEnvelope
+// rejects any message that does not match.
+const EnvelopeSchemaV1 = "v1"
+
+// ErrUnknownEnvelopeVersion is returned by UnmarshalEnvelope when the inbound
+// wire message carries an unrecognised (or absent) schemaVersion field.
+// Consumers must treat this as a permanent error and route to DLX, not retry.
+//
+// ref: Watermill message/router.go handleMessage — unknown message type → Nack, no retry
+var ErrUnknownEnvelopeVersion = errcode.New(errcode.ErrEnvelopeSchema,
+	"outbox: unknown envelope schema version")
 
 // WireMessage is the canonical wire envelope used by outbox relay publishers
 // across all transports (in-memory eventbus, RabbitMQ, future Kafka). Transports
@@ -21,6 +34,7 @@ import (
 //
 // ref: Watermill message.Message — payload + metadata envelope
 type WireMessage struct {
+	SchemaVersion string            `json:"schemaVersion"`
 	ID            string            `json:"id"`
 	AggregateID   string            `json:"aggregateId,omitempty"`
 	AggregateType string            `json:"aggregateType,omitempty"`
@@ -33,8 +47,10 @@ type WireMessage struct {
 }
 
 // MarshalEnvelope serializes a ClaimedEntry into the wire envelope JSON.
+// The output always carries SchemaVersion = EnvelopeSchemaV1.
 func MarshalEnvelope(entry ClaimedEntry) ([]byte, error) {
 	msg := WireMessage{
+		SchemaVersion: EnvelopeSchemaV1,
 		ID:            entry.ID,
 		AggregateID:   entry.AggregateID,
 		AggregateType: entry.AggregateType,
@@ -52,61 +68,40 @@ func MarshalEnvelope(entry ClaimedEntry) ([]byte, error) {
 	return b, nil
 }
 
-// UnmarshalEnvelope tries to decode raw as a WireMessage envelope. If raw
-// looks like an envelope (has "id" + "eventType" + "payload" fields and
-// Payload starts with '{' or '['), it extracts payload + metadata into
-// a kernel/outbox.Entry. Otherwise it wraps raw as a fresh Entry with
-// topic as eventType (fallback compatibility with non-outbox publishes).
+// UnmarshalEnvelope decodes a v1 wire envelope from raw bytes into a kernel/outbox.Entry.
 //
-// This function replaces duplicated logic in runtime/eventbus/eventbus.go
-// (unmarshalInboundEntry) and adapters/rabbitmq/subscriber.go (unmarshalDelivery).
+// Fail-closed semantics (ref: Watermill router.go, K8s workqueue fail-closed):
+//   - JSON parse failure → wrapped error (not ErrUnknownEnvelopeVersion)
+//   - schemaVersion != "v1" (or absent) → ErrUnknownEnvelopeVersion
+//   - empty ID or EventType → error (required fields)
 //
-// Discriminator: require non-empty ID + EventType AND an embedded JSON payload
-// (starts with '{' or '['), matching the check in both transport adapters.
-// Business payloads that happen to parse as an envelope structure are guarded
-// by the isEmbeddedJSON check (very unlikely to be mis-detected).
-//
-// Fallback: raw is wrapped in a freshly stamped Entry with ID = "evt-" + UUID,
-// EventType = topic, and CreatedAt = time.Now(). This preserves pre-envelope
-// direct-publish semantics (InMemoryEventBus path).
+// Legacy fallback has been removed. All producers MUST emit v1 envelopes.
+// Consumers that receive non-v1 messages must Reject (route to DLX), not retry.
 func UnmarshalEnvelope(topic string, raw []byte) (kout.Entry, error) {
 	var msg WireMessage
-	if err := json.Unmarshal(raw, &msg); err == nil &&
-		msg.ID != "" && msg.EventType != "" && isEmbeddedJSON(msg.Payload) {
-		return kout.Entry{
-			ID:            msg.ID,
-			AggregateID:   msg.AggregateID,
-			AggregateType: msg.AggregateType,
-			EventType:     msg.EventType,
-			Topic:         msg.Topic,
-			Payload:       []byte(msg.Payload),
-			Metadata:      msg.Metadata,
-			CreatedAt:     msg.CreatedAt,
-		}, nil
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return kout.Entry{}, fmt.Errorf("outbox: unmarshal envelope: %w", err)
 	}
-	// Fallback: wrap as a fresh entry (direct-publish / non-envelope semantics).
-	// Mirror of runtime/eventbus/eventbus.go unmarshalInboundEntry fallback branch.
-	return kout.Entry{
-		ID:        "evt-" + uuid.NewString(),
-		EventType: topic,
-		Payload:   raw,
-		CreatedAt: time.Now(),
-	}, nil
-}
 
-// isEmbeddedJSON returns true if the raw JSON value is an object or array
-// (relay envelope payload), not a base64 string or primitive.
-// Mirrors the identical helpers in runtime/eventbus and adapters/rabbitmq.
-func isEmbeddedJSON(raw json.RawMessage) bool {
-	for _, b := range raw {
-		switch b {
-		case ' ', '\t', '\n', '\r':
-			continue
-		case '{', '[':
-			return true
-		default:
-			return false
-		}
+	if msg.SchemaVersion != EnvelopeSchemaV1 {
+		return kout.Entry{}, ErrUnknownEnvelopeVersion
 	}
-	return false
+
+	if msg.ID == "" {
+		return kout.Entry{}, fmt.Errorf("outbox: envelope missing required field: id")
+	}
+	if msg.EventType == "" {
+		return kout.Entry{}, fmt.Errorf("outbox: envelope missing required field: eventType")
+	}
+
+	return kout.Entry{
+		ID:            msg.ID,
+		AggregateID:   msg.AggregateID,
+		AggregateType: msg.AggregateType,
+		EventType:     msg.EventType,
+		Topic:         msg.Topic,
+		Payload:       []byte(msg.Payload),
+		Metadata:      msg.Metadata,
+		CreatedAt:     msg.CreatedAt,
+	}, nil
 }

--- a/runtime/outbox/envelope.go
+++ b/runtime/outbox/envelope.go
@@ -88,10 +88,12 @@ func UnmarshalEnvelope(topic string, raw []byte) (kout.Entry, error) {
 	}
 
 	if msg.ID == "" {
-		return kout.Entry{}, fmt.Errorf("outbox: envelope missing required field: id")
+		return kout.Entry{}, errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox: envelope missing required field: id")
 	}
 	if msg.EventType == "" {
-		return kout.Entry{}, fmt.Errorf("outbox: envelope missing required field: eventType")
+		return kout.Entry{}, errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox: envelope missing required field: eventType")
 	}
 
 	return kout.Entry{

--- a/runtime/outbox/envelope.go
+++ b/runtime/outbox/envelope.go
@@ -77,17 +77,18 @@ func MarshalEnvelope(entry ClaimedEntry) ([]byte, error) {
 // business JSON bytes that handlers will receive in Entry.Payload after the
 // bus unwraps.
 //
-// Returns ErrEnvelopeSchema if any required field is missing, to make
-// producer-side contract violations fail-fast instead of silently producing
-// an envelope that the bus would dead-letter.
-func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) ([]byte, error) {
+// Panics on empty id or eventType — these are programmer errors (internal
+// producers pass compile-time constants / NewEntryID()), not runtime
+// conditions. Follows the stdlib Must-style convention (regexp.MustCompile,
+// netip.MustParseAddr) so callers are not forced to handle unreachable
+// branches. json.Marshal of a WireMessage with valid string/byte fields
+// does not fail, so the internal marshal error is also treated as unreachable.
+func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) []byte {
 	if id == "" {
-		return nil, errcode.New(errcode.ErrEnvelopeSchema,
-			"outbox: direct envelope missing required field: id")
+		panic("outbox.MarshalDirectEnvelope: empty id")
 	}
 	if eventType == "" {
-		return nil, errcode.New(errcode.ErrEnvelopeSchema,
-			"outbox: direct envelope missing required field: eventType")
+		panic("outbox.MarshalDirectEnvelope: empty eventType")
 	}
 	msg := WireMessage{
 		SchemaVersion: EnvelopeSchemaV1,
@@ -99,9 +100,12 @@ func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) ([]byte,
 	}
 	b, err := json.Marshal(msg)
 	if err != nil {
-		return nil, errcode.Wrap(errcode.ErrEnvelopeSchema, "outbox: marshal direct envelope", err)
+		// Unreachable: WireMessage fields are strings and []byte; json.Marshal
+		// only fails on cyclic references or unsupported types, neither of which
+		// applies here. Panic so any regression surfaces at the call site.
+		panic("outbox.MarshalDirectEnvelope: json.Marshal unexpectedly failed: " + err.Error())
 	}
-	return b, nil
+	return b
 }
 
 // UnmarshalEnvelope decodes a v1 wire envelope from raw bytes into a kernel/outbox.Entry.

--- a/runtime/outbox/envelope.go
+++ b/runtime/outbox/envelope.go
@@ -2,7 +2,6 @@ package outbox
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	kout "github.com/ghbvf/gocell/kernel/outbox"
@@ -63,7 +62,44 @@ func MarshalEnvelope(entry ClaimedEntry) ([]byte, error) {
 	}
 	b, err := json.Marshal(msg)
 	if err != nil {
-		return nil, fmt.Errorf("outbox: marshal envelope: %w", err)
+		return nil, errcode.Wrap(errcode.ErrEnvelopeSchema, "outbox: marshal envelope", err)
+	}
+	return b, nil
+}
+
+// MarshalDirectEnvelope builds a v1 wire envelope for direct-publish paths
+// (demo mode L2 cells, L4 cells without outbox writer) that do not go through
+// the relay. The returned bytes are suitable for passing to outbox.Publisher.Publish.
+//
+// eventType is the canonical event name (e.g. "event.session.created.v1") —
+// typically the same as topic for direct paths. id must be globally unique
+// (callers should use outbox.NewEntryID() to construct it). payload is the
+// business JSON bytes that handlers will receive in Entry.Payload after the
+// bus unwraps.
+//
+// Returns ErrEnvelopeSchema if any required field is missing, to make
+// producer-side contract violations fail-fast instead of silently producing
+// an envelope that the bus would dead-letter.
+func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) ([]byte, error) {
+	if id == "" {
+		return nil, errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox: direct envelope missing required field: id")
+	}
+	if eventType == "" {
+		return nil, errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox: direct envelope missing required field: eventType")
+	}
+	msg := WireMessage{
+		SchemaVersion: EnvelopeSchemaV1,
+		ID:            id,
+		EventType:     eventType,
+		Topic:         topic,
+		Payload:       json.RawMessage(payload),
+		CreatedAt:     time.Now().UTC(),
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.ErrEnvelopeSchema, "outbox: marshal direct envelope", err)
 	}
 	return b, nil
 }
@@ -71,16 +107,21 @@ func MarshalEnvelope(entry ClaimedEntry) ([]byte, error) {
 // UnmarshalEnvelope decodes a v1 wire envelope from raw bytes into a kernel/outbox.Entry.
 //
 // Fail-closed semantics (ref: Watermill router.go, K8s workqueue fail-closed):
-//   - JSON parse failure → wrapped error (not ErrUnknownEnvelopeVersion)
+//   - JSON parse failure → ErrEnvelopeSchema-coded error wrapping the json error
+//     (distinct from ErrUnknownEnvelopeVersion by sentinel identity; callers that
+//     need to distinguish parse vs schema-version use errors.Is against the
+//     sentinel, while code-based observability groups both under
+//     ErrEnvelopeSchema)
 //   - schemaVersion != "v1" (or absent) → ErrUnknownEnvelopeVersion
-//   - empty ID or EventType → error (required fields)
+//   - empty ID or EventType → ErrEnvelopeSchema error
 //
 // Legacy fallback has been removed. All producers MUST emit v1 envelopes.
 // Consumers that receive non-v1 messages must Reject (route to DLX), not retry.
 func UnmarshalEnvelope(topic string, raw []byte) (kout.Entry, error) {
 	var msg WireMessage
 	if err := json.Unmarshal(raw, &msg); err != nil {
-		return kout.Entry{}, fmt.Errorf("outbox: unmarshal envelope: %w", err)
+		return kout.Entry{}, errcode.Wrap(errcode.ErrEnvelopeSchema,
+			"outbox: unmarshal envelope", err)
 	}
 
 	if msg.SchemaVersion != EnvelopeSchemaV1 {

--- a/runtime/outbox/envelope_test.go
+++ b/runtime/outbox/envelope_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	kout "github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/outbox"
 )
 
@@ -126,7 +127,12 @@ func TestUnmarshalEnvelope_FutureVersion_Rejected(t *testing.T) {
 }
 
 // TestUnmarshalEnvelope_BrokenJSON_Rejected verifies that invalid JSON bytes
-// return a wrapped error (not the schema error).
+// return an ErrEnvelopeSchema-coded error, but NOT the ErrUnknownEnvelopeVersion
+// sentinel (broken JSON is distinct from a recognisable envelope with wrong version).
+//
+// Groups parse failures and schema failures under the same observability code
+// (ERR_ENVELOPE_SCHEMA) while preserving errors.Is against the version sentinel
+// for callers that need to distinguish the two cases.
 func TestUnmarshalEnvelope_BrokenJSON_Rejected(t *testing.T) {
 	raw := []byte(`not json at all {{{`)
 
@@ -137,6 +143,15 @@ func TestUnmarshalEnvelope_BrokenJSON_Rejected(t *testing.T) {
 	// Must NOT be ErrUnknownEnvelopeVersion — it's a JSON parse error.
 	if errors.Is(err, outbox.ErrUnknownEnvelopeVersion) {
 		t.Error("broken JSON should produce a parse error, not ErrUnknownEnvelopeVersion")
+	}
+	// But MUST carry the ErrEnvelopeSchema code so observability / HTTP mapping
+	// groups it with schema-version and missing-field failures.
+	var ce *errcode.Error
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *errcode.Error, got: %T (%v)", err, err)
+	}
+	if ce.Code != errcode.ErrEnvelopeSchema {
+		t.Errorf("code: got %q, want %q", ce.Code, errcode.ErrEnvelopeSchema)
 	}
 }
 
@@ -212,6 +227,65 @@ func TestMarshalEnvelope_WireFormat(t *testing.T) {
 		if _, ok := m[key]; ok {
 			t.Errorf("unexpected PascalCase key %q found in wire JSON", key)
 		}
+	}
+}
+
+// TestMarshalDirectEnvelope_ProducesV1 verifies that direct-publish envelopes
+// carry SchemaVersion=v1 and the supplied fields, and round-trip through
+// UnmarshalEnvelope so the bus delivers the business payload unchanged.
+func TestMarshalDirectEnvelope_ProducesV1(t *testing.T) {
+	topic := "event.session.created.v1"
+	id := "direct-id-1"
+	payload := []byte(`{"sessionId":"s-1","userId":"u-42"}`)
+
+	raw, err := outbox.MarshalDirectEnvelope(topic, topic, id, payload)
+	if err != nil {
+		t.Fatalf("MarshalDirectEnvelope: %v", err)
+	}
+
+	got, err := outbox.UnmarshalEnvelope(topic, raw)
+	if err != nil {
+		t.Fatalf("UnmarshalEnvelope: %v", err)
+	}
+
+	if got.ID != id {
+		t.Errorf("ID: got %q, want %q", got.ID, id)
+	}
+	if got.EventType != topic {
+		t.Errorf("EventType: got %q, want %q", got.EventType, topic)
+	}
+	if got.Topic != topic {
+		t.Errorf("Topic: got %q, want %q", got.Topic, topic)
+	}
+	if string(got.Payload) != string(payload) {
+		t.Errorf("Payload: got %s, want %s", got.Payload, payload)
+	}
+}
+
+// TestMarshalDirectEnvelope_RejectsEmptyRequiredFields verifies fail-fast on
+// producer-side contract violation (empty id / eventType) — distinct from
+// silently producing an envelope the bus would dead-letter.
+func TestMarshalDirectEnvelope_RejectsEmptyRequiredFields(t *testing.T) {
+	tests := []struct {
+		name, topic, eventType, id string
+	}{
+		{"empty id", "t.v1", "t.v1", ""},
+		{"empty eventType", "t.v1", "", "some-id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := outbox.MarshalDirectEnvelope(tt.topic, tt.eventType, tt.id, []byte(`{}`))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var ce *errcode.Error
+			if !errors.As(err, &ce) {
+				t.Fatalf("expected *errcode.Error, got: %T", err)
+			}
+			if ce.Code != errcode.ErrEnvelopeSchema {
+				t.Errorf("code: got %q, want %q", ce.Code, errcode.ErrEnvelopeSchema)
+			}
+		})
 	}
 }
 

--- a/runtime/outbox/envelope_test.go
+++ b/runtime/outbox/envelope_test.go
@@ -238,10 +238,7 @@ func TestMarshalDirectEnvelope_ProducesV1(t *testing.T) {
 	id := "direct-id-1"
 	payload := []byte(`{"sessionId":"s-1","userId":"u-42"}`)
 
-	raw, err := outbox.MarshalDirectEnvelope(topic, topic, id, payload)
-	if err != nil {
-		t.Fatalf("MarshalDirectEnvelope: %v", err)
-	}
+	raw := outbox.MarshalDirectEnvelope(topic, topic, id, payload)
 
 	got, err := outbox.UnmarshalEnvelope(topic, raw)
 	if err != nil {
@@ -262,10 +259,12 @@ func TestMarshalDirectEnvelope_ProducesV1(t *testing.T) {
 	}
 }
 
-// TestMarshalDirectEnvelope_RejectsEmptyRequiredFields verifies fail-fast on
-// producer-side contract violation (empty id / eventType) — distinct from
-// silently producing an envelope the bus would dead-letter.
-func TestMarshalDirectEnvelope_RejectsEmptyRequiredFields(t *testing.T) {
+// TestMarshalDirectEnvelope_PanicsOnEmptyRequiredFields verifies fail-fast on
+// programmer-error input (empty id / eventType). Follows stdlib Must-style
+// convention — callers pass compile-time constants / NewEntryID(), so these
+// inputs never arise at runtime and returning error would force unreachable
+// handling at every call site.
+func TestMarshalDirectEnvelope_PanicsOnEmptyRequiredFields(t *testing.T) {
 	tests := []struct {
 		name, topic, eventType, id string
 	}{
@@ -274,17 +273,12 @@ func TestMarshalDirectEnvelope_RejectsEmptyRequiredFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := outbox.MarshalDirectEnvelope(tt.topic, tt.eventType, tt.id, []byte(`{}`))
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			var ce *errcode.Error
-			if !errors.As(err, &ce) {
-				t.Fatalf("expected *errcode.Error, got: %T", err)
-			}
-			if ce.Code != errcode.ErrEnvelopeSchema {
-				t.Errorf("code: got %q, want %q", ce.Code, errcode.ErrEnvelopeSchema)
-			}
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatal("expected panic, got none")
+				}
+			}()
+			_ = outbox.MarshalDirectEnvelope(tt.topic, tt.eventType, tt.id, []byte(`{}`))
 		})
 	}
 }

--- a/runtime/outbox/envelope_test.go
+++ b/runtime/outbox/envelope_test.go
@@ -2,7 +2,7 @@ package outbox_test
 
 import (
 	"encoding/json"
-	"strings"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,20 +10,58 @@ import (
 	"github.com/ghbvf/gocell/runtime/outbox"
 )
 
-func TestMarshalUnmarshalEnvelope_RoundTrip(t *testing.T) {
+// TestMarshalEnvelope_StampsSchemaVersionV1 verifies that MarshalEnvelope
+// always stamps "schemaVersion":"v1" in the wire JSON.
+func TestMarshalEnvelope_StampsSchemaVersionV1(t *testing.T) {
+	entry := outbox.ClaimedEntry{
+		Entry: kout.Entry{
+			ID:        "stamp-id-1",
+			EventType: "test.event.v1",
+			Topic:     "test.event.v1",
+			Payload:   []byte(`{"key":"value"}`),
+			CreatedAt: time.Now(),
+		},
+	}
+
+	raw, err := outbox.MarshalEnvelope(entry)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal wire JSON: %v", err)
+	}
+
+	sv, ok := m["schemaVersion"]
+	if !ok {
+		t.Fatal("schemaVersion field must be present in wire JSON")
+	}
+	var svStr string
+	if err := json.Unmarshal(sv, &svStr); err != nil {
+		t.Fatalf("schemaVersion must be a string: %v", err)
+	}
+	if svStr != "v1" {
+		t.Errorf("schemaVersion: got %q, want %q", svStr, "v1")
+	}
+}
+
+// TestUnmarshalEnvelope_V1_Success verifies that a well-formed v1 envelope
+// is decoded correctly with all fields preserved.
+func TestUnmarshalEnvelope_V1_Success(t *testing.T) {
 	now := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	entry := outbox.ClaimedEntry{
 		Entry: kout.Entry{
-			ID:            "test-id-1",
-			AggregateID:   "agg-123",
+			ID:            "v1-id-1",
+			AggregateID:   "agg-100",
 			AggregateType: "Order",
 			EventType:     "order.created.v1",
 			Topic:         "order.created.v1",
-			Payload:       []byte(`{"orderId":"123","amount":99}`),
-			Metadata:      map[string]string{"trace_id": "abc123", "request_id": "req-456"},
+			Payload:       []byte(`{"orderId":"o-1","amount":99}`),
+			Metadata:      map[string]string{"trace_id": "t-123"},
 			CreatedAt:     now,
 		},
-		Attempts: 2,
+		Attempts: 1,
 	}
 
 	raw, err := outbox.MarshalEnvelope(entry)
@@ -54,112 +92,130 @@ func TestMarshalUnmarshalEnvelope_RoundTrip(t *testing.T) {
 	if got.Metadata["trace_id"] != entry.Metadata["trace_id"] {
 		t.Errorf("Metadata trace_id: got %q, want %q", got.Metadata["trace_id"], entry.Metadata["trace_id"])
 	}
-	if got.Metadata["request_id"] != entry.Metadata["request_id"] {
-		t.Errorf("Metadata request_id: got %q, want %q", got.Metadata["request_id"], entry.Metadata["request_id"])
-	}
 	if !got.CreatedAt.Equal(entry.CreatedAt) {
 		t.Errorf("CreatedAt: got %v, want %v", got.CreatedAt, entry.CreatedAt)
 	}
 }
 
-func TestUnmarshalEnvelope_Fallback_NonEnvelope(t *testing.T) {
-	topic := "some.topic.v1"
-	raw := []byte(`{"foo":"bar","baz":42}`)
+// TestUnmarshalEnvelope_EmptyVersion_Rejected verifies that an envelope with no
+// schemaVersion field is rejected with ErrUnknownEnvelopeVersion.
+func TestUnmarshalEnvelope_EmptyVersion_Rejected(t *testing.T) {
+	raw := []byte(`{"id":"x","eventType":"foo.v1","payload":{"data":"y"},"createdAt":"2024-01-01T00:00:00Z"}`)
 
-	// Non-envelope payload (no "id" or "eventType" fields) → fresh entry fallback.
-	got, err := outbox.UnmarshalEnvelope(topic, raw)
-	if err != nil {
-		t.Fatalf("UnmarshalEnvelope unexpected error: %v", err)
+	_, err := outbox.UnmarshalEnvelope("foo.v1", raw)
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
-	if !strings.HasPrefix(got.ID, "evt-") {
-		t.Errorf("ID should start with 'evt-', got %q", got.ID)
-	}
-	if got.EventType != topic {
-		t.Errorf("EventType: got %q, want %q", got.EventType, topic)
-	}
-	if string(got.Payload) != string(raw) {
-		t.Errorf("Payload: got %s, want %s", got.Payload, raw)
+	if !errors.Is(err, outbox.ErrUnknownEnvelopeVersion) {
+		t.Errorf("expected ErrUnknownEnvelopeVersion, got: %v", err)
 	}
 }
 
-func TestUnmarshalEnvelope_Fallback_BrokenJSON(t *testing.T) {
-	topic := "some.topic.v1"
-	raw := []byte(`not json`)
+// TestUnmarshalEnvelope_FutureVersion_Rejected verifies that an unknown
+// schemaVersion (e.g., "v99") is rejected with ErrUnknownEnvelopeVersion.
+func TestUnmarshalEnvelope_FutureVersion_Rejected(t *testing.T) {
+	raw := []byte(`{"schemaVersion":"v99","id":"x","eventType":"foo.v1","payload":{"data":"y"},"createdAt":"2024-01-01T00:00:00Z"}`)
 
-	// Broken JSON → fallback (not an error in eventbus path; raw is preserved).
-	got, err := outbox.UnmarshalEnvelope(topic, raw)
-	if err != nil {
-		t.Fatalf("UnmarshalEnvelope unexpected error: %v", err)
+	_, err := outbox.UnmarshalEnvelope("foo.v1", raw)
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
-	if !strings.HasPrefix(got.ID, "evt-") {
-		t.Errorf("ID should start with 'evt-', got %q", got.ID)
-	}
-	if got.EventType != topic {
-		t.Errorf("EventType: got %q, want %q", got.EventType, topic)
-	}
-	if string(got.Payload) != string(raw) {
-		t.Errorf("Payload: got %s, want %s", got.Payload, raw)
+	if !errors.Is(err, outbox.ErrUnknownEnvelopeVersion) {
+		t.Errorf("expected ErrUnknownEnvelopeVersion, got: %v", err)
 	}
 }
 
-func TestUnmarshalEnvelope_Fallback_EmptyPayload(t *testing.T) {
-	topic := "some.topic.v1"
-	var raw []byte
+// TestUnmarshalEnvelope_BrokenJSON_Rejected verifies that invalid JSON bytes
+// return a wrapped error (not the schema error).
+func TestUnmarshalEnvelope_BrokenJSON_Rejected(t *testing.T) {
+	raw := []byte(`not json at all {{{`)
 
-	got, err := outbox.UnmarshalEnvelope(topic, raw)
-	if err != nil {
-		t.Fatalf("UnmarshalEnvelope unexpected error: %v", err)
+	_, err := outbox.UnmarshalEnvelope("some.topic", raw)
+	if err == nil {
+		t.Fatal("expected error for broken JSON, got nil")
 	}
-	if !strings.HasPrefix(got.ID, "evt-") {
-		t.Errorf("ID should start with 'evt-', got %q", got.ID)
+	// Must NOT be ErrUnknownEnvelopeVersion — it's a JSON parse error.
+	if errors.Is(err, outbox.ErrUnknownEnvelopeVersion) {
+		t.Error("broken JSON should produce a parse error, not ErrUnknownEnvelopeVersion")
 	}
 }
 
-func TestUnmarshalEnvelope_Fallback_MissingPayloadField(t *testing.T) {
-	// Envelope-like but missing the embedded "payload" field → fallback.
-	raw := []byte(`{"id":"test-id","eventType":"order.v1"}`)
-
-	got, err := outbox.UnmarshalEnvelope("order.v1", raw)
-	if err != nil {
-		t.Fatalf("UnmarshalEnvelope unexpected error: %v", err)
+// TestUnmarshalEnvelope_MissingRequiredField_Rejected verifies that a v1 envelope
+// with an empty ID or empty EventType is rejected.
+func TestUnmarshalEnvelope_MissingRequiredField_Rejected(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{
+			name: "empty id",
+			raw:  []byte(`{"schemaVersion":"v1","id":"","eventType":"foo.v1","payload":{"d":"y"},"createdAt":"2024-01-01T00:00:00Z"}`),
+		},
+		{
+			name: "missing id field",
+			raw:  []byte(`{"schemaVersion":"v1","eventType":"foo.v1","payload":{"d":"y"},"createdAt":"2024-01-01T00:00:00Z"}`),
+		},
+		{
+			name: "empty eventType",
+			raw:  []byte(`{"schemaVersion":"v1","id":"some-id","eventType":"","payload":{"d":"y"},"createdAt":"2024-01-01T00:00:00Z"}`),
+		},
+		{
+			name: "missing eventType field",
+			raw:  []byte(`{"schemaVersion":"v1","id":"some-id","payload":{"d":"y"},"createdAt":"2024-01-01T00:00:00Z"}`),
+		},
 	}
-	// No payload field → json.RawMessage is nil → isEmbeddedJSON returns false → fallback.
-	if !strings.HasPrefix(got.ID, "evt-") {
-		t.Errorf("ID should start with 'evt-', got %q", got.ID)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := outbox.UnmarshalEnvelope("foo.v1", tt.raw)
+			if err == nil {
+				t.Fatalf("[%s] expected error for missing required field, got nil", tt.name)
+			}
+		})
 	}
 }
 
-func TestUnmarshalEnvelope_Fallback_PayloadNotEmbeddedJSON(t *testing.T) {
-	// Envelope with payload that is a string (not an object/array) → fallback
-	// because isEmbeddedJSON("not embedded") == false.
-	raw := []byte(`{"id":"test-id","eventType":"order.v1","payload":"not embedded"}`)
-
-	got, err := outbox.UnmarshalEnvelope("order.v1", raw)
-	if err != nil {
-		t.Fatalf("UnmarshalEnvelope unexpected error: %v", err)
+// TestMarshalEnvelope_WireFormat verifies that the JSON keys are camelCase
+// (not PascalCase), matching what adapters/postgres/outbox_relay.go produces,
+// and that schemaVersion is included.
+func TestMarshalEnvelope_WireFormat(t *testing.T) {
+	entry := outbox.ClaimedEntry{
+		Entry: kout.Entry{
+			ID:            "wire-id",
+			AggregateID:   "agg-1",
+			AggregateType: "Widget",
+			EventType:     "widget.created.v1",
+			Topic:         "widget.created.v1",
+			Payload:       []byte(`{"widgetId":"w-1"}`),
+			CreatedAt:     time.Now(),
+		},
+		Attempts: 3,
 	}
-	if !strings.HasPrefix(got.ID, "evt-") {
-		t.Errorf("ID should start with 'evt-', got %q", got.ID)
+
+	raw, err := outbox.MarshalEnvelope(entry)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal wire JSON: %v", err)
+	}
+
+	for _, key := range []string{"schemaVersion", "id", "aggregateId", "aggregateType", "eventType", "topic", "payload", "createdAt"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("expected camelCase key %q not found in wire JSON", key)
+		}
+	}
+	// Verify no PascalCase keys leaked.
+	for _, key := range []string{"ID", "AggregateID", "AggregateType", "EventType", "SchemaVersion"} {
+		if _, ok := m[key]; ok {
+			t.Errorf("unexpected PascalCase key %q found in wire JSON", key)
+		}
 	}
 }
 
-func TestUnmarshalEnvelope_Fallback_PayloadIsArray(t *testing.T) {
-	// Envelope with payload that is a JSON array → detected as envelope (array is embedded JSON).
-	raw := []byte(`{"id":"arr-id","eventType":"list.v1","payload":[1,2,3]}`)
-
-	got, err := outbox.UnmarshalEnvelope("list.v1", raw)
-	if err != nil {
-		t.Fatalf("UnmarshalEnvelope unexpected error: %v", err)
-	}
-	// Should be detected as envelope.
-	if got.ID != "arr-id" {
-		t.Errorf("ID: got %q, want %q", got.ID, "arr-id")
-	}
-	if string(got.Payload) != "[1,2,3]" {
-		t.Errorf("Payload: got %s, want [1,2,3]", got.Payload)
-	}
-}
-
+// TestUnmarshalEnvelope_MetadataTransparent verifies metadata round-trip.
 func TestUnmarshalEnvelope_MetadataTransparent(t *testing.T) {
 	meta := map[string]string{
 		"trace_id":       "t-001",
@@ -194,44 +250,5 @@ func TestUnmarshalEnvelope_MetadataTransparent(t *testing.T) {
 	}
 	if len(got.Metadata) != len(meta) {
 		t.Errorf("Metadata len: got %d, want %d", len(got.Metadata), len(meta))
-	}
-}
-
-// TestMarshalEnvelope_WireFormat verifies that the JSON keys are camelCase
-// (not PascalCase), matching what adapters/postgres/outbox_relay.go produces.
-func TestMarshalEnvelope_WireFormat(t *testing.T) {
-	entry := outbox.ClaimedEntry{
-		Entry: kout.Entry{
-			ID:            "wire-id",
-			AggregateID:   "agg-1",
-			AggregateType: "Widget",
-			EventType:     "widget.created.v1",
-			Topic:         "widget.created.v1",
-			Payload:       []byte(`{"widgetId":"w-1"}`),
-			CreatedAt:     time.Now(),
-		},
-		Attempts: 3,
-	}
-
-	raw, err := outbox.MarshalEnvelope(entry)
-	if err != nil {
-		t.Fatalf("MarshalEnvelope: %v", err)
-	}
-
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &m); err != nil {
-		t.Fatalf("unmarshal wire JSON: %v", err)
-	}
-
-	for _, key := range []string{"id", "aggregateId", "aggregateType", "eventType", "topic", "payload", "createdAt"} {
-		if _, ok := m[key]; !ok {
-			t.Errorf("expected camelCase key %q not found in wire JSON", key)
-		}
-	}
-	// Verify no PascalCase keys leaked.
-	for _, key := range []string{"ID", "AggregateID", "AggregateType", "EventType"} {
-		if _, ok := m[key]; ok {
-			t.Errorf("unexpected PascalCase key %q found in wire JSON", key)
-		}
 	}
 }


### PR DESCRIPTION
## Summary

- **P1-14 envelope fail-closed**: Envelope 协议边界收口 — 增加 `schemaVersion:"v1"` 判别、彻底删除 `UnmarshalEnvelope` legacy fallback、`configsubscribe`/`configreceive` unknown action 返回 `PermanentError` → Reject → DLX
- **eventbus 测试 sleep 清理**: 12 处 20ms 启动同步 sleep → `<-bus.Ready(sub)`；DLQ 等待 → `require.Eventually`；消除 CI flaky

对标：Watermill `handler error → Nack` / Kratos Recovery `ErrUnknownRequest` fail-closed 默认

## 改动分层

| 层 | 改动 |
|----|------|
| `pkg/errcode` | 新增 `ErrEnvelopeSchema` |
| `runtime/outbox/envelope.go` | 加 `EnvelopeSchemaV1` 常量 + `SchemaVersion` 字段；`UnmarshalEnvelope` 删除 fallback，非 v1/缺字段/JSON 错误均返回 error |
| `runtime/eventbus/eventbus.go` | invalid envelope 记 dead letter 不再转发给 handler |
| `adapters/rabbitmq/subscriber.go` | 删除 legacy Entry 回退分支 |
| `cells/config-core/slices/configsubscribe` + `cells/access-core/slices/configreceive` | default 分支 `return outbox.NewPermanentError(...)` |
| `kernel/outbox/outboxtest/` | conformance & helper 适配新 envelope wire API |

## Why

背景：relay→consumer 链路存在两处 fail-open（unknown action 静默 `return nil`；envelope 解析失败 fallback 为 legacy Entry），组合后事件静默丢弃。CLAUDE.md 明确当前无外部调用方，直接彻底删除 fallback，对齐 Watermill/Kratos 语义。

依据计划：`docs/plans/202604181700-domain-driven-plan.md` 域 4 Outbox/RabbitMQ — P1-14

## Test plan

- [x] `go test ./runtime/outbox/... ./runtime/eventbus/... ./adapters/rabbitmq/... ./kernel/outbox/... -race -count=5` 通过
- [x] `go test ./cells/config-core/... ./cells/access-core/slices/configreceive/... -race -count=5` 通过
- [x] `golangci-lint run` 所有修改包 0 issues
- [x] eventbus `-race -count=20` 连续 20 次无 flaky
- [ ] CI 全量通过（等 CI）
- [ ] 手工 smoke: POST config → outbox payload 含 `"schemaVersion":"v1"`；`action:"bogus"` → DLQ 记录 + slog warn

## 关键决策

- envelope legacy fallback 彻底删除（无兼容 option）— CLAUDE.md "不考虑向后兼容"
- `NewPermanentError` 包装 → `WrapLegacyHandler` 升级为 `DispositionReject` → DLX
- sleep 清理就近搭车，避免独立 test-only PR 两次打开同一组文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)