### PR TITLE
[codex] Add device list pagination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,7 @@ GOCELL_HMAC_KEY=
 # a fresh random secret before flipping adapter mode to real.
 GOCELL_AUDIT_CURSOR_KEY=
 GOCELL_CONFIG_CURSOR_KEY=
+GOCELL_ACCESS_CURSOR_KEY=
 
 # Cursor codec key rotation (optional — set only during the rotation window).
 # When set, the *_CURSOR_KEY above signs new tokens (signing capability) and the
@@ -109,6 +110,7 @@ GOCELL_CONFIG_CURSOR_KEY=
 # The previous key must also be >= 32 bytes and must not be a demo value.
 # GOCELL_AUDIT_CURSOR_PREVIOUS_KEY=
 # GOCELL_CONFIG_CURSOR_PREVIOUS_KEY=
+# GOCELL_ACCESS_CURSOR_PREVIOUS_KEY=
 
 # Encryption key provider (required when GOCELL_CELL_ADAPTER_MODE=postgres).
 # "local-aes"     — AES-256 envelope encryption with a local master key (dev/CI).

--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -223,6 +223,7 @@ type AccessCore struct {
 	validateSvc         *sessionvalidate.Service
 	authzSvc            *authorizationdecide.Service
 	rbacHandler         *rbaccheck.Handler
+	rbacRunMode         query.RunMode
 	rbacAssignHandler   *rbacassign.Handler
 	configReceiveSvc    *configreceive.Service
 	rbacSessionConsumer *sessionlogout.Consumer
@@ -399,6 +400,7 @@ func (c *AccessCore) initValidate(deps cell.Dependencies) error {
 		c.cursorCodec = codec
 		c.logger.Warn("accesscore: using default cursor codec (demo mode)")
 	}
+	c.rbacRunMode = query.RunModeForDemo(deps.DurabilityMode == cell.DurabilityDemo)
 	return nil
 }
 
@@ -479,8 +481,10 @@ func (c *AccessCore) initSlices() error {
 	c.AddSlice(cell.NewBaseSlice("authorizationdecide", "accesscore", cell.L0))
 
 	// rbac-check
-	rbacSvc := rbaccheck.NewService(c.roleRepo, c.cursorCodec, c.logger,
-		query.RunModeForDemo(c.outboxWriter == nil && c.txRunner == nil))
+	rbacSvc, err := rbaccheck.NewService(c.roleRepo, c.cursorCodec, c.logger, c.rbacRunMode)
+	if err != nil {
+		return err
+	}
 	c.rbacHandler = rbaccheck.NewHandler(rbacSvc)
 	c.AddSlice(cell.NewBaseSlice("rbaccheck", "accesscore", cell.L0))
 

--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/worker"
 )
@@ -82,6 +83,11 @@ func WithJWTVerifier(verifier *auth.JWTVerifier) Option {
 // WithOutboxWriter sets the outbox.Writer for transactional event publishing.
 func WithOutboxWriter(w outbox.Writer) Option {
 	return func(c *AccessCore) { c.outboxWriter = w }
+}
+
+// WithCursorCodec sets the cursor codec for pagination. Required in durable mode.
+func WithCursorCodec(codec *query.CursorCodec) Option {
+	return func(c *AccessCore) { c.cursorCodec = codec }
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
@@ -201,6 +207,7 @@ type AccessCore struct {
 	logger       *slog.Logger
 	jwtIssuer    *auth.JWTIssuer
 	jwtVerifier  *auth.JWTVerifier
+	cursorCodec  *query.CursorCodec
 
 	// Bootstrap configuration (set via WithInitialAdminBootstrap).
 	initialAdminCfg     *initialAdminConfig
@@ -380,6 +387,18 @@ func (c *AccessCore) initValidate(deps cell.Dependencies) error {
 		return errcode.New(errcode.ErrAuthKeyInvalid,
 			"RS256 key pair required: use WithJWTIssuer and WithJWTVerifier")
 	}
+	if c.cursorCodec == nil {
+		if deps.DurabilityMode == cell.DurabilityDurable {
+			return errcode.New(errcode.ErrCellMissingCodec,
+				"accesscore durable mode requires a cursor codec; use WithCursorCodec(query.NewCursorCodec(secret)) — the built-in demo key is public in the source tree")
+		}
+		codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+		if err != nil {
+			return err
+		}
+		c.cursorCodec = codec
+		c.logger.Warn("accesscore: using default cursor codec (demo mode)")
+	}
 	return nil
 }
 
@@ -460,7 +479,8 @@ func (c *AccessCore) initSlices() error {
 	c.AddSlice(cell.NewBaseSlice("authorizationdecide", "accesscore", cell.L0))
 
 	// rbac-check
-	rbacSvc := rbaccheck.NewService(c.roleRepo, c.logger)
+	rbacSvc := rbaccheck.NewService(c.roleRepo, c.cursorCodec, c.logger,
+		query.RunModeForDemo(c.outboxWriter == nil && c.txRunner == nil))
 	c.rbacHandler = rbaccheck.NewHandler(rbacSvc)
 	c.AddSlice(cell.NewBaseSlice("rbaccheck", "accesscore", cell.L0))
 

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
@@ -34,6 +35,20 @@ func (noopTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) e
 
 var _ persistence.TxRunner = noopTxRunner{}
 
+type durableTxRunner struct{}
+
+func (durableTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+var _ persistence.TxRunner = durableTxRunner{}
+
+type durableOutboxWriter struct{}
+
+func (durableOutboxWriter) Write(_ context.Context, _ outbox.Entry) error { return nil }
+
+var _ outbox.Writer = durableOutboxWriter{}
+
 // testPassword is a fixed test-only credential used to seed users in E2E tests.
 // Not a real secret — safe to appear in test source code.
 const testPassword = "secret123" //nolint:gosec // test-only credential
@@ -42,6 +57,7 @@ var (
 	testKeySet, _, _ = auth.MustNewTestKeySet()
 	testIssuer       = mustIssuer(testKeySet)
 	testVerifier     = mustVerifier(testKeySet)
+	testCursorCodec  = mustCursorCodec()
 )
 
 func mustIssuer(ks *auth.KeySet) *auth.JWTIssuer {
@@ -61,6 +77,14 @@ func mustVerifier(ks *auth.KeySet) *auth.JWTVerifier {
 	return v
 }
 
+func mustCursorCodec() *query.CursorCodec {
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+	if err != nil {
+		panic("test setup: " + err.Error())
+	}
+	return codec
+}
+
 func newTestCell() *AccessCore {
 	return NewAccessCore(
 		WithUserRepository(mem.NewUserRepository()),
@@ -71,6 +95,20 @@ func newTestCell() *AccessCore {
 		WithJWTVerifier(testVerifier),
 		WithOutboxWriter(outbox.NoopWriter{}),
 		WithTxManager(noopTxRunner{}),
+	)
+}
+
+func newDurableTestCell() *AccessCore {
+	return NewAccessCore(
+		WithUserRepository(mem.NewUserRepository()),
+		WithSessionRepository(mem.NewSessionRepository()),
+		WithRoleRepository(mem.NewRoleRepository()),
+		WithPublisher(eventbus.New()),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithCursorCodec(testCursorCodec),
+		WithOutboxWriter(durableOutboxWriter{}),
+		WithTxManager(durableTxRunner{}),
 	)
 }
 
@@ -232,6 +270,27 @@ func TestAccessCore_TokenVerifierAndAuthorizer(t *testing.T) {
 
 	assert.NotNil(t, c.TokenVerifier())
 	assert.NotNil(t, c.Authorizer())
+}
+
+func TestAccessCore_Init_DurableMode_UsesProdRBACRunMode(t *testing.T) {
+	c := newDurableTestCell()
+	ctx := context.Background()
+	deps := cell.Dependencies{
+		Config:         make(map[string]any),
+		DurabilityMode: cell.DurabilityDurable,
+	}
+	require.NoError(t, c.Init(ctx, deps))
+
+	r := router.New()
+	c.RegisterRoutes(r)
+	require.NoError(t, r.FinalizeAuth())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/roles/usr-1?cursor=not-a-valid-cursor", nil)
+	req = req.WithContext(auth.TestContext("admin-user", []string{"admin"}))
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestAccessCore_RegisterRoutes(t *testing.T) {

--- a/cells/accesscore/internal/initialadmin/bootstrap_test.go
+++ b/cells/accesscore/internal/initialadmin/bootstrap_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,6 +137,9 @@ func (r *countingRoleRepo) RemoveFromUser(ctx context.Context, userID, roleID st
 }
 func (r *countingRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
 	return r.inner.RemoveFromUserIfNotLast(ctx, userID, roleID)
+}
+func (r *countingRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
+	return r.inner.GetByUserID(ctx, userID)
 }
 
 var _ ports.RoleRepository = (*countingRoleRepo)(nil)

--- a/cells/accesscore/internal/mem/role_repo.go
+++ b/cells/accesscore/internal/mem/role_repo.go
@@ -1,6 +1,7 @@
 package mem
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"sync"
@@ -8,6 +9,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 )
 
 var _ ports.RoleRepository = (*RoleRepository)(nil)
@@ -142,6 +144,56 @@ func (r *RoleRepository) RemoveFromUserIfNotLast(_ context.Context, userID, role
 
 	delete(r.userRoles[userID], roleID)
 	return true, nil
+}
+
+// ListByUserID returns paginated roles for userID sorted per params.
+func (r *RoleRepository) ListByUserID(_ context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	roleIDs, ok := r.userRoles[userID]
+	if !ok {
+		return []*domain.Role{}, nil
+	}
+
+	roles := make([]*domain.Role, 0, len(roleIDs))
+	for rid := range roleIDs {
+		if role, ok := r.roles[rid]; ok {
+			clone := *role
+			clone.Permissions = make([]domain.Permission, len(role.Permissions))
+			copy(clone.Permissions, role.Permissions)
+			roles = append(roles, &clone)
+		}
+	}
+
+	query.Sort(roles, params.Sort, compareRoleField)
+	result, err := query.ApplyCursor(roles, params, roleFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("role-repo: list-by-user: %w", err)
+	}
+	return result, nil
+}
+
+func compareRoleField(a, b *domain.Role, field string) int {
+	switch field {
+	case "name":
+		return cmp.Compare(a.Name, b.Name)
+	case "id":
+		return cmp.Compare(a.ID, b.ID)
+	default:
+		return 0
+	}
+}
+
+func roleFieldValue(r *domain.Role, field string) any {
+	switch field {
+	case "name":
+		return r.Name
+	case "id":
+		return r.ID
+	default:
+		return ""
+	}
 }
 
 // CountByRole returns the number of users assigned to the given role.

--- a/cells/accesscore/internal/ports/role_repo.go
+++ b/cells/accesscore/internal/ports/role_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/pkg/query"
 )
 
 // RoleRepository persists and retrieves Role entities and user-role assignments.
@@ -27,4 +28,7 @@ type RoleRepository interface {
 	// Callers gate outbox emission on changed.
 	RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (changed bool, err error)
 	CountByRole(ctx context.Context, roleID string) (int, error)
+	// ListByUserID returns a paginated list of roles assigned to userID,
+	// sorted and filtered per params.
+	ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error)
 }

--- a/cells/accesscore/slices/rbaccheck/contract_test.go
+++ b/cells/accesscore/slices/rbaccheck/contract_test.go
@@ -2,9 +2,11 @@ package rbaccheck
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -22,17 +24,31 @@ import (
 func newContractRBACHandler() http.Handler {
 	roleRepo := mem.NewRoleRepository()
 	roleRepo.SeedRole(&domain.Role{
-		ID: "r1", Name: "admin",
+		ID: "admin", Name: "admin",
 		Permissions: []domain.Permission{
 			{Resource: "users", Action: "read"},
 		},
 	})
-	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
+	roleRepo.SeedRole(&domain.Role{
+		ID: "operator", Name: "operator",
+		Permissions: []domain.Permission{
+			{Resource: "devices", Action: "write"},
+		},
+	})
+	roleRepo.SeedRole(&domain.Role{
+		ID: "viewer", Name: "viewer",
+		Permissions: []domain.Permission{
+			{Resource: "devices", Action: "read"},
+		},
+	})
+	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "admin")
+	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "operator")
+	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "viewer")
 	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
 	if err != nil {
 		panic(err)
 	}
-	svc, err := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
+	svc, err := NewService(roleRepo, codec, slog.Default(), query.RunModeProd)
 	if err != nil {
 		panic(err)
 	}
@@ -45,6 +61,21 @@ func newContractRBACHandler() http.Handler {
 	return outer
 }
 
+type roleListPage struct {
+	Data       []RoleResponse `json:"data"`
+	NextCursor string         `json:"nextCursor"`
+	HasMore    bool           `json:"hasMore"`
+}
+
+func decodeRoleListPage(t *testing.T, rec *httptest.ResponseRecorder) roleListPage {
+	t.Helper()
+	var page roleListPage
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode role list response: %v", err)
+	}
+	return page
+}
+
 func TestHttpAuthRoleListV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.auth.role.list.v1")
@@ -52,13 +83,57 @@ func TestHttpAuthRoleListV1Serve(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	path := strings.Replace(c.HTTP.Path, "{userID}", "user-1", 1)
-	req := httptest.NewRequest(c.HTTP.Method, path, nil)
+	req := httptest.NewRequest(c.HTTP.Method, path+"?limit=2", nil)
 	req = req.WithContext(auth.TestContext("user-1", nil))
 	h.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
+	page1 := decodeRoleListPage(t, rec)
+	if len(page1.Data) != 2 {
+		t.Fatalf("page 1: expected 2 roles, got %d", len(page1.Data))
+	}
+	if !page1.HasMore {
+		t.Fatal("page 1: expected hasMore=true")
+	}
+	if page1.NextCursor == "" {
+		t.Fatal("page 1: expected non-empty nextCursor")
+	}
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(c.HTTP.Method, path+"?limit=2&cursor="+url.QueryEscape(page1.NextCursor), nil)
+	req2 = req2.WithContext(auth.TestContext("user-1", nil))
+	h.ServeHTTP(rec2, req2)
+	c.ValidateHTTPResponseRecorder(t, rec2)
+	page2 := decodeRoleListPage(t, rec2)
+	if len(page2.Data) != 1 {
+		t.Fatalf("page 2: expected 1 role, got %d", len(page2.Data))
+	}
+	if page2.HasMore {
+		t.Fatal("page 2: expected hasMore=false")
+	}
+	if page2.NextCursor != "" {
+		t.Fatalf("page 2: expected empty nextCursor, got %q", page2.NextCursor)
+	}
 
 	c.MustRejectResponse(t, []byte(`{"data":[]}`))
 	c.MustRejectResponse(t, []byte(`{"data":{"wrong":"shape"},"hasMore":false}`))
+
+	rec400 := httptest.NewRecorder()
+	req400 := httptest.NewRequest(c.HTTP.Method, path+"?limit=notanumber", nil)
+	req400 = req400.WithContext(auth.TestContext("user-1", nil))
+	h.ServeHTTP(rec400, req400)
+	if rec400.Code != http.StatusBadRequest {
+		t.Errorf("invalid limit: expected 400, got %d", rec400.Code)
+	}
+	c.ValidateErrorResponse(t, http.StatusBadRequest, rec400.Body.Bytes())
+
+	recBadCursor := httptest.NewRecorder()
+	reqBadCursor := httptest.NewRequest(c.HTTP.Method, path+"?cursor=not-a-valid-cursor", nil)
+	reqBadCursor = reqBadCursor.WithContext(auth.TestContext("user-1", nil))
+	h.ServeHTTP(recBadCursor, reqBadCursor)
+	if recBadCursor.Code != http.StatusBadRequest {
+		t.Errorf("invalid cursor: expected 400, got %d", recBadCursor.Code)
+	}
+	c.ValidateErrorResponse(t, http.StatusBadRequest, recBadCursor.Body.Bytes())
 }
 
 func TestHttpAuthRoleCheckV1Serve(t *testing.T) {

--- a/cells/accesscore/slices/rbaccheck/contract_test.go
+++ b/cells/accesscore/slices/rbaccheck/contract_test.go
@@ -32,7 +32,10 @@ func newContractRBACHandler() http.Handler {
 	if err != nil {
 		panic(err)
 	}
-	svc := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
+	svc, err := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
+	if err != nil {
+		panic(err)
+	}
 
 	inner := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(inner)

--- a/cells/accesscore/slices/rbaccheck/contract_test.go
+++ b/cells/accesscore/slices/rbaccheck/contract_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -27,7 +28,11 @@ func newContractRBACHandler() http.Handler {
 		},
 	})
 	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
-	svc := NewService(roleRepo, slog.Default())
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+	if err != nil {
+		panic(err)
+	}
+	svc := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
 
 	inner := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(inner)
@@ -48,6 +53,9 @@ func TestHttpAuthRoleListV1Serve(t *testing.T) {
 	req = req.WithContext(auth.TestContext("user-1", nil))
 	h.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
+
+	c.MustRejectResponse(t, []byte(`{"data":[]}`))
+	c.MustRejectResponse(t, []byte(`{"data":{"wrong":"shape"},"hasMore":false}`))
 }
 
 func TestHttpAuthRoleCheckV1Serve(t *testing.T) {

--- a/cells/accesscore/slices/rbaccheck/handler.go
+++ b/cells/accesscore/slices/rbaccheck/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -66,17 +67,19 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 
 func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("userID")
-	roles, err := h.svc.ListRoles(r.Context(), userID)
+
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.svc.ListRoles(r.Context(), userID, pageReq)
 	if err != nil {
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
 
-	resp := make([]RoleResponse, len(roles))
-	for i, role := range roles {
-		resp[i] = toRoleResponse(role)
-	}
-	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": resp, "hasMore": false})
+	httputil.WriteJSON(w, http.StatusOK, query.MapPageResult(result, toRoleResponse))
 }
 
 func (h *Handler) handleHasRole(w http.ResponseWriter, r *http.Request) {

--- a/cells/accesscore/slices/rbaccheck/handler.go
+++ b/cells/accesscore/slices/rbaccheck/handler.go
@@ -68,7 +68,7 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("userID")
 
-	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	pageReq, ok := httputil.ParsePageParamsOrWrite(w, r)
 	if !ok {
 		return
 	}

--- a/cells/accesscore/slices/rbaccheck/handler_test.go
+++ b/cells/accesscore/slices/rbaccheck/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -63,7 +64,11 @@ func setup() http.Handler {
 	})
 	_, _ = roleRepo.AssignToUser(context.Background(), "user-1", "r1")
 
-	svc := NewService(roleRepo, slog.Default())
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+	if err != nil {
+		panic(err)
+	}
+	svc := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux

--- a/cells/accesscore/slices/rbaccheck/handler_test.go
+++ b/cells/accesscore/slices/rbaccheck/handler_test.go
@@ -53,7 +53,8 @@ func TestRoleResponse_EmptyPermissions(t *testing.T) {
 	assert.Empty(t, resp.Permissions)
 }
 
-func setup() http.Handler {
+func setup(t *testing.T, runMode query.RunMode) http.Handler {
+	t.Helper()
 	roleRepo := mem.NewRoleRepository()
 	roleRepo.SeedRole(&domain.Role{
 		ID: "r1", Name: "admin",
@@ -68,7 +69,10 @@ func setup() http.Handler {
 	if err != nil {
 		panic(err)
 	}
-	svc := NewService(roleRepo, codec, slog.Default(), query.RunModeDemo)
+	svc, err := NewService(roleRepo, codec, slog.Default(), runMode)
+	if err != nil {
+		panic(err)
+	}
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux
@@ -185,7 +189,7 @@ func TestHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := setup()
+			r := setup(t, query.RunModeDemo)
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			if tc.subject != "" {
@@ -198,4 +202,15 @@ func TestHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandler_ListRoles_ProdMode_InvalidCursor_Returns400(t *testing.T) {
+	r := setup(t, query.RunModeProd)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/user-1?cursor=not-a-valid-cursor", nil)
+	req = req.WithContext(auth.TestContext("user-1", nil))
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/cells/accesscore/slices/rbaccheck/service.go
+++ b/cells/accesscore/slices/rbaccheck/service.go
@@ -27,8 +27,12 @@ type Service struct {
 }
 
 // NewService creates an rbac-check Service.
-func NewService(roleRepo ports.RoleRepository, codec *query.CursorCodec, logger *slog.Logger, runMode query.RunMode) *Service {
-	return &Service{roleRepo: roleRepo, codec: codec, logger: logger, runMode: runMode}
+// codec must be non-nil; cursor pagination cannot be served without it.
+func NewService(roleRepo ports.RoleRepository, codec *query.CursorCodec, logger *slog.Logger, runMode query.RunMode) (*Service, error) {
+	if codec == nil {
+		return nil, errcode.New(errcode.ErrCellMissingCodec, "rbac-check: cursor codec is required")
+	}
+	return &Service{roleRepo: roleRepo, codec: codec, logger: logger, runMode: runMode}, nil
 }
 
 // HasRole checks if a user has the specified role.
@@ -58,10 +62,10 @@ func (s *Service) ListRoles(ctx context.Context, userID string, pageReq query.Pa
 
 	qctx := query.QueryContext("endpoint", "rbac-list-roles", "userId", userID)
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Role]{
-		Codec:    s.codec,
-		Request:  pageReq,
-		Sort:     roleSort,
-		QueryCtx: qctx,
+		Codec:      s.codec,
+		PageParams: pageReq,
+		Sort:       roleSort,
+		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Role, error) {
 			roles, err := s.roleRepo.ListByUserID(ctx, userID, params)
 			if err != nil {

--- a/cells/accesscore/slices/rbaccheck/service.go
+++ b/cells/accesscore/slices/rbaccheck/service.go
@@ -10,17 +10,25 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 )
+
+var roleSort = []query.SortColumn{
+	{Name: "name", Direction: query.SortASC},
+	{Name: "id", Direction: query.SortASC},
+}
 
 // Service implements RBAC query operations.
 type Service struct {
 	roleRepo ports.RoleRepository
+	codec    *query.CursorCodec
 	logger   *slog.Logger
+	runMode  query.RunMode
 }
 
 // NewService creates an rbac-check Service.
-func NewService(roleRepo ports.RoleRepository, logger *slog.Logger) *Service {
-	return &Service{roleRepo: roleRepo, logger: logger}
+func NewService(roleRepo ports.RoleRepository, codec *query.CursorCodec, logger *slog.Logger, runMode query.RunMode) *Service {
+	return &Service{roleRepo: roleRepo, codec: codec, logger: logger, runMode: runMode}
 }
 
 // HasRole checks if a user has the specified role.
@@ -42,15 +50,29 @@ func (s *Service) HasRole(ctx context.Context, userID, roleName string) (bool, e
 	return false, nil
 }
 
-// ListRoles returns all roles assigned to a user.
-func (s *Service) ListRoles(ctx context.Context, userID string) ([]*domain.Role, error) {
+// ListRoles returns a paginated page of roles assigned to userID.
+func (s *Service) ListRoles(ctx context.Context, userID string, pageReq query.PageParams) (query.PageResult[*domain.Role], error) {
 	if userID == "" {
-		return nil, errcode.New(errcode.ErrAuthRBACInvalidInput, "userID is required")
+		return query.PageResult[*domain.Role]{}, errcode.New(errcode.ErrAuthRBACInvalidInput, "userID is required")
 	}
 
-	roles, err := s.roleRepo.GetByUserID(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("rbac-check: list roles: %w", err)
-	}
-	return roles, nil
+	qctx := query.QueryContext("endpoint", "rbac-list-roles", "userId", userID)
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Role]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     roleSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Role, error) {
+			roles, err := s.roleRepo.ListByUserID(ctx, userID, params)
+			if err != nil {
+				return nil, fmt.Errorf("rbac-check: list roles: %w", err)
+			}
+			return roles, nil
+		},
+		Extract: func(r *domain.Role) []any {
+			return []any{r.Name, r.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "rbac-check"),
+		RunMode:     s.runMode,
+	})
 }

--- a/cells/accesscore/slices/rbaccheck/service_test.go
+++ b/cells/accesscore/slices/rbaccheck/service_test.go
@@ -7,13 +7,24 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func newTestService() (*Service, *mem.RoleRepository) {
+func newTestCodec(t *testing.T) *query.CursorCodec {
+	t.Helper()
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-ACCESS-CORE-key-32!!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return codec
+}
+
+func newTestService(t *testing.T) (*Service, *mem.RoleRepository) {
+	t.Helper()
 	repo := mem.NewRoleRepository()
-	return NewService(repo, slog.Default()), repo
+	return NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo), repo
 }
 
 func TestService_HasRole(t *testing.T) {
@@ -50,7 +61,7 @@ func TestService_HasRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, repo := newTestService()
+			svc, repo := newTestService(t)
 			tt.setup(repo)
 
 			has, err := svc.HasRole(context.Background(), tt.userID, tt.roleName)
@@ -65,19 +76,19 @@ func TestService_HasRole(t *testing.T) {
 }
 
 func TestService_ListRoles(t *testing.T) {
-	svc, repo := newTestService()
+	svc, repo := newTestService(t)
 	repo.SeedRole(&domain.Role{ID: "admin", Name: "admin"})
 	repo.SeedRole(&domain.Role{ID: "viewer", Name: "viewer"})
 	_, _ = repo.AssignToUser(context.Background(), "usr-1", "admin")
 	_, _ = repo.AssignToUser(context.Background(), "usr-1", "viewer")
 
-	roles, err := svc.ListRoles(context.Background(), "usr-1")
+	result, err := svc.ListRoles(context.Background(), "usr-1", query.PageParams{Limit: 50})
 	require.NoError(t, err)
-	assert.Len(t, roles, 2)
+	assert.Len(t, result.Items, 2)
 }
 
 func TestService_ListRolesEmptyInput(t *testing.T) {
-	svc, _ := newTestService()
-	_, err := svc.ListRoles(context.Background(), "")
+	svc, _ := newTestService(t)
+	_, err := svc.ListRoles(context.Background(), "", query.PageParams{})
 	assert.Error(t, err)
 }

--- a/cells/accesscore/slices/rbaccheck/service_test.go
+++ b/cells/accesscore/slices/rbaccheck/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,9 +23,25 @@ func newTestCodec(t *testing.T) *query.CursorCodec {
 }
 
 func newTestService(t *testing.T) (*Service, *mem.RoleRepository) {
+	return newTestServiceWithMode(t, query.RunModeDemo)
+}
+
+func newTestServiceWithMode(t *testing.T, runMode query.RunMode) (*Service, *mem.RoleRepository) {
 	t.Helper()
 	repo := mem.NewRoleRepository()
-	return NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo), repo
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), runMode)
+	require.NoError(t, err)
+	return svc, repo
+}
+
+func TestNewService_RequiresCodec(t *testing.T) {
+	repo := mem.NewRoleRepository()
+	svc, err := NewService(repo, nil, slog.Default(), query.RunModeProd)
+	require.Error(t, err)
+	require.Nil(t, svc)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCellMissingCodec, ecErr.Code)
 }
 
 func TestService_HasRole(t *testing.T) {
@@ -91,4 +108,20 @@ func TestService_ListRolesEmptyInput(t *testing.T) {
 	svc, _ := newTestService(t)
 	_, err := svc.ListRoles(context.Background(), "", query.PageParams{})
 	assert.Error(t, err)
+}
+
+func TestService_ListRoles_ProdMode_BadCursor_ReturnsError(t *testing.T) {
+	svc, repo := newTestServiceWithMode(t, query.RunModeProd)
+	repo.SeedRole(&domain.Role{ID: "admin", Name: "admin"})
+	_, _ = repo.AssignToUser(context.Background(), "usr-1", "admin")
+
+	_, err := svc.ListRoles(context.Background(), "usr-1", query.PageParams{
+		Limit:  50,
+		Cursor: "not-a-valid-cursor",
+	})
+	require.Error(t, err)
+
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }

--- a/cells/accesscore/slices/rbaccheck/service_test.go
+++ b/cells/accesscore/slices/rbaccheck/service_test.go
@@ -95,13 +95,26 @@ func TestService_HasRole(t *testing.T) {
 func TestService_ListRoles(t *testing.T) {
 	svc, repo := newTestService(t)
 	repo.SeedRole(&domain.Role{ID: "admin", Name: "admin"})
+	repo.SeedRole(&domain.Role{ID: "operator", Name: "operator"})
 	repo.SeedRole(&domain.Role{ID: "viewer", Name: "viewer"})
 	_, _ = repo.AssignToUser(context.Background(), "usr-1", "admin")
+	_, _ = repo.AssignToUser(context.Background(), "usr-1", "operator")
 	_, _ = repo.AssignToUser(context.Background(), "usr-1", "viewer")
 
-	result, err := svc.ListRoles(context.Background(), "usr-1", query.PageParams{Limit: 50})
+	result, err := svc.ListRoles(context.Background(), "usr-1", query.PageParams{Limit: 2})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
+	assert.True(t, result.HasMore)
+	require.NotEmpty(t, result.NextCursor)
+
+	next, err := svc.ListRoles(context.Background(), "usr-1", query.PageParams{
+		Limit:  2,
+		Cursor: result.NextCursor,
+	})
+	require.NoError(t, err)
+	assert.Len(t, next.Items, 1)
+	assert.False(t, next.HasMore)
+	assert.Empty(t, next.NextCursor)
 }
 
 func TestService_ListRolesEmptyInput(t *testing.T) {

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -151,7 +151,7 @@ func (s *Service) lookupSession(ctx context.Context, refreshToken string) (*doma
 	s.logger.Error("session-refresh: refresh token reuse detected, session revoked",
 		slog.String("session_id", reuseSession.ID),
 		slog.String("user_id", reuseSession.UserID))
-	return nil, errcode.New(errcode.ErrAuthRefreshTokenReuse, "refresh token reuse detected, session revoked")
+	return nil, errcode.New(errcode.ErrRefreshTokenReused, "refresh token reuse detected, session revoked")
 }
 
 // rotateAndIssue mints new access + refresh tokens, persists the rotated

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -137,7 +137,7 @@ func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		filters.To = t
 	}
 
-	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	pageReq, ok := httputil.ParsePageParamsOrWrite(w, r)
 	if !ok {
 		return
 	}

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -137,13 +137,8 @@ func (h *Handler) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		filters.To = t
 	}
 
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/auditcore/slices/auditquery/service.go
+++ b/cells/auditcore/slices/auditquery/service.go
@@ -44,7 +44,7 @@ func NewService(repo ports.AuditRepository, codec *query.CursorCodec, logger *sl
 }
 
 // Query returns a paginated page of audit entries matching the given filters.
-func (s *Service) Query(ctx context.Context, filters ports.AuditFilters, pageReq query.PageRequest) (query.PageResult[*domain.AuditEntry], error) {
+func (s *Service) Query(ctx context.Context, filters ports.AuditFilters, pageReq query.PageParams) (query.PageResult[*domain.AuditEntry], error) {
 	qctx := query.QueryContext("endpoint", "audit-query",
 		"eventType", filters.EventType,
 		"actorId", filters.ActorID,
@@ -52,10 +52,10 @@ func (s *Service) Query(ctx context.Context, filters ports.AuditFilters, pageReq
 		"to", filters.To.Format(time.RFC3339Nano),
 	)
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.AuditEntry]{
-		Codec:    s.codec,
-		Request:  pageReq,
-		Sort:     auditSort,
-		QueryCtx: qctx,
+		Codec:      s.codec,
+		PageParams: pageReq,
+		Sort:       auditSort,
+		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.AuditEntry, error) {
 			entries, err := s.repo.Query(ctx, filters, params)
 			if err != nil {

--- a/cells/auditcore/slices/auditquery/service_test.go
+++ b/cells/auditcore/slices/auditquery/service_test.go
@@ -104,7 +104,7 @@ func TestService_Query(t *testing.T) {
 			svc, repo := newTestService()
 			tt.seed(repo)
 
-			result, err := svc.Query(context.Background(), tt.filters, query.PageRequest{})
+			result, err := svc.Query(context.Background(), tt.filters, query.PageParams{})
 			require.NoError(t, err)
 			assert.Len(t, result.Items, tt.wantLen)
 		})
@@ -119,7 +119,7 @@ func TestService_Query_FirstPage(t *testing.T) {
 			base.Add(time.Duration(i)*time.Hour))
 	}
 
-	result, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageRequest{Limit: 3})
+	result, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 3)
 	assert.True(t, result.HasMore)
@@ -137,12 +137,12 @@ func TestService_Query_WithCursor(t *testing.T) {
 	}
 
 	// Get first page
-	page1, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageRequest{Limit: 3})
+	page1, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.True(t, page1.HasMore)
 
 	// Get second page using cursor
-	page2, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageRequest{Limit: 3, Cursor: page1.NextCursor})
+	page2, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageParams{Limit: 3, Cursor: page1.NextCursor})
 	require.NoError(t, err)
 	assert.Len(t, page2.Items, 3)
 	// Second page should continue where first left off
@@ -152,7 +152,7 @@ func TestService_Query_WithCursor(t *testing.T) {
 func TestService_Query_InvalidCursor(t *testing.T) {
 	svc, _ := newTestService()
 
-	_, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageRequest{Cursor: "garbage-token"})
+	_, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageParams{Cursor: "garbage-token"})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -165,7 +165,7 @@ func TestService_Query_LastPage(t *testing.T) {
 	seedEntry(repo, "ae-00", "event.test.v1", "usr-1", base)
 	seedEntry(repo, "ae-01", "event.test.v1", "usr-1", base.Add(time.Hour))
 
-	result, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageRequest{Limit: 10})
+	result, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageParams{Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
 	assert.False(t, result.HasMore)
@@ -175,7 +175,7 @@ func TestService_Query_LastPage(t *testing.T) {
 func TestService_Query_Empty(t *testing.T) {
 	svc, _ := newTestService()
 
-	result, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageRequest{})
+	result, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageParams{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Items)
 	assert.False(t, result.HasMore)
@@ -194,14 +194,14 @@ func TestService_Query_CursorContextMismatch(t *testing.T) {
 
 	// Get first page with eventType=login filter.
 	loginFilters := ports.AuditFilters{EventType: "event.login.v1"}
-	page1, err := svc.Query(context.Background(), loginFilters, query.PageRequest{Limit: 3})
+	page1, err := svc.Query(context.Background(), loginFilters, query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.True(t, page1.HasMore)
 	require.NotEmpty(t, page1.NextCursor)
 
 	// Replay the cursor with a different eventType filter — must fail.
 	logoutFilters := ports.AuditFilters{EventType: "event.logout.v1"}
-	_, err = svc.Query(context.Background(), logoutFilters, query.PageRequest{Limit: 3, Cursor: page1.NextCursor})
+	_, err = svc.Query(context.Background(), logoutFilters, query.PageParams{Limit: 3, Cursor: page1.NextCursor})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -248,7 +248,7 @@ func TestService_Query_InvalidCursor_LogsDecode(t *testing.T) {
 
 	badCursor := "garbage-token-should-not-appear-in-log"
 	ctx := ctxkeys.WithRequestID(context.Background(), "req-test-001")
-	_, err := svc.Query(ctx, ports.AuditFilters{}, query.PageRequest{Cursor: badCursor})
+	_, err := svc.Query(ctx, ports.AuditFilters{}, query.PageParams{Cursor: badCursor})
 	require.Error(t, err)
 
 	logs := parseLogLines(t, buf)
@@ -277,7 +277,7 @@ func TestService_Query_InvalidCursor_LogsScope(t *testing.T) {
 
 	// Issue a valid first page to mint a scoped cursor.
 	loginFilters := ports.AuditFilters{EventType: "event.login.v1"}
-	page1, err := svc.Query(context.Background(), loginFilters, query.PageRequest{Limit: 3})
+	page1, err := svc.Query(context.Background(), loginFilters, query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.NotEmpty(t, page1.NextCursor)
 
@@ -288,7 +288,7 @@ func TestService_Query_InvalidCursor_LogsScope(t *testing.T) {
 	// to confirm correlation propagation.
 	logoutFilters := ports.AuditFilters{EventType: "event.logout.v1"}
 	ctxWithReqID := ctxkeys.WithRequestID(context.Background(), "req-test-002")
-	_, err = svc.Query(ctxWithReqID, logoutFilters, query.PageRequest{Limit: 3, Cursor: page1.NextCursor})
+	_, err = svc.Query(ctxWithReqID, logoutFilters, query.PageParams{Limit: 3, Cursor: page1.NextCursor})
 	require.Error(t, err)
 
 	logs := parseLogLines(t, buf)
@@ -310,7 +310,7 @@ func TestService_Query_InvalidCursor_LogsScope(t *testing.T) {
 func TestService_Query_InvalidCursor_NoRequestID(t *testing.T) {
 	svc, _, buf := newTestServiceWithLogBuf()
 
-	_, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageRequest{Cursor: "garbage"})
+	_, err := svc.Query(context.Background(), ports.AuditFilters{}, query.PageParams{Cursor: "garbage"})
 	require.Error(t, err)
 
 	logs := parseLogLines(t, buf)
@@ -332,13 +332,13 @@ func TestService_Query_SubsecondFilterContext(t *testing.T) {
 
 	// Query A: from = base+100ns
 	filtersA := ports.AuditFilters{From: base.Add(100 * time.Nanosecond)}
-	pageA, err := svc.Query(context.Background(), filtersA, query.PageRequest{Limit: 3})
+	pageA, err := svc.Query(context.Background(), filtersA, query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.True(t, pageA.HasMore)
 
 	// Query B: from = base+200ns (same second, different nanosecond)
 	filtersB := ports.AuditFilters{From: base.Add(200 * time.Nanosecond)}
-	_, err = svc.Query(context.Background(), filtersB, query.PageRequest{
+	_, err = svc.Query(context.Background(), filtersB, query.PageParams{
 		Limit:  3,
 		Cursor: pageA.NextCursor,
 	})

--- a/cells/configcore/slices/configread/handler.go
+++ b/cells/configcore/slices/configread/handler.go
@@ -33,7 +33,7 @@ func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleList handles GET /?limit=N&cursor=TOKEN — returns paginated config entries.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	pageReq, ok := httputil.ParsePageParamsOrWrite(w, r)
 	if !ok {
 		return
 	}

--- a/cells/configcore/slices/configread/handler.go
+++ b/cells/configcore/slices/configread/handler.go
@@ -1,7 +1,6 @@
 package configread
 
 import (
-	"log/slog"
 	"net/http"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/dto"
@@ -34,13 +33,8 @@ func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleList handles GET /?limit=N&cursor=TOKEN — returns paginated config entries.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/configcore/slices/configread/service.go
+++ b/cells/configcore/slices/configread/service.go
@@ -56,13 +56,13 @@ func (s *Service) GetByKey(ctx context.Context, key string) (*domain.ConfigEntry
 }
 
 // List returns a paginated page of config entries.
-func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.PageResult[*domain.ConfigEntry], error) {
+func (s *Service) List(ctx context.Context, pageReq query.PageParams) (query.PageResult[*domain.ConfigEntry], error) {
 	qctx := query.QueryContext("endpoint", "config-read")
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.ConfigEntry]{
-		Codec:    s.codec,
-		Request:  pageReq,
-		Sort:     configSort,
-		QueryCtx: qctx,
+		Codec:      s.codec,
+		PageParams: pageReq,
+		Sort:       configSort,
+		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.ConfigEntry, error) {
 			entries, err := s.repo.List(ctx, params)
 			if err != nil {

--- a/cells/configcore/slices/configread/service_test.go
+++ b/cells/configcore/slices/configread/service_test.go
@@ -99,7 +99,7 @@ func TestService_List(t *testing.T) {
 				seedEntry(t, repo, "key-"+string(rune('a'+i)), "v")
 			}
 
-			result, err := svc.List(context.Background(), query.PageRequest{})
+			result, err := svc.List(context.Background(), query.PageParams{})
 			require.NoError(t, err)
 			assert.Len(t, result.Items, tt.wantLen)
 		})
@@ -112,7 +112,7 @@ func TestService_List_FirstPage(t *testing.T) {
 		seedEntry(t, repo, "key-"+string(rune('a'+i)), "v")
 	}
 
-	result, err := svc.List(context.Background(), query.PageRequest{Limit: 3})
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 3)
 	assert.True(t, result.HasMore)
@@ -125,11 +125,11 @@ func TestService_List_WithCursor(t *testing.T) {
 		seedEntry(t, repo, "key-"+string(rune('a'+i)), "v")
 	}
 
-	page1, err := svc.List(context.Background(), query.PageRequest{Limit: 3})
+	page1, err := svc.List(context.Background(), query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.True(t, page1.HasMore)
 
-	page2, err := svc.List(context.Background(), query.PageRequest{Limit: 3, Cursor: page1.NextCursor})
+	page2, err := svc.List(context.Background(), query.PageParams{Limit: 3, Cursor: page1.NextCursor})
 	require.NoError(t, err)
 	assert.Len(t, page2.Items, 2)
 	assert.NotEqual(t, page1.Items[0].ID, page2.Items[0].ID)
@@ -138,7 +138,7 @@ func TestService_List_WithCursor(t *testing.T) {
 func TestService_List_InvalidCursor(t *testing.T) {
 	svc, _ := newTestService()
 
-	_, err := svc.List(context.Background(), query.PageRequest{Cursor: "garbage"})
+	_, err := svc.List(context.Background(), query.PageParams{Cursor: "garbage"})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -160,7 +160,7 @@ func TestService_List_ScopeMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	svc, _ := newTestService()
-	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	_, err = svc.List(context.Background(), query.PageParams{Cursor: token})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -179,7 +179,7 @@ func TestService_List_ContextMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	svc, _ := newTestService()
-	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	_, err = svc.List(context.Background(), query.PageParams{Cursor: token})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -192,7 +192,7 @@ func TestService_List_LastPage(t *testing.T) {
 	seedEntry(t, repo, "key-a", "v")
 	seedEntry(t, repo, "key-b", "v")
 
-	result, err := svc.List(context.Background(), query.PageRequest{Limit: 10})
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
 	assert.False(t, result.HasMore)
@@ -202,7 +202,7 @@ func TestService_List_LastPage(t *testing.T) {
 func TestService_List_Empty(t *testing.T) {
 	svc, _ := newTestService()
 
-	result, err := svc.List(context.Background(), query.PageRequest{})
+	result, err := svc.List(context.Background(), query.PageParams{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Items)
 	assert.False(t, result.HasMore)

--- a/cells/configcore/slices/featureflag/contract_test.go
+++ b/cells/configcore/slices/featureflag/contract_test.go
@@ -10,7 +10,7 @@ func TestHttpConfigFlagsListV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.flags.list.v1")
 
-	c.ValidateResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}],"hasMore":false}`))
+	c.ValidateResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}],"nextCursor":"","hasMore":false}`))
 	c.MustRejectResponse(t, []byte(`{"data":"not-array","hasMore":false}`))
 }
 

--- a/cells/configcore/slices/featureflag/handler.go
+++ b/cells/configcore/slices/featureflag/handler.go
@@ -54,7 +54,7 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleList handles GET / — returns paginated feature flags.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	pageReq, ok := httputil.ParsePageParamsOrWrite(w, r)
 	if !ok {
 		return
 	}

--- a/cells/configcore/slices/featureflag/handler.go
+++ b/cells/configcore/slices/featureflag/handler.go
@@ -1,7 +1,6 @@
 package featureflag
 
 import (
-	"log/slog"
 	"net/http"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
@@ -55,13 +54,8 @@ func NewHandler(svc *Service) *Handler {
 
 // HandleList handles GET / — returns paginated feature flags.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/configcore/slices/featureflag/service.go
+++ b/cells/configcore/slices/featureflag/service.go
@@ -63,13 +63,13 @@ func (s *Service) GetByKey(ctx context.Context, key string) (*domain.FeatureFlag
 }
 
 // List returns a paginated page of feature flags.
-func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.PageResult[*domain.FeatureFlag], error) {
+func (s *Service) List(ctx context.Context, pageReq query.PageParams) (query.PageResult[*domain.FeatureFlag], error) {
 	qctx := query.QueryContext("endpoint", "feature-flag")
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.FeatureFlag]{
-		Codec:    s.codec,
-		Request:  pageReq,
-		Sort:     flagSort,
-		QueryCtx: qctx,
+		Codec:      s.codec,
+		PageParams: pageReq,
+		Sort:       flagSort,
+		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.FeatureFlag, error) {
 			flags, err := s.repo.List(ctx, params)
 			if err != nil {

--- a/cells/configcore/slices/featureflag/service_test.go
+++ b/cells/configcore/slices/featureflag/service_test.go
@@ -79,7 +79,7 @@ func TestService_List(t *testing.T) {
 	seedFlag(t, repo, "f1", domain.FlagBoolean, true, 0)
 	seedFlag(t, repo, "f2", domain.FlagPercentage, true, 50)
 
-	result, err := svc.List(context.Background(), query.PageRequest{Limit: 50})
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 50})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
 	assert.False(t, result.HasMore)
@@ -91,7 +91,7 @@ func TestService_List_FirstPage(t *testing.T) {
 		seedFlag(t, repo, "flag-"+string(rune('a'+i)), domain.FlagBoolean, true, 0)
 	}
 
-	result, err := svc.List(context.Background(), query.PageRequest{Limit: 3})
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 3)
 	assert.True(t, result.HasMore)
@@ -104,11 +104,11 @@ func TestService_List_WithCursor(t *testing.T) {
 		seedFlag(t, repo, "flag-"+string(rune('a'+i)), domain.FlagBoolean, true, 0)
 	}
 
-	page1, err := svc.List(context.Background(), query.PageRequest{Limit: 3})
+	page1, err := svc.List(context.Background(), query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.True(t, page1.HasMore)
 
-	page2, err := svc.List(context.Background(), query.PageRequest{Limit: 3, Cursor: page1.NextCursor})
+	page2, err := svc.List(context.Background(), query.PageParams{Limit: 3, Cursor: page1.NextCursor})
 	require.NoError(t, err)
 	assert.Len(t, page2.Items, 2)
 	assert.NotEqual(t, page1.Items[0].ID, page2.Items[0].ID)
@@ -117,7 +117,7 @@ func TestService_List_WithCursor(t *testing.T) {
 func TestService_List_InvalidCursor(t *testing.T) {
 	svc, _ := newTestService()
 
-	_, err := svc.List(context.Background(), query.PageRequest{Cursor: "garbage"})
+	_, err := svc.List(context.Background(), query.PageParams{Cursor: "garbage"})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -142,7 +142,7 @@ func TestService_List_ScopeMismatch(t *testing.T) {
 	token, err := codec.Encode(cur)
 	require.NoError(t, err)
 
-	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	_, err = svc.List(context.Background(), query.PageParams{Cursor: token})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -164,7 +164,7 @@ func TestService_List_ContextMismatch(t *testing.T) {
 	token, err := codec.Encode(cur)
 	require.NoError(t, err)
 
-	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	_, err = svc.List(context.Background(), query.PageParams{Cursor: token})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -177,7 +177,7 @@ func TestService_List_LastPage(t *testing.T) {
 	seedFlag(t, repo, "flag-a", domain.FlagBoolean, true, 0)
 	seedFlag(t, repo, "flag-b", domain.FlagBoolean, true, 0)
 
-	result, err := svc.List(context.Background(), query.PageRequest{Limit: 10})
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
 	assert.False(t, result.HasMore)
@@ -187,7 +187,7 @@ func TestService_List_LastPage(t *testing.T) {
 func TestService_List_Empty(t *testing.T) {
 	svc, _ := newTestService()
 
-	result, err := svc.List(context.Background(), query.PageRequest{})
+	result, err := svc.List(context.Background(), query.PageParams{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Items)
 	assert.False(t, result.HasMore)

--- a/cells/devicecell/cell.go
+++ b/cells/devicecell/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/devicecell/internal/domain"
 	"github.com/ghbvf/gocell/cells/devicecell/internal/mem"
 	devicecommand "github.com/ghbvf/gocell/cells/devicecell/slices/devicecommand"
+	devicelist "github.com/ghbvf/gocell/cells/devicecell/slices/devicelist"
 	deviceregister "github.com/ghbvf/gocell/cells/devicecell/slices/deviceregister"
 	devicestatus "github.com/ghbvf/gocell/cells/devicecell/slices/devicestatus"
 	"github.com/ghbvf/gocell/kernel/cell"
@@ -67,6 +68,7 @@ type DeviceCell struct {
 	registerHandler *deviceregister.Handler
 	commandHandler  *devicecommand.Handler
 	statusHandler   *devicestatus.Handler
+	listHandler     *devicelist.Handler
 }
 
 // NewDeviceCell creates a new DeviceCell with the given options.
@@ -155,6 +157,15 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	c.statusHandler = devicestatus.NewHandler(statusSvc)
 	c.AddSlice(cell.NewBaseSlice("devicestatus", "devicecell", cell.L0))
 
+	// device-list slice
+	listSvc, err := devicelist.NewService(c.deviceRepo, c.cursorCodec, c.logger,
+		query.RunModeForDemo(deps.DurabilityMode == cell.DurabilityDemo))
+	if err != nil {
+		return fmt.Errorf("device-list: %w", err)
+	}
+	c.listHandler = devicelist.NewHandler(listSvc)
+	c.AddSlice(cell.NewBaseSlice("devicelist", "devicecell", cell.L0))
+
 	return nil
 }
 
@@ -169,6 +180,13 @@ func (c *DeviceCell) RegisterRoutes(mux cell.RouteMux) {
 				Path:    "/",
 				Handler: http.HandlerFunc(c.registerHandler.HandleRegister),
 				Public:  true,
+			})
+			// Device list: paginated listing of all devices.
+			auth.Declare(devices, auth.RouteDecl{
+				Method:  "GET",
+				Path:    "/",
+				Handler: http.HandlerFunc(c.listHandler.HandleList),
+				Policy:  auth.AnyRole("admin"),
 			})
 			// Device status is queried by authenticated operators/devices.
 			auth.Declare(devices, auth.RouteDecl{

--- a/cells/devicecell/cell.go
+++ b/cells/devicecell/cell.go
@@ -181,7 +181,7 @@ func (c *DeviceCell) RegisterRoutes(mux cell.RouteMux) {
 				Handler: http.HandlerFunc(c.registerHandler.HandleRegister),
 				Public:  true,
 			})
-			// Device list: paginated listing of all devices.
+			// Device list: paginated listing of all devices at /api/v1/devices/.
 			auth.Declare(devices, auth.RouteDecl{
 				Method:  "GET",
 				Path:    "/",

--- a/cells/devicecell/cell_test.go
+++ b/cells/devicecell/cell_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/devicecell/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -107,24 +108,14 @@ func TestDeviceCell_RegisterRoutes(t *testing.T) {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	mux := &stubMux{}
+	mux := celltest.NewTestMux()
 	c.RegisterRoutes(mux)
-	assert.GreaterOrEqual(t, mux.handleCount, 3, "should register at least 3 route patterns")
+	metas := mux.DeclaredAuthMetas()
+	require.Contains(t, metas, cell.AuthRouteMeta{
+		Method: http.MethodGet,
+		Path:   "/api/v1/devices",
+	})
 }
-
-// stubMux implements cell.RouteMux for counting route registrations.
-type stubMux struct {
-	handleCount int
-}
-
-func (m *stubMux) Handle(_ string, _ http.Handler) { m.handleCount++ }
-func (m *stubMux) Route(_ string, fn func(cell.RouteMux)) {
-	m.handleCount++
-	fn(m)
-}
-func (m *stubMux) Mount(_ string, _ http.Handler)                          { m.handleCount++ }
-func (m *stubMux) Group(_ func(cell.RouteMux))                             { m.handleCount++ }
-func (m *stubMux) With(_ ...func(http.Handler) http.Handler) cell.RouteMux { return m }
 
 // extractData unmarshals a JSON response and returns the "data" envelope.
 func extractData(t *testing.T, body []byte) map[string]any {
@@ -169,6 +160,27 @@ func TestDeviceCell_RouteRegisterDevice(t *testing.T) {
 
 	data := extractData(t, rec.Body.Bytes())
 	assert.NotEmpty(t, data["id"])
+}
+
+func TestDeviceCell_RouteListDevices_Authz(t *testing.T) {
+	r := initCellWithRouter(t)
+
+	t.Run("401 no auth", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/devices/", nil)
+		r.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("403 non-admin", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/devices/", nil)
+		req = req.WithContext(auth.TestContext("user-1", []string{"viewer"}))
+		r.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
 }
 
 func TestDeviceCell_RouteGetStatus(t *testing.T) {

--- a/cells/devicecell/cell_test.go
+++ b/cells/devicecell/cell_test.go
@@ -36,7 +36,7 @@ func TestDeviceCell_Lifecycle(t *testing.T) {
 
 	// Init
 	require.NoError(t, c.Init(ctx, deps))
-	assert.Len(t, c.OwnedSlices(), 3, "should have 3 slices")
+	assert.Len(t, c.OwnedSlices(), 4, "should have 4 slices")
 
 	// Start
 	require.NoError(t, c.Start(ctx))
@@ -78,7 +78,7 @@ func TestDeviceCell_InitDefaultsRepositories(t *testing.T) {
 		DurabilityMode: cell.DurabilityDemo,
 	}
 	require.NoError(t, c.Init(ctx, deps))
-	assert.Len(t, c.OwnedSlices(), 3)
+	assert.Len(t, c.OwnedSlices(), 4)
 }
 
 func TestDeviceCell_InitNoPublisher(t *testing.T) {

--- a/cells/devicecell/internal/domain/device.go
+++ b/cells/devicecell/internal/domain/device.go
@@ -33,6 +33,8 @@ type Command struct {
 type DeviceRepository interface {
 	Create(ctx context.Context, device *Device) error
 	GetByID(ctx context.Context, id string) (*Device, error)
+	// List returns a paginated list of devices sorted by name ASC, id ASC.
+	List(ctx context.Context, params query.ListParams) ([]*Device, error)
 }
 
 // CommandRepository abstracts command persistence.

--- a/cells/devicecell/internal/mem/repository.go
+++ b/cells/devicecell/internal/mem/repository.go
@@ -58,6 +58,51 @@ func (r *DeviceRepository) GetByID(_ context.Context, id string) (*domain.Device
 	return &out, nil
 }
 
+// List returns paginated devices sorted and cursor-filtered per params.
+func (r *DeviceRepository) List(_ context.Context, params query.ListParams) ([]*domain.Device, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	all := make([]*domain.Device, 0, len(r.devices))
+	for _, d := range r.devices {
+		cp := *d
+		all = append(all, &cp)
+	}
+
+	query.Sort(all, params.Sort, compareDeviceField)
+	result, err := query.ApplyCursor(all, params, deviceFieldValue)
+	if err != nil {
+		return nil, fmt.Errorf("device-repo: list: %w", err)
+	}
+	return result, nil
+}
+
+func compareDeviceField(a, b *domain.Device, field string) int {
+	switch field {
+	case "name":
+		return cmp.Compare(a.Name, b.Name)
+	case "id":
+		return cmp.Compare(a.ID, b.ID)
+	case "status":
+		return cmp.Compare(a.Status, b.Status)
+	default:
+		return 0
+	}
+}
+
+func deviceFieldValue(d *domain.Device, field string) any {
+	switch field {
+	case "name":
+		return d.Name
+	case "id":
+		return d.ID
+	case "status":
+		return d.Status
+	default:
+		return ""
+	}
+}
+
 // CommandRepository is a thread-safe in-memory command store.
 type CommandRepository struct {
 	mu       sync.RWMutex

--- a/cells/devicecell/slices/devicecommand/contract_test.go
+++ b/cells/devicecell/slices/devicecommand/contract_test.go
@@ -117,7 +117,7 @@ func TestCommandDeviceCommandListV1Handle(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "command.device-command.list.v1")
 
-	c.ValidateResponse(t, []byte(`{"data":[{"id":"cmd-1","deviceId":"d-1","payload":"reboot","status":"pending","createdAt":"2026-01-01T00:00:00Z"}],"hasMore":false}`))
+	c.ValidateResponse(t, []byte(`{"data":[{"id":"cmd-1","deviceId":"d-1","payload":"reboot","status":"pending","createdAt":"2026-01-01T00:00:00Z"}],"nextCursor":"","hasMore":false}`))
 	c.MustRejectResponse(t, []byte(`{"data":"not-array","hasMore":false}`))
 }
 

--- a/cells/devicecell/slices/devicecommand/handler.go
+++ b/cells/devicecell/slices/devicecommand/handler.go
@@ -106,7 +106,7 @@ func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleListPending(w http.ResponseWriter, r *http.Request) {
 	deviceID := r.PathValue("id")
 
-	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	pageReq, ok := httputil.ParsePageParamsOrWrite(w, r)
 	if !ok {
 		return
 	}

--- a/cells/devicecell/slices/devicecommand/handler.go
+++ b/cells/devicecell/slices/devicecommand/handler.go
@@ -1,7 +1,6 @@
 package devicecommand
 
 import (
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -107,13 +106,8 @@ func (h *Handler) HandleEnqueue(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleListPending(w http.ResponseWriter, r *http.Request) {
 	deviceID := r.PathValue("id")
 
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/devicecell/slices/devicecommand/service.go
+++ b/cells/devicecell/slices/devicecommand/service.go
@@ -86,16 +86,16 @@ func (s *Service) Enqueue(ctx context.Context, deviceID, payload string) (*domai
 // ListPending returns a paginated page of pending commands for the given device.
 // Sort: created_at ASC, id ASC (FIFO -- oldest pending commands first).
 // This is the poll endpoint used by devices in the L4 latent model.
-func (s *Service) ListPending(ctx context.Context, deviceID string, pageReq query.PageRequest) (query.PageResult[*domain.Command], error) {
+func (s *Service) ListPending(ctx context.Context, deviceID string, pageReq query.PageParams) (query.PageResult[*domain.Command], error) {
 	if _, err := s.deviceRepo.GetByID(ctx, deviceID); err != nil {
 		return query.PageResult[*domain.Command]{}, fmt.Errorf("device-command: lookup device: %w", err)
 	}
 	qctx := query.QueryContext("endpoint", "device-command", "deviceId", deviceID)
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Command]{
-		Codec:    s.codec,
-		Request:  pageReq,
-		Sort:     pendingSort,
-		QueryCtx: qctx,
+		Codec:      s.codec,
+		PageParams: pageReq,
+		Sort:       pendingSort,
+		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Command, error) {
 			cmds, err := s.cmdRepo.ListPending(ctx, deviceID, params)
 			if err != nil {

--- a/cells/devicecell/slices/devicecommand/service_test.go
+++ b/cells/devicecell/slices/devicecommand/service_test.go
@@ -130,7 +130,7 @@ func TestService_ListPending(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := svc.ListPending(ctx, tc.deviceID, query.PageRequest{})
+			result, err := svc.ListPending(ctx, tc.deviceID, query.PageParams{})
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -216,13 +216,13 @@ func TestService_ListPending_CursorDeviceMismatch(t *testing.T) {
 	}
 
 	// Get first page for dev-A.
-	page1, err := svc.ListPending(ctx, "dev-A", query.PageRequest{Limit: 3})
+	page1, err := svc.ListPending(ctx, "dev-A", query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.True(t, page1.HasMore)
 	require.NotEmpty(t, page1.NextCursor)
 
 	// Replay the cursor against dev-B — must fail with context mismatch.
-	_, err = svc.ListPending(ctx, "dev-B", query.PageRequest{Limit: 3, Cursor: page1.NextCursor})
+	_, err = svc.ListPending(ctx, "dev-B", query.PageParams{Limit: 3, Cursor: page1.NextCursor})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -240,7 +240,7 @@ func TestService_Enqueue_ThenListPending_ThenAck(t *testing.T) {
 	require.NoError(t, err)
 
 	// List pending should include the command.
-	result, err := svc.ListPending(ctx, "dev-1", query.PageRequest{})
+	result, err := svc.ListPending(ctx, "dev-1", query.PageParams{})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 1)
 	assert.Equal(t, cmd.ID, result.Items[0].ID)
@@ -249,7 +249,7 @@ func TestService_Enqueue_ThenListPending_ThenAck(t *testing.T) {
 	require.NoError(t, svc.Ack(ctx, "dev-1", cmd.ID))
 
 	// List pending should be empty after ack.
-	result, err = svc.ListPending(ctx, "dev-1", query.PageRequest{})
+	result, err = svc.ListPending(ctx, "dev-1", query.PageParams{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Items)
 }

--- a/cells/devicecell/slices/devicelist/contract_test.go
+++ b/cells/devicecell/slices/devicelist/contract_test.go
@@ -1,0 +1,80 @@
+package devicelist
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/devicecell/internal/domain"
+	"github.com/ghbvf/gocell/cells/devicecell/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+func newContractDeviceListHandler(t *testing.T) http.Handler {
+	t.Helper()
+	repo := mem.NewDeviceRepository()
+	now := time.Now()
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-1", Name: "sensor-alpha", Status: "online", LastSeen: now,
+	})
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-2", Name: "sensor-beta", Status: "offline", LastSeen: now,
+	})
+
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := NewService(repo, codec, slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inner := celltest.NewTestMux()
+	NewHandler(svc).RegisterRoutes(inner)
+
+	outer := http.NewServeMux()
+	prefix := "/api/v1/devices"
+	stripped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/" + strings.TrimPrefix(r.URL.Path, prefix)
+		if r2.URL.Path == "/" || r2.URL.Path == "" {
+			r2.URL.Path = "/"
+		}
+		inner.ServeHTTP(w, r2)
+	})
+	outer.Handle("/api/v1/devices", stripped)
+	outer.Handle("/api/v1/devices/", stripped)
+	return outer
+}
+
+func TestHttpDeviceListV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.device.list.v1")
+	h := newContractDeviceListHandler(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, nil)
+	req = req.WithContext(auth.TestContext("user-1", []string{"admin"}))
+	h.ServeHTTP(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
+
+	c.MustRejectResponse(t, []byte(`{"data":{"wrong":"shape"}}`))
+	c.MustRejectResponse(t, []byte(`{"data":{"id":"dev-1"},"hasMore":false}`))
+	c.MustRejectResponse(t, []byte(`{"data":[],"hasMore":"yes"}`))
+
+	rec400 := httptest.NewRecorder()
+	req400 := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path+"?limit=notanumber", nil)
+	req400 = req400.WithContext(auth.TestContext("user-1", []string{"admin"}))
+	h.ServeHTTP(rec400, req400)
+	if rec400.Code != http.StatusBadRequest {
+		t.Errorf("invalid limit: expected 400, got %d", rec400.Code)
+	}
+}

--- a/cells/devicecell/slices/devicelist/contract_test.go
+++ b/cells/devicecell/slices/devicelist/contract_test.go
@@ -2,9 +2,11 @@ package devicelist
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -27,12 +29,15 @@ func newContractDeviceListHandler(t *testing.T) http.Handler {
 	_ = repo.Create(context.Background(), &domain.Device{
 		ID: "dev-2", Name: "sensor-beta", Status: "offline", LastSeen: now,
 	})
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-3", Name: "sensor-gamma", Status: "online", LastSeen: now,
+	})
 
 	codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	svc, err := NewService(repo, codec, slog.Default(), query.RunModeDemo)
+	svc, err := NewService(repo, codec, slog.Default(), query.RunModeProd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,16 +59,57 @@ func newContractDeviceListHandler(t *testing.T) http.Handler {
 	return outer
 }
 
+type deviceListPage struct {
+	Data       []DeviceResponse `json:"data"`
+	NextCursor string           `json:"nextCursor"`
+	HasMore    bool             `json:"hasMore"`
+}
+
+func decodeDeviceListPage(t *testing.T, rec *httptest.ResponseRecorder) deviceListPage {
+	t.Helper()
+	var page deviceListPage
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode device list response: %v", err)
+	}
+	return page
+}
+
 func TestHttpDeviceListV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.device.list.v1")
 	h := newContractDeviceListHandler(t)
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, nil)
+	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path+"?limit=2", nil)
 	req = req.WithContext(auth.TestContext("user-1", []string{"admin"}))
 	h.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
+	page1 := decodeDeviceListPage(t, rec)
+	if len(page1.Data) != 2 {
+		t.Fatalf("page 1: expected 2 devices, got %d", len(page1.Data))
+	}
+	if !page1.HasMore {
+		t.Fatal("page 1: expected hasMore=true")
+	}
+	if page1.NextCursor == "" {
+		t.Fatal("page 1: expected non-empty nextCursor")
+	}
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path+"?limit=2&cursor="+url.QueryEscape(page1.NextCursor), nil)
+	req2 = req2.WithContext(auth.TestContext("user-1", []string{"admin"}))
+	h.ServeHTTP(rec2, req2)
+	c.ValidateHTTPResponseRecorder(t, rec2)
+	page2 := decodeDeviceListPage(t, rec2)
+	if len(page2.Data) != 1 {
+		t.Fatalf("page 2: expected 1 device, got %d", len(page2.Data))
+	}
+	if page2.HasMore {
+		t.Fatal("page 2: expected hasMore=false")
+	}
+	if page2.NextCursor != "" {
+		t.Fatalf("page 2: expected empty nextCursor, got %q", page2.NextCursor)
+	}
 
 	c.MustRejectResponse(t, []byte(`{"data":{"wrong":"shape"}}`))
 	c.MustRejectResponse(t, []byte(`{"data":{"id":"dev-1"},"hasMore":false}`))
@@ -76,4 +122,14 @@ func TestHttpDeviceListV1Serve(t *testing.T) {
 	if rec400.Code != http.StatusBadRequest {
 		t.Errorf("invalid limit: expected 400, got %d", rec400.Code)
 	}
+	c.ValidateErrorResponse(t, http.StatusBadRequest, rec400.Body.Bytes())
+
+	recBadCursor := httptest.NewRecorder()
+	reqBadCursor := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path+"?cursor=not-a-valid-cursor", nil)
+	reqBadCursor = reqBadCursor.WithContext(auth.TestContext("user-1", []string{"admin"}))
+	h.ServeHTTP(recBadCursor, reqBadCursor)
+	if recBadCursor.Code != http.StatusBadRequest {
+		t.Errorf("invalid cursor: expected 400, got %d", recBadCursor.Code)
+	}
+	c.ValidateErrorResponse(t, http.StatusBadRequest, recBadCursor.Body.Bytes())
 }

--- a/cells/devicecell/slices/devicelist/contract_test.go
+++ b/cells/devicecell/slices/devicelist/contract_test.go
@@ -41,7 +41,7 @@ func newContractDeviceListHandler(t *testing.T) http.Handler {
 	NewHandler(svc).RegisterRoutes(inner)
 
 	outer := http.NewServeMux()
-	prefix := "/api/v1/devices"
+	prefix := "/api/v1/devices/"
 	stripped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r2 := r.Clone(r.Context())
 		r2.URL.Path = "/" + strings.TrimPrefix(r.URL.Path, prefix)
@@ -50,7 +50,6 @@ func newContractDeviceListHandler(t *testing.T) http.Handler {
 		}
 		inner.ServeHTTP(w, r2)
 	})
-	outer.Handle("/api/v1/devices", stripped)
 	outer.Handle("/api/v1/devices/", stripped)
 	return outer
 }

--- a/cells/devicecell/slices/devicelist/handler.go
+++ b/cells/devicecell/slices/devicelist/handler.go
@@ -28,7 +28,7 @@ func toDeviceResponse(d *domain.Device) DeviceResponse {
 	}
 }
 
-// Handler provides the GET /api/v1/devices endpoint.
+// Handler provides the GET /api/v1/devices/ endpoint.
 type Handler struct {
 	svc *Service
 }
@@ -48,9 +48,9 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 	})
 }
 
-// HandleList handles GET /api/v1/devices.
+// HandleList handles GET /api/v1/devices/.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	pageReq, ok := httputil.ParsePageParamsOrWrite(w, r)
 	if !ok {
 		return
 	}

--- a/cells/devicecell/slices/devicelist/handler.go
+++ b/cells/devicecell/slices/devicelist/handler.go
@@ -1,0 +1,65 @@
+package devicelist
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/devicecell/internal/domain"
+	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// DeviceResponse is the public DTO for Device.
+type DeviceResponse struct {
+	ID       string    `json:"id"`
+	Name     string    `json:"name"`
+	Status   string    `json:"status"`
+	LastSeen time.Time `json:"lastSeen"`
+}
+
+func toDeviceResponse(d *domain.Device) DeviceResponse {
+	return DeviceResponse{
+		ID:       d.ID,
+		Name:     d.Name,
+		Status:   d.Status,
+		LastSeen: d.LastSeen,
+	}
+}
+
+// Handler provides the GET /api/v1/devices endpoint.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a device-list Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterRoutes registers device-list routes.
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
+	auth.Declare(mux, auth.RouteDecl{
+		Method:  "GET",
+		Path:    "/",
+		Handler: http.HandlerFunc(h.HandleList),
+		Policy:  auth.AnyRole("admin"),
+	})
+}
+
+// HandleList handles GET /api/v1/devices.
+func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.svc.List(r.Context(), pageReq)
+	if err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, query.MapPageResult(result, toDeviceResponse))
+}

--- a/cells/devicecell/slices/devicelist/handler_test.go
+++ b/cells/devicecell/slices/devicelist/handler_test.go
@@ -1,0 +1,78 @@
+package devicelist
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/devicecell/internal/domain"
+	"github.com/ghbvf/gocell/cells/devicecell/internal/mem"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+func newHandlerForTest(t *testing.T) *Handler {
+	t.Helper()
+	repo := mem.NewDeviceRepository()
+	_ = repo.Create(context.Background(), &domain.Device{
+		ID: "dev-1", Name: "alpha", Status: "online", LastSeen: time.Now(),
+	})
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewHandler(svc)
+}
+
+func TestHandleList_OK(t *testing.T) {
+	h := newHandlerForTest(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(auth.TestContext("user-1", []string{"admin"}))
+
+	h.HandleList(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status=%d, want 200", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, ok := body["data"]; !ok {
+		t.Error("response missing 'data' field")
+	}
+	if _, ok := body["hasMore"]; !ok {
+		t.Error("response missing 'hasMore' field")
+	}
+}
+
+func TestHandleList_InvalidLimit(t *testing.T) {
+	h := newHandlerForTest(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/?limit=abc", nil)
+	r = r.WithContext(auth.TestContext("user-1", nil))
+
+	h.HandleList(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", w.Code)
+	}
+}
+
+func TestHandleList_LimitExceedsMax(t *testing.T) {
+	h := newHandlerForTest(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/?limit=9999", nil)
+	r = r.WithContext(auth.TestContext("user-1", nil))
+
+	h.HandleList(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400", w.Code)
+	}
+}

--- a/cells/devicecell/slices/devicelist/service.go
+++ b/cells/devicecell/slices/devicelist/service.go
@@ -1,0 +1,60 @@
+// Package devicelist implements the device-list slice: paginated device listing.
+// Consistency: L0 LocalOnly — read-only query, no state mutation or outbox publishing.
+package devicelist
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ghbvf/gocell/cells/devicecell/internal/domain"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+// defaultSort orders devices by name ASC, id ASC (stable, human-friendly).
+var defaultSort = []query.SortColumn{
+	{Name: "name", Direction: query.SortASC},
+	{Name: "id", Direction: query.SortASC},
+}
+
+// Service lists devices with cursor pagination.
+type Service struct {
+	deviceRepo domain.DeviceRepository
+	codec      *query.CursorCodec
+	logger     *slog.Logger
+	runMode    query.RunMode
+}
+
+// NewService creates a device-list Service.
+// codec must be non-nil — cursor pagination cannot be served without it.
+func NewService(deviceRepo domain.DeviceRepository, codec *query.CursorCodec, logger *slog.Logger, runMode query.RunMode) (*Service, error) {
+	if codec == nil {
+		return nil, errcode.New(errcode.ErrCellMissingCodec,
+			"device-list: cursor codec is required")
+	}
+	return &Service{deviceRepo: deviceRepo, codec: codec, logger: logger, runMode: runMode}, nil
+}
+
+// List returns a paginated page of devices sorted by name ASC, id ASC.
+func (s *Service) List(ctx context.Context, pageReq query.PageParams) (query.PageResult[*domain.Device], error) {
+	qctx := query.QueryContext("endpoint", "device-list")
+	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Device]{
+		Codec:    s.codec,
+		Request:  pageReq,
+		Sort:     defaultSort,
+		QueryCtx: qctx,
+		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Device, error) {
+			devices, err := s.deviceRepo.List(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("device-list: fetch: %w", err)
+			}
+			return devices, nil
+		},
+		Extract: func(d *domain.Device) []any {
+			return []any{d.Name, d.ID}
+		},
+		OnCursorErr: query.LogCursorError(s.logger, "device-list"),
+		RunMode:     s.runMode,
+	})
+}

--- a/cells/devicecell/slices/devicelist/service.go
+++ b/cells/devicecell/slices/devicelist/service.go
@@ -40,10 +40,10 @@ func NewService(deviceRepo domain.DeviceRepository, codec *query.CursorCodec, lo
 func (s *Service) List(ctx context.Context, pageReq query.PageParams) (query.PageResult[*domain.Device], error) {
 	qctx := query.QueryContext("endpoint", "device-list")
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Device]{
-		Codec:    s.codec,
-		Request:  pageReq,
-		Sort:     defaultSort,
-		QueryCtx: qctx,
+		Codec:      s.codec,
+		PageParams: pageReq,
+		Sort:       defaultSort,
+		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Device, error) {
 			devices, err := s.deviceRepo.List(ctx, params)
 			if err != nil {

--- a/cells/devicecell/slices/devicelist/service_test.go
+++ b/cells/devicecell/slices/devicelist/service_test.go
@@ -96,6 +96,9 @@ func TestService_ListPagination(t *testing.T) {
 	if page2.HasMore {
 		t.Error("expected HasMore=false for last page")
 	}
+	if page2.NextCursor != "" {
+		t.Errorf("expected empty NextCursor on last page, got %q", page2.NextCursor)
+	}
 	if len(page2.Items) != 1 {
 		t.Errorf("expected 1 item on last page, got %d", len(page2.Items))
 	}

--- a/cells/devicecell/slices/devicelist/service_test.go
+++ b/cells/devicecell/slices/devicelist/service_test.go
@@ -1,0 +1,176 @@
+package devicelist
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/cells/devicecell/internal/domain"
+	"github.com/ghbvf/gocell/cells/devicecell/internal/mem"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+func newTestCodec(t *testing.T) *query.CursorCodec {
+	t.Helper()
+	codec, err := query.NewCursorCodec([]byte("gocell-demo-DEVICE-CELL-key-32!!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return codec
+}
+
+func seedDevice(t *testing.T, repo *mem.DeviceRepository, id, name, status string) {
+	t.Helper()
+	err := repo.Create(context.Background(), &domain.Device{
+		ID:       id,
+		Name:     name,
+		Status:   status,
+		LastSeen: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewService_NilCodecReturnsError(t *testing.T) {
+	_, err := NewService(mem.NewDeviceRepository(), nil, slog.Default(), query.RunModeDemo)
+	if err == nil {
+		t.Fatal("expected error for nil codec")
+	}
+	var ecErr *errcode.Error
+	if !errors.As(err, &ecErr) {
+		t.Errorf("expected errcode.Error, got %T: %v", err, err)
+	}
+}
+
+func TestService_ListEmpty(t *testing.T) {
+	svc, err := NewService(mem.NewDeviceRepository(), newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.HasMore {
+		t.Error("expected HasMore=false for empty repo")
+	}
+	if len(result.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(result.Items))
+	}
+}
+
+func TestService_ListPagination(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-1", "alpha", "online")
+	seedDevice(t, repo, "dev-2", "beta", "offline")
+	seedDevice(t, repo, "dev-3", "gamma", "online")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	page1, err := svc.List(context.Background(), query.PageParams{Limit: 2})
+	if err != nil {
+		t.Fatalf("page 1 error: %v", err)
+	}
+	if !page1.HasMore {
+		t.Error("expected HasMore=true for first page")
+	}
+	if len(page1.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(page1.Items))
+	}
+	if page1.NextCursor == "" {
+		t.Error("expected non-empty NextCursor")
+	}
+
+	page2, err := svc.List(context.Background(), query.PageParams{Limit: 2, Cursor: page1.NextCursor})
+	if err != nil {
+		t.Fatalf("page 2 error: %v", err)
+	}
+	if page2.HasMore {
+		t.Error("expected HasMore=false for last page")
+	}
+	if len(page2.Items) != 1 {
+		t.Errorf("expected 1 item on last page, got %d", len(page2.Items))
+	}
+}
+
+func TestService_ListSingleDevice(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-1", "solo", "online")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.HasMore {
+		t.Error("expected HasMore=false for single device")
+	}
+	if result.NextCursor != "" {
+		t.Errorf("expected empty NextCursor when HasMore=false, got %q", result.NextCursor)
+	}
+	if len(result.Items) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result.Items))
+	}
+}
+
+func TestService_ListLimitOne(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-1", "alpha", "online")
+	seedDevice(t, repo, "dev-2", "beta", "offline")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.HasMore {
+		t.Error("expected HasMore=true with limit=1 and 2 devices")
+	}
+	if len(result.Items) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result.Items))
+	}
+	if result.Items[0].Name != "alpha" {
+		t.Errorf("expected first item to be 'alpha' (name ASC), got %q", result.Items[0].Name)
+	}
+}
+
+func TestService_ListSecondarySort(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	seedDevice(t, repo, "dev-z", "sensor", "offline")
+	seedDevice(t, repo, "dev-a", "sensor", "online")
+
+	svc, err := NewService(repo, newTestCodec(t), slog.Default(), query.RunModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(result.Items))
+	}
+	if result.Items[0].ID != "dev-a" {
+		t.Errorf("expected first item id='dev-a' (id ASC), got %q", result.Items[0].ID)
+	}
+	if result.Items[1].ID != "dev-z" {
+		t.Errorf("expected second item id='dev-z', got %q", result.Items[1].ID)
+	}
+}

--- a/cells/devicecell/slices/devicelist/slice.yaml
+++ b/cells/devicecell/slices/devicelist/slice.yaml
@@ -1,0 +1,12 @@
+id: devicelist
+belongsToCell: devicecell
+contractUsages:
+  - contract: http.device.list.v1
+    role: serve
+verify:
+  unit:
+    - unit.devicelist.service
+  contract:
+    - contract.http.device.list.v1.serve
+allowedFiles:
+  - cells/devicecell/slices/devicelist/**

--- a/cells/ordercell/slices/orderquery/handler.go
+++ b/cells/ordercell/slices/orderquery/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleList handles GET /api/v1/orders?limit=N&cursor=TOKEN.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	pageReq, ok := httputil.ParsePageParamsOrWrite(w, r)
 	if !ok {
 		return
 	}

--- a/cells/ordercell/slices/orderquery/handler.go
+++ b/cells/ordercell/slices/orderquery/handler.go
@@ -1,7 +1,6 @@
 package orderquery
 
 import (
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -53,13 +52,8 @@ func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleList handles GET /api/v1/orders?limit=N&cursor=TOKEN.
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
-	pageReq, err := httputil.ParsePageRequest(r)
-	if err != nil {
-		slog.Warn("pagination: request validation failed",
-			slog.String("error", err.Error()),
-			slog.String("path", r.URL.Path),
-		)
-		httputil.WriteDomainError(r.Context(), w, err)
+	pageReq, ok := httputil.ParsePageRequestOrWrite(w, r)
+	if !ok {
 		return
 	}
 

--- a/cells/ordercell/slices/orderquery/service.go
+++ b/cells/ordercell/slices/orderquery/service.go
@@ -51,13 +51,13 @@ func (s *Service) GetByID(ctx context.Context, id string) (*domain.Order, error)
 }
 
 // List returns a paginated page of orders.
-func (s *Service) List(ctx context.Context, pageReq query.PageRequest) (query.PageResult[*domain.Order], error) {
+func (s *Service) List(ctx context.Context, pageReq query.PageParams) (query.PageResult[*domain.Order], error) {
 	qctx := query.QueryContext("endpoint", "order-query")
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*domain.Order]{
-		Codec:    s.codec,
-		Request:  pageReq,
-		Sort:     orderSort,
-		QueryCtx: qctx,
+		Codec:      s.codec,
+		PageParams: pageReq,
+		Sort:       orderSort,
+		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*domain.Order, error) {
 			return s.repo.List(ctx, params)
 		},

--- a/cells/ordercell/slices/orderquery/service_test.go
+++ b/cells/ordercell/slices/orderquery/service_test.go
@@ -106,7 +106,7 @@ func TestService_List_FirstPage(t *testing.T) {
 	repo := seedRepo(seed...)
 	svc := mustNewService(repo, testCodec())
 
-	result, err := svc.List(context.Background(), query.PageRequest{Limit: 3})
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 3)
 	assert.True(t, result.HasMore)
@@ -130,12 +130,12 @@ func TestService_List_WithCursor(t *testing.T) {
 	svc := mustNewService(repo, testCodec())
 
 	// Get first page
-	page1, err := svc.List(context.Background(), query.PageRequest{Limit: 3})
+	page1, err := svc.List(context.Background(), query.PageParams{Limit: 3})
 	require.NoError(t, err)
 	require.True(t, page1.HasMore)
 
 	// Get second page using cursor
-	page2, err := svc.List(context.Background(), query.PageRequest{Limit: 3, Cursor: page1.NextCursor})
+	page2, err := svc.List(context.Background(), query.PageParams{Limit: 3, Cursor: page1.NextCursor})
 	require.NoError(t, err)
 	assert.Len(t, page2.Items, 3)
 	// Second page should continue where first left off
@@ -146,7 +146,7 @@ func TestService_List_InvalidCursor(t *testing.T) {
 	repo := seedRepo()
 	svc := mustNewService(repo, testCodec())
 
-	_, err := svc.List(context.Background(), query.PageRequest{Cursor: "garbage-token"})
+	_, err := svc.List(context.Background(), query.PageParams{Cursor: "garbage-token"})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -162,7 +162,7 @@ func TestService_List_LastPage(t *testing.T) {
 	repo := seedRepo(seed...)
 	svc := mustNewService(repo, testCodec())
 
-	result, err := svc.List(context.Background(), query.PageRequest{Limit: 10})
+	result, err := svc.List(context.Background(), query.PageParams{Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
 	assert.False(t, result.HasMore)
@@ -173,7 +173,7 @@ func TestService_List_Empty(t *testing.T) {
 	repo := seedRepo()
 	svc := mustNewService(repo, testCodec())
 
-	result, err := svc.List(context.Background(), query.PageRequest{})
+	result, err := svc.List(context.Background(), query.PageParams{})
 	require.NoError(t, err)
 	assert.Empty(t, result.Items)
 	assert.False(t, result.HasMore)
@@ -202,7 +202,7 @@ func TestService_List_ScopeMismatch(t *testing.T) {
 	})
 	svc := mustNewService(repo, codec)
 
-	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	_, err = svc.List(context.Background(), query.PageParams{Cursor: token})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -226,7 +226,7 @@ func TestService_List_ContextMismatch(t *testing.T) {
 	})
 	svc := mustNewService(repo, codec)
 
-	_, err = svc.List(context.Background(), query.PageRequest{Cursor: token})
+	_, err = svc.List(context.Background(), query.PageParams{Cursor: token})
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)

--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -31,6 +31,7 @@ func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.C
 		accesscore.WithPublisher(shared.EventBus),
 		accesscore.WithJWTIssuer(shared.JWTDeps.issuer),
 		accesscore.WithJWTVerifier(shared.JWTDeps.verifier),
+		accesscore.WithCursorCodec(shared.CursorCodecs.accessCore),
 	}, m.InitialAdminOpts...)
 	c := accesscore.NewAccessCore(accessOpts...)
 

--- a/cmd/corebundle/demo_keys.go
+++ b/cmd/corebundle/demo_keys.go
@@ -24,8 +24,10 @@ var wellKnownDemoKeys = []string{
 	"gocell-demo-CONFIG-CORE-key-32!!",
 	"gocell-demo-ORDER-CELL-key-32b!!",
 	"gocell-demo-DEVICE-CELL-key-32!!",
+	"gocell-demo-ACCESS-CORE-key-32!!",
 	"corebundle-audit-cursor-key-32b!",
 	"corebundle-cfg-cursor-key--32bb!",
+	"corebundle-access-cursor-key32!!",
 
 	// Service token HMAC (shipped as test fixture; never use in production)
 	"service-secret-32-bytes-xxxxxx!!",

--- a/cmd/corebundle/main.go
+++ b/cmd/corebundle/main.go
@@ -154,13 +154,14 @@ func loadCursorCodec(adapterMode, envName, prevEnvName, devDefault, label string
 	return codec, nil
 }
 
-// cursorCodecs holds the parsed cursor codecs for auditcore and configcore.
+// cursorCodecs holds the parsed cursor codecs for auditcore, configcore, and accesscore.
 type cursorCodecs struct {
-	audit  *query.CursorCodec
-	config *query.CursorCodec
+	audit      *query.CursorCodec
+	config     *query.CursorCodec
+	accessCore *query.CursorCodec
 }
 
-// loadAllCursorCodecs loads and validates the audit and config cursor codecs.
+// loadAllCursorCodecs loads and validates the audit, config, and access cursor codecs.
 // Extracted from run() to reduce cognitive complexity.
 func loadAllCursorCodecs(adapterMode string) (cursorCodecs, error) {
 	audit, err := loadCursorCodec(adapterMode,
@@ -175,7 +176,13 @@ func loadAllCursorCodecs(adapterMode string) (cursorCodecs, error) {
 	if err != nil {
 		return cursorCodecs{}, err
 	}
-	return cursorCodecs{audit: audit, config: cfg}, nil
+	ac, err := loadCursorCodec(adapterMode,
+		"GOCELL_ACCESS_CURSOR_KEY", "GOCELL_ACCESS_CURSOR_PREVIOUS_KEY",
+		"corebundle-access-cursor-key32!!", "access")
+	if err != nil {
+		return cursorCodecs{}, err
+	}
+	return cursorCodecs{audit: audit, config: cfg, accessCore: ac}, nil
 }
 
 // validateModeCoupling enforces that the DATA plane (cellAdapterMode) and

--- a/cmd/corebundle/main_test.go
+++ b/cmd/corebundle/main_test.go
@@ -214,6 +214,30 @@ func TestRun_MissingJWTAudience_FailsFast(t *testing.T) {
 		"run() must fail fast when GOCELL_JWT_AUDIENCE is unset")
 }
 
+func TestRun_RealMode_MissingAccessCursorKey_FailsFast(t *testing.T) {
+	privPEM, pubPEM := generateTestPEM(t)
+	t.Setenv("GOCELL_ADAPTER_MODE", "real")
+	t.Setenv(auth.EnvJWTPrivateKey, string(privPEM))
+	t.Setenv(auth.EnvJWTPublicKey, string(pubPEM))
+	t.Setenv(auth.EnvJWTPrevPublicKey, "")
+	t.Setenv("GOCELL_HMAC_KEY", "prod-hmac-key-replace-32bytes!!!")
+	t.Setenv("GOCELL_JWT_ISSUER", "gocell-real-test")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
+	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
+	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
+	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
+	t.Setenv("GOCELL_METRICS_TOKEN", "metrics-token-present")
+	t.Setenv("GOCELL_ACCESS_CURSOR_KEY", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GOCELL_ACCESS_CURSOR_KEY")
+}
+
 // TestRun_RealMode_MissingVerboseToken_FailsFast ensures the H1-6
 // READYZ-VERBOSE-TOKEN fail-fast integration point — empty
 // GOCELL_READYZ_VERBOSE_TOKEN in real mode must error out before the
@@ -233,6 +257,7 @@ func TestRun_RealMode_MissingVerboseToken_FailsFast(t *testing.T) {
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
 	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_ACCESS_CURSOR_KEY", "access-cursor-key-32b-padded-x!!")
 	t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
 	// The trip-wire: verbose token is empty.
 	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "")
@@ -262,6 +287,7 @@ func TestRun_RealMode_MissingMetricsToken_FailsFast(t *testing.T) {
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
 	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_ACCESS_CURSOR_KEY", "access-cursor-key-32b-padded-x!!")
 	t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
 	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
 	// The trip-wire: metrics token is empty.
@@ -291,6 +317,7 @@ func TestRun_RealMode_MissingServiceSecret_FailsFast(t *testing.T) {
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 	t.Setenv("GOCELL_AUDIT_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
 	t.Setenv("GOCELL_CONFIG_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
+	t.Setenv("GOCELL_ACCESS_CURSOR_KEY", "access-cursor-key-32b-padded-x!!")
 	t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
 	t.Setenv("GOCELL_METRICS_TOKEN", "metrics-token-present")
 	// The trip-wire: service secret is empty.
@@ -421,7 +448,7 @@ func TestBootstrap_UnknownCellAdapterMode_FailsFast(t *testing.T) {
 }
 
 // TestRun_RealMode_DemoKey_FailsFast locks the rejectDemoKey wiring: for
-// each env channel (HMAC key + two cursor keys), injecting a well-known
+// each env channel (HMAC key + three cursor keys), injecting a well-known
 // demo value must abort run() before the HTTP server starts. Guards
 // against reordering that would let demo secrets leak into real mode.
 // ref: K8s kube-apiserver — refuses to start with insecure signing material.
@@ -429,6 +456,7 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 	freshHMAC := "prod-hmac-key-replace-32bytes!!!"
 	freshAudit := "audit-cursor-key-32-bytes-padded!"
 	freshConfig := "config-cursor-key-32b-padded-xx!"
+	freshAccess := "access-cursor-key-32b-padded-x!!"
 
 	type envPatch struct {
 		name, value string
@@ -452,6 +480,16 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 			name:  "config cursor demo literal rejected",
 			patch: envPatch{"GOCELL_CONFIG_CURSOR_KEY", "corebundle-cfg-cursor-key--32bb!"},
 			want:  "GOCELL_CONFIG_CURSOR_KEY",
+		},
+		{
+			name:  "access cursor demo literal rejected",
+			patch: envPatch{"GOCELL_ACCESS_CURSOR_KEY", "corebundle-access-cursor-key32!!"},
+			want:  "GOCELL_ACCESS_CURSOR_KEY",
+		},
+		{
+			name:  "access cursor cell demo literal rejected",
+			patch: envPatch{"GOCELL_ACCESS_CURSOR_KEY", "gocell-demo-ACCESS-CORE-key-32!!"},
+			want:  "GOCELL_ACCESS_CURSOR_KEY",
 		},
 		{
 			name:  "service secret demo literal rejected",
@@ -478,6 +516,7 @@ func TestRun_RealMode_DemoKey_FailsFast(t *testing.T) {
 			t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")
 			t.Setenv("GOCELL_AUDIT_CURSOR_KEY", freshAudit)
 			t.Setenv("GOCELL_CONFIG_CURSOR_KEY", freshConfig)
+			t.Setenv("GOCELL_ACCESS_CURSOR_KEY", freshAccess)
 			t.Setenv("GOCELL_SERVICE_SECRET", freshTestServiceSecret(t))
 			t.Setenv("GOCELL_READYZ_VERBOSE_TOKEN", "readyz-token-present")
 			t.Setenv("GOCELL_METRICS_TOKEN", "metrics-token-present")

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -33,7 +33,7 @@ type SharedDeps struct {
 	// PromStack holds the Prometheus registry, hook observer, and metric provider.
 	PromStack promStack
 
-	// CursorCodecs holds the audit and config cursor codecs.
+	// CursorCodecs holds the audit, config, and access cursor codecs.
 	CursorCodecs cursorCodecs
 
 	// HMACKey is the HMAC secret for auditcore chain authentication.
@@ -107,6 +107,9 @@ func (d *SharedDeps) validateCore() []error {
 	}
 	if d.CursorCodecs.config == nil {
 		missing("CursorCodecs.config")
+	}
+	if d.CursorCodecs.accessCore == nil {
+		missing("CursorCodecs.accessCore")
 	}
 	if len(d.HMACKey) == 0 {
 		missing("HMACKey")

--- a/contracts/command/device-command/list/v1/response.schema.json
+++ b/contracts/command/device-command/list/v1/response.schema.json
@@ -22,5 +22,5 @@
     "nextCursor": { "type": "string" },
     "hasMore": { "type": "boolean" }
   },
-  "required": ["data", "hasMore"]
+  "required": ["data", "nextCursor", "hasMore"]
 }

--- a/contracts/http/audit/list/v1/response.schema.json
+++ b/contracts/http/audit/list/v1/response.schema.json
@@ -22,5 +22,5 @@
     "nextCursor": { "type": "string" },
     "hasMore": { "type": "boolean" }
   },
-  "required": ["data", "hasMore"]
+  "required": ["data", "nextCursor", "hasMore"]
 }

--- a/contracts/http/auth/role/list/v1/contract.yaml
+++ b/contracts/http/auth/role/list/v1/contract.yaml
@@ -12,5 +12,9 @@ endpoints:
     path: /api/v1/access/roles/{userID}
     successStatus: 200
     noContent: false
+    responses:
+      400:
+        description: "Bad request — invalid pagination parameter or cursor"
+        schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
 schemaRefs:
   response: response.schema.json

--- a/contracts/http/auth/role/list/v1/response.schema.json
+++ b/contracts/http/auth/role/list/v1/response.schema.json
@@ -30,5 +30,5 @@
     "nextCursor": { "type": "string" },
     "hasMore": { "type": "boolean" }
   },
-  "required": ["data", "hasMore"]
+  "required": ["data", "nextCursor", "hasMore"]
 }

--- a/contracts/http/config/flags/list/v1/response.schema.json
+++ b/contracts/http/config/flags/list/v1/response.schema.json
@@ -20,5 +20,5 @@
     "nextCursor": { "type": "string" },
     "hasMore": { "type": "boolean" }
   },
-  "required": ["data", "hasMore"]
+  "required": ["data", "nextCursor", "hasMore"]
 }

--- a/contracts/http/config/get/v1/response.schema.json
+++ b/contracts/http/config/get/v1/response.schema.json
@@ -44,9 +44,10 @@
             }
           }
         },
+        "nextCursor": { "type": "string" },
         "hasMore": { "type": "boolean" }
       },
-      "required": ["data", "hasMore"]
+      "required": ["data", "nextCursor", "hasMore"]
     }
   ]
 }

--- a/contracts/http/device/command/list/v1/response.schema.json
+++ b/contracts/http/device/command/list/v1/response.schema.json
@@ -22,5 +22,5 @@
     "nextCursor": { "type": "string" },
     "hasMore": { "type": "boolean" }
   },
-  "required": ["data", "hasMore"]
+  "required": ["data", "nextCursor", "hasMore"]
 }

--- a/contracts/http/device/list/v1/contract.yaml
+++ b/contracts/http/device/list/v1/contract.yaml
@@ -1,0 +1,16 @@
+id: http.device.list.v1
+kind: http
+ownerCell: devicecell
+consistencyLevel: L0
+lifecycle: active
+endpoints:
+  server: devicecell
+  clients:
+    - edge-bff
+  http:
+    method: GET
+    path: /api/v1/devices
+    successStatus: 200
+    noContent: false
+schemaRefs:
+  response: response.schema.json

--- a/contracts/http/device/list/v1/contract.yaml
+++ b/contracts/http/device/list/v1/contract.yaml
@@ -12,5 +12,9 @@ endpoints:
     path: /api/v1/devices/
     successStatus: 200
     noContent: false
+    responses:
+      400:
+        description: "Bad request — invalid pagination parameter or cursor"
+        schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
 schemaRefs:
   response: response.schema.json

--- a/contracts/http/device/list/v1/contract.yaml
+++ b/contracts/http/device/list/v1/contract.yaml
@@ -9,7 +9,7 @@ endpoints:
     - edge-bff
   http:
     method: GET
-    path: /api/v1/devices
+    path: /api/v1/devices/
     successStatus: 200
     noContent: false
 schemaRefs:

--- a/contracts/http/device/list/v1/response.schema.json
+++ b/contracts/http/device/list/v1/response.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.device.list.v1.response",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id":       { "type": "string" },
+          "name":     { "type": "string" },
+          "status":   { "type": "string" },
+          "lastSeen": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "name", "status", "lastSeen"],
+        "additionalProperties": false
+      }
+    },
+    "nextCursor": { "type": "string" },
+    "hasMore":    { "type": "boolean" }
+  },
+  "required": ["data", "hasMore"],
+  "additionalProperties": false
+}

--- a/contracts/http/device/list/v1/response.schema.json
+++ b/contracts/http/device/list/v1/response.schema.json
@@ -20,6 +20,6 @@
     "nextCursor": { "type": "string" },
     "hasMore":    { "type": "boolean" }
   },
-  "required": ["data", "hasMore"],
+  "required": ["data", "nextCursor", "hasMore"],
   "additionalProperties": false
 }

--- a/contracts/http/order/list/v1/response.schema.json
+++ b/contracts/http/order/list/v1/response.schema.json
@@ -19,5 +19,5 @@
     "nextCursor": { "type": "string" },
     "hasMore": { "type": "boolean" }
   },
-  "required": ["data", "hasMore"]
+  "required": ["data", "nextCursor", "hasMore"]
 }

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -32,10 +32,12 @@ Missing required variables cause fail-fast before any assembly initialization.
 | Variable | Purpose | Default (dev) | Required |
 |---|---|---|---|
 | `GOCELL_HMAC_KEY` | HMAC key for session HMAC chains | `dev-hmac-key-replace-in-prod!!!!` | **Real mode** |
-| `GOCELL_AUDIT_CURSOR_KEY` | HMAC key for audit cursor codec | `corebundle-audit-cursor-key-32!` | **Real mode** |
+| `GOCELL_AUDIT_CURSOR_KEY` | HMAC key for audit cursor codec | `corebundle-audit-cursor-key-32b!` | **Real mode** |
 | `GOCELL_AUDIT_CURSOR_PREVIOUS_KEY` | Previous audit cursor key (rotation) | — | No |
-| `GOCELL_CONFIG_CURSOR_KEY` | HMAC key for config cursor codec | `corebundle-cfg-cursor-key--32b!` | **Real mode** |
+| `GOCELL_CONFIG_CURSOR_KEY` | HMAC key for config cursor codec | `corebundle-cfg-cursor-key--32bb!` | **Real mode** |
 | `GOCELL_CONFIG_CURSOR_PREVIOUS_KEY` | Previous config cursor key (rotation) | — | No |
+| `GOCELL_ACCESS_CURSOR_KEY` | HMAC key for access cursor codec | `corebundle-access-cursor-key32!!` | **Real mode** |
+| `GOCELL_ACCESS_CURSOR_PREVIOUS_KEY` | Previous access cursor key (rotation) | — | No |
 
 ## Encryption Key Provider (required when GOCELL_CELL_ADAPTER_MODE=postgres)
 

--- a/examples/iotdevice/README.md
+++ b/examples/iotdevice/README.md
@@ -33,6 +33,12 @@ go run ./examples/iotdevice
 
 The server starts on `:8083`.
 
+Protected routes use a fixed demo bearer token:
+
+```bash
+export IOT_ADMIN_TOKEN=iotdevice-admin-demo-token
+```
+
 ## Docker Mode
 
 Start infrastructure services, then run the application:
@@ -60,10 +66,24 @@ Response (201):
 {"id":"dev-...","name":"sensor-001","status":"online"}
 ```
 
+### List devices
+
+```bash
+curl "http://localhost:8083/api/v1/devices/?limit=50" \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
+```
+
+Response (200):
+
+```json
+{"data":[{"id":"dev-...","name":"sensor-001","status":"online","lastSeen":"..."}],"nextCursor":"","hasMore":false}
+```
+
 ### Send a command to a device
 
 ```bash
 curl -X POST http://localhost:8083/api/v1/devices/{id}/commands \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
   -d '{"payload":"reboot"}'
 ```
@@ -77,19 +97,21 @@ Response (201):
 ### Device polls pending commands
 
 ```bash
-curl http://localhost:8083/api/v1/devices/{id}/commands
+curl http://localhost:8083/api/v1/devices/{id}/commands \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
 ```
 
 Response (200):
 
 ```json
-{"data":[{"id":"cmd-...","deviceId":"dev-...","payload":"reboot","status":"pending","createdAt":"..."}],"total":1}
+{"data":[{"id":"cmd-...","deviceId":"dev-...","payload":"reboot","status":"pending","createdAt":"..."}],"nextCursor":"","hasMore":false}
 ```
 
 ### Device acknowledges command execution
 
 ```bash
-curl -X POST http://localhost:8083/api/v1/devices/{id}/commands/{cmdId}/ack
+curl -X POST http://localhost:8083/api/v1/devices/{id}/commands/{cmdId}/ack \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
 ```
 
 Response (200):
@@ -101,7 +123,8 @@ Response (200):
 ### Query device status
 
 ```bash
-curl http://localhost:8083/api/v1/devices/{id}/status
+curl http://localhost:8083/api/v1/devices/{id}/status \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
 ```
 
 Response (200):
@@ -132,20 +155,25 @@ DEV_ID=$(echo "$DEV" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
 # 2. Send a command
 CMD=$(curl -s -X POST "http://localhost:8083/api/v1/devices/${DEV_ID}/commands" \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
   -d '{"payload":"reboot"}')
 echo "$CMD"
 CMD_ID=$(echo "$CMD" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
 # 3. Device polls for pending commands
-curl -s "http://localhost:8083/api/v1/devices/${DEV_ID}/commands"
+curl -s "http://localhost:8083/api/v1/devices/${DEV_ID}/commands" \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
 
 # 4. Device acknowledges execution
-curl -s -X POST "http://localhost:8083/api/v1/devices/${DEV_ID}/commands/${CMD_ID}/ack"
+curl -s -X POST "http://localhost:8083/api/v1/devices/${DEV_ID}/commands/${CMD_ID}/ack" \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
 
 # 5. Verify no more pending commands
-curl -s "http://localhost:8083/api/v1/devices/${DEV_ID}/commands"
+curl -s "http://localhost:8083/api/v1/devices/${DEV_ID}/commands" \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
 
 # 6. Check device status
-curl -s "http://localhost:8083/api/v1/devices/${DEV_ID}/status"
+curl -s "http://localhost:8083/api/v1/devices/${DEV_ID}/status" \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}"
 ```

--- a/examples/iotdevice/main.go
+++ b/examples/iotdevice/main.go
@@ -13,14 +13,37 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	devicecell "github.com/ghbvf/gocell/cells/devicecell"
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
+
+const demoAdminToken = "iotdevice-admin-demo-token"
+
+type demoTokenVerifier struct{}
+
+func (demoTokenVerifier) VerifyIntent(_ context.Context, token string, expected auth.TokenIntent) (auth.Claims, error) {
+	if expected != auth.TokenIntentAccess || token != demoAdminToken {
+		return auth.Claims{}, errcode.New(errcode.ErrAuthUnauthorized, "invalid demo token")
+	}
+	now := time.Now()
+	return auth.Claims{
+		Subject:   "iotdevice-demo-admin",
+		Issuer:    "iotdevice-demo",
+		Audience:  []string{"gocell"},
+		IssuedAt:  now,
+		ExpiresAt: now.Add(8 * time.Hour),
+		Roles:     []string{"admin", "operator"},
+		TokenUse:  auth.TokenIntentAccess,
+	}, nil
+}
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -60,9 +83,10 @@ func main() {
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithHTTPAddr(":8083"),
+		bootstrap.WithAuthMiddleware(demoTokenVerifier{}),
 	)
 
-	logger.Info("iotdevice: starting on :8083")
+	logger.Info("iotdevice: starting on :8083; protected routes require the documented demo bearer token")
 	if err := app.Run(ctx); err != nil {
 		logger.Error("iotdevice: application exited with error", slog.Any("error", err))
 		os.Exit(1)

--- a/examples/todoorder/README.md
+++ b/examples/todoorder/README.md
@@ -70,10 +70,10 @@ curl http://localhost:8082/api/v1/orders/
 Response (200):
 
 ```json
-{"data":[...],"hasMore":false}
+{"data":[...],"nextCursor":"","hasMore":false}
 ```
 
-When another page exists, the response also includes `nextCursor`.
+When another page exists, `nextCursor` contains the opaque token for the next request.
 
 ### Get order by ID
 

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -532,7 +532,7 @@ const codeFMT15 = "FMT-15"
 
 // validateFMT15 checks that HTTP list-style response schemas:
 //   - include "hasMore" in required fields
-//   - declare "nextCursor" as a property (not required, because PageResult uses omitempty)
+//   - include "nextCursor" in required fields and declare it as a property
 //
 // A response is a "list" when properties.data.type is "array".
 // Skipped when root is empty, for non-HTTP contracts, or when the schema file cannot be read.
@@ -601,7 +601,15 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 			codeFMT15, SeverityError, IssueRequired,
 			contractFile(c.ID),
 			fieldSchemaRefsResponse,
-			fmt.Sprintf("list response schema for contract %q must declare \"nextCursor\" property (omit from required; PageResult omits it on last page)", c.ID),
+			fmt.Sprintf("list response schema for contract %q must declare \"nextCursor\" property", c.ID),
+		))
+	}
+	if !hasNextCursorInRequired(info) {
+		results = append(results, v.newResult(
+			codeFMT15, SeverityError, IssueRequired,
+			contractFile(c.ID),
+			fieldSchemaRefsResponse,
+			fmt.Sprintf("list response schema for contract %q must include \"nextCursor\" in required fields", c.ID),
 		))
 	}
 	return results
@@ -663,9 +671,19 @@ func hasMoreInRequired(info responseSchemaInfo) bool {
 }
 
 // hasNextCursorProperty checks if "nextCursor" is declared as a schema property.
-// The field must be declared (though not in required[]) because PageResult uses
-// omitempty: nextCursor is absent from last-page responses and must not be required.
+// The field must be declared and required because PageResult always serializes
+// nextCursor, using an empty string on the last page.
 // A "nextCursor": null declaration is treated as absent (null is not a valid schema).
 func hasNextCursorProperty(info responseSchemaInfo) bool {
 	return info.Properties.NextCursor != nil && string(*info.Properties.NextCursor) != "null"
+}
+
+// hasNextCursorInRequired checks if "nextCursor" is in the JSON schema required array.
+func hasNextCursorInRequired(info responseSchemaInfo) bool {
+	for _, r := range info.Required {
+		if r == "nextCursor" {
+			return true
+		}
+	}
+	return false
 }

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -3367,15 +3367,17 @@ func TestFMT14(t *testing.T) {
 	}
 }
 
-// --- FMT-15: list response schema must include hasMore in required and declare nextCursor in properties ---
+// --- FMT-15: list response schema must require hasMore and nextCursor ---
 
 func TestFMT15(t *testing.T) {
-	// valid: nextCursor declared in properties, hasMore in required
-	validListSchema := `{"properties":{"data":{"type":"array","items":{"type":"object"}},"nextCursor":{"type":"string"}},"required":["data","hasMore"]}`
-	// missing hasMore from required (nextCursor still in properties)
-	missingHasMore := `{"properties":{"data":{"type":"array","items":{"type":"object"}},"nextCursor":{"type":"string"}},"required":["data"]}`
-	// missing nextCursor from properties (hasMore still in required)
-	missingNextCursor := `{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data","hasMore"]}`
+	// valid: nextCursor declared in properties, hasMore and nextCursor in required
+	validListSchema := `{"properties":{"data":{"type":"array","items":{"type":"object"}},"nextCursor":{"type":"string"}},"required":["data","nextCursor","hasMore"]}`
+	// missing hasMore from required (nextCursor still in properties and required)
+	missingHasMore := `{"properties":{"data":{"type":"array","items":{"type":"object"}},"nextCursor":{"type":"string"}},"required":["data","nextCursor"]}`
+	// missing nextCursor from properties (nextCursor still in required)
+	missingNextCursorProperty := `{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data","nextCursor","hasMore"]}`
+	// missing nextCursor from required (nextCursor still in properties)
+	missingNextCursorRequired := `{"properties":{"data":{"type":"array","items":{"type":"object"}},"nextCursor":{"type":"string"}},"required":["data","hasMore"]}`
 	singleObject := `{"properties":{"data":{"type":"object"}},"required":["data"]}`
 	invalidJSON := `{not json`
 
@@ -3388,7 +3390,7 @@ func TestFMT15(t *testing.T) {
 		wantSeverity Severity // if non-empty, each result must have this severity; defaults to SeverityError
 	}{
 		{
-			name: "list schema with hasMore in required and nextCursor in properties",
+			name: "list schema with hasMore and nextCursor required",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
@@ -3408,7 +3410,15 @@ func TestFMT15(t *testing.T) {
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
-			readFile:  func(_ string) ([]byte, error) { return []byte(missingNextCursor), nil },
+			readFile:  func(_ string) ([]byte, error) { return []byte(missingNextCursorProperty), nil },
+			wantCount: 1,
+		},
+		{
+			name: "list schema missing nextCursor in required",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
+			},
+			readFile:  func(_ string) ([]byte, error) { return []byte(missingNextCursorRequired), nil },
 			wantCount: 1,
 		},
 		{
@@ -3419,7 +3429,7 @@ func TestFMT15(t *testing.T) {
 			readFile: func(_ string) ([]byte, error) {
 				return []byte(`{"properties":{"data":{"type":"array","items":{"type":"object"}}},"required":["data"]}`), nil
 			},
-			wantCount: 2,
+			wantCount: 3,
 		},
 		{
 			name: "non-list schema skipped",
@@ -3441,7 +3451,7 @@ func TestFMT15(t *testing.T) {
 				pm.Contracts["http.auth.login.v1"].SchemaRefs.Response = "response.schema.json"
 			},
 			readFile: func(_ string) ([]byte, error) {
-				return []byte(`{"properties":{"data":{"type":"array"},"nextCursor":null},"required":["data","hasMore"]}`), nil
+				return []byte(`{"properties":{"data":{"type":"array"},"nextCursor":null},"required":["data","nextCursor","hasMore"]}`), nil
 			},
 			wantCount: 1,
 		},

--- a/pkg/httputil/pagination.go
+++ b/pkg/httputil/pagination.go
@@ -7,11 +7,11 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
-// ParsePageRequestOrWrite parses pagination query params from r.
+// ParsePageParamsOrWrite parses pagination query params from r.
 // On error it logs a warning, writes the domain error response, and returns ok=false.
 // The caller must return immediately when ok is false.
-func ParsePageRequestOrWrite(w http.ResponseWriter, r *http.Request) (query.PageParams, bool) {
-	params, err := ParsePageRequest(r)
+func ParsePageParamsOrWrite(w http.ResponseWriter, r *http.Request) (query.PageParams, bool) {
+	params, err := ParsePageParams(r)
 	if err != nil {
 		slog.Warn("pagination: request validation failed",
 			slog.String("error", err.Error()),

--- a/pkg/httputil/pagination.go
+++ b/pkg/httputil/pagination.go
@@ -1,0 +1,24 @@
+package httputil
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+// ParsePageRequestOrWrite parses pagination query params from r.
+// On error it logs a warning, writes the domain error response, and returns ok=false.
+// The caller must return immediately when ok is false.
+func ParsePageRequestOrWrite(w http.ResponseWriter, r *http.Request) (query.PageParams, bool) {
+	params, err := ParsePageRequest(r)
+	if err != nil {
+		slog.Warn("pagination: request validation failed",
+			slog.String("error", err.Error()),
+			slog.String("path", r.URL.Path),
+		)
+		WriteDomainError(r.Context(), w, err)
+		return query.PageParams{}, false
+	}
+	return params, true
+}

--- a/pkg/httputil/pagination_test.go
+++ b/pkg/httputil/pagination_test.go
@@ -10,14 +10,16 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
+type parsePageParamsCase struct {
+	name       string
+	query      string
+	wantOK     bool
+	wantLimit  int
+	wantStatus int
+}
+
 func TestParsePageParamsOrWrite(t *testing.T) {
-	tests := []struct {
-		name       string
-		query      string
-		wantOK     bool
-		wantLimit  int
-		wantStatus int
-	}{
+	tests := []parsePageParamsCase{
 		{
 			name:      "no params uses default",
 			query:     "",
@@ -51,26 +53,65 @@ func TestParsePageParamsOrWrite(t *testing.T) {
 
 			pr, ok := httputil.ParsePageParamsOrWrite(w, r)
 
-			if ok != tc.wantOK {
-				t.Errorf("ok=%v, want %v", ok, tc.wantOK)
-			}
-			if tc.wantOK && pr.Limit != tc.wantLimit {
-				t.Errorf("Limit=%d, want %d", pr.Limit, tc.wantLimit)
-			}
-			if !tc.wantOK && w.Code != tc.wantStatus {
-				t.Errorf("HTTP status=%d, want %d", w.Code, tc.wantStatus)
-			}
-			if tc.wantOK && w.Code != 0 && w.Code != http.StatusOK {
-				t.Errorf("unexpected write on ok=true: HTTP status=%d", w.Code)
-			}
-			if !tc.wantOK {
-				var body map[string]any
-				if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-					t.Errorf("response body is not JSON: %v", err)
-				} else if _, ok := body["error"]; !ok {
-					t.Errorf("response body missing 'error' field: %s", w.Body.String())
-				}
-			}
+			assertParsePageParamsResult(t, tc, pr, ok, w)
 		})
+	}
+}
+
+func assertParsePageParamsResult(
+	t *testing.T,
+	tc parsePageParamsCase,
+	pr query.PageParams,
+	ok bool,
+	w *httptest.ResponseRecorder,
+) {
+	t.Helper()
+
+	if ok != tc.wantOK {
+		t.Errorf("ok=%v, want %v", ok, tc.wantOK)
+		return
+	}
+	if tc.wantOK {
+		assertParsePageParamsSuccess(t, tc, pr, w)
+		return
+	}
+	assertParsePageParamsError(t, tc, w)
+}
+
+func assertParsePageParamsSuccess(
+	t *testing.T,
+	tc parsePageParamsCase,
+	pr query.PageParams,
+	w *httptest.ResponseRecorder,
+) {
+	t.Helper()
+
+	if pr.Limit != tc.wantLimit {
+		t.Errorf("Limit=%d, want %d", pr.Limit, tc.wantLimit)
+	}
+	if w.Code != 0 && w.Code != http.StatusOK {
+		t.Errorf("unexpected write on ok=true: HTTP status=%d", w.Code)
+	}
+}
+
+func assertParsePageParamsError(t *testing.T, tc parsePageParamsCase, w *httptest.ResponseRecorder) {
+	t.Helper()
+
+	if w.Code != tc.wantStatus {
+		t.Errorf("HTTP status=%d, want %d", w.Code, tc.wantStatus)
+	}
+	assertJSONErrorEnvelope(t, w)
+}
+
+func assertJSONErrorEnvelope(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Errorf("response body is not JSON: %v", err)
+		return
+	}
+	if _, ok := body["error"]; !ok {
+		t.Errorf("response body missing 'error' field: %s", w.Body.String())
 	}
 }

--- a/pkg/httputil/pagination_test.go
+++ b/pkg/httputil/pagination_test.go
@@ -1,0 +1,76 @@
+package httputil_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+func TestParsePageRequestOrWrite(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantOK     bool
+		wantLimit  int
+		wantStatus int
+	}{
+		{
+			name:      "no params uses default",
+			query:     "",
+			wantOK:    true,
+			wantLimit: query.DefaultPageSize,
+		},
+		{
+			name:      "valid limit",
+			query:     "limit=10",
+			wantOK:    true,
+			wantLimit: 10,
+		},
+		{
+			name:       "limit exceeds max",
+			query:      "limit=9999",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid limit not a number",
+			query:      "limit=abc",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/?"+tc.query, nil)
+
+			pr, ok := httputil.ParsePageRequestOrWrite(w, r)
+
+			if ok != tc.wantOK {
+				t.Errorf("ok=%v, want %v", ok, tc.wantOK)
+			}
+			if tc.wantOK && pr.Limit != tc.wantLimit {
+				t.Errorf("Limit=%d, want %d", pr.Limit, tc.wantLimit)
+			}
+			if !tc.wantOK && w.Code != tc.wantStatus {
+				t.Errorf("HTTP status=%d, want %d", w.Code, tc.wantStatus)
+			}
+			if tc.wantOK && w.Code != 0 && w.Code != http.StatusOK {
+				t.Errorf("unexpected write on ok=true: HTTP status=%d", w.Code)
+			}
+			if !tc.wantOK {
+				var body map[string]any
+				if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+					t.Errorf("response body is not JSON: %v", err)
+				} else if _, ok := body["error"]; !ok {
+					t.Errorf("response body missing 'error' field: %s", w.Body.String())
+				}
+			}
+		})
+	}
+}

--- a/pkg/httputil/pagination_test.go
+++ b/pkg/httputil/pagination_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
-func TestParsePageRequestOrWrite(t *testing.T) {
+func TestParsePageParamsOrWrite(t *testing.T) {
 	tests := []struct {
 		name       string
 		query      string
@@ -49,7 +49,7 @@ func TestParsePageRequestOrWrite(t *testing.T) {
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, "/?"+tc.query, nil)
 
-			pr, ok := httputil.ParsePageRequestOrWrite(w, r)
+			pr, ok := httputil.ParsePageParamsOrWrite(w, r)
 
 			if ok != tc.wantOK {
 				t.Errorf("ok=%v, want %v", ok, tc.wantOK)

--- a/pkg/httputil/request.go
+++ b/pkg/httputil/request.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
-// ParsePageRequest extracts pagination parameters from URL query params.
+// ParsePageParams extracts pagination parameters from URL query params.
 // Query params: ?limit=N&cursor=TOKEN
 //
 // Returns ErrPageSizeExceeded if limit > MaxPageSize.
@@ -20,7 +20,7 @@ import (
 // can be forced to do before the codec's own length guard fires.
 // ref: kubernetes apiserver 4 KiB continue-token guidance.
 // Zero or negative limits are normalized to DefaultPageSize.
-func ParsePageRequest(r *http.Request) (query.PageParams, error) {
+func ParsePageParams(r *http.Request) (query.PageParams, error) {
 	var pr query.PageParams
 
 	if s := r.URL.Query().Get("limit"); s != "" {

--- a/pkg/httputil/request.go
+++ b/pkg/httputil/request.go
@@ -20,8 +20,8 @@ import (
 // can be forced to do before the codec's own length guard fires.
 // ref: kubernetes apiserver 4 KiB continue-token guidance.
 // Zero or negative limits are normalized to DefaultPageSize.
-func ParsePageRequest(r *http.Request) (query.PageRequest, error) {
-	var pr query.PageRequest
+func ParsePageRequest(r *http.Request) (query.PageParams, error) {
+	var pr query.PageParams
 
 	if s := r.URL.Query().Get("limit"); s != "" {
 		n, err := strconv.Atoi(s)

--- a/pkg/httputil/request_test.go
+++ b/pkg/httputil/request_test.go
@@ -14,102 +14,102 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParsePageRequest_Defaults(t *testing.T) {
+func TestParsePageParams_Defaults(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items", nil)
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Equal(t, query.DefaultPageSize, pr.Limit)
 	assert.Empty(t, pr.Cursor)
 }
 
-func TestParsePageRequest_CustomLimit(t *testing.T) {
+func TestParsePageParams_CustomLimit(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?limit=100", nil)
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Equal(t, 100, pr.Limit)
 }
 
-func TestParsePageRequest_MaxLimit(t *testing.T) {
+func TestParsePageParams_MaxLimit(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?limit=500", nil)
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Equal(t, 500, pr.Limit)
 }
 
-func TestParsePageRequest_ExceedsMax(t *testing.T) {
+func TestParsePageParams_ExceedsMax(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?limit=501", nil)
-	_, err := ParsePageRequest(r)
+	_, err := ParsePageParams(r)
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	assert.True(t, errors.As(err, &ecErr))
 	assert.Equal(t, errcode.ErrPageSizeExceeded, ecErr.Code)
 }
 
-func TestParsePageRequest_ZeroLimit(t *testing.T) {
+func TestParsePageParams_ZeroLimit(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?limit=0", nil)
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Equal(t, query.DefaultPageSize, pr.Limit)
 }
 
-func TestParsePageRequest_NegativeLimit(t *testing.T) {
+func TestParsePageParams_NegativeLimit(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?limit=-1", nil)
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Equal(t, query.DefaultPageSize, pr.Limit)
 }
 
-func TestParsePageRequest_NonNumericLimit(t *testing.T) {
+func TestParsePageParams_NonNumericLimit(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?limit=abc", nil)
-	_, err := ParsePageRequest(r)
+	_, err := ParsePageParams(r)
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	assert.True(t, errors.As(err, &ecErr))
 	assert.Equal(t, errcode.ErrValidationFailed, ecErr.Code)
 }
 
-func TestParsePageRequest_WithCursor(t *testing.T) {
+func TestParsePageParams_WithCursor(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?cursor=TOKEN123", nil)
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Equal(t, query.DefaultPageSize, pr.Limit)
 	assert.Equal(t, "TOKEN123", pr.Cursor)
 }
 
-func TestParsePageRequest_LimitAndCursor(t *testing.T) {
+func TestParsePageParams_LimitAndCursor(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/items?limit=20&cursor=TOKEN", nil)
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Equal(t, 20, pr.Limit)
 	assert.Equal(t, "TOKEN", pr.Cursor)
 }
 
-// TestParsePageRequest_CursorTooLong rejects cursors longer than
+// TestParsePageParams_CursorTooLong rejects cursors longer than
 // query.MaxCursorTokenBytes at the HTTP parse boundary, before any
 // base64/HMAC work — defense against DoS amplification via oversize cursors.
 // ref: kubernetes apiserver 4 KiB continue-token guidance; enforcing at the
 // parse boundary (not only at codec.Decode) avoids wasting work in handlers
 // that forward the cursor through layers before decoding.
-func TestParsePageRequest_CursorTooLong(t *testing.T) {
+func TestParsePageParams_CursorTooLong(t *testing.T) {
 	oversize := strings.Repeat("A", query.MaxCursorTokenBytes+1)
 	u := "/api/v1/items?cursor=" + url.QueryEscape(oversize)
 	r := httptest.NewRequest(http.MethodGet, u, nil)
 
-	_, err := ParsePageRequest(r)
+	_, err := ParsePageParams(r)
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 }
 
-// TestParsePageRequest_CursorAtMaxLength accepts a cursor at exactly the
+// TestParsePageParams_CursorAtMaxLength accepts a cursor at exactly the
 // limit (only tokens strictly longer than the cap are rejected at parse time).
-func TestParsePageRequest_CursorAtMaxLength(t *testing.T) {
+func TestParsePageParams_CursorAtMaxLength(t *testing.T) {
 	atLimit := strings.Repeat("A", query.MaxCursorTokenBytes)
 	u := "/api/v1/items?cursor=" + url.QueryEscape(atLimit)
 	r := httptest.NewRequest(http.MethodGet, u, nil)
 
-	pr, err := ParsePageRequest(r)
+	pr, err := ParsePageParams(r)
 	require.NoError(t, err)
 	assert.Len(t, pr.Cursor, query.MaxCursorTokenBytes)
 }

--- a/pkg/query/mempage.go
+++ b/pkg/query/mempage.go
@@ -46,35 +46,47 @@ func Sort[T any](items []T, cols []SortColumn, compareField CompareFunc[T]) {
 // if Sort is empty when CursorValues is present, or if cursor value types are
 // incompatible.
 func ApplyCursor[T any](items []T, params ListParams, fieldValue FieldFunc[T]) ([]T, error) {
-	if params.CursorValues != nil {
-		if len(params.Sort) == 0 {
-			return nil, cursorInvalid("cursor values present but no sort columns defined")
-		}
-		if len(params.CursorValues) != len(params.Sort) {
-			return nil, cursorInvalid(fmt.Sprintf("cursor values count %d does not match sort columns count %d",
-				len(params.CursorValues), len(params.Sort)))
-		}
+	if err := validateCursorParams(params); err != nil {
+		return nil, err
 	}
 
-	start := 0
-	if params.CursorValues != nil {
-		for i, item := range items {
-			after, err := afterCursor(item, params.Sort, params.CursorValues, fieldValue)
-			if err != nil {
-				return nil, err
-			}
-			if after {
-				start = i
-				break
-			}
-			if i == len(items)-1 {
-				start = len(items) // cursor past all rows
-			}
-		}
+	start, err := findCursorStart(items, params, fieldValue)
+	if err != nil {
+		return nil, err
 	}
 
 	end := min(start+params.FetchLimit(), len(items))
 	return items[start:end], nil
+}
+
+func validateCursorParams(params ListParams) error {
+	if params.CursorValues == nil {
+		return nil
+	}
+	if len(params.Sort) == 0 {
+		return cursorInvalid("cursor values present but no sort columns defined")
+	}
+	if len(params.CursorValues) != len(params.Sort) {
+		return cursorInvalid(fmt.Sprintf("cursor values count %d does not match sort columns count %d",
+			len(params.CursorValues), len(params.Sort)))
+	}
+	return nil
+}
+
+func findCursorStart[T any](items []T, params ListParams, fieldValue FieldFunc[T]) (int, error) {
+	if params.CursorValues == nil {
+		return 0, nil
+	}
+	for i, item := range items {
+		after, err := afterCursor(item, params.Sort, params.CursorValues, fieldValue)
+		if err != nil {
+			return 0, err
+		}
+		if after {
+			return i, nil
+		}
+	}
+	return len(items), nil
 }
 
 // afterCursor returns true if item is strictly after the cursor position
@@ -123,36 +135,67 @@ func afterCursor[T any](item T, cols []SortColumn, cursorValues []any, fieldValu
 func CompareAny(a, b any) (int, error) {
 	a, b = normalizeNumeric(a), normalizeNumeric(b)
 
-	switch av := a.(type) {
-	case string:
-		if bv, ok := b.(string); ok {
-			return cmp.Compare(av, bv), nil
-		}
-		if bt, ok := b.(time.Time); ok {
-			at, err := parseTimeString(av)
-			if err != nil {
-				return 0, err
-			}
-			return at.Compare(bt), nil
-		}
-	case float64:
-		if bv, ok := b.(float64); ok {
-			return cmp.Compare(av, bv), nil
-		}
-	case time.Time:
-		if bt, ok := b.(time.Time); ok {
-			return av.Compare(bt), nil
-		}
-		if bs, ok := b.(string); ok {
-			bt, err := parseTimeString(bs)
-			if err != nil {
-				return 0, err
-			}
-			return av.Compare(bt), nil
-		}
+	if result, ok, err := compareStringValues(a, b); ok {
+		return result, err
+	}
+	if result, ok := compareFloatValues(a, b); ok {
+		return result, nil
+	}
+	if result, ok, err := compareTimeValues(a, b); ok {
+		return result, err
 	}
 
 	return 0, cursorInvalid("unsupported cursor value types")
+}
+
+func compareStringValues(a, b any) (int, bool, error) {
+	av, ok := a.(string)
+	if !ok {
+		return 0, false, nil
+	}
+	switch bv := b.(type) {
+	case string:
+		return cmp.Compare(av, bv), true, nil
+	case time.Time:
+		at, err := parseTimeString(av)
+		if err != nil {
+			return 0, true, err
+		}
+		return at.Compare(bv), true, nil
+	default:
+		return 0, false, nil
+	}
+}
+
+func compareFloatValues(a, b any) (int, bool) {
+	av, ok := a.(float64)
+	if !ok {
+		return 0, false
+	}
+	bv, ok := b.(float64)
+	if !ok {
+		return 0, false
+	}
+	return cmp.Compare(av, bv), true
+}
+
+func compareTimeValues(a, b any) (int, bool, error) {
+	av, ok := a.(time.Time)
+	if !ok {
+		return 0, false, nil
+	}
+	switch bv := b.(type) {
+	case time.Time:
+		return av.Compare(bv), true, nil
+	case string:
+		bt, err := parseTimeString(bv)
+		if err != nil {
+			return 0, true, err
+		}
+		return av.Compare(bt), true, nil
+	default:
+		return 0, false, nil
+	}
 }
 
 // normalizeNumeric converts int to float64 for uniform numeric comparison.

--- a/pkg/query/page.go
+++ b/pkg/query/page.go
@@ -17,15 +17,15 @@ const (
 	SortDESC SortDir = "DESC"
 )
 
-// PageRequest holds pagination parameters parsed from an HTTP request.
-type PageRequest struct {
+// PageParams holds pagination parameters parsed from an HTTP request.
+type PageParams struct {
 	Limit  int    // requested page size
 	Cursor string // opaque cursor token; empty for first page
 }
 
 // Normalize clamps Limit to [1, MaxPageSize], applying DefaultPageSize
 // for zero or negative values.
-func (p *PageRequest) Normalize() {
+func (p *PageParams) Normalize() {
 	if p.Limit <= 0 {
 		p.Limit = DefaultPageSize
 	}
@@ -33,6 +33,9 @@ func (p *PageRequest) Normalize() {
 		p.Limit = MaxPageSize
 	}
 }
+
+// PageRequest is a compatibility alias for older call sites.
+type PageRequest = PageParams
 
 // SortColumn defines a column used in keyset ordering.
 type SortColumn struct {

--- a/pkg/query/page.go
+++ b/pkg/query/page.go
@@ -56,7 +56,7 @@ func (lp ListParams) FetchLimit() int {
 // PageResult wraps a page of results with cursor metadata.
 type PageResult[T any] struct {
 	Items      []T    `json:"data"`
-	NextCursor string `json:"nextCursor,omitempty"`
+	NextCursor string `json:"nextCursor"`
 	HasMore    bool   `json:"hasMore"`
 }
 

--- a/pkg/query/page.go
+++ b/pkg/query/page.go
@@ -34,9 +34,6 @@ func (p *PageParams) Normalize() {
 	}
 }
 
-// PageRequest is a compatibility alias for older call sites.
-type PageRequest = PageParams
-
 // SortColumn defines a column used in keyset ordering.
 type SortColumn struct {
 	Name      string  // SQL column name — must be a trusted identifier, never user input

--- a/pkg/query/page_test.go
+++ b/pkg/query/page_test.go
@@ -9,19 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPageRequest_Normalize_Default(t *testing.T) {
-	var pr PageRequest
+func TestPageParams_Normalize_Default(t *testing.T) {
+	var pr PageParams
 	pr.Normalize()
 	assert.Equal(t, DefaultPageSize, pr.Limit)
 }
 
-func TestPageRequest_Normalize_ClampsMax(t *testing.T) {
-	pr := PageRequest{Limit: 1000}
+func TestPageParams_Normalize_ClampsMax(t *testing.T) {
+	pr := PageParams{Limit: 1000}
 	pr.Normalize()
 	assert.Equal(t, MaxPageSize, pr.Limit)
 }
 
-func TestPageRequest_Normalize_ClampsMin(t *testing.T) {
+func TestPageParams_Normalize_ClampsMin(t *testing.T) {
 	tests := []struct {
 		name  string
 		limit int
@@ -32,21 +32,21 @@ func TestPageRequest_Normalize_ClampsMin(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := PageRequest{Limit: tt.limit}
+			pr := PageParams{Limit: tt.limit}
 			pr.Normalize()
 			assert.Equal(t, DefaultPageSize, pr.Limit)
 		})
 	}
 }
 
-func TestPageRequest_Normalize_KeepsValid(t *testing.T) {
-	pr := PageRequest{Limit: 100}
+func TestPageParams_Normalize_KeepsValid(t *testing.T) {
+	pr := PageParams{Limit: 100}
 	pr.Normalize()
 	assert.Equal(t, 100, pr.Limit)
 }
 
-func TestPageRequest_Normalize_PreservesCursor(t *testing.T) {
-	pr := PageRequest{Limit: 0, Cursor: "some-token"}
+func TestPageParams_Normalize_PreservesCursor(t *testing.T) {
+	pr := PageParams{Limit: 0, Cursor: "some-token"}
 	pr.Normalize()
 	assert.Equal(t, DefaultPageSize, pr.Limit)
 	assert.Equal(t, "some-token", pr.Cursor)
@@ -62,8 +62,8 @@ func TestListParams_FetchLimit_One(t *testing.T) {
 	assert.Equal(t, 2, lp.FetchLimit())
 }
 
-func TestPageRequest_Normalize_ExactMax(t *testing.T) {
-	pr := PageRequest{Limit: MaxPageSize}
+func TestPageParams_Normalize_ExactMax(t *testing.T) {
+	pr := PageParams{Limit: MaxPageSize}
 	pr.Normalize()
 	assert.Equal(t, MaxPageSize, pr.Limit)
 }

--- a/pkg/query/page_test.go
+++ b/pkg/query/page_test.go
@@ -164,5 +164,6 @@ func TestMapPageResult_NilItems_JSONArray(t *testing.T) {
 	b, err := json.Marshal(got)
 	require.NoError(t, err)
 	assert.Contains(t, string(b), `"data":[]`)
+	assert.Contains(t, string(b), `"nextCursor":""`)
 	assert.NotContains(t, string(b), `"data":null`)
 }

--- a/pkg/query/paged_query.go
+++ b/pkg/query/paged_query.go
@@ -20,8 +20,8 @@ type CursorErrorFunc func(ctx context.Context, phase string, err error)
 type PagedQueryConfig[T any] struct {
 	// Codec signs and verifies cursor tokens.
 	Codec *CursorCodec
-	// Request holds the client-supplied limit and cursor token.
-	Request PageRequest
+	// PageParams holds the client-supplied limit and cursor token.
+	PageParams PageParams
 	// Sort defines the keyset column ordering for this query.
 	Sort []SortColumn
 	// QueryCtx is the fingerprint from QueryContext(); must match between page requests.
@@ -51,7 +51,7 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 		return PageResult[T]{}, errcode.New(errcode.ErrInternal,
 			"paged query misconfigured: Codec, Fetch, and Extract must not be nil")
 	}
-	cfg.Request.Normalize()
+	cfg.PageParams.Normalize()
 
 	cursorValues, fallback, err := resolveCursor(ctx, cfg)
 	if err != nil {
@@ -62,7 +62,7 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 	}
 
 	params := ListParams{
-		Limit:        cfg.Request.Limit,
+		Limit:        cfg.PageParams.Limit,
 		CursorValues: cursorValues,
 		Sort:         cfg.Sort,
 	}
@@ -72,7 +72,7 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 		return PageResult[T]{}, err
 	}
 
-	return BuildPageResult(items, cfg.Request.Limit, cfg.Codec, cfg.Sort, cfg.QueryCtx, cfg.Extract)
+	return BuildPageResult(items, cfg.PageParams.Limit, cfg.Codec, cfg.Sort, cfg.QueryCtx, cfg.Extract)
 }
 
 // resolveCursor decodes and validates the cursor token. Returns the keyset
@@ -83,11 +83,11 @@ func ExecutePagedQuery[T any](ctx context.Context, cfg PagedQueryConfig[T]) (Pag
 // Scope/context mismatches always return an error because they indicate a
 // client bug (cross-endpoint cursor reuse), not a transient key issue.
 func resolveCursor[T any](ctx context.Context, cfg PagedQueryConfig[T]) ([]any, bool, error) {
-	if cfg.Request.Cursor == "" {
+	if cfg.PageParams.Cursor == "" {
 		return nil, false, nil
 	}
 
-	cur, err := cfg.Codec.Decode(cfg.Request.Cursor)
+	cur, err := cfg.Codec.Decode(cfg.PageParams.Cursor)
 	if err != nil {
 		reportCursorErr(ctx, cfg.OnCursorErr, CursorPhaseDecode, err)
 		if cfg.RunMode.IsDemo() {
@@ -112,12 +112,12 @@ func reportCursorErr(ctx context.Context, fn CursorErrorFunc, phase string, err 
 
 func fetchFirstPage[T any](ctx context.Context, cfg PagedQueryConfig[T]) (PageResult[T], error) {
 	params := ListParams{
-		Limit: cfg.Request.Limit,
+		Limit: cfg.PageParams.Limit,
 		Sort:  cfg.Sort,
 	}
 	items, err := cfg.Fetch(ctx, params)
 	if err != nil {
 		return PageResult[T]{}, err
 	}
-	return BuildPageResult(items, cfg.Request.Limit, cfg.Codec, cfg.Sort, cfg.QueryCtx, cfg.Extract)
+	return BuildPageResult(items, cfg.PageParams.Limit, cfg.Codec, cfg.Sort, cfg.QueryCtx, cfg.Extract)
 }

--- a/pkg/query/paged_query_test.go
+++ b/pkg/query/paged_query_test.go
@@ -80,12 +80,12 @@ func TestExecutePagedQuery_FirstPage(t *testing.T) {
 	}
 
 	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec:    codec,
-		Request:  PageRequest{Limit: 3},
-		Sort:     pagedTestSort,
-		QueryCtx: QueryContext("endpoint", "test"),
-		Fetch:    makeFetcher(items),
-		Extract:  testExtract,
+		Codec:      codec,
+		PageParams: PageParams{Limit: 3},
+		Sort:       pagedTestSort,
+		QueryCtx:   QueryContext("endpoint", "test"),
+		Fetch:      makeFetcher(items),
+		Extract:    testExtract,
 	})
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 3)
@@ -105,13 +105,13 @@ func TestExecutePagedQuery_SecondPage(t *testing.T) {
 	qctx := QueryContext("endpoint", "test")
 
 	page1, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 3}, Sort: pagedTestSort, QueryCtx: qctx,
+		Codec: codec, PageParams: PageParams{Limit: 3}, Sort: pagedTestSort, QueryCtx: qctx,
 		Fetch: makeFetcher(items), Extract: testExtract,
 	})
 	require.NoError(t, err)
 
 	page2, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 3, Cursor: page1.NextCursor}, Sort: pagedTestSort, QueryCtx: qctx,
+		Codec: codec, PageParams: PageParams{Limit: 3, Cursor: page1.NextCursor}, Sort: pagedTestSort, QueryCtx: qctx,
 		Fetch: makeFetcher(items), Extract: testExtract,
 	})
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestExecutePagedQuery_LastPage_FewerThanLimit(t *testing.T) {
 	}
 
 	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 10}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Limit: 10}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
 	})
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestExecutePagedQuery_Empty(t *testing.T) {
 	codec := newTestCodec(t)
 
 	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 10}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Limit: 10}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 	})
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestExecutePagedQuery_GarbageCursor(t *testing.T) {
 	codec := newTestCodec(t)
 
 	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Cursor: "garbage"}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 	})
 	require.Error(t, err)
@@ -174,7 +174,7 @@ func TestExecutePagedQuery_ScopeMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Cursor: token}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Cursor: token}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 	})
 	require.Error(t, err)
@@ -195,7 +195,7 @@ func TestExecutePagedQuery_ContextMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Cursor: token}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Cursor: token}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 	})
 	require.Error(t, err)
@@ -211,7 +211,7 @@ func TestExecutePagedQuery_OnCursorErr_Decode(t *testing.T) {
 	var capturedErr error
 
 	_, _ = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Cursor: "garbage"}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 		OnCursorErr: func(_ context.Context, phase string, err error) {
 			capturedPhase = phase
@@ -236,7 +236,7 @@ func TestExecutePagedQuery_OnCursorErr_Scope(t *testing.T) {
 
 	var capturedPhase string
 	_, _ = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Cursor: token}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Cursor: token}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 		OnCursorErr: func(_ context.Context, phase string, _ error) {
 			capturedPhase = phase
@@ -250,7 +250,7 @@ func TestExecutePagedQuery_OnCursorErr_NilDoesNotPanic(t *testing.T) {
 	codec := newTestCodec(t)
 
 	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Cursor: "garbage"}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 		OnCursorErr: nil,
 	})
@@ -264,7 +264,7 @@ func TestExecutePagedQuery_FetchErrorPropagated(t *testing.T) {
 	codec := newTestCodec(t)
 
 	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 10}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Limit: 10}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"),
 		Fetch: func(context.Context, ListParams) ([]testItem, error) {
 			return nil, fmt.Errorf("db connection refused")
@@ -283,7 +283,7 @@ func TestExecutePagedQuery_NormalizesLimit(t *testing.T) {
 	}
 
 	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 0}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Limit: 0}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
 	})
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestExecutePagedQuery_RunModeDemo_StaleCursor_ReturnsFirstPage(t *testing.T
 	}
 
 	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 10, Cursor: "garbage"}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Limit: 10, Cursor: "garbage"}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
 		RunMode: RunModeDemo,
 	})
@@ -316,7 +316,7 @@ func TestExecutePagedQuery_RunModeProd_StaleCursor_ReturnsError(t *testing.T) {
 	codec := newTestCodec(t)
 
 	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Cursor: "garbage"}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Cursor: "garbage"}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 		// RunMode unset — zero value must be RunModeProd (fail-closed).
 	})
@@ -342,7 +342,7 @@ func TestExecutePagedQuery_RunModeDemo_ScopeMismatch_StillRejects(t *testing.T) 
 	require.NoError(t, err)
 
 	_, err = ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 10, Cursor: token}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Limit: 10, Cursor: token}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
 		RunMode: RunModeDemo,
 	})
@@ -356,7 +356,7 @@ func TestExecutePagedQuery_RunModeDemo_FetchError_Propagated(t *testing.T) {
 	codec := newTestCodec(t)
 
 	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, Request: PageRequest{Limit: 10, Cursor: "garbage"}, Sort: pagedTestSort,
+		Codec: codec, PageParams: PageParams{Limit: 10, Cursor: "garbage"}, Sort: pagedTestSort,
 		QueryCtx: QueryContext("endpoint", "test"),
 		Fetch: func(context.Context, ListParams) ([]testItem, error) {
 			return nil, fmt.Errorf("db connection refused")

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/assembly"
@@ -496,6 +497,10 @@ func (b *Bootstrap) phase5BuildHTTPRouter(s *phaseState) error {
 		}
 	}
 
+	if err := b.validateAuthVerifierForDeclaredRoutes(rtr); err != nil {
+		return err
+	}
+
 	// After RegisterRoutes has accumulated every Cell's auth declarations via
 	// auth.Declare, finalize the router so AuthMiddleware predicates (public,
 	// password-reset-exempt, delegated) reflect the aggregated metadata. Must
@@ -506,6 +511,30 @@ func (b *Bootstrap) phase5BuildHTTPRouter(s *phaseState) error {
 
 	s.rtr = rtr
 	return nil
+}
+
+func (b *Bootstrap) validateAuthVerifierForDeclaredRoutes(rtr *router.Router) error {
+	if b.authVerifier != nil {
+		return nil
+	}
+
+	var protected []string
+	for _, meta := range rtr.DeclaredAuthMetas() {
+		if meta.Public || meta.Delegated {
+			continue
+		}
+		protected = append(protected, meta.Method+" "+meta.Path)
+	}
+	if len(protected) == 0 {
+		return nil
+	}
+
+	sort.Strings(protected)
+	return fmt.Errorf(
+		"bootstrap: auth verifier required: %d protected route(s) declared without AuthMiddleware/AuthDiscovery: [%s]; "+
+			"add bootstrap.WithAuthMiddleware or bootstrap.WithAuthDiscovery, or mark the route Public/Delegated",
+		len(protected), strings.Join(protected, ", "),
+	)
 }
 
 // registerAllHealthCheckers registers option-supplied, cell-discovered, watcher,

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -4090,6 +4090,50 @@ func (c *duplicateAuthCell) RegisterRoutes(mux cell.RouteMux) {
 	})
 }
 
+type protectedAuthCell struct {
+	*cell.BaseCell
+}
+
+func newProtectedAuthCell(id string) *protectedAuthCell {
+	return &protectedAuthCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{
+			ID:   id,
+			Type: cell.CellTypeCore,
+		}),
+	}
+}
+
+func (c *protectedAuthCell) RegisterRoutes(mux cell.RouteMux) {
+	auth.Declare(mux, auth.RouteDecl{
+		Method: "GET",
+		Path:   "/api/v1/protected",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+		Policy: auth.Authenticated(),
+	})
+}
+
+func TestBootstrap_Phase5_ProtectedRoutesWithoutVerifierFailFast(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-protected-auth", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(newProtectedAuthCell("protected-auth-cell")))
+
+	b := New(
+		WithAssembly(asm),
+		WithShutdownTimeout(time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := b.Run(ctx)
+	require.Error(t, err, "Bootstrap.Run must reject protected route declarations without an auth verifier")
+	assert.Contains(t, err.Error(), "auth verifier required")
+	assert.Contains(t, err.Error(), "GET /api/v1/protected")
+	assert.Contains(t, err.Error(), "WithAuthMiddleware")
+	assert.Contains(t, err.Error(), "WithAuthDiscovery")
+}
+
 func TestBootstrap_Phase5_FinalizeAuthError_PropagatesRollback(t *testing.T) {
 	// F8: a cell that declares the same (method, path) twice causes FinalizeAuth
 	// to fail. Bootstrap.Run must propagate the error and roll back (stop the

--- a/runtime/bootstrap/internal_guard_test.go
+++ b/runtime/bootstrap/internal_guard_test.go
@@ -90,10 +90,11 @@ type routeRegisterCell struct {
 	method    string
 	path      string
 	handler   http.HandlerFunc
+	public    bool
 	delegated bool
 }
 
-func newRouteRegisterCell(id, method, path string, h http.HandlerFunc, delegated bool) *routeRegisterCell {
+func newRouteRegisterCell(id, method, path string, h http.HandlerFunc, public, delegated bool) *routeRegisterCell {
 	return &routeRegisterCell{
 		BaseCell: cell.NewBaseCell(cell.CellMetadata{
 			ID:   id,
@@ -102,6 +103,7 @@ func newRouteRegisterCell(id, method, path string, h http.HandlerFunc, delegated
 		method:    method,
 		path:      path,
 		handler:   h,
+		public:    public,
 		delegated: delegated,
 	}
 }
@@ -111,6 +113,7 @@ func (c *routeRegisterCell) RegisterRoutes(mux cell.RouteMux) {
 		Method:    c.method,
 		Path:      c.path,
 		Handler:   c.handler,
+		Public:    c.public,
 		Delegated: c.delegated,
 	})
 }
@@ -134,12 +137,12 @@ func TestWithInternalEndpointGuard_Wiring(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			internalHit.Add(1)
 			w.WriteHeader(http.StatusOK)
-		}), true)
+		}), false, true)
 	apiCell := newRouteRegisterCell("api-cell", http.MethodGet, "/api/v1/users",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			apiHit.Add(1)
 			w.WriteHeader(http.StatusOK)
-		}), false)
+		}), true, false)
 
 	require.NoError(t, asm.Register(internalCell))
 	require.NoError(t, asm.Register(apiCell))
@@ -233,11 +236,11 @@ func TestWithInternalEndpointGuard_BypassesJWT(t *testing.T) {
 	internalCell := newRouteRegisterCell("internal-cell", http.MethodGet, "/internal/v1/roles",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK) // only reached if guard allows
-		}), true)
+		}), false, true)
 	apiCell := newRouteRegisterCell("api-cell", http.MethodGet, "/api/v1/users",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		}), false)
+		}), false, false)
 
 	require.NoError(t, asm.Register(internalCell))
 	require.NoError(t, asm.Register(apiCell))


### PR DESCRIPTION
## Summary
- port the 192 device list pagination work onto the no-dash naming branch instead of rebasing the old dash-path commits
- add the device list slice/contract on `devicecell`, wire real pagination for `accesscore` role listing, and connect `corebundle` access cursor keys
- unify HTTP pagination parsing via `httputil.ParsePageRequestOrWrite` and `query.PageParams`

## Why
The original `feature/192-device-list-pagination` branch was built on pre-rename paths such as `access-core`, `device-cell`, and `core-bundle`. Rebasing that history onto `refactor/501-naming-no-dash` produced path-rename conflicts and would have risked reintroducing old naming into the new branch. This PR reapplies the final feature state directly on top of the no-dash layout.

## Impact
- `GET /api/v1/devices` is now available on `devicecell` and restricted to `admin`
- `accesscore` role listing now uses cursor pagination instead of returning a fixed `hasMore=false` envelope
- `corebundle` now requires `GOCELL_ACCESS_CURSOR_KEY` in real mode and supports `GOCELL_ACCESS_CURSOR_PREVIOUS_KEY`
- env/docs/examples are aligned with the extra cursor key wiring

## Validation
- `go build ./...`
- `go test ./pkg/httputil ./cells/accesscore/... ./cells/devicecell/... ./cmd/corebundle`
- `golangci-lint run ./pkg/httputil/... ./cells/accesscore/... ./cells/devicecell/... ./cmd/corebundle/...`
