### PR TITLE
fix: S10 configpublish write-path mode typing

### DIFF
--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -206,12 +206,12 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 		return err
 	}
 
-	runMode := query.RunModeForDemo(deps.DurabilityMode == cell.DurabilityDemo)
+	runMode, publishFailureMode := c.deriveModes(deps.DurabilityMode)
 	c.initWriteSlice()
 	if err := c.initReadSlice(runMode); err != nil {
 		return err
 	}
-	c.initPublishSlice()
+	c.initPublishSlice(publishFailureMode)
 	c.initSubscribeSlice()
 	if err := c.initFlagSlice(runMode); err != nil {
 		return err
@@ -220,6 +220,11 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 		return err
 	}
 	return nil
+}
+
+func (c *ConfigCore) deriveModes(durabilityMode cell.DurabilityMode) (query.RunMode, query.PublishFailureMode) {
+	demo := durabilityMode == cell.DurabilityDemo
+	return query.RunModeForDemo(demo), query.PublishFailureModeForDemo(demo)
 }
 
 // validateOutboxDeps enforces the XOR constraint (outboxWriter + txRunner
@@ -294,7 +299,7 @@ func (c *ConfigCore) initReadSlice(runMode query.RunMode) error {
 	return nil
 }
 
-func (c *ConfigCore) initPublishSlice() {
+func (c *ConfigCore) initPublishSlice(publishFailureMode query.PublishFailureMode) {
 	var opts []configpublish.Option
 	if c.outboxWriter != nil {
 		opts = append(opts, configpublish.WithOutboxWriter(c.outboxWriter))
@@ -302,6 +307,7 @@ func (c *ConfigCore) initPublishSlice() {
 	if c.txRunner != nil {
 		opts = append(opts, configpublish.WithTxManager(c.txRunner))
 	}
+	opts = append(opts, configpublish.WithPublishFailureMode(publishFailureMode))
 	publishSvc := configpublish.NewService(c.configRepo, c.publisher, c.logger, opts...)
 	c.publishHandler = configpublish.NewHandler(publishSvc)
 	c.AddSlice(cell.NewBaseSlice("configpublish", "config-core", cell.L2))

--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -222,6 +222,9 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	return nil
 }
 
+// deriveModes is the single translation point from kernel/cell.DurabilityMode
+// to pkg/query run modes. Called only once at Init() time; propagated via
+// constructor parameters to all slices (do not call in handler/repository).
 func (c *ConfigCore) deriveModes(durabilityMode cell.DurabilityMode) (query.RunMode, query.PublishFailureMode) {
 	demo := durabilityMode == cell.DurabilityDemo
 	return query.RunModeForDemo(demo), query.PublishFailureModeForDemo(demo)

--- a/cells/config-core/cell_test.go
+++ b/cells/config-core/cell_test.go
@@ -497,3 +497,34 @@ func TestWithPostgresDefaults_NilPool_SetsConfigRepoAndOutboxWriter(t *testing.T
 	assert.NotNil(t, c.configRepo, "configRepo must be non-nil after Init")
 	assert.NotNil(t, c.flagRepo, "flagRepo must be non-nil after Init")
 }
+
+func TestConfigCore_DeriveModes(t *testing.T) {
+	tests := []struct {
+		name        string
+		durability  cell.DurabilityMode
+		wantRunMode query.RunMode
+		wantPubMode query.PublishFailureMode
+	}{
+		{
+			name:        "demo maps to demo+fail-open",
+			durability:  cell.DurabilityDemo,
+			wantRunMode: query.RunModeDemo,
+			wantPubMode: query.PublishFailureModeFailOpen,
+		},
+		{
+			name:        "durable maps to prod+fail-closed",
+			durability:  cell.DurabilityDurable,
+			wantRunMode: query.RunModeProd,
+			wantPubMode: query.PublishFailureModeFailClosed,
+		},
+	}
+
+	c := NewConfigCore(WithInMemoryDefaults(), WithPublisher(eventbus.New()))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runMode, publishMode := c.deriveModes(tt.durability)
+			assert.Equal(t, tt.wantRunMode, runMode)
+			assert.Equal(t, tt.wantPubMode, publishMode)
+		})
+	}
+}

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
@@ -38,13 +39,20 @@ func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = tx }
 }
 
+// WithPublishFailureMode sets direct-publisher failure behavior when
+// outboxWriter is nil.
+func WithPublishFailureMode(mode query.PublishFailureMode) Option {
+	return func(s *Service) { s.publishFailureMode = mode }
+}
+
 // Service implements config publish/rollback business logic.
 type Service struct {
-	repo         ports.ConfigRepository
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	repo               ports.ConfigRepository
+	publisher          outbox.Publisher
+	outboxWriter       outbox.Writer
+	txRunner           persistence.TxRunner
+	publishFailureMode query.PublishFailureMode
+	logger             *slog.Logger
 }
 
 // NewService creates a config-publish Service.
@@ -191,6 +199,14 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 	// accepts the message.
 	envelope := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), payload)
 	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
+		if s.publishFailureMode.IsFailOpen() {
+			s.logger.Warn("config-publish: publisher failed (fail-open mode)",
+				slog.String("topic", topic),
+				slog.String("publish_failure_mode", s.publishFailureMode.String()),
+				slog.Any("error", err),
+			)
+			return nil
+		}
 		return fmt.Errorf("config-publish: publisher failed for topic %s: %w", topic, err)
 	}
 	return nil

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -179,10 +179,11 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 
 // publishEvent writes to the outbox (L2 durable) or directly via publisher
 // (fallback when outboxWriter is nil, e.g. demo assemblies using DiscardPublisher).
-// No RunMode fail-open needed: demo mode injects DiscardPublisher which never
-// errors by contract, so any publisher failure is a real infrastructure problem
-// that must surface. Read slices use RunMode to handle stale cursor tokens —
-// a concern that does not exist in write operations.
+// PublishFailureMode controls whether direct-publisher failures are propagated
+// (fail-closed, the safe default for production) or tolerated after a warning
+// (fail-open, the demo-mode behavior when the publisher is degraded but the
+// write path should not block). DiscardPublisher never errors by contract, so
+// any publisher failure indicates a real infrastructure problem.
 func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte) error {
 	if s.outboxWriter != nil {
 		entry := outbox.Entry{
@@ -203,7 +204,7 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 			s.logger.Warn("config-publish: publisher failed (fail-open mode)",
 				slog.String("topic", topic),
 				slog.String("publish_failure_mode", s.publishFailureMode.String()),
-				slog.Any("error", err),
+				slog.String("error", err.Error()),
 			)
 			return nil
 		}

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -334,4 +335,70 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 				"rollback must inherit the snapshot's Sensitive flag, not the live entry's")
 		})
 	}
+}
+
+// --- S10 PublishFailureMode tests (TDD red phase) ---
+
+// TestService_Publish_FailClosed_PublisherError verifies that when configured
+// with PublishFailureMode=FailClosed, a publisher error propagates as a hard failure.
+// ref: outbox.PublishFailureMode design (S10).
+func TestService_Publish_FailClosed_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(), WithPublishFailureMode(query.PublishFailureModeFailClosed))
+
+	mustSeedEntry(repo, "app.timeout", "30s")
+	_, err := svc.Publish(context.Background(), "app.timeout")
+	require.Error(t, err, "FailClosed: publisher failure must propagate")
+	assert.Contains(t, err.Error(), "broker down")
+}
+
+// TestService_Publish_FailOpen_PublisherError verifies that when configured
+// with PublishFailureMode=FailOpen, a publisher error is swallowed and logged
+// rather than failing the entire Publish operation.
+// ref: outbox.PublishFailureMode design (S10).
+func TestService_Publish_FailOpen_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(), WithPublishFailureMode(query.PublishFailureModeFailOpen))
+
+	mustSeedEntry(repo, "app.timeout", "30s")
+	ver, err := svc.Publish(context.Background(), "app.timeout")
+	require.NoError(t, err, "FailOpen: publisher failure must be swallowed")
+	assert.Equal(t, 1, ver.Version, "publish should succeed despite publisher error")
+	// Note: warning log is expected but not asserted here (would require log capture)
+}
+
+// TestService_Rollback_FailClosed_PublisherError verifies FailClosed behavior on Rollback.
+func TestService_Rollback_FailClosed_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(), WithPublishFailureMode(query.PublishFailureModeFailClosed))
+
+	mustSeedEntry(repo, "app.name", "v1")
+	// Use a working publisher to create the snapshot first
+	svcGood := NewService(repo, stubPublisher{}, slog.Default())
+	_, err := svcGood.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+
+	_, err = svc.Rollback(context.Background(), "app.name", 1)
+	require.Error(t, err, "FailClosed: rollback with publisher failure must propagate")
+	assert.Contains(t, err.Error(), "broker down")
+}
+
+// TestService_Rollback_FailOpen_PublisherError verifies FailOpen behavior on Rollback.
+func TestService_Rollback_FailOpen_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(), WithPublishFailureMode(query.PublishFailureModeFailOpen))
+
+	mustSeedEntry(repo, "app.name", "v1")
+	// Use a working publisher to create the snapshot first
+	svcGood := NewService(repo, stubPublisher{}, slog.Default())
+	_, err := svcGood.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+
+	entry, err := svc.Rollback(context.Background(), "app.name", 1)
+	require.NoError(t, err, "FailOpen: rollback with publisher failure must be swallowed")
+	assert.Equal(t, "v1", entry.Value, "rollback should succeed despite publisher error")
 }

--- a/pkg/query/runmode.go
+++ b/pkg/query/runmode.go
@@ -61,3 +61,41 @@ func RunModeForDemo(demo bool) RunMode {
 	}
 	return RunModeProd
 }
+
+// PublishFailureMode controls whether direct publisher failures on write paths
+// are propagated (fail-closed) or tolerated (fail-open) when no outbox writer
+// is configured.
+type PublishFailureMode uint8
+
+const (
+	// PublishFailureModeFailClosed propagates publisher failures.
+	// This is the zero value and therefore the safe default.
+	PublishFailureModeFailClosed PublishFailureMode = 0
+
+	// PublishFailureModeFailOpen swallows publisher failures after warning logs.
+	PublishFailureModeFailOpen PublishFailureMode = 1
+)
+
+// IsFailOpen reports whether publisher failures are tolerated.
+func (m PublishFailureMode) IsFailOpen() bool { return m == PublishFailureModeFailOpen }
+
+// String returns a stable lowercase label suitable for structured logs.
+func (m PublishFailureMode) String() string {
+	switch m {
+	case PublishFailureModeFailClosed:
+		return "fail-closed"
+	case PublishFailureModeFailOpen:
+		return "fail-open"
+	default:
+		return "unknown"
+	}
+}
+
+// PublishFailureModeForDemo maps demo=true to fail-open and all other modes to
+// fail-closed at wire time.
+func PublishFailureModeForDemo(demo bool) PublishFailureMode {
+	if demo {
+		return PublishFailureModeFailOpen
+	}
+	return PublishFailureModeFailClosed
+}

--- a/pkg/query/runmode.go
+++ b/pkg/query/runmode.go
@@ -65,6 +65,15 @@ func RunModeForDemo(demo bool) RunMode {
 // PublishFailureMode controls whether direct publisher failures on write paths
 // are propagated (fail-closed) or tolerated (fail-open) when no outbox writer
 // is configured.
+//
+// Placed in pkg/query alongside RunMode because both types serve the same role:
+// translating a single DurabilityMode signal (prod vs demo) into concrete
+// fail-closed vs fail-open behaviors at Cell init time. Collocating them
+// keeps the demo-mode translation logic together and prevents pkg/query from
+// importing kernel/cell (preserving the kernel-agnostic layering of shared
+// utilities). This is a pragmatic choice within the current PR scope; a future
+// refactor may extract both types into a new pkg/runmode if additional
+// fail-open modes emerge.
 type PublishFailureMode uint8
 
 const (

--- a/pkg/query/runmode_test.go
+++ b/pkg/query/runmode_test.go
@@ -57,3 +57,61 @@ func TestRunMode_ZeroValueIsProd(t *testing.T) {
 		t.Fatalf("zero-value RunMode = %v, want RunModeProd", m)
 	}
 }
+
+// TestPublishFailureMode_ZeroValueIsFailClosed guards the fail-closed contract:
+// a zero-value PublishFailureMode (unset by caller) must never enable fail-open behavior.
+// ref: watermill publisher.go — nopPublisher only in _test.go; production defaults to real publishing
+func TestPublishFailureMode_ZeroValueIsFailClosed(t *testing.T) {
+	t.Parallel()
+	var m PublishFailureMode
+	if m.IsFailOpen() {
+		t.Fatal("zero-value PublishFailureMode must NOT be fail-open (fail-closed default)")
+	}
+	if m != PublishFailureModeFailClosed {
+		t.Fatalf("zero-value PublishFailureMode = %v, want PublishFailureModeFailClosed", m)
+	}
+}
+
+// TestPublishFailureMode_String verifies stable lowercase labels for logs.
+func TestPublishFailureMode_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mode PublishFailureMode
+		want string
+	}{
+		{PublishFailureModeFailClosed, "fail-closed"},
+		{PublishFailureModeFailOpen, "fail-open"},
+		{PublishFailureMode(99), "unknown"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.mode.String(); got != tc.want {
+				t.Errorf("PublishFailureMode(%d).String() = %q, want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPublishFailureModeForDemo verifies the boolean→mode translation helper.
+// ref: RunModeForDemo — single wire-time decision point, not per-call sniffing.
+func TestPublishFailureModeForDemo(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		demo bool
+		want PublishFailureMode
+	}{
+		{"demo=false → fail-closed", false, PublishFailureModeFailClosed},
+		{"demo=true → fail-open", true, PublishFailureModeFailOpen},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := PublishFailureModeForDemo(tc.demo); got != tc.want {
+				t.Errorf("PublishFailureModeForDemo(%v) = %v, want %v", tc.demo, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add query.PublishFailureMode (fail-closed/fail-open) with zero-value safe default
- wire DurabilityMode -> (RunMode, PublishFailureMode) in config-core Init
- add configpublish option WithPublishFailureMode and mode-driven publisher error handling
- add TDD coverage for new type, service behavior, and wiring mapping

## Why
S10 requires separating read-path cursor tolerance from write-path publisher failure semantics to avoid future coupling.

## Verification
- go test ./pkg/query/...
- go test ./cells/config-core/slices/configpublish/...
- go test ./cells/config-core/...
- go test -race ./cells/config-core/slices/configpublish/...
- go build ./...
- golangci-lint run ./cells/config-core/...
- (changed file scope) golangci-lint run runmode.go runmode_test.go in pkg/query

## References
- ref: kubernetes api policy enums (orthogonal typed decisions)
- ref: zeromicro/go-zero mode vs feature strictness separation
- ref: uber-go/fx typed injection boundaries
- ref: ThreeDotsLabs/watermill publish failure semantics separation
