### PR TITLE
fix(security): remove example compose hardcoded credentials

### DIFF
--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -67,7 +67,7 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) http.Handler {
 		connID := "ws-" + uuid.NewString()
 		conn := NewConn(connID, wsConn)
 
-		if regErr := hub.Register(conn); regErr != nil {
+		if regErr := hub.Register(r.Context(), conn); regErr != nil {
 			_ = wsConn.Close(websocket.StatusNormalClosure, "registration rejected")
 			slog.Warn("websocket: register rejected",
 				slog.Any("error", regErr),

--- a/cells/accesscore/initialadmin/lifecycle.go
+++ b/cells/accesscore/initialadmin/lifecycle.go
@@ -43,8 +43,8 @@ type config struct {
 // OnStart returns promptly after launching the cleaner in a background
 // goroutine: cleaner.Start blocks on ctx.Done() waiting for TTL expiry,
 // which exceeds bootstrap.Hook.StartTimeout (30s default). The goroutine
-// uses an internal runCtx derived from context.Background; OnStop cancels
-// it to drain the goroutine and then calls cleaner.Stop for explicit
+// uses an internal runCtx derived from context.WithoutCancel(ctx); OnStop
+// cancels it to drain the goroutine and then calls cleaner.Stop for explicit
 // timer cancellation.
 type Lifecycle struct {
 	cfg       config
@@ -198,15 +198,15 @@ func (l *Lifecycle) start(ctx context.Context) error {
 		return nil // admin exists + no orphan → no cleanup needed
 	}
 
-	// Derive a long-lived runCtx from background so cleaner.Start (which blocks
-	// on <-ctx.Done()) is not killed by bootstrap.Hook.StartTimeout (30s). OnStop
-	// cancels runCtx to drain the goroutine.
+	// Derive a long-lived runCtx that preserves caller values but is not killed
+	// by bootstrap.Hook.StartTimeout (30s). OnStop cancels runCtx to drain the
+	// goroutine.
 	//
 	// A concurrent stop() racing with start() is handled by stopped=true: if
 	// stop ran first, we cancel runCtx immediately and do not spawn the
 	// cleaner goroutine (calling cleaner.Start on a stopped cleaner is an error
 	// per the cleaner contract).
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	l.mu.Lock()
 	if l.stopped {
 		l.mu.Unlock()

--- a/examples/iotdevice/README.md
+++ b/examples/iotdevice/README.md
@@ -57,6 +57,7 @@ Start infrastructure services, then run the application:
 
 ```bash
 cd examples/iotdevice
+export GOCELL_EXAMPLE_POSTGRES_PASSWORD="$(openssl rand -base64 24)"
 docker compose up -d
 cd ../..
 # Export the JWT and GOCELL_IOTDEVICE_SERVICE_SECRET variables from Quick Start first.

--- a/examples/iotdevice/docker-compose.yml
+++ b/examples/iotdevice/docker-compose.yml
@@ -4,9 +4,7 @@ services:
     environment:
       POSTGRES_DB: iot_device
       POSTGRES_USER: gocell
-      # Demo credential for local `docker compose up`; DO NOT USE IN PRODUCTION.
-      # nosemgrep: generic.secrets.security.detected-generic-secret
-      POSTGRES_PASSWORD: gocell
+      POSTGRES_PASSWORD: ${GOCELL_EXAMPLE_POSTGRES_PASSWORD:?set GOCELL_EXAMPLE_POSTGRES_PASSWORD for local demo infrastructure}
     ports:
       - "5432:5432"
     volumes:

--- a/examples/ssobff/README.md
+++ b/examples/ssobff/README.md
@@ -24,18 +24,17 @@ The server starts three listeners following `docs/ops/listener-topology.md`:
 
 Each address is overridable via environment variable (see [Environment Variables](#environment-variables)).
 
-## Docker Mode
+## Docker Infrastructure
 
-Start infrastructure services, then run the application:
+Infrastructure services are available for future adapter-based mode. The
+current `ssobff` example still uses in-memory dependencies, so starting these
+containers is optional and does not change runtime storage or event delivery.
 
 ```bash
 cd examples/ssobff
 export GOCELL_EXAMPLE_POSTGRES_PASSWORD="$(openssl rand -base64 24)"
 export GOCELL_EXAMPLE_RABBITMQ_PASSWORD="$(openssl rand -base64 24)"
 docker compose up -d
-cd ../..
-export GOCELL_SSOBFF_SERVICE_SECRET="$(openssl rand -base64 32)"
-go run ./examples/ssobff
 ```
 
 ## Seed User

--- a/examples/ssobff/README.md
+++ b/examples/ssobff/README.md
@@ -24,6 +24,20 @@ The server starts three listeners following `docs/ops/listener-topology.md`:
 
 Each address is overridable via environment variable (see [Environment Variables](#environment-variables)).
 
+## Docker Mode
+
+Start infrastructure services, then run the application:
+
+```bash
+cd examples/ssobff
+export GOCELL_EXAMPLE_POSTGRES_PASSWORD="$(openssl rand -base64 24)"
+export GOCELL_EXAMPLE_RABBITMQ_PASSWORD="$(openssl rand -base64 24)"
+docker compose up -d
+cd ../..
+export GOCELL_SSOBFF_SERVICE_SECRET="$(openssl rand -base64 32)"
+go run ./examples/ssobff
+```
+
 ## Seed User
 
 On first startup, when no admin user exists, the bootstrap process creates
@@ -298,16 +312,4 @@ go run ./examples/ssobff
 # /readyz probe + SIGTERM graceful shutdown). Mirrors the CI examples-
 # smoke job. Required before pushing main.go / option-wiring changes.
 make test-examples-smoke
-```
-
-## Docker Mode (Future)
-
-Infrastructure services are provided for future adapter-based mode:
-
-```bash
-cd examples/ssobff
-docker compose up -d
-cd ../..
-# Export GOCELL_SSOBFF_SERVICE_SECRET and the JWT variables from Quick Start first.
-go run ./examples/ssobff
 ```

--- a/examples/ssobff/docker-compose.yml
+++ b/examples/ssobff/docker-compose.yml
@@ -4,9 +4,7 @@ services:
     environment:
       POSTGRES_DB: sso_bff
       POSTGRES_USER: gocell
-      # Demo credential for local `docker compose up`; DO NOT USE IN PRODUCTION.
-      # nosemgrep: generic.secrets.security.detected-generic-secret
-      POSTGRES_PASSWORD: gocell
+      POSTGRES_PASSWORD: ${GOCELL_EXAMPLE_POSTGRES_PASSWORD:?set GOCELL_EXAMPLE_POSTGRES_PASSWORD for local demo infrastructure}
     ports:
       - "5432:5432"
     volumes:
@@ -34,7 +32,7 @@ services:
       - "15672:15672"
     environment:
       RABBITMQ_DEFAULT_USER: gocell
-      RABBITMQ_DEFAULT_PASS: gocell
+      RABBITMQ_DEFAULT_PASS: ${GOCELL_EXAMPLE_RABBITMQ_PASSWORD:?set GOCELL_EXAMPLE_RABBITMQ_PASSWORD for local demo infrastructure}
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 10s

--- a/examples/todoorder/README.md
+++ b/examples/todoorder/README.md
@@ -53,6 +53,8 @@ Start infrastructure services, then run the application:
 
 ```bash
 cd examples/todoorder
+export GOCELL_EXAMPLE_POSTGRES_PASSWORD="$(openssl rand -base64 24)"
+export GOCELL_EXAMPLE_RABBITMQ_PASSWORD="$(openssl rand -base64 24)"
 docker compose up -d
 cd ../..
 # Export the JWT and GOCELL_TODOORDER_SERVICE_SECRET variables from Quick Start first.

--- a/examples/todoorder/docker-compose.yml
+++ b/examples/todoorder/docker-compose.yml
@@ -4,9 +4,7 @@ services:
     environment:
       POSTGRES_DB: todo_order
       POSTGRES_USER: gocell
-      # Demo credential for local `docker compose up`; DO NOT USE IN PRODUCTION.
-      # nosemgrep: generic.secrets.security.detected-generic-secret
-      POSTGRES_PASSWORD: gocell
+      POSTGRES_PASSWORD: ${GOCELL_EXAMPLE_POSTGRES_PASSWORD:?set GOCELL_EXAMPLE_POSTGRES_PASSWORD for local demo infrastructure}
     ports:
       - "5432:5432"
     volumes:
@@ -34,7 +32,7 @@ services:
       - "15672:15672"
     environment:
       RABBITMQ_DEFAULT_USER: gocell
-      RABBITMQ_DEFAULT_PASS: gocell
+      RABBITMQ_DEFAULT_PASS: ${GOCELL_EXAMPLE_RABBITMQ_PASSWORD:?set GOCELL_EXAMPLE_RABBITMQ_PASSWORD for local demo infrastructure}
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 10s

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -95,8 +95,9 @@ type Hub struct {
 	conns  map[string]*connEntry
 	wg     sync.WaitGroup // tracks readLoop + pingLoop goroutines
 
-	// cancelMu protects runCancel from concurrent Start/Stop access.
+	// cancelMu protects runCtx/runCancel from concurrent Start/Stop access.
 	cancelMu  sync.Mutex
+	runCtx    context.Context
 	runCancel context.CancelFunc
 
 	// shutdownDone is closed when shutdown completes. Lets concurrent
@@ -153,6 +154,7 @@ func (h *Hub) Start(ctx context.Context) error {
 		return errcode.New(ErrWSAlreadyStopped, "websocket: hub already stopped")
 	}
 	h.runCancel = cancel
+	h.runCtx = runCtx
 	h.wg.Add(1)
 	h.cancelMu.Unlock()
 
@@ -177,7 +179,7 @@ func (h *Hub) Start(ctx context.Context) error {
 
 	// External cancellation: run the single shutdown path ourselves.
 	shutdownCtx, shutdownCancel := context.WithTimeout(
-		context.Background(), defaultShutdownTimeout,
+		context.WithoutCancel(ctx), defaultShutdownTimeout,
 	)
 	defer shutdownCancel()
 	_ = h.shutdown(shutdownCtx)
@@ -223,6 +225,8 @@ func (h *Hub) shutdown(ctx context.Context) error {
 	// Cancel run context: stops pingLoop, unblocks Start if still blocking.
 	h.cancelMu.Lock()
 	cancel := h.runCancel
+	h.runCancel = nil
+	h.runCtx = nil
 	h.cancelMu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -284,6 +288,10 @@ func (h *Hub) shutdown(ctx context.Context) error {
 // The Hub must be in the running state (Start called). Register on an
 // idle, stopping, or stopped Hub returns an error and closes the conn.
 func (h *Hub) Register(conn Conn) error {
+	h.cancelMu.Lock()
+	runCtx := h.runCtx
+	h.cancelMu.Unlock()
+
 	h.connMu.Lock()
 	s := h.state.Load()
 	if s == stateStopping {
@@ -302,6 +310,11 @@ func (h *Hub) Register(conn Conn) error {
 		_ = conn.Close()
 		return errcode.New(ErrWSMaxConns, "websocket: max connections reached")
 	}
+	if runCtx == nil {
+		h.connMu.Unlock()
+		_ = conn.Close()
+		return errcode.New(ErrWSHubNotRunning, "websocket: hub is not running, connection rejected")
+	}
 
 	// Evict existing entry with same ID to prevent context leak.
 	var evicted *connEntry
@@ -310,7 +323,7 @@ func (h *Hub) Register(conn Conn) error {
 		evicted = old
 	}
 
-	connCtx, cancel := context.WithCancel(context.Background())
+	connCtx, cancel := context.WithCancel(runCtx)
 	entry := &connEntry{conn: conn, cancel: cancel}
 	h.conns[conn.ID()] = entry
 	h.wg.Add(1)

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -95,9 +95,8 @@ type Hub struct {
 	conns  map[string]*connEntry
 	wg     sync.WaitGroup // tracks readLoop + pingLoop goroutines
 
-	// cancelMu protects runCtx/runCancel from concurrent Start/Stop access.
+	// cancelMu protects runCancel from concurrent Start/Stop access.
 	cancelMu  sync.Mutex
-	runCtx    context.Context
 	runCancel context.CancelFunc
 
 	// shutdownDone is closed when shutdown completes. Lets concurrent
@@ -154,7 +153,6 @@ func (h *Hub) Start(ctx context.Context) error {
 		return errcode.New(ErrWSAlreadyStopped, "websocket: hub already stopped")
 	}
 	h.runCancel = cancel
-	h.runCtx = runCtx
 	h.wg.Add(1)
 	h.cancelMu.Unlock()
 
@@ -226,7 +224,6 @@ func (h *Hub) shutdown(ctx context.Context) error {
 	h.cancelMu.Lock()
 	cancel := h.runCancel
 	h.runCancel = nil
-	h.runCtx = nil
 	h.cancelMu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -281,17 +278,16 @@ func (h *Hub) shutdown(ctx context.Context) error {
 	return err
 }
 
-// Register adds a connection to the Hub and starts reading from it.
+// Register adds a connection to the Hub and starts reading from it. ctx is used
+// as the parent for per-connection values; cancellation is controlled by the
+// Hub so request-scope cancellation does not immediately tear down accepted
+// WebSocket connections after the HTTP handler returns.
 // The read loop uses a per-connection context that is cancelled when the
 // connection is unregistered or the Hub shuts down.
 //
 // The Hub must be in the running state (Start called). Register on an
 // idle, stopping, or stopped Hub returns an error and closes the conn.
-func (h *Hub) Register(conn Conn) error {
-	h.cancelMu.Lock()
-	runCtx := h.runCtx
-	h.cancelMu.Unlock()
-
+func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	h.connMu.Lock()
 	s := h.state.Load()
 	if s == stateStopping {
@@ -310,11 +306,6 @@ func (h *Hub) Register(conn Conn) error {
 		_ = conn.Close()
 		return errcode.New(ErrWSMaxConns, "websocket: max connections reached")
 	}
-	if runCtx == nil {
-		h.connMu.Unlock()
-		_ = conn.Close()
-		return errcode.New(ErrWSHubNotRunning, "websocket: hub is not running, connection rejected")
-	}
 
 	// Evict existing entry with same ID to prevent context leak.
 	var evicted *connEntry
@@ -323,7 +314,7 @@ func (h *Hub) Register(conn Conn) error {
 		evicted = old
 	}
 
-	connCtx, cancel := context.WithCancel(runCtx)
+	connCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	entry := &connEntry{conn: conn, cancel: cancel}
 	h.conns[conn.ID()] = entry
 	h.wg.Add(1)

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -378,6 +378,20 @@ func TestHub_RegisterOnStoppedHub(t *testing.T) {
 	assert.True(t, conn.isClosed())
 }
 
+func TestHub_RegisterWithoutRunContextRejected(t *testing.T) {
+	hub := NewHub(DefaultHubConfig(), nil)
+	hub.state.Store(stateRunning)
+
+	conn := newFakeConn("missing-runctx")
+	err := hub.Register(conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not running")
+	assert.True(t, conn.isClosed())
+
+	hub.state.Store(stateStopped)
+	close(hub.shutdownDone)
+}
+
 func TestHub_Unregister(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(), nil)
 
@@ -702,6 +716,22 @@ func TestDefaultHubConfig(t *testing.T) {
 	assert.Equal(t, 5*time.Second, cfg.PingTimeout)
 	assert.Equal(t, int64(64*1024), cfg.ReadLimit)
 	assert.Equal(t, 2, cfg.PingMissMax)
+}
+
+func TestNewHub_PreservesExplicitConfig(t *testing.T) {
+	cfg := HubConfig{
+		PingInterval:   time.Second,
+		PingTimeout:    250 * time.Millisecond,
+		ReadLimit:      1024,
+		PingMissMax:    5,
+		MaxConnections: 9,
+	}
+	handler := func(context.Context, string, []byte) {}
+
+	hub := NewHub(cfg, handler)
+
+	assert.Equal(t, cfg, hub.Config())
+	assert.NotNil(t, hub.handler)
 }
 
 func TestHub_IsRunning(t *testing.T) {

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -215,7 +215,7 @@ func TestHub_StopTimeout(t *testing.T) {
 
 	// Register a conn whose Close is a no-op (readLoop never exits).
 	stuck := &stuckConn{id: "stuck", closeCh: make(chan struct{})}
-	require.NoError(t, hub.Register(stuck))
+	require.NoError(t, hub.Register(context.Background(), stuck))
 
 	// Stop with very short timeout.
 	stopCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -242,7 +242,7 @@ func TestHub_ExternalContextCancel(t *testing.T) {
 
 	// Register a conn before cancel.
 	conn := newFakeConn("pre-cancel")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	cancel()
@@ -260,7 +260,7 @@ func TestHub_ExternalContextCancel(t *testing.T) {
 
 	// Register must be rejected.
 	lateConn := newFakeConn("post-cancel")
-	err := hub.Register(lateConn)
+	err := hub.Register(context.Background(), lateConn)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not running")
 
@@ -289,7 +289,7 @@ func TestHub_RegisterAndReadLoop(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(), handler)
 
 	conn := newFakeConn("sender")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	conn.readCh <- []byte("hello server")
@@ -306,18 +306,18 @@ func TestHub_RegisterAndReadLoop(t *testing.T) {
 	mu.Unlock()
 }
 
-func TestHub_RegisterUsesStartContextValues(t *testing.T) {
+func TestHub_RegisterUsesContextValues(t *testing.T) {
 	type ctxKey string
 
 	const want = "trace-123"
 	got := make(chan any, 1)
-	ctx := context.WithValue(context.Background(), ctxKey("trace-id"), want)
+	registerCtx := context.WithValue(context.Background(), ctxKey("trace-id"), want)
 	hub := NewHub(DefaultHubConfig(), func(ctx context.Context, _ string, _ []byte) {
 		got <- ctx.Value(ctxKey("trace-id"))
 	})
 
 	startErr := make(chan error, 1)
-	go func() { startErr <- hub.Start(ctx) }()
+	go func() { startErr <- hub.Start(context.Background()) }()
 	t.Cleanup(func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
@@ -330,7 +330,7 @@ func TestHub_RegisterUsesStartContextValues(t *testing.T) {
 	}, time.Second, time.Millisecond)
 
 	conn := newFakeConn("context-values")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(registerCtx, conn))
 	<-conn.readyCh
 
 	conn.readCh <- []byte("hello")
@@ -354,7 +354,7 @@ func TestHub_RegisterDuringStop(t *testing.T) {
 	hub.state.Store(stateStopping)
 
 	conn := newFakeConn("rejected")
-	err := hub.Register(conn)
+	err := hub.Register(context.Background(), conn)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stopping")
 	assert.True(t, conn.isClosed())
@@ -372,31 +372,17 @@ func TestHub_RegisterOnStoppedHub(t *testing.T) {
 	_ = hub.Stop(context.Background())
 
 	conn := newFakeConn("late")
-	err := hub.Register(conn)
+	err := hub.Register(context.Background(), conn)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not running")
 	assert.True(t, conn.isClosed())
-}
-
-func TestHub_RegisterWithoutRunContextRejected(t *testing.T) {
-	hub := NewHub(DefaultHubConfig(), nil)
-	hub.state.Store(stateRunning)
-
-	conn := newFakeConn("missing-runctx")
-	err := hub.Register(conn)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not running")
-	assert.True(t, conn.isClosed())
-
-	hub.state.Store(stateStopped)
-	close(hub.shutdownDone)
 }
 
 func TestHub_Unregister(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(), nil)
 
 	conn := newFakeConn("c1")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	assert.Equal(t, 1, hub.ConnCount())
@@ -412,7 +398,7 @@ func TestHub_UnregisterIdempotent(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(), nil)
 
 	conn := newFakeConn("c1")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	hub.Unregister("c1")
@@ -427,13 +413,13 @@ func TestHub_RegisterDuplicateID(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(), nil)
 
 	connA := newFakeConn("dup")
-	require.NoError(t, hub.Register(connA))
+	require.NoError(t, hub.Register(context.Background(), connA))
 	<-connA.readyCh
 	assert.Equal(t, 1, hub.ConnCount())
 
 	// Register with same ID — old conn should be evicted.
 	connB := newFakeConn("dup")
-	require.NoError(t, hub.Register(connB))
+	require.NoError(t, hub.Register(context.Background(), connB))
 	<-connB.readyCh
 
 	assert.Equal(t, 1, hub.ConnCount(), "map should have exactly 1 entry")
@@ -452,15 +438,15 @@ func TestHub_MaxConnections(t *testing.T) {
 
 	c1 := newFakeConn("c1")
 	c2 := newFakeConn("c2")
-	require.NoError(t, hub.Register(c1))
-	require.NoError(t, hub.Register(c2))
+	require.NoError(t, hub.Register(context.Background(), c1))
+	require.NoError(t, hub.Register(context.Background(), c2))
 	<-c1.readyCh
 	<-c2.readyCh
 	assert.Equal(t, 2, hub.ConnCount())
 
 	// Third connection should be rejected.
 	c3 := newFakeConn("c3")
-	err := hub.Register(c3)
+	err := hub.Register(context.Background(), c3)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max connections")
 	assert.True(t, c3.isClosed(), "rejected conn should be closed")
@@ -487,7 +473,7 @@ func TestHub_RegisterStopRace(t *testing.T) {
 		go func(idx int) {
 			defer registerWg.Done()
 			c := newFakeConn(fmt.Sprintf("race-%d", idx))
-			_ = hub.Register(c)
+			_ = hub.Register(context.Background(), c)
 		}(i)
 	}
 
@@ -508,7 +494,7 @@ func TestHub_ConcurrentBroadcast(t *testing.T) {
 	for i := range conns {
 		c := newFakeConn("bc" + string(rune('0'+i)))
 		conns[i] = c
-		require.NoError(t, hub.Register(c))
+		require.NoError(t, hub.Register(context.Background(), c))
 		<-c.readyCh
 	}
 
@@ -536,8 +522,8 @@ func TestHub_Broadcast(t *testing.T) {
 
 	c1 := newFakeConn("c1")
 	c2 := newFakeConn("c2")
-	require.NoError(t, hub.Register(c1))
-	require.NoError(t, hub.Register(c2))
+	require.NoError(t, hub.Register(context.Background(), c1))
+	require.NoError(t, hub.Register(context.Background(), c2))
 	<-c1.readyCh
 	<-c2.readyCh
 
@@ -554,8 +540,8 @@ func TestHub_BroadcastSlowConn(t *testing.T) {
 	slow := newFakeConn("slow")
 	slow.writeDelay = 200 * time.Millisecond
 
-	require.NoError(t, hub.Register(fast))
-	require.NoError(t, hub.Register(slow))
+	require.NoError(t, hub.Register(context.Background(), fast))
+	require.NoError(t, hub.Register(context.Background(), slow))
 	<-fast.readyCh
 	<-slow.readyCh
 
@@ -572,7 +558,7 @@ func TestHub_Send(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(), nil)
 
 	conn := newFakeConn("target")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	require.NoError(t, hub.Send(context.Background(), "target", []byte("direct")))
@@ -605,7 +591,7 @@ func TestHub_MessageHandler(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(), handler)
 
 	conn := newFakeConn("h1")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	conn.readCh <- []byte("payload")
@@ -637,7 +623,7 @@ func TestHub_PingMissThreshold(t *testing.T) {
 
 	conn := newFakeConn("pinger")
 	conn.pingErr = errors.New("timeout")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	require.Eventually(t, func() bool {
@@ -655,7 +641,7 @@ func TestHub_PingMissReset(t *testing.T) {
 
 	conn := newFakeConn("resilient")
 	conn.pingErr = errors.New("fail")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	// Let 2 ping misses accumulate (below threshold).
@@ -698,7 +684,7 @@ func TestHub_PingLoopRunsOnInterval(t *testing.T) {
 	hub := startHub(t, cfg, nil)
 
 	conn := newFakeConn("counter")
-	require.NoError(t, hub.Register(conn))
+	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
 	// Wait long enough for multiple pings, verify conn is still alive.
@@ -759,7 +745,7 @@ func TestHub_StopDeadlineHonored(t *testing.T) {
 
 	// Register a stuck conn that blocks Close.
 	stuck := &stuckConn{id: "blocker", closeCh: make(chan struct{})}
-	require.NoError(t, hub.Register(stuck))
+	require.NoError(t, hub.Register(context.Background(), stuck))
 
 	// Stop with 100ms deadline — must return within ~200ms regardless of
 	// stuck conn.
@@ -835,7 +821,7 @@ func TestHub_StateMachine(t *testing.T) {
 		return h.Stop(context.Background())
 	}, ""}
 	registerAction := action{"Register", func(h *Hub) error {
-		return h.Register(newFakeConn("sm"))
+		return h.Register(context.Background(), newFakeConn("sm"))
 	}, ""}
 
 	tests := []struct {

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -306,6 +306,42 @@ func TestHub_RegisterAndReadLoop(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestHub_RegisterUsesStartContextValues(t *testing.T) {
+	type ctxKey string
+
+	const want = "trace-123"
+	got := make(chan any, 1)
+	ctx := context.WithValue(context.Background(), ctxKey("trace-id"), want)
+	hub := NewHub(DefaultHubConfig(), func(ctx context.Context, _ string, _ []byte) {
+		got <- ctx.Value(ctxKey("trace-id"))
+	})
+
+	startErr := make(chan error, 1)
+	go func() { startErr <- hub.Start(ctx) }()
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = hub.Stop(stopCtx)
+		<-startErr
+	})
+
+	require.Eventually(t, func() bool {
+		return hub.state.Load() == stateRunning
+	}, time.Second, time.Millisecond)
+
+	conn := newFakeConn("context-values")
+	require.NoError(t, hub.Register(conn))
+	<-conn.readyCh
+
+	conn.readCh <- []byte("hello")
+	select {
+	case value := <-got:
+		assert.Equal(t, want, value)
+	case <-time.After(time.Second):
+		t.Fatal("handler did not receive message")
+	}
+}
+
 func TestHub_RegisterDuringStop(t *testing.T) {
 	hub := NewHub(DefaultHubConfig(), nil)
 	startErr := make(chan error, 1)

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -321,38 +321,8 @@ func findInsecureSkipVerifyAssign(path string) ([]int, error) {
 func testSEC05ExampleComposeCredentialsFromEnv(t *testing.T, root string) {
 	t.Helper()
 
-	files := []string{
-		filepath.Join(root, "examples", "iotdevice", "docker-compose.yml"),
-		filepath.Join(root, "examples", "ssobff", "docker-compose.yml"),
-		filepath.Join(root, "examples", "todoorder", "docker-compose.yml"),
-	}
-	keys := []string{
-		"POSTGRES_PASSWORD:",
-		"RABBITMQ_DEFAULT_PASS:",
-	}
-
-	var violations []string
-	for _, f := range files {
-		data, err := os.ReadFile(f)
-		require.NoErrorf(t, err, "reading %s", f)
-		rel, _ := filepath.Rel(root, f)
-		rel = filepath.ToSlash(rel)
-
-		for i, line := range strings.Split(string(data), "\n") {
-			trimmed := strings.TrimSpace(line)
-			for _, key := range keys {
-				if !strings.HasPrefix(trimmed, key) {
-					continue
-				}
-				value := strings.TrimSpace(strings.TrimPrefix(trimmed, key))
-				if !strings.HasPrefix(value, "${") {
-					violations = append(violations,
-						fmt.Sprintf("%s:%d: %s must be sourced from environment interpolation (%s)",
-							rel, i+1, strings.TrimSuffix(key, ":"), secFailClosed05))
-				}
-			}
-		}
-	}
+	violations, err := findExampleComposeCredentialViolations(root)
+	require.NoError(t, err)
 
 	if len(violations) > 0 {
 		for _, v := range violations {
@@ -361,4 +331,102 @@ func testSEC05ExampleComposeCredentialsFromEnv(t *testing.T, root string) {
 	}
 	assert.Empty(t, violations,
 		"example docker compose credential values must use ${VAR:?required} instead of committed literals")
+}
+
+func TestSEC05ExampleComposeCredentialsRejectsFallbacksInFutureExamples(t *testing.T) {
+	root := t.TempDir()
+	exampleDir := filepath.Join(root, "examples", "futuredevice")
+	require.NoError(t, os.MkdirAll(exampleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(exampleDir, "docker-compose.yml"), []byte(`
+services:
+  postgres:
+    environment:
+      POSTGRES_PASSWORD: ${FUTURE_POSTGRES_PASSWORD:-gocell}
+  rabbitmq:
+    environment:
+      RABBITMQ_DEFAULT_PASS: ${FUTURE_RABBITMQ_PASSWORD:?required}
+`), 0o644))
+
+	violations, err := findExampleComposeCredentialViolations(root)
+	require.NoError(t, err)
+	require.Len(t, violations, 1)
+	assert.Contains(t, violations[0], "examples/futuredevice/docker-compose.yml:5")
+	assert.Contains(t, violations[0], "POSTGRES_PASSWORD")
+}
+
+func findExampleComposeCredentialViolations(root string) ([]string, error) {
+	var violations []string
+	examplesDir := filepath.Join(root, "examples")
+	err := filepath.WalkDir(examplesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) != "docker-compose.yml" {
+			return nil
+		}
+		fileViolations, err := findComposeCredentialViolations(root, path)
+		if err != nil {
+			return err
+		}
+		violations = append(violations, fileViolations...)
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return violations, err
+}
+
+func findComposeCredentialViolations(root, path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	rel, _ := filepath.Rel(root, path)
+	rel = filepath.ToSlash(rel)
+
+	var violations []string
+	for i, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		key, value, ok := strings.Cut(trimmed, ":")
+		if !ok || !isComposeCredentialKey(key) {
+			continue
+		}
+		if !isRequiredComposeEnvInterpolation(value) {
+			violations = append(violations,
+				fmt.Sprintf("%s:%d: %s must use required environment interpolation ${VAR:?message} (%s)",
+					rel, i+1, key, secFailClosed05))
+		}
+	}
+	return violations, nil
+}
+
+func isComposeCredentialKey(key string) bool {
+	return strings.Contains(key, "PASSWORD") || strings.HasSuffix(key, "_PASS")
+}
+
+func isRequiredComposeEnvInterpolation(value string) bool {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, `"'`)
+	if !strings.HasPrefix(value, "${") || !strings.HasSuffix(value, "}") {
+		return false
+	}
+	inner := strings.TrimSuffix(strings.TrimPrefix(value, "${"), "}")
+	name, message, ok := strings.Cut(inner, ":?")
+	if !ok || name == "" || message == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'A' && r <= 'Z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -2,7 +2,7 @@ package archtest
 
 // security_defaults_test.go — static archtest rules for PR-MODE-1 SEC-FAIL-CLOSED.
 //
-// Four sub-tests mirror the SEC-FAIL-CLOSED-01..04 rule IDs:
+// Five sub-tests mirror the SEC-FAIL-CLOSED-01..05 rule IDs:
 //
 //   01  addr-driven gate: bundle.go must not wrap WithListener in IfStmt guarded
 //       by PrimaryHTTPAddr / InternalHTTPAddr / HealthHTTPAddr != "".
@@ -12,6 +12,8 @@ package archtest
 //       and call secutil.ValidateTLSEndpoint.
 //   04  websocket origins: no file in adapters/websocket may assign
 //       opts.InsecureSkipVerify = true.
+//   05  example docker compose credentials must come from environment
+//       interpolation, not committed literal values.
 //
 // ref: tools/archtest/auth_authtest_boundary_test.go — 4 sub-test pattern
 
@@ -34,6 +36,7 @@ const (
 	secFailClosed02 = "SEC-FAIL-CLOSED-02"
 	secFailClosed03 = "SEC-FAIL-CLOSED-03"
 	secFailClosed04 = "SEC-FAIL-CLOSED-04"
+	secFailClosed05 = "SEC-FAIL-CLOSED-05"
 )
 
 func TestSecurityDefaults(t *testing.T) {
@@ -53,6 +56,10 @@ func TestSecurityDefaults(t *testing.T) {
 
 	t.Run(secFailClosed04+"_websocket_must_not_skip_origin_verify", func(t *testing.T) {
 		testSEC04WebSocketOriginVerify(t, root)
+	})
+
+	t.Run(secFailClosed05+"_example_compose_credentials_from_env", func(t *testing.T) {
+		testSEC05ExampleComposeCredentialsFromEnv(t, root)
 	})
 }
 
@@ -309,4 +316,49 @@ func findInsecureSkipVerifyAssign(path string) ([]int, error) {
 		return true
 	})
 	return lines, nil
+}
+
+func testSEC05ExampleComposeCredentialsFromEnv(t *testing.T, root string) {
+	t.Helper()
+
+	files := []string{
+		filepath.Join(root, "examples", "iotdevice", "docker-compose.yml"),
+		filepath.Join(root, "examples", "ssobff", "docker-compose.yml"),
+		filepath.Join(root, "examples", "todoorder", "docker-compose.yml"),
+	}
+	keys := []string{
+		"POSTGRES_PASSWORD:",
+		"RABBITMQ_DEFAULT_PASS:",
+	}
+
+	var violations []string
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		require.NoErrorf(t, err, "reading %s", f)
+		rel, _ := filepath.Rel(root, f)
+		rel = filepath.ToSlash(rel)
+
+		for i, line := range strings.Split(string(data), "\n") {
+			trimmed := strings.TrimSpace(line)
+			for _, key := range keys {
+				if !strings.HasPrefix(trimmed, key) {
+					continue
+				}
+				value := strings.TrimSpace(strings.TrimPrefix(trimmed, key))
+				if !strings.HasPrefix(value, "${") {
+					violations = append(violations,
+						fmt.Sprintf("%s:%d: %s must be sourced from environment interpolation (%s)",
+							rel, i+1, strings.TrimSuffix(key, ":"), secFailClosed05))
+				}
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		for _, v := range violations {
+			t.Logf("%s violation: %s", secFailClosed05, v)
+		}
+	}
+	assert.Empty(t, violations,
+		"example docker compose credential values must use ${VAR:?required} instead of committed literals")
 }


### PR DESCRIPTION
## Summary
- Replace example docker-compose hardcoded PostgreSQL/RabbitMQ passwords with required environment interpolation.
- Preserve caller context values while detaching long-lived initial-admin cleaner and websocket shutdown contexts from cancellation deadlines.
- Add regression coverage for example compose credential literals and websocket connection contexts.
- Update example Docker Mode docs for the required local demo env vars.

Refs: Sonar hardcoded credential findings and context.Background maintainability findings
ref: Go stdlib context.WithoutCancel

## Test Plan
- [x] `go test ./tools/archtest -run TestSecurityDefaults -count=1`
- [x] `go test ./cells/accesscore/initialadmin -run 'TestLifecycle_' -count=1`
- [x] `go test ./runtime/websocket -run 'TestHub_(RegisterUsesStartContextValues|RegisterStopRace|StopUnblocksStart|ExternalContextCancel)' -count=1`
- [x] `go test ./runtime/websocket -count=1`
- [x] `go test ./examples/ssobff ./examples/todoorder ./examples/iotdevice -count=1`
- [x] `GOCELL_EXAMPLE_POSTGRES_PASSWORD=test-postgres GOCELL_EXAMPLE_RABBITMQ_PASSWORD=test-rabbitmq docker compose -f examples/iotdevice/docker-compose.yml config >/dev/null && ...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./tools/archtest ./runtime/websocket ./cells/accesscore/initialadmin`
