### PR TITLE
feat(security): R2a security hardening + observability + token renewal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,25 @@ GOCELL_CONFIG_CURSOR_KEY=
 # GOCELL_AUDIT_CURSOR_PREVIOUS_KEY=
 # GOCELL_CONFIG_CURSOR_PREVIOUS_KEY=
 
+# Encryption key provider (required when GOCELL_CELL_ADAPTER_MODE=postgres).
+# "local-aes"     — AES-256 envelope encryption with a local master key (dev/CI).
+# "vault-transit" — AES-256 envelope encryption with Vault Transit (production).
+# Omit when using in-memory storage (no encryption needed).
+# GOCELL_KEY_PROVIDER=local-aes
+
+# Local AES master key (required when GOCELL_KEY_PROVIDER=local-aes).
+# 32-byte hex-encoded key. Generate: openssl rand -hex 32
+# Real mode rejects well-known demo keys (case-insensitive).
+# GOCELL_MASTER_KEY=
+# GOCELL_MASTER_KEY_PREVIOUS=
+
+# Vault Transit (required when GOCELL_KEY_PROVIDER=vault-transit).
+# Standard Vault SDK env vars; see https://developer.hashicorp.com/vault/docs/commands#environment-variables
+# VAULT_ADDR=https://vault.example.internal:8200
+# VAULT_TOKEN=
+# GOCELL_VAULT_TRANSIT_MOUNT=transit
+# GOCELL_VAULT_TRANSIT_KEY=gocell-config
+
 # /readyz?verbose authentication token (required in GOCELL_ADAPTER_MODE=real
 # to prevent anonymous exposure of internal cell/dependency topology).
 # When unset in dev mode, /readyz?verbose is unauthenticated.

--- a/adapters/vault/client_adapter.go
+++ b/adapters/vault/client_adapter.go
@@ -61,7 +61,8 @@ func (a *vaultAPIClient) Read(ctx context.Context, path string) (map[string]any,
 func (a *vaultAPIClient) LookupSelfToken(ctx context.Context) (*vaultapi.Secret, error) {
 	secret, err := a.client.Auth().Token().LookupSelfWithContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("vault api: token lookup-self: %w", err)
+		return nil, errcode.Wrap(errcode.ErrKeyProviderAuthFailed,
+			"vault api: lookup self token", err)
 	}
 	return secret, nil
 }
@@ -71,5 +72,10 @@ func (a *vaultAPIClient) LookupSelfToken(ctx context.Context) (*vaultapi.Secret,
 //
 // ref: hashicorp/vault api/lifetime_watcher.go@main — Client.NewLifetimeWatcher
 func (a *vaultAPIClient) NewLifetimeWatcher(i *vaultapi.LifetimeWatcherInput) (*vaultapi.LifetimeWatcher, error) {
-	return a.client.NewLifetimeWatcher(i)
+	w, err := a.client.NewLifetimeWatcher(i)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.ErrKeyProviderAuthFailed,
+			"vault api: create lifetime watcher", err)
+	}
+	return w, nil
 }

--- a/adapters/vault/client_adapter.go
+++ b/adapters/vault/client_adapter.go
@@ -52,3 +52,24 @@ func (a *vaultAPIClient) Read(ctx context.Context, path string) (map[string]any,
 	}
 	return resp.Data, nil
 }
+
+// LookupSelfToken implements TokenRenewer. It calls auth/token/lookup-self to
+// retrieve the current token's metadata (TTL, renewable flag, accessor) and
+// returns a *vaultapi.Secret suitable for seeding a LifetimeWatcher.
+//
+// ref: hashicorp/vault api/auth_token.go@main — LookupSelfWithContext
+func (a *vaultAPIClient) LookupSelfToken(ctx context.Context) (*vaultapi.Secret, error) {
+	secret, err := a.client.Auth().Token().LookupSelfWithContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("vault api: token lookup-self: %w", err)
+	}
+	return secret, nil
+}
+
+// NewLifetimeWatcher implements TokenRenewer. It wraps client.NewLifetimeWatcher
+// to create a watcher that automatically renews the token at ~2/3 of its TTL.
+//
+// ref: hashicorp/vault api/lifetime_watcher.go@main — Client.NewLifetimeWatcher
+func (a *vaultAPIClient) NewLifetimeWatcher(i *vaultapi.LifetimeWatcherInput) (*vaultapi.LifetimeWatcher, error) {
+	return a.client.NewLifetimeWatcher(i)
+}

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -45,6 +45,109 @@ type VaultClient interface {
 	Read(ctx context.Context, path string) (map[string]any, error)
 }
 
+// TokenRenewer is an optional capability for VaultClient implementations that
+// support token lifecycle management. The production vaultAPIClient implements
+// this; test fakes do not (static tokens need no renewal).
+//
+// Type-assert the VaultClient to TokenRenewer to enable background renewal:
+//
+//	if r, ok := client.(TokenRenewer); ok { ... }
+//
+// ref: hashicorp/vault api/lifetime_watcher.go@main
+type TokenRenewer interface {
+	// LookupSelfToken returns the token's current metadata (TTL, renewable flag)
+	// by calling auth/token/lookup-self. Required to seed the LifetimeWatcher
+	// with an accurate initial LeaseDuration.
+	LookupSelfToken(ctx context.Context) (*vaultapi.Secret, error)
+	// NewLifetimeWatcher creates a LifetimeWatcher that automatically renews
+	// the token at ~2/3 of its TTL.
+	NewLifetimeWatcher(i *vaultapi.LifetimeWatcherInput) (*vaultapi.LifetimeWatcher, error)
+}
+
+// ---------------------------------------------------------------------------
+// tokenWatcher — abstraction over vaultapi.LifetimeWatcher for testability
+// ---------------------------------------------------------------------------
+
+// tokenWatcher abstracts the Vault SDK LifetimeWatcher channels so that
+// tokenRenewalWorker can be unit-tested without a real Vault connection.
+// The production implementation wraps *vaultapi.LifetimeWatcher directly.
+//
+// ref: hashicorp/vault api/lifetime_watcher.go@main — LifetimeWatcher.Start/Stop/DoneCh/RenewCh
+type tokenWatcher interface {
+	// Start begins the background renewal loop. Blocks until Stop() or the
+	// token can no longer be renewed.
+	Start()
+	// Stop signals the watcher to stop its internal loop.
+	Stop()
+	// DoneCh fires once, either when renewal is no longer possible (nil error)
+	// or when an unrecoverable error occurs.
+	DoneCh() <-chan error
+	// RenewCh fires on each successful token renewal.
+	RenewCh() <-chan *vaultapi.RenewOutput
+}
+
+// vaultLifetimeWatcherAdapter wraps *vaultapi.LifetimeWatcher to satisfy
+// the tokenWatcher interface. It is only used in the production path where
+// a real Vault client supports TokenRenewer.
+type vaultLifetimeWatcherAdapter struct {
+	w *vaultapi.LifetimeWatcher
+}
+
+func (a *vaultLifetimeWatcherAdapter) Start()                                { a.w.Start() }
+func (a *vaultLifetimeWatcherAdapter) Stop()                                 { a.w.Stop() }
+func (a *vaultLifetimeWatcherAdapter) DoneCh() <-chan error                  { return a.w.DoneCh() }
+func (a *vaultLifetimeWatcherAdapter) RenewCh() <-chan *vaultapi.RenewOutput { return a.w.RenewCh() }
+
+// ---------------------------------------------------------------------------
+// tokenRenewalWorker — worker.Worker wrapping the token renewal loop
+// ---------------------------------------------------------------------------
+
+// tokenRenewalWorker implements worker.Worker, wrapping the tokenWatcher
+// lifecycle. Start blocks until the context is cancelled or the token can no
+// longer be renewed. Stop signals the watcher to stop gracefully.
+//
+// ref: hashicorp/vault api/lifetime_watcher.go@main — LifetimeWatcher usage pattern
+type tokenRenewalWorker struct {
+	watcher tokenWatcher
+	logger  *slog.Logger
+}
+
+// Start launches watcher.Start() in a goroutine, then loops on the watcher
+// channels until ctx is done or the token is no longer renewable.
+// Stop() is always called on exit to release watcher resources.
+func (w *tokenRenewalWorker) Start(ctx context.Context) error {
+	go w.watcher.Start()
+	defer w.watcher.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-w.watcher.DoneCh():
+			if err != nil {
+				w.logger.ErrorContext(ctx, "vault-transit: token renewal stopped with error",
+					slog.String("error", err.Error()))
+			} else {
+				w.logger.WarnContext(ctx, "vault-transit: token is no longer renewable")
+			}
+			return err
+		case renewal := <-w.watcher.RenewCh():
+			leaseDuration := 0
+			if renewal.Secret != nil && renewal.Secret.Auth != nil {
+				leaseDuration = renewal.Secret.Auth.LeaseDuration
+			}
+			w.logger.InfoContext(ctx, "vault-transit: token renewed",
+				slog.Int("lease_duration", leaseDuration))
+		}
+	}
+}
+
+// Stop signals the watcher to stop its internal loop.
+func (w *tokenRenewalWorker) Stop(_ context.Context) error {
+	w.watcher.Stop()
+	return nil
+}
+
 // Compile-time interface assertions — fail at build time if the scaffold drifts
 // from the kernel/crypto contracts.
 var _ kcrypto.KeyProvider = (*TransitKeyProvider)(nil)
@@ -254,12 +357,19 @@ type TransitKeyProvider struct {
 	client    VaultClient
 	mountPath string
 	keyName   string
+
+	// renewalWorker manages background Vault token renewal (A13).
+	// nil when the VaultClient does not implement TokenRenewer (e.g. test fakes).
+	renewalWorker *tokenRenewalWorker
+	logger        *slog.Logger
 }
 
 // NewTransitKeyProvider creates a TransitKeyProvider with the given VaultClient.
 // This is the testable constructor — inject a fake VaultClient in tests.
 // The VaultClient interface is exported so external packages can provide
 // custom implementations without importing github.com/hashicorp/vault/api.
+// When the provided client also implements TokenRenewer, background token
+// renewal is automatically configured (but not started — call Worker().Start).
 func NewTransitKeyProvider(client VaultClient, mountPath, keyName string) *TransitKeyProvider {
 	if mountPath == "" {
 		mountPath = "transit"
@@ -271,6 +381,7 @@ func NewTransitKeyProvider(client VaultClient, mountPath, keyName string) *Trans
 		client:    client,
 		mountPath: mountPath,
 		keyName:   keyName,
+		logger:    slog.Default(),
 	}
 }
 
@@ -326,6 +437,13 @@ func NewTransitKeyProviderFromEnv() (*TransitKeyProvider, error) {
 	// Return the classified error directly to preserve errcode identity for callers.
 	ctx := context.Background()
 	if _, err = p.readLatestVersion(ctx); err != nil {
+		return nil, err
+	}
+
+	// A13: initialise background token renewal if the client supports it.
+	// Non-fatal: a warn log is emitted when the client lacks TokenRenewer;
+	// the provider continues to function but the token will expire without notice.
+	if err = p.initTokenRenewal(ctx); err != nil {
 		return nil, err
 	}
 
@@ -600,18 +718,63 @@ func (p *TransitKeyProvider) Checkers() map[string]func() error {
 	}
 }
 
-// Worker returns nil because TransitKeyProvider has no background goroutine.
-// The ManagedResource interface documents that returning nil means no background
-// goroutine is needed; bootstrap skips WithWorkers registration for this resource.
+// Worker returns the token renewal worker when one has been configured, or nil
+// when the VaultClient does not implement TokenRenewer (e.g. test fakes with
+// static tokens). The bootstrap layer skips WithWorkers registration for nil.
 //
 // ref: kernel/lifecycle.ManagedResource — "Returning nil means no background
 //
 //	goroutine is needed"
-func (p *TransitKeyProvider) Worker() worker.Worker { return nil }
+func (p *TransitKeyProvider) Worker() worker.Worker {
+	if p.renewalWorker == nil {
+		return nil
+	}
+	return p.renewalWorker
+}
 
-// Close is a no-op for TransitKeyProvider: the underlying VaultClient manages
-// HTTP connection pooling via the standard net/http.Client (which requires no
-// explicit close). Close satisfies the lifecycle.ManagedResource contract and
-// allows future implementations to flush pending work or drain connections
-// if the VaultClient abstraction changes.
-func (p *TransitKeyProvider) Close(_ context.Context) error { return nil }
+// Close stops the token renewal worker (if configured) and satisfies the
+// lifecycle.ManagedResource contract. The underlying VaultClient manages
+// HTTP connection pooling via net/http.Client, which requires no explicit close.
+func (p *TransitKeyProvider) Close(ctx context.Context) error {
+	if p.renewalWorker != nil {
+		return p.renewalWorker.Stop(ctx)
+	}
+	return nil
+}
+
+// initTokenRenewal configures background token renewal when the client
+// implements TokenRenewer. A warn log is emitted when the client lacks the
+// capability; the provider continues to function without renewal.
+//
+// ref: hashicorp/vault api/lifetime_watcher.go@main — LifetimeWatcher usage pattern
+// ref: external-secrets/external-secrets pkg/provider/vault — ValidateStore (token lookup probe)
+func (p *TransitKeyProvider) initTokenRenewal(ctx context.Context) error {
+	renewer, ok := p.client.(TokenRenewer)
+	if !ok {
+		p.logger.WarnContext(ctx,
+			"vault-transit: VaultClient does not support token renewal; "+
+				"static token will expire without notification")
+		return nil
+	}
+
+	// Look up the current token to seed the LifetimeWatcher with accurate TTL.
+	secret, err := renewer.LookupSelfToken(ctx)
+	if err != nil {
+		return errcode.Wrap(errcode.ErrKeyProviderTransient,
+			"vault-transit: lookup self token for renewal initialisation", err)
+	}
+
+	raw, err := renewer.NewLifetimeWatcher(&vaultapi.LifetimeWatcherInput{
+		Secret: secret,
+	})
+	if err != nil {
+		return errcode.Wrap(errcode.ErrKeyProviderTransient,
+			"vault-transit: create lifetime watcher", err)
+	}
+
+	p.renewalWorker = &tokenRenewalWorker{
+		watcher: &vaultLifetimeWatcherAdapter{w: raw},
+		logger:  p.logger,
+	}
+	return nil
+}

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -106,15 +106,27 @@ func (a *vaultLifetimeWatcherAdapter) RenewCh() <-chan *vaultapi.RenewOutput { r
 // lifecycle. Start blocks until the context is cancelled or the token can no
 // longer be renewed. Stop signals the watcher to stop gracefully.
 //
+// stopOnce ensures watcher.Stop is called at most once regardless of whether
+// the caller invokes Stop explicitly (Worker.Stop, phase 8) and also via
+// Close (ManagedResource.Close, phase 10) during shutdown.
+//
 // ref: hashicorp/vault api/lifetime_watcher.go@main — LifetimeWatcher usage pattern
 type tokenRenewalWorker struct {
-	watcher tokenWatcher
-	logger  *slog.Logger
+	watcher  tokenWatcher
+	logger   *slog.Logger
+	stopOnce sync.Once
 }
 
 // Start launches watcher.Start() in a goroutine, then loops on the watcher
 // channels until ctx is done or the token is no longer renewable.
 // Stop() is always called on exit to release watcher resources.
+//
+// DoneCh semantics:
+//   - channel closed (ok=false): watcher stopped externally → return nil.
+//   - non-nil error: unrecoverable renewal failure → log + return error.
+//   - nil error: token is no longer renewable (operational alert) →
+//     log at Error level + return ErrKeyProviderAuthFailed so the bootstrap
+//     layer can alert operators before token expiry.
 func (w *tokenRenewalWorker) Start(ctx context.Context) error {
 	go w.watcher.Start()
 	defer w.watcher.Stop()
@@ -123,28 +135,61 @@ func (w *tokenRenewalWorker) Start(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case err := <-w.watcher.DoneCh():
-			if err != nil {
-				w.logger.ErrorContext(ctx, "vault-transit: token renewal stopped with error",
-					slog.String("error", err.Error()))
-			} else {
-				w.logger.WarnContext(ctx, "vault-transit: token is no longer renewable")
+		case err, ok := <-w.watcher.DoneCh():
+			if done, result := w.handleDone(ctx, err, ok); done {
+				return result
 			}
-			return err
-		case renewal := <-w.watcher.RenewCh():
-			leaseDuration := 0
-			if renewal.Secret != nil && renewal.Secret.Auth != nil {
-				leaseDuration = renewal.Secret.Auth.LeaseDuration
+		case renewal, ok := <-w.watcher.RenewCh():
+			if stop := w.handleRenewal(ctx, renewal, ok); stop {
+				return nil
 			}
-			w.logger.InfoContext(ctx, "vault-transit: token renewed",
-				slog.Int("lease_duration", leaseDuration))
 		}
 	}
 }
 
-// Stop signals the watcher to stop its internal loop.
+// handleDone processes a DoneCh event. Returns (true, err) when Start should
+// exit, (false, nil) when the event should be ignored (never occurs in practice
+// since DoneCh fires at most once, but the signature is symmetric for clarity).
+func (w *tokenRenewalWorker) handleDone(ctx context.Context, err error, ok bool) (done bool, result error) {
+	if !ok {
+		// Channel closed: watcher stopped externally — clean exit.
+		return true, nil
+	}
+	if err != nil {
+		w.logger.ErrorContext(ctx, "vault-transit: token renewal stopped with error",
+			slog.String("error", err.Error()))
+		return true, err
+	}
+	// nil error = Vault LifetimeWatcher confirmed token is no longer renewable.
+	// Operational alert: return error so bootstrap/supervisor can surface this
+	// before encrypt/decrypt starts failing.
+	w.logger.ErrorContext(ctx, "vault-transit: token is no longer renewable; operator must rotate token before expiry")
+	return true, errcode.New(errcode.ErrKeyProviderAuthFailed,
+		"vault-transit: token is no longer renewable; encrypt/decrypt will fail after token expiry")
+}
+
+// handleRenewal processes a RenewCh event. Returns true when Start should exit
+// (channel closed), false to continue the loop.
+func (w *tokenRenewalWorker) handleRenewal(ctx context.Context, renewal *vaultapi.RenewOutput, ok bool) (stop bool) {
+	if !ok {
+		// RenewCh closed: watcher stopped externally — clean exit.
+		return true
+	}
+	if renewal == nil || renewal.Secret == nil || renewal.Secret.Auth == nil {
+		w.logger.WarnContext(ctx, "vault-transit: received nil or incomplete renewal notification")
+		return false
+	}
+	w.logger.InfoContext(ctx, "vault-transit: token renewed",
+		slog.Int("lease_duration", renewal.Secret.Auth.LeaseDuration))
+	return false
+}
+
+// Stop signals the watcher to stop its internal loop. Idempotent: safe to
+// call multiple times (stopOnce ensures watcher.Stop is invoked exactly once).
 func (w *tokenRenewalWorker) Stop(_ context.Context) error {
-	w.watcher.Stop()
+	w.stopOnce.Do(func() {
+		w.watcher.Stop()
+	})
 	return nil
 }
 
@@ -760,7 +805,7 @@ func (p *TransitKeyProvider) initTokenRenewal(ctx context.Context) error {
 	// Look up the current token to seed the LifetimeWatcher with accurate TTL.
 	secret, err := renewer.LookupSelfToken(ctx)
 	if err != nil {
-		return errcode.Wrap(errcode.ErrKeyProviderTransient,
+		return errcode.Wrap(errcode.ErrKeyProviderAuthFailed,
 			"vault-transit: lookup self token for renewal initialisation", err)
 	}
 
@@ -768,7 +813,7 @@ func (p *TransitKeyProvider) initTokenRenewal(ctx context.Context) error {
 		Secret: secret,
 	})
 	if err != nil {
-		return errcode.Wrap(errcode.ErrKeyProviderTransient,
+		return errcode.Wrap(errcode.ErrKeyProviderAuthFailed,
 			"vault-transit: create lifetime watcher", err)
 	}
 

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -947,51 +947,118 @@ func TestTokenRenewalWorker_Start_StopsOnContextCancel(t *testing.T) {
 
 // TestTokenRenewalWorker_Start_HandlesRenewalNotification verifies that
 // renewal notifications are consumed and logged without blocking Start.
+// Also verifies that a nil renewal is handled gracefully (no panic, no stop).
 func TestTokenRenewalWorker_Start_HandlesRenewalNotification(t *testing.T) {
+	t.Run("valid renewal consumed without error", func(t *testing.T) {
+		fw := newFakeTokenWatcher()
+		w := &tokenRenewalWorker{
+			watcher: fw,
+			logger:  slog.Default(),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- w.Start(ctx)
+		}()
+
+		select {
+		case <-fw.startedCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher.Start() was not called within 2s")
+		}
+
+		fw.renewCh <- &vaultapi.RenewOutput{
+			Secret: &vaultapi.Secret{
+				Auth: &vaultapi.SecretAuth{
+					LeaseDuration: 3600,
+				},
+			},
+		}
+
+		cancel()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Start() returned error on renewal+cancel, want nil: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Start() did not return after context cancel")
+		}
+	})
+
+	t.Run("nil renewal handled gracefully (F7)", func(t *testing.T) {
+		fw := newFakeTokenWatcher()
+		w := &tokenRenewalWorker{
+			watcher: fw,
+			logger:  slog.Default(),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- w.Start(ctx)
+		}()
+
+		select {
+		case <-fw.startedCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher.Start() was not called within 2s")
+		}
+
+		// Send nil renewal — must not panic, must not stop Start.
+		fw.renewCh <- nil
+
+		cancel()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Start() returned error after nil renewal+cancel, want nil: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Start() did not return after context cancel")
+		}
+	})
+}
+
+// TestTokenRenewalWorker_Start_ChannelClosed verifies that Start returns nil
+// when DoneCh is closed externally (channel closed = watcher stopped externally).
+func TestTokenRenewalWorker_Start_ChannelClosed(t *testing.T) {
 	fw := newFakeTokenWatcher()
 	w := &tokenRenewalWorker{
 		watcher: fw,
 		logger:  slog.Default(),
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
 	done := make(chan error, 1)
 	go func() {
 		done <- w.Start(ctx)
 	}()
 
-	// Wait for the watcher's Start goroutine to be scheduled.
-	select {
-	case <-fw.startedCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("watcher.Start() was not called within 2s")
-	}
-
-	// Send a renewal notification with lease_duration
-	fw.renewCh <- &vaultapi.RenewOutput{
-		Secret: &vaultapi.Secret{
-			Auth: &vaultapi.SecretAuth{
-				LeaseDuration: 3600,
-			},
-		},
-	}
-
-	cancel()
+	// Close the channel (not send on it) to simulate external watcher stop.
+	close(fw.doneCh)
 
 	select {
 	case err := <-done:
 		if err != nil {
-			t.Errorf("Start() returned error on renewal+cancel, want nil: %v", err)
+			t.Errorf("Start() on closed DoneCh must return nil, got: %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("Start() did not return after context cancel")
+		t.Fatal("Start() did not return after DoneCh closed")
 	}
 }
 
-// TestTokenRenewalWorker_Start_HandlesDone verifies that Start returns the
-// done channel error when the watcher signals it can no longer renew.
+// TestTokenRenewalWorker_Start_HandlesDone verifies that Start returns a
+// non-nil ErrKeyProviderAuthFailed when the watcher signals the token is
+// no longer renewable (nil error on DoneCh = operational alert, not graceful).
 func TestTokenRenewalWorker_Start_HandlesDone(t *testing.T) {
 	fw := newFakeTokenWatcher()
 	w := &tokenRenewalWorker{
@@ -1006,14 +1073,17 @@ func TestTokenRenewalWorker_Start_HandlesDone(t *testing.T) {
 		done <- w.Start(ctx)
 	}()
 
-	// Signal watcher done with nil error (token no longer renewable, not an error per se)
+	// Signal watcher done with nil error (token no longer renewable).
+	// F3: this must return a non-nil ErrKeyProviderAuthFailed, not nil.
 	fw.doneCh <- nil
 
 	select {
 	case err := <-done:
-		// nil done → Start returns nil (graceful "token expired" path)
-		if err != nil {
-			t.Errorf("Start() on nil DoneCh error = %v, want nil", err)
+		if err == nil {
+			t.Error("Start() on nil DoneCh must return non-nil error (token no longer renewable)")
+		}
+		if !errChainHasCode(err, errcode.ErrKeyProviderAuthFailed) {
+			t.Errorf("expected ErrKeyProviderAuthFailed in error chain, got: %v", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Start() did not return after DoneCh fired")
@@ -1066,6 +1136,27 @@ func TestTokenRenewalWorker_Stop(t *testing.T) {
 	}
 	if !fw.stopped.Load() {
 		t.Error("Stop() must call watcher.Stop()")
+	}
+}
+
+// TestTokenRenewalWorker_Stop_Idempotent verifies that calling Stop twice does
+// not panic or produce errors (F2: double-stop during shutdown).
+func TestTokenRenewalWorker_Stop_Idempotent(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+	}
+
+	ctx := context.Background()
+	if err := w.Stop(ctx); err != nil {
+		t.Errorf("Stop() first call returned unexpected error: %v", err)
+	}
+	if err := w.Stop(ctx); err != nil {
+		t.Errorf("Stop() second call returned unexpected error: %v", err)
+	}
+	if !fw.stopped.Load() {
+		t.Error("Stop() must have called watcher.Stop()")
 	}
 }
 
@@ -1136,4 +1227,82 @@ func TestTransitKeyProvider_ConcurrentEncryptRotate(t *testing.T) {
 
 	wg.Wait()
 	// No race detector report = pass. The test itself needs -race to be meaningful.
+}
+
+// ---------------------------------------------------------------------------
+// F4+F5: initTokenRenewal error code tests
+// ---------------------------------------------------------------------------
+
+// fakeTokenRenewer implements both VaultClient and TokenRenewer for testing
+// initTokenRenewal. LookupSelfToken and NewLifetimeWatcher errors are injectable.
+type fakeTokenRenewer struct {
+	fakeVaultClient
+	lookupErr     error
+	newWatcherErr error
+	lookupSecret  *vaultapi.Secret
+}
+
+var _ TokenRenewer = (*fakeTokenRenewer)(nil)
+
+func (f *fakeTokenRenewer) LookupSelfToken(_ context.Context) (*vaultapi.Secret, error) {
+	if f.lookupErr != nil {
+		return nil, f.lookupErr
+	}
+	if f.lookupSecret != nil {
+		return f.lookupSecret, nil
+	}
+	return &vaultapi.Secret{}, nil
+}
+
+func (f *fakeTokenRenewer) NewLifetimeWatcher(_ *vaultapi.LifetimeWatcherInput) (*vaultapi.LifetimeWatcher, error) {
+	if f.newWatcherErr != nil {
+		return nil, f.newWatcherErr
+	}
+	// Return nil watcher — caller (initTokenRenewal) will panic if it dereferences it.
+	// Tests that exercise the happy path must not call this.
+	return nil, nil
+}
+
+// TestInitTokenRenewal_LookupFails_ReturnsAuthError verifies that a
+// LookupSelfToken failure results in ErrKeyProviderAuthFailed, not
+// ErrKeyProviderTransient (F4: wrong error code at startup).
+func TestInitTokenRenewal_LookupFails_ReturnsAuthError(t *testing.T) {
+	injectedErr := fmt.Errorf("vault: 403 forbidden")
+	fake := &fakeTokenRenewer{
+		fakeVaultClient: fakeVaultClient{latestVersion: 1},
+		lookupErr:       injectedErr,
+	}
+
+	p := NewTransitKeyProvider(fake, "transit", "gocell-config")
+	err := p.initTokenRenewal(context.Background())
+
+	if err == nil {
+		t.Fatal("initTokenRenewal must return error when LookupSelfToken fails")
+	}
+	if !errChainHasCode(err, errcode.ErrKeyProviderAuthFailed) {
+		t.Errorf("expected ErrKeyProviderAuthFailed in error chain, got: %v", err)
+	}
+	if errChainHasCode(err, errcode.ErrKeyProviderTransient) {
+		t.Errorf("must NOT return ErrKeyProviderTransient for LookupSelf failure; got: %v", err)
+	}
+}
+
+// TestInitTokenRenewal_NewWatcherFails_ReturnsAuthError verifies that a
+// NewLifetimeWatcher failure also results in ErrKeyProviderAuthFailed (F4).
+func TestInitTokenRenewal_NewWatcherFails_ReturnsAuthError(t *testing.T) {
+	injectedErr := fmt.Errorf("vault: create watcher: invalid secret")
+	fake := &fakeTokenRenewer{
+		fakeVaultClient: fakeVaultClient{latestVersion: 1},
+		newWatcherErr:   injectedErr,
+	}
+
+	p := NewTransitKeyProvider(fake, "transit", "gocell-config")
+	err := p.initTokenRenewal(context.Background())
+
+	if err == nil {
+		t.Fatal("initTokenRenewal must return error when NewLifetimeWatcher fails")
+	}
+	if !errChainHasCode(err, errcode.ErrKeyProviderAuthFailed) {
+		t.Errorf("expected ErrKeyProviderAuthFailed in error chain, got: %v", err)
+	}
 }

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -24,11 +24,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	vaultapi "github.com/hashicorp/vault/api"
 
@@ -843,6 +845,254 @@ func TestParseVaultKeyID(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// A13: Token LifetimeWatcher tests
+// ---------------------------------------------------------------------------
+
+// fakeTokenWatcher is a controllable fake for the tokenWatcher interface.
+// Channels are buffered to avoid goroutine leaks in tests.
+type fakeTokenWatcher struct {
+	doneCh    chan error
+	renewCh   chan *vaultapi.RenewOutput
+	startedCh chan struct{} // closed when Start() is called
+	stopped   atomic.Bool
+}
+
+func newFakeTokenWatcher() *fakeTokenWatcher {
+	return &fakeTokenWatcher{
+		doneCh:    make(chan error, 1),
+		renewCh:   make(chan *vaultapi.RenewOutput, 4),
+		startedCh: make(chan struct{}),
+	}
+}
+
+func (f *fakeTokenWatcher) Start() { close(f.startedCh) }
+func (f *fakeTokenWatcher) Stop()  { f.stopped.Store(true) }
+
+func (f *fakeTokenWatcher) DoneCh() <-chan error {
+	return f.doneCh
+}
+
+func (f *fakeTokenWatcher) RenewCh() <-chan *vaultapi.RenewOutput {
+	return f.renewCh
+}
+
+// TestTransitKeyProvider_Worker_NilWhenNoRenewal verifies that the default
+// constructor (NewTransitKeyProvider) returns nil Worker — no background
+// goroutine needed when no TokenRenewer is available.
+func TestTransitKeyProvider_Worker_NilWhenNoRenewal(t *testing.T) {
+	fake := &fakeVaultClient{latestVersion: 1}
+	p := NewTransitKeyProvider(fake, "transit", "gocell-config")
+
+	if p.Worker() != nil {
+		t.Error("Worker() must return nil when no renewal worker is configured")
+	}
+}
+
+// TestTransitKeyProvider_Worker_NonNilWhenRenewalConfigured verifies that
+// Worker() returns the configured renewal worker when one is set.
+func TestTransitKeyProvider_Worker_NonNilWhenRenewalConfigured(t *testing.T) {
+	fake := &fakeVaultClient{latestVersion: 1}
+	p := NewTransitKeyProvider(fake, "transit", "gocell-config")
+
+	fw := newFakeTokenWatcher()
+	p.renewalWorker = &tokenRenewalWorker{watcher: fw}
+
+	if p.Worker() == nil {
+		t.Error("Worker() must return non-nil when renewalWorker is set")
+	}
+}
+
+// TestTokenRenewalWorker_Start_StopsOnContextCancel verifies that Start()
+// returns nil when its context is cancelled (graceful shutdown path).
+func TestTokenRenewalWorker_Start_StopsOnContextCancel(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	// Wait until the watcher's Start goroutine has been scheduled before
+	// cancelling — ensures the assertion below is race-free.
+	select {
+	case <-fw.startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher.Start() was not called within 2s")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() returned error on ctx cancel, want nil: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after context cancel")
+	}
+
+	if !fw.stopped.Load() {
+		t.Error("Start() must call watcher.Stop() on exit")
+	}
+}
+
+// TestTokenRenewalWorker_Start_HandlesRenewalNotification verifies that
+// renewal notifications are consumed and logged without blocking Start.
+func TestTokenRenewalWorker_Start_HandlesRenewalNotification(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	// Wait for the watcher's Start goroutine to be scheduled.
+	select {
+	case <-fw.startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher.Start() was not called within 2s")
+	}
+
+	// Send a renewal notification with lease_duration
+	fw.renewCh <- &vaultapi.RenewOutput{
+		Secret: &vaultapi.Secret{
+			Auth: &vaultapi.SecretAuth{
+				LeaseDuration: 3600,
+			},
+		},
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() returned error on renewal+cancel, want nil: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after context cancel")
+	}
+}
+
+// TestTokenRenewalWorker_Start_HandlesDone verifies that Start returns the
+// done channel error when the watcher signals it can no longer renew.
+func TestTokenRenewalWorker_Start_HandlesDone(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+	}
+
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	// Signal watcher done with nil error (token no longer renewable, not an error per se)
+	fw.doneCh <- nil
+
+	select {
+	case err := <-done:
+		// nil done → Start returns nil (graceful "token expired" path)
+		if err != nil {
+			t.Errorf("Start() on nil DoneCh error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after DoneCh fired")
+	}
+
+	if !fw.stopped.Load() {
+		t.Error("Start() must call watcher.Stop() on DoneCh exit")
+	}
+}
+
+// TestTokenRenewalWorker_Start_HandlesDoneWithError verifies that Start
+// propagates a non-nil error from the done channel.
+func TestTokenRenewalWorker_Start_HandlesDoneWithError(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+	}
+
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	injectedErr := errcode.New(errcode.ErrKeyProviderTransient, "vault: token renewal failed")
+	fw.doneCh <- injectedErr
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("Start() must propagate non-nil DoneCh error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after DoneCh fired with error")
+	}
+}
+
+// TestTokenRenewalWorker_Stop verifies that Stop calls watcher.Stop().
+func TestTokenRenewalWorker_Stop(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+	}
+
+	if err := w.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() returned unexpected error: %v", err)
+	}
+	if !fw.stopped.Load() {
+		t.Error("Stop() must call watcher.Stop()")
+	}
+}
+
+// TestTransitKeyProvider_Close_StopsRenewalWorker verifies that Close()
+// stops the renewal worker when one is configured.
+func TestTransitKeyProvider_Close_StopsRenewalWorker(t *testing.T) {
+	fake := &fakeVaultClient{latestVersion: 1}
+	p := NewTransitKeyProvider(fake, "transit", "gocell-config")
+
+	fw := newFakeTokenWatcher()
+	p.renewalWorker = &tokenRenewalWorker{watcher: fw}
+
+	if err := p.Close(context.Background()); err != nil {
+		t.Errorf("Close() returned unexpected error: %v", err)
+	}
+	if !fw.stopped.Load() {
+		t.Error("Close() must call watcher.Stop() when renewalWorker is set")
+	}
+}
+
+// TestVaultAPIClient_ImplementsTokenRenewer is a compile-time assertion that
+// vaultAPIClient satisfies the TokenRenewer interface.
+// The actual interface is in transit_provider.go; this test fails to compile
+// if the implementation is missing or mismatched.
+func TestVaultAPIClient_ImplementsTokenRenewer(t *testing.T) {
+	// This is a compile-time check only; no runtime assertions needed.
+	var _ TokenRenewer = (*vaultAPIClient)(nil)
 }
 
 // ---------------------------------------------------------------------------

--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -180,7 +180,7 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	// Deferred PG repo construction — options are all applied before Init().
 	if c.pgPool != nil && c.configRepo == nil {
 		session := cellpg.NewSession(c.pgPool)
-		c.configRepo = cellpg.NewConfigRepository(session, c.valueTransformer)
+		c.configRepo = cellpg.NewConfigRepository(session, c.valueTransformer, nil)
 		c.flagRepo = cellpg.NewFlagRepository(session)
 	}
 

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -65,6 +65,24 @@ type ConfigRepository struct {
 	onStaleCipher func(key, storedKeyID, currentKeyID string)
 }
 
+// ConfigRepoOption configures optional behaviour on ConfigRepository.
+type ConfigRepoOption func(*ConfigRepository)
+
+// WithOnStaleCipher sets a callback invoked when a stale-key value is detected
+// during a read. Callers may wire this to a prometheus counter:
+//
+//	WithOnStaleCipher(func(key, storedKeyID, currentKeyID string) {
+//	    staleCipherTotal.Inc()
+//	})
+//
+// The callback receives (key, storedKeyID, currentKeyID). When nil, it is
+// skipped; slog.Warn is always emitted regardless.
+func WithOnStaleCipher(fn func(key, storedKeyID, currentKeyID string)) ConfigRepoOption {
+	return func(r *ConfigRepository) {
+		r.onStaleCipher = fn
+	}
+}
+
 // NewConfigRepository creates a ConfigRepository that resolves the ambient
 // pgx.Tx from the context on each call, enabling transactional participation
 // via persistence.TxCtxKey. Session is the sole production entry point;
@@ -73,11 +91,15 @@ type ConfigRepository struct {
 // If logger is nil, slog.Default() is used.
 //
 // Requires migrations 001–010 to be applied first (see adapters/postgres/migrations/).
-func NewConfigRepository(s *Session, tr kcrypto.ValueTransformer, logger *slog.Logger) *ConfigRepository {
+func NewConfigRepository(s *Session, tr kcrypto.ValueTransformer, logger *slog.Logger, opts ...ConfigRepoOption) *ConfigRepository {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &ConfigRepository{session: s, transformer: tr, logger: logger}
+	r := &ConfigRepository{session: s, transformer: tr, logger: logger}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // resolveDB returns the DBTX to use for read calls. When a Session is
@@ -384,7 +406,12 @@ const sensitiveListSentinel = "***"
 // preserves key metadata (KeyID, Stale) for informational purposes, and emits
 // observability signals (slog.Warn + optional onStaleCipher callback) when the
 // stored keyID differs from the current active keyID.
-func (r *ConfigRepository) applySensitiveListSentinel(ctx context.Context, e *domain.ConfigEntry, valueKeyID *string, currentID string) {
+//
+// staleLogged tracks which stale keyIDs have already been logged in this List
+// call to prevent log flooding when many entries share the same stale keyID.
+// The onStaleCipher callback always fires for every stale entry (metric accuracy);
+// only the slog.Warn is deduplicated per distinct keyID per List call.
+func (r *ConfigRepository) applySensitiveListSentinel(ctx context.Context, e *domain.ConfigEntry, valueKeyID *string, currentID string, staleLogged map[string]bool) {
 	e.Value = sensitiveListSentinel
 	if valueKeyID == nil {
 		return
@@ -392,7 +419,16 @@ func (r *ConfigRepository) applySensitiveListSentinel(ctx context.Context, e *do
 	e.KeyID = *valueKeyID
 	if currentID != "" && currentID != *valueKeyID {
 		e.Stale = true
-		r.observeStaleCipher(ctx, e.Key, *valueKeyID, currentID)
+		if r.onStaleCipher != nil {
+			r.onStaleCipher(e.Key, *valueKeyID, currentID)
+		}
+		if !staleLogged[*valueKeyID] {
+			staleLogged[*valueKeyID] = true
+			r.logger.WarnContext(ctx, "config values encrypted with stale key (first occurrence in this List page)",
+				slog.String("stored_key_id", *valueKeyID),
+				slog.String("current_key_id", currentID),
+			)
+		}
 	}
 }
 
@@ -428,6 +464,7 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 	defer rows.Close()
 
 	currentID := r.currentKeyID(ctx)
+	staleLogged := make(map[string]bool)
 	var entries []*domain.ConfigEntry
 	for rows.Next() {
 		var (
@@ -438,7 +475,7 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 			return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: scan failed", err)
 		}
 		if e.Sensitive {
-			r.applySensitiveListSentinel(ctx, &e, valueKeyID, currentID)
+			r.applySensitiveListSentinel(ctx, &e, valueKeyID, currentID, staleLogged)
 		}
 		entries = append(entries, &e)
 	}

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	configcrypto "github.com/ghbvf/gocell/cells/config-core/internal/crypto"
@@ -55,6 +56,13 @@ type ConfigRepository struct {
 	db          DBTX     // test-only: set by newConfigRepositoryFromDBTX (unexported helper in test file)
 	session     *Session // production path: resolves ambient tx via persistence.TxCtxKey
 	transformer kcrypto.ValueTransformer
+	logger      *slog.Logger
+	// onStaleCipher is an optional callback invoked when a stale-key value is
+	// detected during a read. Callers may wire this to a prometheus counter:
+	//   repo.onStaleCipher = func(_, _, _ string) { staleCipherTotal.Inc() }
+	// The callback receives (key, storedKeyID, currentKeyID). When nil, it is
+	// skipped; slog.Warn is always emitted regardless.
+	onStaleCipher func(key, storedKeyID, currentKeyID string)
 }
 
 // NewConfigRepository creates a ConfigRepository that resolves the ambient
@@ -62,9 +70,14 @@ type ConfigRepository struct {
 // via persistence.TxCtxKey. Session is the sole production entry point;
 // use the unexported newConfigRepositoryFromDBTX in tests.
 //
+// If logger is nil, slog.Default() is used.
+//
 // Requires migrations 001–010 to be applied first (see adapters/postgres/migrations/).
-func NewConfigRepository(s *Session, tr kcrypto.ValueTransformer) *ConfigRepository {
-	return &ConfigRepository{session: s, transformer: tr}
+func NewConfigRepository(s *Session, tr kcrypto.ValueTransformer, logger *slog.Logger) *ConfigRepository {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ConfigRepository{session: s, transformer: tr, logger: logger}
 }
 
 // resolveDB returns the DBTX to use for read calls. When a Session is
@@ -257,11 +270,26 @@ func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.Co
 			currentID := r.currentKeyID(ctx)
 			if currentID != "" && currentID != *valueKeyID {
 				e.Stale = true
+				r.observeStaleCipher(ctx, key, *valueKeyID, currentID)
 			}
 		}
 	}
 
 	return &e, nil
+}
+
+// observeStaleCipher emits a slog.Warn and invokes the optional onStaleCipher
+// callback when a sensitive config value is found to be encrypted with a stale
+// (non-current) key. This is the single observability point for M3.
+func (r *ConfigRepository) observeStaleCipher(ctx context.Context, key, storedKeyID, currentKeyID string) {
+	r.logger.WarnContext(ctx, "config value encrypted with stale key",
+		slog.String("key", key),
+		slog.String("stored_key_id", storedKeyID),
+		slog.String("current_key_id", currentKeyID),
+	)
+	if r.onStaleCipher != nil {
+		r.onStaleCipher(key, storedKeyID, currentKeyID)
+	}
 }
 
 // currentKeyID returns the ID of the current key from the transformer.
@@ -352,9 +380,11 @@ func (r *ConfigRepository) Delete(ctx context.Context, key string) error {
 // List does not decrypt sensitive values — callers use GetByKey for plaintext access.
 const sensitiveListSentinel = "***"
 
-// applySensitiveListSentinel redacts the value field of a sensitive list entry
-// and preserves key metadata (KeyID, Stale) for informational purposes.
-func applySensitiveListSentinel(e *domain.ConfigEntry, valueKeyID *string, currentID string) {
+// applySensitiveListSentinel redacts the value field of a sensitive list entry,
+// preserves key metadata (KeyID, Stale) for informational purposes, and emits
+// observability signals (slog.Warn + optional onStaleCipher callback) when the
+// stored keyID differs from the current active keyID.
+func (r *ConfigRepository) applySensitiveListSentinel(ctx context.Context, e *domain.ConfigEntry, valueKeyID *string, currentID string) {
 	e.Value = sensitiveListSentinel
 	if valueKeyID == nil {
 		return
@@ -362,6 +392,7 @@ func applySensitiveListSentinel(e *domain.ConfigEntry, valueKeyID *string, curre
 	e.KeyID = *valueKeyID
 	if currentID != "" && currentID != *valueKeyID {
 		e.Stale = true
+		r.observeStaleCipher(ctx, e.Key, *valueKeyID, currentID)
 	}
 }
 
@@ -407,7 +438,7 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 			return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: scan failed", err)
 		}
 		if e.Sensitive {
-			applySensitiveListSentinel(&e, valueKeyID, currentID)
+			r.applySensitiveListSentinel(ctx, &e, valueKeyID, currentID)
 		}
 		entries = append(entries, &e)
 	}

--- a/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -37,14 +37,14 @@ import (
 // ---------------------------------------------------------------------------
 
 // fakeValueTransformer is a deterministic in-memory transformer that
-// "encrypts" by XOR-ing with 0x55 and records the AAD used during Encrypt.
+// "encrypts" by XOR-ing with 0x55 and embeds the AAD into the edk so that
+// Decrypt can verify AAD binding without mutable state.
 // Round-trip: Encrypt + Decrypt with matching AAD returns the original plaintext.
-// AAD mismatch: Decrypt with a different AAD than was used during Encrypt returns
-// ErrKeyProviderDecryptFailed — exercising the repo-layer cross-row replay protection.
+// AAD mismatch: Decrypt with a different AAD than was encoded in the edk returns
+// ErrConfigDecryptFailed — exercising the repo-layer cross-row replay protection.
 type fakeValueTransformer struct {
-	currentKeyID   string
-	failDecrypt    bool
-	lastEncryptAAD []byte // records AAD from the most recent Encrypt call
+	currentKeyID string
+	failDecrypt  bool
 }
 
 // CurrentKeyID implements crypto.CurrentKeyIDProvider — the optional
@@ -57,33 +57,30 @@ func (f *fakeValueTransformer) CurrentKeyID(_ context.Context) (string, error) {
 const fakeNonce = "FAKENC123456" // 12 bytes
 
 func (f *fakeValueTransformer) Encrypt(_ context.Context, plaintext, aad []byte) ([]byte, string, []byte, []byte, error) {
-	// Record the AAD so Decrypt can verify binding.
-	aadCopy := make([]byte, len(aad))
-	copy(aadCopy, aad)
-	f.lastEncryptAAD = aadCopy
-
 	// Fake cipher: XOR each byte with 0x55.
 	ct := make([]byte, len(plaintext))
 	for i, b := range plaintext {
 		ct[i] = b ^ 0x55
 	}
-	return ct, f.currentKeyID, []byte(fakeNonce), []byte("edk-" + f.currentKeyID), nil
+	// Encode AAD into edk so Decrypt can verify binding without mutable state.
+	edk := append([]byte("edk-"+f.currentKeyID+":aad:"), aad...)
+	return ct, f.currentKeyID, []byte(fakeNonce), edk, nil
 }
 
-func (f *fakeValueTransformer) Decrypt(_ context.Context, ciphertext []byte, keyID string, _, _, aad []byte) ([]byte, error) {
+func (f *fakeValueTransformer) Decrypt(_ context.Context, ciphertext []byte, keyID string, _, edk, aad []byte) ([]byte, error) {
 	if f.failDecrypt {
 		return nil, errcode.New(errcode.ErrKeyProviderDecryptFailed, "fake: forced decrypt failure")
 	}
-	// Check that the keyID is present (any non-empty keyID is OK for fake).
 	if keyID == "" {
 		return nil, errcode.New(errcode.ErrKeyProviderDecryptFailed, "fake: empty keyID")
 	}
-	// Enforce AAD binding: the AAD passed to Decrypt must match what was used
-	// during Encrypt. This exercises the repo-layer cross-row replay protection.
-	if string(aad) != string(f.lastEncryptAAD) {
+	// Verify AAD binding via edk-embedded AAD (stateless check).
+	expectedEDK := append([]byte("edk-"+keyID+":aad:"), aad...)
+	if string(edk) != string(expectedEDK) {
 		return nil, errcode.New(errcode.ErrConfigDecryptFailed,
-			"fake: AAD mismatch — cross-row replay detected")
+			"fake: AAD mismatch (edk does not match expected AAD binding)")
 	}
+	// Reverse XOR.
 	pt := make([]byte, len(ciphertext))
 	for i, b := range ciphertext {
 		pt[i] = b ^ 0x55
@@ -225,13 +222,15 @@ func TestEncrypt_GetByKey_SensitiveDecryptFailed_FailClosed(t *testing.T) {
 // from the current key ID.
 func TestEncrypt_GetByKey_SensitiveStaleKey(t *testing.T) {
 	ctx := context.Background()
-	tr := &fakeValueTransformer{currentKeyID: "local-aes-v2"} // current is v2
+	// Encrypt with v1 (the "old" key) so edk embeds v1.
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	original := "stale-value"
 	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "old_key"))
 	require.NoError(t, err)
 
-	// Row was encrypted with v1 (old key).
+	// Simulate key rotation: current is now v2, but the row was encrypted with v1.
+	tr.currentKeyID = "local-aes-v2"
 	oldKeyID := "local-aes-v1"
 
 	now := time.Now()
@@ -375,25 +374,28 @@ func TestConfigRepo_GetByKey_Sensitive_LegacyPlaintext_ReturnsErr(t *testing.T) 
 // TestConfigRepo_Decrypt_AADMismatch_FailsClosed verifies that the repo returns
 // ErrConfigDecryptFailed when the transformer detects an AAD mismatch.
 // This exercises the cross-row replay protection at the repo boundary.
+//
+// Cross-row replay: ciphertext was encrypted for "other_key" but is stored in
+// the "db_password" row. The edk embeds "other_key"'s AAD; when the repo reads
+// "db_password" it passes "db_password" AAD to Decrypt — mismatch detected.
 func TestConfigRepo_Decrypt_AADMismatch_FailsClosed(t *testing.T) {
 	ctx := context.Background()
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
-	// Encrypt value for key "db_password".
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte("secret"), configcrypto.AADForConfig("config-core", "db_password"))
+	// Encrypt value for "other_key" — edk embeds "other_key" AAD.
+	ct, keyID, nonce, _, err := tr.Encrypt(ctx, []byte("secret"), configcrypto.AADForConfig("config-core", "other_key"))
 	require.NoError(t, err)
 
-	// Now tamper: change the fake's lastEncryptAAD to simulate it having been
-	// originally encrypted for a different key (cross-row replay scenario).
-	// We overwrite it with AAD for a different key so Decrypt will detect mismatch.
-	_, _, _, _, _ = tr.Encrypt(ctx, []byte("other"), configcrypto.AADForConfig("config-core", "other_key"))
-	// lastEncryptAAD is now "other_key" AAD, but the DB row has "db_password" AAD.
+	// Construct an edk that binds to "other_key" AAD (cross-row replay).
+	// When GetByKey reads "db_password", the repo passes "db_password" AAD to
+	// Decrypt, which won't match this edk → ErrConfigDecryptFailed.
+	wrongEDK := append([]byte("edk-"+keyID+":aad:"), configcrypto.AADForConfig("config-core", "other_key")...)
 
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
 			values: []any{"cfg-1", "db_password", "", true, 1, now, now,
-				ct, keyID, edk, nonce},
+				ct, keyID, wrongEDK, nonce},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -638,8 +640,7 @@ func TestList_StaleKey_EmitsWarn(t *testing.T) {
 	logEntries := parseLogEntries(t, &logBuf)
 	require.Len(t, logEntries, 1, "exactly one warn for the stale sensitive entry")
 	assert.Equal(t, "WARN", logEntries[0]["level"])
-	assert.Equal(t, "config value encrypted with stale key", logEntries[0]["msg"])
-	assert.Equal(t, "stale_cfg", logEntries[0]["key"])
+	assert.Equal(t, "config values encrypted with stale key (first occurrence in this List page)", logEntries[0]["msg"])
 	assert.Equal(t, storedKeyID, logEntries[0]["stored_key_id"])
 	assert.Equal(t, "local-aes-v2", logEntries[0]["current_key_id"])
 }
@@ -683,6 +684,162 @@ func TestGetByKey_StaleKey_OnStaleCipherCallback(t *testing.T) {
 	assert.Equal(t, "cb_key", got[0].key)
 	assert.Equal(t, storedKeyID, got[0].storedKeyID)
 	assert.Equal(t, "local-aes-v2", got[0].currentKeyID)
+}
+
+// TestList_StaleKey_LogDedup verifies that List emits slog.Warn only ONCE per
+// distinct stale keyID per List call, even when multiple entries share the same
+// stale keyID. The onStaleCipher callback must still fire for every stale entry
+// (metric accuracy).
+func TestList_StaleKey_LogDedup(t *testing.T) {
+	ctx := context.Background()
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v2"} // current is v2
+
+	storedKeyID := "local-aes-v1" // stale
+
+	now := time.Now()
+	db := &mockDB{
+		queryRows: &mockRowSet{
+			entries: []mockRowValues{
+				// Three sensitive entries all encrypted with the same stale key.
+				{values: []any{"cfg-1", "key_a", "***", true, 1, now, now, &storedKeyID}},
+				{values: []any{"cfg-2", "key_b", "***", true, 1, now, now, &storedKeyID}},
+				{values: []any{"cfg-3", "key_c", "***", true, 1, now, now, &storedKeyID}},
+				// Non-sensitive — no warn expected.
+				{values: []any{"cfg-4", "plain_cfg", "value", false, 1, now, now, (*string)(nil)}},
+			},
+		},
+	}
+
+	var logBuf bytes.Buffer
+	logger := newTestLogger(&logBuf)
+	repo := newEncryptedRepoFromDBTX(db, tr)
+	repo.logger = logger
+
+	// Wire callback to count every stale invocation (metrics accuracy).
+	var callbackCount int
+	repo.onStaleCipher = func(_, _, _ string) { callbackCount++ }
+
+	entries, err := repo.List(ctx, query.ListParams{
+		Limit: 10,
+		Sort:  []query.SortColumn{{Name: "key", Direction: query.SortASC}, {Name: "id", Direction: query.SortASC}},
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 4)
+
+	// All three sensitive entries must be stale.
+	assert.True(t, entries[0].Stale, "key_a must be stale")
+	assert.True(t, entries[1].Stale, "key_b must be stale")
+	assert.True(t, entries[2].Stale, "key_c must be stale")
+	assert.False(t, entries[3].Stale, "plain_cfg must not be stale")
+
+	// Callback must fire for every stale entry (3 total).
+	assert.Equal(t, 3, callbackCount, "onStaleCipher callback must fire for every stale entry")
+
+	// slog.Warn must fire only ONCE for the shared stale keyID.
+	logEntries := parseLogEntries(t, &logBuf)
+	require.Len(t, logEntries, 1, "only one warn per distinct stale keyID per List call")
+	assert.Equal(t, "WARN", logEntries[0]["level"])
+	assert.Equal(t, storedKeyID, logEntries[0]["stored_key_id"])
+	assert.Equal(t, "local-aes-v2", logEntries[0]["current_key_id"])
+}
+
+// TestList_StaleKey_TwoDistinctKeyIDs_TwoWarns verifies that when entries are
+// encrypted with two distinct stale keyIDs, exactly two slog.Warn lines are
+// emitted (one per distinct keyID), but callbacks fire for every entry.
+func TestList_StaleKey_TwoDistinctKeyIDs_TwoWarns(t *testing.T) {
+	ctx := context.Background()
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v3"} // current is v3
+
+	keyIDv1 := "local-aes-v1"
+	keyIDv2 := "local-aes-v2"
+
+	now := time.Now()
+	db := &mockDB{
+		queryRows: &mockRowSet{
+			entries: []mockRowValues{
+				{values: []any{"cfg-1", "key_a", "***", true, 1, now, now, &keyIDv1}},
+				{values: []any{"cfg-2", "key_b", "***", true, 1, now, now, &keyIDv1}},
+				{values: []any{"cfg-3", "key_c", "***", true, 1, now, now, &keyIDv2}},
+			},
+		},
+	}
+
+	var logBuf bytes.Buffer
+	logger := newTestLogger(&logBuf)
+	repo := newEncryptedRepoFromDBTX(db, tr)
+	repo.logger = logger
+
+	var callbackCount int
+	repo.onStaleCipher = func(_, _, _ string) { callbackCount++ }
+
+	entries, err := repo.List(ctx, query.ListParams{
+		Limit: 10,
+		Sort:  []query.SortColumn{{Name: "key", Direction: query.SortASC}, {Name: "id", Direction: query.SortASC}},
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+
+	// All three are stale.
+	assert.True(t, entries[0].Stale)
+	assert.True(t, entries[1].Stale)
+	assert.True(t, entries[2].Stale)
+
+	// Callback fires for all 3.
+	assert.Equal(t, 3, callbackCount)
+
+	// Two distinct keyIDs → two slog.Warn lines.
+	logEntries := parseLogEntries(t, &logBuf)
+	require.Len(t, logEntries, 2, "one warn per distinct stale keyID")
+	assert.Equal(t, "WARN", logEntries[0]["level"])
+	assert.Equal(t, "WARN", logEntries[1]["level"])
+	storedIDs := []string{
+		logEntries[0]["stored_key_id"].(string),
+		logEntries[1]["stored_key_id"].(string),
+	}
+	assert.ElementsMatch(t, []string{keyIDv1, keyIDv2}, storedIDs)
+}
+
+// TestWithOnStaleCipher_Option verifies that NewConfigRepository wired with the
+// WithOnStaleCipher option correctly sets the callback. The test injects a stale
+// key via GetByKey and asserts the callback fires.
+func TestWithOnStaleCipher_Option(t *testing.T) {
+	ctx := context.Background()
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
+
+	original := "value"
+	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "opt_key"))
+	require.NoError(t, err)
+
+	storedKeyID := "local-aes-v1"
+	tr.currentKeyID = "local-aes-v2" // rotate
+
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			values: []any{"cfg-1", "opt_key", "", true, 1, now, now,
+				ct, storedKeyID, edk, nonce},
+		},
+	}
+
+	type callbackArgs struct{ key, storedID, currentID string }
+	var got []callbackArgs
+
+	// Use NewConfigRepository with WithOnStaleCipher option.
+	session := &Session{} // nil pool is fine — db field is set below via direct struct assignment
+	repo := NewConfigRepository(session, tr, nil, WithOnStaleCipher(func(key, storedID, currentID string) {
+		got = append(got, callbackArgs{key, storedID, currentID})
+	}))
+	// Bypass session for unit test — inject mockDB directly.
+	repo.session = nil
+	repo.db = db
+
+	_, err = repo.GetByKey(ctx, "opt_key")
+	require.NoError(t, err)
+
+	require.Len(t, got, 1, "WithOnStaleCipher callback must fire for stale key")
+	assert.Equal(t, "opt_key", got[0].key)
+	assert.Equal(t, storedKeyID, got[0].storedID)
+	assert.Equal(t, "local-aes-v2", got[0].currentID)
 }
 
 // TestGetByKey_FreshKey_OnStaleCipherCallback_NotCalled verifies that the

--- a/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -15,14 +15,18 @@ package postgres
 //   - sensitive=false paths are unaffected (no encryption).
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
 	configcrypto "github.com/ghbvf/gocell/cells/config-core/internal/crypto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,7 +96,7 @@ func (f *fakeValueTransformer) Decrypt(_ context.Context, ciphertext []byte, key
 // ---------------------------------------------------------------------------
 
 func newEncryptedRepoFromDBTX(db DBTX, tr crypto.ValueTransformer) *ConfigRepository {
-	return &ConfigRepository{db: db, transformer: tr}
+	return &ConfigRepository{db: db, transformer: tr, logger: slog.Default()}
 }
 
 // ---------------------------------------------------------------------------
@@ -498,4 +502,212 @@ func TestGetByKey_Sensitive_StaleKey_DifferentStoredAndCurrentKeyID(t *testing.T
 	require.NoError(t, err)
 	assert.True(t, entry.Stale, "entry must be marked stale when storedKeyID != currentKeyID")
 	assert.Equal(t, storedKeyID, entry.KeyID)
+}
+
+// ---------------------------------------------------------------------------
+// M3 — Stale key observability: slog.Warn + onStaleCipher callback
+// ---------------------------------------------------------------------------
+
+// newTestLogger returns a slog.Logger backed by a JSON handler writing to buf.
+// Tests use this to assert structured log fields without relying on string formatting.
+func newTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// parseLogEntries decodes newline-delimited JSON log lines into a slice of maps.
+func parseLogEntries(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var entries []map[string]any
+	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(line, &m), "log line must be valid JSON")
+		entries = append(entries, m)
+	}
+	return entries
+}
+
+// TestGetByKey_StaleKey_EmitsWarn verifies that when GetByKey detects a stale
+// key (stored keyID != current keyID), it emits a slog.Warn with the structured
+// fields: key, stored_key_id, current_key_id.
+func TestGetByKey_StaleKey_EmitsWarn(t *testing.T) {
+	ctx := context.Background()
+	// Encrypt with v1, then rotate current to v2 → stale.
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
+
+	original := "sensitive-value"
+	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "api_secret"))
+	require.NoError(t, err)
+
+	storedKeyID := "local-aes-v1"
+	tr.currentKeyID = "local-aes-v2" // rotate after encrypt
+
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			values: []any{"cfg-1", "api_secret", "", true, 1, now, now,
+				ct, storedKeyID, edk, nonce},
+		},
+	}
+
+	var logBuf bytes.Buffer
+	logger := newTestLogger(&logBuf)
+	repo := newEncryptedRepoFromDBTX(db, tr)
+	repo.logger = logger
+
+	entry, err := repo.GetByKey(ctx, "api_secret")
+	require.NoError(t, err)
+	require.True(t, entry.Stale)
+
+	entries := parseLogEntries(t, &logBuf)
+	require.Len(t, entries, 1, "exactly one log line must be emitted for stale key")
+
+	logEntry := entries[0]
+	assert.Equal(t, "WARN", logEntry["level"], "log level must be WARN")
+	assert.Equal(t, "config value encrypted with stale key", logEntry["msg"])
+	assert.Equal(t, "api_secret", logEntry["key"])
+	assert.Equal(t, storedKeyID, logEntry["stored_key_id"])
+	assert.Equal(t, "local-aes-v2", logEntry["current_key_id"])
+}
+
+// TestGetByKey_FreshKey_NoWarn verifies that no slog.Warn is emitted when the
+// stored keyID matches the current keyID (fresh / non-stale entry).
+func TestGetByKey_FreshKey_NoWarn(t *testing.T) {
+	ctx := context.Background()
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
+
+	original := "fresh-value"
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "fresh_key"))
+	require.NoError(t, err)
+
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			values: []any{"cfg-1", "fresh_key", "", true, 1, now, now,
+				ct, keyID, edk, nonce},
+		},
+	}
+
+	var logBuf bytes.Buffer
+	logger := newTestLogger(&logBuf)
+	repo := newEncryptedRepoFromDBTX(db, tr)
+	repo.logger = logger
+
+	entry, err := repo.GetByKey(ctx, "fresh_key")
+	require.NoError(t, err)
+	assert.False(t, entry.Stale)
+	assert.Empty(t, logBuf.Bytes(), "no log output must be emitted for fresh key")
+}
+
+// TestList_StaleKey_EmitsWarn verifies that List emits slog.Warn for each
+// sensitive entry whose stored keyID differs from the current keyID.
+func TestList_StaleKey_EmitsWarn(t *testing.T) {
+	ctx := context.Background()
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v2"} // current is v2
+
+	storedKeyID := "local-aes-v1" // stale
+
+	now := time.Now()
+	db := &mockDB{
+		queryRows: &mockRowSet{
+			entries: []mockRowValues{
+				// sensitive entry with stale key
+				{values: []any{"cfg-1", "stale_cfg", "***", true, 1, now, now, &storedKeyID}},
+				// non-sensitive entry — no warn expected
+				{values: []any{"cfg-2", "plain_cfg", "value", false, 1, now, now, (*string)(nil)}},
+			},
+		},
+	}
+
+	var logBuf bytes.Buffer
+	logger := newTestLogger(&logBuf)
+	repo := newEncryptedRepoFromDBTX(db, tr)
+	repo.logger = logger
+
+	entries, err := repo.List(ctx, query.ListParams{
+		Limit: 10,
+		Sort:  []query.SortColumn{{Name: "key", Direction: query.SortASC}, {Name: "id", Direction: query.SortASC}},
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.True(t, entries[0].Stale)
+	assert.False(t, entries[1].Stale)
+
+	logEntries := parseLogEntries(t, &logBuf)
+	require.Len(t, logEntries, 1, "exactly one warn for the stale sensitive entry")
+	assert.Equal(t, "WARN", logEntries[0]["level"])
+	assert.Equal(t, "config value encrypted with stale key", logEntries[0]["msg"])
+	assert.Equal(t, "stale_cfg", logEntries[0]["key"])
+	assert.Equal(t, storedKeyID, logEntries[0]["stored_key_id"])
+	assert.Equal(t, "local-aes-v2", logEntries[0]["current_key_id"])
+}
+
+// TestGetByKey_StaleKey_OnStaleCipherCallback verifies that the optional
+// onStaleCipher callback is invoked with the correct arguments when a stale
+// key is detected, enabling callers to wire a prometheus counter.
+func TestGetByKey_StaleKey_OnStaleCipherCallback(t *testing.T) {
+	ctx := context.Background()
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
+
+	original := "value"
+	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "cb_key"))
+	require.NoError(t, err)
+
+	storedKeyID := "local-aes-v1"
+	tr.currentKeyID = "local-aes-v2"
+
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			values: []any{"cfg-1", "cb_key", "", true, 1, now, now,
+				ct, storedKeyID, edk, nonce},
+		},
+	}
+
+	type callbackArgs struct {
+		key, storedKeyID, currentKeyID string
+	}
+	var got []callbackArgs
+
+	repo := newEncryptedRepoFromDBTX(db, tr)
+	repo.onStaleCipher = func(key, storedID, currentID string) {
+		got = append(got, callbackArgs{key, storedID, currentID})
+	}
+
+	_, err = repo.GetByKey(ctx, "cb_key")
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "cb_key", got[0].key)
+	assert.Equal(t, storedKeyID, got[0].storedKeyID)
+	assert.Equal(t, "local-aes-v2", got[0].currentKeyID)
+}
+
+// TestGetByKey_FreshKey_OnStaleCipherCallback_NotCalled verifies that the
+// onStaleCipher callback is NOT called when the key is fresh.
+func TestGetByKey_FreshKey_OnStaleCipherCallback_NotCalled(t *testing.T) {
+	ctx := context.Background()
+	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
+
+	original := "value"
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("config-core", "fresh_cb_key"))
+	require.NoError(t, err)
+
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			values: []any{"cfg-1", "fresh_cb_key", "", true, 1, now, now,
+				ct, keyID, edk, nonce},
+		},
+	}
+
+	called := false
+	repo := newEncryptedRepoFromDBTX(db, tr)
+	repo.onStaleCipher = func(_, _, _ string) { called = true }
+
+	_, err = repo.GetByKey(ctx, "fresh_cb_key")
+	require.NoError(t, err)
+	assert.False(t, called, "onStaleCipher must not be called for a fresh key")
 }

--- a/cells/config-core/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_integration_test.go
@@ -50,7 +50,7 @@ func setupConfigPG(t *testing.T) (*ConfigRepository, *adapterpg.TxManager, func(
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
 	session := NewSession(pool.DB())
-	repo := NewConfigRepository(session, crypto.NoopTransformer{})
+	repo := NewConfigRepository(session, crypto.NoopTransformer{}, nil)
 	txMgr := adapterpg.NewTxManager(pool)
 
 	cleanup := func() {
@@ -303,7 +303,7 @@ func setupConfigPGEncrypted(t *testing.T) (*ConfigRepository, *adapterpg.TxManag
 	transformer := crypto.NewValueTransformer(kp)
 
 	session := NewSession(pool.DB())
-	repo := NewConfigRepository(session, transformer)
+	repo := NewConfigRepository(session, transformer, nil)
 	txMgr := adapterpg.NewTxManager(pool)
 
 	cleanup := func() {

--- a/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 // Session layer, allowing unit tests to inject a mockDB directly.
 // Production code always goes through NewConfigRepository(*Session).
 func newConfigRepositoryFromDBTX(db DBTX) *ConfigRepository {
-	return &ConfigRepository{db: db}
+	return &ConfigRepository{db: db, logger: slog.Default()}
 }
 
 func TestConfigRepository_Create(t *testing.T) {
@@ -400,7 +401,7 @@ func TestConfigRepository_GetVersion_NotFound(t *testing.T) {
 // repo fails with ErrAdapterPGNoTx when no tx is present in context (F-S-1).
 func TestCreate_WithoutTx_ReturnsNoTxError(t *testing.T) {
 	session := NewSession(nil) // nil pool — resolveWrite never reaches pool path
-	repo := NewConfigRepository(session, nil)
+	repo := NewConfigRepository(session, nil, nil)
 
 	err := repo.Create(context.Background(), &domain.ConfigEntry{Key: "k"})
 	require.Error(t, err)
@@ -414,7 +415,7 @@ func TestCreate_WithoutTx_ReturnsNoTxError(t *testing.T) {
 // repo fails with ErrAdapterPGNoTx when no tx is present in context (F-S-1).
 func TestUpdate_WithoutTx_ReturnsNoTxError(t *testing.T) {
 	session := NewSession(nil)
-	repo := NewConfigRepository(session, nil)
+	repo := NewConfigRepository(session, nil, nil)
 
 	err := repo.Update(context.Background(), &domain.ConfigEntry{Key: "k"})
 	require.Error(t, err)
@@ -428,7 +429,7 @@ func TestUpdate_WithoutTx_ReturnsNoTxError(t *testing.T) {
 // repo fails with ErrAdapterPGNoTx when no tx is present in context (F-S-1).
 func TestDelete_WithoutTx_ReturnsNoTxError(t *testing.T) {
 	session := NewSession(nil)
-	repo := NewConfigRepository(session, nil)
+	repo := NewConfigRepository(session, nil, nil)
 
 	err := repo.Delete(context.Background(), "k")
 	require.Error(t, err)
@@ -443,7 +444,7 @@ func TestDelete_WithoutTx_ReturnsNoTxError(t *testing.T) {
 // context (F-S-1).
 func TestPublishVersion_WithoutTx_ReturnsNoTxError(t *testing.T) {
 	session := NewSession(nil)
-	repo := NewConfigRepository(session, nil)
+	repo := NewConfigRepository(session, nil, nil)
 
 	err := repo.PublishVersion(context.Background(), &domain.ConfigVersion{ConfigID: "cfg-1"})
 	require.Error(t, err)
@@ -510,7 +511,7 @@ func TestConfigRepository_List_RowsError(t *testing.T) {
 // resolveWriteDB path returning an error when no tx is in ctx.
 func TestConfigRepository_Create_WithSession_NoTx(t *testing.T) {
 	s := NewSession(nil)
-	repo := NewConfigRepository(s, nil)
+	repo := NewConfigRepository(s, nil, nil)
 
 	err := repo.Create(context.Background(), &domain.ConfigEntry{Key: "k"})
 	require.Error(t, err)
@@ -526,7 +527,7 @@ func TestConfigRepository_Create_WithSession_NoTx(t *testing.T) {
 // path (r.session != nil branch) is exercised.
 func TestConfigRepository_ResolveDB_SessionPath(t *testing.T) {
 	s := NewSession(nil)
-	repo := NewConfigRepository(s, nil)
+	repo := NewConfigRepository(s, nil, nil)
 
 	// GetByKey uses resolveDB (read path). With nil pool the pool.QueryRow
 	// will panic/nil-deref, but that path goes through poolAdapter.QueryRow

--- a/cells/config-core/slices/configpublish/service_integration_test.go
+++ b/cells/config-core/slices/configpublish/service_integration_test.go
@@ -58,7 +58,7 @@ func setupPublishBundle(t *testing.T) (publishServiceBundle, func()) {
 	require.NoError(t, migrator.Up(ctx))
 
 	session := cellpg.NewSession(pool.DB())
-	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{})
+	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil)
 	outboxWriter := adapterpg.NewOutboxWriter()
 	txMgr := adapterpg.NewTxManager(pool)
 

--- a/cells/config-core/slices/configwrite/service_integration_test.go
+++ b/cells/config-core/slices/configwrite/service_integration_test.go
@@ -55,7 +55,7 @@ func setupWriteService(t *testing.T) (writeBundle, func()) {
 	require.NoError(t, migrator.Up(ctx))
 
 	session := cellpg.NewSession(pool.DB())
-	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{})
+	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil)
 	outboxWriter := adapterpg.NewOutboxWriter()
 	txMgr := adapterpg.NewTxManager(pool)
 
@@ -138,7 +138,7 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 	require.NoError(t, migrator.Up(ctx))
 
 	session := cellpg.NewSession(pool.DB())
-	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{})
+	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil)
 
 	// Inject a writer that always fails — simulates outbox unavailable.
 	failingWriter := &recordingWriter{err: errors.New("outbox broker down")}

--- a/cmd/core-bundle/bundle.go
+++ b/cmd/core-bundle/bundle.go
@@ -94,7 +94,7 @@ func defaultRuntimeOptions(
 // ref: kubernetes/kubernetes pkg/apiserver/admission/config.go — missing
 // EncryptionConfig in an active storage path is a startup error, not a warning.
 // ref: go-kratos/kratos config.Watch — required dependency failure aborts boot.
-func buildKeyProvider(storageBackend string) (kcrypto.KeyProvider, error) {
+func buildKeyProvider(storageBackend, adapterMode string) (kcrypto.KeyProvider, error) {
 	providerName := os.Getenv("GOCELL_KEY_PROVIDER")
 	if providerName == "" {
 		if storageBackend == "postgres" {
@@ -108,6 +108,10 @@ func buildKeyProvider(storageBackend string) (kcrypto.KeyProvider, error) {
 	}
 	switch providerName {
 	case "local-aes":
+		masterKeyRaw := os.Getenv("GOCELL_MASTER_KEY")
+		if err := rejectDemoKey(adapterMode, "GOCELL_MASTER_KEY", []byte(masterKeyRaw)); err != nil {
+			return nil, err
+		}
 		kp, err := crypto.NewLocalAESKeyProviderFromEnv()
 		if err != nil {
 			return nil, fmt.Errorf("local-aes key provider: %w", err)

--- a/cmd/core-bundle/bundle.go
+++ b/cmd/core-bundle/bundle.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	adaptervault "github.com/ghbvf/gocell/adapters/vault"
@@ -82,10 +83,12 @@ func defaultRuntimeOptions(
 	return opts
 }
 
-// buildKeyProvider constructs the KeyProvider from GOCELL_KEY_PROVIDER env var.
-// Supported values: "local-aes", "vault-transit".
-// In memory mode (empty env var) nil is returned (no encryption; NoopTransformer via keyProviderToTransformer).
-// In postgres mode (empty env var) the function fails-fast: sensitive-value
+// buildKeyProvider constructs the KeyProvider from the given providerName
+// (pre-read from GOCELL_KEY_PROVIDER by the caller). Supported values:
+// "local-aes", "vault-transit".
+// In memory mode (empty providerName) nil is returned (no encryption;
+// NoopTransformer via keyProviderToTransformer).
+// In postgres mode (empty providerName) the function fails-fast: sensitive-value
 // encryption is a production security invariant; silently wiring NoopTransformer
 // would defeat the stated threat model (see docs/architecture/202604191800-adr-config-value-encryption.md).
 // Operators must explicitly opt in via GOCELL_KEY_PROVIDER=local-aes (dev/CI only) or
@@ -94,8 +97,7 @@ func defaultRuntimeOptions(
 // ref: kubernetes/kubernetes pkg/apiserver/admission/config.go — missing
 // EncryptionConfig in an active storage path is a startup error, not a warning.
 // ref: go-kratos/kratos config.Watch — required dependency failure aborts boot.
-func buildKeyProvider(storageBackend, adapterMode string) (kcrypto.KeyProvider, error) {
-	providerName := os.Getenv("GOCELL_KEY_PROVIDER")
+func buildKeyProvider(storageBackend, adapterMode, providerName string) (kcrypto.KeyProvider, error) {
 	if providerName == "" {
 		if storageBackend == "postgres" {
 			return nil, errcode.New(errcode.ErrConfigKeyMissing,
@@ -109,7 +111,11 @@ func buildKeyProvider(storageBackend, adapterMode string) (kcrypto.KeyProvider, 
 	switch providerName {
 	case "local-aes":
 		masterKeyRaw := os.Getenv("GOCELL_MASTER_KEY")
-		if err := rejectDemoKey(adapterMode, "GOCELL_MASTER_KEY", []byte(masterKeyRaw)); err != nil {
+		// Normalize hex to lowercase before demo-key check: hex.DecodeString is
+		// case-insensitive, so "0123ABCD..." and "0123abcd..." produce identical
+		// key material. Comparing at string level without normalization would let
+		// an uppercase variant of a known demo key slip through.
+		if err := rejectDemoKey(adapterMode, "GOCELL_MASTER_KEY", []byte(strings.ToLower(masterKeyRaw))); err != nil {
 			return nil, err
 		}
 		kp, err := crypto.NewLocalAESKeyProviderFromEnv()

--- a/cmd/core-bundle/bundle_test.go
+++ b/cmd/core-bundle/bundle_test.go
@@ -126,7 +126,7 @@ func newValidatedSharedDeps(t *testing.T, topo bootstrap.Topology) *SharedDeps {
 		deps.InternalGuard = func(h http.Handler) http.Handler { return h }
 	}
 	if topo.StorageBackend == "postgres" {
-		t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
+		deps.KeyProviderName = "local-aes"
 		t.Setenv("GOCELL_MASTER_KEY", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
 	}
 	return deps

--- a/cmd/core-bundle/bundle_test.go
+++ b/cmd/core-bundle/bundle_test.go
@@ -125,6 +125,10 @@ func newValidatedSharedDeps(t *testing.T, topo bootstrap.Topology) *SharedDeps {
 		deps.VerboseToken = "test-verbose"
 		deps.InternalGuard = func(h http.Handler) http.Handler { return h }
 	}
+	if topo.StorageBackend == "postgres" {
+		t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
+		t.Setenv("GOCELL_MASTER_KEY", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
+	}
 	return deps
 }
 

--- a/cmd/core-bundle/config_module.go
+++ b/cmd/core-bundle/config_module.go
@@ -34,7 +34,7 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	kp := m.KeyProviderOverride
 	if kp == nil {
 		var err error
-		kp, err = buildKeyProvider(shared.Topology.StorageBackend, shared.Topology.AdapterMode)
+		kp, err = buildKeyProvider(shared.Topology.StorageBackend, shared.Topology.AdapterMode, shared.KeyProviderName)
 		if err != nil {
 			return nil, nil, fmt.Errorf("config-core key provider: %w", err)
 		}

--- a/cmd/core-bundle/config_module.go
+++ b/cmd/core-bundle/config_module.go
@@ -34,7 +34,7 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	kp := m.KeyProviderOverride
 	if kp == nil {
 		var err error
-		kp, err = buildKeyProvider(shared.Topology.StorageBackend)
+		kp, err = buildKeyProvider(shared.Topology.StorageBackend, shared.Topology.AdapterMode)
 		if err != nil {
 			return nil, nil, fmt.Errorf("config-core key provider: %w", err)
 		}

--- a/cmd/core-bundle/demo_keys.go
+++ b/cmd/core-bundle/demo_keys.go
@@ -29,6 +29,10 @@ var wellKnownDemoKeys = []string{
 
 	// Service token HMAC (shipped as test fixture; never use in production)
 	"service-secret-32-bytes-xxxxxx!!",
+
+	// AES master key (hex-encoded, 64 chars) shipped as test fixture in
+	// cmd/core-bundle and CI; real mode must refuse this value.
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 }
 
 // rejectDemoKey returns an error if adapterMode == "real" and key matches a

--- a/cmd/core-bundle/demo_keys_test.go
+++ b/cmd/core-bundle/demo_keys_test.go
@@ -65,6 +65,19 @@ func TestDevDefaults_AreAllInWellKnownDemoKeys(t *testing.T) {
 	}
 }
 
+// TestMasterKeyDemoHex_IsInWellKnownDemoKeys verifies that the test-fixture
+// hex-encoded master key "0123456789abcdef..." is listed in wellKnownDemoKeys,
+// so that rejectDemoKey blocks it in real adapter mode.
+func TestMasterKeyDemoHex_IsInWellKnownDemoKeys(t *testing.T) {
+	const demoHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	for _, k := range wellKnownDemoKeys {
+		if k == demoHex {
+			return
+		}
+	}
+	t.Errorf("demo master key hex %q not found in wellKnownDemoKeys — real mode will accept it; add to demo_keys.go", demoHex)
+}
+
 // TestCellDemoKeys_AreAllInWellKnownDemoKeys guards against a cell being added
 // with a new per-cell demo codec key (cells/*/cell.go) without the value also
 // appearing in wellKnownDemoKeys. Without this guard, a cell that forgets

--- a/cmd/core-bundle/key_provider_test.go
+++ b/cmd/core-bundle/key_provider_test.go
@@ -16,7 +16,7 @@ import (
 func TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNil(t *testing.T) {
 	t.Setenv("GOCELL_KEY_PROVIDER", "")
 
-	kp, err := buildKeyProvider("memory")
+	kp, err := buildKeyProvider("memory", "")
 	require.NoError(t, err)
 	assert.Nil(t, kp, "memory mode + empty env should return nil (no provider)")
 }
@@ -28,7 +28,7 @@ func TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNil(t *testing.T) {
 func TestBuildKeyProvider_PostgresMode_NoEnv_FailsFast(t *testing.T) {
 	t.Setenv("GOCELL_KEY_PROVIDER", "")
 
-	kp, err := buildKeyProvider("postgres")
+	kp, err := buildKeyProvider("postgres", "")
 	require.Error(t, err, "postgres mode without provider must fail-fast")
 	assert.Nil(t, kp)
 
@@ -45,7 +45,7 @@ func TestBuildKeyProvider_PostgresMode_NoEnv_FailsFast(t *testing.T) {
 func TestBuildKeyProvider_UnknownProvider_Fails(t *testing.T) {
 	t.Setenv("GOCELL_KEY_PROVIDER", "bogus")
 
-	kp, err := buildKeyProvider("postgres")
+	kp, err := buildKeyProvider("postgres", "")
 	require.Error(t, err)
 	assert.Nil(t, kp)
 
@@ -57,13 +57,37 @@ func TestBuildKeyProvider_UnknownProvider_Fails(t *testing.T) {
 	assert.Contains(t, ecErr.Message, "vault-transit")
 }
 
-// TestBuildKeyProvider_LocalAES_Success verifies local-aes provider wiring.
+// TestBuildKeyProvider_LocalAES_Success verifies local-aes provider wiring
+// with a non-demo key in dev mode.
 func TestBuildKeyProvider_LocalAES_Success(t *testing.T) {
-	// 32-byte hex-encoded master key.
+	// 32-byte (64 hex chars) master key — use a non-demo value.
+	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
+	t.Setenv("GOCELL_MASTER_KEY", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
+
+	kp, err := buildKeyProvider("postgres", "dev")
+	require.NoError(t, err)
+	require.NotNil(t, kp)
+}
+
+// TestBuildKeyProvider_LocalAES_DemoKey_RealMode_Rejected verifies that
+// local-aes with a well-known demo master key is rejected in real mode.
+func TestBuildKeyProvider_LocalAES_DemoKey_RealMode_Rejected(t *testing.T) {
 	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
 	t.Setenv("GOCELL_MASTER_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
-	kp, err := buildKeyProvider("postgres")
+	kp, err := buildKeyProvider("postgres", "real")
+	require.Error(t, err)
+	assert.Nil(t, kp)
+	assert.Contains(t, err.Error(), "well-known demo key")
+}
+
+// TestBuildKeyProvider_LocalAES_DemoKey_DevMode_Allowed verifies demo key is
+// accepted in dev mode.
+func TestBuildKeyProvider_LocalAES_DemoKey_DevMode_Allowed(t *testing.T) {
+	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
+	t.Setenv("GOCELL_MASTER_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+	kp, err := buildKeyProvider("postgres", "dev")
 	require.NoError(t, err)
 	require.NotNil(t, kp)
 }
@@ -74,7 +98,7 @@ func TestBuildKeyProvider_LocalAES_MissingKey_Fails(t *testing.T) {
 	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
 	t.Setenv("GOCELL_MASTER_KEY", "")
 
-	kp, err := buildKeyProvider("postgres")
+	kp, err := buildKeyProvider("postgres", "")
 	require.Error(t, err)
 	assert.Nil(t, kp)
 	assert.Contains(t, err.Error(), "local-aes")
@@ -96,7 +120,7 @@ func TestBuildKeyProvider_VaultTransit_InvalidAddr_FailsFast(t *testing.T) {
 	t.Setenv("VAULT_ADDR", "http://127.0.0.1:1")
 	t.Setenv("VAULT_TOKEN", "test-token")
 
-	kp, err := buildKeyProvider("postgres")
+	kp, err := buildKeyProvider("postgres", "dev")
 	require.Error(t, err, "vault-transit with unreachable VAULT_ADDR must fail startup")
 	assert.Nil(t, kp)
 	assert.Contains(t, err.Error(), "vault-transit",

--- a/cmd/core-bundle/key_provider_test.go
+++ b/cmd/core-bundle/key_provider_test.go
@@ -11,24 +11,20 @@ import (
 )
 
 // TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNil verifies that in memory
-// storage mode, an unset GOCELL_KEY_PROVIDER leads to nil (which the caller
+// storage mode, an empty providerName leads to nil (which the caller
 // maps to NoopTransformer). No encryption is required for in-memory storage.
 func TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNil(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "")
-
-	kp, err := buildKeyProvider("memory", "")
+	kp, err := buildKeyProvider("memory", "", "")
 	require.NoError(t, err)
-	assert.Nil(t, kp, "memory mode + empty env should return nil (no provider)")
+	assert.Nil(t, kp, "memory mode + empty provider should return nil (no provider)")
 }
 
 // TestBuildKeyProvider_PostgresMode_NoEnv_FailsFast verifies that postgres
-// storage mode without GOCELL_KEY_PROVIDER returns ErrConfigKeyMissing.
+// storage mode with an empty providerName returns ErrConfigKeyMissing.
 // This is the fail-fast guard that prevents silent NoopTransformer fallback,
 // which would persist sensitive config values unencrypted (security invariant).
 func TestBuildKeyProvider_PostgresMode_NoEnv_FailsFast(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "")
-
-	kp, err := buildKeyProvider("postgres", "")
+	kp, err := buildKeyProvider("postgres", "", "")
 	require.Error(t, err, "postgres mode without provider must fail-fast")
 	assert.Nil(t, kp)
 
@@ -41,11 +37,9 @@ func TestBuildKeyProvider_PostgresMode_NoEnv_FailsFast(t *testing.T) {
 }
 
 // TestBuildKeyProvider_UnknownProvider_Fails verifies that an unrecognised
-// GOCELL_KEY_PROVIDER value fails fast rather than silently degrading.
+// providerName fails fast rather than silently degrading.
 func TestBuildKeyProvider_UnknownProvider_Fails(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "bogus")
-
-	kp, err := buildKeyProvider("postgres", "")
+	kp, err := buildKeyProvider("postgres", "", "bogus")
 	require.Error(t, err)
 	assert.Nil(t, kp)
 
@@ -61,10 +55,9 @@ func TestBuildKeyProvider_UnknownProvider_Fails(t *testing.T) {
 // with a non-demo key in dev mode.
 func TestBuildKeyProvider_LocalAES_Success(t *testing.T) {
 	// 32-byte (64 hex chars) master key — use a non-demo value.
-	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
 	t.Setenv("GOCELL_MASTER_KEY", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
 
-	kp, err := buildKeyProvider("postgres", "dev")
+	kp, err := buildKeyProvider("postgres", "dev", "local-aes")
 	require.NoError(t, err)
 	require.NotNil(t, kp)
 }
@@ -72,10 +65,9 @@ func TestBuildKeyProvider_LocalAES_Success(t *testing.T) {
 // TestBuildKeyProvider_LocalAES_DemoKey_RealMode_Rejected verifies that
 // local-aes with a well-known demo master key is rejected in real mode.
 func TestBuildKeyProvider_LocalAES_DemoKey_RealMode_Rejected(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
 	t.Setenv("GOCELL_MASTER_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
-	kp, err := buildKeyProvider("postgres", "real")
+	kp, err := buildKeyProvider("postgres", "real", "local-aes")
 	require.Error(t, err)
 	assert.Nil(t, kp)
 	assert.Contains(t, err.Error(), "well-known demo key")
@@ -84,10 +76,9 @@ func TestBuildKeyProvider_LocalAES_DemoKey_RealMode_Rejected(t *testing.T) {
 // TestBuildKeyProvider_LocalAES_DemoKey_DevMode_Allowed verifies demo key is
 // accepted in dev mode.
 func TestBuildKeyProvider_LocalAES_DemoKey_DevMode_Allowed(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
 	t.Setenv("GOCELL_MASTER_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
-	kp, err := buildKeyProvider("postgres", "dev")
+	kp, err := buildKeyProvider("postgres", "dev", "local-aes")
 	require.NoError(t, err)
 	require.NotNil(t, kp)
 }
@@ -95,10 +86,9 @@ func TestBuildKeyProvider_LocalAES_DemoKey_DevMode_Allowed(t *testing.T) {
 // TestBuildKeyProvider_LocalAES_MissingKey_Fails verifies local-aes fails
 // when GOCELL_MASTER_KEY is absent.
 func TestBuildKeyProvider_LocalAES_MissingKey_Fails(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "local-aes")
 	t.Setenv("GOCELL_MASTER_KEY", "")
 
-	kp, err := buildKeyProvider("postgres", "")
+	kp, err := buildKeyProvider("postgres", "", "local-aes")
 	require.Error(t, err)
 	assert.Nil(t, kp)
 	assert.Contains(t, err.Error(), "local-aes")
@@ -113,18 +103,42 @@ func TestBuildKeyProvider_LocalAES_MissingKey_Fails(t *testing.T) {
 // Vault container); this unit test only locks the cmd/core-bundle wiring
 // so buildKeyProvider’s vault-transit branch does not regress silently.
 func TestBuildKeyProvider_VaultTransit_InvalidAddr_FailsFast(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "vault-transit")
 	// Deliberately unreachable address — readLatestVersion must surface the
 	// connection failure as a startup error (transient, but still fatal at
 	// startup since the fail-fast check runs in NewTransitKeyProviderFromEnv).
 	t.Setenv("VAULT_ADDR", "http://127.0.0.1:1")
 	t.Setenv("VAULT_TOKEN", "test-token")
 
-	kp, err := buildKeyProvider("postgres", "dev")
+	kp, err := buildKeyProvider("postgres", "dev", "vault-transit")
 	require.Error(t, err, "vault-transit with unreachable VAULT_ADDR must fail startup")
 	assert.Nil(t, kp)
 	assert.Contains(t, err.Error(), "vault-transit",
 		"error must identify provider so operators can route the alert")
+}
+
+// TestBuildKeyProvider_LocalAES_DemoKey_UpperCase_RealMode_Rejected verifies
+// that an uppercase-hex variant of a well-known demo key is rejected in real
+// mode. hex.DecodeString is case-insensitive, so "0123ABCD..." and "0123abcd..."
+// produce identical key material; the demo-key check must normalize to lowercase
+// to catch both forms.
+func TestBuildKeyProvider_LocalAES_DemoKey_UpperCase_RealMode_Rejected(t *testing.T) {
+	t.Setenv("GOCELL_MASTER_KEY", "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")
+
+	kp, err := buildKeyProvider("postgres", "real", "local-aes")
+	require.Error(t, err)
+	assert.Nil(t, kp)
+	assert.Contains(t, err.Error(), "well-known demo key")
+}
+
+// TestBuildKeyProvider_LocalAES_DemoKey_MixedCase_RealMode_Rejected verifies
+// that a mixed-case variant of a well-known demo key is rejected in real mode.
+func TestBuildKeyProvider_LocalAES_DemoKey_MixedCase_RealMode_Rejected(t *testing.T) {
+	t.Setenv("GOCELL_MASTER_KEY", "0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf")
+
+	kp, err := buildKeyProvider("postgres", "real", "local-aes")
+	require.Error(t, err)
+	assert.Nil(t, kp)
+	assert.Contains(t, err.Error(), "well-known demo key")
 }
 
 // TestKeyProviderToTransformer_NilReturnsNoop verifies that a nil provider

--- a/cmd/core-bundle/shared_deps.go
+++ b/cmd/core-bundle/shared_deps.go
@@ -110,6 +110,11 @@ func (d *SharedDeps) validateCore() []error {
 	if d.EventBus == nil {
 		missing("EventBus")
 	}
+	if d.Topology.StorageBackend == "postgres" && os.Getenv("GOCELL_KEY_PROVIDER") == "" {
+		errs = append(errs, errcode.New(errcode.ErrValidationFailed,
+			"SharedDeps: GOCELL_KEY_PROVIDER must be set when StorageBackend=postgres "+
+				"(defense-in-depth; config-core module also validates this)"))
+	}
 	return errs
 }
 

--- a/cmd/core-bundle/shared_deps.go
+++ b/cmd/core-bundle/shared_deps.go
@@ -55,6 +55,10 @@ type SharedDeps struct {
 	// production topology; may be empty in dev mode.
 	VerboseToken string
 
+	// KeyProviderName is the value of GOCELL_KEY_PROVIDER read once at startup.
+	// Empty means no encryption configured (valid only for non-postgres backends).
+	KeyProviderName string
+
 	// metricsHandler is the Prometheus HTTP handler built once in
 	// LoadSharedDepsFromEnv and reused by defaultRuntimeOptions.
 	metricsHandler http.Handler
@@ -110,7 +114,7 @@ func (d *SharedDeps) validateCore() []error {
 	if d.EventBus == nil {
 		missing("EventBus")
 	}
-	if d.Topology.StorageBackend == "postgres" && os.Getenv("GOCELL_KEY_PROVIDER") == "" {
+	if d.Topology.StorageBackend == "postgres" && d.KeyProviderName == "" {
 		errs = append(errs, errcode.New(errcode.ErrValidationFailed,
 			"SharedDeps: GOCELL_KEY_PROVIDER must be set when StorageBackend=postgres "+
 				"(defense-in-depth; config-core module also validates this)"))
@@ -154,6 +158,7 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*SharedDeps, error) {
 		return nil, err
 	}
 	adapterMode := topo.AdapterMode
+	keyProviderName := os.Getenv("GOCELL_KEY_PROVIDER")
 
 	hmacKey, err := loadSecret("GOCELL_HMAC_KEY", "dev-hmac-key-replace-in-prod!!!!", adapterMode)
 	if err != nil {
@@ -201,16 +206,17 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*SharedDeps, error) {
 		slog.String("effective", topo.AdapterInfo()["mode"]))
 
 	deps := &SharedDeps{
-		Topology:       topo,
-		JWTDeps:        jwt,
-		PromStack:      ps,
-		CursorCodecs:   codecs,
-		HMACKey:        hmacKey,
-		EventBus:       eb,
-		InternalGuard:  internalGuard,
-		MetricsToken:   metricsToken,
-		VerboseToken:   verboseToken,
-		metricsHandler: metricsHandler,
+		Topology:        topo,
+		JWTDeps:         jwt,
+		PromStack:       ps,
+		CursorCodecs:    codecs,
+		HMACKey:         hmacKey,
+		EventBus:        eb,
+		InternalGuard:   internalGuard,
+		MetricsToken:    metricsToken,
+		VerboseToken:    verboseToken,
+		KeyProviderName: keyProviderName,
+		metricsHandler:  metricsHandler,
 	}
 
 	if err := deps.Validate(); err != nil {

--- a/cmd/core-bundle/shared_deps_test.go
+++ b/cmd/core-bundle/shared_deps_test.go
@@ -10,13 +10,12 @@ import (
 
 // TestSharedDeps_Validate_PostgresWithoutKeyProvider_Fails verifies that
 // SharedDeps.Validate() returns an error when StorageBackend=postgres but
-// GOCELL_KEY_PROVIDER is unset. This is defense-in-depth: buildKeyProvider
+// KeyProviderName is empty. This is defense-in-depth: buildKeyProvider
 // also checks this, but Validate catches test-constructed SharedDeps.
 func TestSharedDeps_Validate_PostgresWithoutKeyProvider_Fails(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "")
-
 	deps := &SharedDeps{
-		Topology: bootstrap.Topology{StorageBackend: "postgres", AdapterMode: "real"},
+		Topology:        bootstrap.Topology{StorageBackend: "postgres", AdapterMode: "real"},
+		KeyProviderName: "", // explicitly empty
 		// Deliberately leave other fields zero to isolate this check.
 		// Validate will also report other missing fields, but we just need
 		// to find our specific error in the joined result.
@@ -28,16 +27,15 @@ func TestSharedDeps_Validate_PostgresWithoutKeyProvider_Fails(t *testing.T) {
 }
 
 // TestSharedDeps_Validate_MemoryWithoutKeyProvider_OK verifies that
-// memory mode doesn't require GOCELL_KEY_PROVIDER.
+// memory mode doesn't require KeyProviderName.
 func TestSharedDeps_Validate_MemoryWithoutKeyProvider_OK(t *testing.T) {
-	t.Setenv("GOCELL_KEY_PROVIDER", "")
-
 	// Build a minimal SharedDeps for memory mode.
 	// This test only asserts that the KeyProvider check doesn't fire;
 	// other fields will still be missing, so Validate will still error.
 	// We check that the specific "GOCELL_KEY_PROVIDER" message is NOT in the error.
 	deps := &SharedDeps{
-		Topology: bootstrap.Topology{StorageBackend: "memory", AdapterMode: "dev"},
+		Topology:        bootstrap.Topology{StorageBackend: "memory", AdapterMode: "dev"},
+		KeyProviderName: "", // empty is valid for non-postgres
 	}
 
 	err := deps.Validate()

--- a/cmd/core-bundle/shared_deps_test.go
+++ b/cmd/core-bundle/shared_deps_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/runtime/bootstrap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSharedDeps_Validate_PostgresWithoutKeyProvider_Fails verifies that
+// SharedDeps.Validate() returns an error when StorageBackend=postgres but
+// GOCELL_KEY_PROVIDER is unset. This is defense-in-depth: buildKeyProvider
+// also checks this, but Validate catches test-constructed SharedDeps.
+func TestSharedDeps_Validate_PostgresWithoutKeyProvider_Fails(t *testing.T) {
+	t.Setenv("GOCELL_KEY_PROVIDER", "")
+
+	deps := &SharedDeps{
+		Topology: bootstrap.Topology{StorageBackend: "postgres", AdapterMode: "real"},
+		// Deliberately leave other fields zero to isolate this check.
+		// Validate will also report other missing fields, but we just need
+		// to find our specific error in the joined result.
+	}
+
+	err := deps.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GOCELL_KEY_PROVIDER")
+}
+
+// TestSharedDeps_Validate_MemoryWithoutKeyProvider_OK verifies that
+// memory mode doesn't require GOCELL_KEY_PROVIDER.
+func TestSharedDeps_Validate_MemoryWithoutKeyProvider_OK(t *testing.T) {
+	t.Setenv("GOCELL_KEY_PROVIDER", "")
+
+	// Build a minimal SharedDeps for memory mode.
+	// This test only asserts that the KeyProvider check doesn't fire;
+	// other fields will still be missing, so Validate will still error.
+	// We check that the specific "GOCELL_KEY_PROVIDER" message is NOT in the error.
+	deps := &SharedDeps{
+		Topology: bootstrap.Topology{StorageBackend: "memory", AdapterMode: "dev"},
+	}
+
+	err := deps.Validate()
+	// Will error for other missing fields, but NOT for KeyProvider.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "GOCELL_KEY_PROVIDER")
+	}
+}

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -37,6 +37,18 @@ Missing required variables cause fail-fast before any assembly initialization.
 | `GOCELL_CONFIG_CURSOR_KEY` | HMAC key for config cursor codec | `core-bundle-cfg-cursor-key--32b!` | **Real mode** |
 | `GOCELL_CONFIG_CURSOR_PREVIOUS_KEY` | Previous config cursor key (rotation) | — | No |
 
+## Encryption Key Provider (required when GOCELL_CELL_ADAPTER_MODE=postgres)
+
+| Variable | Purpose | Default | Required | Notes |
+|---|---|---|---|---|
+| `GOCELL_KEY_PROVIDER` | Selects the encryption backend for sensitive config values | — | **postgres mode** | `"local-aes"` (dev/CI) or `"vault-transit"` (production). Must be set when `GOCELL_CELL_ADAPTER_MODE=postgres`; startup fails fast otherwise. Memory mode does not encrypt. |
+| `GOCELL_MASTER_KEY` | 32-byte hex-encoded AES key for `local-aes` provider | — | When `GOCELL_KEY_PROVIDER=local-aes` | Generate: `openssl rand -hex 32`. Real mode rejects well-known demo keys (case-insensitive hex comparison). |
+| `GOCELL_MASTER_KEY_PREVIOUS` | Previous master key for key rotation | — | No | Optional; enables decryption of values encrypted with the prior key during rotation window. |
+| `VAULT_ADDR` | Vault server address | `https://127.0.0.1:8200` | When `GOCELL_KEY_PROVIDER=vault-transit` | Standard Vault SDK env var. |
+| `VAULT_TOKEN` | Vault authentication token | — | When `GOCELL_KEY_PROVIDER=vault-transit` | Static token path; token renewal via LifetimeWatcher is automatic when the token is renewable. Real mode will require AppRole/K8s auth in a future release (A14). |
+| `GOCELL_VAULT_TRANSIT_MOUNT` | Vault Transit secrets engine mount path | `transit` | No | |
+| `GOCELL_VAULT_TRANSIT_KEY` | Vault Transit key name | `gocell-config` | No | |
+
 ## Observability / Monitoring
 
 | Variable | Purpose | Default | Required |


### PR DESCRIPTION
## Summary

- **S2**: Reject well-known demo `GOCELL_MASTER_KEY` in real adapter mode (hex-encoded test fixture key added to `wellKnownDemoKeys`)
- **A3**: Defense-in-depth `GOCELL_KEY_PROVIDER` check in `SharedDeps.Validate()` for postgres storage backend
- **M3**: Stale-key observability — `slog.Warn` + optional `onStaleCipher` callback in `ConfigRepository.GetByKey/List`
- **A13**: Vault token `LifetimeWatcher` background renewal via `TokenRenewer` opt-in interface + `tokenRenewalWorker`

## Test plan

- [ ] `TestBuildKeyProvider_LocalAES_DemoKey_RealMode_Rejected` — demo key blocked in real mode
- [ ] `TestBuildKeyProvider_LocalAES_DemoKey_DevMode_Allowed` — demo key accepted in dev mode
- [ ] `TestSharedDeps_Validate_PostgresWithoutKeyProvider_Fails` — missing env var caught
- [ ] `TestGetByKey_StaleKey_EmitsWarn` — slog.Warn emitted with correct fields
- [ ] `TestTokenRenewalWorker_Start_*` — renewal worker lifecycle (cancel, renewal, done, error)
- [ ] `TestVaultAPIClient_ImplementsTokenRenewer` — compile-time assertion
- [ ] All existing tests pass (vault, core-bundle, config-core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)