### PR TITLE
feat(governance): enforce active journey auto checks

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -135,12 +135,13 @@ jobs:
 
       - name: Validate metadata
         if: matrix.static_checks
-        # --strict gates FMT-16/17 (no-dash dirs, allowedFiles match) + FMT-C1/A1
-        # (cell/assembly id no-dash). Mirrors governance.yml's required check —
-        # keeping both wired keeps strict-mode regressions visible on the kernel
-        # shard even if the governance workflow is skipped (fork PR / matrix
-        # rerun edge cases).
+        # --strict gates metadata promotion rules, including active journey
+        # checkRefs resolving to real executable tests.
         run: go run ./cmd/gocell validate --strict
+
+      - name: Verify active journeys
+        if: matrix.static_checks
+        run: go run ./cmd/gocell verify journey --active
 
       - name: Check contract health
         if: matrix.static_checks

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Validate metadata (strict)
         run: go run ./cmd/gocell validate --strict
 
+      - name: Verify active journeys
+        run: go run ./cmd/gocell verify journey --active
+
       - name: Scaffold rejects kebab slice names
         run: |
           set +e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ actors.yaml   — 外部 Actor 注册（参与 contract 但不属于 Cell 模型
 - Cell 之间只通过 contract 通信，禁止直接 import 另一个 Cell 的 internal/
   - 例外：L0 Cell（纯计算库）可被同一 assembly 内的兄弟 Cell 直接 import，无需 contract
 - 动态交付状态（readiness / risk / blocker / done / verified / nextAction / updatedAt）只有 `risk` / `blocker` / `updatedAt` 三字段在 `journeys/status-board.yaml` 的 `StatusBoardEntry` 中合法；其余字段（readiness / done / verified / nextAction）以及所有这些字段出现在 cell.yaml / slice.yaml / contract.yaml / assembly.yaml / journey.yaml 中，均被 `kernel/metadata` parser 的 `yaml.KnownFields(true)` 在解析期拒绝
-- `lifecycle`（draft / active / deprecated）是治理字段，允许写在 contract.yaml 中
+- `contract.lifecycle`（draft / active / deprecated）和 `journey.lifecycle`（active / experimental）是治理字段；active journey 在 strict 模式必须至少有 1 条 auto check
 - cell.yaml 不维护 slices、journeys、contracts 反向索引；如需汇总视图，由工具生成
 - 禁止使用旧字段名：cellId / sliceId / contractId / assemblyId / ownedSlices / authoritativeData / producer / consumers / callsContracts / publishes / consumes（详见 metadata-model-v3.md 迁移附录）
 

--- a/cmd/gocell/app/dispatch.go
+++ b/cmd/gocell/app/dispatch.go
@@ -79,7 +79,7 @@ func PrintUsage() {
 	fmt.Println("    journey-readiness --journey=<journeyID>")
 	fmt.Println("    l0-imports --cell=<cellID>")
 	fmt.Println("    unconditional-skip [--format text|json|sarif]")
-	fmt.Println("  verify      Run tests (slice/cell/journey)           [--id, --files]")
+	fmt.Println("  verify      Run tests (slice/cell/journey)           [--id, --active, --files]")
 	fmt.Println()
 	fmt.Println("Run 'gocell <command> -h' for full flag help on a sub-command.")
 }

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -454,6 +454,54 @@ passCriteria:
 	assert.Contains(t, out, "VERIFY-06")
 }
 
+func TestRunValidate_Strict_DetectsStaleActiveJourneyCheckRef(t *testing.T) {
+	dir := setupProject(t, "cells/platform", "journeys", "tests/integration")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "platform", "cell.yaml"), []byte(`id: platform
+type: core
+consistencyLevel: L1
+owner:
+  team: squad
+  role: cell-owner
+schema:
+  primary: cell_platform
+verify:
+  smoke:
+    - smoke.platform.startup
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "J-stale.yaml"), []byte(`id: J-stale
+goal: stale auto check
+lifecycle: active
+owner:
+  team: squad
+  role: journey-owner
+cells:
+  - platform
+contracts: []
+passCriteria:
+  - text: stale target
+    mode: auto
+    checkRef: journey.J-stale.missing
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "status-board.yaml"), []byte(`- journeyId: J-stale
+  state: todo
+  risk: low
+  blocker: ""
+  updatedAt: 2026-04-27
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tests", "integration", "journey_test.go"), []byte(`package integration
+import "testing"
+func TestOtherJourney(t *testing.T) {}
+`), 0o644))
+
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runValidate([]string{"--root", dir, "--strict"})
+	})
+	require.Error(t, gotErr)
+	assert.Contains(t, out, "VERIFY-06")
+	assert.Contains(t, out, "J-stale")
+}
+
 // Dry-run must still fail-fast on invalid opts — this is the whole point: CI
 // pre-commit hooks can call `scaffold ... --dry-run` and stop on bad inputs
 // without leaving partial files behind.

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -412,6 +412,48 @@ func TestRunScaffoldJourney_DryRun_NoFileWritten(t *testing.T) {
 	assert.NotContains(t, out, "Created journey", "dry-run must not emit a 'Created journey' line")
 }
 
+func TestRunValidate_Strict_DetectsManualOnlyActiveJourney(t *testing.T) {
+	dir := setupProject(t, "cells/platform", "journeys")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "platform", "cell.yaml"), []byte(`id: platform
+type: core
+consistencyLevel: L1
+owner:
+  team: squad
+  role: cell-owner
+schema:
+  primary: cell_platform
+verify:
+  smoke:
+    - smoke.platform.startup
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "J-manual.yaml"), []byte(`id: J-manual
+goal: manual-only journey
+lifecycle: active
+owner:
+  team: squad
+  role: journey-owner
+cells:
+  - platform
+contracts: []
+passCriteria:
+  - text: manual signoff
+    mode: manual
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "status-board.yaml"), []byte(`- journeyId: J-manual
+  state: todo
+  risk: low
+  blocker: ""
+  updatedAt: 2026-04-27
+`), 0o644))
+
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runValidate([]string{"--root", dir, "--strict"})
+	})
+	require.Error(t, gotErr)
+	assert.Contains(t, out, "VERIFY-06")
+}
+
 // Dry-run must still fail-fast on invalid opts — this is the whole point: CI
 // pre-commit hooks can call `scaffold ... --dry-run` and stop on bad inputs
 // without leaving partial files behind.

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -502,6 +502,57 @@ func TestOtherJourney(t *testing.T) {}
 	assert.Contains(t, out, "J-stale")
 }
 
+func TestRunVerifyJourneyActive_DetectsManualOnlyActiveJourney(t *testing.T) {
+	dir := setupProject(t, "cells/platform", "journeys")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cells", "platform", "cell.yaml"), []byte(`id: platform
+type: core
+consistencyLevel: L1
+owner:
+  team: squad
+  role: cell-owner
+schema:
+  primary: cell_platform
+verify:
+  smoke:
+    - smoke.platform.startup
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "J-manual.yaml"), []byte(`id: J-manual
+goal: manual-only journey
+lifecycle: active
+owner:
+  team: squad
+  role: journey-owner
+cells:
+  - platform
+contracts: []
+passCriteria:
+  - text: manual signoff
+    mode: manual
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "status-board.yaml"), []byte(`- journeyId: J-manual
+  state: todo
+  risk: low
+  blocker: ""
+  updatedAt: 2026-04-27
+`), 0o644))
+
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(orig))
+	})
+
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runVerify([]string{"journey", "--active"})
+	})
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "verify journey --active: FAILED")
+	assert.Contains(t, out, "Verify active journeys: FAILED")
+	assert.Contains(t, out, "active journey has no auto checkRef")
+}
+
 // Dry-run must still fail-fast on invalid opts — this is the whole point: CI
 // pre-commit hooks can call `scaffold ... --dry-run` and stop on bad inputs
 // without leaving partial files behind.

--- a/cmd/gocell/app/validate.go
+++ b/cmd/gocell/app/validate.go
@@ -35,7 +35,7 @@ func runValidate(args []string) error {
 	failFast := fs.Bool("fail-fast", false,
 		"stop at the first error and skip remaining rules; trims output to that error (CI-friendly)")
 	strict := fs.Bool("strict", false,
-		"enforce no-dash naming and allowedFiles-mismatch rules (FMT-16 slice/cell/assembly dirs, FMT-17 allowedFiles, FMT-C1 cell id, FMT-A1 assembly id); strict-only, silent without this flag")
+		"enforce strict-only governance rules (VERIFY-06 journey auto checks, FMT-16 slice/cell/assembly dirs, FMT-17 allowedFiles, FMT-C1 cell id, FMT-A1 assembly id)")
 	format := fs.String("format", string(printers.FormatText),
 		"output format: text (non-stable, default) | json | sarif")
 	if err := fs.Parse(args); err != nil {

--- a/cmd/gocell/app/validate.go
+++ b/cmd/gocell/app/validate.go
@@ -35,7 +35,7 @@ func runValidate(args []string) error {
 	failFast := fs.Bool("fail-fast", false,
 		"stop at the first error and skip remaining rules; trims output to that error (CI-friendly)")
 	strict := fs.Bool("strict", false,
-		"enforce strict-only governance rules (VERIFY-06 journey auto checks, FMT-16 slice/cell/assembly dirs, FMT-17 allowedFiles, FMT-C1 cell id, FMT-A1 assembly id)")
+		"enforce strict-only governance rules (VERIFY-06 executable journey auto checks, FMT-16 slice/cell/assembly dirs, FMT-17 allowedFiles, FMT-C1 cell id, FMT-A1 assembly id)")
 	format := fs.String("format", string(printers.FormatText),
 		"output format: text (non-stable, default) | json | sarif")
 	if err := fs.Parse(args); err != nil {

--- a/cmd/gocell/app/verify.go
+++ b/cmd/gocell/app/verify.go
@@ -18,6 +18,7 @@ import (
 //	gocell verify slice --id=<cellID/sliceID>
 //	gocell verify cell --id=<cellID>
 //	gocell verify journey --id=<journeyID>
+//	gocell verify journey --active
 //	gocell verify targets --files=<file1,file2,...>
 func runVerify(args []string) error {
 	if len(args) < 1 {
@@ -117,13 +118,52 @@ func verifyCell(args []string) error {
 }
 
 func verifyJourney(args []string) error {
-	return runVerifyResultCmd(args, verifyResultExec{
-		name: "journey",
-		flag: "id",
-		exec: func(ctx context.Context, r *verify.Runner, id string) (*verify.VerifyResult, error) {
-			return r.RunJourney(ctx, id)
-		},
-	})
+	fs := flag.NewFlagSet("verify journey", flag.ContinueOnError)
+	id := fs.String("id", "", "journey id")
+	active := fs.Bool("active", false, "run all active journeys")
+	format := fs.String("format", "text",
+		"output format: "+strings.Join(printers.SupportedVerifyFormats(), " | "))
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *id == "" && !*active {
+		return fmt.Errorf("exactly one of --id or --active is required")
+	}
+	if *id != "" && *active {
+		return fmt.Errorf("exactly one of --id or --active is required")
+	}
+
+	printer, err := printers.NewVerifyPrinter(*format, os.Stdout)
+	if err != nil {
+		return err
+	}
+	root, project, err := parseProjectMeta()
+	if err != nil {
+		return err
+	}
+
+	runner := verify.NewRunner(project, root)
+	var result *verify.VerifyResult
+	if *active {
+		result, err = runner.RunActiveJourneys(context.Background())
+	} else {
+		result, err = runner.RunJourney(context.Background(), *id)
+	}
+	if err != nil {
+		return fmt.Errorf("verify journey: %w", err)
+	}
+
+	if err := printer.Print(result); err != nil {
+		return fmt.Errorf("emit verify result: %w", err)
+	}
+	if !result.Passed {
+		target := *id
+		if *active {
+			target = "--active"
+		}
+		return fmt.Errorf("verify journey %s: FAILED", target)
+	}
+	return nil
 }
 
 func verifyTargets(args []string) error {

--- a/docs/architecture/metadata-model-v3.md
+++ b/docs/architecture/metadata-model-v3.md
@@ -200,7 +200,7 @@ passCriteria:
     mode: manual
 ```
 
-`lifecycle: active` 表示该 Journey 已进入 strict 验收门禁：每条 `mode: auto` 的 `checkRef` 必须能解析到真实、可执行、非 skip 的 Go 测试目标，且至少存在 1 条这样的自动验收。`checkRef: journey.J-foo.bar-baz` 绑定到测试函数 `TestJFooBarBaz`。`mode: manual` 不允许写 `checkRef`；人工证据不是自动执行引用。`experimental` 可用于脚手架或探索阶段，允许 manual-only。`cells` 是路由锚点，不是完备参与方集合。`contracts` 是验收策展，不是完整依赖图。需要完整依赖图时，从 `slice.contractUsages` 聚合。
+`lifecycle: active` 表示该 Journey 已进入 strict 验收门禁：每条 `mode: auto` 的 `checkRef` 必须能解析到真实、可执行、非 skip 的 Go 测试目标，且至少存在 1 条这样的自动验收。`checkRef: journey.J-foo.bar-baz` 绑定到测试函数 `TestJFooBarBaz`，其中 `J-foo` 必须等于当前 Journey ID，不能借用其他 Journey 的验收测试。`mode: manual` 不允许写 `checkRef`；人工证据不是自动执行引用。`experimental` 可用于脚手架或探索阶段，允许 manual-only。`cells` 是路由锚点，不是完备参与方集合。`contracts` 是验收策展，不是完整依赖图。需要完整依赖图时，从 `slice.contractUsages` 聚合。
 
 ### Status Board
 

--- a/docs/architecture/metadata-model-v3.md
+++ b/docs/architecture/metadata-model-v3.md
@@ -200,7 +200,7 @@ passCriteria:
     mode: manual
 ```
 
-`lifecycle: active` 表示该 Journey 已进入 strict 验收门禁，必须至少有 1 条 `mode: auto` 且带 `checkRef` 的 passCriteria；`experimental` 可用于脚手架或探索阶段，允许 manual-only。`cells` 是路由锚点，不是完备参与方集合。`contracts` 是验收策展，不是完整依赖图。需要完整依赖图时，从 `slice.contractUsages` 聚合。
+`lifecycle: active` 表示该 Journey 已进入 strict 验收门禁：每条 `mode: auto` 的 `checkRef` 必须能解析到真实、可执行、非 skip 的 Go 测试目标，且至少存在 1 条这样的自动验收。`checkRef: journey.J-foo.bar-baz` 绑定到测试函数 `TestJFooBarBaz`。`mode: manual` 不允许写 `checkRef`；人工证据不是自动执行引用。`experimental` 可用于脚手架或探索阶段，允许 manual-only。`cells` 是路由锚点，不是完备参与方集合。`contracts` 是验收策展，不是完整依赖图。需要完整依赖图时，从 `slice.contractUsages` 聚合。
 
 ### Status Board
 
@@ -376,7 +376,7 @@ waivers:
 - 每个 contractUsage 条目必须有 verify.contract 或 waiver（C19）
 - verify 标识符必须遵循前缀分发格式
 - L0 依赖必须在 `l0Dependencies` 中声明（C20）
-- active journey 必须至少有 1 条可自动执行的 passCriteria（`mode: auto` + `checkRef`）
+- active journey 必须至少有 1 条可自动执行的 passCriteria，且所有 auto `checkRef` 都必须解析到真实、可执行、非 skip 的测试目标
 
 ### 格式合规
 

--- a/docs/architecture/metadata-model-v3.md
+++ b/docs/architecture/metadata-model-v3.md
@@ -178,6 +178,7 @@ Projection 额外必填：`replayable`。
 # journeys/J-ssologin.yaml
 id: J-ssologin
 goal: 用户完成 SSO 登录并获得有效 session
+lifecycle: active                  # active | experimental
 owner:
   team: platform
   role: journey-owner
@@ -199,7 +200,7 @@ passCriteria:
     mode: manual
 ```
 
-`cells` 是路由锚点，不是完备参与方集合。`contracts` 是验收策展，不是完整依赖图。需要完整依赖图时，从 `slice.contractUsages` 聚合。
+`lifecycle: active` 表示该 Journey 已进入 strict 验收门禁，必须至少有 1 条 `mode: auto` 且带 `checkRef` 的 passCriteria；`experimental` 可用于脚手架或探索阶段，允许 manual-only。`cells` 是路由锚点，不是完备参与方集合。`contracts` 是验收策展，不是完整依赖图。需要完整依赖图时，从 `slice.contractUsages` 聚合。
 
 ### Status Board
 
@@ -375,10 +376,12 @@ waivers:
 - 每个 contractUsage 条目必须有 verify.contract 或 waiver（C19）
 - verify 标识符必须遵循前缀分发格式
 - L0 依赖必须在 `l0Dependencies` 中声明（C20）
+- active journey 必须至少有 1 条可自动执行的 passCriteria（`mode: auto` + `checkRef`）
 
 ### 格式合规
 
-- `lifecycle` ∈ {draft, active, deprecated}
+- `contract.lifecycle` ∈ {draft, active, deprecated}
+- `journey.lifecycle` ∈ {active, experimental}
 - `cell.type` ∈ {core, edge, support}
 - 交付动态字段不得出现在非 status-board 文件中
 - 已弃用契约不得被新引用（除非有 `migrations` 声明）

--- a/examples/todoorder/cells/ordercell/cell_test.go
+++ b/examples/todoorder/cells/ordercell/cell_test.go
@@ -286,7 +286,7 @@ func TestOrderCell_RouteCreateOrder(t *testing.T) {
 		"POST /api/v1/orders/ should return 201")
 }
 
-func TestJourney_JOrdercreateHttpCreate(t *testing.T) {
+func TestJOrdercreateHttpCreate(t *testing.T) {
 	TestOrderCell_RouteCreateOrder(t)
 }
 

--- a/examples/todoorder/journeys/J-ordercreate.yaml
+++ b/examples/todoorder/journeys/J-ordercreate.yaml
@@ -1,5 +1,6 @@
 id: J-ordercreate
 goal: "Create an order over HTTP and emit order-created through the configured runtime path"
+lifecycle: active
 owner:
   team: examples
   role: order-owner

--- a/journeys/J-accountlockout.yaml
+++ b/journeys/J-accountlockout.yaml
@@ -1,5 +1,6 @@
 id: J-accountlockout
 goal: 多次登录失败后账户自动锁定，管理员可手动解锁
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-accountlockout.yaml
+++ b/journeys/J-accountlockout.yaml
@@ -1,6 +1,6 @@
 id: J-accountlockout
 goal: 多次登录失败后账户自动锁定，管理员可手动解锁
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-auditlogintrail.yaml
+++ b/journeys/J-auditlogintrail.yaml
@@ -1,5 +1,6 @@
 id: J-auditlogintrail
 goal: 登录事件跨 cell 传播并写入审计 hash chain，完整性可验证
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-auditlogintrail.yaml
+++ b/journeys/J-auditlogintrail.yaml
@@ -1,6 +1,6 @@
 id: J-auditlogintrail
 goal: 登录事件跨 cell 传播并写入审计 hash chain，完整性可验证
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-confighotreload.yaml
+++ b/journeys/J-confighotreload.yaml
@@ -1,6 +1,6 @@
 id: J-confighotreload
 goal: 配置变更后所有订阅 cell 热更新生效，服务保持健康
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-confighotreload.yaml
+++ b/journeys/J-confighotreload.yaml
@@ -1,5 +1,6 @@
 id: J-confighotreload
 goal: 配置变更后所有订阅 cell 热更新生效，服务保持健康
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-configrollback.yaml
+++ b/journeys/J-configrollback.yaml
@@ -1,6 +1,6 @@
 id: J-configrollback
 goal: 配置版本回滚后状态订阅 cell 回退生效，审计记录完整
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-configrollback.yaml
+++ b/journeys/J-configrollback.yaml
@@ -1,5 +1,6 @@
 id: J-configrollback
 goal: 配置版本回滚后状态订阅 cell 回退生效，审计记录完整
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-sessionlogout.yaml
+++ b/journeys/J-sessionlogout.yaml
@@ -1,5 +1,6 @@
 id: J-sessionlogout
 goal: 用户主动登出并吊销 session，审计事件正确记录
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-sessionlogout.yaml
+++ b/journeys/J-sessionlogout.yaml
@@ -1,6 +1,6 @@
 id: J-sessionlogout
 goal: 用户主动登出并吊销 session，审计事件正确记录
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-sessionrefresh.yaml
+++ b/journeys/J-sessionrefresh.yaml
@@ -1,5 +1,6 @@
 id: J-sessionrefresh
 goal: 用户使用 refresh token 刷新 session 并获得新的 access token
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-sessionrefresh.yaml
+++ b/journeys/J-sessionrefresh.yaml
@@ -1,6 +1,6 @@
 id: J-sessionrefresh
 goal: 用户使用 refresh token 刷新 session 并获得新的 access token
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-ssologin.yaml
+++ b/journeys/J-ssologin.yaml
@@ -1,6 +1,6 @@
 id: J-ssologin
 goal: 用户完成 SSO 登录并获得有效 session
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner
@@ -14,7 +14,6 @@ contracts:
 passCriteria:
   - text: OIDC 重定向完成 # Phase 3 OIDC 适配器就绪后验证
     mode: manual
-    checkRef: journey.J-ssologin.oidc-redirect
   - text: Session 写入数据库
     mode: auto
     checkRef: journey.J-ssologin.session-db

--- a/journeys/J-ssologin.yaml
+++ b/journeys/J-ssologin.yaml
@@ -1,5 +1,6 @@
 id: J-ssologin
 goal: 用户完成 SSO 登录并获得有效 session
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-useronboarding.yaml
+++ b/journeys/J-useronboarding.yaml
@@ -1,6 +1,6 @@
 id: J-useronboarding
 goal: 新用户完成创建并具备登录能力
-lifecycle: active
+lifecycle: experimental
 owner:
   team: platform
   role: journey-owner

--- a/journeys/J-useronboarding.yaml
+++ b/journeys/J-useronboarding.yaml
@@ -1,5 +1,6 @@
 id: J-useronboarding
 goal: 新用户完成创建并具备登录能力
+lifecycle: active
 owner:
   team: platform
   role: journey-owner

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -110,27 +110,44 @@ func (v *Validator) validateFMT24() []ValidationResult {
 		}
 
 		for i, pc := range j.PassCriteria {
-			modeField := fmt.Sprintf("passCriteria[%d].mode", i)
-			if !validPassCriterionModes[pc.Mode] {
-				results = append(results, v.newResult(
-					"FMT-24", SeverityError, IssueInvalid,
-					file,
-					modeField,
-					fmt.Sprintf("journey %q passCriteria[%d].mode %q is not valid (must be auto or manual)", j.ID, i, pc.Mode),
-				))
-				continue
-			}
-			if pc.Mode == "auto" && strings.TrimSpace(pc.CheckRef) == "" {
-				results = append(results, v.newResult(
-					"FMT-24", SeverityError, IssueRequired,
-					file,
-					fmt.Sprintf("passCriteria[%d].checkRef", i),
-					fmt.Sprintf("journey %q auto passCriteria[%d] requires checkRef", j.ID, i),
-				))
-			}
+			results = append(results, v.validatePassCriterionFMT24(j, file, i, pc)...)
 		}
 	}
 	return results
+}
+
+func (v *Validator) validatePassCriterionFMT24(
+	j *metadata.JourneyMeta,
+	file string,
+	i int,
+	pc metadata.PassCriterion,
+) []ValidationResult {
+	modeField := fmt.Sprintf("passCriteria[%d].mode", i)
+	if !validPassCriterionModes[pc.Mode] {
+		return []ValidationResult{v.newResult(
+			"FMT-24", SeverityError, IssueInvalid,
+			file,
+			modeField,
+			fmt.Sprintf("journey %q passCriteria[%d].mode %q is not valid (must be auto or manual)", j.ID, i, pc.Mode),
+		)}
+	}
+	if pc.Mode == "auto" && strings.TrimSpace(pc.CheckRef) == "" {
+		return []ValidationResult{v.newResult(
+			"FMT-24", SeverityError, IssueRequired,
+			file,
+			fmt.Sprintf("passCriteria[%d].checkRef", i),
+			fmt.Sprintf("journey %q auto passCriteria[%d] requires checkRef", j.ID, i),
+		)}
+	}
+	if pc.Mode == "manual" && strings.TrimSpace(pc.CheckRef) != "" {
+		return []ValidationResult{v.newResult(
+			"FMT-24", SeverityError, IssueForbidden,
+			file,
+			fmt.Sprintf("passCriteria[%d].checkRef", i),
+			fmt.Sprintf("journey %q manual passCriteria[%d] must not declare checkRef", j.ID, i),
+		)}
+	}
+	return nil
 }
 
 // validateFMT02 checks that cell.type is one of {core, edge, support}.

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -35,6 +35,14 @@ var (
 		string(cell.LifecycleActive):     true,
 		string(cell.LifecycleDeprecated): true,
 	}
+	validJourneyLifecycles = map[string]bool{
+		"active":       true,
+		"experimental": true,
+	}
+	validPassCriterionModes = map[string]bool{
+		"auto":   true,
+		"manual": true,
+	}
 	validCellTypes = map[string]bool{
 		string(cell.CellTypeCore):    true,
 		string(cell.CellTypeEdge):    true,
@@ -76,6 +84,50 @@ func (v *Validator) validateFMT01() []ValidationResult {
 				"lifecycle",
 				fmt.Sprintf("contract %q lifecycle %q is not valid (must be draft, active, or deprecated)", c.ID, c.Lifecycle),
 			))
+		}
+	}
+	return results
+}
+
+// validateFMT24 checks journey lifecycle and passCriteria structural validity.
+func (v *Validator) validateFMT24() []ValidationResult {
+	var results []ValidationResult
+	for _, j := range v.project.Journeys {
+		file := journeyFile(j)
+		if !validJourneyLifecycles[j.Lifecycle] {
+			issueType := IssueInvalid
+			message := fmt.Sprintf("journey %q lifecycle %q is not valid (must be active or experimental)", j.ID, j.Lifecycle)
+			if j.Lifecycle == "" {
+				issueType = IssueRequired
+				message = fmt.Sprintf("journey %q lifecycle is required (must be active or experimental)", j.ID)
+			}
+			results = append(results, v.newResult(
+				"FMT-24", SeverityError, issueType,
+				file,
+				"lifecycle",
+				message,
+			))
+		}
+
+		for i, pc := range j.PassCriteria {
+			modeField := fmt.Sprintf("passCriteria[%d].mode", i)
+			if !validPassCriterionModes[pc.Mode] {
+				results = append(results, v.newResult(
+					"FMT-24", SeverityError, IssueInvalid,
+					file,
+					modeField,
+					fmt.Sprintf("journey %q passCriteria[%d].mode %q is not valid (must be auto or manual)", j.ID, i, pc.Mode),
+				))
+				continue
+			}
+			if pc.Mode == "auto" && strings.TrimSpace(pc.CheckRef) == "" {
+				results = append(results, v.newResult(
+					"FMT-24", SeverityError, IssueRequired,
+					file,
+					fmt.Sprintf("passCriteria[%d].checkRef", i),
+					fmt.Sprintf("journey %q auto passCriteria[%d] requires checkRef", j.ID, i),
+				))
+			}
 		}
 	}
 	return results

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -28,6 +28,8 @@ import (
 // ASCII-identifier scope).
 var pathPlaceholderRe = regexp.MustCompile(`\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
+const codeFMT24 = "FMT-24"
+
 // Package-level lookup maps for validation rules, avoiding per-call allocation.
 var (
 	validLifecycles = map[string]bool{
@@ -102,7 +104,7 @@ func (v *Validator) validateFMT24() []ValidationResult {
 				message = fmt.Sprintf("journey %q lifecycle is required (must be active or experimental)", j.ID)
 			}
 			results = append(results, v.newResult(
-				"FMT-24", SeverityError, issueType,
+				codeFMT24, SeverityError, issueType,
 				file,
 				"lifecycle",
 				message,
@@ -125,7 +127,7 @@ func (v *Validator) validatePassCriterionFMT24(
 	modeField := fmt.Sprintf("passCriteria[%d].mode", i)
 	if !validPassCriterionModes[pc.Mode] {
 		return []ValidationResult{v.newResult(
-			"FMT-24", SeverityError, IssueInvalid,
+			codeFMT24, SeverityError, IssueInvalid,
 			file,
 			modeField,
 			fmt.Sprintf("journey %q passCriteria[%d].mode %q is not valid (must be auto or manual)", j.ID, i, pc.Mode),
@@ -133,7 +135,7 @@ func (v *Validator) validatePassCriterionFMT24(
 	}
 	if pc.Mode == "auto" && strings.TrimSpace(pc.CheckRef) == "" {
 		return []ValidationResult{v.newResult(
-			"FMT-24", SeverityError, IssueRequired,
+			codeFMT24, SeverityError, IssueRequired,
 			file,
 			fmt.Sprintf("passCriteria[%d].checkRef", i),
 			fmt.Sprintf("journey %q auto passCriteria[%d] requires checkRef", j.ID, i),
@@ -141,7 +143,7 @@ func (v *Validator) validatePassCriterionFMT24(
 	}
 	if pc.Mode == "manual" && strings.TrimSpace(pc.CheckRef) != "" {
 		return []ValidationResult{v.newResult(
-			"FMT-24", SeverityError, IssueForbidden,
+			codeFMT24, SeverityError, IssueForbidden,
 			file,
 			fmt.Sprintf("passCriteria[%d].checkRef", i),
 			fmt.Sprintf("journey %q manual passCriteria[%d] must not declare checkRef", j.ID, i),

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -137,7 +137,7 @@ func (v *Validator) validatePassCriterionFMT24(
 		return []ValidationResult{v.newResult(
 			codeFMT24, SeverityError, IssueRequired,
 			file,
-			fmt.Sprintf("passCriteria[%d].checkRef", i),
+			fmt.Sprintf(fieldPassCriteriaCheckRefTmpl, i),
 			fmt.Sprintf("journey %q auto passCriteria[%d] requires checkRef", j.ID, i),
 		)}
 	}
@@ -145,7 +145,7 @@ func (v *Validator) validatePassCriterionFMT24(
 		return []ValidationResult{v.newResult(
 			codeFMT24, SeverityError, IssueForbidden,
 			file,
-			fmt.Sprintf("passCriteria[%d].checkRef", i),
+			fmt.Sprintf(fieldPassCriteriaCheckRefTmpl, i),
 			fmt.Sprintf("journey %q manual passCriteria[%d] must not declare checkRef", j.ID, i),
 		)}
 	}

--- a/kernel/governance/rules_strict.go
+++ b/kernel/governance/rules_strict.go
@@ -12,6 +12,7 @@ import (
 //   - FMT-17: slice.yaml allowedFiles first entry does not match the slice directory
 //   - FMT-18: wrapper.ContractSpec literals in cells/** disagree with contracts/**/contract.yaml
 //   - FMT-19: kernel/wrapper/*.go contains forbidden mutable package-level state
+//   - VERIFY-06: active journeys have at least one auto passCriteria checkRef
 //   - FMT-C1: cell.yaml id contains '-' (kebab-case cell id disallowed)
 //   - FMT-A1: assembly.yaml id contains '-' (kebab-case assembly id disallowed)
 //   - DOC-NAME-01: active docs contain a forbidden legacy naming literal
@@ -21,6 +22,7 @@ import (
 // severity to "upgrade" from).
 func (v *Validator) ValidateStrict(strict bool) []ValidationResult {
 	results := v.Validate()
+	results = append(results, v.validateVERIFY06(strict)...)
 	results = append(results, v.validateFMT16(strict)...)
 	results = append(results, v.validateFMT17(strict)...)
 	results = append(results, v.validateFMT18(strict)...)
@@ -39,6 +41,10 @@ func (v *Validator) ValidateStrict(strict bool) []ValidationResult {
 // stops, matching --strict --fail-fast's single-error semantics.
 func (v *Validator) ValidateStrictFailFast() []ValidationResult {
 	results := v.ValidateFailFast()
+	if HasErrors(results) {
+		return results
+	}
+	results = append(results, v.validateVERIFY06(true)...)
 	if HasErrors(results) {
 		return results
 	}

--- a/kernel/governance/rules_strict_test.go
+++ b/kernel/governance/rules_strict_test.go
@@ -131,6 +131,48 @@ func TestStrictValidator_AllowedFilesMismatch(t *testing.T) {
 	}
 }
 
+func TestValidateStrict_IncludesVERIFY06OnlyWhenStrict(t *testing.T) {
+	project := validProject()
+	project.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+		{Text: "manual signoff", Mode: "manual"},
+	}
+
+	v := NewValidator(project, "")
+	for _, r := range v.ValidateStrict(false) {
+		if r.Code == "VERIFY-06" {
+			t.Fatalf("non-strict validation must not produce VERIFY-06: %s", r.Message)
+		}
+	}
+
+	results := v.ValidateStrict(true)
+	found := false
+	for _, r := range results {
+		if r.Code == "VERIFY-06" && r.Severity == SeverityError {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("strict validation must include VERIFY-06 for active manual-only journey")
+	}
+}
+
+func TestValidateStrictFailFast_IncludesVERIFY06WhenBaseClean(t *testing.T) {
+	project := validProject()
+	project.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+		{Text: "manual signoff", Mode: "manual"},
+	}
+
+	results := NewValidator(project, "").ValidateStrictFailFast()
+	if len(results) == 0 {
+		t.Fatal("expected VERIFY-06 from strict fail-fast")
+	}
+	last := results[len(results)-1]
+	if last.Code != "VERIFY-06" || last.Severity != SeverityError {
+		t.Fatalf("expected fail-fast to stop on VERIFY-06, got %#v", last)
+	}
+}
+
 // TestValidateStrictFailFast_ShortCircuitsOnBaseError verifies that when the
 // base ValidateFailFast finds an error, ValidateStrictFailFast returns
 // immediately without appending FMT-16 or FMT-17 results.

--- a/kernel/governance/rules_verify.go
+++ b/kernel/governance/rules_verify.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ghbvf/gocell/kernel/verify"
 )
 
+const (
+	codeVERIFY06                  = "VERIFY-06"
+	fieldPassCriteriaCheckRefTmpl = "passCriteria[%d].checkRef"
+)
+
 // validateVERIFY01 checks that every contractUsage has a matching
 // verify.contract entry or a valid waiver.
 //
@@ -312,7 +317,7 @@ func (v *Validator) validateVERIFY05() []ValidationResult {
 			if pc.CheckRef == "" {
 				continue
 			}
-			field := fmt.Sprintf("passCriteria[%d].checkRef", i)
+			field := fmt.Sprintf(fieldPassCriteriaCheckRefTmpl, i)
 			results = append(results, v.validateVerifyRef(pc.CheckRef, file, field)...)
 		}
 	}
@@ -350,7 +355,7 @@ func (v *Validator) validateVERIFY06Journey(j *metadata.JourneyMeta) []Validatio
 	}
 	if autoCount == 0 {
 		results = append(results, v.newResult(
-			"VERIFY-06", SeverityError, IssueRequired,
+			codeVERIFY06, SeverityError, IssueRequired,
 			journeyFile(j),
 			"passCriteria",
 			fmt.Sprintf("active journey %q must declare at least one auto passCriteria entry with checkRef", j.ID),
@@ -367,9 +372,9 @@ func (v *Validator) validateVERIFY06CheckRef(
 	scope, err := verify.JourneyRefScope(pc.CheckRef)
 	if err != nil || scope != j.ID {
 		return []ValidationResult{v.newResult(
-			"VERIFY-06", SeverityError, IssueMismatch,
+			codeVERIFY06, SeverityError, IssueMismatch,
 			journeyFile(j),
-			fmt.Sprintf("passCriteria[%d].checkRef", i),
+			fmt.Sprintf(fieldPassCriteriaCheckRefTmpl, i),
 			fmt.Sprintf("active journey %q auto checkRef %q must belong to the same journey", j.ID, pc.CheckRef),
 		)}
 	}
@@ -381,9 +386,9 @@ func (v *Validator) validateVERIFY06CheckRef(
 		return nil
 	}
 	return []ValidationResult{v.newResult(
-		"VERIFY-06", SeverityError, IssueRefNotFound,
+		codeVERIFY06, SeverityError, IssueRefNotFound,
 		journeyFile(j),
-		fmt.Sprintf("passCriteria[%d].checkRef", i),
+		fmt.Sprintf(fieldPassCriteriaCheckRefTmpl, i),
 		fmt.Sprintf("active journey %q auto checkRef %q must resolve to an executable non-skipped test target", j.ID, pc.CheckRef),
 	)}
 }

--- a/kernel/governance/rules_verify.go
+++ b/kernel/governance/rules_verify.go
@@ -317,3 +317,36 @@ func (v *Validator) validateVERIFY05() []ValidationResult {
 
 	return results
 }
+
+// validateVERIFY06 checks that strict-mode active journeys have at least one
+// runnable automated pass criterion.
+func (v *Validator) validateVERIFY06(strict bool) []ValidationResult {
+	if !strict {
+		return nil
+	}
+	var results []ValidationResult
+	for _, j := range v.project.Journeys {
+		if j.Lifecycle != "active" {
+			continue
+		}
+		if journeyHasRunnableAutoCheck(j) {
+			continue
+		}
+		results = append(results, v.newResult(
+			"VERIFY-06", SeverityError, IssueRequired,
+			journeyFile(j),
+			"passCriteria",
+			fmt.Sprintf("active journey %q must declare at least one auto passCriteria entry with checkRef", j.ID),
+		))
+	}
+	return results
+}
+
+func journeyHasRunnableAutoCheck(j *metadata.JourneyMeta) bool {
+	for _, pc := range j.PassCriteria {
+		if pc.Mode == "auto" && strings.TrimSpace(pc.CheckRef) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/governance/rules_verify.go
+++ b/kernel/governance/rules_verify.go
@@ -1,6 +1,7 @@
 package governance
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -318,20 +319,35 @@ func (v *Validator) validateVERIFY05() []ValidationResult {
 	return results
 }
 
-// validateVERIFY06 checks that strict-mode active journeys have at least one
-// runnable automated pass criterion.
+// validateVERIFY06 checks that strict-mode active journeys have executable
+// automated acceptance checks. A non-empty checkRef is only a declaration; the
+// gate is the actual test target resolving and running without zero-match or
+// skip-only results.
 func (v *Validator) validateVERIFY06(strict bool) []ValidationResult {
 	if !strict {
 		return nil
 	}
 	var results []ValidationResult
 	for _, j := range v.project.Journeys {
-		if j.Lifecycle != "active" {
+		results = append(results, v.validateVERIFY06Journey(j)...)
+	}
+	return results
+}
+
+func (v *Validator) validateVERIFY06Journey(j *metadata.JourneyMeta) []ValidationResult {
+	if j.Lifecycle != "active" {
+		return nil
+	}
+	var results []ValidationResult
+	autoCount := 0
+	for i, pc := range j.PassCriteria {
+		if pc.Mode != "auto" || strings.TrimSpace(pc.CheckRef) == "" {
 			continue
 		}
-		if journeyHasRunnableAutoCheck(j) {
-			continue
-		}
+		autoCount++
+		results = append(results, v.validateVERIFY06CheckRef(j, i, pc)...)
+	}
+	if autoCount == 0 {
 		results = append(results, v.newResult(
 			"VERIFY-06", SeverityError, IssueRequired,
 			journeyFile(j),
@@ -342,11 +358,22 @@ func (v *Validator) validateVERIFY06(strict bool) []ValidationResult {
 	return results
 }
 
-func journeyHasRunnableAutoCheck(j *metadata.JourneyMeta) bool {
-	for _, pc := range j.PassCriteria {
-		if pc.Mode == "auto" && strings.TrimSpace(pc.CheckRef) != "" {
-			return true
-		}
+func (v *Validator) validateVERIFY06CheckRef(
+	j *metadata.JourneyMeta,
+	i int,
+	pc metadata.PassCriterion,
+) []ValidationResult {
+	if v.verifyJourneyRef == nil {
+		return nil
 	}
-	return false
+	tr, errs := v.verifyJourneyRef(context.Background(), j, pc.CheckRef)
+	if tr.Passed && len(errs) == 0 && !tr.ZeroMatch && !tr.SkippedOnly {
+		return nil
+	}
+	return []ValidationResult{v.newResult(
+		"VERIFY-06", SeverityError, IssueRefNotFound,
+		journeyFile(j),
+		fmt.Sprintf("passCriteria[%d].checkRef", i),
+		fmt.Sprintf("active journey %q auto checkRef %q must resolve to an executable non-skipped test target", j.ID, pc.CheckRef),
+	)}
 }

--- a/kernel/governance/rules_verify.go
+++ b/kernel/governance/rules_verify.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/verify"
 )
 
 // validateVERIFY01 checks that every contractUsage has a matching
@@ -363,6 +364,15 @@ func (v *Validator) validateVERIFY06CheckRef(
 	i int,
 	pc metadata.PassCriterion,
 ) []ValidationResult {
+	scope, err := verify.JourneyRefScope(pc.CheckRef)
+	if err != nil || scope != j.ID {
+		return []ValidationResult{v.newResult(
+			"VERIFY-06", SeverityError, IssueMismatch,
+			journeyFile(j),
+			fmt.Sprintf("passCriteria[%d].checkRef", i),
+			fmt.Sprintf("active journey %q auto checkRef %q must belong to the same journey", j.ID, pc.CheckRef),
+		)}
+	}
 	if v.verifyJourneyRef == nil {
 		return nil
 	}

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -8,10 +8,12 @@
 package governance
 
 import (
+	"context"
 	"os"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/verify"
 )
 
 // Severity of a validation result.
@@ -67,11 +69,16 @@ type ValidationResult struct {
 // the project field so existing rule code keeps using v.project.* directly.
 type Validator struct {
 	locator
-	root       string                            // project root for file existence checks
-	now        func() time.Time                  // clock function (injectable for tests)
-	fileExists func(path string) bool            // file existence check (injectable for tests)
-	readFile   func(path string) ([]byte, error) // file reader (injectable for tests)
-	actorSet   map[string]bool                   // pre-built set of external actor IDs from actors.yaml (membership = external)
+	root             string                            // project root for file existence checks
+	now              func() time.Time                  // clock function (injectable for tests)
+	fileExists       func(path string) bool            // file existence check (injectable for tests)
+	readFile         func(path string) ([]byte, error) // file reader (injectable for tests)
+	actorSet         map[string]bool                   // pre-built set of external actor IDs from actors.yaml (membership = external)
+	verifyJourneyRef func(
+		ctx context.Context,
+		j *metadata.JourneyMeta,
+		ref string,
+	) (verify.TestResult, []error)
 }
 
 // NewValidator creates a Validator for the given parsed project metadata.
@@ -90,7 +97,7 @@ func NewValidator(project *metadata.ProjectMeta, root string) *Validator {
 	for _, a := range project.Actors {
 		actorSet[a.ID] = true
 	}
-	return &Validator{
+	validator := &Validator{
 		locator: locator{project: project},
 		root:    root,
 		now:     time.Now,
@@ -101,6 +108,11 @@ func NewValidator(project *metadata.ProjectMeta, root string) *Validator {
 		readFile: os.ReadFile,
 		actorSet: actorSet,
 	}
+	if root != "" {
+		runner := verify.NewRunner(project, root)
+		validator.verifyJourneyRef = runner.RunJourneyCheckRef
+	}
+	return validator
 }
 
 // Validate runs all rules and returns all findings.

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -149,7 +149,7 @@ func (v *Validator) rules() []func() []ValidationResult {
 		v.validateFMT01, v.validateFMT02, v.validateFMT03, v.validateFMT04,
 		v.validateFMT05, v.validateFMT06, v.validateFMT07, v.validateFMT08,
 		v.validateFMT09, v.validateFMT10, v.validateFMT11, v.validateFMT12,
-		v.validateFMT13, v.validateFMT14, v.validateFMT15,
+		v.validateFMT13, v.validateFMT14, v.validateFMT15, v.validateFMT24,
 		v.validateADV01, v.validateADV03, v.validateADV04, v.validateADV05,
 		v.validateADV06,
 		v.validateOUTGUARD01,

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -156,10 +156,11 @@ func validProject() *metadata.ProjectMeta {
 		},
 		Journeys: map[string]*metadata.JourneyMeta{
 			"J-ssologin": {
-				ID:    "J-ssologin",
-				Goal:  "User completes SSO login",
-				Owner: metadata.OwnerMeta{Team: "platform", Role: "journey-owner"},
-				Cells: []string{"accesscore", "auditcore"},
+				ID:        "J-ssologin",
+				Goal:      "User completes SSO login",
+				Lifecycle: "active",
+				Owner:     metadata.OwnerMeta{Team: "platform", Role: "journey-owner"},
+				Cells:     []string{"accesscore", "auditcore"},
 				Contracts: []string{
 					"http.auth.login.v1",
 					"event.session.created.v1",
@@ -1371,6 +1372,57 @@ func TestVERIFY05(t *testing.T) {
 	}
 }
 
+func TestVERIFY06(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+	}{
+		{
+			name:      "active journey with auto check passes",
+			setup:     func(_ *metadata.ProjectMeta) {},
+			wantCount: 0,
+		},
+		{
+			name: "active journey with only manual criteria fails strict",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "security signoff", Mode: "manual"},
+				}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "active journey auto criterion without checkRef does not count",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "unwired check", Mode: "auto"},
+				}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "experimental journey with only manual criteria passes",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].Lifecycle = "experimental"
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "explore user flow", Mode: "manual"},
+				}
+			},
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, ".")
+			got := findByCode(val.validateVERIFY06(true), "VERIFY-06")
+			assert.Len(t, got, tt.wantCount)
+		})
+	}
+}
+
 // --- FMT rules ---
 
 func TestFMT01(t *testing.T) {
@@ -1405,6 +1457,70 @@ func TestFMT01(t *testing.T) {
 			tt.setup(pm)
 			val := NewValidator(pm, ".")
 			got := findByCode(val.validateFMT01(), "FMT-01")
+			assert.Len(t, got, tt.wantCount)
+		})
+	}
+}
+
+func TestFMT24(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*metadata.ProjectMeta)
+		wantCount int
+	}{
+		{
+			name:      "valid active journey",
+			setup:     func(_ *metadata.ProjectMeta) {},
+			wantCount: 0,
+		},
+		{
+			name: "missing journey lifecycle",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].Lifecycle = ""
+			},
+			wantCount: 1,
+		},
+		{
+			name: "invalid journey lifecycle",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].Lifecycle = "deprecated"
+			},
+			wantCount: 1,
+		},
+		{
+			name: "invalid pass criterion mode",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "broken", Mode: "sometimes", CheckRef: "journey.J-ssologin.broken"},
+				}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "auto criterion requires checkRef",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "unwired", Mode: "auto"},
+				}
+			},
+			wantCount: 1,
+		},
+		{
+			name: "manual criterion may carry documentation checkRef",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "manual signoff", Mode: "manual", CheckRef: "journey.J-ssologin.signoff"},
+				}
+			},
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := validProject()
+			tt.setup(pm)
+			val := NewValidator(pm, ".")
+			got := findByCode(val.validateFMT24(), "FMT-24")
 			assert.Len(t, got, tt.wantCount)
 		})
 	}

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -1425,6 +1425,15 @@ func TestVERIFY06(t *testing.T) {
 			wantCount: 1,
 		},
 		{
+			name: "active journey cannot borrow another journey checkRef",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "other journey check", Mode: "auto", CheckRef: "journey.J-other.session-db"},
+				}
+			},
+			wantCount: 1,
+		},
+		{
 			name: "experimental journey with only manual criteria passes",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Journeys["J-ssologin"].Lifecycle = "experimental"

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -1,6 +1,7 @@
 package governance
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/verify"
 	"github.com/ghbvf/gocell/pkg/contracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -192,6 +194,14 @@ func validProject() *metadata.ProjectMeta {
 			{ID: "edge-bff", MaxConsistencyLevel: "L1"},
 		},
 	}
+}
+
+func verifiedJourneyRefVerifier(
+	_ context.Context,
+	_ *metadata.JourneyMeta,
+	ref string,
+) (verify.TestResult, []error) {
+	return verify.TestResult{Name: ref, Passed: true}, nil
 }
 
 // findByCode returns all results matching the given code.
@@ -1376,12 +1386,25 @@ func TestVERIFY06(t *testing.T) {
 	tests := []struct {
 		name      string
 		setup     func(*metadata.ProjectMeta)
+		verifier  func(context.Context, *metadata.JourneyMeta, string) (verify.TestResult, []error)
 		wantCount int
 	}{
 		{
 			name:      "active journey with auto check passes",
 			setup:     func(_ *metadata.ProjectMeta) {},
 			wantCount: 0,
+		},
+		{
+			name: "active journey with stale auto check fails strict",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
+					{Text: "stale check", Mode: "auto", CheckRef: "journey.J-ssologin.missing"},
+				}
+			},
+			verifier: func(_ context.Context, _ *metadata.JourneyMeta, ref string) (verify.TestResult, []error) {
+				return verify.TestResult{Name: ref, Passed: false, ZeroMatch: true}, nil
+			},
+			wantCount: 1,
 		},
 		{
 			name: "active journey with only manual criteria fails strict",
@@ -1417,6 +1440,10 @@ func TestVERIFY06(t *testing.T) {
 			pm := validProject()
 			tt.setup(pm)
 			val := NewValidator(pm, ".")
+			val.verifyJourneyRef = verifiedJourneyRefVerifier
+			if tt.verifier != nil {
+				val.verifyJourneyRef = tt.verifier
+			}
 			got := findByCode(val.validateVERIFY06(true), "VERIFY-06")
 			assert.Len(t, got, tt.wantCount)
 		})
@@ -1506,13 +1533,13 @@ func TestFMT24(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name: "manual criterion may carry documentation checkRef",
+			name: "manual criterion must not carry checkRef",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Journeys["J-ssologin"].PassCriteria = []metadata.PassCriterion{
 					{Text: "manual signoff", Mode: "manual", CheckRef: "journey.J-ssologin.signoff"},
 				}
 			},
-			wantCount: 0,
+			wantCount: 1,
 		},
 	}
 	for _, tt := range tests {

--- a/kernel/metadata/parser_strict_test.go
+++ b/kernel/metadata/parser_strict_test.go
@@ -89,6 +89,7 @@ build:
 // minimalJourneyYAML is the smallest valid journey YAML content.
 const minimalJourneyYAML = `id: J-test
 goal: test journey
+lifecycle: experimental
 owner:
   team: test
   role: journey-owner

--- a/kernel/metadata/parser_test.go
+++ b/kernel/metadata/parser_test.go
@@ -90,6 +90,7 @@ deliverySemantics: at-least-once
 		// --- journeys ---
 		"journeys/J-ssologin.yaml": &fstest.MapFile{Data: []byte(`id: J-ssologin
 goal: User completes SSO login
+lifecycle: active
 owner:
   team: platform
   role: journey-owner
@@ -263,6 +264,7 @@ func TestParseFS_FullProject(t *testing.T) {
 	assert.Contains(t, pm.Journeys, "J-ssologin")
 	j := pm.Journeys["J-ssologin"]
 	assert.Equal(t, "User completes SSO login", j.Goal)
+	assert.Equal(t, "active", j.Lifecycle)
 	assert.Equal(t, []string{"accesscore", "auditcore"}, j.Cells)
 	assert.Len(t, j.PassCriteria, 2)
 	assert.Equal(t, "auto", j.PassCriteria[0].Mode)

--- a/kernel/metadata/schemas/journey.schema.json
+++ b/kernel/metadata/schemas/journey.schema.json
@@ -69,39 +69,33 @@
             "description": "Whether this criterion is verified automatically or manually.",
             "enum": ["auto", "manual"]
           },
-          "checkRef": {
-            "type": "string",
-            "description": "Reference to an automated check. Required when mode is 'auto'."
+	      "checkRef": {
+	        "type": "string",
+	        "description": "Reference to an automated check. Required when mode is 'auto' and forbidden when mode is 'manual'."
+	      }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": { "mode": { "const": "auto" } },
+              "required": ["mode"]
+            },
+            "then": {
+              "required": ["checkRef"]
+            }
+          },
+          {
+            "if": {
+              "properties": { "mode": { "const": "manual" } },
+              "required": ["mode"]
+            },
+            "then": {
+              "not": { "required": ["checkRef"] }
+            }
           }
-        },
-        "if": {
-          "properties": { "mode": { "const": "auto" } },
-          "required": ["mode"]
-        },
-        "then": {
-          "required": ["checkRef"]
-        }
+        ]
       },
       "minItems": 0
-    }
-  },
-  "if": {
-    "properties": { "lifecycle": { "const": "active" } },
-    "required": ["lifecycle"]
-  },
-  "then": {
-    "properties": {
-      "passCriteria": {
-        "contains": {
-          "type": "object",
-          "required": ["mode", "checkRef"],
-          "properties": {
-            "mode": { "const": "auto" },
-            "checkRef": { "type": "string", "minLength": 1 }
-          }
-        },
-        "minContains": 1
-      }
     }
   }
 }

--- a/kernel/metadata/schemas/journey.schema.json
+++ b/kernel/metadata/schemas/journey.schema.json
@@ -4,7 +4,7 @@
   "title": "GoCell Journey Descriptor",
   "description": "Defines a Journey, the acceptance truth. A Journey specifies what 'done' means for a user-facing capability. It is not a dependency truth.",
   "type": "object",
-  "required": ["id", "goal", "owner", "cells", "passCriteria"],
+  "required": ["id", "goal", "lifecycle", "owner", "cells", "passCriteria"],
   "additionalProperties": false,
   "properties": {
     "id": {
@@ -15,6 +15,11 @@
     "goal": {
       "type": "string",
       "description": "Human-readable goal describing what the journey achieves."
+    },
+    "lifecycle": {
+      "type": "string",
+      "description": "Journey lifecycle. Active journeys participate in strict automated verification; experimental journeys may be manual-only.",
+      "enum": ["active", "experimental"]
     },
     "owner": {
       "type": "object",
@@ -77,7 +82,26 @@
           "required": ["checkRef"]
         }
       },
-      "minItems": 1
+      "minItems": 0
+    }
+  },
+  "if": {
+    "properties": { "lifecycle": { "const": "active" } },
+    "required": ["lifecycle"]
+  },
+  "then": {
+    "properties": {
+      "passCriteria": {
+        "contains": {
+          "type": "object",
+          "required": ["mode", "checkRef"],
+          "properties": {
+            "mode": { "const": "auto" },
+            "checkRef": { "type": "string", "minLength": 1 }
+          }
+        },
+        "minContains": 1
+      }
     }
   }
 }

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -167,6 +167,7 @@ type SchemaRefsMeta = contracts.SchemaRefs
 type JourneyMeta struct {
 	ID           string          `yaml:"id"`
 	Goal         string          `yaml:"goal"`
+	Lifecycle    string          `yaml:"lifecycle"` // "active"|"experimental"
 	Owner        OwnerMeta       `yaml:"owner"`
 	Cells        []string        `yaml:"cells"`
 	Contracts    []string        `yaml:"contracts"`

--- a/kernel/metadata/types_test.go
+++ b/kernel/metadata/types_test.go
@@ -1,8 +1,10 @@
 package metadata
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/ghbvf/gocell/kernel/metadata/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -226,10 +228,11 @@ func TestContractMetaNilReplayable(t *testing.T) {
 
 func TestJourneyMetaRoundTrip(t *testing.T) {
 	orig := JourneyMeta{
-		ID:    "J-ssologin",
-		Goal:  "User completes SSO login",
-		Owner: OwnerMeta{Team: "platform", Role: "journey-owner"},
-		Cells: []string{"accesscore", "auditcore"},
+		ID:        "J-ssologin",
+		Goal:      "User completes SSO login",
+		Lifecycle: "active",
+		Owner:     OwnerMeta{Team: "platform", Role: "journey-owner"},
+		Cells:     []string{"accesscore", "auditcore"},
 		Contracts: []string{
 			"http.auth.login.v1",
 			"event.session.created.v1",
@@ -241,6 +244,7 @@ func TestJourneyMetaRoundTrip(t *testing.T) {
 	}
 	data, got := roundTrip(t, orig)
 	assert.Equal(t, orig, got)
+	assert.Contains(t, string(data), "lifecycle: active")
 
 	// Manual criterion should not have checkRef in output
 	assert.Contains(t, string(data), "mode: manual")
@@ -251,6 +255,23 @@ func TestPassCriterionOmitEmptyCheckRef(t *testing.T) {
 	data, got := roundTrip(t, orig)
 	assert.Equal(t, orig, got)
 	assert.NotContains(t, string(data), "checkRef")
+}
+
+func TestJourneySchemaRequiresLifecycle(t *testing.T) {
+	data, err := schemas.FS.ReadFile("journey.schema.json")
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(data, &doc))
+	required, ok := doc["required"].([]any)
+	require.True(t, ok)
+	assert.Contains(t, required, "lifecycle")
+
+	properties, ok := doc["properties"].(map[string]any)
+	require.True(t, ok)
+	lifecycle, ok := properties["lifecycle"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"active", "experimental"}, lifecycle["enum"])
 }
 
 func TestAssemblyMetaRoundTrip(t *testing.T) {

--- a/kernel/metadata/types_test.go
+++ b/kernel/metadata/types_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/kernel/metadata/schemas"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -272,6 +273,57 @@ func TestJourneySchemaRequiresLifecycle(t *testing.T) {
 	lifecycle, ok := properties["lifecycle"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, []any{"active", "experimental"}, lifecycle["enum"])
+}
+
+func TestJourneySchemaLeavesActiveAutoGateToStrictValidation(t *testing.T) {
+	schema := loadJourneySchema(t)
+	doc := map[string]any{
+		"id":        "J-manual",
+		"goal":      "manual active journey is structurally valid",
+		"lifecycle": "active",
+		"owner": map[string]any{
+			"team": "platform",
+			"role": "journey-owner",
+		},
+		"cells": []any{"accesscore"},
+		"passCriteria": []any{
+			map[string]any{"text": "manual signoff", "mode": "manual"},
+		},
+	}
+	assert.NoError(t, schema.Validate(doc))
+}
+
+func TestJourneySchemaRejectsManualCheckRef(t *testing.T) {
+	schema := loadJourneySchema(t)
+	doc := map[string]any{
+		"id":        "J-manual",
+		"goal":      "manual checkRef is forbidden",
+		"lifecycle": "experimental",
+		"owner": map[string]any{
+			"team": "platform",
+			"role": "journey-owner",
+		},
+		"cells": []any{"accesscore"},
+		"passCriteria": []any{
+			map[string]any{"text": "manual signoff", "mode": "manual", "checkRef": "journey.J-manual.signoff"},
+		},
+	}
+	assert.Error(t, schema.Validate(doc))
+}
+
+func loadJourneySchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	data, err := schemas.FS.ReadFile("journey.schema.json")
+	require.NoError(t, err)
+
+	var doc any
+	require.NoError(t, json.Unmarshal(data, &doc))
+	compiler := jsonschema.NewCompiler()
+	const url = "file:///journey.schema.json"
+	require.NoError(t, compiler.AddResource(url, doc))
+	schema, err := compiler.Compile(url)
+	require.NoError(t, err)
+	return schema
 }
 
 func TestAssemblyMetaRoundTrip(t *testing.T) {

--- a/kernel/scaffold/scaffold_test.go
+++ b/kernel/scaffold/scaffold_test.go
@@ -456,6 +456,7 @@ func TestCreateJourney(t *testing.T) {
 	assert.Contains(t, content, `goal: "User completes SSO login and obtains a valid session"`)
 	assert.Contains(t, content, "team: platform")
 	assert.Contains(t, content, "role: journey-owner")
+	assert.Contains(t, content, "lifecycle: experimental")
 	assert.Contains(t, content, "- accesscore")
 	assert.Contains(t, content, "- auditcore")
 	assert.Contains(t, content, "contracts: []")

--- a/kernel/scaffold/templates/journey.yaml.tpl
+++ b/kernel/scaffold/templates/journey.yaml.tpl
@@ -1,5 +1,6 @@
 id: {{.ID}}
 goal: "{{.Goal}}"
+lifecycle: experimental
 owner:
   team: {{.OwnerTeam}}
   role: journey-owner

--- a/kernel/verify/gotest.go
+++ b/kernel/verify/gotest.go
@@ -13,10 +13,11 @@ import (
 
 // goTestResult holds the outcome of a single `go test` invocation.
 type goTestResult struct {
-	Output    string // combined stdout+stderr
-	Passed    bool   // exit code == 0
-	ZeroMatch bool   // go test ran but no tests matched -run pattern
-	Err       error  // non-ExitError (command couldn't run at all)
+	Output      string // combined stdout+stderr
+	Passed      bool   // exit code == 0
+	ZeroMatch   bool   // go test ran but no tests matched -run pattern
+	SkippedOnly bool   // go test matched tests, but every matched test skipped
+	Err         error  // non-ExitError (command couldn't run at all)
 }
 
 // runGoTest executes `go test` with the given arguments in dir.
@@ -36,7 +37,7 @@ func runGoTest(ctx context.Context, dir string, args []string) goTestResult {
 
 	if runErr == nil {
 		zm := isZeroMatch(output)
-		return goTestResult{Output: output, Passed: true, ZeroMatch: zm}
+		return goTestResult{Output: output, Passed: true, ZeroMatch: zm, SkippedOnly: !zm && isSkipOnly(output)}
 	}
 
 	var exitErr *exec.ExitError
@@ -59,7 +60,16 @@ func isZeroMatch(output string) bool {
 	if !hasNoTests {
 		return false
 	}
+	if strings.Contains(output, "--- SKIP") {
+		return false
+	}
 	// If any test actually ran, it's not a zero match.
 	return !strings.Contains(output, "--- PASS") &&
+		!strings.Contains(output, "--- FAIL")
+}
+
+func isSkipOnly(output string) bool {
+	return strings.Contains(output, "--- SKIP") &&
+		!strings.Contains(output, "--- PASS") &&
 		!strings.Contains(output, "--- FAIL")
 }

--- a/kernel/verify/integration_test.go
+++ b/kernel/verify/integration_test.go
@@ -59,6 +59,20 @@ func TestPass(t *testing.T) {}
 	assert.True(t, res.ZeroMatch, "should detect zero match")
 }
 
+func TestRunGoTest_SkipOnlyReal(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module testmod\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "skip_test.go"), []byte(`package testmod
+import "testing"
+func TestOnlySkip(t *testing.T) { t.Skip("stub") }
+`), 0o644))
+
+	res := runGoTest(context.Background(), dir, []string{"./...", "-v", "-run", "^TestOnlySkip$"})
+	require.NoError(t, res.Err)
+	assert.True(t, res.Passed, "go test exits 0 for skipped tests")
+	assert.True(t, res.SkippedOnly, "stub-only tests must not count as verified")
+}
+
 func TestRunGoTest_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/kernel/verify/ref.go
+++ b/kernel/verify/ref.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -19,7 +20,7 @@ type resolvedRef struct {
 //
 // Supported formats:
 //
-//	journey.{journeyID}.{suffix} → pkg="./journeys/...", pattern=CamelCase(journeyID)+CamelCase(suffix)
+//	journey.{journeyID}.{suffix} → pkg resolved by Runner, pattern=^Test{CamelCase(journeyID)}{CamelCase(suffix)}$
 //	smoke.{cellID}.{suffix}     → pkg="./cells/{cellID}/...", pattern=CamelCase(suffix)
 //	unit.{scope}.{suffix}       → pkg="" (caller provides), pattern=CamelCase(suffix)
 //	contract.{id...}.{role}     → pkg="" (caller provides), pattern=CamelCase(role)
@@ -43,10 +44,11 @@ func resolveRef(ref string) (resolvedRef, error) {
 		// The Runner resolves the actual path at execution time.
 		// Include journeyID in pattern to disambiguate refs with identical suffixes
 		// (e.g., event-publish appears across multiple journeys).
+		testName := "Test" + kebabToCamelCase(parts[1]) + kebabToCamelCase(suffix)
 		return resolvedRef{
 			Kind:       PrefixJourney,
 			Pkg:        "", // resolved by Runner based on project layout
-			RunPattern: kebabToCamelCase(parts[1]) + kebabToCamelCase(suffix),
+			RunPattern: "^" + regexp.QuoteMeta(testName) + "$",
 		}, nil
 
 	case PrefixSmoke:

--- a/kernel/verify/ref.go
+++ b/kernel/verify/ref.go
@@ -11,6 +11,7 @@ import (
 // resolvedRef holds the parsed components of a verify reference string.
 type resolvedRef struct {
 	Kind       string // "journey", "smoke", "unit", "contract"
+	Scope      string // second segment; for journey refs this must equal JourneyMeta.ID
 	Pkg        string // Go test package path; empty means caller-provided
 	RunPattern string // CamelCase -run regex pattern
 }
@@ -40,13 +41,18 @@ func resolveRef(ref string) (resolvedRef, error) {
 
 	switch prefix {
 	case PrefixJourney:
+		journeyID := parts[1]
+		if err := validateSegment(journeyID, "journey ID"); err != nil {
+			return resolvedRef{}, err
+		}
 		// Journey tests may live in ./journeys/... or ./tests/integration/...
 		// The Runner resolves the actual path at execution time.
 		// Include journeyID in pattern to disambiguate refs with identical suffixes
 		// (e.g., event-publish appears across multiple journeys).
-		testName := "Test" + kebabToCamelCase(parts[1]) + kebabToCamelCase(suffix)
+		testName := "Test" + kebabToCamelCase(journeyID) + kebabToCamelCase(suffix)
 		return resolvedRef{
 			Kind:       PrefixJourney,
+			Scope:      journeyID,
 			Pkg:        "", // resolved by Runner based on project layout
 			RunPattern: "^" + regexp.QuoteMeta(testName) + "$",
 		}, nil
@@ -87,6 +93,19 @@ func resolveRef(ref string) (resolvedRef, error) {
 		return resolvedRef{}, errcode.New(errcode.ErrCheckRefInvalid,
 			fmt.Sprintf("ref %q has unknown prefix %q (expected journey, smoke, unit, or contract)", ref, prefix))
 	}
+}
+
+// JourneyRefScope returns the journey ID declared inside a journey checkRef.
+func JourneyRefScope(ref string) (string, error) {
+	resolved, err := resolveRef(ref)
+	if err != nil {
+		return "", err
+	}
+	if resolved.Kind != PrefixJourney {
+		return "", errcode.New(errcode.ErrCheckRefInvalid,
+			fmt.Sprintf("journey checkRef %q must use journey prefix", ref))
+	}
+	return resolved.Scope, nil
 }
 
 // validateSegment rejects path segments that could cause directory traversal.

--- a/kernel/verify/ref_test.go
+++ b/kernel/verify/ref_test.go
@@ -17,7 +17,7 @@ func TestResolveRef(t *testing.T) {
 		{
 			name: "journey ref includes journeyID",
 			ref:  "journey.J-ssologin.session-revoke",
-			want: resolvedRef{Kind: "journey", Pkg: "", RunPattern: "^TestJSsologinSessionRevoke$"},
+			want: resolvedRef{Kind: "journey", Scope: "J-ssologin", Pkg: "", RunPattern: "^TestJSsologinSessionRevoke$"},
 		},
 		{
 			name: "smoke ref",

--- a/kernel/verify/ref_test.go
+++ b/kernel/verify/ref_test.go
@@ -87,3 +87,39 @@ func TestResolveRef(t *testing.T) {
 		})
 	}
 }
+
+func TestJourneyRefScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "journey ref",
+			ref:  "journey.J-ssologin.session-revoke",
+			want: "J-ssologin",
+		},
+		{
+			name:    "non journey ref",
+			ref:     "smoke.accesscore.startup",
+			wantErr: true,
+		},
+		{
+			name:    "invalid ref",
+			ref:     "journey.only-two",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JourneyRefScope(tt.ref)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/kernel/verify/ref_test.go
+++ b/kernel/verify/ref_test.go
@@ -17,7 +17,7 @@ func TestResolveRef(t *testing.T) {
 		{
 			name: "journey ref includes journeyID",
 			ref:  "journey.J-ssologin.session-revoke",
-			want: resolvedRef{Kind: "journey", Pkg: "", RunPattern: "JSsologinSessionRevoke"},
+			want: resolvedRef{Kind: "journey", Pkg: "", RunPattern: "^TestJSsologinSessionRevoke$"},
 		},
 		{
 			name: "smoke ref",

--- a/kernel/verify/runner.go
+++ b/kernel/verify/runner.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
@@ -14,10 +15,11 @@ import (
 
 // TestResult represents the outcome of a single test target.
 type TestResult struct {
-	Name      string
-	Passed    bool
-	Output    string
-	ZeroMatch bool // true when -run pattern matched no tests
+	Name        string
+	Passed      bool
+	Output      string
+	ZeroMatch   bool // true when -run pattern matched no tests
+	SkippedOnly bool // true when matched tests all skipped
 }
 
 // VerifyResult represents the outcome of verifying a slice, cell, or journey.
@@ -169,19 +171,74 @@ func (r *Runner) RunJourney(ctx context.Context, journeyID string) (*VerifyResul
 	}
 
 	for _, ref := range autoRefs {
-		resolved, err := resolveRef(ref)
+		tr, errs := r.RunJourneyCheckRef(ctx, j, ref)
+		result.Results = append(result.Results, tr)
+		result.Errors = append(result.Errors, errs...)
+		if !tr.Passed || len(errs) > 0 {
+			result.Passed = false
+		}
+	}
+	return result, nil
+}
+
+// RunActiveJourneys runs every active journey in the parsed project.
+func (r *Runner) RunActiveJourneys(ctx context.Context) (*VerifyResult, error) {
+	result := &VerifyResult{TargetID: "active journeys", Passed: true}
+	if r.project == nil {
+		return result, nil
+	}
+	for _, id := range sortedJourneyIDs(r.project.Journeys) {
+		j := r.project.Journeys[id]
+		if j.Lifecycle != "active" {
+			continue
+		}
+		jr, err := r.RunJourney(ctx, j.ID)
 		if err != nil {
 			result.Errors = append(result.Errors, err)
-			result.Results = append(result.Results, TestResult{Name: ref, Passed: false})
+			result.Results = append(result.Results, TestResult{Name: j.ID, Passed: false})
 			result.Passed = false
 			continue
 		}
-		pkg, extraArgs := r.resolveJourneyPkg(j, resolved)
-		args := append([]string{pkg, "-v", "-run", resolved.RunPattern}, extraArgs...)
-		res := runGoTest(ctx, r.root, args)
-		recordResult(result, ref, res, pkg, resolved.RunPattern)
+		result.Results = append(result.Results, jr.Results...)
+		result.Errors = append(result.Errors, jr.Errors...)
+		result.ManualPending = append(result.ManualPending, jr.ManualPending...)
+		if !jr.Passed || len(jr.Errors) > 0 {
+			result.Passed = false
+		}
 	}
 	return result, nil
+}
+
+func sortedJourneyIDs(journeys map[string]*metadata.JourneyMeta) []string {
+	ids := make([]string, 0, len(journeys))
+	for id := range journeys {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// RunJourneyCheckRef executes one journey checkRef using the same resolver as
+// RunJourney. Governance strict mode calls this so promotion gates and runtime
+// verification share the exact same target binding.
+func (r *Runner) RunJourneyCheckRef(ctx context.Context, j *metadata.JourneyMeta, ref string) (TestResult, []error) {
+	targetID := ref
+	if j != nil {
+		targetID = j.ID
+	}
+	result := &VerifyResult{TargetID: targetID, Passed: true}
+	resolved, err := resolveRef(ref)
+	if err != nil {
+		return TestResult{Name: ref, Passed: false}, []error{err}
+	}
+	pkg, extraArgs := r.resolveJourneyPkg(j, resolved)
+	args := append([]string{pkg, "-v", "-run", resolved.RunPattern}, extraArgs...)
+	res := runGoTest(ctx, r.root, args)
+	recordResult(result, ref, res, pkg, resolved.RunPattern)
+	if len(result.Results) == 0 {
+		return TestResult{Name: ref, Passed: false}, result.Errors
+	}
+	return result.Results[0], result.Errors
 }
 
 // runRefs resolves each ref independently and runs go test per-ref.
@@ -209,16 +266,25 @@ func (r *Runner) runRefs(ctx context.Context, result *VerifyResult, fallbackPkg 
 // and error propagation in a single place.
 func recordResult(result *VerifyResult, name string, res goTestResult, pkg, pattern string) {
 	tr := TestResult{
-		Name:      name,
-		Passed:    res.Passed,
-		Output:    res.Output,
-		ZeroMatch: res.ZeroMatch,
+		Name:        name,
+		Passed:      res.Passed,
+		Output:      res.Output,
+		ZeroMatch:   res.ZeroMatch,
+		SkippedOnly: res.SkippedOnly,
 	}
 	if res.ZeroMatch {
 		tr.Passed = false
 		msg := fmt.Sprintf("matched no tests in %s", pkg)
 		if pattern != "" {
 			msg = fmt.Sprintf("pattern %q %s — check your YAML ref", pattern, msg)
+		}
+		result.Errors = append(result.Errors, errcode.New(errcode.ErrZeroTestMatch, msg))
+	}
+	if res.SkippedOnly {
+		tr.Passed = false
+		msg := fmt.Sprintf("matched only skipped tests in %s", pkg)
+		if pattern != "" {
+			msg = fmt.Sprintf("pattern %q %s — replace stubs with executable checks", pattern, msg)
 		}
 		result.Errors = append(result.Errors, errcode.New(errcode.ErrZeroTestMatch, msg))
 	}

--- a/kernel/verify/runner.go
+++ b/kernel/verify/runner.go
@@ -202,11 +202,28 @@ func (r *Runner) RunActiveJourneys(ctx context.Context) (*VerifyResult, error) {
 		result.Results = append(result.Results, jr.Results...)
 		result.Errors = append(result.Errors, jr.Errors...)
 		result.ManualPending = append(result.ManualPending, jr.ManualPending...)
+		if !hasAutoCheckRef(j) {
+			result.Results = append(result.Results, TestResult{
+				Name:   j.ID,
+				Passed: false,
+				Output: "active journey has no auto checkRef — automated verification required",
+			})
+			result.Passed = false
+		}
 		if !jr.Passed || len(jr.Errors) > 0 {
 			result.Passed = false
 		}
 	}
 	return result, nil
+}
+
+func hasAutoCheckRef(j *metadata.JourneyMeta) bool {
+	for _, pc := range j.PassCriteria {
+		if pc.Mode == ModeAuto && strings.TrimSpace(pc.CheckRef) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func sortedJourneyIDs(journeys map[string]*metadata.JourneyMeta) []string {
@@ -230,6 +247,14 @@ func (r *Runner) RunJourneyCheckRef(ctx context.Context, j *metadata.JourneyMeta
 	resolved, err := resolveRef(ref)
 	if err != nil {
 		return TestResult{Name: ref, Passed: false}, []error{err}
+	}
+	if resolved.Kind != PrefixJourney {
+		return TestResult{Name: ref, Passed: false}, []error{errcode.New(errcode.ErrCheckRefInvalid,
+			fmt.Sprintf("journey checkRef %q must use journey prefix", ref))}
+	}
+	if j != nil && resolved.Scope != j.ID {
+		return TestResult{Name: ref, Passed: false}, []error{errcode.New(errcode.ErrCheckRefInvalid,
+			fmt.Sprintf("journey checkRef %q belongs to journey %q, not %q", ref, resolved.Scope, j.ID))}
 	}
 	pkg, extraArgs := r.resolveJourneyPkg(j, resolved)
 	args := append([]string{pkg, "-v", "-run", resolved.RunPattern}, extraArgs...)

--- a/kernel/verify/runner_test.go
+++ b/kernel/verify/runner_test.go
@@ -131,6 +131,47 @@ func TestRunJourney_InvalidRef(t *testing.T) {
 	assert.Contains(t, result.Errors[0].Error(), "ERR_CHECKREF_INVALID")
 }
 
+func TestRunActiveJourneys_ManualOnlyActiveFails(t *testing.T) {
+	r := NewRunner(&metadata.ProjectMeta{
+		Journeys: map[string]*metadata.JourneyMeta{
+			"J-test": {
+				ID:        "J-test",
+				Lifecycle: "active",
+				PassCriteria: []metadata.PassCriterion{
+					{Mode: "manual", Text: "Security signoff"},
+				},
+			},
+		},
+	}, t.TempDir())
+
+	result, err := r.RunActiveJourneys(context.Background())
+	require.NoError(t, err)
+	assert.False(t, result.Passed, "active journeys need at least one auto checkRef")
+	require.NotEmpty(t, result.Results)
+	assert.Contains(t, result.Results[len(result.Results)-1].Output, "active journey has no auto checkRef")
+}
+
+func TestRunJourneyCheckRef_RejectsMismatchedJourneyScope(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module testmod\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "journeys"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "journey_test.go"), []byte(`package journeys
+import "testing"
+func TestJOtherHappyPath(t *testing.T) {}
+`), 0o644))
+
+	r := NewRunner(&metadata.ProjectMeta{}, dir)
+	tr, errs := r.RunJourneyCheckRef(
+		context.Background(),
+		&metadata.JourneyMeta{ID: "J-current"},
+		"journey.J-other.happy-path",
+	)
+
+	assert.False(t, tr.Passed, "a journey must not borrow another journey's passing test")
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), `belongs to journey "J-other"`)
+}
+
 func TestResolveJourneyPkg_IntegrationDir(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "tests", "integration"), 0o755))

--- a/kernel/verify/runner_test.go
+++ b/kernel/verify/runner_test.go
@@ -205,7 +205,14 @@ func TestIsZeroMatch(t *testing.T) {
 	assert.True(t, isZeroMatch("testing: warning: no tests to run\nPASS"))
 	assert.True(t, isZeroMatch("?   \tpkg\t[no test files]"))
 	assert.False(t, isZeroMatch("--- PASS: TestFoo (0.00s)\nPASS"))
+	assert.False(t, isZeroMatch("testing: warning: no tests to run\n--- SKIP: TestFoo (0.00s)\nPASS"))
 	assert.False(t, isZeroMatch(""))
+}
+
+func TestIsSkipOnly(t *testing.T) {
+	assert.True(t, isSkipOnly("=== RUN   TestFoo\n--- SKIP: TestFoo (0.00s)\nPASS"))
+	assert.False(t, isSkipOnly("=== RUN   TestFoo\n--- PASS: TestFoo (0.00s)\nPASS"))
+	assert.False(t, isSkipOnly(""))
 }
 
 func TestVerifyCell_NoSmoke(t *testing.T) {
@@ -248,4 +255,13 @@ func TestRecordResult_ZeroMatchMessage(t *testing.T) {
 	assert.False(t, result.Passed)
 	require.Len(t, result.Errors, 1)
 	assert.Contains(t, result.Errors[0].Error(), "check your YAML ref")
+}
+
+func TestRecordResult_SkipOnlyFails(t *testing.T) {
+	result := &VerifyResult{TargetID: "test", Passed: true}
+	res := goTestResult{Output: "--- SKIP: TestFoo (0.00s)\nPASS", Passed: true, SkippedOnly: true}
+	recordResult(result, "ref", res, "./pkg/...", "^TestFoo$")
+	assert.False(t, result.Passed)
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Error(), "only skipped tests")
 }

--- a/kernel/verify/runner_test.go
+++ b/kernel/verify/runner_test.go
@@ -151,6 +151,62 @@ func TestRunActiveJourneys_ManualOnlyActiveFails(t *testing.T) {
 	assert.Contains(t, result.Results[len(result.Results)-1].Output, "active journey has no auto checkRef")
 }
 
+func TestRunActiveJourneys_NilProjectPasses(t *testing.T) {
+	r := NewRunner(nil, t.TempDir())
+
+	result, err := r.RunActiveJourneys(context.Background())
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	assert.Empty(t, result.Results)
+}
+
+func TestRunActiveJourneys_SkipsInactiveJourneys(t *testing.T) {
+	r := NewRunner(&metadata.ProjectMeta{
+		Journeys: map[string]*metadata.JourneyMeta{
+			"J-draft": {
+				ID:        "J-draft",
+				Lifecycle: "experimental",
+				PassCriteria: []metadata.PassCriterion{
+					{Mode: "manual", Text: "Explore manually"},
+				},
+			},
+		},
+	}, t.TempDir())
+
+	result, err := r.RunActiveJourneys(context.Background())
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	assert.Empty(t, result.Results)
+}
+
+func TestRunActiveJourneys_AutoCheckRefPasses(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module testmod\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "journeys"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "journey_test.go"), []byte(`package journeys
+import "testing"
+func TestJActiveHappyPath(t *testing.T) {}
+`), 0o644))
+
+	r := NewRunner(&metadata.ProjectMeta{
+		Journeys: map[string]*metadata.JourneyMeta{
+			"J-active": {
+				ID:        "J-active",
+				Lifecycle: "active",
+				PassCriteria: []metadata.PassCriterion{
+					{Mode: "auto", Text: "Happy path", CheckRef: "journey.J-active.happy-path"},
+				},
+			},
+		},
+	}, dir)
+
+	result, err := r.RunActiveJourneys(context.Background())
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	require.Len(t, result.Results, 1)
+	assert.Equal(t, "journey.J-active.happy-path", result.Results[0].Name)
+}
+
 func TestRunJourneyCheckRef_RejectsMismatchedJourneyScope(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module testmod\n\ngo 1.21\n"), 0o644))
@@ -170,6 +226,20 @@ func TestJOtherHappyPath(t *testing.T) {}
 	assert.False(t, tr.Passed, "a journey must not borrow another journey's passing test")
 	require.Len(t, errs, 1)
 	assert.Contains(t, errs[0].Error(), `belongs to journey "J-other"`)
+}
+
+func TestRunJourneyCheckRef_RejectsNonJourneyRef(t *testing.T) {
+	r := NewRunner(&metadata.ProjectMeta{}, t.TempDir())
+
+	tr, errs := r.RunJourneyCheckRef(
+		context.Background(),
+		&metadata.JourneyMeta{ID: "J-current"},
+		"smoke.accesscore.startup",
+	)
+
+	assert.False(t, tr.Passed)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "must use journey prefix")
 }
 
 func TestResolveJourneyPkg_IntegrationDir(t *testing.T) {


### PR DESCRIPTION
## Summary
- add explicit `journey.lifecycle` with `active | experimental` metadata and schema support
- add base `FMT-24` journey lifecycle/passCriteria validation and strict-only `VERIFY-06` active journey auto-check enforcement
- mark existing journeys active and keep new scaffolded journeys experimental by default

Refs: PR-MODE-8
ref: kubernetes/kubernetes pkg/apis/core/validation/validation.go — accumulated validation-rule style
ref: kubernetes/apimachinery pkg/util/validation/field/errors.go — typed validation finding model

## Test plan
- [x] go -C worktrees/556-pr-mode-8-journey-auto-check test ./kernel/metadata ./kernel/governance ./kernel/scaffold ./cmd/gocell/app -count=1
- [x] go -C worktrees/556-pr-mode-8-journey-auto-check run ./cmd/gocell validate --strict
- [x] go -C worktrees/556-pr-mode-8-journey-auto-check build ./...
- [x] go -C worktrees/556-pr-mode-8-journey-auto-check test ./... -count=1
- [x] golangci-lint run ./...