### PR TITLE
fix(security): reject GOCELL_SERVICE_SECRET demo key in real mode (L0)

### DIFF
--- a/cmd/core-bundle/controlplane_guard_test.go
+++ b/cmd/core-bundle/controlplane_guard_test.go
@@ -54,3 +54,41 @@ func TestInternalGuardFromEnv_WithSecret_GuardRejects401WhenNoHeader(t *testing.
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"guard must reject requests without service token header")
 }
+
+// TestInternalGuardFromEnv_RealMode_DemoServiceSecret_Rejected verifies that
+// internalGuardFromEnv returns an error when GOCELL_SERVICE_SECRET is set to
+// the well-known demo value in real adapter mode. Guards against an attacker
+// forging ServiceTokens using the public demo secret shipped in test fixtures.
+func TestInternalGuardFromEnv_RealMode_DemoServiceSecret_Rejected(t *testing.T) {
+	t.Setenv("GOCELL_SERVICE_SECRET", "service-secret-32-bytes-xxxxxx!!")
+	_, err := internalGuardFromEnv("real")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GOCELL_SERVICE_SECRET",
+		"error must name the offending env var")
+	assert.Contains(t, err.Error(), "well-known demo key",
+		"error must indicate the reason")
+}
+
+// TestInternalGuardFromEnv_DevMode_DemoServiceSecret_Allowed verifies that
+// the demo key check is a no-op outside of real adapter mode, preserving
+// the dev/test workflow where demo fixture values are acceptable.
+func TestInternalGuardFromEnv_DevMode_DemoServiceSecret_Allowed(t *testing.T) {
+	t.Setenv("GOCELL_SERVICE_SECRET", "service-secret-32-bytes-xxxxxx!!")
+	guard, err := internalGuardFromEnv("") // dev mode
+	require.NoError(t, err)
+	assert.NotNil(t, guard, "dev mode must accept demo key and return a guard")
+}
+
+// TestInternalGuardFromEnv_RealMode_DemoPreviousServiceSecret_Rejected verifies
+// that GOCELL_SERVICE_SECRET_PREVIOUS is also checked against the demo blocklist
+// in real adapter mode.
+func TestInternalGuardFromEnv_RealMode_DemoPreviousServiceSecret_Rejected(t *testing.T) {
+	t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
+	t.Setenv("GOCELL_SERVICE_SECRET_PREVIOUS", "service-secret-32-bytes-xxxxxx!!")
+	_, err := internalGuardFromEnv("real")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GOCELL_SERVICE_SECRET_PREVIOUS",
+		"error must name the offending env var")
+	assert.Contains(t, err.Error(), "well-known demo key",
+		"error must indicate the reason")
+}

--- a/cmd/core-bundle/demo_keys_test.go
+++ b/cmd/core-bundle/demo_keys_test.go
@@ -47,6 +47,8 @@ func TestRejectDemoKey_RealMode_EmptyKeyPasses(t *testing.T) {
 func TestDevDefaults_AreAllInWellKnownDemoKeys(t *testing.T) {
 	// The dev defaults currently wired in run(). Keep this list in sync with
 	// main.go's loadSecret/loadCursorCodec call sites when they change.
+	// Note: GOCELL_SERVICE_SECRET has no dev-default (empty disables the guard
+	// in dev mode); rejectDemoKey is called directly in internalGuardFromEnv.
 	devDefaults := []string{
 		"dev-hmac-key-replace-in-prod!!!!", // loadSecret("GOCELL_HMAC_KEY", ...)
 		"core-bundle-audit-cursor-key-32!", // loadCursorCodec("GOCELL_AUDIT_CURSOR_KEY", ...)

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -323,7 +323,8 @@ func internalGuardFromEnv(adapterMode string) (func(http.Handler) http.Handler, 
 	secret := os.Getenv(auth.EnvServiceSecret)
 	if secret == "" {
 		if adapterMode == "real" {
-			return nil, fmt.Errorf("GOCELL_SERVICE_SECRET must be set in adapter mode \"real\" to protect /internal/v1/*")
+			return nil, errcode.New(errcode.ErrValidationFailed,
+				"GOCELL_SERVICE_SECRET must be set in adapter mode \"real\" to protect /internal/v1/*")
 		}
 		slog.Warn("controlplane guard disabled: GOCELL_SERVICE_SECRET is empty (dev mode only)")
 		return nil, nil

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -328,9 +328,15 @@ func internalGuardFromEnv(adapterMode string) (func(http.Handler) http.Handler, 
 		slog.Warn("controlplane guard disabled: GOCELL_SERVICE_SECRET is empty (dev mode only)")
 		return nil, nil
 	}
+	if err := rejectDemoKey(adapterMode, auth.EnvServiceSecret, []byte(secret)); err != nil {
+		return nil, err
+	}
 	prevSecret := os.Getenv(auth.EnvServiceSecretPrevious)
 	var prevBytes []byte
 	if prevSecret != "" {
+		if err := rejectDemoKey(adapterMode, auth.EnvServiceSecretPrevious, []byte(prevSecret)); err != nil {
+			return nil, err
+		}
 		prevBytes = []byte(prevSecret)
 	}
 	ring, err := auth.NewHMACKeyRing([]byte(secret), prevBytes)

--- a/cmd/core-bundle/main_test.go
+++ b/cmd/core-bundle/main_test.go
@@ -458,6 +458,11 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 			patch: envPatch{"GOCELL_SERVICE_SECRET", "service-secret-32-bytes-xxxxxx!!"},
 			want:  "GOCELL_SERVICE_SECRET",
 		},
+		{
+			name:  "service secret previous demo literal rejected",
+			patch: envPatch{"GOCELL_SERVICE_SECRET_PREVIOUS", "service-secret-32-bytes-xxxxxx!!"},
+			want:  "GOCELL_SERVICE_SECRET_PREVIOUS",
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/cmd/core-bundle/main_test.go
+++ b/cmd/core-bundle/main_test.go
@@ -453,6 +453,11 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 			patch: envPatch{"GOCELL_CONFIG_CURSOR_KEY", "core-bundle-cfg-cursor-key--32b!"},
 			want:  "GOCELL_CONFIG_CURSOR_KEY",
 		},
+		{
+			name:  "service secret demo literal rejected",
+			patch: envPatch{"GOCELL_SERVICE_SECRET", "service-secret-32-bytes-xxxxxx!!"},
+			want:  "GOCELL_SERVICE_SECRET",
+		},
 	}
 	for _, tc := range tests {
 		tc := tc


### PR DESCRIPTION
## Summary

- **P0 security fix**: `internalGuardFromEnv()` now calls `rejectDemoKey` on both `GOCELL_SERVICE_SECRET` and `GOCELL_SERVICE_SECRET_PREVIOUS`, closing the gap where the well-known demo value could be used to forge ServiceTokens in `adapterMode=real`
- Matches the existing pattern for HMAC key, master key, and cursor keys

backlog: L0 SERVICE-SECRET-REJECT-DEMO-01

## Test plan

- [x] 3 new unit tests: real-mode current/previous rejection + dev-mode allowance
- [x] 1 table entry in `TestRun_RealMode_DemoKey_FailsFast` for full `run()` path
- [x] `golangci-lint run` 0 issues
- [x] All `cmd/core-bundle` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)