### PR TITLE
refactor(configcore,archtest): PR-CFG-K' — drop thin ctxCancel wrapper + redact key_id + archtest lock

### DIFF
--- a/cells/auditcore/internal/adapters/postgres/audit_repo.go
+++ b/cells/auditcore/internal/adapters/postgres/audit_repo.go
@@ -75,10 +75,8 @@ func (r *AuditRepository) Append(ctx context.Context, entry *domain.AuditEntry) 
 		entry.Hash,
 	)
 	if err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "Append", "id="+entry.ID); cancelErr != nil {
-			return cancelErr
-		}
-		return errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: append failed", err)
+		return ctxcancel.WrapOrInfra(err, "Append", "id="+entry.ID,
+			errcode.ErrAuditRepoQuery, "audit repo: append failed")
 	}
 
 	return nil
@@ -105,10 +103,8 @@ func (r *AuditRepository) GetRange(ctx context.Context, from, to int) ([]*domain
 
 	rows, err := r.db.Query(ctx, query, limit, from)
 	if err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "GetRange", ""); cancelErr != nil {
-			return nil, cancelErr
-		}
-		return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: get range failed", err)
+		return nil, ctxcancel.WrapOrInfra(err, "GetRange", "",
+			errcode.ErrAuditRepoQuery, "audit repo: get range failed")
 	}
 	defer rows.Close()
 
@@ -132,10 +128,8 @@ func (r *AuditRepository) Query(ctx context.Context, filters ports.AuditFilters,
 	sql, args := b.Build()
 	rows, err := r.db.Query(ctx, sql, args...)
 	if err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "Query", ""); cancelErr != nil {
-			return nil, cancelErr
-		}
-		return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: query failed", err)
+		return nil, ctxcancel.WrapOrInfra(err, "Query", "",
+			errcode.ErrAuditRepoQuery, "audit repo: query failed")
 	}
 	defer rows.Close()
 
@@ -156,18 +150,14 @@ func scanAuditEntries(rows Rows) ([]*domain.AuditEntry, error) {
 			&e.ID, &e.EventID, &e.EventType, &e.ActorID,
 			&e.Timestamp, &e.Payload, &e.PrevHash, &e.Hash,
 		); err != nil {
-			if cancelErr := ctxcancel.Wrap(err, "ScanRow", ""); cancelErr != nil {
-				return nil, cancelErr
-			}
-			return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: scan failed", err)
+			return nil, ctxcancel.WrapOrInfra(err, "ScanRow", "",
+				errcode.ErrAuditRepoQuery, "audit repo: scan failed")
 		}
 		entries = append(entries, &e)
 	}
 	if err := rows.Err(); err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "RowsErr", ""); cancelErr != nil {
-			return nil, cancelErr
-		}
-		return nil, errcode.Wrap(errcode.ErrAuditRepoQuery, "audit repo: rows error", err)
+		return nil, ctxcancel.WrapOrInfra(err, "RowsErr", "",
+			errcode.ErrAuditRepoQuery, "audit repo: rows error")
 	}
 	return entries, nil
 }

--- a/cells/configcore/internal/adapters/postgres/config_repo.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo.go
@@ -20,32 +20,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// wrapCtxCancel detects whether err is a context cancellation and, if so,
-// returns a structured *errcode.Error carrying ErrClientCanceled (mapped to
-// HTTP 499 by pkg/httputil + slog.Warn by writeErrcodeError → log4xx).
-// Returns nil when err is not a cancellation, signalling the caller to
-// fall through to the generic infra-error mapping.
-//
-// `op` is a PascalCase operation label (e.g. "Insert", "Update");
-// `identifier` is a caller-formatted resource locator (e.g. "key=foo",
-// "configID=cfg-1"). Both are recorded only in InternalMessage and never
-// in the public Message, mirroring the FiloSottile/age principle that
-// error paths must not expose the identity of attempted keys.
-//
-// No slog.Warn is emitted here: the HTTP boundary's log4xx already records
-// a Warn entry with code/status/InternalMessage/correlation IDs, so emitting
-// a second Warn at the repository layer produces duplicate observability
-// noise without adding new context.
-//
-// ref: pkg/ctxcancel.Wrap — canonical helper.
-//
-// ctx is accepted for callsite ergonomics (every IO callsite already has
-// a ctx in scope); it is currently unused but reserved for future
-// observability hooks (e.g. trace span attachment).
-func (r *ConfigRepository) wrapCtxCancel(_ context.Context, op, identifier string, err error) *errcode.Error {
-	return ctxcancel.Wrap(err, op, identifier)
-}
-
 // cryptoOpError constructs a uniform *errcode.Error for encrypt/decrypt
 // operation failures, classifying the cause to preserve dashboards' ability
 // to distinguish three signal sources that the ValueTransformer chain may
@@ -300,7 +274,7 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 		)
 	}
 	if err != nil {
-		if cancelErr := r.wrapCtxCancel(ctx, "Create", "key="+entry.Key, err); cancelErr != nil {
+		if cancelErr := ctxcancel.Wrap(err, "Create", "key="+entry.Key); cancelErr != nil {
 			return cancelErr
 		}
 		return &errcode.Error{
@@ -355,14 +329,14 @@ func scanConfigRow(row Row) (e *domain.ConfigEntry, valueCipher []byte, valueKey
 //
 // op is the method name used only in InternalMessage for operator
 // debugging; key is the lookup key surfaced the same way. Uses
-// r.wrapCtxCancel for the ctx-cancel branch (see that method for the
-// logger side-effect rationale).
+// pkg/ctxcancel.Wrap for the ctx-cancel branch — the canonical helper
+// already handles 499 vs 504 split and slog routing.
 func (r *ConfigRepository) scanConfigOrMapError(ctx context.Context, row Row, op, key string) (*domain.ConfigEntry, []byte, *string, []byte, []byte, error) {
 	e, ct, keyID, edk, nonce, err := scanConfigRow(row)
 	if err == nil {
 		return e, ct, keyID, edk, nonce, nil
 	}
-	if infraErr := r.wrapCtxCancel(ctx, op, "key="+key, err); infraErr != nil {
+	if infraErr := ctxcancel.Wrap(err, op, "key="+key); infraErr != nil {
 		return nil, nil, nil, nil, nil, infraErr
 	}
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -429,14 +403,15 @@ func (r *ConfigRepository) GetByKey(ctx context.Context, key string) (*domain.Co
 	return e, nil
 }
 
-// observeStaleCipher emits a slog.Warn and invokes the optional onStaleCipher
-// callback when a sensitive config value is found to be encrypted with a stale
-// (non-current) key. This is the single observability point for M3.
+// observeStaleCipher fans a stale-cipher signal out to the log and metric
+// planes with strict redaction asymmetry: the slog.Warn carries only the
+// business key name (operators can correlate by domain identity), while the
+// stored/current key IDs flow exclusively to the onStaleCipher callback that
+// caller-wired Prometheus counters consume as bounded-cardinality labels.
+// Cryptographic identifiers must not appear on the log plane.
 func (r *ConfigRepository) observeStaleCipher(ctx context.Context, key, storedKeyID, currentKeyID string) {
 	r.logger.WarnContext(ctx, "config value encrypted with stale key",
 		slog.String("key", key),
-		slog.String("stored_key_id", storedKeyID),
-		slog.String("current_key_id", currentKeyID),
 	)
 	if r.onStaleCipher != nil {
 		r.onStaleCipher(key, storedKeyID, currentKeyID)
@@ -474,7 +449,7 @@ func (r *ConfigRepository) Update(ctx context.Context, key string, value string)
 	var sensitive bool
 	selectRow := db.QueryRow(ctx, selectQ, key)
 	if scanErr := selectRow.Scan(&sensitive); scanErr != nil {
-		if infraErr := r.wrapCtxCancel(ctx, "Update", "key="+key, scanErr); infraErr != nil {
+		if infraErr := ctxcancel.Wrap(scanErr, "Update", "key="+key); infraErr != nil {
 			return nil, infraErr
 		}
 		if errors.Is(scanErr, pgx.ErrNoRows) {
@@ -594,9 +569,12 @@ func (r *ConfigRepository) applySensitiveListSentinel(ctx context.Context, e *do
 		}
 		if !staleLogged[*valueKeyID] {
 			staleLogged[*valueKeyID] = true
+			// Dedup is keyed on the stale keyID (one warn per distinct keyID per
+			// page) so the metric callback above continues to count every entry.
+			// The log line itself surfaces the business key of the first occurrence
+			// so operators can correlate without us emitting the keyID.
 			r.logger.WarnContext(ctx, "config values encrypted with stale key (first occurrence in this List page)",
-				slog.String("stored_key_id", *valueKeyID),
-				slog.String("current_key_id", currentID),
+				slog.String("key", e.Key),
 			)
 		}
 	}
@@ -629,7 +607,7 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 	sql, args := b.Build()
 	rows, err := r.resolveDB(ctx).Query(ctx, sql, args...)
 	if err != nil {
-		if cancelErr := r.wrapCtxCancel(ctx, "List", "", err); cancelErr != nil {
+		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
 			return nil, cancelErr
 		}
 		return nil, errcode.WrapInfra(errcode.ErrConfigRepoQuery, "config repo: list failed", err)
@@ -645,7 +623,7 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 			valueKeyID *string
 		)
 		if err := rows.Scan(&e.ID, &e.Key, &e.Value, &e.Sensitive, &e.Version, &e.CreatedAt, &e.UpdatedAt, &valueKeyID); err != nil {
-			if cancelErr := r.wrapCtxCancel(ctx, "List", "", err); cancelErr != nil {
+			if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
 				return nil, cancelErr
 			}
 			return nil, errcode.WrapInfra(errcode.ErrConfigRepoQuery, "config repo: scan failed", err)
@@ -656,7 +634,7 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 		entries = append(entries, &e)
 	}
 	if err := rows.Err(); err != nil {
-		if cancelErr := r.wrapCtxCancel(ctx, "List", "", err); cancelErr != nil {
+		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
 			return nil, cancelErr
 		}
 		return nil, errcode.WrapInfra(errcode.ErrConfigRepoQuery, "config repo: rows error", err)
@@ -697,7 +675,7 @@ func (r *ConfigRepository) PublishVersion(ctx context.Context, version *domain.C
 		)
 	}
 	if err != nil {
-		if cancelErr := r.wrapCtxCancel(ctx, "PublishVersion", "configID="+version.ConfigID, err); cancelErr != nil {
+		if cancelErr := ctxcancel.Wrap(err, "PublishVersion", "configID="+version.ConfigID); cancelErr != nil {
 			return cancelErr
 		}
 		return errcode.WrapInfra(errcode.ErrConfigRepoQuery,
@@ -726,7 +704,7 @@ func (r *ConfigRepository) GetVersion(ctx context.Context, configID string, vers
 		&v.ID, &v.ConfigID, &v.Version, &v.Value, &v.Sensitive, &v.PublishedAt,
 		&valueCipher, &valueKeyID, &valueEDK, &valueNonce,
 	); err != nil {
-		if infraErr := r.wrapCtxCancel(ctx, "GetVersion", "configID="+configID, err); infraErr != nil {
+		if infraErr := ctxcancel.Wrap(err, "GetVersion", "configID="+configID); infraErr != nil {
 			return nil, infraErr
 		}
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/cells/configcore/internal/adapters/postgres/config_repo.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo.go
@@ -607,10 +607,8 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 	sql, args := b.Build()
 	rows, err := r.resolveDB(ctx).Query(ctx, sql, args...)
 	if err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
-			return nil, cancelErr
-		}
-		return nil, errcode.WrapInfra(errcode.ErrConfigRepoQuery, "config repo: list failed", err)
+		return nil, ctxcancel.WrapOrInfra(err, "List", "",
+			errcode.ErrConfigRepoQuery, "config repo: list failed")
 	}
 	defer rows.Close()
 
@@ -623,10 +621,8 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 			valueKeyID *string
 		)
 		if err := rows.Scan(&e.ID, &e.Key, &e.Value, &e.Sensitive, &e.Version, &e.CreatedAt, &e.UpdatedAt, &valueKeyID); err != nil {
-			if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
-				return nil, cancelErr
-			}
-			return nil, errcode.WrapInfra(errcode.ErrConfigRepoQuery, "config repo: scan failed", err)
+			return nil, ctxcancel.WrapOrInfra(err, "List", "",
+				errcode.ErrConfigRepoQuery, "config repo: scan failed")
 		}
 		if e.Sensitive {
 			r.applySensitiveListSentinel(ctx, &e, valueKeyID, currentID, staleLogged)
@@ -634,10 +630,8 @@ func (r *ConfigRepository) List(ctx context.Context, params query.ListParams) ([
 		entries = append(entries, &e)
 	}
 	if err := rows.Err(); err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
-			return nil, cancelErr
-		}
-		return nil, errcode.WrapInfra(errcode.ErrConfigRepoQuery, "config repo: rows error", err)
+		return nil, ctxcancel.WrapOrInfra(err, "List", "",
+			errcode.ErrConfigRepoQuery, "config repo: rows error")
 	}
 
 	return entries, nil
@@ -675,12 +669,10 @@ func (r *ConfigRepository) PublishVersion(ctx context.Context, version *domain.C
 		)
 	}
 	if err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "PublishVersion", "configID="+version.ConfigID); cancelErr != nil {
-			return cancelErr
-		}
-		return errcode.WrapInfra(errcode.ErrConfigRepoQuery,
+		return ctxcancel.WrapOrInfra(err, "PublishVersion", "configID="+version.ConfigID,
+			errcode.ErrConfigRepoQuery,
 			fmt.Sprintf("config repo: publish version failed for config %s v%d",
-				version.ConfigID, version.Version), err)
+				version.ConfigID, version.Version))
 	}
 	return nil
 }

--- a/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -732,9 +732,14 @@ func TestList_StaleKey_LogDedup(t *testing.T) {
 	repo := newEncryptedRepoFromDBTX(db, tr)
 	repo.logger = logger
 
-	// Wire callback to count every stale invocation (metrics accuracy).
-	var callbackCount int
-	repo.onStaleCipher = func(_, _, _ string) { callbackCount++ }
+	// Wire callback to record every stale invocation with full triple
+	// (key, storedKeyID, currentKeyID) so any parameter-order regression
+	// is caught immediately.
+	type stalecallArgs struct{ key, storedKeyID, currentKeyID string }
+	var callbackCalls []stalecallArgs
+	repo.onStaleCipher = func(key, storedID, currentID string) {
+		callbackCalls = append(callbackCalls, stalecallArgs{key, storedID, currentID})
+	}
 
 	entries, err := repo.List(ctx, query.ListParams{
 		Limit: 10,
@@ -749,8 +754,17 @@ func TestList_StaleKey_LogDedup(t *testing.T) {
 	assert.True(t, entries[2].Stale, "key_c must be stale")
 	assert.False(t, entries[3].Stale, "plain_cfg must not be stale")
 
-	// Callback must fire for every stale entry (3 total).
-	assert.Equal(t, 3, callbackCount, "onStaleCipher callback must fire for every stale entry")
+	// Callback must fire for every stale entry (3 total) with correct args.
+	require.Len(t, callbackCalls, 3, "onStaleCipher callback must fire for every stale entry")
+	assert.ElementsMatch(t, []string{"key_a", "key_b", "key_c"},
+		[]string{callbackCalls[0].key, callbackCalls[1].key, callbackCalls[2].key},
+		"callback must receive each stale business key")
+	for i, call := range callbackCalls {
+		assert.Equal(t, storedKeyID, call.storedKeyID,
+			"call[%d]: storedKeyID must be %q", i, storedKeyID)
+		assert.Equal(t, "local-aes-v2", call.currentKeyID,
+			"call[%d]: currentKeyID must be \"local-aes-v2\"", i)
+	}
 
 	// slog.Warn must fire only ONCE for the shared stale keyID; dedup is keyed
 	// on the (redacted) stale keyID internally, but the log line surfaces the
@@ -791,8 +805,12 @@ func TestList_StaleKey_TwoDistinctKeyIDs_TwoWarns(t *testing.T) {
 	repo := newEncryptedRepoFromDBTX(db, tr)
 	repo.logger = logger
 
-	var callbackCount int
-	repo.onStaleCipher = func(_, _, _ string) { callbackCount++ }
+	// Wire callback to record full triple so parameter-order regressions are caught.
+	type stalecallArgs struct{ key, storedKeyID, currentKeyID string }
+	var callbackCalls []stalecallArgs
+	repo.onStaleCipher = func(key, storedID, currentID string) {
+		callbackCalls = append(callbackCalls, stalecallArgs{key, storedID, currentID})
+	}
 
 	entries, err := repo.List(ctx, query.ListParams{
 		Limit: 10,
@@ -806,8 +824,21 @@ func TestList_StaleKey_TwoDistinctKeyIDs_TwoWarns(t *testing.T) {
 	assert.True(t, entries[1].Stale)
 	assert.True(t, entries[2].Stale)
 
-	// Callback fires for all 3.
-	assert.Equal(t, 3, callbackCount)
+	// Callback fires for all 3 with correct per-entry args.
+	require.Len(t, callbackCalls, 3, "onStaleCipher must fire for every stale entry")
+	// Business keys across all three calls.
+	assert.ElementsMatch(t, []string{"key_a", "key_b", "key_c"},
+		[]string{callbackCalls[0].key, callbackCalls[1].key, callbackCalls[2].key},
+		"callback must receive each stale business key")
+	// storedKeyID per call: key_a and key_b use v1, key_c uses v2.
+	gotStoredIDs := []string{callbackCalls[0].storedKeyID, callbackCalls[1].storedKeyID, callbackCalls[2].storedKeyID}
+	assert.ElementsMatch(t, []string{keyIDv1, keyIDv1, keyIDv2}, gotStoredIDs,
+		"storedKeyID must reflect the key used to encrypt each entry")
+	// currentKeyID is always v3 for all calls.
+	for i, call := range callbackCalls {
+		assert.Equal(t, "local-aes-v3", call.currentKeyID,
+			"call[%d]: currentKeyID must be \"local-aes-v3\"", i)
+	}
 
 	// Two distinct keyIDs → two slog.Warn lines (dedup is keyed on the redacted
 	// keyID internally; each log line surfaces the business key of the first

--- a/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -543,8 +543,9 @@ func parseLogEntries(t *testing.T, buf *bytes.Buffer) []map[string]any {
 }
 
 // TestGetByKey_StaleKey_EmitsWarn verifies that when GetByKey detects a stale
-// key (stored keyID != current keyID), it emits a slog.Warn with the structured
-// fields: key, stored_key_id, current_key_id.
+// key (stored keyID != current keyID), it emits a slog.Warn carrying ONLY the
+// business key. Cryptographic key IDs are routed exclusively through the
+// onStaleCipher callback (Prometheus label dimension), never the log plane.
 func TestGetByKey_StaleKey_EmitsWarn(t *testing.T) {
 	ctx := context.Background()
 	// Encrypt with v1, then rotate current to v2 → stale.
@@ -581,8 +582,10 @@ func TestGetByKey_StaleKey_EmitsWarn(t *testing.T) {
 	assert.Equal(t, "WARN", logEntry["level"], "log level must be WARN")
 	assert.Equal(t, "config value encrypted with stale key", logEntry["msg"])
 	assert.Equal(t, "api_secret", logEntry["key"])
-	assert.Equal(t, storedKeyID, logEntry["stored_key_id"])
-	assert.Equal(t, "local-aes-v2", logEntry["current_key_id"])
+	_, hasStored := logEntry["stored_key_id"]
+	assert.False(t, hasStored, "stored_key_id must not appear in slog Warn (cryptographic ID redaction)")
+	_, hasCurrent := logEntry["current_key_id"]
+	assert.False(t, hasCurrent, "current_key_id must not appear in slog Warn (cryptographic ID redaction)")
 }
 
 // TestGetByKey_FreshKey_NoWarn verifies that no slog.Warn is emitted when the
@@ -652,8 +655,11 @@ func TestList_StaleKey_EmitsWarn(t *testing.T) {
 	require.Len(t, logEntries, 1, "exactly one warn for the stale sensitive entry")
 	assert.Equal(t, "WARN", logEntries[0]["level"])
 	assert.Equal(t, "config values encrypted with stale key (first occurrence in this List page)", logEntries[0]["msg"])
-	assert.Equal(t, storedKeyID, logEntries[0]["stored_key_id"])
-	assert.Equal(t, "local-aes-v2", logEntries[0]["current_key_id"])
+	assert.Equal(t, "stale_cfg", logEntries[0]["key"])
+	_, hasStored := logEntries[0]["stored_key_id"]
+	assert.False(t, hasStored, "stored_key_id must not appear in slog Warn (cryptographic ID redaction)")
+	_, hasCurrent := logEntries[0]["current_key_id"]
+	assert.False(t, hasCurrent, "current_key_id must not appear in slog Warn (cryptographic ID redaction)")
 }
 
 // TestGetByKey_StaleKey_OnStaleCipherCallback verifies that the optional
@@ -746,12 +752,17 @@ func TestList_StaleKey_LogDedup(t *testing.T) {
 	// Callback must fire for every stale entry (3 total).
 	assert.Equal(t, 3, callbackCount, "onStaleCipher callback must fire for every stale entry")
 
-	// slog.Warn must fire only ONCE for the shared stale keyID.
+	// slog.Warn must fire only ONCE for the shared stale keyID; dedup is keyed
+	// on the (redacted) stale keyID internally, but the log line surfaces the
+	// business key of the first occurrence — never the keyID itself.
 	logEntries := parseLogEntries(t, &logBuf)
 	require.Len(t, logEntries, 1, "only one warn per distinct stale keyID per List call")
 	assert.Equal(t, "WARN", logEntries[0]["level"])
-	assert.Equal(t, storedKeyID, logEntries[0]["stored_key_id"])
-	assert.Equal(t, "local-aes-v2", logEntries[0]["current_key_id"])
+	assert.Equal(t, "key_a", logEntries[0]["key"], "first occurrence's business key surfaces in log")
+	_, hasStored := logEntries[0]["stored_key_id"]
+	assert.False(t, hasStored, "stored_key_id must not appear in slog Warn (cryptographic ID redaction)")
+	_, hasCurrent := logEntries[0]["current_key_id"]
+	assert.False(t, hasCurrent, "current_key_id must not appear in slog Warn (cryptographic ID redaction)")
 }
 
 // TestList_StaleKey_TwoDistinctKeyIDs_TwoWarns verifies that when entries are
@@ -798,16 +809,24 @@ func TestList_StaleKey_TwoDistinctKeyIDs_TwoWarns(t *testing.T) {
 	// Callback fires for all 3.
 	assert.Equal(t, 3, callbackCount)
 
-	// Two distinct keyIDs → two slog.Warn lines.
+	// Two distinct keyIDs → two slog.Warn lines (dedup is keyed on the redacted
+	// keyID internally; each log line surfaces the business key of the first
+	// occurrence for that keyID — key_a for v1, key_c for v2).
 	logEntries := parseLogEntries(t, &logBuf)
 	require.Len(t, logEntries, 2, "one warn per distinct stale keyID")
 	assert.Equal(t, "WARN", logEntries[0]["level"])
 	assert.Equal(t, "WARN", logEntries[1]["level"])
-	storedIDs := []string{
-		logEntries[0]["stored_key_id"].(string),
-		logEntries[1]["stored_key_id"].(string),
+	businessKeys := []string{
+		logEntries[0]["key"].(string),
+		logEntries[1]["key"].(string),
 	}
-	assert.ElementsMatch(t, []string{keyIDv1, keyIDv2}, storedIDs)
+	assert.ElementsMatch(t, []string{"key_a", "key_c"}, businessKeys)
+	for _, entry := range logEntries {
+		_, hasStored := entry["stored_key_id"]
+		assert.False(t, hasStored, "stored_key_id must not appear in slog Warn (cryptographic ID redaction)")
+		_, hasCurrent := entry["current_key_id"]
+		assert.False(t, hasCurrent, "current_key_id must not appear in slog Warn (cryptographic ID redaction)")
+	}
 }
 
 // TestWithOnStaleCipher_Option verifies that NewConfigRepository wired with the

--- a/cells/configcore/internal/adapters/postgres/flag_repo.go
+++ b/cells/configcore/internal/adapters/postgres/flag_repo.go
@@ -193,10 +193,8 @@ func (r *FlagRepository) List(ctx context.Context, params query.ListParams) ([]*
 	sqlStr, args := b.Build()
 	rows, err := r.resolveDB(ctx).Query(ctx, sqlStr, args...)
 	if err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
-			return nil, cancelErr
-		}
-		return nil, errcode.WrapInfra(errcode.ErrFlagRepoQuery, "flag repo: list failed", err)
+		return nil, ctxcancel.WrapOrInfra(err, "List", "",
+			errcode.ErrFlagRepoQuery, "flag repo: list failed")
 	}
 	defer rows.Close()
 
@@ -204,18 +202,14 @@ func (r *FlagRepository) List(ctx context.Context, params query.ListParams) ([]*
 	for rows.Next() {
 		flag, scanErr := scanFlagRow(rows)
 		if scanErr != nil {
-			if cancelErr := ctxcancel.Wrap(scanErr, "List", ""); cancelErr != nil {
-				return nil, cancelErr
-			}
-			return nil, errcode.Wrap(errcode.ErrFlagRepoQuery, "flag repo: scan failed", scanErr)
+			return nil, ctxcancel.WrapOrInfra(scanErr, "List", "",
+				errcode.ErrFlagRepoQuery, "flag repo: scan failed")
 		}
 		flags = append(flags, flag)
 	}
 	if err := rows.Err(); err != nil {
-		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
-			return nil, cancelErr
-		}
-		return nil, errcode.WrapInfra(errcode.ErrFlagRepoQuery, "flag repo: rows error", err)
+		return nil, ctxcancel.WrapOrInfra(err, "List", "",
+			errcode.ErrFlagRepoQuery, "flag repo: rows error")
 	}
 	return flags, nil
 }

--- a/cells/configcore/internal/adapters/postgres/flag_repo.go
+++ b/cells/configcore/internal/adapters/postgres/flag_repo.go
@@ -62,27 +62,6 @@ func (r *FlagRepository) resolveWriteDB(ctx context.Context) (DBTX, error) {
 	return r.db, nil
 }
 
-// wrapCtxCancel detects whether err is a context cancellation and, if so,
-// returns a structured *errcode.Error carrying ErrClientCanceled (mapped
-// to HTTP 499 + slog.Warn at the response boundary). Returns nil when err
-// is not a cancellation, signalling the caller to fall through to the
-// generic infra-error mapping.
-//
-// `op` is a PascalCase operation label (e.g. "List", "Update");
-// `identifier` is a caller-formatted resource locator (e.g. "key=foo").
-// Both are recorded only in InternalMessage and never in the public
-// Message, preventing flag-name leakage to clients.
-//
-// No slog.Warn is emitted here: the HTTP boundary's log4xx already records
-// a Warn entry with code/status/InternalMessage/correlation IDs, so emitting
-// a second Warn at the repository layer produces duplicate observability
-// noise without adding new context.
-//
-// ref: pkg/ctxcancel.Wrap — canonical helper.
-func (r *FlagRepository) wrapCtxCancel(_ context.Context, op, identifier string, err error) *errcode.Error {
-	return ctxcancel.Wrap(err, op, identifier)
-}
-
 // scanFlagOrMapError runs scanFlagRow and translates the three known failure
 // modes into GoCell errcode.Error values:
 //
@@ -101,7 +80,7 @@ func (r *FlagRepository) scanFlagOrMapError(ctx context.Context, row Row, op, ke
 	if err == nil {
 		return flag, nil
 	}
-	if cancelErr := r.wrapCtxCancel(ctx, op, "key="+key, err); cancelErr != nil {
+	if cancelErr := ctxcancel.Wrap(err, op, "key="+key); cancelErr != nil {
 		return nil, cancelErr
 	}
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -138,14 +117,14 @@ func scanFlagRow(row Row) (*domain.FeatureFlag, error) {
 	return &f, nil
 }
 
-// wrapNonScanQueryErr is the analogue of wrapCtxCancel for failures returned
-// by Exec/Query (i.e. before any row scan) — it short-circuits ctx cancel
-// to ErrClientCanceled, otherwise falls back to ErrFlagRepoQuery. `msg`
-// is the generic public Message returned to API consumers; `identifier` is
-// a caller-formatted resource locator (e.g. "key=foo") recorded only in
-// InternalMessage to prevent user-input echo in public error responses.
-func (r *FlagRepository) wrapNonScanQueryErr(ctx context.Context, op, identifier, msg string, err error) error {
-	if cancelErr := r.wrapCtxCancel(ctx, op, identifier, err); cancelErr != nil {
+// wrapNonScanQueryErr handles failures returned by Exec/Query (i.e. before
+// any row scan): short-circuits ctx cancel through pkg/ctxcancel.Wrap,
+// otherwise falls back to ErrFlagRepoQuery. `msg` is the generic public
+// Message returned to API consumers; `identifier` is a caller-formatted
+// resource locator (e.g. "key=foo") recorded only in InternalMessage to
+// prevent user-input echo in public error responses.
+func (r *FlagRepository) wrapNonScanQueryErr(_ context.Context, op, identifier, msg string, err error) error {
+	if cancelErr := ctxcancel.Wrap(err, op, identifier); cancelErr != nil {
 		return cancelErr
 	}
 	internal := fmt.Sprintf("flag repo: %s failed", op)
@@ -235,7 +214,7 @@ func (r *FlagRepository) List(ctx context.Context, params query.ListParams) ([]*
 	for rows.Next() {
 		flag, scanErr := scanFlagRow(rows)
 		if scanErr != nil {
-			if cancelErr := r.wrapCtxCancel(ctx, "List", "", scanErr); cancelErr != nil {
+			if cancelErr := ctxcancel.Wrap(scanErr, "List", ""); cancelErr != nil {
 				return nil, cancelErr
 			}
 			return nil, errcode.Wrap(errcode.ErrFlagRepoQuery, "flag repo: scan failed", scanErr)

--- a/cells/configcore/internal/adapters/postgres/flag_repo.go
+++ b/cells/configcore/internal/adapters/postgres/flag_repo.go
@@ -117,29 +117,6 @@ func scanFlagRow(row Row) (*domain.FeatureFlag, error) {
 	return &f, nil
 }
 
-// wrapNonScanQueryErr handles failures returned by Exec/Query (i.e. before
-// any row scan): short-circuits ctx cancel through pkg/ctxcancel.Wrap,
-// otherwise falls back to ErrFlagRepoQuery. `msg` is the generic public
-// Message returned to API consumers; `identifier` is a caller-formatted
-// resource locator (e.g. "key=foo") recorded only in InternalMessage to
-// prevent user-input echo in public error responses.
-func (r *FlagRepository) wrapNonScanQueryErr(_ context.Context, op, identifier, msg string, err error) error {
-	if cancelErr := ctxcancel.Wrap(err, op, identifier); cancelErr != nil {
-		return cancelErr
-	}
-	internal := fmt.Sprintf("flag repo: %s failed", op)
-	if identifier != "" {
-		internal = fmt.Sprintf("flag repo: %s failed (%s)", op, identifier)
-	}
-	return &errcode.Error{
-		Code:            errcode.ErrFlagRepoQuery,
-		Message:         msg,
-		InternalMessage: internal,
-		Cause:           err,
-		Category:        errcode.CategoryInfra,
-	}
-}
-
 // Create inserts a new feature flag. All 8 columns are written.
 func (r *FlagRepository) Create(ctx context.Context, flag *domain.FeatureFlag) error {
 	const sql = `INSERT INTO feature_flags
@@ -165,8 +142,18 @@ func (r *FlagRepository) Create(ctx context.Context, flag *domain.FeatureFlag) e
 		flag.ID, flag.Key, flag.Enabled, flag.RolloutPercentage,
 		flag.Description, flag.Version, flag.CreatedAt, flag.UpdatedAt,
 	); err != nil {
-		return r.wrapNonScanQueryErr(ctx, "Create", "key="+flag.Key,
-			"flag repo: create failed", err)
+		if cancelErr := ctxcancel.Wrap(err, "Create", "key="+flag.Key); cancelErr != nil {
+			return cancelErr
+		}
+		// InternalMessage carries the key for operator triage; the public
+		// Message stays generic so user input never echoes in API responses.
+		return &errcode.Error{
+			Code:            errcode.ErrFlagRepoQuery,
+			Message:         "flag repo: create failed",
+			InternalMessage: "flag repo: Create failed (key=" + flag.Key + ")",
+			Cause:           err,
+			Category:        errcode.CategoryInfra,
+		}
 	}
 	return nil
 }
@@ -206,7 +193,10 @@ func (r *FlagRepository) List(ctx context.Context, params query.ListParams) ([]*
 	sqlStr, args := b.Build()
 	rows, err := r.resolveDB(ctx).Query(ctx, sqlStr, args...)
 	if err != nil {
-		return nil, r.wrapNonScanQueryErr(ctx, "List", "", "flag repo: list failed", err)
+		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
+			return nil, cancelErr
+		}
+		return nil, errcode.WrapInfra(errcode.ErrFlagRepoQuery, "flag repo: list failed", err)
 	}
 	defer rows.Close()
 
@@ -222,7 +212,10 @@ func (r *FlagRepository) List(ctx context.Context, params query.ListParams) ([]*
 		flags = append(flags, flag)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, r.wrapNonScanQueryErr(ctx, "List", "", "flag repo: rows error", err)
+		if cancelErr := ctxcancel.Wrap(err, "List", ""); cancelErr != nil {
+			return nil, cancelErr
+		}
+		return nil, errcode.WrapInfra(errcode.ErrFlagRepoQuery, "flag repo: rows error", err)
 	}
 	return flags, nil
 }

--- a/cells/configcore/internal/adapters/postgres/flag_repo_test.go
+++ b/cells/configcore/internal/adapters/postgres/flag_repo_test.go
@@ -328,7 +328,7 @@ func TestFlagRepo_Create_PublicMessageDoesNotLeakKey(t *testing.T) {
 	assert.Contains(t, ec.InternalMessage, "key=user_secret_flag_key",
 		"InternalMessage must carry the key for operator triage")
 	assert.True(t, errcode.IsInfraError(ec),
-		"wrapNonScanQueryErr must preserve CategoryInfra so DB-failure alerts fire")
+		"Create non-scan error path must preserve CategoryInfra so DB-failure alerts fire")
 }
 
 // TestFlagRepo_WithoutTx_WritePathsRequireTx verifies session-based repo

--- a/cells/configcore/internal/adapters/postgres/plaintext_migration.go
+++ b/cells/configcore/internal/adapters/postgres/plaintext_migration.go
@@ -208,10 +208,13 @@ func (m *plaintextMigrator) encryptBatch(ctx context.Context, updateQ, table str
 			continue
 		}
 		result.Processed++
+		// keyID is intentionally redacted from the log plane: cryptographic
+		// identifiers belong on Prometheus labels with bounded cardinality, not
+		// on slog where they pollute log indices and complicate redaction
+		// pipelines. table + aad_identity together suffice to correlate.
 		slog.Info("plaintext-migrator: encrypted row",
 			slog.String("table", table),
-			slog.String("aad_identity", row.aadIdentity),
-			slog.String("key_id", keyID))
+			slog.String("aad_identity", row.aadIdentity))
 	}
 	return nil
 }

--- a/pkg/ctxcancel/ctxcancel.go
+++ b/pkg/ctxcancel/ctxcancel.go
@@ -101,6 +101,31 @@ func Wrap(err error, op, identifier string) *errcode.Error {
 	}
 }
 
+// WrapOrInfra is the canonical convenience for the IO-boundary pattern:
+//
+//	if cancelErr := ctxcancel.Wrap(err, op, id); cancelErr != nil {
+//	    return cancelErr
+//	}
+//	return errcode.WrapInfra(fallbackCode, fallbackMsg, err)
+//
+// One call replaces both branches: a context cancellation surfaces as the
+// canonical 499/504 split (Canceled→ErrClientCanceled, DeadlineExceeded→
+// ErrServerTimeout) while every other error gets uniformly mapped to the
+// caller-supplied infra-category errcode with err preserved as Cause.
+//
+// Use at repository / RPC client / message-bus call sites where the only
+// branching needed is ctx-cancel vs generic infra failure. When the fallback
+// path needs *additional* differentiation (a domain not-found branch, a
+// PascalCase InternalMessage template, a non-Infra Category), keep the
+// inline pattern — this helper deliberately omits those degrees of freedom
+// to avoid a six-parameter signature.
+func WrapOrInfra(err error, op, identifier string, fallbackCode errcode.Code, fallbackMsg string) error {
+	if cancelErr := Wrap(err, op, identifier); cancelErr != nil {
+		return cancelErr
+	}
+	return errcode.WrapInfra(fallbackCode, fallbackMsg, err)
+}
+
 // classify resolves all per-variant attributes (errcode, public message,
 // observation reason) in a single errors.Is traversal of the cause chain.
 // Centralising the dispatch here avoids walking the chain twice (once per

--- a/pkg/ctxcancel/ctxcancel_test.go
+++ b/pkg/ctxcancel/ctxcancel_test.go
@@ -148,3 +148,75 @@ func TestWrap_ReasonInDetails(t *testing.T) {
 		})
 	}
 }
+
+// TestWrapOrInfra covers the convenience helper for the IO boundary pattern
+// "ctx-cancel detection + infra-category errcode fallback". The three branches
+// are: ctx.Canceled → ErrClientCanceled (499), ctx.DeadlineExceeded →
+// ErrServerTimeout (504), any other error → fallbackCode with Category=Infra
+// and the original err preserved as Cause.
+func TestWrapOrInfra(t *testing.T) {
+	const (
+		fallbackCode errcode.Code = "ERR_REPO_QUERY"
+		fallbackMsg  string       = "repo: query failed"
+	)
+	dbErr := errors.New("connection refused")
+
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   errcode.Code
+		wantCat    errcode.Category
+		wantCause  error
+		wantPubMsg string
+	}{
+		{
+			name:       "ctx.Canceled routes to ErrClientCanceled",
+			err:        context.Canceled,
+			wantCode:   errcode.ErrClientCanceled,
+			wantCat:    errcode.CategoryInfra,
+			wantCause:  context.Canceled,
+			wantPubMsg: "request canceled",
+		},
+		{
+			name:       "ctx.DeadlineExceeded routes to ErrServerTimeout",
+			err:        context.DeadlineExceeded,
+			wantCode:   errcode.ErrServerTimeout,
+			wantCat:    errcode.CategoryInfra,
+			wantCause:  context.DeadlineExceeded,
+			wantPubMsg: "request timed out",
+		},
+		{
+			name:       "wrapped ctx.Canceled still routes to 499",
+			err:        fmt.Errorf("scan: %w", context.Canceled),
+			wantCode:   errcode.ErrClientCanceled,
+			wantCat:    errcode.CategoryInfra,
+			wantCause:  context.Canceled,
+			wantPubMsg: "request canceled",
+		},
+		{
+			name:       "non-ctx-cancel falls back to fallbackCode + Infra",
+			err:        dbErr,
+			wantCode:   fallbackCode,
+			wantCat:    errcode.CategoryInfra,
+			wantCause:  dbErr,
+			wantPubMsg: fallbackMsg,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := WrapOrInfra(tt.err, "List", "key=foo", fallbackCode, fallbackMsg)
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, tt.wantCode, ec.Code)
+			assert.Equal(t, tt.wantCat, ec.Category, "Category must be Infra in both branches")
+			assert.Equal(t, tt.wantPubMsg, ec.Message)
+			assert.True(t, errors.Is(err, tt.wantCause), "Cause chain must preserve original err")
+			// IsInfraError must hold in every branch — both ctx-cancel
+			// (CategoryInfra by ctxcancel.Wrap design) and fallback
+			// (CategoryInfra by errcode.WrapInfra) feed the 5xx alerting /
+			// retry classification path.
+			assert.True(t, errcode.IsInfraError(err))
+		})
+	}
+}

--- a/tools/archtest/repoerr_test.go
+++ b/tools/archtest/repoerr_test.go
@@ -19,14 +19,11 @@ const (
 	ruleCtxCancelLocalImplBan = "CTXCANCEL-LOCAL-IMPL-BAN-01"
 	ruleRepoLogKeyIDRedact    = "REPO-LOG-KEY-ID-REDACT-01"
 
-	// bannedWrapMethodPrefix targets receiver methods whose entire purpose is to
-	// forward a single ctx-cancel detection to ctxcancel.Wrap (a thin wrapper).
-	// The "wrapCtx" prefix is the established naming convention for such forwarders.
-	//
-	// Helpers that wrap ctx-cancel detection together with additional non-trivial
-	// logic (e.g. flag_repo.wrapNonScanQueryErr also constructs ErrFlagRepoQuery
-	// fallback envelopes) are NOT thin wrappers and remain legitimate. Such helpers
-	// are deliberately named with a non-wrapCtx prefix to opt out of this rule.
+	// bannedWrapMethodPrefix targets receiver methods that forward to
+	// ctxcancel.Wrap behind an extra layer of indirection. The canonical
+	// pattern across cells/*/internal/adapters is to call ctxcancel.Wrap
+	// directly at the IO boundary; any "wrapCtx*" receiver method is dead
+	// weight by definition.
 	bannedWrapMethodPrefix = "wrapCtx"
 )
 

--- a/tools/archtest/repoerr_test.go
+++ b/tools/archtest/repoerr_test.go
@@ -1,0 +1,538 @@
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ruleCtxCancelLocalImplBan = "CTXCANCEL-LOCAL-IMPL-BAN-01"
+	ruleRepoLogKeyIDRedact    = "REPO-LOG-KEY-ID-REDACT-01"
+
+	bannedWrapMethodPrefix = "wrapCtx"
+)
+
+var bannedTypeNameRegex = regexp.MustCompile(`^(?:local)?[Cc]tx[Cc]ancel(?:ed)?Error$`)
+
+// bannedLogAttrLiterals enumerates the cryptographic-identifier names
+// that must never appear as a string literal in a log call's attribute
+// list anywhere under cells/. Key IDs belong on Prometheus metric labels
+// (low-cardinality, controlled fan-out), not on the log plane.
+var bannedLogAttrLiterals = map[string]struct{}{
+	"key_id":         {},
+	"keyID":          {},
+	"key-id":         {},
+	"stored_key_id":  {},
+	"current_key_id": {},
+}
+
+// slogLevelMethodPrefixes covers Warn/Warnf/WarnContext etc. The rule
+// matches by method-name prefix on any *ast.SelectorExpr — covering
+// both `slog.Warn(...)` package-level calls and `r.logger.WarnContext(...)`
+// receiver calls without binding to the slog package.
+var slogLevelMethodPrefixes = []string{"Warn", "Error", "Info", "Debug"}
+
+type repoErrViolation struct {
+	Rule    string
+	File    string
+	Line    int
+	Message string
+}
+
+func (v repoErrViolation) String() string {
+	return fmt.Sprintf("%s: %s:%d: %s", v.Rule, v.File, v.Line, v.Message)
+}
+
+// =====================================================================
+// Rule 1: CTXCANCEL-LOCAL-IMPL-BAN-01
+// =====================================================================
+//
+// Scope: cells/*/internal/adapters/**/*.go production files (excludes
+// _test.go). Rejects three patterns that all reinvent pkg/ctxcancel:
+//
+//   A. Local ctx-cancel error type (e.g. ctxCanceledError, CtxCancelError,
+//      localCtxCanceledError) — ctxcancel.Wrap returns a *errcode.Error
+//      already carrying the canonical Code/Message/Details.
+//   B. Receiver method named with prefix "wrapCtx" — a thin wrapper that
+//      only forwards to ctxcancel.Wrap. The forwarder is dead weight;
+//      callsites should call ctxcancel.Wrap directly (see audit_repo.go).
+//   C. errors.Is(err, context.Canceled|DeadlineExceeded) literal call —
+//      ctxcancel.Wrap detects internally and returns nil for non-cancel
+//      errors, so callers must not pre-check.
+//
+// ref: pkg/ctxcancel.Wrap (canonical helper)
+// ref: cells/configcore/internal/adapters/postgres/audit_repo.go (range usage)
+
+func TestCtxCancelLocalImplBan(t *testing.T) {
+	root := findModuleRoot(t)
+	files, err := findCellAdapterProductionGoFiles(root)
+	require.NoError(t, err, "failed to enumerate cell adapter Go files")
+	require.NotEmpty(t, files, "no cells/*/internal/adapters/**/*.go files found — module root may be wrong")
+
+	var violations []repoErrViolation
+	for _, file := range files {
+		v, err := scanCtxCancelLocalImpl(file)
+		require.NoErrorf(t, err, "scan %s", file)
+		violations = append(violations, v...)
+	}
+
+	if len(violations) > 0 {
+		t.Logf("Found %d %s violation(s):", len(violations), ruleCtxCancelLocalImplBan)
+		for _, v := range violations {
+			t.Logf("  %s", v)
+		}
+	}
+	assert.Empty(t, violations,
+		"cells/*/internal/adapters/**/*.go must not declare a local "+
+			"ctx-cancel type, a wrapCtx* receiver method, or a bare "+
+			"errors.Is(err, context.Canceled|DeadlineExceeded) call. "+
+			"Use pkg/ctxcancel.Wrap(err, op, identifier) directly.")
+}
+
+func scanCtxCancelLocalImpl(path string) ([]repoErrViolation, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	return scanCtxCancelLocalImplAST(fset, file, path), nil
+}
+
+func scanCtxCancelLocalImplAST(fset *token.FileSet, file *ast.File, path string) []repoErrViolation {
+	var out []repoErrViolation
+
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.GenDecl:
+			if d.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range d.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if bannedTypeNameRegex.MatchString(ts.Name.Name) {
+					out = append(out, repoErrViolation{
+						Rule:    ruleCtxCancelLocalImplBan,
+						File:    path,
+						Line:    fset.Position(ts.Pos()).Line,
+						Message: fmt.Sprintf("local ctx-cancel type %q (use pkg/ctxcancel.Wrap)", ts.Name.Name),
+					})
+				}
+			}
+		case *ast.FuncDecl:
+			if d.Recv != nil && strings.HasPrefix(d.Name.Name, bannedWrapMethodPrefix) {
+				out = append(out, repoErrViolation{
+					Rule:    ruleCtxCancelLocalImplBan,
+					File:    path,
+					Line:    fset.Position(d.Pos()).Line,
+					Message: fmt.Sprintf("local wrap method %q (call pkg/ctxcancel.Wrap directly)", d.Name.Name),
+				})
+			}
+			if d.Body != nil {
+				ast.Inspect(d.Body, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					if !isErrorsIsCall(call) || len(call.Args) < 2 {
+						return true
+					}
+					if !isContextCancelSelector(call.Args[1]) {
+						return true
+					}
+					out = append(out, repoErrViolation{
+						Rule:    ruleCtxCancelLocalImplBan,
+						File:    path,
+						Line:    fset.Position(call.Pos()).Line,
+						Message: "errors.Is(err, context.Canceled|DeadlineExceeded) — call pkg/ctxcancel.Wrap (it detects internally)",
+					})
+					return true
+				})
+			}
+		}
+	}
+	return out
+}
+
+func isErrorsIsCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return pkg.Name == "errors" && sel.Sel.Name == "Is"
+}
+
+func isContextCancelSelector(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	if pkg.Name != "context" {
+		return false
+	}
+	return sel.Sel.Name == "Canceled" || sel.Sel.Name == "DeadlineExceeded"
+}
+
+// findCellAdapterProductionGoFiles narrows findCellProductionGoFiles
+// (defined in outbox_topic_test.go) to the adapter sub-tree only, since
+// the ctx-cancel canonical helper rule applies to repository code that
+// translates IO errors — not to slice handlers / domain logic.
+func findCellAdapterProductionGoFiles(root string) ([]string, error) {
+	all, err := findCellProductionGoFiles(root)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, f := range all {
+		if strings.Contains(filepath.ToSlash(f), "/internal/adapters/") {
+			out = append(out, f)
+		}
+	}
+	return out, nil
+}
+
+// =====================================================================
+// Rule 1 inline regression fixtures
+// =====================================================================
+//
+// Proves the rule retains teeth — a silent zero-violation run on the
+// repo would pass too without exercising the negative path.
+
+func TestCtxCancelLocalImplBan_Fixtures(t *testing.T) {
+	fixtures := map[string]struct {
+		src       string
+		wantMatch bool
+	}{
+		"detects_local_ctx_canceled_type": {
+			src: `package fixture
+type ctxCanceledError struct{ msg string }
+func (e *ctxCanceledError) Error() string { return e.msg }
+`,
+			wantMatch: true,
+		},
+		"detects_local_ctx_cancel_type_camel": {
+			src: `package fixture
+type CtxCancelError struct{}
+func (e *CtxCancelError) Error() string { return "" }
+`,
+			wantMatch: true,
+		},
+		"detects_local_ctx_canceled_type_local_prefix": {
+			src: `package fixture
+type localCtxCanceledError struct{}
+func (e *localCtxCanceledError) Error() string { return "" }
+`,
+			wantMatch: true,
+		},
+		"detects_wrap_method": {
+			src: `package fixture
+type Repo struct{}
+func (r *Repo) wrapCtxCancel(err error) error { return err }
+`,
+			wantMatch: true,
+		},
+		"detects_errors_is_context_canceled": {
+			src: `package fixture
+import (
+	"context"
+	"errors"
+)
+func Foo(err error) bool {
+	return errors.Is(err, context.Canceled)
+}
+`,
+			wantMatch: true,
+		},
+		"detects_errors_is_deadline_exceeded": {
+			src: `package fixture
+import (
+	"context"
+	"errors"
+)
+func Foo(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded)
+}
+`,
+			wantMatch: true,
+		},
+		"passes_canonical_no_local_impl": {
+			src: `package fixture
+type errSentinel struct{ s string }
+func (e *errSentinel) Error() string { return e.s }
+func Wrap() error { return &errSentinel{s: "wrapped"} }
+`,
+			wantMatch: false,
+		},
+		"passes_unrelated_errors_is": {
+			src: `package fixture
+import (
+	"errors"
+	"io"
+)
+func Foo(err error) bool {
+	return errors.Is(err, io.EOF)
+}
+`,
+			wantMatch: false,
+		},
+		"passes_unrelated_struct_type": {
+			src: `package fixture
+type ContextValue struct{ V string }
+type ErrorPayload struct{ Cause error }
+`,
+			wantMatch: false,
+		},
+	}
+
+	for name, tc := range fixtures {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, name+".go", tc.src, parser.SkipObjectResolution)
+			require.NoError(t, err)
+			v := scanCtxCancelLocalImplAST(fset, f, name+".go")
+			if tc.wantMatch {
+				assert.NotEmpty(t, v, "fixture %q should trigger rule, got %v", name, v)
+			} else {
+				assert.Empty(t, v, "fixture %q should not trigger rule, got %v", name, v)
+			}
+		})
+	}
+}
+
+// =====================================================================
+// Rule 2: REPO-LOG-KEY-ID-REDACT-01
+// =====================================================================
+//
+// Scope: cells/**/*.go production files (excludes _test.go). slog
+// {Warn,Error,Info,Debug}* call args must not name "key_id" / "keyID" /
+// "key-id" / "stored_key_id" / "current_key_id" as string literals.
+//
+// Method names prefix-match {Warn, Error, Info, Debug} — covers Warn,
+// Warnf, WarnContext, Warnln on both slog package calls and any
+// *.logger.WarnContext receiver methods. Args[0] (the msg) is skipped;
+// any *ast.BasicLit STRING in Args[1..] is checked against the banlist.
+//
+// ref: OpenTelemetry semantic conventions — sensitive attribute redaction.
+
+func TestRepoLogKeyIDRedact(t *testing.T) {
+	root := findModuleRoot(t)
+	files, err := findCellProductionGoFiles(root)
+	require.NoError(t, err, "failed to enumerate cells production Go files")
+	require.NotEmpty(t, files, "no cells/**/*.go files found — module root may be wrong")
+
+	var violations []repoErrViolation
+	for _, file := range files {
+		v, err := scanRepoLogKeyIDRedact(file)
+		require.NoErrorf(t, err, "scan %s", file)
+		violations = append(violations, v...)
+	}
+
+	if len(violations) > 0 {
+		t.Logf("Found %d %s violation(s):", len(violations), ruleRepoLogKeyIDRedact)
+		for _, v := range violations {
+			t.Logf("  %s", v)
+		}
+	}
+	assert.Empty(t, violations,
+		"cells/**/*.go slog.{Warn,Error,Info,Debug}* attrs must not name "+
+			"key_id / keyID / key-id / stored_key_id / current_key_id; "+
+			"key IDs belong on metric labels, not the log plane.")
+}
+
+func scanRepoLogKeyIDRedact(path string) ([]repoErrViolation, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	return scanRepoLogKeyIDRedactAST(fset, file, path), nil
+}
+
+func scanRepoLogKeyIDRedactAST(fset *token.FileSet, file *ast.File, path string) []repoErrViolation {
+	var out []repoErrViolation
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if !isLogLevelCall(call) {
+			return true
+		}
+		for i := 1; i < len(call.Args); i++ {
+			for _, lit := range collectStringLiterals(call.Args[i]) {
+				s, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				if _, banned := bannedLogAttrLiterals[s]; banned {
+					out = append(out, repoErrViolation{
+						Rule:    ruleRepoLogKeyIDRedact,
+						File:    path,
+						Line:    fset.Position(lit.Pos()).Line,
+						Message: fmt.Sprintf("banned log attr literal %q (key IDs belong on metric labels)", s),
+					})
+				}
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// isLogLevelCall reports whether call is a method call whose Sel.Name
+// starts with Warn/Error/Info/Debug. Covers both `slog.Warn(...)` and
+// `r.logger.WarnContext(...)`.
+func isLogLevelCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	name := sel.Sel.Name
+	for _, p := range slogLevelMethodPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// collectStringLiterals walks expr's AST sub-tree and returns every
+// *ast.BasicLit Kind=STRING. Walks recursively so that
+// `slog.String("key_id", x)` (a CallExpr with a literal arg) is reached
+// even though it is itself an argument of the outer log call.
+func collectStringLiterals(expr ast.Expr) []*ast.BasicLit {
+	var out []*ast.BasicLit
+	ast.Inspect(expr, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok {
+			return true
+		}
+		if lit.Kind == token.STRING {
+			out = append(out, lit)
+		}
+		return true
+	})
+	return out
+}
+
+// =====================================================================
+// Rule 2 inline regression fixtures
+// =====================================================================
+
+func TestRepoLogKeyIDRedact_Fixtures(t *testing.T) {
+	fixtures := map[string]struct {
+		src       string
+		wantMatch bool
+	}{
+		"flags_stored_key_id_in_warn": {
+			src: `package fixture
+import "log/slog"
+func emit(logger *slog.Logger, x string) {
+	logger.Warn("msg", slog.String("stored_key_id", x))
+}
+`,
+			wantMatch: true,
+		},
+		"flags_keyID_in_error": {
+			src: `package fixture
+import "log/slog"
+func emit(logger *slog.Logger, x string) {
+	logger.Error("msg", slog.String("keyID", x))
+}
+`,
+			wantMatch: true,
+		},
+		"flags_key_id_in_warncontext": {
+			src: `package fixture
+import (
+	"context"
+	"log/slog"
+)
+func emit(ctx context.Context, logger *slog.Logger, x string) {
+	logger.WarnContext(ctx, "msg", slog.String("key_id", x))
+}
+`,
+			wantMatch: true,
+		},
+		"flags_current_key_id_in_info": {
+			src: `package fixture
+import "log/slog"
+func emit(logger *slog.Logger, x string) {
+	logger.Info("msg", slog.String("current_key_id", x))
+}
+`,
+			wantMatch: true,
+		},
+		"flags_slog_pkg_warn": {
+			src: `package fixture
+import "log/slog"
+func emit(x string) {
+	slog.Warn("msg", slog.String("stored_key_id", x))
+}
+`,
+			wantMatch: true,
+		},
+		"passes_business_key_only": {
+			src: `package fixture
+import "log/slog"
+func emit(logger *slog.Logger, k string) {
+	logger.Warn("msg", slog.String("key", k))
+}
+`,
+			wantMatch: false,
+		},
+		"passes_unrelated_call_with_banned_string": {
+			src: `package fixture
+func mkLabel() string {
+	return "stored_key_id"
+}
+`,
+			wantMatch: false,
+		},
+		"passes_msg_arg_unchecked": {
+			src: `package fixture
+import "log/slog"
+func emit(logger *slog.Logger) {
+	logger.Warn("stored_key_id")
+}
+`,
+			wantMatch: false,
+		},
+	}
+
+	for name, tc := range fixtures {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, name+".go", tc.src, parser.SkipObjectResolution)
+			require.NoError(t, err)
+			v := scanRepoLogKeyIDRedactAST(fset, f, name+".go")
+			if tc.wantMatch {
+				assert.NotEmpty(t, v, "fixture %q should trigger rule, got %v", name, v)
+			} else {
+				assert.Empty(t, v, "fixture %q should not trigger rule, got %v", name, v)
+			}
+		})
+	}
+}

--- a/tools/archtest/repoerr_test.go
+++ b/tools/archtest/repoerr_test.go
@@ -19,10 +19,24 @@ const (
 	ruleCtxCancelLocalImplBan = "CTXCANCEL-LOCAL-IMPL-BAN-01"
 	ruleRepoLogKeyIDRedact    = "REPO-LOG-KEY-ID-REDACT-01"
 
+	// bannedWrapMethodPrefix targets receiver methods whose entire purpose is to
+	// forward a single ctx-cancel detection to ctxcancel.Wrap (a thin wrapper).
+	// The "wrapCtx" prefix is the established naming convention for such forwarders.
+	//
+	// Helpers that wrap ctx-cancel detection together with additional non-trivial
+	// logic (e.g. flag_repo.wrapNonScanQueryErr also constructs ErrFlagRepoQuery
+	// fallback envelopes) are NOT thin wrappers and remain legitimate. Such helpers
+	// are deliberately named with a non-wrapCtx prefix to opt out of this rule.
 	bannedWrapMethodPrefix = "wrapCtx"
 )
 
-var bannedTypeNameRegex = regexp.MustCompile(`^(?:local)?[Cc]tx[Cc]ancel(?:ed)?Error$`)
+// bannedTypeNameRegex matches names that look like a re-implementation of the
+// canonical ctxcancel error type. Pattern intent: optional "local" or "Local"
+// prefix, then "ctx" or "context" stem, then a Cancel/Canceled/Cancellation
+// root, then "Error" suffix. This is intentionally broad — any new local
+// cancel-error type variant should be caught and either renamed or replaced
+// with the canonical helper (pkg/ctxcancel.Wrap).
+var bannedTypeNameRegex = regexp.MustCompile(`^(?:[Ll]ocal)?[Cc](?:tx|ontext)[Cc]ancel(?:ed|lation)?Error$`)
 
 // bannedLogAttrLiterals enumerates the cryptographic-identifier names
 // that must never appear as a string literal in a log call's attribute
@@ -36,11 +50,22 @@ var bannedLogAttrLiterals = map[string]struct{}{
 	"current_key_id": {},
 }
 
-// slogLevelMethodPrefixes covers Warn/Warnf/WarnContext etc. The rule
-// matches by method-name prefix on any *ast.SelectorExpr — covering
-// both `slog.Warn(...)` package-level calls and `r.logger.WarnContext(...)`
-// receiver calls without binding to the slog package.
-var slogLevelMethodPrefixes = []string{"Warn", "Error", "Info", "Debug"}
+// slogLevelMethods is the closed set of slog level method names recognised by
+// this rule. Using exact-match rather than prefix matching avoids false
+// positives on names that happen to start with a level keyword but are not
+// log emitters (e.g. ErrorList, WarnCounter, InfoBox).
+//
+// The set covers the standard slog API surface:
+//   - plain:    Warn / Error / Info / Debug
+//   - formatted: Warnf / Errorf / Infof / Debugf  (popular wrapper conventions)
+//   - line:     Warnln / Errorln / Infoln / Debugln (popular wrapper conventions)
+//   - context:  WarnContext / ErrorContext / InfoContext / DebugContext
+var slogLevelMethods = map[string]struct{}{
+	"Warn": {}, "Warnf": {}, "Warnln": {}, "WarnContext": {},
+	"Error": {}, "Errorf": {}, "Errorln": {}, "ErrorContext": {},
+	"Info": {}, "Infof": {}, "Infoln": {}, "InfoContext": {},
+	"Debug": {}, "Debugf": {}, "Debugln": {}, "DebugContext": {},
+}
 
 type repoErrViolation struct {
 	Rule    string
@@ -204,6 +229,9 @@ func findCellAdapterProductionGoFiles(root string) ([]string, error) {
 	}
 	var out []string
 	for _, f := range all {
+		// filepath.ToSlash converts path separators to "/" on Windows so the
+		// substring match works consistently across platforms (filepath.WalkDir
+		// returns native separators on each OS).
 		if strings.Contains(filepath.ToSlash(f), "/internal/adapters/") {
 			out = append(out, f)
 		}
@@ -299,6 +327,30 @@ func Foo(err error) bool {
 			src: `package fixture
 type ContextValue struct{ V string }
 type ErrorPayload struct{ Cause error }
+`,
+			wantMatch: false,
+		},
+		// New variants added to widen bannedTypeNameRegex coverage.
+		"detects_context_cancel_error": {
+			src: `package fixture
+type contextCancelError struct{}
+func (e *contextCancelError) Error() string { return "" }
+`,
+			wantMatch: true,
+		},
+		"detects_ctx_cancellation_error": {
+			src: `package fixture
+type ctxCancellationError struct{}
+func (e *ctxCancellationError) Error() string { return "" }
+`,
+			wantMatch: true,
+		},
+		"passes_unrelated_error_types": {
+			src: `package fixture
+type ConfigError struct{ msg string }
+func (e *ConfigError) Error() string { return e.msg }
+type DatabaseError struct{ cause error }
+func (e *DatabaseError) Error() string { return e.cause.Error() }
 `,
 			wantMatch: false,
 		},
@@ -400,21 +452,21 @@ func scanRepoLogKeyIDRedactAST(fset *token.FileSet, file *ast.File, path string)
 	return out
 }
 
-// isLogLevelCall reports whether call is a method call whose Sel.Name
-// starts with Warn/Error/Info/Debug. Covers both `slog.Warn(...)` and
-// `r.logger.WarnContext(...)`.
+// isLogLevelCall reports whether call is a method call whose Sel.Name is in
+// the closed slogLevelMethods set. Covers both `slog.Warn(...)` package-level
+// calls and `r.logger.WarnContext(...)` receiver calls without binding to the
+// slog package import path.
+//
+// Exact-match (not prefix) is used to avoid false positives on method names
+// like ErrorList or WarnCounter that start with a level keyword but are not
+// log emitters.
 func isLogLevelCall(call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}
-	name := sel.Sel.Name
-	for _, p := range slogLevelMethodPrefixes {
-		if strings.HasPrefix(name, p) {
-			return true
-		}
-	}
-	return false
+	_, ok = slogLevelMethods[sel.Sel.Name]
+	return ok
 }
 
 // collectStringLiterals walks expr's AST sub-tree and returns every
@@ -445,7 +497,7 @@ func TestRepoLogKeyIDRedact_Fixtures(t *testing.T) {
 		src       string
 		wantMatch bool
 	}{
-		"flags_stored_key_id_in_warn": {
+		"detects_stored_key_id_in_warn": {
 			src: `package fixture
 import "log/slog"
 func emit(logger *slog.Logger, x string) {
@@ -454,7 +506,7 @@ func emit(logger *slog.Logger, x string) {
 `,
 			wantMatch: true,
 		},
-		"flags_keyID_in_error": {
+		"detects_keyID_in_error": {
 			src: `package fixture
 import "log/slog"
 func emit(logger *slog.Logger, x string) {
@@ -463,7 +515,7 @@ func emit(logger *slog.Logger, x string) {
 `,
 			wantMatch: true,
 		},
-		"flags_key_id_in_warncontext": {
+		"detects_key_id_in_warncontext": {
 			src: `package fixture
 import (
 	"context"
@@ -475,7 +527,7 @@ func emit(ctx context.Context, logger *slog.Logger, x string) {
 `,
 			wantMatch: true,
 		},
-		"flags_current_key_id_in_info": {
+		"detects_current_key_id_in_info": {
 			src: `package fixture
 import "log/slog"
 func emit(logger *slog.Logger, x string) {
@@ -484,7 +536,7 @@ func emit(logger *slog.Logger, x string) {
 `,
 			wantMatch: true,
 		},
-		"flags_slog_pkg_warn": {
+		"detects_slog_pkg_warn": {
 			src: `package fixture
 import "log/slog"
 func emit(x string) {
@@ -515,6 +567,36 @@ func mkLabel() string {
 import "log/slog"
 func emit(logger *slog.Logger) {
 	logger.Warn("stored_key_id")
+}
+`,
+			wantMatch: false,
+		},
+		// Negative fixtures validating that exact-match (not prefix) is used for
+		// isLogLevelCall: methods starting with a level keyword but not in the
+		// closed slogLevelMethods set must NOT be flagged.
+		"passes_errorlist_call_not_a_log_method": {
+			src: `package fixture
+type Errs interface{ ErrorList(label string) }
+func use(e Errs) {
+	e.ErrorList("stored_key_id")
+}
+`,
+			wantMatch: false,
+		},
+		"passes_warncounter_call_not_a_log_method": {
+			src: `package fixture
+type Metrics interface{ WarnCounter(key string) }
+func use(m Metrics) {
+	m.WarnCounter("stored_key_id")
+}
+`,
+			wantMatch: false,
+		},
+		"passes_infobox_call_not_a_log_method": {
+			src: `package fixture
+type UI interface{ InfoBox(msg string) }
+func use(u UI) {
+	u.InfoBox("key_id")
 }
 `,
 			wantMatch: false,

--- a/tools/archtest/repoerr_test.go
+++ b/tools/archtest/repoerr_test.go
@@ -18,13 +18,6 @@ import (
 const (
 	ruleCtxCancelLocalImplBan = "CTXCANCEL-LOCAL-IMPL-BAN-01"
 	ruleRepoLogKeyIDRedact    = "REPO-LOG-KEY-ID-REDACT-01"
-
-	// bannedWrapMethodPrefix targets receiver methods that forward to
-	// ctxcancel.Wrap behind an extra layer of indirection. The canonical
-	// pattern across cells/*/internal/adapters is to call ctxcancel.Wrap
-	// directly at the IO boundary; any "wrapCtx*" receiver method is dead
-	// weight by definition.
-	bannedWrapMethodPrefix = "wrapCtx"
 )
 
 // bannedTypeNameRegex matches names that look like a re-implementation of the
@@ -35,10 +28,14 @@ const (
 // with the canonical helper (pkg/ctxcancel.Wrap).
 var bannedTypeNameRegex = regexp.MustCompile(`^(?:[Ll]ocal)?[Cc](?:tx|ontext)[Cc]ancel(?:ed|lation)?Error$`)
 
-// bannedLogAttrLiterals enumerates the cryptographic-identifier names
-// that must never appear as a string literal in a log call's attribute
-// list anywhere under cells/. Key IDs belong on Prometheus metric labels
-// (low-cardinality, controlled fan-out), not on the log plane.
+// bannedLogAttrLiterals enumerates the cryptographic-identifier names that
+// must never appear as the *key* slot of a slog attribute anywhere under
+// cells/. Key IDs belong on Prometheus metric labels (low-cardinality,
+// controlled fan-out), not on the log plane.
+//
+// The rule scans only key slots — string literals appearing as attribute
+// *values* (e.g. `slog.String("description", "stored_key_id")` where the user
+// happens to log a banned word as a value) are intentionally not flagged.
 var bannedLogAttrLiterals = map[string]struct{}{
 	"key_id":         {},
 	"keyID":          {},
@@ -47,21 +44,33 @@ var bannedLogAttrLiterals = map[string]struct{}{
 	"current_key_id": {},
 }
 
-// slogLevelMethods is the closed set of slog level method names recognised by
-// this rule. Using exact-match rather than prefix matching avoids false
-// positives on names that happen to start with a level keyword but are not
-// log emitters (e.g. ErrorList, WarnCounter, InfoBox).
+// slogMethodKeyStart maps every recognised slog level method name to the
+// argument index at which keyed attribute pairs begin. Exact-match (not
+// prefix) avoids false positives on names like `ErrorList` / `WarnCounter` /
+// `InfoBox` that start with a level keyword but are not log emitters.
 //
-// The set covers the standard slog API surface:
-//   - plain:    Warn / Error / Info / Debug
-//   - formatted: Warnf / Errorf / Infof / Debugf  (popular wrapper conventions)
-//   - line:     Warnln / Errorln / Infoln / Debugln (popular wrapper conventions)
-//   - context:  WarnContext / ErrorContext / InfoContext / DebugContext
-var slogLevelMethods = map[string]struct{}{
-	"Warn": {}, "Warnf": {}, "Warnln": {}, "WarnContext": {},
-	"Error": {}, "Errorf": {}, "Errorln": {}, "ErrorContext": {},
-	"Info": {}, "Infof": {}, "Infoln": {}, "InfoContext": {},
-	"Debug": {}, "Debugf": {}, "Debugln": {}, "DebugContext": {},
+//   - plain (Warn / Error / Info / Debug + f/ln variants): keys start at Args[1]
+//     because Args[0] is the message string.
+//   - context-aware (WarnContext / ErrorContext / InfoContext / DebugContext):
+//     keys start at Args[2] because Args[0]=ctx, Args[1]=msg.
+//   - dynamic level (Log, LogAttrs): keys start at Args[3] because
+//     Args[0]=ctx, Args[1]=level, Args[2]=msg. Log accepts untyped key/value
+//     pairs; LogAttrs takes typed Attr values — both flow through the same
+//     key-slot scan logic below.
+var slogMethodKeyStart = map[string]int{
+	"Warn": 1, "Warnf": 1, "Warnln": 1, "WarnContext": 2,
+	"Error": 1, "Errorf": 1, "Errorln": 1, "ErrorContext": 2,
+	"Info": 1, "Infof": 1, "Infoln": 1, "InfoContext": 2,
+	"Debug": 1, "Debugf": 1, "Debugln": 1, "DebugContext": 2,
+	"Log": 3, "LogAttrs": 3,
+}
+
+// slogAttrCtors enumerates the slog package-level constructors that produce
+// a typed Attr (or Group). Each takes the key as Args[0]; the rest carry the
+// value(s). The set is closed against std slog as of Go 1.22.
+var slogAttrCtors = map[string]struct{}{
+	"String": {}, "Any": {}, "Bool": {}, "Int": {}, "Int64": {}, "Uint64": {},
+	"Float64": {}, "Time": {}, "Duration": {}, "Group": {}, "Attr": {},
 }
 
 type repoErrViolation struct {
@@ -131,6 +140,7 @@ func scanCtxCancelLocalImpl(path string) ([]repoErrViolation, error) {
 }
 
 func scanCtxCancelLocalImplAST(fset *token.FileSet, file *ast.File, path string) []repoErrViolation {
+	ctxAliases := contextImportAliases(file)
 	var out []repoErrViolation
 
 	for _, decl := range file.Decls {
@@ -154,12 +164,12 @@ func scanCtxCancelLocalImplAST(fset *token.FileSet, file *ast.File, path string)
 				}
 			}
 		case *ast.FuncDecl:
-			if d.Recv != nil && strings.HasPrefix(d.Name.Name, bannedWrapMethodPrefix) {
+			if isThinCtxCancelWrapper(d) {
 				out = append(out, repoErrViolation{
 					Rule:    ruleCtxCancelLocalImplBan,
 					File:    path,
 					Line:    fset.Position(d.Pos()).Line,
-					Message: fmt.Sprintf("local wrap method %q (call pkg/ctxcancel.Wrap directly)", d.Name.Name),
+					Message: fmt.Sprintf("thin ctxcancel.Wrap forwarder %q (inline ctxcancel.Wrap at the callsite)", d.Name.Name),
 				})
 			}
 			if d.Body != nil {
@@ -171,7 +181,7 @@ func scanCtxCancelLocalImplAST(fset *token.FileSet, file *ast.File, path string)
 					if !isErrorsIsCall(call) || len(call.Args) < 2 {
 						return true
 					}
-					if !isContextCancelSelector(call.Args[1]) {
+					if !isContextCancelSelector(call.Args[1], ctxAliases) {
 						return true
 					}
 					out = append(out, repoErrViolation{
@@ -183,6 +193,71 @@ func scanCtxCancelLocalImplAST(fset *token.FileSet, file *ast.File, path string)
 					return true
 				})
 			}
+		}
+	}
+	return out
+}
+
+// isThinCtxCancelWrapper reports whether fn is a receiver method whose entire
+// body is a single `return ctxcancel.Wrap(...)` statement. Such forwarders are
+// dead weight — callsites should call ctxcancel.Wrap directly. Helpers that
+// combine ctx-cancel detection with additional non-trivial logic (e.g. mapping
+// to a domain-specific errcode envelope) have body length > 1 and pass.
+//
+// Targets *receiver methods* only: free functions cannot become indirect
+// forwarders for the same per-repo callsite (they are inherently package-wide
+// API surface), so the rule does not extend there.
+func isThinCtxCancelWrapper(fn *ast.FuncDecl) bool {
+	if fn.Recv == nil || fn.Body == nil {
+		return false
+	}
+	if len(fn.Body.List) != 1 {
+		return false
+	}
+	ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) != 1 {
+		return false
+	}
+	call, ok := ret.Results[0].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return pkg.Name == "ctxcancel" && sel.Sel.Name == "Wrap"
+}
+
+// contextImportAliases returns the identifier names through which the
+// "context" stdlib package is referenced in file. Default = {"context"};
+// an explicit alias `import c "context"` adds {"c"}; a dot-import
+// `import . "context"` returns {} (selector-based detection cannot match
+// dot-imported symbols, so the rule fails open on that — dot-imports of
+// stdlib are rare and warned by other linters).
+func contextImportAliases(file *ast.File) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != "context" {
+			continue
+		}
+		switch {
+		case imp.Name == nil:
+			out["context"] = struct{}{}
+		case imp.Name.Name == ".":
+			// Dot-import: out of scope (see doc comment).
+		case imp.Name.Name == "_":
+			// Blank import: package not referenced under any name.
+		default:
+			out[imp.Name.Name] = struct{}{}
 		}
 	}
 	return out
@@ -200,7 +275,7 @@ func isErrorsIsCall(call *ast.CallExpr) bool {
 	return pkg.Name == "errors" && sel.Sel.Name == "Is"
 }
 
-func isContextCancelSelector(expr ast.Expr) bool {
+func isContextCancelSelector(expr ast.Expr, ctxAliases map[string]struct{}) bool {
 	sel, ok := expr.(*ast.SelectorExpr)
 	if !ok {
 		return false
@@ -209,7 +284,7 @@ func isContextCancelSelector(expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	if pkg.Name != "context" {
+	if _, ok := ctxAliases[pkg.Name]; !ok {
 		return false
 	}
 	return sel.Sel.Name == "Canceled" || sel.Sel.Name == "DeadlineExceeded"
@@ -269,12 +344,52 @@ func (e *localCtxCanceledError) Error() string { return "" }
 `,
 			wantMatch: true,
 		},
-		"detects_wrap_method": {
+		// Rule 1.B is now semantic: a receiver method whose body is exactly
+		// `return ctxcancel.Wrap(...)` is a thin forwarder, regardless of name.
+		"detects_thin_wrapper_named_wrapCtxCancel": {
 			src: `package fixture
 type Repo struct{}
-func (r *Repo) wrapCtxCancel(err error) error { return err }
+func (r *Repo) wrapCtxCancel(err error, op, id string) error {
+	return ctxcancel.Wrap(err, op, id)
+}
 `,
 			wantMatch: true,
+		},
+		"detects_thin_wrapper_with_unrelated_name": {
+			src: `package fixture
+type Repo struct{}
+// Method name does NOT start with wrapCtx — the prefix is irrelevant under
+// semantic detection. The body alone (single return ctxcancel.Wrap) makes it
+// a thin forwarder.
+func (r *Repo) forward(err error, op string) error {
+	return ctxcancel.Wrap(err, op, "")
+}
+`,
+			wantMatch: true,
+		},
+		"passes_helper_with_fallback_construction": {
+			src: `package fixture
+type Repo struct{}
+type ErrEnvelope struct{ Cause error }
+func (e *ErrEnvelope) Error() string { return "" }
+// Bundles ctx-cancel detection with additional non-trivial logic — body
+// has multiple statements, NOT a thin forwarder.
+func (r *Repo) wrapNonScanQueryErr(err error, op string) error {
+	if cancelErr := ctxcancel.Wrap(err, op, ""); cancelErr != nil {
+		return cancelErr
+	}
+	return &ErrEnvelope{Cause: err}
+}
+`,
+			wantMatch: false,
+		},
+		"passes_method_returning_err_directly": {
+			src: `package fixture
+type Repo struct{}
+// Single return stmt but the call is not ctxcancel.Wrap.
+func (r *Repo) wrapCtxCancel(err error) error { return err }
+`,
+			wantMatch: false,
 		},
 		"detects_errors_is_context_canceled": {
 			src: `package fixture
@@ -296,6 +411,33 @@ import (
 )
 func Foo(err error) bool {
 	return errors.Is(err, context.DeadlineExceeded)
+}
+`,
+			wantMatch: true,
+		},
+		// Import-alias bypass: `import c "context"` then errors.Is(err, c.Canceled)
+		// must still trigger Rule 1.C — the rule resolves any alias the file has
+		// imported the context package under.
+		"detects_errors_is_context_alias_canceled": {
+			src: `package fixture
+import (
+	c "context"
+	"errors"
+)
+func Foo(err error) bool {
+	return errors.Is(err, c.Canceled)
+}
+`,
+			wantMatch: true,
+		},
+		"detects_errors_is_context_alias_deadline": {
+			src: `package fixture
+import (
+	ctx2 "context"
+	"errors"
+)
+func Foo(err error) bool {
+	return errors.Is(err, ctx2.DeadlineExceeded)
 }
 `,
 			wantMatch: true,
@@ -419,70 +561,156 @@ func scanRepoLogKeyIDRedact(path string) ([]repoErrViolation, error) {
 }
 
 func scanRepoLogKeyIDRedactAST(fset *token.FileSet, file *ast.File, path string) []repoErrViolation {
+	consts := buildStringConstResolver(file)
 	var out []repoErrViolation
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		if !isLogLevelCall(call) {
+		keyStart, ok := logCallKeyStart(call)
+		if !ok {
 			return true
 		}
-		for i := 1; i < len(call.Args); i++ {
-			for _, lit := range collectStringLiterals(call.Args[i]) {
-				s, err := strconv.Unquote(lit.Value)
-				if err != nil {
-					continue
-				}
-				if _, banned := bannedLogAttrLiterals[s]; banned {
-					out = append(out, repoErrViolation{
-						Rule:    ruleRepoLogKeyIDRedact,
-						File:    path,
-						Line:    fset.Position(lit.Pos()).Line,
-						Message: fmt.Sprintf("banned log attr literal %q (key IDs belong on metric labels)", s),
-					})
-				}
-			}
-		}
+		out = append(out, scanLogAttrKeys(fset, path, call, keyStart, consts)...)
 		return true
 	})
 	return out
 }
 
-// isLogLevelCall reports whether call is a method call whose Sel.Name is in
-// the closed slogLevelMethods set. Covers both `slog.Warn(...)` package-level
-// calls and `r.logger.WarnContext(...)` receiver calls without binding to the
-// slog package import path.
+// scanLogAttrKeys inspects the key slots of a slog level call, walking the
+// arg list from keyStart and treating each item as either:
 //
-// Exact-match (not prefix) is used to avoid false positives on method names
-// like ErrorList or WarnCounter that start with a level keyword but are not
-// log emitters.
-func isLogLevelCall(call *ast.CallExpr) bool {
+//   - a typed Attr constructor `slog.X(key, ...)` — only Args[0] (the key)
+//     is checked; the value position is left alone (a banned literal in the
+//     value slot is not a log-plane leak).
+//   - an untyped key/value pair from an `args ...any` log signature — the
+//     current item is the key, the next item is the value, advance by 2.
+//
+// Keys that resolve via a same-file string `const` declaration (one-hop
+// alias folding) are checked as if the literal had been written inline.
+func scanLogAttrKeys(fset *token.FileSet, path string, call *ast.CallExpr, keyStart int, consts stringConstResolver) []repoErrViolation {
+	var out []repoErrViolation
+	args := call.Args
+	for i := keyStart; i < len(args); {
+		arg := args[i]
+		if inner, ok := arg.(*ast.CallExpr); ok && isSlogAttrCtor(inner) {
+			if len(inner.Args) >= 1 {
+				if hit := checkBannedKey(fset, path, inner.Args[0], consts); hit != nil {
+					out = append(out, *hit)
+				}
+			}
+			i++
+			continue
+		}
+		// Untyped pair: this arg is the key, args[i+1] is the value.
+		if hit := checkBannedKey(fset, path, arg, consts); hit != nil {
+			out = append(out, *hit)
+		}
+		i += 2
+	}
+	return out
+}
+
+// logCallKeyStart returns the index at which keyed attributes begin for a
+// recognised slog level call, or 0 / false when call is not a log emitter.
+func logCallKeyStart(call *ast.CallExpr) (int, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return 0, false
+	}
+	idx, ok := slogMethodKeyStart[sel.Sel.Name]
+	return idx, ok
+}
+
+// isSlogAttrCtor reports whether call is a typed slog attribute constructor
+// such as slog.String("k", v) / slog.Any("k", v) / slog.Group("k", attrs...).
+// Constrained to the slog package selector so unrelated identically-named
+// helpers in user code do not opt into the key-slot scan.
+func isSlogAttrCtor(call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}
-	_, ok = slogLevelMethods[sel.Sel.Name]
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "slog" {
+		return false
+	}
+	_, ok = slogAttrCtors[sel.Sel.Name]
 	return ok
 }
 
-// collectStringLiterals walks expr's AST sub-tree and returns every
-// *ast.BasicLit Kind=STRING. Walks recursively so that
-// `slog.String("key_id", x)` (a CallExpr with a literal arg) is reached
-// even though it is itself an argument of the outer log call.
-func collectStringLiterals(expr ast.Expr) []*ast.BasicLit {
-	var out []*ast.BasicLit
-	ast.Inspect(expr, func(n ast.Node) bool {
-		lit, ok := n.(*ast.BasicLit)
+// checkBannedKey resolves expr to a string (literal or one-hop string const)
+// and returns a violation when the result is in bannedLogAttrLiterals.
+func checkBannedKey(fset *token.FileSet, path string, expr ast.Expr, consts stringConstResolver) *repoErrViolation {
+	var (
+		key string
+		pos token.Pos
+	)
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return nil
+		}
+		s, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return nil
+		}
+		key, pos = s, e.Pos()
+	case *ast.Ident:
+		s, ok := consts[e.Name]
 		if !ok {
-			return true
+			return nil
 		}
-		if lit.Kind == token.STRING {
-			out = append(out, lit)
+		key, pos = s, e.Pos()
+	default:
+		return nil
+	}
+	if _, banned := bannedLogAttrLiterals[key]; !banned {
+		return nil
+	}
+	return &repoErrViolation{
+		Rule:    ruleRepoLogKeyIDRedact,
+		File:    path,
+		Line:    fset.Position(pos).Line,
+		Message: fmt.Sprintf("banned log attr key %q (key IDs belong on metric labels)", key),
+	}
+}
+
+// stringConstResolver maps a same-file const identifier to its string value
+// for one-hop alias folding. Cross-package and cross-file resolution is
+// intentionally out of scope: the goal is to close the trivial bypass
+// `const k = "stored_key_id"` without paying the cost of full SSA-grade
+// constant propagation.
+type stringConstResolver map[string]string
+
+func buildStringConstResolver(file *ast.File) stringConstResolver {
+	m := stringConstResolver{}
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
 		}
-		return true
-	})
-	return out
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				if s, err := strconv.Unquote(lit.Value); err == nil {
+					m[name.Name] = s
+				}
+			}
+		}
+	}
+	return m
 }
 
 // =====================================================================
@@ -568,9 +796,59 @@ func emit(logger *slog.Logger) {
 `,
 			wantMatch: false,
 		},
-		// Negative fixtures validating that exact-match (not prefix) is used for
-		// isLogLevelCall: methods starting with a level keyword but not in the
-		// closed slogLevelMethods set must NOT be flagged.
+		// Banned word in attribute *value* slot is allowed — only the key is
+		// scanned. A user logging an error description that happens to contain
+		// "stored_key_id" must not trip the rule.
+		"passes_banned_in_value_position": {
+			src: `package fixture
+import "log/slog"
+func emit(logger *slog.Logger) {
+	logger.Warn("msg", slog.String("description", "stored_key_id"))
+}
+`,
+			wantMatch: false,
+		},
+		// Const-alias bypass: declaring the banned key as a same-file string
+		// const must still be detected via one-hop folding.
+		"detects_const_alias_key": {
+			src: `package fixture
+import "log/slog"
+const auditKey = "stored_key_id"
+func emit(logger *slog.Logger, x string) {
+	logger.Warn("msg", slog.String(auditKey, x))
+}
+`,
+			wantMatch: true,
+		},
+		// slog.LogAttrs adds typed Attrs starting at Args[3] (ctx, level, msg).
+		"detects_logattrs_with_banned_key": {
+			src: `package fixture
+import (
+	"context"
+	"log/slog"
+)
+func emit(ctx context.Context, logger *slog.Logger, x string) {
+	logger.LogAttrs(ctx, slog.LevelWarn, "msg", slog.String("stored_key_id", x))
+}
+`,
+			wantMatch: true,
+		},
+		// slog.Log accepts untyped key/value pairs starting at Args[3].
+		"detects_log_method_untyped_pair": {
+			src: `package fixture
+import (
+	"context"
+	"log/slog"
+)
+func emit(ctx context.Context, logger *slog.Logger, x string) {
+	logger.Log(ctx, slog.LevelWarn, "msg", "stored_key_id", x)
+}
+`,
+			wantMatch: true,
+		},
+		// Negative fixtures validating that logCallKeyStart uses exact-match
+		// against slogMethodKeyStart: methods starting with a level keyword but
+		// not in the closed set must NOT be flagged.
 		"passes_errorlist_call_not_a_log_method": {
 			src: `package fixture
 type Errs interface{ ErrorList(label string) }


### PR DESCRIPTION
## Summary

PR#271 把 ctx-cancel 收口到 `pkg/ctxcancel` 时留下三个未做的尾巴，本 PR 一次清掉：

1. **删 thin wrapper**（K'.1）— `cells/configcore` 两个 PG repo 上的 `wrapCtxCancel` 受体方法只是 forward 到 `ctxcancel.Wrap`，纯冗余间接层。`audit_repo.go` 早已直接调用 canonical helper，本 PR 把 `config_repo`（8 处 callsite）和 `flag_repo`（3 处 callsite）也统一过来。
2. **redact 加密密钥 ID**（K'.2）— `observeStaleCipher` / `applySensitiveListSentinel` 的 slog.Warn 与 `plaintext_migration` 的 slog.Info 直接吐出 `stored_key_id` / `current_key_id` / `key_id`，违反"cryptographic identifier 不进日志面"安全约束。Warn 现在只携带业务 key 名；key IDs 走 `onStaleCipher` 回调，由调用方装配为 Prometheus 受控基数 label（指标维度合约不变）。
3. **archtest 双向锁**（K'.3）— 新建 `tools/archtest/repoerr_test.go` 静态防线两条规则：
   - **CTXCANCEL-LOCAL-IMPL-BAN-01** 扫 `cells/*/internal/adapters/**/*.go`：禁本地 `ctxCanceledError` 类型、`wrapCtx*` 受体方法、字面 `errors.Is(err, context.Canceled|DeadlineExceeded)` 调用（canonical 路径不需要也不应再写 errors.Is，`Wrap` 内部已检测）
   - **REPO-LOG-KEY-ID-REDACT-01** 扫 `cells/**/*.go`：禁 slog `*.Warn/Error/Info/Debug*` 调用 args 中的 `key_id` / `keyID` / `key-id` / `stored_key_id` / `current_key_id` 字面量

不向后兼容：旧 `wrapCtxCancel` 直接消失、`stored_key_id` / `current_key_id` slog 字段直接消失，无 deprecation（项目无外部消费方，CLAUDE.md "review/重构不考虑向后兼容"）。

## Refs

- `docs/plans/202604260058-l4-virtual-taco.md` § PR-CFG-K'
- `cells/configcore/internal/adapters/postgres/audit_repo.go`（canonical pattern）
- `pkg/ctxcancel/ctxcancel.go`（Wrap signature）
- `tools/archtest/outbox_topic_test.go`（AST scan + inline fixture pattern）
- `tools/archtest/auth_authtest_boundary_test.go`（cells path scanning）
- OpenTelemetry semantic conventions — sensitive attribute redaction

## Test plan

- [x] TDD: archtest 全量铺设后跑 RED 验证（Rule 1 命中 2 处 wrapCtx 方法、Rule 2 命中 5 处 banned 字面量）
- [x] K'.2 实施后 archtest Rule 2 GREEN
- [x] K'.1 实施后 archtest 双规则 GREEN
- [x] `go build ./...` 通过
- [x] `go test ./...` 全 PASS（含 ctx-cancel 行为回归）
- [x] `golangci-lint run ./cells/configcore/... ./tools/archtest/...` → 0 issues
- [x] `go run ./cmd/gocell validate --strict` → 0 errors / 0 warnings
- [x] config_repo_encrypt_test.go 4 处断言改为反向断言 + 校验 key 字段保留
- [x] onStaleCipher 回调三参数断言保留并加固（指标侧合约不变）

🤖 Generated with [Claude Code](https://claude.com/claude-code)