### PR TITLE
PR-MODE-5 CONTRACT-INPUT-CONSTRAINT — FMT-25 + 全仓 input 约束消化

### DIFF
--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -436,10 +436,10 @@ func TestHttpAuthUserChangePasswordV1Serve(t *testing.T) {
 	}}
 	handler, _ := setupContractHandlerWithIssuer(t, stubIssuer)
 
-	// Validate request schema.
-	c.ValidateRequest(t, []byte(`{"oldPassword":"oldP@ss","newPassword":"newP@ss"}`))
-	c.MustRejectRequest(t, []byte(`{"oldPassword":"oldP@ss"}`))                           // missing newPassword
-	c.MustRejectRequest(t, []byte(`{"oldPassword":"old","newPassword":"new","extra":1}`)) // additionalProperties
+	// Validate request schema. Passwords must satisfy minLength:8 / maxLength:72 (FMT-24 + bcrypt).
+	c.ValidateRequest(t, []byte(`{"oldPassword":"oldP@ss12","newPassword":"newP@ss12"}`))
+	c.MustRejectRequest(t, []byte(`{"oldPassword":"oldP@ss12"}`))                                   // missing newPassword
+	c.MustRejectRequest(t, []byte(`{"oldPassword":"old12345","newPassword":"new12345","extra":1}`)) // additionalProperties
 
 	// Create a user to change password on.
 	userID := createUserForContractTest(t, handler, createContract)
@@ -484,10 +484,10 @@ func TestHttpAuthUserCreateV1_RequirePasswordResetField(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 
-	// requirePasswordReset is optional — should be accepted.
-	c.ValidateRequest(t, []byte(`{"username":"u","email":"u@u.com","password":"p","requirePasswordReset":true}`))
+	// requirePasswordReset is optional — should be accepted (password ≥ 8 chars per FMT-24).
+	c.ValidateRequest(t, []byte(`{"username":"u","email":"u@u.com","password":"p1234567","requirePasswordReset":true}`))
 	// Without the optional field — also valid.
-	c.ValidateRequest(t, []byte(`{"username":"u","email":"u@u.com","password":"p"}`))
+	c.ValidateRequest(t, []byte(`{"username":"u","email":"u@u.com","password":"p1234567"}`))
 }
 
 func TestHttpAuthUserPatchV1_RequirePasswordResetField(t *testing.T) {

--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -436,7 +436,7 @@ func TestHttpAuthUserChangePasswordV1Serve(t *testing.T) {
 	}}
 	handler, _ := setupContractHandlerWithIssuer(t, stubIssuer)
 
-	// Validate request schema. Passwords must satisfy minLength:8 / maxLength:72 (FMT-24 + bcrypt).
+	// Validate request schema. Passwords must satisfy minLength:8 / maxLength:72 (FMT-25 + bcrypt).
 	c.ValidateRequest(t, []byte(`{"oldPassword":"oldP@ss12","newPassword":"newP@ss12"}`))
 	c.MustRejectRequest(t, []byte(`{"oldPassword":"oldP@ss12"}`))                                   // missing newPassword
 	c.MustRejectRequest(t, []byte(`{"oldPassword":"old12345","newPassword":"new12345","extra":1}`)) // additionalProperties
@@ -484,7 +484,7 @@ func TestHttpAuthUserCreateV1_RequirePasswordResetField(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 
-	// requirePasswordReset is optional — should be accepted (password ≥ 8 chars per FMT-24).
+	// requirePasswordReset is optional — should be accepted (password ≥ 8 chars per FMT-25).
 	c.ValidateRequest(t, []byte(`{"username":"u","email":"u@u.com","password":"p1234567","requirePasswordReset":true}`))
 	// Without the optional field — also valid.
 	c.ValidateRequest(t, []byte(`{"username":"u","email":"u@u.com","password":"p1234567"}`))

--- a/cells/accesscore/slices/sessionlogin/contract_test.go
+++ b/cells/accesscore/slices/sessionlogin/contract_test.go
@@ -10,7 +10,7 @@ func TestHttpAuthLoginV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.auth.login.v1")
 
-	c.ValidateRequest(t, []byte(`{"username":"alice","password":"secret"}`))
+	c.ValidateRequest(t, []byte(`{"username":"alice","password":"secret12"}`))
 	c.ValidateResponse(t, []byte(`{"data":{"accessToken":"tok","refreshToken":"rtok","expiresAt":"2026-01-01T00:00:00Z","sessionId":"sess-1","userId":"usr-1","passwordResetRequired":false}}`))
 	c.MustRejectRequest(t, []byte(`{"username":"alice"}`))
 	// Schema enforces additionalProperties:false — unknown fields must be rejected.

--- a/cells/accesscore/slices/sessionrefresh/contract_test.go
+++ b/cells/accesscore/slices/sessionrefresh/contract_test.go
@@ -10,7 +10,7 @@ func TestHttpAuthRefreshV1Serve(t *testing.T) {
 	root := contracttest.ContractsRoot()
 	c := contracttest.LoadByID(t, root, "http.auth.refresh.v1")
 
-	c.ValidateRequest(t, []byte(`{"refreshToken":"old-tok"}`))
+	c.ValidateRequest(t, []byte(`{"refreshToken":"old-token-with-min-len20"}`))
 	c.ValidateResponse(t, []byte(`{"data":{"accessToken":"new","refreshToken":"new-r","expiresAt":"2026-01-01T00:00:00Z","sessionId":"sess-1","userId":"usr-1","passwordResetRequired":false}}`))
 	c.MustRejectRequest(t, []byte(`{"refreshToken":"t","extra":"bad"}`))
 	// Schema enforces additionalProperties:false — unknown fields must be rejected.

--- a/contracts/http/audit/list/v1/contract.yaml
+++ b/contracts/http/audit/list/v1/contract.yaml
@@ -14,9 +14,13 @@ endpoints:
       cursor:
         type: string
         required: false
+        minLength: 0
+        maxLength: 256
       limit:
         type: integer
         required: false
+        minimum: 1
+        maximum: 500
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/auth/login/v1/request.schema.json
+++ b/contracts/http/auth/login/v1/request.schema.json
@@ -3,8 +3,8 @@
   "title": "http.auth.login.v1.request",
   "type": "object",
   "properties": {
-    "username": { "type": "string" },
-    "password": { "type": "string" }
+    "username": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "password": { "type": "string", "minLength": 8, "maxLength": 72 }
   },
   "required": ["username", "password"],
   "additionalProperties": false

--- a/contracts/http/auth/refresh/v1/request.schema.json
+++ b/contracts/http/auth/refresh/v1/request.schema.json
@@ -3,7 +3,7 @@
   "title": "http.auth.refresh.v1.request",
   "type": "object",
   "properties": {
-    "refreshToken": { "type": "string" }
+    "refreshToken": { "type": "string", "minLength": 20, "maxLength": 4096 }
   },
   "required": ["refreshToken"],
   "additionalProperties": false

--- a/contracts/http/auth/role/assign/v1/request.schema.json
+++ b/contracts/http/auth/role/assign/v1/request.schema.json
@@ -3,8 +3,8 @@
   "title": "http.auth.role.assign.v1.request",
   "type": "object",
   "properties": {
-    "userId": { "type": "string", "minLength": 1 },
-    "roleId": { "type": "string", "minLength": 1 }
+    "userId": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "roleId": { "type": "string", "minLength": 1, "maxLength": 64 }
   },
   "required": ["userId", "roleId"],
   "additionalProperties": false

--- a/contracts/http/auth/role/check/v1/contract.yaml
+++ b/contracts/http/auth/role/check/v1/contract.yaml
@@ -16,6 +16,8 @@ endpoints:
         format: uuid
       roleName:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/auth/role/list/v1/contract.yaml
+++ b/contracts/http/auth/role/list/v1/contract.yaml
@@ -18,9 +18,13 @@ endpoints:
       cursor:
         type: string
         required: false
+        minLength: 0
+        maxLength: 256
       limit:
         type: integer
         required: false
+        minimum: 1
+        maximum: 500
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/auth/role/revoke/v1/request.schema.json
+++ b/contracts/http/auth/role/revoke/v1/request.schema.json
@@ -3,8 +3,8 @@
   "title": "http.auth.role.revoke.v1.request",
   "type": "object",
   "properties": {
-    "userId": { "type": "string", "minLength": 1 },
-    "roleId": { "type": "string", "minLength": 1 }
+    "userId": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "roleId": { "type": "string", "minLength": 1, "maxLength": 64 }
   },
   "required": ["userId", "roleId"],
   "additionalProperties": false

--- a/contracts/http/auth/user/change-password/v1/request.schema.json
+++ b/contracts/http/auth/user/change-password/v1/request.schema.json
@@ -4,10 +4,14 @@
   "type": "object",
   "properties": {
     "oldPassword": {
-      "type": "string"
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 72
     },
     "newPassword": {
-      "type": "string"
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 72
     }
   },
   "required": ["oldPassword", "newPassword"],

--- a/contracts/http/auth/user/create/v1/request.schema.json
+++ b/contracts/http/auth/user/create/v1/request.schema.json
@@ -4,13 +4,19 @@
   "type": "object",
   "properties": {
     "username": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
     },
     "email": {
-      "type": "string"
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 320
     },
     "password": {
-      "type": "string"
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 72
     },
     "requirePasswordReset": {
       "type": "boolean"

--- a/contracts/http/auth/user/patch/v1/request.schema.json
+++ b/contracts/http/auth/user/patch/v1/request.schema.json
@@ -4,13 +4,19 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
     },
     "email": {
-      "type": "string"
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 320
     },
     "status": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32
     },
     "requirePasswordReset": {
       "type": "boolean"

--- a/contracts/http/auth/user/update/v1/request.schema.json
+++ b/contracts/http/auth/user/update/v1/request.schema.json
@@ -4,7 +4,9 @@
   "type": "object",
   "properties": {
     "email": {
-      "type": "string"
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 320
     }
   },
   "additionalProperties": false

--- a/contracts/http/config/delete/v1/contract.yaml
+++ b/contracts/http/config/delete/v1/contract.yaml
@@ -15,6 +15,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 204
     noContent: true
     responses:

--- a/contracts/http/config/flags/create/v1/request.schema.json
+++ b/contracts/http/config/flags/create/v1/request.schema.json
@@ -4,10 +4,10 @@
   "type": "object",
   "required": ["key"],
   "properties": {
-    "key": { "type": "string", "minLength": 1 },
+    "key": { "type": "string", "minLength": 1, "maxLength": 128 },
     "enabled": { "type": "boolean" },
     "rolloutPercentage": { "type": "integer", "minimum": 0, "maximum": 100 },
-    "description": { "type": "string" }
+    "description": { "type": "string", "minLength": 0, "maxLength": 1024 }
   },
   "additionalProperties": false
 }

--- a/contracts/http/config/flags/delete/v1/contract.yaml
+++ b/contracts/http/config/flags/delete/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 204
     noContent: true
     responses:

--- a/contracts/http/config/flags/evaluate/v1/contract.yaml
+++ b/contracts/http/config/flags/evaluate/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/flags/evaluate/v1/request.schema.json
+++ b/contracts/http/config/flags/evaluate/v1/request.schema.json
@@ -3,7 +3,7 @@
   "title": "http.config.flags.evaluate.v1.request",
   "type": "object",
   "properties": {
-    "subject": { "type": "string" }
+    "subject": { "type": "string", "minLength": 1, "maxLength": 256 }
   },
   "required": ["subject"],
   "additionalProperties": false

--- a/contracts/http/config/flags/get/v1/contract.yaml
+++ b/contracts/http/config/flags/get/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/flags/list/v1/contract.yaml
+++ b/contracts/http/config/flags/list/v1/contract.yaml
@@ -14,9 +14,13 @@ endpoints:
       cursor:
         type: string
         required: false
+        minLength: 0
+        maxLength: 256
       limit:
         type: integer
         required: false
+        minimum: 1
+        maximum: 500
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/flags/toggle/v1/contract.yaml
+++ b/contracts/http/config/flags/toggle/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/flags/update/v1/contract.yaml
+++ b/contracts/http/config/flags/update/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/flags/update/v1/request.schema.json
+++ b/contracts/http/config/flags/update/v1/request.schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "enabled": { "type": "boolean" },
     "rolloutPercentage": { "type": "integer", "minimum": 0, "maximum": 100 },
-    "description": { "type": "string" }
+    "description": { "type": "string", "minLength": 0, "maxLength": 1024 }
   },
   "required": ["enabled", "rolloutPercentage", "description"],
   "additionalProperties": false

--- a/contracts/http/config/get/v1/contract.yaml
+++ b/contracts/http/config/get/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/internal/get/v1/contract.yaml
+++ b/contracts/http/config/internal/get/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/list/v1/contract.yaml
+++ b/contracts/http/config/list/v1/contract.yaml
@@ -14,9 +14,13 @@ endpoints:
       cursor:
         type: string
         required: false
+        minLength: 0
+        maxLength: 256
       limit:
         type: integer
         required: false
+        minimum: 1
+        maximum: 500
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/publish/v1/contract.yaml
+++ b/contracts/http/config/publish/v1/contract.yaml
@@ -15,6 +15,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 201
     noContent: false
     responses:

--- a/contracts/http/config/rollback/v1/contract.yaml
+++ b/contracts/http/config/rollback/v1/contract.yaml
@@ -16,6 +16,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/rollback/v1/request.schema.json
+++ b/contracts/http/config/rollback/v1/request.schema.json
@@ -3,7 +3,7 @@
   "title": "http.config.rollback.v1.request",
   "type": "object",
   "properties": {
-    "version": { "type": "integer", "minimum": 1 }
+    "version": { "type": "integer", "minimum": 1, "maximum": 99999 }
   },
   "required": ["version"],
   "additionalProperties": false

--- a/contracts/http/config/update/v1/contract.yaml
+++ b/contracts/http/config/update/v1/contract.yaml
@@ -15,6 +15,8 @@ endpoints:
     pathParams:
       key:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/config/update/v1/request.schema.json
+++ b/contracts/http/config/update/v1/request.schema.json
@@ -3,7 +3,7 @@
   "title": "http.config.update.v1.request",
   "type": "object",
   "properties": {
-    "value": { "type": "string" }
+    "value": { "type": "string", "minLength": 0, "maxLength": 4096 }
   },
   "required": ["value"],
   "additionalProperties": false

--- a/contracts/http/config/write/v1/request.schema.json
+++ b/contracts/http/config/write/v1/request.schema.json
@@ -3,8 +3,8 @@
   "title": "http.config.write.v1.request",
   "type": "object",
   "properties": {
-    "key": { "type": "string" },
-    "value": { "type": "string" },
+    "key": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "value": { "type": "string", "minLength": 0, "maxLength": 4096 },
     "sensitive": { "type": "boolean" }
   },
   "required": ["key", "value"],

--- a/examples/iotdevice/contracts/command/device-command/ack/v1/request.schema.json
+++ b/examples/iotdevice/contracts/command/device-command/ack/v1/request.schema.json
@@ -5,7 +5,9 @@
   "properties": {
     "reason": {
       "type": "string",
-      "enum": ["success", "failure", "rejected"]
+      "enum": ["success", "failure", "rejected"],
+      "minLength": 1,
+      "maxLength": 32
     }
   },
   "required": ["reason"],

--- a/examples/iotdevice/contracts/command/device-command/enqueue/v1/request.schema.json
+++ b/examples/iotdevice/contracts/command/device-command/enqueue/v1/request.schema.json
@@ -3,8 +3,8 @@
   "title": "command.device-command.enqueue.v1.request",
   "type": "object",
   "properties": {
-    "commandType": { "type": "string" },
-    "payload": { "type": "string" }
+    "commandType": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "payload": { "type": "string", "minLength": 0, "maxLength": 4096 }
   },
   "required": ["payload"],
   "additionalProperties": false

--- a/examples/iotdevice/contracts/http/device/command/ack/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/command/ack/v1/contract.yaml
@@ -13,8 +13,12 @@ endpoints:
     pathParams:
       id:
         type: string
+        minLength: 1
+        maxLength: 256
       cmdId:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/examples/iotdevice/contracts/http/device/command/ack/v1/request.schema.json
+++ b/examples/iotdevice/contracts/http/device/command/ack/v1/request.schema.json
@@ -5,7 +5,9 @@
   "properties": {
     "reason": {
       "type": "string",
-      "enum": ["success", "failure", "rejected"]
+      "enum": ["success", "failure", "rejected"],
+      "minLength": 1,
+      "maxLength": 32
     }
   },
   "required": ["reason"],

--- a/examples/iotdevice/contracts/http/device/command/dequeue/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/command/dequeue/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       id:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/examples/iotdevice/contracts/http/device/command/enqueue/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/command/enqueue/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       id:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 201
     noContent: false
     responses:

--- a/examples/iotdevice/contracts/http/device/command/enqueue/v1/request.schema.json
+++ b/examples/iotdevice/contracts/http/device/command/enqueue/v1/request.schema.json
@@ -3,8 +3,8 @@
   "title": "http.device.command.enqueue.v1.request",
   "type": "object",
   "properties": {
-    "commandType": { "type": "string" },
-    "payload": { "type": "string" }
+    "commandType": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "payload": { "type": "string", "minLength": 0, "maxLength": 4096 }
   },
   "required": ["payload"],
   "additionalProperties": false

--- a/examples/iotdevice/contracts/http/device/command/extend-lease/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/command/extend-lease/v1/contract.yaml
@@ -13,8 +13,12 @@ endpoints:
     pathParams:
       id:
         type: string
+        minLength: 1
+        maxLength: 256
       cmdId:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/examples/iotdevice/contracts/http/device/command/report/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/command/report/v1/contract.yaml
@@ -13,8 +13,12 @@ endpoints:
     pathParams:
       id:
         type: string
+        minLength: 1
+        maxLength: 256
       cmdId:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
 schemaRefs:

--- a/examples/iotdevice/contracts/http/device/register/v1/request.schema.json
+++ b/examples/iotdevice/contracts/http/device/register/v1/request.schema.json
@@ -3,7 +3,7 @@
   "title": "http.device.register.v1.request",
   "type": "object",
   "properties": {
-    "name": { "type": "string" }
+    "name": { "type": "string", "minLength": 1, "maxLength": 128 }
   },
   "required": ["name"],
   "additionalProperties": false

--- a/examples/iotdevice/contracts/http/device/status/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/status/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       id:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
 schemaRefs:

--- a/examples/todoorder/contracts/http/order/create/v1/request.schema.json
+++ b/examples/todoorder/contracts/http/order/create/v1/request.schema.json
@@ -3,7 +3,7 @@
   "title": "http.order.create.v1.request",
   "type": "object",
   "properties": {
-    "item": { "type": "string" }
+    "item": { "type": "string", "minLength": 1, "maxLength": 256 }
   },
   "required": ["item"],
   "additionalProperties": false

--- a/examples/todoorder/contracts/http/order/get/v1/contract.yaml
+++ b/examples/todoorder/contracts/http/order/get/v1/contract.yaml
@@ -13,6 +13,8 @@ endpoints:
     pathParams:
       id:
         type: string
+        minLength: 1
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/kernel/governance/rules_strict_extra.go
+++ b/kernel/governance/rules_strict_extra.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/contracts"
 )
 
-// Rule ID constants for FMT-20..FMT-24. Extracted so that each rule ID string
+// Rule ID constants for FMT-20..FMT-25. Extracted so that each rule ID string
 // is declared in exactly one place; Sonar code-smell rule S1192 (duplicate
 // string literals) no longer fires for these identifiers.
 const (
@@ -21,7 +21,7 @@ const (
 	ruleFMT21 = "FMT-21"
 	ruleFMT22 = "FMT-22"
 	ruleFMT23 = "FMT-23"
-	ruleFMT24 = "FMT-24"
+	ruleFMT25 = "FMT-25"
 )
 
 // --- FMT-20 (formerly FMT-RESPONSE-STRICT-01) ---
@@ -126,28 +126,116 @@ func walkSchemaObject(node map[string]any, path string, missing *[]string) {
 }
 
 // walkSchemaTreeDepth is the shared depth-guarded JSON-schema visitor used by
-// FMT-20 (additionalProperties) and FMT-24 (input constraints). It applies
-// `visit` at every node, then recurses into properties (for objects) and
-// items (for arrays). depth > 32 causes early return to prevent unbounded
-// recursion on pathological schemas.
+// FMT-20 (additionalProperties) and FMT-25 (input constraints). It applies
+// `visit` at every node, resolves local $ref targets, then recurses through
+// object properties, array items, patternProperties, and common composition
+// keywords. depth > 32 causes early return to prevent unbounded recursion on
+// pathological schemas.
 //
 // Note: visit is called at every node — branch on node["type"] inside visit
 // if a check applies only to objects/strings/integers etc.
 func walkSchemaTreeDepth(node map[string]any, path string, depth int, visit func(node map[string]any, path string)) {
+	walkSchemaTreeDepthRoot(node, node, path, depth, map[string]bool{}, visit)
+}
+
+func walkSchemaTreeDepthRoot(root, node map[string]any, path string, depth int, seenRefs map[string]bool, visit func(node map[string]any, path string)) {
 	if depth > 32 {
 		return
 	}
 	visit(node, path)
-	if props, ok := node["properties"].(map[string]any); ok {
-		for key, val := range props {
-			if child, ok := val.(map[string]any); ok {
-				walkSchemaTreeDepth(child, path+"."+key, depth+1, visit)
+	if ref, ok := node["$ref"].(string); ok && !seenRefs[ref] {
+		if target, ok := resolveLocalSchemaRef(root, ref); ok {
+			seenRefs[ref] = true
+			walkSchemaTreeDepthRoot(root, target, path, depth+1, seenRefs, visit)
+			delete(seenRefs, ref)
+		}
+	}
+	walkSchemaNamedMapChildren(root, node, path, depth, seenRefs, visit)
+	walkSchemaNamedObjectChildren(root, node, path, depth, seenRefs, visit)
+	walkSchemaNamedArrayChildren(root, node, path, depth, seenRefs, visit)
+}
+
+func walkSchemaNamedMapChildren(root, node map[string]any, path string, depth int, seenRefs map[string]bool, visit func(node map[string]any, path string)) {
+	for _, keyword := range []string{"properties", "patternProperties", "dependentSchemas"} {
+		children, ok := node[keyword].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, key := range sortedAnyMapKeys(children) {
+			if child, ok := children[key].(map[string]any); ok {
+				childPath := path + "." + key
+				if keyword != "properties" {
+					childPath = path + "." + keyword + "." + key
+				}
+				walkSchemaTreeDepthRoot(root, child, childPath, depth+1, seenRefs, visit)
 			}
 		}
 	}
-	if items, ok := node["items"].(map[string]any); ok {
-		walkSchemaTreeDepth(items, path+".items", depth+1, visit)
+}
+
+func walkSchemaNamedObjectChildren(root, node map[string]any, path string, depth int, seenRefs map[string]bool, visit func(node map[string]any, path string)) {
+	for _, keyword := range []string{
+		"items",
+		"additionalProperties",
+		"contains",
+		"propertyNames",
+		"not",
+		"if",
+		"then",
+		"else",
+		"unevaluatedProperties",
+	} {
+		if child, ok := node[keyword].(map[string]any); ok {
+			walkSchemaTreeDepthRoot(root, child, path+"."+keyword, depth+1, seenRefs, visit)
+		}
 	}
+}
+
+func walkSchemaNamedArrayChildren(root, node map[string]any, path string, depth int, seenRefs map[string]bool, visit func(node map[string]any, path string)) {
+	for _, keyword := range []string{"allOf", "anyOf", "oneOf", "prefixItems"} {
+		children, ok := node[keyword].([]any)
+		if !ok {
+			continue
+		}
+		for i, val := range children {
+			if child, ok := val.(map[string]any); ok {
+				walkSchemaTreeDepthRoot(root, child, fmt.Sprintf("%s.%s[%d]", path, keyword, i), depth+1, seenRefs, visit)
+			}
+		}
+	}
+}
+
+func sortedAnyMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func resolveLocalSchemaRef(root map[string]any, ref string) (map[string]any, bool) {
+	if !strings.HasPrefix(ref, "#/") {
+		return nil, false
+	}
+	var cur any = root
+	for _, part := range strings.Split(strings.TrimPrefix(ref, "#/"), "/") {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = obj[decodeJSONPointerToken(part)]
+		if !ok {
+			return nil, false
+		}
+	}
+	target, ok := cur.(map[string]any)
+	return target, ok
+}
+
+func decodeJSONPointerToken(s string) string {
+	s = strings.ReplaceAll(s, "~1", "/")
+	return strings.ReplaceAll(s, "~0", "~")
 }
 
 // checkAdditionalProperties emits a violation when the node has no
@@ -301,13 +389,14 @@ func (v *Validator) validateContractDeprecatedCleanup01() []ValidationResult {
 	return results
 }
 
-// --- FMT-24 (input constraint enforcement) ---
+// --- FMT-25 (input constraint enforcement) ---
 
 // inputConstraintViolation captures a single missing-constraint finding from
 // either a request schema (path = JSON-pointer) or a contract.yaml param
-// (path = "queryParams.<name>" / "pathParams.<name>").
+// (path = "endpoints.http.queryParams.<name>.<facet>" /
+// "endpoints.http.pathParams.<name>.<facet>").
 type inputConstraintViolation struct {
-	location string // JSON pointer or "<paramKind>.<paramName>"
+	location string // JSON pointer or full metadata field path.
 	missing  string // "minLength" | "maxLength" | "minimum" | "maximum"
 }
 
@@ -323,7 +412,7 @@ type inputConstraintViolation struct {
 // Severity: Error, IssueRequired (missing facets fail the build; existing
 // declarations of explicit zero are accepted).
 //
-// Rule ID: FMT-24.
+// Rule ID: FMT-25.
 //
 // ref: OWASP API Security Top 10 — API4:2019 Lack of Resources & Rate Limiting
 // (input size bounds defend against DoS and overlong-payload attacks).
@@ -331,41 +420,66 @@ type inputConstraintViolation struct {
 func (v *Validator) validateFMTInputConstraint01() []ValidationResult {
 	var results []ValidationResult
 	for _, c := range v.project.Contracts {
-		if c.Kind != "http" {
-			continue
-		}
-		// Part A: request.schema.json (top-level only — response/error schemas
-		// are out of scope per parent plan §3 PR-V1-EVOLVE-ADR).
-		if c.SchemaRefs.Request != "" {
-			absPath := filepath.Join(v.root, c.Dir, c.SchemaRefs.Request)
-			missing, err := scanSchemaForInputConstraints(absPath)
-			if err != nil && !os.IsNotExist(err) {
-				// Parse/IO errors are definitive violations (fail-closed).
-				results = append(results, v.newResult(
-					ruleFMT24, SeverityError, IssueInvalid,
-					filepath.Join(c.Dir, c.SchemaRefs.Request), "$",
-					fmt.Sprintf("contract %q request schema %q failed to parse: %v",
-						c.ID, c.SchemaRefs.Request, err),
-				))
-			}
-			for _, viol := range missing {
-				results = append(results, v.newResult(
-					ruleFMT24, SeverityError, IssueRequired,
-					filepath.Join(c.Dir, c.SchemaRefs.Request), viol.location,
-					fmt.Sprintf("contract %q request schema field %s missing %s",
-						c.ID, viol.location, viol.missing),
-				))
-			}
-		}
-		// Part B + C: contract.yaml queryParams + pathParams.
-		if c.Endpoints.HTTP != nil {
-			results = append(results,
-				v.checkParamSchemaConstraints(c, c.Endpoints.HTTP.QueryParams, "queryParams")...)
-			results = append(results,
-				v.checkParamSchemaConstraints(c, c.Endpoints.HTTP.PathParams, "pathParams")...)
-		}
+		results = append(results, v.validateContractInputConstraints(c)...)
 	}
 	return results
+}
+
+func (v *Validator) validateContractInputConstraints(c *metadata.ContractMeta) []ValidationResult {
+	if c.Kind != "http" {
+		return nil
+	}
+	var results []ValidationResult
+	results = append(results, v.validateRequestSchemaInputConstraints(c)...)
+	results = append(results, v.validateParamInputConstraints(c)...)
+	return results
+}
+
+func (v *Validator) validateRequestSchemaInputConstraints(c *metadata.ContractMeta) []ValidationResult {
+	if c.SchemaRefs.Request == "" {
+		return nil
+	}
+	schemaFile := filepath.Join(c.Dir, c.SchemaRefs.Request)
+	absPath := filepath.Join(v.root, schemaFile)
+	missing, err := scanSchemaForInputConstraints(absPath)
+	if err != nil && !os.IsNotExist(err) {
+		return []ValidationResult{v.newResult(
+			ruleFMT25, SeverityError, IssueInvalid,
+			schemaFile, "$",
+			fmt.Sprintf("contract %q request schema %q failed to parse: %v",
+				c.ID, c.SchemaRefs.Request, err),
+		)}
+	}
+	var results []ValidationResult
+	for _, viol := range missing {
+		results = append(results, v.newResult(
+			ruleFMT25, SeverityError, IssueRequired,
+			schemaFile, viol.location,
+			fmt.Sprintf("contract %q request schema field %s missing %s",
+				c.ID, viol.location, viol.missing),
+		))
+	}
+	return results
+}
+
+func (v *Validator) validateParamInputConstraints(c *metadata.ContractMeta) []ValidationResult {
+	if c.Endpoints.HTTP == nil {
+		return nil
+	}
+	h := c.Endpoints.HTTP
+	results := v.checkParamSchemaConstraints(c, h.QueryParams, "queryParams")
+	if v.pathParamsReadyForInputConstraints(c, h) {
+		results = append(results, v.checkParamSchemaConstraints(c, h.PathParams, "pathParams")...)
+	}
+	return results
+}
+
+func (v *Validator) pathParamsReadyForInputConstraints(c *metadata.ContractMeta, h *metadata.HTTPTransportMeta) bool {
+	file := contractFile(c)
+	if len(v.validateFMT13Path(c, h, file)) > 0 {
+		return false
+	}
+	return len(v.validateFMT13PathParams(c, h, file)) == 0
 }
 
 // scanSchemaForInputConstraints reads a JSON schema file and walks every node,
@@ -440,7 +554,8 @@ func (v *Validator) checkParamSchemaConstraints(c *metadata.ContractMeta, params
 
 	var results []ValidationResult
 	for _, name := range names {
-		results = append(results, v.checkSingleParamConstraints(c, params[name], paramKind+"."+name)...)
+		fieldBase := fmt.Sprintf("endpoints.http.%s.%s", paramKind, name)
+		results = append(results, v.checkSingleParamConstraints(c, params[name], fieldBase)...)
 	}
 	return results
 }
@@ -475,16 +590,17 @@ type missingFacet struct {
 }
 
 // emitMissingFacets returns one ValidationResult per missing facet.
-func (v *Validator) emitMissingFacets(c *metadata.ContractMeta, field string, facets []missingFacet) []ValidationResult {
+func (v *Validator) emitMissingFacets(c *metadata.ContractMeta, fieldBase string, facets []missingFacet) []ValidationResult {
 	var results []ValidationResult
 	for _, f := range facets {
 		if !f.missing {
 			continue
 		}
+		field := fieldBase + "." + f.name
 		results = append(results, v.newResult(
-			ruleFMT24, SeverityError, IssueRequired,
+			ruleFMT25, SeverityError, IssueRequired,
 			contractFile(c), field,
-			fmt.Sprintf("contract %q %s missing %s", c.ID, field, f.name),
+			fmt.Sprintf("contract %q %s missing %s", c.ID, fieldBase, f.name),
 		))
 	}
 	return results

--- a/kernel/governance/rules_strict_extra.go
+++ b/kernel/governance/rules_strict_extra.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/contracts"
 )
 
-// Rule ID constants for FMT-20..FMT-23. Extracted so that each rule ID string
+// Rule ID constants for FMT-20..FMT-24. Extracted so that each rule ID string
 // is declared in exactly one place; Sonar code-smell rule S1192 (duplicate
 // string literals) no longer fires for these identifiers.
 const (
@@ -20,6 +21,7 @@ const (
 	ruleFMT21 = "FMT-21"
 	ruleFMT22 = "FMT-22"
 	ruleFMT23 = "FMT-23"
+	ruleFMT24 = "FMT-24"
 )
 
 // --- FMT-20 (formerly FMT-RESPONSE-STRICT-01) ---
@@ -112,30 +114,40 @@ func scanSchemaForStrictMissing(absPath string) ([]string, error) {
 	return missing, nil
 }
 
-// walkSchemaObject recursively walks a schema node. When the node is an object
-// type (map with "type":"object"), it checks for an explicit additionalProperties
-// declaration (true or false) and recurses into "properties" and "items".
+// walkSchemaObject recursively walks a schema node and applies
+// checkAdditionalProperties at each "type":"object" node. Implemented via the
+// shared walkSchemaTreeDepth framework.
 func walkSchemaObject(node map[string]any, path string, missing *[]string) {
-	walkSchemaObjectDepth(node, path, missing, 0)
+	walkSchemaTreeDepth(node, path, 0, func(n map[string]any, p string) {
+		if t, _ := n["type"].(string); t == "object" {
+			checkAdditionalProperties(n, p, missing)
+		}
+	})
 }
 
-// walkSchemaObjectDepth is the depth-guarded implementation of walkSchemaObject.
-// depth > 32 causes early return to prevent unbounded recursion on pathological schemas.
+// walkSchemaTreeDepth is the shared depth-guarded JSON-schema visitor used by
+// FMT-20 (additionalProperties) and FMT-24 (input constraints). It applies
+// `visit` at every node, then recurses into properties (for objects) and
+// items (for arrays). depth > 32 causes early return to prevent unbounded
+// recursion on pathological schemas.
 //
-// For "type":"object" nodes: checks additionalProperties and recurses into properties.
-// For any node with an "items" sub-schema (including "type":"array" nodes): recurses
-// into items so that array-typed properties with object items are also validated.
-func walkSchemaObjectDepth(node map[string]any, path string, missing *[]string, depth int) {
+// Note: visit is called at every node — branch on node["type"] inside visit
+// if a check applies only to objects/strings/integers etc.
+func walkSchemaTreeDepth(node map[string]any, path string, depth int, visit func(node map[string]any, path string)) {
 	if depth > 32 {
 		return
 	}
-	typVal, _ := node["type"].(string)
-	if typVal == "object" {
-		checkAdditionalProperties(node, path, missing)
-		walkSchemaPropertiesDepth(node, path, missing, depth+1)
+	visit(node, path)
+	if props, ok := node["properties"].(map[string]any); ok {
+		for key, val := range props {
+			if child, ok := val.(map[string]any); ok {
+				walkSchemaTreeDepth(child, path+"."+key, depth+1, visit)
+			}
+		}
 	}
-	// Always recurse into items (covers "type":"array" nodes whose items is an object).
-	walkSchemaItemsDepth(node, path, missing, depth+1)
+	if items, ok := node["items"].(map[string]any); ok {
+		walkSchemaTreeDepth(items, path+".items", depth+1, visit)
+	}
 }
 
 // checkAdditionalProperties emits a violation when the node has no
@@ -156,27 +168,6 @@ func checkAdditionalProperties(node map[string]any, path string, missing *[]stri
 	}
 	// Object value (schema form) is not a deliberate open/closed declaration.
 	*missing = append(*missing, path)
-}
-
-// walkSchemaPropertiesDepth is the depth-guarded implementation for recursing into properties.
-func walkSchemaPropertiesDepth(node map[string]any, path string, missing *[]string, depth int) {
-	props, ok := node["properties"].(map[string]any)
-	if !ok {
-		return
-	}
-	for key, val := range props {
-		if child, ok := val.(map[string]any); ok {
-			walkSchemaObjectDepth(child, path+"."+key, missing, depth)
-		}
-	}
-}
-
-// walkSchemaItemsDepth is the depth-guarded implementation for recursing into items.
-func walkSchemaItemsDepth(node map[string]any, path string, missing *[]string, depth int) {
-	items, ok := node["items"].(map[string]any)
-	if ok {
-		walkSchemaObjectDepth(items, path+".items", missing, depth)
-	}
 }
 
 // --- FMT-21 (formerly FMT-CONTRACT-DIR-ID-MATCH-01) ---
@@ -306,6 +297,195 @@ func (v *Validator) validateContractDeprecatedCleanup01() []ValidationResult {
 				),
 			))
 		}
+	}
+	return results
+}
+
+// --- FMT-24 (input constraint enforcement) ---
+
+// inputConstraintViolation captures a single missing-constraint finding from
+// either a request schema (path = JSON-pointer) or a contract.yaml param
+// (path = "queryParams.<name>" / "pathParams.<name>").
+type inputConstraintViolation struct {
+	location string // JSON pointer or "<paramKind>.<paramName>"
+	missing  string // "minLength" | "maxLength" | "minimum" | "maximum"
+}
+
+// validateFMTInputConstraint01 enforces input-side schema constraints on
+// HTTP-kind contracts:
+//   - request.schema.json: every "type":"string" leaf must declare both
+//     minLength and maxLength; every "type":"integer" leaf must declare both
+//     minimum and maximum.
+//   - contract.yaml.queryParams / pathParams: same rules apply to each
+//     ParamSchema, with one exemption: Format == "uuid" skips minLength /
+//     maxLength enforcement (RFC 4122 fixes UUIDs at 36 chars).
+//
+// Severity: Error, IssueRequired (missing facets fail the build; existing
+// declarations of explicit zero are accepted).
+//
+// Rule ID: FMT-24.
+//
+// ref: OWASP API Security Top 10 — API4:2019 Lack of Resources & Rate Limiting
+// (input size bounds defend against DoS and overlong-payload attacks).
+// ref: JSON Schema Draft 2020-12 string/numeric validation vocabulary.
+func (v *Validator) validateFMTInputConstraint01() []ValidationResult {
+	var results []ValidationResult
+	for _, c := range v.project.Contracts {
+		if c.Kind != "http" {
+			continue
+		}
+		// Part A: request.schema.json (top-level only — response/error schemas
+		// are out of scope per parent plan §3 PR-V1-EVOLVE-ADR).
+		if c.SchemaRefs.Request != "" {
+			absPath := filepath.Join(v.root, c.Dir, c.SchemaRefs.Request)
+			missing, err := scanSchemaForInputConstraints(absPath)
+			if err != nil && !os.IsNotExist(err) {
+				// Parse/IO errors are definitive violations (fail-closed).
+				results = append(results, v.newResult(
+					ruleFMT24, SeverityError, IssueInvalid,
+					filepath.Join(c.Dir, c.SchemaRefs.Request), "$",
+					fmt.Sprintf("contract %q request schema %q failed to parse: %v",
+						c.ID, c.SchemaRefs.Request, err),
+				))
+			}
+			for _, viol := range missing {
+				results = append(results, v.newResult(
+					ruleFMT24, SeverityError, IssueRequired,
+					filepath.Join(c.Dir, c.SchemaRefs.Request), viol.location,
+					fmt.Sprintf("contract %q request schema field %s missing %s",
+						c.ID, viol.location, viol.missing),
+				))
+			}
+		}
+		// Part B + C: contract.yaml queryParams + pathParams.
+		if c.Endpoints.HTTP != nil {
+			results = append(results,
+				v.checkParamSchemaConstraints(c, c.Endpoints.HTTP.QueryParams, "queryParams")...)
+			results = append(results,
+				v.checkParamSchemaConstraints(c, c.Endpoints.HTTP.PathParams, "pathParams")...)
+		}
+	}
+	return results
+}
+
+// scanSchemaForInputConstraints reads a JSON schema file and walks every node,
+// emitting a violation for each missing minLength/maxLength on strings and
+// minimum/maximum on integers. Paths use the same JSON-pointer style as
+// scanSchemaForStrictMissing (e.g. "$", "$.user.name", "$.tags.items").
+func scanSchemaForInputConstraints(absPath string) ([]inputConstraintViolation, error) {
+	raw, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, err
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return nil, fmt.Errorf("invalid JSON schema %s: %w", absPath, err)
+	}
+	var missing []inputConstraintViolation
+	walkSchemaTreeDepth(schema, "$", 0, func(n map[string]any, p string) {
+		checkInputConstraints(n, p, &missing)
+	})
+	// Sort for deterministic output across runs (map iteration is unordered).
+	sort.Slice(missing, func(i, j int) bool {
+		if missing[i].location != missing[j].location {
+			return missing[i].location < missing[j].location
+		}
+		return missing[i].missing < missing[j].missing
+	})
+	return missing, nil
+}
+
+// checkInputConstraints branches on node["type"] and records missing facets.
+// Strings missing minLength or maxLength → violations.
+// Integers missing minimum or maximum → violations.
+// Other types (boolean, number, object, array) are unaffected.
+func checkInputConstraints(node map[string]any, path string, missing *[]inputConstraintViolation) {
+	typVal, _ := node["type"].(string)
+	switch typVal {
+	case "string":
+		if _, ok := node["minLength"]; !ok {
+			*missing = append(*missing, inputConstraintViolation{location: path, missing: "minLength"})
+		}
+		if _, ok := node["maxLength"]; !ok {
+			*missing = append(*missing, inputConstraintViolation{location: path, missing: "maxLength"})
+		}
+	case "integer":
+		if _, ok := node["minimum"]; !ok {
+			*missing = append(*missing, inputConstraintViolation{location: path, missing: "minimum"})
+		}
+		if _, ok := node["maximum"]; !ok {
+			*missing = append(*missing, inputConstraintViolation{location: path, missing: "maximum"})
+		}
+	}
+}
+
+// checkParamSchemaConstraints scans a map of ParamSchema (queryParams or
+// pathParams) and emits violations for missing constraints. paramKind is the
+// label used in the error message ("queryParams" or "pathParams").
+//
+// String params with Format == "uuid" are exempt from minLength / maxLength
+// enforcement: RFC 4122 fixes UUIDs at 36 characters, so schema-level length
+// constraints are redundant. The exemption applies only to length checks;
+// integer constraints still apply unconditionally.
+func (v *Validator) checkParamSchemaConstraints(c *metadata.ContractMeta, params map[string]contracts.ParamSchema, paramKind string) []ValidationResult {
+	if len(params) == 0 {
+		return nil
+	}
+	// Stable iteration order for deterministic output.
+	names := make([]string, 0, len(params))
+	for name := range params {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var results []ValidationResult
+	for _, name := range names {
+		results = append(results, v.checkSingleParamConstraints(c, params[name], paramKind+"."+name)...)
+	}
+	return results
+}
+
+// checkSingleParamConstraints checks one ParamSchema for missing min/max
+// declarations. Branches on Type (string vs integer); other types are
+// untouched. Format == "uuid" exempts string params from length checks.
+func (v *Validator) checkSingleParamConstraints(c *metadata.ContractMeta, p contracts.ParamSchema, field string) []ValidationResult {
+	switch p.Type {
+	case "string":
+		if p.Format == "uuid" {
+			return nil // RFC 4122 fixes length; schema-level constraint is redundant.
+		}
+		return v.emitMissingFacets(c, field, []missingFacet{
+			{p.MinLength == nil, "minLength"},
+			{p.MaxLength == nil, "maxLength"},
+		})
+	case "integer":
+		return v.emitMissingFacets(c, field, []missingFacet{
+			{p.Minimum == nil, "minimum"},
+			{p.Maximum == nil, "maximum"},
+		})
+	}
+	return nil
+}
+
+// missingFacet describes a single facet check: when present is false, emit a
+// violation naming the facet (e.g. "minLength").
+type missingFacet struct {
+	missing bool
+	name    string
+}
+
+// emitMissingFacets returns one ValidationResult per missing facet.
+func (v *Validator) emitMissingFacets(c *metadata.ContractMeta, field string, facets []missingFacet) []ValidationResult {
+	var results []ValidationResult
+	for _, f := range facets {
+		if !f.missing {
+			continue
+		}
+		results = append(results, v.newResult(
+			ruleFMT24, SeverityError, IssueRequired,
+			contractFile(c), field,
+			fmt.Sprintf("contract %q %s missing %s", c.ID, field, f.name),
+		))
 	}
 	return results
 }

--- a/kernel/governance/rules_strict_extra_test.go
+++ b/kernel/governance/rules_strict_extra_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/contracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -836,4 +837,310 @@ func TestScanSchemaForStrictMissing_Basic(t *testing.T) {
 	// Top-level object missing additionalProperties → "$"
 	// $.data has it set → no violation
 	assert.Equal(t, []string{"$"}, paths)
+}
+
+// --- FMT-24 (HTTP input constraint: minLength/maxLength on strings, minimum/maximum on integers) ---
+
+// fmt24WriteSchema is a test helper that writes a JSON schema string to a
+// contract directory and returns the absolute schema path. Encapsulates the
+// repeated TempDir + MkdirAll + WriteFile dance used across FMT-24 tests.
+func fmt24WriteSchema(t *testing.T, dir, contractRel, body string) string {
+	t.Helper()
+	full := filepath.Join(dir, contractRel)
+	require.NoError(t, os.MkdirAll(full, 0o755))
+	p := filepath.Join(full, "request.schema.json")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+	return p
+}
+
+// fmt24Project builds a ProjectMeta containing one HTTP contract with the
+// given request schema reference. queryParams / pathParams are optional —
+// pass nil to omit. Used by every FMT-24 schema-driven test below.
+func fmt24Project(contractID, contractDir string, queryParams, pathParams map[string]contracts.ParamSchema) *metadata.ProjectMeta {
+	cm := &metadata.ContractMeta{
+		ID:        contractID,
+		Kind:      "http",
+		OwnerCell: "testcell",
+		Lifecycle: "active",
+		SchemaRefs: metadata.SchemaRefsMeta{
+			Request: "request.schema.json",
+		},
+		Dir:  contractDir,
+		File: contractDir + "/contract.yaml",
+	}
+	if queryParams != nil || pathParams != nil {
+		cm.Endpoints = metadata.EndpointsMeta{
+			HTTP: &metadata.HTTPTransportMeta{
+				Method:        "GET",
+				Path:          "/x",
+				PathParams:    pathParams,
+				QueryParams:   queryParams,
+				SuccessStatus: 200,
+			},
+		}
+	}
+	return &metadata.ProjectMeta{
+		Cells:       map[string]*metadata.CellMeta{},
+		Slices:      map[string]*metadata.SliceMeta{},
+		Contracts:   map[string]*metadata.ContractMeta{contractID: cm},
+		Journeys:    map[string]*metadata.JourneyMeta{},
+		Assemblies:  map[string]*metadata.AssemblyMeta{},
+		StatusBoard: nil,
+	}
+}
+
+// TestFMT24_RequestStringMissingMinLength verifies a violation fires when a
+// string field in request.schema.json lacks minLength.
+func TestFMT24_RequestStringMissingMinLength(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"username": {"type": "string", "maxLength": 128}
+		}
+	}`
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+
+	v := NewValidator(pm, dir)
+	results := v.Validate()
+	matches := findByCode(results, "FMT-24")
+	require.Len(t, matches, 1, "expected 1 violation for username missing minLength, got %d: %v", len(matches), matches)
+	assert.Equal(t, "$.username", matches[0].Field)
+	assert.Equal(t, SeverityError, matches[0].Severity)
+	assert.Contains(t, matches[0].Message, "minLength")
+}
+
+// TestFMT24_RequestStringMissingMaxLength verifies a violation fires when a
+// string field lacks maxLength (even if minLength is set).
+func TestFMT24_RequestStringMissingMaxLength(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"username": {"type": "string", "minLength": 1}
+		}
+	}`
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	require.Len(t, matches, 1, "expected 1 violation for username missing maxLength")
+	assert.Contains(t, matches[0].Message, "maxLength")
+}
+
+// TestFMT24_RequestIntegerMissingMinimumMaximum verifies violations fire when
+// integer fields lack minimum or maximum.
+func TestFMT24_RequestIntegerMissingMinimumMaximum(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"version": {"type": "integer", "minimum": 1},
+			"page":    {"type": "integer"}
+		}
+	}`
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	// version: missing maximum (1 violation)
+	// page:    missing minimum + missing maximum (2 violations)
+	require.Len(t, matches, 3, "expected 3 violations, got %d: %v", len(matches), matches)
+}
+
+// TestFMT24_RequestNestedObjectStringConstraints verifies the walker recurses
+// into nested objects.
+func TestFMT24_RequestNestedObjectStringConstraints(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"user": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"name": {"type": "string"}
+				}
+			}
+		}
+	}`
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	// user.name missing both → 2 violations (one per missing facet)
+	require.Len(t, matches, 2)
+	for _, m := range matches {
+		assert.Equal(t, "$.user.name", m.Field)
+	}
+}
+
+// TestFMT24_RequestArrayItemsStringConstraints verifies the walker recurses
+// into items of array properties.
+func TestFMT24_RequestArrayItemsStringConstraints(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"tags": {
+				"type": "array",
+				"items": {"type": "string"}
+			}
+		}
+	}`
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	// tags.items missing minLength + maxLength → 2 violations at $.tags.items
+	require.Len(t, matches, 2)
+	for _, m := range matches {
+		assert.Equal(t, "$.tags.items", m.Field)
+	}
+}
+
+// TestFMT24_QueryParamsStringMissingConstraints verifies that
+// contract.yaml.queryParams string fields are also checked.
+func TestFMT24_QueryParamsStringMissingConstraints(t *testing.T) {
+	dir := t.TempDir()
+	// Provide a clean request schema so only the queryParams violation fires.
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+		`{"type": "object", "additionalProperties": false}`)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1",
+		map[string]contracts.ParamSchema{
+			"cursor": {Type: "string"}, // missing minLength + maxLength
+		}, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	require.Len(t, matches, 2, "expected 2 violations for cursor missing both, got %d: %v", len(matches), matches)
+	for _, m := range matches {
+		assert.Contains(t, m.Field, "queryParams.cursor")
+	}
+}
+
+// TestFMT24_QueryParamsIntegerMissingConstraints verifies that integer
+// queryParams (e.g. limit) without minimum/maximum trigger violations.
+func TestFMT24_QueryParamsIntegerMissingConstraints(t *testing.T) {
+	dir := t.TempDir()
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+		`{"type": "object", "additionalProperties": false}`)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1",
+		map[string]contracts.ParamSchema{
+			"limit": {Type: "integer"}, // missing minimum + maximum
+		}, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	require.Len(t, matches, 2)
+	for _, m := range matches {
+		assert.Contains(t, m.Field, "queryParams.limit")
+	}
+}
+
+// TestFMT24_PathParamsStringMissingConstraints verifies pathParams plain
+// strings are checked.
+func TestFMT24_PathParamsStringMissingConstraints(t *testing.T) {
+	dir := t.TempDir()
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+		`{"type": "object", "additionalProperties": false}`)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil,
+		map[string]contracts.ParamSchema{
+			"key": {Type: "string"}, // plain string, no format → must be checked
+		})
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	require.Len(t, matches, 2)
+	for _, m := range matches {
+		assert.Contains(t, m.Field, "pathParams.key")
+	}
+}
+
+// TestFMT24_PathParamsUUIDFormatExempt verifies that pathParams with
+// format:"uuid" are exempted from minLength/maxLength enforcement (RFC 4122
+// fixes UUIDs at 36 characters; schema-level constraints would be redundant).
+func TestFMT24_PathParamsUUIDFormatExempt(t *testing.T) {
+	dir := t.TempDir()
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+		`{"type": "object", "additionalProperties": false}`)
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil,
+		map[string]contracts.ParamSchema{
+			"id": {Type: "string", Format: "uuid"}, // exempt
+		})
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	assert.Empty(t, matches, "format:uuid pathParams must be exempt from FMT-24, got: %v", matches)
+}
+
+// TestFMT24_CleanSchemaProducesNoViolations verifies that a fully-constrained
+// schema and a fully-constrained set of params produce zero FMT-24 violations.
+func TestFMT24_CleanSchemaProducesNoViolations(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"name":  {"type": "string", "minLength": 1, "maxLength": 128},
+			"limit": {"type": "integer", "minimum": 1, "maximum": 500}
+		}
+	}`
+	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
+	one := 1
+	twoFiftySix := 256
+	fiveHundred := 500
+	pm := fmt24Project("http.test.v1", "contracts/http/test/v1",
+		map[string]contracts.ParamSchema{
+			"cursor": {Type: "string", MinLength: &one, MaxLength: &twoFiftySix},
+			"limit":  {Type: "integer", Minimum: &one, Maximum: &fiveHundred},
+		},
+		map[string]contracts.ParamSchema{
+			"id":  {Type: "string", Format: "uuid"},                           // uuid exempt
+			"key": {Type: "string", MinLength: &one, MaxLength: &twoFiftySix}, // plain string with constraints
+		})
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-24")
+	assert.Empty(t, matches, "fully-constrained schema/params must produce no FMT-24, got: %v", matches)
+}
+
+// TestFMT24_NonHTTPContractIgnored verifies that non-HTTP contracts (event,
+// command, projection) are not scanned by FMT-24.
+func TestFMT24_NonHTTPContractIgnored(t *testing.T) {
+	dir := t.TempDir()
+	pm := &metadata.ProjectMeta{
+		Cells:  map[string]*metadata.CellMeta{},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"event.test.v1": {
+				ID:        "event.test.v1",
+				Kind:      "event",
+				OwnerCell: "testcell",
+				Lifecycle: "active",
+				SchemaRefs: metadata.SchemaRefsMeta{
+					Payload: "payload.schema.json",
+				},
+				Dir:  "contracts/event/test/v1",
+				File: "contracts/event/test/v1/contract.yaml",
+			},
+		},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+
+	v := NewValidator(pm, dir)
+	results := v.Validate()
+	matches := findByCode(results, "FMT-24")
+	assert.Empty(t, matches, "non-HTTP contract must not be scanned by FMT-24")
 }

--- a/kernel/governance/rules_strict_extra_test.go
+++ b/kernel/governance/rules_strict_extra_test.go
@@ -839,12 +839,12 @@ func TestScanSchemaForStrictMissing_Basic(t *testing.T) {
 	assert.Equal(t, []string{"$"}, paths)
 }
 
-// --- FMT-24 (HTTP input constraint: minLength/maxLength on strings, minimum/maximum on integers) ---
+// --- FMT-25 (HTTP input constraint: minLength/maxLength on strings, minimum/maximum on integers) ---
 
-// fmt24WriteSchema is a test helper that writes a JSON schema string to a
+// fmt25WriteSchema is a test helper that writes a JSON schema string to a
 // contract directory and returns the absolute schema path. Encapsulates the
-// repeated TempDir + MkdirAll + WriteFile dance used across FMT-24 tests.
-func fmt24WriteSchema(t *testing.T, dir, contractRel, body string) string {
+// repeated TempDir + MkdirAll + WriteFile dance used across FMT-25 tests.
+func fmt25WriteSchema(t *testing.T, dir, contractRel, body string) string {
 	t.Helper()
 	full := filepath.Join(dir, contractRel)
 	require.NoError(t, os.MkdirAll(full, 0o755))
@@ -853,10 +853,10 @@ func fmt24WriteSchema(t *testing.T, dir, contractRel, body string) string {
 	return p
 }
 
-// fmt24Project builds a ProjectMeta containing one HTTP contract with the
+// fmt25Project builds a ProjectMeta containing one HTTP contract with the
 // given request schema reference. queryParams / pathParams are optional —
-// pass nil to omit. Used by every FMT-24 schema-driven test below.
-func fmt24Project(contractID, contractDir string, queryParams, pathParams map[string]contracts.ParamSchema) *metadata.ProjectMeta {
+// pass nil to omit. Used by every FMT-25 schema-driven test below.
+func fmt25Project(contractID, contractDir string, queryParams, pathParams map[string]contracts.ParamSchema) *metadata.ProjectMeta {
 	cm := &metadata.ContractMeta{
 		ID:        contractID,
 		Kind:      "http",
@@ -869,10 +869,14 @@ func fmt24Project(contractID, contractDir string, queryParams, pathParams map[st
 		File: contractDir + "/contract.yaml",
 	}
 	if queryParams != nil || pathParams != nil {
+		path := "/x"
+		for _, name := range sortedParamKeys(pathParams) {
+			path += "/{" + name + "}"
+		}
 		cm.Endpoints = metadata.EndpointsMeta{
 			HTTP: &metadata.HTTPTransportMeta{
 				Method:        "GET",
-				Path:          "/x",
+				Path:          path,
 				PathParams:    pathParams,
 				QueryParams:   queryParams,
 				SuccessStatus: 200,
@@ -889,9 +893,9 @@ func fmt24Project(contractID, contractDir string, queryParams, pathParams map[st
 	}
 }
 
-// TestFMT24_RequestStringMissingMinLength verifies a violation fires when a
+// TestFMT25_RequestStringMissingMinLength verifies a violation fires when a
 // string field in request.schema.json lacks minLength.
-func TestFMT24_RequestStringMissingMinLength(t *testing.T) {
+func TestFMT25_RequestStringMissingMinLength(t *testing.T) {
 	dir := t.TempDir()
 	body := `{
 		"type": "object",
@@ -900,21 +904,21 @@ func TestFMT24_RequestStringMissingMinLength(t *testing.T) {
 			"username": {"type": "string", "maxLength": 128}
 		}
 	}`
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil, nil)
 
 	v := NewValidator(pm, dir)
 	results := v.Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	require.Len(t, matches, 1, "expected 1 violation for username missing minLength, got %d: %v", len(matches), matches)
 	assert.Equal(t, "$.username", matches[0].Field)
 	assert.Equal(t, SeverityError, matches[0].Severity)
 	assert.Contains(t, matches[0].Message, "minLength")
 }
 
-// TestFMT24_RequestStringMissingMaxLength verifies a violation fires when a
+// TestFMT25_RequestStringMissingMaxLength verifies a violation fires when a
 // string field lacks maxLength (even if minLength is set).
-func TestFMT24_RequestStringMissingMaxLength(t *testing.T) {
+func TestFMT25_RequestStringMissingMaxLength(t *testing.T) {
 	dir := t.TempDir()
 	body := `{
 		"type": "object",
@@ -923,18 +927,18 @@ func TestFMT24_RequestStringMissingMaxLength(t *testing.T) {
 			"username": {"type": "string", "minLength": 1}
 		}
 	}`
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil, nil)
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	require.Len(t, matches, 1, "expected 1 violation for username missing maxLength")
 	assert.Contains(t, matches[0].Message, "maxLength")
 }
 
-// TestFMT24_RequestIntegerMissingMinimumMaximum verifies violations fire when
+// TestFMT25_RequestIntegerMissingMinimumMaximum verifies violations fire when
 // integer fields lack minimum or maximum.
-func TestFMT24_RequestIntegerMissingMinimumMaximum(t *testing.T) {
+func TestFMT25_RequestIntegerMissingMinimumMaximum(t *testing.T) {
 	dir := t.TempDir()
 	body := `{
 		"type": "object",
@@ -944,19 +948,19 @@ func TestFMT24_RequestIntegerMissingMinimumMaximum(t *testing.T) {
 			"page":    {"type": "integer"}
 		}
 	}`
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil, nil)
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	// version: missing maximum (1 violation)
 	// page:    missing minimum + missing maximum (2 violations)
 	require.Len(t, matches, 3, "expected 3 violations, got %d: %v", len(matches), matches)
 }
 
-// TestFMT24_RequestNestedObjectStringConstraints verifies the walker recurses
+// TestFMT25_RequestNestedObjectStringConstraints verifies the walker recurses
 // into nested objects.
-func TestFMT24_RequestNestedObjectStringConstraints(t *testing.T) {
+func TestFMT25_RequestNestedObjectStringConstraints(t *testing.T) {
 	dir := t.TempDir()
 	body := `{
 		"type": "object",
@@ -971,11 +975,11 @@ func TestFMT24_RequestNestedObjectStringConstraints(t *testing.T) {
 			}
 		}
 	}`
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil, nil)
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	// user.name missing both → 2 violations (one per missing facet)
 	require.Len(t, matches, 2)
 	for _, m := range matches {
@@ -983,9 +987,9 @@ func TestFMT24_RequestNestedObjectStringConstraints(t *testing.T) {
 	}
 }
 
-// TestFMT24_RequestArrayItemsStringConstraints verifies the walker recurses
+// TestFMT25_RequestArrayItemsStringConstraints verifies the walker recurses
 // into items of array properties.
-func TestFMT24_RequestArrayItemsStringConstraints(t *testing.T) {
+func TestFMT25_RequestArrayItemsStringConstraints(t *testing.T) {
 	dir := t.TempDir()
 	body := `{
 		"type": "object",
@@ -997,11 +1001,11 @@ func TestFMT24_RequestArrayItemsStringConstraints(t *testing.T) {
 			}
 		}
 	}`
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil, nil)
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	// tags.items missing minLength + maxLength → 2 violations at $.tags.items
 	require.Len(t, matches, 2)
 	for _, m := range matches {
@@ -1009,84 +1013,193 @@ func TestFMT24_RequestArrayItemsStringConstraints(t *testing.T) {
 	}
 }
 
-// TestFMT24_QueryParamsStringMissingConstraints verifies that
+// TestFMT25_RequestLocalRefStringConstraints verifies local $ref targets are
+// resolved at the referring field path.
+func TestFMT25_RequestLocalRefStringConstraints(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"name": {"$ref": "#/$defs/name"}
+		},
+		"$defs": {
+			"name": {"type": "string"}
+		}
+	}`
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-25")
+	require.Len(t, matches, 2)
+	for _, m := range matches {
+		assert.Equal(t, "$.name", m.Field)
+	}
+}
+
+// TestFMT25_RequestCombinatorStringConstraints verifies common composition
+// keywords are traversed instead of hiding unconstrained inputs.
+func TestFMT25_RequestCombinatorStringConstraints(t *testing.T) {
+	dir := t.TempDir()
+	body := `{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"name": {
+				"allOf": [
+					{"type": "string", "minLength": 1}
+				]
+			}
+		}
+	}`
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil, nil)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-25")
+	require.Len(t, matches, 1)
+	assert.Equal(t, "$.name.allOf[0]", matches[0].Field)
+	assert.Contains(t, matches[0].Message, "maxLength")
+}
+
+// TestFMT25_QueryParamsStringMissingConstraints verifies that
 // contract.yaml.queryParams string fields are also checked.
-func TestFMT24_QueryParamsStringMissingConstraints(t *testing.T) {
+func TestFMT25_QueryParamsStringMissingConstraints(t *testing.T) {
 	dir := t.TempDir()
 	// Provide a clean request schema so only the queryParams violation fires.
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1",
 		`{"type": "object", "additionalProperties": false}`)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1",
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1",
 		map[string]contracts.ParamSchema{
 			"cursor": {Type: "string"}, // missing minLength + maxLength
 		}, nil)
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	require.Len(t, matches, 2, "expected 2 violations for cursor missing both, got %d: %v", len(matches), matches)
-	for _, m := range matches {
-		assert.Contains(t, m.Field, "queryParams.cursor")
-	}
+	assert.Equal(t, "endpoints.http.queryParams.cursor.minLength", matches[0].Field)
+	assert.Equal(t, "endpoints.http.queryParams.cursor.maxLength", matches[1].Field)
 }
 
-// TestFMT24_QueryParamsIntegerMissingConstraints verifies that integer
+// TestFMT25_QueryParamsIntegerMissingConstraints verifies that integer
 // queryParams (e.g. limit) without minimum/maximum trigger violations.
-func TestFMT24_QueryParamsIntegerMissingConstraints(t *testing.T) {
+func TestFMT25_QueryParamsIntegerMissingConstraints(t *testing.T) {
 	dir := t.TempDir()
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1",
 		`{"type": "object", "additionalProperties": false}`)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1",
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1",
 		map[string]contracts.ParamSchema{
 			"limit": {Type: "integer"}, // missing minimum + maximum
 		}, nil)
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	require.Len(t, matches, 2)
-	for _, m := range matches {
-		assert.Contains(t, m.Field, "queryParams.limit")
-	}
+	assert.Equal(t, "endpoints.http.queryParams.limit.minimum", matches[0].Field)
+	assert.Equal(t, "endpoints.http.queryParams.limit.maximum", matches[1].Field)
 }
 
-// TestFMT24_PathParamsStringMissingConstraints verifies pathParams plain
+// TestFMT25_PathParamsStringMissingConstraints verifies pathParams plain
 // strings are checked.
-func TestFMT24_PathParamsStringMissingConstraints(t *testing.T) {
+func TestFMT25_PathParamsStringMissingConstraints(t *testing.T) {
 	dir := t.TempDir()
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1",
 		`{"type": "object", "additionalProperties": false}`)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil,
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil,
 		map[string]contracts.ParamSchema{
 			"key": {Type: "string"}, // plain string, no format → must be checked
 		})
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
+	matches := findByCode(results, "FMT-25")
 	require.Len(t, matches, 2)
-	for _, m := range matches {
-		assert.Contains(t, m.Field, "pathParams.key")
-	}
+	assert.Equal(t, "endpoints.http.pathParams.key.minLength", matches[0].Field)
+	assert.Equal(t, "endpoints.http.pathParams.key.maxLength", matches[1].Field)
 }
 
-// TestFMT24_PathParamsUUIDFormatExempt verifies that pathParams with
+// TestFMT25_ParamFindingsUseLocatableMetadataPaths verifies param-side
+// findings use full YAML paths so CLI output can include line/column anchors.
+func TestFMT25_ParamFindingsUseLocatableMetadataPaths(t *testing.T) {
+	dir := t.TempDir()
+	contractRel := "contracts/http/test/v1"
+	fmt25WriteSchema(t, dir, contractRel, `{"type": "object", "additionalProperties": false}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, contractRel, "contract.yaml"), []byte(`id: http.test.v1
+kind: http
+ownerCell: testcell
+consistencyLevel: L1
+lifecycle: active
+endpoints:
+  server: testcell
+  clients: []
+  http:
+    method: GET
+    path: /api/v1/test/{key}
+    pathParams:
+      key:
+        type: string
+    queryParams:
+      cursor:
+        type: string
+        required: false
+    successStatus: 200
+    noContent: false
+schemaRefs:
+  request: request.schema.json
+`), 0o644))
+	pm, err := metadata.NewParser(dir).Parse()
+	require.NoError(t, err)
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-25")
+	require.Len(t, matches, 4)
+	for _, m := range matches {
+		assert.NotZero(t, m.Line, "field %s should locate a YAML line", m.Field)
+		assert.NotZero(t, m.Column, "field %s should locate a YAML column", m.Field)
+	}
+	assert.Equal(t, "endpoints.http.queryParams.cursor.minLength", matches[0].Field)
+	assert.Equal(t, "endpoints.http.queryParams.cursor.maxLength", matches[1].Field)
+	assert.Equal(t, "endpoints.http.pathParams.key.minLength", matches[2].Field)
+	assert.Equal(t, "endpoints.http.pathParams.key.maxLength", matches[3].Field)
+}
+
+// TestFMT25_SkipsInvalidPathParams verifies FMT-25 does not add follow-on
+// facet noise for pathParams that FMT-13 already rejected.
+func TestFMT25_SkipsInvalidPathParams(t *testing.T) {
+	dir := t.TempDir()
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1",
+		`{"type": "object", "additionalProperties": false}`)
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil,
+		map[string]contracts.ParamSchema{
+			"ghost": {Type: "string"}, // no {ghost} placeholder in path
+		})
+	pm.Contracts["http.test.v1"].Endpoints.HTTP.Path = "/x"
+
+	results := NewValidator(pm, dir).Validate()
+	matches := findByCode(results, "FMT-25")
+	assert.Empty(t, matches)
+}
+
+// TestFMT25_PathParamsUUIDFormatExempt verifies that pathParams with
 // format:"uuid" are exempted from minLength/maxLength enforcement (RFC 4122
 // fixes UUIDs at 36 characters; schema-level constraints would be redundant).
-func TestFMT24_PathParamsUUIDFormatExempt(t *testing.T) {
+func TestFMT25_PathParamsUUIDFormatExempt(t *testing.T) {
 	dir := t.TempDir()
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1",
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1",
 		`{"type": "object", "additionalProperties": false}`)
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1", nil,
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1", nil,
 		map[string]contracts.ParamSchema{
 			"id": {Type: "string", Format: "uuid"}, // exempt
 		})
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
-	assert.Empty(t, matches, "format:uuid pathParams must be exempt from FMT-24, got: %v", matches)
+	matches := findByCode(results, "FMT-25")
+	assert.Empty(t, matches, "format:uuid pathParams must be exempt from FMT-25, got: %v", matches)
 }
 
-// TestFMT24_CleanSchemaProducesNoViolations verifies that a fully-constrained
-// schema and a fully-constrained set of params produce zero FMT-24 violations.
-func TestFMT24_CleanSchemaProducesNoViolations(t *testing.T) {
+// TestFMT25_CleanSchemaProducesNoViolations verifies that a fully-constrained
+// schema and a fully-constrained set of params produce zero FMT-25 violations.
+func TestFMT25_CleanSchemaProducesNoViolations(t *testing.T) {
 	dir := t.TempDir()
 	body := `{
 		"type": "object",
@@ -1096,11 +1209,11 @@ func TestFMT24_CleanSchemaProducesNoViolations(t *testing.T) {
 			"limit": {"type": "integer", "minimum": 1, "maximum": 500}
 		}
 	}`
-	fmt24WriteSchema(t, dir, "contracts/http/test/v1", body)
+	fmt25WriteSchema(t, dir, "contracts/http/test/v1", body)
 	one := 1
 	twoFiftySix := 256
 	fiveHundred := 500
-	pm := fmt24Project("http.test.v1", "contracts/http/test/v1",
+	pm := fmt25Project("http.test.v1", "contracts/http/test/v1",
 		map[string]contracts.ParamSchema{
 			"cursor": {Type: "string", MinLength: &one, MaxLength: &twoFiftySix},
 			"limit":  {Type: "integer", Minimum: &one, Maximum: &fiveHundred},
@@ -1111,13 +1224,13 @@ func TestFMT24_CleanSchemaProducesNoViolations(t *testing.T) {
 		})
 
 	results := NewValidator(pm, dir).Validate()
-	matches := findByCode(results, "FMT-24")
-	assert.Empty(t, matches, "fully-constrained schema/params must produce no FMT-24, got: %v", matches)
+	matches := findByCode(results, "FMT-25")
+	assert.Empty(t, matches, "fully-constrained schema/params must produce no FMT-25, got: %v", matches)
 }
 
-// TestFMT24_NonHTTPContractIgnored verifies that non-HTTP contracts (event,
-// command, projection) are not scanned by FMT-24.
-func TestFMT24_NonHTTPContractIgnored(t *testing.T) {
+// TestFMT25_NonHTTPContractIgnored verifies that non-HTTP contracts (event,
+// command, projection) are not scanned by FMT-25.
+func TestFMT25_NonHTTPContractIgnored(t *testing.T) {
 	dir := t.TempDir()
 	pm := &metadata.ProjectMeta{
 		Cells:  map[string]*metadata.CellMeta{},
@@ -1141,6 +1254,6 @@ func TestFMT24_NonHTTPContractIgnored(t *testing.T) {
 
 	v := NewValidator(pm, dir)
 	results := v.Validate()
-	matches := findByCode(results, "FMT-24")
-	assert.Empty(t, matches, "non-HTTP contract must not be scanned by FMT-24")
+	matches := findByCode(results, "FMT-25")
+	assert.Empty(t, matches, "non-HTTP contract must not be scanned by FMT-25")
 }

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -158,6 +158,7 @@ func (v *Validator) rules() []func() []ValidationResult {
 		v.validateFMTContractDirIDMatch01,
 		v.validateStatusBoardStateEnum01,
 		v.validateContractDeprecatedCleanup01,
+		v.validateFMTInputConstraint01,
 		v.validateCONTRACTCONSISTENCYEMIT01,
 	}
 }

--- a/kernel/metadata/schemas/contract.schema.json
+++ b/kernel/metadata/schemas/contract.schema.json
@@ -84,6 +84,24 @@
         "format": {
           "type": "string",
           "description": "Optional format hint (e.g. uuid, date-time, int64)."
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum string length accepted for this parameter. Required by FMT-25 for non-uuid string path/query params."
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum string length accepted for this parameter. Required by FMT-25 for non-uuid string path/query params."
+        },
+        "minimum": {
+          "type": "integer",
+          "description": "Minimum integer value accepted for this parameter. Required by FMT-25 for integer path/query params."
+        },
+        "maximum": {
+          "type": "integer",
+          "description": "Maximum integer value accepted for this parameter. Required by FMT-25 for integer path/query params."
         }
       }
     }

--- a/kernel/metadata/schemas/contract_schema_test.go
+++ b/kernel/metadata/schemas/contract_schema_test.go
@@ -1,0 +1,63 @@
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContractSchemaAllowsParamConstraintFacets(t *testing.T) {
+	raw, err := FS.ReadFile("contract.schema.json")
+	require.NoError(t, err)
+
+	var schemaDoc any
+	require.NoError(t, json.Unmarshal(raw, &schemaDoc))
+
+	compiler := jsonschema.NewCompiler()
+	const schemaURL = "https://gocell.dev/schemas/contract.schema.json"
+	require.NoError(t, compiler.AddResource(schemaURL, schemaDoc))
+	schema, err := compiler.Compile(schemaURL)
+	require.NoError(t, err)
+
+	var contractDoc any
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "http.test.v1",
+		"kind": "http",
+		"ownerCell": "testcell",
+		"consistencyLevel": "L1",
+		"lifecycle": "active",
+		"endpoints": {
+			"server": "testcell",
+			"clients": [],
+			"http": {
+				"method": "GET",
+				"path": "/api/v1/test/{key}",
+				"pathParams": {
+					"key": {
+						"type": "string",
+						"minLength": 1,
+						"maxLength": 128
+					}
+				},
+				"queryParams": {
+					"limit": {
+						"type": "integer",
+						"required": false,
+						"minimum": 1,
+						"maximum": 500
+					}
+				},
+				"successStatus": 200,
+				"noContent": false
+			}
+		},
+		"schemaRefs": {
+			"request": "request.schema.json"
+		}
+	}`), &contractDoc))
+
+	assert.NoError(t, schema.Validate(contractDoc))
+}

--- a/kernel/scaffold/templates/contract-http.yaml.tpl
+++ b/kernel/scaffold/templates/contract-http.yaml.tpl
@@ -9,6 +9,8 @@ endpoints:
   # TODO: fill in the transport layer. FMT-13 enforces path ↔ pathParams
   # consistency once `endpoints.http` is present, so every `{name}` token in
   # `path` must appear as a pathParams key with a typed `type:`.
+  # FMT-25 also requires min/max facets for string and integer path/query
+  # params, except `format: uuid` string params where UUID length is fixed.
   # The placeholder below intentionally fails `gocell validate --strict`
   # (path `/TODO/{id}` carries an `{id}` token with no pathParams declaration)
   # so the scaffold output advertises that it is not ready to ship.
@@ -18,11 +20,18 @@ endpoints:
     # pathParams:                     # TODO: one entry per `{name}` in path
     #   id:
     #     type: string                # string | integer | number | boolean | uuid
-    #     format: uuid                # optional hint (uuid, date-time, int64, …)
+    #     format: uuid                # optional hint; uuid is exempt from FMT-25 length facets
     # queryParams:                    # uncomment if the endpoint accepts query args
     #   cursor:
     #     type: string
     #     required: false
+    #     minLength: 0
+    #     maxLength: 256
+    #   limit:
+    #     type: integer
+    #     required: false
+    #     minimum: 1
+    #     maximum: 500
     successStatus: 200
     noContent: false
     # responses:                      # REQUIRED when endpoint is not Public=true —

--- a/pkg/contracts/schema_types.go
+++ b/pkg/contracts/schema_types.go
@@ -42,13 +42,13 @@ type HTTPTransport struct {
 //
 // Format is a free-form hint (e.g. "uuid", "date-time", "int64") — it does
 // not influence FMT-13 enforcement today, but static tooling (codegen,
-// OpenAPI export) consumes it. Governance rule FMT-24 exempts
+// OpenAPI export) consumes it. Governance rule FMT-25 exempts
 // `format: "uuid"` from minLength/maxLength enforcement (UUIDs are fixed
 // at 36 characters per RFC 4122).
 //
 // MinLength / MaxLength / Minimum / Maximum are *int (not int) for the
 // same three-state reason as Required: nil = "not declared", non-nil =
-// "declared, even if zero". Governance rule FMT-24 distinguishes the
+// "declared, even if zero". Governance rule FMT-25 distinguishes the
 // two: missing declarations are violations; explicit zero (e.g.
 // `minLength: 0` to permit empty strings) is accepted.
 type ParamSchema struct {

--- a/pkg/contracts/schema_types.go
+++ b/pkg/contracts/schema_types.go
@@ -42,11 +42,23 @@ type HTTPTransport struct {
 //
 // Format is a free-form hint (e.g. "uuid", "date-time", "int64") — it does
 // not influence FMT-13 enforcement today, but static tooling (codegen,
-// OpenAPI export) consumes it.
+// OpenAPI export) consumes it. Governance rule FMT-24 exempts
+// `format: "uuid"` from minLength/maxLength enforcement (UUIDs are fixed
+// at 36 characters per RFC 4122).
+//
+// MinLength / MaxLength / Minimum / Maximum are *int (not int) for the
+// same three-state reason as Required: nil = "not declared", non-nil =
+// "declared, even if zero". Governance rule FMT-24 distinguishes the
+// two: missing declarations are violations; explicit zero (e.g.
+// `minLength: 0` to permit empty strings) is accepted.
 type ParamSchema struct {
-	Type     string `yaml:"type"               json:"type"`
-	Required *bool  `yaml:"required,omitempty" json:"required,omitempty"`
-	Format   string `yaml:"format,omitempty"   json:"format,omitempty"`
+	Type      string `yaml:"type"                json:"type"`
+	Required  *bool  `yaml:"required,omitempty"  json:"required,omitempty"`
+	Format    string `yaml:"format,omitempty"    json:"format,omitempty"`
+	MinLength *int   `yaml:"minLength,omitempty" json:"minLength,omitempty"`
+	MaxLength *int   `yaml:"maxLength,omitempty" json:"maxLength,omitempty"`
+	Minimum   *int   `yaml:"minimum,omitempty"   json:"minimum,omitempty"`
+	Maximum   *int   `yaml:"maximum,omitempty"   json:"maximum,omitempty"`
 }
 
 // ParamTypes lists the accepted `type` values for ParamSchema.

--- a/pkg/contracts/schema_types_test.go
+++ b/pkg/contracts/schema_types_test.go
@@ -154,6 +154,65 @@ func TestParamSchemaRequiredThreeStates(t *testing.T) {
 	})
 }
 
+// TestParamSchemaConstraintsRoundTrip locks in YAML round-trip semantics for
+// the four new constraint fields (MinLength, MaxLength, Minimum, Maximum).
+// They are *int so omitted/zero/non-zero are three distinct states, mirroring
+// the three-state Required pattern (FMT-24 governance rule depends on the
+// distinction between "no declaration" and "declared as zero").
+func TestParamSchemaConstraintsRoundTrip(t *testing.T) {
+	zero := 0
+	nonZero := 500
+	t.Run("nil constraints are omitted", func(t *testing.T) {
+		data, got := roundTrip(t, ParamSchema{Type: "string"})
+		assert.Nil(t, got.MinLength)
+		assert.Nil(t, got.MaxLength)
+		assert.Nil(t, got.Minimum)
+		assert.Nil(t, got.Maximum)
+		assert.NotContains(t, string(data), "minLength")
+		assert.NotContains(t, string(data), "maxLength")
+		assert.NotContains(t, string(data), "minimum")
+		assert.NotContains(t, string(data), "maximum")
+	})
+	t.Run("zero values are emitted (not omitted)", func(t *testing.T) {
+		data, got := roundTrip(t, ParamSchema{
+			Type:      "string",
+			MinLength: &zero,
+		})
+		require.NotNil(t, got.MinLength)
+		assert.Equal(t, 0, *got.MinLength)
+		assert.Contains(t, string(data), "minLength: 0")
+	})
+	t.Run("non-zero string constraints round-trip", func(t *testing.T) {
+		one := 1
+		twoFiftySix := 256
+		data, got := roundTrip(t, ParamSchema{
+			Type:      "string",
+			MinLength: &one,
+			MaxLength: &twoFiftySix,
+		})
+		require.NotNil(t, got.MinLength)
+		require.NotNil(t, got.MaxLength)
+		assert.Equal(t, 1, *got.MinLength)
+		assert.Equal(t, 256, *got.MaxLength)
+		assert.Contains(t, string(data), "minLength: 1")
+		assert.Contains(t, string(data), "maxLength: 256")
+	})
+	t.Run("integer constraints round-trip", func(t *testing.T) {
+		one := 1
+		data, got := roundTrip(t, ParamSchema{
+			Type:    "integer",
+			Minimum: &one,
+			Maximum: &nonZero,
+		})
+		require.NotNil(t, got.Minimum)
+		require.NotNil(t, got.Maximum)
+		assert.Equal(t, 1, *got.Minimum)
+		assert.Equal(t, 500, *got.Maximum)
+		assert.Contains(t, string(data), "minimum: 1")
+		assert.Contains(t, string(data), "maximum: 500")
+	})
+}
+
 func TestParamTypesWhitelist(t *testing.T) {
 	for _, name := range []string{"string", "integer", "number", "boolean", "uuid"} {
 		assert.True(t, ParamTypes[name], "%s should be accepted", name)

--- a/pkg/contracts/schema_types_test.go
+++ b/pkg/contracts/schema_types_test.go
@@ -157,7 +157,7 @@ func TestParamSchemaRequiredThreeStates(t *testing.T) {
 // TestParamSchemaConstraintsRoundTrip locks in YAML round-trip semantics for
 // the four new constraint fields (MinLength, MaxLength, Minimum, Maximum).
 // They are *int so omitted/zero/non-zero are three distinct states, mirroring
-// the three-state Required pattern (FMT-24 governance rule depends on the
+// the three-state Required pattern (FMT-25 governance rule depends on the
 // distinction between "no declaration" and "declared as zero").
 func TestParamSchemaConstraintsRoundTrip(t *testing.T) {
 	zero := 0


### PR DESCRIPTION
## Summary

落地父 plan 「反复模式根治」§阶段 1 PR-MODE-5 — 「输入约束缺位」反复模式治理。

新增 always-on 治理规则 **FMT-25**，扫所有 HTTP-kind contract，强制：
- `request.schema.json` 中所有 `type:string` 必须有 `minLength`+`maxLength`，所有 `type:integer` 必须有 `minimum`+`maximum`（递归 nested object / array items / local `$ref` / common composition keywords）
- `contract.yaml.queryParams` + `pathParams` 中 string/integer 字段同样的 facet 要求
- 单一豁免：`format:uuid` 的 ParamSchema 不强制 length（RFC 4122 锁定 36 字符）

业务消化（CI 始终绿）：
- 主仓 14 个 request.schema.json（auth/* + config/*）
- 主仓 4 个 list endpoint contract.yaml（cursor/limit）+ 12 个 plain string pathParams contract.yaml
- examples 6 个 request.schema.json + 7 个 pathParams contract.yaml
- 3 个 contract-test fixture 同步到新约束

`pkg/contracts.ParamSchema` 扩展 4 个 `*int` 字段（MinLength/MaxLength/Minimum/Maximum）支持 contract.yaml 表达约束；FMT-20 与 FMT-25 共享 `walkSchemaTreeDepth` 公共递归框架。

Review follow-up:
- renumbered input-constraint rule to **FMT-25** so PR #295 can retain FMT-24 for journey lifecycle/passCriteria
- updated `kernel/metadata/schemas/contract.schema.json` to allow ParamSchema constraint facets
- made param-side diagnostics use locatable `endpoints.http.*` field paths
- added local `$ref` / composition traversal coverage for request schemas
- refreshed HTTP scaffold param examples with FMT-25-required facets

## Test plan

- [x] `go test ./kernel/governance/... ./kernel/metadata/schemas ./pkg/contracts/...`
- [x] `go test ./kernel/scaffold/... ./cells/accesscore/slices/identitymanage/... ./cells/accesscore/slices/sessionlogin/... ./cells/accesscore/slices/sessionrefresh/...`
- [x] `go run ./cmd/gocell validate --strict` 0 errors / 0 warnings
- [x] `go test ./...` 全量 PASS
- [x] `golangci-lint run ./kernel/governance/... ./kernel/metadata/schemas/... ./kernel/scaffold/... ./pkg/contracts/... ./cells/accesscore/slices/identitymanage/...` 0 issues
- [x] `gofmt -l` 0 files for touched Go files

Earlier test plan retained from initial PR validation:
- [x] `go test -tags=integration ./adapters/... ./tests/integration/... ./cmd/corebundle/...` PASS
- [x] `go run ./cmd/gocell validate` 0 errors / 0 warnings

## Refs

- Refs: parent plan `docs/plans/202604270020-1-2-ci-3-claude-ship-reactive-bachman.md` §阶段 1 PR-MODE-5
- ref: OWASP API Security Top 10 — API4:2019 Lack of Resources & Rate Limiting
- ref: JSON Schema Draft 2020-12 string/numeric validation vocabulary
- ref: RFC 4122 (UUID format) — basis for length-check exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)
