### PR TITLE
PR-MODE-6 ERROR-FIRST-API: convert ~33 panics to error-first + Must* + archtest

### DIFF
--- a/.claude/rules/gocell/runtime-api.md
+++ b/.claude/rules/gocell/runtime-api.md
@@ -11,41 +11,59 @@ paths:
 ## Auth 路由声明 + 三 listener + RouteGroup (PR-A14b / PR262)
 
 每个 Cell 实现 `RouteGroupContributor` 接口，通过 `RouteGroups()` 声明路由组。
-每个路由组指定目标 listener、URL 前缀、以及注册回调（`Register func(mux cell.RouteMux)`）。
+每个路由组指定目标 listener、URL 前缀、以及注册回调（`Register func(mux cell.RouteMux) error` — PR-MODE-6: error-first 链路，phase5 把 Register 的错误连同 cell+listener+prefix 上下文 wrap 后冒泡到 `Bootstrap.Run`）。
 Bootstrap 在 phase5 收集所有路由组并挂载到对应 listener 的 chi.Mux 上。
 
-每条业务路由通过 `auth.Mount(mux, auth.Route{...})` 注册（**不是** `auth.Declare`/`auth.RouteDecl` —— 这两个旧符号已删除）。`auth.Route.Contract` 是 `wrapper.ContractSpec`，承载 method+path+contract id；Mount 自动 strip listener prefix、注册 chi handler、转发 AuthRouteMeta 给 FinalizeAuth。
+每条业务路由通过 `auth.Mount(mux, auth.Route{...})` 注册（**不是** `auth.Declare`/`auth.RouteDecl` —— 这两个旧符号已删除）。`auth.Route.Contract` 是 `wrapper.ContractSpec`，承载 method+path+contract id；Mount 自动 strip listener prefix、注册 chi handler、转发 AuthRouteMeta 给 FinalizeAuth。Mount 返回 `error`（PR-MODE-6 ERROR-FIRST-API）；`auth.MustMount` 是 composition-root fail-fast 包装，但 **slice handler 内部应直接用 `auth.Mount` + 错误传播**，让错误一路冒泡到 phase5。
 
 ```go
-// Cell.RouteGroups — PR-A14b 声明式路由组
+// Slice handler — RegisterRoutes 返回 error，使用 auth.Mount + 错误传播
+func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
+    if err := auth.Mount(mux, auth.Route{
+        Contract: specSessionsLogin, // wrapper.ContractSpec — Method+Path+Kind=http
+        Handler:  http.HandlerFunc(h.loginHandler.HandleLogin),
+        Public:   true,              // JWT 豁免
+    }); err != nil {
+        return err
+    }
+    if err := auth.Mount(mux, auth.Route{
+        Contract:            specSessionsLogout,
+        Handler:             http.HandlerFunc(h.logoutHandler.HandleLogout),
+        PasswordResetExempt: true,   // 允许 reset-required token 穿过
+    }); err != nil {
+        return err
+    }
+    return nil
+}
+
+// Cell.RouteGroups — PR-A14b 声明式路由组（PR-MODE-6 错误链路贯通）
 func (c *AccessCore) RouteGroups() []cell.RouteGroup {
     return []cell.RouteGroup{
         {
             Listener: cell.PrimaryListener,
             Prefix:   "/api/v1/access",
-            Register: func(mux cell.RouteMux) {
+            Register: func(mux cell.RouteMux) error {
+                // mux.Route 的 callback 仍是 func(RouteMux) 无 error 返回，
+                // 用 outer-variable closure 捕获 slice 错误并通过 Register 返回
+                // 给 phase5。bootstrap/mountOneRouteGroup 用同样模式。
+                var firstErr error
+                captureErr := func(err error) {
+                    if err != nil && firstErr == nil {
+                        firstErr = err
+                    }
+                }
                 mux.Route("/sessions", func(s cell.RouteMux) {
-                    auth.Mount(s, auth.Route{
-                        Contract: specSessionsLogin, // wrapper.ContractSpec — Method+Path+Kind=http
-                        Handler:  http.HandlerFunc(c.loginHandler.HandleLogin),
-                        Public:   true,                     // JWT 豁免
-                    })
-                    auth.Mount(s, auth.Route{
-                        Contract:            specSessionsLogout,
-                        Handler:             http.HandlerFunc(c.logoutHandler.HandleLogout),
-                        PasswordResetExempt: true,         // 允许 reset-required token 穿过
-                    })
+                    captureErr(c.loginHandler.RegisterRoutes(s))
+                    captureErr(c.logoutHandler.RegisterRoutes(s))
                 })
+                return firstErr
             },
         },
         {
             Listener: cell.InternalListener,
             Prefix:   "/internal/v1/access",
-            Register: func(mux cell.RouteMux) {
-                auth.Mount(mux, auth.Route{
-                    Contract: specRolesAssign,
-                    Handler:  http.HandlerFunc(c.rbacAssignHandler.HandleAssign),
-                })
+            Register: func(mux cell.RouteMux) error {
+                return c.rbacAssignHandler.RegisterRoutes(mux)
             },
         },
     }
@@ -54,12 +72,16 @@ func (c *AccessCore) RouteGroups() []cell.RouteGroup {
 // composition root — WithListener(ref, addr, authChain []cell.ListenerAuth, ...ListenerOption)
 // JWT auth lives on the listener auth chain; there is no separate WithAuthMiddleware /
 // WithAuthDiscovery option (PR262: typed AuthPlan replaces cell.Policy).
+//
+// AuthPlan 构造函数（PR-MODE-6）现在是 error-first：`cell.NewAuthJWT(v) (AuthJWT, error)`。
+// composition root 用 `cell.MustNewAuthJWT(v)` panic-on-misconfig 简化静态字面量；
+// 数据驱动场景用 `cell.NewAuthJWT(v)` 显式处理 error。
 bootstrap.New(
     bootstrap.WithAssembly(asm),
     bootstrap.WithListener(cell.PrimaryListener, ":8080",
-        []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}),
+        []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}),
     bootstrap.WithListener(cell.InternalListener, "127.0.0.1:9090",
-        []cell.ListenerAuth{cell.NewAuthServiceToken(nonceStore, ring)}),
+        []cell.ListenerAuth{cell.MustNewAuthServiceToken(nonceStore, ring)}),
     bootstrap.WithListener(cell.HealthListener, "127.0.0.1:9091", nil),
 )
 ```
@@ -80,9 +102,9 @@ bootstrap.New(
 
 | 构造函数 | 说明 | 典型 listener |
 |---------|------|--------------|
-| `cell.NewAuthJWT(verifier)` | JWT 验证（直接注入 IntentTokenVerifier） | PrimaryListener |
-| `cell.NewAuthJWTFromAssembly(asm)` | JWT 验证（phase4 自动从 authProvider Cell 发现 verifier） | PrimaryListener |
-| `cell.NewAuthServiceToken(store, ring)` | HMAC-SHA256 service token | InternalListener |
+| `cell.MustNewAuthJWT(verifier)` / `cell.NewAuthJWT(v) (AuthJWT, error)` | JWT 验证（直接注入 IntentTokenVerifier）。Must 适用于静态 composition；error-first 适用于运行时配置。 | PrimaryListener |
+| `cell.MustNewAuthJWTFromAssembly(asm)` / `cell.NewAuthJWTFromAssembly(asm) (..., error)` | JWT 验证（phase4 自动从 authProvider Cell 发现 verifier） | PrimaryListener |
+| `cell.MustNewAuthServiceToken(store, ring)` / `cell.NewAuthServiceToken(...) (..., error)` | HMAC-SHA256 service token | InternalListener |
 | `cell.AuthMTLS{}` | mTLS — 仅断言存在 peer cert；链验证由 `tls.Config.ClientAuth=RequireAndVerifyClientCert` 在握手层完成（必须配置 WithListenerTLS） | InternalListener（高安全场景） |
 | `nil` | 无验证（等同于 `cell.AuthNone{}`；推荐 nil 减少样板） | HealthListener（loopback 隔离） |
 
@@ -92,8 +114,8 @@ bootstrap.New(
 // mTLS + service-token 双层守护（外层 transport 证书验证 + 内层 HMAC token 防重放）
 bootstrap.WithListener(cell.InternalListener, "127.0.0.1:9090",
     []cell.ListenerAuth{
-        cell.AuthMTLS{},                                // 外层：peer cert presence check
-        cell.NewAuthServiceToken(nonceStore, ring),     // 内层：HMAC-SHA256 + replay guard
+        cell.AuthMTLS{},                                    // 外层：peer cert presence check
+        cell.MustNewAuthServiceToken(nonceStore, ring),     // 内层：HMAC-SHA256 + replay guard
     },
     bootstrap.WithListenerTLS(tlsCfg), // ClientAuth=RequireAndVerifyClientCert + ClientCAs required
 )
@@ -127,9 +149,9 @@ token 直接 plumb 到 `runtime/http/health.Handler.SetVerboseToken`；不匹配
 const WebhookListener cell.ListenerRef = "webhook"
 
 bootstrap.WithListener(cell.PrimaryListener, ":8080",
-    []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)})
+    []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)})
 bootstrap.WithListener(WebhookListener, ":8090",
-    []cell.ListenerAuth{cell.NewAuthServiceToken(store, ring)})
+    []cell.ListenerAuth{cell.MustNewAuthServiceToken(store, ring)})
 ```
 
 历史 `cell.GroupAuth` 接口、`cell.AuthVerboseToken` 类型、`bootstrap.WithLivezAuth/WithReadyzAuth/WithMetricsAuth` options 均已删除。`AUTH-PLAN-04 (LAYER-09)` archtest 仍禁止 cells 直接构造 AuthPlan（composition root 责任）。
@@ -181,7 +203,7 @@ internal listener 的 `ServiceTokenMiddleware` 必须带一个 replay-safe `auth
 - 路由级 Policy 存在时，Listener 认证链中间件在路由层之前运行（链中间件先于路由 handler）
 - `Public: true` 不能与路由级 `Policy` 同时设置（FinalizeAuth fail-fast）
 - `Public: true` 是 JWT 豁免标志，只对安装了 JWT 中间件的 listener 有意义
-- JWT 单一路径（PR262）：`cell.NewAuthJWT(verifier)` 直接注入；`cell.NewAuthJWTFromAssembly(asm)` phase4 时通过 `AuthJWTFromAssembly.Validate()` 从 `authProvider` Cell 发现 verifier。**没有** `WithAuthMiddleware` / `WithAuthDiscovery` 等 Bootstrap 顶层 Option。Verifier 流向 `router.WithAuthMiddleware`，自动获取 FinalizeAuth 编译的 Public/PasswordResetExempt matcher，零样板。
+- JWT 单一路径（PR262 / PR-MODE-6）：`cell.MustNewAuthJWT(verifier)`（或 error-first 的 `cell.NewAuthJWT(v)`）直接注入；`cell.MustNewAuthJWTFromAssembly(asm)` phase4 时通过 `AuthJWTFromAssembly.Validate()` 从 `authProvider` Cell 发现 verifier。**没有** `WithAuthMiddleware` / `WithAuthDiscovery` 等 Bootstrap 顶层 Option。Verifier 流向 `router.WithAuthMiddleware`，自动获取 FinalizeAuth 编译的 Public/PasswordResetExempt matcher，零样板。
 - `/internal/v1/*` 路由（`IsInternal()` 为 true）必须挂在 InternalListener；非 internal 路径不得挂在 InternalListener（FinalizeAuth 双向 fail-fast 校验）。
 
 ### 规则
@@ -193,4 +215,4 @@ internal listener 的 `ServiceTokenMiddleware` 必须带一个 replay-safe `auth
 - CORS OPTIONS：当前无 CORS middleware；如需公开 OPTIONS 请显式 `auth.Mount` + `Public: true`
 - 禁止在 `cmd/*` / `examples/*/main.go` 硬编码业务路径字面量（`grep '"POST /api/v1/"'` 必须为空）
 - Cell 禁止直接 import `runtime/http/router`；通过 `cell.RouteMux` / `cell.RouteGroup` 声明路由（LAYER-07）
-- Cell 禁止构造 AuthPlan 值（`cell.NewAuthJWT` 等）；认证计划由 composition root（`cmd/`）组装后通过 `WithListener` 注入（LAYER-09 / AUTH-PLAN-04）
+- Cell 禁止构造 AuthPlan 值（`cell.NewAuthJWT` / `cell.MustNewAuthJWT` / `cell.NewAuthServiceToken` / `cell.MustNewAuthServiceToken` 等所有变体）；认证计划由 composition root（`cmd/`）组装后通过 `WithListener` 注入（LAYER-09 / AUTH-PLAN-04）

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"time"
@@ -110,19 +111,21 @@ func (r refreshRow) toToken() *refresh.Token {
 	}
 }
 
-// NewRefreshStore constructs a PGRefreshStore.
-func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Clock, randReader io.Reader) *PGRefreshStore {
+// NewRefreshStore constructs a PGRefreshStore. Returns a non-nil error if
+// pool/clock are nil or policy values are out of range; callers that prefer
+// fail-fast at composition time can use MustNewRefreshStore.
+func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Clock, randReader io.Reader) (*PGRefreshStore, error) {
 	if pool == nil {
-		panic("postgres.NewRefreshStore: pool must not be nil")
+		return nil, fmt.Errorf("postgres.NewRefreshStore: pool must not be nil")
 	}
 	if clock == nil {
-		panic("postgres.NewRefreshStore: clock must not be nil")
+		return nil, fmt.Errorf("postgres.NewRefreshStore: clock must not be nil")
 	}
 	if policy.MaxAge <= 0 {
-		panic("postgres.NewRefreshStore: policy.MaxAge must be positive")
+		return nil, fmt.Errorf("postgres.NewRefreshStore: policy.MaxAge must be positive")
 	}
 	if policy.ReuseInterval < 0 {
-		panic("postgres.NewRefreshStore: policy.ReuseInterval must not be negative")
+		return nil, fmt.Errorf("postgres.NewRefreshStore: policy.ReuseInterval must not be negative")
 	}
 	if randReader == nil {
 		randReader = rand.Reader
@@ -132,7 +135,17 @@ func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Cl
 		policy: policy,
 		clock:  clock,
 		rand:   randReader,
+	}, nil
+}
+
+// MustNewRefreshStore is the composition-root fail-fast variant of
+// NewRefreshStore. It panics when NewRefreshStore returns an error.
+func MustNewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Clock, randReader io.Reader) *PGRefreshStore {
+	store, err := NewRefreshStore(pool, policy, clock, randReader)
+	if err != nil {
+		panic(err.Error())
 	}
+	return store
 }
 
 // execCtx executes a SQL statement against the ambient transaction in ctx when

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -34,7 +34,7 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 		require.NoError(t, migrator.Up(ctx))
 
 		clock := storetest.NewFakeClock(baseTime)
-		store := NewRefreshStore(p.DB(), policy, clock, nil)
+		store := MustNewRefreshStore(p.DB(), policy, clock, nil)
 		return store, clock
 	})
 }
@@ -187,7 +187,7 @@ func TestPGRefreshStore_DMLState(t *testing.T) {
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	policy := refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: 7 * 24 * time.Hour}
-	store := NewRefreshStore(p.DB(), policy, clock, nil)
+	store := MustNewRefreshStore(p.DB(), policy, clock, nil)
 
 	const sessionID = "sess-dml-state"
 	const subjectID = "usr-dml-state"
@@ -267,7 +267,7 @@ func TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback(t *testing.T) {
 	require.NoError(t, migrator.Up(ctx))
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
-	store := NewRefreshStore(p.DB(), refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	store := MustNewRefreshStore(p.DB(), refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 	txm := NewTxManager(p)
 
 	parentWire, _, err := store.Issue(ctx, "sess-reuse-ambient", "usr-reuse-ambient")
@@ -298,7 +298,7 @@ func TestPGRefreshStore_SessionLockRejectsChildValidatedBeforeCascade(t *testing
 	require.NoError(t, migrator.Up(ctx))
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
-	store := NewRefreshStore(p.DB(), refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	store := MustNewRefreshStore(p.DB(), refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 
 	parentWire, _, err := store.Issue(ctx, "sess-reuse-lock", "usr-reuse-lock")
 	require.NoError(t, err)

--- a/adapters/postgres/refresh_store_test.go
+++ b/adapters/postgres/refresh_store_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// NewRefreshStore constructor panics
+// NewRefreshStore constructor validation
 // ---------------------------------------------------------------------------
 
-func TestNewRefreshStore_Panics(t *testing.T) {
+func TestNewRefreshStore_ReturnsErrorOnInvalidArgs(t *testing.T) {
 	validClock := storetest.NewFakeClock(time.Now())
 	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
 
@@ -26,36 +26,39 @@ func TestNewRefreshStore_Panics(t *testing.T) {
 	dummyPool := new(pgxpool.Pool)
 
 	t.Run("nil_pool", func(t *testing.T) {
-		assert.Panics(t, func() {
-			NewRefreshStore(nil, validPolicy, validClock, nil)
-		})
+		_, err := NewRefreshStore(nil, validPolicy, validClock, nil)
+		assert.Error(t, err)
 	})
 
 	t.Run("nil_clock", func(t *testing.T) {
-		assert.Panics(t, func() {
-			NewRefreshStore(dummyPool, validPolicy, nil, nil)
-		})
+		_, err := NewRefreshStore(dummyPool, validPolicy, nil, nil)
+		assert.Error(t, err)
 	})
 
 	t.Run("zero_MaxAge", func(t *testing.T) {
 		p := refresh.Policy{ReuseInterval: time.Second, MaxAge: 0}
-		assert.Panics(t, func() {
-			NewRefreshStore(dummyPool, p, validClock, nil)
-		})
+		_, err := NewRefreshStore(dummyPool, p, validClock, nil)
+		assert.Error(t, err)
 	})
 
 	t.Run("negative_MaxAge", func(t *testing.T) {
 		p := refresh.Policy{ReuseInterval: time.Second, MaxAge: -time.Hour}
-		assert.Panics(t, func() {
-			NewRefreshStore(dummyPool, p, validClock, nil)
-		})
+		_, err := NewRefreshStore(dummyPool, p, validClock, nil)
+		assert.Error(t, err)
 	})
 
 	t.Run("negative_ReuseInterval", func(t *testing.T) {
 		p := refresh.Policy{ReuseInterval: -time.Second, MaxAge: time.Hour}
-		assert.Panics(t, func() {
-			NewRefreshStore(dummyPool, p, validClock, nil)
-		})
+		_, err := NewRefreshStore(dummyPool, p, validClock, nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestMustNewRefreshStore_PanicsOnNilPool(t *testing.T) {
+	validClock := storetest.NewFakeClock(time.Now())
+	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
+	assert.Panics(t, func() {
+		MustNewRefreshStore(nil, validPolicy, validClock, nil)
 	})
 }
 
@@ -64,11 +67,10 @@ func TestNewRefreshStore_NilRandReader_UsesDefault(t *testing.T) {
 	validClock := storetest.NewFakeClock(time.Now())
 	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
 
-	// nil randReader must not panic — constructor falls back to crypto/rand.Reader.
-	assert.NotPanics(t, func() {
-		s := NewRefreshStore(dummyPool, validPolicy, validClock, nil)
-		assert.NotNil(t, s.rand, "rand field must be non-nil after constructor")
-	})
+	// nil randReader must not error — constructor falls back to crypto/rand.Reader.
+	s, err := NewRefreshStore(dummyPool, validPolicy, validClock, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, s.rand, "rand field must be non-nil after constructor")
 }
 
 // ---------------------------------------------------------------------------

--- a/cells/accesscore/cell_routes.go
+++ b/cells/accesscore/cell_routes.go
@@ -48,25 +48,45 @@ func (c *AccessCore) RouteGroups() []cell.RouteGroup {
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1/access",
 			Register: func(mux cell.RouteMux) error {
+				// mux.Route's callback signature is func(RouteMux) (no error
+				// return), so slice RegisterRoutes errors are captured via
+				// outer-variable closure and surfaced through this Register's
+				// error return — bootstrap phase5 wraps with cell+listener+prefix
+				// context. Same pattern as bootstrap/mountOneRouteGroup.
+				var firstErr error
+				captureErr := func(err error) {
+					if err != nil && firstErr == nil {
+						firstErr = err
+					}
+				}
 				mux.Route("/setup", func(s cell.RouteMux) {
-					c.setupHandler.RegisterRoutes(s)
+					captureErr(c.setupHandler.RegisterRoutes(s))
 				})
-				mux.Route("/users", c.identityHandler.RegisterRoutes)
+				mux.Route("/users", func(s cell.RouteMux) {
+					captureErr(c.identityHandler.RegisterRoutes(s))
+				})
 				mux.Route("/sessions", func(s cell.RouteMux) {
-					c.loginHandler.RegisterRoutes(s)
-					c.refreshHandler.RegisterRoutes(s)
-					c.logoutHandler.RegisterRoutes(s)
+					captureErr(c.loginHandler.RegisterRoutes(s))
+					captureErr(c.refreshHandler.RegisterRoutes(s))
+					captureErr(c.logoutHandler.RegisterRoutes(s))
 				})
-				mux.Route("/roles", c.rbacHandler.RegisterRoutes)
-				return nil
+				mux.Route("/roles", func(s cell.RouteMux) {
+					captureErr(c.rbacHandler.RegisterRoutes(s))
+				})
+				return firstErr
 			},
 		},
 		{
 			Listener: cell.InternalListener,
 			Prefix:   "/internal/v1/access",
 			Register: func(mux cell.RouteMux) error {
-				mux.Route("/roles", c.rbacAssignHandler.RegisterRoutes)
-				return nil
+				var firstErr error
+				mux.Route("/roles", func(s cell.RouteMux) {
+					if err := c.rbacAssignHandler.RegisterRoutes(s); err != nil {
+						firstErr = err
+					}
+				})
+				return firstErr
 			},
 		},
 	}

--- a/cells/accesscore/cell_routes.go
+++ b/cells/accesscore/cell_routes.go
@@ -47,7 +47,7 @@ func (c *AccessCore) RouteGroups() []cell.RouteGroup {
 		{
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1/access",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				mux.Route("/setup", func(s cell.RouteMux) {
 					c.setupHandler.RegisterRoutes(s)
 				})
@@ -58,13 +58,15 @@ func (c *AccessCore) RouteGroups() []cell.RouteGroup {
 					c.logoutHandler.RegisterRoutes(s)
 				})
 				mux.Route("/roles", c.rbacHandler.RegisterRoutes)
+				return nil
 			},
 		},
 		{
 			Listener: cell.InternalListener,
 			Prefix:   "/internal/v1/access",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				mux.Route("/roles", c.rbacAssignHandler.RegisterRoutes)
+				return nil
 			},
 		},
 	}

--- a/cells/accesscore/cell_routes.go
+++ b/cells/accesscore/cell_routes.go
@@ -5,6 +5,8 @@
 package accesscore
 
 import (
+	"fmt"
+
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/wrapper"
@@ -73,16 +75,24 @@ func (c *AccessCore) RouteGroups() []cell.RouteGroup {
 func (c *AccessCore) RegisterSubscriptions(r cell.EventRouter) error {
 	// config-receive: config state-sync events from configcore.
 	upsertedHandler := outbox.WrapLegacyHandler(c.configReceiveSvc.HandleEntryUpserted)
-	r.AddContractHandler(specEventConfigEntryUpserted, upsertedHandler, "accesscore")
+	if err := r.AddContractHandler(specEventConfigEntryUpserted, upsertedHandler, "accesscore"); err != nil {
+		return fmt.Errorf("accesscore: subscribe %s: %w", specEventConfigEntryUpserted.Topic, err)
+	}
 
 	deletedHandler := outbox.WrapLegacyHandler(c.configReceiveSvc.HandleEntryDeleted)
-	r.AddContractHandler(specEventConfigEntryDeleted, deletedHandler, "accesscore")
+	if err := r.AddContractHandler(specEventConfigEntryDeleted, deletedHandler, "accesscore"); err != nil {
+		return fmt.Errorf("accesscore: subscribe %s: %w", specEventConfigEntryDeleted.Topic, err)
+	}
 
 	// rbac-session-sync: invalidate sessions on role assignment or revocation.
 	// Same handler + same consumer group across both topics — HandleRoleChanged
 	// is topic-agnostic.
 	roleHandler := outbox.WrapLegacyHandler(c.rbacSessionConsumer.HandleRoleChanged)
-	r.AddContractHandler(specEventRoleAssigned, roleHandler, "accesscore-rbac-session-sync")
-	r.AddContractHandler(specEventRoleRevoked, roleHandler, "accesscore-rbac-session-sync")
+	if err := r.AddContractHandler(specEventRoleAssigned, roleHandler, "accesscore-rbac-session-sync"); err != nil {
+		return fmt.Errorf("accesscore: subscribe %s: %w", specEventRoleAssigned.Topic, err)
+	}
+	if err := r.AddContractHandler(specEventRoleRevoked, roleHandler, "accesscore-rbac-session-sync"); err != nil {
+		return fmt.Errorf("accesscore: subscribe %s: %w", specEventRoleRevoked.Topic, err)
+	}
 	return nil
 }

--- a/cells/accesscore/cell_routes.go
+++ b/cells/accesscore/cell_routes.go
@@ -20,6 +20,12 @@ import (
 //
 // HTTP contract specs are owned by each slice's handler.go (single source of
 // truth); RouteGroups below delegates to slice.RegisterRoutes for HTTP wiring.
+
+// errFmtSubscribe is the wrap format used by RegisterSubscriptions when an
+// AddContractHandler call rejects a spec. Centralized so the four wrap
+// sites stay aligned and SonarCloud's duplicate-literal rule is satisfied.
+const errFmtSubscribe = "accesscore: subscribe %s: %w"
+
 var (
 	specEventConfigEntryUpserted = wrapper.EventSpec("event.config.entry-upserted.v1", "amqp")
 	specEventConfigEntryDeleted  = wrapper.EventSpec("event.config.entry-deleted.v1", "amqp")
@@ -98,12 +104,12 @@ func (c *AccessCore) RegisterSubscriptions(r cell.EventRouter) error {
 	// config-receive: config state-sync events from configcore.
 	upsertedHandler := outbox.WrapLegacyHandler(c.configReceiveSvc.HandleEntryUpserted)
 	if err := r.AddContractHandler(specEventConfigEntryUpserted, upsertedHandler, "accesscore"); err != nil {
-		return fmt.Errorf("accesscore: subscribe %s: %w", specEventConfigEntryUpserted.Topic, err)
+		return fmt.Errorf(errFmtSubscribe, specEventConfigEntryUpserted.Topic, err)
 	}
 
 	deletedHandler := outbox.WrapLegacyHandler(c.configReceiveSvc.HandleEntryDeleted)
 	if err := r.AddContractHandler(specEventConfigEntryDeleted, deletedHandler, "accesscore"); err != nil {
-		return fmt.Errorf("accesscore: subscribe %s: %w", specEventConfigEntryDeleted.Topic, err)
+		return fmt.Errorf(errFmtSubscribe, specEventConfigEntryDeleted.Topic, err)
 	}
 
 	// rbac-session-sync: invalidate sessions on role assignment or revocation.
@@ -111,10 +117,10 @@ func (c *AccessCore) RegisterSubscriptions(r cell.EventRouter) error {
 	// is topic-agnostic.
 	roleHandler := outbox.WrapLegacyHandler(c.rbacSessionConsumer.HandleRoleChanged)
 	if err := r.AddContractHandler(specEventRoleAssigned, roleHandler, "accesscore-rbac-session-sync"); err != nil {
-		return fmt.Errorf("accesscore: subscribe %s: %w", specEventRoleAssigned.Topic, err)
+		return fmt.Errorf(errFmtSubscribe, specEventRoleAssigned.Topic, err)
 	}
 	if err := r.AddContractHandler(specEventRoleRevoked, roleHandler, "accesscore-rbac-session-sync"); err != nil {
-		return fmt.Errorf("accesscore: subscribe %s: %w", specEventRoleRevoked.Topic, err)
+		return fmt.Errorf(errFmtSubscribe, specEventRoleRevoked.Topic, err)
 	}
 	return nil
 }

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -118,10 +118,10 @@ func newE2EFixture() *e2eFixture {
 	// Policies are declared via auth.Mount to match production wiring.
 	mux := celltest.NewTestMux()
 	h := NewHandler(idmSvc)
-	auth.Mount(mux, auth.Route{Contract: testHTTPContract("POST", "/api/v1/access/users"), Handler: http.HandlerFunc(h.handleCreate), Policy: auth.AnyRole(domain.RoleAdmin)})
-	auth.Mount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/access/users/{id}"), Handler: http.HandlerFunc(h.handleGet), Policy: auth.SelfOr("id", domain.RoleAdmin)})
-	auth.Mount(mux, auth.Route{Contract: testHTTPContract("PATCH", "/api/v1/access/users/{id}"), Handler: http.HandlerFunc(h.handlePatch), Policy: auth.SelfOr("id", domain.RoleAdmin)})
-	auth.Mount(mux, auth.Route{Contract: testHTTPContract("POST", "/api/v1/access/users/{id}/password"), Handler: http.HandlerFunc(h.handleChangePassword), Policy: auth.SelfOr("id", domain.RoleAdmin)})
+	auth.MustMount(mux, auth.Route{Contract: testHTTPContract("POST", "/api/v1/access/users"), Handler: http.HandlerFunc(h.handleCreate), Policy: auth.AnyRole(domain.RoleAdmin)})
+	auth.MustMount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/access/users/{id}"), Handler: http.HandlerFunc(h.handleGet), Policy: auth.SelfOr("id", domain.RoleAdmin)})
+	auth.MustMount(mux, auth.Route{Contract: testHTTPContract("PATCH", "/api/v1/access/users/{id}"), Handler: http.HandlerFunc(h.handlePatch), Policy: auth.SelfOr("id", domain.RoleAdmin)})
+	auth.MustMount(mux, auth.Route{Contract: testHTTPContract("POST", "/api/v1/access/users/{id}/password"), Handler: http.HandlerFunc(h.handleChangePassword), Policy: auth.SelfOr("id", domain.RoleAdmin)})
 
 	return &e2eFixture{
 		mux:         mux,

--- a/cells/accesscore/slices/identitymanage/handler.go
+++ b/cells/accesscore/slices/identitymanage/handler.go
@@ -108,52 +108,69 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers identity-manage routes on the given mux via
 // auth.Mount so every request emits a contract-tagged span. Policy is
 // declared at registration time; handler bodies contain only business logic.
-func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specUserCreate,
 		Handler:  http.HandlerFunc(h.handleCreate),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specUserGet,
 		Handler:  http.HandlerFunc(h.handleGet),
 		Policy:   auth.SelfOr("id", domain.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specUserUpdate,
 		Handler:  http.HandlerFunc(h.handleUpdate),
 		Policy:   auth.SelfOr("id", domain.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specUserPatch,
 		Handler:  http.HandlerFunc(h.handlePatch),
 		Policy:   auth.SelfOr("id", domain.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specUserDelete,
 		Handler:  http.HandlerFunc(h.handleDelete),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specUserLock,
 		Handler:  http.HandlerFunc(h.handleLock),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specUserUnlock,
 		Handler:  http.HandlerFunc(h.handleUnlock),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
-	})
+	}); err != nil {
+		return err
+	}
 	// POST /{id}/password: SelfOr policy + PasswordResetExempt so a user whose
 	// token carries password_reset_required=true can still reach this endpoint
 	// to satisfy the reset requirement. Router.FinalizeAuth aggregates this
 	// declaration alongside all other Cell declarations at Bootstrap phase 5.
-	auth.MustMount(mux, auth.Route{
+	if err := auth.Mount(mux, auth.Route{
 		Contract:            specUserChangePassword,
 		Handler:             http.HandlerFunc(h.handleChangePassword),
 		Policy:              auth.SelfOr("id", domain.RoleAdmin),
 		PasswordResetExempt: true,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {

--- a/cells/accesscore/slices/identitymanage/handler.go
+++ b/cells/accesscore/slices/identitymanage/handler.go
@@ -109,37 +109,37 @@ func NewHandler(svc *Service) *Handler {
 // auth.Mount so every request emits a contract-tagged span. Policy is
 // declared at registration time; handler bodies contain only business logic.
 func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specUserCreate,
 		Handler:  http.HandlerFunc(h.handleCreate),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specUserGet,
 		Handler:  http.HandlerFunc(h.handleGet),
 		Policy:   auth.SelfOr("id", domain.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specUserUpdate,
 		Handler:  http.HandlerFunc(h.handleUpdate),
 		Policy:   auth.SelfOr("id", domain.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specUserPatch,
 		Handler:  http.HandlerFunc(h.handlePatch),
 		Policy:   auth.SelfOr("id", domain.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specUserDelete,
 		Handler:  http.HandlerFunc(h.handleDelete),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specUserLock,
 		Handler:  http.HandlerFunc(h.handleLock),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specUserUnlock,
 		Handler:  http.HandlerFunc(h.handleUnlock),
 		Policy:   auth.AnyRole(domain.RoleAdmin),
@@ -148,7 +148,7 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 	// token carries password_reset_required=true can still reach this endpoint
 	// to satisfy the reset requirement. Router.FinalizeAuth aggregates this
 	// declaration alongside all other Cell declarations at Bootstrap phase 5.
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract:            specUserChangePassword,
 		Handler:             http.HandlerFunc(h.handleChangePassword),
 		Policy:              auth.SelfOr("id", domain.RoleAdmin),

--- a/cells/accesscore/slices/identitymanage/handler_test.go
+++ b/cells/accesscore/slices/identitymanage/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -45,7 +46,12 @@ func setup() http.Handler {
 		panic("setup: " + err.Error())
 	}
 	mux := celltest.NewTestMux()
-	mux.Route("/api/v1/access/users", NewHandler(svc).RegisterRoutes)
+	h := NewHandler(svc)
+	mux.Route("/api/v1/access/users", func(s cell.RouteMux) {
+		if err := h.RegisterRoutes(s); err != nil {
+			panic("setup: RegisterRoutes: " + err.Error())
+		}
+	})
 	return mux
 }
 
@@ -62,7 +68,12 @@ func setupWithIssuer(issuer TokenIssuer) (http.Handler, *mem.UserRepository) {
 		panic("setupWithIssuer: " + err.Error())
 	}
 	mux := celltest.NewTestMux()
-	mux.Route("/api/v1/access/users", NewHandler(svc).RegisterRoutes)
+	h := NewHandler(svc)
+	mux.Route("/api/v1/access/users", func(s cell.RouteMux) {
+		if err := h.RegisterRoutes(s); err != nil {
+			panic("setupWithIssuer: RegisterRoutes: " + err.Error())
+		}
+	})
 	return mux, repo
 }
 

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -529,7 +529,7 @@ func (s *Service) publish(ctx context.Context, topic string, payload any) error 
 		return fmt.Errorf("identity-manage: marshal event payload: %w", err)
 	}
 	entry := outbox.Entry{
-		ID:        outbox.NewEntryID(),
+		ID:        outbox.MustNewEntryID(),
 		EventType: topic,
 		Payload:   data,
 	}

--- a/cells/accesscore/slices/rbacassign/contract_test.go
+++ b/cells/accesscore/slices/rbacassign/contract_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -30,7 +31,12 @@ func newContractHandler() http.Handler {
 
 	svc := NewService(roleRepo, mem.NewSessionRepository(), slog.Default())
 	mux := celltest.NewTestMux()
-	mux.Route("/internal/v1/access/roles", NewHandler(svc).RegisterRoutes)
+	h := NewHandler(svc)
+	mux.Route("/internal/v1/access/roles", func(s cell.RouteMux) {
+		if err := h.RegisterRoutes(s); err != nil {
+			panic("newContractHandler: RegisterRoutes: " + err.Error())
+		}
+	})
 	return mux
 }
 

--- a/cells/accesscore/slices/rbacassign/handler.go
+++ b/cells/accesscore/slices/rbacassign/handler.go
@@ -65,14 +65,14 @@ type RevokeRequest struct {
 // business logic (no inline guard calls).
 func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
 	internalAdminPolicy := auth.AnyRole(auth.RoleInternalAdmin)
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specRoleAssign,
 		Handler:  http.HandlerFunc(h.handleAssign),
 		Policy:   internalAdminPolicy,
 		// Route lives on InternalListener (/internal/v1/*); internal affinity
 		// is derived from the path prefix via AuthRouteMeta.IsInternal().
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specRoleRevoke,
 		Handler:  http.HandlerFunc(h.handleRevoke),
 		Policy:   internalAdminPolicy,

--- a/cells/accesscore/slices/rbacassign/handler.go
+++ b/cells/accesscore/slices/rbacassign/handler.go
@@ -63,20 +63,25 @@ type RevokeRequest struct {
 // RegisterRoutes registers rbac-assign routes on the given mux.
 // Policy is declared at registration time; handler bodies contain only
 // business logic (no inline guard calls).
-func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) error {
 	internalAdminPolicy := auth.AnyRole(auth.RoleInternalAdmin)
-	auth.MustMount(mux, auth.Route{
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specRoleAssign,
 		Handler:  http.HandlerFunc(h.handleAssign),
 		Policy:   internalAdminPolicy,
 		// Route lives on InternalListener (/internal/v1/*); internal affinity
 		// is derived from the path prefix via AuthRouteMeta.IsInternal().
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specRoleRevoke,
 		Handler:  http.HandlerFunc(h.handleRevoke),
 		Policy:   internalAdminPolicy,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *Handler) handleAssign(w http.ResponseWriter, r *http.Request) {

--- a/cells/accesscore/slices/rbacassign/handler_test.go
+++ b/cells/accesscore/slices/rbacassign/handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -28,7 +29,12 @@ func setupHandler() (http.Handler, *mem.RoleRepository) {
 
 	svc := NewService(roleRepo, mem.NewSessionRepository(), slog.Default())
 	mux := celltest.NewTestMux()
-	mux.Route("/internal/v1/access/roles", NewHandler(svc).RegisterRoutes)
+	h := NewHandler(svc)
+	mux.Route("/internal/v1/access/roles", func(s cell.RouteMux) {
+		if err := h.RegisterRoutes(s); err != nil {
+			panic("setupHandler: RegisterRoutes: " + err.Error())
+		}
+	})
 	return mux, roleRepo
 }
 

--- a/cells/accesscore/slices/rbacassign/service.go
+++ b/cells/accesscore/slices/rbacassign/service.go
@@ -86,7 +86,7 @@ func (s *Service) writeOutboxEntry(ctx context.Context, eventType string, evt dt
 		return fmt.Errorf("rbac-assign: marshal role-changed event: %w", err)
 	}
 	entry := outbox.Entry{
-		ID:        outbox.NewEntryID(),
+		ID:        outbox.MustNewEntryID(),
 		EventType: eventType,
 		Payload:   payload,
 	}

--- a/cells/accesscore/slices/rbaccheck/contract_test.go
+++ b/cells/accesscore/slices/rbaccheck/contract_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/contracttest"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -55,7 +56,12 @@ func newContractRBACHandler() http.Handler {
 	}
 
 	mux := celltest.NewTestMux()
-	mux.Route("/api/v1/access/roles", NewHandler(svc).RegisterRoutes)
+	h := NewHandler(svc)
+	mux.Route("/api/v1/access/roles", func(s cell.RouteMux) {
+		if err := h.RegisterRoutes(s); err != nil {
+			panic("newContractRBACHandler: RegisterRoutes: " + err.Error())
+		}
+	})
 	return mux
 }
 

--- a/cells/accesscore/slices/rbaccheck/handler.go
+++ b/cells/accesscore/slices/rbaccheck/handler.go
@@ -65,12 +65,12 @@ func NewHandler(svc *Service) *Handler {
 // so every request emits a contract-tagged span. Policy is declared at
 // registration time; handler bodies contain only business logic.
 func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specRoleList,
 		Handler:  http.HandlerFunc(h.handleListRoles),
 		Policy:   auth.SelfOr("userID", "admin"),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specRoleCheck,
 		Handler:  http.HandlerFunc(h.handleHasRole),
 		Policy:   auth.SelfOr("userID", "admin"),

--- a/cells/accesscore/slices/rbaccheck/handler.go
+++ b/cells/accesscore/slices/rbaccheck/handler.go
@@ -64,17 +64,22 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers rbac-check routes on the given mux via auth.Mount
 // so every request emits a contract-tagged span. Policy is declared at
 // registration time; handler bodies contain only business logic.
-func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specRoleList,
 		Handler:  http.HandlerFunc(h.handleListRoles),
 		Policy:   auth.SelfOr("userID", "admin"),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specRoleCheck,
 		Handler:  http.HandlerFunc(h.handleHasRole),
 		Policy:   auth.SelfOr("userID", "admin"),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {

--- a/cells/accesscore/slices/rbaccheck/handler_test.go
+++ b/cells/accesscore/slices/rbaccheck/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -78,7 +79,10 @@ func setup(t *testing.T, runMode query.RunMode) http.Handler {
 		panic(err)
 	}
 	mux := celltest.NewTestMux()
-	mux.Route("/api/v1/access/roles", NewHandler(svc).RegisterRoutes)
+	h := NewHandler(svc)
+	mux.Route("/api/v1/access/roles", func(s cell.RouteMux) {
+		require.NoError(t, h.RegisterRoutes(s))
+	})
 	return mux
 }
 

--- a/cells/accesscore/slices/sessionlogin/handler.go
+++ b/cells/accesscore/slices/sessionlogin/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 // RegisterRoutes registers the session-login route on mux. Login is a public
 // endpoint (no JWT required): callers identify themselves via username+password.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specLogin,
 		Handler:  http.HandlerFunc(h.HandleLogin),
 		Public:   true,

--- a/cells/accesscore/slices/sessionlogin/handler.go
+++ b/cells/accesscore/slices/sessionlogin/handler.go
@@ -51,10 +51,13 @@ func (h *Handler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 // RegisterRoutes registers the session-login route on mux. Login is a public
 // endpoint (no JWT required): callers identify themselves via username+password.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specLogin,
 		Handler:  http.HandlerFunc(h.HandleLogin),
 		Public:   true,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cells/accesscore/slices/sessionlogout/handler.go
+++ b/cells/accesscore/slices/sessionlogout/handler.go
@@ -37,7 +37,7 @@ func NewHandler(svc *Service) *Handler {
 // route reachable while the caller still owes a password reset (standard
 // user-self-recovery flow).
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract:            specSessionDelete,
 		Handler:             http.HandlerFunc(h.HandleLogout),
 		PasswordResetExempt: true,

--- a/cells/accesscore/slices/sessionlogout/handler.go
+++ b/cells/accesscore/slices/sessionlogout/handler.go
@@ -36,12 +36,15 @@ func NewHandler(svc *Service) *Handler {
 // AuthMiddleware still requires a valid JWT; PasswordResetExempt keeps the
 // route reachable while the caller still owes a password reset (standard
 // user-self-recovery flow).
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract:            specSessionDelete,
 		Handler:             http.HandlerFunc(h.HandleLogout),
 		PasswordResetExempt: true,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleLogout handles DELETE /api/v1/access/sessions/{id}.

--- a/cells/accesscore/slices/sessionrefresh/handler.go
+++ b/cells/accesscore/slices/sessionrefresh/handler.go
@@ -32,7 +32,7 @@ func NewHandler(svc *Service) *Handler {
 // Refresh is a public endpoint: callers supply a refresh token in the request
 // body; no JWT is required.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specRefresh,
 		Handler:  http.HandlerFunc(h.HandleRefresh),
 		Public:   true,

--- a/cells/accesscore/slices/sessionrefresh/handler.go
+++ b/cells/accesscore/slices/sessionrefresh/handler.go
@@ -31,12 +31,15 @@ func NewHandler(svc *Service) *Handler {
 // CH-04/CH-05 governance can correlate this contract to HandleRefresh.
 // Refresh is a public endpoint: callers supply a refresh token in the request
 // body; no JWT is required.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specRefresh,
 		Handler:  http.HandlerFunc(h.HandleRefresh),
 		Public:   true,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleRefresh handles POST /api/v1/access/sessions/refresh.

--- a/cells/accesscore/slices/setup/handler.go
+++ b/cells/accesscore/slices/setup/handler.go
@@ -43,12 +43,12 @@ func NewHandler(svc *Service) *Handler {
 // /acl/bootstrap convention rather than Vault's top-level /sys/init) so the
 // path matches Cell ownership.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specSetupStatus,
 		Handler:  http.HandlerFunc(h.HandleStatus),
 		Public:   true,
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specSetupAdmin,
 		Handler:  http.HandlerFunc(h.HandleCreateAdmin),
 		Public:   true,

--- a/cells/accesscore/slices/setup/handler.go
+++ b/cells/accesscore/slices/setup/handler.go
@@ -42,17 +42,22 @@ func NewHandler(svc *Service) *Handler {
 // The /setup tree is mounted under the cell's /access prefix (Consul
 // /acl/bootstrap convention rather than Vault's top-level /sys/init) so the
 // path matches Cell ownership.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specSetupStatus,
 		Handler:  http.HandlerFunc(h.HandleStatus),
 		Public:   true,
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specSetupAdmin,
 		Handler:  http.HandlerFunc(h.HandleCreateAdmin),
 		Public:   true,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleStatus handles GET /api/v1/access/setup/status.

--- a/cells/accesscore/slices/setup/service.go
+++ b/cells/accesscore/slices/setup/service.go
@@ -285,7 +285,7 @@ func (s *Service) publishUserCreated(ctx context.Context, user *domain.User) err
 		return fmt.Errorf("setup: marshal user.created payload: %w", err)
 	}
 	entry := outbox.Entry{
-		ID:        outbox.NewEntryID(),
+		ID:        outbox.MustNewEntryID(),
 		EventType: dto.TopicUserCreated,
 		Payload:   payload,
 	}

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -369,8 +369,9 @@ func (c *AuditCore) RouteGroups() []cell.RouteGroup {
 		{
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1/audit",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				c.queryHandler.RegisterRoutes(mux)
+				return nil
 			},
 		},
 	}

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -370,8 +370,7 @@ func (c *AuditCore) RouteGroups() []cell.RouteGroup {
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1/audit",
 			Register: func(mux cell.RouteMux) error {
-				c.queryHandler.RegisterRoutes(mux)
-				return nil
+				return c.queryHandler.RegisterRoutes(mux)
 			},
 		},
 	}

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -388,7 +388,9 @@ func (c *AuditCore) RegisterSubscriptions(r cell.EventRouter) error {
 			return fmt.Errorf("auditcore: missing ContractSpec for topic %q — "+
 				"auditAppendSpecs and auditappend.Topics must stay in sync", topic)
 		}
-		r.AddContractHandler(spec, handler, "auditcore")
+		if err := r.AddContractHandler(spec, handler, "auditcore"); err != nil {
+			return fmt.Errorf("auditcore: subscribe %s: %w", topic, err)
+		}
 	}
 	return nil
 }

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -77,12 +77,15 @@ func auditQueryPolicy(r *http.Request) error {
 
 // RegisterRoutes registers auditquery routes with the audit-query policy
 // via auth.Mount so every request emits a contract-tagged span.
-func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specAuditList,
 		Handler:  http.HandlerFunc(h.HandleQuery),
 		Policy:   auditQueryPolicy,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleQuery handles GET /api/v1/audit/entries.

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -78,7 +78,7 @@ func auditQueryPolicy(r *http.Request) error {
 // RegisterRoutes registers auditquery routes with the audit-query policy
 // via auth.Mount so every request emits a contract-tagged span.
 func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specAuditList,
 		Handler:  http.HandlerFunc(h.HandleQuery),
 		Policy:   auditQueryPolicy,

--- a/cells/configcore/cell_routes.go
+++ b/cells/configcore/cell_routes.go
@@ -41,31 +41,45 @@ func (c *ConfigCore) RouteGroups() []cell.RouteGroup {
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1",
 			Register: func(mux cell.RouteMux) error {
+				// mux.Route's callback signature is func(RouteMux) (no error
+				// return), so slice RegisterRoutes errors are captured via
+				// outer-variable closure and surfaced through this Register's
+				// error return — bootstrap phase5 wraps with cell+listener+prefix
+				// context.
+				var firstErr error
+				captureErr := func(err error) {
+					if err != nil && firstErr == nil {
+						firstErr = err
+					}
+				}
 				mux.Route("/config", func(cfg cell.RouteMux) {
-					c.readHandler.RegisterRoutes(cfg)
-					c.writeHandler.RegisterRoutes(cfg)
-					c.publishHandler.RegisterRoutes(cfg)
+					captureErr(c.readHandler.RegisterRoutes(cfg))
+					captureErr(c.writeHandler.RegisterRoutes(cfg))
+					captureErr(c.publishHandler.RegisterRoutes(cfg))
 				})
 				mux.Route("/flags", func(f cell.RouteMux) {
-					c.flagHandler.RegisterRoutes(f)
-					c.flagWriteHandler.RegisterRoutes(f)
+					captureErr(c.flagHandler.RegisterRoutes(f))
+					captureErr(c.flagWriteHandler.RegisterRoutes(f))
 				})
-				return nil
+				return firstErr
 			},
 		},
 		{
 			// InternalListener: service-token authentication is enforced by the
-			// listener chain (cell.NewAuthServiceToken). Per-route Policy further
+			// listener chain (cell.MustNewAuthServiceToken). Per-route Policy further
 			// requires the principal's RoleInternalAdmin (injected by
 			// ServiceTokenMiddleware). PR-CFG-G1: refetch endpoint lets accesscore
 			// fetch the current value after receiving an entry-upserted event.
 			Listener: cell.InternalListener,
 			Prefix:   "/internal/v1",
 			Register: func(mux cell.RouteMux) error {
+				var firstErr error
 				mux.Route("/config", func(cfg cell.RouteMux) {
-					c.readHandler.RegisterInternalRoutes(cfg)
+					if err := c.readHandler.RegisterInternalRoutes(cfg); err != nil {
+						firstErr = err
+					}
 				})
-				return nil
+				return firstErr
 			},
 		},
 	}

--- a/cells/configcore/cell_routes.go
+++ b/cells/configcore/cell_routes.go
@@ -40,7 +40,7 @@ func (c *ConfigCore) RouteGroups() []cell.RouteGroup {
 		{
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				mux.Route("/config", func(cfg cell.RouteMux) {
 					c.readHandler.RegisterRoutes(cfg)
 					c.writeHandler.RegisterRoutes(cfg)
@@ -50,6 +50,7 @@ func (c *ConfigCore) RouteGroups() []cell.RouteGroup {
 					c.flagHandler.RegisterRoutes(f)
 					c.flagWriteHandler.RegisterRoutes(f)
 				})
+				return nil
 			},
 		},
 		{
@@ -60,10 +61,11 @@ func (c *ConfigCore) RouteGroups() []cell.RouteGroup {
 			// fetch the current value after receiving an entry-upserted event.
 			Listener: cell.InternalListener,
 			Prefix:   "/internal/v1",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				mux.Route("/config", func(cfg cell.RouteMux) {
 					c.readHandler.RegisterInternalRoutes(cfg)
 				})
+				return nil
 			},
 		},
 	}

--- a/cells/configcore/cell_routes.go
+++ b/cells/configcore/cell_routes.go
@@ -4,6 +4,8 @@
 package configcore
 
 import (
+	"fmt"
+
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/wrapper"
@@ -71,9 +73,13 @@ func (c *ConfigCore) RouteGroups() []cell.RouteGroup {
 // The Router manages goroutine lifecycle and setup-error detection.
 func (c *ConfigCore) RegisterSubscriptions(r cell.EventRouter) error {
 	upsertedHandler := outbox.WrapLegacyHandler(c.subscribeSvc.HandleEntryUpserted)
-	r.AddContractHandler(specEventConfigEntryUpserted, upsertedHandler, "configcore")
+	if err := r.AddContractHandler(specEventConfigEntryUpserted, upsertedHandler, "configcore"); err != nil {
+		return fmt.Errorf("configcore: subscribe %s: %w", specEventConfigEntryUpserted.Topic, err)
+	}
 
 	deletedHandler := outbox.WrapLegacyHandler(c.subscribeSvc.HandleEntryDeleted)
-	r.AddContractHandler(specEventConfigEntryDeleted, deletedHandler, "configcore")
+	if err := r.AddContractHandler(specEventConfigEntryDeleted, deletedHandler, "configcore"); err != nil {
+		return fmt.Errorf("configcore: subscribe %s: %w", specEventConfigEntryDeleted.Topic, err)
+	}
 	return nil
 }

--- a/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
@@ -235,7 +235,7 @@ func TestConfigRepo_Integration_AtomicTx(t *testing.T) {
 			Version: 1,
 		}
 		outboxEntry := outbox.Entry{
-			ID:            outbox.NewEntryID(),
+			ID:            outbox.MustNewEntryID(),
 			AggregateID:   entry.ID,
 			AggregateType: "config_entry",
 			EventType:     domain.TopicConfigEntryUpserted,

--- a/cells/configcore/slices/configpublish/handler.go
+++ b/cells/configcore/slices/configpublish/handler.go
@@ -65,12 +65,12 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers configpublish routes with admin-only policies
 // via auth.Mount so every request emits a contract-tagged span.
 func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigPublish,
 		Handler:  http.HandlerFunc(h.HandlePublish),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigRollback,
 		Handler:  http.HandlerFunc(h.HandleRollback),
 		Policy:   auth.AnyRole(dto.RoleAdmin),

--- a/cells/configcore/slices/configpublish/handler.go
+++ b/cells/configcore/slices/configpublish/handler.go
@@ -64,17 +64,22 @@ func NewHandler(svc *Service) *Handler {
 
 // RegisterRoutes registers configpublish routes with admin-only policies
 // via auth.Mount so every request emits a contract-tagged span.
-func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigPublish,
 		Handler:  http.HandlerFunc(h.HandlePublish),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigRollback,
 		Handler:  http.HandlerFunc(h.HandleRollback),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandlePublish handles POST /{key}/publish — publishes a config entry.

--- a/cells/configcore/slices/configread/handler.go
+++ b/cells/configcore/slices/configread/handler.go
@@ -47,12 +47,12 @@ func NewHandler(svc *Service) *Handler {
 // Both routes are admin-gated (auth.AnyRole(RoleAdmin)). Mounted on
 // PrimaryListener for /api/v1/config/* by ConfigCore.RouteGroups.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigList,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
@@ -68,7 +68,7 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
 // redacted "******" placeholder) applies on both listeners; consumers must
 // not log Value for sensitive entries (see configport.go ConfigEntry doc).
 func (h *Handler) RegisterInternalRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigInternalGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(auth.RoleInternalAdmin),

--- a/cells/configcore/slices/configread/handler.go
+++ b/cells/configcore/slices/configread/handler.go
@@ -46,17 +46,22 @@ func NewHandler(svc *Service) *Handler {
 // CH-04/CH-05 governance can correlate contracts to handler functions.
 // Both routes are admin-gated (auth.AnyRole(RoleAdmin)). Mounted on
 // PrimaryListener for /api/v1/config/* by ConfigCore.RouteGroups.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigList,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // RegisterInternalRoutes registers the internal control-plane GET that
@@ -67,12 +72,15 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
 // Reuses HandleGet — the same response shape (sensitive=true returns the
 // redacted "******" placeholder) applies on both listeners; consumers must
 // not log Value for sensitive entries (see configport.go ConfigEntry doc).
-func (h *Handler) RegisterInternalRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterInternalRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigInternalGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(auth.RoleInternalAdmin),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleGet handles GET /{key} — returns a single config entry.

--- a/cells/configcore/slices/configwrite/handler.go
+++ b/cells/configcore/slices/configwrite/handler.go
@@ -96,17 +96,17 @@ func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 // sub-router adapter) so production wiring, contract tests, and cell-level
 // integration tests share the same auth.Mount declarations.
 func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigWrite,
 		Handler:  http.HandlerFunc(h.HandleCreate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigUpdate,
 		Handler:  http.HandlerFunc(h.HandleUpdate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specConfigDelete,
 		Handler:  http.HandlerFunc(h.HandleDelete),
 		Policy:   auth.AnyRole(dto.RoleAdmin),

--- a/cells/configcore/slices/configwrite/handler.go
+++ b/cells/configcore/slices/configwrite/handler.go
@@ -95,20 +95,27 @@ func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 // cell.RouteHandler (satisfied by *http.ServeMux, cell.RouteMux, and the chi
 // sub-router adapter) so production wiring, contract tests, and cell-level
 // integration tests share the same auth.Mount declarations.
-func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigWrite,
 		Handler:  http.HandlerFunc(h.HandleCreate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigUpdate,
 		Handler:  http.HandlerFunc(h.HandleUpdate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specConfigDelete,
 		Handler:  http.HandlerFunc(h.HandleDelete),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cells/configcore/slices/featureflag/handler.go
+++ b/cells/configcore/slices/featureflag/handler.go
@@ -83,22 +83,29 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers feature-flag read routes on mux via auth.Mount so
 // CH-04/CH-05 governance can correlate contracts to handler functions.
 // All routes are admin-gated (auth.AnyRole(RoleAdmin)).
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specFlagsList,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specFlagsGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specFlagsEvaluate,
 		Handler:  http.HandlerFunc(h.HandleEvaluate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleList handles GET / — returns paginated feature flags.

--- a/cells/configcore/slices/featureflag/handler.go
+++ b/cells/configcore/slices/featureflag/handler.go
@@ -84,17 +84,17 @@ func NewHandler(svc *Service) *Handler {
 // CH-04/CH-05 governance can correlate contracts to handler functions.
 // All routes are admin-gated (auth.AnyRole(RoleAdmin)).
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specFlagsList,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specFlagsGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specFlagsEvaluate,
 		Handler:  http.HandlerFunc(h.HandleEvaluate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),

--- a/cells/configcore/slices/flagwrite/handler.go
+++ b/cells/configcore/slices/flagwrite/handler.go
@@ -221,25 +221,34 @@ func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 // auth.Mount so every request emits a contract-tagged span. The mux
 // argument is cell.RouteHandler so production wiring (cell.RouteMux) and
 // contract tests (*http.ServeMux) share the same declarations.
-func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specFlagsCreate,
 		Handler:  http.HandlerFunc(h.HandleCreate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specFlagsUpdate,
 		Handler:  http.HandlerFunc(h.HandleUpdate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specFlagsToggle,
 		Handler:  http.HandlerFunc(h.HandleToggle),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specFlagsDelete,
 		Handler:  http.HandlerFunc(h.HandleDelete),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cells/configcore/slices/flagwrite/handler.go
+++ b/cells/configcore/slices/flagwrite/handler.go
@@ -222,22 +222,22 @@ func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 // argument is cell.RouteHandler so production wiring (cell.RouteMux) and
 // contract tests (*http.ServeMux) share the same declarations.
 func (h *Handler) RegisterRoutes(mux cell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specFlagsCreate,
 		Handler:  http.HandlerFunc(h.HandleCreate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specFlagsUpdate,
 		Handler:  http.HandlerFunc(h.HandleUpdate),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specFlagsToggle,
 		Handler:  http.HandlerFunc(h.HandleToggle),
 		Policy:   auth.AnyRole(dto.RoleAdmin),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specFlagsDelete,
 		Handler:  http.HandlerFunc(h.HandleDelete),
 		Policy:   auth.AnyRole(dto.RoleAdmin),

--- a/cmd/corebundle/auth_integration_test.go
+++ b/cmd/corebundle/auth_integration_test.go
@@ -99,7 +99,7 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 	require.NoError(t, asm.Register(cc))
 	require.NoError(t, asm.Register(auc))
 
-	// F3: public routes (login, refresh) are declared via auth.Mount(Public:true)
+	// F3: public routes (login, refresh) are declared via auth.MustMount(Public:true)
 	// inside accesscore's RegisterRoutes. PolicyJWTFromAssembly is now a
 	// cell.Policy (round-3 collapse): its Validate hook resolves the verifier
 	// from accesscore's authProvider during phase4.
@@ -313,7 +313,7 @@ func TestAuthWiring_InternalGuard_RequiresServiceToken(t *testing.T) {
 	// listener. JWT AuthMiddleware is never installed on the internal mux —
 	// PolicyServiceToken is the sole authentication layer for the control plane.
 	// F3: public routes (login, refresh) are declared by accesscore via
-	// auth.Mount(Public:true); PolicyJWTFromAssembly is the PrimaryListener's
+	// auth.MustMount(Public:true); PolicyJWTFromAssembly is the PrimaryListener's
 	// cell.Policy (round-3 collapse) and resolves the verifier lazily at phase4.
 	_ = guard // guard is superseded by PolicyServiceToken below
 	internalLn := newCorebundleLocalListener(t)

--- a/cmd/corebundle/auth_integration_test.go
+++ b/cmd/corebundle/auth_integration_test.go
@@ -105,7 +105,7 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 	// from accesscore's authProvider during phase4.
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
-		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
+		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
 		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", nil, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(2*time.Second),
@@ -317,10 +317,10 @@ func TestAuthWiring_InternalGuard_RequiresServiceToken(t *testing.T) {
 	// cell.Policy (round-3 collapse) and resolves the verifier lazily at phase4.
 	_ = guard // guard is superseded by PolicyServiceToken below
 	internalLn := newCorebundleLocalListener(t)
-	internalAuthChain := []cell.ListenerAuth{cell.NewAuthServiceToken(nonceStore, ring)}
+	internalAuthChain := []cell.ListenerAuth{cell.MustNewAuthServiceToken(nonceStore, ring)}
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
-		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
+		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
 		bootstrap.WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain,
 			bootstrap.WithListenerNet(internalLn)),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
@@ -529,7 +529,7 @@ func TestAuthWiring_HealthListener_PrimaryDoesNotServeHealthz(t *testing.T) {
 
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
-		bootstrap.WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)},
+		bootstrap.WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 			bootstrap.WithListenerNet(primaryLn)),
 		bootstrap.WithListener(cell.InternalListener, internalLn.Addr().String(), nil,
 			bootstrap.WithListenerNet(internalLn)),

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -110,7 +110,7 @@ func defaultRuntimeOptions(
 	if shared.PrimaryHTTPAddr != "" {
 		opts = append(opts, bootstrap.WithListener(
 			cell.PrimaryListener, shared.PrimaryHTTPAddr,
-			[]cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)},
+			[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 		))
 	}
 	if shared.InternalHTTPAddr != "" {
@@ -138,7 +138,7 @@ func buildInternalAuthChain(guard *internalGuard) []cell.ListenerAuth {
 	if guard == nil {
 		return nil
 	}
-	return []cell.ListenerAuth{cell.NewAuthServiceToken(guard.NonceStore(), guard.ring)}
+	return []cell.ListenerAuth{cell.MustNewAuthServiceToken(guard.NonceStore(), guard.ring)}
 }
 
 // buildKeyProvider constructs the KeyProvider from the supplied providerName,

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -372,7 +372,7 @@ func buildBootstrapFromShared(t *testing.T, shared *SharedDeps, primaryLn net.Li
 	opts = append(opts, bootstrap.WithListener(
 		cell.PrimaryListener,
 		primaryLn.Addr().String(),
-		[]cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)},
+		[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 		bootstrap.WithListenerNet(primaryLn),
 	))
 	opts = append(opts, extra...)

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -224,7 +224,7 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 
 	baseOpts := []bootstrap.Option{
 		bootstrap.WithAssembly(asm),
-		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
+		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
 		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", nil, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(3 * time.Second),
@@ -583,7 +583,7 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 
 	baseOpts := []bootstrap.Option{
 		bootstrap.WithAssembly(asm),
-		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
+		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
 		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", nil, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(3 * time.Second),

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -98,7 +98,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
-		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
+		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
 		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", nil, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(2*time.Second),

--- a/cmd/corebundle/vault_readiness_wiring_test.go
+++ b/cmd/corebundle/vault_readiness_wiring_test.go
@@ -111,7 +111,7 @@ func buildBootstrapWithFakeKeyProvider(t *testing.T, shared *SharedDeps, kp kcry
 	opts = append(opts, bootstrap.WithListener(
 		cell.PrimaryListener,
 		primaryLn.Addr().String(),
-		[]cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)},
+		[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 		bootstrap.WithListenerNet(primaryLn),
 	))
 	opts = append(opts, extra...)

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -1,0 +1,204 @@
+# ADR: Architectural Panic Whitelist (ERROR-FIRST-API-01)
+
+> Date: 2026-04-27
+> Status: Accepted
+> Context PR: PR-MODE-6 ERROR-FIRST-API (refactor/555-pr-mode-6-error-first-api)
+> Tag: ERROR-FIRST-API-01
+
+## Context
+
+GoCell's six-role retrospective (`bak/20260426-layered-six-role-review/`)
+identified **panic on misuse** as one of eight recurring patterns: 28+
+constructor- and registration-time panics scattered across `kernel/wrapper/`,
+`kernel/cell/auth_plan.go`, `kernel/outbox/`, `kernel/idempotency/`,
+`runtime/auth/route.go`, `runtime/eventrouter/`, and `adapters/postgres/`.
+Cells that consult runtime configuration (planned future state) cannot
+recover from misconfiguration if construction panics; tests cannot exercise
+the validation surface without `recover()`-based scaffolding; operators see
+crash dumps for what should be structured 4xx/5xx responses.
+
+PR-MODE-6 introduces the `tools/archtest/error_first_test.go::TestErrorFirstAPI01`
+rule: **error-less function declarations in the enrolled file scope MUST NOT
+contain `panic(...)` calls**. Auto-exemptions: `Must*`-prefixed names and
+`func init()`. The rule scans 13 enrolled files (the parent plan's PR-MODE-6
+scope). Future PRs may extend the scope; the path forward is in §Roadmap.
+
+## Decision
+
+### 1. Convert all 28+ panics in scope to error-first APIs
+
+The bulk of the work refactors registration/construction sites to return
+error and provides `Must*` wrappers (composition-root convenience that
+panic on error):
+
+- `kernel/cell/auth_plan.go::NewAuthJWT` / `NewAuthJWTFromAssembly` /
+  `NewAuthServiceToken` → `(plan, error)` + `MustNewAuth*` wrappers
+- `kernel/wrapper/handler.go::HTTPHandler` → `(handler, error)` + `MustHTTPHandler`
+- `kernel/wrapper/consumer.go::WrapConsumer` → `(consumer, error)` + `MustWrapConsumer`
+- `runtime/eventrouter/router.go::AddContractHandler` → `error`
+  (`kernel/cell.EventRouter` interface signature updated; cells'
+  `RegisterSubscriptions` propagate the error)
+- `runtime/auth/route.go::Mount` → `error` + `MustMount` wrapper
+  (`cell.RouteGroup.Register` signature changed to `func(RouteMux) error`;
+  bootstrap phase5 propagates)
+- `adapters/postgres/refresh_store.go::NewRefreshStore` → `(*PGRefreshStore, error)`
+  + `MustNewRefreshStore`
+- `kernel/outbox/entry_id.go::NewEntryID` → `(string, error)` + `MustNewEntryID`
+- `kernel/idempotency/inmem.go::newToken` → `(string, error)` (private;
+  propagated to `Claim` which already returns error)
+
+### 2. Rename `MarshalDirectEnvelope` → `MustMarshalDirectEnvelope`
+
+Internal envelope construction with caller-controlled invariants. Marshalling
+failure indicates a writer-side programmer error; the rename makes the
+panic semantics explicit (auto-exempted by the `Must*` rule).
+
+### 3. Map worker nil-exit to `ErrWorkerExitedEarly` sentinel
+
+`runtime/worker.WorkerGroup.Start` previously produced silent
+`firstErr=nil` when a member worker terminated early without context
+cancellation. Modelled as `kworker.ErrWorkerExitedEarly` so callers can
+`errors.Is`-detect the abnormal signal — not strictly part of the panic
+refactor, but bundled for the same "fail loudly, propagate errors" theme.
+
+### 4. Hardcoded ADR-pinned whitelist (1 file)
+
+The archtest holds **one** file-level whitelist entry. Every other panic
+in the scoped files is either refactored, renamed, or in an `init()`
+function (auto-exempt).
+
+| # | File | Justification |
+|---|---|---|
+| 1 | `kernel/wrapper/lifecycle.go` | `recoverAndFinishWithRedactor` is the middle of a `defer recover()` chain that re-panics so the outer `runtime/http/middleware.Recovery` middleware can record + serialize the panic. Refactoring it to return error would dismantle the entire recover propagation idiom and force every wrapped consumer to pre-route panics through a synthetic error path before Go's runtime gets the chance. |
+
+### 5. Auto-exempt categories
+
+- **`Must*` prefix**: Go community convention for the panic-on-misuse
+  twin of an error-returning constructor. Examples in this PR:
+  `MustNewAuthJWT`, `MustHTTPHandler`, `MustWrapConsumer`,
+  `MustMount`, `MustNewRefreshStore`, `MustNewEntryID`,
+  `MustMarshalDirectEnvelope` (renamed from non-Must form), plus
+  pre-existing `MustValidateLabels`, `MustRegister`, `MustNewTestKeyProvider`,
+  `MustCookieSession`, etc.
+- **`func init()`**: Init cannot return error; package-level invariant
+  violations are by definition fatal. Example: `adapters/postgres/embed.go`
+  embedded migrations subdir loading.
+
+## Rationale
+
+### Why error-first over Must-renaming for 28+ sites?
+
+For cell composition roots, fail-fast at startup IS the right
+semantic — cells statically declare their routes and auth plans, and a
+spec literal that fails validation is a build-time bug. So why introduce
+an error-returning surface at all?
+
+Three reasons:
+
+1. **Future runtime-config sites**: Cells that resolve their auth plan
+   or contract specs from runtime config (Vault secrets, dynamic feature
+   flags, multi-tenant route registries) need to refuse misconfiguration
+   gracefully — return 503 to a controlplane endpoint, surface to
+   `/readyz`, etc. Panic forces a process restart that operators cannot
+   intercept.
+
+2. **Test ergonomics**: Negative-path tests no longer need `recover()`
+   scaffolding. `assert.Error(t, err)` reads naturally and groups with
+   the rest of the test suite's error assertions.
+
+3. **Layered visibility**: bootstrap phase5 already returns error to
+   `Bootstrap.Run`; surfacing route registration / consumer subscription
+   failures through that channel keeps the operator's view of "what
+   went wrong at startup" coherent — log + structured error, not a
+   stack trace.
+
+The `Must*` wrappers preserve the static-composition ergonomics: cells
+that construct a single static `cell.NewAuthJWTFromAssembly(asm)` continue
+to write `cell.MustNewAuthJWTFromAssembly(asm)` with no error-handling
+boilerplate.
+
+### Why minimum (1) whitelist?
+
+Each whitelist entry is a future regression risk: a new contributor sees
+"there are some panics here, panicking must be OK" and adds another. The
+review loop catches new architectural panic claims via the ADR, not via
+the archtest list. By keeping the whitelist to **just** the
+defer-recover-re-panic case (which is structurally not refactorable), we
+maximize the "panic in error-less function = bug" signal.
+
+The previous design (5 entries) was rejected: outbox crypto/rand failures
+and envelope marshal invariants were absorbable as either error
+propagation (entry_id, idempotency) or `Must*` rename (envelope), so they
+moved out of the whitelist. The HTTP router state machine (`runtime/http/router/router.go`,
+5 panics across `FinalizeAuth`/`Mount`/state transitions) is **out of
+scope for the archtest**: that file is not in the enrolled list yet.
+PR-MODE-6.1 (scope expansion) may add it later, alongside a router refactor
+or its own whitelist entry.
+
+### Whitelist mechanics
+
+Hardcoded in `tools/archtest/error_first_test.go`:
+
+```go
+var errorFirstWhitelistedFiles = map[string]string{
+    "kernel/wrapper/lifecycle.go": "recoverAndFinishWithRedactor re-panics from defer recover",
+}
+```
+
+To add an entry: open a PR, update this ADR's §4 table with a new row,
+update the map. Reviewer must reject any whitelist addition that's
+absorbable as `Must*` rename or error propagation.
+
+### Trade-offs
+
+- **API surface growth**: ~12 new `Must*` wrappers added; doubled the
+  registration-API count. Mitigated by uniform naming convention and
+  one-line documentation referencing the canonical error-first variant.
+- **Caller refactor cost**: ~80 production + test call sites updated.
+  Bulk-handled via `perl -i -pe` substitution; reviewer should focus on
+  the few sites that needed manual closure rewrites
+  (`cell.RouteGroup.Register` signature change, `cells/{accesscore,auditcore,configcore}`
+  `RegisterSubscriptions` error propagation).
+- **Test split**: panic-asserting tests split into
+  `Test*_ReturnsError*` (on the canonical error path) and
+  `TestMust*_Panics*` (on the wrapper). Adds test count but improves
+  intent clarity.
+
+## Roadmap
+
+Future PR-MODE-6.1 candidates for archtest scope expansion (each costs
+its own refactor + propagation pass):
+
+- `kernel/persistence/tx.go::RunInTx` — single panic on nil fn, easy
+  refactor to error.
+- `kernel/observability/metrics/metrics.go` — already auto-exempt via
+  `MustRegister` prefix, but worth confirming the pattern holds when new
+  metrics are added.
+- `runtime/distlock/locker.go::New` — 5 config-validation panics; refactor
+  + propagation to `cmd/corebundle` distlock wiring.
+- `runtime/auth/refresh/memstore/store.go::New` — 3 config-validation
+  panics; analogue of `adapters/postgres/refresh_store.go`.
+- `runtime/http/middleware/circuit_breaker.go` — Allower nil check + re-panic.
+- `runtime/http/health/health.go::Register` — nil-checker / duplicate-name
+  panics.
+- `runtime/http/router/router.go` — state-machine post-conditions (5 sites);
+  largest scope; either whitelist-as-architectural or major refactor of
+  `FinalizeAuth`.
+- `cells/accesscore/slices/sessionlogin/service.go::NewService` — 7 nil-check
+  panics; the cells-layer first foothold for the rule.
+
+Order suggestion: each PR adds 1-3 files to `errorFirstEnforcedFiles`
+in the archtest, refactors the corresponding panics, and updates this
+ADR's §Roadmap to mark the file done.
+
+## References
+
+- Parent plan: `docs/plans/202604270020-1-2-ci-3-claude-ship-reactive-bachman.md`
+  §阶段 1 PR-MODE-6 ERROR-FIRST-API.
+- Sub-plan / commit log: `~/.claude/plans/docs-plans-202604270020-1-2-ci-3-claude-scalable-stroustrup.md`.
+- Six-role review report: `bak/20260426-layered-six-role-review/`.
+- Go std lib precedent: `crypto/uuid` panics on `crypto/rand.Read` failure
+  ([documented behaviour](https://pkg.go.dev/crypto/rand#Read)) — informs
+  the `MustNewEntryID` decision.
+- `Must*` convention: `regexp.MustCompile`, `template.Must`,
+  `kubernetes/client-go MustGetSelfLink`.

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -181,9 +181,15 @@ its own refactor + propagation pass):
 - `runtime/http/middleware/circuit_breaker.go` — Allower nil check + re-panic.
 - `runtime/http/health/health.go::Register` — nil-checker / duplicate-name
   panics.
-- `runtime/http/router/router.go` — state-machine post-conditions (5 sites);
-  largest scope; either whitelist-as-architectural or major refactor of
-  `FinalizeAuth`.
+- `runtime/http/router/router.go` — state-machine post-conditions (5 sites:
+  lines 128/345/415/581/593). **Decision pending PR-MODE-6.1**: the most
+  likely outcome is to whitelist as architectural (these are internal
+  invariants validated upstream by `auth.Mount`, not caller-facing
+  preconditions), bringing the whitelist count from 1 → 2. Alternative is
+  a `FinalizeAuth` API refactor that bubbles the invariant errors to
+  bootstrap; rejected for this PR because the panic semantics already
+  match `auth.Mount`'s contract (startup-fatal). Track via PR-MODE-6.1
+  scope expansion, not as ad-hoc backlog.
 - `cells/accesscore/slices/sessionlogin/service.go::NewService` — 7 nil-check
   panics; the cells-layer first foothold for the rule.
 

--- a/examples/iotdevice/auth.go
+++ b/examples/iotdevice/auth.go
@@ -52,5 +52,9 @@ func newInternalAuthChainFromEnv() ([]cell.ListenerAuth, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create internal listener nonce store: %w", err)
 	}
-	return []cell.ListenerAuth{cell.NewAuthServiceToken(store, ring)}, nil
+	plan, err := cell.NewAuthServiceToken(store, ring)
+	if err != nil {
+		return nil, fmt.Errorf("build internal auth chain: %w", err)
+	}
+	return []cell.ListenerAuth{plan}, nil
 }

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -287,23 +287,28 @@ func (c *DeviceCell) RouteGroups() []cell.RouteGroup {
 			// outer Route("/api/v1") wrapper that would double-prefix.
 			Prefix: "",
 			Register: func(mux cell.RouteMux) error {
+				var firstErr error
+				captureErr := func(err error) {
+					if err != nil && firstErr == nil {
+						firstErr = err
+					}
+				}
 				mux.Route("/api/v1/devices", func(devices cell.RouteMux) {
-					c.registerHandler.RegisterRoutes(devices)
-					c.listHandler.RegisterRoutes(devices)
-					c.statusHandler.RegisterRoutes(devices)
+					captureErr(c.registerHandler.RegisterRoutes(devices))
+					captureErr(c.listHandler.RegisterRoutes(devices))
+					captureErr(c.statusHandler.RegisterRoutes(devices))
 					// device-command public routes (enqueue, dequeue, report, ack,
 					// extend-lease) live under /api/v1/devices/{id}/commands.
-					c.commandHandler.RegisterRoutes(devices)
+					captureErr(c.commandHandler.RegisterRoutes(devices))
 				})
-				return nil
+				return firstErr
 			},
 		},
 		{
 			Listener: cell.InternalListener,
 			Prefix:   "",
 			Register: func(mux cell.RouteMux) error {
-				c.commandHandler.RegisterInternalRoutes(mux)
-				return nil
+				return c.commandHandler.RegisterInternalRoutes(mux)
 			},
 		},
 	}

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -286,7 +286,7 @@ func (c *DeviceCell) RouteGroups() []cell.RouteGroup {
 			// paths, so we mount routes directly on the root mux without an
 			// outer Route("/api/v1") wrapper that would double-prefix.
 			Prefix: "",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				mux.Route("/api/v1/devices", func(devices cell.RouteMux) {
 					c.registerHandler.RegisterRoutes(devices)
 					c.listHandler.RegisterRoutes(devices)
@@ -295,13 +295,15 @@ func (c *DeviceCell) RouteGroups() []cell.RouteGroup {
 					// extend-lease) live under /api/v1/devices/{id}/commands.
 					c.commandHandler.RegisterRoutes(devices)
 				})
+				return nil
 			},
 		},
 		{
 			Listener: cell.InternalListener,
 			Prefix:   "",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				c.commandHandler.RegisterInternalRoutes(mux)
+				return nil
 			},
 		},
 	}

--- a/examples/iotdevice/cells/devicecell/slices/devicecommand/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommand/handler.go
@@ -86,27 +86,27 @@ func NewHandler(svc *Service) *Handler {
 
 // RegisterRoutes registers device-command routes on the given mux.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specCommandEnqueue,
 		Handler:  http.HandlerFunc(h.HandleEnqueue),
 		Policy:   auth.AnyRole(dto.RoleAdmin, dto.RoleOperator),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specCommandDequeue,
 		Handler:  http.HandlerFunc(h.HandleDequeue),
 		Policy:   auth.SelfOr("id", "admin"),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specCommandReport,
 		Handler:  http.HandlerFunc(h.HandleReport),
 		Policy:   auth.SelfOr("id", "admin"),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specCommandAck,
 		Handler:  http.HandlerFunc(h.HandleAck),
 		Policy:   auth.SelfOr("id", "admin"),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specCommandExtendLease,
 		Handler:  http.HandlerFunc(h.HandleExtendLease),
 		Policy:   auth.SelfOr("id", "admin"),
@@ -117,7 +117,7 @@ func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
 // listener. The bootstrap internal middleware authenticates service tokens;
 // the route policy then requires the built-in internal admin role.
 func (h *Handler) RegisterInternalRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specInternalCommandScanActive,
 		Handler:  http.HandlerFunc(h.HandleScanActive),
 		Policy:   auth.AnyRole(auth.RoleInternalAdmin),

--- a/examples/iotdevice/cells/devicecell/slices/devicecommand/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommand/handler.go
@@ -85,45 +85,59 @@ func NewHandler(svc *Service) *Handler {
 }
 
 // RegisterRoutes registers device-command routes on the given mux.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specCommandEnqueue,
 		Handler:  http.HandlerFunc(h.HandleEnqueue),
 		Policy:   auth.AnyRole(dto.RoleAdmin, dto.RoleOperator),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specCommandDequeue,
 		Handler:  http.HandlerFunc(h.HandleDequeue),
 		Policy:   auth.SelfOr("id", "admin"),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specCommandReport,
 		Handler:  http.HandlerFunc(h.HandleReport),
 		Policy:   auth.SelfOr("id", "admin"),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specCommandAck,
 		Handler:  http.HandlerFunc(h.HandleAck),
 		Policy:   auth.SelfOr("id", "admin"),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specCommandExtendLease,
 		Handler:  http.HandlerFunc(h.HandleExtendLease),
 		Policy:   auth.SelfOr("id", "admin"),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // RegisterInternalRoutes registers device-command ops routes on the internal
 // listener. The bootstrap internal middleware authenticates service tokens;
 // the route policy then requires the built-in internal admin role.
-func (h *Handler) RegisterInternalRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterInternalRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specInternalCommandScanActive,
 		Handler:  http.HandlerFunc(h.HandleScanActive),
 		Policy:   auth.AnyRole(auth.RoleInternalAdmin),
 		// Route lives on InternalListener (/internal/v1/*); internal affinity
 		// is derived from the path prefix via AuthRouteMeta.IsInternal().
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // enqueueRequest is the JSON body for POST /api/v1/devices/{id}/commands.

--- a/examples/iotdevice/cells/devicecell/slices/devicelist/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicelist/handler.go
@@ -45,12 +45,15 @@ func NewHandler(svc *Service) *Handler {
 }
 
 // RegisterRoutes registers device-list routes.
-func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteMux) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specDeviceListSlice,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole("admin"),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleList handles GET /api/v1/devices/.

--- a/examples/iotdevice/cells/devicecell/slices/devicelist/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicelist/handler.go
@@ -46,7 +46,7 @@ func NewHandler(svc *Service) *Handler {
 
 // RegisterRoutes registers device-list routes.
 func (h *Handler) RegisterRoutes(mux kcell.RouteMux) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specDeviceListSlice,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole("admin"),

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/handler.go
@@ -50,7 +50,7 @@ func NewHandler(svc *Service) *Handler {
 // CH-04/CH-05 governance can correlate this contract to HandleRegister.
 // Device registration is a public endpoint: devices bootstrap without a user JWT.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specDeviceRegister,
 		Handler:  http.HandlerFunc(h.HandleRegister),
 		Public:   true,

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/handler.go
@@ -49,12 +49,15 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers the device-register route on mux via auth.Mount so
 // CH-04/CH-05 governance can correlate this contract to HandleRegister.
 // Device registration is a public endpoint: devices bootstrap without a user JWT.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specDeviceRegister,
 		Handler:  http.HandlerFunc(h.HandleRegister),
 		Public:   true,
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // registerRequest is the JSON body for POST /api/v1/devices.

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
@@ -88,7 +88,7 @@ func (s *Service) Register(ctx context.Context, name string) (*domain.Device, er
 		return device, nil
 	}
 	entry := outbox.Entry{
-		ID:        outbox.NewEntryID(),
+		ID:        outbox.MustNewEntryID(),
 		EventType: TopicDeviceRegistered,
 		Payload:   payload,
 	}

--- a/examples/iotdevice/cells/devicecell/slices/devicestatus/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicestatus/handler.go
@@ -54,7 +54,7 @@ func NewHandler(svc *Service) *Handler {
 // CH-04/CH-05 governance can correlate this contract to HandleGetStatus.
 // Device status is queried by operators or by the device itself.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specDeviceStatus,
 		Handler:  http.HandlerFunc(h.HandleGetStatus),
 		Policy:   auth.AnyRole(dto.RoleOperator, dto.RoleDevice),

--- a/examples/iotdevice/cells/devicecell/slices/devicestatus/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicestatus/handler.go
@@ -53,12 +53,15 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers the device-status route on mux via auth.Mount so
 // CH-04/CH-05 governance can correlate this contract to HandleGetStatus.
 // Device status is queried by operators or by the device itself.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specDeviceStatus,
 		Handler:  http.HandlerFunc(h.HandleGetStatus),
 		Policy:   auth.AnyRole(dto.RoleOperator, dto.RoleDevice),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleGetStatus handles GET /api/v1/devices/{id}/status.

--- a/examples/iotdevice/main.go
+++ b/examples/iotdevice/main.go
@@ -82,7 +82,7 @@ func main() {
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
-		bootstrap.WithListener(cell.PrimaryListener, ":8083", []cell.ListenerAuth{cell.NewAuthJWT(jwtVerifier)}),
+		bootstrap.WithListener(cell.PrimaryListener, ":8083", []cell.ListenerAuth{cell.MustNewAuthJWT(jwtVerifier)}),
 		bootstrap.WithListener(cell.InternalListener, ":9083", internalAuthChain),
 		bootstrap.WithHealthRoutes(healthOpts...),
 	)

--- a/examples/ssobff/internal_auth.go
+++ b/examples/ssobff/internal_auth.go
@@ -24,5 +24,9 @@ func newInternalAuthChainFromEnv() ([]cell.ListenerAuth, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create internal listener nonce store: %w", err)
 	}
-	return []cell.ListenerAuth{cell.NewAuthServiceToken(store, ring)}, nil
+	plan, err := cell.NewAuthServiceToken(store, ring)
+	if err != nil {
+		return nil, fmt.Errorf("build internal auth chain: %w", err)
+	}
+	return []cell.ListenerAuth{plan}, nil
 }

--- a/examples/ssobff/main.go
+++ b/examples/ssobff/main.go
@@ -186,7 +186,7 @@ func main() {
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
-		bootstrap.WithListener(cell.PrimaryListener, primaryAddr, []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}),
+		bootstrap.WithListener(cell.PrimaryListener, primaryAddr, []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}),
 		bootstrap.WithListener(cell.InternalListener, internalAddr, internalAuthChain),
 		// Dedicated health listener on a loopback port — keeps /healthz, /readyz,
 		// /metrics off the public port (8081) so probes and metric scrapers do

--- a/examples/ssobff/walkthrough_test.go
+++ b/examples/ssobff/walkthrough_test.go
@@ -257,7 +257,7 @@ func buildWalkthroughServer(t *testing.T, stateDir string, capHandler *capturing
 	// RouteGroups callback. FinalizeAuth compiles them into the router's auth
 	// predicates. The walkthrough uses a single test router (httptest.NewServer
 	// is one process), so RouteGroups intended for InternalListener are mounted
-	// here too — auth.Mount(Public:true) on /internal paths still works because
+	// here too — auth.MustMount(Public:true) on /internal paths still works because
 	// the matcher fires before AuthMiddleware and the test never exercises a
 	// JWT-only internal route.
 	r := router.New(

--- a/examples/todoorder/auth.go
+++ b/examples/todoorder/auth.go
@@ -52,5 +52,9 @@ func newInternalAuthChainFromEnv() ([]cell.ListenerAuth, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create internal listener nonce store: %w", err)
 	}
-	return []cell.ListenerAuth{cell.NewAuthServiceToken(store, ring)}, nil
+	plan, err := cell.NewAuthServiceToken(store, ring)
+	if err != nil {
+		return nil, fmt.Errorf("build internal auth chain: %w", err)
+	}
+	return []cell.ListenerAuth{plan}, nil
 }

--- a/examples/todoorder/cells/ordercell/cell.go
+++ b/examples/todoorder/cells/ordercell/cell.go
@@ -191,11 +191,12 @@ func (c *OrderCell) RouteGroups() []cell.RouteGroup {
 		{
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1",
-			Register: func(mux cell.RouteMux) {
+			Register: func(mux cell.RouteMux) error {
 				mux.Route("/orders", func(orders cell.RouteMux) {
 					c.createHandler.RegisterRoutes(orders)
 					c.queryHandler.RegisterRoutes(orders)
 				})
+				return nil
 			},
 		},
 	}

--- a/examples/todoorder/cells/ordercell/cell.go
+++ b/examples/todoorder/cells/ordercell/cell.go
@@ -192,11 +192,17 @@ func (c *OrderCell) RouteGroups() []cell.RouteGroup {
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1",
 			Register: func(mux cell.RouteMux) error {
+				var firstErr error
+				captureErr := func(err error) {
+					if err != nil && firstErr == nil {
+						firstErr = err
+					}
+				}
 				mux.Route("/orders", func(orders cell.RouteMux) {
-					c.createHandler.RegisterRoutes(orders)
-					c.queryHandler.RegisterRoutes(orders)
+					captureErr(c.createHandler.RegisterRoutes(orders))
+					captureErr(c.queryHandler.RegisterRoutes(orders))
 				})
-				return nil
+				return firstErr
 			},
 		},
 	}

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/handler.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/handler.go
@@ -50,7 +50,7 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers the order-create route on mux via auth.Mount so
 // CH-04/CH-05 governance can correlate this contract to HandleCreate.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specOrderCreate,
 		Handler:  http.HandlerFunc(h.HandleCreate),
 		Policy:   auth.AnyRole(dto.RoleCustomer),

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/handler.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/handler.go
@@ -49,12 +49,15 @@ func NewHandler(svc *Service) *Handler {
 
 // RegisterRoutes registers the order-create route on mux via auth.Mount so
 // CH-04/CH-05 governance can correlate this contract to HandleCreate.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specOrderCreate,
 		Handler:  http.HandlerFunc(h.HandleCreate),
 		Policy:   auth.AnyRole(dto.RoleCustomer),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // createRequest is the JSON body for POST /api/v1/orders.

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/service.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/service.go
@@ -122,7 +122,7 @@ func (s *Service) buildOrderCreatedEntry(order *domain.Order) (outbox.Entry, err
 		return outbox.Entry{}, fmt.Errorf("order-create: marshal event: %w", err)
 	}
 	entry := outbox.Entry{
-		ID:            outbox.NewEntryID(),
+		ID:            outbox.MustNewEntryID(),
 		AggregateID:   order.ID,
 		AggregateType: "order",
 		EventType:     TopicOrderCreated,

--- a/examples/todoorder/cells/ordercell/slices/orderquery/handler.go
+++ b/examples/todoorder/cells/ordercell/slices/orderquery/handler.go
@@ -56,17 +56,22 @@ func NewHandler(svc *Service) *Handler {
 
 // RegisterRoutes registers order-query routes on mux via auth.Mount so
 // CH-04/CH-05 governance can correlate contracts to handler functions.
-func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.MustMount(mux, auth.Route{
+func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specOrderGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(dto.RoleCustomer),
-	})
-	auth.MustMount(mux, auth.Route{
+	}); err != nil {
+		return err
+	}
+	if err := auth.Mount(mux, auth.Route{
 		Contract: specOrderList,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole(dto.RoleCustomer),
-	})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // HandleGet handles GET /api/v1/orders/{id}.

--- a/examples/todoorder/cells/ordercell/slices/orderquery/handler.go
+++ b/examples/todoorder/cells/ordercell/slices/orderquery/handler.go
@@ -57,12 +57,12 @@ func NewHandler(svc *Service) *Handler {
 // RegisterRoutes registers order-query routes on mux via auth.Mount so
 // CH-04/CH-05 governance can correlate contracts to handler functions.
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) {
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specOrderGet,
 		Handler:  http.HandlerFunc(h.HandleGet),
 		Policy:   auth.AnyRole(dto.RoleCustomer),
 	})
-	auth.Mount(mux, auth.Route{
+	auth.MustMount(mux, auth.Route{
 		Contract: specOrderList,
 		Handler:  http.HandlerFunc(h.HandleList),
 		Policy:   auth.AnyRole(dto.RoleCustomer),

--- a/examples/todoorder/main.go
+++ b/examples/todoorder/main.go
@@ -89,7 +89,7 @@ func main() {
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithListener(cell.PrimaryListener, ":8082",
-			[]cell.ListenerAuth{cell.NewAuthJWT(jwtVerifier)}),
+			[]cell.ListenerAuth{cell.MustNewAuthJWT(jwtVerifier)}),
 		bootstrap.WithListener(cell.InternalListener, ":9082", internalAuthChain),
 		bootstrap.WithHealthRoutes(healthOpts...),
 	)

--- a/kernel/cell/auth_plan.go
+++ b/kernel/cell/auth_plan.go
@@ -100,13 +100,25 @@ type AuthJWT struct {
 	Verifier IntentTokenVerifier
 }
 
-// NewAuthJWT constructs an AuthJWT plan. Panics if v is nil, following
-// bootstrap's fail-fast convention for programmer errors at composition time.
-func NewAuthJWT(v IntentTokenVerifier) AuthJWT {
+// NewAuthJWT constructs an AuthJWT plan. Returns an error when v is nil so the
+// caller can decide between fail-fast (use MustNewAuthJWT) and graceful refusal.
+func NewAuthJWT(v IntentTokenVerifier) (AuthJWT, error) {
 	if v == nil {
-		panic("cell: NewAuthJWT verifier must not be nil; use NewAuthJWTFromAssembly(asm) to discover from an authProvider cell")
+		return AuthJWT{}, fmt.Errorf("cell: NewAuthJWT verifier must not be nil; use NewAuthJWTFromAssembly(asm) to discover from an authProvider cell")
 	}
-	return AuthJWT{Verifier: v}
+	return AuthJWT{Verifier: v}, nil
+}
+
+// MustNewAuthJWT is the composition-root convenience wrapper around NewAuthJWT
+// that panics when the constructor returns an error. Suitable for static wiring
+// where verifier presence is a build-time invariant; callers that resolve the
+// verifier from runtime config should use NewAuthJWT directly.
+func MustNewAuthJWT(v IntentTokenVerifier) AuthJWT {
+	plan, err := NewAuthJWT(v)
+	if err != nil {
+		panic(err.Error())
+	}
+	return plan
 }
 
 func (AuthJWT) authPlanKind() AuthKind { return AuthKindJWT }
@@ -153,16 +165,27 @@ type AuthJWTFromAssembly struct {
 	resolved *atomic.Pointer[IntentTokenVerifier]
 }
 
-// NewAuthJWTFromAssembly constructs an AuthJWTFromAssembly plan.
-// Panics if asm is nil.
-func NewAuthJWTFromAssembly(asm AssemblyRef) AuthJWTFromAssembly {
+// NewAuthJWTFromAssembly constructs an AuthJWTFromAssembly plan. Returns an
+// error when asm is nil; use MustNewAuthJWTFromAssembly for fail-fast static
+// wiring.
+func NewAuthJWTFromAssembly(asm AssemblyRef) (AuthJWTFromAssembly, error) {
 	if asm == nil {
-		panic("cell: NewAuthJWTFromAssembly assembly must not be nil")
+		return AuthJWTFromAssembly{}, fmt.Errorf("cell: NewAuthJWTFromAssembly assembly must not be nil")
 	}
 	return AuthJWTFromAssembly{
 		Assembly: asm,
 		resolved: &atomic.Pointer[IntentTokenVerifier]{},
+	}, nil
+}
+
+// MustNewAuthJWTFromAssembly is the composition-root convenience wrapper around
+// NewAuthJWTFromAssembly that panics on misconfiguration.
+func MustNewAuthJWTFromAssembly(asm AssemblyRef) AuthJWTFromAssembly {
+	plan, err := NewAuthJWTFromAssembly(asm)
+	if err != nil {
+		panic(err.Error())
 	}
+	return plan
 }
 
 func (AuthJWTFromAssembly) authPlanKind() AuthKind { return AuthKindJWTFromAssembly }
@@ -239,25 +262,37 @@ type AuthServiceToken struct {
 	Ring HMACKeyring
 }
 
-// NewAuthServiceToken constructs an AuthServiceToken plan. Panics if either
-// argument is nil or if ring.Current() returns fewer than MinHMACKeyBytes bytes
-// — both are required for a properly guarded internal listener; a short HMAC
-// secret silently weakens MAC strength and is rejected at construction time
+// NewAuthServiceToken constructs an AuthServiceToken plan. Returns an error if
+// either argument is nil or if ring.Current() returns fewer than MinHMACKeyBytes
+// bytes — both are required for a properly guarded internal listener; a short
+// HMAC secret silently weakens MAC strength and is rejected at construction time
 // (NIST SP 800-107 §5.3.4 — HMAC key length must match underlying hash
 // security strength: 256-bit / 32-byte for HMAC-SHA-256).
-func NewAuthServiceToken(store NonceStore, ring HMACKeyring) AuthServiceToken {
+//
+// Use MustNewAuthServiceToken for fail-fast static wiring at composition root.
+func NewAuthServiceToken(store NonceStore, ring HMACKeyring) (AuthServiceToken, error) {
 	if store == nil {
-		panic("cell: NewAuthServiceToken store must not be nil")
+		return AuthServiceToken{}, fmt.Errorf("cell: NewAuthServiceToken store must not be nil")
 	}
 	if ring == nil {
-		panic("cell: NewAuthServiceToken ring must not be nil")
+		return AuthServiceToken{}, fmt.Errorf("cell: NewAuthServiceToken ring must not be nil")
 	}
 	if got := len(ring.Current()); got < MinHMACKeyBytes {
-		panic(fmt.Sprintf(
+		return AuthServiceToken{}, fmt.Errorf(
 			"cell: NewAuthServiceToken HMAC ring.Current() returned %d bytes, minimum is %d (NIST SP 800-107)",
-			got, MinHMACKeyBytes))
+			got, MinHMACKeyBytes)
 	}
-	return AuthServiceToken{Store: store, Ring: ring}
+	return AuthServiceToken{Store: store, Ring: ring}, nil
+}
+
+// MustNewAuthServiceToken is the composition-root convenience wrapper around
+// NewAuthServiceToken that panics on misconfiguration.
+func MustNewAuthServiceToken(store NonceStore, ring HMACKeyring) AuthServiceToken {
+	plan, err := NewAuthServiceToken(store, ring)
+	if err != nil {
+		panic(err.Error())
+	}
+	return plan
 }
 
 func (AuthServiceToken) authPlanKind() AuthKind { return AuthKindServiceToken }

--- a/kernel/cell/auth_plan_test.go
+++ b/kernel/cell/auth_plan_test.go
@@ -41,10 +41,10 @@ func TestAuthPlan_Describe(t *testing.T) {
 		want string
 	}{
 		{"AuthNone", cell.AuthNone{}, "none"},
-		{"AuthJWT", cell.NewAuthJWT(verifier), "jwt"},
-		{"AuthJWTFromAssembly", cell.NewAuthJWTFromAssembly(asm), "jwt"},
+		{"AuthJWT", cell.MustNewAuthJWT(verifier), "jwt"},
+		{"AuthJWTFromAssembly", cell.MustNewAuthJWTFromAssembly(asm), "jwt"},
 		{"AuthMTLS", cell.AuthMTLS{}, "mtls"},
-		{"AuthServiceToken", cell.NewAuthServiceToken(store, ring), "service-token"},
+		{"AuthServiceToken", cell.MustNewAuthServiceToken(store, ring), "service-token"},
 	}
 
 	for _, tc := range tests {
@@ -81,46 +81,64 @@ func TestAuthPlan_AuthKind(t *testing.T) {
 	}
 }
 
-// ─── Constructor nil/empty panic guards ───────────────────────────────────────
+// ─── Constructor nil/empty error guards ───────────────────────────────────────
 
-func TestNewAuthJWT_NilPanics(t *testing.T) {
+func TestNewAuthJWT_NilReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := cell.NewAuthJWT(nil); err == nil {
+		t.Error("expected error for nil verifier, got nil")
+	}
+}
+
+func TestMustNewAuthJWT_NilPanics(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		if recover() == nil {
 			t.Error("expected panic for nil verifier, got none")
 		}
 	}()
-	cell.NewAuthJWT(nil)
+	cell.MustNewAuthJWT(nil)
 }
 
-func TestNewAuthJWTFromAssembly_NilPanics(t *testing.T) {
+func TestNewAuthJWTFromAssembly_NilReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := cell.NewAuthJWTFromAssembly(nil); err == nil { //nolint:staticcheck // SA1012: deliberate nil arg
+		t.Error("expected error for nil assembly, got nil")
+	}
+}
+
+func TestMustNewAuthJWTFromAssembly_NilPanics(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		if recover() == nil {
 			t.Error("expected panic for nil assembly, got none")
 		}
 	}()
-	cell.NewAuthJWTFromAssembly(nil) //nolint:staticcheck // SA1012: deliberate nil arg to test panic guard
+	cell.MustNewAuthJWTFromAssembly(nil) //nolint:staticcheck // SA1012: deliberate nil arg to test panic guard
 }
 
-func TestNewAuthServiceToken_NilStorePanics(t *testing.T) {
+func TestNewAuthServiceToken_NilStoreReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := cell.NewAuthServiceToken(nil, &stubHMACKeyring{}); err == nil {
+		t.Error("expected error for nil store, got nil")
+	}
+}
+
+func TestNewAuthServiceToken_NilRingReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := cell.NewAuthServiceToken(&stubNonceStore{}, nil); err == nil {
+		t.Error("expected error for nil ring, got nil")
+	}
+}
+
+func TestMustNewAuthServiceToken_NilStorePanics(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		if recover() == nil {
 			t.Error("expected panic for nil store, got none")
 		}
 	}()
-	cell.NewAuthServiceToken(nil, &stubHMACKeyring{})
-}
-
-func TestNewAuthServiceToken_NilRingPanics(t *testing.T) {
-	t.Parallel()
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic for nil ring, got none")
-		}
-	}()
-	cell.NewAuthServiceToken(&stubNonceStore{}, nil)
+	cell.MustNewAuthServiceToken(nil, &stubHMACKeyring{})
 }
 
 // shortHMACKeyring intentionally returns a secret below MinHMACKeyBytes to
@@ -132,27 +150,20 @@ func (*shortHMACKeyring) Secrets() [][]byte { return [][]byte{(&shortHMACKeyring
 
 func TestNewAuthServiceToken_RejectsShortKey(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected panic for short HMAC ring.Current(), got none")
-		}
-		msg, ok := r.(string)
-		if !ok {
-			t.Fatalf("panic value is not string: %T %v", r, r)
-		}
-		// Panic message format (auth_plan.go::NewAuthServiceToken):
-		//   "cell: NewAuthServiceToken HMAC ring.Current() returned 31 bytes, minimum is 32 (NIST SP 800-107)"
-		if !strings.Contains(msg, "minimum is 32") {
-			t.Errorf("panic message must mention 'minimum is 32': %q", msg)
-		}
-	}()
 	// Pre-condition: stub returns 31 bytes (one short of MinHMACKeyBytes=32).
 	if got := len((&shortHMACKeyring{}).Current()); got >= cell.MinHMACKeyBytes {
 		t.Fatalf("test fixture broken: shortHMACKeyring.Current() returned %d bytes, want < %d",
 			got, cell.MinHMACKeyBytes)
 	}
-	cell.NewAuthServiceToken(&stubNonceStore{}, &shortHMACKeyring{})
+	_, err := cell.NewAuthServiceToken(&stubNonceStore{}, &shortHMACKeyring{})
+	if err == nil {
+		t.Fatal("expected error for short HMAC ring.Current(), got nil")
+	}
+	// Error message format (auth_plan.go::NewAuthServiceToken):
+	//   "cell: NewAuthServiceToken HMAC ring.Current() returned 31 bytes, minimum is 32 (NIST SP 800-107)"
+	if !strings.Contains(err.Error(), "minimum is 32") {
+		t.Errorf("error message must mention 'minimum is 32': %q", err.Error())
+	}
 }
 
 // ─── AuthJWT fields ───────────────────────────────────────────────────────────
@@ -160,7 +171,10 @@ func TestNewAuthServiceToken_RejectsShortKey(t *testing.T) {
 func TestNewAuthJWT_StoresVerifier(t *testing.T) {
 	t.Parallel()
 	v := &stubVerifier{}
-	p := cell.NewAuthJWT(v)
+	p, err := cell.NewAuthJWT(v)
+	if err != nil {
+		t.Fatalf("NewAuthJWT returned unexpected error: %v", err)
+	}
 	if p.Verifier != v {
 		t.Errorf("NewAuthJWT Verifier field mismatch: got %v, want %v", p.Verifier, v)
 	}
@@ -172,7 +186,10 @@ func TestAuthJWTFromAssembly_ResolvedVerifier(t *testing.T) {
 	t.Parallel()
 
 	asm := &stubAssemblyRef{id: "test"}
-	p := cell.NewAuthJWTFromAssembly(asm)
+	p, err := cell.NewAuthJWTFromAssembly(asm)
+	if err != nil {
+		t.Fatalf("NewAuthJWTFromAssembly returned unexpected error: %v", err)
+	}
 
 	// Before SetResolved, ResolvedVerifier returns nil.
 	if got := p.ResolvedVerifier(); got != nil {

--- a/kernel/cell/celltest/eventrouter.go
+++ b/kernel/cell/celltest/eventrouter.go
@@ -20,12 +20,16 @@ type StubEventRouter struct {
 }
 
 // AddContractHandler records the topic (derived from spec.Topic), handler,
-// consumerGroup, and the full ContractSpec.
-func (r *StubEventRouter) AddContractHandler(spec wrapper.ContractSpec, handler outbox.EntryHandler, consumerGroup string) {
+// consumerGroup, and the full ContractSpec. The stub never validates the
+// inputs — production-style validation lives in runtime/eventrouter.Router.
+// Returns nil unconditionally so cells can exercise their RegisterSubscriptions
+// happy path without bringing in the full router pipeline.
+func (r *StubEventRouter) AddContractHandler(spec wrapper.ContractSpec, handler outbox.EntryHandler, consumerGroup string) error {
 	r.Topics = append(r.Topics, spec.Topic)
 	r.Handlers = append(r.Handlers, handler)
 	r.ConsumerGroups = append(r.ConsumerGroups, consumerGroup)
 	r.Contracts = append(r.Contracts, spec)
+	return nil
 }
 
 // HandlerCount returns the number of registered handlers.

--- a/kernel/cell/celltest/eventrouter_test.go
+++ b/kernel/cell/celltest/eventrouter_test.go
@@ -18,12 +18,12 @@ func TestStubEventRouter_AddContractHandler(t *testing.T) {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
 
-	r.AddContractHandler(testEventSpec("topic.a.v1"), handler, "cell-a")
+	_ = r.AddContractHandler(testEventSpec("topic.a.v1"), handler, "cell-a")
 	assert.Equal(t, 1, r.HandlerCount())
 	assert.Equal(t, "topic.a.v1", r.Topics[0])
 	assert.Equal(t, "cell-a", r.ConsumerGroups[0])
 
-	r.AddContractHandler(testEventSpec("topic.b.v1"), handler, "cell-b")
+	_ = r.AddContractHandler(testEventSpec("topic.b.v1"), handler, "cell-b")
 	assert.Equal(t, 2, r.HandlerCount())
 	assert.Equal(t, "topic.b.v1", r.Topics[1])
 	assert.Equal(t, "cell-b", r.ConsumerGroups[1])
@@ -42,8 +42,8 @@ func TestStubEventRouter_SliceInvariant(t *testing.T) {
 
 	specA := testEventSpec("event.a.v1")
 	specB := testEventSpec("event.b.v1")
-	r.AddContractHandler(specA, handler, "cell-a")
-	r.AddContractHandler(specB, handler, "cell-b")
+	_ = r.AddContractHandler(specA, handler, "cell-a")
+	_ = r.AddContractHandler(specB, handler, "cell-b")
 
 	require.Len(t, r.Topics, 2, "Topics count")
 	require.Len(t, r.Handlers, 2, "Handlers count")

--- a/kernel/cell/registrar.go
+++ b/kernel/cell/registrar.go
@@ -207,7 +207,11 @@ type EventRouter interface {
 	// bootstrap's ContractTracingMiddleware wraps the subscription so every
 	// consumed entry emits a CONSUME span annotated with gocell.contract.id
 	// / messaging.destination.
-	AddContractHandler(spec wrapper.ContractSpec, handler outbox.EntryHandler, consumerGroup string)
+	//
+	// Returns a non-nil error when handler is nil, consumerGroup is empty,
+	// spec.Kind != "event", or spec.Validate() fails. Callers (typically
+	// Cell.RegisterSubscriptions) should propagate the error.
+	AddContractHandler(spec wrapper.ContractSpec, handler outbox.EntryHandler, consumerGroup string) error
 }
 
 // EventRegistrar is optionally implemented by Cells that subscribe to events.

--- a/kernel/cell/registrar_test.go
+++ b/kernel/cell/registrar_test.go
@@ -62,8 +62,9 @@ type mockEventRouter struct {
 	topics []string
 }
 
-func (m *mockEventRouter) AddContractHandler(spec wrapper.ContractSpec, _ outbox.EntryHandler, _ string) {
+func (m *mockEventRouter) AddContractHandler(spec wrapper.ContractSpec, _ outbox.EntryHandler, _ string) error {
 	m.topics = append(m.topics, spec.Topic)
+	return nil
 }
 
 // Compile-time check.
@@ -77,10 +78,9 @@ type eventCell struct {
 
 func (e *eventCell) RegisterSubscriptions(r EventRouter) error {
 	e.registered = true
-	r.AddContractHandler(testEventSpec("session.created"), func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	return r.AddContractHandler(testEventSpec("session.created"), func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}, "test")
-	return nil
 }
 
 // Compile-time check.
@@ -97,10 +97,9 @@ func (d *dualRouteGroupEventCell) RouteGroups() []RouteGroup { return d.groups }
 
 func (d *dualRouteGroupEventCell) RegisterSubscriptions(r EventRouter) error {
 	d.eventRegistered = true
-	r.AddContractHandler(testEventSpec("device.enrolled"), func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	return r.AddContractHandler(testEventSpec("device.enrolled"), func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}, "test")
-	return nil
 }
 
 // Compile-time checks.

--- a/kernel/cell/registrar_test.go
+++ b/kernel/cell/registrar_test.go
@@ -120,7 +120,7 @@ func TestRouteGroupContributor_TypeAssertion(t *testing.T) {
 			{
 				Listener: ref,
 				Prefix:   "/api/v1/sessions",
-				Register: func(mux RouteMux) { mux.Handle("/login", http.NotFoundHandler()) },
+				Register: func(mux RouteMux) error { mux.Handle("/login", http.NotFoundHandler()); return nil },
 			},
 		},
 	}
@@ -187,7 +187,7 @@ func TestDualRouteGroupEventCell_BothInterfaces(t *testing.T) {
 			{
 				Listener: ref,
 				Prefix:   "/api/v1/devices",
-				Register: func(mux RouteMux) { mux.Handle("/", http.NotFoundHandler()) },
+				Register: func(mux RouteMux) error { mux.Handle("/", http.NotFoundHandler()); return nil },
 			},
 		},
 	}
@@ -284,7 +284,7 @@ func TestConfigReloader_DualRouteGroupAndReloader(t *testing.T) {
 			{
 				Listener: ref,
 				Prefix:   "/api/v1/keys",
-				Register: func(mux RouteMux) { mux.Handle("/", http.NotFoundHandler()) },
+				Register: func(mux RouteMux) error { mux.Handle("/", http.NotFoundHandler()); return nil },
 			},
 		},
 	}

--- a/kernel/cell/routegroup.go
+++ b/kernel/cell/routegroup.go
@@ -26,7 +26,11 @@ type RouteGroup struct {
 	// Register is called by bootstrap to mount the cell's sub-tree on the
 	// chosen mux. Required; a nil Register is a programmer error detected
 	// at phase5 validation time.
-	Register func(mux RouteMux)
+	//
+	// Returning a non-nil error aborts the bootstrap walk; the error is
+	// wrapped with the cell ID + group prefix at the phase5 call site so
+	// operators see which sub-tree failed mounting.
+	Register func(mux RouteMux) error
 	// CellID is the identifier of the cell that contributed this group.
 	// Set automatically by bootstrap during phase5CollectRouteGroups for
 	// error-context enrichment (OPS-02). Cells do not need to populate this.
@@ -38,7 +42,7 @@ type RouteGroup struct {
 // and register function. Equivalent to declaring the struct literal inline.
 //
 // DX-05: reduces boilerplate in cells that declare a single route group.
-func SingleGroup(l ListenerRef, prefix string, fn func(RouteMux)) RouteGroup {
+func SingleGroup(l ListenerRef, prefix string, fn func(RouteMux) error) RouteGroup {
 	return RouteGroup{Listener: l, Prefix: prefix, Register: fn}
 }
 

--- a/kernel/cell/routegroup_test.go
+++ b/kernel/cell/routegroup_test.go
@@ -37,12 +37,12 @@ func TestRouteGroup_ContributorReturnsDeclaredGroups(t *testing.T) {
 		{
 			Listener: cell.PrimaryListener,
 			Prefix:   "/api/v1/foo",
-			Register: func(mux cell.RouteMux) {},
+			Register: func(mux cell.RouteMux) error { return nil },
 		},
 		{
 			Listener: cell.InternalListener,
 			Prefix:   "/internal/v1/foo",
-			Register: func(mux cell.RouteMux) {},
+			Register: func(mux cell.RouteMux) error { return nil },
 		},
 	}
 
@@ -88,21 +88,21 @@ func TestRouteGroup_FieldCombinations(t *testing.T) {
 	}{
 		{
 			name:     "primary_listener_with_prefix",
-			rg:       cell.RouteGroup{Listener: cell.PrimaryListener, Prefix: "/api/v1/x", Register: func(cell.RouteMux) {}},
+			rg:       cell.RouteGroup{Listener: cell.PrimaryListener, Prefix: "/api/v1/x", Register: func(cell.RouteMux) error { return nil }},
 			wantRef:  "primary",
 			wantPfx:  "/api/v1/x",
 			wantNilR: false,
 		},
 		{
 			name:     "internal_listener_with_prefix",
-			rg:       cell.RouteGroup{Listener: cell.InternalListener, Prefix: "/internal/v1/y", Register: func(cell.RouteMux) {}},
+			rg:       cell.RouteGroup{Listener: cell.InternalListener, Prefix: "/internal/v1/y", Register: func(cell.RouteMux) error { return nil }},
 			wantRef:  "internal",
 			wantPfx:  "/internal/v1/y",
 			wantNilR: false,
 		},
 		{
 			name:     "health_listener_no_prefix",
-			rg:       cell.RouteGroup{Listener: cell.HealthListener, Prefix: "", Register: func(cell.RouteMux) {}},
+			rg:       cell.RouteGroup{Listener: cell.HealthListener, Prefix: "", Register: func(cell.RouteMux) error { return nil }},
 			wantRef:  "health",
 			wantPfx:  "",
 			wantNilR: false,
@@ -144,7 +144,7 @@ func assertRouteGroupFields(t *testing.T, rg cell.RouteGroup, wantRef, wantPfx s
 // TestRouteGroup_SingleGroupConstructor covers the DX-05 SingleGroup helper.
 func TestRouteGroup_SingleGroupConstructor(t *testing.T) {
 	t.Parallel()
-	rg := cell.SingleGroup(cell.PrimaryListener, "/api/v1/sg", func(cell.RouteMux) {})
+	rg := cell.SingleGroup(cell.PrimaryListener, "/api/v1/sg", func(cell.RouteMux) error { return nil })
 	if rg.Listener.String() != "primary" {
 		t.Errorf("SingleGroup Listener = %q, want primary", rg.Listener.String())
 	}

--- a/kernel/governance/rules_http_response_alignment.go
+++ b/kernel/governance/rules_http_response_alignment.go
@@ -458,7 +458,10 @@ func extractContractIDFromLit(expr ast.Expr) string {
 	return ""
 }
 
-// isAuthMountCall returns true when the call is auth.Mount(…).
+// isAuthMountCall returns true when the call is auth.Mount(…) or
+// auth.MustMount(…). Both signatures share the (mux, Route) shape and bind
+// a wrapper.ContractSpec literal; the governance scanner correlates the
+// route declaration regardless of which variant the cell uses.
 func isAuthMountCall(call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
@@ -468,7 +471,7 @@ func isAuthMountCall(call *ast.CallExpr) bool {
 	if !ok {
 		return false
 	}
-	return pkg.Name == "auth" && sel.Sel.Name == "Mount"
+	return pkg.Name == "auth" && (sel.Sel.Name == "Mount" || sel.Sel.Name == "MustMount")
 }
 
 // extractAuthMountContractAndHandler parses an auth.Mount call and returns

--- a/kernel/idempotency/idempotency_test.go
+++ b/kernel/idempotency/idempotency_test.go
@@ -2,6 +2,7 @@ package idempotency
 
 import (
 	"context"
+	"crypto/rand"
 	"testing"
 	"time"
 
@@ -108,6 +109,7 @@ func TestInMemClaimer_Claim_ExpiredLease_ReacquiredBySecond(t *testing.T) {
 	c := &InMemClaimer{
 		entries: make(map[string]*inMemEntry),
 		now:     func() time.Time { return time.Unix(1000, 0) },
+		rand:    rand.Reader,
 	}
 	ctx := context.Background()
 
@@ -175,6 +177,7 @@ func TestInMemReceipt_Extend_Success(t *testing.T) {
 	c := &InMemClaimer{
 		entries: make(map[string]*inMemEntry),
 		now:     func() time.Time { return time.Unix(1000, 0) },
+		rand:    rand.Reader,
 	}
 	ctx := context.Background()
 
@@ -216,6 +219,7 @@ func TestInMemReceipt_Extend_TokenMismatch_ReturnsErrLeaseExpired(t *testing.T) 
 	c := &InMemClaimer{
 		entries: make(map[string]*inMemEntry),
 		now:     func() time.Time { return time.Unix(1000, 0) },
+		rand:    rand.Reader,
 	}
 	ctx := context.Background()
 
@@ -236,6 +240,7 @@ func TestInMemReceipt_Extend_AfterExpiredLease_ReturnsErrLeaseExpired(t *testing
 	c := &InMemClaimer{
 		entries: make(map[string]*inMemEntry),
 		now:     func() time.Time { return now },
+		rand:    rand.Reader,
 	}
 	ctx := context.Background()
 

--- a/kernel/idempotency/inmem.go
+++ b/kernel/idempotency/inmem.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -64,7 +65,10 @@ func (c *InMemClaimer) Claim(_ context.Context, key string, leaseTTL, doneTTL ti
 		delete(c.entries, key)
 	}
 
-	token := newToken()
+	token, err := newToken()
+	if err != nil {
+		return ClaimAcquired, nil, err
+	}
 	c.entries[key] = &inMemEntry{
 		state:     ClaimAcquired,
 		token:     token,
@@ -136,13 +140,12 @@ func (r *inMemReceipt) Extend(_ context.Context, ttl time.Duration) error {
 
 var errStaleReceipt = errors.New("idempotency: receipt is stale (claim was released or expired)")
 
-func newToken() string {
+func newToken() (string, error) {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// Entropy failure is non-recoverable; match stdlib uuid panic behaviour.
-		panic("idempotency: crypto/rand.Read failed: " + err.Error())
+		return "", fmt.Errorf("idempotency: crypto/rand.Read failed: %w", err)
 	}
-	return hex.EncodeToString(b[:])
+	return hex.EncodeToString(b[:]), nil
 }
 
 // Compile-time check that InMemClaimer satisfies Claimer.

--- a/kernel/idempotency/inmem.go
+++ b/kernel/idempotency/inmem.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 )
@@ -29,6 +30,10 @@ type InMemClaimer struct {
 	entries map[string]*inMemEntry
 	// now is indirected for tests; production uses time.Now.
 	now func() time.Time
+	// rand is the entropy source for token generation. Indirected for tests
+	// that need to exercise the crypto/rand.Read failure path; production
+	// uses crypto/rand.Reader.
+	rand io.Reader
 }
 
 type inMemEntry struct {
@@ -40,11 +45,13 @@ type inMemEntry struct {
 	expiresAt time.Time
 }
 
-// NewInMemClaimer creates a new in-memory Claimer with default wall-clock.
+// NewInMemClaimer creates a new in-memory Claimer with default wall-clock
+// and the OS entropy source (crypto/rand.Reader).
 func NewInMemClaimer() *InMemClaimer {
 	return &InMemClaimer{
 		entries: make(map[string]*inMemEntry),
 		now:     time.Now,
+		rand:    rand.Reader,
 	}
 }
 
@@ -65,9 +72,15 @@ func (c *InMemClaimer) Claim(_ context.Context, key string, leaseTTL, doneTTL ti
 		delete(c.entries, key)
 	}
 
-	token, err := newToken()
+	token, err := newToken(c.rand)
 	if err != nil {
-		return ClaimAcquired, nil, err
+		// Honour the Claimer contract documented in idempotency.go (`(_, nil, err)`):
+		// state must NOT be ClaimAcquired when receipt is nil, otherwise callers
+		// that branch on `state == ClaimAcquired` and use the receipt would
+		// dereference nil. ClaimBusy signals "another consumer is processing"
+		// which is the closest-equivalent caller-action (requeue) for an
+		// infrastructure-level entropy failure.
+		return ClaimBusy, nil, err
 	}
 	c.entries[key] = &inMemEntry{
 		state:     ClaimAcquired,
@@ -140,10 +153,10 @@ func (r *inMemReceipt) Extend(_ context.Context, ttl time.Duration) error {
 
 var errStaleReceipt = errors.New("idempotency: receipt is stale (claim was released or expired)")
 
-func newToken() (string, error) {
+func newToken(r io.Reader) (string, error) {
 	var b [8]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", fmt.Errorf("idempotency: crypto/rand.Read failed: %w", err)
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return "", fmt.Errorf("idempotency: rand source read failed: %w", err)
 	}
 	return hex.EncodeToString(b[:]), nil
 }

--- a/kernel/idempotency/inmem_test.go
+++ b/kernel/idempotency/inmem_test.go
@@ -2,6 +2,7 @@ package idempotency
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -149,5 +150,33 @@ func TestInMemClaimer_Release_AfterLeaseExpiryAndReclaim_ReturnsStaleError(t *te
 	state, _, _ := c.Claim(ctx, "k", time.Minute, time.Hour)
 	if state != ClaimBusy {
 		t.Fatalf("stale Release must not drop newer claim's entry, got state %v", state)
+	}
+}
+
+// errReader always returns the configured error; used to exercise the
+// crypto/rand.Read failure branch in InMemClaimer.Claim without depending
+// on a broken host entropy source.
+type errReader struct{ err error }
+
+func (r errReader) Read(_ []byte) (int, error) { return 0, r.err }
+
+// TestInMemClaimer_Claim_RandFailure_PreservesContract verifies the Claimer
+// contract: when the entropy source fails, Claim must return state \!= ClaimAcquired
+// and a nil receipt so callers branching on `state == ClaimAcquired` cannot
+// nil-deref. ClaimBusy is the closest-equivalent caller-action (requeue) for
+// this transient infrastructure failure.
+func TestInMemClaimer_Claim_RandFailure_PreservesContract(t *testing.T) {
+	c := NewInMemClaimer()
+	c.rand = errReader{err: errors.New("entropy exhausted")}
+
+	state, receipt, err := c.Claim(context.Background(), "k1", time.Minute, time.Hour)
+	if err == nil {
+		t.Fatal("expected entropy failure to surface as Claim error")
+	}
+	if state == ClaimAcquired {
+		t.Fatalf("Claimer contract violation: state=ClaimAcquired with nil receipt would nil-deref callers; got state=%v", state)
+	}
+	if receipt != nil {
+		t.Fatalf("Claimer contract: receipt must be nil on infrastructure error; got %T", receipt)
 	}
 }

--- a/kernel/outbox/emit.go
+++ b/kernel/outbox/emit.go
@@ -32,7 +32,7 @@ func Emit[T any](ctx context.Context, emitter Emitter, topic string, payload T) 
 		return fmt.Errorf("outbox.Emit(%s): marshal payload: %w", topic, err)
 	}
 	entry := Entry{
-		ID:        NewEntryID(),
+		ID:        MustNewEntryID(),
 		EventType: topic,
 		Payload:   data,
 	}

--- a/kernel/outbox/emit.go
+++ b/kernel/outbox/emit.go
@@ -31,8 +31,12 @@ func Emit[T any](ctx context.Context, emitter Emitter, topic string, payload T) 
 	if err != nil {
 		return fmt.Errorf("outbox.Emit(%s): marshal payload: %w", topic, err)
 	}
+	id, err := NewEntryID()
+	if err != nil {
+		return fmt.Errorf("outbox.Emit(%s): new entry id: %w", topic, err)
+	}
 	entry := Entry{
-		ID:        MustNewEntryID(),
+		ID:        id,
 		EventType: topic,
 		Payload:   data,
 	}

--- a/kernel/outbox/entry_id.go
+++ b/kernel/outbox/entry_id.go
@@ -3,6 +3,7 @@ package outbox
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 )
 
 // EntryIDPrefix is the prefix for all outbox entry IDs — distinguishes
@@ -16,14 +17,27 @@ const EntryIDPrefix = "evt-"
 //
 // Uses crypto/rand directly (not github.com/google/uuid) because kernel/ may
 // only depend on the Go standard library per CLAUDE.md's layering rule.
-func NewEntryID() string {
+//
+// Returns the wrapped crypto/rand.Read error if the OS entropy source is
+// broken; callers that prefer fail-fast wiring can use MustNewEntryID.
+func NewEntryID() (string, error) {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// crypto/rand.Read only returns an error on broken entropy sources,
-		// which is non-recoverable. Panic is consistent with stdlib uuid libs.
-		panic("outbox: crypto/rand.Read failed: " + err.Error())
+		return "", fmt.Errorf("outbox: crypto/rand.Read failed: %w", err)
 	}
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant RFC 4122
-	return EntryIDPrefix + hex.EncodeToString(b[:])
+	return EntryIDPrefix + hex.EncodeToString(b[:]), nil
+}
+
+// MustNewEntryID is the panic-on-error variant of NewEntryID. crypto/rand.Read
+// only fails on broken OS entropy, which is non-recoverable, so most call
+// sites use this Must variant; outbox writers that want to surface the error
+// to upstream tx callers should use NewEntryID directly.
+func MustNewEntryID() string {
+	id, err := NewEntryID()
+	if err != nil {
+		panic(err.Error())
+	}
+	return id
 }

--- a/kernel/outbox/entry_id_test.go
+++ b/kernel/outbox/entry_id_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewEntryID_HasPrefix(t *testing.T) {
-	id := NewEntryID()
+	id := MustNewEntryID()
 	if !strings.HasPrefix(id, EntryIDPrefix) {
 		t.Fatalf("expected prefix %q, got %q", EntryIDPrefix, id)
 	}
@@ -18,7 +18,7 @@ func TestNewEntryID_HasPrefix(t *testing.T) {
 func TestNewEntryID_Unique(t *testing.T) {
 	seen := make(map[string]struct{}, 1024)
 	for i := range 1024 {
-		id := NewEntryID()
+		id := MustNewEntryID()
 		if _, dup := seen[id]; dup {
 			t.Fatalf("duplicate entry ID %q at iteration %d", id, i)
 		}
@@ -28,7 +28,7 @@ func TestNewEntryID_Unique(t *testing.T) {
 
 func TestNewEntryID_PassesSafeIDConstraints(t *testing.T) {
 	for range 100 {
-		id := NewEntryID()
+		id := MustNewEntryID()
 		assert.True(t, idutil.IsSafeID(id), "entry ID %q must pass IsSafeID", id)
 		assert.LessOrEqual(t, len(id), idutil.MaxMetadataIDLen)
 	}

--- a/kernel/outbox/envelope.go
+++ b/kernel/outbox/envelope.go
@@ -56,17 +56,14 @@ func MarshalEnvelope(entry Entry) ([]byte, error) {
 }
 
 // MustMarshalDirectEnvelope builds a v1 wire envelope for direct-publish
-// paths. Panics on missing required fields (id/eventType) or json.Marshal
-// failure — these are internal invariants violated only by writer-side
-// programming errors, not user input. The Must prefix marks the panic
-// semantics explicitly; callers that need a recoverable error path should
-// use MarshalEnvelope directly.
+// paths. Panics with errcode-tagged messages on missing required fields
+// (id/eventType) or json.Marshal failure — these are internal invariants
+// violated only by writer-side programming errors, not user input. The
+// Must prefix marks the panic semantics explicitly; callers that need a
+// recoverable error path should use MarshalEnvelope directly.
 func MustMarshalDirectEnvelope(topic, eventType, id string, payload []byte) []byte {
-	if id == "" {
-		panic("outbox.MustMarshalDirectEnvelope: empty id")
-	}
-	if eventType == "" {
-		panic("outbox.MustMarshalDirectEnvelope: empty eventType")
+	if err := validateDirectEnvelopeArgs(id, eventType); err != nil {
+		panic(err.Error())
 	}
 	raw, err := MarshalEnvelope(Entry{
 		ID:        id,
@@ -76,9 +73,26 @@ func MustMarshalDirectEnvelope(topic, eventType, id string, payload []byte) []by
 		CreatedAt: time.Now().UTC(),
 	})
 	if err != nil {
-		panic("outbox.MustMarshalDirectEnvelope: json.Marshal unexpectedly failed: " + err.Error())
+		panic(errcode.Wrap(errcode.ErrEnvelopeSchema,
+			"outbox.MustMarshalDirectEnvelope: json.Marshal unexpectedly failed", err).Error())
 	}
 	return raw
+}
+
+// validateDirectEnvelopeArgs returns a non-nil errcode error when id or
+// eventType are empty. Shared with MustMarshalDirectEnvelope so the
+// validation messages stay consistent with the rest of kernel/outbox's
+// errcode-tagged error surface.
+func validateDirectEnvelopeArgs(id, eventType string) error {
+	if id == "" {
+		return errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox.MustMarshalDirectEnvelope: empty id")
+	}
+	if eventType == "" {
+		return errcode.New(errcode.ErrEnvelopeSchema,
+			"outbox.MustMarshalDirectEnvelope: empty eventType")
+	}
+	return nil
 }
 
 // UnmarshalEnvelope decodes a v1 wire envelope into an Entry.

--- a/kernel/outbox/envelope.go
+++ b/kernel/outbox/envelope.go
@@ -55,13 +55,18 @@ func MarshalEnvelope(entry Entry) ([]byte, error) {
 	return b, nil
 }
 
-// MarshalDirectEnvelope builds a v1 wire envelope for direct-publish paths.
-func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) []byte {
+// MustMarshalDirectEnvelope builds a v1 wire envelope for direct-publish
+// paths. Panics on missing required fields (id/eventType) or json.Marshal
+// failure — these are internal invariants violated only by writer-side
+// programming errors, not user input. The Must prefix marks the panic
+// semantics explicitly; callers that need a recoverable error path should
+// use MarshalEnvelope directly.
+func MustMarshalDirectEnvelope(topic, eventType, id string, payload []byte) []byte {
 	if id == "" {
-		panic("outbox.MarshalDirectEnvelope: empty id")
+		panic("outbox.MustMarshalDirectEnvelope: empty id")
 	}
 	if eventType == "" {
-		panic("outbox.MarshalDirectEnvelope: empty eventType")
+		panic("outbox.MustMarshalDirectEnvelope: empty eventType")
 	}
 	raw, err := MarshalEnvelope(Entry{
 		ID:        id,
@@ -71,7 +76,7 @@ func MarshalDirectEnvelope(topic, eventType, id string, payload []byte) []byte {
 		CreatedAt: time.Now().UTC(),
 	})
 	if err != nil {
-		panic("outbox.MarshalDirectEnvelope: json.Marshal unexpectedly failed: " + err.Error())
+		panic("outbox.MustMarshalDirectEnvelope: json.Marshal unexpectedly failed: " + err.Error())
 	}
 	return raw
 }

--- a/kernel/outbox/envelope_test.go
+++ b/kernel/outbox/envelope_test.go
@@ -110,7 +110,7 @@ func TestMarshalDirectEnvelope_ProducesV1(t *testing.T) {
 	id := "direct-id-1"
 	payload := []byte(`{"sessionId":"s-1","userId":"u-42"}`)
 
-	raw := MarshalDirectEnvelope(topic, topic, id, payload)
+	raw := MustMarshalDirectEnvelope(topic, topic, id, payload)
 
 	got, err := UnmarshalEnvelope(topic, raw)
 	require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestMarshalDirectEnvelope_PanicsOnEmptyRequiredFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Panics(t, func() {
-				_ = MarshalDirectEnvelope(tt.topic, tt.eventType, tt.id, []byte(`{}`))
+				_ = MustMarshalDirectEnvelope(tt.topic, tt.eventType, tt.id, []byte(`{}`))
 			})
 		})
 	}

--- a/kernel/outbox/observability_test.go
+++ b/kernel/outbox/observability_test.go
@@ -520,7 +520,7 @@ func TestSubscriberWithMiddleware_RestoreIsOutermost(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestEntryID_RoundTrip_InjectAndRestore(t *testing.T) {
-	entryID := NewEntryID()
+	entryID := MustNewEntryID()
 	ctx := ctxkeys.WithRequestID(context.Background(), entryID)
 
 	e := Entry{ID: "e1", EventType: "test.v1", Payload: []byte(`{}`)}

--- a/kernel/worker/worker.go
+++ b/kernel/worker/worker.go
@@ -11,13 +11,27 @@
 // from the group runner.
 package worker
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrWorkerExitedEarly is the sentinel error returned by WorkerGroup when a
+// member Worker.Start returns nil while the group context is still live.
+// Workers are long-running; an early successful exit is indistinguishable
+// from a silent cancellation, and the previous behaviour (record nil, leave
+// firstErr unset) masked the abnormal state from operators. Modelling it as
+// a typed error lets the group propagate the failure and lets callers
+// errors.Is-check for it during shutdown reasoning.
+var ErrWorkerExitedEarly = errors.New("worker: exited early without error before context cancellation")
 
 // Worker represents a long-running background task.
 //
 // Contract:
 //   - Start blocks until ctx is cancelled or the worker completes normally.
-//     A non-nil error signals abnormal exit.
+//     A non-nil error signals abnormal exit. A nil return from Start while
+//     ctx is still live is itself an abnormal signal — the runtime
+//     WorkerGroup converts that into ErrWorkerExitedEarly.
 //   - Stop signals graceful shutdown, bounded by ctx. Should be idempotent.
 type Worker interface {
 	Start(ctx context.Context) error

--- a/kernel/wrapper/consumer.go
+++ b/kernel/wrapper/consumer.go
@@ -90,15 +90,19 @@ func defaultEventSpanName(spec ContractSpec) string {
 // WithConsumerErrorRedactor allows callers to scrub error text before it
 // reaches span.RecordError (F5 / round-4). Applied uniformly to the three
 // RecordError call sites below (Requeue/Reject disposition + panic path).
-func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...ConsumerOption) ConsumerFunc {
+//
+// Returns a non-nil error when fn is nil, spec.Kind != "event", or
+// spec.Validate fails. Callers that want to fail-fast at composition time
+// should use MustWrapConsumer.
+func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...ConsumerOption) (ConsumerFunc, error) {
 	if fn == nil {
-		panic("wrapper.WrapConsumer: fn must not be nil")
+		return nil, fmt.Errorf("wrapper.WrapConsumer: fn must not be nil")
 	}
 	if spec.Kind != "event" {
-		panic(fmt.Sprintf("wrapper.WrapConsumer: spec.Kind %q must be \"event\"", spec.Kind))
+		return nil, fmt.Errorf("wrapper.WrapConsumer: spec.Kind %q must be \"event\"", spec.Kind)
 	}
 	if err := spec.Validate(); err != nil {
-		panic(err.Error())
+		return nil, fmt.Errorf("wrapper.WrapConsumer: %w", err)
 	}
 	if tr == nil {
 		tr = NoopTracer{}
@@ -146,7 +150,19 @@ func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...Consume
 		}
 		span.End()
 		return res
+	}, nil
+}
+
+// MustWrapConsumer is the composition-root fail-fast variant of WrapConsumer.
+// It panics when WrapConsumer returns an error. Suitable for static wiring
+// where the spec is a build-time literal; use WrapConsumer directly when the
+// spec is data-driven.
+func MustWrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...ConsumerOption) ConsumerFunc {
+	c, err := WrapConsumer(tr, spec, fn, opts...)
+	if err != nil {
+		panic(err.Error())
 	}
+	return c
 }
 
 // identityRedactor is the default — passes errors through unchanged.

--- a/kernel/wrapper/consumer_test.go
+++ b/kernel/wrapper/consumer_test.go
@@ -23,7 +23,7 @@ func TestWrapConsumer_PassesAckResultThrough(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 	res := w(context.Background(), outbox.Entry{EventType: "session.revoked.v1"})
 	if res.Disposition != outbox.DispositionAck {
 		t.Errorf("want Ack, got %v", res.Disposition)
@@ -55,7 +55,7 @@ func TestWrapConsumer_MarksErrorOnRequeue(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: transient}
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 	res := w(context.Background(), outbox.Entry{})
 
 	if res.Disposition != outbox.DispositionRequeue {
@@ -75,7 +75,7 @@ func TestWrapConsumer_RedactsDispositionErrors(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("raw token")}
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner, wrapper.WithConsumerErrorRedactor(func(error) error {
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner, wrapper.WithConsumerErrorRedactor(func(error) error {
 		return errors.New("redacted")
 	}))
 	res := w(context.Background(), outbox.Entry{})
@@ -94,7 +94,7 @@ func TestWrapConsumer_RedactsMissingDispositionErrorFallback(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionReject}
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner, wrapper.WithConsumerErrorRedactor(func(err error) error {
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner, wrapper.WithConsumerErrorRedactor(func(err error) error {
 		return errors.New("safe: " + err.Error())
 	}))
 	_ = w(context.Background(), outbox.Entry{})
@@ -111,7 +111,7 @@ func TestWrapConsumer_MarksErrorOnReject(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionReject, Err: permanent}
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 	res := w(context.Background(), outbox.Entry{})
 
 	if res.Disposition != outbox.DispositionReject {
@@ -123,26 +123,32 @@ func TestWrapConsumer_MarksErrorOnReject(t *testing.T) {
 	}
 }
 
-func TestWrapConsumer_PanicsOnNonEventSpec(t *testing.T) {
+func TestWrapConsumer_ReturnsErrorOnNonEventSpec(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected panic on http spec")
-		}
-	}()
-	_ = wrapper.WrapConsumer(wrapper.NoopTracer{}, loginSpec(), func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
+	_, err := wrapper.WrapConsumer(wrapper.NoopTracer{}, loginSpec(), func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
+	if err == nil {
+		t.Fatal("expected error on http spec")
+	}
 }
 
-func TestWrapConsumer_PanicsOnNilFn(t *testing.T) {
+func TestWrapConsumer_ReturnsErrorOnNilFn(t *testing.T) {
+	t.Parallel()
+	_, err := wrapper.WrapConsumer(wrapper.NoopTracer{}, eventSpec(), nil)
+	if err == nil {
+		t.Fatal("expected error on nil fn")
+	}
+}
+
+func TestMustWrapConsumer_PanicsOnNilFn(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected panic on nil fn")
 		}
 	}()
-	_ = wrapper.WrapConsumer(wrapper.NoopTracer{}, eventSpec(), nil)
+	_ = wrapper.MustWrapConsumer(wrapper.NoopTracer{}, eventSpec(), nil)
 }
 
 func TestWrapConsumer_PutsContractIDInContext(t *testing.T) {
@@ -152,7 +158,7 @@ func TestWrapConsumer_PutsContractIDInContext(t *testing.T) {
 		seen = wrapper.ContractIDFromContext(ctx)
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
-	w := wrapper.WrapConsumer(wrapper.NoopTracer{}, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(wrapper.NoopTracer{}, eventSpec(), inner)
 	_ = w(context.Background(), outbox.Entry{})
 	if seen != "event.session.revoked.v1" {
 		t.Errorf("ContractID missing from ctx; got %q", seen)
@@ -167,7 +173,7 @@ func TestWrapConsumer_NilTracer_FallsBackToNoop(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	}
-	w := wrapper.WrapConsumer(nil, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(nil, eventSpec(), inner)
 	res := w(context.Background(), outbox.Entry{})
 	if res.Disposition != outbox.DispositionAck {
 		t.Errorf("want Ack with nil tracer, got %v", res.Disposition)
@@ -182,7 +188,7 @@ func TestWrapConsumer_PanicInHandler(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		panic(boom)
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 
 	defer func() {
 		r := recover()
@@ -213,7 +219,7 @@ func TestWrapConsumer_PanicNonError(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		panic("string panic value")
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 
 	defer func() {
 		_ = recover()
@@ -239,7 +245,7 @@ func TestWrapConsumer_InvalidDispositionRecordsError(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{} // zero value: Disposition is invalid
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 	res := w(context.Background(), outbox.Entry{})
 
 	// Result is passed through untouched — downstream decides downgrade.
@@ -267,7 +273,7 @@ func TestWrapConsumer_InvalidDispositionWithExplicitError(t *testing.T) {
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.Disposition(99), Err: explicit}
 	}
-	w := wrapper.WrapConsumer(tr, eventSpec(), inner)
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 	_ = w(context.Background(), outbox.Entry{})
 	span := tr.only(t)
 	if len(span.errs) != 1 || !errors.Is(span.errs[0], explicit) {

--- a/kernel/wrapper/handler.go
+++ b/kernel/wrapper/handler.go
@@ -30,16 +30,19 @@ import (
 // runtime/http/middleware.Tracing (span status = error + RecordError on
 // the outer span).
 //
-// spec is validated at call time; invalid specs or nil handlers panic
-// (fail-fast at registration time beats a silent miss at request time).
+// spec is validated at call time; invalid specs or nil handlers cause a
+// non-nil error to be returned so the caller can choose between fail-fast
+// (use MustHTTPHandler) and graceful refusal at composition time.
 //
 // ref: go-kratos/kratos middleware/tracing/tracing.go — the middleware is
 // the single HTTP server span owner; handlers contribute attributes, not
 // spans.
 // ref: open-telemetry/opentelemetry-go-contrib otelhttp — "one middleware,
 // one span" invariant; late-binding route metadata via chi RouteContext.
-func HTTPHandler(spec ContractSpec, next http.Handler) http.Handler {
-	validateHTTPHandlerArgs(spec, next)
+func HTTPHandler(spec ContractSpec, next http.Handler) (http.Handler, error) {
+	if err := validateHTTPHandlerArgs(spec, next); err != nil {
+		return nil, err
+	}
 	baseAttrs := httpBaseAttrs(spec)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,19 +51,32 @@ func HTTPHandler(spec ContractSpec, next http.Handler) http.Handler {
 			carrier.Attrs = append(carrier.Attrs, baseAttrs...)
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))
-	})
+	}), nil
 }
 
-func validateHTTPHandlerArgs(spec ContractSpec, next http.Handler) {
-	if next == nil {
-		panic("wrapper.HTTPHandler: next handler must not be nil")
-	}
-	if spec.Kind != "http" {
-		panic(fmt.Sprintf("wrapper.HTTPHandler: spec.Kind %q must be \"http\"", spec.Kind))
-	}
-	if err := spec.Validate(); err != nil {
+// MustHTTPHandler is the composition-root fail-fast variant of HTTPHandler.
+// It panics when HTTPHandler returns an error. Suitable for static wiring
+// where the spec is a build-time literal; use HTTPHandler directly when the
+// spec is data-driven.
+func MustHTTPHandler(spec ContractSpec, next http.Handler) http.Handler {
+	h, err := HTTPHandler(spec, next)
+	if err != nil {
 		panic(err.Error())
 	}
+	return h
+}
+
+func validateHTTPHandlerArgs(spec ContractSpec, next http.Handler) error {
+	if next == nil {
+		return fmt.Errorf("wrapper.HTTPHandler: next handler must not be nil")
+	}
+	if spec.Kind != "http" {
+		return fmt.Errorf("wrapper.HTTPHandler: spec.Kind %q must be \"http\"", spec.Kind)
+	}
+	if err := spec.Validate(); err != nil {
+		return fmt.Errorf("wrapper.HTTPHandler: %w", err)
+	}
+	return nil
 }
 
 func httpBaseAttrs(spec ContractSpec) []Attr {

--- a/kernel/wrapper/handler_test.go
+++ b/kernel/wrapper/handler_test.go
@@ -36,7 +36,7 @@ func TestHTTPHandler_WritesContractIDIntoContext(t *testing.T) {
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		seen, _ = ctxkeys.ContractIDFrom(r.Context())
 	})
-	h := wrapper.HTTPHandler(loginSpec(), inner)
+	h := wrapper.MustHTTPHandler(loginSpec(), inner)
 	req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
 	h.ServeHTTP(httptest.NewRecorder(), req)
 	assert.Equal(t, "http.auth.login.v1", seen)
@@ -49,7 +49,7 @@ func TestHTTPHandler_AppendsContractAttrsToCarrier(t *testing.T) {
 	t.Parallel()
 	carrier := &wrapper.AttrCarrier{}
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
-	h := wrapper.HTTPHandler(loginSpec(), inner)
+	h := wrapper.MustHTTPHandler(loginSpec(), inner)
 
 	req := httptest.NewRequest("POST", "/api/v1/auth/login", nil).
 		WithContext(wrapper.WithAttrCarrier(context.Background(), carrier))
@@ -76,7 +76,7 @@ func TestHTTPHandler_NoCarrier_StillInvokesInner(t *testing.T) {
 		called = true
 		w.WriteHeader(200)
 	})
-	h := wrapper.HTTPHandler(loginSpec(), inner)
+	h := wrapper.MustHTTPHandler(loginSpec(), inner)
 	req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -84,8 +84,9 @@ func TestHTTPHandler_NoCarrier_StillInvokesInner(t *testing.T) {
 	assert.Equal(t, 200, rec.Code)
 }
 
-// TestHTTPHandler_PanicsOnInvalidSpec asserts registration-time fail-fast.
-func TestHTTPHandler_PanicsOnInvalidSpec(t *testing.T) {
+// TestHTTPHandler_ReturnsErrorOnInvalidSpec asserts registration-time
+// validation: HTTPHandler returns a non-nil error rather than panicking.
+func TestHTTPHandler_ReturnsErrorOnInvalidSpec(t *testing.T) {
 	t.Parallel()
 	cases := []wrapper.ContractSpec{
 		{},                      // all empty
@@ -94,33 +95,35 @@ func TestHTTPHandler_PanicsOnInvalidSpec(t *testing.T) {
 		{ID: "a", Kind: "http", Transport: "http", Method: "POST"}, // missing path
 	}
 	for _, spec := range cases {
-		func(s wrapper.ContractSpec) {
-			defer func() {
-				require.NotNil(t, recover(), "expected panic for %+v", s)
-			}()
-			_ = wrapper.HTTPHandler(s, okHandler(200))
-		}(spec)
+		_, err := wrapper.HTTPHandler(spec, okHandler(200))
+		assert.Errorf(t, err, "expected error for %+v", spec)
 	}
 }
 
-// TestHTTPHandler_PanicsOnNilHandler ensures nil inner handler is rejected.
-func TestHTTPHandler_PanicsOnNilHandler(t *testing.T) {
+// TestHTTPHandler_ReturnsErrorOnNilHandler ensures nil inner handler is rejected.
+func TestHTTPHandler_ReturnsErrorOnNilHandler(t *testing.T) {
+	t.Parallel()
+	_, err := wrapper.HTTPHandler(loginSpec(), nil)
+	require.Error(t, err)
+}
+
+// TestHTTPHandler_ReturnsErrorOnNonHTTPKind ensures event-kind specs are rejected.
+func TestHTTPHandler_ReturnsErrorOnNonHTTPKind(t *testing.T) {
+	t.Parallel()
+	_, err := wrapper.HTTPHandler(wrapper.ContractSpec{
+		ID: "event.x.v1", Kind: "event", Transport: "amqp", Topic: "x",
+	}, okHandler(200))
+	require.Error(t, err)
+}
+
+// TestMustHTTPHandler_PanicsOnNilHandler asserts the Must wrapper panics on
+// the same misuse where HTTPHandler returns error.
+func TestMustHTTPHandler_PanicsOnNilHandler(t *testing.T) {
 	t.Parallel()
 	defer func() {
 		require.NotNil(t, recover(), "expected panic on nil handler")
 	}()
-	_ = wrapper.HTTPHandler(loginSpec(), nil)
-}
-
-// TestHTTPHandler_PanicsOnNonHTTPKind ensures event-kind specs are rejected.
-func TestHTTPHandler_PanicsOnNonHTTPKind(t *testing.T) {
-	t.Parallel()
-	defer func() {
-		require.NotNil(t, recover(), "expected panic on non-http kind")
-	}()
-	_ = wrapper.HTTPHandler(wrapper.ContractSpec{
-		ID: "event.x.v1", Kind: "event", Transport: "amqp", Topic: "x",
-	}, okHandler(200))
+	_ = wrapper.MustHTTPHandler(loginSpec(), nil)
 }
 
 // TestAttrCarrier_Nil_ReturnsCtxUnchanged ensures WithAttrCarrier(nil) is a

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -438,7 +438,7 @@ func assertPasswordResetErrorWithHint(t *testing.T, rec *httptest.ResponseRecord
 
 // testExemptMatcher returns the canonical (method, path) matcher used by the
 // test suite when exercising the password-reset gate. Mirrors the matcher that
-// Router.FinalizeAuth compiles from auth.Mount(Route{PasswordResetExempt: true})
+// Router.FinalizeAuth compiles from auth.MustMount(Route{PasswordResetExempt: true})
 // metadata declared by accesscore's identity and session cells.
 func testExemptMatcher(t *testing.T) func(method, urlPath string) bool {
 	t.Helper()

--- a/runtime/auth/route.go
+++ b/runtime/auth/route.go
@@ -63,10 +63,16 @@ type Route struct {
 //     path before handing off to the top-level Router's declaration
 //     table).
 //
-// Mount panics on invalid configurations (fail-fast at startup is
-// preferred over silent runtime drift).
-func Mount(mux cell.RouteHandler, r Route) {
-	r.validateOrPanic()
+// Mount returns a non-nil error on invalid configurations so callers
+// (cell.RouteGroup.Register) can propagate the failure to bootstrap phase5
+// without aborting the program. Composition-root call sites that want
+// fail-fast wiring can wrap the error in a panic at the top of the call
+// chain; cells that consult runtime config should propagate the error
+// instead.
+func Mount(mux cell.RouteHandler, r Route) error {
+	if err := r.validate(); err != nil {
+		return err
+	}
 
 	prefix := ""
 	if p, ok := mux.(cell.Prefixer); ok {
@@ -80,12 +86,12 @@ func Mount(mux cell.RouteHandler, r Route) {
 		prefix = ""
 	}
 	if prefix != "" && !isPathSegmentPrefix(r.Contract.Path, prefix) {
-		panic(fmt.Sprintf(
+		return fmt.Errorf(
 			"auth.Mount %s %s: Contract.Path does not extend mux mount prefix %q — "+
 				"sub-routers must declare a Contract.Path that begins with the prefix "+
 				"on a path-segment boundary. Fix the Contract.Path or the Route()/Mount() "+
-				"the caller used to scope the sub-router.",
-			r.Contract.Method, r.Contract.Path, prefix))
+				"the caller used to scope the sub-router",
+			r.Contract.Method, r.Contract.Path, prefix)
 	}
 	relPath := stripMountPrefix(r.Contract.Path, prefix)
 
@@ -96,7 +102,11 @@ func Mount(mux cell.RouteHandler, r Route) {
 	// wrapper.HTTPHandler is a pure ctx contributor (round-4) — it writes
 	// ContractID + contract attrs into ctx so the outer middleware.Tracing
 	// span late-binds them. No inner span is created.
-	handler = wrapper.MustHTTPHandler(r.Contract, handler)
+	wrapped, err := wrapper.HTTPHandler(r.Contract, handler)
+	if err != nil {
+		return fmt.Errorf("auth.Mount: %w", err)
+	}
+	handler = wrapped
 
 	cleanedRel := path.Clean(relPath)
 	mux.Handle(r.Contract.Method+" "+cleanedRel, handler)
@@ -114,6 +124,17 @@ func Mount(mux cell.RouteHandler, r Route) {
 	}
 	if declarer, ok := mux.(cell.HTTPContractDeclarer); ok {
 		declarer.DeclareHTTPContract(r.Contract)
+	}
+	return nil
+}
+
+// MustMount is the composition-root fail-fast variant of Mount. It panics
+// when Mount returns an error. Suitable for top-level wiring where the
+// caller has no error-return path; cells should use Mount inside their
+// RouteGroup.Register closure and propagate the error.
+func MustMount(mux cell.RouteHandler, r Route) {
+	if err := Mount(mux, r); err != nil {
+		panic(err.Error())
 	}
 }
 
@@ -163,51 +184,55 @@ func stripMountPrefix(fullPath, prefix string) string {
 	return stripped
 }
 
-func (r Route) validateOrPanic() {
+func (r Route) validate() error {
 	if r.Handler == nil {
-		panic("auth.Mount: Handler must not be nil")
+		return fmt.Errorf("auth.Mount: Handler must not be nil")
 	}
 	if r.Contract.ID == "" {
-		panic("auth.Mount: Route.Contract.ID must be set — round-4 dropped the " +
+		return fmt.Errorf("auth.Mount: Route.Contract.ID must be set — round-4 dropped the " +
 			"untraced legacy registration shape; every Mount call must bind a " +
 			"wrapper.ContractSpec literal. If the contract has no YAML yet, " +
-			"author one in contracts/ first.")
+			"author one in contracts/ first")
 	}
-	r.validateContractShape()
-	r.validateBypassCompatibility()
+	if err := r.validateContractShape(); err != nil {
+		return err
+	}
+	return r.validateBypassCompatibility()
 }
 
 // validateContractShape verifies the Contract shape at registration time
 // so startup fails fast on structural mistakes.
-func (r Route) validateContractShape() {
+func (r Route) validateContractShape() error {
 	if r.Contract.Kind != "http" {
-		panic(fmt.Sprintf("auth.Mount: Contract.Kind %q must be \"http\"", r.Contract.Kind))
+		return fmt.Errorf("auth.Mount: Contract.Kind %q must be \"http\"", r.Contract.Kind)
 	}
 	if r.Contract.Method == "" {
-		panic("auth.Mount: Contract.Method must not be empty")
+		return fmt.Errorf("auth.Mount: Contract.Method must not be empty")
 	}
 	if r.Contract.Method != strings.ToUpper(strings.TrimSpace(r.Contract.Method)) {
-		panic(fmt.Sprintf("auth.Mount: Contract.Method %q must be upper-case", r.Contract.Method))
+		return fmt.Errorf("auth.Mount: Contract.Method %q must be upper-case", r.Contract.Method)
 	}
 	if !validRouteMethods[r.Contract.Method] {
-		panic(fmt.Sprintf(
+		return fmt.Errorf(
 			"auth.Mount: Contract.Method %q not recognised (GET/HEAD/POST/PUT/PATCH/DELETE/OPTIONS/CONNECT/TRACE)",
-			r.Contract.Method))
+			r.Contract.Method)
 	}
 	if r.Contract.Path == "" || r.Contract.Path[0] != '/' {
-		panic(fmt.Sprintf("auth.Mount: Contract.Path %q must start with '/'", r.Contract.Path))
+		return fmt.Errorf("auth.Mount: Contract.Path %q must start with '/'", r.Contract.Path)
 	}
+	return nil
 }
 
-func (r Route) validateBypassCompatibility() {
+func (r Route) validateBypassCompatibility() error {
 	if r.Public && r.Policy != nil {
-		panic(fmt.Sprintf(
+		return fmt.Errorf(
 			"auth.Mount %s %s: Public=true conflicts with non-nil Policy (public routes have no server-side authorization)",
-			r.Contract.Method, r.Contract.Path))
+			r.Contract.Method, r.Contract.Path)
 	}
 	if r.Public && r.PasswordResetExempt {
-		panic(fmt.Sprintf(
+		return fmt.Errorf(
 			"auth.Mount %s %s: Public=true conflicts with PasswordResetExempt=true (gate runs only for authenticated tokens)",
-			r.Contract.Method, r.Contract.Path))
+			r.Contract.Method, r.Contract.Path)
 	}
+	return nil
 }

--- a/runtime/auth/route.go
+++ b/runtime/auth/route.go
@@ -96,7 +96,7 @@ func Mount(mux cell.RouteHandler, r Route) {
 	// wrapper.HTTPHandler is a pure ctx contributor (round-4) — it writes
 	// ContractID + contract attrs into ctx so the outer middleware.Tracing
 	// span late-binds them. No inner span is created.
-	handler = wrapper.HTTPHandler(r.Contract, handler)
+	handler = wrapper.MustHTTPHandler(r.Contract, handler)
 
 	cleanedRel := path.Clean(relPath)
 	mux.Handle(r.Contract.Method+" "+cleanedRel, handler)

--- a/runtime/auth/route_test.go
+++ b/runtime/auth/route_test.go
@@ -79,53 +79,50 @@ func TestMount_WritesContractIDIntoContext(t *testing.T) {
 	assert.Equal(t, "http.auth.login.v1", seen)
 }
 
-func TestMount_PanicsOnMissingContractID(t *testing.T) {
-	defer func() {
-		require.NotNil(t, recover(), "expected panic on empty Contract.ID")
-	}()
-	Mount(newCaptureMux(), Route{Handler: noopHandler})
+func TestMount_ReturnsErrorOnMissingContractID(t *testing.T) {
+	err := Mount(newCaptureMux(), Route{Handler: noopHandler})
+	require.Error(t, err)
 }
 
-func TestMount_PanicsOnNilHandler(t *testing.T) {
-	defer func() {
-		require.NotNil(t, recover(), "expected panic on nil Handler")
-	}()
-	Mount(newCaptureMux(), Route{Contract: loginContractSpec()})
+func TestMount_ReturnsErrorOnNilHandler(t *testing.T) {
+	err := Mount(newCaptureMux(), Route{Contract: loginContractSpec()})
+	require.Error(t, err)
 }
 
-func TestMount_PanicsOnNonHTTPKind(t *testing.T) {
-	defer func() {
-		require.NotNil(t, recover(), "expected panic on non-http kind")
-	}()
-	Mount(newCaptureMux(), Route{
+func TestMount_ReturnsErrorOnNonHTTPKind(t *testing.T) {
+	err := Mount(newCaptureMux(), Route{
 		Contract: wrapper.ContractSpec{ID: "event.x.v1", Kind: "event", Transport: "amqp", Topic: "x"},
 		Handler:  noopHandler,
 	})
+	require.Error(t, err)
 }
 
-func TestMount_PanicsOnInvalidMethod(t *testing.T) {
-	defer func() {
-		require.NotNil(t, recover(), "expected panic on invalid method")
-	}()
-	Mount(newCaptureMux(), Route{
+func TestMount_ReturnsErrorOnInvalidMethod(t *testing.T) {
+	err := Mount(newCaptureMux(), Route{
 		Contract: wrapper.ContractSpec{
 			ID: "http.x.v1", Kind: "http", Transport: "http",
 			Method: "foo", Path: "/x",
 		},
 		Handler: noopHandler,
 	})
+	require.Error(t, err)
 }
 
-func TestMount_PanicsPublicWithPolicy(t *testing.T) {
-	defer func() {
-		require.NotNil(t, recover(), "expected panic on Public+Policy")
-	}()
-	Mount(newCaptureMux(), Route{
+func TestMount_ReturnsErrorOnPublicWithPolicy(t *testing.T) {
+	err := Mount(newCaptureMux(), Route{
 		Contract: loginContractSpec(),
 		Handler:  noopHandler,
 		Public:   true,
 		Policy:   requireAuthenticatedPolicy(),
 	})
+	require.Error(t, err)
+}
+
+func TestMustMount_PanicsOnNilHandler(t *testing.T) {
+	defer func() {
+		require.NotNil(t, recover(), "expected panic on nil Handler")
+	}()
+	MustMount(newCaptureMux(), Route{Contract: loginContractSpec()})
 }
 
 func TestRequirePolicy_NilPanics(t *testing.T) {
@@ -285,32 +282,30 @@ func TestMount_AcceptsRootPrefix(t *testing.T) {
 	assert.Equal(t, "/api/v1/access/sessions/login", mux.metas[0].Path)
 }
 
-func TestMount_PanicsOnPrefixMismatch(t *testing.T) {
+func TestMount_ReturnsErrorOnPrefixMismatch(t *testing.T) {
 	mux := newPrefixedCaptureMux("/api/v1/access")
-	require.Panics(t, func() {
-		Mount(mux, Route{
-			Contract: wrapper.ContractSpec{
-				ID: "http.foo.bar.v1", Kind: "http", Transport: "http",
-				Method: "GET", Path: "/foo/bar",
-			},
-			Handler: noopHandler,
-			Public:  true,
-		})
+	err := Mount(mux, Route{
+		Contract: wrapper.ContractSpec{
+			ID: "http.foo.bar.v1", Kind: "http", Transport: "http",
+			Method: "GET", Path: "/foo/bar",
+		},
+		Handler: noopHandler,
+		Public:  true,
 	})
+	require.Error(t, err)
 }
 
-func TestMount_PanicsOnPartialSegmentPrefix(t *testing.T) {
+func TestMount_ReturnsErrorOnPartialSegmentPrefix(t *testing.T) {
 	mux := newPrefixedCaptureMux("/api/v1/a")
-	require.Panics(t, func() {
-		Mount(mux, Route{
-			Contract: wrapper.ContractSpec{
-				ID: "http.auth.x.v1", Kind: "http", Transport: "http",
-				Method: "GET", Path: "/api/v1/auth/x",
-			},
-			Handler: noopHandler,
-			Public:  true,
-		})
+	err := Mount(mux, Route{
+		Contract: wrapper.ContractSpec{
+			ID: "http.auth.x.v1", Kind: "http", Transport: "http",
+			Method: "GET", Path: "/api/v1/auth/x",
+		},
+		Handler: noopHandler,
+		Public:  true,
 	})
+	require.Error(t, err)
 }
 
 func TestMount_AcceptsValidSegmentPrefix(t *testing.T) {

--- a/runtime/bootstrap/auth_plan_apply_test.go
+++ b/runtime/bootstrap/auth_plan_apply_test.go
@@ -75,7 +75,7 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 	ring := &applyStubHMACKeyring{}
 	asm := &applyStubAssemblyRef{id: "test-asm"}
 
-	resolvedPlan := cell.NewAuthJWTFromAssembly(asm)
+	resolvedPlan := cell.MustNewAuthJWTFromAssembly(asm)
 	resolvedPlan.SetResolved(verifier)
 
 	ref := cell.PrimaryListener
@@ -97,7 +97,7 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 		},
 		{
 			name:          "AuthJWT",
-			chain:         []cell.ListenerAuth{cell.NewAuthJWT(verifier)},
+			chain:         []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)},
 			wantMWCount:   0,
 			wantRouterOpt: true,
 			wantDescribe:  "jwt",
@@ -112,7 +112,7 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 		{
 			name: "AuthJWTFromAssembly_unresolved",
 			chain: []cell.ListenerAuth{
-				cell.NewAuthJWTFromAssembly(asm), // not SetResolved
+				cell.MustNewAuthJWTFromAssembly(asm), // not SetResolved
 			},
 			wantErr: true,
 		},
@@ -125,7 +125,7 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 		},
 		{
 			name:          "AuthServiceToken",
-			chain:         []cell.ListenerAuth{cell.NewAuthServiceToken(store, ring)},
+			chain:         []cell.ListenerAuth{cell.MustNewAuthServiceToken(store, ring)},
 			wantMWCount:   1,
 			wantRouterOpt: false,
 			wantDescribe:  "service-token",
@@ -134,7 +134,7 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 			name: "MultiPlan_MTLSAndServiceToken",
 			chain: []cell.ListenerAuth{
 				cell.AuthMTLS{},
-				cell.NewAuthServiceToken(store, ring),
+				cell.MustNewAuthServiceToken(store, ring),
 			},
 			wantMWCount:   2,
 			wantRouterOpt: false,
@@ -258,7 +258,7 @@ func TestRunAuthPlanValidateHooks_DiscoverScenarios(t *testing.T) {
 		asm := &fakeAssemblyWithCells{id: "no-providers", cells: map[string]cell.Cell{}}
 		b := newMinimalBootstrap()
 		b.listenerConfigs[cell.PrimaryListener] = listenerConfig{
-			authChain: []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)},
+			authChain: []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 		}
 		err := b.runAuthPlanValidateHooks()
 		require.Error(t, err)
@@ -276,7 +276,7 @@ func TestRunAuthPlanValidateHooks_DiscoverScenarios(t *testing.T) {
 		}
 		b := newMinimalBootstrap()
 		b.listenerConfigs[cell.PrimaryListener] = listenerConfig{
-			authChain: []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)},
+			authChain: []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 		}
 		err := b.runAuthPlanValidateHooks()
 		require.Error(t, err)
@@ -293,7 +293,7 @@ func TestRunAuthPlanValidateHooks_DiscoverScenarios(t *testing.T) {
 		}
 		b := newMinimalBootstrap()
 		b.listenerConfigs[cell.PrimaryListener] = listenerConfig{
-			authChain: []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)},
+			authChain: []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 		}
 		err := b.runAuthPlanValidateHooks()
 		require.Error(t, err)
@@ -308,7 +308,7 @@ func TestRunAuthPlanValidateHooks_DiscoverScenarios(t *testing.T) {
 				"cell-auth": newFakeAuthCell("cell-auth", verifier),
 			},
 		}
-		plan := cell.NewAuthJWTFromAssembly(asm)
+		plan := cell.MustNewAuthJWTFromAssembly(asm)
 		b := newMinimalBootstrap()
 		b.listenerConfigs[cell.PrimaryListener] = listenerConfig{
 			authChain: []cell.ListenerAuth{plan},
@@ -356,7 +356,7 @@ func TestExplicitAuthNone(t *testing.T) {
 		{"nil_chain", nil, false},
 		{"empty_chain", []cell.ListenerAuth{}, false},
 		{"auth_none_explicit", []cell.ListenerAuth{cell.AuthNone{}}, true},
-		{"jwt_plan", []cell.ListenerAuth{cell.NewAuthJWT(verifier)}, false},
+		{"jwt_plan", []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)}, false},
 		{"mtls_plan", []cell.ListenerAuth{cell.AuthMTLS{}}, false},
 	}
 	for _, tc := range tests {

--- a/runtime/bootstrap/auth_plan_validate_test.go
+++ b/runtime/bootstrap/auth_plan_validate_test.go
@@ -56,28 +56,28 @@ func TestValidateAuthChainJWTSingleton(t *testing.T) {
 	}{
 		{
 			name:    "AcceptsJWTFirst",
-			chain:   []cell.ListenerAuth{cell.NewAuthJWT(verifier), cell.AuthMTLS{}},
+			chain:   []cell.ListenerAuth{cell.MustNewAuthJWT(verifier), cell.AuthMTLS{}},
 			wantErr: false,
 		},
 		{
 			name:    "AcceptsJWTFromAssemblyFirst",
-			chain:   []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm), cell.NewAuthServiceToken(&applyStubNonceStore{}, &applyStubHMACKeyring{})},
+			chain:   []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm), cell.MustNewAuthServiceToken(&applyStubNonceStore{}, &applyStubHMACKeyring{})},
 			wantErr: false,
 		},
 		{
 			name:    "AcceptsJWTAlone",
-			chain:   []cell.ListenerAuth{cell.NewAuthJWT(verifier)},
+			chain:   []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)},
 			wantErr: false,
 		},
 		{
 			name:    "RejectsJWTNotFirst",
-			chain:   []cell.ListenerAuth{cell.AuthMTLS{}, cell.NewAuthJWT(verifier)},
+			chain:   []cell.ListenerAuth{cell.AuthMTLS{}, cell.MustNewAuthJWT(verifier)},
 			wantErr: true,
 			errMsg:  "must be sole/first plan",
 		},
 		{
 			name:    "RejectsDuplicateJWT",
-			chain:   []cell.ListenerAuth{cell.NewAuthJWT(verifier), cell.NewAuthJWT(verifier)},
+			chain:   []cell.ListenerAuth{cell.MustNewAuthJWT(verifier), cell.MustNewAuthJWT(verifier)},
 			wantErr: true,
 			errMsg:  "at most one",
 		},
@@ -126,7 +126,7 @@ func TestValidateAuthPlanAssemblyMatch(t *testing.T) {
 		b := New(
 			WithAssembly(asmA),
 			WithListener(cell.PrimaryListener, "127.0.0.1:0",
-				[]cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asmA)}),
+				[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asmA)}),
 		)
 		err := b.validateAuthPlanAssemblyMatch()
 		require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestValidateAuthPlanAssemblyMatch(t *testing.T) {
 		b := New(
 			WithAssembly(asmA),
 			WithListener(cell.PrimaryListener, "127.0.0.1:0",
-				[]cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asmB)}),
+				[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asmB)}),
 		)
 		err := b.validateAuthPlanAssemblyMatch()
 		require.Error(t, err)
@@ -238,21 +238,21 @@ func TestCheckJWTSingleton(t *testing.T) {
 		errMsg  string
 	}{
 		{"empty", nil, false, ""},
-		{"jwt_alone", []cell.ListenerAuth{cell.NewAuthJWT(verifier)}, false, ""},
-		{"jwt_from_assembly_alone", []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, false, ""},
+		{"jwt_alone", []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)}, false, ""},
+		{"jwt_from_assembly_alone", []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, false, ""},
 		{
 			"jwt_not_first",
-			[]cell.ListenerAuth{cell.AuthMTLS{}, cell.NewAuthJWT(verifier)},
+			[]cell.ListenerAuth{cell.AuthMTLS{}, cell.MustNewAuthJWT(verifier)},
 			true, "sole/first",
 		},
 		{
 			"dual_jwt",
-			[]cell.ListenerAuth{cell.NewAuthJWT(verifier), cell.NewAuthJWT(verifier)},
+			[]cell.ListenerAuth{cell.MustNewAuthJWT(verifier), cell.MustNewAuthJWT(verifier)},
 			true, "at most one",
 		},
 		{
 			"jwt_and_jwt_from_assembly",
-			[]cell.ListenerAuth{cell.NewAuthJWT(verifier), cell.NewAuthJWTFromAssembly(asm)},
+			[]cell.ListenerAuth{cell.MustNewAuthJWT(verifier), cell.MustNewAuthJWTFromAssembly(asm)},
 			true, "at most one",
 		},
 	}

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -43,7 +43,7 @@ import (
 // RES-5 the isolation runs as router early-responder middleware before
 // FinalizeAuth's policy-coverage walk reaches it, so no whitelist hole is
 // needed.
-// Health probes (/healthz, /readyz) are declared via auth.Mount(Public:true)
+// Health probes (/healthz, /readyz) are declared via auth.MustMount(Public:true)
 // inside HealthRouteGroups and do not need any whitelist entry.
 
 // phaseState extends runState with phase-local values that must be shared
@@ -638,16 +638,24 @@ func (b *Bootstrap) mountOneRouteGroup(rtr *router.Router, rg cell.RouteGroup, _
 	if len(rg.Middleware) > 0 {
 		mws := rg.Middleware
 		inner := register
-		register = func(sub cell.RouteMux) {
-			inner(sub.With(mws...))
+		register = func(sub cell.RouteMux) error {
+			return inner(sub.With(mws...))
 		}
 	}
+	var registerErr error
 	if rg.Prefix != "" {
-		rtr.Route(rg.Prefix, register)
+		// rtr.Route signature is from cell.RouteMux which still takes a no-error
+		// closure; capture the Register error via the outer variable so it
+		// surfaces to the phase5 walker.
+		rtr.Route(rg.Prefix, func(sub cell.RouteMux) {
+			if err := register(sub); err != nil {
+				registerErr = err
+			}
+		})
 	} else {
-		register(rtr)
+		registerErr = register(rtr)
 	}
-	return nil
+	return registerErr
 }
 
 // phase5FinalizeAllRouters installs /internal/v1/* isolation on the primary

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -646,7 +646,9 @@ func (b *Bootstrap) mountOneRouteGroup(rtr *router.Router, rg cell.RouteGroup, _
 	if rg.Prefix != "" {
 		// rtr.Route signature is from cell.RouteMux which still takes a no-error
 		// closure; capture the Register error via the outer variable so it
-		// surfaces to the phase5 walker.
+		// surfaces to the phase5 walker. rtr.Route is synchronous (chi.Mux
+		// builds the sub-tree before returning) so registerErr is read after
+		// the closure exits — no data race on the outer variable.
 		rtr.Route(rg.Prefix, func(sub cell.RouteMux) {
 			if err := register(sub); err != nil {
 				registerErr = err

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -2383,15 +2383,16 @@ func (c *httpCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.PrimaryListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		Register: func(mux cell.RouteMux) error {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"data":"ok"}`))
 			}), Policy: authtest.RequireAuthenticated()})
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"data":{"token":"test"}}`))
 			}), Public: true})
+			return nil
 		},
 	}}
 }
@@ -2468,7 +2469,7 @@ func TestBootstrap_WithAuthMiddleware_ProtectedRoute_Returns401(t *testing.T) {
 	}
 }
 
-// publicHTTPCell registers routes as public via auth.Mount(Public:true),
+// publicHTTPCell registers routes as public via auth.MustMount(Public:true),
 // following the F3 pattern where cells own their auth declarations.
 type publicHTTPCell struct {
 	*cell.BaseCell
@@ -2484,21 +2485,22 @@ func (c *publicHTTPCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.PrimaryListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		Register: func(mux cell.RouteMux) error {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"data":"ok"}`))
 			}), Public: true})
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"data":{"token":"test"}}`))
 			}), Public: true})
+			return nil
 		},
 	}}
 }
 
 func TestBootstrap_WithAuthMiddleware_PublicRoute_Passes(t *testing.T) {
-	// F3: public routes are declared via auth.Mount(Public:true) inside the cell.
+	// F3: public routes are declared via auth.MustMount(Public:true) inside the cell.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
@@ -2647,10 +2649,10 @@ func TestGracefulShutdown_ReadyzUnhealthyBeforeHTTPStop(t *testing.T) {
 // caller-supplied route registration function, used by tracing E2E tests.
 type tracingTestCell struct {
 	*cell.BaseCell
-	registerFn func(mux cell.RouteMux)
+	registerFn func(mux cell.RouteMux) error
 }
 
-func newTracingTestCell(id string, fn func(mux cell.RouteMux)) *tracingTestCell {
+func newTracingTestCell(id string, fn func(mux cell.RouteMux) error) *tracingTestCell {
 	return &tracingTestCell{
 		BaseCell: cell.NewBaseCell(cell.CellMetadata{
 			ID:   id,
@@ -2679,11 +2681,12 @@ func TestBootstrap_TracingE2E_BusinessRoute(t *testing.T) {
 	// PR-A14a: register via raw mux.Handle + coverage whitelist so the route
 	// is neither Public (which starts a new trace root) nor policy-guarded
 	// (which would 401 without a verifier). Handler runs, tracing works.
-	tc := newTracingTestCell("trace-biz", func(mux cell.RouteMux) {
+	tc := newTracingTestCell("trace-biz", func(mux cell.RouteMux) error {
 		mux.Handle("GET /api/v1/trace-test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
 			w.WriteHeader(http.StatusOK)
 		}))
+		return nil
 	})
 
 	asm := assembly.New(assembly.Config{ID: "trace-e2e", DurabilityMode: cell.DurabilityDemo})
@@ -2721,11 +2724,12 @@ func TestBootstrap_TracingE2E_UpstreamPropagation(t *testing.T) {
 	var gotTraceID string
 	// PR-A14a: see TestBootstrap_TracingE2E_BusinessRoute rationale for the
 	// raw-Handle + whitelist pattern.
-	tc := newTracingTestCell("trace-upstream", func(mux cell.RouteMux) {
+	tc := newTracingTestCell("trace-upstream", func(mux cell.RouteMux) error {
 		mux.Handle("GET /api/v1/propagate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotTraceID, _ = ctxkeys.TraceIDFrom(r.Context())
 			w.WriteHeader(http.StatusOK)
 		}))
+		return nil
 	})
 
 	asm := assembly.New(assembly.Config{ID: "trace-upstream", DurabilityMode: cell.DurabilityDemo})
@@ -2766,10 +2770,11 @@ func TestBootstrap_TracingE2E_PanicRoute(t *testing.T) {
 	ln := newLocalListener(t)
 	tracer := tracing.NewTracer("bootstrap-panic-e2e")
 
-	tc := newTracingTestCell("trace-panic", func(mux cell.RouteMux) {
+	tc := newTracingTestCell("trace-panic", func(mux cell.RouteMux) error {
 		mux.Handle("GET /api/v1/boom", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("boom for tracing test")
 		}))
+		return nil
 	})
 
 	asm := assembly.New(assembly.Config{ID: "trace-panic", DurabilityMode: cell.DurabilityDemo})
@@ -2866,17 +2871,18 @@ func (c *authProviderCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.PrimaryListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		Register: func(mux cell.RouteMux) error {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"data":"ok"}`))
 			}), Policy: authtest.RequireAuthenticated()})
 			// F3: login is declared as a public route so auth discovery tests can verify
 			// that no-token requests bypass JWT checks on this endpoint.
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"data":"login-ok"}`))
 			}), Public: true})
+			return nil
 		},
 	}}
 }
@@ -2944,7 +2950,7 @@ func TestBootstrap_AuthDiscovery_PublicRoute_Passes(t *testing.T) {
 		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
-		// F3: public routes are declared via auth.Mount(Public:true) in the cell.
+		// F3: public routes are declared via auth.MustMount(Public:true) in the cell.
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3120,7 +3126,7 @@ func TestBootstrap_TrustBoundary_PublicEndpoint_IgnoresClientIDs(t *testing.T) {
 		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
-		// F3: public routes declared via auth.Mount(Public:true) in authProviderCell.
+		// F3: public routes declared via auth.MustMount(Public:true) in authProviderCell.
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3429,19 +3435,20 @@ func (c *traceCapturingCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.PrimaryListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
+		Register: func(mux cell.RouteMux) error {
 			// F3: public/ping is declared public so it creates new trace roots and
 			// rejects client-supplied request IDs.
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/public/ping"), Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/public/ping"), Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				tid, _ := ctxkeys.TraceIDFrom(r.Context())
 				c.gotPublic <- tid
 				w.WriteHeader(http.StatusOK)
 			}), Public: true})
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/protected/ping"), Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/protected/ping"), Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				tid, _ := ctxkeys.TraceIDFrom(r.Context())
 				c.gotProtected <- tid
 				w.WriteHeader(http.StatusOK)
 			}), Policy: authtest.RequireAuthenticated()})
+			return nil
 		},
 	}}
 }
@@ -3578,9 +3585,10 @@ func (c *publicPingAuthCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.PrimaryListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
+		Register: func(mux cell.RouteMux) error {
 			// F3: GET /api/v1/public/ping is declared public; HEAD alias is automatic.
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/public/ping"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/public/ping"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+			return nil
 		},
 	}}
 }
@@ -3783,13 +3791,14 @@ func (c *duplicateAuthCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.PrimaryListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
+		Register: func(mux cell.RouteMux) error {
 			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/dup"), Handler: handler, Public: true})
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/dup"), Handler: handler, Public: true})
 			// Declare the same (method, path) a second time — must trigger FinalizeAuth error.
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/dup"), Handler: handler, Public: true})
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/dup"), Handler: handler, Public: true})
+			return nil
 		},
 	}}
 }
@@ -3811,10 +3820,11 @@ func (c *protectedAuthCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.PrimaryListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
-			auth.Mount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/protected"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		Register: func(mux cell.RouteMux) error {
+			auth.MustMount(mux, auth.Route{Contract: testHTTPContract("GET", "/api/v1/protected"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}), Policy: authtest.RequireAuthenticated()})
+			return nil
 		},
 	}}
 }
@@ -3941,16 +3951,17 @@ func (c *duplicateInternalCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.InternalListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
-			auth.Mount(mux, auth.Route{
+		Register: func(mux cell.RouteMux) error {
+			auth.MustMount(mux, auth.Route{
 				Contract: testHTTPContract("POST", "/internal/v1/dup-internal"),
 				Handler:  handler,
 			})
 			// Duplicate declaration — must trigger FinalizeAuth error.
-			auth.Mount(mux, auth.Route{
+			auth.MustMount(mux, auth.Route{
 				Contract: testHTTPContract("POST", "/internal/v1/dup-internal"),
 				Handler:  handler,
 			})
+			return nil
 		},
 	}}
 }
@@ -4010,18 +4021,19 @@ func (c *duplicateHealthCell) RouteGroups() []cell.RouteGroup {
 	return []cell.RouteGroup{{
 		Listener: cell.HealthListener,
 		Prefix:   "",
-		Register: func(mux cell.RouteMux) {
-			auth.Mount(mux, auth.Route{
+		Register: func(mux cell.RouteMux) error {
+			auth.MustMount(mux, auth.Route{
 				Contract: testHTTPContract("GET", "/api/v1/health-dup"),
 				Handler:  handler,
 				Public:   true,
 			})
 			// Duplicate declaration — must trigger FinalizeAuth error.
-			auth.Mount(mux, auth.Route{
+			auth.MustMount(mux, auth.Route{
 				Contract: testHTTPContract("GET", "/api/v1/health-dup"),
 				Handler:  handler,
 				Public:   true,
 			})
+			return nil
 		},
 	}}
 }
@@ -4077,12 +4089,13 @@ func (c *unknownListenerCell) RouteGroups() []cell.RouteGroup {
 		{
 			Listener: cell.ListenerRef{}, // zero value — undeclared
 			Prefix:   "/api/v1/unknown",
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{
 					Contract: testHTTPContract(http.MethodGet, "/api/v1/unknown/ping"),
 					Handler:  http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
 					Public:   true,
 				})
+				return nil
 			},
 		},
 	}

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -2427,7 +2427,7 @@ func TestBootstrap_WithAuthMiddleware_ProtectedRoute_Returns401(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWT(verifier)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 	)
@@ -2512,7 +2512,7 @@ func TestBootstrap_WithAuthMiddleware_PublicRoute_Passes(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWT(verifier)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 	)
@@ -2894,7 +2894,7 @@ func TestBootstrap_AuthDiscovery_ProtectedRoute_Returns401(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 	)
@@ -2941,7 +2941,7 @@ func TestBootstrap_AuthDiscovery_PublicRoute_Passes(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 		// F3: public routes are declared via auth.Mount(Public:true) in the cell.
@@ -3004,7 +3004,7 @@ func TestBootstrap_WithAuthMiddleware_Precedence(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWT(explicitVerifier)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWT(explicitVerifier)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 	)
@@ -3052,7 +3052,7 @@ func TestBootstrap_AuthDiscovery_NoProvider_FailsClosed(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 	)
@@ -3084,7 +3084,7 @@ func TestBootstrap_AuthDiscovery_MultipleProviders_FailsFast(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 	)
@@ -3117,7 +3117,7 @@ func TestBootstrap_TrustBoundary_PublicEndpoint_IgnoresClientIDs(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 		// F3: public routes declared via auth.Mount(Public:true) in authProviderCell.
@@ -3464,7 +3464,7 @@ func TestBootstrap_TrustBoundary_PublicEndpoint_TraceparentIgnored(t *testing.T)
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithTracer(tracer),
 		WithShutdownTimeout(2*time.Second),
@@ -3601,7 +3601,7 @@ func TestBootstrap_HEADAlias_BypassesAuth(t *testing.T) {
 
 	b := New(
 		WithAssembly(asm),
-		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
+		WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, WithListenerNet(ln)),
 		WithListener(cell.InternalListener, "127.0.0.1:0", nil, WithListenerNet(newLocalListener(t))),
 		WithShutdownTimeout(2*time.Second),
 	)

--- a/runtime/bootstrap/consumer_tracing_integration_test.go
+++ b/runtime/bootstrap/consumer_tracing_integration_test.go
@@ -145,7 +145,7 @@ func TestBootstrap_ConsumerTracingIntegration(t *testing.T) {
 	// Publish one entry on the topic and await handler invocation.
 	// The bus requires a v1 wire envelope, built via outbox.MarshalDirectEnvelope.
 	bodyPayload, _ := json.Marshal(map[string]string{"hello": "world"})
-	envelope := outbox.MarshalDirectEnvelope(spec.Topic, "integration.test", "integration-evt-1", bodyPayload)
+	envelope := outbox.MustMarshalDirectEnvelope(spec.Topic, "integration.test", "integration-evt-1", bodyPayload)
 	err := bus.Publish(ctx, spec.Topic, envelope)
 	require.NoError(t, err)
 

--- a/runtime/bootstrap/consumer_tracing_integration_test.go
+++ b/runtime/bootstrap/consumer_tracing_integration_test.go
@@ -95,7 +95,7 @@ func (c *consumerSpyCell) RegisterSubscriptions(r cell.EventRouter) error {
 		c.calls <- entry
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
 	})
-	r.AddContractHandler(c.spec, handler, "consumer-spy")
+	_ = r.AddContractHandler(c.spec, handler, "consumer-spy")
 	return nil
 }
 

--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -44,15 +44,17 @@ func (c *dualListenerCell) RouteGroups() []cell.RouteGroup {
 		{
 			Listener: cell.PrimaryListener,
 			Prefix:   "",
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/test/ping"), Handler: http.HandlerFunc(c.onPublic), Public: true})
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/test/ping"), Handler: http.HandlerFunc(c.onPublic), Public: true})
+				return nil
 			},
 		},
 		{
 			Listener: cell.InternalListener,
 			Prefix:   "",
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/internal/v1/admin/ping"), Handler: http.HandlerFunc(c.onInternal)})
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{Contract: testHTTPContract(http.MethodGet, "/internal/v1/admin/ping"), Handler: http.HandlerFunc(c.onInternal)})
+				return nil
 			},
 		},
 	}
@@ -544,9 +546,10 @@ func (c *duplicateMetaCell) RouteGroups() []cell.RouteGroup {
 		{
 			Listener: cell.PrimaryListener,
 			Prefix:   "",
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{Contract: spec, Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
-				auth.Mount(mux, auth.Route{Contract: spec, Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{Contract: spec, Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+				auth.MustMount(mux, auth.Route{Contract: spec, Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+				return nil
 			},
 		},
 	}
@@ -744,12 +747,13 @@ func (c *middlewareOrderCell) RouteGroups() []cell.RouteGroup {
 			Listener:   cell.PrimaryListener,
 			Prefix:     "/api/v1/mwtest",
 			Middleware: []func(http.Handler) http.Handler{mw1, mw2},
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{
 					Contract: testHTTPContract(http.MethodGet, "/api/v1/mwtest/ping"),
 					Handler:  http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
 					Public:   true,
 				})
+				return nil
 			},
 		},
 	}

--- a/runtime/bootstrap/health.go
+++ b/runtime/bootstrap/health.go
@@ -119,22 +119,24 @@ func HealthRouteGroups(h *health.Handler, opts ...HealthRouteGroupOption) []cell
 	groups := []cell.RouteGroup{
 		{
 			Listener: cell.HealthListener,
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{
 					Contract: specHealthLivez,
 					Handler:  h.LivezHandler(),
 					Public:   true,
 				})
+				return nil
 			},
 		},
 		{
 			Listener: cell.HealthListener,
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{
 					Contract: specHealthReadyz,
 					Handler:  h.ReadyzHandler(),
 					Public:   true,
 				})
+				return nil
 			},
 		},
 	}
@@ -142,12 +144,13 @@ func HealthRouteGroups(h *health.Handler, opts ...HealthRouteGroupOption) []cell
 		mh := cfg.metricsHandler
 		groups = append(groups, cell.RouteGroup{
 			Listener: cell.HealthListener,
-			Register: func(mux cell.RouteMux) {
-				auth.Mount(mux, auth.Route{
+			Register: func(mux cell.RouteMux) error {
+				auth.MustMount(mux, auth.Route{
 					Contract: specHealthMetrics,
 					Handler:  mh,
 					Public:   true,
 				})
+				return nil
 			},
 		})
 	}

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -135,7 +135,7 @@ func TestPhase0_RejectsAuthJWTFromAssemblyMismatch(t *testing.T) {
 	b := New(
 		WithAssembly(asmA),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0",
-			[]cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asmB)}),
+			[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asmB)}),
 	)
 	err := b.phase0ValidateOptions()
 	require.Error(t, err)
@@ -149,7 +149,7 @@ func TestPhase0_AcceptsAuthJWTFromAssemblyMatch(t *testing.T) {
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0",
-			[]cell.ListenerAuth{cell.NewAuthJWTFromAssembly(asm)}),
+			[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}),
 	)
 	require.NoError(t, b.phase0ValidateOptions())
 }
@@ -241,7 +241,7 @@ func TestChainProtectsRoutes(t *testing.T) {
 		},
 		{
 			name:  "auth_jwt_protected",
-			chain: []cell.ListenerAuth{cell.NewAuthJWT(stubVerifier)},
+			chain: []cell.ListenerAuth{cell.MustNewAuthJWT(stubVerifier)},
 			want:  true,
 		},
 		{
@@ -251,7 +251,7 @@ func TestChainProtectsRoutes(t *testing.T) {
 		},
 		{
 			name:  "auth_service_token_protected",
-			chain: []cell.ListenerAuth{cell.NewAuthServiceToken(&stubNonceStore{}, &stubHMACKeyring{})},
+			chain: []cell.ListenerAuth{cell.MustNewAuthServiceToken(&stubNonceStore{}, &stubHMACKeyring{})},
 			want:  true,
 		},
 		{
@@ -264,7 +264,7 @@ func TestChainProtectsRoutes(t *testing.T) {
 			// Multi-protective chain (mTLS outer + HMAC inner) is the
 			// canonical InternalListener configuration.
 			name:  "mixed_mtls_plus_service_token_protected",
-			chain: []cell.ListenerAuth{cell.AuthMTLS{}, cell.NewAuthServiceToken(&stubNonceStore{}, &stubHMACKeyring{})},
+			chain: []cell.ListenerAuth{cell.AuthMTLS{}, cell.MustNewAuthServiceToken(&stubNonceStore{}, &stubHMACKeyring{})},
 			want:  true,
 		},
 	}

--- a/runtime/eventrouter/add_contract_handler_test.go
+++ b/runtime/eventrouter/add_contract_handler_test.go
@@ -89,25 +89,23 @@ func okHandler() outbox.EntryHandler {
 
 // --- Guard tests ---
 
-func TestAddContractHandler_NilHandler_Panics(t *testing.T) {
+func TestAddContractHandler_NilHandler_ReturnsError(t *testing.T) {
 	t.Parallel()
 	r := New(&blockingSubscriber{})
-	assert.PanicsWithValue(t,
-		"eventrouter: AddContractHandler called with nil handler",
-		func() { r.AddContractHandler(configEntryUpsertedSpec(), nil, "accesscore") },
-	)
+	err := r.AddContractHandler(configEntryUpsertedSpec(), nil, "accesscore")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil handler")
 }
 
-func TestAddContractHandler_EmptyConsumerGroup_Panics(t *testing.T) {
+func TestAddContractHandler_EmptyConsumerGroup_ReturnsError(t *testing.T) {
 	t.Parallel()
 	r := New(&blockingSubscriber{})
-	assert.PanicsWithValue(t,
-		"eventrouter: AddContractHandler called with empty consumerGroup; cells must declare their identity",
-		func() { r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "") },
-	)
+	err := r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty consumerGroup")
 }
 
-func TestAddContractHandler_NonEventSpec_Panics(t *testing.T) {
+func TestAddContractHandler_NonEventSpec_ReturnsError(t *testing.T) {
 	t.Parallel()
 	// Spec with Kind != "event" must be rejected at registration time.
 	httpSpec := wrapper.ContractSpec{
@@ -115,10 +113,8 @@ func TestAddContractHandler_NonEventSpec_Panics(t *testing.T) {
 		Method: "POST", Path: "/x",
 	}
 	r := New(&blockingSubscriber{})
-	defer func() {
-		require.NotNil(t, recover(), "expected panic on non-event spec")
-	}()
-	r.AddContractHandler(httpSpec, okHandler(), "mycell")
+	err := r.AddContractHandler(httpSpec, okHandler(), "mycell")
+	require.Error(t, err)
 }
 
 // --- Happy-path registration + tracing middleware ---
@@ -126,7 +122,7 @@ func TestAddContractHandler_NonEventSpec_Panics(t *testing.T) {
 func TestAddContractHandler_RegistersBusinessHandler(t *testing.T) {
 	t.Parallel()
 	r := New(&blockingSubscriber{})
-	r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "accesscore")
+	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "accesscore"))
 	assert.Equal(t, 1, r.HandlerCount())
 
 	// Router stores the business handler; bootstrap-owned middleware wraps it.
@@ -140,10 +136,10 @@ func TestContractTracingMiddleware_WrapsWithContractSpan(t *testing.T) {
 	r := New(&blockingSubscriber{})
 
 	var inner bool
-	r.AddContractHandler(configEntryUpsertedSpec(), func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		inner = true
 		return outbox.HandleResult{Disposition: outbox.DispositionAck}
-	}, "accesscore")
+	}, "accesscore"))
 	require.Equal(t, 1, r.HandlerCount())
 
 	// Drive one entry through the middleware position used by bootstrap:
@@ -232,7 +228,7 @@ func TestAddContractHandler_MultipleRegistrations_HandlersGrow(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		spec := configEntryUpsertedSpec()
 		spec.Topic = spec.Topic + "." + string(rune('a'+i))
-		r.AddContractHandler(spec, okHandler(), "accesscore")
+		require.NoError(t, r.AddContractHandler(spec, okHandler(), "accesscore"))
 	}
 	assert.Equal(t, 3, r.HandlerCount())
 }
@@ -243,7 +239,7 @@ func TestAddContractHandler_MultipleRegistrations_HandlersGrow(t *testing.T) {
 func TestAddContractHandler_HandlerConfigShape(t *testing.T) {
 	t.Parallel()
 	r := New(&blockingSubscriber{})
-	r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "accesscore")
+	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "accesscore"))
 	require.Equal(t, 1, len(r.handlers))
 	cfg := r.handlers[0]
 	assert.Equal(t, "event.config.entry-upserted.v1", cfg.topic, "topic derived from spec.Topic")

--- a/runtime/eventrouter/contract_middleware.go
+++ b/runtime/eventrouter/contract_middleware.go
@@ -15,10 +15,12 @@ import (
 //
 // Router.AddContractHandler is the only registration entry point, and it
 // validates the ContractSpec at registration time — no subscription reaches
-// this middleware without a populated ContractID. wrapper.WrapConsumer's
+// this middleware without a populated ContractID. wrapper.MustWrapConsumer's
 // spec.Validate() is the second line of defence: if any caller ever bypasses
 // AddContractHandler and still threads an empty-ID subscription through,
-// WrapConsumer panics at construction time.
+// WrapConsumer panics at construction time. The outbox.SubscriptionMiddleware
+// closure has no error-return path; MustWrapConsumer matches the contract
+// while keeping the spec-validation defense in depth.
 func ContractTracingMiddleware(tr wrapper.Tracer, redactor wrapper.ErrorRedactor) outbox.SubscriptionMiddleware {
 	return func(sub outbox.Subscription, next outbox.EntryHandler) outbox.EntryHandler {
 		spec := wrapper.ContractSpec{
@@ -31,6 +33,6 @@ func ContractTracingMiddleware(tr wrapper.Tracer, redactor wrapper.ErrorRedactor
 		if redactor != nil {
 			opts = append(opts, wrapper.WithConsumerErrorRedactor(redactor))
 		}
-		return wrapper.WrapConsumer(tr, spec, next, opts...)
+		return wrapper.MustWrapConsumer(tr, spec, next, opts...)
 	}
 }

--- a/runtime/eventrouter/router.go
+++ b/runtime/eventrouter/router.go
@@ -108,22 +108,26 @@ func New(sub outbox.Subscriber, opts ...Option) *Router {
 // subscription middleware pipeline owns wrapper.WrapConsumer so the span sits
 // outside ConsumerBase (and after observability metadata restore).
 //
-// spec.Kind MUST be "event" and spec.Topic MUST be set (WrapConsumer
-// panics otherwise). topic used for the Subscriber.Setup /Subscribe
-// lifecycle is derived from spec.Topic — callers do not pass a separate
-// topic string.
-func (r *Router) AddContractHandler(spec wrapper.ContractSpec, handler outbox.EntryHandler, consumerGroup string) {
+// spec.Kind MUST be "event" and spec.Topic MUST be set. topic used for the
+// Subscriber.Setup / Subscribe lifecycle is derived from spec.Topic — callers
+// do not pass a separate topic string.
+//
+// Returns a non-nil error when handler is nil, consumerGroup is empty, the
+// spec is malformed, or kernel/cell.EventRouter contract is otherwise
+// violated; callers (Cell.RegisterSubscriptions) should propagate the error
+// to the bootstrap phase5 walker.
+func (r *Router) AddContractHandler(spec wrapper.ContractSpec, handler outbox.EntryHandler, consumerGroup string) error {
 	if handler == nil {
-		panic("eventrouter: AddContractHandler called with nil handler")
+		return fmt.Errorf("eventrouter: AddContractHandler called with nil handler")
 	}
 	if consumerGroup == "" {
-		panic("eventrouter: AddContractHandler called with empty consumerGroup; cells must declare their identity")
+		return fmt.Errorf("eventrouter: AddContractHandler called with empty consumerGroup; cells must declare their identity")
 	}
 	if spec.Kind != "event" {
-		panic(fmt.Sprintf("eventrouter: Contract.Kind %q must be \"event\"", spec.Kind))
+		return fmt.Errorf("eventrouter: Contract.Kind %q must be \"event\"", spec.Kind)
 	}
 	if err := spec.Validate(); err != nil {
-		panic(err.Error())
+		return fmt.Errorf("eventrouter: AddContractHandler: %w", err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -133,6 +137,7 @@ func (r *Router) AddContractHandler(spec wrapper.ContractSpec, handler outbox.En
 		consumerGroup: consumerGroup,
 		contract:      spec,
 	})
+	return nil
 }
 
 // errAlreadyRunning is returned if Run is called more than once.

--- a/runtime/eventrouter/router_close_test.go
+++ b/runtime/eventrouter/router_close_test.go
@@ -141,7 +141,7 @@ func TestRouterClose_CallsStopIntakeBeforeCancel(t *testing.T) {
 	composite := newCompositeStopIntakeSubscriber()
 
 	r := New(composite)
-	r.AddContractHandler(testEventSpec("topic.drain"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.drain"), noopHandler, "test")
 
 	ctx := context.Background()
 	done := make(chan error, 1)
@@ -208,7 +208,7 @@ func TestRouterClose_NoStopIntakeFallback(t *testing.T) {
 func TestRouterClose_NoStopIntakeFallback_WithHandlers(t *testing.T) {
 	sub := &blockingSubscriber{}
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	ctx := context.Background()
 	done := make(chan error, 1)
@@ -302,7 +302,7 @@ func TestRouterClose_WaitsForInflightAfterStopIntake(t *testing.T) {
 	sub := newInflightSubscriber(handlerDuration)
 
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.inflight"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.inflight"), noopHandler, "test")
 
 	ctx := context.Background()
 	done := make(chan error, 1)
@@ -354,7 +354,7 @@ func TestRouterClose_StopIntakeError_ContinuesShutdown(t *testing.T) {
 		stopIntakeErr: context.DeadlineExceeded, // simulate StopIntake timeout
 	}
 	r := New(sr)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	ctx := context.Background()
 	done := make(chan error, 1)

--- a/runtime/eventrouter/router_test.go
+++ b/runtime/eventrouter/router_test.go
@@ -95,8 +95,8 @@ func TestRouter_AddContractHandler_RegistersTopics(t *testing.T) {
 	sub := &blockingSubscriber{}
 	r := New(sub)
 
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
-	r.AddContractHandler(testEventSpec("topic.b"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.b"), noopHandler, "test")
 
 	assert.Equal(t, 2, r.HandlerCount())
 }
@@ -105,9 +105,9 @@ func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 	sub := &blockingSubscriber{}
 	r := New(sub)
 
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
-	r.AddContractHandler(testEventSpec("topic.b"), noopHandler, "test")
-	r.AddContractHandler(testEventSpec("topic.c"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.b"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.c"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -153,7 +153,7 @@ func TestRouter_Run_SubscribeError_ReturnsError(t *testing.T) {
 	sub := &failingSubscriber{err: subscribeErr}
 	r := New(sub)
 
-	r.AddContractHandler(testEventSpec("topic.fail"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.fail"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -190,7 +190,7 @@ func TestRouter_Close_CancelsSubscriptions(t *testing.T) {
 	sub := &blockingSubscriber{}
 	r := New(sub)
 
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	ctx := context.Background()
 	done := make(chan error, 1)
@@ -219,7 +219,7 @@ func TestRouter_Run_HandlerReceivesMessages(t *testing.T) {
 	}
 
 	r := New(bus)
-	r.AddContractHandler(testEventSpec("test.topic"), handler, "test")
+	_ = r.AddContractHandler(testEventSpec("test.topic"), handler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -312,7 +312,7 @@ func TestRouter_Run_RuntimeError_AfterStartup(t *testing.T) {
 		err:   errors.New("connection lost"),
 	}
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -329,7 +329,7 @@ func TestRouter_HealthLifecycle(t *testing.T) {
 		err:   errors.New("connection lost"),
 	}
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	require.Error(t, r.Health(), "router must be unhealthy before Run")
 
@@ -358,7 +358,7 @@ func TestRouter_HealthLifecycle(t *testing.T) {
 func TestRouter_Health_AfterGracefulShutdown(t *testing.T) {
 	sub := &blockingSubscriber{}
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -387,7 +387,7 @@ func TestRouter_Health_AfterGracefulShutdown(t *testing.T) {
 func TestRouter_Run_DoubleRun_ReturnsError(t *testing.T) {
 	sub := &blockingSubscriber{}
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -429,7 +429,7 @@ func TestRouter_Close_Timeout(t *testing.T) {
 	stuck := make(chan struct{})
 	sub := &stuckSubscriber{block: stuck}
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.stuck"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.stuck"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -446,25 +446,21 @@ func TestRouter_Close_Timeout(t *testing.T) {
 	close(stuck) // unblock the subscriber so test cleanup works
 }
 
-func TestRouter_AddContractHandler_PanicsOnEmptyTopic(t *testing.T) {
+func TestRouter_AddContractHandler_ReturnsErrorOnEmptyTopic(t *testing.T) {
 	r := New(&blockingSubscriber{})
-	assert.Panics(t, func() {
-		r.AddContractHandler(testEventSpec(""), noopHandler, "test")
-	})
+	assert.Error(t, r.AddContractHandler(testEventSpec(""), noopHandler, "test"))
 }
 
-func TestRouter_AddContractHandler_PanicsOnNilHandler(t *testing.T) {
+func TestRouter_AddContractHandler_ReturnsErrorOnNilHandler(t *testing.T) {
 	r := New(&blockingSubscriber{})
-	assert.Panics(t, func() {
-		r.AddContractHandler(testEventSpec("topic"), nil, "test")
-	})
+	assert.Error(t, r.AddContractHandler(testEventSpec("topic"), nil, "test"))
 }
 
 func TestRouter_Run_PanicInSubscriber_CapturedAsError(t *testing.T) {
 	// A subscriber whose Subscribe panics.
 	panickySub := &panickingSubscriber{}
 	r := New(panickySub)
-	r.AddContractHandler(testEventSpec("topic.panic"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.panic"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -517,7 +513,7 @@ type mockCell struct {
 }
 
 func (m *mockCell) RegisterSubscriptions(r cell.EventRouter) error {
-	r.AddContractHandler(testEventSpec("mock.topic"), m.handler, "mock-cell")
+	_ = r.AddContractHandler(testEventSpec("mock.topic"), m.handler, "mock-cell")
 	return nil
 }
 
@@ -665,9 +661,9 @@ func TestRouter_ConsumerGroup_PropagatesToSubscriber(t *testing.T) {
 	sub := &recordingGroupSubscriber{}
 	r := New(sub)
 
-	r.AddContractHandler(testEventSpec("session.created"), noopHandler, "auditcore")
-	r.AddContractHandler(testEventSpec("config.entry-upserted"), noopHandler, "configcore")
-	r.AddContractHandler(testEventSpec("legacy.event"), noopHandler, "legacy-cell")
+	_ = r.AddContractHandler(testEventSpec("session.created"), noopHandler, "auditcore")
+	_ = r.AddContractHandler(testEventSpec("config.entry-upserted"), noopHandler, "configcore")
+	_ = r.AddContractHandler(testEventSpec("legacy.event"), noopHandler, "legacy-cell")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -695,13 +691,11 @@ func TestRouter_ConsumerGroup_PropagatesToSubscriber(t *testing.T) {
 	assert.Equal(t, "legacy-cell", groupByTopic["legacy.event"])
 }
 
-func TestRouter_AddContractHandler_PanicsOnEmptyConsumerGroup(t *testing.T) {
+func TestRouter_AddContractHandler_ReturnsErrorOnEmptyConsumerGroup(t *testing.T) {
 	r := New(&blockingSubscriber{})
-	assert.PanicsWithValue(t,
-		"eventrouter: AddContractHandler called with empty consumerGroup; cells must declare their identity",
-		func() {
-			r.AddContractHandler(testEventSpec("topic"), noopHandler, "")
-		})
+	err := r.AddContractHandler(testEventSpec("topic"), noopHandler, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty consumerGroup")
 }
 
 // ---------------------------------------------------------------------------
@@ -807,7 +801,7 @@ func TestRouter_RunBlocksUntilReady_NoTimeout(t *testing.T) {
 	sub := newDelayedReadySubscriber(readyDelay)
 
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -836,7 +830,7 @@ func TestRouter_SetupErrorAborts(t *testing.T) {
 	sub := &setupFailSubscriber{err: setupErr}
 
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.fail"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.fail"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -921,9 +915,9 @@ func TestRouter_ReadyError_PartialNotReady_NoLeak(t *testing.T) {
 
 	r := New(sub, WithReadyTimeout(0)) // disable timeout to isolate setupErr path
 
-	r.AddContractHandler(testEventSpec("topic.fast"), noopHandler, "test")
-	r.AddContractHandler(testEventSpec(sub.subscribeErrTopic), noopHandler, "test")
-	r.AddContractHandler(testEventSpec(sub.slowReadyTopic), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.fast"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec(sub.subscribeErrTopic), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec(sub.slowReadyTopic), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -968,9 +962,9 @@ func TestRouter_PartialReady_BlocksUntilAll(t *testing.T) {
 	}
 
 	r := New(sub)
-	r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
-	r.AddContractHandler(testEventSpec("topic.b"), noopHandler, "test")
-	r.AddContractHandler(testEventSpec("topic.c"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.a"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.b"), noopHandler, "test")
+	_ = r.AddContractHandler(testEventSpec("topic.c"), noopHandler, "test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/runtime/http/router/router_authmeta_test.go
+++ b/runtime/http/router/router_authmeta_test.go
@@ -54,7 +54,7 @@ func TestAuthDeclare_NestedRoute_ForwardsWithPrefix(t *testing.T) {
 
 	// Cells commonly register routes under nested mux.Route scopes:
 	//   mux.Route("/api/v1", func(v1) { v1.Route("/access", func(a) {
-	//       a.Route("/sessions", func(s) { auth.Mount(s, Route{...}) })
+	//       a.Route("/sessions", func(s) { auth.MustMount(s, Route{...}) })
 	//   })})
 	// The adapter chain must compose the mount prefixes so the declared
 	// meta reaches the Router with the full path. Production convention:
@@ -64,8 +64,8 @@ func TestAuthDeclare_NestedRoute_ForwardsWithPrefix(t *testing.T) {
 	r.Route("/api/v1", func(v1 kcell.RouteMux) {
 		v1.Route("/access", func(a kcell.RouteMux) {
 			a.Route("/sessions", func(s kcell.RouteMux) {
-				auth.Mount(s, auth.Route{Contract: testHTTPContract("POST", "/api/v1/access/sessions/login"), Handler: okHandler, Public: true})
-				auth.Mount(s, auth.Route{Contract: testHTTPContract("DELETE", "/api/v1/access/sessions/{id}"), Handler: okHandler, Policy: authtest.RequireAuthenticated(), PasswordResetExempt: true})
+				auth.MustMount(s, auth.Route{Contract: testHTTPContract("POST", "/api/v1/access/sessions/login"), Handler: okHandler, Public: true})
+				auth.MustMount(s, auth.Route{Contract: testHTTPContract("DELETE", "/api/v1/access/sessions/{id}"), Handler: okHandler, Policy: authtest.RequireAuthenticated(), PasswordResetExempt: true})
 			})
 		})
 	})
@@ -154,7 +154,7 @@ func TestFinalizeAuth_InternalPathOnHealth_Rejected(t *testing.T) {
 func TestFinalizeAuth_InternalPathOnInternal_Accepted(t *testing.T) {
 	r, err := NewForListener(kcell.InternalListener)
 	require.NoError(t, err)
-	auth.Mount(r, auth.Route{
+	auth.MustMount(r, auth.Route{
 		Contract: testHTTPContract("GET", "/internal/v1/probe"),
 		Handler:  okHandler,
 	})
@@ -167,7 +167,7 @@ func TestFinalizeAuth_InternalPathOnZeroRef_Accepted(t *testing.T) {
 	// the consistency check skips the listener-identity rule for that case so
 	// existing test fixtures stay valid.
 	r := New()
-	auth.Mount(r, auth.Route{
+	auth.MustMount(r, auth.Route{
 		Contract: testHTTPContract("GET", "/internal/v1/probe"),
 		Handler:  okHandler,
 	})
@@ -180,7 +180,7 @@ func TestFinalizeAuth_NoVerifier_EmitsWarn_ByDefault(t *testing.T) {
 	defer restore()
 
 	r := New() // no AuthMiddleware, no suppression
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/healthz"), Handler: okHandler, Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/healthz"), Handler: okHandler, Public: true})
 	require.NoError(t, r.FinalizeAuth())
 
 	assert.Contains(t, buf.String(), "AuthMiddleware is not installed",
@@ -194,7 +194,7 @@ func TestFinalizeAuth_NoVerifier_SuppressedWarn_NoOutput(t *testing.T) {
 	// Mirrors how bootstrap wires HealthListener routers post-R2-11.
 	r, err := NewE(WithSuppressNoAuthVerifierWarn())
 	require.NoError(t, err)
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/healthz"), Handler: okHandler, Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/healthz"), Handler: okHandler, Public: true})
 	require.NoError(t, r.FinalizeAuth())
 
 	assert.NotContains(t, buf.String(), "AuthMiddleware is not installed",
@@ -211,8 +211,8 @@ func TestFinalizeAuth_PublicMeta_BypassesAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/public"), Handler: okHandler, Public: true})
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/protected"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/public"), Handler: okHandler, Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/protected"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Public route: no token → 200
@@ -240,8 +240,8 @@ func TestFinalizeAuth_PasswordResetExempt_Meta(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("POST", "/exempt"), Handler: okHandler, PasswordResetExempt: true})
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/blocked"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("POST", "/exempt"), Handler: okHandler, PasswordResetExempt: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/blocked"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Exempt route with password-reset token → 200
@@ -316,9 +316,9 @@ func TestFinalizeAuth_HintDerivedFromPostExemptMeta(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/blocked"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/blocked"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
 	// POST + PasswordResetExempt meta should derive hint.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("POST", "/change-password"), Handler: okHandler, PasswordResetExempt: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("POST", "/change-password"), Handler: okHandler, PasswordResetExempt: true})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Non-exempt route → 403 with changePasswordEndpoint hint
@@ -348,9 +348,9 @@ func TestFinalizeAuth_MultipleDeclaredPublic_ORMerged(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/declared-public-a"), Handler: okHandler, Public: true})
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/declared-public-b"), Handler: okHandler, Public: true})
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/protected"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/declared-public-a"), Handler: okHandler, Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/declared-public-b"), Handler: okHandler, Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/protected"), Handler: okHandler, Policy: authtest.RequireAuthenticated()})
 	require.NoError(t, r.FinalizeAuth())
 
 	// First declared public route: no token → 200
@@ -487,7 +487,7 @@ func TestFinalizeAuth_PolicyCoverage_DetectsMissingPolicy(t *testing.T) {
 	r.Handle("GET /unguarded", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
 
 	// /guarded is registered via auth.Mount — covered.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/guarded"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}), Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/guarded"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}), Policy: authtest.RequireAuthenticated()})
 
 	err = r.FinalizeAuth()
 	require.Error(t, err)
@@ -500,8 +500,8 @@ func TestFinalizeAuth_PolicyCoverage_AllDeclaredOK(t *testing.T) {
 	r, err := NewE(WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}))
 	require.NoError(t, err)
 
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("GET", "/api/v1/items"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}), Policy: authtest.RequireAuthenticated()})
-	auth.Mount(r, auth.Route{Contract: testHTTPContract("POST", "/api/v1/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}), Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/api/v1/items"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}), Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract("POST", "/api/v1/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}), Public: true})
 
 	err = r.FinalizeAuth()
 	require.NoError(t, err)

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -361,7 +361,7 @@ func TestWithTracer_InternalContractRouteTraced(t *testing.T) {
 	tracer := &routerSpyTracer{}
 	r := New(WithTracer(tracer))
 
-	auth.Mount(r, auth.Route{
+	auth.MustMount(r, auth.Route{
 		Contract: testHTTPContract(http.MethodGet, "/internal/v1/rbac/check"),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
@@ -594,7 +594,7 @@ func TestWithTracer_RateLimitedContractRouteTagged(t *testing.T) {
 	limiter := &routerTestLimiter{allow: false}
 	tracer := &routerSpyTracer{}
 	r := New(WithRateLimiter(limiter), WithTracer(tracer))
-	auth.Mount(r, auth.Route{
+	auth.MustMount(r, auth.Route{
 		Contract: testHTTPContract(http.MethodGet, "/api/v1/rl-contract/{id}"),
 		Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 			t.Fatal("handler should not be called when rate limited")
@@ -857,7 +857,7 @@ func TestWithAuthMiddleware_ProtectedRoute_ValidToken_Returns200(t *testing.T) {
 }
 
 func TestWithAuthMiddleware_PublicEndpoint_SkipsAuth(t *testing.T) {
-	// F3: public endpoints are declared via auth.Mount(Public:true) + FinalizeAuth.
+	// F3: public endpoints are declared via auth.MustMount(Public:true) + FinalizeAuth.
 	verifier := &routerTestVerifier{
 		err: fmt.Errorf("should not be called"),
 	}
@@ -866,7 +866,7 @@ func TestWithAuthMiddleware_PublicEndpoint_SkipsAuth(t *testing.T) {
 	loginHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: loginHandler, Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/access/sessions/login"), Handler: loginHandler, Public: true})
 	require.NoError(t, r.FinalizeAuth())
 
 	rec := httptest.NewRecorder()
@@ -1004,12 +1004,12 @@ func TestWithRequestIDOptions_PublicEndpoint(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDeclareAuth_AuthBypass(t *testing.T) {
-	// F3: public routes declared via auth.Mount(Public:true) bypass JWT check.
+	// F3: public routes declared via auth.MustMount(Public:true) bypass JWT check.
 	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}}}
 	r := New(WithAuthMiddleware(verifier))
 
 	var reached bool
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { reached = true; w.WriteHeader(http.StatusOK) }), Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { reached = true; w.WriteHeader(http.StatusOK) }), Public: true})
 	require.NoError(t, r.FinalizeAuth())
 
 	rec := httptest.NewRecorder()
@@ -1025,10 +1025,10 @@ func TestDeclareAuth_AuthBypass_MethodMismatch_Returns401(t *testing.T) {
 	verifier := &routerTestVerifier{err: fmt.Errorf("should not be called")}
 	r := New(WithAuthMiddleware(verifier))
 
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
 	// Register GET with a policy so it is covered by policy enforcement;
 	// the verifier always fails so a GET without a token still returns 401.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("GET must not bypass auth when only POST is declared public")
 	}), Policy: authtest.RequireAuthenticated()})
 	require.NoError(t, r.FinalizeAuth())
@@ -1052,7 +1052,7 @@ func TestDeclareAuth_TracingNewRoot(t *testing.T) {
 	)
 
 	var publicTraceID, internalTraceID string
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		publicTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
 		w.WriteHeader(http.StatusOK)
 	}), Public: true})
@@ -1087,7 +1087,7 @@ func TestDeclareAuth_RequestIDRejectsClient(t *testing.T) {
 	r := New(WithPolicyCoverageWhitelist([]string{"/internal/*"}))
 
 	var publicID, internalID string
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		publicID, _ = ctxkeys.RequestIDFrom(req.Context())
 		w.WriteHeader(http.StatusOK)
 	}), Public: true})
@@ -1117,9 +1117,9 @@ func TestDeclareAuth_ProtectedStillRequiresAuth(t *testing.T) {
 	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}}}
 	r := New(WithAuthMiddleware(verifier))
 
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
 	// /api/v1/data is protected — declared with a policy to satisfy coverage enforcement.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/data"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Policy: authtest.RequireAuthenticated()})
 	require.NoError(t, r.FinalizeAuth())
 
 	// Protected endpoint without token → 401.
@@ -1144,7 +1144,7 @@ func TestDeclareAuth_UserTracingOptions_FineGrained(t *testing.T) {
 		WithPolicyCoverageWhitelist([]string{"/fine-grained-public/*"}),
 	)
 
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}), Public: true})
 	// PR-A14a: /fine-grained-public is whitelisted + registered raw (non-public).
@@ -1161,7 +1161,7 @@ func TestDeclareAuth_UserTracingOptions_FineGrained(t *testing.T) {
 		})),
 		WithPolicyCoverageWhitelist([]string{"/fine-grained-public/*"}),
 	)
-	auth.Mount(r2, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	auth.MustMount(r2, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		publicTraceID, _ = ctxkeys.TraceIDFrom(req.Context())
 		w.WriteHeader(http.StatusOK)
 	}), Public: true})
@@ -1274,7 +1274,7 @@ func TestDeclareAuth_PathNormalization(t *testing.T) {
 	r := New()
 
 	var gotID string
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1//login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1//login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		gotID, _ = ctxkeys.RequestIDFrom(req.Context())
 		w.WriteHeader(http.StatusOK)
 	}), Public: true})
@@ -1297,10 +1297,10 @@ func TestDeclareAuth_MethodAware_GETDoesNotBypassForPOSTOnly(t *testing.T) {
 	}
 	r := New(WithAuthMiddleware(verifier))
 
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
 	// Register the GET handler with a policy so it is covered by policy enforcement;
 	// auth middleware will require a valid token for GET.
-	auth.Mount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Policy: authtest.RequireAuthenticated()})
+	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Policy: authtest.RequireAuthenticated()})
 	require.NoError(t, r.FinalizeAuth())
 
 	// POST without token → public, 200.

--- a/runtime/worker/worker.go
+++ b/runtime/worker/worker.go
@@ -56,6 +56,13 @@ func (g *WorkerGroup) Add(w Worker) {
 // Start launches all workers concurrently. It blocks until all workers
 // return. If any worker returns a non-context error, all sibling workers are
 // cancelled via a shared context. The first error encountered is returned.
+//
+// Early-exit handling: a worker that returns nil while the group context is
+// still live has terminated its long-running loop without signalling failure
+// — historically that produced a silent firstErr=nil. The group now records
+// kworker.ErrWorkerExitedEarly so callers can errors.Is-detect the abnormal
+// signal. Returns from a Stop or context cancellation propagate untouched
+// (errors.Is(err, context.Canceled) is honoured).
 func (g *WorkerGroup) Start(ctx context.Context) error {
 	g.mu.Lock()
 	workers := make([]Worker, len(g.workers))
@@ -75,11 +82,16 @@ func (g *WorkerGroup) Start(ctx context.Context) error {
 		wg.Add(1)
 		go func(w Worker) {
 			defer wg.Done()
-			if err := w.Start(groupCtx); err != nil {
-				slog.Error("worker exited with error", slog.Any("error", err))
-				errOnce.Do(func() { firstErr = err })
-				cancel() // cancel sibling workers
+			err := w.Start(groupCtx)
+			if err == nil && groupCtx.Err() == nil {
+				err = kworker.ErrWorkerExitedEarly
 			}
+			if err == nil {
+				return
+			}
+			slog.Error("worker exited with error", slog.Any("error", err))
+			errOnce.Do(func() { firstErr = err })
+			cancel() // cancel sibling workers
 		}(w)
 	}
 

--- a/runtime/worker/worker.go
+++ b/runtime/worker/worker.go
@@ -9,6 +9,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 
@@ -89,7 +90,9 @@ func (g *WorkerGroup) Start(ctx context.Context) error {
 			if err == nil {
 				return
 			}
-			slog.Error("worker exited with error", slog.Any("error", err))
+			slog.Error("worker exited with error",
+				slog.String("worker_type", fmt.Sprintf("%T", w)),
+				slog.Any("error", err))
 			errOnce.Do(func() { firstErr = err })
 			cancel() // cancel sibling workers
 		}(w)

--- a/runtime/worker/worker_test.go
+++ b/runtime/worker/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	kworker "github.com/ghbvf/gocell/kernel/worker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,6 +84,23 @@ func TestWorkerGroup_StartError(t *testing.T) {
 	err := g.Start(context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, "start failed", err.Error())
+}
+
+// earlyExitWorker.Start returns nil immediately (without ctx cancellation).
+// WorkerGroup must convert that into ErrWorkerExitedEarly so callers can
+// detect the abnormal signal via errors.Is.
+type earlyExitWorker struct{}
+
+func (earlyExitWorker) Start(_ context.Context) error { return nil }
+func (earlyExitWorker) Stop(_ context.Context) error  { return nil }
+
+func TestWorkerGroup_NilExitMappedToErrExitedEarly(t *testing.T) {
+	g := NewWorkerGroup()
+	g.Add(earlyExitWorker{})
+
+	err := g.Start(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, kworker.ErrWorkerExitedEarly)
 }
 
 func TestWorkerGroup_Stop(t *testing.T) {

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -11,11 +11,13 @@ package archtest
 //   - `func init()` (init cannot return error; package-level invariant violations
 //     are by definition fatal)
 //
-// File-level whitelist (architectural panic permitted):
-//   - kernel/wrapper/lifecycle.go — `recoverAndFinishWithRedactor` is the
-//     middle of a `defer recover()` chain that re-panics so the outer
-//     Recovery middleware can record + serialize the panic. Refactoring
-//     it to error would dismantle the entire recover propagation idiom.
+// Function-level whitelist (architectural panic permitted):
+//   - kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor — middle
+//     of a `defer recover()` chain that re-panics so the outer Recovery
+//     middleware can record + serialize the panic. Refactoring it to
+//     error would dismantle the entire recover propagation idiom. Any
+//     OTHER error-less function in lifecycle.go that contains panic() is
+//     still reported as a violation.
 //
 // Enforced file scope (PR-MODE-6):
 //   - kernel/wrapper/handler.go, consumer.go, spec.go, lifecycle.go (whitelisted)
@@ -47,7 +49,7 @@ const ruleErrorFirstAPI01 = "ERROR-FIRST-API-01"
 
 // errorFirstEnforcedFiles are the relative paths (from module root) of files
 // whose declarations must satisfy ERROR-FIRST-API-01. Slash-separated for
-// portability; convertedwith filepath.FromSlash before stat.
+// portability; converted with filepath.FromSlash before stat.
 var errorFirstEnforcedFiles = []string{
 	"kernel/wrapper/handler.go",
 	"kernel/wrapper/consumer.go",
@@ -59,16 +61,19 @@ var errorFirstEnforcedFiles = []string{
 	"kernel/idempotency/inmem.go",
 	"kernel/worker/worker.go",
 	"runtime/eventrouter/router.go",
+	"runtime/eventrouter/contract_middleware.go",
 	"runtime/auth/route.go",
 	"runtime/worker/worker.go",
 	"adapters/postgres/refresh_store.go",
 }
 
-// errorFirstWhitelistedFiles are slash-separated paths that the rule scans but
-// allows panic(s) in error-less functions. ADR-pinned (≤ 5 entries):
-// docs/architecture/202604270030-architectural-panic-whitelist.md
-var errorFirstWhitelistedFiles = map[string]string{
-	"kernel/wrapper/lifecycle.go": "recoverAndFinishWithRedactor re-panics from defer recover",
+// errorFirstWhitelistedFunctions maps "<rel-path>::<funcName>" to a
+// justification. The rule SCANS the file but skips only the listed function;
+// any other error-less function in the same file that contains panic() is
+// still reported as a violation. ADR-pinned in
+// docs/architecture/202604270030-architectural-panic-whitelist.md (§4).
+var errorFirstWhitelistedFunctions = map[string]string{
+	"kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor": "re-panics from defer recover so outer Recovery middleware can serialize the panic",
 }
 
 // errorFirstViolation describes a single ERROR-FIRST-API-01 violation.
@@ -86,9 +91,6 @@ func TestErrorFirstAPI01(t *testing.T) {
 
 	var violations []errorFirstViolation
 	for _, rel := range errorFirstEnforcedFiles {
-		if _, whitelisted := errorFirstWhitelistedFiles[rel]; whitelisted {
-			continue
-		}
 		abs := filepath.Join(root, filepath.FromSlash(rel))
 		v := scanFileForErrorFirstViolations(t, abs, rel)
 		violations = append(violations, v...)
@@ -129,6 +131,10 @@ func scanFileForErrorFirstViolations(t *testing.T, abs, rel string) []errorFirst
 			continue
 		}
 		if signatureReturnsError(fd.Type.Results) {
+			continue
+		}
+		whitelistKey := rel + "::" + fd.Name.Name
+		if _, whitelisted := errorFirstWhitelistedFunctions[whitelistKey]; whitelisted {
 			continue
 		}
 		findPanicCalls(fd.Body, func(callPos token.Pos) {

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -1,0 +1,209 @@
+package archtest
+
+// error_first_test.go enforces ERROR-FIRST-API-01: in the explicitly enrolled
+// files (PR-MODE-6 scope), exported and unexported function declarations whose
+// return signature does NOT include an error MUST NOT contain a `panic(...)`
+// call in the function body.
+//
+// Auto-exemptions:
+//   - Function name starts with "Must" (Go community convention for the
+//     panic-on-misuse twin of an error-returning constructor)
+//   - `func init()` (init cannot return error; package-level invariant violations
+//     are by definition fatal)
+//
+// File-level whitelist (architectural panic permitted):
+//   - kernel/wrapper/lifecycle.go — `recoverAndFinishWithRedactor` is the
+//     middle of a `defer recover()` chain that re-panics so the outer
+//     Recovery middleware can record + serialize the panic. Refactoring
+//     it to error would dismantle the entire recover propagation idiom.
+//
+// Enforced file scope (PR-MODE-6):
+//   - kernel/wrapper/handler.go, consumer.go, spec.go, lifecycle.go (whitelisted)
+//   - kernel/cell/auth_plan.go
+//   - kernel/outbox/entry_id.go, envelope.go
+//   - kernel/idempotency/inmem.go
+//   - kernel/worker/worker.go
+//   - runtime/eventrouter/router.go
+//   - runtime/auth/route.go
+//   - runtime/worker/worker.go
+//   - adapters/postgres/refresh_store.go
+//
+// Future PRs may extend the scope; see
+// docs/architecture/202604270030-architectural-panic-whitelist.md §Roadmap.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const ruleErrorFirstAPI01 = "ERROR-FIRST-API-01"
+
+// errorFirstEnforcedFiles are the relative paths (from module root) of files
+// whose declarations must satisfy ERROR-FIRST-API-01. Slash-separated for
+// portability; convertedwith filepath.FromSlash before stat.
+var errorFirstEnforcedFiles = []string{
+	"kernel/wrapper/handler.go",
+	"kernel/wrapper/consumer.go",
+	"kernel/wrapper/spec.go",
+	"kernel/wrapper/lifecycle.go",
+	"kernel/cell/auth_plan.go",
+	"kernel/outbox/entry_id.go",
+	"kernel/outbox/envelope.go",
+	"kernel/idempotency/inmem.go",
+	"kernel/worker/worker.go",
+	"runtime/eventrouter/router.go",
+	"runtime/auth/route.go",
+	"runtime/worker/worker.go",
+	"adapters/postgres/refresh_store.go",
+}
+
+// errorFirstWhitelistedFiles are slash-separated paths that the rule scans but
+// allows panic(s) in error-less functions. ADR-pinned (≤ 5 entries):
+// docs/architecture/202604270030-architectural-panic-whitelist.md
+var errorFirstWhitelistedFiles = map[string]string{
+	"kernel/wrapper/lifecycle.go": "recoverAndFinishWithRedactor re-panics from defer recover",
+}
+
+// errorFirstViolation describes a single ERROR-FIRST-API-01 violation.
+type errorFirstViolation struct {
+	File     string // relative slash path from module root
+	Line     int
+	FuncName string
+	Reason   string
+}
+
+// TestErrorFirstAPI01 walks the enforced file list and reports panic() calls
+// inside error-less function declarations.
+func TestErrorFirstAPI01(t *testing.T) {
+	root := findModuleRoot(t)
+
+	var violations []errorFirstViolation
+	for _, rel := range errorFirstEnforcedFiles {
+		if _, whitelisted := errorFirstWhitelistedFiles[rel]; whitelisted {
+			continue
+		}
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		v := scanFileForErrorFirstViolations(t, abs, rel)
+		violations = append(violations, v...)
+	}
+
+	if len(violations) > 0 {
+		t.Logf("%s: %d violation(s):", ruleErrorFirstAPI01, len(violations))
+		for _, v := range violations {
+			t.Logf("  %s:%d  %s — %s", v.File, v.Line, v.FuncName, v.Reason)
+		}
+	}
+	assert.Empty(t, violations,
+		"%s: error-less functions must not contain panic(); use error-returning signature, "+
+			"rename to Must*, or add an ADR-justified file-level whitelist entry "+
+			"(see docs/architecture/202604270030-architectural-panic-whitelist.md)",
+		ruleErrorFirstAPI01)
+}
+
+// scanFileForErrorFirstViolations parses a single Go source file and returns
+// any panic() call inside an error-less function (excluding Must*-prefixed
+// functions and init).
+func scanFileForErrorFirstViolations(t *testing.T, abs, rel string) []errorFirstViolation {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, abs, nil, parser.SkipObjectResolution|parser.ParseComments)
+	require.NoErrorf(t, err, "%s: parse failed", rel)
+
+	var violations []errorFirstViolation
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		if isInitFunc(fd) {
+			continue
+		}
+		if strings.HasPrefix(fd.Name.Name, "Must") {
+			continue
+		}
+		if signatureReturnsError(fd.Type.Results) {
+			continue
+		}
+		findPanicCalls(fd.Body, func(callPos token.Pos) {
+			violations = append(violations, errorFirstViolation{
+				File:     rel,
+				Line:     fset.Position(callPos).Line,
+				FuncName: fd.Name.Name,
+				Reason:   "function does not return error but contains panic()",
+			})
+		})
+	}
+	return violations
+}
+
+// isInitFunc returns true if fd is `func init()` (no receiver, no params, no
+// return values, name "init").
+func isInitFunc(fd *ast.FuncDecl) bool {
+	if fd.Name.Name != "init" {
+		return false
+	}
+	if fd.Recv != nil {
+		return false
+	}
+	return true
+}
+
+// signatureReturnsError returns true if the FieldList contains at least one
+// field whose type is the identifier `error` (built-in) — handles single
+// return, named returns, and tuple returns.
+func signatureReturnsError(results *ast.FieldList) bool {
+	if results == nil {
+		return false
+	}
+	for _, field := range results.List {
+		if isErrorIdent(field.Type) {
+			return true
+		}
+	}
+	return false
+}
+
+// isErrorIdent returns true when expr is the unqualified identifier `error`.
+// Qualified types (e.g., pkg.MyError) and pointer/slice/array wrappers are
+// intentionally rejected — only the built-in `error` interface satisfies the
+// rule.
+func isErrorIdent(expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return id.Name == "error"
+}
+
+// findPanicCalls walks body and invokes onPanic for every call to the built-in
+// `panic` function. Calls inside nested function literals are also reported —
+// a closure that panics still violates the rule unless the enclosing function
+// returns error (which would let the closure propagate the failure instead).
+//
+// Built-in panic detection: the rule matches `panic(...)` where the Fun is the
+// unqualified identifier `panic`. Re-defined locals (e.g. `var panic = func()`)
+// would shadow the built-in; we treat them the same as the built-in to keep
+// the rule conservative — there is no production reason to shadow `panic`.
+func findPanicCalls(body *ast.BlockStmt, onPanic func(token.Pos)) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name == "panic" {
+			onPanic(call.Pos())
+		}
+		return true
+	})
+}


### PR DESCRIPTION
## Summary

PR-MODE-6 of the **反复模式根治** plan (`docs/plans/202604270020-1-2-ci-3-claude-ship-reactive-bachman.md`).

Converts **~33 panic sites** across 11 enrolled files into either error-returning APIs (with `Must*` composition-root wrappers) or `Must*` rename. Adds `tools/archtest/error_first_test.go::TestErrorFirstAPI01` as a static rule that prevents regression. ADR pins the **1**-entry architectural panic whitelist.

### Scope

| Change | Sites |
|---|---|
| `kernel/cell/auth_plan.go` `NewAuthJWT/NewAuthJWTFromAssembly/NewAuthServiceToken` → `(plan, error)` + `MustNewAuth*` | 5 |
| `kernel/wrapper/handler.go::HTTPHandler` → `(handler, error)` + `MustHTTPHandler` | 3 |
| `kernel/wrapper/consumer.go::WrapConsumer` → `(consumer, error)` + `MustWrapConsumer` | 3 |
| `runtime/eventrouter/router.go::AddContractHandler` → `error`; `kernel/cell.EventRouter` interface signature updated; cells' `RegisterSubscriptions` propagate | 4 |
| `runtime/auth/route.go::Mount` → `error` + `MustMount`; `cell.RouteGroup.Register` signature → `func(RouteMux) error`; bootstrap phase5 propagates | 9 |
| `adapters/postgres/refresh_store.go::NewRefreshStore` → `(*PGRefreshStore, error)` + `MustNewRefreshStore` | 4 |
| `kernel/outbox/entry_id.go::NewEntryID` → `(string, error)` + `MustNewEntryID` | 1 |
| `kernel/outbox/envelope.go::MarshalDirectEnvelope` → renamed `MustMarshalDirectEnvelope` (Must auto-exempt) | 3 |
| `kernel/idempotency/inmem.go::newToken` → `(string, error)`; `Claim` propagates | 1 |
| `runtime/worker/worker.go::WorkerGroup.Start` records `kworker.ErrWorkerExitedEarly` for nil-exit-while-live | n/a (sentinel) |
| `kernel/governance/rules_http_response_alignment.go::isAuthMountCall` recognizes both `auth.Mount` and `auth.MustMount` | 1 |
| `tools/archtest/error_first_test.go` new rule TestErrorFirstAPI01 (1-entry whitelist: `kernel/wrapper/lifecycle.go`) | new |
| `docs/architecture/202604270030-architectural-panic-whitelist.md` ADR | new |

### Architectural Panic Whitelist (ADR-pinned, 1 entry)

| File | Justification |
|---|---|
| `kernel/wrapper/lifecycle.go` | `recoverAndFinishWithRedactor` re-panics from `defer recover()` so the outer Recovery middleware can serialize the panic. Refactoring it to return error would dismantle the recover propagation idiom. |

Auto-exempt: `Must*`-prefixed names, `func init()`. ADR documents the scope-expansion roadmap (kernel/persistence, runtime/distlock, runtime/auth/refresh/memstore, runtime/http/router, etc).

### Test split

Existing panic-asserting tests split into `Test*_ReturnsError*` (canonical error path) + `TestMust*_Panics*` (the wrapper).

## Refs

- `Refs: PR-MODE-6` (parent plan: `docs/plans/202604270020-1-2-ci-3-claude-ship-reactive-bachman.md`)
- `ref: regexp.MustCompile / template.Must / kubernetes/client-go MustGetSelfLink` — `Must*` convention
- `ref: ThreeDotsLabs/watermill router.go` — eventrouter AddContractHandler signature

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags=integration ./...` clean
- [x] `go test ./...` all green
- [x] `go test ./tools/archtest/... -race` — TestErrorFirstAPI01 PASSES
- [x] `go run ./cmd/gocell validate --strict` — 0 errors / 0 warnings
- [x] `go run ./cmd/gocell check contract-health` — 0 errors / 0 warnings
- [x] `golangci-lint run ./...` — 0 issues
- [x] CI integration command: `go test -tags=integration,e2e ./adapters/... ./tests/integration/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)