### PR TITLE
feat(device-list,rbaccheck,httputil): device-list slice + rbaccheck pagination + ParsePageRequestOrWrite (P1-8 + L8)

### DIFF
--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/worker"
 )
@@ -82,6 +83,11 @@ func WithJWTVerifier(verifier *auth.JWTVerifier) Option {
 // WithOutboxWriter sets the outbox.Writer for transactional event publishing.
 func WithOutboxWriter(w outbox.Writer) Option {
 	return func(c *AccessCore) { c.outboxWriter = w }
+}
+
+// WithCursorCodec sets the cursor codec for pagination. Required in durable mode.
+func WithCursorCodec(codec *query.CursorCodec) Option {
+	return func(c *AccessCore) { c.cursorCodec = codec }
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
@@ -201,6 +207,7 @@ type AccessCore struct {
 	logger       *slog.Logger
 	jwtIssuer    *auth.JWTIssuer
 	jwtVerifier  *auth.JWTVerifier
+	cursorCodec  *query.CursorCodec
 
 	// Bootstrap configuration (set via WithInitialAdminBootstrap).
 	initialAdminCfg     *initialAdminConfig
@@ -459,8 +466,18 @@ func (c *AccessCore) initSlices() error {
 	c.authzSvc = authorizationdecide.NewService(c.roleRepo, c.logger)
 	c.AddSlice(cell.NewBaseSlice("authorizationdecide", "access-core", cell.L0))
 
+	// Initialize cursor codec for pagination (rbac-check).
+	if c.cursorCodec == nil {
+		codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+		if err != nil {
+			return err
+		}
+		c.cursorCodec = codec
+		c.logger.Warn("access-core: using default cursor codec (demo mode)")
+	}
+
 	// rbac-check
-	rbacSvc := rbaccheck.NewService(c.roleRepo, c.logger)
+	rbacSvc := rbaccheck.NewService(c.roleRepo, c.cursorCodec, c.logger)
 	c.rbacHandler = rbaccheck.NewHandler(rbacSvc)
 	c.AddSlice(cell.NewBaseSlice("rbaccheck", "access-core", cell.L0))
 

--- a/cells/access-core/cell.go
+++ b/cells/access-core/cell.go
@@ -406,7 +406,7 @@ func (c *AccessCore) validateDemoMode() error {
 
 // initSlices constructs all 9 slice services and handlers.
 // Extracted from Init to reduce cognitive complexity.
-func (c *AccessCore) initSlices() error {
+func (c *AccessCore) initSlices(deps cell.Dependencies) error {
 	// session-login must be constructed before identity-manage because
 	// ChangePassword injects loginSvc as the TokenIssuer.
 	var loginOpts []sessionlogin.Option
@@ -468,6 +468,10 @@ func (c *AccessCore) initSlices() error {
 
 	// Initialize cursor codec for pagination (rbac-check).
 	if c.cursorCodec == nil {
+		if deps.DurabilityMode == cell.DurabilityDurable {
+			return errcode.New(errcode.ErrCellMissingCodec,
+				"access-core durable mode requires a cursor codec; use WithCursorCodec(query.NewCursorCodec(secret)) — the built-in demo key is public in the source tree")
+		}
 		codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
 		if err != nil {
 			return err
@@ -477,7 +481,8 @@ func (c *AccessCore) initSlices() error {
 	}
 
 	// rbac-check
-	rbacSvc := rbaccheck.NewService(c.roleRepo, c.cursorCodec, c.logger)
+	rbacSvc := rbaccheck.NewService(c.roleRepo, c.cursorCodec, c.logger,
+		query.RunModeForDemo(deps.DurabilityMode == cell.DurabilityDemo))
 	c.rbacHandler = rbaccheck.NewHandler(rbacSvc)
 	c.AddSlice(cell.NewBaseSlice("rbaccheck", "access-core", cell.L0))
 
@@ -526,7 +531,7 @@ func (c *AccessCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := c.runInitialAdminBootstrap(ctx); err != nil {
 		return err
 	}
-	if err := c.initSlices(); err != nil {
+	if err := c.initSlices(deps); err != nil {
 		return err
 	}
 	return nil

--- a/cells/access-core/internal/initialadmin/bootstrap_test.go
+++ b/cells/access-core/internal/initialadmin/bootstrap_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,6 +137,9 @@ func (r *countingRoleRepo) RemoveFromUser(ctx context.Context, userID, roleID st
 }
 func (r *countingRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
 	return r.inner.RemoveFromUserIfNotLast(ctx, userID, roleID)
+}
+func (r *countingRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
+	return r.inner.GetByUserID(ctx, userID)
 }
 
 var _ ports.RoleRepository = (*countingRoleRepo)(nil)

--- a/cells/access-core/internal/initialadmin/bootstrap_test.go
+++ b/cells/access-core/internal/initialadmin/bootstrap_test.go
@@ -139,7 +139,7 @@ func (r *countingRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, 
 	return r.inner.RemoveFromUserIfNotLast(ctx, userID, roleID)
 }
 func (r *countingRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
-	return r.inner.GetByUserID(ctx, userID)
+	return r.inner.ListByUserID(ctx, userID, params)
 }
 
 var _ ports.RoleRepository = (*countingRoleRepo)(nil)

--- a/cells/access-core/internal/mem/role_repo.go
+++ b/cells/access-core/internal/mem/role_repo.go
@@ -1,6 +1,7 @@
 package mem
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"sync"
@@ -8,6 +9,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 )
 
 var _ ports.RoleRepository = (*RoleRepository)(nil)
@@ -142,6 +144,56 @@ func (r *RoleRepository) RemoveFromUserIfNotLast(_ context.Context, userID, role
 
 	delete(r.userRoles[userID], roleID)
 	return true, nil
+}
+
+// ListByUserID returns paginated roles for userID sorted per params.
+func (r *RoleRepository) ListByUserID(_ context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	roleIDs, ok := r.userRoles[userID]
+	if !ok {
+		return []*domain.Role{}, nil
+	}
+
+	roles := make([]*domain.Role, 0, len(roleIDs))
+	for rid := range roleIDs {
+		if role, ok := r.roles[rid]; ok {
+			clone := *role
+			clone.Permissions = make([]domain.Permission, len(role.Permissions))
+			copy(clone.Permissions, role.Permissions)
+			roles = append(roles, &clone)
+		}
+	}
+
+	query.Sort(roles, params.Sort, compareRoleField)
+	result, err := query.ApplyCursor(roles, params, roleFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("role-repo: list-by-user: %w", err)
+	}
+	return result, nil
+}
+
+func compareRoleField(a, b *domain.Role, field string) int {
+	switch field {
+	case "name":
+		return cmp.Compare(a.Name, b.Name)
+	case "id":
+		return cmp.Compare(a.ID, b.ID)
+	default:
+		return 0
+	}
+}
+
+func roleFieldValue(r *domain.Role, field string) any {
+	switch field {
+	case "name":
+		return r.Name
+	case "id":
+		return r.ID
+	default:
+		return ""
+	}
 }
 
 // CountByRole returns the number of users assigned to the given role.

--- a/cells/access-core/internal/ports/role_repo.go
+++ b/cells/access-core/internal/ports/role_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
+	"github.com/ghbvf/gocell/pkg/query"
 )
 
 // RoleRepository persists and retrieves Role entities and user-role assignments.
@@ -27,4 +28,7 @@ type RoleRepository interface {
 	// Callers gate outbox emission on changed.
 	RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (changed bool, err error)
 	CountByRole(ctx context.Context, roleID string) (int, error)
+	// ListByUserID returns a paginated list of roles assigned to userID,
+	// sorted and filtered per params.
+	ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error)
 }

--- a/cells/access-core/slices/rbaccheck/contract_test.go
+++ b/cells/access-core/slices/rbaccheck/contract_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -27,7 +28,12 @@ func newContractRBACHandler() http.Handler {
 		},
 	})
 	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
-	svc := NewService(roleRepo, slog.Default())
+
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+	if err != nil {
+		panic(err)
+	}
+	svc := NewService(roleRepo, codec, slog.Default())
 
 	inner := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(inner)
@@ -48,6 +54,11 @@ func TestHttpAuthRoleListV1Serve(t *testing.T) {
 	req = req.WithContext(auth.TestContext("user-1", nil))
 	h.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
+
+	// MustRejectResponse: missing required hasMore field
+	c.MustRejectResponse(t, []byte(`{"data":[]}`))
+	// MustRejectResponse: data is not an array
+	c.MustRejectResponse(t, []byte(`{"data":{"wrong":"shape"},"hasMore":false}`))
 }
 
 func TestHttpAuthRoleCheckV1Serve(t *testing.T) {

--- a/cells/access-core/slices/rbaccheck/contract_test.go
+++ b/cells/access-core/slices/rbaccheck/contract_test.go
@@ -33,7 +33,7 @@ func newContractRBACHandler() http.Handler {
 	if err != nil {
 		panic(err)
 	}
-	svc := NewService(roleRepo, codec, slog.Default())
+	svc := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
 
 	inner := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(inner)

--- a/cells/access-core/slices/rbaccheck/handler.go
+++ b/cells/access-core/slices/rbaccheck/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -66,17 +67,19 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 
 func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("userID")
-	roles, err := h.svc.ListRoles(r.Context(), userID)
+
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.svc.ListRoles(r.Context(), userID, pageReq)
 	if err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
 
-	resp := make([]RoleResponse, len(roles))
-	for i, role := range roles {
-		resp[i] = toRoleResponse(role)
-	}
-	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": resp, "hasMore": false})
+	httputil.WriteJSON(w, http.StatusOK, query.MapPageResult(result, toRoleResponse))
 }
 
 func (h *Handler) handleHasRole(w http.ResponseWriter, r *http.Request) {

--- a/cells/access-core/slices/rbaccheck/handler_test.go
+++ b/cells/access-core/slices/rbaccheck/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -63,7 +64,11 @@ func setup() http.Handler {
 	})
 	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
 
-	svc := NewService(roleRepo, slog.Default())
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+	if err != nil {
+		panic(err)
+	}
+	svc := NewService(roleRepo, codec, slog.Default())
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux

--- a/cells/access-core/slices/rbaccheck/handler_test.go
+++ b/cells/access-core/slices/rbaccheck/handler_test.go
@@ -68,7 +68,7 @@ func setup() http.Handler {
 	if err != nil {
 		panic(err)
 	}
-	svc := NewService(roleRepo, codec, slog.Default())
+	svc := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux

--- a/cells/access-core/slices/rbaccheck/service.go
+++ b/cells/access-core/slices/rbaccheck/service.go
@@ -23,11 +23,12 @@ type Service struct {
 	roleRepo ports.RoleRepository
 	codec    *query.CursorCodec
 	logger   *slog.Logger
+	runMode  query.RunMode
 }
 
 // NewService creates an rbac-check Service.
-func NewService(roleRepo ports.RoleRepository, codec *query.CursorCodec, logger *slog.Logger) *Service {
-	return &Service{roleRepo: roleRepo, codec: codec, logger: logger}
+func NewService(roleRepo ports.RoleRepository, codec *query.CursorCodec, logger *slog.Logger, runMode query.RunMode) *Service {
+	return &Service{roleRepo: roleRepo, codec: codec, logger: logger, runMode: runMode}
 }
 
 // HasRole checks if a user has the specified role.
@@ -72,6 +73,6 @@ func (s *Service) ListRoles(ctx context.Context, userID string, pageReq query.Pa
 			return []any{r.Name, r.ID}
 		},
 		OnCursorErr: query.LogCursorError(s.logger, "rbac-check"),
-		RunMode:     query.RunModeProd,
+		RunMode:     s.runMode,
 	})
 }

--- a/cells/access-core/slices/rbaccheck/service.go
+++ b/cells/access-core/slices/rbaccheck/service.go
@@ -10,17 +10,24 @@ import (
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 )
+
+var roleSort = []query.SortColumn{
+	{Name: "name", Direction: query.SortASC},
+	{Name: "id", Direction: query.SortASC},
+}
 
 // Service implements RBAC query operations.
 type Service struct {
 	roleRepo ports.RoleRepository
+	codec    *query.CursorCodec
 	logger   *slog.Logger
 }
 
 // NewService creates an rbac-check Service.
-func NewService(roleRepo ports.RoleRepository, logger *slog.Logger) *Service {
-	return &Service{roleRepo: roleRepo, logger: logger}
+func NewService(roleRepo ports.RoleRepository, codec *query.CursorCodec, logger *slog.Logger) *Service {
+	return &Service{roleRepo: roleRepo, codec: codec, logger: logger}
 }
 
 // HasRole checks if a user has the specified role.
@@ -42,15 +49,29 @@ func (s *Service) HasRole(ctx context.Context, userID, roleName string) (bool, e
 	return false, nil
 }
 
-// ListRoles returns all roles assigned to a user.
-func (s *Service) ListRoles(ctx context.Context, userID string) ([]*domain.Role, error) {
+// ListRoles returns a paginated page of roles assigned to userID.
+func (s *Service) ListRoles(ctx context.Context, userID string, pageReq query.PageRequest) (query.PageResult[*domain.Role], error) {
 	if userID == "" {
-		return nil, errcode.New(errcode.ErrAuthRBACInvalidInput, "userID is required")
+		return query.PageResult[*domain.Role]{}, errcode.New(errcode.ErrAuthRBACInvalidInput, "userID is required")
 	}
 
-	roles, err := s.roleRepo.GetByUserID(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("rbac-check: list roles: %w", err)
-	}
-	return roles, nil
+	qctx := query.QueryContext("endpoint", "rbac-list-roles", "userId", userID)
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Role]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     roleSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Role, error) {
+			roles, err := s.roleRepo.ListByUserID(ctx, userID, params)
+			if err != nil {
+				return nil, fmt.Errorf("rbac-check: list roles: %w", err)
+			}
+			return roles, nil
+		},
+		Extract: func(r *domain.Role) []any {
+			return []any{r.Name, r.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "rbac-check"),
+		RunMode:     query.RunModeProd,
+	})
 }

--- a/cells/access-core/slices/rbaccheck/service_test.go
+++ b/cells/access-core/slices/rbaccheck/service_test.go
@@ -7,13 +7,24 @@ import (
 
 	"github.com/ghbvf/gocell/cells/access-core/internal/domain"
 	"github.com/ghbvf/gocell/cells/access-core/internal/mem"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func newTestService() (*Service, *mem.RoleRepository) {
+func newTestCodec(t *testing.T) *query.CursorCodec {
+	t.Helper()
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return codec
+}
+
+func newTestService(t *testing.T) (*Service, *mem.RoleRepository) {
+	t.Helper()
 	repo := mem.NewRoleRepository()
-	return NewService(repo, slog.Default()), repo
+	return NewService(repo, newTestCodec(t), slog.Default()), repo
 }
 
 func TestService_HasRole(t *testing.T) {
@@ -50,7 +61,7 @@ func TestService_HasRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, repo := newTestService()
+			svc, repo := newTestService(t)
 			tt.setup(repo)
 
 			has, err := svc.HasRole(context.Background(), tt.userID, tt.roleName)
@@ -65,19 +76,19 @@ func TestService_HasRole(t *testing.T) {
 }
 
 func TestService_ListRoles(t *testing.T) {
-	svc, repo := newTestService()
+	svc, repo := newTestService(t)
 	repo.SeedRole(&domain.Role{ID: "admin", Name: "admin"})
 	repo.SeedRole(&domain.Role{ID: "viewer", Name: "viewer"})
 	_, _ = repo.AssignToUser(context.Background(), "usr-1", "admin")
 	_, _ = repo.AssignToUser(context.Background(), "usr-1", "viewer")
 
-	roles, err := svc.ListRoles(context.Background(), "usr-1")
+	result, err := svc.ListRoles(context.Background(), "usr-1", query.PageRequest{Limit: 50})
 	require.NoError(t, err)
-	assert.Len(t, roles, 2)
+	assert.Len(t, result.Items, 2)
 }
 
 func TestService_ListRolesEmptyInput(t *testing.T) {
-	svc, _ := newTestService()
-	_, err := svc.ListRoles(context.Background(), "")
+	svc, _ := newTestService(t)
+	_, err := svc.ListRoles(context.Background(), "", query.PageRequest{})
 	assert.Error(t, err)
 }

--- a/cells/access-core/slices/rbaccheck/service_test.go
+++ b/cells/access-core/slices/rbaccheck/service_test.go
@@ -24,7 +24,7 @@ func newTestCodec(t *testing.T) *query.CursorCodec {
 func newTestService(t *testing.T) (*Service, *mem.RoleRepository) {
 	t.Helper()
 	repo := mem.NewRoleRepository()
-	return NewService(repo, newTestCodec(t), slog.Default()), repo
+	return NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo), repo
 }
 
 func TestService_HasRole(t *testing.T) {

--- a/cells/audit-core/slices/auditquery/handler.go
+++ b/cells/audit-core/slices/auditquery/handler.go
@@ -137,13 +137,8 @@ func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		filters.To = t
 	}
 
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/config-core/slices/configread/handler.go
+++ b/cells/config-core/slices/configread/handler.go
@@ -1,7 +1,6 @@
 package configread
 
 import (
-	"log/slog"
 	"net/http"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/dto"
@@ -34,13 +33,8 @@ func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleList handles GET /?limit=N&cursor=TOKEN — returns paginated config entries.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/config-core/slices/featureflag/handler.go
+++ b/cells/config-core/slices/featureflag/handler.go
@@ -1,7 +1,6 @@
 package featureflag
 
 import (
-	"log/slog"
 	"net/http"
 
 	"github.com/ghbvf/gocell/cells/config-core/internal/domain"
@@ -55,13 +54,8 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleList handles GET / — returns paginated feature flags.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/device-cell/cell.go
+++ b/cells/device-cell/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
 	devicecommand "github.com/ghbvf/gocell/cells/device-cell/slices/devicecommand"
+	devicelist "github.com/ghbvf/gocell/cells/device-cell/slices/devicelist"
 	deviceregister "github.com/ghbvf/gocell/cells/device-cell/slices/deviceregister"
 	devicestatus "github.com/ghbvf/gocell/cells/device-cell/slices/devicestatus"
 	"github.com/ghbvf/gocell/kernel/cell"
@@ -67,6 +68,7 @@ type DeviceCell struct {
 	registerHandler *deviceregister.Handler
 	commandHandler  *devicecommand.Handler
 	statusHandler   *devicestatus.Handler
+	listHandler     *devicelist.Handler
 }
 
 // NewDeviceCell creates a new DeviceCell with the given options.
@@ -155,6 +157,15 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	c.statusHandler = devicestatus.NewHandler(statusSvc)
 	c.AddSlice(cell.NewBaseSlice("devicestatus", "device-cell", cell.L0))
 
+	// device-list slice
+	listSvc, err := devicelist.NewService(c.deviceRepo, c.cursorCodec, c.logger,
+		query.RunModeForDemo(deps.DurabilityMode == cell.DurabilityDemo))
+	if err != nil {
+		return fmt.Errorf("device-list: %w", err)
+	}
+	c.listHandler = devicelist.NewHandler(listSvc)
+	c.AddSlice(cell.NewBaseSlice("devicelist", "device-cell", cell.L0))
+
 	return nil
 }
 
@@ -169,6 +180,13 @@ func (c *DeviceCell) RegisterRoutes(mux cell.RouteMux) {
 				Path:    "/",
 				Handler: http.HandlerFunc(c.registerHandler.HandleRegister),
 				Public:  true,
+			})
+			// Device list: paginated listing of all devices.
+			auth.Declare(devices, auth.RouteDecl{
+				Method:  "GET",
+				Path:    "/",
+				Handler: http.HandlerFunc(c.listHandler.HandleList),
+				Policy:  auth.Authenticated(),
 			})
 			// Device status is queried by authenticated operators/devices.
 			auth.Declare(devices, auth.RouteDecl{

--- a/cells/device-cell/cell.go
+++ b/cells/device-cell/cell.go
@@ -190,7 +190,7 @@ func (c *DeviceCell) RegisterRoutes(mux cell.RouteMux) {
 				Method:  "GET",
 				Path:    "/",
 				Handler: http.HandlerFunc(c.listHandler.HandleList),
-				Policy:  auth.Authenticated(),
+				Policy:  auth.AnyRole("admin"),
 			})
 			// Device status is queried by authenticated operators/devices.
 			auth.Declare(devices, auth.RouteDecl{

--- a/cells/device-cell/cell.go
+++ b/cells/device-cell/cell.go
@@ -22,6 +22,10 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
+// demoCursorKey is the public demo-mode cursor codec key.
+// In durable mode a secret key must be supplied via WithCursorCodec.
+const demoCursorKey = "gocell-demo-DEVICE-CELL-key-32!!"
+
 // Compile-time interface checks.
 var (
 	_ cell.Cell          = (*DeviceCell)(nil)
@@ -135,7 +139,7 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 				"device-cell durable mode requires a cursor codec; use WithCursorCodec(query.NewCursorCodec(secret)) — the built-in demo key is public in the source tree")
 		}
 		// Each cell uses a distinct demo key to prevent cross-cell cursor reuse in demo mode.
-		codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!"))
+		codec, err := query.NewCursorCodec([]byte(demoCursorKey))
 		if err != nil {
 			return err
 		}

--- a/cells/device-cell/cell_test.go
+++ b/cells/device-cell/cell_test.go
@@ -36,7 +36,7 @@ func TestDeviceCell_Lifecycle(t *testing.T) {
 
 	// Init
 	require.NoError(t, c.Init(ctx, deps))
-	assert.Len(t, c.OwnedSlices(), 3, "should have 3 slices")
+	assert.Len(t, c.OwnedSlices(), 4, "should have 4 slices")
 
 	// Start
 	require.NoError(t, c.Start(ctx))
@@ -78,7 +78,7 @@ func TestDeviceCell_InitDefaultsRepositories(t *testing.T) {
 		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
-	assert.Len(t, c.OwnedSlices(), 3)
+	assert.Len(t, c.OwnedSlices(), 4)
 }
 
 func TestDeviceCell_InitNoPublisher(t *testing.T) {

--- a/cells/device-cell/internal/domain/device.go
+++ b/cells/device-cell/internal/domain/device.go
@@ -33,6 +33,8 @@ type Command struct {
 type DeviceRepository interface {
 	Create(ctx context.Context, device *Device) error
 	GetByID(ctx context.Context, id string) (*Device, error)
+	// List returns a paginated list of devices sorted by name ASC, id ASC.
+	List(ctx context.Context, params query.ListParams) ([]*Device, error)
 }
 
 // CommandRepository abstracts command persistence.

--- a/cells/device-cell/internal/mem/repository.go
+++ b/cells/device-cell/internal/mem/repository.go
@@ -58,6 +58,51 @@ func (r *DeviceRepository) GetByID(_ context.Context, id string) (*domain.Device
 	return &out, nil
 }
 
+// List returns paginated devices sorted and cursor-filtered per params.
+func (r *DeviceRepository) List(_ context.Context, params query.ListParams) ([]*domain.Device, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	all := make([]*domain.Device, 0, len(r.devices))
+	for _, d := range r.devices {
+		cp := *d
+		all = append(all, &cp)
+	}
+
+	query.Sort(all, params.Sort, compareDeviceField)
+	result, err := query.ApplyCursor(all, params, deviceFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("device-repo: list: %w", err)
+	}
+	return result, nil
+}
+
+func compareDeviceField(a, b *domain.Device, field string) int {
+	switch field {
+	case "name":
+		return cmp.Compare(a.Name, b.Name)
+	case "id":
+		return cmp.Compare(a.ID, b.ID)
+	case "status":
+		return cmp.Compare(a.Status, b.Status)
+	default:
+		return 0
+	}
+}
+
+func deviceFieldValue(d *domain.Device, field string) any {
+	switch field {
+	case "name":
+		return d.Name
+	case "id":
+		return d.ID
+	case "status":
+		return d.Status
+	default:
+		return ""
+	}
+}
+
 // CommandRepository is a thread-safe in-memory command store.
 type CommandRepository struct {
 	mu       sync.RWMutex

--- a/cells/device-cell/slices/devicecommand/handler.go
+++ b/cells/device-cell/slices/devicecommand/handler.go
@@ -1,7 +1,6 @@
 package devicecommand
 
 import (
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -107,13 +106,8 @@ func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleListPending(w http.ResponseWriter, r *http.Request) {
 	deviceID := r.PathValue("id")
 
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/device-cell/slices/devicelist/contract_test.go
+++ b/cells/device-cell/slices/devicelist/contract_test.go
@@ -5,11 +5,13 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
 	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -26,7 +28,7 @@ func newContractDeviceListHandler(t *testing.T) http.Handler {
 		ID: "dev-2", Name: "sensor-beta", Status: "offline", LastSeen: now,
 	})
 
-	codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!"))
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!")) // must match cell.go demoCursorKey
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,11 +36,25 @@ func newContractDeviceListHandler(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHandler(svc)
 
-	mux := http.NewServeMux()
-	mux.Handle("GET /api/v1/devices", auth.RequirePolicy(auth.Authenticated())(http.HandlerFunc(h.HandleList)))
-	return mux
+	inner := celltest.NewTestMux()
+	NewHandler(svc).RegisterRoutes(inner)
+
+	outer := http.NewServeMux()
+	// The contract path is /api/v1/devices (no trailing slash). Strip the prefix
+	// and normalise to "/" so the inner handler registered at "GET /" matches.
+	prefix := "/api/v1/devices"
+	stripped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/" + strings.TrimPrefix(r.URL.Path, prefix)
+		if r2.URL.Path == "/" || r2.URL.Path == "" {
+			r2.URL.Path = "/"
+		}
+		inner.ServeHTTP(w, r2)
+	})
+	outer.Handle("/api/v1/devices", stripped)
+	outer.Handle("/api/v1/devices/", stripped)
+	return outer
 }
 
 func TestHttpDeviceListV1Serve(t *testing.T) {
@@ -56,4 +72,6 @@ func TestHttpDeviceListV1Serve(t *testing.T) {
 	c.MustRejectResponse(t, []byte(`{"data":{"wrong":"shape"}}`))
 	// MustRejectResponse: data is not an array
 	c.MustRejectResponse(t, []byte(`{"data":{"id":"dev-1"},"hasMore":false}`))
+	// MustRejectResponse: hasMore must be bool, not string
+	c.MustRejectResponse(t, []byte(`{"data":[],"hasMore":"yes"}`))
 }

--- a/cells/device-cell/slices/devicelist/contract_test.go
+++ b/cells/device-cell/slices/devicelist/contract_test.go
@@ -64,7 +64,7 @@ func TestHttpDeviceListV1Serve(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, nil)
-	req = req.WithContext(auth.TestContext("user-1", nil))
+	req = req.WithContext(auth.TestContext("user-1", []string{"admin"}))
 	h.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 
@@ -74,4 +74,13 @@ func TestHttpDeviceListV1Serve(t *testing.T) {
 	c.MustRejectResponse(t, []byte(`{"data":{"id":"dev-1"},"hasMore":false}`))
 	// MustRejectResponse: hasMore must be bool, not string
 	c.MustRejectResponse(t, []byte(`{"data":[],"hasMore":"yes"}`))
+
+	// 400: invalid limit parameter
+	rec400 := httptest.NewRecorder()
+	req400 := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path+"?limit=notanumber", nil)
+	req400 = req400.WithContext(auth.TestContext("user-1", []string{"admin"}))
+	h.ServeHTTP(rec400, req400)
+	if rec400.Code != http.StatusBadRequest {
+		t.Errorf("invalid limit: expected 400, got %d", rec400.Code)
+	}
 }

--- a/cells/device-cell/slices/devicelist/contract_test.go
+++ b/cells/device-cell/slices/devicelist/contract_test.go
@@ -1,0 +1,59 @@
+package devicelist
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
+	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
+	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+func newContractDeviceListHandler(t *testing.T) http.Handler {
+	t.Helper()
+	repo := mem.NewDeviceRepository()
+	now := time.Now()
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-1", Name: "sensor-alpha", Status: "online", LastSeen: now,
+	})
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-2", Name: "sensor-beta", Status: "offline", LastSeen: now,
+	})
+
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := NewService(repo, codec, slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := NewHandler(svc)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/devices", auth.RequirePolicy(auth.Authenticated())(http.HandlerFunc(h.HandleList)))
+	return mux
+}
+
+func TestHttpDeviceListV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.device.list.v1")
+	h := newContractDeviceListHandler(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, nil)
+	req = req.WithContext(auth.TestContext("user-1", nil))
+	h.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
+
+	// MustRejectResponse: wrong shape (missing required fields)
+	c.MustRejectResponse(t, []byte(`{"data":{"wrong":"shape"}}`))
+	// MustRejectResponse: data is not an array
+	c.MustRejectResponse(t, []byte(`{"data":{"id":"dev-1"},"hasMore":false}`))
+}

--- a/cells/device-cell/slices/devicelist/handler.go
+++ b/cells/device-cell/slices/devicelist/handler.go
@@ -1,0 +1,65 @@
+package devicelist
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
+	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// DeviceResponse is the public DTO for Device.
+type DeviceResponse struct {
+	ID       string    `json:"id"`
+	Name     string    `json:"name"`
+	Status   string    `json:"status"`
+	LastSeen time.Time `json:"lastSeen"`
+}
+
+func toDeviceResponse(d *domain.Device) DeviceResponse {
+	return DeviceResponse{
+		ID:       d.ID,
+		Name:     d.Name,
+		Status:   d.Status,
+		LastSeen: d.LastSeen,
+	}
+}
+
+// Handler provides the GET /api/v1/devices endpoint.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a device-list Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterRoutes registers device-list routes.
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
+	auth.Declare(mux, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/",
+		Handler: http.HandlerFunc(h.HandleList),
+		Policy:  auth.Authenticated(),
+	})
+}
+
+// HandleList handles GET /api/v1/devices.
+func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.svc.List(r.Context(), pageReq)
+	if err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, query.MapPageResult(result, toDeviceResponse))
+}

--- a/cells/device-cell/slices/devicelist/handler.go
+++ b/cells/device-cell/slices/devicelist/handler.go
@@ -44,7 +44,7 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 		Method:  "GET",
 		Path:    "/",
 		Handler: http.HandlerFunc(h.HandleList),
-		Policy:  auth.Authenticated(),
+		Policy:  auth.AnyRole("admin"),
 	})
 }
 

--- a/cells/device-cell/slices/devicelist/handler_test.go
+++ b/cells/device-cell/slices/devicelist/handler_test.go
@@ -32,7 +32,7 @@ func TestHandleList_OK(t *testing.T) {
 	h := newHandlerForTest(t)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r = r.WithContext(auth.TestContext("user-1", nil))
+	r = r.WithContext(auth.TestContext("user-1", []string{"admin"}))
 
 	h.HandleList(w, r)
 

--- a/cells/device-cell/slices/devicelist/handler_test.go
+++ b/cells/device-cell/slices/devicelist/handler_test.go
@@ -1,0 +1,78 @@
+package devicelist
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
+	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+func newHandlerForTest(t *testing.T) *Handler {
+	t.Helper()
+	repo := mem.NewDeviceRepository()
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-1", Name: "alpha", Status: "online", LastSeen: time.Now(),
+	})
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewHandler(svc)
+}
+
+func TestHandleList_OK(t *testing.T) {
+	h := newHandlerForTest(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(auth.TestContext("user-1", nil))
+
+	h.HandleList(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status=%d, want 200", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, ok := body["data"]; !ok {
+		t.Error("response missing 'data' field")
+	}
+	if _, ok := body["hasMore"]; !ok {
+		t.Error("response missing 'hasMore' field")
+	}
+}
+
+func TestHandleList_InvalidLimit(t *testing.T) {
+	h := newHandlerForTest(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/?limit=abc", nil)
+	r = r.WithContext(auth.TestContext("user-1", nil))
+
+	h.HandleList(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", w.Code)
+	}
+}
+
+func TestHandleList_LimitExceedsMax(t *testing.T) {
+	h := newHandlerForTest(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/?limit=9999", nil)
+	r = r.WithContext(auth.TestContext("user-1", nil))
+
+	h.HandleList(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", w.Code)
+	}
+}

--- a/cells/device-cell/slices/devicelist/service.go
+++ b/cells/device-cell/slices/devicelist/service.go
@@ -1,4 +1,5 @@
 // Package devicelist implements the device-list slice: paginated device listing.
+// Consistency: L0 LocalOnly — read-only query, no state mutation or outbox publishing.
 package devicelist
 
 import (

--- a/cells/device-cell/slices/devicelist/service.go
+++ b/cells/device-cell/slices/devicelist/service.go
@@ -1,0 +1,59 @@
+// Package devicelist implements the device-list slice: paginated device listing.
+package devicelist
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+// defaultSort orders devices by name ASC, id ASC (stable, human-friendly).
+var defaultSort = []query.SortColumn{
+	{Name: "name", Direction: query.SortASC},
+	{Name: "id", Direction: query.SortASC},
+}
+
+// Service lists devices with cursor pagination.
+type Service struct {
+	deviceRepo domain.DeviceRepository
+	codec      *query.CursorCodec
+	logger     *slog.Logger
+	runMode    query.RunMode
+}
+
+// NewService creates a device-list Service.
+// codec must be non-nil — cursor pagination cannot be served without it.
+func NewService(deviceRepo domain.DeviceRepository, codec *query.CursorCodec, logger *slog.Logger, runMode query.RunMode) (*Service, error) {
+	if codec == nil {
+		return nil, errcode.New(errcode.ErrCellMissingCodec,
+			"device-list: cursor codec is required")
+	}
+	return &Service{deviceRepo: deviceRepo, codec: codec, logger: logger, runMode: runMode}, nil
+}
+
+// List returns a paginated page of devices sorted by name ASC, id ASC.
+func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.PageResult[*domain.Device], error) {
+	qctx := query.QueryContext("endpoint", "device-list")
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Device]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     defaultSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Device, error) {
+			devices, err := s.deviceRepo.List(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("device-list: fetch: %w", err)
+			}
+			return devices, nil
+		},
+		Extract: func(d *domain.Device) []any {
+			return []any{d.Name, d.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "device-list"),
+		RunMode:     s.runMode,
+	})
+}

--- a/cells/device-cell/slices/devicelist/service_test.go
+++ b/cells/device-cell/slices/devicelist/service_test.go
@@ -1,0 +1,104 @@
+package devicelist
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/device-cell/internal/domain"
+	"github.com/ghbvf/gocell/cells/device-cell/internal/mem"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+func newTestCodec(t *testing.T) *query.CursorCodec {
+	t.Helper()
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return codec
+}
+
+func seedDevice(t *testing.T, repo *mem.DeviceRepository, id, name, status string) {
+	t.Helper()
+	err := repo.Create(context.Background(), &domain.Device{
+		ID:       id,
+		Name:     name,
+		Status:   status,
+		LastSeen: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewService_NilCodecReturnsError(t *testing.T) {
+	_, err := NewService(mem.NewDeviceRepository(), nil, slog.Default(), query.RunModeDemo)
+	if err == nil {
+		t.Fatal("expected error for nil codec")
+	}
+	var ecErr *errcode.Error
+	if !errors.As(err, &ecErr) {
+		t.Errorf("expected errcode.Error, got %T: %v", err, err)
+	}
+}
+
+func TestService_ListEmpty(t *testing.T) {
+	svc, err := NewService(mem.NewDeviceRepository(), newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageRequest{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.HasMore {
+		t.Error("expected HasMore=false for empty repo")
+	}
+	if len(result.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(result.Items))
+	}
+}
+
+func TestService_ListPagination(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-1", "alpha", "online")
+	seedDevice(t, repo, "dev-2", "beta", "offline")
+	seedDevice(t, repo, "dev-3", "gamma", "online")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First page: limit 2
+	page1, err := svc.List(context.Background(), query.PageRequest{Limit: 2})
+	if err != nil {
+		t.Fatalf("page 1 error: %v", err)
+	}
+	if !page1.HasMore {
+		t.Error("expected HasMore=true for first page")
+	}
+	if len(page1.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(page1.Items))
+	}
+	if page1.NextCursor == "" {
+		t.Error("expected non-empty NextCursor")
+	}
+
+	// Second page using cursor
+	page2, err := svc.List(context.Background(), query.PageRequest{Limit: 2, Cursor: page1.NextCursor})
+	if err != nil {
+		t.Fatalf("page 2 error: %v", err)
+	}
+	if page2.HasMore {
+		t.Error("expected HasMore=false for last page")
+	}
+	if len(page2.Items) != 1 {
+		t.Errorf("expected 1 item on last page, got %d", len(page2.Items))
+	}
+}

--- a/cells/device-cell/slices/devicelist/service_test.go
+++ b/cells/device-cell/slices/devicelist/service_test.go
@@ -102,3 +102,80 @@ func TestService_ListPagination(t *testing.T) {
 		t.Errorf("expected 1 item on last page, got %d", len(page2.Items))
 	}
 }
+
+func TestService_ListSingleDevice(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-1", "solo", "online")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageRequest{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.HasMore {
+		t.Error("expected HasMore=false for single device")
+	}
+	if result.NextCursor != "" {
+		t.Errorf("expected empty NextCursor when HasMore=false, got %q", result.NextCursor)
+	}
+	if len(result.Items) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result.Items))
+	}
+}
+
+func TestService_ListLimitOne(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-1", "alpha", "online")
+	seedDevice(t, repo, "dev-2", "beta", "offline")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageRequest{Limit: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.HasMore {
+		t.Error("expected HasMore=true with limit=1 and 2 devices")
+	}
+	if len(result.Items) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result.Items))
+	}
+	// First item should be "alpha" (name ASC sort)
+	if result.Items[0].Name != "alpha" {
+		t.Errorf("expected first item to be 'alpha' (name ASC), got %q", result.Items[0].Name)
+	}
+}
+
+func TestService_ListSecondarySort(t *testing.T) {
+	// Two devices with same name — secondary sort by id ASC must be stable.
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-z", "sensor", "offline")
+	seedDevice(t, repo, "dev-a", "sensor", "online")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageRequest{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(result.Items))
+	}
+	// id ASC: "dev-a" before "dev-z"
+	if result.Items[0].ID != "dev-a" {
+		t.Errorf("expected first item id='dev-a' (id ASC), got %q", result.Items[0].ID)
+	}
+	if result.Items[1].ID != "dev-z" {
+		t.Errorf("expected second item id='dev-z', got %q", result.Items[1].ID)
+	}
+}

--- a/cells/device-cell/slices/devicelist/slice.yaml
+++ b/cells/device-cell/slices/devicelist/slice.yaml
@@ -1,0 +1,12 @@
+id: devicelist
+belongsToCell: device-cell
+contractUsages:
+  - contract: http.device.list.v1
+    role: serve
+verify:
+  unit:
+    - unit.devicelist.service
+  contract:
+    - contract.http.device.list.v1.serve
+allowedFiles:
+  - cells/device-cell/slices/devicelist/**

--- a/cells/order-cell/slices/orderquery/handler.go
+++ b/cells/order-cell/slices/orderquery/handler.go
@@ -1,7 +1,6 @@
 package orderquery
 
 import (
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -53,13 +52,8 @@ func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleList handles GET /api/v1/orders?limit=N&cursor=TOKEN.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cmd/core-bundle/access_module.go
+++ b/cmd/core-bundle/access_module.go
@@ -31,6 +31,7 @@ func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.C
 		accesscore.WithPublisher(shared.EventBus),
 		accesscore.WithJWTIssuer(shared.JWTDeps.issuer),
 		accesscore.WithJWTVerifier(shared.JWTDeps.verifier),
+		accesscore.WithCursorCodec(shared.CursorCodecs.accessCore),
 	}, m.InitialAdminOpts...)
 	c := accesscore.NewAccessCore(accessOpts...)
 

--- a/cmd/core-bundle/demo_keys.go
+++ b/cmd/core-bundle/demo_keys.go
@@ -24,8 +24,10 @@ var wellKnownDemoKeys = []string{
 	"gocell-demo-CONFIG-CORE-key-32!!",
 	"gocell-demo-ORDER-CELL-key-32b!!",
 	"gocell-demo-DEVICE-CELL-key-32!!",
+	"gocell-demo-ACCESS-CORE-key-32!!",
 	"core-bundle-audit-cursor-key-32!",
 	"core-bundle-cfg-cursor-key--32b!",
+	"core-bundle-access-cursor-key32!",
 
 	// Service token HMAC (shipped as test fixture; never use in production)
 	"service-secret-32-bytes-xxxxxx!!",

--- a/cmd/core-bundle/main.go
+++ b/cmd/core-bundle/main.go
@@ -154,13 +154,14 @@ func loadCursorCodec(adapterMode, envName, prevEnvName, devDefault, label string
 	return codec, nil
 }
 
-// cursorCodecs holds the parsed cursor codecs for audit-core and config-core.
+// cursorCodecs holds the parsed cursor codecs for audit-core, config-core, and access-core.
 type cursorCodecs struct {
-	audit  *query.CursorCodec
-	config *query.CursorCodec
+	audit      *query.CursorCodec
+	config     *query.CursorCodec
+	accessCore *query.CursorCodec
 }
 
-// loadAllCursorCodecs loads and validates the audit and config cursor codecs.
+// loadAllCursorCodecs loads and validates the audit, config, and access-core cursor codecs.
 // Extracted from run() to reduce cognitive complexity.
 func loadAllCursorCodecs(adapterMode string) (cursorCodecs, error) {
 	audit, err := loadCursorCodec(adapterMode,
@@ -175,7 +176,13 @@ func loadAllCursorCodecs(adapterMode string) (cursorCodecs, error) {
 	if err != nil {
 		return cursorCodecs{}, err
 	}
-	return cursorCodecs{audit: audit, config: cfg}, nil
+	ac, err := loadCursorCodec(adapterMode,
+		"GOCELL_ACCESS_CURSOR_KEY", "GOCELL_ACCESS_CURSOR_PREVIOUS_KEY",
+		"core-bundle-access-cursor-key32!", "access-core")
+	if err != nil {
+		return cursorCodecs{}, err
+	}
+	return cursorCodecs{audit: audit, config: cfg, accessCore: ac}, nil
 }
 
 // validateModeCoupling enforces that the DATA plane (cellAdapterMode) and

--- a/cmd/core-bundle/main_test.go
+++ b/cmd/core-bundle/main_test.go
@@ -233,6 +233,7 @@ func TestRun_RealMode_MissingVerboseToken_FailsFast(t *testing.T) {
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
 	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_ACCESS_CURSOR_KEY", "access-cursor-key-32b-padded-x!!")
 	t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
 	// The trip-wire: verbose token is empty.
 	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "")
@@ -262,6 +263,7 @@ func TestRun_RealMode_MissingMetricsToken_FailsFast(t *testing.T) {
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
 	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_ACCESS_CURSOR_KEY", "access-cursor-key-32b-padded-x!!")
 	t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
 	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
 	// The trip-wire: metrics token is empty.
@@ -291,6 +293,7 @@ func TestRun_RealMode_MissingServiceSecret_FailsFast(t *testing.T) {
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
 	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_ACCESS_CURSOR_KEY", "access-cursor-key-32b-padded-x!!")
 	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
 	t.Setenv("GOCELL_METRICS_TOKEN", "metrics-token-present")
 	// The trip-wire: service secret is empty.
@@ -429,6 +432,7 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 	freshHMAC := "prod-hmac-key-replace-32bytes!!!"
 	freshAudit := "audit-cursor-key-32-bytes-padded!"
 	freshConfig := "config-cursor-key-32b-padded-xx!"
+	freshAccess := "access-cursor-key-32b-padded-x!!"
 
 	type envPatch struct {
 		name, value string
@@ -452,6 +456,16 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 			name:  "config cursor demo literal rejected",
 			patch: envPatch{"GOCELL_CONFIG_CURSOR_KEY", "core-bundle-cfg-cursor-key--32b!"},
 			want:  "GOCELL_CONFIG_CURSOR_KEY",
+		},
+		{
+			name:  "access cursor demo literal rejected",
+			patch: envPatch{"GOCELL_ACCESS_CURSOR_KEY", "core-bundle-access-cursor-key32!"},
+			want:  "GOCELL_ACCESS_CURSOR_KEY",
+		},
+		{
+			name:  "access cursor cell demo literal rejected",
+			patch: envPatch{"GOCELL_ACCESS_CURSOR_KEY", "gocell-demo-ACCESS-CORE-key-32!!"},
+			want:  "GOCELL_ACCESS_CURSOR_KEY",
 		},
 		{
 			name:  "service secret demo literal rejected",
@@ -478,6 +492,7 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 			t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 			t.Setenv("GOCELL_AUDIT_CURSOR_KEY", freshAudit)
 			t.Setenv("GOCELL_CONFIG_CURSOR_KEY", freshConfig)
+			t.Setenv("GOCELL_ACCESS_CURSOR_KEY", freshAccess)
 			t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
 			t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
 			t.Setenv("GOCELL_METRICS_TOKEN", "metrics-token-present")

--- a/cmd/core-bundle/shared_deps.go
+++ b/cmd/core-bundle/shared_deps.go
@@ -108,6 +108,9 @@ func (d *SharedDeps) validateCore() []error {
 	if d.CursorCodecs.config == nil {
 		missing("CursorCodecs.config")
 	}
+	if d.CursorCodecs.accessCore == nil {
+		missing("CursorCodecs.accessCore")
+	}
 	if len(d.HMACKey) == 0 {
 		missing("HMACKey")
 	}

--- a/contracts/http/device/list/v1/contract.yaml
+++ b/contracts/http/device/list/v1/contract.yaml
@@ -1,0 +1,16 @@
+id: http.device.list.v1
+kind: http
+ownerCell: device-cell
+consistencyLevel: L0
+lifecycle: active
+endpoints:
+  server: device-cell
+  clients:
+    - edge-bff
+  http:
+    method: GET
+    path: /api/v1/devices
+    successStatus: 200
+    noContent: false
+schemaRefs:
+  response: response.schema.json

--- a/contracts/http/device/list/v1/response.schema.json
+++ b/contracts/http/device/list/v1/response.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.device.list.v1.response",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id":       { "type": "string" },
+          "name":     { "type": "string" },
+          "status":   { "type": "string" },
+          "lastSeen": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "name", "status", "lastSeen"],
+        "additionalProperties": false
+      }
+    },
+    "nextCursor": { "type": "string" },
+    "hasMore":    { "type": "boolean" }
+  },
+  "required": ["data", "hasMore"],
+  "additionalProperties": false
+}

--- a/pkg/httputil/pagination.go
+++ b/pkg/httputil/pagination.go
@@ -1,0 +1,24 @@
+package httputil
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+// ParsePageRequestOrWrite parses pagination query params from r.
+// On error it logs a warning, writes the domain error response, and returns ok=false.
+// The caller must return immediately when ok is false.
+func ParsePageRequestOrWrite(w http.ResponseWriter, r *http.Request) (query.PageRequest, bool) {
+	pr, err := ParsePageRequest(r)
+	if err != nil {
+		slog.Warn("pagination: request validation failed",
+			slog.String("error", err.Error()),
+			slog.String("path", r.URL.Path),
+		)
+		WriteDomainError(r.Context(), w, err)
+		return query.PageRequest{}, false
+	}
+	return pr, true
+}

--- a/pkg/httputil/pagination_test.go
+++ b/pkg/httputil/pagination_test.go
@@ -1,6 +1,7 @@
 package httputil_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -61,6 +62,14 @@ func TestParsePageRequestOrWrite(t *testing.T) {
 			}
 			if tc.wantOK && w.Code != 0 && w.Code != http.StatusOK {
 				t.Errorf("unexpected write on ok=true: HTTP status=%d", w.Code)
+			}
+			if !tc.wantOK {
+				var body map[string]any
+				if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+					t.Errorf("response body is not JSON: %v", err)
+				} else if _, ok := body["error"]; !ok {
+					t.Errorf("response body missing 'error' field: %s", w.Body.String())
+				}
 			}
 		})
 	}

--- a/pkg/httputil/pagination_test.go
+++ b/pkg/httputil/pagination_test.go
@@ -1,0 +1,67 @@
+package httputil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+func TestParsePageRequestOrWrite(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantOK     bool
+		wantLimit  int
+		wantStatus int
+	}{
+		{
+			name:      "no params uses default",
+			query:     "",
+			wantOK:    true,
+			wantLimit: query.DefaultPageSize,
+		},
+		{
+			name:      "valid limit",
+			query:     "limit=10",
+			wantOK:    true,
+			wantLimit: 10,
+		},
+		{
+			name:       "limit exceeds max",
+			query:      "limit=9999",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid limit not a number",
+			query:      "limit=abc",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/?"+tc.query, nil)
+
+			pr, ok := httputil.ParsePageRequestOrWrite(w, r)
+
+			if ok != tc.wantOK {
+				t.Errorf("ok=%v, want %v", ok, tc.wantOK)
+			}
+			if tc.wantOK && pr.Limit != tc.wantLimit {
+				t.Errorf("Limit=%d, want %d", pr.Limit, tc.wantLimit)
+			}
+			if !tc.wantOK && w.Code != tc.wantStatus {
+				t.Errorf("HTTP status=%d, want %d", w.Code, tc.wantStatus)
+			}
+			if tc.wantOK && w.Code != 0 && w.Code != http.StatusOK {
+				t.Errorf("unexpected write on ok=true: HTTP status=%d", w.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **L8**: `pkg/httputil/pagination.go` 新增 `ParsePageRequestOrWrite` helper，消除 5 个 handler 中重复的 6 行分页错误处理模式（auditquery / orderquery / devicecommand / featureflag / configread）
- **P1-8 device-list**: 新建 `cells/device-cell/slices/devicelist/`，实现 `GET /api/v1/devices` cursor 分页；扩展 `DeviceRepository.List`；新建 `contracts/http/device/list/v1/`
- **P1-8 rbaccheck**: 修复 `handleListRoles` 永远返回 `hasMore:false` / 无 `nextCursor` 问题；新增 `ports.RoleRepository.ListByUserID`；access-core 增加 `cursorCodec` 初始化；rbaccheck contract_test 补 `MustRejectResponse`

## Changed Files

| 区域 | 文件 |
|------|------|
| Helper | `pkg/httputil/pagination.go` (new) |
| L8 Handler 更新 | 5 × `handler.go` (auditquery/orderquery/devicecommand/featureflag/configread) |
| device-list slice | `cells/device-cell/slices/devicelist/` (new: service/handler/slice.yaml/contract_test) |
| device-list contract | `contracts/http/device/list/v1/` (new) |
| device-cell domain/mem | `domain/device.go` + `mem/repository.go` (List method) |
| device-cell cell.go | listHandler wiring |
| rbaccheck | service.go / handler.go / contract_test.go |
| access-core ports/mem | `ports/role_repo.go` + `mem/role_repo.go` (ListByUserID) |
| access-core cell.go | cursorCodec + WithCursorCodec |

## Test plan

- [ ] `go test ./pkg/httputil/...` — ParsePageRequestOrWrite unit tests
- [ ] `go test ./cells/device-cell/...` — device-list contract_test + devicecommand updated handler
- [ ] `go test ./cells/access-core/slices/rbaccheck/...` — rbaccheck service/handler/contract_test
- [ ] `go test ./cells/access-core/...` — access-core integration (cell_test)
- [ ] `go build ./...` — 全量构建通过
- [ ] `gocell validate` — 元数据一致性
- [ ] `golangci-lint run ./...` — 0 issues

Refs: P1-8, L8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)