### PR TITLE
PR-CFG-G2 GOVERNANCE-AND-RESIDUE — contract consistency + governance + UX/CLI residue

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ GoCell provides Cell/Slice runtime primitives, governance toolchain, and built-i
 ## Quick Start (5 minutes)
 
 The todoorder example requires JWT keys and a service secret for the internal listener.
-Copy-paste the five steps below in a single terminal:
+Run the commands from the repository root. If you have not cloned it yet:
+
+```bash
+git clone https://github.com/ghbvf/gocell.git
+cd gocell
+```
+
+Then copy-paste the steps below in a single terminal:
 
 ```bash
 # Step 1 — generate RS256 key pair
@@ -30,7 +37,10 @@ export TODOORDER_TOKEN="$(go run ./examples/todoorder/localtoken)"
 # Step 4 — start the server (primary :8082, internal :9082)
 go run ./examples/todoorder &
 
-# Step 5 — exercise the API
+# Step 5 — wait for readiness
+until curl -fsS http://localhost:8082/readyz >/dev/null; do sleep 0.2; done
+
+# Step 6 — exercise the API
 curl -s -X POST http://localhost:8082/api/v1/orders/ \
   -H "Authorization: Bearer $TODOORDER_TOKEN" \
   -H 'Content-Type: application/json' \

--- a/README.md
+++ b/README.md
@@ -6,25 +6,42 @@ GoCell provides Cell/Slice runtime primitives, governance toolchain, and built-i
 
 ## Quick Start (5 minutes)
 
-```bash
-git clone https://github.com/ghbvf/gocell.git
-cd gocell
-go run ./examples/todoorder
-```
-
-Open another terminal:
+The todoorder example requires JWT keys and a service secret since PR-CFG-F.
+Copy-paste the five steps below in a single terminal:
 
 ```bash
-# Create an order
-curl -s -X POST http://localhost:8082/api/v1/orders \
+# Step 1 — generate RS256 key pair
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+  -out /tmp/gocell-todoorder-jwt.key
+openssl rsa -in /tmp/gocell-todoorder-jwt.key -pubout \
+  -out /tmp/gocell-todoorder-jwt.pub
+
+# Step 2 — set required env vars
+export GOCELL_JWT_PRIVATE_KEY="$(cat /tmp/gocell-todoorder-jwt.key)"
+export GOCELL_JWT_PUBLIC_KEY="$(cat /tmp/gocell-todoorder-jwt.pub)"
+export GOCELL_JWT_ISSUER=todoorder-local
+export GOCELL_JWT_AUDIENCE=gocell
+export GOCELL_TODOORDER_SERVICE_SECRET="$(openssl rand -base64 32)"
+
+# Step 3 — mint a test RS256 token (role:customer, signed by the local key)
+export TODOORDER_TOKEN="$(go run ./examples/todoorder/localtoken)"
+
+# Step 4 — start the server (primary :8082, internal :9082)
+go run ./examples/todoorder &
+
+# Step 5 — exercise the API
+curl -s -X POST http://localhost:8082/api/v1/orders/ \
+  -H "Authorization: Bearer $TODOORDER_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"item":"my first order"}' | jq .
 
-# List orders
-curl -s http://localhost:8082/api/v1/orders | jq .
+curl -s http://localhost:8082/api/v1/orders/ \
+  -H "Authorization: Bearer $TODOORDER_TOKEN" | jq .
 ```
 
 Check the application logs — you should see `event.order.created consumed`.
+
+For full configuration options (production hardening, real-mode adapters, multi-pod), see `examples/todoorder/README.md`.
 
 ## Core Concepts
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GoCell provides Cell/Slice runtime primitives, governance toolchain, and built-i
 
 ## Quick Start (5 minutes)
 
-The todoorder example requires JWT keys and a service secret since PR-CFG-F.
+The todoorder example requires JWT keys and a service secret for the internal listener.
 Copy-paste the five steps below in a single terminal:
 
 ```bash
@@ -24,6 +24,7 @@ export GOCELL_JWT_AUDIENCE=gocell
 export GOCELL_TODOORDER_SERVICE_SECRET="$(openssl rand -base64 32)"
 
 # Step 3 — mint a test RS256 token (role:customer, signed by the local key)
+# reads $GOCELL_JWT_PRIVATE_KEY/$GOCELL_JWT_ISSUER/$GOCELL_JWT_AUDIENCE from env
 export TODOORDER_TOKEN="$(go run ./examples/todoorder/localtoken)"
 
 # Step 4 — start the server (primary :8082, internal :9082)

--- a/adapters/vault/readiness_test.go
+++ b/adapters/vault/readiness_test.go
@@ -276,23 +276,7 @@ func TestTransitReadiness_RevokedToken(t *testing.T) {
 		"revoked token must return ErrKeyProviderAuthFailed (Vault returns 403 after revocation), got: %v", probeErr)
 }
 
-// ---------------------------------------------------------------------------
-// TC-INT-10: /readyz HTTP integration
-// Skipped with explanation: current bootstrap wiring does not expose a
-// standalone /readyz HTTP server in unit/integration test context.
-// Checkers() return value is verified directly in TC-INT-6 to TC-INT-9.
-// ---------------------------------------------------------------------------
-
-// TestTransitReadiness_ReadyzHTTPIntegration is intentionally skipped.
-//
-// The /readyz HTTP endpoint is assembled at the bootstrap layer
-// (runtime/bootstrap), which is out of scope for adapters/vault integration
-// tests. The readiness probe function itself is verified by TC-INT-6 to
-// TC-INT-9 at the Checkers() level. A full bootstrap-layer /readyz HTTP test
-// requires the composition root and is tracked as a separate journey test
-// (see journeys/J-readiness.yaml).
-func TestTransitReadiness_ReadyzHTTPIntegration(t *testing.T) {
-	t.Skipf("TC-INT-10: /readyz HTTP integration requires bootstrap composition root; " +
-		"Checkers() readiness probe is covered by TC-INT-6 to TC-INT-9. " +
-		"See journeys/J-readiness.yaml for full HTTP integration tracking.")
-}
+// TC-INT-10 (/readyz HTTP integration) was removed: it was a permanent stub
+// with an unconditional t.Skip (no infrastructure condition). The Checkers()
+// readiness probe is verified by TC-INT-6 to TC-INT-9. A full bootstrap-layer
+// /readyz HTTP test is tracked as a journey test in journeys/J-readiness.yaml.

--- a/cells/configcore/slices/configpublish/handler.go
+++ b/cells/configcore/slices/configpublish/handler.go
@@ -90,7 +90,7 @@ func (h *Handler) HandlePublish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": toConfigVersionResponse(version)})
+	httputil.WriteJSON(w, http.StatusCreated, map[string]any{"data": toConfigVersionResponse(version)})
 }
 
 // HandleRollback handles POST /{key}/rollback — rolls back a config entry.

--- a/cells/configcore/slices/configpublish/handler_test.go
+++ b/cells/configcore/slices/configpublish/handler_test.go
@@ -127,7 +127,7 @@ func TestHandler_HandlePublish_OK(t *testing.T) {
 	req := withAdmin(httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/publish", nil))
 	handler.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusCreated, w.Code)
 	body := w.Body.String()
 	assert.Contains(t, body, `"publishedAt"`)
 	assert.Contains(t, body, `"configId"`)
@@ -209,7 +209,7 @@ func TestHandler_HandlePublish_SensitiveRedacted(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := withAdmin(httptest.NewRequest(http.MethodPost, configPrefix+"/db.password/publish", nil))
 	handler.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusCreated, w.Code)
 
 	var resp struct {
 		Data struct {
@@ -234,7 +234,7 @@ func TestHandler_HandlePublish_NonSensitiveVisible(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := withAdmin(httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/publish", nil))
 	handler.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusCreated, w.Code)
 
 	var resp struct {
 		Data struct {

--- a/cells/configcore/slices/configpublish/handler_test.go
+++ b/cells/configcore/slices/configpublish/handler_test.go
@@ -78,7 +78,10 @@ func TestConfigVersionResponse_Fields(t *testing.T) {
 	assert.Contains(t, s, `"configId"`)
 	assert.Contains(t, s, `"version"`)
 	assert.Contains(t, s, `"value"`)
-	// PR#155 review F3: lock the sensitive JSON tag so removing it would fail here.
+	// configpublish RESPONSE DTO deliberately exposes the `sensitive` flag so
+	// callers know to redact UI; this is unrelated to PR-CFG-G2's removal of
+	// `sensitive` from contracts/http/config/update/v1/request.schema.json
+	// (which deleted the request-side field that handler/service/repo never read).
 	assert.Contains(t, s, `"sensitive"`)
 	assert.Contains(t, s, `"publishedAt"`)
 }

--- a/cells/configcore/slices/featureflag/contract_test.go
+++ b/cells/configcore/slices/featureflag/contract_test.go
@@ -16,7 +16,8 @@ func TestHttpConfigFlagsListV1Serve(t *testing.T) {
 	assert.True(t, has403, "http.config.flags.list.v1 must declare 403 (route is RoleAdmin-gated)")
 	c.ValidateErrorResponse(t, 403, []byte(`{"error":{"code":"ERR_AUTH_FORBIDDEN","message":"access denied","details":{}}}`))
 
-	c.ValidateResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}],"nextCursor":"","hasMore":false}`))
+	c.ValidateResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100,"description":"Dark mode toggle","version":1,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}],"nextCursor":"","hasMore":false}`))
+	c.MustRejectResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}],"nextCursor":"","hasMore":false}`))
 	c.MustRejectResponse(t, []byte(`{"data":"not-array","hasMore":false}`))
 }
 
@@ -28,7 +29,8 @@ func TestHttpConfigFlagsGetV1Serve(t *testing.T) {
 	assert.True(t, has403, "http.config.flags.get.v1 must declare 403 (route is RoleAdmin-gated)")
 	c.ValidateErrorResponse(t, 403, []byte(`{"error":{"code":"ERR_AUTH_FORBIDDEN","message":"access denied","details":{}}}`))
 
-	c.ValidateResponse(t, []byte(`{"data":{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}}`))
+	c.ValidateResponse(t, []byte(`{"data":{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100,"description":"Dark mode toggle","version":1,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}}`))
+	c.MustRejectResponse(t, []byte(`{"data":{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}}`))
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }
 

--- a/cells/configcore/slices/featureflag/contract_test.go
+++ b/cells/configcore/slices/featureflag/contract_test.go
@@ -19,6 +19,8 @@ func TestHttpConfigFlagsListV1Serve(t *testing.T) {
 	c.ValidateResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100,"description":"Dark mode toggle","version":1,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}],"nextCursor":"","hasMore":false}`))
 	c.MustRejectResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}],"nextCursor":"","hasMore":false}`))
 	c.MustRejectResponse(t, []byte(`{"data":"not-array","hasMore":false}`))
+	// D5: type constraint — version must be integer (minimum:1), not string.
+	c.MustRejectResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100,"description":"Dark mode toggle","version":"not-a-number","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}],"nextCursor":"","hasMore":false}`))
 }
 
 func TestHttpConfigFlagsGetV1Serve(t *testing.T) {
@@ -32,6 +34,8 @@ func TestHttpConfigFlagsGetV1Serve(t *testing.T) {
 	c.ValidateResponse(t, []byte(`{"data":{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100,"description":"Dark mode toggle","version":1,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}}`))
 	c.MustRejectResponse(t, []byte(`{"data":{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100}}`))
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
+	// D5: type constraint — version must be integer (minimum:1), not string.
+	c.MustRejectResponse(t, []byte(`{"data":{"id":"f-1","key":"dark-mode","type":"boolean","enabled":true,"rolloutPercentage":100,"description":"Dark mode toggle","version":"not-a-number","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}}`))
 }
 
 func TestHttpConfigFlagsEvaluateV1Serve(t *testing.T) {

--- a/cells/configcore/slices/featureflag/handler.go
+++ b/cells/configcore/slices/featureflag/handler.go
@@ -2,6 +2,7 @@ package featureflag
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -11,11 +12,15 @@ import (
 // FeatureFlagResponse is the public DTO for FeatureFlag, isolating the API
 // contract from the domain model.
 type FeatureFlagResponse struct {
-	ID                string `json:"id"`
-	Key               string `json:"key"`
-	Type              string `json:"type"`
-	Enabled           bool   `json:"enabled"`
-	RolloutPercentage int    `json:"rolloutPercentage"`
+	ID                string    `json:"id"`
+	Key               string    `json:"key"`
+	Type              string    `json:"type"`
+	Enabled           bool      `json:"enabled"`
+	RolloutPercentage int       `json:"rolloutPercentage"`
+	Description       string    `json:"description"`
+	Version           int       `json:"version"`
+	CreatedAt         time.Time `json:"createdAt"`
+	UpdatedAt         time.Time `json:"updatedAt"`
 }
 
 func toFeatureFlagResponse(f *domain.FeatureFlag) FeatureFlagResponse {
@@ -25,6 +30,8 @@ func toFeatureFlagResponse(f *domain.FeatureFlag) FeatureFlagResponse {
 	return FeatureFlagResponse{
 		ID: f.ID, Key: f.Key, Type: string(f.Type),
 		Enabled: f.Enabled, RolloutPercentage: f.RolloutPercentage,
+		Description: f.Description, Version: f.Version,
+		CreatedAt: f.CreatedAt, UpdatedAt: f.UpdatedAt,
 	}
 }
 

--- a/cells/configcore/slices/featureflag/handler_test.go
+++ b/cells/configcore/slices/featureflag/handler_test.go
@@ -126,10 +126,10 @@ func TestHandler_HandleList(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
 	item := resp.Data[0]
-	assert.Contains(t, item, "description")
-	assert.Contains(t, item, "version")
-	assert.Contains(t, item, "createdAt")
-	assert.Contains(t, item, "updatedAt")
+	assert.Equal(t, "Dark mode toggle", item["description"], "description must match fixture value")
+	assert.Equal(t, float64(1), item["version"], "version must match fixture value")
+	assert.NotEmpty(t, item["createdAt"], "createdAt must be non-empty")
+	assert.NotEmpty(t, item["updatedAt"], "updatedAt must be non-empty")
 }
 
 func TestHandler_HandleGet_Found(t *testing.T) {

--- a/cells/configcore/slices/featureflag/handler_test.go
+++ b/cells/configcore/slices/featureflag/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
@@ -32,9 +33,12 @@ func TestToEvaluateResultResponse_NilInput(t *testing.T) {
 }
 
 func TestFeatureFlagResponse_Fields(t *testing.T) {
+	now := time.Now()
 	flag := &domain.FeatureFlag{
 		ID: "ff-1", Key: "dark-mode", Type: domain.FlagBoolean,
 		Enabled: true, RolloutPercentage: 80,
+		Description: "Toggles dark mode UI", Version: 2,
+		CreatedAt: now, UpdatedAt: now,
 	}
 	resp := toFeatureFlagResponse(flag)
 
@@ -43,6 +47,10 @@ func TestFeatureFlagResponse_Fields(t *testing.T) {
 	assert.Equal(t, "boolean", resp.Type)
 	assert.True(t, resp.Enabled)
 	assert.Equal(t, 80, resp.RolloutPercentage)
+	assert.Equal(t, "Toggles dark mode UI", resp.Description)
+	assert.Equal(t, 2, resp.Version)
+	assert.Equal(t, now, resp.CreatedAt)
+	assert.Equal(t, now, resp.UpdatedAt)
 
 	// Verify camelCase JSON keys.
 	b, err := json.Marshal(resp)
@@ -53,6 +61,10 @@ func TestFeatureFlagResponse_Fields(t *testing.T) {
 	assert.Contains(t, s, `"type"`)
 	assert.Contains(t, s, `"enabled"`)
 	assert.Contains(t, s, `"rolloutPercentage"`)
+	assert.Contains(t, s, `"description"`)
+	assert.Contains(t, s, `"version"`)
+	assert.Contains(t, s, `"createdAt"`)
+	assert.Contains(t, s, `"updatedAt"`)
 }
 
 func TestEvaluateResultResponse_Fields(t *testing.T) {
@@ -92,8 +104,11 @@ func setupHandlerWithCodec() (http.Handler, *mem.FlagRepository, *query.CursorCo
 
 func TestHandler_HandleList(t *testing.T) {
 	handler, repo := setupHandler()
+	now := time.Now()
 	require.NoError(t, repo.Create(context.Background(), &domain.FeatureFlag{
 		ID: "f1", Key: "dark-mode", Type: domain.FlagBoolean, Enabled: true,
+		Description: "Dark mode toggle", Version: 1,
+		CreatedAt: now, UpdatedAt: now,
 	}))
 
 	w := httptest.NewRecorder()
@@ -103,12 +118,27 @@ func TestHandler_HandleList(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "dark-mode")
 	assert.Contains(t, w.Body.String(), "\"hasMore\"")
+
+	// Verify 4 new fields are present in list items.
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	item := resp.Data[0]
+	assert.Contains(t, item, "description")
+	assert.Contains(t, item, "version")
+	assert.Contains(t, item, "createdAt")
+	assert.Contains(t, item, "updatedAt")
 }
 
 func TestHandler_HandleGet_Found(t *testing.T) {
 	handler, repo := setupHandler()
+	now := time.Now()
 	require.NoError(t, repo.Create(context.Background(), &domain.FeatureFlag{
 		ID: "f1", Key: "dark-mode", Type: domain.FlagBoolean, Enabled: true,
+		Description: "Dark mode toggle", Version: 3,
+		CreatedAt: now, UpdatedAt: now,
 	}))
 
 	w := httptest.NewRecorder()
@@ -118,7 +148,7 @@ func TestHandler_HandleGet_Found(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "dark-mode")
 
-	// Verify camelCase JSON keys (#27n).
+	// Verify camelCase JSON keys including 4 new fields (#27n).
 	var raw map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
 	var dataMap map[string]any
@@ -128,6 +158,12 @@ func TestHandler_HandleGet_Found(t *testing.T) {
 	assert.Contains(t, dataMap, "type", "key must be camelCase")
 	assert.Contains(t, dataMap, "enabled", "key must be camelCase")
 	assert.Contains(t, dataMap, "rolloutPercentage", "key must be camelCase")
+	assert.Contains(t, dataMap, "description", "description must be present")
+	assert.Contains(t, dataMap, "version", "version must be present")
+	assert.Contains(t, dataMap, "createdAt", "createdAt must be present")
+	assert.Contains(t, dataMap, "updatedAt", "updatedAt must be present")
+	assert.Equal(t, "Dark mode toggle", dataMap["description"])
+	assert.Equal(t, float64(3), dataMap["version"])
 }
 
 func TestHandler_HandleGet_NotFound(t *testing.T) {

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -417,5 +417,5 @@ func publishConfig(t *testing.T, baseURL, token, key string) {
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.Equal(t, http.StatusOK, resp.StatusCode, "config publish must return 200")
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "config publish must return 201 (creates new ConfigVersion)")
 }

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -206,12 +207,23 @@ func checkSliceCoverage(args []string) error {
 
 	if *cellID != "" {
 		if _, ok := project.Cells[*cellID]; !ok {
+			ids := make([]string, 0, len(project.Cells))
+			for id := range project.Cells {
+				ids = append(ids, id)
+			}
+			sort.Strings(ids)
+			available := ids
+			suffix := ""
+			if len(ids) > 10 {
+				available = ids[:10]
+				suffix = ", ..."
+			}
 			return printAndCheck(*format, []governance.ValidationResult{{
 				Code:      "CHECK-CELL-NOT-FOUND",
 				Severity:  governance.SeverityError,
 				IssueType: governance.IssueRequired,
 				Scope:     cmdSliceCoverage,
-				Message:   fmt.Sprintf("cell %q not found in project", *cellID),
+				Message:   fmt.Sprintf("cell %q not found in project; available cells: [%s%s]", *cellID, strings.Join(available, ", "), suffix),
 			}}, cmdSliceCoverage, "")
 		}
 	}
@@ -825,7 +837,7 @@ func runUnconditionalSkipAnalyzer(patterns []string, root string) ([]governance.
 		Mode:       packages.LoadAllSyntax,
 		Tests:      true,
 		Dir:        root,
-		BuildFlags: []string{"-tags=integration e2e examples_smoke"},
+		BuildFlags: []string{"-tags=integration,e2e,examples_smoke"},
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -204,6 +204,18 @@ func checkSliceCoverage(args []string) error {
 		return fmt.Errorf(errMetadataParse, err)
 	}
 
+	if *cellID != "" {
+		if _, ok := project.Cells[*cellID]; !ok {
+			return printAndCheck(*format, []governance.ValidationResult{{
+				Code:      "CHECK-CELL-NOT-FOUND",
+				Severity:  governance.SeverityError,
+				IssueType: governance.IssueRequired,
+				Scope:     cmdSliceCoverage,
+				Message:   fmt.Sprintf("cell %q not found in project", *cellID),
+			}}, cmdSliceCoverage, "")
+		}
+	}
+
 	var results []governance.ValidationResult
 	cellCount := 0
 	sliceCount := 0
@@ -805,10 +817,15 @@ func checkUnconditionalSkip(args []string) error {
 func runUnconditionalSkipAnalyzer(patterns []string, root string) ([]governance.ValidationResult, error) {
 	// packages.LoadAllSyntax loads type-annotated syntax for initial packages
 	// and all transitive dependencies — the minimum mode checker.Analyze needs.
+	// BuildFlags includes the build tags used by integration, e2e, and smoke
+	// test files so the analyzer sees those files instead of silently skipping
+	// them — without this, //go:build integration test files are invisible and
+	// unconditional t.Skip calls inside them are never reported.
 	cfg := &packages.Config{
-		Mode:  packages.LoadAllSyntax,
-		Tests: true,
-		Dir:   root,
+		Mode:       packages.LoadAllSyntax,
+		Tests:      true,
+		Dir:        root,
+		BuildFlags: []string{"-tags=integration e2e examples_smoke"},
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -182,6 +182,22 @@ func countContractHealthErrors(results []governance.ValidationResult) int {
 	return countErrors(results)
 }
 
+// availableCellsMsg builds the "available cells: [...]" fragment for error messages.
+// Returns at most 10 sorted cell IDs, appending ", ..." when there are more.
+func availableCellsMsg(cells map[string]*metadata.CellMeta) string {
+	ids := make([]string, 0, len(cells))
+	for id := range cells {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	suffix := ""
+	if len(ids) > 10 {
+		ids = ids[:10]
+		suffix = ", ..."
+	}
+	return "[" + strings.Join(ids, ", ") + suffix + "]"
+}
+
 // checkSliceCoverage checks that every slices/ subdirectory has a slice.yaml
 // and that each parsed SliceMeta correctly references its parent cell.
 //
@@ -207,23 +223,12 @@ func checkSliceCoverage(args []string) error {
 
 	if *cellID != "" {
 		if _, ok := project.Cells[*cellID]; !ok {
-			ids := make([]string, 0, len(project.Cells))
-			for id := range project.Cells {
-				ids = append(ids, id)
-			}
-			sort.Strings(ids)
-			available := ids
-			suffix := ""
-			if len(ids) > 10 {
-				available = ids[:10]
-				suffix = ", ..."
-			}
 			return printAndCheck(*format, []governance.ValidationResult{{
 				Code:      "CHECK-CELL-NOT-FOUND",
 				Severity:  governance.SeverityError,
 				IssueType: governance.IssueRequired,
 				Scope:     cmdSliceCoverage,
-				Message:   fmt.Sprintf("cell %q not found in project; available cells: [%s%s]", *cellID, strings.Join(available, ", "), suffix),
+				Message:   fmt.Sprintf("cell %q not found in project; available cells: %s", *cellID, availableCellsMsg(project.Cells)),
 			}}, cmdSliceCoverage, "")
 		}
 	}

--- a/cmd/gocell/app/check_test.go
+++ b/cmd/gocell/app/check_test.go
@@ -550,6 +550,76 @@ func TestCheckL0ImportsForSingleCell_NonL0JSONFormat(t *testing.T) {
 	assert.Empty(t, doc.Issues, "non-L0 skip must produce zero issues")
 }
 
+// TestCheckSliceCoverage_UnknownCell verifies that --cell=<id> with an ID not
+// present in the project produces CHECK-CELL-NOT-FOUND and a non-nil error
+// (non-zero exit). Previously this was a silent false-green pass.
+func TestCheckSliceCoverage_UnknownCell(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n"), 0o644))
+
+	// Minimal project with one real cell so the parser succeeds.
+	cellDir := filepath.Join(root, "cells", "realcell")
+	require.NoError(t, os.MkdirAll(cellDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cellDir, "cell.yaml"), []byte(
+		"id: realcell\ntype: core\nconsistencyLevel: L1\nowner:\n  team: t\n  role: r\nschema:\n  primary: t\nverify:\n  smoke: []\n"),
+		0o644))
+
+	orig, _ := os.Getwd()
+	require.NoError(t, os.Chdir(root))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	err := runCheck([]string{"slice-coverage", "--cell=does-not-exist"})
+	require.Error(t, err, "unknown --cell must produce non-zero exit")
+	assert.Contains(t, err.Error(), "issue(s)", "error must report finding count")
+
+	// Also verify the finding code in JSON output.
+	out := captureStdout(t, func() {
+		_ = runCheck([]string{"slice-coverage", "--cell=does-not-exist", "--format=json"})
+	})
+	assert.Contains(t, out, "CHECK-CELL-NOT-FOUND", "JSON output must contain CHECK-CELL-NOT-FOUND code")
+}
+
+// TestRunUnconditionalSkipAnalyzer_BuildTaggedFile verifies that
+// BuildFlags=-tags=integration e2e examples_smoke causes the analyzer to
+// include build-tagged test files. Without BuildFlags those files are silently
+// excluded by go/packages and unconditional t.Skip calls inside them are never
+// reported.
+//
+// Strategy: write a temp Go module with a //go:build examples_smoke test file
+// that contains an unconditional t.Skip, then assert the analyzer finds it.
+func TestRunUnconditionalSkipAnalyzer_BuildTaggedFile(t *testing.T) {
+	root := t.TempDir()
+
+	// Minimal go.mod — the module path must resolve; no external deps needed.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte(
+		"module example.com/skiptest\n\ngo 1.22\n"), 0o644))
+
+	// A package directory.
+	pkgDir := filepath.Join(root, "mypkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+
+	// A non-tagged file so the package is visible even without build tags.
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "main.go"), []byte(
+		"package mypkg\n"), 0o644))
+
+	// A build-tagged test file with an unconditional t.Skip.
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "smoke_test.go"), []byte(
+		"//go:build examples_smoke\n\npackage mypkg\n\nimport \"testing\"\n\nfunc TestSmoke(t *testing.T) {\n\tt.Skip(\"unconditional stub\")\n}\n"), 0o644))
+
+	results, err := runUnconditionalSkipAnalyzer([]string{"./..."}, root)
+	require.NoError(t, err, "analyzer must not error on this synthetic module")
+
+	var found bool
+	for _, r := range results {
+		if r.Code == "UNCONDITIONAL-SKIP-01" && strings.Contains(r.File, "smoke_test.go") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"analyzer with BuildFlags must report UNCONDITIONAL-SKIP-01 in build-tagged file; got: %+v", results)
+}
+
 // ---------------------------------------------------------------------------
 // Metadata parse error path for each subcommand
 // ---------------------------------------------------------------------------

--- a/cmd/gocell/app/check_test.go
+++ b/cmd/gocell/app/check_test.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -13,6 +15,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/go/packages"
 )
+
+// goModVersion returns the major.minor version string of the running Go toolchain
+// (e.g. "1.22") so generated go.mod files track the actual toolchain instead of
+// a hardcoded value that drifts over time.
+func goModVersion() string {
+	v := runtime.Version() // e.g. "go1.26.1"
+	v = strings.TrimPrefix(v, "go")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return v
+}
 
 func TestCheckContractHealthCI(t *testing.T) {
 	// Run against the real project — should pass with 0 issues.
@@ -572,11 +587,19 @@ func TestCheckSliceCoverage_UnknownCell(t *testing.T) {
 	require.Error(t, err, "unknown --cell must produce non-zero exit")
 	assert.Contains(t, err.Error(), "issue(s)", "error must report finding count")
 
+	// Verify the text-format output contains the finding code and available cells.
+	textOut := captureStdout(t, func() {
+		_ = runCheck([]string{"slice-coverage", "--cell=does-not-exist"})
+	})
+	assert.Contains(t, textOut, "CHECK-CELL-NOT-FOUND", "text output must contain CHECK-CELL-NOT-FOUND code")
+	assert.Contains(t, textOut, "available cells", "text output must list available cells")
+
 	// Also verify the finding code in JSON output.
 	out := captureStdout(t, func() {
 		_ = runCheck([]string{"slice-coverage", "--cell=does-not-exist", "--format=json"})
 	})
 	assert.Contains(t, out, "CHECK-CELL-NOT-FOUND", "JSON output must contain CHECK-CELL-NOT-FOUND code")
+	assert.Contains(t, out, "available cells", "JSON output must include available cells in message")
 }
 
 // TestRunUnconditionalSkipAnalyzer_BuildTaggedFile verifies that
@@ -591,8 +614,9 @@ func TestRunUnconditionalSkipAnalyzer_BuildTaggedFile(t *testing.T) {
 	root := t.TempDir()
 
 	// Minimal go.mod — the module path must resolve; no external deps needed.
+	// Use the actual toolchain version so this fixture tracks upgrades automatically.
 	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte(
-		"module example.com/skiptest\n\ngo 1.22\n"), 0o644))
+		fmt.Sprintf("module example.com/skiptest\n\ngo %s\n", goModVersion())), 0o644))
 
 	// A package directory.
 	pkgDir := filepath.Join(root, "mypkg")

--- a/contracts/http/audit/list/v1/contract.yaml
+++ b/contracts/http/audit/list/v1/contract.yaml
@@ -1,7 +1,7 @@
 id: http.audit.list.v1
 kind: http
 ownerCell: auditcore
-consistencyLevel: L2
+consistencyLevel: L0
 lifecycle: active
 endpoints:
   server: auditcore

--- a/contracts/http/auth/login/v1/contract.yaml
+++ b/contracts/http/auth/login/v1/contract.yaml
@@ -1,8 +1,10 @@
 id: http.auth.login.v1
 kind: http
 ownerCell: accesscore
-consistencyLevel: L1
+consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.session.created.v1
 endpoints:
   server: accesscore
   clients:

--- a/contracts/http/auth/role/assign/v1/contract.yaml
+++ b/contracts/http/auth/role/assign/v1/contract.yaml
@@ -1,8 +1,10 @@
 id: http.auth.role.assign.v1
 kind: http
 ownerCell: accesscore
-consistencyLevel: L0
+consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.role.assigned.v1
 endpoints:
   server: accesscore
   clients:

--- a/contracts/http/auth/role/revoke/v1/contract.yaml
+++ b/contracts/http/auth/role/revoke/v1/contract.yaml
@@ -1,8 +1,10 @@
 id: http.auth.role.revoke.v1
 kind: http
 ownerCell: accesscore
-consistencyLevel: L0
+consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.role.revoked.v1
 endpoints:
   server: accesscore
   clients:

--- a/contracts/http/auth/session/delete/v1/contract.yaml
+++ b/contracts/http/auth/session/delete/v1/contract.yaml
@@ -1,8 +1,10 @@
 id: http.auth.session.delete.v1
 kind: http
 ownerCell: accesscore
-consistencyLevel: L1
+consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.session.revoked.v1
 endpoints:
   server: accesscore
   clients:

--- a/contracts/http/auth/setup/admin/v1/contract.yaml
+++ b/contracts/http/auth/setup/admin/v1/contract.yaml
@@ -3,6 +3,8 @@ kind: http
 ownerCell: accesscore
 consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.user.created.v1
 endpoints:
   server: accesscore
   clients:

--- a/contracts/http/auth/user/create/v1/contract.yaml
+++ b/contracts/http/auth/user/create/v1/contract.yaml
@@ -1,8 +1,10 @@
 id: http.auth.user.create.v1
 kind: http
 ownerCell: accesscore
-consistencyLevel: L1
+consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.user.created.v1
 endpoints:
   server: accesscore
   clients:

--- a/contracts/http/auth/user/lock/v1/contract.yaml
+++ b/contracts/http/auth/user/lock/v1/contract.yaml
@@ -1,8 +1,10 @@
 id: http.auth.user.lock.v1
 kind: http
 ownerCell: accesscore
-consistencyLevel: L1
+consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.user.locked.v1
 endpoints:
   server: accesscore
   clients:

--- a/contracts/http/config/delete/v1/contract.yaml
+++ b/contracts/http/config/delete/v1/contract.yaml
@@ -3,6 +3,8 @@ kind: http
 ownerCell: configcore
 consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.config.entry-deleted.v1
 endpoints:
   server: configcore
   clients:

--- a/contracts/http/config/flags/create/v1/contract.yaml
+++ b/contracts/http/config/flags/create/v1/contract.yaml
@@ -1,7 +1,7 @@
 id: http.config.flags.create.v1
 kind: http
 ownerCell: configcore
-consistencyLevel: L2
+consistencyLevel: L1
 lifecycle: active
 endpoints:
   server: configcore

--- a/contracts/http/config/flags/delete/v1/contract.yaml
+++ b/contracts/http/config/flags/delete/v1/contract.yaml
@@ -1,7 +1,7 @@
 id: http.config.flags.delete.v1
 kind: http
 ownerCell: configcore
-consistencyLevel: L2
+consistencyLevel: L1
 lifecycle: active
 endpoints:
   server: configcore

--- a/contracts/http/config/flags/get/v1/response.schema.json
+++ b/contracts/http/config/flags/get/v1/response.schema.json
@@ -7,14 +7,18 @@
   "properties": {
     "data": {
       "type": "object",
-      "required": ["id", "key", "type", "enabled", "rolloutPercentage"],
+      "required": ["id", "key", "type", "enabled", "rolloutPercentage", "description", "version", "createdAt", "updatedAt"],
       "additionalProperties": false,
       "properties": {
         "id": { "type": "string" },
         "key": { "type": "string" },
         "type": { "type": "string", "enum": ["boolean", "percentage"] },
         "enabled": { "type": "boolean" },
-        "rolloutPercentage": { "type": "integer", "minimum": 0, "maximum": 100 }
+        "rolloutPercentage": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "description": { "type": "string" },
+        "version": { "type": "integer", "minimum": 1 },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
       }
     }
   }

--- a/contracts/http/config/flags/list/v1/response.schema.json
+++ b/contracts/http/config/flags/list/v1/response.schema.json
@@ -9,14 +9,18 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "key", "type", "enabled", "rolloutPercentage"],
+        "required": ["id", "key", "type", "enabled", "rolloutPercentage", "description", "version", "createdAt", "updatedAt"],
         "additionalProperties": false,
         "properties": {
           "id": { "type": "string" },
           "key": { "type": "string" },
           "type": { "type": "string", "enum": ["boolean", "percentage"] },
           "enabled": { "type": "boolean" },
-          "rolloutPercentage": { "type": "integer", "minimum": 0, "maximum": 100 }
+          "rolloutPercentage": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "description": { "type": "string" },
+          "version": { "type": "integer", "minimum": 1 },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
         }
       }
     },

--- a/contracts/http/config/flags/toggle/v1/contract.yaml
+++ b/contracts/http/config/flags/toggle/v1/contract.yaml
@@ -1,7 +1,7 @@
 id: http.config.flags.toggle.v1
 kind: http
 ownerCell: configcore
-consistencyLevel: L2
+consistencyLevel: L1
 lifecycle: active
 endpoints:
   server: configcore

--- a/contracts/http/config/flags/update/v1/contract.yaml
+++ b/contracts/http/config/flags/update/v1/contract.yaml
@@ -1,7 +1,7 @@
 id: http.config.flags.update.v1
 kind: http
 ownerCell: configcore
-consistencyLevel: L2
+consistencyLevel: L1
 lifecycle: active
 endpoints:
   server: configcore

--- a/contracts/http/config/publish/v1/contract.yaml
+++ b/contracts/http/config/publish/v1/contract.yaml
@@ -16,7 +16,7 @@ endpoints:
     pathParams:
       key:
         type: string
-    successStatus: 200
+    successStatus: 201
     noContent: false
     responses:
       401:

--- a/contracts/http/config/publish/v1/contract.yaml
+++ b/contracts/http/config/publish/v1/contract.yaml
@@ -5,7 +5,6 @@ consistencyLevel: L2
 lifecycle: active
 triggers:
   - event.config.version-published.v1
-  - event.config.entry-upserted.v1
 endpoints:
   server: configcore
   clients:

--- a/contracts/http/config/publish/v1/contract.yaml
+++ b/contracts/http/config/publish/v1/contract.yaml
@@ -3,6 +3,9 @@ kind: http
 ownerCell: configcore
 consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.config.version-published.v1
+  - event.config.entry-upserted.v1
 endpoints:
   server: configcore
   clients:

--- a/contracts/http/config/rollback/v1/contract.yaml
+++ b/contracts/http/config/rollback/v1/contract.yaml
@@ -3,6 +3,8 @@ kind: http
 ownerCell: configcore
 consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.config.rollback.v1
 endpoints:
   server: configcore
   clients:

--- a/contracts/http/config/rollback/v1/contract.yaml
+++ b/contracts/http/config/rollback/v1/contract.yaml
@@ -4,6 +4,7 @@ ownerCell: configcore
 consistencyLevel: L2
 lifecycle: active
 triggers:
+  - event.config.entry-upserted.v1
   - event.config.rollback.v1
 endpoints:
   server: configcore

--- a/contracts/http/config/update/v1/contract.yaml
+++ b/contracts/http/config/update/v1/contract.yaml
@@ -3,6 +3,8 @@ kind: http
 ownerCell: configcore
 consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.config.entry-upserted.v1
 endpoints:
   server: configcore
   clients:

--- a/contracts/http/config/update/v1/request.schema.json
+++ b/contracts/http/config/update/v1/request.schema.json
@@ -3,8 +3,7 @@
   "title": "http.config.update.v1.request",
   "type": "object",
   "properties": {
-    "value": { "type": "string" },
-    "sensitive": { "type": "boolean" }
+    "value": { "type": "string" }
   },
   "required": ["value"],
   "additionalProperties": false

--- a/contracts/http/config/write/v1/contract.yaml
+++ b/contracts/http/config/write/v1/contract.yaml
@@ -3,6 +3,8 @@ kind: http
 ownerCell: configcore
 consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.config.entry-upserted.v1
 endpoints:
   server: configcore
   clients:

--- a/docs/architecture/metadata-model-v3.md
+++ b/docs/architecture/metadata-model-v3.md
@@ -110,12 +110,13 @@ schemaRefs:
 
 #### `triggers` 字段语义
 
-L2+ HTTP contract 必须声明非空的 `triggers`。值为 owner cell 的 HTTP handler 成功时通过 outbox 发布的事件 topic 字符串。`CONTRACT-CONSISTENCY-EMIT-01` 规则对此进行双向校验：
+L2+ HTTP contract 必须声明非空的 `triggers`。值为 owner cell 的 HTTP handler 成功时通过 outbox 发布的事件 contract ID / topic 字符串。`CONTRACT-CONSISTENCY-EMIT-01` 规则对此进行双向校验：
 
-- **正向检查**：contract 声明的每个 trigger 必须能在 `cells/<ownerCell>/slices/` 下的非测试 Go 文件中找到对应的 `outbox.Emit` 或 `*.Emitter.Emit` 调用。
-- **反向检查**：service 代码中出现的每个 emit topic 必须在该 cell 的至少一个 HTTP contract 的 `triggers` 中声明。
+- **引用检查**：每个 trigger 必须引用已存在的 `kind: event` contract，且 event contract 的 owner / publisher 与 HTTP owner cell 一致；服务该 HTTP contract 的 slice 必须同时声明对应 event contract 的 `role: publish`。
+- **正向检查**：contract 声明的每个 trigger 必须能在服务该 HTTP contract 的 slice 非测试 Go 文件中找到对应的 `outbox.Emit` 或 `*.Emitter.Emit` 调用。
+- **反向检查**：HTTP-serving slice 代码中出现的每个 emit topic 必须在该 slice 服务的至少一个 HTTP contract 的 `triggers` 中声明。
 
-Topic 值必须是字符串字面量或具名常量（`dto.TopicX` / `domain.TopicX`）；动态 `fmt.Sprintf` 表达式被拒绝（运行时不可知）。
+Topic 值必须是字符串字面量或具名常量（`dto.TopicX` / `domain.TopicX`）；动态 `fmt.Sprintf` 表达式和 helper / receiver 路径上的 unresolved topic 都会被拒绝（运行时不可知）。
 
 完整 HTTP 传输层示例（`GET /api/v1/access/users/{id}` 带 cursor 分页 + 401/403）：
 

--- a/docs/architecture/metadata-model-v3.md
+++ b/docs/architecture/metadata-model-v3.md
@@ -88,8 +88,10 @@ verify:
 id: http.auth.login.v1
 kind: http                        # derived-anchor，可省略
 ownerCell: accesscore            # 缺省 = provider，可省略
-consistencyLevel: L1
+consistencyLevel: L2
 lifecycle: active
+triggers:
+  - event.session.created.v1     # outbox topic emitted by handler on success (L2+)
 endpoints:
   server: accesscore
   clients:
@@ -105,6 +107,15 @@ schemaRefs:
   request: request.schema.json
   response: response.schema.json
 ```
+
+#### `triggers` 字段语义
+
+L2+ HTTP contract 必须声明非空的 `triggers`。值为 owner cell 的 HTTP handler 成功时通过 outbox 发布的事件 topic 字符串。`CONTRACT-CONSISTENCY-EMIT-01` 规则对此进行双向校验：
+
+- **正向检查**：contract 声明的每个 trigger 必须能在 `cells/<ownerCell>/slices/` 下的非测试 Go 文件中找到对应的 `outbox.Emit` 或 `*.Emitter.Emit` 调用。
+- **反向检查**：service 代码中出现的每个 emit topic 必须在该 cell 的至少一个 HTTP contract 的 `triggers` 中声明。
+
+Topic 值必须是字符串字面量或具名常量（`dto.TopicX` / `domain.TopicX`）；动态 `fmt.Sprintf` 表达式被拒绝（运行时不可知）。
 
 完整 HTTP 传输层示例（`GET /api/v1/access/users/{id}` 带 cursor 分页 + 401/403）：
 

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -71,14 +71,16 @@ go test -tags integration ./tests/integration/... -run TestAssembly -count=1 -v
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
+> Defaults below describe the local docker-compose / testcontainer dev loop. **Never reuse these values in production** — they are public dev fixtures (e.g. RabbitMQ `guest:guest`, MinIO `minioadmin:minioadmin`) and will fail security scans. CI provides real values via secrets.
+
+| Variable | Default (local dev only) | Description |
+|----------|--------------------------|-------------|
 | `GOCELL_CONFIGCORE_DATABASE_URL` | (testcontainer; see test setup) | PostgreSQL DSN for configcore integration tests. Most tests start their own container and pass DSN directly. |
 | `GOCELL_REDIS_ADDR` | `localhost:6379` | Redis address |
-| `GOCELL_AMQP_URL` | `amqp://guest:guest@localhost:5672/` | RabbitMQ connection URL |
+| `GOCELL_AMQP_URL` | (set from CI secret; local docker-compose default uses public `guest:guest@localhost:5672`) | RabbitMQ connection URL |
 | `GOCELL_S3_ENDPOINT` | `http://localhost:9000` | MinIO / S3 endpoint |
-| `GOCELL_S3_ACCESS_KEY` | `minioadmin` | S3 access key |
-| `GOCELL_S3_SECRET_KEY` | `minioadmin` | S3 secret key |
+| `GOCELL_S3_ACCESS_KEY` | (set from CI secret; local docker-compose default is the public `minioadmin` fixture) | S3 access key |
+| `GOCELL_S3_SECRET_KEY` | (set from CI secret; local docker-compose default is the public `minioadmin` fixture) | S3 secret key |
 | `GOCELL_OIDC_ISSUER` | `http://localhost:8080/realms/gocell` | OIDC issuer URL |
 
 ## CI Pipeline

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -64,7 +64,7 @@ go test -tags integration ./tests/integration/... -run TestAssembly -count=1 -v
    }
    ```
 
-   Permanent stub tests (will never run) MUST be deleted, not marked `t.Skip` — see `tools/nogo/unconditionalskip` analyzer (PR-CFG-D).
+   Permanent stub tests (will never run) MUST be deleted, not marked `t.Skip` — run `gocell check unconditional-skip ./...` to detect violations; analyzer at `tools/nogo/unconditionalskip`.
 3. Read connection parameters from environment variables (e.g., `GOCELL_CONFIGCORE_DATABASE_URL`, `GOCELL_REDIS_ADDR`). Most integration tests start their own testcontainer and pass the DSN directly; see `cmd/corebundle/main_integration_test.go` for the pattern.
 4. Each test must be self-contained: create its own schema/queue/bucket, run assertions, then clean up.
 5. Use `t.Parallel()` only when tests do not share mutable state (e.g., separate database schemas).

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -56,7 +56,15 @@ go test -tags integration ./tests/integration/... -run TestAssembly -count=1 -v
 ## Writing a New Integration Test
 
 1. Add `//go:build integration` as the first line (before `package`).
-2. Use `t.Skip("stub: requires ...")` for placeholder tests until the infrastructure helper is ready.
+2. Conditional skip pattern: wrap `t.Skip` in an environment or build-tag guard so it never runs unconditionally:
+
+   ```go
+   if testing.Short() || os.Getenv("GOCELL_PG_DSN") == "" {
+       t.Skip("requires PG_DSN")
+   }
+   ```
+
+   Permanent stub tests (will never run) MUST be deleted, not marked `t.Skip` — see `tools/nogo/unconditionalskip` analyzer (PR-CFG-D).
 3. Read connection parameters from environment variables (e.g., `GOCELL_CONFIGCORE_DATABASE_URL`, `GOCELL_REDIS_ADDR`). Most integration tests start their own testcontainer and pass the DSN directly; see `cmd/corebundle/main_integration_test.go` for the pattern.
 4. Each test must be self-contained: create its own schema/queue/bucket, run assertions, then clean up.
 5. Use `t.Parallel()` only when tests do not share mutable state (e.g., separate database schemas).

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -29,7 +29,7 @@ go test -tags integration ./... -count=1 -v
 go test -tags integration ./adapters/postgres/... -count=1 -v
 go test -tags integration ./adapters/redis/...    -count=1 -v
 go test -tags integration ./adapters/rabbitmq/... -count=1 -v
-go test -tags integration ./adapters/websocket/.. -count=1 -v
+go test -tags integration ./adapters/websocket/... -count=1 -v
 # adapters/oidc and adapters/s3 are thin SDK wrappers with unit tests only.
 ```
 

--- a/examples/iotdevice/README.md
+++ b/examples/iotdevice/README.md
@@ -101,10 +101,13 @@ curl -X POST http://localhost:8083/api/v1/devices/{id}/commands \
   -d '{"payload":"reboot"}'
 ```
 
+`commandType` is optional in the enqueue request (only `payload` is required).
+Omitting it leaves the field empty; the device sees it in the dequeue response.
+
 Response (201):
 
 ```json
-{"data":{"id":"cmd-...","deviceId":"dev-...","payload":"reboot","status":"pending","createdAt":"..."}}
+{"data":{"id":"cmd-...","deviceId":"dev-...","commandType":"","payload":"reboot","status":"pending","createdAt":"..."}}
 ```
 
 ### Device dequeues commands
@@ -117,7 +120,7 @@ curl http://localhost:8083/api/v1/devices/{id}/commands \
 Response (200):
 
 ```json
-{"data":[{"id":"cmd-...","deviceId":"dev-...","payload":"reboot","status":"sent","attempt":1,"createdAt":"...","sentAt":"..."}],"nextCursor":"","hasMore":false}
+{"data":[{"id":"cmd-...","deviceId":"dev-...","commandType":"","payload":"reboot","status":"sent","attempt":1,"createdAt":"...","sentAt":"..."}],"nextCursor":"","hasMore":false}
 ```
 
 ### Device reports command receipt

--- a/examples/iotdevice/README.md
+++ b/examples/iotdevice/README.md
@@ -69,6 +69,7 @@ go run ./examples/iotdevice
 
 ```bash
 curl -X POST http://localhost:8083/api/v1/devices \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
   -d '{"name":"sensor-001"}'
 ```

--- a/examples/iotdevice/README.md
+++ b/examples/iotdevice/README.md
@@ -99,16 +99,16 @@ Response (200):
 curl -X POST http://localhost:8083/api/v1/devices/{id}/commands \
   -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
-  -d '{"payload":"reboot"}'
+  -d '{"commandType":"default","payload":"reboot"}'
 ```
 
 `commandType` is optional in the enqueue request (only `payload` is required).
-Omitting it leaves the field empty; the device sees it in the dequeue response.
+Omitting it defaults the field to `"default"`; the device sees that value in the dequeue response.
 
 Response (201):
 
 ```json
-{"data":{"id":"cmd-...","deviceId":"dev-...","commandType":"","payload":"reboot","status":"pending","createdAt":"..."}}
+{"data":{"id":"cmd-...","deviceId":"dev-...","commandType":"default","payload":"reboot","status":"pending","createdAt":"..."}}
 ```
 
 ### Device dequeues commands
@@ -121,7 +121,7 @@ curl http://localhost:8083/api/v1/devices/{id}/commands \
 Response (200):
 
 ```json
-{"data":[{"id":"cmd-...","deviceId":"dev-...","commandType":"","payload":"reboot","status":"sent","attempt":1,"createdAt":"...","sentAt":"..."}],"nextCursor":"","hasMore":false}
+{"data":[{"id":"cmd-...","deviceId":"dev-...","commandType":"default","payload":"reboot","status":"sent","attempt":1,"createdAt":"...","sentAt":"..."}],"nextCursor":"","hasMore":false}
 ```
 
 ### Device reports command receipt
@@ -134,7 +134,7 @@ curl -X POST http://localhost:8083/api/v1/devices/{id}/commands/{cmdId}/report \
 Response (200):
 
 ```json
-{"data":{"id":"cmd-...","deviceId":"dev-...","payload":"reboot","status":"delivered","attempt":1,"createdAt":"...","sentAt":"...","deliveredAt":"..."}}
+{"data":{"id":"cmd-...","deviceId":"dev-...","commandType":"default","payload":"reboot","status":"delivered","attempt":1,"createdAt":"...","sentAt":"...","deliveredAt":"..."}}
 ```
 
 ### Device acknowledges command execution
@@ -149,7 +149,7 @@ curl -X POST http://localhost:8083/api/v1/devices/{id}/commands/{cmdId}/ack \
 Response (200):
 
 ```json
-{"data":{"id":"cmd-...","deviceId":"dev-...","payload":"reboot","status":"succeeded","attempt":1,"createdAt":"...","sentAt":"...","deliveredAt":"...","completedAt":"..."}}
+{"data":{"id":"cmd-...","deviceId":"dev-...","commandType":"default","payload":"reboot","status":"succeeded","attempt":1,"createdAt":"...","sentAt":"...","deliveredAt":"...","completedAt":"..."}}
 ```
 
 ### Query device status
@@ -180,6 +180,7 @@ curl -H "X-Readyz-Token: $GOCELL_READYZ_VERBOSE_TOKEN" 'http://localhost:8083/re
 ```bash
 # 1. Register a device
 DEV=$(curl -s -X POST http://localhost:8083/api/v1/devices \
+  -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
   -d '{"name":"sensor-001"}')
 echo "$DEV"
@@ -189,7 +190,7 @@ DEV_ID=$(echo "$DEV" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 CMD=$(curl -s -X POST "http://localhost:8083/api/v1/devices/${DEV_ID}/commands" \
   -H "Authorization: Bearer ${IOT_ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
-  -d '{"payload":"reboot"}')
+  -d '{"commandType":"default","payload":"reboot"}')
 echo "$CMD"
 CMD_ID=$(echo "$CMD" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 

--- a/kernel/governance/rules_consistency.go
+++ b/kernel/governance/rules_consistency.go
@@ -42,14 +42,62 @@ type cellPkgConsts = map[string]pkgConstMap
 // between HTTP contract triggers and outbox emit calls in service files.
 // Contracts under examples/ are excluded — they are illustrative and may
 // not conform to the full governance model.
+//
+// Structured as two phases:
+//
+//  1. Per-cell phase: scan emit topics and run reverse-check unconditionally for
+//     every cell that has HTTP contracts. Also discovers cells that have no HTTP
+//     contracts but do emit — their topics must not be undeclared.
+//
+//  2. Per-contract phase: run constraint-1/2 checks and forward-check (every
+//     declared trigger must appear in the cell's emit set).
+//
+// The per-cell phase runs before the per-contract loop so that reverse-check is
+// never gated on a contract having non-empty triggers.
 func (v *Validator) validateCONTRACTCONSISTENCYEMIT01() []ValidationResult {
+	cellTriggerSets := buildCellTriggerSets(v.project.Contracts)
+	cellEmitSets, perCellResults := v.runPerCellPhase(cellTriggerSets)
+	perContractResults := v.runPerContractPhase(cellEmitSets)
+	return append(perCellResults, perContractResults...)
+}
+
+// runPerCellPhase scans emit topics and runs reverse-checks for all cells with
+// HTTP contracts that have declared triggers. Returns the emit-set cache and findings.
+//
+// Reverse-check only runs for cells that have at least one HTTP contract with
+// non-empty triggers (L2+ contract). A cell whose only HTTP contracts are L0/L1
+// with no triggers is typically event-driven: its emits come from event-subscription
+// handlers, not from HTTP endpoints, and those emits do not need HTTP trigger
+// declarations. Skipping reverse-check for such cells avoids false positives
+// without weakening the forward-check (which still runs per-contract in phase 2).
+func (v *Validator) runPerCellPhase(cellTriggerSets map[string]map[string]struct{}) (
+	map[string]map[string]struct{}, []ValidationResult,
+) {
 	var results []ValidationResult
+	cellEmitSets := map[string]map[string]struct{}{}
 
-	// Pre-compute per-cell declared triggers (union of all HTTP contracts in cell).
-	cellTriggerCache := buildCellTriggerCache(v.project)
-	cellEmitCache := map[string]map[string]struct{}{} // ownerCell → emitted topics
-	reverseChecked := map[string]bool{}
+	for ownerCell, triggerSet := range cellTriggerSets {
+		emits, scanResults := scanCellEmitTopics(v.root, ownerCell, "")
+		results = append(results, scanResults...)
+		cellEmitSets[ownerCell] = emits
+		if len(triggerSet) == 0 {
+			continue // event-driven cell — no HTTP trigger declarations needed
+		}
+		results = append(results, v.checkReverseEmits(ownerCell, emits, triggerSet)...)
+	}
 
+	// Scan cells that have NO HTTP contracts at all but do emit — every emit is unaccounted.
+	for _, ownerCell := range discoverEmittingCellsWithoutHTTPContracts(v.root, cellTriggerSets) {
+		emits, scanResults := scanCellEmitTopics(v.root, ownerCell, "")
+		results = append(results, scanResults...)
+		results = append(results, v.checkReverseEmits(ownerCell, emits, nil)...)
+	}
+	return cellEmitSets, results
+}
+
+// runPerContractPhase runs constraint-1/2 and forward-check for each HTTP contract.
+func (v *Validator) runPerContractPhase(cellEmitSets map[string]map[string]struct{}) []ValidationResult {
+	var results []ValidationResult
 	for _, c := range v.project.Contracts {
 		if cell.ContractKind(c.Kind) != cell.ContractHTTP {
 			continue
@@ -59,16 +107,10 @@ func (v *Validator) validateCONTRACTCONSISTENCYEMIT01() []ValidationResult {
 		}
 		r, skip := v.checkConsistencyConstraints12(c)
 		results = append(results, r...)
-		if skip || len(c.Triggers) == 0 {
+		if skip || len(c.Triggers) == 0 || !isL2OrHigher(c.ConsistencyLevel) {
 			continue
 		}
-		emitTopics, scanResults := lazyLoadEmitTopics(cellEmitCache, c.OwnerCell, v.root, contractFile(c))
-		results = append(results, scanResults...)
-		results = append(results, v.checkForwardTriggers(c, emitTopics)...)
-		if !reverseChecked[c.OwnerCell] {
-			reverseChecked[c.OwnerCell] = true
-			results = append(results, v.checkReverseEmits(c.OwnerCell, emitTopics, cellTriggerCache)...)
-		}
+		results = append(results, v.checkForwardTriggers(c, cellEmitSets[c.OwnerCell])...)
 	}
 	return results
 }
@@ -78,24 +120,101 @@ func isExamplePath(p string) bool {
 	return strings.HasPrefix(p, "examples/")
 }
 
-// buildCellTriggerCache pre-computes per-cell declared triggers for all HTTP contracts.
-func buildCellTriggerCache(project *metadata.ProjectMeta) map[string]map[string]struct{} {
-	cache := map[string]map[string]struct{}{}
-	for _, c := range project.Contracts {
+// buildCellTriggerSets pre-computes per-cell declared triggers for all HTTP contracts.
+// Returns a map of ownerCell → set of declared trigger topic strings.
+func buildCellTriggerSets(contracts map[string]*metadata.ContractMeta) map[string]map[string]struct{} {
+	sets := map[string]map[string]struct{}{}
+	for _, c := range contracts {
 		if cell.ContractKind(c.Kind) != cell.ContractHTTP {
 			continue
 		}
 		if isExamplePath(c.File) || isExamplePath(c.Dir) {
 			continue
 		}
-		if cache[c.OwnerCell] == nil {
-			cache[c.OwnerCell] = map[string]struct{}{}
+		if sets[c.OwnerCell] == nil {
+			sets[c.OwnerCell] = map[string]struct{}{}
 		}
 		for _, t := range c.Triggers {
-			cache[c.OwnerCell][t] = struct{}{}
+			sets[c.OwnerCell][t] = struct{}{}
 		}
 	}
-	return cache
+	return sets
+}
+
+// discoverEmittingCellsWithoutHTTPContracts walks cells/ to find cells that have
+// no HTTP contracts (not in knownCells) but contain outbox.Emit or receiver .Emit
+// calls. Only non-example cells are considered.
+func discoverEmittingCellsWithoutHTTPContracts(root string, knownCells map[string]map[string]struct{}) []string {
+	cellsDir := filepath.Join(root, "cells")
+	entries, err := os.ReadDir(cellsDir)
+	if err != nil {
+		return nil
+	}
+	var extras []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if _, known := knownCells[name]; known {
+			continue
+		}
+		// Skip cells under examples/ paths (cell dir is directly under cells/).
+		slicesDir := filepath.Join(cellsDir, name, "slices")
+		if _, statErr := os.Stat(slicesDir); statErr != nil {
+			continue
+		}
+		if cellHasAnyEmit(slicesDir) {
+			extras = append(extras, name)
+		}
+	}
+	return extras
+}
+
+// cellHasAnyEmit does a quick scan of all non-test Go files under slicesDir to
+// check whether any file contains an outbox.Emit or receiver .Emit call.
+func cellHasAnyEmit(slicesDir string) bool {
+	found := false
+	fset := token.NewFileSet()
+	_ = filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
+		if found || err != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+		if fileHasEmitCall(f) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+// fileHasEmitCall returns true if the file's AST contains any outbox.Emit or
+// receiver .Emit call site.
+func fileHasEmitCall(f *ast.File) bool {
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if (isOutboxEmitCall(call) && len(call.Args) >= 3) ||
+			(isReceiverEmitCall(call) && len(call.Args) >= 2) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 // checkConsistencyConstraints12 validates constraints 1 and 2 for a contract.
@@ -120,19 +239,6 @@ func (v *Validator) checkConsistencyConstraints12(c *metadata.ContractMeta) ([]V
 	return nil, false
 }
 
-// lazyLoadEmitTopics loads or returns cached emit topics for the given cell.
-func lazyLoadEmitTopics(
-	cache map[string]map[string]struct{},
-	ownerCell, root, fileForError string,
-) (map[string]struct{}, []ValidationResult) {
-	if topics, ok := cache[ownerCell]; ok {
-		return topics, nil
-	}
-	topics, results := scanCellEmitTopics(root, ownerCell, fileForError)
-	cache[ownerCell] = topics
-	return topics, results
-}
-
 // checkForwardTriggers validates that each contract trigger appears in emitTopics.
 func (v *Validator) checkForwardTriggers(c *metadata.ContractMeta, emitTopics map[string]struct{}) []ValidationResult {
 	var results []ValidationResult
@@ -149,15 +255,15 @@ func (v *Validator) checkForwardTriggers(c *metadata.ContractMeta, emitTopics ma
 }
 
 // checkReverseEmits validates that each emitted topic appears in declared triggers.
+// declared may be nil when a cell has no HTTP contracts; in that case every emit fails.
 func (v *Validator) checkReverseEmits(
 	ownerCell string,
 	emitTopics map[string]struct{},
-	cellTriggerCache map[string]map[string]struct{},
+	declared map[string]struct{},
 ) []ValidationResult {
 	var results []ValidationResult
-	declaredTriggers := cellTriggerCache[ownerCell]
 	for t := range emitTopics {
-		if _, found := declaredTriggers[t]; !found {
+		if _, found := declared[t]; !found {
 			results = append(results, v.newScopedResult(
 				codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
 				"project", "triggers",
@@ -171,11 +277,17 @@ func (v *Validator) checkReverseEmits(
 // scanCellEmitTopics scans all non-test Go files under cells/<ownerCell>/slices/
 // and returns the set of resolvable topic strings emitted by the cell.
 //
-// Resolution strategy:
+// Resolution strategy (in order of precision):
 //  1. outbox.Emit(ctx, emitter, TOPIC, ...) — third arg resolved if literal or const;
 //     call expressions → dynamic-topic error.
 //  2. EventType: EXPR in outbox.Entry composite literals — resolved if literal or const.
-//  3. All dto/domain TopicXxx selectors anywhere in the file — catches indirect helper patterns.
+//  3. Pre-assigned entry variable passed to receiver Emit — walk back assignments.
+//  4. Same-package helper: if a function calls helper(ctx, dto.TopicX) and helper's body
+//     emits via outbox.Emit(ctx, e, topicParam, ...) where topicParam is the matching
+//     parameter, resolve via the call-site argument expression.
+//
+// Topic selectors in subscriber/comparison contexts are NOT collected — only
+// direct emit call evidence counts.
 func scanCellEmitTopics(root, ownerCell, fileForError string) (map[string]struct{}, []ValidationResult) {
 	topics := map[string]struct{}{}
 	var results []ValidationResult
@@ -188,85 +300,478 @@ func scanCellEmitTopics(root, ownerCell, fileForError string) (map[string]struct
 	}
 
 	fset := token.NewFileSet()
-	_ = filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
-		return scanSliceFile(path, d, err, fset, pkgConsts, fileForError, root, topics, &results)
-	})
+
+	// Two-pass approach: first collect all function declarations across all files
+	// so that helper resolution can reference them, then scan for emits.
+	allFiles := collectParsedFiles(fset, slicesDir)
+	helperMap := buildHelperEmitMap(allFiles, pkgConsts)
+
+	for _, f := range allFiles {
+		scanResults := scanFileForEmits(f, fset, pkgConsts, helperMap, fileForError, root, topics)
+		results = append(results, scanResults...)
+	}
 	return topics, results
 }
 
-// scanSliceFile is the WalkDir callback body for scanCellEmitTopics.
-// It skips directories, test files, and unparseable files; for each non-test
-// Go file it runs emit scanning and, only when emit calls are found, also
-// collects selector-based topic hints.
-func scanSliceFile(
-	path string, d fs.DirEntry, err error,
-	fset *token.FileSet,
-	pkgConsts cellPkgConsts,
-	fileForError, root string,
-	topics map[string]struct{},
-	results *[]ValidationResult,
-) error {
-	if err != nil {
-		return nil
-	}
-	if d.IsDir() {
-		if n := d.Name(); n == "mem" || n == "testdata" {
-			return filepath.SkipDir
+// parsedFile wraps a parsed AST file for use in the two-pass emit scan.
+type parsedFile struct {
+	ast *ast.File
+}
+
+// collectParsedFiles walks slicesDir and parses all non-test Go files,
+// returning their ASTs paired with file-level const maps.
+func collectParsedFiles(fset *token.FileSet, slicesDir string) []parsedFile {
+	var files []parsedFile
+	_ = filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
 		}
+		if d.IsDir() {
+			if n := d.Name(); n == "mem" || n == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+		files = append(files, parsedFile{ast: f})
 		return nil
+	})
+	return files
+}
+
+// helperEmitFunc describes a same-package helper function whose body contains a
+// single outbox.Emit call where the topic comes from one of its parameters.
+type helperEmitFunc struct {
+	// paramIndex is the 0-based index of the parameter that carries the topic.
+	paramIndex int
+}
+
+// buildHelperEmitMap scans all files to find functions and methods that:
+//   - have ≥1 parameter
+//   - contain an outbox.Emit call (or receiver emit via outbox.Entry{EventType:param})
+//     whose topic comes from one of the function/method's parameters (not a const)
+//
+// Returns map of funcName → helperEmitFunc.
+// Both plain functions and methods are included (keyed by bare name).
+// Only one-topic-from-param functions/methods are supported (first match wins).
+// Two-level chains are handled: if a function/method calls another helper whose
+// body emits and that helper is also in the map, the caller is also registered.
+func buildHelperEmitMap(files []parsedFile, pkgConsts cellPkgConsts) map[string]helperEmitFunc {
+	helpers := map[string]helperEmitFunc{}
+	// First pass: direct emitters (outbox.Emit or receiver emit with entry var).
+	registerDirectEmitters(files, pkgConsts, helpers)
+	// Second pass: transitive callers — functions/methods that call a known helper.
+	registerTransitiveCallers(files, pkgConsts, helpers)
+	return helpers
+}
+
+// registerDirectEmitters adds all functions/methods whose body directly emits
+// (via outbox.Emit or receiver emit with entry var) using a parameter as the topic.
+func registerDirectEmitters(files []parsedFile, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
+	for _, pf := range files {
+		scanFuncDeclsForDirectEmit(pf.ast.Decls, pkgConsts, helpers)
 	}
-	if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-		return nil
+}
+
+// scanFuncDeclsForDirectEmit processes a list of declarations looking for
+// direct-emit helper functions.
+func scanFuncDeclsForDirectEmit(decls []ast.Decl, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
+	for _, decl := range decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Body == nil || fn.Type.Params == nil {
+			continue
+		}
+		paramNames := funcParamNames(fn)
+		if len(paramNames) == 0 {
+			continue
+		}
+		if idx, found := findHelperTopicParamIndex(fn.Body, paramNames, pkgConsts); found {
+			helpers[fn.Name.Name] = helperEmitFunc{paramIndex: idx}
+		}
 	}
-	f, parseErr := parser.ParseFile(fset, path, nil, 0)
-	if parseErr != nil {
-		return nil
+}
+
+// registerTransitiveCallers adds functions/methods that call a known helper and
+// pass one of their own parameters as the helper's topic argument.
+func registerTransitiveCallers(files []parsedFile, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
+	for _, pf := range files {
+		scanFuncDeclsForTransitive(pf.ast.Decls, pkgConsts, helpers)
 	}
-	fileConsts := collectFileConsts(f, pkgConsts)
-	scanResults, hasEmit := scanFileForEmits(f, fset, pkgConsts, fileConsts, fileForError, root, topics)
-	*results = append(*results, scanResults...)
-	// Only collect topic selectors from files that contain real emit calls.
-	// Restricting to emit-call files prevents subscriber topic constants
-	// (e.g. in subscribe(ctx, dto.TopicX, handler)) from being counted as
-	// emit evidence, which would cause false-negatives in the reverse check.
-	if hasEmit {
-		collectAllTopicSelectors(f, pkgConsts, topics)
+}
+
+// scanFuncDeclsForTransitive processes a list of declarations looking for
+// transitive-emit helper functions.
+func scanFuncDeclsForTransitive(decls []ast.Decl, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
+	for _, decl := range decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Body == nil || fn.Type.Params == nil {
+			continue
+		}
+		if _, already := helpers[fn.Name.Name]; already {
+			continue
+		}
+		paramNames := funcParamNames(fn)
+		if len(paramNames) == 0 {
+			continue
+		}
+		if idx, found := findTransitiveHelperParamIndex(fn.Body, paramNames, pkgConsts, helpers); found {
+			helpers[fn.Name.Name] = helperEmitFunc{paramIndex: idx}
+		}
 	}
-	return nil
+}
+
+// funcParamNames returns the ordered list of parameter names for a FuncDecl.
+func funcParamNames(fn *ast.FuncDecl) []string {
+	var names []string
+	for _, field := range fn.Type.Params.List {
+		for _, n := range field.Names {
+			names = append(names, n.Name)
+		}
+	}
+	return names
+}
+
+// findHelperTopicParamIndex inspects a function/method body for emit evidence
+// where the topic comes from one of the function's parameters.
+//
+// Patterns detected:
+//  1. outbox.Emit(ctx, e, topicParam, ...) where topicParam ∈ paramNames.
+//  2. entry := outbox.Entry{EventType: eventTypeParam, ...}; recv.Emit(ctx, entry)
+//     where eventTypeParam ∈ paramNames.
+//
+// Returns the matching parameter index and true on first match found.
+func findHelperTopicParamIndex(body *ast.BlockStmt, paramNames []string, pkgConsts cellPkgConsts) (int, bool) {
+	// Pattern 1: outbox.Emit(ctx, e, topicParam, ...).
+	if idx, found := findOutboxEmitTopicParam(body, paramNames, pkgConsts); found {
+		return idx, true
+	}
+	// Pattern 2: entry := outbox.Entry{EventType: param}; recv.Emit(ctx, entry).
+	return findReceiverEmitViaEntryParam(body, paramNames, pkgConsts)
+}
+
+// findOutboxEmitTopicParam checks if the body contains outbox.Emit(ctx, e, topicParam, ...)
+// where topicParam is a parameter identifier. Returns the parameter index on match.
+func findOutboxEmitTopicParam(body *ast.BlockStmt, paramNames []string, pkgConsts cellPkgConsts) (int, bool) {
+	dummyConsts := pkgConstMap{}
+	var foundIdx int
+	var found bool
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isOutboxEmitCall(call) || len(call.Args) < 3 {
+			return true
+		}
+		topicArg := call.Args[2]
+		ident, ok := topicArg.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if _, resolved := resolveTopicExpr(topicArg, pkgConsts, dummyConsts); resolved {
+			return true // const — direct resolution handles it
+		}
+		for i, p := range paramNames {
+			if ident.Name == p {
+				foundIdx = i
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return foundIdx, found
+}
+
+// findReceiverEmitViaEntryParam checks if the body contains:
+//
+//	entry := outbox.Entry{EventType: paramIdent, ...}
+//	recv.Emit(ctx, entry)
+//
+// where paramIdent is one of paramNames. Returns the parameter index on match.
+func findReceiverEmitViaEntryParam(body *ast.BlockStmt, paramNames []string, pkgConsts cellPkgConsts) (int, bool) {
+	entryVarToParamIdx := collectEntryVarBindings(body, paramNames, pkgConsts)
+	if len(entryVarToParamIdx) == 0 {
+		return 0, false
+	}
+	return findReceiverEmitWithEntry(body, entryVarToParamIdx)
+}
+
+// collectEntryVarBindings finds all `varName := outbox.Entry{EventType: paramIdent}`
+// assignments where paramIdent is one of paramNames, and returns varName → paramIndex.
+func collectEntryVarBindings(body *ast.BlockStmt, paramNames []string, pkgConsts cellPkgConsts) map[string]int {
+	dummyConsts := pkgConstMap{}
+	bindings := map[string]int{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		stmt, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		collectEntryBindingsFromAssign(stmt, paramNames, pkgConsts, dummyConsts, bindings)
+		return true
+	})
+	return bindings
+}
+
+// collectEntryBindingsFromAssign inspects a single assignment statement for
+// outbox.Entry{EventType: paramIdent} patterns.
+func collectEntryBindingsFromAssign(
+	stmt *ast.AssignStmt,
+	paramNames []string,
+	pkgConsts cellPkgConsts,
+	dummyConsts pkgConstMap,
+	bindings map[string]int,
+) {
+	for i, lhs := range stmt.Lhs {
+		lhsIdent, ok := lhs.(*ast.Ident)
+		if !ok || i >= len(stmt.Rhs) {
+			continue
+		}
+		compLit, ok := stmt.Rhs[i].(*ast.CompositeLit)
+		if !ok || !isOutboxEntryType(compLit) {
+			continue
+		}
+		if pi, found := findEventTypeParamInCompLit(compLit, paramNames, pkgConsts, dummyConsts); found {
+			bindings[lhsIdent.Name] = pi
+		}
+	}
+}
+
+// findEventTypeParamInCompLit looks for EventType: paramIdent in a composite literal,
+// returning the index of the matching parameter name.
+func findEventTypeParamInCompLit(
+	compLit *ast.CompositeLit,
+	paramNames []string,
+	pkgConsts cellPkgConsts,
+	dummyConsts pkgConstMap,
+) (int, bool) {
+	for _, elt := range compLit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "EventType" {
+			continue
+		}
+		valIdent, ok := kv.Value.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if _, resolved := resolveTopicExpr(kv.Value, pkgConsts, dummyConsts); resolved {
+			continue // const — not from param
+		}
+		for pi, p := range paramNames {
+			if valIdent.Name == p {
+				return pi, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// findReceiverEmitWithEntry checks for recv.Emit(ctx, entryVar) where entryVar
+// is a key in entryVarToParamIdx. Returns the matching parameter index.
+func findReceiverEmitWithEntry(body *ast.BlockStmt, entryVarToParamIdx map[string]int) (int, bool) {
+	var foundIdx int
+	var found bool
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isReceiverEmitCall(call) || len(call.Args) < 2 {
+			return true
+		}
+		entryArg, ok := call.Args[1].(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if pi, ok := entryVarToParamIdx[entryArg.Name]; ok {
+			foundIdx = pi
+			found = true
+		}
+		return !found
+	})
+	return foundIdx, found
+}
+
+// isOutboxEntryType checks whether a composite literal is (or looks like) outbox.Entry.
+// We use a heuristic: the type is either a selector "outbox.Entry" or we check for
+// the presence of an EventType field (since we can't resolve imports in stdlib-only mode).
+func isOutboxEntryType(compLit *ast.CompositeLit) bool {
+	if compLit.Type == nil {
+		return false
+	}
+	sel, ok := compLit.Type.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return pkg.Name == "outbox" && sel.Sel.Name == "Entry"
+}
+
+// findTransitiveHelperParamIndex detects functions/methods that call a known helper
+// (from the helpers map) and pass one of their own parameters as the topic arg.
+// Returns the parameter index in the current function and true on first match.
+func findTransitiveHelperParamIndex(
+	body *ast.BlockStmt,
+	paramNames []string,
+	pkgConsts cellPkgConsts,
+	helpers map[string]helperEmitFunc,
+) (int, bool) {
+	dummyConsts := pkgConstMap{}
+	var foundIdx int
+	var found bool
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		idx, ok := resolveTransitiveTopicParam(call, paramNames, pkgConsts, dummyConsts, helpers)
+		if ok {
+			foundIdx = idx
+			found = true
+		}
+		return !found
+	})
+	return foundIdx, found
+}
+
+// resolveTransitiveTopicParam checks if the call is to a known helper and whether
+// one of the caller's paramNames is passed as the helper's topic argument.
+func resolveTransitiveTopicParam(
+	call *ast.CallExpr,
+	paramNames []string,
+	pkgConsts cellPkgConsts,
+	dummyConsts pkgConstMap,
+	helpers map[string]helperEmitFunc,
+) (int, bool) {
+	calledName := resolveCallName(call)
+	if calledName == "" {
+		return 0, false
+	}
+	helper, ok := helpers[calledName]
+	if !ok || helper.paramIndex >= len(call.Args) {
+		return 0, false
+	}
+	topicArg := call.Args[helper.paramIndex]
+	ident, ok := topicArg.(*ast.Ident)
+	if !ok {
+		return 0, false
+	}
+	if _, resolved := resolveTopicExpr(topicArg, pkgConsts, dummyConsts); resolved {
+		return 0, false // const — handled by direct scan
+	}
+	for i, p := range paramNames {
+		if ident.Name == p {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// resolveCallName extracts the bare function/method name from a call expression.
+// For ident calls (foo(...)), returns "foo".
+// For selector calls (s.foo(...) or pkg.foo(...)), returns "foo".
+// Returns "" for complex call expressions.
+func resolveCallName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	}
+	return ""
 }
 
 // scanFileForEmits walks a single parsed file's AST and collects emitted topics.
-// Returns the validation results and a boolean indicating whether the file
-// contained at least one real emit call site (outbox.Emit or receiver *.Emit).
+// It returns validation results for dynamic-topic errors.
+// Emit evidence is exclusively from:
+//   - outbox.Emit(ctx, e, TOPIC, ...) direct calls
+//   - receiver.Emit(ctx, outbox.Entry{EventType: TOPIC}) inline composite
+//   - receiver.Emit(ctx, entryVar) where entryVar was assigned outbox.Entry{EventType:...}
+//   - helper(ctx, dto.TopicX) calls where helper's body emits via topicParam
 func scanFileForEmits(
-	f *ast.File,
+	pf parsedFile,
 	fset *token.FileSet,
 	pkgConsts cellPkgConsts,
-	fileConsts pkgConstMap,
+	helperMap map[string]helperEmitFunc,
 	fileForError string,
 	root string,
 	topics map[string]struct{},
-) ([]ValidationResult, bool) {
+) []ValidationResult {
+	f := pf.ast
+	fileConsts := collectFileConsts(f, pkgConsts)
 	var results []ValidationResult
-	var hasEmit bool
 	ast.Inspect(f, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
+
+		// outbox.Emit(ctx, emitter, TOPIC, payload) — direct call.
 		if isOutboxEmitCall(call) && len(call.Args) >= 3 {
-			hasEmit = true
 			r := collectOutboxEmitTopic(call, fset, pkgConsts, fileConsts, fileForError, root, topics)
 			results = append(results, r...)
 			return true
 		}
+
+		// receiver.Emit(ctx, entry) — receiver-style emit.
 		if isReceiverEmitCall(call) && len(call.Args) >= 2 {
-			hasEmit = true
 			collectReceiverEmitTopics(call.Args[1], f, pkgConsts, fileConsts, topics)
+			return true
 		}
+
+		// helper(args...) — check if this is a known same-package helper.
+		collectHelperCallTopics(call, f, pkgConsts, fileConsts, helperMap, topics)
 		return true
 	})
-	return results, hasEmit
+	return results
+}
+
+// collectHelperCallTopics checks whether call is a call to a known helper function
+// or method that emits via a topic parameter, and if so resolves the topic from
+// the call-site argument.
+//
+// Handles both plain function calls (helper(...)) and receiver/selector method
+// calls (s.method(...), pkg.Func(...)). The helper map is keyed by bare name
+// so we match on the last segment (method name) regardless of receiver type.
+func collectHelperCallTopics(
+	call *ast.CallExpr,
+	f *ast.File,
+	pkgConsts cellPkgConsts,
+	fileConsts pkgConstMap,
+	helperMap map[string]helperEmitFunc,
+	topics map[string]struct{},
+) {
+	calledName := resolveCallName(call)
+	if calledName == "" {
+		return
+	}
+	helper, ok := helperMap[calledName]
+	if !ok {
+		return
+	}
+	if helper.paramIndex >= len(call.Args) {
+		return
+	}
+	topicArg := call.Args[helper.paramIndex]
+	if topic, resolved := resolveTopicExpr(topicArg, pkgConsts, fileConsts); resolved {
+		topics[topic] = struct{}{}
+	}
 }
 
 // collectOutboxEmitTopic extracts the topic from outbox.Emit third arg.
@@ -584,31 +1089,4 @@ func extractEventTypeFromCompLit(compLit *ast.CompositeLit, pkgConsts cellPkgCon
 		return resolveTopicExpr(kv.Value, pkgConsts, fileConsts)
 	}
 	return "", false
-}
-
-// collectAllTopicSelectors scans the file for dto/domain TopicXxx selectors
-// and adds resolvable ones to topics. This handles indirect patterns where
-// topics are passed to helper methods rather than used directly in emit calls.
-//
-// Only dto/domain package qualifiers are collected; file-level string constants
-// are intentionally excluded to avoid treating subscriber topic constants as emits.
-func collectAllTopicSelectors(f *ast.File, pkgConsts cellPkgConsts, topics map[string]struct{}) {
-	ast.Inspect(f, func(n ast.Node) bool {
-		sel, ok := n.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		ident, ok := sel.X.(*ast.Ident)
-		if !ok {
-			return true
-		}
-		if (ident.Name == "dto" || ident.Name == "domain") && strings.HasPrefix(sel.Sel.Name, "Topic") {
-			if pkgMap, ok := pkgConsts[ident.Name]; ok {
-				if val, ok := pkgMap[sel.Sel.Name]; ok {
-					topics[val] = struct{}{}
-				}
-			}
-		}
-		return true
-	})
 }

--- a/kernel/governance/rules_consistency.go
+++ b/kernel/governance/rules_consistency.go
@@ -1,0 +1,579 @@
+package governance
+
+// Rule CONTRACT-CONSISTENCY-EMIT-01 validates bidirectional alignment between
+// HTTP contract triggers and outbox.Emit calls in the owning cell's service files.
+//
+// Three constraints:
+//  1. L2+ HTTP contract without triggers → Error (triggers required)
+//  2. Triggers present but consistencyLevel ∈ {L0, L1} → Error (level mismatch)
+//  3. Bidirectional AST check: every trigger must appear in a resolvable emit
+//     call somewhere in the cell's slice service files, and every resolvable
+//     emit call topic must be covered by a trigger in some HTTP contract of the
+//     same cell.
+//
+// ref: tools/archtest/outbox_service_test.go — same-package const propagation
+// ref: golang.org/x/tools/go/analysis/passes/nilness rule discipline
+// Stdlib go/ast only — kernel/ cannot import golang.org/x/tools/go/packages.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+const codeContractConsistencyEmit01 = "CONTRACT-CONSISTENCY-EMIT-01"
+
+// pkgConstMap maps constName → stringValue for a single package.
+type pkgConstMap = map[string]string
+
+// cellPkgConsts maps pkgIdent ("dto" or "domain") → pkgConstMap.
+type cellPkgConsts = map[string]pkgConstMap
+
+// validateCONTRACTCONSISTENCYEMIT01 checks three consistency constraints
+// between HTTP contract triggers and outbox emit calls in service files.
+// Contracts under examples/ are excluded — they are illustrative and may
+// not conform to the full governance model.
+func (v *Validator) validateCONTRACTCONSISTENCYEMIT01() []ValidationResult {
+	var results []ValidationResult
+
+	// Pre-compute per-cell declared triggers (union of all HTTP contracts in cell).
+	cellTriggerCache := buildCellTriggerCache(v.project)
+	cellEmitCache := map[string]map[string]struct{}{} // ownerCell → emitted topics
+	reverseChecked := map[string]bool{}
+
+	for _, c := range v.project.Contracts {
+		if cell.ContractKind(c.Kind) != cell.ContractHTTP {
+			continue
+		}
+		if isExamplePath(c.File) || isExamplePath(c.Dir) {
+			continue
+		}
+		r, skip := v.checkConsistencyConstraints12(c)
+		results = append(results, r...)
+		if skip || len(c.Triggers) == 0 {
+			continue
+		}
+		emitTopics, scanResults := lazyLoadEmitTopics(cellEmitCache, c.OwnerCell, v.root, contractFile(c))
+		results = append(results, scanResults...)
+		results = append(results, v.checkForwardTriggers(c, emitTopics)...)
+		if !reverseChecked[c.OwnerCell] {
+			reverseChecked[c.OwnerCell] = true
+			results = append(results, v.checkReverseEmits(c.OwnerCell, emitTopics, cellTriggerCache)...)
+		}
+	}
+	return results
+}
+
+// isExamplePath returns true if the path is under an examples/ subtree.
+func isExamplePath(p string) bool {
+	return strings.HasPrefix(p, "examples/")
+}
+
+// buildCellTriggerCache pre-computes per-cell declared triggers for all HTTP contracts.
+func buildCellTriggerCache(project *metadata.ProjectMeta) map[string]map[string]struct{} {
+	cache := map[string]map[string]struct{}{}
+	for _, c := range project.Contracts {
+		if cell.ContractKind(c.Kind) != cell.ContractHTTP {
+			continue
+		}
+		if isExamplePath(c.File) || isExamplePath(c.Dir) {
+			continue
+		}
+		if cache[c.OwnerCell] == nil {
+			cache[c.OwnerCell] = map[string]struct{}{}
+		}
+		for _, t := range c.Triggers {
+			cache[c.OwnerCell][t] = struct{}{}
+		}
+	}
+	return cache
+}
+
+// checkConsistencyConstraints12 validates constraints 1 and 2 for a contract.
+// Returns results and whether the caller should skip further checks for this contract.
+func (v *Validator) checkConsistencyConstraints12(c *metadata.ContractMeta) ([]ValidationResult, bool) {
+	// Constraint 1: L2+ HTTP contract must have non-empty triggers.
+	if isL2OrHigher(c.ConsistencyLevel) && len(c.Triggers) == 0 {
+		return []ValidationResult{v.newResult(
+			codeContractConsistencyEmit01, SeverityError, IssueRequired,
+			contractFile(c), "triggers",
+			fmt.Sprintf("contract %q: L2+ HTTP contract must declare non-empty triggers (matches outbox.Emit topics)", c.ID),
+		)}, true
+	}
+	// Constraint 2: triggers present but level ∈ {L0, L1}.
+	if len(c.Triggers) > 0 && !isL2OrHigher(c.ConsistencyLevel) {
+		return []ValidationResult{v.newResult(
+			codeContractConsistencyEmit01, SeverityError, IssueMismatch,
+			contractFile(c), "triggers",
+			fmt.Sprintf("contract %q declares triggers but consistencyLevel=%s; triggers imply L2+", c.ID, c.ConsistencyLevel),
+		)}, true
+	}
+	return nil, false
+}
+
+// lazyLoadEmitTopics loads or returns cached emit topics for the given cell.
+func lazyLoadEmitTopics(
+	cache map[string]map[string]struct{},
+	ownerCell, root, fileForError string,
+) (map[string]struct{}, []ValidationResult) {
+	if topics, ok := cache[ownerCell]; ok {
+		return topics, nil
+	}
+	topics, results := scanCellEmitTopics(root, ownerCell, fileForError)
+	cache[ownerCell] = topics
+	return topics, results
+}
+
+// checkForwardTriggers validates that each contract trigger appears in emitTopics.
+func (v *Validator) checkForwardTriggers(c *metadata.ContractMeta, emitTopics map[string]struct{}) []ValidationResult {
+	var results []ValidationResult
+	for _, t := range c.Triggers {
+		if _, found := emitTopics[t]; !found {
+			results = append(results, v.newResult(
+				codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
+				contractFile(c), "triggers",
+				fmt.Sprintf("contract %q declares trigger %q but no service.go in cell %s emits it", c.ID, t, c.OwnerCell),
+			))
+		}
+	}
+	return results
+}
+
+// checkReverseEmits validates that each emitted topic appears in declared triggers.
+func (v *Validator) checkReverseEmits(
+	ownerCell string,
+	emitTopics map[string]struct{},
+	cellTriggerCache map[string]map[string]struct{},
+) []ValidationResult {
+	var results []ValidationResult
+	declaredTriggers := cellTriggerCache[ownerCell]
+	for t := range emitTopics {
+		if _, found := declaredTriggers[t]; !found {
+			results = append(results, v.newScopedResult(
+				codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
+				"project", "triggers",
+				fmt.Sprintf("service emits topic %q but no HTTP contract in cell %s declares it in triggers", t, ownerCell),
+			))
+		}
+	}
+	return results
+}
+
+// scanCellEmitTopics scans all non-test Go files under cells/<ownerCell>/slices/
+// and returns the set of resolvable topic strings emitted by the cell.
+//
+// Resolution strategy:
+//  1. outbox.Emit(ctx, emitter, TOPIC, ...) — third arg resolved if literal or const;
+//     call expressions → dynamic-topic error.
+//  2. EventType: EXPR in outbox.Entry composite literals — resolved if literal or const.
+//  3. All dto/domain TopicXxx selectors anywhere in the file — catches indirect helper patterns.
+func scanCellEmitTopics(root, ownerCell, fileForError string) (map[string]struct{}, []ValidationResult) {
+	topics := map[string]struct{}{}
+	var results []ValidationResult
+
+	cellDir := filepath.Join(root, "cells", ownerCell)
+	pkgConsts := buildPkgConsts(cellDir)
+	slicesDir := filepath.Join(cellDir, "slices")
+	if _, err := os.Stat(slicesDir); err != nil {
+		return topics, results
+	}
+
+	fset := token.NewFileSet()
+	_ = filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if n := d.Name(); n == "mem" || n == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+		fileConsts := collectFileConsts(f, pkgConsts)
+		scanResults := scanFileForEmits(f, fset, pkgConsts, fileConsts, fileForError, topics)
+		results = append(results, scanResults...)
+		collectAllTopicSelectors(f, pkgConsts, topics)
+		return nil
+	})
+	return topics, results
+}
+
+// scanFileForEmits walks a single parsed file's AST and collects emitted topics.
+func scanFileForEmits(
+	f *ast.File,
+	fset *token.FileSet,
+	pkgConsts cellPkgConsts,
+	fileConsts pkgConstMap,
+	fileForError string,
+	topics map[string]struct{},
+) []ValidationResult {
+	var results []ValidationResult
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isOutboxEmitCall(call) && len(call.Args) >= 3 {
+			r := collectOutboxEmitTopic(call, fset, pkgConsts, fileConsts, fileForError, topics)
+			results = append(results, r...)
+			return true
+		}
+		if isReceiverEmitCall(call) && len(call.Args) >= 2 {
+			collectReceiverEmitTopics(call.Args[1], f, pkgConsts, fileConsts, topics)
+		}
+		return true
+	})
+	return results
+}
+
+// collectOutboxEmitTopic extracts the topic from outbox.Emit third arg.
+// Appends to topics on success; returns a dynamic-topic error on call expressions.
+func collectOutboxEmitTopic(
+	call *ast.CallExpr,
+	fset *token.FileSet,
+	pkgConsts cellPkgConsts,
+	fileConsts pkgConstMap,
+	fileForError string,
+	topics map[string]struct{},
+) []ValidationResult {
+	topicExpr := call.Args[2]
+	topic, resolved := resolveTopicExpr(topicExpr, pkgConsts, fileConsts)
+	if resolved {
+		topics[topic] = struct{}{}
+		return nil
+	}
+	if isDynamicExpr(topicExpr) {
+		pos := fset.Position(call.Pos())
+		return []ValidationResult{{
+			Code:      codeContractConsistencyEmit01,
+			Severity:  SeverityError,
+			IssueType: IssueInvalid,
+			File:      fileForError,
+			Field:     "triggers",
+			Message: fmt.Sprintf(
+				"dynamic topic in emit not allowed at %s:%d; topic must be string literal or named constant",
+				pos.Filename, pos.Line,
+			),
+		}}
+	}
+	return nil
+}
+
+// collectReceiverEmitTopics resolves topics from a receiver-style Emit call.
+func collectReceiverEmitTopics(
+	entryArg ast.Expr,
+	f *ast.File,
+	pkgConsts cellPkgConsts,
+	fileConsts pkgConstMap,
+	topics map[string]struct{},
+) {
+	for _, t := range extractEntryTopics(entryArg, f, pkgConsts, fileConsts) {
+		topics[t] = struct{}{}
+	}
+}
+
+// buildPkgConsts scans internal/dto and internal/domain under cellDir
+// for string constants and returns a map of pkgIdent → constName → stringValue.
+func buildPkgConsts(cellDir string) cellPkgConsts {
+	pkgConsts := cellPkgConsts{}
+	for _, sub := range []string{"internal/dto", "internal/domain"} {
+		dir := filepath.Join(cellDir, sub)
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+		parts := strings.Split(sub, "/")
+		pkgIdent := parts[len(parts)-1]
+		if pkgConsts[pkgIdent] == nil {
+			pkgConsts[pkgIdent] = pkgConstMap{}
+		}
+		parseGoDir(dir, pkgConsts[pkgIdent])
+	}
+	return pkgConsts
+}
+
+// parseGoDir parses all non-test Go files in dir and extracts string const declarations.
+func parseGoDir(dir string, consts pkgConstMap) {
+	fset := token.NewFileSet()
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+		extractStringConsts(f, consts)
+		return nil
+	})
+}
+
+// extractStringConsts walks a parsed file and adds string const declarations to consts.
+func extractStringConsts(f *ast.File, consts pkgConstMap) {
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.CONST {
+			continue
+		}
+		extractStringConstsFromGenDecl(genDecl, consts)
+	}
+}
+
+// extractStringConstsFromGenDecl extracts string const values from a single GenDecl.
+func extractStringConstsFromGenDecl(genDecl *ast.GenDecl, consts pkgConstMap) {
+	for _, spec := range genDecl.Specs {
+		vspec, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		extractStringConstsFromSpec(vspec, consts)
+	}
+}
+
+// extractStringConstsFromSpec extracts string const values from a single ValueSpec.
+func extractStringConstsFromSpec(vspec *ast.ValueSpec, consts pkgConstMap) {
+	for i, name := range vspec.Names {
+		if i >= len(vspec.Values) {
+			continue
+		}
+		lit, ok := vspec.Values[i].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			continue
+		}
+		if val, err := strconv.Unquote(lit.Value); err == nil {
+			consts[name.Name] = val
+		}
+	}
+}
+
+// collectFileConsts gathers const declarations from a single parsed file,
+// resolving alias consts like: const TopicX = dto.TopicX.
+func collectFileConsts(f *ast.File, pkgConsts cellPkgConsts) pkgConstMap {
+	fileConsts := pkgConstMap{}
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			collectFileConstSpec(spec, pkgConsts, fileConsts)
+		}
+	}
+	return fileConsts
+}
+
+// collectFileConstSpec resolves a single const spec value.
+func collectFileConstSpec(spec ast.Spec, pkgConsts cellPkgConsts, fileConsts pkgConstMap) {
+	vspec, ok := spec.(*ast.ValueSpec)
+	if !ok {
+		return
+	}
+	for i, name := range vspec.Names {
+		if i >= len(vspec.Values) {
+			continue
+		}
+		val := resolveConstValue(vspec.Values[i], pkgConsts)
+		if val != "" {
+			fileConsts[name.Name] = val
+		}
+	}
+}
+
+// resolveConstValue extracts the string value of a const expression.
+func resolveConstValue(expr ast.Expr, pkgConsts cellPkgConsts) string {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		if v.Kind == token.STRING {
+			if val, err := strconv.Unquote(v.Value); err == nil {
+				return val
+			}
+		}
+	case *ast.SelectorExpr:
+		if ident, ok := v.X.(*ast.Ident); ok {
+			if pkgMap, ok := pkgConsts[ident.Name]; ok {
+				return pkgMap[v.Sel.Name] // "" if not found
+			}
+		}
+	}
+	return ""
+}
+
+// resolveTopicExpr resolves an AST expression to a string topic value.
+// Returns ("", false) if unresolvable (not a dynamic/call expression).
+func resolveTopicExpr(expr ast.Expr, pkgConsts cellPkgConsts, fileConsts pkgConstMap) (string, bool) {
+	if val, ok := resolveBasicLit(expr); ok {
+		return val, true
+	}
+	if val, ok := resolveSelectorExpr(expr, pkgConsts); ok {
+		return val, true
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		if val, ok := fileConsts[ident.Name]; ok {
+			return val, true
+		}
+	}
+	return "", false
+}
+
+// resolveBasicLit extracts the string value from a BasicLit expression.
+func resolveBasicLit(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	val, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return val, true
+}
+
+// resolveSelectorExpr resolves a pkg.Const selector expression using pkgConsts.
+func resolveSelectorExpr(expr ast.Expr, pkgConsts cellPkgConsts) (string, bool) {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	pkgMap, ok := pkgConsts[ident.Name]
+	if !ok {
+		return "", false
+	}
+	val, ok := pkgMap[sel.Sel.Name]
+	return val, ok
+}
+
+// isDynamicExpr returns true if the expression is a call expression (fmt.Sprintf etc.).
+func isDynamicExpr(expr ast.Expr) bool {
+	_, isCall := expr.(*ast.CallExpr)
+	return isCall
+}
+
+// isOutboxEmitCall returns true if the call is outbox.Emit(...).
+func isOutboxEmitCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Emit" {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == "outbox"
+}
+
+// isReceiverEmitCall returns true if the call matches <receiver>.Emit(...)
+// where the receiver is not "outbox" package.
+func isReceiverEmitCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Emit" {
+		return false
+	}
+	if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "outbox" {
+		return false
+	}
+	return true
+}
+
+// extractEntryTopics resolves the EventType from the entry argument of a receiver Emit call.
+// Handles both inline composite literals and pre-assigned entry variables.
+func extractEntryTopics(entryArg ast.Expr, f *ast.File, pkgConsts cellPkgConsts, fileConsts pkgConstMap) []string {
+	if compLit, ok := entryArg.(*ast.CompositeLit); ok {
+		topic, found := extractEventTypeFromCompLit(compLit, pkgConsts, fileConsts)
+		if found {
+			return []string{topic}
+		}
+		return nil
+	}
+	ident, ok := entryArg.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	return findEntryTopicsFromIdent(ident.Name, f, pkgConsts, fileConsts)
+}
+
+// findEntryTopicsFromIdent searches the file AST for assignments to the given
+// identifier and resolves their EventType fields.
+func findEntryTopicsFromIdent(name string, f *ast.File, pkgConsts cellPkgConsts, fileConsts pkgConstMap) []string {
+	var topics []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		stmt, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range stmt.Lhs {
+			lhsIdent, ok := lhs.(*ast.Ident)
+			if !ok || lhsIdent.Name != name || i >= len(stmt.Rhs) {
+				continue
+			}
+			if compLit, ok := stmt.Rhs[i].(*ast.CompositeLit); ok {
+				if topic, found := extractEventTypeFromCompLit(compLit, pkgConsts, fileConsts); found {
+					topics = append(topics, topic)
+				}
+			}
+		}
+		return true
+	})
+	return topics
+}
+
+// extractEventTypeFromCompLit finds the EventType field in a composite literal.
+func extractEventTypeFromCompLit(compLit *ast.CompositeLit, pkgConsts cellPkgConsts, fileConsts pkgConstMap) (string, bool) {
+	for _, elt := range compLit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "EventType" {
+			continue
+		}
+		return resolveTopicExpr(kv.Value, pkgConsts, fileConsts)
+	}
+	return "", false
+}
+
+// collectAllTopicSelectors scans the file for dto/domain TopicXxx selectors
+// and adds resolvable ones to topics. This handles indirect patterns where
+// topics are passed to helper methods rather than used directly in emit calls.
+//
+// Only dto/domain package qualifiers are collected; file-level string constants
+// are intentionally excluded to avoid treating subscriber topic constants as emits.
+func collectAllTopicSelectors(f *ast.File, pkgConsts cellPkgConsts, topics map[string]struct{}) {
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if (ident.Name == "dto" || ident.Name == "domain") && strings.HasPrefix(sel.Sel.Name, "Topic") {
+			if pkgMap, ok := pkgConsts[ident.Name]; ok {
+				if val, ok := pkgMap[sel.Sel.Name]; ok {
+					topics[val] = struct{}{}
+				}
+			}
+		}
+		return true
+	})
+}

--- a/kernel/governance/rules_consistency.go
+++ b/kernel/governance/rules_consistency.go
@@ -1,15 +1,14 @@
 package governance
 
 // Rule CONTRACT-CONSISTENCY-EMIT-01 validates bidirectional alignment between
-// HTTP contract triggers and outbox.Emit calls in the owning cell's service files.
+// HTTP contract triggers and outbox.Emit calls in the slice serving that HTTP contract.
 //
 // Three constraints:
 //  1. L2+ HTTP contract without triggers → Error (triggers required)
 //  2. Triggers present but consistencyLevel ∈ {L0, L1} → Error (level mismatch)
 //  3. Bidirectional AST check: every trigger must appear in a resolvable emit
-//     call somewhere in the cell's slice service files, and every resolvable
-//     emit call topic must be covered by a trigger in some HTTP contract of the
-//     same cell.
+//     call in the serving slice, and every resolvable emit topic in that serving
+//     slice must be covered by one of the HTTP contracts served by the slice.
 //
 // ref: tools/archtest/outbox_service_test.go — same-package const propagation
 // ref: golang.org/x/tools/go/analysis/passes/nilness rule discipline
@@ -38,6 +37,19 @@ type pkgConstMap = map[string]string
 // cellPkgConsts maps pkgIdent ("dto" or "domain") → pkgConstMap.
 type cellPkgConsts = map[string]pkgConstMap
 
+type consistencyIndex struct {
+	contractByID       map[string]*metadata.ContractMeta
+	httpServeSlices    map[string][]sliceRef
+	eventPublishSlices map[string][]sliceRef
+}
+
+type sliceRef struct {
+	cellID  string
+	sliceID string
+	dir     string
+	file    string
+}
+
 // validateCONTRACTCONSISTENCYEMIT01 checks three consistency constraints
 // between HTTP contract triggers and outbox emit calls in service files.
 // Contracts under examples/ are excluded — they are illustrative and may
@@ -45,58 +57,153 @@ type cellPkgConsts = map[string]pkgConstMap
 //
 // Structured as two phases:
 //
-//  1. Per-cell phase: scan emit topics and run reverse-check unconditionally for
-//     every cell that has HTTP contracts. Also discovers cells that have no HTTP
-//     contracts but do emit — their topics must not be undeclared.
+//  1. Per-slice phase: scan emit topics only for slices that serve L2+ HTTP
+//     contracts with triggers, then reverse-check those emits against contracts
+//     served by the same slice.
 //
 //  2. Per-contract phase: run constraint-1/2 checks and forward-check (every
-//     declared trigger must appear in the cell's emit set).
+//     declared trigger must reference a real event contract and appear in the
+//     serving slice's emit set).
 //
-// The per-cell phase runs before the per-contract loop so that reverse-check is
-// never gated on a contract having non-empty triggers.
+// The per-slice phase runs before the per-contract loop so reverse-checks are
+// evaluated once per serving slice instead of once per contract.
 func (v *Validator) validateCONTRACTCONSISTENCYEMIT01() []ValidationResult {
-	cellTriggerSets := buildCellTriggerSets(v.project.Contracts)
-	cellEmitSets, perCellResults := v.runPerCellPhase(cellTriggerSets)
-	perContractResults := v.runPerContractPhase(cellEmitSets)
-	return append(perCellResults, perContractResults...)
+	idx := buildConsistencyIndex(v.project)
+	sliceEmitSets, perSliceResults := v.runPerSlicePhase(idx)
+	perContractResults := v.runPerContractPhase(idx, sliceEmitSets)
+	return append(perSliceResults, perContractResults...)
 }
 
-// runPerCellPhase scans emit topics and runs reverse-checks for all cells with
-// HTTP contracts that have declared triggers. Returns the emit-set cache and findings.
-//
-// Reverse-check only runs for cells that have at least one HTTP contract with
-// non-empty triggers (L2+ contract). A cell whose only HTTP contracts are L0/L1
-// with no triggers is typically event-driven: its emits come from event-subscription
-// handlers, not from HTTP endpoints, and those emits do not need HTTP trigger
-// declarations. Skipping reverse-check for such cells avoids false positives
-// without weakening the forward-check (which still runs per-contract in phase 2).
-func (v *Validator) runPerCellPhase(cellTriggerSets map[string]map[string]struct{}) (
+func buildConsistencyIndex(project *metadata.ProjectMeta) consistencyIndex {
+	idx := consistencyIndex{
+		contractByID:       map[string]*metadata.ContractMeta{},
+		httpServeSlices:    map[string][]sliceRef{},
+		eventPublishSlices: map[string][]sliceRef{},
+	}
+	if project == nil {
+		return idx
+	}
+	for id, c := range project.Contracts {
+		idx.contractByID[id] = c
+	}
+	for key, s := range project.Slices {
+		if s == nil {
+			continue
+		}
+		ref := newSliceRef(key, s)
+		for _, cu := range s.ContractUsages {
+			switch cu.Role {
+			case "serve":
+				idx.httpServeSlices[cu.Contract] = append(idx.httpServeSlices[cu.Contract], ref)
+			case "publish":
+				idx.eventPublishSlices[cu.Contract] = append(idx.eventPublishSlices[cu.Contract], ref)
+			}
+		}
+	}
+	return idx
+}
+
+func newSliceRef(key string, s *metadata.SliceMeta) sliceRef {
+	cellID := s.BelongsToCell
+	sliceID := s.ID
+	if cellID == "" || sliceID == "" {
+		parts := strings.Split(key, "/")
+		if len(parts) == 2 {
+			if cellID == "" {
+				cellID = parts[0]
+			}
+			if sliceID == "" {
+				sliceID = parts[1]
+			}
+		}
+	}
+	cellDir := s.CellDir
+	if cellDir == "" {
+		cellDir = cellID
+	}
+	sliceDir := s.Dir
+	if sliceDir == "" {
+		sliceDir = sliceID
+	}
+	dir := filepath.ToSlash(filepath.Join("cells", cellDir, "slices", sliceDir))
+	if s.File != "" {
+		dir = filepath.ToSlash(filepath.Dir(s.File))
+	}
+	return sliceRef{
+		cellID:  cellID,
+		sliceID: sliceID,
+		dir:     dir,
+		file:    s.File,
+	}
+}
+
+func (r sliceRef) key() string {
+	return r.cellID + "/" + r.sliceID + "@" + r.dir
+}
+
+// runPerSlicePhase scans only HTTP-serving slices and runs reverse-checks
+// against the triggers declared by HTTP contracts served by that same slice.
+func (v *Validator) runPerSlicePhase(idx consistencyIndex) (
 	map[string]map[string]struct{}, []ValidationResult,
 ) {
-	var results []ValidationResult
-	cellEmitSets := map[string]map[string]struct{}{}
+	sliceTriggerSets := map[string]map[string]struct{}{}
+	slicesByKey := map[string]sliceRef{}
 
-	for ownerCell, triggerSet := range cellTriggerSets {
-		emits, scanResults := scanCellEmitTopics(v.root, ownerCell, "")
-		results = append(results, scanResults...)
-		cellEmitSets[ownerCell] = emits
-		if len(triggerSet) == 0 {
-			continue // event-driven cell — no HTTP trigger declarations needed
+	for _, c := range v.project.Contracts {
+		addServingSliceTriggers(c, idx, slicesByKey, sliceTriggerSets)
+	}
+	return v.scanServingSlices(slicesByKey, sliceTriggerSets)
+}
+
+func addServingSliceTriggers(
+	c *metadata.ContractMeta,
+	idx consistencyIndex,
+	slicesByKey map[string]sliceRef,
+	sliceTriggerSets map[string]map[string]struct{},
+) {
+	if cell.ContractKind(c.Kind) != cell.ContractHTTP || isExamplePath(c.File) || isExamplePath(c.Dir) {
+		return
+	}
+	if len(c.Triggers) == 0 || !isL2OrHigher(c.ConsistencyLevel) {
+		return
+	}
+	for _, ref := range idx.httpServeSlices[c.ID] {
+		key := ref.key()
+		slicesByKey[key] = ref
+		if sliceTriggerSets[key] == nil {
+			sliceTriggerSets[key] = map[string]struct{}{}
 		}
-		results = append(results, v.checkReverseEmits(ownerCell, emits, triggerSet)...)
+		addTriggers(sliceTriggerSets[key], c.Triggers)
 	}
+}
 
-	// Scan cells that have NO HTTP contracts at all but do emit — every emit is unaccounted.
-	for _, ownerCell := range discoverEmittingCellsWithoutHTTPContracts(v.root, cellTriggerSets) {
-		emits, scanResults := scanCellEmitTopics(v.root, ownerCell, "")
-		results = append(results, scanResults...)
-		results = append(results, v.checkReverseEmits(ownerCell, emits, nil)...)
+func addTriggers(dst map[string]struct{}, triggers []string) {
+	for _, trigger := range triggers {
+		dst[trigger] = struct{}{}
 	}
-	return cellEmitSets, results
+}
+
+func (v *Validator) scanServingSlices(
+	slicesByKey map[string]sliceRef,
+	sliceTriggerSets map[string]map[string]struct{},
+) (map[string]map[string]struct{}, []ValidationResult) {
+	var results []ValidationResult
+	sliceEmitSets := map[string]map[string]struct{}{}
+
+	for key, ref := range slicesByKey {
+		emits, scanResults := scanSliceEmitTopics(v.root, ref, "")
+		results = append(results, scanResults...)
+		sliceEmitSets[key] = emits
+		results = append(results, v.checkReverseEmits(ref, emits, sliceTriggerSets[key])...)
+	}
+	return sliceEmitSets, results
 }
 
 // runPerContractPhase runs constraint-1/2 and forward-check for each HTTP contract.
-func (v *Validator) runPerContractPhase(cellEmitSets map[string]map[string]struct{}) []ValidationResult {
+func (v *Validator) runPerContractPhase(
+	idx consistencyIndex,
+	sliceEmitSets map[string]map[string]struct{},
+) []ValidationResult {
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
 		if cell.ContractKind(c.Kind) != cell.ContractHTTP {
@@ -110,7 +217,9 @@ func (v *Validator) runPerContractPhase(cellEmitSets map[string]map[string]struc
 		if skip || len(c.Triggers) == 0 || !isL2OrHigher(c.ConsistencyLevel) {
 			continue
 		}
-		results = append(results, v.checkForwardTriggers(c, cellEmitSets[c.OwnerCell])...)
+		servingSlices := idx.httpServeSlices[c.ID]
+		results = append(results, v.checkTriggerContracts(c, servingSlices, idx)...)
+		results = append(results, v.checkForwardTriggers(c, servingSlices, sliceEmitSets)...)
 	}
 	return results
 }
@@ -118,103 +227,6 @@ func (v *Validator) runPerContractPhase(cellEmitSets map[string]map[string]struc
 // isExamplePath returns true if the path is under an examples/ subtree.
 func isExamplePath(p string) bool {
 	return strings.HasPrefix(p, "examples/")
-}
-
-// buildCellTriggerSets pre-computes per-cell declared triggers for all HTTP contracts.
-// Returns a map of ownerCell → set of declared trigger topic strings.
-func buildCellTriggerSets(contracts map[string]*metadata.ContractMeta) map[string]map[string]struct{} {
-	sets := map[string]map[string]struct{}{}
-	for _, c := range contracts {
-		if cell.ContractKind(c.Kind) != cell.ContractHTTP {
-			continue
-		}
-		if isExamplePath(c.File) || isExamplePath(c.Dir) {
-			continue
-		}
-		if sets[c.OwnerCell] == nil {
-			sets[c.OwnerCell] = map[string]struct{}{}
-		}
-		for _, t := range c.Triggers {
-			sets[c.OwnerCell][t] = struct{}{}
-		}
-	}
-	return sets
-}
-
-// discoverEmittingCellsWithoutHTTPContracts walks cells/ to find cells that have
-// no HTTP contracts (not in knownCells) but contain outbox.Emit or receiver .Emit
-// calls. Only non-example cells are considered.
-func discoverEmittingCellsWithoutHTTPContracts(root string, knownCells map[string]map[string]struct{}) []string {
-	cellsDir := filepath.Join(root, "cells")
-	entries, err := os.ReadDir(cellsDir)
-	if err != nil {
-		return nil
-	}
-	var extras []string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if _, known := knownCells[name]; known {
-			continue
-		}
-		// Skip cells under examples/ paths (cell dir is directly under cells/).
-		slicesDir := filepath.Join(cellsDir, name, "slices")
-		if _, statErr := os.Stat(slicesDir); statErr != nil {
-			continue
-		}
-		if cellHasAnyEmit(slicesDir) {
-			extras = append(extras, name)
-		}
-	}
-	return extras
-}
-
-// cellHasAnyEmit does a quick scan of all non-test Go files under slicesDir to
-// check whether any file contains an outbox.Emit or receiver .Emit call.
-func cellHasAnyEmit(slicesDir string) bool {
-	found := false
-	fset := token.NewFileSet()
-	_ = filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
-		if found || err != nil || d.IsDir() {
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		f, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			return nil
-		}
-		if fileHasEmitCall(f) {
-			found = true
-		}
-		return nil
-	})
-	return found
-}
-
-// fileHasEmitCall returns true if the file's AST contains any outbox.Emit or
-// receiver .Emit call site.
-func fileHasEmitCall(f *ast.File) bool {
-	found := false
-	ast.Inspect(f, func(n ast.Node) bool {
-		if found {
-			return false
-		}
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		if (isOutboxEmitCall(call) && len(call.Args) >= 3) ||
-			(isReceiverEmitCall(call) && len(call.Args) >= 2) {
-			found = true
-			return false
-		}
-		return true
-	})
-	return found
 }
 
 // checkConsistencyConstraints12 validates constraints 1 and 2 for a contract.
@@ -239,16 +251,84 @@ func (v *Validator) checkConsistencyConstraints12(c *metadata.ContractMeta) ([]V
 	return nil, false
 }
 
-// checkForwardTriggers validates that each contract trigger appears in emitTopics.
-func (v *Validator) checkForwardTriggers(c *metadata.ContractMeta, emitTopics map[string]struct{}) []ValidationResult {
+func (v *Validator) checkTriggerContracts(
+	c *metadata.ContractMeta,
+	servingSlices []sliceRef,
+	idx consistencyIndex,
+) []ValidationResult {
 	var results []ValidationResult
+	if len(servingSlices) == 0 {
+		results = append(results, v.newResult(
+			codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
+			contractFile(c), "triggers",
+			fmt.Sprintf("contract %q declares triggers but no slice declares role: serve for it", c.ID),
+		))
+	}
 	for _, t := range c.Triggers {
-		if _, found := emitTopics[t]; !found {
+		eventContract, ok := idx.contractByID[t]
+		if !ok {
 			results = append(results, v.newResult(
 				codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
 				contractFile(c), "triggers",
-				fmt.Sprintf("contract %q declares trigger %q but no non-test Go file under cells/%s/slices/ emits it via outbox.Emit or *.Emitter.Emit; topic must be string literal or named constant (dynamic fmt.Sprintf rejected)", c.ID, t, c.OwnerCell),
+				fmt.Sprintf("contract %q declares trigger %q but it does not reference an existing event contract", c.ID, t),
 			))
+			continue
+		}
+		if cell.ContractKind(eventContract.Kind) != cell.ContractEvent {
+			results = append(results, v.newResult(
+				codeContractConsistencyEmit01, SeverityError, IssueMismatch,
+				contractFile(c), "triggers",
+				fmt.Sprintf("contract %q declares trigger %q but referenced contract kind=%s; triggers must reference kind:event contracts", c.ID, t, eventContract.Kind),
+			))
+			continue
+		}
+		if eventContract.OwnerCell != c.OwnerCell || eventContract.Endpoints.Publisher != c.OwnerCell {
+			results = append(results, v.newResult(
+				codeContractConsistencyEmit01, SeverityError, IssueMismatch,
+				contractFile(c), "triggers",
+				fmt.Sprintf("contract %q declares trigger %q but event contract owner/publisher must both be %s", c.ID, t, c.OwnerCell),
+			))
+		}
+		for _, ref := range servingSlices {
+			if !slicePublishes(idx, ref, t) {
+				results = append(results, v.newResult(
+					codeContractConsistencyEmit01, SeverityError, IssueMismatch,
+					contractFile(c), "triggers",
+					fmt.Sprintf("contract %q declares trigger %q but serving slice %s/%s does not declare role: publish for that event contract", c.ID, t, ref.cellID, ref.sliceID),
+				))
+			}
+		}
+	}
+	return results
+}
+
+func slicePublishes(idx consistencyIndex, ref sliceRef, contractID string) bool {
+	for _, publisher := range idx.eventPublishSlices[contractID] {
+		if publisher.key() == ref.key() {
+			return true
+		}
+	}
+	return false
+}
+
+// checkForwardTriggers validates that each contract trigger appears in emitTopics
+// from each slice that serves that HTTP contract.
+func (v *Validator) checkForwardTriggers(
+	c *metadata.ContractMeta,
+	servingSlices []sliceRef,
+	sliceEmitSets map[string]map[string]struct{},
+) []ValidationResult {
+	var results []ValidationResult
+	for _, ref := range servingSlices {
+		emitTopics := sliceEmitSets[ref.key()]
+		for _, t := range c.Triggers {
+			if _, found := emitTopics[t]; !found {
+				results = append(results, v.newResult(
+					codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
+					contractFile(c), "triggers",
+					fmt.Sprintf("contract %q declares trigger %q but no non-test Go file under %s emits it via outbox.Emit or *.Emitter.Emit; serving slice %s/%s must emit the trigger topic as a string literal or named constant", c.ID, t, ref.dir, ref.cellID, ref.sliceID),
+				))
+			}
 		}
 	}
 	return results
@@ -257,7 +337,7 @@ func (v *Validator) checkForwardTriggers(c *metadata.ContractMeta, emitTopics ma
 // checkReverseEmits validates that each emitted topic appears in declared triggers.
 // declared may be nil when a cell has no HTTP contracts; in that case every emit fails.
 func (v *Validator) checkReverseEmits(
-	ownerCell string,
+	ref sliceRef,
 	emitTopics map[string]struct{},
 	declared map[string]struct{},
 ) []ValidationResult {
@@ -267,43 +347,26 @@ func (v *Validator) checkReverseEmits(
 			results = append(results, v.newScopedResult(
 				codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
 				"project", "triggers",
-				fmt.Sprintf("service emits topic %q but no HTTP contract in cell %s declares it in triggers; fix: add %q to triggers in one of cells/%s's HTTP contract.yaml files (or change the emit if dead code)", t, ownerCell, t, ownerCell),
+				fmt.Sprintf("service emits topic %q in serving slice %s/%s but no HTTP contract served by that slice declares it in triggers; fix: add %q to the slice's HTTP contract triggers or change the emit if dead code", t, ref.cellID, ref.sliceID, t),
 			))
 		}
 	}
 	return results
 }
 
-// scanCellEmitTopics scans all non-test Go files under cells/<ownerCell>/slices/
-// and returns the set of resolvable topic strings emitted by the cell.
-//
-// Resolution strategy (in order of precision):
-//  1. outbox.Emit(ctx, emitter, TOPIC, ...) — third arg resolved if literal or const;
-//     call expressions → dynamic-topic error.
-//  2. EventType: EXPR in outbox.Entry composite literals — resolved if literal or const.
-//  3. Pre-assigned entry variable passed to receiver Emit — walk back assignments.
-//  4. Same-package helper: if a function calls helper(ctx, dto.TopicX) and helper's body
-//     emits via outbox.Emit(ctx, e, topicParam, ...) where topicParam is the matching
-//     parameter, resolve via the call-site argument expression.
-//
-// Topic selectors in subscriber/comparison contexts are NOT collected — only
-// direct emit call evidence counts.
-func scanCellEmitTopics(root, ownerCell, fileForError string) (map[string]struct{}, []ValidationResult) {
+func scanSliceEmitTopics(root string, ref sliceRef, fileForError string) (map[string]struct{}, []ValidationResult) {
 	topics := map[string]struct{}{}
 	var results []ValidationResult
 
-	cellDir := filepath.Join(root, "cells", ownerCell)
+	cellDir := filepath.Join(root, "cells", ref.cellID)
 	pkgConsts := buildPkgConsts(cellDir)
-	slicesDir := filepath.Join(cellDir, "slices")
-	if _, err := os.Stat(slicesDir); err != nil {
+	sliceDir := filepath.Join(root, filepath.FromSlash(ref.dir))
+	if _, err := os.Stat(sliceDir); err != nil {
 		return topics, results
 	}
 
 	fset := token.NewFileSet()
-
-	// Two-pass approach: first collect all function declarations across all files
-	// so that helper resolution can reference them, then scan for emits.
-	allFiles := collectParsedFiles(fset, slicesDir)
+	allFiles := collectParsedFiles(fset, sliceDir)
 	helperMap := buildHelperEmitMap(allFiles, pkgConsts)
 
 	for _, f := range allFiles {
@@ -315,7 +378,10 @@ func scanCellEmitTopics(root, ownerCell, fileForError string) (map[string]struct
 
 // parsedFile wraps a parsed AST file for use in the two-pass emit scan.
 type parsedFile struct {
-	ast *ast.File
+	ast         *ast.File
+	path        string
+	dir         string
+	packageName string
 }
 
 // collectParsedFiles walks slicesDir and parses all non-test Go files,
@@ -339,7 +405,12 @@ func collectParsedFiles(fset *token.FileSet, slicesDir string) []parsedFile {
 		if parseErr != nil {
 			return nil
 		}
-		files = append(files, parsedFile{ast: f})
+		files = append(files, parsedFile{
+			ast:         f,
+			path:        path,
+			dir:         filepath.Dir(path),
+			packageName: f.Name.Name,
+		})
 		return nil
 	})
 	return files
@@ -352,18 +423,24 @@ type helperEmitFunc struct {
 	paramIndex int
 }
 
+type helperKey struct {
+	dir      string
+	pkg      string
+	name     string
+	receiver string
+}
+
 // buildHelperEmitMap scans all files to find functions and methods that:
 //   - have ≥1 parameter
 //   - contain an outbox.Emit call (or receiver emit via outbox.Entry{EventType:param})
 //     whose topic comes from one of the function/method's parameters (not a const)
 //
-// Returns map of funcName → helperEmitFunc.
-// Both plain functions and methods are included (keyed by bare name).
+// Returns map of package-dir + function/method identity → helperEmitFunc.
 // Only one-topic-from-param functions/methods are supported (first match wins).
 // Two-level chains are handled: if a function/method calls another helper whose
 // body emits and that helper is also in the map, the caller is also registered.
-func buildHelperEmitMap(files []parsedFile, pkgConsts cellPkgConsts) map[string]helperEmitFunc {
-	helpers := map[string]helperEmitFunc{}
+func buildHelperEmitMap(files []parsedFile, pkgConsts cellPkgConsts) map[helperKey]helperEmitFunc {
+	helpers := map[helperKey]helperEmitFunc{}
 	// First pass: direct emitters (outbox.Emit or receiver emit with entry var).
 	registerDirectEmitters(files, pkgConsts, helpers)
 	// Second pass: transitive callers — functions/methods that call a known helper.
@@ -373,16 +450,16 @@ func buildHelperEmitMap(files []parsedFile, pkgConsts cellPkgConsts) map[string]
 
 // registerDirectEmitters adds all functions/methods whose body directly emits
 // (via outbox.Emit or receiver emit with entry var) using a parameter as the topic.
-func registerDirectEmitters(files []parsedFile, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
+func registerDirectEmitters(files []parsedFile, pkgConsts cellPkgConsts, helpers map[helperKey]helperEmitFunc) {
 	for _, pf := range files {
-		scanFuncDeclsForDirectEmit(pf.ast.Decls, pkgConsts, helpers)
+		scanFuncDeclsForDirectEmit(pf, pkgConsts, helpers)
 	}
 }
 
 // scanFuncDeclsForDirectEmit processes a list of declarations looking for
 // direct-emit helper functions.
-func scanFuncDeclsForDirectEmit(decls []ast.Decl, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
-	for _, decl := range decls {
+func scanFuncDeclsForDirectEmit(pf parsedFile, pkgConsts cellPkgConsts, helpers map[helperKey]helperEmitFunc) {
+	for _, decl := range pf.ast.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Name == nil || fn.Body == nil || fn.Type.Params == nil {
 			continue
@@ -392,37 +469,48 @@ func scanFuncDeclsForDirectEmit(decls []ast.Decl, pkgConsts cellPkgConsts, helpe
 			continue
 		}
 		if idx, found := findHelperTopicParamIndex(fn.Body, paramNames, pkgConsts); found {
-			helpers[fn.Name.Name] = helperEmitFunc{paramIndex: idx}
+			helpers[funcHelperKey(pf, fn)] = helperEmitFunc{paramIndex: idx}
 		}
 	}
 }
 
 // registerTransitiveCallers adds functions/methods that call a known helper and
 // pass one of their own parameters as the helper's topic argument.
-func registerTransitiveCallers(files []parsedFile, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
+func registerTransitiveCallers(files []parsedFile, pkgConsts cellPkgConsts, helpers map[helperKey]helperEmitFunc) {
 	for _, pf := range files {
-		scanFuncDeclsForTransitive(pf.ast.Decls, pkgConsts, helpers)
+		scanFuncDeclsForTransitive(pf, pkgConsts, helpers)
 	}
 }
 
 // scanFuncDeclsForTransitive processes a list of declarations looking for
 // transitive-emit helper functions.
-func scanFuncDeclsForTransitive(decls []ast.Decl, pkgConsts cellPkgConsts, helpers map[string]helperEmitFunc) {
-	for _, decl := range decls {
+func scanFuncDeclsForTransitive(pf parsedFile, pkgConsts cellPkgConsts, helpers map[helperKey]helperEmitFunc) {
+	for _, decl := range pf.ast.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Name == nil || fn.Body == nil || fn.Type.Params == nil {
 			continue
 		}
-		if _, already := helpers[fn.Name.Name]; already {
+		key := funcHelperKey(pf, fn)
+		if _, already := helpers[key]; already {
 			continue
 		}
 		paramNames := funcParamNames(fn)
 		if len(paramNames) == 0 {
 			continue
 		}
-		if idx, found := findTransitiveHelperParamIndex(fn.Body, paramNames, pkgConsts, helpers); found {
-			helpers[fn.Name.Name] = helperEmitFunc{paramIndex: idx}
+		scope := functionScope(fn)
+		if idx, found := findTransitiveHelperParamIndex(fn.Body, pf, scope, paramNames, pkgConsts, helpers); found {
+			helpers[key] = helperEmitFunc{paramIndex: idx}
 		}
+	}
+}
+
+func funcHelperKey(pf parsedFile, fn *ast.FuncDecl) helperKey {
+	return helperKey{
+		dir:      pf.dir,
+		pkg:      pf.packageName,
+		name:     fn.Name.Name,
+		receiver: receiverTypeName(fn),
 	}
 }
 
@@ -435,6 +523,52 @@ func funcParamNames(fn *ast.FuncDecl) []string {
 		}
 	}
 	return names
+}
+
+type emitScope struct {
+	receiverVars map[string]string
+}
+
+func functionScope(fn *ast.FuncDecl) emitScope {
+	scope := emitScope{receiverVars: map[string]string{}}
+	if fn.Recv != nil {
+		addReceiverVars(scope.receiverVars, fn.Recv.List)
+	}
+	if fn.Type.Params != nil {
+		addReceiverVars(scope.receiverVars, fn.Type.Params.List)
+	}
+	return scope
+}
+
+func addReceiverVars(receiverVars map[string]string, fields []*ast.Field) {
+	for _, field := range fields {
+		typ := exprTypeName(field.Type)
+		if typ == "" {
+			continue
+		}
+		for _, name := range field.Names {
+			receiverVars[name.Name] = typ
+		}
+	}
+}
+
+func receiverTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	return exprTypeName(fn.Recv.List[0].Type)
+}
+
+func exprTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return exprTypeName(t.X)
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	}
+	return ""
 }
 
 // findHelperTopicParamIndex inspects a function/method body for emit evidence
@@ -625,9 +759,11 @@ func isOutboxEntryType(compLit *ast.CompositeLit) bool {
 // Returns the parameter index in the current function and true on first match.
 func findTransitiveHelperParamIndex(
 	body *ast.BlockStmt,
+	pf parsedFile,
+	scope emitScope,
 	paramNames []string,
 	pkgConsts cellPkgConsts,
-	helpers map[string]helperEmitFunc,
+	helpers map[helperKey]helperEmitFunc,
 ) (int, bool) {
 	dummyConsts := pkgConstMap{}
 	var foundIdx int
@@ -640,7 +776,7 @@ func findTransitiveHelperParamIndex(
 		if !ok {
 			return true
 		}
-		idx, ok := resolveTransitiveTopicParam(call, paramNames, pkgConsts, dummyConsts, helpers)
+		idx, ok := resolveTransitiveTopicParam(call, pf, scope, paramNames, pkgConsts, dummyConsts, helpers)
 		if ok {
 			foundIdx = idx
 			found = true
@@ -654,16 +790,18 @@ func findTransitiveHelperParamIndex(
 // one of the caller's paramNames is passed as the helper's topic argument.
 func resolveTransitiveTopicParam(
 	call *ast.CallExpr,
+	pf parsedFile,
+	scope emitScope,
 	paramNames []string,
 	pkgConsts cellPkgConsts,
 	dummyConsts pkgConstMap,
-	helpers map[string]helperEmitFunc,
+	helpers map[helperKey]helperEmitFunc,
 ) (int, bool) {
-	calledName := resolveCallName(call)
-	if calledName == "" {
+	calledKey, ok := resolveHelperCallKey(call, pf, scope)
+	if !ok {
 		return 0, false
 	}
-	helper, ok := helpers[calledName]
+	helper, ok := helpers[calledKey]
 	if !ok || helper.paramIndex >= len(call.Args) {
 		return 0, false
 	}
@@ -683,18 +821,31 @@ func resolveTransitiveTopicParam(
 	return 0, false
 }
 
-// resolveCallName extracts the bare function/method name from a call expression.
-// For ident calls (foo(...)), returns "foo".
-// For selector calls (s.foo(...) or pkg.foo(...)), returns "foo".
-// Returns "" for complex call expressions.
-func resolveCallName(call *ast.CallExpr) string {
+func resolveHelperCallKey(call *ast.CallExpr, pf parsedFile, scope emitScope) (helperKey, bool) {
 	switch fn := call.Fun.(type) {
 	case *ast.Ident:
-		return fn.Name
+		return helperKey{
+			dir:  pf.dir,
+			pkg:  pf.packageName,
+			name: fn.Name,
+		}, true
 	case *ast.SelectorExpr:
-		return fn.Sel.Name
+		ident, ok := fn.X.(*ast.Ident)
+		if !ok {
+			return helperKey{}, false
+		}
+		receiver, ok := scope.receiverVars[ident.Name]
+		if !ok {
+			return helperKey{}, false
+		}
+		return helperKey{
+			dir:      pf.dir,
+			pkg:      pf.packageName,
+			name:     fn.Sel.Name,
+			receiver: receiver,
+		}, true
 	}
-	return ""
+	return helperKey{}, false
 }
 
 // scanFileForEmits walks a single parsed file's AST and collects emitted topics.
@@ -708,37 +859,220 @@ func scanFileForEmits(
 	pf parsedFile,
 	fset *token.FileSet,
 	pkgConsts cellPkgConsts,
-	helperMap map[string]helperEmitFunc,
+	helperMap map[helperKey]helperEmitFunc,
 	fileForError string,
 	root string,
 	topics map[string]struct{},
 ) []ValidationResult {
-	f := pf.ast
-	fileConsts := collectFileConsts(f, pkgConsts)
 	var results []ValidationResult
-	ast.Inspect(f, func(n ast.Node) bool {
+	fileConsts := collectFileConsts(pf.ast, pkgConsts)
+	for _, decl := range pf.ast.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		ctx := emitScanContext{
+			pf:         pf,
+			fset:       fset,
+			pkgConsts:  pkgConsts,
+			fileConsts: fileConsts,
+			helperMap:  helperMap,
+			root:       root,
+			topics:     topics,
+			scope:      functionScope(fn),
+			paramNames: funcParamNames(fn),
+		}
+		if helper, ok := helperMap[funcHelperKey(pf, fn)]; ok {
+			ctx.currentHelperParam = helper.paramIndex
+		} else {
+			ctx.currentHelperParam = -1
+		}
+		state := emitScanState{entryTopics: map[string][]string{}}
+		results = append(results, scanBlockForEmits(fn.Body, ctx, &state)...)
+	}
+	return results
+}
+
+type emitScanContext struct {
+	pf                 parsedFile
+	fset               *token.FileSet
+	pkgConsts          cellPkgConsts
+	fileConsts         pkgConstMap
+	helperMap          map[helperKey]helperEmitFunc
+	root               string
+	topics             map[string]struct{}
+	scope              emitScope
+	paramNames         []string
+	currentHelperParam int
+}
+
+type emitScanState struct {
+	entryTopics map[string][]string
+}
+
+func scanBlockForEmits(block *ast.BlockStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	if block == nil {
+		return nil
+	}
+	var results []ValidationResult
+	for _, stmt := range block.List {
+		results = append(results, scanStmtForEmits(stmt, ctx, state)...)
+	}
+	return results
+}
+
+func scanStmtForEmits(stmt ast.Stmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	switch s := stmt.(type) {
+	case *ast.AssignStmt:
+		results := collectEntryAssignments(s, ctx, state)
+		return append(results, scanNodeForEmitCalls(s, ctx, state)...)
+	case *ast.DeclStmt:
+		results := collectEntryDecls(s, ctx, state)
+		return append(results, scanNodeForEmitCalls(s, ctx, state)...)
+	case *ast.ReturnStmt, *ast.ExprStmt, *ast.GoStmt, *ast.DeferStmt, *ast.SendStmt:
+		return scanNodeForEmitCalls(s, ctx, state)
+	case *ast.IfStmt:
+		return scanIfForEmits(s, ctx, state)
+	case *ast.ForStmt:
+		return scanForForEmits(s, ctx, state)
+	case *ast.RangeStmt:
+		return scanRangeForEmits(s, ctx, state)
+	case *ast.SwitchStmt:
+		return scanSwitchForEmits(s, ctx, state)
+	case *ast.TypeSwitchStmt:
+		return scanTypeSwitchForEmits(s, ctx, state)
+	case *ast.SelectStmt:
+		return scanSelectForEmits(s, ctx, state)
+	case *ast.BlockStmt:
+		return scanBlockForEmits(s, ctx, state)
+	default:
+		return scanNodeForEmitCalls(s, ctx, state)
+	}
+}
+
+func scanIfForEmits(stmt *ast.IfStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	if stmt.Init != nil {
+		results = append(results, scanStmtForEmits(stmt.Init, ctx, state)...)
+	}
+	if stmt.Cond != nil {
+		results = append(results, scanNodeForEmitCalls(stmt.Cond, ctx, state)...)
+	}
+	results = append(results, scanBlockForEmits(stmt.Body, ctx, state)...)
+	if stmt.Else != nil {
+		results = append(results, scanElseForEmits(stmt.Else, ctx, state)...)
+	}
+	return results
+}
+
+func scanForForEmits(stmt *ast.ForStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	if stmt.Init != nil {
+		results = append(results, scanStmtForEmits(stmt.Init, ctx, state)...)
+	}
+	if stmt.Cond != nil {
+		results = append(results, scanNodeForEmitCalls(stmt.Cond, ctx, state)...)
+	}
+	if stmt.Post != nil {
+		results = append(results, scanStmtForEmits(stmt.Post, ctx, state)...)
+	}
+	return append(results, scanBlockForEmits(stmt.Body, ctx, state)...)
+}
+
+func scanRangeForEmits(stmt *ast.RangeStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	results := scanNodeForEmitCalls(stmt.X, ctx, state)
+	return append(results, scanBlockForEmits(stmt.Body, ctx, state)...)
+}
+
+func scanElseForEmits(node ast.Stmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	if block, ok := node.(*ast.BlockStmt); ok {
+		return scanBlockForEmits(block, ctx, state)
+	}
+	return scanStmtForEmits(node, ctx, state)
+}
+
+func scanSwitchForEmits(stmt *ast.SwitchStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	if stmt.Init != nil {
+		results = append(results, scanStmtForEmits(stmt.Init, ctx, state)...)
+	}
+	if stmt.Tag != nil {
+		results = append(results, scanNodeForEmitCalls(stmt.Tag, ctx, state)...)
+	}
+	for _, item := range stmt.Body.List {
+		clause, ok := item.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, expr := range clause.List {
+			results = append(results, scanNodeForEmitCalls(expr, ctx, state)...)
+		}
+		for _, bodyStmt := range clause.Body {
+			results = append(results, scanStmtForEmits(bodyStmt, ctx, state)...)
+		}
+	}
+	return results
+}
+
+func scanTypeSwitchForEmits(stmt *ast.TypeSwitchStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	if stmt.Init != nil {
+		results = append(results, scanStmtForEmits(stmt.Init, ctx, state)...)
+	}
+	if stmt.Assign != nil {
+		results = append(results, scanStmtForEmits(stmt.Assign, ctx, state)...)
+	}
+	for _, item := range stmt.Body.List {
+		clause, ok := item.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, bodyStmt := range clause.Body {
+			results = append(results, scanStmtForEmits(bodyStmt, ctx, state)...)
+		}
+	}
+	return results
+}
+
+func scanSelectForEmits(stmt *ast.SelectStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	for _, item := range stmt.Body.List {
+		clause, ok := item.(*ast.CommClause)
+		if !ok {
+			continue
+		}
+		if clause.Comm != nil {
+			results = append(results, scanStmtForEmits(clause.Comm, ctx, state)...)
+		}
+		for _, bodyStmt := range clause.Body {
+			results = append(results, scanStmtForEmits(bodyStmt, ctx, state)...)
+		}
+	}
+	return results
+}
+
+func scanNodeForEmitCalls(node ast.Node, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	ast.Inspect(node, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-
-		// outbox.Emit(ctx, emitter, TOPIC, payload) — direct call.
-		if isOutboxEmitCall(call) && len(call.Args) >= 3 {
-			r := collectOutboxEmitTopic(call, fset, pkgConsts, fileConsts, fileForError, root, topics)
-			results = append(results, r...)
-			return true
-		}
-
-		// receiver.Emit(ctx, entry) — receiver-style emit.
-		if isReceiverEmitCall(call) && len(call.Args) >= 2 {
-			collectReceiverEmitTopics(call.Args[1], f, pkgConsts, fileConsts, topics)
-			return true
-		}
-
-		// helper(args...) — check if this is a known same-package helper.
-		collectHelperCallTopics(call, f, pkgConsts, fileConsts, helperMap, topics)
+		results = append(results, collectEmitCallTopics(call, ctx, state)...)
 		return true
 	})
+	return results
+}
+
+func collectEmitCallTopics(call *ast.CallExpr, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	if isOutboxEmitCall(call) && len(call.Args) >= 3 {
+		return collectOutboxEmitTopic(call, ctx, state)
+	}
+	if isReceiverEmitCall(call) && len(call.Args) >= 2 {
+		results = append(results, collectReceiverEmitTopics(call.Args[1], ctx, state)...)
+	}
+	results = append(results, collectHelperCallTopics(call, ctx)...)
 	return results
 }
 
@@ -746,32 +1080,37 @@ func scanFileForEmits(
 // or method that emits via a topic parameter, and if so resolves the topic from
 // the call-site argument.
 //
-// Handles both plain function calls (helper(...)) and receiver/selector method
-// calls (s.method(...), pkg.Func(...)). The helper map is keyed by bare name
-// so we match on the last segment (method name) regardless of receiver type.
+// Handles plain function calls (helper(...)) and receiver method calls when the
+// receiver variable can be tied to the current function's receiver or parameter
+// type. Package selectors and arbitrary selector last-segment matches are not
+// accepted as helper evidence.
 func collectHelperCallTopics(
 	call *ast.CallExpr,
-	f *ast.File,
-	pkgConsts cellPkgConsts,
-	fileConsts pkgConstMap,
-	helperMap map[string]helperEmitFunc,
-	topics map[string]struct{},
-) {
-	calledName := resolveCallName(call)
-	if calledName == "" {
-		return
-	}
-	helper, ok := helperMap[calledName]
+	ctx emitScanContext,
+) []ValidationResult {
+	calledKey, ok := resolveHelperCallKey(call, ctx.pf, ctx.scope)
 	if !ok {
-		return
+		return nil
+	}
+	helper, ok := ctx.helperMap[calledKey]
+	if !ok {
+		return nil
 	}
 	if helper.paramIndex >= len(call.Args) {
-		return
+		return nil
 	}
 	topicArg := call.Args[helper.paramIndex]
-	if topic, resolved := resolveTopicExpr(topicArg, pkgConsts, fileConsts); resolved {
-		topics[topic] = struct{}{}
+	if topic, resolved := resolveTopicExpr(topicArg, ctx.pkgConsts, ctx.fileConsts); resolved {
+		ctx.topics[topic] = struct{}{}
+		return nil
 	}
+	if isCurrentHelperTopicParam(topicArg, ctx) {
+		return nil
+	}
+	return []ValidationResult{dynamicTopicResult(
+		topicArg, ctx.fset, ctx.root,
+		"dynamic topic in helper emit not allowed; topic argument must resolve to a string literal or named constant",
+	)}
 }
 
 // collectOutboxEmitTopic extracts the topic from outbox.Emit third arg.
@@ -779,52 +1118,121 @@ func collectHelperCallTopics(
 // root is used to compute a project-relative file path for the finding.
 func collectOutboxEmitTopic(
 	call *ast.CallExpr,
-	fset *token.FileSet,
-	pkgConsts cellPkgConsts,
-	fileConsts pkgConstMap,
-	fileForError string,
-	root string,
-	topics map[string]struct{},
+	ctx emitScanContext,
+	state *emitScanState,
 ) []ValidationResult {
 	topicExpr := call.Args[2]
-	topic, resolved := resolveTopicExpr(topicExpr, pkgConsts, fileConsts)
+	topic, resolved := resolveTopicExpr(topicExpr, ctx.pkgConsts, ctx.fileConsts)
 	if resolved {
-		topics[topic] = struct{}{}
+		ctx.topics[topic] = struct{}{}
+		return nil
+	}
+	if isCurrentHelperTopicParam(topicExpr, ctx) {
 		return nil
 	}
 	if isDynamicExpr(topicExpr) {
-		pos := fset.Position(call.Pos())
-		relFile := pos.Filename
-		if root != "" {
-			if rel, err := filepath.Rel(root, pos.Filename); err == nil {
-				relFile = rel
-			}
-		}
-		return []ValidationResult{{
-			Code:      codeContractConsistencyEmit01,
-			Severity:  SeverityError,
-			IssueType: IssueInvalid,
-			File:      relFile,
-			Field:     "triggers",
-			Message: fmt.Sprintf(
-				"dynamic topic in emit not allowed at %s:%d; topic must be string literal or named constant",
-				relFile, pos.Line,
-			),
-		}}
+		return []ValidationResult{dynamicTopicResult(
+			topicExpr, ctx.fset, ctx.root,
+			"dynamic topic in emit not allowed; topic must be string literal or named constant",
+		)}
 	}
+	_ = state
 	return nil
 }
 
 // collectReceiverEmitTopics resolves topics from a receiver-style Emit call.
 func collectReceiverEmitTopics(
 	entryArg ast.Expr,
-	f *ast.File,
-	pkgConsts cellPkgConsts,
-	fileConsts pkgConstMap,
-	topics map[string]struct{},
-) {
-	for _, t := range extractEntryTopics(entryArg, f, pkgConsts, fileConsts) {
-		topics[t] = struct{}{}
+	ctx emitScanContext,
+	state *emitScanState,
+) []ValidationResult {
+	resolved, results := extractEntryTopics(entryArg, ctx, state)
+	for _, t := range resolved {
+		ctx.topics[t] = struct{}{}
+	}
+	return results
+}
+
+func collectEntryAssignments(stmt *ast.AssignStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	var results []ValidationResult
+	for i, lhs := range stmt.Lhs {
+		lhsIdent, ok := lhs.(*ast.Ident)
+		if !ok || i >= len(stmt.Rhs) {
+			continue
+		}
+		compLit, ok := stmt.Rhs[i].(*ast.CompositeLit)
+		if !ok || !isOutboxEntryType(compLit) {
+			delete(state.entryTopics, lhsIdent.Name)
+			continue
+		}
+		results = append(results, bindEntryTopic(lhsIdent.Name, compLit, ctx, state)...)
+	}
+	return results
+}
+
+func collectEntryDecls(stmt *ast.DeclStmt, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	genDecl, ok := stmt.Decl.(*ast.GenDecl)
+	if !ok || genDecl.Tok != token.VAR {
+		return nil
+	}
+	var results []ValidationResult
+	for _, spec := range genDecl.Specs {
+		vspec, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for i, name := range vspec.Names {
+			if i >= len(vspec.Values) {
+				continue
+			}
+			compLit, ok := vspec.Values[i].(*ast.CompositeLit)
+			if !ok || !isOutboxEntryType(compLit) {
+				continue
+			}
+			results = append(results, bindEntryTopic(name.Name, compLit, ctx, state)...)
+		}
+	}
+	return results
+}
+
+func bindEntryTopic(name string, compLit *ast.CompositeLit, ctx emitScanContext, state *emitScanState) []ValidationResult {
+	topic, found, results := extractEventTypeFromCompLit(compLit, ctx)
+	if found {
+		state.entryTopics[name] = []string{topic}
+		return results
+	}
+	delete(state.entryTopics, name)
+	return results
+}
+
+func isCurrentHelperTopicParam(expr ast.Expr, ctx emitScanContext) bool {
+	if ctx.currentHelperParam < 0 || ctx.currentHelperParam >= len(ctx.paramNames) {
+		return false
+	}
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == ctx.paramNames[ctx.currentHelperParam]
+}
+
+func dynamicTopicResult(expr ast.Expr, fset *token.FileSet, root, message string) ValidationResult {
+	pos := fset.Position(expr.Pos())
+	relFile := pos.Filename
+	if root != "" {
+		if rel, err := filepath.Rel(root, pos.Filename); err == nil {
+			relFile = filepath.ToSlash(rel)
+		}
+	}
+	return ValidationResult{
+		Code:      codeContractConsistencyEmit01,
+		Severity:  SeverityError,
+		IssueType: IssueInvalid,
+		File:      relFile,
+		Field:     "triggers",
+		Message: fmt.Sprintf(
+			"%s at %s:%d:%d",
+			message, relFile, pos.Line, pos.Column,
+		),
+		Line:   pos.Line,
+		Column: pos.Column,
 	}
 }
 
@@ -1034,49 +1442,25 @@ func isReceiverEmitCall(call *ast.CallExpr) bool {
 }
 
 // extractEntryTopics resolves the EventType from the entry argument of a receiver Emit call.
-// Handles both inline composite literals and pre-assigned entry variables.
-func extractEntryTopics(entryArg ast.Expr, f *ast.File, pkgConsts cellPkgConsts, fileConsts pkgConstMap) []string {
+// Handles both inline composite literals and entry variables assigned earlier in the
+// current function body.
+func extractEntryTopics(entryArg ast.Expr, ctx emitScanContext, state *emitScanState) ([]string, []ValidationResult) {
 	if compLit, ok := entryArg.(*ast.CompositeLit); ok {
-		topic, found := extractEventTypeFromCompLit(compLit, pkgConsts, fileConsts)
+		topic, found, results := extractEventTypeFromCompLit(compLit, ctx)
 		if found {
-			return []string{topic}
+			return []string{topic}, results
 		}
-		return nil
+		return nil, results
 	}
 	ident, ok := entryArg.(*ast.Ident)
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return findEntryTopicsFromIdent(ident.Name, f, pkgConsts, fileConsts)
-}
-
-// findEntryTopicsFromIdent searches the file AST for assignments to the given
-// identifier and resolves their EventType fields.
-func findEntryTopicsFromIdent(name string, f *ast.File, pkgConsts cellPkgConsts, fileConsts pkgConstMap) []string {
-	var topics []string
-	ast.Inspect(f, func(n ast.Node) bool {
-		stmt, ok := n.(*ast.AssignStmt)
-		if !ok {
-			return true
-		}
-		for i, lhs := range stmt.Lhs {
-			lhsIdent, ok := lhs.(*ast.Ident)
-			if !ok || lhsIdent.Name != name || i >= len(stmt.Rhs) {
-				continue
-			}
-			if compLit, ok := stmt.Rhs[i].(*ast.CompositeLit); ok {
-				if topic, found := extractEventTypeFromCompLit(compLit, pkgConsts, fileConsts); found {
-					topics = append(topics, topic)
-				}
-			}
-		}
-		return true
-	})
-	return topics
+	return state.entryTopics[ident.Name], nil
 }
 
 // extractEventTypeFromCompLit finds the EventType field in a composite literal.
-func extractEventTypeFromCompLit(compLit *ast.CompositeLit, pkgConsts cellPkgConsts, fileConsts pkgConstMap) (string, bool) {
+func extractEventTypeFromCompLit(compLit *ast.CompositeLit, ctx emitScanContext) (string, bool, []ValidationResult) {
 	for _, elt := range compLit.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {
@@ -1086,7 +1470,19 @@ func extractEventTypeFromCompLit(compLit *ast.CompositeLit, pkgConsts cellPkgCon
 		if !ok || key.Name != "EventType" {
 			continue
 		}
-		return resolveTopicExpr(kv.Value, pkgConsts, fileConsts)
+		if topic, resolved := resolveTopicExpr(kv.Value, ctx.pkgConsts, ctx.fileConsts); resolved {
+			return topic, true, nil
+		}
+		if isCurrentHelperTopicParam(kv.Value, ctx) {
+			return "", false, nil
+		}
+		if isDynamicExpr(kv.Value) {
+			return "", false, []ValidationResult{dynamicTopicResult(
+				kv.Value, ctx.fset, ctx.root,
+				"dynamic topic in receiver emit not allowed; EventType must resolve to a string literal or named constant",
+			)}
+		}
+		return "", false, nil
 	}
-	return "", false
+	return "", false, nil
 }

--- a/kernel/governance/rules_consistency.go
+++ b/kernel/governance/rules_consistency.go
@@ -141,7 +141,7 @@ func (v *Validator) checkForwardTriggers(c *metadata.ContractMeta, emitTopics ma
 			results = append(results, v.newResult(
 				codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
 				contractFile(c), "triggers",
-				fmt.Sprintf("contract %q declares trigger %q but no service.go in cell %s emits it", c.ID, t, c.OwnerCell),
+				fmt.Sprintf("contract %q declares trigger %q but no non-test Go file under cells/%s/slices/ emits it via outbox.Emit or *.Emitter.Emit; topic must be string literal or named constant (dynamic fmt.Sprintf rejected)", c.ID, t, c.OwnerCell),
 			))
 		}
 	}
@@ -161,7 +161,7 @@ func (v *Validator) checkReverseEmits(
 			results = append(results, v.newScopedResult(
 				codeContractConsistencyEmit01, SeverityError, IssueRefNotFound,
 				"project", "triggers",
-				fmt.Sprintf("service emits topic %q but no HTTP contract in cell %s declares it in triggers", t, ownerCell),
+				fmt.Sprintf("service emits topic %q but no HTTP contract in cell %s declares it in triggers; fix: add %q to triggers in one of cells/%s's HTTP contract.yaml files (or change the emit if dead code)", t, ownerCell, t, ownerCell),
 			))
 		}
 	}
@@ -206,50 +206,64 @@ func scanCellEmitTopics(root, ownerCell, fileForError string) (map[string]struct
 			return nil
 		}
 		fileConsts := collectFileConsts(f, pkgConsts)
-		scanResults := scanFileForEmits(f, fset, pkgConsts, fileConsts, fileForError, topics)
+		scanResults, hasEmit := scanFileForEmits(f, fset, pkgConsts, fileConsts, fileForError, root, topics)
 		results = append(results, scanResults...)
-		collectAllTopicSelectors(f, pkgConsts, topics)
+		// Only collect topic selectors from files that contain real emit calls.
+		// Restricting to emit-call files prevents subscriber topic constants
+		// (e.g. in subscribe(ctx, dto.TopicX, handler)) from being counted as
+		// emit evidence, which would cause false-negatives in the reverse check.
+		if hasEmit {
+			collectAllTopicSelectors(f, pkgConsts, topics)
+		}
 		return nil
 	})
 	return topics, results
 }
 
 // scanFileForEmits walks a single parsed file's AST and collects emitted topics.
+// Returns the validation results and a boolean indicating whether the file
+// contained at least one real emit call site (outbox.Emit or receiver *.Emit).
 func scanFileForEmits(
 	f *ast.File,
 	fset *token.FileSet,
 	pkgConsts cellPkgConsts,
 	fileConsts pkgConstMap,
 	fileForError string,
+	root string,
 	topics map[string]struct{},
-) []ValidationResult {
+) ([]ValidationResult, bool) {
 	var results []ValidationResult
+	var hasEmit bool
 	ast.Inspect(f, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
 		if isOutboxEmitCall(call) && len(call.Args) >= 3 {
-			r := collectOutboxEmitTopic(call, fset, pkgConsts, fileConsts, fileForError, topics)
+			hasEmit = true
+			r := collectOutboxEmitTopic(call, fset, pkgConsts, fileConsts, fileForError, root, topics)
 			results = append(results, r...)
 			return true
 		}
 		if isReceiverEmitCall(call) && len(call.Args) >= 2 {
+			hasEmit = true
 			collectReceiverEmitTopics(call.Args[1], f, pkgConsts, fileConsts, topics)
 		}
 		return true
 	})
-	return results
+	return results, hasEmit
 }
 
 // collectOutboxEmitTopic extracts the topic from outbox.Emit third arg.
 // Appends to topics on success; returns a dynamic-topic error on call expressions.
+// root is used to compute a project-relative file path for the finding.
 func collectOutboxEmitTopic(
 	call *ast.CallExpr,
 	fset *token.FileSet,
 	pkgConsts cellPkgConsts,
 	fileConsts pkgConstMap,
 	fileForError string,
+	root string,
 	topics map[string]struct{},
 ) []ValidationResult {
 	topicExpr := call.Args[2]
@@ -260,15 +274,21 @@ func collectOutboxEmitTopic(
 	}
 	if isDynamicExpr(topicExpr) {
 		pos := fset.Position(call.Pos())
+		relFile := pos.Filename
+		if root != "" {
+			if rel, err := filepath.Rel(root, pos.Filename); err == nil {
+				relFile = rel
+			}
+		}
 		return []ValidationResult{{
 			Code:      codeContractConsistencyEmit01,
 			Severity:  SeverityError,
 			IssueType: IssueInvalid,
-			File:      fileForError,
+			File:      relFile,
 			Field:     "triggers",
 			Message: fmt.Sprintf(
 				"dynamic topic in emit not allowed at %s:%d; topic must be string literal or named constant",
-				pos.Filename, pos.Line,
+				relFile, pos.Line,
 			),
 		}}
 	}

--- a/kernel/governance/rules_consistency.go
+++ b/kernel/governance/rules_consistency.go
@@ -189,35 +189,50 @@ func scanCellEmitTopics(root, ownerCell, fileForError string) (map[string]struct
 
 	fset := token.NewFileSet()
 	_ = filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			if n := d.Name(); n == "mem" || n == "testdata" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		f, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			return nil
-		}
-		fileConsts := collectFileConsts(f, pkgConsts)
-		scanResults, hasEmit := scanFileForEmits(f, fset, pkgConsts, fileConsts, fileForError, root, topics)
-		results = append(results, scanResults...)
-		// Only collect topic selectors from files that contain real emit calls.
-		// Restricting to emit-call files prevents subscriber topic constants
-		// (e.g. in subscribe(ctx, dto.TopicX, handler)) from being counted as
-		// emit evidence, which would cause false-negatives in the reverse check.
-		if hasEmit {
-			collectAllTopicSelectors(f, pkgConsts, topics)
-		}
-		return nil
+		return scanSliceFile(path, d, err, fset, pkgConsts, fileForError, root, topics, &results)
 	})
 	return topics, results
+}
+
+// scanSliceFile is the WalkDir callback body for scanCellEmitTopics.
+// It skips directories, test files, and unparseable files; for each non-test
+// Go file it runs emit scanning and, only when emit calls are found, also
+// collects selector-based topic hints.
+func scanSliceFile(
+	path string, d fs.DirEntry, err error,
+	fset *token.FileSet,
+	pkgConsts cellPkgConsts,
+	fileForError, root string,
+	topics map[string]struct{},
+	results *[]ValidationResult,
+) error {
+	if err != nil {
+		return nil
+	}
+	if d.IsDir() {
+		if n := d.Name(); n == "mem" || n == "testdata" {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+	if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		return nil
+	}
+	f, parseErr := parser.ParseFile(fset, path, nil, 0)
+	if parseErr != nil {
+		return nil
+	}
+	fileConsts := collectFileConsts(f, pkgConsts)
+	scanResults, hasEmit := scanFileForEmits(f, fset, pkgConsts, fileConsts, fileForError, root, topics)
+	*results = append(*results, scanResults...)
+	// Only collect topic selectors from files that contain real emit calls.
+	// Restricting to emit-call files prevents subscriber topic constants
+	// (e.g. in subscribe(ctx, dto.TopicX, handler)) from being counted as
+	// emit evidence, which would cause false-negatives in the reverse check.
+	if hasEmit {
+		collectAllTopicSelectors(f, pkgConsts, topics)
+	}
+	return nil
 }
 
 // scanFileForEmits walks a single parsed file's AST and collects emitted topics.

--- a/kernel/governance/rules_consistency_test.go
+++ b/kernel/governance/rules_consistency_test.go
@@ -1,0 +1,529 @@
+package governance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// buildConsistencyProject creates a minimal ProjectMeta for CONTRACT-CONSISTENCY-EMIT-01 tests.
+// ownerCell: the cell that owns the contracts.
+// contracts: list of (id, consistencyLevel, triggers...) tuples.
+func buildConsistencyProject(ownerCell string, contracts []*metadata.ContractMeta) *metadata.ProjectMeta {
+	contractMap := map[string]*metadata.ContractMeta{}
+	for _, c := range contracts {
+		contractMap[c.ID] = c
+	}
+	return &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			ownerCell: {
+				ID:               ownerCell,
+				Type:             "core",
+				ConsistencyLevel: "L2",
+				DurabilityMode:   "durable",
+				Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+				Schema:           metadata.SchemaMeta{Primary: "cell_test"},
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke." + ownerCell + ".startup"}},
+				Dir:              ownerCell,
+				File:             "cells/" + ownerCell + "/cell.yaml",
+			},
+		},
+		Slices:     map[string]*metadata.SliceMeta{},
+		Contracts:  contractMap,
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+}
+
+// httpContract creates a ContractMeta for an HTTP contract.
+func httpContract(id, ownerCell, consistencyLevel string, triggers []string) *metadata.ContractMeta {
+	return &metadata.ContractMeta{
+		ID:               id,
+		Kind:             "http",
+		OwnerCell:        ownerCell,
+		ConsistencyLevel: consistencyLevel,
+		Lifecycle:        "active",
+		Triggers:         triggers,
+		Endpoints: metadata.EndpointsMeta{
+			Server:  ownerCell,
+			Clients: []string{"edge-bff"},
+			HTTP: &metadata.HTTPTransportMeta{
+				Method:        "POST",
+				Path:          "/api/v1/test",
+				SuccessStatus: 201,
+			},
+		},
+		Dir:  "contracts/http/test/action/v1",
+		File: "contracts/http/test/action/v1/contract.yaml",
+	}
+}
+
+// writeDtoConst writes a Go file defining a topic constant in a dto package.
+func writeDtoConst(t *testing.T, dir, constName, topicValue string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	src := "package dto\n\nconst " + constName + " = \"" + topicValue + "\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "topics.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("write topics.go: %v", err)
+	}
+}
+
+// writeServiceFile writes a Go service file with an emit call.
+func writeServiceFile(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "service.go"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write service.go: %v", err)
+	}
+}
+
+// findResultByCode returns all ValidationResults matching the given code.
+func findResultByCode(results []ValidationResult, code string) []ValidationResult {
+	var out []ValidationResult
+	for _, r := range results {
+		if r.Code == code {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseA: L2 contract + triggers + service emits → PASS.
+func TestCONTRACTCONSISTENCYEMIT01_CaseA(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+
+	// Write dto topic constant.
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicTestCreated", topic)
+
+	// Write service.go that emits via outbox.Emit with dto.TopicTestCreated.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	return outbox.Emit(ctx, e, dto.TopicTestCreated, struct{}{})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	if got := findResultByCode(results, codeContractConsistencyEmit01); len(got) != 0 {
+		t.Errorf("case A: expected 0 findings, got %d: %v", len(got), got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseB: triggers present + L1 → level mismatch error.
+func TestCONTRACTCONSISTENCYEMIT01_CaseB(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L1", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+	if len(got) != 1 {
+		t.Fatalf("case B: expected 1 finding, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0].Message, "triggers imply L2+") {
+		t.Errorf("case B: expected 'triggers imply L2+' in message, got: %s", got[0].Message)
+	}
+	if got[0].Severity != SeverityError {
+		t.Errorf("case B: expected SeverityError, got %s", got[0].Severity)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseC: L2 contract + no triggers → required error.
+func TestCONTRACTCONSISTENCYEMIT01_CaseC(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", nil),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+	if len(got) != 1 {
+		t.Fatalf("case C: expected 1 finding, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0].Message, "must declare non-empty triggers") {
+		t.Errorf("case C: expected 'must declare non-empty triggers' in message, got: %s", got[0].Message)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseD: contract trigger not emitted by service → forward check fail.
+func TestCONTRACTCONSISTENCYEMIT01_CaseD(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	declaredTopic := "event.test.created.v1"
+	emittedTopic := "event.test.other.v1"
+
+	// Write dto with a different topic than what the contract declares.
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicTestOther", emittedTopic)
+
+	// Service emits a different topic.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	return outbox.Emit(ctx, e, dto.TopicTestOther, struct{}{})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{declaredTopic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+
+	// Expect: forward check fail (declared not emitted) + reverse check fail (emitted not declared).
+	forwardFail := false
+	reverseFail := false
+	for _, r := range got {
+		if strings.Contains(r.Message, "no service.go") && strings.Contains(r.Message, declaredTopic) {
+			forwardFail = true
+		}
+		if strings.Contains(r.Message, "service emits") && strings.Contains(r.Message, emittedTopic) {
+			reverseFail = true
+		}
+	}
+	if !forwardFail {
+		t.Errorf("case D: expected forward check failure for %q, findings: %v", declaredTopic, got)
+	}
+	if !reverseFail {
+		t.Errorf("case D: expected reverse check failure for %q, findings: %v", emittedTopic, got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseE: service emits topic not in any contract trigger → reverse check fail.
+func TestCONTRACTCONSISTENCYEMIT01_CaseE(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	declaredTopic := "event.test.created.v1"
+	extraTopic := "event.test.extra.v1"
+
+	// Write dto with both topics.
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	if err := os.MkdirAll(dtoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dtoDir, "topics.go"), []byte(`package dto
+
+const (
+	TopicTestCreated = "`+declaredTopic+`"
+	TopicTestExtra   = "`+extraTopic+`"
+)
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Service emits both topics.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	_ = outbox.Emit(ctx, e, dto.TopicTestCreated, struct{}{})
+	return outbox.Emit(ctx, e, dto.TopicTestExtra, struct{}{})
+}
+`)
+
+	// Contract only declares one trigger.
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{declaredTopic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+
+	reverseFail := false
+	for _, r := range got {
+		if strings.Contains(r.Message, "service emits") && strings.Contains(r.Message, extraTopic) {
+			reverseFail = true
+		}
+	}
+	if !reverseFail {
+		t.Errorf("case E: expected reverse check failure for %q, findings: %v", extraTopic, got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseF: dynamic topic in outbox.Emit → error.
+func TestCONTRACTCONSISTENCYEMIT01_CaseF(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+
+	// dto has the constant.
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicTestCreated", topic)
+
+	// Service uses a dynamic topic via fmt.Sprintf in outbox.Emit.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"fmt"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter, v string) error {
+	return outbox.Emit(ctx, e, fmt.Sprintf("event.x.%s", v), struct{}{})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+
+	dynamicFail := false
+	for _, r := range got {
+		if strings.Contains(r.Message, "dynamic topic in emit") {
+			dynamicFail = true
+		}
+	}
+	if !dynamicFail {
+		t.Errorf("case F: expected dynamic topic error, findings: %v", got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_ReceiverEmitInlineCompLit verifies that the
+// receiver-style emit with an inline composite literal is correctly resolved.
+func TestCONTRACTCONSISTENCYEMIT01_ReceiverEmitInlineCompLit(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.done.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicTestDone", topic)
+
+	// Service uses receiver-style emit with inline composite literal.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+type emitter interface {
+	Emit(ctx context.Context, entry outbox.Entry) error
+}
+
+func doEmit(ctx context.Context, e emitter) error {
+	return e.Emit(ctx, outbox.Entry{EventType: dto.TopicTestDone})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.done.v1", ownerCell, "L2", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	if got := findResultByCode(results, codeContractConsistencyEmit01); len(got) != 0 {
+		t.Errorf("receiver-emit-inline: expected 0 findings, got %d: %v", len(got), got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_ReceiverEmitPreBuiltEntry verifies that a
+// pre-built entry variable passed to receiver-style emit is resolved via
+// the assignment walk-back.
+func TestCONTRACTCONSISTENCYEMIT01_ReceiverEmitPreBuiltEntry(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.done.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicTestDone", topic)
+
+	// Service builds entry variable and then calls receiver emit.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+type emitter interface {
+	Emit(ctx context.Context, entry outbox.Entry) error
+}
+
+func doEmit(ctx context.Context, e emitter) error {
+	entry := outbox.Entry{EventType: dto.TopicTestDone}
+	return e.Emit(ctx, entry)
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.done.v1", ownerCell, "L2", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	if got := findResultByCode(results, codeContractConsistencyEmit01); len(got) != 0 {
+		t.Errorf("receiver-emit-prebuilt: expected 0 findings, got %d: %v", len(got), got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_IndirectHelper verifies that topic resolution
+// works when the topic constant is passed as an argument to a helper method
+// (collectAllTopicSelectors picks up dto.TopicXxx selectors anywhere in the file).
+func TestCONTRACTCONSISTENCYEMIT01_IndirectHelper(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicTestCreated", topic)
+
+	// Service passes topic to a helper — dto.TopicTestCreated appears in the file
+	// but not directly in an outbox.Emit or entry.EventType context.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func publish(ctx context.Context, e outbox.Emitter, topic string) error {
+	return outbox.Emit(ctx, e, topic, struct{}{})
+}
+
+func doWork(ctx context.Context, e outbox.Emitter) error {
+	return publish(ctx, e, dto.TopicTestCreated)
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+
+	// outbox.Emit sees "topic" (an ident not in fileConsts) → not resolved directly.
+	// But collectAllTopicSelectors picks up dto.TopicTestCreated from doWork.
+	// Forward check should pass; no dynamic-topic error (the ident is not a call expr).
+	dynamicErrors := 0
+	for _, r := range findResultByCode(results, codeContractConsistencyEmit01) {
+		if strings.Contains(r.Message, "dynamic topic") {
+			dynamicErrors++
+		}
+	}
+	if dynamicErrors > 0 {
+		t.Errorf("indirect-helper: should not emit dynamic topic error for ident arg, got %d dynamic errors", dynamicErrors)
+	}
+
+	// The forward check should pass because collectAllTopicSelectors found the topic.
+	forwardErrors := 0
+	for _, r := range findResultByCode(results, codeContractConsistencyEmit01) {
+		if strings.Contains(r.Message, "no service.go") {
+			forwardErrors++
+		}
+	}
+	if forwardErrors > 0 {
+		t.Errorf("indirect-helper: forward check should pass via selector scan, got %d errors: %v",
+			forwardErrors, findResultByCode(results, codeContractConsistencyEmit01))
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_ExamplesSkipped verifies that contracts under
+// examples/ are not checked by this rule.
+func TestCONTRACTCONSISTENCYEMIT01_ExamplesSkipped(t *testing.T) {
+	root := t.TempDir()
+
+	project := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			"ordercell": {
+				ID:               "ordercell",
+				Type:             "core",
+				ConsistencyLevel: "L2",
+				DurabilityMode:   "durable",
+				Owner:            metadata.OwnerMeta{Team: "examples", Role: "cell-owner"},
+				Schema:           metadata.SchemaMeta{Primary: "orders"},
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.ordercell.startup"}},
+				Dir:              "ordercell",
+				File:             "examples/todoorder/cells/ordercell/cell.yaml",
+			},
+		},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"http.order.create.v1": {
+				ID:               "http.order.create.v1",
+				Kind:             "http",
+				OwnerCell:        "ordercell",
+				ConsistencyLevel: "L2",
+				Lifecycle:        "active",
+				Triggers:         nil, // no triggers — would fail if not skipped
+				Endpoints: metadata.EndpointsMeta{
+					Server:  "ordercell",
+					Clients: []string{"edge-bff"},
+					HTTP: &metadata.HTTPTransportMeta{
+						Method:        "POST",
+						Path:          "/api/v1/orders/",
+						SuccessStatus: 201,
+					},
+				},
+				Dir:  "examples/todoorder/contracts/http/order/create/v1",
+				File: "examples/todoorder/contracts/http/order/create/v1/contract.yaml",
+			},
+		},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	if got := findResultByCode(results, codeContractConsistencyEmit01); len(got) != 0 {
+		t.Errorf("examples-skipped: expected 0 findings, got %d: %v", len(got), got)
+	}
+}

--- a/kernel/governance/rules_consistency_test.go
+++ b/kernel/governance/rules_consistency_test.go
@@ -17,6 +17,18 @@ func buildConsistencyProject(ownerCell string, contracts []*metadata.ContractMet
 	for _, c := range contracts {
 		contractMap[c.ID] = c
 	}
+	for _, c := range contracts {
+		if c.Kind != "http" {
+			continue
+		}
+		for _, trigger := range c.Triggers {
+			if _, exists := contractMap[trigger]; !exists {
+				contractMap[trigger] = eventContract(trigger, ownerCell)
+			}
+		}
+	}
+	slices := map[string]*metadata.SliceMeta{}
+	addSliceUsages(slices, ownerCell, "testslice", defaultContractUsages(contracts)...)
 	return &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{
 			ownerCell: {
@@ -31,7 +43,7 @@ func buildConsistencyProject(ownerCell string, contracts []*metadata.ContractMet
 				File:             "cells/" + ownerCell + "/cell.yaml",
 			},
 		},
-		Slices:     map[string]*metadata.SliceMeta{},
+		Slices:     slices,
 		Contracts:  contractMap,
 		Journeys:   map[string]*metadata.JourneyMeta{},
 		Assemblies: map[string]*metadata.AssemblyMeta{},
@@ -58,6 +70,61 @@ func httpContract(id, ownerCell, consistencyLevel string, triggers []string) *me
 		},
 		Dir:  "contracts/http/test/action/v1",
 		File: "contracts/http/test/action/v1/contract.yaml",
+	}
+}
+
+// eventContract creates a ContractMeta for an event contract whose id is also
+// the outbox topic string.
+func eventContract(id, ownerCell string) *metadata.ContractMeta {
+	return &metadata.ContractMeta{
+		ID:               id,
+		Kind:             "event",
+		OwnerCell:        ownerCell,
+		ConsistencyLevel: "L2",
+		Lifecycle:        "active",
+		Endpoints: metadata.EndpointsMeta{
+			Publisher: ownerCell,
+			Subscribers: []string{
+				"auditcore",
+			},
+		},
+		Dir:  strings.ReplaceAll(id, ".", "/"),
+		File: "contracts/" + strings.ReplaceAll(id, ".", "/") + "/contract.yaml",
+	}
+}
+
+func defaultContractUsages(contracts []*metadata.ContractMeta) []metadata.ContractUsage {
+	seen := map[string]struct{}{}
+	var usages []metadata.ContractUsage
+	for _, c := range contracts {
+		if c.Kind != "http" {
+			continue
+		}
+		usages = append(usages, metadata.ContractUsage{Contract: c.ID, Role: "serve"})
+		for _, trigger := range c.Triggers {
+			if _, ok := seen[trigger]; ok {
+				continue
+			}
+			seen[trigger] = struct{}{}
+			usages = append(usages, metadata.ContractUsage{Contract: trigger, Role: "publish"})
+		}
+	}
+	return usages
+}
+
+func addSliceUsages(slices map[string]*metadata.SliceMeta, ownerCell, sliceID string, usages ...metadata.ContractUsage) {
+	key := ownerCell + "/" + sliceID
+	slices[key] = &metadata.SliceMeta{
+		ID:             sliceID,
+		BelongsToCell:  ownerCell,
+		ContractUsages: usages,
+		Verify: metadata.SliceVerifyMeta{
+			Unit:     []string{"unit." + sliceID + ".service"},
+			Contract: []string{},
+		},
+		Dir:     sliceID,
+		CellDir: ownerCell,
+		File:    "cells/" + ownerCell + "/slices/" + sliceID + "/slice.yaml",
 	}
 }
 
@@ -93,6 +160,22 @@ func findResultByCode(results []ValidationResult, code string) []ValidationResul
 		}
 	}
 	return out
+}
+
+func hasFindingContaining(results []ValidationResult, parts ...string) bool {
+	for _, r := range results {
+		matches := true
+		for _, part := range parts {
+			if !strings.Contains(r.Message, part) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
 }
 
 // TestCONTRACTCONSISTENCYEMIT01_CaseA: L2 contract + triggers + service emits → PASS.
@@ -596,6 +679,14 @@ func register(sub handler) {
 	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
 		httpContract("http.test.a.v1", ownerCell, "L2", []string{topicA}),
 	})
+	project.Slices = map[string]*metadata.SliceMeta{}
+	addSliceUsages(project.Slices, ownerCell, "emitterslice",
+		metadata.ContractUsage{Contract: "http.test.a.v1", Role: "serve"},
+		metadata.ContractUsage{Contract: topicA, Role: "publish"},
+	)
+	addSliceUsages(project.Slices, ownerCell, "subscriberslice",
+		metadata.ContractUsage{Contract: topicB, Role: "subscribe"},
+	)
 
 	v := NewValidator(project, root)
 	results := v.validateCONTRACTCONSISTENCYEMIT01()
@@ -835,5 +926,403 @@ func check(topic string) bool {
 		if strings.Contains(r.Message, topicZ) {
 			t.Errorf("SubscriberSelectorIgnored: dto.TopicZ from comparison-only code must not appear in emit topics; finding: %v", r)
 		}
+	}
+}
+
+func TestCONTRACTCONSISTENCYEMIT01_EmitMustComeFromServingSlice(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+	httpID := "http.test.action.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicTestCreated", topic)
+
+	servingDir := filepath.Join(root, "cells", ownerCell, "slices", "httpslice")
+	writeServiceFile(t, servingDir, `package httpslice
+
+func handle() error {
+	return nil
+}
+`)
+
+	emittingDir := filepath.Join(root, "cells", ownerCell, "slices", "emitterslice")
+	writeServiceFile(t, emittingDir, `package emitterslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	return outbox.Emit(ctx, e, dto.TopicTestCreated, struct{}{})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract(httpID, ownerCell, "L2", []string{topic}),
+	})
+	project.Slices = map[string]*metadata.SliceMeta{}
+	addSliceUsages(project.Slices, ownerCell, "httpslice",
+		metadata.ContractUsage{Contract: httpID, Role: "serve"},
+		metadata.ContractUsage{Contract: topic, Role: "publish"},
+	)
+	addSliceUsages(project.Slices, ownerCell, "emitterslice",
+		metadata.ContractUsage{Contract: topic, Role: "publish"},
+	)
+
+	v := NewValidator(project, root)
+	got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01)
+	if !hasFindingContaining(got, "httpslice", "no non-test Go file", topic) {
+		t.Fatalf("expected serving-slice forward failure for %q, findings: %v", topic, got)
+	}
+}
+
+func TestCONTRACTCONSISTENCYEMIT01_TriggerMustReferenceExistingEventContract(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.missing.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicMissing", topic)
+
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	return outbox.Emit(ctx, e, dto.TopicMissing, struct{}{})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+	})
+	delete(project.Contracts, topic)
+
+	v := NewValidator(project, root)
+	got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01)
+	if !hasFindingContaining(got, "trigger", topic, "existing event contract") {
+		t.Fatalf("expected missing event-contract trigger finding, findings: %v", got)
+	}
+}
+
+func TestCONTRACTCONSISTENCYEMIT01_TriggerMustReferenceEventKind(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	writeDtoConst(t, dtoDir, "TopicCreated", topic)
+
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	return outbox.Emit(ctx, e, dto.TopicCreated, struct{}{})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+		{
+			ID:               topic,
+			Kind:             "command",
+			OwnerCell:        ownerCell,
+			ConsistencyLevel: "L2",
+			Lifecycle:        "active",
+			Endpoints: metadata.EndpointsMeta{
+				Handler: ownerCell,
+			},
+			Dir:  "contracts/command/test/created/v1",
+			File: "contracts/command/test/created/v1/contract.yaml",
+		},
+	})
+
+	v := NewValidator(project, root)
+	got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01)
+	if !hasFindingContaining(got, "trigger", topic, "kind:event") {
+		t.Fatalf("expected non-event trigger finding, findings: %v", got)
+	}
+}
+
+func TestCONTRACTCONSISTENCYEMIT01_ReceiverDynamicTopicRejected(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"fmt"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+type emitter interface {
+	Emit(ctx context.Context, entry outbox.Entry) error
+}
+
+func doEmit(ctx context.Context, e emitter, suffix string) error {
+	return e.Emit(ctx, outbox.Entry{EventType: fmt.Sprintf("event.test.%s.v1", suffix)})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01)
+	dynamicFound := false
+	for _, r := range got {
+		if strings.Contains(r.Message, "dynamic topic") && r.File != "" && r.Line > 0 && r.Column > 0 {
+			dynamicFound = true
+		}
+	}
+	if !dynamicFound {
+		t.Fatalf("expected receiver dynamic-topic finding with source position, findings: %v", got)
+	}
+}
+
+func TestCONTRACTCONSISTENCYEMIT01_HelperDynamicTopicRejected(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic := "event.test.created.v1"
+
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"fmt"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func publish(ctx context.Context, e outbox.Emitter, topic string) error {
+	return outbox.Emit(ctx, e, topic, struct{}{})
+}
+
+func doEmit(ctx context.Context, e outbox.Emitter, suffix string) error {
+	return publish(ctx, e, fmt.Sprintf("event.test.%s.v1", suffix))
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+	})
+
+	v := NewValidator(project, root)
+	got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01)
+	dynamicFound := false
+	for _, r := range got {
+		if strings.Contains(r.Message, "dynamic topic") && r.File != "" && r.Line > 0 && r.Column > 0 {
+			dynamicFound = true
+		}
+	}
+	if !dynamicFound {
+		t.Fatalf("expected helper dynamic-topic finding with source position, findings: %v", got)
+	}
+}
+
+func TestCONTRACTCONSISTENCYEMIT01_HelperAndEntryEvidenceScoped(t *testing.T) {
+	t.Run("helper with same name in another package does not count", func(t *testing.T) {
+		root := t.TempDir()
+		ownerCell := "testcell"
+		topic := "event.test.created.v1"
+
+		dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+		writeDtoConst(t, dtoDir, "TopicTestCreated", topic)
+
+		sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+		writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func publish(ctx context.Context, e outbox.Emitter, topic string) error {
+	return nil
+}
+
+func doWork(ctx context.Context, e outbox.Emitter) error {
+	return publish(ctx, e, dto.TopicTestCreated)
+}
+`)
+		otherPkgDir := filepath.Join(sliceDir, "otherpkg")
+		writeServiceFile(t, otherPkgDir, `package otherpkg
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func publish(ctx context.Context, e outbox.Emitter, topic string) error {
+	return outbox.Emit(ctx, e, topic, struct{}{})
+}
+`)
+
+		project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+			httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+		})
+
+		v := NewValidator(project, root)
+		got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01)
+		if !hasFindingContaining(got, "no non-test Go file", topic) {
+			t.Fatalf("expected same-name helper in another package not to satisfy trigger, findings: %v", got)
+		}
+	})
+
+	t.Run("entry variable in another function does not count", func(t *testing.T) {
+		root := t.TempDir()
+		ownerCell := "testcell"
+		topic := "event.test.created.v1"
+
+		dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+		writeDtoConst(t, dtoDir, "TopicTestCreated", topic)
+
+		sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+		writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+type emitter interface {
+	Emit(ctx context.Context, entry outbox.Entry) error
+}
+
+func unrelated() {
+	entry := outbox.Entry{EventType: dto.TopicTestCreated}
+	_ = entry
+}
+
+func doEmit(ctx context.Context, e emitter) error {
+	return e.Emit(ctx, entry)
+}
+`)
+
+		project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+			httpContract("http.test.action.v1", ownerCell, "L2", []string{topic}),
+		})
+
+		v := NewValidator(project, root)
+		got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01)
+		if !hasFindingContaining(got, "no non-test Go file", topic) {
+			t.Fatalf("expected same-name entry in another function not to satisfy trigger, findings: %v", got)
+		}
+	})
+}
+
+func TestCONTRACTCONSISTENCYEMIT01_ControlFlowAndLocalConstEvidence(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topics := []string{
+		"event.test.if.v1",
+		"event.test.else.v1",
+		"event.test.for.v1",
+		"event.test.range.v1",
+		"event.test.switch.v1",
+		"event.test.typeswitch.v1",
+		"event.test.select.v1",
+		"event.test.var.v1",
+		"event.test.alias.v1",
+		"event.test.literal.v1",
+	}
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	if err := os.MkdirAll(dtoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dtoDir, "topics.go"), []byte(`package dto
+
+const (
+	TopicIf         = "event.test.if.v1"
+	TopicElse       = "event.test.else.v1"
+	TopicFor        = "event.test.for.v1"
+	TopicRange      = "event.test.range.v1"
+	TopicSwitch     = "event.test.switch.v1"
+	TopicTypeSwitch = "event.test.typeswitch.v1"
+	TopicSelect     = "event.test.select.v1"
+	TopicVar        = "event.test.var.v1"
+	TopicAlias      = "event.test.alias.v1"
+)
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+const LocalAlias = dto.TopicAlias
+
+type emitter interface {
+	Emit(ctx context.Context, entry outbox.Entry) error
+}
+
+func doEmit(ctx context.Context, receiver emitter, out outbox.Emitter, ch <-chan struct{}, value any, n int) error {
+	if n > 0 {
+		entry := outbox.Entry{EventType: dto.TopicIf}
+		_ = receiver.Emit(ctx, entry)
+	} else {
+		entry := outbox.Entry{EventType: dto.TopicElse}
+		_ = receiver.Emit(ctx, entry)
+	}
+	for i := 0; i < 1; i++ {
+		_ = outbox.Emit(ctx, out, dto.TopicFor, struct{}{})
+	}
+	for range []int{1} {
+		_ = outbox.Emit(ctx, out, dto.TopicRange, struct{}{})
+	}
+	switch n {
+	case 1:
+		_ = outbox.Emit(ctx, out, dto.TopicSwitch, struct{}{})
+	}
+	switch value.(type) {
+	case string:
+		_ = outbox.Emit(ctx, out, dto.TopicTypeSwitch, struct{}{})
+	}
+	select {
+	case <-ch:
+		_ = outbox.Emit(ctx, out, dto.TopicSelect, struct{}{})
+	default:
+	}
+	var declared = outbox.Entry{EventType: dto.TopicVar}
+	_ = receiver.Emit(ctx, declared)
+	_ = outbox.Emit(ctx, out, LocalAlias, struct{}{})
+	return outbox.Emit(ctx, out, "event.test.literal.v1", struct{}{})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.control.v1", ownerCell, "L2", topics),
+	})
+
+	v := NewValidator(project, root)
+	if got := findResultByCode(v.validateCONTRACTCONSISTENCYEMIT01(), codeContractConsistencyEmit01); len(got) != 0 {
+		t.Fatalf("control-flow/local-const evidence should satisfy all triggers, got %d findings: %v", len(got), got)
 	}
 }

--- a/kernel/governance/rules_consistency_test.go
+++ b/kernel/governance/rules_consistency_test.go
@@ -535,3 +535,220 @@ func TestCONTRACTCONSISTENCYEMIT01_ExamplesSkipped(t *testing.T) {
 		t.Errorf("examples-skipped: expected 0 findings, got %d: %v", len(got), got)
 	}
 }
+
+// TestCONTRACTCONSISTENCYEMIT01_SubscriberTopicNotCollected is a regression test
+// for A2: collectAllTopicSelectors must NOT be called for files that contain no real
+// emit call sites. A slice that only subscribes to dto.TopicB must not contribute
+// dto.TopicB to the cell's emit-topic set.
+func TestCONTRACTCONSISTENCYEMIT01_SubscriberTopicNotCollected(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topicA := "event.test.a.v1"
+	topicB := "event.test.b.v1"
+
+	// dto has both constants.
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	if err := os.MkdirAll(dtoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dtoDir, "topics.go"), []byte("package dto\n\nconst (\n\tTopicA = \""+topicA+"\"\n\tTopicB = \""+topicB+"\"\n)\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// emitter-slice: emits TopicA via outbox.Emit.
+	emitterDir := filepath.Join(root, "cells", ownerCell, "slices", "emitterslice")
+	writeServiceFile(t, emitterDir, `package emitterslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	return outbox.Emit(ctx, e, dto.TopicA, struct{}{})
+}
+`)
+
+	// subscriber-slice: subscribes to TopicB — but does NOT emit. Uses dto.TopicB only
+	// in a subscribe call. This file must NOT contribute TopicB to emit topics.
+	subDir := filepath.Join(root, "cells", ownerCell, "slices", "subscriberslice")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "service.go"), []byte(`package subscriberslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+)
+
+type handler func(ctx context.Context, topic string) error
+
+func register(sub handler) {
+	sub(context.Background(), dto.TopicB)
+}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Contract declares only TopicA as trigger (L2).
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.a.v1", ownerCell, "L2", []string{topicA}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+
+	// TopicB must NOT appear in emit topics — no reverse finding for it.
+	for _, r := range got {
+		if strings.Contains(r.Message, topicB) {
+			t.Errorf("SubscriberTopicNotCollected: dto.TopicB from subscriber-only file must not appear in emit topics; finding: %v", r)
+		}
+	}
+	// TopicA is correctly emitted and declared — no forward/reverse errors for it.
+	if len(got) != 0 {
+		t.Errorf("SubscriberTopicNotCollected: expected 0 findings, got %d: %v", len(got), got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseE_ReverseMismatch is the existing CaseE renamed
+// to clarify it tests the reverse-mismatch (emit without declaration) path.
+// The original CaseE function is preserved under its original name for git history.
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseE_NoOpPassthrough: L0 contract, no triggers, no
+// service.go for the cell → 0 ValidationResults (bottom-out path that was missing).
+func TestCONTRACTCONSISTENCYEMIT01_CaseE_NoOpPassthrough(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+
+	// L0 HTTP contract — no triggers, no cells/<ownerCell>/slices directory.
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.noop.v1", ownerCell, "L0", nil),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+	if len(got) != 0 {
+		t.Errorf("CaseE_NoOpPassthrough: expected 0 findings for L0 no-triggers, got %d: %v", len(got), got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_CaseD_ReceiverStyle: receiver-style Emit emits TopicX,
+// contract declares TopicY. Expects both forward (declared Y but no emit Y) and
+// reverse (emit X but no declare X) findings.
+func TestCONTRACTCONSISTENCYEMIT01_CaseD_ReceiverStyle(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	declaredTopic := "event.y.v1"
+	emittedTopic := "event.x.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	if err := os.MkdirAll(dtoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dtoDir, "topics.go"), []byte("package dto\n\nconst (\n\tTopicX = \""+emittedTopic+"\"\n\tTopicY = \""+declaredTopic+"\"\n)\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+type emitter interface {
+	Emit(ctx context.Context, entry outbox.Entry) error
+}
+
+func doEmit(ctx context.Context, e emitter) error {
+	return e.Emit(ctx, outbox.Entry{EventType: dto.TopicX})
+}
+`)
+
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.y.v1", ownerCell, "L2", []string{declaredTopic}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+
+	forwardFail := false
+	reverseFail := false
+	for _, r := range got {
+		if strings.Contains(r.Message, "no non-test Go file") && strings.Contains(r.Message, declaredTopic) {
+			forwardFail = true
+		}
+		if strings.Contains(r.Message, "service emits") && strings.Contains(r.Message, emittedTopic) {
+			reverseFail = true
+		}
+	}
+	if !forwardFail {
+		t.Errorf("CaseD_ReceiverStyle: expected forward failure for %q, findings: %v", declaredTopic, got)
+	}
+	if !reverseFail {
+		t.Errorf("CaseD_ReceiverStyle: expected reverse failure for %q, findings: %v", emittedTopic, got)
+	}
+}
+
+// TestCONTRACTCONSISTENCYEMIT01_MultiContractNoDuplicateFindings: same ownerCell has
+// 2 L2 HTTP contracts each declaring 1 trigger; service emits a 3rd topic not in either
+// contract. Assert the reverse finding for the 3rd topic appears exactly once.
+func TestCONTRACTCONSISTENCYEMIT01_MultiContractNoDuplicateFindings(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "testcell"
+	topic1 := "event.test.one.v1"
+	topic2 := "event.test.two.v1"
+	extraTopic := "event.test.extra.v1"
+
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	if err := os.MkdirAll(dtoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dtoDir, "topics.go"), []byte("package dto\n\nconst (\n\tTopicOne   = \""+topic1+"\"\n\tTopicTwo   = \""+topic2+"\"\n\tTopicExtra = \""+extraTopic+"\"\n)\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "testslice")
+	writeServiceFile(t, sliceDir, `package testslice
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/testcell/internal/dto"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+func doEmit(ctx context.Context, e outbox.Emitter) error {
+	_ = outbox.Emit(ctx, e, dto.TopicOne, struct{}{})
+	_ = outbox.Emit(ctx, e, dto.TopicTwo, struct{}{})
+	return outbox.Emit(ctx, e, dto.TopicExtra, struct{}{})
+}
+`)
+
+	// Two L2 contracts, each declaring one of the two topics.
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.test.one.v1", ownerCell, "L2", []string{topic1}),
+		httpContract("http.test.two.v1", ownerCell, "L2", []string{topic2}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+
+	extraCount := 0
+	for _, r := range got {
+		if strings.Contains(r.Message, "service emits") && strings.Contains(r.Message, extraTopic) {
+			extraCount++
+		}
+	}
+	if extraCount != 1 {
+		t.Errorf("MultiContractNoDuplicateFindings: expected exactly 1 reverse finding for %q, got %d; findings: %v",
+			extraTopic, extraCount, got)
+	}
+}

--- a/kernel/governance/rules_consistency_test.go
+++ b/kernel/governance/rules_consistency_test.go
@@ -213,7 +213,7 @@ func doEmit(ctx context.Context, e outbox.Emitter) error {
 	forwardFail := false
 	reverseFail := false
 	for _, r := range got {
-		if strings.Contains(r.Message, "no service.go") && strings.Contains(r.Message, declaredTopic) {
+		if strings.Contains(r.Message, "no non-test Go file") && strings.Contains(r.Message, declaredTopic) {
 			forwardFail = true
 		}
 		if strings.Contains(r.Message, "service emits") && strings.Contains(r.Message, emittedTopic) {
@@ -320,13 +320,21 @@ func doEmit(ctx context.Context, e outbox.Emitter, v string) error {
 	got := findResultByCode(results, codeContractConsistencyEmit01)
 
 	dynamicFail := false
+	relPathOK := false
 	for _, r := range got {
 		if strings.Contains(r.Message, "dynamic topic in emit") {
 			dynamicFail = true
+			// B4: file path in finding must be relative (not absolute).
+			if r.File != "" && !strings.HasPrefix(r.File, "/") {
+				relPathOK = true
+			}
 		}
 	}
 	if !dynamicFail {
 		t.Errorf("case F: expected dynamic topic error, findings: %v", got)
+	}
+	if !relPathOK {
+		t.Errorf("case F: dynamic topic finding must report a relative file path, findings: %v", got)
 	}
 }
 
@@ -466,7 +474,7 @@ func doWork(ctx context.Context, e outbox.Emitter) error {
 	// The forward check should pass because collectAllTopicSelectors found the topic.
 	forwardErrors := 0
 	for _, r := range findResultByCode(results, codeContractConsistencyEmit01) {
-		if strings.Contains(r.Message, "no service.go") {
+		if strings.Contains(r.Message, "no non-test Go file") {
 			forwardErrors++
 		}
 	}

--- a/kernel/governance/rules_consistency_test.go
+++ b/kernel/governance/rules_consistency_test.go
@@ -752,3 +752,88 @@ func doEmit(ctx context.Context, e outbox.Emitter) error {
 			extraTopic, extraCount, got)
 	}
 }
+
+// TestCONTRACTCONSISTENCYEMIT01_SubscriberSelectorIgnored is a regression test
+// verifying that a subscribe(ctx, dto.TopicY, h) call and a comparison
+// `if topic == dto.TopicZ {}` in a service file do NOT contribute their topic
+// selectors to the cell's emit-topic set. Only actual outbox.Emit calls (or
+// receiver *.Emit calls with an outbox.Entry) count as emit evidence.
+//
+// Setup:
+//   - Cell "foo" has one HTTP contract with consistencyLevel: L2 and
+//     triggers: [event.foo.y.v1].
+//   - The cell's service.go subscribes to dto.TopicY and compares dto.TopicZ
+//     but contains NO outbox.Emit call to either topic.
+//
+// Expected: forward-check fails because nothing actually emits event.foo.y.v1.
+func TestCONTRACTCONSISTENCYEMIT01_SubscriberSelectorIgnored(t *testing.T) {
+	root := t.TempDir()
+	ownerCell := "foo"
+	topicY := "event.foo.y.v1"
+	topicZ := "event.foo.z.v1"
+
+	// Write dto with both constants.
+	dtoDir := filepath.Join(root, "cells", ownerCell, "internal", "dto")
+	if err := os.MkdirAll(dtoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dtoDir, "topics.go"), []byte(
+		"package dto\n\nconst (\n\tTopicY = \""+topicY+"\"\n\tTopicZ = \""+topicZ+"\"\n)\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// handler/service.go: subscribes to dto.TopicY and compares dto.TopicZ —
+	// but contains NO outbox.Emit call to either.
+	sliceDir := filepath.Join(root, "cells", ownerCell, "slices", "handler")
+	if err := os.MkdirAll(sliceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sliceDir, "service.go"), []byte(`package handler
+
+import (
+	"context"
+	"github.com/ghbvf/gocell/cells/foo/internal/dto"
+)
+
+type subscribeFn func(ctx context.Context, topic string, handler func()) error
+
+func register(ctx context.Context, sub subscribeFn) error {
+	return sub(ctx, dto.TopicY, func() {})
+}
+
+func check(topic string) bool {
+	return topic == dto.TopicZ
+}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Contract declares trigger event.foo.y.v1 (L2).
+	project := buildConsistencyProject(ownerCell, []*metadata.ContractMeta{
+		httpContract("http.foo.x.v1", ownerCell, "L2", []string{topicY}),
+	})
+
+	v := NewValidator(project, root)
+	results := v.validateCONTRACTCONSISTENCYEMIT01()
+	got := findResultByCode(results, codeContractConsistencyEmit01)
+
+	// Forward check must fail: no file actually emits event.foo.y.v1.
+	forwardFail := false
+	for _, r := range got {
+		if strings.Contains(r.Message, "no non-test Go file") && strings.Contains(r.Message, topicY) {
+			forwardFail = true
+		}
+	}
+	if !forwardFail {
+		t.Errorf("SubscriberSelectorIgnored: expected forward-check failure for %q (subscriber/comparison must not count as emit); findings: %v",
+			topicY, got)
+	}
+
+	// TopicZ must NOT appear as an emitted topic (no reverse finding for it).
+	for _, r := range got {
+		if strings.Contains(r.Message, topicZ) {
+			t.Errorf("SubscriberSelectorIgnored: dto.TopicZ from comparison-only code must not appear in emit topics; finding: %v", r)
+		}
+	}
+}

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -386,15 +386,33 @@ const (
 	fieldSchemaRefsResponse = "schemaRefs.response"
 )
 
-// validateFMT13 checks optional HTTP transport metadata on migrated HTTP contracts.
-// Legacy HTTP contracts may omit endpoints.http entirely, but once present it must
-// be internally consistent and must not conflict with no-content semantics.
+// validateFMT13 checks HTTP transport metadata on contracts.
+//
+// Two cases are checked:
+//   - kind=http with nil endpoints.http → Error: required block missing (FMT-13 必填化)
+//   - any kind with non-nil endpoints.http → delegate to validateFMT13ForContract,
+//     which rejects non-http contracts declaring endpoints.http and validates the
+//     block's internal consistency for http contracts.
 func (v *Validator) validateFMT13() []ValidationResult {
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
-		if c.Endpoints.HTTP == nil {
+		isHTTP := cell.ContractKind(c.Kind) == cell.ContractHTTP
+		if isHTTP && c.Endpoints.HTTP == nil {
+			// FMT-13 必填化: HTTP contracts must now declare endpoints.http.
+			results = append(results, v.newResult(
+				codeFMT13, SeverityError, IssueRequired,
+				contractFile(c),
+				"endpoints.http",
+				fmt.Sprintf("HTTP contract %q must declare endpoints.http (method/path/successStatus)", c.ID),
+			))
 			continue
 		}
+		if c.Endpoints.HTTP == nil {
+			// Non-HTTP contract without endpoints.http — nothing to validate.
+			continue
+		}
+		// endpoints.http is non-nil: validate it (validateFMT13ForContract also
+		// rejects non-http contracts that erroneously declare endpoints.http).
 		results = append(results, v.validateFMT13ForContract(c)...)
 	}
 	return results

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -403,7 +403,7 @@ func (v *Validator) validateFMT13() []ValidationResult {
 				codeFMT13, SeverityError, IssueRequired,
 				contractFile(c),
 				"endpoints.http",
-				fmt.Sprintf("HTTP contract %q must declare endpoints.http (method/path/successStatus)", c.ID),
+				fmt.Sprintf("HTTP contract %q must declare endpoints.http; add to contract.yaml:\n  http:\n    method: GET                # GET|POST|PUT|PATCH|DELETE\n    path: /api/v1/...\n    successStatus: 200\n    noContent: false", c.ID),
 			))
 			continue
 		}

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -57,8 +57,11 @@ func TestFMT13_MissingEndpointsHTTP(t *testing.T) {
 	if len(fmt13Errors) != 1 {
 		t.Fatalf("FMT-13 missing endpoints.http: expected 1 error, got %d: %v", len(fmt13Errors), fmt13Errors)
 	}
-	if !strings.Contains(fmt13Errors[0].Message, "must declare endpoints.http") {
-		t.Errorf("FMT-13: expected 'must declare endpoints.http' in message, got: %s", fmt13Errors[0].Message)
+	if !strings.Contains(fmt13Errors[0].Message, "endpoints.http") {
+		t.Errorf("FMT-13: expected 'endpoints.http' in message, got: %s", fmt13Errors[0].Message)
+	}
+	if !strings.Contains(fmt13Errors[0].Message, "method:") {
+		t.Errorf("FMT-13: expected 'method:' YAML template in message, got: %s", fmt13Errors[0].Message)
 	}
 }
 

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -1,0 +1,138 @@
+package governance
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// TestFMT13_MissingEndpointsHTTP verifies that an HTTP contract without
+// endpoints.http produces a FMT-13 SeverityError.
+func TestFMT13_MissingEndpointsHTTP(t *testing.T) {
+	project := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			"accesscore": {
+				ID:               "accesscore",
+				Type:             "core",
+				ConsistencyLevel: "L1",
+				Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+				Schema:           metadata.SchemaMeta{Primary: "cell_access_core"},
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.accesscore.startup"}},
+				Dir:              "accesscore",
+				File:             "cells/accesscore/cell.yaml",
+			},
+		},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"http.test.missing.v1": {
+				ID:               "http.test.missing.v1",
+				Kind:             "http",
+				OwnerCell:        "accesscore",
+				ConsistencyLevel: "L1",
+				Lifecycle:        "active",
+				Endpoints: metadata.EndpointsMeta{
+					Server:  "accesscore",
+					Clients: []string{"edge-bff"},
+					// HTTP is nil — missing endpoints.http
+				},
+				Dir:  "contracts/http/test/missing/v1",
+				File: "contracts/http/test/missing/v1/contract.yaml",
+			},
+		},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+
+	v := NewValidator(project, "")
+	results := v.validateFMT13()
+
+	var fmt13Errors []ValidationResult
+	for _, r := range results {
+		if r.Code == codeFMT13 && r.Severity == SeverityError {
+			fmt13Errors = append(fmt13Errors, r)
+		}
+	}
+
+	if len(fmt13Errors) != 1 {
+		t.Fatalf("FMT-13 missing endpoints.http: expected 1 error, got %d: %v", len(fmt13Errors), fmt13Errors)
+	}
+	if !strings.Contains(fmt13Errors[0].Message, "must declare endpoints.http") {
+		t.Errorf("FMT-13: expected 'must declare endpoints.http' in message, got: %s", fmt13Errors[0].Message)
+	}
+}
+
+// TestFMT13_NonHTTPContractSkipped verifies that non-HTTP contracts are not
+// flagged by FMT-13 even when they have no endpoints.http block.
+func TestFMT13_NonHTTPContractSkipped(t *testing.T) {
+	project := &metadata.ProjectMeta{
+		Cells:  map[string]*metadata.CellMeta{},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"event.test.created.v1": {
+				ID:               "event.test.created.v1",
+				Kind:             "event",
+				OwnerCell:        "accesscore",
+				ConsistencyLevel: "L2",
+				Lifecycle:        "active",
+				Endpoints: metadata.EndpointsMeta{
+					Publisher:   "accesscore",
+					Subscribers: []string{"auditcore"},
+				},
+				Dir:  "contracts/event/test/created/v1",
+				File: "contracts/event/test/created/v1/contract.yaml",
+			},
+		},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+
+	v := NewValidator(project, "")
+	results := v.validateFMT13()
+
+	for _, r := range results {
+		if r.Code == codeFMT13 {
+			t.Errorf("FMT-13: unexpected finding on non-HTTP contract: %v", r)
+		}
+	}
+}
+
+// TestFMT13_HTTPContractWithEndpoints verifies that an HTTP contract with
+// a valid endpoints.http block produces no FMT-13 error.
+func TestFMT13_HTTPContractWithEndpoints(t *testing.T) {
+	project := &metadata.ProjectMeta{
+		Cells:  map[string]*metadata.CellMeta{},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"http.test.ok.v1": {
+				ID:               "http.test.ok.v1",
+				Kind:             "http",
+				OwnerCell:        "accesscore",
+				ConsistencyLevel: "L1",
+				Lifecycle:        "active",
+				Endpoints: metadata.EndpointsMeta{
+					Server:  "accesscore",
+					Clients: []string{"edge-bff"},
+					HTTP: &metadata.HTTPTransportMeta{
+						Method:        "GET",
+						Path:          "/api/v1/test",
+						SuccessStatus: 200,
+					},
+				},
+				Dir:  "contracts/http/test/ok/v1",
+				File: "contracts/http/test/ok/v1/contract.yaml",
+			},
+		},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+
+	v := NewValidator(project, "")
+	results := v.validateFMT13()
+
+	for _, r := range results {
+		if r.Code == codeFMT13 && r.Severity == SeverityError {
+			t.Errorf("FMT-13: unexpected error for contract with valid endpoints.http: %v", r)
+		}
+	}
+}

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -156,6 +156,7 @@ func (v *Validator) rules() []func() []ValidationResult {
 		v.validateFMTContractDirIDMatch01,
 		v.validateStatusBoardStateEnum01,
 		v.validateContractDeprecatedCleanup01,
+		v.validateCONTRACTCONSISTENCYEMIT01,
 	}
 }
 

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -110,6 +110,15 @@ func validProject() *metadata.ProjectMeta {
 				Endpoints: metadata.EndpointsMeta{
 					Server:  "accesscore",
 					Clients: []string{"auditcore"},
+					// FMT-13 now requires endpoints.http on all HTTP contracts.
+					// Use NoContent:true / 204 so no response schema file is needed,
+					// keeping validProject self-contained (no filesystem deps).
+					HTTP: &metadata.HTTPTransportMeta{
+						Method:        "DELETE",
+						Path:          "/api/v1/access/sessions/login",
+						SuccessStatus: 204,
+						NoContent:     true,
+					},
 				},
 				Dir:  "contracts/http/auth/login/v1",
 				File: "contracts/http/auth/login/v1/contract.yaml",
@@ -2967,10 +2976,15 @@ func TestFMT13(t *testing.T) {
 		wantField    string
 	}{
 		{
-			name:         "legacy http contract without transport metadata is allowed",
-			setup:        func(_ *metadata.ProjectMeta) {},
-			wantErrors:   0,
+			// FMT-13 now requires endpoints.http on all HTTP contracts (FMT-13 必填化).
+			// Remove the endpoints.http from the contract to trigger the error.
+			name: "http contract without transport metadata is now required (FMT-13必填化)",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.auth.login.v1"].Endpoints.HTTP = nil
+			},
+			wantErrors:   1,
 			wantWarnings: 0,
+			wantField:    "endpoints.http",
 		},
 		{
 			name: "complete migrated http contract is allowed",

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -98,7 +98,13 @@ type ContractMeta struct {
 	OwnerCell         string         `yaml:"ownerCell"`
 	ConsistencyLevel  string         `yaml:"consistencyLevel"`
 	Lifecycle         string         `yaml:"lifecycle"`          // draft|active|deprecated
-	Triggers          []string       `yaml:"triggers,omitempty"` // event topics emitted by this contract's handler (L2+)
+	// Triggers lists the outbox event topics emitted by this contract's owner
+	// cell when the HTTP handler succeeds. Required for L2+ HTTP contracts.
+	// Each value MUST be a string literal or named constant (dto.TopicX /
+	// domain.TopicX); dynamic expressions (fmt.Sprintf, variables) are rejected
+	// by CONTRACT-CONSISTENCY-EMIT-01. Validated bidirectionally against
+	// outbox.Emit call sites in cells/<ownerCell>/slices/**/service.go.
+	Triggers []string `yaml:"triggers,omitempty"`
 	Endpoints         EndpointsMeta  `yaml:"endpoints"`
 	SchemaRefs        SchemaRefsMeta `yaml:"schemaRefs,omitempty"`
 	Replayable        *bool          `yaml:"replayable,omitempty"`

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -97,7 +97,7 @@ type ContractMeta struct {
 	Kind              string         `yaml:"kind"` // http|event|command|projection
 	OwnerCell         string         `yaml:"ownerCell"`
 	ConsistencyLevel  string         `yaml:"consistencyLevel"`
-	Lifecycle         string         `yaml:"lifecycle"` // draft|active|deprecated
+	Lifecycle         string         `yaml:"lifecycle"`          // draft|active|deprecated
 	Triggers          []string       `yaml:"triggers,omitempty"` // event topics emitted by this contract's handler (L2+)
 	Endpoints         EndpointsMeta  `yaml:"endpoints"`
 	SchemaRefs        SchemaRefsMeta `yaml:"schemaRefs,omitempty"`

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -93,18 +93,18 @@ type WaiverMeta struct {
 
 // ContractMeta maps to contracts/{kind}/{domain...}/{version}/contract.yaml.
 type ContractMeta struct {
-	ID                string         `yaml:"id"`
-	Kind              string         `yaml:"kind"` // http|event|command|projection
-	OwnerCell         string         `yaml:"ownerCell"`
-	ConsistencyLevel  string         `yaml:"consistencyLevel"`
-	Lifecycle         string         `yaml:"lifecycle"`          // draft|active|deprecated
+	ID               string `yaml:"id"`
+	Kind             string `yaml:"kind"` // http|event|command|projection
+	OwnerCell        string `yaml:"ownerCell"`
+	ConsistencyLevel string `yaml:"consistencyLevel"`
+	Lifecycle        string `yaml:"lifecycle"` // draft|active|deprecated
 	// Triggers lists the outbox event topics emitted by this contract's owner
 	// cell when the HTTP handler succeeds. Required for L2+ HTTP contracts.
 	// Each value MUST be a string literal or named constant (dto.TopicX /
 	// domain.TopicX); dynamic expressions (fmt.Sprintf, variables) are rejected
 	// by CONTRACT-CONSISTENCY-EMIT-01. Validated bidirectionally against
 	// outbox.Emit call sites in cells/<ownerCell>/slices/**/service.go.
-	Triggers []string `yaml:"triggers,omitempty"`
+	Triggers          []string       `yaml:"triggers,omitempty"`
 	Endpoints         EndpointsMeta  `yaml:"endpoints"`
 	SchemaRefs        SchemaRefsMeta `yaml:"schemaRefs,omitempty"`
 	Replayable        *bool          `yaml:"replayable,omitempty"`

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -98,6 +98,7 @@ type ContractMeta struct {
 	OwnerCell         string         `yaml:"ownerCell"`
 	ConsistencyLevel  string         `yaml:"consistencyLevel"`
 	Lifecycle         string         `yaml:"lifecycle"` // draft|active|deprecated
+	Triggers          []string       `yaml:"triggers,omitempty"` // event topics emitted by this contract's handler (L2+)
 	Endpoints         EndpointsMeta  `yaml:"endpoints"`
 	SchemaRefs        SchemaRefsMeta `yaml:"schemaRefs,omitempty"`
 	Replayable        *bool          `yaml:"replayable,omitempty"`


### PR DESCRIPTION
## Summary

PR-CFG-G2 (~6.5h plan, ~9h actual) — **纯 contract / governance / UX / docs 层** 治理收尾，与 G1 文件域无交集。从 batch2 plan `docs/plans/202604260058-l4-virtual-taco.md` 派生。

- **G.4 contract.consistencyLevel ↔ emit 真一致**（11 个 L2+ HTTP contract 全集）
  - 6 个 L0/L1 → L2 + 添加 `triggers`：`auth/user/{create,lock}`, `auth/login`, `auth/session/delete`, `auth/role/{assign,revoke}`
  - 5 个已 L2 + 添加 `triggers`：`config/{write,update,delete,publish,rollback}`, `auth/setup/admin`
  - 5 个反向漂移修正（声明 L2 但 service 不 emit）：`audit/list` L2→L0；`config/flags/{create,update,delete,toggle}` L2→L1
  - 新规则 `kernel/governance/rules_consistency.go::CONTRACT-CONSISTENCY-EMIT-01` 三段约束（L2+ ⟹ triggers ∧ triggers ⟹ L2+ ∧ 双向 emit AST 匹配；动态 topic 即 fail）
  - FMT-13 必填化（HTTP contract 缺 `endpoints.http` 直接 fail；blast radius=0）
  - 删除 `contracts/http/config/update/v1/request.schema.json::sensitive` 字段（handler/service/repo 从未读取）
- **G.5 UX**
  - `FeatureFlagResponse` 新增 `description`/`version`/`createdAt`/`updatedAt`（domain/repo 已有，纯 DTO 映射）；同步 `flags/list+get` schema
  - `POST /api/v1/config/{key}/publish` 200 → **201 Created**（语义对齐 write/create）
- **G.7 D/E 合并后 review C.1 残尾**
  - 顶层 `README.md` quickstart 重写为 5 步可执行（openssl→env→`localtoken`→go run→curl），修复 PR #281 后失效路径
  - `examples/iotdevice/README.md` dequeue/enqueue 示例补 `commandType` + 可选性
  - `docs/guides/integration-testing.md` step 2 用条件 skip 取代无条件 `t.Skip`（与 PR #276 unconditionalskip analyzer 对齐）
  - `cmd/gocell check slice-coverage --cell=<unknown>` 不再假绿（返回 `CHECK-CELL-NOT-FOUND`）
  - `cmd/gocell check unconditional-skip` 加 `BuildFlags=-tags=integration,e2e,examples_smoke`（之前 build-tagged 测试静默漏检）；连带删除 `adapters/vault/readiness_test.go::TestTransitReadiness_ReadyzHTTPIntegration` 永久 stub

## Refs
- PR-CFG-G2 from `docs/plans/202604260058-l4-virtual-taco.md`
- ref: `tools/archtest/outbox_service_test.go` AST 同包常量传播 pattern（CONSISTENCY-EMIT-01 复用）
- ref: `golang.org/x/tools/go/analysis/passes/nilness` 规则纪律
- ref: kratos examples HTTP contract 201 vs 200 create 语义

## Commits
1. `4e5009a6` c1 — 16 contract.yaml 调齐 + sensitive 字段删除 + `ContractMeta.Triggers` 字段
2. `c7f0db3d` c2 — 新规则 + FMT-13 必填化（kernel/governance/）
3. `075d45d3` c3 — FeatureFlagResponse + schema + publish 201
4. `6fce27ff` c4 — README × 2 + integration-testing.md + check.go × 2
5. `64f9430e` style — gofmt comment alignment
6. `fea36491` test — corebundle integration test publish 200→201

## Test plan
- [x] `go build ./...` 0 errors
- [x] `go test ./...` 全绿（`runtime/http/router` WebSocket 测试本地需 `dangerouslyDisableSandbox` due to bind permission）
- [x] `go test -tags=integration` CI scope 全绿（adapters/postgres+redis+rabbitmq+vault+oidc+otel+ratelimit+s3+websocket+ssobff+iotdevice+todoorder+identitymanage+bootstrap+corebundle）
- [x] `go run ./cmd/gocell validate --strict` 0 errors
- [x] `golangci-lint run ./...` 0 issues
- [x] `gocell check slice-coverage --cell=does-not-exist` exits 1 with `CHECK-CELL-NOT-FOUND`
- [x] `gocell check unconditional-skip ./...` 0 unhandled
- [x] 顶层 README quickstart 实际可执行（mint token + curl 200/201）
- [x] 新规则 `CONTRACT-CONSISTENCY-EMIT-01` 测试覆盖 6 cases (A-F)：合规 / level mismatch / no triggers / forward miss / reverse miss / dynamic topic
- [x] FMT-13 测试覆盖：HTTP contract 缺 endpoints.http → fail

## Not done (out of scope, by design)
- 不引入 `PATCH /config/{key}/sensitive` 端点（未来需求）
- 不改 `evaluate` schema（极简语义有意保留）
- 不改 `auth/refresh` / `auth/role/list` consistencyLevel（grep 已确认不 emit，当前声明正确）
- 不改 service.go 业务逻辑（G1 范围）
- 不动 `boundary.yaml`（PR-CFG-I.X2 范围）
- 不动 `cell_init.go::ensureCursorCodec`（PR-CFG-I.X3 范围）

🤖 Generated with [Claude Code](https://claude.com/claude-code)