### PR TITLE
fix(accesscore): identity Lock/Unlock atomic + Create input validation

### DIFF
--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -126,8 +126,14 @@ type CreateInput struct {
 
 // Create creates a new user and publishes an event.
 // The plain-text password is bcrypt-hashed before storage.
+//
+// Validation order matches setup.CreateAdmin (username → email → password) so
+// both code paths reject the same blank input with the same field message,
+// avoiding domain-layer error-class drift (audit S-4).
 func (s *Service) Create(ctx context.Context, input CreateInput) (*domain.User, error) {
 	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
+		validation.F("username", input.Username),
+		validation.F("email", input.Email),
 		validation.F("password", input.Password),
 	); err != nil {
 		return nil, err
@@ -258,6 +264,11 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 }
 
 // Lock locks a user account and publishes an event.
+//
+// Read-modify-write atomicity: GetByID, user.Lock(), Update, session/refresh
+// revoke and the outbox publish all run inside the same RunInTx closure. A
+// concurrent transaction that mutates the user between the read and the write
+// would otherwise be silently lost (audit S-3).
 func (s *Service) Lock(ctx context.Context, id string) error {
 	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
 		validation.F("id", id),
@@ -265,13 +276,12 @@ func (s *Service) Lock(ctx context.Context, id string) error {
 		return err
 	}
 
-	user, err := s.repo.GetByID(ctx, id)
-	if err != nil {
-		return fmt.Errorf("identity-manage: lock: %w", err)
-	}
-
-	user.Lock()
 	if err := s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
+		user, err := s.repo.GetByID(txCtx, id)
+		if err != nil {
+			return fmt.Errorf("identity-manage: lock: %w", err)
+		}
+		user.Lock()
 		if err := s.repo.Update(txCtx, user); err != nil {
 			return fmt.Errorf("identity-manage: lock: %w", err)
 		}
@@ -299,6 +309,10 @@ func (s *Service) Lock(ctx context.Context, id string) error {
 }
 
 // Unlock unlocks a user account.
+//
+// Read-modify-write atomicity: GetByID + user.Unlock() + Update share one
+// RunInTx closure so a concurrent mutation between the read and the write
+// cannot be silently lost (audit S-3, mirrors Lock).
 func (s *Service) Unlock(ctx context.Context, id string) error {
 	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
 		validation.F("id", id),
@@ -306,14 +320,18 @@ func (s *Service) Unlock(ctx context.Context, id string) error {
 		return err
 	}
 
-	user, err := s.repo.GetByID(ctx, id)
-	if err != nil {
-		return fmt.Errorf("identity-manage: unlock: %w", err)
-	}
-
-	user.Unlock()
-	if err := s.repo.Update(ctx, user); err != nil {
-		return fmt.Errorf("identity-manage: unlock: %w", err)
+	if err := s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
+		user, err := s.repo.GetByID(txCtx, id)
+		if err != nil {
+			return fmt.Errorf("identity-manage: unlock: %w", err)
+		}
+		user.Unlock()
+		if err := s.repo.Update(txCtx, user); err != nil {
+			return fmt.Errorf("identity-manage: unlock: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	s.logger.Info("user unlocked", slog.String("user_id", id))

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -292,14 +292,26 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 // revoke and the outbox publish all run inside the same RunInTx closure. A
 // concurrent transaction that mutates the user between the read and the write
 // would otherwise be silently lost (audit S-3).
+//
+// The transactional body lives in lockUserAndRevokeSessions to keep this
+// outer method's cognitive complexity within the CLAUDE.md ≤15 budget that
+// the 5-step closure would otherwise blow past (mirrors the
+// updatePasswordAndRevokeSessions split used by ChangePassword).
 func (s *Service) Lock(ctx context.Context, id string) error {
 	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
 		validation.F("id", id),
 	); err != nil {
 		return err
 	}
+	if err := s.lockUserAndRevokeSessions(ctx, id); err != nil {
+		return err
+	}
+	s.logger.Info("user locked", slog.String("user_id", id))
+	return nil
+}
 
-	if err := s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
+func (s *Service) lockUserAndRevokeSessions(ctx context.Context, id string) error {
+	return s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
 		user, err := s.repo.GetByID(txCtx, id)
 		if err != nil {
 			return fmt.Errorf("identity-manage: lock: %w", err)
@@ -323,12 +335,7 @@ func (s *Service) Lock(ctx context.Context, id string) error {
 			return err
 		}
 		return nil
-	}); err != nil {
-		return err
-	}
-
-	s.logger.Info("user locked", slog.String("user_id", id))
-	return nil
+	})
 }
 
 // Unlock unlocks a user account.

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -192,46 +192,69 @@ type UpdateInput struct {
 
 // Update modifies user attributes using JSON merge patch semantics:
 // only non-nil fields are applied; missing fields are left unchanged.
+//
+// Read-modify-write atomicity: GetByID, the in-place field application and
+// Update share a single RunInTx closure, mirroring Lock/Unlock — a concurrent
+// transaction mutating the user between the read and the write would otherwise
+// be silently lost (audit S-3 same-pattern, reviewer F7).
+//
+// The status string is validated before opening the tx: it is a pure input
+// check and rejecting invalid values upfront avoids opening a tx that will
+// only roll back.
 func (s *Service) Update(ctx context.Context, input UpdateInput) (*domain.User, error) {
 	if err := validation.RequireNotBlank(errcode.ErrAuthIdentityInvalidInput,
 		validation.F("id", input.ID),
 	); err != nil {
 		return nil, err
 	}
-
-	user, err := s.repo.GetByID(ctx, input.ID)
-	if err != nil {
-		return nil, fmt.Errorf("identity-manage: update: %w", err)
+	if input.Status != nil &&
+		*input.Status != string(domain.StatusActive) &&
+		*input.Status != string(domain.StatusSuspended) {
+		return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput, "status must be 'active' or 'suspended'")
 	}
 
-	if input.Name != nil {
-		user.Username = *input.Name
-	}
-	if input.Email != nil {
-		user.Email = *input.Email
-	}
-	if input.Status != nil {
-		status := domain.UserStatus(*input.Status)
-		if *input.Status != string(domain.StatusActive) && *input.Status != string(domain.StatusSuspended) {
-			return nil, errcode.New(errcode.ErrAuthIdentityInvalidInput, "status must be 'active' or 'suspended'")
+	var user *domain.User
+	if err := s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
+		u, err := s.repo.GetByID(txCtx, input.ID)
+		if err != nil {
+			return fmt.Errorf("identity-manage: update: %w", err)
 		}
-		user.Status = status
-	}
-	if input.RequirePasswordReset != nil {
-		if *input.RequirePasswordReset {
-			user.MarkPasswordResetRequired()
-		} else {
-			user.ClearPasswordResetRequired()
+		applyUpdateFields(u, input)
+		if err := s.repo.Update(txCtx, u); err != nil {
+			return fmt.Errorf("identity-manage: update: %w", err)
 		}
-	}
-	user.UpdatedAt = time.Now()
-
-	if err := s.repo.Update(ctx, user); err != nil {
-		return nil, fmt.Errorf("identity-manage: update: %w", err)
+		user = u
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	s.logger.Info("user updated", slog.String("user_id", user.ID))
 	return user, nil
+}
+
+// applyUpdateFields applies JSON-merge-patch semantics in-place on u: every
+// non-nil field in input overwrites the corresponding field on u. Pure
+// function — extracted from Update to keep that method's cognitive complexity
+// inside the 15-line CLAUDE.md budget once the RunInTx closure was added.
+func applyUpdateFields(u *domain.User, input UpdateInput) {
+	if input.Name != nil {
+		u.Username = *input.Name
+	}
+	if input.Email != nil {
+		u.Email = *input.Email
+	}
+	if input.Status != nil {
+		u.Status = domain.UserStatus(*input.Status)
+	}
+	if input.RequirePasswordReset != nil {
+		if *input.RequirePasswordReset {
+			u.MarkPasswordResetRequired()
+		} else {
+			u.ClearPasswordResetRequired()
+		}
+	}
+	u.UpdatedAt = time.Now()
 }
 
 // Delete removes a user. Before the user row is deleted, all sessions and

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -562,4 +563,209 @@ func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
 	})
 	require.NoError(t, err, "publish failure in demo mode must not fail Create")
 	assert.NotEmpty(t, user.ID)
+}
+
+// ---------------------------------------------------------------------------
+// PR-CFG-H — Lock/Unlock atomicity (audit S-3) +
+//             Create blank-input validation (audit S-4)
+// ---------------------------------------------------------------------------
+
+// recordingTxRunner observes whether the wrapped repository call happened
+// inside RunInTx. inTx is true only between RunInTx invocation and the
+// closure's return. runs counts how many times RunInTx was invoked.
+type recordingTxRunner struct {
+	inTx bool
+	runs int
+}
+
+func (r *recordingTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	r.runs++
+	r.inTx = true
+	defer func() { r.inTx = false }()
+	return fn(ctx)
+}
+
+// observingUserRepo snapshots `runner.inTx` at the moment GetByID / Update
+// fire so a test can assert read-modify-write atomicity. Embedding the
+// ports.UserRepository interface satisfies the contract for unobserved
+// methods (GetByUsername / Delete).
+type observingUserRepo struct {
+	ports.UserRepository
+	runner      *recordingTxRunner
+	getInTx     bool
+	updInTx     bool
+	createCalls int
+}
+
+func (r *observingUserRepo) Create(ctx context.Context, user *domain.User) error {
+	r.createCalls++
+	return r.UserRepository.Create(ctx, user)
+}
+
+func (r *observingUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
+	r.getInTx = r.runner.inTx
+	return r.UserRepository.GetByID(ctx, id)
+}
+
+func (r *observingUserRepo) Update(ctx context.Context, user *domain.User) error {
+	r.updInTx = r.runner.inTx
+	return r.UserRepository.Update(ctx, user)
+}
+
+// failingUpdateRepo wraps a real repo but always fails Update — used to
+// drive the Unlock-error-propagation test. GetByID is forwarded so the
+// service's read step succeeds.
+type failingUpdateRepo struct {
+	ports.UserRepository
+	updateErr error
+	updates   int
+}
+
+func (r *failingUpdateRepo) Update(_ context.Context, _ *domain.User) error {
+	r.updates++
+	return r.updateErr
+}
+
+// newAtomicitySvc wires Service with a recordingTxRunner + observingUserRepo
+// so atomicity tests can inspect inTx state without touching production wiring.
+func newAtomicitySvc(t *testing.T) (*Service, *observingUserRepo, *recordingTxRunner) {
+	t.Helper()
+	runner := &recordingTxRunner{}
+	repo := &observingUserRepo{UserRepository: mem.NewUserRepository(), runner: runner}
+	svc, err := NewService(repo, mem.NewSessionRepository(), newIdentityRefreshStore(), slog.Default(),
+		WithTokenIssuer(minimalStubIssuer),
+		WithTxManager(runner))
+	require.NoError(t, err)
+	return svc, repo, runner
+}
+
+// TestService_Lock_GetByIDAndUpdateInsideTx asserts the read-modify-write
+// chain in Lock executes inside one RunInTx, closing the TOCTOU window where
+// a concurrent transaction could mutate the user between the read and the
+// write (audit S-3).
+func TestService_Lock_GetByIDAndUpdateInsideTx(t *testing.T) {
+	svc, repo, runner := newAtomicitySvc(t)
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "lock-atomic", Email: "l@a.t", Password: "hash",
+	})
+	require.NoError(t, err)
+	// Reset observation state so the Lock call is captured in isolation
+	// (Create itself runs inside RunInTx and would otherwise be conflated).
+	repo.getInTx, repo.updInTx, runner.runs = false, false, 0
+
+	require.NoError(t, svc.Lock(context.Background(), user.ID))
+	assert.Equal(t, 1, runner.runs, "Lock must run inside exactly one tx")
+	assert.True(t, repo.getInTx, "Lock.GetByID must be observed inside RunInTx (no TOCTOU window)")
+	assert.True(t, repo.updInTx, "Lock.Update must run inside the same tx")
+}
+
+// TestService_Unlock_GetByIDAndUpdateInsideTx asserts Unlock now runs the
+// read-modify-write chain in a single RunInTx. Pre-fix, Unlock had no tx
+// wrapping at all; post-fix both repo calls observe inTx=true (audit S-3).
+func TestService_Unlock_GetByIDAndUpdateInsideTx(t *testing.T) {
+	svc, repo, runner := newAtomicitySvc(t)
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "unlock-atomic", Email: "u@a.t", Password: "hash",
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Lock(context.Background(), user.ID))
+	repo.getInTx, repo.updInTx, runner.runs = false, false, 0
+
+	require.NoError(t, svc.Unlock(context.Background(), user.ID))
+	assert.Equal(t, 1, runner.runs, "Unlock must run inside exactly one tx")
+	assert.True(t, repo.getInTx, "Unlock.GetByID must be observed inside RunInTx (no TOCTOU window)")
+	assert.True(t, repo.updInTx, "Unlock.Update must run inside the same tx")
+}
+
+// TestService_Unlock_UpdateErrorPropagatesAndAbortsBeforeLog asserts that an
+// Update failure inside Unlock's tx returns a wrapped error and prevents the
+// success log line from running. The error must wrap "identity-manage:
+// unlock:" so the call site is identifiable.
+func TestService_Unlock_UpdateErrorPropagatesAndAbortsBeforeLog(t *testing.T) {
+	innerRepo := mem.NewUserRepository()
+	user, err := domain.NewUser("rb", "rb@e.t", "hash")
+	require.NoError(t, err)
+	user.ID = "usr-rb"
+	user.Lock()
+	require.NoError(t, innerRepo.Create(context.Background(), user))
+
+	failRepo := &failingUpdateRepo{UserRepository: innerRepo, updateErr: errors.New("disk full")}
+	runner := &recordingTxRunner{}
+	svc, err := NewService(failRepo, mem.NewSessionRepository(), newIdentityRefreshStore(), slog.Default(),
+		WithTokenIssuer(minimalStubIssuer),
+		WithTxManager(runner))
+	require.NoError(t, err)
+
+	err = svc.Unlock(context.Background(), "usr-rb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity-manage: unlock:",
+		"error must wrap with the unlock call-site prefix")
+	assert.Contains(t, err.Error(), "disk full", "underlying error must be unwrapable")
+	assert.Equal(t, 1, runner.runs, "RunInTx must have been invoked exactly once")
+	assert.Equal(t, 1, failRepo.updates, "Update was attempted inside the tx")
+}
+
+// TestService_Create_BlankUsername_RejectsBeforeRepoCreate asserts that a
+// blank username is caught by validation.RequireNotBlank with the typed
+// invalid-input code, and that no expensive work (bcrypt, repo.Create) runs
+// (audit S-4).
+func TestService_Create_BlankUsername_RejectsBeforeRepoCreate(t *testing.T) {
+	runner := &recordingTxRunner{}
+	repo := &observingUserRepo{UserRepository: mem.NewUserRepository(), runner: runner}
+	svc, err := NewService(repo, mem.NewSessionRepository(), newIdentityRefreshStore(), slog.Default(),
+		WithTokenIssuer(minimalStubIssuer),
+		WithTxManager(runner))
+	require.NoError(t, err)
+
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "", Email: "ok@e.t", Password: "pw",
+	})
+	require.Error(t, err)
+	assert.Nil(t, user)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code,
+		"blank username must be rejected with the identity-invalid-input code")
+	assert.Contains(t, err.Error(), "username is required")
+	assert.Equal(t, 0, repo.createCalls, "repo.Create must not run when input is blank")
+	assert.Equal(t, 0, runner.runs, "RunInTx must not run when input validation fails")
+}
+
+// TestService_Create_BlankEmail_RejectsBeforeRepoCreate is the email-blank
+// twin of TestService_Create_BlankUsername_RejectsBeforeRepoCreate.
+func TestService_Create_BlankEmail_RejectsBeforeRepoCreate(t *testing.T) {
+	runner := &recordingTxRunner{}
+	repo := &observingUserRepo{UserRepository: mem.NewUserRepository(), runner: runner}
+	svc, err := NewService(repo, mem.NewSessionRepository(), newIdentityRefreshStore(), slog.Default(),
+		WithTokenIssuer(minimalStubIssuer),
+		WithTxManager(runner))
+	require.NoError(t, err)
+
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "ok", Email: "", Password: "pw",
+	})
+	require.Error(t, err)
+	assert.Nil(t, user)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code)
+	assert.Contains(t, err.Error(), "email is required")
+	assert.Equal(t, 0, repo.createCalls)
+	assert.Equal(t, 0, runner.runs)
+}
+
+// TestService_Create_RequireNotBlankShortCircuitsOnFirstField asserts the
+// validator returns on the FIRST blank field in declaration order
+// (username → email → password), matching setup.CreateAdmin's order so the
+// two paths produce identical messages for identical inputs.
+func TestService_Create_RequireNotBlankShortCircuitsOnFirstField(t *testing.T) {
+	svc := newTestService()
+	_, err := svc.Create(context.Background(), CreateInput{
+		Username: "", Email: "", Password: "",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "username is required",
+		"validator must short-circuit on the first declared field; setup.CreateAdmin uses the same order")
+	assert.NotContains(t, err.Error(), "email is required")
+	assert.NotContains(t, err.Error(), "password is required")
 }

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -1,6 +1,7 @@
 package identitymanage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -16,6 +17,8 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
+	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -825,15 +828,115 @@ func TestService_Create_BlankPassword_RoutesIdentityInvalidInputCode(t *testing.
 // TestService_Create_RequireNotBlankShortCircuitsOnFirstField asserts the
 // validator returns on the FIRST blank field in declaration order
 // (username → email → password), matching setup.CreateAdmin's order so the
-// two paths produce identical messages for identical inputs.
+// two paths produce identical messages for identical inputs. Asserts both
+// the typed error code (stable contract) and the field-name message
+// (debuggability).
 func TestService_Create_RequireNotBlankShortCircuitsOnFirstField(t *testing.T) {
 	svc := newTestService()
 	_, err := svc.Create(context.Background(), CreateInput{
 		Username: "", Email: "", Password: "",
 	})
 	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code,
+		"blank-input rejection must route the typed identity-invalid-input code regardless of which field short-circuits")
 	assert.Contains(t, err.Error(), "username is required",
 		"validator must short-circuit on the first declared field; setup.CreateAdmin uses the same order")
 	assert.NotContains(t, err.Error(), "email is required")
 	assert.NotContains(t, err.Error(), "password is required")
+}
+
+// ---------------------------------------------------------------------------
+// PR-CFG-H — Lock failure-injection coverage (review six-role P2-1)
+// ---------------------------------------------------------------------------
+
+// spyEmitter implements outbox.Emitter, counting calls and returning a fixed
+// error so tests can assert publish-path failure handling. err == nil makes
+// it pure-counter spy.
+type spyEmitter struct {
+	err   error
+	calls int
+}
+
+func (e *spyEmitter) Emit(_ context.Context, _ outbox.Entry) error {
+	e.calls++
+	return e.err
+}
+
+// failingRefreshStore wraps a real refresh.Store and forces RevokeUser to
+// return a fixed error, exercising Lock's refresh-revoke failure branch
+// (review P2-1).
+type failingRefreshStore struct {
+	refresh.Store
+	revokeUserErr error
+	calls         int
+}
+
+func (s *failingRefreshStore) RevokeUser(_ context.Context, _ string) error {
+	s.calls++
+	return s.revokeUserErr
+}
+
+// TestService_Lock_RefreshRevokeFailureAbortsBeforePublishAndLog asserts the
+// Lock transaction aborts on refresh-store revoke failure: the error wraps
+// the call-site prefix, the outbox publish does not run (would commit a
+// "user.locked" event for a still-unrevoked refresh chain), and the success
+// log line does not fire (would mislead operators).
+func TestService_Lock_RefreshRevokeFailureAbortsBeforePublishAndLog(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	domainUser, err := domain.NewUser("rf-fail", "rf@e.t", "hash")
+	require.NoError(t, err)
+	domainUser.ID = "usr-rf-fail"
+	require.NoError(t, userRepo.Create(context.Background(), domainUser))
+
+	failRefresh := &failingRefreshStore{
+		Store:         newIdentityRefreshStore(),
+		revokeUserErr: errors.New("refresh DB unavailable"),
+	}
+	emitter := &spyEmitter{}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	svc, err := NewService(userRepo, mem.NewSessionRepository(), failRefresh, logger,
+		WithEmitter(emitter), WithTokenIssuer(minimalStubIssuer))
+	require.NoError(t, err)
+
+	err = svc.Lock(context.Background(), "usr-rf-fail")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lock revoke refresh chains",
+		"error must wrap the refresh-revoke call-site prefix")
+	assert.Contains(t, err.Error(), "refresh DB unavailable", "underlying error must be unwrapable")
+	assert.Equal(t, 1, failRefresh.calls, "refresh.RevokeUser was attempted once")
+	assert.Equal(t, 0, emitter.calls,
+		"publish must not run after refresh-revoke failure: tx must abort first or a TopicUserLocked event would commit while the refresh chain stays live")
+	assert.Nil(t, sloghelper.FindLogEntry(buf.String(), "user locked"),
+		"success log line must not fire when the tx aborts")
+}
+
+// TestService_Lock_PublishFailureAbortsBeforeLog asserts the success log
+// does not fire when the outbox publish itself fails: the failed publish is
+// the last step inside the tx, so a missing log line is the operator-visible
+// signal that the lock was not durably announced.
+func TestService_Lock_PublishFailureAbortsBeforeLog(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	domainUser, err := domain.NewUser("pub-fail", "pub@e.t", "hash")
+	require.NoError(t, err)
+	domainUser.ID = "usr-pub-fail"
+	require.NoError(t, userRepo.Create(context.Background(), domainUser))
+
+	emitter := &spyEmitter{err: errors.New("broker unavailable")}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	svc, err := NewService(userRepo, mem.NewSessionRepository(), newIdentityRefreshStore(), logger,
+		WithEmitter(emitter), WithTokenIssuer(minimalStubIssuer))
+	require.NoError(t, err)
+
+	err = svc.Lock(context.Background(), "usr-pub-fail")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broker unavailable", "underlying publish error must be unwrapable")
+	assert.Equal(t, 1, emitter.calls, "publish was attempted exactly once for TopicUserLocked")
+	assert.Nil(t, sloghelper.FindLogEntry(buf.String(), "user locked"),
+		"success log line must not fire when the tx publish step fails")
 }

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -659,6 +659,47 @@ func TestService_Lock_GetByIDAndUpdateInsideTx(t *testing.T) {
 	assert.True(t, repo.updInTx, "Lock.Update must run inside the same tx")
 }
 
+// TestService_Update_GetByIDAndUpdateInsideTx asserts Update's read-modify-
+// write chain runs inside a single RunInTx, closing the same TOCTOU window
+// pattern as Lock/Unlock (audit S-3 same-pattern, reviewer F7). Pre-fix
+// Update had no tx wrapping; post-fix both repo calls observe inTx=true.
+func TestService_Update_GetByIDAndUpdateInsideTx(t *testing.T) {
+	svc, repo, runner := newAtomicitySvc(t)
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "update-atomic", Email: "u@p.t", Password: "hash",
+	})
+	require.NoError(t, err)
+	repo.getInTx, repo.updInTx, runner.runs = false, false, 0
+
+	newEmail := "new@p.t"
+	updated, err := svc.Update(context.Background(), UpdateInput{ID: user.ID, Email: &newEmail})
+	require.NoError(t, err)
+	assert.Equal(t, "new@p.t", updated.Email)
+	assert.Equal(t, 1, runner.runs, "Update must run inside exactly one tx")
+	assert.True(t, repo.getInTx, "Update.GetByID must be observed inside RunInTx (no TOCTOU window)")
+	assert.True(t, repo.updInTx, "Update.Update must run inside the same tx")
+}
+
+// TestService_Update_InvalidStatusFailsBeforeTx asserts that the cheap
+// status string validation rejects invalid values before opening a tx —
+// invalid input is not a database concern.
+func TestService_Update_InvalidStatusFailsBeforeTx(t *testing.T) {
+	svc, repo, runner := newAtomicitySvc(t)
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "upd-bad-status", Email: "b@s.t", Password: "hash",
+	})
+	require.NoError(t, err)
+	repo.getInTx, repo.updInTx, runner.runs = false, false, 0
+
+	bad := "deleted"
+	_, err = svc.Update(context.Background(), UpdateInput{ID: user.ID, Status: &bad})
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code)
+	assert.Equal(t, 0, runner.runs, "invalid status must be rejected before opening a tx")
+}
+
 // TestService_Unlock_GetByIDAndUpdateInsideTx asserts Unlock now runs the
 // read-modify-write chain in a single RunInTx. Pre-fix, Unlock had no tx
 // wrapping at all; post-fix both repo calls observe inTx=true (audit S-3).

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -754,6 +754,33 @@ func TestService_Create_BlankEmail_RejectsBeforeRepoCreate(t *testing.T) {
 	assert.Equal(t, 0, runner.runs)
 }
 
+// TestService_Create_BlankPassword_RoutesIdentityInvalidInputCode covers the
+// third RequireNotBlank field. Pre-fix this path was already wired
+// (password was the sole field), so the case is a regression guard ensuring
+// the error code stays bound to the service boundary
+// (ErrAuthIdentityInvalidInput) and never leaks domain.NewUser's
+// ErrAuthInvalidInput.
+func TestService_Create_BlankPassword_RoutesIdentityInvalidInputCode(t *testing.T) {
+	runner := &recordingTxRunner{}
+	repo := &observingUserRepo{UserRepository: mem.NewUserRepository(), runner: runner}
+	svc, err := NewService(repo, mem.NewSessionRepository(), newIdentityRefreshStore(), slog.Default(),
+		WithTokenIssuer(minimalStubIssuer),
+		WithTxManager(runner))
+	require.NoError(t, err)
+
+	user, err := svc.Create(context.Background(), CreateInput{
+		Username: "ok", Email: "ok@e.t", Password: "",
+	})
+	require.Error(t, err)
+	assert.Nil(t, user)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthIdentityInvalidInput, ec.Code)
+	assert.Contains(t, err.Error(), "password is required")
+	assert.Equal(t, 0, repo.createCalls)
+	assert.Equal(t, 0, runner.runs)
+}
+
 // TestService_Create_RequireNotBlankShortCircuitsOnFirstField asserts the
 // validator returns on the FIRST blank field in declaration order
 // (username → email → password), matching setup.CreateAdmin's order so the


### PR DESCRIPTION
## Summary

PR-CFG-H 切片自 `docs/plans/202604260058-l4-virtual-taco.md`。清零 audit S-3 / S-4。

- **S-3 Lock/Unlock 读-改-写非原子** — `Lock` 之前在 `RunInTx` 之外读 `repo.GetByID`，`Unlock` 完全没有事务包裹。本 PR 把两段读-改-写全部下沉到同一个 `RunInTx` 闭包，关闭 TOCTOU 窗口。
- **S-4 Create 输入校验缺口** — `Create` 之前只用 `validation.RequireNotBlank` 校 `password`，空 `username/email` 由 `domain.NewUser` 报 `ErrAuthInvalidInput`，与 `setup.CreateAdmin` 行为漂移。本 PR 把 `RequireNotBlank` 扩到三字段（`username` → `email` → `password`），错误归到 service 边界的 `ErrAuthIdentityInvalidInput`，bcrypt + `repo.Create` 提前短路。

## Refs

- audit S-3, S-4 (PR-CFG-H)
- 计划：`docs/plans/202604260058-l4-virtual-taco.md` § PR-CFG-H
- ref: `kernel/persistence.TxRunner`（read-modify-write 必须共享同一 ctx）

## Test plan

- [x] `go test ./cells/accesscore/slices/identitymanage/...` 全绿（含 6 个新增用例）
- [x] `go test -race ./cells/accesscore/...` 全绿，无 race detector 告警
- [x] `go test ./...` 全仓绿
- [x] `golangci-lint run ./cells/accesscore/slices/identitymanage/...` — 0 issues
- [x] `go run ./cmd/gocell validate --strict` — 0 errors

## 新增测试

| 用例 | 断言 |
|---|---|
| `TestService_Lock_GetByIDAndUpdateInsideTx` | Lock 的 GetByID + Update 都观测到 `runner.inTx == true`，`runs == 1` |
| `TestService_Unlock_GetByIDAndUpdateInsideTx` | Unlock 同上（pre-fix `runs == 0`） |
| `TestService_Unlock_UpdateErrorPropagatesAndAbortsBeforeLog` | 失败的 Update 返回 `identity-manage: unlock: %w` 包装 |
| `TestService_Create_BlankUsername_RejectsBeforeRepoCreate` | `ErrAuthIdentityInvalidInput` + `username is required` + `repo.Create` 不调 |
| `TestService_Create_BlankEmail_RejectsBeforeRepoCreate` | 同上，`email is required` |
| `TestService_Create_RequireNotBlankShortCircuitsOnFirstField` | 三字段全空时仅返回 `username is required`（短路顺序） |