### PR TITLE
feat(accesscore): PR-A26 setup slice + adminprovision shared service

### DIFF
--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionlogout"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionrefresh"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionvalidate"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/setup"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
@@ -141,6 +142,7 @@ type AccessCore struct {
 	loginHandler    *sessionlogin.Handler
 	refreshHandler  *sessionrefresh.Handler
 	logoutHandler   *sessionlogout.Handler
+	setupHandler    *setup.Handler
 
 	// Services exposed for composition (e.g. TokenVerifier, Authorizer).
 	validateSvc         *sessionvalidate.Service

--- a/cells/accesscore/cell_init.go
+++ b/cells/accesscore/cell_init.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/google/uuid"
+
 	"github.com/ghbvf/gocell/cells/accesscore/initialadmin"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/authorizationdecide"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
@@ -14,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionlogout"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionrefresh"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/sessionvalidate"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/setup"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
@@ -132,6 +136,22 @@ func (c *AccessCore) initSlices() error {
 	// config-receive: subscribes to config.changed events from configcore
 	c.configReceiveSvc = configreceive.NewService(c.logger)
 	c.AddSlice(cell.NewBaseSlice("configreceive", "accesscore", cell.L3))
+
+	// setup: interactive first-run admin provisioning (Public HTTP endpoints).
+	// Uses shared adminprovision.Provisioner so semantics match initialadmin.
+	setupProv, err := adminprovision.NewProvisioner(c.userRepo, c.roleRepo, c.logger, uuid.NewString)
+	if err != nil {
+		return err
+	}
+	setupSvc, err := setup.NewService(setupProv, c.logger,
+		setup.WithEmitter(c.emitter),
+		setup.WithTxManager(c.txRunner),
+	)
+	if err != nil {
+		return err
+	}
+	c.setupHandler = setup.NewHandler(setupSvc)
+	c.AddSlice(cell.NewBaseSlice("setup", "accesscore", cell.L2))
 	return nil
 }
 

--- a/cells/accesscore/cell_routes.go
+++ b/cells/accesscore/cell_routes.go
@@ -47,6 +47,26 @@ func (c *AccessCore) Authorizer() auth.Authorizer {
 
 // RegisterRoutes registers HTTP routes for accesscore.
 func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
+	// Interactive first-run admin provisioning (Public). Top-level path by
+	// design — setup is a system-level concern, not access-cell-internal from
+	// the caller's perspective. Both endpoints must remain Public: true
+	// because no admin exists yet to authenticate against; post-init they
+	// return 409 via CountByRole fast-path.
+	mux.Route("/api/v1/setup", func(sub cell.RouteMux) {
+		auth.Declare(sub, auth.RouteDecl{
+			Method:  "GET",
+			Path:    "/status",
+			Handler: http.HandlerFunc(c.setupHandler.HandleStatus),
+			Public:  true,
+		})
+		auth.Declare(sub, auth.RouteDecl{
+			Method:  "POST",
+			Path:    "/admin",
+			Handler: http.HandlerFunc(c.setupHandler.HandleCreateAdmin),
+			Public:  true,
+		})
+	})
+
 	mux.Route("/api/v1/access", func(sub cell.RouteMux) {
 		// Identity management: /api/v1/access/users
 		sub.Route("/users", c.identityHandler.RegisterRoutes)

--- a/cells/accesscore/cell_routes.go
+++ b/cells/accesscore/cell_routes.go
@@ -47,27 +47,28 @@ func (c *AccessCore) Authorizer() auth.Authorizer {
 
 // RegisterRoutes registers HTTP routes for accesscore.
 func (c *AccessCore) RegisterRoutes(mux cell.RouteMux) {
-	// Interactive first-run admin provisioning (Public). Top-level path by
-	// design — setup is a system-level concern, not access-cell-internal from
-	// the caller's perspective. Both endpoints must remain Public: true
-	// because no admin exists yet to authenticate against; post-init they
-	// return 409 via CountByRole fast-path.
-	mux.Route("/api/v1/setup", func(sub cell.RouteMux) {
-		auth.Declare(sub, auth.RouteDecl{
-			Method:  "GET",
-			Path:    "/status",
-			Handler: http.HandlerFunc(c.setupHandler.HandleStatus),
-			Public:  true,
-		})
-		auth.Declare(sub, auth.RouteDecl{
-			Method:  "POST",
-			Path:    "/admin",
-			Handler: http.HandlerFunc(c.setupHandler.HandleCreateAdmin),
-			Public:  true,
-		})
-	})
-
 	mux.Route("/api/v1/access", func(sub cell.RouteMux) {
+		// Interactive first-run admin provisioning, scoped under /access/ so
+		// the path prefix matches Cell ownership (Consul /acl/bootstrap
+		// convention, rather than Vault's top-level /sys/init). Both endpoints
+		// are Public: no admin exists yet to authenticate against; once an
+		// admin exists, the endpoint returns 410 Gone via a fast-path Status
+		// check before bcrypt runs.
+		sub.Route("/setup", func(s cell.RouteMux) {
+			auth.Declare(s, auth.RouteDecl{
+				Method:  "GET",
+				Path:    "/status",
+				Handler: http.HandlerFunc(c.setupHandler.HandleStatus),
+				Public:  true,
+			})
+			auth.Declare(s, auth.RouteDecl{
+				Method:  "POST",
+				Path:    "/admin",
+				Handler: http.HandlerFunc(c.setupHandler.HandleCreateAdmin),
+				Public:  true,
+			})
+		})
+
 		// Identity management: /api/v1/access/users
 		sub.Route("/users", c.identityHandler.RegisterRoutes)
 

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -227,7 +227,7 @@ func TestAccessCore_Lifecycle(t *testing.T) {
 
 	// Init
 	require.NoError(t, c.Init(ctx, deps))
-	assert.Equal(t, 9, len(c.OwnedSlices()), "should have 9 slices")
+	assert.Equal(t, 10, len(c.OwnedSlices()), "should have 10 slices")
 
 	// Start
 	require.NoError(t, c.Start(ctx))

--- a/cells/accesscore/initialadmin/bootstrap.go
+++ b/cells/accesscore/initialadmin/bootstrap.go
@@ -4,7 +4,6 @@ package initialadmin
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,9 +15,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/worker"
 )
 
@@ -60,12 +58,15 @@ type bootstrapConfig struct {
 	Hasher PasswordHasher
 }
 
-// bootstrapper orchestrates initial admin creation: CountByRole → generate
-// password → bcrypt → create user (PasswordResetRequired=true) → assign admin
-// role → writeCredentialFile → return cleaner worker.
+// bootstrapper orchestrates initial admin creation: delegate race-safe user+role
+// persistence to adminprovision → writeCredentialFile → return cleaner worker.
+//
+// Race / orphan / duplicate semantics live in adminprovision.Provisioner; this
+// layer owns only the credfile write + cleanup worker + probeWriteable.
 type bootstrapper struct {
-	deps BootstrapDeps
-	cfg  bootstrapConfig
+	deps        BootstrapDeps
+	cfg         bootstrapConfig
+	provisioner *adminprovision.Provisioner
 }
 
 // newBootstrapper validates deps and cfg, applies defaults, and returns a
@@ -106,7 +107,11 @@ func newBootstrapper(deps BootstrapDeps, cfg bootstrapConfig) (*bootstrapper, er
 		cfg.Hasher = defaultPasswordHasher()
 	}
 
-	return &bootstrapper{deps: deps, cfg: cfg}, nil
+	prov, err := adminprovision.NewProvisioner(deps.UserRepo, deps.RoleRepo, deps.Logger, uuid.NewString)
+	if err != nil {
+		return nil, fmt.Errorf("initialadmin: build provisioner: %w", err)
+	}
+	return &bootstrapper{deps: deps, cfg: cfg, provisioner: prov}, nil
 }
 
 // ensureAdmin executes the bootstrap sequence. It is idempotent: if an admin
@@ -132,18 +137,18 @@ func newBootstrapper(deps BootstrapDeps, cfg bootstrapConfig) (*bootstrapper, er
 // at the composition root via SweepHook so that orphan cred files are cleaned
 // even when adminExists==true causes ensureAdmin to return early.
 func (b *bootstrapper) ensureAdmin(ctx context.Context) (worker.Worker, error) {
-	// Check whether an admin already exists.
-	exists, err := b.adminExists(ctx)
+	// Pre-flight: fail fast if admin already exists (no credfile probe needed).
+	exists, err := b.provisioner.Status(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initialadmin: check status: %w", err)
 	}
 	if exists {
 		return nil, nil
 	}
 
-	// Pre-flight check: verify the credential directory is writable before
-	// creating the admin user. This catches permission issues at startup time
-	// rather than after user creation (P1-6 fix).
+	// Pre-flight: verify the credential directory is writable before creating
+	// the admin user. This catches permission issues at startup time rather
+	// than after user creation (P1-6 fix).
 	if err := b.probeWriteable(); err != nil {
 		return nil, fmt.Errorf("initial admin bootstrap: credential dir not writable: %w", err)
 	}
@@ -154,48 +159,35 @@ func (b *bootstrapper) ensureAdmin(ctx context.Context) (worker.Worker, error) {
 		return nil, err
 	}
 
-	// Ensure admin role and create the bootstrap user.
-	user, err := b.ensureRoleAndCreateUser(ctx, hash)
+	// Delegate race-safe persistence to adminprovision.
+	user, outcome, err := b.provisioner.Ensure(ctx, adminprovision.ProvisionInput{
+		Username:     b.cfg.Username,
+		Email:        b.cfg.Username + "@gocell.local",
+		PasswordHash: hash,
+		RequireReset: true,
+		IDPrefix:     "usr-bootstrap-",
+	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initialadmin: ensure: %w", err)
 	}
-	if user == nil {
-		// Concurrent bootstrap race: another replica already created admin.
+	switch outcome {
+	case adminprovision.OutcomeAlreadyExists, adminprovision.OutcomeRaceSkipped:
+		// Concurrent replica / prior bootstrap won the race. Silent skip.
 		return nil, nil
+	case adminprovision.OutcomeCreated, adminprovision.OutcomeOrphanRecovered:
+		// Fall through to credfile write.
+	default:
+		return nil, fmt.Errorf("initialadmin: unexpected provision outcome %d", outcome)
 	}
 
-	// Write credential file and return cleaner. On failure, compensate the
-	// user/role writes so the bootstrap can self-heal on next startup.
+	// Write credential file. On failure, compensate the user/role writes so
+	// the next startup can self-heal (adminExists==false again).
 	cleaner, werr := b.writeFileAndMakeCleaner(password)
 	if werr != nil {
-		b.compensateAfterCredFileFailure(ctx, user.ID)
+		b.provisioner.Compensate(ctx, user.ID)
 		return nil, werr
 	}
 	return cleaner, nil
-}
-
-// compensateAfterCredFileFailure best-effort removes the role assignment and
-// user row after writeCredentialFile fails. Errors are logged but not
-// surfaced — the operator's immediate concern is the credfile failure, and a
-// stale row at most forces a manual recount on next startup. We log rather
-// than silent-drop so ops can spot leaked rows and clean them up explicitly.
-func (b *bootstrapper) compensateAfterCredFileFailure(ctx context.Context, userID string) {
-	if err := b.deps.RoleRepo.RemoveFromUser(ctx, userID, domain.RoleAdmin); err != nil {
-		b.deps.Logger.Error("initial admin bootstrap: compensating role unassign failed",
-			slog.String("event", "initial_admin_bootstrap_compensate"),
-			slog.String("user_id", userID),
-			slog.Any("error", err))
-	}
-	if err := b.deps.UserRepo.Delete(ctx, userID); err != nil {
-		b.deps.Logger.Error("initial admin bootstrap: compensating user delete failed",
-			slog.String("event", "initial_admin_bootstrap_compensate"),
-			slog.String("user_id", userID),
-			slog.Any("error", err))
-		return
-	}
-	b.deps.Logger.Warn("initial admin bootstrap: compensated after credfile failure; retry on next startup",
-		slog.String("event", "initial_admin_bootstrap_compensate"),
-		slog.String("user_id", userID))
 }
 
 // probeWriteable verifies the credential file directory is writable by creating
@@ -230,22 +222,6 @@ func maybeMacOSHint(credPath string, err error) error {
 	return err
 }
 
-// adminExists checks if at least one user holds the admin role.
-func (b *bootstrapper) adminExists(ctx context.Context) (bool, error) {
-	count, err := b.deps.RoleRepo.CountByRole(ctx, domain.RoleAdmin)
-	if err != nil {
-		return false, fmt.Errorf("initialadmin: count admin users: %w", err)
-	}
-	if count > 0 {
-		b.deps.Logger.Debug("initial admin bootstrap skipped: admin already exists",
-			slog.String("event", "initial_admin_bootstrap"),
-			slog.Int("admin_count", count),
-		)
-		return true, nil
-	}
-	return false, nil
-}
-
 // generateAndHash creates a random password and returns (plaintext, bcrypt hash).
 // The intermediate byte slice is zeroed after hashing.
 func (b *bootstrapper) generateAndHash() (password string, hash []byte, err error) {
@@ -264,114 +240,6 @@ func (b *bootstrapper) generateAndHash() (password string, hash []byte, err erro
 		return "", nil, fmt.Errorf("initialadmin: hash password: %w", err)
 	}
 	return password, hash, nil
-}
-
-// ensureRoleAndCreateUser idempotently creates the admin role and user.
-// Returns nil user (no error) on a concurrent-bootstrap silent skip.
-func (b *bootstrapper) ensureRoleAndCreateUser(ctx context.Context, hash []byte) (*domain.User, error) {
-	adminRole := &domain.Role{
-		ID:   domain.RoleAdmin,
-		Name: domain.RoleAdmin,
-		Permissions: []domain.Permission{
-			{Resource: "*", Action: "*"},
-		},
-	}
-	if err := b.deps.RoleRepo.Create(ctx, adminRole); err != nil {
-		var ecErr *errcode.Error
-		if !errors.As(err, &ecErr) || ecErr.Code != errcode.ErrAuthRoleDuplicate {
-			return nil, fmt.Errorf("initialadmin: ensure admin role: %w", err)
-		}
-		// Role already exists — continue.
-	}
-
-	user, err := domain.NewUser(
-		b.cfg.Username,
-		b.cfg.Username+"@gocell.local",
-		string(hash),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("initialadmin: construct user: %w", err)
-	}
-	user.ID = "usr-bootstrap-" + uuid.NewString()
-	user.MarkPasswordResetRequired()
-
-	if err := b.deps.UserRepo.Create(ctx, user); err != nil {
-		existing, resolveErr := b.resolveDuplicateUser(ctx, err)
-		if resolveErr != nil {
-			return nil, resolveErr
-		}
-		if existing == nil {
-			// Silent skip: another replica finished the bootstrap concurrently.
-			return nil, nil
-		}
-		// Orphan-user recovery: UserRepo.Create returned duplicate but no admin
-		// role exists yet — a previous run crashed between Create and
-		// AssignToUser. Rewrite the existing row's password hash with the
-		// freshly generated one (the old hash is orphaned — we no longer know
-		// the plaintext) and re-assert PasswordResetRequired, so the credfile
-		// written below matches what's in the repo. Then fall through to
-		// AssignToUser on the existing ID.
-		existing.PasswordHash = string(hash)
-		existing.MarkPasswordResetRequired()
-		if err := b.deps.UserRepo.Update(ctx, existing); err != nil {
-			return nil, fmt.Errorf("initialadmin: reset orphan user credentials: %w", err)
-		}
-		user = existing
-	}
-
-	if _, err := b.deps.RoleRepo.AssignToUser(ctx, user.ID, domain.RoleAdmin); err != nil {
-		return nil, fmt.Errorf("initialadmin: assign admin role: %w", err)
-	}
-	return user, nil
-}
-
-// resolveDuplicateUser interprets a UserRepo.Create duplicate error into one of
-// three outcomes:
-//
-//   - not a duplicate → return (nil, wrapped-error): caller surfaces the error
-//   - duplicate + recount > 0 (another pod already completed bootstrap) →
-//     return (nil, nil): caller silently skips
-//   - duplicate + recount == 0 (orphan user from a previous crashed run) →
-//     return (existingUser, nil): caller resumes with that user ID so
-//     AssignToUser finishes the half-done bootstrap
-//
-// The orphan-recovery branch is the idempotent alternative to saga-style
-// step-level compensation (which none of GitLab / Keycloak / Vault / Consul
-// implement in their bootstrap flows). In the current in-memory repo the
-// orphan state cannot persist across restarts, so this path only activates
-// once we switch to PG (X1 PG-DOMAIN-REPO); having the logic in place now
-// keeps the bootstrap contract consistent across the memory/PG transition.
-//
-// ref: GitLab db/fixtures/production/001_admin.rb (single-tx, no compensation),
-// Keycloak ApplianceBootstrap.createMasterRealmAdminUser (catch duplicate,
-// return false), Vault operator init (detect partial-init, resume).
-func (b *bootstrapper) resolveDuplicateUser(ctx context.Context, createErr error) (*domain.User, error) {
-	var ecErr *errcode.Error
-	if !errors.As(createErr, &ecErr) || ecErr.Code != errcode.ErrAuthUserDuplicate {
-		return nil, fmt.Errorf("initialadmin: create user: %w", createErr)
-	}
-	recount, err := b.deps.RoleRepo.CountByRole(ctx, domain.RoleAdmin)
-	if err != nil {
-		return nil, fmt.Errorf("initialadmin: recount after duplicate user: %w", err)
-	}
-	if recount > 0 {
-		b.deps.Logger.Debug("initial admin bootstrap: duplicate user creation race, admin already exists",
-			slog.String("event", "initial_admin_bootstrap"),
-		)
-		return nil, nil
-	}
-	// Orphan recovery: a prior run crashed after UserRepo.Create but before
-	// AssignToUser committed. Pull the existing row and let the caller retry
-	// AssignToUser on its ID.
-	existing, err := b.deps.UserRepo.GetByUsername(ctx, b.cfg.Username)
-	if err != nil {
-		return nil, fmt.Errorf("initialadmin: lookup orphan user for recovery: %w", err)
-	}
-	b.deps.Logger.Info("initial admin bootstrap: resuming orphan-user recovery",
-		slog.String("event", "initial_admin_bootstrap_orphan_recover"),
-		slog.String("user_id", existing.ID),
-	)
-	return existing, nil
 }
 
 // writeFileAndMakeCleaner writes the credential file and constructs the cleanup worker.

--- a/cells/accesscore/initialadmin/bootstrap_branches_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_branches_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,105 +117,6 @@ func (r *errOnUpdateUserRepo) Delete(ctx context.Context, id string) error {
 var _ ports.UserRepository = (*errOnUpdateUserRepo)(nil)
 
 // ---------------------------------------------------------------------------
-// compensateAfterCredFileFailure branch coverage
-// ---------------------------------------------------------------------------
-
-// TestCompensate_BothSucceed verifies the happy-path of compensateAfterCredFileFailure:
-// both RemoveFromUser and Delete succeed — only the Warn log is emitted.
-func TestCompensate_BothSucceed(t *testing.T) {
-	logger, handler := newBootstrapCapturingLogger()
-	roleRepo := mem.NewRoleRepository()
-	userRepo := mem.NewUserRepository()
-
-	// Set up an admin user and role assignment.
-	require.NoError(t, roleRepo.Create(context.Background(), &domain.Role{
-		ID: domain.RoleAdmin, Name: domain.RoleAdmin,
-	}))
-	user, err := domain.NewUser("admin", "admin@gocell.local", "hash")
-	require.NoError(t, err)
-	user.ID = "usr-test-compensate"
-	require.NoError(t, userRepo.Create(context.Background(), user))
-	_, err = roleRepo.AssignToUser(context.Background(), user.ID, domain.RoleAdmin)
-	require.NoError(t, err)
-
-	bs := &bootstrapper{
-		deps: BootstrapDeps{UserRepo: userRepo, RoleRepo: roleRepo, Logger: logger},
-		cfg:  bootstrapConfig{Username: "admin"},
-	}
-	bs.compensateAfterCredFileFailure(context.Background(), user.ID)
-
-	// Warn log must be emitted.
-	rec, found := handler.findByEvent("initial_admin_bootstrap_compensate")
-	assert.True(t, found, "expected compensate log record")
-	assert.Equal(t, rec.attrs["user_id"], user.ID)
-}
-
-// TestCompensate_RemoveFromUserFails verifies that when RoleRepo.RemoveFromUser
-// returns an error, compensateAfterCredFileFailure logs an Error and still
-// attempts the user Delete.
-func TestCompensate_RemoveFromUserFails(t *testing.T) {
-	logger, handler := newBootstrapCapturingLogger()
-	removeErr := errors.New("role repo unavailable")
-	roleRepo := &errRoleRepo{inner: mem.NewRoleRepository(), removeFromUserErr: removeErr}
-	userRepo := mem.NewUserRepository()
-
-	user, err := domain.NewUser("admin", "admin@gocell.local", "hash")
-	require.NoError(t, err)
-	user.ID = "usr-test-remove-fail"
-	require.NoError(t, userRepo.Create(context.Background(), user))
-
-	bs := &bootstrapper{
-		deps: BootstrapDeps{UserRepo: userRepo, RoleRepo: roleRepo, Logger: logger},
-		cfg:  bootstrapConfig{Username: "admin"},
-	}
-	bs.compensateAfterCredFileFailure(context.Background(), user.ID)
-
-	// Error log for RemoveFromUser failure.
-	handler.mu.Lock()
-	defer handler.mu.Unlock()
-	hasError := false
-	for _, r := range handler.records {
-		if r.level.String() == "ERROR" {
-			hasError = true
-			break
-		}
-	}
-	assert.True(t, hasError, "expected Error log when RemoveFromUser fails")
-}
-
-// TestCompensate_UserDeleteFails verifies that when UserRepo.Delete returns an
-// error, compensateAfterCredFileFailure logs an Error (not the Warn success log).
-func TestCompensate_UserDeleteFails(t *testing.T) {
-	logger, handler := newBootstrapCapturingLogger()
-	deleteErr := errors.New("user repo unavailable")
-	roleRepo := mem.NewRoleRepository()
-	userRepo := &errUserRepo{inner: mem.NewUserRepository(), deleteErr: deleteErr}
-
-	user, err := domain.NewUser("admin", "admin@gocell.local", "hash")
-	require.NoError(t, err)
-	user.ID = "usr-test-delete-fail"
-	require.NoError(t, userRepo.inner.Create(context.Background(), user))
-
-	bs := &bootstrapper{
-		deps: BootstrapDeps{UserRepo: userRepo, RoleRepo: roleRepo, Logger: logger},
-		cfg:  bootstrapConfig{Username: "admin"},
-	}
-	bs.compensateAfterCredFileFailure(context.Background(), user.ID)
-
-	// Error log for Delete failure.
-	handler.mu.Lock()
-	defer handler.mu.Unlock()
-	hasError := false
-	for _, r := range handler.records {
-		if r.level.String() == "ERROR" && r.attrs["user_id"] == user.ID {
-			hasError = true
-			break
-		}
-	}
-	assert.True(t, hasError, "expected Error log when Delete fails")
-}
-
-// ---------------------------------------------------------------------------
 // maybeMacOSHint branch coverage
 // ---------------------------------------------------------------------------
 
@@ -254,105 +154,6 @@ func TestMaybeMacOSHint_Darwin(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ensureRoleAndCreateUser branch coverage
-// ---------------------------------------------------------------------------
-
-// TestEnsureRoleAndCreateUser_UpdateOrphanFails exercises the branch where
-// UserRepo.Update fails during orphan-user recovery.
-func TestEnsureRoleAndCreateUser_UpdateOrphanFails(t *testing.T) {
-	logger, _ := newBootstrapCapturingLogger()
-
-	innerUserRepo := mem.NewUserRepository()
-	updateErr := errors.New("DB update timeout")
-	userRepo := &errOnUpdateUserRepo{inner: innerUserRepo, updateErr: updateErr}
-
-	roleRepo := mem.NewRoleRepository()
-
-	// Pre-create an orphan user (duplicate username already in repo).
-	orphan, err := domain.NewUser("admin", "admin@gocell.local", "$2a$12$orphanhash")
-	require.NoError(t, err)
-	orphan.ID = "usr-orphan-update-fail"
-	require.NoError(t, innerUserRepo.Create(context.Background(), orphan))
-	// No role assignment — orphan state.
-
-	bs := &bootstrapper{
-		deps: BootstrapDeps{UserRepo: userRepo, RoleRepo: roleRepo, Logger: logger},
-		cfg:  bootstrapConfig{Username: "admin"},
-	}
-
-	hash := []byte("$2a$04$newhash")
-	result, err := bs.ensureRoleAndCreateUser(context.Background(), hash)
-	require.Error(t, err, "Update failure during orphan recovery must surface as error")
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "orphan")
-}
-
-// ---------------------------------------------------------------------------
-// resolveDuplicateUser branch coverage
-// ---------------------------------------------------------------------------
-
-// TestResolveDuplicateUser_CountByRoleError exercises the branch where
-// CountByRole returns an error during duplicate resolution.
-func TestResolveDuplicateUser_CountByRoleError(t *testing.T) {
-	logger, _ := newBootstrapCapturingLogger()
-	countErr := errors.New("DB connection lost")
-	roleRepo := &errRoleRepo{inner: mem.NewRoleRepository(), countByRoleErr: countErr}
-	userRepo := mem.NewUserRepository()
-
-	bs := &bootstrapper{
-		deps: BootstrapDeps{UserRepo: userRepo, RoleRepo: roleRepo, Logger: logger},
-		cfg:  bootstrapConfig{Username: "admin"},
-	}
-
-	dupErr := errcode.New(errcode.ErrAuthUserDuplicate, "username already exists")
-	result, err := bs.resolveDuplicateUser(context.Background(), dupErr)
-	require.Error(t, err, "CountByRole error must propagate")
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "recount")
-}
-
-// TestResolveDuplicateUser_GetByUsernameError exercises the branch where
-// GetByUsername fails during orphan recovery (CountByRole returns 0 but lookup fails).
-func TestResolveDuplicateUser_GetByUsernameError(t *testing.T) {
-	logger, _ := newBootstrapCapturingLogger()
-	getErr := errors.New("DB read error")
-	userRepo := &errUserRepo{inner: mem.NewUserRepository(), getByUsernameErr: getErr}
-	roleRepo := mem.NewRoleRepository()
-
-	bs := &bootstrapper{
-		deps: BootstrapDeps{UserRepo: userRepo, RoleRepo: roleRepo, Logger: logger},
-		cfg:  bootstrapConfig{Username: "admin"},
-	}
-
-	dupErr := errcode.New(errcode.ErrAuthUserDuplicate, "username already exists")
-	// CountByRole returns 0 (no admin yet) → triggers GetByUsername → which fails.
-	result, err := bs.resolveDuplicateUser(context.Background(), dupErr)
-	require.Error(t, err, "GetByUsername error during orphan recovery must surface")
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "lookup orphan")
-}
-
-// TestResolveDuplicateUser_NonDuplicateError exercises the branch where the
-// create error is not ErrAuthUserDuplicate — it must be returned unwrapped.
-func TestResolveDuplicateUser_NonDuplicateError(t *testing.T) {
-	logger, _ := newBootstrapCapturingLogger()
-	bs := &bootstrapper{
-		deps: BootstrapDeps{
-			UserRepo: mem.NewUserRepository(),
-			RoleRepo: mem.NewRoleRepository(),
-			Logger:   logger,
-		},
-		cfg: bootstrapConfig{Username: "admin"},
-	}
-
-	nonDupErr := errors.New("unexpected repo error")
-	result, err := bs.resolveDuplicateUser(context.Background(), nonDupErr)
-	require.Error(t, err)
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "create user")
-}
-
-// ---------------------------------------------------------------------------
 // sweep branch coverage
 // ---------------------------------------------------------------------------
 
@@ -378,31 +179,6 @@ func TestWithPasswordSourceForTesting_SetsSource(t *testing.T) {
 	l := NewLifecycle(WithPasswordSourceForTesting(src))
 	assert.Equal(t, src, l.cfg.PasswordSource,
 		"WithPasswordSourceForTesting must set cfg.PasswordSource")
-}
-
-// ---------------------------------------------------------------------------
-// adminExists error path
-// ---------------------------------------------------------------------------
-
-// TestAdminExists_CountByRoleError verifies that a CountByRole error is
-// propagated through adminExists.
-func TestAdminExists_CountByRoleError(t *testing.T) {
-	logger, _ := newBootstrapCapturingLogger()
-	countErr := errors.New("count error")
-	roleRepo := &errRoleRepo{inner: mem.NewRoleRepository(), countByRoleErr: countErr}
-
-	bs := &bootstrapper{
-		deps: BootstrapDeps{
-			UserRepo: mem.NewUserRepository(),
-			RoleRepo: roleRepo,
-			Logger:   logger,
-		},
-		cfg: bootstrapConfig{},
-	}
-
-	_, err := bs.adminExists(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "count admin users")
 }
 
 // ---------------------------------------------------------------------------

--- a/cells/accesscore/internal/adminprovision/doc.go
+++ b/cells/accesscore/internal/adminprovision/doc.go
@@ -1,0 +1,17 @@
+// Package adminprovision encapsulates the idempotent, race-safe "bring the
+// first admin into existence" domain logic shared by two consumers:
+//
+//   - cells/accesscore/initialadmin: headless startup Lifecycle that writes
+//     a credential file (auto-generated password) on first run.
+//   - cells/accesscore/slices/setup: interactive POST /api/v1/setup/admin
+//     HTTP endpoint (operator-supplied password).
+//
+// The package is caller-tx-neutral: Ensure does not open its own transaction
+// and does not emit events, so callers compose it with whichever persistence
+// boundary they own (no tx for initialadmin, TxRunner + outbox for setup).
+//
+// Outcomes are modeled as a ProvisionOutcome enum rather than a boolean so
+// callers can distinguish fresh creates (write credfile / emit event), prior
+// completions (silent skip / 409), concurrent-replica races (silent skip),
+// and orphan-recovery resumption (previous crashed run).
+package adminprovision

--- a/cells/accesscore/internal/adminprovision/doc.go
+++ b/cells/accesscore/internal/adminprovision/doc.go
@@ -3,15 +3,18 @@
 //
 //   - cells/accesscore/initialadmin: headless startup Lifecycle that writes
 //     a credential file (auto-generated password) on first run.
-//   - cells/accesscore/slices/setup: interactive POST /api/v1/setup/admin
+//   - cells/accesscore/slices/setup: interactive POST /api/v1/access/setup/admin
 //     HTTP endpoint (operator-supplied password).
 //
 // The package is caller-tx-neutral: Ensure does not open its own transaction
 // and does not emit events, so callers compose it with whichever persistence
 // boundary they own (no tx for initialadmin, TxRunner + outbox for setup).
+// Ensure is serialized internally via sync.Mutex so fast-path → Create → Assign
+// is atomic within a single process; multi-instance deployments must add a
+// cross-process lock (e.g. pg_advisory_xact_lock) in the PG adapter.
 //
 // Outcomes are modeled as a ProvisionOutcome enum rather than a boolean so
 // callers can distinguish fresh creates (write credfile / emit event), prior
-// completions (silent skip / 409), concurrent-replica races (silent skip),
+// completions (silent skip / 410), concurrent-replica races (silent skip),
 // and orphan-recovery resumption (previous crashed run).
 package adminprovision

--- a/cells/accesscore/internal/adminprovision/provisioner.go
+++ b/cells/accesscore/internal/adminprovision/provisioner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
@@ -61,7 +62,19 @@ type UUIDGenerator func() string
 // It is caller-tx-neutral: Ensure does not open a transaction; callers wrap
 // it with their own TxRunner if atomicity across Ensure + adjacent writes is
 // required.
+//
+// Concurrency: Ensure is serialized through an internal mutex so the
+// CountByRole fast-path → Create → Assign sequence is atomic within a single
+// process. This closes the read-after-check window that would otherwise let
+// two concurrent callers with different usernames both pass the fast-path and
+// each persist an admin row (UserRepo's per-username uniqueness does not
+// protect against "admin role has two holders"). The mutex is sufficient for
+// single-process deployments (demo, single-instance PG). Multi-instance PG
+// deployments must layer a cross-process lock on top — the PG adapter is
+// expected to acquire pg_advisory_xact_lock at Ensure entry; see
+// ADMINPROVISION-DIST-LOCK-01 in docs/backlog.md.
 type Provisioner struct {
+	mu       sync.Mutex
 	userRepo ports.UserRepository
 	roleRepo ports.RoleRepository
 	logger   *slog.Logger
@@ -123,6 +136,12 @@ func (p *Provisioner) Ensure(ctx context.Context, in ProvisionInput) (*domain.Us
 	if len(in.PasswordHash) == 0 {
 		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: PasswordHash is required")
 	}
+
+	// Serialize the fast-path → Create → Assign sequence so two concurrent
+	// Ensure callers cannot both pass CountByRole==0 and each persist a
+	// distinct admin user. Single-process scope only; see Provisioner godoc.
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	// 1. Fast path.
 	exists, err := p.Status(ctx)
@@ -235,10 +254,13 @@ func (p *Provisioner) createUserOrRecover(ctx context.Context, in ProvisionInput
 	if err != nil {
 		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: lookup orphan user: %w", err)
 	}
+	// Orphan recovery must fully reassert the caller's RequireReset intent,
+	// not just "set when true". A setup-path orphan recovery (RequireReset=false)
+	// that inherited PasswordResetRequired=true from a crashed bootstrap-path
+	// run would otherwise force the operator to reset a password they just
+	// chose, contradicting the interactive setup semantics.
 	existing.PasswordHash = string(in.PasswordHash)
-	if in.RequireReset {
-		existing.MarkPasswordResetRequired()
-	}
+	existing.PasswordResetRequired = in.RequireReset
 	if err := p.userRepo.Update(ctx, existing); err != nil {
 		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: reset orphan credentials: %w", err)
 	}

--- a/cells/accesscore/internal/adminprovision/provisioner.go
+++ b/cells/accesscore/internal/adminprovision/provisioner.go
@@ -1,0 +1,249 @@
+package adminprovision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// ProvisionOutcome is the result classification returned from Ensure.
+//
+// Callers decide per outcome whether to persist side effects (credfile, event)
+// or surface 409 / silently skip.
+type ProvisionOutcome int
+
+const (
+	// OutcomeUnknown is the zero value; it is never returned successfully.
+	OutcomeUnknown ProvisionOutcome = iota
+	// OutcomeCreated means a fresh admin user + role assignment were persisted.
+	// Caller may emit user.created event and/or write credential file.
+	OutcomeCreated
+	// OutcomeAlreadyExists means at least one admin existed at the fast-path
+	// CountByRole check; no side effects were performed. Caller returns 409
+	// (HTTP) or nil (Lifecycle — silent skip).
+	OutcomeAlreadyExists
+	// OutcomeRaceSkipped means the fast-path CountByRole read zero admins but
+	// a concurrent replica persisted the admin between check and create.
+	// No rows were written. Caller treats the same as OutcomeAlreadyExists.
+	OutcomeRaceSkipped
+	// OutcomeOrphanRecovered means a prior run crashed after UserRepo.Create
+	// but before RoleRepo.AssignToUser committed. Ensure re-asserted the
+	// password hash and completed AssignToUser. The admin row existed before
+	// Ensure ran; the returned user is the recovered row. Callers treat this
+	// like OutcomeCreated for credfile / response purposes but typically skip
+	// event emission (the event was presumably emitted on the crashed run).
+	OutcomeOrphanRecovered
+)
+
+// ProvisionInput holds the inputs for a single Ensure call.
+//
+// PasswordHash is pre-hashed by the caller (bcrypt). Provisioner never sees
+// plaintext. IDPrefix is free-form and preserves caller-side distinguishability
+// in audit logs ("usr-bootstrap-" vs. "usr-").
+type ProvisionInput struct {
+	Username     string
+	Email        string
+	PasswordHash []byte
+	RequireReset bool
+	IDPrefix     string
+}
+
+// UUIDGenerator returns a fresh UUID string. Injected for deterministic tests.
+type UUIDGenerator func() string
+
+// Provisioner is the shared domain service.
+//
+// It is caller-tx-neutral: Ensure does not open a transaction; callers wrap
+// it with their own TxRunner if atomicity across Ensure + adjacent writes is
+// required.
+type Provisioner struct {
+	userRepo ports.UserRepository
+	roleRepo ports.RoleRepository
+	logger   *slog.Logger
+	newID    UUIDGenerator
+}
+
+// NewProvisioner constructs a Provisioner. All dependencies are required;
+// passing nil returns an error so mis-wired assemblies fail at startup rather
+// than at the first Ensure call.
+func NewProvisioner(userRepo ports.UserRepository, roleRepo ports.RoleRepository, logger *slog.Logger, newID UUIDGenerator) (*Provisioner, error) {
+	if userRepo == nil {
+		return nil, fmt.Errorf("adminprovision: UserRepository is required")
+	}
+	if roleRepo == nil {
+		return nil, fmt.Errorf("adminprovision: RoleRepository is required")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("adminprovision: Logger is required")
+	}
+	if newID == nil {
+		return nil, fmt.Errorf("adminprovision: UUIDGenerator is required")
+	}
+	return &Provisioner{
+		userRepo: userRepo,
+		roleRepo: roleRepo,
+		logger:   logger,
+		newID:    newID,
+	}, nil
+}
+
+// Status reports whether at least one admin user exists.
+//
+// Infrastructure errors bubble up unchanged so callers can distinguish a known
+// "no admin" from a transient RoleRepo outage.
+func (p *Provisioner) Status(ctx context.Context) (bool, error) {
+	count, err := p.roleRepo.CountByRole(ctx, domain.RoleAdmin)
+	if err != nil {
+		return false, fmt.Errorf("adminprovision: count admin users: %w", err)
+	}
+	return count > 0, nil
+}
+
+// Ensure idempotently provisions the first admin. It is race-safe across
+// concurrent replicas; see ProvisionOutcome for branch semantics.
+//
+// Steps:
+//  1. Fast-path CountByRole: if > 0, return OutcomeAlreadyExists (no I/O writes).
+//  2. Ensure admin role exists (tolerate ErrAuthRoleDuplicate).
+//  3. Build user with prefix + uuid, persist via UserRepo.Create.
+//     - On ErrAuthUserDuplicate: recount admins. > 0 → OutcomeRaceSkipped
+//     (concurrent replica finished first). == 0 → orphan recovery:
+//     load existing user by username, rewrite hash + reset flag, resume
+//     AssignToUser; returns OutcomeOrphanRecovered.
+//  4. AssignToUser(user, admin) — idempotent per port contract.
+func (p *Provisioner) Ensure(ctx context.Context, in ProvisionInput) (*domain.User, ProvisionOutcome, error) {
+	if in.IDPrefix == "" {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: IDPrefix is required")
+	}
+	if len(in.PasswordHash) == 0 {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: PasswordHash is required")
+	}
+
+	// 1. Fast path.
+	exists, err := p.Status(ctx)
+	if err != nil {
+		return nil, OutcomeUnknown, err
+	}
+	if exists {
+		p.logger.Debug("admin provision skipped: admin already exists",
+			slog.String("event", "admin_provision_skip"))
+		return nil, OutcomeAlreadyExists, nil
+	}
+
+	// 2. Ensure admin role.
+	if err := p.ensureAdminRole(ctx); err != nil {
+		return nil, OutcomeUnknown, err
+	}
+
+	// 3. Persist user (with race / orphan detection).
+	user, outcome, err := p.createUserOrRecover(ctx, in)
+	if err != nil || outcome == OutcomeRaceSkipped {
+		return nil, outcome, err
+	}
+
+	// 4. Assign admin role (idempotent).
+	if _, err := p.roleRepo.AssignToUser(ctx, user.ID, domain.RoleAdmin); err != nil {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: assign admin role: %w", err)
+	}
+
+	return user, outcome, nil
+}
+
+// Compensate best-effort removes the admin role assignment and user row after
+// a post-Ensure side effect (e.g., credfile write) fails. Errors are logged,
+// not returned: the operator's immediate concern is the outer failure.
+func (p *Provisioner) Compensate(ctx context.Context, userID string) {
+	if err := p.roleRepo.RemoveFromUser(ctx, userID, domain.RoleAdmin); err != nil {
+		p.logger.Error("admin provision compensate: unassign role failed",
+			slog.String("event", "admin_provision_compensate"),
+			slog.String("user_id", userID),
+			slog.Any("error", err))
+	}
+	if err := p.userRepo.Delete(ctx, userID); err != nil {
+		p.logger.Error("admin provision compensate: delete user failed",
+			slog.String("event", "admin_provision_compensate"),
+			slog.String("user_id", userID),
+			slog.Any("error", err))
+		return
+	}
+	p.logger.Warn("admin provision compensated; retry on next invocation",
+		slog.String("event", "admin_provision_compensate"),
+		slog.String("user_id", userID))
+}
+
+func (p *Provisioner) ensureAdminRole(ctx context.Context) error {
+	adminRole := &domain.Role{
+		ID:   domain.RoleAdmin,
+		Name: domain.RoleAdmin,
+		Permissions: []domain.Permission{
+			{Resource: "*", Action: "*"},
+		},
+	}
+	if err := p.roleRepo.Create(ctx, adminRole); err != nil {
+		var ecErr *errcode.Error
+		if !errors.As(err, &ecErr) || ecErr.Code != errcode.ErrAuthRoleDuplicate {
+			return fmt.Errorf("adminprovision: ensure admin role: %w", err)
+		}
+	}
+	return nil
+}
+
+// createUserOrRecover persists a new admin user or resumes orphan recovery.
+// Return convention:
+//   - (user, OutcomeCreated, nil)          — fresh row persisted
+//   - (user, OutcomeOrphanRecovered, nil)  — existing orphan row reclaimed
+//   - (nil, OutcomeRaceSkipped, nil)       — concurrent replica finished first
+//   - (nil, OutcomeUnknown, err)           — infra error
+func (p *Provisioner) createUserOrRecover(ctx context.Context, in ProvisionInput) (*domain.User, ProvisionOutcome, error) {
+	user, err := domain.NewUser(in.Username, in.Email, string(in.PasswordHash))
+	if err != nil {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: construct user: %w", err)
+	}
+	user.ID = in.IDPrefix + p.newID()
+	if in.RequireReset {
+		user.MarkPasswordResetRequired()
+	}
+
+	createErr := p.userRepo.Create(ctx, user)
+	if createErr == nil {
+		return user, OutcomeCreated, nil
+	}
+
+	var ecErr *errcode.Error
+	if !errors.As(createErr, &ecErr) || ecErr.Code != errcode.ErrAuthUserDuplicate {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: create user: %w", createErr)
+	}
+
+	// Duplicate — race or orphan recovery.
+	recount, err := p.roleRepo.CountByRole(ctx, domain.RoleAdmin)
+	if err != nil {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: recount after duplicate user: %w", err)
+	}
+	if recount > 0 {
+		p.logger.Debug("admin provision: duplicate user creation race; admin already exists",
+			slog.String("event", "admin_provision_race"))
+		return nil, OutcomeRaceSkipped, nil
+	}
+
+	// Orphan recovery.
+	existing, err := p.userRepo.GetByUsername(ctx, in.Username)
+	if err != nil {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: lookup orphan user: %w", err)
+	}
+	existing.PasswordHash = string(in.PasswordHash)
+	if in.RequireReset {
+		existing.MarkPasswordResetRequired()
+	}
+	if err := p.userRepo.Update(ctx, existing); err != nil {
+		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: reset orphan credentials: %w", err)
+	}
+	p.logger.Info("admin provision: resuming orphan-user recovery",
+		slog.String("event", "admin_provision_orphan_recover"),
+		slog.String("user_id", existing.ID))
+	return existing, OutcomeOrphanRecovered, nil
+}

--- a/cells/accesscore/internal/adminprovision/provisioner_test.go
+++ b/cells/accesscore/internal/adminprovision/provisioner_test.go
@@ -1,0 +1,478 @@
+package adminprovision_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func fixedUUID(ids ...string) adminprovision.UUIDGenerator {
+	i := -1
+	return func() string {
+		i++
+		if i >= len(ids) {
+			return "id-default"
+		}
+		return ids[i]
+	}
+}
+
+func stdInput() adminprovision.ProvisionInput {
+	return adminprovision.ProvisionInput{
+		Username:     "admin",
+		Email:        "admin@local",
+		PasswordHash: []byte("$2a$10$stubhash0000000000000000000000000000000000000000"),
+		RequireReset: true,
+		IDPrefix:     "usr-bootstrap-",
+	}
+}
+
+// --- NewProvisioner -------------------------------------------------------
+
+func TestNewProvisioner_NilDependency_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name string
+		user ports.UserRepository
+		role ports.RoleRepository
+		log  *slog.Logger
+		id   adminprovision.UUIDGenerator
+	}{
+		{name: "nil user repo", user: nil, role: mem.NewRoleRepository(), log: discardLogger(), id: fixedUUID("x")},
+		{name: "nil role repo", user: mem.NewUserRepository(), role: nil, log: discardLogger(), id: fixedUUID("x")},
+		{name: "nil logger", user: mem.NewUserRepository(), role: mem.NewRoleRepository(), log: nil, id: fixedUUID("x")},
+		{name: "nil uuid gen", user: mem.NewUserRepository(), role: mem.NewRoleRepository(), log: discardLogger(), id: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := adminprovision.NewProvisioner(tc.user, tc.role, tc.log, tc.id)
+			require.Error(t, err)
+		})
+	}
+}
+
+// --- Status ---------------------------------------------------------------
+
+func TestProvisioner_Status_NoAdmin_ReturnsFalse(t *testing.T) {
+	p := newProvisioner(t, mem.NewUserRepository(), mem.NewRoleRepository(), fixedUUID("x"))
+	has, err := p.Status(context.Background())
+	require.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestProvisioner_Status_WithAdmin_ReturnsTrue(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	seedAdmin(t, userRepo, roleRepo, "usr-seed")
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
+	has, err := p.Status(context.Background())
+	require.NoError(t, err)
+	assert.True(t, has)
+}
+
+func TestProvisioner_Status_InfraError_Surfaced(t *testing.T) {
+	roleRepo := &errRoleRepo{countErr: errors.New("boom")}
+	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
+	_, err := p.Status(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "count admin users")
+	assert.ErrorContains(t, err, "boom")
+}
+
+// --- Ensure ---------------------------------------------------------------
+
+func TestProvisioner_Ensure_FreshSystem_CreatesUserAndRole(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("aaaa-1111"))
+
+	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.NoError(t, err)
+	assert.Equal(t, adminprovision.OutcomeCreated, outcome)
+	require.NotNil(t, user)
+	assert.Equal(t, "usr-bootstrap-aaaa-1111", user.ID)
+	assert.True(t, user.PasswordResetRequired)
+	// Role assigned
+	cnt, err := roleRepo.CountByRole(context.Background(), domain.RoleAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+}
+
+func TestProvisioner_Ensure_AdminExists_FastPathSkipsNoWrites(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	seedAdmin(t, userRepo, roleRepo, "usr-prior")
+
+	// Wrap repos to observe that Create is never called on the fast path.
+	counting := &countingUserRepo{UserRepository: userRepo}
+	p := newProvisioner(t, counting, roleRepo, fixedUUID("x"))
+
+	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.NoError(t, err)
+	assert.Equal(t, adminprovision.OutcomeAlreadyExists, outcome)
+	assert.Nil(t, user)
+	assert.Equal(t, 0, counting.creates, "no user write on fast path")
+}
+
+func TestProvisioner_Ensure_RaceSkipped_NoCreatedUserReturned(t *testing.T) {
+	// Fake user repo: Create returns ErrAuthUserDuplicate.
+	// Fake role repo: CountByRole returns 0 first (fast-path), 1 on recount.
+	userRepo := &duplicateUserRepo{}
+	roleRepo := &scriptedRoleRepo{counts: []int{0, 1}}
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
+
+	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.NoError(t, err)
+	assert.Equal(t, adminprovision.OutcomeRaceSkipped, outcome)
+	assert.Nil(t, user)
+	assert.False(t, roleRepo.assignCalled, "AssignToUser must NOT run on race path")
+}
+
+func TestProvisioner_Ensure_OrphanRecovered_ResumesAssignment(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	// Pre-seed an orphan user (previous crash between Create + Assign): row
+	// exists but no admin role assigned.
+	orphan, err := domain.NewUser("admin", "admin@local", "$2a$10$oldhash000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	orphan.ID = "usr-orphan-prior"
+	require.NoError(t, userRepo.Create(context.Background(), orphan))
+
+	roleRepo := mem.NewRoleRepository()
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
+
+	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.NoError(t, err)
+	assert.Equal(t, adminprovision.OutcomeOrphanRecovered, outcome)
+	require.NotNil(t, user)
+	assert.Equal(t, "usr-orphan-prior", user.ID, "orphan ID preserved")
+	// Hash was rewritten to the new caller-supplied hash
+	refreshed, err := userRepo.GetByID(context.Background(), "usr-orphan-prior")
+	require.NoError(t, err)
+	assert.Equal(t, string(stdInput().PasswordHash), refreshed.PasswordHash)
+	// Role now assigned
+	cnt, err := roleRepo.CountByRole(context.Background(), domain.RoleAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+}
+
+func TestProvisioner_Ensure_OrphanUpdateFails_Surfaced(t *testing.T) {
+	// Orphan path reached, but UserRepo.Update fails when rewriting the hash.
+	inner := mem.NewUserRepository()
+	orphan, _ := domain.NewUser("admin", "admin@local", "$2a$10$orphanold")
+	orphan.ID = "usr-orphan-pre"
+	require.NoError(t, inner.Create(context.Background(), orphan))
+	userRepo := &updateFailUserRepo{inner: inner, updateErr: errors.New("update failed")}
+
+	roleRepo := mem.NewRoleRepository()
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
+	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.Error(t, err)
+	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+	assert.ErrorContains(t, err, "reset orphan credentials")
+}
+
+func TestProvisioner_Ensure_OrphanLookupFails_Surfaced(t *testing.T) {
+	// Duplicate Create + CountByRole=0 → orphan recovery triggers GetByUsername;
+	// but GetByUsername fails.
+	userRepo := &orphanLookupFailRepo{duplicateUserRepo: duplicateUserRepo{}, lookupErr: errors.New("lookup failed")}
+	roleRepo := &scriptedRoleRepo{counts: []int{0, 0}}
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
+	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.Error(t, err)
+	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+	assert.ErrorContains(t, err, "lookup orphan user")
+}
+
+func TestProvisioner_Ensure_RecountAfterDuplicateFails_Surfaced(t *testing.T) {
+	// Duplicate Create, but the recount itself errors.
+	userRepo := &duplicateUserRepo{}
+	roleRepo := &recountErrRoleRepo{firstCount: 0, recountErr: errors.New("recount failed")}
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
+	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.Error(t, err)
+	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+	assert.ErrorContains(t, err, "recount after duplicate user")
+}
+
+func TestProvisioner_Ensure_RoleRepoCountError_Surfaced(t *testing.T) {
+	roleRepo := &errRoleRepo{countErr: errors.New("boom")}
+	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
+	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.Error(t, err)
+	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+}
+
+func TestProvisioner_Ensure_RoleCreateNonDuplicateError_Surfaced(t *testing.T) {
+	roleRepo := &errRoleRepo{createErr: errors.New("pg down")}
+	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
+	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.Error(t, err)
+	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+	assert.ErrorContains(t, err, "ensure admin role")
+}
+
+func TestProvisioner_Ensure_RoleCreateDuplicate_Tolerated(t *testing.T) {
+	// Admin role already exists (but no users assigned yet).
+	roleRepo := mem.NewRoleRepository()
+	role := &domain.Role{ID: domain.RoleAdmin, Name: domain.RoleAdmin}
+	require.NoError(t, roleRepo.Create(context.Background(), role))
+
+	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
+	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.NoError(t, err)
+	assert.Equal(t, adminprovision.OutcomeCreated, outcome)
+	require.NotNil(t, user)
+}
+
+func TestProvisioner_Ensure_UserCreateInfraError_Surfaced(t *testing.T) {
+	userRepo := &errUserRepo{createErr: errors.New("db down")}
+	p := newProvisioner(t, userRepo, mem.NewRoleRepository(), fixedUUID("x"))
+	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.Error(t, err)
+	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+	assert.ErrorContains(t, err, "create user")
+}
+
+func TestProvisioner_Ensure_AssignToUserError_Surfaced(t *testing.T) {
+	roleRepo := &errRoleRepo{assignErr: errors.New("fk violation")}
+	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
+	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	require.Error(t, err)
+	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+	assert.ErrorContains(t, err, "assign admin role")
+}
+
+func TestProvisioner_Ensure_InvalidInput_Errors(t *testing.T) {
+	p := newProvisioner(t, mem.NewUserRepository(), mem.NewRoleRepository(), fixedUUID("x"))
+	tests := []struct {
+		name string
+		in   adminprovision.ProvisionInput
+	}{
+		{"missing prefix", adminprovision.ProvisionInput{Username: "u", Email: "u@x", PasswordHash: []byte("h")}},
+		{"missing hash", adminprovision.ProvisionInput{Username: "u", Email: "u@x", IDPrefix: "usr-"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, outcome, err := p.Ensure(context.Background(), tc.in)
+			require.Error(t, err)
+			assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
+		})
+	}
+}
+
+// --- Compensate -----------------------------------------------------------
+
+func TestProvisioner_Compensate_RemovesRoleAndUser(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("zzz"))
+	user, _, err := p.Ensure(context.Background(), stdInput())
+	require.NoError(t, err)
+	require.NotNil(t, user)
+
+	p.Compensate(context.Background(), user.ID)
+
+	cnt, err := roleRepo.CountByRole(context.Background(), domain.RoleAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cnt, "role assignment removed")
+	_, err = userRepo.GetByID(context.Background(), user.ID)
+	require.Error(t, err, "user row removed")
+}
+
+func TestProvisioner_Compensate_ToleratesErrorsLogOnly(t *testing.T) {
+	userRepo := &errUserRepo{deleteErr: errors.New("delete failed")}
+	roleRepo := &errRoleRepo{removeErr: errors.New("remove failed")}
+	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
+	// Must not panic / return error.
+	p.Compensate(context.Background(), "usr-phantom")
+}
+
+// --- test helpers ---------------------------------------------------------
+
+func newProvisioner(t *testing.T, user ports.UserRepository, role ports.RoleRepository, id adminprovision.UUIDGenerator) *adminprovision.Provisioner {
+	t.Helper()
+	p, err := adminprovision.NewProvisioner(user, role, discardLogger(), id)
+	require.NoError(t, err)
+	return p
+}
+
+func seedAdmin(t *testing.T, userRepo ports.UserRepository, roleRepo ports.RoleRepository, id string) {
+	t.Helper()
+	u, err := domain.NewUser("seedadmin", "seed@local", "$2a$10$hash000000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	u.ID = id
+	require.NoError(t, userRepo.Create(context.Background(), u))
+	require.NoError(t, roleRepo.Create(context.Background(), &domain.Role{ID: domain.RoleAdmin, Name: domain.RoleAdmin}))
+	_, err = roleRepo.AssignToUser(context.Background(), u.ID, domain.RoleAdmin)
+	require.NoError(t, err)
+}
+
+// countingUserRepo wraps a UserRepository and counts Create calls.
+type countingUserRepo struct {
+	ports.UserRepository
+	creates int
+}
+
+func (c *countingUserRepo) Create(ctx context.Context, u *domain.User) error {
+	c.creates++
+	return c.UserRepository.Create(ctx, u)
+}
+
+// duplicateUserRepo always rejects Create with ErrAuthUserDuplicate. GetByUsername
+// returns an existing user so orphan-recovery can be simulated.
+type duplicateUserRepo struct{}
+
+func (r *duplicateUserRepo) Create(ctx context.Context, u *domain.User) error {
+	return errcode.New(errcode.ErrAuthUserDuplicate, "duplicate")
+}
+func (r *duplicateUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
+	return nil, errors.New("not expected on race path")
+}
+func (r *duplicateUserRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
+	u, _ := domain.NewUser(username, username+"@x", "$2a$10$hashold")
+	u.ID = "usr-orphan"
+	return u, nil
+}
+func (r *duplicateUserRepo) Update(ctx context.Context, u *domain.User) error { return nil }
+func (r *duplicateUserRepo) Delete(ctx context.Context, id string) error      { return nil }
+
+// scriptedRoleRepo returns CountByRole values from a scripted sequence; tracks
+// whether AssignToUser / Create was called.
+type scriptedRoleRepo struct {
+	counts       []int
+	i            int
+	assignCalled bool
+}
+
+func (r *scriptedRoleRepo) Create(ctx context.Context, role *domain.Role) error { return nil }
+func (r *scriptedRoleRepo) AssignToUser(ctx context.Context, userID, roleID string) (bool, error) {
+	r.assignCalled = true
+	return true, nil
+}
+func (r *scriptedRoleRepo) CountByRole(ctx context.Context, roleID string) (int, error) {
+	if r.i >= len(r.counts) {
+		return r.counts[len(r.counts)-1], nil
+	}
+	v := r.counts[r.i]
+	r.i++
+	return v, nil
+}
+func (r *scriptedRoleRepo) GetByUserID(ctx context.Context, userID string) ([]*domain.Role, error) {
+	return nil, nil
+}
+func (r *scriptedRoleRepo) RemoveFromUser(ctx context.Context, userID, roleID string) error {
+	return nil
+}
+func (r *scriptedRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
+	return true, nil
+}
+func (r *scriptedRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
+	return nil, nil
+}
+func (r *scriptedRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
+	return nil, nil
+}
+
+// errRoleRepo injects errors into each method.
+type errRoleRepo struct {
+	createErr error
+	countErr  error
+	assignErr error
+	removeErr error
+}
+
+func (r *errRoleRepo) Create(ctx context.Context, role *domain.Role) error { return r.createErr }
+func (r *errRoleRepo) AssignToUser(ctx context.Context, userID, roleID string) (bool, error) {
+	return false, r.assignErr
+}
+func (r *errRoleRepo) CountByRole(ctx context.Context, roleID string) (int, error) {
+	return 0, r.countErr
+}
+func (r *errRoleRepo) GetByUserID(ctx context.Context, userID string) ([]*domain.Role, error) {
+	return nil, nil
+}
+func (r *errRoleRepo) RemoveFromUser(ctx context.Context, userID, roleID string) error {
+	return r.removeErr
+}
+func (r *errRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
+	return true, nil
+}
+func (r *errRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
+	return nil, nil
+}
+func (r *errRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
+	return nil, nil
+}
+
+// updateFailUserRepo wraps mem.UserRepository but returns updateErr from Update.
+type updateFailUserRepo struct {
+	inner     *mem.UserRepository
+	updateErr error
+}
+
+func (r *updateFailUserRepo) Create(ctx context.Context, u *domain.User) error {
+	return errcode.New(errcode.ErrAuthUserDuplicate, "duplicate")
+}
+func (r *updateFailUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
+	return r.inner.GetByID(ctx, id)
+}
+func (r *updateFailUserRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
+	return r.inner.GetByUsername(ctx, username)
+}
+func (r *updateFailUserRepo) Update(ctx context.Context, u *domain.User) error { return r.updateErr }
+func (r *updateFailUserRepo) Delete(ctx context.Context, id string) error      { return nil }
+
+// orphanLookupFailRepo extends duplicateUserRepo to fail GetByUsername.
+type orphanLookupFailRepo struct {
+	duplicateUserRepo
+	lookupErr error
+}
+
+func (r *orphanLookupFailRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
+	return nil, r.lookupErr
+}
+
+// recountErrRoleRepo returns firstCount then recountErr on subsequent CountByRole.
+type recountErrRoleRepo struct {
+	scriptedRoleRepo
+	firstCount int
+	recountErr error
+	called     int
+}
+
+func (r *recountErrRoleRepo) CountByRole(ctx context.Context, roleID string) (int, error) {
+	r.called++
+	if r.called == 1 {
+		return r.firstCount, nil
+	}
+	return 0, r.recountErr
+}
+
+// errUserRepo injects errors into each method.
+type errUserRepo struct {
+	createErr error
+	deleteErr error
+}
+
+func (r *errUserRepo) Create(ctx context.Context, u *domain.User) error { return r.createErr }
+func (r *errUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
+	return nil, errors.New("not seeded")
+}
+func (r *errUserRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
+	return nil, errors.New("not seeded")
+}
+func (r *errUserRepo) Update(ctx context.Context, u *domain.User) error { return nil }
+func (r *errUserRepo) Delete(ctx context.Context, id string) error      { return r.deleteErr }

--- a/cells/accesscore/internal/dto/user_events.go
+++ b/cells/accesscore/internal/dto/user_events.go
@@ -1,0 +1,24 @@
+package dto
+
+// Topic constants for user-lifecycle events (L2 OutboxFact).
+//
+// Shared between accesscore slices that produce user events (identitymanage,
+// setup) so there's a single source of truth. Downstream consumers in other
+// cells (auditcore) match against these topic strings directly via wire-level
+// string literals — the dto package is accesscore-internal and must not be
+// imported by other cells (CLAUDE.md 分层依赖规则).
+const (
+	TopicUserCreated = "event.user.created.v1"
+	TopicUserLocked  = "event.user.locked.v1"
+)
+
+// UserCreatedEvent is the payload for event.user.created.v1.
+//
+// Wire format uses snake_case to match the frozen event.user.created.v1 schema
+// (contracts/event/user/created/v1/payload.schema.json). New event contracts
+// should use camelCase per cell-patterns.md; this schema is grandfathered until
+// the v1.0 post-release migration.
+type UserCreatedEvent struct {
+	UserID   string `json:"user_id"`
+	Username string `json:"username"`
+}

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -31,9 +31,12 @@ type TokenIssuer interface {
 	IssueForUser(ctx context.Context, userID string) (dto.TokenPair, error)
 }
 
+// Topic constants are defined in cells/accesscore/internal/dto to allow sharing
+// with the setup slice without either slice importing the other. These locals
+// preserve the existing TestXxx(TopicUserCreated...) style in the test suite.
 const (
-	TopicUserCreated = "event.user.created.v1"
-	TopicUserLocked  = "event.user.locked.v1"
+	TopicUserCreated = dto.TopicUserCreated
+	TopicUserLocked  = dto.TopicUserLocked
 )
 
 // Option configures an identity-manage Service.
@@ -124,7 +127,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.User, 
 		user.MarkPasswordResetRequired()
 	}
 
-	eventPayload := map[string]any{"user_id": user.ID, "username": user.Username}
+	eventPayload := dto.UserCreatedEvent{UserID: user.ID, Username: user.Username}
 	if err := s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
 		if err := s.repo.Create(txCtx, user); err != nil {
 			return fmt.Errorf("identity-manage: create: %w", err)
@@ -364,7 +367,7 @@ func (s *Service) ChangePassword(ctx context.Context, input ChangePasswordInput)
 	return pair, nil
 }
 
-func (s *Service) publish(ctx context.Context, topic string, payload map[string]any) error {
+func (s *Service) publish(ctx context.Context, topic string, payload any) error {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("identity-manage: marshal event payload: %w", err)

--- a/cells/accesscore/slices/setup/contract_test.go
+++ b/cells/accesscore/slices/setup/contract_test.go
@@ -1,8 +1,15 @@
 package setup_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/setup"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 )
 
@@ -16,6 +23,15 @@ func TestHttpAuthSetupStatusV1Serve(t *testing.T) {
 	c.MustRejectResponse(t, []byte(`{"data":{"hasAdmin":false,"unexpected":"x"}}`))
 	// required hasAdmin
 	c.MustRejectResponse(t, []byte(`{"data":{}}`))
+
+	// Also exercise the real handler and feed its recorded output through the
+	// contract validator so serialisation bugs would surface.
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), nil)
+	h := setup.NewHandler(svc)
+	req := httptest.NewRequest(http.MethodGet, c.HTTP.Path, nil)
+	rec := httptest.NewRecorder()
+	h.HandleStatus(rec, req)
+	c.ValidateHTTPResponseRecorder(t, rec)
 }
 
 func TestHttpAuthSetupAdminV1Serve(t *testing.T) {
@@ -31,4 +47,17 @@ func TestHttpAuthSetupAdminV1Serve(t *testing.T) {
 	c.MustRejectRequest(t, []byte(`{"username":"root","email":"root@local","password":"p","extra":"field"}`))
 	// Empty strings → reject (minLength:1)
 	c.MustRejectRequest(t, []byte(`{"username":"","email":"root@local","password":"p"}`))
+	// Password too short → reject (minLength:8)
+	c.MustRejectRequest(t, []byte(`{"username":"u","email":"u@x","password":"short"}`))
+
+	// Real-handler produced 201 payload must satisfy the response schema.
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), &stubWriter{})
+	h := setup.NewHandler(svc)
+	body := `{"username":"root","email":"root@local","password":"SecretPass!23"}`
+	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.HandleCreateAdmin(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	c.ValidateHTTPResponseRecorder(t, rec)
 }

--- a/cells/accesscore/slices/setup/contract_test.go
+++ b/cells/accesscore/slices/setup/contract_test.go
@@ -1,0 +1,34 @@
+package setup_test
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/contracttest"
+)
+
+func TestHttpAuthSetupStatusV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.auth.setup.status.v1")
+
+	c.ValidateResponse(t, []byte(`{"data":{"hasAdmin":false}}`))
+	c.ValidateResponse(t, []byte(`{"data":{"hasAdmin":true}}`))
+	// additionalProperties:false — unknown fields rejected.
+	c.MustRejectResponse(t, []byte(`{"data":{"hasAdmin":false,"unexpected":"x"}}`))
+	// required hasAdmin
+	c.MustRejectResponse(t, []byte(`{"data":{}}`))
+}
+
+func TestHttpAuthSetupAdminV1Serve(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.auth.setup.admin.v1")
+
+	c.ValidateRequest(t, []byte(`{"username":"root","email":"root@local","password":"SecretPass!23"}`))
+	c.ValidateResponse(t, []byte(`{"data":{"id":"usr-123","username":"root","email":"root@local","createdAt":"2026-04-24T12:00:00Z"}}`))
+
+	// Missing required fields → reject
+	c.MustRejectRequest(t, []byte(`{"username":"root","email":"root@local"}`))
+	// Unknown fields → reject
+	c.MustRejectRequest(t, []byte(`{"username":"root","email":"root@local","password":"p","extra":"field"}`))
+	// Empty strings → reject (minLength:1)
+	c.MustRejectRequest(t, []byte(`{"username":"","email":"root@local","password":"p"}`))
+}

--- a/cells/accesscore/slices/setup/contract_test.go
+++ b/cells/accesscore/slices/setup/contract_test.go
@@ -1,13 +1,16 @@
 package setup_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/setup"
 	"github.com/ghbvf/gocell/pkg/contracttest"
@@ -60,4 +63,34 @@ func TestHttpAuthSetupAdminV1Serve(t *testing.T) {
 	h.HandleCreateAdmin(rec, req)
 	require.Equal(t, http.StatusCreated, rec.Code)
 	c.ValidateHTTPResponseRecorder(t, rec)
+}
+
+// TestEventUserCreatedV1Publish_FromSetup closes the slice.yaml
+// contract.event.user.created.v1.publish verification gap: the setup slice
+// declares it publishes event.user.created.v1, so this test must drive the
+// real handler path and assert the emitted outbox entry's payload + headers
+// both satisfy the event contract.
+func TestEventUserCreatedV1Publish_FromSetup(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "event.user.created.v1")
+
+	w := &stubWriter{}
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), w)
+
+	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, w.entries, 1, "setup.CreateAdmin must emit exactly one event on fresh create")
+	entry := w.entries[0]
+	assert.Equal(t, dto.TopicUserCreated, entry.EventType)
+
+	// Payload + headers must satisfy the published contract schema.
+	c.ValidatePayload(t, entry.Payload)
+	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
+	// Negative: schema rejects an incomplete payload.
+	c.MustRejectPayload(t, []byte(`{"user_id":"x"}`))
 }

--- a/cells/accesscore/slices/setup/handler.go
+++ b/cells/accesscore/slices/setup/handler.go
@@ -16,7 +16,7 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// HandleStatus handles GET /api/v1/setup/status.
+// HandleStatus handles GET /api/v1/access/setup/status.
 func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	out, err := h.svc.Status(r.Context())
 	if err != nil {
@@ -26,7 +26,7 @@ func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": out})
 }
 
-// HandleCreateAdmin handles POST /api/v1/setup/admin.
+// HandleCreateAdmin handles POST /api/v1/access/setup/admin.
 func (h *Handler) HandleCreateAdmin(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Username string `json:"username"`

--- a/cells/accesscore/slices/setup/handler.go
+++ b/cells/accesscore/slices/setup/handler.go
@@ -1,0 +1,51 @@
+package setup
+
+import (
+	"net/http"
+
+	"github.com/ghbvf/gocell/pkg/httputil"
+)
+
+// Handler exposes the setup endpoints over HTTP.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a setup Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// HandleStatus handles GET /api/v1/setup/status.
+func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	out, err := h.svc.Status(r.Context())
+	if err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": out})
+}
+
+// HandleCreateAdmin handles POST /api/v1/setup/admin.
+func (h *Handler) HandleCreateAdmin(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Username string `json:"username"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := httputil.DecodeJSONStrict(r, &req); err != nil {
+		httputil.WriteDecodeError(r.Context(), w, err)
+		return
+	}
+
+	out, err := h.svc.CreateAdmin(r.Context(), CreateAdminInput{
+		Username: req.Username,
+		Email:    req.Email,
+		Password: req.Password,
+	})
+	if err != nil {
+		httputil.WriteDomainError(r.Context(), w, err)
+		return
+	}
+	httputil.WriteJSON(w, http.StatusCreated, map[string]any{"data": out})
+}

--- a/cells/accesscore/slices/setup/handler_test.go
+++ b/cells/accesscore/slices/setup/handler_test.go
@@ -1,0 +1,137 @@
+package setup_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/setup"
+)
+
+func newHandlerFresh(t *testing.T) *setup.Handler {
+	t.Helper()
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), &stubWriter{})
+	return setup.NewHandler(svc)
+}
+
+// --- HandleStatus ---------------------------------------------------------
+
+func TestHandler_Status_FreshSystem_ReturnsFalse(t *testing.T) {
+	h := newHandlerFresh(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/status", nil)
+
+	h.HandleStatus(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data setup.StatusOutput `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Data.HasAdmin)
+}
+
+func TestHandler_Status_WithAdmin_ReturnsTrue(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	seedAdmin(t, userRepo, roleRepo)
+	svc := newService(t, userRepo, roleRepo, nil)
+	h := setup.NewHandler(svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/status", nil)
+	h.HandleStatus(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data setup.StatusOutput `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Data.HasAdmin)
+}
+
+// --- HandleCreateAdmin ----------------------------------------------------
+
+func TestHandler_CreateAdmin_FreshSystem_Returns201(t *testing.T) {
+	h := newHandlerFresh(t)
+
+	body := `{"username":"root","email":"root@local","password":"SecretPass!23"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdmin(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var resp struct {
+		Data setup.CreateAdminOutput `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "root", resp.Data.Username)
+	assert.Equal(t, "root@local", resp.Data.Email)
+	assert.Contains(t, resp.Data.ID, "usr-")
+	assert.NotEmpty(t, resp.Data.CreatedAt)
+}
+
+func TestHandler_CreateAdmin_AlreadyExists_Returns409(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	seedAdmin(t, userRepo, roleRepo)
+	svc := newService(t, userRepo, roleRepo, &stubWriter{})
+	h := setup.NewHandler(svc)
+
+	body := `{"username":"root","email":"root@local","password":"SecretPass!23"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdmin(w, req)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "ERR_SETUP_ALREADY_INITIALIZED")
+}
+
+func TestHandler_CreateAdmin_MalformedJSON_Returns400(t *testing.T) {
+	h := newHandlerFresh(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdmin(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandler_CreateAdmin_UnknownField_Returns400(t *testing.T) {
+	h := newHandlerFresh(t)
+
+	body := `{"username":"u","email":"u@x","password":"p","extra":"field"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdmin(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "DecodeJSONStrict rejects unknown fields")
+}
+
+func TestHandler_CreateAdmin_BlankPassword_Returns400(t *testing.T) {
+	h := newHandlerFresh(t)
+
+	body := `{"username":"root","email":"root@local","password":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdmin(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "ERR_AUTH_IDENTITY_INVALID_INPUT")
+}

--- a/cells/accesscore/slices/setup/handler_test.go
+++ b/cells/accesscore/slices/setup/handler_test.go
@@ -25,7 +25,7 @@ func newHandlerFresh(t *testing.T) *setup.Handler {
 func TestHandler_Status_FreshSystem_ReturnsFalse(t *testing.T) {
 	h := newHandlerFresh(t)
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/status", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/setup/status", nil)
 
 	h.HandleStatus(w, req)
 
@@ -45,7 +45,7 @@ func TestHandler_Status_WithAdmin_ReturnsTrue(t *testing.T) {
 	h := setup.NewHandler(svc)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/status", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/setup/status", nil)
 	h.HandleStatus(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -62,7 +62,7 @@ func TestHandler_CreateAdmin_FreshSystem_Returns201(t *testing.T) {
 	h := newHandlerFresh(t)
 
 	body := `{"username":"root","email":"root@local","password":"SecretPass!23"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/setup/admin", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -79,7 +79,7 @@ func TestHandler_CreateAdmin_FreshSystem_Returns201(t *testing.T) {
 	assert.NotEmpty(t, resp.Data.CreatedAt)
 }
 
-func TestHandler_CreateAdmin_AlreadyExists_Returns409(t *testing.T) {
+func TestHandler_CreateAdmin_AlreadyExists_Returns410(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	roleRepo := mem.NewRoleRepository()
 	seedAdmin(t, userRepo, roleRepo)
@@ -87,20 +87,22 @@ func TestHandler_CreateAdmin_AlreadyExists_Returns409(t *testing.T) {
 	h := setup.NewHandler(svc)
 
 	body := `{"username":"root","email":"root@local","password":"SecretPass!23"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/setup/admin", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
 	h.HandleCreateAdmin(w, req)
 
-	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Equal(t, http.StatusGone, w.Code)
 	assert.Contains(t, w.Body.String(), "ERR_SETUP_ALREADY_INITIALIZED")
+	assert.Contains(t, w.Body.String(), `"nextAction":"login"`)
+	assert.Contains(t, w.Body.String(), `"loginEndpoint":"/api/v1/access/sessions/login"`)
 }
 
 func TestHandler_CreateAdmin_MalformedJSON_Returns400(t *testing.T) {
 	h := newHandlerFresh(t)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(`not-json`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/setup/admin", strings.NewReader(`not-json`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -113,7 +115,7 @@ func TestHandler_CreateAdmin_UnknownField_Returns400(t *testing.T) {
 	h := newHandlerFresh(t)
 
 	body := `{"username":"u","email":"u@x","password":"p","extra":"field"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/setup/admin", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -126,7 +128,7 @@ func TestHandler_CreateAdmin_BlankPassword_Returns400(t *testing.T) {
 	h := newHandlerFresh(t)
 
 	body := `{"username":"root","email":"root@local","password":""}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/admin", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/access/setup/admin", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 

--- a/cells/accesscore/slices/setup/service.go
+++ b/cells/accesscore/slices/setup/service.go
@@ -1,0 +1,196 @@
+// Package setup implements the interactive first-run admin provisioning slice.
+//
+// Two Public HTTP endpoints:
+//
+//	GET  /api/v1/setup/status   — returns {"hasAdmin": bool}
+//	POST /api/v1/setup/admin    — creates the first admin; 409 after initialized
+//
+// Race-safe admin creation is delegated to cells/accesscore/internal/adminprovision
+// so the semantics match the headless initialadmin Lifecycle exactly.
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+// TopicUserCreated is the event topic published on fresh admin creation.
+// Same contract / topic as identitymanage emits so downstream projections
+// treat the first admin as a regular user.created fact.
+const TopicUserCreated = "event.user.created.v1"
+
+// UserIDPrefix distinguishes setup-path admins from bootstrap-path admins in
+// audit logs ("usr-" vs. "usr-bootstrap-").
+const UserIDPrefix = "usr-"
+
+// Option configures a Service.
+type Option func(*Service)
+
+// WithEmitter sets the event emitter. Defaults to a Noop emitter.
+func WithEmitter(e outbox.Emitter) Option {
+	return func(s *Service) {
+		if e != nil {
+			s.emitter = e
+		}
+	}
+}
+
+// WithTxManager sets the TxRunner for L2 atomicity (user write + event emit).
+func WithTxManager(tx persistence.TxRunner) Option {
+	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
+}
+
+// Service implements the setup slice's business logic.
+type Service struct {
+	provisioner *adminprovision.Provisioner
+	txRunner    persistence.TxRunner
+	emitter     outbox.Emitter
+	logger      *slog.Logger
+}
+
+// NewService constructs a Service. provisioner is required; passing nil returns
+// an error so mis-wired assemblies fail at startup.
+func NewService(provisioner *adminprovision.Provisioner, logger *slog.Logger, opts ...Option) (*Service, error) {
+	if provisioner == nil {
+		return nil, fmt.Errorf("setup: provisioner is required")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("setup: logger is required")
+	}
+	s := &Service{
+		provisioner: provisioner,
+		txRunner:    persistence.NoopTxRunner{},
+		emitter:     outbox.NewNoopEmitter(),
+		logger:      logger,
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s, nil
+}
+
+// StatusOutput is the response shape for GET /api/v1/setup/status.
+type StatusOutput struct {
+	HasAdmin bool `json:"hasAdmin"`
+}
+
+// Status returns whether the system already has at least one admin.
+func (s *Service) Status(ctx context.Context) (StatusOutput, error) {
+	has, err := s.provisioner.Status(ctx)
+	if err != nil {
+		return StatusOutput{}, fmt.Errorf("setup: status: %w", err)
+	}
+	return StatusOutput{HasAdmin: has}, nil
+}
+
+// CreateAdminInput holds the operator-supplied first-admin fields.
+type CreateAdminInput struct {
+	Username string
+	Email    string
+	Password string
+}
+
+// CreateAdminOutput is the response shape for POST /api/v1/setup/admin.
+type CreateAdminOutput struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// CreateAdmin provisions the first admin user with an operator-chosen password.
+//
+// Returns errcode.ErrSetupAlreadyInitialized when an admin already exists
+// (either at the fast-path Status check or after a race detected inside
+// adminprovision.Ensure).
+//
+// Consistency: L2 (OutboxFact). The user write + event emit share a single
+// TxRunner scope so event publication is atomic with row persistence.
+func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*CreateAdminOutput, error) {
+	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
+		validation.F("username", in.Username),
+		validation.F("email", in.Email),
+		validation.F("password", in.Password),
+	); err != nil {
+		return nil, err
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(in.Password), domain.BcryptCost)
+	if err != nil {
+		return nil, fmt.Errorf("setup: hash password: %w", err)
+	}
+
+	var out *CreateAdminOutput
+	err = s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
+		user, outcome, perr := s.provisioner.Ensure(txCtx, adminprovision.ProvisionInput{
+			Username:     in.Username,
+			Email:        in.Email,
+			PasswordHash: hash,
+			RequireReset: false,
+			IDPrefix:     UserIDPrefix,
+		})
+		if perr != nil {
+			return fmt.Errorf("setup: ensure admin: %w", perr)
+		}
+		switch outcome {
+		case adminprovision.OutcomeAlreadyExists, adminprovision.OutcomeRaceSkipped:
+			return errcode.New(errcode.ErrSetupAlreadyInitialized,
+				"first-run admin already provisioned; use /api/v1/access/sessions/login")
+		case adminprovision.OutcomeCreated:
+			if err := s.publishUserCreated(txCtx, user); err != nil {
+				return err
+			}
+		case adminprovision.OutcomeOrphanRecovered:
+			// Deliberate: do NOT emit user.created on orphan recovery — the
+			// crashed prior run presumably emitted it before the credfile
+			// failure. Duplicating the event would confuse idempotent consumers
+			// that dedupe on (event_type, user_id).
+			s.logger.Info("setup: orphan user recovered; event emission skipped",
+				slog.String("event", "setup_orphan_recover"),
+				slog.String("user_id", user.ID))
+		default:
+			return fmt.Errorf("setup: unexpected provision outcome %d", outcome)
+		}
+		out = &CreateAdminOutput{
+			ID:        user.ID,
+			Username:  user.Username,
+			Email:     user.Email,
+			CreatedAt: user.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z07:00"),
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Service) publishUserCreated(ctx context.Context, user *domain.User) error {
+	payload, err := json.Marshal(map[string]any{
+		"user_id":  user.ID,
+		"username": user.Username,
+	})
+	if err != nil {
+		return fmt.Errorf("setup: marshal user.created payload: %w", err)
+	}
+	entry := outbox.Entry{
+		ID:        outbox.NewEntryID(),
+		EventType: TopicUserCreated,
+		Payload:   payload,
+	}
+	if err := s.emitter.Emit(ctx, entry); err != nil {
+		return fmt.Errorf("setup: emit user.created: %w", err)
+	}
+	return nil
+}

--- a/cells/accesscore/slices/setup/service.go
+++ b/cells/accesscore/slices/setup/service.go
@@ -2,8 +2,8 @@
 //
 // Two Public HTTP endpoints:
 //
-//	GET  /api/v1/setup/status   — returns {"hasAdmin": bool}
-//	POST /api/v1/setup/admin    — creates the first admin; 409 after initialized
+//	GET  /api/v1/access/setup/status   — returns {"hasAdmin": bool}
+//	POST /api/v1/access/setup/admin    — creates the first admin; 410 Gone after initialized
 //
 // Race-safe admin creation is delegated to cells/accesscore/internal/adminprovision
 // so the semantics match the headless initialadmin Lifecycle exactly.
@@ -14,22 +14,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
-
-// TopicUserCreated is the event topic published on fresh admin creation.
-// Same contract / topic as identitymanage emits so downstream projections
-// treat the first admin as a regular user.created fact.
-const TopicUserCreated = "event.user.created.v1"
 
 // UserIDPrefix distinguishes setup-path admins from bootstrap-path admins in
 // audit logs ("usr-" vs. "usr-bootstrap-").
@@ -92,7 +89,7 @@ func NewService(provisioner *adminprovision.Provisioner, logger *slog.Logger, op
 	return s, nil
 }
 
-// StatusOutput is the response shape for GET /api/v1/setup/status.
+// StatusOutput is the response shape for GET /api/v1/access/setup/status.
 type StatusOutput struct {
 	HasAdmin bool `json:"hasAdmin"`
 }
@@ -113,7 +110,7 @@ type CreateAdminInput struct {
 	Password string
 }
 
-// CreateAdminOutput is the response shape for POST /api/v1/setup/admin.
+// CreateAdminOutput is the response shape for POST /api/v1/access/setup/admin.
 type CreateAdminOutput struct {
 	ID        string `json:"id"`
 	Username  string `json:"username"`
@@ -135,9 +132,14 @@ type CreateAdminOutput struct {
 // Demo-mode caveat: When wired with persistence.NoopTxRunner (in-memory
 // repositories), RunInTx has no rollback, so a publishUserCreated failure
 // after a successful adminprovision.Ensure leaves the user + role persisted
-// without the event emitted. The next POST hits the fast-path 409 via
+// without the event emitted. The next POST hits the fast-path 410 via
 // CountByRole. Production must wire a real TxRunner; demo mode accepts this
 // gap as it matches the identitymanage.Create pattern (service.go:128-139).
+//
+// Security: bcrypt runs AFTER the Status fast-path so a flood of POSTs after
+// admin exists returns 410 in ~milliseconds without CPU burn. bcrypt cost=12
+// is only paid on the single winning request (plus same-process concurrent
+// race-losers before the internal mutex in adminprovision serializes them).
 func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*CreateAdminOutput, error) {
 	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
 		validation.F("username", in.Username),
@@ -150,6 +152,20 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput,
 			fmt.Sprintf("password length must be between %d and %d characters",
 				MinPasswordLen, MaxPasswordLen))
+	}
+	if strings.ContainsAny(in.Email, "\r\n\t\x00") || strings.ContainsAny(in.Username, "\r\n\t\x00") {
+		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput,
+			"username and email must not contain control characters")
+	}
+
+	// Fast-path: if admin already exists, return 410 without touching bcrypt.
+	// This keeps anonymous floods on the retired endpoint in O(1) roundtrip.
+	hasAdmin, err := s.provisioner.Status(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("setup: status: %w", err)
+	}
+	if hasAdmin {
+		return nil, setupRetiredError()
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(in.Password), domain.BcryptCost)
@@ -171,8 +187,7 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 		}
 		switch outcome {
 		case adminprovision.OutcomeAlreadyExists, adminprovision.OutcomeRaceSkipped:
-			return errcode.New(errcode.ErrSetupAlreadyInitialized,
-				"first-run admin already provisioned; use /api/v1/access/sessions/login")
+			return setupRetiredError()
 		case adminprovision.OutcomeCreated:
 			if err := s.publishUserCreated(txCtx, user); err != nil {
 				return err
@@ -202,17 +217,33 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 	return out, nil
 }
 
+// setupRetiredError is returned when the first-run admin already exists. It
+// maps to HTTP 410 Gone (see pkg/httputil) — the endpoint is not just
+// temporarily conflicting, it is permanently retired for the lifetime of this
+// deployment. Machine-readable next-action lives in details so clients do not
+// need to parse the message.
+func setupRetiredError() error {
+	return errcode.WithDetails(
+		errcode.New(errcode.ErrSetupAlreadyInitialized,
+			"first-run admin already provisioned; this endpoint is retired"),
+		map[string]any{
+			"nextAction":    "login",
+			"loginEndpoint": "/api/v1/access/sessions/login",
+		},
+	)
+}
+
 func (s *Service) publishUserCreated(ctx context.Context, user *domain.User) error {
-	payload, err := json.Marshal(map[string]any{
-		"user_id":  user.ID,
-		"username": user.Username,
+	payload, err := json.Marshal(dto.UserCreatedEvent{
+		UserID:   user.ID,
+		Username: user.Username,
 	})
 	if err != nil {
 		return fmt.Errorf("setup: marshal user.created payload: %w", err)
 	}
 	entry := outbox.Entry{
 		ID:        outbox.NewEntryID(),
-		EventType: TopicUserCreated,
+		EventType: dto.TopicUserCreated,
 		Payload:   payload,
 	}
 	if err := s.emitter.Emit(ctx, entry); err != nil {

--- a/cells/accesscore/slices/setup/service.go
+++ b/cells/accesscore/slices/setup/service.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -33,6 +34,17 @@ const TopicUserCreated = "event.user.created.v1"
 // UserIDPrefix distinguishes setup-path admins from bootstrap-path admins in
 // audit logs ("usr-" vs. "usr-bootstrap-").
 const UserIDPrefix = "usr-"
+
+// Password length bounds for the setup endpoint:
+//   - MinPasswordLen mirrors the schema's minLength:8 and is low enough to not
+//     surprise first-run operators on low-entropy test setups.
+//   - MaxPasswordLen caps bcrypt input. bcrypt itself truncates at 72 bytes,
+//     so the cap prevents unbounded CPU / memory on adversarial inputs
+//     without changing effective security (anything beyond 72 is discarded).
+const (
+	MinPasswordLen = 8
+	MaxPasswordLen = 128
+)
 
 // Option configures a Service.
 type Option func(*Service)
@@ -115,8 +127,17 @@ type CreateAdminOutput struct {
 // (either at the fast-path Status check or after a race detected inside
 // adminprovision.Ensure).
 //
-// Consistency: L2 (OutboxFact). The user write + event emit share a single
-// TxRunner scope so event publication is atomic with row persistence.
+// Consistency: L2 (OutboxFact) in durable mode. The user write + event emit
+// share a single TxRunner scope so event publication is atomic with row
+// persistence — if the emit fails, the tx rolls back and the user row is
+// removed.
+//
+// Demo-mode caveat: When wired with persistence.NoopTxRunner (in-memory
+// repositories), RunInTx has no rollback, so a publishUserCreated failure
+// after a successful adminprovision.Ensure leaves the user + role persisted
+// without the event emitted. The next POST hits the fast-path 409 via
+// CountByRole. Production must wire a real TxRunner; demo mode accepts this
+// gap as it matches the identitymanage.Create pattern (service.go:128-139).
 func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*CreateAdminOutput, error) {
 	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
 		validation.F("username", in.Username),
@@ -124,6 +145,11 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 		validation.F("password", in.Password),
 	); err != nil {
 		return nil, err
+	}
+	if len(in.Password) < MinPasswordLen || len(in.Password) > MaxPasswordLen {
+		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput,
+			fmt.Sprintf("password length must be between %d and %d characters",
+				MinPasswordLen, MaxPasswordLen))
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(in.Password), domain.BcryptCost)
@@ -156,7 +182,7 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 			// crashed prior run presumably emitted it before the credfile
 			// failure. Duplicating the event would confuse idempotent consumers
 			// that dedupe on (event_type, user_id).
-			s.logger.Info("setup: orphan user recovered; event emission skipped",
+			s.logger.Warn("setup: orphan user recovered; event emission skipped",
 				slog.String("event", "setup_orphan_recover"),
 				slog.String("user_id", user.ID))
 		default:
@@ -166,7 +192,7 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 			ID:        user.ID,
 			Username:  user.Username,
 			Email:     user.Email,
-			CreatedAt: user.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z07:00"),
+			CreatedAt: user.CreatedAt.UTC().Format(time.RFC3339Nano),
 		}
 		return nil
 	})

--- a/cells/accesscore/slices/setup/service.go
+++ b/cells/accesscore/slices/setup/service.go
@@ -141,21 +141,8 @@ type CreateAdminOutput struct {
 // is only paid on the single winning request (plus same-process concurrent
 // race-losers before the internal mutex in adminprovision serializes them).
 func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*CreateAdminOutput, error) {
-	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
-		validation.F("username", in.Username),
-		validation.F("email", in.Email),
-		validation.F("password", in.Password),
-	); err != nil {
+	if err := validateCreateAdminInput(in); err != nil {
 		return nil, err
-	}
-	if len(in.Password) < MinPasswordLen || len(in.Password) > MaxPasswordLen {
-		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput,
-			fmt.Sprintf("password length must be between %d and %d characters",
-				MinPasswordLen, MaxPasswordLen))
-	}
-	if strings.ContainsAny(in.Email, "\r\n\t\x00") || strings.ContainsAny(in.Username, "\r\n\t\x00") {
-		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput,
-			"username and email must not contain control characters")
 	}
 
 	// Fast-path: if admin already exists, return 410 without touching bcrypt.
@@ -175,33 +162,9 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 
 	var out *CreateAdminOutput
 	err = s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
-		user, outcome, perr := s.provisioner.Ensure(txCtx, adminprovision.ProvisionInput{
-			Username:     in.Username,
-			Email:        in.Email,
-			PasswordHash: hash,
-			RequireReset: false,
-			IDPrefix:     UserIDPrefix,
-		})
-		if perr != nil {
-			return fmt.Errorf("setup: ensure admin: %w", perr)
-		}
-		switch outcome {
-		case adminprovision.OutcomeAlreadyExists, adminprovision.OutcomeRaceSkipped:
-			return setupRetiredError()
-		case adminprovision.OutcomeCreated:
-			if err := s.publishUserCreated(txCtx, user); err != nil {
-				return err
-			}
-		case adminprovision.OutcomeOrphanRecovered:
-			// Deliberate: do NOT emit user.created on orphan recovery — the
-			// crashed prior run presumably emitted it before the credfile
-			// failure. Duplicating the event would confuse idempotent consumers
-			// that dedupe on (event_type, user_id).
-			s.logger.Warn("setup: orphan user recovered; event emission skipped",
-				slog.String("event", "setup_orphan_recover"),
-				slog.String("user_id", user.ID))
-		default:
-			return fmt.Errorf("setup: unexpected provision outcome %d", outcome)
+		user, err := s.provisionAndMaybeEmit(txCtx, in, hash)
+		if err != nil {
+			return err
 		}
 		out = &CreateAdminOutput{
 			ID:        user.ID,
@@ -215,6 +178,63 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 		return nil, err
 	}
 	return out, nil
+}
+
+// validateCreateAdminInput enforces blank/length/control-char rules before any
+// persistence or CPU-expensive work happens. Pulled out of CreateAdmin to keep
+// its cognitive complexity within 15 (gocognit CLAUDE.md limit).
+func validateCreateAdminInput(in CreateAdminInput) error {
+	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
+		validation.F("username", in.Username),
+		validation.F("email", in.Email),
+		validation.F("password", in.Password),
+	); err != nil {
+		return err
+	}
+	if len(in.Password) < MinPasswordLen || len(in.Password) > MaxPasswordLen {
+		return errcode.New(errcode.ErrAuthIdentityInvalidInput,
+			fmt.Sprintf("password length must be between %d and %d characters",
+				MinPasswordLen, MaxPasswordLen))
+	}
+	if strings.ContainsAny(in.Email, "\r\n\t\x00") || strings.ContainsAny(in.Username, "\r\n\t\x00") {
+		return errcode.New(errcode.ErrAuthIdentityInvalidInput,
+			"username and email must not contain control characters")
+	}
+	return nil
+}
+
+// provisionAndMaybeEmit runs adminprovision.Ensure inside the caller-provided
+// tx and emits user.created only on OutcomeCreated. Orphan recovery
+// deliberately skips the event (the crashed prior run already emitted it; a
+// duplicate would confuse idempotent consumers that dedupe on event_type+user_id).
+// Extracted from CreateAdmin to keep CreateAdmin under the cognitive-complexity
+// ceiling after adding the pre-bcrypt Status fast-path.
+func (s *Service) provisionAndMaybeEmit(ctx context.Context, in CreateAdminInput, hash []byte) (*domain.User, error) {
+	user, outcome, err := s.provisioner.Ensure(ctx, adminprovision.ProvisionInput{
+		Username:     in.Username,
+		Email:        in.Email,
+		PasswordHash: hash,
+		RequireReset: false,
+		IDPrefix:     UserIDPrefix,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("setup: ensure admin: %w", err)
+	}
+	switch outcome {
+	case adminprovision.OutcomeAlreadyExists, adminprovision.OutcomeRaceSkipped:
+		return nil, setupRetiredError()
+	case adminprovision.OutcomeCreated:
+		if err := s.publishUserCreated(ctx, user); err != nil {
+			return nil, err
+		}
+	case adminprovision.OutcomeOrphanRecovered:
+		s.logger.Warn("setup: orphan user recovered; event emission skipped",
+			slog.String("event", "setup_orphan_recover"),
+			slog.String("user_id", user.ID))
+	default:
+		return nil, fmt.Errorf("setup: unexpected provision outcome %d", outcome)
+	}
+	return user, nil
 }
 
 // setupRetiredError is returned when the first-run admin already exists. It

--- a/cells/accesscore/slices/setup/service_test.go
+++ b/cells/accesscore/slices/setup/service_test.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +18,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/setup"
@@ -102,7 +106,7 @@ func TestService_CreateAdmin_FreshSystem_Creates_EmitsEvent(t *testing.T) {
 	require.NotNil(t, out)
 	assert.Equal(t, "root", out.Username)
 	assert.Equal(t, "root@local", out.Email)
-	assert.True(t, len(out.ID) > 0 && out.ID[:4] == "usr-")
+	assert.True(t, strings.HasPrefix(out.ID, setup.UserIDPrefix))
 
 	// Verify admin role assigned
 	cnt, err := roleRepo.CountByRole(context.Background(), domain.RoleAdmin)
@@ -111,7 +115,7 @@ func TestService_CreateAdmin_FreshSystem_Creates_EmitsEvent(t *testing.T) {
 
 	// Verify event emitted
 	require.Len(t, w.entries, 1, "one user.created event expected")
-	assert.Equal(t, setup.TopicUserCreated, w.entries[0].EventType)
+	assert.Equal(t, dto.TopicUserCreated, w.entries[0].EventType)
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(w.entries[0].Payload, &payload))
 	assert.Equal(t, out.ID, payload["user_id"])
@@ -243,7 +247,8 @@ func TestService_CreateAdmin_EmitterFailure_Propagates(t *testing.T) {
 }
 
 func TestService_CreateAdmin_ProvisionerInfraError_Propagates(t *testing.T) {
-	// RoleRepo.CountByRole error — bubbles through provisioner.Status.
+	// RoleRepo.CountByRole error — bubbles through the Status fast-path (before
+	// bcrypt runs). Wrapped as "setup: status: ..." per CreateAdmin's fast-path.
 	userRepo := mem.NewUserRepository()
 	roleRepo := &countErrRoleRepo{err: errors.New("pg down")}
 	svc := newService(t, userRepo, roleRepo, nil)
@@ -254,7 +259,154 @@ func TestService_CreateAdmin_ProvisionerInfraError_Propagates(t *testing.T) {
 		Password: "SecretPass!23",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ensure admin")
+	assert.Contains(t, err.Error(), "setup: status")
+	assert.Contains(t, err.Error(), "pg down")
+}
+
+// --- New in S-5: concurrent, bcrypt-skip, rollback ------------------------
+
+// TestService_CreateAdmin_Concurrent_OnlyOneSucceeds exercises the Provisioner
+// mutex: 10 goroutines all POST distinct usernames into a fresh repo; exactly
+// one must return a CreateAdminOutput and the other nine must return
+// ErrSetupAlreadyInitialized. This is the primary verification of the
+// read-after-check atomicity fix (round-1 P0).
+func TestService_CreateAdmin_Concurrent_OnlyOneSucceeds(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	svc := newService(t, userRepo, roleRepo, &stubWriter{})
+
+	const workers = 10
+	type result struct {
+		out *setup.CreateAdminOutput
+		err error
+	}
+	results := make(chan result, workers)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	done.Add(workers)
+	for i := 0; i < workers; i++ {
+		i := i
+		go func() {
+			defer done.Done()
+			start.Wait()
+			out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+				Username: "root" + strconv.Itoa(i),
+				Email:    "root" + strconv.Itoa(i) + "@local",
+				Password: "SecretPass!23",
+			})
+			results <- result{out: out, err: err}
+		}()
+	}
+	start.Done()
+	done.Wait()
+	close(results)
+
+	successes := 0
+	retireds := 0
+	for r := range results {
+		switch {
+		case r.err == nil && r.out != nil:
+			successes++
+		case r.err != nil:
+			var ec *errcode.Error
+			if errors.As(r.err, &ec) && ec.Code == errcode.ErrSetupAlreadyInitialized {
+				retireds++
+			} else {
+				t.Fatalf("unexpected error: %v", r.err)
+			}
+		}
+	}
+	assert.Equal(t, 1, successes, "exactly one caller must create the admin")
+	assert.Equal(t, workers-1, retireds, "all other callers must see retired")
+
+	// Final authoritative count is 1.
+	cnt, err := roleRepo.CountByRole(context.Background(), domain.RoleAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+}
+
+// TestService_CreateAdmin_AlreadyExists_DoesNotHashPassword verifies that the
+// 410 fast-path short-circuits bcrypt — previous versions hashed the password
+// before checking Status, burning ~1-2s CPU per anonymous POST after admin
+// already existed (round-1 M-01).
+func TestService_CreateAdmin_AlreadyExists_DoesNotHashPassword(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	seedAdmin(t, userRepo, roleRepo)
+	svc := newService(t, userRepo, roleRepo, &stubWriter{})
+
+	start := time.Now()
+	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrSetupAlreadyInitialized, ec.Code)
+	// bcrypt at domain.BcryptCost (=12) takes ~200-2000ms on commodity hardware.
+	// 100ms is a generous ceiling — if bcrypt ran, we'd blow past this.
+	assert.Less(t, elapsed, 100*time.Millisecond,
+		"410 fast-path must not call bcrypt")
+}
+
+// TestService_CreateAdmin_OrphanRecovered_ClearsResetFlag_WhenInteractive
+// pins the RequireReset=false semantics on orphan recovery: a row seeded with
+// PasswordResetRequired=true (e.g., prior bootstrap-path run that crashed)
+// must have the flag cleared after setup-path Ensure reclaims it, otherwise
+// the operator who just chose a password would be force-reset on first login
+// (round-1 M-02).
+func TestService_CreateAdmin_OrphanRecovered_ClearsResetFlag_WhenInteractive(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	orphan, err := domain.NewUser("root", "root@local", "$2a$10$oldhash00000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	orphan.ID = "usr-bootstrap-prior"
+	orphan.MarkPasswordResetRequired()
+	require.NoError(t, userRepo.Create(context.Background(), orphan))
+
+	roleRepo := mem.NewRoleRepository()
+	svc := newService(t, userRepo, roleRepo, &stubWriter{})
+
+	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "usr-bootstrap-prior", out.ID)
+
+	refreshed, err := userRepo.GetByID(context.Background(), "usr-bootstrap-prior")
+	require.NoError(t, err)
+	assert.False(t, refreshed.PasswordResetRequired,
+		"interactive setup must clear the orphan's reset flag so operator-chosen password is immediately usable")
+}
+
+// TestService_CreateAdmin_ControlCharInField_Returns400 pins the email/username
+// control-character rejection (round-1 N-07).
+func TestService_CreateAdmin_ControlCharInField_Returns400(t *testing.T) {
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), &stubWriter{})
+	tests := []struct {
+		name string
+		in   setup.CreateAdminInput
+	}{
+		{"newline in email", setup.CreateAdminInput{Username: "root", Email: "root@local\n", Password: "SecretPass!23"}},
+		{"tab in username", setup.CreateAdminInput{Username: "ro\tot", Email: "root@local", Password: "SecretPass!23"}},
+		{"cr in email", setup.CreateAdminInput{Username: "root", Email: "root\r@local", Password: "SecretPass!23"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.CreateAdmin(context.Background(), tc.in)
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code)
+		})
+	}
 }
 
 // --- helpers --------------------------------------------------------------

--- a/cells/accesscore/slices/setup/service_test.go
+++ b/cells/accesscore/slices/setup/service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,6 +125,41 @@ func TestService_CreateAdmin_FreshSystem_Creates_EmitsEvent(t *testing.T) {
 	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(persisted.PasswordHash), []byte("SecretPass!23")))
 }
 
+func TestService_CreateAdmin_OrphanRecovered_ReturnsUser_NoEmit(t *testing.T) {
+	// Pre-seed a user row with the target username but no admin role assigned
+	// (simulates a prior run that crashed between UserRepo.Create and
+	// RoleRepo.AssignToUser). CreateAdmin must recover the orphan row, rewrite
+	// the password hash, assign the admin role, and deliberately NOT emit
+	// event.user.created.v1 — the event was presumably emitted by the crashed
+	// run.
+	userRepo := mem.NewUserRepository()
+	orphan, err := domain.NewUser("root", "root@local", "$2a$10$oldhash00000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	orphan.ID = "usr-orphan-prior"
+	require.NoError(t, userRepo.Create(context.Background(), orphan))
+
+	roleRepo := mem.NewRoleRepository()
+	w := &stubWriter{}
+	svc := newService(t, userRepo, roleRepo, w)
+
+	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "usr-orphan-prior", out.ID, "orphan row reused")
+
+	// Crucially: no event.user.created.v1 emitted on OrphanRecovered.
+	assert.Empty(t, w.entries, "orphan recovery must not emit duplicate event")
+
+	// Admin role now assigned to the orphan user.
+	cnt, err := roleRepo.CountByRole(context.Background(), domain.RoleAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+}
+
 func TestService_CreateAdmin_AlreadyExists_Returns409_NoEmit(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	roleRepo := mem.NewRoleRepository()
@@ -160,6 +196,30 @@ func TestService_CreateAdmin_BlankField_Returns400(t *testing.T) {
 			out, err := svc.CreateAdmin(context.Background(), tc.in)
 			require.Error(t, err)
 			assert.Nil(t, out)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code)
+		})
+	}
+}
+
+func TestService_CreateAdmin_PasswordLengthOutOfRange_Returns400(t *testing.T) {
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), nil)
+	tests := []struct {
+		name     string
+		password string
+	}{
+		{"too short (7 chars)", "abc1234"},
+		{"too long (129 chars)", strings.Repeat("x", 129)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+				Username: "root",
+				Email:    "root@local",
+				Password: tc.password,
+			})
+			require.Error(t, err)
 			var ec *errcode.Error
 			require.ErrorAs(t, err, &ec)
 			assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code)

--- a/cells/accesscore/slices/setup/service_test.go
+++ b/cells/accesscore/slices/setup/service_test.go
@@ -1,0 +1,235 @@
+package setup_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/setup"
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+type stubWriter struct {
+	entries []outbox.Entry
+	err     error
+}
+
+func (s *stubWriter) Write(_ context.Context, e outbox.Entry) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.entries = append(s.entries, e)
+	return nil
+}
+
+func newService(t *testing.T, userRepo ports.UserRepository, roleRepo ports.RoleRepository, w *stubWriter) *setup.Service {
+	t.Helper()
+	prov, err := adminprovision.NewProvisioner(userRepo, roleRepo, discardLogger(), func() string { return "fixed-uuid" })
+	require.NoError(t, err)
+	opts := []setup.Option{}
+	if w != nil {
+		opts = append(opts, setup.WithEmitter(testoutbox.MustEmitter(t, w)))
+	}
+	svc, err := setup.NewService(prov, discardLogger(), opts...)
+	require.NoError(t, err)
+	return svc
+}
+
+// --- NewService validation ------------------------------------------------
+
+func TestNewService_NilProvisioner_Error(t *testing.T) {
+	_, err := setup.NewService(nil, discardLogger())
+	require.Error(t, err)
+}
+
+func TestNewService_NilLogger_Error(t *testing.T) {
+	prov, _ := adminprovision.NewProvisioner(mem.NewUserRepository(), mem.NewRoleRepository(), discardLogger(), func() string { return "x" })
+	_, err := setup.NewService(prov, nil)
+	require.Error(t, err)
+}
+
+// --- Status ---------------------------------------------------------------
+
+func TestService_Status_NoAdmin_ReturnsFalse(t *testing.T) {
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), nil)
+	out, err := svc.Status(context.Background())
+	require.NoError(t, err)
+	assert.False(t, out.HasAdmin)
+}
+
+func TestService_Status_WithAdmin_ReturnsTrue(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	seedAdmin(t, userRepo, roleRepo)
+
+	svc := newService(t, userRepo, roleRepo, nil)
+	out, err := svc.Status(context.Background())
+	require.NoError(t, err)
+	assert.True(t, out.HasAdmin)
+}
+
+// --- CreateAdmin ----------------------------------------------------------
+
+func TestService_CreateAdmin_FreshSystem_Creates_EmitsEvent(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	w := &stubWriter{}
+	svc := newService(t, userRepo, roleRepo, w)
+
+	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "root", out.Username)
+	assert.Equal(t, "root@local", out.Email)
+	assert.True(t, len(out.ID) > 0 && out.ID[:4] == "usr-")
+
+	// Verify admin role assigned
+	cnt, err := roleRepo.CountByRole(context.Background(), domain.RoleAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+
+	// Verify event emitted
+	require.Len(t, w.entries, 1, "one user.created event expected")
+	assert.Equal(t, setup.TopicUserCreated, w.entries[0].EventType)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(w.entries[0].Payload, &payload))
+	assert.Equal(t, out.ID, payload["user_id"])
+	assert.Equal(t, "root", payload["username"])
+
+	// Verify persisted user does NOT have PasswordResetRequired
+	persisted, err := userRepo.GetByID(context.Background(), out.ID)
+	require.NoError(t, err)
+	assert.False(t, persisted.PasswordResetRequired, "setup path creates with operator-chosen password")
+	// Verify password was hashed with bcrypt
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(persisted.PasswordHash), []byte("SecretPass!23")))
+}
+
+func TestService_CreateAdmin_AlreadyExists_Returns409_NoEmit(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	seedAdmin(t, userRepo, roleRepo)
+
+	w := &stubWriter{}
+	svc := newService(t, userRepo, roleRepo, w)
+
+	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	require.Error(t, err)
+	assert.Nil(t, out)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrSetupAlreadyInitialized, ec.Code)
+	assert.Empty(t, w.entries, "no event on 409 path")
+}
+
+func TestService_CreateAdmin_BlankField_Returns400(t *testing.T) {
+	svc := newService(t, mem.NewUserRepository(), mem.NewRoleRepository(), nil)
+	tests := []struct {
+		name string
+		in   setup.CreateAdminInput
+	}{
+		{"blank username", setup.CreateAdminInput{Username: "", Email: "e@x", Password: "p"}},
+		{"blank email", setup.CreateAdminInput{Username: "u", Email: "", Password: "p"}},
+		{"blank password", setup.CreateAdminInput{Username: "u", Email: "e@x", Password: ""}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := svc.CreateAdmin(context.Background(), tc.in)
+			require.Error(t, err)
+			assert.Nil(t, out)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code)
+		})
+	}
+}
+
+func TestService_CreateAdmin_EmitterFailure_Propagates(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	roleRepo := mem.NewRoleRepository()
+	w := &stubWriter{err: errors.New("broker down")}
+	svc := newService(t, userRepo, roleRepo, w)
+
+	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "emit user.created")
+}
+
+func TestService_CreateAdmin_ProvisionerInfraError_Propagates(t *testing.T) {
+	// RoleRepo.CountByRole error — bubbles through provisioner.Status.
+	userRepo := mem.NewUserRepository()
+	roleRepo := &countErrRoleRepo{err: errors.New("pg down")}
+	svc := newService(t, userRepo, roleRepo, nil)
+
+	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		Username: "root",
+		Email:    "root@local",
+		Password: "SecretPass!23",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ensure admin")
+}
+
+// --- helpers --------------------------------------------------------------
+
+func seedAdmin(t *testing.T, userRepo ports.UserRepository, roleRepo ports.RoleRepository) {
+	t.Helper()
+	u, err := domain.NewUser("existing", "existing@local", "$2a$10$stubhashXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+	require.NoError(t, err)
+	u.ID = "usr-seed"
+	require.NoError(t, userRepo.Create(context.Background(), u))
+	require.NoError(t, roleRepo.Create(context.Background(), &domain.Role{ID: domain.RoleAdmin, Name: domain.RoleAdmin}))
+	_, err = roleRepo.AssignToUser(context.Background(), u.ID, domain.RoleAdmin)
+	require.NoError(t, err)
+}
+
+// countErrRoleRepo wraps a mem role repo but errors on CountByRole.
+type countErrRoleRepo struct {
+	err error
+}
+
+func (r *countErrRoleRepo) Create(_ context.Context, _ *domain.Role) error { return nil }
+func (r *countErrRoleRepo) AssignToUser(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+func (r *countErrRoleRepo) CountByRole(_ context.Context, _ string) (int, error) { return 0, r.err }
+func (r *countErrRoleRepo) GetByUserID(_ context.Context, _ string) ([]*domain.Role, error) {
+	return nil, nil
+}
+func (r *countErrRoleRepo) RemoveFromUser(_ context.Context, _, _ string) error { return nil }
+func (r *countErrRoleRepo) RemoveFromUserIfNotLast(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+func (r *countErrRoleRepo) GetByID(_ context.Context, _ string) (*domain.Role, error) {
+	return nil, nil
+}
+func (r *countErrRoleRepo) ListByUserID(_ context.Context, _ string, _ query.ListParams) ([]*domain.Role, error) {
+	return nil, nil
+}

--- a/cells/accesscore/slices/setup/slice.yaml
+++ b/cells/accesscore/slices/setup/slice.yaml
@@ -1,0 +1,19 @@
+id: setup
+belongsToCell: accesscore
+contractUsages:
+  - contract: http.auth.setup.status.v1
+    role: serve
+  - contract: http.auth.setup.admin.v1
+    role: serve
+  - contract: event.user.created.v1
+    role: publish
+verify:
+  unit:
+    - unit.setup.service
+  contract:
+    - contract.http.auth.setup.status.v1.serve
+    - contract.http.auth.setup.admin.v1.serve
+    - contract.event.user.created.v1.publish
+
+allowedFiles:
+  - cells/accesscore/slices/setup/**

--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	accesscore "github.com/ghbvf/gocell/cells/accesscore"
 	"github.com/ghbvf/gocell/cells/accesscore/initialadmin"
@@ -11,17 +12,40 @@ import (
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 )
 
-// AccessCoreModule wires accesscore: JWT issuer/verifier + EventBus +
-// initial-admin bootstrap worker + cursor codec.
-// It reads accesscore-namespaced environment variables directly.
+// AdminProvisionModeEnv selects how the first admin is provisioned.
+//
+//	"interactive" (default) — no admin created at startup; operator must POST
+//	                          to /api/v1/access/setup/admin to create one.
+//	                          setup GET returns {"hasAdmin":false} until done.
+//	"bootstrap"             — initialadmin Lifecycle runs at startup, generates
+//	                          a random password, writes it to the credential
+//	                          file for out-of-band retrieval. setup POST is
+//	                          effectively 410 for the lifetime of the deployment.
+//
+// Two modes are mutually exclusive by construction: "bootstrap" enables the
+// Lifecycle that creates the admin; "interactive" leaves the provisioning job
+// to the HTTP endpoint. This removes the "double-owner" ambiguity where both
+// were wired simultaneously and whichever raced first won.
+const AdminProvisionModeEnv = "GOCELL_ACCESSCORE_ADMIN_PROVISION_MODE"
+
+// AccessCoreModule wires accesscore: JWT issuer/verifier + EventBus + cursor
+// codec, and conditionally the initial-admin bootstrap Lifecycle when the
+// GOCELL_ACCESSCORE_ADMIN_PROVISION_MODE environment variable selects it.
 //
 // ref: uber-go/fx fx.Module("accesscore", ...) — self-contained module.
 // backlog: S29 CORE-BUNDLE-APP-BUILDER-01
 type AccessCoreModule struct {
-	// InitialAdminOpts are additional options for the initial-admin bootstrap
-	// path. Production leaves this nil so default bcrypt cost=12 is used.
-	// Tests inject a low-cost hasher to avoid blocking CI.
+	// InitialAdminOpts are additional options passed to the initial-admin
+	// bootstrap Lifecycle when GOCELL_ACCESSCORE_ADMIN_PROVISION_MODE=bootstrap.
+	// Production leaves this nil so default bcrypt cost=12 is used; tests
+	// inject a low-cost hasher to avoid blocking CI.
 	InitialAdminOpts []initialadmin.LifecycleOption
+
+	// ForceBootstrap, when true, enables the initial-admin Lifecycle regardless
+	// of the environment variable. Used by integration tests that want to
+	// exercise the bootstrap path without setting the env var in the test
+	// process. Production code must not set this; go through the env var.
+	ForceBootstrap bool
 }
 
 // ID returns the stable identifier used in error messages.
@@ -55,7 +79,9 @@ func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.C
 		accesscore.WithJWTIssuer(shared.JWTDeps.issuer),
 		accesscore.WithJWTVerifier(shared.JWTDeps.verifier),
 		accesscore.WithCursorCodec(cursorCodec),
-		accesscore.WithInitialAdminBootstrap(m.InitialAdminOpts...),
+	}
+	if m.ForceBootstrap || os.Getenv(AdminProvisionModeEnv) == "bootstrap" {
+		accessOpts = append(accessOpts, accesscore.WithInitialAdminBootstrap(m.InitialAdminOpts...))
 	}
 	c := accesscore.NewAccessCore(accessOpts...)
 	// Bootstrap phase3b auto-discovers c.LifecycleHooks() — no WithWorkers needed.

--- a/cmd/corebundle/buildapp_env_integration_test.go
+++ b/cmd/corebundle/buildapp_env_integration_test.go
@@ -92,7 +92,7 @@ func TestBuildApp_Postgres_UsesConfigCoreDatabaseURL(t *testing.T) {
 
 	cells, cellOpts, err := BuildApp(ctx, shared,
 		ConfigCoreModule{},
-		AccessCoreModule{InitialAdminOpts: fastAdminBootstrapOpts()},
+		AccessCoreModule{ForceBootstrap: true, InitialAdminOpts: fastAdminBootstrapOpts()},
 		AuditCoreModule{},
 	)
 	require.NoError(t, err, "BuildApp must succeed: env→pool wiring must complete without error")

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -170,7 +170,7 @@ func buildBootstrapFromShared(t *testing.T, shared *SharedDeps, extra ...bootstr
 
 	cells, cellOpts, err := BuildApp(ctx, shared,
 		ConfigCoreModule{},
-		AccessCoreModule{InitialAdminOpts: fastAdminBootstrapOpts()},
+		AccessCoreModule{ForceBootstrap: true, InitialAdminOpts: fastAdminBootstrapOpts()},
 		AuditCoreModule{},
 	)
 	if err != nil {

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -174,7 +174,10 @@ func TestIntegration_AdminExists_OrphanSwept(t *testing.T) {
 	_, err := os.Stat(credPath)
 	require.NoError(t, err, "orphan credential file must exist before bootstrap")
 
-	// Configure env for run().
+	// Configure env for run(). Interactive mode is the default in S-2; this
+	// P1-16 test exercises the initialadmin Lifecycle's sweep path, so opt
+	// explicitly into bootstrap mode.
+	t.Setenv(AdminProvisionModeEnv, "bootstrap")
 	t.Setenv("GOCELL_STATE_DIR", stateDir)
 	t.Setenv("GOCELL_JWT_ISSUER", "gocell-sweep-test")
 	t.Setenv("GOCELL_JWT_AUDIENCE", "gocell")

--- a/cmd/corebundle/main_test.go
+++ b/cmd/corebundle/main_test.go
@@ -83,8 +83,12 @@ func TestLoadKeySet_UnknownMode_StillGeneratesEphemeral(t *testing.T) {
 func TestRun_DevMode_StartsAndCancels(t *testing.T) {
 	// run() with an immediately-cancelled context exercises the full assembly
 	// path (cells, bootstrap) without needing a real HTTP listener.
-	// Set GOCELL_STATE_DIR to a writable temp dir so WithInitialAdminBootstrap
-	// can write the credential file (default /run/gocell is not writable in CI).
+	// Default provision mode is "interactive" (no admin at startup). Opt into
+	// bootstrap mode to exercise the Lifecycle + credfile wiring that the
+	// original test was designed around.
+	t.Setenv(AdminProvisionModeEnv, "bootstrap")
+	// STATE_DIR is needed in bootstrap mode (default /run/gocell is not
+	// writable in CI).
 	t.Setenv("GOCELL_STATE_DIR", t.TempDir())
 	// GOCELL_JWT_ISSUER and GOCELL_JWT_AUDIENCE are required in all modes (C5).
 	t.Setenv("GOCELL_JWT_ISSUER", "gocell-dev-test")
@@ -349,8 +353,8 @@ func TestBootstrap_DemoModeUsesInMemory(t *testing.T) {
 	// Ensure GOCELL_CELL_ADAPTER_MODE is unset (selects in-memory path).
 	// GOCELL_CONFIGCORE_DATABASE_URL is not read in memory mode — no DSN required.
 	t.Setenv("GOCELL_CELL_ADAPTER_MODE", "")
-	// Set GOCELL_STATE_DIR to a writable temp dir so WithInitialAdminBootstrap
-	// can write the credential file (default /run/gocell is not writable in CI).
+	// Opt into bootstrap mode to match the original test's startup path.
+	t.Setenv(AdminProvisionModeEnv, "bootstrap")
 	t.Setenv("GOCELL_STATE_DIR", t.TempDir())
 	// GOCELL_JWT_ISSUER and GOCELL_JWT_AUDIENCE required in all modes (C5).
 	t.Setenv("GOCELL_JWT_ISSUER", "gocell-dev-test")

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	accesscore "github.com/ghbvf/gocell/cells/accesscore"
+	auditcore "github.com/ghbvf/gocell/cells/auditcore"
+	configcore "github.com/ghbvf/gocell/cells/configcore"
+	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/bootstrap"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+)
+
+// setupHTTPClient uses a longer timeout than the shared testHTTPClient because
+// bcrypt at domain.BcryptCost=12 takes ~1-2s per password hash, which exceeds
+// the 2s client-default when the CPU is contended by parallel test packages.
+var setupHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// TestSetupEndpoints_FirstRunFlow boots a real assembly (accesscore+configcore+auditcore)
+// and walks the interactive first-run admin flow end-to-end:
+//
+//  1. GET /api/v1/setup/status            → {hasAdmin:false}  (no JWT required)
+//  2. POST /api/v1/setup/admin            → 201 + user body
+//  3. POST /api/v1/setup/admin (again)    → 409 ERR_SETUP_ALREADY_INITIALIZED
+//  4. GET /api/v1/setup/status            → {hasAdmin:true}
+//  5. POST /api/v1/access/sessions/login  → 201 with access/refresh tokens
+//
+// Step 5 proves the setup-created admin can actually authenticate — i.e. the
+// password was hashed and persisted correctly by bcrypt round-trip.
+func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	privKey, pubKey := auth.MustGenerateTestKeyPair()
+	keySet, err := auth.NewKeySet(privKey, pubKey)
+	require.NoError(t, err)
+	jwtIssuer, err := auth.NewJWTIssuer(keySet, "test", 15*time.Minute,
+		auth.WithIssuerAudiencesFromSlice([]string{"gocell"}))
+	require.NoError(t, err)
+	jwtVerifier, err := auth.NewJWTVerifier(keySet, auth.WithExpectedAudiences("gocell"))
+	require.NoError(t, err)
+
+	eb := eventbus.New()
+	var nw outbox.Writer = outbox.NoopWriter{}
+
+	auditCursorCodec, err := query.NewCursorCodec([]byte("test-audit-cursor-key-32-bytes!!"))
+	require.NoError(t, err)
+	configCursorCodec, err := query.NewCursorCodec([]byte("test-config-cursor-key-32bytes!!"))
+	require.NoError(t, err)
+
+	ac := accesscore.NewAccessCore(
+		accesscore.WithInMemoryDefaults(),
+		accesscore.WithPublisher(eb),
+		accesscore.WithJWTIssuer(jwtIssuer),
+		accesscore.WithJWTVerifier(jwtVerifier),
+		accesscore.WithOutboxWriter(nw),
+		accesscore.WithTxManager(noopTxRunner{}),
+	)
+	cc := configcore.NewConfigCore(
+		configcore.WithInMemoryDefaults(),
+		configcore.WithPublisher(eb),
+		configcore.WithOutboxWriter(nw),
+		configcore.WithTxManager(noopTxRunner{}),
+		configcore.WithCursorCodec(configCursorCodec),
+	)
+	auc := auditcore.NewAuditCore(
+		auditcore.WithInMemoryDefaults(),
+		auditcore.WithPublisher(eb),
+		auditcore.WithHMACKey([]byte("test-hmac-key-32-bytes-long!!!!")),
+		auditcore.WithOutboxWriter(nw),
+		auditcore.WithTxManager(noopTxRunner{}),
+		auditcore.WithCursorCodec(auditCursorCodec),
+	)
+
+	asm := assembly.New(assembly.Config{ID: "setup-test", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(ac))
+	require.NoError(t, asm.Register(cc))
+	require.NoError(t, asm.Register(auc))
+
+	app := bootstrap.New(
+		bootstrap.WithAssembly(asm),
+		bootstrap.WithPrimaryListener(ln),
+		bootstrap.WithInternalListener(newCorebundleLocalListener(t)),
+		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
+		bootstrap.WithShutdownTimeout(2*time.Second),
+		bootstrap.WithAuthDiscovery(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- app.Run(ctx) }()
+	defer func() {
+		cancel()
+		select {
+		case runErr := <-done:
+			assert.NoError(t, runErr)
+		case <-time.After(5 * time.Second):
+			t.Fatal("bootstrap did not shut down in time")
+		}
+	}()
+
+	addr := ln.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, err := setupHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond, "HTTP server did not become ready")
+
+	base := "http://" + addr
+
+	// 1. Fresh system: hasAdmin=false (endpoint is Public — no Authorization header).
+	t.Run("status_before_returns_false", func(t *testing.T) {
+		resp, err := setupHTTPClient.Get(base + "/api/v1/setup/status")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "setup/status must be Public (not 401)")
+		var body struct {
+			Data struct {
+				HasAdmin bool `json:"hasAdmin"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.False(t, body.Data.HasAdmin)
+	})
+
+	// 2. Create first admin.
+	password := "SecretPass!23"
+	t.Run("create_admin_returns_201", func(t *testing.T) {
+		payload := `{"username":"root","email":"root@local","password":"` + password + `"}`
+		resp, err := setupHTTPClient.Post(base+"/api/v1/setup/admin", "application/json", strings.NewReader(payload))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusCreated, resp.StatusCode, "first setup/admin POST must return 201")
+		var body struct {
+			Data struct {
+				ID       string `json:"id"`
+				Username string `json:"username"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.Equal(t, "root", body.Data.Username)
+		assert.Contains(t, body.Data.ID, "usr-")
+	})
+
+	// 3. Second POST must 409.
+	t.Run("second_create_returns_409", func(t *testing.T) {
+		payload := `{"username":"root2","email":"other@local","password":"AnotherPass!99"}`
+		resp, err := setupHTTPClient.Post(base+"/api/v1/setup/admin", "application/json", strings.NewReader(payload))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusConflict, resp.StatusCode)
+		raw, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), "ERR_SETUP_ALREADY_INITIALIZED")
+	})
+
+	// 4. Status now reports hasAdmin=true.
+	t.Run("status_after_returns_true", func(t *testing.T) {
+		resp, err := setupHTTPClient.Get(base + "/api/v1/setup/status")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		var body struct {
+			Data struct {
+				HasAdmin bool `json:"hasAdmin"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.True(t, body.Data.HasAdmin)
+	})
+
+	// 5. Created admin can login with the password they chose — confirms bcrypt
+	//    round-trip and role assignment both succeeded.
+	t.Run("created_admin_can_login", func(t *testing.T) {
+		payload := `{"username":"root","password":"` + password + `"}`
+		resp, err := setupHTTPClient.Post(base+"/api/v1/access/sessions/login",
+			"application/json", strings.NewReader(payload))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusCreated, resp.StatusCode, "setup-created admin must be able to login")
+		var body struct {
+			Data struct {
+				AccessToken  string `json:"accessToken"`
+				RefreshToken string `json:"refreshToken"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.NotEmpty(t, body.Data.AccessToken)
+		assert.NotEmpty(t, body.Data.RefreshToken)
+	})
+}

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -34,10 +34,10 @@ var setupHTTPClient = &http.Client{Timeout: 10 * time.Second}
 // TestSetupEndpoints_FirstRunFlow boots a real assembly (accesscore+configcore+auditcore)
 // and walks the interactive first-run admin flow end-to-end:
 //
-//  1. GET /api/v1/setup/status            → {hasAdmin:false}  (no JWT required)
-//  2. POST /api/v1/setup/admin            → 201 + user body
-//  3. POST /api/v1/setup/admin (again)    → 409 ERR_SETUP_ALREADY_INITIALIZED
-//  4. GET /api/v1/setup/status            → {hasAdmin:true}
+//  1. GET /api/v1/access/setup/status            → {hasAdmin:false}  (no JWT required)
+//  2. POST /api/v1/access/setup/admin            → 201 + user body
+//  3. POST /api/v1/access/setup/admin (again)    → 410 ERR_SETUP_ALREADY_INITIALIZED
+//  4. GET /api/v1/access/setup/status            → {hasAdmin:true}
 //  5. POST /api/v1/access/sessions/login  → 201 with access/refresh tokens
 //
 // Step 5 proves the setup-created admin can actually authenticate — i.e. the
@@ -128,7 +128,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 
 	// 1. Fresh system: hasAdmin=false (endpoint is Public — no Authorization header).
 	t.Run("status_before_returns_false", func(t *testing.T) {
-		resp, err := setupHTTPClient.Get(base + "/api/v1/setup/status")
+		resp, err := setupHTTPClient.Get(base + "/api/v1/access/setup/status")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode, "setup/status must be Public (not 401)")
@@ -145,7 +145,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 	password := "SecretPass!23"
 	t.Run("create_admin_returns_201", func(t *testing.T) {
 		payload := `{"username":"root","email":"root@local","password":"` + password + `"}`
-		resp, err := setupHTTPClient.Post(base+"/api/v1/setup/admin", "application/json", strings.NewReader(payload))
+		resp, err := setupHTTPClient.Post(base+"/api/v1/access/setup/admin", "application/json", strings.NewReader(payload))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusCreated, resp.StatusCode, "first setup/admin POST must return 201")
@@ -160,21 +160,22 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 		assert.Contains(t, body.Data.ID, "usr-")
 	})
 
-	// 3. Second POST must 409.
-	t.Run("second_create_returns_409", func(t *testing.T) {
+	// 3. Second POST must 410 Gone (one-shot lifecycle).
+	t.Run("second_create_returns_410", func(t *testing.T) {
 		payload := `{"username":"root2","email":"other@local","password":"AnotherPass!99"}`
-		resp, err := setupHTTPClient.Post(base+"/api/v1/setup/admin", "application/json", strings.NewReader(payload))
+		resp, err := setupHTTPClient.Post(base+"/api/v1/access/setup/admin", "application/json", strings.NewReader(payload))
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusConflict, resp.StatusCode)
+		assert.Equal(t, http.StatusGone, resp.StatusCode)
 		raw, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Contains(t, string(raw), "ERR_SETUP_ALREADY_INITIALIZED")
+		assert.Contains(t, string(raw), `"nextAction":"login"`)
 	})
 
 	// 4. Status now reports hasAdmin=true.
 	t.Run("status_after_returns_true", func(t *testing.T) {
-		resp, err := setupHTTPClient.Get(base + "/api/v1/setup/status")
+		resp, err := setupHTTPClient.Get(base + "/api/v1/access/setup/status")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		var body struct {

--- a/cmd/corebundle/vault_readiness_wiring_test.go
+++ b/cmd/corebundle/vault_readiness_wiring_test.go
@@ -82,7 +82,7 @@ func buildBootstrapWithFakeKeyProvider(t *testing.T, shared *SharedDeps, kp kcry
 
 	cells, cellOpts, err := BuildApp(ctx, shared,
 		ConfigCoreModule{KeyProviderOverride: kp},
-		AccessCoreModule{InitialAdminOpts: fastAdminBootstrapOpts()},
+		AccessCoreModule{ForceBootstrap: true, InitialAdminOpts: fastAdminBootstrapOpts()},
 		AuditCoreModule{},
 	)
 	if err != nil {

--- a/contracts/http/auth/setup/admin/v1/contract.yaml
+++ b/contracts/http/auth/setup/admin/v1/contract.yaml
@@ -9,15 +9,15 @@ endpoints:
     - edge-bff
   http:
     method: POST
-    path: /api/v1/setup/admin
+    path: /api/v1/access/setup/admin
     successStatus: 201
     noContent: false
     responses:
       400:
         description: "Bad request — missing or blank required fields"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
-      409:
-        description: "Conflict — first-run admin already provisioned; use /api/v1/access/sessions/login"
+      410:
+        description: "Gone — first-run admin already provisioned; endpoint retired for this deployment. Response details include nextAction=login and loginEndpoint."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
 schemaRefs:
   request: request.schema.json

--- a/contracts/http/auth/setup/admin/v1/contract.yaml
+++ b/contracts/http/auth/setup/admin/v1/contract.yaml
@@ -1,0 +1,24 @@
+id: http.auth.setup.admin.v1
+kind: http
+ownerCell: accesscore
+consistencyLevel: L2
+lifecycle: active
+endpoints:
+  server: accesscore
+  clients:
+    - edge-bff
+  http:
+    method: POST
+    path: /api/v1/setup/admin
+    successStatus: 201
+    noContent: false
+    responses:
+      400:
+        description: "Bad request — missing or blank required fields"
+        schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
+      409:
+        description: "Conflict — first-run admin already provisioned; use /api/v1/access/sessions/login"
+        schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
+schemaRefs:
+  request: request.schema.json
+  response: response.schema.json

--- a/contracts/http/auth/setup/admin/v1/request.schema.json
+++ b/contracts/http/auth/setup/admin/v1/request.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.setup.admin.v1.request",
+  "type": "object",
+  "properties": {
+    "username": { "type": "string", "minLength": 1 },
+    "email": { "type": "string", "minLength": 1 },
+    "password": { "type": "string", "minLength": 1 }
+  },
+  "required": ["username", "email", "password"],
+  "additionalProperties": false
+}

--- a/contracts/http/auth/setup/admin/v1/request.schema.json
+++ b/contracts/http/auth/setup/admin/v1/request.schema.json
@@ -3,9 +3,9 @@
   "title": "http.auth.setup.admin.v1.request",
   "type": "object",
   "properties": {
-    "username": { "type": "string", "minLength": 1 },
-    "email": { "type": "string", "minLength": 1 },
-    "password": { "type": "string", "minLength": 1 }
+    "username": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "email": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "password": { "type": "string", "minLength": 8, "maxLength": 128 }
   },
   "required": ["username", "email", "password"],
   "additionalProperties": false

--- a/contracts/http/auth/setup/admin/v1/response.schema.json
+++ b/contracts/http/auth/setup/admin/v1/response.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.setup.admin.v1.response",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "username": { "type": "string" },
+        "email": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "username", "email", "createdAt"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["data"],
+  "additionalProperties": false
+}

--- a/contracts/http/auth/setup/status/v1/contract.yaml
+++ b/contracts/http/auth/setup/status/v1/contract.yaml
@@ -9,7 +9,7 @@ endpoints:
     - edge-bff
   http:
     method: GET
-    path: /api/v1/setup/status
+    path: /api/v1/access/setup/status
     successStatus: 200
     noContent: false
 schemaRefs:

--- a/contracts/http/auth/setup/status/v1/contract.yaml
+++ b/contracts/http/auth/setup/status/v1/contract.yaml
@@ -1,0 +1,16 @@
+id: http.auth.setup.status.v1
+kind: http
+ownerCell: accesscore
+consistencyLevel: L0
+lifecycle: active
+endpoints:
+  server: accesscore
+  clients:
+    - edge-bff
+  http:
+    method: GET
+    path: /api/v1/setup/status
+    successStatus: 200
+    noContent: false
+schemaRefs:
+  response: response.schema.json

--- a/contracts/http/auth/setup/status/v1/response.schema.json
+++ b/contracts/http/auth/setup/status/v1/response.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "http.auth.setup.status.v1.response",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "hasAdmin": { "type": "boolean" }
+      },
+      "required": ["hasAdmin"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["data"],
+  "additionalProperties": false
+}

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -100,9 +100,11 @@ const (
 	// DELETE /api/v1/access/sessions/{id}) bypass this check.
 	ErrAuthPasswordResetRequired Code = "ERR_AUTH_PASSWORD_RESET_REQUIRED"
 	// ErrSetupAlreadyInitialized signals that the interactive first-run admin
-	// endpoint (POST /api/v1/setup/admin) was invoked after the system already
-	// has at least one admin. The caller should authenticate via
-	// /api/v1/access/sessions/login instead. Maps to HTTP 409.
+	// endpoint (POST /api/v1/access/setup/admin) was invoked after the system
+	// already has at least one admin. The caller should authenticate via
+	// /api/v1/access/sessions/login instead. Maps to HTTP 410 Gone: the endpoint
+	// is permanently retired for the lifetime of the deployment (one-shot
+	// lifecycle), not just temporarily conflicting.
 	ErrSetupAlreadyInitialized Code = "ERR_SETUP_ALREADY_INITIALIZED"
 
 	// Config-core cell error codes.

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -99,6 +99,11 @@ const (
 	// Only the exempt endpoints (POST /api/v1/access/users/{id}/password and
 	// DELETE /api/v1/access/sessions/{id}) bypass this check.
 	ErrAuthPasswordResetRequired Code = "ERR_AUTH_PASSWORD_RESET_REQUIRED"
+	// ErrSetupAlreadyInitialized signals that the interactive first-run admin
+	// endpoint (POST /api/v1/setup/admin) was invoked after the system already
+	// has at least one admin. The caller should authenticate via
+	// /api/v1/access/sessions/login instead. Maps to HTTP 409.
+	ErrSetupAlreadyInitialized Code = "ERR_SETUP_ALREADY_INITIALIZED"
 
 	// Config-core cell error codes.
 	ErrConfigNotFound            Code = "ERR_CONFIG_NOT_FOUND"

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -292,12 +292,13 @@ var codeToStatus = map[errcode.Code]int{
 	errcode.ErrAuthPasswordResetRequired: http.StatusForbidden,
 
 	// --- 409 Conflict ---
-	errcode.ErrAuthUserDuplicate:   http.StatusConflict,
-	errcode.ErrAuthSelfDelete:      http.StatusConflict,
-	errcode.ErrAuthRoleDuplicate:   http.StatusConflict,
-	errcode.ErrConfigDuplicate:     http.StatusConflict,
-	errcode.ErrConfigRepoDuplicate: http.StatusConflict,
-	errcode.ErrFlagDuplicate:       http.StatusConflict,
+	errcode.ErrAuthUserDuplicate:       http.StatusConflict,
+	errcode.ErrAuthSelfDelete:          http.StatusConflict,
+	errcode.ErrAuthRoleDuplicate:       http.StatusConflict,
+	errcode.ErrConfigDuplicate:         http.StatusConflict,
+	errcode.ErrConfigRepoDuplicate:     http.StatusConflict,
+	errcode.ErrFlagDuplicate:           http.StatusConflict,
+	errcode.ErrSetupAlreadyInitialized: http.StatusConflict,
 
 	// --- 429 Too Many Requests ---
 	errcode.ErrRateLimited: http.StatusTooManyRequests,

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -292,13 +292,20 @@ var codeToStatus = map[errcode.Code]int{
 	errcode.ErrAuthPasswordResetRequired: http.StatusForbidden,
 
 	// --- 409 Conflict ---
-	errcode.ErrAuthUserDuplicate:       http.StatusConflict,
-	errcode.ErrAuthSelfDelete:          http.StatusConflict,
-	errcode.ErrAuthRoleDuplicate:       http.StatusConflict,
-	errcode.ErrConfigDuplicate:         http.StatusConflict,
-	errcode.ErrConfigRepoDuplicate:     http.StatusConflict,
-	errcode.ErrFlagDuplicate:           http.StatusConflict,
-	errcode.ErrSetupAlreadyInitialized: http.StatusConflict,
+	errcode.ErrAuthUserDuplicate:   http.StatusConflict,
+	errcode.ErrAuthSelfDelete:      http.StatusConflict,
+	errcode.ErrAuthRoleDuplicate:   http.StatusConflict,
+	errcode.ErrConfigDuplicate:     http.StatusConflict,
+	errcode.ErrConfigRepoDuplicate: http.StatusConflict,
+	errcode.ErrFlagDuplicate:       http.StatusConflict,
+
+	// --- 410 Gone ---
+	// Setup is a one-shot lifecycle endpoint: once the first admin exists, the
+	// endpoint is permanently retired for the lifetime of this deployment.
+	// 410 signals "permanently unavailable" (vs. 409's "retry may succeed"),
+	// shrinks the anonymous attack surface, and lets installer UIs distinguish
+	// "not initialized yet" from "already past initialization window".
+	errcode.ErrSetupAlreadyInitialized: http.StatusGone,
 
 	// --- 429 Too Many Requests ---
 	errcode.ErrRateLimited: http.StatusTooManyRequests,

--- a/pkg/httputil/response_test.go
+++ b/pkg/httputil/response_test.go
@@ -97,7 +97,9 @@ func TestMapCodeToStatus_ExplicitMapping(t *testing.T) {
 		{errcode.ErrConfigDuplicate, http.StatusConflict},
 		{errcode.ErrConfigRepoDuplicate, http.StatusConflict},
 		{errcode.ErrFlagDuplicate, http.StatusConflict},
-		{errcode.ErrSetupAlreadyInitialized, http.StatusConflict},
+
+		// One-shot lifecycle retired -> 410
+		{errcode.ErrSetupAlreadyInitialized, http.StatusGone},
 
 		// Verify/kernel codes
 		{errcode.ErrCheckRefInvalid, http.StatusBadRequest},

--- a/pkg/httputil/response_test.go
+++ b/pkg/httputil/response_test.go
@@ -97,6 +97,7 @@ func TestMapCodeToStatus_ExplicitMapping(t *testing.T) {
 		{errcode.ErrConfigDuplicate, http.StatusConflict},
 		{errcode.ErrConfigRepoDuplicate, http.StatusConflict},
 		{errcode.ErrFlagDuplicate, http.StatusConflict},
+		{errcode.ErrSetupAlreadyInitialized, http.StatusConflict},
 
 		// Verify/kernel codes
 		{errcode.ErrCheckRefInvalid, http.StatusBadRequest},


### PR DESCRIPTION
## Summary

Adds the interactive first-run admin HTTP surface (PR-A26 AUTH-SETUP-ENDPOINT, v1.0 P0) and extracts admin-provisioning as a shared internal domain service so both the headless `initialadmin` Lifecycle and the new HTTP `setup` slice share one race-safe, **atomic** implementation.

**Round-2 update (commits `86762227` + `33077ac0`)** addresses a 6-seat reviewer pass that found a P0 concurrency gap, a P1 double-owner wiring, and 6 additional findings. All closed in this PR — no defer items with P0/P1 severity.

### HTTP surface

| Method | Path | Auth | Body | Status |
|--------|------|------|------|--------|
| `GET` | `/api/v1/access/setup/status` | **Public** | — | `200 {"data":{"hasAdmin":bool}}` |
| `POST` | `/api/v1/access/setup/admin` | **Public** | `{username,email,password}` | `201 {"data":{id,username,email,createdAt}}` / `410 ERR_SETUP_ALREADY_INITIALIZED` |

**Path scoping (round-2):** `/api/v1/setup/*` → `/api/v1/access/setup/*` — follows Consul's `/acl/bootstrap` convention (per-cell path prefix) to match GoCell's `/api/v1/{cell}/*` invariant. Vault's top-level `/sys/init` alternative was rejected: GoCell has no system-level Cell, and top-level `/setup/` would collide with future configcore/auditcore bootstrap needs.

**One-shot semantics (round-2):** `410 Gone` (was `409 Conflict`). Post-initialization the endpoint is permanently retired for the lifetime of the deployment; `409` (retry-may-succeed) was the wrong verb. Response `details` carries machine-readable `nextAction: "login"` + `loginEndpoint: "/api/v1/access/sessions/login"` so clients do not parse natural-language messages.

**Fast-path (round-2 M-01):** `bcrypt.GenerateFromPassword` runs **after** the Status fast-path. Anonymous flood on the retired endpoint returns `410` in ~milliseconds instead of burning ~1-2s CPU per request at cost=12.

### Provisioning owner model (round-2, NOT back-compat)

`GOCELL_ACCESSCORE_ADMIN_PROVISION_MODE` env var (default **`interactive`**):

| Mode | `initialadmin` Lifecycle | setup HTTP endpoint | Intended use |
|------|-------------------------|----------------------|--------------|
| `interactive` (default) | disabled | operator must POST to create admin | installer UI, developer dev, v1.0 default |
| `bootstrap` | enabled — writes random password to credfile | returns `410` once admin exists | headless CI / automated deploys |

Removes the previous double-owner race where `initialadmin` always won at startup and the new setup endpoint was dead-on-arrival. Test code can force-enable via `AccessCoreModule{ForceBootstrap: true}` without touching process env.

### Atomic one-shot admin (round-2 P0)

`adminprovision.Provisioner.Ensure` is now serialized through a `sync.Mutex`:

```go
p.mu.Lock()
defer p.mu.Unlock()
// Status → Create → Assign now atomic within a single process
```

Closes the read-after-check window that would otherwise let two concurrent POSTs with different usernames both pass `CountByRole==0` and each persist a distinct admin row (UserRepo's per-username uniqueness does not protect "admin role has two holders"). Covered by new `TestService_CreateAdmin_Concurrent_OnlyOneSucceeds` (10 goroutines, exactly 1 × 201, 9 × 410, race detector clean). Multi-instance PG cross-process lock tracked under `ADMINPROVISION-DIST-LOCK-01` (gated on PG adapter implementation).

### Shared package `cells/accesscore/internal/adminprovision`

```go
type ProvisionOutcome int
const (
    OutcomeUnknown ProvisionOutcome = iota
    OutcomeCreated           // fresh persist
    OutcomeAlreadyExists     // fast-path hasAdmin > 0
    OutcomeRaceSkipped       // concurrent replica won
    OutcomeOrphanRecovered   // prior crashed-run orphan row reclaimed
)

type Provisioner struct { /* mu, userRepo, roleRepo, logger, newID */ }

func NewProvisioner(user, role ports, logger *slog.Logger, newID UUIDGenerator) (*Provisioner, error)
func (p *Provisioner) Status(ctx) (bool, error)
func (p *Provisioner) Ensure(ctx, in ProvisionInput) (*User, ProvisionOutcome, error)  // serialized
func (p *Provisioner) Compensate(ctx, userID)
```

Caller-tx-neutral: `Ensure` does not open a transaction, composing with both `initialadmin`'s no-tx path and `setup`'s L2 outbox-tx path.

**Orphan recovery fix (round-2 M-02):** orphan recovery now unconditionally assigns `existing.PasswordResetRequired = in.RequireReset` (was `if in.RequireReset { MarkPasswordResetRequired() }`). Without this fix, setup-path orphan recovery after a crashed bootstrap-path run would inherit a stale `PasswordResetRequired=true` flag, forcing reset on a password the operator just chose.

### Shared event DTO (round-2 N-03 + F-02)

`cells/accesscore/internal/dto/user_events.go`:

```go
const (
    TopicUserCreated = "event.user.created.v1"
    TopicUserLocked  = "event.user.locked.v1"
)
type UserCreatedEvent struct {
    UserID   string `json:"user_id"`
    Username string `json:"username"`
}
```

`setup` and `identitymanage` both publish via this typed struct (was `map[string]any` in both places, duplicating the topic string).

### Refactor

`cells/accesscore/initialadmin/bootstrap.go` replaces ~170 LOC of duplicated logic (`adminExists`, `ensureRoleAndCreateUser`, `resolveDuplicateUser`, `compensateAfterCredFileFailure`) with a single switch on `ProvisionOutcome`. Public `Lifecycle` API unchanged — zero churn to `cells/accesscore/cell.go` or `cmd/corebundle`.

Four provisioner-level branch-coverage tests move from `bootstrap_branches_test.go` → `adminprovision/provisioner_test.go` where they belong.

### Contracts

```
contracts/http/auth/setup/status/v1/   id: http.auth.setup.status.v1 · L0 · GET 200
contracts/http/auth/setup/admin/v1/    id: http.auth.setup.admin.v1  · L2 · POST 201/410
```

Setup slice declares 3 contractUsages: two `serve` + one `publish` (`event.user.created.v1`, shared with `identitymanage`). Round-2 added `TestEventUserCreatedV1Publish_FromSetup` so the `contract.event.user.created.v1.publish` verification slot in `slice.yaml` is actually covered by a test (was declared without coverage in round-1).

### Errcode

`errcode.ErrSetupAlreadyInitialized` → `http.StatusGone` (410, was 409 in round-1).

### Coverage

- `adminprovision`: **98.6%** (target 90%)
- `setup`: **87.1%** (target 80%)
- `cmd/corebundle/setup_integration_test.go` walks status → create → 410 → status → login end-to-end (verifies `nextAction`/`loginEndpoint` details payload)

### Round-2 review findings closed in this PR

| ID | Severity | Resolution |
|----|----------|-----------|
| P0 concurrency | blocker | `sync.Mutex` in Ensure + `TestService_CreateAdmin_Concurrent_OnlyOneSucceeds` |
| P1-A double-owner | blocker | env-gated provision mode; `interactive` default |
| P1-B public exposure | high | 410 fast-path before bcrypt + backlog `SETUP-ADMIN-RATE-LIMIT-01` for production gateways |
| P1-C event contract test | high | `TestEventUserCreatedV1Publish_FromSetup` in `contract_test.go` |
| P2 concurrent/rollback tests | medium | concurrent + bcrypt-skip + orphan-reset-clear + control-char tests |
| M-01 bcrypt DoS | Cx2 | bcrypt moved after `provisioner.Status` |
| M-02 orphan reset flag | Cx2 | direct assignment `existing.PasswordResetRequired = in.RequireReset` |
| N-01 path namespacing | Cx1 | `/api/v1/setup/*` → `/api/v1/access/setup/*` |
| N-02 brittle prefix check | Cx1 | `strings.HasPrefix(out.ID, setup.UserIDPrefix)` |
| N-03 typed event DTO | Cx2 | `internal/dto/user_events.go` shared by setup + identitymanage |
| N-04 409 message leak | Cx1 | `details.nextAction`/`loginEndpoint` + generic message |
| N-05 slice.yaml consistencyLevel | — | Closed: `SliceMeta` type does not accept the field (`kernel/metadata/types.go:61`) |
| N-07 email control chars | Cx1 | `strings.ContainsAny(email, "\r\n\t\x00")` reject |

### Refs

- Source plan: `docs/plans/202604232330-025-architecture-pr-implementation-plan.md` §PR-A26
- Working plan: `docs-plans-202604232330-025-architectur-unified-wadler.md`
- Round-2 review: `docs/reviews/202604242002-pr247-reviewer.md` + user-provided 6-seat report
- `ref: HashiCorp Consul /acl/bootstrap` (path scoping per subsystem)
- `ref: HashiCorp Vault /sys/init` (410 Gone semantics for one-shot lifecycle)
- `ref: Keycloak bootstrap-admin CLI` (owner exclusivity model — bootstrap and HTTP setup are mutually exclusive)
- `ref: GitLab db/fixtures/production/001_admin.rb` (single-tx, no compensation — informed `initialadmin`'s design)

### Backlog items registered (not this PR)

| ID | Trigger | Why out of scope |
|----|---------|------------------|
| `ADMINPROVISION-DIST-LOCK-01` | PG adapter for accesscore | Cross-process lock requires PG `pg_advisory_xact_lock`; mem repo covered by in-process mutex |
| `SETUP-ADMIN-RATE-LIMIT-01` | Public-facing deployment | Fast-path 410 already mitigates CPU DoS; rate-limit is per-deployment risk model |
| `SETUP-PATH-NAMESPACE-POLICY-01` | — | Add rule to `api-versioning.md` reserving `/api/v1/setup/` top-level for future cross-cell system bootstrap |
| `SETUP-ORPHAN-E2E-01` | PG adapter for accesscore | In-memory repo reset per BuildApp — orphan E2E requires real DB persistence |

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...`
- [x] `go run ./cmd/gocell validate` + `gocell validate --strict` (0 errors, 1 pre-existing REF-16 warn)
- [x] `go run ./cmd/gocell check contract-health` (PASS)
- [x] `go test -race -count=1 ./cells/accesscore/... ./pkg/errcode/... ./pkg/httputil/... ./cmd/corebundle/...`
- [x] CI-exact integration scope: `go test -tags=integration -timeout 15m ./adapters/... ./tests/integration/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/...`
- [x] `golangci-lint run --new-from-merge-base=origin/develop` on full tree — **0 issues**
- [x] Manual smoke: `curl` walk of status → 201 create → 410 re-create → status → login (via integration test harness)
- [x] CI green (after cognitive-complexity refactor in `33077ac0`)
- [x] Six-dimension review green

## Out of scope

- S-5xx-code-mask (`docs/backlog.md:34`) — PR-A7 review residual
- Installer UI — separate frontend repo consumes these contracts
- Moving `initialadmin/credfile_*.go` to `pkg/admincred/` — still accesscore-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)
