### PR TITLE
fix(bootstrap): drain workerErrCh in teardown to prevent goroutine leak

### DIFF
--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -766,7 +766,22 @@ func (b *Bootstrap) phase8StartWorkers(runCtx context.Context, s *phaseState) {
 	s.workerErrCh = workerErrCh
 	s.addTeardown(func(c context.Context) error {
 		workerCancel()
-		return wg.Stop(c)
+		stopErr := wg.Stop(c)
+		// Wait for the wg.Start goroutine to finish so that all worker goroutines
+		// have fully exited before Run() returns.
+		//
+		// In the ctx-cancel path, phase9 never reads from workerErrCh, so the
+		// goroutine is still blocked on wg.Wait(). We drain it here to prevent
+		// goroutine leaks and races on state set inside worker goroutines (e.g.,
+		// the workerCtxCancelledAt atomic in tests).
+		//
+		// In the worker-error path, phase9 already drained the error; the channel
+		// is closed and this select returns immediately.
+		select {
+		case <-workerErrCh:
+		case <-c.Done():
+		}
+		return stopErr
 	})
 }
 


### PR DESCRIPTION
## Summary

- `phase8StartWorkers` 的 teardown 在 ctx-cancel 路径下提前返回，`wg.Start` goroutine 因 `wg.Wait()` 仍在阻塞而泄漏到下一个测试
- `workerCtxCancelledAt` 原子值可能在 `b.Run()` 返回时尚未被 worker goroutine 写入，导致 `require.NotZero` 偶发失败
- 泄漏的 goroutine 调用 `slog` 造成测试间日志交错

修复：在 teardown 闭包中 drain `workerErrCh`，确保 `b.Run()` 返回前所有 worker goroutine 已完全退出。worker-error 路径下 channel 已被 phase9 消费并 close，select 立即返回，无额外开销。

## Test plan

- [x] `go test ./runtime/bootstrap/ -run TestShutdown -count=3 -race` 全部通过
- [x] `golangci-lint run ./runtime/bootstrap/...` 0 issues
- [x] `TestShutdown_RunCtxIndependentOfExternalCtx -count=5` 稳定通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)