### PR TITLE
feat(outbox): P1-15 relay failure budget + readiness probe

### DIFF
--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -70,6 +70,27 @@ func (c *fakeClaimer) Claim(_ context.Context, key string, _, _ time.Duration) (
 
 var _ idempotency.Claimer = (*fakeClaimer)(nil)
 
+// signalingClaimer wraps an inner Claimer and sends on the started channel
+// the first time Claim is invoked. Used to replace time.Sleep startup synchronisation
+// in tests that need to cancel ctx after the claimer has been called.
+type signalingClaimer struct {
+	inner   idempotency.Claimer
+	started chan<- struct{}
+	once    sync.Once
+}
+
+func (s *signalingClaimer) Claim(ctx context.Context, key string, leaseTTL, renewInterval time.Duration) (idempotency.ClaimState, Receipt, error) {
+	s.once.Do(func() {
+		select {
+		case s.started <- struct{}{}:
+		default:
+		}
+	})
+	return s.inner.Claim(ctx, key, leaseTTL, renewInterval)
+}
+
+var _ idempotency.Claimer = (*signalingClaimer)(nil)
+
 type claimOutcome struct {
 	state   idempotency.ClaimState
 	receipt Receipt
@@ -434,13 +455,20 @@ func TestConsumerBase_Wrap_CtxCancelled_DuringRetry_Requeues(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Signal channel: handler sends when it has been called, meaning ConsumerBase
+	// is about to enter the retry backoff sleep — safe to cancel ctx at that point.
+	started := make(chan struct{}, 1)
 	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
 		return HandleResult{Disposition: DispositionRequeue, Err: errors.New("transient")}
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(20 * time.Millisecond)
+		<-started
 		cancel()
 	}()
 
@@ -506,7 +534,13 @@ func TestConsumerBase_Wrap_ClaimError_FailClosed_ExhaustedRequeues(t *testing.T)
 }
 
 func TestConsumerBase_Wrap_ClaimError_FailClosed_CtxCancel(t *testing.T) {
-	claimer := &fakeClaimer{err: errors.New("redis down")}
+	// Signal channel: claimer sends when first called, meaning ConsumerBase is about
+	// to enter the claim retry backoff sleep — safe to cancel ctx at that point.
+	claimStarted := make(chan struct{}, 1)
+	claimer := &signalingClaimer{
+		inner:   &fakeClaimer{err: errors.New("redis down")},
+		started: claimStarted,
+	}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
 		ClaimRetryCount:     5,
@@ -520,7 +554,7 @@ func TestConsumerBase_Wrap_ClaimError_FailClosed_CtxCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(20 * time.Millisecond)
+		<-claimStarted
 		cancel()
 	}()
 

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -113,6 +113,12 @@ const (
 	// Resilience middleware error codes.
 	ErrCircuitOpen Code = "ERR_CIRCUIT_OPEN"
 
+	// Outbox relay health error codes.
+	// ErrRelayBudgetExhausted signals that an outbox relay operation (poll /
+	// reclaim / cleanup) has exceeded its consecutive-failure threshold, tripping
+	// the failure budget and marking /readyz unhealthy.
+	ErrRelayBudgetExhausted Code = "ERR_RELAY_BUDGET_EXHAUSTED"
+
 	// Observability configuration error.
 	// Raised by kernel / runtime observability constructors when a
 	// required dependency (Provider, cellID) is missing or malformed.

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -301,10 +301,11 @@ var codeToStatus = map[errcode.Code]int{
 	errcode.ErrBodyTooLarge: http.StatusRequestEntityTooLarge,
 
 	// --- 503 Service Unavailable ---
-	errcode.ErrCircuitOpen:     http.StatusServiceUnavailable,
-	errcode.ErrWSHubStopping:   http.StatusServiceUnavailable,
-	errcode.ErrWSHubNotRunning: http.StatusServiceUnavailable,
-	errcode.ErrWSMaxConns:      http.StatusServiceUnavailable,
+	errcode.ErrCircuitOpen:          http.StatusServiceUnavailable,
+	errcode.ErrWSHubStopping:        http.StatusServiceUnavailable,
+	errcode.ErrWSHubNotRunning:      http.StatusServiceUnavailable,
+	errcode.ErrWSMaxConns:           http.StatusServiceUnavailable,
+	errcode.ErrRelayBudgetExhausted: http.StatusServiceUnavailable,
 
 	// --- 500 Internal Server Error ---
 	errcode.ErrInternal:          http.StatusInternalServerError,

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -381,8 +382,14 @@ func WithRelayHealth(r *runtimeoutbox.Relay) Option {
 			b.relayHealthNil = true
 			return
 		}
-		for name, fn := range r.HealthCheckers() {
-			b.healthCheckers = append(b.healthCheckers, namedChecker{name: name, fn: fn})
+		checkers := r.HealthCheckers()
+		names := make([]string, 0, len(checkers))
+		for k := range checkers {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			b.healthCheckers = append(b.healthCheckers, namedChecker{name: name, fn: checkers[name]})
 		}
 	}
 }
@@ -1068,7 +1075,14 @@ func (b *Bootstrap) Run(ctx context.Context) error { //nolint:gocognit // comple
 	// (e.g. session-store), aligning with the authProvider discovery pattern.
 	for _, id := range asm.CellIDs() {
 		if hcc, ok := asm.Cell(id).(cell.HealthContributor); ok {
-			for name, fn := range hcc.HealthCheckers() {
+			cellCheckers := hcc.HealthCheckers()
+			cellNames := make([]string, 0, len(cellCheckers))
+			for k := range cellCheckers {
+				cellNames = append(cellNames, k)
+			}
+			sort.Strings(cellNames)
+			for _, name := range cellNames {
+				fn := cellCheckers[name]
 				if fn == nil {
 					return rollback(fmt.Errorf("bootstrap: cell %q returned nil health checker for %q", id, name))
 				}

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -33,8 +33,8 @@ import (
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
-	runtimeoutbox "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
+	runtimeoutbox "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/shutdown"
 	"github.com/ghbvf/gocell/runtime/worker"
 )

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
+	runtimeoutbox "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
 	"github.com/ghbvf/gocell/runtime/shutdown"
 	"github.com/ghbvf/gocell/runtime/worker"
@@ -361,6 +362,31 @@ func WithBrokerHealth(bc BrokerHealthChecker) Option {
 	}
 }
 
+// WithRelayHealth registers the relay's named health checkers (one per enabled
+// FailureBudget) into the /readyz endpoint. Checkers are named:
+//
+//   - "outbox-relay-poll"
+//   - "outbox-relay-reclaim"
+//   - "outbox-relay-cleanup"
+//
+// Only budgets with a positive threshold are registered; threshold=0 (disabled)
+// budgets are silently skipped. A nil relay is rejected at Run() time with a
+// fatal error, mirroring the WithBrokerHealth fail-fast contract.
+//
+// ref: controller-runtime AddReadyzCheck — named-checker aggregation pattern.
+// ref: runtime/bootstrap.WithBrokerHealth — sibling fail-fast pattern.
+func WithRelayHealth(r *runtimeoutbox.Relay) Option {
+	return func(b *Bootstrap) {
+		if r == nil {
+			b.relayHealthNil = true
+			return
+		}
+		for name, fn := range r.HealthCheckers() {
+			b.healthCheckers = append(b.healthCheckers, namedChecker{name: name, fn: fn})
+		}
+	}
+}
+
 // isNilBrokerHealthChecker detects both plain-nil interface values and the
 // "typed nil" gotcha (non-nil interface wrapping a nil pointer/slice/etc.).
 // The typed-nil case would satisfy `bc != nil` but panic on method dispatch.
@@ -603,6 +629,10 @@ type Bootstrap struct {
 	// time via router.WithInternalPathPrefixGuard after prefix validation.
 	internalGuardPrefix string
 	internalGuard       func(http.Handler) http.Handler
+
+	// relayHealthNil is set by WithRelayHealth when a nil relay is passed.
+	// Checked at Run() to fail-fast rather than silently skipping relay health.
+	relayHealthNil bool
 }
 
 // New creates a Bootstrap with the given options.
@@ -688,6 +718,12 @@ func (b *Bootstrap) Run(ctx context.Context) error { //nolint:gocognit // comple
 	// rather than silently operating without the intended protection.
 	if err := b.validateInternalGuard(); err != nil {
 		return err
+	}
+
+	// Fail-fast: nil relay passed to WithRelayHealth — surfaces misconfiguration
+	// at startup instead of silently skipping relay health registration.
+	if b.relayHealthNil {
+		return fmt.Errorf("bootstrap: relay must not be nil in WithRelayHealth")
 	}
 
 	// Fail-fast: WithAuthMiddleware and WithPublicEndpoints are mutually

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
+	"github.com/ghbvf/gocell/runtime/observability/tracing"
 	runtimeoutbox "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
-	"github.com/ghbvf/gocell/runtime/observability/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -3653,6 +3653,126 @@ func TestWithRelayHealth_NilRelay_FailsFast(t *testing.T) {
 	assert.Contains(t, err.Error(), "relay")
 }
 
+// bootstrapFailingStore wraps outboxtest.FakeStore to inject a controllable
+// ClaimPending error, enabling budget-trip testing in bootstrap integration tests.
+type bootstrapFailingStore struct {
+	*outboxtest.FakeStore
+	mu       sync.Mutex
+	claimErr error
+}
+
+func (s *bootstrapFailingStore) setClaimErr(err error) {
+	s.mu.Lock()
+	s.claimErr = err
+	s.mu.Unlock()
+}
+
+func (s *bootstrapFailingStore) ClaimPending(ctx context.Context, batchSize int) ([]runtimeoutbox.ClaimedEntry, error) {
+	s.mu.Lock()
+	err := s.claimErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return s.FakeStore.ClaimPending(ctx, batchSize)
+}
+
+// TestWithRelayHealth_TrippedBudget_Returns503 verifies the P1-15 core contract:
+// poll budget trip → /readyz returns 503; store recovery → /readyz returns 200.
+func TestWithRelayHealth_TrippedBudget_Returns503(t *testing.T) {
+	ln := newLocalListener(t)
+	asm := assembly.New(assembly.Config{ID: "test-relay-trip", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(newTestCell("cell-1")))
+
+	store := &bootstrapFailingStore{FakeStore: outboxtest.NewFakeStore()}
+	store.setClaimErr(errors.New("db down"))
+
+	cfg := runtimeoutbox.RelayConfig{
+		PollInterval:         5 * time.Millisecond,
+		ReclaimInterval:      10 * time.Millisecond,
+		BatchSize:            10,
+		MaxAttempts:          3,
+		BaseRetryDelay:       1 * time.Millisecond,
+		MaxRetryDelay:        10 * time.Millisecond,
+		ClaimTTL:             100 * time.Millisecond,
+		RetentionPeriod:      1 * time.Hour,
+		DeadRetentionPeriod:  24 * time.Hour,
+		CleanupWaitFloor:     5 * time.Millisecond,
+		PollFailureBudget:    3, // small threshold for fast test
+		ReclaimFailureBudget: 3,
+		CleanupFailureBudget: 3,
+	}
+	relay := runtimeoutbox.NewRelay(store, &outbox.DiscardPublisher{}, cfg)
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithRelayHealth(relay),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("bootstrap did not shut down in time")
+		}
+	}()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// Start the relay so its poll loop drives the failure budget.
+	relayCtx, relayCancel := context.WithCancel(ctx)
+	relayDone := make(chan error, 1)
+	go func() { relayDone <- relay.Start(relayCtx) }()
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer stopCancel()
+		_ = relay.Stop(stopCtx)
+		relayCancel()
+		<-relayDone
+	}()
+
+	// Phase 1: store is failing — budget must trip and /readyz must return 503.
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz", addr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusServiceUnavailable
+	}, 3*time.Second, 20*time.Millisecond, "/readyz must return 503 after poll budget trips")
+
+	// Verify verbose output contains the unhealthy checker name.
+	verboseResp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz?verbose", addr))
+	require.NoError(t, err)
+	defer verboseResp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, verboseResp.StatusCode)
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(verboseResp.Body).Decode(&body))
+	deps, ok := body["dependencies"].(map[string]any)
+	require.True(t, ok, "response must contain dependencies map")
+	require.Contains(t, deps, "outbox-relay-poll", "poll checker must appear in verbose output")
+	pollStatus, _ := deps["outbox-relay-poll"].(string)
+	assert.Equal(t, "unhealthy", pollStatus, "outbox-relay-poll: status must be unhealthy")
+
+	// Phase 2: store recovers — budget must reset and /readyz must return 200.
+	store.setClaimErr(nil)
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz", addr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 20*time.Millisecond, "/readyz must return 200 after store recovers")
+}
+
 func TestWithRelayHealth_DisabledBudget_SkipsChecker(t *testing.T) {
 	ln := newLocalListener(t)
 	asm := assembly.New(assembly.Config{ID: "test-relay-disabled", DurabilityMode: cell.DurabilityDemo})

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
+	runtimeoutbox "github.com/ghbvf/gocell/runtime/outbox"
+	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3553,6 +3555,153 @@ func TestBootstrap_HEADAlias_BypassesAuth(t *testing.T) {
 		"HEAD must bypass auth when GET is declared public (RFC 7231 §4.3.2 alias)")
 	assert.Equal(t, int32(0), verifier.callCount.Load(),
 		"verifier must not be called for HEAD request to GET-public endpoint")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B3 WithRelayHealth tests
+// ---------------------------------------------------------------------------
+
+func newTestRelay() *runtimeoutbox.Relay {
+	cfg := runtimeoutbox.RelayConfig{
+		PollInterval:         5 * time.Millisecond,
+		ReclaimInterval:      10 * time.Millisecond,
+		BatchSize:            10,
+		MaxAttempts:          3,
+		BaseRetryDelay:       1 * time.Millisecond,
+		MaxRetryDelay:        10 * time.Millisecond,
+		ClaimTTL:             100 * time.Millisecond,
+		RetentionPeriod:      1 * time.Hour,
+		DeadRetentionPeriod:  24 * time.Hour,
+		CleanupWaitFloor:     5 * time.Millisecond,
+		PollFailureBudget:    3,
+		ReclaimFailureBudget: 3,
+		CleanupFailureBudget: 3,
+	}
+	return runtimeoutbox.NewRelay(outboxtest.NewFakeStore(), &outbox.DiscardPublisher{}, cfg)
+}
+
+func TestWithRelayHealth_RegistersCheckers(t *testing.T) {
+	ln := newLocalListener(t)
+
+	asm := assembly.New(assembly.Config{ID: "test-relay-health", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(newTestCell("cell-1")))
+
+	relay := newTestRelay()
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithRelayHealth(relay),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	// GET /readyz?verbose — all three relay checkers must appear.
+	resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz?verbose", addr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	deps, ok := body["dependencies"].(map[string]any)
+	require.True(t, ok, "response must contain dependencies map")
+
+	assert.Contains(t, deps, "outbox-relay-poll", "poll checker must be in /readyz?verbose")
+	assert.Contains(t, deps, "outbox-relay-reclaim", "reclaim checker must be in /readyz?verbose")
+	assert.Contains(t, deps, "outbox-relay-cleanup", "cleanup checker must be in /readyz?verbose")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+func TestWithRelayHealth_NilRelay_FailsFast(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-relay-nil", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(newTestCell("cell-1")))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(newLocalListener(t)),
+		WithShutdownTimeout(2*time.Second),
+		WithRelayHealth(nil),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := b.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relay")
+}
+
+func TestWithRelayHealth_DisabledBudget_SkipsChecker(t *testing.T) {
+	ln := newLocalListener(t)
+	asm := assembly.New(assembly.Config{ID: "test-relay-disabled", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(newTestCell("cell-1")))
+
+	// Build a relay with poll budget disabled (=0), others enabled.
+	cfg := runtimeoutbox.RelayConfig{
+		PollInterval:         5 * time.Millisecond,
+		ReclaimInterval:      10 * time.Millisecond,
+		BatchSize:            10,
+		MaxAttempts:          3,
+		BaseRetryDelay:       1 * time.Millisecond,
+		MaxRetryDelay:        10 * time.Millisecond,
+		ClaimTTL:             100 * time.Millisecond,
+		RetentionPeriod:      1 * time.Hour,
+		DeadRetentionPeriod:  24 * time.Hour,
+		CleanupWaitFloor:     5 * time.Millisecond,
+		PollFailureBudget:    0, // disabled
+		ReclaimFailureBudget: 3,
+		CleanupFailureBudget: 3,
+	}
+	relay := runtimeoutbox.NewRelay(outboxtest.NewFakeStore(), &outbox.DiscardPublisher{}, cfg)
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(ln),
+		WithShutdownTimeout(2*time.Second),
+		WithRelayHealth(relay),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	addr := ln.Addr().String()
+	waitForHealthy(t, addr)
+
+	resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz?verbose", addr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	deps, _ := body["dependencies"].(map[string]any)
+
+	assert.NotContains(t, deps, "outbox-relay-poll",
+		"disabled poll budget must not register a checker")
+	assert.Contains(t, deps, "outbox-relay-reclaim")
+	assert.Contains(t, deps, "outbox-relay-cleanup")
 
 	cancel()
 	select {

--- a/runtime/outbox/config.go
+++ b/runtime/outbox/config.go
@@ -40,6 +40,16 @@ type RelayConfig struct {
 	// ref: Temporal client.Options{MetricsHandler} — inject-at-construction pattern
 	Metrics kout.RelayCollector
 
+	// Failure budget semantics — IMPORTANT:
+	//
+	// The zero value of RelayConfig{} leaves all three *FailureBudget fields at 0,
+	// which disables all health checkers entirely.  This is NOT the same as
+	// DefaultRelayConfig(), which sets each budget to 5.  Callers that construct
+	// a RelayConfig literal and want health reporting must either call
+	// DefaultRelayConfig() or set at least one *FailureBudget to a positive value.
+	// A relay whose three budgets are all zero will never report unhealthy in
+	// /readyz, regardless of how many consecutive loop failures occur.
+
 	// PollFailureBudget is the consecutive poll-loop failure count that trips
 	// /readyz unhealthy. 0 disables the checker. Default 5.
 	// ref: K8s workqueue ItemExponentialFailureRateLimiter — absolute count + Forget.

--- a/runtime/outbox/config.go
+++ b/runtime/outbox/config.go
@@ -39,6 +39,24 @@ type RelayConfig struct {
 	// If nil, a NoopRelayCollector is used (zero overhead).
 	// ref: Temporal client.Options{MetricsHandler} — inject-at-construction pattern
 	Metrics kout.RelayCollector
+
+	// PollFailureBudget is the consecutive poll-loop failure count that trips
+	// /readyz unhealthy. 0 disables the checker. Default 5.
+	// ref: K8s workqueue ItemExponentialFailureRateLimiter — absolute count + Forget.
+	PollFailureBudget int
+	// ReclaimFailureBudget is the consecutive reclaim-loop failure count that
+	// trips /readyz unhealthy. 0 disables. Default 5.
+	ReclaimFailureBudget int
+	// CleanupFailureBudget is the consecutive cleanup-loop failure count that
+	// trips /readyz unhealthy. 0 disables. Default 5.
+	CleanupFailureBudget int
+
+	// cleanupWaitFloor is the minimum sleep between cleanup passes.
+	// Exported as a field so tests can lower it to 1ms without touching
+	// the global constant. <= 0 uses the package default (5s).
+	// This field is intentionally unexported; tests must use fastCfg() or
+	// set it via the RelayConfig literal.
+	CleanupWaitFloor time.Duration
 }
 
 // DefaultRelayConfig returns a RelayConfig with sensible defaults.
@@ -46,15 +64,18 @@ type RelayConfig struct {
 // zero behaviour change during Phase C migration.
 func DefaultRelayConfig() RelayConfig {
 	return RelayConfig{
-		PollInterval:        1 * time.Second,
-		BatchSize:           100,
-		RetentionPeriod:     72 * time.Hour,
-		MaxAttempts:         5,
-		BaseRetryDelay:      5 * time.Second,
-		ClaimTTL:            60 * time.Second,
-		MaxRetryDelay:       5 * time.Minute,
-		ReclaimInterval:     30 * time.Second,
-		DeadRetentionPeriod: 30 * 24 * time.Hour, // 30 days
+		PollInterval:         1 * time.Second,
+		BatchSize:            100,
+		RetentionPeriod:      72 * time.Hour,
+		MaxAttempts:          5,
+		BaseRetryDelay:       5 * time.Second,
+		ClaimTTL:             60 * time.Second,
+		MaxRetryDelay:        5 * time.Minute,
+		ReclaimInterval:      30 * time.Second,
+		DeadRetentionPeriod:  30 * 24 * time.Hour, // 30 days
+		PollFailureBudget:    5,
+		ReclaimFailureBudget: 5,
+		CleanupFailureBudget: 5,
 	}
 }
 
@@ -89,6 +110,17 @@ func (c RelayConfig) WithDefaults() RelayConfig {
 	}
 	if c.DeadRetentionPeriod <= 0 {
 		c.DeadRetentionPeriod = d.DeadRetentionPeriod
+	}
+	// Failure budget fields: < 0 means "use default"; 0 is the explicit
+	// "disabled" sentinel and must not be overwritten.
+	if c.PollFailureBudget < 0 {
+		c.PollFailureBudget = d.PollFailureBudget
+	}
+	if c.ReclaimFailureBudget < 0 {
+		c.ReclaimFailureBudget = d.ReclaimFailureBudget
+	}
+	if c.CleanupFailureBudget < 0 {
+		c.CleanupFailureBudget = d.CleanupFailureBudget
 	}
 	return c
 }

--- a/runtime/outbox/config.go
+++ b/runtime/outbox/config.go
@@ -51,11 +51,10 @@ type RelayConfig struct {
 	// trips /readyz unhealthy. 0 disables. Default 5.
 	CleanupFailureBudget int
 
-	// cleanupWaitFloor is the minimum sleep between cleanup passes.
-	// Exported as a field so tests can lower it to 1ms without touching
-	// the global constant. <= 0 uses the package default (5s).
-	// This field is intentionally unexported; tests must use fastCfg() or
-	// set it via the RelayConfig literal.
+	// CleanupWaitFloor is the minimum sleep between cleanup passes.
+	// Exported so tests can lower it to 1ms without touching the global
+	// constant. <= 0 uses the package default (5s).
+	// Tests can set it directly via the RelayConfig literal.
 	CleanupWaitFloor time.Duration
 }
 

--- a/runtime/outbox/config.go
+++ b/runtime/outbox/config.go
@@ -40,16 +40,6 @@ type RelayConfig struct {
 	// ref: Temporal client.Options{MetricsHandler} — inject-at-construction pattern
 	Metrics kout.RelayCollector
 
-	// Failure budget semantics — IMPORTANT:
-	//
-	// The zero value of RelayConfig{} leaves all three *FailureBudget fields at 0,
-	// which disables all health checkers entirely.  This is NOT the same as
-	// DefaultRelayConfig(), which sets each budget to 5.  Callers that construct
-	// a RelayConfig literal and want health reporting must either call
-	// DefaultRelayConfig() or set at least one *FailureBudget to a positive value.
-	// A relay whose three budgets are all zero will never report unhealthy in
-	// /readyz, regardless of how many consecutive loop failures occur.
-
 	// PollFailureBudget is the consecutive poll-loop failure count that trips
 	// /readyz unhealthy. 0 disables the checker. Default 5.
 	// ref: K8s workqueue ItemExponentialFailureRateLimiter — absolute count + Forget.

--- a/runtime/outbox/export_test.go
+++ b/runtime/outbox/export_test.go
@@ -1,0 +1,12 @@
+// Package outbox — test-only exports for internal helpers.
+// This file is compiled only during `go test`; it exposes unexported symbols
+// needed by the external _test package without widening the public API.
+package outbox
+
+import "log/slog"
+
+// NewFailureBudgetWithLogger exposes newFailureBudgetWithLogger for
+// external test packages that need to inject a capturing slog.Handler.
+func NewFailureBudgetWithLogger(name string, threshold int, logger *slog.Logger) *FailureBudget {
+	return newFailureBudgetWithLogger(name, threshold, logger)
+}

--- a/runtime/outbox/health.go
+++ b/runtime/outbox/health.go
@@ -35,12 +35,12 @@ type FailureBudget struct {
 // threshold=0 disables the budget (Checker always returns nil, Tripped always false).
 // Uses slog.Default() as the logger.
 func NewFailureBudget(name string, threshold int) *FailureBudget {
-	return NewFailureBudgetWithLogger(name, threshold, slog.Default())
+	return newFailureBudgetWithLogger(name, threshold, slog.Default())
 }
 
-// NewFailureBudgetWithLogger creates a FailureBudget with an explicit logger.
-// This variant is used in tests to capture log output.
-func NewFailureBudgetWithLogger(name string, threshold int, logger *slog.Logger) *FailureBudget {
+// newFailureBudgetWithLogger creates a FailureBudget with an explicit logger.
+// Internal helper; used in tests to capture log output via a custom slog.Handler.
+func newFailureBudgetWithLogger(name string, threshold int, logger *slog.Logger) *FailureBudget {
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/runtime/outbox/health.go
+++ b/runtime/outbox/health.go
@@ -135,6 +135,19 @@ func (b *FailureBudget) Checker() func() error {
 	}
 }
 
+// Reset clears the consecutive failure counter and tripped state.
+// Called on Relay.Start to avoid stale state from a previous run.
+// Does NOT log; silent state reset.
+func (b *FailureBudget) Reset() {
+	if b.threshold <= 0 {
+		return
+	}
+	b.consec.Store(0)
+	b.tripped.Store(false)
+	b.loggedTrip.Store(false)
+	b.loggedRecover.Store(false)
+}
+
 // Tripped returns true when the consecutive failure count has reached the
 // threshold and has not yet been reset by a successful Record(nil) call.
 func (b *FailureBudget) Tripped() bool {

--- a/runtime/outbox/health.go
+++ b/runtime/outbox/health.go
@@ -1,0 +1,136 @@
+package outbox
+
+import (
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// FailureBudget tracks consecutive failures for a named operation and exposes
+// a health.Checker compatible probe. When the consecutive failure count reaches
+// the threshold the budget is "tripped" and Checker() returns a non-nil error.
+// A single success resets the counter and clears the tripped state.
+//
+// Design: absolute count (no sliding window), success clears zero — mirrors
+// K8s workqueue ItemExponentialFailureRateLimiter.Forget(item) semantics.
+//
+// ref: k8s.io/client-go/util/workqueue/default_rate_limiters.go — absolute
+// count + Forget(item) clears to zero; no decay window.
+// ref: controller-runtime/pkg/healthz — AddReadyzCheck(name, Checker) aggregation.
+type FailureBudget struct {
+	name      string
+	threshold int64
+	consec    atomic.Int64
+	tripped   atomic.Bool
+	// logged* tracks whether the log for the current state has been emitted
+	// to prevent repeat log spam on stable tripped/recovered state.
+	loggedTrip    atomic.Bool
+	loggedRecover atomic.Bool
+	logger        *slog.Logger
+}
+
+// NewFailureBudget creates a FailureBudget with the given name and threshold.
+// threshold=0 disables the budget (Checker always returns nil, Tripped always false).
+// Uses slog.Default() as the logger.
+func NewFailureBudget(name string, threshold int) *FailureBudget {
+	return NewFailureBudgetWithLogger(name, threshold, slog.Default())
+}
+
+// NewFailureBudgetWithLogger creates a FailureBudget with an explicit logger.
+// This variant is used in tests to capture log output.
+func NewFailureBudgetWithLogger(name string, threshold int, logger *slog.Logger) *FailureBudget {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FailureBudget{
+		name:      name,
+		threshold: int64(threshold),
+		logger:    logger,
+	}
+}
+
+// Record records the outcome of one operation. err!=nil increments the
+// consecutive failure counter and trips the budget when the threshold is
+// reached. err==nil resets the counter and clears the tripped state.
+//
+// Thread-safe: uses atomic operations throughout.
+func (b *FailureBudget) Record(err error) {
+	if b.threshold <= 0 {
+		return // disabled
+	}
+
+	if err != nil {
+		b.recordFailure()
+	} else {
+		b.recordSuccess()
+	}
+}
+
+// recordFailure handles the err!=nil path of Record.
+func (b *FailureBudget) recordFailure() {
+	newConsec := b.consec.Add(1)
+	if newConsec < b.threshold {
+		return
+	}
+	// At or past threshold: try to trip.
+	if b.tripped.CompareAndSwap(false, true) {
+		// We were the goroutine that tripped it — log once.
+		b.loggedRecover.Store(false) // reset recover-log flag for next recovery
+		if b.loggedTrip.CompareAndSwap(false, true) {
+			b.logger.Warn("outbox relay: failure budget exhausted",
+				slog.String("name", b.name),
+				slog.Int64("threshold", b.threshold),
+				slog.Int64("consecutive_failures", newConsec),
+			)
+		}
+	}
+}
+
+// recordSuccess handles the err==nil path of Record.
+func (b *FailureBudget) recordSuccess() {
+	b.consec.Store(0)
+	if b.tripped.CompareAndSwap(true, false) {
+		// We were the goroutine that cleared the trip — log once.
+		b.loggedTrip.Store(false) // reset trip-log flag for next trip
+		if b.loggedRecover.CompareAndSwap(false, true) {
+			b.logger.Info("outbox relay: failure budget recovered",
+				slog.String("name", b.name),
+			)
+		}
+	}
+}
+
+// Checker returns a func() error suitable for use as a health.Checker.
+// When threshold is 0 (disabled), returns nil.
+// When the budget is not tripped, the returned func returns nil.
+// When tripped, the returned func returns an error containing the budget name
+// and threshold.
+func (b *FailureBudget) Checker() func() error {
+	if b.threshold <= 0 {
+		return nil
+	}
+	return func() error {
+		if !b.tripped.Load() {
+			return nil
+		}
+		return errcode.New(errcode.ErrRelayBudgetExhausted,
+			fmt.Sprintf("relay failure budget %q exhausted: %d consecutive failures reached threshold %d",
+				b.name, b.consec.Load(), b.threshold))
+	}
+}
+
+// Tripped returns true when the consecutive failure count has reached the
+// threshold and has not yet been reset by a successful Record(nil) call.
+func (b *FailureBudget) Tripped() bool {
+	if b.threshold <= 0 {
+		return false
+	}
+	return b.tripped.Load()
+}
+
+// ConsecutiveFailures returns the current consecutive failure count.
+func (b *FailureBudget) ConsecutiveFailures() int64 {
+	return b.consec.Load()
+}

--- a/runtime/outbox/health.go
+++ b/runtime/outbox/health.go
@@ -69,6 +69,13 @@ func (b *FailureBudget) Record(err error) {
 }
 
 // recordFailure handles the err!=nil path of Record.
+//
+// Invariant: each state transition clears only the *opposite* side's log flag.
+// The trip path (false→true) clears loggedRecover so the next recovery logs.
+// The recover path (true→false) clears loggedTrip so the next trip logs.
+// This prevents the ABA window where clearing the same-side flag could race
+// with a concurrent recordSuccess that just set it — each CAS winner owns
+// exactly one side and only resets the other.
 func (b *FailureBudget) recordFailure() {
 	newConsec := b.consec.Add(1)
 	if newConsec < b.threshold {
@@ -76,8 +83,11 @@ func (b *FailureBudget) recordFailure() {
 	}
 	// At or past threshold: try to trip.
 	if b.tripped.CompareAndSwap(false, true) {
-		// We were the goroutine that tripped it — log once.
-		b.loggedRecover.Store(false) // reset recover-log flag for next recovery
+		// We tripped: clear the recover-log flag so the next recovery logs.
+		// Do NOT touch loggedTrip here — the CAS already guarantees we are the
+		// sole goroutine entering this branch; loggedTrip is cleared by the
+		// preceding recover path.
+		b.loggedRecover.Store(false)
 		if b.loggedTrip.CompareAndSwap(false, true) {
 			b.logger.Warn("outbox relay: failure budget exhausted",
 				slog.String("name", b.name),
@@ -89,11 +99,15 @@ func (b *FailureBudget) recordFailure() {
 }
 
 // recordSuccess handles the err==nil path of Record.
+//
+// Invariant: see recordFailure. The recover path (true→false) clears
+// loggedTrip so the next exhaustion logs. It does NOT touch loggedRecover,
+// which is cleared by the trip path, eliminating the ABA window.
 func (b *FailureBudget) recordSuccess() {
 	b.consec.Store(0)
 	if b.tripped.CompareAndSwap(true, false) {
-		// We were the goroutine that cleared the trip — log once.
-		b.loggedTrip.Store(false) // reset trip-log flag for next trip
+		// We recovered: clear the trip-log flag so the next exhaustion logs.
+		b.loggedTrip.Store(false)
 		if b.loggedRecover.CompareAndSwap(false, true) {
 			b.logger.Info("outbox relay: failure budget recovered",
 				slog.String("name", b.name),

--- a/runtime/outbox/health_test.go
+++ b/runtime/outbox/health_test.go
@@ -1,7 +1,6 @@
 package outbox_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -20,7 +19,6 @@ import (
 type capturingSlogHandler struct {
 	mu      sync.Mutex
 	records []slog.Record
-	buf     bytes.Buffer
 }
 
 func (h *capturingSlogHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
@@ -32,8 +30,8 @@ func (h *capturingSlogHandler) Handle(_ context.Context, r slog.Record) error {
 	return nil
 }
 
-func (h *capturingSlogHandler) WithAttrs(_ []slog.Attr) slog.Handler  { return h }
-func (h *capturingSlogHandler) WithGroup(_ string) slog.Handler       { return h }
+func (h *capturingSlogHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingSlogHandler) WithGroup(_ string) slog.Handler      { return h }
 
 func (h *capturingSlogHandler) countByLevel(level slog.Level) int {
 	h.mu.Lock()

--- a/runtime/outbox/health_test.go
+++ b/runtime/outbox/health_test.go
@@ -185,3 +185,38 @@ func TestFailureBudget_TripAndRecover_LogsOnce(t *testing.T) {
 	assert.Equal(t, 1, h.countByLevel(slog.LevelInfo),
 		"repeated successes after recover must not re-log Info")
 }
+
+// ---------------------------------------------------------------------------
+// TestFailureBudget_Reset_ClearsState
+// ---------------------------------------------------------------------------
+
+func TestFailureBudget_Reset_ClearsState(t *testing.T) {
+	const threshold = 3
+	fb := outbox.NewFailureBudget("reset-test", threshold)
+
+	// Trip the budget.
+	for range threshold {
+		fb.Record(errors.New("err"))
+	}
+	require.True(t, fb.Tripped(), "budget must be tripped before Reset")
+	require.Equal(t, int64(threshold), fb.ConsecutiveFailures())
+
+	// Reset must clear all state.
+	fb.Reset()
+	assert.False(t, fb.Tripped(), "Reset must clear tripped state")
+	assert.Equal(t, int64(0), fb.ConsecutiveFailures(), "Reset must clear consecutive failure count")
+	assert.Nil(t, fb.Checker()(), "Checker must return nil (healthy) after Reset")
+
+	// Verify reset budget can trip again after threshold new failures.
+	for range threshold {
+		fb.Record(errors.New("err"))
+	}
+	assert.True(t, fb.Tripped(), "budget must be able to trip again after Reset")
+}
+
+func TestFailureBudget_Reset_DisabledBudget_Noop(t *testing.T) {
+	fb := outbox.NewFailureBudget("disabled", 0) // threshold=0 → disabled
+	// Should not panic.
+	fb.Reset()
+	assert.False(t, fb.Tripped())
+}

--- a/runtime/outbox/health_test.go
+++ b/runtime/outbox/health_test.go
@@ -1,0 +1,189 @@
+package outbox_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/ghbvf/gocell/runtime/outbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// capturingSlogHandler captures log records for assertion in tests.
+// ---------------------------------------------------------------------------
+
+type capturingSlogHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+	buf     bytes.Buffer
+}
+
+func (h *capturingSlogHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *capturingSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *capturingSlogHandler) WithAttrs(_ []slog.Attr) slog.Handler  { return h }
+func (h *capturingSlogHandler) WithGroup(_ string) slog.Handler       { return h }
+
+func (h *capturingSlogHandler) countByLevel(level slog.Level) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	count := 0
+	for _, r := range h.records {
+		if r.Level == level {
+			count++
+		}
+	}
+	return count
+}
+
+// ---------------------------------------------------------------------------
+// TestFailureBudget_BelowThreshold_NotTripped
+// ---------------------------------------------------------------------------
+
+func TestFailureBudget_BelowThreshold_NotTripped(t *testing.T) {
+	const threshold = 5
+	fb := outbox.NewFailureBudget("test", threshold)
+
+	for i := range threshold - 1 {
+		fb.Record(errors.New("err"))
+		assert.Falsef(t, fb.Tripped(), "should not trip after %d failures", i+1)
+		assert.Nilf(t, fb.Checker()(), "Checker should return nil before threshold, got error after %d failures", i+1)
+	}
+
+	assert.Equal(t, int64(threshold-1), fb.ConsecutiveFailures())
+}
+
+// ---------------------------------------------------------------------------
+// TestFailureBudget_AtThreshold_Trips
+// ---------------------------------------------------------------------------
+
+func TestFailureBudget_AtThreshold_Trips(t *testing.T) {
+	const threshold = 3
+	fb := outbox.NewFailureBudget("relay-test", threshold)
+
+	for range threshold {
+		fb.Record(errors.New("err"))
+	}
+
+	assert.True(t, fb.Tripped(), "should trip exactly at threshold")
+	require.NotNil(t, fb.Checker(), "Checker must not be nil when tripped")
+	checkerErr := fb.Checker()()
+	require.Error(t, checkerErr)
+	assert.Contains(t, checkerErr.Error(), "relay-test")
+}
+
+// ---------------------------------------------------------------------------
+// TestFailureBudget_SuccessResets
+// ---------------------------------------------------------------------------
+
+func TestFailureBudget_SuccessResets(t *testing.T) {
+	const threshold = 3
+	fb := outbox.NewFailureBudget("reset-test", threshold)
+
+	for range threshold {
+		fb.Record(errors.New("err"))
+	}
+	require.True(t, fb.Tripped())
+
+	fb.Record(nil)
+
+	assert.False(t, fb.Tripped(), "success must reset tripped state")
+	assert.Equal(t, int64(0), fb.ConsecutiveFailures(), "success must zero consecutive failures")
+	assert.Nil(t, fb.Checker()(), "Checker must return nil after reset")
+}
+
+// ---------------------------------------------------------------------------
+// TestFailureBudget_ThresholdZero_Disabled
+// ---------------------------------------------------------------------------
+
+func TestFailureBudget_ThresholdZero_Disabled(t *testing.T) {
+	fb := outbox.NewFailureBudget("disabled", 0)
+
+	for range 100 {
+		fb.Record(errors.New("err"))
+	}
+
+	assert.False(t, fb.Tripped(), "threshold=0 must never trip")
+	assert.Nil(t, fb.Checker(), "threshold=0 Checker must return nil function")
+}
+
+// ---------------------------------------------------------------------------
+// TestFailureBudget_Concurrent
+// ---------------------------------------------------------------------------
+
+func TestFailureBudget_Concurrent(t *testing.T) {
+	// 50 goroutines × 100 Record calls each with error — no success resets.
+	// After all goroutines finish, the budget must be tripped (5000 errors >> threshold 10).
+	// Primary goal: no data race under -race.
+	const (
+		goroutines = 50
+		iterations = 100
+	)
+
+	fb := outbox.NewFailureBudget("concurrent", 10)
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				fb.Record(errors.New("err"))
+			}
+		}()
+	}
+	wg.Wait()
+
+	// All goroutines sent errors — budget must be tripped.
+	assert.True(t, fb.Tripped(), "budget must be tripped after all-error run")
+	assert.GreaterOrEqual(t, fb.ConsecutiveFailures(), int64(10),
+		"consecutive failures must be >= threshold")
+}
+
+// ---------------------------------------------------------------------------
+// TestFailureBudget_TripAndRecover_LogsOnce
+// ---------------------------------------------------------------------------
+
+func TestFailureBudget_TripAndRecover_LogsOnce(t *testing.T) {
+	const threshold = 3
+	h := &capturingSlogHandler{}
+	logger := slog.New(h)
+	fb := outbox.NewFailureBudgetWithLogger("log-test", threshold, logger)
+
+	// Trip: should log exactly one Warn.
+	for range threshold {
+		fb.Record(errors.New("err"))
+	}
+	assert.Equal(t, 1, h.countByLevel(slog.LevelWarn),
+		"first trip must log exactly one Warn")
+
+	// More failures: no additional Warn logs.
+	for range 5 {
+		fb.Record(errors.New("err"))
+	}
+	assert.Equal(t, 1, h.countByLevel(slog.LevelWarn),
+		"repeated failures after trip must not re-log Warn")
+
+	// Recover: should log exactly one Info.
+	fb.Record(nil)
+	assert.Equal(t, 1, h.countByLevel(slog.LevelInfo),
+		"first recovery must log exactly one Info")
+
+	// More successes: no additional Info logs.
+	for range 5 {
+		fb.Record(nil)
+	}
+	assert.Equal(t, 1, h.countByLevel(slog.LevelInfo),
+		"repeated successes after recover must not re-log Info")
+}

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -120,14 +120,6 @@ func NewRelay(store Store, pub kout.Publisher, cfg RelayConfig) *Relay {
 	// ref: runtime/http/middleware/safe_observe.go — same pattern for HTTP metrics.
 	metrics := &safeRelayCollector{inner: cfg.Metrics}
 
-	// Guard: all three failure budgets at zero means no loop health will ever be
-	// reflected in /readyz.  This is the zero-value trap: RelayConfig{} disables
-	// all budgets, unlike DefaultRelayConfig() which sets each to 5.
-	if cfg.PollFailureBudget == 0 && cfg.ReclaimFailureBudget == 0 && cfg.CleanupFailureBudget == 0 {
-		slog.Warn("outbox relay: all failure budgets disabled, /readyz will not reflect relay health",
-			slog.String("hint", "use outbox.DefaultRelayConfig() or set at least one *FailureBudget > 0"))
-	}
-
 	// Guard: ClaimTTL must exceed 2x PollInterval to prevent ReclaimStale
 	// from reclaiming entries still being processed.
 	if cfg.ClaimTTL <= cfg.PollInterval*2 {

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -176,6 +176,18 @@ func (r *Relay) Start(ctx context.Context) error {
 	r.wg.Add(3)
 	r.mu.Unlock()
 
+	// Reset budgets so stale trip state from a previous run does not bleed into
+	// the new run.  Must happen after CAS (exclusive) and before goroutines start.
+	if r.pollBudget != nil {
+		r.pollBudget.Reset()
+	}
+	if r.reclaimBudget != nil {
+		r.reclaimBudget.Reset()
+	}
+	if r.cleanupBudget != nil {
+		r.cleanupBudget.Reset()
+	}
+
 	r.state.Store(int32(relayRunning))
 	close(r.readyCh)
 

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -141,6 +141,7 @@ func NewRelay(store Store, pub kout.Publisher, cfg RelayConfig) *Relay {
 		pub:     pub,
 		cfg:     cfg,
 		metrics: metrics,
+		readyCh: make(chan struct{}),
 	}
 	// Instantiate failure budgets. threshold=0 → nil (disabled).
 	if cfg.PollFailureBudget > 0 {
@@ -168,17 +169,15 @@ func (r *Relay) Start(ctx context.Context) error {
 
 	ctx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
-	ready := make(chan struct{})
 
 	r.mu.Lock()
 	r.cancel = cancel
 	r.done = done
-	r.readyCh = ready
 	r.wg.Add(3)
 	r.mu.Unlock()
 
 	r.state.Store(int32(relayRunning))
-	close(ready)
+	close(r.readyCh)
 
 	defer func() {
 		r.wg.Wait()
@@ -186,7 +185,7 @@ func (r *Relay) Start(ctx context.Context) error {
 		r.mu.Lock()
 		r.cancel = nil
 		r.done = nil
-		r.readyCh = nil // clear so Ready() returns nil between Stop and next Start
+		r.readyCh = make(chan struct{}) // fresh open channel; next Start() will close it
 		r.state.Store(int32(relayStopped))
 		close(done)
 		r.mu.Unlock()
@@ -222,12 +221,15 @@ func (r *Relay) Start(ctx context.Context) error {
 // It respects the caller's context deadline: if ctx expires before goroutines
 // finish, Stop returns an error instead of blocking indefinitely.
 func (r *Relay) Stop(ctx context.Context) error {
-	// If never started, no-op (consistent with worker.Worker contract).
+	// If never started (or already stopped), no-op (consistent with worker.Worker
+	// contract).  We detect this by checking cancel under mu: cancel is only set
+	// during an active Start() call and cleared by the Start() defer on shutdown.
 	r.mu.Lock()
+	notStarted := r.cancel == nil && relayState(r.state.Load()) == relayStopped
 	ready := r.readyCh
 	r.mu.Unlock()
 
-	if ready == nil {
+	if notStarted {
 		return nil
 	}
 
@@ -667,8 +669,10 @@ func (r *Relay) HealthCheckers() map[string]func() error {
 //	    // timeout
 //	}
 //
-// If Start() has not been called yet, Ready() returns nil — a nil channel
-// blocks forever, which callers should handle with a timeout.
+// Ready() never returns nil. Before Start() completes (or after Stop()), the
+// returned channel is open and will not close until the next Start() runs to
+// completion. Callers that want to detect the "not yet started" state should
+// still guard the select with a timeout.
 func (r *Relay) Ready() <-chan struct{} {
 	r.mu.Lock()
 	ch := r.readyCh

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -120,6 +120,14 @@ func NewRelay(store Store, pub kout.Publisher, cfg RelayConfig) *Relay {
 	// ref: runtime/http/middleware/safe_observe.go — same pattern for HTTP metrics.
 	metrics := &safeRelayCollector{inner: cfg.Metrics}
 
+	// Guard: all three failure budgets at zero means no loop health will ever be
+	// reflected in /readyz.  This is the zero-value trap: RelayConfig{} disables
+	// all budgets, unlike DefaultRelayConfig() which sets each to 5.
+	if cfg.PollFailureBudget == 0 && cfg.ReclaimFailureBudget == 0 && cfg.CleanupFailureBudget == 0 {
+		slog.Warn("outbox relay: all failure budgets disabled, /readyz will not reflect relay health",
+			slog.String("hint", "use outbox.DefaultRelayConfig() or set at least one *FailureBudget > 0"))
+	}
+
 	// Guard: ClaimTTL must exceed 2x PollInterval to prevent ReclaimStale
 	// from reclaiming entries still being processed.
 	if cfg.ClaimTTL <= cfg.PollInterval*2 {

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -178,6 +178,7 @@ func (r *Relay) Start(ctx context.Context) error {
 		r.mu.Lock()
 		r.cancel = nil
 		r.done = nil
+		r.readyCh = nil // clear so Ready() returns nil between Stop and next Start
 		r.state.Store(int32(relayStopped))
 		close(done)
 		r.mu.Unlock()

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -99,6 +99,12 @@ type Relay struct {
 	readyCh chan struct{} // closed once Start() transitions to relayRunning
 
 	wg sync.WaitGroup
+
+	// Failure budgets for each background loop. nil means disabled (threshold=0).
+	// ref: K8s workqueue ItemExponentialFailureRateLimiter — absolute count + Forget.
+	pollBudget    *FailureBudget
+	reclaimBudget *FailureBudget
+	cleanupBudget *FailureBudget
 }
 
 // NewRelay creates a Relay that polls from store and publishes via pub.
@@ -122,12 +128,23 @@ func NewRelay(store Store, pub kout.Publisher, cfg RelayConfig) *Relay {
 			slog.Duration("poll_interval", cfg.PollInterval))
 	}
 
-	return &Relay{
+	r := &Relay{
 		store:   store,
 		pub:     pub,
 		cfg:     cfg,
 		metrics: metrics,
 	}
+	// Instantiate failure budgets. threshold=0 → nil (disabled).
+	if cfg.PollFailureBudget > 0 {
+		r.pollBudget = NewFailureBudget("outbox-relay-poll", cfg.PollFailureBudget)
+	}
+	if cfg.ReclaimFailureBudget > 0 {
+		r.reclaimBudget = NewFailureBudget("outbox-relay-reclaim", cfg.ReclaimFailureBudget)
+	}
+	if cfg.CleanupFailureBudget > 0 {
+		r.cleanupBudget = NewFailureBudget("outbox-relay-cleanup", cfg.CleanupFailureBudget)
+	}
+	return r
 }
 
 // ---------------------------------------------------------------------------
@@ -250,10 +267,14 @@ func (r *Relay) pollLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := r.pollOnce(ctx); err != nil {
+			err := r.pollOnce(ctx)
+			if err != nil {
 				slog.Error("outbox relay: poll failed",
 					slog.Any("error", err),
 				)
+			}
+			if r.pollBudget != nil {
+				r.pollBudget.Record(err)
 			}
 		}
 	}
@@ -269,10 +290,14 @@ func (r *Relay) reclaimLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := r.reclaimStale(ctx); err != nil {
+			err := r.reclaimStale(ctx)
+			if err != nil {
 				slog.Error("outbox relay: reclaim failed",
 					slog.Any("error", err),
 				)
+			}
+			if r.reclaimBudget != nil {
+				r.reclaimBudget.Record(err)
 			}
 		}
 	}
@@ -286,8 +311,12 @@ func (r *Relay) reclaimLoop(ctx context.Context) {
 // rows exist for a long time.
 func (r *Relay) cleanupLoop(ctx context.Context) {
 	for {
-		if err := r.cleanup(ctx); err != nil {
+		err := r.cleanup(ctx)
+		if err != nil {
 			slog.Error("outbox relay: cleanup failed", slog.Any("error", err))
+		}
+		if r.cleanupBudget != nil {
+			r.cleanupBudget.Record(err)
 		}
 
 		wait := r.nextCleanupWait(ctx)
@@ -299,12 +328,12 @@ func (r *Relay) cleanupLoop(ctx context.Context) {
 	}
 }
 
-// cleanupWaitFloor and cleanupWaitCeiling bound the cleanup wake-up sleep.
+// defaultCleanupWaitFloor and cleanupWaitCeiling bound the cleanup wake-up sleep.
 // Floor avoids tight-loop on clock skew. Ceiling forces a periodic re-check
 // even when the table is empty (OldestEligibleAt returns ok=false).
 const (
-	cleanupWaitFloor   = 5 * time.Second
-	cleanupWaitCeiling = 1 * time.Hour
+	defaultCleanupWaitFloor = 5 * time.Second
+	cleanupWaitCeiling      = 1 * time.Hour
 )
 
 // nextCleanupWait computes how long the cleanup loop should sleep before the
@@ -327,10 +356,20 @@ func (r *Relay) nextCleanupWait(ctx context.Context) time.Duration {
 		}
 	}
 
-	if wait < cleanupWaitFloor {
-		wait = cleanupWaitFloor
+	floor := r.cleanupWaitFloor()
+	if wait < floor {
+		wait = floor
 	}
 	return wait
+}
+
+// cleanupWaitFloor returns the effective cleanup floor duration:
+// cfg.CleanupWaitFloor if positive, otherwise defaultCleanupWaitFloor.
+func (r *Relay) cleanupWaitFloor() time.Duration {
+	if r.cfg.CleanupWaitFloor > 0 {
+		return r.cfg.CleanupWaitFloor
+	}
+	return defaultCleanupWaitFloor
 }
 
 // oldestOrZero wraps Store.OldestEligibleAt with logging and an idle-fallback:
@@ -579,6 +618,53 @@ func (r *Relay) cappedDelay(d time.Duration) time.Duration {
 		return r.cfg.MaxRetryDelay
 	}
 	return d
+}
+
+// ---------------------------------------------------------------------------
+// Health and readiness
+// ---------------------------------------------------------------------------
+
+// HealthCheckers returns a map of named health checker functions, one per
+// enabled failure budget. The returned functions implement the
+// health.Checker contract: nil return = healthy; non-nil = unhealthy.
+//
+// Only budgets with a positive threshold are included; threshold=0 (disabled)
+// budgets are excluded from the map so callers can safely iterate all entries
+// and register them unconditionally.
+//
+// ref: controller-runtime/pkg/healthz AddReadyzCheck — named-checker aggregation.
+func (r *Relay) HealthCheckers() map[string]func() error {
+	m := make(map[string]func() error)
+	if r.pollBudget != nil {
+		m["outbox-relay-poll"] = r.pollBudget.Checker()
+	}
+	if r.reclaimBudget != nil {
+		m["outbox-relay-reclaim"] = r.reclaimBudget.Checker()
+	}
+	if r.cleanupBudget != nil {
+		m["outbox-relay-cleanup"] = r.cleanupBudget.Checker()
+	}
+	return m
+}
+
+// Ready returns the channel that is closed when Start() has transitioned the
+// relay to the running state. Callers can use this to synchronise without
+// polling:
+//
+//	select {
+//	case <-relay.Ready():
+//	    // relay is running
+//	case <-time.After(deadline):
+//	    // timeout
+//	}
+//
+// If Start() has not been called yet, Ready() returns nil — a nil channel
+// blocks forever, which callers should handle with a timeout.
+func (r *Relay) Ready() <-chan struct{} {
+	r.mu.Lock()
+	ch := r.readyCh
+	r.mu.Unlock()
+	return ch
 }
 
 // retryDelay computes exponential backoff with jitter and cap.

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -270,7 +270,7 @@ func (r *Relay) pollLoop(ctx context.Context) {
 		case <-ticker.C:
 			err := r.pollOnce(ctx)
 			if err != nil {
-				slog.Error("outbox relay: poll failed",
+				slog.Warn("outbox relay: poll failed",
 					slog.Any("error", err),
 				)
 			}
@@ -293,7 +293,7 @@ func (r *Relay) reclaimLoop(ctx context.Context) {
 		case <-ticker.C:
 			err := r.reclaimStale(ctx)
 			if err != nil {
-				slog.Error("outbox relay: reclaim failed",
+				slog.Warn("outbox relay: reclaim failed",
 					slog.Any("error", err),
 				)
 			}
@@ -314,7 +314,7 @@ func (r *Relay) cleanupLoop(ctx context.Context) {
 	for {
 		err := r.cleanup(ctx)
 		if err != nil {
-			slog.Error("outbox relay: cleanup failed", slog.Any("error", err))
+			slog.Warn("outbox relay: cleanup failed", slog.Any("error", err))
 		}
 		if r.cleanupBudget != nil {
 			r.cleanupBudget.Record(err)

--- a/runtime/outbox/relay_internal_test.go
+++ b/runtime/outbox/relay_internal_test.go
@@ -269,12 +269,15 @@ func TestRelay_Cleanup_DeletesPublishedAndDead(t *testing.T) {
 		metrics: &safeRelayCollector{inner: kout.NoopRelayCollector{}},
 	}
 
-	// Sleep briefly so time.Now().Add(-1ms) is definitely after the forced past timestamps.
-	time.Sleep(5 * time.Millisecond)
-
-	err := relay.cleanup(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, 0, store.count(), "both published and dead entries must be deleted")
+	// Use Eventually so the test remains deterministic: the 1ms retention period
+	// must have elapsed before cleanup can delete entries. In practice the 48h-old
+	// timestamps far predate any reasonable cutoff, so this resolves in one tick.
+	require.Eventually(t, func() bool {
+		if err := relay.cleanup(context.Background()); err != nil {
+			return false
+		}
+		return store.count() == 0
+	}, time.Second, 2*time.Millisecond, "both published and dead entries must be deleted")
 }
 
 func TestRelay_Cleanup_NoEntries_NoError(t *testing.T) {

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -117,6 +117,7 @@ func fastCfg() outbox.RelayConfig {
 		ClaimTTL:            100 * time.Millisecond,
 		RetentionPeriod:     1 * time.Hour,
 		DeadRetentionPeriod: 24 * time.Hour,
+		CleanupWaitFloor:    5 * time.Millisecond,
 	}
 }
 
@@ -547,6 +548,239 @@ func TestRelay_SanitizesError_InLastError(t *testing.T) {
 	require.Len(t, snap, 1)
 	assert.NotContains(t, snap[0].LastError, "secret123", "sensitive data must be redacted")
 	assert.Contains(t, snap[0].LastError, "<REDACTED>")
+}
+
+// ---------------------------------------------------------------------------
+// B2 FailureBudget integration tests
+// ---------------------------------------------------------------------------
+
+// failingStore is a Store whose ClaimPending / ReclaimStale / CleanupPublished
+// methods can be configured to always return an error.
+type failingStore struct {
+	*outboxtest.FakeStore
+	mu             sync.Mutex
+	claimErr       error
+	reclaimErr     error
+	cleanupPubErr  error
+}
+
+func newFailingStore() *failingStore {
+	return &failingStore{FakeStore: outboxtest.NewFakeStore()}
+}
+
+func (s *failingStore) setClaimErr(err error) {
+	s.mu.Lock()
+	s.claimErr = err
+	s.mu.Unlock()
+}
+
+func (s *failingStore) setReclaimErr(err error) {
+	s.mu.Lock()
+	s.reclaimErr = err
+	s.mu.Unlock()
+}
+
+func (s *failingStore) setCleanupPubErr(err error) {
+	s.mu.Lock()
+	s.cleanupPubErr = err
+	s.mu.Unlock()
+}
+
+func (s *failingStore) ClaimPending(ctx context.Context, batchSize int) ([]outbox.ClaimedEntry, error) {
+	s.mu.Lock()
+	err := s.claimErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return s.FakeStore.ClaimPending(ctx, batchSize)
+}
+
+func (s *failingStore) ReclaimStale(ctx context.Context, claimTTL time.Duration, maxAttempts int, base, maxDelay time.Duration) (int, error) {
+	s.mu.Lock()
+	err := s.reclaimErr
+	s.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return s.FakeStore.ReclaimStale(ctx, claimTTL, maxAttempts, base, maxDelay)
+}
+
+func (s *failingStore) CleanupPublished(ctx context.Context, cutoff time.Time, batchSize int) (int, error) {
+	s.mu.Lock()
+	err := s.cleanupPubErr
+	s.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return s.FakeStore.CleanupPublished(ctx, cutoff, batchSize)
+}
+
+// OldestEligibleAt returns a fake "very recent past" time for published status
+// when a cleanupPubErr is set, so nextCleanupWait schedules quickly via floor.
+func (s *failingStore) OldestEligibleAt(ctx context.Context, status string) (time.Time, bool, error) {
+	s.mu.Lock()
+	cpErr := s.cleanupPubErr
+	s.mu.Unlock()
+	if cpErr != nil && status == "published" {
+		// Return a time just barely in the past so nextCleanupWait computes
+		// near-zero and falls to cleanupWaitFloor (set to 5ms in tests).
+		return time.Now().Add(-time.Millisecond), true, nil
+	}
+	return s.FakeStore.OldestEligibleAt(ctx, status)
+}
+
+func budgetCfg() outbox.RelayConfig {
+	cfg := fastCfg()
+	cfg.PollFailureBudget = 3
+	cfg.ReclaimFailureBudget = 3
+	cfg.CleanupFailureBudget = 3
+	// Use a tiny RetentionPeriod so nextCleanupWait returns floor (5ms) when
+	// OldestEligibleAt reports a row was published ~1ms ago.
+	cfg.RetentionPeriod = time.Millisecond
+	cfg.DeadRetentionPeriod = time.Millisecond
+	return cfg
+}
+
+func TestRelay_PollFailureBudget_TripsAfterConsecutiveFailures(t *testing.T) {
+	store := newFailingStore()
+	store.setClaimErr(errors.New("db down"))
+
+	relay := outbox.NewRelay(store, newFakePublisher(), budgetCfg())
+
+	_, stop := startRelay(t, relay)
+	defer stop()
+
+	// Wait for the poll budget checker to become non-nil (trip).
+	require.Eventually(t, func() bool {
+		checkers := relay.HealthCheckers()
+		fn, ok := checkers["outbox-relay-poll"]
+		if !ok {
+			return false
+		}
+		return fn() != nil
+	}, 2*time.Second, 5*time.Millisecond, "poll budget must trip after consecutive failures")
+}
+
+func TestRelay_PollFailureBudget_ResetsOnSuccess(t *testing.T) {
+	store := newFailingStore()
+	store.setClaimErr(errors.New("db down"))
+
+	relay := outbox.NewRelay(store, newFakePublisher(), budgetCfg())
+
+	_, stop := startRelay(t, relay)
+	defer stop()
+
+	// Trip first.
+	require.Eventually(t, func() bool {
+		checkers := relay.HealthCheckers()
+		fn, ok := checkers["outbox-relay-poll"]
+		return ok && fn() != nil
+	}, 2*time.Second, 5*time.Millisecond, "budget must trip")
+
+	// Clear the error so poll succeeds.
+	store.setClaimErr(nil)
+
+	// Checker must recover.
+	require.Eventually(t, func() bool {
+		checkers := relay.HealthCheckers()
+		fn, ok := checkers["outbox-relay-poll"]
+		return ok && fn() == nil
+	}, 2*time.Second, 5*time.Millisecond, "poll budget must reset after success")
+}
+
+func TestRelay_ReclaimFailureBudget_Independent(t *testing.T) {
+	// Only reclaim fails — poll and cleanup must remain healthy.
+	store := newFailingStore()
+	store.setReclaimErr(errors.New("reclaim db down"))
+
+	relay := outbox.NewRelay(store, newFakePublisher(), budgetCfg())
+
+	_, stop := startRelay(t, relay)
+	defer stop()
+
+	require.Eventually(t, func() bool {
+		checkers := relay.HealthCheckers()
+		fn, ok := checkers["outbox-relay-reclaim"]
+		return ok && fn() != nil
+	}, 2*time.Second, 5*time.Millisecond, "reclaim budget must trip")
+
+	// Poll checker must still be healthy.
+	checkers := relay.HealthCheckers()
+	if fn, ok := checkers["outbox-relay-poll"]; ok {
+		assert.Nil(t, fn(), "poll checker must remain healthy when only reclaim fails")
+	}
+}
+
+func TestRelay_CleanupFailureBudget_Independent(t *testing.T) {
+	// Only cleanup fails — poll budget must remain healthy.
+	store := newFailingStore()
+	store.setCleanupPubErr(errors.New("cleanup db down"))
+
+	relay := outbox.NewRelay(store, newFakePublisher(), budgetCfg())
+
+	_, stop := startRelay(t, relay)
+	defer stop()
+
+	require.Eventually(t, func() bool {
+		checkers := relay.HealthCheckers()
+		fn, ok := checkers["outbox-relay-cleanup"]
+		return ok && fn() != nil
+	}, 2*time.Second, 5*time.Millisecond, "cleanup budget must trip")
+
+	// Poll checker must still be healthy.
+	checkers := relay.HealthCheckers()
+	if fn, ok := checkers["outbox-relay-poll"]; ok {
+		assert.Nil(t, fn(), "poll checker must remain healthy when only cleanup fails")
+	}
+}
+
+func TestRelay_HealthCheckers_RegistersThree(t *testing.T) {
+	relay := outbox.NewRelay(outboxtest.NewFakeStore(), newFakePublisher(), budgetCfg())
+	checkers := relay.HealthCheckers()
+
+	require.Contains(t, checkers, "outbox-relay-poll", "poll checker must be registered")
+	require.Contains(t, checkers, "outbox-relay-reclaim", "reclaim checker must be registered")
+	require.Contains(t, checkers, "outbox-relay-cleanup", "cleanup checker must be registered")
+	assert.Len(t, checkers, 3)
+}
+
+func TestRelay_FailureBudgetThresholdZero_DisablesChecker(t *testing.T) {
+	cfg := fastCfg()
+	cfg.PollFailureBudget = 0    // disabled
+	cfg.ReclaimFailureBudget = 3 // enabled
+	cfg.CleanupFailureBudget = 3 // enabled
+
+	relay := outbox.NewRelay(outboxtest.NewFakeStore(), newFakePublisher(), cfg)
+	checkers := relay.HealthCheckers()
+
+	assert.NotContains(t, checkers, "outbox-relay-poll",
+		"threshold=0 must not register poll checker")
+	assert.Contains(t, checkers, "outbox-relay-reclaim")
+	assert.Contains(t, checkers, "outbox-relay-cleanup")
+}
+
+func TestRelay_Ready_ReturnsReadyChannel(t *testing.T) {
+	relay := outbox.NewRelay(outboxtest.NewFakeStore(), newFakePublisher(), fastCfg())
+
+	_, stop := startRelay(t, relay)
+	defer stop()
+
+	// Ready() returns nil before Start() has set up readyCh. Poll until non-nil,
+	// then read from it. Design: nil channel blocks forever — caller must handle
+	// with a timeout or poll as shown here.
+	require.Eventually(t, func() bool {
+		ch := relay.Ready()
+		if ch == nil {
+			return false
+		}
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 2*time.Millisecond, "relay.Ready() must close after Start")
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -592,10 +592,10 @@ func TestRelay_SanitizesError_InLastError(t *testing.T) {
 // methods can be configured to always return an error.
 type failingStore struct {
 	*outboxtest.FakeStore
-	mu             sync.Mutex
-	claimErr       error
-	reclaimErr     error
-	cleanupPubErr  error
+	mu            sync.Mutex
+	claimErr      error
+	reclaimErr    error
+	cleanupPubErr error
 }
 
 func newFailingStore() *failingStore {

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -261,8 +261,19 @@ func TestRelay_Shutdown_CleanStop(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- relay.Start(ctx) }()
 
-	// Give relay time to start.
-	time.Sleep(20 * time.Millisecond)
+	// Wait for relay to reach running state via Ready() instead of time.Sleep.
+	require.Eventually(t, func() bool {
+		ch := relay.Ready()
+		if ch == nil {
+			return false
+		}
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond, "relay not ready")
 
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer stopCancel()
@@ -291,8 +302,19 @@ func TestRelay_DoubleStart_Error(t *testing.T) {
 	relay := outbox.NewRelay(store, newFakePublisher(), fastCfg())
 
 	go func() { _ = relay.Start(t.Context()) }()
-	// Give relay time to reach running state.
-	time.Sleep(20 * time.Millisecond)
+	// Wait for relay to reach running state.
+	require.Eventually(t, func() bool {
+		ch := relay.Ready()
+		if ch == nil {
+			return false
+		}
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond, "relay not ready for DoubleStart test")
 
 	err := relay.Start(context.Background())
 	require.Error(t, err)
@@ -308,7 +330,19 @@ func TestRelay_CanRestartAfterStop(t *testing.T) {
 		errCh := make(chan error, 1)
 		go func() { errCh <- relay.Start(ctx) }()
 
-		time.Sleep(20 * time.Millisecond)
+		// Wait for relay to be ready before stopping.
+		require.Eventually(t, func() bool {
+			ch := relay.Ready()
+			if ch == nil {
+				return false
+			}
+			select {
+			case <-ch:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, time.Millisecond, "relay not ready in iteration %d", i)
 
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		err := relay.Stop(stopCtx)

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -800,6 +800,58 @@ func TestRelay_FailureBudgetThresholdZero_DisablesChecker(t *testing.T) {
 	assert.Contains(t, checkers, "outbox-relay-cleanup")
 }
 
+func TestRelay_CanRestartAfterTrip_ResetsBudget(t *testing.T) {
+	// Threshold=3 so we trip quickly without a long poll loop.
+	store := newFailingStore()
+	store.setClaimErr(errors.New("db down"))
+
+	cfg := budgetCfg()
+	cfg.PollFailureBudget = 3
+	relay := outbox.NewRelay(store, newFakePublisher(), cfg)
+
+	// --- First run: trip the poll budget ---
+	_, stop := startRelay(t, relay)
+
+	require.Eventually(t, func() bool {
+		checkers := relay.HealthCheckers()
+		fn, ok := checkers["outbox-relay-poll"]
+		return ok && fn() != nil
+	}, 2*time.Second, 5*time.Millisecond, "poll budget must trip during first run")
+
+	stop() // gracefully stop; defer in Start resets readyCh for next Start
+
+	// Wait until state is relayStopped so we can restart.
+	require.Eventually(t, func() bool {
+		checkers := relay.HealthCheckers()
+		fn, ok := checkers["outbox-relay-poll"]
+		// The checker still exists; it reflects state at the time of the last run.
+		// We just need the relay to have fully stopped.
+		_ = fn
+		_ = ok
+		return true // we'll use Ready() channel approach below
+	}, 100*time.Millisecond, 2*time.Millisecond)
+
+	// Clear the error so the second run succeeds.
+	store.setClaimErr(nil)
+
+	// --- Second run: budget must be reset before first poll ---
+	_, stop2 := startRelay(t, relay)
+	defer stop2()
+
+	// Wait for relay to be running.
+	select {
+	case <-relay.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("relay did not become ready for second run")
+	}
+
+	// Immediately after start (before any poll result), poll checker must be
+	// healthy because Reset() cleared the stale trip from the first run.
+	checkers := relay.HealthCheckers()
+	require.Contains(t, checkers, "outbox-relay-poll", "poll checker must be registered on second run")
+	assert.Nil(t, checkers["outbox-relay-poll"](), "poll checker must be healthy immediately after restart (Reset cleared stale trip)")
+}
+
 func TestRelay_Ready_ReturnsReadyChannel(t *testing.T) {
 	relay := outbox.NewRelay(outboxtest.NewFakeStore(), newFakePublisher(), fastCfg())
 

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -739,13 +739,14 @@ func TestRelay_ReclaimFailureBudget_Independent(t *testing.T) {
 		return ok && fn() != nil
 	}, 2*time.Second, 5*time.Millisecond, "reclaim budget must trip")
 
+	// Verify poll checker exists upfront (fail-fast if absent, catching silent skips).
+	checkers := relay.HealthCheckers()
+	require.Contains(t, checkers, "outbox-relay-poll", "poll checker must be registered")
+	pollChecker := checkers["outbox-relay-poll"]
+
 	// Poll checker must never become unhealthy while only reclaim fails.
 	assert.Never(t, func() bool {
-		checkers := relay.HealthCheckers()
-		if fn, ok := checkers["outbox-relay-poll"]; ok {
-			return fn() != nil
-		}
-		return false
+		return pollChecker() != nil
 	}, 100*time.Millisecond, 5*time.Millisecond, "poll budget should not trip while only reclaim fails")
 }
 
@@ -765,13 +766,14 @@ func TestRelay_CleanupFailureBudget_Independent(t *testing.T) {
 		return ok && fn() != nil
 	}, 2*time.Second, 5*time.Millisecond, "cleanup budget must trip")
 
+	// Verify poll checker exists upfront (fail-fast if absent, catching silent skips).
+	checkers2 := relay.HealthCheckers()
+	require.Contains(t, checkers2, "outbox-relay-poll", "poll checker must be registered")
+	pollChecker2 := checkers2["outbox-relay-poll"]
+
 	// Poll checker must never become unhealthy while only cleanup fails.
 	assert.Never(t, func() bool {
-		checkers := relay.HealthCheckers()
-		if fn, ok := checkers["outbox-relay-poll"]; ok {
-			return fn() != nil
-		}
-		return false
+		return pollChecker2() != nil
 	}, 100*time.Millisecond, 5*time.Millisecond, "poll budget should not trip while only cleanup fails")
 }
 

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -806,14 +806,10 @@ func TestRelay_Ready_ReturnsReadyChannel(t *testing.T) {
 	_, stop := startRelay(t, relay)
 	defer stop()
 
-	// Ready() returns nil before Start() has set up readyCh. Poll until non-nil,
-	// then read from it. Design: nil channel blocks forever — caller must handle
-	// with a timeout or poll as shown here.
+	// Ready() never returns nil (B1: pre-allocated in NewRelay). Before Start()
+	// completes, the channel is open (blocks); after relayRunning, it is closed.
 	require.Eventually(t, func() bool {
 		ch := relay.Ready()
-		if ch == nil {
-			return false
-		}
 		select {
 		case <-ch:
 			return true

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -739,11 +739,14 @@ func TestRelay_ReclaimFailureBudget_Independent(t *testing.T) {
 		return ok && fn() != nil
 	}, 2*time.Second, 5*time.Millisecond, "reclaim budget must trip")
 
-	// Poll checker must still be healthy.
-	checkers := relay.HealthCheckers()
-	if fn, ok := checkers["outbox-relay-poll"]; ok {
-		assert.Nil(t, fn(), "poll checker must remain healthy when only reclaim fails")
-	}
+	// Poll checker must never become unhealthy while only reclaim fails.
+	assert.Never(t, func() bool {
+		checkers := relay.HealthCheckers()
+		if fn, ok := checkers["outbox-relay-poll"]; ok {
+			return fn() != nil
+		}
+		return false
+	}, 100*time.Millisecond, 5*time.Millisecond, "poll budget should not trip while only reclaim fails")
 }
 
 func TestRelay_CleanupFailureBudget_Independent(t *testing.T) {
@@ -762,11 +765,14 @@ func TestRelay_CleanupFailureBudget_Independent(t *testing.T) {
 		return ok && fn() != nil
 	}, 2*time.Second, 5*time.Millisecond, "cleanup budget must trip")
 
-	// Poll checker must still be healthy.
-	checkers := relay.HealthCheckers()
-	if fn, ok := checkers["outbox-relay-poll"]; ok {
-		assert.Nil(t, fn(), "poll checker must remain healthy when only cleanup fails")
-	}
+	// Poll checker must never become unhealthy while only cleanup fails.
+	assert.Never(t, func() bool {
+		checkers := relay.HealthCheckers()
+		if fn, ok := checkers["outbox-relay-poll"]; ok {
+			return fn() != nil
+		}
+		return false
+	}, 100*time.Millisecond, 5*time.Millisecond, "poll budget should not trip while only cleanup fails")
 }
 
 func TestRelay_HealthCheckers_RegistersThree(t *testing.T) {


### PR DESCRIPTION
## Summary

- **P1-15 relay readiness budget**: 引入 `FailureBudget` 原子状态机（对标 K8s workqueue 绝对计数 + 成功清零），poll/reclaim/cleanup 三个独立 budget；连续失败 ≥ 阈值（默认 5）→ checker fail → `/readyz` 返回 503
- **Bootstrap 接线**：新增 `bootstrap.WithRelayHealth(*outbox.Relay)` option 自动注册三个 checker
- **测试 sleep 清理**：`relay_test.go` / `consumer_base_test.go` 共 6 处启动同步 sleep → `Relay.Ready()` channel / `require.Eventually` / signal chan

对标：K8s client-go workqueue `TypedItemExponentialFailureRateLimiter` / controller-runtime `AddReadyzCheck` / go-micro `RegisterCheck{Critical:true}`

## 改动分层

| 层 | 改动 |
|----|------|
| `pkg/errcode` + `pkg/httputil` | 新增 `ErrRelayBudgetExhausted` → 503 映射 |
| `runtime/outbox/health.go` (新) | `FailureBudget` 原子状态机 + `Checker()` 工厂 |
| `runtime/outbox/config.go` | `RelayConfig` 加 `PollFailureBudget/ReclaimFailureBudget/CleanupFailureBudget`（默认 5，0 禁用） |
| `runtime/outbox/relay.go` | poll/reclaim/cleanup 循环调用 `Record(err)`；新增 `HealthCheckers()` + `Ready()` |
| `runtime/bootstrap/bootstrap.go` | `WithRelayHealth` option + nil fail-fast |
| `kernel/outbox/consumer_base_test.go` | lease renewal 启动同步 sleep → signal chan |

## Why

背景：relay 连续失败仅 `slog.Error`，`/readyz` 始终 200；真实故障（broker 断连、DB 失联）无法通过 K8s readiness probe 传导到流量摘除。彻底方案：FailureBudget 原子计数器，成功即清零，不用滑动窗口（K8s 模型）。

依据计划：`docs/plans/202604181700-domain-driven-plan.md` 域 4 Outbox/RabbitMQ — P1-15

## 关键决策

- **阈值默认 5**（对标 K8s `maxFastAttempts=3` + relay poll interval ~5s → 约 25s 宽容期）
- **三个独立 budget**，互不干扰（poll 失败不影响 reclaim/cleanup 的 readiness）
- **阈值 0 = 禁用** checker，兼容测试环境
- **无滑动窗口**：短暂抖动一次成功即恢复 readiness，不引入时间窗口复杂度

## Test plan

- [x] `go test ./runtime/outbox/... -race -count=20`（含 FailureBudget 并发 race 测试）
- [x] `go test ./runtime/bootstrap/... ./kernel/outbox/... -race -count=5`
- [x] `golangci-lint run` 所有修改包 0 issues
- [ ] CI 全量（等 CI）
- [ ] 手工 smoke：stop PG → ~25s → `/readyz` 503 + `?verbose` 显示 `outbox-relay-poll: unhealthy`；recover PG → 下次成功 poll 切回 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)