### PR TITLE
fix(governance): FMT-15 enforce nextCursor + fail-closed + combinator detection

### DIFF
--- a/contracts/http/auth/role/list/v1/response.schema.json
+++ b/contracts/http/auth/role/list/v1/response.schema.json
@@ -27,6 +27,7 @@
         "additionalProperties": false
       }
     },
+    "nextCursor": { "type": "string" },
     "hasMore": { "type": "boolean" }
   },
   "required": ["data", "hasMore"]

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -557,7 +557,7 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 	if err != nil {
 		return nil // REF-12 handles missing files
 	}
-	info, ok := parseResponseSchema(data)
+	info, ok := parseListSchemaInfo(data)
 	if !ok || !isListSchema(info) {
 		return nil
 	}
@@ -587,16 +587,14 @@ type responseSchemaInfo struct {
 		Data struct {
 			Type string `json:"type"`
 		} `json:"data"`
-		// NextCursor is non-nil when "nextCursor" is declared in the schema properties.
-		// It must be declared (though not required) because PageResult uses omitempty:
-		// the field is absent on the last page and must not appear in required[].
+		// NextCursor is non-nil when the "nextCursor" property is declared in the schema.
 		NextCursor *json.RawMessage `json:"nextCursor"`
 	} `json:"properties"`
 	Required []string `json:"required"`
 }
 
-// parseResponseSchema unmarshals the minimal fields needed for list-lint checks.
-func parseResponseSchema(data []byte) (responseSchemaInfo, bool) {
+// parseListSchemaInfo unmarshals the minimal fields needed for list-lint checks.
+func parseListSchemaInfo(data []byte) (responseSchemaInfo, bool) {
 	var info responseSchemaInfo
 	if err := json.Unmarshal(data, &info); err != nil {
 		return info, false
@@ -605,6 +603,9 @@ func parseResponseSchema(data []byte) (responseSchemaInfo, bool) {
 }
 
 // isListSchema checks if a JSON schema has properties.data.type == "array".
+// Note: dual-mode schemas that use oneOf/anyOf instead of a top-level
+// "type":"array" on properties.data are not detected here and are silently
+// skipped by FMT-15. Such schemas require manual review at the contract level.
 func isListSchema(info responseSchemaInfo) bool {
 	return info.Properties.Data.Type == "array"
 }
@@ -619,7 +620,10 @@ func hasMoreInRequired(info responseSchemaInfo) bool {
 	return false
 }
 
-// hasNextCursorProperty checks if "nextCursor" is declared in the schema properties.
+// hasNextCursorProperty checks if "nextCursor" is declared as a schema property.
+// The field must be declared (though not in required[]) because PageResult uses
+// omitempty: nextCursor is absent from last-page responses and must not be required.
+// A "nextCursor": null declaration is treated as absent (null is not a valid schema).
 func hasNextCursorProperty(info responseSchemaInfo) bool {
-	return info.Properties.NextCursor != nil
+	return info.Properties.NextCursor != nil && string(*info.Properties.NextCursor) != "null"
 }

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -527,6 +527,9 @@ func (v *Validator) validateFMT14() []ValidationResult {
 	return results
 }
 
+// codeFMT15 is the rule code for HTTP list response schema validation.
+const codeFMT15 = "FMT-15"
+
 // validateFMT15 checks that HTTP list-style response schemas:
 //   - include "hasMore" in required fields
 //   - declare "nextCursor" as a property (not required, because PageResult uses omitempty)
@@ -561,7 +564,7 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 			return nil // REF-12 handles missing files
 		}
 		return []ValidationResult{v.newResult(
-			"FMT-15", SeverityError, IssueInvalid,
+			codeFMT15, SeverityError, IssueInvalid,
 			contractFile(c.ID), fieldSchemaRefsResponse,
 			fmt.Sprintf("cannot read response schema for contract %q: %v", c.ID, err),
 		)}
@@ -569,14 +572,14 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 	info, err := parseListSchemaInfo(data)
 	if err != nil {
 		return []ValidationResult{v.newResult(
-			"FMT-15", SeverityError, IssueInvalid,
+			codeFMT15, SeverityError, IssueInvalid,
 			contractFile(c.ID), fieldSchemaRefsResponse,
 			fmt.Sprintf("response schema for contract %q is not valid JSON: %v", c.ID, err),
 		)}
 	}
 	if hasCombinator(info) && looksLikeListSchema(info) {
 		return []ValidationResult{v.newResult(
-			"FMT-15", SeverityWarning, IssueInvalid,
+			codeFMT15, SeverityWarning, IssueInvalid,
 			contractFile(c.ID), fieldSchemaRefsResponse,
 			fmt.Sprintf("response schema for contract %q uses oneOf/anyOf/allOf: FMT-15 cannot verify list constraints; split into single-shape contracts", c.ID),
 		)}
@@ -587,7 +590,7 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 	var results []ValidationResult
 	if !hasMoreInRequired(info) {
 		results = append(results, v.newResult(
-			"FMT-15", SeverityError, IssueRequired,
+			codeFMT15, SeverityError, IssueRequired,
 			contractFile(c.ID),
 			fieldSchemaRefsResponse,
 			fmt.Sprintf("list response schema for contract %q must include \"hasMore\" in required fields", c.ID),
@@ -595,7 +598,7 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 	}
 	if !hasNextCursorProperty(info) {
 		results = append(results, v.newResult(
-			"FMT-15", SeverityError, IssueRequired,
+			codeFMT15, SeverityError, IssueRequired,
 			contractFile(c.ID),
 			fieldSchemaRefsResponse,
 			fmt.Sprintf("list response schema for contract %q must declare \"nextCursor\" property (omit from required; PageResult omits it on last page)", c.ID),

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -2,7 +2,9 @@ package governance
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -543,7 +545,7 @@ func (v *Validator) validateFMT15() []ValidationResult {
 }
 
 // checkFMT15Contract validates a single contract's list response schema for FMT-15.
-// Returns one error per violated constraint.
+// Returns one result per violated constraint.
 func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationResult {
 	if c.Kind != "http" || c.SchemaRefs.Response == "" {
 		return nil
@@ -555,10 +557,31 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 	}
 	data, err := v.readFile(schemaPath)
 	if err != nil {
-		return nil // REF-12 handles missing files
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // REF-12 handles missing files
+		}
+		return []ValidationResult{v.newResult(
+			"FMT-15", SeverityError, IssueInvalid,
+			contractFile(c.ID), fieldSchemaRefsResponse,
+			fmt.Sprintf("cannot read response schema for contract %q: %v", c.ID, err),
+		)}
 	}
-	info, ok := parseListSchemaInfo(data)
-	if !ok || !isListSchema(info) {
+	info, err := parseListSchemaInfo(data)
+	if err != nil {
+		return []ValidationResult{v.newResult(
+			"FMT-15", SeverityError, IssueInvalid,
+			contractFile(c.ID), fieldSchemaRefsResponse,
+			fmt.Sprintf("response schema for contract %q is not valid JSON: %v", c.ID, err),
+		)}
+	}
+	if hasCombinator(info) && looksLikeListSchema(info) {
+		return []ValidationResult{v.newResult(
+			"FMT-15", SeverityWarning, IssueInvalid,
+			contractFile(c.ID), fieldSchemaRefsResponse,
+			fmt.Sprintf("response schema for contract %q uses oneOf/anyOf/allOf: FMT-15 cannot verify list constraints; split into single-shape contracts", c.ID),
+		)}
+	}
+	if !isListSchema(info) {
 		return nil
 	}
 	var results []ValidationResult
@@ -589,25 +612,41 @@ type responseSchemaInfo struct {
 		} `json:"data"`
 		// NextCursor is non-nil when the "nextCursor" property is declared in the schema.
 		NextCursor *json.RawMessage `json:"nextCursor"`
+		// HasMore is non-nil when the "hasMore" property is declared in the schema.
+		HasMore *json.RawMessage `json:"hasMore"`
 	} `json:"properties"`
 	Required []string `json:"required"`
+	// Combinator fields: non-nil when the schema uses oneOf/anyOf/allOf at the root level.
+	OneOf *json.RawMessage `json:"oneOf"`
+	AnyOf *json.RawMessage `json:"anyOf"`
+	AllOf *json.RawMessage `json:"allOf"`
 }
 
 // parseListSchemaInfo unmarshals the minimal fields needed for list-lint checks.
-func parseListSchemaInfo(data []byte) (responseSchemaInfo, bool) {
+// Returns an error if data is not valid JSON.
+func parseListSchemaInfo(data []byte) (responseSchemaInfo, error) {
 	var info responseSchemaInfo
 	if err := json.Unmarshal(data, &info); err != nil {
-		return info, false
+		return info, err
 	}
-	return info, true
+	return info, nil
 }
 
 // isListSchema checks if a JSON schema has properties.data.type == "array".
-// Note: dual-mode schemas that use oneOf/anyOf instead of a top-level
-// "type":"array" on properties.data are not detected here and are silently
-// skipped by FMT-15. Such schemas require manual review at the contract level.
 func isListSchema(info responseSchemaInfo) bool {
 	return info.Properties.Data.Type == "array"
+}
+
+// hasCombinator reports whether the schema uses oneOf/anyOf/allOf at the root level.
+func hasCombinator(info responseSchemaInfo) bool {
+	return info.OneOf != nil || info.AnyOf != nil || info.AllOf != nil
+}
+
+// looksLikeListSchema reports whether a schema appears list-related by checking
+// whether "hasMore" or "nextCursor" are declared in the top-level properties.
+// Used together with hasCombinator to avoid false positives on non-list schemas.
+func looksLikeListSchema(info responseSchemaInfo) bool {
+	return info.Properties.HasMore != nil || hasNextCursorProperty(info)
 }
 
 // hasMoreInRequired checks if "hasMore" is in the JSON schema required array.

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -525,8 +525,11 @@ func (v *Validator) validateFMT14() []ValidationResult {
 	return results
 }
 
-// validateFMT15 checks that HTTP list-style response schemas include "hasMore"
-// in their required fields. A response is a "list" when properties.data.type is "array".
+// validateFMT15 checks that HTTP list-style response schemas:
+//   - include "hasMore" in required fields
+//   - declare "nextCursor" as a property (not required, because PageResult uses omitempty)
+//
+// A response is a "list" when properties.data.type is "array".
 // Skipped when root is empty, for non-HTTP contracts, or when the schema file cannot be read.
 func (v *Validator) validateFMT15() []ValidationResult {
 	if v.root == "" {
@@ -534,33 +537,46 @@ func (v *Validator) validateFMT15() []ValidationResult {
 	}
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
-		if c.Kind != "http" || c.SchemaRefs.Response == "" {
-			continue
-		}
-		contractDir := filepath.Join(v.root, contractDirFromID(c.ID))
-		schemaPath := filepath.Join(contractDir, c.SchemaRefs.Response)
-		if !IsWithinRoot(v.root, schemaPath) {
-			continue
-		}
-		data, err := v.readFile(schemaPath)
-		if err != nil {
-			continue // REF-12 handles missing files
-		}
-		info, ok := parseResponseSchema(data)
-		if !ok {
-			continue
-		}
-		if !isListSchema(info) {
-			continue
-		}
-		if !hasMoreInRequired(info) {
-			results = append(results, v.newResult(
-				"FMT-15", SeverityError, IssueRequired,
-				contractFile(c.ID),
-				fieldSchemaRefsResponse,
-				fmt.Sprintf("list response schema for contract %q must include \"hasMore\" in required fields", c.ID),
-			))
-		}
+		results = append(results, v.checkFMT15Contract(c)...)
+	}
+	return results
+}
+
+// checkFMT15Contract validates a single contract's list response schema for FMT-15.
+// Returns one error per violated constraint.
+func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationResult {
+	if c.Kind != "http" || c.SchemaRefs.Response == "" {
+		return nil
+	}
+	contractDir := filepath.Join(v.root, contractDirFromID(c.ID))
+	schemaPath := filepath.Join(contractDir, c.SchemaRefs.Response)
+	if !IsWithinRoot(v.root, schemaPath) {
+		return nil
+	}
+	data, err := v.readFile(schemaPath)
+	if err != nil {
+		return nil // REF-12 handles missing files
+	}
+	info, ok := parseResponseSchema(data)
+	if !ok || !isListSchema(info) {
+		return nil
+	}
+	var results []ValidationResult
+	if !hasMoreInRequired(info) {
+		results = append(results, v.newResult(
+			"FMT-15", SeverityError, IssueRequired,
+			contractFile(c.ID),
+			fieldSchemaRefsResponse,
+			fmt.Sprintf("list response schema for contract %q must include \"hasMore\" in required fields", c.ID),
+		))
+	}
+	if !hasNextCursorProperty(info) {
+		results = append(results, v.newResult(
+			"FMT-15", SeverityError, IssueRequired,
+			contractFile(c.ID),
+			fieldSchemaRefsResponse,
+			fmt.Sprintf("list response schema for contract %q must declare \"nextCursor\" property (omit from required; PageResult omits it on last page)", c.ID),
+		))
 	}
 	return results
 }
@@ -571,6 +587,10 @@ type responseSchemaInfo struct {
 		Data struct {
 			Type string `json:"type"`
 		} `json:"data"`
+		// NextCursor is non-nil when "nextCursor" is declared in the schema properties.
+		// It must be declared (though not required) because PageResult uses omitempty:
+		// the field is absent on the last page and must not appear in required[].
+		NextCursor *json.RawMessage `json:"nextCursor"`
 	} `json:"properties"`
 	Required []string `json:"required"`
 }
@@ -597,4 +617,9 @@ func hasMoreInRequired(info responseSchemaInfo) bool {
 		}
 	}
 	return false
+}
+
+// hasNextCursorProperty checks if "nextCursor" is declared in the schema properties.
+func hasNextCursorProperty(info responseSchemaInfo) bool {
+	return info.Properties.NextCursor != nil
 }

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -3380,11 +3380,12 @@ func TestFMT15(t *testing.T) {
 	invalidJSON := `{not json`
 
 	tests := []struct {
-		name      string
-		emptyRoot bool // when true, Validator is created with root=""
-		setup     func(*metadata.ProjectMeta)
-		readFile  func(string) ([]byte, error)
-		wantCount int
+		name         string
+		emptyRoot    bool // when true, Validator is created with root=""
+		setup        func(*metadata.ProjectMeta)
+		readFile     func(string) ([]byte, error)
+		wantCount    int
+		wantSeverity Severity // if non-empty, each result must have this severity; defaults to SeverityError
 	}{
 		{
 			name: "list schema with hasMore in required and nextCursor in properties",
@@ -3445,7 +3446,7 @@ func TestFMT15(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name: "file read error skipped gracefully",
+			name: "file read ErrNotExist skipped (REF-12 handles)",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
@@ -3453,11 +3454,52 @@ func TestFMT15(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name: "invalid JSON skipped",
+			name: "file read non-ENOENT IO error reports FMT-15",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return nil, os.ErrPermission },
+			wantCount: 1,
+		},
+		{
+			name: "invalid JSON reports FMT-15",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
 			readFile:  func(_ string) ([]byte, error) { return []byte(invalidJSON), nil },
+			wantCount: 1,
+		},
+		{
+			name: "list-like schema with oneOf combinator reports FMT-15 warning",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile: func(_ string) ([]byte, error) {
+				return []byte(`{"properties":{"data":{},"nextCursor":{"type":"string"},"hasMore":{"type":"boolean"}},"oneOf":[{"properties":{"data":{"type":"object"}}},{"properties":{"data":{"type":"array"}}}]}`), nil
+			},
+			wantCount:    1,
+			wantSeverity: SeverityWarning,
+		},
+		{
+			name: "list-like schema with anyOf combinator reports FMT-15 warning",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile: func(_ string) ([]byte, error) {
+				return []byte(`{"properties":{"data":{},"hasMore":{"type":"boolean"}},"anyOf":[{"properties":{"data":{"type":"array"}}}]}`), nil
+			},
+			wantCount:    1,
+			wantSeverity: SeverityWarning,
+		},
+		{
+			name: "non-list combinator schema silently skipped",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile: func(_ string) ([]byte, error) {
+				// combinator but no hasMore/nextCursor at top level → not list-related
+				return []byte(`{"properties":{"data":{}},"oneOf":[{"properties":{"data":{"type":"string"}}},{"properties":{"data":{"type":"integer"}}}]}`), nil
+			},
 			wantCount: 0,
 		},
 		{
@@ -3492,8 +3534,12 @@ func TestFMT15(t *testing.T) {
 			}
 			got := findByCode(val.validateFMT15(), "FMT-15")
 			assert.Len(t, got, tt.wantCount)
+			wantSev := tt.wantSeverity
+			if wantSev == "" {
+				wantSev = SeverityError
+			}
 			for _, r := range got {
-				assert.Equal(t, SeverityError, r.Severity)
+				assert.Equal(t, wantSev, r.Severity)
 			}
 		})
 	}

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -3381,6 +3381,7 @@ func TestFMT15(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		emptyRoot bool // when true, Validator is created with root=""
 		setup     func(*metadata.ProjectMeta)
 		readFile  func(string) ([]byte, error)
 		wantCount int
@@ -3410,6 +3411,16 @@ func TestFMT15(t *testing.T) {
 			wantCount: 1,
 		},
 		{
+			name: "list schema missing both hasMore and nextCursor",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile: func(_ string) ([]byte, error) {
+				return []byte(`{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data"]}`), nil
+			},
+			wantCount: 2,
+		},
+		{
 			name: "non-list schema skipped",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
@@ -3422,6 +3433,16 @@ func TestFMT15(t *testing.T) {
 			setup:     func(_ *metadata.ProjectMeta) {},
 			readFile:  nil,
 			wantCount: 0,
+		},
+		{
+			name: "nextCursor declared as null is not a valid property",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile: func(_ string) ([]byte, error) {
+				return []byte(`{"properties":{"data":{"type":"array"},"nextCursor":null},"required":["data","hasMore"]}`), nil
+			},
+			wantCount: 1,
 		},
 		{
 			name: "file read error skipped gracefully",
@@ -3448,12 +3469,13 @@ func TestFMT15(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name: "empty root skipped",
+			name:      "empty root skipped",
+			emptyRoot: true, // root="" causes early return in validateFMT15
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
 			readFile:  func(_ string) ([]byte, error) { return []byte(missingHasMore), nil },
-			wantCount: 0, // root="" causes early return
+			wantCount: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -3461,7 +3483,7 @@ func TestFMT15(t *testing.T) {
 			pm := validProject()
 			tt.setup(pm)
 			root := "/fake/root"
-			if tt.name == "empty root skipped" {
+			if tt.emptyRoot {
 				root = ""
 			}
 			val := NewValidator(pm, root)

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -3367,11 +3367,15 @@ func TestFMT14(t *testing.T) {
 	}
 }
 
-// --- FMT-15: list response schema must include hasMore ---
+// --- FMT-15: list response schema must include hasMore in required and declare nextCursor in properties ---
 
 func TestFMT15(t *testing.T) {
-	validListSchema := `{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data","hasMore"]}`
-	missingHasMore := `{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data"]}`
+	// valid: nextCursor declared in properties, hasMore in required
+	validListSchema := `{"properties":{"data":{"type":"array","items":{"type":"object"}},"nextCursor":{"type":"string"}},"required":["data","hasMore"]}`
+	// missing hasMore from required (nextCursor still in properties)
+	missingHasMore := `{"properties":{"data":{"type":"array","items":{"type":"object"}},"nextCursor":{"type":"string"}},"required":["data"]}`
+	// missing nextCursor from properties (hasMore still in required)
+	missingNextCursor := `{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data","hasMore"]}`
 	singleObject := `{"properties":{"data":{"type":"object"}},"required":["data"]}`
 	invalidJSON := `{not json`
 
@@ -3382,7 +3386,7 @@ func TestFMT15(t *testing.T) {
 		wantCount int
 	}{
 		{
-			name: "list schema with hasMore in required",
+			name: "list schema with hasMore in required and nextCursor in properties",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
@@ -3395,6 +3399,14 @@ func TestFMT15(t *testing.T) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
 			readFile:  func(_ string) ([]byte, error) { return []byte(missingHasMore), nil },
+			wantCount: 1,
+		},
+		{
+			name: "list schema missing nextCursor in properties",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(missingNextCursor), nil },
 			wantCount: 1,
 		},
 		{


### PR DESCRIPTION
## Problem

FMT-15 only enforced `hasMore` in the `required` array of HTTP list response schemas. Three gaps:
1. `nextCursor` was entirely unchecked — a schema could omit it with no governance error
2. Unreadable files and invalid JSON were silently skipped (fail-open)
3. Schemas using `oneOf`/`anyOf`/`allOf` were skipped with no signal

## Design decisions

**nextCursor in properties, not required[]**: `pkg/query/PageResult` uses `json:"nextCursor,omitempty"` — the field is absent from last-page responses. Adding it to `required[]` would break schema validation for last-page responses. We check it is *declared* as a property instead.

**combinator → SeverityWarning**: A schema with `oneOf`/`anyOf`/`allOf` is unsupported for list-shape detection. Rather than silently skipping (invisible) or hard-erroring (forces schema split in same PR), emit a Warning so CI surfaces the issue without blocking. Triggered only when the schema also has list-related signals (`hasMore`/`nextCursor` in top-level properties).

**fail-closed on I/O/JSON errors**: `os.ErrNotExist` is the only silent skip path (REF-12 handles missing files). All other I/O errors and invalid JSON produce FMT-15 errors.

## Changes

### `kernel/governance/rules_fmt.go`
- `responseSchemaInfo` gains `NextCursor`/`HasMore` property fields and `OneOf`/`AnyOf`/`AllOf` combinator fields
- `parseListSchemaInfo` returns `error` instead of `bool`
- Extracts `checkFMT15Contract` (keeps `validateFMT15` cognitive complexity ≤ 15)
- New helpers: `hasNextCursorProperty`, `hasCombinator`, `looksLikeListSchema`
- `hasMoreInRequired` retained, `hasNextCursorProperty` added with null-guard
- Renamed `parseResponseSchema` → `parseListSchemaInfo` for clarity
- `isListSchema` documents dual-mode schema (oneOf) as known blind spot

### `kernel/governance/validate_test.go`
- `wantSeverity` field added to test struct (defaults to `SeverityError`)
- `emptyRoot bool` field replaces string-matched root condition
- 17 subtests total (was 11): added `missingNextCursor`, `missingBoth`, `null-property`, `file IO error`, `invalid JSON error`, `oneOf warning`, `anyOf warning`, `non-list combinator skip`

### `contracts/http/auth/role/list/v1/response.schema.json`
- Adds missing `"nextCursor": { "type": "string" }` property declaration

## Known limitation

`contracts/http/config/get/v1/response.schema.json` uses `oneOf` (dual-mode: single-entry + list). FMT-15 emits a Warning on this schema. The fix (split into `http.config.get.v1` + `http.config.list.v1`) is tracked in backlog as **CONFIG-GET-DUAL-MODE-SPLIT-01**.

## Test plan
- [x] `go test ./kernel/governance/... -run TestFMT15` — 17/17 subtests pass
- [x] `golangci-lint run ./kernel/governance/...` — 0 issues in changed files
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)