### PR TITLE
[codex] refactor outbox emitters and demo tx defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ asm := assembly.New(assembly.Config{ID: "prod", DurabilityMode: cell.DurabilityD
 asm := assembly.New(assembly.Config{ID: "dev", DurabilityMode: cell.DurabilityDemo})
 ```
 
-`cmd/corebundle` maps real adapter topology to `DurabilityDurable`; development
-and memory topologies use `DurabilityDemo` so examples can run without a
-database or broker. Demo mode is explicit: Cells inject `NoopTxRunner` /
-`NoopEmitter` when dependencies are absent, or a direct `outbox.Emitter` when a
-publisher is supplied without a durable writer. Durable mode never silently
-falls back to those no-op dependencies.
+`cmd/corebundle` maps PostgreSQL storage topology to `DurabilityDurable`;
+development and memory storage topologies use `DurabilityDemo` so examples can
+run without a database or broker. Demo mode is explicit: Cells inject
+`NoopTxRunner` / `NoopEmitter` when dependencies are absent, or a direct
+`outbox.Emitter` when a publisher is supplied without a durable writer. Durable
+mode never silently falls back to those no-op dependencies.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ GoCell assemblies must declare a `DurabilityMode` explicitly (zero value is reje
 
 | Mode | Value | Noop Allowed | Use Case |
 |------|-------|-------------|----------|
-| `DurabilityDemo` | 1 | Yes — `NoopWriter`, `NoopTxRunner`, `DiscardPublisher` accepted | Development, unit tests, examples |
-| `DurabilityDurable` | 2 | No — `CheckNotNoop` rejects at `Init()` | Production (`cmd/corebundle`) |
+| `DurabilityDemo` | 1 | Yes — `NoopWriter`, `NoopTxRunner`, `DiscardPublisher` accepted; missing Tx/outbox dependencies are completed with explicit no-op defaults | Development, unit tests, examples |
+| `DurabilityDurable` | 2 | No — `CheckNotNoop` rejects at `Init()` and L2 Cells require a real outbox writer + Tx runner | Production storage topologies |
 
 ```go
 // Production
@@ -220,6 +220,13 @@ asm := assembly.New(assembly.Config{ID: "prod", DurabilityMode: cell.DurabilityD
 // Development / tests
 asm := assembly.New(assembly.Config{ID: "dev", DurabilityMode: cell.DurabilityDemo})
 ```
+
+`cmd/corebundle` maps real adapter topology to `DurabilityDurable`; development
+and memory topologies use `DurabilityDemo` so examples can run without a
+database or broker. Demo mode is explicit: Cells inject `NoopTxRunner` /
+`NoopEmitter` when dependencies are absent, or a direct `outbox.Emitter` when a
+publisher is supplied without a durable writer. Durable mode never silently
+falls back to those no-op dependencies.
 
 ## Architecture
 
@@ -268,17 +275,32 @@ examples/  ← all layers
 
 ### Outbox Wiring
 
-The transactional outbox is split across three layers — write at the cell, store + relay loop in `runtime/outbox`, persistence in `adapters/postgres`:
+The transactional outbox is split across three layers — Cell services depend on
+`persistence.TxRunner` + `outbox.Emitter`, store + relay loop lives in
+`runtime/outbox`, and persistence lives in `adapters/postgres`:
 
 ```go
-// 1. Write inside the cell's business transaction (any package)
-postgres.NewOutboxWriter().Write(txCtx, entry)
+// 1. Adapt the durable writer at the Cell boundary.
+emitter, err := outbox.NewWriterEmitter(postgres.NewOutboxWriter())
+if err != nil {
+    return err
+}
 
-// 2. Compose the relay at bootstrap (cmd/corebundle, examples, etc.)
+// 2. Service code writes business state + emits inside the same transaction.
+err = txRunner.RunInTx(ctx, func(txCtx context.Context) error {
+    // ... write business state ...
+    return emitter.Emit(txCtx, entry)
+})
+
+// 3. Compose the relay at bootstrap (cmd/corebundle, examples, etc.)
 store := postgres.NewOutboxStore(pool.DB())
 relay := outbox.NewRelay(store, publisher, outbox.DefaultRelayConfig())
 // relay implements worker.Worker — register with bootstrap to manage lifecycle.
 ```
+
+Direct-publish demo paths use `outbox.NewDirectEmitter`; durable writer and
+direct publisher paths both marshal the same `kernel/outbox` v1 wire envelope.
+`runtime/outbox` owns relay/store runtime state only.
 
 `runtime/outbox` defines the SQL-dialect-neutral `Store` interface (`ClaimPending` / `MarkPublished` / `MarkRetry` / `MarkDead` / `ReclaimStale` / `CleanupPublished` / `CleanupDead` / `OldestEligibleAt`) and the `Relay` worker that owns the poll / reclaim / cleanup goroutines. Cleanup is data-driven: it sleeps until the next published / dead row crosses its retention window, so an idle table costs zero DB cycles.
 

--- a/cells/accesscore/auth_integration_test.go
+++ b/cells/accesscore/auth_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionlogout"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionrefresh"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionvalidate"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -172,7 +173,7 @@ func TestAuthIntent_RefreshTokenSucceedsAtRefreshPath(t *testing.T) {
 //
 //  1. Seed admin role + two users (bob with session, admin with a second admin role holder).
 //  2. Revoke bob's "member" role via rbacassign.Service in durable mode
-//     (stubOutboxWriter + stubTxRunner injected via WithOutboxWriter / WithTxManager).
+//     (stubOutboxWriter wrapped as an emitter, plus stubTxRunner).
 //  3. Deliver the outbox entry synchronously to the sessionlogout consumer.
 //  4. Assert that bob's session is now revoked.
 //
@@ -207,7 +208,7 @@ func TestAuthIntegration_RoleRevokeInvalidatesSession(t *testing.T) {
 	stubWriter := &rbacStubOutboxWriter{}
 	stubTx := &rbacStubTxRunner{}
 	assignSvc := rbacassign.NewService(roleRepo, sessionRepo, slog.Default(),
-		rbacassign.WithOutboxWriter(stubWriter),
+		rbacassign.WithEmitter(testoutbox.MustEmitter(t, stubWriter)),
 		rbacassign.WithTxManager(stubTx),
 	)
 

--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -204,6 +204,7 @@ type AccessCore struct {
 	publisher    outbox.Publisher
 	outboxWriter outbox.Writer
 	txRunner     persistence.TxRunner
+	emitter      outbox.Emitter
 	logger       *slog.Logger
 	jwtIssuer    *auth.JWTIssuer
 	jwtVerifier  *auth.JWTVerifier
@@ -224,6 +225,7 @@ type AccessCore struct {
 	authzSvc            *authorizationdecide.Service
 	rbacHandler         *rbaccheck.Handler
 	rbacRunMode         query.RunMode
+	rbacEmitterMode     bool
 	rbacAssignHandler   *rbacassign.Handler
 	configReceiveSvc    *configreceive.Service
 	rbacSessionConsumer *sessionlogout.Consumer
@@ -372,17 +374,8 @@ func (c *AccessCore) runInitialAdminBootstrap(ctx context.Context) error {
 // initValidate performs fail-fast validation of required dependencies before
 // constructing slices. Extracted from Init to reduce cognitive complexity.
 func (c *AccessCore) initValidate(deps cell.Dependencies) error {
-	if (c.outboxWriter == nil) != (c.txRunner == nil) {
-		return errcode.New(errcode.ErrCellMissingOutbox,
-			"accesscore durable mode requires both outboxWriter and txRunner")
-	}
-	if err := cell.CheckNotNoop(deps.DurabilityMode, "accesscore", c.outboxWriter, c.txRunner, c.publisher); err != nil {
+	if err := c.resolveOutboxDeps(deps.DurabilityMode); err != nil {
 		return err
-	}
-	if c.outboxWriter == nil && c.txRunner == nil {
-		if err := c.validateDemoMode(); err != nil {
-			return err
-		}
 	}
 	if c.jwtIssuer == nil || c.jwtVerifier == nil {
 		return errcode.New(errcode.ErrAuthKeyInvalid,
@@ -404,13 +397,32 @@ func (c *AccessCore) initValidate(deps cell.Dependencies) error {
 	return nil
 }
 
-// validateDemoMode is called when both outboxWriter and txRunner are nil.
-func (c *AccessCore) validateDemoMode() error {
-	if c.publisher == nil {
-		return errcode.New(errcode.ErrCellMissingOutbox,
-			"accesscore requires publisher or outbox writer; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
+func (c *AccessCore) resolveOutboxDeps(mode cell.DurabilityMode) error {
+	if err := cell.CheckNotNoop(mode, "accesscore", c.outboxWriter, c.txRunner, c.publisher); err != nil {
+		return err
 	}
-	if c.ConsistencyLevel() >= cell.L2 {
+	if mode == cell.DurabilityDurable {
+		if c.outboxWriter == nil || c.txRunner == nil {
+			return errcode.New(errcode.ErrCellMissingOutbox,
+				"accesscore durable mode requires real outboxWriter and txRunner")
+		}
+		emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
+		if err != nil {
+			return err
+		}
+		c.emitter = emitter
+		c.rbacEmitterMode = true
+		return nil
+	}
+
+	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
+	emitter, emitterMode, err := c.resolveDemoEmitter()
+	if err != nil {
+		return err
+	}
+	c.emitter = emitter
+	c.rbacEmitterMode = emitterMode
+	if c.ConsistencyLevel() >= cell.L2 && c.outboxWriter == nil {
 		c.logger.Warn("accesscore: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",
 			slog.String("cell", c.ID()),
 			slog.Int("consistency_level", int(c.ConsistencyLevel())))
@@ -418,32 +430,37 @@ func (c *AccessCore) validateDemoMode() error {
 	return nil
 }
 
+func (c *AccessCore) resolveDemoEmitter() (outbox.Emitter, bool, error) {
+	if c.publisher != nil && (c.outboxWriter == nil || isNoopDep(c.outboxWriter)) {
+		emitter, err := outbox.NewDirectEmitter(c.publisher, outbox.DirectPublishFailOpen, c.logger)
+		return emitter, false, err
+	}
+	if c.outboxWriter != nil {
+		emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
+		return emitter, !isNoopDep(c.outboxWriter), err
+	}
+	return outbox.NewNoopEmitter(), false, nil
+}
+
+func isNoopDep(dep any) bool {
+	n, ok := dep.(interface{ Noop() bool })
+	return ok && n.Noop()
+}
+
 // initSlices constructs all 9 slice services and handlers.
 // Extracted from Init to reduce cognitive complexity.
 func (c *AccessCore) initSlices() error {
 	// session-login must be constructed before identity-manage because
 	// ChangePassword injects loginSvc as the TokenIssuer.
-	var loginOpts []sessionlogin.Option
-	if c.outboxWriter != nil {
-		loginOpts = append(loginOpts, sessionlogin.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		loginOpts = append(loginOpts, sessionlogin.WithTxManager(c.txRunner))
-	}
-	loginSvc := sessionlogin.NewService(c.userRepo, c.sessionRepo, c.roleRepo, c.publisher, c.jwtIssuer, c.logger, loginOpts...)
+	loginOpts := []sessionlogin.Option{sessionlogin.WithEmitter(c.emitter), sessionlogin.WithTxManager(c.txRunner)}
+	loginSvc := sessionlogin.NewService(c.userRepo, c.sessionRepo, c.roleRepo, c.jwtIssuer, c.logger, loginOpts...)
 	c.loginHandler = sessionlogin.NewHandler(loginSvc)
 	c.AddSlice(cell.NewBaseSlice("sessionlogin", "accesscore", cell.L2))
 
 	// identity-manage: inject loginSvc as TokenIssuer for ChangePassword.
-	var identityOpts []identitymanage.Option
-	if c.outboxWriter != nil {
-		identityOpts = append(identityOpts, identitymanage.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		identityOpts = append(identityOpts, identitymanage.WithTxManager(c.txRunner))
-	}
+	identityOpts := []identitymanage.Option{identitymanage.WithEmitter(c.emitter), identitymanage.WithTxManager(c.txRunner)}
 	identityOpts = append(identityOpts, identitymanage.WithTokenIssuer(loginSvc))
-	identitySvc, err := identitymanage.NewService(c.userRepo, c.sessionRepo, c.publisher, c.logger, identityOpts...)
+	identitySvc, err := identitymanage.NewService(c.userRepo, c.sessionRepo, c.logger, identityOpts...)
 	if err != nil {
 		return err
 	}
@@ -465,14 +482,8 @@ func (c *AccessCore) initSlices() error {
 	c.AddSlice(cell.NewBaseSlice("sessionrefresh", "accesscore", cell.L1))
 
 	// session-logout
-	var logoutOpts []sessionlogout.Option
-	if c.outboxWriter != nil {
-		logoutOpts = append(logoutOpts, sessionlogout.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		logoutOpts = append(logoutOpts, sessionlogout.WithTxManager(c.txRunner))
-	}
-	logoutSvc := sessionlogout.NewService(c.sessionRepo, c.publisher, c.logger, logoutOpts...)
+	logoutOpts := []sessionlogout.Option{sessionlogout.WithEmitter(c.emitter), sessionlogout.WithTxManager(c.txRunner)}
+	logoutSvc := sessionlogout.NewService(c.sessionRepo, c.logger, logoutOpts...)
 	c.logoutHandler = sessionlogout.NewHandler(logoutSvc)
 	c.AddSlice(cell.NewBaseSlice("sessionlogout", "accesscore", cell.L2))
 
@@ -504,17 +515,14 @@ func (c *AccessCore) initSlices() error {
 // initRbacAssign constructs the rbac-assign slice. Extracted to keep initSlices
 // within cognitive complexity bounds.
 func (c *AccessCore) initRbacAssign() {
-	var rbacOpts []rbacassign.Option
-	if c.outboxWriter != nil {
-		rbacOpts = append(rbacOpts, rbacassign.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		rbacOpts = append(rbacOpts, rbacassign.WithTxManager(c.txRunner))
+	rbacOpts := []rbacassign.Option{rbacassign.WithTxManager(c.txRunner)}
+	if c.rbacEmitterMode {
+		rbacOpts = append(rbacOpts, rbacassign.WithEmitter(c.emitter))
 	}
 	rbacAssignSvc := rbacassign.NewService(c.roleRepo, c.sessionRepo, c.logger, rbacOpts...)
 	c.rbacAssignHandler = rbacassign.NewHandler(rbacAssignSvc)
 	rbacAssignLevel := cell.L0
-	if c.outboxWriter != nil && c.txRunner != nil {
+	if c.rbacEmitterMode {
 		rbacAssignLevel = cell.L2
 	}
 	c.AddSlice(cell.NewBaseSlice("rbacassign", "accesscore", rbacAssignLevel))

--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -414,6 +414,14 @@ func (c *AccessCore) resolveOutboxDeps(mode cell.DurabilityMode) error {
 		c.rbacEmitterMode = true
 		return nil
 	}
+	if (c.outboxWriter == nil) != (c.txRunner == nil) {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"accesscore demo mode requires outboxWriter and txRunner together; inject both explicitly")
+	}
+	if c.publisher == nil && c.outboxWriter == nil {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"accesscore demo mode requires an explicit event sink; provide publisher or outboxWriter+txRunner")
+	}
 
 	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
 	emitter, emitterMode, err := c.resolveDemoEmitter()
@@ -439,7 +447,8 @@ func (c *AccessCore) resolveDemoEmitter() (outbox.Emitter, bool, error) {
 		emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
 		return emitter, !isNoopDep(c.outboxWriter), err
 	}
-	return outbox.NewNoopEmitter(), false, nil
+	return nil, false, errcode.New(errcode.ErrCellMissingOutbox,
+		"accesscore demo mode requires an explicit event sink")
 }
 
 func isNoopDep(dep any) bool {

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -141,7 +141,7 @@ func TestAccessCore_Init_RequiresJWTVerifier(t *testing.T) {
 	assert.Contains(t, err.Error(), "WithJWTVerifier")
 }
 
-func TestInit_DemoMode_OutboxWithoutTx_Succeeds(t *testing.T) {
+func TestInit_DemoMode_OutboxWithoutTx_Fails(t *testing.T) {
 	c := NewAccessCore(
 		WithUserRepository(mem.NewUserRepository()),
 		WithSessionRepository(mem.NewSessionRepository()),
@@ -154,10 +154,11 @@ func TestInit_DemoMode_OutboxWithoutTx_Succeeds(t *testing.T) {
 	)
 	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outboxWriter and txRunner")
 }
 
-func TestInit_DemoMode_TxWithoutOutbox_Succeeds(t *testing.T) {
+func TestInit_DemoMode_TxWithoutOutbox_Fails(t *testing.T) {
 	c := NewAccessCore(
 		WithUserRepository(mem.NewUserRepository()),
 		WithSessionRepository(mem.NewSessionRepository()),
@@ -170,7 +171,8 @@ func TestInit_DemoMode_TxWithoutOutbox_Succeeds(t *testing.T) {
 	)
 	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outboxWriter and txRunner")
 }
 
 func TestInit_TxRunnerXOR_BothPresent(t *testing.T) {
@@ -180,14 +182,15 @@ func TestInit_TxRunnerXOR_BothPresent(t *testing.T) {
 	require.NoError(t, c.Init(context.Background(), deps))
 }
 
-func TestInit_DemoMode_NoPublisherNoOutbox_SucceedsWithNoopEmitter(t *testing.T) {
+func TestInit_DemoMode_NoPublisherNoOutbox_Fails(t *testing.T) {
 	c := NewAccessCore(
 		WithInMemoryDefaults(),
 		WithJWTIssuer(testIssuer),
 		WithJWTVerifier(testVerifier),
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit event sink")
 }
 
 func TestInit_DemoMode_WithPublisher_Succeeds(t *testing.T) {
@@ -197,6 +200,18 @@ func TestInit_DemoMode_WithPublisher_Succeeds(t *testing.T) {
 		WithPublisher(eventbus.New()),
 		WithJWTIssuer(testIssuer),
 		WithJWTVerifier(testVerifier),
+	)
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, err)
+}
+
+func TestInit_DemoMode_ExplicitNoopOutboxPair_Succeeds(t *testing.T) {
+	c := NewAccessCore(
+		WithInMemoryDefaults(),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(persistence.NoopTxRunner{}),
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, err)

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -142,8 +141,7 @@ func TestAccessCore_Init_RequiresJWTVerifier(t *testing.T) {
 	assert.Contains(t, err.Error(), "WithJWTVerifier")
 }
 
-func TestInit_TxRunnerXOR_OutboxWithoutTx(t *testing.T) {
-	// outboxWriter present but txRunner missing → XOR mismatch → error
+func TestInit_DemoMode_OutboxWithoutTx_Succeeds(t *testing.T) {
 	c := NewAccessCore(
 		WithUserRepository(mem.NewUserRepository()),
 		WithSessionRepository(mem.NewSessionRepository()),
@@ -156,15 +154,10 @@ func TestInit_TxRunnerXOR_OutboxWithoutTx(t *testing.T) {
 	)
 	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
-	require.Error(t, err)
-	var ecErr *errcode.Error
-	require.ErrorAs(t, err, &ecErr)
-	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
-	assert.Contains(t, err.Error(), "txRunner")
+	require.NoError(t, err)
 }
 
-func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
-	// txRunner present but outboxWriter missing → XOR mismatch → error
+func TestInit_DemoMode_TxWithoutOutbox_Succeeds(t *testing.T) {
 	c := NewAccessCore(
 		WithUserRepository(mem.NewUserRepository()),
 		WithSessionRepository(mem.NewSessionRepository()),
@@ -177,11 +170,7 @@ func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
 	)
 	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	err := c.Init(context.Background(), deps)
-	require.Error(t, err)
-	var ecErr *errcode.Error
-	require.ErrorAs(t, err, &ecErr)
-	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
-	assert.Contains(t, err.Error(), "txRunner")
+	require.NoError(t, err)
 }
 
 func TestInit_TxRunnerXOR_BothPresent(t *testing.T) {
@@ -191,17 +180,14 @@ func TestInit_TxRunnerXOR_BothPresent(t *testing.T) {
 	require.NoError(t, c.Init(context.Background(), deps))
 }
 
-func TestInit_DemoMode_RequiresPublisher(t *testing.T) {
-	// L2 cell with neither outbox nor tx, but no publisher → error
+func TestInit_DemoMode_NoPublisherNoOutbox_SucceedsWithNoopEmitter(t *testing.T) {
 	c := NewAccessCore(
 		WithInMemoryDefaults(),
 		WithJWTIssuer(testIssuer),
 		WithJWTVerifier(testVerifier),
-		// no publisher, no outbox, no tx
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "publisher")
+	require.NoError(t, err)
 }
 
 func TestInit_DemoMode_WithPublisher_Succeeds(t *testing.T) {

--- a/cells/accesscore/options_test.go
+++ b/cells/accesscore/options_test.go
@@ -61,17 +61,16 @@ func TestRegisterSubscriptions(t *testing.T) {
 	assert.Equal(t, "accesscore-rbac-session-sync", r.ConsumerGroups[2])
 }
 
-func TestInit_MissingOutboxWriter(t *testing.T) {
-	// L2 cell without outboxWriter (but with txRunner) should fail via XOR check.
+func TestInit_DurableMode_MissingOutboxWriter(t *testing.T) {
 	c := NewAccessCore(
 		WithJWTIssuer(testIssuer),
 		WithJWTVerifier(testVerifier),
 		WithTxManager(noopTxRunner{}),
 	)
-	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDurable}
 	err := c.Init(context.Background(), deps)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "txRunner")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outboxWriter")
 }
 
 func TestInit_DurableMode_RejectsNoopWriter(t *testing.T) {

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,13 +90,12 @@ func newE2EFixture() *e2eFixture {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	roleRepo := mem.NewRoleRepository()
-	eb := eventbus.New()
 
 	loginSvc := sessionlogin.NewService(
-		userRepo, sessionRepo, roleRepo, eb, e2eIssuer, slog.Default(),
+		userRepo, sessionRepo, roleRepo, e2eIssuer, slog.Default(),
 	)
 
-	idmSvc, err := NewService(userRepo, sessionRepo, eb, slog.Default(),
+	idmSvc, err := NewService(userRepo, sessionRepo, slog.Default(),
 		WithTokenIssuer(&e2eTokenIssuer{svc: loginSvc}),
 	)
 	if err != nil {

--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -3,6 +3,7 @@ package identitymanage
 import (
 	"context"
 	"encoding/json"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -63,7 +64,7 @@ func setupContractHandlerWithOutbox(t testing.TB) (http.Handler, *contractRecord
 	t.Helper()
 	writer := &contractRecordingWriter{}
 	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(contractTxRunner{}), WithTokenIssuer(contractStubIssuer))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(contractTxRunner{}), WithTokenIssuer(contractStubIssuer))
 	if err != nil {
 		t.Fatalf("setupContractHandlerWithOutbox: %v", err)
 	}

--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,7 +51,7 @@ var contractStubIssuer TokenIssuer = &stubTokenIssuer{}
 
 func setupContractHandler(t testing.TB) http.Handler {
 	t.Helper()
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithTokenIssuer(contractStubIssuer))
 	if err != nil {
 		t.Fatalf("setupContractHandler: %v", err)
@@ -63,7 +62,7 @@ func setupContractHandler(t testing.TB) http.Handler {
 func setupContractHandlerWithOutbox(t testing.TB) (http.Handler, *contractRecordingWriter) {
 	t.Helper()
 	writer := &contractRecordingWriter{}
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(contractTxRunner{}), WithTokenIssuer(contractStubIssuer))
 	if err != nil {
 		t.Fatalf("setupContractHandlerWithOutbox: %v", err)
@@ -125,7 +124,7 @@ func buildMux(svc *Service) http.Handler {
 func setupContractHandlerWithIssuer(t testing.TB, issuer TokenIssuer) (http.Handler, *mem.UserRepository) {
 	t.Helper()
 	repo := mem.NewUserRepository()
-	svc, err := NewService(repo, mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(repo, mem.NewSessionRepository(), slog.Default(),
 		WithTokenIssuer(issuer))
 	if err != nil {
 		t.Fatalf("setupContractHandlerWithIssuer: %v", err)

--- a/cells/accesscore/slices/identitymanage/handler_test.go
+++ b/cells/accesscore/slices/identitymanage/handler_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
 // handlerStubIssuer is a minimal TokenIssuer stub used by handler tests that
@@ -28,7 +27,7 @@ import (
 var handlerStubIssuer TokenIssuer = &stubTokenIssuer{}
 
 func setup() http.Handler {
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithTokenIssuer(handlerStubIssuer))
 	if err != nil {
 		panic("setup: " + err.Error())
@@ -45,7 +44,7 @@ func setupWithIssuer(issuer TokenIssuer) (http.Handler, *mem.UserRepository) {
 	if effectiveIssuer == nil {
 		effectiveIssuer = handlerStubIssuer
 	}
-	svc, err := NewService(repo, mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(repo, mem.NewSessionRepository(), slog.Default(),
 		WithTokenIssuer(effectiveIssuer))
 	if err != nil {
 		panic("setupWithIssuer: " + err.Error())

--- a/cells/accesscore/slices/identitymanage/outbox_test.go
+++ b/cells/accesscore/slices/identitymanage/outbox_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -163,7 +162,7 @@ func TestHandler_Unlock_NotFound(t *testing.T) {
 
 func TestService_WithOutboxWriter(t *testing.T) {
 	ow := &stubOutboxWriter{}
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithOutboxWriter(ow), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
@@ -178,7 +177,7 @@ func TestService_WithOutboxWriter(t *testing.T) {
 
 func TestService_WithTxManager(t *testing.T) {
 	tx := &stubTxRunner{}
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithTxManager(tx), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
@@ -191,7 +190,7 @@ func TestService_WithTxManager(t *testing.T) {
 
 func TestService_Lock_WithOutbox(t *testing.T) {
 	ow := &stubOutboxWriter{}
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithOutboxWriter(ow), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
@@ -236,7 +235,7 @@ func TestService_Update_EmptyID(t *testing.T) {
 
 func TestService_Create_OutboxWriteError(t *testing.T) {
 	ow := &stubOutboxWriter{err: errors.New("outbox unavailable")}
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithOutboxWriter(ow), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
@@ -250,7 +249,7 @@ func TestService_Create_OutboxWriteError(t *testing.T) {
 func TestService_Lock_OutboxWriteError(t *testing.T) {
 	repo := mem.NewUserRepository()
 	// Create user with working outbox
-	svcCreate, err := NewService(repo, mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svcCreate, err := NewService(repo, mem.NewSessionRepository(), slog.Default(),
 		WithOutboxWriter(&stubOutboxWriter{}), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 	user, err := svcCreate.Create(context.Background(), CreateInput{
@@ -260,7 +259,7 @@ func TestService_Lock_OutboxWriteError(t *testing.T) {
 
 	// Lock with failing outbox
 	failWriter := &stubOutboxWriter{err: errors.New("outbox unavailable")}
-	svcLock, err := NewService(repo, mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svcLock, err := NewService(repo, mem.NewSessionRepository(), slog.Default(),
 		WithOutboxWriter(failWriter), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 

--- a/cells/accesscore/slices/identitymanage/outbox_test.go
+++ b/cells/accesscore/slices/identitymanage/outbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -160,10 +161,10 @@ func TestHandler_Unlock_NotFound(t *testing.T) {
 
 // --- outbox/tx service tests ---
 
-func TestService_WithOutboxWriter(t *testing.T) {
+func TestService_WithEmitter(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
-		WithOutboxWriter(ow), WithTokenIssuer(outboxStubIssuer))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{
@@ -191,7 +192,7 @@ func TestService_WithTxManager(t *testing.T) {
 func TestService_Lock_WithOutbox(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
-		WithOutboxWriter(ow), WithTokenIssuer(outboxStubIssuer))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
 	user, err := svc.Create(context.Background(), CreateInput{
@@ -236,7 +237,7 @@ func TestService_Update_EmptyID(t *testing.T) {
 func TestService_Create_OutboxWriteError(t *testing.T) {
 	ow := &stubOutboxWriter{err: errors.New("outbox unavailable")}
 	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
-		WithOutboxWriter(ow), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{
@@ -250,7 +251,7 @@ func TestService_Lock_OutboxWriteError(t *testing.T) {
 	repo := mem.NewUserRepository()
 	// Create user with working outbox
 	svcCreate, err := NewService(repo, mem.NewSessionRepository(), slog.Default(),
-		WithOutboxWriter(&stubOutboxWriter{}), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
+		WithEmitter(testoutbox.MustEmitter(t, &stubOutboxWriter{})), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 	user, err := svcCreate.Create(context.Background(), CreateInput{
 		Username: "bob", Email: "b@c.d", Password: "hash",
@@ -260,7 +261,7 @@ func TestService_Lock_OutboxWriteError(t *testing.T) {
 	// Lock with failing outbox
 	failWriter := &stubOutboxWriter{err: errors.New("outbox unavailable")}
 	svcLock, err := NewService(repo, mem.NewSessionRepository(), slog.Default(),
-		WithOutboxWriter(failWriter), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
+		WithEmitter(testoutbox.MustEmitter(t, failWriter)), WithTxManager(&stubTxRunner{}), WithTokenIssuer(outboxStubIssuer))
 	require.NoError(t, err)
 
 	err = svcLock.Lock(context.Background(), user.ID)

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -47,15 +47,6 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -39,14 +38,27 @@ const (
 // Option configures an identity-manage Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // WithTokenIssuer injects the token issuer used by ChangePassword to issue a
@@ -58,21 +70,26 @@ func WithTokenIssuer(ti TokenIssuer) Option {
 
 // Service implements identity management business logic.
 type Service struct {
-	repo         ports.UserRepository
-	sessionRepo  ports.SessionRepository
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
-	tokenIssuer  TokenIssuer
+	repo        ports.UserRepository
+	sessionRepo ports.SessionRepository
+	txRunner    persistence.TxRunner
+	emitter     outbox.Emitter
+	logger      *slog.Logger
+	tokenIssuer TokenIssuer
 }
 
 // NewService creates an identity-manage Service. tokenIssuer is required;
 // callers must supply it via WithTokenIssuer. Omitting it or passing nil
 // returns errcode.ErrCellMissingTokenIssuer so mis-wired assemblies fail at
 // startup rather than at the first ChangePassword call.
-func NewService(repo ports.UserRepository, sessionRepo ports.SessionRepository, pub outbox.Publisher, logger *slog.Logger, opts ...Option) (*Service, error) {
-	s := &Service{repo: repo, sessionRepo: sessionRepo, publisher: pub, logger: logger}
+func NewService(repo ports.UserRepository, sessionRepo ports.SessionRepository, logger *slog.Logger, opts ...Option) (*Service, error) {
+	s := &Service{
+		repo:        repo,
+		sessionRepo: sessionRepo,
+		txRunner:    persistence.NoopTxRunner{},
+		emitter:     outbox.NewNoopEmitter(),
+		logger:      logger,
+	}
 	for _, o := range opts {
 		o(s)
 	}
@@ -346,34 +363,17 @@ func (s *Service) publish(ctx context.Context, topic string, payload map[string]
 	if err != nil {
 		return fmt.Errorf("identity-manage: marshal event payload: %w", err)
 	}
-	if s.outboxWriter != nil {
-		entry := outbox.Entry{
-			ID:        outbox.NewEntryID(),
-			EventType: topic,
-			Payload:   data,
-		}
-		if err := s.outboxWriter.Write(ctx, entry); err != nil {
-			return fmt.Errorf("identity-manage: write outbox entry: %w", err)
-		}
-		return nil
+	entry := outbox.Entry{
+		ID:        outbox.NewEntryID(),
+		EventType: topic,
+		Payload:   data,
 	}
-	// Demo mode: publisher failure is logged but not propagated since
-	// demo mode does not guarantee L2 atomicity. Wrap in v1 wire envelope so
-	// the eventbus fail-closed schema check (P1-14) accepts the message.
-	envelope := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), data)
-	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
-		s.logger.Warn("identity-manage: failed to publish event (demo mode)",
-			slog.Any("error", err), slog.String("topic", topic))
+	if err := s.emitter.Emit(ctx, entry); err != nil {
+		return fmt.Errorf("identity-manage: emit event: %w", err)
 	}
 	return nil
 }
 
-// runInTx executes fn in a transaction if txRunner is configured, otherwise
-// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
-// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +24,7 @@ import (
 var minimalStubIssuer TokenIssuer = &stubTokenIssuer{}
 
 func newTestService() *Service {
-	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 		WithTokenIssuer(minimalStubIssuer))
 	if err != nil {
 		panic("newTestService: " + err.Error())
@@ -36,7 +36,7 @@ func newTestService() *Service {
 // error when WithTokenIssuer is omitted or nil, enforcing fail-fast wiring.
 func TestNewService_RequiresTokenIssuer(t *testing.T) {
 	t.Run("no WithTokenIssuer option", func(t *testing.T) {
-		svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default())
+		svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default())
 		require.Error(t, err, "NewService without WithTokenIssuer must fail")
 		assert.Nil(t, svc)
 		var ec *errcode.Error
@@ -45,7 +45,7 @@ func TestNewService_RequiresTokenIssuer(t *testing.T) {
 	})
 
 	t.Run("WithTokenIssuer(nil)", func(t *testing.T) {
-		svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+		svc, err := NewService(mem.NewUserRepository(), mem.NewSessionRepository(), slog.Default(),
 			WithTokenIssuer(nil))
 		require.Error(t, err, "NewService with nil tokenIssuer must fail")
 		assert.Nil(t, svc)
@@ -101,7 +101,7 @@ func TestService_LockUnlock(t *testing.T) {
 
 func TestService_Lock_RevokesSession(t *testing.T) {
 	sessionRepo := mem.NewSessionRepository()
-	svc, err := NewService(mem.NewUserRepository(), sessionRepo, eventbus.New(), slog.Default(),
+	svc, err := NewService(mem.NewUserRepository(), sessionRepo, slog.Default(),
 		WithTokenIssuer(minimalStubIssuer))
 	require.NoError(t, err)
 
@@ -214,7 +214,7 @@ func newServiceWithIssuer(issuer TokenIssuer) (*Service, *mem.UserRepository) {
 	if effectiveIssuer == nil {
 		effectiveIssuer = minimalStubIssuer
 	}
-	svc, err := NewService(repo, mem.NewSessionRepository(), eventbus.New(), slog.Default(),
+	svc, err := NewService(repo, mem.NewSessionRepository(), slog.Default(),
 		WithTokenIssuer(effectiveIssuer))
 	if err != nil {
 		panic("newServiceWithIssuer: " + err.Error())
@@ -337,7 +337,7 @@ func TestService_ChangePassword_RevokesPriorSessions(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	stub := &stubTokenIssuer{pair: dto.TokenPair{AccessToken: "new-at", SessionID: "sess-new"}}
-	svc, err := NewService(userRepo, sessionRepo, eventbus.New(), slog.Default(),
+	svc, err := NewService(userRepo, sessionRepo, slog.Default(),
 		WithTokenIssuer(stub))
 	require.NoError(t, err)
 
@@ -423,7 +423,7 @@ func TestService_ChangePassword_RevokeFailureAbortsAndNoToken(t *testing.T) {
 		pair: dto.TokenPair{AccessToken: "must-not-see"},
 	}
 	spyIssuer := &recordingTokenIssuer{inner: stub, called: &issuerCalled}
-	svc, err := NewService(userRepo, sessionRepo, eventbus.New(), slog.Default(),
+	svc, err := NewService(userRepo, sessionRepo, slog.Default(),
 		WithTokenIssuer(spyIssuer),
 		WithTxManager(&snapshotTxRunner{repo: userRepo, userID: "usr-cp-tx-fail"}))
 	require.NoError(t, err)
@@ -551,8 +551,10 @@ func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	fp := failingPublisher{err: errors.New("broker unavailable")}
-	svc, err := NewService(userRepo, sessionRepo, fp, slog.Default(),
-		WithTokenIssuer(&stubTokenIssuer{}))
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, slog.Default())
+	require.NoError(t, err)
+	svc, err := NewService(userRepo, sessionRepo, slog.Default(),
+		WithEmitter(emitter), WithTokenIssuer(&stubTokenIssuer{}))
 	require.NoError(t, err)
 
 	user, err := svc.Create(context.Background(), CreateInput{

--- a/cells/accesscore/slices/rbacassign/outbox_test.go
+++ b/cells/accesscore/slices/rbacassign/outbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -50,8 +51,9 @@ func (r *trackingSessionRepo) RevokeByUserID(ctx context.Context, userID string)
 	return r.SessionRepository.RevokeByUserID(ctx, userID)
 }
 
-// newDurableTestService creates a Service with outboxWriter + txRunner injected (durable mode).
-func newDurableTestService(ow *stubOutboxWriter, tx *stubTxRunner) (*Service, *mem.RoleRepository, *trackingSessionRepo) {
+// newDurableTestService creates a Service with emitter + txRunner injected (durable mode).
+func newDurableTestService(t testing.TB, ow *stubOutboxWriter, tx *stubTxRunner) (*Service, *mem.RoleRepository, *trackingSessionRepo) {
+	t.Helper()
 	roleRepo := mem.NewRoleRepository()
 	roleRepo.SeedRole(&domain.Role{
 		ID:   "admin",
@@ -62,7 +64,7 @@ func newDurableTestService(ow *stubOutboxWriter, tx *stubTxRunner) (*Service, *m
 	})
 	sessionRepo := &trackingSessionRepo{SessionRepository: mem.NewSessionRepository()}
 	svc := NewService(roleRepo, sessionRepo, slog.Default(),
-		WithOutboxWriter(ow),
+		WithEmitter(testoutbox.MustEmitter(t, ow)),
 		WithTxManager(tx),
 	)
 	return svc, roleRepo, sessionRepo
@@ -75,7 +77,7 @@ func newDurableTestService(ow *stubOutboxWriter, tx *stubTxRunner) (*Service, *m
 func TestService_Assign_Durable_WritesOutboxAtomically(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc, _, sessionRepo := newDurableTestService(ow, tx)
+	svc, _, sessionRepo := newDurableTestService(t, ow, tx)
 
 	err := svc.Assign(context.Background(), "alice", "admin")
 	require.NoError(t, err)
@@ -103,7 +105,7 @@ func TestService_Assign_Durable_WritesOutboxAtomically(t *testing.T) {
 func TestService_Revoke_Durable_WritesOutboxAtomically(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc, roleRepo, sessionRepo := newDurableTestService(ow, tx)
+	svc, roleRepo, sessionRepo := newDurableTestService(t, ow, tx)
 
 	// Need two admins so last-admin guard passes.
 	_, _ = roleRepo.AssignToUser(context.Background(), "alice", "admin")
@@ -136,13 +138,13 @@ func TestService_Durable_OutboxWriteFailure_PropagatesError(t *testing.T) {
 	outboxErr := errors.New("outbox write failed")
 	ow := &stubOutboxWriter{err: outboxErr}
 	tx := &stubTxRunner{}
-	svc, _, _ := newDurableTestService(ow, tx)
+	svc, _, _ := newDurableTestService(t, ow, tx)
 
 	err := svc.Assign(context.Background(), "alice", "admin")
 	require.Error(t, err, "Assign must return error when outbox write fails")
 	assert.ErrorIs(t, err, outboxErr, "original outbox error must be in the chain")
 
-	// outboxWriter.entries is empty because Write returned error before appending.
+	// outbox entries are empty because Write returned error before appending.
 	assert.Empty(t, ow.entries)
 }
 
@@ -151,7 +153,7 @@ func TestService_Durable_OutboxWriteFailure_PropagatesError(t *testing.T) {
 func TestService_Durable_DoesNotCallSessionRepoDirectly(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc, roleRepo, sessionRepo := newDurableTestService(ow, tx)
+	svc, roleRepo, sessionRepo := newDurableTestService(t, ow, tx)
 
 	// Assign.
 	require.NoError(t, svc.Assign(context.Background(), "u1", "admin"))
@@ -171,7 +173,7 @@ func TestService_Durable_DoesNotCallSessionRepoDirectly(t *testing.T) {
 func TestService_Assign_Durable_RepeatIsNoop(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc, _, sessionRepo := newDurableTestService(ow, tx)
+	svc, _, sessionRepo := newDurableTestService(t, ow, tx)
 
 	require.NoError(t, svc.Assign(context.Background(), "alice", "admin"))
 	require.Len(t, ow.entries, 1, "first assign must publish exactly one event")
@@ -190,7 +192,7 @@ func TestService_Assign_Durable_RepeatIsNoop(t *testing.T) {
 func TestService_Revoke_Durable_NonMemberIsNoop(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc, roleRepo, sessionRepo := newDurableTestService(ow, tx)
+	svc, roleRepo, sessionRepo := newDurableTestService(t, ow, tx)
 
 	// Seed two other holders so the last-admin guard does not short-circuit.
 	_, _ = roleRepo.AssignToUser(context.Background(), "bob", "admin")

--- a/cells/accesscore/slices/rbacassign/service.go
+++ b/cells/accesscore/slices/rbacassign/service.go
@@ -15,21 +15,16 @@ import (
 
 // Service handles RBAC role assignment and revocation.
 //
-// Durable mode (outboxWriter + txRunner both non-nil): writes role row and
-// event.role.{assigned,revoked}.v1 outbox entry atomically in one DB transaction.
-// Session revocation is handled asynchronously by sessionlogout.Consumer which
-// subscribes to both topics. This provides L2 OutboxFact atomicity — the partial-commit
-// window from the legacy dual-write is eliminated.
+// When the Cell injects an emitter for asynchronous role-change delivery, the
+// role mutation and event.role.{assigned,revoked}.v1 emission run in one
+// transaction and session revocation moves to the sessionlogout consumer.
 //
-// Demo mode (both nil): preserves today's synchronous dual-write behaviour —
-// roleRepo.{AssignToUser,RemoveFromUserIfNotLast} then sessionRepo.RevokeByUserID
-// in-process. Suitable for in-memory repos where "transaction" semantics are
-// implicit within a single goroutine.
+// With the default noop emitter, the service preserves the in-process
+// role-change + session-revoke flow used by demo and in-memory wiring.
 //
-// Idempotent no-op handling (both modes): the role repository reports whether
-// the call actually changed state. On no-op (repeat assign or revoke-non-member),
-// no outbox entry is written and no session revoke is triggered — the operation
-// is externally invisible, preventing false role-change facts.
+// The role repository reports whether the call actually changed state. On a
+// no-op (repeat assign or revoke-non-member), no event is emitted and no
+// session revoke is triggered, preventing false role-change facts.
 //
 // ref: Watermill SQL outbox + sessionlogin/service.go persistSession pattern.
 type Service struct {
@@ -54,25 +49,15 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-			s.syncSessionRevocation = false
-		}
-	}
-}
-
-// WithTxManager sets the TxRunner for L2 atomicity (must be paired with WithOutboxWriter).
+// WithTxManager sets the TxRunner for L2 atomicity (must be paired with WithEmitter).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // NewService creates a new rbac-assign service.
-// In durable mode (both WithOutboxWriter and WithTxManager provided), session
-// revocation is delegated to the sessionlogout consumer via the outbox.
-// In demo mode (no opts), the legacy dual-write is used.
+// When WithEmitter is provided, session revocation is delegated to the
+// sessionlogout consumer. With default options, the legacy in-process revoke
+// path is used.
 func NewService(
 	roleRepo ports.RoleRepository,
 	sessionRepo ports.SessionRepository,
@@ -115,10 +100,11 @@ func (s *Service) writeOutboxEntry(ctx context.Context, eventType string, evt dt
 	return nil
 }
 
-// persistChange wraps a role mutation + outbox write in a single transaction (durable mode)
-// or delegates to the legacy dual-write (demo mode). writeFn returns whether the repository
-// actually mutated state; the outbox entry (durable) or session revoke (demo) is skipped
-// on a no-op so repeat calls do not publish false role-change facts.
+// persistChange wraps a role mutation in the configured transaction runner.
+// When an async emitter is configured it also emits the role-change event; with
+// the default noop emitter it keeps the in-process session revoke path. writeFn
+// returns whether the repository actually mutated state, so no-op calls never
+// emit false role-change facts.
 func (s *Service) persistChange(
 	ctx context.Context,
 	writeFn func(ctx context.Context) (changed bool, err error),

--- a/cells/accesscore/slices/rbacassign/service.go
+++ b/cells/accesscore/slices/rbacassign/service.go
@@ -33,24 +33,40 @@ import (
 //
 // ref: Watermill SQL outbox + sessionlogin/service.go persistSession pattern.
 type Service struct {
-	roleRepo     ports.RoleRepository
-	sessionRepo  ports.SessionRepository
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	roleRepo              ports.RoleRepository
+	sessionRepo           ports.SessionRepository
+	txRunner              persistence.TxRunner
+	emitter               outbox.Emitter
+	syncSessionRevocation bool
+	logger                *slog.Logger
 }
 
 // Option configures a rbac-assign Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing (L2 durable mode).
+// WithEmitter sets the event emitter and disables in-process session revoke.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+			s.syncSessionRevocation = false
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+			s.syncSessionRevocation = false
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for L2 atomicity (must be paired with WithOutboxWriter).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // NewService creates a new rbac-assign service.
@@ -64,9 +80,12 @@ func NewService(
 	opts ...Option,
 ) *Service {
 	s := &Service{
-		roleRepo:    roleRepo,
-		sessionRepo: sessionRepo,
-		logger:      logger,
+		roleRepo:              roleRepo,
+		sessionRepo:           sessionRepo,
+		txRunner:              persistence.NoopTxRunner{},
+		emitter:               outbox.NewNoopEmitter(),
+		syncSessionRevocation: true,
+		logger:                logger,
 	}
 	for _, o := range opts {
 		o(s)
@@ -74,24 +93,13 @@ func NewService(
 	return s
 }
 
-// isDurableMode returns true when both outboxWriter and txRunner are configured.
-func (s *Service) isDurableMode() bool {
-	return s.outboxWriter != nil && s.txRunner != nil
-}
-
-// runInTx wraps fn in a transaction if txRunner is configured, otherwise calls fn directly.
+// runInTx wraps fn in a transaction runner.
 func (s *Service) runInTx(ctx context.Context, fn func(context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }
 
 // writeOutboxEntry writes a role-change outbox entry. Called inside a transaction.
 func (s *Service) writeOutboxEntry(ctx context.Context, eventType string, evt dto.RoleChangedEvent) error {
-	if s.outboxWriter == nil {
-		return nil
-	}
 	payload, err := json.Marshal(evt)
 	if err != nil {
 		return fmt.Errorf("rbac-assign: marshal role-changed event: %w", err)
@@ -101,8 +109,8 @@ func (s *Service) writeOutboxEntry(ctx context.Context, eventType string, evt dt
 		EventType: eventType,
 		Payload:   payload,
 	}
-	if err := s.outboxWriter.Write(ctx, entry); err != nil {
-		return fmt.Errorf("rbac-assign: write outbox entry: %w", err)
+	if err := s.emitter.Emit(ctx, entry); err != nil {
+		return fmt.Errorf("rbac-assign: emit role-changed event: %w", err)
 	}
 	return nil
 }
@@ -117,26 +125,18 @@ func (s *Service) persistChange(
 	evt dto.RoleChangedEvent,
 	topic string,
 ) (changed bool, err error) {
-	if s.isDurableMode() {
-		// Durable: atomically persist role change + outbox entry.
-		// Session revocation is handled asynchronously by the consumer.
-		err = s.runInTx(ctx, func(txCtx context.Context) error {
-			var innerErr error
-			changed, innerErr = writeFn(txCtx)
-			if innerErr != nil {
-				return innerErr
-			}
-			if !changed {
-				return nil
-			}
-			return s.writeOutboxEntry(txCtx, topic, evt)
-		})
-		return changed, err
-	}
-
-	// Demo mode: synchronous dual-write (legacy behaviour), gated on changed.
-	changed, err = writeFn(ctx)
-	if err != nil {
+	err = s.runInTx(ctx, func(txCtx context.Context) error {
+		var innerErr error
+		changed, innerErr = writeFn(txCtx)
+		if innerErr != nil {
+			return innerErr
+		}
+		if !changed || s.syncSessionRevocation {
+			return nil
+		}
+		return s.writeOutboxEntry(txCtx, topic, evt)
+	})
+	if err != nil || !s.syncSessionRevocation {
 		return changed, err
 	}
 	if !changed {
@@ -175,7 +175,7 @@ func (s *Service) Assign(ctx context.Context, userID, roleID string) error {
 	}
 
 	mode := "demo"
-	if s.isDurableMode() {
+	if !s.syncSessionRevocation {
 		mode = "durable"
 	}
 	s.logger.Info("role assigned",
@@ -210,7 +210,7 @@ func (s *Service) Revoke(ctx context.Context, userID, roleID string) error {
 	}
 
 	mode := "demo"
-	if s.isDurableMode() {
+	if !s.syncSessionRevocation {
 		mode = "durable"
 	}
 	s.logger.Info("role revoked",

--- a/cells/accesscore/slices/rbacassign/service_test.go
+++ b/cells/accesscore/slices/rbacassign/service_test.go
@@ -240,7 +240,7 @@ func TestService_Assign_SessionRevokeFail_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "session revoke failed")
 }
 
-// TestService_DemoMode_* proves that in demo mode (no WithOutboxWriter / WithTxManager),
+// TestService_DemoMode_* proves that in demo mode (no WithEmitter / WithTxManager),
 // sessionRepo.RevokeByUserID is still called exactly once per Assign and Revoke, preserving
 // backward-compatible dual-write behaviour.
 func TestService_DemoMode_Assign_CallsSessionRevoke(t *testing.T) {

--- a/cells/accesscore/slices/sessionlogin/handler_test.go
+++ b/cells/accesscore/slices/sessionlogin/handler_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
 // testIssuer is declared in service_test.go
@@ -31,7 +30,7 @@ func setup() *Handler {
 	}
 	_ = userRepo.Create(context.Background(), user)
 
-	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(), eventbus.New(), testIssuer, slog.Default())
+	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(), testIssuer, slog.Default())
 	return NewHandler(svc)
 }
 

--- a/cells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogin/outbox_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +46,7 @@ func TestService_WithOutboxWriter(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	ow := &stubOutboxWriter{}
 	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(),
-		eventbus.New(), testIssuer, slog.Default(), WithOutboxWriter(ow))
+		testIssuer, slog.Default(), WithOutboxWriter(ow))
 
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
 	seedUserDirect(userRepo, "alice", string(hash))
@@ -63,7 +62,7 @@ func TestService_WithTxManager(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	tx := &stubTxRunner{}
 	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(),
-		eventbus.New(), testIssuer, slog.Default(), WithTxManager(tx))
+		testIssuer, slog.Default(), WithTxManager(tx))
 
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
 	seedUserDirect(userRepo, "bob", string(hash))

--- a/cells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogin/outbox_test.go
@@ -2,6 +2,7 @@ package sessionlogin
 
 import (
 	"context"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -42,11 +43,11 @@ func seedUserDirect(repo *mem.UserRepository, username, passwordHash string) {
 	_ = repo.Create(context.Background(), user)
 }
 
-func TestService_WithOutboxWriter(t *testing.T) {
+func TestService_WithEmitter(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	ow := &stubOutboxWriter{}
 	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(),
-		testIssuer, slog.Default(), WithOutboxWriter(ow))
+		testIssuer, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
 	seedUserDirect(userRepo, "alice", string(hash))

--- a/cells/accesscore/slices/sessionlogin/service.go
+++ b/cells/accesscore/slices/sessionlogin/service.go
@@ -44,15 +44,6 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }

--- a/cells/accesscore/slices/sessionlogin/service.go
+++ b/cells/accesscore/slices/sessionlogin/service.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -36,26 +35,38 @@ type TokenPair struct {
 // Option configures a session-login Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service implements password login with JWT issuance.
 type Service struct {
-	userRepo     ports.UserRepository
-	sessionRepo  ports.SessionRepository
-	roleRepo     ports.RoleRepository
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	issuer       *auth.JWTIssuer
-	logger       *slog.Logger
+	userRepo    ports.UserRepository
+	sessionRepo ports.SessionRepository
+	roleRepo    ports.RoleRepository
+	txRunner    persistence.TxRunner
+	emitter     outbox.Emitter
+	issuer      *auth.JWTIssuer
+	logger      *slog.Logger
 }
 
 // NewService creates a session-login Service.
@@ -67,7 +78,6 @@ func NewService(
 	userRepo ports.UserRepository,
 	sessionRepo ports.SessionRepository,
 	roleRepo ports.RoleRepository,
-	pub outbox.Publisher,
 	issuer *auth.JWTIssuer,
 	logger *slog.Logger,
 	opts ...Option,
@@ -76,7 +86,8 @@ func NewService(
 		userRepo:    userRepo,
 		sessionRepo: sessionRepo,
 		roleRepo:    roleRepo,
-		publisher:   pub,
+		txRunner:    persistence.NoopTxRunner{},
+		emitter:     outbox.NewNoopEmitter(),
 		issuer:      issuer,
 		logger:      logger,
 	}
@@ -145,8 +156,6 @@ func (s *Service) Login(ctx context.Context, input LoginInput) (*TokenPair, erro
 		return nil, err
 	}
 
-	s.maybePublishDirect(ctx, payload)
-
 	s.logger.Info("user logged in",
 		slog.String("user_id", user.ID), slog.String("session_id", session.ID))
 	return &TokenPair{
@@ -171,50 +180,23 @@ func (s *Service) fetchRoleNames(ctx context.Context, userID string) ([]string, 
 	return names, nil
 }
 
-// persistSession writes the session and (when configured) the outbox entry,
-// optionally wrapped in a transaction when txRunner is available.
+// persistSession writes the session and emits the outbox entry.
 func (s *Service) persistSession(ctx context.Context, session *domain.Session, payload []byte) error {
 	do := func(txCtx context.Context) error {
 		if err := s.sessionRepo.Create(txCtx, session); err != nil {
 			return fmt.Errorf("session-login: persist session: %w", err)
 		}
-		return s.writeOutboxEntry(txCtx, payload)
-	}
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, do)
-	}
-	return do(ctx)
-}
-
-// writeOutboxEntry writes a session.created outbox entry when the writer is configured.
-func (s *Service) writeOutboxEntry(ctx context.Context, payload []byte) error {
-	if s.outboxWriter == nil {
+		entry := outbox.Entry{
+			ID:        outbox.NewEntryID(),
+			EventType: TopicSessionCreated,
+			Payload:   payload,
+		}
+		if err := s.emitter.Emit(txCtx, entry); err != nil {
+			return fmt.Errorf("session-login: emit event: %w", err)
+		}
 		return nil
 	}
-	entry := outbox.Entry{
-		ID:        outbox.NewEntryID(),
-		EventType: TopicSessionCreated,
-		Payload:   payload,
-	}
-	if err := s.outboxWriter.Write(ctx, entry); err != nil {
-		return fmt.Errorf("session-login: write outbox entry: %w", err)
-	}
-	return nil
-}
-
-// maybePublishDirect publishes directly when outbox is not in use (demo mode).
-// Wraps the business payload in a v1 wire envelope so the eventbus fail-closed
-// schema check (P1-14) accepts the message and subscribers receive it.
-func (s *Service) maybePublishDirect(ctx context.Context, payload []byte) {
-	if s.outboxWriter != nil {
-		return
-	}
-	envelope := outboxrt.MarshalDirectEnvelope(TopicSessionCreated, TopicSessionCreated, outbox.NewEntryID(), payload)
-	if pubErr := s.publisher.Publish(ctx, TopicSessionCreated, envelope); pubErr != nil {
-		s.logger.Warn("session-login: failed to publish event (demo mode)",
-			slog.Any("error", pubErr),
-			slog.String("topic", TopicSessionCreated))
-	}
+	return s.txRunner.RunInTx(ctx, do)
 }
 
 // issueAccessToken signs a short-lived JWT with intent=access for calling

--- a/cells/accesscore/slices/sessionlogin/service_test.go
+++ b/cells/accesscore/slices/sessionlogin/service_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,8 +63,7 @@ func newTestService() (*Service, *mem.UserRepository) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	roleRepo := mem.NewRoleRepository()
-	eb := eventbus.New()
-	return NewService(userRepo, sessionRepo, roleRepo, eb, testIssuer, slog.Default()), userRepo
+	return NewService(userRepo, sessionRepo, roleRepo, testIssuer, slog.Default()), userRepo
 }
 
 // seedUser creates a user with a bcrypt-hashed password.
@@ -234,8 +233,7 @@ func TestService_IssueForUser_SessionPersisted(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	roleRepo := mem.NewRoleRepository()
-	eb := eventbus.New()
-	svc := NewService(userRepo, sessionRepo, roleRepo, eb, testIssuer, slog.Default())
+	svc := NewService(userRepo, sessionRepo, roleRepo, testIssuer, slog.Default())
 	seedUser(userRepo, "issue-persist", "pass123")
 
 	u, err := userRepo.GetByUsername(context.Background(), "issue-persist")
@@ -261,7 +259,9 @@ func TestService_Login_PublishError_DoesNotFailLogin(t *testing.T) {
 	seedUser(userRepo, "pub-err", "pass123")
 
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
-	svc := NewService(userRepo, sessionRepo, roleRepo, fp, testIssuer, slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, slog.Default())
+	require.NoError(t, err)
+	svc := NewService(userRepo, sessionRepo, roleRepo, testIssuer, slog.Default(), WithEmitter(emitter))
 
 	pair, err := svc.Login(context.Background(), LoginInput{Username: "pub-err", Password: "pass123"})
 	require.NoError(t, err, "publish failure in demo mode should not fail login")

--- a/cells/accesscore/slices/sessionlogout/contract_test.go
+++ b/cells/accesscore/slices/sessionlogout/contract_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +58,7 @@ func TestHttpAuthSessionDeleteV1Serve(t *testing.T) {
 
 	sessionRepo := mem.NewSessionRepository()
 	sessID := seedContractSession(sessionRepo)
-	svc := NewService(sessionRepo, eventbus.New(), slog.Default(),
+	svc := NewService(sessionRepo, slog.Default(),
 		WithOutboxWriter(&recordingWriter{}), WithTxManager(noopTxRunner{}))
 
 	mux := http.NewServeMux()
@@ -85,7 +84,7 @@ func TestEventSessionRevokedV1Publish(t *testing.T) {
 
 	sessionRepo := mem.NewSessionRepository()
 	writer := &recordingWriter{}
-	svc := NewService(sessionRepo, eventbus.New(), slog.Default(),
+	svc := NewService(sessionRepo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(noopTxRunner{}))
 
 	sessID := seedContractSession(sessionRepo)
@@ -163,7 +162,7 @@ func TestService_Logout_OutboxWriteError(t *testing.T) {
 	sessionRepo := mem.NewSessionRepository()
 	seedContractSession(sessionRepo)
 	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
-	svc := NewService(sessionRepo, eventbus.New(), slog.Default(),
+	svc := NewService(sessionRepo, slog.Default(),
 		WithOutboxWriter(failWriter), WithTxManager(noopTxRunner{}))
 
 	err := svc.Logout(context.Background(), "sess-1", "usr-1")

--- a/cells/accesscore/slices/sessionlogout/contract_test.go
+++ b/cells/accesscore/slices/sessionlogout/contract_test.go
@@ -3,6 +3,7 @@ package sessionlogout
 import (
 	"context"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +60,7 @@ func TestHttpAuthSessionDeleteV1Serve(t *testing.T) {
 	sessionRepo := mem.NewSessionRepository()
 	sessID := seedContractSession(sessionRepo)
 	svc := NewService(sessionRepo, slog.Default(),
-		WithOutboxWriter(&recordingWriter{}), WithTxManager(noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(noopTxRunner{}))
 
 	mux := http.NewServeMux()
 	mux.Handle("DELETE /api/v1/access/sessions/{id}", http.HandlerFunc(NewHandler(svc).HandleLogout))
@@ -85,7 +86,7 @@ func TestEventSessionRevokedV1Publish(t *testing.T) {
 	sessionRepo := mem.NewSessionRepository()
 	writer := &recordingWriter{}
 	svc := NewService(sessionRepo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(noopTxRunner{}))
 
 	sessID := seedContractSession(sessionRepo)
 
@@ -163,7 +164,7 @@ func TestService_Logout_OutboxWriteError(t *testing.T) {
 	seedContractSession(sessionRepo)
 	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
 	svc := NewService(sessionRepo, slog.Default(),
-		WithOutboxWriter(failWriter), WithTxManager(noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, failWriter)), WithTxManager(noopTxRunner{}))
 
 	err := svc.Logout(context.Background(), "sess-1", "usr-1")
 	require.Error(t, err, "Logout must propagate outbox.Write error to preserve L2 atomicity")

--- a/cells/accesscore/slices/sessionlogout/handler_test.go
+++ b/cells/accesscore/slices/sessionlogout/handler_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
 func setup() *Handler {
@@ -27,7 +26,7 @@ func setup() *Handler {
 	other.ID = "sess-victim"
 	_ = sessionRepo.Create(context.Background(), other)
 
-	svc := NewService(sessionRepo, eventbus.New(), slog.Default())
+	svc := NewService(sessionRepo, slog.Default())
 	return NewHandler(svc)
 }
 

--- a/cells/accesscore/slices/sessionlogout/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogout/outbox_test.go
@@ -2,6 +2,7 @@ package sessionlogout
 
 import (
 	"context"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -29,10 +30,10 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 
 // --- tests ---
 
-func TestService_WithOutboxWriter(t *testing.T) {
+func TestService_WithEmitter(t *testing.T) {
 	repo := mem.NewSessionRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	seedSession(repo, "sess-1", "usr-1")
 
@@ -58,7 +59,7 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(ow), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTxManager(tx))
 
 	seedSession(repo, "sess-1", "usr-1")
 

--- a/cells/accesscore/slices/sessionlogout/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogout/outbox_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +32,7 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 func TestService_WithOutboxWriter(t *testing.T) {
 	repo := mem.NewSessionRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
 
 	seedSession(repo, "sess-1", "usr-1")
 
@@ -46,7 +45,7 @@ func TestService_WithOutboxWriter(t *testing.T) {
 func TestService_WithTxManager(t *testing.T) {
 	repo := mem.NewSessionRepository()
 	tx := &stubTxRunner{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithTxManager(tx))
+	svc := NewService(repo, slog.Default(), WithTxManager(tx))
 
 	seedSession(repo, "sess-1", "usr-1")
 
@@ -58,7 +57,7 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	repo := mem.NewSessionRepository()
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc := NewService(repo, eventbus.New(), slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(ow), WithTxManager(tx))
 
 	seedSession(repo, "sess-1", "usr-1")

--- a/cells/accesscore/slices/sessionlogout/service.go
+++ b/cells/accesscore/slices/sessionlogout/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 )
 
 const (
@@ -22,35 +21,47 @@ const (
 // Option configures a session-logout Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service implements session revocation.
 type Service struct {
-	sessionRepo  ports.SessionRepository
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	sessionRepo ports.SessionRepository
+	txRunner    persistence.TxRunner
+	emitter     outbox.Emitter
+	logger      *slog.Logger
 }
 
 // NewService creates a session-logout Service.
 func NewService(
 	sessionRepo ports.SessionRepository,
-	pub outbox.Publisher,
 	logger *slog.Logger,
 	opts ...Option,
 ) *Service {
 	s := &Service{
 		sessionRepo: sessionRepo,
-		publisher:   pub,
+		txRunner:    persistence.NoopTxRunner{},
+		emitter:     outbox.NewNoopEmitter(),
 		logger:      logger,
 	}
 	for _, o := range opts {
@@ -59,13 +70,9 @@ func NewService(
 	return s
 }
 
-// persistRevoke wraps the session update + outbox write in a txRunner-aware call.
-// When txRunner is nil (demo mode), fn is called directly without a transaction.
+// persistRevoke wraps the session update + event emit in a transaction runner.
 func (s *Service) persistRevoke(ctx context.Context, fn func(context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }
 
 // Logout revokes the caller's own session identified by sessionID.
@@ -96,32 +103,19 @@ func (s *Service) Logout(ctx context.Context, sessionID, callerUserID string) er
 		if err := s.sessionRepo.RevokeByIDAndOwner(txCtx, sessionID, callerUserID); err != nil {
 			return err
 		}
-		if s.outboxWriter != nil {
-			entry := outbox.Entry{
-				ID:        outbox.NewEntryID(),
-				EventType: TopicSessionRevoked,
-				Payload:   payload,
-			}
-			if writeErr := s.outboxWriter.Write(txCtx, entry); writeErr != nil {
-				return fmt.Errorf("session-logout: write outbox entry: %w", writeErr)
-			}
+		entry := outbox.Entry{
+			ID:        outbox.NewEntryID(),
+			EventType: TopicSessionRevoked,
+			Payload:   payload,
+		}
+		if emitErr := s.emitter.Emit(txCtx, entry); emitErr != nil {
+			return fmt.Errorf("session-logout: emit event: %w", emitErr)
 		}
 		return nil
 	}
 
 	if err := s.persistRevoke(ctx, revokeAndPublish); err != nil {
 		return err
-	}
-
-	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
-	// so the eventbus fail-closed schema check (P1-14) accepts the message.
-	if s.outboxWriter == nil {
-		envelope := outboxrt.MarshalDirectEnvelope(TopicSessionRevoked, TopicSessionRevoked, outbox.NewEntryID(), payload)
-		if pubErr := s.publisher.Publish(ctx, TopicSessionRevoked, envelope); pubErr != nil {
-			s.logger.Warn("session-logout: failed to publish event (demo mode)",
-				slog.Any("error", pubErr),
-				slog.String("topic", TopicSessionRevoked))
-		}
 	}
 
 	s.logger.Info("session revoked",

--- a/cells/accesscore/slices/sessionlogout/service.go
+++ b/cells/accesscore/slices/sessionlogout/service.go
@@ -30,15 +30,6 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }

--- a/cells/accesscore/slices/sessionlogout/service_test.go
+++ b/cells/accesscore/slices/sessionlogout/service_test.go
@@ -9,16 +9,15 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func newTestService() (*Service, *mem.SessionRepository) {
 	repo := mem.NewSessionRepository()
-	eb := eventbus.New()
-	return NewService(repo, eb, slog.Default()), repo
+	return NewService(repo, slog.Default()), repo
 }
 
 func seedSession(repo *mem.SessionRepository, id, userID string) {
@@ -125,9 +124,11 @@ func TestService_Logout_PublishError_DoesNotFailLogout(t *testing.T) {
 	seedSession(repo, "sess-pub", "usr-1")
 
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
-	svc := NewService(repo, fp, slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, slog.Default())
+	require.NoError(t, err)
+	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
 
-	err := svc.Logout(context.Background(), "sess-pub", "usr-1")
+	err = svc.Logout(context.Background(), "sess-pub", "usr-1")
 	require.NoError(t, err, "publish failure in demo mode should not fail logout")
 }
 

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -159,8 +159,8 @@ func (c *AuditCore) resolveHMACKey(cfg map[string]any) error {
 	return nil
 }
 
-// validateOutboxDeps enforces the XOR constraint on outboxWriter/txRunner and
-// the demo-mode publisher requirement.
+// validateOutboxDeps rejects noop implementations in durable mode and requires
+// demo mode to use an explicit event sink instead of synthesized defaults.
 func (c *AuditCore) validateOutboxDeps(mode cell.DurabilityMode) error {
 	if err := cell.CheckNotNoop(mode, "auditcore", c.outboxWriter, c.txRunner, c.publisher); err != nil {
 		return err
@@ -176,6 +176,14 @@ func (c *AuditCore) validateOutboxDeps(mode cell.DurabilityMode) error {
 		}
 		c.emitter = emitter
 		return nil
+	}
+	if (c.outboxWriter == nil) != (c.txRunner == nil) {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"auditcore demo mode requires outboxWriter and txRunner together; inject both explicitly")
+	}
+	if c.publisher == nil && c.outboxWriter == nil {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"auditcore demo mode requires an explicit event sink; provide publisher or outboxWriter+txRunner")
 	}
 
 	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
@@ -199,7 +207,8 @@ func (c *AuditCore) resolveDemoEmitter() (outbox.Emitter, error) {
 	if c.outboxWriter != nil {
 		return outbox.NewWriterEmitter(c.outboxWriter)
 	}
-	return outbox.NewNoopEmitter(), nil
+	return nil, errcode.New(errcode.ErrCellMissingOutbox,
+		"auditcore demo mode requires an explicit event sink")
 }
 
 func isNoopDep(dep any) bool {

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -87,6 +87,7 @@ type AuditCore struct {
 	publisher    outbox.Publisher
 	outboxWriter outbox.Writer
 	txRunner     persistence.TxRunner
+	emitter      outbox.Emitter
 	cursorCodec  *query.CursorCodec
 	logger       *slog.Logger
 	hmacKey      []byte
@@ -161,29 +162,49 @@ func (c *AuditCore) resolveHMACKey(cfg map[string]any) error {
 // validateOutboxDeps enforces the XOR constraint on outboxWriter/txRunner and
 // the demo-mode publisher requirement.
 func (c *AuditCore) validateOutboxDeps(mode cell.DurabilityMode) error {
-	// Fail-fast: outboxWriter and txRunner must be both present or both absent (XOR constraint).
-	// Both present = durable mode (L2 atomicity). Both absent = demo/in-memory mode.
-	if (c.outboxWriter == nil) != (c.txRunner == nil) {
-		return errcode.New(errcode.ErrCellMissingOutbox,
-			"auditcore durable mode requires both outboxWriter and txRunner")
-	}
-	// Durable mode: reject noop implementations.
 	if err := cell.CheckNotNoop(mode, "auditcore", c.outboxWriter, c.txRunner, c.publisher); err != nil {
 		return err
 	}
-	// Demo mode: both nil → require publisher for degraded event delivery.
-	if c.outboxWriter == nil && c.txRunner == nil {
-		if c.publisher == nil {
+	if mode == cell.DurabilityDurable {
+		if c.outboxWriter == nil || c.txRunner == nil {
 			return errcode.New(errcode.ErrCellMissingOutbox,
-				"auditcore requires publisher or outbox writer; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
+				"auditcore durable mode requires real outboxWriter and txRunner")
 		}
-		if c.ConsistencyLevel() >= cell.L2 {
-			c.logger.Warn("auditcore: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",
-				slog.String("cell", c.ID()),
-				slog.Int("consistency_level", int(c.ConsistencyLevel())))
+		emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
+		if err != nil {
+			return err
 		}
+		c.emitter = emitter
+		return nil
+	}
+
+	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
+	emitter, err := c.resolveDemoEmitter()
+	if err != nil {
+		return err
+	}
+	c.emitter = emitter
+	if c.ConsistencyLevel() >= cell.L2 && c.outboxWriter == nil {
+		c.logger.Warn("auditcore: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",
+			slog.String("cell", c.ID()),
+			slog.Int("consistency_level", int(c.ConsistencyLevel())))
 	}
 	return nil
+}
+
+func (c *AuditCore) resolveDemoEmitter() (outbox.Emitter, error) {
+	if c.publisher != nil && (c.outboxWriter == nil || isNoopDep(c.outboxWriter)) {
+		return outbox.NewDirectEmitter(c.publisher, outbox.DirectPublishFailOpen, c.logger)
+	}
+	if c.outboxWriter != nil {
+		return outbox.NewWriterEmitter(c.outboxWriter)
+	}
+	return outbox.NewNoopEmitter(), nil
+}
+
+func isNoopDep(dep any) bool {
+	n, ok := dep.(interface{ Noop() bool })
+	return ok && n.Noop()
 }
 
 // initSlices constructs and registers the audit-append, audit-verify, and
@@ -191,26 +212,14 @@ func (c *AuditCore) validateOutboxDeps(mode cell.DurabilityMode) error {
 // because it requires the cursor codec to be resolved first.
 func (c *AuditCore) initSlices() {
 	// audit-append
-	var appendOpts []auditappend.Option
-	if c.outboxWriter != nil {
-		appendOpts = append(appendOpts, auditappend.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		appendOpts = append(appendOpts, auditappend.WithTxManager(c.txRunner))
-	}
-	c.appendSvc = auditappend.NewService(c.auditRepo, c.hmacKey, c.publisher, c.logger, appendOpts...)
+	appendOpts := []auditappend.Option{auditappend.WithEmitter(c.emitter), auditappend.WithTxManager(c.txRunner)}
+	c.appendSvc = auditappend.NewService(c.auditRepo, c.hmacKey, c.logger, appendOpts...)
 	// L3: 订阅 accesscore/configcore 跨 cell 事件，slice 级别可高于 cell 级别。
 	c.AddSlice(cell.NewBaseSlice("auditappend", "auditcore", cell.L3))
 
 	// audit-verify
-	var verifyOpts []auditverify.Option
-	if c.outboxWriter != nil {
-		verifyOpts = append(verifyOpts, auditverify.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		verifyOpts = append(verifyOpts, auditverify.WithTxManager(c.txRunner))
-	}
-	c.verifySvc = auditverify.NewService(c.auditRepo, c.hmacKey, c.publisher, c.logger, verifyOpts...)
+	verifyOpts := []auditverify.Option{auditverify.WithEmitter(c.emitter), auditverify.WithTxManager(c.txRunner)}
+	c.verifySvc = auditverify.NewService(c.auditRepo, c.hmacKey, c.logger, verifyOpts...)
 	// L2: publishes event.audit.integrity-verified.v1 via transactional outbox.
 	c.AddSlice(cell.NewBaseSlice("auditverify", "auditcore", cell.L2))
 

--- a/cells/auditcore/cell_test.go
+++ b/cells/auditcore/cell_test.go
@@ -129,7 +129,7 @@ func TestAuditCore_HMACKeyFromConfig(t *testing.T) {
 
 // --- L2 Hard Gate: durable-mode dependency checks ---
 
-func TestInit_DemoMode_OutboxWithoutTx_Succeeds(t *testing.T) {
+func TestInit_DemoMode_OutboxWithoutTx_Fails(t *testing.T) {
 	c := NewAuditCore(
 		WithAuditRepository(mem.NewAuditRepository()),
 		WithArchiveStore(mem.NewArchiveStore()),
@@ -139,10 +139,11 @@ func TestInit_DemoMode_OutboxWithoutTx_Succeeds(t *testing.T) {
 		// txRunner intentionally omitted
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outboxWriter and txRunner")
 }
 
-func TestInit_DemoMode_TxWithoutOutbox_Succeeds(t *testing.T) {
+func TestInit_DemoMode_TxWithoutOutbox_Fails(t *testing.T) {
 	c := NewAuditCore(
 		WithAuditRepository(mem.NewAuditRepository()),
 		WithArchiveStore(mem.NewArchiveStore()),
@@ -152,17 +153,19 @@ func TestInit_DemoMode_TxWithoutOutbox_Succeeds(t *testing.T) {
 		// outboxWriter intentionally omitted
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outboxWriter and txRunner")
 }
 
-func TestInit_DemoMode_NoPublisherNoOutbox_SucceedsWithNoopEmitter(t *testing.T) {
+func TestInit_DemoMode_NoPublisherNoOutbox_Fails(t *testing.T) {
 	c := NewAuditCore(
 		WithAuditRepository(mem.NewAuditRepository()),
 		WithArchiveStore(mem.NewArchiveStore()),
 		WithHMACKey(testHMACKey),
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit event sink")
 }
 
 func TestInit_DurableMode_RejectsNoopWriter(t *testing.T) {
@@ -195,6 +198,18 @@ func TestInit_DemoMode_WithPublisher_Succeeds(t *testing.T) {
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, err, "demo mode with publisher should succeed")
+}
+
+func TestInit_DemoMode_ExplicitNoopOutboxPair_Succeeds(t *testing.T) {
+	c := NewAuditCore(
+		WithAuditRepository(mem.NewAuditRepository()),
+		WithArchiveStore(mem.NewArchiveStore()),
+		WithHMACKey(testHMACKey),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(persistence.NoopTxRunner{}),
+	)
+	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, err)
 }
 
 func TestAuditCore_RegisterRoutes(t *testing.T) {

--- a/cells/auditcore/cell_test.go
+++ b/cells/auditcore/cell_test.go
@@ -127,10 +127,9 @@ func TestAuditCore_HMACKeyFromConfig(t *testing.T) {
 	require.NoError(t, c.Init(ctx, deps))
 }
 
-// --- L2 Hard Gate: XOR constraint + publisher check ---
+// --- L2 Hard Gate: durable-mode dependency checks ---
 
-func TestInit_TxRunnerXOR_OutboxWithoutTx(t *testing.T) {
-	// outboxWriter present but txRunner missing → XOR mismatch → error
+func TestInit_DemoMode_OutboxWithoutTx_Succeeds(t *testing.T) {
 	c := NewAuditCore(
 		WithAuditRepository(mem.NewAuditRepository()),
 		WithArchiveStore(mem.NewArchiveStore()),
@@ -140,15 +139,10 @@ func TestInit_TxRunnerXOR_OutboxWithoutTx(t *testing.T) {
 		// txRunner intentionally omitted
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
-	require.Error(t, err)
-	var ecErr *errcode.Error
-	require.ErrorAs(t, err, &ecErr)
-	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
-	assert.Contains(t, err.Error(), "both outboxWriter and txRunner")
+	require.NoError(t, err)
 }
 
-func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
-	// txRunner present but outboxWriter missing → XOR mismatch → error
+func TestInit_DemoMode_TxWithoutOutbox_Succeeds(t *testing.T) {
 	c := NewAuditCore(
 		WithAuditRepository(mem.NewAuditRepository()),
 		WithArchiveStore(mem.NewArchiveStore()),
@@ -158,26 +152,17 @@ func TestInit_TxRunnerXOR_TxWithoutOutbox(t *testing.T) {
 		// outboxWriter intentionally omitted
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
-	require.Error(t, err)
-	var ecErr *errcode.Error
-	require.ErrorAs(t, err, &ecErr)
-	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
-	assert.Contains(t, err.Error(), "both outboxWriter and txRunner")
+	require.NoError(t, err)
 }
 
-func TestInit_DemoMode_RequiresPublisher(t *testing.T) {
+func TestInit_DemoMode_NoPublisherNoOutbox_SucceedsWithNoopEmitter(t *testing.T) {
 	c := NewAuditCore(
 		WithAuditRepository(mem.NewAuditRepository()),
 		WithArchiveStore(mem.NewArchiveStore()),
 		WithHMACKey(testHMACKey),
-		// No outboxWriter, no txRunner, no publisher.
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: map[string]any{}, DurabilityMode: cell.DurabilityDemo})
-	require.Error(t, err)
-	var ecErr *errcode.Error
-	require.ErrorAs(t, err, &ecErr)
-	assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
-	assert.Contains(t, err.Error(), "publisher")
+	require.NoError(t, err)
 }
 
 func TestInit_DurableMode_RejectsNoopWriter(t *testing.T) {

--- a/cells/auditcore/slices/auditappend/outbox_test.go
+++ b/cells/auditcore/slices/auditappend/outbox_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/auditcore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +32,7 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 func TestService_WithOutboxWriter(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(ow))
 
 	entry := outbox.Entry{
 		ID:        "evt-1",
@@ -49,7 +48,7 @@ func TestService_WithOutboxWriter(t *testing.T) {
 func TestService_WithTxManager(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	tx := &stubTxRunner{}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(), WithTxManager(tx))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithTxManager(tx))
 
 	entry := outbox.Entry{
 		ID:        "evt-1",
@@ -65,7 +64,7 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(),
+	svc := NewService(repo, testHMACKey, slog.Default(),
 		WithOutboxWriter(ow), WithTxManager(tx))
 
 	entry := outbox.Entry{

--- a/cells/auditcore/slices/auditappend/outbox_test.go
+++ b/cells/auditcore/slices/auditappend/outbox_test.go
@@ -2,6 +2,7 @@ package auditappend
 
 import (
 	"context"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -29,10 +30,10 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 
 // --- tests ---
 
-func TestService_WithOutboxWriter(t *testing.T) {
+func TestService_WithEmitter(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	entry := outbox.Entry{
 		ID:        "evt-1",
@@ -65,7 +66,7 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
 	svc := NewService(repo, testHMACKey, slog.Default(),
-		WithOutboxWriter(ow), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTxManager(tx))
 
 	entry := outbox.Entry{
 		ID:        "evt-1",

--- a/cells/auditcore/slices/auditappend/service.go
+++ b/cells/auditcore/slices/auditappend/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ghbvf/gocell/cells/auditcore/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -38,40 +37,52 @@ var Topics = []string{
 // Option configures an audit-append Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service appends events to the hash chain and persists them.
 type Service struct {
-	mu           sync.Mutex
-	repo         ports.AuditRepository
-	chain        *domain.HashChain
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	mu       sync.Mutex
+	repo     ports.AuditRepository
+	chain    *domain.HashChain
+	txRunner persistence.TxRunner
+	emitter  outbox.Emitter
+	logger   *slog.Logger
 }
 
 // NewService creates an audit-append Service.
 func NewService(
 	repo ports.AuditRepository,
 	hmacKey []byte,
-	pub outbox.Publisher,
 	logger *slog.Logger,
 	opts ...Option,
 ) *Service {
 	s := &Service{
-		repo:      repo,
-		chain:     domain.NewHashChain(hmacKey),
-		publisher: pub,
-		logger:    logger,
+		repo:     repo,
+		chain:    domain.NewHashChain(hmacKey),
+		txRunner: persistence.NoopTxRunner{},
+		emitter:  outbox.NewNoopEmitter(),
+		logger:   logger,
 	}
 	for _, o := range opts {
 		o(s)
@@ -137,17 +148,6 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) error {
 		return persistErr
 	}
 
-	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
-	// so the eventbus fail-closed schema check (P1-14) accepts the message.
-	if s.outboxWriter == nil {
-		envelope := outboxrt.MarshalDirectEnvelope(TopicAuditAppended, TopicAuditAppended, outbox.NewEntryID(), appendedPayload)
-		if pubErr := s.publisher.Publish(ctx, TopicAuditAppended, envelope); pubErr != nil {
-			s.logger.Warn("audit-append: failed to publish appended event (demo mode)",
-				slog.Any("error", pubErr),
-				slog.String("topic", TopicAuditAppended))
-		}
-	}
-
 	s.logger.Info("audit entry appended",
 		slog.String("entry_id", auditEntry.ID),
 		slog.String("event_type", entry.EventType))
@@ -161,10 +161,7 @@ func (s *Service) buildPersistFn(auditEntry *domain.AuditEntry, appendedPayload 
 		if err := s.repo.Append(txCtx, auditEntry); err != nil {
 			return err
 		}
-		if s.outboxWriter == nil {
-			return nil
-		}
-		return s.outboxWriter.Write(txCtx, outbox.Entry{
+		return s.emitter.Emit(txCtx, outbox.Entry{
 			ID:        outbox.NewEntryID(),
 			EventType: TopicAuditAppended,
 			Payload:   appendedPayload,
@@ -172,14 +169,8 @@ func (s *Service) buildPersistFn(auditEntry *domain.AuditEntry, appendedPayload 
 	}
 }
 
-// runPersist executes fn in a transaction if txRunner is configured, otherwise
-// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
-// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runPersist(ctx context.Context, fn func(context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }
 
 // ChainLen returns the number of entries in the chain (for testing).

--- a/cells/auditcore/slices/auditappend/service.go
+++ b/cells/auditcore/slices/auditappend/service.go
@@ -46,15 +46,6 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }

--- a/cells/auditcore/slices/auditappend/service_test.go
+++ b/cells/auditcore/slices/auditappend/service_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/auditcore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,8 +18,7 @@ var testHMACKey = []byte("test-hmac-key-32bytes-long!!!!!!!")
 
 func newTestService() (*Service, *mem.AuditRepository) {
 	repo := mem.NewAuditRepository()
-	eb := eventbus.New()
-	return NewService(repo, testHMACKey, eb, slog.Default()), repo
+	return NewService(repo, testHMACKey, slog.Default()), repo
 }
 
 func TestService_HandleEvent(t *testing.T) {
@@ -93,10 +91,9 @@ func TestService_HandleEvent_ChainGrows(t *testing.T) {
 
 func TestService_HandleEvent_InvalidPayload_LogsWarning(t *testing.T) {
 	repo := mem.NewAuditRepository()
-	eb := eventbus.New()
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	svc := NewService(repo, testHMACKey, eb, logger)
+	svc := NewService(repo, testHMACKey, logger)
 
 	entry := outbox.Entry{
 		ID:        "evt-bad-json",
@@ -127,14 +124,16 @@ func (f failingPublisher) Close(_ context.Context) error                       {
 func TestService_HandleEvent_PublishError_DoesNotFailAppend(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
-	svc := NewService(repo, testHMACKey, fp, slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, slog.Default())
+	require.NoError(t, err)
+	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(emitter))
 
 	entry := outbox.Entry{
 		ID:        "evt-pub-err",
 		EventType: "event.user.created.v1",
 		Payload:   mustJSON(map[string]any{"user_id": "usr-1"}),
 	}
-	err := svc.HandleEvent(context.Background(), entry)
+	err = svc.HandleEvent(context.Background(), entry)
 	require.NoError(t, err, "publish failure in demo mode should not fail append")
 	assert.Equal(t, 1, svc.ChainLen(), "entry should still be appended to chain")
 }

--- a/cells/auditcore/slices/auditverify/outbox_test.go
+++ b/cells/auditcore/slices/auditverify/outbox_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ghbvf/gocell/cells/auditcore/internal/domain"
 	"github.com/ghbvf/gocell/cells/auditcore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +44,7 @@ func (f *failingTxRunner) RunInTx(_ context.Context, _ func(context.Context) err
 func TestService_WithOutboxWriter(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(ow))
 
 	// Build a small valid chain.
 	chain := domain.NewHashChain(testHMACKey)
@@ -67,7 +66,7 @@ func TestService_WithOutboxWriter(t *testing.T) {
 func TestService_WithTxManager(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	tx := &stubTxRunner{}
-	_ = NewService(repo, testHMACKey, eventbus.New(), slog.Default(), WithTxManager(tx))
+	_ = NewService(repo, testHMACKey, slog.Default(), WithTxManager(tx))
 	// TxManager option is set — verifying it compiles and runs.
 	assert.Equal(t, 0, tx.calls)
 }
@@ -76,7 +75,7 @@ func TestService_VerifyChain_OutboxWriteError_ReturnsError(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	failErr := fmt.Errorf("outbox write failure")
 	fw := &failingOutboxWriter{err: failErr}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(), WithOutboxWriter(fw))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(fw))
 
 	// Build a valid chain so we reach the outbox write path.
 	chain := domain.NewHashChain(testHMACKey)
@@ -98,7 +97,7 @@ func TestService_VerifyChain_WithTxRunner_RunsInTx(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(),
+	svc := NewService(repo, testHMACKey, slog.Default(),
 		WithOutboxWriter(ow), WithTxManager(tx))
 
 	chain := domain.NewHashChain(testHMACKey)
@@ -119,7 +118,7 @@ func TestService_VerifyChain_TxRunnerError_ReturnsError(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	txErr := fmt.Errorf("db connection lost")
 	ftx := &failingTxRunner{err: txErr}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(),
+	svc := NewService(repo, testHMACKey, slog.Default(),
 		WithOutboxWriter(ow), WithTxManager(ftx))
 
 	chain := domain.NewHashChain(testHMACKey)
@@ -146,7 +145,9 @@ func TestService_VerifyChain_PublishError_DoesNotFailVerify(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
 	// No outboxWriter → goes through direct-publish path.
-	svc := NewService(repo, testHMACKey, fp, slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, slog.Default())
+	require.NoError(t, err)
+	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(emitter))
 
 	chain := domain.NewHashChain(testHMACKey)
 	for i := range 3 {
@@ -163,7 +164,7 @@ func TestService_VerifyChain_PublishError_DoesNotFailVerify(t *testing.T) {
 func TestService_VerifyChain_InvalidChain_WithOutbox(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, testHMACKey, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(ow))
 
 	chain := domain.NewHashChain(testHMACKey)
 	for i := range 3 {

--- a/cells/auditcore/slices/auditverify/outbox_test.go
+++ b/cells/auditcore/slices/auditverify/outbox_test.go
@@ -3,6 +3,7 @@ package auditverify
 import (
 	"context"
 	"fmt"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -41,10 +42,10 @@ func (f *failingTxRunner) RunInTx(_ context.Context, _ func(context.Context) err
 
 // --- tests ---
 
-func TestService_WithOutboxWriter(t *testing.T) {
+func TestService_WithEmitter(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	// Build a small valid chain.
 	chain := domain.NewHashChain(testHMACKey)
@@ -75,7 +76,7 @@ func TestService_VerifyChain_OutboxWriteError_ReturnsError(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	failErr := fmt.Errorf("outbox write failure")
 	fw := &failingOutboxWriter{err: failErr}
-	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(fw))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, fw)))
 
 	// Build a valid chain so we reach the outbox write path.
 	chain := domain.NewHashChain(testHMACKey)
@@ -98,7 +99,7 @@ func TestService_VerifyChain_WithTxRunner_RunsInTx(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
 	svc := NewService(repo, testHMACKey, slog.Default(),
-		WithOutboxWriter(ow), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTxManager(tx))
 
 	chain := domain.NewHashChain(testHMACKey)
 	for i := range 3 {
@@ -119,7 +120,7 @@ func TestService_VerifyChain_TxRunnerError_ReturnsError(t *testing.T) {
 	txErr := fmt.Errorf("db connection lost")
 	ftx := &failingTxRunner{err: txErr}
 	svc := NewService(repo, testHMACKey, slog.Default(),
-		WithOutboxWriter(ow), WithTxManager(ftx))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTxManager(ftx))
 
 	chain := domain.NewHashChain(testHMACKey)
 	for i := range 3 {
@@ -164,7 +165,7 @@ func TestService_VerifyChain_PublishError_DoesNotFailVerify(t *testing.T) {
 func TestService_VerifyChain_InvalidChain_WithOutbox(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, testHMACKey, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	chain := domain.NewHashChain(testHMACKey)
 	for i := range 3 {

--- a/cells/auditcore/slices/auditverify/service.go
+++ b/cells/auditcore/slices/auditverify/service.go
@@ -37,15 +37,6 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
@@ -95,7 +86,9 @@ func (s *Service) VerifyChain(ctx context.Context, from, to int) (*VerifyResult,
 		EntriesChecked:    len(entries),
 	}
 
-	// Publish verification result via outbox (durable) or direct publish (demo).
+	// Publish the verification result through the injected emitter. Cell wiring
+	// decides whether that emitter is backed by durable outbox delivery or demo
+	// direct delivery.
 	payload, err := json.Marshal(map[string]any{
 		"valid":             valid,
 		"firstInvalidIndex": firstInvalid,

--- a/cells/auditcore/slices/auditverify/service.go
+++ b/cells/auditcore/slices/auditverify/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ghbvf/gocell/cells/auditcore/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 )
 
 const (
@@ -29,39 +28,51 @@ type VerifyResult struct {
 // Option configures an audit-verify Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service verifies hash chain integrity.
 type Service struct {
-	repo         ports.AuditRepository
-	chain        *domain.HashChain
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	repo     ports.AuditRepository
+	chain    *domain.HashChain
+	txRunner persistence.TxRunner
+	emitter  outbox.Emitter
+	logger   *slog.Logger
 }
 
 // NewService creates an audit-verify Service.
 func NewService(
 	repo ports.AuditRepository,
 	hmacKey []byte,
-	pub outbox.Publisher,
 	logger *slog.Logger,
 	opts ...Option,
 ) *Service {
 	s := &Service{
-		repo:      repo,
-		chain:     domain.NewHashChain(hmacKey),
-		publisher: pub,
-		logger:    logger,
+		repo:     repo,
+		chain:    domain.NewHashChain(hmacKey),
+		txRunner: persistence.NoopTxRunner{},
+		emitter:  outbox.NewNoopEmitter(),
+		logger:   logger,
 	}
 	for _, o := range opts {
 		o(s)
@@ -100,17 +111,6 @@ func (s *Service) VerifyChain(ctx context.Context, from, to int) (*VerifyResult,
 		return result, fmt.Errorf("audit-verify: persist: %w", persistErr)
 	}
 
-	// Fallback direct publish when outbox is not in use. Wrap in v1 wire envelope
-	// so the eventbus fail-closed schema check (P1-14) accepts the message.
-	if s.outboxWriter == nil {
-		envelope := outboxrt.MarshalDirectEnvelope(TopicIntegrityVerified, TopicIntegrityVerified, outbox.NewEntryID(), payload)
-		if pubErr := s.publisher.Publish(ctx, TopicIntegrityVerified, envelope); pubErr != nil {
-			s.logger.Warn("audit-verify: failed to publish event (demo mode)",
-				slog.Any("error", pubErr),
-				slog.String("topic", TopicIntegrityVerified))
-		}
-	}
-
 	s.logger.Info("hash chain verification completed",
 		slog.Bool("valid", valid), slog.Int("entries_checked", len(entries)))
 
@@ -120,10 +120,7 @@ func (s *Service) VerifyChain(ctx context.Context, from, to int) (*VerifyResult,
 // buildPersistFn returns a transaction function that writes the outbox event.
 func (s *Service) buildPersistFn(payload []byte) func(context.Context) error {
 	return func(txCtx context.Context) error {
-		if s.outboxWriter == nil {
-			return nil
-		}
-		return s.outboxWriter.Write(txCtx, outbox.Entry{
+		return s.emitter.Emit(txCtx, outbox.Entry{
 			ID:        outbox.NewEntryID(),
 			EventType: TopicIntegrityVerified,
 			Payload:   payload,
@@ -131,12 +128,6 @@ func (s *Service) buildPersistFn(payload []byte) func(context.Context) error {
 	}
 }
 
-// runPersist executes fn in a transaction if txRunner is configured, otherwise
-// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
-// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runPersist(ctx context.Context, fn func(context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }

--- a/cells/auditcore/slices/auditverify/service_test.go
+++ b/cells/auditcore/slices/auditverify/service_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/auditcore/internal/domain"
 	"github.com/ghbvf/gocell/cells/auditcore/internal/mem"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,8 +15,7 @@ var testHMACKey = []byte("test-hmac-key-32bytes-long!!!!!!!")
 
 func newTestService() (*Service, *mem.AuditRepository) {
 	repo := mem.NewAuditRepository()
-	eb := eventbus.New()
-	return NewService(repo, testHMACKey, eb, slog.Default()), repo
+	return NewService(repo, testHMACKey, slog.Default()), repo
 }
 
 func TestService_VerifyChain_Empty(t *testing.T) {

--- a/cells/configcore/cell.go
+++ b/cells/configcore/cell.go
@@ -238,9 +238,8 @@ func (c *ConfigCore) deriveModes(durabilityMode cell.DurabilityMode) (query.RunM
 	return query.RunModeForDemo(demo), configpublish.PublishFailureModeForDemo(demo)
 }
 
-// validateOutboxDeps enforces the XOR constraint (outboxWriter + txRunner
-// must be both present or both absent) and rejects noop implementations in
-// durable mode.
+// validateOutboxDeps rejects noop implementations in durable mode and requires
+// demo mode to use an explicit event sink instead of synthesized defaults.
 func (c *ConfigCore) validateOutboxDeps(deps cell.Dependencies, publishFailureMode configpublish.PublishFailureMode) error {
 	if err := cell.CheckNotNoop(deps.DurabilityMode, "configcore", c.outboxWriter, c.txRunner, c.publisher); err != nil {
 		return err
@@ -256,6 +255,14 @@ func (c *ConfigCore) validateOutboxDeps(deps cell.Dependencies, publishFailureMo
 		}
 		c.emitter = emitter
 		return nil
+	}
+	if (c.outboxWriter == nil) != (c.txRunner == nil) {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"configcore demo mode requires outboxWriter and txRunner together; inject both explicitly")
+	}
+	if c.publisher == nil && c.outboxWriter == nil {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"configcore demo mode requires an explicit event sink; provide publisher or outboxWriter+txRunner")
 	}
 
 	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
@@ -279,7 +286,8 @@ func (c *ConfigCore) resolveDemoEmitter(publishFailureMode configpublish.Publish
 	if c.outboxWriter != nil {
 		return outbox.NewWriterEmitter(c.outboxWriter)
 	}
-	return outbox.NewNoopEmitter(), nil
+	return nil, errcode.New(errcode.ErrCellMissingOutbox,
+		"configcore demo mode requires an explicit event sink")
 }
 
 func configDirectPublishMode(mode configpublish.PublishFailureMode) outbox.DirectPublishFailureMode {

--- a/cells/configcore/cell.go
+++ b/cells/configcore/cell.go
@@ -213,7 +213,7 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := c.initReadSlice(runMode); err != nil {
 		return err
 	}
-	c.initPublishSlice(publishFailureMode)
+	c.initPublishSlice()
 	c.initSubscribeSlice()
 	if err := c.initFlagSlice(runMode); err != nil {
 		return err
@@ -333,11 +333,10 @@ func (c *ConfigCore) initReadSlice(runMode query.RunMode) error {
 	return nil
 }
 
-func (c *ConfigCore) initPublishSlice(publishFailureMode configpublish.PublishFailureMode) {
+func (c *ConfigCore) initPublishSlice() {
 	opts := []configpublish.Option{
 		configpublish.WithEmitter(c.emitter),
 		configpublish.WithTxManager(c.txRunner),
-		configpublish.WithPublishFailureMode(publishFailureMode),
 	}
 	publishSvc := configpublish.NewService(c.configRepo, c.logger, opts...)
 	c.publishHandler = configpublish.NewHandler(publishSvc)

--- a/cells/configcore/cell.go
+++ b/cells/configcore/cell.go
@@ -143,6 +143,7 @@ type ConfigCore struct {
 	publisher          outbox.Publisher
 	outboxWriter       outbox.Writer
 	txRunner           persistence.TxRunner
+	emitter            outbox.Emitter
 	cursorCodec        *query.CursorCodec
 	logger             *slog.Logger
 	keyProvider        kcrypto.KeyProvider
@@ -199,14 +200,15 @@ func (c *ConfigCore) Init(ctx context.Context, deps cell.Dependencies) error {
 		c.flagRepo = cellpg.NewFlagRepository(session)
 	}
 
-	if err := c.validateOutboxDeps(deps); err != nil {
+	runMode, publishFailureMode := c.deriveModes(deps.DurabilityMode)
+
+	if err := c.validateOutboxDeps(deps, publishFailureMode); err != nil {
 		return err
 	}
 	if err := c.ensureCursorCodec(deps); err != nil {
 		return err
 	}
 
-	runMode, publishFailureMode := c.deriveModes(deps.DurabilityMode)
 	c.initWriteSlice()
 	if err := c.initReadSlice(runMode); err != nil {
 		return err
@@ -239,28 +241,57 @@ func (c *ConfigCore) deriveModes(durabilityMode cell.DurabilityMode) (query.RunM
 // validateOutboxDeps enforces the XOR constraint (outboxWriter + txRunner
 // must be both present or both absent) and rejects noop implementations in
 // durable mode.
-func (c *ConfigCore) validateOutboxDeps(deps cell.Dependencies) error {
-	// XOR constraint: both present = durable mode; both absent = demo mode.
-	if (c.outboxWriter == nil) != (c.txRunner == nil) {
-		return errcode.New(errcode.ErrCellMissingOutbox,
-			"configcore durable mode requires both outboxWriter and txRunner")
-	}
+func (c *ConfigCore) validateOutboxDeps(deps cell.Dependencies, publishFailureMode configpublish.PublishFailureMode) error {
 	if err := cell.CheckNotNoop(deps.DurabilityMode, "configcore", c.outboxWriter, c.txRunner, c.publisher); err != nil {
 		return err
 	}
-	// Demo mode: require publisher for degraded event delivery.
-	if c.outboxWriter == nil && c.txRunner == nil {
-		if c.publisher == nil {
+	if deps.DurabilityMode == cell.DurabilityDurable {
+		if c.outboxWriter == nil || c.txRunner == nil {
 			return errcode.New(errcode.ErrCellMissingOutbox,
-				"configcore requires publisher or outbox writer; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
+				"configcore durable mode requires real outboxWriter and txRunner")
 		}
-		if c.ConsistencyLevel() >= cell.L2 {
-			c.logger.Warn("configcore: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",
-				slog.String("cell", c.ID()),
-				slog.Int("consistency_level", int(c.ConsistencyLevel())))
+		emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
+		if err != nil {
+			return err
 		}
+		c.emitter = emitter
+		return nil
+	}
+
+	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
+	emitter, err := c.resolveDemoEmitter(publishFailureMode)
+	if err != nil {
+		return err
+	}
+	c.emitter = emitter
+	if c.ConsistencyLevel() >= cell.L2 && c.outboxWriter == nil {
+		c.logger.Warn("configcore: running without outboxWriter+txRunner, L2 transactional atomicity not guaranteed (demo mode)",
+			slog.String("cell", c.ID()),
+			slog.Int("consistency_level", int(c.ConsistencyLevel())))
 	}
 	return nil
+}
+
+func (c *ConfigCore) resolveDemoEmitter(publishFailureMode configpublish.PublishFailureMode) (outbox.Emitter, error) {
+	if c.publisher != nil && (c.outboxWriter == nil || isNoopDep(c.outboxWriter)) {
+		return outbox.NewDirectEmitter(c.publisher, configDirectPublishMode(publishFailureMode), c.logger)
+	}
+	if c.outboxWriter != nil {
+		return outbox.NewWriterEmitter(c.outboxWriter)
+	}
+	return outbox.NewNoopEmitter(), nil
+}
+
+func configDirectPublishMode(mode configpublish.PublishFailureMode) outbox.DirectPublishFailureMode {
+	if mode.IsFailOpen() {
+		return outbox.DirectPublishFailOpen
+	}
+	return outbox.DirectPublishFailClosed
+}
+
+func isNoopDep(dep any) bool {
+	n, ok := dep.(interface{ Noop() bool })
+	return ok && n.Noop()
 }
 
 // ensureCursorCodec sets a default cursor codec in demo mode or returns an
@@ -286,14 +317,8 @@ func (c *ConfigCore) ensureCursorCodec(deps cell.Dependencies) error {
 }
 
 func (c *ConfigCore) initWriteSlice() {
-	var opts []configwrite.Option
-	if c.outboxWriter != nil {
-		opts = append(opts, configwrite.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		opts = append(opts, configwrite.WithTxManager(c.txRunner))
-	}
-	writeSvc := configwrite.NewService(c.configRepo, c.publisher, c.logger, opts...)
+	opts := []configwrite.Option{configwrite.WithEmitter(c.emitter), configwrite.WithTxManager(c.txRunner)}
+	writeSvc := configwrite.NewService(c.configRepo, c.logger, opts...)
 	c.writeHandler = configwrite.NewHandler(writeSvc)
 	c.AddSlice(cell.NewBaseSlice("configwrite", "configcore", cell.L2))
 }
@@ -309,15 +334,12 @@ func (c *ConfigCore) initReadSlice(runMode query.RunMode) error {
 }
 
 func (c *ConfigCore) initPublishSlice(publishFailureMode configpublish.PublishFailureMode) {
-	var opts []configpublish.Option
-	if c.outboxWriter != nil {
-		opts = append(opts, configpublish.WithOutboxWriter(c.outboxWriter))
+	opts := []configpublish.Option{
+		configpublish.WithEmitter(c.emitter),
+		configpublish.WithTxManager(c.txRunner),
+		configpublish.WithPublishFailureMode(publishFailureMode),
 	}
-	if c.txRunner != nil {
-		opts = append(opts, configpublish.WithTxManager(c.txRunner))
-	}
-	opts = append(opts, configpublish.WithPublishFailureMode(publishFailureMode))
-	publishSvc := configpublish.NewService(c.configRepo, c.publisher, c.logger, opts...)
+	publishSvc := configpublish.NewService(c.configRepo, c.logger, opts...)
 	c.publishHandler = configpublish.NewHandler(publishSvc)
 	c.AddSlice(cell.NewBaseSlice("configpublish", "configcore", cell.L2))
 }
@@ -340,13 +362,7 @@ func (c *ConfigCore) initFlagSlice(runMode query.RunMode) error {
 // initFlagWriteSlice registers the flag-write L2 slice: Create/Update/Toggle/Delete
 // with transactional outbox (flag.changed.v1 event).
 func (c *ConfigCore) initFlagWriteSlice() error {
-	var opts []flagwrite.Option
-	if c.outboxWriter != nil {
-		opts = append(opts, flagwrite.WithOutboxWriter(c.outboxWriter))
-	}
-	if c.txRunner != nil {
-		opts = append(opts, flagwrite.WithTxManager(c.txRunner))
-	}
+	opts := []flagwrite.Option{flagwrite.WithEmitter(c.emitter), flagwrite.WithTxManager(c.txRunner)}
 	flagWriteSvc, err := flagwrite.NewService(c.flagRepo, c.logger, opts...)
 	if err != nil {
 		return fmt.Errorf("configcore: init flag-write slice: %w", err)

--- a/cells/configcore/cell_test.go
+++ b/cells/configcore/cell_test.go
@@ -89,7 +89,7 @@ func TestConfigCore_Startup(t *testing.T) {
 	require.NoError(t, c.Stop(ctx))
 }
 
-func TestConfigCore_InitRejectsHalfConfiguredDurablePath(t *testing.T) {
+func TestConfigCore_InitDemoMode_AllowsHalfConfiguredPath(t *testing.T) {
 	tests := []struct {
 		name string
 		opts []Option
@@ -116,10 +116,7 @@ func TestConfigCore_InitRejectsHalfConfiguredDurablePath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewConfigCore(tt.opts...)
 			err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
-			require.Error(t, err)
-			var ecErr *errcode.Error
-			require.ErrorAs(t, err, &ecErr)
-			assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -143,11 +140,10 @@ func TestConfigCore_InitDurableMode_RejectsNoopWriter(t *testing.T) {
 	assert.Contains(t, err.Error(), "durable mode")
 }
 
-func TestConfigCore_InitDemoMode_RequiresPublisher(t *testing.T) {
+func TestConfigCore_InitDemoMode_NoPublisherNoOutbox_SucceedsWithNoopEmitter(t *testing.T) {
 	c := NewConfigCore(WithInMemoryDefaults())
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "publisher")
+	require.NoError(t, err)
 }
 
 func TestConfigCore_InitDemoMode_WithPublisher_Succeeds(t *testing.T) {

--- a/cells/configcore/cell_test.go
+++ b/cells/configcore/cell_test.go
@@ -89,7 +89,7 @@ func TestConfigCore_Startup(t *testing.T) {
 	require.NoError(t, c.Stop(ctx))
 }
 
-func TestConfigCore_InitDemoMode_AllowsHalfConfiguredPath(t *testing.T) {
+func TestConfigCore_InitDemoMode_RejectsHalfConfiguredPath(t *testing.T) {
 	tests := []struct {
 		name string
 		opts []Option
@@ -116,7 +116,8 @@ func TestConfigCore_InitDemoMode_AllowsHalfConfiguredPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewConfigCore(tt.opts...)
 			err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
-			require.NoError(t, err)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "outboxWriter and txRunner")
 		})
 	}
 }
@@ -140,16 +141,27 @@ func TestConfigCore_InitDurableMode_RejectsNoopWriter(t *testing.T) {
 	assert.Contains(t, err.Error(), "durable mode")
 }
 
-func TestConfigCore_InitDemoMode_NoPublisherNoOutbox_SucceedsWithNoopEmitter(t *testing.T) {
+func TestConfigCore_InitDemoMode_NoPublisherNoOutbox_Fails(t *testing.T) {
 	c := NewConfigCore(WithInMemoryDefaults())
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit event sink")
 }
 
 func TestConfigCore_InitDemoMode_WithPublisher_Succeeds(t *testing.T) {
 	c := NewConfigCore(
 		WithInMemoryDefaults(),
 		WithPublisher(eventbus.New()),
+	)
+	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, err)
+}
+
+func TestConfigCore_InitDemoMode_ExplicitNoopOutboxPair_Succeeds(t *testing.T) {
+	c := NewConfigCore(
+		WithInMemoryDefaults(),
+		WithOutboxWriter(outbox.NoopWriter{}),
+		WithTxManager(persistence.NoopTxRunner{}),
 	)
 	err := c.Init(context.Background(), cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, err)

--- a/cells/configcore/slices/configpublish/contract_test.go
+++ b/cells/configcore/slices/configpublish/contract_test.go
@@ -21,7 +21,7 @@ import (
 func newContractService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }

--- a/cells/configcore/slices/configpublish/contract_test.go
+++ b/cells/configcore/slices/configpublish/contract_test.go
@@ -3,6 +3,7 @@ package configpublish
 import (
 	"context"
 	"encoding/json"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -18,11 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newContractService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+func newContractService(t testing.TB) (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+	t.Helper()
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -51,7 +53,7 @@ func newContractMux(svc *Service) *http.ServeMux {
 func TestHttpConfigPublishV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.publish.v1")
-	svc, repo, _ := newContractService()
+	svc, repo, _ := newContractService(t)
 	seedContractEntry(repo, "app.name", "value")
 
 	mux := newContractMux(svc)
@@ -72,7 +74,7 @@ func TestHttpConfigPublishV1Serve(t *testing.T) {
 func TestHttpConfigRollbackV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.rollback.v1")
-	svc, repo, _ := newContractService()
+	svc, repo, _ := newContractService(t)
 	seedContractEntry(repo, "app.name", "value")
 
 	// Publish first to create version 1 so rollback target exists.
@@ -114,7 +116,7 @@ type errEnvelope struct {
 func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.publish.v1")
-	svc, _, _ := newContractService()
+	svc, _, _ := newContractService(t)
 	mux := newContractMux(svc)
 
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
@@ -157,7 +159,7 @@ func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.rollback.v1")
-	svc, _, _ := newContractService()
+	svc, _, _ := newContractService(t)
 	mux := newContractMux(svc)
 
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
@@ -196,7 +198,7 @@ func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 func TestEventConfigChangedV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
-	svc, repo, writer := newContractService()
+	svc, repo, writer := newContractService(t)
 	seedContractEntry(repo, "app.name", "value")
 
 	_, err := svc.Publish(context.Background(), "app.name")
@@ -213,7 +215,7 @@ func TestEventConfigChangedV1Publish(t *testing.T) {
 func TestEventConfigRollbackV1Publish(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.rollback.v1")
-	svc, repo, writer := newContractService()
+	svc, repo, writer := newContractService(t)
 	seedContractEntry(repo, "app.name", "v1")
 
 	// Publish first to create a version, then rollback

--- a/cells/configcore/slices/configpublish/handler_test.go
+++ b/cells/configcore/slices/configpublish/handler_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,7 +97,7 @@ func TestConfigVersionResponse_OmitsNilPublishedAt(t *testing.T) {
 
 func setupHandler() (http.Handler, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
-	svc := NewService(repo, eventbus.New(), slog.Default())
+	svc := NewService(repo, slog.Default())
 	h := NewHandler(svc)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -246,7 +245,7 @@ func TestHandler_HandleRollback_OK(t *testing.T) {
 	handler, repo := setupHandler()
 	seedForPublish(t, repo, "app.name", "v1")
 	// Publish first to create a version.
-	svc := NewService(repo, eventbus.New(), slog.Default())
+	svc := NewService(repo, slog.Default())
 	_, err := svc.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
 
@@ -306,7 +305,7 @@ func TestHandler_HandleRollback_SensitiveRedacted(t *testing.T) {
 		Version: 1, CreatedAt: now, UpdatedAt: now,
 	}))
 	// Publish v1 carries Sensitive=true into the snapshot.
-	svc := NewService(repo, eventbus.New(), slog.Default())
+	svc := NewService(repo, slog.Default())
 	_, err := svc.Publish(context.Background(), "db.password")
 	require.NoError(t, err)
 
@@ -383,7 +382,7 @@ func TestHandler_HandleRollback_InvalidVersion(t *testing.T) {
 func TestService_WithOutboxWriter(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
 
 	seedForService(repo, "k1", "v1")
 	_, err := svc.Publish(context.Background(), "k1")
@@ -396,7 +395,7 @@ func TestService_WithOutboxWriter(t *testing.T) {
 func TestService_WithTxManager(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	tx := &stubTxRunner{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithTxManager(tx))
+	svc := NewService(repo, slog.Default(), WithTxManager(tx))
 
 	seedForService(repo, "k2", "v2")
 	_, err := svc.Publish(context.Background(), "k2")
@@ -408,7 +407,7 @@ func TestService_WithTxManager(t *testing.T) {
 func TestService_Rollback_WithOutbox(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
 
 	seedForService(repo, "k3", "v3")
 	_, err := svc.Publish(context.Background(), "k3")

--- a/cells/configcore/slices/configpublish/handler_test.go
+++ b/cells/configcore/slices/configpublish/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -379,10 +380,10 @@ func TestHandler_HandleRollback_InvalidVersion(t *testing.T) {
 
 // --- outbox/tx tests ---
 
-func TestService_WithOutboxWriter(t *testing.T) {
+func TestService_WithEmitter(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	seedForService(repo, "k1", "v1")
 	_, err := svc.Publish(context.Background(), "k1")
@@ -407,7 +408,7 @@ func TestService_WithTxManager(t *testing.T) {
 func TestService_Rollback_WithOutbox(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	seedForService(repo, "k3", "v3")
 	_, err := svc.Publish(context.Background(), "k3")

--- a/cells/configcore/slices/configpublish/service.go
+++ b/cells/configcore/slices/configpublish/service.go
@@ -32,26 +32,10 @@ const (
 // Option configures a config-publish Service.
 type Option func(*Service)
 
-func directPublishMode(mode PublishFailureMode) outbox.DirectPublishFailureMode {
-	if mode.IsFailOpen() {
-		return outbox.DirectPublishFailOpen
-	}
-	return outbox.DirectPublishFailClosed
-}
-
 // WithEmitter sets the event emitter.
 func WithEmitter(e outbox.Emitter) Option {
 	return func(s *Service) {
 		if e != nil {
-			s.emitter = e
-		}
-	}
-}
-
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
 			s.emitter = e
 		}
 	}
@@ -62,22 +46,12 @@ func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
-// WithPublishFailureMode records direct-publisher failure intent for Cell-level
-// emitter construction. Zero value is fail-closed (safe production default).
-//
-// S10 MODE-SEMANTIC-SPLIT-01: separated from query.RunMode so read-path cursor
-// tolerance and write-path publisher failure semantics evolve independently.
-func WithPublishFailureMode(mode PublishFailureMode) Option {
-	return func(s *Service) { s.publishFailureMode = mode }
-}
-
 // Service implements config publish/rollback business logic.
 type Service struct {
-	repo               ports.ConfigRepository
-	txRunner           persistence.TxRunner
-	emitter            outbox.Emitter
-	publishFailureMode PublishFailureMode
-	logger             *slog.Logger
+	repo     ports.ConfigRepository
+	txRunner persistence.TxRunner
+	emitter  outbox.Emitter
+	logger   *slog.Logger
 }
 
 // NewService creates a config-publish Service.

--- a/cells/configcore/slices/configpublish/service.go
+++ b/cells/configcore/slices/configpublish/service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -33,18 +32,38 @@ const (
 // Option configures a config-publish Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+func directPublishMode(mode PublishFailureMode) outbox.DirectPublishFailureMode {
+	if mode.IsFailOpen() {
+		return outbox.DirectPublishFailOpen
+	}
+	return outbox.DirectPublishFailClosed
+}
+
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
-// WithPublishFailureMode sets direct-publisher failure behavior when
-// outboxWriter is nil. Zero value is fail-closed (safe production default).
+// WithPublishFailureMode records direct-publisher failure intent for Cell-level
+// emitter construction. Zero value is fail-closed (safe production default).
 //
 // S10 MODE-SEMANTIC-SPLIT-01: separated from query.RunMode so read-path cursor
 // tolerance and write-path publisher failure semantics evolve independently.
@@ -55,19 +74,19 @@ func WithPublishFailureMode(mode PublishFailureMode) Option {
 // Service implements config publish/rollback business logic.
 type Service struct {
 	repo               ports.ConfigRepository
-	publisher          outbox.Publisher
-	outboxWriter       outbox.Writer
 	txRunner           persistence.TxRunner
+	emitter            outbox.Emitter
 	publishFailureMode PublishFailureMode
 	logger             *slog.Logger
 }
 
 // NewService creates a config-publish Service.
-func NewService(repo ports.ConfigRepository, pub outbox.Publisher, logger *slog.Logger, opts ...Option) *Service {
+func NewService(repo ports.ConfigRepository, logger *slog.Logger, opts ...Option) *Service {
 	s := &Service{
-		repo:      repo,
-		publisher: pub,
-		logger:    logger,
+		repo:     repo,
+		txRunner: persistence.NoopTxRunner{},
+		emitter:  outbox.NewNoopEmitter(),
+		logger:   logger,
 	}
 	for _, o := range opts {
 		o(s)
@@ -174,50 +193,19 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 	return updated, nil
 }
 
-// runInTx executes fn in a transaction if txRunner is configured, otherwise
-// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
-// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }
 
-// publishEvent writes to the outbox (L2 durable) or directly via publisher
-// (fallback when outboxWriter is nil, e.g. demo assemblies using DiscardPublisher).
-// PublishFailureMode controls whether direct-publisher failures are propagated
-// (fail-closed, the safe default for production) or tolerated after a warning
-// (fail-open, the demo-mode behavior when the publisher is degraded but the
-// write path should not block). DiscardPublisher never errors by contract, so
-// any publisher failure indicates a real infrastructure problem.
+// publishEvent emits the config event through the injected emitter.
 func (s *Service) publishEvent(ctx context.Context, topic string, payload []byte) error {
-	if s.outboxWriter != nil {
-		entry := outbox.Entry{
-			ID:        outbox.NewEntryID(),
-			EventType: topic,
-			Payload:   payload,
-		}
-		if err := s.outboxWriter.Write(ctx, entry); err != nil {
-			return fmt.Errorf("config-publish: write outbox entry: %w", err)
-		}
-		return nil
+	entry := outbox.Entry{
+		ID:        outbox.NewEntryID(),
+		EventType: topic,
+		Payload:   payload,
 	}
-	// Wrap in v1 wire envelope so the eventbus fail-closed schema check (P1-14)
-	// accepts the message.
-	envelope := outboxrt.MarshalDirectEnvelope(topic, topic, outbox.NewEntryID(), payload)
-	if err := s.publisher.Publish(ctx, topic, envelope); err != nil {
-		if s.publishFailureMode.IsFailOpen() {
-			// topic + error are sufficient for demo-mode triage; the key is inside
-			// the serialized payload and would require unmarshaling to extract.
-			s.logger.Warn("config-publish: publisher failed (fail-open mode)",
-				slog.String("topic", topic),
-				slog.String("publish_failure_mode", s.publishFailureMode.String()),
-				slog.String("error", err.Error()),
-			)
-			return nil
-		}
-		return fmt.Errorf("config-publish: publisher failed for topic %s: %w", topic, err)
+	if err := s.emitter.Emit(ctx, entry); err != nil {
+		return fmt.Errorf("config-publish: emit event for topic %s: %w", topic, err)
 	}
 	return nil
 }

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -5,6 +5,7 @@ package configpublish
 import (
 	"context"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 	"time"
@@ -64,7 +65,7 @@ func setupPublishBundle(t *testing.T) (publishServiceBundle, func()) {
 	txMgr := adapterpg.NewTxManager(pool)
 
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(outboxWriter),
+		WithEmitter(testoutbox.MustEmitter(t, outboxWriter)),
 		WithTxManager(txMgr),
 	)
 
@@ -213,7 +214,7 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 	// First: seed and publish using a good writer.
 	goodWriter := adapterpg.NewOutboxWriter()
 	svcGood := NewService(repo, slog.Default(),
-		WithOutboxWriter(goodWriter),
+		WithEmitter(testoutbox.MustEmitter(t, goodWriter)),
 		WithTxManager(txMgr),
 	)
 
@@ -230,7 +231,7 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 	// Now inject a failing writer — simulates outbox broker down during Rollback.
 	failingWriter := &recordingWriter{err: errors.New("outbox broker down")}
 	svcFail := NewService(repo, slog.Default(),
-		WithOutboxWriter(failingWriter),
+		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
 		WithTxManager(txMgr),
 	)
 

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -63,7 +63,7 @@ func setupPublishBundle(t *testing.T) (publishServiceBundle, func()) {
 	outboxWriter := adapterpg.NewOutboxWriter()
 	txMgr := adapterpg.NewTxManager(pool)
 
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(outboxWriter),
 		WithTxManager(txMgr),
 	)
@@ -212,7 +212,7 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 
 	// First: seed and publish using a good writer.
 	goodWriter := adapterpg.NewOutboxWriter()
-	svcGood := NewService(repo, stubPublisher{}, slog.Default(),
+	svcGood := NewService(repo, slog.Default(),
 		WithOutboxWriter(goodWriter),
 		WithTxManager(txMgr),
 	)
@@ -229,7 +229,7 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 
 	// Now inject a failing writer — simulates outbox broker down during Rollback.
 	failingWriter := &recordingWriter{err: errors.New("outbox broker down")}
-	svcFail := NewService(repo, stubPublisher{}, slog.Default(),
+	svcFail := NewService(repo, slog.Default(),
 		WithOutboxWriter(failingWriter),
 		WithTxManager(txMgr),
 	)

--- a/cells/configcore/slices/configpublish/service_test.go
+++ b/cells/configcore/slices/configpublish/service_test.go
@@ -10,23 +10,29 @@ import (
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func newTestService() (*Service, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
-	eb := eventbus.New()
 	logger := slog.Default()
-	return NewService(repo, eb, logger), repo
+	return NewService(repo, logger), repo
+}
+
+func newDirectTestEmitter(t *testing.T, pub outbox.Publisher, mode outbox.DirectPublishFailureMode) outbox.Emitter {
+	t.Helper()
+	emitter, err := outbox.NewDirectEmitter(pub, mode, slog.Default())
+	require.NoError(t, err)
+	return emitter
 }
 
 func newDurableTestService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
@@ -128,7 +134,8 @@ func TestService_Rollback(t *testing.T) {
 func TestService_Publish_PublisherError_Propagates(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker unavailable")}
-	svc := NewService(repo, pub, slog.Default()) // no outboxWriter → publisher path; error propagates
+	svc := NewService(repo, slog.Default(),
+		WithEmitter(newDirectTestEmitter(t, pub, outbox.DirectPublishFailClosed)))
 
 	mustSeedEntry(repo, "k", "v1")
 	_, err := svc.Publish(context.Background(), "k")
@@ -141,7 +148,7 @@ func TestService_Publish_PublisherError_Propagates(t *testing.T) {
 func TestService_Publish_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	mustSeedEntry(repo, "app.name", "value")
 
@@ -153,12 +160,12 @@ func TestService_Publish_OutboxWriteError(t *testing.T) {
 func TestService_Rollback_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	mustSeedEntry(repo, "app.name", "v1")
 	// Publish first (use a working writer), then swap to failing writer for rollback.
 	goodWriter := &testutil.RecordingWriter{}
-	svcGood := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svcGood := NewService(repo, slog.Default(),
 		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
@@ -186,7 +193,7 @@ func TestPublishVersion_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	mustSeedEntry(repo, "app.name", "value")
@@ -200,7 +207,7 @@ func TestPublishVersion_CallsTxRunnerRunInTxOnce(t *testing.T) {
 // Sensitive flag so downstream consumers (handler, postgres replay) can redact uniformly.
 func TestService_Publish_SensitiveEntry_VersionCarriesFlag(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default())
+	svc := NewService(repo, slog.Default())
 	now := time.Now()
 	require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
 		ID: "cfg-secret", Key: "db.password", Value: "s3cret!", Sensitive: true,
@@ -241,7 +248,7 @@ func TestService_Rollback_VersionNotFound(t *testing.T) {
 
 func TestService_Publish_NonSensitiveEntry_VersionFlagFalse(t *testing.T) {
 	repo := mem.NewConfigRepository()
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default())
+	svc := NewService(repo, slog.Default())
 	mustSeedEntry(repo, "app.name", "gocell")
 
 	ver, err := svc.Publish(context.Background(), "app.name")
@@ -268,7 +275,7 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := mem.NewConfigRepository()
-			svc := NewService(repo, testutil.StubPublisher{}, slog.Default())
+			svc := NewService(repo, slog.Default())
 			now := time.Now()
 			require.NoError(t, repo.Create(context.Background(), &domain.ConfigEntry{
 				ID: "cfg-x", Key: "app.x", Value: "v1", Sensitive: tt.seedSensitive,
@@ -302,7 +309,8 @@ func TestService_Rollback_RestoresSnapshotSensitivity(t *testing.T) {
 func TestService_Publish_FailClosed_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
-	svc := NewService(repo, pub, slog.Default(),
+	svc := NewService(repo, slog.Default(),
+		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailClosed))),
 		WithPublishFailureMode(PublishFailureModeFailClosed))
 
 	mustSeedEntry(repo, "app.timeout", "30s")
@@ -317,7 +325,8 @@ func TestService_Publish_FailClosed_PublisherError(t *testing.T) {
 func TestService_Publish_FailOpen_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
-	svc := NewService(repo, pub, slog.Default(),
+	svc := NewService(repo, slog.Default(),
+		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailOpen))),
 		WithPublishFailureMode(PublishFailureModeFailOpen))
 
 	mustSeedEntry(repo, "app.timeout", "30s")
@@ -331,11 +340,12 @@ func TestService_Publish_FailOpen_PublisherError(t *testing.T) {
 func TestService_Rollback_FailClosed_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
-	svc := NewService(repo, pub, slog.Default(),
+	svc := NewService(repo, slog.Default(),
+		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailClosed))),
 		WithPublishFailureMode(PublishFailureModeFailClosed))
 
 	mustSeedEntry(repo, "app.x", "v1")
-	svcOK := NewService(repo, testutil.StubPublisher{}, slog.Default())
+	svcOK := NewService(repo, slog.Default())
 	_, err := svcOK.Publish(context.Background(), "app.x")
 	require.NoError(t, err)
 
@@ -349,11 +359,12 @@ func TestService_Rollback_FailClosed_PublisherError(t *testing.T) {
 func TestService_Rollback_FailOpen_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
-	svc := NewService(repo, pub, slog.Default(),
+	svc := NewService(repo, slog.Default(),
+		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailOpen))),
 		WithPublishFailureMode(PublishFailureModeFailOpen))
 
 	mustSeedEntry(repo, "app.x", "v1")
-	svcOK := NewService(repo, testutil.StubPublisher{}, slog.Default())
+	svcOK := NewService(repo, slog.Default())
 	_, err := svcOK.Publish(context.Background(), "app.x")
 	require.NoError(t, err)
 

--- a/cells/configcore/slices/configpublish/service_test.go
+++ b/cells/configcore/slices/configpublish/service_test.go
@@ -3,6 +3,7 @@ package configpublish
 import (
 	"context"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 	"time"
@@ -29,11 +30,12 @@ func newDirectTestEmitter(t *testing.T, pub outbox.Publisher, mode outbox.Direct
 	return emitter
 }
 
-func newDurableTestService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+func newDurableTestService(t testing.TB) (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+	t.Helper()
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -149,7 +151,7 @@ func TestService_Publish_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	mustSeedEntry(repo, "app.name", "value")
 
 	_, err := svc.Publish(context.Background(), "app.name")
@@ -161,12 +163,12 @@ func TestService_Rollback_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	mustSeedEntry(repo, "app.name", "v1")
 	// Publish first (use a working writer), then swap to failing writer for rollback.
 	goodWriter := &testutil.RecordingWriter{}
 	svcGood := NewService(repo, slog.Default(),
-		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, goodWriter)), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Publish(context.Background(), "app.name")
 	require.NoError(t, err)
 
@@ -176,7 +178,7 @@ func TestService_Rollback_OutboxWriteError(t *testing.T) {
 }
 
 func TestService_Publish_DurableMode_CapturesOutboxEntry(t *testing.T) {
-	svc, repo, writer := newDurableTestService()
+	svc, repo, writer := newDurableTestService(t)
 	mustSeedEntry(repo, "app.name", "value")
 
 	ver, err := svc.Publish(context.Background(), "app.name")
@@ -194,7 +196,7 @@ func TestPublishVersion_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
 
 	mustSeedEntry(repo, "app.name", "value")
 	_, err := svc.Publish(context.Background(), "app.name")
@@ -310,8 +312,7 @@ func TestService_Publish_FailClosed_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, slog.Default(),
-		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailClosed))),
-		WithPublishFailureMode(PublishFailureModeFailClosed))
+		WithEmitter(newDirectTestEmitter(t, pub, outbox.DirectPublishFailClosed)))
 
 	mustSeedEntry(repo, "app.timeout", "30s")
 	_, err := svc.Publish(context.Background(), "app.timeout")
@@ -326,8 +327,7 @@ func TestService_Publish_FailOpen_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, slog.Default(),
-		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailOpen))),
-		WithPublishFailureMode(PublishFailureModeFailOpen))
+		WithEmitter(newDirectTestEmitter(t, pub, outbox.DirectPublishFailOpen)))
 
 	mustSeedEntry(repo, "app.timeout", "30s")
 	ver, err := svc.Publish(context.Background(), "app.timeout")
@@ -341,8 +341,7 @@ func TestService_Rollback_FailClosed_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, slog.Default(),
-		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailClosed))),
-		WithPublishFailureMode(PublishFailureModeFailClosed))
+		WithEmitter(newDirectTestEmitter(t, pub, outbox.DirectPublishFailClosed)))
 
 	mustSeedEntry(repo, "app.x", "v1")
 	svcOK := NewService(repo, slog.Default())
@@ -360,8 +359,7 @@ func TestService_Rollback_FailOpen_PublisherError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	pub := testutil.FailingPublisher{Err: errors.New("broker down")}
 	svc := NewService(repo, slog.Default(),
-		WithEmitter(newDirectTestEmitter(t, pub, directPublishMode(PublishFailureModeFailOpen))),
-		WithPublishFailureMode(PublishFailureModeFailOpen))
+		WithEmitter(newDirectTestEmitter(t, pub, outbox.DirectPublishFailOpen)))
 
 	mustSeedEntry(repo, "app.x", "v1")
 	svcOK := NewService(repo, slog.Default())

--- a/cells/configcore/slices/configwrite/contract_test.go
+++ b/cells/configcore/slices/configwrite/contract_test.go
@@ -21,7 +21,7 @@ import (
 func newContractService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }

--- a/cells/configcore/slices/configwrite/contract_test.go
+++ b/cells/configcore/slices/configwrite/contract_test.go
@@ -3,6 +3,7 @@ package configwrite
 import (
 	"context"
 	"encoding/json"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -18,11 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newContractService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+func newContractService(t testing.TB) (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+	t.Helper()
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -44,7 +46,7 @@ func newContractMux(svc *Service) *http.ServeMux {
 func TestHttpConfigWriteV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.config.write.v1")
-	svc, _, _ := newContractService()
+	svc, _, _ := newContractService(t)
 
 	mux := newContractMux(svc)
 
@@ -66,7 +68,7 @@ func TestHttpConfigWriteV1Serve(t *testing.T) {
 // are tested here alongside the happy-path contract test so that auth-guard
 // regressions are caught at the contract boundary, not just in unit tests.
 func TestHttpConfigWriteV1_AuthzNegative(t *testing.T) {
-	svc, _, _ := newContractService()
+	svc, _, _ := newContractService(t)
 	mux := newContractMux(svc)
 	body := `{"key":"app.name","value":"myapp"}`
 
@@ -107,7 +109,7 @@ func TestHttpConfigWriteV1_AuthzNegative(t *testing.T) {
 func TestEventConfigChangedV1Publish_Create(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
-	svc, _, writer := newContractService()
+	svc, _, writer := newContractService(t)
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "app.name", Value: "myapp"})
 	require.NoError(t, err)
@@ -123,7 +125,7 @@ func TestEventConfigChangedV1Publish_Create(t *testing.T) {
 func TestEventConfigChangedV1Publish_Update(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
-	svc, _, writer := newContractService()
+	svc, _, writer := newContractService(t)
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v1"})
 	require.NoError(t, err)
@@ -141,7 +143,7 @@ func TestEventConfigChangedV1Publish_Update(t *testing.T) {
 func TestEventConfigChangedV1Publish_Delete(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.changed.v1")
-	svc, _, writer := newContractService()
+	svc, _, writer := newContractService(t)
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)

--- a/cells/configcore/slices/configwrite/handler_test.go
+++ b/cells/configcore/slices/configwrite/handler_test.go
@@ -3,6 +3,7 @@ package configwrite
 import (
 	"context"
 	"encoding/json"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -240,7 +241,7 @@ func TestHandler_HandleUpdate_SensitiveRedacted(t *testing.T) {
 func TestService_Create_SensitiveEventPayloadRedacted(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	_, err := svc.Create(context.Background(), CreateInput{
 		Key: "db.password", Value: "s3cret!", Sensitive: true,
@@ -256,10 +257,10 @@ func TestService_Create_SensitiveEventPayloadRedacted(t *testing.T) {
 
 // --- outbox/tx service tests ---
 
-func TestService_WithOutboxWriter(t *testing.T) {
+func TestService_WithEmitter(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k1", Value: "v1"})
 	require.NoError(t, err)
@@ -284,7 +285,7 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(ow), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTxManager(tx))
 
 	// Create
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k1", Value: "v1"})

--- a/cells/configcore/slices/configwrite/handler_test.go
+++ b/cells/configcore/slices/configwrite/handler_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,7 +48,7 @@ func withAdmin(req *http.Request) *http.Request {
 
 func setupHandler() (http.Handler, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
-	svc := NewService(repo, eventbus.New(), slog.Default())
+	svc := NewService(repo, slog.Default())
 	h := NewHandler(svc)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -241,7 +240,7 @@ func TestHandler_HandleUpdate_SensitiveRedacted(t *testing.T) {
 func TestService_Create_SensitiveEventPayloadRedacted(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
 
 	_, err := svc.Create(context.Background(), CreateInput{
 		Key: "db.password", Value: "s3cret!", Sensitive: true,
@@ -260,7 +259,7 @@ func TestService_Create_SensitiveEventPayloadRedacted(t *testing.T) {
 func TestService_WithOutboxWriter(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithOutboxWriter(ow))
+	svc := NewService(repo, slog.Default(), WithOutboxWriter(ow))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k1", Value: "v1"})
 	require.NoError(t, err)
@@ -272,7 +271,7 @@ func TestService_WithOutboxWriter(t *testing.T) {
 func TestService_WithTxManager(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	tx := &stubTxRunner{}
-	svc := NewService(repo, eventbus.New(), slog.Default(), WithTxManager(tx))
+	svc := NewService(repo, slog.Default(), WithTxManager(tx))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k1", Value: "v1"})
 	require.NoError(t, err)
@@ -284,7 +283,7 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc := NewService(repo, eventbus.New(), slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(ow), WithTxManager(tx))
 
 	// Create

--- a/cells/configcore/slices/configwrite/service.go
+++ b/cells/configcore/slices/configwrite/service.go
@@ -33,15 +33,6 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }

--- a/cells/configcore/slices/configwrite/service.go
+++ b/cells/configcore/slices/configwrite/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -25,31 +24,44 @@ const TopicConfigChanged = domain.TopicConfigChanged
 // Option configures a config-write Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service implements config write business logic.
 type Service struct {
-	repo         ports.ConfigRepository
-	publisher    outbox.Publisher
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	repo     ports.ConfigRepository
+	txRunner persistence.TxRunner
+	emitter  outbox.Emitter
+	logger   *slog.Logger
 }
 
 // NewService creates a config-write Service.
-func NewService(repo ports.ConfigRepository, pub outbox.Publisher, logger *slog.Logger, opts ...Option) *Service {
+func NewService(repo ports.ConfigRepository, logger *slog.Logger, opts ...Option) *Service {
 	s := &Service{
-		repo:      repo,
-		publisher: pub,
-		logger:    logger,
+		repo:     repo,
+		txRunner: persistence.NoopTxRunner{},
+		emitter:  outbox.NewNoopEmitter(),
+		logger:   logger,
 	}
 	for _, o := range opts {
 		o(s)
@@ -151,14 +163,8 @@ func (s *Service) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-// runInTx executes fn in a transaction if txRunner is configured, otherwise
-// calls fn(ctx) directly. Nil txRunner is intentional for query-only slices;
-// Cell Init() validates txRunner presence for CUD slices before Start().
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }
 
 func (s *Service) publishChange(ctx context.Context, action string, entry *domain.ConfigEntry) error {
@@ -175,26 +181,13 @@ func (s *Service) publishChange(ctx context.Context, action string, entry *domai
 	if err != nil {
 		return fmt.Errorf("config-write: marshal event payload: %w", err)
 	}
-	if s.outboxWriter != nil {
-		outboxEntry := outbox.Entry{
-			ID:        outbox.NewEntryID(),
-			EventType: TopicConfigChanged,
-			Payload:   payload,
-		}
-		if err := s.outboxWriter.Write(ctx, outboxEntry); err != nil {
-			return fmt.Errorf("config-write: write outbox entry: %w", err)
-		}
-		return nil
+	outboxEntry := outbox.Entry{
+		ID:        outbox.NewEntryID(),
+		EventType: TopicConfigChanged,
+		Payload:   payload,
 	}
-	// Demo mode: publisher failure is logged but not propagated since
-	// demo mode does not guarantee L2 atomicity. Wrap in v1 wire envelope so
-	// the eventbus fail-closed schema check (P1-14) accepts the message.
-	envelope := outboxrt.MarshalDirectEnvelope(TopicConfigChanged, TopicConfigChanged, outbox.NewEntryID(), payload)
-	if err := s.publisher.Publish(ctx, TopicConfigChanged, envelope); err != nil {
-		s.logger.Warn("config-write: failed to publish event (demo mode)",
-			slog.Any("error", err),
-			slog.String("key", entry.Key),
-		)
+	if err := s.emitter.Emit(ctx, outboxEntry); err != nil {
+		return fmt.Errorf("config-write: emit event: %w", err)
 	}
 	return nil
 }

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -5,6 +5,7 @@ package configwrite
 import (
 	"context"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -60,7 +61,7 @@ func setupWriteService(t *testing.T) (writeBundle, func()) {
 	txMgr := adapterpg.NewTxManager(pool)
 
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(outboxWriter),
+		WithEmitter(testoutbox.MustEmitter(t, outboxWriter)),
 		WithTxManager(txMgr),
 	)
 
@@ -208,7 +209,7 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 
 	txMgr := adapterpg.NewTxManager(pool)
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(failingWriter),
+		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
 		WithTxManager(txMgr),
 	)
 

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -59,7 +59,7 @@ func setupWriteService(t *testing.T) (writeBundle, func()) {
 	outboxWriter := adapterpg.NewOutboxWriter()
 	txMgr := adapterpg.NewTxManager(pool)
 
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(outboxWriter),
 		WithTxManager(txMgr),
 	)
@@ -207,7 +207,7 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 	failingWriter := &recordingWriter{err: errors.New("outbox broker down")}
 
 	txMgr := adapterpg.NewTxManager(pool)
-	svc := NewService(repo, stubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(failingWriter),
 		WithTxManager(txMgr),
 	)

--- a/cells/configcore/slices/configwrite/service_test.go
+++ b/cells/configcore/slices/configwrite/service_test.go
@@ -8,22 +8,21 @@ import (
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
-	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func newTestService() (*Service, *mem.ConfigRepository) {
 	repo := mem.NewConfigRepository()
-	eb := eventbus.New()
 	logger := slog.Default()
-	return NewService(repo, eb, logger), repo
+	return NewService(repo, logger), repo
 }
 
 func newDurableTestService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
@@ -172,7 +171,7 @@ func TestService_Delete(t *testing.T) {
 func TestService_Create_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
@@ -183,13 +182,13 @@ func TestService_Create_OutboxWriteError(t *testing.T) {
 func TestService_Update_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	goodWriter := &testutil.RecordingWriter{}
-	svcGood := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svcGood := NewService(repo, slog.Default(),
 		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v1"})
 	require.NoError(t, err)
 
 	failWriter := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(failWriter), WithTxManager(&testutil.NoopTxRunner{}))
 
 	_, err = svc.Update(context.Background(), UpdateInput{Key: "k", Value: "v2"})
@@ -200,13 +199,13 @@ func TestService_Update_OutboxWriteError(t *testing.T) {
 func TestService_Delete_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	goodWriter := &testutil.RecordingWriter{}
-	svcGood := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svcGood := NewService(repo, slog.Default(),
 		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
 
 	failWriter := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(failWriter), WithTxManager(&testutil.NoopTxRunner{}))
 
 	err = svc.Delete(context.Background(), "k")
@@ -230,7 +229,7 @@ func TestCreate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
@@ -245,11 +244,11 @@ func TestUpdate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	// Seed via direct repo insert (bypasses service tx counter).
-	_, _ = NewService(repo, testutil.StubPublisher{}, slog.Default()).Create(
+	_, _ = NewService(repo, slog.Default()).Create(
 		context.Background(), CreateInput{Key: "k", Value: "v1"})
 
 	tx.Calls = 0 // reset counter after seed
@@ -265,11 +264,11 @@ func TestDelete_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
-	svc := NewService(repo, testutil.StubPublisher{}, slog.Default(),
+	svc := NewService(repo, slog.Default(),
 		WithOutboxWriter(writer), WithTxManager(tx))
 
 	// Seed via direct repo insert (bypasses service tx counter).
-	_, _ = NewService(repo, testutil.StubPublisher{}, slog.Default()).Create(
+	_, _ = NewService(repo, slog.Default()).Create(
 		context.Background(), CreateInput{Key: "k", Value: "v1"})
 
 	tx.Calls = 0 // reset counter after seed
@@ -285,7 +284,9 @@ func TestDelete_CallsTxRunnerRunInTxOnce(t *testing.T) {
 func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	fp := testutil.FailingPublisher{Err: errors.New("broker unavailable")}
-	svc := NewService(repo, fp, slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, slog.Default())
+	require.NoError(t, err)
+	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
 
 	entry, err := svc.Create(context.Background(), CreateInput{Key: "pub-err", Value: "v"})
 	require.NoError(t, err, "publish failure in demo mode must not fail Create")

--- a/cells/configcore/slices/configwrite/service_test.go
+++ b/cells/configcore/slices/configwrite/service_test.go
@@ -3,6 +3,7 @@ package configwrite
 import (
 	"context"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -19,11 +20,12 @@ func newTestService() (*Service, *mem.ConfigRepository) {
 	return NewService(repo, logger), repo
 }
 
-func newDurableTestService() (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+func newDurableTestService(t testing.TB) (*Service, *mem.ConfigRepository, *testutil.RecordingWriter) {
+	t.Helper()
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	return svc, repo, writer
 }
 
@@ -172,7 +174,7 @@ func TestService_Create_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.Error(t, err, "Create must propagate outbox.Write error to preserve L2 atomicity")
@@ -183,13 +185,13 @@ func TestService_Update_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	goodWriter := &testutil.RecordingWriter{}
 	svcGood := NewService(repo, slog.Default(),
-		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, goodWriter)), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v1"})
 	require.NoError(t, err)
 
 	failWriter := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(failWriter), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, failWriter)), WithTxManager(&testutil.NoopTxRunner{}))
 
 	_, err = svc.Update(context.Background(), UpdateInput{Key: "k", Value: "v2"})
 	require.Error(t, err, "Update must propagate outbox.Write error to preserve L2 atomicity")
@@ -200,13 +202,13 @@ func TestService_Delete_OutboxWriteError(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	goodWriter := &testutil.RecordingWriter{}
 	svcGood := NewService(repo, slog.Default(),
-		WithOutboxWriter(goodWriter), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, goodWriter)), WithTxManager(&testutil.NoopTxRunner{}))
 	_, err := svcGood.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
 
 	failWriter := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(failWriter), WithTxManager(&testutil.NoopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, failWriter)), WithTxManager(&testutil.NoopTxRunner{}))
 
 	err = svc.Delete(context.Background(), "k")
 	require.Error(t, err, "Delete must propagate outbox.Write error to preserve L2 atomicity")
@@ -214,7 +216,7 @@ func TestService_Delete_OutboxWriteError(t *testing.T) {
 }
 
 func TestService_Create_DurableMode_CapturesOutboxEntry(t *testing.T) {
-	svc, _, writer := newDurableTestService()
+	svc, _, writer := newDurableTestService(t)
 
 	entry, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
@@ -230,7 +232,7 @@ func TestCreate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
 
 	_, err := svc.Create(context.Background(), CreateInput{Key: "k", Value: "v"})
 	require.NoError(t, err)
@@ -245,7 +247,7 @@ func TestUpdate_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
 
 	// Seed via direct repo insert (bypasses service tx counter).
 	_, _ = NewService(repo, slog.Default()).Create(
@@ -265,7 +267,7 @@ func TestDelete_CallsTxRunnerRunInTxOnce(t *testing.T) {
 	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
 
 	// Seed via direct repo insert (bypasses service tx counter).
 	_, _ = NewService(repo, slog.Default()).Create(

--- a/cells/configcore/slices/flagwrite/contract_test.go
+++ b/cells/configcore/slices/flagwrite/contract_test.go
@@ -3,6 +3,7 @@ package flagwrite
 import (
 	"context"
 	"encoding/json"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func newContractService(t *testing.T) *Service {
 	repo := mem.NewFlagRepository()
 	writer := &recordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +186,7 @@ func TestEventFlagChangedV1Publish(t *testing.T) {
 	repo := mem.NewFlagRepository()
 	writer := &recordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
 
 	_, err = svc.Create(testAdminCtx(), CreateInput{Key: "event-flag", Enabled: true, Description: "ev"})

--- a/cells/configcore/slices/flagwrite/ctx_cancel_test.go
+++ b/cells/configcore/slices/flagwrite/ctx_cancel_test.go
@@ -3,6 +3,7 @@ package flagwrite
 import (
 	"context"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -47,7 +48,7 @@ func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 	txRunner := &cancellingTxRunner{}
 
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(txRunner))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(txRunner))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{
@@ -78,7 +79,7 @@ func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 	// Seed a flag so Toggle reaches the RunInTx call.
 	writer := &recordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{Key: "toggle-cancel"})
 	require.NoError(t, err)
@@ -86,7 +87,7 @@ func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 	// Now create a service with the cancelling tx runner.
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(&recordingWriter{}), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Toggle(context.Background(), "toggle-cancel", true)
@@ -105,7 +106,7 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
 	writer := &recordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{
 		Key:         "update-cancel",
@@ -115,7 +116,7 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(&recordingWriter{}), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Update(context.Background(), UpdateInput{
@@ -139,14 +140,14 @@ func TestFlagWrite_Delete_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
 	writer := &recordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{Key: "delete-cancel"})
 	require.NoError(t, err)
 
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(&recordingWriter{}), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	err = svc.Delete(context.Background(), "delete-cancel")

--- a/cells/configcore/slices/flagwrite/service.go
+++ b/cells/configcore/slices/flagwrite/service.go
@@ -49,15 +49,6 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
@@ -72,13 +63,9 @@ type Service struct {
 }
 
 // NewService creates a flag-write Service.
-//
-// Defensive invariant: outboxWriter and txRunner must either both be set or
-// both be nil (demo mode). Providing one without the other is a wiring error
-// that breaks L2 atomicity and is returned as an error so callers can fail-fast
-// at construction time rather than at the first CUD operation.
-//
-// ref: go-micro — constructor validates coupling invariants before returning.
+// Cell wiring decides whether the injected emitter/runner pair is backed by a
+// durable outbox path or by demo defaults; the service always runs through the
+// same TxRunner + Emitter abstractions.
 func NewService(repo ports.FlagRepository, logger *slog.Logger, opts ...Option) (*Service, error) {
 	s := &Service{
 		repo:     repo,

--- a/cells/configcore/slices/flagwrite/service.go
+++ b/cells/configcore/slices/flagwrite/service.go
@@ -40,22 +40,35 @@ type FlagChangedPayload struct {
 // Option configures a flag-write Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for transactional event publishing.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service implements flag write business logic (L2 OutboxFact).
 type Service struct {
-	repo         ports.FlagRepository
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	repo     ports.FlagRepository
+	txRunner persistence.TxRunner
+	emitter  outbox.Emitter
+	logger   *slog.Logger
 }
 
 // NewService creates a flag-write Service.
@@ -68,17 +81,13 @@ type Service struct {
 // ref: go-micro — constructor validates coupling invariants before returning.
 func NewService(repo ports.FlagRepository, logger *slog.Logger, opts ...Option) (*Service, error) {
 	s := &Service{
-		repo:   repo,
-		logger: logger,
+		repo:     repo,
+		txRunner: persistence.NoopTxRunner{},
+		emitter:  outbox.NewNoopEmitter(),
+		logger:   logger,
 	}
 	for _, o := range opts {
 		o(s)
-	}
-	// Defensive check: outboxWriter and txRunner must be set together.
-	if (s.outboxWriter != nil) != (s.txRunner != nil) {
-		return nil, errcode.New(errcode.ErrCellMissingOutbox,
-			"flagwrite: outboxWriter and txRunner must both be set or both be nil; "+
-				"providing one without the other breaks L2 atomicity")
 	}
 	return s, nil
 }
@@ -206,22 +215,11 @@ func (s *Service) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-// runInTx executes fn in a transaction if txRunner is configured, otherwise
-// calls fn(ctx) directly. Cell Init() validates txRunner presence for CUD slices.
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
-	if s.txRunner != nil {
-		return s.txRunner.RunInTx(ctx, fn)
-	}
-	return fn(ctx)
+	return s.txRunner.RunInTx(ctx, fn)
 }
 
 func (s *Service) emitFlagChanged(ctx context.Context, action string, flag *domain.FeatureFlag) error {
-	if s.outboxWriter == nil {
-		// Demo mode: outboxWriter is nil (txRunner is also nil per NewService invariant).
-		// This path is only reachable when Service is constructed without WithOutboxWriter,
-		// which is allowed for local demo/testing without a real broker.
-		return nil
-	}
 	// Single event identifier shared by both the transport envelope and the
 	// payload body. headers.event_id (contract idempotency key) is carried in
 	// outbox.Entry.ID at the transport level; payload.eventId mirrors it so
@@ -252,8 +250,8 @@ func (s *Service) emitFlagChanged(ctx context.Context, action string, flag *doma
 		EventType: TopicFlagChanged,
 		Payload:   payload,
 	}
-	if err := s.outboxWriter.Write(ctx, entry); err != nil {
-		return fmt.Errorf("flag-write: write outbox entry: %w", err)
+	if err := s.emitter.Emit(ctx, entry); err != nil {
+		return fmt.Errorf("flag-write: emit event: %w", err)
 	}
 	return nil
 }

--- a/cells/configcore/slices/flagwrite/service_test.go
+++ b/cells/configcore/slices/flagwrite/service_test.go
@@ -95,9 +95,9 @@ func seedFlag(t *testing.T, repo *mem.FlagRepository, key string) *domain.Featur
 
 // --- Test: XOR violation guard ---
 
-// TestNewService_XORViolation verifies that NewService rejects half-wired
-// configs: providing only outboxWriter or only txRunner breaks L2 atomicity.
-func TestNewService_XORViolation(t *testing.T) {
+// TestNewService_AllowsHalfWiredDemoPath verifies that service construction no
+// longer uses nil-mode coupling; Cell wiring owns durable-mode validation.
+func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 	cases := []struct {
 		name string
 		opts []Option
@@ -108,8 +108,7 @@ func TestNewService_XORViolation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := NewService(mem.NewFlagRepository(), slog.Default(), tc.opts...)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "must both be set")
+			require.NoError(t, err)
 		})
 	}
 }

--- a/cells/configcore/slices/flagwrite/service_test.go
+++ b/cells/configcore/slices/flagwrite/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 	"time"
@@ -69,7 +70,7 @@ func newDurableTestService(t *testing.T) (*Service, *mem.FlagRepository, *record
 	repo := mem.NewFlagRepository()
 	writer := &recordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer),
+		WithEmitter(testoutbox.MustEmitter(t, writer)),
 		WithTxManager(&noopTxRunner{}))
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +103,7 @@ func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"only_outbox_writer", []Option{WithOutboxWriter(&recordingWriter{})}},
+		{"only_emitter", []Option{WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{}))}},
 		{"only_tx_runner", []Option{WithTxManager(&noopTxRunner{})}},
 	}
 	for _, tc := range cases {
@@ -122,7 +123,7 @@ func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 	writer := &recordingWriter{}
 	tx := &noopTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
 	require.NoError(t, err)
 
 	flag, err := svc.Create(context.Background(), CreateInput{
@@ -151,7 +152,7 @@ func TestFlagWrite_RepoFails_NoOutboxWrite(t *testing.T) {
 	writer := &recordingWriter{}
 	tx := &failingTxRunner{failErr: errors.New("tx commit failed")}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(tx))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{Key: "k"})
@@ -229,7 +230,7 @@ func TestFlagWrite_OutboxWriteError_PropagatesFromCreate(t *testing.T) {
 	repo := mem.NewFlagRepository()
 	writer := &recordingWriter{err: errors.New("outbox unavailable")}
 	svc, err := NewService(repo, slog.Default(),
-		WithOutboxWriter(writer), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{Key: "k"})

--- a/cells/internal/testoutbox/emitter.go
+++ b/cells/internal/testoutbox/emitter.go
@@ -1,0 +1,17 @@
+package testoutbox
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func MustEmitter(t testing.TB, w outbox.Writer) outbox.Emitter {
+	t.Helper()
+
+	emitter, err := outbox.NewWriterEmitter(w)
+	if err != nil {
+		t.Fatalf("create writer emitter: %v", err)
+	}
+	return emitter
+}

--- a/cmd/corebundle/app.go
+++ b/cmd/corebundle/app.go
@@ -15,7 +15,7 @@ import (
 // Flow:
 //  1. shared.Validate() — startup invariant check (all required deps present).
 //  2. For each module: module.Provide(ctx, shared) → cell.Cell + []bootstrap.Option.
-//  3. Return aggregated (cells, opts). The cmd layer calls buildAssembly(cells...)
+//  3. Return aggregated (cells, opts). The cmd layer calls buildAssembly(...)
 //     + bootstrap.New(opts...) to complete the wiring.
 //
 // BuildApp returns ([]cell.Cell, []bootstrap.Option, error) rather than

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -46,7 +46,7 @@ func buildAssembly(ps promStack, mode cell.DurabilityMode, cells ...cell.Cell) (
 }
 
 func durabilityModeForTopology(topo bootstrap.Topology) cell.DurabilityMode {
-	if topo.AdapterMode == "real" {
+	if topo.StorageBackend == "postgres" {
 		return cell.DurabilityDurable
 	}
 	return cell.DurabilityDemo

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -28,11 +28,11 @@ import (
 )
 
 // buildAssembly constructs the corebundle Assembly and registers the three
-// cells with durable mode. Extracted to keep run() cognitive complexity ≤ 15.
-func buildAssembly(ps promStack, cells ...cell.Cell) (*assembly.CoreAssembly, error) {
+// cells. Extracted to keep run() cognitive complexity ≤ 15.
+func buildAssembly(ps promStack, mode cell.DurabilityMode, cells ...cell.Cell) (*assembly.CoreAssembly, error) {
 	asm := assembly.New(assembly.Config{
 		ID:              "corebundle",
-		DurabilityMode:  cell.DurabilityDurable,
+		DurabilityMode:  mode,
 		HookObserver:    ps.hookObserver,
 		MetricsProvider: ps.metricProvider,
 		// HookTimeout omitted → assembly.DefaultHookTimeout (30s) applies.
@@ -43,6 +43,13 @@ func buildAssembly(ps promStack, cells ...cell.Cell) (*assembly.CoreAssembly, er
 		}
 	}
 	return asm, nil
+}
+
+func durabilityModeForTopology(topo bootstrap.Topology) cell.DurabilityMode {
+	if topo.AdapterMode == "real" {
+		return cell.DurabilityDurable
+	}
+	return cell.DurabilityDemo
 }
 
 // defaultRuntimeOptions constructs the ordered bootstrap.Option slice from the

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -149,7 +149,7 @@ func buildBootstrapFromShared(t *testing.T, shared *SharedDeps, extra ...bootstr
 		return nil, err
 	}
 
-	asm, err := buildAssembly(shared.PromStack, cells...)
+	asm, err := buildAssembly(shared.PromStack, durabilityModeForTopology(shared.Topology), cells...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	accesscore "github.com/ghbvf/gocell/cells/accesscore"
+	"github.com/ghbvf/gocell/kernel/cell"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	kworker "github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -130,6 +131,36 @@ func newValidatedSharedDeps(t *testing.T, topo bootstrap.Topology) *SharedDeps {
 		t.Setenv("GOCELL_MASTER_KEY", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
 	}
 	return deps
+}
+
+func TestDurabilityModeForTopology_UsesStorageBackend(t *testing.T) {
+	tests := []struct {
+		name string
+		topo bootstrap.Topology
+		want cell.DurabilityMode
+	}{
+		{
+			name: "memory real remains demo",
+			topo: bootstrap.Topology{StorageBackend: "memory", AdapterMode: "real"},
+			want: cell.DurabilityDemo,
+		},
+		{
+			name: "postgres real is durable",
+			topo: bootstrap.Topology{StorageBackend: "postgres", AdapterMode: "real"},
+			want: cell.DurabilityDurable,
+		},
+		{
+			name: "memory dev remains demo",
+			topo: bootstrap.Topology{StorageBackend: "memory", AdapterMode: "dev"},
+			want: cell.DurabilityDemo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, durabilityModeForTopology(tt.topo))
+		})
+	}
 }
 
 // buildBootstrapFromShared is the test-path assembly helper, equivalent to the

--- a/cmd/corebundle/main.go
+++ b/cmd/corebundle/main.go
@@ -2,9 +2,9 @@
 // It bootstraps configcore, accesscore, and auditcore with in-memory
 // repositories by default, suitable for development and integration testing.
 //
-// DurabilityDurable is set to reject noop placeholders (NoopWriter,
-// NoopTxRunner, DiscardPublisher) even in dev mode. Set GOCELL_ADAPTER_MODE=real
-// to require all secrets from env vars (fail-fast on missing).
+// DurabilityDemo is used in dev/memory mode so Cells auto-fill explicit no-op
+// dependencies. Set GOCELL_ADAPTER_MODE=real to switch the assembly to
+// DurabilityDurable and require all production dependencies and secrets.
 //
 // # Required env vars (all adapter modes)
 //
@@ -395,7 +395,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	asm, err := buildAssembly(shared.PromStack, cells...)
+	asm, err := buildAssembly(shared.PromStack, durabilityModeForTopology(shared.Topology), cells...)
 	if err != nil {
 		return fmt.Errorf("build assembly: %w", err)
 	}

--- a/cmd/corebundle/main.go
+++ b/cmd/corebundle/main.go
@@ -2,9 +2,10 @@
 // It bootstraps configcore, accesscore, and auditcore with in-memory
 // repositories by default, suitable for development and integration testing.
 //
-// DurabilityDemo is used in dev/memory mode so Cells auto-fill explicit no-op
-// dependencies. Set GOCELL_ADAPTER_MODE=real to switch the assembly to
-// DurabilityDurable and require all production dependencies and secrets.
+// DurabilityDemo is used with memory storage so Cells auto-fill explicit no-op
+// dependencies. Set GOCELL_CELL_ADAPTER_MODE=postgres to switch the assembly
+// to DurabilityDurable and require real writer/tx dependencies; set
+// GOCELL_ADAPTER_MODE=real to enable production control-plane secret checks.
 //
 // # Required env vars (all adapter modes)
 //

--- a/cmd/corebundle/vault_readiness_wiring_test.go
+++ b/cmd/corebundle/vault_readiness_wiring_test.go
@@ -89,7 +89,7 @@ func buildBootstrapWithFakeKeyProvider(t *testing.T, shared *SharedDeps, kp kcry
 		return nil, err
 	}
 
-	asm, err := buildAssembly(shared.PromStack, cells...)
+	asm, err := buildAssembly(shared.PromStack, durabilityModeForTopology(shared.Topology), cells...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -118,7 +118,11 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := cell.CheckNotNoop(deps.DurabilityMode, "devicecell", c.publisher); err != nil {
 		return err
 	}
-	emitter, err := outbox.NewDirectEmitter(c.publisher, outbox.DirectPublishFailOpen, c.logger)
+	publishFailureMode := outbox.DirectPublishFailOpen
+	if deps.DurabilityMode == cell.DurabilityDurable {
+		publishFailureMode = outbox.DirectPublishFailClosed
+	}
+	emitter, err := outbox.NewDirectEmitter(c.publisher, publishFailureMode, c.logger)
 	if err != nil {
 		return err
 	}

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -114,15 +114,14 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 			"devicecell requires publisher; use WithPublisher(&outbox.DiscardPublisher{}) for demo mode")
 	}
 
-	// Durable mode: reject noop publisher (#27c-2).
+	// Durable mode still rejects noop publishers, but direct publish remains
+	// fail-open here because this example path has no transactional outbox.
+	// The request succeeds once persistence succeeds; publish misses are
+	// operational follow-up, not create failure.
 	if err := cell.CheckNotNoop(deps.DurabilityMode, "devicecell", c.publisher); err != nil {
 		return err
 	}
-	publishFailureMode := outbox.DirectPublishFailOpen
-	if deps.DurabilityMode == cell.DurabilityDurable {
-		publishFailureMode = outbox.DirectPublishFailClosed
-	}
-	emitter, err := outbox.NewDirectEmitter(c.publisher, publishFailureMode, c.logger)
+	emitter, err := outbox.NewDirectEmitter(c.publisher, outbox.DirectPublishFailOpen, c.logger)
 	if err != nil {
 		return err
 	}

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -91,8 +91,8 @@ func NewDeviceCell(opts ...Option) *DeviceCell {
 }
 
 // Init sets up repositories, slice services, and handlers.
-// L4 Cells do not use outboxWriter (KG-07 decision). The publisher is used
-// directly for event publishing.
+// L4 Cells do not use outboxWriter (KG-07 decision). The Cell boundary
+// adapts the publisher to a direct emitter for event publishing.
 func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := c.BaseCell.Init(ctx, deps); err != nil {
 		return err
@@ -118,9 +118,13 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := cell.CheckNotNoop(deps.DurabilityMode, "devicecell", c.publisher); err != nil {
 		return err
 	}
+	emitter, err := outbox.NewDirectEmitter(c.publisher, outbox.DirectPublishFailOpen, c.logger)
+	if err != nil {
+		return err
+	}
 
 	// device-register slice
-	registerSvc := deviceregister.NewService(c.deviceRepo, c.publisher, c.logger)
+	registerSvc := deviceregister.NewService(c.deviceRepo, c.logger, deviceregister.WithEmitter(emitter))
 	c.registerHandler = deviceregister.NewHandler(registerSvc)
 	c.AddSlice(cell.NewBaseSlice("deviceregister", "devicecell", cell.L4))
 

--- a/examples/iotdevice/cells/devicecell/cell_test.go
+++ b/examples/iotdevice/cells/devicecell/cell_test.go
@@ -1,8 +1,10 @@
 package devicecell
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/router"
@@ -25,6 +28,21 @@ func newTestCell() *DeviceCell {
 		WithCommandRepository(mem.NewCommandRepository()),
 		WithPublisher(eventbus.New()),
 	)
+}
+
+type failingPublisher struct{}
+
+func (failingPublisher) Publish(_ context.Context, _ string, _ []byte) error {
+	return errors.New("publish failed")
+}
+
+func (failingPublisher) Close(_ context.Context) error { return nil }
+
+func newTestCursorCodec(t *testing.T) *query.CursorCodec {
+	t.Helper()
+	codec, err := query.NewCursorCodec(bytes.Repeat([]byte("k"), 32))
+	require.NoError(t, err)
+	return codec
 }
 
 func TestDeviceCell_Lifecycle(t *testing.T) {
@@ -304,4 +322,45 @@ func TestDeviceCell_DurableMode_RejectsMissingCursorCodec(t *testing.T) {
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCellMissingCodec, ecErr.Code)
 	assert.Contains(t, err.Error(), "cursor codec")
+}
+
+func TestDeviceCell_DurableMode_RegisterPublishFailureReturnsError(t *testing.T) {
+	c := NewDeviceCell(
+		WithDeviceRepository(mem.NewDeviceRepository()),
+		WithCommandRepository(mem.NewCommandRepository()),
+		WithPublisher(failingPublisher{}),
+		WithCursorCodec(newTestCursorCodec(t)),
+	)
+	require.NoError(t, c.Init(context.Background(), cell.Dependencies{
+		Config:         map[string]any{},
+		DurabilityMode: cell.DurabilityDurable,
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/", strings.NewReader(`{"name":"sensor-fail"}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.registerHandler.HandleRegister(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code,
+		"durable mode must not return success when device.registered publish fails")
+}
+
+func TestDeviceCell_DemoMode_RegisterPublishFailureReturnsCreated(t *testing.T) {
+	c := NewDeviceCell(
+		WithDeviceRepository(mem.NewDeviceRepository()),
+		WithCommandRepository(mem.NewCommandRepository()),
+		WithPublisher(failingPublisher{}),
+	)
+	require.NoError(t, c.Init(context.Background(), cell.Dependencies{
+		Config:         map[string]any{},
+		DurabilityMode: cell.DurabilityDemo,
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/", strings.NewReader(`{"name":"sensor-demo"}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.registerHandler.HandleRegister(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code,
+		"demo mode keeps direct publish fail-open behavior")
 }

--- a/examples/iotdevice/cells/devicecell/cell_test.go
+++ b/examples/iotdevice/cells/devicecell/cell_test.go
@@ -324,7 +324,7 @@ func TestDeviceCell_DurableMode_RejectsMissingCursorCodec(t *testing.T) {
 	assert.Contains(t, err.Error(), "cursor codec")
 }
 
-func TestDeviceCell_DurableMode_RegisterPublishFailureReturnsError(t *testing.T) {
+func TestDeviceCell_DurableMode_RegisterPublishFailureReturnsCreated(t *testing.T) {
 	c := NewDeviceCell(
 		WithDeviceRepository(mem.NewDeviceRepository()),
 		WithCommandRepository(mem.NewCommandRepository()),
@@ -341,8 +341,8 @@ func TestDeviceCell_DurableMode_RegisterPublishFailureReturnsError(t *testing.T)
 	req.Header.Set("Content-Type", "application/json")
 	c.registerHandler.HandleRegister(rec, req)
 
-	assert.Equal(t, http.StatusInternalServerError, rec.Code,
-		"durable mode must not return success when device.registered publish fails")
+	assert.Equal(t, http.StatusCreated, rec.Code,
+		"device creation must stay successful after persistence even if direct publish fails")
 }
 
 func TestDeviceCell_DemoMode_RegisterPublishFailureReturnsCreated(t *testing.T) {

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/contract_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/contract_test.go
@@ -37,7 +37,11 @@ var _ outbox.Publisher = (*recordingPublisher)(nil)
 func newContractHandler() (http.Handler, *recordingPublisher) {
 	repo := mem.NewDeviceRepository()
 	pub := &recordingPublisher{}
-	svc := NewService(repo, pub, slog.Default())
+	emitter, err := outbox.NewDirectEmitter(pub, outbox.DirectPublishFailOpen, slog.Default())
+	if err != nil {
+		panic(err)
+	}
+	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
 	mux := http.NewServeMux()
 	mux.Handle("POST /api/v1/devices", http.HandlerFunc(NewHandler(svc).HandleRegister))
 	return mux, pub

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/handler_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/handler_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/mem"
-	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,8 +38,7 @@ func TestDeviceRegisterResponse_Fields(t *testing.T) {
 
 func setupRegisterHandler() *Handler {
 	repo := mem.NewDeviceRepository()
-	pub := eventbus.New()
-	svc := NewService(repo, pub, slog.Default())
+	svc := NewService(repo, slog.Default())
 	return NewHandler(svc)
 }
 

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	outboxrt "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/google/uuid"
 )
 
@@ -36,18 +35,34 @@ func toDeviceRegisteredEvent(d *domain.Device) deviceRegisteredEvent {
 
 // Service handles device registration business logic.
 type Service struct {
-	repo      domain.DeviceRepository
-	publisher outbox.Publisher
-	logger    *slog.Logger
+	repo    domain.DeviceRepository
+	emitter outbox.Emitter
+	logger  *slog.Logger
+}
+
+// Option configures a device-register Service.
+type Option func(*Service)
+
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
 }
 
 // NewService creates a device-register Service.
-func NewService(repo domain.DeviceRepository, publisher outbox.Publisher, logger *slog.Logger) *Service {
-	return &Service{
-		repo:      repo,
-		publisher: publisher,
-		logger:    logger,
+func NewService(repo domain.DeviceRepository, logger *slog.Logger, opts ...Option) *Service {
+	s := &Service{
+		repo:    repo,
+		emitter: outbox.NewNoopEmitter(),
+		logger:  logger,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 // Register creates a new device and publishes a device.registered event.
@@ -67,17 +82,17 @@ func (s *Service) Register(ctx context.Context, name string) (*domain.Device, er
 		return nil, fmt.Errorf("device-register: persist: %w", err)
 	}
 
-	// L4 Cell uses publisher.Publish directly (no outboxWriter per KG-07).
-	// Payload is wrapped in a v1 wire envelope so the eventbus fail-closed
-	// schema check (P1-14) accepts the message.
 	payload, err := json.Marshal(toDeviceRegisteredEvent(device))
 	if err != nil {
 		s.logger.Error("device-register: marshal event failed", slog.Any("error", err))
 		return device, nil
 	}
-	envelope := outboxrt.MarshalDirectEnvelope(TopicDeviceRegistered, TopicDeviceRegistered, outbox.NewEntryID(), payload)
-
-	if err := s.publisher.Publish(ctx, TopicDeviceRegistered, envelope); err != nil {
+	entry := outbox.Entry{
+		ID:        outbox.NewEntryID(),
+		EventType: TopicDeviceRegistered,
+		Payload:   payload,
+	}
+	if err := s.emitter.Emit(ctx, entry); err != nil {
 		s.logger.Error("device-register: publish event failed",
 			slog.String("device_id", device.ID),
 			slog.Any("error", err),

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
@@ -98,11 +98,6 @@ func (s *Service) Register(ctx context.Context, name string) (*domain.Device, er
 			slog.Any("error", err),
 		)
 		return nil, fmt.Errorf("device-register: emit event: %w", err)
-	} else {
-		s.logger.Info("device-register: event published",
-			slog.String("device_id", device.ID),
-			slog.String("topic", TopicDeviceRegistered),
-		)
 	}
 
 	return device, nil

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
@@ -97,6 +97,7 @@ func (s *Service) Register(ctx context.Context, name string) (*domain.Device, er
 			slog.String("device_id", device.ID),
 			slog.Any("error", err),
 		)
+		return nil, fmt.Errorf("device-register: emit event: %w", err)
 	} else {
 		s.logger.Info("device-register: event published",
 			slog.String("device_id", device.ID),

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
@@ -96,6 +96,19 @@ func TestService_Register_PublishFails_StillReturnsDevice(t *testing.T) {
 	assert.NotEmpty(t, dev.ID)
 }
 
+func TestService_Register_PublishFails_FailClosedReturnsError(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailClosed, slog.Default())
+	require.NoError(t, err)
+	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
+
+	dev, err := svc.Register(context.Background(), "sensor-c")
+	require.Error(t, err, "fail-closed publish failure must propagate")
+	assert.Nil(t, dev)
+	assert.Contains(t, err.Error(), "emit event")
+	assert.Contains(t, err.Error(), "publish failed")
+}
+
 func TestService_Register_DuplicateID_IsUnlikelyButHandled(t *testing.T) {
 	// Since uuid.NewString generates random IDs, duplicate is practically
 	// impossible. We verify two sequential calls succeed without collision.

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/mem"
-	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,8 +23,7 @@ func (failPublisher) Close(_ context.Context) error { return nil }
 
 func newTestService() (*Service, *mem.DeviceRepository) {
 	repo := mem.NewDeviceRepository()
-	pub := eventbus.New()
-	return NewService(repo, pub, slog.Default()), repo
+	return NewService(repo, slog.Default()), repo
 }
 
 func TestService_Register(t *testing.T) {
@@ -87,7 +86,9 @@ func TestService_Register_PersistsDevice(t *testing.T) {
 
 func TestService_Register_PublishFails_StillReturnsDevice(t *testing.T) {
 	repo := mem.NewDeviceRepository()
-	svc := NewService(repo, failPublisher{}, slog.Default())
+	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailOpen, slog.Default())
+	require.NoError(t, err)
+	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
 
 	dev, err := svc.Register(context.Background(), "sensor-c")
 	require.NoError(t, err, "publish failure should not propagate as error")

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
@@ -1,6 +1,7 @@
 package deviceregister
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -9,6 +10,7 @@ import (
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/mem"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -107,6 +109,25 @@ func TestService_Register_PublishFails_FailClosedReturnsError(t *testing.T) {
 	assert.Nil(t, dev)
 	assert.Contains(t, err.Error(), "emit event")
 	assert.Contains(t, err.Error(), "publish failed")
+}
+
+func TestService_Register_FailOpenDoesNotLogPublished(t *testing.T) {
+	repo := mem.NewDeviceRepository()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailOpen, logger)
+	require.NoError(t, err)
+	svc := NewService(repo, logger, WithEmitter(emitter))
+
+	dev, err := svc.Register(context.Background(), "sensor-log")
+	require.NoError(t, err)
+	require.NotNil(t, dev)
+
+	logOutput := logBuf.String()
+	warnEntry := sloghelper.FindLogEntry(logOutput, "direct publish failed")
+	require.NotNil(t, warnEntry, "expected warn log for fail-open publish miss")
+	assert.Nil(t, sloghelper.FindLogEntry(logOutput, "event published"),
+		"fail-open path must not log a false published-success message")
 }
 
 func TestService_Register_DuplicateID_IsUnlikelyButHandled(t *testing.T) {

--- a/examples/todoorder/cells/ordercell/cell.go
+++ b/examples/todoorder/cells/ordercell/cell.go
@@ -159,11 +159,11 @@ func (c *OrderCell) resolveOutboxDeps(mode cell.DurabilityMode) error {
 		c.emitter = emitter
 		return nil
 	}
-	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
-	if c.outboxWriter == nil {
-		c.emitter = outbox.NewNoopEmitter()
-		return nil
+	if c.outboxWriter == nil || c.txRunner == nil {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"ordercell demo mode requires outboxWriter and txRunner together; inject both explicitly")
 	}
+	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
 	emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
 	if err != nil {
 		return err

--- a/examples/todoorder/cells/ordercell/cell.go
+++ b/examples/todoorder/cells/ordercell/cell.go
@@ -61,6 +61,7 @@ type OrderCell struct {
 	repo         domain.OrderRepository
 	outboxWriter outbox.Writer
 	txRunner     persistence.TxRunner
+	emitter      outbox.Emitter
 	cursorCodec  *query.CursorCodec
 	logger       *slog.Logger
 
@@ -88,21 +89,12 @@ func NewOrderCell(opts ...Option) *OrderCell {
 }
 
 // Init sets up repositories, slice services, and handlers.
-// outboxWriter and txRunner are required. For demo mode, inject
-// outbox.NoopWriter{} + persistence.NoopTxRunner{} for a unified code path.
 func (c *OrderCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := c.BaseCell.Init(ctx, deps); err != nil {
 		return err
 	}
 
-	// outboxWriter + txRunner are mandatory (demo uses NoopWriter + NoopTxRunner).
-	if c.outboxWriter == nil || c.txRunner == nil {
-		return errcode.New(errcode.ErrCellMissingOutbox,
-			"ordercell requires outboxWriter and txRunner; use outbox.NoopWriter{} + persistence.NoopTxRunner{} for demo mode")
-	}
-
-	// Durable mode: reject noop implementations (#27c-2 BOOTSTRAP-STRICT-MODE).
-	if err := cell.CheckNotNoop(deps.DurabilityMode, "ordercell", c.outboxWriter, c.txRunner); err != nil {
+	if err := c.resolveOutboxDeps(deps.DurabilityMode); err != nil {
 		return err
 	}
 
@@ -114,7 +106,7 @@ func (c *OrderCell) Init(ctx context.Context, deps cell.Dependencies) error {
 
 	// order-create slice — unified outbox path, no publisher fork.
 	createSvc := ordercreate.NewService(c.repo, c.logger,
-		ordercreate.WithOutboxWriter(c.outboxWriter),
+		ordercreate.WithEmitter(c.emitter),
 		ordercreate.WithTxManager(c.txRunner),
 	)
 	c.createHandler = ordercreate.NewHandler(createSvc)
@@ -148,6 +140,35 @@ func (c *OrderCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	c.queryHandler = orderquery.NewHandler(querySvc)
 	c.AddSlice(cell.NewBaseSlice("orderquery", "ordercell", cell.L0))
 
+	return nil
+}
+
+func (c *OrderCell) resolveOutboxDeps(mode cell.DurabilityMode) error {
+	if err := cell.CheckNotNoop(mode, "ordercell", c.outboxWriter, c.txRunner); err != nil {
+		return err
+	}
+	if mode == cell.DurabilityDurable {
+		if c.outboxWriter == nil || c.txRunner == nil {
+			return errcode.New(errcode.ErrCellMissingOutbox,
+				"ordercell durable mode requires real outboxWriter and txRunner")
+		}
+		emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
+		if err != nil {
+			return err
+		}
+		c.emitter = emitter
+		return nil
+	}
+	c.txRunner = persistence.RunnerOrNoop(c.txRunner)
+	if c.outboxWriter == nil {
+		c.emitter = outbox.NewNoopEmitter()
+		return nil
+	}
+	emitter, err := outbox.NewWriterEmitter(c.outboxWriter)
+	if err != nil {
+		return err
+	}
+	c.emitter = emitter
 	return nil
 }
 

--- a/examples/todoorder/cells/ordercell/cell_test.go
+++ b/examples/todoorder/cells/ordercell/cell_test.go
@@ -80,9 +80,9 @@ func TestOrderCell_InitDefaults(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:    "no options fails — outboxWriter+txRunner required",
-			opts:    nil,
-			wantErr: true,
+			name:       "no options succeeds with demo noop emitter",
+			opts:       nil,
+			wantSlices: 2,
 		},
 		{
 			name: "NoopWriter + NoopTxRunner succeeds (demo mode)",
@@ -110,24 +110,22 @@ func TestOrderCell_InitDefaults(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "outboxWriter and txRunner")
-			} else {
-				require.NoError(t, err)
-				assert.Len(t, c.OwnedSlices(), tt.wantSlices)
+				return
 			}
+			require.NoError(t, err)
+			assert.Len(t, c.OwnedSlices(), tt.wantSlices)
 		})
 	}
 }
 
-func TestOrderCell_DefaultInit_RequiresOutboxWriterAndTxRunner(t *testing.T) {
+func TestOrderCell_DefaultInit_DemoModeSucceedsWithNoopEmitter(t *testing.T) {
 	c := NewOrderCell()
 	err := c.Init(context.Background(), newTestDeps())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "outboxWriter and txRunner")
-	assert.Contains(t, err.Error(), "NoopWriter")
-	assert.Contains(t, err.Error(), "NoopTxRunner")
+	require.NoError(t, err)
+	assert.Len(t, c.OwnedSlices(), 2)
 }
 
-func TestOrderCell_InitRejectsHalfConfiguredPath(t *testing.T) {
+func TestOrderCell_DemoMode_AllowsHalfConfiguredPath(t *testing.T) {
 	tests := []struct {
 		name string
 		opts []Option
@@ -146,10 +144,7 @@ func TestOrderCell_InitRejectsHalfConfiguredPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewOrderCell(tt.opts...)
 			err := c.Init(context.Background(), newTestDeps())
-			require.Error(t, err)
-			var ecErr *errcode.Error
-			require.ErrorAs(t, err, &ecErr)
-			assert.Equal(t, errcode.ErrCellMissingOutbox, ecErr.Code)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/examples/todoorder/cells/ordercell/cell_test.go
+++ b/examples/todoorder/cells/ordercell/cell_test.go
@@ -80,9 +80,9 @@ func TestOrderCell_InitDefaults(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "no options succeeds with demo noop emitter",
-			opts:       nil,
-			wantSlices: 2,
+			name:    "no options fails without explicit outbox pair",
+			opts:    nil,
+			wantErr: true,
 		},
 		{
 			name: "NoopWriter + NoopTxRunner succeeds (demo mode)",
@@ -118,14 +118,14 @@ func TestOrderCell_InitDefaults(t *testing.T) {
 	}
 }
 
-func TestOrderCell_DefaultInit_DemoModeSucceedsWithNoopEmitter(t *testing.T) {
+func TestOrderCell_DefaultInit_DemoModeRequiresExplicitOutboxPair(t *testing.T) {
 	c := NewOrderCell()
 	err := c.Init(context.Background(), newTestDeps())
-	require.NoError(t, err)
-	assert.Len(t, c.OwnedSlices(), 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outboxWriter and txRunner")
 }
 
-func TestOrderCell_DemoMode_AllowsHalfConfiguredPath(t *testing.T) {
+func TestOrderCell_DemoMode_RejectsHalfConfiguredPath(t *testing.T) {
 	tests := []struct {
 		name string
 		opts []Option
@@ -144,7 +144,8 @@ func TestOrderCell_DemoMode_AllowsHalfConfiguredPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewOrderCell(tt.opts...)
 			err := c.Init(context.Background(), newTestDeps())
-			require.NoError(t, err)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "outboxWriter and txRunner")
 		})
 	}
 }

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/contract_test.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/contract_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/ghbvf/gocell/pkg/contracttest"
 )
 
-func newContractHandler() (http.Handler, *recordingWriter) {
+func newContractHandler(t testing.TB) (http.Handler, *recordingWriter) {
+	t.Helper()
 	repo := mem.NewOrderRepository()
 	writer := &recordingWriter{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(writer), WithTxManager(&stubTxRunner{}))
+	svc := NewService(repo, slog.Default(), WithEmitter(mustEmitter(t, writer)), WithTxManager(&stubTxRunner{}))
 	mux := http.NewServeMux()
 	mux.Handle("POST /api/v1/orders/", http.HandlerFunc(NewHandler(svc).HandleCreate))
 	return mux, writer
@@ -24,7 +25,7 @@ func newContractHandler() (http.Handler, *recordingWriter) {
 func TestHttpOrderCreateV1Serve(t *testing.T) {
 	root := contracttest.ExampleContractsRoot("todoorder")
 	c := contracttest.LoadByID(t, root, "http.order.create.v1")
-	h, _ := newContractHandler()
+	h, _ := newContractHandler(t)
 
 	c.ValidateRequest(t, []byte(`{"item":"widget"}`))
 	c.MustRejectRequest(t, []byte(`{"item":"x","extra":"bad"}`))
@@ -40,7 +41,7 @@ func TestEventOrderCreatedV1Publish(t *testing.T) {
 	root := contracttest.ExampleContractsRoot("todoorder")
 	httpContract := contracttest.LoadByID(t, root, "http.order.create.v1")
 	c := contracttest.LoadByID(t, root, "event.order-created.v1")
-	h, writer := newContractHandler()
+	h, writer := newContractHandler(t)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(httpContract.HTTP.Method, httpContract.HTTP.Path, strings.NewReader(`{"item":"widget"}`))

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/handler_test.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/handler_test.go
@@ -39,10 +39,11 @@ func TestOrderCreateResponse_Fields(t *testing.T) {
 	assert.Contains(t, s, `"status"`)
 }
 
-func newTestHandler() *Handler {
+func newTestHandler(t testing.TB) *Handler {
+	t.Helper()
 	repo := mem.NewOrderRepository()
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(outbox.NoopWriter{}),
+		WithEmitter(mustEmitter(t, outbox.NoopWriter{})),
 		WithTxManager(persistence.NoopTxRunner{}),
 	)
 	return NewHandler(svc)
@@ -83,7 +84,7 @@ func TestHandleCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := newTestHandler()
+			h := newTestHandler(t)
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/orders/", strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
@@ -97,7 +98,7 @@ func TestHandleCreate(t *testing.T) {
 }
 
 func TestHandleCreate_ResponseBody(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orders/", strings.NewReader(`{"item":"laptop"}`))
 	req.Header.Set("Content-Type", "application/json")

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/service.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/service.go
@@ -49,24 +49,14 @@ func WithEmitter(e outbox.Emitter) Option {
 	}
 }
 
-// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
-func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) {
-		if e, err := outbox.NewWriterEmitter(w); err == nil {
-			s.emitter = e
-		}
-	}
-}
-
 // WithTxManager sets the TxRunner for transactional guarantees.
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service handles order creation business logic.
-// Both outboxWriter and txRunner are required — the cell Init() enforces this.
-// Demo mode uses outbox.NoopWriter + persistence.NoopTxRunner for a unified
-// code path with zero fork.
+// Cell wiring injects either durable or demo defaults, but the service always
+// runs through the same Emitter + TxRunner code path.
 type Service struct {
 	repo     domain.OrderRepository
 	txRunner persistence.TxRunner
@@ -75,8 +65,6 @@ type Service struct {
 }
 
 // NewService creates an order-create Service.
-// outboxWriter and txRunner must be set via options; the cell Init()
-// validates their presence before constructing the Service.
 func NewService(repo domain.OrderRepository, logger *slog.Logger, opts ...Option) *Service {
 	s := &Service{
 		repo:     repo,

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/service.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/service.go
@@ -40,14 +40,27 @@ func toOrderCreatedEvent(o *domain.Order) orderCreatedEvent {
 // Option configures the order-create Service.
 type Option func(*Service)
 
-// WithOutboxWriter sets the outbox.Writer for event emission.
+// WithEmitter sets the event emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithOutboxWriter adapts an outbox.Writer for existing tests and wiring.
 func WithOutboxWriter(w outbox.Writer) Option {
-	return func(s *Service) { s.outboxWriter = w }
+	return func(s *Service) {
+		if e, err := outbox.NewWriterEmitter(w); err == nil {
+			s.emitter = e
+		}
+	}
 }
 
 // WithTxManager sets the TxRunner for transactional guarantees.
 func WithTxManager(tx persistence.TxRunner) Option {
-	return func(s *Service) { s.txRunner = tx }
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
 // Service handles order creation business logic.
@@ -55,10 +68,10 @@ func WithTxManager(tx persistence.TxRunner) Option {
 // Demo mode uses outbox.NoopWriter + persistence.NoopTxRunner for a unified
 // code path with zero fork.
 type Service struct {
-	repo         domain.OrderRepository
-	outboxWriter outbox.Writer
-	txRunner     persistence.TxRunner
-	logger       *slog.Logger
+	repo     domain.OrderRepository
+	txRunner persistence.TxRunner
+	emitter  outbox.Emitter
+	logger   *slog.Logger
 }
 
 // NewService creates an order-create Service.
@@ -66,8 +79,10 @@ type Service struct {
 // validates their presence before constructing the Service.
 func NewService(repo domain.OrderRepository, logger *slog.Logger, opts ...Option) *Service {
 	s := &Service{
-		repo:   repo,
-		logger: logger,
+		repo:     repo,
+		txRunner: persistence.NoopTxRunner{},
+		emitter:  outbox.NewNoopEmitter(),
+		logger:   logger,
 	}
 	for _, o := range opts {
 		o(s)
@@ -97,27 +112,19 @@ func (s *Service) Create(ctx context.Context, item string) (*domain.Order, error
 		if err := s.repo.Create(txCtx, order); err != nil {
 			return fmt.Errorf("order-create: persist: %w", err)
 		}
-		if err := s.outboxWriter.Write(txCtx, entry); err != nil {
-			return fmt.Errorf("order-create: write outbox: %w", err)
+		if err := s.emitter.Emit(txCtx, entry); err != nil {
+			return fmt.Errorf("order-create: emit event: %w", err)
 		}
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 
-	if n, ok := s.outboxWriter.(interface{ Noop() bool }); ok && n.Noop() {
-		s.logger.Debug("order-create: outbox entry processed (noop: not persisted)",
-			slog.String("order_id", order.ID),
-			slog.String("entry_id", entry.ID),
-			slog.String("topic", entry.RoutingTopic()),
-		)
-	} else {
-		s.logger.Info("order-create: outbox entry written",
-			slog.String("order_id", order.ID),
-			slog.String("entry_id", entry.ID),
-			slog.String("topic", entry.RoutingTopic()),
-		)
-	}
+	s.logger.Info("order-create: event emitted",
+		slog.String("order_id", order.ID),
+		slog.String("entry_id", entry.ID),
+		slog.String("topic", entry.RoutingTopic()),
+	)
 	return order, nil
 }
 

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/service_test.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/service_test.go
@@ -34,6 +34,13 @@ func (w *recordingWriter) Write(_ context.Context, entry outbox.Entry) error {
 
 var _ outbox.Writer = (*recordingWriter)(nil)
 
+func mustEmitter(t testing.TB, w outbox.Writer) outbox.Emitter {
+	t.Helper()
+	emitter, err := outbox.NewWriterEmitter(w)
+	require.NoError(t, err)
+	return emitter
+}
+
 type stubTxRunner struct {
 	calls int
 }
@@ -67,7 +74,7 @@ func TestService_Create(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewService(mem.NewOrderRepository(), slog.Default(),
-				WithOutboxWriter(outbox.NoopWriter{}),
+				WithEmitter(mustEmitter(t, outbox.NoopWriter{})),
 				WithTxManager(persistence.NoopTxRunner{}),
 			)
 
@@ -93,7 +100,7 @@ func TestService_Create_WritesOutboxEntry(t *testing.T) {
 	repo := mem.NewOrderRepository()
 	writer := &recordingWriter{}
 	txRunner := &stubTxRunner{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(writer), WithTxManager(txRunner))
+	svc := NewService(repo, slog.Default(), WithEmitter(mustEmitter(t, writer)), WithTxManager(txRunner))
 
 	order, err := svc.Create(context.Background(), "outbox-item")
 	require.NoError(t, err)
@@ -112,7 +119,7 @@ func TestService_Create_OutboxWriterFailureReturnsError(t *testing.T) {
 	repo := mem.NewOrderRepository()
 	writer := &recordingWriter{err: errors.New("outbox unavailable")}
 	txRunner := &stubTxRunner{}
-	svc := NewService(repo, slog.Default(), WithOutboxWriter(writer), WithTxManager(txRunner))
+	svc := NewService(repo, slog.Default(), WithEmitter(mustEmitter(t, writer)), WithTxManager(txRunner))
 
 	order, err := svc.Create(context.Background(), "outbox-item")
 	require.Error(t, err)
@@ -133,7 +140,7 @@ func TestService_Create_NoopWriterDemoPath(t *testing.T) {
 	// Demo mode: NoopWriter validates entries then discards. Same outbox code path.
 	repo := mem.NewOrderRepository()
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(outbox.NoopWriter{}),
+		WithEmitter(mustEmitter(t, outbox.NoopWriter{})),
 		WithTxManager(persistence.NoopTxRunner{}),
 	)
 
@@ -146,7 +153,7 @@ func TestService_Create_NoopWriterDemoPath(t *testing.T) {
 func TestService_Create_PersistsOrder(t *testing.T) {
 	repo := mem.NewOrderRepository()
 	svc := NewService(repo, slog.Default(),
-		WithOutboxWriter(outbox.NoopWriter{}),
+		WithEmitter(mustEmitter(t, outbox.NoopWriter{})),
 		WithTxManager(persistence.NoopTxRunner{}),
 	)
 
@@ -170,7 +177,7 @@ func (failRepo) Create(_ context.Context, _ *domain.Order) error {
 
 func TestService_Create_RepoFailure(t *testing.T) {
 	svc := NewService(failRepo{}, slog.Default(),
-		WithOutboxWriter(outbox.NoopWriter{}),
+		WithEmitter(mustEmitter(t, outbox.NoopWriter{})),
 		WithTxManager(persistence.NoopTxRunner{}),
 	)
 

--- a/kernel/outbox/doc.go
+++ b/kernel/outbox/doc.go
@@ -1,6 +1,6 @@
 // Package outbox defines interfaces for the transactional outbox pattern:
-// Writer (insert within a transaction), Relay (poll-and-publish), Publisher
-// (fire-and-forget), and Subscriber (consume).
+// Writer (insert within a transaction), Emitter (write-or-direct abstraction),
+// Relay (poll-and-publish), Publisher (fire-and-forget), and Subscriber (consume).
 //
 // The package also provides the L4 (Device Latent) command queue state machine:
 // CommandEntry, CommandStatus (Pending→Sent→Delivered→Succeeded/Failed/Expired/Canceled),

--- a/kernel/outbox/emitter.go
+++ b/kernel/outbox/emitter.go
@@ -1,0 +1,115 @@
+package outbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// Emitter emits an outbox entry either by writing it to a durable outbox or by
+// directly publishing its canonical wire envelope.
+type Emitter interface {
+	Emit(ctx context.Context, entry Entry) error
+}
+
+// DirectPublishFailureMode controls direct publisher error handling.
+type DirectPublishFailureMode int
+
+const (
+	DirectPublishFailClosed DirectPublishFailureMode = iota + 1
+	DirectPublishFailOpen
+)
+
+// WriterEmitter emits by writing entries to the transactional outbox.
+type WriterEmitter struct {
+	writer Writer
+}
+
+// NewWriterEmitter adapts an outbox Writer into an Emitter.
+func NewWriterEmitter(w Writer) (*WriterEmitter, error) {
+	if isNilEmitterDependency(w) {
+		return nil, errcode.New(errcode.ErrCellMissingOutbox,
+			"outbox: nil writer for WriterEmitter")
+	}
+	return &WriterEmitter{writer: w}, nil
+}
+
+// NewNoopEmitter returns an Emitter backed by NoopWriter.
+func NewNoopEmitter() Emitter {
+	return &WriterEmitter{writer: NoopWriter{}}
+}
+
+func (e *WriterEmitter) Emit(ctx context.Context, entry Entry) error {
+	if e == nil || isNilEmitterDependency(e.writer) {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"outbox: nil writer for WriterEmitter")
+	}
+	return e.writer.Write(ctx, entry)
+}
+
+var _ Emitter = (*WriterEmitter)(nil)
+
+// DirectEmitter emits by wrapping entries in the v1 wire envelope and calling
+// Publisher.Publish directly.
+type DirectEmitter struct {
+	publisher Publisher
+	mode      DirectPublishFailureMode
+	logger    *slog.Logger
+}
+
+// NewDirectEmitter adapts a Publisher into an Emitter that publishes v1 wire
+// envelopes. A nil logger uses slog.Default().
+func NewDirectEmitter(p Publisher, mode DirectPublishFailureMode, loggers ...*slog.Logger) (*DirectEmitter, error) {
+	if isNilEmitterDependency(p) {
+		return nil, errcode.New(errcode.ErrCellMissingOutbox,
+			"outbox: nil publisher for DirectEmitter")
+	}
+	logger := slog.Default()
+	if len(loggers) > 0 && loggers[0] != nil {
+		logger = loggers[0]
+	}
+	return &DirectEmitter{publisher: p, mode: mode, logger: logger}, nil
+}
+
+func (e *DirectEmitter) Emit(ctx context.Context, entry Entry) error {
+	if e == nil || isNilEmitterDependency(e.publisher) {
+		return errcode.New(errcode.ErrCellMissingOutbox,
+			"outbox: nil publisher for DirectEmitter")
+	}
+	if err := entry.Validate(); err != nil {
+		return err
+	}
+	envelope, err := MarshalEnvelope(entry)
+	if err != nil {
+		return err
+	}
+	topic := entry.RoutingTopic()
+	if err := e.publisher.Publish(ctx, topic, envelope); err != nil {
+		if e.mode == DirectPublishFailOpen {
+			e.logger.Warn("outbox: direct publish failed (fail-open)",
+				slog.String("topic", topic),
+				slog.String("error", err.Error()))
+			return nil
+		}
+		return fmt.Errorf("outbox: direct publish failed for topic %s: %w", topic, err)
+	}
+	return nil
+}
+
+var _ Emitter = (*DirectEmitter)(nil)
+
+func isNilEmitterDependency(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/kernel/outbox/emitter_test.go
+++ b/kernel/outbox/emitter_test.go
@@ -1,0 +1,122 @@
+package outbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ Emitter = (*WriterEmitter)(nil)
+var _ Emitter = (*DirectEmitter)(nil)
+
+func TestWriterEmitter_ConstructRejectsNilWriter(t *testing.T) {
+	_, err := NewWriterEmitter(nil)
+
+	assert.Error(t, err)
+}
+
+func TestWriterEmitter_EmitDelegatesToWriter(t *testing.T) {
+	writer := &recordingEmitterWriter{}
+	emitter, err := NewWriterEmitter(writer)
+	require.NoError(t, err)
+
+	entry := validEntry("writer-emitter")
+	err = emitter.Emit(context.Background(), entry)
+
+	require.NoError(t, err)
+	require.Len(t, writer.entries, 1)
+	assert.Equal(t, entry.ID, writer.entries[0].ID)
+}
+
+func TestDirectEmitter_ConstructRejectsNilPublisher(t *testing.T) {
+	_, err := NewDirectEmitter(nil, DirectPublishFailClosed)
+
+	assert.Error(t, err)
+}
+
+func TestDirectEmitter_EmitWrapsV1EnvelopeAndPublishes(t *testing.T) {
+	publisher := &recordingEmitterPublisher{}
+	emitter, err := NewDirectEmitter(publisher, DirectPublishFailClosed)
+	require.NoError(t, err)
+
+	entry := validEntry("direct-emitter")
+	entry.Topic = "direct.topic.v1"
+	entry.EventType = "direct.event.v1"
+
+	err = emitter.Emit(context.Background(), entry)
+
+	require.NoError(t, err)
+	require.Len(t, publisher.calls, 1)
+	assert.Equal(t, entry.Topic, publisher.calls[0].topic)
+
+	got, err := UnmarshalEnvelope(entry.Topic, publisher.calls[0].payload)
+	require.NoError(t, err)
+	assert.Equal(t, entry.ID, got.ID)
+	assert.Equal(t, entry.EventType, got.EventType)
+	assert.Equal(t, entry.Topic, got.Topic)
+	assert.Equal(t, string(entry.Payload), string(got.Payload))
+}
+
+func TestDirectEmitter_FailClosedReturnsPublishError(t *testing.T) {
+	want := errors.New("broker down")
+	publisher := &recordingEmitterPublisher{err: want}
+	emitter, err := NewDirectEmitter(publisher, DirectPublishFailClosed)
+	require.NoError(t, err)
+
+	got := emitter.Emit(context.Background(), validEntry("direct-fail-closed"))
+
+	assert.ErrorIs(t, got, want)
+}
+
+func TestDirectEmitter_FailOpenSwallowsPublishError(t *testing.T) {
+	want := errors.New("broker down")
+	publisher := &recordingEmitterPublisher{err: want}
+	emitter, err := NewDirectEmitter(publisher, DirectPublishFailOpen)
+	require.NoError(t, err)
+
+	got := emitter.Emit(context.Background(), validEntry("direct-fail-open"))
+
+	assert.NoError(t, got)
+	require.Len(t, publisher.calls, 1, "fail-open must still attempt publish")
+}
+
+func TestDirectEmitter_InvalidEntryFailsBeforePublish(t *testing.T) {
+	publisher := &recordingEmitterPublisher{}
+	emitter, err := NewDirectEmitter(publisher, DirectPublishFailOpen)
+	require.NoError(t, err)
+
+	got := emitter.Emit(context.Background(), Entry{})
+
+	assert.Error(t, got)
+	assert.Empty(t, publisher.calls)
+}
+
+type recordingEmitterWriter struct {
+	entries []Entry
+	err     error
+}
+
+func (w *recordingEmitterWriter) Write(_ context.Context, entry Entry) error {
+	w.entries = append(w.entries, entry)
+	return w.err
+}
+
+type emitterPublishCall struct {
+	topic   string
+	payload []byte
+}
+
+type recordingEmitterPublisher struct {
+	calls []emitterPublishCall
+	err   error
+}
+
+func (p *recordingEmitterPublisher) Publish(_ context.Context, topic string, payload []byte) error {
+	p.calls = append(p.calls, emitterPublishCall{topic: topic, payload: payload})
+	return p.err
+}
+
+func (p *recordingEmitterPublisher) Close(_ context.Context) error { return nil }

--- a/kernel/outbox/envelope.go
+++ b/kernel/outbox/envelope.go
@@ -1,0 +1,110 @@
+package outbox
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// EnvelopeSchemaV1 is the canonical schema version for outbox wire envelopes.
+const EnvelopeSchemaV1 = "v1"
+
+// ErrUnknownEnvelopeVersion is returned when a wire message carries an
+// unrecognised or absent schemaVersion field.
+var ErrUnknownEnvelopeVersion = errcode.New(errcode.ErrEnvelopeSchema,
+	"outbox: unknown envelope schema version")
+
+// WireMessage is the canonical wire envelope used by outbox relay and direct
+// publisher paths across transports.
+type WireMessage struct {
+	SchemaVersion string            `json:"schemaVersion"`
+	ID            string            `json:"id"`
+	AggregateID   string            `json:"aggregateId,omitempty"`
+	AggregateType string            `json:"aggregateType,omitempty"`
+	EventType     string            `json:"eventType"`
+	Topic         string            `json:"topic,omitempty"`
+	Payload       json.RawMessage   `json:"payload"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	CreatedAt     time.Time         `json:"createdAt"`
+	Attempts      int               `json:"attempts,omitempty"`
+}
+
+// MarshalEnvelope serializes an Entry into the canonical v1 wire envelope.
+func MarshalEnvelope(entry Entry) ([]byte, error) {
+	createdAt := entry.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	msg := WireMessage{
+		SchemaVersion: EnvelopeSchemaV1,
+		ID:            entry.ID,
+		AggregateID:   entry.AggregateID,
+		AggregateType: entry.AggregateType,
+		EventType:     entry.EventType,
+		Topic:         entry.RoutingTopic(),
+		Payload:       json.RawMessage(entry.Payload),
+		Metadata:      entry.Metadata,
+		CreatedAt:     createdAt,
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.ErrEnvelopeSchema, "outbox: marshal envelope", err)
+	}
+	return b, nil
+}
+
+// MarshalDirectEnvelope builds a v1 wire envelope for direct-publish paths.
+func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) []byte {
+	if id == "" {
+		panic("outbox.MarshalDirectEnvelope: empty id")
+	}
+	if eventType == "" {
+		panic("outbox.MarshalDirectEnvelope: empty eventType")
+	}
+	raw, err := MarshalEnvelope(Entry{
+		ID:        id,
+		EventType: eventType,
+		Topic:     topic,
+		Payload:   payload,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		panic("outbox.MarshalDirectEnvelope: json.Marshal unexpectedly failed: " + err.Error())
+	}
+	return raw
+}
+
+// UnmarshalEnvelope decodes a v1 wire envelope into an Entry.
+func UnmarshalEnvelope(topic string, raw []byte) (Entry, error) {
+	var msg WireMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return Entry{}, errcode.Wrap(errcode.ErrEnvelopeSchema,
+			"outbox: unmarshal envelope", err)
+	}
+	if msg.SchemaVersion != EnvelopeSchemaV1 {
+		return Entry{}, ErrUnknownEnvelopeVersion
+	}
+	if msg.ID == "" {
+		return Entry{}, errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox: envelope missing required field: id")
+	}
+	if msg.EventType == "" {
+		return Entry{}, errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox: envelope missing required field: eventType")
+	}
+	entryTopic := msg.Topic
+	if entryTopic == "" {
+		entryTopic = topic
+	}
+	return Entry{
+		ID:            msg.ID,
+		AggregateID:   msg.AggregateID,
+		AggregateType: msg.AggregateType,
+		EventType:     msg.EventType,
+		Topic:         entryTopic,
+		Payload:       []byte(msg.Payload),
+		Metadata:      msg.Metadata,
+		CreatedAt:     msg.CreatedAt,
+	}, nil
+}

--- a/kernel/outbox/envelope_test.go
+++ b/kernel/outbox/envelope_test.go
@@ -1,0 +1,139 @@
+package outbox
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalEnvelope_StampsSchemaVersionV1(t *testing.T) {
+	entry := Entry{
+		ID:        "stamp-id-1",
+		EventType: "test.event.v1",
+		Topic:     "test.event.v1",
+		Payload:   []byte(`{"key":"value"}`),
+		CreatedAt: time.Now(),
+	}
+
+	raw, err := MarshalEnvelope(entry)
+	require.NoError(t, err)
+
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	var got string
+	require.NoError(t, json.Unmarshal(m["schemaVersion"], &got))
+	assert.Equal(t, EnvelopeSchemaV1, got)
+}
+
+func TestUnmarshalEnvelope_V1Success(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 30, 0, 0, time.UTC)
+	entry := Entry{
+		ID:            "v1-id-1",
+		AggregateID:   "agg-100",
+		AggregateType: "Order",
+		EventType:     "order.created.v1",
+		Topic:         "order.created.v1",
+		Payload:       []byte(`{"orderId":"o-1","amount":99}`),
+		Metadata:      map[string]string{"trace_id": "t-123"},
+		CreatedAt:     now,
+	}
+
+	raw, err := MarshalEnvelope(entry)
+	require.NoError(t, err)
+
+	got, err := UnmarshalEnvelope(entry.Topic, raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, entry.ID, got.ID)
+	assert.Equal(t, entry.AggregateID, got.AggregateID)
+	assert.Equal(t, entry.AggregateType, got.AggregateType)
+	assert.Equal(t, entry.EventType, got.EventType)
+	assert.Equal(t, entry.Topic, got.Topic)
+	assert.Equal(t, string(entry.Payload), string(got.Payload))
+	assert.Equal(t, entry.Metadata, got.Metadata)
+	assert.True(t, got.CreatedAt.Equal(now))
+}
+
+func TestUnmarshalEnvelope_UnknownVersionRejected(t *testing.T) {
+	raw := []byte(`{"schemaVersion":"v99","id":"x","eventType":"foo.v1","payload":{"data":"y"},"createdAt":"2026-04-23T00:00:00Z"}`)
+
+	_, err := UnmarshalEnvelope("foo.v1", raw)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownEnvelopeVersion)
+}
+
+func TestUnmarshalEnvelope_BrokenJSONRejected(t *testing.T) {
+	_, err := UnmarshalEnvelope("some.topic", []byte(`not json at all {{{`))
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrUnknownEnvelopeVersion)
+
+	var ce *errcode.Error
+	require.True(t, errors.As(err, &ce))
+	assert.Equal(t, errcode.ErrEnvelopeSchema, ce.Code)
+}
+
+func TestUnmarshalEnvelope_MissingRequiredFieldRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{
+			name: "empty id",
+			raw:  []byte(`{"schemaVersion":"v1","id":"","eventType":"foo.v1","payload":{"d":"y"},"createdAt":"2026-04-23T00:00:00Z"}`),
+		},
+		{
+			name: "empty eventType",
+			raw:  []byte(`{"schemaVersion":"v1","id":"some-id","eventType":"","payload":{"d":"y"},"createdAt":"2026-04-23T00:00:00Z"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := UnmarshalEnvelope("foo.v1", tt.raw)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestMarshalDirectEnvelope_ProducesV1(t *testing.T) {
+	topic := "event.session.created.v1"
+	id := "direct-id-1"
+	payload := []byte(`{"sessionId":"s-1","userId":"u-42"}`)
+
+	raw := MarshalDirectEnvelope(topic, topic, id, payload)
+
+	got, err := UnmarshalEnvelope(topic, raw)
+	require.NoError(t, err)
+	assert.Equal(t, id, got.ID)
+	assert.Equal(t, topic, got.EventType)
+	assert.Equal(t, topic, got.Topic)
+	assert.Equal(t, string(payload), string(got.Payload))
+}
+
+func TestMarshalDirectEnvelope_PanicsOnEmptyRequiredFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		topic     string
+		eventType string
+		id        string
+	}{
+		{name: "empty id", topic: "t.v1", eventType: "t.v1", id: ""},
+		{name: "empty eventType", topic: "t.v1", eventType: "", id: "some-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Panics(t, func() {
+				_ = MarshalDirectEnvelope(tt.topic, tt.eventType, tt.id, []byte(`{}`))
+			})
+		})
+	}
+}

--- a/kernel/persistence/tx.go
+++ b/kernel/persistence/tx.go
@@ -32,3 +32,14 @@ var _ TxRunner = NoopTxRunner{}
 
 // Noop implements cell.Nooper. CheckNotNoop rejects NoopTxRunner in durable mode.
 func (NoopTxRunner) Noop() bool { return true }
+
+// RunnerOrNoop returns r when it is non-nil, otherwise an explicit NoopTxRunner.
+//
+// This keeps call paths unconditional while still making demo-mode transaction
+// behavior visible to durability checks.
+func RunnerOrNoop(r TxRunner) TxRunner {
+	if r == nil {
+		return NoopTxRunner{}
+	}
+	return r
+}

--- a/kernel/persistence/tx_test.go
+++ b/kernel/persistence/tx_test.go
@@ -50,3 +50,48 @@ func TestNoopTxRunner_PassesContext(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestRunnerOrNoop_NilReturnsNoop(t *testing.T) {
+	runner := RunnerOrNoop(nil)
+
+	_, ok := runner.(NoopTxRunner)
+	assert.True(t, ok, "nil TxRunner must become NoopTxRunner")
+
+	var called bool
+	err := runner.RunInTx(context.Background(), func(context.Context) error {
+		called = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called, "NoopTxRunner fallback must execute fn")
+}
+
+func TestRunnerOrNoop_RealRunnerReturnedUnchanged(t *testing.T) {
+	real := &recordingTxRunner{}
+
+	runner := RunnerOrNoop(real)
+
+	assert.Same(t, real, runner)
+	err := runner.RunInTx(context.Background(), func(context.Context) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, real.calls)
+}
+
+func TestRunnerOrNoop_NilFallbackPreservesNilFnPanic(t *testing.T) {
+	runner := RunnerOrNoop(nil)
+
+	assert.PanicsWithValue(t, "persistence: nil fn passed to RunInTx", func() {
+		_ = runner.RunInTx(context.Background(), nil)
+	})
+}
+
+type recordingTxRunner struct {
+	calls int
+}
+
+func (r *recordingTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	r.calls++
+	return fn(ctx)
+}

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -33,6 +33,22 @@ func newStubCell(id string) *stubCell {
 	return &stubCell{BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: id, Type: cell.CellTypeCore})}
 }
 
+func findAccessLogEntry(logs []byte, wantPath string) (map[string]any, bool) {
+	for _, line := range bytes.Split(logs, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry["msg"] == "http request" && entry["path"] == wantPath {
+			return entry, true
+		}
+	}
+	return nil, false
+}
+
 func TestRouterImplementsRouteMux(t *testing.T) {
 	r := New()
 	var mux cell.RouteMux = r
@@ -184,23 +200,9 @@ func TestPanicRequestRecordedInAccessLog(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
-	// Parse all JSON log entries and find the access log (level=INFO, msg="http request").
-	var found bool
-	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
-		if len(line) == 0 {
-			continue
-		}
-		var entry map[string]any
-		if err := json.Unmarshal(line, &entry); err != nil {
-			continue
-		}
-		if entry["msg"] == "http request" {
-			found = true
-			assert.Equal(t, float64(500), entry["status"], "access log must capture status 500 for panic requests")
-			break
-		}
-	}
-	assert.True(t, found, "access log entry must exist for panic request")
+	entry, found := findAccessLogEntry(buf.Bytes(), "/boom")
+	require.True(t, found, "access log entry must exist for panic request")
+	assert.Equal(t, float64(500), entry["status"], "access log must capture status 500 for panic requests")
 }
 
 func TestPanicRequestRecordedInMetrics(t *testing.T) {
@@ -243,22 +245,9 @@ func TestNormalRequestUnchanged(t *testing.T) {
 	assert.Equal(t, `{"data":"ok"}`, rec.Body.String())
 
 	// Verify access log has status 200.
-	var found bool
-	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
-		if len(line) == 0 {
-			continue
-		}
-		var entry map[string]any
-		if err := json.Unmarshal(line, &entry); err != nil {
-			continue
-		}
-		if entry["msg"] == "http request" {
-			found = true
-			assert.Equal(t, float64(200), entry["status"])
-			break
-		}
-	}
-	assert.True(t, found, "access log entry must exist")
+	entry, found := findAccessLogEntry(buf.Bytes(), "/ok")
+	require.True(t, found, "access log entry must exist")
+	assert.Equal(t, float64(200), entry["status"])
 
 	// Verify metrics recorded status 200.
 	snap := mc.Snapshot()
@@ -454,22 +443,9 @@ func TestWithTracer_TraceIDInAccessLog(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	// Parse the access log entry and check for trace_id.
-	var found bool
-	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
-		if len(line) == 0 {
-			continue
-		}
-		var entry map[string]any
-		if err := json.Unmarshal(line, &entry); err != nil {
-			continue
-		}
-		if entry["msg"] == "http request" {
-			found = true
-			assert.NotEmpty(t, entry["trace_id"], "access log must include trace_id when tracing is configured")
-			break
-		}
-	}
-	assert.True(t, found, "access log entry must exist")
+	entry, found := findAccessLogEntry(buf.Bytes(), "/log-trace")
+	require.True(t, found, "access log entry must exist")
+	assert.NotEmpty(t, entry["trace_id"], "access log must include trace_id when tracing is configured")
 }
 
 func TestAccessLog_IncludesRealIP(t *testing.T) {
@@ -492,24 +468,11 @@ func TestAccessLog_IncludesRealIP(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	// Parse all JSON log entries and find the access log (msg="http request").
-	var found bool
-	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
-		if len(line) == 0 {
-			continue
-		}
-		var entry map[string]any
-		if err := json.Unmarshal(line, &entry); err != nil {
-			continue
-		}
-		if entry["msg"] == "http request" {
-			found = true
-			assert.Equal(t, "203.0.113.50", entry["real_ip"],
-				"access log must include real_ip extracted from X-Forwarded-For")
-			break
-		}
-	}
-	assert.True(t, found, "access log entry must exist")
+	// Parse all JSON log entries and find the access log for this request.
+	entry, found := findAccessLogEntry(buf.Bytes(), "/real-ip-test")
+	require.True(t, found, "access log entry must exist")
+	assert.Equal(t, "203.0.113.50", entry["real_ip"],
+		"access log must include real_ip extracted from X-Forwarded-For")
 }
 
 func TestWithTracer_PanicRequestTraced(t *testing.T) {

--- a/runtime/outbox/envelope.go
+++ b/runtime/outbox/envelope.go
@@ -1,154 +1,32 @@
 package outbox
 
-import (
-	"encoding/json"
-	"time"
+import kout "github.com/ghbvf/gocell/kernel/outbox"
 
-	kout "github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/pkg/errcode"
-)
+// EnvelopeSchemaV1 is kept for compatibility; kernel/outbox owns the value.
+const EnvelopeSchemaV1 = kout.EnvelopeSchemaV1
 
-// EnvelopeSchemaV1 is the canonical schema version for outbox wire envelopes.
-// All envelopes produced by MarshalEnvelope carry this version; UnmarshalEnvelope
-// rejects any message that does not match.
-const EnvelopeSchemaV1 = "v1"
+// ErrUnknownEnvelopeVersion is kept for compatibility; kernel/outbox owns the
+// sentinel so errors.Is works across runtime and kernel callers.
+var ErrUnknownEnvelopeVersion = kout.ErrUnknownEnvelopeVersion
 
-// ErrUnknownEnvelopeVersion is returned by UnmarshalEnvelope when the inbound
-// wire message carries an unrecognised (or absent) schemaVersion field.
-// Consumers must treat this as a permanent error and route to DLX, not retry.
-//
-// ref: Watermill message/router.go handleMessage — unknown message type → Nack, no retry
-var ErrUnknownEnvelopeVersion = errcode.New(errcode.ErrEnvelopeSchema,
-	"outbox: unknown envelope schema version")
+// WireMessage is kept for compatibility; kernel/outbox owns the wire schema.
+type WireMessage = kout.WireMessage
 
-// WireMessage is the canonical wire envelope used by outbox relay publishers
-// across all transports (in-memory eventbus, RabbitMQ, future Kafka). Transports
-// MUST unmarshal payloads through UnmarshalEnvelope to share this contract.
-//
-// Fields use camelCase JSON tags, matching the serialization produced by
-// adapters/postgres/outbox_relay.go publishAll and consumed by
-// adapters/rabbitmq/subscriber.go unmarshalDelivery. Keeping a single canonical
-// struct here replaces the duplicated outboxMessage / outboxWireMessage definitions
-// scattered across those two packages.
-//
-// ref: Watermill message.Message — payload + metadata envelope
-type WireMessage struct {
-	SchemaVersion string            `json:"schemaVersion"`
-	ID            string            `json:"id"`
-	AggregateID   string            `json:"aggregateId,omitempty"`
-	AggregateType string            `json:"aggregateType,omitempty"`
-	EventType     string            `json:"eventType"`
-	Topic         string            `json:"topic,omitempty"`
-	Payload       json.RawMessage   `json:"payload"`
-	Metadata      map[string]string `json:"metadata,omitempty"`
-	CreatedAt     time.Time         `json:"createdAt"`
-	Attempts      int               `json:"attempts,omitempty"`
-}
-
-// MarshalEnvelope serializes a ClaimedEntry into the wire envelope JSON.
-// The output always carries SchemaVersion = EnvelopeSchemaV1.
+// MarshalEnvelope serializes a claimed runtime entry into the canonical v1
+// wire envelope. Attempts stays runtime relay/store state and is not part of
+// the kernel-owned envelope contract.
 func MarshalEnvelope(entry ClaimedEntry) ([]byte, error) {
-	msg := WireMessage{
-		SchemaVersion: EnvelopeSchemaV1,
-		ID:            entry.ID,
-		AggregateID:   entry.AggregateID,
-		AggregateType: entry.AggregateType,
-		EventType:     entry.EventType,
-		Topic:         entry.RoutingTopic(),
-		Payload:       json.RawMessage(entry.Payload),
-		Metadata:      entry.Metadata,
-		CreatedAt:     entry.CreatedAt,
-		Attempts:      entry.Attempts,
-	}
-	b, err := json.Marshal(msg)
-	if err != nil {
-		return nil, errcode.Wrap(errcode.ErrEnvelopeSchema, "outbox: marshal envelope", err)
-	}
-	return b, nil
+	return kout.MarshalEnvelope(entry.Entry)
 }
 
-// MarshalDirectEnvelope builds a v1 wire envelope for direct-publish paths
-// (demo mode L2 cells, L4 cells without outbox writer) that do not go through
-// the relay. The returned bytes are suitable for passing to outbox.Publisher.Publish.
-//
-// eventType is the canonical event name (e.g. "event.session.created.v1") —
-// typically the same as topic for direct paths. id must be globally unique
-// (callers should use outbox.NewEntryID() to construct it). payload is the
-// business JSON bytes that handlers will receive in Entry.Payload after the
-// bus unwraps.
-//
-// Panics on empty id or eventType — these are programmer errors (internal
-// producers pass compile-time constants / NewEntryID()), not runtime
-// conditions. Follows the stdlib Must-style convention (regexp.MustCompile,
-// netip.MustParseAddr) so callers are not forced to handle unreachable
-// branches. json.Marshal of a WireMessage with valid string/byte fields
-// does not fail, so the internal marshal error is also treated as unreachable.
+// MarshalDirectEnvelope delegates direct-publish envelope construction to
+// kernel/outbox while preserving the runtime/outbox call site.
 func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) []byte {
-	if id == "" {
-		panic("outbox.MarshalDirectEnvelope: empty id")
-	}
-	if eventType == "" {
-		panic("outbox.MarshalDirectEnvelope: empty eventType")
-	}
-	msg := WireMessage{
-		SchemaVersion: EnvelopeSchemaV1,
-		ID:            id,
-		EventType:     eventType,
-		Topic:         topic,
-		Payload:       json.RawMessage(payload),
-		CreatedAt:     time.Now().UTC(),
-	}
-	b, err := json.Marshal(msg)
-	if err != nil {
-		// Unreachable: WireMessage fields are strings and []byte; json.Marshal
-		// only fails on cyclic references or unsupported types, neither of which
-		// applies here. Panic so any regression surfaces at the call site.
-		panic("outbox.MarshalDirectEnvelope: json.Marshal unexpectedly failed: " + err.Error())
-	}
-	return b
+	return kout.MarshalDirectEnvelope(topic, eventType, id, payload)
 }
 
-// UnmarshalEnvelope decodes a v1 wire envelope from raw bytes into a kernel/outbox.Entry.
-//
-// Fail-closed semantics (ref: Watermill router.go, K8s workqueue fail-closed):
-//   - JSON parse failure → ErrEnvelopeSchema-coded error wrapping the json error
-//     (distinct from ErrUnknownEnvelopeVersion by sentinel identity; callers that
-//     need to distinguish parse vs schema-version use errors.Is against the
-//     sentinel, while code-based observability groups both under
-//     ErrEnvelopeSchema)
-//   - schemaVersion != "v1" (or absent) → ErrUnknownEnvelopeVersion
-//   - empty ID or EventType → ErrEnvelopeSchema error
-//
-// Legacy fallback has been removed. All producers MUST emit v1 envelopes.
-// Consumers that receive non-v1 messages must Reject (route to DLX), not retry.
+// UnmarshalEnvelope delegates envelope decoding to kernel/outbox while
+// preserving the runtime/outbox call site.
 func UnmarshalEnvelope(topic string, raw []byte) (kout.Entry, error) {
-	var msg WireMessage
-	if err := json.Unmarshal(raw, &msg); err != nil {
-		return kout.Entry{}, errcode.Wrap(errcode.ErrEnvelopeSchema,
-			"outbox: unmarshal envelope", err)
-	}
-
-	if msg.SchemaVersion != EnvelopeSchemaV1 {
-		return kout.Entry{}, ErrUnknownEnvelopeVersion
-	}
-
-	if msg.ID == "" {
-		return kout.Entry{}, errcode.New(errcode.ErrEnvelopeSchema,
-			"outbox: envelope missing required field: id")
-	}
-	if msg.EventType == "" {
-		return kout.Entry{}, errcode.New(errcode.ErrEnvelopeSchema,
-			"outbox: envelope missing required field: eventType")
-	}
-
-	return kout.Entry{
-		ID:            msg.ID,
-		AggregateID:   msg.AggregateID,
-		AggregateType: msg.AggregateType,
-		EventType:     msg.EventType,
-		Topic:         msg.Topic,
-		Payload:       []byte(msg.Payload),
-		Metadata:      msg.Metadata,
-		CreatedAt:     msg.CreatedAt,
-	}, nil
+	return kout.UnmarshalEnvelope(topic, raw)
 }

--- a/runtime/outbox/envelope_test.go
+++ b/runtime/outbox/envelope_test.go
@@ -3,6 +3,7 @@ package outbox_test
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -230,6 +231,61 @@ func TestMarshalEnvelope_WireFormat(t *testing.T) {
 	}
 }
 
+func TestMarshalEnvelope_DelegatesToKernelEnvelope(t *testing.T) {
+	entry := outbox.ClaimedEntry{
+		Entry: kout.Entry{
+			ID:            "kernel-delegate-id",
+			AggregateID:   "agg-kernel-delegate",
+			AggregateType: "Widget",
+			EventType:     "widget.delegated.v1",
+			Topic:         "widgets.v1",
+			Payload:       []byte(`{"widgetId":"w-1"}`),
+			Metadata:      map[string]string{"trace_id": "trace-1"},
+			CreatedAt:     time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+		},
+		Attempts: 4,
+	}
+
+	got, err := outbox.MarshalEnvelope(entry)
+	if err != nil {
+		t.Fatalf("runtime MarshalEnvelope: %v", err)
+	}
+	want, err := kout.MarshalEnvelope(entry.Entry)
+	if err != nil {
+		t.Fatalf("kernel MarshalEnvelope: %v", err)
+	}
+
+	assertJSONEqual(t, got, want)
+}
+
+func TestUnmarshalEnvelope_DelegatesKernelTopicFallback(t *testing.T) {
+	raw := []byte(`{"schemaVersion":"v1","id":"fallback-id","eventType":"fallback.event.v1","payload":{"ok":true},"createdAt":"2026-04-23T00:00:00Z"}`)
+
+	got, err := outbox.UnmarshalEnvelope("fallback.topic.v1", raw)
+	if err != nil {
+		t.Fatalf("UnmarshalEnvelope: %v", err)
+	}
+
+	if got.Topic != "fallback.topic.v1" {
+		t.Errorf("Topic: got %q, want fallback topic", got.Topic)
+	}
+}
+
+func TestUnmarshalEnvelope_UsesKernelVersionSentinel(t *testing.T) {
+	if !errors.Is(outbox.ErrUnknownEnvelopeVersion, kout.ErrUnknownEnvelopeVersion) {
+		t.Fatal("runtime ErrUnknownEnvelopeVersion must delegate to kernel sentinel")
+	}
+
+	raw := []byte(`{"schemaVersion":"v99","id":"x","eventType":"foo.v1","payload":{"data":"y"},"createdAt":"2026-04-23T00:00:00Z"}`)
+	_, err := outbox.UnmarshalEnvelope("foo.v1", raw)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, kout.ErrUnknownEnvelopeVersion) {
+		t.Errorf("expected kernel ErrUnknownEnvelopeVersion, got: %v", err)
+	}
+}
+
 // TestMarshalDirectEnvelope_ProducesV1 verifies that direct-publish envelopes
 // carry SchemaVersion=v1 and the supplied fields, and round-trip through
 // UnmarshalEnvelope so the bus delivers the business payload unchanged.
@@ -318,5 +374,21 @@ func TestUnmarshalEnvelope_MetadataTransparent(t *testing.T) {
 	}
 	if len(got.Metadata) != len(meta) {
 		t.Errorf("Metadata len: got %d, want %d", len(got.Metadata), len(meta))
+	}
+}
+
+func assertJSONEqual(t *testing.T, got, want []byte) {
+	t.Helper()
+
+	var gotJSON any
+	if err := json.Unmarshal(got, &gotJSON); err != nil {
+		t.Fatalf("unmarshal got JSON: %v", err)
+	}
+	var wantJSON any
+	if err := json.Unmarshal(want, &wantJSON); err != nil {
+		t.Fatalf("unmarshal want JSON: %v", err)
+	}
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		t.Fatalf("JSON mismatch:\n got: %s\nwant: %s", got, want)
 	}
 }

--- a/tools/archtest/doc.go
+++ b/tools/archtest/doc.go
@@ -7,9 +7,9 @@
 //
 // Rules enforced (from CLAUDE.md):
 //
-//   LAYER-01: kernel/ may only import stdlib, pkg/, and kernel/ (allow-list)
-//   LAYER-02: cells/ must not import adapters/
-//   LAYER-03: runtime/ must not import cells/ or adapters/
-//   LAYER-04: adapters/ must not import cells/, cmd/, or examples/
-//   LAYER-05: cells/A must not import cells/B/internal/ (cross-cell isolation)
+//	LAYER-01: kernel/ may only import stdlib, pkg/, and kernel/ (allow-list)
+//	LAYER-02: cells/ must not import adapters/
+//	LAYER-03: runtime/ must not import cells/ or adapters/
+//	LAYER-04: adapters/ must not import cells/, cmd/, or examples/
+//	LAYER-05: cells/A must not import cells/B/internal/ (cross-cell isolation)
 package archtest

--- a/tools/archtest/outbox_service_test.go
+++ b/tools/archtest/outbox_service_test.go
@@ -1,0 +1,237 @@
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	outboxServiceRuleTxRunnerNil     = "OUTBOX-SERVICE-01"
+	outboxServiceRuleDirectPublish   = "OUTBOX-SERVICE-02"
+	outboxServiceRuleRuntimeOutbox   = "OUTBOX-SERVICE-03"
+	outboxServiceRulePublisherMode   = "OUTBOX-SERVICE-04"
+	outboxRuntimeImportRelPath       = "runtime/outbox"
+	outboxServiceGlobReadablePattern = "cells/**/slices/**/service.go"
+)
+
+type outboxServiceViolation struct {
+	Rule    string
+	File    string
+	Line    int
+	Message string
+}
+
+func (v outboxServiceViolation) String() string {
+	return fmt.Sprintf("%s: %s:%d: %s", v.Rule, v.File, v.Line, v.Message)
+}
+
+func TestSliceServicesDoNotBypassTransactionalOutbox(t *testing.T) {
+	root := findModuleRoot(t)
+	modPath := readModulePath(t, root)
+
+	violations := checkSliceServiceOutboxRules(t, root, modPath)
+	byRule := groupOutboxServiceViolations(violations)
+
+	if len(violations) > 0 {
+		t.Logf("Found %d outbox service architecture violation(s):", len(violations))
+		for _, v := range violations {
+			t.Logf("  %s", v)
+		}
+	}
+
+	t.Run("OUTBOX-SERVICE-01_no_txrunner_nil_mode", func(t *testing.T) {
+		assert.Empty(t, byRule[outboxServiceRuleTxRunnerNil],
+			"%s must not branch on txRunner == nil or txRunner != nil", outboxServiceGlobReadablePattern)
+	})
+	t.Run("OUTBOX-SERVICE-02_no_direct_publisher_publish", func(t *testing.T) {
+		assert.Empty(t, byRule[outboxServiceRuleDirectPublish],
+			"%s must not call Publisher.Publish directly from the service layer", outboxServiceGlobReadablePattern)
+	})
+	t.Run("OUTBOX-SERVICE-03_no_runtime_outbox_import", func(t *testing.T) {
+		assert.Empty(t, byRule[outboxServiceRuleRuntimeOutbox],
+			"%s must not import runtime/outbox", outboxServiceGlobReadablePattern)
+	})
+	t.Run("OUTBOX-SERVICE-04_no_publisher_mode_parsing", func(t *testing.T) {
+		assert.Empty(t, byRule[outboxServiceRulePublisherMode],
+			"%s must not depend on outbox.Publisher or construct DirectEmitter; Cell boundary owns mode parsing", outboxServiceGlobReadablePattern)
+	})
+}
+
+func checkSliceServiceOutboxRules(t *testing.T, root, modPath string) []outboxServiceViolation {
+	t.Helper()
+
+	files, err := findSliceServiceFiles(root)
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "no %s files found", outboxServiceGlobReadablePattern)
+
+	var violations []outboxServiceViolation
+	for _, file := range files {
+		fileViolations, err := checkSliceServiceOutboxFile(root, modPath, file)
+		require.NoError(t, err)
+		violations = append(violations, fileViolations...)
+	}
+	return violations
+}
+
+func findSliceServiceFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(filepath.Join(root, "cells"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "vendor" || d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if isSliceServiceFile(root, path) {
+			files = append(files, path)
+		}
+		return nil
+	})
+	sort.Strings(files)
+	return files, err
+}
+
+func isSliceServiceFile(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	return strings.HasPrefix(rel, "cells/") &&
+		strings.Contains(rel, "/slices/") &&
+		strings.HasSuffix(rel, "/service.go")
+}
+
+func checkSliceServiceOutboxFile(root, modPath, path string) ([]outboxServiceViolation, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return nil, err
+	}
+	rel = filepath.ToSlash(rel)
+
+	var violations []outboxServiceViolation
+	for _, imp := range file.Imports {
+		importPath, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			return nil, err
+		}
+		if importPath == modPath+"/"+outboxRuntimeImportRelPath {
+			violations = append(violations, outboxServiceViolation{
+				Rule:    outboxServiceRuleRuntimeOutbox,
+				File:    rel,
+				Line:    fset.Position(imp.Pos()).Line,
+				Message: "service layer must not import runtime/outbox",
+			})
+		}
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch expr := n.(type) {
+		case *ast.BinaryExpr:
+			if isTxRunnerNilComparison(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRuleTxRunnerNil,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not branch on txRunner nil mode",
+				})
+			}
+		case *ast.CallExpr:
+			if isDirectPublishCall(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRuleDirectPublish,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not call Publisher.Publish directly",
+				})
+			}
+			if isDirectEmitterConstructor(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRulePublisherMode,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not construct DirectEmitter",
+				})
+			}
+		case *ast.SelectorExpr:
+			if isOutboxPublisherSelector(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRulePublisherMode,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not expose outbox.Publisher dependencies",
+				})
+			}
+		}
+		return true
+	})
+
+	return violations, nil
+}
+
+func isTxRunnerNilComparison(expr *ast.BinaryExpr) bool {
+	if expr.Op != token.EQL && expr.Op != token.NEQ {
+		return false
+	}
+	return (isTxRunnerExpr(expr.X) && isNilIdent(expr.Y)) ||
+		(isNilIdent(expr.X) && isTxRunnerExpr(expr.Y))
+}
+
+func isTxRunnerExpr(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "txRunner"
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "txRunner"
+	default:
+		return false
+	}
+}
+
+func isNilIdent(expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == "nil"
+}
+
+func isDirectPublishCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "Publish"
+}
+
+func isDirectEmitterConstructor(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "NewDirectEmitter"
+}
+
+func isOutboxPublisherSelector(expr *ast.SelectorExpr) bool {
+	ident, ok := expr.X.(*ast.Ident)
+	return ok && ident.Name == "outbox" && expr.Sel.Name == "Publisher"
+}
+
+func groupOutboxServiceViolations(violations []outboxServiceViolation) map[string][]string {
+	byRule := make(map[string][]string)
+	for _, v := range violations {
+		byRule[v.Rule] = append(byRule[v.Rule], v.String())
+	}
+	return byRule
+}

--- a/tools/archtest/outbox_service_test.go
+++ b/tools/archtest/outbox_service_test.go
@@ -21,6 +21,7 @@ const (
 	outboxServiceRuleDirectPublish   = "OUTBOX-SERVICE-02"
 	outboxServiceRuleRuntimeOutbox   = "OUTBOX-SERVICE-03"
 	outboxServiceRulePublisherMode   = "OUTBOX-SERVICE-04"
+	outboxServiceRuleWriterAdapter   = "OUTBOX-SERVICE-05_no_writer_adapter_option"
 	outboxRuntimeImportRelPath       = "runtime/outbox"
 	outboxServiceGlobReadablePattern = "cells/**/slices/**/service.go"
 )
@@ -65,6 +66,10 @@ func TestSliceServicesDoNotBypassTransactionalOutbox(t *testing.T) {
 	t.Run("OUTBOX-SERVICE-04_no_publisher_mode_parsing", func(t *testing.T) {
 		assert.Empty(t, byRule[outboxServiceRulePublisherMode],
 			"%s must not depend on outbox.Publisher or construct DirectEmitter; Cell boundary owns mode parsing", outboxServiceGlobReadablePattern)
+	})
+	t.Run("OUTBOX-SERVICE-05_no_writer_adapter_option", func(t *testing.T) {
+		assert.Empty(t, byRule[outboxServiceRuleWriterAdapter],
+			"%s must not define WithOutboxWriter; service layer owns WithEmitter / WithTxManager only", outboxServiceGlobReadablePattern)
 	})
 }
 
@@ -147,6 +152,23 @@ func checkSliceServiceOutboxFile(root, modPath, path string) ([]outboxServiceVio
 
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch expr := n.(type) {
+		case *ast.FuncDecl:
+			if isWithOutboxWriterFunc(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRuleWriterAdapter,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not define WithOutboxWriter adapter option",
+				})
+			}
+			if isPublisherModeParsingFunc(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRulePublisherMode,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not define direct-publisher mode helpers/options",
+				})
+			}
 		case *ast.BinaryExpr:
 			if isTxRunnerNilComparison(expr) {
 				violations = append(violations, outboxServiceViolation{
@@ -182,11 +204,45 @@ func checkSliceServiceOutboxFile(root, modPath, path string) ([]outboxServiceVio
 					Message: "service layer must not expose outbox.Publisher dependencies",
 				})
 			}
+			if isOutboxDirectPublishModeSelector(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRulePublisherMode,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not reference outbox direct-publish mode types or constants",
+				})
+			}
+		case *ast.Field:
+			if hasPublisherModeState(expr.Names) || isPublishFailureModeExpr(expr.Type) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRulePublisherMode,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not store publisher mode state",
+				})
+			}
+		case *ast.Ident:
+			if isPublisherModeIdent(expr) {
+				violations = append(violations, outboxServiceViolation{
+					Rule:    outboxServiceRulePublisherMode,
+					File:    rel,
+					Line:    fset.Position(expr.Pos()).Line,
+					Message: "service layer must not define or use direct-publisher mode names",
+				})
+			}
 		}
 		return true
 	})
 
 	return violations, nil
+}
+
+func isWithOutboxWriterFunc(fn *ast.FuncDecl) bool {
+	return fn.Name.Name == "WithOutboxWriter"
+}
+
+func isPublisherModeParsingFunc(fn *ast.FuncDecl) bool {
+	return fn.Name.Name == "WithPublishFailureMode" || fn.Name.Name == "directPublishMode"
 }
 
 func isTxRunnerNilComparison(expr *ast.BinaryExpr) bool {
@@ -226,6 +282,48 @@ func isDirectEmitterConstructor(call *ast.CallExpr) bool {
 func isOutboxPublisherSelector(expr *ast.SelectorExpr) bool {
 	ident, ok := expr.X.(*ast.Ident)
 	return ok && ident.Name == "outbox" && expr.Sel.Name == "Publisher"
+}
+
+func isOutboxDirectPublishModeSelector(expr *ast.SelectorExpr) bool {
+	ident, ok := expr.X.(*ast.Ident)
+	if !ok || ident.Name != "outbox" {
+		return false
+	}
+	switch expr.Sel.Name {
+	case "DirectPublishFailureMode", "DirectPublishFailOpen", "DirectPublishFailClosed":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasPublisherModeState(names []*ast.Ident) bool {
+	for _, name := range names {
+		if name != nil && name.Name == "publishFailureMode" {
+			return true
+		}
+	}
+	return false
+}
+
+func isPublishFailureModeExpr(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "PublishFailureMode"
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "PublishFailureMode"
+	default:
+		return false
+	}
+}
+
+func isPublisherModeIdent(id *ast.Ident) bool {
+	switch id.Name {
+	case "WithPublishFailureMode", "directPublishMode", "publishFailureMode":
+		return true
+	default:
+		return false
+	}
 }
 
 func groupOutboxServiceViolations(violations []outboxServiceViolation) map[string][]string {


### PR DESCRIPTION
## Summary

- centralize outbox wire envelopes and event emitters in `kernel/outbox`
- add `persistence.RunnerOrNoop` and move demo-mode no-op Tx/outbox defaults to Cell boundaries
- refactor L2 slice services to use `persistence.TxRunner` + `outbox.Emitter`
- keep `runtime/outbox` focused on store/relay runtime state through kernel envelope wrappers
- add archtest guards against nil TxRunner branching, direct service publish calls, runtime/outbox imports, and service-level publisher mode parsing

## Impact

Demo assemblies can initialize without Tx/outbox dependencies by receiving explicit no-op defaults. Durable mode still fails fast when L2 Cells lack a real writer or Tx runner. Direct publisher and durable writer paths now share the same v1 kernel outbox wire envelope.

## Validation

- `git diff --check`
- `go run ./cmd/gocell validate --strict` (0 errors, 3 existing warnings)
- `go build ./...`
- `go test ./...`
- `golangci-lint run ./cmd/corebundle ./cells/accesscore/... ./cells/auditcore/... ./cells/configcore/... ./cells/ordercell/... ./cells/devicecell/... ./kernel/outbox/... ./kernel/persistence ./runtime/outbox/... ./tools/archtest`
