### PR TITLE
feat(auth): F1 JWT config.Registry — 单一事实源

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,9 @@ GOCELL_S3_REGION=us-east-1
 GOCELL_JWT_PRIVATE_KEY=
 GOCELL_JWT_PUBLIC_KEY=
 
-# JWT identity and audience — required in ALL adapter modes (no fallback).
+# JWT identity and audience — required in ALL adapter modes (dev and real alike;
+# no fallback even when GOCELL_CELL_ADAPTER_MODE or GOCELL_ADAPTER_MODE is unset).
+# The service fails fast at startup if either variable is missing or whitespace-only.
 # GOCELL_JWT_ISSUER: written into the iss claim of every issued token and
 #   verified on every inbound JWT. Must be a stable identifier for your
 #   deployment (e.g. "https://auth.example.com" or "my-service").

--- a/cells/access-core/cell_test.go
+++ b/cells/access-core/cell_test.go
@@ -46,7 +46,7 @@ var (
 
 func mustIssuer(ks *auth.KeySet) *auth.JWTIssuer {
 	i, err := auth.NewJWTIssuer(ks, "gocell-access-core", 15*time.Minute,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/access-core/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/access-core/slices/identitymanage/changepassword_e2e_test.go
@@ -45,11 +45,11 @@ import (
 var e2eTestKeySet, _, _ = auth.MustNewTestKeySet()
 
 // e2eIssuer is used by the login service.
-// WithDefaultAudience("gocell") must match the e2eVerifier's WithExpectedAudiences("gocell")
-// so that VerifyIntent passes audience validation.
+// WithIssuerAudiencesFromSlice(["gocell"]) must match the e2eVerifier's
+// WithExpectedAudiences("gocell") so that VerifyIntent passes audience validation.
 var e2eIssuer = func() *auth.JWTIssuer {
 	i, err := auth.NewJWTIssuer(e2eTestKeySet, "gocell-access-core", 15*time.Minute,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	if err != nil {
 		panic("e2e test setup: " + err.Error())
 	}

--- a/cells/access-core/slices/sessionlogin/service.go
+++ b/cells/access-core/slices/sessionlogin/service.go
@@ -55,13 +55,14 @@ type Service struct {
 	outboxWriter outbox.Writer
 	txRunner     persistence.TxRunner
 	issuer       *auth.JWTIssuer
-	audience     []string
 	logger       *slog.Logger
 }
 
 // NewService creates a session-login Service.
-// The audience for issued tokens is read from issuer.DefaultAudience() at
-// construction time so there is no hard-coded audience constant in this slice.
+// The audience for issued tokens is carried inside issuer (set from Registry at
+// construction time via config.NewJWTIssuerFromRegistry). This slice does not
+// cache or re-read the audience — issuer.Issue with nil Audience falls back to
+// the issuer's configured default (S31 audience deduplication).
 func NewService(
 	userRepo ports.UserRepository,
 	sessionRepo ports.SessionRepository,
@@ -77,7 +78,6 @@ func NewService(
 		roleRepo:    roleRepo,
 		publisher:   pub,
 		issuer:      issuer,
-		audience:    issuer.DefaultAudience(),
 		logger:      logger,
 	}
 	for _, o := range opts {
@@ -220,12 +220,11 @@ func (s *Service) maybePublishDirect(ctx context.Context, payload []byte) {
 // issueAccessToken signs a short-lived JWT with intent=access for calling
 // business endpoints. Access tokens carry roles for RBAC decisions and the
 // passwordResetRequired flag so middleware can enforce server-side reset.
-// The audience is sourced from s.audience (populated from issuer.DefaultAudience()
-// at construction) — no hard-coded audience constant.
+// Audience is nil — the issuer's configured default (from Registry) is used
+// automatically; this slice does not duplicate audience configuration (S31).
 func (s *Service) issueAccessToken(subject string, roles []string, sessionID string, passwordResetRequired bool) (string, error) {
 	return s.issuer.Issue(auth.TokenIntentAccess, subject, auth.IssueOptions{
 		Roles:                 roles,
-		Audience:              s.audience,
 		SessionID:             sessionID,
 		PasswordResetRequired: passwordResetRequired,
 	})
@@ -296,11 +295,9 @@ func (s *Service) IssueForUser(ctx context.Context, userID string) (dto.TokenPai
 // issueRefreshToken signs a longer-lived JWT with intent=refresh. Refresh
 // tokens do not carry roles: they are consumed only by /auth/refresh, which
 // looks up the current roles from the session's user on each rotation.
-// The audience is sourced from s.audience (populated from issuer.DefaultAudience()
-// at construction) — no hard-coded audience constant.
+// Audience is nil — falls back to issuer's configured default from Registry (S31).
 func (s *Service) issueRefreshToken(subject, sessionID string) (string, error) {
 	return s.issuer.Issue(auth.TokenIntentRefresh, subject, auth.IssueOptions{
-		Audience:  s.audience,
 		SessionID: sessionID,
 	})
 }

--- a/cells/access-core/slices/sessionlogin/service_test.go
+++ b/cells/access-core/slices/sessionlogin/service_test.go
@@ -24,17 +24,19 @@ var (
 
 func init() {
 	var err error
+	// Issuer is constructed with a default audience via WithIssuerAudiencesFromSlice
+	// (Registry path). The slice service no longer caches audience separately (S31).
 	testIssuer, err = auth.NewJWTIssuer(testKeySet, "gocell-access-core", auth.DefaultAccessTokenTTL,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
 }
 
-// TestNewService_InheritsAudienceFromIssuer verifies that NewService reads the
-// default audience from the issuer's DefaultAudience() and uses it when minting
-// tokens, so no external constant (like auth.DefaultJWTAudience) is required.
-func TestNewService_InheritsAudienceFromIssuer(t *testing.T) {
+// TestNewService_IssuerDefaultAudienceWrittenToTokens verifies that when the
+// issuer is constructed with a default audience (Registry path), the Service
+// writes that audience into issued tokens without caching it separately (S31).
+func TestNewService_IssuerDefaultAudienceWrittenToTokens(t *testing.T) {
 	svc, userRepo := newTestService()
 	seedUser(userRepo, "aud-user", "pass123")
 
@@ -44,17 +46,17 @@ func TestNewService_InheritsAudienceFromIssuer(t *testing.T) {
 	pair, err := svc.Login(context.Background(), LoginInput{Username: "aud-user", Password: "pass123"})
 	require.NoError(t, err)
 
-	// The access token must carry the audience from the issuer's DefaultAudience.
+	// The access token must carry the audience from the issuer's configured default.
 	accessClaims, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Contains(t, accessClaims.Audience, "gocell",
-		"access token aud must be populated from issuer.DefaultAudience()")
+		"access token aud must be populated from issuer default audience (Registry)")
 
 	// The refresh token must also carry the audience.
 	refreshClaims, err := verifier.VerifyIntent(context.Background(), pair.RefreshToken, auth.TokenIntentRefresh)
 	require.NoError(t, err)
 	assert.Contains(t, refreshClaims.Audience, "gocell",
-		"refresh token aud must be populated from issuer.DefaultAudience()")
+		"refresh token aud must be populated from issuer default audience (Registry)")
 }
 
 func newTestService() (*Service, *mem.UserRepository) {

--- a/cells/access-core/slices/sessionrefresh/service.go
+++ b/cells/access-core/slices/sessionrefresh/service.go
@@ -40,7 +40,6 @@ type Service struct {
 	userRepo    ports.UserRepository
 	roleRepo    ports.RoleRepository
 	issuer      *auth.JWTIssuer
-	audience    []string
 	verifier    auth.IntentTokenVerifier
 	logger      *slog.Logger
 }
@@ -53,8 +52,8 @@ type Service struct {
 // production. Pass mem.NewUserRepository() in tests that do not exercise the
 // flag.
 //
-// The audience for issued tokens is read from issuer.DefaultAudience() at
-// construction time so there is no hard-coded audience constant in this slice.
+// The audience for issued tokens is carried inside issuer (set from Registry at
+// construction time). This slice does not cache audience separately (S31).
 func NewService(
 	sessionRepo ports.SessionRepository,
 	roleRepo ports.RoleRepository,
@@ -69,7 +68,6 @@ func NewService(
 		roleRepo:    roleRepo,
 		userRepo:    userRepo,
 		issuer:      issuer,
-		audience:    issuer.DefaultAudience(),
 		verifier:    verifier,
 		logger:      logger,
 	}
@@ -250,12 +248,10 @@ func (s *Service) verifyRefreshToken(ctx context.Context, refreshToken string) e
 
 // issueAccessToken signs a short-lived JWT with intent=access carrying roles and
 // the passwordResetRequired flag so middleware can enforce server-side reset.
-// The audience is sourced from s.audience (populated from issuer.DefaultAudience()
-// at construction) — no hard-coded audience constant.
+// Audience is nil — falls back to issuer's configured default from Registry (S31).
 func (s *Service) issueAccessToken(subject string, roles []string, sessionID string, passwordResetRequired bool) (string, error) {
 	return s.issuer.Issue(auth.TokenIntentAccess, subject, auth.IssueOptions{
 		Roles:                 roles,
-		Audience:              s.audience,
 		SessionID:             sessionID,
 		PasswordResetRequired: passwordResetRequired,
 	})
@@ -263,11 +259,9 @@ func (s *Service) issueAccessToken(subject string, roles []string, sessionID str
 
 // issueRefreshToken signs a JWT with intent=refresh. Refresh tokens carry no
 // roles: /auth/refresh refetches roles from the session's user on rotation.
-// The audience is sourced from s.audience (populated from issuer.DefaultAudience()
-// at construction) — no hard-coded audience constant.
+// Audience is nil — falls back to issuer's configured default from Registry (S31).
 func (s *Service) issueRefreshToken(subject, sessionID string) (string, error) {
 	return s.issuer.Issue(auth.TokenIntentRefresh, subject, auth.IssueOptions{
-		Audience:  s.audience,
 		SessionID: sessionID,
 	})
 }

--- a/cells/access-core/slices/sessionrefresh/service_test.go
+++ b/cells/access-core/slices/sessionrefresh/service_test.go
@@ -28,8 +28,10 @@ var (
 
 func init() {
 	var err error
+	// Issuer is constructed with a default audience via WithIssuerAudiencesFromSlice
+	// (Registry path). The slice service no longer caches audience separately (S31).
 	testIssuer, err = auth.NewJWTIssuer(testKeySet, "gocell-access-core", auth.DefaultAccessTokenTTL,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
@@ -39,10 +41,10 @@ func init() {
 	}
 }
 
-// TestNewService_InheritsAudienceFromIssuer_Refresh verifies that the sessionrefresh
-// Service reads the default audience from issuer.DefaultAudience() and uses it when
-// minting new tokens during rotation, without relying on a hard-coded constant.
-func TestNewService_InheritsAudienceFromIssuer_Refresh(t *testing.T) {
+// TestNewService_IssuerDefaultAudienceWrittenOnRefresh verifies that the
+// sessionrefresh Service issues tokens with the audience configured in the
+// issuer (Registry path), without caching audience separately (S31).
+func TestNewService_IssuerDefaultAudienceWrittenOnRefresh(t *testing.T) {
 	svc, sessionRepo := newTestService("usr-aud-refresh")
 
 	rt := issueTestToken("usr-aud-refresh")
@@ -60,12 +62,12 @@ func TestNewService_InheritsAudienceFromIssuer_Refresh(t *testing.T) {
 	accessClaims, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, auth.TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Contains(t, accessClaims.Audience, "gocell",
-		"rotated access token aud must come from issuer.DefaultAudience()")
+		"rotated access token aud must come from issuer default audience (Registry)")
 
 	refreshClaims, err := verifier.VerifyIntent(context.Background(), pair.RefreshToken, auth.TokenIntentRefresh)
 	require.NoError(t, err)
 	assert.Contains(t, refreshClaims.Audience, "gocell",
-		"rotated refresh token aud must come from issuer.DefaultAudience()")
+		"rotated refresh token aud must come from issuer default audience (Registry)")
 }
 
 // newTestService creates a refresh service with a minimal in-memory userRepo

--- a/cmd/core-bundle/auth_integration_test.go
+++ b/cmd/core-bundle/auth_integration_test.go
@@ -52,7 +52,8 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 	privKey, pubKey := auth.MustGenerateTestKeyPair()
 	keySet, err := auth.NewKeySet(privKey, pubKey)
 	require.NoError(t, err)
-	jwtIssuer, err := auth.NewJWTIssuer(keySet, "test", 15*time.Minute, auth.WithDefaultAudience("gocell"))
+	jwtIssuer, err := auth.NewJWTIssuer(keySet, "test", 15*time.Minute,
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	require.NoError(t, err)
 	jwtVerifier, err := auth.NewJWTVerifier(keySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
@@ -233,7 +234,7 @@ func TestAuthWiring_InternalGuard_RequiresServiceToken(t *testing.T) {
 	keySet, err := auth.NewKeySet(privKey, pubKey)
 	require.NoError(t, err)
 	jwtIssuer, err := auth.NewJWTIssuer(keySet, "guard-test", 15*time.Minute,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	require.NoError(t, err)
 	jwtVerifier, err := auth.NewJWTVerifier(keySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)

--- a/cmd/core-bundle/jwt_aud_integration_test.go
+++ b/cmd/core-bundle/jwt_aud_integration_test.go
@@ -48,8 +48,8 @@ func TestBuildJWTDeps_VerifierEnforcesAudience(t *testing.T) {
 
 	t.Run("rejects_explicitly_empty_audience", func(t *testing.T) {
 		// Issue a token with an explicit wrong audience to test rejection.
-		// (nil audience now falls back to the configured default "gocell" via
-		// WithDefaultAudience, so we must supply an explicit wrong value instead.)
+		// (nil audience falls back to the Registry-configured default "gocell",
+		// so we must supply an explicit wrong value instead.)
 		tok, err := deps.issuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{
 			Audience: []string{"not-gocell"},
 		})
@@ -71,13 +71,14 @@ func TestBuildJWTDeps_VerifierAudience_MatchesIssuerDefault(t *testing.T) {
 	deps, err := buildJWTDeps("")
 	require.NoError(t, err)
 
-	// issuer.DefaultAudience() returns the audience configured via GOCELL_JWT_AUDIENCE.
-	// Simulate what sessionlogin.Service.issueAccessToken does: rely on issuer.DefaultAudience().
+	// The audience configured via GOCELL_JWT_AUDIENCE is set as the issuer's default
+	// (via Registry). Simulate what sessionlogin.Service.issueAccessToken does: rely on
+	// the issuer's Registry-configured default audience.
 	tok, err := deps.issuer.Issue(
 		auth.TokenIntentAccess, "user-1", auth.IssueOptions{
 			Roles:     []string{"admin"},
 			SessionID: "sess-1",
-			// Audience left nil — issuer writes deps.issuer.DefaultAudience() automatically.
+			// Audience left nil — issuer uses Registry-configured default automatically.
 		},
 	)
 	require.NoError(t, err)

--- a/cmd/core-bundle/jwt_deps_test.go
+++ b/cmd/core-bundle/jwt_deps_test.go
@@ -1,7 +1,8 @@
-// Tests for env-var-driven JWT dependency loading (C5).
+// Tests for env-var-driven JWT dependency loading (C5 / F1 Registry).
 //
 // GOCELL_JWT_ISSUER and GOCELL_JWT_AUDIENCE are required in all adapter modes
-// (there is no fallback default value).
+// (there is no fallback default value). After F1, loading is done via
+// authconfig.FromEnv; these tests exercise buildJWTDeps end-to-end.
 package main
 
 import (
@@ -17,59 +18,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- loadJWTIssuer ---
+// --- buildJWTDeps: env-var validation ---
 
-// TestLoadJWTIssuer_MissingEnvVar_Error verifies that an unset GOCELL_JWT_ISSUER
-// returns an error containing the env var name.
-func TestLoadJWTIssuer_MissingEnvVar_Error(t *testing.T) {
+// TestBuildJWTDeps_MissingIssuer_Error verifies that an unset GOCELL_JWT_ISSUER
+// causes buildJWTDeps to fail fast.
+func TestBuildJWTDeps_MissingIssuer_Error(t *testing.T) {
 	t.Setenv("GOCELL_JWT_ISSUER", "")
-	_, err := loadJWTIssuer("")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+	_, err := buildJWTDeps("")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "GOCELL_JWT_ISSUER",
 		"error must name the missing env var")
 }
 
-// TestLoadJWTIssuer_SetEnvVar_Used verifies that a set GOCELL_JWT_ISSUER is returned.
-func TestLoadJWTIssuer_SetEnvVar_Used(t *testing.T) {
+// TestBuildJWTDeps_MissingAudience_Error verifies that an unset GOCELL_JWT_AUDIENCE
+// causes buildJWTDeps to fail fast.
+func TestBuildJWTDeps_MissingAudience_Error(t *testing.T) {
 	t.Setenv("GOCELL_JWT_ISSUER", "gocell-prod")
-	val, err := loadJWTIssuer("")
-	require.NoError(t, err)
-	assert.Equal(t, "gocell-prod", val)
-}
-
-// TestLoadJWTIssuer_RealMode_AlsoRequired ensures real mode is equally strict.
-func TestLoadJWTIssuer_RealMode_AlsoRequired(t *testing.T) {
-	t.Setenv("GOCELL_JWT_ISSUER", "")
-	_, err := loadJWTIssuer("real")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "GOCELL_JWT_ISSUER")
-}
-
-// --- loadJWTAudience ---
-
-// TestLoadJWTAudience_MissingEnvVar_Error verifies that an unset GOCELL_JWT_AUDIENCE
-// returns an error containing the env var name.
-func TestLoadJWTAudience_MissingEnvVar_Error(t *testing.T) {
 	t.Setenv("GOCELL_JWT_AUDIENCE", "")
-	_, err := loadJWTAudience("")
+	_, err := buildJWTDeps("")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "GOCELL_JWT_AUDIENCE",
 		"error must name the missing env var")
-}
-
-// TestLoadJWTAudience_SetEnvVar_Used verifies that a set GOCELL_JWT_AUDIENCE is returned.
-func TestLoadJWTAudience_SetEnvVar_Used(t *testing.T) {
-	t.Setenv("GOCELL_JWT_AUDIENCE", "my-service")
-	val, err := loadJWTAudience("")
-	require.NoError(t, err)
-	assert.Equal(t, "my-service", val)
 }
 
 // --- buildJWTDeps integration ---
 
 // TestBuildJWTDeps_RealMode_VerifierRejectsWrongIssuer builds JWT deps and
 // verifies that a token carrying a different iss claim is rejected.
-// Uses the same key set to isolate the issuer check from key mismatch.
 func TestBuildJWTDeps_RealMode_VerifierRejectsWrongIssuer(t *testing.T) {
 	t.Setenv("GOCELL_JWT_ISSUER", "correct-issuer")
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
@@ -78,11 +54,10 @@ func TestBuildJWTDeps_RealMode_VerifierRejectsWrongIssuer(t *testing.T) {
 	require.NoError(t, err)
 
 	// Issue a token using a separate key set with iss="wrong-issuer", then verify
-	// using a verifier that expects iss="correct-issuer". The key mismatch is
-	// intentional isolation: we test only the issuer claim enforcement.
+	// using a verifier that expects iss="correct-issuer".
 	ks, _, _ := auth.MustNewTestKeySet()
 	wrongIssuerIssuer, err := auth.NewJWTIssuer(ks, "wrong-issuer", 15*time.Minute,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	require.NoError(t, err)
 	wrongVerifier, err := auth.NewJWTVerifier(ks,
 		auth.WithExpectedAudiences("gocell"),
@@ -121,10 +96,7 @@ func TestBuildJWTDeps_RealMode_VerifierRejectsWrongAudience(t *testing.T) {
 // TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongIssuer is an end-to-end
 // wiring test: it builds deps via buildJWTDeps (reading issuer from env) and
 // then uses deps.verifier to reject a token signed with a different issuer.
-// This locks the env → issuer → verifier wiring that the prior RealMode tests
-// missed (B3 finding): the prior test created an independent verifier with
-// explicit options, so it never proved that the verifier produced by
-// buildJWTDeps reads GOCELL_JWT_ISSUER correctly.
+// Locks env → Registry → issuer → verifier wiring (B3).
 func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongIssuer(t *testing.T) {
 	t.Setenv("GOCELL_JWT_ISSUER", "prod-iss")
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
@@ -133,16 +105,11 @@ func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongIssuer(t *testing.T) {
 	require.NoError(t, err, "buildJWTDeps must succeed with valid env vars")
 
 	// Use a separate key set and issuer so key mismatch does not interfere.
-	// We want to isolate the issuer claim check on deps.verifier.
 	ks, _, _ := auth.MustNewTestKeySet()
 	wrongIssuer, err := auth.NewJWTIssuer(ks, "wrong-iss", 15*time.Minute,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	require.NoError(t, err)
 
-	// Create a separate verifier for the alternative key set that trusts wrong-iss.
-	// deps.verifier uses its own key set and expects "prod-iss" — key mismatch
-	// will always fail, which is intentional: the goal is to assert that deps.verifier
-	// rejects the token (regardless of whether it is due to key mismatch or issuer).
 	tok, err := wrongIssuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{
 		Audience: []string{"gocell"},
 	})
@@ -152,14 +119,11 @@ func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongIssuer(t *testing.T) {
 	_, err = deps.verifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
 	require.Error(t, err,
 		"deps.verifier (wired from GOCELL_JWT_ISSUER=prod-iss) must reject a token "+
-			"issued by wrong-iss; this locks env→verifier wiring (B3)")
+			"issued by wrong-iss; locks env→Registry→verifier wiring (B3)")
 }
 
 // TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongAudience is an end-to-end
-// wiring test: it builds deps via buildJWTDeps and uses deps.issuer to sign a
-// token with the wrong audience, then asserts deps.verifier rejects it.
-// This complements the B3 fix by verifying GOCELL_JWT_AUDIENCE flows into the
-// verifier's audience check (not just into the issuer's default audience).
+// wiring test: builds deps and verifies GOCELL_JWT_AUDIENCE flows into verifier.
 func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongAudience(t *testing.T) {
 	t.Setenv("GOCELL_JWT_ISSUER", "prod-iss")
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
@@ -177,11 +141,11 @@ func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongAudience(t *testing.T) {
 	_, err = deps.verifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
 	require.Error(t, err,
 		"deps.verifier must reject token with aud=wrong-service; "+
-			"locks GOCELL_JWT_AUDIENCE→verifier wiring (B3)")
+			"locks GOCELL_JWT_AUDIENCE→Registry→verifier wiring (B3)")
 }
 
 // TestBuildJWTDeps_LogsEffectiveConfig verifies that buildJWTDeps emits a
-// structured Info log with issuer, audience, and adapter_mode fields.
+// structured Info log with issuer, audiences, and adapter_mode fields.
 func TestBuildJWTDeps_LogsEffectiveConfig(t *testing.T) {
 	t.Setenv("GOCELL_JWT_ISSUER", "log-test-issuer")
 	t.Setenv("GOCELL_JWT_AUDIENCE", "log-test-aud")
@@ -210,8 +174,9 @@ func TestBuildJWTDeps_LogsEffectiveConfig(t *testing.T) {
 		}
 		found = true
 		assert.Equal(t, "log-test-issuer", record["issuer"], "log must contain issuer field")
-		assert.Equal(t, "log-test-aud", record["audience"], "log must contain audience field")
 		assert.Equal(t, "testmode", record["adapter_mode"], "log must contain adapter_mode field")
+		// audiences is now a []string (slog.Any) rather than a plain string
+		assert.NotNil(t, record["audiences"], "log must contain audiences field")
 	}
 	assert.True(t, found, "structured log 'core-bundle: JWT deps built' must be emitted by buildJWTDeps")
 }

--- a/cmd/core-bundle/jwt_deps_test.go
+++ b/cmd/core-bundle/jwt_deps_test.go
@@ -8,15 +8,41 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
+	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// setTestJWTKeyEnv installs a PEM-encoded RSA key pair into GOCELL_JWT_PRIVATE_KEY /
+// GOCELL_JWT_PUBLIC_KEY so that a subsequent loadKeySet("") call reads the same
+// key material the caller can reload via auth.LoadKeySetFromEnv. This eliminates
+// the hidden key-mismatch dimension that would otherwise mask wiring regressions
+// in issuer/audience validation tests (B3 wiring lock integrity).
+//
+// Returns nothing: state is restored by t.Setenv at the end of the test.
+func setTestJWTKeyEnv(t *testing.T) {
+	t.Helper()
+	priv, pub := auth.MustGenerateTestKeyPair()
+	privPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err, "marshal test public key")
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	t.Setenv(auth.EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(auth.EnvJWTPublicKey, string(pubPEM))
+}
 
 // --- buildJWTDeps: env-var validation ---
 
@@ -42,106 +68,115 @@ func TestBuildJWTDeps_MissingAudience_Error(t *testing.T) {
 		"error must name the missing env var")
 }
 
-// --- buildJWTDeps integration ---
+// --- buildJWTDeps wiring integration ---
+//
+// These tests lock env → Registry → issuer/verifier wiring (B3) by isolating
+// each failure dimension. The key material is injected via env so deps and the
+// test-side issuer share the SAME keyset — a signature failure would otherwise
+// short-circuit before iss/aud claim checks, turning the test into a false
+// positive that passes even when issuer/audience wiring is broken.
 
-// TestBuildJWTDeps_RealMode_VerifierRejectsWrongIssuer builds JWT deps and
-// verifies that a token carrying a different iss claim is rejected.
-func TestBuildJWTDeps_RealMode_VerifierRejectsWrongIssuer(t *testing.T) {
-	t.Setenv("GOCELL_JWT_ISSUER", "correct-issuer")
-	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
-
-	_, err := buildJWTDeps("")
-	require.NoError(t, err)
-
-	// Issue a token using a separate key set with iss="wrong-issuer", then verify
-	// using a verifier that expects iss="correct-issuer".
-	ks, _, _ := auth.MustNewTestKeySet()
-	wrongIssuerIssuer, err := auth.NewJWTIssuer(ks, "wrong-issuer", 15*time.Minute,
-		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
-	require.NoError(t, err)
-	wrongVerifier, err := auth.NewJWTVerifier(ks,
-		auth.WithExpectedAudiences("gocell"),
-		auth.WithExpectedIssuer("correct-issuer"))
-	require.NoError(t, err)
-
-	tok, err := wrongIssuerIssuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{
-		Audience: []string{"gocell"},
-	})
-	require.NoError(t, err)
-
-	// Verify using a verifier that expects "correct-issuer" but token has "wrong-issuer".
-	_, err = wrongVerifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
-	require.Error(t, err, "token with wrong iss must be rejected")
-	assert.Contains(t, err.Error(), "issuer", "error must mention issuer mismatch")
-}
-
-// TestBuildJWTDeps_RealMode_VerifierRejectsWrongAudience builds JWT deps and
-// verifies that a token signed with a different audience is rejected.
-func TestBuildJWTDeps_RealMode_VerifierRejectsWrongAudience(t *testing.T) {
-	t.Setenv("GOCELL_JWT_ISSUER", "correct-issuer")
-	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
-
-	deps, err := buildJWTDeps("")
-	require.NoError(t, err)
-
-	tok, err := deps.issuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{
-		Audience: []string{"wrong-service"},
-	})
-	require.NoError(t, err)
-
-	_, err = deps.verifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
-	require.Error(t, err, "token with wrong aud must be rejected")
-}
-
-// TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongIssuer is an end-to-end
-// wiring test: it builds deps via buildJWTDeps (reading issuer from env) and
-// then uses deps.verifier to reject a token signed with a different issuer.
-// Locks env → Registry → issuer → verifier wiring (B3).
+// TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongIssuer locks the
+// GOCELL_JWT_ISSUER → Registry → verifier.expectedIssuer wiring. The token is
+// signed with deps' own keyset (via env) but carries iss="wrong-iss"; signature
+// verification passes, then the issuer check rejects. We assert the specific
+// errcode (ErrAuthInvalidTokenIntent) and message ("issuer") so a regression
+// into a signature-level failure — which would also produce a non-nil error —
+// is caught.
 func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongIssuer(t *testing.T) {
+	setTestJWTKeyEnv(t)
 	t.Setenv("GOCELL_JWT_ISSUER", "prod-iss")
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 
 	deps, err := buildJWTDeps("")
 	require.NoError(t, err, "buildJWTDeps must succeed with valid env vars")
 
-	// Use a separate key set and issuer so key mismatch does not interfere.
-	ks, _, _ := auth.MustNewTestKeySet()
+	// Reload the exact same key material from env — deps already loaded it, so
+	// tokens signed with this ks are signature-valid against deps.verifier.
+	ks, err := auth.LoadKeySetFromEnv()
+	require.NoError(t, err, "reload keyset from env to mirror deps wiring")
+
 	wrongIssuer, err := auth.NewJWTIssuer(ks, "wrong-iss", 15*time.Minute,
 		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	require.NoError(t, err)
 
-	tok, err := wrongIssuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{
-		Audience: []string{"gocell"},
-	})
+	tok, err := wrongIssuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{})
 	require.NoError(t, err)
 
-	// deps.verifier must reject the token — wrong key and wrong issuer both contribute.
 	_, err = deps.verifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
 	require.Error(t, err,
-		"deps.verifier (wired from GOCELL_JWT_ISSUER=prod-iss) must reject a token "+
-			"issued by wrong-iss; locks env→Registry→verifier wiring (B3)")
+		"deps.verifier (wired from GOCELL_JWT_ISSUER=prod-iss) must reject token with iss=wrong-iss")
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr),
+		"rejection must be an *errcode.Error (got %T); otherwise upstream wiring may be bypassing Registry", err)
+	assert.Equal(t, errcode.ErrAuthInvalidTokenIntent, ecErr.Code,
+		"wrong-iss must surface ErrAuthInvalidTokenIntent; a different code means either "+
+			"signature verification failed first (key-mismatch pseudo-positive) or the iss check did not run")
+	// The safe client-facing Message distinguishes iss vs aud branches even
+	// though both share a single error code (enumeration-defense collapses
+	// them at the HTTP layer; see runtime/auth/jwt.go::checkIssuer).
+	assert.Contains(t, strings.ToLower(ecErr.Message), "issuer",
+		"Message must mention 'issuer' so a regression swapping the iss/aud branches is caught")
 }
 
-// TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongAudience is an end-to-end
-// wiring test: builds deps and verifies GOCELL_JWT_AUDIENCE flows into verifier.
+// TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongAudience locks the
+// GOCELL_JWT_AUDIENCE → Registry → verifier.expectedAudiences wiring.
+// deps.issuer is used to sign (same key) but with an overridden wrong audience.
 func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongAudience(t *testing.T) {
+	setTestJWTKeyEnv(t)
 	t.Setenv("GOCELL_JWT_ISSUER", "prod-iss")
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 
 	deps, err := buildJWTDeps("")
 	require.NoError(t, err, "buildJWTDeps must succeed with valid env vars")
 
-	// Issue a token overriding the audience with a wrong value.
 	tok, err := deps.issuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{
 		Audience: []string{"wrong-service"},
 	})
 	require.NoError(t, err)
 
-	// deps.verifier expects aud="gocell" (from GOCELL_JWT_AUDIENCE env var).
 	_, err = deps.verifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
-	require.Error(t, err,
-		"deps.verifier must reject token with aud=wrong-service; "+
-			"locks GOCELL_JWT_AUDIENCE→Registry→verifier wiring (B3)")
+	require.Error(t, err, "deps.verifier must reject token with aud=wrong-service")
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "rejection must be an *errcode.Error, got %T", err)
+	assert.Equal(t, errcode.ErrAuthInvalidTokenIntent, ecErr.Code,
+		"wrong-aud must surface ErrAuthInvalidTokenIntent")
+	assert.Contains(t, strings.ToLower(ecErr.Message), "audience",
+		"Message must mention 'audience' so a regression swapping iss/aud branches is caught")
+}
+
+// TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongKey isolates the signature
+// verification dimension: a token signed by a key NOT known to deps.verifier
+// must be rejected with ErrAuthUnauthorized (distinct code from iss/aud
+// mismatches). This complements the WrongIssuer/WrongAudience tests, ensuring
+// all three failure modes remain independently distinguishable.
+func TestBuildJWTDeps_ProdWiring_VerifierRejectsWrongKey(t *testing.T) {
+	setTestJWTKeyEnv(t)
+	t.Setenv("GOCELL_JWT_ISSUER", "prod-iss")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	deps, err := buildJWTDeps("")
+	require.NoError(t, err)
+
+	// Build a completely independent keyset — deps.verifier has no public key
+	// matching this kid, so verification must fail at the signature step.
+	strangerKS, _, _ := auth.MustNewTestKeySet()
+	stranger, err := auth.NewJWTIssuer(strangerKS, "prod-iss", 15*time.Minute,
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
+	require.NoError(t, err)
+
+	tok, err := stranger.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{})
+	require.NoError(t, err)
+
+	_, err = deps.verifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
+	require.Error(t, err, "deps.verifier must reject token signed by unknown key")
+
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "rejection must be an *errcode.Error, got %T", err)
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ecErr.Code,
+		"unknown signing key must surface ErrAuthUnauthorized (signature failure), not ErrAuthInvalidTokenIntent")
 }
 
 // TestBuildJWTDeps_LogsEffectiveConfig verifies that buildJWTDeps emits a

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
+	authconfig "github.com/ghbvf/gocell/runtime/auth/config"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
@@ -381,76 +382,55 @@ func buildConfigCoreOpts(ctx context.Context, pub outbox.Publisher, metricsProvi
 	}
 }
 
-// loadRequiredEnv loads a required env var. Returns an error if the value is
-// empty; there is no fallback default. Used for env vars that are mandatory
-// in all adapter modes (e.g. GOCELL_JWT_ISSUER, GOCELL_JWT_AUDIENCE).
-func loadRequiredEnv(envKey, description string) (string, error) {
-	v := os.Getenv(envKey)
-	if v == "" {
-		return "", fmt.Errorf("%s must be set (%s)", envKey, description)
-	}
-	return v, nil
-}
-
-// loadJWTIssuer loads the JWT issuer string from GOCELL_JWT_ISSUER.
-// The env var is required in all adapter modes — there is no fallback default.
-func loadJWTIssuer(adapterMode string) (string, error) {
-	return loadRequiredEnv("GOCELL_JWT_ISSUER", fmt.Sprintf("adapter mode %q", adapterMode))
-}
-
-// loadJWTAudience loads the JWT audience string from GOCELL_JWT_AUDIENCE.
-// The env var is required in all adapter modes — there is no fallback default.
-func loadJWTAudience(adapterMode string) (string, error) {
-	return loadRequiredEnv("GOCELL_JWT_AUDIENCE", fmt.Sprintf("adapter mode %q", adapterMode))
-}
-
 // jwtDeps groups JWT signing and verification components built at startup.
+// registry is the single source of truth for all JWT configuration; issuer
+// and verifier are constructed from registry so they share the same settings.
 type jwtDeps struct {
 	issuer   *auth.JWTIssuer
 	verifier *auth.JWTVerifier
+	registry *authconfig.Registry
 }
 
-// buildJWTDeps loads the key set and constructs issuer + verifier.
+// buildJWTDeps loads the key set and constructs a Registry + issuer + verifier.
 // GOCELL_JWT_ISSUER and GOCELL_JWT_AUDIENCE are required in all modes;
 // missing values cause fail-fast before any assembly init.
 //
 // ref: kube-apiserver --service-account-issuer — required at startup.
+// ref: Hydra internal/driver/config.DefaultProvider — single Registry pattern
+// plan: docs/plans/202604191515-auth-federated-whistle.md §F1
 func buildJWTDeps(adapterMode string) (jwtDeps, error) {
-	iss, err := loadJWTIssuer(adapterMode)
-	if err != nil {
-		return jwtDeps{}, err
-	}
-	aud, err := loadJWTAudience(adapterMode)
-	if err != nil {
-		return jwtDeps{}, err
-	}
-
 	keySet, err := loadKeySet(adapterMode)
 	if err != nil {
 		return jwtDeps{}, fmt.Errorf("load JWT key set: %w", err)
 	}
-	issuer, err := auth.NewJWTIssuer(keySet, iss, auth.DefaultAccessTokenTTL,
-		auth.WithDefaultAudience(aud))
+
+	// Registry reads GOCELL_JWT_ISSUER and GOCELL_JWT_AUDIENCE, then validates
+	// them in real mode. Config errors use ErrAuthVerifierConfig so operators
+	// can distinguish startup misconfigurations from runtime key errors.
+	reg, err := authconfig.FromEnv(
+		authconfig.WithKeys(keySet),
+		authconfig.WithRealMode(true),
+	)
+	if err != nil {
+		return jwtDeps{}, fmt.Errorf("build JWT registry: %w", err)
+	}
+
+	issuer, err := authconfig.NewJWTIssuerFromRegistry(reg, auth.DefaultAccessTokenTTL)
 	if err != nil {
 		return jwtDeps{}, fmt.Errorf("create JWT issuer: %w", err)
 	}
-	// WithExpectedAudiences enforces RFC 8725 §3.3 audience validation in
-	// VerifyIntent: tokens whose aud claim does not contain aud are rejected
-	// with ERR_AUTH_UNAUTHORIZED before reaching business handlers.
-	// WithExpectedIssuer enforces iss claim equality per RFC 7519 §4.1.1.
-	verifier, err := auth.NewJWTVerifier(keySet,
-		auth.WithExpectedAudiences(aud),
-		auth.WithExpectedIssuer(iss))
+
+	verifier, err := authconfig.NewJWTVerifierFromRegistry(reg)
 	if err != nil {
 		return jwtDeps{}, fmt.Errorf("create JWT verifier: %w", err)
 	}
 
 	slog.Info("core-bundle: JWT deps built",
-		slog.String("issuer", iss),
-		slog.String("audience", aud),
+		slog.String("issuer", reg.Issuer()),
+		slog.Any("audiences", reg.Audiences()),
 		slog.String("adapter_mode", adapterMode))
 
-	return jwtDeps{issuer: issuer, verifier: verifier}, nil
+	return jwtDeps{issuer: issuer, verifier: verifier, registry: reg}, nil
 }
 
 // adminBootstrapWorkerOpts wires WithInitialAdminBootstrap + WithBootstrapWorkerSink

--- a/cmd/core-bundle/outbox_e2e_integration_test.go
+++ b/cmd/core-bundle/outbox_e2e_integration_test.go
@@ -157,7 +157,8 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 	privKey, pubKey := auth.MustGenerateTestKeyPair()
 	keySet, err := auth.NewKeySet(privKey, pubKey)
 	require.NoError(t, err)
-	jwtIssuer, err := auth.NewJWTIssuer(keySet, "test", 15*time.Minute, auth.WithDefaultAudience("gocell"))
+	jwtIssuer, err := auth.NewJWTIssuer(keySet, "test", 15*time.Minute,
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	require.NoError(t, err)
 	jwtVerifier, err := auth.NewJWTVerifier(keySet, auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -8,8 +8,8 @@ Missing required variables cause fail-fast before any assembly initialization.
 
 | Variable | Purpose | Default | Required | Notes |
 |---|---|---|---|---|
-| `GOCELL_JWT_ISSUER` | JWT `iss` claim written by JWTIssuer and verified by JWTVerifier on every authenticated request | — | **All modes** | Introduced in PR #AUTH-TRUST-BOUNDARY-160 (C5). There is no default value; missing this variable causes fail-fast at startup. |
-| `GOCELL_JWT_AUDIENCE` | JWT `aud` claim written by JWTIssuer and verified by JWTVerifier on every authenticated request | — | **All modes** | Introduced in PR #AUTH-TRUST-BOUNDARY-160 (C5). Must match the value expected by all session-login/refresh token consumers. There is no default value; missing this variable causes fail-fast at startup. |
+| `GOCELL_JWT_ISSUER` | JWT `iss` claim written by JWTIssuer and verified by JWTVerifier on every authenticated request | — | **All modes** | Required regardless of `GOCELL_CELL_ADAPTER_MODE` or `GOCELL_ADAPTER_MODE`; there is no dev fallback. Missing this variable causes fail-fast at startup. |
+| `GOCELL_JWT_AUDIENCE` | JWT `aud` claim written by JWTIssuer and verified by JWTVerifier on every authenticated request | — | **All modes** | Required regardless of `GOCELL_CELL_ADAPTER_MODE` or `GOCELL_ADAPTER_MODE`; there is no dev fallback. Must match the value expected by all session-login/refresh token consumers. Missing this variable causes fail-fast at startup. Note: `GOCELL_JWT_AUDIENCES` (comma-separated multi-value) is not yet implemented; when introduced, migration path and priority over `GOCELL_JWT_AUDIENCE` will be defined. |
 
 ## RSA Key Set (for JWT signing and verification)
 

--- a/examples/sso-bff/main.go
+++ b/examples/sso-bff/main.go
@@ -59,7 +59,7 @@ func main() {
 		os.Exit(1)
 	}
 	jwtIssuer, err := auth.NewJWTIssuer(keySet, "sso-bff-dev", 15*time.Minute,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	if err != nil {
 		logger.Error("failed to create JWT issuer", slog.Any("error", err))
 		os.Exit(1)

--- a/examples/sso-bff/walkthrough_test.go
+++ b/examples/sso-bff/walkthrough_test.go
@@ -164,7 +164,7 @@ func buildWalkthroughServer(t *testing.T, stateDir string, capHandler *capturing
 	require.NoError(t, err)
 
 	jwtIssuer, err := auth.NewJWTIssuer(keySet, "sso-bff-test", 15*time.Minute,
-		auth.WithDefaultAudience("gocell"))
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
 	require.NoError(t, err)
 
 	jwtVerifier, err := auth.NewJWTVerifier(keySet,

--- a/runtime/auth/config/doc.go
+++ b/runtime/auth/config/doc.go
@@ -1,0 +1,13 @@
+// Package config is the production wiring entrypoint for runtime/auth
+// components. Callers MUST use NewJWTIssuerFromRegistry /
+// NewJWTVerifierFromRegistry to obtain issuer/verifier instances; direct
+// calls to auth.NewJWTIssuer / auth.NewJWTVerifier are reserved for
+// tests and future internal wiring.
+//
+// The Registry struct is the single source of truth for (Issuer,
+// Audiences, KeySet, Clock) — established in F1 per
+// docs/plans/202604191515-auth-federated-whistle.md.
+//
+// ref: Hydra internal/driver/config.DefaultProvider — single Registry pattern
+// ref: Kratos middleware/auth/jwt WithParserOptions — one-time injection
+package config

--- a/runtime/auth/config/registry.go
+++ b/runtime/auth/config/registry.go
@@ -1,0 +1,249 @@
+// Package config provides the JWT configuration Registry — a single source of
+// truth for JWT issuer, audiences, key material, and clock.
+//
+// ref: Hydra internal/driver/config.DefaultProvider — single Registry pattern
+// ref: Kratos middleware/auth/jwt WithParserOptions — one-time injection
+// plan: docs/plans/202604191515-auth-federated-whistle.md §F1
+package config
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// Registry is the single source of truth for JWT configuration.
+// All JWT consumers (JWTIssuer, JWTVerifier, middleware) obtain their
+// configuration from Registry instead of carrying per-instance copies.
+//
+// Registry is safe for concurrent read access after construction.
+type Registry struct {
+	issuer    string
+	audiences []string
+	keyProv   auth.SigningKeyProvider
+	keyStore  auth.VerificationKeyStore
+	clock     func() time.Time
+	realMode  bool
+}
+
+// Config carries the inputs for constructing a Registry.
+type Config struct {
+	// Issuer is the JWT issuer claim (iss). Required when RealMode is true.
+	// Corresponds to GOCELL_JWT_ISSUER.
+	Issuer string
+
+	// Audiences is the list of accepted JWT audience values. Required when
+	// RealMode is true. Corresponds to GOCELL_JWT_AUDIENCE (single value
+	// stored as []string{"value"}). Future: GOCELL_JWT_AUDIENCES comma-separated.
+	Audiences []string
+
+	// KeyProv supplies the active RSA signing key. May be nil in non-real mode.
+	KeyProv auth.SigningKeyProvider
+
+	// KeyStore provides public keys for JWT verification. May be nil in non-real mode.
+	KeyStore auth.VerificationKeyStore
+
+	// Clock overrides the time source. Nil defaults to time.Now.
+	Clock func() time.Time
+
+	// RealMode enforces non-empty Issuer and Audiences at construction time.
+	// Set to true in production; leave false for dev/test.
+	RealMode bool
+}
+
+// New constructs a Registry from the given Config. Returns an error when
+// RealMode is true and Issuer or Audiences are missing.
+//
+// Configuration errors use errcode.ErrAuthVerifierConfig so operators can
+// distinguish startup misconfigurations from runtime key errors.
+func New(cfg Config) (*Registry, error) {
+	if cfg.RealMode {
+		if cfg.Issuer == "" {
+			return nil, errcode.New(errcode.ErrAuthVerifierConfig,
+				"JWT registry: Issuer is required in real mode (set GOCELL_JWT_ISSUER)")
+		}
+		if len(cfg.Audiences) == 0 {
+			return nil, errcode.New(errcode.ErrAuthVerifierConfig,
+				"JWT registry: Audiences must not be empty in real mode (set GOCELL_JWT_AUDIENCE)")
+		}
+	}
+
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+
+	auds := make([]string, len(cfg.Audiences))
+	copy(auds, cfg.Audiences)
+
+	return &Registry{
+		issuer:    cfg.Issuer,
+		audiences: auds,
+		keyProv:   cfg.KeyProv,
+		keyStore:  cfg.KeyStore,
+		clock:     clock,
+		realMode:  cfg.RealMode,
+	}, nil
+}
+
+// Issuer returns the JWT issuer string (iss claim).
+func (r *Registry) Issuer() string { return r.issuer }
+
+// Audiences returns a defensive copy of the configured audience allowlist.
+// Mutating the returned slice does not affect the Registry.
+func (r *Registry) Audiences() []string {
+	if len(r.audiences) == 0 {
+		return nil
+	}
+	out := make([]string, len(r.audiences))
+	copy(out, r.audiences)
+	return out
+}
+
+// SigningKeyProvider returns the configured key provider for JWT signing.
+// May be nil when the Registry was constructed in non-real mode without keys.
+func (r *Registry) SigningKeyProvider() auth.SigningKeyProvider { return r.keyProv }
+
+// VerificationKeyStore returns the configured key store for JWT verification.
+// May be nil when the Registry was constructed in non-real mode without keys.
+func (r *Registry) VerificationKeyStore() auth.VerificationKeyStore { return r.keyStore }
+
+// Clock returns the time function used for token timestamps.
+// Always non-nil — defaults to time.Now when not configured.
+func (r *Registry) Clock() func() time.Time { return r.clock }
+
+// ---- FromEnv ----
+
+// EnvOption configures FromEnv behavior.
+type EnvOption func(*envConfig)
+
+type envConfig struct {
+	realMode bool
+	keyProv  auth.SigningKeyProvider
+	keyStore auth.VerificationKeyStore
+	clock    func() time.Time
+}
+
+// WithRealMode enables real-mode validation (fail-fast on missing env vars).
+func WithRealMode(v bool) EnvOption {
+	return func(c *envConfig) { c.realMode = v }
+}
+
+// WithKeys sets the key provider and key store for the registry built by FromEnv.
+func WithKeys(prov auth.SigningKeyProvider) EnvOption {
+	return func(c *envConfig) {
+		c.keyProv = prov
+		if ks, ok := prov.(auth.VerificationKeyStore); ok {
+			c.keyStore = ks
+		}
+	}
+}
+
+// WithKeySeparate sets key provider and key store independently.
+func WithKeySeparate(prov auth.SigningKeyProvider, store auth.VerificationKeyStore) EnvOption {
+	return func(c *envConfig) {
+		c.keyProv = prov
+		c.keyStore = store
+	}
+}
+
+// WithEnvClock overrides the time source for a FromEnv-built Registry.
+func WithEnvClock(fn func() time.Time) EnvOption {
+	return func(c *envConfig) { c.clock = fn }
+}
+
+// envVarIssuer is the environment variable for the JWT issuer.
+// Defined as constant to satisfy ≥3-use string rule.
+const envVarIssuer = "GOCELL_JWT_ISSUER"
+
+// envVarAudience is the environment variable for the JWT audience.
+// Future: GOCELL_JWT_AUDIENCES (comma-separated multi-value) — see
+// docs/ops/env-vars.md for migration notes.
+const envVarAudience = "GOCELL_JWT_AUDIENCE"
+
+// FromEnv constructs a Registry by reading GOCELL_JWT_ISSUER and
+// GOCELL_JWT_AUDIENCE from the environment.
+//
+// The audience env var stores a single value stored as []string{value}.
+// When the value is empty and RealMode is false, Audiences will be nil.
+//
+// Returns an error in real mode when required env vars are missing or empty.
+func FromEnv(opts ...EnvOption) (*Registry, error) {
+	ec := &envConfig{}
+	for _, o := range opts {
+		o(ec)
+	}
+
+	issuer := strings.TrimSpace(os.Getenv(envVarIssuer))
+	audience := strings.TrimSpace(os.Getenv(envVarAudience))
+
+	var audiences []string
+	if audience != "" {
+		audiences = []string{audience}
+	}
+
+	return New(Config{
+		Issuer:    issuer,
+		Audiences: audiences,
+		KeyProv:   ec.keyProv,
+		KeyStore:  ec.keyStore,
+		Clock:     ec.clock,
+		RealMode:  ec.realMode,
+	})
+}
+
+// ---- Factory functions ----
+
+// NewJWTIssuerFromRegistry constructs a *auth.JWTIssuer whose issuer string,
+// default audiences, signing key, and clock are all sourced from reg.
+//
+// This is the single authorised entry point for creating a JWTIssuer in
+// production code; the raw NewJWTIssuer constructor is retained only for
+// test helpers that build issuers independently of Registry.
+//
+// ref: Hydra internal/driver/config.DefaultProvider — configuration through registry
+func NewJWTIssuerFromRegistry(reg *Registry, ttl time.Duration, opts ...auth.JWTIssuerOption) (*auth.JWTIssuer, error) {
+	if reg == nil {
+		return nil, errcode.New(errcode.ErrAuthVerifierConfig, "JWT registry must not be nil")
+	}
+	if reg.keyProv == nil {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "JWT registry: SigningKeyProvider is nil")
+	}
+
+	// Merge registry-derived settings first, then apply caller opts so opts
+	// can override (e.g. WithRefreshTTL in tests).
+	baseOpts := []auth.JWTIssuerOption{
+		auth.WithIssuerAudiencesFromSlice(reg.Audiences()),
+		auth.WithIssuerClock(reg.Clock()),
+	}
+	return auth.NewJWTIssuer(reg.keyProv, reg.issuer, ttl, append(baseOpts, opts...)...)
+}
+
+// NewJWTVerifierFromRegistry constructs a *auth.JWTVerifier whose expected
+// audiences, expected issuer, verification key store, and clock are all
+// sourced from reg.
+//
+// ref: Hydra internal/driver/config.DefaultProvider — configuration through registry
+func NewJWTVerifierFromRegistry(reg *Registry, opts ...auth.JWTVerifierOption) (*auth.JWTVerifier, error) {
+	if reg == nil {
+		return nil, errcode.New(errcode.ErrAuthVerifierConfig, "JWT registry must not be nil")
+	}
+	if reg.keyStore == nil {
+		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "JWT registry: VerificationKeyStore is nil")
+	}
+	auds := reg.Audiences()
+	if len(auds) == 0 {
+		return nil, errcode.New(errcode.ErrAuthVerifierConfig,
+			"JWT registry: Audiences must not be empty for verifier construction")
+	}
+
+	baseOpts := []auth.JWTVerifierOption{
+		auth.WithExpectedAudiences(auds[0], auds[1:]...),
+		auth.WithExpectedIssuer(reg.issuer),
+		auth.WithVerifierClock(reg.Clock()),
+	}
+	return auth.NewJWTVerifier(reg.keyStore, append(baseOpts, opts...)...)
+}

--- a/runtime/auth/config/registry.go
+++ b/runtime/auth/config/registry.go
@@ -2,12 +2,30 @@ package config
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
+
+// isNilInterfaceValue reports whether an interface value is nil or a typed-nil
+// (e.g., var ks *KeySet = nil passed through auth.SigningKeyProvider). Plain
+// `v == nil` returns false for typed-nil because the interface carries a
+// non-nil type descriptor. Mirrors auth.isNilInterfaceValue — kept local to
+// avoid widening the auth package's public API.
+func isNilInterfaceValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	}
+	return false
+}
 
 // Registry is the single source of truth for JWT configuration.
 // All JWT consumers (JWTIssuer, JWTVerifier, middleware) obtain their
@@ -135,20 +153,31 @@ func WithRealMode(v bool) EnvOption {
 }
 
 // WithKeys sets the key provider and key store for the registry built by FromEnv.
+// Typed-nil inputs are rejected (not stored); the subsequent factory call will
+// fail with a clear "SigningKeyProvider is nil" error rather than panicking at
+// first method dispatch.
 func WithKeys(prov auth.SigningKeyProvider) EnvOption {
 	return func(c *envConfig) {
+		if isNilInterfaceValue(prov) {
+			return
+		}
 		c.keyProv = prov
-		if ks, ok := prov.(auth.VerificationKeyStore); ok {
+		if ks, ok := prov.(auth.VerificationKeyStore); ok && !isNilInterfaceValue(ks) {
 			c.keyStore = ks
 		}
 	}
 }
 
 // WithKeySeparate sets key provider and key store independently.
+// Typed-nil inputs are filtered out per WithKeys' rationale.
 func WithKeySeparate(prov auth.SigningKeyProvider, store auth.VerificationKeyStore) EnvOption {
 	return func(c *envConfig) {
-		c.keyProv = prov
-		c.keyStore = store
+		if !isNilInterfaceValue(prov) {
+			c.keyProv = prov
+		}
+		if !isNilInterfaceValue(store) {
+			c.keyStore = store
+		}
 	}
 }
 
@@ -211,7 +240,7 @@ func NewJWTIssuerFromRegistry(reg *Registry, ttl time.Duration, opts ...auth.JWT
 	if reg == nil {
 		return nil, errcode.New(errcode.ErrAuthVerifierConfig, "JWT registry must not be nil")
 	}
-	if reg.keyProv == nil {
+	if isNilInterfaceValue(reg.keyProv) {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "JWT registry: SigningKeyProvider is nil")
 	}
 
@@ -233,7 +262,7 @@ func NewJWTVerifierFromRegistry(reg *Registry, opts ...auth.JWTVerifierOption) (
 	if reg == nil {
 		return nil, errcode.New(errcode.ErrAuthVerifierConfig, "JWT registry must not be nil")
 	}
-	if reg.keyStore == nil {
+	if isNilInterfaceValue(reg.keyStore) {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "JWT registry: VerificationKeyStore is nil")
 	}
 	auds := reg.Audiences()

--- a/runtime/auth/config/registry.go
+++ b/runtime/auth/config/registry.go
@@ -1,9 +1,3 @@
-// Package config provides the JWT configuration Registry — a single source of
-// truth for JWT issuer, audiences, key material, and clock.
-//
-// ref: Hydra internal/driver/config.DefaultProvider — single Registry pattern
-// ref: Kratos middleware/auth/jwt WithParserOptions — one-time injection
-// plan: docs/plans/202604191515-auth-federated-whistle.md §F1
 package config
 
 import (
@@ -60,12 +54,23 @@ type Config struct {
 // Configuration errors use errcode.ErrAuthVerifierConfig so operators can
 // distinguish startup misconfigurations from runtime key errors.
 func New(cfg Config) (*Registry, error) {
+	issuer := strings.TrimSpace(cfg.Issuer)
+
+	// Trim and filter whitespace-only audience elements before validation so
+	// that "   " is treated identically to "" (avoids RealMode bypass).
+	var auds []string
+	for _, a := range cfg.Audiences {
+		if t := strings.TrimSpace(a); t != "" {
+			auds = append(auds, t)
+		}
+	}
+
 	if cfg.RealMode {
-		if cfg.Issuer == "" {
+		if issuer == "" {
 			return nil, errcode.New(errcode.ErrAuthVerifierConfig,
 				"JWT registry: Issuer is required in real mode (set GOCELL_JWT_ISSUER)")
 		}
-		if len(cfg.Audiences) == 0 {
+		if len(auds) == 0 {
 			return nil, errcode.New(errcode.ErrAuthVerifierConfig,
 				"JWT registry: Audiences must not be empty in real mode (set GOCELL_JWT_AUDIENCE)")
 		}
@@ -76,11 +81,8 @@ func New(cfg Config) (*Registry, error) {
 		clock = time.Now
 	}
 
-	auds := make([]string, len(cfg.Audiences))
-	copy(auds, cfg.Audiences)
-
 	return &Registry{
-		issuer:    cfg.Issuer,
+		issuer:    issuer,
 		audiences: auds,
 		keyProv:   cfg.KeyProv,
 		keyStore:  cfg.KeyStore,
@@ -160,8 +162,8 @@ func WithEnvClock(fn func() time.Time) EnvOption {
 const envVarIssuer = "GOCELL_JWT_ISSUER"
 
 // envVarAudience is the environment variable for the JWT audience.
-// Future: GOCELL_JWT_AUDIENCES (comma-separated multi-value) — see
-// docs/ops/env-vars.md for migration notes.
+// Future: GOCELL_JWT_AUDIENCES (comma-separated multi-value) — not yet
+// implemented; priority and migration path will be defined when introduced.
 const envVarAudience = "GOCELL_JWT_AUDIENCE"
 
 // FromEnv constructs a Registry by reading GOCELL_JWT_ISSUER and
@@ -241,6 +243,7 @@ func NewJWTVerifierFromRegistry(reg *Registry, opts ...auth.JWTVerifierOption) (
 	}
 
 	baseOpts := []auth.JWTVerifierOption{
+		// auds is guaranteed non-empty by the check above; auds[1:] is the zero-length slice when len==1.
 		auth.WithExpectedAudiences(auds[0], auds[1:]...),
 		auth.WithExpectedIssuer(reg.issuer),
 		auth.WithVerifierClock(reg.Clock()),

--- a/runtime/auth/config/registry_test.go
+++ b/runtime/auth/config/registry_test.go
@@ -322,6 +322,92 @@ func TestNewJWTVerifierFromRegistry_EmptyAudiences(t *testing.T) {
 	require.Error(t, err, "empty Audiences must return error for verifier construction")
 }
 
+// ----- F1-001 / F1-002 whitespace trim tests -----
+
+// TestNew_RealMode_WhitespaceOnlyIssuerRejected verifies that a whitespace-only
+// Issuer is rejected in RealMode (F1-001 security fix).
+func TestNew_RealMode_WhitespaceOnlyIssuerRejected(t *testing.T) {
+	_, err := config.New(config.Config{
+		Issuer:    "   ",
+		Audiences: []string{"gocell"},
+		RealMode:  true,
+	})
+	require.Error(t, err, "RealMode + whitespace-only Issuer must return error")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error, got %T: %v", err, err)
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code)
+}
+
+// TestNew_RealMode_WhitespaceAudienceElement verifies that a whitespace-only
+// audience element is treated as empty and rejected in RealMode (F1-002 security fix).
+func TestNew_RealMode_WhitespaceAudienceElement(t *testing.T) {
+	_, err := config.New(config.Config{
+		Issuer:    "https://gocell.example",
+		Audiences: []string{"   "},
+		RealMode:  true,
+	})
+	require.Error(t, err, "RealMode + whitespace-only Audience element must return error")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error, got %T: %v", err, err)
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code)
+}
+
+// TestNew_TrimsIssuerAndAudiences verifies that leading/trailing whitespace is
+// trimmed and stored trimmed values are returned by accessors.
+func TestNew_TrimsIssuerAndAudiences(t *testing.T) {
+	reg, err := config.New(config.Config{
+		Issuer:    " acme ",
+		Audiences: []string{" a ", " b "},
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "acme", reg.Issuer(), "issuer must be trimmed")
+	assert.Equal(t, []string{"a", "b"}, reg.Audiences(), "audience elements must be trimmed")
+}
+
+// ----- F1-005 WithKeys signing-only provider tests -----
+
+// stubSigningOnlyProvider satisfies auth.SigningKeyProvider but does NOT
+// implement auth.VerificationKeyStore — used to test the WithKeys type
+// assertion failure path.
+type stubSigningOnlyProvider struct{}
+
+func (s *stubSigningOnlyProvider) SigningKey() *rsa.PrivateKey { return nil }
+func (s *stubSigningOnlyProvider) SigningKeyID() string        { return "signing-only-kid" }
+
+// TestWithKeys_SigningOnly_LeavesVerificationStoreNil verifies that when a
+// provider implements only SigningKeyProvider (not VerificationKeyStore), the
+// type assertion in WithKeys fails gracefully and VerificationKeyStore remains nil.
+func TestWithKeys_SigningOnly_LeavesVerificationStoreNil(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "gocell")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	prov := &stubSigningOnlyProvider{}
+	reg, err := config.FromEnv(config.WithKeys(prov))
+	require.NoError(t, err)
+
+	assert.NotNil(t, reg.SigningKeyProvider(), "SigningKeyProvider must be set")
+	assert.Nil(t, reg.VerificationKeyStore(),
+		"VerificationKeyStore must be nil when provider does not implement it")
+}
+
+// TestWithKeys_SigningOnly_VerifierReturnsError verifies that
+// NewJWTVerifierFromRegistry returns an error when VerificationKeyStore is nil.
+func TestWithKeys_SigningOnly_VerifierReturnsError(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "gocell")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	prov := &stubSigningOnlyProvider{}
+	reg, err := config.FromEnv(config.WithKeys(prov))
+	require.NoError(t, err)
+
+	_, err = config.NewJWTVerifierFromRegistry(reg)
+	require.Error(t, err, "NewJWTVerifierFromRegistry must fail when VerificationKeyStore is nil")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error, got %T: %v", err, err)
+	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code)
+}
+
 // TestNewJWTIssuerVerifierFromRegistry_EndToEnd verifies the full round-trip:
 // issue a token via Registry-constructed issuer, verify with Registry-constructed verifier.
 func TestNewJWTIssuerVerifierFromRegistry_EndToEnd(t *testing.T) {

--- a/runtime/auth/config/registry_test.go
+++ b/runtime/auth/config/registry_test.go
@@ -408,6 +408,152 @@ func TestWithKeys_SigningOnly_VerifierReturnsError(t *testing.T) {
 	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code)
 }
 
+// ----- typed-nil defensive tests -----
+
+// TestNewJWTIssuerFromRegistry_TypedNilKeyProv verifies that a typed-nil
+// SigningKeyProvider (e.g., var ks *auth.KeySet = nil stored into Config.KeyProv)
+// is rejected at factory invocation, not at first token issuance where it
+// would panic on nil method receiver.
+func TestNewJWTIssuerFromRegistry_TypedNilKeyProv(t *testing.T) {
+	var ks *auth.KeySet // typed-nil
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyProv:   ks, // interface holds (type=*KeySet, value=nil)
+		RealMode:  false,
+	})
+	require.NoError(t, err, "Registry construction must accept typed-nil (validation deferred to factory)")
+
+	_, err = config.NewJWTIssuerFromRegistry(reg, 15*time.Minute)
+	require.Error(t, err, "typed-nil KeyProv must be rejected by the factory")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error, got %T", err)
+	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code,
+		"typed-nil must surface ErrAuthKeyInvalid (same as plain-nil) — not slip through and panic later")
+}
+
+// TestNewJWTVerifierFromRegistry_TypedNilKeyStore verifies the same guarantee
+// for the verifier path.
+func TestNewJWTVerifierFromRegistry_TypedNilKeyStore(t *testing.T) {
+	var ks *auth.KeySet
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyStore:  ks,
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+
+	_, err = config.NewJWTVerifierFromRegistry(reg)
+	require.Error(t, err, "typed-nil KeyStore must be rejected by the factory")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error, got %T", err)
+	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code)
+}
+
+// TestWithKeys_TypedNilProvider verifies that WithKeys silently drops typed-nil
+// inputs so subsequent factory calls surface a clean ErrAuthKeyInvalid rather
+// than a misleading "provider set, store not set" state.
+func TestWithKeys_TypedNilProvider(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "gocell")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	var prov auth.SigningKeyProvider = (*auth.KeySet)(nil)
+	reg, err := config.FromEnv(config.WithKeys(prov))
+	require.NoError(t, err)
+	assert.Nil(t, reg.SigningKeyProvider(),
+		"typed-nil provider must NOT be stored (would panic downstream)")
+	assert.Nil(t, reg.VerificationKeyStore(),
+		"typed-nil provider must not populate the verification store either")
+}
+
+// ----- Registry error-code type-assertion upgrades (F1-review-002) -----
+//
+// Confirms that constructor errors from the Registry path are *errcode.Error
+// values with the specific code consumers can branch on; plain require.Error
+// would pass even on bare fmt.Errorf regressions.
+
+// TestFromEnv_MissingIssuer_RealMode_ErrorCode asserts the specific code
+// beyond merely "error".
+func TestFromEnv_MissingIssuer_RealMode_ErrorCode(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	_, err := config.FromEnv(config.WithRealMode(true))
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be *errcode.Error, got %T", err)
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code)
+}
+
+func TestFromEnv_MissingAudience_RealMode_ErrorCode(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "https://auth.example")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "")
+
+	_, err := config.FromEnv(config.WithRealMode(true))
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be *errcode.Error, got %T", err)
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code)
+}
+
+// TestNewJWTIssuerFromRegistry_NilRegistry_ErrorCode replaces the bare
+// require.Error in TestNewJWTIssuerFromRegistry_NilRegistry with a specific
+// code check (the original test is kept for smoke).
+func TestNewJWTIssuerFromRegistry_NilRegistry_ErrorCode(t *testing.T) {
+	_, err := config.NewJWTIssuerFromRegistry(nil, 15*time.Minute)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be *errcode.Error, got %T", err)
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code,
+		"nil Registry is a config error, not a key-material error")
+}
+
+func TestNewJWTVerifierFromRegistry_NilRegistry_ErrorCode(t *testing.T) {
+	_, err := config.NewJWTVerifierFromRegistry(nil)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code)
+}
+
+// TestNewJWTVerifierFromRegistry_EmptyAudiences_ErrorCode tightens
+// TestNewJWTVerifierFromRegistry_EmptyAudiences.
+func TestNewJWTVerifierFromRegistry_EmptyAudiences_ErrorCode(t *testing.T) {
+	ks, _, _ := auth.MustNewTestKeySet()
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: nil,
+		KeyStore:  ks,
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+
+	_, err = config.NewJWTVerifierFromRegistry(reg)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code)
+}
+
+// TestNewJWTIssuerFromRegistry_NilKeyProv_ErrorCode tightens the nil-KeyProv case.
+func TestNewJWTIssuerFromRegistry_NilKeyProv_ErrorCode(t *testing.T) {
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyProv:   nil,
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+
+	_, err = config.NewJWTIssuerFromRegistry(reg, 15*time.Minute)
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthKeyInvalid, ecErr.Code,
+		"missing key material must surface as ErrAuthKeyInvalid, distinct from config-shape errors")
+}
+
 // TestNewJWTIssuerVerifierFromRegistry_EndToEnd verifies the full round-trip:
 // issue a token via Registry-constructed issuer, verify with Registry-constructed verifier.
 func TestNewJWTIssuerVerifierFromRegistry_EndToEnd(t *testing.T) {

--- a/runtime/auth/config/registry_test.go
+++ b/runtime/auth/config/registry_test.go
@@ -1,0 +1,352 @@
+// Package config_test exercises the JWT config.Registry single-source-of-truth.
+//
+// ref: Hydra internal/driver/config.DefaultProvider — single Registry pattern
+// ref: Kratos middleware/auth/jwt WithParserOptions — one-time injection
+// plan: docs/plans/202604191515-auth-federated-whistle.md §F1
+package config_test
+
+import (
+	"context"
+	"crypto/rsa"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/auth/config"
+)
+
+// stubKeySet is a minimal in-memory key provider/store for tests.
+// It satisfies both auth.SigningKeyProvider and auth.VerificationKeyStore.
+type stubKeySet struct{}
+
+func (s *stubKeySet) SigningKey() *rsa.PrivateKey                     { return nil }
+func (s *stubKeySet) SigningKeyID() string                            { return "stub-kid" }
+func (s *stubKeySet) PublicKeyByKID(_ string) (*rsa.PublicKey, error) { return nil, nil }
+
+// TestNew_RealMode_IssuerRequired verifies that RealMode=true requires a non-empty Issuer.
+func TestNew_RealMode_IssuerRequired(t *testing.T) {
+	_, err := config.New(config.Config{
+		Issuer:    "",
+		Audiences: []string{"gocell"},
+		RealMode:  true,
+	})
+	require.Error(t, err, "RealMode + empty Issuer must return error")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error, got %T: %v", err, err)
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code,
+		"config error must use ErrAuthVerifierConfig")
+}
+
+// TestNew_RealMode_AudiencesRequired verifies that RealMode=true requires non-nil Audiences.
+func TestNew_RealMode_AudiencesRequired(t *testing.T) {
+	_, err := config.New(config.Config{
+		Issuer:    "https://gocell.example",
+		Audiences: nil,
+		RealMode:  true,
+	})
+	require.Error(t, err, "RealMode + nil Audiences must return error")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr), "error must be errcode.Error")
+	assert.Equal(t, errcode.ErrAuthVerifierConfig, ecErr.Code)
+}
+
+// TestNew_RealMode_EmptyAudiencesRequired verifies that RealMode=true rejects empty Audiences slice.
+func TestNew_RealMode_EmptyAudiencesRequired(t *testing.T) {
+	_, err := config.New(config.Config{
+		Issuer:    "https://gocell.example",
+		Audiences: []string{},
+		RealMode:  true,
+	})
+	require.Error(t, err, "RealMode + empty Audiences slice must return error")
+}
+
+// TestNew_NonRealMode_AllowsEmpty verifies that dev/test mode allows empty config (no hard error).
+func TestNew_NonRealMode_AllowsEmpty(t *testing.T) {
+	reg, err := config.New(config.Config{
+		Issuer:    "",
+		Audiences: nil,
+		RealMode:  false,
+	})
+	require.NoError(t, err, "non-real mode must allow empty config")
+	require.NotNil(t, reg)
+	assert.Equal(t, "", reg.Issuer())
+	assert.Empty(t, reg.Audiences())
+}
+
+// TestRegistry_Audiences_ReturnsCopy verifies that mutating the returned slice
+// does not affect subsequent calls (defensive copy).
+func TestRegistry_Audiences_ReturnsCopy(t *testing.T) {
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell", "api-gateway"},
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+
+	first := reg.Audiences()
+	first[0] = "mutated"
+
+	second := reg.Audiences()
+	assert.Equal(t, "gocell", second[0],
+		"mutating returned slice must not affect registry state")
+}
+
+// TestRegistry_Clock_DefaultsToTimeNow verifies that a nil Clock falls back to time.Now.
+func TestRegistry_Clock_DefaultsToTimeNow(t *testing.T) {
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		Clock:     nil,
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+
+	clockFn := reg.Clock()
+	require.NotNil(t, clockFn, "Clock() must not return nil")
+
+	now := time.Now()
+	clocked := clockFn()
+	delta := clocked.Sub(now)
+	if delta < 0 {
+		delta = -delta
+	}
+	assert.Less(t, delta, time.Second,
+		"default clock must return time close to time.Now()")
+}
+
+// TestFromEnv_ReadsIssuerAndAudience verifies that FromEnv reads GOCELL_JWT_ISSUER
+// and GOCELL_JWT_AUDIENCE from the environment.
+func TestFromEnv_ReadsIssuerAndAudience(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "https://auth.example")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "my-service")
+
+	reg, err := config.FromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "https://auth.example", reg.Issuer())
+	assert.Equal(t, []string{"my-service"}, reg.Audiences())
+}
+
+// TestFromEnv_MissingIssuer_RealMode_Error verifies that FromEnv in real mode
+// fails fast when GOCELL_JWT_ISSUER is unset.
+func TestFromEnv_MissingIssuer_RealMode_Error(t *testing.T) {
+	// Ensure env is clear.
+	t.Setenv("GOCELL_JWT_ISSUER", "")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	_, err := config.FromEnv(config.WithRealMode(true))
+	require.Error(t, err, "missing GOCELL_JWT_ISSUER in real mode must return error")
+}
+
+// TestFromEnv_MissingAudience_RealMode_Error verifies fail-fast on missing GOCELL_JWT_AUDIENCE.
+func TestFromEnv_MissingAudience_RealMode_Error(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "https://auth.example")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "")
+
+	_, err := config.FromEnv(config.WithRealMode(true))
+	require.Error(t, err, "missing GOCELL_JWT_AUDIENCE in real mode must return error")
+}
+
+// TestRegistry_KeyProviders_PassThrough verifies that key provider/store supplied
+// via Config are returned unchanged by the accessor methods.
+func TestRegistry_KeyProviders_PassThrough(t *testing.T) {
+	_ = auth.SigningKeyProvider((*stubKeySet)(nil))   // compile-time interface check
+	_ = auth.VerificationKeyStore((*stubKeySet)(nil)) // compile-time interface check
+
+	prov := &stubKeySet{}
+	store := &stubKeySet{}
+
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyProv:   prov,
+		KeyStore:  store,
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+	assert.Same(t, prov, reg.SigningKeyProvider(),
+		"SigningKeyProvider() must return the same object that was passed in")
+	assert.Same(t, store, reg.VerificationKeyStore(),
+		"VerificationKeyStore() must return the same object that was passed in")
+}
+
+// TestFromEnv_IgnoresUnsetVars verifies FromEnv returns empty values for unset env (non-real mode).
+func TestFromEnv_IgnoresUnsetVars(t *testing.T) {
+	os.Unsetenv("GOCELL_JWT_ISSUER")   //nolint:errcheck
+	os.Unsetenv("GOCELL_JWT_AUDIENCE") //nolint:errcheck
+
+	reg, err := config.FromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "", reg.Issuer())
+	assert.Empty(t, reg.Audiences())
+}
+
+// TestFromEnv_WithKeys verifies that WithKeys sets both key provider and store
+// when the same object implements both interfaces.
+func TestFromEnv_WithKeys(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "gocell")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	ks, _, _ := auth.MustNewTestKeySet()
+	reg, err := config.FromEnv(config.WithKeys(ks))
+	require.NoError(t, err)
+	assert.NotNil(t, reg.SigningKeyProvider(), "SigningKeyProvider must be set via WithKeys")
+	assert.NotNil(t, reg.VerificationKeyStore(), "VerificationKeyStore must be set via WithKeys")
+}
+
+// TestFromEnv_WithKeySeparate verifies WithKeySeparate sets providers independently.
+func TestFromEnv_WithKeySeparate(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "gocell")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	prov := &stubKeySet{}
+	store := &stubKeySet{}
+
+	reg, err := config.FromEnv(config.WithKeySeparate(prov, store))
+	require.NoError(t, err)
+	assert.Same(t, prov, reg.SigningKeyProvider())
+	assert.Same(t, store, reg.VerificationKeyStore())
+}
+
+// TestFromEnv_WithEnvClock verifies WithEnvClock overrides the clock.
+func TestFromEnv_WithEnvClock(t *testing.T) {
+	t.Setenv("GOCELL_JWT_ISSUER", "gocell")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+
+	fixed := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	clockFn := func() time.Time { return fixed }
+
+	reg, err := config.FromEnv(config.WithEnvClock(clockFn))
+	require.NoError(t, err)
+	assert.Equal(t, fixed, reg.Clock()(), "custom clock must be used")
+}
+
+// TestNewJWTIssuerFromRegistry_Success verifies that a Registry with valid keys
+// produces a working JWTIssuer.
+func TestNewJWTIssuerFromRegistry_Success(t *testing.T) {
+	ks, _, _ := auth.MustNewTestKeySet()
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyProv:   ks,
+		KeyStore:  ks,
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+
+	issuer, err := config.NewJWTIssuerFromRegistry(reg, 15*time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, issuer)
+
+	// Issue a token to verify it works end-to-end.
+	tok, err := issuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, tok)
+}
+
+// TestNewJWTIssuerFromRegistry_NilRegistry returns an error.
+func TestNewJWTIssuerFromRegistry_NilRegistry(t *testing.T) {
+	_, err := config.NewJWTIssuerFromRegistry(nil, 15*time.Minute)
+	require.Error(t, err)
+}
+
+// TestNewJWTIssuerFromRegistry_NilKeyProv returns an error when KeyProv is nil.
+func TestNewJWTIssuerFromRegistry_NilKeyProv(t *testing.T) {
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyProv:   nil, // nil
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+
+	_, err = config.NewJWTIssuerFromRegistry(reg, 15*time.Minute)
+	require.Error(t, err, "nil KeyProv must return error")
+}
+
+// TestNewJWTVerifierFromRegistry_Success verifies that a Registry with valid keys
+// produces a working JWTVerifier.
+func TestNewJWTVerifierFromRegistry_Success(t *testing.T) {
+	ks, _, _ := auth.MustNewTestKeySet()
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyProv:   ks,
+		KeyStore:  ks,
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+
+	verifier, err := config.NewJWTVerifierFromRegistry(reg)
+	require.NoError(t, err)
+	require.NotNil(t, verifier)
+}
+
+// TestNewJWTVerifierFromRegistry_NilRegistry returns an error.
+func TestNewJWTVerifierFromRegistry_NilRegistry(t *testing.T) {
+	_, err := config.NewJWTVerifierFromRegistry(nil)
+	require.Error(t, err)
+}
+
+// TestNewJWTVerifierFromRegistry_NilKeyStore returns an error when KeyStore is nil.
+func TestNewJWTVerifierFromRegistry_NilKeyStore(t *testing.T) {
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell"},
+		KeyStore:  nil, // nil
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+
+	_, err = config.NewJWTVerifierFromRegistry(reg)
+	require.Error(t, err, "nil KeyStore must return error")
+}
+
+// TestNewJWTVerifierFromRegistry_EmptyAudiences returns an error when Audiences is empty.
+func TestNewJWTVerifierFromRegistry_EmptyAudiences(t *testing.T) {
+	ks, _, _ := auth.MustNewTestKeySet()
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell",
+		Audiences: nil, // empty
+		KeyStore:  ks,
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+
+	_, err = config.NewJWTVerifierFromRegistry(reg)
+	require.Error(t, err, "empty Audiences must return error for verifier construction")
+}
+
+// TestNewJWTIssuerVerifierFromRegistry_EndToEnd verifies the full round-trip:
+// issue a token via Registry-constructed issuer, verify with Registry-constructed verifier.
+func TestNewJWTIssuerVerifierFromRegistry_EndToEnd(t *testing.T) {
+	ks, _, _ := auth.MustNewTestKeySet()
+	reg, err := config.New(config.Config{
+		Issuer:    "gocell-test",
+		Audiences: []string{"gocell"},
+		KeyProv:   ks,
+		KeyStore:  ks,
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+
+	issuer, err := config.NewJWTIssuerFromRegistry(reg, 15*time.Minute)
+	require.NoError(t, err)
+
+	verifier, err := config.NewJWTVerifierFromRegistry(reg)
+	require.NoError(t, err)
+
+	tok, err := issuer.Issue(auth.TokenIntentAccess, "user-1", auth.IssueOptions{})
+	require.NoError(t, err)
+
+	claims, err := verifier.VerifyIntent(context.Background(), tok, auth.TokenIntentAccess)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", claims.Subject)
+	assert.Equal(t, "gocell-test", claims.Issuer)
+	assert.Contains(t, claims.Audience, "gocell")
+}

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -327,28 +327,22 @@ func WithRefreshTTL(d time.Duration) JWTIssuerOption {
 	}
 }
 
-// WithDefaultAudience sets the audience written into tokens when IssueOptions.Audience
-// is nil. The first argument is required; additional audiences may be provided as
-// variadic arguments. When IssueOptions.Audience is non-nil it takes precedence over
-// the default (override semantics).
+// WithIssuerAudiencesFromSlice sets the audience written into tokens when
+// IssueOptions.Audience is nil (fallback / default audience). The slice is
+// copied defensively. Empty or nil slices are silently ignored.
 //
-// Upper layers (sessionlogin/sessionrefresh) may read the configured default via
-// DefaultAudience() to share a single source of truth for the expected audience.
-func WithDefaultAudience(first string, rest ...string) JWTIssuerOption {
-	auds := append([]string{first}, rest...)
-	return func(i *JWTIssuer) { i.defaultAudience = auds }
-}
-
-// DefaultAudience returns a copy of the default audience slice configured via
-// WithDefaultAudience. Returns nil when no default audience is configured.
-// The returned slice is an independent copy — mutating it does not affect the issuer.
-func (i *JWTIssuer) DefaultAudience() []string {
-	if i == nil || len(i.defaultAudience) == 0 {
-		return nil
+// This is the canonical way to configure default audiences when constructing
+// a JWTIssuer from a config.Registry. The config package uses this option
+// internally; production code should prefer config.NewJWTIssuerFromRegistry
+// instead of calling this directly.
+func WithIssuerAudiencesFromSlice(auds []string) JWTIssuerOption {
+	cp := make([]string, len(auds))
+	copy(cp, auds)
+	return func(i *JWTIssuer) {
+		if len(cp) > 0 {
+			i.defaultAudience = cp
+		}
 	}
-	out := make([]string, len(i.defaultAudience))
-	copy(out, i.defaultAudience)
-	return out
 }
 
 // NewJWTIssuer creates a JWTIssuer using the active signing key from the provider.

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -3,12 +3,29 @@ package auth
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/golang-jwt/jwt/v5"
 )
+
+// isNilInterfaceValue reports whether an interface value is nil or a typed-nil
+// (e.g., a nil *KeySet passed as SigningKeyProvider). Plain `v == nil` returns
+// false for typed-nil because the interface carries a non-nil type descriptor;
+// reflection is the only reliable check without assuming a concrete type.
+func isNilInterfaceValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	}
+	return false
+}
 
 // DefaultAccessTokenTTL is the default time-to-live for access tokens issued
 // by JWTIssuer. Can be overridden by cmd/* via NewJWTIssuer or WithRefreshTTL.
@@ -131,8 +148,12 @@ func WithVerifierClock(fn func() time.Time) JWTVerifierOption {
 
 // NewJWTVerifier creates a JWTVerifier that validates tokens by looking up the
 // signing key from the VerificationKeyStore using the token's kid header.
+//
+// Rejects both plain-nil and typed-nil keys (e.g. var ks *KeySet = nil passed
+// through an interface variable): a typed-nil would panic on the first method
+// call downstream, so we fail fast at construction.
 func NewJWTVerifier(keys VerificationKeyStore, opts ...JWTVerifierOption) (*JWTVerifier, error) {
-	if keys == nil {
+	if isNilInterfaceValue(keys) {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "verification key store must not be nil")
 	}
 	v := &JWTVerifier{keys: keys}
@@ -346,8 +367,10 @@ func WithIssuerAudiencesFromSlice(auds []string) JWTIssuerOption {
 }
 
 // NewJWTIssuer creates a JWTIssuer using the active signing key from the provider.
+//
+// Rejects both plain-nil and typed-nil keys (see NewJWTVerifier).
 func NewJWTIssuer(keys SigningKeyProvider, issuer string, ttl time.Duration, opts ...JWTIssuerOption) (*JWTIssuer, error) {
-	if keys == nil {
+	if isNilInterfaceValue(keys) {
 		return nil, errcode.New(errcode.ErrAuthKeyInvalid, "signing key provider must not be nil")
 	}
 	i := &JWTIssuer{

--- a/runtime/auth/jwt_aud_test.go
+++ b/runtime/auth/jwt_aud_test.go
@@ -243,13 +243,14 @@ func decodeTokenAudience(t *testing.T, tokenStr string) []string {
 	return parseAudience(mc["aud"])
 }
 
-// TestJWTIssuer_WithDefaultAudience_UsedWhenOptsEmpty verifies that when the
-// issuer is constructed with WithDefaultAudience and Issue is called with an
-// empty IssueOptions.Audience, the default audience is written into the token.
-func TestJWTIssuer_WithDefaultAudience_UsedWhenOptsEmpty(t *testing.T) {
+// TestJWTIssuer_WithIssuerAudiencesFromSlice_UsedWhenOptsEmpty verifies that
+// when the issuer is constructed with WithIssuerAudiencesFromSlice (Registry
+// path) and Issue is called with an empty IssueOptions.Audience, the default
+// audience is written into the token.
+func TestJWTIssuer_WithIssuerAudiencesFromSlice_UsedWhenOptsEmpty(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour,
-		WithDefaultAudience("gocell"),
+		WithIssuerAudiencesFromSlice([]string{"gocell"}),
 	)
 	require.NoError(t, err)
 
@@ -261,12 +262,12 @@ func TestJWTIssuer_WithDefaultAudience_UsedWhenOptsEmpty(t *testing.T) {
 		"default audience must be written when IssueOptions.Audience is nil")
 }
 
-// TestJWTIssuer_WithDefaultAudience_OverriddenByIssueOpts verifies that when
-// IssueOptions.Audience is non-nil, it takes precedence over the default audience.
-func TestJWTIssuer_WithDefaultAudience_OverriddenByIssueOpts(t *testing.T) {
+// TestJWTIssuer_WithIssuerAudiencesFromSlice_OverriddenByIssueOpts verifies that
+// IssueOptions.Audience takes precedence over the default audience from Registry.
+func TestJWTIssuer_WithIssuerAudiencesFromSlice_OverriddenByIssueOpts(t *testing.T) {
 	ks := mustTestKeySet(t)
 	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour,
-		WithDefaultAudience("gocell"),
+		WithIssuerAudiencesFromSlice([]string{"gocell"}),
 	)
 	require.NoError(t, err)
 
@@ -275,41 +276,22 @@ func TestJWTIssuer_WithDefaultAudience_OverriddenByIssueOpts(t *testing.T) {
 
 	aud := decodeTokenAudience(t, tok)
 	assert.Equal(t, []string{"other"}, aud,
-		"IssueOptions.Audience must override the default audience")
+		"IssueOptions.Audience must override the default audience from Registry")
 }
 
-// TestJWTIssuer_DefaultAudience_ReturnsConfiguredValue verifies the DefaultAudience
-// accessor: returns a copy of the configured slice; nil when not configured;
-// mutating the returned slice does not affect future calls (copy semantics).
-func TestJWTIssuer_DefaultAudience_ReturnsConfiguredValue(t *testing.T) {
+// TestJWTIssuer_WithIssuerAudiencesFromSlice_MultipleAudiences verifies that
+// multiple audiences from Registry are all written when IssueOptions.Audience is nil.
+func TestJWTIssuer_WithIssuerAudiencesFromSlice_MultipleAudiences(t *testing.T) {
 	ks := mustTestKeySet(t)
+	issuer, err := NewJWTIssuer(ks, "gocell", time.Hour,
+		WithIssuerAudiencesFromSlice([]string{"gocell", "api-gateway"}),
+	)
+	require.NoError(t, err)
 
-	t.Run("returns configured value", func(t *testing.T) {
-		issuer, err := NewJWTIssuer(ks, "gocell", time.Hour,
-			WithDefaultAudience("gocell", "api-gateway"),
-		)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"gocell", "api-gateway"}, issuer.DefaultAudience())
-	})
+	tok, err := issuer.Issue(TokenIntentAccess, "user-1", IssueOptions{})
+	require.NoError(t, err)
 
-	t.Run("returns nil when not configured", func(t *testing.T) {
-		issuer, err := NewJWTIssuer(ks, "gocell", time.Hour)
-		require.NoError(t, err)
-		assert.Nil(t, issuer.DefaultAudience(),
-			"DefaultAudience must return nil when WithDefaultAudience was not called")
-	})
-
-	t.Run("mutating returned slice does not affect next call", func(t *testing.T) {
-		issuer, err := NewJWTIssuer(ks, "gocell", time.Hour,
-			WithDefaultAudience("gocell"),
-		)
-		require.NoError(t, err)
-
-		got := issuer.DefaultAudience()
-		got[0] = "mutated"
-
-		// Second call must return original value, proving copy semantics.
-		assert.Equal(t, []string{"gocell"}, issuer.DefaultAudience(),
-			"DefaultAudience must return an independent copy each call")
-	})
+	aud := decodeTokenAudience(t, tok)
+	assert.Equal(t, []string{"gocell", "api-gateway"}, aud,
+		"all configured audiences must appear in issued token")
 }

--- a/runtime/auth/jwt_test.go
+++ b/runtime/auth/jwt_test.go
@@ -338,6 +338,27 @@ func TestNewJWTIssuer_NilKeySetReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
 }
 
+// TestNewJWTVerifier_TypedNilKeySet verifies that a typed-nil concrete pointer
+// passed through the VerificationKeyStore interface is rejected at
+// construction. Without reflection-based nil detection, `keys == nil` returns
+// false (interface has a non-nil type descriptor) and the typed-nil would
+// propagate to the first PublicKeyByKID call, where it panics.
+func TestNewJWTVerifier_TypedNilKeySet(t *testing.T) {
+	var ks *KeySet // typed-nil: type=*KeySet, value=nil
+	_, err := NewJWTVerifier(ks)
+	require.Error(t, err, "typed-nil KeySet must be rejected at construction, not at first method call")
+	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
+}
+
+// TestNewJWTIssuer_TypedNilKeySet verifies the same guarantee for the signing
+// provider path.
+func TestNewJWTIssuer_TypedNilKeySet(t *testing.T) {
+	var ks *KeySet
+	_, err := NewJWTIssuer(ks, "gocell", time.Hour)
+	require.Error(t, err, "typed-nil KeySet must be rejected at construction, not at first method call")
+	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
+}
+
 // --- Multi-key verification (US2 via JWT) ---
 
 func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {


### PR DESCRIPTION
## Summary

- 新建 `runtime/auth/config.Registry`，一次性持有 `(Issuer, Audiences, KeySet, Clock)`；`config.FromEnv()` 读取 `GOCELL_JWT_ISSUER` / `GOCELL_JWT_AUDIENCE` 并在 real mode 下 fail-fast
- 新增 `config.NewJWTIssuerFromRegistry` / `config.NewJWTVerifierFromRegistry` 作为生产构造唯一入口；删除 `WithDefaultAudience` option + `DefaultAudience()` accessor；新增 `auth.WithIssuerAudiencesFromSlice` option 供 Registry path 使用
- `sessionlogin` / `sessionrefresh` 删除 `audience` 字段 copy，Issue 时走 issuer 内置默认值；`cmd/core-bundle/buildJWTDeps` 重构为 Registry-first，删除 `loadJWTIssuer` / `loadJWTAudience` 两个 helper

## 吸收 backlog

- **S18** JWT issuer 漂移（env → main → Issuer.field → slice 副本）
- **S31** audience 冗余 copy（sessionlogin/sessionrefresh 各自缓存 audience 字段）
- **S20** env loader 内聚（loadJWTIssuer/loadJWTAudience 已被 config.FromEnv 吸收）

## 对标

- `ref: Ory Hydra internal/driver/config.DefaultProvider` — 单一 Registry 模式；所有 JWT 配置归一命名空间
- `ref: go-kratos middleware/auth/jwt WithParserOptions` — 一次注入 issuer/audiences，Issuer/Verifier 共享

## Test plan

- [x] `runtime/auth/config` 新建全套 table-driven 测试，coverage **100%**
- [x] `runtime/auth` 测试覆盖 `WithIssuerAudiencesFromSlice` 行为，coverage **93%**
- [x] `sessionlogin` / `sessionrefresh` service_test 更新为 Registry path
- [x] `cmd/core-bundle/jwt_deps_test.go` 完全重写：删除旧 loadJWTIssuer/loadJWTAudience 测试，补充 Registry 端到端 wiring 测试
- [x] `go build ./... && go build -tags=integration ./... && go vet ./...` — 0 错误
- [x] `golangci-lint run ./runtime/auth/... ./cells/access-core/... ./cmd/core-bundle/... ./examples/sso-bff/...` — **0 issues**
- [ ] `TestAuthWiring_*` 网络绑定测试在 sandbox 下因 `bind: operation not permitted` 跳过（非本 PR 引入，与 JWT Registry 无关）

## Plan ref

`docs/plans/202604191515-auth-federated-whistle.md §F1`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)