### PR TITLE
test(distlock): fix TestManager_HeapOrder flaky race on lazy eventAdd

### DIFF
--- a/runtime/distlock/manager_test.go
+++ b/runtime/distlock/manager_test.go
@@ -24,6 +24,21 @@ func waitPendingTimers(t *testing.T, fc *locktest.FakeClock, want int) {
 	}
 }
 
+// waitTrackedLocks spins until m.Snapshot().Locks >= want. Used after Acquire
+// to force a synchronization point: Acquire merely enqueues an eventAdd to
+// the manager goroutine, so without this barrier subsequent fc.Advance calls
+// can race ahead of handleAdd and capture a later nextRenew baseline.
+func waitTrackedLocks(t *testing.T, m *distlock.Manager, want int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for m.Snapshot().Locks < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("waitTrackedLocks: timed out waiting for %d tracked locks (got %d)", want, m.Snapshot().Locks)
+		}
+		runtime.Gosched()
+	}
+}
+
 // waitForRenewM waits until fd.Calls("Renew") >= want using RenewNotify.
 func waitForRenewM(t *testing.T, m *distlock.Manager, fd *locktest.FakeDriver, want int) {
 	t.Helper()
@@ -75,6 +90,11 @@ func TestManager_HeapOrder(t *testing.T) {
 	m := mgr(l)
 	<-m.Started()
 
+	// Synchronization barrier: both Acquires only enqueue eventAdd events. We
+	// need both handleAdd calls to land at fake-clock time 0 so key2.nextRenew
+	// is fixed at 5s (not at "time of first Advance" + 5s). Without this, the
+	// later phases assume a heap layout that may not hold.
+	waitTrackedLocks(t, m, 2)
 	// Wait for the manager to register the first timer (h[0]=key1, deadline 2s).
 	waitPendingTimers(t, fc, 1)
 


### PR DESCRIPTION
## Summary

- 修复 `runtime/distlock` 的 `TestManager_HeapOrder` 竞态：`Acquire` 只是把 `eventAdd` 投递到 manager goroutine，原来的 `waitPendingTimers(1)` 只确保 **第一把锁**（key1）的 timer 注册，**第二把锁**（key2）可能还在 channel 里。如果 `fc.Advance(2s+1ms)` 抢在 `handleAdd(key2)` 之前跑，key2 的 `nextRenew` 就基于 fake-clock `2s+1ms` 计算成 `7s+1ms`，而不是测试假设的 `5s`。Phase 3 推进 1s 到 `5s+2ms` 永远到不了 key2 的 timer，第 3 次 Renew 永不触发，60s 超时报 `want=3, got=2`。
- 在第一次 `Advance` 之前加 `waitTrackedLocks(m, 2)` 同步屏障，强制两个 `handleAdd` 都在 fake-clock 时间 0 完成。
- 这是 PR-A20 (#260) 引入的预存 flaky；阻塞 PR #263 CI。纯测试改动，生产代码未动。

## Test plan

- [x] `go test ./runtime/distlock/... -run TestManager_HeapOrder -count=200` — 200/200 通过（修复前本地 1/20 失败）
- [x] `go test ./runtime/distlock/... -race -count=5` — 全绿
- [x] `golangci-lint run ./runtime/distlock/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)