### PR TITLE
refactor(governance,cells): PR-CFG-B CELL-GRAPH-INTEGRITY — LAYER-09 + ADV-05 + entry-upserted metadata-only + flag.changed retire

### DIFF
--- a/.claude/rules/gocell/cell-patterns.md
+++ b/.claude/rules/gocell/cell-patterns.md
@@ -59,11 +59,13 @@ c.ValidatePayload(t, pub.calls[0].payload)
 ## ADV-05 治理规则：active event 必须有 subscriber
 
 `kernel/governance` ADV-05 在 `gocell validate` 阶段对每个 `kind: event` 的 contract 强制：
-- 若 `lifecycle: active`（或 `lifecycle: draft`）且 `endpoints.subscribers` 为空（nil 或 []），SeverityError 阻断 CI
+- 若 `lifecycle: active` 且 `endpoints.subscribers` 为空（nil 或 []），SeverityError 阻断 CI
+- `lifecycle: draft` 给豁免（设计期允许"未连线"，转 active 时再要求订阅，对标 K8s API deprecation policy / Watermill router lifecycle）
 - `lifecycle: deprecated` 给豁免（dead event 标记为 deprecated 即可）
 - subscribers 可以是 cell ID 或 actor ID（actors.yaml 注册的 external 系统）
 
 典型修复路径：
 - 真死事件 → `lifecycle: deprecated`
+- 设计中尚未连线 → `lifecycle: draft`（待真实 producer/consumer 落地后转 active）
 - 内部 fan-out 但还没 consumer → 添加占位 cell consumer（注释说明意图）
 - 对外 fan-out 给 SIEM/外部平台 → actors.yaml 注册 actor + subscribers 引用 actor ID

--- a/.claude/rules/gocell/cell-patterns.md
+++ b/.claude/rules/gocell/cell-patterns.md
@@ -55,3 +55,15 @@ h.ServeHTTP(rec, req)
 c.ValidateHTTPResponseRecorder(t, rec)
 c.ValidatePayload(t, pub.calls[0].payload)
 ```
+
+## ADV-05 治理规则：active event 必须有 subscriber
+
+`kernel/governance` ADV-05 在 `gocell validate` 阶段对每个 `kind: event` 的 contract 强制：
+- 若 `lifecycle: active`（或 `lifecycle: draft`）且 `endpoints.subscribers` 为空（nil 或 []），SeverityError 阻断 CI
+- `lifecycle: deprecated` 给豁免（dead event 标记为 deprecated 即可）
+- subscribers 可以是 cell ID 或 actor ID（actors.yaml 注册的 external 系统）
+
+典型修复路径：
+- 真死事件 → `lifecycle: deprecated`
+- 内部 fan-out 但还没 consumer → 添加占位 cell consumer（注释说明意图）
+- 对外 fan-out 给 SIEM/外部平台 → actors.yaml 注册 actor + subscribers 引用 actor ID

--- a/actors.yaml
+++ b/actors.yaml
@@ -1,3 +1,8 @@
+# External actors registered for ADV-05 satisfaction:
+# - external-audit-sink: real external SIEM/audit-collector consuming auditcore L2 events
+# - example-iot-platform: example external IoT platform for examples/iotdevice walkthrough
+# - example-order-platform: example external order processor for examples/todoorder walkthrough
+# If you add a new external actor, also add a comment line here describing its role.
 - id: edge-bff
   type: external
   maxConsistencyLevel: L4

--- a/actors.yaml
+++ b/actors.yaml
@@ -8,10 +8,10 @@
   maxConsistencyLevel: L4
 - id: external-audit-sink
   type: external
-  maxConsistencyLevel: L4
+  maxConsistencyLevel: L2
 - id: example-iot-platform
   type: external
   maxConsistencyLevel: L4
 - id: example-order-platform
   type: external
-  maxConsistencyLevel: L4
+  maxConsistencyLevel: L2

--- a/actors.yaml
+++ b/actors.yaml
@@ -1,3 +1,12 @@
 - id: edge-bff
   type: external
   maxConsistencyLevel: L4
+- id: external-audit-sink
+  type: external
+  maxConsistencyLevel: L4
+- id: example-iot-platform
+  type: external
+  maxConsistencyLevel: L4
+- id: example-order-platform
+  type: external
+  maxConsistencyLevel: L4

--- a/cells/accesscore/internal/dto/config_event_decoder.go
+++ b/cells/accesscore/internal/dto/config_event_decoder.go
@@ -27,8 +27,12 @@ type EntryUpserted struct {
 }
 
 // EntryDeleted is accesscore's local typed view of event.config.entry-deleted.v1.
+// Version is the version of the deleted entry; consumers use it for monotonic
+// tombstone protection — a replayed older upsert must be rejected when
+// event.Version <= tombstone version.
 type EntryDeleted struct {
-	Key string
+	Key     string
+	Version int
 }
 
 // internal wire structs; not exported
@@ -38,7 +42,8 @@ type entryUpsertedWire struct {
 }
 
 type entryDeletedWire struct {
-	Key string `json:"key"`
+	Key     string `json:"key"`
+	Version int    `json:"version"`
 }
 
 // DecodeEntryUpserted strictly decodes and validates event.config.entry-upserted.v1.
@@ -58,7 +63,7 @@ func DecodeEntryUpserted(data []byte) (EntryUpserted, error) {
 }
 
 // DecodeEntryDeleted strictly decodes and validates event.config.entry-deleted.v1.
-// Rejects unknown fields and enforces non-empty key.
+// Rejects unknown fields and enforces non-empty key and version >= 1.
 func DecodeEntryDeleted(data []byte) (EntryDeleted, error) {
 	var wire entryDeletedWire
 	if err := decodeStrict(data, &wire); err != nil {
@@ -66,6 +71,9 @@ func DecodeEntryDeleted(data []byte) (EntryDeleted, error) {
 	}
 	if strings.TrimSpace(wire.Key) == "" {
 		return EntryDeleted{}, fmt.Errorf("entry-deleted missing key")
+	}
+	if wire.Version < 1 {
+		return EntryDeleted{}, fmt.Errorf("entry-deleted invalid version %d for key %q", wire.Version, wire.Key)
 	}
 	return EntryDeleted(wire), nil
 }

--- a/cells/accesscore/internal/dto/config_event_decoder.go
+++ b/cells/accesscore/internal/dto/config_event_decoder.go
@@ -1,0 +1,86 @@
+// Package dto contains accesscore's local typed views of cross-cell event payloads.
+//
+// Per cell-patterns.md, contracts/ JSON Schema is the single source of truth for
+// inter-cell wire format; each consuming cell maintains its own typed view +
+// decoder rather than importing the producer cell's Go types. The ~40 LoC of
+// duplicated decode logic between accesscore/configreceive and configcore is
+// the accepted cost of cell isolation.
+//
+// ref: NATS subject+bytes / Watermill payload-bytes / go-micro broker boundary.
+package dto
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// EntryUpserted is accesscore's local typed view of event.config.entry-upserted.v1.
+// Schema source of truth: contracts/event/config/entry-upserted/v1/payload.schema.json.
+// Metadata-only: payload carries key + version; subscribers refetch via
+// GET /api/v1/config/{key} when they actually need the value.
+type EntryUpserted struct {
+	Key     string
+	Version int
+}
+
+// EntryDeleted is accesscore's local typed view of event.config.entry-deleted.v1.
+type EntryDeleted struct {
+	Key string
+}
+
+// internal wire structs; not exported
+type entryUpsertedWire struct {
+	Key     string `json:"key"`
+	Version int    `json:"version"`
+}
+
+type entryDeletedWire struct {
+	Key string `json:"key"`
+}
+
+// DecodeEntryUpserted strictly decodes and validates event.config.entry-upserted.v1.
+// Rejects unknown fields (including legacy "value") and enforces non-empty key + version >= 1.
+func DecodeEntryUpserted(data []byte) (EntryUpserted, error) {
+	var wire entryUpsertedWire
+	if err := decodeStrict(data, &wire); err != nil {
+		return EntryUpserted{}, err
+	}
+	if strings.TrimSpace(wire.Key) == "" {
+		return EntryUpserted{}, fmt.Errorf("entry-upserted missing key")
+	}
+	if wire.Version < 1 {
+		return EntryUpserted{}, fmt.Errorf("entry-upserted invalid version %d for key %q", wire.Version, wire.Key)
+	}
+	return EntryUpserted(wire), nil
+}
+
+// DecodeEntryDeleted strictly decodes and validates event.config.entry-deleted.v1.
+// Rejects unknown fields and enforces non-empty key.
+func DecodeEntryDeleted(data []byte) (EntryDeleted, error) {
+	var wire entryDeletedWire
+	if err := decodeStrict(data, &wire); err != nil {
+		return EntryDeleted{}, err
+	}
+	if strings.TrimSpace(wire.Key) == "" {
+		return EntryDeleted{}, fmt.Errorf("entry-deleted missing key")
+	}
+	return EntryDeleted(wire), nil
+}
+
+func decodeStrict(data []byte, dst any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values in payload")
+		}
+		return err
+	}
+	return nil
+}

--- a/cells/accesscore/internal/dto/config_event_decoder_test.go
+++ b/cells/accesscore/internal/dto/config_event_decoder_test.go
@@ -83,12 +83,17 @@ func TestDecodeEntryDeleted(t *testing.T) {
 		payload string
 		wantErr bool
 		wantKey string
+		wantVer int
 	}{
-		{"valid", `{"key":"k1"}`, false, "k1"},
-		{"missing-key", `{}`, true, ""},
-		{"empty-key", `{"key":""}`, true, ""},
-		{"unknown-field", `{"key":"k1","extra":"x"}`, true, ""},
-		{"multiple-json-values", `{"key":"k1"}{"key":"k2"}`, true, ""},
+		{"valid v1", `{"key":"k1","version":1}`, false, "k1", 1},
+		{"valid v42", `{"key":"k1","version":42}`, false, "k1", 42},
+		{"missing-key", `{"version":1}`, true, "", 0},
+		{"empty-key", `{"key":"","version":1}`, true, "", 0},
+		{"missing-version", `{"key":"k1"}`, true, "", 0},
+		{"version-zero", `{"key":"k1","version":0}`, true, "", 0},
+		{"version-negative", `{"key":"k1","version":-1}`, true, "", 0},
+		{"unknown-field", `{"key":"k1","version":1,"extra":"x"}`, true, "", 0},
+		{"multiple-json-values", `{"key":"k1","version":1}{"key":"k2","version":2}`, true, "", 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -99,6 +104,39 @@ func TestDecodeEntryDeleted(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantKey, ev.Key)
+			assert.Equal(t, tc.wantVer, ev.Version)
+		})
+	}
+}
+
+// TestDecodeEntryDeleted_AlignedWithContractSchema verifies that every
+// valid payload accepted by DecodeEntryDeleted also passes the canonical
+// JSON Schema at contracts/event/config/entry-deleted/v1/payload.schema.json.
+func TestDecodeEntryDeleted_AlignedWithContractSchema(t *testing.T) {
+	c := contracttest.LoadByID(t, contracttest.ContractsRoot(), "event.config.entry-deleted.v1")
+
+	validCases := []struct {
+		name    string
+		payload string
+	}{
+		{"minimal valid", `{"key":"k1","version":1}`},
+		{"version 42", `{"key":"app.name","version":42}`},
+	}
+
+	for _, tc := range validCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payloadBytes := []byte(tc.payload)
+
+			ev, err := DecodeEntryDeleted(payloadBytes)
+			require.NoError(t, err, "decoder rejected a payload that should be valid")
+
+			encoded, err := json.Marshal(map[string]any{
+				"key":     ev.Key,
+				"version": ev.Version,
+			})
+			require.NoError(t, err)
+
+			c.ValidatePayload(t, encoded)
 		})
 	}
 }

--- a/cells/accesscore/internal/dto/config_event_decoder_test.go
+++ b/cells/accesscore/internal/dto/config_event_decoder_test.go
@@ -1,0 +1,64 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeEntryUpserted(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantErr bool
+		wantKey string
+		wantVer int
+	}{
+		{"valid", `{"key":"k1","version":2}`, false, "k1", 2},
+		{"value-field-rejected (metadata-only)", `{"key":"k1","value":"v","version":2}`, true, "", 0},
+		{"missing-key", `{"version":2}`, true, "", 0},
+		{"empty-key", `{"key":"","version":2}`, true, "", 0},
+		{"missing-version", `{"key":"k1"}`, true, "", 0},
+		{"invalid-version-zero", `{"key":"k1","version":0}`, true, "", 0},
+		{"unknown-field", `{"key":"k1","version":2,"extra":1}`, true, "", 0},
+		{"multiple-json-values", `{"key":"k1","version":1}{"key":"k2","version":2}`, true, "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, err := DecodeEntryUpserted([]byte(tc.payload))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, ev.Key)
+			assert.Equal(t, tc.wantVer, ev.Version)
+		})
+	}
+}
+
+func TestDecodeEntryDeleted(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantErr bool
+		wantKey string
+	}{
+		{"valid", `{"key":"k1"}`, false, "k1"},
+		{"missing-key", `{}`, true, ""},
+		{"empty-key", `{"key":""}`, true, ""},
+		{"unknown-field", `{"key":"k1","extra":"x"}`, true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, err := DecodeEntryDeleted([]byte(tc.payload))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, ev.Key)
+		})
+	}
+}

--- a/cells/accesscore/internal/dto/config_event_decoder_test.go
+++ b/cells/accesscore/internal/dto/config_event_decoder_test.go
@@ -1,8 +1,10 @@
 package dto
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +40,43 @@ func TestDecodeEntryUpserted(t *testing.T) {
 	}
 }
 
+// TestDecodeEntryUpserted_AlignedWithContractSchema verifies that every
+// valid payload accepted by DecodeEntryUpserted also passes the canonical
+// JSON Schema at contracts/event/config/entry-upserted/v1/payload.schema.json.
+// This alignment test catches decoder/schema drift early.
+func TestDecodeEntryUpserted_AlignedWithContractSchema(t *testing.T) {
+	c := contracttest.LoadByID(t, contracttest.ContractsRoot(), "event.config.entry-upserted.v1")
+
+	validCases := []struct {
+		name    string
+		payload string
+	}{
+		{"minimal valid", `{"key":"k1","version":2}`},
+		{"version 1", `{"key":"jwt.ttl","version":1}`},
+		{"version 42", `{"key":"app.name","version":42}`},
+	}
+
+	for _, tc := range validCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payloadBytes := []byte(tc.payload)
+
+			// Decoder must accept it.
+			ev, err := DecodeEntryUpserted(payloadBytes)
+			require.NoError(t, err, "decoder rejected a payload that should be valid")
+
+			// Re-encode through the decoder's output to ensure round-trip.
+			encoded, err := json.Marshal(map[string]any{
+				"key":     ev.Key,
+				"version": ev.Version,
+			})
+			require.NoError(t, err)
+
+			// Contract schema must also accept it.
+			c.ValidatePayload(t, encoded)
+		})
+	}
+}
+
 func TestDecodeEntryDeleted(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -49,6 +88,7 @@ func TestDecodeEntryDeleted(t *testing.T) {
 		{"missing-key", `{}`, true, ""},
 		{"empty-key", `{"key":""}`, true, ""},
 		{"unknown-field", `{"key":"k1","extra":"x"}`, true, ""},
+		{"multiple-json-values", `{"key":"k1"}{"key":"k2"}`, true, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cells/accesscore/slices/configreceive/service.go
+++ b/cells/accesscore/slices/configreceive/service.go
@@ -48,7 +48,7 @@ func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) err
 		return outbox.NewPermanentError(fmt.Errorf("config-receive: unmarshal entry-upserted payload: %w", err))
 	}
 
-	s.logger.Info("config-receive: config upserted",
+	s.logger.Debug("config-receive: config upserted",
 		slog.String("key", event.Key),
 		slog.Int("version", event.Version))
 	return nil
@@ -63,6 +63,6 @@ func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) erro
 		return outbox.NewPermanentError(fmt.Errorf("config-receive: unmarshal entry-deleted payload: %w", err))
 	}
 
-	s.logger.Info("config-receive: config deleted", slog.String("key", event.Key))
+	s.logger.Debug("config-receive: config deleted", slog.String("key", event.Key))
 	return nil
 }

--- a/cells/accesscore/slices/configreceive/service.go
+++ b/cells/accesscore/slices/configreceive/service.go
@@ -21,6 +21,11 @@ const (
 
 // Service consumes config change events for accesscore.
 //
+// NOTE: HandleEntryUpserted/HandleEntryDeleted are currently observability-only
+// (logs only). Real consumers (JWT TTL refresh, key rotation interval) will land
+// in a follow-up; the current subscription is a placeholder per ADV-05
+// (active event must have subscribers).
+//
 // Consumer: cg-accesscore-config-events
 // Idempotency: log-only (no side effects), inherently idempotent
 // Disposition: Ack on success / Reject on permanent unmarshal or semantic error

--- a/cells/accesscore/slices/configreceive/service.go
+++ b/cells/accesscore/slices/configreceive/service.go
@@ -63,6 +63,8 @@ func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) erro
 		return outbox.NewPermanentError(fmt.Errorf("config-receive: unmarshal entry-deleted payload: %w", err))
 	}
 
-	s.logger.Debug("config-receive: config deleted", slog.String("key", event.Key))
+	s.logger.Debug("config-receive: config deleted",
+		slog.String("key", event.Key),
+		slog.Int("version", event.Version))
 	return nil
 }

--- a/cells/accesscore/slices/configreceive/service.go
+++ b/cells/accesscore/slices/configreceive/service.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	configevents "github.com/ghbvf/gocell/cells/configcore/events"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
@@ -36,7 +36,7 @@ func NewService(logger *slog.Logger) *Service {
 
 // HandleEntryUpserted processes an event.config.entry-upserted.v1 event.
 func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) error {
-	event, err := configevents.DecodeEntryUpserted(entry.Payload)
+	event, err := dto.DecodeEntryUpserted(entry.Payload)
 	if err != nil {
 		s.logger.Error("config-receive: failed to unmarshal entry-upserted event, routing to dead letter",
 			slog.Any("error", err), slog.String("entry_id", entry.ID))
@@ -51,7 +51,7 @@ func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) err
 
 // HandleEntryDeleted processes an event.config.entry-deleted.v1 event.
 func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) error {
-	event, err := configevents.DecodeEntryDeleted(entry.Payload)
+	event, err := dto.DecodeEntryDeleted(entry.Payload)
 	if err != nil {
 		s.logger.Error("config-receive: failed to unmarshal entry-deleted event, routing to dead letter",
 			slog.Any("error", err), slog.String("entry_id", entry.ID))

--- a/cells/accesscore/slices/configreceive/service_test.go
+++ b/cells/accesscore/slices/configreceive/service_test.go
@@ -74,7 +74,7 @@ func TestHandleEntryDeleted_ValidPayload(t *testing.T) {
 	entry := outbox.Entry{
 		ID:      "evt-del-1",
 		Topic:   TopicConfigEntryDeleted,
-		Payload: []byte(`{"key":"jwt.ttl"}`),
+		Payload: []byte(`{"key":"jwt.ttl","version":3}`),
 	}
 	assert.NoError(t, svc.HandleEntryDeleted(context.Background(), entry))
 }
@@ -86,8 +86,10 @@ func TestHandleEntryDeleted_InvalidPayload_PermanentError(t *testing.T) {
 		wantErr string
 	}{
 		{"invalid json", []byte("not-json{"), "unmarshal"},
-		{"missing key", []byte(`{}`), "missing key"},
-		{"extra value field", []byte(`{"key":"jwt.ttl","value":"old"}`), "unknown field"},
+		{"missing key", []byte(`{"version":1}`), "missing key"},
+		{"missing version", []byte(`{"key":"jwt.ttl"}`), "invalid version"},
+		{"version zero", []byte(`{"key":"jwt.ttl","version":0}`), "invalid version"},
+		{"extra value field", []byte(`{"key":"jwt.ttl","version":1,"value":"old"}`), "unknown field"},
 	}
 
 	for _, tt := range tests {

--- a/cells/accesscore/slices/configreceive/service_test.go
+++ b/cells/accesscore/slices/configreceive/service_test.go
@@ -41,6 +41,7 @@ func TestHandleEntryUpserted_InvalidPayload_PermanentError(t *testing.T) {
 		{"invalid json", []byte("not-json{"), "unmarshal"},
 		{"missing key", []byte(`{"version":1}`), "missing key"},
 		{"empty key", []byte(`{"key":"","version":1}`), "missing key"},
+		{"blank key whitespace", []byte(`{"key":"   ","version":1}`), "missing key"},
 		{"missing version", []byte(`{"key":"jwt.ttl"}`), "invalid version"},
 		{"invalid version zero", []byte(`{"key":"jwt.ttl","version":0}`), "invalid version"},
 		// value field is rejected — payload must be metadata-only

--- a/cells/accesscore/slices/configreceive/service_test.go
+++ b/cells/accesscore/slices/configreceive/service_test.go
@@ -2,11 +2,9 @@ package configreceive
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
 	"testing"
 
-	configevents "github.com/ghbvf/gocell/cells/configcore/events"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,29 +12,21 @@ import (
 
 func TestHandleEntryUpserted_ValidPayload(t *testing.T) {
 	tests := []struct {
-		name  string
-		value string
+		name    string
+		payload []byte
 	}{
-		{"non-empty value", "30m"},
-		{"empty value is present", ""},
+		{"metadata-only key+version", []byte(`{"key":"jwt.ttl","version":1}`)},
+		{"higher version", []byte(`{"key":"jwt.ttl","version":42}`)},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewService(slog.Default())
-			payload, err := json.Marshal(configevents.EntryUpserted{
-				Key:     "jwt.ttl",
-				Value:   tt.value,
-				Version: 1,
-			})
-			require.NoError(t, err)
-
 			entry := outbox.Entry{
 				ID:      "evt-1",
 				Topic:   TopicConfigEntryUpserted,
-				Payload: payload,
+				Payload: tt.payload,
 			}
-
 			assert.NoError(t, svc.HandleEntryUpserted(context.Background(), entry))
 		})
 	}
@@ -49,11 +39,14 @@ func TestHandleEntryUpserted_InvalidPayload_PermanentError(t *testing.T) {
 		wantErr string
 	}{
 		{"invalid json", []byte("not-json{"), "unmarshal"},
-		{"missing key", []byte(`{"value":"30m","version":1}`), "missing key"},
-		{"missing value field", []byte(`{"key":"jwt.ttl","version":1}`), "missing value"},
-		{"invalid version", []byte(`{"key":"jwt.ttl","value":"30m","version":0}`), "invalid version"},
-		{"extra sensitive field", []byte(`{"key":"jwt.ttl","value":"30m","version":1,"sensitive":false}`), "unknown field"},
-		{"old action field", []byte(`{"action":"updated","key":"jwt.ttl","value":"30m","version":1}`), "unknown field"},
+		{"missing key", []byte(`{"version":1}`), "missing key"},
+		{"empty key", []byte(`{"key":"","version":1}`), "missing key"},
+		{"missing version", []byte(`{"key":"jwt.ttl"}`), "invalid version"},
+		{"invalid version zero", []byte(`{"key":"jwt.ttl","version":0}`), "invalid version"},
+		// value field is rejected — payload must be metadata-only
+		{"value field present", []byte(`{"key":"jwt.ttl","value":"30m","version":1}`), "unknown field"},
+		{"extra sensitive field", []byte(`{"key":"jwt.ttl","version":1,"sensitive":false}`), "unknown field"},
+		{"old action field", []byte(`{"action":"updated","key":"jwt.ttl","version":1}`), "unknown field"},
 	}
 
 	for _, tt := range tests {
@@ -77,15 +70,11 @@ func TestHandleEntryUpserted_InvalidPayload_PermanentError(t *testing.T) {
 
 func TestHandleEntryDeleted_ValidPayload(t *testing.T) {
 	svc := NewService(slog.Default())
-	payload, err := json.Marshal(configevents.EntryDeleted{Key: "jwt.ttl"})
-	require.NoError(t, err)
-
 	entry := outbox.Entry{
 		ID:      "evt-del-1",
 		Topic:   TopicConfigEntryDeleted,
-		Payload: payload,
+		Payload: []byte(`{"key":"jwt.ttl"}`),
 	}
-
 	assert.NoError(t, svc.HandleEntryDeleted(context.Background(), entry))
 }
 
@@ -128,14 +117,11 @@ func TestWrapLegacyHandler_EntryUpserted_ValidPayload_Ack(t *testing.T) {
 	svc := NewService(slog.Default())
 	handler := outbox.WrapLegacyHandler(svc.HandleEntryUpserted)
 
-	payload, err := json.Marshal(configevents.EntryUpserted{
-		Key:     "jwt.ttl",
-		Value:   "",
-		Version: 1,
-	})
-	require.NoError(t, err)
-
-	entry := outbox.Entry{ID: "evt-wrap-1", Topic: TopicConfigEntryUpserted, Payload: payload}
+	entry := outbox.Entry{
+		ID:      "evt-wrap-1",
+		Topic:   TopicConfigEntryUpserted,
+		Payload: []byte(`{"key":"jwt.ttl","version":1}`),
+	}
 	result := handler(context.Background(), entry)
 
 	assert.Equal(t, outbox.DispositionAck, result.Disposition)
@@ -153,14 +139,15 @@ func TestWrapLegacyHandler_EntryUpserted_InvalidJSON_Reject(t *testing.T) {
 	assert.Error(t, result.Err)
 }
 
-func TestWrapLegacyHandler_EntryUpserted_MissingValue_Reject(t *testing.T) {
+func TestWrapLegacyHandler_EntryUpserted_ValueField_Reject(t *testing.T) {
 	svc := NewService(slog.Default())
 	handler := outbox.WrapLegacyHandler(svc.HandleEntryUpserted)
 
+	// value field is now rejected — metadata-only schema
 	entry := outbox.Entry{
 		ID:      "evt-wrap-3",
 		Topic:   TopicConfigEntryUpserted,
-		Payload: []byte(`{"key":"jwt.ttl","version":1}`),
+		Payload: []byte(`{"key":"jwt.ttl","value":"30m","version":1}`),
 	}
 	result := handler(context.Background(), entry)
 

--- a/cells/accesscore/slices/setup/slice.yaml
+++ b/cells/accesscore/slices/setup/slice.yaml
@@ -1,5 +1,6 @@
 id: setup
 belongsToCell: accesscore
+consistencyLevel: L2
 contractUsages:
   - contract: http.auth.setup.status.v1
     role: serve

--- a/cells/auditcore/slices/auditappend/contract_test.go
+++ b/cells/auditcore/slices/auditappend/contract_test.go
@@ -63,10 +63,19 @@ func TestEventConfigEntryDeletedV1Subscribe(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.entry-deleted.v1")
 
-	c.ValidatePayload(t, []byte(`{"key":"k"}`))
+	// Valid: key + version required.
+	c.ValidatePayload(t, []byte(`{"key":"k","version":1}`))
+	c.ValidatePayload(t, []byte(`{"key":"k","version":7}`))
+
+	// Missing required fields.
 	c.MustRejectPayload(t, []byte(`{}`))
+	c.MustRejectPayload(t, []byte(`{"key":"k"}`))   // missing version
+	c.MustRejectPayload(t, []byte(`{"version":1}`)) // missing key
 	c.MustRejectPayload(t, []byte(`{"key":""}`))
 	c.MustRejectPayload(t, []byte(`{"key":"   "}`))
+
+	// Invalid version.
+	c.MustRejectPayload(t, []byte(`{"key":"k","version":0}`))
 }
 
 func TestEventConfigVersionPublishedV1Subscribe(t *testing.T) {

--- a/cells/auditcore/slices/auditappend/contract_test.go
+++ b/cells/auditcore/slices/auditappend/contract_test.go
@@ -52,12 +52,11 @@ func TestEventConfigEntryUpsertedV1Subscribe(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.entry-upserted.v1")
 
-	c.ValidatePayload(t, []byte(`{"key":"k","value":"v","version":1}`))
-	c.ValidatePayload(t, []byte(`{"key":"k","value":"","version":1}`))
-	c.MustRejectPayload(t, []byte(`{"key":"k","version":1}`))
-	c.MustRejectPayload(t, []byte(`{"key":"","value":"v","version":1}`))
-	c.MustRejectPayload(t, []byte(`{"key":"   ","value":"v","version":1}`))
-	c.MustRejectPayload(t, []byte(`{"key":"k","value":"v","version":0}`))
+	c.ValidatePayload(t, []byte(`{"key":"k","version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"k","value":"v","version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"","version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"   ","version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"k","version":0}`))
 }
 
 func TestEventConfigEntryDeletedV1Subscribe(t *testing.T) {

--- a/cells/configcore/cell_init.go
+++ b/cells/configcore/cell_init.go
@@ -182,15 +182,16 @@ func (c *ConfigCore) initFlagSlice(runMode query.RunMode) error {
 	return nil
 }
 
-// initFlagWriteSlice registers the flag-write L2 slice: Create/Update/Toggle/Delete
-// with transactional outbox (flag.changed.v1 event).
+// initFlagWriteSlice registers the flag-write L1 slice: Create/Update/Toggle/Delete
+// with local transaction only. event.flag.changed.v1 was retired (PR-CFG-B 2026-04-25):
+// the contract never had a subscriber, so outbox emission was dead work.
 func (c *ConfigCore) initFlagWriteSlice() error {
-	opts := []flagwrite.Option{flagwrite.WithEmitter(c.emitter), flagwrite.WithTxManager(c.txRunner)}
+	opts := []flagwrite.Option{flagwrite.WithTxManager(c.txRunner)}
 	flagWriteSvc, err := flagwrite.NewService(c.flagRepo, c.logger, opts...)
 	if err != nil {
 		return fmt.Errorf("configcore: init flag-write slice: %w", err)
 	}
 	c.flagWriteHandler = flagwrite.NewHandler(flagWriteSvc)
-	c.AddSlice(cell.NewBaseSlice("flagwrite", "configcore", cell.L2))
+	c.AddSlice(cell.NewBaseSlice("flagwrite", "configcore", cell.L1))
 	return nil
 }

--- a/cells/configcore/internal/domain/config_events.go
+++ b/cells/configcore/internal/domain/config_events.go
@@ -1,23 +1,14 @@
 package domain
 
-import "github.com/ghbvf/gocell/cells/configcore/internal/events"
-
 // Event payload structs for configcore (L2 OutboxFact).
 //
 // JSON field names are camelCase per cell-patterns.md (HTTP DTO 和事件 payload
 // 统一 camelCase). The previous snake_case fields (config_id, target_version,
 // new_version) were retired as part of PR-A6's full-break sweep.
 //
-// ConfigEntryUpsertedEvent is metadata-only: subscribers MUST refetch via
-// GET /api/v1/config/{key} to obtain the value.
-// ref: NATS subject+bytes / Watermill payload-bytes boundary.
-
-// ConfigEntryUpsertedEvent is the metadata-only payload for event.config.entry-upserted.v1.
-type ConfigEntryUpsertedEvent = events.EntryUpserted
-
-// ConfigEntryDeletedEvent is the payload for event.config.entry-deleted.v1.
-type ConfigEntryDeletedEvent = events.EntryDeleted
-
+// ConfigEntryUpsertedEvent and ConfigEntryDeletedEvent aliases have been removed
+// (F-ARCH-03). Internal slices and tests import
+// cells/configcore/internal/events directly for those types.
 // ConfigVersionPublishedEvent is the payload for
 // event.config.version-published.v1. Produced by configpublish.Publish.
 // No `action` field — topic name carries the semantic.

--- a/cells/configcore/internal/domain/config_events.go
+++ b/cells/configcore/internal/domain/config_events.go
@@ -1,6 +1,6 @@
 package domain
 
-import "github.com/ghbvf/gocell/cells/configcore/events"
+import "github.com/ghbvf/gocell/cells/configcore/internal/events"
 
 // Event payload structs for configcore (L2 OutboxFact).
 //
@@ -8,10 +8,11 @@ import "github.com/ghbvf/gocell/cells/configcore/events"
 // 统一 camelCase). The previous snake_case fields (config_id, target_version,
 // new_version) were retired as part of PR-A6's full-break sweep.
 //
-// State-sync payload aliases point at cells/configcore/events so other cells
-// can decode public config events without importing configcore/internal.
+// ConfigEntryUpsertedEvent is metadata-only: subscribers MUST refetch via
+// GET /api/v1/config/{key} to obtain the value.
+// ref: NATS subject+bytes / Watermill payload-bytes boundary.
 
-// ConfigEntryUpsertedEvent is the payload for event.config.entry-upserted.v1.
+// ConfigEntryUpsertedEvent is the metadata-only payload for event.config.entry-upserted.v1.
 type ConfigEntryUpsertedEvent = events.EntryUpserted
 
 // ConfigEntryDeletedEvent is the payload for event.config.entry-deleted.v1.

--- a/cells/configcore/internal/domain/topics.go
+++ b/cells/configcore/internal/domain/topics.go
@@ -16,5 +16,4 @@ const (
 	TopicConfigEntryDeleted     = "event.config.entry-deleted.v1"
 	TopicConfigVersionPublished = "event.config.version-published.v1"
 	TopicConfigRollback         = "event.config.rollback.v1"
-	TopicFlagChanged            = "event.flag.changed.v1"
 )

--- a/cells/configcore/internal/events/config_events.go
+++ b/cells/configcore/internal/events/config_events.go
@@ -7,6 +7,8 @@
 // ref: NATS subject+bytes / Watermill payload-bytes boundary — event carries
 // metadata only (key + version). Subscribers MUST refetch via
 // GET /api/v1/config/{key} to obtain the current value.
+//
+// Internal slices of configcore may import this package directly (it's the canonical decoder for the producer cell).
 package events
 
 import (

--- a/cells/configcore/internal/events/config_events.go
+++ b/cells/configcore/internal/events/config_events.go
@@ -1,4 +1,12 @@
-// Package events defines configcore's public event wire payloads and decoders.
+// Package events defines configcore's internal event wire payloads and decoders.
+//
+// This package is internal to configcore. External cells that consume
+// event.config.entry-upserted.v1 must maintain their own local decoder — the
+// canonical schema is contracts/event/config/entry-upserted/v1/payload.schema.json.
+//
+// ref: NATS subject+bytes / Watermill payload-bytes boundary — event carries
+// metadata only (key + version). Subscribers MUST refetch via
+// GET /api/v1/config/{key} to obtain the current value.
 package events
 
 import (
@@ -9,10 +17,10 @@ import (
 	"strings"
 )
 
-// EntryUpserted is the payload for event.config.entry-upserted.v1.
+// EntryUpserted is the metadata-only payload for event.config.entry-upserted.v1.
+// Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
 type EntryUpserted struct {
 	Key     string `json:"key"`
-	Value   string `json:"value"`
 	Version int    `json:"version"`
 }
 
@@ -21,28 +29,20 @@ type EntryDeleted struct {
 	Key string `json:"key"`
 }
 
-type entryUpsertedWire struct {
-	Key     string  `json:"key"`
-	Value   *string `json:"value"`
-	Version int     `json:"version"`
-}
-
 // DecodeEntryUpserted strictly decodes and validates event.config.entry-upserted.v1.
+// The payload must not contain a "value" field — this decoder rejects unknown fields.
 func DecodeEntryUpserted(data []byte) (EntryUpserted, error) {
-	var wire entryUpsertedWire
-	if err := decodeStrict(data, &wire); err != nil {
+	var event EntryUpserted
+	if err := decodeStrict(data, &event); err != nil {
 		return EntryUpserted{}, err
 	}
-	if strings.TrimSpace(wire.Key) == "" {
+	if strings.TrimSpace(event.Key) == "" {
 		return EntryUpserted{}, fmt.Errorf("entry-upserted missing key")
 	}
-	if wire.Value == nil {
-		return EntryUpserted{}, fmt.Errorf("entry-upserted missing value for key %q", wire.Key)
+	if event.Version < 1 {
+		return EntryUpserted{}, fmt.Errorf("entry-upserted invalid version %d for key %q", event.Version, event.Key)
 	}
-	if wire.Version < 1 {
-		return EntryUpserted{}, fmt.Errorf("entry-upserted invalid version %d for key %q", wire.Version, wire.Key)
-	}
-	return EntryUpserted{Key: wire.Key, Value: *wire.Value, Version: wire.Version}, nil
+	return event, nil
 }
 
 // DecodeEntryDeleted strictly decodes and validates event.config.entry-deleted.v1.

--- a/cells/configcore/internal/events/config_events.go
+++ b/cells/configcore/internal/events/config_events.go
@@ -26,9 +26,13 @@ type EntryUpserted struct {
 	Version int    `json:"version"`
 }
 
-// EntryDeleted is the payload for event.config.entry-deleted.v1.
+// EntryDeleted is the metadata-only payload for event.config.entry-deleted.v1.
+// Version is the version of the deleted entry; subscribers use it for monotonic
+// tombstone protection — a replayed older upsert must be rejected when
+// event.Version <= tombstone version.
 type EntryDeleted struct {
-	Key string `json:"key"`
+	Key     string `json:"key"`
+	Version int    `json:"version"`
 }
 
 // DecodeEntryUpserted strictly decodes and validates event.config.entry-upserted.v1.
@@ -55,6 +59,9 @@ func DecodeEntryDeleted(data []byte) (EntryDeleted, error) {
 	}
 	if strings.TrimSpace(event.Key) == "" {
 		return EntryDeleted{}, fmt.Errorf("entry-deleted missing key")
+	}
+	if event.Version < 1 {
+		return EntryDeleted{}, fmt.Errorf("entry-deleted invalid version %d for key %q", event.Version, event.Key)
 	}
 	return event, nil
 }

--- a/cells/configcore/internal/events/config_events_test.go
+++ b/cells/configcore/internal/events/config_events_test.go
@@ -60,14 +60,19 @@ func TestDecodeEntryDeleted(t *testing.T) {
 		payload     []byte
 		wantErr     bool
 		wantKey     string
+		wantVersion int
 		errContains string
 	}{
-		{"valid", []byte(`{"key":"jwt.ttl"}`), false, "jwt.ttl", ""},
-		{"missing key", []byte(`{}`), true, "", "missing key"},
-		{"blank key", []byte(`{"key":"  "}`), true, "", "missing key"},
-		{"unknown field", []byte(`{"key":"jwt.ttl","value":"old"}`), true, "", "unknown field"},
-		{"multiple json values", []byte(`{"key":"jwt.ttl"}{}`), true, "", "multiple JSON values"},
-		{"invalid json", []byte("not-json"), true, "", "invalid"},
+		{"valid v1", []byte(`{"key":"jwt.ttl","version":1}`), false, "jwt.ttl", 1, ""},
+		{"valid v42", []byte(`{"key":"app.name","version":42}`), false, "app.name", 42, ""},
+		{"missing key", []byte(`{"version":1}`), true, "", 0, "missing key"},
+		{"blank key", []byte(`{"key":"  ","version":1}`), true, "", 0, "missing key"},
+		{"missing version", []byte(`{"key":"jwt.ttl"}`), true, "", 0, "invalid version"},
+		{"version zero", []byte(`{"key":"jwt.ttl","version":0}`), true, "", 0, "invalid version"},
+		{"version negative", []byte(`{"key":"jwt.ttl","version":-1}`), true, "", 0, "invalid version"},
+		{"unknown field", []byte(`{"key":"jwt.ttl","version":1,"value":"old"}`), true, "", 0, "unknown field"},
+		{"multiple json values", []byte(`{"key":"jwt.ttl","version":1}{}`), true, "", 0, "multiple JSON values"},
+		{"invalid json", []byte("not-json"), true, "", 0, "invalid"},
 	}
 
 	for _, tt := range tests {
@@ -82,6 +87,7 @@ func TestDecodeEntryDeleted(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantKey, got.Key)
+			assert.Equal(t, tt.wantVersion, got.Version)
 		})
 	}
 }

--- a/cells/configcore/internal/events/config_events_test.go
+++ b/cells/configcore/internal/events/config_events_test.go
@@ -55,28 +55,33 @@ func TestDecodeEntryUpsertedRejectsInvalidPayload(t *testing.T) {
 }
 
 func TestDecodeEntryDeleted(t *testing.T) {
-	got, err := DecodeEntryDeleted([]byte(`{"key":"jwt.ttl"}`))
-	require.NoError(t, err)
-	assert.Equal(t, "jwt.ttl", got.Key)
-}
-
-func TestDecodeEntryDeletedRejectsInvalidPayload(t *testing.T) {
 	tests := []struct {
-		name    string
-		payload []byte
-		wantErr string
+		name        string
+		payload     []byte
+		wantErr     bool
+		wantKey     string
+		errContains string
 	}{
-		{"invalid json", []byte("not-json"), "invalid"},
-		{"missing key", []byte(`{}`), "missing key"},
-		{"blank key", []byte(`{"key":"  "}`), "missing key"},
-		{"unknown field", []byte(`{"key":"jwt.ttl","value":"old"}`), "unknown field"},
+		{"valid", []byte(`{"key":"jwt.ttl"}`), false, "jwt.ttl", ""},
+		{"missing key", []byte(`{}`), true, "", "missing key"},
+		{"blank key", []byte(`{"key":"  "}`), true, "", "missing key"},
+		{"unknown field", []byte(`{"key":"jwt.ttl","value":"old"}`), true, "", "unknown field"},
+		{"multiple json values", []byte(`{"key":"jwt.ttl"}{}`), true, "", "multiple JSON values"},
+		{"invalid json", []byte("not-json"), true, "", "invalid"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := DecodeEntryDeleted(tt.payload)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
+			got, err := DecodeEntryDeleted(tt.payload)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKey, got.Key)
 		})
 	}
 }

--- a/cells/configcore/internal/events/config_events_test.go
+++ b/cells/configcore/internal/events/config_events_test.go
@@ -9,21 +9,21 @@ import (
 
 func TestDecodeEntryUpserted(t *testing.T) {
 	tests := []struct {
-		name      string
-		payload   []byte
-		wantValue string
+		name        string
+		payload     []byte
+		wantKey     string
+		wantVersion int
 	}{
-		{"non-empty value", []byte(`{"key":"jwt.ttl","value":"30m","version":1}`), "30m"},
-		{"empty value", []byte(`{"key":"jwt.ttl","value":"","version":1}`), ""},
+		{"valid metadata-only payload", []byte(`{"key":"jwt.ttl","version":1}`), "jwt.ttl", 1},
+		{"version > 1", []byte(`{"key":"app.name","version":42}`), "app.name", 42},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := DecodeEntryUpserted(tt.payload)
 			require.NoError(t, err)
-			assert.Equal(t, "jwt.ttl", got.Key)
-			assert.Equal(t, tt.wantValue, got.Value)
-			assert.Equal(t, 1, got.Version)
+			assert.Equal(t, tt.wantKey, got.Key)
+			assert.Equal(t, tt.wantVersion, got.Version)
 		})
 	}
 }
@@ -35,12 +35,14 @@ func TestDecodeEntryUpsertedRejectsInvalidPayload(t *testing.T) {
 		wantErr string
 	}{
 		{"invalid json", []byte("not-json"), "invalid"},
-		{"missing key", []byte(`{"value":"30m","version":1}`), "missing key"},
-		{"blank key", []byte(`{"key":"  ","value":"30m","version":1}`), "missing key"},
-		{"missing value", []byte(`{"key":"jwt.ttl","version":1}`), "missing value"},
-		{"invalid version", []byte(`{"key":"jwt.ttl","value":"30m","version":0}`), "invalid version"},
-		{"unknown field", []byte(`{"key":"jwt.ttl","value":"30m","version":1,"sensitive":false}`), "unknown field"},
-		{"multiple values", []byte(`{"key":"jwt.ttl","value":"30m","version":1} {}`), "multiple JSON values"},
+		{"missing key", []byte(`{"version":1}`), "missing key"},
+		{"blank key", []byte(`{"key":"  ","version":1}`), "missing key"},
+		{"invalid version zero", []byte(`{"key":"jwt.ttl","version":0}`), "invalid version"},
+		{"invalid version negative", []byte(`{"key":"jwt.ttl","version":-1}`), "invalid version"},
+		// Critical: wire carrying value field must be rejected (DisallowUnknownFields)
+		{"value field present — must reject", []byte(`{"key":"jwt.ttl","value":"30m","version":1}`), "unknown field"},
+		{"sensitive field present", []byte(`{"key":"jwt.ttl","version":1,"sensitive":false}`), "unknown field"},
+		{"multiple values", []byte(`{"key":"jwt.ttl","version":1} {}`), "multiple JSON values"},
 	}
 
 	for _, tt := range tests {

--- a/cells/configcore/slices/configpublish/contract_test.go
+++ b/cells/configcore/slices/configpublish/contract_test.go
@@ -240,6 +240,8 @@ func TestEventConfigRollbackV1Publish_RollbackEmitsStateThenAudit(t *testing.T) 
 	assert.Equal(t, domain.TopicConfigEntryUpserted, stateEntry.EventType)
 	upserted.ValidatePayload(t, stateEntry.Payload)
 	upserted.ValidateHeaders(t, []byte(`{"event_id":"`+stateEntry.ID+`"}`))
+	// Metadata-only: value field must be absent and forbidden.
+	upserted.MustRejectPayload(t, []byte(`{"key":"app.name","value":"v1","version":2}`))
 
 	auditEntry := writer.Entries[1]
 	assert.Equal(t, domain.TopicConfigRollback, auditEntry.EventType)

--- a/cells/configcore/slices/configpublish/service.go
+++ b/cells/configcore/slices/configpublish/service.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	configevents "github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/cells/configcore/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
@@ -141,7 +142,7 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 		// Metadata-only: event carries key+version only.
 		// Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
 		// ref: NATS subject+bytes / Watermill payload-bytes boundary.
-		if err := outbox.Emit(txCtx, s.emitter, domain.TopicConfigEntryUpserted, domain.ConfigEntryUpsertedEvent{
+		if err := outbox.Emit(txCtx, s.emitter, domain.TopicConfigEntryUpserted, configevents.EntryUpserted{
 			Key:     key,
 			Version: updated.Version,
 		}); err != nil {

--- a/cells/configcore/slices/configpublish/service.go
+++ b/cells/configcore/slices/configpublish/service.go
@@ -138,13 +138,11 @@ func (s *Service) Rollback(ctx context.Context, key string, targetVersion int) (
 			return fmt.Errorf("config-publish: rollback update: %w", err)
 		}
 
-		eventValue := updated.Value
-		if updated.Sensitive {
-			eventValue = "******"
-		}
+		// Metadata-only: event carries key+version only.
+		// Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
+		// ref: NATS subject+bytes / Watermill payload-bytes boundary.
 		if err := outbox.Emit(txCtx, s.emitter, domain.TopicConfigEntryUpserted, domain.ConfigEntryUpsertedEvent{
 			Key:     key,
-			Value:   eventValue,
 			Version: updated.Version,
 		}); err != nil {
 			return err

--- a/cells/configcore/slices/configpublish/service_test.go
+++ b/cells/configcore/slices/configpublish/service_test.go
@@ -2,6 +2,7 @@ package configpublish
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	"github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -388,4 +390,46 @@ func TestService_Rollback_FailOpen_PublisherError(t *testing.T) {
 	rolled, err := svc.Rollback(context.Background(), "app.x", 1)
 	require.NoError(t, err, "FailOpen: publisher failure must be swallowed on rollback")
 	assert.Equal(t, "v1", rolled.Value)
+}
+
+// TestRollback_DurableMode_UpsertedPayloadIsMetadataOnly asserts that the
+// entry-upserted event emitted during Rollback carries only key+version
+// and does NOT include a "value" field (metadata-only contract, F-TEST-03).
+func TestRollback_DurableMode_UpsertedPayloadIsMetadataOnly(t *testing.T) {
+	svc, repo, writer := newDurableTestService(t)
+
+	mustSeedEntry(repo, "app.name", "v1")
+
+	// Publish first to create a version snapshot.
+	_, err := svc.Publish(context.Background(), "app.name")
+	require.NoError(t, err)
+	writer.Entries = writer.Entries[:0] // reset writer after publish
+
+	// Rollback to version 1.
+	_, err = svc.Rollback(context.Background(), "app.name", 1)
+	require.NoError(t, err)
+
+	// Rollback emits two entries: [0]=entry-upserted, [1]=config-rollback.
+	require.GreaterOrEqual(t, len(writer.Entries), 1, "Rollback must emit at least one outbox entry")
+
+	// Find the entry-upserted entry.
+	var upsertedPayload []byte
+	for _, e := range writer.Entries {
+		if e.EventType == domain.TopicConfigEntryUpserted {
+			upsertedPayload = e.Payload
+			break
+		}
+	}
+	require.NotNil(t, upsertedPayload, "Rollback must emit a TopicConfigEntryUpserted entry")
+
+	// Assert payload decodes correctly as metadata-only.
+	decoded, decErr := events.DecodeEntryUpserted(upsertedPayload)
+	require.NoError(t, decErr, "entry-upserted payload from Rollback must be valid")
+	assert.Equal(t, "app.name", decoded.Key)
+
+	// Assert no "value" field is present.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(upsertedPayload, &raw))
+	_, hasValue := raw["value"]
+	assert.False(t, hasValue, "entry-upserted payload must NOT contain 'value' field (metadata-only)")
 }

--- a/cells/configcore/slices/configsubscribe/contract_test.go
+++ b/cells/configcore/slices/configsubscribe/contract_test.go
@@ -10,13 +10,25 @@ func TestEventConfigEntryUpsertedV1Subscribe(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.entry-upserted.v1")
 
-	c.ValidatePayload(t, []byte(`{"key":"app.name","value":"newval","version":2}`))
-	c.ValidatePayload(t, []byte(`{"key":"app.name","value":"","version":2}`))
+	// Metadata-only schema: only key+version, no value field.
+	c.ValidatePayload(t, []byte(`{"key":"app.name","version":2}`))
+	c.ValidatePayload(t, []byte(`{"key":"app.name","version":1}`))
 	c.ValidateHeaders(t, []byte(`{"event_id":"evt-sub-1"}`))
-	c.MustRejectPayload(t, []byte(`{"key":"app.name","version":2}`))
-	c.MustRejectPayload(t, []byte(`{"key":"","value":"newval","version":2}`))
-	c.MustRejectPayload(t, []byte(`{"key":"   ","value":"newval","version":2}`))
-	c.MustRejectPayload(t, []byte(`{"key":"app.name","value":"newval","version":0}`))
+
+	// Missing required fields
+	c.MustRejectPayload(t, []byte(`{"version":2}`))
+	c.MustRejectPayload(t, []byte(`{"key":"app.name"}`))
+
+	// Invalid key values
+	c.MustRejectPayload(t, []byte(`{"key":"","version":2}`))
+	c.MustRejectPayload(t, []byte(`{"key":"   ","version":2}`))
+
+	// Invalid version
+	c.MustRejectPayload(t, []byte(`{"key":"app.name","version":0}`))
+
+	// value field must be rejected (metadata-only schema, additionalProperties: false)
+	c.MustRejectPayload(t, []byte(`{"key":"app.name","value":"newval","version":2}`))
+
 	c.MustRejectHeaders(t, []byte(`{}`))
 }
 

--- a/cells/configcore/slices/configsubscribe/contract_test.go
+++ b/cells/configcore/slices/configsubscribe/contract_test.go
@@ -36,10 +36,23 @@ func TestEventConfigEntryDeletedV1Subscribe(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "event.config.entry-deleted.v1")
 
-	c.ValidatePayload(t, []byte(`{"key":"app.name"}`))
+	// Valid: key + version (metadata-only + tombstone protection).
+	c.ValidatePayload(t, []byte(`{"key":"app.name","version":1}`))
+	c.ValidatePayload(t, []byte(`{"key":"app.name","version":42}`))
 	c.ValidateHeaders(t, []byte(`{"event_id":"evt-del-1"}`))
+
+	// Missing required fields.
 	c.MustRejectPayload(t, []byte(`{}`))
-	c.MustRejectPayload(t, []byte(`{"key":""}`))
-	c.MustRejectPayload(t, []byte(`{"key":"   "}`))
+	c.MustRejectPayload(t, []byte(`{"key":"app.name"}`)) // missing version
+	c.MustRejectPayload(t, []byte(`{"version":1}`))      // missing key
+	c.MustRejectPayload(t, []byte(`{"key":"","version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"   ","version":1}`))
+
+	// Invalid version.
+	c.MustRejectPayload(t, []byte(`{"key":"app.name","version":0}`))
+
+	// Additional properties forbidden.
+	c.MustRejectPayload(t, []byte(`{"key":"app.name","version":1,"value":"old"}`))
+
 	c.MustRejectHeaders(t, []byte(`{}`))
 }

--- a/cells/configcore/slices/configsubscribe/service.go
+++ b/cells/configcore/slices/configsubscribe/service.go
@@ -1,5 +1,9 @@
 // Package configsubscribe implements the config-subscribe slice: consumes
-// config state-sync events to update a local cache.
+// config state-sync events to update a local version-tracking cache.
+//
+// Metadata-only model: event.config.entry-upserted.v1 carries only key+version.
+// Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
+// ref: NATS subject+bytes / Watermill payload-bytes boundary.
 package configsubscribe
 
 import (
@@ -8,8 +12,8 @@ import (
 	"log/slog"
 	"sync"
 
-	configevents "github.com/ghbvf/gocell/cells/configcore/events"
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	configevents "github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
@@ -20,28 +24,29 @@ const (
 	TopicConfigEntryDeleted  = domain.TopicConfigEntryDeleted
 )
 
-// Cache holds the latest config values observed from events.
+// Cache tracks the latest known version for each config key observed from events.
+// It does NOT store values — subscribers must refetch via GET /api/v1/config/{key}.
 type Cache struct {
-	mu     sync.RWMutex
-	values map[string]string
+	mu       sync.RWMutex
+	versions map[string]int
 }
 
-// Get returns the cached value for a key.
-func (c *Cache) Get(key string) (string, bool) {
+// GetVersion returns the last known version for a key.
+func (c *Cache) GetVersion(key string) (int, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	v, ok := c.values[key]
+	v, ok := c.versions[key]
 	return v, ok
 }
 
-// Len returns the number of cached entries.
+// Len returns the number of tracked keys.
 func (c *Cache) Len() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return len(c.values)
+	return len(c.versions)
 }
 
-// Service consumes config change events and maintains a local cache.
+// Service consumes config change events and maintains a local version-tracking cache.
 type Service struct {
 	cache  *Cache
 	logger *slog.Logger
@@ -50,7 +55,7 @@ type Service struct {
 // NewService creates a config-subscribe Service.
 func NewService(logger *slog.Logger) *Service {
 	return &Service{
-		cache:  &Cache{values: make(map[string]string)},
+		cache:  &Cache{versions: make(map[string]int)},
 		logger: logger,
 	}
 }
@@ -61,11 +66,13 @@ func (s *Service) Cache() *Cache {
 }
 
 // HandleEntryUpserted processes an event.config.entry-upserted.v1 event.
+// Records the known version for the key; does not store a value.
+// Callers wanting the current value must refetch via GET /api/v1/config/{key}.
 //
 // Consumer: cg-configcore-entry-upserted
-// Idempotency key: N/A (in-memory cache, idempotent by nature)
-// ACK timing: after cache update
-// Retry: transient errors -> NACK+backoff / permanent errors -> dead letter
+// Idempotency: Claimer (two-phase Claim/Commit/Release), TTL 24h
+// Disposition: Ack on success / Requeue on transient / Reject on permanent
+// DLX: broker-native via DispositionReject → Nack(requeue=false)
 func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) error {
 	event, err := configevents.DecodeEntryUpserted(entry.Payload)
 	if err != nil {
@@ -75,7 +82,7 @@ func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) err
 	}
 
 	s.cache.mu.Lock()
-	s.cache.values[event.Key] = event.Value
+	s.cache.versions[event.Key] = event.Version
 	s.cache.mu.Unlock()
 	s.logger.Info("config-subscribe: cache updated",
 		slog.String("key", event.Key),
@@ -93,7 +100,7 @@ func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) erro
 	}
 
 	s.cache.mu.Lock()
-	delete(s.cache.values, event.Key)
+	delete(s.cache.versions, event.Key)
 	s.cache.mu.Unlock()
 	s.logger.Info("config-subscribe: key deleted from cache",
 		slog.String("key", event.Key))

--- a/cells/configcore/slices/configsubscribe/service.go
+++ b/cells/configcore/slices/configsubscribe/service.go
@@ -1,7 +1,8 @@
 // Package configsubscribe implements the config-subscribe slice: consumes
 // config state-sync events to update a local version-tracking cache.
 //
-// Metadata-only model: event.config.entry-upserted.v1 carries only key+version.
+// Metadata-only model: event.config.entry-upserted.v1 and
+// event.config.entry-deleted.v1 carry only key+version.
 // Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
 // ref: NATS subject+bytes / Watermill payload-bytes boundary.
 package configsubscribe
@@ -16,28 +17,59 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
-// Cache tracks the latest known version for each config key observed from events.
-// It does NOT store values — subscribers must refetch via GET /api/v1/config/{key}.
+// cacheEntry tracks the highest version seen for a config key plus a presence
+// flag indicating whether the key is currently active (present=true) or
+// tombstoned by a delete event (present=false).
 //
-// versions only, no cached values; subscribers MUST refetch via GET for the actual value.
-type Cache struct {
-	mu       sync.RWMutex
-	versions map[string]int
+// Design invariant: version is monotonically non-decreasing — it is NEVER
+// reset or decremented, not even on delete. This means a replayed older upsert
+// (at-least-once delivery) arriving after a delete will be rejected because
+// event.Version <= tombstone.version.
+//
+// Memory note: tombstone entries (present=false) are retained for the lifetime
+// of the process so that the monotonic protection holds across replays. If
+// process memory becomes a concern (e.g. high-churn keys) a TTL-based eviction
+// or persistent tombstone store should be introduced — that is out of scope for
+// this PR.
+type cacheEntry struct {
+	version int  // highest version seen, never decremented
+	present bool // false = tombstoned by a delete event
 }
 
-// GetVersion returns the last known version for a key.
-func (c *Cache) GetVersion(key string) (int, bool) {
+// Cache tracks the latest known version and presence for each config key
+// observed from events.
+// It does NOT store values — subscribers must refetch via GET /api/v1/config/{key}.
+type Cache struct {
+	mu      sync.RWMutex
+	entries map[string]cacheEntry
+}
+
+// GetVersion returns the last known version for a key and whether the entry is
+// currently active (present=true).  present=false means the key was deleted
+// (tombstoned); the version returned is the tombstone version.
+func (c *Cache) GetVersion(key string) (version int, present bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	v, ok := c.versions[key]
-	return v, ok
+	e, ok := c.entries[key]
+	if !ok {
+		return 0, false
+	}
+	return e.version, e.present
 }
 
-// Len returns the number of tracked keys.
+// Len returns the number of active (present=true) entries.
+// Tombstoned entries are excluded to avoid the count growing unboundedly
+// with deleted keys.
 func (c *Cache) Len() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return len(c.versions)
+	n := 0
+	for _, e := range c.entries {
+		if e.present {
+			n++
+		}
+	}
+	return n
 }
 
 // Service consumes config change events and maintains a local version-tracking cache.
@@ -49,7 +81,7 @@ type Service struct {
 // NewService creates a config-subscribe Service.
 func NewService(logger *slog.Logger) *Service {
 	return &Service{
-		cache:  &Cache{versions: make(map[string]int)},
+		cache:  &Cache{entries: make(map[string]cacheEntry)},
 		logger: logger,
 	}
 }
@@ -64,7 +96,7 @@ func (s *Service) Cache() *Cache {
 // Callers wanting the current value must refetch via GET /api/v1/config/{key}.
 //
 // Version monotonicity: events with a version <= the known version for the key
-// are silently dropped (stale or replayed entry).
+// (including versions <= a tombstone version) are silently dropped.
 //
 // Consumer: cg-configcore-entry-upserted
 // Idempotency: Claimer (two-phase Claim/Commit/Release), TTL 24h
@@ -79,16 +111,16 @@ func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) err
 	}
 
 	s.cache.mu.Lock()
-	known := s.cache.versions[event.Key]
-	if event.Version <= known {
+	known := s.cache.entries[event.Key]
+	if event.Version <= known.version {
 		s.cache.mu.Unlock()
 		s.logger.Debug("config-subscribe: stale or replayed entry-upserted ignored",
 			slog.String("key", event.Key),
 			slog.Int("incoming_version", event.Version),
-			slog.Int("known_version", known))
+			slog.Int("known_version", known.version))
 		return nil
 	}
-	s.cache.versions[event.Key] = event.Version
+	s.cache.entries[event.Key] = cacheEntry{version: event.Version, present: true}
 	s.cache.mu.Unlock()
 	s.logger.Debug("config-subscribe: cache updated",
 		slog.String("key", event.Key),
@@ -97,6 +129,20 @@ func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) err
 }
 
 // HandleEntryDeleted processes an event.config.entry-deleted.v1 event.
+//
+// Tombstone model: instead of deleting the cache entry, we record a tombstone
+// (present=false) at the deleted version. This preserves monotonic protection:
+// a replayed older upsert arriving after the delete will be rejected because
+// event.Version <= tombstone.version.
+//
+// Stale-delete guard: if event.Version <= known.version the delete event itself
+// is stale/replayed and is dropped without modifying the cache. This prevents
+// an old delete event from overwriting a newer upsert that arrived in between.
+//
+// Consumer: cg-configcore-entry-deleted
+// Idempotency: Claimer (two-phase Claim/Commit/Release), TTL 24h
+// Disposition: Ack on success / Requeue on transient / Reject on permanent
+// DLX: broker-native via DispositionReject → Nack(requeue=false)
 func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) error {
 	event, err := configevents.DecodeEntryDeleted(entry.Payload)
 	if err != nil {
@@ -106,16 +152,24 @@ func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) erro
 	}
 
 	s.cache.mu.Lock()
-	_, existed := s.cache.versions[event.Key]
-	delete(s.cache.versions, event.Key)
-	s.cache.mu.Unlock()
-
-	if existed {
-		s.logger.Debug("config-subscribe: key deleted from cache",
-			slog.String("key", event.Key))
-	} else {
-		s.logger.Debug("config-subscribe: delete event for unknown key (idempotent)",
-			slog.String("key", event.Key))
+	known := s.cache.entries[event.Key]
+	// Stale-delete guard: drop if event.Version < known.version.
+	// A delete at version V must be accepted when V >= known.version:
+	//   - V == known.version: this is the delete of the currently known entry.
+	//   - V > known.version: a newer delete (e.g. key re-created and deleted again).
+	// Only V < known.version is truly stale (a delete that predates a newer upsert).
+	if event.Version < known.version {
+		s.cache.mu.Unlock()
+		s.logger.Debug("config-subscribe: stale entry-deleted ignored (predates a newer upsert)",
+			slog.String("key", event.Key),
+			slog.Int("incoming_version", event.Version),
+			slog.Int("known_version", known.version))
+		return nil
 	}
+	s.cache.entries[event.Key] = cacheEntry{version: event.Version, present: false}
+	s.cache.mu.Unlock()
+	s.logger.Debug("config-subscribe: key tombstoned in cache",
+		slog.String("key", event.Key),
+		slog.Int("version", event.Version))
 	return nil
 }

--- a/cells/configcore/slices/configsubscribe/service.go
+++ b/cells/configcore/slices/configsubscribe/service.go
@@ -90,7 +90,7 @@ func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) err
 	}
 	s.cache.versions[event.Key] = event.Version
 	s.cache.mu.Unlock()
-	s.logger.Info("config-subscribe: cache updated",
+	s.logger.Debug("config-subscribe: cache updated",
 		slog.String("key", event.Key),
 		slog.Int("version", event.Version))
 	return nil
@@ -111,7 +111,7 @@ func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) erro
 	s.cache.mu.Unlock()
 
 	if existed {
-		s.logger.Info("config-subscribe: key deleted from cache",
+		s.logger.Debug("config-subscribe: key deleted from cache",
 			slog.String("key", event.Key))
 	} else {
 		s.logger.Debug("config-subscribe: delete event for unknown key (idempotent)",

--- a/cells/configcore/slices/configsubscribe/service.go
+++ b/cells/configcore/slices/configsubscribe/service.go
@@ -12,20 +12,14 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	configevents "github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
-// Re-exported from domain so external callers / tests can refer to the topic
-// without importing internal/domain directly.
-const (
-	TopicConfigEntryUpserted = domain.TopicConfigEntryUpserted
-	TopicConfigEntryDeleted  = domain.TopicConfigEntryDeleted
-)
-
 // Cache tracks the latest known version for each config key observed from events.
 // It does NOT store values — subscribers must refetch via GET /api/v1/config/{key}.
+//
+// versions only, no cached values; subscribers MUST refetch via GET for the actual value.
 type Cache struct {
 	mu       sync.RWMutex
 	versions map[string]int
@@ -69,6 +63,9 @@ func (s *Service) Cache() *Cache {
 // Records the known version for the key; does not store a value.
 // Callers wanting the current value must refetch via GET /api/v1/config/{key}.
 //
+// Version monotonicity: events with a version <= the known version for the key
+// are silently dropped (stale or replayed entry).
+//
 // Consumer: cg-configcore-entry-upserted
 // Idempotency: Claimer (two-phase Claim/Commit/Release), TTL 24h
 // Disposition: Ack on success / Requeue on transient / Reject on permanent
@@ -82,6 +79,15 @@ func (s *Service) HandleEntryUpserted(_ context.Context, entry outbox.Entry) err
 	}
 
 	s.cache.mu.Lock()
+	known := s.cache.versions[event.Key]
+	if event.Version <= known {
+		s.cache.mu.Unlock()
+		s.logger.Debug("config-subscribe: stale or replayed entry-upserted ignored",
+			slog.String("key", event.Key),
+			slog.Int("incoming_version", event.Version),
+			slog.Int("known_version", known))
+		return nil
+	}
 	s.cache.versions[event.Key] = event.Version
 	s.cache.mu.Unlock()
 	s.logger.Info("config-subscribe: cache updated",
@@ -100,9 +106,16 @@ func (s *Service) HandleEntryDeleted(_ context.Context, entry outbox.Entry) erro
 	}
 
 	s.cache.mu.Lock()
+	_, existed := s.cache.versions[event.Key]
 	delete(s.cache.versions, event.Key)
 	s.cache.mu.Unlock()
-	s.logger.Info("config-subscribe: key deleted from cache",
-		slog.String("key", event.Key))
+
+	if existed {
+		s.logger.Info("config-subscribe: key deleted from cache",
+			slog.String("key", event.Key))
+	} else {
+		s.logger.Debug("config-subscribe: delete event for unknown key (idempotent)",
+			slog.String("key", event.Key))
+	}
 	return nil
 }

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -19,12 +19,12 @@ func makeEntryUpserted(key string, version int) outbox.Entry {
 		Key:     key,
 		Version: version,
 	})
-	return outbox.Entry{ID: "test-upsert", Topic: TopicConfigEntryUpserted, Payload: payload}
+	return outbox.Entry{ID: "test-upsert", Topic: domain.TopicConfigEntryUpserted, Payload: payload}
 }
 
 func makeEntryDeleted(key string) outbox.Entry {
 	payload, _ := json.Marshal(domain.ConfigEntryDeletedEvent{Key: key})
-	return outbox.Entry{ID: "test-delete", Topic: TopicConfigEntryDeleted, Payload: payload}
+	return outbox.Entry{ID: "test-delete", Topic: domain.TopicConfigEntryDeleted, Payload: payload}
 }
 
 func TestService_HandleEntryUpserted(t *testing.T) {
@@ -77,6 +77,21 @@ func TestService_HandleEntryUpserted(t *testing.T) {
 	}
 }
 
+// TestService_HandleEntryUpserted_Monotonicity verifies that stale or replayed
+// events (version <= known version) are ignored without overwriting the cache.
+func TestService_HandleEntryUpserted_Monotonicity(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	// v3 → v5 → v3 (replay): final state must be v5.
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 3)))
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 5)))
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 3)))
+
+	v, ok := svc.Cache().GetVersion("k")
+	require.True(t, ok)
+	assert.Equal(t, 5, v, "stale/replayed event must not overwrite higher version")
+}
+
 func TestService_HandleEntryDeleted(t *testing.T) {
 	svc := NewService(slog.Default())
 	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 1)))
@@ -85,6 +100,16 @@ func TestService_HandleEntryDeleted(t *testing.T) {
 	assert.Equal(t, 0, svc.Cache().Len())
 	_, ok := svc.Cache().GetVersion("k")
 	assert.False(t, ok)
+}
+
+// TestService_HandleEntryDeleted_NonExistentKey verifies that deleting a key that
+// was never seen is a no-op (idempotent) and does not error.
+func TestService_HandleEntryDeleted_NonExistentKey(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	// No prior upsert — delete should succeed silently.
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("nonexistent")))
+	assert.Equal(t, 0, svc.Cache().Len())
 }
 
 func TestService_HandleEntryUpserted_InvalidPayload(t *testing.T) {
@@ -105,7 +130,7 @@ func TestService_HandleEntryUpserted_InvalidPayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewService(slog.Default())
-			entry := outbox.Entry{ID: "bad", Topic: TopicConfigEntryUpserted, Payload: tt.payload}
+			entry := outbox.Entry{ID: "bad", Topic: domain.TopicConfigEntryUpserted, Payload: tt.payload}
 
 			err := svc.HandleEntryUpserted(context.Background(), entry)
 			require.Error(t, err)
@@ -134,7 +159,7 @@ func TestService_HandleEntryDeleted_InvalidPayload(t *testing.T) {
 			svc := NewService(slog.Default())
 			require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("existing.key", 1)))
 
-			entry := outbox.Entry{ID: "bad-delete", Topic: TopicConfigEntryDeleted, Payload: tt.payload}
+			entry := outbox.Entry{ID: "bad-delete", Topic: domain.TopicConfigEntryDeleted, Payload: tt.payload}
 			err := svc.HandleEntryDeleted(context.Background(), entry)
 			require.Error(t, err)
 
@@ -147,29 +172,28 @@ func TestService_HandleEntryDeleted_InvalidPayload(t *testing.T) {
 	}
 }
 
-func TestWrapLegacyHandler_InvalidPayload_Reject(t *testing.T) {
-	svc := NewService(slog.Default())
-	handler := outbox.WrapLegacyHandler(svc.HandleEntryUpserted)
-
-	entry := outbox.Entry{ID: "bad", Topic: TopicConfigEntryUpserted, Payload: []byte("not-json")}
-	result := handler(context.Background(), entry)
-
-	assert.Equal(t, outbox.DispositionReject, result.Disposition)
-	assert.Error(t, result.Err)
-}
-
-func TestWrapLegacyHandler_ValueFieldPresent_Reject(t *testing.T) {
-	svc := NewService(slog.Default())
-	handler := outbox.WrapLegacyHandler(svc.HandleEntryUpserted)
-
-	// Old wire format with value field — must be rejected
-	entry := outbox.Entry{
-		ID:      "bad",
-		Topic:   TopicConfigEntryUpserted,
-		Payload: []byte(`{"key":"k","value":"some-value","version":1}`),
+// TestWrapLegacyHandler_Reject_Cases is a table-driven test covering both
+// invalid JSON and the forbidden value field in a metadata-only payload.
+func TestWrapLegacyHandler_Reject_Cases(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"invalid json", []byte("not-json")},
+		// Old wire format with value field — must be rejected
+		{"value field present", []byte(`{"key":"k","value":"some-value","version":1}`)},
 	}
-	result := handler(context.Background(), entry)
 
-	assert.Equal(t, outbox.DispositionReject, result.Disposition)
-	assert.Error(t, result.Err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewService(slog.Default())
+			handler := outbox.WrapLegacyHandler(svc.HandleEntryUpserted)
+
+			entry := outbox.Entry{ID: "bad", Topic: domain.TopicConfigEntryUpserted, Payload: tc.payload}
+			result := handler(context.Background(), entry)
+
+			assert.Equal(t, outbox.DispositionReject, result.Disposition)
+			assert.Error(t, result.Err)
+		})
+	}
 }

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeEntryUpserted(key, value string, version int) outbox.Entry {
+// makeEntryUpserted builds a metadata-only outbox.Entry for entry-upserted.
+// The payload carries only key+version — no value field.
+func makeEntryUpserted(key string, version int) outbox.Entry {
 	payload, _ := json.Marshal(domain.ConfigEntryUpsertedEvent{
 		Key:     key,
-		Value:   value,
 		Version: version,
 	})
 	return outbox.Entry{ID: "test-upsert", Topic: TopicConfigEntryUpserted, Payload: payload}
@@ -28,35 +29,35 @@ func makeEntryDeleted(key string) outbox.Entry {
 
 func TestService_HandleEntryUpserted(t *testing.T) {
 	tests := []struct {
-		name      string
-		events    []outbox.Entry
-		wantKey   string
-		wantValue string
-		wantLen   int
+		name        string
+		events      []outbox.Entry
+		wantKey     string
+		wantVersion int
+		wantLen     int
 	}{
 		{
-			name:      "created state updates cache",
-			events:    []outbox.Entry{makeEntryUpserted("app.name", "gocell", 1)},
-			wantKey:   "app.name",
-			wantValue: "gocell",
-			wantLen:   1,
+			name:        "created state updates cache",
+			events:      []outbox.Entry{makeEntryUpserted("app.name", 1)},
+			wantKey:     "app.name",
+			wantVersion: 1,
+			wantLen:     1,
 		},
 		{
-			name: "updated state updates cache",
+			name: "updated state updates cache to latest version",
 			events: []outbox.Entry{
-				makeEntryUpserted("k", "v1", 1),
-				makeEntryUpserted("k", "v2", 2),
+				makeEntryUpserted("k", 1),
+				makeEntryUpserted("k", 2),
 			},
-			wantKey:   "k",
-			wantValue: "v2",
-			wantLen:   1,
+			wantKey:     "k",
+			wantVersion: 2,
+			wantLen:     1,
 		},
 		{
-			name:      "empty value is cached",
-			events:    []outbox.Entry{makeEntryUpserted("empty", "", 1)},
-			wantKey:   "empty",
-			wantValue: "",
-			wantLen:   1,
+			name:        "version 5 is tracked",
+			events:      []outbox.Entry{makeEntryUpserted("timeout", 5)},
+			wantKey:     "timeout",
+			wantVersion: 5,
+			wantLen:     1,
 		},
 	}
 
@@ -69,20 +70,20 @@ func TestService_HandleEntryUpserted(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.wantLen, svc.Cache().Len())
-			v, ok := svc.Cache().Get(tt.wantKey)
+			v, ok := svc.Cache().GetVersion(tt.wantKey)
 			require.True(t, ok)
-			assert.Equal(t, tt.wantValue, v)
+			assert.Equal(t, tt.wantVersion, v)
 		})
 	}
 }
 
 func TestService_HandleEntryDeleted(t *testing.T) {
 	svc := NewService(slog.Default())
-	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", "v", 1)))
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 1)))
 	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k")))
 
 	assert.Equal(t, 0, svc.Cache().Len())
-	_, ok := svc.Cache().Get("k")
+	_, ok := svc.Cache().GetVersion("k")
 	assert.False(t, ok)
 }
 
@@ -93,11 +94,12 @@ func TestService_HandleEntryUpserted_InvalidPayload(t *testing.T) {
 		wantErr string
 	}{
 		{"invalid json", []byte("not-json"), "unmarshal"},
-		{"missing key", []byte(`{"value":"v","version":1}`), "missing key"},
-		{"missing value", []byte(`{"key":"k","version":1}`), "missing value"},
-		{"invalid version", []byte(`{"key":"k","value":"v","version":0}`), "invalid version"},
-		{"extra sensitive field", []byte(`{"key":"k","value":"v","version":1,"sensitive":false}`), "unknown field"},
-		{"old action field", []byte(`{"action":"updated","key":"k","value":"v","version":1}`), "unknown field"},
+		{"missing key", []byte(`{"version":1}`), "missing key"},
+		// value field must now be rejected (metadata-only schema)
+		{"value field present", []byte(`{"key":"k","value":"v","version":1}`), "unknown field"},
+		{"invalid version zero", []byte(`{"key":"k","version":0}`), "invalid version"},
+		{"extra sensitive field", []byte(`{"key":"k","version":1,"sensitive":false}`), "unknown field"},
+		{"old action field", []byte(`{"action":"updated","key":"k","version":1}`), "unknown field"},
 	}
 
 	for _, tt := range tests {
@@ -130,7 +132,7 @@ func TestService_HandleEntryDeleted_InvalidPayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewService(slog.Default())
-			require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("existing.key", "existing-value", 1)))
+			require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("existing.key", 1)))
 
 			entry := outbox.Entry{ID: "bad-delete", Topic: TopicConfigEntryDeleted, Payload: tt.payload}
 			err := svc.HandleEntryDeleted(context.Background(), entry)
@@ -139,9 +141,8 @@ func TestService_HandleEntryDeleted_InvalidPayload(t *testing.T) {
 			var permErr *outbox.PermanentError
 			require.ErrorAs(t, err, &permErr)
 			assert.Equal(t, 1, svc.Cache().Len(), "cache must be unchanged after invalid delete")
-			v, ok := svc.Cache().Get("existing.key")
+			_, ok := svc.Cache().GetVersion("existing.key")
 			require.True(t, ok)
-			assert.Equal(t, "existing-value", v)
 		})
 	}
 }
@@ -157,11 +158,16 @@ func TestWrapLegacyHandler_InvalidPayload_Reject(t *testing.T) {
 	assert.Error(t, result.Err)
 }
 
-func TestWrapLegacyHandler_MissingValue_Reject(t *testing.T) {
+func TestWrapLegacyHandler_ValueFieldPresent_Reject(t *testing.T) {
 	svc := NewService(slog.Default())
 	handler := outbox.WrapLegacyHandler(svc.HandleEntryUpserted)
 
-	entry := outbox.Entry{ID: "bad", Topic: TopicConfigEntryUpserted, Payload: []byte(`{"key":"k","version":1}`)}
+	// Old wire format with value field — must be rejected
+	entry := outbox.Entry{
+		ID:      "bad",
+		Topic:   TopicConfigEntryUpserted,
+		Payload: []byte(`{"key":"k","value":"some-value","version":1}`),
+	}
 	result := handler(context.Background(), entry)
 
 	assert.Equal(t, outbox.DispositionReject, result.Disposition)

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	configevents "github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,7 @@ import (
 // makeEntryUpserted builds a metadata-only outbox.Entry for entry-upserted.
 // The payload carries only key+version — no value field.
 func makeEntryUpserted(key string, version int) outbox.Entry {
-	payload, _ := json.Marshal(domain.ConfigEntryUpsertedEvent{
+	payload, _ := json.Marshal(configevents.EntryUpserted{
 		Key:     key,
 		Version: version,
 	})
@@ -23,7 +24,7 @@ func makeEntryUpserted(key string, version int) outbox.Entry {
 }
 
 func makeEntryDeleted(key string) outbox.Entry {
-	payload, _ := json.Marshal(domain.ConfigEntryDeletedEvent{Key: key})
+	payload, _ := json.Marshal(configevents.EntryDeleted{Key: key})
 	return outbox.Entry{ID: "test-delete", Topic: domain.TopicConfigEntryDeleted, Payload: payload}
 }
 

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -23,8 +23,9 @@ func makeEntryUpserted(key string, version int) outbox.Entry {
 	return outbox.Entry{ID: "test-upsert", Topic: domain.TopicConfigEntryUpserted, Payload: payload}
 }
 
-func makeEntryDeleted(key string) outbox.Entry {
-	payload, _ := json.Marshal(configevents.EntryDeleted{Key: key})
+// makeEntryDeleted builds an outbox.Entry for entry-deleted with the given version.
+func makeEntryDeleted(key string, version int) outbox.Entry {
+	payload, _ := json.Marshal(configevents.EntryDeleted{Key: key, Version: version})
 	return outbox.Entry{ID: "test-delete", Topic: domain.TopicConfigEntryDeleted, Payload: payload}
 }
 
@@ -34,6 +35,7 @@ func TestService_HandleEntryUpserted(t *testing.T) {
 		events      []outbox.Entry
 		wantKey     string
 		wantVersion int
+		wantPresent bool
 		wantLen     int
 	}{
 		{
@@ -41,6 +43,7 @@ func TestService_HandleEntryUpserted(t *testing.T) {
 			events:      []outbox.Entry{makeEntryUpserted("app.name", 1)},
 			wantKey:     "app.name",
 			wantVersion: 1,
+			wantPresent: true,
 			wantLen:     1,
 		},
 		{
@@ -51,6 +54,7 @@ func TestService_HandleEntryUpserted(t *testing.T) {
 			},
 			wantKey:     "k",
 			wantVersion: 2,
+			wantPresent: true,
 			wantLen:     1,
 		},
 		{
@@ -58,6 +62,7 @@ func TestService_HandleEntryUpserted(t *testing.T) {
 			events:      []outbox.Entry{makeEntryUpserted("timeout", 5)},
 			wantKey:     "timeout",
 			wantVersion: 5,
+			wantPresent: true,
 			wantLen:     1,
 		},
 	}
@@ -72,7 +77,7 @@ func TestService_HandleEntryUpserted(t *testing.T) {
 
 			assert.Equal(t, tt.wantLen, svc.Cache().Len())
 			v, ok := svc.Cache().GetVersion(tt.wantKey)
-			require.True(t, ok)
+			require.Equal(t, tt.wantPresent, ok)
 			assert.Equal(t, tt.wantVersion, v)
 		})
 	}
@@ -96,20 +101,106 @@ func TestService_HandleEntryUpserted_Monotonicity(t *testing.T) {
 func TestService_HandleEntryDeleted(t *testing.T) {
 	svc := NewService(slog.Default())
 	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 1)))
-	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k")))
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k", 2)))
 
+	// Len counts only active entries; after delete, Len must be 0.
 	assert.Equal(t, 0, svc.Cache().Len())
-	_, ok := svc.Cache().GetVersion("k")
-	assert.False(t, ok)
+	// GetVersion still returns the tombstone version, but present=false.
+	v, present := svc.Cache().GetVersion("k")
+	assert.False(t, present, "tombstoned key must return present=false")
+	assert.Equal(t, 2, v, "tombstone must record the delete version")
 }
 
 // TestService_HandleEntryDeleted_NonExistentKey verifies that deleting a key that
-// was never seen is a no-op (idempotent) and does not error.
+// was never seen records a tombstone and does not error.
 func TestService_HandleEntryDeleted_NonExistentKey(t *testing.T) {
 	svc := NewService(slog.Default())
 
-	// No prior upsert — delete should succeed silently.
-	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("nonexistent")))
+	// No prior upsert — delete must still succeed and record a tombstone.
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("nonexistent", 1)))
+	assert.Equal(t, 0, svc.Cache().Len())
+	v, present := svc.Cache().GetVersion("nonexistent")
+	assert.False(t, present)
+	assert.Equal(t, 1, v)
+}
+
+// TestService_Tombstone_ReplayedOlderUpsertRejected verifies the core protection:
+// upsert v1 → delete v2 → replayed upsert v1 → cache stays tombstoned at v2.
+func TestService_Tombstone_ReplayedOlderUpsertRejected(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 1)))
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k", 2)))
+	// Replayed older upsert must be rejected.
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 1)))
+
+	v, present := svc.Cache().GetVersion("k")
+	assert.False(t, present, "replayed upsert must not resurrect a tombstoned key")
+	assert.Equal(t, 2, v, "tombstone version must not be overwritten by stale upsert")
+	assert.Equal(t, 0, svc.Cache().Len())
+}
+
+// TestService_Tombstone_ReplayedOlderDeleteRejected verifies symmetric replay
+// protection on the delete side: upsert v3 → delete v2 (stale) → cache stays
+// active at v3.
+func TestService_Tombstone_ReplayedOlderDeleteRejected(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 3)))
+	// Stale delete with older version must be dropped.
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k", 2)))
+
+	v, present := svc.Cache().GetVersion("k")
+	assert.True(t, present, "stale delete must not tombstone a newer active entry")
+	assert.Equal(t, 3, v)
+	assert.Equal(t, 1, svc.Cache().Len())
+}
+
+// TestService_Tombstone_DeleteThenHigherUpsertRestores verifies the recovery
+// path: delete v2 → upsert v3 → cache becomes active at v3.
+func TestService_Tombstone_DeleteThenHigherUpsertRestores(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 1)))
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k", 2)))
+	// A new upsert with version > tombstone restores the entry.
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 3)))
+
+	v, present := svc.Cache().GetVersion("k")
+	assert.True(t, present, "upsert after delete with higher version must restore entry")
+	assert.Equal(t, 3, v)
+	assert.Equal(t, 1, svc.Cache().Len())
+}
+
+// TestService_GetVersion_AfterDelete_ReturnsTombstoneVersion explicitly asserts
+// the tombstone semantics of GetVersion: present=false, version=tombstone version.
+// The delete event carries the same version as the last upsert (normal producer path).
+func TestService_GetVersion_AfterDelete_ReturnsTombstoneVersion(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 5)))
+	// Normal delete: version equals the last upsert version (V >= known → accepted).
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k", 5)))
+
+	v, present := svc.Cache().GetVersion("k")
+	assert.False(t, present, "GetVersion must return present=false after delete")
+	assert.Equal(t, 5, v, "GetVersion must return the tombstone version")
+}
+
+// TestService_Tombstone_SameVersionDeleteAccepted verifies that a delete event
+// carrying the same version as the last upsert is accepted and tombstones the entry.
+// This is the normal producer path: Delete returns the row's current version, so
+// the delete event version == last upsert version.
+func TestService_Tombstone_SameVersionDeleteAccepted(t *testing.T) {
+	svc := NewService(slog.Default())
+
+	require.NoError(t, svc.HandleEntryUpserted(context.Background(), makeEntryUpserted("k", 3)))
+	// delete at same version as existing upsert: V >= known → accepted as tombstone.
+	require.NoError(t, svc.HandleEntryDeleted(context.Background(), makeEntryDeleted("k", 3)))
+
+	v, present := svc.Cache().GetVersion("k")
+	assert.False(t, present, "same-version delete must tombstone the entry")
+	assert.Equal(t, 3, v)
 	assert.Equal(t, 0, svc.Cache().Len())
 }
 
@@ -151,8 +242,10 @@ func TestService_HandleEntryDeleted_InvalidPayload(t *testing.T) {
 		wantErr string
 	}{
 		{"invalid json", []byte("not-json"), "unmarshal"},
-		{"missing key", []byte(`{}`), "missing key"},
-		{"extra value field", []byte(`{"key":"existing.key","value":"old"}`), "unknown field"},
+		{"missing key", []byte(`{"version":1}`), "missing key"},
+		{"missing version", []byte(`{"key":"existing.key"}`), "invalid version"},
+		{"version zero", []byte(`{"key":"existing.key","version":0}`), "invalid version"},
+		{"extra value field", []byte(`{"key":"existing.key","value":"old","version":1}`), "unknown field"},
 	}
 
 	for _, tt := range tests {

--- a/cells/configcore/slices/configwrite/contract_test.go
+++ b/cells/configcore/slices/configwrite/contract_test.go
@@ -171,7 +171,12 @@ func TestEventConfigEntryDeletedV1Publish_Delete(t *testing.T) {
 	assert.Equal(t, domain.TopicConfigEntryDeleted, entry.EventType)
 	c.ValidatePayload(t, entry.Payload)
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
+
+	// Negative cases: missing required fields or invalid version.
 	c.MustRejectPayload(t, []byte(`{}`))
 	c.MustRejectPayload(t, []byte(`{"key":""}`))
 	c.MustRejectPayload(t, []byte(`{"key":"   "}`))
+	c.MustRejectPayload(t, []byte(`{"key":"k"}`))                           // missing version
+	c.MustRejectPayload(t, []byte(`{"key":"k","version":0}`))               // invalid version
+	c.MustRejectPayload(t, []byte(`{"key":"k","version":1,"value":"old"}`)) // extra field
 }

--- a/cells/configcore/slices/configwrite/contract_test.go
+++ b/cells/configcore/slices/configwrite/contract_test.go
@@ -124,12 +124,14 @@ func TestEventConfigEntryUpsertedV1Publish_Create(t *testing.T) {
 	assert.Equal(t, domain.TopicConfigEntryUpserted, entry.EventType)
 	c.ValidatePayload(t, entry.Payload)
 	c.ValidateHeaders(t, []byte(`{"event_id":"`+entry.ID+`"}`))
-	c.MustRejectPayload(t, []byte(`{"key":"app.name","version":1}`))
-	c.MustRejectPayload(t, []byte(`{"key":"app.name","value":"myapp"}`))
-	c.MustRejectPayload(t, []byte(`{"key":"","value":"myapp","version":1}`))
-	c.MustRejectPayload(t, []byte(`{"key":"   ","value":"myapp","version":1}`))
-	c.MustRejectPayload(t, []byte(`{"key":"app.name","value":"myapp","version":0}`))
-	c.ValidatePayload(t, []byte(`{"key":"app.name","value":"","version":1}`))
+	// Metadata-only: missing version must be rejected; value field must be rejected.
+	c.MustRejectPayload(t, []byte(`{"key":"app.name"}`))
+	c.MustRejectPayload(t, []byte(`{"version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"","version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"   ","version":1}`))
+	c.MustRejectPayload(t, []byte(`{"key":"app.name","version":0}`))
+	// value field is now forbidden (additionalProperties: false)
+	c.MustRejectPayload(t, []byte(`{"key":"app.name","value":"myapp","version":1}`))
 	c.MustRejectHeaders(t, []byte(`{}`))
 }
 

--- a/cells/configcore/slices/configwrite/handler_test.go
+++ b/cells/configcore/slices/configwrite/handler_test.go
@@ -269,7 +269,11 @@ func TestHandler_HandleUpdate_SensitiveRedacted(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "new-secret")
 }
 
-func TestService_Create_SensitiveEventPayloadRedacted(t *testing.T) {
+// TestService_Create_SensitiveEventPayloadMetadataOnly verifies that the event
+// payload for a sensitive entry carries only metadata (key+version) — no value
+// field at all. Metadata-only model eliminates redaction entirely by not
+// including the value in the event. Subscribers must refetch via GET /api/v1/config/{key}.
+func TestService_Create_SensitiveEventPayloadMetadataOnly(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	ow := &stubOutboxWriter{}
 	svc := NewService(repo, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
@@ -282,9 +286,10 @@ func TestService_Create_SensitiveEventPayloadRedacted(t *testing.T) {
 	require.Len(t, ow.entries, 1)
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(ow.entries[0].Payload, &payload))
-	assert.Equal(t, "******", payload["value"], "sensitive value must be redacted in event payload")
-	assert.NotEqual(t, "s3cret!", payload["value"])
+	assert.NotContains(t, payload, "value", "metadata-only event must not contain value field")
 	assert.NotContains(t, payload, "sensitive", "state-sync events must not expose sensitive classification")
+	assert.Equal(t, "db.password", payload["key"])
+	assert.Equal(t, float64(1), payload["version"])
 }
 
 // --- outbox/tx service tests ---

--- a/cells/configcore/slices/configwrite/service.go
+++ b/cells/configcore/slices/configwrite/service.go
@@ -166,7 +166,10 @@ func (s *Service) publishUpserted(ctx context.Context, entry *domain.ConfigEntry
 }
 
 func (s *Service) publishDeleted(ctx context.Context, entry *domain.ConfigEntry) error {
+	// Metadata-only: event carries key+version of the deleted entry.
+	// Subscribers use version for monotonic tombstone protection against stale upsert replays.
 	return outbox.Emit(ctx, s.emitter, domain.TopicConfigEntryDeleted, configevents.EntryDeleted{
-		Key: entry.Key,
+		Key:     entry.Key,
+		Version: entry.Version,
 	})
 }

--- a/cells/configcore/slices/configwrite/service.go
+++ b/cells/configcore/slices/configwrite/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	configevents "github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/cells/configcore/internal/ports"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
@@ -158,14 +159,14 @@ func (s *Service) publishUpserted(ctx context.Context, entry *domain.ConfigEntry
 	// Metadata-only: event carries key+version only.
 	// Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
 	// ref: NATS subject+bytes / Watermill payload-bytes boundary.
-	return outbox.Emit(ctx, s.emitter, domain.TopicConfigEntryUpserted, domain.ConfigEntryUpsertedEvent{
+	return outbox.Emit(ctx, s.emitter, domain.TopicConfigEntryUpserted, configevents.EntryUpserted{
 		Key:     entry.Key,
 		Version: entry.Version,
 	})
 }
 
 func (s *Service) publishDeleted(ctx context.Context, entry *domain.ConfigEntry) error {
-	return outbox.Emit(ctx, s.emitter, domain.TopicConfigEntryDeleted, domain.ConfigEntryDeletedEvent{
+	return outbox.Emit(ctx, s.emitter, domain.TopicConfigEntryDeleted, configevents.EntryDeleted{
 		Key: entry.Key,
 	})
 }

--- a/cells/configcore/slices/configwrite/service.go
+++ b/cells/configcore/slices/configwrite/service.go
@@ -155,13 +155,11 @@ func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) erro
 }
 
 func (s *Service) publishUpserted(ctx context.Context, entry *domain.ConfigEntry) error {
-	eventValue := entry.Value
-	if entry.Sensitive {
-		eventValue = "******"
-	}
+	// Metadata-only: event carries key+version only.
+	// Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
+	// ref: NATS subject+bytes / Watermill payload-bytes boundary.
 	return outbox.Emit(ctx, s.emitter, domain.TopicConfigEntryUpserted, domain.ConfigEntryUpsertedEvent{
 		Key:     entry.Key,
-		Value:   eventValue,
 		Version: entry.Version,
 	})
 }

--- a/cells/configcore/slices/configwrite/service_test.go
+++ b/cells/configcore/slices/configwrite/service_test.go
@@ -2,12 +2,14 @@ package configwrite
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	"github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -224,6 +226,16 @@ func TestService_Create_DurableMode_CapturesOutboxEntry(t *testing.T) {
 	assert.Equal(t, "k", entry.Key)
 	require.Len(t, writer.Entries, 1)
 	assert.Equal(t, domain.TopicConfigEntryUpserted, writer.Entries[0].EventType)
+
+	// F-TEST-02: assert payload is metadata-only — no "value" field.
+	decoded, decErr := events.DecodeEntryUpserted(writer.Entries[0].Payload)
+	require.NoError(t, decErr, "outbox payload must decode as valid entry-upserted")
+	assert.Equal(t, "k", decoded.Key)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &raw))
+	_, hasValue := raw["value"]
+	assert.False(t, hasValue, "entry-upserted payload must NOT contain 'value' field (metadata-only)")
 }
 
 // TestCreate_CallsTxRunnerRunInTxOnce asserts that Create wraps both the repo

--- a/cells/configcore/slices/flagwrite/contract_test.go
+++ b/cells/configcore/slices/flagwrite/contract_test.go
@@ -2,7 +2,6 @@ package flagwrite
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +11,6 @@ import (
 	"github.com/ghbvf/gocell/cells/configcore/internal/dto"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/cells/configcore/internal/testutil"
-	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/contracttest"
@@ -42,9 +40,8 @@ func newContractMux(svc *Service) http.Handler {
 func newContractService(t *testing.T) *Service {
 	t.Helper()
 	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
+		WithTxManager(&testutil.NoopTxRunner{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,39 +175,6 @@ func TestHttpConfigFlagsDeleteV1Serve(t *testing.T) {
 	req = req.WithContext(auth.TestContext(testAdminSubject, []string{dto.RoleAdmin}))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body)
-}
-
-// --- Event contract test ---
-
-func TestEventFlagChangedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
-	c := contracttest.LoadByID(t, root, "event.flag.changed.v1")
-
-	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
-	require.NoError(t, err)
-
-	_, err = svc.Create(testAdminCtx(), CreateInput{Key: "event-flag", Enabled: true, Description: "ev"})
-	require.NoError(t, err)
-
-	require.Len(t, writer.Entries, 1)
-	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
-
-	c.ValidatePayload(t, writer.Entries[0].Payload)
-	assert.Equal(t, "created", payload.Action)
-	assert.Equal(t, "event-flag", payload.Key)
-
-	// Contract invariant: payload.eventId must equal the transport-level
-	// envelope identifier (outbox.Entry.ID) because headers.event_id —
-	// declared idempotencyKey in contract.yaml — is carried via Entry.ID.
-	// Two independent UUIDs here would let headers-based idempotency drift
-	// from payload-based inspection. See headers.schema.json description.
-	assert.Equal(t, writer.Entries[0].ID, payload.EventID,
-		"contract drift: payload.eventId must mirror outbox.Entry.ID so "+
-			"headers.event_id (idempotencyKey) is coherent across envelope and body")
 }
 
 func testAdminCtx() context.Context {

--- a/cells/configcore/slices/flagwrite/ctx_cancel_test.go
+++ b/cells/configcore/slices/flagwrite/ctx_cancel_test.go
@@ -3,7 +3,6 @@ package flagwrite
 import (
 	"context"
 	"errors"
-	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 
@@ -42,14 +41,11 @@ var _ persistence.TxRunner = (*cancellingTxRunner)(nil)
 // the context without calling fn:
 //  1. Service.Create returns context.Canceled.
 //  2. The in-memory repo has no entry for the key (rollback side-effect absent).
-//  3. The outbox writer received no entries.
 func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
 	txRunner := &cancellingTxRunner{}
 
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(txRunner))
+	svc, err := NewService(repo, slog.Default(), WithTxManager(txRunner))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{
@@ -68,9 +64,6 @@ func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 	require.ErrorAs(t, repoErr, &ecErr)
 	assert.Equal(t, errcode.ErrFlagNotFound, ecErr.Code,
 		"ErrFlagNotFound expected — flag must not persist after ctx cancel rollback")
-
-	// Verify outbox has no durable entries.
-	assert.Empty(t, writer.Entries, "outbox must have no entries after rollback")
 }
 
 // TestFlagWrite_Toggle_CtxCancel_ReturnsError verifies Toggle propagates
@@ -78,17 +71,14 @@ func TestFlagWrite_CtxCancel_RollsBackTx(t *testing.T) {
 func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
 	// Seed a flag so Toggle reaches the RunInTx call.
-	writer := &testutil.RecordingWriter{}
-	seedSvc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
+	seedSvc, err := NewService(repo, slog.Default(), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{Key: "toggle-cancel"})
 	require.NoError(t, err)
 
 	// Now create a service with the cancelling tx runner.
 	cancelTx := &cancellingTxRunner{}
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{})), WithTxManager(cancelTx))
+	svc, err := NewService(repo, slog.Default(), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Toggle(context.Background(), "toggle-cancel", true)
@@ -105,9 +95,7 @@ func TestFlagWrite_Toggle_CtxCancel_ReturnsError(t *testing.T) {
 // context cancellation and leaves the flag unchanged.
 func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
-	seedSvc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
+	seedSvc, err := NewService(repo, slog.Default(), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{
 		Key:         "update-cancel",
@@ -116,8 +104,7 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 	require.NoError(t, err)
 
 	cancelTx := &cancellingTxRunner{}
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{})), WithTxManager(cancelTx))
+	svc, err := NewService(repo, slog.Default(), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	_, err = svc.Update(context.Background(), UpdateInput{
@@ -139,16 +126,13 @@ func TestFlagWrite_Update_CtxCancel_ReturnsError(t *testing.T) {
 // context cancellation and leaves the flag in the repo.
 func TestFlagWrite_Delete_CtxCancel_ReturnsError(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
-	seedSvc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
+	seedSvc, err := NewService(repo, slog.Default(), WithTxManager(&testutil.NoopTxRunner{}))
 	require.NoError(t, err)
 	_, err = seedSvc.Create(context.Background(), CreateInput{Key: "delete-cancel"})
 	require.NoError(t, err)
 
 	cancelTx := &cancellingTxRunner{}
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{})), WithTxManager(cancelTx))
+	svc, err := NewService(repo, slog.Default(), WithTxManager(cancelTx))
 	require.NoError(t, err)
 
 	err = svc.Delete(context.Background(), "delete-cancel")

--- a/cells/configcore/slices/flagwrite/service.go
+++ b/cells/configcore/slices/flagwrite/service.go
@@ -1,77 +1,48 @@
 // Package flagwrite implements the flag-write slice: Create/Update/Delete/Toggle
-// feature flags with transactional outbox event publishing (L2 consistency).
+// feature flags with transactional repo writes (L1 consistency).
 //
-// L2 OutboxFact: repo writes + outbox writes are wrapped in a single RunInTx
-// per operation. Failure in either rolls back both.
+// L1 LocalTx: repo writes are wrapped in a single RunInTx per operation.
+// Failure rolls back the transaction.
 //
-// ref: Unleash src/lib/db/feature-environment-store.ts — "write + event must
-// be in the same transaction" (Unleash lesson: splitting them caused data loss).
+// event.flag.changed.v1 was retired by PR-CFG-B (2026-04-25): the contract
+// never had a subscriber, so emitting it was dead work. The contract is now
+// lifecycle: deprecated. Flag write is downgraded to L1.
 package flagwrite
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/cells/configcore/internal/ports"
-	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/google/uuid"
 )
 
-// TopicFlagChanged is the outbox event topic for flag change events.
-const TopicFlagChanged = domain.TopicFlagChanged
-
-// FlagChangedPayload is the typed event payload for flag.changed.v1.
-// JSON keys are camelCase per GoCell event payload convention.
-type FlagChangedPayload struct {
-	EventID    string    `json:"eventId"`
-	Action     string    `json:"action"`
-	Key        string    `json:"key"`
-	Enabled    bool      `json:"enabled"`
-	Version    int       `json:"version"`
-	OccurredAt time.Time `json:"occurredAt"`
-}
-
 // Option configures a flag-write Service.
 type Option func(*Service)
 
-// WithEmitter sets the event emitter.
-func WithEmitter(e outbox.Emitter) Option {
-	return func(s *Service) {
-		if e != nil {
-			s.emitter = e
-		}
-	}
-}
-
-// WithTxManager sets the TxRunner for transactional guarantees (L2 atomicity).
+// WithTxManager sets the TxRunner for transactional guarantees (L1 atomicity).
 func WithTxManager(tx persistence.TxRunner) Option {
 	return func(s *Service) { s.txRunner = persistence.RunnerOrNoop(tx) }
 }
 
-// Service implements flag write business logic (L2 OutboxFact).
+// Service implements flag write business logic (L1 LocalTx).
 type Service struct {
 	repo     ports.FlagRepository
 	txRunner persistence.TxRunner
-	emitter  outbox.Emitter
 	logger   *slog.Logger
 }
 
 // NewService creates a flag-write Service.
-// Cell wiring decides whether the injected emitter/runner pair is backed by a
-// durable outbox path or by demo defaults; the service always runs through the
-// same TxRunner + Emitter abstractions.
 func NewService(repo ports.FlagRepository, logger *slog.Logger, opts ...Option) (*Service, error) {
 	s := &Service{
 		repo:     repo,
 		txRunner: persistence.NoopTxRunner{},
-		emitter:  outbox.NewNoopEmitter(),
 		logger:   logger,
 	}
 	for _, o := range opts {
@@ -96,7 +67,7 @@ type UpdateInput struct {
 	Description       string
 }
 
-// Create creates a new feature flag and emits flag.changed.v1 (action=created).
+// Create creates a new feature flag (L1 LocalTx).
 func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.FeatureFlag, error) {
 	if err := validation.RequireNotBlank(errcode.ErrFlagInvalidInput,
 		validation.F("key", input.Key),
@@ -120,7 +91,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.Featur
 		if err := s.repo.Create(txCtx, flag); err != nil {
 			return fmt.Errorf("flag-write: create: %w", err)
 		}
-		return s.emitFlagChanged(txCtx, "created", flag)
+		return nil
 	}); err != nil {
 		return nil, err
 	}
@@ -129,7 +100,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.Featur
 	return flag, nil
 }
 
-// Update modifies an existing feature flag and emits flag.changed.v1 (action=updated).
+// Update modifies an existing feature flag (L1 LocalTx).
 // The repo UPDATE uses version=version+1 RETURNING to eliminate the read-modify-write
 // TOCTOU race: two concurrent Updates both see the same DB-authoritative version.
 func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.FeatureFlag, error) {
@@ -147,7 +118,7 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.Featur
 		if err != nil {
 			return fmt.Errorf("flag-write: update: %w", err)
 		}
-		return s.emitFlagChanged(txCtx, "updated", updated)
+		return nil
 	}); err != nil {
 		return nil, err
 	}
@@ -158,7 +129,7 @@ func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.Featur
 	return updated, nil
 }
 
-// Toggle toggles the enabled state of a feature flag and emits flag.changed.v1 (action=toggled).
+// Toggle toggles the enabled state of a feature flag (L1 LocalTx).
 // Toggle does not overwrite rollout_percentage or description.
 func (s *Service) Toggle(ctx context.Context, key string, enabled bool) (*domain.FeatureFlag, error) {
 	if err := validation.RequireNotBlank(errcode.ErrFlagInvalidInput,
@@ -175,7 +146,7 @@ func (s *Service) Toggle(ctx context.Context, key string, enabled bool) (*domain
 		if err != nil {
 			return fmt.Errorf("flag-write: toggle: %w", err)
 		}
-		return s.emitFlagChanged(txCtx, "toggled", updated)
+		return nil
 	}); err != nil {
 		return nil, err
 	}
@@ -186,7 +157,7 @@ func (s *Service) Toggle(ctx context.Context, key string, enabled bool) (*domain
 	return updated, nil
 }
 
-// Delete removes a feature flag and emits flag.changed.v1 (action=deleted).
+// Delete removes a feature flag (L1 LocalTx).
 // The repo DELETE uses RETURNING to obtain the deleted entity atomically, eliminating
 // the read-before-delete TOCTOU race where a concurrent Update could change the
 // flag between GetByKey and DELETE.
@@ -198,11 +169,10 @@ func (s *Service) Delete(ctx context.Context, key string) error {
 	}
 
 	if err := s.runInTx(ctx, func(txCtx context.Context) error {
-		deleted, err := s.repo.Delete(txCtx, key)
-		if err != nil {
+		if _, err := s.repo.Delete(txCtx, key); err != nil {
 			return fmt.Errorf("flag-write: delete: %w", err)
 		}
-		return s.emitFlagChanged(txCtx, "deleted", deleted)
+		return nil
 	}); err != nil {
 		return err
 	}
@@ -213,41 +183,4 @@ func (s *Service) Delete(ctx context.Context, key string) error {
 
 func (s *Service) runInTx(ctx context.Context, fn func(ctx context.Context) error) error {
 	return s.txRunner.RunInTx(ctx, fn)
-}
-
-func (s *Service) emitFlagChanged(ctx context.Context, action string, flag *domain.FeatureFlag) error {
-	// Single event identifier shared by both the transport envelope and the
-	// payload body. headers.event_id (contract idempotency key) is carried in
-	// outbox.Entry.ID at the transport level; payload.eventId mirrors it so
-	// legacy consumers that read the body see the same value. Two parallel
-	// UUIDs here would drift, making headers-based idempotency inconsistent
-	// with payload-based inspection.
-	//
-	// ref: Watermill message/router.go handleMessage — message.UUID is the
-	// single identity threaded through publisher, middleware, and consumer.
-	// ref: contracts/event/session/created/v1/headers.schema.json — same
-	// convention ("event_id is carried in outbox.Entry.ID at the transport
-	// level"), now applied uniformly to flag.changed.v1.
-	eventID := outbox.NewEntryID()
-	payload, err := json.Marshal(FlagChangedPayload{
-		EventID:    eventID,
-		Action:     action,
-		Key:        flag.Key,
-		Enabled:    flag.Enabled,
-		Version:    flag.Version,
-		OccurredAt: time.Now(),
-	})
-	if err != nil {
-		return fmt.Errorf("flag-write: marshal flag.changed.v1 payload: %w", err)
-	}
-
-	entry := outbox.Entry{
-		ID:        eventID,
-		EventType: TopicFlagChanged,
-		Payload:   payload,
-	}
-	if err := s.emitter.Emit(ctx, entry); err != nil {
-		return fmt.Errorf("flag-write: emit event: %w", err)
-	}
-	return nil
 }

--- a/cells/configcore/slices/flagwrite/service_test.go
+++ b/cells/configcore/slices/flagwrite/service_test.go
@@ -2,9 +2,7 @@ package flagwrite
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
 	"time"
@@ -32,17 +30,15 @@ var _ persistence.TxRunner = (*failingTxRunner)(nil)
 
 // --- helpers ---
 
-func newDurableTestService(t *testing.T) (*Service, *mem.FlagRepository, *testutil.RecordingWriter) {
+func newTestService(t *testing.T) (*Service, *mem.FlagRepository) {
 	t.Helper()
 	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
 	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)),
 		WithTxManager(&testutil.NoopTxRunner{}))
 	if err != nil {
 		t.Fatal(err)
 	}
-	return svc, repo, writer
+	return svc, repo
 }
 
 func seedFlag(t *testing.T, repo *mem.FlagRepository, key string) *domain.FeatureFlag {
@@ -61,7 +57,7 @@ func seedFlag(t *testing.T, repo *mem.FlagRepository, key string) *domain.Featur
 	return flag
 }
 
-// --- Test: XOR violation guard ---
+// --- Test: constructor ---
 
 // TestNewService_AllowsHalfWiredDemoPath verifies that service construction no
 // longer uses nil-mode coupling; Cell wiring owns durable-mode validation.
@@ -70,8 +66,8 @@ func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"only_emitter", []Option{WithEmitter(testoutbox.MustEmitter(t, &testutil.RecordingWriter{}))}},
 		{"only_tx_runner", []Option{WithTxManager(&testutil.NoopTxRunner{})}},
+		{"no_opts", []Option{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -83,14 +79,12 @@ func TestNewService_AllowsHalfWiredDemoPath(t *testing.T) {
 
 // --- Test: Create atomicity ---
 
-// TestFlagWrite_Create_Atomic_RepoAndOutbox verifies that Create writes repo +
-// outbox in a single tx; repo failure also prevents outbox write.
-func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
+// TestFlagWrite_Create_Atomic_RepoInTx verifies that Create writes repo
+// inside a single tx; repo failure propagates correctly.
+func TestFlagWrite_Create_Atomic_RepoInTx(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
 	tx := &testutil.NoopTxRunner{}
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
+	svc, err := NewService(repo, slog.Default(), WithTxManager(tx))
 	require.NoError(t, err)
 
 	flag, err := svc.Create(context.Background(), CreateInput{
@@ -100,25 +94,18 @@ func TestFlagWrite_Create_Atomic_RepoAndOutbox(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my-flag", flag.Key)
 	assert.Equal(t, 1, tx.Calls, "Create must call RunInTx exactly once")
-	require.Len(t, writer.Entries, 1)
-	assert.Equal(t, TopicFlagChanged, writer.Entries[0].EventType)
+
+	// Flag must be persisted in repo.
+	got, err := repo.GetByKey(context.Background(), "my-flag")
+	require.NoError(t, err)
+	assert.Equal(t, "my-flag", got.Key)
 }
 
-// TestFlagWrite_Create_RepoFails_NoOutboxWrite verifies that a tx-level
-// failure propagates as an error to the caller.
-//
-// Scope note: the in-memory recordingWriter has no transaction-aware
-// rollback — it records every Write call unconditionally. This test
-// therefore exercises only the error-propagation path; the "outbox is not
-// durable when tx rolls back" invariant is verified at the L2 durability
-// boundary by PG integration tests that run against a real database
-// where Write inside a rolled-back tx is genuinely discarded.
-func TestFlagWrite_RepoFails_NoOutboxWrite(t *testing.T) {
+// TestFlagWrite_Create_RepoFails propagates tx-level failures to the caller.
+func TestFlagWrite_Create_RepoFails(t *testing.T) {
 	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{}
 	tx := &failingTxRunner{failErr: errors.New("tx commit failed")}
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(tx))
+	svc, err := NewService(repo, slog.Default(), WithTxManager(tx))
 	require.NoError(t, err)
 
 	_, err = svc.Create(context.Background(), CreateInput{Key: "k"})
@@ -126,34 +113,24 @@ func TestFlagWrite_RepoFails_NoOutboxWrite(t *testing.T) {
 	assert.Contains(t, err.Error(), "tx commit failed")
 }
 
-// --- Test: Toggle emits flag.changed.v1 ---
+// --- Test: Toggle business result ---
 
-// TestFlagWrite_Toggle_EmitsFlagChangedEvent verifies Toggle writes
-// outbox with action=toggled payload.
-func TestFlagWrite_Toggle_EmitsFlagChangedEvent(t *testing.T) {
-	svc, repo, writer := newDurableTestService(t)
+// TestFlagWrite_Toggle_TogglesFlag verifies Toggle sets the correct enabled state.
+func TestFlagWrite_Toggle_TogglesFlag(t *testing.T) {
+	svc, repo := newTestService(t)
 	seedFlag(t, repo, "feature-x")
 
 	flag, err := svc.Toggle(context.Background(), "feature-x", true)
 	require.NoError(t, err)
 	assert.True(t, flag.Enabled)
-
-	require.Len(t, writer.Entries, 1)
-	assert.Equal(t, TopicFlagChanged, writer.Entries[0].EventType)
-
-	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
-	assert.Equal(t, "toggled", payload.Action)
-	assert.Equal(t, "feature-x", payload.Key)
-	assert.True(t, payload.Enabled)
+	assert.Equal(t, "feature-x", flag.Key)
 }
 
-// --- Test: Update emits flag.changed.v1 ---
+// --- Test: Update business result ---
 
-// TestFlagWrite_Update_EmitsFlagChangedEvent verifies Update outbox payload
-// has action=updated.
-func TestFlagWrite_Update_EmitsFlagChangedEvent(t *testing.T) {
-	svc, repo, writer := newDurableTestService(t)
+// TestFlagWrite_Update_UpdatesFlag verifies Update modifies the flag fields.
+func TestFlagWrite_Update_UpdatesFlag(t *testing.T) {
+	svc, repo := newTestService(t)
 	seedFlag(t, repo, "feat-update")
 
 	flag, err := svc.Update(context.Background(), UpdateInput{
@@ -164,42 +141,30 @@ func TestFlagWrite_Update_EmitsFlagChangedEvent(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "feat-update", flag.Key)
-
-	require.Len(t, writer.Entries, 1)
-	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
-	assert.Equal(t, "updated", payload.Action)
-	assert.Equal(t, "feat-update", payload.Key)
+	assert.True(t, flag.Enabled)
+	assert.Equal(t, 50, flag.RolloutPercentage)
+	assert.Equal(t, "updated desc", flag.Description)
 }
 
-// --- Test: Delete emits flag.changed.v1 ---
+// --- Test: Delete business result ---
 
-// TestFlagWrite_Delete_EmitsFlagChangedEvent verifies Delete outbox payload
-// has action=deleted.
-func TestFlagWrite_Delete_EmitsFlagChangedEvent(t *testing.T) {
-	svc, repo, writer := newDurableTestService(t)
+// TestFlagWrite_Delete_RemovesFlag verifies Delete removes the flag from repo.
+func TestFlagWrite_Delete_RemovesFlag(t *testing.T) {
+	svc, repo := newTestService(t)
 	seedFlag(t, repo, "feat-delete")
 
 	err := svc.Delete(context.Background(), "feat-delete")
 	require.NoError(t, err)
 
-	require.Len(t, writer.Entries, 1)
-	var payload FlagChangedPayload
-	require.NoError(t, json.Unmarshal(writer.Entries[0].Payload, &payload))
-	assert.Equal(t, "deleted", payload.Action)
-	assert.Equal(t, "feat-delete", payload.Key)
+	_, getErr := repo.GetByKey(context.Background(), "feat-delete")
+	require.Error(t, getErr, "flag must be removed after Delete")
 }
 
-// --- Test: outbox write failure propagates ---
+// --- Test: validation ---
 
-func TestFlagWrite_OutboxWriteError_PropagatesFromCreate(t *testing.T) {
-	repo := mem.NewFlagRepository()
-	writer := &testutil.RecordingWriter{Err: errors.New("outbox unavailable")}
-	svc, err := NewService(repo, slog.Default(),
-		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(&testutil.NoopTxRunner{}))
-	require.NoError(t, err)
-
-	_, err = svc.Create(context.Background(), CreateInput{Key: "k"})
+// TestFlagWrite_Create_BlankKey rejects blank key with validation error.
+func TestFlagWrite_Create_BlankKey(t *testing.T) {
+	svc, _ := newTestService(t)
+	_, err := svc.Create(context.Background(), CreateInput{Key: ""})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "outbox")
 }

--- a/cells/configcore/slices/flagwrite/service_test.go
+++ b/cells/configcore/slices/flagwrite/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"reflect"
 	"testing"
 	"time"
 
@@ -167,4 +168,39 @@ func TestFlagWrite_Create_BlankKey(t *testing.T) {
 	svc, _ := newTestService(t)
 	_, err := svc.Create(context.Background(), CreateInput{Key: ""})
 	require.Error(t, err)
+}
+
+// TestFlagWrite_NoOutboxEmit_AfterDowngrade is a regression lock that guards
+// against accidental re-introduction of an outbox emitter in the flag-write
+// Service after the PR-CFG-B downgrade from L2 to L1.
+//
+// event.flag.changed.v1 was retired (lifecycle: deprecated) because it never
+// had a subscriber. This test ensures flag-write remains emitter-free even if
+// future refactors add outbox.Emitter-typed fields to the struct.
+func TestFlagWrite_NoOutboxEmit_AfterDowngrade(t *testing.T) {
+	// Structural assertion: Service must not contain an "emitter" field.
+	svcType := reflect.TypeOf(Service{})
+	for i := 0; i < svcType.NumField(); i++ {
+		field := svcType.Field(i)
+		assert.NotEqual(t, "emitter", field.Name,
+			"Service must not have an emitter field after L2→L1 downgrade (event.flag.changed.v1 retired)")
+	}
+
+	// Behavioural assertion: Create/Update/Toggle/Delete must succeed without
+	// any outbox writer being injected, confirming no emit attempt is made.
+	repo := mem.NewFlagRepository()
+	svc, err := NewService(repo, slog.Default(), WithTxManager(&testutil.NoopTxRunner{}))
+	require.NoError(t, err)
+
+	_, createErr := svc.Create(context.Background(), CreateInput{Key: "flag-no-emit", Description: "test"})
+	require.NoError(t, createErr, "Create must succeed without emitter (L1 only)")
+
+	_, updateErr := svc.Update(context.Background(), UpdateInput{Key: "flag-no-emit", Description: "updated"})
+	require.NoError(t, updateErr, "Update must succeed without emitter (L1 only)")
+
+	_, toggleErr := svc.Toggle(context.Background(), "flag-no-emit", true)
+	require.NoError(t, toggleErr, "Toggle must succeed without emitter (L1 only)")
+
+	deleteErr := svc.Delete(context.Background(), "flag-no-emit")
+	require.NoError(t, deleteErr, "Delete must succeed without emitter (L1 only)")
 }

--- a/cells/configcore/slices/flagwrite/slice.yaml
+++ b/cells/configcore/slices/flagwrite/slice.yaml
@@ -1,5 +1,7 @@
 id: flagwrite
 belongsToCell: configcore
+# consistencyLevel: L1 — explicitly L1 LocalTx (not L2); slice.yaml inherits cell.yaml L2 by default
+# but flag-write dropped outbox emission (event.flag.changed.v1 retired by PR #266)
 contractUsages:
   - contract: http.config.flags.create.v1
     role: serve

--- a/cells/configcore/slices/flagwrite/slice.yaml
+++ b/cells/configcore/slices/flagwrite/slice.yaml
@@ -9,8 +9,6 @@ contractUsages:
     role: serve
   - contract: http.config.flags.delete.v1
     role: serve
-  - contract: event.flag.changed.v1
-    role: publish
 verify:
   unit:
     - unit.flagwrite.service
@@ -19,7 +17,6 @@ verify:
     - contract.http.config.flags.update.v1.serve
     - contract.http.config.flags.toggle.v1.serve
     - contract.http.config.flags.delete.v1.serve
-    - contract.event.flag.changed.v1.publish
   waivers: []
 
 allowedFiles:

--- a/cells/configcore/slices/flagwrite/slice.yaml
+++ b/cells/configcore/slices/flagwrite/slice.yaml
@@ -1,7 +1,6 @@
 id: flagwrite
 belongsToCell: configcore
-# consistencyLevel: L1 — explicitly L1 LocalTx (not L2); slice.yaml inherits cell.yaml L2 by default
-# but flag-write dropped outbox emission (event.flag.changed.v1 retired by PR #266)
+consistencyLevel: L1  # L1 LocalTx; flag-write dropped outbox emission (event.flag.changed.v1 retired by PR #266)
 contractUsages:
   - contract: http.config.flags.create.v1
     role: serve

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -18,8 +18,13 @@
 //   - Publisher passed to buildConfigCoreOpts is the in-memory eventbus `eb`
 //     (matching cmd/corebundle/main.go:492).
 //   - Subscription is registered on the same `eb` and asserts the received
-//     Entry.Payload parses as a business event (action/key/value), which
+//     Entry.Payload parses as a business event (action/key/version), which
 //     requires the F1 envelope-unwrap fix to work.
+//
+// PR-CFG-B metadata-only model: event.config.entry-upserted.v1 payload carries
+// only key+version (no value field). The A11+F1 regression guard still validates
+// the full envelope-unwrap path; only the payload field set has changed.
+// Subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value.
 package main
 
 import (
@@ -60,9 +65,10 @@ import (
 // event.config.entry-upserted.v1. If the relay's wire envelope reaches
 // subscribers unwrapped (F1 bug), these fields will all be empty and the
 // regression guard fires.
+//
+// PR-CFG-B metadata-only model: only key+version are present; value is omitted.
 type configEntryUpsertedBusinessPayload struct {
 	Key     string `json:"key"`
-	Value   string `json:"value"`
 	Version int    `json:"version"`
 }
 
@@ -263,13 +269,13 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 		defer recvMu.Unlock()
 		for _, r := range recvs {
 			if r.parsed && r.payload.Key == "e2e.test.key" &&
-				r.payload.Value == "e2e-value" && r.payload.Version >= 1 {
+				r.payload.Version >= 1 {
 				return true
 			}
 		}
 		return false
 	}, 30*time.Second, 200*time.Millisecond,
-		"A11+F1 regression guard: entry-upserted business payload with key/value/version must reach subscriber; "+
+		"A11+F1 regression guard: entry-upserted business payload with key/version must reach subscriber (PR-CFG-B metadata-only model); "+
 			"missing fields indicate relay→eventbus envelope was not unwrapped")
 
 	// Additional diagnostic: list what actually arrived in case the above fails.

--- a/contracts/event/audit/appended/v1/contract.yaml
+++ b/contracts/event/audit/appended/v1/contract.yaml
@@ -5,7 +5,7 @@ consistencyLevel: L2
 lifecycle: active
 endpoints:
   publisher: auditcore
-  subscribers: []
+  subscribers: [external-audit-sink]
 schemaRefs:
   headers: headers.schema.json
   payload: payload.schema.json

--- a/contracts/event/audit/integrity-verified/v1/contract.yaml
+++ b/contracts/event/audit/integrity-verified/v1/contract.yaml
@@ -5,7 +5,7 @@ consistencyLevel: L2
 lifecycle: active
 endpoints:
   publisher: auditcore
-  subscribers: []
+  subscribers: [external-audit-sink]
 schemaRefs:
   headers: headers.schema.json
   payload: payload.schema.json

--- a/contracts/event/config/entry-deleted/v1/payload.schema.json
+++ b/contracts/event/config/entry-deleted/v1/payload.schema.json
@@ -2,10 +2,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "event.config.entry-deleted.v1.payload",
   "type": "object",
-  "description": "Emitted after config Delete to tell subscribers to remove the key from local state.",
+  "description": "Emitted after config Delete. Metadata-only: carries key + version. version is the version of the deleted entry and is used by subscribers for monotonic tombstone protection — a replayed older upsert (at-least-once delivery) must be rejected when version <= tombstone version.",
   "properties": {
-    "key": { "type": "string", "pattern": "\\S" }
+    "key":     { "type": "string", "pattern": "\\S" },
+    "version": { "type": "integer", "minimum": 1, "description": "Version of the deleted config entry. Subscribers use this to protect against stale upsert replays after a delete." }
   },
-  "required": ["key"],
+  "required": ["key", "version"],
   "additionalProperties": false
 }

--- a/contracts/event/config/entry-upserted/v1/contract.yaml
+++ b/contracts/event/config/entry-upserted/v1/contract.yaml
@@ -1,4 +1,5 @@
 id: event.config.entry-upserted.v1
+description: "Metadata-only: subscribers MUST refetch current value via GET /api/v1/config/{key}. Payload carries only key+version for cache invalidation."
 kind: event
 ownerCell: configcore
 consistencyLevel: L2

--- a/contracts/event/config/entry-upserted/v1/payload.schema.json
+++ b/contracts/event/config/entry-upserted/v1/payload.schema.json
@@ -4,8 +4,8 @@
   "type": "object",
   "description": "Metadata-only notification: subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value. ref: NATS subject+bytes / Watermill payload-bytes boundary.",
   "properties": {
-    "key": { "type": "string", "pattern": "\\S" },
-    "version": { "type": "integer", "minimum": 1 }
+    "key": { "type": "string", "pattern": "\\S", "description": "non-blank config key; matches ConfigEntry.Key validation" },
+    "version": { "type": "integer", "minimum": 1, "description": "monotonically increasing; starts at 1, matches ConfigEntry.Version" }
   },
   "required": ["key", "version"],
   "additionalProperties": false

--- a/contracts/event/config/entry-upserted/v1/payload.schema.json
+++ b/contracts/event/config/entry-upserted/v1/payload.schema.json
@@ -2,12 +2,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "event.config.entry-upserted.v1.payload",
   "type": "object",
-  "description": "Emitted after config Create/Update/Rollback to distribute the current config value that subscribers should apply. value is required and may be an empty string.",
+  "description": "Metadata-only notification: subscribers MUST refetch via GET /api/v1/config/{key} to obtain the value. ref: NATS subject+bytes / Watermill payload-bytes boundary.",
   "properties": {
     "key": { "type": "string", "pattern": "\\S" },
-    "value": { "type": "string" },
     "version": { "type": "integer", "minimum": 1 }
   },
-  "required": ["key", "value", "version"],
+  "required": ["key", "version"],
   "additionalProperties": false
 }

--- a/contracts/event/flag/changed/v1/contract.yaml
+++ b/contracts/event/flag/changed/v1/contract.yaml
@@ -2,11 +2,11 @@ id: event.flag.changed.v1
 kind: event
 ownerCell: configcore
 consistencyLevel: L2
-lifecycle: active
+lifecycle: deprecated
 endpoints:
   publisher: configcore
   subscribers: []
-  # TODO: add auditcore once the consumer is implemented in auditcore slice
+  # deprecated 2026-04-25: dead event since v1.0; never had subscriber, retired by PR-CFG-B
 schemaRefs:
   headers: headers.schema.json
   payload: payload.schema.json

--- a/contracts/event/flag/changed/v1/contract.yaml
+++ b/contracts/event/flag/changed/v1/contract.yaml
@@ -1,4 +1,5 @@
 id: event.flag.changed.v1
+description: "Retired same-PR as deprecation per CLAUDE.md no-backward-compat rule (gocell-internal only, no external consumers)"
 kind: event
 ownerCell: configcore
 consistencyLevel: L2
@@ -6,7 +7,7 @@ lifecycle: deprecated
 endpoints:
   publisher: configcore
   subscribers: []
-  # deprecated 2026-04-25: dead event since v1.0; never had subscriber, retired by PR-CFG-B
+  # deprecated 2026-04-25: dead event since v1.0; never had subscriber, retired by PR #266
 schemaRefs:
   headers: headers.schema.json
   payload: payload.schema.json

--- a/contracts/event/flag/changed/v1/payload.schema.json
+++ b/contracts/event/flag/changed/v1/payload.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "DEPRECATED 2026-04-25 (PR #266): retired event, no subscriber",
   "title": "event.flag.changed.v1.payload",
   "type": "object",
   "required": ["eventId", "action", "key", "enabled", "version", "occurredAt"],

--- a/examples/iotdevice/contracts/event/device-registered/v1/contract.yaml
+++ b/examples/iotdevice/contracts/event/device-registered/v1/contract.yaml
@@ -5,7 +5,7 @@ consistencyLevel: L4
 lifecycle: active
 endpoints:
   publisher: devicecell
-  subscribers: []
+  subscribers: [example-iot-platform]
 schemaRefs:
   headers: headers.schema.json
   payload: payload.schema.json

--- a/examples/todoorder/contracts/event/order-created/v1/contract.yaml
+++ b/examples/todoorder/contracts/event/order-created/v1/contract.yaml
@@ -5,7 +5,7 @@ consistencyLevel: L2
 lifecycle: active
 endpoints:
   publisher: ordercell
-  subscribers: []
+  subscribers: [example-order-platform]
 schemaRefs:
   headers: headers.schema.json
   payload: payload.schema.json

--- a/kernel/governance/rules_advisory.go
+++ b/kernel/governance/rules_advisory.go
@@ -65,3 +65,32 @@ func (v *Validator) validateADV04() []ValidationResult {
 	}
 	return results
 }
+
+// validateADV05 checks that active event contracts have at least one subscriber.
+// An event contract with lifecycle "active" and an empty (or nil) subscribers list
+// is a dead event — it will never be consumed and its producer is publishing to
+// no one. The contract must either be marked lifecycle: deprecated or a subscriber
+// must be added.
+//
+// lifecycle "deprecated" is explicitly exempted because the contract is already
+// on its way out; non-event contracts (http, command, projection) are not checked.
+func (v *Validator) validateADV05() []ValidationResult {
+	var results []ValidationResult
+	for _, c := range v.project.Contracts {
+		if c.Kind != "event" {
+			continue
+		}
+		if c.Lifecycle == "deprecated" {
+			continue
+		}
+		if len(c.Endpoints.Subscribers) == 0 {
+			results = append(results, v.newResult(
+				"ADV-05", SeverityError, IssueForbidden,
+				contractFile(c.ID),
+				"endpoints.subscribers",
+				fmt.Sprintf("event contract %q is active but has no subscribers; mark lifecycle: deprecated or add a subscriber", c.ID),
+			))
+		}
+	}
+	return results
+}

--- a/kernel/governance/rules_advisory.go
+++ b/kernel/governance/rules_advisory.go
@@ -69,18 +69,19 @@ func (v *Validator) validateADV04() []ValidationResult {
 // validateADV05 checks that active event contracts have at least one subscriber.
 // An event contract with lifecycle "active" and an empty (or nil) subscribers list
 // is a dead event — it will never be consumed and its producer is publishing to
-// no one. The contract must either be marked lifecycle: deprecated or a subscriber
-// must be added.
+// no one. The contract must either be wired with subscribers or moved out of active.
 //
-// lifecycle "deprecated" is explicitly exempted because the contract is already
-// on its way out; non-event contracts (http, command, projection) are not checked.
+// Only lifecycle "active" is checked. Draft contracts are allowed to be unwired
+// during the design phase — subscribers are not required until the contract
+// transitions to active. Deprecated contracts are on their way out and are also
+// exempt. Non-event contracts (http, command, projection) are not checked.
 func (v *Validator) validateADV05() []ValidationResult {
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
 		if c.Kind != "event" {
 			continue
 		}
-		if c.Lifecycle == "deprecated" {
+		if c.Lifecycle != "active" {
 			continue
 		}
 		if len(c.Endpoints.Subscribers) == 0 {

--- a/kernel/governance/rules_advisory.go
+++ b/kernel/governance/rules_advisory.go
@@ -88,7 +88,7 @@ func (v *Validator) validateADV05() []ValidationResult {
 				"ADV-05", SeverityError, IssueForbidden,
 				contractFile(c.ID),
 				"endpoints.subscribers",
-				fmt.Sprintf("event contract %q is active but has no subscribers; mark lifecycle: deprecated or add a subscriber", c.ID),
+				fmt.Sprintf("event contract %q is active but has no subscribers; mark lifecycle: deprecated or add at least one cell or actor to endpoints.subscribers in the contract.yaml", c.ID),
 			))
 		}
 	}

--- a/kernel/governance/rules_slice.go
+++ b/kernel/governance/rules_slice.go
@@ -1,0 +1,61 @@
+package governance
+
+import (
+	"fmt"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+)
+
+// validateSliceConsistency checks that if a slice declares an explicit
+// consistencyLevel, it must be ≤ the parent cell's consistencyLevel
+// (a slice can downgrade but never upgrade beyond its cell's contract).
+//
+// Rule: SLICE-CONSISTENCY-01
+// Rationale: slice.consistencyLevel allows a cell to host slices with weaker
+// guarantees (e.g., a L2 cell with an L1 slice that doesn't emit events);
+// upgrading would silently break the cell-level contract.
+func (v *Validator) validateSliceConsistency() []ValidationResult {
+	var results []ValidationResult
+	for key, s := range v.project.Slices {
+		if s.ConsistencyLevel == "" {
+			// empty means inherit cell — always valid
+			continue
+		}
+		sliceLevel, err := cell.ParseLevel(s.ConsistencyLevel)
+		if err != nil {
+			results = append(results, v.newResult(
+				"SLICE-CONSISTENCY-01", SeverityError, IssueInvalid,
+				sliceFile(key),
+				"consistencyLevel",
+				fmt.Sprintf(
+					"slice %q declares consistencyLevel %q which is not valid (must be L0-L4)",
+					s.ID, s.ConsistencyLevel,
+				),
+			))
+			continue
+		}
+		parentCell, ok := v.project.Cells[s.BelongsToCell]
+		if !ok {
+			// REF-01 already catches missing parent cell; skip here
+			continue
+		}
+		cellLevel, err := cell.ParseLevel(parentCell.ConsistencyLevel)
+		if err != nil {
+			// FMT-03 already catches invalid cell consistencyLevel; skip here
+			continue
+		}
+		if sliceLevel > cellLevel {
+			results = append(results, v.newResult(
+				"SLICE-CONSISTENCY-01", SeverityError, IssueInvalid,
+				sliceFile(key),
+				"consistencyLevel",
+				fmt.Sprintf(
+					"slice %q declares consistencyLevel %q which is stronger than parent cell %q (%q); "+
+						"a slice can downgrade but not upgrade",
+					s.ID, s.ConsistencyLevel, parentCell.ID, parentCell.ConsistencyLevel,
+				),
+			))
+		}
+	}
+	return results
+}

--- a/kernel/governance/rules_slice_test.go
+++ b/kernel/governance/rules_slice_test.go
@@ -1,0 +1,120 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSliceConsistency(t *testing.T) {
+	tests := []struct {
+		name           string
+		cellLevel      string
+		sliceLevel     string
+		wantErrorCount int
+		wantCode       string
+	}{
+		{
+			name:           "slice with no explicit level inherits cell - 0 findings",
+			cellLevel:      "L2",
+			sliceLevel:     "",
+			wantErrorCount: 0,
+		},
+		{
+			name:           "slice level equals cell level - 0 findings",
+			cellLevel:      "L2",
+			sliceLevel:     "L2",
+			wantErrorCount: 0,
+		},
+		{
+			name:           "slice downgrade L1 in L2 cell - 0 findings",
+			cellLevel:      "L2",
+			sliceLevel:     "L1",
+			wantErrorCount: 0,
+		},
+		{
+			name:           "slice L0 in L3 cell - 0 findings",
+			cellLevel:      "L3",
+			sliceLevel:     "L0",
+			wantErrorCount: 0,
+		},
+		{
+			name:           "slice upgrades L3 in L2 cell - 1 error",
+			cellLevel:      "L2",
+			sliceLevel:     "L3",
+			wantErrorCount: 1,
+			wantCode:       "SLICE-CONSISTENCY-01",
+		},
+		{
+			name:           "slice empty string treated as inherit - 0 findings",
+			cellLevel:      "L1",
+			sliceLevel:     "",
+			wantErrorCount: 0,
+		},
+		{
+			name:           "slice invalid level L9 - 1 error",
+			cellLevel:      "L2",
+			sliceLevel:     "L9",
+			wantErrorCount: 1,
+			wantCode:       "SLICE-CONSISTENCY-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := &metadata.ProjectMeta{
+				Cells: map[string]*metadata.CellMeta{
+					"testcell": {
+						ID:               "testcell",
+						ConsistencyLevel: tt.cellLevel,
+					},
+				},
+				Slices: map[string]*metadata.SliceMeta{
+					"testcell/testslice": {
+						ID:               "testslice",
+						BelongsToCell:    "testcell",
+						ConsistencyLevel: tt.sliceLevel,
+					},
+				},
+				Contracts:  map[string]*metadata.ContractMeta{},
+				Journeys:   map[string]*metadata.JourneyMeta{},
+				Assemblies: map[string]*metadata.AssemblyMeta{},
+			}
+			v := NewValidator(project, ".")
+			results := v.validateSliceConsistency()
+
+			var errCount int
+			for _, r := range results {
+				if r.Severity == SeverityError {
+					errCount++
+					if tt.wantCode != "" {
+						assert.Equal(t, tt.wantCode, r.Code)
+					}
+				}
+			}
+			assert.Equal(t, tt.wantErrorCount, errCount, "unexpected error count")
+		})
+	}
+}
+
+// TestValidateSliceConsistency_MissingParentCell verifies that a slice with
+// no registered parent cell is skipped (REF-01 covers the missing cell).
+func TestValidateSliceConsistency_MissingParentCell(t *testing.T) {
+	project := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{},
+		Slices: map[string]*metadata.SliceMeta{
+			"ghostcell/testslice": {
+				ID:               "testslice",
+				BelongsToCell:    "ghostcell",
+				ConsistencyLevel: "L3",
+			},
+		},
+		Contracts:  map[string]*metadata.ContractMeta{},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+	v := NewValidator(project, ".")
+	results := v.validateSliceConsistency()
+	assert.Empty(t, results, "missing parent cell should be silently skipped")
+}

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -149,7 +149,7 @@ func (v *Validator) rules() []func() []ValidationResult {
 		v.validateFMT05, v.validateFMT06, v.validateFMT07, v.validateFMT08,
 		v.validateFMT09, v.validateFMT10, v.validateFMT11, v.validateFMT12,
 		v.validateFMT13, v.validateFMT14, v.validateFMT15,
-		v.validateADV01, v.validateADV03, v.validateADV04,
+		v.validateADV01, v.validateADV03, v.validateADV04, v.validateADV05,
 		v.validateOUTGUARD01,
 	}
 }

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -151,6 +151,7 @@ func (v *Validator) rules() []func() []ValidationResult {
 		v.validateFMT13, v.validateFMT14, v.validateFMT15,
 		v.validateADV01, v.validateADV03, v.validateADV04, v.validateADV05,
 		v.validateOUTGUARD01,
+		v.validateSliceConsistency,
 	}
 }
 

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -2564,6 +2564,41 @@ func TestADV05(t *testing.T) {
 			},
 			wantCount: 0,
 		},
+		{
+			name: "draft lifecycle empty subscribers should error (draft not exempt)",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["event.draft.nosubscribers.v1"] = &metadata.ContractMeta{
+					ID:               "event.draft.nosubscribers.v1",
+					Kind:             "event",
+					OwnerCell:        "accesscore",
+					ConsistencyLevel: "L2",
+					Lifecycle:        "draft",
+					Endpoints: metadata.EndpointsMeta{
+						Publisher:   "accesscore",
+						Subscribers: []string{},
+					},
+				}
+			},
+			wantCount: 1,
+			wantSev:   SeverityError,
+		},
+		{
+			name: "draft lifecycle with subscribers → 0 findings",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["event.draft.withsubs.v1"] = &metadata.ContractMeta{
+					ID:               "event.draft.withsubs.v1",
+					Kind:             "event",
+					OwnerCell:        "accesscore",
+					ConsistencyLevel: "L2",
+					Lifecycle:        "draft",
+					Endpoints: metadata.EndpointsMeta{
+						Publisher:   "accesscore",
+						Subscribers: []string{"auditcore"},
+					},
+				}
+			},
+			wantCount: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2575,7 +2610,7 @@ func TestADV05(t *testing.T) {
 			for _, r := range got {
 				assert.Equal(t, tt.wantSev, r.Severity)
 				assert.Equal(t, IssueForbidden, r.IssueType)
-				assert.Contains(t, r.Message, "active but has no subscribers")
+				assert.Contains(t, r.Message, "is active but has no subscribers")
 			}
 		})
 	}

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -2565,7 +2565,7 @@ func TestADV05(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name: "draft lifecycle empty subscribers should error (draft not exempt)",
+			name: "draft lifecycle with empty subscribers → 0 findings (draft exempt)",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["event.draft.nosubscribers.v1"] = &metadata.ContractMeta{
 					ID:               "event.draft.nosubscribers.v1",
@@ -2579,11 +2579,10 @@ func TestADV05(t *testing.T) {
 					},
 				}
 			},
-			wantCount: 1,
-			wantSev:   SeverityError,
+			wantCount: 0,
 		},
 		{
-			name: "draft lifecycle with subscribers → 0 findings",
+			name: "draft lifecycle with subscribers → 0 findings (draft exempt)",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Contracts["event.draft.withsubs.v1"] = &metadata.ContractMeta{
 					ID:               "event.draft.withsubs.v1",
@@ -4057,7 +4056,7 @@ func TestOUTGUARD01(t *testing.T) {
 	}
 }
 
-func TestOUTGUARD01_L3_L4_Warning(t *testing.T) {
+func TestOUTGUARD01_L3_L4_Error(t *testing.T) {
 	pm := validProject()
 	// Suppress existing L2 warnings.
 	pm.Cells["accesscore"].DurabilityMode = "durable"

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -2479,6 +2479,108 @@ func TestADV04(t *testing.T) {
 	}
 }
 
+// --- ADV-05: active event contract with no subscribers ---
+
+func TestADV05(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+		wantSev   Severity
+	}{
+		{
+			name: "event contract active with empty subscribers → 1 error",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["event.dead.nosubscribers.v1"] = &metadata.ContractMeta{
+					ID:               "event.dead.nosubscribers.v1",
+					Kind:             "event",
+					OwnerCell:        "accesscore",
+					ConsistencyLevel: "L2",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Publisher:   "accesscore",
+						Subscribers: []string{},
+					},
+				}
+			},
+			wantCount: 1,
+			wantSev:   SeverityError,
+		},
+		{
+			name: "event contract active with nil subscribers → 1 error",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["event.dead.nilsubs.v1"] = &metadata.ContractMeta{
+					ID:               "event.dead.nilsubs.v1",
+					Kind:             "event",
+					OwnerCell:        "accesscore",
+					ConsistencyLevel: "L2",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Publisher:   "accesscore",
+						Subscribers: nil,
+					},
+				}
+			},
+			wantCount: 1,
+			wantSev:   SeverityError,
+		},
+		{
+			name: "event contract active with subscribers → 0 findings",
+			setup: func(pm *metadata.ProjectMeta) {
+				// event.session.created.v1 already has subscribers in validProject()
+			},
+			wantCount: 0,
+		},
+		{
+			name: "event contract deprecated with empty subscribers → 0 findings (exempt)",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["event.old.deprecated.v1"] = &metadata.ContractMeta{
+					ID:               "event.old.deprecated.v1",
+					Kind:             "event",
+					OwnerCell:        "accesscore",
+					ConsistencyLevel: "L2",
+					Lifecycle:        "deprecated",
+					Endpoints: metadata.EndpointsMeta{
+						Publisher:   "accesscore",
+						Subscribers: []string{},
+					},
+				}
+			},
+			wantCount: 0,
+		},
+		{
+			name: "http contract with no clients field → 0 findings (not event kind)",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.some.endpoint.v1"] = &metadata.ContractMeta{
+					ID:               "http.some.endpoint.v1",
+					Kind:             "http",
+					OwnerCell:        "accesscore",
+					ConsistencyLevel: "L1",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Server: "accesscore",
+					},
+				}
+			},
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, "")
+			got := findByCode(val.validateADV05(), "ADV-05")
+			assert.Len(t, got, tt.wantCount)
+			for _, r := range got {
+				assert.Equal(t, tt.wantSev, r.Severity)
+				assert.Equal(t, IssueForbidden, r.IssueType)
+				assert.Contains(t, r.Message, "active but has no subscribers")
+			}
+		})
+	}
+}
+
 // --- helper function tests for new utilities ---
 
 func TestContractDirFromID(t *testing.T) {

--- a/kernel/metadata/parser_integration_test.go
+++ b/kernel/metadata/parser_integration_test.go
@@ -123,9 +123,13 @@ func TestParseRealProject(t *testing.T) {
 	assert.GreaterOrEqual(t, len(pm.StatusBoard), 8, "expected at least 8 status-board entries")
 	assert.LessOrEqual(t, len(pm.StatusBoard), 12, "unexpected extra status-board entries parsed — update this bound if new entries were added intentionally")
 
-	// --- Actors: 1 ---
-	assert.Len(t, pm.Actors, 1, "expected 1 actor")
-	assert.Equal(t, "edge-bff", pm.Actors[0].ID)
+	// --- Actors: 4 (edge-bff + 3 external subscribers added by PR-CFG-B for ADV-05) ---
+	assert.Len(t, pm.Actors, 4, "expected 4 actors")
+	actorIDs := make([]string, 0, len(pm.Actors))
+	for _, a := range pm.Actors {
+		actorIDs = append(actorIDs, a.ID)
+	}
+	assert.ElementsMatch(t, []string{"edge-bff", "external-audit-sink", "example-iot-platform", "example-order-platform"}, actorIDs)
 
 	// Spot-check a well-known cell.
 	ac := pm.Cells["accesscore"]

--- a/kernel/metadata/parser_strict_test.go
+++ b/kernel/metadata/parser_strict_test.go
@@ -327,3 +327,54 @@ verify:
 	assert.True(t, lineNumberRe.MatchString(err.Error()),
 		fmt.Sprintf("expected error to contain 'line N' but got: %s", err.Error()))
 }
+
+// TestParser_SliceConsistencyLevelAccepted verifies that the new optional
+// slice.yaml field "consistencyLevel" is accepted by KnownFields(true) and
+// correctly round-trips through the parser into SliceMeta.ConsistencyLevel.
+func TestParser_SliceConsistencyLevelAccepted(t *testing.T) {
+	tests := []struct {
+		name      string
+		sliceYAML string
+		wantLevel string
+	}{
+		{
+			name: "slice with explicit L1 accepted",
+			sliceYAML: `id: testslice
+belongsToCell: testcell
+consistencyLevel: L1
+contractUsages: []
+verify:
+  unit: []
+  contract: []
+`,
+			wantLevel: "L1",
+		},
+		{
+			name: "slice without consistencyLevel accepted",
+			sliceYAML: `id: testslice
+belongsToCell: testcell
+contractUsages: []
+verify:
+  unit: []
+  contract: []
+`,
+			wantLevel: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fsys := fstest.MapFS{
+				"cells/testcell/cell.yaml":                   &fstest.MapFile{Data: []byte(minimalCellYAML)},
+				"cells/testcell/slices/testslice/slice.yaml": &fstest.MapFile{Data: []byte(tt.sliceYAML)},
+			}
+			p := NewParser("")
+			pm, err := p.ParseFS(fsys)
+			require.NoError(t, err, "slice.yaml with consistencyLevel must not be rejected")
+			s, ok := pm.Slices["testcell/testslice"]
+			require.True(t, ok, "expected slice to be parsed")
+			assert.Equal(t, tt.wantLevel, s.ConsistencyLevel)
+		})
+	}
+}

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -59,14 +59,15 @@ type L0DepMeta struct {
 // map key prevents a path-vs-id split from fooling the validator (e.g. a
 // kebab directory paired with a no-dash id in slice.yaml).
 type SliceMeta struct {
-	ID             string          `yaml:"id"`
-	BelongsToCell  string          `yaml:"belongsToCell"`
-	ContractUsages []ContractUsage `yaml:"contractUsages"`
-	Verify         SliceVerifyMeta `yaml:"verify"`
-	AllowedFiles   []string        `yaml:"allowedFiles,omitempty"`
-	Dir            string          `yaml:"-"` // slice directory segment, set by parser
-	CellDir        string          `yaml:"-"` // parent cell directory segment, set by parser
-	File           string          `yaml:"-"` // parsed slice.yaml path relative to project root
+	ID               string          `yaml:"id"`
+	BelongsToCell    string          `yaml:"belongsToCell"`
+	ConsistencyLevel string          `yaml:"consistencyLevel,omitempty"` // "L0"-"L4"; if empty, inherits cell.ConsistencyLevel; if set, MUST be ≤ cell.ConsistencyLevel
+	ContractUsages   []ContractUsage `yaml:"contractUsages"`
+	Verify           SliceVerifyMeta `yaml:"verify"`
+	AllowedFiles     []string        `yaml:"allowedFiles,omitempty"`
+	Dir              string          `yaml:"-"` // slice directory segment, set by parser
+	CellDir          string          `yaml:"-"` // parent cell directory segment, set by parser
+	File             string          `yaml:"-"` // parsed slice.yaml path relative to project root
 }
 
 // ContractUsage declares a Slice's participation in a Contract.

--- a/tools/archtest/archtest_test.go
+++ b/tools/archtest/archtest_test.go
@@ -171,6 +171,24 @@ func checkLayering(modPrefix string, pkgs []pkgInfo) []violation {
 			if v := checkCellOwnedSubpackage(modPrefix, pkg.ImportPath, imp, srcLayer); v != nil {
 				out = append(out, *v)
 			}
+
+			// LAYER-09: cells/X must not import cells/Y/events (cross-cell public events package).
+			// rationale: cell-patterns.md three-tier DTO rule — cells/{cell}/events/ packages
+			// are owned by the declaring cell; sibling cells must use contract wire types instead.
+			// Same-cell self-import is allowed; cmd/ and examples/ are unrestricted.
+			impCell := cellOf(modPrefix, imp)
+			if srcCell != "" && impCell != "" && srcCell != impCell {
+				impRel := strings.TrimPrefix(imp, modPrefix)
+				eventsPrefix := "cells/" + impCell + "/events"
+				if impRel == eventsPrefix || strings.HasPrefix(impRel, eventsPrefix+"/") {
+					out = append(out, violation{
+						Rule:    "LAYER-09",
+						Pkg:     pkg.ImportPath,
+						Import:  imp,
+						Message: fmt.Sprintf("LAYER-09: %s imports %s (cross-cell events package; use contract wire types instead)", pkg.ImportPath, imp),
+					})
+				}
+			}
 		}
 	}
 	return out
@@ -334,6 +352,15 @@ func TestLayeringRules(t *testing.T) {
 		}
 		assert.Empty(t, hits,
 			"HTTPRegistrar must not appear anywhere in the codebase; the legacy interface has been fully removed (PR-A14b)")
+	})
+
+	// LAYER-09: cells/X must not import cells/Y/events (cross-cell public events package).
+	// cells/{cell}/events/ packages are owned by the declaring cell; sibling cells must
+	// communicate via contract wire types, not by directly importing the events package.
+	t.Run("LAYER-09_no_cross_cell_events_imports", func(t *testing.T) {
+		assert.Empty(t, byRule["LAYER-09"],
+			"cells/ must not import another cell's events/ package (cells/{cell}/events/); "+
+				"use contract wire types instead (cell-patterns.md three-tier DTO rule)")
 	})
 }
 
@@ -783,6 +810,57 @@ func TestCheckLayering(t *testing.T) {
 			// This case documents the expected clean result so the table is self-consistent.
 			wantRules: nil,
 		},
+		// LAYER-09: cells/X must not import cells/Y/events (cross-cell public events package).
+		// rationale: cell-patterns.md three-tier DTO rule — cells/{cell}/events/ must not be
+		// shared as wire types across cell boundaries.
+		{
+			name: "LAYER-09 violation: cells/auditcore imports cells/configcore/events",
+			pkgs: []pkgInfo{
+				{
+					ImportPath: "github.com/ghbvf/gocell/cells/auditcore/slices/auditappend",
+					Imports: []string{
+						"github.com/ghbvf/gocell/cells/configcore/events", // cross-cell events import — forbidden
+					},
+				},
+			},
+			wantRules: []string{"LAYER-09"},
+		},
+		{
+			name: "LAYER-09 clean: cells/configcore imports cells/configcore/events (same cell, allowed)",
+			pkgs: []pkgInfo{
+				{
+					ImportPath: "github.com/ghbvf/gocell/cells/configcore/slices/configpublish",
+					Imports: []string{
+						"github.com/ghbvf/gocell/cells/configcore/events", // same cell — OK
+					},
+				},
+			},
+			wantRules: nil,
+		},
+		{
+			name: "LAYER-09 clean: examples imports cells/configcore/events (unrestricted)",
+			pkgs: []pkgInfo{
+				{
+					ImportPath: "github.com/ghbvf/gocell/examples/ssobff",
+					Imports: []string{
+						"github.com/ghbvf/gocell/cells/configcore/events", // examples unrestricted
+					},
+				},
+			},
+			wantRules: nil,
+		},
+		{
+			name: "LAYER-09 clean: cmd imports cells/configcore/events (unrestricted)",
+			pkgs: []pkgInfo{
+				{
+					ImportPath: "github.com/ghbvf/gocell/cmd/corebundle",
+					Imports: []string{
+						"github.com/ghbvf/gocell/cells/configcore/events", // cmd unrestricted
+					},
+				},
+			},
+			wantRules: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -886,4 +964,69 @@ func TestLayeringRules_LAYER08_NegativeProbe(t *testing.T) {
 		"LAYER-08 negative probe: grepInDir must detect 'HTTPRegistrar' in the synthetic fixture")
 	assert.Contains(t, hits[0], "fake_router.go",
 		"hit must reference the violating file")
+}
+
+// TestLayeringRules_LAYER09_NegativeProbe is the "test the test" meta-test for
+// LAYER-09. It builds synthetic pkgInfo slices covering all four boundary cases
+// (cross-cell violation, same-cell allowed, examples allowed, cmd allowed) and
+// runs checkLayering to confirm the rule fires exactly when expected.
+func TestLayeringRules_LAYER09_NegativeProbe(t *testing.T) {
+	t.Parallel()
+
+	const modPrefix = "github.com/ghbvf/gocell/"
+
+	tests := []struct {
+		name        string
+		src         string
+		imp         string
+		wantViolate bool
+	}{
+		{
+			name:        "cross-cell: auditcore imports configcore/events → violation",
+			src:         modPrefix + "cells/auditcore/slices/auditappend",
+			imp:         modPrefix + "cells/configcore/events",
+			wantViolate: true,
+		},
+		{
+			name:        "same-cell: configcore imports configcore/events → allowed",
+			src:         modPrefix + "cells/configcore/slices/configpublish",
+			imp:         modPrefix + "cells/configcore/events",
+			wantViolate: false,
+		},
+		{
+			name:        "examples imports configcore/events → allowed",
+			src:         modPrefix + "examples/ssobff",
+			imp:         modPrefix + "cells/configcore/events",
+			wantViolate: false,
+		},
+		{
+			name:        "cmd imports configcore/events → allowed",
+			src:         modPrefix + "cmd/corebundle",
+			imp:         modPrefix + "cells/configcore/events",
+			wantViolate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pkgs := []pkgInfo{{ImportPath: tt.src, Imports: []string{tt.imp}}}
+			violations := checkLayering(modPrefix, pkgs)
+			var layer09 []violation
+			for _, v := range violations {
+				if v.Rule == "LAYER-09" {
+					layer09 = append(layer09, v)
+				}
+			}
+			if tt.wantViolate {
+				require.NotEmpty(t, layer09,
+					"LAYER-09 negative probe: expected violation for %s → %s", tt.src, tt.imp)
+				assert.Contains(t, layer09[0].Message, "LAYER-09")
+				assert.Contains(t, layer09[0].Message, tt.imp)
+			} else {
+				assert.Empty(t, layer09,
+					"LAYER-09 negative probe: expected no violation for %s → %s", tt.src, tt.imp)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Wave 2.5 abstraction **B (CELL-GRAPH-INTEGRITY)** — introduces 1 platform governance abstraction and clears all existing violations in the same PR (no allowlist, no carry-over).

This is the second of 4 mega-PRs that consolidate the original 7 PR-CFG-1..7 plan into 4 abstraction-aligned PRs (per discussion 2026-04-25 — Option A).

## Governance abstractions added

**1. archtest LAYER-09** (\`tools/archtest/archtest_test.go\`) — \`cells/X\` cannot import \`cells/Y/events\` (cross-cell public events package). Same-cell self-use allowed; \`examples/\` and \`cmd/\` unrestricted. Codifies \`.claude/rules/gocell/cell-patterns.md\` "DTO 三档 — C 档跨 cell 共享禁止" rule that was previously documentation-only.

**2. kernel/governance ADV-05 CONTRACT-DEAD-EVENT-01** (\`kernel/governance/rules_advisory.go\`) — event kind contract with \`lifecycle: active\` AND empty \`endpoints.subscribers\` fails with SeverityError. \`lifecycle: deprecated\` exempts; cell or actor subscribers both count as non-empty.

## Existing violations cleared (no allowlist)

### entry-upserted metadata-only refactor (B1b/B1c 激进方案)
- \`contracts/event/config/entry-upserted/v1/payload.schema.json\` drops \`value\` field; payload is now \`{key, version}\` only
- \`cells/configcore/events/\` (public package) → moved to \`cells/configcore/internal/events/\` (no longer importable cross-cell)
- 3 producers (configwrite/configpublish.Publish/configpublish.Rollback) emit \`{Key, Version}\` only — sensitivity redaction (\`"******"\`) removed since payload no longer carries value
- \`configsubscribe.Cache\` reshaped from \`map[string]string\` (values) to \`map[string]int\` (versions); \`Get(key)\` → \`GetVersion(key)\`

### accesscore local decoder
- New \`cells/accesscore/internal/dto/config_event_decoder.go\` — typed view + \`DecodeEntryUpserted/Deleted\` with \`DisallowUnknownFields\`
- \`configreceive/service.go\` no longer imports \`cells/configcore/events\`; cross-cell Go-type dependency severed; schema in \`contracts/\` remains the single source of truth

### flag.changed.v1 retired
- \`contracts/event/flag/changed/v1/contract.yaml\` → \`lifecycle: deprecated\`
- flagwrite drops 4 \`emitFlagChanged\` calls + emitter field + \`WithEmitter\` Option (L2 → L1 downgrade)

### audit/iotdevice/todoorder fan-out events
ADV-05 surfaced 4 additional dead-event candidates that turned out to be intentional external fan-out points. Cleared by registering external actors:
- \`actors.yaml\` adds \`external-audit-sink\`, \`example-iot-platform\`, \`example-order-platform\`
- \`audit.appended\` + \`audit.integrity-verified\` → subscribers: \`[external-audit-sink]\`
- \`device-registered\` → subscribers: \`[example-iot-platform]\`
- \`order-created\` → subscribers: \`[example-order-platform]\`

## Why same PR

Single-rule landings would be CI-red on the 6 existing violations; clearing them in the same PR avoids the allowlist anti-pattern. ADV-05 + LAYER-09 are both governance abstractions whose first violations belong with their introduction commit.

## Refs

- Plan: \`docs/plans/202604232330-025-architecture-pr-implementation-plan.md\` Wave 2.5 (Option A restructure)
- Backlog: PR-CFG-B replaces PR-CFG-2 + PR-CFG-3
- Supersedes: backlog \`PR250-F1\` (sensitive wire field decision)
- ref: NATS subject+bytes / Watermill \`message.Payload []byte\` boundary / k8s ValidatingAdmissionPolicy resourcified rules / cell-patterns.md DTO 三档

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go build -tags=integration ./...\` — clean
- [x] \`go test ./...\` — all pass (router_test panic in sandbox is pre-existing httptest local listener issue, unrelated)
- [x] \`go run ./cmd/gocell validate\` — 0 errors (1 unrelated REF-16 generated/boundary.yaml warning)
- [x] \`golangci-lint run ./tools/archtest/... ./kernel/governance/... ./cells/configcore/... ./cells/accesscore/...\` — 0 issues
- [x] LAYER-09 archtest passes (zero violations after accesscore local decoder)
- [x] ADV-05 fixture tests cover: active+empty (error), active+nonempty (clean), deprecated+empty (exempt), non-event kind (clean)
- [x] entry-upserted contract tests rewritten to assert metadata-only schema (rejects \`value\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)