### PR TITLE
fix(audit-core,router): enforce auth policy + startup route coverage (L1+L2)

### DIFF
--- a/cells/audit-core/cell.go
+++ b/cells/audit-core/cell.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
@@ -122,9 +121,31 @@ func NewAuditCore(opts ...Option) *AuditCore {
 
 // Init constructs all 4 slices.
 func (c *AuditCore) Init(ctx context.Context, deps cell.Dependencies) error {
-	// Resolve HMAC key from Dependencies.Config if not set via option.
+	if err := c.resolveHMACKey(deps.Config); err != nil {
+		return err
+	}
+	if err := c.BaseCell.Init(ctx, deps); err != nil {
+		return err
+	}
+	if err := c.validateOutboxDeps(deps.DurabilityMode); err != nil {
+		return err
+	}
+	c.initSlices()
+	// Default cursor codec for pagination if not injected. Durable mode
+	// refuses the public demo-key fallback — an assembly that forgets to
+	// wire a production codec must fail closed, not silently sign cursors
+	// with a key that ships in the source tree.
+	// ref: zeromicro/go-zero MustSetUp — fatal on insecure default config.
+	if err := c.initCursorCodec(deps.DurabilityMode); err != nil {
+		return err
+	}
+	return c.initQuerySlice(deps.DurabilityMode)
+}
+
+// resolveHMACKey populates c.hmacKey from config if not set via option.
+func (c *AuditCore) resolveHMACKey(cfg map[string]any) error {
 	if len(c.hmacKey) == 0 {
-		if raw, ok := deps.Config["audit.hmac_key"]; ok {
+		if raw, ok := cfg["audit.hmac_key"]; ok {
 			if s, ok := raw.(string); ok && s != "" {
 				c.hmacKey = []byte(s)
 			}
@@ -134,23 +155,22 @@ func (c *AuditCore) Init(ctx context.Context, deps cell.Dependencies) error {
 		return errcode.New(errcode.ErrValidationFailed,
 			"audit-core: HMAC key is required (set via WithHMACKey or config audit.hmac_key)")
 	}
+	return nil
+}
 
-	if err := c.BaseCell.Init(ctx, deps); err != nil {
-		return err
-	}
-
+// validateOutboxDeps enforces the XOR constraint on outboxWriter/txRunner and
+// the demo-mode publisher requirement.
+func (c *AuditCore) validateOutboxDeps(mode cell.DurabilityMode) error {
 	// Fail-fast: outboxWriter and txRunner must be both present or both absent (XOR constraint).
 	// Both present = durable mode (L2 atomicity). Both absent = demo/in-memory mode.
 	if (c.outboxWriter == nil) != (c.txRunner == nil) {
 		return errcode.New(errcode.ErrCellMissingOutbox,
 			"audit-core durable mode requires both outboxWriter and txRunner")
 	}
-
 	// Durable mode: reject noop implementations.
-	if err := cell.CheckNotNoop(deps.DurabilityMode, "audit-core", c.outboxWriter, c.txRunner, c.publisher); err != nil {
+	if err := cell.CheckNotNoop(mode, "audit-core", c.outboxWriter, c.txRunner, c.publisher); err != nil {
 		return err
 	}
-
 	// Demo mode: both nil → require publisher for degraded event delivery.
 	if c.outboxWriter == nil && c.txRunner == nil {
 		if c.publisher == nil {
@@ -163,7 +183,13 @@ func (c *AuditCore) Init(ctx context.Context, deps cell.Dependencies) error {
 				slog.Int("consistency_level", int(c.ConsistencyLevel())))
 		}
 	}
+	return nil
+}
 
+// initSlices constructs and registers the audit-append, audit-verify, and
+// audit-archive slices. audit-query is initialised separately in initQuerySlice
+// because it requires the cursor codec to be resolved first.
+func (c *AuditCore) initSlices() {
 	// audit-append
 	var appendOpts []auditappend.Option
 	if c.outboxWriter != nil {
@@ -191,25 +217,18 @@ func (c *AuditCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	// audit-archive (stub)
 	c.archiveSvc = auditarchive.NewService()
 	c.AddSlice(cell.NewBaseSlice("auditarchive", "audit-core", cell.L1))
+}
 
-	// Default cursor codec for pagination if not injected. Durable mode
-	// refuses the public demo-key fallback — an assembly that forgets to
-	// wire a production codec must fail closed, not silently sign cursors
-	// with a key that ships in the source tree.
-	// ref: zeromicro/go-zero MustSetUp — fatal on insecure default config.
-	if err := c.initCursorCodec(deps.DurabilityMode); err != nil {
-		return err
-	}
-
-	// audit-query
+// initQuerySlice constructs the audit-query handler slice. Must be called after
+// initCursorCodec so that c.cursorCodec is set.
+func (c *AuditCore) initQuerySlice(mode cell.DurabilityMode) error {
 	querySvc, err := auditquery.NewService(c.auditRepo, c.cursorCodec, c.logger,
-		query.RunModeForDemo(deps.DurabilityMode == cell.DurabilityDemo))
+		query.RunModeForDemo(mode == cell.DurabilityDemo))
 	if err != nil {
 		return fmt.Errorf("audit-query: %w", err)
 	}
 	c.queryHandler = auditquery.NewHandler(querySvc)
 	c.AddSlice(cell.NewBaseSlice("auditquery", "audit-core", cell.L0))
-
 	return nil
 }
 
@@ -238,7 +257,7 @@ func (c *AuditCore) initCursorCodec(mode cell.DurabilityMode) error {
 // RegisterRoutes registers HTTP routes for audit-core.
 func (c *AuditCore) RegisterRoutes(mux cell.RouteMux) {
 	mux.Route("/api/v1/audit", func(sub cell.RouteMux) {
-		sub.Handle("GET /entries", http.HandlerFunc(c.queryHandler.HandleQuery))
+		c.queryHandler.RegisterRoutes(sub)
 	})
 }
 

--- a/cells/audit-core/cell_test.go
+++ b/cells/audit-core/cell_test.go
@@ -273,8 +273,8 @@ func TestAuditCore_RouteQueryEntries(t *testing.T) {
 	req = req.WithContext(auth.TestContext("usr-1", nil))
 	r.ServeHTTP(rec, req)
 
-	assert.NotEqual(t, http.StatusNotFound, rec.Code,
-		"GET /api/v1/audit/entries should not return 404 (got %d)", rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"GET /api/v1/audit/entries should return 200 (got %d)", rec.Code)
 }
 
 // TestInit_DurableMode_RejectsMissingCursorCodec locks the fail-fast

--- a/cells/audit-core/cell_test.go
+++ b/cells/audit-core/cell_test.go
@@ -266,9 +266,11 @@ func TestAuditCore_RouteQueryEntries(t *testing.T) {
 
 	r := router.New()
 	c.RegisterRoutes(r)
+	require.NoError(t, r.FinalizeAuth())
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries", nil)
+	req = req.WithContext(auth.TestContext("usr-1", nil))
 	r.ServeHTTP(rec, req)
 
 	assert.NotEqual(t, http.StatusNotFound, rec.Code,
@@ -355,6 +357,7 @@ func TestAuditCore_Wiring_StaleCursor_DemoVsDurable(t *testing.T) {
 
 			r := router.New()
 			c.RegisterRoutes(r)
+			require.NoError(t, r.FinalizeAuth())
 
 			rec := httptest.NewRecorder()
 			ctx := auth.TestContext("admin-user", []string{"admin"})

--- a/cells/audit-core/slices/auditquery/contract_test.go
+++ b/cells/audit-core/slices/auditquery/contract_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
+// newContractQueryHandler builds an http.Handler that registers auditquery
+// routes at the canonical API prefix via RegisterRoutes + http.StripPrefix.
+// RegisterRoutes calls auth.Declare to install the auditQueryPolicy, so the
+// contract test exercises the same guard the production mux uses — not just
+// the happy-path handler.
 func newContractQueryHandler(entries ...*domain.AuditEntry) http.Handler {
 	repo := mem.NewAuditRepository()
 	for _, e := range entries {
@@ -25,9 +30,11 @@ func newContractQueryHandler(entries ...*domain.AuditEntry) http.Handler {
 		panic(err)
 	}
 	h := NewHandler(svc)
-	mux := http.NewServeMux()
-	mux.Handle("GET /api/v1/audit/entries", http.HandlerFunc(h.HandleQuery))
-	return mux
+	inner := http.NewServeMux()
+	h.RegisterRoutes(inner)
+	outer := http.NewServeMux()
+	outer.Handle("/api/v1/audit/", http.StripPrefix("/api/v1/audit", inner))
+	return outer
 }
 
 func TestHttpAuditListV1Serve(t *testing.T) {

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/audit-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/audit-core/internal/ports"
+	cell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -64,6 +65,19 @@ func auditQueryPolicy(r *http.Request) error {
 		return nil
 	}
 	return auth.AnyRole("admin")(r)
+}
+
+// RegisterRoutes registers auditquery routes with the audit-query policy on
+// any cell.RouteHandler (satisfied by both *http.ServeMux and cell.RouteMux)
+// so production wiring, contract tests, and cell-level integration tests
+// share the same auth.Declare declarations.
+func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
+	auth.Declare(mux, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/entries",
+		Handler: http.HandlerFunc(h.HandleQuery),
+		Policy:  auditQueryPolicy,
+	})
 }
 
 // HandleQuery handles GET /api/v1/audit/entries.

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -93,6 +93,10 @@ func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	// fail closed rather than panic on nil dereference.
 	p, ok := auth.FromContext(r.Context())
 	if !ok {
+		slog.Error("audit: handler reached without principal — policy chain may be misconfigured",
+			slog.String("path", r.URL.Path),
+			slog.String("method", r.Method),
+		)
 		httputil.WriteError(r.Context(), w, http.StatusUnauthorized, string(errcode.ErrAuthUnauthorized), "authentication required")
 		return
 	}

--- a/cells/audit-core/slices/auditquery/handler_test.go
+++ b/cells/audit-core/slices/auditquery/handler_test.go
@@ -233,6 +233,83 @@ func TestAuditEntryResponse_ExcludesInternalFields(t *testing.T) {
 	assert.NotContains(t, body, `"hash"`)
 }
 
+// TestHandler_RegisterRoutes_AuthzNegative validates that RegisterRoutes installs
+// the auditQueryPolicy so unauthenticated and cross-user requests are rejected at
+// the route layer, not inside HandleQuery. This mirrors the production guard path.
+func TestHandler_RegisterRoutes_AuthzNegative(t *testing.T) {
+	repo := mem.NewAuditRepository()
+	svc, err := NewService(repo, testCodec(), slog.Default(), query.RunModeProd)
+	require.NoError(t, err)
+	h := NewHandler(svc)
+
+	// Seed one entry for usr-1 and one for usr-2.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, repo.Append(context.Background(), &domain.AuditEntry{
+		ID: "rr-1", EventID: "evt-rr-1", EventType: "event.test.v1",
+		ActorID: "usr-1", Timestamp: base, Payload: []byte("{}"),
+	}))
+	require.NoError(t, repo.Append(context.Background(), &domain.AuditEntry{
+		ID: "rr-2", EventID: "evt-rr-2", EventType: "event.test.v1",
+		ActorID: "usr-2", Timestamp: base.Add(time.Hour), Payload: []byte("{}"),
+	}))
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	tests := []struct {
+		name       string
+		subject    string
+		roles      []string
+		actorID    string
+		wantStatus int
+	}{
+		{
+			name:       "no_auth",
+			subject:    "",
+			roles:      nil,
+			actorID:    "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "non_admin_cross_user",
+			subject:    "usr-1",
+			roles:      []string{"viewer"},
+			actorID:    "usr-2",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "self_access",
+			subject:    "usr-1",
+			roles:      nil,
+			actorID:    "usr-1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "admin_cross_user",
+			subject:    "admin-1",
+			roles:      []string{"admin"},
+			actorID:    "usr-2",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			url := "/entries"
+			if tc.actorID != "" {
+				url += "?actorId=" + tc.actorID
+			}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			if tc.subject != "" {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			mux.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
 // Trust boundary tests (#27q)
 func TestHandleQuery_ActorBinding(t *testing.T) {
 	repo := mem.NewAuditRepository()
@@ -240,15 +317,10 @@ func TestHandleQuery_ActorBinding(t *testing.T) {
 	require.NoError(t, err)
 	h := NewHandler(svc)
 
-	// securedMux registers HandleQuery with auditQueryPolicy via auth.Declare so
-	// that trust boundary tests go through the policy as in production.
+	// securedMux registers HandleQuery via RegisterRoutes, mirroring production
+	// wiring so trust boundary tests exercise the same auth.Declare guard.
 	securedMux := http.NewServeMux()
-	auth.Declare(securedMux, auth.RouteDecl{
-		Method:  "GET",
-		Path:    "/api/v1/audit/entries",
-		Handler: http.HandlerFunc(h.HandleQuery),
-		Policy:  auditQueryPolicy,
-	})
+	h.RegisterRoutes(securedMux)
 
 	// Seed entries for two actors
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -311,7 +383,7 @@ func TestHandleQuery_ActorBinding(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries"+tc.query, nil)
+			req := httptest.NewRequest(http.MethodGet, "/entries"+tc.query, nil)
 			if tc.subject != "" {
 				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
 			}

--- a/cells/audit-core/slices/auditquery/handler_test.go
+++ b/cells/audit-core/slices/auditquery/handler_test.go
@@ -334,12 +334,13 @@ func TestHandleQuery_ActorBinding(t *testing.T) {
 	}))
 
 	tests := []struct {
-		name       string
-		query      string
-		subject    string
-		roles      []string
-		wantStatus int
-		wantCount  int // -1 = don't check
+		name            string
+		query           string
+		subject         string
+		roles           []string
+		injectEmptyAuth bool // inject auth.TestContext("", nil) — authenticated but empty Subject
+		wantStatus      int
+		wantCount       int // -1 = don't check
 	}{
 		{
 			name:       "self actorId matches subject",
@@ -378,13 +379,23 @@ func TestHandleQuery_ActorBinding(t *testing.T) {
 			wantStatus: http.StatusUnauthorized,
 			wantCount:  -1,
 		},
+		{
+			name:            "empty subject in principal returns 401",
+			query:           "",
+			injectEmptyAuth: true,
+			wantStatus:      http.StatusUnauthorized,
+			wantCount:       -1,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/entries"+tc.query, nil)
-			if tc.subject != "" {
+			switch {
+			case tc.injectEmptyAuth:
+				req = req.WithContext(auth.TestContext("", tc.roles))
+			case tc.subject != "":
 				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
 			}
 			securedMux.ServeHTTP(w, req)

--- a/cells/order-cell/cell.go
+++ b/cells/order-cell/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // Compile-time interface checks.
@@ -154,9 +155,24 @@ func (c *OrderCell) Init(ctx context.Context, deps cell.Dependencies) error {
 func (c *OrderCell) RegisterRoutes(mux cell.RouteMux) {
 	mux.Route("/api/v1", func(v1 cell.RouteMux) {
 		v1.Route("/orders", func(orders cell.RouteMux) {
-			orders.Handle("POST /", http.HandlerFunc(c.createHandler.HandleCreate))
-			orders.Handle("GET /", http.HandlerFunc(c.queryHandler.HandleList))
-			orders.Handle("GET /{id}", http.HandlerFunc(c.queryHandler.HandleGet))
+			auth.Declare(orders, auth.RouteDecl{
+				Method:  "POST",
+				Path:    "/",
+				Handler: http.HandlerFunc(c.createHandler.HandleCreate),
+				Policy:  auth.Authenticated(),
+			})
+			auth.Declare(orders, auth.RouteDecl{
+				Method:  "GET",
+				Path:    "/",
+				Handler: http.HandlerFunc(c.queryHandler.HandleList),
+				Policy:  auth.Authenticated(),
+			})
+			auth.Declare(orders, auth.RouteDecl{
+				Method:  "GET",
+				Path:    "/{id}",
+				Handler: http.HandlerFunc(c.queryHandler.HandleGet),
+				Policy:  auth.Authenticated(),
+			})
 		})
 	})
 }

--- a/cells/order-cell/cell_test.go
+++ b/cells/order-cell/cell_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/http/router"
 )
 
@@ -254,6 +255,7 @@ func initCellWithRouter(t *testing.T) *router.Router {
 
 	r := router.New()
 	c.RegisterRoutes(r)
+	require.NoError(t, r.FinalizeAuth())
 	return r
 }
 
@@ -263,6 +265,7 @@ func TestOrderCell_RouteCreateOrder(t *testing.T) {
 	body := `{"item":"test-widget"}`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orders/", strings.NewReader(body))
+	req = req.WithContext(auth.TestContext("usr-1", nil))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(rec, req)
 
@@ -275,6 +278,7 @@ func TestOrderCell_RouteListOrders(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/", nil)
+	req = req.WithContext(auth.TestContext("usr-1", nil))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code,
@@ -288,6 +292,7 @@ func TestOrderCell_RouteGetOrder(t *testing.T) {
 	body := `{"item":"queryable"}`
 	createRec := httptest.NewRecorder()
 	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/orders/", strings.NewReader(body))
+	createReq = createReq.WithContext(auth.TestContext("usr-1", nil))
 	createReq.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(createRec, createReq)
 	require.Equal(t, http.StatusCreated, createRec.Code)
@@ -305,6 +310,7 @@ func TestOrderCell_RouteGetOrder(t *testing.T) {
 	// GET the created order by its actual ID.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/"+orderID, nil)
+	req = req.WithContext(auth.TestContext("usr-1", nil))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code,
@@ -316,6 +322,7 @@ func TestOrderCell_RouteGetOrder_NotFound(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/nonexistent", nil)
+	req = req.WithContext(auth.TestContext("usr-1", nil))
 	r.ServeHTTP(rec, req)
 
 	// 404 is the correct domain response for a nonexistent order.

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -2227,14 +2227,24 @@ func newHTTPCell(id string) *httpCell {
 }
 
 func (c *httpCell) RegisterRoutes(mux cell.RouteMux) {
-	mux.Handle("GET /api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"data":"ok"}`))
-	}))
-	mux.Handle("POST /api/v1/access/sessions/login", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"data":{"token":"test"}}`))
-	}))
+	auth.Declare(mux, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/api/v1/data",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":"ok"}`))
+		}),
+		Policy: auth.Authenticated(),
+	})
+	auth.Declare(mux, auth.RouteDecl{
+		Method: http.MethodPost,
+		Path:   "/api/v1/access/sessions/login",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"token":"test"}}`))
+		}),
+		Public: true,
+	})
 }
 
 // bootstrapTestVerifier is a minimal IntentTokenVerifier for bootstrap tests.
@@ -2322,10 +2332,15 @@ func newPublicHTTPCell(id string) *publicHTTPCell {
 }
 
 func (c *publicHTTPCell) RegisterRoutes(mux cell.RouteMux) {
-	mux.Handle("GET /api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"data":"ok"}`))
-	}))
+	auth.Declare(mux, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/api/v1/data",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":"ok"}`))
+		}),
+		Public: true,
+	})
 	auth.Declare(mux, auth.RouteDecl{
 		Method: http.MethodPost,
 		Path:   "/api/v1/access/sessions/login",
@@ -2517,10 +2532,15 @@ func TestBootstrap_TracingE2E_BusinessRoute(t *testing.T) {
 
 	var gotTraceID string
 	tc := newTracingTestCell("trace-biz", func(mux cell.RouteMux) {
-		mux.Handle("GET /api/v1/trace-test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
-			w.WriteHeader(http.StatusOK)
-		}))
+		auth.Declare(mux, auth.RouteDecl{
+			Method: http.MethodGet,
+			Path:   "/api/v1/trace-test",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
+				w.WriteHeader(http.StatusOK)
+			}),
+			Delegated: true,
+		})
 	})
 
 	asm := assembly.New(assembly.Config{ID: "trace-e2e", DurabilityMode: cell.DurabilityDemo})
@@ -2555,10 +2575,15 @@ func TestBootstrap_TracingE2E_UpstreamPropagation(t *testing.T) {
 
 	var gotTraceID string
 	tc := newTracingTestCell("trace-upstream", func(mux cell.RouteMux) {
-		mux.Handle("GET /api/v1/propagate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
-			w.WriteHeader(http.StatusOK)
-		}))
+		auth.Declare(mux, auth.RouteDecl{
+			Method: http.MethodGet,
+			Path:   "/api/v1/propagate",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
+				w.WriteHeader(http.StatusOK)
+			}),
+			Delegated: true,
+		})
 	})
 
 	asm := assembly.New(assembly.Config{ID: "trace-upstream", DurabilityMode: cell.DurabilityDemo})
@@ -2598,9 +2623,14 @@ func TestBootstrap_TracingE2E_PanicRoute(t *testing.T) {
 	tracer := tracing.NewTracer("bootstrap-panic-e2e")
 
 	tc := newTracingTestCell("trace-panic", func(mux cell.RouteMux) {
-		mux.Handle("GET /api/v1/boom", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-			panic("boom for tracing test")
-		}))
+		auth.Declare(mux, auth.RouteDecl{
+			Method: http.MethodGet,
+			Path:   "/api/v1/boom",
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				panic("boom for tracing test")
+			}),
+			Delegated: true,
+		})
 	})
 
 	asm := assembly.New(assembly.Config{ID: "trace-panic", DurabilityMode: cell.DurabilityDemo})
@@ -2687,10 +2717,15 @@ func (c *authProviderCell) TokenVerifier() auth.IntentTokenVerifier {
 }
 
 func (c *authProviderCell) RegisterRoutes(mux cell.RouteMux) {
-	mux.Handle("GET /api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"data":"ok"}`))
-	}))
+	auth.Declare(mux, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/api/v1/data",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":"ok"}`))
+		}),
+		Policy: auth.Authenticated(),
+	})
 	// F3: login is declared as a public route so auth discovery tests can verify
 	// that no-token requests bypass JWT checks on this endpoint.
 	auth.Declare(mux, auth.RouteDecl{
@@ -3257,11 +3292,16 @@ func (c *traceCapturingCell) RegisterRoutes(mux cell.RouteMux) {
 		}),
 		Public: true,
 	})
-	mux.Handle("GET /api/v1/protected/ping", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tid, _ := ctxkeys.TraceIDFrom(r.Context())
-		c.gotProtected <- tid
-		w.WriteHeader(http.StatusOK)
-	}))
+	auth.Declare(mux, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/api/v1/protected/ping",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tid, _ := ctxkeys.TraceIDFrom(r.Context())
+			c.gotProtected <- tid
+			w.WriteHeader(http.StatusOK)
+		}),
+		Policy: auth.Authenticated(),
+	})
 }
 
 // TestBootstrap_TrustBoundary_PublicEndpoint_TraceparentIgnored verifies the

--- a/runtime/bootstrap/internal_guard_test.go
+++ b/runtime/bootstrap/internal_guard_test.go
@@ -87,23 +87,32 @@ func TestWithInternalEndpointGuard_PrefixMustEndWithSlash(t *testing.T) {
 // routeRegisterCell registers an HTTP route at the given path so we can probe it.
 type routeRegisterCell struct {
 	*cell.BaseCell
-	path    string
-	handler http.HandlerFunc
+	method    string
+	path      string
+	handler   http.HandlerFunc
+	delegated bool
 }
 
-func newRouteRegisterCell(id, path string, h http.HandlerFunc) *routeRegisterCell {
+func newRouteRegisterCell(id, method, path string, h http.HandlerFunc, delegated bool) *routeRegisterCell {
 	return &routeRegisterCell{
 		BaseCell: cell.NewBaseCell(cell.CellMetadata{
 			ID:   id,
 			Type: cell.CellTypeCore,
 		}),
-		path:    path,
-		handler: h,
+		method:    method,
+		path:      path,
+		handler:   h,
+		delegated: delegated,
 	}
 }
 
 func (c *routeRegisterCell) RegisterRoutes(mux cell.RouteMux) {
-	mux.Handle(c.path, c.handler)
+	auth.Declare(mux, auth.RouteDecl{
+		Method:    c.method,
+		Path:      c.path,
+		Handler:   c.handler,
+		Delegated: c.delegated,
+	})
 }
 
 func TestWithInternalEndpointGuard_Wiring(t *testing.T) {
@@ -121,16 +130,16 @@ func TestWithInternalEndpointGuard_Wiring(t *testing.T) {
 
 	asm := assembly.New(assembly.Config{ID: "guard-wiring-test", DurabilityMode: cell.DurabilityDemo})
 
-	internalCell := newRouteRegisterCell("internal-cell", "/internal/v1/roles",
+	internalCell := newRouteRegisterCell("internal-cell", http.MethodGet, "/internal/v1/roles",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			internalHit.Add(1)
 			w.WriteHeader(http.StatusOK)
-		}))
-	apiCell := newRouteRegisterCell("api-cell", "/api/v1/users",
+		}), true)
+	apiCell := newRouteRegisterCell("api-cell", http.MethodGet, "/api/v1/users",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			apiHit.Add(1)
 			w.WriteHeader(http.StatusOK)
-		}))
+		}), false)
 
 	require.NoError(t, asm.Register(internalCell))
 	require.NoError(t, asm.Register(apiCell))
@@ -221,14 +230,14 @@ func TestWithInternalEndpointGuard_BypassesJWT(t *testing.T) {
 
 	asm := assembly.New(assembly.Config{ID: "bypass-jwt-test", DurabilityMode: cell.DurabilityDemo})
 
-	internalCell := newRouteRegisterCell("internal-cell", "/internal/v1/roles",
+	internalCell := newRouteRegisterCell("internal-cell", http.MethodGet, "/internal/v1/roles",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK) // only reached if guard allows
-		}))
-	apiCell := newRouteRegisterCell("api-cell", "/api/v1/users",
+		}), true)
+	apiCell := newRouteRegisterCell("api-cell", http.MethodGet, "/api/v1/users",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		}))
+		}), false)
 
 	require.NoError(t, asm.Register(internalCell))
 	require.NoError(t, asm.Register(apiCell))

--- a/runtime/http/router/policy_coverage.go
+++ b/runtime/http/router/policy_coverage.go
@@ -42,6 +42,10 @@ var businessMethods = map[string]bool{
 // chi and stdlib ServeMux both route HEAD to the GET handler automatically, so
 // requiring a separate HEAD auth.Declare would be redundant boilerplate.
 //
+// OPTIONS routes must be explicitly declared via auth.Declare (typically with
+// Public: true for CORS preflight). Unlike HEAD, there is no auto-coverage
+// from GET declarations.
+//
 // ref: kubernetes/apiserver — structural injection guarantees every handler
 // has an authorizer; GoCell achieves the same guarantee at startup time
 // by enumerating chi routes and comparing against auth.Declare metadata.
@@ -70,30 +74,9 @@ func verifyPolicyCoverage(
 	// Walk registered routes and collect uncovered ones.
 	var uncovered []string
 	for _, r := range registeredRoutes {
-		method := strings.ToUpper(r.Method)
-		cleanedPath := path.Clean(r.Path)
-
-		// Skip non-business methods (e.g. CONNECT from chi sub-router internals).
-		if !businessMethods[method] {
-			continue
+		if entry, ok := classifyRoute(r, declared, getDeclared, exactWhitelist, prefixWhitelist); !ok {
+			uncovered = append(uncovered, entry)
 		}
-
-		// Already declared via auth.Declare.
-		if declared[method+"\x00"+cleanedPath] {
-			continue
-		}
-
-		// HEAD auto-covered by GET declaration (RFC 7231 §4.3.2).
-		if method == "HEAD" && getDeclared[cleanedPath] {
-			continue
-		}
-
-		// Whitelisted.
-		if matchWhitelist(method, cleanedPath, exactWhitelist, prefixWhitelist) {
-			continue
-		}
-
-		uncovered = append(uncovered, method+" "+cleanedPath)
 	}
 
 	if len(uncovered) == 0 {
@@ -105,6 +88,51 @@ func verifyPolicyCoverage(
 			"use auth.Declare to register routes, or add to WithPolicyCoverageWhitelist if exempt",
 		len(uncovered), strings.Join(uncovered, ", "),
 	)
+}
+
+// classifyRoute decides whether a single registered route is covered.
+// Returns (entry, false) when the route is uncovered, where entry is the
+// human-readable label to include in the error. Returns ("", true) when
+// the route is covered or skipped (non-business method).
+func classifyRoute(
+	r routeKey,
+	declared map[string]bool,
+	getDeclared map[string]bool,
+	exactWhitelist map[string]bool,
+	prefixWhitelist []string,
+) (entry string, covered bool) {
+	method := strings.ToUpper(r.Method)
+	cleanedPath := path.Clean(r.Path)
+
+	// Flag routes with empty or unrecognized methods — these cannot be
+	// covered by auth.Declare which requires an explicit HTTP method.
+	// chi.Walk should not produce empty methods, but defense-in-depth
+	// catches malformed route registrations.
+	if method == "" {
+		return "(empty method) " + cleanedPath, false
+	}
+
+	// Skip non-business methods (e.g. CONNECT from chi sub-router internals).
+	if !businessMethods[method] {
+		return "", true
+	}
+
+	// Already declared via auth.Declare.
+	if declared[method+"\x00"+cleanedPath] {
+		return "", true
+	}
+
+	// HEAD auto-covered by GET declaration (RFC 7231 §4.3.2).
+	if method == "HEAD" && getDeclared[cleanedPath] {
+		return "", true
+	}
+
+	// Whitelisted.
+	if matchWhitelist(method, cleanedPath, exactWhitelist, prefixWhitelist) {
+		return "", true
+	}
+
+	return method + " " + cleanedPath, false
 }
 
 // parseWhitelist splits whitelist entries into exact and prefix sets.

--- a/runtime/http/router/policy_coverage.go
+++ b/runtime/http/router/policy_coverage.go
@@ -1,0 +1,159 @@
+package router
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	kcell "github.com/ghbvf/gocell/kernel/cell"
+)
+
+// routeKey is a (method, path) pair from the chi router tree.
+type routeKey struct {
+	Method string
+	Path   string
+}
+
+// businessMethods is the set of HTTP methods that must have an auth declaration.
+// CONNECT and TRACE are excluded: they are infrastructure-level methods that
+// GoCell cells never register as business handlers.
+var businessMethods = map[string]bool{
+	"GET":     true,
+	"HEAD":    true,
+	"POST":    true,
+	"PUT":     true,
+	"PATCH":   true,
+	"DELETE":  true,
+	"OPTIONS": true,
+}
+
+// verifyPolicyCoverage checks that every registered business route has an
+// auth declaration (via auth.Declare). Routes that are Public, Delegated,
+// or whitelisted are auto-exempted.
+//
+// Returns an error listing all uncovered routes. Intended to be called by
+// FinalizeAuth after all Cell RegisterRoutes calls have completed.
+//
+// Whitelist entries support two formats:
+//   - Exact: "METHOD /path" (e.g. "GET /debug/pprof")
+//   - Prefix: "/path/*"     (e.g. "/debug/*" — method-agnostic prefix exemption)
+//
+// HEAD is auto-covered when the same path has a GET declaration (RFC 7231 §4.3.2):
+// chi and stdlib ServeMux both route HEAD to the GET handler automatically, so
+// requiring a separate HEAD auth.Declare would be redundant boilerplate.
+//
+// ref: kubernetes/apiserver — structural injection guarantees every handler
+// has an authorizer; GoCell achieves the same guarantee at startup time
+// by enumerating chi routes and comparing against auth.Declare metadata.
+func verifyPolicyCoverage(
+	registeredRoutes []routeKey,
+	declaredMetas []kcell.AuthRouteMeta,
+	whitelist []string,
+) error {
+	// Build declared set: any auth.Declare call (Public/Delegated/Policy) counts
+	// as coverage. Keyed on "METHOD\x00/clean/path".
+	declared := make(map[string]bool, len(declaredMetas))
+	// Track GET declarations for HEAD auto-coverage (RFC 7231 §4.3.2).
+	getDeclared := make(map[string]bool, len(declaredMetas))
+
+	for _, m := range declaredMetas {
+		key := strings.ToUpper(m.Method) + "\x00" + path.Clean(m.Path)
+		declared[key] = true
+		if strings.EqualFold(m.Method, "GET") {
+			getDeclared[path.Clean(m.Path)] = true
+		}
+	}
+
+	// Parse whitelist entries.
+	exactWhitelist, prefixWhitelist := parseWhitelist(whitelist)
+
+	// Walk registered routes and collect uncovered ones.
+	var uncovered []string
+	for _, r := range registeredRoutes {
+		method := strings.ToUpper(r.Method)
+		cleanedPath := path.Clean(r.Path)
+
+		// Skip non-business methods (e.g. CONNECT from chi sub-router internals).
+		if !businessMethods[method] {
+			continue
+		}
+
+		// Already declared via auth.Declare.
+		if declared[method+"\x00"+cleanedPath] {
+			continue
+		}
+
+		// HEAD auto-covered by GET declaration (RFC 7231 §4.3.2).
+		if method == "HEAD" && getDeclared[cleanedPath] {
+			continue
+		}
+
+		// Whitelisted.
+		if matchWhitelist(method, cleanedPath, exactWhitelist, prefixWhitelist) {
+			continue
+		}
+
+		uncovered = append(uncovered, method+" "+cleanedPath)
+	}
+
+	if len(uncovered) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"router: %d route(s) registered without auth.Declare: [%s]; "+
+			"use auth.Declare to register routes, or add to WithPolicyCoverageWhitelist if exempt",
+		len(uncovered), strings.Join(uncovered, ", "),
+	)
+}
+
+// parseWhitelist splits whitelist entries into exact and prefix sets.
+//
+// Exact entries have the format "METHOD /path" (e.g. "GET /debug/pprof").
+// Prefix entries have the format "/path/*" (e.g. "/debug/*").
+// All other formats are silently ignored (fail-open for whitelist parsing;
+// FinalizeAuth validates business route coverage separately).
+func parseWhitelist(whitelist []string) (exact map[string]bool, prefixes []string) {
+	exact = make(map[string]bool, len(whitelist))
+	for _, entry := range whitelist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		// Prefix pattern: starts with '/' and ends with '/*'.
+		if strings.HasPrefix(entry, "/") && strings.HasSuffix(entry, "/*") {
+			// Normalize: strip the trailing '*' to get the prefix stem.
+			stem := strings.TrimSuffix(entry, "*")
+			prefixes = append(prefixes, stem)
+			continue
+		}
+		// Exact pattern: "METHOD /path".
+		parts := strings.SplitN(entry, " ", 2)
+		if len(parts) == 2 {
+			method := strings.ToUpper(strings.TrimSpace(parts[0]))
+			p := path.Clean(strings.TrimSpace(parts[1]))
+			exact[method+"\x00"+p] = true
+		}
+	}
+	return exact, prefixes
+}
+
+// matchWhitelist returns true when (method, cleanPath) is covered by the
+// exact whitelist or any prefix pattern.
+//
+// stem is the prefix stored by parseWhitelist, e.g. "/debug/" for "/debug/*".
+// A cleanPath matches the stem when it equals the stem-without-trailing-slash
+// (e.g. "/debug") or when it starts with the stem (e.g. "/debug/pprof").
+func matchWhitelist(method, cleanPath string, exact map[string]bool, prefixes []string) bool {
+	if exact[method+"\x00"+cleanPath] {
+		return true
+	}
+	for _, stem := range prefixes {
+		// stem has a trailing '/'; strip it to get the exact-match form.
+		stemNoTrailing := strings.TrimSuffix(stem, "/")
+		if cleanPath == stemNoTrailing || strings.HasPrefix(cleanPath, stemNoTrailing+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/runtime/http/router/policy_coverage.go
+++ b/runtime/http/router/policy_coverage.go
@@ -111,8 +111,8 @@ func verifyPolicyCoverage(
 //
 // Exact entries have the format "METHOD /path" (e.g. "GET /debug/pprof").
 // Prefix entries have the format "/path/*" (e.g. "/debug/*").
-// All other formats are silently ignored (fail-open for whitelist parsing;
-// FinalizeAuth validates business route coverage separately).
+// Malformed entries are silently skipped — FinalizeAuth still enforces
+// coverage for any route not matched by a valid entry (fail-closed overall).
 func parseWhitelist(whitelist []string) (exact map[string]bool, prefixes []string) {
 	exact = make(map[string]bool, len(whitelist))
 	for _, entry := range whitelist {

--- a/runtime/http/router/policy_coverage_test.go
+++ b/runtime/http/router/policy_coverage_test.go
@@ -1,0 +1,131 @@
+package router
+
+import (
+	"testing"
+
+	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyPolicyCoverage(t *testing.T) {
+	tests := []struct {
+		name        string
+		routes      []routeKey            // registered routes from chi.Walk
+		metas       []kcell.AuthRouteMeta // declared auth metas
+		whitelist   []string              // whitelist patterns
+		wantErr     bool
+		errContains string // substring in error message
+	}{
+		{
+			name: "all_declared_no_error",
+			routes: []routeKey{
+				{Method: "GET", Path: "/api/v1/users"},
+				{Method: "POST", Path: "/api/v1/users"},
+			},
+			metas: []kcell.AuthRouteMeta{
+				{Method: "GET", Path: "/api/v1/users"},
+				{Method: "POST", Path: "/api/v1/users"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing_policy_returns_error",
+			routes: []routeKey{
+				{Method: "GET", Path: "/api/v1/users"},
+				{Method: "POST", Path: "/api/v1/orders"},
+			},
+			metas: []kcell.AuthRouteMeta{
+				{Method: "GET", Path: "/api/v1/users"},
+				// POST /api/v1/orders intentionally missing
+			},
+			wantErr:     true,
+			errContains: "POST /api/v1/orders",
+		},
+		{
+			name: "public_route_auto_exempt",
+			routes: []routeKey{
+				{Method: "POST", Path: "/api/v1/auth/login"},
+			},
+			metas: []kcell.AuthRouteMeta{
+				{Method: "POST", Path: "/api/v1/auth/login", Public: true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "delegated_route_auto_exempt",
+			routes: []routeKey{
+				{Method: "GET", Path: "/internal/v1/service"},
+			},
+			metas: []kcell.AuthRouteMeta{
+				{Method: "GET", Path: "/internal/v1/service", Delegated: true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "whitelisted_exact_match",
+			routes: []routeKey{
+				{Method: "GET", Path: "/debug/pprof"},
+			},
+			metas:     []kcell.AuthRouteMeta{},
+			whitelist: []string{"GET /debug/pprof"},
+			wantErr:   false,
+		},
+		{
+			name: "whitelisted_prefix_match",
+			routes: []routeKey{
+				{Method: "GET", Path: "/debug/pprof"},
+				{Method: "GET", Path: "/debug/vars"},
+			},
+			metas:     []kcell.AuthRouteMeta{},
+			whitelist: []string{"/debug/*"},
+			wantErr:   false,
+		},
+		{
+			name: "multiple_missing_actionable_error",
+			routes: []routeKey{
+				{Method: "GET", Path: "/api/v1/items"},
+				{Method: "DELETE", Path: "/api/v1/items/{id}"},
+				{Method: "POST", Path: "/api/v1/items"},
+			},
+			metas: []kcell.AuthRouteMeta{
+				{Method: "POST", Path: "/api/v1/items"},
+				// GET /api/v1/items and DELETE /api/v1/items/{id} missing
+			},
+			wantErr:     true,
+			errContains: "2 route(s)",
+		},
+		{
+			name:    "empty_routes_no_error",
+			routes:  []routeKey{},
+			metas:   []kcell.AuthRouteMeta{},
+			wantErr: false,
+		},
+		{
+			name: "head_auto_covered_by_get",
+			routes: []routeKey{
+				{Method: "GET", Path: "/api/v1/resources"},
+				{Method: "HEAD", Path: "/api/v1/resources"},
+			},
+			metas: []kcell.AuthRouteMeta{
+				{Method: "GET", Path: "/api/v1/resources"},
+				// HEAD is not declared but auto-covered by GET per RFC 7231 §4.3.2
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyPolicyCoverage(tc.routes, tc.metas, tc.whitelist)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/runtime/http/router/policy_coverage_test.go
+++ b/runtime/http/router/policy_coverage_test.go
@@ -102,6 +102,16 @@ func TestVerifyPolicyCoverage(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "malformed_whitelist_entry_silently_ignored",
+			routes: []routeKey{
+				{Method: "GET", Path: "/api/v1/secret"},
+			},
+			metas:       []kcell.AuthRouteMeta{},
+			whitelist:   []string{"INVALID_ENTRY", "just-a-word"},
+			wantErr:     true,
+			errContains: "GET /api/v1/secret",
+		},
+		{
 			name: "head_auto_covered_by_get",
 			routes: []routeKey{
 				{Method: "GET", Path: "/api/v1/resources"},

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -665,10 +665,11 @@ func (r *Router) FinalizeAuth() error {
 		r.deriveHint()
 
 		// Warn when auth declarations exist but no verifier is installed: the
-		// Public/Policy/PasswordResetExempt semantics compile successfully but
-		// AuthMiddleware is absent so none of the declarations have any effect.
+		// Public/PasswordResetExempt matchers need AuthMiddleware to run, but
+		// Policy guards are inlined into handlers via RequirePolicy at Declare
+		// time and remain effective regardless.
 		if r.authVerifier == nil {
-			slog.Warn("router: FinalizeAuth compiled route auth declarations but AuthMiddleware is not installed; Public/Policy/PasswordResetExempt declarations will have no effect",
+			slog.Warn("router: FinalizeAuth compiled route auth declarations but AuthMiddleware is not installed; Public/PasswordResetExempt matchers will have no effect (Policy guards run inline regardless)",
 				slog.Int("declared", len(r.declaredAuthMetas)))
 		}
 	}

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -249,6 +249,19 @@ func WithInternalPathPrefixGuard(prefix string, guard func(http.Handler) http.Ha
 	}
 }
 
+// WithPolicyCoverageWhitelist sets route patterns exempt from policy coverage
+// verification. Entries use "METHOD /path" for exact match or "/path/*" for
+// prefix match. Routes on outerMux (healthz, readyz, metrics) are
+// automatically excluded.
+//
+// ref: kubernetes/apiserver — structural injection guarantees authorizer
+// presence; GoCell's startup-time verification achieves the same guarantee.
+func WithPolicyCoverageWhitelist(patterns []string) Option {
+	return func(r *Router) {
+		r.policyCoverageWhitelist = append(r.policyCoverageWhitelist, patterns...)
+	}
+}
+
 // Router wraps chi.Mux and implements kernel/cell.RouteMux.
 //
 // Internally it uses two chi.Mux instances:
@@ -303,6 +316,10 @@ type Router struct {
 	// POST + PasswordResetExempt meta. Served at request time via
 	// WithPasswordResetChangeEndpointHintFn.
 	derivedHint string
+
+	// policyCoverageWhitelist holds patterns exempt from policy coverage
+	// verification. Populated by WithPolicyCoverageWhitelist.
+	policyCoverageWhitelist []string
 }
 
 // New creates a Router with default middleware and optional configuration.
@@ -623,40 +640,63 @@ func (r *Router) DeclareAuthMeta(m kcell.AuthRouteMeta) {
 //   - "router: FinalizeAuth called twice"
 //   - "router: duplicate auth declaration METHOD /path"
 //
-// It is safe to call FinalizeAuth with an empty declaredAuthMetas slice (no-op
-// beyond setting authFinalized).
+// It is safe to call FinalizeAuth with an empty declaredAuthMetas slice; the
+// policy coverage check still runs to catch routes registered without any
+// auth.Declare call.
 func (r *Router) FinalizeAuth() error {
 	if r.authFinalized {
 		return fmt.Errorf("router: FinalizeAuth called twice")
 	}
 	r.authFinalized = true
 
-	if len(r.declaredAuthMetas) == 0 {
-		return nil
+	if len(r.declaredAuthMetas) > 0 {
+		partitioned, err := partitionAuthMetas(r.declaredAuthMetas)
+		if err != nil {
+			return err
+		}
+
+		if err := r.mergePublicMatcher(partitioned.publicEntries); err != nil {
+			return err
+		}
+		if err := r.mergeExemptMatcher(partitioned.exemptEntries); err != nil {
+			return err
+		}
+		r.mergeDelegatedMatcher(partitioned.delegatedMatcher)
+		r.deriveHint()
+
+		// Warn when auth declarations exist but no verifier is installed: the
+		// Public/Policy/PasswordResetExempt semantics compile successfully but
+		// AuthMiddleware is absent so none of the declarations have any effect.
+		if r.authVerifier == nil {
+			slog.Warn("router: FinalizeAuth compiled route auth declarations but AuthMiddleware is not installed; Public/Policy/PasswordResetExempt declarations will have no effect",
+				slog.Int("declared", len(r.declaredAuthMetas)))
+		}
 	}
 
-	partitioned, err := partitionAuthMetas(r.declaredAuthMetas)
-	if err != nil {
-		return err
+	// Policy coverage verification: every business route registered on r.mux
+	// must have a corresponding auth.Declare call (Public, Delegated, or with
+	// Policy). Routes on outerMux (healthz, readyz, metrics) are excluded.
+	routes := r.enumerateBusinessRoutes()
+	if err := verifyPolicyCoverage(routes, r.declaredAuthMetas, r.policyCoverageWhitelist); err != nil {
+		return fmt.Errorf("router: policy coverage: %w", err)
 	}
 
-	if err := r.mergePublicMatcher(partitioned.publicEntries); err != nil {
-		return err
-	}
-	if err := r.mergeExemptMatcher(partitioned.exemptEntries); err != nil {
-		return err
-	}
-	r.mergeDelegatedMatcher(partitioned.delegatedMatcher)
-	r.deriveHint()
-
-	// Warn when auth declarations exist but no verifier is installed: the
-	// Public/Policy/PasswordResetExempt semantics compile successfully but
-	// AuthMiddleware is absent so none of the declarations have any effect.
-	if r.authVerifier == nil && len(r.declaredAuthMetas) > 0 {
-		slog.Warn("router: FinalizeAuth compiled route auth declarations but AuthMiddleware is not installed; Public/Policy/PasswordResetExempt declarations will have no effect",
-			slog.Int("declared", len(r.declaredAuthMetas)))
-	}
 	return nil
+}
+
+// enumerateBusinessRoutes walks the chi business mux and returns all registered
+// (method, path) pairs. Infrastructure routes on outerMux (healthz, readyz,
+// metrics) are excluded because they are not registered through Cell
+// RegisterRoutes.
+func (r *Router) enumerateBusinessRoutes() []routeKey {
+	var routes []routeKey
+	// chi.Walk never returns a non-nil error when the walker callback always
+	// returns nil; the error return is part of the interface but unused here.
+	_ = chi.Walk(r.mux, func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		routes = append(routes, routeKey{Method: method, Path: route})
+		return nil
+	})
+	return routes
 }
 
 // authMetaPartition holds the categorised results of partitionAuthMetas.

--- a/runtime/http/router/router_authmeta_test.go
+++ b/runtime/http/router/router_authmeta_test.go
@@ -121,10 +121,18 @@ func TestFinalizeAuth_PublicMeta_BypassesAuth(t *testing.T) {
 	r, err := NewE(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
-	r.Handle("/public", okHandler)
-	r.Handle("/protected", okHandler)
-
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/public", Public: true})
+	// Use auth.Declare so every registered route has a corresponding auth declaration.
+	auth.Declare(r, auth.RouteDecl{
+		Method: "GET", Path: "/public",
+		Handler: okHandler,
+		Public:  true,
+	})
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/protected",
+		Handler: okHandler,
+		Policy:  auth.Authenticated(),
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Public route: no token → 200
@@ -151,10 +159,19 @@ func TestFinalizeAuth_PasswordResetExempt_Meta(t *testing.T) {
 	r, err := NewE(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
-	r.Handle("/exempt", okHandler)
-	r.Handle("/blocked", okHandler)
-
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "POST", Path: "/exempt", PasswordResetExempt: true})
+	// Use auth.Declare so every registered route has a corresponding auth declaration.
+	auth.Declare(r, auth.RouteDecl{
+		Method:              "POST",
+		Path:                "/exempt",
+		Handler:             okHandler,
+		PasswordResetExempt: true,
+	})
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/blocked",
+		Handler: okHandler,
+		Policy:  auth.Authenticated(),
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Exempt route with password-reset token → 200
@@ -228,13 +245,18 @@ func TestFinalizeAuth_HintDerivedFromPostExemptMeta(t *testing.T) {
 	r, err := NewE(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
-	r.Handle("/blocked", okHandler)
-	r.Handle("/change-password", okHandler)
-
-	// No legacy hint set; POST + PasswordResetExempt meta should derive hint
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{
+	// Use auth.Declare so every registered route has a corresponding auth declaration.
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/blocked",
+		Handler: okHandler,
+		Policy:  auth.Authenticated(),
+	})
+	// POST + PasswordResetExempt meta should derive hint.
+	auth.Declare(r, auth.RouteDecl{
 		Method:              "POST",
 		Path:                "/change-password",
+		Handler:             okHandler,
 		PasswordResetExempt: true,
 	})
 	require.NoError(t, r.FinalizeAuth())
@@ -265,12 +287,23 @@ func TestFinalizeAuth_MultipleDeclaredPublic_ORMerged(t *testing.T) {
 	r, err := NewE(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
-	r.Handle("/declared-public-a", okHandler)
-	r.Handle("/declared-public-b", okHandler)
-	r.Handle("/protected", okHandler)
-
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/declared-public-a", Public: true})
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/declared-public-b", Public: true})
+	// Use auth.Declare so every registered route has a corresponding auth declaration.
+	auth.Declare(r, auth.RouteDecl{
+		Method: "GET", Path: "/declared-public-a",
+		Handler: okHandler,
+		Public:  true,
+	})
+	auth.Declare(r, auth.RouteDecl{
+		Method: "GET", Path: "/declared-public-b",
+		Handler: okHandler,
+		Public:  true,
+	})
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/protected",
+		Handler: okHandler,
+		Policy:  auth.Authenticated(),
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// First declared public route: no token → 200
@@ -357,11 +390,20 @@ func TestFinalizeAuth_DelegatedMeta_BypassesJWT(t *testing.T) {
 	r, err := NewE(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
-	r.Handle("/delegated", okHandler)
-	r.Handle("/normal", okHandler)
-
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/delegated", Delegated: true})
-	// /normal has no meta → it requires JWT.
+	// Use auth.Declare so every registered route has a corresponding auth declaration.
+	auth.Declare(r, auth.RouteDecl{
+		Method:    "GET",
+		Path:      "/delegated",
+		Handler:   okHandler,
+		Delegated: true,
+	})
+	// /normal requires JWT — declared with Policy to satisfy coverage enforcement.
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/normal",
+		Handler: okHandler,
+		Policy:  auth.Authenticated(),
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Delegated route: no token → 200 (JWT verification skipped).
@@ -401,11 +443,17 @@ func TestFinalizeAuth_DelegatedMeta_ORMergesWithInternalGuard(t *testing.T) {
 	require.NoError(t, err)
 
 	// Declare a delegated route outside the internal prefix.
-	r.Handle("/api/v1/svc-route", okHandler)
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/api/v1/svc-route", Delegated: true})
+	auth.Declare(r, auth.RouteDecl{
+		Method:    "GET",
+		Path:      "/api/v1/svc-route",
+		Handler:   okHandler,
+		Delegated: true,
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Route under /internal/v1/ is already delegated via the guard option.
+	// Registered after FinalizeAuth so it is not subject to coverage verification;
+	// the internal prefix guard provides the auth layer for this path.
 	r.Handle("/internal/v1/thing", okHandler)
 
 	// Internal prefix route: JWT skipped (delegated), guard passes with token.
@@ -432,10 +480,14 @@ func TestFinalizeAuth_MethodCaseNormalisation(t *testing.T) {
 	r, err := NewE(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
-	r.Handle("/submit", okHandler)
-
+	// Use auth.Declare so the registered route has a corresponding auth declaration.
 	// Method declared as "POST" (uppercase — validateOrPanic enforces this).
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "POST", Path: "/submit", Delegated: true})
+	auth.Declare(r, auth.RouteDecl{
+		Method:    "POST",
+		Path:      "/submit",
+		Handler:   okHandler,
+		Delegated: true,
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// net/http canonicalises Method to uppercase for incoming requests, so POST
@@ -446,4 +498,69 @@ func TestFinalizeAuth_MethodCaseNormalisation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/submit", nil)
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "POST declared delegated route must bypass JWT verification")
+}
+
+// ---------------------------------------------------------------------------
+// Policy coverage verification tests
+// ---------------------------------------------------------------------------
+
+func TestFinalizeAuth_PolicyCoverage_DetectsMissingPolicy(t *testing.T) {
+	// A route registered via raw Handle without auth.Declare must cause
+	// FinalizeAuth to return an error listing the uncovered route.
+	r, err := NewE(WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}))
+	require.NoError(t, err)
+
+	// /unguarded is registered without auth.Declare — coverage violation.
+	r.Handle("GET /unguarded", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+
+	// /guarded is registered via auth.Declare — covered.
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/guarded",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		Policy:  auth.Authenticated(),
+	})
+
+	err = r.FinalizeAuth()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GET /unguarded", "error must list the uncovered route")
+	assert.NotContains(t, err.Error(), "GET /guarded", "covered route must not appear in error")
+}
+
+func TestFinalizeAuth_PolicyCoverage_AllDeclaredOK(t *testing.T) {
+	// All registered routes have auth.Declare — FinalizeAuth must succeed.
+	r, err := NewE(WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}))
+	require.NoError(t, err)
+
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/api/v1/items",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		Policy:  auth.Authenticated(),
+	})
+	auth.Declare(r, auth.RouteDecl{
+		Method:  "POST",
+		Path:    "/api/v1/login",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		Public:  true,
+	})
+
+	err = r.FinalizeAuth()
+	require.NoError(t, err)
+}
+
+func TestFinalizeAuth_PolicyCoverage_WhitelistExempts(t *testing.T) {
+	// Routes matching WithPolicyCoverageWhitelist patterns are exempt from
+	// coverage enforcement even when registered via raw Handle.
+	r, err := NewE(
+		WithPolicyCoverageWhitelist([]string{"/debug/*"}),
+		WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}),
+	)
+	require.NoError(t, err)
+
+	// Registered without auth.Declare but whitelisted via prefix pattern.
+	r.Handle("GET /debug/pprof", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+
+	err = r.FinalizeAuth()
+	require.NoError(t, err, "whitelisted route must not trigger policy coverage error")
 }

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -971,10 +971,16 @@ func TestDeclareAuth_AuthBypass_MethodMismatch_Returns401(t *testing.T) {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
 		Public:  true,
 	})
-	// Also register the GET so the router can match it (otherwise 404).
-	r.Handle("/api/v1/auth/login", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("GET must not bypass auth when only POST is declared public")
-	}))
+	// Register GET with a policy so it is covered by policy enforcement;
+	// the verifier always fails so a GET without a token still returns 401.
+	auth.Declare(r, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/api/v1/auth/login",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("GET must not bypass auth when only POST is declared public")
+		}),
+		Policy: auth.Authenticated(),
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	rec := httptest.NewRecorder()
@@ -1000,10 +1006,17 @@ func TestDeclareAuth_TracingNewRoot(t *testing.T) {
 		}),
 		Public: true,
 	})
-	r.Handle("/internal", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		internalTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
-		w.WriteHeader(http.StatusOK)
-	}))
+	// /internal uses Delegated so it is covered by policy enforcement; no auth
+	// verifier is installed so Delegated is the right semantic.
+	auth.Declare(r, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/internal",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			internalTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+		Delegated: true,
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
@@ -1038,10 +1051,17 @@ func TestDeclareAuth_RequestIDRejectsClient(t *testing.T) {
 		}),
 		Public: true,
 	})
-	r.Handle("/internal", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		internalID, _ = ctxkeys.RequestIDFrom(req.Context())
-		w.WriteHeader(http.StatusOK)
-	}))
+	// /internal uses Delegated so it is covered by policy enforcement; no auth
+	// verifier is installed so Delegated is the right semantic.
+	auth.Declare(r, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/internal",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			internalID, _ = ctxkeys.RequestIDFrom(req.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+		Delegated: true,
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	rec := httptest.NewRecorder()
@@ -1070,9 +1090,13 @@ func TestDeclareAuth_ProtectedStillRequiresAuth(t *testing.T) {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
 		Public:  true,
 	})
-	r.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	// /api/v1/data is protected — declared with a policy to satisfy coverage enforcement.
+	auth.Declare(r, auth.RouteDecl{
+		Method:  http.MethodGet,
+		Path:    "/api/v1/data",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+		Policy:  auth.Authenticated(),
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Protected endpoint without token → 401.
@@ -1104,9 +1128,13 @@ func TestDeclareAuth_UserTracingOptions_FineGrained(t *testing.T) {
 		}),
 		Public: true,
 	})
-	r.Handle("/fine-grained-public", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	// /fine-grained-public uses Delegated so it is covered by policy enforcement.
+	auth.Declare(r, auth.RouteDecl{
+		Method:    http.MethodGet,
+		Path:      "/fine-grained-public",
+		Handler:   http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+		Delegated: true,
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	var publicTraceID, fineTraceID string
@@ -1127,10 +1155,16 @@ func TestDeclareAuth_UserTracingOptions_FineGrained(t *testing.T) {
 		}),
 		Public: true,
 	})
-	r2.Handle("/fine-grained-public", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		fineTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
-		w.WriteHeader(http.StatusOK)
-	}))
+	// /fine-grained-public uses Delegated so it is covered by policy enforcement.
+	auth.Declare(r2, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/fine-grained-public",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			fineTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+		Delegated: true,
+	})
 	require.NoError(t, r2.FinalizeAuth())
 
 	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
@@ -1208,10 +1242,16 @@ func TestDeclareAuth_NoPublicDecls_TracingUnchanged(t *testing.T) {
 	r := New(WithTracer(tracer))
 
 	var traceID string
-	r.Handle("/test", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		traceID, _ = ctxkeys.TraceIDFrom(req.Context())
-		w.WriteHeader(http.StatusOK)
-	}))
+	// /test uses Delegated so it is covered by policy enforcement; no auth verifier is installed.
+	auth.Declare(r, auth.RouteDecl{
+		Method: http.MethodGet,
+		Path:   "/test",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			traceID, _ = ctxkeys.TraceIDFrom(req.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+		Delegated: true,
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
@@ -1263,10 +1303,14 @@ func TestDeclareAuth_MethodAware_GETDoesNotBypassForPOSTOnly(t *testing.T) {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
 		Public:  true,
 	})
-	// Register the GET handler so it can be matched and receive auth check.
-	r.Handle("/api/v1/auth/login", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	// Register the GET handler with a policy so it is covered by policy enforcement;
+	// auth middleware will require a valid token for GET.
+	auth.Declare(r, auth.RouteDecl{
+		Method:  http.MethodGet,
+		Path:    "/api/v1/auth/login",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+		Policy:  auth.Authenticated(),
+	})
 	require.NoError(t, r.FinalizeAuth())
 
 	// POST without token → public, 200.


### PR DESCRIPTION
## Summary

- **L1 AUDIT-ROUTE-POLICY-01 (P0 Cx2)**: `cells/audit-core/cell.go:241` registered `GET /entries` via bare `sub.Handle()`, bypassing `auth.Declare()` and `auditQueryPolicy`. Non-admin users could read other users' audit records. Fix: `Handler.RegisterRoutes(mux cell.RouteHandler)` calls `auth.Declare` with `auditQueryPolicy`; `cell.go` delegates to it.
- **L2 ROUTE-POLICY-REGISTRY-01 (P1 Cx3)**: No compile/startup-time detection of routes without auth policy. Fix: `FinalizeAuth()` now enumerates business routes via `chi.Walk` and verifies each has a corresponding `auth.Declare` call. Uncovered routes fail startup with actionable error. HEAD auto-covered by GET (RFC 7231 §4.3.2). Whitelist support via `WithPolicyCoverageWhitelist`.

ref: kubernetes/apiserver — structural injection guarantees authorizer presence
ref: ory/oathkeeper — no-match = 404 default-deny

## Changes

### L1 (audit-core)
| File | Change |
|------|--------|
| `cells/audit-core/slices/auditquery/handler.go` | Add `RegisterRoutes(mux cell.RouteHandler)` with `auth.Declare` + `auditQueryPolicy` |
| `cells/audit-core/cell.go` | Replace bare `sub.Handle()` → `c.queryHandler.RegisterRoutes(sub)`; extract Init helpers for cognitive complexity |
| `cells/audit-core/slices/auditquery/handler_test.go` | Add `TestHandler_RegisterRoutes_AuthzNegative` (401/403/200/admin); refactor `TestHandleQuery_ActorBinding` |
| `cells/audit-core/slices/auditquery/contract_test.go` | Use `RegisterRoutes` + `StripPrefix` pattern |
| `cells/audit-core/cell_test.go` | Add `FinalizeAuth()` + `auth.TestContext` for route tests |

### L2 (router policy coverage)
| File | Change |
|------|--------|
| `runtime/http/router/policy_coverage.go` | **New**: `verifyPolicyCoverage()` pure function, `routeKey`, `parseWhitelist`, `matchWhitelist` |
| `runtime/http/router/policy_coverage_test.go` | **New**: 9 table-driven tests |
| `runtime/http/router/router.go` | Add `policyCoverageWhitelist` field, `WithPolicyCoverageWhitelist` Option, `enumerateBusinessRoutes()`, wire into `FinalizeAuth()` |
| `runtime/http/router/router_authmeta_test.go` | Fix 7 existing tests to use `auth.Declare`; add 3 policy coverage integration tests |
| `runtime/http/router/router_test.go` | Fix 7 existing tests to use `auth.Declare` |

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./cells/audit-core/...` — all pass
- [x] `go test ./runtime/http/router/...` — 59/60 pass (1 pre-existing WebSocket sandbox failure)
- [x] `golangci-lint run ./cells/audit-core/... ./runtime/http/router/...` — 0 issues
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)