### PR TITLE
docs: register PR #225 reviewer findings (N1, NF-2) to backlog

### DIFF
--- a/docs/plans/docs-backlog-md-docs-reviews-2026042219-graceful-backus.md
+++ b/docs/plans/docs-backlog-md-docs-reviews-2026042219-graceful-backus.md
@@ -194,6 +194,7 @@
 | S24 | **AUTH-MIDDLEWARE-AUD-REFRESH-E2E-01** `httptest.NewServer` + 真实 `AuthMiddleware` | 1h 🟡 | `runtime/auth/middleware_aud_test.go` |
 | F10 | **TEST-JOURNEY-ASSEMBLY-HARNESS-01** 28 条 `t.Skip` journey 集成测试 | 8h 🟡 | `tests/integration/` + assembly fixture |
 | A10 | **OBS-LGTM-INTEGRATION-01** 夜间 OTel collector OTLP 兼容性 | 2h 🟡 | `adapters/otel/integration_test.go` |
+| N1 | **RMQ-WAITANDCLOSE-ABANDONED-GOROUTINE-TEST-01** `subscription_run.waitAndClose` 在 ctx 超时后留下 goroutine 跑完 `localWg.Wait()` 再 `close(done)`（无接收方），属于 intentional abandoned-on-timeout 模式但缺测试覆盖确认其最终退出 | 2h | `adapters/rabbitmq/subscription_run.go` + `subscription_run_test.go`（来源：PR #225 reviewer 第二轮 N1） |
 
 #### CI / 供应链
 

--- a/docs/plans/docs-backlog-md-docs-reviews-2026042219-graceful-backus.md
+++ b/docs/plans/docs-backlog-md-docs-reviews-2026042219-graceful-backus.md
@@ -195,6 +195,7 @@
 | F10 | **TEST-JOURNEY-ASSEMBLY-HARNESS-01** 28 条 `t.Skip` journey 集成测试 | 8h 🟡 | `tests/integration/` + assembly fixture |
 | A10 | **OBS-LGTM-INTEGRATION-01** 夜间 OTel collector OTLP 兼容性 | 2h 🟡 | `adapters/otel/integration_test.go` |
 | N1 | **RMQ-WAITANDCLOSE-ABANDONED-GOROUTINE-TEST-01** `subscription_run.waitAndClose` 在 ctx 超时后留下 goroutine 跑完 `localWg.Wait()` 再 `close(done)`（无接收方），属于 intentional abandoned-on-timeout 模式但缺测试覆盖确认其最终退出 | 2h | `adapters/rabbitmq/subscription_run.go` + `subscription_run_test.go`（来源：PR #225 reviewer 第二轮 N1） |
+| NF-2 | **SESSIONLOGOUT-DOUBLE-REVOKE-TEST-FIX-01** `sessionlogout/service_test.go:86-93` "already revoked self logout" 用例只调 `s.Revoke()` 但漏 `repo.Update(ctx, s)`，revoke 标志未持久化；测试当前因 `RevokeByIDAndOwner` 对未撤销 session 也成功而通过——双重撤销幂等路径其实没被覆盖 | 0.5h | `cells/accesscore/slices/sessionlogout/service_test.go`（来源：PR #225 reviewer 第三轮 NF-2） |
 
 #### CI / 供应链
 


### PR DESCRIPTION
## Summary

Registers two PR #225 reviewer findings to the backlog as P2 测试覆盖 items. Both are **pre-existing** test gaps in files PR #225 did not touch — out-of-scope for that PR but worth tracking.

### N1 — RMQ-WAITANDCLOSE-ABANDONED-GOROUTINE-TEST-01

`adapters/rabbitmq/subscription_run.go` `waitAndClose` runs `localWg.Wait() + close(done)` in a goroutine after the outer function has already returned via the `ctx.Done()` branch. The unbuffered `done` channel has no receiver at that point. This is an intentional abandoned-on-timeout pattern (process-exit semantics consistent with fx StopTimeout) but lacks a regression test confirming the goroutine eventually exits without leaking.

### NF-2 — SESSIONLOGOUT-DOUBLE-REVOKE-TEST-FIX-01

`cells/accesscore/slices/sessionlogout/service_test.go:86-93` "already revoked self logout" case calls `s.Revoke()` on the retrieved domain object but never calls `repo.Update(ctx, s)` to persist the revoke flag. The in-memory repo's `RevokeByIDAndOwner` check passes for non-revoked sessions too, so the test passes without actually exercising double-revoke idempotency.

## Test plan

- [x] gocell validate --strict passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)