### PR TITLE
refactor(crypto): KeyProvider interfaces → kernel/crypto (R1b)

### DIFF
--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/cells/config-core/slices/featureflag"
 	"github.com/ghbvf/gocell/cells/config-core/slices/flagwrite"
 	"github.com/ghbvf/gocell/kernel/cell"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -83,7 +84,7 @@ func WithInMemoryDefaults() Option {
 // WithKeyProvider sets the KeyProvider for sensitive config value encryption.
 // The provider is used to construct a ValueTransformer that encrypts/decrypts
 // sensitive=true values at the repository boundary.
-func WithKeyProvider(p crypto.KeyProvider) Option {
+func WithKeyProvider(p kcrypto.KeyProvider) Option {
 	return func(c *ConfigCore) {
 		c.keyProvider = p
 		c.valueTransformer = crypto.NewValueTransformer(p)
@@ -92,7 +93,7 @@ func WithKeyProvider(p crypto.KeyProvider) Option {
 
 // WithValueTransformer sets the ValueTransformer directly (alternative to
 // WithKeyProvider; useful in tests that inject a pre-built transformer).
-func WithValueTransformer(t crypto.ValueTransformer) Option {
+func WithValueTransformer(t kcrypto.ValueTransformer) Option {
 	return func(c *ConfigCore) { c.valueTransformer = t }
 }
 
@@ -135,8 +136,8 @@ type ConfigCore struct {
 	txRunner         persistence.TxRunner
 	cursorCodec      *query.CursorCodec
 	logger           *slog.Logger
-	keyProvider      crypto.KeyProvider
-	valueTransformer crypto.ValueTransformer
+	keyProvider      kcrypto.KeyProvider
+	valueTransformer kcrypto.ValueTransformer
 	pgPool           *pgxpool.Pool // stored by WithPostgresDefaults for deferred Init()
 
 	// Slice services and handlers.

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	configcrypto "github.com/ghbvf/gocell/cells/config-core/internal/crypto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
@@ -94,7 +95,7 @@ func (r *ConfigRepository) encryptValue(ctx context.Context, key, value string) 
 		return nil, "", nil, nil, errcode.New(errcode.ErrConfigKeyMissing,
 			"config repo: no ValueTransformer configured for sensitive entry")
 	}
-	aad := kcrypto.AADForConfig(cellID, key)
+	aad := configcrypto.AADForConfig(cellID, key)
 	ct, keyID, nonce, edk, err = r.transformer.Encrypt(ctx, []byte(value), aad)
 	if err != nil {
 		return nil, "", nil, nil, fmt.Errorf("config repo: encrypt value for key %s: %w", key, err)
@@ -109,7 +110,7 @@ func (r *ConfigRepository) decryptValue(ctx context.Context, key string, ct []by
 		return "", errcode.New(errcode.ErrConfigDecryptFailed,
 			"config repo: no ValueTransformer configured, cannot decrypt sensitive value")
 	}
-	aad := kcrypto.AADForConfig(cellID, key)
+	aad := configcrypto.AADForConfig(cellID, key)
 	pt, err := r.transformer.Decrypt(ctx, ct, keyID, nonce, edk, aad)
 	if err != nil {
 		return "", errcode.Wrap(errcode.ErrConfigDecryptFailed,

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -14,7 +14,6 @@ import (
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
-	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -54,7 +53,7 @@ var _ ports.ConfigRepository = (*ConfigRepository)(nil)
 type ConfigRepository struct {
 	db          DBTX     // test-only: set by newConfigRepositoryFromDBTX (unexported helper in test file)
 	session     *Session // production path: resolves ambient tx via persistence.TxCtxKey
-	transformer crypto.ValueTransformer
+	transformer kcrypto.ValueTransformer
 }
 
 // NewConfigRepository creates a ConfigRepository that resolves the ambient
@@ -63,7 +62,7 @@ type ConfigRepository struct {
 // use the unexported newConfigRepositoryFromDBTX in tests.
 //
 // Requires migrations 001–010 to be applied first (see adapters/postgres/migrations/).
-func NewConfigRepository(s *Session, tr crypto.ValueTransformer) *ConfigRepository {
+func NewConfigRepository(s *Session, tr kcrypto.ValueTransformer) *ConfigRepository {
 	return &ConfigRepository{session: s, transformer: tr}
 }
 
@@ -232,11 +231,11 @@ func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.Co
 
 // currentKeyID returns the ID of the current key from the transformer.
 // Returns "" if the transformer does not support key introspection or fails.
-// Discovery is via the optional crypto.CurrentKeyIDProvider extension
+// Discovery is via the optional kcrypto.CurrentKeyIDProvider extension
 // interface — NoopTransformer does not implement it, so staleness is never
 // computed for non-sensitive values.
 func (r *ConfigRepository) currentKeyID(ctx context.Context) string {
-	if c, ok := r.transformer.(crypto.CurrentKeyIDProvider); ok {
+	if c, ok := r.transformer.(kcrypto.CurrentKeyIDProvider); ok {
 		id, err := c.CurrentKeyID(ctx)
 		if err != nil {
 			return ""

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/crypto"
@@ -94,7 +95,7 @@ func (r *ConfigRepository) encryptValue(ctx context.Context, key, value string) 
 		return nil, "", nil, nil, errcode.New(errcode.ErrConfigKeyMissing,
 			"config repo: no ValueTransformer configured for sensitive entry")
 	}
-	aad := crypto.AADForConfig(cellID, key)
+	aad := kcrypto.AADForConfig(cellID, key)
 	ct, keyID, nonce, edk, err = r.transformer.Encrypt(ctx, []byte(value), aad)
 	if err != nil {
 		return nil, "", nil, nil, fmt.Errorf("config repo: encrypt value for key %s: %w", key, err)
@@ -109,7 +110,7 @@ func (r *ConfigRepository) decryptValue(ctx context.Context, key string, ct []by
 		return "", errcode.New(errcode.ErrConfigDecryptFailed,
 			"config repo: no ValueTransformer configured, cannot decrypt sensitive value")
 	}
-	aad := crypto.AADForConfig(cellID, key)
+	aad := kcrypto.AADForConfig(cellID, key)
 	pt, err := r.transformer.Decrypt(ctx, ct, keyID, nonce, edk, aad)
 	if err != nil {
 		return "", errcode.Wrap(errcode.ErrConfigDecryptFailed,

--- a/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	configcrypto "github.com/ghbvf/gocell/cells/config-core/internal/crypto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
-	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/stretchr/testify/assert"
@@ -174,7 +174,7 @@ func TestEncrypt_GetByKey_SensitiveDecryptsValue(t *testing.T) {
 
 	// Build what the DB row looks like after encryption.
 	original := "s3cr3t"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "db_password"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "db_password"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -224,7 +224,7 @@ func TestEncrypt_GetByKey_SensitiveStaleKey(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v2"} // current is v2
 
 	original := "stale-value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "old_key"))
+	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "old_key"))
 	require.NoError(t, err)
 
 	// Row was encrypted with v1 (old key).
@@ -323,7 +323,7 @@ func TestEncrypt_GetVersion_SensitiveDecryptsValue(t *testing.T) {
 
 	original := "published-secret"
 	// Use "cfg-1" as the AAD key — matches v.ConfigID used by GetVersion decryptValue.
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "cfg-1"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "cfg-1"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -376,13 +376,13 @@ func TestConfigRepo_Decrypt_AADMismatch_FailsClosed(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	// Encrypt value for key "db_password".
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte("secret"), kcrypto.AADForConfig("config-core", "db_password"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte("secret"), configcrypto.AADForConfig("config-core", "db_password"))
 	require.NoError(t, err)
 
 	// Now tamper: change the fake's lastEncryptAAD to simulate it having been
 	// originally encrypted for a different key (cross-row replay scenario).
 	// We overwrite it with AAD for a different key so Decrypt will detect mismatch.
-	_, _, _, _, _ = tr.Encrypt(ctx, []byte("other"), kcrypto.AADForConfig("config-core", "other_key"))
+	_, _, _, _, _ = tr.Encrypt(ctx, []byte("other"), configcrypto.AADForConfig("config-core", "other_key"))
 	// lastEncryptAAD is now "other_key" AAD, but the DB row has "db_password" AAD.
 
 	now := time.Now()
@@ -452,7 +452,7 @@ func TestCurrentKeyID_ProviderReturnsError(t *testing.T) {
 	}
 
 	original := "some-secret"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "my_key"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "my_key"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -478,7 +478,7 @@ func TestGetByKey_Sensitive_StaleKey_DifferentStoredAndCurrentKeyID(t *testing.T
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"} // encrypt with v1 first
 
 	original := "stale-value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "cfg_key"))
+	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "cfg_key"))
 	require.NoError(t, err)
 
 	// Now simulate key rotation: current is v2, but stored row has v1.

--- a/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/stretchr/testify/assert"
@@ -173,7 +174,7 @@ func TestEncrypt_GetByKey_SensitiveDecryptsValue(t *testing.T) {
 
 	// Build what the DB row looks like after encryption.
 	original := "s3cr3t"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), crypto.AADForConfig("config-core", "db_password"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "db_password"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -223,7 +224,7 @@ func TestEncrypt_GetByKey_SensitiveStaleKey(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v2"} // current is v2
 
 	original := "stale-value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), crypto.AADForConfig("config-core", "old_key"))
+	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "old_key"))
 	require.NoError(t, err)
 
 	// Row was encrypted with v1 (old key).
@@ -322,7 +323,7 @@ func TestEncrypt_GetVersion_SensitiveDecryptsValue(t *testing.T) {
 
 	original := "published-secret"
 	// Use "cfg-1" as the AAD key — matches v.ConfigID used by GetVersion decryptValue.
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), crypto.AADForConfig("config-core", "cfg-1"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "cfg-1"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -375,13 +376,13 @@ func TestConfigRepo_Decrypt_AADMismatch_FailsClosed(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	// Encrypt value for key "db_password".
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte("secret"), crypto.AADForConfig("config-core", "db_password"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte("secret"), kcrypto.AADForConfig("config-core", "db_password"))
 	require.NoError(t, err)
 
 	// Now tamper: change the fake's lastEncryptAAD to simulate it having been
 	// originally encrypted for a different key (cross-row replay scenario).
 	// We overwrite it with AAD for a different key so Decrypt will detect mismatch.
-	_, _, _, _, _ = tr.Encrypt(ctx, []byte("other"), crypto.AADForConfig("config-core", "other_key"))
+	_, _, _, _, _ = tr.Encrypt(ctx, []byte("other"), kcrypto.AADForConfig("config-core", "other_key"))
 	// lastEncryptAAD is now "other_key" AAD, but the DB row has "db_password" AAD.
 
 	now := time.Now()
@@ -451,7 +452,7 @@ func TestCurrentKeyID_ProviderReturnsError(t *testing.T) {
 	}
 
 	original := "some-secret"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), crypto.AADForConfig("config-core", "my_key"))
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "my_key"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -477,7 +478,7 @@ func TestGetByKey_Sensitive_StaleKey_DifferentStoredAndCurrentKeyID(t *testing.T
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"} // encrypt with v1 first
 
 	original := "stale-value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), crypto.AADForConfig("config-core", "cfg_key"))
+	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), kcrypto.AADForConfig("config-core", "cfg_key"))
 	require.NoError(t, err)
 
 	// Now simulate key rotation: current is v2, but stored row has v1.

--- a/cells/config-core/internal/adapters/postgres/plaintext_migration.go
+++ b/cells/config-core/internal/adapters/postgres/plaintext_migration.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	configcrypto "github.com/ghbvf/gocell/cells/config-core/internal/crypto"
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
@@ -175,7 +176,7 @@ func (m *plaintextMigrator) fetchBatch(ctx context.Context, selectQ, table strin
 // encryptBatch encrypts each row in the batch and writes it back.
 func (m *plaintextMigrator) encryptBatch(ctx context.Context, updateQ, table string, batch []pendingRow, result *PlaintextMigrationResult) error {
 	for _, row := range batch {
-		aad := kcrypto.AADForConfig(cellID, row.key)
+		aad := configcrypto.AADForConfig(cellID, row.key)
 		ct, keyID, nonce, edk, encErr := m.transformer.Encrypt(ctx, []byte(row.value), aad)
 		if encErr != nil {
 			return fmt.Errorf("plaintext-migrator: encrypt key=%s: %w", row.key, encErr)

--- a/cells/config-core/internal/adapters/postgres/plaintext_migration.go
+++ b/cells/config-core/internal/adapters/postgres/plaintext_migration.go
@@ -8,7 +8,6 @@ import (
 
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/crypto"
 )
 
 // PlaintextMigrationConfig controls the batch-encrypt migration behaviour.
@@ -81,7 +80,7 @@ type pendingRow struct {
 // that it can be run as a one-off admin tool independently of normal traffic.
 type plaintextMigrator struct {
 	db          DBTX
-	transformer crypto.ValueTransformer
+	transformer kcrypto.ValueTransformer
 	cfg         PlaintextMigrationConfig
 }
 
@@ -89,7 +88,7 @@ type plaintextMigrator struct {
 // transformer. db must already be in a live transaction (the caller is
 // responsible for Tx management so the migrator can participate in the
 // caller's transaction boundary or run outside one as needed).
-func newPlaintextMigrator(db DBTX, transformer crypto.ValueTransformer, cfg PlaintextMigrationConfig) (*plaintextMigrator, error) {
+func newPlaintextMigrator(db DBTX, transformer kcrypto.ValueTransformer, cfg PlaintextMigrationConfig) (*plaintextMigrator, error) {
 	if transformer == nil {
 		return nil, errcode.New(errcode.ErrConfigKeyMissing,
 			"plaintext-migrator: transformer must not be nil")

--- a/cells/config-core/internal/adapters/postgres/plaintext_migration.go
+++ b/cells/config-core/internal/adapters/postgres/plaintext_migration.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/crypto"
 )
@@ -175,7 +176,7 @@ func (m *plaintextMigrator) fetchBatch(ctx context.Context, selectQ, table strin
 // encryptBatch encrypts each row in the batch and writes it back.
 func (m *plaintextMigrator) encryptBatch(ctx context.Context, updateQ, table string, batch []pendingRow, result *PlaintextMigrationResult) error {
 	for _, row := range batch {
-		aad := crypto.AADForConfig(cellID, row.key)
+		aad := kcrypto.AADForConfig(cellID, row.key)
 		ct, keyID, nonce, edk, encErr := m.transformer.Encrypt(ctx, []byte(row.value), aad)
 		if encErr != nil {
 			return fmt.Errorf("plaintext-migrator: encrypt key=%s: %w", row.key, encErr)

--- a/cells/config-core/internal/adapters/postgres/plaintext_migration_test.go
+++ b/cells/config-core/internal/adapters/postgres/plaintext_migration_test.go
@@ -1,11 +1,15 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"testing"
 
+	configcrypto "github.com/ghbvf/gocell/cells/config-core/internal/crypto"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -323,4 +327,105 @@ func TestPlaintextMigrator_MigrateConfigVersions_SingleRow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Processed)
 	require.Len(t, db.execCalls, 1)
+}
+
+// ---------------------------------------------------------------------------
+// aadAwareTransformer — encodes AAD into the ciphertext so Decrypt can verify
+// ---------------------------------------------------------------------------
+
+// aadAwareTransformer is an in-memory transformer that embeds the AAD length
+// and bytes at the head of the ciphertext. This allows Decrypt to assert that
+// the caller supplied the identical AAD that was used during Encrypt, proving
+// that the migration wires the correct AAD (cellID + configKey).
+//
+// Ciphertext layout: [4-byte big-endian AAD length][AAD bytes][plaintext bytes]
+type aadAwareTransformer struct {
+	keyID string
+}
+
+func (t *aadAwareTransformer) Encrypt(_ context.Context, pt, aad []byte) ([]byte, string, []byte, []byte, error) {
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(aad)))
+	ct := make([]byte, 0, 4+len(aad)+len(pt))
+	ct = append(ct, lenBuf[:]...)
+	ct = append(ct, aad...)
+	ct = append(ct, pt...)
+	return ct, t.keyID, nil, nil, nil
+}
+
+func (t *aadAwareTransformer) Decrypt(_ context.Context, ct []byte, _ string, _, _, aad []byte) ([]byte, error) {
+	if len(ct) < 4 {
+		return nil, errors.New("cipher too short")
+	}
+	aadLen := binary.BigEndian.Uint32(ct[:4])
+	if int(4+aadLen) > len(ct) {
+		return nil, errors.New("cipher malformed")
+	}
+	storedAAD := ct[4 : 4+aadLen]
+	if !bytes.Equal(storedAAD, aad) {
+		return nil, errcode.New(errcode.ErrKeyProviderDecryptFailed, "aad mismatch")
+	}
+	return ct[4+aadLen:], nil
+}
+
+// ---------------------------------------------------------------------------
+// TestPlaintextMigration_AADBinding
+// ---------------------------------------------------------------------------
+
+// TestPlaintextMigration_AADBinding verifies that the migrator passes the
+// correct AAD (cellID + configKey) to the transformer, so the ciphertext is
+// bound to the specific row identity and cannot be transplanted.
+//
+// Test flow:
+//  1. Migrate a plaintext row → ciphertext stored in db.execCalls.
+//  2. Extract the ciphertext and decrypt it with the CORRECT AAD → plaintext matches.
+//  3. Attempt to decrypt the same ciphertext with a WRONG AAD → must fail with
+//     ErrKeyProviderDecryptFailed (cross-row replay protection verified).
+func TestPlaintextMigration_AADBinding(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		configKey string
+		value     string
+	}{
+		{name: "api_key row", configKey: "api_key", value: "sk-secret"},
+		{name: "db_password row", configKey: "db_password", value: "p@ssw0rd!"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &aadAwareTransformer{keyID: "test-key-v1"}
+			db := &batchFakeDB{
+				rows: []migrationRow{
+					{id: "row-1", key: tc.configKey, value: tc.value, sensitive: true},
+				},
+			}
+			m, err := newPlaintextMigrator(db, tr, PlaintextMigrationConfig{BatchSize: 10})
+			require.NoError(t, err)
+
+			result, err := m.MigrateConfigEntries(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Processed)
+			require.Len(t, db.execCalls, 1)
+
+			// Extract the ciphertext written to the DB.
+			ct, ok := db.execCalls[0].args[0].([]byte)
+			require.True(t, ok, "first arg of UPDATE must be []byte ciphertext")
+
+			// Correct AAD: must decrypt successfully and match original plaintext.
+			correctAAD := configcrypto.AADForConfig(cellID, tc.configKey)
+			pt, err := tr.Decrypt(ctx, ct, "test-key-v1", nil, nil, correctAAD)
+			require.NoError(t, err, "Decrypt with correct AAD must succeed")
+			assert.Equal(t, tc.value, string(pt), "decrypted plaintext must match original")
+
+			// Wrong AAD (different configKey): must fail — cross-row replay blocked.
+			wrongAAD := configcrypto.AADForConfig(cellID, "other_key")
+			_, err = tr.Decrypt(ctx, ct, "test-key-v1", nil, nil, wrongAAD)
+			require.Error(t, err, "Decrypt with wrong AAD must fail")
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec), "error must be errcode.Error")
+			assert.Equal(t, errcode.ErrKeyProviderDecryptFailed, ec.Code)
+		})
+	}
 }

--- a/cells/config-core/internal/crypto/aad.go
+++ b/cells/config-core/internal/crypto/aad.go
@@ -1,0 +1,19 @@
+// Package crypto provides config-core-specific crypto helpers.
+//
+// kernel/crypto defines pure crypto contracts (KeyProvider, ValueTransformer,
+// etc). AAD formatting is config-core business logic and lives here.
+//
+// ref: kubernetes/apiserver pkg/storage/value — AAD (etcd key path) computed
+// by the storage layer, not the generic transformer contract.
+package crypto
+
+import "fmt"
+
+// AADForConfig computes the Additional Authenticated Data for a config entry.
+// Format: "cell:{cellID}/key:{configKey}"
+//
+// Using a composite key prevents a ciphertext encrypted for one config entry
+// from being transplanted into a different entry (cross-row replay attack).
+func AADForConfig(cellID, configKey string) []byte {
+	return []byte(fmt.Sprintf("cell:%s/key:%s", cellID, configKey))
+}

--- a/cells/config-core/internal/crypto/aad_test.go
+++ b/cells/config-core/internal/crypto/aad_test.go
@@ -1,0 +1,44 @@
+package crypto_test
+
+import (
+	"testing"
+
+	configcrypto "github.com/ghbvf/gocell/cells/config-core/internal/crypto"
+)
+
+func TestAADForConfig_Format(t *testing.T) {
+	tests := []struct {
+		name      string
+		cellID    string
+		configKey string
+		want      string
+	}{
+		{
+			name:      "basic",
+			cellID:    "config-core",
+			configKey: "api_key",
+			want:      "cell:config-core/key:api_key",
+		},
+		{
+			name:      "empty strings",
+			cellID:    "",
+			configKey: "",
+			want:      "cell:/key:",
+		},
+		{
+			name:      "special chars",
+			cellID:    "my-cell",
+			configKey: "some/complex:key",
+			want:      "cell:my-cell/key:some/complex:key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(configcrypto.AADForConfig(tc.cellID, tc.configKey))
+			if got != tc.want {
+				t.Fatalf("AADForConfig(%q, %q) = %q; want %q", tc.cellID, tc.configKey, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/core-bundle/bundle.go
+++ b/cmd/core-bundle/bundle.go
@@ -13,6 +13,7 @@ import (
 	auditcore "github.com/ghbvf/gocell/cells/audit-core"
 	configcore "github.com/ghbvf/gocell/cells/config-core"
 	"github.com/ghbvf/gocell/kernel/assembly"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -93,7 +94,7 @@ type AppDeps struct {
 	// BuildBootstrap constructs a ValueTransformer from KeyProvider internally.
 	// Tests that need to inject a custom transformer should use configCellOpts
 	// (e.g. configcore.WithValueTransformer(fakeT)).
-	KeyProvider crypto.KeyProvider
+	KeyProvider kcrypto.KeyProvider
 }
 
 // Validate is the single authoritative gate for startup invariants. It checks
@@ -486,7 +487,7 @@ func assembleFromDeps(d assembledDeps) []bootstrap.Option {
 // ref: kubernetes/kubernetes pkg/apiserver/admission/config.go — missing
 // EncryptionConfig in an active storage path is a startup error, not a warning.
 // ref: go-kratos/kratos config.Watch — required dependency failure aborts boot.
-func buildKeyProvider(storageBackend string) (crypto.KeyProvider, error) {
+func buildKeyProvider(storageBackend string) (kcrypto.KeyProvider, error) {
 	providerName := os.Getenv("GOCELL_KEY_PROVIDER")
 	if providerName == "" {
 		if storageBackend == "postgres" {
@@ -521,7 +522,7 @@ func buildKeyProvider(storageBackend string) (crypto.KeyProvider, error) {
 
 // keyProviderToTransformer wraps a KeyProvider in a ValueTransformer.
 // When kp is nil (no encryption configured), returns NoopTransformer.
-func keyProviderToTransformer(kp crypto.KeyProvider) crypto.ValueTransformer {
+func keyProviderToTransformer(kp kcrypto.KeyProvider) kcrypto.ValueTransformer {
 	if kp == nil {
 		return crypto.NoopTransformer{}
 	}
@@ -545,7 +546,7 @@ func keyProviderToTransformer(kp crypto.KeyProvider) crypto.ValueTransformer {
 //
 // ref: Kratos wire — adapter selected at assembly init time, not run time.
 // ref: uber-go/fx lifecycle — external resources hook via ManagedResource.
-func buildConfigCoreOpts(ctx context.Context, topo bootstrap.Topology, pub outbox.Publisher, metricsProvider metrics.Provider, vt crypto.ValueTransformer) (kernellifecycle.ManagedResource, []configcore.Option, error) {
+func buildConfigCoreOpts(ctx context.Context, topo bootstrap.Topology, pub outbox.Publisher, metricsProvider metrics.Provider, vt kcrypto.ValueTransformer) (kernellifecycle.ManagedResource, []configcore.Option, error) {
 	switch topo.StorageBackend {
 	case "postgres":
 		pool, err := adapterpg.NewPool(ctx, adapterpg.ConfigFromEnv())

--- a/kernel/crypto/doc.go
+++ b/kernel/crypto/doc.go
@@ -1,14 +1,23 @@
 // Package crypto defines the kernel-level cryptographic interfaces:
-// KeyProvider, KeyHandle, ValueTransformer, CurrentKeyIDProvider, and the
-// AADForConfig helper.
+// KeyProvider, KeyHandle, ValueTransformer, and CurrentKeyIDProvider.
 //
-// Implementations (LocalAES, VaultTransit) live in runtime/crypto/ or
-// adapters/*/. runtime/crypto re-exports these interfaces via type aliases
-// so that existing callers using "runtime/crypto" continue to compile
-// without change; kernel/crypto itself has no dependency on runtime or
-// adapters.
+// This package is the authoritative contract layer. Implementations
+// (LocalAES, VaultTransit) live in runtime/crypto/ or adapters/*/.
 //
-// kernel/crypto/ must not import runtime/ or adapters/ — it is the
+// runtime/crypto exposes interface type aliases to kernel/crypto so that
+// runtime/crypto implementations (LocalAESKeyProvider, VaultTransitKeyProvider,
+// keyProviderTransformer, NoopTransformer) type-check against the kernel
+// contract. This is NOT a backwards-compatibility shim — kernel/crypto is the
+// authoritative contract and external consumers should import it directly.
+//
+// Breaking changes from pre-kernel split: AADForConfig helper moved to
+// cells/config-core/internal/crypto; consumers must update imports from
+// kcrypto.AADForConfig to configcrypto.AADForConfig. AAD formatting is
+// config-core business logic (cell:{cellID}/key:{configKey} uses cellID and
+// configKey which are config-core domain concepts), not a generic crypto
+// contract.
+//
+// kernel/crypto/ must not import runtime/, adapters/, or cells/ — it is the
 // interface-only package for the adapters→kernel-only dependency rule.
 //
 // ref: kubernetes/kubernetes staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go

--- a/kernel/crypto/doc.go
+++ b/kernel/crypto/doc.go
@@ -1,0 +1,14 @@
+// Package crypto defines the kernel-level cryptographic interfaces:
+// KeyProvider, KeyHandle, ValueTransformer, CurrentKeyIDProvider, and the
+// AADForConfig helper.
+//
+// Implementations (LocalAES, VaultTransit) live in runtime/crypto/ and are
+// exposed via type aliases so that callers importing kernel/crypto receive the
+// same concrete types without creating a dependency on runtime/.
+//
+// This package may only depend on the standard library, preserving the
+// kernel→no-runtime layering rule.
+//
+// ref: kubernetes/kubernetes staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
+// ref: PR#200 R1a kernel/lifecycle layering pattern
+package crypto

--- a/kernel/crypto/doc.go
+++ b/kernel/crypto/doc.go
@@ -2,12 +2,14 @@
 // KeyProvider, KeyHandle, ValueTransformer, CurrentKeyIDProvider, and the
 // AADForConfig helper.
 //
-// Implementations (LocalAES, VaultTransit) live in runtime/crypto/ and are
-// exposed via type aliases so that callers importing kernel/crypto receive the
-// same concrete types without creating a dependency on runtime/.
+// Implementations (LocalAES, VaultTransit) live in runtime/crypto/ or
+// adapters/*/. runtime/crypto re-exports these interfaces via type aliases
+// so that existing callers using "runtime/crypto" continue to compile
+// without change; kernel/crypto itself has no dependency on runtime or
+// adapters.
 //
-// This package may only depend on the standard library, preserving the
-// kernel→no-runtime layering rule.
+// kernel/crypto/ must not import runtime/ or adapters/ — it is the
+// interface-only package for the adapters→kernel-only dependency rule.
 //
 // ref: kubernetes/kubernetes staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
 // ref: PR#200 R1a kernel/lifecycle layering pattern

--- a/kernel/crypto/key_provider.go
+++ b/kernel/crypto/key_provider.go
@@ -1,0 +1,57 @@
+package crypto
+
+import (
+	"context"
+)
+
+// KeyProvider abstracts a KMS backend. Implementations must be safe for
+// concurrent use.
+//
+// ref: kubernetes/kubernetes staging/.../storage/value/transformer.go@master
+type KeyProvider interface {
+	// Current returns the active KeyHandle for encrypting new values.
+	// The returned handle's ID() is stored alongside the ciphertext so that
+	// the correct key can be looked up during decryption.
+	Current(ctx context.Context) (KeyHandle, error)
+
+	// ByID returns the KeyHandle identified by keyID. Callers use this to
+	// decrypt values encrypted by a previous key version.
+	// Returns ErrKeyNotFound when the key is absent from the keyring.
+	ByID(ctx context.Context, keyID string) (KeyHandle, error)
+
+	// Rotate generates or activates a new key version. The previous key
+	// remains in the keyring so that existing ciphertexts can still be
+	// decrypted. Returns the new key's ID.
+	Rotate(ctx context.Context) (newKeyID string, err error)
+}
+
+// KeyHandle is a thin handle for a specific key version. It provides the
+// cryptographic primitives needed by ValueTransformer.
+//
+// Contract:
+//   - Encrypt MUST generate a fresh nonce on every call (nonce uniqueness).
+//   - Decrypt MUST validate the aad; mismatched aad MUST return ErrDecryptFailed.
+//   - nonce and edk semantics are provider-specific. VaultTransit may return
+//     nil/empty slices because key material is managed server-side.
+//
+// ref: hashicorp/vault sdk/helper/keysutil/policy.go@main:L127 (keyID version prefix)
+type KeyHandle interface {
+	// ID returns the key version identifier (e.g. "local-aes-v1", "vault-transit:v3").
+	ID() string
+
+	// Encrypt encrypts plaintext under this key using the provided aad as
+	// Additional Authenticated Data.  Returns:
+	//   - ciphertext: the encrypted payload (opaque bytes; may embed nonce for
+	//     some backends like VaultTransit).
+	//   - nonce:      random IV used for AES-GCM (nil for backends that embed it).
+	//   - edk:        encrypted DEK for envelope encryption (nil for backends
+	//     like VaultTransit that manage keys server-side).
+	//   - err:        non-nil on any encryption failure (fail-closed).
+	Encrypt(ctx context.Context, plaintext, aad []byte) (ciphertext, nonce, edk []byte, err error)
+
+	// Decrypt decrypts ciphertext encrypted by this key. The aad must match
+	// exactly what was provided to Encrypt; mismatched aad returns ErrDecryptFailed.
+	//
+	// nonce and edk may be nil for backends that embed these within ciphertext.
+	Decrypt(ctx context.Context, ciphertext, nonce, edk, aad []byte) (plaintext []byte, err error)
+}

--- a/kernel/crypto/key_provider_test.go
+++ b/kernel/crypto/key_provider_test.go
@@ -1,0 +1,77 @@
+package crypto_test
+
+import (
+	"context"
+	"testing"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+)
+
+// ---------------------------------------------------------------------------
+// Compile-time contract assertions
+// ---------------------------------------------------------------------------
+
+// fakeProvider is a minimal KeyProvider for compile-time assertions only.
+type fakeProvider struct{}
+
+func (fakeProvider) Current(_ context.Context) (kcrypto.KeyHandle, error)        { return nil, nil }
+func (fakeProvider) ByID(_ context.Context, _ string) (kcrypto.KeyHandle, error) { return nil, nil }
+func (fakeProvider) Rotate(_ context.Context) (string, error)                    { return "", nil }
+
+// fakeHandle is a minimal KeyHandle for compile-time assertions only.
+type fakeHandle struct{}
+
+func (fakeHandle) ID() string { return "fake-v1" }
+func (fakeHandle) Encrypt(_ context.Context, _, _ []byte) ([]byte, []byte, []byte, error) {
+	return nil, nil, nil, nil
+}
+func (fakeHandle) Decrypt(_ context.Context, _, _, _, _ []byte) ([]byte, error) { return nil, nil }
+
+// Compile-time contract checks — these fail at build time if the interfaces
+// are not satisfied, mirroring the kernel/lifecycle and kernel/worker pattern.
+var _ kcrypto.KeyProvider = fakeProvider{}
+var _ kcrypto.KeyHandle = fakeHandle{}
+
+// ---------------------------------------------------------------------------
+// Method-call tests (verifying interface shape at runtime)
+// ---------------------------------------------------------------------------
+
+func TestKeyProvider_InterfaceMethods(t *testing.T) {
+	ctx := context.Background()
+	var p kcrypto.KeyProvider = fakeProvider{}
+
+	_, err := p.Current(ctx)
+	if err != nil {
+		t.Fatalf("Current: unexpected error: %v", err)
+	}
+
+	_, err = p.ByID(ctx, "some-key")
+	if err != nil {
+		t.Fatalf("ByID: unexpected error: %v", err)
+	}
+
+	id, err := p.Rotate(ctx)
+	if err != nil {
+		t.Fatalf("Rotate: unexpected error: %v", err)
+	}
+	_ = id
+}
+
+func TestKeyHandle_InterfaceMethods(t *testing.T) {
+	ctx := context.Background()
+	var h kcrypto.KeyHandle = fakeHandle{}
+
+	if h.ID() != "fake-v1" {
+		t.Fatalf("ID: expected fake-v1, got %s", h.ID())
+	}
+
+	_, _, _, err := h.Encrypt(ctx, []byte("plain"), []byte("aad"))
+	if err != nil {
+		t.Fatalf("Encrypt: unexpected error: %v", err)
+	}
+
+	_, err = h.Decrypt(ctx, nil, nil, nil, []byte("aad"))
+	if err != nil {
+		t.Fatalf("Decrypt: unexpected error: %v", err)
+	}
+}

--- a/kernel/crypto/value_transformer.go
+++ b/kernel/crypto/value_transformer.go
@@ -1,0 +1,56 @@
+package crypto
+
+import (
+	"context"
+	"fmt"
+)
+
+// ValueTransformer is the caller-facing encryption interface for sensitive
+// config values. It is a thin wrapper over KeyProvider that:
+//   - Uses the current key for Encrypt.
+//   - Uses ByID(keyID) for Decrypt so historical keys remain accessible.
+//   - Accepts pre-computed AAD so callers can bind ciphertext to the row's
+//     identity (preventing ciphertext transplant attacks).
+//
+// Optional extension interface: implementations MAY also satisfy
+// CurrentKeyIDProvider to expose the current key ID; this is used by the
+// config repository to compute the Stale staleness signal for rotation-driven
+// lazy re-encryption. NoopTransformer deliberately does not implement it
+// (nothing to be stale against).
+//
+// ref: kubernetes/kubernetes staging/.../storage/value/transformer.go@master
+type ValueTransformer interface {
+	// Encrypt encrypts plaintext under the current key.
+	// Returns (ciphertext, keyID, nonce, edk, error).
+	// keyID identifies the key version; store alongside the ciphertext so that
+	// Decrypt can resolve the correct historical key on read.
+	Encrypt(ctx context.Context, plaintext, aad []byte) (ciphertext []byte, keyID string, nonce, edk []byte, err error)
+
+	// Decrypt decrypts ciphertext using the key identified by keyID.
+	// Fail-closed: returns an error on any decryption failure; never returns
+	// the raw ciphertext or an empty slice as a fallback.
+	Decrypt(ctx context.Context, ciphertext []byte, keyID string, nonce, edk, aad []byte) (plaintext []byte, err error)
+}
+
+// CurrentKeyIDProvider is the optional extension interface for ValueTransformer
+// implementations that can report their current key ID. Discovered at runtime
+// via type assertion (`if c, ok := tr.(CurrentKeyIDProvider); ok { ... }`).
+// A nil error with an empty string is reserved for "no key" (e.g. Noop); a
+// non-empty string represents the active key version label used for staleness
+// comparison against per-row stored key IDs.
+type CurrentKeyIDProvider interface {
+	CurrentKeyID(ctx context.Context) (string, error)
+}
+
+// ---------------------------------------------------------------------------
+// AAD helpers
+// ---------------------------------------------------------------------------
+
+// AADForConfig computes the Additional Authenticated Data for a config entry.
+// Format: "cell:{cellID}/key:{configKey}"
+//
+// Using a composite key prevents a ciphertext encrypted for one config entry
+// from being transplanted into a different entry (cross-row replay attack).
+func AADForConfig(cellID, configKey string) []byte {
+	return []byte(fmt.Sprintf("cell:%s/key:%s", cellID, configKey))
+}

--- a/kernel/crypto/value_transformer.go
+++ b/kernel/crypto/value_transformer.go
@@ -2,7 +2,6 @@ package crypto
 
 import (
 	"context"
-	"fmt"
 )
 
 // ValueTransformer is the caller-facing encryption interface for sensitive
@@ -40,17 +39,4 @@ type ValueTransformer interface {
 // comparison against per-row stored key IDs.
 type CurrentKeyIDProvider interface {
 	CurrentKeyID(ctx context.Context) (string, error)
-}
-
-// ---------------------------------------------------------------------------
-// AAD helpers
-// ---------------------------------------------------------------------------
-
-// AADForConfig computes the Additional Authenticated Data for a config entry.
-// Format: "cell:{cellID}/key:{configKey}"
-//
-// Using a composite key prevents a ciphertext encrypted for one config entry
-// from being transplanted into a different entry (cross-row replay attack).
-func AADForConfig(cellID, configKey string) []byte {
-	return []byte(fmt.Sprintf("cell:%s/key:%s", cellID, configKey))
 }

--- a/kernel/crypto/value_transformer_test.go
+++ b/kernel/crypto/value_transformer_test.go
@@ -1,0 +1,118 @@
+package crypto_test
+
+import (
+	"context"
+	"testing"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+)
+
+// ---------------------------------------------------------------------------
+// Compile-time contract assertions
+// ---------------------------------------------------------------------------
+
+// fakeTransformer satisfies ValueTransformer.
+type fakeTransformer struct{}
+
+func (fakeTransformer) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, string, []byte, []byte, error) {
+	return plaintext, "fake-key-v1", nil, nil, nil
+}
+func (fakeTransformer) Decrypt(_ context.Context, ciphertext []byte, _ string, _, _, _ []byte) ([]byte, error) {
+	return ciphertext, nil
+}
+
+// fakeCurrentKeyIDProvider satisfies CurrentKeyIDProvider.
+type fakeCurrentKeyIDProvider struct{}
+
+func (fakeCurrentKeyIDProvider) CurrentKeyID(_ context.Context) (string, error) {
+	return "fake-key-v1", nil
+}
+
+var _ kcrypto.ValueTransformer = fakeTransformer{}
+var _ kcrypto.CurrentKeyIDProvider = fakeCurrentKeyIDProvider{}
+
+// ---------------------------------------------------------------------------
+// AADForConfig format test
+// ---------------------------------------------------------------------------
+
+func TestAADForConfig_Format(t *testing.T) {
+	tests := []struct {
+		name      string
+		cellID    string
+		configKey string
+		want      string
+	}{
+		{
+			name:      "basic",
+			cellID:    "config-core",
+			configKey: "api_key",
+			want:      "cell:config-core/key:api_key",
+		},
+		{
+			name:      "empty strings",
+			cellID:    "",
+			configKey: "",
+			want:      "cell:/key:",
+		},
+		{
+			name:      "special chars",
+			cellID:    "my-cell",
+			configKey: "some/complex:key",
+			want:      "cell:my-cell/key:some/complex:key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(kcrypto.AADForConfig(tc.cellID, tc.configKey))
+			if got != tc.want {
+				t.Fatalf("AADForConfig(%q, %q) = %q; want %q", tc.cellID, tc.configKey, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValueTransformer interface method tests
+// ---------------------------------------------------------------------------
+
+func TestValueTransformer_InterfaceMethods(t *testing.T) {
+	ctx := context.Background()
+	var tr kcrypto.ValueTransformer = fakeTransformer{}
+
+	plaintext := []byte("secret-value")
+	aad := kcrypto.AADForConfig("test-cell", "test-key")
+
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
+	if err != nil {
+		t.Fatalf("Encrypt: unexpected error: %v", err)
+	}
+	if keyID == "" {
+		t.Fatal("Encrypt: keyID must not be empty")
+	}
+
+	recovered, err := tr.Decrypt(ctx, ct, keyID, nonce, edk, aad)
+	if err != nil {
+		t.Fatalf("Decrypt: unexpected error: %v", err)
+	}
+	if string(recovered) != string(plaintext) {
+		t.Fatalf("round-trip mismatch: got %q, want %q", recovered, plaintext)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CurrentKeyIDProvider interface test
+// ---------------------------------------------------------------------------
+
+func TestCurrentKeyIDProvider_InterfaceMethods(t *testing.T) {
+	ctx := context.Background()
+	var p kcrypto.CurrentKeyIDProvider = fakeCurrentKeyIDProvider{}
+
+	id, err := p.CurrentKeyID(ctx)
+	if err != nil {
+		t.Fatalf("CurrentKeyID: unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Fatal("CurrentKeyID: returned empty string unexpectedly")
+	}
+}

--- a/kernel/crypto/value_transformer_test.go
+++ b/kernel/crypto/value_transformer_test.go
@@ -32,47 +32,6 @@ var _ kcrypto.ValueTransformer = fakeTransformer{}
 var _ kcrypto.CurrentKeyIDProvider = fakeCurrentKeyIDProvider{}
 
 // ---------------------------------------------------------------------------
-// AADForConfig format test
-// ---------------------------------------------------------------------------
-
-func TestAADForConfig_Format(t *testing.T) {
-	tests := []struct {
-		name      string
-		cellID    string
-		configKey string
-		want      string
-	}{
-		{
-			name:      "basic",
-			cellID:    "config-core",
-			configKey: "api_key",
-			want:      "cell:config-core/key:api_key",
-		},
-		{
-			name:      "empty strings",
-			cellID:    "",
-			configKey: "",
-			want:      "cell:/key:",
-		},
-		{
-			name:      "special chars",
-			cellID:    "my-cell",
-			configKey: "some/complex:key",
-			want:      "cell:my-cell/key:some/complex:key",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := string(kcrypto.AADForConfig(tc.cellID, tc.configKey))
-			if got != tc.want {
-				t.Fatalf("AADForConfig(%q, %q) = %q; want %q", tc.cellID, tc.configKey, got, tc.want)
-			}
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
 // ValueTransformer interface method tests
 // ---------------------------------------------------------------------------
 
@@ -81,7 +40,7 @@ func TestValueTransformer_InterfaceMethods(t *testing.T) {
 	var tr kcrypto.ValueTransformer = fakeTransformer{}
 
 	plaintext := []byte("secret-value")
-	aad := kcrypto.AADForConfig("test-cell", "test-key")
+	aad := []byte("cell:test-cell/key:test-key") // AADForConfig moved to cells/config-core/internal/crypto
 
 	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 	if err != nil {

--- a/runtime/crypto/key_provider.go
+++ b/runtime/crypto/key_provider.go
@@ -17,10 +17,21 @@ package crypto
 
 import kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 
-// KeyProvider is a type alias for kernel/crypto.KeyProvider.
-// Abstracts a KMS backend; implementations must be safe for concurrent use.
+// KeyProvider is a type alias for the kernel KeyProvider interface. The
+// authoritative definition lives in kernel/crypto.
+//
+// This is not a migration shim — the alias exists so runtime/crypto
+// implementations (LocalAES, VaultTransit, keyProviderTransformer)
+// type-check against the kernel contract without importing kernel/crypto
+// from every local impl file.
+//
+// Guidance for new consumers: code in cells/ or cmd/ referencing only
+// interfaces SHOULD import kernel/crypto directly and reference
+// kcrypto.KeyProvider (the kernel contract).
 type KeyProvider = kcrypto.KeyProvider
 
-// KeyHandle is a type alias for kernel/crypto.KeyHandle.
-// A thin handle for a specific key version providing Encrypt/Decrypt.
+// KeyHandle is a type alias for the kernel KeyHandle interface. The
+// authoritative definition lives in kernel/crypto.
+//
+// See KeyProvider alias comment for guidance on import choices.
 type KeyHandle = kcrypto.KeyHandle

--- a/runtime/crypto/key_provider.go
+++ b/runtime/crypto/key_provider.go
@@ -6,62 +6,21 @@
 //   - KeyHandle represents a specific key version, provides Encrypt/Decrypt.
 //   - ValueTransformer is a thin caller-facing wrapper over KeyProvider.
 //
-// ref: kubernetes/kubernetes staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go@master:L1-L40
+// Interfaces (KeyProvider, KeyHandle, ValueTransformer, CurrentKeyIDProvider)
+// are defined in kernel/crypto and re-exported here via type aliases so that
+// existing import paths continue to work without modification.
+//
+// ref: kubernetes/kubernetes staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go@master
 // ref: hashicorp/vault vault/barrier_aes_gcm.go@main:L1199-L1233
+// ref: PR#200 R1a kernel/lifecycle type-alias bridge pattern
 package crypto
 
-import (
-	"context"
-)
+import kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 
-// KeyProvider abstracts a KMS backend. Implementations must be safe for
-// concurrent use.
-//
-// ref: kubernetes/kubernetes staging/.../storage/value/transformer.go@master
-type KeyProvider interface {
-	// Current returns the active KeyHandle for encrypting new values.
-	// The returned handle's ID() is stored alongside the ciphertext so that
-	// the correct key can be looked up during decryption.
-	Current(ctx context.Context) (KeyHandle, error)
+// KeyProvider is a type alias for kernel/crypto.KeyProvider.
+// Abstracts a KMS backend; implementations must be safe for concurrent use.
+type KeyProvider = kcrypto.KeyProvider
 
-	// ByID returns the KeyHandle identified by keyID. Callers use this to
-	// decrypt values encrypted by a previous key version.
-	// Returns ErrKeyNotFound when the key is absent from the keyring.
-	ByID(ctx context.Context, keyID string) (KeyHandle, error)
-
-	// Rotate generates or activates a new key version. The previous key
-	// remains in the keyring so that existing ciphertexts can still be
-	// decrypted. Returns the new key's ID.
-	Rotate(ctx context.Context) (newKeyID string, err error)
-}
-
-// KeyHandle is a thin handle for a specific key version. It provides the
-// cryptographic primitives needed by ValueTransformer.
-//
-// Contract:
-//   - Encrypt MUST generate a fresh nonce on every call (nonce uniqueness).
-//   - Decrypt MUST validate the aad; mismatched aad MUST return ErrDecryptFailed.
-//   - nonce and edk semantics are provider-specific. VaultTransit may return
-//     nil/empty slices because key material is managed server-side.
-//
-// ref: hashicorp/vault sdk/helper/keysutil/policy.go@main:L127 (keyID version prefix)
-type KeyHandle interface {
-	// ID returns the key version identifier (e.g. "local-aes-v1", "vault-transit:v3").
-	ID() string
-
-	// Encrypt encrypts plaintext under this key using the provided aad as
-	// Additional Authenticated Data.  Returns:
-	//   - ciphertext: the encrypted payload (opaque bytes; may embed nonce for
-	//     some backends like VaultTransit).
-	//   - nonce:      random IV used for AES-GCM (nil for backends that embed it).
-	//   - edk:        encrypted DEK for envelope encryption (nil for backends
-	//     like VaultTransit that manage keys server-side).
-	//   - err:        non-nil on any encryption failure (fail-closed).
-	Encrypt(ctx context.Context, plaintext, aad []byte) (ciphertext, nonce, edk []byte, err error)
-
-	// Decrypt decrypts ciphertext encrypted by this key. The aad must match
-	// exactly what was provided to Encrypt; mismatched aad returns ErrDecryptFailed.
-	//
-	// nonce and edk may be nil for backends that embed these within ciphertext.
-	Decrypt(ctx context.Context, ciphertext, nonce, edk, aad []byte) (plaintext []byte, err error)
-}
+// KeyHandle is a type alias for kernel/crypto.KeyHandle.
+// A thin handle for a specific key version providing Encrypt/Decrypt.
+type KeyHandle = kcrypto.KeyHandle

--- a/runtime/crypto/value_transformer.go
+++ b/runtime/crypto/value_transformer.go
@@ -7,13 +7,23 @@ import (
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 )
 
-// ValueTransformer is a type alias for kernel/crypto.ValueTransformer.
-// The caller-facing encryption interface for sensitive config values.
+// ValueTransformer is a type alias for the kernel ValueTransformer interface.
+// The authoritative definition lives in kernel/crypto.
+//
+// This is not a migration shim — the alias exists so runtime/crypto
+// implementations (keyProviderTransformer, NoopTransformer)
+// type-check against the kernel contract without importing kernel/crypto
+// from every local impl file.
+//
+// Guidance for new consumers: code in cells/ or cmd/ referencing only
+// interfaces SHOULD import kernel/crypto directly and reference
+// kcrypto.ValueTransformer (the kernel contract).
 type ValueTransformer = kcrypto.ValueTransformer
 
-// CurrentKeyIDProvider is a type alias for kernel/crypto.CurrentKeyIDProvider.
-// Optional extension interface for ValueTransformer implementations that can
-// report their current key ID.
+// CurrentKeyIDProvider is a type alias for the kernel CurrentKeyIDProvider
+// interface. The authoritative definition lives in kernel/crypto.
+//
+// See ValueTransformer alias comment for guidance on import choices.
 type CurrentKeyIDProvider = kcrypto.CurrentKeyIDProvider
 
 // keyProviderTransformer is the production ValueTransformer backed by a KeyProvider.

--- a/runtime/crypto/value_transformer.go
+++ b/runtime/crypto/value_transformer.go
@@ -3,44 +3,18 @@ package crypto
 import (
 	"context"
 	"fmt"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 )
 
-// ValueTransformer is the caller-facing encryption interface for sensitive
-// config values. It is a thin wrapper over KeyProvider that:
-//   - Uses the current key for Encrypt.
-//   - Uses ByID(keyID) for Decrypt so historical keys remain accessible.
-//   - Accepts pre-computed AAD so callers can bind ciphertext to the row's
-//     identity (preventing ciphertext transplant attacks).
-//
-// Optional extension interface: implementations MAY also satisfy
-// CurrentKeyIDProvider to expose the current key ID; this is used by the
-// config repository to compute the Stale staleness signal for rotation-driven
-// lazy re-encryption. NoopTransformer deliberately does not implement it
-// (nothing to be stale against).
-//
-// ref: kubernetes/kubernetes staging/.../storage/value/transformer.go@master
-type ValueTransformer interface {
-	// Encrypt encrypts plaintext under the current key.
-	// Returns (ciphertext, keyID, nonce, edk, error).
-	// keyID identifies the key version; store alongside the ciphertext so that
-	// Decrypt can resolve the correct historical key on read.
-	Encrypt(ctx context.Context, plaintext, aad []byte) (ciphertext []byte, keyID string, nonce, edk []byte, err error)
+// ValueTransformer is a type alias for kernel/crypto.ValueTransformer.
+// The caller-facing encryption interface for sensitive config values.
+type ValueTransformer = kcrypto.ValueTransformer
 
-	// Decrypt decrypts ciphertext using the key identified by keyID.
-	// Fail-closed: returns an error on any decryption failure; never returns
-	// the raw ciphertext or an empty slice as a fallback.
-	Decrypt(ctx context.Context, ciphertext []byte, keyID string, nonce, edk, aad []byte) (plaintext []byte, err error)
-}
-
-// CurrentKeyIDProvider is the optional extension interface for ValueTransformer
-// implementations that can report their current key ID. Discovered at runtime
-// via type assertion (`if c, ok := tr.(CurrentKeyIDProvider); ok { ... }`).
-// A nil error with an empty string is reserved for "no key" (e.g. Noop); a
-// non-empty string represents the active key version label used for staleness
-// comparison against per-row stored key IDs.
-type CurrentKeyIDProvider interface {
-	CurrentKeyID(ctx context.Context) (string, error)
-}
+// CurrentKeyIDProvider is a type alias for kernel/crypto.CurrentKeyIDProvider.
+// Optional extension interface for ValueTransformer implementations that can
+// report their current key ID.
+type CurrentKeyIDProvider = kcrypto.CurrentKeyIDProvider
 
 // keyProviderTransformer is the production ValueTransformer backed by a KeyProvider.
 type keyProviderTransformer struct {
@@ -110,17 +84,4 @@ func (NoopTransformer) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, 
 // Decrypt returns ciphertext as-is.
 func (NoopTransformer) Decrypt(_ context.Context, ciphertext []byte, _ string, _, _, _ []byte) ([]byte, error) {
 	return ciphertext, nil
-}
-
-// ---------------------------------------------------------------------------
-// AAD helpers
-// ---------------------------------------------------------------------------
-
-// AADForConfig computes the Additional Authenticated Data for a config entry.
-// Format: "cell:{cellID}/key:{configKey}"
-//
-// Using a composite key prevents a ciphertext encrypted for one config entry
-// from being transplanted into a different entry (cross-row replay attack).
-func AADForConfig(cellID, configKey string) []byte {
-	return []byte(fmt.Sprintf("cell:%s/key:%s", cellID, configKey))
 }

--- a/runtime/crypto/value_transformer_test.go
+++ b/runtime/crypto/value_transformer_test.go
@@ -5,12 +5,18 @@ import (
 	"errors"
 	"testing"
 
-	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testAAD constructs a test AAD in the config-core format.
+// AADForConfig was moved to cells/config-core/internal/crypto;
+// runtime/crypto tests use this local helper to avoid a cells/ import.
+func testAAD(configKey string) []byte {
+	return []byte("cell:config-core/key:" + configKey)
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -45,7 +51,7 @@ func TestValueTransformer_EncryptDecrypt_RoundTrip(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			plaintext := []byte(tc.value)
-			aad := kcrypto.AADForConfig("config-core", tc.configKey)
+			aad := testAAD(tc.configKey)
 
 			ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 			require.NoError(t, err)
@@ -93,7 +99,7 @@ func TestValueTransformer_DecryptByHistoricalKeyID(t *testing.T) {
 	require.NoError(t, err)
 
 	plaintext := []byte("old-secret")
-	aad := kcrypto.AADForConfig("config-core", "legacy_key")
+	aad := testAAD("legacy_key")
 
 	ct, nonce, edk, err := previousHandle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
@@ -114,8 +120,8 @@ func TestValueTransformer_DecryptWrongAAD_FailClosed(t *testing.T) {
 	tr := newTestTransformer(t)
 
 	plaintext := []byte("value")
-	aad := kcrypto.AADForConfig("config-core", "my_key")
-	wrongAAD := kcrypto.AADForConfig("config-core", "other_key")
+	aad := testAAD("my_key")
+	wrongAAD := testAAD("other_key")
 
 	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
@@ -137,7 +143,7 @@ func TestValueTransformer_UnknownKeyID_FailClosed(t *testing.T) {
 	tr := newTestTransformer(t)
 
 	plaintext := []byte("value")
-	aad := kcrypto.AADForConfig("config-core", "my_key")
+	aad := testAAD("my_key")
 	ct, _, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
@@ -154,7 +160,7 @@ func TestNoopTransformer_Passthrough(t *testing.T) {
 	tr := crypto.NoopTransformer{}
 
 	plaintext := []byte("public-config-value")
-	aad := kcrypto.AADForConfig("config-core", "public_key")
+	aad := testAAD("public_key")
 
 	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
@@ -169,11 +175,15 @@ func TestNoopTransformer_Passthrough(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestAADForConfig_Format
+// TestAADForConfig_Format — local helper format test
 // ---------------------------------------------------------------------------
 
-func TestAADForConfig_Format(t *testing.T) {
-	aad := kcrypto.AADForConfig("config-core", "api_key")
+// TestTestAAD_Format verifies the local testAAD helper used by this test file
+// produces the expected config-core AAD format.
+// The canonical AADForConfig implementation lives in
+// cells/config-core/internal/crypto.
+func TestTestAAD_Format(t *testing.T) {
+	aad := testAAD("api_key")
 	assert.Equal(t, []byte("cell:config-core/key:api_key"), aad)
 }
 

--- a/runtime/crypto/value_transformer_test.go
+++ b/runtime/crypto/value_transformer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,7 @@ func TestValueTransformer_EncryptDecrypt_RoundTrip(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			plaintext := []byte(tc.value)
-			aad := crypto.AADForConfig("config-core", tc.configKey)
+			aad := kcrypto.AADForConfig("config-core", tc.configKey)
 
 			ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 			require.NoError(t, err)
@@ -92,7 +93,7 @@ func TestValueTransformer_DecryptByHistoricalKeyID(t *testing.T) {
 	require.NoError(t, err)
 
 	plaintext := []byte("old-secret")
-	aad := crypto.AADForConfig("config-core", "legacy_key")
+	aad := kcrypto.AADForConfig("config-core", "legacy_key")
 
 	ct, nonce, edk, err := previousHandle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
@@ -113,8 +114,8 @@ func TestValueTransformer_DecryptWrongAAD_FailClosed(t *testing.T) {
 	tr := newTestTransformer(t)
 
 	plaintext := []byte("value")
-	aad := crypto.AADForConfig("config-core", "my_key")
-	wrongAAD := crypto.AADForConfig("config-core", "other_key")
+	aad := kcrypto.AADForConfig("config-core", "my_key")
+	wrongAAD := kcrypto.AADForConfig("config-core", "other_key")
 
 	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
@@ -136,7 +137,7 @@ func TestValueTransformer_UnknownKeyID_FailClosed(t *testing.T) {
 	tr := newTestTransformer(t)
 
 	plaintext := []byte("value")
-	aad := crypto.AADForConfig("config-core", "my_key")
+	aad := kcrypto.AADForConfig("config-core", "my_key")
 	ct, _, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
@@ -153,7 +154,7 @@ func TestNoopTransformer_Passthrough(t *testing.T) {
 	tr := crypto.NoopTransformer{}
 
 	plaintext := []byte("public-config-value")
-	aad := crypto.AADForConfig("config-core", "public_key")
+	aad := kcrypto.AADForConfig("config-core", "public_key")
 
 	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
@@ -172,7 +173,7 @@ func TestNoopTransformer_Passthrough(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAADForConfig_Format(t *testing.T) {
-	aad := crypto.AADForConfig("config-core", "api_key")
+	aad := kcrypto.AADForConfig("config-core", "api_key")
 	assert.Equal(t, []byte("cell:config-core/key:api_key"), aad)
 }
 


### PR DESCRIPTION
## Summary

- Moves `KeyProvider`, `KeyHandle`, `ValueTransformer`, `CurrentKeyIDProvider` interfaces and `AADForConfig` helper from `runtime/crypto/` into new `kernel/crypto/` package
- `runtime/crypto/` retains all implementations (`LocalAES`, `keyProviderTransformer`, `NoopTransformer`) and re-exports the interfaces as type aliases — existing import paths work without change
- External consumers (`cells/config-core` adapters, `cmd/core-bundle`) updated to call `kcrypto.AADForConfig` from `kernel/crypto`; interface references work transparently via aliases

## Motivation

`adapters/vault` (R1c) and `adapters/awskms` (S14a) must implement the crypto interfaces but cannot depend on `runtime/` (layering rule: adapters → kernel only). Interfaces in `runtime/crypto/` blocked that path.

## Layering verification

```
go list -deps ./kernel/crypto/... | grep -E 'github\.com/ghbvf/gocell/(runtime|adapters)/'
# → no output (OK)
```

## Test plan

- [x] `go build ./...` — PASS
- [x] `go build -tags=integration ./...` — PASS
- [x] `go test ./kernel/crypto/...` — new package, all PASS
- [x] `go test ./runtime/crypto/...` — equivalent coverage retained, all PASS
- [x] `go test ./cells/config-core/...` — all PASS
- [x] `golangci-lint run ./kernel/crypto/... ./runtime/crypto/... ./cells/config-core/... ./cmd/core-bundle/...` — 0 issues
- [x] `cmd/core-bundle` network-bind failures confirmed pre-existing on baseline (sandbox restriction)

## Pattern reference

Same type-alias bridge pattern as PR#200 (R1a): `kernel/lifecycle.ManagedResource`, `kernel/worker.Worker`.

backlog: S14a `adapters/vault` + `adapters/awskms` paths now unblocked

ref: kubernetes/apiserver `pkg/storage/value/transformer.go`
ref: PR#200 R1a `kernel/lifecycle` layering pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)