### PR TITLE
feat(auth): F7 Principal 统一契约 + Authenticator 接口

### DIFF
--- a/cells/access-core/slices/identitymanage/handler.go
+++ b/cells/access-core/slices/identitymanage/handler.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/dto"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -196,7 +195,7 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 
 	// Prevent admin self-deletion — removing own account would lock out the
 	// operator with no recovery path if this is the last admin.
-	if subject, ok := ctxkeys.SubjectFrom(r.Context()); ok && subject == id {
+	if p, ok := auth.FromContext(r.Context()); ok && p.Subject == id {
 		httputil.WriteDomainError(r.Context(), w,
 			errcode.New(errcode.ErrAuthSelfDelete, "cannot delete own account"))
 		return

--- a/cells/access-core/slices/sessionlogout/contract_test.go
+++ b/cells/access-core/slices/sessionlogout/contract_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/contracttest"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,7 +72,7 @@ func TestHttpAuthSessionDeleteV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	// Simulate the auth middleware having populated the caller's subject in ctx.
 	req := httptest.NewRequest(c.HTTP.Method, path, nil).
-		WithContext(ctxkeys.WithSubject(context.Background(), "usr-1"))
+		WithContext(auth.TestContext("usr-1", nil))
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 }

--- a/cells/access-core/slices/sessionlogout/handler.go
+++ b/cells/access-core/slices/sessionlogout/handler.go
@@ -3,9 +3,9 @@ package sessionlogout
 import (
 	"net/http"
 
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // Handler provides HTTP endpoints for session logout.
@@ -27,8 +27,8 @@ func NewHandler(svc *Service) *Handler {
 func (h *Handler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 
-	callerUserID, ok := ctxkeys.SubjectFrom(r.Context())
-	if !ok || callerUserID == "" {
+	p, ok := auth.FromContext(r.Context())
+	if !ok || p.Subject == "" {
 		// Auth middleware guarantees subject presence on protected routes.
 		// Reaching this branch means the route was misconfigured as public —
 		// fail closed rather than leak a revoke op to an unauthenticated caller.
@@ -36,6 +36,7 @@ func (h *Handler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 			errcode.New(errcode.ErrAuthInvalidToken, "missing subject"))
 		return
 	}
+	callerUserID := p.Subject
 
 	if err := h.svc.Logout(r.Context(), sessionID, callerUserID); err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)

--- a/cells/access-core/slices/sessionlogout/handler_test.go
+++ b/cells/access-core/slices/sessionlogout/handler_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
@@ -75,9 +75,11 @@ func TestHandleLogout(t *testing.T) {
 			h := setup()
 			w := httptest.NewRecorder()
 			sessionID := strings.TrimPrefix(tc.path, "/")
-			ctx := context.Background()
+			var ctx context.Context
 			if tc.caller != "" {
-				ctx = ctxkeys.WithSubject(ctx, tc.caller)
+				ctx = auth.TestContext(tc.caller, nil)
+			} else {
+				ctx = context.Background()
 			}
 			req := httptest.NewRequest(http.MethodDelete, tc.path, nil).WithContext(ctx)
 			req.SetPathValue("id", sessionID)

--- a/cells/access-core/slices/sessionlogout/handler_test.go
+++ b/cells/access-core/slices/sessionlogout/handler_test.go
@@ -68,6 +68,14 @@ func TestHandleLogout(t *testing.T) {
 			caller:     "",
 			wantStatus: http.StatusUnauthorized,
 		},
+		{
+			// Defense-in-depth: Principal is present in context (ok=true) but
+			// Subject is empty — handler must still reject with 401.
+			name:       "principal present but empty subject returns 401",
+			path:       "/sess-1",
+			caller:     "empty-subject-sentinel",
+			wantStatus: http.StatusUnauthorized,
+		},
 	}
 
 	for _, tc := range tests {
@@ -76,9 +84,18 @@ func TestHandleLogout(t *testing.T) {
 			w := httptest.NewRecorder()
 			sessionID := strings.TrimPrefix(tc.path, "/")
 			var ctx context.Context
-			if tc.caller != "" {
+			switch {
+			case tc.name == "principal present but empty subject returns 401":
+				// Inject a Principal with ok=true but Subject="" to exercise the
+				// second branch of: if !ok || p.Subject == ""
+				ctx = auth.WithPrincipal(context.Background(), &auth.Principal{
+					Kind:       auth.PrincipalUser,
+					Subject:    "",
+					AuthMethod: "test",
+				})
+			case tc.caller != "":
 				ctx = auth.TestContext(tc.caller, nil)
-			} else {
+			default:
 				ctx = context.Background()
 			}
 			req := httptest.NewRequest(http.MethodDelete, tc.path, nil).WithContext(ctx)

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -75,7 +75,13 @@ func auditQueryPolicy(r *http.Request) error {
 // Policy is enforced by auditQueryPolicy (see above).
 func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	// auditQueryPolicy (declared at route registration) guarantees subject presence.
-	p, _ := auth.FromContext(r.Context())
+	// Guard defensively: if policy is misconfigured and auth middleware didn't run,
+	// fail closed rather than panic on nil dereference.
+	p, ok := auth.FromContext(r.Context())
+	if !ok {
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, string(errcode.ErrAuthUnauthorized), "authentication required")
+		return
+	}
 	subject := p.Subject
 
 	actorID := r.URL.Query().Get("actorId")

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -56,12 +55,12 @@ func NewHandler(svc *Service) *Handler {
 // TODO(S43): role-name literal — migrate to permission-based authz when PERMISSION-BASED-AUTHZ-01 lands.
 func auditQueryPolicy(r *http.Request) error {
 	ctx := r.Context()
-	subject, ok := ctxkeys.SubjectFrom(ctx)
-	if !ok || subject == "" {
+	p, ok := auth.FromContext(ctx)
+	if !ok || p.Subject == "" {
 		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
 	}
 	actorID := r.URL.Query().Get("actorId")
-	if actorID == "" || actorID == subject {
+	if actorID == "" || actorID == p.Subject {
 		return nil
 	}
 	return auth.AnyRole("admin")(r)
@@ -76,7 +75,8 @@ func auditQueryPolicy(r *http.Request) error {
 // Policy is enforced by auditQueryPolicy (see above).
 func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	// auditQueryPolicy (declared at route registration) guarantees subject presence.
-	subject, _ := ctxkeys.SubjectFrom(r.Context())
+	p, _ := auth.FromContext(r.Context())
+	subject := p.Subject
 
 	actorID := r.URL.Query().Get("actorId")
 	if actorID == "" {

--- a/pkg/ctxkeys/doc.go
+++ b/pkg/ctxkeys/doc.go
@@ -1,4 +1,7 @@
 // Package ctxkeys provides typed context keys and helper functions for
 // propagating GoCell identifiers (cell, slice, correlation, journey, trace,
-// span) through context.Context.
+// span, request, ip) through context.Context.
+//
+// Authentication subject is propagated via runtime/auth.Principal —
+// use auth.WithPrincipal / auth.FromContext instead of a ctxkeys entry.
 package ctxkeys

--- a/pkg/ctxkeys/keys.go
+++ b/pkg/ctxkeys/keys.go
@@ -18,7 +18,6 @@ const (
 	SpanID        ctxKey = "span_id"
 	RequestID     ctxKey = "request_id"
 	RealIP        ctxKey = "real_ip"
-	Subject       ctxKey = "subject"
 )
 
 // --- CellID ---
@@ -122,18 +121,5 @@ func WithRealIP(ctx context.Context, ip string) context.Context {
 // RealIPFrom extracts the client's real IP from ctx. The boolean indicates presence.
 func RealIPFrom(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(RealIP).(string)
-	return v, ok
-}
-
-// --- Subject ---
-
-// WithSubject returns a new context carrying the authenticated subject identifier.
-func WithSubject(ctx context.Context, sub string) context.Context {
-	return context.WithValue(ctx, Subject, sub)
-}
-
-// SubjectFrom extracts the authenticated subject from ctx. The boolean indicates presence.
-func SubjectFrom(ctx context.Context) (string, bool) {
-	v, ok := ctx.Value(Subject).(string)
 	return v, ok
 }

--- a/pkg/ctxkeys/keys_test.go
+++ b/pkg/ctxkeys/keys_test.go
@@ -152,24 +152,6 @@ func TestRealIPRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSubjectRoundTrip(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-	}{
-		{name: "user id", value: "user-42"},
-		{name: "empty string", value: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := WithSubject(context.Background(), tt.value)
-			got, ok := SubjectFrom(ctx)
-			assert.True(t, ok)
-			assert.Equal(t, tt.value, got)
-		})
-	}
-}
-
 func TestFromMissingKey(t *testing.T) {
 	ctx := context.Background()
 
@@ -185,7 +167,6 @@ func TestFromMissingKey(t *testing.T) {
 		{name: "SpanID missing", fn: SpanIDFrom},
 		{name: "RequestID missing", fn: RequestIDFrom},
 		{name: "RealIP missing", fn: RealIPFrom},
-		{name: "Subject missing", fn: SubjectFrom},
 	}
 
 	for _, tt := range tests {
@@ -207,7 +188,6 @@ func TestMultipleKeysInSameContext(t *testing.T) {
 	ctx = WithSpanID(ctx, "span-xyz")
 	ctx = WithRequestID(ctx, "req-001")
 	ctx = WithRealIP(ctx, "10.0.0.1")
-	ctx = WithSubject(ctx, "admin")
 
 	cellID, ok := CellIDFrom(ctx)
 	assert.True(t, ok)
@@ -240,8 +220,4 @@ func TestMultipleKeysInSameContext(t *testing.T) {
 	realIP, ok := RealIPFrom(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, "10.0.0.1", realIP)
-
-	subject, ok := SubjectFrom(ctx)
-	assert.True(t, ok)
-	assert.Equal(t, "admin", subject)
 }

--- a/runtime/auth/auth.go
+++ b/runtime/auth/auth.go
@@ -110,16 +110,3 @@ type VerificationKeyStore interface {
 	PublicKeyByKID(kid string) (*rsa.PublicKey, error)
 }
 
-// claimsKey is the context key for storing Claims.
-type claimsKey struct{}
-
-// WithClaims returns a new context carrying the given Claims.
-func WithClaims(ctx context.Context, c Claims) context.Context {
-	return context.WithValue(ctx, claimsKey{}, c)
-}
-
-// ClaimsFrom extracts Claims from ctx. The boolean indicates presence.
-func ClaimsFrom(ctx context.Context) (Claims, bool) {
-	c, ok := ctx.Value(claimsKey{}).(Claims)
-	return c, ok
-}

--- a/runtime/auth/auth_test.go
+++ b/runtime/auth/auth_test.go
@@ -3,32 +3,25 @@ package auth
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClaims_ContextRoundTrip(t *testing.T) {
-	claims := Claims{
-		Subject:   "user-123",
-		Issuer:    "gocell",
-		Audience:  []string{"api"},
-		ExpiresAt: time.Now().Add(time.Hour),
-		IssuedAt:  time.Now(),
-		Roles:     []string{"admin", "user"},
-		Extra:     map[string]any{"tenant": "acme"},
+func TestPrincipal_ContextRoundTrip(t *testing.T) {
+	p := &Principal{
+		Kind:    PrincipalUser,
+		Subject: "user-123",
+		Roles:   []string{"admin", "user"},
 	}
 
-	ctx := WithClaims(context.Background(), claims)
-	got, ok := ClaimsFrom(ctx)
+	ctx := WithPrincipal(context.Background(), p)
+	got, ok := FromContext(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, "user-123", got.Subject)
-	assert.Equal(t, "gocell", got.Issuer)
 	assert.Equal(t, []string{"admin", "user"}, got.Roles)
-	assert.Equal(t, "acme", got.Extra["tenant"])
 }
 
-func TestClaims_MissingFromContext(t *testing.T) {
-	_, ok := ClaimsFrom(context.Background())
+func TestPrincipal_MissingFromContext(t *testing.T) {
+	_, ok := FromContext(context.Background())
 	assert.False(t, ok)
 }

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -1,0 +1,206 @@
+// Package auth: Authenticator contract.
+//
+// An Authenticator inspects an *http.Request and returns one of three outcomes:
+//
+//	(p, true, nil)    — credential present and valid; caller stops the chain.
+//	(nil, false, nil) — credential absent; caller should try the next authenticator.
+//	(nil, false, err) — credential present but invalid; caller MUST NOT fall through.
+//
+// ref: kubernetes/apiserver pkg/authentication/request/union/union.go (FailOnError=true)
+package auth
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Authenticator inspects an HTTP request and resolves the caller's identity.
+type Authenticator interface {
+	Authenticate(r *http.Request) (*Principal, bool, error)
+}
+
+// AuthenticatorFunc is a function that implements Authenticator.
+type AuthenticatorFunc func(r *http.Request) (*Principal, bool, error)
+
+// Authenticate implements Authenticator.
+func (f AuthenticatorFunc) Authenticate(r *http.Request) (*Principal, bool, error) {
+	return f(r)
+}
+
+// UnionAuthenticator tries each child in order and returns the first successful
+// result. An error from any child short-circuits the chain (FailOnError semantics).
+type UnionAuthenticator struct {
+	children []Authenticator
+}
+
+// NewUnionAuthenticator returns a UnionAuthenticator that delegates to children
+// in the order provided.
+func NewUnionAuthenticator(children ...Authenticator) *UnionAuthenticator {
+	return &UnionAuthenticator{children: children}
+}
+
+// Authenticate iterates over child authenticators and returns the first result
+// that indicates a valid credential. If a child returns an error the chain stops
+// immediately and the error is propagated (credential present but invalid).
+func (u *UnionAuthenticator) Authenticate(r *http.Request) (*Principal, bool, error) {
+	for _, child := range u.children {
+		p, ok, err := child.Authenticate(r)
+		if err != nil {
+			// Credential present but invalid — short-circuit, no fallthrough.
+			return nil, false, err
+		}
+		if ok {
+			// Credential valid — stop the chain.
+			return p, true, nil
+		}
+		// Credential absent — try the next authenticator.
+	}
+	return nil, false, nil
+}
+
+// NewJWTAuthenticator returns an Authenticator that extracts a Bearer token
+// from the Authorization header and verifies its "access" intent using v.
+//
+// Outcomes:
+//
+//	(p, true, nil)    — token present and valid; Principal populated from claims.
+//	(nil, false, nil) — no Authorization header, or non-Bearer scheme (let Union continue).
+//	(nil, false, err) — Bearer token present but VerifyIntent rejected it (short-circuit).
+//
+// ref: kubernetes/apiserver pkg/authentication/request/bearertoken/bearertoken.go
+func NewJWTAuthenticator(v IntentTokenVerifier) Authenticator {
+	return AuthenticatorFunc(func(r *http.Request) (*Principal, bool, error) {
+		token := extractBearerToken(r)
+		if token == "" {
+			// No Bearer credential — absent, let the Union try the next authenticator.
+			return nil, false, nil
+		}
+		claims, err := v.VerifyIntent(r.Context(), token, TokenIntentAccess)
+		if err != nil {
+			// Credential present but invalid — short-circuit.
+			return nil, false, err
+		}
+		return jwtClaimsToPrincipal(claims), true, nil
+	})
+}
+
+// jwtClaimsToPrincipal converts verified JWT Claims to a Principal.
+// Roles is a defensive copy so callers cannot mutate the underlying slice.
+// The Claims map contains exactly three entries (sid, iss, token_use);
+// other JWT fields (aud, exp, iat, …) are intentionally excluded.
+func jwtClaimsToPrincipal(c Claims) *Principal {
+	roles := append([]string(nil), c.Roles...)
+	return &Principal{
+		Kind:                  PrincipalUser,
+		Subject:               c.Subject,
+		Roles:                 roles,
+		AuthMethod:            "jwt",
+		PasswordResetRequired: c.PasswordResetRequired,
+		Claims: map[string]string{
+			"sid":       c.SessionID,
+			"iss":       c.Issuer,
+			"token_use": string(c.TokenUse),
+		},
+	}
+}
+
+// NewServiceTokenAuthenticator returns an Authenticator that validates HMAC
+// service tokens (Authorization: ServiceToken <ts>:<nonce>:<mac>).
+//
+// Outcomes:
+//
+//	(p, true, nil)    — ServiceToken header present and valid.
+//	(nil, false, nil) — no Authorization header, or non-"ServiceToken" scheme.
+//	(nil, false, err) — ServiceToken present but validation failed (expired, bad MAC, replay).
+//
+// Options reuse ServiceTokenOption so callers share the same clock/nonce/metrics
+// injection points as ServiceTokenMiddleware.
+func NewServiceTokenAuthenticator(ring *HMACKeyRing, opts ...ServiceTokenOption) Authenticator {
+	cfg := serviceTokenConfig{now: time.Now}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return AuthenticatorFunc(func(r *http.Request) (*Principal, bool, error) {
+		raw := r.Header.Get("Authorization")
+		if raw == "" {
+			return nil, false, nil
+		}
+		scheme, payload, ok := strings.Cut(raw, " ")
+		if !ok || !strings.EqualFold(scheme, "ServiceToken") {
+			// Bearer or other scheme — absent for this authenticator.
+			return nil, false, nil
+		}
+		payload = strings.TrimSpace(payload)
+		if err := verifyServiceTokenPayload(ring, payload, cfg, r); err != nil {
+			return nil, false, err
+		}
+		roles := append([]string(nil), BuiltinServiceRoles(ServiceNameInternal)...)
+		return &Principal{
+			Kind:       PrincipalService,
+			Subject:    ServiceNameInternal,
+			Roles:      roles,
+			AuthMethod: "service_token",
+		}, true, nil
+	})
+}
+
+// verifyServiceTokenPayload validates the raw payload portion of a ServiceToken
+// header (everything after "ServiceToken "). It enforces:
+//   - 3-part format: {timestamp}:{nonce}:{hex_hmac}
+//   - timestamp within ServiceTokenMaxAge
+//   - HMAC valid for any key in ring
+//   - nonce not replayed (if cfg.nonceStore is set)
+//
+// Errors use fmt.Errorf to avoid circular import of errcode; the HTTP layer
+// maps these to ERR_AUTH_UNAUTHORIZED. This helper is intentionally package-private.
+func verifyServiceTokenPayload(ring *HMACKeyRing, payload string, cfg serviceTokenConfig, r *http.Request) error {
+	parts := strings.SplitN(payload, ":", 3)
+	if len(parts) == 2 {
+		return fmt.Errorf("auth: legacy 2-part service token format rejected")
+	}
+	if len(parts) != 3 {
+		return fmt.Errorf("auth: %s", msgInvalidServiceTokenFormat)
+	}
+
+	tsStr := parts[0]
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("auth: invalid service token timestamp")
+	}
+
+	nowFn := cfg.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	now := nowFn()
+	tokenTime := time.Unix(ts, 0)
+	age := now.Sub(tokenTime)
+	if age < 0 {
+		age = -age
+	}
+	if age >= ServiceTokenMaxAge {
+		return fmt.Errorf("auth: service token expired")
+	}
+
+	nonce, sigHex := parts[1], parts[2]
+	message := buildServiceTokenMessage(r.Method, r.URL.Path, r.URL.RawQuery, tsStr, nonce)
+
+	providedMAC, err := hex.DecodeString(sigHex)
+	if err != nil {
+		return fmt.Errorf("auth: %s", msgInvalidServiceTokenFormat)
+	}
+	if !verifyServiceTokenMAC(ring, message, providedMAC) {
+		return fmt.Errorf("auth: invalid service token MAC")
+	}
+
+	if cfg.nonceStore != nil {
+		if err := cfg.nonceStore.CheckAndMark(r.Context(), nonce); err != nil {
+			return fmt.Errorf("auth: service token replay detected: %w", err)
+		}
+	}
+	return nil
+}

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -11,11 +11,12 @@ package auth
 
 import (
 	"encoding/hex"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // Authenticator inspects an HTTP request and resolves the caller's identity.
@@ -84,6 +85,12 @@ func NewJWTAuthenticator(v IntentTokenVerifier) Authenticator {
 			// Credential present but invalid — short-circuit.
 			return nil, false, err
 		}
+		// G1.A: Reject tokens with an empty subject. An empty "sub" claim
+		// indicates a JWT signing bug or OIDC misconfiguration; accepting it
+		// would allow a bearer with roles to pass RequireAnyRole unchecked.
+		if claims.Subject == "" {
+			return nil, false, errcode.NewAuth(errcode.ErrAuthUnauthorized, "token subject missing")
+		}
 		return jwtClaimsToPrincipal(claims), true, nil
 	})
 }
@@ -119,6 +126,9 @@ func jwtClaimsToPrincipal(c Claims) *Principal {
 //
 // Options reuse ServiceTokenOption so callers share the same clock/nonce/metrics
 // injection points as ServiceTokenMiddleware.
+//
+// NonceStore is nil by default; omitting it disables replay detection.
+// Production deployments MUST supply WithNonceStore.
 func NewServiceTokenAuthenticator(ring *HMACKeyRing, opts ...ServiceTokenOption) Authenticator {
 	cfg := serviceTokenConfig{now: time.Now}
 	for _, o := range opts {
@@ -155,21 +165,24 @@ func NewServiceTokenAuthenticator(ring *HMACKeyRing, opts ...ServiceTokenOption)
 //   - HMAC valid for any key in ring
 //   - nonce not replayed (if cfg.nonceStore is set)
 //
-// Errors use fmt.Errorf to avoid circular import of errcode; the HTTP layer
-// maps these to ERR_AUTH_UNAUTHORIZED. This helper is intentionally package-private.
+// Nonce replay errors preserve the original NonceStore error as the Cause so
+// callers can inspect it with errors.Is (e.g. to distinguish ErrNonceReused
+// from a store failure and map to the correct HTTP status code).
+//
+// This helper is intentionally package-private.
 func verifyServiceTokenPayload(ring *HMACKeyRing, payload string, cfg serviceTokenConfig, r *http.Request) error {
 	parts := strings.SplitN(payload, ":", 3)
 	if len(parts) == 2 {
-		return fmt.Errorf("auth: legacy 2-part service token format rejected")
+		return errcode.NewAuth(errcode.ErrAuthUnauthorized, "legacy 2-part service token format rejected")
 	}
 	if len(parts) != 3 {
-		return fmt.Errorf("auth: %s", msgInvalidServiceTokenFormat)
+		return errcode.NewAuth(errcode.ErrAuthUnauthorized, msgInvalidServiceTokenFormat)
 	}
 
 	tsStr := parts[0]
 	ts, err := strconv.ParseInt(tsStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("auth: invalid service token timestamp")
+		return errcode.NewAuth(errcode.ErrAuthUnauthorized, "invalid service token timestamp")
 	}
 
 	nowFn := cfg.now
@@ -183,7 +196,7 @@ func verifyServiceTokenPayload(ring *HMACKeyRing, payload string, cfg serviceTok
 		age = -age
 	}
 	if age >= ServiceTokenMaxAge {
-		return fmt.Errorf("auth: service token expired")
+		return errcode.NewAuth(errcode.ErrAuthTokenExpired, "service token expired")
 	}
 
 	nonce, sigHex := parts[1], parts[2]
@@ -191,15 +204,17 @@ func verifyServiceTokenPayload(ring *HMACKeyRing, payload string, cfg serviceTok
 
 	providedMAC, err := hex.DecodeString(sigHex)
 	if err != nil {
-		return fmt.Errorf("auth: %s", msgInvalidServiceTokenFormat)
+		return errcode.NewAuth(errcode.ErrAuthUnauthorized, msgInvalidServiceTokenFormat)
 	}
 	if !verifyServiceTokenMAC(ring, message, providedMAC) {
-		return fmt.Errorf("auth: invalid service token MAC")
+		return errcode.NewAuth(errcode.ErrAuthUnauthorized, "invalid service token MAC")
 	}
 
 	if cfg.nonceStore != nil {
 		if err := cfg.nonceStore.CheckAndMark(r.Context(), nonce); err != nil {
-			return fmt.Errorf("auth: service token replay detected: %w", err)
+			// Preserve the original NonceStore error as Cause so callers can
+			// distinguish ErrNonceReused (replay → 401) from store failures (→ 500).
+			return errcode.WrapAuth(errcode.ErrAuthUnauthorized, "service token nonce check failed", err)
 		}
 	}
 	return nil

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -1,0 +1,487 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// stubAuthenticator is a test double for the Authenticator interface.
+type stubAuthenticator struct {
+	principal *Principal
+	ok        bool
+	err       error
+	calls     int
+}
+
+func (s *stubAuthenticator) Authenticate(_ *http.Request) (*Principal, bool, error) {
+	s.calls++
+	return s.principal, s.ok, s.err
+}
+
+func newRequest(t *testing.T) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(http.MethodGet, "/", nil)
+}
+
+func TestAuthenticatorFunc_Adapter(t *testing.T) {
+	want := &Principal{Kind: PrincipalUser, Subject: "u1"}
+	fn := AuthenticatorFunc(func(_ *http.Request) (*Principal, bool, error) {
+		return want, true, nil
+	})
+	got, ok, err := fn.Authenticate(newRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != want {
+		t.Error("expected same Principal pointer")
+	}
+}
+
+func TestUnionAuthenticator_FirstMatchWins(t *testing.T) {
+	want := &Principal{Kind: PrincipalUser, Subject: "first"}
+	first := &stubAuthenticator{principal: want, ok: true}
+	second := &stubAuthenticator{principal: &Principal{Subject: "second"}, ok: true}
+	third := &stubAuthenticator{principal: &Principal{Subject: "third"}, ok: true}
+
+	u := NewUnionAuthenticator(first, second, third)
+	got, ok, err := u.Authenticate(newRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != want {
+		t.Errorf("expected first principal, got %v", got)
+	}
+	if second.calls != 0 {
+		t.Errorf("second authenticator should not have been called, got %d calls", second.calls)
+	}
+	if third.calls != 0 {
+		t.Errorf("third authenticator should not have been called, got %d calls", third.calls)
+	}
+}
+
+func TestUnionAuthenticator_SkipAbsentCredential(t *testing.T) {
+	want := &Principal{Kind: PrincipalService, Subject: "svc"}
+	first := &stubAuthenticator{principal: nil, ok: false, err: nil}
+	second := &stubAuthenticator{principal: want, ok: true}
+
+	u := NewUnionAuthenticator(first, second)
+	got, ok, err := u.Authenticate(newRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != want {
+		t.Errorf("expected second principal, got %v", got)
+	}
+	if first.calls != 1 {
+		t.Errorf("first authenticator should have been called once, got %d", first.calls)
+	}
+	if second.calls != 1 {
+		t.Errorf("second authenticator should have been called once, got %d", second.calls)
+	}
+}
+
+func TestUnionAuthenticator_InvalidCredentialShortCircuits(t *testing.T) {
+	errInvalid := errors.New("token expired")
+	first := &stubAuthenticator{principal: nil, ok: false, err: errInvalid}
+	second := &stubAuthenticator{principal: &Principal{Subject: "should-not-reach"}, ok: true}
+
+	u := NewUnionAuthenticator(first, second)
+	got, ok, err := u.Authenticate(newRequest(t))
+	if !errors.Is(err, errInvalid) {
+		t.Errorf("expected errInvalid, got %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false on error")
+	}
+	if got != nil {
+		t.Errorf("expected nil principal on error, got %v", got)
+	}
+	if second.calls != 0 {
+		t.Errorf("second authenticator must not be called on error, got %d calls", second.calls)
+	}
+}
+
+func TestUnionAuthenticator_EmptyChildren(t *testing.T) {
+	u := NewUnionAuthenticator()
+	got, ok, err := u.Authenticate(newRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false with no children")
+	}
+	if got != nil {
+		t.Errorf("expected nil principal, got %v", got)
+	}
+}
+
+func TestUnionAuthenticator_AllAbsent(t *testing.T) {
+	first := &stubAuthenticator{principal: nil, ok: false}
+	second := &stubAuthenticator{principal: nil, ok: false}
+
+	u := NewUnionAuthenticator(first, second)
+	got, ok, err := u.Authenticate(newRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false when all absent")
+	}
+	if got != nil {
+		t.Errorf("expected nil principal, got %v", got)
+	}
+	if first.calls != 1 {
+		t.Errorf("first should be called once, got %d", first.calls)
+	}
+	if second.calls != 1 {
+		t.Errorf("second should be called once, got %d", second.calls)
+	}
+}
+
+// --- T2: JWT Authenticator tests ---
+
+// stubVerifier is a minimal IntentTokenVerifier test double.
+type stubVerifier struct {
+	claims Claims
+	err    error
+}
+
+func (s *stubVerifier) VerifyIntent(_ context.Context, _ string, _ TokenIntent) (Claims, error) {
+	return s.claims, s.err
+}
+
+func newGetRequest(t *testing.T, authHeader string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	return req
+}
+
+func TestJWTAuthenticator_NoAuthHeader_Absent(t *testing.T) {
+	v := &stubVerifier{}
+	a := NewJWTAuthenticator(v)
+	p, ok, err := a.Authenticate(newGetRequest(t, ""))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false (absent credential)")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+func TestJWTAuthenticator_NonBearerScheme_Absent(t *testing.T) {
+	v := &stubVerifier{}
+	a := NewJWTAuthenticator(v)
+	// Non-Bearer scheme must be treated as absent so Union can try next authenticator.
+	p, ok, err := a.Authenticate(newGetRequest(t, "Basic dXNlcjpwYXNz"))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false for non-Bearer scheme")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+func TestJWTAuthenticator_InvalidToken_Error(t *testing.T) {
+	errInvalid := errors.New("signature invalid")
+	v := &stubVerifier{err: errInvalid}
+	a := NewJWTAuthenticator(v)
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer bad-token"))
+	if !errors.Is(err, errInvalid) {
+		t.Fatalf("expected errInvalid, got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false on error")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal on error, got %v", p)
+	}
+}
+
+func TestJWTAuthenticator_IntentMismatch_Error(t *testing.T) {
+	errIntent := errors.New("wrong intent: refresh token presented at access endpoint")
+	v := &stubVerifier{err: errIntent}
+	a := NewJWTAuthenticator(v)
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer refresh-token"))
+	if !errors.Is(err, errIntent) {
+		t.Fatalf("expected intent error, got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false on intent mismatch")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+func TestJWTAuthenticator_Success_PrincipalShape(t *testing.T) {
+	claims := Claims{
+		Subject:               "user-42",
+		Roles:                 []string{"admin", "user"},
+		SessionID:             "sess-xyz",
+		Issuer:                "gocell-issuer",
+		TokenUse:              TokenIntentAccess,
+		Audience:              []string{"gocell"},
+		PasswordResetRequired: true,
+	}
+	v := &stubVerifier{claims: claims}
+	a := NewJWTAuthenticator(v)
+
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer valid-access-token"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true on success")
+	}
+	if p == nil {
+		t.Fatal("expected non-nil principal")
+	}
+
+	// Kind must be PrincipalUser.
+	if p.Kind != PrincipalUser {
+		t.Errorf("expected Kind=PrincipalUser, got %v", p.Kind)
+	}
+	// Subject must match claims.Subject.
+	if p.Subject != claims.Subject {
+		t.Errorf("expected Subject=%q, got %q", claims.Subject, p.Subject)
+	}
+	// AuthMethod must be "jwt".
+	if p.AuthMethod != "jwt" {
+		t.Errorf("expected AuthMethod=%q, got %q", "jwt", p.AuthMethod)
+	}
+	// PasswordResetRequired must be forwarded.
+	if !p.PasswordResetRequired {
+		t.Error("expected PasswordResetRequired=true")
+	}
+	// Roles must be a copy of claims.Roles.
+	if len(p.Roles) != len(claims.Roles) {
+		t.Fatalf("expected %d roles, got %d", len(claims.Roles), len(p.Roles))
+	}
+	for i, r := range claims.Roles {
+		if p.Roles[i] != r {
+			t.Errorf("role[%d]: expected %q, got %q", i, r, p.Roles[i])
+		}
+	}
+	// Roles must be a copy — mutating Principal.Roles must not affect original.
+	originalFirstRole := claims.Roles[0]
+	p.Roles[0] = "mutated"
+	if claims.Roles[0] != originalFirstRole {
+		t.Error("Principal.Roles must be a defensive copy; mutating it affected claims.Roles")
+	}
+
+	// Claims map must have exactly 3 keys: sid, iss, token_use.
+	if len(p.Claims) != 3 {
+		t.Errorf("expected exactly 3 Claims map entries, got %d: %v", len(p.Claims), p.Claims)
+	}
+	if p.Claims["sid"] != claims.SessionID {
+		t.Errorf("expected Claims[sid]=%q, got %q", claims.SessionID, p.Claims["sid"])
+	}
+	if p.Claims["iss"] != claims.Issuer {
+		t.Errorf("expected Claims[iss]=%q, got %q", claims.Issuer, p.Claims["iss"])
+	}
+	if p.Claims["token_use"] != string(claims.TokenUse) {
+		t.Errorf("expected Claims[token_use]=%q, got %q", string(claims.TokenUse), p.Claims["token_use"])
+	}
+	// Audience must NOT appear in Claims map.
+	if _, ok := p.Claims["aud"]; ok {
+		t.Error("Audience must not appear in Principal.Claims map")
+	}
+}
+
+// --- T3: ServiceToken Authenticator tests ---
+
+func TestServiceTokenAuthenticator_NoHeader_Absent(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	a := NewServiceTokenAuthenticator(ring)
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	p, ok, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false (absent credential)")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+func TestServiceTokenAuthenticator_BearerSchemeIgnored_Absent(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	a := NewServiceTokenAuthenticator(ring)
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "Bearer some-jwt-token")
+	p, ok, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected no error (Bearer ignored), got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false: Bearer scheme must be absent for ServiceToken authenticator")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+func TestServiceTokenAuthenticator_InvalidMAC_Error(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	// Construct a token with wrong HMAC (last byte flipped).
+	goodToken := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
+	badToken := goodToken[:len(goodToken)-2] + "ff"
+	req.Header.Set("Authorization", "ServiceToken "+badToken)
+	p, ok, err := a.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for invalid MAC, got nil")
+	}
+	if ok {
+		t.Fatal("expected ok=false on invalid MAC")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+func TestServiceTokenAuthenticator_Expired_Error(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	oldTime := now.Add(-6 * time.Minute)
+	// Token is signed for 6 minutes ago — exceeds ServiceTokenMaxAge.
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", oldTime)
+	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	p, ok, err := a.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+	if ok {
+		t.Fatal("expected ok=false for expired token")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+func TestServiceTokenAuthenticator_NonceReplay_Error(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	store, err := NewInMemoryNonceStore(5 * time.Minute)
+	if err != nil {
+		t.Fatalf("NewInMemoryNonceStore: %v", err)
+	}
+	a := NewServiceTokenAuthenticator(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithNonceStore(store),
+	)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
+
+	// First use — must succeed.
+	req1 := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req1.Header.Set("Authorization", "ServiceToken "+token)
+	p1, ok1, err1 := a.Authenticate(req1)
+	if err1 != nil {
+		t.Fatalf("first use unexpected error: %v", err1)
+	}
+	if !ok1 {
+		t.Fatal("first use expected ok=true")
+	}
+	if p1 == nil {
+		t.Fatal("first use expected non-nil principal")
+	}
+
+	// Second use (replay) — must error.
+	req2 := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req2.Header.Set("Authorization", "ServiceToken "+token)
+	p2, ok2, err2 := a.Authenticate(req2)
+	if err2 == nil {
+		t.Fatal("replay expected error, got nil")
+	}
+	if ok2 {
+		t.Fatal("replay expected ok=false")
+	}
+	if p2 != nil {
+		t.Fatalf("replay expected nil principal, got %v", p2)
+	}
+}
+
+func TestServiceTokenAuthenticator_Success_PrincipalShape(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+
+	p, ok, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true on success")
+	}
+	if p == nil {
+		t.Fatal("expected non-nil principal")
+	}
+
+	// Kind must be PrincipalService.
+	if p.Kind != PrincipalService {
+		t.Errorf("expected Kind=PrincipalService, got %v", p.Kind)
+	}
+	// Subject must be ServiceNameInternal.
+	if p.Subject != ServiceNameInternal {
+		t.Errorf("expected Subject=%q, got %q", ServiceNameInternal, p.Subject)
+	}
+	// AuthMethod must be "service_token".
+	if p.AuthMethod != "service_token" {
+		t.Errorf("expected AuthMethod=%q, got %q", "service_token", p.AuthMethod)
+	}
+	// PasswordResetRequired must be false.
+	if p.PasswordResetRequired {
+		t.Error("expected PasswordResetRequired=false for service principal")
+	}
+	// Roles must match BuiltinServiceRoles(ServiceNameInternal).
+	expectedRoles := BuiltinServiceRoles(ServiceNameInternal)
+	if len(p.Roles) != len(expectedRoles) {
+		t.Fatalf("expected %d roles, got %d", len(expectedRoles), len(p.Roles))
+	}
+	for i, r := range expectedRoles {
+		if p.Roles[i] != r {
+			t.Errorf("role[%d]: expected %q, got %q", i, r, p.Roles[i])
+		}
+	}
+	// Roles must be a copy — mutating Principal.Roles must not affect BuiltinServiceRoles.
+	if len(p.Roles) > 0 {
+		original := p.Roles[0]
+		p.Roles[0] = "mutated"
+		fresh := BuiltinServiceRoles(ServiceNameInternal)
+		if fresh[0] != original {
+			t.Error("Principal.Roles must be a defensive copy")
+		}
+	}
+}

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -3,10 +3,13 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // stubAuthenticator is a test double for the Authenticator interface.
@@ -483,5 +486,150 @@ func TestServiceTokenAuthenticator_Success_PrincipalShape(t *testing.T) {
 		if fresh[0] != original {
 			t.Error("Principal.Roles must be a defensive copy")
 		}
+	}
+}
+
+// TestJWTAuthenticator_EmptySubject_Error verifies that a JWT token with an
+// empty "sub" claim is rejected at the Authenticator layer (G1.A primary defence).
+// An empty subject indicates a malformed JWT — downstream code must never
+// receive a PrincipalUser with Subject="".
+func TestJWTAuthenticator_EmptySubject_Error(t *testing.T) {
+	// Verifier succeeds but returns claims with empty Subject.
+	v := &stubVerifier{claims: Claims{
+		Subject:   "",
+		Roles:     []string{"admin"},
+		SessionID: "sess-1",
+		Issuer:    "gocell-issuer",
+		TokenUse:  TokenIntentAccess,
+	}}
+	a := NewJWTAuthenticator(v)
+
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer token-with-empty-sub"))
+	if err == nil {
+		t.Fatal("expected error for JWT with empty subject, got nil")
+	}
+	if ok {
+		t.Fatal("expected ok=false for JWT with empty subject")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal for JWT with empty subject, got %v", p)
+	}
+	// Must be an auth unauthorized error.
+	var ecErr *errcode.Error
+	if !errors.As(err, &ecErr) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ecErr.Code != errcode.ErrAuthUnauthorized {
+		t.Errorf("expected ErrAuthUnauthorized, got %v", ecErr.Code)
+	}
+}
+
+// --- F3: Union cross-bleed test ---
+
+// TestUnionAuthenticator_BearerAndServiceToken_NoCrossBleed verifies that when
+// Union(JWT, ServiceToken) receives "Authorization: ServiceToken <payload>",
+// the JWT authenticator returns absent (nil, false, nil) — because it sees a
+// non-Bearer scheme — and the ServiceToken authenticator validates the
+// credential and returns a valid Principal. No cross-bleed between the two.
+func TestUnionAuthenticator_BearerAndServiceToken_NoCrossBleed(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+
+	// trackingVerifier records whether VerifyIntent was called.
+	// The JWT authenticator short-circuits before calling VerifyIntent when
+	// extractBearerToken returns "" (non-Bearer scheme), so it must NOT be called.
+	verifierCalled := false
+	trackingVerifier := &trackingIntentVerifier{onVerify: func() { verifierCalled = true }}
+
+	jwtAuth := NewJWTAuthenticator(trackingVerifier)
+	svcAuth := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	union := NewUnionAuthenticator(jwtAuth, svcAuth)
+
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+
+	p, ok, err := union.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true: ServiceToken authenticator should have matched")
+	}
+	if p == nil {
+		t.Fatal("expected non-nil principal")
+	}
+	if p.Kind != PrincipalService {
+		t.Errorf("expected Kind=PrincipalService, got %v", p.Kind)
+	}
+	if verifierCalled {
+		t.Error("JWT VerifyIntent must not be called for a ServiceToken header (non-Bearer scheme returns absent before verification)")
+	}
+}
+
+// trackingIntentVerifier is a test double that calls onVerify when VerifyIntent
+// is invoked, then returns zero Claims and nil error.
+type trackingIntentVerifier struct {
+	onVerify func()
+}
+
+func (v *trackingIntentVerifier) VerifyIntent(_ context.Context, _ string, _ TokenIntent) (Claims, error) {
+	if v.onVerify != nil {
+		v.onVerify()
+	}
+	return Claims{}, nil
+}
+
+// --- F4: ServiceToken Authenticator — legacy 2-part + future timestamp ---
+
+// TestServiceTokenAuthenticator_LegacyTwoPart_Error verifies that a 2-part
+// legacy format token is rejected at the Authenticator level (not just via
+// ServiceTokenMiddleware), returning an error that classifies as a 4xx.
+func TestServiceTokenAuthenticator_LegacyTwoPart_Error(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+
+	// Build a 2-part token: {timestamp}:{hex_hmac} (no nonce).
+	tsStr := fmt.Sprintf("%d", now.Unix())
+	legacyToken := tsStr + ":deadbeef00112233"
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+legacyToken)
+
+	p, ok, err := a.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for legacy 2-part token, got nil")
+	}
+	if ok {
+		t.Fatal("expected ok=false for legacy 2-part token")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
+	}
+}
+
+// TestServiceTokenAuthenticator_FutureTimestamp_Error verifies that a token
+// with a timestamp in the future (age > ServiceTokenMaxAge) is rejected.
+func TestServiceTokenAuthenticator_FutureTimestamp_Error(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	// "now" as seen by the authenticator.
+	now := time.Now()
+	// Token is signed 10 minutes in the future relative to the authenticator's clock.
+	futureTime := now.Add(10 * time.Minute)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", futureTime)
+
+	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+
+	p, ok, err := a.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for future timestamp token, got nil")
+	}
+	if ok {
+		t.Fatal("expected ok=false for future timestamp token")
+	}
+	if p != nil {
+		t.Fatalf("expected nil principal, got %v", p)
 	}
 }

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -18,12 +18,19 @@ import (
 // pattern; deviated: combined self+role check instead of separate authz middleware.
 //
 // Errors:
-//   - ErrAuthUnauthorized: no Principal in context (auth middleware did not run)
+//   - ErrAuthUnauthorized: no Principal in context, or PrincipalUser with empty Subject
 //   - ErrAuthForbidden: subject does not match targetID and lacks bypass roles
 func RequireSelfOrRole(ctx context.Context, targetID string, bypassRoles ...string) error {
 	p, ok := FromContext(ctx)
 	if !ok {
 		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
+	}
+	// G1.B: Defence-in-depth. PrincipalUser must always carry a non-empty Subject;
+	// an empty Subject indicates the primary authenticator allowed a malformed token
+	// through. PrincipalService Subject is always ServiceNameInternal (non-empty);
+	// PrincipalAnonymous Subject is intentionally empty by design.
+	if p.Kind == PrincipalUser && p.Subject == "" {
+		return errcode.New(errcode.ErrAuthUnauthorized, "principal subject missing")
 	}
 
 	if targetID == "" {
@@ -64,12 +71,19 @@ func principalHasAnyRole(p *Principal, roles []string) bool {
 // Calling with zero roles always returns ErrAuthForbidden (no role can match).
 //
 // Errors:
-//   - ErrAuthUnauthorized: no Principal in context (auth middleware did not run)
+//   - ErrAuthUnauthorized: no Principal in context, or PrincipalUser with empty Subject
 //   - ErrAuthForbidden: subject does not hold any of the required roles
 func RequireAnyRole(ctx context.Context, roles ...string) error {
 	p, ok := FromContext(ctx)
 	if !ok {
 		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
+	}
+	// G1.B: Defence-in-depth. PrincipalUser must always carry a non-empty Subject;
+	// an empty Subject indicates the primary authenticator allowed a malformed token
+	// through. PrincipalService Subject is always ServiceNameInternal (non-empty);
+	// PrincipalAnonymous Subject is intentionally empty by design.
+	if p.Kind == PrincipalUser && p.Subject == "" {
+		return errcode.New(errcode.ErrAuthUnauthorized, "principal subject missing")
 	}
 
 	if principalHasAnyRole(p, roles) {
@@ -81,11 +95,15 @@ func RequireAnyRole(ctx context.Context, roles ...string) error {
 
 // TestContext creates a context carrying the given subject and roles for use
 // in handler tests across cells/. Follows the net/http/httptest naming pattern.
+//
+// This helper is NOT deprecated; it is the recommended way to inject a
+// Principal in handler tests.
 func TestContext(subject string, roles []string) context.Context {
 	p := &Principal{
-		Kind:    PrincipalUser,
-		Subject: subject,
-		Roles:   append([]string(nil), roles...),
+		Kind:       PrincipalUser,
+		Subject:    subject,
+		Roles:      append([]string(nil), roles...),
+		AuthMethod: "test",
 	}
 	return WithPrincipal(context.Background(), p)
 }

--- a/runtime/auth/authz.go
+++ b/runtime/auth/authz.go
@@ -2,8 +2,8 @@ package auth
 
 import (
 	"context"
+	"slices"
 
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
@@ -18,51 +18,37 @@ import (
 // pattern; deviated: combined self+role check instead of separate authz middleware.
 //
 // Errors:
-//   - ErrAuthUnauthorized: no subject in context (auth middleware did not run)
+//   - ErrAuthUnauthorized: no Principal in context (auth middleware did not run)
 //   - ErrAuthForbidden: subject does not match targetID and lacks bypass roles
 func RequireSelfOrRole(ctx context.Context, targetID string, bypassRoles ...string) error {
-	subject, ok := ctxkeys.SubjectFrom(ctx)
-	if !ok || subject == "" {
+	p, ok := FromContext(ctx)
+	if !ok {
 		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
 	}
 
 	if targetID == "" {
 		loggerFrom(ctx).Warn("authz: RequireSelfOrRole called with empty targetID",
-			"subject", subject)
+			"subject", p.Subject)
 	}
 
-	if targetID != "" && subject == targetID {
+	if targetID != "" && p.Subject == targetID {
 		return nil
 	}
 
-	if hasAnyRole(ctx, bypassRoles) {
+	if principalHasAnyRole(p, bypassRoles) {
 		return nil
 	}
 
 	return errcode.New(errcode.ErrAuthForbidden, "access denied")
 }
 
-// hasAnyRole checks whether the authenticated Claims in ctx carry at least
-// one of the specified roles. Returns false when roles is empty, Claims are
-// absent, or no role matches.
-func hasAnyRole(ctx context.Context, roles []string) bool {
-	if len(roles) == 0 {
+// principalHasAnyRole checks whether p holds at least one of the given roles.
+// Returns false when roles is empty or p is nil.
+func principalHasAnyRole(p *Principal, roles []string) bool {
+	if p == nil || len(roles) == 0 {
 		return false
 	}
-	claims, ok := ClaimsFrom(ctx)
-	if !ok {
-		return false
-	}
-	roleSet := make(map[string]bool, len(roles))
-	for _, r := range roles {
-		roleSet[r] = true
-	}
-	for _, r := range claims.Roles {
-		if roleSet[r] {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(roles, p.HasRole)
 }
 
 // RequireAnyRole checks that the authenticated subject holds at least one of
@@ -78,15 +64,15 @@ func hasAnyRole(ctx context.Context, roles []string) bool {
 // Calling with zero roles always returns ErrAuthForbidden (no role can match).
 //
 // Errors:
-//   - ErrAuthUnauthorized: no subject in context (auth middleware did not run)
+//   - ErrAuthUnauthorized: no Principal in context (auth middleware did not run)
 //   - ErrAuthForbidden: subject does not hold any of the required roles
 func RequireAnyRole(ctx context.Context, roles ...string) error {
-	subject, ok := ctxkeys.SubjectFrom(ctx)
-	if !ok || subject == "" {
+	p, ok := FromContext(ctx)
+	if !ok {
 		return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
 	}
 
-	if hasAnyRole(ctx, roles) {
+	if principalHasAnyRole(p, roles) {
 		return nil
 	}
 
@@ -96,6 +82,10 @@ func RequireAnyRole(ctx context.Context, roles ...string) error {
 // TestContext creates a context carrying the given subject and roles for use
 // in handler tests across cells/. Follows the net/http/httptest naming pattern.
 func TestContext(subject string, roles []string) context.Context {
-	ctx := ctxkeys.WithSubject(context.Background(), subject)
-	return WithClaims(ctx, Claims{Subject: subject, Roles: roles})
+	p := &Principal{
+		Kind:    PrincipalUser,
+		Subject: subject,
+		Roles:   append([]string(nil), roles...),
+	}
+	return WithPrincipal(context.Background(), p)
 }

--- a/runtime/auth/authz_test.go
+++ b/runtime/auth/authz_test.go
@@ -133,11 +133,11 @@ func TestRequireAnyRole(t *testing.T) {
 			wantCode: errcode.ErrAuthUnauthorized,
 		},
 		{
-			name:     "empty string subject still has principal — forbidden if no role",
+			name:     "empty string subject — ErrAuthUnauthorized (subject invariant enforced at authz entry)",
 			ctx:      withPrincipalCtx("", nil),
 			roles:    []string{"admin"},
 			wantErr:  true,
-			wantCode: errcode.ErrAuthForbidden,
+			wantCode: errcode.ErrAuthUnauthorized,
 		},
 		{
 			name:     "empty required roles denied",
@@ -247,6 +247,39 @@ func TestRequireSelfOrRole_RoleMatch_Ok(t *testing.T) {
 	})
 	err := RequireSelfOrRole(ctx, "user-42", "admin")
 	assert.NoError(t, err)
+}
+
+// TestRequireAnyRole_EmptyUserSubject_Unauthorized verifies that a PrincipalUser
+// with an empty Subject is rejected with ErrAuthUnauthorized by RequireAnyRole
+// (G1.B authz-entry defence). This guards against JWTs with missing "sub" claims
+// bypassing the primary authenticator check and reaching authz with empty subject.
+func TestRequireAnyRole_EmptyUserSubject_Unauthorized(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), &Principal{
+		Kind:    PrincipalUser,
+		Subject: "",
+		Roles:   []string{"admin"},
+	})
+	err := RequireAnyRole(ctx, "admin")
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ecErr.Code)
+}
+
+// TestRequireSelfOrRole_EmptyUserSubject_Unauthorized verifies that a PrincipalUser
+// with an empty Subject is rejected with ErrAuthUnauthorized by RequireSelfOrRole
+// (G1.B authz-entry defence).
+func TestRequireSelfOrRole_EmptyUserSubject_Unauthorized(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), &Principal{
+		Kind:    PrincipalUser,
+		Subject: "",
+		Roles:   []string{"admin"},
+	})
+	err := RequireSelfOrRole(ctx, "user-42", "admin")
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ecErr.Code)
 }
 
 // withPrincipalCtx builds a context carrying a PrincipalUser with the given

--- a/runtime/auth/authz_test.go
+++ b/runtime/auth/authz_test.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,21 +23,21 @@ func TestRequireSelfOrRole(t *testing.T) {
 	}{
 		{
 			name:     "self-access allowed",
-			ctx:      withSubjectAndClaims("user-1", nil),
+			ctx:      withPrincipalCtx("user-1", nil),
 			targetID: "user-1",
 			roles:    []string{"admin"},
 			wantErr:  false,
 		},
 		{
 			name:     "admin bypass allowed",
-			ctx:      withSubjectAndClaims("user-2", []string{"admin"}),
+			ctx:      withPrincipalCtx("user-2", []string{"admin"}),
 			targetID: "user-1",
 			roles:    []string{"admin"},
 			wantErr:  false,
 		},
 		{
 			name:     "different user no admin denied",
-			ctx:      withSubjectAndClaims("user-2", []string{"viewer"}),
+			ctx:      withPrincipalCtx("user-2", []string{"viewer"}),
 			targetID: "user-1",
 			roles:    []string{"admin"},
 			wantErr:  true,
@@ -54,7 +53,7 @@ func TestRequireSelfOrRole(t *testing.T) {
 		},
 		{
 			name:     "empty targetID denied",
-			ctx:      withSubjectAndClaims("user-1", nil),
+			ctx:      withPrincipalCtx("user-1", nil),
 			targetID: "",
 			roles:    []string{"admin"},
 			wantErr:  true,
@@ -62,14 +61,14 @@ func TestRequireSelfOrRole(t *testing.T) {
 		},
 		{
 			name:     "multiple bypass roles second matches",
-			ctx:      withSubjectAndClaims("user-2", []string{"operator"}),
+			ctx:      withPrincipalCtx("user-2", []string{"operator"}),
 			targetID: "user-1",
 			roles:    []string{"admin", "operator"},
 			wantErr:  false,
 		},
 		{
 			name:     "no bypass roles specified only self allowed",
-			ctx:      withSubjectAndClaims("user-2", []string{"admin"}),
+			ctx:      withPrincipalCtx("user-2", []string{"admin"}),
 			targetID: "user-1",
 			roles:    nil,
 			wantErr:  true,
@@ -102,47 +101,47 @@ func TestRequireAnyRole(t *testing.T) {
 	}{
 		{
 			name:    "admin role allowed",
-			ctx:     withSubjectAndClaims("user-1", []string{"admin"}),
+			ctx:     withPrincipalCtx("user-1", []string{"admin"}),
 			roles:   []string{"admin"},
 			wantErr: false,
 		},
 		{
 			name:    "second role matches",
-			ctx:     withSubjectAndClaims("user-1", []string{"operator"}),
+			ctx:     withPrincipalCtx("user-1", []string{"operator"}),
 			roles:   []string{"admin", "operator"},
 			wantErr: false,
 		},
 		{
 			name:     "no matching role denied",
-			ctx:      withSubjectAndClaims("user-1", []string{"viewer"}),
+			ctx:      withPrincipalCtx("user-1", []string{"viewer"}),
 			roles:    []string{"admin"},
 			wantErr:  true,
 			wantCode: errcode.ErrAuthForbidden,
 		},
 		{
-			name:     "no roles in claims denied",
-			ctx:      withSubjectAndClaims("user-1", nil),
+			name:     "no roles in principal denied",
+			ctx:      withPrincipalCtx("user-1", nil),
 			roles:    []string{"admin"},
 			wantErr:  true,
 			wantCode: errcode.ErrAuthForbidden,
 		},
 		{
-			name:     "missing subject denied",
+			name:     "missing principal denied",
 			ctx:      context.Background(),
 			roles:    []string{"admin"},
 			wantErr:  true,
 			wantCode: errcode.ErrAuthUnauthorized,
 		},
 		{
-			name:     "empty string subject denied",
-			ctx:      withSubjectAndClaims("", nil),
+			name:     "empty string subject still has principal — forbidden if no role",
+			ctx:      withPrincipalCtx("", nil),
 			roles:    []string{"admin"},
 			wantErr:  true,
-			wantCode: errcode.ErrAuthUnauthorized,
+			wantCode: errcode.ErrAuthForbidden,
 		},
 		{
 			name:     "empty required roles denied",
-			ctx:      withSubjectAndClaims("user-1", []string{"admin"}),
+			ctx:      withPrincipalCtx("user-1", []string{"admin"}),
 			roles:    nil,
 			wantErr:  true,
 			wantCode: errcode.ErrAuthForbidden,
@@ -168,16 +167,94 @@ func TestRequireSelfOrRole_EmptyTargetID_LogsWarning(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 	ctx := withLogger(context.Background(), logger)
-	ctx = ctxkeys.WithSubject(ctx, "user-1")
-	ctx = WithClaims(ctx, Claims{Subject: "user-1", Roles: []string{"admin"}})
+	ctx = WithPrincipal(ctx, &Principal{
+		Kind:    PrincipalUser,
+		Subject: "user-1",
+		Roles:   []string{"admin"},
+	})
 
 	err := RequireSelfOrRole(ctx, "", "admin")
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "empty targetID")
 }
 
-func withSubjectAndClaims(subject string, roles []string) context.Context {
-	ctx := ctxkeys.WithSubject(context.Background(), subject)
-	ctx = WithClaims(ctx, Claims{Subject: subject, Roles: roles})
-	return ctx
+// TestRequireAnyRole_ServicePrincipalAlsoWorks verifies that a service Principal
+// (Kind=PrincipalService) is accepted by RequireAnyRole when its role matches.
+func TestRequireAnyRole_ServicePrincipalAlsoWorks(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), &Principal{
+		Kind:    PrincipalService,
+		Subject: ServiceNameInternal,
+		Roles:   []string{RoleInternalAdmin},
+	})
+	err := RequireAnyRole(ctx, RoleInternalAdmin)
+	assert.NoError(t, err)
+}
+
+// TestRequireAnyRole_NoPrincipal_Unauthorized verifies that a ctx with no
+// Principal returns ErrAuthUnauthorized (401 domain error).
+func TestRequireAnyRole_NoPrincipal_Unauthorized(t *testing.T) {
+	err := RequireAnyRole(context.Background(), "admin")
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ecErr.Code)
+}
+
+// TestRequireAnyRole_PrincipalWithoutRole_Forbidden verifies that a Principal
+// present in ctx but lacking the required role returns ErrAuthForbidden (403).
+func TestRequireAnyRole_PrincipalWithoutRole_Forbidden(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), &Principal{
+		Kind:    PrincipalUser,
+		Subject: "user-1",
+		Roles:   []string{"viewer"},
+	})
+	err := RequireAnyRole(ctx, "admin")
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthForbidden, ecErr.Code)
+}
+
+// TestRequireSelfOrRole_NoPrincipal_Unauthorized verifies that a ctx with no
+// Principal returns ErrAuthUnauthorized.
+func TestRequireSelfOrRole_NoPrincipal_Unauthorized(t *testing.T) {
+	err := RequireSelfOrRole(context.Background(), "user-1", "admin")
+	require.Error(t, err)
+	var ecErr *errcode.Error
+	require.True(t, errors.As(err, &ecErr))
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ecErr.Code)
+}
+
+// TestRequireSelfOrRole_SelfMatch_Ok verifies that a Principal whose Subject
+// matches targetSubject returns nil regardless of roles.
+func TestRequireSelfOrRole_SelfMatch_Ok(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), &Principal{
+		Kind:    PrincipalUser,
+		Subject: "user-42",
+		Roles:   nil,
+	})
+	err := RequireSelfOrRole(ctx, "user-42", "admin")
+	assert.NoError(t, err)
+}
+
+// TestRequireSelfOrRole_RoleMatch_Ok verifies that a Principal whose Subject
+// does not match but holds the required role returns nil.
+func TestRequireSelfOrRole_RoleMatch_Ok(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), &Principal{
+		Kind:    PrincipalUser,
+		Subject: "user-99",
+		Roles:   []string{"admin"},
+	})
+	err := RequireSelfOrRole(ctx, "user-42", "admin")
+	assert.NoError(t, err)
+}
+
+// withPrincipalCtx builds a context carrying a PrincipalUser with the given
+// subject and roles. Used by authz_test table-driven tests.
+func withPrincipalCtx(subject string, roles []string) context.Context {
+	return WithPrincipal(context.Background(), &Principal{
+		Kind:    PrincipalUser,
+		Subject: subject,
+		Roles:   append([]string(nil), roles...),
+	})
 }

--- a/runtime/auth/guard.go
+++ b/runtime/auth/guard.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"net/http"
 
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
@@ -45,12 +44,12 @@ func Secured(h http.HandlerFunc, policy Policy) http.HandlerFunc {
 	}
 }
 
-// Authenticated returns a Policy that requires an authenticated subject
-// (any non-empty subject in context). Use for endpoints that only need
-// to verify a user is logged in, regardless of role.
+// Authenticated returns a Policy that requires an authenticated Principal in
+// context. Use for endpoints that only need to verify a user is logged in,
+// regardless of role. Returns ErrAuthUnauthorized when no Principal is present.
 func Authenticated() Policy {
 	return func(r *http.Request) error {
-		if subject, ok := ctxkeys.SubjectFrom(r.Context()); !ok || subject == "" {
+		if _, ok := FromContext(r.Context()); !ok {
 			return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
 		}
 		return nil

--- a/runtime/auth/guard.go
+++ b/runtime/auth/guard.go
@@ -46,11 +46,20 @@ func Secured(h http.HandlerFunc, policy Policy) http.HandlerFunc {
 
 // Authenticated returns a Policy that requires an authenticated Principal in
 // context. Use for endpoints that only need to verify a user is logged in,
-// regardless of role. Returns ErrAuthUnauthorized when no Principal is present.
+// regardless of role. Returns ErrAuthUnauthorized when no Principal is present
+// or when the Principal is a PrincipalUser with an empty Subject (defence-in-depth
+// against malformed JWT tokens that slip past the primary authenticator).
 func Authenticated() Policy {
 	return func(r *http.Request) error {
-		if _, ok := FromContext(r.Context()); !ok {
+		p, ok := FromContext(r.Context())
+		if !ok {
 			return errcode.New(errcode.ErrAuthUnauthorized, "authentication required")
+		}
+		// G1.B: Defence-in-depth. PrincipalUser must always carry a non-empty
+		// Subject. PrincipalService is always ServiceNameInternal (non-empty);
+		// PrincipalAnonymous Subject is intentionally empty by design.
+		if p.Kind == PrincipalUser && p.Subject == "" {
+			return errcode.New(errcode.ErrAuthUnauthorized, "principal subject missing")
 		}
 		return nil
 	}

--- a/runtime/auth/guard_test.go
+++ b/runtime/auth/guard_test.go
@@ -118,9 +118,10 @@ func TestAuthenticated(t *testing.T) {
 			wantCode: errcode.ErrAuthUnauthorized,
 		},
 		{
-			name:    "principal present with empty subject — authenticated (subject validation is caller's responsibility)",
-			ctx:     WithPrincipal(context.Background(), &Principal{Subject: "", Kind: PrincipalUser}),
-			wantErr: false,
+			name:     "principal present with empty subject — ErrAuthUnauthorized (subject invariant enforced at authz entry)",
+			ctx:      WithPrincipal(context.Background(), &Principal{Subject: "", Kind: PrincipalUser}),
+			wantErr:  true,
+			wantCode: errcode.ErrAuthUnauthorized,
 		},
 	}
 

--- a/runtime/auth/guard_test.go
+++ b/runtime/auth/guard_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,10 +118,9 @@ func TestAuthenticated(t *testing.T) {
 			wantCode: errcode.ErrAuthUnauthorized,
 		},
 		{
-			name:     "empty string subject — ErrAuthUnauthorized",
-			ctx:      ctxkeys.WithSubject(context.Background(), ""),
-			wantErr:  true,
-			wantCode: errcode.ErrAuthUnauthorized,
+			name:    "principal present with empty subject — authenticated (subject validation is caller's responsibility)",
+			ctx:     WithPrincipal(context.Background(), &Principal{Subject: "", Kind: PrincipalUser}),
+			wantErr: false,
 		},
 	}
 

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
@@ -118,7 +117,7 @@ func buildPublicMatcher(publicEndpoints []string, cfg authConfig) func(*http.Req
 
 // handleAuthRequest extracts the bearer token, verifies it (with intent=access
 // when the verifier supports it), records metrics, and either forwards to
-// next with claims attached or writes a 401 response.
+// next with claims and Principal attached or writes a 401 response.
 //
 // Enumeration defense: all verification failures — including
 // ErrAuthInvalidTokenIntent — are mapped to the generic ERR_AUTH_UNAUTHORIZED
@@ -169,8 +168,9 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 		return
 	}
 
-	ctx := WithClaims(r.Context(), claims)
-	ctx = ctxkeys.WithSubject(ctx, claims.Subject)
+	// Inject the unified Principal (F7 wiring).
+	p := jwtClaimsToPrincipal(claims)
+	ctx := WithPrincipal(r.Context(), p)
 	ctx = withLogger(ctx, cfg.logger)
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
@@ -261,23 +261,23 @@ func RequireRole(authorizer Authorizer, roles ...string) func(http.Handler) http
 }
 
 func handleRequireRole(authorizer Authorizer, roles []string, roleSet map[string]bool, next http.Handler, w http.ResponseWriter, r *http.Request) {
-	claims, ok := ClaimsFrom(r.Context())
+	p, ok := FromContext(r.Context())
 	if !ok {
 		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "authentication required")
 		return
 	}
 
-	if hasMatchingRole(claims, roleSet) {
+	if hasMatchingRoleList(p.Roles, roleSet) {
 		next.ServeHTTP(w, r)
 		return
 	}
 
 	if authorizer != nil {
-		allowed, err := checkAuthorizer(authorizer, r, claims.Subject, roles)
+		allowed, err := checkAuthorizer(authorizer, r, p.Subject, roles)
 		if err != nil {
 			loggerFrom(r.Context()).Error("authorization check failed",
 				"error", err,
-				"subject", claims.Subject,
+				"subject", p.Subject,
 			)
 			httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
 			return
@@ -291,8 +291,8 @@ func handleRequireRole(authorizer Authorizer, roles []string, roleSet map[string
 	httputil.WriteError(r.Context(), w, http.StatusForbidden, "ERR_AUTH_FORBIDDEN", "insufficient permissions")
 }
 
-func hasMatchingRole(claims Claims, roleSet map[string]bool) bool {
-	for _, role := range claims.Roles {
+func hasMatchingRoleList(roleList []string, roleSet map[string]bool) bool {
+	for _, role := range roleList {
 		if roleSet[role] {
 			return true
 		}

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -126,9 +126,9 @@ func buildPublicMatcher(publicEndpoints []string, cfg authConfig) func(*http.Req
 // via the "reason" label on the auth_token_verify_total metric (ops-only
 // signal) and in structured logs; it is never forwarded to the HTTP response.
 func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler, verifier IntentTokenVerifier, cfg authConfig) {
-	token := extractBearerToken(r)
+	token, reason := extractBearerTokenWithReason(r)
 	if token == "" {
-		cfg.metrics.recordTokenVerifyCounter("failure", "missing")
+		cfg.metrics.recordTokenVerifyCounter("failure", reason)
 		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "missing or invalid authorization header")
 		return
 	}
@@ -164,6 +164,11 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 	// their password and obtains a new token without the claim. If no matcher
 	// is wired, the gate rejects every request — fail-closed default.
 	if claims.PasswordResetRequired && !isPasswordResetExempt(cfg, r.Method, r.URL.Path) {
+		cfg.logger.Info("auth: password reset required gate blocked request",
+			"subject", claims.Subject,
+			"path", r.URL.Path,
+			"method", r.Method,
+		)
 		writePasswordResetRequired(w, cfg.passwordResetChangeEndpointHint)
 		return
 	}
@@ -313,14 +318,27 @@ func checkAuthorizer(authorizer Authorizer, r *http.Request, subject string, rol
 	return false, nil
 }
 
-func extractBearerToken(r *http.Request) string {
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		return ""
+// extractBearerTokenWithReason returns the raw Bearer token value and a
+// human-readable reason string for observability. When the token is absent the
+// reason is one of:
+//
+//   - "missing"      — no Authorization header at all
+//   - "wrong_scheme" — Authorization header present but non-Bearer scheme
+//
+// When a token is found, reason is "".
+func extractBearerTokenWithReason(r *http.Request) (token, reason string) {
+	raw := r.Header.Get("Authorization")
+	if raw == "" {
+		return "", "missing"
 	}
-	parts := strings.SplitN(auth, " ", 2)
+	parts := strings.SplitN(raw, " ", 2)
 	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
-		return ""
+		return "", "wrong_scheme"
 	}
-	return strings.TrimSpace(parts[1])
+	return strings.TrimSpace(parts[1]), ""
+}
+
+func extractBearerToken(r *http.Request) string {
+	token, _ := extractBearerTokenWithReason(r)
+	return token
 }

--- a/runtime/auth/middleware_intent_test.go
+++ b/runtime/auth/middleware_intent_test.go
@@ -43,10 +43,10 @@ func TestAuthMiddleware_CallsVerifyIntentWithAccessExpectation(t *testing.T) {
 		accessClaims: Claims{Subject: "u1", Roles: []string{"user"}, TokenUse: TokenIntentAccess},
 	}
 	handler := AuthMiddleware(verifier, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		claims, ok := ClaimsFrom(r.Context())
+		p, ok := FromContext(r.Context())
 		assert.True(t, ok)
-		assert.Equal(t, "u1", claims.Subject)
-		assert.Equal(t, TokenIntentAccess, claims.TokenUse)
+		assert.Equal(t, "u1", p.Subject)
+		assert.Equal(t, string(TokenIntentAccess), p.Claims["token_use"])
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/stretchr/testify/assert"
@@ -46,13 +45,9 @@ func TestAuthMiddleware_ValidToken(t *testing.T) {
 		claims: Claims{Subject: "user-1", Roles: []string{"admin"}},
 	}
 	handler := AuthMiddleware(verifier, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		claims, ok := ClaimsFrom(r.Context())
+		p, ok := FromContext(r.Context())
 		assert.True(t, ok)
-		assert.Equal(t, "user-1", claims.Subject)
-
-		sub, ok := ctxkeys.SubjectFrom(r.Context())
-		assert.True(t, ok)
-		assert.Equal(t, "user-1", sub)
+		assert.Equal(t, "user-1", p.Subject)
 
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -215,7 +210,7 @@ func TestRequireRole_HasRole(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	ctx := WithClaims(req.Context(), Claims{Subject: "u1", Roles: []string{"admin", "user"}})
+	ctx := WithPrincipal(req.Context(), &Principal{Kind: PrincipalUser, Subject: "u1", Roles: []string{"admin", "user"}})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -229,7 +224,7 @@ func TestRequireRole_MissingRole(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	ctx := WithClaims(req.Context(), Claims{Subject: "u1", Roles: []string{"user"}})
+	ctx := WithPrincipal(req.Context(), &Principal{Kind: PrincipalUser, Subject: "u1", Roles: []string{"user"}})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -238,7 +233,7 @@ func TestRequireRole_MissingRole(t *testing.T) {
 	assertErrorCode(t, rec, "ERR_AUTH_FORBIDDEN")
 }
 
-func TestRequireRole_NoClaims(t *testing.T) {
+func TestRequireRole_NoPrincipal(t *testing.T) {
 	handler := RequireRole(nil, "admin")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -257,7 +252,7 @@ func TestRequireRole_AuthorizerFallback(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
-	ctx := WithClaims(req.Context(), Claims{Subject: "u1", Roles: []string{"viewer"}})
+	ctx := WithPrincipal(req.Context(), &Principal{Kind: PrincipalUser, Subject: "u1", Roles: []string{"viewer"}})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -272,7 +267,7 @@ func TestRequireRole_AuthorizerError(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	ctx := WithClaims(req.Context(), Claims{Subject: "u1", Roles: []string{"user"}})
+	ctx := WithPrincipal(req.Context(), &Principal{Kind: PrincipalUser, Subject: "u1", Roles: []string{"user"}})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -864,6 +859,118 @@ func TestAuthMiddleware_NilDelegatedMatcher_NoEffect(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"without WithDelegatedMatcher, even /internal/v1/* paths must require JWT")
+}
+
+// --- T4: Principal injection tests ---
+
+// TestAuthMiddleware_InjectsPrincipal verifies that a valid JWT causes the
+// middleware to inject a Principal into the request context with the correct
+// fields populated from the JWT claims.
+func TestAuthMiddleware_InjectsPrincipal(t *testing.T) {
+	verifier := &mockVerifier{
+		claims: Claims{
+			Subject:               "user-42",
+			Roles:                 []string{"admin", "editor"},
+			SessionID:             "sess-abc",
+			Issuer:                "gocell-issuer",
+			TokenUse:              TokenIntentAccess,
+			PasswordResetRequired: false,
+		},
+	}
+	var gotPrincipal *Principal
+	handler := AuthMiddleware(verifier, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p, ok := FromContext(r.Context())
+		require.True(t, ok, "Principal must be present in context after successful auth")
+		gotPrincipal = p
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, gotPrincipal)
+	assert.Equal(t, PrincipalUser, gotPrincipal.Kind)
+	assert.Equal(t, "user-42", gotPrincipal.Subject)
+	assert.ElementsMatch(t, []string{"admin", "editor"}, gotPrincipal.Roles)
+	assert.Equal(t, "jwt", gotPrincipal.AuthMethod)
+	assert.False(t, gotPrincipal.PasswordResetRequired)
+	assert.Equal(t, "sess-abc", gotPrincipal.Claims["sid"])
+	assert.Equal(t, "gocell-issuer", gotPrincipal.Claims["iss"])
+	assert.Equal(t, string(TokenIntentAccess), gotPrincipal.Claims["token_use"])
+}
+
+// TestAuthMiddleware_InjectsPrincipal_PasswordResetRequired verifies that
+// PasswordResetRequired=true is propagated to the injected Principal.
+func TestAuthMiddleware_InjectsPrincipal_PasswordResetRequired(t *testing.T) {
+	verifier := &mockVerifier{
+		claims: Claims{
+			Subject:               "usr-bootstrap",
+			PasswordResetRequired: true,
+		},
+	}
+	handler := AuthMiddleware(verifier, nil,
+		WithPasswordResetExemptMatcher(func(method, path string) bool {
+			return method == http.MethodPost && path == "/api/v1/access/users/usr-bootstrap/password"
+		}),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p, ok := FromContext(r.Context())
+		require.True(t, ok)
+		assert.True(t, p.PasswordResetRequired)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/users/usr-bootstrap/password", nil)
+	req.Header.Set("Authorization", "Bearer reset-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestAuthMiddleware_NoPrincipalOnUnauth verifies that on a public endpoint
+// (skipped by the middleware), no Principal is injected into context.
+// Public endpoints do not authenticate — callers on public endpoints get
+// (nil, false) from FromContext, consistent with Kratos selector style.
+func TestAuthMiddleware_NoPrincipalOnUnauth(t *testing.T) {
+	verifier := &mockVerifier{err: fmt.Errorf("must not be called")}
+	handler := AuthMiddleware(verifier, []string{"/public/path"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p, ok := FromContext(r.Context())
+			assert.False(t, ok, "public endpoint must not have Principal in context")
+			assert.Nil(t, p)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/public/path", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestRequireRole_ReadsPrincipalFromContext verifies that RequireRole resolves
+// roles exclusively from the Principal (T6: Claims fallback removed).
+func TestRequireRole_ReadsPrincipalFromContext(t *testing.T) {
+	handler := RequireRole(nil, "admin")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	// Inject Principal only — no Claims needed after T6.
+	ctx := WithPrincipal(req.Context(), &Principal{
+		Kind:    PrincipalUser,
+		Subject: "u1",
+		Roles:   []string{"admin", "user"},
+	})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 // --- matchPathTemplate unit tests ---

--- a/runtime/auth/principal.go
+++ b/runtime/auth/principal.go
@@ -8,13 +8,19 @@ import (
 type PrincipalKind int
 
 const (
-	PrincipalUser      PrincipalKind = iota // JWT user
-	PrincipalService                        // service token / mTLS machine
-	PrincipalAnonymous                      // public endpoint
+	// PrincipalUnknown is the zero value of PrincipalKind; it indicates an
+	// uninitialised Principal and must never appear in a fully-constructed
+	// Principal returned by an Authenticator.
+	PrincipalUnknown   PrincipalKind = iota
+	PrincipalUser                    // JWT user
+	PrincipalService                 // service token / mTLS machine
+	PrincipalAnonymous               // public endpoint
 )
 
 func (k PrincipalKind) String() string {
 	switch k {
+	case PrincipalUnknown:
+		return "unknown"
 	case PrincipalUser:
 		return "user"
 	case PrincipalService:
@@ -27,19 +33,20 @@ func (k PrincipalKind) String() string {
 }
 
 // Principal is the unified authn subject injected into request context after
-// successful authentication. Claims is treated as read-only after construction;
-// callers must not mutate the map (concurrent reads only).
-//
-// Principal supersedes the legacy Claims context value (see Claims in auth.go);
-// AuthMiddleware will inject Principal once F7 wiring lands. New handlers should
-// consume FromContext rather than reading Claims directly.
+// successful authentication. AuthMiddleware and ServiceTokenMiddleware both
+// populate Principal via WithPrincipal; handlers consume it via FromContext.
+// Principal is the authoritative authn context for all business routes (F1/F7).
 type Principal struct {
 	Kind                  PrincipalKind
 	Subject               string
 	Roles                 []string
 	AuthMethod            string
 	PasswordResetRequired bool
-	Claims                map[string]string
+	// Claims is a read-only snapshot of supplementary JWT claims (e.g. "sid",
+	// "iss", "token_use"). Callers must treat Claims as a read-only snapshot;
+	// mutating it has no effect on authentication decisions and may corrupt
+	// shared state.
+	Claims map[string]string
 }
 
 // HasRole is nil-safe: a nil receiver always returns false.
@@ -66,6 +73,11 @@ func FromContext(ctx context.Context) (*Principal, bool) {
 	if p == nil {
 		return nil, false
 	}
+	if p.Kind == PrincipalUnknown {
+		// Zero-value Principal was stored; treat as absent to prevent
+		// uninitialised structs from leaking through as valid principals.
+		return nil, false
+	}
 	return p, true
 }
 
@@ -87,9 +99,9 @@ const (
 )
 
 // BuiltinServiceRoles returns the compile-time hard-coded role set for
-// well-known internal services. Dynamic, configurable service roles will be
-// resolved via config.Registry once F1 lands; treat this as a temporary
-// bootstrap until then.
+// well-known internal services. Dynamic, configurable service roles are
+// resolved via config.Registry (F1, PR#197); the compile-time set here covers
+// bootstrap and test scenarios where the registry is not available.
 func BuiltinServiceRoles(name string) []string {
 	switch name {
 	case ServiceNameInternal:

--- a/runtime/auth/principal.go
+++ b/runtime/auth/principal.go
@@ -34,11 +34,12 @@ func (k PrincipalKind) String() string {
 // AuthMiddleware will inject Principal once F7 wiring lands. New handlers should
 // consume FromContext rather than reading Claims directly.
 type Principal struct {
-	Kind       PrincipalKind
-	Subject    string
-	Roles      []string
-	AuthMethod string
-	Claims     map[string]string
+	Kind                  PrincipalKind
+	Subject               string
+	Roles                 []string
+	AuthMethod            string
+	PasswordResetRequired bool
+	Claims                map[string]string
 }
 
 // HasRole is nil-safe: a nil receiver always returns false.

--- a/runtime/auth/principal_test.go
+++ b/runtime/auth/principal_test.go
@@ -104,6 +104,25 @@ func TestMustFromContext_Panics(t *testing.T) {
 	MustFromContext(context.Background())
 }
 
+func TestPrincipal_PasswordResetRequired_DefaultFalse(t *testing.T) {
+	var p Principal
+	if p.PasswordResetRequired {
+		t.Error("zero-value Principal.PasswordResetRequired must be false")
+	}
+}
+
+func TestPrincipal_PasswordResetRequired_RoundTrip(t *testing.T) {
+	original := &Principal{Kind: PrincipalUser, PasswordResetRequired: true}
+	ctx := WithPrincipal(context.Background(), original)
+	got, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("expected ok=true from FromContext")
+	}
+	if !got.PasswordResetRequired {
+		t.Error("PasswordResetRequired must survive WithPrincipal/FromContext round-trip")
+	}
+}
+
 func TestBuiltinServiceRoles(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -252,7 +252,17 @@ func handleServiceToken(cfg serviceTokenConfig, ring *HMACKeyRing, next http.Han
 	}
 
 	cfg.metrics.recordServiceVerify("success", "ok")
-	next.ServeHTTP(w, r)
+
+	// Inject the unified service Principal (F7/T5 wiring).
+	roles := append([]string(nil), BuiltinServiceRoles(ServiceNameInternal)...)
+	p := &Principal{
+		Kind:       PrincipalService,
+		Subject:    ServiceNameInternal,
+		Roles:      roles,
+		AuthMethod: "service_token",
+	}
+	ctx := WithPrincipal(r.Context(), p)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // checkNonceReplay handles nonce-based replay detection. Returns true if the

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -161,6 +161,9 @@ func LoadHMACKeyRingFromEnv() (*HMACKeyRing, error) {
 //
 // Verification tries each secret in the key ring in order (current, then
 // previous). Tokens older than 5 minutes (exclusive boundary) are rejected.
+//
+// Principal construction is fully delegated to NewServiceTokenAuthenticator
+// so that the service identity shape is defined in a single place.
 func ServiceTokenMiddleware(ring *HMACKeyRing, opts ...ServiceTokenOption) func(http.Handler) http.Handler {
 	cfg := serviceTokenConfig{now: time.Now, logger: slog.Default()}
 	for _, o := range opts {
@@ -176,16 +179,26 @@ func ServiceTokenMiddleware(ring *HMACKeyRing, opts ...ServiceTokenOption) func(
 			})
 		}
 	}
+
+	// Construct a single Authenticator instance for the lifetime of this
+	// middleware. All validation and Principal construction is delegated here,
+	// eliminating the previously duplicated logic in handleServiceToken.
+	auth := NewServiceTokenAuthenticator(ring, opts...)
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handleServiceToken(cfg, ring, next, w, r)
+			handleServiceToken(cfg, auth, next, w, r)
 		})
 	}
 }
 
 // handleServiceToken contains all request-handling logic extracted from
 // ServiceTokenMiddleware to reduce cognitive complexity.
-func handleServiceToken(cfg serviceTokenConfig, ring *HMACKeyRing, next http.Handler, w http.ResponseWriter, r *http.Request) {
+// Validation and Principal construction are fully delegated to the provided
+// Authenticator (NewServiceTokenAuthenticator); this function maps the returned
+// error to granular metrics labels and HTTP responses, preserving all existing
+// metric reason labels and HTTP status codes.
+func handleServiceToken(cfg serviceTokenConfig, auth Authenticator, next http.Handler, w http.ResponseWriter, r *http.Request) {
 	token := extractServiceToken(r)
 	if token == "" {
 		cfg.metrics.recordServiceVerify("failure", "missing")
@@ -193,97 +206,78 @@ func handleServiceToken(cfg serviceTokenConfig, ring *HMACKeyRing, next http.Han
 		return
 	}
 
-	parts := strings.SplitN(token, ":", 3)
-	if len(parts) == 2 {
-		// 2-part legacy format ({timestamp}:{hex_hmac}) — no nonce, always rejected.
-		// Recorded separately so ops can observe residual legacy token traffic.
-		cfg.metrics.recordServiceVerify("failure", "legacy_format")
+	// Log legacy 2-part format before validation so ops can observe the traffic.
+	if parts := strings.SplitN(token, ":", 3); len(parts) == 2 {
 		cfg.logger.WarnContext(r.Context(), "legacy service token format rejected",
 			slog.String("path", r.URL.Path),
 			slog.String("format", "2-part"),
 		)
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", msgInvalidServiceTokenFormat)
-		return
-	}
-	if len(parts) != 3 {
-		cfg.metrics.recordServiceVerify("failure", "invalid_format")
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", msgInvalidServiceTokenFormat)
-		return
 	}
 
-	tsStr := parts[0]
-	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	p, ok, err := auth.Authenticate(r)
 	if err != nil {
-		cfg.metrics.recordServiceVerify("failure", "invalid_format")
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token timestamp")
+		writeServiceTokenError(cfg, err, w, r)
 		return
 	}
-
-	now := cfg.now()
-	tokenTime := time.Unix(ts, 0)
-	age := now.Sub(tokenTime)
-	if age < 0 {
-		age = -age
-	}
-	if age >= ServiceTokenMaxAge {
-		cfg.metrics.recordServiceVerify("failure", "expired")
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token expired")
-		return
-	}
-
-	nonce, sigHex := parts[1], parts[2]
-	message := buildServiceTokenMessage(r.Method, r.URL.Path, r.URL.RawQuery, tsStr, nonce)
-
-	providedMAC, err := hex.DecodeString(sigHex)
-	if err != nil {
-		cfg.metrics.recordServiceVerify("failure", "invalid_format")
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", msgInvalidServiceTokenFormat)
-		return
-	}
-
-	if !verifyServiceTokenMAC(ring, message, providedMAC) {
-		cfg.metrics.recordServiceVerify("failure", "invalid_mac")
-		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
-		return
-	}
-
-	if blocked := checkNonceReplay(cfg, nonce, w, r); blocked {
+	if !ok {
+		// Absent: no ServiceToken header (already handled by extractServiceToken
+		// above, so this branch is a safety net for unexpected absent outcomes).
+		cfg.metrics.recordServiceVerify("failure", "missing")
+		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "missing service token")
 		return
 	}
 
 	cfg.metrics.recordServiceVerify("success", "ok")
-
-	// Inject the unified service Principal (F7/T5 wiring).
-	roles := append([]string(nil), BuiltinServiceRoles(ServiceNameInternal)...)
-	p := &Principal{
-		Kind:       PrincipalService,
-		Subject:    ServiceNameInternal,
-		Roles:      roles,
-		AuthMethod: "service_token",
-	}
 	ctx := WithPrincipal(r.Context(), p)
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// checkNonceReplay handles nonce-based replay detection. Returns true if the
-// request was blocked (response already written).
-func checkNonceReplay(cfg serviceTokenConfig, nonce string, w http.ResponseWriter, r *http.Request) bool {
-	if cfg.nonceStore == nil {
-		return false
-	}
-	err := cfg.nonceStore.CheckAndMark(r.Context(), nonce)
-	if err == nil {
-		return false
-	}
+// writeServiceTokenError maps a verifyServiceTokenPayload error to granular
+// metrics labels and the appropriate HTTP response. It preserves the
+// middleware's split between 401 (auth failures, replay) and 500 (nonce store
+// infrastructure failures) by inspecting the wrapped Cause.
+func writeServiceTokenError(cfg serviceTokenConfig, err error, w http.ResponseWriter, r *http.Request) {
+	// errors.Is traverses the full chain, so ErrNonceReused in the Cause matches.
 	if errors.Is(err, ErrNonceReused) {
 		cfg.metrics.recordServiceVerify("failure", "replay")
 		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "service token replay detected")
-	} else {
-		cfg.metrics.recordServiceVerify("failure", "nonce_store_error")
-		cfg.logger.Error("nonce store check failed", slog.Any("error", err))
-		httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
+		return
 	}
-	return true
+
+	// If the error has a Cause (wrapped by WrapAuth for nonce check failures)
+	// that is NOT ErrNonceReused, it is a nonce store infrastructure failure.
+	var ec *errcode.Error
+	if errors.As(err, &ec) && ec.Cause != nil {
+		cfg.metrics.recordServiceVerify("failure", "nonce_store_error")
+		cfg.logger.Error("nonce store check failed", slog.Any("error", ec.Cause))
+		httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", "internal server error")
+		return
+	}
+
+	// Classify remaining auth errors by their message for metric granularity.
+	reason := classifyServiceTokenVerifyError(err)
+	cfg.metrics.recordServiceVerify("failure", reason)
+	httputil.WriteError(r.Context(), w, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED", "invalid service token")
+}
+
+// classifyServiceTokenVerifyError maps a verifyServiceTokenPayload error to a
+// metric reason label. This mirrors the legacy per-branch labels from the
+// original handleServiceToken implementation.
+func classifyServiceTokenVerifyError(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "legacy 2-part"):
+		return "legacy_format"
+	case strings.Contains(msg, "expired"):
+		return "expired"
+	case strings.Contains(msg, "invalid service token MAC"):
+		return "invalid_mac"
+	default:
+		return "invalid_format"
+	}
 }
 
 // verifyServiceTokenMAC checks whether the provided MAC is valid for message

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -627,6 +627,40 @@ func TestServiceTokenMiddleware_QueryBoundInSignature(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec2.Code)
 }
 
+// --- T5: ServicePrincipal injection tests ---
+
+// TestServiceTokenMiddleware_InjectsServicePrincipal verifies that a valid
+// ServiceToken causes the middleware to inject a Principal into the request
+// context with the correct service identity fields.
+func TestServiceTokenMiddleware_InjectsServicePrincipal(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
+
+	var gotPrincipal *Principal
+	handler := ServiceTokenMiddleware(ring, WithServiceTokenClock(func() time.Time { return now }))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p, ok := FromContext(r.Context())
+			require.True(t, ok, "Principal must be present in context after valid service token")
+			gotPrincipal = p
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, gotPrincipal)
+	assert.Equal(t, PrincipalService, gotPrincipal.Kind)
+	assert.Equal(t, ServiceNameInternal, gotPrincipal.Subject)
+	assert.Contains(t, gotPrincipal.Roles, RoleInternalAdmin)
+	assert.Equal(t, "service_token", gotPrincipal.AuthMethod)
+	assert.False(t, gotPrincipal.PasswordResetRequired)
+}
+
 func TestCanonicalQuery_SortsKeys(t *testing.T) {
 	assert.Equal(t, "a=1&b=2", canonicalQuery("b=2&a=1"))
 	assert.Equal(t, "", canonicalQuery(""))

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -787,9 +787,9 @@ func TestWithAuthMiddleware_ProtectedRoute_ValidToken_Returns200(t *testing.T) {
 
 	var gotSubject string
 	r.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		claims, ok := auth.ClaimsFrom(req.Context())
-		assert.True(t, ok, "claims must be in context")
-		gotSubject = claims.Subject
+		p, ok := auth.FromContext(req.Context())
+		assert.True(t, ok, "principal must be in context")
+		gotSubject = p.Subject
 		w.WriteHeader(http.StatusOK)
 	}))
 


### PR DESCRIPTION
## 背景

当前 GoCell authn 有三条互斥通道：JWT middleware 写 \`ctx.Claims\`、ServiceToken middleware 不写任何身份、handler 读 \`ctx.Subject\` 或 \`ctx.Claims\` 两条路径。后果：\`/internal/v1/access/roles/assign\` 走 service token 时，downstream \`RequireAnyRole\` 读 JWT claims 得到空 → 401/403（走得通但用不上）。

F7 作为 Wave 0 基石件：统一所有 authn 路径产出 \`Principal\`，handler 只从 ctx 读 Principal，JWT/ServiceToken/未来 mTLS 行为对齐。F7 是 F3 Selector 和 F4 RouteGroup 的前置。

## 关键决策

| # | 决策 | 选择 |
|---|------|------|
| Q1 | password_reset_required 承载 | Principal 加 \`PasswordResetRequired bool\` 强类型字段 |
| Q2 | \`WithClaims\` / \`ClaimsFrom\` ctx helper | **删除导出**（Claims struct 保留作 verifier 返回类型） |
| Q3 | \`ctxkeys.WithSubject\` / \`SubjectFrom\` | **本 PR 一并下线** + 迁移 3 个下游 handler |
| Q4 / R-B3 | UnionAuthenticator 是否生产启用 | **仅交付接口 + 单测**，bootstrap 不装；F3/F4 需要同链 chain-fallback 时再 wiring |
| Q5 | Principal.Claims map 内容 | 仅放 \`sid\` / \`iss\` / \`token_use\` 三项扁平审计元信息 |

## 改动摘要

### 新增
- \`runtime/auth/authenticator.go\` — Authenticator interface + AuthenticatorFunc + UnionAuthenticator + NewJWTAuthenticator + NewServiceTokenAuthenticator
- \`runtime/auth/authenticator_test.go\` — 17 个测试用例

### 重构（runtime/auth）
- \`principal.go\` — Principal struct 加 \`PasswordResetRequired bool\`
- \`middleware.go\` — handleAuthRequest 调 Authenticator.Authenticate；password-reset gate 读 \`p.PasswordResetRequired\`；成功注入 Principal；handleRequireRole 改用 \`p.HasRole\`
- \`servicetoken.go\` — handleServiceToken 成功分支注入 service Principal (\`Subject=gocell-internal, Roles=[role:internal-admin], AuthMethod=service_token\`)
- \`authz.go\` — RequireAnyRole / RequireSelfOrRole / TestContext 切 Principal；hasAnyRole 改用 \`slices.ContainsFunc\`
- \`auth.go\` — 删除 \`WithClaims\` / \`ClaimsFrom\` / \`claimsKey\` 三个导出
- \`guard.go\` — Authenticated 改读 FromContext

### 下游迁移（ctxkeys.Subject 下线）
- \`cells/access-core/slices/sessionlogout/handler.go\` — SubjectFrom → FromContext
- \`cells/access-core/slices/identitymanage/handler.go\` — 同上
- \`cells/audit-core/slices/auditquery/handler.go\` — 同上
- \`pkg/ctxkeys\` 保留其他 8 个 key（CellID/SliceID/CorrelationID 等），仅删 Subject 相关（\`Subject\` 常量 / \`WithSubject\` / \`SubjectFrom\`）

## 对标参考

- \`ref: kubernetes/apiserver pkg/authentication/request/union/union.go\` — Union 三元语义 (FailOnError=true)
- \`ref: kubernetes/apiserver pkg/authentication/user/user.go\` — user.Info 用户/机器统一建模
- \`ref: kubernetes/apiserver pkg/endpoints/request/context.go\` — \`UserFrom\` comma-ok 读取惯例
- \`ref: go-kratos/kratos middleware/auth/jwt\` — unexported ctx key (\`type principalKey struct{}\`)
- \`ref: grpc-ecosystem/go-grpc-middleware interceptors/auth/auth.go\` — AuthFunc 返回 newCtx 模式

## 验证

- \`go test ./runtime/auth/... -count=1 -race\` → pass
- \`go test -tags=integration ./... -count=1\` → pass（2 处 pre-existing flake：\`TxManager\` / \`AtomicWithOutbox\` testcontainer 启动时序，retry 全 pass，与 F7 无关）
- \`go build -tags=integration ./...\` → 0 error
- \`golangci-lint run --new-from-rev=origin/develop\` → 0 issues
- grep 回归 \`auth\\.WithClaims\\|auth\\.ClaimsFrom\\|ctxkeys\\.WithSubject\\|ctxkeys\\.SubjectFrom\` → 0 命中

## 工时与范围

- 预估 4h → 实际 ~7.5h（T0-T9），超支原因：Q3 一并下线 ctxkeys.Subject 扩大到 3 handler 迁移（+1.5h）、TDD 全量测试覆盖（+1h）、Q2 导出删除扩散测试文件（+0.4h）

## 范围外（未本 PR 处理）

- \`runtime/http/router/router_test.go\` 中 10 条 pre-existing lint warnings（nhooyr.io/websocket 弃用迁移到 coder/websocket、Go 1.24 \`strings.SplitSeq\` 惯用法）— 与本 PR 无关，本 PR 单行修改未触发行号漂移，\`--new-from-rev=origin/develop\` 0 new issues
- UnionAuthenticator 的生产 bootstrap wiring — 留给 F3 Selector / F4 RouteGroup PR

## Test plan

- [x] runtime/auth 包全单测 race detector 通过
- [x] 全库 integration test 通过（含 testcontainer 集测）
- [x] lint new-from-rev 0 issues
- [x] grep 回归 0 命中
- [x] \`/internal/v1/access/roles/assign\` 走 service token → 200 (auth_integration_test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)