### PR TITLE
refactor(ctxkeys): split Cell-model keys into kernel/ctxkeys

### DIFF
--- a/kernel/ctxkeys/doc.go
+++ b/kernel/ctxkeys/doc.go
@@ -2,7 +2,7 @@
 // (cell, slice, journey) propagated through context.Context.
 //
 // Generic observability and networking keys (request, trace, span,
-// correlation, real IP) live in pkg/ctxkeys. Cell-model keys belong here
-// because they encode GoCell architectural concepts rather than generic
-// cross-service conventions.
+// correlation, real IP) live in github.com/ghbvf/gocell/pkg/ctxkeys.
+// Cell-model keys belong here because they encode GoCell architectural
+// concepts rather than generic cross-service conventions.
 package ctxkeys

--- a/kernel/ctxkeys/doc.go
+++ b/kernel/ctxkeys/doc.go
@@ -1,0 +1,8 @@
+// Package ctxkeys provides typed context keys for Cell-model identifiers
+// (cell, slice, journey) propagated through context.Context.
+//
+// Generic observability and networking keys (request, trace, span,
+// correlation, real IP) live in pkg/ctxkeys. Cell-model keys belong here
+// because they encode GoCell architectural concepts rather than generic
+// cross-service conventions.
+package ctxkeys

--- a/kernel/ctxkeys/keys.go
+++ b/kernel/ctxkeys/keys.go
@@ -1,0 +1,46 @@
+package ctxkeys
+
+import "context"
+
+// ctxKey is an unexported type to prevent key collisions with other packages.
+type ctxKey string
+
+// Cell-model context keys propagated through context.Context.
+const (
+	CellID    ctxKey = "cell_id"
+	SliceID   ctxKey = "slice_id"
+	JourneyID ctxKey = "journey_id"
+)
+
+// WithCellID returns a new context carrying the given cell ID.
+func WithCellID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, CellID, id)
+}
+
+// CellIDFrom extracts the cell ID from ctx. The boolean indicates presence.
+func CellIDFrom(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(CellID).(string)
+	return v, ok
+}
+
+// WithSliceID returns a new context carrying the given slice ID.
+func WithSliceID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, SliceID, id)
+}
+
+// SliceIDFrom extracts the slice ID from ctx. The boolean indicates presence.
+func SliceIDFrom(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(SliceID).(string)
+	return v, ok
+}
+
+// WithJourneyID returns a new context carrying the given journey ID.
+func WithJourneyID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, JourneyID, id)
+}
+
+// JourneyIDFrom extracts the journey ID from ctx. The boolean indicates presence.
+func JourneyIDFrom(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(JourneyID).(string)
+	return v, ok
+}

--- a/kernel/ctxkeys/keys.go
+++ b/kernel/ctxkeys/keys.go
@@ -17,7 +17,9 @@ func WithCellID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, CellID, id)
 }
 
-// CellIDFrom extracts the cell ID from ctx. The boolean indicates presence.
+// CellIDFrom extracts the cell ID from ctx. The boolean reports whether the
+// key was present; it can be true with an empty value, so callers that treat
+// "" as invalid must check both ok and v != "".
 func CellIDFrom(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(CellID).(string)
 	return v, ok
@@ -28,7 +30,9 @@ func WithSliceID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, SliceID, id)
 }
 
-// SliceIDFrom extracts the slice ID from ctx. The boolean indicates presence.
+// SliceIDFrom extracts the slice ID from ctx. The boolean reports whether the
+// key was present; it can be true with an empty value, so callers that treat
+// "" as invalid must check both ok and v != "".
 func SliceIDFrom(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(SliceID).(string)
 	return v, ok
@@ -39,7 +43,9 @@ func WithJourneyID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, JourneyID, id)
 }
 
-// JourneyIDFrom extracts the journey ID from ctx. The boolean indicates presence.
+// JourneyIDFrom extracts the journey ID from ctx. The boolean reports whether
+// the key was present; it can be true with an empty value, so callers that
+// treat "" as invalid must check both ok and v != "".
 func JourneyIDFrom(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(JourneyID).(string)
 	return v, ok

--- a/kernel/ctxkeys/keys_test.go
+++ b/kernel/ctxkeys/keys_test.go
@@ -1,0 +1,102 @@
+package ctxkeys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCellIDRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "normal id", value: "accesscore"},
+		{name: "empty string", value: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithCellID(context.Background(), tt.value)
+			got, ok := CellIDFrom(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, tt.value, got)
+		})
+	}
+}
+
+func TestSliceIDRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "normal id", value: "authlogin"},
+		{name: "empty string", value: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithSliceID(context.Background(), tt.value)
+			got, ok := SliceIDFrom(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, tt.value, got)
+		})
+	}
+}
+
+func TestJourneyIDRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "journey id", value: "J-SSO-001"},
+		{name: "empty string", value: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithJourneyID(context.Background(), tt.value)
+			got, ok := JourneyIDFrom(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, tt.value, got)
+		})
+	}
+}
+
+func TestFromMissingKey(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		fn   func(context.Context) (string, bool)
+	}{
+		{name: "CellID missing", fn: CellIDFrom},
+		{name: "SliceID missing", fn: SliceIDFrom},
+		{name: "JourneyID missing", fn: JourneyIDFrom},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := tt.fn(ctx)
+			assert.False(t, ok)
+			assert.Equal(t, "", got)
+		})
+	}
+}
+
+func TestMultipleKeysInSameContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithCellID(ctx, "accesscore")
+	ctx = WithSliceID(ctx, "authlogin")
+	ctx = WithJourneyID(ctx, "J-SSO-001")
+
+	cellID, ok := CellIDFrom(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "accesscore", cellID)
+
+	sliceID, ok := SliceIDFrom(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "authlogin", sliceID)
+
+	journeyID, ok := JourneyIDFrom(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "J-SSO-001", journeyID)
+}

--- a/pkg/ctxkeys/doc.go
+++ b/pkg/ctxkeys/doc.go
@@ -2,9 +2,9 @@
 // networking identifiers (correlation, trace, span, request, real IP)
 // propagated through context.Context.
 //
-// Cell-model identifiers (cell, slice, journey) live in kernel/ctxkeys
-// because they encode GoCell architectural concepts rather than generic
-// cross-service conventions.
+// Cell-model identifiers (cell, slice, journey) live in
+// github.com/ghbvf/gocell/kernel/ctxkeys because they encode GoCell
+// architectural concepts rather than generic cross-service conventions.
 //
 // Authentication subject is propagated via runtime/auth.Principal —
 // use auth.WithPrincipal / auth.FromContext instead of a ctxkeys entry.

--- a/pkg/ctxkeys/doc.go
+++ b/pkg/ctxkeys/doc.go
@@ -1,6 +1,10 @@
-// Package ctxkeys provides typed context keys and helper functions for
-// propagating GoCell identifiers (cell, slice, correlation, journey, trace,
-// span, request, ip) through context.Context.
+// Package ctxkeys provides typed context keys for generic observability and
+// networking identifiers (correlation, trace, span, request, real IP)
+// propagated through context.Context.
+//
+// Cell-model identifiers (cell, slice, journey) live in kernel/ctxkeys
+// because they encode GoCell architectural concepts rather than generic
+// cross-service conventions.
 //
 // Authentication subject is propagated via runtime/auth.Principal —
 // use auth.WithPrincipal / auth.FromContext instead of a ctxkeys entry.

--- a/pkg/ctxkeys/keys.go
+++ b/pkg/ctxkeys/keys.go
@@ -1,6 +1,3 @@
-// Package ctxkeys provides typed context keys and helper functions for
-// propagating GoCell identifiers (cell, slice, correlation, journey, trace,
-// span) through context.Context.
 package ctxkeys
 
 import "context"
@@ -8,43 +5,14 @@ import "context"
 // ctxKey is an unexported type to prevent key collisions with other packages.
 type ctxKey string
 
-// Context key constants used across the GoCell framework.
+// Generic observability and networking context keys.
 const (
-	CellID        ctxKey = "cell_id"
-	SliceID       ctxKey = "slice_id"
 	CorrelationID ctxKey = "correlation_id"
-	JourneyID     ctxKey = "journey_id"
 	TraceID       ctxKey = "trace_id"
 	SpanID        ctxKey = "span_id"
 	RequestID     ctxKey = "request_id"
 	RealIP        ctxKey = "real_ip"
 )
-
-// --- CellID ---
-
-// WithCellID returns a new context carrying the given cell ID.
-func WithCellID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, CellID, id)
-}
-
-// CellIDFrom extracts the cell ID from ctx. The boolean indicates presence.
-func CellIDFrom(ctx context.Context) (string, bool) {
-	v, ok := ctx.Value(CellID).(string)
-	return v, ok
-}
-
-// --- SliceID ---
-
-// WithSliceID returns a new context carrying the given slice ID.
-func WithSliceID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, SliceID, id)
-}
-
-// SliceIDFrom extracts the slice ID from ctx. The boolean indicates presence.
-func SliceIDFrom(ctx context.Context) (string, bool) {
-	v, ok := ctx.Value(SliceID).(string)
-	return v, ok
-}
 
 // --- CorrelationID ---
 
@@ -56,19 +24,6 @@ func WithCorrelationID(ctx context.Context, id string) context.Context {
 // CorrelationIDFrom extracts the correlation ID from ctx. The boolean indicates presence.
 func CorrelationIDFrom(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(CorrelationID).(string)
-	return v, ok
-}
-
-// --- JourneyID ---
-
-// WithJourneyID returns a new context carrying the given journey ID.
-func WithJourneyID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, JourneyID, id)
-}
-
-// JourneyIDFrom extracts the journey ID from ctx. The boolean indicates presence.
-func JourneyIDFrom(ctx context.Context) (string, bool) {
-	v, ok := ctx.Value(JourneyID).(string)
 	return v, ok
 }
 

--- a/pkg/ctxkeys/keys_test.go
+++ b/pkg/ctxkeys/keys_test.go
@@ -7,42 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCellIDRoundTrip(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-	}{
-		{name: "normal id", value: "accesscore"},
-		{name: "empty string", value: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := WithCellID(context.Background(), tt.value)
-			got, ok := CellIDFrom(ctx)
-			assert.True(t, ok)
-			assert.Equal(t, tt.value, got)
-		})
-	}
-}
-
-func TestSliceIDRoundTrip(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-	}{
-		{name: "normal id", value: "auth-login"},
-		{name: "empty string", value: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := WithSliceID(context.Background(), tt.value)
-			got, ok := SliceIDFrom(ctx)
-			assert.True(t, ok)
-			assert.Equal(t, tt.value, got)
-		})
-	}
-}
-
 func TestCorrelationIDRoundTrip(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -55,24 +19,6 @@ func TestCorrelationIDRoundTrip(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := WithCorrelationID(context.Background(), tt.value)
 			got, ok := CorrelationIDFrom(ctx)
-			assert.True(t, ok)
-			assert.Equal(t, tt.value, got)
-		})
-	}
-}
-
-func TestJourneyIDRoundTrip(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-	}{
-		{name: "journey id", value: "J-SSO-001"},
-		{name: "empty string", value: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := WithJourneyID(context.Background(), tt.value)
-			got, ok := JourneyIDFrom(ctx)
 			assert.True(t, ok)
 			assert.Equal(t, tt.value, got)
 		})
@@ -159,10 +105,7 @@ func TestFromMissingKey(t *testing.T) {
 		name string
 		fn   func(context.Context) (string, bool)
 	}{
-		{name: "CellID missing", fn: CellIDFrom},
-		{name: "SliceID missing", fn: SliceIDFrom},
 		{name: "CorrelationID missing", fn: CorrelationIDFrom},
-		{name: "JourneyID missing", fn: JourneyIDFrom},
 		{name: "TraceID missing", fn: TraceIDFrom},
 		{name: "SpanID missing", fn: SpanIDFrom},
 		{name: "RequestID missing", fn: RequestIDFrom},
@@ -180,30 +123,15 @@ func TestFromMissingKey(t *testing.T) {
 
 func TestMultipleKeysInSameContext(t *testing.T) {
 	ctx := context.Background()
-	ctx = WithCellID(ctx, "accesscore")
-	ctx = WithSliceID(ctx, "auth-login")
 	ctx = WithCorrelationID(ctx, "corr-123")
-	ctx = WithJourneyID(ctx, "J-SSO-001")
 	ctx = WithTraceID(ctx, "trace-abc")
 	ctx = WithSpanID(ctx, "span-xyz")
 	ctx = WithRequestID(ctx, "req-001")
 	ctx = WithRealIP(ctx, "10.0.0.1")
 
-	cellID, ok := CellIDFrom(ctx)
-	assert.True(t, ok)
-	assert.Equal(t, "accesscore", cellID)
-
-	sliceID, ok := SliceIDFrom(ctx)
-	assert.True(t, ok)
-	assert.Equal(t, "auth-login", sliceID)
-
 	corrID, ok := CorrelationIDFrom(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, "corr-123", corrID)
-
-	journeyID, ok := JourneyIDFrom(ctx)
-	assert.True(t, ok)
-	assert.Equal(t, "J-SSO-001", journeyID)
 
 	traceID, ok := TraceIDFrom(ctx)
 	assert.True(t, ok)

--- a/runtime/observability/logging/logging.go
+++ b/runtime/observability/logging/logging.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"os"
 
+	kctxkeys "github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 )
 
@@ -105,7 +106,7 @@ func extractContextAttrs(ctx context.Context) []slog.Attr {
 	if v, ok := ctxkeys.CorrelationIDFrom(ctx); ok && v != "" {
 		attrs = append(attrs, slog.String("correlation_id", v))
 	}
-	if v, ok := ctxkeys.CellIDFrom(ctx); ok && v != "" {
+	if v, ok := kctxkeys.CellIDFrom(ctx); ok && v != "" {
 		attrs = append(attrs, slog.String("cell_id", v))
 	}
 

--- a/runtime/observability/logging/logging.go
+++ b/runtime/observability/logging/logging.go
@@ -14,6 +14,10 @@ import (
 	"log/slog"
 	"os"
 
+	// Cell-model keys (cell/slice/journey) live in kernel/ctxkeys; generic
+	// obs/networking keys (request/trace/span/correlation/real IP) live in
+	// pkg/ctxkeys. pkg/ must not depend on kernel/, so dual-import is the
+	// intentional resolution — do not collapse into a single package.
 	kctxkeys "github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 )

--- a/runtime/observability/logging/logging_test.go
+++ b/runtime/observability/logging/logging_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"testing"
 
+	kctxkeys "github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,7 @@ func TestContextHandler_JSON_WithAllContextValues(t *testing.T) {
 	ctx = ctxkeys.WithSpanID(ctx, "span-xyz")
 	ctx = ctxkeys.WithRequestID(ctx, "req-123")
 	ctx = ctxkeys.WithCorrelationID(ctx, "corr-123")
-	ctx = ctxkeys.WithCellID(ctx, "accesscore")
+	ctx = kctxkeys.WithCellID(ctx, "accesscore")
 
 	logger.InfoContext(ctx, "test message", slog.String("extra", "value"))
 


### PR DESCRIPTION
## Summary

Split `pkg/ctxkeys/` into two packages by semantic domain:

- **New `kernel/ctxkeys/`** — `CellID`, `SliceID`, `JourneyID` (Cell-model concepts)
- **`pkg/ctxkeys/` retains** — `RequestID`, `TraceID`, `SpanID`, `CorrelationID`, `RealIP` (generic obs/networking, W3C conventions)

## Why not full migration

The original finding (P0-2 PKG-CTXKEYS-LAYER-01, `docs/reviews/202604221954-review-from-other-verification.md` §A1) proposed moving the whole package to `kernel/`. Verified 4 pkg-layer consumers (`pkg/httputil/response.go`, `pkg/query/cursor_logger.go` and their tests) use only the generic observability keys — full migration would violate `pkg/` layer independence (CLAUDE.md: `pkg/ 不依赖 kernel/`), forcing a cascading rewrite of `httputil` + `query`.

Splitting by semantic domain resolves the layer concern without touching pkg consumers. Cell-model keys (intrinsic to GoCell architecture) move up; industry-standard obs keys stay generic.

## Consumer impact

Only `runtime/observability/logging/logging.go` and its test use Cell-model keys (just `CellID`). Updated to dual-import both packages with `kctxkeys` alias. 32 remaining importers use only surviving generic keys — no change.

## Test plan

- [x] `go build ./...` — 0 errors
- [x] `go build -tags=integration ./...` — 0 errors
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./kernel/ctxkeys/... ./pkg/ctxkeys/... ./runtime/observability/logging/...` — 0 issues
- [x] New `kernel/ctxkeys/keys_test.go` covers round-trip / missing-key / multi-key for Cell-model keys
- [x] `pkg/ctxkeys/keys_test.go` retains coverage for all 5 generic keys

Refs: **P0-2 PKG-CTXKEYS-LAYER-01**