### PR TITLE
test(distlock): clarify fake clock timer order contract

### DIFF
--- a/runtime/distlock/locktest/fake_clock.go
+++ b/runtime/distlock/locktest/fake_clock.go
@@ -71,8 +71,12 @@ func (fc *FakeClock) NewTimerAt(deadline time.Time) distlock.Timer {
 }
 
 // Advance moves the clock forward by d and fires all timers whose deadline
-// has passed. Timers are fired in deadline order (earliest first).
-// Returns after all due timers' channels have been written.
+// has passed. Returns after all due timers' channels have been written.
+//
+// Timers use independent buffered channels, so callers should not rely on
+// observing any cross-timer delivery order when one Advance makes multiple
+// timers due at once. If a future caller needs ordered callbacks or a unified
+// event stream, add explicit ordered dispatch semantics and tests together.
 func (fc *FakeClock) Advance(d time.Duration) {
 	fc.mu.Lock()
 	fc.now = fc.now.Add(d)

--- a/runtime/distlock/locktest/fake_clock_test.go
+++ b/runtime/distlock/locktest/fake_clock_test.go
@@ -68,9 +68,11 @@ func TestFakeClock_Advance_DoesNotFireFutureTimers(t *testing.T) {
 	timer.Stop()
 }
 
-// TestFakeClock_Advance_PreservesOrder verifies that timers fire in deadline
-// order (earliest first) when multiple timers have different deadlines.
-func TestFakeClock_Advance_PreservesOrder(t *testing.T) {
+// TestFakeClock_Advance_FiresAllDueTimersFromOneAdvance verifies that all
+// timers due at or before the new fake time fire, even when they were
+// registered out of deadline order. Cross-timer delivery order is not part of
+// FakeClock's observable contract because each timer has its own channel.
+func TestFakeClock_Advance_FiresAllDueTimersFromOneAdvance(t *testing.T) {
 	fc := locktest.NewFakeClock(epoch)
 
 	// Create timers in reverse order of deadlines.
@@ -82,7 +84,8 @@ func TestFakeClock_Advance_PreservesOrder(t *testing.T) {
 	fired := make([]int, 0, 3)
 	fc.Advance(4 * time.Second)
 
-	// All three should have fired. Drain channels.
+	// All three should have fired. Drain by timer identity; this intentionally
+	// does not assert cross-channel delivery order.
 	for _, pair := range []struct {
 		timer distlockTimer
 		idx   int
@@ -102,7 +105,7 @@ func TestFakeClock_Advance_PreservesOrder(t *testing.T) {
 }
 
 // distlockTimer is a local alias for the Timer interface returned by FakeClock.
-// Used in TestFakeClock_Advance_PreservesOrder to hold heterogeneous timers.
+// Used by fake clock tests to hold heterogeneous timers.
 type distlockTimer interface {
 	C() <-chan time.Time
 	Stop() bool


### PR DESCRIPTION
## Summary

Follow-up to #274 after the PR was merged before the review follow-up commit landed.

Clarifies that `locktest.FakeClock.Advance` only promises that due timers fire; it does not expose or promise cross-timer delivery order because each timer has an independent buffered channel.

## Changes

- Narrow `FakeClock.Advance` documentation to the observable contract.
- Rename the prior order-oriented test to assert that all due timers fire from one `Advance`.
- Leave a local note that future ordered callbacks or unified event stream support must add explicit dispatch semantics and tests together.

## Test plan

- [x] `go test ./runtime/distlock/...`
- [x] `go test ./runtime/distlock/... -race -count=3`
- [x] `golangci-lint run ./runtime/distlock/...`

Refs #274