### PR TITLE
refactor(config-core): atomic RETURNING eliminates TOCTOU stale-read + S10 mode separation

### DIFF
--- a/cells/config-core/cell.go
+++ b/cells/config-core/cell.go
@@ -206,12 +206,12 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 		return err
 	}
 
-	runMode := query.RunModeForDemo(deps.DurabilityMode == cell.DurabilityDemo)
+	runMode, publishFailureMode := c.deriveModes(deps.DurabilityMode)
 	c.initWriteSlice()
 	if err := c.initReadSlice(runMode); err != nil {
 		return err
 	}
-	c.initPublishSlice()
+	c.initPublishSlice(publishFailureMode)
 	c.initSubscribeSlice()
 	if err := c.initFlagSlice(runMode); err != nil {
 		return err
@@ -220,6 +220,20 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 		return err
 	}
 	return nil
+}
+
+// deriveModes is the single translation point from kernel/cell.DurabilityMode
+// to run modes used by slices. Called only once at Init() time; propagated via
+// constructor parameters (do not call in handler/repository).
+//
+// S10 MODE-SEMANTIC-SPLIT-01: read-path cursor tolerance (RunMode) and write-
+// path publisher failure semantics (PublishFailureMode) are separate types that
+// evolve independently.
+//
+// ref: Uber fx Provide/Decorate — each decision gets its own typed injection.
+func (c *ConfigCore) deriveModes(durabilityMode cell.DurabilityMode) (query.RunMode, configpublish.PublishFailureMode) {
+	demo := durabilityMode == cell.DurabilityDemo
+	return query.RunModeForDemo(demo), configpublish.PublishFailureModeForDemo(demo)
 }
 
 // validateOutboxDeps enforces the XOR constraint (outboxWriter + txRunner
@@ -294,7 +308,7 @@ func (c *ConfigCore) initReadSlice(runMode query.RunMode) error {
 	return nil
 }
 
-func (c *ConfigCore) initPublishSlice() {
+func (c *ConfigCore) initPublishSlice(publishFailureMode configpublish.PublishFailureMode) {
 	var opts []configpublish.Option
 	if c.outboxWriter != nil {
 		opts = append(opts, configpublish.WithOutboxWriter(c.outboxWriter))
@@ -302,6 +316,7 @@ func (c *ConfigCore) initPublishSlice() {
 	if c.txRunner != nil {
 		opts = append(opts, configpublish.WithTxManager(c.txRunner))
 	}
+	opts = append(opts, configpublish.WithPublishFailureMode(publishFailureMode))
 	publishSvc := configpublish.NewService(c.configRepo, c.publisher, c.logger, opts...)
 	c.publishHandler = configpublish.NewHandler(publishSvc)
 	c.AddSlice(cell.NewBaseSlice("configpublish", "config-core", cell.L2))

--- a/cells/config-core/cell_test.go
+++ b/cells/config-core/cell_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
+	"github.com/ghbvf/gocell/cells/config-core/slices/configpublish"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -496,4 +497,37 @@ func TestWithPostgresDefaults_NilPool_SetsConfigRepoAndOutboxWriter(t *testing.T
 	require.NoError(t, c.Init(t.Context(), cell.Dependencies{DurabilityMode: cell.DurabilityDurable}))
 	assert.NotNil(t, c.configRepo, "configRepo must be non-nil after Init")
 	assert.NotNil(t, c.flagRepo, "flagRepo must be non-nil after Init")
+}
+
+// S10: deriveModes translates DurabilityMode into independent RunMode and
+// PublishFailureMode at Init() time.
+func TestConfigCore_DeriveModes(t *testing.T) {
+	tests := []struct {
+		name        string
+		durability  cell.DurabilityMode
+		wantRunMode query.RunMode
+		wantPubMode configpublish.PublishFailureMode
+	}{
+		{
+			name:        "demo maps to demo+fail-open",
+			durability:  cell.DurabilityDemo,
+			wantRunMode: query.RunModeDemo,
+			wantPubMode: configpublish.PublishFailureModeFailOpen,
+		},
+		{
+			name:        "durable maps to prod+fail-closed",
+			durability:  cell.DurabilityDurable,
+			wantRunMode: query.RunModeProd,
+			wantPubMode: configpublish.PublishFailureModeFailClosed,
+		},
+	}
+
+	c := NewConfigCore(WithInMemoryDefaults(), WithPublisher(eventbus.New()))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runMode, publishMode := c.deriveModes(tt.durability)
+			assert.Equal(t, tt.wantRunMode, runMode)
+			assert.Equal(t, tt.wantPubMode, publishMode)
+		})
+	}
 }

--- a/cells/config-core/cell_test.go
+++ b/cells/config-core/cell_test.go
@@ -520,6 +520,12 @@ func TestConfigCore_DeriveModes(t *testing.T) {
 			wantRunMode: query.RunModeProd,
 			wantPubMode: configpublish.PublishFailureModeFailClosed,
 		},
+		{
+			name:        "unknown maps to prod+fail-closed (safe default)",
+			durability:  cell.DurabilityMode(99),
+			wantRunMode: query.RunModeProd,
+			wantPubMode: configpublish.PublishFailureModeFailClosed,
+		},
 	}
 
 	c := NewConfigCore(WithInMemoryDefaults(), WithPublisher(eventbus.New()))

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -210,6 +210,8 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 		if encErr != nil {
 			return encErr
 		}
+		// NOTE: SQL param order (edk, nonce) differs from encryptValue return
+		// order (nonce, edk). Matches column order: value_edk=$10, value_nonce=$11.
 		const q = `INSERT INTO config_entries
 			(id, key, value, sensitive, version, created_at, updated_at,
 			 value_cipher, value_key_id, value_edk, value_nonce)
@@ -375,6 +377,8 @@ func (r *ConfigRepository) Update(ctx context.Context, key string, value string,
 		if encErr != nil {
 			return nil, encErr
 		}
+		// NOTE: SQL param order (edk, nonce) differs from encryptValue return
+		// order (nonce, edk). Matches the column order: value_edk=$3, value_nonce=$4.
 		const q = `UPDATE config_entries
 			SET value = '', sensitive = true, version = version+1, updated_at = now(),
 			    value_cipher = $1, value_key_id = $2, value_edk = $3, value_nonce = $4

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -242,6 +242,12 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 // order stays in sync between GetByKey, Update RETURNING, and Delete RETURNING.
 const configEntryColumns = "id, key, value, sensitive, version, created_at, updated_at, value_cipher, value_key_id, value_edk, value_nonce"
 
+// listEntryColumns is the reduced column set for List operations. It excludes
+// cipher payload columns (value_cipher, value_edk, value_nonce) because List
+// does not decrypt sensitive values — it returns "***" sentinel instead.
+// See applySensitiveListSentinel for the redaction logic.
+const listEntryColumns = "id, key, value, sensitive, version, created_at, updated_at, value_key_id"
+
 // scanConfigRow scans one row (order matches configEntryColumns) into a
 // ConfigEntry plus the raw cipher tuple. The caller is responsible for
 // decrypting the cipher tuple via decryptScannedEntry.
@@ -362,15 +368,55 @@ func (r *ConfigRepository) currentKeyID(ctx context.Context) string {
 	return ""
 }
 
-// Update atomically updates an existing config entry and returns the updated
-// row via UPDATE...RETURNING, eliminating the stale-read TOCTOU window.
-// For sensitive=true: re-encrypts value and writes cipher columns.
-func (r *ConfigRepository) Update(ctx context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error) {
+// Update atomically sets value and increments version. Preserves the existing
+// sensitive flag — reads it internally via SELECT...FOR UPDATE to eliminate
+// any TOCTOU race on the sensitive flag. Callers do not need to pre-read the
+// entry. Returns ErrConfigRepoNotFound if the key does not exist.
+func (r *ConfigRepository) Update(ctx context.Context, key string, value string) (*domain.ConfigEntry, error) {
 	db, err := r.resolveWriteDB(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Lock the row and read the current sensitive flag atomically.
+	const selectQ = `SELECT sensitive FROM config_entries WHERE key = $1 FOR UPDATE`
+	var sensitive bool
+	selectRow := db.QueryRow(ctx, selectQ, key)
+	if scanErr := selectRow.Scan(&sensitive); scanErr != nil {
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			return nil, &errcode.Error{
+				Code:            errcode.ErrConfigRepoNotFound,
+				Message:         "config not found",
+				InternalMessage: fmt.Sprintf("config repo: Update miss key=%s", key),
+				Cause:           scanErr,
+			}
+		}
+		return nil, &errcode.Error{
+			Code:            errcode.ErrConfigRepoQuery,
+			Message:         "config repo query failed",
+			InternalMessage: fmt.Sprintf("config repo: Update select-for-update error key=%s", key),
+			Cause:           scanErr,
+		}
+	}
+
+	return r.doUpdate(ctx, db, key, value, sensitive)
+}
+
+// UpdateForRollback atomically sets value AND sensitive, increments version.
+// Used exclusively by configpublish.Rollback to restore a snapshot's sensitivity
+// alongside its value. Returns ErrConfigRepoNotFound if the key does not exist.
+func (r *ConfigRepository) UpdateForRollback(ctx context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error) {
+	db, err := r.resolveWriteDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return r.doUpdate(ctx, db, key, value, sensitive)
+}
+
+// doUpdate performs the actual UPDATE...RETURNING for both Update and
+// UpdateForRollback. sensitive is the resolved flag (read by caller or provided
+// directly). For sensitive=true: re-encrypts value and writes cipher columns.
+func (r *ConfigRepository) doUpdate(ctx context.Context, db DBTX, key string, value string, sensitive bool) (*domain.ConfigEntry, error) {
 	var row Row
 	if sensitive {
 		ct, keyID, nonce, edk, encErr := r.encryptValue(ctx, key, value)
@@ -477,7 +523,7 @@ func (r *ConfigRepository) applySensitiveListSentinel(ctx context.Context, e *do
 // exposure of sensitive values in list responses.
 func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([]*domain.ConfigEntry, error) {
 	b := query.NewBuilder()
-	b.Append("SELECT id, key, value, sensitive, version, created_at, updated_at, value_key_id FROM config_entries WHERE 1=1")
+	b.Append("SELECT " + listEntryColumns + " FROM config_entries WHERE 1=1")
 
 	if err := query.AppendKeyset(b, params); err != nil {
 		return nil, errcode.Wrap(errcode.ErrConfigRepoQuery, "config repo: keyset build failed", err)

--- a/cells/config-core/internal/adapters/postgres/config_repo.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo.go
@@ -235,69 +235,99 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 	return nil
 }
 
-// GetByKey retrieves a config entry by key with transparent decryption for
-// sensitive entries. Sets entry.Stale=true when keyID != current active key.
-func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.ConfigEntry, error) {
-	const q = `SELECT id, key, value, sensitive, version, created_at, updated_at,
-		value_cipher, value_key_id, value_edk, value_nonce
-		FROM config_entries WHERE key = $1`
+// configEntryColumns is the canonical column list for config_entries used by
+// every SELECT/RETURNING projection in this file. Centralised so the column
+// order stays in sync between GetByKey, Update RETURNING, and Delete RETURNING.
+const configEntryColumns = "id, key, value, sensitive, version, created_at, updated_at, value_cipher, value_key_id, value_edk, value_nonce"
 
-	row := r.resolveDB(ctx).QueryRow(ctx, q, key)
-
-	var (
-		e           domain.ConfigEntry
-		valueCipher []byte
-		valueKeyID  *string
-		valueEDK    []byte
-		valueNonce  []byte
-	)
-	if err := row.Scan(
-		&e.ID, &e.Key, &e.Value, &e.Sensitive, &e.Version, &e.CreatedAt, &e.UpdatedAt,
+// scanConfigRow scans one row (order matches configEntryColumns) into a
+// ConfigEntry plus the raw cipher tuple. The caller is responsible for
+// decrypting the cipher tuple via decryptScannedEntry.
+func scanConfigRow(row Row) (e *domain.ConfigEntry, valueCipher []byte, valueKeyID *string, valueEDK []byte, valueNonce []byte, err error) {
+	var entry domain.ConfigEntry
+	if scanErr := row.Scan(
+		&entry.ID, &entry.Key, &entry.Value, &entry.Sensitive, &entry.Version,
+		&entry.CreatedAt, &entry.UpdatedAt,
 		&valueCipher, &valueKeyID, &valueEDK, &valueNonce,
-	); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &errcode.Error{
-				Code:            errcode.ErrConfigRepoNotFound,
-				Message:         "config not found",
-				InternalMessage: fmt.Sprintf("config repo: GetByKey miss key=%s", key),
-				Cause:           err,
-			}
-		}
-		return nil, &errcode.Error{
-			Code:            errcode.ErrConfigRepoQuery,
-			Message:         "config repo query failed",
-			InternalMessage: fmt.Sprintf("config repo: GetByKey scan error key=%s", key),
+	); scanErr != nil {
+		return nil, nil, nil, nil, nil, scanErr
+	}
+	return &entry, valueCipher, valueKeyID, valueEDK, valueNonce, nil
+}
+
+// scanConfigOrMapError calls scanConfigRow and translates the two known failure
+// modes into GoCell errcode.Error values:
+//
+//   - pgx.ErrNoRows  → ErrConfigRepoNotFound (domain not-found; maps to 404).
+//   - anything else  → ErrConfigRepoQuery (infra failure; maps to 500).
+//
+// op is the method name used only in InternalMessage for operator debugging;
+// key is the lookup key surfaced the same way.
+func scanConfigOrMapError(row Row, op, key string) (*domain.ConfigEntry, []byte, *string, []byte, []byte, error) {
+	e, ct, keyID, edk, nonce, err := scanConfigRow(row)
+	if err == nil {
+		return e, ct, keyID, edk, nonce, nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, nil, nil, nil, &errcode.Error{
+			Code:            errcode.ErrConfigRepoNotFound,
+			Message:         "config not found",
+			InternalMessage: fmt.Sprintf("config repo: %s miss key=%s", op, key),
 			Cause:           err,
 		}
 	}
+	return nil, nil, nil, nil, nil, &errcode.Error{
+		Code:            errcode.ErrConfigRepoQuery,
+		Message:         "config repo query failed",
+		InternalMessage: fmt.Sprintf("config repo: %s scan error key=%s", op, key),
+		Cause:           err,
+	}
+}
 
-	// Fail-closed enforcement for sensitive entries.
-	if e.Sensitive {
-		if len(valueCipher) == 0 || valueKeyID == nil || *valueKeyID == "" {
-			// Legacy plaintext row: sensitive=true but value_cipher IS NULL.
-			// Block read until plaintext_migration completes to enforce
-			// fail-closed semantics — never return plaintext from unencrypted rows.
-			return nil, errcode.New(errcode.ErrConfigDecryptFailed,
-				"sensitive value is in legacy plaintext format; run plaintext_migration tool before reading")
-		}
-		plain, err := r.decryptValue(ctx, key, valueCipher, *valueKeyID, valueNonce, valueEDK)
-		if err != nil {
-			return nil, err
-		}
-		e.Value = plain
-		e.KeyID = *valueKeyID
+// decryptScannedEntry applies fail-closed sensitive-value decryption and stale-key
+// detection to an already-scanned ConfigEntry. For non-sensitive entries it is a
+// no-op. The cipher tuple fields (ct, keyID, edk, nonce) are the raw values
+// returned by scanConfigRow.
+func (r *ConfigRepository) decryptScannedEntry(ctx context.Context, e *domain.ConfigEntry, ct []byte, keyID *string, nonce, edk []byte) error {
+	if !e.Sensitive {
+		return nil
+	}
+	if len(ct) == 0 || keyID == nil || *keyID == "" {
+		// Legacy plaintext row: sensitive=true but value_cipher IS NULL.
+		return errcode.New(errcode.ErrConfigDecryptFailed,
+			"sensitive value is in legacy plaintext format; run plaintext_migration tool before reading")
+	}
+	plain, err := r.decryptValue(ctx, e.Key, ct, *keyID, nonce, edk)
+	if err != nil {
+		return err
+	}
+	e.Value = plain
+	e.KeyID = *keyID
 
-		// Staleness check: if the stored keyID differs from current, mark stale.
-		if r.transformer != nil {
-			currentID := r.currentKeyID(ctx)
-			if currentID != "" && currentID != *valueKeyID {
-				e.Stale = true
-				r.observeStaleCipher(ctx, key, *valueKeyID, currentID)
-			}
+	// Staleness check: if the stored keyID differs from current, mark stale.
+	if r.transformer != nil {
+		currentID := r.currentKeyID(ctx)
+		if currentID != "" && currentID != *keyID {
+			e.Stale = true
+			r.observeStaleCipher(ctx, e.Key, *keyID, currentID)
 		}
 	}
+	return nil
+}
 
-	return &e, nil
+// GetByKey retrieves a config entry by key with transparent decryption for
+// sensitive entries. Sets entry.Stale=true when keyID != current active key.
+func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.ConfigEntry, error) {
+	const q = `SELECT ` + configEntryColumns + ` FROM config_entries WHERE key = $1`
+	row := r.resolveDB(ctx).QueryRow(ctx, q, key)
+	e, ct, keyID, edk, nonce, err := scanConfigOrMapError(row, "GetByKey", key)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.decryptScannedEntry(ctx, e, ct, keyID, nonce, edk); err != nil {
+		return nil, err
+	}
+	return e, nil
 }
 
 // observeStaleCipher emits a slog.Warn and invokes the optional onStaleCipher
@@ -330,72 +360,65 @@ func (r *ConfigRepository) currentKeyID(ctx context.Context) string {
 	return ""
 }
 
-// Update updates an existing config entry.
+// Update atomically updates an existing config entry and returns the updated
+// row via UPDATE...RETURNING, eliminating the stale-read TOCTOU window.
 // For sensitive=true: re-encrypts value and writes cipher columns.
-func (r *ConfigRepository) Update(ctx context.Context, entry *domain.ConfigEntry) error {
-	if entry.UpdatedAt.IsZero() {
-		entry.UpdatedAt = time.Now()
-	}
-
+func (r *ConfigRepository) Update(ctx context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error) {
 	db, err := r.resolveWriteDB(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	var affected int64
-	if entry.Sensitive {
-		ct, keyID, nonce, edk, encErr := r.encryptValue(ctx, entry.Key, entry.Value)
+	var row Row
+	if sensitive {
+		ct, keyID, nonce, edk, encErr := r.encryptValue(ctx, key, value)
 		if encErr != nil {
-			return encErr
+			return nil, encErr
 		}
 		const q = `UPDATE config_entries
-			SET value = $1, sensitive = $2, version = $3, updated_at = $4,
-			    value_cipher = $5, value_key_id = $6, value_edk = $7, value_nonce = $8
-			WHERE key = $9`
-		affected, err = db.Exec(ctx, q,
-			"", entry.Sensitive, entry.Version, entry.UpdatedAt,
-			ct, keyID, edk, nonce, entry.Key,
-		)
+			SET value = '', sensitive = true, version = version+1, updated_at = now(),
+			    value_cipher = $1, value_key_id = $2, value_edk = $3, value_nonce = $4
+			WHERE key = $5
+			RETURNING ` + configEntryColumns
+		row = db.QueryRow(ctx, q, ct, keyID, edk, nonce, key)
 	} else {
 		const q = `UPDATE config_entries
-			SET value = $1, sensitive = $2, version = $3, updated_at = $4,
+			SET value = $1, sensitive = false, version = version+1, updated_at = now(),
 			    value_cipher = NULL, value_key_id = NULL, value_edk = NULL, value_nonce = NULL
-			WHERE key = $5`
-		affected, err = db.Exec(ctx, q,
-			entry.Value, entry.Sensitive, entry.Version, entry.UpdatedAt, entry.Key,
-		)
+			WHERE key = $2
+			RETURNING ` + configEntryColumns
+		row = db.QueryRow(ctx, q, value, key)
 	}
-	if err != nil {
-		return errcode.Wrap(errcode.ErrConfigRepoQuery,
-			fmt.Sprintf("config repo: update failed for key %s", entry.Key), err)
+
+	e, ct, keyID, edk, nonce, scanErr := scanConfigOrMapError(row, "Update", key)
+	if scanErr != nil {
+		return nil, scanErr
 	}
-	if affected == 0 {
-		return errcode.Safe(errcode.ErrConfigRepoNotFound,
-			"config not found",
-			fmt.Sprintf("config repo: Update miss key=%s", entry.Key))
+	if err := r.decryptScannedEntry(ctx, e, ct, keyID, nonce, edk); err != nil {
+		return nil, err
 	}
-	return nil
+	return e, nil
 }
 
-// Delete removes a config entry by key.
-func (r *ConfigRepository) Delete(ctx context.Context, key string) error {
-	const q = `DELETE FROM config_entries WHERE key = $1`
+// Delete atomically removes a config entry by key and returns the deleted row
+// via DELETE...RETURNING, enabling callers to publish a tombstone event without
+// a separate pre-read.
+func (r *ConfigRepository) Delete(ctx context.Context, key string) (*domain.ConfigEntry, error) {
+	const q = `DELETE FROM config_entries WHERE key = $1 RETURNING ` + configEntryColumns
 
 	db, err := r.resolveWriteDB(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	affected, err := db.Exec(ctx, q, key)
-	if err != nil {
-		return errcode.Wrap(errcode.ErrConfigRepoQuery,
-			fmt.Sprintf("config repo: delete failed for key %s", key), err)
+	row := db.QueryRow(ctx, q, key)
+	e, ct, keyID, edk, nonce, scanErr := scanConfigOrMapError(row, "Delete", key)
+	if scanErr != nil {
+		return nil, scanErr
 	}
-	if affected == 0 {
-		return errcode.Safe(errcode.ErrConfigRepoNotFound,
-			"config not found",
-			fmt.Sprintf("config repo: Delete miss key=%s", key))
+	if err := r.decryptScannedEntry(ctx, e, ct, keyID, nonce, edk); err != nil {
+		return nil, err
 	}
-	return nil
+	return e, nil
 }
 
 // sensitiveListSentinel is the placeholder value returned by List for sensitive entries.

--- a/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -271,25 +271,31 @@ func TestEncrypt_GetByKey_NonSensitive_NoDecryption(t *testing.T) {
 }
 
 // TestEncrypt_Update_SensitiveWritesCipherColumns verifies that Update for a
-// sensitive entry writes cipher columns.
+// sensitive entry writes cipher columns and returns the updated entry via RETURNING.
 func TestEncrypt_Update_SensitiveWritesCipherColumns(t *testing.T) {
-	db := &mockDB{execAffected: 1}
+	ctx := context.Background()
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
-	repo := newEncryptedRepoFromDBTX(db, tr)
 
-	entry := &domain.ConfigEntry{
-		Key:       "api_key",
-		Value:     "new-secret",
-		Sensitive: true,
-		Version:   2,
-	}
-
-	err := repo.Update(context.Background(), entry)
+	// Build what the DB RETURNING row looks like after encryption.
+	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte("new-secret"), configcrypto.AADForConfig("config-core", "api_key"))
 	require.NoError(t, err)
 
-	sql := db.execCalls[0].sql
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			values: []any{"cfg-1", "api_key", "", true, 2, now, now, ct, keyID, edk, nonce},
+		},
+	}
+	repo := newEncryptedRepoFromDBTX(db, tr)
+
+	entry, err := repo.Update(context.Background(), "api_key", "new-secret", true)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+
+	sql := db.queryRowCalls[0].sql
 	assert.Contains(t, sql, "UPDATE config_entries")
 	assert.Contains(t, sql, "value_cipher")
+	assert.Equal(t, "new-secret", entry.Value, "Update must return decrypted plaintext")
 }
 
 // TestEncrypt_PublishVersion_SensitiveWritesCipherColumns verifies that

--- a/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -270,9 +270,10 @@ func TestEncrypt_GetByKey_NonSensitive_NoDecryption(t *testing.T) {
 	assert.Equal(t, "GoCell", entry.Value)
 }
 
-// TestEncrypt_Update_SensitiveWritesCipherColumns verifies that Update for a
-// sensitive entry writes cipher columns and returns the updated entry via RETURNING.
-func TestEncrypt_Update_SensitiveWritesCipherColumns(t *testing.T) {
+// TestEncrypt_UpdateForRollback_SensitiveWritesCipherColumns verifies that
+// UpdateForRollback for a sensitive entry writes cipher columns and returns the
+// updated entry via RETURNING.
+func TestEncrypt_UpdateForRollback_SensitiveWritesCipherColumns(t *testing.T) {
 	ctx := context.Background()
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
@@ -288,14 +289,14 @@ func TestEncrypt_Update_SensitiveWritesCipherColumns(t *testing.T) {
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
 
-	entry, err := repo.Update(context.Background(), "api_key", "new-secret", true)
+	entry, err := repo.UpdateForRollback(context.Background(), "api_key", "new-secret", true)
 	require.NoError(t, err)
 	require.NotNil(t, entry)
 
 	sql := db.queryRowCalls[0].sql
 	assert.Contains(t, sql, "UPDATE config_entries")
 	assert.Contains(t, sql, "value_cipher")
-	assert.Equal(t, "new-secret", entry.Value, "Update must return decrypted plaintext")
+	assert.Equal(t, "new-secret", entry.Value, "UpdateForRollback must return decrypted plaintext")
 }
 
 // TestEncrypt_PublishVersion_SensitiveWritesCipherColumns verifies that

--- a/cells/config-core/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_integration_test.go
@@ -101,11 +101,16 @@ func TestConfigRepo_Integration_CRUD(t *testing.T) {
 			return repo.Create(txCtx, entry)
 		}))
 
-		entry.Value = "updated"
-		entry.Version = 2
+		var updated *domain.ConfigEntry
 		require.NoError(t, txMgr.RunInTx(ctx, func(txCtx context.Context) error {
-			return repo.Update(txCtx, entry)
+			var err error
+			updated, err = repo.Update(txCtx, "integration.update.key", "updated", false)
+			return err
 		}))
+
+		require.NotNil(t, updated)
+		assert.Equal(t, "updated", updated.Value)
+		assert.Equal(t, 2, updated.Version)
 
 		got, err := repo.GetByKey(ctx, "integration.update.key")
 		require.NoError(t, err)
@@ -124,9 +129,14 @@ func TestConfigRepo_Integration_CRUD(t *testing.T) {
 			return repo.Create(txCtx, entry)
 		}))
 
+		var deleted *domain.ConfigEntry
 		require.NoError(t, txMgr.RunInTx(ctx, func(txCtx context.Context) error {
-			return repo.Delete(txCtx, "integration.delete.key")
+			var err error
+			deleted, err = repo.Delete(txCtx, "integration.delete.key")
+			return err
 		}))
+		require.NotNil(t, deleted)
+		assert.Equal(t, "to-be-deleted", deleted.Value)
 
 		_, err := repo.GetByKey(ctx, "integration.delete.key")
 		require.Error(t, err)
@@ -360,10 +370,9 @@ func TestConfigRepo_Integration_Encryption_RoundTrip(t *testing.T) {
 			return repo.Create(txCtx, entry)
 		}))
 
-		entry.Value = "rotated-token"
-		entry.Version = 2
 		require.NoError(t, txMgr.RunInTx(ctx, func(txCtx context.Context) error {
-			return repo.Update(txCtx, entry)
+			_, err := repo.Update(txCtx, entry.Key, "rotated-token", true)
+			return err
 		}))
 
 		got, err := repo.GetByKey(ctx, entry.Key)

--- a/cells/config-core/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_integration_test.go
@@ -104,7 +104,7 @@ func TestConfigRepo_Integration_CRUD(t *testing.T) {
 		var updated *domain.ConfigEntry
 		require.NoError(t, txMgr.RunInTx(ctx, func(txCtx context.Context) error {
 			var err error
-			updated, err = repo.Update(txCtx, "integration.update.key", "updated", false)
+			updated, err = repo.Update(txCtx, "integration.update.key", "updated")
 			return err
 		}))
 
@@ -371,7 +371,7 @@ func TestConfigRepo_Integration_Encryption_RoundTrip(t *testing.T) {
 		}))
 
 		require.NoError(t, txMgr.RunInTx(ctx, func(txCtx context.Context) error {
-			_, err := repo.Update(txCtx, entry.Key, "rotated-token", true)
+			_, err := repo.UpdateForRollback(txCtx, entry.Key, "rotated-token", true)
 			return err
 		}))
 

--- a/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -122,7 +122,48 @@ func TestConfigRepository_GetByKey_NotFound(t *testing.T) {
 	assert.Equal(t, errcode.ErrConfigRepoQuery, ec.Code)
 }
 
+// TestConfigRepository_Update tests the new 3-arg Update (SELECT FOR UPDATE + UPDATE RETURNING).
+// The mock returns the SELECT FOR UPDATE row first (sensitive=false), then the UPDATE RETURNING row.
 func TestConfigRepository_Update(t *testing.T) {
+	now := time.Now()
+	seqDB := &sequencedMockDB{
+		rows: []*mockRow{
+			{values: []any{false}}, // SELECT FOR UPDATE → sensitive=false
+			{values: []any{"cfg-1", "app.name", "GoCell v2", false, 2, now, now, nil, nil, nil, nil}}, // UPDATE RETURNING
+		},
+	}
+	repo := newConfigRepositoryFromDBTX(seqDB)
+
+	entry, err := repo.Update(context.Background(), "app.name", "GoCell v2")
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, "GoCell v2", entry.Value)
+
+	require.Len(t, seqDB.queryRowCalls, 2)
+	assert.Contains(t, seqDB.queryRowCalls[0].sql, "FOR UPDATE")
+	assert.Contains(t, seqDB.queryRowCalls[1].sql, "UPDATE config_entries")
+}
+
+// TestConfigRepository_Update_NotFound tests that Update returns ErrConfigRepoNotFound
+// when the SELECT FOR UPDATE finds no row.
+func TestConfigRepository_Update_NotFound(t *testing.T) {
+	seqDB := &sequencedMockDB{
+		rows: []*mockRow{
+			{scanErr: pgx.ErrNoRows}, // SELECT FOR UPDATE → not found
+		},
+	}
+	repo := newConfigRepositoryFromDBTX(seqDB)
+
+	_, err := repo.Update(context.Background(), "missing", "v")
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code)
+}
+
+// TestConfigRepository_UpdateForRollback tests the 4-arg UpdateForRollback method.
+func TestConfigRepository_UpdateForRollback(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
@@ -132,7 +173,7 @@ func TestConfigRepository_Update(t *testing.T) {
 	}
 	repo := newConfigRepositoryFromDBTX(db)
 
-	entry, err := repo.Update(context.Background(), "app.name", "GoCell v2", false)
+	entry, err := repo.UpdateForRollback(context.Background(), "app.name", "GoCell v2", false)
 	require.NoError(t, err)
 	require.NotNil(t, entry)
 	assert.Equal(t, "GoCell v2", entry.Value)
@@ -141,13 +182,15 @@ func TestConfigRepository_Update(t *testing.T) {
 	assert.Contains(t, db.queryRowCalls[0].sql, "UPDATE config_entries")
 }
 
-func TestConfigRepository_Update_NotFound(t *testing.T) {
+// TestConfigRepository_UpdateForRollback_NotFound tests that UpdateForRollback
+// returns ErrConfigRepoNotFound when the key is not found.
+func TestConfigRepository_UpdateForRollback_NotFound(t *testing.T) {
 	db := &mockDB{
 		queryRowResult: &mockRow{scanErr: pgx.ErrNoRows},
 	}
 	repo := newConfigRepositoryFromDBTX(db)
 
-	_, err := repo.Update(context.Background(), "missing", "v", false)
+	_, err := repo.UpdateForRollback(context.Background(), "missing", "v", false)
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -431,7 +474,7 @@ func TestUpdate_WithoutTx_ReturnsNoTxError(t *testing.T) {
 	session := NewSession(nil)
 	repo := NewConfigRepository(session, nil, nil)
 
-	_, err := repo.Update(context.Background(), "k", "v", false)
+	_, err := repo.Update(context.Background(), "k", "v")
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -700,3 +743,30 @@ func (r *mockRowSet) Scan(dest ...any) error {
 
 func (r *mockRowSet) Close()     {}
 func (r *mockRowSet) Err() error { return r.rowsErr }
+
+// sequencedMockDB returns a different mockRow for each successive QueryRow call.
+// Used to test methods that make multiple QueryRow calls (e.g. Update which
+// issues SELECT...FOR UPDATE then UPDATE...RETURNING).
+type sequencedMockDB struct {
+	queryRowCalls []dbCallRecord
+	rows          []*mockRow
+	idx           int
+}
+
+func (s *sequencedMockDB) Exec(_ context.Context, sql string, args ...any) (int64, error) {
+	return 0, nil
+}
+
+func (s *sequencedMockDB) Query(_ context.Context, sql string, args ...any) (Rows, error) {
+	return &mockRowSet{}, nil
+}
+
+func (s *sequencedMockDB) QueryRow(_ context.Context, sql string, args ...any) Row {
+	s.queryRowCalls = append(s.queryRowCalls, dbCallRecord{sql: sql, args: args})
+	if s.idx >= len(s.rows) {
+		return &mockRow{scanErr: assert.AnError}
+	}
+	row := s.rows[s.idx]
+	s.idx++
+	return row
+}

--- a/cells/config-core/internal/adapters/postgres/config_repo_test.go
+++ b/cells/config-core/internal/adapters/postgres/config_repo_test.go
@@ -123,27 +123,31 @@ func TestConfigRepository_GetByKey_NotFound(t *testing.T) {
 }
 
 func TestConfigRepository_Update(t *testing.T) {
-	db := &mockDB{execAffected: 1}
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			// 11 columns matching configEntryColumns for RETURNING
+			values: []any{"cfg-1", "app.name", "GoCell v2", false, 2, now, now, nil, nil, nil, nil},
+		},
+	}
 	repo := newConfigRepositoryFromDBTX(db)
 
-	entry := &domain.ConfigEntry{
-		Key:     "app.name",
-		Value:   "GoCell v2",
-		Version: 2,
-	}
-
-	err := repo.Update(context.Background(), entry)
+	entry, err := repo.Update(context.Background(), "app.name", "GoCell v2", false)
 	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, "GoCell v2", entry.Value)
 
-	require.Len(t, db.execCalls, 1)
-	assert.Contains(t, db.execCalls[0].sql, "UPDATE config_entries")
+	require.Len(t, db.queryRowCalls, 1)
+	assert.Contains(t, db.queryRowCalls[0].sql, "UPDATE config_entries")
 }
 
 func TestConfigRepository_Update_NotFound(t *testing.T) {
-	db := &mockDB{execAffected: 0}
+	db := &mockDB{
+		queryRowResult: &mockRow{scanErr: pgx.ErrNoRows},
+	}
 	repo := newConfigRepositoryFromDBTX(db)
 
-	err := repo.Update(context.Background(), &domain.ConfigEntry{Key: "missing"})
+	_, err := repo.Update(context.Background(), "missing", "v", false)
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -152,21 +156,31 @@ func TestConfigRepository_Update_NotFound(t *testing.T) {
 }
 
 func TestConfigRepository_Delete(t *testing.T) {
-	db := &mockDB{execAffected: 1}
+	now := time.Now()
+	db := &mockDB{
+		queryRowResult: &mockRow{
+			// 11 columns matching configEntryColumns for RETURNING
+			values: []any{"cfg-1", "app.name", "GoCell", false, 1, now, now, nil, nil, nil, nil},
+		},
+	}
 	repo := newConfigRepositoryFromDBTX(db)
 
-	err := repo.Delete(context.Background(), "app.name")
+	deleted, err := repo.Delete(context.Background(), "app.name")
 	require.NoError(t, err)
+	require.NotNil(t, deleted)
+	assert.Equal(t, "app.name", deleted.Key)
 
-	require.Len(t, db.execCalls, 1)
-	assert.Contains(t, db.execCalls[0].sql, "DELETE FROM config_entries")
+	require.Len(t, db.queryRowCalls, 1)
+	assert.Contains(t, db.queryRowCalls[0].sql, "DELETE FROM config_entries")
 }
 
 func TestConfigRepository_Delete_NotFound(t *testing.T) {
-	db := &mockDB{execAffected: 0}
+	db := &mockDB{
+		queryRowResult: &mockRow{scanErr: pgx.ErrNoRows},
+	}
 	repo := newConfigRepositoryFromDBTX(db)
 
-	err := repo.Delete(context.Background(), "missing")
+	_, err := repo.Delete(context.Background(), "missing")
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -417,7 +431,7 @@ func TestUpdate_WithoutTx_ReturnsNoTxError(t *testing.T) {
 	session := NewSession(nil)
 	repo := NewConfigRepository(session, nil, nil)
 
-	err := repo.Update(context.Background(), &domain.ConfigEntry{Key: "k"})
+	_, err := repo.Update(context.Background(), "k", "v", false)
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -431,7 +445,7 @@ func TestDelete_WithoutTx_ReturnsNoTxError(t *testing.T) {
 	session := NewSession(nil)
 	repo := NewConfigRepository(session, nil, nil)
 
-	err := repo.Delete(context.Background(), "k")
+	_, err := repo.Delete(context.Background(), "k")
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -548,6 +562,7 @@ type dbCallRecord struct {
 type mockDB struct {
 	execCalls      []dbCallRecord
 	queryCalls     []dbCallRecord
+	queryRowCalls  []dbCallRecord
 	queryRows      *mockRowSet
 	queryRowResult *mockRow
 	execErr        error
@@ -574,7 +589,8 @@ func (m *mockDB) Query(_ context.Context, sql string, args ...any) (Rows, error)
 	return m.queryRows, nil
 }
 
-func (m *mockDB) QueryRow(_ context.Context, _ string, _ ...any) Row {
+func (m *mockDB) QueryRow(_ context.Context, sql string, args ...any) Row {
+	m.queryRowCalls = append(m.queryRowCalls, dbCallRecord{sql: sql, args: args})
 	if m.queryRowResult == nil {
 		return &mockRow{scanErr: assert.AnError}
 	}

--- a/cells/config-core/internal/mem/config_repo.go
+++ b/cells/config-core/internal/mem/config_repo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/ports"
@@ -56,27 +57,33 @@ func (r *ConfigRepository) GetByKey(_ context.Context, key string) (*domain.Conf
 	return &clone, nil
 }
 
-func (r *ConfigRepository) Update(_ context.Context, entry *domain.ConfigEntry) error {
+func (r *ConfigRepository) Update(_ context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, exists := r.entries[entry.Key]; !exists {
-		return errcode.New(errcode.ErrConfigNotFound, "config not found: "+entry.Key)
+	existing, ok := r.entries[key]
+	if !ok {
+		return nil, errcode.New(errcode.ErrConfigNotFound, "config not found: "+key)
 	}
-	clone := *entry
-	r.entries[entry.Key] = &clone
-	return nil
+	existing.Value = value
+	existing.Sensitive = sensitive
+	existing.Version++
+	existing.UpdatedAt = time.Now()
+	clone := *existing
+	return &clone, nil
 }
 
-func (r *ConfigRepository) Delete(_ context.Context, key string) error {
+func (r *ConfigRepository) Delete(_ context.Context, key string) (*domain.ConfigEntry, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, exists := r.entries[key]; !exists {
-		return errcode.New(errcode.ErrConfigNotFound, "config not found: "+key)
+	existing, ok := r.entries[key]
+	if !ok {
+		return nil, errcode.New(errcode.ErrConfigNotFound, "config not found: "+key)
 	}
+	clone := *existing
 	delete(r.entries, key)
-	return nil
+	return &clone, nil
 }
 
 // List returns config entries sorted and paginated according to params.

--- a/cells/config-core/internal/mem/config_repo.go
+++ b/cells/config-core/internal/mem/config_repo.go
@@ -57,7 +57,23 @@ func (r *ConfigRepository) GetByKey(_ context.Context, key string) (*domain.Conf
 	return &clone, nil
 }
 
-func (r *ConfigRepository) Update(_ context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error) {
+func (r *ConfigRepository) Update(_ context.Context, key string, value string) (*domain.ConfigEntry, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, ok := r.entries[key]
+	if !ok {
+		return nil, errcode.New(errcode.ErrConfigNotFound, "config not found: "+key)
+	}
+	existing.Value = value
+	// Preserve existing Sensitive — do NOT change it.
+	existing.Version++
+	existing.UpdatedAt = time.Now()
+	clone := *existing
+	return &clone, nil
+}
+
+func (r *ConfigRepository) UpdateForRollback(_ context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/cells/config-core/internal/mem/config_repo_test.go
+++ b/cells/config-core/internal/mem/config_repo_test.go
@@ -100,17 +100,18 @@ func TestConfigRepository_Update(t *testing.T) {
 	}))
 
 	t.Run("success", func(t *testing.T) {
-		require.NoError(t, repo.Update(ctx, &domain.ConfigEntry{
-			ID: "cfg-1", Key: "app.name", Value: "new", Version: 2,
-			CreatedAt: now, UpdatedAt: time.Now(),
-		}))
+		updated, err := repo.Update(ctx, "app.name", "new", false)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "new", updated.Value)
+		assert.Equal(t, 2, updated.Version)
 		got, err := repo.GetByKey(ctx, "app.name")
 		require.NoError(t, err)
 		assert.Equal(t, "new", got.Value)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		err := repo.Update(ctx, &domain.ConfigEntry{Key: "missing"})
+		_, err := repo.Update(ctx, "missing", "v", false)
 		require.Error(t, err)
 		var ecErr *errcode.Error
 		require.ErrorAs(t, err, &ecErr)
@@ -127,13 +128,17 @@ func TestConfigRepository_Delete(t *testing.T) {
 	}))
 
 	t.Run("success", func(t *testing.T) {
-		require.NoError(t, repo.Delete(ctx, "app.name"))
-		_, err := repo.GetByKey(ctx, "app.name")
+		deleted, err := repo.Delete(ctx, "app.name")
+		require.NoError(t, err)
+		require.NotNil(t, deleted)
+		assert.Equal(t, "app.name", deleted.Key)
+		assert.Equal(t, "v", deleted.Value)
+		_, err = repo.GetByKey(ctx, "app.name")
 		require.Error(t, err)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		err := repo.Delete(ctx, "missing")
+		_, err := repo.Delete(ctx, "missing")
 		require.Error(t, err)
 	})
 }

--- a/cells/config-core/internal/mem/config_repo_test.go
+++ b/cells/config-core/internal/mem/config_repo_test.go
@@ -95,23 +95,52 @@ func TestConfigRepository_Update(t *testing.T) {
 
 	now := time.Now()
 	require.NoError(t, repo.Create(ctx, &domain.ConfigEntry{
-		ID: "cfg-1", Key: "app.name", Value: "old", Version: 1,
+		ID: "cfg-1", Key: "app.name", Value: "old", Sensitive: false, Version: 1,
 		CreatedAt: now, UpdatedAt: now,
 	}))
 
-	t.Run("success", func(t *testing.T) {
-		updated, err := repo.Update(ctx, "app.name", "new", false)
+	t.Run("success preserves sensitive flag", func(t *testing.T) {
+		updated, err := repo.Update(ctx, "app.name", "new")
 		require.NoError(t, err)
 		require.NotNil(t, updated)
 		assert.Equal(t, "new", updated.Value)
 		assert.Equal(t, 2, updated.Version)
+		assert.False(t, updated.Sensitive, "Update must preserve the existing sensitive flag")
 		got, err := repo.GetByKey(ctx, "app.name")
 		require.NoError(t, err)
 		assert.Equal(t, "new", got.Value)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := repo.Update(ctx, "missing", "v", false)
+		_, err := repo.Update(ctx, "missing", "v")
+		require.Error(t, err)
+		var ecErr *errcode.Error
+		require.ErrorAs(t, err, &ecErr)
+		assert.Equal(t, errcode.ErrConfigNotFound, ecErr.Code)
+	})
+}
+
+func TestConfigRepository_UpdateForRollback(t *testing.T) {
+	repo := NewConfigRepository()
+	ctx := context.Background()
+
+	now := time.Now()
+	require.NoError(t, repo.Create(ctx, &domain.ConfigEntry{
+		ID: "cfg-1", Key: "app.name", Value: "old", Sensitive: false, Version: 1,
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	t.Run("changes sensitive flag", func(t *testing.T) {
+		updated, err := repo.UpdateForRollback(ctx, "app.name", "secret", true)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "secret", updated.Value)
+		assert.True(t, updated.Sensitive, "UpdateForRollback must set the provided sensitive flag")
+		assert.Equal(t, 2, updated.Version)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := repo.UpdateForRollback(ctx, "missing", "v", false)
 		require.Error(t, err)
 		var ecErr *errcode.Error
 		require.ErrorAs(t, err, &ecErr)
@@ -610,4 +639,30 @@ func TestConfigRepository_ConcurrentCRUDAndList(t *testing.T) {
 	wg.Wait()
 	assert.Zero(t, writeErrors.Load(), "concurrent writes should not error (unique keys)")
 	assert.Zero(t, readErrors.Load(), "concurrent reads should not error")
+}
+
+// TestConcurrentUpdate_NoLostWrite verifies that concurrent Update calls on the
+// same key each increment the version exactly once — no lost writes under race.
+func TestConcurrentUpdate_NoLostWrite(t *testing.T) {
+	repo := NewConfigRepository()
+	now := time.Now()
+	_ = repo.Create(context.Background(), &domain.ConfigEntry{
+		ID: "cfg-1", Key: "k", Value: "v0", Version: 1,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, _ = repo.Update(context.Background(), "k", fmt.Sprintf("v%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	entry, err := repo.GetByKey(context.Background(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, goroutines+1, entry.Version, "each Update must increment version exactly once")
 }

--- a/cells/config-core/internal/ports/config_repo.go
+++ b/cells/config-core/internal/ports/config_repo.go
@@ -12,11 +12,17 @@ import (
 type ConfigRepository interface {
 	Create(ctx context.Context, entry *domain.ConfigEntry) error
 	GetByKey(ctx context.Context, key string) (*domain.ConfigEntry, error)
-	// Update modifies the config entry identified by key. The sensitive parameter
-	// is caller-provided; the repo does NOT verify it against the current row value.
-	// Callers must read the current sensitive flag before invoking Update (e.g.,
-	// via GetByKey inside the same transaction) to avoid stale-flag overwrites.
-	Update(ctx context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error)
+	// Update atomically sets value and increments version. Preserves the existing
+	// sensitive flag — the repo reads it internally via SELECT...FOR UPDATE to
+	// eliminate any TOCTOU race on the sensitive flag. Callers do not need to
+	// pre-read the entry. Returns ErrConfigRepoNotFound if the key does not exist.
+	Update(ctx context.Context, key string, value string) (*domain.ConfigEntry, error)
+	// UpdateForRollback atomically sets value AND sensitive, increments version.
+	// Used exclusively by configpublish.Rollback to restore a snapshot's sensitivity
+	// alongside its value. Returns ErrConfigRepoNotFound if the key does not exist.
+	// TODO(505-followup): add WHERE version=$expected for optimistic locking;
+	// return ErrConfigVersionConflict (409) on mismatch.
+	UpdateForRollback(ctx context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error)
 	Delete(ctx context.Context, key string) (*domain.ConfigEntry, error)
 	List(ctx context.Context, params query.ListParams) ([]*domain.ConfigEntry, error)
 	PublishVersion(ctx context.Context, version *domain.ConfigVersion) error

--- a/cells/config-core/internal/ports/config_repo.go
+++ b/cells/config-core/internal/ports/config_repo.go
@@ -12,8 +12,8 @@ import (
 type ConfigRepository interface {
 	Create(ctx context.Context, entry *domain.ConfigEntry) error
 	GetByKey(ctx context.Context, key string) (*domain.ConfigEntry, error)
-	Update(ctx context.Context, entry *domain.ConfigEntry) error
-	Delete(ctx context.Context, key string) error
+	Update(ctx context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error)
+	Delete(ctx context.Context, key string) (*domain.ConfigEntry, error)
 	List(ctx context.Context, params query.ListParams) ([]*domain.ConfigEntry, error)
 	PublishVersion(ctx context.Context, version *domain.ConfigVersion) error
 	GetVersion(ctx context.Context, configID string, version int) (*domain.ConfigVersion, error)

--- a/cells/config-core/internal/ports/config_repo.go
+++ b/cells/config-core/internal/ports/config_repo.go
@@ -12,6 +12,10 @@ import (
 type ConfigRepository interface {
 	Create(ctx context.Context, entry *domain.ConfigEntry) error
 	GetByKey(ctx context.Context, key string) (*domain.ConfigEntry, error)
+	// Update modifies the config entry identified by key. The sensitive parameter
+	// is caller-provided; the repo does NOT verify it against the current row value.
+	// Callers must read the current sensitive flag before invoking Update (e.g.,
+	// via GetByKey inside the same transaction) to avoid stale-flag overwrites.
 	Update(ctx context.Context, key string, value string, sensitive bool) (*domain.ConfigEntry, error)
 	Delete(ctx context.Context, key string) (*domain.ConfigEntry, error)
 	List(ctx context.Context, params query.ListParams) ([]*domain.ConfigEntry, error)

--- a/cells/config-core/internal/testutil/testutil.go
+++ b/cells/config-core/internal/testutil/testutil.go
@@ -1,0 +1,51 @@
+// Package testutil provides shared test doubles for config-core slice tests.
+package testutil
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+)
+
+// RecordingWriter records outbox entries written to it. Set Err to simulate failures.
+type RecordingWriter struct {
+	Entries []outbox.Entry
+	Err     error
+}
+
+func (w *RecordingWriter) Write(_ context.Context, entry outbox.Entry) error {
+	if w.Err != nil {
+		return w.Err
+	}
+	w.Entries = append(w.Entries, entry)
+	return nil
+}
+
+var _ outbox.Writer = (*RecordingWriter)(nil)
+
+// NoopTxRunner executes fn directly without a real transaction. Tracks call count.
+type NoopTxRunner struct{ Calls int }
+
+func (s *NoopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	s.Calls++
+	return fn(ctx)
+}
+
+var _ persistence.TxRunner = (*NoopTxRunner)(nil)
+
+// StubPublisher is a no-op outbox.Publisher for testing.
+type StubPublisher struct{}
+
+func (StubPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
+func (StubPublisher) Close(_ context.Context) error                       { return nil }
+
+var _ outbox.Publisher = StubPublisher{}
+
+// FailingPublisher returns Err on every Publish call.
+type FailingPublisher struct{ Err error }
+
+func (f FailingPublisher) Publish(_ context.Context, _ string, _ []byte) error { return f.Err }
+func (f FailingPublisher) Close(_ context.Context) error                       { return nil }
+
+var _ outbox.Publisher = FailingPublisher{}

--- a/cells/config-core/slices/configpublish/contract_test.go
+++ b/cells/config-core/slices/configpublish/contract_test.go
@@ -12,16 +12,17 @@ import (
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
+	"github.com/ghbvf/gocell/cells/config-core/internal/testutil"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/require"
 )
 
-func newContractService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+func newContractService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	writer := &testutil.RecordingWriter{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -201,8 +202,8 @@ func TestEventConfigChangedV1Publish(t *testing.T) {
 	_, err := svc.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
 
-	require.Len(t, writer.entries, 1, "Publish must emit one outbox entry")
-	entry := writer.entries[0]
+	require.Len(t, writer.Entries, 1, "Publish must emit one outbox entry")
+	entry := writer.Entries[0]
 	c.ValidatePayload(t, entry.Payload)
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"action":"published","key":"app.name"}`))
@@ -218,13 +219,13 @@ func TestEventConfigRollbackV1Publish(t *testing.T) {
 	// Publish first to create a version, then rollback
 	_, err := svc.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
-	writer.entries = nil // reset
+	writer.Entries = nil // reset
 
 	_, err = svc.Rollback(context.Background(), "app.name", 1)
 	require.NoError(t, err)
 
-	require.Len(t, writer.entries, 1, "Rollback must emit one outbox entry")
-	entry := writer.entries[0]
+	require.Len(t, writer.Entries, 1, "Rollback must emit one outbox entry")
+	entry := writer.Entries[0]
 	c.ValidatePayload(t, entry.Payload)
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"action":"rollback","key":"app.name"}`))

--- a/cells/config-core/slices/configpublish/mode.go
+++ b/cells/config-core/slices/configpublish/mode.go
@@ -1,0 +1,54 @@
+// Package configpublish — PublishFailureMode type.
+//
+// S10 MODE-SEMANTIC-SPLIT-01: separates write-path publisher failure semantics
+// from read-path cursor tolerance (query.RunMode). Defined here — not in
+// pkg/query — because it is a configpublish-specific concern. If audit-core or
+// access-core need the same pattern later, promote to a shared location.
+//
+// ref: Uber fx — each decision gets its own typed injection boundary.
+// ref: Kubernetes — orthogonal typed policy enums.
+package configpublish
+
+// PublishFailureMode controls whether direct publisher failures on write paths
+// are propagated (fail-closed) or tolerated (fail-open) when no outbox writer
+// is configured.
+//
+// Zero value is fail-closed — the safe production default. Demo assemblies
+// using DiscardPublisher set fail-open so the write path does not block.
+type PublishFailureMode uint8
+
+const (
+	// PublishFailureModeFailClosed propagates publisher failures as errors.
+	// This is the zero value and therefore the safe default for production.
+	PublishFailureModeFailClosed PublishFailureMode = iota
+
+	// PublishFailureModeFailOpen swallows publisher failures after a warning
+	// log, allowing the write path to succeed even when the publisher is
+	// degraded. Intended for demo mode only.
+	PublishFailureModeFailOpen
+)
+
+// IsFailOpen reports whether publisher failures are tolerated.
+func (m PublishFailureMode) IsFailOpen() bool { return m == PublishFailureModeFailOpen }
+
+// String returns a stable lowercase label suitable for structured logs and
+// metrics. Unknown values return "unknown" to prevent silent misuse.
+func (m PublishFailureMode) String() string {
+	switch m {
+	case PublishFailureModeFailClosed:
+		return "fail-closed"
+	case PublishFailureModeFailOpen:
+		return "fail-open"
+	default:
+		return "unknown"
+	}
+}
+
+// PublishFailureModeForDemo maps demo=true to fail-open and all other modes to
+// fail-closed. Called once at Cell Init() time; do not call per-request.
+func PublishFailureModeForDemo(demo bool) PublishFailureMode {
+	if demo {
+		return PublishFailureModeFailOpen
+	}
+	return PublishFailureModeFailClosed
+}

--- a/cells/config-core/slices/configpublish/mode_test.go
+++ b/cells/config-core/slices/configpublish/mode_test.go
@@ -1,0 +1,66 @@
+package configpublish
+
+import "testing"
+
+// TestPublishFailureMode_ZeroValueIsFailClosed guards the fail-closed contract:
+// a zero-value PublishFailureMode (unset by caller) must never enable fail-open
+// behavior, ensuring safe-by-default production semantics.
+//
+// ref: watermill publisher.go — nopPublisher only in _test.go; production
+// defaults to real publishing.
+func TestPublishFailureMode_ZeroValueIsFailClosed(t *testing.T) {
+	t.Parallel()
+	var m PublishFailureMode
+	if m.IsFailOpen() {
+		t.Fatal("zero-value PublishFailureMode must NOT be fail-open (fail-closed default)")
+	}
+	if m != PublishFailureModeFailClosed {
+		t.Fatalf("zero-value PublishFailureMode = %v, want PublishFailureModeFailClosed", m)
+	}
+}
+
+// TestPublishFailureMode_String verifies stable lowercase labels for structured
+// logs and metrics. Changing these strings is a breaking change for log parsers.
+func TestPublishFailureMode_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mode PublishFailureMode
+		want string
+	}{
+		{PublishFailureModeFailClosed, "fail-closed"},
+		{PublishFailureModeFailOpen, "fail-open"},
+		{PublishFailureMode(99), "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.mode.String(); got != tc.want {
+				t.Errorf("PublishFailureMode(%d).String() = %q, want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPublishFailureModeForDemo verifies the boolean→mode translation helper.
+// This is the single wire-time decision point, not per-call sniffing.
+//
+// ref: query.RunModeForDemo — same pattern applied to read-path mode.
+func TestPublishFailureModeForDemo(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		demo bool
+		want PublishFailureMode
+	}{
+		{"demo=false → fail-closed", false, PublishFailureModeFailClosed},
+		{"demo=true → fail-open", true, PublishFailureModeFailOpen},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := PublishFailureModeForDemo(tc.demo); got != tc.want {
+				t.Errorf("PublishFailureModeForDemo(%v) = %v, want %v", tc.demo, got, tc.want)
+			}
+		})
+	}
+}

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -1,5 +1,10 @@
 // Package configpublish implements the config-publish slice: Publish/Rollback
 // versioned config snapshots.
+//
+// All reads and writes happen inside runInTx to eliminate the TOCTOU stale-read
+// race that existed when GetByKey/GetVersion were called before the transaction.
+//
+// ref: flagwrite — same "all-inside-tx" pattern.
 package configpublish
 
 import (
@@ -38,13 +43,23 @@ func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = tx }
 }
 
+// WithPublishFailureMode sets direct-publisher failure behavior when
+// outboxWriter is nil. Zero value is fail-closed (safe production default).
+//
+// S10 MODE-SEMANTIC-SPLIT-01: separated from query.RunMode so read-path cursor
+// tolerance and write-path publisher failure semantics evolve independently.
+func WithPublishFailureMode(mode PublishFailureMode) Option {
+	return func(s *Service) { s.publishFailureMode = mode }
+}
+
 // Service implements config publish/rollback business logic.
 type Service struct {
-	repo         ports.ConfigRepository
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	repo               ports.ConfigRepository
+	publisher          outbox.Publisher
+	outboxWriter       outbox.Writer
+	txRunner           persistence.TxRunner
+	publishFailureMode PublishFailureMode
+	logger             *slog.Logger
 }
 
 // NewService creates a config-publish Service.
@@ -61,37 +76,39 @@ func NewService(repo ports.ConfigRepository, pub outbox.Publisher, logger *slog.
 }
 
 // Publish creates a versioned snapshot of a config entry.
+// All reads happen inside runInTx so the snapshot is consistent with the write.
 func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersion, error) {
 	if key == "" {
 		return nil, errcode.New(errcode.ErrConfigPublishInvalidInput, "key is required")
 	}
 
-	entry, err := s.repo.GetByKey(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("config-publish: publish: %w", err)
-	}
-
-	now := time.Now()
-	version := &domain.ConfigVersion{
-		ID:          "ver" + "-" + uuid.NewString(),
-		ConfigID:    entry.ID,
-		Version:     entry.Version,
-		Value:       entry.Value,
-		Sensitive:   entry.Sensitive,
-		PublishedAt: &now,
-	}
-
-	payload, err := json.Marshal(map[string]any{
-		"action":    "published",
-		"key":       key,
-		"config_id": entry.ID,
-		"version":   version.Version,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("config-publish: marshal event payload: %w", err)
-	}
-
+	var version *domain.ConfigVersion
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
+		entry, err := s.repo.GetByKey(txCtx, key)
+		if err != nil {
+			return fmt.Errorf("config-publish: publish: %w", err)
+		}
+
+		now := time.Now()
+		version = &domain.ConfigVersion{
+			ID:          "ver" + "-" + uuid.NewString(),
+			ConfigID:    entry.ID,
+			Version:     entry.Version,
+			Value:       entry.Value,
+			Sensitive:   entry.Sensitive,
+			PublishedAt: &now,
+		}
+
+		payload, err := json.Marshal(map[string]any{
+			"action":    "published",
+			"key":       key,
+			"config_id": entry.ID,
+			"version":   version.Version,
+		})
+		if err != nil {
+			return fmt.Errorf("config-publish: marshal event payload: %w", err)
+		}
+
 		if err := s.repo.PublishVersion(txCtx, version); err != nil {
 			return fmt.Errorf("config-publish: publish version: %w", err)
 		}
@@ -106,6 +123,9 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 }
 
 // Rollback reverts a config entry to a specific version.
+// All reads (GetByKey + GetVersion) and the atomic Update happen inside runInTx
+// to eliminate the TOCTOU stale-read race where a concurrent write could change
+// the entry between the reads and the update.
 func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (*domain.ConfigEntry, error) {
 	if key == "" {
 		return nil, errcode.New(errcode.ErrConfigPublishInvalidInput, "key is required")
@@ -115,39 +135,33 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 			"rollback target version must be >= 1")
 	}
 
-	entry, err := s.repo.GetByKey(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("config-publish: rollback: %w", err)
-	}
-
-	ver, err := s.repo.GetVersion(ctx, entry.ID, targetVersion)
-	if err != nil {
-		return nil, fmt.Errorf("config-publish: rollback: version not found: %w", err)
-	}
-
-	entry.Value = ver.Value
-	// Restore the snapshot's sensitivity so a rolled-back entry inherits the
-	// redaction policy that was in force at the snapshot time. Otherwise a
-	// sensitivity flip between the target version and the live entry would
-	// either leak a secret (entry was sensitive, snapshot was plain) or
-	// over-redact a public value (snapshot was sensitive, entry is now plain).
-	entry.Sensitive = ver.Sensitive
-	entry.Version++
-	entry.UpdatedAt = time.Now()
-
-	payload, err := json.Marshal(map[string]any{
-		"action":         "rollback",
-		"key":            key,
-		"target_version": targetVersion,
-		"new_version":    entry.Version,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("config-publish: marshal event payload: %w", err)
-	}
-
+	var updated *domain.ConfigEntry
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
-		if err := s.repo.Update(txCtx, entry); err != nil {
+		entry, err := s.repo.GetByKey(txCtx, key)
+		if err != nil {
+			return fmt.Errorf("config-publish: rollback: %w", err)
+		}
+
+		ver, err := s.repo.GetVersion(txCtx, entry.ID, targetVersion)
+		if err != nil {
+			return fmt.Errorf("config-publish: rollback: version not found: %w", err)
+		}
+
+		// Atomic UPDATE...RETURNING restores the snapshot's value and sensitivity.
+		// The repo handles version=version+1 and updated_at=now() internally.
+		updated, err = s.repo.Update(txCtx, key, ver.Value, ver.Sensitive)
+		if err != nil {
 			return fmt.Errorf("config-publish: rollback update: %w", err)
+		}
+
+		payload, err := json.Marshal(map[string]any{
+			"action":         "rollback",
+			"key":            key,
+			"target_version": targetVersion,
+			"new_version":    updated.Version,
+		})
+		if err != nil {
+			return fmt.Errorf("config-publish: marshal event payload: %w", err)
 		}
 		return s.publishEvent(txCtx, TopicConfigRollback, payload)
 	}); err != nil {
@@ -156,7 +170,7 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 
 	s.logger.Info("config rolled back",
 		slog.String("key", key), slog.Int("target_version", targetVersion))
-	return entry, nil
+	return updated, nil
 }
 
 // runInTx executes fn in a transaction if txRunner is configured, otherwise
@@ -171,10 +185,11 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 
 // publishEvent writes to the outbox (L2 durable) or directly via publisher
 // (fallback when outboxWriter is nil, e.g. demo assemblies using DiscardPublisher).
-// No RunMode fail-open needed: demo mode injects DiscardPublisher which never
-// errors by contract, so any publisher failure is a real infrastructure problem
-// that must surface. Read slices use RunMode to handle stale cursor tokens —
-// a concern that does not exist in write operations.
+// PublishFailureMode controls whether direct-publisher failures are propagated
+// (fail-closed, the safe default for production) or tolerated after a warning
+// (fail-open, the demo-mode behavior when the publisher is degraded but the
+// write path should not block). DiscardPublisher never errors by contract, so
+// any publisher failure indicates a real infrastructure problem.
 func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte) error {
 	if s.outboxWriter != nil {
 		entry := outbox.Entry{
@@ -191,6 +206,14 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 	// accepts the message.
 	envelope := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), payload)
 	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
+		if s.publishFailureMode.IsFailOpen() {
+			s.logger.Warn("config-publish: publisher failed (fail-open mode)",
+				slog.String("topic", topic),
+				slog.String("publish_failure_mode", s.publishFailureMode.String()),
+				slog.String("error", err.Error()),
+			)
+			return nil
+		}
 		return fmt.Errorf("config-publish: publisher failed for topic %s: %w", topic, err)
 	}
 	return nil

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -104,6 +104,7 @@ func (s *Service) Publish(ctx context.Context, key string) (*domain.ConfigVersio
 			"key":       key,
 			"config_id": entry.ID,
 			"version":   version.Version,
+			"sensitive": entry.Sensitive,
 		})
 		if err != nil {
 			return fmt.Errorf("config-publish: marshal event payload: %w", err)
@@ -149,7 +150,7 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 
 		// Atomic UPDATE...RETURNING restores the snapshot's value and sensitivity.
 		// The repo handles version=version+1 and updated_at=now() internally.
-		updated, err = s.repo.Update(txCtx, key, ver.Value, ver.Sensitive)
+		updated, err = s.repo.UpdateForRollback(txCtx, key, ver.Value, ver.Sensitive)
 		if err != nil {
 			return fmt.Errorf("config-publish: rollback update: %w", err)
 		}

--- a/cells/config-core/slices/configpublish/service.go
+++ b/cells/config-core/slices/configpublish/service.go
@@ -207,6 +207,8 @@ func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte
 	envelope := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), payload)
 	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
 		if s.publishFailureMode.IsFailOpen() {
+			// topic + error are sufficient for demo-mode triage; the key is inside
+			// the serialized payload and would require unmarshaling to extract.
 			s.logger.Warn("config-publish: publisher failed (fail-open mode)",
 				slog.String("topic", topic),
 				slog.String("publish_failure_mode", s.publishFailureMode.String()),

--- a/cells/config-core/slices/configpublish/service_integration_test.go
+++ b/cells/config-core/slices/configpublish/service_integration_test.go
@@ -4,6 +4,7 @@ package configpublish
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -144,4 +145,102 @@ func TestPublishVersion_AtomicWithOutbox(t *testing.T) {
 	after := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigChanged)
 	assert.Equal(t, 1, after-before,
 		"Publish must co-commit exactly one %s outbox row (L2 atomicity)", domain.TopicConfigChanged)
+}
+
+// TestRollback_AtomicWithOutbox verifies that config_entries (version bump) and
+// outbox_entries rows are both committed in the same transaction (L2 atomicity)
+// during Rollback. Uses a real PostgreSQL backend.
+func TestRollback_AtomicWithOutbox(t *testing.T) {
+	bundle, cleanup := setupPublishBundle(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed an entry and publish a version so Rollback has a target.
+	seedConfigEntry(t, bundle, "integration.rollback.key", "rollback-value")
+
+	// Publish v1 to create a config_versions row to roll back to.
+	ver, err := bundle.svc.Publish(ctx, "integration.rollback.key")
+	require.NoError(t, err)
+	assert.Equal(t, 1, ver.Version)
+
+	// Baseline: count outbox rows after Publish (exactly 1 from Publish above).
+	before := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigRollback)
+	require.Equal(t, 0, before, "no rollback outbox rows should exist before Rollback call")
+
+	// Rollback to version 1.
+	rolled, err := bundle.svc.Rollback(ctx, "integration.rollback.key", 1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, rolled.Version,
+		"Rollback must increment the config_entries version (UPDATE...RETURNING)")
+
+	// Outbox-side: Rollback's L2 co-commit must have added exactly one
+	// event.config.rollback row to outbox_entries in the same tx.
+	after := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigRollback)
+	assert.Equal(t, 1, after-before,
+		"Rollback must co-commit exactly one %s outbox row (L2 atomicity)", domain.TopicConfigRollback)
+}
+
+// TestRollback_AtomicWithOutbox_FailureRollsBackBoth verifies that when the outbox
+// write fails during Rollback, both the config_entries update and the outbox write
+// are rolled back (transaction atomicity).
+func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx, testutil.PostgresImage,
+		tcpostgres.WithDatabase("test"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = container.Terminate(ctx) }()
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
+	require.NoError(t, err)
+	defer func() { _ = pool.Close(ctx) }()
+
+	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx))
+
+	session := cellpg.NewSession(pool.DB())
+	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil)
+	txMgr := adapterpg.NewTxManager(pool)
+
+	// First: seed and publish using a good writer.
+	goodWriter := adapterpg.NewOutboxWriter()
+	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(goodWriter),
+		WithTxManager(txMgr),
+	)
+
+	b := publishServiceBundle{svc: svcGood, repo: repo, pool: pool.DB(), txMgr: txMgr}
+	seedConfigEntry(t, b, "rollback.failure.key", "initial-value")
+	_, err = svcGood.Publish(ctx, "rollback.failure.key")
+	require.NoError(t, err)
+
+	// Capture the config_entries version before the failing Rollback.
+	entryBefore, err := repo.GetByKey(ctx, "rollback.failure.key")
+	require.NoError(t, err)
+	versionBefore := entryBefore.Version
+
+	// Now inject a failing writer — simulates outbox broker down during Rollback.
+	failingWriter := &recordingWriter{err: errors.New("outbox broker down")}
+	svcFail := NewService(repo, stubPublisher{}, slog.Default(),
+		WithOutboxWriter(failingWriter),
+		WithTxManager(txMgr),
+	)
+
+	_, err = svcFail.Rollback(ctx, "rollback.failure.key", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outbox")
+
+	// config_entries version must NOT have changed (rolled back).
+	entryAfter, err := repo.GetByKey(ctx, "rollback.failure.key")
+	require.NoError(t, err)
+	assert.Equal(t, versionBefore, entryAfter.Version,
+		"config_entries version must not change when outbox write fails (atomic rollback)")
 }

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -9,53 +9,12 @@ import (
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
-	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/cells/config-core/internal/testutil"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// --- test doubles (ref: order-create/service_test.go) ---
-
-type recordingWriter struct {
-	entries []outbox.Entry
-	err     error
-}
-
-func (w *recordingWriter) Write(_ context.Context, entry outbox.Entry) error {
-	if w.err != nil {
-		return w.err
-	}
-	w.entries = append(w.entries, entry)
-	return nil
-}
-
-var _ outbox.Writer = (*recordingWriter)(nil)
-
-type noopTxRunner struct{ calls int }
-
-func (s *noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
-	s.calls++
-	return fn(ctx)
-}
-
-var _ persistence.TxRunner = (*noopTxRunner)(nil)
-
-type stubPublisher struct{}
-
-func (stubPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
-func (stubPublisher) Close(_ context.Context) error                       { return nil }
-
-var _ outbox.Publisher = stubPublisher{}
-
-type failingPublisher struct{ err error }
-
-func (p failingPublisher) Publish(_ context.Context, _ string, _ []byte) error { return p.err }
-func (p failingPublisher) Close(_ context.Context) error                       { return nil }
-
-var _ outbox.Publisher = failingPublisher{}
 
 func newTestService() (*Service, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
@@ -64,11 +23,11 @@ func newTestService() (*Service, *mem.ConfigRepository) {
 	return NewService(repo, eb, logger), repo
 }
 
-func newDurableTestService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+func newDurableTestService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	writer := &testutil.RecordingWriter{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -168,7 +127,7 @@ func TestService_Rollback(t *testing.T) {
 // ref: watermill/components/forwarder — publish failure wraps+returns.
 func TestService_Publish_PublisherError_Propagates(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	pub := failingPublisher{err: errors.New("broker unavailable")}
+	pub := testutil.FailingPublisher{Err: errors.New("broker unavailable")}
 	svc := NewService(repo, pub, slog.Default()) // no outboxWriter → publisher path; error propagates
 
 	mustSeedEntry(repo, "k", "v1")
@@ -181,9 +140,9 @@ func TestService_Publish_PublisherError_Propagates(t *testing.T) {
 
 func TestService_Publish_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{err: errors.New("outbox unavailable")}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	mustSeedEntry(repo, "app.name", "value")
 
 	_, err := svc.Publish(context.Background(), "app.name")
@@ -193,14 +152,14 @@ func TestService_Publish_OutboxWriteError(t *testing.T) {
 
 func TestService_Rollback_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{err: errors.New("outbox unavailable")}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	mustSeedEntry(repo, "app.name", "v1")
 	// Publish first (use a working writer), then swap to failing writer for rollback.
-	goodWriter := &recordingWriter{}
-	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(goodWriter), WithTxManager(&noopTxRunner{}))
+	goodWriter := &testutil.RecordingWriter{}
+	svcGood := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
 
@@ -216,8 +175,8 @@ func TestService_Publish_DurableMode_CapturesOutboxEntry(t *testing.T) {
 	ver, err := svc.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
 	assert.Equal(t, 1, ver.Version)
-	require.Len(t, writer.entries, 1)
-	assert.Equal(t, TopicConfigChanged, writer.entries[0].EventType)
+	require.Len(t, writer.Entries, 1)
+	assert.Equal(t, TopicConfigChanged, writer.Entries[0].EventType)
 }
 
 // TestPublishVersion_CallsTxRunnerRunInTxOnce asserts that Publish wraps both
@@ -225,23 +184,23 @@ func TestService_Publish_DurableMode_CapturesOutboxEntry(t *testing.T) {
 // (L2 atomicity).
 func TestPublishVersion_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	tx := &noopTxRunner{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
+	writer := &testutil.RecordingWriter{}
+	tx := &testutil.NoopTxRunner{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	mustSeedEntry(repo, "app.name", "value")
 	_, err := svc.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
-	assert.Equal(t, 1, tx.calls, "Publish must call RunInTx exactly once")
-	assert.Len(t, writer.entries, 1, "outbox entry must be written inside the tx")
+	assert.Equal(t, 1, tx.Calls, "Publish must call RunInTx exactly once")
+	assert.Len(t, writer.Entries, 1, "outbox entry must be written inside the tx")
 }
 
 // H2-2 CONFIGPUBLISH-REDACT-01: domain.ConfigVersion must carry the source entry's
 // Sensitive flag so downstream consumers (handler, postgres replay) can redact uniformly.
 func TestService_Publish_SensitiveEntry_VersionCarriesFlag(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	svc := NewService(repo, stubPublisher{}, slog.Default())
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default())
 	now := time.Now()
 	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
 		ID: "cfg-secret", Key: "db.password", Value: "s3cret!", Sensitive: true,
@@ -282,7 +241,7 @@ func TestService_Rollback_VersionNotFound(t *testing.T) {
 
 func TestService_Publish_NonSensitiveEntry_VersionFlagFalse(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	svc := NewService(repo, stubPublisher{}, slog.Default())
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default())
 	mustSeedEntry(repo, "app.name", "gocell")
 
 	ver, err := svc.Publish(context.Background(), "app.name")
@@ -309,7 +268,7 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := mem.NewConfigRepository()
-			svc := NewService(repo, stubPublisher{}, slog.Default())
+			svc := NewService(repo, testutil.StubPublisher{}, slog.Default())
 			now := time.Now()
 			require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
 				ID: "cfg-x", Key: "app.x", Value: "v1", Sensitive: tt.seedSensitive,
@@ -323,7 +282,7 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 			if tt.flipToSensitiveAt > 0 {
 				live, err := repo.GetByKey(context.Background(), "app.x")
 				require.NoError(t, err)
-				_, err = repo.Update(context.Background(), live.Key, "v-live", !tt.seedSensitive)
+				_, err = repo.UpdateForRollback(context.Background(), live.Key, "v-live", !tt.seedSensitive)
 				require.NoError(t, err)
 			}
 
@@ -342,7 +301,7 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 // as a hard failure.
 func TestService_Publish_FailClosed_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	pub := failingPublisher{err: errors.New("broker down")}
+	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, pub, slog.Default(),
 		WithPublishFailureMode(PublishFailureModeFailClosed))
 
@@ -357,7 +316,7 @@ func TestService_Publish_FailClosed_PublisherError(t *testing.T) {
 // rather than failing the entire Publish operation.
 func TestService_Publish_FailOpen_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	pub := failingPublisher{err: errors.New("broker down")}
+	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, pub, slog.Default(),
 		WithPublishFailureMode(PublishFailureModeFailOpen))
 
@@ -371,12 +330,12 @@ func TestService_Publish_FailOpen_PublisherError(t *testing.T) {
 // Rollback path's direct-publisher fallback.
 func TestService_Rollback_FailClosed_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	pub := failingPublisher{err: errors.New("broker down")}
+	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, pub, slog.Default(),
 		WithPublishFailureMode(PublishFailureModeFailClosed))
 
 	mustSeedEntry(repo, "app.x", "v1")
-	svcOK := NewService(repo, stubPublisher{}, slog.Default())
+	svcOK := NewService(repo, testutil.StubPublisher{}, slog.Default())
 	_, err := svcOK.Publish(context.Background(), "app.x")
 	require.NoError(t, err)
 
@@ -389,12 +348,12 @@ func TestService_Rollback_FailClosed_PublisherError(t *testing.T) {
 // Rollback path's direct-publisher fallback.
 func TestService_Rollback_FailOpen_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	pub := failingPublisher{err: errors.New("broker down")}
+	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, pub, slog.Default(),
 		WithPublishFailureMode(PublishFailureModeFailOpen))
 
 	mustSeedEntry(repo, "app.x", "v1")
-	svcOK := NewService(repo, stubPublisher{}, slog.Default())
+	svcOK := NewService(repo, testutil.StubPublisher{}, slog.Default())
 	_, err := svcOK.Publish(context.Background(), "app.x")
 	require.NoError(t, err)
 

--- a/cells/config-core/slices/configpublish/service_test.go
+++ b/cells/config-core/slices/configpublish/service_test.go
@@ -323,9 +323,8 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 			if tt.flipToSensitiveAt > 0 {
 				live, err := repo.GetByKey(context.Background(), "app.x")
 				require.NoError(t, err)
-				live.Sensitive = !tt.seedSensitive
-				live.Value = "v-live"
-				require.NoError(t, repo.Update(context.Background(), live))
+				_, err = repo.Update(context.Background(), live.Key, "v-live", !tt.seedSensitive)
+				require.NoError(t, err)
 			}
 
 			rolled, err := svc.Rollback(context.Background(), "app.x", 1)
@@ -334,4 +333,72 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 				"rollback must inherit the snapshot's Sensitive flag, not the live entry's")
 		})
 	}
+}
+
+// --- S10 PublishFailureMode tests ---
+
+// TestService_Publish_FailClosed_PublisherError verifies that when configured
+// with PublishFailureMode=FailClosed (the default), a publisher error propagates
+// as a hard failure.
+func TestService_Publish_FailClosed_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(),
+		WithPublishFailureMode(PublishFailureModeFailClosed))
+
+	mustSeedEntry(repo, "app.timeout", "30s")
+	_, err := svc.Publish(context.Background(), "app.timeout")
+	require.Error(t, err, "FailClosed: publisher failure must propagate")
+	assert.Contains(t, err.Error(), "broker down")
+}
+
+// TestService_Publish_FailOpen_PublisherError verifies that when configured
+// with PublishFailureMode=FailOpen, a publisher error is swallowed and logged
+// rather than failing the entire Publish operation.
+func TestService_Publish_FailOpen_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(),
+		WithPublishFailureMode(PublishFailureModeFailOpen))
+
+	mustSeedEntry(repo, "app.timeout", "30s")
+	ver, err := svc.Publish(context.Background(), "app.timeout")
+	require.NoError(t, err, "FailOpen: publisher failure must be swallowed")
+	assert.Equal(t, 1, ver.Version)
+}
+
+// TestService_Rollback_FailClosed_PublisherError verifies fail-closed on the
+// Rollback path's direct-publisher fallback.
+func TestService_Rollback_FailClosed_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(),
+		WithPublishFailureMode(PublishFailureModeFailClosed))
+
+	mustSeedEntry(repo, "app.x", "v1")
+	svcOK := NewService(repo, stubPublisher{}, slog.Default())
+	_, err := svcOK.Publish(context.Background(), "app.x")
+	require.NoError(t, err)
+
+	_, err = svc.Rollback(context.Background(), "app.x", 1)
+	require.Error(t, err, "FailClosed: publisher failure must propagate on rollback")
+	assert.Contains(t, err.Error(), "broker down")
+}
+
+// TestService_Rollback_FailOpen_PublisherError verifies fail-open on the
+// Rollback path's direct-publisher fallback.
+func TestService_Rollback_FailOpen_PublisherError(t *testing.T) {
+	repo := mem.NewConfigRepository()
+	pub := failingPublisher{err: errors.New("broker down")}
+	svc := NewService(repo, pub, slog.Default(),
+		WithPublishFailureMode(PublishFailureModeFailOpen))
+
+	mustSeedEntry(repo, "app.x", "v1")
+	svcOK := NewService(repo, stubPublisher{}, slog.Default())
+	_, err := svcOK.Publish(context.Background(), "app.x")
+	require.NoError(t, err)
+
+	rolled, err := svc.Rollback(context.Background(), "app.x", 1)
+	require.NoError(t, err, "FailOpen: publisher failure must be swallowed on rollback")
+	assert.Equal(t, "v1", rolled.Value)
 }

--- a/cells/config-core/slices/configwrite/contract_test.go
+++ b/cells/config-core/slices/configwrite/contract_test.go
@@ -11,17 +11,18 @@ import (
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
+	"github.com/ghbvf/gocell/cells/config-core/internal/testutil"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func newContractService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+func newContractService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	writer := &testutil.RecordingWriter{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -111,8 +112,8 @@ func TestEventConfigChangedV1Publish_Create(t *testing.T) {
 	_, err := svc.Create(context.Background(), CreateInput{Key: "app.name", Value: "myapp"})
 	require.NoError(t, err)
 
-	require.Len(t, writer.entries, 1, "Create must emit one outbox entry")
-	entry := writer.entries[0]
+	require.Len(t, writer.Entries, 1, "Create must emit one outbox entry")
+	entry := writer.Entries[0]
 	c.ValidatePayload(t, entry.Payload)
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 	c.MustRejectPayload(t, []byte(`{"action":"created","key":"app.name"}`))
@@ -126,13 +127,13 @@ func TestEventConfigChangedV1Publish_Update(t *testing.T) {
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v1"})
 	require.NoError(t, err)
-	writer.entries = nil // reset
+	writer.Entries = nil // reset
 
 	_, err = svc.Update(context.Background(), UpdateInput{Key: "k", Value: "v2"})
 	require.NoError(t, err)
 
-	require.Len(t, writer.entries, 1, "Update must emit one outbox entry")
-	entry := writer.entries[0]
+	require.Len(t, writer.Entries, 1, "Update must emit one outbox entry")
+	entry := writer.Entries[0]
 	c.ValidatePayload(t, entry.Payload)
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 }
@@ -144,13 +145,13 @@ func TestEventConfigChangedV1Publish_Delete(t *testing.T) {
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
-	writer.entries = nil // reset
+	writer.Entries = nil // reset
 
 	err = svc.Delete(context.Background(), "k")
 	require.NoError(t, err)
 
-	require.Len(t, writer.entries, 1, "Delete must emit one outbox entry")
-	entry := writer.entries[0]
+	require.Len(t, writer.Entries, 1, "Delete must emit one outbox entry")
+	entry := writer.Entries[0]
 	c.ValidatePayload(t, entry.Payload)
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
 }

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -104,11 +104,9 @@ type UpdateInput struct {
 }
 
 // Update modifies an existing config entry and publishes a change event.
-// All reads and writes happen inside runInTx to eliminate the TOCTOU stale-read
-// race: GetByKey reads the current sensitive flag under the same transaction
-// that performs the atomic UPDATE...RETURNING.
-//
-// ref: flagwrite.Update — same "all-inside-tx" pattern.
+// The repo reads the sensitive flag internally via SELECT...FOR UPDATE, so no
+// pre-read is needed here. The entire update and outbox write are wrapped in
+// a single transaction for L2 atomicity.
 func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.ConfigEntry, error) {
 	if input.Key == "" {
 		return nil, errcode.New(errcode.ErrConfigInvalidInput, "key is required")
@@ -116,22 +114,8 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.Config
 
 	var updated *domain.ConfigEntry
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
-		// Read inside tx to obtain the current sensitive flag (not changed by
-		// UpdateInput). The ambient transaction ensures this read is consistent
-		// with the subsequent UPDATE.
-		current, err := s.repo.GetByKey(txCtx, input.Key)
-		// NOTE: Under READ COMMITTED (PostgreSQL default), a concurrent Rollback
-		// that changes sensitive between this read and the UPDATE below could make
-		// the sensitive flag stale. This is acceptable because:
-		// 1. No API changes sensitive in a normal Update flow (UpdateInput has no
-		//    Sensitive field); only Rollback restores sensitivity from snapshots.
-		// 2. Concurrent Rollback + Update on the same key is an extremely rare
-		//    admin race. If stricter guarantees are needed, upgrade to REPEATABLE
-		//    READ or add SELECT...FOR UPDATE to the read inside the tx.
-		if err != nil {
-			return fmt.Errorf("config-write: update: %w", err)
-		}
-		updated, err = s.repo.Update(txCtx, input.Key, input.Value, current.Sensitive)
+		var err error
+		updated, err = s.repo.Update(txCtx, input.Key, input.Value)
 		if err != nil {
 			return fmt.Errorf("config-write: update: %w", err)
 		}

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -120,6 +120,14 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.Config
 		// UpdateInput). The ambient transaction ensures this read is consistent
 		// with the subsequent UPDATE.
 		current, err := s.repo.GetByKey(txCtx, input.Key)
+		// NOTE: Under READ COMMITTED (PostgreSQL default), a concurrent Rollback
+		// that changes sensitive between this read and the UPDATE below could make
+		// the sensitive flag stale. This is acceptable because:
+		// 1. No API changes sensitive in a normal Update flow (UpdateInput has no
+		//    Sensitive field); only Rollback restores sensitivity from snapshots.
+		// 2. Concurrent Rollback + Update on the same key is an extremely rare
+		//    admin race. If stricter guarantees are needed, upgrade to REPEATABLE
+		//    READ or add SELECT...FOR UPDATE to the read inside the tx.
 		if err != nil {
 			return fmt.Errorf("config-write: update: %w", err)
 		}

--- a/cells/config-core/slices/configwrite/service.go
+++ b/cells/config-core/slices/configwrite/service.go
@@ -104,34 +104,36 @@ type UpdateInput struct {
 }
 
 // Update modifies an existing config entry and publishes a change event.
+// All reads and writes happen inside runInTx to eliminate the TOCTOU stale-read
+// race: GetByKey reads the current sensitive flag under the same transaction
+// that performs the atomic UPDATE...RETURNING.
+//
+// ref: flagwrite.Update — same "all-inside-tx" pattern.
 func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.ConfigEntry, error) {
 	if input.Key == "" {
 		return nil, errcode.New(errcode.ErrConfigInvalidInput, "key is required")
 	}
 
-	entry, err := s.repo.GetByKey(ctx, input.Key)
-	if err != nil {
-		return nil, fmt.Errorf("config-write: update: %w", err)
-	}
-
-	entry.Value = input.Value
-	entry.Version++
-	entry.UpdatedAt = time.Now()
-
+	var updated *domain.ConfigEntry
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
-		if err := s.repo.Update(txCtx, entry); err != nil {
+		// Read inside tx to obtain the current sensitive flag (not changed by
+		// UpdateInput). The ambient transaction ensures this read is consistent
+		// with the subsequent UPDATE.
+		current, err := s.repo.GetByKey(txCtx, input.Key)
+		if err != nil {
 			return fmt.Errorf("config-write: update: %w", err)
 		}
-		if err := s.publishChange(txCtx, "updated", entry); err != nil {
-			return err
+		updated, err = s.repo.Update(txCtx, input.Key, input.Value, current.Sensitive)
+		if err != nil {
+			return fmt.Errorf("config-write: update: %w", err)
 		}
-		return nil
+		return s.publishChange(txCtx, "updated", updated)
 	}); err != nil {
 		return nil, err
 	}
 
-	s.logger.Info("config entry updated", slog.String("key", entry.Key), slog.Int("version", entry.Version))
-	return entry, nil
+	s.logger.Info("config entry updated", slog.String("key", updated.Key), slog.Int("version", updated.Version))
+	return updated, nil
 }
 
 // Delete removes a config entry by key and publishes a change event.
@@ -140,16 +142,12 @@ func (s *Service) Delete(ctx context.Context, key string) error {
 		return errcode.New(errcode.ErrConfigInvalidInput, "key is required")
 	}
 
-	entry, err := s.repo.GetByKey(ctx, key)
-	if err != nil {
-		return fmt.Errorf("config-write: delete: %w", err)
-	}
-
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
-		if err := s.repo.Delete(txCtx, key); err != nil {
+		deleted, err := s.repo.Delete(txCtx, key)
+		if err != nil {
 			return fmt.Errorf("config-write: delete: %w", err)
 		}
-		if err := s.publishChange(txCtx, "deleted", entry); err != nil {
+		if err := s.publishChange(txCtx, "deleted", deleted); err != nil {
 			return err
 		}
 		return nil

--- a/cells/config-core/slices/configwrite/service_integration_test.go
+++ b/cells/config-core/slices/configwrite/service_integration_test.go
@@ -111,6 +111,69 @@ func TestCreate_AtomicWithOutbox(t *testing.T) {
 		"Create must co-commit exactly one %s outbox row (L2 atomicity)", domain.TopicConfigChanged)
 }
 
+// TestUpdate_AtomicWithOutbox verifies that the config_entries row is updated
+// and an outbox_entries row is co-committed in the same transaction (L2 atomicity).
+func TestUpdate_AtomicWithOutbox(t *testing.T) {
+	bundle, cleanup := setupWriteService(t)
+	defer cleanup()
+
+	// Seed an entry via Create (which itself commits atomically).
+	_, err := bundle.svc.Create(context.Background(), CreateInput{
+		Key:   "integration.atomic.update",
+		Value: "initial",
+	})
+	require.NoError(t, err)
+
+	// Baseline: 1 outbox row from Create above.
+	before := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigChanged)
+
+	updated, err := bundle.svc.Update(context.Background(), UpdateInput{
+		Key:   "integration.atomic.update",
+		Value: "updated-value",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "integration.atomic.update", updated.Key)
+	assert.Equal(t, 2, updated.Version, "Update must bump version")
+
+	// Outbox-side: Update's L2 co-commit must have added exactly one outbox row.
+	after := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigChanged)
+	assert.Equal(t, 1, after-before,
+		"Update must co-commit exactly one %s outbox row (L2 atomicity)", domain.TopicConfigChanged)
+}
+
+// TestDelete_AtomicWithOutbox verifies that the config_entries row is deleted
+// and an outbox_entries row is co-committed in the same transaction (L2 atomicity).
+func TestDelete_AtomicWithOutbox(t *testing.T) {
+	bundle, cleanup := setupWriteService(t)
+	defer cleanup()
+
+	// Seed an entry via Create.
+	_, err := bundle.svc.Create(context.Background(), CreateInput{
+		Key:   "integration.atomic.delete",
+		Value: "to-be-deleted",
+	})
+	require.NoError(t, err)
+
+	// Baseline: 1 outbox row from Create above.
+	before := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigChanged)
+
+	err = bundle.svc.Delete(context.Background(), "integration.atomic.delete")
+	require.NoError(t, err)
+
+	// Outbox-side: Delete's L2 co-commit must have added exactly one outbox row.
+	after := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigChanged)
+	assert.Equal(t, 1, after-before,
+		"Delete must co-commit exactly one %s outbox row (L2 atomicity)", domain.TopicConfigChanged)
+
+	// Domain-side: the config_entries row must be absent after Delete.
+	_, getErr := bundle.svc.repo.GetByKey(context.Background(), "integration.atomic.delete")
+	require.Error(t, getErr, "config_entries row must not exist after Delete")
+	var ec *errcode.Error
+	require.ErrorAs(t, getErr, &ec)
+	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code,
+		"deleted entry must return ErrConfigRepoNotFound")
+}
+
 // TestCreate_RollbackOnOutboxFailure verifies that when the outbox write
 // returns a permanent error, the config_entries row is absent (transaction
 // rolled back atomically).

--- a/cells/config-core/slices/configwrite/service_test.go
+++ b/cells/config-core/slices/configwrite/service_test.go
@@ -7,45 +7,11 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/mem"
-	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/cells/config-core/internal/testutil"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// --- test doubles (ref: order-create/service_test.go) ---
-
-type recordingWriter struct {
-	entries []outbox.Entry
-	err     error
-}
-
-func (w *recordingWriter) Write(_ context.Context, entry outbox.Entry) error {
-	if w.err != nil {
-		return w.err
-	}
-	w.entries = append(w.entries, entry)
-	return nil
-}
-
-var _ outbox.Writer = (*recordingWriter)(nil)
-
-type noopTxRunner struct{ calls int }
-
-func (s *noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
-	s.calls++
-	return fn(ctx)
-}
-
-var _ persistence.TxRunner = (*noopTxRunner)(nil)
-
-type stubPublisher struct{}
-
-func (stubPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
-func (stubPublisher) Close(_ context.Context) error                       { return nil }
-
-var _ outbox.Publisher = stubPublisher{}
 
 func newTestService() (*Service, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
@@ -54,11 +20,11 @@ func newTestService() (*Service, *mem.ConfigRepository) {
 	return NewService(repo, eb, logger), repo
 }
 
-func newDurableTestService() (*Service, *mem.ConfigRepository, *recordingWriter) {
+func newDurableTestService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	writer := &testutil.RecordingWriter{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -205,9 +171,9 @@ func TestService_Delete(t *testing.T) {
 
 func TestService_Create_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{err: errors.New("outbox unavailable")}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.Error(t, err, "Create must propagate outbox.Write error to preserve L2 atomicity")
@@ -216,15 +182,15 @@ func TestService_Create_OutboxWriteError(t *testing.T) {
 
 func TestService_Update_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	goodWriter := &recordingWriter{}
-	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(goodWriter), WithTxManager(&noopTxRunner{}))
+	goodWriter := &testutil.RecordingWriter{}
+	svcGood := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v1"})
 	require.NoError(t, err)
 
-	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(failWriter), WithTxManager(&noopTxRunner{}))
+	failWriter := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(failWriter), WithTxManager(&testutil.NoopTxRunner{}))
 
 	_, err = svc.Update(context.Background(), UpdateInput{Key: "k", Value: "v2"})
 	require.Error(t, err, "Update must propagate outbox.Write error to preserve L2 atomicity")
@@ -233,15 +199,15 @@ func TestService_Update_OutboxWriteError(t *testing.T) {
 
 func TestService_Delete_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	goodWriter := &recordingWriter{}
-	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(goodWriter), WithTxManager(&noopTxRunner{}))
+	goodWriter := &testutil.RecordingWriter{}
+	svcGood := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
 
-	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
-		WithOutboxWriter(failWriter), WithTxManager(&noopTxRunner{}))
+	failWriter := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+		WithOutboxWriter(failWriter), WithTxManager(&testutil.NoopTxRunner{}))
 
 	err = svc.Delete(context.Background(), "k")
 	require.Error(t, err, "Delete must propagate outbox.Write error to preserve L2 atomicity")
@@ -254,43 +220,42 @@ func TestService_Create_DurableMode_CapturesOutboxEntry(t *testing.T) {
 	entry, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
 	assert.Equal(t, "k", entry.Key)
-	require.Len(t, writer.entries, 1)
-	assert.Equal(t, TopicConfigChanged, writer.entries[0].EventType)
+	require.Len(t, writer.Entries, 1)
+	assert.Equal(t, TopicConfigChanged, writer.Entries[0].EventType)
 }
 
 // TestCreate_CallsTxRunnerRunInTxOnce asserts that Create wraps both the repo
 // write and outbox write inside a single RunInTx call (L2 atomicity).
 func TestCreate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	tx := &noopTxRunner{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
+	writer := &testutil.RecordingWriter{}
+	tx := &testutil.NoopTxRunner{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
-	assert.Equal(t, 1, tx.calls, "Create must call RunInTx exactly once")
-	assert.Len(t, writer.entries, 1, "outbox entry must be written inside the tx")
+	assert.Equal(t, 1, tx.Calls, "Create must call RunInTx exactly once")
+	assert.Len(t, writer.Entries, 1, "outbox entry must be written inside the tx")
 }
 
-// TestUpdate_CallsTxRunnerRunInTxOnce asserts that Update wraps the GetByKey
-// read, repo.Update write, and outbox write inside a single RunInTx call
-// (L2 atomicity — all reads and writes are transactional).
+// TestUpdate_CallsTxRunnerRunInTxOnce asserts that Update wraps repo.Update
+// write and outbox write inside a single RunInTx call (L2 atomicity).
 func TestUpdate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	tx := &noopTxRunner{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
+	writer := &testutil.RecordingWriter{}
+	tx := &testutil.NoopTxRunner{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	// Seed via direct repo insert (bypasses service tx counter).
-	_, _ = NewService(repo, stubPublisher{}, slog.Default()).Create(
+	_, _ = NewService(repo, testutil.StubPublisher{}, slog.Default()).Create(
 		context.Background(), CreateInput{Key: "k", Value: "v1"})
 
-	tx.calls = 0 // reset counter after seed
+	tx.Calls = 0 // reset counter after seed
 	_, err := svc.Update(context.Background(), UpdateInput{Key: "k", Value: "v2"})
 	require.NoError(t, err)
-	assert.Equal(t, 1, tx.calls, "Update must call RunInTx exactly once")
+	assert.Equal(t, 1, tx.Calls, "Update must call RunInTx exactly once")
 }
 
 // TestDelete_CallsTxRunnerRunInTxOnce asserts that Delete wraps repo.Delete
@@ -298,29 +263,20 @@ func TestUpdate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 // single RunInTx call (L2 atomicity — no pre-fetch outside the tx).
 func TestDelete_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	writer := &recordingWriter{}
-	tx := &noopTxRunner{}
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
+	writer := &testutil.RecordingWriter{}
+	tx := &testutil.NoopTxRunner{}
+	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	// Seed via direct repo insert (bypasses service tx counter).
-	_, _ = NewService(repo, stubPublisher{}, slog.Default()).Create(
+	_, _ = NewService(repo, testutil.StubPublisher{}, slog.Default()).Create(
 		context.Background(), CreateInput{Key: "k", Value: "v1"})
 
-	tx.calls = 0 // reset counter after seed
+	tx.Calls = 0 // reset counter after seed
 	err := svc.Delete(context.Background(), "k")
 	require.NoError(t, err)
-	assert.Equal(t, 1, tx.calls, "Delete must call RunInTx exactly once")
+	assert.Equal(t, 1, tx.Calls, "Delete must call RunInTx exactly once")
 }
-
-// failingPublisher returns an error on every Publish call, used to drive the
-// publisher-error warn-log branch in Service.publishChange (demo mode).
-type failingPublisher struct{ err error }
-
-func (f failingPublisher) Publish(_ context.Context, _ string, _ []byte) error { return f.err }
-func (f failingPublisher) Close(_ context.Context) error                       { return nil }
-
-var _ outbox.Publisher = failingPublisher{}
 
 // TestService_Create_PublishError_DoesNotFailCreate verifies that demo-mode
 // publisher failure in Service.publishChange is logged but does not propagate
@@ -328,7 +284,7 @@ var _ outbox.Publisher = failingPublisher{}
 // publish path was wrapped in a v1 envelope (P1-14 follow-up).
 func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	fp := failingPublisher{err: errors.New("broker unavailable")}
+	fp := testutil.FailingPublisher{Err: errors.New("broker unavailable")}
 	svc := NewService(repo, fp, slog.Default())
 
 	entry, err := svc.Create(context.Background(), CreateInput{Key: "pub-err", Value: "v"})

--- a/cells/config-core/slices/configwrite/service_test.go
+++ b/cells/config-core/slices/configwrite/service_test.go
@@ -273,8 +273,9 @@ func TestCreate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	assert.Len(t, writer.entries, 1, "outbox entry must be written inside the tx")
 }
 
-// TestUpdate_CallsTxRunnerRunInTxOnce asserts that Update wraps the repo+outbox
-// writes in a single RunInTx (the pre-fetch GetByKey is outside the tx).
+// TestUpdate_CallsTxRunnerRunInTxOnce asserts that Update wraps the GetByKey
+// read, repo.Update write, and outbox write inside a single RunInTx call
+// (L2 atomicity — all reads and writes are transactional).
 func TestUpdate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &recordingWriter{}
@@ -292,8 +293,9 @@ func TestUpdate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	assert.Equal(t, 1, tx.calls, "Update must call RunInTx exactly once")
 }
 
-// TestDelete_CallsTxRunnerRunInTxOnce asserts that Delete wraps the repo+outbox
-// writes in a single RunInTx (the pre-fetch GetByKey is outside the tx).
+// TestDelete_CallsTxRunnerRunInTxOnce asserts that Delete wraps repo.Delete
+// (which returns the deleted entry via RETURNING) and outbox write inside a
+// single RunInTx call (L2 atomicity — no pre-fetch outside the tx).
 func TestDelete_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &recordingWriter{}

--- a/contracts/event/config/changed/v1/payload.schema.json
+++ b/contracts/event/config/changed/v1/payload.schema.json
@@ -8,7 +8,8 @@
     "key": { "type": "string" },
     "value": { "type": "string" },
     "version": { "type": "integer" },
-    "config_id": { "type": "string" }
+    "config_id": { "type": "string" },
+    "sensitive": { "type": "boolean" }
   },
   "additionalProperties": false,
   "oneOf": [
@@ -27,11 +28,11 @@
       "required": ["action", "key"]
     },
     {
-      "description": "published: includes config_id and version (no value)",
+      "description": "published: includes config_id, version, and sensitive flag",
       "properties": {
         "action": { "const": "published" }
       },
-      "required": ["action", "key", "config_id", "version"]
+      "required": ["action", "key", "config_id", "version", "sensitive"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **TOCTOU fix**: configwrite Update/Delete and configpublish Publish/Rollback previously read data outside the transaction boundary, creating a race where concurrent writes could cause lost updates or stale event payloads. All reads now happen inside `runInTx`.
- **Repo atomic signatures**: `ConfigRepository.Update` returns `(*ConfigEntry, error)` via `UPDATE...SET version=version+1 RETURNING`; `Delete` returns deleted entity via `DELETE...RETURNING`. Shared `scanConfigRow`/`decryptScannedEntry` helpers extracted (ref: ent graph.go pattern).
- **S10 MODE-SEMANTIC-SPLIT-01**: `PublishFailureMode` type defined in `configpublish` package (not `pkg/query`) with fail-closed zero-value default. `cell.go` `deriveModes` translates `DurabilityMode → (RunMode, PublishFailureMode)`.
- Supersedes PR #215 (S10 content redone with correct package placement).

## Problem evidence

| Method | Before | After |
|--------|--------|-------|
| `configwrite.Update` | `GetByKey(ctx)` outside tx, version++ in memory | `GetByKey(txCtx)` + `repo.Update(txCtx)` RETURNING inside tx |
| `configwrite.Delete` | `GetByKey(ctx)` outside tx for event payload | `repo.Delete(txCtx)` RETURNING inside tx |
| `configpublish.Publish` | `GetByKey(ctx)` outside tx to build ConfigVersion | `GetByKey(txCtx)` inside tx |
| `configpublish.Rollback` | Two reads outside tx (GetByKey + GetVersion) — worst case | Both reads + `repo.Update` RETURNING all inside tx |

## References
- ref: flagwrite service.go — same "all-inside-tx + RETURNING" pattern
- ref: watermill-sql publisher.go — upstream tx delegation for outbox atomicity
- ref: go-zero sqlx/tx.go — high-order function Session injection
- ref: go-gorm/optimisticlock version.go — RETURNING + version increment pattern

## Files changed (15)

| File | Change |
|------|--------|
| `internal/ports/config_repo.go` | Update/Delete signature change |
| `internal/adapters/postgres/config_repo.go` | Shared helpers + RETURNING impl |
| `internal/mem/config_repo.go` | New signatures |
| `slices/configwrite/service.go` | Reads moved inside tx |
| `slices/configpublish/service.go` | Reads inside tx + S10 PublishFailureMode |
| `slices/configpublish/mode.go` | **New** — PublishFailureMode type |
| `cell.go` | deriveModes + initPublishSlice(mode) |
| + 8 test files | Adapted signatures + S10 + DeriveModes tests |

## Test plan
- [x] `go build ./...` — passes
- [x] `go build -tags=integration ./...` — passes
- [x] `go test ./cells/config-core/...` — all 13 packages pass
- [x] `golangci-lint run ./cells/config-core/...` — 0 issues
- [x] Audit: all `GetByKey`/`GetVersion` calls use `txCtx` (inside tx), not `ctx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)