### PR TITLE
refactor(corebundle): per-cell HMAC loader + cursorCodecConfig struct (PR-227 P2 close-out)

### DIFF
--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -36,13 +36,13 @@ func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.C
 	// Cursor codec for accesscore: read env via LoadCursorKeys then build.
 	accessPrimary, accessPrevious := LoadCursorKeys("ACCESSCORE")
 	cursorCodec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  shared.Topology.AdapterMode,
-		EnvLabel:     "GOCELL_ACCESSCORE_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_ACCESSCORE_CURSOR_PREVIOUS_KEY",
-		Primary:      accessPrimary,
-		Previous:     accessPrevious,
-		DevDefault:   "corebundle-access-cursor-key32!!",
-		Label:        "access",
+		AdapterMode: shared.Topology.AdapterMode,
+		EnvName:     "GOCELL_ACCESSCORE_CURSOR_KEY",
+		PrevEnvName: "GOCELL_ACCESSCORE_CURSOR_PREVIOUS_KEY",
+		Primary:     accessPrimary,
+		Previous:    accessPrevious,
+		DevDefault:  "corebundle-access-cursor-key32!!",
+		Label:       "access",
 	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("accesscore cursor codec: %w", err)

--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -35,10 +35,15 @@ func (AccessCoreModule) ID() string { return "accesscore" }
 func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
 	// Cursor codec for accesscore: read env via LoadCursorKeys then build.
 	accessPrimary, accessPrevious := LoadCursorKeys("ACCESSCORE")
-	cursorCodec, err := buildCursorCodec(shared.Topology.AdapterMode,
-		"GOCELL_ACCESSCORE_CURSOR_KEY", "GOCELL_ACCESSCORE_CURSOR_PREVIOUS_KEY",
-		accessPrimary, accessPrevious,
-		"corebundle-access-cursor-key32!!", "access")
+	cursorCodec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  shared.Topology.AdapterMode,
+		EnvLabel:     "GOCELL_ACCESSCORE_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_ACCESSCORE_CURSOR_PREVIOUS_KEY",
+		Primary:      accessPrimary,
+		Previous:     accessPrevious,
+		DevDefault:   "corebundle-access-cursor-key32!!",
+		Label:        "access",
+	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("accesscore cursor codec: %w", err)
 	}

--- a/cmd/corebundle/audit_module.go
+++ b/cmd/corebundle/audit_module.go
@@ -29,21 +29,30 @@ func (AuditCoreModule) ID() string { return "auditcore" }
 func (AuditCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
 	// Cursor codec for auditcore: read env via LoadCursorKeys then build.
 	auditPrimary, auditPrevious := LoadCursorKeys("AUDITCORE")
-	cursorCodec, err := buildCursorCodec(shared.Topology.AdapterMode,
-		"GOCELL_AUDITCORE_CURSOR_KEY", "GOCELL_AUDITCORE_CURSOR_PREVIOUS_KEY",
-		auditPrimary, auditPrevious,
-		"corebundle-audit-cursor-key-32b!", "audit")
+	cursorCodec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  shared.Topology.AdapterMode,
+		EnvLabel:     "GOCELL_AUDITCORE_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_AUDITCORE_CURSOR_PREVIOUS_KEY",
+		Primary:      auditPrimary,
+		Previous:     auditPrevious,
+		DevDefault:   "corebundle-audit-cursor-key-32b!",
+		Label:        "audit",
+	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("auditcore cursor codec: %w", err)
 	}
 
 	// HMAC key for audit hash chain.
-	hmacKeyStr, err := loadSecret("GOCELL_AUDITCORE_HMAC_KEY", "dev-hmac-key-replace-in-prod!!!!", shared.Topology.AdapterMode)
+	hmacPrimary := LoadCellHMACKey("AUDITCORE")
+	hmacKeyStr, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: shared.Topology.AdapterMode,
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     hmacPrimary,
+		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
+		Label:       "auditcore HMAC",
+	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("auditcore HMAC key: %w", err)
-	}
-	if err := rejectDemoKey(shared.Topology.AdapterMode, "GOCELL_AUDITCORE_HMAC_KEY", hmacKeyStr); err != nil {
-		return nil, nil, nil, err
 	}
 
 	c := auditcore.NewAuditCore(

--- a/cmd/corebundle/audit_module.go
+++ b/cmd/corebundle/audit_module.go
@@ -30,13 +30,13 @@ func (AuditCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.Cell
 	// Cursor codec for auditcore: read env via LoadCursorKeys then build.
 	auditPrimary, auditPrevious := LoadCursorKeys("AUDITCORE")
 	cursorCodec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  shared.Topology.AdapterMode,
-		EnvLabel:     "GOCELL_AUDITCORE_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_AUDITCORE_CURSOR_PREVIOUS_KEY",
-		Primary:      auditPrimary,
-		Previous:     auditPrevious,
-		DevDefault:   "corebundle-audit-cursor-key-32b!",
-		Label:        "audit",
+		AdapterMode: shared.Topology.AdapterMode,
+		EnvName:     "GOCELL_AUDITCORE_CURSOR_KEY",
+		PrevEnvName: "GOCELL_AUDITCORE_CURSOR_PREVIOUS_KEY",
+		Primary:     auditPrimary,
+		Previous:    auditPrevious,
+		DevDefault:  "corebundle-audit-cursor-key-32b!",
+		Label:       "audit",
 	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("auditcore cursor codec: %w", err)
@@ -44,12 +44,11 @@ func (AuditCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.Cell
 
 	// HMAC key for audit hash chain.
 	hmacPrimary := LoadCellHMACKey("AUDITCORE")
-	hmacKeyStr, err := buildHMACKey(hmacKeyConfig{
+	hmacKey, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: shared.Topology.AdapterMode,
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     hmacPrimary,
 		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
-		Label:       "auditcore HMAC",
 	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("auditcore HMAC key: %w", err)
@@ -58,7 +57,7 @@ func (AuditCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.Cell
 	c := auditcore.NewAuditCore(
 		auditcore.WithInMemoryDefaults(),
 		auditcore.WithPublisher(shared.EventBus),
-		auditcore.WithHMACKey(hmacKeyStr),
+		auditcore.WithHMACKey(hmacKey),
 		auditcore.WithCursorCodec(cursorCodec),
 	)
 	return c, nil, nil, nil

--- a/cmd/corebundle/audit_module_test.go
+++ b/cmd/corebundle/audit_module_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/bootstrap"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalSharedDepsForAuditTest builds a SharedDeps that passes Validate() for
+// memory topology with an empty AdapterMode. It sets GOCELL_STATE_DIR and the
+// JWT env vars required by the build path, but leaves all cell-specific secrets
+// (HMAC key, cursor keys) for the caller to set via t.Setenv.
+func minimalSharedDepsForAuditTest(t *testing.T, adapterMode string) *SharedDeps {
+	t.Helper()
+	t.Setenv("GOCELL_STATE_DIR", t.TempDir())
+	t.Setenv("GOCELL_JWT_ISSUER", "test-issuer")
+	t.Setenv("GOCELL_JWT_AUDIENCE", "test-audience")
+
+	eb := eventbus.New()
+	privKey, pubKey := auth.MustGenerateTestKeyPair()
+	keySet, err := auth.NewKeySet(privKey, pubKey)
+	require.NoError(t, err)
+	issuer, err := auth.NewJWTIssuer(keySet, "test-issuer", 15*time.Minute,
+		auth.WithIssuerAudiencesFromSlice([]string{"test-audience"}))
+	require.NoError(t, err)
+	verifier, err := auth.NewJWTVerifier(keySet,
+		auth.WithExpectedAudiences("test-audience"))
+	require.NoError(t, err)
+
+	ps, err := buildPromStack()
+	require.NoError(t, err)
+
+	return &SharedDeps{
+		Topology:  bootstrap.Topology{StorageBackend: "memory", AdapterMode: adapterMode},
+		JWTDeps:   jwtDeps{issuer: issuer, verifier: verifier},
+		PromStack: ps,
+		EventBus:  eb,
+	}
+}
+
+// TestAuditCoreModule_Provide_HMACKeyMissing_RealMode verifies that when the
+// HMAC key env var is absent in adapter mode "real", AuditCoreModule.Provide
+// returns an error that:
+//   - contains the env variable name (GOCELL_AUDITCORE_HMAC_KEY) for operator
+//     diagnosis, and
+//   - contains the label prefix "auditcore HMAC" exactly once (outer module
+//     wrapper), not twice (which would indicate buildHMACKey also embeds it).
+//
+// This test will FAIL on HEAD where the error chain is:
+//
+//	"auditcore HMAC key: auditcore HMAC: GOCELL_AUDITCORE_HMAC_KEY must be set ..."
+//
+// giving strings.Count("auditcore HMAC") == 2.
+//
+// Refs: PR#232 review finding P2 (double label in audit module error chain).
+func TestAuditCoreModule_Provide_HMACKeyMissing_RealMode(t *testing.T) {
+	// Ensure the HMAC key env var is absent.
+	t.Setenv("GOCELL_AUDITCORE_HMAC_KEY", "")
+	// Provide a valid cursor key so the error comes from the HMAC path, not the
+	// cursor path.
+	t.Setenv("GOCELL_AUDITCORE_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
+
+	shared := minimalSharedDepsForAuditTest(t, "real")
+
+	_, _, _, err := AuditCoreModule{}.Provide(context.Background(), shared)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GOCELL_AUDITCORE_HMAC_KEY",
+		"error must name the env var for operator diagnosis")
+	// The label "auditcore HMAC" must appear exactly once (from the outer module
+	// wrapper "auditcore HMAC key: ..."). If buildHMACKey also embeds it the
+	// count rises to 2, which this assertion will catch.
+	assert.Equal(t, 1, strings.Count(err.Error(), "auditcore HMAC"),
+		"label must appear exactly once in the error chain; got %q", err.Error())
+}

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -101,6 +101,14 @@ func defaultRuntimeOptions(
 // Operators must explicitly opt in via GOCELL_CONFIGCORE_KEY_PROVIDER=local-aes
 // (dev/CI only) or vault-transit (production).
 //
+// Note: buildKeyProvider intentionally keeps a positional-argument signature
+// (unlike buildCursorCodec / buildHMACKey which use config structs) because
+// its input set is small, fixed, and semantically distinct per argument
+// (storageBackend determines whether encryption is required at all, the
+// other four only matter when providerName == "local-aes"). Wrapping in a
+// struct would obscure this branching logic. Revisit if a sixth argument is
+// ever needed.
+//
 // ref: kubernetes/kubernetes pkg/apiserver/admission/config.go — missing
 // EncryptionConfig in an active storage path is a startup error, not a warning.
 // ref: go-kratos/kratos config.Watch — required dependency failure aborts boot.

--- a/cmd/corebundle/config_module.go
+++ b/cmd/corebundle/config_module.go
@@ -48,10 +48,15 @@ var configStaleCipherOpts = prom.CounterOpts{
 func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
 	// 1. Cursor codec: read configcore-namespaced env via LoadCursorKeys then build.
 	cfgPrimary, cfgPrevious := LoadCursorKeys("CONFIGCORE")
-	cursorCodec, err := buildCursorCodec(shared.Topology.AdapterMode,
-		"GOCELL_CONFIGCORE_CURSOR_KEY", "GOCELL_CONFIGCORE_CURSOR_PREVIOUS_KEY",
-		cfgPrimary, cfgPrevious,
-		"corebundle-cfg-cursor-key--32bb!", "config")
+	cursorCodec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  shared.Topology.AdapterMode,
+		EnvLabel:     "GOCELL_CONFIGCORE_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_CONFIGCORE_CURSOR_PREVIOUS_KEY",
+		Primary:      cfgPrimary,
+		Previous:     cfgPrevious,
+		DevDefault:   "corebundle-cfg-cursor-key--32bb!",
+		Label:        "config",
+	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("configcore cursor codec: %w", err)
 	}

--- a/cmd/corebundle/config_module.go
+++ b/cmd/corebundle/config_module.go
@@ -49,13 +49,13 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	// 1. Cursor codec: read configcore-namespaced env via LoadCursorKeys then build.
 	cfgPrimary, cfgPrevious := LoadCursorKeys("CONFIGCORE")
 	cursorCodec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  shared.Topology.AdapterMode,
-		EnvLabel:     "GOCELL_CONFIGCORE_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_CONFIGCORE_CURSOR_PREVIOUS_KEY",
-		Primary:      cfgPrimary,
-		Previous:     cfgPrevious,
-		DevDefault:   "corebundle-cfg-cursor-key--32bb!",
-		Label:        "config",
+		AdapterMode: shared.Topology.AdapterMode,
+		EnvName:     "GOCELL_CONFIGCORE_CURSOR_KEY",
+		PrevEnvName: "GOCELL_CONFIGCORE_CURSOR_PREVIOUS_KEY",
+		Primary:     cfgPrimary,
+		Previous:    cfgPrevious,
+		DevDefault:  "corebundle-cfg-cursor-key--32bb!",
+		Label:       "config",
 	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("configcore cursor codec: %w", err)

--- a/cmd/corebundle/cursor_codec_test.go
+++ b/cmd/corebundle/cursor_codec_test.go
@@ -15,10 +15,15 @@ import (
 // adapterMode) the dev default secret produces a usable codec when primary is
 // empty, matching the dev-fallback contract.
 func TestBuildCursorCodec_DevDefault_Succeeds(t *testing.T) {
-	codec, err := buildCursorCodec("", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		"", "",
-		"corebundle-audit-cursor-key-32b!", "audit")
+	codec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      "",
+		Previous:     "",
+		DevDefault:   "corebundle-audit-cursor-key-32b!",
+		Label:        "audit",
+	})
 	require.NoError(t, err)
 	require.NotNil(t, codec)
 
@@ -30,10 +35,15 @@ func TestBuildCursorCodec_DevDefault_Succeeds(t *testing.T) {
 // mode "real" an empty primary triggers the hard-error branch, and the error
 // preserves the env-label for operator diagnosis.
 func TestBuildCursorCodec_RealModePrimaryEmpty_FailFast(t *testing.T) {
-	codec, err := buildCursorCodec("real", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		"", "",
-		"corebundle-audit-cursor-key-32b!", "audit")
+	codec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "real",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      "",
+		Previous:     "",
+		DevDefault:   "corebundle-audit-cursor-key-32b!",
+		Label:        "audit",
+	})
 	require.Error(t, err)
 	assert.Nil(t, codec)
 	assert.Contains(t, err.Error(), "GOCELL_TEST_CURSOR_KEY",
@@ -47,10 +57,15 @@ func TestBuildCursorCodec_RealModePrimaryEmpty_FailFast(t *testing.T) {
 // primary is non-empty, a well-known demo value is rejected in real mode.
 // Reachable if an operator copies the dev default into prod config.
 func TestBuildCursorCodec_DemoKeyInRealMode_Rejected(t *testing.T) {
-	_, err := buildCursorCodec("real", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		"corebundle-audit-cursor-key-32b!", "",
-		"corebundle-audit-cursor-key-32b!", "audit")
+	_, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "real",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      "corebundle-audit-cursor-key-32b!",
+		Previous:     "",
+		DevDefault:   "corebundle-audit-cursor-key-32b!",
+		Label:        "audit",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "well-known demo key",
 		"error must come from rejectDemoKey")
@@ -68,10 +83,15 @@ func TestBuildCursorCodec_WithPreviousKey_Rotation(t *testing.T) {
 	keyOld := bytes.Repeat([]byte("O"), 32)
 	keyStranger := bytes.Repeat([]byte("S"), 32)
 
-	codec, err := buildCursorCodec("real", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		string(keyNew), string(keyOld),
-		"unused-dev-default", "audit")
+	codec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "real",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      string(keyNew),
+		Previous:     string(keyOld),
+		DevDefault:   "unused-dev-default",
+		Label:        "audit",
+	})
 	require.NoError(t, err)
 
 	// Token signed by the old key (operator deployed it before the rotation)
@@ -98,10 +118,15 @@ func TestBuildCursorCodec_WithPreviousKey_Rotation(t *testing.T) {
 // than silently ignoring the rotation intent.
 func TestBuildCursorCodec_PreviousKeyShortInRealMode_FailFast(t *testing.T) {
 	keyNew := bytes.Repeat([]byte("N"), 32)
-	codec, err := buildCursorCodec("real", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		string(keyNew), "too-short",
-		"unused", "audit")
+	codec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "real",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      string(keyNew),
+		Previous:     "too-short",
+		DevDefault:   "unused",
+		Label:        "audit",
+	})
 	require.Error(t, err)
 	assert.Nil(t, codec)
 	// Error must come from NewCursorCodec previous-key length check and be
@@ -124,10 +149,15 @@ func TestBuildCursorCodec_PreviousKeyShortInRealMode_FailFast(t *testing.T) {
 // Single-key is the default stable state; rotation is a temporary window.
 func TestBuildCursorCodec_PreviousKeyEmpty_OK(t *testing.T) {
 	keyNew := bytes.Repeat([]byte("N"), 32)
-	codec, err := buildCursorCodec("real", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		string(keyNew), "",
-		"unused", "audit")
+	codec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "real",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      string(keyNew),
+		Previous:     "",
+		DevDefault:   "unused",
+		Label:        "audit",
+	})
 	require.NoError(t, err)
 	require.NotNil(t, codec)
 
@@ -144,10 +174,15 @@ func TestBuildCursorCodec_PreviousKeyEmpty_OK(t *testing.T) {
 // well-known demo value in the rotation slot.
 func TestBuildCursorCodec_PreviousKeyDemoInRealMode_Rejected(t *testing.T) {
 	keyNew := bytes.Repeat([]byte("N"), 32)
-	_, err := buildCursorCodec("real", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		string(keyNew), "corebundle-audit-cursor-key-32b!",
-		"unused", "audit")
+	_, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "real",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      string(keyNew),
+		Previous:     "corebundle-audit-cursor-key-32b!",
+		DevDefault:   "unused",
+		Label:        "audit",
+	})
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "demo")
 	assert.Contains(t, err.Error(), "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
@@ -160,10 +195,15 @@ func TestBuildCursorCodec_PreviousKeyDemoInRealMode_Rejected(t *testing.T) {
 // ref: S2-C1 — NewCursorCodec rejects identical current/previous keys.
 func TestBuildCursorCodec_CurrentEqualsPrevious_Rejected(t *testing.T) {
 	sameKey := bytes.Repeat([]byte("K"), 32)
-	codec, err := buildCursorCodec("real", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		string(sameKey), string(sameKey),
-		"unused", "audit")
+	codec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "real",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      string(sameKey),
+		Previous:     string(sameKey),
+		DevDefault:   "unused",
+		Label:        "audit",
+	})
 	require.Error(t, err)
 	assert.Nil(t, codec)
 	assert.Contains(t, err.Error(), "previous cursor key must differ from current",
@@ -174,10 +214,15 @@ func TestBuildCursorCodec_CurrentEqualsPrevious_Rejected(t *testing.T) {
 // current and previous keys are shorter than 32 bytes, the error reports the
 // current key length first (NewCursorCodec validates current before previous).
 func TestBuildCursorCodec_BothKeysShort_ReportsFirst(t *testing.T) {
-	codec, err := buildCursorCodec("", "GOCELL_TEST_CURSOR_KEY",
-		"GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		"short-current-11", "short-previous-1",
-		"unused-dev-default", "audit")
+	codec, err := buildCursorCodec(cursorCodecConfig{
+		AdapterMode:  "",
+		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:      "short-current-11",
+		Previous:     "short-previous-1",
+		DevDefault:   "unused-dev-default",
+		Label:        "audit",
+	})
 	require.Error(t, err)
 	assert.Nil(t, codec)
 	// NewCursorCodec validates current length first; the error must mention

--- a/cmd/corebundle/cursor_codec_test.go
+++ b/cmd/corebundle/cursor_codec_test.go
@@ -16,13 +16,13 @@ import (
 // empty, matching the dev-fallback contract.
 func TestBuildCursorCodec_DevDefault_Succeeds(t *testing.T) {
 	codec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      "",
-		Previous:     "",
-		DevDefault:   "corebundle-audit-cursor-key-32b!",
-		Label:        "audit",
+		AdapterMode: "",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     "",
+		Previous:    "",
+		DevDefault:  "corebundle-audit-cursor-key-32b!",
+		Label:       "audit",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, codec)
@@ -36,13 +36,13 @@ func TestBuildCursorCodec_DevDefault_Succeeds(t *testing.T) {
 // preserves the env-label for operator diagnosis.
 func TestBuildCursorCodec_RealModePrimaryEmpty_FailFast(t *testing.T) {
 	codec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "real",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      "",
-		Previous:     "",
-		DevDefault:   "corebundle-audit-cursor-key-32b!",
-		Label:        "audit",
+		AdapterMode: "real",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     "",
+		Previous:    "",
+		DevDefault:  "corebundle-audit-cursor-key-32b!",
+		Label:       "audit",
 	})
 	require.Error(t, err)
 	assert.Nil(t, codec)
@@ -58,13 +58,13 @@ func TestBuildCursorCodec_RealModePrimaryEmpty_FailFast(t *testing.T) {
 // Reachable if an operator copies the dev default into prod config.
 func TestBuildCursorCodec_DemoKeyInRealMode_Rejected(t *testing.T) {
 	_, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "real",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      "corebundle-audit-cursor-key-32b!",
-		Previous:     "",
-		DevDefault:   "corebundle-audit-cursor-key-32b!",
-		Label:        "audit",
+		AdapterMode: "real",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     "corebundle-audit-cursor-key-32b!",
+		Previous:    "",
+		DevDefault:  "corebundle-audit-cursor-key-32b!",
+		Label:       "audit",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "well-known demo key",
@@ -84,13 +84,13 @@ func TestBuildCursorCodec_WithPreviousKey_Rotation(t *testing.T) {
 	keyStranger := bytes.Repeat([]byte("S"), 32)
 
 	codec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "real",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      string(keyNew),
-		Previous:     string(keyOld),
-		DevDefault:   "unused-dev-default",
-		Label:        "audit",
+		AdapterMode: "real",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     string(keyNew),
+		Previous:    string(keyOld),
+		DevDefault:  "unused-dev-default",
+		Label:       "audit",
 	})
 	require.NoError(t, err)
 
@@ -119,13 +119,13 @@ func TestBuildCursorCodec_WithPreviousKey_Rotation(t *testing.T) {
 func TestBuildCursorCodec_PreviousKeyShortInRealMode_FailFast(t *testing.T) {
 	keyNew := bytes.Repeat([]byte("N"), 32)
 	codec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "real",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      string(keyNew),
-		Previous:     "too-short",
-		DevDefault:   "unused",
-		Label:        "audit",
+		AdapterMode: "real",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     string(keyNew),
+		Previous:    "too-short",
+		DevDefault:  "unused",
+		Label:       "audit",
 	})
 	require.Error(t, err)
 	assert.Nil(t, codec)
@@ -150,13 +150,13 @@ func TestBuildCursorCodec_PreviousKeyShortInRealMode_FailFast(t *testing.T) {
 func TestBuildCursorCodec_PreviousKeyEmpty_OK(t *testing.T) {
 	keyNew := bytes.Repeat([]byte("N"), 32)
 	codec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "real",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      string(keyNew),
-		Previous:     "",
-		DevDefault:   "unused",
-		Label:        "audit",
+		AdapterMode: "real",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     string(keyNew),
+		Previous:    "",
+		DevDefault:  "unused",
+		Label:       "audit",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, codec)
@@ -175,13 +175,13 @@ func TestBuildCursorCodec_PreviousKeyEmpty_OK(t *testing.T) {
 func TestBuildCursorCodec_PreviousKeyDemoInRealMode_Rejected(t *testing.T) {
 	keyNew := bytes.Repeat([]byte("N"), 32)
 	_, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "real",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      string(keyNew),
-		Previous:     "corebundle-audit-cursor-key-32b!",
-		DevDefault:   "unused",
-		Label:        "audit",
+		AdapterMode: "real",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     string(keyNew),
+		Previous:    "corebundle-audit-cursor-key-32b!",
+		DevDefault:  "unused",
+		Label:       "audit",
 	})
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "demo")
@@ -196,13 +196,13 @@ func TestBuildCursorCodec_PreviousKeyDemoInRealMode_Rejected(t *testing.T) {
 func TestBuildCursorCodec_CurrentEqualsPrevious_Rejected(t *testing.T) {
 	sameKey := bytes.Repeat([]byte("K"), 32)
 	codec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "real",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      string(sameKey),
-		Previous:     string(sameKey),
-		DevDefault:   "unused",
-		Label:        "audit",
+		AdapterMode: "real",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     string(sameKey),
+		Previous:    string(sameKey),
+		DevDefault:  "unused",
+		Label:       "audit",
 	})
 	require.Error(t, err)
 	assert.Nil(t, codec)
@@ -215,13 +215,13 @@ func TestBuildCursorCodec_CurrentEqualsPrevious_Rejected(t *testing.T) {
 // current key length first (NewCursorCodec validates current before previous).
 func TestBuildCursorCodec_BothKeysShort_ReportsFirst(t *testing.T) {
 	codec, err := buildCursorCodec(cursorCodecConfig{
-		AdapterMode:  "",
-		EnvLabel:     "GOCELL_TEST_CURSOR_KEY",
-		PrevEnvLabel: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
-		Primary:      "short-current-11",
-		Previous:     "short-previous-1",
-		DevDefault:   "unused-dev-default",
-		Label:        "audit",
+		AdapterMode: "",
+		EnvName:     "GOCELL_TEST_CURSOR_KEY",
+		PrevEnvName: "GOCELL_TEST_CURSOR_PREVIOUS_KEY",
+		Primary:     "short-current-11",
+		Previous:    "short-previous-1",
+		DevDefault:  "unused-dev-default",
+		Label:       "audit",
 	})
 	require.Error(t, err)
 	assert.Nil(t, codec)

--- a/cmd/corebundle/demo_keys_test.go
+++ b/cmd/corebundle/demo_keys_test.go
@@ -51,7 +51,7 @@ func TestDevDefaults_AreAllInWellKnownDemoKeys(t *testing.T) {
 	// Note: GOCELL_SERVICE_SECRET has no dev-default (empty disables the guard
 	// in dev mode); rejectDemoKey is called directly in internalGuardFromEnv.
 	devDefaults := []string{
-		"dev-hmac-key-replace-in-prod!!!!", // loadSecret("GOCELL_AUDITCORE_HMAC_KEY", ...)
+		"dev-hmac-key-replace-in-prod!!!!", // buildHMACKey("GOCELL_AUDITCORE_HMAC_KEY", ...)
 		"corebundle-audit-cursor-key-32b!", // buildCursorCodec(... LoadCursorKeys("AUDITCORE") ...)
 		"corebundle-cfg-cursor-key--32bb!", // buildCursorCodec(... LoadCursorKeys("CONFIGCORE") ...)
 	}

--- a/cmd/corebundle/hmac_key_test.go
+++ b/cmd/corebundle/hmac_key_test.go
@@ -13,10 +13,9 @@ import (
 func TestBuildHMACKey_DevDefault_Succeeds(t *testing.T) {
 	key, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: "",
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     "",
 		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
-		Label:       "auditcore HMAC",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []byte("dev-hmac-key-replace-in-prod!!!!"), key)
@@ -24,18 +23,18 @@ func TestBuildHMACKey_DevDefault_Succeeds(t *testing.T) {
 
 // TestBuildHMACKey_RealModePrimaryEmpty_FailFast asserts that in adapter
 // mode "real" an empty Primary triggers the hard-error branch, and the error
-// contains the label, env label, and adapter mode for operator diagnosis.
+// contains the env variable name and adapter mode for operator diagnosis.
+// Note: buildHMACKey no longer embeds a module label — that context is added
+// by the module caller (e.g. audit_module.go "auditcore HMAC key: ...").
 func TestBuildHMACKey_RealModePrimaryEmpty_FailFast(t *testing.T) {
 	key, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: "real",
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     "",
 		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
-		Label:       "auditcore HMAC",
 	})
 	require.Error(t, err)
 	assert.Nil(t, key)
-	assert.Contains(t, err.Error(), "auditcore HMAC", "error must include label")
 	assert.Contains(t, err.Error(), "GOCELL_AUDITCORE_HMAC_KEY", "error must name the env var")
 	assert.Contains(t, err.Error(), "adapter mode \"real\"", "error must indicate the triggering mode")
 }
@@ -45,10 +44,9 @@ func TestBuildHMACKey_RealModePrimaryEmpty_FailFast(t *testing.T) {
 func TestBuildHMACKey_DemoKeyInRealMode_Rejected(t *testing.T) {
 	key, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: "real",
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     "dev-hmac-key-replace-in-prod!!!!",
 		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
-		Label:       "auditcore HMAC",
 	})
 	require.Error(t, err)
 	assert.Nil(t, key)
@@ -63,10 +61,9 @@ func TestBuildHMACKey_HappyPath(t *testing.T) {
 	fresh := "this-is-a-fresh-real-hmac-key-!!"
 	key, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: "real",
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     fresh,
 		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
-		Label:       "auditcore HMAC",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []byte(fresh), key)
@@ -78,10 +75,9 @@ func TestBuildHMACKey_DevMode_NonDemoPrimary_Succeeds(t *testing.T) {
 	primary := "custom-dev-hmac-key-value-here!!"
 	key, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: "",
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     primary,
 		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
-		Label:       "auditcore HMAC",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []byte(primary), key)
@@ -97,10 +93,9 @@ func TestBuildHMACKey_DevMode_DemoKeyPrimary_Succeeds(t *testing.T) {
 	demoKey := "dev-hmac-key-replace-in-prod!!!!"
 	key, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: "",
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     demoKey,
 		DevDefault:  demoKey,
-		Label:       "auditcore HMAC",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []byte(demoKey), key,
@@ -108,25 +103,21 @@ func TestBuildHMACKey_DevMode_DemoKeyPrimary_Succeeds(t *testing.T) {
 }
 
 // TestBuildHMACKey_RealMode_ErrorFormat_NoDoubleLabel pins the expected error
-// format from buildHMACKey directly: the returned error must NOT self-embed the
-// label ("auditcore HMAC") — that context belongs to the module wrapper
-// (audit_module.go). Embedding it here causes a double-label when the module
+// format from buildHMACKey directly: the returned error must NOT self-embed a
+// module label — that context belongs to the module wrapper (audit_module.go).
+// Embedding a label in buildHMACKey causes a double-label when the module
 // prepends "auditcore HMAC key: ...".
 //
-// Expected post-fix: err.Error() == `GOCELL_AUDITCORE_HMAC_KEY must be set in
+// Expected: err.Error() == `GOCELL_AUDITCORE_HMAC_KEY must be set in
 // adapter mode "real"` (zero occurrences of "auditcore HMAC").
-//
-// This test will FAIL on HEAD where buildHMACKey emits
-// `"auditcore HMAC: GOCELL_AUDITCORE_HMAC_KEY must be set ..."`.
 //
 // Refs: PR#232 review finding P2 (double label in error chain).
 func TestBuildHMACKey_RealMode_ErrorFormat_NoDoubleLabel(t *testing.T) {
 	_, err := buildHMACKey(hmacKeyConfig{
 		AdapterMode: "real",
-		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		EnvName:     "GOCELL_AUDITCORE_HMAC_KEY",
 		Primary:     "",
 		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
-		Label:       "auditcore HMAC",
 	})
 	require.Error(t, err)
 	// buildHMACKey itself must NOT embed the label — the module wrapper owns that.

--- a/cmd/corebundle/hmac_key_test.go
+++ b/cmd/corebundle/hmac_key_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildHMACKey_DevDefault_Succeeds confirms that in dev mode (empty
+// AdapterMode) with an empty Primary, the DevDefault is returned as bytes.
+func TestBuildHMACKey_DevDefault_Succeeds(t *testing.T) {
+	key, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: "",
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     "",
+		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
+		Label:       "auditcore HMAC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("dev-hmac-key-replace-in-prod!!!!"), key)
+}
+
+// TestBuildHMACKey_RealModePrimaryEmpty_FailFast asserts that in adapter
+// mode "real" an empty Primary triggers the hard-error branch, and the error
+// contains the label, env label, and adapter mode for operator diagnosis.
+func TestBuildHMACKey_RealModePrimaryEmpty_FailFast(t *testing.T) {
+	key, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: "real",
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     "",
+		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
+		Label:       "auditcore HMAC",
+	})
+	require.Error(t, err)
+	assert.Nil(t, key)
+	assert.Contains(t, err.Error(), "auditcore HMAC", "error must include label")
+	assert.Contains(t, err.Error(), "GOCELL_AUDITCORE_HMAC_KEY", "error must name the env var")
+	assert.Contains(t, err.Error(), "adapter mode \"real\"", "error must indicate the triggering mode")
+}
+
+// TestBuildHMACKey_DemoKeyInRealMode_Rejected asserts that a well-known demo
+// value is rejected in real mode even when Primary is set.
+func TestBuildHMACKey_DemoKeyInRealMode_Rejected(t *testing.T) {
+	key, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: "real",
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     "dev-hmac-key-replace-in-prod!!!!",
+		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
+		Label:       "auditcore HMAC",
+	})
+	require.Error(t, err)
+	assert.Nil(t, key)
+	assert.Contains(t, err.Error(), "well-known demo key",
+		"error must come from rejectDemoKey")
+	assert.Contains(t, err.Error(), "GOCELL_AUDITCORE_HMAC_KEY")
+}
+
+// TestBuildHMACKey_HappyPath asserts that a non-demo primary key in real mode
+// is returned as-is without error.
+func TestBuildHMACKey_HappyPath(t *testing.T) {
+	fresh := "this-is-a-fresh-real-hmac-key-!!"
+	key, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: "real",
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     fresh,
+		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
+		Label:       "auditcore HMAC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte(fresh), key)
+}
+
+// TestBuildHMACKey_DevMode_NonDemoPrimary_Succeeds asserts that in dev mode
+// with a non-demo primary value, the primary is returned directly.
+func TestBuildHMACKey_DevMode_NonDemoPrimary_Succeeds(t *testing.T) {
+	primary := "custom-dev-hmac-key-value-here!!"
+	key, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: "",
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     primary,
+		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
+		Label:       "auditcore HMAC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte(primary), key)
+}

--- a/cmd/corebundle/hmac_key_test.go
+++ b/cmd/corebundle/hmac_key_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,4 +85,55 @@ func TestBuildHMACKey_DevMode_NonDemoPrimary_Succeeds(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []byte(primary), key)
+}
+
+// TestBuildHMACKey_DevMode_DemoKeyPrimary_Succeeds locks in the design decision
+// that rejectDemoKey is a no-op in dev mode: an operator who hasn't rotated
+// away from the well-known dev default must still be able to start the service
+// in dev/demo topology. Real mode is the enforcement gate.
+//
+// Refs: PR#232 review finding P2 (dev mode must not reject demo keys).
+func TestBuildHMACKey_DevMode_DemoKeyPrimary_Succeeds(t *testing.T) {
+	demoKey := "dev-hmac-key-replace-in-prod!!!!"
+	key, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: "",
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     demoKey,
+		DevDefault:  demoKey,
+		Label:       "auditcore HMAC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte(demoKey), key,
+		"dev mode must return the demo key without error — rejectDemoKey is a no-op outside real mode")
+}
+
+// TestBuildHMACKey_RealMode_ErrorFormat_NoDoubleLabel pins the expected error
+// format from buildHMACKey directly: the returned error must NOT self-embed the
+// label ("auditcore HMAC") — that context belongs to the module wrapper
+// (audit_module.go). Embedding it here causes a double-label when the module
+// prepends "auditcore HMAC key: ...".
+//
+// Expected post-fix: err.Error() == `GOCELL_AUDITCORE_HMAC_KEY must be set in
+// adapter mode "real"` (zero occurrences of "auditcore HMAC").
+//
+// This test will FAIL on HEAD where buildHMACKey emits
+// `"auditcore HMAC: GOCELL_AUDITCORE_HMAC_KEY must be set ..."`.
+//
+// Refs: PR#232 review finding P2 (double label in error chain).
+func TestBuildHMACKey_RealMode_ErrorFormat_NoDoubleLabel(t *testing.T) {
+	_, err := buildHMACKey(hmacKeyConfig{
+		AdapterMode: "real",
+		EnvLabel:    "GOCELL_AUDITCORE_HMAC_KEY",
+		Primary:     "",
+		DevDefault:  "dev-hmac-key-replace-in-prod!!!!",
+		Label:       "auditcore HMAC",
+	})
+	require.Error(t, err)
+	// buildHMACKey itself must NOT embed the label — the module wrapper owns that.
+	assert.Equal(t, 0, strings.Count(err.Error(), "auditcore HMAC"),
+		"buildHMACKey must not self-embed the label; got: %q", err.Error())
+	assert.Contains(t, err.Error(), "GOCELL_AUDITCORE_HMAC_KEY",
+		"error must still name the env var for operator diagnosis")
+	assert.Contains(t, err.Error(), "adapter mode \"real\"",
+		"error must indicate the triggering mode")
 }

--- a/cmd/corebundle/main_test.go
+++ b/cmd/corebundle/main_test.go
@@ -80,35 +80,6 @@ func TestLoadKeySet_UnknownMode_StillGeneratesEphemeral(t *testing.T) {
 	assert.NotNil(t, ks)
 }
 
-func TestLoadSecret_WithEnv(t *testing.T) {
-	t.Setenv("TEST_KEY_FOR_ENVDEFAULT", "actual-value")
-	got, err := loadSecret("TEST_KEY_FOR_ENVDEFAULT", "fallback", "")
-	require.NoError(t, err)
-	assert.Equal(t, []byte("actual-value"), got)
-}
-
-func TestLoadSecret_DevMode_Fallback(t *testing.T) {
-	t.Setenv("TEST_KEY_FOR_ENVDEFAULT_MISS", "")
-	got, err := loadSecret("TEST_KEY_FOR_ENVDEFAULT_MISS", "fallback", "")
-	require.NoError(t, err)
-	assert.Equal(t, []byte("fallback"), got)
-}
-
-func TestLoadSecret_RealMode_MissingEnv(t *testing.T) {
-	t.Setenv("TEST_KEY_REAL_MISS", "")
-	_, err := loadSecret("TEST_KEY_REAL_MISS", "fallback", "real")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "TEST_KEY_REAL_MISS")
-	assert.Contains(t, err.Error(), "real")
-}
-
-func TestLoadSecret_RealMode_WithEnv(t *testing.T) {
-	t.Setenv("TEST_KEY_REAL_OK", "prod-secret")
-	got, err := loadSecret("TEST_KEY_REAL_OK", "fallback", "real")
-	require.NoError(t, err)
-	assert.Equal(t, []byte("prod-secret"), got)
-}
-
 func TestRun_DevMode_StartsAndCancels(t *testing.T) {
 	// run() with an immediately-cancelled context exercises the full assembly
 	// path (cells, bootstrap) without needing a real HTTP listener.

--- a/cmd/corebundle/per_cell_adapter.go
+++ b/cmd/corebundle/per_cell_adapter.go
@@ -95,8 +95,14 @@ func LoadConfigCoreKeyProvider() (providerName, masterKey, prevMasterKey string)
 		os.Getenv("GOCELL_CONFIGCORE_MASTER_KEY_PREVIOUS")
 }
 
-// LoadAuditCoreHMACKey reads GOCELL_AUDITCORE_HMAC_KEY and returns its raw
-// string value. An empty value means the key is not configured.
-func LoadAuditCoreHMACKey() string {
-	return os.Getenv("GOCELL_AUDITCORE_HMAC_KEY")
+// LoadCellHMACKey reads the HMAC key env var for a specific cell using the
+// per-cell namespace convention (GOCELL_<CELLID>_HMAC_KEY). The returned value
+// is the raw env string — callers pass it to buildHMACKey for dev-fallback,
+// demo-key rejection, and real-mode fail-fast validation.
+//
+// cellEnvPrefix is the uppercase cell id (e.g. "AUDITCORE").
+//
+// ref: Kratos config/env prefix-strip convention.
+func LoadCellHMACKey(cellEnvPrefix string) string {
+	return os.Getenv("GOCELL_" + cellEnvPrefix + "_HMAC_KEY")
 }

--- a/cmd/corebundle/per_cell_adapter_test.go
+++ b/cmd/corebundle/per_cell_adapter_test.go
@@ -184,19 +184,30 @@ func TestLoadConfigCoreKeyProvider_AllEmpty(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestLoadAuditCoreHMACKey
+// TestLoadCellHMACKey
 // ---------------------------------------------------------------------------
 
-func TestLoadAuditCoreHMACKey_ReturnsValue(t *testing.T) {
+func TestLoadCellHMACKey_AUDITCORE_ReturnsValue(t *testing.T) {
 	t.Setenv("GOCELL_AUDITCORE_HMAC_KEY", "audit-hmac-key-value-here-32!!!!")
 
-	key := LoadAuditCoreHMACKey()
+	key := LoadCellHMACKey("AUDITCORE")
 	assert.Equal(t, "audit-hmac-key-value-here-32!!!!", key)
 }
 
-func TestLoadAuditCoreHMACKey_EmptyReturnsEmpty(t *testing.T) {
+func TestLoadCellHMACKey_AUDITCORE_EmptyReturnsEmpty(t *testing.T) {
 	t.Setenv("GOCELL_AUDITCORE_HMAC_KEY", "")
 
-	key := LoadAuditCoreHMACKey()
+	key := LoadCellHMACKey("AUDITCORE")
 	assert.Equal(t, "", key)
+}
+
+func TestLoadCellHMACKey_CrossCellIsolation(t *testing.T) {
+	t.Setenv("GOCELL_AUDITCORE_HMAC_KEY", "audit-hmac-key-value-here-32!!!!")
+	t.Setenv("GOCELL_CONFIGCORE_HMAC_KEY", "")
+
+	auditKey := LoadCellHMACKey("AUDITCORE")
+	configKey := LoadCellHMACKey("CONFIGCORE")
+
+	assert.Equal(t, "audit-hmac-key-value-here-32!!!!", auditKey)
+	assert.Equal(t, "", configKey, "CONFIGCORE prefix must not pick up AUDITCORE HMAC key")
 }

--- a/cmd/corebundle/secrets.go
+++ b/cmd/corebundle/secrets.go
@@ -4,30 +4,10 @@ package main
 import (
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
-
-// loadSecret loads a secret from the given environment variable. In "real"
-// adapter mode, the env var is required and missing values are a hard error.
-// In dev mode, missing values fall back to devDefault with a warning.
-//
-// ref: Kubernetes two-phase validation — Complete then Validate, both fail-fast.
-func loadSecret(envKey, devDefault, adapterMode string) ([]byte, error) {
-	if v := os.Getenv(envKey); v != "" {
-		return []byte(v), nil
-	}
-	if isRealMode(adapterMode) {
-		return nil, fmt.Errorf("%s must be set in adapter mode \"real\"", envKey)
-	}
-	slog.Warn("using dev-only default; set env var for production",
-		slog.String("var", envKey),
-		slog.String("mode", "dev-fallback"),
-		slog.String("action_required", "set env var before real mode"))
-	return []byte(devDefault), nil
-}
 
 // loadKeySet returns a KeySet, preferring environment-provided keys.
 // In "real" adapter mode, env keys are required (fail-fast if missing).
@@ -54,24 +34,54 @@ func loadKeySet(adapterMode string) (*auth.KeySet, error) {
 // cursorCodecConfig encapsulates buildCursorCodec parameters to avoid passing
 // 7 positional string arguments at every call site.
 type cursorCodecConfig struct {
-	AdapterMode  string
-	EnvLabel     string // primary env name, used only in error messages / slog
-	PrevEnvLabel string // previous env name, used only in error messages / slog
-	Primary      string
-	Previous     string
-	DevDefault   string
-	Label        string // "audit" / "config" / "access"
+	AdapterMode string
+	EnvName     string // primary env variable name, used in error messages / slog
+	PrevEnvName string // previous env variable name, used in error messages / slog
+	Primary     string
+	Previous    string
+	DevDefault  string
+	Label       string // "audit" / "config" / "access"
+}
+
+// resolveAndRejectDemoKey picks key material from the provided primary (or
+// falls back to devDefault in dev mode), fails fast in real mode when primary
+// is empty, and rejects known-demo key values. It is the shared prefix used by
+// buildCursorCodec and buildHMACKey — extracting it keeps the two public
+// builders slim and avoids SonarCloud duplication complaints on their
+// prologues.
+//
+// ref: go-zero core/service/serviceconf.go — strict mode rejects insecure
+// defaults uniformly across subsystems.
+func resolveAndRejectDemoKey(adapterMode, envLabel, primary, devDefault string) ([]byte, error) {
+	var key []byte
+	switch {
+	case primary != "":
+		key = []byte(primary)
+	case isRealMode(adapterMode):
+		return nil, fmt.Errorf("%s must be set in adapter mode \"real\"", envLabel)
+	default:
+		slog.Warn("using dev-only default; set env var for production",
+			slog.String("var", envLabel),
+			slog.String("mode", "dev-fallback"),
+			slog.String("action_required", "set env var before real mode"))
+		key = []byte(devDefault)
+	}
+	if err := rejectDemoKey(adapterMode, envLabel, key); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 // buildCursorCodec constructs a CursorCodec from already-read primary and
 // previous key strings. This is the low-level builder used by modules after
 // they read env via LoadCursorKeys; it does not call os.Getenv itself.
 //
-// Primary must be non-empty in "real" adapter mode (enforced via loadSecret
-// semantics: callers pass "" for primary when the env var was unset, which
-// triggers the real-mode fail-fast). Previous may be empty (single-key mode).
+// Primary must be non-empty in "real" adapter mode (enforced via
+// resolveAndRejectDemoKey: callers pass "" for primary when the env var was
+// unset, which triggers the real-mode fail-fast). Previous may be empty
+// (single-key mode).
 //
-// cfg.EnvLabel and cfg.PrevEnvLabel are used only in error messages and the
+// cfg.EnvName and cfg.PrevEnvName are used only in error messages and the
 // slog rotation log so operators can identify which env var to check.
 // cfg.DevDefault is used when primary is empty in dev mode.
 //
@@ -81,26 +91,15 @@ type cursorCodecConfig struct {
 // ref: gorilla/securecookie CodecsFromPairs — ordered key list, first match
 // wins during decode.
 func buildCursorCodec(cfg cursorCodecConfig) (*query.CursorCodec, error) {
-	var key []byte
-	if cfg.Primary != "" {
-		key = []byte(cfg.Primary)
-	} else if isRealMode(cfg.AdapterMode) {
-		return nil, fmt.Errorf("%s cursor key: %s must be set in adapter mode \"real\"", cfg.Label, cfg.EnvLabel)
-	} else {
-		slog.Warn("using dev-only default; set env var for production",
-			slog.String("var", cfg.EnvLabel),
-			slog.String("mode", "dev-fallback"),
-			slog.String("action_required", "set env var before real mode"))
-		key = []byte(cfg.DevDefault)
-	}
-	if err := rejectDemoKey(cfg.AdapterMode, cfg.EnvLabel, key); err != nil {
-		return nil, err
+	key, err := resolveAndRejectDemoKey(cfg.AdapterMode, cfg.EnvName, cfg.Primary, cfg.DevDefault)
+	if err != nil {
+		return nil, fmt.Errorf("%s cursor key: %w", cfg.Label, err)
 	}
 
 	var prevKey []byte
 	if cfg.Previous != "" {
 		prevKey = []byte(cfg.Previous)
-		if err := rejectDemoKey(cfg.AdapterMode, cfg.PrevEnvLabel, prevKey); err != nil {
+		if err := rejectDemoKey(cfg.AdapterMode, cfg.PrevEnvName, prevKey); err != nil {
 			return nil, err
 		}
 	}
@@ -112,8 +111,8 @@ func buildCursorCodec(cfg cursorCodecConfig) (*query.CursorCodec, error) {
 	if len(prevKey) > 0 {
 		slog.Info("cursor key rotation active",
 			slog.String("label", cfg.Label),
-			slog.String("current_env", cfg.EnvLabel),
-			slog.String("previous_env", cfg.PrevEnvLabel))
+			slog.String("current_env", cfg.EnvName),
+			slog.String("previous_env", cfg.PrevEnvName))
 	}
 	return codec, nil
 }
@@ -121,34 +120,22 @@ func buildCursorCodec(cfg cursorCodecConfig) (*query.CursorCodec, error) {
 // hmacKeyConfig encapsulates buildHMACKey parameters.
 type hmacKeyConfig struct {
 	AdapterMode string
-	EnvLabel    string // used in error messages
+	EnvName     string // env variable name used in error messages
 	Primary     string // provided by LoadCellHMACKey; empty → dev fallback
 	DevDefault  string // dev mode fallback value
-	Label       string // "auditcore HMAC" etc., used in error wrapping
 }
 
-// buildHMACKey loads and validates the HMAC key. Logic mirrors buildCursorCodec:
+// buildHMACKey loads and validates the HMAC key by delegating to
+// resolveAndRejectDemoKey. Logic:
 //   - primary non-empty: use directly
-//   - primary empty + real mode: fail-fast
+//   - primary empty + real mode: fail-fast with envName in error message
 //   - primary empty + dev mode: use DevDefault + slog.Warn
 //   - all paths: rejectDemoKey applied before returning
 //
+// The error message contains only the env variable name — no module label.
+// Module callers (e.g. audit_module.go) wrap with their own context label.
+//
 // ref: Kratos config/env prefix-strip convention — each module reads its own namespace.
 func buildHMACKey(cfg hmacKeyConfig) ([]byte, error) {
-	var key []byte
-	if cfg.Primary != "" {
-		key = []byte(cfg.Primary)
-	} else if isRealMode(cfg.AdapterMode) {
-		return nil, fmt.Errorf("%s: %s must be set in adapter mode \"real\"", cfg.Label, cfg.EnvLabel)
-	} else {
-		slog.Warn("using dev-only default; set env var for production",
-			slog.String("var", cfg.EnvLabel),
-			slog.String("mode", "dev-fallback"),
-			slog.String("action_required", "set env var before real mode"))
-		key = []byte(cfg.DevDefault)
-	}
-	if err := rejectDemoKey(cfg.AdapterMode, cfg.EnvLabel, key); err != nil {
-		return nil, err
-	}
-	return key, nil
+	return resolveAndRejectDemoKey(cfg.AdapterMode, cfg.EnvName, cfg.Primary, cfg.DevDefault)
 }

--- a/cmd/corebundle/secrets.go
+++ b/cmd/corebundle/secrets.go
@@ -51,57 +51,104 @@ func loadKeySet(adapterMode string) (*auth.KeySet, error) {
 	return auth.NewKeySet(privKey, pubKey)
 }
 
+// cursorCodecConfig encapsulates buildCursorCodec parameters to avoid passing
+// 7 positional string arguments at every call site.
+type cursorCodecConfig struct {
+	AdapterMode  string
+	EnvLabel     string // primary env name, used only in error messages / slog
+	PrevEnvLabel string // previous env name, used only in error messages / slog
+	Primary      string
+	Previous     string
+	DevDefault   string
+	Label        string // "audit" / "config" / "access"
+}
+
 // buildCursorCodec constructs a CursorCodec from already-read primary and
 // previous key strings. This is the low-level builder used by modules after
 // they read env via LoadCursorKeys; it does not call os.Getenv itself.
 //
-// primary must be non-empty in "real" adapter mode (enforced via loadSecret
+// Primary must be non-empty in "real" adapter mode (enforced via loadSecret
 // semantics: callers pass "" for primary when the env var was unset, which
-// triggers the real-mode fail-fast). previous may be empty (single-key mode).
+// triggers the real-mode fail-fast). Previous may be empty (single-key mode).
 //
-// envLabelForErr and prevEnvLabelForErr are used only in error messages and
-// the slog rotation log so operators can identify which env var to check.
-// devDefault is used when primary is empty in dev mode.
+// cfg.EnvLabel and cfg.PrevEnvLabel are used only in error messages and the
+// slog rotation log so operators can identify which env var to check.
+// cfg.DevDefault is used when primary is empty in dev mode.
 //
 // ref: kube-apiserver --service-account-signing-key-file (single current) +
 // --service-account-key-file (multi verification) — same signing/verification
 // split applied to cursor HMAC tokens.
 // ref: gorilla/securecookie CodecsFromPairs — ordered key list, first match
 // wins during decode.
-func buildCursorCodec(adapterMode, envLabelForErr, prevEnvLabelForErr, primary, previous, devDefault, label string) (*query.CursorCodec, error) {
+func buildCursorCodec(cfg cursorCodecConfig) (*query.CursorCodec, error) {
 	var key []byte
-	if primary != "" {
-		key = []byte(primary)
-	} else if isRealMode(adapterMode) {
-		return nil, fmt.Errorf("%s cursor key: %s must be set in adapter mode \"real\"", label, envLabelForErr)
+	if cfg.Primary != "" {
+		key = []byte(cfg.Primary)
+	} else if isRealMode(cfg.AdapterMode) {
+		return nil, fmt.Errorf("%s cursor key: %s must be set in adapter mode \"real\"", cfg.Label, cfg.EnvLabel)
 	} else {
 		slog.Warn("using dev-only default; set env var for production",
-			slog.String("var", envLabelForErr),
+			slog.String("var", cfg.EnvLabel),
 			slog.String("mode", "dev-fallback"),
 			slog.String("action_required", "set env var before real mode"))
-		key = []byte(devDefault)
+		key = []byte(cfg.DevDefault)
 	}
-	if err := rejectDemoKey(adapterMode, envLabelForErr, key); err != nil {
+	if err := rejectDemoKey(cfg.AdapterMode, cfg.EnvLabel, key); err != nil {
 		return nil, err
 	}
 
 	var prevKey []byte
-	if previous != "" {
-		prevKey = []byte(previous)
-		if err := rejectDemoKey(adapterMode, prevEnvLabelForErr, prevKey); err != nil {
+	if cfg.Previous != "" {
+		prevKey = []byte(cfg.Previous)
+		if err := rejectDemoKey(cfg.AdapterMode, cfg.PrevEnvLabel, prevKey); err != nil {
 			return nil, err
 		}
 	}
 
 	codec, err := query.NewCursorCodec(key, prevKey)
 	if err != nil {
-		return nil, fmt.Errorf("create %s cursor codec: %w", label, err)
+		return nil, fmt.Errorf("create %s cursor codec: %w", cfg.Label, err)
 	}
 	if len(prevKey) > 0 {
 		slog.Info("cursor key rotation active",
-			slog.String("label", label),
-			slog.String("current_env", envLabelForErr),
-			slog.String("previous_env", prevEnvLabelForErr))
+			slog.String("label", cfg.Label),
+			slog.String("current_env", cfg.EnvLabel),
+			slog.String("previous_env", cfg.PrevEnvLabel))
 	}
 	return codec, nil
+}
+
+// hmacKeyConfig encapsulates buildHMACKey parameters.
+type hmacKeyConfig struct {
+	AdapterMode string
+	EnvLabel    string // used in error messages
+	Primary     string // provided by LoadCellHMACKey; empty → dev fallback
+	DevDefault  string // dev mode fallback value
+	Label       string // "auditcore HMAC" etc., used in error wrapping
+}
+
+// buildHMACKey loads and validates the HMAC key. Logic mirrors buildCursorCodec:
+//   - primary non-empty: use directly
+//   - primary empty + real mode: fail-fast
+//   - primary empty + dev mode: use DevDefault + slog.Warn
+//   - all paths: rejectDemoKey applied before returning
+//
+// ref: Kratos config/env prefix-strip convention — each module reads its own namespace.
+func buildHMACKey(cfg hmacKeyConfig) ([]byte, error) {
+	var key []byte
+	if cfg.Primary != "" {
+		key = []byte(cfg.Primary)
+	} else if isRealMode(cfg.AdapterMode) {
+		return nil, fmt.Errorf("%s: %s must be set in adapter mode \"real\"", cfg.Label, cfg.EnvLabel)
+	} else {
+		slog.Warn("using dev-only default; set env var for production",
+			slog.String("var", cfg.EnvLabel),
+			slog.String("mode", "dev-fallback"),
+			slog.String("action_required", "set env var before real mode"))
+		key = []byte(cfg.DevDefault)
+	}
+	if err := rejectDemoKey(cfg.AdapterMode, cfg.EnvLabel, key); err != nil {
+		return nil, err
+	}
+	return key, nil
 }


### PR DESCRIPTION
## Summary

This PR closes out the 2 P2 findings left open after PR#227 merged.

- **Task 1 — cursorCodecConfig struct**: `buildCursorCodec` had 7 positional `string` parameters — easy to mis-order and hard to read at call sites. Introduce `cursorCodecConfig` struct; update all 3 call sites (`audit_module.go`, `config_module.go`, `access_module.go`) and all 8 tests in `cursor_codec_test.go` to use struct literals. Function body logic is unchanged.

- **Task 2 — HMAC key full symmetry (option d)**: `LoadAuditCoreHMACKey()` was a one-off cell-specific loader with no symmetry to the other loaders, and its only caller used `loadSecret` + bare `rejectDemoKey` rather than a dedicated builder. Generalize to `LoadCellHMACKey(cellEnvPrefix string)` (mirrors `LoadCursorKeys` / `LoadPGConfig`), add `buildHMACKey(hmacKeyConfig)` that mirrors `buildCursorCodec` exactly (primary/dev-fallback/rejectDemoKey), and wire `audit_module.go` through the new pair.

After this PR, all three secret-loader pairs are fully symmetric:

| Secret | Loader (raw env) | Builder (validate + demo-reject + dev-fallback) |
|--------|-----------------|------------------------------------------------|
| Cursor | `LoadCursorKeys(cellEnvPrefix)` | `buildCursorCodec(cursorCodecConfig)` |
| Master | `LoadConfigCoreKeyProvider()` | `buildKeyProvider(...)` |
| HMAC | `LoadCellHMACKey(cellEnvPrefix)` | `buildHMACKey(hmacKeyConfig)` |

## Changes

- `cmd/corebundle/secrets.go` — `cursorCodecConfig` struct + new `hmacKeyConfig` struct + `buildHMACKey`
- `cmd/corebundle/per_cell_adapter.go` — `LoadAuditCoreHMACKey` → `LoadCellHMACKey(cellEnvPrefix)`
- `cmd/corebundle/audit_module.go` — cursor codec + HMAC loading updated to struct call form
- `cmd/corebundle/config_module.go` — cursor codec updated to struct call form
- `cmd/corebundle/access_module.go` — cursor codec updated to struct call form
- `cmd/corebundle/cursor_codec_test.go` — 8 tests updated to struct literals (semantics unchanged)
- `cmd/corebundle/per_cell_adapter_test.go` — `TestLoadAuditCoreHMACKey_*` → `TestLoadCellHMACKey_*` + new cross-cell isolation test
- `cmd/corebundle/hmac_key_test.go` — new; 5 table-driven cases for `buildHMACKey`
- `cmd/corebundle/demo_keys_test.go` — comment updated: source now `buildHMACKey` not `loadSecret`

## Validation

- `go build ./...` — clean
- `go build -tags=integration ./...` — clean
- `go test ./cmd/corebundle/... ./runtime/crypto/... ./adapters/postgres/... ./pkg/errcode/...` — all pass (network-binding tests fail only due to sandbox, pre-existing)
- `go vet -tags=integration ./cmd/corebundle/...` — clean
- `golangci-lint run ./cmd/corebundle/...` — **0 issues**

## Test plan

- [ ] All `TestBuildCursorCodec_*` tests pass with struct literal form
- [ ] All `TestBuildHMACKey_*` tests pass (5 new cases)
- [ ] `TestLoadCellHMACKey_CrossCellIsolation` verifies prefix isolation
- [ ] `TestDevDefaults_AreAllInWellKnownDemoKeys` still passes (comment updated)

## Refs

Closes PR#227 P2 review findings:
- P2-1: `buildCursorCodec` 7-parameter positional string signature
- P2-2: `LoadAuditCoreHMACKey` unused production caller + asymmetric pattern

ref: Kratos config/env prefix-strip convention (LoadCellHMACKey)
ref: kube-apiserver two-phase Complete+Validate (buildHMACKey fail-fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)