### PR TITLE
fix(contracts): guard query parameter metadata drift

### DIFF
--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -196,6 +196,7 @@ func TestHttpAuthUserPatchV1Serve(t *testing.T) {
 	c.ValidateRequest(t, []byte(`{"name":"Bob"}`))
 	c.ValidateRequest(t, []byte(`{"email":"new@b.com"}`))
 	c.ValidateRequest(t, []byte(`{"name":"Bob","email":"new@b.com","status":"active"}`))
+	c.MustRejectRequest(t, []byte(`{"email":"new@b.com","extra":"ignored"}`))
 
 	c.MustRejectResponse(t, []byte(`{"wrong":"shape"}`))
 }

--- a/cells/accesscore/slices/identitymanage/handler.go
+++ b/cells/accesscore/slices/identitymanage/handler.go
@@ -1,6 +1,7 @@
 package identitymanage
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -242,51 +243,53 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	// JSON merge patch: only fields present in the JSON body are updated.
-	// Patchable fields: name, email, status. Other fields are silently ignored.
-	// Uses DecodeJSON (not strict) because map targets accept any key by design.
-	var raw map[string]json.RawMessage
-	if err := httputil.DecodeJSON(r, &raw); err != nil {
+	var req struct {
+		Name                 json.RawMessage `json:"name"`
+		Email                json.RawMessage `json:"email"`
+		Status               json.RawMessage `json:"status"`
+		RequirePasswordReset json.RawMessage `json:"requirePasswordReset"`
+	}
+	if err := httputil.DecodeJSONStrict(r, &req); err != nil {
 		httputil.WriteDecodeError(r.Context(), w, err)
 		return
 	}
 
 	input := UpdateInput{ID: id}
-	if v, ok := raw["name"]; ok {
-		var name string
-		if err := json.Unmarshal(v, &name); err != nil {
-			httputil.WriteError(r.Context(), w, http.StatusBadRequest,
-				string(errcode.ErrValidationFailed), fmt.Sprintf("field 'name' must be a string: %v", err))
-			return
-		}
-		input.Name = &name
+	name, err := decodePatchString(req.Name, "name")
+	if err != nil {
+		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
+			string(errcode.ErrValidationFailed), err.Error())
+		return
 	}
-	if v, ok := raw["email"]; ok {
-		var email string
-		if err := json.Unmarshal(v, &email); err != nil {
-			httputil.WriteError(r.Context(), w, http.StatusBadRequest,
-				string(errcode.ErrValidationFailed), fmt.Sprintf("field 'email' must be a string: %v", err))
-			return
-		}
-		input.Email = &email
+	if name != nil {
+		input.Name = name
 	}
-	if v, ok := raw["status"]; ok {
-		var status string
-		if err := json.Unmarshal(v, &status); err != nil {
-			httputil.WriteError(r.Context(), w, http.StatusBadRequest,
-				string(errcode.ErrValidationFailed), fmt.Sprintf("field 'status' must be a string: %v", err))
-			return
-		}
-		input.Status = &status
+	email, err := decodePatchString(req.Email, "email")
+	if err != nil {
+		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
+			string(errcode.ErrValidationFailed), err.Error())
+		return
 	}
-	if v, ok := raw["requirePasswordReset"]; ok {
-		var flag bool
-		if err := json.Unmarshal(v, &flag); err != nil {
-			httputil.WriteError(r.Context(), w, http.StatusBadRequest,
-				string(errcode.ErrValidationFailed), fmt.Sprintf("field 'requirePasswordReset' must be a boolean: %v", err))
-			return
-		}
-		input.RequirePasswordReset = &flag
+	if email != nil {
+		input.Email = email
+	}
+	status, err := decodePatchString(req.Status, "status")
+	if err != nil {
+		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
+			string(errcode.ErrValidationFailed), err.Error())
+		return
+	}
+	if status != nil {
+		input.Status = status
+	}
+	requirePasswordReset, err := decodePatchBool(req.RequirePasswordReset, "requirePasswordReset")
+	if err != nil {
+		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
+			string(errcode.ErrValidationFailed), err.Error())
+		return
+	}
+	if requirePasswordReset != nil {
+		input.RequirePasswordReset = requirePasswordReset
 	}
 
 	user, err := h.svc.Update(r.Context(), input)
@@ -295,6 +298,34 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": toUserResponse(user)})
+}
+
+func decodePatchString(raw json.RawMessage, field string) (*string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, fmt.Errorf("field '%s' must be a string", field)
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("field '%s' must be a string: %w", field, err)
+	}
+	return &value, nil
+}
+
+func decodePatchBool(raw json.RawMessage, field string) (*bool, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, fmt.Errorf("field '%s' must be a boolean", field)
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("field '%s' must be a boolean: %w", field, err)
+	}
+	return &value, nil
 }
 
 func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {

--- a/cells/accesscore/slices/identitymanage/handler_test.go
+++ b/cells/accesscore/slices/identitymanage/handler_test.go
@@ -339,7 +339,7 @@ func TestHandler_UpdateUnknownField(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestHandler_PatchAcceptsUnknownFields(t *testing.T) {
+func TestHandler_PatchRejectsUnknownFields(t *testing.T) {
 	r := setup()
 
 	// Create a user first (as admin).
@@ -357,14 +357,15 @@ func TestHandler_PatchAcceptsUnknownFields(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
 
-	// PATCH with unknown field should succeed (merge patch accepts any key, self-access).
+	// PATCH request schema is strict; unknown fields should fail fast instead
+	// of being silently ignored.
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPatch, identityPrefix+"/"+created.Data.ID,
 		strings.NewReader(`{"email":"new@f.com","extra":"ignored"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(auth.TestContext(created.Data.ID, nil)) // self-access
 	r.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code, "PATCH uses DecodeJSON (not strict); unknown fields must be accepted for merge patch semantics")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "PATCH must reject unknown fields to match additionalProperties:false")
 }
 
 func TestHandler_CreateThenGetThenDelete(t *testing.T) {

--- a/cells/auditcore/slices/auditquery/contract_test.go
+++ b/cells/auditcore/slices/auditquery/contract_test.go
@@ -71,3 +71,44 @@ func TestHttpAuditListV1Serve_Empty(t *testing.T) {
 
 	c.MustRejectResponse(t, []byte(`{"data":"not-array","hasMore":false}`))
 }
+
+func TestHttpAuditListV1_QueryParamsMetadata(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.audit.list.v1")
+	if c.HTTP == nil {
+		t.Fatal("HTTP transport metadata should be loaded")
+	}
+
+	want := map[string]string{
+		"actorId":   "string",
+		"cursor":    "string",
+		"eventType": "string",
+		"from":      "string",
+		"limit":     "integer",
+		"to":        "string",
+	}
+	if len(c.HTTP.QueryParams) != len(want) {
+		t.Fatalf("queryParams count = %d, want %d (%v)", len(c.HTTP.QueryParams), len(want), want)
+	}
+	for name, wantType := range want {
+		param, ok := c.HTTP.QueryParams[name]
+		if !ok {
+			t.Fatalf("queryParams missing %q", name)
+		}
+		if param.Type != wantType {
+			t.Fatalf("queryParams.%s.type = %q, want %q", name, param.Type, wantType)
+		}
+	}
+	if got := c.HTTP.QueryParams["cursor"].MaxLength; got == nil || *got != query.MaxCursorTokenBytes {
+		t.Fatalf("queryParams.cursor.maxLength = %v, want %d", got, query.MaxCursorTokenBytes)
+	}
+	if got := c.HTTP.QueryParams["limit"].Maximum; got == nil || *got != query.MaxPageSize {
+		t.Fatalf("queryParams.limit.maximum = %v, want %d", got, query.MaxPageSize)
+	}
+	if got := c.HTTP.QueryParams["from"].Format; got != "date-time" {
+		t.Fatalf("queryParams.from.format = %q, want date-time", got)
+	}
+	if got := c.HTTP.QueryParams["to"].Format; got != "date-time" {
+		t.Fatalf("queryParams.to.format = %q, want date-time", got)
+	}
+}

--- a/contracts/http/audit/list/v1/contract.yaml
+++ b/contracts/http/audit/list/v1/contract.yaml
@@ -11,16 +11,38 @@ endpoints:
     method: GET
     path: /api/v1/audit/entries
     queryParams:
-      cursor:
+      actorId:
         type: string
         required: false
         minLength: 0
         maxLength: 256
+      cursor:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 4096
+      eventType:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 256
+      from:
+        type: string
+        format: date-time
+        required: false
+        minLength: 0
+        maxLength: 64
       limit:
         type: integer
         required: false
         minimum: 1
         maximum: 500
+      to:
+        type: string
+        format: date-time
+        required: false
+        minLength: 0
+        maxLength: 64
     successStatus: 200
     noContent: false
     responses:

--- a/contracts/http/auth/role/list/v1/contract.yaml
+++ b/contracts/http/auth/role/list/v1/contract.yaml
@@ -19,7 +19,7 @@ endpoints:
         type: string
         required: false
         minLength: 0
-        maxLength: 256
+        maxLength: 4096
       limit:
         type: integer
         required: false

--- a/contracts/http/config/flags/list/v1/contract.yaml
+++ b/contracts/http/config/flags/list/v1/contract.yaml
@@ -15,7 +15,7 @@ endpoints:
         type: string
         required: false
         minLength: 0
-        maxLength: 256
+        maxLength: 4096
       limit:
         type: integer
         required: false

--- a/contracts/http/config/list/v1/contract.yaml
+++ b/contracts/http/config/list/v1/contract.yaml
@@ -15,7 +15,7 @@ endpoints:
         type: string
         required: false
         minLength: 0
-        maxLength: 256
+        maxLength: 4096
       limit:
         type: integer
         required: false

--- a/examples/iotdevice/contracts/http/device/command/dequeue/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/command/dequeue/v1/contract.yaml
@@ -15,6 +15,17 @@ endpoints:
         type: string
         minLength: 1
         maxLength: 256
+    queryParams:
+      cursor:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 4096
+      limit:
+        type: integer
+        required: false
+        minimum: 1
+        maximum: 500
     successStatus: 200
     noContent: false
     responses:

--- a/examples/iotdevice/contracts/http/device/list/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/device/list/v1/contract.yaml
@@ -10,6 +10,17 @@ endpoints:
   http:
     method: GET
     path: /api/v1/devices/
+    queryParams:
+      cursor:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 4096
+      limit:
+        type: integer
+        required: false
+        minimum: 1
+        maximum: 500
     successStatus: 200
     noContent: false
     responses:

--- a/examples/iotdevice/contracts/http/internal/devicecommands/list/v1/contract.yaml
+++ b/examples/iotdevice/contracts/http/internal/devicecommands/list/v1/contract.yaml
@@ -9,6 +9,27 @@ endpoints:
   http:
     method: GET
     path: /internal/v1/devicecommands
+    queryParams:
+      cursor:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 4096
+      deviceId:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 256
+      limit:
+        type: integer
+        required: false
+        minimum: 1
+        maximum: 500
+      statuses:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 256
     successStatus: 200
     noContent: false
     responses:

--- a/examples/todoorder/contracts/http/order/list/v1/contract.yaml
+++ b/examples/todoorder/contracts/http/order/list/v1/contract.yaml
@@ -10,6 +10,17 @@ endpoints:
   http:
     method: GET
     path: /api/v1/orders/
+    queryParams:
+      cursor:
+        type: string
+        required: false
+        minLength: 0
+        maxLength: 4096
+      limit:
+        type: integer
+        required: false
+        minimum: 1
+        maximum: 500
     successStatus: 200
     noContent: false
     responses:

--- a/runtime/config/watcher.go
+++ b/runtime/config/watcher.go
@@ -143,6 +143,7 @@ type Watcher struct {
 	pendingPivot  bool           // true if any coalesced event was a symlink pivot
 	debounceMu    sync.Mutex     // protects timer + pendingPivot manipulation
 	closed        atomic.Bool    // admission gate: true after Close() starts
+	callbackGate  sync.Mutex     // serializes callback admission with Close Wait
 	callbackWg    sync.WaitGroup // tracks in-flight callback execution
 	closeErr      error          // cached Close result
 }
@@ -389,8 +390,23 @@ func (w *Watcher) firePendingCallbacks() {
 	w.fireCallbacks(pivot)
 }
 
-func (w *Watcher) fireCallbacks(symPivot bool) {
+// beginCallback admits one callback run and records it as in-flight.
+// The gate makes the closed check and WaitGroup Add atomic with Close's
+// transition to drain, so Add cannot race with Wait.
+func (w *Watcher) beginCallback() bool {
+	w.callbackGate.Lock()
+	defer w.callbackGate.Unlock()
+	if w.closed.Load() {
+		return false
+	}
 	w.callbackWg.Add(1)
+	return true
+}
+
+func (w *Watcher) fireCallbacks(symPivot bool) {
+	if !w.beginCallback() {
+		return
+	}
 	defer w.callbackWg.Done()
 
 	w.mu.Lock()
@@ -427,9 +443,10 @@ func (w *Watcher) fireCallbacks(symPivot bool) {
 // ref: uber-go/fx lifecycle OnStop(ctx) — ContextCloser pattern.
 func (w *Watcher) Close(ctx context.Context) error {
 	w.closeOnce.Do(func() {
-		// Set admission gate first — firePendingCallbacks and scheduleCallback
-		// check this before touching the WaitGroup, preventing Add-after-Wait.
+		// Stop admitting callbacks before waiting for in-flight ones.
+		w.callbackGate.Lock()
 		w.closed.Store(true)
+		w.callbackGate.Unlock()
 		close(w.done)
 
 		// Stop debounce timers to prevent goroutine leaks. Timer goroutines

--- a/runtime/config/watcher_test.go
+++ b/runtime/config/watcher_test.go
@@ -699,6 +699,50 @@ func TestWatcher_Close_DuringDebounceTimer(t *testing.T) {
 	require.NoError(t, w.Close(context.Background()), "Close(ctx) during active debounce timer must not error")
 }
 
+func TestWatcher_Close_ConcurrentImmediateCallbacksRace(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "config.yaml")
+	touchFile(t, file, "key: v0")
+
+	w, err := NewWatcher(file, WithDebounce(0))
+	require.NoError(t, err)
+
+	callbackStarted := make(chan struct{})
+	releaseCallbacks := make(chan struct{})
+	var startedOnce sync.Once
+	w.OnChange(func(_ WatchEvent) {
+		startedOnce.Do(func() { close(callbackStarted) })
+		<-releaseCallbacks
+	})
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			w.fireCallbacks(false)
+		}()
+	}
+
+	close(start)
+	select {
+	case <-callbackStarted:
+	case <-time.After(2 * time.Second):
+		close(releaseCallbacks)
+		wg.Wait()
+		t.Fatal("callback did not start")
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_ = w.Close(closeCtx)
+
+	close(releaseCallbacks)
+	wg.Wait()
+}
+
 func TestWatcher_RaceDetection_ConcurrentWriteAndClose(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "config.yaml")

--- a/tools/archtest/queryparam_drift_test.go
+++ b/tools/archtest/queryparam_drift_test.go
@@ -183,7 +183,7 @@ func scanQueryParamFile(root, path string) ([]routeQueryBinding, map[string]map[
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 	if err != nil {
-		return nil, nil, nil
+		return nil, nil, fmt.Errorf("parse %s: %w", filepath.ToSlash(path), err)
 	}
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
@@ -192,6 +192,18 @@ func scanQueryParamFile(root, path string) ([]routeQueryBinding, map[string]map[
 	rel = filepath.ToSlash(rel)
 	specIDs := collectContractSpecIDs(file)
 	return collectRouteBindings(fset, file, rel, specIDs), collectQueryParamUses(file, rel), nil
+}
+
+func TestScanQueryParamFile_ParseErrorFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "cells", "badcell", "slices", "bad", "handler.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("package bad\nfunc broken("), 0o644))
+
+	_, _, err := scanQueryParamFile(root, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse")
+	assert.Contains(t, err.Error(), filepath.ToSlash(path))
 }
 
 func collectContractSpecIDs(file *ast.File) map[string]string {
@@ -424,11 +436,24 @@ func routeFuncKeys(rel string, expr ast.Expr) []string {
 }
 
 func routeFuncKeysFromCall(rel string, call *ast.CallExpr) []string {
-	var funcs []string
+	funcs := routeFuncKeys(rel, call.Fun)
 	for _, arg := range call.Args {
 		funcs = append(funcs, routeFuncKeys(rel, arg)...)
 	}
 	return funcs
+}
+
+func TestRouteFuncKeysFromCallIncludesCalleeAndArgs(t *testing.T) {
+	expr, err := parser.ParseExpr(`wrapPolicy(auditQueryPolicy, h.HandleQuery)`)
+	require.NoError(t, err)
+
+	got := routeFuncKeys("cells/auditcore/slices/auditquery/handler.go", expr)
+
+	assert.ElementsMatch(t, []string{
+		"cells/auditcore/slices/auditquery/handler.go#wrapPolicy",
+		"cells/auditcore/slices/auditquery/handler.go#auditQueryPolicy",
+		"cells/auditcore/slices/auditquery/handler.go#HandleQuery",
+	}, got)
 }
 
 func queryGetParam(call *ast.CallExpr) (string, bool) {

--- a/tools/archtest/queryparam_drift_test.go
+++ b/tools/archtest/queryparam_drift_test.go
@@ -1,0 +1,514 @@
+package archtest
+
+// queryparam_drift_test.go - static archtest for PR-MODE-3 META-QUERYPARAM-DRIFT.
+//
+// The rule compares query parameters consumed by HTTP handlers/policies against
+// the endpoint's contract.yaml declaration. The contract is the source of truth;
+// every query parameter read from r.URL.Query().Get("...") or from the shared
+// pagination parser must appear under endpoints.http.queryParams, and declared
+// query params must be consumed by the mounted handler or policy.
+//
+// ref: kubernetes/pkg/apis/core/validation/validation.go - collect all field
+//      errors with precise field paths instead of short-circuiting.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const queryParamDriftRule = "META-QUERYPARAM-DRIFT-01"
+
+type queryParamContract struct {
+	ID        string `yaml:"id"`
+	Endpoints struct {
+		HTTP struct {
+			QueryParams map[string]queryParamSchema `yaml:"queryParams"`
+		} `yaml:"http"`
+	} `yaml:"endpoints"`
+	File string `yaml:"-"`
+}
+
+type queryParamSchema struct {
+	Type      string `yaml:"type"`
+	Format    string `yaml:"format"`
+	Required  bool   `yaml:"required"`
+	MinLength *int   `yaml:"minLength"`
+	MaxLength *int   `yaml:"maxLength"`
+	Minimum   *int   `yaml:"minimum"`
+	Maximum   *int   `yaml:"maximum"`
+}
+
+type routeQueryBinding struct {
+	ContractID string
+	File       string
+	Line       int
+	Funcs      []string
+}
+
+type queryParamViolation struct {
+	ContractID string
+	File       string
+	Line       int
+	Param      string
+	Kind       string
+}
+
+func (v queryParamViolation) String() string {
+	return fmt.Sprintf("%s: %s:%d: contract %s %s query param %q",
+		queryParamDriftRule, v.File, v.Line, v.ContractID, v.Kind, v.Param)
+}
+
+func TestQueryParamContractDrift(t *testing.T) {
+	root := findModuleRoot(t)
+
+	violations, err := checkQueryParamContractDrift(root)
+	require.NoError(t, err)
+
+	for _, v := range violations {
+		t.Log(v.String())
+	}
+	assert.Empty(t, violations,
+		"META-QUERYPARAM-DRIFT-01: HTTP handlers/policies and contract.yaml "+
+			"must declare the same query params. Add missing endpoints.http.queryParams "+
+			"entries or remove stale declarations.")
+}
+
+func checkQueryParamContractDrift(root string) ([]queryParamViolation, error) {
+	contracts, err := loadHTTPQueryParamContracts(root)
+	if err != nil {
+		return nil, err
+	}
+	bindings, usedByFunc, err := collectRouteQueryBindings(root)
+	if err != nil {
+		return nil, err
+	}
+	return compareQueryParams(contracts, bindings, usedByFunc), nil
+}
+
+func loadHTTPQueryParamContracts(root string) (map[string]queryParamContract, error) {
+	out := map[string]queryParamContract{}
+	for _, dir := range []string{filepath.Join(root, "contracts"), filepath.Join(root, "examples")} {
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if shouldSkipQueryParamDir(d.Name()) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if filepath.Base(path) != "contract.yaml" || !strings.Contains(filepath.ToSlash(path), "/contracts/http/") {
+				return nil
+			}
+			c, err := parseQueryParamContract(path)
+			if err != nil {
+				return err
+			}
+			out[c.ID] = c
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func parseQueryParamContract(path string) (queryParamContract, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return queryParamContract{}, err
+	}
+	var c queryParamContract
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return queryParamContract{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	c.File = filepath.ToSlash(path)
+	return c, nil
+}
+
+func collectRouteQueryBindings(root string) ([]routeQueryBinding, map[string]map[string]struct{}, error) {
+	files, err := findQueryParamScanFiles(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	var bindings []routeQueryBinding
+	usedByFunc := map[string]map[string]struct{}{}
+	for _, file := range files {
+		fileBindings, fileUsed, err := scanQueryParamFile(root, file)
+		if err != nil {
+			return nil, nil, err
+		}
+		bindings = append(bindings, fileBindings...)
+		for fn, params := range fileUsed {
+			usedByFunc[fn] = params
+		}
+	}
+	return bindings, usedByFunc, nil
+}
+
+func findQueryParamScanFiles(root string) ([]string, error) {
+	var files []string
+	for _, dir := range []string{filepath.Join(root, "cells"), filepath.Join(root, "examples")} {
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+		found, err := findProductionGoFilesInDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, found...)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func scanQueryParamFile(root, path string) ([]routeQueryBinding, map[string]map[string]struct{}, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, nil, nil
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return nil, nil, err
+	}
+	rel = filepath.ToSlash(rel)
+	specIDs := collectContractSpecIDs(file)
+	return collectRouteBindings(fset, file, rel, specIDs), collectQueryParamUses(file, rel), nil
+}
+
+func collectContractSpecIDs(file *ast.File) map[string]string {
+	specs := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			collectValueSpecContractIDs(specs, valueSpec)
+		}
+	}
+	return specs
+}
+
+func collectValueSpecContractIDs(out map[string]string, spec *ast.ValueSpec) {
+	for i, name := range spec.Names {
+		if i >= len(spec.Values) {
+			continue
+		}
+		if id, ok := contractSpecIDFromExpr(spec.Values[i]); ok {
+			out[name.Name] = id
+		}
+	}
+}
+
+func collectRouteBindings(fset *token.FileSet, file *ast.File, rel string, specIDs map[string]string) []routeQueryBinding {
+	var bindings []routeQueryBinding
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok || !isAuthRouteLiteral(lit) {
+			return true
+		}
+		binding, ok := routeBindingFromLiteral(fset, lit, rel, specIDs)
+		if ok {
+			bindings = append(bindings, binding)
+		}
+		return true
+	})
+	return bindings
+}
+
+func routeBindingFromLiteral(fset *token.FileSet, lit *ast.CompositeLit, rel string, specIDs map[string]string) (routeQueryBinding, bool) {
+	var contractID string
+	var funcs []string
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "Contract":
+			contractID, _ = routeContractID(kv.Value, specIDs)
+		case "Handler", "Policy":
+			funcs = append(funcs, routeFuncKeys(rel, kv.Value)...)
+		}
+	}
+	if contractID == "" || len(funcs) == 0 {
+		return routeQueryBinding{}, false
+	}
+	return routeQueryBinding{
+		ContractID: contractID,
+		File:       rel,
+		Line:       fset.Position(lit.Pos()).Line,
+		Funcs:      uniqueStrings(funcs),
+	}, true
+}
+
+func collectQueryParamUses(file *ast.File, rel string) map[string]map[string]struct{} {
+	out := map[string]map[string]struct{}{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		params := collectFuncQueryParams(fn.Body)
+		if len(params) > 0 {
+			out[funcKey(rel, fn.Name.Name)] = params
+		}
+	}
+	return out
+}
+
+func collectFuncQueryParams(body *ast.BlockStmt) map[string]struct{} {
+	params := map[string]struct{}{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if queryParam, ok := queryGetParam(call); ok {
+			params[queryParam] = struct{}{}
+		}
+		if isParsePageParamsCall(call) {
+			params["cursor"] = struct{}{}
+			params["limit"] = struct{}{}
+		}
+		return true
+	})
+	return params
+}
+
+func compareQueryParams(
+	contracts map[string]queryParamContract,
+	bindings []routeQueryBinding,
+	usedByFunc map[string]map[string]struct{},
+) []queryParamViolation {
+	var violations []queryParamViolation
+	for _, binding := range bindings {
+		contract, ok := contracts[binding.ContractID]
+		if !ok {
+			continue
+		}
+		declared := stringSetKeys(contract.Endpoints.HTTP.QueryParams)
+		used := queryParamsForBinding(binding, usedByFunc)
+		violations = append(violations, missingQueryParamViolations(binding, declared, used)...)
+		violations = append(violations, staleQueryParamViolations(binding, declared, used)...)
+		violations = append(violations, paginationBoundViolations(binding, contract, used)...)
+	}
+	sort.Slice(violations, func(i, j int) bool {
+		return violations[i].String() < violations[j].String()
+	})
+	return violations
+}
+
+func queryParamsForBinding(binding routeQueryBinding, usedByFunc map[string]map[string]struct{}) map[string]struct{} {
+	used := map[string]struct{}{}
+	for _, fn := range binding.Funcs {
+		for param := range usedByFunc[fn] {
+			used[param] = struct{}{}
+		}
+	}
+	return used
+}
+
+func missingQueryParamViolations(binding routeQueryBinding, declared, used map[string]struct{}) []queryParamViolation {
+	var violations []queryParamViolation
+	for param := range used {
+		if _, ok := declared[param]; !ok {
+			violations = append(violations, newQueryParamViolation(binding, param, "uses undeclared"))
+		}
+	}
+	return violations
+}
+
+func staleQueryParamViolations(binding routeQueryBinding, declared, used map[string]struct{}) []queryParamViolation {
+	var violations []queryParamViolation
+	for param := range declared {
+		if _, ok := used[param]; !ok {
+			violations = append(violations, newQueryParamViolation(binding, param, "declares unused"))
+		}
+	}
+	return violations
+}
+
+func newQueryParamViolation(binding routeQueryBinding, param, kind string) queryParamViolation {
+	return queryParamViolation{
+		ContractID: binding.ContractID,
+		File:       binding.File,
+		Line:       binding.Line,
+		Param:      param,
+		Kind:       kind,
+	}
+}
+
+func paginationBoundViolations(binding routeQueryBinding, contract queryParamContract, used map[string]struct{}) []queryParamViolation {
+	var violations []queryParamViolation
+	if _, ok := used["cursor"]; ok {
+		schema, declared := contract.Endpoints.HTTP.QueryParams["cursor"]
+		if declared && (schema.MaxLength == nil || *schema.MaxLength != query.MaxCursorTokenBytes) {
+			violations = append(violations, newQueryParamViolation(binding, "cursor", "declares maxLength different from query.MaxCursorTokenBytes"))
+		}
+	}
+	if _, ok := used["limit"]; ok {
+		schema, declared := contract.Endpoints.HTTP.QueryParams["limit"]
+		if declared && (schema.Maximum == nil || *schema.Maximum != query.MaxPageSize) {
+			violations = append(violations, newQueryParamViolation(binding, "limit", "declares maximum different from query.MaxPageSize"))
+		}
+	}
+	return violations
+}
+
+func contractSpecIDFromExpr(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok || !isContractSpecLiteral(lit) {
+		return "", false
+	}
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "ID" {
+			continue
+		}
+		return stringLiteralValue(kv.Value)
+	}
+	return "", false
+}
+
+func routeContractID(expr ast.Expr, specIDs map[string]string) (string, bool) {
+	if ident, ok := expr.(*ast.Ident); ok {
+		id, ok := specIDs[ident.Name]
+		return id, ok
+	}
+	return contractSpecIDFromExpr(expr)
+}
+
+func routeFuncKeys(rel string, expr ast.Expr) []string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return []string{funcKey(rel, e.Name)}
+	case *ast.SelectorExpr:
+		return []string{funcKey(rel, e.Sel.Name)}
+	case *ast.CallExpr:
+		return routeFuncKeysFromCall(rel, e)
+	default:
+		return nil
+	}
+}
+
+func routeFuncKeysFromCall(rel string, call *ast.CallExpr) []string {
+	var funcs []string
+	for _, arg := range call.Args {
+		funcs = append(funcs, routeFuncKeys(rel, arg)...)
+	}
+	return funcs
+}
+
+func queryGetParam(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Get" || len(call.Args) != 1 {
+		return "", false
+	}
+	if !isURLQueryCall(sel.X) {
+		return "", false
+	}
+	return stringLiteralValue(call.Args[0])
+}
+
+func isURLQueryCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "Query"
+}
+
+func isParsePageParamsCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if ok && sel.Sel.Name == "ParsePageParamsOrWrite" {
+		return true
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	return ok && ident.Name == "ParsePageParamsOrWrite"
+}
+
+func isAuthRouteLiteral(lit *ast.CompositeLit) bool {
+	sel, ok := lit.Type.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "Route"
+}
+
+func isContractSpecLiteral(lit *ast.CompositeLit) bool {
+	sel, ok := lit.Type.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "ContractSpec"
+}
+
+func stringLiteralValue(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	val, err := strconv.Unquote(lit.Value)
+	return val, err == nil
+}
+
+func stringSetKeys[V any](m map[string]V) map[string]struct{} {
+	out := map[string]struct{}{}
+	for key := range m {
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func funcKey(rel, name string) string {
+	return rel + "#" + name
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, value := range in {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func shouldSkipQueryParamDir(name string) bool {
+	switch name {
+	case ".git", ".claude", "vendor", "worktrees", "generated", "testdata":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- add META-QUERYPARAM-DRIFT-01 archtest that correlates auth.Route handlers/policies with HTTP contract queryParams
- align audit/config/role/example list contracts with handler-read query params and shared pagination bounds
- make identity PATCH reject unknown fields to match additionalProperties:false

Refs: PR-MODE-3, docs/plans/202604270020-1-2-ci-3-claude-ship-reactive-bachman.md

ref: Kubernetes pkg/apis/core/validation/validation.go - accumulated field-path validation style
ref: tools/archtest/topic_const_resolver.go - repo-local AST/static archtest pattern

## Test plan
- [x] go build ./...
- [x] go test ./tools/archtest -race -count=1
- [x] go test ./... -count=1
- [x] go run ./cmd/gocell validate --strict
- [x] golangci-lint run ./...
- [x] go test -tags=integration ./adapters/... ./cmd/corebundle/... -timeout 15m -count=1