### PR TITLE
feat(adapters/postgres): PGRefreshStore for refresh.Store (F2)

### DIFF
--- a/adapters/postgres/migrations/007_refresh_tokens.sql
+++ b/adapters/postgres/migrations/007_refresh_tokens.sql
@@ -13,8 +13,8 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
     obsolete_token TEXT        NULL,
     session_id     TEXT        NOT NULL,
     subject_id     TEXT        NOT NULL,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
-    last_used      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at     TIMESTAMPTZ NOT NULL,
+    last_used      TIMESTAMPTZ NOT NULL,
     expires_at     TIMESTAMPTZ NOT NULL,
     revoked_at     TIMESTAMPTZ NULL
 );

--- a/adapters/postgres/migrations/011_refresh_tokens_token_index.sql
+++ b/adapters/postgres/migrations/011_refresh_tokens_token_index.sql
@@ -1,0 +1,14 @@
+-- Migration 011: add non-partial token index for Branch 2 lookups.
+-- checkActiveStateSQL queries by token without revoked_at filter;
+-- the existing partial index (idx_refresh_tokens_token_active) only covers
+-- non-revoked rows. This index covers all rows for the state-check path.
+-- ref: PR#213 review finding P1-Cx1.
+
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token
+    ON refresh_tokens (token);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_refresh_tokens_token;

--- a/adapters/postgres/migrations/011_refresh_tokens_token_index.sql
+++ b/adapters/postgres/migrations/011_refresh_tokens_token_index.sql
@@ -2,13 +2,24 @@
 -- checkActiveStateSQL queries by token without revoked_at filter;
 -- the existing partial index (idx_refresh_tokens_token_active) only covers
 -- non-revoked rows. This index covers all rows for the state-check path.
--- ref: PR#213 review finding P1-Cx1.
+--
+-- Uses CONCURRENTLY to avoid blocking writes on a table that may already
+-- contain data. CONCURRENTLY cannot run inside a transaction block, hence
+-- the NO TRANSACTION annotation.
+--
+-- If this migration is interrupted, the index may be left in INVALID state.
+-- Detect: SELECT indexname FROM pg_indexes WHERE indexname = 'idx_refresh_tokens_token'
+--         INTERSECT
+--         SELECT relname FROM pg_class WHERE relkind = 'i' AND NOT indisvalid;
+-- Cleanup: DROP INDEX CONCURRENTLY IF EXISTS idx_refresh_tokens_token; then re-run migration.
+--
+-- ref: PR#213 review finding P1-Cx1 + multi-seat review P1.
 
 -- +goose Up
-SET LOCAL lock_timeout = '5s';
-
-CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token
+-- +goose NO TRANSACTION
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_refresh_tokens_token
     ON refresh_tokens (token);
 
 -- +goose Down
-DROP INDEX IF EXISTS idx_refresh_tokens_token;
+-- +goose NO TRANSACTION
+DROP INDEX CONCURRENTLY IF EXISTS idx_refresh_tokens_token;

--- a/adapters/postgres/migrator_test.go
+++ b/adapters/postgres/migrator_test.go
@@ -135,7 +135,7 @@ func TestMigrationsFS_SubDirectory(t *testing.T) {
 			sqlFiles = append(sqlFiles, e.Name())
 		}
 	}
-	assert.Len(t, sqlFiles, 10, "should have 10 goose-annotated SQL files (001-010)")
+	assert.Len(t, sqlFiles, 11, "should have 11 goose-annotated SQL files (001-011)")
 }
 
 func TestMigrationDirection_Values(t *testing.T) {

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+	"log/slog"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -16,6 +17,10 @@ import (
 
 // Compile-time assertion: PGRefreshStore implements refresh.Store.
 var _ refresh.Store = (*PGRefreshStore)(nil)
+
+// errCASMiss is returned internally when a CAS UPDATE/SELECT matched no row.
+// It is unexported so callers compare with errors.Is rather than pgx.ErrNoRows.
+var errCASMiss = errors.New("refresh store: CAS miss")
 
 // gcBatchSize is the number of rows deleted per GC batch iteration.
 const gcBatchSize = 1000
@@ -79,6 +84,9 @@ WHERE id IN (
 // Consistency: L1 LocalTx — Rotate is atomic within a single transaction;
 // Issue and Revoke are single-statement writes.
 //
+// Token values are stored in plaintext. See backlog X11 (REFRESH-HMAC-SPLIT-01)
+// for the planned HMAC-split upgrade that stores only hash(verifier).
+//
 // ref: dexidp/dex storage/sql/sql.go (pgx-based refresh token CAS pattern)
 // ref: F2 contract C1-C7 from docs/plans/202604191515-auth-federated-whistle.md
 type PGRefreshStore struct {
@@ -93,6 +101,9 @@ type PGRefreshStore struct {
 // clock must not be nil. policy.MaxAge must be positive. If randReader is nil,
 // crypto/rand.Reader is used.
 func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Clock, randReader io.Reader) *PGRefreshStore {
+	if pool == nil {
+		panic("postgres.NewRefreshStore: pool must not be nil")
+	}
 	if clock == nil {
 		panic("postgres.NewRefreshStore: clock must not be nil")
 	}
@@ -234,7 +245,7 @@ func (s *PGRefreshStore) rotateInTx(ctx context.Context, tx pgx.Tx, presentedTok
 	if err == nil {
 		return tok, nil
 	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	if !errors.Is(err, errCASMiss) {
 		return nil, err
 	}
 
@@ -250,7 +261,7 @@ func (s *PGRefreshStore) rotateInTx(ctx context.Context, tx pgx.Tx, presentedTok
 	if err == nil {
 		return tok, nil
 	}
-	if errors.Is(err, pgx.ErrNoRows) {
+	if errors.Is(err, errCASMiss) {
 		// Branch 4b: check if it's an obsolete token on a revoked row.
 		var dummy int
 		scanErr := tx.QueryRow(ctx, checkObsoleteRevokedSQL, presentedToken).Scan(&dummy)
@@ -264,14 +275,14 @@ func (s *PGRefreshStore) rotateInTx(ctx context.Context, tx pgx.Tx, presentedTok
 }
 
 // tryRotateActive attempts the CAS UPDATE for an active, valid token.
-// Returns (token, nil) on success, (nil, pgx.ErrNoRows) when the UPDATE matched
+// Returns (token, nil) on success, (nil, errCASMiss) when the UPDATE matched
 // no row (token absent, revoked, or expired), or (nil, infraErr) on DB error.
 func (s *PGRefreshStore) tryRotateActive(ctx context.Context, tx pgx.Tx, presentedToken, newTokenID string, now time.Time) (*refresh.Token, error) {
 	row := tx.QueryRow(ctx, rotateActiveSQL, newTokenID, now, presentedToken, now)
 	tok, err := scanTokenRow(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, pgx.ErrNoRows
+			return nil, errCASMiss
 		}
 		return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: rotate active", err)
 	}
@@ -305,35 +316,27 @@ func (s *PGRefreshStore) checkActiveState(ctx context.Context, tx pgx.Tx, presen
 // of the current-generation record.
 //
 // Returns (token, nil) for grace retry, (nil, ErrTokenReused) for reuse attack,
-// or (nil, pgx.ErrNoRows) when no active record holds this as obsolete_token.
+// or (nil, errCASMiss) when no active record holds this as obsolete_token.
 func (s *PGRefreshStore) tryObsolete(ctx context.Context, tx pgx.Tx, presentedToken string, now time.Time) (*refresh.Token, error) {
 	row := tx.QueryRow(ctx, lookupByObsoleteSQL, presentedToken)
 
-	var (
-		id            int64
-		token         string
-		obsoleteToken *string
-		sessionID     string
-		subjectID     string
-		createdAt     time.Time
-		lastUsed      time.Time
-		expiresAt     time.Time
-		revokedAt     *time.Time
-	)
-	err := row.Scan(&id, &token, &obsoleteToken, &sessionID, &subjectID, &createdAt, &lastUsed, &expiresAt, &revokedAt)
+	tok, err := scanFullTokenRow(row)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, pgx.ErrNoRows
+		return nil, errCASMiss
 	}
 	if err != nil {
 		return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: lookup by obsolete", err)
 	}
 
 	// Branch 4: grace window elapsed → cascade revoke + ErrTokenReused.
-	elapsed := now.Sub(lastUsed)
+	elapsed := now.Sub(tok.LastUsed)
 	if elapsed > s.policy.ReuseInterval {
-		if _, execErr := tx.Exec(ctx, revokeSessionSQL, now, sessionID); execErr != nil {
+		if _, execErr := tx.Exec(ctx, revokeSessionSQL, now, tok.SessionID); execErr != nil {
 			return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: cascade revoke on reuse", execErr)
 		}
+		slog.Error("refresh token reuse detected",
+			slog.String("session_id", tok.SessionID),
+		)
 		return nil, refresh.ErrTokenReused
 	}
 
@@ -343,14 +346,7 @@ func (s *PGRefreshStore) tryObsolete(ctx context.Context, tx pgx.Tx, presentedTo
 	// memstore.rotateObsolete behaviour.
 	//
 	// ref: memstore/store.go rotateObsolete — tok.ObsoleteToken = ""
-	tok := &refresh.Token{
-		ID:        token,
-		SessionID: sessionID,
-		SubjectID: subjectID,
-		CreatedAt: createdAt,
-		LastUsed:  lastUsed,
-		ExpiresAt: expiresAt,
-	}
+	tok.ObsoleteToken = ""
 	return tok, nil
 }
 
@@ -367,6 +363,38 @@ func scanTokenRow(row RowScanner) (*refresh.Token, error) {
 		expiresAt     time.Time
 	)
 	if err := row.Scan(&id, &token, &obsoleteToken, &sessionID, &subjectID, &createdAt, &lastUsed, &expiresAt); err != nil {
+		return nil, err
+	}
+	tok := &refresh.Token{
+		ID:        token,
+		SessionID: sessionID,
+		SubjectID: subjectID,
+		CreatedAt: createdAt,
+		LastUsed:  lastUsed,
+		ExpiresAt: expiresAt,
+	}
+	if obsoleteToken != nil {
+		tok.ObsoleteToken = *obsoleteToken
+	}
+	return tok, nil
+}
+
+// scanFullTokenRow reads all columns including revokedAt, as returned by
+// lookupByObsoleteSQL. revokedAt is scanned but not included in Token (which
+// has no revocation field); callers needing it should inspect the raw scan.
+func scanFullTokenRow(row RowScanner) (*refresh.Token, error) {
+	var (
+		id            int64
+		token         string
+		obsoleteToken *string
+		sessionID     string
+		subjectID     string
+		createdAt     time.Time
+		lastUsed      time.Time
+		expiresAt     time.Time
+		revokedAt     *time.Time
+	)
+	if err := row.Scan(&id, &token, &obsoleteToken, &sessionID, &subjectID, &createdAt, &lastUsed, &expiresAt, &revokedAt); err != nil {
 		return nil, err
 	}
 	tok := &refresh.Token{

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -1,0 +1,384 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/refresh"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Compile-time assertion: PGRefreshStore implements refresh.Store.
+var _ refresh.Store = (*PGRefreshStore)(nil)
+
+// gcBatchSize is the number of rows deleted per GC batch iteration.
+const gcBatchSize = 1000
+
+// SQL constants for PGRefreshStore operations.
+const issueSQL = `
+INSERT INTO refresh_tokens (token, session_id, subject_id, created_at, last_used, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id`
+
+const rotateActiveSQL = `
+UPDATE refresh_tokens
+SET token = $1,
+    obsolete_token = token,
+    last_used = $2
+WHERE token = $3
+  AND revoked_at IS NULL
+  AND expires_at > $4
+RETURNING id, token, obsolete_token, session_id, subject_id, created_at, last_used, expires_at`
+
+const checkActiveStateSQL = `
+SELECT revoked_at, expires_at
+FROM refresh_tokens
+WHERE token = $1
+LIMIT 1`
+
+const lookupByObsoleteSQL = `
+SELECT id, token, obsolete_token, session_id, subject_id, created_at, last_used, expires_at, revoked_at
+FROM refresh_tokens
+WHERE obsolete_token = $1
+  AND revoked_at IS NULL
+LIMIT 1`
+
+const checkObsoleteRevokedSQL = `
+SELECT 1
+FROM refresh_tokens
+WHERE obsolete_token = $1
+  AND revoked_at IS NOT NULL
+LIMIT 1`
+
+const revokeSessionSQL = `
+UPDATE refresh_tokens
+SET revoked_at = $1
+WHERE session_id = $2
+  AND revoked_at IS NULL`
+
+const gcBatchSQL = `
+DELETE FROM refresh_tokens
+WHERE id IN (
+    SELECT id FROM refresh_tokens
+    WHERE expires_at < $1
+    LIMIT $2
+    FOR UPDATE SKIP LOCKED
+)`
+
+// PGRefreshStore implements refresh.Store over PostgreSQL using pgx.
+//
+// All time values are sourced from the injected clock (never PG's now()),
+// so that the FakeClock in storetest can drive deterministic behaviour.
+//
+// Consistency: L1 LocalTx — Rotate is atomic within a single transaction;
+// Issue and Revoke are single-statement writes.
+//
+// ref: dexidp/dex storage/sql/sql.go (pgx-based refresh token CAS pattern)
+// ref: F2 contract C1-C7 from docs/plans/202604191515-auth-federated-whistle.md
+type PGRefreshStore struct {
+	pool   *pgxpool.Pool
+	policy refresh.Policy
+	clock  refresh.Clock
+	rand   io.Reader
+}
+
+// NewRefreshStore constructs a PGRefreshStore.
+//
+// clock must not be nil. policy.MaxAge must be positive. If randReader is nil,
+// crypto/rand.Reader is used.
+func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Clock, randReader io.Reader) *PGRefreshStore {
+	if clock == nil {
+		panic("postgres.NewRefreshStore: clock must not be nil")
+	}
+	if policy.MaxAge <= 0 {
+		panic("postgres.NewRefreshStore: policy.MaxAge must be positive")
+	}
+	if randReader == nil {
+		randReader = rand.Reader
+	}
+	return &PGRefreshStore{
+		pool:   pool,
+		policy: policy,
+		clock:  clock,
+		rand:   randReader,
+	}
+}
+
+// generateTokenID produces a 43-character base64url token from 32 random bytes.
+//
+// 32 bytes → 256 bits of entropy; base64.RawURLEncoding gives ceil(32*4/3)=43 chars.
+// ref: dexidp/dex server/refreshhandlers.go newRefreshToken()
+func (s *PGRefreshStore) generateTokenID() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := io.ReadFull(s.rand, buf); err != nil {
+		return "", errcode.Wrap(ErrAdapterPGQuery, "refresh store: generate token id", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// Issue creates a new refresh chain for (sessionID, subjectID).
+//
+// Consistency: L1 LocalTx — single INSERT, no outbox event.
+func (s *PGRefreshStore) Issue(ctx context.Context, sessionID, subjectID string) (*refresh.Token, error) {
+	tokenID, err := s.generateTokenID()
+	if err != nil {
+		return nil, err
+	}
+
+	now := s.clock.Now()
+	expiresAt := now.Add(s.policy.MaxAge)
+
+	var id int64
+	err = s.pool.QueryRow(ctx, issueSQL, tokenID, sessionID, subjectID, now, now, expiresAt).Scan(&id)
+	if err != nil {
+		return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: issue", err)
+	}
+
+	return &refresh.Token{
+		ID:        tokenID,
+		SessionID: sessionID,
+		SubjectID: subjectID,
+		CreatedAt: now,
+		LastUsed:  now,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// Revoke marks all tokens in the session as revoked.
+//
+// Idempotent: 0 rows affected is not an error.
+// Consistency: L1 LocalTx — single UPDATE within one statement.
+func (s *PGRefreshStore) Revoke(ctx context.Context, sessionID string) error {
+	now := s.clock.Now()
+	_, err := s.pool.Exec(ctx, revokeSessionSQL, now, sessionID)
+	if err != nil {
+		return errcode.Wrap(ErrAdapterPGQuery, "refresh store: revoke", err)
+	}
+	return nil
+}
+
+// GC removes tokens whose expires_at < olderThan in batches of gcBatchSize.
+// Returns the total count of rows deleted.
+//
+// Consistency: L0 LocalOnly — best-effort cleanup, no transactional guarantee.
+func (s *PGRefreshStore) GC(ctx context.Context, olderThan time.Time) (int, error) {
+	total := 0
+	for {
+		ct, err := s.pool.Exec(ctx, gcBatchSQL, olderThan, gcBatchSize)
+		if err != nil {
+			return total, errcode.Wrap(ErrAdapterPGQuery, "refresh store: gc batch", err)
+		}
+		deleted := int(ct.RowsAffected())
+		total += deleted
+		if deleted < gcBatchSize {
+			break
+		}
+	}
+	return total, nil
+}
+
+// Rotate advances the chain one generation using a single transaction.
+//
+// State machine branches (see refresh.Store interface for full contract):
+//  1. CAS active — UPDATE the current active token; returns new token.
+//  2. Active exists but revoked/expired — surface ErrTokenRevoked/ErrTokenExpired.
+//  3. Obsolete grace retry — presented token is a previous-generation obsolete;
+//     within ReuseInterval → return current token idempotently.
+//  4. Obsolete reuse detection — grace window elapsed → cascade Revoke + ErrTokenReused.
+//  5. Not found in either index → ErrTokenNotFound.
+//
+// Consistency: L1 LocalTx — all branches execute within one BEGIN/COMMIT block.
+func (s *PGRefreshStore) Rotate(ctx context.Context, presentedToken string) (*refresh.Token, error) {
+	now := s.clock.Now()
+
+	newTokenID, err := s.generateTokenID()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, errcode.Wrap(ErrAdapterPGConnect, "refresh store: rotate begin", err)
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(context.WithoutCancel(ctx))
+		}
+	}()
+
+	tok, err := s.rotateInTx(ctx, tx, presentedToken, newTokenID, now)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, errcode.Wrap(ErrAdapterPGConnect, "refresh store: rotate commit", err)
+	}
+	committed = true
+
+	return tok, nil
+}
+
+// rotateInTx orchestrates the five Rotate branches within an open transaction.
+func (s *PGRefreshStore) rotateInTx(ctx context.Context, tx pgx.Tx, presentedToken, newTokenID string, now time.Time) (*refresh.Token, error) {
+	// Branch 1: CAS active token.
+	tok, err := s.tryRotateActive(ctx, tx, presentedToken, newTokenID, now)
+	if err == nil {
+		return tok, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	// CAS missed — token either revoked, expired, or is an obsolete token.
+	// Branch 2: check if it exists as an active (but invalid) record.
+	if stateErr := s.checkActiveState(ctx, tx, presentedToken); stateErr != nil {
+		return nil, stateErr
+	}
+
+	// Not an active record — check obsolete branches.
+	// Branch 3 & 4: check the obsolete token index.
+	tok, err = s.tryObsolete(ctx, tx, presentedToken, now)
+	if err == nil {
+		return tok, nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Branch 4b: check if it's an obsolete token on a revoked row.
+		var dummy int
+		scanErr := tx.QueryRow(ctx, checkObsoleteRevokedSQL, presentedToken).Scan(&dummy)
+		if scanErr == nil {
+			return nil, refresh.ErrTokenRevoked
+		}
+		// Branch 5: genuinely not found in any index.
+		return nil, refresh.ErrTokenNotFound
+	}
+	return nil, err
+}
+
+// tryRotateActive attempts the CAS UPDATE for an active, valid token.
+// Returns (token, nil) on success, (nil, pgx.ErrNoRows) when the UPDATE matched
+// no row (token absent, revoked, or expired), or (nil, infraErr) on DB error.
+func (s *PGRefreshStore) tryRotateActive(ctx context.Context, tx pgx.Tx, presentedToken, newTokenID string, now time.Time) (*refresh.Token, error) {
+	row := tx.QueryRow(ctx, rotateActiveSQL, newTokenID, now, presentedToken, now)
+	tok, err := scanTokenRow(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, pgx.ErrNoRows
+		}
+		return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: rotate active", err)
+	}
+	return tok, nil
+}
+
+// checkActiveState inspects the record for presentedToken to decide whether
+// it's revoked or expired. Returns ErrTokenRevoked, ErrTokenExpired, or nil
+// (meaning: no active record found at all, should proceed to obsolete check).
+// Returns pgx.ErrNoRows when the token does not exist in the active index.
+func (s *PGRefreshStore) checkActiveState(ctx context.Context, tx pgx.Tx, presentedToken string) error {
+	var revokedAt *time.Time
+	var expiresAt time.Time // scan destination only; not compared (CAS already excluded valid tokens)
+	err := tx.QueryRow(ctx, checkActiveStateSQL, presentedToken).Scan(&revokedAt, &expiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// No active record — caller should check obsolete index.
+		return nil
+	}
+	if err != nil {
+		return errcode.Wrap(ErrAdapterPGQuery, "refresh store: check active state", err)
+	}
+	// Record exists but was filtered out by rotateActiveSQL's WHERE clause.
+	if revokedAt != nil {
+		return refresh.ErrTokenRevoked
+	}
+	// Not revoked but CAS excluded it — must be expired (expires_at <= now).
+	return refresh.ErrTokenExpired
+}
+
+// tryObsolete handles Branches 3 and 4: presented token is the obsolete token
+// of the current-generation record.
+//
+// Returns (token, nil) for grace retry, (nil, ErrTokenReused) for reuse attack,
+// or (nil, pgx.ErrNoRows) when no active record holds this as obsolete_token.
+func (s *PGRefreshStore) tryObsolete(ctx context.Context, tx pgx.Tx, presentedToken string, now time.Time) (*refresh.Token, error) {
+	row := tx.QueryRow(ctx, lookupByObsoleteSQL, presentedToken)
+
+	var (
+		id            int64
+		token         string
+		obsoleteToken *string
+		sessionID     string
+		subjectID     string
+		createdAt     time.Time
+		lastUsed      time.Time
+		expiresAt     time.Time
+		revokedAt     *time.Time
+	)
+	err := row.Scan(&id, &token, &obsoleteToken, &sessionID, &subjectID, &createdAt, &lastUsed, &expiresAt, &revokedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, pgx.ErrNoRows
+	}
+	if err != nil {
+		return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: lookup by obsolete", err)
+	}
+
+	// Branch 4: grace window elapsed → cascade revoke + ErrTokenReused.
+	elapsed := now.Sub(lastUsed)
+	if elapsed > s.policy.ReuseInterval {
+		if _, execErr := tx.Exec(ctx, revokeSessionSQL, now, sessionID); execErr != nil {
+			return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: cascade revoke on reuse", execErr)
+		}
+		return nil, refresh.ErrTokenReused
+	}
+
+	// Branch 3: grace retry — return the current active token. ObsoleteToken
+	// is intentionally blank in the grace-retry response (only the goroutine
+	// that performed the actual rotation receives ObsoleteToken). This matches
+	// memstore.rotateObsolete behaviour.
+	//
+	// ref: memstore/store.go rotateObsolete — tok.ObsoleteToken = ""
+	tok := &refresh.Token{
+		ID:        token,
+		SessionID: sessionID,
+		SubjectID: subjectID,
+		CreatedAt: createdAt,
+		LastUsed:  lastUsed,
+		ExpiresAt: expiresAt,
+	}
+	return tok, nil
+}
+
+// scanTokenRow reads the columns returned by rotateActiveSQL into a Token.
+func scanTokenRow(row RowScanner) (*refresh.Token, error) {
+	var (
+		id            int64
+		token         string
+		obsoleteToken *string
+		sessionID     string
+		subjectID     string
+		createdAt     time.Time
+		lastUsed      time.Time
+		expiresAt     time.Time
+	)
+	if err := row.Scan(&id, &token, &obsoleteToken, &sessionID, &subjectID, &createdAt, &lastUsed, &expiresAt); err != nil {
+		return nil, err
+	}
+	tok := &refresh.Token{
+		ID:        token,
+		SessionID: sessionID,
+		SubjectID: subjectID,
+		CreatedAt: createdAt,
+		LastUsed:  lastUsed,
+		ExpiresAt: expiresAt,
+	}
+	if obsoleteToken != nil {
+		tok.ObsoleteToken = *obsoleteToken
+	}
+	return tok, nil
+}

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -110,6 +110,9 @@ func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Cl
 	if policy.MaxAge <= 0 {
 		panic("postgres.NewRefreshStore: policy.MaxAge must be positive")
 	}
+	if policy.ReuseInterval < 0 {
+		panic("postgres.NewRefreshStore: policy.ReuseInterval must not be negative")
+	}
 	if randReader == nil {
 		randReader = rand.Reader
 	}
@@ -226,16 +229,18 @@ func (s *PGRefreshStore) Rotate(ctx context.Context, presentedToken string) (*re
 	}()
 
 	tok, err := s.rotateInTx(ctx, tx, presentedToken, newTokenID, now)
-	if err != nil {
-		return nil, err
+
+	// Commit when: success (happy/grace) OR reuse cascade (revoke must persist).
+	// Rollback when: revoked/expired/not-found (read-only branches).
+	needCommit := err == nil || errors.Is(err, refresh.ErrTokenReused)
+	if needCommit {
+		if cErr := tx.Commit(ctx); cErr != nil {
+			return nil, errcode.Wrap(ErrAdapterPGConnect, "refresh store: rotate commit", cErr)
+		}
+		committed = true
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return nil, errcode.Wrap(ErrAdapterPGConnect, "refresh store: rotate commit", err)
-	}
-	committed = true
-
-	return tok, nil
+	return tok, err
 }
 
 // rotateInTx orchestrates the five Rotate branches within an open transaction.
@@ -268,8 +273,11 @@ func (s *PGRefreshStore) rotateInTx(ctx context.Context, tx pgx.Tx, presentedTok
 		if scanErr == nil {
 			return nil, refresh.ErrTokenRevoked
 		}
-		// Branch 5: genuinely not found in any index.
-		return nil, refresh.ErrTokenNotFound
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			// Branch 5: genuinely not found in any index.
+			return nil, refresh.ErrTokenNotFound
+		}
+		return nil, errcode.Wrap(ErrAdapterPGQuery, "refresh store: check obsolete revoked", scanErr)
 	}
 	return nil, err
 }

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -4,41 +4,66 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPGRefreshStore_ContractSuite(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
+	base, cleanup := setupPostgres(t)
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
-	// Run migrations using a dedicated tracking table so this test's schema
-	// version tracking does not collide with other integration test suites.
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_refresh_store")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
 	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	// Clean any residual data before the parallel contract suite.
-	// Each subtest uses unique session IDs, but GC counts ALL expired rows
-	// including those from other subtests — T13 is sensitive to this.
-	_, err = pool.DB().Exec(ctx, "TRUNCATE refresh_tokens")
-	require.NoError(t, err)
-
+	// Each factory call gets its own PG schema so parallel subtests are fully
+	// isolated. GC (T13) only sees rows it inserted — no shared-table pollution.
 	storetest.RunContractSuite(t, func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
 		t.Helper()
 
+		p := isolatedSchemaPool(t, ctx, base)
+		migrator, err := NewMigrator(p, MigrationsFS(), "schema_migrations")
+		require.NoError(t, err)
+		require.NoError(t, migrator.Up(ctx))
+
 		clock := storetest.NewFakeClock(baseTime)
-		store := NewRefreshStore(pool.DB(), policy, clock, nil)
+		store := NewRefreshStore(p.DB(), policy, clock, nil)
 		return store, clock
 	})
+}
+
+// isolatedSchemaPool creates a fresh PG schema and returns a Pool whose
+// search_path is scoped to that schema. t.Cleanup drops the schema and closes
+// the pool after the subtest finishes.
+func isolatedSchemaPool(t *testing.T, ctx context.Context, base *Pool) *Pool {
+	t.Helper()
+
+	schema := fmt.Sprintf("ts%016x", rand.Int63())
+	_, err := base.DB().Exec(ctx, "CREATE SCHEMA "+schema)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = base.DB().Exec(context.Background(), "DROP SCHEMA "+schema+" CASCADE")
+	})
+
+	cfg := base.DB().Config()
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = make(map[string]string)
+	}
+	cfg.ConnConfig.RuntimeParams["search_path"] = schema
+
+	inner, err := pgxpool.NewWithConfig(ctx, cfg)
+	require.NoError(t, err)
+
+	p := &Pool{inner: inner, config: base.config}
+	t.Cleanup(func() { _ = p.Close(context.Background()) })
+	return p
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -26,12 +26,14 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 
 	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
+	// Clean any residual data before the parallel contract suite.
+	// Each subtest uses unique session IDs, but GC counts ALL expired rows
+	// including those from other subtests — T13 is sensitive to this.
+	_, err = pool.DB().Exec(ctx, "TRUNCATE refresh_tokens")
+	require.NoError(t, err)
+
 	storetest.RunContractSuite(t, func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
 		t.Helper()
-		// No TRUNCATE: storetest assigns unique session IDs per test case
-		// ("sess-1".."sess-13b") and unique random tokens, so parallel subtests
-		// do not collide. The container is fresh per TestPGRefreshStore_ContractSuite
-		// invocation, so stale rows from a previous run are not a concern.
 
 		clock := storetest.NewFakeClock(baseTime)
 		store := NewRefreshStore(pool.DB(), policy, clock, nil)

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/runtime/auth/refresh"
+	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPGRefreshStore_ContractSuite(t *testing.T) {
+	pool, cleanup := setupPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	// Run migrations
+	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations")
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx))
+
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	storetest.RunContractSuite(t, func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
+		t.Helper()
+		_, err := pool.DB().Exec(ctx, "TRUNCATE refresh_tokens")
+		require.NoError(t, err)
+
+		clock := storetest.NewFakeClock(baseTime)
+		store := NewRefreshStore(pool.DB(), policy, clock, nil)
+		return store, clock
+	})
+}

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,5 +36,98 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 		clock := storetest.NewFakeClock(baseTime)
 		store := NewRefreshStore(pool.DB(), policy, clock, nil)
 		return store, clock
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestMigration007_StructuralAssertions
+// ---------------------------------------------------------------------------
+
+// TestMigration007_StructuralAssertions verifies the column layout and index
+// set of the refresh_tokens table after migration 007 is applied
+// (P2-Cx2 structural evidence).
+func TestMigration007_StructuralAssertions(t *testing.T) {
+	pool, cleanup := setupPostgres(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_007_struct")
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations")
+
+	// --- table exists ---
+	t.Run("refresh_tokens_table_exists", func(t *testing.T) {
+		var exists bool
+		err := pool.DB().QueryRow(ctx,
+			"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'refresh_tokens')").
+			Scan(&exists)
+		require.NoError(t, err)
+		assert.True(t, exists, "refresh_tokens table must exist after migration 007")
+	})
+
+	// --- columns ---
+	wantColumns := []string{
+		"id", "token", "obsolete_token", "session_id", "subject_id",
+		"created_at", "last_used", "expires_at", "revoked_at",
+	}
+	for _, col := range wantColumns {
+		col := col
+		t.Run("refresh_tokens_has_col_"+col, func(t *testing.T) {
+			var exists bool
+			err := pool.DB().QueryRow(ctx,
+				`SELECT EXISTS (
+					SELECT 1 FROM information_schema.columns
+					WHERE table_name = 'refresh_tokens' AND column_name = $1
+				)`, col).Scan(&exists)
+			require.NoError(t, err)
+			assert.Truef(t, exists, "refresh_tokens must have column %q", col)
+		})
+	}
+
+	// --- indexes ---
+	wantIndexes := []string{
+		"idx_refresh_tokens_token_active",
+		"idx_refresh_tokens_obsolete_active",
+		"idx_refresh_tokens_session",
+		"idx_refresh_tokens_expires",
+	}
+	for _, idx := range wantIndexes {
+		idx := idx
+		t.Run("index_exists_"+idx, func(t *testing.T) {
+			var exists bool
+			err := pool.DB().QueryRow(ctx,
+				"SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = $1)", idx).
+				Scan(&exists)
+			require.NoError(t, err)
+			assert.Truef(t, exists, "index %q must exist after migration 007", idx)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestMigration011_StructuralAssertions
+// ---------------------------------------------------------------------------
+
+// TestMigration011_StructuralAssertions verifies that migration 011 creates
+// the non-partial idx_refresh_tokens_token index covering all rows
+// (P2-Cx2 structural evidence).
+func TestMigration011_StructuralAssertions(t *testing.T) {
+	pool, cleanup := setupPostgres(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_011_struct")
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations including 011")
+
+	t.Run("idx_refresh_tokens_token_exists", func(t *testing.T) {
+		var exists bool
+		err := pool.DB().QueryRow(ctx,
+			"SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_refresh_tokens_token')").
+			Scan(&exists)
+		require.NoError(t, err)
+		assert.True(t, exists, "idx_refresh_tokens_token must exist after migration 011")
 	})
 }

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -17,8 +17,9 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
-	// Run migrations
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations")
+	// Run migrations using a dedicated tracking table so this test's schema
+	// version tracking does not collide with other integration test suites.
+	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_refresh_store")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 
@@ -26,8 +27,10 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 
 	storetest.RunContractSuite(t, func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
 		t.Helper()
-		_, err := pool.DB().Exec(ctx, "TRUNCATE refresh_tokens")
-		require.NoError(t, err)
+		// No TRUNCATE: storetest assigns unique session IDs per test case
+		// ("sess-1".."sess-13b") and unique random tokens, so parallel subtests
+		// do not collide. The container is fresh per TestPGRefreshStore_ContractSuite
+		// invocation, so stale rows from a previous run are not a concern.
 
 		clock := storetest.NewFakeClock(baseTime)
 		store := NewRefreshStore(pool.DB(), policy, clock, nil)

--- a/adapters/postgres/refresh_store_test.go
+++ b/adapters/postgres/refresh_store_test.go
@@ -1,0 +1,252 @@
+package postgres
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/runtime/auth/refresh"
+	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// NewRefreshStore constructor panics
+// ---------------------------------------------------------------------------
+
+func TestNewRefreshStore_Panics(t *testing.T) {
+	validClock := storetest.NewFakeClock(time.Now())
+	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
+
+	// dummyPool is a non-nil *pgxpool.Pool used only to pass the nil check in
+	// the constructor — it is never used for actual DB calls in these tests.
+	dummyPool := new(pgxpool.Pool)
+
+	t.Run("nil_pool", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewRefreshStore(nil, validPolicy, validClock, nil)
+		})
+	})
+
+	t.Run("nil_clock", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewRefreshStore(dummyPool, validPolicy, nil, nil)
+		})
+	})
+
+	t.Run("zero_MaxAge", func(t *testing.T) {
+		p := refresh.Policy{ReuseInterval: time.Second, MaxAge: 0}
+		assert.Panics(t, func() {
+			NewRefreshStore(dummyPool, p, validClock, nil)
+		})
+	})
+
+	t.Run("negative_MaxAge", func(t *testing.T) {
+		p := refresh.Policy{ReuseInterval: time.Second, MaxAge: -time.Hour}
+		assert.Panics(t, func() {
+			NewRefreshStore(dummyPool, p, validClock, nil)
+		})
+	})
+
+	t.Run("negative_ReuseInterval", func(t *testing.T) {
+		p := refresh.Policy{ReuseInterval: -time.Second, MaxAge: time.Hour}
+		assert.Panics(t, func() {
+			NewRefreshStore(dummyPool, p, validClock, nil)
+		})
+	})
+}
+
+func TestNewRefreshStore_NilRandReader_UsesDefault(t *testing.T) {
+	dummyPool := new(pgxpool.Pool)
+	validClock := storetest.NewFakeClock(time.Now())
+	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
+
+	// nil randReader must not panic — constructor falls back to crypto/rand.Reader.
+	assert.NotPanics(t, func() {
+		s := NewRefreshStore(dummyPool, validPolicy, validClock, nil)
+		assert.NotNil(t, s.rand, "rand field must be non-nil after constructor")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// generateTokenID — pure function, controllable via io.Reader
+// ---------------------------------------------------------------------------
+
+func TestGenerateTokenID_Length(t *testing.T) {
+	// 32 zero bytes → base64url(32 bytes) = 43 chars (RawURLEncoding, no padding).
+	src := bytes.NewReader(make([]byte, 32))
+	s := &PGRefreshStore{rand: src}
+
+	id, err := s.generateTokenID()
+	require.NoError(t, err)
+	assert.Len(t, id, 43, "token ID must be exactly 43 characters")
+}
+
+func TestGenerateTokenID_ReaderError(t *testing.T) {
+	sentinel := errors.New("entropy source exhausted")
+	s := &PGRefreshStore{rand: &errorReader{err: sentinel}}
+
+	_, err := s.generateTokenID()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "reader error must be wrapped and surfaced")
+}
+
+// ---------------------------------------------------------------------------
+// scanTokenRow / scanFullTokenRow — RowScanner stub
+// ---------------------------------------------------------------------------
+
+func TestScanTokenRow_ErrNoRows(t *testing.T) {
+	row := &stubRow{err: pgx.ErrNoRows}
+	tok, err := scanTokenRow(row)
+	assert.Nil(t, tok)
+	assert.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestScanTokenRow_ScanError(t *testing.T) {
+	sentinel := errors.New("db scan failure")
+	row := &stubRow{err: sentinel}
+	tok, err := scanTokenRow(row)
+	assert.Nil(t, tok)
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestScanTokenRow_NilObsoleteToken(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	row := newScanRow(
+		int64(1),           // id
+		"tok-abc",          // token
+		(*string)(nil),     // obsolete_token NULL
+		"sess-1",           // session_id
+		"user-1",           // subject_id
+		now,                // created_at
+		now,                // last_used
+		now.Add(time.Hour), // expires_at
+	)
+	tok, err := scanTokenRow(row)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	assert.Equal(t, "tok-abc", tok.ID)
+	assert.Empty(t, tok.ObsoleteToken, "nil obsolete_token must map to empty string")
+	assert.Equal(t, "sess-1", tok.SessionID)
+	assert.Equal(t, "user-1", tok.SubjectID)
+}
+
+func TestScanTokenRow_WithObsoleteToken(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := "old-tok"
+	row := newScanRow(
+		int64(2),
+		"tok-def",
+		&prev,
+		"sess-2",
+		"user-2",
+		now,
+		now,
+		now.Add(time.Hour),
+	)
+	tok, err := scanTokenRow(row)
+	require.NoError(t, err)
+	assert.Equal(t, "old-tok", tok.ObsoleteToken)
+}
+
+func TestScanFullTokenRow_ErrNoRows(t *testing.T) {
+	row := &stubRow{err: pgx.ErrNoRows}
+	tok, err := scanFullTokenRow(row)
+	assert.Nil(t, tok)
+	assert.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestScanFullTokenRow_WithObsoleteToken(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := "old-tok-full"
+	row := newFullScanRow(
+		int64(4), "tok-jkl", &prev, "sess-4", "user-4",
+		now, now, now.Add(time.Hour), nil,
+	)
+	tok, err := scanFullTokenRow(row)
+	require.NoError(t, err)
+	assert.Equal(t, "old-tok-full", tok.ObsoleteToken)
+}
+
+func TestScanFullTokenRow_WithRevokedAt(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	revoked := now.Add(-time.Minute)
+	row := newFullScanRow(
+		int64(3),
+		"tok-ghi",
+		(*string)(nil),
+		"sess-3",
+		"user-3",
+		now,
+		now,
+		now.Add(time.Hour),
+		&revoked,
+	)
+	tok, err := scanFullTokenRow(row)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	assert.Equal(t, "tok-ghi", tok.ID)
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// errorReader always returns the configured error from Read.
+type errorReader struct{ err error }
+
+func (r *errorReader) Read(_ []byte) (int, error) { return 0, r.err }
+
+// stubRow returns a fixed error from Scan, simulating DB failure or no-rows.
+type stubRow struct{ err error }
+
+func (r *stubRow) Scan(_ ...any) error { return r.err }
+
+// scanRow holds pre-set values and populates dest pointers in order.
+// Supports: *int64, *string, **string, *time.Time, **time.Time.
+type scanRow struct{ vals []any }
+
+func (r *scanRow) Scan(dest ...any) error {
+	for i, d := range dest {
+		if i >= len(r.vals) {
+			break
+		}
+		switch dp := d.(type) {
+		case *int64:
+			if v, ok := r.vals[i].(int64); ok {
+				*dp = v
+			}
+		case *string:
+			if v, ok := r.vals[i].(string); ok {
+				*dp = v
+			}
+		case **string:
+			if v, ok := r.vals[i].(*string); ok {
+				*dp = v
+			}
+		case *time.Time:
+			if v, ok := r.vals[i].(time.Time); ok {
+				*dp = v
+			}
+		case **time.Time:
+			if v, ok := r.vals[i].(*time.Time); ok {
+				*dp = v
+			}
+		}
+	}
+	return nil
+}
+
+// newScanRow constructs a scanRow for scanTokenRow (8 columns).
+func newScanRow(id int64, token string, obsolete *string, session, subject string, created, lastUsed, expires time.Time) *scanRow {
+	return &scanRow{vals: []any{id, token, obsolete, session, subject, created, lastUsed, expires}}
+}
+
+// newFullScanRow constructs a scanRow for scanFullTokenRow (9 columns, includes revokedAt).
+func newFullScanRow(id int64, token string, obsolete *string, session, subject string, created, lastUsed, expires time.Time, revokedAt *time.Time) *scanRow {
+	return &scanRow{vals: []any{id, token, obsolete, session, subject, created, lastUsed, expires, revokedAt}}
+}

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -129,15 +129,23 @@ type InvalidIndex struct {
 }
 
 // DetectInvalidIndexes queries pg_index for any indexes marked as invalid
-// (indisvalid = false). These can occur when CREATE INDEX CONCURRENTLY is
-// interrupted. The caller should log a warning and consider manual cleanup.
+// (indisvalid = false) within the current schema. These can occur when
+// CREATE INDEX CONCURRENTLY is interrupted. The caller should log a warning
+// and consider manual cleanup.
+//
+// The check is scoped to current_schema() so that indexes in other schemas
+// (e.g. parallel test schemas) do not block migrations in unrelated schemas.
 //
 // Returns an empty slice when no invalid indexes are found.
 func DetectInvalidIndexes(ctx context.Context, pool *Pool) ([]InvalidIndex, error) {
-	const q = `SELECT indexrelid::regclass::text AS index_name,
-		indrelid::regclass::text AS table_name
-		FROM pg_index
-		WHERE NOT indisvalid`
+	const q = `SELECT n.nspname || '.' || c.relname AS index_name,
+		t.relname AS table_name
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_class t ON t.oid = i.indrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE NOT i.indisvalid
+		  AND n.nspname = current_schema()`
 
 	rows, err := pool.inner.Query(ctx, q)
 	if err != nil {

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -133,12 +133,13 @@ type InvalidIndex struct {
 // CREATE INDEX CONCURRENTLY is interrupted. The caller should log a warning
 // and consider manual cleanup.
 //
-// The check is scoped to current_schema() so that indexes in other schemas
-// (e.g. parallel test schemas) do not block migrations in unrelated schemas.
+// The check is scoped to current_schema() so that in-progress CONCURRENTLY
+// builds in other schemas (e.g. parallel test schemas) do not block
+// migrations in unrelated schemas.
 //
 // Returns an empty slice when no invalid indexes are found.
 func DetectInvalidIndexes(ctx context.Context, pool *Pool) ([]InvalidIndex, error) {
-	const q = `SELECT n.nspname || '.' || c.relname AS index_name,
+	const q = `SELECT c.relname AS index_name,
 		t.relname AS table_name
 		FROM pg_index i
 		JOIN pg_class c ON c.oid = i.indexrelid

--- a/adapters/postgres/schema_guard_test.go
+++ b/adapters/postgres/schema_guard_test.go
@@ -41,9 +41,9 @@ func TestExpectedVersion_FromEmbedFS(t *testing.T) {
 	fsys := MigrationsFS()
 	v, err := ExpectedVersion(fsys)
 	require.NoError(t, err)
-	// Currently 10 migrations (001-010).
-	assert.Equal(t, int64(10), v,
-		"expected version should be exactly 10 (current migration count)")
+	// Currently 11 migrations (001-011).
+	assert.Equal(t, int64(11), v,
+		"expected version should be exactly 11 (current migration count)")
 }
 
 func TestExpectedVersion_SyntheticFS(t *testing.T) {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -119,11 +119,11 @@
 | X5 | **P3-TD-11 access-core domain 拆分** User/Session/Role | 4h | X1 | 历史 Batch 8 |
 | X9 | **LINT-MODERN-01** (Cx2, P3): 全仓库 modernization baseline 清理（rangeint / stringsseq / forvar / inline / testingcontext / any / nhooyr.io→coder/websocket）。独立 PR，不混入功能 | 6h | — | PR#163 post-review |
 | X10 | **AUTH-REFRESH-OPAQUE-01** (Cx3, 🟠 条件延后，X1 PG-DOMAIN-REPO 上线后触发): refresh token 由 JWT 改为 opaque string + server-side rotation store（RFC 6819 §5.2.2.2）；减小 JWT 承载、允许即时撤销 | 1-2d | `runtime/auth/` + `adapters/postgres/` 新 refresh_token_store | PR#166 R1-F2-7 |
-| X11 | **REFRESH-HMAC-SPLIT-01** (Cx3, 🟠 条件延后，F2-5 集成后): HMAC-split token 格式 (selector\|verifier)，DB 存 selector 明文 + SHA-256(verifier)。需 migration ALTER + Store 接口变更。防 DB 泄漏后 token 被直接使用 | 4h | `runtime/auth/refresh/` + `adapters/postgres/refresh_store.go` + migration | 开源对标 Hydra 双层防护 |
-| X12 | **REFRESH-IDLE-EXPIRE-01** (Cx2, 🟠 条件延后，F2-5 集成后): `idle_expires_at` 滑动窗口列 + Policy.MaxIdle。长时间未使用的 token 提前过期 | 3h | `runtime/auth/refresh/types.go` + `adapters/postgres/` + migration | 开源对标 Zitadel 双过期列 |
-| X13 | **REFRESH-PARTITION-01** (Cx2, 🟠 条件延后，高吞吐场景): `expires_at` range 分区，用 DROP PARTITION 替代批量 DELETE 进行 GC | 3h | migration + DBA ops runbook | 通用 PG 高吞吐模式 |
-| X14 | **REFRESH-GRACE-COUNTER-01** (Cx2, 🟠 条件延后，F2-5 集成后): `first_used_at` + `used_times` 列，grace 窗口内限制重用次数上限 | 2h | `adapters/postgres/refresh_store.go` + migration | 开源对标 Hydra COALESCE 模式 |
-| X15 | **REFRESH-OPAQUE-INTEGRATION-01** (Cx3, 🟠 条件延后，PG-DOMAIN-REPO 后): sessionrefresh/sessionlogin 切换 opaque token + 接线 access_module.go。替换当前 JWT refresh token 为 opaque + refresh.Store | 6h | `cells/access-core/slices/sessionrefresh/` + `cmd/core-bundle/access_module.go` | F2 plan 后续集成 |
+| X11 | **REFRESH-HMAC-SPLIT-01** (Cx3, 🟠 条件延后，**X15 之前必须完成**): HMAC-split token 格式 (selector\|verifier)，DB 存 selector 明文 + SHA-256(verifier)。需 migration ALTER + Store 接口变更。防 DB 泄漏后 token 被直接使用。**必须在 X15 上线前完成**——明文 token 入库后改格式需数据迁移 | 4h | `runtime/auth/refresh/` + `adapters/postgres/refresh_store.go` + migration | 开源对标 Hydra 双层防护 |
+| X12 | **REFRESH-IDLE-EXPIRE-01** (Cx2, 🟠 条件延后，X15 集成后): `idle_expires_at` 滑动窗口列 + Policy.MaxIdle。长时间未使用的 token 提前过期 | 3h | `runtime/auth/refresh/types.go` + `adapters/postgres/` + migration | 开源对标 Zitadel 双过期列 |
+| X13 | **REFRESH-PARTITION-01** (Cx2, 🟠 条件延后，生产流量达阈值后): `expires_at` range 分区，用 DROP PARTITION 替代批量 DELETE 进行 GC | 3h | migration + DBA ops runbook | 通用 PG 高吞吐模式 |
+| X14 | **REFRESH-GRACE-COUNTER-01** (Cx2, 🟠 条件延后，X15 集成后): `first_used_at` + `used_times` 列，grace 窗口内限制重用次数上限 | 2h | `adapters/postgres/refresh_store.go` + migration | 开源对标 Hydra COALESCE 模式 |
+| X15 | **REFRESH-OPAQUE-INTEGRATION-01** (Cx3, 🟠 条件延后，**X11 完成后**): sessionrefresh/sessionlogin 切换 opaque token + 接线 access_module.go。替换当前 JWT refresh token 为 opaque + refresh.Store。前置: X11 HMAC-split | 6h | `cells/access-core/slices/sessionrefresh/` + `cmd/core-bundle/access_module.go` | F2 plan 后续集成 |
 
 ---
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -119,6 +119,11 @@
 | X5 | **P3-TD-11 access-core domain 拆分** User/Session/Role | 4h | X1 | 历史 Batch 8 |
 | X9 | **LINT-MODERN-01** (Cx2, P3): 全仓库 modernization baseline 清理（rangeint / stringsseq / forvar / inline / testingcontext / any / nhooyr.io→coder/websocket）。独立 PR，不混入功能 | 6h | — | PR#163 post-review |
 | X10 | **AUTH-REFRESH-OPAQUE-01** (Cx3, 🟠 条件延后，X1 PG-DOMAIN-REPO 上线后触发): refresh token 由 JWT 改为 opaque string + server-side rotation store（RFC 6819 §5.2.2.2）；减小 JWT 承载、允许即时撤销 | 1-2d | `runtime/auth/` + `adapters/postgres/` 新 refresh_token_store | PR#166 R1-F2-7 |
+| X11 | **REFRESH-HMAC-SPLIT-01** (Cx3, 🟠 条件延后，F2-5 集成后): HMAC-split token 格式 (selector\|verifier)，DB 存 selector 明文 + SHA-256(verifier)。需 migration ALTER + Store 接口变更。防 DB 泄漏后 token 被直接使用 | 4h | `runtime/auth/refresh/` + `adapters/postgres/refresh_store.go` + migration | 开源对标 Hydra 双层防护 |
+| X12 | **REFRESH-IDLE-EXPIRE-01** (Cx2, 🟠 条件延后，F2-5 集成后): `idle_expires_at` 滑动窗口列 + Policy.MaxIdle。长时间未使用的 token 提前过期 | 3h | `runtime/auth/refresh/types.go` + `adapters/postgres/` + migration | 开源对标 Zitadel 双过期列 |
+| X13 | **REFRESH-PARTITION-01** (Cx2, 🟠 条件延后，高吞吐场景): `expires_at` range 分区，用 DROP PARTITION 替代批量 DELETE 进行 GC | 3h | migration + DBA ops runbook | 通用 PG 高吞吐模式 |
+| X14 | **REFRESH-GRACE-COUNTER-01** (Cx2, 🟠 条件延后，F2-5 集成后): `first_used_at` + `used_times` 列，grace 窗口内限制重用次数上限 | 2h | `adapters/postgres/refresh_store.go` + migration | 开源对标 Hydra COALESCE 模式 |
+| X15 | **REFRESH-OPAQUE-INTEGRATION-01** (Cx3, 🟠 条件延后，PG-DOMAIN-REPO 后): sessionrefresh/sessionlogin 切换 opaque token + 接线 access_module.go。替换当前 JWT refresh token 为 opaque + refresh.Store | 6h | `cells/access-core/slices/sessionrefresh/` + `cmd/core-bundle/access_module.go` | F2 plan 后续集成 |
 
 ---
 

--- a/docs/plans/202604191515-auth-federated-whistle.md
+++ b/docs/plans/202604191515-auth-federated-whistle.md
@@ -490,7 +490,7 @@ func (b *Bootstrapper) RegisterLifecycle(lc bootstrap.Lifecycle) {
 | PR-AUTH-F1-JWT-REGISTRY | F1 JWT 配置 Registry | S18 + S31 + S20 | 5h |
 | PR-AUTH-F7-PRINCIPAL | F7 Principal 统一契约 + Authenticator 接口 + handler authz 切换 | 审查 P1-A | 4h |
 | PR-AUTH-F3-SELECTOR | F3 Selector Builder + 移除 cmd/main.go 硬编码业务路径 | S35 彻底版 + S39 | 2h |
-| PR-AUTH-F2-REFRESH-PG | F2 Refresh token opaque + PG store + migration 007 | P1-17 + X10 一次到位 | 1.5d |
+| PR-AUTH-F2-REFRESH-PG | F2 Refresh token opaque + PG store + migration 007 | P1-17 + X10 一次到位 | 1.5d | **PG Store 已完成** PR#213 |
 | PR-AUTH-F4-ROUTEGROUP | F4 独立 listener + RouteGroup + merged-state e2e | R4 + S32 + PR#185 方案 C + 审查 P2-C | 1.5d |
 
 **Wave 0 顺序**（已锁定）：F5 → F6 → F1 → **F7** → F3 → F2 → F4
@@ -513,6 +513,33 @@ func (b *Bootstrapper) RegisterLifecycle(lc bootstrap.Lifecycle) {
 ### Wave 2 — 无（F2 Wave 0 已完工）
 
 ~~原计划 Wave 2 F2 PG 持久化~~ → 已并入 Wave 0 PR-AUTH-F2-REFRESH-PG 一次完工
+
+### F2 进度更新（2026-04-21）
+
+**已完成（PR#213）**：
+- `adapters/postgres/refresh_store.go` — PGRefreshStore 实现（Issue/Rotate/Revoke/GC）
+- `adapters/postgres/refresh_store_integration_test.go` — storetest 13 条契约测试 + migration 结构断言
+- `adapters/postgres/migrations/007_refresh_tokens.sql` — 移除 DEFAULT now()（Clock 注入）
+- `adapters/postgres/migrations/011_refresh_tokens_token_index.sql` — 非部分 token 索引（review P1 修复）
+- 开源对标 Hydra/Zitadel/Dex：CAS Rotate、分批 GC SKIP LOCKED、部分唯一索引
+
+**F2 后续工作（backlog X11-X15，已更新依赖顺序）**：
+
+```
+X11 HMAC-SPLIT (4h) ──→ X15 OPAQUE-INTEGRATION (6h) ──→ X12 IDLE-EXPIRE (3h)
+                                                    ──→ X14 GRACE-COUNTER (2h)
+                                                    ──→ X13 PARTITION (3h, 生产扩容时)
+```
+
+| # | ID | 工时 | 触发条件 | 说明 |
+|---|-----|------|---------|------|
+| X11 | REFRESH-HMAC-SPLIT-01 | 4h | PG store 已有 ✅ | **必须在 X15 之前**。HMAC-split token (selector\|verifier)，DB 存 selector 明文 + SHA-256(verifier)。明文 token 入库后改格式需数据迁移，ref: Hydra |
+| X15 | REFRESH-OPAQUE-INTEGRATION-01 | 6h | X11 完成后 | sessionrefresh/sessionlogin 切换 opaque token + 接线 access_module.go |
+| X12 | REFRESH-IDLE-EXPIRE-01 | 3h | X15 之后 | idle_expires_at 滑动窗口，ref: Zitadel |
+| X14 | REFRESH-GRACE-COUNTER-01 | 2h | X15 之后 | first_used_at + used_times 列，grace 窗口重用次数上限，ref: Hydra |
+| X13 | REFRESH-PARTITION-01 | 3h | 生产流量达阈值 | expires_at range 分区，DROP PARTITION 替代批量 DELETE |
+
+**关键依赖**：X11 必须在 X15 之前完成——一旦 X15 上线，明文 token 入库后改 HMAC-split 格式需要数据迁移。
 
 ---
 
@@ -706,6 +733,7 @@ D5  F4 merged-state e2e (0.5d)
   文件范围: runtime/auth/refresh/（新）+ adapters/postgres/refresh_store.go（新）+
     migrations/007_refresh_tokens.sql（新）+ sessionlogin/service.go + sessionrefresh/service.go + contract schema
   验证门禁: testcontainers 100 goroutine 并发 Rotate CAS；reuseInterval 窗口测试
+  状态（2026-04-21）: **PG Store 部分已完成** PR#213 合入。剩余: X11 HMAC-split → X15 service 集成（见上方 F2 后续工作）
   ────────────────────────────────────────
   #: 7
   PR: PR-AUTH-F4-ROUTEGROUP


### PR DESCRIPTION
## Summary
- Implements `adapters/postgres/refresh_store.go` — PostgreSQL backend for `runtime/auth/refresh.Store` interface (F2 from auth-federated-whistle plan)
- Five-branch CAS Rotate flow: active CAS UPDATE / revoked / expired / grace retry / reuse detection with cascade revoke
- Batched GC with `FOR UPDATE SKIP LOCKED` (Zitadel pattern) to avoid blocking concurrent Rotate
- Clock injection for storetest FakeClock compatibility — all timestamps via `clock.Now()`, no PG `now()`
- Migration 007: removed `DEFAULT now()` from `created_at`/`last_used` (never deployed, Store injects explicit values)
- Backlog additions (X11-X15): HMAC-split token hashing, idle expiration, range partitioning, grace counter, opaque token integration

## Open-source references
- **Hydra/Fosite**: CAS rotation pattern, graceful rotation with `first_used_at`/`used_times` (deferred to X14)
- **Zitadel**: Batched GC with `SKIP LOCKED` (adopted), dual expiration columns (deferred to X12)
- **Dex**: Single-generation obsolete invariant (adopted), plaintext token storage (adopted, HMAC-split deferred to X11)

## Key design decisions
| Decision | Choice | Reason |
|----------|--------|--------|
| Token storage | Plaintext (not hashed) | SHA-256 conflicts with grace-retry returning raw token; correct approach is HMAC-split (X11) |
| Transaction model | L1 self-managed tx (not Session/TxManager) | No outbox participation needed |
| Rotate concurrency | Row-level lock via CAS UPDATE WHERE | T10 concurrent CAS: 1 winner rotates, 99 grace-retry idempotently |
| GC | Batched DELETE + SKIP LOCKED | Avoids blocking Rotate queries during cleanup |

## Test plan
- [ ] `go test -tags integration ./adapters/postgres/... -run TestPGRefreshStore_ContractSuite -v` — all 13 contract tests (T1-T13)
- [ ] `go test ./runtime/auth/refresh/memstore/... -v` — oracle regression ✅
- [ ] `go test ./adapters/postgres/...` — existing unit tests ✅
- [ ] `go build -tags=integration ./adapters/postgres/...` — compilation ✅
- [ ] `golangci-lint run ./adapters/postgres/...` — 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)