### PR TITLE
fix(auth): errcode classifier + infra/domain error separation (P1-18/S40/S43)

### DIFF
--- a/cells/access-core/internal/mem/session_repo.go
+++ b/cells/access-core/internal/mem/session_repo.go
@@ -57,7 +57,7 @@ func (r *SessionRepository) GetByID(_ context.Context, id string) (*domain.Sessi
 
 	s, ok := r.byID[id]
 	if !ok {
-		return nil, errcode.New(errcode.ErrSessionNotFound, "session not found: "+id)
+		return nil, errcode.NewDomain(errcode.ErrSessionNotFound, "session not found: "+id)
 	}
 	clone := *s
 	return &clone, nil
@@ -69,7 +69,7 @@ func (r *SessionRepository) GetByRefreshToken(_ context.Context, token string) (
 
 	s, ok := r.byRefresh[token]
 	if !ok {
-		return nil, errcode.New(errcode.ErrSessionNotFound, "session not found by refresh token")
+		return nil, errcode.NewDomain(errcode.ErrSessionNotFound, "session not found by refresh token")
 	}
 	clone := *s
 	return &clone, nil
@@ -81,7 +81,7 @@ func (r *SessionRepository) GetByPreviousRefreshToken(_ context.Context, token s
 
 	s, ok := r.byPrevRefresh[token]
 	if !ok {
-		return nil, errcode.New(errcode.ErrSessionNotFound, "session not found by previous refresh token")
+		return nil, errcode.NewDomain(errcode.ErrSessionNotFound, "session not found by previous refresh token")
 	}
 	clone := *s
 	return &clone, nil
@@ -93,7 +93,7 @@ func (r *SessionRepository) Update(_ context.Context, session *domain.Session) e
 
 	old, ok := r.byID[session.ID]
 	if !ok {
-		return errcode.New(errcode.ErrSessionNotFound, "session not found: "+session.ID)
+		return errcode.NewDomain(errcode.ErrSessionNotFound, "session not found: "+session.ID)
 	}
 
 	// Optimistic lock: reject if version mismatch.
@@ -126,7 +126,7 @@ func (r *SessionRepository) RevokeByIDAndOwner(_ context.Context, id, ownerUserI
 
 	s, ok := r.byID[id]
 	if !ok || s.UserID != ownerUserID {
-		return errcode.New(errcode.ErrSessionNotFound, "session not found: "+id)
+		return errcode.NewDomain(errcode.ErrSessionNotFound, "session not found: "+id)
 	}
 	s.Revoke()
 	return nil
@@ -150,7 +150,7 @@ func (r *SessionRepository) Delete(_ context.Context, id string) error {
 
 	s, ok := r.byID[id]
 	if !ok {
-		return errcode.New(errcode.ErrSessionNotFound, "session not found: "+id)
+		return errcode.NewDomain(errcode.ErrSessionNotFound, "session not found: "+id)
 	}
 	delete(r.byRefresh, s.RefreshToken)
 	if s.PreviousRefreshToken != "" {

--- a/cells/access-core/slices/sessionrefresh/service.go
+++ b/cells/access-core/slices/sessionrefresh/service.go
@@ -101,12 +101,35 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*TokenPair,
 }
 
 // lookupSession retrieves the active session for the given refresh token.
-// On session-not-found it checks for token reuse and revokes the session if detected.
+//
+// Error routing (P1-18 REFRESH-INFRA-ERROR-CLASSIFY-01):
+//   - infra error (plain / CategoryInfra / CategoryUnspecified) → logged at
+//     slog.Error, returned as ErrAuthRefreshFailed; does NOT enter reuse branch.
+//   - domain ErrSessionNotFound (CategoryDomain + whitelist) → enters reuse
+//     detection branch to check for stolen-token replay.
+//   - other domain / auth errors → returned as ErrAuthRefreshFailed + Warn.
 func (s *Service) lookupSession(ctx context.Context, refreshToken string) (*domain.Session, error) {
 	session, err := s.sessionRepo.GetByRefreshToken(ctx, refreshToken)
 	if err == nil {
 		return session, nil
 	}
+
+	// Infra errors must not enter the reuse branch — they indicate a storage
+	// outage, not a missing token. Fail-closed and log at Error.
+	if errcode.IsInfraError(err) {
+		s.logger.Error("session-refresh: infra error on session lookup",
+			slog.Any("error", err))
+		return nil, errcode.New(errcode.ErrAuthRefreshFailed, "session lookup unavailable")
+	}
+
+	// Only domain ErrSessionNotFound enters reuse detection. Any other domain /
+	// auth errcode is mapped to ErrAuthRefreshFailed.
+	if !errcode.IsDomainNotFound(err, string(errcode.ErrSessionNotFound)) {
+		s.logger.Warn("session-refresh: unexpected error on session lookup",
+			slog.Any("error", err))
+		return nil, errcode.New(errcode.ErrAuthRefreshFailed, "session not found")
+	}
+
 	// Check for refresh token reuse: if the token was previously valid
 	// but has been rotated out, revoke the entire session to prevent
 	// stolen token replay attacks.

--- a/cells/access-core/slices/sessionrefresh/service.go
+++ b/cells/access-core/slices/sessionrefresh/service.go
@@ -124,7 +124,7 @@ func (s *Service) lookupSession(ctx context.Context, refreshToken string) (*doma
 
 	// Only domain ErrSessionNotFound enters reuse detection. Any other domain /
 	// auth errcode is mapped to ErrAuthRefreshFailed.
-	if !errcode.IsDomainNotFound(err, string(errcode.ErrSessionNotFound)) {
+	if !errcode.IsDomainNotFound(err, errcode.ErrSessionNotFound) {
 		s.logger.Warn("session-refresh: unexpected error on session lookup",
 			slog.Any("error", err))
 		return nil, errcode.New(errcode.ErrAuthRefreshFailed, "session not found")
@@ -135,6 +135,13 @@ func (s *Service) lookupSession(ctx context.Context, refreshToken string) (*doma
 	// stolen token replay attacks.
 	reuseSession, reuseErr := s.sessionRepo.GetByPreviousRefreshToken(ctx, refreshToken)
 	if reuseErr != nil {
+		// Infra errors on the reuse lookup must be surfaced — they signal a
+		// storage outage, not a missing token. Log at Error and return so the
+		// caller sees an infra fault rather than silently discarding it.
+		if errcode.IsInfraError(reuseErr) {
+			s.logger.Error("session-refresh: infra error on previous-token lookup",
+				slog.Any("error", reuseErr))
+		}
 		return nil, errcode.New(errcode.ErrAuthRefreshFailed, "session not found")
 	}
 	reuseSession.Revoke()

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -435,9 +436,16 @@ func TestLookupSession_InfraError_DoesNotEnterReuseBranch(t *testing.T) {
 			assert.Nil(t, pair)
 
 			logOutput := buf.String()
-			assert.Contains(t, logOutput, `"level":"ERROR"`,
+			// P1-4: use precise JSON-line matching to avoid false positives from
+			// other log lines during the request lifecycle.
+			entry := sloghelper.FindLogEntry(logOutput, "infra error on session lookup")
+			require.NotNil(t, entry,
+				"expected a log line containing 'infra error on session lookup'")
+			assert.Equal(t, "ERROR", entry["level"],
 				"infra lookup error must be logged at ERROR")
-			assert.NotContains(t, logOutput, "reuse",
+			// Confirm the reuse-detection path was not entered.
+			reuseEntry := sloghelper.FindLogEntry(logOutput, "refresh token reuse detected")
+			assert.Nil(t, reuseEntry,
 				"infra error must not be logged as token reuse")
 		})
 	}
@@ -494,4 +502,59 @@ func TestRefresh_FlagStillSetWhenUserNotChanged(t *testing.T) {
 	claims, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)
 	require.NoError(t, err)
 	assert.True(t, claims.PasswordResetRequired, "access token claim must be true when flag not cleared")
+}
+
+// notFoundThenInfraSessionRepo is a session repo stub used in P1-2 tests.
+// GetByRefreshToken returns domain ErrSessionNotFound (triggers reuse branch),
+// GetByPreviousRefreshToken returns an infra error.
+type notFoundThenInfraSessionRepo struct {
+	mem.SessionRepository
+	reuseErr error
+}
+
+func (r *notFoundThenInfraSessionRepo) GetByRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, errcode.NewDomain(errcode.ErrSessionNotFound, "session not found")
+}
+
+func (r *notFoundThenInfraSessionRepo) GetByPreviousRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, r.reuseErr
+}
+
+// TestLookupSession_ReuseErr_InfraError_LogsAtError verifies P1-2:
+// when GetByRefreshToken returns domain not-found (enters reuse branch) and
+// GetByPreviousRefreshToken returns an infra error, lookupSession must log at
+// slog.Error so ops dashboards surface the storage outage.
+func TestLookupSession_ReuseErr_InfraError_LogsAtError(t *testing.T) {
+	infraReuseErrs := []struct {
+		name string
+		err  error
+	}{
+		{"plain DB timeout on reuse lookup", fmt.Errorf("db connection timeout")},
+		{"CategoryInfra on reuse lookup", errcode.NewInfra(errcode.ErrInternal, "storage unavailable")},
+	}
+
+	for _, tc := range infraReuseErrs {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			sessionRepo := &notFoundThenInfraSessionRepo{
+				SessionRepository: *mem.NewSessionRepository(),
+				reuseErr:          tc.err,
+			}
+			roleRepo := mem.NewRoleRepository()
+			userRepo := mem.NewUserRepository()
+			svc := NewService(sessionRepo, roleRepo, userRepo, testIssuer, testVerifier, logger)
+
+			rt := issueTestToken("usr-reuseinfra")
+
+			pair, err := svc.Refresh(context.Background(), rt)
+			require.Error(t, err, "infra error on reuse lookup must cause Refresh to fail")
+			assert.Nil(t, pair)
+
+			logOutput := buf.String()
+			assert.Contains(t, logOutput, `"level":"ERROR"`,
+				"infra error on reuse lookup must be logged at ERROR")
+		})
+	}
 }

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -1,7 +1,9 @@
 package sessionrefresh
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"testing"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -371,6 +374,97 @@ func TestRefresh_FlagPropagatesFromCurrentUser_AfterClear(t *testing.T) {
 	claims, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)
 	require.NoError(t, err)
 	assert.False(t, claims.PasswordResetRequired, "access token claim must be false after flag cleared")
+}
+
+// infraSessionRepo is a session repo stub whose GetByRefreshToken returns an
+// infra error (e.g. db timeout). Used to test P1-18: infra errors must not
+// enter the reuse detection branch.
+type infraSessionRepo struct {
+	mem.SessionRepository
+	infraErr error
+}
+
+func newInfraSessionRepo(infraErr error) *infraSessionRepo {
+	return &infraSessionRepo{
+		SessionRepository: *mem.NewSessionRepository(),
+		infraErr:          infraErr,
+	}
+}
+
+func (r *infraSessionRepo) GetByRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, r.infraErr
+}
+
+// notFoundSessionRepo is a session repo stub whose GetByRefreshToken returns
+// a domain ErrSessionNotFound (expected reuse-detection path).
+type notFoundSessionRepo struct {
+	mem.SessionRepository
+}
+
+func (r *notFoundSessionRepo) GetByRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, errcode.NewDomain(errcode.ErrSessionNotFound, "session not found")
+}
+
+// TestLookupSession_InfraError_DoesNotEnterReuseBranch verifies P1-18:
+// when GetByRefreshToken returns an infra error (plain error or CategoryInfra),
+// lookupSession must NOT proceed to GetByPreviousRefreshToken (reuse branch).
+// It must return an error and log at slog.Error.
+func TestLookupSession_InfraError_DoesNotEnterReuseBranch(t *testing.T) {
+	infraErrors := []struct {
+		name string
+		err  error
+	}{
+		{"plain DB timeout", fmt.Errorf("db connection timeout")},
+		{"CategoryInfra errcode", errcode.NewInfra(errcode.ErrInternal, "storage unavailable")},
+	}
+
+	for _, tc := range infraErrors {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			sessionRepo := newInfraSessionRepo(tc.err)
+			roleRepo := mem.NewRoleRepository()
+			userRepo := mem.NewUserRepository()
+			svc := NewService(sessionRepo, roleRepo, userRepo, testIssuer, testVerifier, logger)
+
+			rt := issueTestToken("usr-infra")
+
+			pair, err := svc.Refresh(context.Background(), rt)
+			require.Error(t, err, "infra error must cause Refresh to fail")
+			assert.Nil(t, pair)
+
+			logOutput := buf.String()
+			assert.Contains(t, logOutput, `"level":"ERROR"`,
+				"infra lookup error must be logged at ERROR")
+			assert.NotContains(t, logOutput, "reuse",
+				"infra error must not be logged as token reuse")
+		})
+	}
+}
+
+// TestLookupSession_DomainNotFound_EntersReuseBranch verifies that a domain
+// ErrSessionNotFound still enters the reuse detection branch (preserved
+// existing behaviour).
+func TestLookupSession_DomainNotFound_EntersReuseBranch(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// notFoundSessionRepo returns domain ErrSessionNotFound on primary lookup
+	// and nil error on GetByPreviousRefreshToken (simulating no reuse found).
+	sessionRepo := &notFoundSessionRepo{
+		SessionRepository: *mem.NewSessionRepository(),
+	}
+	roleRepo := mem.NewRoleRepository()
+	userRepo := mem.NewUserRepository()
+	svc := NewService(sessionRepo, roleRepo, userRepo, testIssuer, testVerifier, logger)
+
+	rt := issueTestToken("usr-notfound")
+
+	// GetByPreviousRefreshToken will also not find it → returns ErrAuthRefreshFailed
+	_, err := svc.Refresh(context.Background(), rt)
+	require.Error(t, err, "session not found must still fail refresh")
+	assert.Contains(t, err.Error(), "ERR_AUTH_REFRESH_FAILED")
 }
 
 // TestRefresh_FlagStillSetWhenUserNotChanged ensures that a user who has not

--- a/cells/access-core/slices/sessionvalidate/service.go
+++ b/cells/access-core/slices/sessionvalidate/service.go
@@ -116,7 +116,7 @@ func (s *Service) enforceSessionState(ctx context.Context, claims auth.Claims) (
 // logged at Warn. Any infra error, unclassified error, or non-whitelisted
 // errcode is logged at Error — fail-closed, ref S40.
 func (s *Service) logSessionLookupError(sid, subject string, err error) {
-	if errcode.IsDomainNotFound(err, string(errcode.ErrSessionNotFound)) {
+	if errcode.IsDomainNotFound(err, errcode.ErrSessionNotFound) {
 		s.logger.Warn("session-validate: session not found",
 			slog.String("sid", sid),
 			slog.String("subject", subject))

--- a/cells/access-core/slices/sessionvalidate/service.go
+++ b/cells/access-core/slices/sessionvalidate/service.go
@@ -4,7 +4,6 @@ package sessionvalidate
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
@@ -112,9 +111,12 @@ func (s *Service) enforceSessionState(ctx context.Context, claims auth.Claims) (
 
 // logSessionLookupError distinguishes "not found" (expected / logged at Warn)
 // from infrastructure failures (Error) so dashboards can alert correctly.
+//
+// Only domain-layer not-found codes on the whitelist (ErrSessionNotFound) are
+// logged at Warn. Any infra error, unclassified error, or non-whitelisted
+// errcode is logged at Error — fail-closed, ref S40.
 func (s *Service) logSessionLookupError(sid, subject string, err error) {
-	var ec *errcode.Error
-	if errors.As(err, &ec) {
+	if errcode.IsDomainNotFound(err, string(errcode.ErrSessionNotFound)) {
 		s.logger.Warn("session-validate: session not found",
 			slog.String("sid", sid),
 			slog.String("subject", subject))

--- a/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/cells/access-core/slices/sessionvalidate/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -290,14 +291,24 @@ func TestLogSessionLookupError_LogLevel(t *testing.T) {
 			logOutput := buf.String()
 			require.NotEmpty(t, logOutput, "expected at least one log line")
 
-			// Find the session-lookup log line (not the JWT verification line).
+			// P1-3: use precise JSON-line matching to avoid false positives from
+			// other log lines (e.g. JWT verification Warn). We locate the specific
+			// session-lookup log line by message substring before asserting level.
 			if tt.wantLogLevel == slog.LevelWarn {
-				assert.Contains(t, logOutput, `"level":"WARN"`,
+				entry := sloghelper.FindLogEntry(logOutput, "session not found")
+				require.NotNil(t, entry,
+					"expected a log line containing 'session not found'")
+				assert.Equal(t, "WARN", entry["level"],
 					"domain not-found whitelisted error must log at WARN")
-				assert.NotContains(t, logOutput, `"level":"ERROR"`,
-					"must not emit ERROR when domain not-found whitelist matches")
+				// Confirm no ERROR line for this specific lookup message.
+				errEntry := sloghelper.FindLogEntry(logOutput, "session repo unavailable")
+				assert.Nil(t, errEntry,
+					"must not emit ERROR 'session repo unavailable' when domain not-found whitelist matches")
 			} else {
-				assert.Contains(t, logOutput, `"level":"ERROR"`,
+				entry := sloghelper.FindLogEntry(logOutput, "session repo unavailable")
+				require.NotNil(t, entry,
+					"expected a log line containing 'session repo unavailable'")
+				assert.Equal(t, "ERROR", entry["level"],
 					"infra / non-whitelisted error must log at ERROR")
 			}
 		})

--- a/cells/access-core/slices/sessionvalidate/service_test.go
+++ b/cells/access-core/slices/sessionvalidate/service_test.go
@@ -1,6 +1,7 @@
 package sessionvalidate
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -214,4 +216,90 @@ func TestService_Verify_NilSessionRepo_NoSid(t *testing.T) {
 	claims, err := svc.Verify(context.Background(), tok)
 	require.NoError(t, err)
 	assert.Equal(t, "usr-1", claims.Subject)
+}
+
+// capturingRepo wraps a real or stub session repo and allows injecting errors
+// with specific errcode categories for logSessionLookupError tests.
+type capturingRepo struct {
+	getByIDErr error
+}
+
+func (r capturingRepo) Create(_ context.Context, _ *domain.Session) error { return nil }
+func (r capturingRepo) GetByID(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, r.getByIDErr
+}
+func (r capturingRepo) GetByRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, nil
+}
+func (r capturingRepo) GetByPreviousRefreshToken(_ context.Context, _ string) (*domain.Session, error) {
+	return nil, nil
+}
+func (r capturingRepo) Update(_ context.Context, _ *domain.Session) error       { return nil }
+func (r capturingRepo) Delete(_ context.Context, _ string) error                { return nil }
+func (r capturingRepo) RevokeByUserID(_ context.Context, _ string) error        { return nil }
+func (r capturingRepo) RevokeByIDAndOwner(_ context.Context, _, _ string) error { return nil }
+
+// TestLogSessionLookupError_LogLevel verifies S40: IsDomainNotFound whitelist
+// determines log level — only whitelisted domain not-found codes produce Warn;
+// all other errors (infra, non-whitelisted errcode, plain) produce Error.
+func TestLogSessionLookupError_LogLevel(t *testing.T) {
+	tests := []struct {
+		name          string
+		repoErr       error
+		wantLogLevel  slog.Level
+		wantLogSubstr string
+	}{
+		{
+			name:         "plain infra error logs at Error",
+			repoErr:      fmt.Errorf("db connection timeout"),
+			wantLogLevel: slog.LevelError,
+		},
+		{
+			name:         "errcode ErrSessionNotFound (domain, whitelist) logs at Warn",
+			repoErr:      errcode.NewDomain(errcode.ErrSessionNotFound, "session not found"),
+			wantLogLevel: slog.LevelWarn,
+		},
+		{
+			name:         "non-whitelisted errcode domain logs at Error",
+			repoErr:      errcode.NewDomain(errcode.ErrOrderNotFound, "order not found"),
+			wantLogLevel: slog.LevelError,
+		},
+		{
+			name:         "errcode with CategoryInfra logs at Error",
+			repoErr:      errcode.NewInfra(errcode.ErrInternal, "db down"),
+			wantLogLevel: slog.LevelError,
+		},
+		{
+			name:         "errcode with CategoryUnspecified (zero) logs at Error (fail-closed)",
+			repoErr:      errcode.New(errcode.ErrSessionNotFound, "not found"),
+			wantLogLevel: slog.LevelError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			svc := NewService(testVerifier, capturingRepo{getByIDErr: tt.repoErr}, logger)
+
+			tok, err := IssueTestToken(testPrivKey, "usr-log", nil, time.Hour, "sess-log-test")
+			require.NoError(t, err)
+
+			_, _ = svc.Verify(context.Background(), tok)
+
+			logOutput := buf.String()
+			require.NotEmpty(t, logOutput, "expected at least one log line")
+
+			// Find the session-lookup log line (not the JWT verification line).
+			if tt.wantLogLevel == slog.LevelWarn {
+				assert.Contains(t, logOutput, `"level":"WARN"`,
+					"domain not-found whitelisted error must log at WARN")
+				assert.NotContains(t, logOutput, `"level":"ERROR"`,
+					"must not emit ERROR when domain not-found whitelist matches")
+			} else {
+				assert.Contains(t, logOutput, `"level":"ERROR"`,
+					"infra / non-whitelisted error must log at ERROR")
+			}
+		})
+	}
 }

--- a/pkg/errcode/classify.go
+++ b/pkg/errcode/classify.go
@@ -1,0 +1,216 @@
+package errcode
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+)
+
+// Category classifies the origin of an error for log-level routing and
+// dual-channel triage (infra vs domain). The zero value CategoryUnspecified
+// is treated as infra (fail-closed) by all classifiers.
+//
+// ref: k8s apimachinery pkg/api/errors — IsNotFound dual-channel pattern
+// (infra errors must never map to domain not-found)
+type Category int
+
+const (
+	// CategoryUnspecified is the zero value. Classifiers treat it as infra
+	// (fail-closed) to prevent leaking infra faults into domain branches.
+	CategoryUnspecified Category = iota
+
+	// CategoryDomain signals a well-known business-layer condition
+	// (resource not found, conflict, validation failure).
+	CategoryDomain
+
+	// CategoryInfra signals an infrastructure failure (DB down, network
+	// timeout, bad connection). Must never be mapped to domain not-found.
+	CategoryInfra
+
+	// CategoryValidation signals a caller input validation failure (400-class).
+	CategoryValidation
+
+	// CategoryAuth signals an authentication / authorisation failure (401/403).
+	CategoryAuth
+)
+
+// NewInfra creates an *Error with CategoryInfra.
+// Use this for storage, network, and dependency failures so they are
+// never confused with domain not-found conditions.
+func NewInfra(code Code, message string) *Error {
+	return &Error{
+		Code:     code,
+		Message:  message,
+		Category: CategoryInfra,
+	}
+}
+
+// NewDomain creates an *Error with CategoryDomain.
+// Use this for well-known business-layer conditions (resource missing,
+// conflict, etc.) that callers may handle specifically.
+func NewDomain(code Code, message string) *Error {
+	return &Error{
+		Code:     code,
+		Message:  message,
+		Category: CategoryDomain,
+	}
+}
+
+// IsInfraError reports whether err represents an infrastructure failure.
+//
+// Fail-closed semantics: any error that is not definitively classified as
+// a domain / validation / auth error is treated as infra. This prevents
+// infra outages from silently propagating into domain-not-found branches.
+//
+// Returns false only for nil. Returns true for:
+//   - context.Canceled / context.DeadlineExceeded
+//   - driver.ErrBadConn / sql.ErrConnDone
+//   - *Error with Category == CategoryInfra or CategoryUnspecified
+//   - any unrecognised plain error (fail-closed)
+func IsInfraError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Well-known infra sentinels.
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, sql.ErrConnDone) {
+		return true
+	}
+
+	// Classified errcode: only domain / validation / auth are NOT infra.
+	var ec *Error
+	if errors.As(err, &ec) {
+		switch ec.Category {
+		case CategoryDomain, CategoryValidation, CategoryAuth:
+			return false
+		default:
+			// CategoryInfra or CategoryUnspecified → fail-closed infra.
+			return true
+		}
+	}
+
+	// Unrecognised plain error → fail-closed, treat as infra.
+	return true
+}
+
+// IsDomainNotFound reports whether err is a domain-layer not-found condition
+// whose code is in the caller-supplied whitelist. Both conditions must hold:
+//
+//  1. err must be an *Error with Category == CategoryDomain
+//  2. err.Code must appear in codes
+//
+// This two-gated check prevents infra errors from ever matching, regardless
+// of which code they carry — the dual-channel invariant from k8s IsNotFound.
+func IsDomainNotFound(err error, codes ...string) bool {
+	if err == nil {
+		return false
+	}
+	var ec *Error
+	if !errors.As(err, &ec) {
+		return false
+	}
+	if ec.Category != CategoryDomain {
+		return false
+	}
+	target := string(ec.Code)
+	for _, c := range codes {
+		if c == target {
+			return true
+		}
+	}
+	return false
+}
+
+// expected4xxCodes is the set of error codes that map to HTTP 400-499 responses.
+// These represent expected client-side / business rejection conditions that
+// should be logged at Warn level rather than Error.
+var expected4xxCodes = map[Code]bool{
+	// 400 — bad request / validation
+	ErrValidationFailed:          true,
+	ErrAuthLoginInvalidInput:     true,
+	ErrAuthRefreshInvalidInput:   true,
+	ErrAuthSessionInvalidInput:   true,
+	ErrAuthIdentityInvalidInput:  true,
+	ErrAuthInvalidInput:          true,
+	ErrAuthRBACInvalidInput:      true,
+	ErrCursorInvalid:             true,
+	ErrPageSizeExceeded:          true,
+	ErrInvalidTimeFormat:         true,
+	ErrConfigInvalidInput:        true,
+	ErrConfigPublishInvalidInput: true,
+	ErrFlagInvalidInput:          true,
+	ErrCheckRefInvalid:           true,
+	ErrAuthLogoutInvalidInput:    true,
+
+	// 401 — authentication failure
+	ErrAuthUnauthorized:       true,
+	ErrAuthTokenInvalid:       true,
+	ErrAuthTokenExpired:       true,
+	ErrAuthInvalidTokenIntent: true,
+	ErrAuthInvalidToken:       true,
+	ErrAuthLoginFailed:        true,
+	ErrAuthRefreshFailed:      true,
+	ErrAuthKeyInvalid:         true,
+	ErrAuthKeyMissing:         true,
+
+	// 403 — forbidden
+	ErrAuthForbidden:             true,
+	ErrCSRFOriginDenied:          true,
+	ErrAuthPasswordResetRequired: true,
+	ErrAuthSelfDelete:            true,
+	ErrAuthUserLocked:            true,
+
+	// 404 — resource not found
+	ErrSessionNotFound:    true,
+	ErrOrderNotFound:      true,
+	ErrDeviceNotFound:     true,
+	ErrCommandNotFound:    true,
+	ErrAuthUserNotFound:   true,
+	ErrAuthRoleNotFound:   true,
+	ErrMetadataNotFound:   true,
+	ErrCellNotFound:       true,
+	ErrSliceNotFound:      true,
+	ErrContractNotFound:   true,
+	ErrAssemblyNotFound:   true,
+	ErrJourneyNotFound:    true,
+	ErrConfigNotFound:     true,
+	ErrConfigRepoNotFound: true,
+	ErrFlagNotFound:       true,
+	ErrAuditRepoNotFound:  true,
+	ErrWSConnNotFound:     true,
+
+	// 409 — conflict
+	ErrSessionConflict:       true,
+	ErrAuthUserDuplicate:     true,
+	ErrAuthRoleDuplicate:     true,
+	ErrConfigDuplicate:       true,
+	ErrConfigRepoDuplicate:   true,
+	ErrFlagDuplicate:         true,
+	ErrAuthRefreshTokenReuse: true,
+
+	// 413 — payload too large
+	ErrBodyTooLarge: true,
+
+	// 429 — rate limited
+	ErrRateLimited: true,
+}
+
+// IsExpected4xx reports whether err maps to an HTTP 400-499 response code.
+// These are expected client-side / business rejection conditions that callers
+// should log at Warn level; true infrastructure failures should be Error.
+//
+// Returns false for nil and for unclassified / plain errors (which are infra).
+func IsExpected4xx(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ec *Error
+	if !errors.As(err, &ec) {
+		return false
+	}
+	return expected4xxCodes[ec.Code]
+}

--- a/pkg/errcode/classify.go
+++ b/pkg/errcode/classify.go
@@ -57,6 +57,31 @@ func NewDomain(code Code, message string) *Error {
 	}
 }
 
+// WrapInfra creates an *Error with CategoryInfra that wraps the supplied cause.
+// Use this when an infrastructure failure has an underlying cause that should be
+// preserved for error chain inspection (errors.Is / errors.As / Unwrap).
+// The cause is stored in Error.Cause and exposed via Error.Error() in logs.
+func WrapInfra(code Code, message string, cause error) *Error {
+	return &Error{
+		Code:     code,
+		Message:  message,
+		Category: CategoryInfra,
+		Cause:    cause,
+	}
+}
+
+// WrapDomain creates an *Error with CategoryDomain that wraps the supplied cause.
+// Use this when a domain-layer condition has an underlying cause to preserve.
+// The cause is stored in Error.Cause and exposed via Error.Error() in logs.
+func WrapDomain(code Code, message string, cause error) *Error {
+	return &Error{
+		Code:     code,
+		Message:  message,
+		Category: CategoryDomain,
+		Cause:    cause,
+	}
+}
+
 // IsInfraError reports whether err represents an infrastructure failure.
 //
 // Fail-closed semantics: any error that is not definitively classified as
@@ -68,6 +93,13 @@ func NewDomain(code Code, message string) *Error {
 //   - driver.ErrBadConn / sql.ErrConnDone
 //   - *Error with Category == CategoryInfra or CategoryUnspecified
 //   - any unrecognised plain error (fail-closed)
+//
+// Stdlib sentinel coverage is intentionally narrow (context.* / sql.Err* /
+// driver.ErrBadConn). Adapters that return wrapped plain errors are covered
+// by the fail-closed fallback: CategoryUnspecified → treated as infra.
+// New adapters that return wrapped custom error types should construct them
+// with NewInfra (or WrapInfra) so the category is explicit rather than
+// relying on the fallback; no change to classify.go is required.
 func IsInfraError(err error) bool {
 	if err == nil {
 		return false
@@ -105,7 +137,9 @@ func IsInfraError(err error) bool {
 //
 // This two-gated check prevents infra errors from ever matching, regardless
 // of which code they carry — the dual-channel invariant from k8s IsNotFound.
-func IsDomainNotFound(err error, codes ...string) bool {
+//
+// Callers pass Code constants directly; no string(...) conversion is needed.
+func IsDomainNotFound(err error, codes ...Code) bool {
 	if err == nil {
 		return false
 	}
@@ -116,9 +150,8 @@ func IsDomainNotFound(err error, codes ...string) bool {
 	if ec.Category != CategoryDomain {
 		return false
 	}
-	target := string(ec.Code)
 	for _, c := range codes {
-		if c == target {
+		if ec.Code == c {
 			return true
 		}
 	}
@@ -155,7 +188,10 @@ var expected4xxCodes = map[Code]bool{
 	ErrAuthLoginFailed:        true,
 	ErrAuthRefreshFailed:      true,
 	ErrAuthKeyInvalid:         true,
-	ErrAuthKeyMissing:         true,
+	// ErrAuthKeyMissing intentionally omitted: codeToStatus maps it to HTTP 500
+	// (infrastructure misconfiguration). Including it here would cause
+	// AuthMiddleware to downgrade an infra fault to Warn, masking the outage.
+	// ErrAuthVerifierConfig is likewise 500 and must not appear here.
 
 	// 403 — forbidden
 	ErrAuthForbidden:             true,

--- a/pkg/errcode/classify_test.go
+++ b/pkg/errcode/classify_test.go
@@ -99,65 +99,67 @@ func TestIsInfraError(t *testing.T) {
 }
 
 // TestIsDomainNotFound covers the whitelist-based domain-not-found classifier.
+// P2-1: IsDomainNotFound now accepts ...Code instead of ...string, so callers
+// pass Code constants directly without string(...) conversion.
 func TestIsDomainNotFound(t *testing.T) {
 	tests := []struct {
 		name  string
 		err   error
-		codes []string
+		codes []Code
 		want  bool
 	}{
 		{
 			name:  "nil error",
 			err:   nil,
-			codes: []string{string(ErrSessionNotFound)},
+			codes: []Code{ErrSessionNotFound},
 			want:  false,
 		},
 		{
 			name:  "domain not-found code in whitelist",
 			err:   NewDomain(ErrSessionNotFound, "session not found"),
-			codes: []string{string(ErrSessionNotFound)},
+			codes: []Code{ErrSessionNotFound},
 			want:  true,
 		},
 		{
 			name:  "domain not-found code not in whitelist",
 			err:   NewDomain(ErrSessionNotFound, "session not found"),
-			codes: []string{string(ErrOrderNotFound)},
+			codes: []Code{ErrOrderNotFound},
 			want:  false,
 		},
 		{
 			name:  "infra error is not domain not-found",
 			err:   NewInfra(ErrInternal, "db down"),
-			codes: []string{string(ErrInternal)},
+			codes: []Code{ErrInternal},
 			want:  false,
 		},
 		{
 			name:  "plain error is not domain not-found",
 			err:   errors.New("connection refused"),
-			codes: []string{},
+			codes: []Code{},
 			want:  false,
 		},
 		{
 			name:  "errcode with CategoryUnspecified is not domain not-found",
 			err:   New(ErrSessionNotFound, "not found"),
-			codes: []string{string(ErrSessionNotFound)},
+			codes: []Code{ErrSessionNotFound},
 			want:  false,
 		},
 		{
 			name:  "multiple whitelist codes — first matches",
 			err:   NewDomain(ErrSessionNotFound, "not found"),
-			codes: []string{string(ErrSessionNotFound), string(ErrOrderNotFound)},
+			codes: []Code{ErrSessionNotFound, ErrOrderNotFound},
 			want:  true,
 		},
 		{
 			name:  "multiple whitelist codes — second matches",
 			err:   NewDomain(ErrOrderNotFound, "order not found"),
-			codes: []string{string(ErrSessionNotFound), string(ErrOrderNotFound)},
+			codes: []Code{ErrSessionNotFound, ErrOrderNotFound},
 			want:  true,
 		},
 		{
 			name:  "empty code whitelist never matches",
 			err:   NewDomain(ErrSessionNotFound, "not found"),
-			codes: []string{},
+			codes: []Code{},
 			want:  false,
 		},
 	}
@@ -279,4 +281,53 @@ func TestNew_BackwardCompatibility(t *testing.T) {
 	// Unspecified is fail-closed → treated as infra.
 	assert.True(t, IsInfraError(err),
 		"CategoryUnspecified is fail-closed and must be treated as infra")
+}
+
+// TestWrapInfra verifies that WrapInfra sets CategoryInfra and preserves the cause.
+// P2-2: WrapInfra / WrapDomain are convenience constructors for cause-preserving
+// classified errors, complementing NewInfra / NewDomain for the no-cause case.
+func TestWrapInfra(t *testing.T) {
+	cause := errors.New("connection refused")
+	err := WrapInfra(ErrInternal, "db unavailable", cause)
+
+	assert.Equal(t, CategoryInfra, err.Category)
+	assert.Equal(t, ErrInternal, err.Code)
+	assert.Equal(t, "db unavailable", err.Message)
+	assert.Equal(t, cause, err.Cause, "cause must be preserved")
+	assert.True(t, IsInfraError(err), "WrapInfra result must be classified as infra")
+	// Unwrap chain: errors.Is must reach the cause.
+	assert.True(t, errors.Is(err, cause), "errors.Is must traverse Cause via Unwrap")
+}
+
+// TestWrapDomain verifies that WrapDomain sets CategoryDomain and preserves the cause.
+func TestWrapDomain(t *testing.T) {
+	cause := errors.New("underlying repo error")
+	err := WrapDomain(ErrSessionNotFound, "session not found", cause)
+
+	assert.Equal(t, CategoryDomain, err.Category)
+	assert.Equal(t, ErrSessionNotFound, err.Code)
+	assert.Equal(t, "session not found", err.Message)
+	assert.Equal(t, cause, err.Cause, "cause must be preserved")
+	assert.False(t, IsInfraError(err), "WrapDomain result must not be classified as infra")
+	assert.True(t, IsDomainNotFound(err, ErrSessionNotFound),
+		"WrapDomain result must be classified as domain not-found when code matches")
+	// Unwrap chain: errors.Is must reach the cause.
+	assert.True(t, errors.Is(err, cause), "errors.Is must traverse Cause via Unwrap")
+}
+
+// TestIsExpected4xx_ErrMetadataNotFound verifies P2-5: ErrMetadataNotFound maps
+// to HTTP 404 in codeToStatus and belongs in the expected4xxCodes whitelist.
+func TestIsExpected4xx_ErrMetadataNotFound(t *testing.T) {
+	err := New(ErrMetadataNotFound, "metadata not found")
+	assert.True(t, IsExpected4xx(err),
+		"ErrMetadataNotFound (404) must be in expected4xxCodes whitelist")
+}
+
+// TestIsExpected4xx_ErrAuthKeyMissing_IsNotExpected4xx verifies P1-1:
+// ErrAuthKeyMissing maps to HTTP 500 in codeToStatus (infra misconfiguration)
+// and must NOT appear in the expected4xxCodes whitelist.
+func TestIsExpected4xx_ErrAuthKeyMissing_IsNotExpected4xx(t *testing.T) {
+	err := New(ErrAuthKeyMissing, "no signing key configured")
+	assert.False(t, IsExpected4xx(err),
+		"ErrAuthKeyMissing (500/infra) must NOT be in expected4xxCodes whitelist")
 }

--- a/pkg/errcode/classify_test.go
+++ b/pkg/errcode/classify_test.go
@@ -1,0 +1,282 @@
+package errcode
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsInfraError covers the fail-closed dual-channel classifier.
+// Unrecognised plain errors are treated as infra (fail-closed) to prevent
+// leaking infra faults into domain-not-found branches.
+func TestIsInfraError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not infra",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "context.Canceled is infra",
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "context.DeadlineExceeded is infra",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "driver.ErrBadConn is infra",
+			err:  driver.ErrBadConn,
+			want: true,
+		},
+		{
+			name: "sql.ErrConnDone is infra",
+			err:  sql.ErrConnDone,
+			want: true,
+		},
+		{
+			name: "wrapped context.Canceled is infra",
+			err:  errors.Join(errors.New("outer"), context.Canceled),
+			want: true,
+		},
+		{
+			name: "errcode with CategoryInfra is infra",
+			err:  &Error{Code: ErrInternal, Message: "db down", Category: CategoryInfra},
+			want: true,
+		},
+		{
+			name: "errcode with CategoryDomain is not infra",
+			err:  &Error{Code: ErrSessionNotFound, Message: "not found", Category: CategoryDomain},
+			want: false,
+		},
+		{
+			name: "errcode with CategoryAuth is not infra",
+			err:  &Error{Code: ErrAuthUnauthorized, Message: "unauthorized", Category: CategoryAuth},
+			want: false,
+		},
+		{
+			name: "errcode with CategoryValidation is not infra",
+			err:  &Error{Code: ErrValidationFailed, Message: "bad input", Category: CategoryValidation},
+			want: false,
+		},
+		{
+			name: "errcode with CategoryUnspecified (zero value) is fail-closed infra",
+			err:  &Error{Code: ErrInternal, Message: "unclassified"},
+			want: true,
+		},
+		{
+			name: "plain unclassified error is fail-closed infra",
+			err:  errors.New("some unknown error"),
+			want: true,
+		},
+		{
+			name: "NewInfra creates infra error",
+			err:  NewInfra(ErrInternal, "storage unavailable"),
+			want: true,
+		},
+		{
+			name: "NewDomain creates domain error (not infra)",
+			err:  NewDomain(ErrSessionNotFound, "session not found"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsInfraError(tt.err))
+		})
+	}
+}
+
+// TestIsDomainNotFound covers the whitelist-based domain-not-found classifier.
+func TestIsDomainNotFound(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		codes []string
+		want  bool
+	}{
+		{
+			name:  "nil error",
+			err:   nil,
+			codes: []string{string(ErrSessionNotFound)},
+			want:  false,
+		},
+		{
+			name:  "domain not-found code in whitelist",
+			err:   NewDomain(ErrSessionNotFound, "session not found"),
+			codes: []string{string(ErrSessionNotFound)},
+			want:  true,
+		},
+		{
+			name:  "domain not-found code not in whitelist",
+			err:   NewDomain(ErrSessionNotFound, "session not found"),
+			codes: []string{string(ErrOrderNotFound)},
+			want:  false,
+		},
+		{
+			name:  "infra error is not domain not-found",
+			err:   NewInfra(ErrInternal, "db down"),
+			codes: []string{string(ErrInternal)},
+			want:  false,
+		},
+		{
+			name:  "plain error is not domain not-found",
+			err:   errors.New("connection refused"),
+			codes: []string{},
+			want:  false,
+		},
+		{
+			name:  "errcode with CategoryUnspecified is not domain not-found",
+			err:   New(ErrSessionNotFound, "not found"),
+			codes: []string{string(ErrSessionNotFound)},
+			want:  false,
+		},
+		{
+			name:  "multiple whitelist codes — first matches",
+			err:   NewDomain(ErrSessionNotFound, "not found"),
+			codes: []string{string(ErrSessionNotFound), string(ErrOrderNotFound)},
+			want:  true,
+		},
+		{
+			name:  "multiple whitelist codes — second matches",
+			err:   NewDomain(ErrOrderNotFound, "order not found"),
+			codes: []string{string(ErrSessionNotFound), string(ErrOrderNotFound)},
+			want:  true,
+		},
+		{
+			name:  "empty code whitelist never matches",
+			err:   NewDomain(ErrSessionNotFound, "not found"),
+			codes: []string{},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsDomainNotFound(tt.err, tt.codes...))
+		})
+	}
+}
+
+// TestIsExpected4xx covers the HTTP 4xx classification for log-level routing.
+func TestIsExpected4xx(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not expected 4xx",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "ErrAuthUnauthorized (401) is expected 4xx",
+			err:  New(ErrAuthUnauthorized, "unauthorized"),
+			want: true,
+		},
+		{
+			name: "ErrAuthForbidden (403) is expected 4xx",
+			err:  New(ErrAuthForbidden, "forbidden"),
+			want: true,
+		},
+		{
+			name: "ErrSessionNotFound (404) is expected 4xx",
+			err:  New(ErrSessionNotFound, "not found"),
+			want: true,
+		},
+		{
+			name: "ErrAuthTokenInvalid (401) is expected 4xx",
+			err:  New(ErrAuthTokenInvalid, "invalid token"),
+			want: true,
+		},
+		{
+			name: "ErrAuthTokenExpired (401) is expected 4xx",
+			err:  New(ErrAuthTokenExpired, "expired"),
+			want: true,
+		},
+		{
+			name: "ErrValidationFailed (400) is expected 4xx",
+			err:  New(ErrValidationFailed, "bad input"),
+			want: true,
+		},
+		{
+			name: "ErrSessionConflict (409) is expected 4xx",
+			err:  New(ErrSessionConflict, "conflict"),
+			want: true,
+		},
+		{
+			name: "ErrInternal (500) is NOT expected 4xx",
+			err:  New(ErrInternal, "internal error"),
+			want: false,
+		},
+		{
+			name: "plain error is NOT expected 4xx",
+			err:  errors.New("some error"),
+			want: false,
+		},
+		{
+			name: "ErrAuthInvalidToken (401) is expected 4xx",
+			err:  New(ErrAuthInvalidToken, "invalid"),
+			want: true,
+		},
+		{
+			name: "ErrAuthLoginFailed (401) is expected 4xx",
+			err:  New(ErrAuthLoginFailed, "login failed"),
+			want: true,
+		},
+		{
+			name: "ErrRateLimited (429) is expected 4xx",
+			err:  New(ErrRateLimited, "too many requests"),
+			want: true,
+		},
+		{
+			name: "ErrBodyTooLarge (413) is expected 4xx",
+			err:  New(ErrBodyTooLarge, "body too large"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsExpected4xx(tt.err))
+		})
+	}
+}
+
+// TestNewInfra_CategoryField verifies the Category field is set correctly.
+func TestNewInfra_CategoryField(t *testing.T) {
+	err := NewInfra(ErrInternal, "db unavailable")
+	assert.Equal(t, CategoryInfra, err.Category)
+	assert.Equal(t, ErrInternal, err.Code)
+	assert.Equal(t, "db unavailable", err.Message)
+}
+
+// TestNewDomain_CategoryField verifies NewDomain sets CategoryDomain.
+func TestNewDomain_CategoryField(t *testing.T) {
+	err := NewDomain(ErrSessionNotFound, "session not found")
+	assert.Equal(t, CategoryDomain, err.Category)
+	assert.Equal(t, ErrSessionNotFound, err.Code)
+}
+
+// TestNew_BackwardCompatibility verifies that the existing New() constructor
+// produces CategoryUnspecified (zero value), preserving all prior behaviour.
+func TestNew_BackwardCompatibility(t *testing.T) {
+	err := New(ErrCellNotFound, "not found")
+	assert.Equal(t, CategoryUnspecified, err.Category,
+		"New() must preserve zero-value Category for backward compat")
+	// Unspecified is fail-closed → treated as infra.
+	assert.True(t, IsInfraError(err),
+		"CategoryUnspecified is fail-closed and must be treated as infra")
+}

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -149,12 +149,19 @@ const (
 // InternalMessage holds diagnostic detail that must never be exposed to
 // API consumers. When present, Error() uses it (for logs/traces); HTTP
 // response writers use Message (safe for clients).
+//
+// Category classifies the error origin for log-level routing and infra/domain
+// triage. The zero value CategoryUnspecified is treated as infra (fail-closed).
+// Use NewInfra / NewDomain constructors to set the appropriate category; the
+// legacy New / Wrap / Safe constructors leave Category at its zero value to
+// preserve backward compatibility.
 type Error struct {
 	Code            Code
 	Message         string
 	InternalMessage string
 	Details         map[string]any
 	Cause           error
+	Category        Category
 }
 
 // Error returns a formatted string representation for logging/diagnostics.
@@ -226,5 +233,6 @@ func WithDetails(err *Error, details map[string]any) *Error {
 		InternalMessage: err.InternalMessage,
 		Details:         merged,
 		Cause:           err.Cause,
+		Category:        err.Category,
 	}
 }

--- a/pkg/testutil/sloghelper/sloghelper.go
+++ b/pkg/testutil/sloghelper/sloghelper.go
@@ -1,0 +1,38 @@
+// Package sloghelper provides test helpers for asserting slog JSON output.
+// It avoids false positives from full-string Contains/NotContains by parsing
+// each log line individually and matching on specific message substrings.
+package sloghelper
+
+import (
+	"bufio"
+	"encoding/json"
+	"strings"
+)
+
+// FindLogEntry scans the JSON log output (one JSON object per line) and returns
+// the first parsed line whose "msg" value contains msgSubstr. Returns nil if no
+// matching line is found. Malformed JSON lines are silently skipped.
+//
+// Typical use in tests:
+//
+//	entry := sloghelper.FindLogEntry(buf.String(), "session not found")
+//	require.NotNil(t, entry, "expected a log line about session not found")
+//	assert.Equal(t, "WARN", entry["level"])
+func FindLogEntry(logOutput, msgSubstr string) map[string]any {
+	scanner := bufio.NewScanner(strings.NewReader(logOutput))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		msg, _ := entry["msg"].(string)
+		if strings.Contains(msg, msgSubstr) {
+			return entry
+		}
+	}
+	return nil
+}

--- a/pkg/testutil/sloghelper/sloghelper_test.go
+++ b/pkg/testutil/sloghelper/sloghelper_test.go
@@ -1,0 +1,48 @@
+package sloghelper_test
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindLogEntry(t *testing.T) {
+	logOutput := `{"level":"INFO","msg":"service started","component":"auth"}
+{"level":"WARN","msg":"session not found","sid":"s1","subject":"u1"}
+{"level":"ERROR","msg":"session repo unavailable","sid":"s2","error":"db down"}
+`
+
+	t.Run("finds warn line by msg substring", func(t *testing.T) {
+		entry := sloghelper.FindLogEntry(logOutput, "session not found")
+		require.NotNil(t, entry)
+		assert.Equal(t, "WARN", entry["level"])
+		assert.Equal(t, "s1", entry["sid"])
+	})
+
+	t.Run("finds error line by msg substring", func(t *testing.T) {
+		entry := sloghelper.FindLogEntry(logOutput, "repo unavailable")
+		require.NotNil(t, entry)
+		assert.Equal(t, "ERROR", entry["level"])
+	})
+
+	t.Run("returns nil when no match", func(t *testing.T) {
+		entry := sloghelper.FindLogEntry(logOutput, "does not exist")
+		assert.Nil(t, entry)
+	})
+
+	t.Run("skips malformed JSON lines", func(t *testing.T) {
+		mixed := `not-json
+{"level":"ERROR","msg":"real error"}
+`
+		entry := sloghelper.FindLogEntry(mixed, "real error")
+		require.NotNil(t, entry)
+		assert.Equal(t, "ERROR", entry["level"])
+	})
+
+	t.Run("empty log output returns nil", func(t *testing.T) {
+		entry := sloghelper.FindLogEntry("", "anything")
+		assert.Nil(t, entry)
+	})
+}

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -138,11 +138,21 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 	claims, err := verifier.VerifyIntent(r.Context(), token, TokenIntentAccess)
 	if err != nil {
 		cfg.metrics.recordTokenVerify("failure", classifyTokenError(err), time.Since(start))
-		cfg.logger.Error("token verification failed",
-			"error", err,
-			"path", r.URL.Path,
-			"remote_addr", r.RemoteAddr,
-		)
+		// S43: expected 4xx (invalid/expired token, unauthorized) → Warn;
+		// infra errors (key load failure, verifier init error) → Error.
+		if errcode.IsExpected4xx(err) {
+			cfg.logger.Warn("token verification failed",
+				"error", err,
+				"path", r.URL.Path,
+				"remote_addr", r.RemoteAddr,
+			)
+		} else {
+			cfg.logger.Error("token verification failed",
+				"error", err,
+				"path", r.URL.Path,
+				"remote_addr", r.RemoteAddr,
+			)
+		}
 		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid token")
 		return
 	}

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -295,6 +296,82 @@ func TestAuthMiddleware_WithLogger_LogsToBuffer(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Contains(t, buf.String(), "token verification failed")
+}
+
+// TestAuthMiddleware_LogLevel_Expected4xx_Warn verifies S43: expected 4xx errors
+// (invalid token, expired token, unauthorized) must log at Warn, not Error.
+func TestAuthMiddleware_LogLevel_Expected4xx_Warn(t *testing.T) {
+	expected4xxErrs := []struct {
+		name string
+		err  error
+	}{
+		{"ErrAuthTokenInvalid", errcode.New(errcode.ErrAuthTokenInvalid, "invalid token")},
+		{"ErrAuthTokenExpired", errcode.New(errcode.ErrAuthTokenExpired, "token expired")},
+		{"ErrAuthUnauthorized", errcode.New(errcode.ErrAuthUnauthorized, "unauthorized")},
+		{"ErrAuthInvalidToken", errcode.New(errcode.ErrAuthInvalidToken, "invalid")},
+	}
+
+	for _, tc := range expected4xxErrs {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			verifier := &mockVerifier{err: tc.err}
+			handler := AuthMiddleware(verifier, nil, WithLogger(logger))(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					t.Fatal("should not be called")
+				}),
+			)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+			req.Header.Set("Authorization", "Bearer bad-token")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+			logOutput := buf.String()
+			assert.Contains(t, logOutput, `"level":"WARN"`,
+				"expected 4xx token error must log at WARN, not ERROR")
+			assert.NotContains(t, logOutput, `"level":"ERROR"`,
+				"expected 4xx error must not produce an ERROR log")
+		})
+	}
+}
+
+// TestAuthMiddleware_LogLevel_InfraError_Error verifies S43: infra errors
+// (verifier init failure, key load failure) must log at Error, not Warn.
+func TestAuthMiddleware_LogLevel_InfraError_Error(t *testing.T) {
+	infraErrs := []struct {
+		name string
+		err  error
+	}{
+		{"plain verifier error", fmt.Errorf("key loading failed: connection refused")},
+		{"CategoryInfra errcode", errcode.NewInfra(errcode.ErrInternal, "key set unavailable")},
+	}
+
+	for _, tc := range infraErrs {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			verifier := &mockVerifier{err: tc.err}
+			handler := AuthMiddleware(verifier, nil, WithLogger(logger))(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					t.Fatal("should not be called")
+				}),
+			)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+			req.Header.Set("Authorization", "Bearer any-token")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+			logOutput := buf.String()
+			assert.Contains(t, logOutput, `"level":"ERROR"`,
+				"infra error must log at ERROR")
+			assert.NotContains(t, logOutput, `"level":"WARN"`,
+				"infra error must not produce a WARN log")
+		})
+	}
 }
 
 func TestAuthMiddleware_WithMetrics_NoPanic(t *testing.T) {

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -329,16 +330,22 @@ func TestAuthMiddleware_LogLevel_Expected4xx_Warn(t *testing.T) {
 
 			assert.Equal(t, http.StatusUnauthorized, rec.Code)
 			logOutput := buf.String()
-			assert.Contains(t, logOutput, `"level":"WARN"`,
+			// P2-4: precise JSON-line matching — locate the token verification log
+			// line specifically, ignoring any unrelated ERROR lines that may exist.
+			entry := sloghelper.FindLogEntry(logOutput, "token verification failed")
+			require.NotNil(t, entry,
+				"expected a log line containing 'token verification failed'")
+			assert.Equal(t, "WARN", entry["level"],
 				"expected 4xx token error must log at WARN, not ERROR")
-			assert.NotContains(t, logOutput, `"level":"ERROR"`,
-				"expected 4xx error must not produce an ERROR log")
 		})
 	}
 }
 
 // TestAuthMiddleware_LogLevel_InfraError_Error verifies S43: infra errors
 // (verifier init failure, key load failure) must log at Error, not Warn.
+//
+// P1-1: ErrAuthKeyMissing maps to HTTP 500 in codeToStatus (infra), so it must
+// NOT appear in expected4xxCodes. This test confirms it logs at Error level.
 func TestAuthMiddleware_LogLevel_InfraError_Error(t *testing.T) {
 	infraErrs := []struct {
 		name string
@@ -346,6 +353,8 @@ func TestAuthMiddleware_LogLevel_InfraError_Error(t *testing.T) {
 	}{
 		{"plain verifier error", fmt.Errorf("key loading failed: connection refused")},
 		{"CategoryInfra errcode", errcode.NewInfra(errcode.ErrInternal, "key set unavailable")},
+		// P1-1: ErrAuthKeyMissing is HTTP 500 (infra misconfiguration); must log Error.
+		{"ErrAuthKeyMissing is infra 500", errcode.New(errcode.ErrAuthKeyMissing, "no signing key configured")},
 	}
 
 	for _, tc := range infraErrs {
@@ -366,10 +375,12 @@ func TestAuthMiddleware_LogLevel_InfraError_Error(t *testing.T) {
 
 			assert.Equal(t, http.StatusUnauthorized, rec.Code)
 			logOutput := buf.String()
-			assert.Contains(t, logOutput, `"level":"ERROR"`,
+			// P2-4: precise JSON-line matching on the token verification log line.
+			entry := sloghelper.FindLogEntry(logOutput, "token verification failed")
+			require.NotNil(t, entry,
+				"expected a log line containing 'token verification failed'")
+			assert.Equal(t, "ERROR", entry["level"],
 				"infra error must log at ERROR")
-			assert.NotContains(t, logOutput, `"level":"WARN"`,
-				"infra error must not produce a WARN log")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- **pkg/errcode/classify.go** (new): `IsInfraError`, `IsDomainNotFound`, `IsExpected4xx` classifier API + `Category` enum with `NewInfra`/`NewDomain` constructors; backward-compatible (existing `New()` leaves `Category` at zero)
- **P1-18**: `sessionrefresh.lookupSession` now routes infra errors directly to `slog.Error` + `ErrAuthRefreshFailed`, never entering the reuse-detection branch
- **S40**: `sessionvalidate.logSessionLookupError` replaces `errors.As(errcode.Error)` broad match with `IsDomainNotFound` whitelist; only `ErrSessionNotFound` → Warn, everything else → Error
- **S43**: `AuthMiddleware.handleAuthRequest` uses `IsExpected4xx` to route expected 401/403 rejections to Warn and true infra errors to Error

## Rationale

Architecture foundation F5 of 7-stone Auth plan. Dual-channel classification pattern: infra errors must never be confused with domain not-found (ref: k8s apimachinery `pkg/api/errors.IsNotFound`).

Fail-closed invariant: `CategoryUnspecified` (zero value from legacy `New()`) is treated as infra by all classifiers, so pre-existing errors are never silently downgraded.

## Backlog references

- P1-18 REFRESH-INFRA-ERROR-CLASSIFY-01 (P1)
- S40 VALIDATE-ERRCODE-CLASSIFY-01 (P2)
- S43 AUTH-FAILURE-LOG-LEVEL-01 (P2)

## Test plan

- [x] `pkg/errcode/classify_test.go` — 20+ table-driven cases: `IsInfraError` (nil, context sentinels, db sentinels, CategoryInfra/Domain/Auth/Validation/Unspecified, plain error); `IsDomainNotFound` (whitelist, infra gate, CategoryUnspecified gate); `IsExpected4xx` (401/403/404/409/400/413/429 vs 500 vs plain)
- [x] `sessionvalidate/service_test.go` — `TestLogSessionLookupError_LogLevel`: 5 cases covering infra error, domain whitelist, non-whitelist domain, CategoryInfra, CategoryUnspecified; verifies log level in JSON buffer
- [x] `sessionrefresh/service_test.go` — `TestLookupSession_InfraError_DoesNotEnterReuseBranch` (2 sub-cases), `TestLookupSession_DomainNotFound_EntersReuseBranch`; verifies no reuse log on infra
- [x] `runtime/auth/middleware_test.go` — `TestAuthMiddleware_LogLevel_Expected4xx_Warn` (4 sub-cases), `TestAuthMiddleware_LogLevel_InfraError_Error` (2 sub-cases)
- [x] `go build ./...` — clean
- [x] `go build -tags=integration ./...` — clean
- [x] `go test ./pkg/errcode/... ./cells/access-core/... ./runtime/auth/...` — all green (15 packages)
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)