### PR TITLE
PR-A43 LISTENER-TEST-GAPS — 18 deliverables (PR237-T1/F06 + PR225-N1 + phase0 + archtest gate)

### DIFF
--- a/adapters/rabbitmq/subscription_run.go
+++ b/adapters/rabbitmq/subscription_run.go
@@ -29,11 +29,21 @@ type subscriptionRun struct {
 	consumerTag string
 	localWg     sync.WaitGroup // tracks processDelivery goroutines of this run only
 	closed      sync.Once
+	// wgDoneCh is closed exactly once when all in-flight deliveries have
+	// completed (localWg.Wait() returns in any wg-waiter goroutine).
+	// Initialised by newSubscriptionRun; closeWgDone ensures only one of the
+	// potentially concurrent wg-waiters closes it.
+	wgDoneCh    chan struct{}
+	closeWgDone sync.Once
 }
 
 // newSubscriptionRun creates a subscriptionRun for the given channel and consumer tag.
 func newSubscriptionRun(ch AMQPChannel, tag string) *subscriptionRun {
-	return &subscriptionRun{ch: ch, consumerTag: tag}
+	return &subscriptionRun{
+		ch:          ch,
+		consumerTag: tag,
+		wgDoneCh:    make(chan struct{}),
+	}
 }
 
 // registerDelivery marks one in-flight processDelivery goroutine started.
@@ -54,7 +64,9 @@ func (r *subscriptionRun) markDeliveryDone() {
 // Phase 1: waits for localWg (all processDelivery goroutines of this run).
 // If ctx expires before all goroutines complete, returns ctx.Err() immediately
 // without closing the channel — the channel will be abandoned (process-exit
-// cleanup semantics, matching the existing Close timeout path).
+// cleanup semantics, matching the existing Close timeout path). The internal
+// wg-waiter goroutine continues running until localWg.Wait() returns; callers
+// that need to observe its exit (e.g. leak tests) should use wgDone().
 //
 // Phase 2: closes the AMQP channel via sync.Once so that concurrent callers
 // (subscribeOnce exit path + Subscriber.Close) cannot double-close.
@@ -63,14 +75,19 @@ func (r *subscriptionRun) markDeliveryDone() {
 // ref: ThreeDotsLabs/watermill-amqp subscriber.go — closedChan→WaitGroup→ch.Close
 func (r *subscriptionRun) waitAndClose(ctx context.Context) error {
 	// Phase 1: wait for in-flight deliveries bounded by ctx.
-	done := make(chan struct{})
+	// The wg-waiter goroutine closes r.wgDoneCh when localWg.Wait() returns,
+	// providing a happens-before signal for goroutine-exit assertions in tests.
+	// wgDoneCh is initialised by newSubscriptionRun so this goroutine captures
+	// a stable reference with no data race even when waitAndClose is called
+	// concurrently from subscribeOnce and Subscriber.Close.
+	// closeWgDone ensures only one of the concurrent wg-waiters closes the channel.
 	go func() {
 		r.localWg.Wait()
-		close(done)
+		r.closeWgDone.Do(func() { close(r.wgDoneCh) })
 	}()
 
 	select {
-	case <-done:
+	case <-r.wgDoneCh:
 	case <-ctx.Done():
 		slog.Warn("rabbitmq: subscriptionRun wait-inflight ctx expired",
 			slog.String("consumer_tag", r.consumerTag),
@@ -89,6 +106,14 @@ func (r *subscriptionRun) waitAndClose(ctx context.Context) error {
 		}
 	})
 	return closeErr
+}
+
+// wgDone returns a channel that is closed when all in-flight deliveries have
+// completed (localWg.Wait() has returned in the wg-waiter goroutine spawned by
+// waitAndClose). The channel is ready as soon as newSubscriptionRun returns;
+// it is closed at most once regardless of concurrent waitAndClose calls.
+func (r *subscriptionRun) wgDone() <-chan struct{} {
+	return r.wgDoneCh
 }
 
 // cancelWithBudget issues basic.cancel for this run's consumer with per-call timeout.

--- a/adapters/rabbitmq/subscription_run_test.go
+++ b/adapters/rabbitmq/subscription_run_test.go
@@ -3,7 +3,6 @@ package rabbitmq
 import (
 	"context"
 	"errors"
-	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,12 +11,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// recordingChannel wraps mockChannel and records Close call timestamps so
-// A19 ordering assertions can compare ackCallOrder vs closeCallOrder.
+// recordingChannel wraps mockChannel and records ordering information for A19
+// happens-before assertions.
+//
+// Two complementary ordering proofs are supported:
+//
+//  1. Wall-clock: closeTime records the timestamp of Close() for tests that
+//     compare against Ack timestamps (subscriber_close_ctx_test.go A19 E2E).
+//
+//  2. Causal flag: deliveryDoneFlag is set atomically by the test immediately
+//     before markDeliveryDone; closeSeenDoneFlag records whether the flag was
+//     already set when Close() ran. This proves wg.Done happened-before ch.Close
+//     without relying on clock resolution (TestSubscriptionRun_CloseWaitsLocalWg).
 type recordingChannel struct {
 	*mockChannel
-	closeTime  atomic.Pointer[time.Time]
-	closeCount atomic.Int32
+	// closeTime records when Close() was called — used by A19 E2E timestamp tests.
+	closeTime atomic.Pointer[time.Time]
+	// deliveryDoneFlag is set by the test before markDeliveryDone. Close() checks
+	// that it is already set, establishing the happens-before: wg.Done → ch.Close.
+	deliveryDoneFlag atomic.Bool
+	// closeSeenDoneFlag records whether deliveryDoneFlag was observed true inside
+	// Close(), verifying the A19 causal ordering guarantee at the call site.
+	closeSeenDoneFlag atomic.Bool
+	closeCount        atomic.Int32
 }
 
 func newRecordingChannel() *recordingChannel {
@@ -28,6 +44,9 @@ func (r *recordingChannel) Close() error {
 	r.closeCount.Add(1)
 	t := time.Now()
 	r.closeTime.Store(&t)
+	// Record whether the delivery-done flag was set BEFORE Close was called.
+	// If the A19 invariant holds (wg.Wait before ch.Close), this must always be true.
+	r.closeSeenDoneFlag.Store(r.deliveryDoneFlag.Load())
 	return r.mockChannel.Close()
 }
 
@@ -78,19 +97,26 @@ func TestSubscriptionRun_RegisterDeliveryAndWait(t *testing.T) {
 
 // TestSubscriptionRun_CloseWaitsLocalWg asserts the A19 ordering guarantee:
 // ch.Close must NOT be called before localWg.Wait() returns.
-// We verify this by checking that the channel's Close timestamp is after
-// the last markDeliveryDone call.
+//
+// We verify causal ordering via an atomic flag rather than wall-clock timestamps:
+// rc.deliveryDoneFlag is set atomically immediately before markDeliveryDone is called.
+// recordingChannel.Close() reads that flag inside the call and stores the observation
+// in closeSeenDoneFlag. If the A19 invariant holds (wg.Wait before ch.Close), the flag
+// must always be observed as true — regardless of clock resolution.
 func TestSubscriptionRun_CloseWaitsLocalWg(t *testing.T) {
 	rc := newRecordingChannel()
 	run := newSubscriptionRun(rc, "cg-a19-order")
 
 	run.registerDelivery()
 
-	var lastDoneTime time.Time
 	done := make(chan struct{})
 	go func() {
 		time.Sleep(80 * time.Millisecond)
-		lastDoneTime = time.Now()
+		// Set the flag atomically BEFORE calling markDeliveryDone. Because
+		// wgDoneCh is closed (and ch.Close called) only after localWg.Wait()
+		// returns, Close() can only execute after this store — establishing the
+		// happens-before relationship we are asserting.
+		rc.deliveryDoneFlag.Store(true)
 		run.markDeliveryDone()
 		close(done)
 	}()
@@ -102,10 +128,9 @@ func TestSubscriptionRun_CloseWaitsLocalWg(t *testing.T) {
 	<-done
 
 	require.NoError(t, err)
-	require.NotNil(t, rc.closeTime.Load(), "ch.Close must have been called")
-	closeT := *rc.closeTime.Load()
-	assert.True(t, closeT.After(lastDoneTime) || closeT.Equal(lastDoneTime),
-		"ch.Close (%s) must happen after markDeliveryDone (%s)", closeT, lastDoneTime)
+	assert.Equal(t, int32(1), rc.closeCount.Load(), "ch.Close must have been called exactly once")
+	assert.True(t, rc.closeSeenDoneFlag.Load(),
+		"ch.Close must observe deliveryDoneFlag=true, proving wg.Wait happened-before ch.Close (A19)")
 }
 
 // TestSubscriptionRun_WaitAndClose_Idempotent verifies that calling waitAndClose
@@ -152,14 +177,13 @@ func TestSubscriptionRun_CtxTimeout(t *testing.T) {
 // verifies that when waitAndClose returns DeadlineExceeded (ctx expired before
 // in-flight deliveries drained), the internal wg-waiter goroutine does NOT
 // leak permanently. After releasing the delivery via markDeliveryDone(), the
-// abandoned goroutine must exit within a generous window so that long-running
-// test suites do not accumulate goroutine leaks from successive reconnect cycles.
+// abandoned goroutine must exit.
 //
-// Goroutine-exit is verified by: waiting for the count to rise (wg-waiter
-// spawned), then checking it falls back to the per-call baseline after
-// markDeliveryDone. The per-call baseline is taken just before waitAndClose so
-// that the already-live test-framework goroutines are included and we only
-// track the delta introduced by the wg-waiter.
+// Goroutine-exit is verified via the happens-before channel signal from
+// run.wgDone(): after markDeliveryDone unblocks localWg.Wait(), the wg-waiter
+// goroutine closes wgDoneCh, which this test receives within a 1 s window.
+// Using a channel signal instead of runtime.NumGoroutine() avoids false
+// negatives from GC goroutines and other test-framework noise.
 func TestSubscriptionRun_WaitAndClose_CtxTimeout_AbandonedGoroutineEventuallyExits(t *testing.T) {
 	ch := newMockChannel()
 	run := newSubscriptionRun(ch, "cg-abandon-exits")
@@ -167,10 +191,6 @@ func TestSubscriptionRun_WaitAndClose_CtxTimeout_AbandonedGoroutineEventuallyExi
 	// Register one in-flight delivery; the goroutine inside waitAndClose will
 	// block on localWg.Wait() until we call markDeliveryDone below.
 	run.registerDelivery()
-
-	// Capture baseline immediately before calling waitAndClose so the
-	// wg-waiter goroutine has not started yet.
-	baselineCount := runtime.NumGoroutine()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
 	defer cancel()
@@ -183,23 +203,21 @@ func TestSubscriptionRun_WaitAndClose_CtxTimeout_AbandonedGoroutineEventuallyExi
 	assert.False(t, ch.closeCalled,
 		"ch.Close must not be called when waitAndClose returns early due to ctx expiry")
 
-	// Confirm the wg-waiter goroutine is alive: the count must rise above
-	// baseline while the delivery is still in-flight.
-	var countWhileBlocked int
-	require.Eventually(t, func() bool {
-		countWhileBlocked = runtime.NumGoroutine()
-		return countWhileBlocked > baselineCount
-	}, 200*time.Millisecond, 5*time.Millisecond,
-		"wg-waiter goroutine must be observable after ctx-expired waitAndClose (baseline was %d)",
-		baselineCount)
+	// Capture wgDone channel; it is initialised by newSubscriptionRun and
+	// will be closed when the wg-waiter goroutine (spawned inside waitAndClose)
+	// finishes localWg.Wait().
+	wgDone := run.wgDone()
 
 	// Release the in-flight delivery — this unblocks the abandoned wg-waiter goroutine.
 	run.markDeliveryDone()
 
-	// The abandoned goroutine must exit: count must drop below its peak.
-	assert.Eventually(t, func() bool {
-		return runtime.NumGoroutine() < countWhileBlocked
-	}, 500*time.Millisecond, 10*time.Millisecond,
-		"goroutine count must decrease from peak (%d) after markDeliveryDone unblocks the abandoned wg-waiter",
-		countWhileBlocked)
+	// The wg-waiter goroutine must exit: wgDoneCh is closed as a happens-before
+	// signal immediately after localWg.Wait() returns.  1 s is generous enough
+	// to tolerate slow CI machines while still catching real leaks.
+	select {
+	case <-wgDone:
+		// goroutine exited as expected
+	case <-time.After(1 * time.Second):
+		t.Fatal("wg-waiter goroutine did not exit within 1 s after markDeliveryDone")
+	}
 }

--- a/adapters/rabbitmq/subscription_run_test.go
+++ b/adapters/rabbitmq/subscription_run_test.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -145,4 +146,60 @@ func TestSubscriptionRun_CtxTimeout(t *testing.T) {
 
 	// The inflight delivery is never completed — release it to avoid goroutine leak.
 	t.Cleanup(func() { run.markDeliveryDone() })
+}
+
+// TestSubscriptionRun_WaitAndClose_CtxTimeout_AbandonedGoroutineEventuallyExits
+// verifies that when waitAndClose returns DeadlineExceeded (ctx expired before
+// in-flight deliveries drained), the internal wg-waiter goroutine does NOT
+// leak permanently. After releasing the delivery via markDeliveryDone(), the
+// abandoned goroutine must exit within a generous window so that long-running
+// test suites do not accumulate goroutine leaks from successive reconnect cycles.
+//
+// Goroutine-exit is verified by: waiting for the count to rise (wg-waiter
+// spawned), then checking it falls back to the per-call baseline after
+// markDeliveryDone. The per-call baseline is taken just before waitAndClose so
+// that the already-live test-framework goroutines are included and we only
+// track the delta introduced by the wg-waiter.
+func TestSubscriptionRun_WaitAndClose_CtxTimeout_AbandonedGoroutineEventuallyExits(t *testing.T) {
+	ch := newMockChannel()
+	run := newSubscriptionRun(ch, "cg-abandon-exits")
+
+	// Register one in-flight delivery; the goroutine inside waitAndClose will
+	// block on localWg.Wait() until we call markDeliveryDone below.
+	run.registerDelivery()
+
+	// Capture baseline immediately before calling waitAndClose so the
+	// wg-waiter goroutine has not started yet.
+	baselineCount := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	err := run.waitAndClose(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"waitAndClose must return DeadlineExceeded when ctx expires with in-flight delivery")
+
+	// Channel must NOT have been closed: Phase 2 is skipped on ctx expiry.
+	assert.False(t, ch.closeCalled,
+		"ch.Close must not be called when waitAndClose returns early due to ctx expiry")
+
+	// Confirm the wg-waiter goroutine is alive: the count must rise above
+	// baseline while the delivery is still in-flight.
+	var countWhileBlocked int
+	require.Eventually(t, func() bool {
+		countWhileBlocked = runtime.NumGoroutine()
+		return countWhileBlocked > baselineCount
+	}, 200*time.Millisecond, 5*time.Millisecond,
+		"wg-waiter goroutine must be observable after ctx-expired waitAndClose (baseline was %d)",
+		baselineCount)
+
+	// Release the in-flight delivery — this unblocks the abandoned wg-waiter goroutine.
+	run.markDeliveryDone()
+
+	// The abandoned goroutine must exit: count must drop below its peak.
+	assert.Eventually(t, func() bool {
+		return runtime.NumGoroutine() < countWhileBlocked
+	}, 500*time.Millisecond, 10*time.Millisecond,
+		"goroutine count must decrease from peak (%d) after markDeliveryDone unblocks the abandoned wg-waiter",
+		countWhileBlocked)
 }

--- a/cells/accesscore/auth_integration_test.go
+++ b/cells/accesscore/auth_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // AUTH-INT-REACHABILITY-01 + PR-P0-AUTH-INTENT cell-level integration tests.
 //
 // These tests exercise the end-to-end composition of session-login (to mint a
@@ -379,13 +381,6 @@ type rbacStubTxRunner struct{}
 func (rbacStubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) error {
 	return fn(context.Background())
 }
-
-// noopPublisher implements eventbus.Publisher for tests that do not care
-// about published events. Keeps AccessCore.Init happy in demo mode.
-type noopPublisher struct{}
-
-func (noopPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
-func (noopPublisher) Close(_ context.Context) error                       { return nil }
 
 // Compile-time proof these tests hit the real slices (not stubs).
 var (

--- a/cells/accesscore/auth_refresh_aud_integration_test.go
+++ b/cells/accesscore/auth_refresh_aud_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // PR-A30 S22 REFRESH-AUD-REAL-ROUTE-TEST-01.
 //
 // Refresh tokens are opaque (PR-A29) — audience is on the *response* access JWT,

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -1019,3 +1019,12 @@ func TestAccessCore_PasswordResetExempt_PropagatesViaRouter(t *testing.T) {
 		"%s %s must appear in Router.DeclaredAuthMetas(); got %v",
 		wantMethod, wantPath, r.DeclaredAuthMetas())
 }
+
+// noopPublisher implements eventbus.Publisher for tests that do not care
+// about published events. Keeps AccessCore.Init happy in demo mode.
+type noopPublisher struct{}
+
+func (noopPublisher) Publish(_ context.Context, _ string, _ []byte) error { return nil }
+func (noopPublisher) Close(_ context.Context) error                       { return nil }
+
+var _ outbox.Publisher = noopPublisher{}

--- a/cmd/corebundle/auth_integration_test.go
+++ b/cmd/corebundle/auth_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package main
 
 import (

--- a/cmd/corebundle/internal_guard_env_test.go
+++ b/cmd/corebundle/internal_guard_env_test.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,6 +20,10 @@ import (
 // captureSlogWarnLines installs a JSON slog handler capturing Warn-and-above
 // records into a buffer. Returns the buffer and a restore function.
 // The restore must be called via t.Cleanup to avoid polluting other tests.
+//
+// NOT concurrency-safe: callers must not run parallel sub-tests while this
+// capture is active, because slog.SetDefault replaces the global logger for
+// the entire process.
 func captureSlogWarnLines(t *testing.T) (*bytes.Buffer, func()) {
 	t.Helper()
 	var buf bytes.Buffer
@@ -118,6 +124,25 @@ func TestInternalGuardFromEnv_WarnLogging_TableDriven(t *testing.T) {
 
 			assert.Equal(t, tc.wantWarnCnt, countWarnLines(buf),
 				"case %q: unexpected number of slog.Warn lines", tc.name)
+
+			// Deep assertions for specific cases.
+			switch tc.name {
+			case "real_no_secret":
+				// internalGuardFromEnv must return ERR_CONTROLPLANE_SERVICE_SECRET_MISSING
+				// when GOCELL_SERVICE_SECRET is empty in adapter mode "real".
+				var ec *errcode.Error
+				require.ErrorAs(t, err, &ec,
+					"real_no_secret: error must be an *errcode.Error")
+				assert.Equal(t, errcode.ErrControlplaneServiceSecretMissing, ec.Code,
+					"real_no_secret: error code must be ERR_CONTROLPLANE_SERVICE_SECRET_MISSING")
+			case "real_with_secret":
+				// The guard must have a non-noop NonceStore installed.
+				require.NotNil(t, guard, "real_with_secret: guard must not be nil")
+				ns := guard.NonceStore()
+				require.NotNil(t, ns, "real_with_secret: NonceStore must not be nil")
+				assert.NotEqual(t, auth.NonceStoreKindNoop, ns.Kind(),
+					"real_with_secret: NonceStore must not be noop in adapter mode real")
+			}
 		})
 	}
 }

--- a/cmd/corebundle/internal_guard_env_test.go
+++ b/cmd/corebundle/internal_guard_env_test.go
@@ -1,0 +1,123 @@
+// F06: table-driven tests for internalGuardFromEnv slog.Warn emission.
+//
+// Verifies that the "controlplane guard disabled" warning is emitted exactly
+// once in dev mode with an empty secret, and NOT emitted in other branches
+// (dev+secret, real+no-secret-returns-error, real+secret-installs-guard).
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureSlogWarnLines installs a JSON slog handler capturing Warn-and-above
+// records into a buffer. Returns the buffer and a restore function.
+// The restore must be called via t.Cleanup to avoid polluting other tests.
+func captureSlogWarnLines(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	return &buf, func() { slog.SetDefault(prev) }
+}
+
+// countWarnLines counts JSON log lines whose "level" == "WARN" in buf.
+func countWarnLines(buf *bytes.Buffer) int {
+	count := 0
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec["level"] == "WARN" {
+			count++
+		}
+	}
+	return count
+}
+
+func TestInternalGuardFromEnv_WarnLogging_TableDriven(t *testing.T) {
+	tests := []struct {
+		name        string
+		adapterMode string
+		secret      string // empty means t.Setenv("GOCELL_SERVICE_SECRET", "")
+		wantWarnCnt int
+		wantErr     bool
+		wantGuard   bool
+	}{
+		{
+			name:        "dev_no_secret",
+			adapterMode: "",
+			secret:      "",
+			wantWarnCnt: 1,
+			wantErr:     false,
+			wantGuard:   false,
+		},
+		{
+			name:        "dev_with_secret",
+			adapterMode: "",
+			// freshTestServiceSecret is called per-case below to keep each test hermetic.
+			wantWarnCnt: 0,
+			wantErr:     false,
+			wantGuard:   true,
+		},
+		{
+			name:        "real_no_secret",
+			adapterMode: "real",
+			secret:      "",
+			wantWarnCnt: 0,
+			wantErr:     true,
+			wantGuard:   false,
+		},
+		{
+			name:        "real_with_secret",
+			adapterMode: "real",
+			wantWarnCnt: 0,
+			wantErr:     false,
+			wantGuard:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Resolve secret: cases that need a real secret get a fresh one.
+			secret := tc.secret
+			if tc.wantGuard {
+				secret = freshTestServiceSecret(t)
+			}
+			t.Setenv("GOCELL_SERVICE_SECRET", secret)
+
+			buf, restore := captureSlogWarnLines(t)
+			t.Cleanup(restore)
+
+			guard, err := internalGuardFromEnv(tc.adapterMode, nil)
+
+			if tc.wantErr {
+				require.Error(t, err,
+					"case %q: expected error but got nil", tc.name)
+			} else {
+				require.NoError(t, err,
+					"case %q: unexpected error: %v", tc.name, err)
+			}
+
+			if tc.wantGuard {
+				assert.NotNil(t, guard,
+					"case %q: expected non-nil guard", tc.name)
+			} else {
+				assert.Nil(t, guard,
+					"case %q: expected nil guard", tc.name)
+			}
+
+			assert.Equal(t, tc.wantWarnCnt, countWarnLines(buf),
+				"case %q: unexpected number of slog.Warn lines", tc.name)
+		})
+	}
+}

--- a/cmd/corebundle/jwt_aud_integration_test.go
+++ b/cmd/corebundle/jwt_aud_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // Integration tests for audience validation wiring in buildJWTDeps (PR-R-AUTH-AUD-VALIDATION).
 //
 // Verifies that the verifier constructed by buildJWTDeps enforces RFC 8725 §3.3:

--- a/cmd/corebundle/metrics_wiring_integration_test.go
+++ b/cmd/corebundle/metrics_wiring_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package main
 
 import (

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package main
 
 import (

--- a/kernel/governance/location_integration_test.go
+++ b/kernel/governance/location_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package governance_test
 
 import (

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -285,11 +285,8 @@ func (b *Bootstrap) validateHTTPListenerConfigs() error {
 		return err
 	}
 	for ref, cfg := range b.listenerConfigs {
-		if cfg.net == nil && cfg.addr == "" {
-			return fmt.Errorf("bootstrap: listener %q has no address or pre-bound net.Listener; use WithListener addr or WithListenerNet", ref.String())
-		}
-		if cfg.shutGrace < 0 {
-			return fmt.Errorf("bootstrap: listener %q has negative shutdownGrace %v; use a non-negative duration or zero to inherit the global shutdownTimeout", ref.String(), cfg.shutGrace)
+		if err := validateListenerConfig(ref, cfg); err != nil {
+			return err
 		}
 	}
 	// B2: when a metrics handler is configured, a dedicated HealthListener must
@@ -300,6 +297,22 @@ func (b *Bootstrap) validateHTTPListenerConfigs() error {
 				"bootstrap: WithHealthRoutes(WithMetricsHandler(...)) requires a dedicated HealthListener; " +
 					"add WithListener(cell.HealthListener, ...) to isolate /metrics from the primary listener")
 		}
+	}
+	return nil
+}
+
+// validateListenerConfig validates a single listener config: address presence,
+// shutdownGrace sign, and TLS handshake-ability. Extracted from
+// validateHTTPListenerConfigs to keep cognitive complexity within budget.
+func validateListenerConfig(ref cell.ListenerRef, cfg listenerConfig) error {
+	if cfg.net == nil && cfg.addr == "" {
+		return fmt.Errorf("bootstrap: listener %q has no address or pre-bound net.Listener; use WithListener addr or WithListenerNet", ref.String())
+	}
+	if cfg.shutGrace < 0 {
+		return fmt.Errorf("bootstrap: listener %q has negative shutdownGrace %v; use a non-negative duration or zero to inherit the global shutdownTimeout", ref.String(), cfg.shutGrace)
+	}
+	if cfg.tls != nil && len(cfg.tls.Certificates) == 0 && cfg.tls.GetCertificate == nil && cfg.tls.GetConfigForClient == nil {
+		return fmt.Errorf("bootstrap: listener %q TLS config has no Certificates / GetCertificate / GetConfigForClient; the server cannot perform a TLS handshake", ref.String())
 	}
 	return nil
 }

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ package bootstrap
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -303,7 +304,10 @@ func (b *Bootstrap) validateHTTPListenerConfigs() error {
 
 // validateListenerConfig validates a single listener config: address presence,
 // shutdownGrace sign, and TLS handshake-ability. Extracted from
-// validateHTTPListenerConfigs to keep cognitive complexity within budget.
+// validateHTTPListenerConfigs to keep that function's cognitive complexity within
+// budget: combining the three conditions (addr+net presence, shutGrace sign, TLS
+// certificate availability) with per-listener ref context and error formatting
+// would push the outer function beyond the limit of 15.
 func validateListenerConfig(ref cell.ListenerRef, cfg listenerConfig) error {
 	if cfg.net == nil && cfg.addr == "" {
 		return fmt.Errorf("bootstrap: listener %q has no address or pre-bound net.Listener; use WithListener addr or WithListenerNet", ref.String())
@@ -311,8 +315,40 @@ func validateListenerConfig(ref cell.ListenerRef, cfg listenerConfig) error {
 	if cfg.shutGrace < 0 {
 		return fmt.Errorf("bootstrap: listener %q has negative shutdownGrace %v; use a non-negative duration or zero to inherit the global shutdownTimeout", ref.String(), cfg.shutGrace)
 	}
-	if cfg.tls != nil && len(cfg.tls.Certificates) == 0 && cfg.tls.GetCertificate == nil && cfg.tls.GetConfigForClient == nil {
+	if err := validateListenerTLSConfig(ref, cfg.tls); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateListenerTLSConfig fail-fasts when the supplied tls.Config cannot
+// possibly produce a successful handshake. The check covers two distinct
+// failure modes that crypto/tls otherwise only surfaces at handshake time:
+//
+//  1. No certificate source at all (Certificates / GetCertificate /
+//     GetConfigForClient all empty / nil).
+//  2. A static Certificates slice present but every entry is a zero-value
+//     tls.Certificate — i.e. no certificate chain AND no private key — which
+//     trips an opaque "tls: no certificates configured" / "tls: failed to
+//     find any PEM data" once the first ClientHello arrives.
+//
+// nil cfg is a non-TLS listener and returns nil.
+func validateListenerTLSConfig(ref cell.ListenerRef, cfg *tls.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.Certificates) == 0 && cfg.GetCertificate == nil && cfg.GetConfigForClient == nil {
 		return fmt.Errorf("bootstrap: listener %q TLS config has no Certificates / GetCertificate / GetConfigForClient; the server cannot perform a TLS handshake", ref.String())
+	}
+	// Static Certificates must each carry at least a chain or a key. Dynamic
+	// sources (GetCertificate / GetConfigForClient) are trusted as opaque
+	// callbacks and intentionally not introspected here.
+	if len(cfg.Certificates) > 0 {
+		for i, c := range cfg.Certificates {
+			if len(c.Certificate) == 0 && c.PrivateKey == nil && c.Leaf == nil {
+				return fmt.Errorf("bootstrap: listener %q TLS Certificates[%d] is a zero-value tls.Certificate (no chain, no private key); load a real key pair via tls.LoadX509KeyPair or set GetCertificate", ref.String(), i)
+			}
+		}
 	}
 	return nil
 }

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -1109,10 +1109,10 @@ func (b *Bootstrap) phase7StartHTTPServer(s *phaseState) error {
 	}
 	httpErrCh := b.phase7ServeAll(servers)
 	s.httpErrCh = httpErrCh
-	// Capture servers slice for teardown (OPS-01: pass boundServers for named logging).
-	capturedServers := servers
+	// Convert to shutdownTasks for teardown (OPS-01: named logging via shutdownTask.name).
+	shutTasks := boundServersToTasks(servers)
 	s.addTeardown(func(c context.Context) error {
-		return shutdownAllServers(c, capturedServers)
+		return shutdownAllServers(c, shutTasks)
 	})
 	return nil
 }
@@ -1247,7 +1247,16 @@ func resolveListener(cfg listenerConfig) (ln net.Listener, owned bool, err error
 	return tcpLn, true, nil
 }
 
-// shutdownAllServers drains all servers in parallel. Each server uses a
+// shutdownTask represents a single server shutdown operation with its name and
+// grace period. Extracted from boundServer to allow tests to inject arbitrary
+// shutdown functions without requiring a real http.Server.
+type shutdownTask struct {
+	name      string
+	shutGrace time.Duration
+	shutdown  func(context.Context) error
+}
+
+// shutdownAllServers drains all servers in parallel. Each task uses a
 // per-server context derived from the parent ctx:
 //   - when shutGrace > 0 (set via WithListenerShutdownGrace), the parent ctx
 //     is wrapped with context.WithTimeout(ctx, shutGrace) so shutGrace is an
@@ -1258,40 +1267,52 @@ func resolveListener(cfg listenerConfig) (ln net.Listener, owned bool, err error
 //
 // Errors are aggregated via errors.Join so operators see every failure.
 //
-// OPS-01: accepts []boundServer so each shutdown log line carries the listener
-// name instead of an opaque numeric index.
-//
+// OPS-01: each task carries a name so shutdown log lines identify the listener.
 // R2-03: parent ctx (not context.Background) is the timeout parent so the
 // global shutdownTimeout always bounds per-listener drains.
-func shutdownAllServers(ctx context.Context, servers []boundServer) error {
+func shutdownAllServers(ctx context.Context, tasks []shutdownTask) error {
 	slog.Info("bootstrap: draining HTTP servers")
 	type drainResult struct {
 		err error
 	}
-	resultCh := make(chan drainResult, len(servers))
-	for _, bs := range servers {
-		bs := bs // capture
+	resultCh := make(chan drainResult, len(tasks))
+	for _, task := range tasks {
+		task := task // capture
 		go func() {
-			shutCtx, cancel := shutdownCtxFor(ctx, bs.shutGrace)
+			shutCtx, cancel := shutdownCtxFor(ctx, task.shutGrace)
 			defer cancel()
-			err := bs.srv.Shutdown(shutCtx)
+			err := task.shutdown(shutCtx)
 			if err != nil {
 				slog.Error("bootstrap: HTTP server drain failed",
-					slog.String("listener", bs.name), slog.Any("error", err))
+					slog.String("listener", task.name), slog.Any("error", err))
 			} else {
-				slog.Info("bootstrap: HTTP server drained", slog.String("listener", bs.name))
+				slog.Info("bootstrap: HTTP server drained", slog.String("listener", task.name))
 			}
 			resultCh <- drainResult{err: err}
 		}()
 	}
 	var errs []error
-	for range servers {
+	for range tasks {
 		r := <-resultCh
 		if r.err != nil {
 			errs = append(errs, r.err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// boundServersToTasks converts []boundServer into []shutdownTask for shutdownAllServers.
+func boundServersToTasks(servers []boundServer) []shutdownTask {
+	tasks := make([]shutdownTask, len(servers))
+	for i, bs := range servers {
+		bs := bs // capture
+		tasks[i] = shutdownTask{
+			name:      bs.name,
+			shutGrace: bs.shutGrace,
+			shutdown:  bs.srv.Shutdown,
+		}
+	}
+	return tasks
 }
 
 // phase8StartWorkers starts the WorkerGroup using the caller-supplied runCtx

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -1285,6 +1285,12 @@ func shutdownAllServers(ctx context.Context, tasks []shutdownTask) error {
 			if err != nil {
 				slog.Error("bootstrap: HTTP server drain failed",
 					slog.String("listener", task.name), slog.Any("error", err))
+				// OPS-01: wrap with the listener name so the returned error chain
+				// preserves the same attribution that already lives in the slog
+				// line. Without this, errors.Join collapses to opaque "shutdown
+				// failed" lines once the goroutine returns and operators can no
+				// longer tell which listener tripped from the error object alone.
+				err = fmt.Errorf("listener %q shutdown: %w", task.name, err)
 			} else {
 				slog.Info("bootstrap: HTTP server drained", slog.String("listener", task.name))
 			}
@@ -1305,7 +1311,6 @@ func shutdownAllServers(ctx context.Context, tasks []shutdownTask) error {
 func boundServersToTasks(servers []boundServer) []shutdownTask {
 	tasks := make([]shutdownTask, len(servers))
 	for i, bs := range servers {
-		bs := bs // capture
 		tasks[i] = shutdownTask{
 			name:      bs.name,
 			shutGrace: bs.shutGrace,

--- a/runtime/bootstrap/consumer_tracing_integration_test.go
+++ b/runtime/bootstrap/consumer_tracing_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package bootstrap
 
 import (

--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -2,10 +2,12 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -514,4 +516,413 @@ func TestDualListener_BootstrapOwnedPrimary_InternalBindFails(t *testing.T) {
 	require.Error(t, err, "internal bind failure must cause Run to return an error")
 	assert.Contains(t, err.Error(), "listen internal",
 		"error must identify the failing listener as 'internal'")
+}
+
+// ---------------------------------------------------------------------------
+// T-01: FinalizeAuth duplicate meta detection
+// ---------------------------------------------------------------------------
+
+// duplicateMetaCell mounts two routes with the same (method, path) to trigger
+// FinalizeAuth duplicate detection.
+type duplicateMetaCell struct {
+	*cell.BaseCell
+}
+
+func (c *duplicateMetaCell) RouteGroups() []cell.RouteGroup {
+	spec := testHTTPContract(http.MethodGet, "/api/v1/dup/ping")
+	return []cell.RouteGroup{
+		{
+			Listener: cell.PrimaryListener,
+			Prefix:   "",
+			Register: func(mux cell.RouteMux) {
+				auth.Mount(mux, auth.Route{Contract: spec, Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+				auth.Mount(mux, auth.Route{Contract: spec, Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+			},
+		},
+	}
+}
+
+// TestDualListener_FinalizeAuth_DuplicateMeta_Errors verifies that FinalizeAuth
+// returns an error when the same (method, path) pair is mounted twice on the
+// primary listener — protecting configuration cleanliness (FinalizeAuth invariant).
+func TestDualListener_FinalizeAuth_DuplicateMeta_Errors(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "dup-meta-test", DurabilityMode: cell.DurabilityDemo})
+	c := &duplicateMetaCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: "dup-meta-cell", Type: cell.CellTypeCore}),
+	}
+	require.NoError(t, asm.Register(c))
+
+	primaryLn := newLocalListener(t)
+	b := New(
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), nil, WithListenerNet(primaryLn)),
+		WithShutdownTimeout(time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := b.Run(ctx)
+	require.Error(t, err, "duplicate route meta must cause Run to return an error")
+}
+
+// ---------------------------------------------------------------------------
+// T-02: shutdownAllServers aggregates partial errors (Wave C dependency)
+// ---------------------------------------------------------------------------
+
+// TestShutdownAllServers_AggregatesPartialErrors verifies that shutdownAllServers
+// collects errors from all tasks and joins them, not short-circuiting on the first.
+func TestShutdownAllServers_AggregatesPartialErrors(t *testing.T) {
+	err1 := errors.New("server-a shutdown timeout")
+	err2 := errors.New("server-b connection reset")
+
+	tasks := []shutdownTask{
+		{
+			name:      "server-a",
+			shutGrace: 0,
+			shutdown:  func(_ context.Context) error { return err1 },
+		},
+		{
+			name:      "server-b",
+			shutGrace: 0,
+			shutdown:  func(_ context.Context) error { return err2 },
+		},
+		{
+			name:      "server-c",
+			shutGrace: 0,
+			shutdown:  func(_ context.Context) error { return nil },
+		},
+	}
+
+	ctx := context.Background()
+	got := shutdownAllServers(ctx, tasks)
+	require.Error(t, got, "shutdownAllServers must return error when any task fails")
+	assert.True(t, errors.Is(got, err1) || strings.Contains(got.Error(), err1.Error()),
+		"joined error must contain err1")
+	assert.True(t, errors.Is(got, err2) || strings.Contains(got.Error(), err2.Error()),
+		"joined error must contain err2")
+}
+
+// ---------------------------------------------------------------------------
+// T-03: Phase7ServeAll dual listener — no close race (-race required)
+// ---------------------------------------------------------------------------
+
+// TestPhase7ServeAll_DualListener_NoCloseRace verifies that concurrent Serve
+// goroutines do not race on shared state when the listeners are closed in
+// parallel during shutdown. This test is only meaningful with -race.
+func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
+	// This test is intentionally NOT skipped in -short because it validates a
+	// safety property (no data race) under parallel server shutdown.
+	primaryLn := newLocalListener(t)
+	internalLn := newLocalListener(t)
+
+	c := newDualListenerCell(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+	)
+	asm := assembly.New(assembly.Config{ID: "race-test", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(c))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), nil, WithListenerNet(primaryLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), nil, WithListenerNet(internalLn)),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	primaryAddr := primaryLn.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
+
+	// Fire concurrent requests while shutting down to exercise the race window.
+	var inFlight atomic.Int32
+	for i := 0; i < 4; i++ {
+		go func() {
+			inFlight.Add(1)
+			defer inFlight.Add(-1)
+			_, _ = testHTTPClient.Get(fmt.Sprintf("http://%s/api/v1/test/ping", primaryAddr))
+		}()
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T-04: Phase7BindListeners — owned socket closed on sibling failure
+// ---------------------------------------------------------------------------
+
+// TestPhase7BindListeners_OwnedSocket_ClosedOnSiblingFailure verifies that
+// when bootstrap owns a socket (primary :0) and the next bind fails (collision),
+// the already-owned socket is released. This mirrors TEST-11 for the generic path.
+func TestPhase7BindListeners_OwnedSocket_ClosedOnSiblingFailure(t *testing.T) {
+	// Hold a port so internal bind collides.
+	holdLn := newLocalListener(t)
+	collidingAddr := holdLn.Addr().String()
+
+	asm := assembly.New(assembly.Config{ID: "owned-sibling-fail", DurabilityMode: cell.DurabilityDemo})
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil),  // bootstrap-owned; should succeed then be released
+		WithListener(cell.InternalListener, collidingAddr, nil), // collides
+		WithShutdownTimeout(time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := b.Run(ctx)
+	require.Error(t, err, "sibling bind failure must propagate")
+	assert.Contains(t, err.Error(), "listen internal")
+}
+
+// ---------------------------------------------------------------------------
+// T-05: RouteGroup Middleware order preserved
+// ---------------------------------------------------------------------------
+
+// middlewareOrderCell mounts a route with two middleware that record call order.
+type middlewareOrderCell struct {
+	*cell.BaseCell
+	order *[]string
+}
+
+func (c *middlewareOrderCell) RouteGroups() []cell.RouteGroup {
+	order := c.order
+	mw1 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			*order = append(*order, "mw1")
+			next.ServeHTTP(w, r)
+		})
+	}
+	mw2 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			*order = append(*order, "mw2")
+			next.ServeHTTP(w, r)
+		})
+	}
+	return []cell.RouteGroup{
+		{
+			Listener:   cell.PrimaryListener,
+			Prefix:     "/api/v1/mwtest",
+			Middleware: []func(http.Handler) http.Handler{mw1, mw2},
+			Register: func(mux cell.RouteMux) {
+				auth.Mount(mux, auth.Route{
+					Contract: testHTTPContract(http.MethodGet, "/api/v1/mwtest/ping"),
+					Handler:  http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+					Public:   true,
+				})
+			},
+		},
+	}
+}
+
+// TestRouteGroup_Middleware_OrderPreserved verifies that RouteGroup.Middleware
+// entries are applied in declaration order: first registered is outermost.
+func TestRouteGroup_Middleware_OrderPreserved(t *testing.T) {
+	var order []string
+	c := &middlewareOrderCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{ID: "mw-order-cell", Type: cell.CellTypeCore}),
+		order:    &order,
+	}
+	asm := assembly.New(assembly.Config{ID: "mw-order-test", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(c))
+
+	primaryLn := newLocalListener(t)
+	b := New(
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), nil, WithListenerNet(primaryLn)),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	primaryAddr := primaryLn.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
+
+	resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/api/v1/mwtest/ping", primaryAddr))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, []string{"mw1", "mw2"}, order,
+		"middleware must execute in declaration order (first registered = outermost)")
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T-09: AuthWiring internal guard waits for internal listener ready
+// ---------------------------------------------------------------------------
+
+// TestAuthWiring_InternalGuard_WaitsForInternalListenerReady verifies that
+// the internal listener is serving before the primary listener becomes healthy.
+// Both must be bound and accepting before /healthz returns 200.
+func TestAuthWiring_InternalGuard_WaitsForInternalListenerReady(t *testing.T) {
+	primaryLn := newLocalListener(t)
+	internalLn := newLocalListener(t)
+
+	c := newDualListenerCell(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+	)
+	asm := assembly.New(assembly.Config{ID: "auth-wiring-test", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(c))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), nil, WithListenerNet(primaryLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), nil, WithListenerNet(internalLn)),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	primaryAddr := primaryLn.Addr().String()
+	internalAddr := internalLn.Addr().String()
+	// Wait for primary healthy.
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
+
+	// Internal listener must also be reachable by the time primary is healthy.
+	resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/internal/v1/admin/ping", internalAddr))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"internal listener must be reachable after primary becomes healthy")
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T-10: Goroutine baseline after server stable
+// ---------------------------------------------------------------------------
+
+// TestShutdown_NumGoroutineBaseline_AfterServerStable verifies that after a
+// clean shutdown, the goroutine count does not permanently exceed the baseline
+// taken just before shutdown began.
+func TestShutdown_NumGoroutineBaseline_AfterServerStable(t *testing.T) {
+	primaryLn := newLocalListener(t)
+	internalLn := newLocalListener(t)
+
+	c := newDualListenerCell(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+	)
+	asm := assembly.New(assembly.Config{ID: "goroutine-baseline-test", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Register(c))
+
+	b := New(
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), nil, WithListenerNet(primaryLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), nil, WithListenerNet(internalLn)),
+		WithShutdownTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	primaryAddr := primaryLn.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
+
+	baseline := runtime.NumGoroutine()
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baseline
+	}, 2*time.Second, 50*time.Millisecond,
+		"goroutine count must not exceed baseline after clean shutdown")
+}
+
+// ---------------------------------------------------------------------------
+// Phase0 三连：NoListeners / DuplicateListenerRefs / MetricsRequiresHealth
+// ---------------------------------------------------------------------------
+
+// TestPhase0_NoListenersDeclared verifies that phase0 fails fast when no
+// listeners are declared.
+func TestPhase0_NoListenersDeclared(t *testing.T) {
+	b := New() // no WithListener calls
+	err := b.phase0ValidateOptions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no HTTP listeners declared")
+}
+
+// TestPhase0_DuplicateListenerRefs verifies that phase0 fails fast when the
+// same ListenerRef is declared more than once.
+func TestPhase0_DuplicateListenerRefs(t *testing.T) {
+	b := New(
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil),
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil), // duplicate
+	)
+	err := b.phase0ValidateOptions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate WithListener")
+}
+
+// TestPhase0_MetricsRequiresHealthListener verifies that configuring a metrics
+// handler without a dedicated HealthListener is rejected at phase0 (B2 rule).
+func TestPhase0_MetricsRequiresHealthListener(t *testing.T) {
+	b := New(
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil),
+		WithHealthRoutes(WithMetricsHandler(http.NewServeMux())),
+	)
+	err := b.phase0ValidateOptions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithHealthRoutes(WithMetricsHandler")
 }

--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -357,6 +358,7 @@ func TestDualListener_ShutdownClosesBothServersNoGoroutineLeak(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	primaryAddr := primaryLn.Addr().String()
+	internalAddr := internalLn.Addr().String()
 	require.Eventually(t, func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
@@ -366,6 +368,11 @@ func TestDualListener_ShutdownClosesBothServersNoGoroutineLeak(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
 
+	// Baseline is taken AFTER the server is confirmed stable (healthz 200 above).
+	// All bootstrap-internal goroutines (HTTP serve loops, etc.) are already running,
+	// so the baseline already includes them. Taking it here — before cancel() — provides
+	// a happens-before synchronisation point: no goroutine launches between this line
+	// and cancel().
 	before := runtime.NumGoroutine()
 
 	cancel()
@@ -381,14 +388,12 @@ func TestDualListener_ShutdownClosesBothServersNoGoroutineLeak(t *testing.T) {
 		return runtime.NumGoroutine() <= before
 	}, 2*time.Second, 50*time.Millisecond, "goroutine count did not return to baseline")
 
-	// Both listeners must be closed after shutdown — new Listen on same
-	// *:0 port won't collide since ports are ephemeral, but the listeners
-	// themselves should report closed when double-closed.
-	// net.Listener's Close is idempotent-ish: second close typically returns
-	// errClosed, not an error we must propagate. We just verify they're not
-	// accepting.
+	// Both listeners must be closed after shutdown — verify neither accepts new connections.
 	_, err := net.Dial("tcp", primaryAddr)
 	assert.Error(t, err, "primary listener should be closed; Dial must fail")
+
+	_, err = net.Dial("tcp", internalAddr)
+	assert.Error(t, err, "internal listener should be closed; Dial must fail")
 }
 
 // TestTripleListener_ShutdownNoGoroutineLeak extends the dual-listener goroutine
@@ -428,6 +433,11 @@ func TestTripleListener_ShutdownNoGoroutineLeak(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, 3*time.Second, 50*time.Millisecond, "health listener did not become ready")
 
+	// Baseline is taken AFTER the server is confirmed stable (healthz 200 above).
+	// All bootstrap-internal goroutines (HTTP serve loops, etc.) are already running,
+	// so the baseline already includes them. Taking it here — before cancel() — provides
+	// a happens-before synchronisation point: no goroutine launches between this line
+	// and cancel().
 	before := runtime.NumGoroutine()
 
 	cancel()
@@ -600,6 +610,13 @@ func TestShutdownAllServers_AggregatesPartialErrors(t *testing.T) {
 		"joined error must contain err1")
 	assert.True(t, errors.Is(got, err2) || strings.Contains(got.Error(), err2.Error()),
 		"joined error must contain err2")
+	// OPS-01: aggregated error must preserve per-listener attribution so
+	// operators can pick out which listener tripped from the error object alone
+	// (matching the slog "listener=" attribute).
+	assert.Contains(t, got.Error(), `listener "server-a"`,
+		"joined error must wrap err1 with listener name")
+	assert.Contains(t, got.Error(), `listener "server-b"`,
+		"joined error must wrap err2 with listener name")
 }
 
 // ---------------------------------------------------------------------------
@@ -644,9 +661,14 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
 
 	// Fire concurrent requests while shutting down to exercise the race window.
+	// WaitGroup ensures all in-flight goroutines have exited before the test
+	// function returns, preventing goroutine leaks that could pollute later tests.
+	var wg sync.WaitGroup
 	var inFlight atomic.Int32
 	for i := 0; i < 4; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			inFlight.Add(1)
 			defer inFlight.Add(-1)
 			_, _ = testHTTPClient.Get(fmt.Sprintf("http://%s/api/v1/test/ping", primaryAddr))
@@ -660,6 +682,9 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("bootstrap did not shut down in time")
 	}
+
+	// Wait for all in-flight request goroutines to complete.
+	wg.Wait()
 }
 
 // ---------------------------------------------------------------------------
@@ -874,6 +899,12 @@ func TestShutdown_NumGoroutineBaseline_AfterServerStable(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
 
+	// Baseline is taken AFTER the server is confirmed stable (healthz 200 returned
+	// above). Taking it here ensures that all bootstrap-internal goroutines (HTTP
+	// serve loops, worker loops, etc.) are already running, so the baseline already
+	// includes them. Taking it before cancel() also provides a happens-before
+	// synchronisation point: there are no in-flight goroutine launches between this
+	// line and cancel().
 	baseline := runtime.NumGoroutine()
 
 	cancel()
@@ -884,6 +915,10 @@ func TestShutdown_NumGoroutineBaseline_AfterServerStable(t *testing.T) {
 		t.Fatal("bootstrap did not shut down in time")
 	}
 
+	// 2 s convergence window: the Go runtime does not reclaim goroutine stack
+	// frames synchronously; after Run returns the net/http server and internal
+	// goroutines are in the process of exiting.  2 s is generous enough to
+	// tolerate slow CI machines while still catching real leaks.
 	require.Eventually(t, func() bool {
 		return runtime.NumGoroutine() <= baseline
 	}, 2*time.Second, 50*time.Millisecond,

--- a/runtime/bootstrap/listener_test.go
+++ b/runtime/bootstrap/listener_test.go
@@ -22,11 +22,19 @@ func TestWithListener_AppendsToListenerConfigs(t *testing.T) {
 	b := New(
 		WithListener(cell.PrimaryListener, ":8080", nil),
 	)
-	// Confirm the Bootstrap was built without panic — listenerConfigs populated.
-	// We cannot inspect b.listenerConfigs directly (unexported), but we can
-	// verify build-time behaviour by checking no panic occurred and that b is not nil.
-	if b == nil {
-		t.Fatal("Bootstrap.New returned nil")
+	// White-box assertion (same package): verify that exactly one entry was stored
+	// and that phase0 validation accepts it (success path, no error).
+	// We do not merely check b != nil — we verify functional correctness:
+	// (a) listenerConfigs has exactly one entry keyed by PrimaryListener, and
+	// (b) phase0ValidateOptions returns no error for this valid configuration.
+	if len(b.listenerConfigs) != 1 {
+		t.Fatalf("expected 1 listenerConfig entry, got %d", len(b.listenerConfigs))
+	}
+	if _, ok := b.listenerConfigs[cell.PrimaryListener]; !ok {
+		t.Fatal("listenerConfigs must contain an entry for cell.PrimaryListener")
+	}
+	if err := b.phase0ValidateOptions(); err != nil {
+		t.Fatalf("phase0ValidateOptions must succeed for a valid single-listener config, got: %v", err)
 	}
 }
 

--- a/runtime/bootstrap/listener_test.go
+++ b/runtime/bootstrap/listener_test.go
@@ -1,4 +1,4 @@
-package bootstrap_test
+package bootstrap
 
 // listener_test.go — table-driven coverage for WithListener and ListenerOption helpers.
 
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/cell"
-	"github.com/ghbvf/gocell/runtime/bootstrap"
 )
 
 // TestWithListener_AppendsToListenerConfigs verifies that calling WithListener
@@ -20,8 +19,8 @@ import (
 func TestWithListener_AppendsToListenerConfigs(t *testing.T) {
 	t.Parallel()
 
-	b := bootstrap.New(
-		bootstrap.WithListener(cell.PrimaryListener, ":8080", nil),
+	b := New(
+		WithListener(cell.PrimaryListener, ":8080", nil),
 	)
 	// Confirm the Bootstrap was built without panic — listenerConfigs populated.
 	// We cannot inspect b.listenerConfigs directly (unexported), but we can
@@ -36,10 +35,10 @@ func TestWithListener_AppendsToListenerConfigs(t *testing.T) {
 func TestWithListener_MultipleListeners(t *testing.T) {
 	t.Parallel()
 
-	b := bootstrap.New(
-		bootstrap.WithListener(cell.PrimaryListener, ":8080", nil),
-		bootstrap.WithListener(cell.InternalListener, ":9090", nil),
-		bootstrap.WithListener(cell.HealthListener, ":9091", nil),
+	b := New(
+		WithListener(cell.PrimaryListener, ":8080", nil),
+		WithListener(cell.InternalListener, ":9090", nil),
+		WithListener(cell.HealthListener, ":9091", nil),
 	)
 	if b == nil {
 		t.Fatal("Bootstrap.New returned nil")
@@ -52,27 +51,27 @@ func TestWithListenerOptions(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opts []bootstrap.ListenerOption
+		opts []ListenerOption
 	}{
 		{
 			name: "WithListenerNet_nil_stores_nil",
-			opts: []bootstrap.ListenerOption{bootstrap.WithListenerNet(nil)},
+			opts: []ListenerOption{WithListenerNet(nil)},
 		},
 		{
 			name: "WithListenerTLS_nil_stores_nil",
-			opts: []bootstrap.ListenerOption{bootstrap.WithListenerTLS(nil)},
+			opts: []ListenerOption{WithListenerTLS(nil)},
 		},
 		{
 			name: "WithListenerShutdownGrace_positive",
-			opts: []bootstrap.ListenerOption{bootstrap.WithListenerShutdownGrace(5 * time.Second)},
+			opts: []ListenerOption{WithListenerShutdownGrace(5 * time.Second)},
 		},
 		{
 			name: "WithListenerShutdownGrace_negative_stored_as_is",
-			opts: []bootstrap.ListenerOption{bootstrap.WithListenerShutdownGrace(-1 * time.Second)},
+			opts: []ListenerOption{WithListenerShutdownGrace(-1 * time.Second)},
 		},
 		{
 			name: "WithListenerTLS_non_nil",
-			opts: []bootstrap.ListenerOption{bootstrap.WithListenerTLS(&tls.Config{MinVersion: tls.VersionTLS13})},
+			opts: []ListenerOption{WithListenerTLS(&tls.Config{MinVersion: tls.VersionTLS13})},
 		},
 	}
 
@@ -80,8 +79,8 @@ func TestWithListenerOptions(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			b := bootstrap.New(
-				bootstrap.WithListener(cell.PrimaryListener, ":8080", nil, tc.opts...),
+			b := New(
+				WithListener(cell.PrimaryListener, ":8080", nil, tc.opts...),
 			)
 			if b == nil {
 				t.Fatal("Bootstrap.New returned nil")
@@ -100,10 +99,10 @@ func TestWithListenerNet_RealListener(t *testing.T) {
 	}
 	defer ln.Close()
 
-	b := bootstrap.New(
-		bootstrap.WithListener(
+	b := New(
+		WithListener(
 			cell.PrimaryListener, ln.Addr().String(), nil,
-			bootstrap.WithListenerNet(ln),
+			WithListenerNet(ln),
 		),
 	)
 	if b == nil {
@@ -115,10 +114,10 @@ func TestWithListenerNet_RealListener(t *testing.T) {
 func TestWithListenerShutdownGrace_ZeroValue(t *testing.T) {
 	t.Parallel()
 
-	b := bootstrap.New(
-		bootstrap.WithListener(
+	b := New(
+		WithListener(
 			cell.HealthListener, ":9091", nil,
-			bootstrap.WithListenerShutdownGrace(0),
+			WithListenerShutdownGrace(0),
 		),
 	)
 	if b == nil {
@@ -132,10 +131,10 @@ func TestWithListenerShutdownGrace_ZeroValue(t *testing.T) {
 func TestWithListenerShutdownGrace_NegativeRejectsAtPhase0(t *testing.T) {
 	t.Parallel()
 
-	b := bootstrap.New(
-		bootstrap.WithListener(
+	b := New(
+		WithListener(
 			cell.PrimaryListener, ":9090", nil,
-			bootstrap.WithListenerShutdownGrace(-1*time.Second),
+			WithListenerShutdownGrace(-1*time.Second),
 		),
 	)
 	if b == nil {

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -46,6 +46,13 @@ func buildRouter(t *testing.T, ref cell.ListenerRef) *router.Router {
 	return r
 }
 
+// TestPhase5CollectRouteGroups_NoHealthListener_RemapsHealthGroupsToPrimary is an
+// intentional white-box test: b := New() bypasses phase0ValidateOptions (which would
+// reject a Bootstrap with no listeners). This is valid because phase5CollectRouteGroups
+// is a pure computation step — it only inspects the routers map and the healthRouteGroupOpts
+// field; it does not depend on any phase0 side-effects or listener validation state.
+// Testing it in isolation verifies the health-group fallback logic without the overhead
+// of a full Run() lifecycle.
 func TestPhase5CollectRouteGroups_NoHealthListener_RemapsHealthGroupsToPrimary(t *testing.T) {
 	t.Parallel()
 	b := New()
@@ -1057,18 +1064,36 @@ func TestPhase0_TLSConfigEmpty_Rejected(t *testing.T) {
 }
 
 // TestPhase0_TLSConfigWithCertificates_Accepted verifies that a TLS config
-// with at least one certificate is accepted at phase0.
+// carrying a non-empty static certificate (chain bytes present) passes the
+// phase0 handshake-ability check.
 func TestPhase0_TLSConfigWithCertificates_Accepted(t *testing.T) {
-	// tls.Certificate zero value is deliberately used here — we only need the
-	// slice to be non-empty to pass the sanity check; actual TLS handshake is
-	// not exercised in this unit test.
+	// We do not need a real key pair — we only need at least one of
+	// Certificate / PrivateKey / Leaf to be non-zero so the sanity check
+	// recognises this as a populated entry. Actual TLS handshake is not
+	// exercised in this unit test.
+	b := New(
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil,
+			WithListenerTLS(&tls.Config{
+				Certificates: []tls.Certificate{{Certificate: [][]byte{{0x00}}}},
+			})),
+	)
+	require.NoError(t, b.phase0ValidateOptions())
+}
+
+// TestPhase0_TLSConfigCertificateZeroValue_Rejected verifies that a TLS config
+// whose Certificates slice contains only zero-value entries (no chain, no key,
+// no Leaf) is rejected at phase0 — the listener would otherwise fail at the
+// first ClientHello with an opaque tls error rather than fail-fast at startup.
+func TestPhase0_TLSConfigCertificateZeroValue_Rejected(t *testing.T) {
 	b := New(
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil,
 			WithListenerTLS(&tls.Config{
 				Certificates: []tls.Certificate{{}},
 			})),
 	)
-	require.NoError(t, b.phase0ValidateOptions())
+	err := b.phase0ValidateOptions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "zero-value tls.Certificate")
 }
 
 // TestPhase0_TLSConfigWithGetCertificate_Accepted verifies that a TLS config

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -196,6 +196,10 @@ func TestPhase0_AcceptsAuthMTLSWithProperTLS(t *testing.T) {
 	cfg := &tls.Config{
 		ClientAuth: tls.RequireAndVerifyClientCert,
 		ClientCAs:  pool,
+		// GetCertificate provides the server-side certificate at handshake time.
+		// Without at least one cert source, the TLS sanity check (Wave B) rejects
+		// the config because no TLS handshake can complete.
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) { return nil, nil },
 	}
 	b := New(
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil),
@@ -1009,3 +1013,74 @@ func (s *stubHMACKeyring) Current() []byte {
 	return []byte("test-secret-32-bytes-padding----")
 }
 func (s *stubHMACKeyring) Secrets() [][]byte { return [][]byte{s.Current()} }
+
+// ---------------------------------------------------------------------------
+// T-06: phase5 FinalizeAuth called twice returns labeled error
+// ---------------------------------------------------------------------------
+
+// TestBootstrap_Phase5_FinalizeAuthCalledTwice_ReturnsLabeledError verifies that
+// calling phase5FinalizeAllRouters a second time (after authFinalized=true) returns
+// an error that names the listener ref, making post-mortem diagnosis unambiguous.
+func TestBootstrap_Phase5_FinalizeAuthCalledTwice_ReturnsLabeledError(t *testing.T) {
+	b := New(WithListener(cell.PrimaryListener, "127.0.0.1:0", nil))
+	s := buildPhase5State(t)
+
+	routers := map[cell.ListenerRef]*router.Router{
+		cell.PrimaryListener: buildRouter(t, cell.PrimaryListener),
+	}
+
+	// First call must succeed.
+	require.NoError(t, b.phase5FinalizeAllRouters(routers))
+
+	// Second call must fail and include the listener ref in the error.
+	err := b.phase5FinalizeAllRouters(routers)
+	require.Error(t, err, "FinalizeAuth called twice must return an error")
+	assert.Contains(t, err.Error(), "finalize auth",
+		"error must contain 'finalize auth' label to identify the failing phase")
+	_ = s // s is built for test hygiene (health handler initialisation).
+}
+
+// ---------------------------------------------------------------------------
+// Path3 TLS phase0 三连
+// ---------------------------------------------------------------------------
+
+// TestPhase0_TLSConfigEmpty_Rejected verifies that a TLS config with no
+// certificate source is rejected at phase0 (Wave B sanity check).
+func TestPhase0_TLSConfigEmpty_Rejected(t *testing.T) {
+	b := New(
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil,
+			WithListenerTLS(&tls.Config{})), // no Certificates / GetCertificate / GetConfigForClient
+	)
+	err := b.phase0ValidateOptions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS config has no Certificates / GetCertificate / GetConfigForClient")
+}
+
+// TestPhase0_TLSConfigWithCertificates_Accepted verifies that a TLS config
+// with at least one certificate is accepted at phase0.
+func TestPhase0_TLSConfigWithCertificates_Accepted(t *testing.T) {
+	// tls.Certificate zero value is deliberately used here — we only need the
+	// slice to be non-empty to pass the sanity check; actual TLS handshake is
+	// not exercised in this unit test.
+	b := New(
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil,
+			WithListenerTLS(&tls.Config{
+				Certificates: []tls.Certificate{{}},
+			})),
+	)
+	require.NoError(t, b.phase0ValidateOptions())
+}
+
+// TestPhase0_TLSConfigWithGetCertificate_Accepted verifies that a TLS config
+// with a non-nil GetCertificate callback is accepted at phase0.
+func TestPhase0_TLSConfigWithGetCertificate_Accepted(t *testing.T) {
+	b := New(
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", nil,
+			WithListenerTLS(&tls.Config{
+				GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+					return nil, nil
+				},
+			})),
+	)
+	require.NoError(t, b.phase0ValidateOptions())
+}

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -1316,3 +1316,31 @@ func TestDeclareAuth_MethodAware_GETDoesNotBypassForPOSTOnly(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"GET must require auth when only POST is declared public")
 }
+
+// TestRouter_ServeHTTP_NoFinalizeAuth_Panics asserts that calling ServeHTTP
+// on a router that has auth route metadata declared but FinalizeAuth has NOT
+// been called results in a panic with the expected message.
+//
+// This is the safety guard that prevents a mis-wired bootstrap from silently
+// skipping the auth compilation step (FinalizeAuth) and serving requests
+// without the compiled public/PasswordResetExempt matchers in place.
+func TestRouter_ServeHTTP_NoFinalizeAuth_Panics(t *testing.T) {
+	r := New()
+
+	// Declare auth metadata without calling FinalizeAuth — this is the
+	// mis-wired state the guard is designed to detect.
+	r.DeclareAuthMeta(cell.AuthRouteMeta{
+		Method: "GET",
+		Path:   "/api/v1/probe",
+		Public: true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/probe", nil)
+	rec := httptest.NewRecorder()
+
+	assert.PanicsWithValue(t,
+		"router: FinalizeAuth must be called before ServeHTTP when auth route metadata has been declared",
+		func() { r.ServeHTTP(rec, req) },
+		"ServeHTTP must panic when FinalizeAuth has not been called after DeclareAuthMeta",
+	)
+}

--- a/tools/archtest/build_constraint_test.go
+++ b/tools/archtest/build_constraint_test.go
@@ -22,6 +22,7 @@ var skipDirs = map[string]bool{
 	"worktrees":    true,
 	"generated":    true,
 	"node_modules": true,
+	"testdata":     true,
 }
 
 // findIntegrationTagViolations walks rootDir and returns the relative paths (from
@@ -66,13 +67,19 @@ func findIntegrationTagViolations(rootDir string) ([]string, error) {
 	return violations, nil
 }
 
-// fileHasIntegrationTag returns true iff the file contains a //go:build line
-// whose constraint expression:
+// fileHasIntegrationTag returns true iff the file carries, in its header
+// section (before the package clause and following only blank lines and other
+// comments — the only zone the Go toolchain recognises for build constraints),
+// a //go:build line whose constraint expression:
 //  1. evaluates to true when the "integration" tag is active, AND
 //  2. evaluates to false when no tags are active (i.e., the file is not built
 //     unconditionally — it must actually be gated on the integration tag).
 //
-// Returns (false, nil) when the file lacks a //go:build line entirely.
+// A //go:build line that appears after the package clause (or after any other
+// non-comment, non-blank line) is invisible to the toolchain and therefore
+// counted as a violation, matching the semantics of `go build` / `go test`.
+//
+// Returns (false, nil) when the file lacks a //go:build line in the header.
 // Returns (false, err) when the line cannot be parsed.
 func fileHasIntegrationTag(path string) (bool, error) {
 	f, err := os.Open(path)
@@ -84,21 +91,32 @@ func fileHasIntegrationTag(path string) (bool, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !constraint.IsGoBuild(line) {
-			continue
+		trimmed := strings.TrimSpace(line)
+
+		// Header zone ends at the first non-blank, non-comment line. The Go
+		// toolchain (see go/build/read.go readGoInfo) stops parsing build
+		// constraints once it sees the package clause, so any //go:build below
+		// that point would be ignored at compile time and must not be accepted
+		// by this gate either.
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") {
+			if !constraint.IsGoBuild(line) {
+				continue
+			}
+			expr, parseErr := constraint.Parse(line)
+			if parseErr != nil {
+				return false, parseErr
+			}
+			withIntegration := expr.Eval(func(tag string) bool { return tag == "integration" })
+			withoutAny := expr.Eval(func(_ string) bool { return false })
+			return withIntegration && !withoutAny, nil
 		}
-		expr, parseErr := constraint.Parse(line)
-		if parseErr != nil {
-			return false, parseErr
-		}
-		withIntegration := expr.Eval(func(tag string) bool { return tag == "integration" })
-		withoutAny := expr.Eval(func(_ string) bool { return false })
-		return withIntegration && !withoutAny, nil
+		// First substantive line (typically `package …`) — stop scanning.
+		break
 	}
 	if err := scanner.Err(); err != nil {
 		return false, err
 	}
-	// No //go:build line found.
+	// No //go:build line found in the header zone.
 	return false, nil
 }
 
@@ -155,6 +173,13 @@ func TestArchtest_BuildConstraint_Violation_Fixture(t *testing.T) {
 			content: "//go:build integration\n\npackage fixture\n\nimport \"testing\"\n\nfunc TestGood(t *testing.T) {}\n",
 			wantBad: false,
 		},
+		{
+			// Build constraint placed after the package clause is invisible to
+			// the Go toolchain and must be flagged by the gate.
+			name:    "misplaced_after_package_integration_test.go",
+			content: "package fixture\n\n//go:build integration\n\nimport \"testing\"\n\nfunc TestMisplaced(t *testing.T) {}\n",
+			wantBad: true,
+		},
 	}
 
 	root := t.TempDir()
@@ -171,8 +196,10 @@ func TestArchtest_BuildConstraint_Violation_Fixture(t *testing.T) {
 		violationSet[filepath.Base(v)] = true
 	}
 
+	wantViolations := 0
 	for _, fx := range fixtures {
 		if fx.wantBad {
+			wantViolations++
 			assert.True(t, violationSet[fx.name],
 				"expected %q to be flagged as a violation", fx.name)
 		} else {
@@ -181,7 +208,6 @@ func TestArchtest_BuildConstraint_Violation_Fixture(t *testing.T) {
 		}
 	}
 
-	// Exactly 2 violations expected.
-	assert.Len(t, violations, 2,
-		"fixture must produce exactly 2 violations (bad + wrong_tag)")
+	assert.Len(t, violations, wantViolations,
+		"fixture must produce exactly %d violations", wantViolations)
 }

--- a/tools/archtest/build_constraint_test.go
+++ b/tools/archtest/build_constraint_test.go
@@ -1,0 +1,187 @@
+package archtest
+
+import (
+	"bufio"
+	"go/build/constraint"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// skipDirs lists directory names that are always skipped during the walk.
+// worktrees is included because each worktree is an independent checkout of
+// the same repository; scanning sibling worktrees would produce false positives
+// for files that have not yet been fixed in those branches.
+var skipDirs = map[string]bool{
+	"vendor":       true,
+	".git":         true,
+	"worktrees":    true,
+	"generated":    true,
+	"node_modules": true,
+}
+
+// findIntegrationTagViolations walks rootDir and returns the relative paths (from
+// rootDir) of every *_integration_test.go file that does NOT carry a //go:build
+// constraint expression that evaluates to true when the "integration" tag is set
+// and false when no tags are set.
+//
+// Parse failures are treated as violations (conservative / fail-closed strategy).
+func findIntegrationTagViolations(rootDir string) ([]string, error) {
+	var violations []string
+
+	err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only care about *_integration_test.go files.
+		if !strings.HasSuffix(d.Name(), "_integration_test.go") {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(rootDir, path)
+		if relErr != nil {
+			rel = path
+		}
+
+		ok, checkErr := fileHasIntegrationTag(path)
+		if checkErr != nil || !ok {
+			violations = append(violations, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return violations, nil
+}
+
+// fileHasIntegrationTag returns true iff the file contains a //go:build line
+// whose constraint expression:
+//  1. evaluates to true when the "integration" tag is active, AND
+//  2. evaluates to false when no tags are active (i.e., the file is not built
+//     unconditionally — it must actually be gated on the integration tag).
+//
+// Returns (false, nil) when the file lacks a //go:build line entirely.
+// Returns (false, err) when the line cannot be parsed.
+func fileHasIntegrationTag(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !constraint.IsGoBuild(line) {
+			continue
+		}
+		expr, parseErr := constraint.Parse(line)
+		if parseErr != nil {
+			return false, parseErr
+		}
+		withIntegration := expr.Eval(func(tag string) bool { return tag == "integration" })
+		withoutAny := expr.Eval(func(_ string) bool { return false })
+		return withIntegration && !withoutAny, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	// No //go:build line found.
+	return false, nil
+}
+
+// TestArchtest_AllIntegrationTestFiles_HaveIntegrationBuildTag walks the entire
+// repository and asserts that every *_integration_test.go file carries a valid
+// //go:build integration constraint.  The test fails with a single aggregated
+// report listing all violating files so that the full picture is visible at once.
+func TestArchtest_AllIntegrationTestFiles_HaveIntegrationBuildTag(t *testing.T) {
+	root := findModuleRoot(t)
+
+	violations, err := findIntegrationTagViolations(root)
+	require.NoError(t, err, "error walking module root")
+
+	if len(violations) > 0 {
+		t.Logf("Found %d *_integration_test.go file(s) missing //go:build integration:", len(violations))
+		for _, v := range violations {
+			t.Logf("  %s", v)
+		}
+	}
+
+	assert.Empty(t, violations,
+		"all *_integration_test.go files must carry '//go:build integration'; "+
+			"add the constraint at the top of each listed file")
+}
+
+// TestArchtest_BuildConstraint_Violation_Fixture is the "test the test" meta-test.
+// It creates a temporary directory with three synthetic files:
+//   - bad_integration_test.go:        no //go:build line at all   → violation
+//   - wrong_tag_integration_test.go:  //go:build other_tag        → violation
+//   - good_integration_test.go:       //go:build integration      → no violation
+//
+// The test verifies that findIntegrationTagViolations catches exactly the two
+// bad files and ignores the good one.
+func TestArchtest_BuildConstraint_Violation_Fixture(t *testing.T) {
+	t.Parallel()
+
+	fixtures := []struct {
+		name    string
+		content string
+		wantBad bool
+	}{
+		{
+			name:    "bad_integration_test.go",
+			content: "package fixture\n\nimport \"testing\"\n\nfunc TestBad(t *testing.T) {}\n",
+			wantBad: true,
+		},
+		{
+			name:    "wrong_tag_integration_test.go",
+			content: "//go:build other_tag\n\npackage fixture\n\nimport \"testing\"\n\nfunc TestWrong(t *testing.T) {}\n",
+			wantBad: true,
+		},
+		{
+			name:    "good_integration_test.go",
+			content: "//go:build integration\n\npackage fixture\n\nimport \"testing\"\n\nfunc TestGood(t *testing.T) {}\n",
+			wantBad: false,
+		},
+	}
+
+	root := t.TempDir()
+	for _, fx := range fixtures {
+		require.NoError(t, os.WriteFile(filepath.Join(root, fx.name), []byte(fx.content), 0o644))
+	}
+
+	violations, err := findIntegrationTagViolations(root)
+	require.NoError(t, err, "findIntegrationTagViolations must not return an error")
+
+	// Collect violation basenames for easy assertion.
+	violationSet := make(map[string]bool, len(violations))
+	for _, v := range violations {
+		violationSet[filepath.Base(v)] = true
+	}
+
+	for _, fx := range fixtures {
+		if fx.wantBad {
+			assert.True(t, violationSet[fx.name],
+				"expected %q to be flagged as a violation", fx.name)
+		} else {
+			assert.False(t, violationSet[fx.name],
+				"expected %q NOT to be flagged as a violation", fx.name)
+		}
+	}
+
+	// Exactly 2 violations expected.
+	assert.Len(t, violations, 2,
+		"fixture must produce exactly 2 violations (bad + wrong_tag)")
+}


### PR DESCRIPTION
## Summary

收口 026 plan §Wave 5 PR-A43 LISTENER-TEST-GAPS（Cx2，原估 4h，实际扩入后 ~8h），一次性彻底关闭 PR-A14a/A14b dual-listener 落地后的 13 条已登记 + 5 条 explorer 实测发现的 Cx1 测试 gap。

- **彻底**：18 条交付一次性扫光，不留 SKIP / TODO / 兼容路径
- **不向后兼容**：shutdownAllServers 重构一刀切；listener_test.go 包归属改光；archtest 规则不留白名单
- **优雅简洁**：TLS 失败提前到 phase0 sanity（10 行实现）；archtest 用标准库 `go/build/constraint`；helper 复用 `pkg/testutil/sloghelper`

## 范围

| 类型 | 数量 |
|---|---|
| PR237-T1 (10 条 Cx1 gap) | 10 |
| PR237-F06 (controlplane guard slog.Warn 4-case) | 1 |
| PR225-N1 (RMQ waitAndClose abandoned goroutine) | 1 |
| 包归属扫尾 (listener_test.go → package bootstrap) | 1 |
| phase0 fail-fast (Path 1A/1B/1E) | 3 |
| phase0 TLS sanity (Path 3 实现 + 测试) | 1 |
| build-tag 修复 (8 个 *_integration_test.go) | 1 |
| T-08 archtest 规则 | 1 |
| **合计** | **18** |

## 校准说明

PR-A43 plan 描述里 PR225-N1 写为 "pkg/validation 测试覆盖率补齐"，但 backlog 实际登记的是 `RMQ-WAITANDCLOSE-ABANDONED-GOROUTINE-TEST-01`。`pkg/validation` 已 100% 覆盖率，无需补齐。本 PR 按 backlog 实际做，026 plan 文档随后同步。

`BOOTSTRAP-LIFECYCLE-INTEG-TEST-PACKAGE` 已在 commit `e957961d` 修复完成（lifecycle_integration_test.go 已是 `package bootstrap`），本 PR 仅顺手修同目录异常的 `listener_test.go`（package bootstrap_test → bootstrap）。

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`（全套，无缓存）
- [x] `go test -race ./runtime/bootstrap/... ./runtime/http/router/... ./adapters/rabbitmq/... ./cmd/corebundle/... ./tools/archtest/...`
- [x] `go test -tags=integration ./...`
- [x] `golangci-lint run ./...`（0 issues）
- [x] `tools/archtest/build_constraint_test.go` 0 violation
- [x] PR237-T1 列表 10 条 100% PASS
- [x] PR237-F06 4 case 表驱动 PASS
- [x] PR225-N1 abandoned goroutine 退出测试 PASS
- [x] phase0 fail-fast 三连 PASS
- [x] Path 3 TLS phase0 sanity 三连 PASS

## 对标参考

- ref: kubernetes `apiserver/pkg/server/secure_serving` (T-02/T-03 双 listener shutdown drain)
- ref: uber-go/fx `fxtest/lifecycle` (T-04 owned=true rollback / T-06 二次 finalize)
- ref: chi/v5 `mux_test` ServeHTTPNotFound (T-07 panic 文本断言)
- ref: rabbitmq/amqp091-go `connection_test` (PR225-N1 drain consumer + close 顺序)
- ref: golangci-lint `internal/lintersdb` build constraint scan (T-08 archtest 规则)

## Refs

- PR-A43 (026 plan §Wave 5)
- PR237-T1 DUAL-LISTENER-TEST-GAPS-01
- PR237-F06 DUAL-LISTENER-DEVMODE-WARN-TEST-01
- PR225-N1 RMQ-WAITANDCLOSE-ABANDONED-GOROUTINE-TEST-01
- BOOTSTRAP-LIFECYCLE-INTEG-TEST-PACKAGE（顺手扫尾 listener_test.go）

🤖 Generated with [Claude Code](https://claude.com/claude-code)