### PR TITLE
fix(configcore): restore integration vet — shared RecordingWriter + Pool.Close(ctx)

### DIFF
--- a/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
@@ -317,7 +317,7 @@ func setupConfigPGEncrypted(t *testing.T) (*ConfigRepository, *adapterpg.TxManag
 	txMgr := adapterpg.NewTxManager(pool)
 
 	cleanup := func() {
-		pool.Close()
+		_ = pool.Close(ctx)
 		if err := container.Terminate(ctx); err != nil {
 			t.Logf("WARN: failed to terminate postgres container: %v", err)
 		}

--- a/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
@@ -54,7 +54,9 @@ func setupConfigPG(t *testing.T) (*ConfigRepository, *adapterpg.TxManager, func(
 	txMgr := adapterpg.NewTxManager(pool)
 
 	cleanup := func() {
-		_ = pool.Close(ctx)
+		if err := pool.Close(ctx); err != nil {
+			t.Logf("WARN: pool close: %v", err)
+		}
 		if err := container.Terminate(ctx); err != nil {
 			t.Logf("WARN: failed to terminate postgres container: %v", err)
 		}
@@ -317,7 +319,9 @@ func setupConfigPGEncrypted(t *testing.T) (*ConfigRepository, *adapterpg.TxManag
 	txMgr := adapterpg.NewTxManager(pool)
 
 	cleanup := func() {
-		_ = pool.Close(ctx)
+		if err := pool.Close(ctx); err != nil {
+			t.Logf("WARN: pool close: %v", err)
+		}
 		if err := container.Terminate(ctx); err != nil {
 			t.Logf("WARN: failed to terminate postgres container: %v", err)
 		}

--- a/cells/configcore/internal/testutil/testutil.go
+++ b/cells/configcore/internal/testutil/testutil.go
@@ -1,4 +1,10 @@
-// Package testutil provides shared test doubles for configcore slice tests.
+// Package testutil provides test doubles and helpers scoped to the configcore
+// cell. It lives under internal/ to enforce the per-cell convention: other
+// cells (auditcore, accesscore) that need similar test doubles should define
+// their own internal/testutil rather than cross-cell-share, preserving the
+// cell isolation boundary. If a truly cross-cell test utility emerges in the
+// future, it should be elevated to cells/testutil/ or pkg/testutil/ — but
+// that decision is deferred until the need is concrete.
 package testutil
 
 import (

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -13,6 +13,7 @@ import (
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	cellpg "github.com/ghbvf/gocell/cells/configcore/internal/adapters/postgres"
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
 	"github.com/google/uuid"
@@ -229,7 +230,7 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 	versionBefore := entryBefore.Version
 
 	// Now inject a failing writer — simulates outbox broker down during Rollback.
-	failingWriter := &recordingWriter{err: errors.New("outbox broker down")}
+	failingWriter := &configcoretest.RecordingWriter{Err: errors.New("outbox broker down")}
 	svcFail := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
 		WithTxManager(txMgr),

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -13,7 +13,7 @@ import (
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	cellpg "github.com/ghbvf/gocell/cells/configcore/internal/adapters/postgres"
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
-	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
+	cctestutil "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
 	"github.com/google/uuid"
@@ -71,7 +71,9 @@ func setupPublishBundle(t *testing.T) (publishServiceBundle, func()) {
 	)
 
 	cleanup := func() {
-		_ = pool.Close(ctx)
+		if err := pool.Close(ctx); err != nil {
+			t.Logf("WARN: pool close: %v", err)
+		}
 		if err := container.Terminate(ctx); err != nil {
 			t.Logf("WARN: failed to terminate postgres container: %v", err)
 		}
@@ -186,6 +188,7 @@ func TestRollback_AtomicWithOutbox(t *testing.T) {
 // write fails during Rollback, both the config_entries update and the outbox write
 // are rolled back (transaction atomicity).
 func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
+	testutil.RequireDocker(t)
 	ctx := context.Background()
 
 	container, err := tcpostgres.Run(ctx, testutil.PostgresImage,
@@ -202,7 +205,11 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
-	defer func() { _ = pool.Close(ctx) }()
+	defer func() {
+		if err := pool.Close(ctx); err != nil {
+			t.Logf("WARN: pool close: %v", err)
+		}
+	}()
 
 	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
 	require.NoError(t, err)
@@ -230,7 +237,7 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 	versionBefore := entryBefore.Version
 
 	// Now inject a failing writer — simulates outbox broker down during Rollback.
-	failingWriter := &configcoretest.RecordingWriter{Err: errors.New("outbox broker down")}
+	failingWriter := &cctestutil.RecordingWriter{Err: errors.New("outbox broker down")}
 	svcFail := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
 		WithTxManager(txMgr),

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -12,6 +12,7 @@ import (
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	cellpg "github.com/ghbvf/gocell/cells/configcore/internal/adapters/postgres"
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
@@ -205,7 +206,7 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil)
 
 	// Inject a writer that always fails — simulates outbox unavailable.
-	failingWriter := &recordingWriter{err: errors.New("outbox broker down")}
+	failingWriter := &configcoretest.RecordingWriter{Err: errors.New("outbox broker down")}
 
 	txMgr := adapterpg.NewTxManager(pool)
 	svc := NewService(repo, slog.Default(),

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -12,7 +12,7 @@ import (
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	cellpg "github.com/ghbvf/gocell/cells/configcore/internal/adapters/postgres"
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
-	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
+	cctestutil "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
@@ -180,6 +180,7 @@ func TestDelete_AtomicWithOutbox(t *testing.T) {
 // returns a permanent error, the config_entries row is absent (transaction
 // rolled back atomically).
 func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
+	testutil.RequireDocker(t)
 	ctx := context.Background()
 
 	container, err := tcpostgres.Run(ctx, testutil.PostgresImage,
@@ -196,7 +197,11 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
-	defer func() { _ = pool.Close(ctx) }()
+	defer func() {
+		if err := pool.Close(ctx); err != nil {
+			t.Logf("WARN: pool close: %v", err)
+		}
+	}()
 
 	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
 	require.NoError(t, err)
@@ -206,7 +211,7 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil)
 
 	// Inject a writer that always fails — simulates outbox unavailable.
-	failingWriter := &configcoretest.RecordingWriter{Err: errors.New("outbox broker down")}
+	failingWriter := &cctestutil.RecordingWriter{Err: errors.New("outbox broker down")}
 
 	txMgr := adapterpg.NewTxManager(pool)
 	svc := NewService(repo, slog.Default(),

--- a/cells/configcore/slices/flagwrite/contract_test.go
+++ b/cells/configcore/slices/flagwrite/contract_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/dto"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
-	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
+	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
@@ -40,9 +40,9 @@ func newContractMux(svc *Service) *http.ServeMux {
 func newContractService(t *testing.T) *Service {
 	t.Helper()
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,9 +185,9 @@ func TestEventFlagChangedV1Publish(t *testing.T) {
 	c := contracttest.LoadByID(t, root, "event.flag.changed.v1")
 
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 
 	_, err = svc.Create(testAdminCtx(), CreateInput{Key: "event-flag", Enabled: true, Description: "ev"})

--- a/cells/configcore/slices/flagwrite/contract_test.go
+++ b/cells/configcore/slices/flagwrite/contract_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/dto"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
+	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func newContractMux(svc *Service) *http.ServeMux {
 func newContractService(t *testing.T) *Service {
 	t.Helper()
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	if err != nil {
@@ -184,7 +185,7 @@ func TestEventFlagChangedV1Publish(t *testing.T) {
 	c := contracttest.LoadByID(t, root, "event.flag.changed.v1")
 
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
@@ -192,11 +193,11 @@ func TestEventFlagChangedV1Publish(t *testing.T) {
 	_, err = svc.Create(testAdminCtx(), CreateInput{Key: "event-flag", Enabled: true, Description: "ev"})
 	require.NoError(t, err)
 
-	require.Len(t, writer.entries, 1)
+	require.Len(t, writer.Entries, 1)
 	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.entries[0].Payload, &payload))
+	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
 
-	c.ValidatePayload(t, writer.entries[0].Payload)
+	c.ValidatePayload(t, writer.Entries[0].Payload)
 	assert.Equal(t, "created", payload.Action)
 	assert.Equal(t, "event-flag", payload.Key)
 
@@ -205,7 +206,7 @@ func TestEventFlagChangedV1Publish(t *testing.T) {
 	// declared idempotencyKey in contract.yaml — is carried via Entry.ID.
 	// Two independent UUIDs here would let headers-based idempotency drift
 	// from payload-based inspection. See headers.schema.json description.
-	assert.Equal(t, writer.entries[0].ID, payload.EventID,
+	assert.Equal(t, writer.Entries[0].ID, payload.EventID,
 		"contract drift: payload.eventId must mirror outbox.Entry.ID so "+
 			"headers.event_id (idempotencyKey) is coherent across envelope and body")
 }

--- a/cells/configcore/slices/flagwrite/ctx_cancel_test.go
+++ b/cells/configcore/slices/flagwrite/ctx_cancel_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
-	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
+	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +45,7 @@ var _ persistence.TxRunner = (*cancellingTxRunner)(nil)
 //  3. The outbox writer received no entries.
 func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	txRunner := &cancellingTxRunner{}
 
 	svc, err := NewService(repo, slog.Default(),
@@ -78,9 +78,9 @@ func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
 	// Seed a flag so Toggle reaches the RunInTx call.
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{Key: "toggle-cancel"})
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 	// Now create a service with the cancelling tx runner.
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{})), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Toggle(context.Background(), "toggle-cancel", true)
@@ -105,9 +105,9 @@ func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 // context cancellation and leaves the flag unchanged.
 func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{
 		Key:         "update-cancel",
@@ -117,7 +117,7 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{})), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Update(context.Background(), UpdateInput{
@@ -139,16 +139,16 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 // context cancellation and leaves the flag in the repo.
 func TestFlagWrite_Delete_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{Key: "delete-cancel"})
 	require.NoError(t, err)
 
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{})), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	err = svc.Delete(context.Background(), "delete-cancel")

--- a/cells/configcore/slices/flagwrite/ctx_cancel_test.go
+++ b/cells/configcore/slices/flagwrite/ctx_cancel_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
+	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,7 @@ var _ persistence.TxRunner = (*cancellingTxRunner)(nil)
 //  3. The outbox writer received no entries.
 func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	txRunner := &cancellingTxRunner{}
 
 	svc, err := NewService(repo, slog.Default(),
@@ -69,7 +70,7 @@ func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 		"ErrFlagNotFound expected — flag must not persist after ctx cancel rollback")
 
 	// Verify outbox has no durable entries.
-	assert.Empty(t, writer.entries, "outbox must have no entries after rollback")
+	assert.Empty(t, writer.Entries, "outbox must have no entries after rollback")
 }
 
 // TestFlagWrite_Toggle_CtxCancel_ReturnsError verifies Toggle propagates
@@ -77,7 +78,7 @@ func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
 	// Seed a flag so Toggle reaches the RunInTx call.
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
@@ -87,7 +88,7 @@ func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 	// Now create a service with the cancelling tx runner.
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Toggle(context.Background(), "toggle-cancel", true)
@@ -104,7 +105,7 @@ func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 // context cancellation and leaves the flag unchanged.
 func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
@@ -116,7 +117,7 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Update(context.Background(), UpdateInput{
@@ -138,7 +139,7 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 // context cancellation and leaves the flag in the repo.
 func TestFlagWrite_Delete_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	seedSvc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)
@@ -147,7 +148,7 @@ func TestFlagWrite_Delete_CtxCancel_ReturnsError(t *testing.T) {
 
 	cancelTx := &cancellingTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(cancelTx))
+		WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{})), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	err = svc.Delete(context.Background(), "delete-cancel")

--- a/cells/configcore/slices/flagwrite/service_test.go
+++ b/cells/configcore/slices/flagwrite/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
+	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/stretchr/testify/assert"
@@ -18,21 +19,6 @@ import (
 )
 
 // --- test doubles ---
-
-type recordingWriter struct {
-	entries []outbox.Entry
-	err     error
-}
-
-func (w *recordingWriter) Write(_ context.Context, entry outbox.Entry) error {
-	if w.err != nil {
-		return w.err
-	}
-	w.entries = append(w.entries, entry)
-	return nil
-}
-
-var _ outbox.Writer = (*recordingWriter)(nil)
 
 type noopTxRunner struct{ calls int }
 
@@ -65,10 +51,10 @@ var _ outbox.Publisher = stubPublisher{}
 
 // --- helpers ---
 
-func newDurableTestService(t *testing.T) (*Service, *mem.FlagRepository, *recordingWriter) {
+func newDurableTestService(t *testing.T) (*Service, *mem.FlagRepository, *configcoretest.RecordingWriter) {
 	t.Helper()
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)),
 		WithTxManager(&noopTxRunner{}))
@@ -103,7 +89,7 @@ func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"only_emitter", []Option{WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{}))}},
+		{"only_emitter", []Option{WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{}))}},
 		{"only_tx_runner", []Option{WithTxManager(&noopTxRunner{})}},
 	}
 	for _, tc := range cases {
@@ -120,7 +106,7 @@ func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 // outbox in a single tx; repo failure also prevents outbox write.
 func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	tx := &noopTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
@@ -133,8 +119,8 @@ func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my-flag", flag.Key)
 	assert.Equal(t, 1, tx.calls, "Create must call RunInTx exactly once")
-	require.Len(t, writer.entries, 1)
-	assert.Equal(t, TopicFlagChanged, writer.entries[0].EventType)
+	require.Len(t, writer.Entries, 1)
+	assert.Equal(t, TopicFlagChanged, writer.Entries[0].EventType)
 }
 
 // TestFlagWrite_Create_RepoFails_NoOutboxWrite verifies that a tx-level
@@ -149,7 +135,7 @@ func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 // where Write inside a rolled-back tx is genuinely discarded.
 func TestFlagWrite_RepoFails_NoOutboxWrite(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{}
+	writer := &configcoretest.RecordingWriter{}
 	tx := &failingTxRunner{failErr: errors.New("tx commit failed")}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
@@ -172,11 +158,11 @@ func TestFlagWrite_Toggle_EmitsFlagChangedEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, flag.Enabled)
 
-	require.Len(t, writer.entries, 1)
-	assert.Equal(t, TopicFlagChanged, writer.entries[0].EventType)
+	require.Len(t, writer.Entries, 1)
+	assert.Equal(t, TopicFlagChanged, writer.Entries[0].EventType)
 
 	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.entries[0].Payload, &payload))
+	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
 	assert.Equal(t, "toggled", payload.Action)
 	assert.Equal(t, "feature-x", payload.Key)
 	assert.True(t, payload.Enabled)
@@ -199,9 +185,9 @@ func TestFlagWrite_Update_EmitsFlagChangedEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "feat-update", flag.Key)
 
-	require.Len(t, writer.entries, 1)
+	require.Len(t, writer.Entries, 1)
 	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.entries[0].Payload, &payload))
+	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
 	assert.Equal(t, "updated", payload.Action)
 	assert.Equal(t, "feat-update", payload.Key)
 }
@@ -217,9 +203,9 @@ func TestFlagWrite_Delete_EmitsFlagChangedEvent(t *testing.T) {
 	err := svc.Delete(context.Background(), "feat-delete")
 	require.NoError(t, err)
 
-	require.Len(t, writer.entries, 1)
+	require.Len(t, writer.Entries, 1)
 	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.entries[0].Payload, &payload))
+	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
 	assert.Equal(t, "deleted", payload.Action)
 	assert.Equal(t, "feat-delete", payload.Key)
 }
@@ -228,7 +214,7 @@ func TestFlagWrite_Delete_EmitsFlagChangedEvent(t *testing.T) {
 
 func TestFlagWrite_OutboxWriteError_PropagatesFromCreate(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &recordingWriter{err: errors.New("outbox unavailable")}
+	writer := &configcoretest.RecordingWriter{Err: errors.New("outbox unavailable")}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
 	require.NoError(t, err)

--- a/cells/configcore/slices/flagwrite/service_test.go
+++ b/cells/configcore/slices/flagwrite/service_test.go
@@ -11,23 +11,11 @@ import (
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
-	configcoretest "github.com/ghbvf/gocell/cells/configcore/internal/testutil"
-	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// --- test doubles ---
-
-type noopTxRunner struct{ calls int }
-
-func (s *noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
-	s.calls++
-	return fn(ctx)
-}
-
-var _ persistence.TxRunner = (*noopTxRunner)(nil)
 
 // failingTxRunner simulates a tx that wraps fn but fails after fn returns nil,
 // used to simulate a rollback scenario where in-memory repo already applied the
@@ -42,22 +30,15 @@ func (f *failingTxRunner) RunInTx(_ context.Context, fn func(context.Context) er
 
 var _ persistence.TxRunner = (*failingTxRunner)(nil)
 
-type stubPublisher struct{}
-
-func (stubPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
-func (stubPublisher) Close(_ context.Context) error                       { return nil }
-
-var _ outbox.Publisher = stubPublisher{}
-
 // --- helpers ---
 
-func newDurableTestService(t *testing.T) (*Service, *mem.FlagRepository, *configcoretest.RecordingWriter) {
+func newDurableTestService(t *testing.T) (*Service, *mem.FlagRepository, *testutil.RecordingWriter) {
 	t.Helper()
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)),
-		WithTxManager(&noopTxRunner{}))
+		WithTxManager(&testutil.NoopTxRunner{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,8 +70,8 @@ func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"only_emitter", []Option{WithEmitter(testoutbox.MustEmitter(t, &configcoretest.RecordingWriter{}))}},
-		{"only_tx_runner", []Option{WithTxManager(&noopTxRunner{})}},
+		{"only_emitter", []Option{WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{}))}},
+		{"only_tx_runner", []Option{WithTxManager(&testutil.NoopTxRunner{})}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -106,8 +87,8 @@ func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 // outbox in a single tx; repo failure also prevents outbox write.
 func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
-	tx := &noopTxRunner{}
+	writer := &testutil.RecordingWriter{}
+	tx := &testutil.NoopTxRunner{}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
 	require.NoError(t, err)
@@ -118,7 +99,7 @@ func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "my-flag", flag.Key)
-	assert.Equal(t, 1, tx.calls, "Create must call RunInTx exactly once")
+	assert.Equal(t, 1, tx.Calls, "Create must call RunInTx exactly once")
 	require.Len(t, writer.Entries, 1)
 	assert.Equal(t, TopicFlagChanged, writer.Entries[0].EventType)
 }
@@ -129,13 +110,12 @@ func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 // Scope note: the in-memory recordingWriter has no transaction-aware
 // rollback — it records every Write call unconditionally. This test
 // therefore exercises only the error-propagation path; the "outbox is not
-// durable when tx rolls back" invariant is covered at the L2 durability
-// boundary by the PG integration tests (flag_ctx_cancel_integration_test.go
-// and flag_restart_integration_test.go), which run against a real database
+// durable when tx rolls back" invariant is verified at the L2 durability
+// boundary by PG integration tests that run against a real database
 // where Write inside a rolled-back tx is genuinely discarded.
 func TestFlagWrite_RepoFails_NoOutboxWrite(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{}
+	writer := &testutil.RecordingWriter{}
 	tx := &failingTxRunner{failErr: errors.New("tx commit failed")}
 	svc, err := NewService(repo, slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
@@ -214,9 +194,9 @@ func TestFlagWrite_Delete_EmitsFlagChangedEvent(t *testing.T) {
 
 func TestFlagWrite_OutboxWriteError_PropagatesFromCreate(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &configcoretest.RecordingWriter{Err: errors.New("outbox unavailable")}
+	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&noopTxRunner{}))
+		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{Key: "k"})


### PR DESCRIPTION
## Summary

Three compilation errors from `go vet -tags=integration ./cells/configcore/...` introduced by prior PRs:

- **PR#224** (outbox emitter refactor): `configpublish` and `configwrite` integration tests referenced `recordingWriter` which was only defined in `flagwrite/service_test.go` — not accessible across packages
- **PR-A2 #225** (Pool.Close ctx signature): `setupConfigPGEncrypted` cleanup closure called `pool.Close()` without ctx argument after the signature changed to `Close(ctx context.Context) error`

## Fix

- Migrated all `flagwrite` test files (`service_test.go`, `contract_test.go`, `ctx_cancel_test.go`) to use the pre-existing shared `cells/configcore/internal/testutil.RecordingWriter` (exported fields `Entries`/`Err`) instead of the package-local `recordingWriter` struct
- Wired `configpublish/service_integration_test.go` and `configwrite/service_integration_test.go` to the same shared type via import alias `configcoretest`
- Fixed `pool.Close()` → `pool.Close(ctx)` in `setupConfigPGEncrypted` cleanup; `ctx` was already in scope from the enclosing function

No production code changed. Only test files modified.

## Test plan

- [x] `go vet ./cells/configcore/...` — green
- [x] `go vet -tags=integration ./cells/configcore/...` — green (was failing with 3 errors)
- [x] `go vet ./...` — green
- [x] `go vet -tags=integration ./...` — green
- [x] `go build ./...` — green
- [x] `go build -tags=integration ./...` — green
- [x] `go test ./cells/configcore/...` — all 14 packages pass
- [x] `golangci-lint run ./cells/configcore/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)