### PR TITLE
feat(security): R2b keyID contract + stale cipher metric + renewal counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Follow these steps to create a custom Cell from scratch.
 ### Step 1: Create Cell directory and metadata
 
 ```bash
-mkdir -p cells/my-cell/slices/my-action
+mkdir -p cells/my-cell/slices/myaction
 ```
 
 Create `cells/my-cell/cell.yaml`:
@@ -87,16 +87,16 @@ verify:
     - my-cell/smoke
 ```
 
-Create `cells/my-cell/slices/my-action/slice.yaml`:
+Create `cells/my-cell/slices/myaction/slice.yaml`:
 ```yaml
-id: my-action
+id: myaction
 belongsToCell: my-cell
 contractUsages:
   - contract: http.my-api.v1
     role: serve
 verify:
-  unit: my-action/unit
-  contract: my-action/contract
+  unit: myaction/unit
+  contract: myaction/contract
 ```
 
 ### Step 2: Define the domain
@@ -231,7 +231,7 @@ asm := assembly.New(assembly.Config{ID: "dev", DurabilityMode: cell.DurabilityDe
 ├── runtime/      — HTTP middleware, auth, worker, observability, bootstrap
 ├── adapters/     — External system adapters (postgres / redis / rabbitmq / websocket / s3 / oidc)
 ├── pkg/          — Shared utilities (errcode / ctxkeys / httputil / query)
-├── cmd/          — CLI (gocell validate / scaffold / generate / check / verify)
+├── cmd/          — CLI (gocell validate [--strict] / scaffold / generate / check / verify)
 ├── examples/     — Example projects (sso-bff / todo-order / iot-device)
 ├── templates/    — Project templates (ADR / cell-design / contract-review / runbook / postmortem / grafana)
 └── generated/    — Tool-generated artifacts (indexes, derived views)

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/prometheus/client_golang/prometheus"
 
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
@@ -112,9 +113,11 @@ func (a *vaultLifetimeWatcherAdapter) RenewCh() <-chan *vaultapi.RenewOutput { r
 //
 // ref: hashicorp/vault api/lifetime_watcher.go@main — LifetimeWatcher usage pattern
 type tokenRenewalWorker struct {
-	watcher  tokenWatcher
-	logger   *slog.Logger
-	stopOnce sync.Once
+	watcher      tokenWatcher
+	logger       *slog.Logger
+	stopOnce     sync.Once
+	renewSuccess prometheus.Counter // vault_token_renew_success_total; nil when not configured
+	renewFailure prometheus.Counter // vault_token_renew_failure_total; nil when not configured
 }
 
 // Start launches watcher.Start() in a goroutine, then loops on the watcher
@@ -158,12 +161,18 @@ func (w *tokenRenewalWorker) handleDone(ctx context.Context, err error, ok bool)
 	if err != nil {
 		w.logger.ErrorContext(ctx, "vault-transit: token renewal stopped with error",
 			slog.String("error", err.Error()))
+		if w.renewFailure != nil {
+			w.renewFailure.Inc()
+		}
 		return true, err
 	}
 	// nil error = Vault LifetimeWatcher confirmed token is no longer renewable.
 	// Operational alert: return error so bootstrap/supervisor can surface this
 	// before encrypt/decrypt starts failing.
 	w.logger.ErrorContext(ctx, "vault-transit: token is no longer renewable; operator must rotate token before expiry")
+	if w.renewFailure != nil {
+		w.renewFailure.Inc()
+	}
 	return true, errcode.New(errcode.ErrKeyProviderAuthFailed,
 		"vault-transit: token is no longer renewable; encrypt/decrypt will fail after token expiry")
 }
@@ -181,6 +190,9 @@ func (w *tokenRenewalWorker) handleRenewal(ctx context.Context, renewal *vaultap
 	}
 	w.logger.InfoContext(ctx, "vault-transit: token renewed",
 		slog.Int("lease_duration", renewal.Secret.Auth.LeaseDuration))
+	if w.renewSuccess != nil {
+		w.renewSuccess.Inc()
+	}
 	return false
 }
 
@@ -323,9 +335,8 @@ func (h *vaultTransitHandle) Decrypt(ctx context.Context, ciphertext, nonce, edk
 		return nil, errcode.Wrap(errcode.ErrKeyProviderDecryptFailed,
 			"vault-transit: malformed edk prefix", parseErr)
 	}
-	if h.id != edkVersion {
-		return nil, errcode.New(errcode.ErrKeyProviderDecryptFailed,
-			fmt.Sprintf("vault-transit: keyID %q does not match edk version %q", h.id, edkVersion))
+	if err := kcrypto.MatchKeyID(h.id, edkVersion); err != nil {
+		return nil, errcode.Wrap(errcode.ErrKeyProviderDecryptFailed, "vault-transit: keyID mismatch", err)
 	}
 
 	// 1. Unwrap DEK via Vault Transit.
@@ -820,6 +831,18 @@ func (p *TransitKeyProvider) initTokenRenewal(ctx context.Context) error {
 	p.renewalWorker = &tokenRenewalWorker{
 		watcher: &vaultLifetimeWatcherAdapter{w: raw},
 		logger:  p.logger,
+		renewSuccess: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "gocell",
+			Subsystem: "vault",
+			Name:      "token_renew_success_total",
+			Help:      "Number of successful Vault token renewals.",
+		}),
+		renewFailure: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "gocell",
+			Subsystem: "vault",
+			Name:      "token_renew_failure_total",
+			Help:      "Number of Vault token renewal failures (token no longer renewable).",
+		}),
 	}
 	return nil
 }

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -306,7 +306,7 @@ func (h *vaultTransitHandle) wrapDEKWithVault(ctx context.Context, dek []byte) (
 			"vault-transit: encrypt response missing string 'ciphertext' field")
 	}
 
-	keyID, err = parseVaultKeyID(ciphertextStr)
+	keyID, err = parseVaultKeyID(ciphertextStr, errcode.ErrKeyProviderEncryptFailed)
 	if err != nil {
 		return nil, "", err
 	}
@@ -330,10 +330,9 @@ func (h *vaultTransitHandle) Decrypt(ctx context.Context, ciphertext, nonce, edk
 	// and confirm it matches h.id ("vault-transit:vN"). A mismatch indicates that
 	// the caller supplied an edk that belongs to a different key version, which is
 	// a permanent error (no retry will fix a misrouted keyID).
-	edkVersion, parseErr := parseVaultKeyID(string(edk))
+	edkVersion, parseErr := parseVaultKeyID(string(edk), errcode.ErrKeyProviderDecryptFailed)
 	if parseErr != nil {
-		return nil, errcode.Wrap(errcode.ErrKeyProviderDecryptFailed,
-			"vault-transit: malformed edk prefix", parseErr)
+		return nil, parseErr
 	}
 	if err := kcrypto.MatchKeyID(h.id, edkVersion); err != nil {
 		return nil, errcode.Wrap(errcode.ErrKeyProviderDecryptFailed, "vault-transit: keyID mismatch", err)
@@ -718,16 +717,20 @@ func isTransientHTTPStatus(code int) bool {
 // ciphertext string. The ciphertext format is "vault:vN:base64..." where N is
 // the key version integer.
 //
-// Returns "vault-transit:vN" on success, or ErrKeyProviderEncryptFailed if the
+// errCode is the errcode.Code to use on parse failure — callers should pass
+// ErrKeyProviderEncryptFailed on the encrypt path and ErrKeyProviderDecryptFailed
+// on the decrypt path so that the returned error code matches the operation.
+//
+// Returns "vault-transit:vN" on success, or an errcode wrapping errCode if the
 // prefix is not in the expected "vault:vN:" format.
 //
 // ref: hashicorp/vault sdk/helper/keysutil/policy.go@main:L127 (version prefix)
 // ref: kubernetes/kubernetes kmsv2/envelope.go@master (EncryptResponse.KeyID)
-func parseVaultKeyID(ciphertext string) (string, error) {
+func parseVaultKeyID(ciphertext string, errCode errcode.Code) (string, error) {
 	// Expected format: "vault:vN:base64payload"
 	parts := strings.SplitN(ciphertext, ":", 3)
 	if len(parts) != 3 || parts[0] != "vault" || !strings.HasPrefix(parts[1], "v") {
-		return "", errcode.New(errcode.ErrKeyProviderEncryptFailed,
+		return "", errcode.New(errCode,
 			fmt.Sprintf("vault-transit: unexpected ciphertext prefix (want 'vault:vN:...'): %q", ciphertext))
 	}
 	return vaultKeyIDPrefix + parts[1], nil
@@ -772,6 +775,18 @@ func (p *TransitKeyProvider) Checkers() map[string]func() error {
 			return err
 		},
 	}
+}
+
+// RenewalMetrics returns the Prometheus collectors for token renewal
+// observability. The composition root must register these with its
+// prometheus.Registerer so that renewal counters appear in /metrics scrapes.
+// Returns nil when no renewal worker is configured (VaultClient did not
+// implement TokenRenewer, e.g. test fakes with static tokens).
+func (p *TransitKeyProvider) RenewalMetrics() []prometheus.Collector {
+	if p.renewalWorker == nil {
+		return nil
+	}
+	return []prometheus.Collector{p.renewalWorker.renewSuccess, p.renewalWorker.renewFailure}
 }
 
 // Worker returns the token renewal worker when one has been configured, or nil

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -132,7 +132,7 @@ type tokenRenewalWorker struct {
 //     layer can alert operators before token expiry.
 func (w *tokenRenewalWorker) Start(ctx context.Context) error {
 	go w.watcher.Start()
-	defer w.watcher.Stop()
+	defer w.stopOnce.Do(func() { w.watcher.Stop() })
 
 	for {
 		select {

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -730,8 +730,14 @@ func parseVaultKeyID(ciphertext string, errCode errcode.Code) (string, error) {
 	// Expected format: "vault:vN:base64payload"
 	parts := strings.SplitN(ciphertext, ":", 3)
 	if len(parts) != 3 || parts[0] != "vault" || !strings.HasPrefix(parts[1], "v") {
+		// Do NOT include the full ciphertext in the error message — it contains
+		// the wrapped DEK and would leak to server-side logs via the 5xx error chain.
+		prefix := ciphertext
+		if len(prefix) > 12 {
+			prefix = prefix[:12] + "..."
+		}
 		return "", errcode.New(errCode,
-			fmt.Sprintf("vault-transit: unexpected ciphertext prefix (want 'vault:vN:...'): %q", ciphertext))
+			fmt.Sprintf("vault-transit: unexpected ciphertext prefix (want 'vault:vN:...'): %q", prefix))
 	}
 	return vaultKeyIDPrefix + parts[1], nil
 }
@@ -841,6 +847,10 @@ func (p *TransitKeyProvider) initTokenRenewal(ctx context.Context) error {
 	if err != nil {
 		return errcode.Wrap(errcode.ErrKeyProviderAuthFailed,
 			"vault-transit: create lifetime watcher", err)
+	}
+	if raw == nil {
+		return errcode.New(errcode.ErrKeyProviderAuthFailed,
+			"vault-transit: NewLifetimeWatcher returned nil without error")
 	}
 
 	p.renewalWorker = &tokenRenewalWorker{

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -830,7 +830,7 @@ func TestParseVaultKeyID(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseVaultKeyID(tc.ciphertext)
+			got, err := parseVaultKeyID(tc.ciphertext, errcode.ErrKeyProviderEncryptFailed)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("parseVaultKeyID(%q) expected error, got nil (keyID=%q)", tc.ciphertext, got)
@@ -902,6 +902,38 @@ func TestTransitKeyProvider_Worker_NonNilWhenRenewalConfigured(t *testing.T) {
 
 	if p.Worker() == nil {
 		t.Error("Worker() must return non-nil when renewalWorker is set")
+	}
+}
+
+// TestTransitKeyProvider_RenewalMetrics_NilWhenNoRenewal verifies that
+// RenewalMetrics returns nil when no renewal worker is configured.
+func TestTransitKeyProvider_RenewalMetrics_NilWhenNoRenewal(t *testing.T) {
+	fake := &fakeVaultClient{latestVersion: 1}
+	p := NewTransitKeyProvider(fake, "transit", "gocell-config")
+
+	if got := p.RenewalMetrics(); got != nil {
+		t.Errorf("RenewalMetrics() = %v, want nil when no renewal worker configured", got)
+	}
+}
+
+// TestTransitKeyProvider_RenewalMetrics_ReturnsTwoCollectors verifies that
+// RenewalMetrics returns exactly two collectors (success, failure) when a
+// renewal worker with counters is configured.
+func TestTransitKeyProvider_RenewalMetrics_ReturnsTwoCollectors(t *testing.T) {
+	fake := &fakeVaultClient{latestVersion: 1}
+	p := NewTransitKeyProvider(fake, "transit", "gocell-config")
+
+	successCtr, failureCtr := newRenewalCounters()
+	fw := newFakeTokenWatcher()
+	p.renewalWorker = &tokenRenewalWorker{
+		watcher:      fw,
+		renewSuccess: successCtr,
+		renewFailure: failureCtr,
+	}
+
+	got := p.RenewalMetrics()
+	if len(got) != 2 {
+		t.Errorf("RenewalMetrics() returned %d collectors, want 2", len(got))
 	}
 }
 

--- a/adapters/vault/transit_renewal_metrics_test.go
+++ b/adapters/vault/transit_renewal_metrics_test.go
@@ -19,6 +19,7 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
 
 	"log/slog"
 )
@@ -78,8 +79,10 @@ func TestTokenRenewalWorker_HandleRenewal_IncrementsSuccessCounter(t *testing.T)
 		},
 	}
 
-	// Give the loop a moment to consume the renewal before cancelling.
-	time.Sleep(20 * time.Millisecond)
+	// Wait for the loop to consume the renewal before cancelling.
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(successCtr) >= 1
+	}, time.Second, time.Millisecond)
 	cancel()
 
 	select {
@@ -136,7 +139,9 @@ func TestTokenRenewalWorker_HandleRenewal_MultipleRenewals_AccumulatesSuccessCou
 	fw.renewCh <- renewal
 
 	// Wait for all three to be consumed.
-	time.Sleep(30 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(successCtr) >= 3
+	}, time.Second, time.Millisecond)
 	cancel()
 
 	select {
@@ -267,7 +272,10 @@ func TestTokenRenewalWorker_NilCounters_NoopOnRenewal(t *testing.T) {
 			Auth: &vaultapi.SecretAuth{LeaseDuration: 3600},
 		},
 	}
-	time.Sleep(10 * time.Millisecond)
+	// Wait for the renewal to be consumed before cancelling.
+	require.Eventually(t, func() bool {
+		return len(fw.renewCh) == 0
+	}, time.Second, time.Millisecond)
 	cancel()
 
 	select {

--- a/adapters/vault/transit_renewal_metrics_test.go
+++ b/adapters/vault/transit_renewal_metrics_test.go
@@ -1,0 +1,311 @@
+package vault
+
+// A13 metrics tests: Prometheus counters for token renewal worker.
+//
+// These tests verify that:
+//   - handleRenewal increments vault_token_renew_success_total on each
+//     successful renewal notification.
+//   - handleDone increments vault_token_renew_failure_total when the token
+//     is no longer renewable (nil error on DoneCh).
+//   - handleDone increments vault_token_renew_failure_total when the watcher
+//     reports a non-nil error.
+//   - Existing tests without counters continue to work (nil-guard).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"log/slog"
+)
+
+// newRenewalCounters creates a pair of unregistered Prometheus counters for
+// use in tests. The counters are NOT registered in any registry — they are
+// standalone counters exercised via testutil.ToFloat64.
+func newRenewalCounters() (success, failure prometheus.Counter) {
+	success = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "gocell",
+		Subsystem: "vault",
+		Name:      "token_renew_success_total",
+		Help:      "Number of successful Vault token renewals.",
+	})
+	failure = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "gocell",
+		Subsystem: "vault",
+		Name:      "token_renew_failure_total",
+		Help:      "Number of Vault token renewal failures (token no longer renewable).",
+	})
+	return success, failure
+}
+
+// TestTokenRenewalWorker_HandleRenewal_IncrementsSuccessCounter verifies that
+// a valid renewal notification increments renewSuccess and leaves renewFailure
+// at zero.
+func TestTokenRenewalWorker_HandleRenewal_IncrementsSuccessCounter(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	successCtr, failureCtr := newRenewalCounters()
+
+	w := &tokenRenewalWorker{
+		watcher:      fw,
+		logger:       slog.Default(),
+		renewSuccess: successCtr,
+		renewFailure: failureCtr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	// Wait for the fake watcher's Start to be called.
+	select {
+	case <-fw.startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher.Start() was not called within 2s")
+	}
+
+	// Send one valid renewal.
+	fw.renewCh <- &vaultapi.RenewOutput{
+		Secret: &vaultapi.Secret{
+			Auth: &vaultapi.SecretAuth{LeaseDuration: 3600},
+		},
+	}
+
+	// Give the loop a moment to consume the renewal before cancelling.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() returned error, want nil: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after context cancel")
+	}
+
+	if got := testutil.ToFloat64(successCtr); got != 1 {
+		t.Errorf("renewSuccess counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(failureCtr); got != 0 {
+		t.Errorf("renewFailure counter = %v, want 0", got)
+	}
+}
+
+// TestTokenRenewalWorker_HandleRenewal_MultipleRenewals_AccumulatesSuccessCounter
+// verifies that multiple renewal events accumulate on the success counter.
+func TestTokenRenewalWorker_HandleRenewal_MultipleRenewals_AccumulatesSuccessCounter(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	successCtr, failureCtr := newRenewalCounters()
+
+	w := &tokenRenewalWorker{
+		watcher:      fw,
+		logger:       slog.Default(),
+		renewSuccess: successCtr,
+		renewFailure: failureCtr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	select {
+	case <-fw.startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher.Start() was not called within 2s")
+	}
+
+	renewal := &vaultapi.RenewOutput{
+		Secret: &vaultapi.Secret{
+			Auth: &vaultapi.SecretAuth{LeaseDuration: 3600},
+		},
+	}
+	fw.renewCh <- renewal
+	fw.renewCh <- renewal
+	fw.renewCh <- renewal
+
+	// Wait for all three to be consumed.
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after context cancel")
+	}
+
+	if got := testutil.ToFloat64(successCtr); got != 3 {
+		t.Errorf("renewSuccess counter = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(failureCtr); got != 0 {
+		t.Errorf("renewFailure counter = %v, want 0", got)
+	}
+}
+
+// TestTokenRenewalWorker_HandleDone_NilError_IncrementsFailureCounter verifies
+// that a nil error on DoneCh (token no longer renewable) increments
+// renewFailure and leaves renewSuccess at zero.
+func TestTokenRenewalWorker_HandleDone_NilError_IncrementsFailureCounter(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	successCtr, failureCtr := newRenewalCounters()
+
+	w := &tokenRenewalWorker{
+		watcher:      fw,
+		logger:       slog.Default(),
+		renewSuccess: successCtr,
+		renewFailure: failureCtr,
+	}
+
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	// Signal token no longer renewable (nil error on DoneCh).
+	fw.doneCh <- nil
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("Start() must return non-nil error when token is no longer renewable")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after DoneCh fired")
+	}
+
+	if got := testutil.ToFloat64(failureCtr); got != 1 {
+		t.Errorf("renewFailure counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(successCtr); got != 0 {
+		t.Errorf("renewSuccess counter = %v, want 0", got)
+	}
+}
+
+// TestTokenRenewalWorker_HandleDone_NonNilError_IncrementsFailureCounter
+// verifies that a non-nil error on DoneCh (unrecoverable failure) also
+// increments renewFailure.
+func TestTokenRenewalWorker_HandleDone_NonNilError_IncrementsFailureCounter(t *testing.T) {
+	fw := newFakeTokenWatcher()
+	successCtr, failureCtr := newRenewalCounters()
+
+	w := &tokenRenewalWorker{
+		watcher:      fw,
+		logger:       slog.Default(),
+		renewSuccess: successCtr,
+		renewFailure: failureCtr,
+	}
+
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	// Signal unrecoverable renewal error.
+	fw.doneCh <- context.DeadlineExceeded
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("Start() must return non-nil error on DoneCh error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after DoneCh fired with error")
+	}
+
+	if got := testutil.ToFloat64(failureCtr); got != 1 {
+		t.Errorf("renewFailure counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(successCtr); got != 0 {
+		t.Errorf("renewSuccess counter = %v, want 0", got)
+	}
+}
+
+// TestTokenRenewalWorker_NilCounters_NoopOnRenewal verifies that the nil
+// counter guard works: existing code paths that do not supply counters do not
+// panic.
+func TestTokenRenewalWorker_NilCounters_NoopOnRenewal(t *testing.T) {
+	fw := newFakeTokenWatcher()
+
+	// No counters — matches existing test construction style.
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+		// renewSuccess and renewFailure are nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	select {
+	case <-fw.startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher.Start() not called")
+	}
+
+	fw.renewCh <- &vaultapi.RenewOutput{
+		Secret: &vaultapi.Secret{
+			Auth: &vaultapi.SecretAuth{LeaseDuration: 3600},
+		},
+	}
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() returned unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return")
+	}
+	// No panic = pass.
+}
+
+// TestTokenRenewalWorker_NilCounters_NoopOnDone verifies that the nil counter
+// guard works when DoneCh fires (no panic when renewFailure is nil).
+func TestTokenRenewalWorker_NilCounters_NoopOnDone(t *testing.T) {
+	fw := newFakeTokenWatcher()
+
+	w := &tokenRenewalWorker{
+		watcher: fw,
+		logger:  slog.Default(),
+	}
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Start(ctx)
+	}()
+
+	fw.doneCh <- nil
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("Start() must return non-nil error on nil DoneCh")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return")
+	}
+	// No panic = pass.
+}

--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/jackc/pgx/v5/pgxpool"
+	prom "github.com/prometheus/client_golang/prometheus"
 )
 
 // Compile-time interface checks.
@@ -98,6 +99,13 @@ func WithValueTransformer(t kcrypto.ValueTransformer) Option {
 	return func(c *ConfigCore) { c.valueTransformer = t }
 }
 
+// WithOnStaleCipherMetric sets a Prometheus counter that increments when a
+// config value encrypted with a stale (non-current) key is read. Wire this
+// from the composition root to enable M3 stale-key observability.
+func WithOnStaleCipherMetric(c prom.Counter) Option {
+	return func(cc *ConfigCore) { cc.staleCipherCounter = c }
+}
+
 // WithPostgresDefaults wires the config-core cell with PostgreSQL-backed
 // repositories and a transactional outbox. Use this option when
 // GOCELL_CELL_ADAPTER_MODE=postgres. The caller is responsible for applying
@@ -130,16 +138,17 @@ func WithPostgresDefaults(pool *pgxpool.Pool, outboxWriter outbox.Writer) Option
 // ConfigCore is the config-core Cell implementation.
 type ConfigCore struct {
 	*cell.BaseCell
-	configRepo       ports.ConfigRepository
-	flagRepo         ports.FlagRepository
-	publisher        outbox.Publisher
-	outboxWriter     outbox.Writer
-	txRunner         persistence.TxRunner
-	cursorCodec      *query.CursorCodec
-	logger           *slog.Logger
-	keyProvider      kcrypto.KeyProvider
-	valueTransformer kcrypto.ValueTransformer
-	pgPool           *pgxpool.Pool // stored by WithPostgresDefaults for deferred Init()
+	configRepo         ports.ConfigRepository
+	flagRepo           ports.FlagRepository
+	publisher          outbox.Publisher
+	outboxWriter       outbox.Writer
+	txRunner           persistence.TxRunner
+	cursorCodec        *query.CursorCodec
+	logger             *slog.Logger
+	keyProvider        kcrypto.KeyProvider
+	valueTransformer   kcrypto.ValueTransformer
+	pgPool             *pgxpool.Pool // stored by WithPostgresDefaults for deferred Init()
+	staleCipherCounter prom.Counter  // optional; incremented on stale-key reads (M3)
 
 	// Slice services and handlers.
 	writeHandler     *configwrite.Handler
@@ -180,7 +189,13 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	// Deferred PG repo construction — options are all applied before Init().
 	if c.pgPool != nil && c.configRepo == nil {
 		session := cellpg.NewSession(c.pgPool)
-		c.configRepo = cellpg.NewConfigRepository(session, c.valueTransformer, nil)
+		var repoOpts []cellpg.ConfigRepoOption
+		if c.staleCipherCounter != nil {
+			repoOpts = append(repoOpts, cellpg.WithOnStaleCipher(func(_, _, _ string) {
+				c.staleCipherCounter.Inc()
+			}))
+		}
+		c.configRepo = cellpg.NewConfigRepository(session, c.valueTransformer, nil, repoOpts...)
 		c.flagRepo = cellpg.NewFlagRepository(session)
 	}
 

--- a/cells/config-core/cell_stale_cipher_test.go
+++ b/cells/config-core/cell_stale_cipher_test.go
@@ -1,16 +1,12 @@
 package configcore
 
 import (
-	"context"
 	"testing"
 
-	"github.com/ghbvf/gocell/kernel/cell"
-	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestWithOnStaleCipherMetric_WiresCallback verifies that WithOnStaleCipherMetric
@@ -30,46 +26,24 @@ func TestWithOnStaleCipherMetric_WiresCallback(t *testing.T) {
 	assert.Equal(t, counter, c.staleCipherCounter, "WithOnStaleCipherMetric must set staleCipherCounter field")
 }
 
-// TestWithOnStaleCipherMetric_CounterIncrements verifies end-to-end that the
-// Prometheus counter wired via WithOnStaleCipherMetric is incremented when a
-// stale-cipher event is triggered through the configured callback. This test
-// exercises only the callback wiring path in Init() — it does not require a
-// real Postgres connection.
-//
-// The strategy: inject a custom ConfigRepository whose onStaleCipher callback
-// was already set by Init(), simulate a stale-cipher event by directly invoking
-// the callback, and verify the counter incremented.
-func TestWithOnStaleCipherMetric_CounterIncrements(t *testing.T) {
-	reg := prom.NewRegistry()
+// TestWithOnStaleCipherMetric_CounterIsLive verifies that the Prometheus counter
+// stored by WithOnStaleCipherMetric is a live, registered counter that can be
+// incremented and observed. This is a field-level wiring test; the full callback
+// chain (repo.observeStaleCipher → onStaleCipher → counter.Inc) is covered by
+// config_repo_encrypt_test.go:TestWithOnStaleCipher_Option.
+func TestWithOnStaleCipherMetric_CounterIsLive(t *testing.T) {
 	counter := prom.NewCounter(prom.CounterOpts{
-		Namespace: "gocell",
-		Subsystem: "config",
-		Name:      "stale_cipher_total_increments_test",
-		Help:      "Test counter for stale cipher increment verification.",
+		Name: "config_stale_cipher_total_live_test",
 	})
-	require.NoError(t, reg.Register(counter))
 
 	c := NewConfigCore(
 		WithOnStaleCipherMetric(counter),
 		WithInMemoryDefaults(),
 		WithPublisher(eventbus.New()),
-		WithOutboxWriter(outbox.NoopWriter{}),
-		WithTxManager(noopTxRunner{}),
 	)
 
-	// Init must succeed.
-	require.NoError(t, c.Init(context.Background(), cell.Dependencies{
-		Config:         make(map[string]any),
-		DurabilityMode: cell.DurabilityDemo,
-	}))
-
-	// The counter must start at 0.
 	assert.Equal(t, float64(0), testutil.ToFloat64(counter))
-
-	// Invoke the counter directly (the field is package-accessible in this
-	// same-package test) to confirm it is live and wired.
 	c.staleCipherCounter.Inc()
-
 	assert.Equal(t, float64(1), testutil.ToFloat64(counter),
-		"Inc() on staleCipherCounter must increment the prometheus counter")
+		"counter must be live and incrementable")
 }

--- a/cells/config-core/cell_stale_cipher_test.go
+++ b/cells/config-core/cell_stale_cipher_test.go
@@ -1,0 +1,73 @@
+package configcore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithOnStaleCipherMetric_WiresCallback verifies that WithOnStaleCipherMetric
+// sets the staleCipherCounter field on the ConfigCore struct so that Init() can
+// forward the increment callback to the ConfigRepository.
+func TestWithOnStaleCipherMetric_WiresCallback(t *testing.T) {
+	counter := prom.NewCounter(prom.CounterOpts{
+		Name: "config_stale_cipher_total_test",
+	})
+	c := NewConfigCore(
+		WithOnStaleCipherMetric(counter),
+		WithInMemoryDefaults(),
+		WithPublisher(eventbus.New()),
+	)
+	assert.NotNil(t, c.staleCipherCounter, "WithOnStaleCipherMetric must set staleCipherCounter field")
+}
+
+// TestWithOnStaleCipherMetric_CounterIncrements verifies end-to-end that the
+// Prometheus counter wired via WithOnStaleCipherMetric is incremented when a
+// stale-cipher event is triggered through the configured callback. This test
+// exercises only the callback wiring path in Init() — it does not require a
+// real Postgres connection.
+//
+// The strategy: inject a custom ConfigRepository whose onStaleCipher callback
+// was already set by Init(), simulate a stale-cipher event by directly invoking
+// the callback, and verify the counter incremented.
+func TestWithOnStaleCipherMetric_CounterIncrements(t *testing.T) {
+	reg := prom.NewRegistry()
+	counter := prom.NewCounter(prom.CounterOpts{
+		Namespace: "gocell",
+		Subsystem: "config",
+		Name:      "stale_cipher_total_increments_test",
+		Help:      "Test counter for stale cipher increment verification.",
+	})
+	require.NoError(t, reg.Register(counter))
+
+	c := NewConfigCore(
+		WithOnStaleCipherMetric(counter),
+		WithInMemoryDefaults(),
+		WithPublisher(eventbus.New()),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(noopTxRunner{}),
+	)
+
+	// Init must succeed.
+	require.NoError(t, c.Init(context.Background(), cell.Dependencies{
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDemo,
+	}))
+
+	// The counter must start at 0.
+	assert.Equal(t, float64(0), testutil.ToFloat64(counter))
+
+	// Invoke the counter directly (the field is package-accessible in this
+	// same-package test) to confirm it is live and wired.
+	c.staleCipherCounter.Inc()
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(counter),
+		"Inc() on staleCipherCounter must increment the prometheus counter")
+}

--- a/cells/config-core/cell_stale_cipher_test.go
+++ b/cells/config-core/cell_stale_cipher_test.go
@@ -25,7 +25,9 @@ func TestWithOnStaleCipherMetric_WiresCallback(t *testing.T) {
 		WithInMemoryDefaults(),
 		WithPublisher(eventbus.New()),
 	)
-	assert.NotNil(t, c.staleCipherCounter, "WithOnStaleCipherMetric must set staleCipherCounter field")
+	// The PG Init() wiring path (pgPool != nil → NewConfigRepository receives
+	// WithOnStaleCipher option) is covered by config_repo_encrypt_test.go:TestWithOnStaleCipher_Option.
+	assert.Equal(t, counter, c.staleCipherCounter, "WithOnStaleCipherMetric must set staleCipherCounter field")
 }
 
 // TestWithOnStaleCipherMetric_CounterIncrements verifies end-to-end that the

--- a/cmd/core-bundle/config_module.go
+++ b/cmd/core-bundle/config_module.go
@@ -63,15 +63,9 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	// same process (e.g. integration tests with shared registry) are handled
 	// gracefully: AlreadyRegisteredError carries the existing collector so we
 	// can reuse it instead of creating an orphaned counter.
-	staleCipherCounter := prom.NewCounter(configStaleCipherOpts)
-	if regErr := shared.PromStack.registry.Register(staleCipherCounter); regErr != nil {
-		if are, ok := regErr.(prom.AlreadyRegisteredError); ok {
-			if existing, ok2 := are.ExistingCollector.(prom.Counter); ok2 {
-				staleCipherCounter = existing
-			}
-		}
-		// Non-AlreadyRegisteredError: counter is still usable without registration;
-		// metrics simply won't appear in /metrics scrapes for this run.
+	staleCipherCounter, err := registerOrReuseCounter(shared.PromStack.registry, configStaleCipherOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("config-core: register stale_cipher counter: %w", err)
 	}
 
 	baseOpts := []configcore.Option{
@@ -84,10 +78,10 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	}
 	c := configcore.NewConfigCore(append(baseOpts, cellOpts...)...)
 
-	// A13: register vault token renewal counters when the KeyProvider exposes
-	// them. Uses the same Register-not-MustRegister pattern as staleCipherCounter
-	// so repeated Provide calls in integration tests are handled gracefully.
-	registerRenewalMetrics(kp, shared.PromStack.registry)
+	// A13: register vault token renewal counters when the KeyProvider exposes them.
+	if err := registerRenewalMetrics(kp, shared.PromStack.registry); err != nil {
+		return nil, nil, fmt.Errorf("config-core: register renewal metrics: %w", err)
+	}
 
 	var opts []bootstrap.Option
 	if pgRes != nil {
@@ -115,19 +109,37 @@ type renewalMetricsProvider interface {
 }
 
 // registerRenewalMetrics registers per-collector metrics exposed by KeyProvider
-// implementations that satisfy renewalMetricsProvider. Uses Register (not
-// MustRegister) so repeated Provide calls in integration tests are graceful:
-// AlreadyRegisteredError and other non-fatal errors leave counters usable
-// in memory while simply omitting them from /metrics scrapes.
-func registerRenewalMetrics(kp kcrypto.KeyProvider, reg prom.Registerer) {
+// implementations that satisfy renewalMetricsProvider. Returns error on
+// registration failures other than AlreadyRegisteredError.
+func registerRenewalMetrics(kp kcrypto.KeyProvider, reg prom.Registerer) error {
 	rmp, ok := kp.(renewalMetricsProvider)
 	if !ok {
-		return
+		return nil
 	}
 	for _, col := range rmp.RenewalMetrics() {
-		// Non-fatal: AlreadyRegisteredError is benign on integration-test re-run;
-		// other errors leave the counter usable in memory only.
-		//nolint:errcheck
-		_ = reg.Register(col)
+		if err := reg.Register(col); err != nil {
+			if _, ok := err.(prom.AlreadyRegisteredError); !ok {
+				return fmt.Errorf("vault renewal metric: %w", err)
+			}
+		}
 	}
+	return nil
+}
+
+// registerOrReuseCounter registers a new counter with the given opts. If the
+// counter is already registered (AlreadyRegisteredError), it reuses the
+// existing collector. Any other registration error is returned as-is.
+func registerOrReuseCounter(reg prom.Registerer, opts prom.CounterOpts) (prom.Counter, error) {
+	c := prom.NewCounter(opts)
+	if err := reg.Register(c); err != nil {
+		are, ok := err.(prom.AlreadyRegisteredError)
+		if !ok {
+			return nil, err
+		}
+		if existing, ok2 := are.ExistingCollector.(prom.Counter); ok2 {
+			return existing, nil
+		}
+		return nil, fmt.Errorf("existing collector is not a Counter: %w", err)
+	}
+	return c, nil
 }

--- a/cmd/core-bundle/config_module.go
+++ b/cmd/core-bundle/config_module.go
@@ -84,6 +84,11 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	}
 	c := configcore.NewConfigCore(append(baseOpts, cellOpts...)...)
 
+	// A13: register vault token renewal counters when the KeyProvider exposes
+	// them. Uses the same Register-not-MustRegister pattern as staleCipherCounter
+	// so repeated Provide calls in integration tests are handled gracefully.
+	registerRenewalMetrics(kp, shared.PromStack.registry)
+
 	var opts []bootstrap.Option
 	if pgRes != nil {
 		opts = append(opts, bootstrap.WithManagedResource(pgRes))
@@ -101,3 +106,28 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 }
 
 var _ CellModule = ConfigCoreModule{}
+
+// renewalMetricsProvider is a local interface satisfied by vault.TransitKeyProvider
+// (and any future KeyProvider that exposes Prometheus renewal metrics). Using an
+// interface avoids importing the vault adapter package directly from config_module.go.
+type renewalMetricsProvider interface {
+	RenewalMetrics() []prom.Collector
+}
+
+// registerRenewalMetrics registers per-collector metrics exposed by KeyProvider
+// implementations that satisfy renewalMetricsProvider. Uses Register (not
+// MustRegister) so repeated Provide calls in integration tests are graceful:
+// AlreadyRegisteredError and other non-fatal errors leave counters usable
+// in memory while simply omitting them from /metrics scrapes.
+func registerRenewalMetrics(kp kcrypto.KeyProvider, reg prom.Registerer) {
+	rmp, ok := kp.(renewalMetricsProvider)
+	if !ok {
+		return
+	}
+	for _, col := range rmp.RenewalMetrics() {
+		// Non-fatal: AlreadyRegisteredError is benign on integration-test re-run;
+		// other errors leave the counter usable in memory only.
+		//nolint:errcheck
+		_ = reg.Register(col)
+	}
+}

--- a/cmd/core-bundle/config_module.go
+++ b/cmd/core-bundle/config_module.go
@@ -9,6 +9,7 @@ import (
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
+	prom "github.com/prometheus/client_golang/prometheus"
 )
 
 // ConfigCoreModule wires config-core: KeyProvider → ValueTransformer →
@@ -28,6 +29,17 @@ type ConfigCoreModule struct {
 // ID returns the stable identifier used in error messages.
 func (ConfigCoreModule) ID() string { return "config-core" }
 
+// configStaleCipherOpts is the Prometheus counter descriptor for M3 stale-key
+// observability. The counter is registered against the isolated per-run
+// Prometheus registry (shared.PromStack.registry) inside Provide so it
+// never touches the global default registry and remains isolated between tests.
+var configStaleCipherOpts = prom.CounterOpts{
+	Namespace: "gocell",
+	Subsystem: "config",
+	Name:      "stale_cipher_total",
+	Help:      "Number of config values read that are encrypted with a non-current key version.",
+}
+
 // Provide resolves all config-core-specific dependencies and returns the
 // constructed cell and any bootstrap.Options (e.g. WithManagedResource).
 func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell.Cell, []bootstrap.Option, error) {
@@ -46,9 +58,26 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 		return nil, nil, err
 	}
 
+	// Register the stale-cipher counter against the isolated per-run registry.
+	// Use Register (not MustRegister) so that repeated Provide calls in the
+	// same process (e.g. integration tests with shared registry) are handled
+	// gracefully: AlreadyRegisteredError carries the existing collector so we
+	// can reuse it instead of creating an orphaned counter.
+	staleCipherCounter := prom.NewCounter(configStaleCipherOpts)
+	if regErr := shared.PromStack.registry.Register(staleCipherCounter); regErr != nil {
+		if are, ok := regErr.(prom.AlreadyRegisteredError); ok {
+			if existing, ok2 := are.ExistingCollector.(prom.Counter); ok2 {
+				staleCipherCounter = existing
+			}
+		}
+		// Non-AlreadyRegisteredError: counter is still usable without registration;
+		// metrics simply won't appear in /metrics scrapes for this run.
+	}
+
 	baseOpts := []configcore.Option{
 		configcore.WithPublisher(shared.EventBus),
 		configcore.WithCursorCodec(shared.CursorCodecs.config),
+		configcore.WithOnStaleCipherMetric(staleCipherCounter),
 	}
 	if vt != nil {
 		baseOpts = append(baseOpts, configcore.WithValueTransformer(vt))

--- a/kernel/crypto/key_provider.go
+++ b/kernel/crypto/key_provider.go
@@ -36,6 +36,9 @@ type KeyProvider interface {
 //   - KeyID MUST reflect the KEK version actually used to wrap the data/DEK;
 //     for LocalAES this equals handle.ID(); for VaultTransit this is parsed
 //     from the wrapped DEK prefix "vault:vN:".
+//   - keyID is "verifiable metadata": callers SHOULD use MatchKeyID() to verify
+//     that a stored keyID matches the handle used for decryption. This prevents
+//     silent data corruption from misrouted key versions.
 //
 // ref: hashicorp/vault sdk/helper/keysutil/policy.go@main:L127 (keyID version prefix)
 // ref: kubernetes/kubernetes staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go@master (EncryptResponse.KeyID)

--- a/kernel/crypto/verifykeyid.go
+++ b/kernel/crypto/verifykeyid.go
@@ -26,49 +26,47 @@ func ParseKeyID(keyID string) (provider string, version int, err error) {
 			"invalid keyID: empty string")
 	}
 
-	// Try colon separator first: "{provider}:v{N}"
-	if idx := strings.LastIndex(keyID, ":v"); idx >= 0 {
-		providerPart := keyID[:idx]
-		versionStr := keyID[idx+2:] // skip ":v"
-		if providerPart == "" {
-			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
-				fmt.Sprintf("invalid keyID %q: empty provider before ':v'", keyID))
-		}
-		v, parseErr := strconv.Atoi(versionStr)
-		if parseErr != nil {
-			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
-				fmt.Sprintf("invalid keyID %q: non-numeric version %q", keyID, versionStr))
-		}
-		if v < 0 {
-			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
-				fmt.Sprintf("invalid keyID %q: negative version %d", keyID, v))
-		}
-		return providerPart, v, nil
+	// Try colon separator first (e.g. "vault-transit:v3").
+	if p, v, ok, err := tryParseVersionSuffix(keyID, ":v"); ok || err != nil {
+		return p, v, err
 	}
-
-	// Try dash separator: "{provider}-v{N}"
-	// The version segment is the last "-v{N}" suffix.
-	if idx := strings.LastIndex(keyID, "-v"); idx >= 0 {
-		providerPart := keyID[:idx]
-		versionStr := keyID[idx+2:] // skip "-v"
-		if providerPart == "" {
-			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
-				fmt.Sprintf("invalid keyID %q: empty provider before '-v'", keyID))
-		}
-		v, parseErr := strconv.Atoi(versionStr)
-		if parseErr != nil {
-			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
-				fmt.Sprintf("invalid keyID %q: non-numeric version %q", keyID, versionStr))
-		}
-		if v < 0 {
-			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
-				fmt.Sprintf("invalid keyID %q: negative version %d", keyID, v))
-		}
-		return providerPart, v, nil
+	// Try dash separator (e.g. "local-aes-v1").
+	if p, v, ok, err := tryParseVersionSuffix(keyID, "-v"); ok || err != nil {
+		return p, v, err
 	}
 
 	return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
 		fmt.Sprintf("invalid keyID %q: must end with '-v{N}' or ':v{N}'", keyID))
+}
+
+// tryParseVersionSuffix attempts to parse a version suffix from keyID using sep
+// as the separator (either ":v" or "-v"). It finds the last occurrence of sep,
+// splits keyID into provider and version string, and validates both parts.
+//
+// Returns (provider, version, true, nil) on success.
+// Returns ("", 0, false, nil) when sep is not found in keyID.
+// Returns ("", 0, true, err) when sep is found but the format is invalid.
+func tryParseVersionSuffix(keyID, sep string) (provider string, version int, found bool, err error) {
+	idx := strings.LastIndex(keyID, sep)
+	if idx < 0 {
+		return "", 0, false, nil
+	}
+	provider = keyID[:idx]
+	versionStr := keyID[idx+len(sep):]
+	if provider == "" {
+		return "", 0, true, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+			fmt.Sprintf("invalid keyID %q: empty provider before %q", keyID, sep))
+	}
+	v, parseErr := strconv.Atoi(versionStr)
+	if parseErr != nil {
+		return "", 0, true, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+			fmt.Sprintf("invalid keyID %q: non-numeric version %q", keyID, versionStr))
+	}
+	if v < 0 {
+		return "", 0, true, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+			fmt.Sprintf("invalid keyID %q: negative version %d", keyID, v))
+	}
+	return provider, v, true, nil
 }
 
 // MatchKeyID verifies that handleID and edkKeyID refer to the same provider

--- a/kernel/crypto/verifykeyid.go
+++ b/kernel/crypto/verifykeyid.go
@@ -1,0 +1,83 @@
+package crypto
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// ParseKeyID parses a key version identifier of the form "{provider}-v{N}" or
+// "{provider}:v{N}" and returns the provider name and version number.
+//
+// Both dash-separated (e.g. "local-aes-v1") and colon-separated (e.g.
+// "vault-transit:v3") formats are supported. The provider is everything before
+// the last "-vN" or ":vN" segment.
+//
+// Returns ErrKeyProviderDecryptFailed on any parse error.
+func ParseKeyID(keyID string) (provider string, version int, err error) {
+	if keyID == "" {
+		return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+			"invalid keyID: empty string")
+	}
+
+	// Try colon separator first: "{provider}:v{N}"
+	if idx := strings.LastIndex(keyID, ":v"); idx >= 0 {
+		providerPart := keyID[:idx]
+		versionStr := keyID[idx+2:] // skip ":v"
+		if providerPart == "" {
+			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+				fmt.Sprintf("invalid keyID %q: empty provider before ':v'", keyID))
+		}
+		v, parseErr := strconv.Atoi(versionStr)
+		if parseErr != nil {
+			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+				fmt.Sprintf("invalid keyID %q: non-numeric version %q", keyID, versionStr))
+		}
+		return providerPart, v, nil
+	}
+
+	// Try dash separator: "{provider}-v{N}"
+	// The version segment is the last "-v{N}" suffix.
+	if idx := strings.LastIndex(keyID, "-v"); idx >= 0 {
+		providerPart := keyID[:idx]
+		versionStr := keyID[idx+2:] // skip "-v"
+		if providerPart == "" {
+			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+				fmt.Sprintf("invalid keyID %q: empty provider before '-v'", keyID))
+		}
+		v, parseErr := strconv.Atoi(versionStr)
+		if parseErr != nil {
+			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+				fmt.Sprintf("invalid keyID %q: non-numeric version %q", keyID, versionStr))
+		}
+		return providerPart, v, nil
+	}
+
+	return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+		fmt.Sprintf("invalid keyID %q: must end with '-v{N}' or ':v{N}'", keyID))
+}
+
+// MatchKeyID verifies that handleID and edkKeyID refer to the same provider
+// and key version. Returns nil when they match, or a descriptive
+// ErrKeyProviderDecryptFailed error when they do not.
+//
+// Callers SHOULD call MatchKeyID before decryption to prevent silent data
+// corruption from misrouted key versions.
+func MatchKeyID(handleID, edkKeyID string) error {
+	hp, hv, err := ParseKeyID(handleID)
+	if err != nil {
+		return err
+	}
+	ep, ev, err := ParseKeyID(edkKeyID)
+	if err != nil {
+		return err
+	}
+
+	if hp != ep || hv != ev {
+		return errcode.New(errcode.ErrKeyProviderDecryptFailed,
+			fmt.Sprintf("keyID mismatch: handle %q does not match edk %q", handleID, edkKeyID))
+	}
+	return nil
+}

--- a/kernel/crypto/verifykeyid.go
+++ b/kernel/crypto/verifykeyid.go
@@ -15,7 +15,11 @@ import (
 // "vault-transit:v3") formats are supported. The provider is everything before
 // the last "-vN" or ":vN" segment.
 //
-// Returns ErrKeyProviderDecryptFailed on any parse error.
+// v0 is a valid version (used by LocalAES "local-aes-v0"). Negative versions
+// (e.g. "local-aes-v-1") are rejected.
+//
+// Returns ErrKeyProviderDecryptFailed on any parse error, including negative
+// or non-numeric version strings.
 func ParseKeyID(keyID string) (provider string, version int, err error) {
 	if keyID == "" {
 		return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
@@ -35,6 +39,10 @@ func ParseKeyID(keyID string) (provider string, version int, err error) {
 			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
 				fmt.Sprintf("invalid keyID %q: non-numeric version %q", keyID, versionStr))
 		}
+		if v < 0 {
+			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+				fmt.Sprintf("invalid keyID %q: negative version %d", keyID, v))
+		}
 		return providerPart, v, nil
 	}
 
@@ -52,6 +60,10 @@ func ParseKeyID(keyID string) (provider string, version int, err error) {
 			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
 				fmt.Sprintf("invalid keyID %q: non-numeric version %q", keyID, versionStr))
 		}
+		if v < 0 {
+			return "", 0, errcode.New(errcode.ErrKeyProviderDecryptFailed,
+				fmt.Sprintf("invalid keyID %q: negative version %d", keyID, v))
+		}
 		return providerPart, v, nil
 	}
 
@@ -62,6 +74,10 @@ func ParseKeyID(keyID string) (provider string, version int, err error) {
 // MatchKeyID verifies that handleID and edkKeyID refer to the same provider
 // and key version. Returns nil when they match, or a descriptive
 // ErrKeyProviderDecryptFailed error when they do not.
+//
+// Malformed input (including empty strings, missing version suffix, negative
+// versions, or non-numeric version strings) is forwarded as
+// ErrKeyProviderDecryptFailed from the underlying ParseKeyID call.
 //
 // Callers SHOULD call MatchKeyID before decryption to prevent silent data
 // corruption from misrouted key versions.

--- a/kernel/crypto/verifykeyid_test.go
+++ b/kernel/crypto/verifykeyid_test.go
@@ -1,0 +1,172 @@
+package crypto_test
+
+import (
+	"strings"
+	"testing"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+)
+
+// ---------------------------------------------------------------------------
+// ParseKeyID tests
+// ---------------------------------------------------------------------------
+
+func TestParseKeyID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		keyID           string
+		wantProvider    string
+		wantVersion     int
+		wantErrContains string
+	}{
+		{
+			name:         "local-aes dash separator v1",
+			keyID:        "local-aes-v1",
+			wantProvider: "local-aes",
+			wantVersion:  1,
+		},
+		{
+			name:         "local-aes dash separator v0",
+			keyID:        "local-aes-v0",
+			wantProvider: "local-aes",
+			wantVersion:  0,
+		},
+		{
+			name:         "vault-transit colon separator v3",
+			keyID:        "vault-transit:v3",
+			wantProvider: "vault-transit",
+			wantVersion:  3,
+		},
+		{
+			name:         "vault-transit colon separator v1",
+			keyID:        "vault-transit:v1",
+			wantProvider: "vault-transit",
+			wantVersion:  1,
+		},
+		{
+			name:            "empty string",
+			keyID:           "",
+			wantErrContains: "invalid keyID",
+		},
+		{
+			name:            "no version suffix",
+			keyID:           "no-version",
+			wantErrContains: "invalid keyID",
+		},
+		{
+			name:            "non-numeric version",
+			keyID:           "bad:vXYZ",
+			wantErrContains: "invalid keyID",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider, version, err := kcrypto.ParseKeyID(tc.keyID)
+
+			if tc.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("ParseKeyID(%q): expected error containing %q, got nil", tc.keyID, tc.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Fatalf("ParseKeyID(%q): error %q does not contain %q", tc.keyID, err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseKeyID(%q): unexpected error: %v", tc.keyID, err)
+			}
+			if provider != tc.wantProvider {
+				t.Errorf("ParseKeyID(%q): provider = %q, want %q", tc.keyID, provider, tc.wantProvider)
+			}
+			if version != tc.wantVersion {
+				t.Errorf("ParseKeyID(%q): version = %d, want %d", tc.keyID, version, tc.wantVersion)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MatchKeyID tests
+// ---------------------------------------------------------------------------
+
+func TestMatchKeyID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		handleID        string
+		edkKeyID        string
+		wantErrContains string
+	}{
+		{
+			name:     "same provider and version - local-aes v1",
+			handleID: "local-aes-v1",
+			edkKeyID: "local-aes-v1",
+		},
+		{
+			name:     "same provider and version - vault-transit v3",
+			handleID: "vault-transit:v3",
+			edkKeyID: "vault-transit:v3",
+		},
+		{
+			name:            "different version - vault-transit",
+			handleID:        "vault-transit:v2",
+			edkKeyID:        "vault-transit:v3",
+			wantErrContains: "vault-transit:v2",
+		},
+		{
+			name:            "different version includes both IDs in message",
+			handleID:        "local-aes-v1",
+			edkKeyID:        "local-aes-v2",
+			wantErrContains: "local-aes-v2",
+		},
+		{
+			name:            "different provider",
+			handleID:        "local-aes-v1",
+			edkKeyID:        "vault-transit:v1",
+			wantErrContains: "local-aes",
+		},
+		{
+			name:            "malformed handleID",
+			handleID:        "bad-handle",
+			edkKeyID:        "vault-transit:v1",
+			wantErrContains: "invalid keyID",
+		},
+		{
+			name:            "malformed edkKeyID",
+			handleID:        "vault-transit:v1",
+			edkKeyID:        "bad-edk",
+			wantErrContains: "invalid keyID",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := kcrypto.MatchKeyID(tc.handleID, tc.edkKeyID)
+
+			if tc.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("MatchKeyID(%q, %q): expected error containing %q, got nil",
+						tc.handleID, tc.edkKeyID, tc.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Fatalf("MatchKeyID(%q, %q): error %q does not contain %q",
+						tc.handleID, tc.edkKeyID, err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("MatchKeyID(%q, %q): unexpected error: %v", tc.handleID, tc.edkKeyID, err)
+			}
+		})
+	}
+}

--- a/kernel/crypto/verifykeyid_test.go
+++ b/kernel/crypto/verifykeyid_test.go
@@ -60,6 +60,22 @@ func TestParseKeyID(t *testing.T) {
 			keyID:           "bad:vXYZ",
 			wantErrContains: "invalid keyID",
 		},
+		{
+			name:            "negative version dash separator",
+			keyID:           "local-aes-v-1",
+			wantErrContains: "negative version",
+		},
+		{
+			name:            "negative version colon separator",
+			keyID:           "vault-transit:v-5",
+			wantErrContains: "negative version",
+		},
+		{
+			name:         "colon separator takes precedence over dash for unambiguous input",
+			keyID:        "provider-x:v2",
+			wantProvider: "provider-x",
+			wantVersion:  2, // colon separator tried first; dash in provider name is fine
+		},
 	}
 
 	for _, tc := range tests {
@@ -143,6 +159,12 @@ func TestMatchKeyID(t *testing.T) {
 			handleID:        "vault-transit:v1",
 			edkKeyID:        "bad-edk",
 			wantErrContains: "invalid keyID",
+		},
+		{
+			name:            "negative version in handleID",
+			handleID:        "local-aes-v-1",
+			edkKeyID:        "local-aes-v1",
+			wantErrContains: "negative version",
 		},
 	}
 


### PR DESCRIPTION
## Summary

R2 finalize (S4b/A14 deferred to production Vault deployment):

- **A20**: `kernel/crypto.ParseKeyID` / `MatchKeyID` helpers — structured keyID parsing + cross-provider verification; Vault `Decrypt` migrated; `KeyHandle` godoc upgraded to "verifiable metadata" contract
- **M3**: `WithOnStaleCipherMetric(prometheus.Counter)` on ConfigCore; composition root wires `gocell_config_stale_cipher_total` against shared registry
- **A13**: `vault_token_renew_success_total` / `failure_total` Prometheus counters on `tokenRenewalWorker`, nil-guarded for backward compat

backlog: A20 + M3 + A13 (counters)

## Test plan

- [x] `go build ./...` zero errors
- [x] `golangci-lint run` 0 issues on modified packages
- [x] `go test ./kernel/crypto/...` — 14 table-driven cases for ParseKeyID/MatchKeyID
- [x] `go test ./adapters/vault/...` — 6 new renewal counter tests + existing 47 pass
- [x] `go test ./cells/config-core/...` — 2 new stale cipher metric tests pass
- [x] `go test ./cmd/core-bundle/...` — all pass (sandbox bind failure excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)