### PR TITLE
feat(outbox,archtest,health): PR-A49 — expand fail-open guard + /readyz degraded

### DIFF
--- a/cells/accesscore/cell_providers.go
+++ b/cells/accesscore/cell_providers.go
@@ -14,6 +14,7 @@ package accesscore
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/kernel/cell"
@@ -28,6 +29,11 @@ import (
 // ports.HealthCheckable. Both in-memory and real adapters implement
 // HealthCheckable, so the probe is present in all modes. Returns an
 // empty map only when sessionRepo is nil (no repo injected at all).
+//
+// The emitter checker (outbox-failopen-rate.accesscore) is enabled by default
+// at a 5% threshold; it returns cell.ErrDegraded when the fail-open drop ratio
+// sustained between two /readyz probes exceeds that threshold. Disable via
+// outbox.WithFailOpenRateThreshold(0) when constructing the emitter.
 func (c *AccessCore) HealthCheckers() map[string]func(context.Context) error {
 	checkers := make(map[string]func(context.Context) error)
 	if hc, ok := c.sessionRepo.(ports.HealthCheckable); ok {
@@ -41,7 +47,10 @@ func (c *AccessCore) HealthCheckers() map[string]func(context.Context) error {
 	if hc, ok := c.emitter.(cell.HealthContributor); ok {
 		for k, v := range hc.HealthCheckers() {
 			if _, dup := checkers[k]; dup {
-				continue // checker name collision — emitter checker name is cellID-scoped, so this is unexpected; skip silently to preserve startup
+				slog.Error("accesscore: duplicate health checker name; emitter checker dropped",
+					slog.String("checker", k),
+					slog.String("source", "outbox-emitter"))
+				continue
 			}
 			checkers[k] = v
 		}

--- a/cells/accesscore/cell_providers.go
+++ b/cells/accesscore/cell_providers.go
@@ -16,6 +16,7 @@ import (
 	"context"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -32,6 +33,17 @@ func (c *AccessCore) HealthCheckers() map[string]func(context.Context) error {
 	if hc, ok := c.sessionRepo.(ports.HealthCheckable); ok {
 		checkers["session-store"] = func(ctx context.Context) error {
 			return hc.Health(ctx)
+		}
+	}
+	// PR-A49: aggregate emitter (DirectEmitter) HealthContributor checkers.
+	// The /readyz aggregator surfaces fail-open drop ratio degraded signals
+	// via cell.ErrDegraded → HTTP 200 + status="degraded".
+	if hc, ok := c.emitter.(cell.HealthContributor); ok {
+		for k, v := range hc.HealthCheckers() {
+			if _, dup := checkers[k]; dup {
+				continue // checker name collision — emitter checker name is cellID-scoped, so this is unexpected; skip silently to preserve startup
+			}
+			checkers[k] = v
 		}
 	}
 	return checkers

--- a/cells/accesscore/options_test.go
+++ b/cells/accesscore/options_test.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,4 +110,40 @@ func TestInit_MissingJWTIssuerAndVerifier(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "WithJWTIssuer")
 	assert.Contains(t, err.Error(), "WithJWTVerifier")
+}
+
+// TestHealthCheckers_WithDirectEmitter verifies that after Init with a
+// DirectEmitter-backed publisher, HealthCheckers returns both the
+// session-store checker and the outbox-failopen-rate checker.
+func TestHealthCheckers_WithDirectEmitter(t *testing.T) {
+	c := NewAccessCore(
+		WithInMemoryDefaults(),
+		WithJWTIssuer(testIssuer),
+		WithJWTVerifier(testVerifier),
+		WithOutboxDeps(eventbus.New(), nil),
+		WithRefreshMetricsProvider(metrics.NopProvider{}),
+	)
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	require.NoError(t, c.Init(context.Background(), deps))
+
+	checkers := c.HealthCheckers()
+	require.Contains(t, checkers, "session-store", "session-store checker must be present")
+	const emitterKey = "outbox-failopen-rate:accesscore"
+	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
+	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
+}
+
+// TestHealthCheckers_WithNoopEmitter verifies that when the emitter does not
+// implement cell.HealthContributor (e.g. DiscardPublisher-backed emitter
+// after Init in demo mode with no metrics), only cell-owned checkers appear.
+func TestHealthCheckers_NoEmitterChecker(t *testing.T) {
+	// WithEmitter(nil) → emitter field stays nil → no HealthContributor
+	c := NewAccessCore(WithInMemoryDefaults())
+	// Do NOT Init — emitter is nil pre-Init; HealthCheckers must handle that.
+	checkers := c.HealthCheckers()
+	assert.Contains(t, checkers, "session-store", "session-store must still be present")
+	for k := range checkers {
+		assert.NotContains(t, k, "outbox-failopen-rate",
+			"nil emitter must not produce outbox checker: key=%s", k)
+	}
 }

--- a/cells/accesscore/options_test.go
+++ b/cells/accesscore/options_test.go
@@ -128,7 +128,7 @@ func TestHealthCheckers_WithDirectEmitter(t *testing.T) {
 
 	checkers := c.HealthCheckers()
 	require.Contains(t, checkers, "session-store", "session-store checker must be present")
-	const emitterKey = "outbox-failopen-rate:accesscore"
+	const emitterKey = "outbox-failopen-rate.accesscore"
 	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
 	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
 }

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -555,7 +555,7 @@ func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	fp := failingPublisher{err: errors.New("broker unavailable")}
-	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc, err := NewService(userRepo, sessionRepo, newIdentityRefreshStore(), slog.Default(),
 		WithEmitter(emitter), WithTokenIssuer(&stubTokenIssuer{}))

--- a/cells/accesscore/slices/sessionlogin/service_test.go
+++ b/cells/accesscore/slices/sessionlogin/service_test.go
@@ -470,7 +470,7 @@ func TestService_Login_PublishError_DoesNotFailLogin(t *testing.T) {
 	seedUser(userRepo, "pub-err", "pass123")
 
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
-	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc := NewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default(), WithEmitter(emitter))
 

--- a/cells/accesscore/slices/sessionlogout/service_test.go
+++ b/cells/accesscore/slices/sessionlogout/service_test.go
@@ -133,7 +133,7 @@ func TestService_Logout_PublishError_DoesNotFailLogout(t *testing.T) {
 	seedSession(repo, "sess-pub", "usr-1")
 
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
-	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc := NewService(repo, newLogoutRefreshStore(), slog.Default(), WithEmitter(emitter))
 

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -64,6 +64,7 @@ var (
 	_ cell.Cell                  = (*AuditCore)(nil)
 	_ cell.RouteGroupContributor = (*AuditCore)(nil)
 	_ cell.EventRegistrar        = (*AuditCore)(nil)
+	_ cell.HealthContributor     = (*AuditCore)(nil)
 )
 
 // Option configures an AuditCore Cell.
@@ -172,6 +173,24 @@ type AuditCore struct {
 	verifySvc    *auditverify.Service
 	archiveSvc   *auditarchive.Service
 	queryHandler *auditquery.Handler
+}
+
+// HealthCheckers implements cell.HealthContributor. Aggregates the outbox
+// emitter's HealthCheckers (currently fail-open drop rate → degraded signal)
+// so /readyz surfaces "audit events are being lost in fail-open path"
+// without polluting the cell's primary Cell.Health() signal.
+//
+// Note: auditcore uses DirectPublishFailClosed, so the fail-open checker
+// will never trip in normal operation; the checker is still wired for
+// consistency and forward-compatibility.
+func (c *AuditCore) HealthCheckers() map[string]func(context.Context) error {
+	checkers := make(map[string]func(context.Context) error)
+	if hc, ok := c.emitter.(cell.HealthContributor); ok {
+		for k, v := range hc.HealthCheckers() {
+			checkers[k] = v
+		}
+	}
+	return checkers
 }
 
 // NewAuditCore creates a new AuditCore Cell.

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -183,10 +183,21 @@ type AuditCore struct {
 // Note: auditcore uses DirectPublishFailClosed, so the fail-open checker
 // will never trip in normal operation; the checker is still wired for
 // consistency and forward-compatibility.
+//
+// The emitter checker (outbox-failopen-rate.auditcore) is enabled by default
+// at a 5% threshold; it returns cell.ErrDegraded when the fail-open drop ratio
+// sustained between two /readyz probes exceeds that threshold. Disable via
+// outbox.WithFailOpenRateThreshold(0) when constructing the emitter.
 func (c *AuditCore) HealthCheckers() map[string]func(context.Context) error {
 	checkers := make(map[string]func(context.Context) error)
 	if hc, ok := c.emitter.(cell.HealthContributor); ok {
 		for k, v := range hc.HealthCheckers() {
+			if _, dup := checkers[k]; dup {
+				slog.Error("auditcore: duplicate health checker name; emitter checker dropped",
+					slog.String("checker", k),
+					slog.String("source", "outbox-emitter"))
+				continue
+			}
 			checkers[k] = v
 		}
 	}

--- a/cells/auditcore/cell_test.go
+++ b/cells/auditcore/cell_test.go
@@ -451,3 +451,25 @@ func (w *recordingWriter) Write(_ context.Context, entry outbox.Entry) error {
 	w.entries = append(w.entries, entry)
 	return nil
 }
+
+// TestAuditCore_HealthCheckers_WithDirectEmitter verifies that after Init with
+// a DirectEmitter-backed publisher, HealthCheckers returns the
+// outbox-failopen-rate checker scoped to "auditcore".
+func TestAuditCore_HealthCheckers_WithDirectEmitter(t *testing.T) {
+	c := newTestCell()
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	require.NoError(t, c.Init(context.Background(), deps))
+
+	checkers := c.HealthCheckers()
+	const emitterKey = "outbox-failopen-rate:auditcore"
+	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
+	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
+}
+
+// TestAuditCore_HealthCheckers_NilEmitter verifies that HealthCheckers returns
+// an empty map when the emitter does not implement cell.HealthContributor.
+func TestAuditCore_HealthCheckers_NilEmitter(t *testing.T) {
+	c := NewAuditCore() // no emitter set
+	checkers := c.HealthCheckers()
+	assert.Empty(t, checkers, "nil emitter must produce empty health checkers map")
+}

--- a/cells/auditcore/cell_test.go
+++ b/cells/auditcore/cell_test.go
@@ -461,7 +461,7 @@ func TestAuditCore_HealthCheckers_WithDirectEmitter(t *testing.T) {
 	require.NoError(t, c.Init(context.Background(), deps))
 
 	checkers := c.HealthCheckers()
-	const emitterKey = "outbox-failopen-rate:auditcore"
+	const emitterKey = "outbox-failopen-rate.auditcore"
 	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
 	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
 }

--- a/cells/auditcore/slices/auditappend/service_test.go
+++ b/cells/auditcore/slices/auditappend/service_test.go
@@ -134,7 +134,7 @@ func (f failingPublisher) Close(_ context.Context) error                       {
 func TestService_HandleEvent_PublishError_DoesNotFailAppend(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
-	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "auditcore", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "auditcore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(emitter))
 

--- a/cells/auditcore/slices/auditverify/outbox_test.go
+++ b/cells/auditcore/slices/auditverify/outbox_test.go
@@ -148,7 +148,7 @@ func TestService_VerifyChain_PublishError_DoesNotFailVerify(t *testing.T) {
 	repo := mem.NewAuditRepository()
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
 	// No outboxWriter → goes through direct-publish path.
-	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "auditcore", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "auditcore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc := NewService(repo, testHMACKey, slog.Default(), WithEmitter(emitter))
 

--- a/cells/configcore/cell.go
+++ b/cells/configcore/cell.go
@@ -3,6 +3,7 @@
 package configcore
 
 import (
+	"context"
 	"log/slog"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
@@ -29,6 +30,7 @@ var (
 	_ cell.Cell                  = (*ConfigCore)(nil)
 	_ cell.RouteGroupContributor = (*ConfigCore)(nil)
 	_ cell.EventRegistrar        = (*ConfigCore)(nil)
+	_ cell.HealthContributor     = (*ConfigCore)(nil)
 )
 
 // Option configures a ConfigCore Cell.
@@ -188,6 +190,20 @@ type ConfigCore struct {
 	flagHandler      *featureflag.Handler
 	flagWriteHandler *flagwrite.Handler
 	subscribeSvc     *configsubscribe.Service
+}
+
+// HealthCheckers implements cell.HealthContributor. Aggregates the outbox
+// emitter's HealthCheckers (currently fail-open drop rate → degraded signal)
+// so /readyz surfaces "config events are being lost in fail-open path"
+// without polluting the cell's primary Cell.Health() signal.
+func (c *ConfigCore) HealthCheckers() map[string]func(context.Context) error {
+	checkers := make(map[string]func(context.Context) error)
+	if hc, ok := c.emitter.(cell.HealthContributor); ok {
+		for k, v := range hc.HealthCheckers() {
+			checkers[k] = v
+		}
+	}
+	return checkers
 }
 
 // NewConfigCore creates a new ConfigCore Cell.

--- a/cells/configcore/cell.go
+++ b/cells/configcore/cell.go
@@ -196,10 +196,21 @@ type ConfigCore struct {
 // emitter's HealthCheckers (currently fail-open drop rate → degraded signal)
 // so /readyz surfaces "config events are being lost in fail-open path"
 // without polluting the cell's primary Cell.Health() signal.
+//
+// The emitter checker (outbox-failopen-rate.configcore) is enabled by default
+// at a 5% threshold; it returns cell.ErrDegraded when the fail-open drop ratio
+// sustained between two /readyz probes exceeds that threshold. Disable via
+// outbox.WithFailOpenRateThreshold(0) when constructing the emitter.
 func (c *ConfigCore) HealthCheckers() map[string]func(context.Context) error {
 	checkers := make(map[string]func(context.Context) error)
 	if hc, ok := c.emitter.(cell.HealthContributor); ok {
 		for k, v := range hc.HealthCheckers() {
+			if _, dup := checkers[k]; dup {
+				slog.Error("configcore: duplicate health checker name; emitter checker dropped",
+					slog.String("checker", k),
+					slog.String("source", "outbox-emitter"))
+				continue
+			}
 			checkers[k] = v
 		}
 	}

--- a/cells/configcore/cell_test.go
+++ b/cells/configcore/cell_test.go
@@ -638,7 +638,7 @@ func TestConfigCore_HealthCheckers_WithDirectEmitter(t *testing.T) {
 	require.NoError(t, c.Init(context.Background(), deps))
 
 	checkers := c.HealthCheckers()
-	const emitterKey = "outbox-failopen-rate:configcore"
+	const emitterKey = "outbox-failopen-rate.configcore"
 	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
 	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
 }

--- a/cells/configcore/cell_test.go
+++ b/cells/configcore/cell_test.go
@@ -628,3 +628,25 @@ func TestConfigCore_DeriveModes(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigCore_HealthCheckers_WithDirectEmitter verifies that after Init
+// with a DirectEmitter-backed publisher, HealthCheckers returns the
+// outbox-failopen-rate checker scoped to "configcore".
+func TestConfigCore_HealthCheckers_WithDirectEmitter(t *testing.T) {
+	c := newTestCell()
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	require.NoError(t, c.Init(context.Background(), deps))
+
+	checkers := c.HealthCheckers()
+	const emitterKey = "outbox-failopen-rate:configcore"
+	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
+	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
+}
+
+// TestConfigCore_HealthCheckers_NilEmitter verifies that HealthCheckers returns
+// an empty map when the emitter does not implement cell.HealthContributor.
+func TestConfigCore_HealthCheckers_NilEmitter(t *testing.T) {
+	c := NewConfigCore() // no emitter set
+	checkers := c.HealthCheckers()
+	assert.Empty(t, checkers, "nil emitter must produce empty health checkers map")
+}

--- a/cells/configcore/slices/configpublish/service_test.go
+++ b/cells/configcore/slices/configpublish/service_test.go
@@ -28,7 +28,7 @@ func newTestService() (*Service, *mem.ConfigRepository) {
 
 func newDirectTestEmitter(t *testing.T, pub outbox.Publisher, mode outbox.DirectPublishFailureMode) outbox.Emitter {
 	t.Helper()
-	emitter, err := outbox.NewDirectEmitter(pub, mode, metrics.NopProvider{}, "configcore", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(pub, mode, metrics.NopProvider{}, "configcore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	return emitter
 }

--- a/cells/configcore/slices/configwrite/service_test.go
+++ b/cells/configcore/slices/configwrite/service_test.go
@@ -300,7 +300,7 @@ func TestDelete_CallsTxRunnerRunInTxOnce(t *testing.T) {
 func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
 	repo := mem.NewConfigRepository()
 	fp := testutil.FailingPublisher{Err: errors.New("broker unavailable")}
-	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "configcore", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "configcore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
 

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -44,6 +44,7 @@ var (
 	_ cell.RouteGroupContributor = (*DeviceCell)(nil)
 	_ cell.LifecycleContributor  = (*DeviceCell)(nil)
 	_ kcommand.QueueRegistrar    = (*DeviceCell)(nil)
+	_ cell.HealthContributor     = (*DeviceCell)(nil)
 )
 
 type commandQueueStore interface {
@@ -86,6 +87,7 @@ type DeviceCell struct {
 	*cell.BaseCell
 	deviceRepo      domain.DeviceRepository
 	publisher       outbox.Publisher
+	emitter         outbox.Emitter // set during Init; retained for HealthCheckers
 	cursorCodec     *query.CursorCodec
 	logger          *slog.Logger
 	metricsProvider metrics.Provider
@@ -96,6 +98,20 @@ type DeviceCell struct {
 	commandHandler  *devicecommand.Handler
 	statusHandler   *devicestatus.Handler
 	listHandler     *devicelist.Handler
+}
+
+// HealthCheckers implements cell.HealthContributor. Aggregates the outbox
+// emitter's HealthCheckers (fail-open drop rate → degraded signal) so /readyz
+// surfaces "device events are being lost in fail-open path" without polluting
+// the cell's primary Cell.Health() signal.
+func (c *DeviceCell) HealthCheckers() map[string]func(context.Context) error {
+	checkers := make(map[string]func(context.Context) error)
+	if hc, ok := c.emitter.(cell.HealthContributor); ok {
+		for k, v := range hc.HealthCheckers() {
+			checkers[k] = v
+		}
+	}
+	return checkers
 }
 
 // RegisterCommandQueue implements kernel/command.QueueRegistrar. The supplied
@@ -175,13 +191,14 @@ func (c *DeviceCell) Init(ctx context.Context, deps cell.Dependencies) error {
 	if err := cell.CheckNotNoop(deps.DurabilityMode, "devicecell", c.publisher); err != nil {
 		return err
 	}
-	emitter, err := c.buildEmitter()
+	builtEmitter, err := c.buildEmitter()
 	if err != nil {
 		return err
 	}
+	c.emitter = builtEmitter
 
 	// device-register slice
-	registerSvc := deviceregister.NewService(c.deviceRepo, c.logger, deviceregister.WithEmitter(emitter))
+	registerSvc := deviceregister.NewService(c.deviceRepo, c.logger, deviceregister.WithEmitter(builtEmitter))
 	c.registerHandler = deviceregister.NewHandler(registerSvc)
 	c.AddSlice(cell.NewBaseSlice("deviceregister", "devicecell", cell.L4))
 

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -145,7 +145,7 @@ func (c *DeviceCell) buildEmitter() (*outbox.DirectEmitter, error) {
 	if mp == nil {
 		mp = metrics.NopProvider{}
 	}
-	return outbox.NewDirectEmitter(c.publisher, outbox.DirectPublishFailOpen, mp, "devicecell", c.logger)
+	return outbox.NewDirectEmitter(c.publisher, outbox.DirectPublishFailOpen, mp, "devicecell", outbox.WithLogger(c.logger))
 }
 
 // Init sets up repositories, slice services, and handlers.

--- a/examples/iotdevice/cells/devicecell/cell_test.go
+++ b/examples/iotdevice/cells/devicecell/cell_test.go
@@ -480,7 +480,7 @@ func TestDeviceCell_HealthCheckers_WithDirectEmitter(t *testing.T) {
 	require.NoError(t, c.Init(context.Background(), deps))
 
 	checkers := c.HealthCheckers()
-	const emitterKey = "outbox-failopen-rate:devicecell"
+	const emitterKey = "outbox-failopen-rate.devicecell"
 	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
 	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
 }

--- a/examples/iotdevice/cells/devicecell/cell_test.go
+++ b/examples/iotdevice/cells/devicecell/cell_test.go
@@ -470,3 +470,25 @@ func TestDeviceCell_DemoMode_RegisterPublishFailureReturnsCreated(t *testing.T) 
 	assert.Equal(t, http.StatusCreated, rec.Code,
 		"demo mode keeps direct publish fail-open behavior")
 }
+
+// TestDeviceCell_HealthCheckers_WithDirectEmitter verifies that after Init
+// with a DirectEmitter-backed publisher, HealthCheckers returns the
+// outbox-failopen-rate checker scoped to "devicecell".
+func TestDeviceCell_HealthCheckers_WithDirectEmitter(t *testing.T) {
+	c := newTestCell()
+	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
+	require.NoError(t, c.Init(context.Background(), deps))
+
+	checkers := c.HealthCheckers()
+	const emitterKey = "outbox-failopen-rate:devicecell"
+	require.Contains(t, checkers, emitterKey, "DirectEmitter health checker must be aggregated")
+	assert.NoError(t, checkers[emitterKey](context.Background()), "fresh emitter should be healthy")
+}
+
+// TestDeviceCell_HealthCheckers_BeforeInit verifies that HealthCheckers
+// returns an empty map before Init (emitter field is nil).
+func TestDeviceCell_HealthCheckers_BeforeInit(t *testing.T) {
+	c := newTestCell() // emitter not set until Init
+	checkers := c.HealthCheckers()
+	assert.Empty(t, checkers, "pre-Init emitter field is nil; no health checkers expected")
+}

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/contract_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/contract_test.go
@@ -37,7 +37,7 @@ var _ outbox.Publisher = (*recordingPublisher)(nil)
 func newContractHandler() (http.Handler, *recordingPublisher) {
 	repo := mem.NewDeviceRepository()
 	pub := &recordingPublisher{}
-	emitter, err := outbox.NewDirectEmitter(pub, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "devicecell", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(pub, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "devicecell", outbox.WithLogger(slog.Default()))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service_test.go
@@ -89,7 +89,7 @@ func TestService_Register_PersistsDevice(t *testing.T) {
 
 func TestService_Register_PublishFails_StillReturnsDevice(t *testing.T) {
 	repo := mem.NewDeviceRepository()
-	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "devicecell", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "devicecell", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
 
@@ -101,7 +101,7 @@ func TestService_Register_PublishFails_StillReturnsDevice(t *testing.T) {
 
 func TestService_Register_PublishFails_FailClosedReturnsError(t *testing.T) {
 	repo := mem.NewDeviceRepository()
-	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailClosed, metrics.NopProvider{}, "devicecell", slog.Default())
+	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailClosed, metrics.NopProvider{}, "devicecell", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
 	svc := NewService(repo, slog.Default(), WithEmitter(emitter))
 
@@ -116,7 +116,7 @@ func TestService_Register_FailOpenDoesNotLogPublished(t *testing.T) {
 	repo := mem.NewDeviceRepository()
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "devicecell", logger)
+	emitter, err := outbox.NewDirectEmitter(failPublisher{}, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "devicecell", outbox.WithLogger(logger))
 	require.NoError(t, err)
 	svc := NewService(repo, logger, WithEmitter(emitter))
 

--- a/kernel/cell/health.go
+++ b/kernel/cell/health.go
@@ -1,6 +1,6 @@
 package cell
 
-import "errors"
+import "github.com/ghbvf/gocell/kernel/outbox"
 
 // ErrDegraded is the canonical sentinel returned by cell.HealthContributor
 // checkers to signal "operational but degraded" — the cell is still serving
@@ -14,10 +14,14 @@ import "errors"
 // the actionable signal; ErrDegraded is the on-the-wire indicator that the
 // pod knows it is in a degraded state.
 //
+// This is an alias to outbox.ErrDegraded so that errors.Is matches regardless
+// of which symbol the caller uses.
+//
 // ref: envoyproxy/envoy admin /ready — DEGRADED returns 200, distinguishing
 // "soft failure, do not evict" from "hard failure, drain traffic".
 // ref: HealthStatus.Status type tag in kernel/cell/types.go:63
 // ("healthy" | "degraded" | "unhealthy") — degraded is already a first-class
 // state on the per-cell HealthStatus; this sentinel extends it to the
 // per-checker plane.
-var ErrDegraded = errors.New("cell: degraded")
+// ref: kernel/outbox/emitter.go ErrDegraded — authoritative definition.
+var ErrDegraded = outbox.ErrDegraded

--- a/kernel/cell/health.go
+++ b/kernel/cell/health.go
@@ -9,6 +9,10 @@ import "github.com/ghbvf/gocell/kernel/outbox"
 // via errors.Is and maps it to HTTP 200 + body status="degraded" rather than
 // 503, so K8s readinessProbe does not evict the pod for soft-failure signals.
 //
+// Note: the authoritative definition lives in kernel/outbox because
+// kernel/cell already imports kernel/outbox (registrar/mode_resolver);
+// reversing the dependency would create an import cycle.
+//
 // Operators should pair degraded responses with Prometheus alerts on the
 // underlying metric (e.g., gocell_outbox_emit_failopen_dropped_total) for
 // the actionable signal; ErrDegraded is the on-the-wire indicator that the

--- a/kernel/cell/health.go
+++ b/kernel/cell/health.go
@@ -1,0 +1,23 @@
+package cell
+
+import "errors"
+
+// ErrDegraded is the canonical sentinel returned by cell.HealthContributor
+// checkers to signal "operational but degraded" — the cell is still serving
+// traffic, but a non-critical capability is impaired (e.g., outbox fail-open
+// drop rate exceeded threshold). The /readyz aggregator detects ErrDegraded
+// via errors.Is and maps it to HTTP 200 + body status="degraded" rather than
+// 503, so K8s readinessProbe does not evict the pod for soft-failure signals.
+//
+// Operators should pair degraded responses with Prometheus alerts on the
+// underlying metric (e.g., gocell_outbox_emit_failopen_dropped_total) for
+// the actionable signal; ErrDegraded is the on-the-wire indicator that the
+// pod knows it is in a degraded state.
+//
+// ref: envoyproxy/envoy admin /ready — DEGRADED returns 200, distinguishing
+// "soft failure, do not evict" from "hard failure, drain traffic".
+// ref: HealthStatus.Status type tag in kernel/cell/types.go:63
+// ("healthy" | "degraded" | "unhealthy") — degraded is already a first-class
+// state on the per-cell HealthStatus; this sentinel extends it to the
+// per-checker plane.
+var ErrDegraded = errors.New("cell: degraded")

--- a/kernel/cell/mode_resolver.go
+++ b/kernel/cell/mode_resolver.go
@@ -107,7 +107,7 @@ func resolveDemoEmitter(cfg EmitterConfig, logger *slog.Logger) (EmitterOutcome,
 			return EmitterOutcome{}, errcode.New(errcode.ErrCellMissingOutbox,
 				cfg.CellID+" demo mode with direct publisher requires MetricsProvider; pass kernel/observability/metrics.NopProvider{} explicitly in tests (e.g. via cells/{accesscore,auditcore,configcore}.WithMetricsProvider(...))")
 		}
-		emitter, err := outbox.NewDirectEmitter(cfg.Publisher, cfg.DirectPublishMode, cfg.MetricsProvider, cfg.CellID, logger)
+		emitter, err := outbox.NewDirectEmitter(cfg.Publisher, cfg.DirectPublishMode, cfg.MetricsProvider, cfg.CellID, outbox.WithLogger(logger))
 		if err != nil {
 			return EmitterOutcome{}, err
 		}

--- a/kernel/outbox/emitter.go
+++ b/kernel/outbox/emitter.go
@@ -2,6 +2,7 @@ package outbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -70,7 +71,33 @@ type DirectEmitter struct {
 	cellID            string
 	logger            *slog.Logger
 	failOpenDroppedCv metrics.CounterVec
+	failOpenTracker   *failOpenTracker
 }
+
+// DirectEmitterOption configures NewDirectEmitter.
+type DirectEmitterOption func(*directEmitterOptions)
+
+type directEmitterOptions struct {
+	logger             *slog.Logger
+	failOpenRateThresh float64
+}
+
+// WithLogger overrides slog.Default() for this DirectEmitter's structured logs.
+func WithLogger(l *slog.Logger) DirectEmitterOption {
+	return func(o *directEmitterOptions) { o.logger = l }
+}
+
+// WithFailOpenRateThreshold sets the drop ratio threshold above which the
+// emitter's HealthCheckers checker reports cell.ErrDegraded. The implicit
+// time window is the interval between two /readyz probes (typically
+// 10-30s). 0 disables the checker; default is 0.05 (5%).
+//
+// ref: kernel/outbox/failopen_tracker.go for ratio semantics.
+func WithFailOpenRateThreshold(ratio float64) DirectEmitterOption {
+	return func(o *directEmitterOptions) { o.failOpenRateThresh = ratio }
+}
+
+const defaultFailOpenRateThreshold = 0.05 // 5%
 
 // NewDirectEmitter adapts a Publisher into an Emitter that publishes v1 wire
 // envelopes. cellID is the owning Cell's ID and is used as the "cell" label on
@@ -79,8 +106,11 @@ type DirectEmitter struct {
 // register the fail-open dropped counter (fqName after Namespace injection:
 // gocell_outbox_emit_failopen_dropped_total); pass metrics.NopProvider{} in
 // tests or demos where no backend is wired. A nil mp returns an errcode error.
-// A nil logger uses slog.Default().
-func NewDirectEmitter(p Publisher, mode DirectPublishFailureMode, mp metrics.Provider, cellID string, loggers ...*slog.Logger) (*DirectEmitter, error) {
+//
+// Use WithLogger to override the default slog.Default() logger.
+// Use WithFailOpenRateThreshold to set the drop-ratio threshold for the
+// HealthCheckers checker (default 5%; 0 disables).
+func NewDirectEmitter(p Publisher, mode DirectPublishFailureMode, mp metrics.Provider, cellID string, opts ...DirectEmitterOption) (*DirectEmitter, error) {
 	if isNilEmitterDependency(p) {
 		return nil, errcode.New(errcode.ErrCellMissingOutbox,
 			"outbox: nil publisher for DirectEmitter")
@@ -101,11 +131,24 @@ func NewDirectEmitter(p Publisher, mode DirectPublishFailureMode, mp metrics.Pro
 	if err != nil {
 		return nil, fmt.Errorf("outbox: register failopen_dropped counter: %w", err)
 	}
-	logger := slog.Default()
-	if len(loggers) > 0 && loggers[0] != nil {
-		logger = loggers[0]
+	cfg := &directEmitterOptions{
+		logger:             slog.Default(),
+		failOpenRateThresh: defaultFailOpenRateThreshold,
 	}
-	return &DirectEmitter{publisher: p, mode: mode, cellID: cellID, logger: logger, failOpenDroppedCv: cv}, nil
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.logger == nil {
+		cfg.logger = slog.Default() // 防御 WithLogger(nil)
+	}
+	return &DirectEmitter{
+		publisher:         p,
+		mode:              mode,
+		cellID:            cellID,
+		logger:            cfg.logger,
+		failOpenDroppedCv: cv,
+		failOpenTracker:   newFailOpenTracker(cfg.failOpenRateThresh),
+	}, nil
 }
 
 // Emit validates the entry, injects observability metadata from ctx, marshals
@@ -148,14 +191,57 @@ func (e *DirectEmitter) Emit(ctx context.Context, entry Entry) error {
 				"cell":  e.cellID,
 				"topic": topic,
 			}).Inc()
+			e.failOpenTracker.RecordDrop()
 			return nil
 		}
 		return fmt.Errorf("outbox: direct publish failed for topic %s: %w", topic, err)
 	}
+	e.failOpenTracker.RecordSuccess()
 	return nil
 }
 
 var _ Emitter = (*DirectEmitter)(nil)
+
+// ErrDegraded is the canonical sentinel returned by DirectEmitter.HealthCheckers
+// to signal "operational but degraded" — the emitter is still serving requests
+// but the fail-open drop ratio has exceeded the configured threshold, meaning
+// events are silently lost at an elevated rate.
+//
+// The /readyz aggregator detects ErrDegraded via errors.Is and maps it to
+// HTTP 200 + body status="degraded" rather than 503, so K8s readinessProbe
+// does not evict the pod for soft-failure signals.
+//
+// kernel/cell.ErrDegraded is an alias to this sentinel so that callers
+// referencing either symbol satisfy the same errors.Is chain.
+//
+// ref: envoyproxy/envoy admin /ready — DEGRADED returns 200, distinguishing
+// "soft failure, do not evict" from "hard failure, drain traffic".
+// ref: kernel/cell/health.go — cell-layer alias to this sentinel.
+var ErrDegraded = errors.New("outbox: degraded")
+
+// HealthCheckers implements cell.HealthContributor. The checker name is
+// scoped by cellID to avoid collisions when multiple cells own a
+// DirectEmitter (each /readyz checker name MUST be globally unique).
+//
+// The checker returns ErrDegraded when the fail-open drop ratio exceeds the
+// threshold configured via WithFailOpenRateThreshold (default 5%). The /readyz
+// aggregator detects this via errors.Is and maps to HTTP 200 + status="degraded"
+// rather than 503.
+//
+// ref: kernel/outbox/emitter.go ErrDegraded
+// ref: cells/accesscore/cell_providers.go:22-38 — kebab-case checker name convention
+func (e *DirectEmitter) HealthCheckers() map[string]func(context.Context) error {
+	return map[string]func(context.Context) error{
+		"outbox-failopen-rate:" + e.cellID: e.checkFailOpenRate,
+	}
+}
+
+func (e *DirectEmitter) checkFailOpenRate(_ context.Context) error {
+	if e.failOpenTracker.Tripped() {
+		return fmt.Errorf("outbox: fail-open drop ratio exceeded threshold for cell %q: %w", e.cellID, ErrDegraded)
+	}
+	return nil
+}
 
 // DurabilityReporter is an optional interface Emitter implementations may
 // expose so callers (typically Cell boundaries) can query whether this

--- a/kernel/outbox/emitter.go
+++ b/kernel/outbox/emitter.go
@@ -88,9 +88,15 @@ func WithLogger(l *slog.Logger) DirectEmitterOption {
 }
 
 // WithFailOpenRateThreshold sets the drop ratio threshold above which the
-// emitter's HealthCheckers checker reports cell.ErrDegraded. The implicit
-// time window is the interval between two /readyz probes (typically
-// 10-30s). 0 disables the checker; default is 0.05 (5%).
+// emitter's HealthCheckers checker reports cell.ErrDegraded.
+//
+// Default is 0.05 (5%) — the tracker is enabled by default because fail-open
+// drop monitoring is framework infrastructure responsibility, not a per-cell
+// opt-in (CLAUDE.md "生产配置禁止静默降级"). Pass WithFailOpenRateThreshold(0)
+// to explicitly disable.
+//
+// The implicit time window is the interval between two /readyz probes
+// (typically 10-30s under K8s readinessProbe).
 //
 // ref: kernel/outbox/failopen_tracker.go for ratio semantics.
 func WithFailOpenRateThreshold(ratio float64) DirectEmitterOption {
@@ -217,7 +223,7 @@ var _ Emitter = (*DirectEmitter)(nil)
 // ref: envoyproxy/envoy admin /ready — DEGRADED returns 200, distinguishing
 // "soft failure, do not evict" from "hard failure, drain traffic".
 // ref: kernel/cell/health.go — cell-layer alias to this sentinel.
-var ErrDegraded = errors.New("outbox: degraded")
+var ErrDegraded = errors.New("degraded")
 
 // HealthCheckers implements cell.HealthContributor. The checker name is
 // scoped by cellID to avoid collisions when multiple cells own a
@@ -228,11 +234,18 @@ var ErrDegraded = errors.New("outbox: degraded")
 // aggregator detects this via errors.Is and maps to HTTP 200 + status="degraded"
 // rather than 503.
 //
+// Implementation note: the underlying tracker uses delta semantics — two
+// consecutive /readyz probes with no new emit between them yield ratio
+// 0/0 → not tripped (preserve healthy state). Operators monitoring
+// degraded transitions via /readyz should not interpret a return-to-healthy
+// as "drops have stopped"; pair with the gocell_outbox_emit_failopen_dropped_total
+// counter for the actionable signal.
+//
 // ref: kernel/outbox/emitter.go ErrDegraded
 // ref: cells/accesscore/cell_providers.go:22-38 — kebab-case checker name convention
 func (e *DirectEmitter) HealthCheckers() map[string]func(context.Context) error {
 	return map[string]func(context.Context) error{
-		"outbox-failopen-rate:" + e.cellID: e.checkFailOpenRate,
+		"outbox-failopen-rate." + e.cellID: e.checkFailOpenRate,
 	}
 }
 

--- a/kernel/outbox/emitter_test.go
+++ b/kernel/outbox/emitter_test.go
@@ -3,6 +3,7 @@ package outbox
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"testing"
 
@@ -403,13 +404,12 @@ func TestNewDirectEmitter_CounterVecRegistrationFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "failopen_dropped counter")
 }
 
-// TestNewDirectEmitter_WithLogger verifies that the optional variadic logger
-// parameter is accepted and wired into the emitter (covers the logger-injection
-// branch in NewDirectEmitter).
+// TestNewDirectEmitter_WithLogger verifies that WithLogger option is accepted
+// and wired into the emitter (covers the logger-injection branch in NewDirectEmitter).
 func TestNewDirectEmitter_WithLogger(t *testing.T) {
 	logger := slog.Default()
 	publisher := &recordingEmitterPublisher{err: errors.New("broker down")}
-	emitter, err := NewDirectEmitter(publisher, DirectPublishFailOpen, metrics.NopProvider{}, "testcell", logger)
+	emitter, err := NewDirectEmitter(publisher, DirectPublishFailOpen, metrics.NopProvider{}, "testcell", WithLogger(logger))
 	require.NoError(t, err)
 	require.NotNil(t, emitter)
 	// Confirm emitter works — fail-open path must not error.
@@ -421,6 +421,87 @@ func TestNewDirectEmitter_WithLogger(t *testing.T) {
 func TestWriterEmitter_Durable_NilReceiver(t *testing.T) {
 	var e *WriterEmitter
 	assert.False(t, e.Durable())
+}
+
+// ---------------------------------------------------------------------------
+// HealthCheckers tests
+// ---------------------------------------------------------------------------
+
+// TestDirectEmitter_HealthCheckers_DegradedOnHighDropRatio verifies that after
+// all publishes fail (fail-open), the HealthCheckers checker reports ErrDegraded.
+func TestDirectEmitter_HealthCheckers_DegradedOnHighDropRatio(t *testing.T) {
+	fp := &recordingEmitterPublisher{err: errors.New("broker down")}
+	e, err := NewDirectEmitter(fp, DirectPublishFailOpen, metrics.NopProvider{}, "testcell")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	entry := validEntry("health-degrade")
+	for i := 0; i < 10; i++ {
+		require.NoError(t, e.Emit(ctx, entry)) // fail-open does not return err
+	}
+
+	checkers := e.HealthCheckers()
+	require.Contains(t, checkers, "outbox-failopen-rate:testcell")
+
+	// 10 drops / 10 total = 100% > 5% default threshold → Tripped
+	checkErr := checkers["outbox-failopen-rate:testcell"](ctx)
+	require.Error(t, checkErr)
+	assert.ErrorIs(t, checkErr, ErrDegraded)
+}
+
+// TestDirectEmitter_HealthCheckers_HealthyOnLowDropRatio verifies that when
+// all publishes succeed (zero drops), the HealthCheckers checker returns nil.
+func TestDirectEmitter_HealthCheckers_HealthyOnLowDropRatio(t *testing.T) {
+	pub := &recordingEmitterPublisher{} // no error → success path
+	e, err := NewDirectEmitter(pub, DirectPublishFailOpen, metrics.NopProvider{}, "testcell")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	entry := validEntry("health-ok")
+	for i := 0; i < 10; i++ {
+		require.NoError(t, e.Emit(ctx, entry))
+	}
+
+	checkers := e.HealthCheckers()
+	require.Contains(t, checkers, "outbox-failopen-rate:testcell")
+
+	// 0 drops / 10 total = 0% < 5% threshold → not tripped
+	checkErr := checkers["outbox-failopen-rate:testcell"](ctx)
+	assert.NoError(t, checkErr)
+}
+
+// TestNewDirectEmitter_WithLoggerOption verifies that WithLogger injects a custom
+// logger and that the fail-open Warn is written through it (not slog.Default()).
+func TestNewDirectEmitter_WithLoggerOption(t *testing.T) {
+	customLogger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fp := &recordingEmitterPublisher{err: errors.New("broker down")}
+	e, err := NewDirectEmitter(fp, DirectPublishFailOpen, metrics.NopProvider{}, "testcell",
+		WithLogger(customLogger))
+	require.NoError(t, err)
+	require.NotNil(t, e)
+
+	// Trigger fail-open path; must not error even though publish fails.
+	require.NoError(t, e.Emit(context.Background(), validEntry("log-opt")))
+}
+
+// TestNewDirectEmitter_WithFailOpenRateThresholdZeroDisables verifies that
+// WithFailOpenRateThreshold(0) disables the degraded check (checker always nil).
+func TestNewDirectEmitter_WithFailOpenRateThresholdZeroDisables(t *testing.T) {
+	fp := &recordingEmitterPublisher{err: errors.New("broker down")}
+	e, err := NewDirectEmitter(fp, DirectPublishFailOpen, metrics.NopProvider{}, "testcell",
+		WithFailOpenRateThreshold(0))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	entry := validEntry("thresh-zero")
+	for i := 0; i < 100; i++ {
+		require.NoError(t, e.Emit(ctx, entry))
+	}
+
+	// threshold 0 → Tripped always false
+	checkErr := e.HealthCheckers()["outbox-failopen-rate:testcell"](ctx)
+	assert.NoError(t, checkErr)
 }
 
 // TestDirectEmitter_InjectsObservabilityFromContext verifies that DirectEmitter.Emit

--- a/kernel/outbox/emitter_test.go
+++ b/kernel/outbox/emitter_test.go
@@ -441,10 +441,10 @@ func TestDirectEmitter_HealthCheckers_DegradedOnHighDropRatio(t *testing.T) {
 	}
 
 	checkers := e.HealthCheckers()
-	require.Contains(t, checkers, "outbox-failopen-rate:testcell")
+	require.Contains(t, checkers, "outbox-failopen-rate.testcell")
 
 	// 10 drops / 10 total = 100% > 5% default threshold → Tripped
-	checkErr := checkers["outbox-failopen-rate:testcell"](ctx)
+	checkErr := checkers["outbox-failopen-rate.testcell"](ctx)
 	require.Error(t, checkErr)
 	assert.ErrorIs(t, checkErr, ErrDegraded)
 }
@@ -463,10 +463,10 @@ func TestDirectEmitter_HealthCheckers_HealthyOnLowDropRatio(t *testing.T) {
 	}
 
 	checkers := e.HealthCheckers()
-	require.Contains(t, checkers, "outbox-failopen-rate:testcell")
+	require.Contains(t, checkers, "outbox-failopen-rate.testcell")
 
 	// 0 drops / 10 total = 0% < 5% threshold → not tripped
-	checkErr := checkers["outbox-failopen-rate:testcell"](ctx)
+	checkErr := checkers["outbox-failopen-rate.testcell"](ctx)
 	assert.NoError(t, checkErr)
 }
 
@@ -500,7 +500,7 @@ func TestNewDirectEmitter_WithFailOpenRateThresholdZeroDisables(t *testing.T) {
 	}
 
 	// threshold 0 → Tripped always false
-	checkErr := e.HealthCheckers()["outbox-failopen-rate:testcell"](ctx)
+	checkErr := e.HealthCheckers()["outbox-failopen-rate.testcell"](ctx)
 	assert.NoError(t, checkErr)
 }
 
@@ -536,3 +536,20 @@ func TestDirectEmitter_InjectsObservabilityFromContext(t *testing.T) {
 	assert.Equal(t, wantTraceID, got.Observability.TraceID,
 		"DirectEmitter must inject trace_id from ctx into entry.Observability")
 }
+
+// TestNewDirectEmitter_WithLoggerNilFallsBackToDefault verifies that
+// WithLogger(nil) falls back to slog.Default() in NewDirectEmitter
+// (defensive — protects against accidental nil logger from caller).
+func TestNewDirectEmitter_WithLoggerNilFallsBackToDefault(t *testing.T) {
+	e, err := NewDirectEmitter(noopPub{}, DirectPublishFailClosed, metrics.NopProvider{}, "test-cell",
+		WithLogger(nil))
+	require.NoError(t, err)
+	require.NotNil(t, e)
+	// Trigger Emit path, confirm no panic.
+	require.NoError(t, e.Emit(context.Background(), validEntry("logger-nil-test")))
+}
+
+type noopPub struct{}
+
+func (noopPub) Publish(_ context.Context, _ string, _ []byte) error { return nil }
+func (noopPub) Close(_ context.Context) error                       { return nil }

--- a/kernel/outbox/envelope.go
+++ b/kernel/outbox/envelope.go
@@ -28,7 +28,6 @@ type WireMessage struct {
 	Metadata      map[string]string     `json:"metadata,omitempty"`
 	Observability ObservabilityMetadata `json:"observability,omitempty"`
 	CreatedAt     time.Time             `json:"createdAt"`
-	Attempts      int                   `json:"attempts,omitempty"`
 }
 
 // MarshalEnvelope serializes an Entry into the canonical v1 wire envelope.

--- a/kernel/outbox/envelope_test.go
+++ b/kernel/outbox/envelope_test.go
@@ -41,6 +41,7 @@ func TestUnmarshalEnvelope_V1Success(t *testing.T) {
 		Topic:         "order.created.v1",
 		Payload:       []byte(`{"orderId":"o-1","amount":99}`),
 		Metadata:      map[string]string{"trace_id": "t-123"},
+		Observability: ObservabilityMetadata{TraceID: "abc123"},
 		CreatedAt:     now,
 	}
 
@@ -58,6 +59,7 @@ func TestUnmarshalEnvelope_V1Success(t *testing.T) {
 	assert.Equal(t, string(entry.Payload), string(got.Payload))
 	assert.Equal(t, entry.Metadata, got.Metadata)
 	assert.True(t, got.CreatedAt.Equal(now))
+	assert.Equal(t, entry.Observability, got.Observability)
 }
 
 func TestUnmarshalEnvelope_UnknownVersionRejected(t *testing.T) {
@@ -116,6 +118,39 @@ func TestMarshalDirectEnvelope_ProducesV1(t *testing.T) {
 	assert.Equal(t, topic, got.EventType)
 	assert.Equal(t, topic, got.Topic)
 	assert.Equal(t, string(payload), string(got.Payload))
+}
+
+func TestUnmarshalEnvelope_PreservesObservability(t *testing.T) {
+	// W3C traceparent: version(2)-traceID(32)-spanID(16)-flags(2) = 55 bytes, lowercase hex.
+	obs := ObservabilityMetadata{
+		TraceID:       "4bf92f3577b34da6a3ce929d0e0e4736",
+		TraceParent:   "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		RequestID:     "req-abc-123",
+		CorrelationID: "corr-xyz-456",
+	}
+
+	entry := Entry{
+		ID:            "obs-rt-1",
+		EventType:     "test.event.v1",
+		Topic:         "test.event.v1",
+		Payload:       []byte(`{"x":1}`),
+		Metadata:      map[string]string{"foo": "bar"},
+		Observability: obs,
+		CreatedAt:     time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC),
+	}
+
+	raw, err := MarshalEnvelope(entry)
+	require.NoError(t, err)
+
+	got, err := UnmarshalEnvelope(entry.Topic, raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, obs.TraceID, got.Observability.TraceID)
+	assert.Equal(t, obs.TraceParent, got.Observability.TraceParent)
+	assert.Equal(t, obs.RequestID, got.Observability.RequestID)
+	assert.Equal(t, obs.CorrelationID, got.Observability.CorrelationID)
+	// struct-equal 兜底：未来新增字段时测试自动失败
+	assert.Equal(t, obs, got.Observability)
 }
 
 func TestMarshalDirectEnvelope_PanicsOnEmptyRequiredFields(t *testing.T) {

--- a/kernel/outbox/failopen_tracker.go
+++ b/kernel/outbox/failopen_tracker.go
@@ -1,0 +1,73 @@
+package outbox
+
+import "sync"
+
+// failOpenTracker tracks the ratio of fail-open dropped emits to total emits.
+// It is checked from /readyz to surface "outbox is in fail-open path losing
+// events" as a soft-failure (degraded) signal without dependence on time
+// constants — the implicit window is the interval between two consecutive
+// /readyz probes (typically 10-30s under K8s readinessProbe), so the tracker
+// adapts naturally to probe cadence and emit volume.
+//
+// Algorithm: maintain monotonic totalEmits + droppedEmits counters; on each
+// Tripped() call, compute ratio = (deltaDropped / deltaTotal) since the last
+// call and compare against the configured threshold. With no new emits between
+// calls, return false (no signal to evaluate; preserve healthy state).
+//
+// ref: prometheus increase()/rate() — semantically "delta per scrape window";
+// we use the /readyz probe cadence as the implicit window.
+type failOpenTracker struct {
+	mu             sync.Mutex
+	totalEmits     uint64
+	droppedEmits   uint64
+	lastTotal      uint64
+	lastDropped    uint64
+	thresholdRatio float64 // 0 or negative disables the tracker (always returns false)
+}
+
+func newFailOpenTracker(thresholdRatio float64) *failOpenTracker {
+	return &failOpenTracker{thresholdRatio: thresholdRatio}
+}
+
+// RecordSuccess increments totalEmits.
+func (t *failOpenTracker) RecordSuccess() {
+	t.mu.Lock()
+	t.totalEmits++
+	t.mu.Unlock()
+}
+
+// RecordDrop increments BOTH totalEmits and droppedEmits, so totalEmits is
+// the denominator of every emit attempt — successful + dropped.
+func (t *failOpenTracker) RecordDrop() {
+	t.mu.Lock()
+	t.totalEmits++
+	t.droppedEmits++
+	t.mu.Unlock()
+}
+
+// Tripped returns true if the drop ratio since the last call exceeds the
+// configured threshold. If no emits occurred since the last call (deltaTotal
+// == 0), returns false (preserve healthy state).
+//
+// Side effect: updates lastTotal/lastDropped to current values.
+func (t *failOpenTracker) Tripped() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.thresholdRatio <= 0 {
+		return false
+	}
+
+	deltaTotal := t.totalEmits - t.lastTotal
+	deltaDropped := t.droppedEmits - t.lastDropped
+
+	t.lastTotal = t.totalEmits
+	t.lastDropped = t.droppedEmits
+
+	if deltaTotal == 0 {
+		return false
+	}
+
+	ratio := float64(deltaDropped) / float64(deltaTotal)
+	return ratio > t.thresholdRatio
+}

--- a/kernel/outbox/failopen_tracker_test.go
+++ b/kernel/outbox/failopen_tracker_test.go
@@ -1,0 +1,77 @@
+package outbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFailOpenTracker_TrippedOnHighRatio(t *testing.T) {
+	tr := newFailOpenTracker(0.5)
+	for i := 0; i < 5; i++ {
+		tr.RecordSuccess()
+	}
+	for i := 0; i < 6; i++ {
+		tr.RecordDrop()
+	}
+	// ratio = 6 / (5+6) = 0.545 > 0.5
+	assert.True(t, tr.Tripped())
+}
+
+func TestFailOpenTracker_HealthyOnLowRatio(t *testing.T) {
+	tr := newFailOpenTracker(0.05)
+	for i := 0; i < 100; i++ {
+		tr.RecordSuccess()
+	}
+	for i := 0; i < 2; i++ {
+		tr.RecordDrop()
+	}
+	// ratio = 2/102 ≈ 0.0196 < 0.05
+	assert.False(t, tr.Tripped())
+}
+
+func TestFailOpenTracker_NoEmitsBetweenChecks(t *testing.T) {
+	tr := newFailOpenTracker(0.05)
+	tr.RecordSuccess()
+	tr.RecordDrop()
+	_ = tr.Tripped() // first check sets baseline
+	// no new emits
+	assert.False(t, tr.Tripped(), "no new emits since last check should not trip")
+}
+
+func TestFailOpenTracker_ZeroThresholdDisabled(t *testing.T) {
+	tr := newFailOpenTracker(0)
+	for i := 0; i < 100; i++ {
+		tr.RecordDrop()
+	}
+	assert.False(t, tr.Tripped(), "threshold=0 disables the tracker")
+}
+
+func TestFailOpenTracker_RecoveryAfterDropStop(t *testing.T) {
+	tr := newFailOpenTracker(0.05)
+	for i := 0; i < 10; i++ {
+		tr.RecordDrop()
+	}
+	assert.True(t, tr.Tripped()) // baseline + degraded
+	// recovery: no more drops, only success
+	for i := 0; i < 100; i++ {
+		tr.RecordSuccess()
+	}
+	assert.False(t, tr.Tripped(), "after drops stop and successes flow, tracker recovers")
+}
+
+func TestFailOpenTracker_NegativeOrInvalidThreshold(t *testing.T) {
+	// Negative ratio is treated like 0 (disabled) — defensive
+	tr := newFailOpenTracker(-0.1)
+	for i := 0; i < 100; i++ {
+		tr.RecordDrop()
+	}
+	assert.False(t, tr.Tripped(), "negative threshold should disable")
+
+	// > 1.0 is allowed (effectively never trips since ratio ≤ 1.0)
+	tr2 := newFailOpenTracker(1.5)
+	for i := 0; i < 100; i++ {
+		tr2.RecordDrop()
+	}
+	assert.False(t, tr2.Tripped(), "threshold > 1.0 effectively disables")
+}

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 )
@@ -67,7 +68,7 @@ type Checker = func(context.Context) error
 
 // ProbeResult captures the outcome of a single readiness probe execution.
 type ProbeResult struct {
-	Status   string        // "healthy" | "unhealthy" | "timeout"
+	Status   string        // "healthy" | "degraded" | "unhealthy" | "timeout"
 	Duration time.Duration // wall-clock time spent inside the probe
 	// Err is exposed in /readyz?verbose output (truncated to maxVerboseErrLen).
 	// Probe implementations MUST NOT include connection strings, tokens, or
@@ -224,7 +225,7 @@ func (h *Handler) LivezHandler() http.HandlerFunc {
 // the same key. The struct owns its data — adapter info is snapshotted
 // under Handler.mu inside computeReadyz so writeTo runs lock-free.
 type readyzResult struct {
-	allHealthy   bool
+	overall      string // "healthy" | "degraded" | "unhealthy"
 	verbose      bool
 	cells        map[string]string         // nil when !verbose
 	dependencies map[string]map[string]any // nil when !verbose
@@ -301,7 +302,7 @@ func (h *Handler) computeReadyzSafe(verbose bool) (result readyzResult) {
 		if r := recover(); r != nil {
 			slog.Error("readyz: recovered panic during readiness computation",
 				slog.Any("panic", r))
-			result = readyzResult{allHealthy: false}
+			result = readyzResult{overall: "unhealthy"}
 		}
 	}()
 	return h.computeReadyz(verbose)
@@ -316,7 +317,7 @@ func (h *Handler) computeReadyzSafe(verbose bool) (result readyzResult) {
 // the result is fully self-contained — writeTo can serialise it without
 // touching Handler state.
 func (h *Handler) computeReadyz(verbose bool) readyzResult {
-	allHealthy, cells := h.aggregateCellHealth(verbose)
+	cellOverall, cells := h.aggregateCellHealth(verbose)
 
 	h.mu.RLock()
 	checkersCopy := make(map[string]Checker, len(h.checkers))
@@ -330,12 +331,13 @@ func (h *Handler) computeReadyz(verbose bool) readyzResult {
 	h.mu.RUnlock()
 
 	results := h.runProbesParallel(checkersCopy)
-	probeHealthy, dependencies := h.aggregateProbeResults(results, verbose)
-	if !probeHealthy {
-		allHealthy = false
+	probeOverall, dependencies := h.aggregateProbeResults(results, verbose)
+	worst := rankStatus(cellOverall)
+	if r := rankStatus(probeOverall); r > worst {
+		worst = r
 	}
 	return readyzResult{
-		allHealthy:   allHealthy,
+		overall:      statusFromRank(worst),
 		verbose:      verbose,
 		cells:        cells,
 		dependencies: dependencies,
@@ -355,36 +357,39 @@ func cloneAdapterInfo(src map[string]string) map[string]string {
 }
 
 // aggregateCellHealth computes cell readiness and optionally builds the verbose
-// cells map. Returns (allHealthy, cells).
-func (h *Handler) aggregateCellHealth(verbose bool) (bool, map[string]string) {
+// cells map. Returns (overall, cells) where overall is the worst-case status
+// across all cells: healthy(0) < degraded(1) < unhealthy(2).
+func (h *Handler) aggregateCellHealth(verbose bool) (string, map[string]string) {
 	cellHealth := h.assembly.Health()
 	var cells map[string]string
 	if verbose {
 		cells = make(map[string]string, len(cellHealth))
 	}
-	allHealthy := true
+	worst := 0 // healthy
 	for id, hs := range cellHealth {
 		if verbose {
 			cells[id] = hs.Status
 		}
-		if hs.Status != "healthy" {
-			allHealthy = false
+		if r := rankStatus(hs.Status); r > worst {
+			worst = r
 		}
 	}
-	return allHealthy, cells
+	return statusFromRank(worst), cells
 }
 
 // aggregateProbeResults converts ProbeResult map to verbose dependency output.
-// Returns (allHealthy, dependencies). dependencies is nil when verbose is false.
-func (h *Handler) aggregateProbeResults(results map[string]ProbeResult, verbose bool) (bool, map[string]map[string]any) {
+// Returns (overall, dependencies) where overall is the worst-case status
+// across all probe results: healthy(0) < degraded(1) < unhealthy(2).
+// dependencies is nil when verbose is false.
+func (h *Handler) aggregateProbeResults(results map[string]ProbeResult, verbose bool) (string, map[string]map[string]any) {
 	var dependencies map[string]map[string]any
 	if verbose {
 		dependencies = make(map[string]map[string]any, len(results))
 	}
-	allHealthy := true
+	worst := 0 // healthy
 	for name, pr := range results {
-		if pr.Status != "healthy" {
-			allHealthy = false
+		if r := rankStatus(pr.Status); r > worst {
+			worst = r
 		}
 		if verbose {
 			entry := map[string]any{
@@ -397,30 +402,37 @@ func (h *Handler) aggregateProbeResults(results map[string]ProbeResult, verbose 
 			dependencies[name] = entry
 		}
 	}
-	return allHealthy, dependencies
+	return statusFromRank(worst), dependencies
 }
 
 // writeTo serialises the readyz result through the project-standard envelope:
 //
-//	200 → {"data":  {"status":"healthy", ...verbose fields}}
+//	200 → {"data":  {"status":"healthy"|"degraded", ...verbose fields}}
 //	503 → {"error": {"code":"ERR_READYZ_UNHEALTHY", "message":"...",
 //	                  "details": {...verbose fields}}}
+//
+// degraded maps to HTTP 200 — a degraded service (fail-open) should NOT
+// trigger pod eviction; operators monitor degraded via the response body
+// status field or the underlying Prometheus counter.
+// ref: envoyproxy/envoy admin /ready — DEGRADED returns 200.
 //
 // Verbose fields (cells, dependencies, adapters) live under data or details
 // so consumers walk one consistent path regardless of status. Adapters are
 // omitted when no adapter info has been registered.
 func (r readyzResult) writeTo(w http.ResponseWriter) {
 	body := r.verboseFields()
-	if r.allHealthy {
-		body["status"] = "healthy"
+	body["status"] = r.overall
+	switch r.overall {
+	case "healthy", "degraded":
+		// HTTP 200 — degraded does NOT trigger pod eviction.
 		writeJSON(w, http.StatusOK, envelopeData(body))
-		return
+	default: // "unhealthy"
+		writeJSON(w, http.StatusServiceUnavailable, envelopeError(
+			errcode.ErrReadyzUnhealthy,
+			"readiness checks failed",
+			body,
+		))
 	}
-	writeJSON(w, http.StatusServiceUnavailable, envelopeError(
-		errcode.ErrReadyzUnhealthy,
-		"readiness checks failed",
-		body,
-	))
 }
 
 // verboseFields returns the cells / dependencies / adapters payload (or an
@@ -505,6 +517,9 @@ func runOneProbe(ctx context.Context, fn Checker, deadline time.Duration) (pr Pr
 	case errors.Is(ctx.Err(), context.DeadlineExceeded), errors.Is(err, context.DeadlineExceeded):
 		pr.Status = "timeout"
 		pr.Err = fmt.Errorf("probe did not return within deadline %s (ctx: %w)", deadline, err)
+	case errors.Is(err, cell.ErrDegraded):
+		pr.Status = "degraded"
+		pr.Err = err
 	default:
 		pr.Status = "unhealthy"
 		pr.Err = err
@@ -632,6 +647,32 @@ func envelopeError(code errcode.Code, message string, details map[string]any) ma
 			"message": message,
 			"details": details,
 		},
+	}
+}
+
+// rankStatus encodes severity ordering for aggregation:
+// healthy(0) < degraded(1) < unhealthy(2). timeout maps to unhealthy(2).
+// Used by aggregators: result = max(per-source ranks).
+func rankStatus(s string) int {
+	switch s {
+	case "healthy":
+		return 0
+	case "degraded":
+		return 1
+	default: // unhealthy, timeout, anything else
+		return 2
+	}
+}
+
+// statusFromRank converts a rank value back to a canonical status string.
+func statusFromRank(r int) string {
+	switch r {
+	case 0:
+		return "healthy"
+	case 1:
+		return "degraded"
+	default:
+		return "unhealthy"
 	}
 }
 

--- a/runtime/http/health/health_test.go
+++ b/runtime/http/health/health_test.go
@@ -1157,7 +1157,7 @@ func TestReadyz_DegradedReturns200WithStatusField(t *testing.T) {
 
 	h := New(asm)
 	h.SetVerboseToken(testVerboseToken)
-	h.RegisterChecker("outbox-failopen-rate:configcore", func(_ context.Context) error {
+	h.RegisterChecker("outbox-failopen-rate.configcore", func(_ context.Context) error {
 		return fmt.Errorf("drop ratio exceeded: %w", cell.ErrDegraded)
 	})
 
@@ -1200,35 +1200,51 @@ func TestReadyz_UnhealthyTrumpsDegraded(t *testing.T) {
 	assert.Equal(t, string(errcode.ErrReadyzUnhealthy), errObj["code"])
 }
 
-// TestReadyz_DegradedAggregatesFromCellHealth verifies that when a cell reports
-// HealthStatus.Status="degraded" and all probes are healthy, the aggregate
-// result is "degraded" (HTTP 200 with status field).
+// stubDegradedCell is a minimal Cell that always reports HealthStatus.Status="degraded".
+// Used by TestReadyz_DegradedAggregatesFromCellHealth to exercise the E2E path
+// through ReadyzHandler → aggregateCellHealth → assembly.Health() → cell.Health().
+type stubDegradedCell struct {
+	*cell.BaseCell
+}
+
+func newStubDegradedCell(id string) *stubDegradedCell {
+	return &stubDegradedCell{
+		BaseCell: cell.NewBaseCell(cell.CellMetadata{
+			ID:   id,
+			Type: cell.CellTypeCore,
+		}),
+	}
+}
+
+// Health overrides BaseCell.Health() to always return "degraded", simulating
+// a cell that is started but operating in a degraded state.
+func (s *stubDegradedCell) Health() cell.HealthStatus {
+	return cell.HealthStatus{Status: "degraded"}
+}
+
+// TestReadyz_DegradedAggregatesFromCellHealth verifies the E2E path:
+// when a cell's Health() returns HealthStatus.Status="degraded" and no probe
+// checkers are registered, ReadyzHandler must respond HTTP 200 with body
+// status="degraded" (not "unhealthy" / 503).
 func TestReadyz_DegradedAggregatesFromCellHealth(t *testing.T) {
 	asm := assembly.New(assembly.Config{ID: "test-cell-degraded", DurabilityMode: cell.DurabilityDemo})
+	c := newStubDegradedCell("degraded-cell")
+	require.NoError(t, asm.Register(c))
 	require.NoError(t, asm.Start(context.Background()))
 	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
 
 	h := New(asm)
 	h.SetVerboseToken(testVerboseToken)
-	// No checkers — only cell health contributes.
-	// Directly call aggregateCellHealth after injecting a degraded status.
-	// We simulate by calling computeReadyz with a custom assembly snapshot.
-	// Instead, test via the rank helpers directly:
-	rank := rankStatus("degraded")
-	assert.Equal(t, 1, rank, "degraded must have rank 1")
-	assert.Greater(t, rankStatus("unhealthy"), rank, "unhealthy must outrank degraded")
-	assert.Greater(t, rank, rankStatus("healthy"), "degraded must outrank healthy")
-	assert.Equal(t, "degraded", statusFromRank(1))
-	assert.Equal(t, "healthy", statusFromRank(0))
-	assert.Equal(t, "unhealthy", statusFromRank(2))
+	// No probe checkers — only cell Health() contributes to the aggregate.
 
-	// Verify that a purely-healthy assembly + no checkers gives HTTP 200 / healthy.
 	rec := httptest.NewRecorder()
 	req := newVerboseRequest("/readyz?verbose=true")
 	h.ReadyzHandler().ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "degraded cell must produce HTTP 200, not 503")
 	data := dataBody(t, rec)
-	assert.Equal(t, "healthy", data["status"])
+	assert.Equal(t, "degraded", data["status"],
+		"ReadyzHandler must aggregate cell HealthStatus='degraded' into body status='degraded'")
 }
 
 // TestReadyz_VerboseExposesDegradedDependency verifies that when a probe returns
@@ -1240,7 +1256,7 @@ func TestReadyz_VerboseExposesDegradedDependency(t *testing.T) {
 
 	h := New(asm)
 	h.SetVerboseToken(testVerboseToken)
-	h.RegisterChecker("outbox-failopen-rate:configcore", func(_ context.Context) error {
+	h.RegisterChecker("outbox-failopen-rate.configcore", func(_ context.Context) error {
 		return fmt.Errorf("drop ratio exceeded: %w", cell.ErrDegraded)
 	})
 
@@ -1253,8 +1269,8 @@ func TestReadyz_VerboseExposesDegradedDependency(t *testing.T) {
 	data := dataBody(t, rec)
 	deps, ok := data["dependencies"].(map[string]any)
 	require.True(t, ok, "verbose body must contain dependencies map")
-	entry, ok := deps["outbox-failopen-rate:configcore"].(map[string]any)
-	require.True(t, ok, "outbox-failopen-rate:configcore must be present in dependencies")
+	entry, ok := deps["outbox-failopen-rate.configcore"].(map[string]any)
+	require.True(t, ok, "outbox-failopen-rate.configcore must be present in dependencies")
 	assert.Equal(t, "degraded", entry["status"],
 		"verbose dependency entry status must be 'degraded'")
 	_, hasErr := entry["error"]

--- a/runtime/http/health/health_test.go
+++ b/runtime/http/health/health_test.go
@@ -1142,3 +1142,188 @@ func TestReadyz_VerboseDependencies_StructuredOutput(t *testing.T) {
 	assert.True(t, hasErr, "unhealthy probe must include error field")
 	assert.Contains(t, errStr, "disk full")
 }
+
+// --- Three-state (healthy / degraded / unhealthy) tests (PR-A49 B4) ---
+
+// TestReadyz_DegradedReturns200WithStatusField verifies that a probe returning
+// a wrapped cell.ErrDegraded produces HTTP 200 with body status="degraded".
+// degraded must NOT trigger pod eviction (fail-open semantic).
+func TestReadyz_DegradedReturns200WithStatusField(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-degraded", DurabilityMode: cell.DurabilityDemo})
+	c := newStubCell("configcore")
+	require.NoError(t, asm.Register(c))
+	require.NoError(t, asm.Start(context.Background()))
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	h := New(asm)
+	h.SetVerboseToken(testVerboseToken)
+	h.RegisterChecker("outbox-failopen-rate:configcore", func(_ context.Context) error {
+		return fmt.Errorf("drop ratio exceeded: %w", cell.ErrDegraded)
+	})
+
+	rec := httptest.NewRecorder()
+	req := newVerboseRequest("/readyz?verbose=true")
+	h.ReadyzHandler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "degraded must return HTTP 200, not 503")
+
+	data := dataBody(t, rec)
+	assert.Equal(t, "degraded", data["status"], "body status must be 'degraded'")
+}
+
+// TestReadyz_UnhealthyTrumpsDegraded verifies that when both a degraded checker
+// and an unhealthy checker are registered, the aggregate result is "unhealthy"
+// and the response is HTTP 503.
+func TestReadyz_UnhealthyTrumpsDegraded(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-unhealthy-trumps", DurabilityMode: cell.DurabilityDemo})
+	c := newStubCell("configcore")
+	require.NoError(t, asm.Register(c))
+	require.NoError(t, asm.Start(context.Background()))
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	h := New(asm)
+	h.SetVerboseToken(testVerboseToken)
+	h.RegisterChecker("degraded-probe", func(_ context.Context) error {
+		return fmt.Errorf("soft degradation: %w", cell.ErrDegraded)
+	})
+	h.RegisterChecker("unhealthy-probe", func(_ context.Context) error {
+		return fmt.Errorf("db unreachable")
+	})
+
+	rec := httptest.NewRecorder()
+	req := newVerboseRequest("/readyz?verbose=true")
+	h.ReadyzHandler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "unhealthy must trump degraded → 503")
+
+	errObj := errorBody(t, rec)
+	assert.Equal(t, string(errcode.ErrReadyzUnhealthy), errObj["code"])
+}
+
+// TestReadyz_DegradedAggregatesFromCellHealth verifies that when a cell reports
+// HealthStatus.Status="degraded" and all probes are healthy, the aggregate
+// result is "degraded" (HTTP 200 with status field).
+func TestReadyz_DegradedAggregatesFromCellHealth(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-cell-degraded", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Start(context.Background()))
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	h := New(asm)
+	h.SetVerboseToken(testVerboseToken)
+	// No checkers — only cell health contributes.
+	// Directly call aggregateCellHealth after injecting a degraded status.
+	// We simulate by calling computeReadyz with a custom assembly snapshot.
+	// Instead, test via the rank helpers directly:
+	rank := rankStatus("degraded")
+	assert.Equal(t, 1, rank, "degraded must have rank 1")
+	assert.Greater(t, rankStatus("unhealthy"), rank, "unhealthy must outrank degraded")
+	assert.Greater(t, rank, rankStatus("healthy"), "degraded must outrank healthy")
+	assert.Equal(t, "degraded", statusFromRank(1))
+	assert.Equal(t, "healthy", statusFromRank(0))
+	assert.Equal(t, "unhealthy", statusFromRank(2))
+
+	// Verify that a purely-healthy assembly + no checkers gives HTTP 200 / healthy.
+	rec := httptest.NewRecorder()
+	req := newVerboseRequest("/readyz?verbose=true")
+	h.ReadyzHandler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	data := dataBody(t, rec)
+	assert.Equal(t, "healthy", data["status"])
+}
+
+// TestReadyz_VerboseExposesDegradedDependency verifies that when a probe returns
+// a wrapped cell.ErrDegraded, the verbose body dependency entry has status="degraded".
+func TestReadyz_VerboseExposesDegradedDependency(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-verbose-degraded", DurabilityMode: cell.DurabilityDemo})
+	require.NoError(t, asm.Start(context.Background()))
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	h := New(asm)
+	h.SetVerboseToken(testVerboseToken)
+	h.RegisterChecker("outbox-failopen-rate:configcore", func(_ context.Context) error {
+		return fmt.Errorf("drop ratio exceeded: %w", cell.ErrDegraded)
+	})
+
+	rec := httptest.NewRecorder()
+	req := newVerboseRequest("/readyz?verbose=true")
+	h.ReadyzHandler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "degraded probe must produce HTTP 200")
+
+	data := dataBody(t, rec)
+	deps, ok := data["dependencies"].(map[string]any)
+	require.True(t, ok, "verbose body must contain dependencies map")
+	entry, ok := deps["outbox-failopen-rate:configcore"].(map[string]any)
+	require.True(t, ok, "outbox-failopen-rate:configcore must be present in dependencies")
+	assert.Equal(t, "degraded", entry["status"],
+		"verbose dependency entry status must be 'degraded'")
+	_, hasErr := entry["error"]
+	assert.True(t, hasErr, "degraded dependency must include error field")
+}
+
+// TestReadyz_HealthyAllAcrossBoard verifies the sanity check: all healthy → HTTP 200
+// with status="healthy".
+func TestReadyz_HealthyAllAcrossBoard(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-all-healthy", DurabilityMode: cell.DurabilityDemo})
+	c := newStubCell("cell-1")
+	require.NoError(t, asm.Register(c))
+	require.NoError(t, asm.Start(context.Background()))
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	h := New(asm)
+	h.RegisterChecker("db", func(_ context.Context) error { return nil })
+	h.RegisterChecker("cache", func(_ context.Context) error { return nil })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	h.ReadyzHandler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	data := dataBody(t, rec)
+	assert.Equal(t, "healthy", data["status"])
+}
+
+// TestRunOneProbe_DegradedSentinelMappedToDegraded is a unit test that directly
+// calls runOneProbe with a checker returning a wrapped cell.ErrDegraded and
+// verifies ProbeResult.Status == "degraded".
+func TestRunOneProbe_DegradedSentinelMappedToDegraded(t *testing.T) {
+	checker := func(_ context.Context) error {
+		return fmt.Errorf("drop ratio exceeded: %w", cell.ErrDegraded)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pr := runOneProbe(ctx, checker, 5*time.Second)
+
+	assert.Equal(t, "degraded", pr.Status,
+		"checker returning wrapped cell.ErrDegraded must produce ProbeResult.Status=degraded")
+	require.NotNil(t, pr.Err, "degraded probe must carry non-nil Err")
+	assert.Contains(t, pr.Err.Error(), "drop ratio exceeded")
+}
+
+// TestRankStatus verifies the rank ordering used by the three-state aggregator.
+func TestRankStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   int
+	}{
+		{"healthy", 0},
+		{"degraded", 1},
+		{"unhealthy", 2},
+		{"timeout", 2},
+		{"unknown", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, rankStatus(tt.status))
+		})
+	}
+}
+
+// TestStatusFromRank verifies the inverse of rankStatus.
+func TestStatusFromRank(t *testing.T) {
+	assert.Equal(t, "healthy", statusFromRank(0))
+	assert.Equal(t, "degraded", statusFromRank(1))
+	assert.Equal(t, "unhealthy", statusFromRank(2))
+	assert.Equal(t, "unhealthy", statusFromRank(99))
+}

--- a/tools/archtest/helpers_test.go
+++ b/tools/archtest/helpers_test.go
@@ -1,0 +1,38 @@
+package archtest
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// findCellProductionGoFiles walks cells/** for production .go files
+// (excluding _test.go + vendor + .git + testdata + generated). Used by both
+// the outbox topic scanner (via packages.Load) and by AST-only scanners in
+// repoerr_test.go that do not require type information.
+func findCellProductionGoFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(filepath.Join(root, "cells"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", "worktrees", "testdata", "generated", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	sort.Strings(files)
+	return files, err
+}

--- a/tools/archtest/outbox_topic_test.go
+++ b/tools/archtest/outbox_topic_test.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"testing"
 
@@ -60,6 +58,9 @@ func (v outboxTopicViolation) String() string {
 // ref: kubernetes apiserver/pkg/audit Backend.FailurePolicy (Ignore/Fail)
 // ref: ThreeDotsLabs/watermill message/router/middleware/retry.go
 func TestSecurityTopicsDoNotOptInFailOpen(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode (loads ./cells/... module-wide, ~5-10s)")
+	}
 	root := findModuleRoot(t)
 
 	violations, err := checkOutboxTopicFailOpenRule(root)
@@ -291,34 +292,4 @@ func findArchTestDir(t *testing.T) string {
 	t.Helper()
 	root := findModuleRoot(t)
 	return filepath.Join(root, "tools", "archtest")
-}
-
-// findCellProductionGoFiles walks cells/** for production .go files
-// (excluding _test.go + vendor + .git + testdata + generated). Used by both
-// the outbox topic scanner (via packages.Load) and by AST-only scanners in
-// repoerr_test.go that do not require type information.
-func findCellProductionGoFiles(root string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(filepath.Join(root, "cells"), func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			switch d.Name() {
-			case "vendor", "worktrees", "testdata", "generated", ".git":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") {
-			return nil
-		}
-		if strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		files = append(files, path)
-		return nil
-	})
-	sort.Strings(files)
-	return files, err
 }

--- a/tools/archtest/outbox_topic_test.go
+++ b/tools/archtest/outbox_topic_test.go
@@ -30,7 +30,7 @@ const (
 //
 // ref: kubernetes apiserver/pkg/audit — audit events default to Fail policy;
 // operators opt into Ignore per backend, not per event type.
-var outboxSecurityTopicPattern = regexp.MustCompile(`^(session|user|role|audit)\.`)
+var outboxSecurityTopicPattern = regexp.MustCompile(`^(event\.)?(session|user|role|audit)\.`)
 
 type outboxTopicViolation struct {
 	Rule    string
@@ -46,7 +46,8 @@ func (v outboxTopicViolation) String() string {
 // TestSecurityTopicsDoNotOptInFailOpen enforces OUTBOX-TOPIC-FAILOPEN-01:
 // an outbox.Entry composite literal whose Topic or EventType string constant
 // matches one of the security-sensitive prefixes (session.*, user.*, role.*,
-// audit.*) must not set FailurePolicy: outbox.FailurePolicyFailOpen.
+// audit.* and their event.* contract forms) must not set FailurePolicy:
+// outbox.FailurePolicyFailOpen.
 //
 // The scanner uses go/types TypesInfo to evaluate Topic/EventType field
 // expressions, covering BasicLit, same-package const Idents, and cross-package
@@ -74,8 +75,8 @@ func TestSecurityTopicsDoNotOptInFailOpen(t *testing.T) {
 	}
 
 	assert.Empty(t, violations,
-		"security-sensitive topics (session.*, user.*, role.*, audit.*) must not "+
-			"set FailurePolicy: outbox.FailurePolicyFailOpen on the outbox.Entry "+
+		"security-sensitive topics (session.*, user.*, role.*, audit.*, event.* security contracts) "+
+			"must not set FailurePolicy: outbox.FailurePolicyFailOpen on the outbox.Entry "+
 			"literal; drop silently = lose audit invariant. Leave FailurePolicy "+
 			"unset (= Default, falls through to Cell ctor default = FailClosed).")
 }
@@ -212,11 +213,13 @@ func extractStringField(r *topicConstResolver, pkg *packages.Package, lit *ast.C
 // packages.Load to exercise the full type-checking path.
 //
 // Cases:
-//   - basicliteral: BasicLit "session.created.v1" + FailOpen → flagged
-//   - samepackage_const: Ident sessionTopic (= "session.created.v1") + FailOpen → flagged
-//   - crosspackage_dto: SelectorExpr dto.TopicSessionCreated + FailOpen → flagged
+//   - basicliteral: BasicLit "session.created.v1" + FailOpen -> flagged
+//   - eventprefixed: BasicLit "event.session.created.v1" + FailOpen -> flagged
+//   - samepackage_const: Ident sessionTopic (= "session.created.v1") + FailOpen -> flagged
+//   - crosspackage_dto: SelectorExpr dto.TopicSessionCreated + FailOpen -> flagged
+//   - crosspackage_event_dto: SelectorExpr dto.TopicSessionCreated + event. prefix + FailOpen -> flagged
 //   - samepackage_failclosed: same-package const + FailClosed → not flagged
-//   - nonsecurity_metric: non-security topic + FailOpen → not flagged
+//   - nonsecurity_metric: non-security topic + FailOpen -> not flagged
 func TestSecurityTopicsDoNotOptInFailOpen_RegressionFixtures(t *testing.T) {
 	fixturesRoot := filepath.Join(findArchTestDir(t), "testdata", "topic_const_fixtures")
 
@@ -225,8 +228,10 @@ func TestSecurityTopicsDoNotOptInFailOpen_RegressionFixtures(t *testing.T) {
 		wantMatch bool
 	}{
 		{"./basicliteral_session_failopen", true},
+		{"./basicliteral_event_session_failopen", true},
 		{"./samepackage_const_session_failopen", true},
 		{"./crosspackage_dto_session_failopen/consumer", true},
+		{"./crosspackage_event_dto_session_failopen/consumer", true},
 		{"./samepackage_const_session_failclosed", false},
 		{"./nonsecurity_metric_failopen_passes", false},
 	}

--- a/tools/archtest/outbox_topic_test.go
+++ b/tools/archtest/outbox_topic_test.go
@@ -3,18 +3,17 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
-	"go/parser"
 	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 const (
@@ -47,23 +46,19 @@ func (v outboxTopicViolation) String() string {
 }
 
 // TestSecurityTopicsDoNotOptInFailOpen enforces OUTBOX-TOPIC-FAILOPEN-01:
-// an outbox.Entry composite literal whose Topic or EventType string literal
+// an outbox.Entry composite literal whose Topic or EventType string constant
 // matches one of the security-sensitive prefixes (session.*, user.*, role.*,
 // audit.*) must not set FailurePolicy: outbox.FailurePolicyFailOpen.
 //
-// This guards the F9 per-entry failure policy contract: Cells default to
-// DirectPublishFailClosed; individual entries opt into FailOpen for
-// observational sinks. Security / audit-chain events must not opt in —
-// dropping them silently loses the audit invariant.
+// The scanner uses go/types TypesInfo to evaluate Topic/EventType field
+// expressions, covering BasicLit, same-package const Idents, and cross-package
+// SelectorExprs (e.g. dto.TopicSessionCreated). go/types' built-in constant
+// folding provides full intra-module const propagation without manual SSA.
 //
-// Scope: scans all non-test .go files under cells/** (both Cell top-level
-// packages and slices/internal service packages). Excludes _test.go files
-// so fixtures can exercise the negative path without tripping the rule.
+// Scope: scans all non-test .go files under cells/** via packages.Load.
 //
 // ref: kubernetes apiserver/pkg/audit Backend.FailurePolicy (Ignore/Fail)
-// — failure policy is per-event category, not per-sink.
-// ref: ThreeDotsLabs/watermill message/router/middleware/retry.go —
-// per-message disposition rather than publisher-level switch.
+// ref: ThreeDotsLabs/watermill message/router/middleware/retry.go
 func TestSecurityTopicsDoNotOptInFailOpen(t *testing.T) {
 	root := findModuleRoot(t)
 
@@ -84,72 +79,52 @@ func TestSecurityTopicsDoNotOptInFailOpen(t *testing.T) {
 			"unset (= Default, falls through to Cell ctor default = FailClosed).")
 }
 
+// checkOutboxTopicFailOpenRule loads all cells/ packages with full type info
+// and scans every non-test Go file for OUTBOX-TOPIC-FAILOPEN-01 violations.
 func checkOutboxTopicFailOpenRule(root string) ([]outboxTopicViolation, error) {
-	files, err := findCellProductionGoFiles(root)
+	r, err := CellsTopicResolver(root)
 	if err != nil {
 		return nil, err
 	}
 	var violations []outboxTopicViolation
-	for _, file := range files {
-		fileViolations, err := scanOutboxTopicFailOpen(root, file)
+	for _, p := range r.pkgs {
+		pkgViolations, err := scanPackage(root, p, r)
 		if err != nil {
 			return nil, err
 		}
-		violations = append(violations, fileViolations...)
+		violations = append(violations, pkgViolations...)
 	}
 	return violations, nil
 }
 
-// findCellProductionGoFiles walks cells/** for production .go files
-// (excluding _test.go + vendor + .git).
-func findCellProductionGoFiles(root string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(filepath.Join(root, "cells"), func(path string, d os.DirEntry, err error) error {
+// scanPackage scans all non-test Go files in a loaded package for violations.
+// packages.Package.Syntax is aligned with GoFiles via Fset.Position.
+func scanPackage(root string, p *packages.Package, r *topicConstResolver) ([]outboxTopicViolation, error) {
+	var violations []outboxTopicViolation
+	for _, file := range p.Syntax {
+		absPath := p.Fset.Position(file.Pos()).Filename
+		if strings.HasSuffix(absPath, "_test.go") {
+			continue
+		}
+		rel, err := filepath.Rel(root, absPath)
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("filepath.Rel: %w", err)
 		}
-		if d.IsDir() {
-			switch d.Name() {
-			case "vendor", "worktrees", "testdata", "generated", ".git":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") {
-			return nil
-		}
-		if strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		files = append(files, path)
-		return nil
-	})
-	sort.Strings(files)
-	return files, err
+		rel = filepath.ToSlash(rel)
+		violations = append(violations, scanOutboxTopicFailOpenAST(p.Fset, file, rel, r, p)...)
+	}
+	return violations, nil
 }
 
-// scanOutboxTopicFailOpen parses a single .go file and returns any
-// composite-literal violations of OUTBOX-TOPIC-FAILOPEN-01.
-func scanOutboxTopicFailOpen(root, path string) ([]outboxTopicViolation, error) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
-	if err != nil {
-		return nil, err
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return nil, err
-	}
-	rel = filepath.ToSlash(rel)
-	return scanOutboxTopicFailOpenAST(fset, file, rel), nil
-}
-
-// scanOutboxTopicFailOpenAST is the core AST-matching routine shared by the
-// production file scanner (scanOutboxTopicFailOpen) and the regression
-// fixture test. Given a parsed file + fileset, it returns every
-// outbox.Entry composite literal that opts into FailurePolicyFailOpen with
-// a Topic or EventType matching the security-sensitive prefix regex.
-func scanOutboxTopicFailOpenAST(fset *token.FileSet, file *ast.File, fileLabel string) []outboxTopicViolation {
+// scanOutboxTopicFailOpenAST is the core AST-matching routine. Given a parsed
+// file, fileset, resolver, and the owning package (for TypesInfo lookup), it
+// returns every outbox.Entry composite literal that opts into
+// FailurePolicyFailOpen with a Topic or EventType matching the
+// security-sensitive prefix regex.
+//
+// Topic/EventType field values are evaluated via topicConstResolver.ResolveString,
+// covering BasicLit, same-package const Ident, and cross-package SelectorExpr.
+func scanOutboxTopicFailOpenAST(fset *token.FileSet, file *ast.File, fileLabel string, r *topicConstResolver, pkg *packages.Package) []outboxTopicViolation {
 	var violations []outboxTopicViolation
 	ast.Inspect(file, func(n ast.Node) bool {
 		lit, ok := n.(*ast.CompositeLit)
@@ -159,8 +134,8 @@ func scanOutboxTopicFailOpenAST(fset *token.FileSet, file *ast.File, fileLabel s
 		if !isOutboxEntryLiteral(lit) {
 			return true
 		}
-		topic, topicOK := extractStringField(lit, outboxTopicEntryField)
-		eventType, eventTypeOK := extractStringField(lit, outboxTopicEventTypeField)
+		topic, topicOK := extractStringField(r, pkg, lit, outboxTopicEntryField)
+		eventType, eventTypeOK := extractStringField(r, pkg, lit, outboxTopicEventTypeField)
 
 		var matched string
 		switch {
@@ -211,10 +186,11 @@ func isOutboxEntryLiteral(lit *ast.CompositeLit) bool {
 	return false
 }
 
-// extractStringField returns the constant-string value for the named field
-// of a composite literal, if present. Returns ok=false when the field is
-// missing or its value is not a string literal.
-func extractStringField(lit *ast.CompositeLit, fieldName string) (string, bool) {
+// extractStringField returns the resolved constant-string value for the named
+// field of a composite literal, if present. Uses topicConstResolver to evaluate
+// BasicLit, same-package const Ident, and cross-package SelectorExpr uniformly.
+// Returns ok=false when the field is missing or its value is not a constant string.
+func extractStringField(r *topicConstResolver, pkg *packages.Package, lit *ast.CompositeLit, fieldName string) (string, bool) {
 	for _, elt := range lit.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {
@@ -224,96 +200,60 @@ func extractStringField(lit *ast.CompositeLit, fieldName string) (string, bool) 
 		if !ok || key.Name != fieldName {
 			continue
 		}
-		bl, ok := kv.Value.(*ast.BasicLit)
-		if !ok || bl.Kind != token.STRING {
-			return "", false
-		}
-		unquoted, err := strconv.Unquote(bl.Value)
-		if err != nil {
-			return "", false
-		}
-		return unquoted, true
+		return r.ResolveString(pkg, kv.Value)
 	}
 	return "", false
 }
 
-// TestSecurityTopicsDoNotOptInFailOpen_RegressionFixture asserts that the
-// scanner actually flags a bad pattern. This complements the repo-wide
-// scan (which reports zero violations today) by proving the rule retains
-// teeth — a silent 0-violation run on an empty ruleset would pass too.
-func TestSecurityTopicsDoNotOptInFailOpen_RegressionFixture(t *testing.T) {
-	fixtures := map[string]struct {
-		src       string
+// TestSecurityTopicsDoNotOptInFailOpen_RegressionFixtures asserts that the
+// scanner correctly flags (or passes) each fixture scenario. The fixture set
+// uses real Go packages under testdata/topic_const_fixtures/ loaded via
+// packages.Load to exercise the full type-checking path.
+//
+// Cases:
+//   - basicliteral: BasicLit "session.created.v1" + FailOpen → flagged
+//   - samepackage_const: Ident sessionTopic (= "session.created.v1") + FailOpen → flagged
+//   - crosspackage_dto: SelectorExpr dto.TopicSessionCreated + FailOpen → flagged
+//   - samepackage_failclosed: same-package const + FailClosed → not flagged
+//   - nonsecurity_metric: non-security topic + FailOpen → not flagged
+func TestSecurityTopicsDoNotOptInFailOpen_RegressionFixtures(t *testing.T) {
+	fixturesRoot := filepath.Join(findArchTestDir(t), "testdata", "topic_const_fixtures")
+
+	cases := []struct {
+		pattern   string
 		wantMatch bool
 	}{
-		"session_with_failopen_is_flagged": {
-			src: `package fixture
-import "github.com/ghbvf/gocell/kernel/outbox"
-var _ = outbox.Entry{
-	Topic:         "session.created.v1",
-	EventType:     "session.created.v1",
-	ID:            "x",
-	FailurePolicy: outbox.FailurePolicyFailOpen,
-}
-`,
-			wantMatch: true,
-		},
-		"audit_event_type_with_failopen_flagged": {
-			src: `package fixture
-import "github.com/ghbvf/gocell/kernel/outbox"
-var _ = outbox.Entry{
-	EventType:     "audit.appended.v1",
-	ID:            "x",
-	FailurePolicy: outbox.FailurePolicyFailOpen,
-}
-`,
-			wantMatch: true,
-		},
-		"session_with_failclosed_passes": {
-			src: `package fixture
-import "github.com/ghbvf/gocell/kernel/outbox"
-var _ = outbox.Entry{
-	Topic:         "session.created.v1",
-	ID:            "x",
-	FailurePolicy: outbox.FailurePolicyFailClosed,
-}
-`,
-			wantMatch: false,
-		},
-		"session_with_default_policy_passes": {
-			src: `package fixture
-import "github.com/ghbvf/gocell/kernel/outbox"
-var _ = outbox.Entry{
-	Topic: "session.created.v1",
-	ID:    "x",
-}
-`,
-			wantMatch: false,
-		},
-		"non_security_topic_with_failopen_passes": {
-			src: `package fixture
-import "github.com/ghbvf/gocell/kernel/outbox"
-var _ = outbox.Entry{
-	Topic:         "metric.recorded.v1",
-	ID:            "x",
-	FailurePolicy: outbox.FailurePolicyFailOpen,
-}
-`,
-			wantMatch: false,
-		},
+		{"./basicliteral_session_failopen", true},
+		{"./samepackage_const_session_failopen", true},
+		{"./crosspackage_dto_session_failopen/consumer", true},
+		{"./samepackage_const_session_failclosed", false},
+		{"./nonsecurity_metric_failopen_passes", false},
 	}
 
-	for name, tc := range fixtures {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, name+".go", tc.src, parser.SkipObjectResolution)
-			require.NoError(t, err)
-			violations := scanOutboxTopicFailOpenAST(fset, file, name+".go")
-			if tc.wantMatch {
-				assert.NotEmpty(t, violations, "fixture %q should have triggered the rule", name)
+	for _, c := range cases {
+		c := c
+		t.Run(c.pattern, func(t *testing.T) {
+			r, err := newTopicConstResolver(fixturesRoot, c.pattern)
+			require.NoError(t, err, "load fixture package %s", c.pattern)
+
+			var violations []outboxTopicViolation
+			for _, p := range r.pkgs {
+				for _, file := range p.Syntax {
+					absPath := p.Fset.Position(file.Pos()).Filename
+					if strings.HasSuffix(absPath, "_test.go") {
+						continue
+					}
+					rel, err := filepath.Rel(fixturesRoot, absPath)
+					require.NoError(t, err)
+					rel = filepath.ToSlash(rel)
+					violations = append(violations, scanOutboxTopicFailOpenAST(p.Fset, file, rel, r, p)...)
+				}
+			}
+
+			if c.wantMatch {
+				assert.NotEmpty(t, violations, "fixture %q should trigger OUTBOX-TOPIC-FAILOPEN-01", c.pattern)
 			} else {
-				assert.Empty(t, violations, "fixture %q should not have triggered the rule, got: %v", name, violations)
+				assert.Empty(t, violations, "fixture %q should not trigger rule, got: %v", c.pattern, violations)
 			}
 		})
 	}
@@ -343,4 +283,42 @@ func entryHasFailOpenPolicy(lit *ast.CompositeLit) bool {
 		}
 	}
 	return false
+}
+
+// findArchTestDir returns the absolute path of the tools/archtest directory,
+// used to locate testdata fixtures at test runtime.
+func findArchTestDir(t *testing.T) string {
+	t.Helper()
+	root := findModuleRoot(t)
+	return filepath.Join(root, "tools", "archtest")
+}
+
+// findCellProductionGoFiles walks cells/** for production .go files
+// (excluding _test.go + vendor + .git + testdata + generated). Used by both
+// the outbox topic scanner (via packages.Load) and by AST-only scanners in
+// repoerr_test.go that do not require type information.
+func findCellProductionGoFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(filepath.Join(root, "cells"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", "worktrees", "testdata", "generated", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	sort.Strings(files)
+	return files, err
 }

--- a/tools/archtest/testdata/topic_const_fixtures/basicliteral_event_session_failopen/usage.go
+++ b/tools/archtest/testdata/topic_const_fixtures/basicliteral_event_session_failopen/usage.go
@@ -1,0 +1,13 @@
+// Package basicliteral_event_session_failopen is a fixture that uses the
+// project contract topic shape directly in the Topic field. Expects
+// OUTBOX-TOPIC-FAILOPEN-01 to fire.
+package basicliteral_event_session_failopen
+
+import "fixturetest/outbox"
+
+var _ = outbox.Entry{
+	ID:            "x",
+	Topic:         "event.session.created.v1",
+	EventType:     "event.session.created.v1",
+	FailurePolicy: outbox.FailurePolicyFailOpen,
+}

--- a/tools/archtest/testdata/topic_const_fixtures/basicliteral_session_failopen/usage.go
+++ b/tools/archtest/testdata/topic_const_fixtures/basicliteral_session_failopen/usage.go
@@ -1,0 +1,12 @@
+// Package basicliteral_session_failopen is a fixture that uses a BasicLit
+// string directly in the Topic field. Expects OUTBOX-TOPIC-FAILOPEN-01 to fire.
+package basicliteral_session_failopen
+
+import "fixturetest/outbox"
+
+var _ = outbox.Entry{
+	ID:            "x",
+	Topic:         "session.created.v1",
+	EventType:     "session.created.v1",
+	FailurePolicy: outbox.FailurePolicyFailOpen,
+}

--- a/tools/archtest/testdata/topic_const_fixtures/crosspackage_dto_session_failopen/consumer/usage.go
+++ b/tools/archtest/testdata/topic_const_fixtures/crosspackage_dto_session_failopen/consumer/usage.go
@@ -1,0 +1,16 @@
+// Package consumer exercises cross-package const resolution: Topic is set
+// via dto.TopicSessionCreated (a SelectorExpr). The resolver must follow the
+// import chain through go/types TypesInfo to retrieve "session.created.v1".
+package consumer
+
+import (
+	"fixturetest/crosspackage_dto_session_failopen/dto"
+	"fixturetest/outbox"
+)
+
+var _ = outbox.Entry{
+	ID:            "x",
+	Topic:         dto.TopicSessionCreated,
+	EventType:     dto.TopicSessionCreated,
+	FailurePolicy: outbox.FailurePolicyFailOpen,
+}

--- a/tools/archtest/testdata/topic_const_fixtures/crosspackage_dto_session_failopen/dto/topics.go
+++ b/tools/archtest/testdata/topic_const_fixtures/crosspackage_dto_session_failopen/dto/topics.go
@@ -1,0 +1,6 @@
+// Package dto provides topic constants as a separate package. Exercises
+// cross-package const resolution via SelectorExpr (dto.TopicSessionCreated).
+package dto
+
+// TopicSessionCreated is the canonical topic string for session-created events.
+const TopicSessionCreated = "session.created.v1"

--- a/tools/archtest/testdata/topic_const_fixtures/crosspackage_event_dto_session_failopen/consumer/usage.go
+++ b/tools/archtest/testdata/topic_const_fixtures/crosspackage_event_dto_session_failopen/consumer/usage.go
@@ -1,0 +1,15 @@
+// Package consumer exercises cross-package const resolution for project
+// contract topic strings such as "event.session.created.v1".
+package consumer
+
+import (
+	"fixturetest/crosspackage_event_dto_session_failopen/dto"
+	"fixturetest/outbox"
+)
+
+var _ = outbox.Entry{
+	ID:            "x",
+	Topic:         dto.TopicSessionCreated,
+	EventType:     dto.TopicSessionCreated,
+	FailurePolicy: outbox.FailurePolicyFailOpen,
+}

--- a/tools/archtest/testdata/topic_const_fixtures/crosspackage_event_dto_session_failopen/dto/topics.go
+++ b/tools/archtest/testdata/topic_const_fixtures/crosspackage_event_dto_session_failopen/dto/topics.go
@@ -1,0 +1,6 @@
+// Package dto provides event-prefixed topic constants as a separate package.
+// Exercises cross-package const resolution via SelectorExpr.
+package dto
+
+// TopicSessionCreated is the canonical project topic string for session-created events.
+const TopicSessionCreated = "event.session.created.v1"

--- a/tools/archtest/testdata/topic_const_fixtures/go.mod
+++ b/tools/archtest/testdata/topic_const_fixtures/go.mod
@@ -1,0 +1,3 @@
+module fixturetest
+
+go 1.22

--- a/tools/archtest/testdata/topic_const_fixtures/nonsecurity_metric_failopen_passes/usage.go
+++ b/tools/archtest/testdata/topic_const_fixtures/nonsecurity_metric_failopen_passes/usage.go
@@ -1,0 +1,14 @@
+// Package nonsecurity_metric_failopen_passes is a negative fixture:
+// Topic is a non-security topic ("metric.recorded.v1") with FailOpen.
+// Rule must NOT fire because the topic prefix is not in the security set.
+package nonsecurity_metric_failopen_passes
+
+import "fixturetest/outbox"
+
+const metricTopic = "metric.recorded.v1"
+
+var _ = outbox.Entry{
+	ID:            "x",
+	Topic:         metricTopic,
+	FailurePolicy: outbox.FailurePolicyFailOpen,
+}

--- a/tools/archtest/testdata/topic_const_fixtures/outbox/outbox.go
+++ b/tools/archtest/testdata/topic_const_fixtures/outbox/outbox.go
@@ -1,0 +1,25 @@
+// Package outbox provides a minimal stub of kernel/outbox for archtest
+// fixture testing. Only the fields and constants exercised by the
+// OUTBOX-TOPIC-FAILOPEN-01 scanner are reproduced here.
+package outbox
+
+// Entry is the minimal stub of kernel/outbox.Entry sufficient for topic-
+// const resolver fixture tests.
+type Entry struct {
+	ID            string
+	Topic         string
+	EventType     string
+	FailurePolicy FailurePolicy
+}
+
+// FailurePolicy controls per-entry publisher failure behaviour.
+type FailurePolicy int
+
+const (
+	// FailurePolicyDefault is the zero value; falls through to Emitter default.
+	FailurePolicyDefault FailurePolicy = iota
+	// FailurePolicyFailOpen drops on publisher failure.
+	FailurePolicyFailOpen
+	// FailurePolicyFailClosed surfaces publisher failure to caller.
+	FailurePolicyFailClosed
+)

--- a/tools/archtest/testdata/topic_const_fixtures/samepackage_const_session_failclosed/usage.go
+++ b/tools/archtest/testdata/topic_const_fixtures/samepackage_const_session_failclosed/usage.go
@@ -1,0 +1,14 @@
+// Package samepackage_const_session_failclosed is a negative fixture:
+// Topic resolves to a security-sensitive string but FailurePolicy is
+// FailClosed (not FailOpen). Rule must NOT fire.
+package samepackage_const_session_failclosed
+
+import "fixturetest/outbox"
+
+const sessionTopic = "session.created.v1"
+
+var _ = outbox.Entry{
+	ID:            "x",
+	Topic:         sessionTopic,
+	FailurePolicy: outbox.FailurePolicyFailClosed,
+}

--- a/tools/archtest/testdata/topic_const_fixtures/samepackage_const_session_failopen/consts.go
+++ b/tools/archtest/testdata/topic_const_fixtures/samepackage_const_session_failopen/consts.go
@@ -1,0 +1,5 @@
+// Package samepackage_const_session_failopen exercises same-package const
+// resolution: Topic is set via a package-level const, not a BasicLit.
+package samepackage_const_session_failopen
+
+const sessionTopic = "session.created.v1"

--- a/tools/archtest/testdata/topic_const_fixtures/samepackage_const_session_failopen/usage.go
+++ b/tools/archtest/testdata/topic_const_fixtures/samepackage_const_session_failopen/usage.go
@@ -1,0 +1,12 @@
+package samepackage_const_session_failopen
+
+import "fixturetest/outbox"
+
+// sessionTopic is defined in consts.go. The resolver must evaluate it through
+// go/types TypesInfo to reach the underlying string "session.created.v1".
+var _ = outbox.Entry{
+	ID:            "x",
+	Topic:         sessionTopic,
+	EventType:     sessionTopic,
+	FailurePolicy: outbox.FailurePolicyFailOpen,
+}

--- a/tools/archtest/topic_const_resolver.go
+++ b/tools/archtest/topic_const_resolver.go
@@ -93,20 +93,32 @@ func flattenPackagesErrors(pkgs []*packages.Package) []packages.Error {
 	return out
 }
 
-// sharedResolverOnce guards the module-wide singleton for cells/.
+// sharedResolverMu guards the module-wide singleton for cells/.
+// err paths are NOT cached — if loading fails the next call will retry.
+// Only a successful load is cached; this avoids permanently poisoning the
+// singleton on transient failures (e.g. missing toolchain during partial CI).
 var (
-	sharedResolverOnce sync.Once
-	sharedResolver     *topicConstResolver
-	sharedResolverErr  error
+	sharedResolverMu sync.Mutex
+	sharedResolver   *topicConstResolver
 )
 
 // CellsTopicResolver lazily loads "./cells/..." with full type info and
 // returns a shared resolver. Module root is determined by the caller via
 // findModuleRoot. All callers that target cells/* should reuse this singleton
 // — packages loading is the dominant cost.
+//
+// Error paths are not cached: a failure on one call allows the next caller
+// to retry (e.g. after a missing toolchain becomes available).
 func CellsTopicResolver(modRoot string) (*topicConstResolver, error) {
-	sharedResolverOnce.Do(func() {
-		sharedResolver, sharedResolverErr = newTopicConstResolver(modRoot, "./cells/...")
-	})
-	return sharedResolver, sharedResolverErr
+	sharedResolverMu.Lock()
+	defer sharedResolverMu.Unlock()
+	if sharedResolver != nil {
+		return sharedResolver, nil
+	}
+	r, err := newTopicConstResolver(modRoot, "./cells/...")
+	if err != nil {
+		return nil, err // do not cache err; next call will retry
+	}
+	sharedResolver = r
+	return r, nil
 }

--- a/tools/archtest/topic_const_resolver.go
+++ b/tools/archtest/topic_const_resolver.go
@@ -1,0 +1,112 @@
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/constant"
+	"sync"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// topicConstResolver evaluates compile-time string constants in arbitrary
+// expressions (BasicLit, Ident referring to const, SelectorExpr referring
+// to const in another package). Uses go/types' built-in constant folding,
+// which transparently handles intra-module cross-package const propagation
+// (e.g. dto.TopicSessionCreated → "session.created.v1").
+//
+// The resolver is module-scoped: a single packages.Load("./cells/...")
+// produces a TypesInfo per package, and the resolver dispatches ResolveString()
+// based on the package owning the AST node. Loading is cached per
+// resolver instance.
+//
+// ref: golang.org/x/tools/go/packages — NeedTypesInfo + constant folding
+// ref: go/types TypesInfo.Types — maps ast.Expr to TypeAndValue (incl. const)
+// ref: kernel/governance/rules_wrapper.go FMT-19 — earlier AST const scanner
+//
+//	(BasicLit + ValueSpec only; this resolver supersedes it for outbox
+//	topic checks by going through go/types)
+type topicConstResolver struct {
+	pkgs      []*packages.Package
+	pkgByFile map[string]*packages.Package // absolute file path → package
+}
+
+// newTopicConstResolver loads all packages matching pattern (e.g. "./cells/...")
+// with full type info. The returned resolver caches the package set and a
+// file→package index for O(1) ResolveString dispatch.
+func newTopicConstResolver(modRoot string, pattern string) (*topicConstResolver, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports |
+			packages.NeedDeps,
+		Dir: modRoot,
+	}
+	pkgs, err := packages.Load(cfg, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("packages.Load: %w", err)
+	}
+	if errs := flattenPackagesErrors(pkgs); len(errs) > 0 {
+		return nil, fmt.Errorf("packages.Load: %d error(s): first=%v", len(errs), errs[0])
+	}
+	fileIdx := make(map[string]*packages.Package)
+	for _, p := range pkgs {
+		for _, f := range p.GoFiles {
+			fileIdx[f] = p
+		}
+	}
+	return &topicConstResolver{pkgs: pkgs, pkgByFile: fileIdx}, nil
+}
+
+// PackageForFile returns the loaded packages.Package owning the given file
+// path (absolute). Returns nil if the file is not in the loaded set.
+func (r *topicConstResolver) PackageForFile(absPath string) *packages.Package {
+	return r.pkgByFile[absPath]
+}
+
+// ResolveString attempts to evaluate expr as a string constant. Returns
+// (value, true) when go/types confirms expr has a constant string value;
+// (zero, false) for non-constant or non-string expressions.
+//
+// Handles BasicLit, Ident referring to const, SelectorExpr referring to
+// const in another package — go/types' built-in folding makes all three
+// equivalent at the TypesInfo level.
+func (r *topicConstResolver) ResolveString(pkg *packages.Package, expr ast.Expr) (string, bool) {
+	if pkg == nil || pkg.TypesInfo == nil {
+		return "", false
+	}
+	tv, ok := pkg.TypesInfo.Types[expr]
+	if !ok || tv.Value == nil {
+		return "", false
+	}
+	if tv.Value.Kind() != constant.String {
+		return "", false
+	}
+	return constant.StringVal(tv.Value), true
+}
+
+// flattenPackagesErrors collects all packages.Package.Errors into a flat slice.
+func flattenPackagesErrors(pkgs []*packages.Package) []packages.Error {
+	var out []packages.Error
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		out = append(out, p.Errors...)
+	})
+	return out
+}
+
+// sharedResolverOnce guards the module-wide singleton for cells/.
+var (
+	sharedResolverOnce sync.Once
+	sharedResolver     *topicConstResolver
+	sharedResolverErr  error
+)
+
+// CellsTopicResolver lazily loads "./cells/..." with full type info and
+// returns a shared resolver. Module root is determined by the caller via
+// findModuleRoot. All callers that target cells/* should reuse this singleton
+// — packages loading is the dominant cost.
+func CellsTopicResolver(modRoot string) (*topicConstResolver, error) {
+	sharedResolverOnce.Do(func() {
+		sharedResolver, sharedResolverErr = newTopicConstResolver(modRoot, "./cells/...")
+	})
+	return sharedResolver, sharedResolverErr
+}

--- a/tools/archtest/topic_const_resolver_test.go
+++ b/tools/archtest/topic_const_resolver_test.go
@@ -1,0 +1,136 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+// buildFakePkg compiles src in-process using go/types and wraps the resulting
+// TypesInfo in a packages.Package stub. This avoids packages.Load (which needs
+// a real module on disk) while still exercising ResolveString through the same
+// TypesInfo path used in production.
+func buildFakePkg(t *testing.T, src string) (*packages.Package, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", src, 0)
+	require.NoError(t, err, "parse fixture source")
+
+	info := &types.Info{Types: make(map[ast.Expr]types.TypeAndValue)}
+	conf := types.Config{Importer: importer.Default()}
+	typesPkg, err := conf.Check("fixture", fset, []*ast.File{file}, info)
+	require.NoError(t, err, "type-check fixture source")
+
+	fakePkg := &packages.Package{
+		Fset:      fset,
+		Syntax:    []*ast.File{file},
+		TypesInfo: info,
+		Types:     typesPkg,
+	}
+	return fakePkg, file
+}
+
+// firstCallArgs finds the first *ast.CallExpr in the file and returns its
+// argument slice. Used by tests that embed test values as function arguments.
+func firstCallArgs(t *testing.T, file *ast.File) []ast.Expr {
+	t.Helper()
+	var args []ast.Expr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if args != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if ok {
+			args = call.Args
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, args, "no call expression found in fixture")
+	return args
+}
+
+// TestResolveString_HandlesBasicLitIdentSelector covers the three expression
+// kinds that the production scanner encounters:
+//   - Ident referencing a package-level const → folded by go/types
+//   - BasicLit string literal → folded by go/types
+//   - BinaryExpr (concat of const + literal) → folded by go/types
+func TestResolveString_HandlesBasicLitIdentSelector(t *testing.T) {
+	src := `package fixture
+import "fmt"
+const SessionTopic = "session.created.v1"
+func init() { fmt.Println(SessionTopic, "literal", SessionTopic + ".suffix") }
+`
+	fakePkg, file := buildFakePkg(t, src)
+	args := firstCallArgs(t, file)
+	require.Len(t, args, 3)
+
+	r := &topicConstResolver{}
+
+	// Ident → const value
+	v, ok := r.ResolveString(fakePkg, args[0])
+	assert.True(t, ok, "Ident referring to const should resolve")
+	assert.Equal(t, "session.created.v1", v)
+
+	// BasicLit → literal value
+	v, ok = r.ResolveString(fakePkg, args[1])
+	assert.True(t, ok, "BasicLit should resolve")
+	assert.Equal(t, "literal", v)
+
+	// BinaryExpr → go/types folds to "session.created.v1.suffix"
+	v, ok = r.ResolveString(fakePkg, args[2])
+	assert.True(t, ok, "BinaryExpr of const + literal should resolve")
+	assert.Equal(t, "session.created.v1.suffix", v)
+}
+
+// TestResolveString_RejectsNonString verifies that integer constants return
+// ok=false.
+func TestResolveString_RejectsNonString(t *testing.T) {
+	src := `package fixture
+import "fmt"
+const N = 42
+func init() { fmt.Println(N) }
+`
+	fakePkg, file := buildFakePkg(t, src)
+	args := firstCallArgs(t, file)
+	require.Len(t, args, 1)
+
+	r := &topicConstResolver{}
+	_, ok := r.ResolveString(fakePkg, args[0])
+	assert.False(t, ok, "integer const should not resolve as string")
+}
+
+// TestResolveString_RejectsNonConst verifies that runtime variables (not
+// compile-time constants) return ok=false.
+func TestResolveString_RejectsNonConst(t *testing.T) {
+	src := `package fixture
+import "fmt"
+var s string = "x"
+func init() { fmt.Println(s) }
+`
+	fakePkg, file := buildFakePkg(t, src)
+	args := firstCallArgs(t, file)
+	require.Len(t, args, 1)
+
+	r := &topicConstResolver{}
+	_, ok := r.ResolveString(fakePkg, args[0])
+	assert.False(t, ok, "runtime variable should not resolve as const string")
+}
+
+// TestResolveString_NilPkg ensures no panic when pkg or TypesInfo is nil.
+func TestResolveString_NilPkg(t *testing.T) {
+	r := &topicConstResolver{}
+	// nil package
+	_, ok := r.ResolveString(nil, &ast.BasicLit{})
+	assert.False(t, ok)
+	// nil TypesInfo
+	_, ok = r.ResolveString(&packages.Package{TypesInfo: nil}, &ast.BasicLit{})
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

PR-A49 OUTBOX-ARCHTEST-EXPAND（Wave 7 Batch 2，Cx3）— 一次收口 outbox archtest 静态守卫升级 + fail-open 路径运行时联动 + envelope round-trip 缺口三个子项，让安全/审计 topic 的"绝不静默丢"承诺有完整的静态 + 运行时双层保护。

### 子项关闭

- **PR245-F5** envelope test audit — 删除 `WireMessage.Attempts` 死字段（relay 用 store 列管理 attempts，wire 字段从未被 producer 写入也从未被 consumer 读取）；`TestUnmarshalEnvelope_PreservesObservability` 全字段断言 + struct-equal 兜底
- **PR245-F6** archtest scope expand — `OUTBOX-TOPIC-FAILOPEN-01` 升级 `packages.Load` + `go/types TypesInfo` 常量评估，覆盖同包 const Ident（`const sessionTopic = "..."`） + 跨包 SelectorExpr（`dto.TopicSessionCreated`），借 `go/types` 内置常量折叠免去手写 SSA 数据流分析
- **MULTI-REVIEW-RES-2** OUTBOX-FAILOPEN-SECURITY-EVENT-ALERT-01 — `DirectEmitter` 默认开启 drop-ratio tracker（默认 5%，可通过 `WithFailOpenRateThreshold` 调整 / 0 禁用）；`HealthCheckers()` 方法暴露 `outbox-failopen-rate:<cellID>` checker；超阈值返回 `cell.ErrDegraded` sentinel；`/readyz` 三态聚合（healthy/degraded/unhealthy），degraded → HTTP 200 + body `status="degraded"`，unhealthy → 503

### 关键设计决策

1. **drop ratio 替代时间窗口**：`(deltaDropped / deltaTotal) > threshold` 增量比例；隐式窗口是两次 /readyz probe 间隔（10-30s），自适应 K8s readinessProbe 频率，无 sliding window 数据结构
2. **degraded 不触发 503**：HTTP 始终 200（除真实 unhealthy/timeout）；fail-open 本意为不阻塞业务，503 触发 K8s 驱逐与该语义直接冲突；degraded 通过 verbose body + Prometheus counter 双通道告警（不影响 K8s probe 决策）
3. **packages.Load + TypesInfo 替代 SSA**：`go/types` 内置常量传播自动覆盖跨包 SelectorExpr，比手写 SSA 简单 10× 且效果等价
4. **NewDirectEmitter 改 functional options**：删除 `loggers ...*slog.Logger` 旧签名，新增 `WithLogger` / `WithFailOpenRateThreshold`；18 处调用站点全部同步更新
5. **ErrDegraded sentinel 位置**：因 `kernel/cell` 已依赖 `kernel/outbox`（mode_resolver / registrar），权威定义放 `kernel/outbox` 避免循环；`kernel/cell.ErrDegraded = outbox.ErrDegraded` 别名，`errors.Is` 链不变

### 改动统计

12 commits / kernel/outbox + kernel/cell + tools/archtest + runtime/http/health + 3 cells (configcore/auditcore/accesscore) + examples/iotdevice + 18 处 NewDirectEmitter 调用站点

### Acceptance（plan §Wave 7 PR-A49 验收 4 条）

- ✅ archtest AST 模式扫到 const 定义点（同包 + 跨包 fixture 全 PASS）
- ✅ fail-open drop counter `gocell_outbox_emit_failopen_dropped_total{cell,topic}` 在三 cell demo 拓扑下保持可观测（既有 counter 行为不变）
- ✅ /readyz 在持续 fail-open drop（>5%）时返回 200 + `data.status="degraded"` + verbose `dependencies["outbox-failopen-rate:<cellID>"].status="degraded"`
- ✅ rule 通过 PR-A6 所有 event topic（`event.session.* user.* role.* audit.* config.*`）

### Refs

- `Refs: PR-A49 OUTBOX-ARCHTEST-EXPAND`
- `ref: golang.org/x/tools/go/packages` — LoadAllSyntax + TypesInfo 常量评估
- `ref: github.com/ThreeDotsLabs/watermill components/metrics` — fail-open publisher decorator 模式
- `ref: envoyproxy/envoy admin /ready` — DEGRADED returns 200 不驱逐
- `ref: k8s.io/apiserver/pkg/server/healthz` — readiness probe 二态语义（degraded 不触发 503）
- `ref: kernel/governance/rules_wrapper.go FMT-19` — 早期 AST 常量扫描原型
- `ref: prometheus rate()/increase()` — delta-per-window 语义

## Test plan

- [x] `go build ./...` 通过
- [x] `go test ./...` 全 PASS（133 packages，0 fail）
- [x] `golangci-lint run ./...` 0 issues
- [x] `go test ./tools/archtest/...` 0 violations
- [x] `kernel/outbox` 新代码覆盖率 ≥ 90%（failopen_tracker 100%，包整体 96.1%）
- [x] `runtime/http/health` 三态分支单元 + 集成测试覆盖
- [x] testdata fixture 5 case：basicliteral / samepackage const / crosspackage dto / failclosed / non-security 全 PASS
- [ ] examples/ssobff 集成验证 /readyz?verbose（跳过 — ssobff 需 DB/完整环境配置；CI e2egate 已覆盖）

🤖 Generated with [Claude Code](https://claude.com/claude-code)