### PR TITLE
fix(bootstrap,ci): align integration test package + add runtime/bootstrap to integration-test scope

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -155,7 +155,12 @@ jobs:
         # including it, the "integration" build tag was never compiled in CI.
         # cells/accesscore/slices/identitymanage also has an integration test
         # (changepassword_e2e_test.go) that exercises the real AuthMiddleware.
-        run: go test -tags=integration -coverprofile=coverage-integration.out -coverpkg=./... ./adapters/... ./tests/integration/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... -count=1 -timeout 15m
+        # runtime/bootstrap carries lifecycle_integration_test.go (HookStartStop
+        # ordering + LIFO rollback precision probes); without this path the
+        # //go:build integration file silently never compiles in CI, masking
+        # regressions (exactly how the package-declaration break this PR fixes
+        # stayed invisible — the test was never built).
+        run: go test -tags=integration -coverprofile=coverage-integration.out -coverpkg=./... ./adapters/... ./tests/integration/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m
 
       - name: Upload integration coverage profile
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/runtime/bootstrap/lifecycle_integration_test.go
+++ b/runtime/bootstrap/lifecycle_integration_test.go
@@ -1,6 +1,13 @@
 //go:build integration
 
-package bootstrap_test
+// File lives in internal `package bootstrap` to match every other *_test.go in
+// this directory. The earlier `package bootstrap_test` caused a build failure
+// under `go test -tags=integration ./runtime/bootstrap/...` because the file
+// referenced the unexported helper `newLocalListener` and the option constructor
+// `WithInternalListener` without a package qualifier. Current integration CI
+// scope does not include runtime/bootstrap so the break stayed invisible in CI;
+// local full-repo integration runs would hit it.
+package bootstrap
 
 import (
 	"context"
@@ -12,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,12 +59,12 @@ func TestLifecycleIntegration_HookStartStop_Ordering(t *testing.T) {
 
 	var onStartCalled bool
 
-	b := bootstrap.New(
-		bootstrap.WithPrimaryListener(ln),
+	b := New(
+		WithPrimaryListener(ln),
 		WithInternalListener(newLocalListener(t)),
-		bootstrap.WithShutdownTimeout(3*time.Second),
-		bootstrap.WithLifecycle(func(lc bootstrap.Lifecycle) {
-			_ = lc.Append(bootstrap.Hook{
+		WithShutdownTimeout(3*time.Second),
+		WithLifecycle(func(lc Lifecycle) {
+			_ = lc.Append(Hook{
 				Name: "timing-probe",
 				OnStart: func(_ context.Context) error {
 					mu.Lock()
@@ -129,11 +135,11 @@ func TestLifecycleIntegration_HookPartialFailure_PreciseRollback(t *testing.T) {
 
 	boomErr := errors.New("boom")
 
-	b := bootstrap.New(
-		bootstrap.WithShutdownTimeout(3*time.Second),
-		bootstrap.WithLifecycle(func(lc bootstrap.Lifecycle) {
+	b := New(
+		WithShutdownTimeout(3*time.Second),
+		WithLifecycle(func(lc Lifecycle) {
 			// Hook A: succeeds; its OnStop must run during rollback.
-			_ = lc.Append(bootstrap.Hook{
+			_ = lc.Append(Hook{
 				Name: "A",
 				OnStart: func(_ context.Context) error {
 					record("A.start")
@@ -146,7 +152,7 @@ func TestLifecycleIntegration_HookPartialFailure_PreciseRollback(t *testing.T) {
 			})
 			// Hook B: OnStart fails — triggers LIFO rollback of A.
 			// B.OnStop must NOT be called (B never completed OnStart).
-			_ = lc.Append(bootstrap.Hook{
+			_ = lc.Append(Hook{
 				Name: "B",
 				OnStart: func(_ context.Context) error {
 					return boomErr
@@ -157,7 +163,7 @@ func TestLifecycleIntegration_HookPartialFailure_PreciseRollback(t *testing.T) {
 				},
 			})
 			// Hook C: must never run at all (B failed before C was reached).
-			_ = lc.Append(bootstrap.Hook{
+			_ = lc.Append(Hook{
 				Name: "C",
 				OnStart: func(_ context.Context) error {
 					t.Error("C.OnStart must not run")

--- a/runtime/bootstrap/lifecycle_integration_test.go
+++ b/runtime/bootstrap/lifecycle_integration_test.go
@@ -1,13 +1,14 @@
 //go:build integration
 
-// File lives in internal `package bootstrap` to match every other *_test.go in
-// this directory. The earlier `package bootstrap_test` caused a build failure
-// under `go test -tags=integration ./runtime/bootstrap/...` because the file
-// referenced the unexported helper `newLocalListener` and the option constructor
-// `WithInternalListener` without a package qualifier. Current integration CI
-// scope does not include runtime/bootstrap so the break stayed invisible in CI;
-// local full-repo integration runs would hit it.
 package bootstrap
+
+// Note: file lives in internal `package bootstrap` to match every other
+// *_test.go in this directory. The earlier `package bootstrap_test` caused a
+// build failure under `go test -tags=integration ./runtime/bootstrap/...`
+// because the file referenced the unexported helper `newLocalListener` and the
+// option constructor `WithInternalListener` without a package qualifier.
+// Current integration CI scope does not include runtime/bootstrap so the break
+// stayed invisible in CI; local full-repo integration runs would hit it.
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
Two related commits fixing the same end-to-end gap — the bootstrap integration tests were broken *and* the CI never compiled them.

1. **\`runtime/bootstrap/lifecycle_integration_test.go\`** was the only \`*_test.go\` in its directory declared as \`package bootstrap_test\` (external). It referenced the unexported helper \`newLocalListener\` and the option constructor \`WithInternalListener\` without a package qualifier, so \`go test -tags=integration ./runtime/bootstrap/...\` failed to build. **Fix**: switch to internal \`package bootstrap\` to match every other test file in the directory; drop the redundant \`bootstrap.\` qualifier and the unused self-import.

2. **\`_build-lint.yml\` integration-test scope**: add \`./runtime/bootstrap/...\`. Without this, the tests fixed by commit 1 are still dead code — \`integration-test\` job never compiles them. This is how the package-declaration break in commit 1 stayed invisible in CI for weeks despite being latent. Adding the path closes the loop so every future integration test under \`runtime/bootstrap/\` is covered automatically.

## Why CI stayed green before
\`pr-ci / integration-test\` only ran \`go test -tags=integration\` on
\`./adapters/... ./tests/integration/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/...\`
— \`runtime/bootstrap\` was outside that list. Discovered via local full-repo \`go test -tags=integration ./...\` during PR #246 round-6 review.

## Reproduction (before commit 1)
\`\`\`
$ go test -tags=integration -run=none ./runtime/bootstrap/...
runtime/bootstrap/lifecycle_integration_test.go:58:3: undefined: WithInternalListener
runtime/bootstrap/lifecycle_integration_test.go:58:24: undefined: newLocalListener
FAIL	github.com/ghbvf/gocell/runtime/bootstrap [build failed]
\`\`\`

## Test plan
- [x] \`go test -tags=integration -run=TestLifecycleIntegration ./runtime/bootstrap/...\` passes locally
- [x] \`go test -tags=integration ./runtime/bootstrap/...\` (full scope) passes in 7.1s locally
- [x] \`golangci-lint run ./runtime/bootstrap/...\` — 0 issues
- [ ] CI \`integration-test\` job green with the new \`./runtime/bootstrap/...\` path compiled and executed

## Cost
~7s added to \`integration-test\` wall time. No change to build-test or sonar.

## Design choice (commit 1)
Option (a) chosen: align with every other test file in \`runtime/bootstrap/\` (all use internal \`package bootstrap\`). Alternative (keep \`package bootstrap_test\`, move \`newLocalListener\` to an exported \`bootstrap.NewLocalListenerForTest\` or a testhelper subpackage) would force a test-only export surface for a white-box lifecycle probe and diverges from the directory convention.

## Merge note for PR #255
PR #255 (plan A matrix sharding) also modifies the integration-test command line in \`_build-lint.yml\` (\`-coverpkg=./...\` removal + \`-covermode=atomic\` addition). Merging this PR first will cause a trivial one-line conflict on that command; resolution is straightforward — keep both changes (this PR's new path + #255's flag changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)