### PR TITLE
refactor(pkg,kernel): extract shared contract types + hide yaml.v3 AST (L6+K1)

### DIFF
--- a/kernel/governance/locate_test.go
+++ b/kernel/governance/locate_test.go
@@ -6,15 +6,13 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
-// parseNode is a test helper that parses src into a yaml.Node (DocumentNode).
-func parseNode(t *testing.T, src string) *yaml.Node {
+// prepareNode is a test helper that stores a YAML source as a file node
+// on the ProjectMeta via the public PrepareFileNode method.
+func prepareNode(t *testing.T, pm *metadata.ProjectMeta, file, src string) {
 	t.Helper()
-	var n yaml.Node
-	require.NoError(t, yaml.Unmarshal([]byte(src), &n))
-	return &n
+	require.NoError(t, pm.PrepareFileNode(file, []byte(src)))
 }
 
 // TestValidator_Locate_KnownField: locate returns the line/column for an
@@ -28,7 +26,7 @@ func TestValidator_Locate_KnownField(t *testing.T) {
 	pm := &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{},
 	}
-	pm.SetFileNode("cells/access-core/cell.yaml", parseNode(t, src))
+	prepareNode(t, pm, "cells/access-core/cell.yaml", src)
 	v := NewValidator(pm, "")
 
 	line, col := v.locate("cells/access-core/cell.yaml", "id")
@@ -52,7 +50,7 @@ func TestValidator_Locate_Fallbacks(t *testing.T) {
 	assert.Zero(t, col)
 
 	// File present but field not found.
-	pm.SetFileNode("foo.yaml", parseNode(t, "id: x\n"))
+	prepareNode(t, pm, "foo.yaml", "id: x\n")
 	line, col = v.locate("foo.yaml", "nope")
 	assert.Zero(t, line)
 	assert.Zero(t, col)
@@ -79,7 +77,7 @@ func TestValidator_NewResult_AutoFillsLocation(t *testing.T) {
 	pm := &metadata.ProjectMeta{
 		Slices: map[string]*metadata.SliceMeta{},
 	}
-	pm.SetFileNode("cells/x/slices/s/slice.yaml", parseNode(t, src))
+	prepareNode(t, pm, "cells/x/slices/s/slice.yaml", src)
 	v := NewValidator(pm, "")
 
 	r := v.newResult("REF-02", SeverityError, IssueRefNotFound,
@@ -133,7 +131,7 @@ func TestDependencyChecker_NewResult_AutoFillsLocation(t *testing.T) {
 	pm := &metadata.ProjectMeta{
 		Slices: map[string]*metadata.SliceMeta{},
 	}
-	pm.SetFileNode("cells/x/slices/s/slice.yaml", parseNode(t, src))
+	prepareNode(t, pm, "cells/x/slices/s/slice.yaml", src)
 	dc := NewDependencyChecker(pm)
 
 	r := dc.newResult("DEP-01", SeverityError, IssueMismatch,

--- a/kernel/governance/locate_test.go
+++ b/kernel/governance/locate_test.go
@@ -27,10 +27,8 @@ func TestValidator_Locate_KnownField(t *testing.T) {
 
 	pm := &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{},
-		FileNodes: map[string]*yaml.Node{
-			"cells/access-core/cell.yaml": parseNode(t, src),
-		},
 	}
+	pm.SetFileNode("cells/access-core/cell.yaml", parseNode(t, src))
 	v := NewValidator(pm, "")
 
 	line, col := v.locate("cells/access-core/cell.yaml", "id")
@@ -42,25 +40,19 @@ func TestValidator_Locate_KnownField(t *testing.T) {
 	assert.Positive(t, col, "owner.team column")
 }
 
-// TestValidator_Locate_Fallbacks: empty file, empty field, missing FileNodes,
+// TestValidator_Locate_Fallbacks: empty file, empty field, missing file nodes,
 // missing file entry, and missing field all return (0, 0).
 func TestValidator_Locate_Fallbacks(t *testing.T) {
 	pm := &metadata.ProjectMeta{Cells: map[string]*metadata.CellMeta{}}
 	v := NewValidator(pm, "")
 
-	// FileNodes map entirely absent.
+	// No file nodes set at all.
 	line, col := v.locate("foo.yaml", "id")
 	assert.Zero(t, line)
 	assert.Zero(t, col)
 
-	// FileNodes map present but empty.
-	pm.FileNodes = map[string]*yaml.Node{}
-	line, col = v.locate("foo.yaml", "id")
-	assert.Zero(t, line)
-	assert.Zero(t, col)
-
 	// File present but field not found.
-	pm.FileNodes["foo.yaml"] = parseNode(t, "id: x\n")
+	pm.SetFileNode("foo.yaml", parseNode(t, "id: x\n"))
 	line, col = v.locate("foo.yaml", "nope")
 	assert.Zero(t, line)
 	assert.Zero(t, col)
@@ -86,10 +78,8 @@ func TestValidator_NewResult_AutoFillsLocation(t *testing.T) {
 
 	pm := &metadata.ProjectMeta{
 		Slices: map[string]*metadata.SliceMeta{},
-		FileNodes: map[string]*yaml.Node{
-			"cells/x/slices/s/slice.yaml": parseNode(t, src),
-		},
 	}
+	pm.SetFileNode("cells/x/slices/s/slice.yaml", parseNode(t, src))
 	v := NewValidator(pm, "")
 
 	r := v.newResult("REF-02", SeverityError, IssueRefNotFound,
@@ -142,10 +132,8 @@ func TestDependencyChecker_NewResult_AutoFillsLocation(t *testing.T) {
 
 	pm := &metadata.ProjectMeta{
 		Slices: map[string]*metadata.SliceMeta{},
-		FileNodes: map[string]*yaml.Node{
-			"cells/x/slices/s/slice.yaml": parseNode(t, src),
-		},
 	}
+	pm.SetFileNode("cells/x/slices/s/slice.yaml", parseNode(t, src))
 	dc := NewDependencyChecker(pm)
 
 	r := dc.newResult("DEP-01", SeverityError, IssueMismatch,
@@ -158,7 +146,7 @@ func TestDependencyChecker_NewResult_AutoFillsLocation(t *testing.T) {
 }
 
 // TestDependencyChecker_Locate_FallsBack verifies the nil-project / missing
-// FileNodes fallback shared with Validator.
+// file nodes fallback shared with Validator.
 func TestDependencyChecker_Locate_FallsBack(t *testing.T) {
 	dc := NewDependencyChecker(nil)
 	// Safe on a nil project (NewDependencyChecker stores it as-is but locate

--- a/kernel/governance/location_integration_test.go
+++ b/kernel/governance/location_integration_test.go
@@ -248,7 +248,7 @@ func TestLocation_DEP02_ScopeNotFile(t *testing.T) {
 }
 
 // TestLocation_NoNodes_NoCrash confirms that validators tolerate a
-// ProjectMeta without FileNodes (e.g. constructed manually in a test): the Line
+// ProjectMeta without file nodes (e.g. constructed manually in a test): the Line
 // and Column fields are simply zero.
 func TestLocation_NoNodes_NoCrash(t *testing.T) {
 	pm := &metadata.ProjectMeta{
@@ -266,8 +266,8 @@ func TestLocation_NoNodes_NoCrash(t *testing.T) {
 	for _, r := range results {
 		if r.Code == "REF-01" {
 			seenRef01 = true
-			assert.Zero(t, r.Line, "Line should be 0 without FileNodes")
-			assert.Zero(t, r.Column, "Column should be 0 without FileNodes")
+			assert.Zero(t, r.Line, "Line should be 0 without file nodes")
+			assert.Zero(t, r.Column, "Column should be 0 without file nodes")
 		}
 	}
 	assert.True(t, seenRef01, "REF-01 should be produced")

--- a/kernel/governance/locator.go
+++ b/kernel/governance/locator.go
@@ -16,20 +16,16 @@ type locator struct {
 
 // locate returns the 1-based (line, column) of `field` inside `file` using
 // the yaml.Node cache captured by the parser. Returns (0, 0) when any
-// precondition is missing (no FileNodes, no matching file, unresolvable path).
+// precondition is missing (no file nodes, no matching file, unresolvable path).
 // Rules should prefer newResult, which wraps this call.
 func (l *locator) locate(file, field string) (line, col int) {
 	if file == "" || field == "" {
 		return 0, 0
 	}
-	if l.project == nil || l.project.FileNodes == nil {
+	if l.project == nil {
 		return 0, 0
 	}
-	n, ok := l.project.FileNodes[file]
-	if !ok || n == nil {
-		return 0, 0
-	}
-	pos := metadata.Locate(n, field)
+	pos := l.project.Locate(file, field)
 	return pos.Line, pos.Column
 }
 

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -48,7 +48,7 @@ func (p *Parser) ParseFS(fsys fs.FS) (*ProjectMeta, error) {
 		Contracts:  make(map[string]*ContractMeta),
 		Journeys:   make(map[string]*JourneyMeta),
 		Assemblies: make(map[string]*AssemblyMeta),
-		FileNodes:  make(map[string]*yaml.Node),
+		fileNodes:  make(map[string]*yaml.Node),
 	}
 
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, walkErr error) error {
@@ -138,7 +138,7 @@ func (p *Parser) parseCell(fsys fs.FS, path string, pm *ProjectMeta) error {
 		return err
 	}
 	if node != nil {
-		pm.FileNodes[path] = node
+		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.ErrMetadataInvalid,
@@ -168,7 +168,7 @@ func (p *Parser) parseSlice(fsys fs.FS, path string, pm *ProjectMeta) error {
 		return err
 	}
 	if node != nil {
-		pm.FileNodes[path] = node
+		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.ErrMetadataInvalid,
@@ -218,7 +218,7 @@ func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
 		return err
 	}
 	if node != nil {
-		pm.FileNodes[path] = node
+		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.ErrMetadataInvalid,
@@ -244,7 +244,7 @@ func (p *Parser) parseJourney(fsys fs.FS, path string, pm *ProjectMeta) error {
 		return err
 	}
 	if node != nil {
-		pm.FileNodes[path] = node
+		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.ErrMetadataInvalid,
@@ -265,7 +265,7 @@ func (p *Parser) parseAssembly(fsys fs.FS, path string, pm *ProjectMeta) error {
 		return err
 	}
 	if node != nil {
-		pm.FileNodes[path] = node
+		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.ErrMetadataInvalid,
@@ -286,7 +286,7 @@ func (p *Parser) parseStatusBoard(fsys fs.FS, path string, pm *ProjectMeta) erro
 		return err
 	}
 	if node != nil {
-		pm.FileNodes[path] = node
+		pm.fileNodes[path] = node
 	}
 	pm.StatusBoard = entries
 	return nil
@@ -299,7 +299,7 @@ func (p *Parser) parseActors(fsys fs.FS, path string, pm *ProjectMeta) error {
 		return err
 	}
 	if node != nil {
-		pm.FileNodes[path] = node
+		pm.fileNodes[path] = node
 	}
 	pm.Actors = actors
 	return nil
@@ -308,7 +308,7 @@ func (p *Parser) parseActors(fsys fs.FS, path string, pm *ProjectMeta) error {
 // maxMetadataFileSize caps a single YAML file at 1 MiB. Real metadata files
 // are <50 KB; a 20× headroom guards against adversarial inputs (or the wrong
 // fixture accidentally dropped into cells/ or contracts/) blowing up memory
-// once the yaml.Node AST is retained on ProjectMeta.FileNodes for the life of a
+// once the yaml.Node AST is retained on ProjectMeta.fileNodes for the life of a
 // Validator.
 const maxMetadataFileSize = 1 << 20 // 1 MiB
 

--- a/kernel/metadata/parser_nodes_test.go
+++ b/kernel/metadata/parser_nodes_test.go
@@ -73,7 +73,7 @@ build:
 	p := NewParser(".")
 	pm, err := p.ParseFS(fs)
 	require.NoError(t, err)
-	require.NotNil(t, pm.FileNodes, "pm.FileNodes must be populated")
+	require.True(t, pm.HasFileNodes(), "pm.FileNodes must be populated")
 
 	wantFiles := []string{
 		"cells/x/cell.yaml",
@@ -85,7 +85,7 @@ build:
 		"journeys/status-board.yaml",
 	}
 	for _, path := range wantFiles {
-		n, ok := pm.FileNodes[path]
+		n, ok := pm.FileNode(path)
 		if !ok {
 			t.Errorf("missing Node for %s", path)
 			continue
@@ -117,7 +117,7 @@ func TestParseFS_NodesEnableLocate(t *testing.T) {
 	pm, err := p.ParseFS(fs)
 	require.NoError(t, err)
 
-	root := pm.FileNodes["cells/x/cell.yaml"]
+	root, _ := pm.FileNode("cells/x/cell.yaml")
 	require.NotNil(t, root)
 
 	// Top-level field line numbers.
@@ -194,8 +194,8 @@ func TestParseFS_NodesAbsentWhenEmpty(t *testing.T) {
 	pm, err := p.ParseFS(fs)
 	require.NoError(t, err)
 
-	_, haveActors := pm.FileNodes["actors.yaml"]
-	_, haveStatus := pm.FileNodes["journeys/status-board.yaml"]
+	_, haveActors := pm.FileNode("actors.yaml")
+	_, haveStatus := pm.FileNode("journeys/status-board.yaml")
 	assert.False(t, haveActors, "empty actors.yaml should not populate FileNodes")
 	assert.False(t, haveStatus, "empty status-board.yaml should not populate FileNodes")
 }

--- a/kernel/metadata/parser_nodes_test.go
+++ b/kernel/metadata/parser_nodes_test.go
@@ -85,7 +85,7 @@ build:
 		"journeys/status-board.yaml",
 	}
 	for _, path := range wantFiles {
-		n, ok := pm.FileNode(path)
+		n, ok := pm.fileNode(path)
 		if !ok {
 			t.Errorf("missing Node for %s", path)
 			continue
@@ -117,7 +117,7 @@ func TestParseFS_NodesEnableLocate(t *testing.T) {
 	pm, err := p.ParseFS(fs)
 	require.NoError(t, err)
 
-	root, _ := pm.FileNode("cells/x/cell.yaml")
+	root, _ := pm.fileNode("cells/x/cell.yaml")
 	require.NotNil(t, root)
 
 	// Top-level field line numbers.
@@ -194,8 +194,8 @@ func TestParseFS_NodesAbsentWhenEmpty(t *testing.T) {
 	pm, err := p.ParseFS(fs)
 	require.NoError(t, err)
 
-	_, haveActors := pm.FileNode("actors.yaml")
-	_, haveStatus := pm.FileNode("journeys/status-board.yaml")
+	_, haveActors := pm.fileNode("actors.yaml")
+	_, haveStatus := pm.fileNode("journeys/status-board.yaml")
 	assert.False(t, haveActors, "empty actors.yaml should not populate FileNodes")
 	assert.False(t, haveStatus, "empty status-board.yaml should not populate FileNodes")
 }

--- a/kernel/metadata/parser_size_test.go
+++ b/kernel/metadata/parser_size_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestParseFS_RejectsOversizeFile guards the 1 MiB ceiling on metadata YAML
-// files. ProjectMeta.FileNodes retains the full AST for the life of the
+// files. ProjectMeta retains the full AST (via fileNodes) for the life of the
 // Validator, so an oversized file would inflate live memory 2–3×.
 func TestParseFS_RejectsOversizeFile(t *testing.T) {
 	// Build a ~1.1 MiB cell.yaml by padding the description field.

--- a/kernel/metadata/project_locate_test.go
+++ b/kernel/metadata/project_locate_test.go
@@ -67,6 +67,24 @@ func TestProjectMeta_HasFileNodes(t *testing.T) {
 	assert.True(t, pm.HasFileNodes())
 }
 
+func TestProjectMeta_Locate_NilReceiver(t *testing.T) {
+	var pm *ProjectMeta
+	pos := pm.Locate("any.yaml", "id")
+	assert.False(t, pos.Known())
+}
+
+func TestProjectMeta_FileNode_NilReceiver(t *testing.T) {
+	var pm *ProjectMeta
+	n, ok := pm.FileNode("any.yaml")
+	assert.Nil(t, n)
+	assert.False(t, ok)
+}
+
+func TestProjectMeta_HasFileNodes_NilReceiver(t *testing.T) {
+	var pm *ProjectMeta
+	assert.False(t, pm.HasFileNodes())
+}
+
 // parseTestNode decodes a YAML string into a *yaml.Node for testing.
 func parseTestNode(t *testing.T, src string) *yaml.Node {
 	t.Helper()

--- a/kernel/metadata/project_locate_test.go
+++ b/kernel/metadata/project_locate_test.go
@@ -11,7 +11,7 @@ import (
 func TestProjectMeta_Locate_Known(t *testing.T) {
 	pm := &ProjectMeta{}
 	node := parseTestNode(t, "id: test-cell\nowner:\n  team: platform\n")
-	pm.SetFileNode("cells/test/cell.yaml", node)
+	pm.setFileNode("cells/test/cell.yaml", node)
 
 	pos := pm.Locate("cells/test/cell.yaml", "id")
 	assert.True(t, pos.Known())
@@ -27,7 +27,7 @@ func TestProjectMeta_Locate_NilFileNodes(t *testing.T) {
 func TestProjectMeta_Locate_MissingFile(t *testing.T) {
 	pm := &ProjectMeta{}
 	node := parseTestNode(t, "id: x\n")
-	pm.SetFileNode("a.yaml", node)
+	pm.setFileNode("a.yaml", node)
 
 	pos := pm.Locate("b.yaml", "id")
 	assert.False(t, pos.Known())
@@ -36,7 +36,7 @@ func TestProjectMeta_Locate_MissingFile(t *testing.T) {
 func TestProjectMeta_Locate_EmptyArgs(t *testing.T) {
 	pm := &ProjectMeta{}
 	node := parseTestNode(t, "id: x\n")
-	pm.SetFileNode("a.yaml", node)
+	pm.setFileNode("a.yaml", node)
 
 	assert.False(t, pm.Locate("", "id").Known())
 	assert.False(t, pm.Locate("a.yaml", "").Known())
@@ -45,16 +45,16 @@ func TestProjectMeta_Locate_EmptyArgs(t *testing.T) {
 func TestProjectMeta_FileNode_Present(t *testing.T) {
 	pm := &ProjectMeta{}
 	node := parseTestNode(t, "id: x\n")
-	pm.SetFileNode("a.yaml", node)
+	pm.setFileNode("a.yaml", node)
 
-	got, ok := pm.FileNode("a.yaml")
+	got, ok := pm.fileNode("a.yaml")
 	require.True(t, ok)
 	assert.NotNil(t, got)
 }
 
 func TestProjectMeta_FileNode_Absent(t *testing.T) {
 	pm := &ProjectMeta{}
-	got, ok := pm.FileNode("missing.yaml")
+	got, ok := pm.fileNode("missing.yaml")
 	assert.False(t, ok)
 	assert.Nil(t, got)
 }
@@ -63,7 +63,7 @@ func TestProjectMeta_HasFileNodes(t *testing.T) {
 	pm := &ProjectMeta{}
 	assert.False(t, pm.HasFileNodes())
 
-	pm.SetFileNode("a.yaml", parseTestNode(t, "id: x\n"))
+	pm.setFileNode("a.yaml", parseTestNode(t, "id: x\n"))
 	assert.True(t, pm.HasFileNodes())
 }
 
@@ -75,7 +75,7 @@ func TestProjectMeta_Locate_NilReceiver(t *testing.T) {
 
 func TestProjectMeta_FileNode_NilReceiver(t *testing.T) {
 	var pm *ProjectMeta
-	n, ok := pm.FileNode("any.yaml")
+	n, ok := pm.fileNode("any.yaml")
 	assert.Nil(t, n)
 	assert.False(t, ok)
 }
@@ -83,6 +83,22 @@ func TestProjectMeta_FileNode_NilReceiver(t *testing.T) {
 func TestProjectMeta_HasFileNodes_NilReceiver(t *testing.T) {
 	var pm *ProjectMeta
 	assert.False(t, pm.HasFileNodes())
+}
+
+func TestProjectMeta_PrepareFileNode(t *testing.T) {
+	pm := &ProjectMeta{}
+	err := pm.PrepareFileNode("cells/test/cell.yaml", []byte("id: test-cell\nowner:\n  team: platform\n"))
+	require.NoError(t, err)
+
+	pos := pm.Locate("cells/test/cell.yaml", "id")
+	assert.True(t, pos.Known())
+	assert.Equal(t, 1, pos.Line)
+}
+
+func TestProjectMeta_PrepareFileNode_InvalidYAML(t *testing.T) {
+	pm := &ProjectMeta{}
+	err := pm.PrepareFileNode("bad.yaml", []byte(":\n  :\n    : ["))
+	assert.Error(t, err)
 }
 
 // parseTestNode decodes a YAML string into a *yaml.Node for testing.

--- a/kernel/metadata/project_locate_test.go
+++ b/kernel/metadata/project_locate_test.go
@@ -1,0 +1,76 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProjectMeta_Locate_Known(t *testing.T) {
+	pm := &ProjectMeta{}
+	node := parseTestNode(t, "id: test-cell\nowner:\n  team: platform\n")
+	pm.SetFileNode("cells/test/cell.yaml", node)
+
+	pos := pm.Locate("cells/test/cell.yaml", "id")
+	assert.True(t, pos.Known())
+	assert.Equal(t, 1, pos.Line)
+}
+
+func TestProjectMeta_Locate_NilFileNodes(t *testing.T) {
+	pm := &ProjectMeta{}
+	pos := pm.Locate("any.yaml", "id")
+	assert.False(t, pos.Known())
+}
+
+func TestProjectMeta_Locate_MissingFile(t *testing.T) {
+	pm := &ProjectMeta{}
+	node := parseTestNode(t, "id: x\n")
+	pm.SetFileNode("a.yaml", node)
+
+	pos := pm.Locate("b.yaml", "id")
+	assert.False(t, pos.Known())
+}
+
+func TestProjectMeta_Locate_EmptyArgs(t *testing.T) {
+	pm := &ProjectMeta{}
+	node := parseTestNode(t, "id: x\n")
+	pm.SetFileNode("a.yaml", node)
+
+	assert.False(t, pm.Locate("", "id").Known())
+	assert.False(t, pm.Locate("a.yaml", "").Known())
+}
+
+func TestProjectMeta_FileNode_Present(t *testing.T) {
+	pm := &ProjectMeta{}
+	node := parseTestNode(t, "id: x\n")
+	pm.SetFileNode("a.yaml", node)
+
+	got, ok := pm.FileNode("a.yaml")
+	require.True(t, ok)
+	assert.NotNil(t, got)
+}
+
+func TestProjectMeta_FileNode_Absent(t *testing.T) {
+	pm := &ProjectMeta{}
+	got, ok := pm.FileNode("missing.yaml")
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestProjectMeta_HasFileNodes(t *testing.T) {
+	pm := &ProjectMeta{}
+	assert.False(t, pm.HasFileNodes())
+
+	pm.SetFileNode("a.yaml", parseTestNode(t, "id: x\n"))
+	assert.True(t, pm.HasFileNodes())
+}
+
+// parseTestNode decodes a YAML string into a *yaml.Node for testing.
+func parseTestNode(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &n))
+	return &n
+}

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -241,7 +241,7 @@ func (pm *ProjectMeta) SetFileNode(file string, node *yaml.Node) {
 // FileNode returns the parsed YAML document node for the given file path.
 // Returns (nil, false) if the file was not parsed or file nodes are not available.
 func (pm *ProjectMeta) FileNode(file string) (*yaml.Node, bool) {
-	if pm.fileNodes == nil {
+	if pm == nil || pm.fileNodes == nil {
 		return nil, false
 	}
 	n, ok := pm.fileNodes[file]
@@ -250,5 +250,8 @@ func (pm *ProjectMeta) FileNode(file string) (*yaml.Node, bool) {
 
 // HasFileNodes reports whether any file nodes have been stored.
 func (pm *ProjectMeta) HasFileNodes() bool {
+	if pm == nil {
+		return false
+	}
 	return len(pm.fileNodes) > 0
 }

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -2,7 +2,10 @@
 // and provides a file-system-based parser to load them into a unified ProjectMeta.
 package metadata
 
-import "gopkg.in/yaml.v3"
+import (
+	"github.com/ghbvf/gocell/pkg/contracts"
+	"gopkg.in/yaml.v3"
+)
 
 // CellMeta maps to cells/{id}/cell.yaml.
 //
@@ -133,35 +136,17 @@ type EndpointsMeta struct {
 	Readers  []string `yaml:"readers,omitempty"`
 }
 
-// HTTPResponseMeta describes an expected error response for a specific HTTP
-// status code. It references a JSON Schema file (relative to the contract
-// directory) that describes the error response body.
-type HTTPResponseMeta struct {
-	Description string `yaml:"description"`
-	SchemaRef   string `yaml:"schemaRef"`
-}
+// HTTPResponseMeta is a type alias for contracts.HTTPResponse.
+// It describes an expected error response for a specific HTTP status code.
+type HTTPResponseMeta = contracts.HTTPResponse
 
-// HTTPTransportMeta holds transport-level details for migrated HTTP contracts.
-// It is optional so legacy HTTP contracts can remain schema-only until migrated.
-type HTTPTransportMeta struct {
-	Method        string                   `yaml:"method"`
-	Path          string                   `yaml:"path"`
-	SuccessStatus int                      `yaml:"successStatus"`
-	NoContent     bool                     `yaml:"noContent"`
-	Responses     map[int]HTTPResponseMeta `yaml:"responses,omitempty"`
-}
+// HTTPTransportMeta is a type alias for contracts.HTTPTransport.
+// It holds transport-level details for migrated HTTP contracts.
+type HTTPTransportMeta = contracts.HTTPTransport
 
-// SchemaRefsMeta holds JSON Schema file references relative to the contract directory.
-// Known keys are request, response, payload, headers; additional string-valued keys
-// are captured in Extra to stay compatible with contract.schema.json's
-// additionalProperties: {"type":"string"}.
-type SchemaRefsMeta struct {
-	Request  string            `yaml:"request,omitempty"`
-	Response string            `yaml:"response,omitempty"`
-	Payload  string            `yaml:"payload,omitempty"`
-	Headers  string            `yaml:"headers,omitempty"`
-	Extra    map[string]string `yaml:",inline"`
-}
+// SchemaRefsMeta is a type alias for contracts.SchemaRefs.
+// It holds JSON Schema file references relative to the contract directory.
+type SchemaRefsMeta = contracts.SchemaRefs
 
 // JourneyMeta maps to journeys/J-*.yaml.
 type JourneyMeta struct {
@@ -219,9 +204,51 @@ type ProjectMeta struct {
 	Assemblies  map[string]*AssemblyMeta // keyed by assembly ID
 	StatusBoard []StatusBoardEntry
 	Actors      []ActorMeta
-	// FileNodes maps each parsed YAML file path (as walked during ParseFS) to its
+	// fileNodes maps each parsed YAML file path (as walked during ParseFS) to its
 	// root DocumentNode, enabling validator rules to report precise
 	// file:line:column locations. nil when the project was constructed
 	// manually (e.g. in tests); callers must tolerate that case.
-	FileNodes map[string]*yaml.Node
+	// Access via Locate, FileNode, SetFileNode, or HasFileNodes.
+	fileNodes map[string]*yaml.Node
+}
+
+// Locate returns the Position of the YAML value at the given dotted field path
+// inside file. Returns a zero Position when any precondition is missing (nil
+// receiver, no file nodes, file not found, path unresolvable).
+func (pm *ProjectMeta) Locate(file, path string) Position {
+	if pm == nil || file == "" || path == "" {
+		return Position{}
+	}
+	if pm.fileNodes == nil {
+		return Position{}
+	}
+	n, ok := pm.fileNodes[file]
+	if !ok || n == nil {
+		return Position{}
+	}
+	return Locate(n, path)
+}
+
+// SetFileNode stores a parsed YAML document node for the given file path.
+// It initializes the internal map on first use.
+func (pm *ProjectMeta) SetFileNode(file string, node *yaml.Node) {
+	if pm.fileNodes == nil {
+		pm.fileNodes = make(map[string]*yaml.Node)
+	}
+	pm.fileNodes[file] = node
+}
+
+// FileNode returns the parsed YAML document node for the given file path.
+// Returns (nil, false) if the file was not parsed or file nodes are not available.
+func (pm *ProjectMeta) FileNode(file string) (*yaml.Node, bool) {
+	if pm.fileNodes == nil {
+		return nil, false
+	}
+	n, ok := pm.fileNodes[file]
+	return n, ok
+}
+
+// HasFileNodes reports whether any file nodes have been stored.
+func (pm *ProjectMeta) HasFileNodes() bool {
+	return len(pm.fileNodes) > 0
 }

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -3,6 +3,8 @@
 package metadata
 
 import (
+	"fmt"
+
 	"github.com/ghbvf/gocell/pkg/contracts"
 	"gopkg.in/yaml.v3"
 )
@@ -208,7 +210,7 @@ type ProjectMeta struct {
 	// root DocumentNode, enabling validator rules to report precise
 	// file:line:column locations. nil when the project was constructed
 	// manually (e.g. in tests); callers must tolerate that case.
-	// Access via Locate, FileNode, SetFileNode, or HasFileNodes.
+	// Access via Locate, PrepareFileNode, HasFileNodes.
 	fileNodes map[string]*yaml.Node
 }
 
@@ -229,18 +231,31 @@ func (pm *ProjectMeta) Locate(file, path string) Position {
 	return Locate(n, path)
 }
 
-// SetFileNode stores a parsed YAML document node for the given file path.
-// It initializes the internal map on first use.
-func (pm *ProjectMeta) SetFileNode(file string, node *yaml.Node) {
+// setFileNode stores a parsed YAML document node for the given file path.
+// It initializes the internal map on first use. Same-package only (parser).
+func (pm *ProjectMeta) setFileNode(file string, node *yaml.Node) {
 	if pm.fileNodes == nil {
 		pm.fileNodes = make(map[string]*yaml.Node)
 	}
 	pm.fileNodes[file] = node
 }
 
-// FileNode returns the parsed YAML document node for the given file path.
+// PrepareFileNode parses yamlSource into a document node and stores it for
+// the given file path. This is the public entry point for test setup —
+// callers never need to import yaml.v3 directly.
+func (pm *ProjectMeta) PrepareFileNode(file string, yamlSource []byte) error {
+	var root yaml.Node
+	if err := yaml.Unmarshal(yamlSource, &root); err != nil {
+		return fmt.Errorf("metadata: PrepareFileNode %s: %w", file, err)
+	}
+	pm.setFileNode(file, &root)
+	return nil
+}
+
+// fileNode returns the parsed YAML document node for the given file path.
 // Returns (nil, false) if the file was not parsed or file nodes are not available.
-func (pm *ProjectMeta) FileNode(file string) (*yaml.Node, bool) {
+// Same-package only; external callers use Locate.
+func (pm *ProjectMeta) fileNode(file string) (*yaml.Node, bool) {
 	if pm == nil || pm.fileNodes == nil {
 		return nil, false
 	}

--- a/pkg/contracts/schema_types.go
+++ b/pkg/contracts/schema_types.go
@@ -30,9 +30,13 @@ type HTTPResponse struct {
 // keys are captured in Extra to stay compatible with contract.schema.json's
 // additionalProperties: {"type":"string"}.
 type SchemaRefs struct {
-	Request  string            `yaml:"request,omitempty"  json:"request,omitempty"`
-	Response string            `yaml:"response,omitempty" json:"response,omitempty"`
-	Payload  string            `yaml:"payload,omitempty"  json:"payload,omitempty"`
-	Headers  string            `yaml:"headers,omitempty"  json:"headers,omitempty"`
-	Extra    map[string]string `yaml:",inline"            json:"-"`
+	Request  string `yaml:"request,omitempty"  json:"request,omitempty"`
+	Response string `yaml:"response,omitempty" json:"response,omitempty"`
+	Payload  string `yaml:"payload,omitempty"  json:"payload,omitempty"`
+	Headers  string `yaml:"headers,omitempty"  json:"headers,omitempty"`
+	// Extra captures additional string-valued schema ref keys beyond the four
+	// well-known ones, via yaml:",inline". It is excluded from JSON serialization
+	// (json:"-") because Go's encoding/json does not support inline maps; callers
+	// that need JSON output should implement custom MarshalJSON if needed.
+	Extra map[string]string `yaml:",inline"            json:"-"`
 }

--- a/pkg/contracts/schema_types.go
+++ b/pkg/contracts/schema_types.go
@@ -1,0 +1,38 @@
+// Package contracts defines shared schema and transport types used by both
+// kernel/metadata (the YAML metadata model) and pkg/contracttest (the test
+// validation helpers). Extracting these types into pkg/ avoids model
+// duplication while respecting the layering rule: pkg/ has no kernel/ dependency.
+//
+// ref: k8s.io/apimachinery — shared types in a standalone base package,
+// single dependency direction from higher layers.
+package contracts
+
+// HTTPTransport holds transport-level details for HTTP contracts.
+// It is optional so legacy HTTP contracts can remain schema-only until migrated.
+type HTTPTransport struct {
+	Method        string               `yaml:"method"        json:"method"`
+	Path          string               `yaml:"path"          json:"path"`
+	SuccessStatus int                  `yaml:"successStatus" json:"successStatus"`
+	NoContent     bool                 `yaml:"noContent"     json:"noContent"`
+	Responses     map[int]HTTPResponse `yaml:"responses,omitempty" json:"responses,omitempty"`
+}
+
+// HTTPResponse describes a declared error response for a specific HTTP status code.
+// It references a JSON Schema file (relative to the contract directory) that
+// describes the error response body.
+type HTTPResponse struct {
+	Description string `yaml:"description" json:"description"`
+	SchemaRef   string `yaml:"schemaRef"   json:"schemaRef"`
+}
+
+// SchemaRefs holds JSON Schema file references relative to the contract directory.
+// Known keys are request, response, payload, headers; additional string-valued
+// keys are captured in Extra to stay compatible with contract.schema.json's
+// additionalProperties: {"type":"string"}.
+type SchemaRefs struct {
+	Request  string            `yaml:"request,omitempty"  json:"request,omitempty"`
+	Response string            `yaml:"response,omitempty" json:"response,omitempty"`
+	Payload  string            `yaml:"payload,omitempty"  json:"payload,omitempty"`
+	Headers  string            `yaml:"headers,omitempty"  json:"headers,omitempty"`
+	Extra    map[string]string `yaml:",inline"            json:"-"`
+}

--- a/pkg/contracts/schema_types_test.go
+++ b/pkg/contracts/schema_types_test.go
@@ -1,0 +1,108 @@
+package contracts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// roundTrip marshals v to YAML, unmarshals into a new T, and returns both.
+func roundTrip[T any](t *testing.T, v T) ([]byte, T) {
+	t.Helper()
+	data, err := yaml.Marshal(v)
+	require.NoError(t, err, "marshal should succeed")
+
+	var got T
+	err = yaml.Unmarshal(data, &got)
+	require.NoError(t, err, "unmarshal should succeed")
+	return data, got
+}
+
+func TestHTTPTransportYAMLRoundTrip(t *testing.T) {
+	orig := HTTPTransport{
+		Method:        "POST",
+		Path:          "/api/v1/test",
+		SuccessStatus: 200,
+		NoContent:     false,
+		Responses: map[int]HTTPResponse{
+			401: {Description: "Unauthorized", SchemaRef: "error.json"},
+			403: {Description: "Forbidden", SchemaRef: "error.json"},
+		},
+	}
+	data, got := roundTrip(t, orig)
+	assert.Equal(t, orig, got)
+	assert.Contains(t, string(data), "method: POST")
+	assert.Contains(t, string(data), "path: /api/v1/test")
+	assert.Contains(t, string(data), "successStatus: 200")
+}
+
+func TestHTTPTransportYAMLRoundTrip_NoContent(t *testing.T) {
+	orig := HTTPTransport{
+		Method:        "DELETE",
+		Path:          "/api/v1/users/{userId}",
+		SuccessStatus: 204,
+		NoContent:     true,
+	}
+	data, got := roundTrip(t, orig)
+	assert.Equal(t, orig, got)
+	assert.NotContains(t, string(data), "responses")
+}
+
+func TestHTTPResponseYAMLRoundTrip(t *testing.T) {
+	orig := HTTPResponse{
+		Description: "Not Found",
+		SchemaRef:   "error.json",
+	}
+	_, got := roundTrip(t, orig)
+	assert.Equal(t, orig, got)
+}
+
+func TestSchemaRefsYAMLRoundTrip(t *testing.T) {
+	orig := SchemaRefs{
+		Request:  "request.schema.json",
+		Response: "response.schema.json",
+		Payload:  "payload.schema.json",
+		Headers:  "headers.schema.json",
+		Extra:    map[string]string{"custom": "custom.schema.json"},
+	}
+	data, got := roundTrip(t, orig)
+	assert.Equal(t, orig, got)
+	assert.Contains(t, string(data), "custom: custom.schema.json")
+}
+
+func TestSchemaRefsInlinePrecedence(t *testing.T) {
+	raw := `request: req.json
+response: res.json
+custom: extra.json
+`
+	var sr SchemaRefs
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &sr))
+
+	assert.Equal(t, "req.json", sr.Request)
+	assert.Equal(t, "res.json", sr.Response)
+	assert.Empty(t, sr.Payload)
+
+	assert.Equal(t, map[string]string{"custom": "extra.json"}, sr.Extra)
+
+	_, hasRequest := sr.Extra["request"]
+	assert.False(t, hasRequest, "named field 'request' must not leak into Extra")
+}
+
+func TestSchemaRefsExtraRoundTrip(t *testing.T) {
+	orig := SchemaRefs{
+		Request: "req.json",
+		Extra:   map[string]string{"custom": "extra.json"},
+	}
+	data, got := roundTrip(t, orig)
+	assert.Equal(t, "req.json", got.Request)
+	assert.Equal(t, "extra.json", got.Extra["custom"])
+	assert.Contains(t, string(data), "custom: extra.json")
+}
+
+func TestSchemaRefsEmpty(t *testing.T) {
+	var sr SchemaRefs
+	data, _ := roundTrip(t, sr)
+	assert.Equal(t, "{}\n", string(data))
+}

--- a/pkg/contracts/schema_types_test.go
+++ b/pkg/contracts/schema_types_test.go
@@ -103,6 +103,6 @@ func TestSchemaRefsExtraRoundTrip(t *testing.T) {
 
 func TestSchemaRefsEmpty(t *testing.T) {
 	var sr SchemaRefs
-	data, _ := roundTrip(t, sr)
-	assert.Equal(t, "{}\n", string(data))
+	_, got := roundTrip(t, sr)
+	assert.Equal(t, sr, got, "empty SchemaRefs round-trip should preserve zero value")
 }

--- a/pkg/contracttest/contracttest.go
+++ b/pkg/contracttest/contracttest.go
@@ -231,7 +231,7 @@ func compileSchemaFile(t testing.TB, dir, filename string) *jsonschema.Schema {
 	}
 
 	compiler := jsonschema.NewCompiler()
-	url := "file:///" + filepath.Base(filename)
+	url := "file:///" + filepath.Clean(fullPath)
 	if err := compiler.AddResource(url, doc); err != nil {
 		t.Fatalf("contracttest: add schema resource %q: %v", fullPath, err)
 	}
@@ -351,7 +351,7 @@ func compileSchemaFileAbsolute(t testing.TB, dir, filename string) *jsonschema.S
 	}
 
 	compiler := jsonschema.NewCompiler()
-	url := "file:///" + filepath.Base(filename)
+	url := "file:///" + filepath.Clean(fullPath)
 	if err := compiler.AddResource(url, doc); err != nil {
 		t.Fatalf("contracttest: add schema resource %q: %v", fullPath, err)
 	}

--- a/pkg/contracttest/contracttest.go
+++ b/pkg/contracttest/contracttest.go
@@ -44,6 +44,7 @@ type Contract struct {
 	responseSchema *jsonschema.Schema
 	payloadSchema  *jsonschema.Schema
 	headersSchema  *jsonschema.Schema
+	extraSchemas   map[string]*jsonschema.Schema // keyed by extra ref name
 }
 
 // HTTPTransport holds optional transport metadata for migrated HTTP contracts.
@@ -113,6 +114,11 @@ func Load(t testing.TB, contractDir string) *Contract {
 	c.payloadSchema = compileSchemaFile(t, contractDir, cy.SchemaRefs.Payload)
 	c.headersSchema = compileSchemaFile(t, contractDir, cy.SchemaRefs.Headers)
 
+	c.extraSchemas = make(map[string]*jsonschema.Schema)
+	for key, filename := range cy.SchemaRefs.Extra {
+		c.extraSchemas[key] = compileSchemaFile(t, contractDir, filename)
+	}
+
 	return c
 }
 
@@ -149,6 +155,32 @@ func (c *Contract) ValidatePayload(t testing.TB, jsonData []byte) {
 func (c *Contract) ValidateHeaders(t testing.TB, jsonData []byte) {
 	t.Helper()
 	validateJSON(t, c.headersSchema, jsonData, "headers")
+}
+
+// ValidateSchemaRef validates jsonData against the schema referenced by the
+// given key name. This covers both well-known refs (request, response, payload,
+// headers) and extra refs declared in schemaRefs. No-op if the key is not found.
+func (c *Contract) ValidateSchemaRef(t testing.TB, key string, jsonData []byte) {
+	t.Helper()
+	switch key {
+	case "request":
+		c.ValidateRequest(t, jsonData)
+		return
+	case "response":
+		c.ValidateResponse(t, jsonData)
+		return
+	case "payload":
+		c.ValidatePayload(t, jsonData)
+		return
+	case "headers":
+		c.ValidateHeaders(t, jsonData)
+		return
+	}
+	schema, ok := c.extraSchemas[key]
+	if !ok {
+		return // no-op: ref not declared
+	}
+	validateJSON(t, schema, jsonData, key)
 }
 
 // ValidateHTTPResponseRecorder validates an HTTP provider response against the

--- a/pkg/contracttest/contracttest.go
+++ b/pkg/contracttest/contracttest.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ghbvf/gocell/pkg/contracts"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"gopkg.in/yaml.v3"
 )
@@ -46,53 +47,26 @@ type Contract struct {
 }
 
 // HTTPTransport holds optional transport metadata for migrated HTTP contracts.
-type HTTPTransport struct {
-	Method        string
-	Path          string
-	SuccessStatus int
-	NoContent     bool
-	Responses     map[int]HTTPResponseEntry
-}
+// It is an alias of contracts.HTTPTransport to preserve the public API.
+type HTTPTransport = contracts.HTTPTransport
 
 // HTTPResponseEntry describes a declared error response for a specific HTTP status code.
-type HTTPResponseEntry struct {
-	Description string
-	SchemaRef   string
-}
+// It is an alias of contracts.HTTPResponse to preserve the public API.
+type HTTPResponseEntry = contracts.HTTPResponse
 
 // contractYAML is a local struct for parsing contract.yaml without
 // importing kernel/metadata (avoids coupling).
 type contractYAML struct {
-	ID               string         `yaml:"id"`
-	Kind             string         `yaml:"kind"`
-	OwnerCell        string         `yaml:"ownerCell"`
-	ConsistencyLevel string         `yaml:"consistencyLevel"`
-	Endpoints        endpointsYAML  `yaml:"endpoints"`
-	SchemaRefs       schemaRefsYAML `yaml:"schemaRefs"`
+	ID               string               `yaml:"id"`
+	Kind             string               `yaml:"kind"`
+	OwnerCell        string               `yaml:"ownerCell"`
+	ConsistencyLevel string               `yaml:"consistencyLevel"`
+	Endpoints        endpointsYAML        `yaml:"endpoints"`
+	SchemaRefs       contracts.SchemaRefs `yaml:"schemaRefs"`
 }
 
 type endpointsYAML struct {
-	HTTP *httpTransportYAML `yaml:"http,omitempty"`
-}
-
-type httpTransportYAML struct {
-	Method        string                        `yaml:"method"`
-	Path          string                        `yaml:"path"`
-	SuccessStatus int                           `yaml:"successStatus"`
-	NoContent     bool                          `yaml:"noContent"`
-	Responses     map[int]httpResponseEntryYAML `yaml:"responses,omitempty"`
-}
-
-type httpResponseEntryYAML struct {
-	Description string `yaml:"description"`
-	SchemaRef   string `yaml:"schemaRef"`
-}
-
-type schemaRefsYAML struct {
-	Request  string `yaml:"request,omitempty"`
-	Response string `yaml:"response,omitempty"`
-	Payload  string `yaml:"payload,omitempty"`
-	Headers  string `yaml:"headers,omitempty"`
+	HTTP *contracts.HTTPTransport `yaml:"http,omitempty"`
 }
 
 // ContractsRoot returns the absolute path to the contracts/ directory,
@@ -330,23 +304,8 @@ func formatValidationErrorDetail(ve *jsonschema.ValidationError, indent string) 
 	return sb.String()
 }
 
-func newHTTPTransport(meta *httpTransportYAML) *HTTPTransport {
-	if meta == nil {
-		return nil
-	}
-	t := &HTTPTransport{
-		Method:        meta.Method,
-		Path:          meta.Path,
-		SuccessStatus: meta.SuccessStatus,
-		NoContent:     meta.NoContent,
-	}
-	if len(meta.Responses) > 0 {
-		t.Responses = make(map[int]HTTPResponseEntry, len(meta.Responses))
-		for status, entry := range meta.Responses {
-			t.Responses[status] = HTTPResponseEntry(entry)
-		}
-	}
-	return t
+func newHTTPTransport(meta *contracts.HTTPTransport) *HTTPTransport {
+	return meta
 }
 
 // ValidateErrorResponse validates body against the JSON Schema declared for

--- a/pkg/contracttest/contracttest_test.go
+++ b/pkg/contracttest/contracttest_test.go
@@ -272,7 +272,6 @@ func TestContractsRoot(t *testing.T) {
 type mockTB struct {
 	testing.TB
 	failed bool
-	logs   []string
 }
 
 func (m *mockTB) Helper() {}

--- a/pkg/contracttest/contracttest_test.go
+++ b/pkg/contracttest/contracttest_test.go
@@ -1,9 +1,11 @@
 package contracttest
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -272,19 +274,31 @@ func TestContractsRoot(t *testing.T) {
 type mockTB struct {
 	testing.TB
 	failed bool
+	msgs   []string
 }
 
 func (m *mockTB) Helper() {}
 
 func (m *mockTB) Errorf(format string, args ...any) {
 	m.failed = true
+	m.msgs = append(m.msgs, fmt.Sprintf(format, args...))
 }
 
 func (m *mockTB) Fatalf(format string, args ...any) {
 	m.failed = true
+	m.msgs = append(m.msgs, fmt.Sprintf(format, args...))
 	// In a real test this would stop execution; here we just record.
 	// Tests using mockTB for Fatal should check after a single call.
 	panic("mockTB.Fatalf called")
+}
+
+func (m *mockTB) containsMsg(substr string) bool {
+	for _, msg := range m.msgs {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *mockTB) Log(args ...any)                 {}

--- a/pkg/contracttest/error_response_test.go
+++ b/pkg/contracttest/error_response_test.go
@@ -55,6 +55,14 @@ func TestValidateErrorResponse(t *testing.T) {
 			wantFail:   true,
 			wantMsg:    "no endpoints.http",
 		},
+		{
+			name:       "status with empty schemaRef",
+			contractID: "http.test.errresp.v1",
+			status:     429,
+			body:       []byte(`{}`),
+			wantFail:   true,
+			wantMsg:    "empty schemaRef",
+		},
 	}
 
 	for _, tt := range tests {
@@ -67,6 +75,9 @@ func TestValidateErrorResponse(t *testing.T) {
 			}
 			if !tt.wantFail && mockT.failed {
 				t.Errorf("expected ValidateErrorResponse to pass but it failed")
+			}
+			if tt.wantMsg != "" && !mockT.containsMsg(tt.wantMsg) {
+				t.Errorf("expected error containing %q, got %v", tt.wantMsg, mockT.msgs)
 			}
 		})
 	}

--- a/pkg/contracttest/extra_schema_refs_test.go
+++ b/pkg/contracttest/extra_schema_refs_test.go
@@ -42,8 +42,8 @@ func TestContractYAML_ExtraSchemaRefs(t *testing.T) {
 }
 
 // TestLoad_ExtraSchemaRefs confirms the full Load path with a non-standard
-// schemaRefs key: the contract loads successfully (extra keys are ignored by
-// the schema compiler) and the known refs are compiled.
+// schemaRefs key: the contract loads successfully, known refs are compiled,
+// and extra refs are accessible via ValidateSchemaRef.
 func TestLoad_ExtraSchemaRefs(t *testing.T) {
 	dir := filepath.Join(testdataRoot(), "http", "test", "extrarefs", "v1")
 	c := Load(t, dir)
@@ -53,4 +53,21 @@ func TestLoad_ExtraSchemaRefs(t *testing.T) {
 	}
 	// Prove that the response schema was compiled by validating a minimal document.
 	c.ValidateResponse(t, []byte(`{"data":{}}`))
+
+	// Prove that ValidateSchemaRef dispatches to extra schemas.
+	// custom.schema.json requires {"code": <string>}.
+	c.ValidateSchemaRef(t, "customKey", []byte(`{"code":"ok"}`))
+
+	// Prove that ValidateSchemaRef rejects invalid data against the extra schema.
+	mockT := &mockTB{}
+	c.ValidateSchemaRef(mockT, "customKey", []byte(`{}`)) // missing required "code"
+	if !mockT.failed {
+		t.Error("expected ValidateSchemaRef to fail for missing required field, but it passed")
+	}
+
+	// Prove that ValidateSchemaRef is a no-op for unknown keys.
+	c.ValidateSchemaRef(t, "nonexistentKey", []byte(`{"anything":"goes"}`))
+
+	// Prove that ValidateSchemaRef dispatches well-known keys correctly.
+	c.ValidateSchemaRef(t, "response", []byte(`{"data":{}}`))
 }

--- a/pkg/contracttest/extra_schema_refs_test.go
+++ b/pkg/contracttest/extra_schema_refs_test.go
@@ -51,7 +51,6 @@ func TestLoad_ExtraSchemaRefs(t *testing.T) {
 	if c.ID != "http.test.extrarefs.v1" {
 		t.Errorf("ID = %q, want %q", c.ID, "http.test.extrarefs.v1")
 	}
-	if c.responseSchema == nil {
-		t.Error("responseSchema should be compiled from the 'response' schemaRef, got nil")
-	}
+	// Prove that the response schema was compiled by validating a minimal document.
+	c.ValidateResponse(t, []byte(`{"data":{}}`))
 }

--- a/pkg/contracttest/extra_schema_refs_test.go
+++ b/pkg/contracttest/extra_schema_refs_test.go
@@ -1,0 +1,57 @@
+package contracttest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestContractYAML_ExtraSchemaRefs proves that extra (non-standard) schema ref
+// keys survive YAML parsing. This was the L6 bug: the previous schemaRefsYAML
+// struct lacked the Extra field, silently dropping unknown keys.
+func TestContractYAML_ExtraSchemaRefs(t *testing.T) {
+	dir := filepath.Join(testdataRoot(), "http", "test", "extrarefs", "v1")
+
+	data, err := os.ReadFile(filepath.Join(dir, "contract.yaml"))
+	if err != nil {
+		t.Fatalf("read contract.yaml: %v", err)
+	}
+
+	var cy contractYAML
+	if err := yaml.Unmarshal(data, &cy); err != nil {
+		t.Fatalf("parse contract.yaml: %v", err)
+	}
+
+	if cy.SchemaRefs.Response == "" {
+		t.Error("SchemaRefs.Response should be populated, got empty string")
+	}
+
+	if len(cy.SchemaRefs.Extra) == 0 {
+		t.Fatal("SchemaRefs.Extra should contain the non-standard key 'customKey', got empty map")
+	}
+
+	got, ok := cy.SchemaRefs.Extra["customKey"]
+	if !ok {
+		t.Fatalf("SchemaRefs.Extra missing 'customKey'; Extra = %v", cy.SchemaRefs.Extra)
+	}
+	if got != "custom.schema.json" {
+		t.Errorf("SchemaRefs.Extra[customKey] = %q, want %q", got, "custom.schema.json")
+	}
+}
+
+// TestLoad_ExtraSchemaRefs confirms the full Load path with a non-standard
+// schemaRefs key: the contract loads successfully (extra keys are ignored by
+// the schema compiler) and the known refs are compiled.
+func TestLoad_ExtraSchemaRefs(t *testing.T) {
+	dir := filepath.Join(testdataRoot(), "http", "test", "extrarefs", "v1")
+	c := Load(t, dir)
+
+	if c.ID != "http.test.extrarefs.v1" {
+		t.Errorf("ID = %q, want %q", c.ID, "http.test.extrarefs.v1")
+	}
+	if c.responseSchema == nil {
+		t.Error("responseSchema should be compiled from the 'response' schemaRef, got nil")
+	}
+}

--- a/pkg/contracttest/testdata/contracts/http/test/errresp/v1/contract.yaml
+++ b/pkg/contracttest/testdata/contracts/http/test/errresp/v1/contract.yaml
@@ -18,3 +18,6 @@ endpoints:
       403:
         description: "Forbidden"
         schemaRef: "../../../../../../../../contracts/shared/errors/error-response-v1.schema.json"
+      429:
+        description: "Too Many Requests"
+        schemaRef: ""

--- a/pkg/contracttest/testdata/contracts/http/test/extrarefs/v1/contract.yaml
+++ b/pkg/contracttest/testdata/contracts/http/test/extrarefs/v1/contract.yaml
@@ -1,0 +1,14 @@
+id: http.test.extrarefs.v1
+kind: http
+ownerCell: test-cell
+consistencyLevel: L1
+lifecycle: active
+endpoints:
+  http:
+    method: GET
+    path: /api/v1/test/extrarefs
+    successStatus: 200
+    noContent: false
+schemaRefs:
+  response: response.schema.json
+  customKey: custom.schema.json

--- a/pkg/contracttest/testdata/contracts/http/test/extrarefs/v1/custom.schema.json
+++ b/pkg/contracttest/testdata/contracts/http/test/extrarefs/v1/custom.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": "string"
+    }
+  },
+  "required": ["code"],
+  "additionalProperties": false
+}

--- a/pkg/contracttest/testdata/contracts/http/test/extrarefs/v1/response.schema.json
+++ b/pkg/contracttest/testdata/contracts/http/test/extrarefs/v1/response.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object"
+    }
+  },
+  "required": ["data"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- **L6 CONTRACTTEST-MODEL-ALIGN-01**: Create `pkg/contracts/` with shared `HTTPTransport`, `HTTPResponse`, `SchemaRefs` types. `kernel/metadata` uses type aliases for backward compat. `pkg/contracttest` deletes duplicated types and imports shared package. **Fixes** silent `Extra` schema refs drop bug.
- **K1 METADATA-PROJECTLOC-IFACE-01**: Unexport `ProjectMeta.FileNodes` → `fileNodes`. Add `Locate`/`SetFileNode`/`FileNode`/`HasFileNodes` methods. `governance/locator.go` delegates to `pm.Locate()`, removing yaml.v3 from governance non-test imports.

ref: k8s.io/apimachinery — shared types in standalone base package, single dependency direction
ref: cuelang/cue types.go — opaque struct hiding internal AST behind method-based access

## Test plan

- [x] `go test ./pkg/contracts/...` — new round-trip + inline precedence tests
- [x] `go test ./kernel/metadata/...` — existing tests unchanged + new ProjectMeta.Locate tests
- [x] `go test ./kernel/governance/...` — migrate locate_test.go to SetFileNode API
- [x] `go test ./pkg/contracttest/...` — new ExtraSchemaRefs test proves bug fix
- [x] `go test ./cmd/gocell/...` — downstream consumers unaffected
- [x] `go build -tags=integration ./...` — full build clean
- [x] `golangci-lint run` — 0 new issues
- [x] Verify `governance/locator.go` no longer imports yaml.v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)