### PR TITLE
feat(adapters): add vault and rabbitmq diagnostics

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -13,3 +13,9 @@
 
 - 禁止 Debug 级别 dump 完整请求/响应 body（生产中泄漏敏感信息）
 - 错误日志必须包含结构化关联字段（`execution_id`、`policy_id` 等），禁止裸 `slog.Error("failed")`
+
+## Readyz Probe 命名
+
+- Adapter readiness probe 使用 stable snake_case，并以后缀 `_ready` 表示依赖可用性，例如 `rabbitmq_ready`、`vault_transit_ready`。
+- 一个 adapter 只有单一外部依赖时，禁止同时暴露多个同义 ready probe；多角色 worker 可用 `component-role` 拆分不同失败域。
+- probe 名是运维契约；改名必须同步 dashboard / alert / 文档，并用 archtest 或单测锁定。

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci/golangci-lint-action"
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.static_checks
         uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
-          version: v2.11
+          version: v2.11.0
           # only-new-issues uses the GitHub pull-request diff API which
           # refuses diffs larger than 300 files; fall back to
           # --new-from-merge-base so mass-rename PRs (repo-wide renames,

--- a/adapters/postgres/pool_resource.go
+++ b/adapters/postgres/pool_resource.go
@@ -17,7 +17,7 @@ type poolCloser interface {
 }
 
 // PGResource wraps a Pool as a lifecycle.ManagedResource. Bootstrap uses it to:
-//   - Register the pool health probe in /readyz under the "postgres" name.
+//   - Register the pool health probe in /readyz under the "postgres_ready" name.
 //   - Close the pool during LIFO shutdown.
 //
 // The outbox relay is registered independently via bootstrap.WithManagedResource
@@ -29,7 +29,7 @@ type poolCloser interface {
 // by Hook registration; GoCell converges this into a single ManagedResource.
 type PGResource struct {
 	pool          *Pool
-	name          string                          // health checker name; default "postgres"
+	name          string                          // health checker name; default "postgres_ready"
 	closeOverride poolCloser                      // non-nil only in tests; replaces pool for Close()
 	healthFunc    func(ctx context.Context) error // non-nil only in tests; replaces pool.Health
 }
@@ -39,7 +39,7 @@ type PGResource struct {
 // pool at runtime — a silent nil would produce a panic during /readyz
 // probe or shutdown, both of which are the worst times to discover it.
 //
-// name is always "postgres".
+// name is always "postgres_ready".
 //
 // ref: uber-go/fx internal/lifecycle/lifecycle.go Append — resource
 // registration does no nil-substitution; bad inputs surface immediately.
@@ -50,7 +50,7 @@ func NewPGResource(pool *Pool) (*PGResource, error) {
 	}
 	return &PGResource{
 		pool: pool,
-		name: "postgres",
+		name: "postgres_ready",
 	}, nil
 }
 

--- a/adapters/postgres/pool_resource_test.go
+++ b/adapters/postgres/pool_resource_test.go
@@ -28,8 +28,8 @@ func TestNewPGResource_Fields(t *testing.T) {
 	if res.pool != pool {
 		t.Error("pool field not set correctly")
 	}
-	if res.name != "postgres" {
-		t.Errorf("expected name 'postgres', got %q", res.name)
+	if res.name != "postgres_ready" {
+		t.Errorf("expected name 'postgres_ready', got %q", res.name)
 	}
 }
 
@@ -73,9 +73,9 @@ func TestPGResource_CheckersReturnsNamed(t *testing.T) {
 	if len(checkers) != 1 {
 		t.Fatalf("expected 1 checker, got %d", len(checkers))
 	}
-	fn, ok := checkers["postgres"]
+	fn, ok := checkers["postgres_ready"]
 	if !ok {
-		t.Fatal("expected checker named 'postgres'")
+		t.Fatal("expected checker named 'postgres_ready'")
 	}
 	if fn == nil {
 		t.Error("checker function must not be nil")
@@ -102,7 +102,7 @@ func (s *stubCloser) Close(_ context.Context) error { s.called++; return nil }
 // exactly once and always returns nil.
 func TestPGResource_CloseReturnsNil(t *testing.T) {
 	sc := &stubCloser{}
-	res := &PGResource{name: "postgres", closeOverride: sc}
+	res := &PGResource{name: "postgres_ready", closeOverride: sc}
 
 	if err := res.Close(context.Background()); err != nil {
 		t.Errorf("Close() returned non-nil error: %v", err)
@@ -125,7 +125,7 @@ func TestPGResource_ImplementsManagedResource(t *testing.T) {
 func TestPGResource_CheckerTimeout(t *testing.T) {
 	var receivedDeadline time.Time
 	res := &PGResource{
-		name: "postgres",
+		name: "postgres_ready",
 		healthFunc: func(ctx context.Context) error {
 			dl, _ := ctx.Deadline()
 			receivedDeadline = dl
@@ -134,7 +134,7 @@ func TestPGResource_CheckerTimeout(t *testing.T) {
 	}
 
 	checkers := res.Checkers()
-	fn := checkers["postgres"]
+	fn := checkers["postgres_ready"]
 	if fn == nil {
 		t.Fatal("checker fn must not be nil")
 	}

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -41,16 +41,16 @@ var (
 	errHealthClosed         = errcode.New(ErrAdapterAMQPConnect, "rabbitmq: connection is closed")
 )
 
-// ConnectionState represents the lifecycle state of a Connection.
+// ConnectionPhase represents the lifecycle state of a Connection.
 //
 // ref: wagslane/go-rabbitmq connection_manager.go — adopted explicit state tracking
 // with RWMutex protection (checkout/checkin pattern). Deviated: uses channel-close
 // signaling instead of checkout callbacks.
-type ConnectionState uint8
+type ConnectionPhase uint8
 
 const (
 	// StateConnecting is the initial state before the first successful connection.
-	StateConnecting ConnectionState = iota
+	StateConnecting ConnectionPhase = iota
 	// StateConnected means the connection is live and ready for use.
 	StateConnected
 	// StateDisconnected means the connection was lost and reconnection is in progress.
@@ -60,7 +60,7 @@ const (
 )
 
 // String returns a human-readable label for the connection state.
-func (s ConnectionState) String() string {
+func (s ConnectionPhase) String() string {
 	switch s {
 	case StateConnecting:
 		return "connecting"
@@ -78,8 +78,19 @@ func (s ConnectionState) String() string {
 // MarshalText implements encoding.TextMarshaler so that JSON serialization
 // of PoolStats.State produces a human-readable string ("connected") instead
 // of a numeric uint8 value.
-func (s ConnectionState) MarshalText() ([]byte, error) {
+func (s ConnectionPhase) MarshalText() ([]byte, error) {
 	return []byte(s.String()), nil
+}
+
+// ConnectionState is a structured diagnostic snapshot for dashboards and
+// operator tooling. LastError is sanitized and must never include AMQP URL
+// credentials.
+type ConnectionState struct {
+	State             ConnectionPhase `json:"state"`
+	Message           string          `json:"message"`
+	LastError         string          `json:"lastError,omitempty"`
+	LastDisconnectAt  time.Time       `json:"lastDisconnectAt,omitempty"`
+	ReconnectAttempts int             `json:"reconnectAttempts"`
 }
 
 // isPermanentDialError returns true if the error from Dial indicates a
@@ -280,7 +291,7 @@ func DefaultDial(url string) (AMQPConnection, error) {
 
 // Connection manages an AMQP connection with auto-reconnect and channel pooling.
 //
-// Connection has four lifecycle states (see ConnectionState):
+// Connection has four lifecycle states (see ConnectionPhase):
 //   - connecting:   initial state before first successful dial
 //   - connected:    ready for use (connected channel is closed)
 //   - disconnected: lost connection, attempting backoff reconnect
@@ -307,7 +318,10 @@ type Connection struct {
 
 	// state tracks the connection lifecycle for Health() and observability.
 	// Protected by mu.
-	state ConnectionState
+	state             ConnectionPhase
+	lastError         string
+	lastDisconnectAt  time.Time
+	reconnectAttempts int
 }
 
 // NewConnection creates a new Connection with the given config.
@@ -386,29 +400,16 @@ func (c *Connection) reconnectLoop() {
 			return
 		}
 
-		closeCh := conn.NotifyClose(make(chan *amqp.Error, 1))
-
-		select {
-		case <-c.closeCh:
+		closeErr, ok := c.waitForCloseNotification(conn)
+		if !ok {
 			return
-		case amqpErr, ok := <-closeCh:
-			if !ok {
-				return
-			}
-			if amqpErr != nil {
-				slog.Warn("rabbitmq: connection lost, reconnecting",
-					slog.Any("error", amqpErr))
-			}
 		}
 
 		// RMQ-RACE-01 fix: create a new connected channel BEFORE draining
 		// the pool so that any concurrent WaitConnected callers who hold a
 		// reference to the old (closed) channel will see a different reference
 		// on re-validation and loop back to wait on the new channel.
-		c.mu.Lock()
-		c.connected = make(chan struct{})
-		c.state = StateDisconnected
-		c.mu.Unlock()
+		c.markDisconnected(closeErr)
 
 		// Drain the channel pool on disconnect.
 		c.drainChannelPool()
@@ -423,6 +424,37 @@ func (c *Connection) reconnectLoop() {
 			return
 		}
 	}
+}
+
+func (c *Connection) waitForCloseNotification(conn AMQPConnection) (*amqp.Error, bool) {
+	closeCh := conn.NotifyClose(make(chan *amqp.Error, 1))
+	select {
+	case <-c.closeCh:
+		return nil, false
+	case amqpErr, ok := <-closeCh:
+		if !ok {
+			return nil, false
+		}
+		if amqpErr != nil {
+			slog.Warn("rabbitmq: connection lost, reconnecting",
+				slog.String("error", sanitizeErrorURL(amqpErr.Error(), c.config.URL)))
+		}
+		return amqpErr, true
+	}
+}
+
+func (c *Connection) markDisconnected(closeErr *amqp.Error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.connected = make(chan struct{})
+	c.state = StateDisconnected
+	c.lastDisconnectAt = time.Now().UTC()
+	c.reconnectAttempts = 0
+	if closeErr != nil {
+		c.lastError = sanitizeErrorURL(closeErr.Error(), c.config.URL)
+		return
+	}
+	c.lastError = "connection close notification received"
 }
 
 // reconnectWithBackoff attempts to re-establish the connection with capped
@@ -452,6 +484,9 @@ func (c *Connection) reconnectWithBackoff() bool {
 		}
 
 		delay := c.backoffDelay(attempt)
+		c.mu.Lock()
+		c.reconnectAttempts = attempt + 1
+		c.mu.Unlock()
 		slog.Warn("rabbitmq: reconnect attempt",
 			slog.Int("attempt", attempt+1),
 			slog.Duration("delay", delay))
@@ -463,9 +498,13 @@ func (c *Connection) reconnectWithBackoff() bool {
 		}
 
 		if err := c.connect(); err != nil {
+			sanitizedErr := sanitizeErrorURL(err.Error(), c.config.URL)
+			c.mu.Lock()
+			c.lastError = sanitizedErr
+			c.mu.Unlock()
 			slog.Warn("rabbitmq: reconnect failed, retrying indefinitely",
 				slog.Int("attempt", attempt+1),
-				slog.String("error", sanitizeErrorURL(err.Error(), c.config.URL)))
+				slog.String("error", sanitizedErr))
 			attempt++
 			continue
 		}
@@ -637,7 +676,7 @@ func (c *Connection) Health(ctx context.Context) error {
 type PoolStats struct {
 	ChannelPoolSize int             `json:"channelPoolSize"` // configured pool capacity (subscriber only)
 	IdleChannels    int             `json:"idleChannels"`    // channels currently idle in pool (subscriber only)
-	State           ConnectionState `json:"state"`           // current connection lifecycle state
+	State           ConnectionPhase `json:"state"`           // current connection lifecycle state
 }
 
 // PoolStats returns structured pool statistics suitable for metrics collection
@@ -653,13 +692,38 @@ func (c *Connection) PoolStats() PoolStats {
 	}
 }
 
-// ConnectionStatus returns the current lifecycle state of the connection.
+// ConnectionStatus returns a structured lifecycle snapshot of the connection.
 // Useful for dashboards, structured logging, and operational tooling.
 func (c *Connection) ConnectionStatus() ConnectionState {
 	c.mu.RLock()
-	s := c.state
+	s := c.connectionStatusLocked()
 	c.mu.RUnlock()
 	return s
+}
+
+func (c *Connection) connectionStatusLocked() ConnectionState {
+	return ConnectionState{
+		State:             c.state,
+		Message:           connectionStateMessage(c.state),
+		LastError:         c.lastError,
+		LastDisconnectAt:  c.lastDisconnectAt,
+		ReconnectAttempts: c.reconnectAttempts,
+	}
+}
+
+func connectionStateMessage(state ConnectionPhase) string {
+	switch state {
+	case StateConnected:
+		return "connected"
+	case StateDisconnected:
+		return "reconnecting"
+	case StateConnecting:
+		return "connecting"
+	case StateTerminal:
+		return "terminal"
+	default:
+		return "unknown"
+	}
 }
 
 // Compile-time assertion: Connection satisfies lifecycle.ManagedResource.
@@ -724,7 +788,24 @@ func (c *Connection) Close(ctx context.Context) error {
 	c.closed = true
 	close(c.closeCh)
 	conn := c.conn
+	status := c.connectionStatusLocked()
+	idleChannels := len(c.channelPool)
 	c.mu.Unlock()
+
+	fields := []slog.Attr{
+		slog.String("reason", "managed_resource_close"),
+		slog.String("state", status.State.String()),
+		slog.String("message", status.Message),
+		slog.Int("reconnectAttempts", status.ReconnectAttempts),
+		slog.Int("idleChannels", idleChannels),
+	}
+	if status.LastError != "" {
+		fields = append(fields, slog.String("lastError", status.LastError))
+	}
+	if !status.LastDisconnectAt.IsZero() {
+		fields = append(fields, slog.Time("lastDisconnectAt", status.LastDisconnectAt))
+	}
+	slog.LogAttrs(ctx, slog.LevelInfo, "rabbitmq: closing connection", fields...)
 
 	c.drainChannelPool()
 

--- a/adapters/rabbitmq/doc.go
+++ b/adapters/rabbitmq/doc.go
@@ -45,6 +45,14 @@
 // "rabbitmq_ready" probe (wrapping Health(ctx)) is exposed on /readyz
 // automatically.
 //
+// Wiring example:
+//
+//	conn, _ := rabbitmq.NewConnection(rabbitmq.Config{URL: amqpURL})
+//	pub := rabbitmq.NewPublisher(conn)
+//	sub := rabbitmq.NewSubscriber(conn, rabbitmq.SubscriberConfig{QueueName: "audit"})
+//	app, _ := bootstrap.New(bootstrap.WithManagedResource(conn))
+//	_ = pub; _ = sub; _ = app
+//
 // ref: ThreeDotsLabs/watermill-amqp — reconnect + ACK/NACK + channel lifecycle
 // ref: uber-go/fx app.go StopTimeout — ctx as shared shutdown budget
 // ref: rabbitmq/amqp091-go channel.go — Cancel→drain→Wait→Close graceful stop order

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -155,7 +155,7 @@ func TestIntegration_ConnectionHealth(t *testing.T) {
 
 	err := conn.Health(context.Background())
 	assert.NoError(t, err, "Health should succeed on a live RabbitMQ")
-	assert.Equal(t, StateConnected, conn.ConnectionStatus())
+	assert.Equal(t, StateConnected, conn.ConnectionStatus().State)
 }
 
 // TestIntegration_PublishConsume publishes a message and consumes it
@@ -170,9 +170,9 @@ func TestIntegration_PublishConsume(t *testing.T) {
 
 	// Subscribe and receive.
 	sub := NewSubscriber(conn, SubscriberConfig{
-		QueueName:       queueName,
-		PrefetchCount:   1,
-		DLXExchange:     "test.dlx",
+		QueueName:     queueName,
+		PrefetchCount: 1,
+		DLXExchange:   "test.dlx",
 	})
 
 	ctx := context.Background()
@@ -304,9 +304,9 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 
 	// --- Start main subscriber with ConsumerBase-wrapped handler ---
 	sub := NewSubscriber(conn, SubscriberConfig{
-		QueueName:       mainQueue,
-		PrefetchCount:   1,
-		DLXExchange:     dlxExchange,
+		QueueName:     mainQueue,
+		PrefetchCount: 1,
+		DLXExchange:   dlxExchange,
 	})
 
 	var callCount atomic.Int32
@@ -394,7 +394,7 @@ func TestIntegration_ConnectionRecovery(t *testing.T) {
 
 	// 1. Verify initial healthy state.
 	require.NoError(t, conn.Health(context.Background()), "initial Health should be nil")
-	assert.Equal(t, StateConnected, conn.ConnectionStatus())
+	assert.Equal(t, StateConnected, conn.ConnectionStatus().State)
 
 	// 2. Force-close all connections via rabbitmqctl.
 	exitCode, _, err := container.Exec(ctx, []string{
@@ -411,8 +411,8 @@ func TestIntegration_ConnectionRecovery(t *testing.T) {
 
 	// Verify the state is Disconnected (not Terminal).
 	status := conn.ConnectionStatus()
-	assert.True(t, status == StateDisconnected || status == StateConnecting,
-		"state should be Disconnected or Connecting during reconnect, got %s", status)
+	assert.True(t, status.State == StateDisconnected || status.State == StateConnecting,
+		"state should be Disconnected or Connecting during reconnect, got %s", status.State)
 
 	// 4. Health() should recover after reconnect succeeds.
 	require.Eventually(t, func() bool {
@@ -420,7 +420,7 @@ func TestIntegration_ConnectionRecovery(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond,
 		"Health() should recover after successful reconnect")
 
-	assert.Equal(t, StateConnected, conn.ConnectionStatus(),
+	assert.Equal(t, StateConnected, conn.ConnectionStatus().State,
 		"state should be Connected after recovery")
 
 	// 5. Verify connection is usable: acquire and release a channel.
@@ -476,9 +476,9 @@ func TestIntegration_DLXBrokerNative(t *testing.T) {
 
 	// --- Start the main subscriber with DLX configured ---
 	sub := NewSubscriber(conn, SubscriberConfig{
-		QueueName:       mainQueue,
-		PrefetchCount:   1,
-		DLXExchange:     dlxExchange,
+		QueueName:     mainQueue,
+		PrefetchCount: 1,
+		DLXExchange:   dlxExchange,
 	})
 
 	subCtx, subCancel := context.WithTimeout(ctx, 20*time.Second)

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -4123,7 +4123,7 @@ func TestConnection_Health_StateDistinction(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		state    ConnectionState
+		state    ConnectionPhase
 		conn     AMQPConnection
 		permErr  error
 		wantCode errcode.Code
@@ -4185,8 +4185,8 @@ func TestConnection_Health_StateDistinction(t *testing.T) {
 func TestConnection_ConnectionStatus(t *testing.T) {
 	tests := []struct {
 		name  string
-		state ConnectionState
-		want  ConnectionState
+		state ConnectionPhase
+		want  ConnectionPhase
 	}{
 		{"connecting", StateConnecting, StateConnecting},
 		{"connected", StateConnected, StateConnected},
@@ -4203,9 +4203,73 @@ func TestConnection_ConnectionStatus(t *testing.T) {
 				terminalCh: make(chan struct{}),
 				state:      tt.state,
 			}
-			assert.Equal(t, tt.want, c.ConnectionStatus())
+			assert.Equal(t, tt.want, c.ConnectionStatus().State)
 		})
 	}
+}
+
+func TestConnection_ConnectionStatus_StructuredDiagnosticSanitizesError(t *testing.T) {
+	rawURL := "amqp://user:secret@localhost:5672/vhost"
+	disconnectedAt := time.Unix(1714400000, 0).UTC()
+	c := &Connection{
+		config:            Config{URL: rawURL},
+		closeCh:           make(chan struct{}),
+		connected:         make(chan struct{}),
+		terminalCh:        make(chan struct{}),
+		state:             StateDisconnected,
+		lastError:         sanitizeErrorURL("read "+rawURL+": EOF", rawURL),
+		lastDisconnectAt:  disconnectedAt,
+		reconnectAttempts: 2,
+		channelPool:       make(chan AMQPChannel, 1),
+	}
+
+	status := c.ConnectionStatus()
+	assert.Equal(t, StateDisconnected, status.State)
+	assert.Equal(t, "reconnecting", status.Message)
+	assert.Equal(t, disconnectedAt, status.LastDisconnectAt)
+	assert.Equal(t, 2, status.ReconnectAttempts)
+	assert.Contains(t, status.LastError, "amqp://***:***@localhost:5672/vhost")
+
+	b, err := json.Marshal(status)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "secret")
+	assert.NotContains(t, string(b), "user:secret@")
+	assert.Contains(t, string(b), `"state":"disconnected"`)
+	assert.Contains(t, string(b), `"reconnectAttempts":2`)
+}
+
+func TestConnection_Close_LogsStructuredDiagnostic(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	rawURL := "amqp://user:secret@localhost:5672/vhost"
+	mockConn := newMockConnection()
+	c := &Connection{
+		config:            Config{URL: rawURL},
+		conn:              mockConn,
+		closeCh:           make(chan struct{}),
+		connected:         make(chan struct{}),
+		terminalCh:        make(chan struct{}),
+		channelPool:       make(chan AMQPChannel, 3),
+		state:             StateDisconnected,
+		lastError:         sanitizeErrorURL("lost "+rawURL, rawURL),
+		lastDisconnectAt:  time.Unix(1714400000, 0).UTC(),
+		reconnectAttempts: 2,
+	}
+	c.channelPool <- newMockChannel()
+
+	require.NoError(t, c.Close(context.Background()))
+
+	logLine := buf.String()
+	assert.Contains(t, logLine, `"msg":"rabbitmq: closing connection"`)
+	assert.Contains(t, logLine, `"reason":"managed_resource_close"`)
+	assert.Contains(t, logLine, `"state":"disconnected"`)
+	assert.Contains(t, logLine, `"reconnectAttempts":2`)
+	assert.Contains(t, logLine, `"idleChannels":1`)
+	assert.NotContains(t, logLine, "secret")
+	assert.NotContains(t, logLine, "user:secret@")
 }
 
 func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
@@ -4241,7 +4305,7 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 	defer conn.Close(context.Background()) //nolint:errcheck
 
 	// Initial state: Connected.
-	assert.Equal(t, StateConnected, conn.ConnectionStatus(), "initial state should be Connected")
+	assert.Equal(t, StateConnected, conn.ConnectionStatus().State, "initial state should be Connected")
 
 	// Wait for reconnectLoop to register NotifyClose.
 	require.Eventually(t, func() bool {
@@ -4264,7 +4328,7 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 		return dialCount >= 2
 	}, 2*time.Second, time.Millisecond)
 
-	assert.Equal(t, StateDisconnected, conn.ConnectionStatus(),
+	assert.Equal(t, StateDisconnected, conn.ConnectionStatus().State,
 		"state should be Disconnected during reconnect")
 
 	// Unblock reconnect.
@@ -4272,20 +4336,20 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 
 	// State should recover to Connected.
 	require.Eventually(t, func() bool {
-		return conn.ConnectionStatus() == StateConnected
+		return conn.ConnectionStatus().State == StateConnected
 	}, 2*time.Second, time.Millisecond)
 }
 
-func TestConnectionState_String(t *testing.T) {
+func TestConnectionPhase_String(t *testing.T) {
 	tests := []struct {
-		state ConnectionState
+		state ConnectionPhase
 		want  string
 	}{
 		{StateConnecting, "connecting"},
 		{StateConnected, "connected"},
 		{StateDisconnected, "disconnected"},
 		{StateTerminal, "terminal"},
-		{ConnectionState(99), "unknown(99)"},
+		{ConnectionPhase(99), "unknown(99)"},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, tt.state.String())

--- a/adapters/vault/auth_test.go
+++ b/adapters/vault/auth_test.go
@@ -474,23 +474,7 @@ func TestKubernetesAuth_Login_ReadsServiceAccountJWTAndSetsClientToken(t *testin
 	)
 	jwtPath := writeTempFile(t, wantJWT)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/v1/auth/kubernetes/login" {
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-		var req map[string]string
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		if req["role"] != wantRole {
-			t.Fatalf("role = %q, want %q", req["role"], wantRole)
-		}
-		if req["jwt"] != wantJWT {
-			t.Fatalf("jwt = %q, want projected service account JWT", req["jwt"])
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"auth":{"client_token":"vault-k8s-token","lease_duration":3600,"renewable":true}}`))
-	}))
+	server := newKubernetesLoginTestServer(t, wantRole, wantJWT)
 	defer server.Close()
 
 	cfg := vaultapi.DefaultConfig()
@@ -508,6 +492,37 @@ func TestKubernetesAuth_Login_ReadsServiceAccountJWTAndSetsClientToken(t *testin
 	if err != nil {
 		t.Fatalf("Login: %v", err)
 	}
+	assertKubernetesAuthLoginResult(t, result, client)
+}
+
+func newKubernetesLoginTestServer(t *testing.T, wantRole, wantJWT string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertKubernetesLoginRequest(t, r, wantRole, wantJWT)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"auth":{"client_token":"vault-k8s-token","lease_duration":3600,"renewable":true}}`))
+	}))
+}
+
+func assertKubernetesLoginRequest(t *testing.T, r *http.Request, wantRole, wantJWT string) {
+	t.Helper()
+	if r.Method != http.MethodPut || r.URL.Path != "/v1/auth/kubernetes/login" {
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}
+	var req map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if req["role"] != wantRole {
+		t.Fatalf("role = %q, want %q", req["role"], wantRole)
+	}
+	if req["jwt"] != wantJWT {
+		t.Fatalf("jwt = %q, want projected service account JWT", req["jwt"])
+	}
+}
+
+func assertKubernetesAuthLoginResult(t *testing.T, result AuthResult, client *vaultapi.Client) {
+	t.Helper()
 	if result.ClientToken != "vault-k8s-token" {
 		t.Errorf("ClientToken = %q, want vault-k8s-token", result.ClientToken)
 	}

--- a/adapters/vault/auth_test.go
+++ b/adapters/vault/auth_test.go
@@ -22,7 +22,10 @@ package vault
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -461,6 +464,61 @@ func TestNewKubernetesAuth_EmptyRole_Fails(t *testing.T) {
 	_, err := NewKubernetesAuth(client, "", "", "")
 	if err == nil {
 		t.Fatal("expected error for empty role, got nil")
+	}
+}
+
+func TestKubernetesAuth_Login_ReadsServiceAccountJWTAndSetsClientToken(t *testing.T) {
+	const (
+		wantRole = "gocell-config-reader"
+		wantJWT  = "projected-service-account-jwt"
+	)
+	jwtPath := writeTempFile(t, wantJWT)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/auth/kubernetes/login" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var req map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req["role"] != wantRole {
+			t.Fatalf("role = %q, want %q", req["role"], wantRole)
+		}
+		if req["jwt"] != wantJWT {
+			t.Fatalf("jwt = %q, want projected service account JWT", req["jwt"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"auth":{"client_token":"vault-k8s-token","lease_duration":3600,"renewable":true}}`))
+	}))
+	defer server.Close()
+
+	cfg := vaultapi.DefaultConfig()
+	cfg.Address = server.URL
+	client, err := vaultapi.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("vaultapi.NewClient: %v", err)
+	}
+	auth, err := NewKubernetesAuth(client, wantRole, jwtPath, "kubernetes")
+	if err != nil {
+		t.Fatalf("NewKubernetesAuth: %v", err)
+	}
+
+	result, err := auth.Login(context.Background())
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if result.ClientToken != "vault-k8s-token" {
+		t.Errorf("ClientToken = %q, want vault-k8s-token", result.ClientToken)
+	}
+	if result.LeaseSeconds != 3600 {
+		t.Errorf("LeaseSeconds = %d, want 3600", result.LeaseSeconds)
+	}
+	if !result.Renewable {
+		t.Error("Renewable = false, want true")
+	}
+	if got := client.Token(); got != "vault-k8s-token" {
+		t.Errorf("client.Token() = %q, want vault-k8s-token", got)
 	}
 }
 

--- a/adapters/vault/integration_test.go
+++ b/adapters/vault/integration_test.go
@@ -26,10 +26,11 @@ import (
 
 // startVaultContainer starts a Vault dev-mode container for integration tests.
 // The transit secret engine is enabled and the key "gocell-config" is created
-// during init. Returns (addr, token, teardown). Skips the test if the container
-// cannot start (CI without Docker daemon).
+// during init. Returns (addr, token, teardown). Only a missing Docker daemon is
+// allowed to skip; image digest, init command, and address failures must fail.
 func startVaultContainer(t *testing.T) (addr, token string, teardown func()) {
 	t.Helper()
+	testutil.RequireDocker(t)
 	ctx := context.Background()
 
 	container, err := vaultcontainer.Run(ctx,
@@ -40,15 +41,13 @@ func startVaultContainer(t *testing.T) (addr, token string, teardown func()) {
 			"write -f transit/keys/gocell-config",
 		),
 	)
-	if err != nil {
-		t.Skipf("vault container unavailable: %v", err)
-	}
+	require.NoError(t, err, "start vault container")
 
 	vaultAddr, err := container.HttpHostAddress(ctx)
 	if err != nil {
 		_ = container.Terminate(ctx)
-		t.Skipf("vault container address unavailable: %v", err)
 	}
+	require.NoError(t, err, "get vault container HTTP address")
 
 	teardown = func() {
 		_ = container.Terminate(ctx)

--- a/adapters/vault/integration_test.go
+++ b/adapters/vault/integration_test.go
@@ -19,6 +19,7 @@ import (
 
 	vaultadapter "github.com/ghbvf/gocell/adapters/vault"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/tests/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,7 @@ func startVaultContainer(t *testing.T) (addr, token string, teardown func()) {
 	ctx := context.Background()
 
 	container, err := vaultcontainer.Run(ctx,
-		"hashicorp/vault:1.17",
+		testutil.VaultImage,
 		vaultcontainer.WithToken("root-test-token"),
 		vaultcontainer.WithInitCommand(
 			"secrets enable transit",

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -1148,6 +1148,34 @@ func (p *TransitKeyProvider) RenewalMetrics() []prometheus.Collector {
 	return collectors
 }
 
+// CacheVersionMetrics returns the Prometheus collector exposing the latest
+// Vault Transit key version cached by this process. The collector is not
+// registered here; composition roots own registry selection and duplicate
+// handling.
+func (p *TransitKeyProvider) CacheVersionMetrics() []prometheus.Collector {
+	return []prometheus.Collector{
+		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: "gocell",
+			Subsystem: "vault",
+			Name:      "cached_key_version",
+			Help:      "Latest Vault Transit key version cached by this process; 0 means cache miss.",
+			ConstLabels: prometheus.Labels{
+				"mount_path": p.mountPath,
+				"key_name":   p.keyName,
+			},
+		}, func() float64 {
+			return float64(p.cachedLatestVersion.Load())
+		}),
+	}
+}
+
+// Metrics returns all Prometheus collectors exposed by TransitKeyProvider.
+func (p *TransitKeyProvider) Metrics() []prometheus.Collector {
+	collectors := p.CacheVersionMetrics()
+	collectors = append(collectors, p.RenewalMetrics()...)
+	return collectors
+}
+
 // Worker returns the token renewal worker when one has been configured, or nil
 // when the VaultClient does not implement TokenRenewer (e.g. test fakes with
 // static tokens). The bootstrap layer skips WithWorkers registration for nil.

--- a/adapters/vault/transit_renewal_metrics_test.go
+++ b/adapters/vault/transit_renewal_metrics_test.go
@@ -13,7 +13,9 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +26,28 @@ import (
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
+
+func TestTransitKeyProvider_CacheVersionMetrics_ReportsCachedLatestVersion(t *testing.T) {
+	fake := &fakeVaultClient{latestVersion: 7}
+	p := newTestProvider(t, fake)
+
+	collectors := p.CacheVersionMetrics()
+	require.Len(t, collectors, 1)
+	assertCachedKeyVersionMetric(t, collectors[0], 7)
+
+	_, err := p.Rotate(context.Background())
+	require.NoError(t, err)
+	assertCachedKeyVersionMetric(t, collectors[0], 8)
+}
+
+func assertCachedKeyVersionMetric(t *testing.T, collector prometheus.Collector, version int) {
+	t.Helper()
+	expected := strings.NewReader(fmt.Sprintf(`# HELP gocell_vault_cached_key_version Latest Vault Transit key version cached by this process; 0 means cache miss.
+# TYPE gocell_vault_cached_key_version gauge
+gocell_vault_cached_key_version{key_name="gocell-config",mount_path="transit"} %d
+`, version))
+	require.NoError(t, testutil.CollectAndCompare(collector, expected, "gocell_vault_cached_key_version"))
+}
 
 // newRenewalCounters creates a pair of unregistered Prometheus counters for
 // use in tests. The counters are NOT registered in any registry — they are

--- a/cmd/corebundle/buildapp_env_integration_test.go
+++ b/cmd/corebundle/buildapp_env_integration_test.go
@@ -136,13 +136,13 @@ func TestConfigCoreModule_Provide_UsesConfigCoreDatabaseURL(t *testing.T) {
 
 	pgRes := provisional[0]
 
-	// Verify the ManagedResource exposes a "postgres" checker (the name used by
+	// Verify the ManagedResource exposes a "postgres_ready" checker (the name used by
 	// adapterpg.PGResource) and that it reports healthy against the live container
 	// started by setupPostgresForMain.
 	checkers := pgRes.Checkers()
-	pgChecker, ok := checkers["postgres"]
-	require.True(t, ok, "ManagedResource must expose a \"postgres\" checker (adapterpg.PGResource default name)")
-	require.NoError(t, pgChecker(ctx), "postgres checker must pass for the live container DSN")
+	pgChecker, ok := checkers["postgres_ready"]
+	require.True(t, ok, "ManagedResource must expose a \"postgres_ready\" checker (adapterpg.PGResource default name)")
+	require.NoError(t, pgChecker(ctx), "postgres_ready checker must pass for the live container DSN")
 
 	// Close the resource to avoid leaking the connection pool.
 	// Ignore the error — the test has already passed at this point and pool
@@ -190,7 +190,7 @@ func TestConfigCoreModule_Provide_RollsBackPGResourceOnRenewalMetricError(t *tes
 	}.Provide(ctx, shared)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "register renewal metrics")
+	assert.Contains(t, err.Error(), "register key provider metrics")
 	assert.Empty(t, provisional, "failed Provide must not return provisional resources")
 	assert.Nil(t, shared.SharedPGPool, "failed Provide must clear the shared PG pool after rollback")
 }

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -126,7 +126,7 @@ func defaultRuntimeOptions(
 	}
 	if shared.RedisClient != nil {
 		opts = append(opts,
-			bootstrap.WithHealthChecker("redis", shared.RedisClient.Health),
+			bootstrap.WithHealthChecker("redis_ready", shared.RedisClient.Health),
 			bootstrap.WithManagedCloser(shared.RedisClient),
 		)
 	}

--- a/cmd/corebundle/config_module.go
+++ b/cmd/corebundle/config_module.go
@@ -132,7 +132,7 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	}
 	c := configcore.NewConfigCore(append(baseOpts, cellOpts...)...)
 
-	// A13: register vault token renewal counters when the KeyProvider exposes them.
+	// Register Vault diagnostics when the KeyProvider exposes them.
 	if err := registerRenewalMetrics(kp, shared.PromStack.registry); err != nil {
 		shared.SharedPGPool = nil
 		rollback()
@@ -164,18 +164,29 @@ type renewalMetricsProvider interface {
 	RenewalMetrics() []prom.Collector
 }
 
+type keyProviderMetricsProvider interface {
+	Metrics() []prom.Collector
+}
+
 // registerRenewalMetrics registers per-collector metrics exposed by KeyProvider
 // implementations that satisfy renewalMetricsProvider. Returns error on
 // registration failures other than AlreadyRegisteredError.
 func registerRenewalMetrics(kp kcrypto.KeyProvider, reg prom.Registerer) error {
+	if mp, ok := kp.(keyProviderMetricsProvider); ok {
+		return registerCollectors(mp.Metrics(), reg, "key provider metric")
+	}
 	rmp, ok := kp.(renewalMetricsProvider)
 	if !ok {
 		return nil
 	}
-	for _, col := range rmp.RenewalMetrics() {
+	return registerCollectors(rmp.RenewalMetrics(), reg, "vault renewal metric")
+}
+
+func registerCollectors(collectors []prom.Collector, reg prom.Registerer, label string) error {
+	for _, col := range collectors {
 		if err := reg.Register(col); err != nil {
 			if _, ok := err.(prom.AlreadyRegisteredError); !ok {
-				return fmt.Errorf("vault renewal metric: %w", err)
+				return fmt.Errorf("%s: %w", label, err)
 			}
 		}
 	}

--- a/cmd/corebundle/config_module.go
+++ b/cmd/corebundle/config_module.go
@@ -133,10 +133,10 @@ func (m ConfigCoreModule) Provide(ctx context.Context, shared *SharedDeps) (cell
 	c := configcore.NewConfigCore(append(baseOpts, cellOpts...)...)
 
 	// Register Vault diagnostics when the KeyProvider exposes them.
-	if err := registerRenewalMetrics(kp, shared.PromStack.registry); err != nil {
+	if err := registerKeyProviderMetrics(kp, shared); err != nil {
 		shared.SharedPGPool = nil
 		rollback()
-		return nil, nil, nil, fmt.Errorf("configcore: register renewal metrics: %w", err)
+		return nil, nil, nil, fmt.Errorf("configcore: register key provider metrics: %w", err)
 	}
 
 	// Relay opts: in postgres mode, relayOpts contains WithManagedResource(relay)
@@ -168,29 +168,62 @@ type keyProviderMetricsProvider interface {
 	Metrics() []prom.Collector
 }
 
-// registerRenewalMetrics registers per-collector metrics exposed by KeyProvider
-// implementations that satisfy renewalMetricsProvider. Returns error on
-// registration failures other than AlreadyRegisteredError.
-func registerRenewalMetrics(kp kcrypto.KeyProvider, reg prom.Registerer) error {
+// registerKeyProviderMetrics registers the current KeyProvider's diagnostics.
+// These collectors may close over provider instance state (GaugeFunc), so a
+// repeated Provide against the same SharedDeps must replace the previous owned
+// collector set instead of reusing or silently ignoring duplicates.
+func registerKeyProviderMetrics(kp kcrypto.KeyProvider, shared *SharedDeps) error {
+	return replaceRegisteredCollectors(
+		shared.PromStack.registry,
+		&shared.keyProviderMetricCollectors,
+		keyProviderMetricCollectors(kp),
+		"key provider metric",
+	)
+}
+
+func keyProviderMetricCollectors(kp kcrypto.KeyProvider) []prom.Collector {
 	if mp, ok := kp.(keyProviderMetricsProvider); ok {
-		return registerCollectors(mp.Metrics(), reg, "key provider metric")
+		return mp.Metrics()
 	}
 	rmp, ok := kp.(renewalMetricsProvider)
 	if !ok {
 		return nil
 	}
-	return registerCollectors(rmp.RenewalMetrics(), reg, "vault renewal metric")
+	return rmp.RenewalMetrics()
 }
 
-func registerCollectors(collectors []prom.Collector, reg prom.Registerer, label string) error {
+func replaceRegisteredCollectors(reg prom.Registerer, current *[]prom.Collector, next []prom.Collector, label string) error {
+	previous := append([]prom.Collector(nil), (*current)...)
+	unregisterCollectors(reg, previous)
+
+	registered, err := registerCollectorSet(reg, next, label)
+	if err != nil {
+		unregisterCollectors(reg, registered)
+		if _, restoreErr := registerCollectorSet(reg, previous, label+" restore"); restoreErr != nil {
+			return fmt.Errorf("%w (also failed to restore previous collectors: %v)", err, restoreErr)
+		}
+		return err
+	}
+
+	*current = registered
+	return nil
+}
+
+func registerCollectorSet(reg prom.Registerer, collectors []prom.Collector, label string) ([]prom.Collector, error) {
+	registered := make([]prom.Collector, 0, len(collectors))
 	for _, col := range collectors {
 		if err := reg.Register(col); err != nil {
-			if _, ok := err.(prom.AlreadyRegisteredError); !ok {
-				return fmt.Errorf("%s: %w", label, err)
-			}
+			return registered, fmt.Errorf("%s: %w", label, err)
 		}
+		registered = append(registered, col)
 	}
-	return nil
+	return registered, nil
+}
+
+func unregisterCollectors(reg prom.Registerer, collectors []prom.Collector) {
+	for _, col := range collectors {
+		reg.Unregister(col)
+	}
 }
 
 // registerOrReuseCounter registers a new counter with the given opts. If the

--- a/cmd/corebundle/config_module_metrics_test.go
+++ b/cmd/corebundle/config_module_metrics_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	"github.com/ghbvf/gocell/runtime/bootstrap"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type cachedVersionMetricsProvider struct {
+	fakeKeyProvider
+	version float64
+}
+
+func (p *cachedVersionMetricsProvider) Metrics() []prom.Collector {
+	return []prom.Collector{
+		prom.NewGaugeFunc(prom.GaugeOpts{
+			Namespace: "gocell",
+			Subsystem: "vault",
+			Name:      "cached_key_version",
+			Help:      "Latest Vault Transit key version cached by this process; 0 means cache miss.",
+			ConstLabels: prom.Labels{
+				"mount_path": "transit",
+				"key_name":   "gocell-config",
+			},
+		}, func() float64 {
+			return p.version
+		}),
+	}
+}
+
+var _ kcrypto.KeyProvider = (*cachedVersionMetricsProvider)(nil)
+
+func TestConfigCoreModule_Provide_ReplacesKeyProviderMetricsOnRepeatedProvide(t *testing.T) {
+	shared := newValidatedSharedDeps(t, bootstrap.Topology{StorageBackend: "memory", AdapterMode: "dev"})
+	ctx := context.Background()
+
+	_, _, _, err := ConfigCoreModule{
+		KeyProviderOverride: &cachedVersionMetricsProvider{version: 1},
+	}.Provide(ctx, shared)
+	require.NoError(t, err)
+	assertCachedKeyVersionFromRegistry(t, shared.PromStack.registry, 1)
+
+	_, _, _, err = ConfigCoreModule{
+		KeyProviderOverride: &cachedVersionMetricsProvider{version: 2},
+	}.Provide(ctx, shared)
+	require.NoError(t, err)
+	assertCachedKeyVersionFromRegistry(t, shared.PromStack.registry, 2)
+}
+
+func assertCachedKeyVersionFromRegistry(t *testing.T, registry *prom.Registry, version float64) {
+	t.Helper()
+	expected := strings.NewReader(fmt.Sprintf(`# HELP gocell_vault_cached_key_version Latest Vault Transit key version cached by this process; 0 means cache miss.
+# TYPE gocell_vault_cached_key_version gauge
+gocell_vault_cached_key_version{key_name="gocell-config",mount_path="transit"} %g
+`, version))
+	require.NoError(t, testutil.GatherAndCompare(registry, expected, "gocell_vault_cached_key_version"))
+}

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
+	prom "github.com/prometheus/client_golang/prometheus"
 )
 
 // SharedDeps holds cross-cutting dependencies required by every Cell module.
@@ -123,6 +124,13 @@ type SharedDeps struct {
 	// metricsHandler is the Prometheus HTTP handler built once in
 	// LoadSharedDepsFromEnv and reused by defaultRuntimeOptions.
 	metricsHandler http.Handler
+
+	// keyProviderMetricCollectors are the collectors currently registered for
+	// the ConfigCore KeyProvider. ConfigCoreModule.Provide may be called more
+	// than once against the same SharedDeps in tests/rebuild paths; tracking
+	// ownership here lets the module replace provider-bound GaugeFunc collectors
+	// instead of leaving stale closures attached to an older provider instance.
+	keyProviderMetricCollectors []prom.Collector
 }
 
 type sharedReplayDeps struct {

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -85,13 +85,13 @@ the `X-Readyz-Token` header.
 ```json
 {
   "data": {
-    "status": "healthy",
-    "cells":   { "accesscore": "healthy", "auditcore": "healthy" },
-    "dependencies": {
-      "postgres-ping": { "status": "healthy", "duration_ms": 3 }
-    },
-    "adapters": { "storage": "postgres", "eventbus": "rabbitmq" }
-  }
+	    "status": "healthy",
+	    "cells":   { "accesscore": "healthy", "auditcore": "healthy" },
+	    "dependencies": {
+	      "postgres_ready": { "status": "healthy", "duration_ms": 3 }
+	    },
+	    "adapters": { "storage": "postgres", "eventbus": "rabbitmq" }
+	  }
 }
 ```
 
@@ -103,12 +103,12 @@ the `X-Readyz-Token` header.
     "code": "ERR_READYZ_UNHEALTHY",
     "message": "readiness checks failed",
     "details": {
-      "cells": { "accesscore": "healthy", "auditcore": "degraded" },
-      "dependencies": {
-        "postgres-ping": { "status": "healthy", "duration_ms": 3 },
-        "rabbitmq": { "status": "unhealthy", "duration_ms": 12,
-                       "error": "connection refused" }
-      },
+	      "cells": { "accesscore": "healthy", "auditcore": "degraded" },
+	      "dependencies": {
+	        "postgres_ready": { "status": "healthy", "duration_ms": 3 },
+	        "rabbitmq_ready": { "status": "unhealthy", "duration_ms": 12,
+	                       "error": "connection refused" }
+	      },
       "adapters": { "storage": "postgres", "eventbus": "rabbitmq" }
     }
   }

--- a/kernel/lifecycle/doc.go
+++ b/kernel/lifecycle/doc.go
@@ -45,4 +45,23 @@
 // consumes ManagedResource via WithManagedResource to register /readyz checkers,
 // start/stop the worker, and close the resource in LIFO order during shutdown.
 // See managed_resource.go for the full contract.
+//
+// Implementation checklist:
+//
+//   - Resource owner types implement all three methods directly: Checkers,
+//     Worker, and Close. Subresources that use a caller-owned connection or pool
+//     stay out of the contract and must be listed in the adapter archtest
+//     opt-out table with a category and reason.
+//   - Checkers return stable snake_case probe names. Adapter readiness probes
+//     use the suffix "_ready" (for example, "rabbitmq_ready" and
+//     "vault_transit_ready"). Multi-role workers may use component-role names
+//     only when a single "_ready" probe would hide distinct failure domains.
+//   - Checker functions must accept the caller's context, avoid unbounded I/O,
+//     and return nil only when the specific dependency needed by the adapter is
+//     usable. Prefer business-path probes over generic process health.
+//   - Worker returns nil when no bootstrap-managed goroutine is needed. A nil
+//     Worker is a contract statement, not a fallback path.
+//   - Close must be idempotent, must honour ctx for network/drain operations,
+//     and should log structured diagnostics before discarding state that helps
+//     explain shutdown or reconnect behaviour.
 package lifecycle

--- a/tests/testutil/images.go
+++ b/tests/testutil/images.go
@@ -1,14 +1,16 @@
 // Package testutil provides shared test utilities for integration tests.
 package testutil
 
-// Testcontainer images pinned to specific patch versions.
-// Floating minor tags (e.g., "postgres:15-alpine") are forbidden — they cause
-// non-reproducible CI builds when upstream pushes a new patch release.
+// Testcontainer images pinned to specific patch versions and immutable digests.
+// Floating minor tags (e.g., "postgres:15-alpine") and tag-only patch pins are
+// forbidden because they cause non-reproducible CI builds when upstream retags.
 //
-// Update procedure: bump the patch version, run `go test ./tests/testutil/...`
-// to verify the format, then run integration tests.
+// Update procedure: bump the patch version, refresh the manifest-list digest
+// for the exact tag, run `go test ./tests/testutil/...` to verify the format,
+// then run integration tests.
 const (
-	PostgresImage = "postgres:15.13-alpine"
-	RedisImage    = "redis:7.4.2-alpine"
-	RabbitMQImage = "rabbitmq:3.12.14-management-alpine"
+	PostgresImage = "postgres:15.13-alpine@sha256:1414298ea93186123a6dcf872f778ba3bd2347edcbd2f31aa7bb2d9814ff5393"
+	RedisImage    = "redis:7.4.2-alpine@sha256:02419de7eddf55aa5bcf49efb74e88fa8d931b4d77c07eff8a6b2144472b6952"
+	RabbitMQImage = "rabbitmq:3.12.14-management-alpine@sha256:0b44fbcc3a4bf22d00090f1353127577dbe1fcb109c41669733a9d7ecf6c3a78"
+	VaultImage    = "hashicorp/vault:1.17@sha256:74a4ab138ab5d64725e89cd9a9c73f7040c7fe49e98b71697b275ca9a69919df"
 )

--- a/tests/testutil/images_test.go
+++ b/tests/testutil/images_test.go
@@ -7,29 +7,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// patchPinned matches name:X.Y.Z (3+ version segments) — redis, rabbitmq.
-var patchPinned = regexp.MustCompile(`^[a-z]+:\d+\.\d+\.\d+`)
-
-// minorPinned matches name:X.Y (2+ version segments) — postgres uses 2-segment versions.
-var minorPinned = regexp.MustCompile(`^[a-z]+:\d+\.\d+`)
+var imagePinnedByDigest = regexp.MustCompile(`^[a-z0-9./-]+:\d+\.\d+(\.\d+)?[a-z0-9.-]*@sha256:[a-f0-9]{64}$`)
 
 // TestContainerImagesPinned verifies that all testcontainer image constants
-// use pinned versions, not floating tags like "postgres:15-alpine".
-//
-// postgres uses 2-segment versions (15.13); redis and rabbitmq use 3-segment (7.4.2, 3.12.14).
+// use tag+digest pinning, not floating tags like "postgres:15-alpine".
 func TestContainerImagesPinned(t *testing.T) {
-	t.Run("PostgresImage pinned to minor", func(t *testing.T) {
-		assert.Regexp(t, minorPinned, PostgresImage,
-			"PostgresImage = %q must be pinned (MAJOR.MINOR)", PostgresImage)
-	})
-	t.Run("RedisImage pinned to patch", func(t *testing.T) {
-		assert.Regexp(t, patchPinned, RedisImage,
-			"RedisImage = %q must be pinned (MAJOR.MINOR.PATCH)", RedisImage)
-	})
-	t.Run("RabbitMQImage pinned to patch", func(t *testing.T) {
-		assert.Regexp(t, patchPinned, RabbitMQImage,
-			"RabbitMQImage = %q must be pinned (MAJOR.MINOR.PATCH)", RabbitMQImage)
-	})
+	images := map[string]string{
+		"PostgresImage": PostgresImage,
+		"RedisImage":    RedisImage,
+		"RabbitMQImage": RabbitMQImage,
+		"VaultImage":    VaultImage,
+	}
+	for name, image := range images {
+		t.Run(name, func(t *testing.T) {
+			assert.Regexp(t, imagePinnedByDigest, image,
+				"%s = %q must be tag+digest pinned (name:version@sha256:digest)", name, image)
+		})
+	}
 }
 
 // TestContainerImagesPinned_RejectsFloating verifies that floating tags are
@@ -37,16 +31,16 @@ func TestContainerImagesPinned(t *testing.T) {
 func TestContainerImagesPinned_RejectsFloating(t *testing.T) {
 	floating := []string{
 		"postgres:15-alpine",
+		"postgres:15.13-alpine",
 		"redis:7-alpine",
+		"redis:7.4.2-alpine",
 		"rabbitmq:3-management-alpine",
+		"rabbitmq:3.12.14-management-alpine",
+		"hashicorp/vault:1.17",
 	}
 
 	for _, img := range floating {
-		assert.NotRegexp(t, patchPinned, img,
-			"%q is a floating tag and must NOT match the pinned pattern", img)
+		assert.NotRegexp(t, imagePinnedByDigest, img,
+			"%q lacks a digest and must NOT match the pinned pattern", img)
 	}
-
-	// postgres:15-alpine must also fail the minor pattern (only 1 segment before hyphen).
-	assert.NotRegexp(t, minorPinned, "postgres:15-alpine",
-		"postgres:15-alpine must NOT match minor-pinned pattern")
 }

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -53,6 +53,34 @@ updates:
 		"group names must not satisfy the guard unless a pattern covers the action")
 }
 
+func TestDependabotCoversCIAndGolangCILintRejectsNonRootPatternOnly(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"
+    groups:
+      golangci:
+        patterns:
+          - "golangci/golangci-lint-action"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`)
+	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
+		"golangci-lint action pattern must be attached to the root github-actions update")
+}
+
 type dependabotConfig struct {
 	Version int                `yaml:"version"`
 	Updates []dependabotUpdate `yaml:"updates"`
@@ -83,18 +111,13 @@ func validateDependabotCoversCIAndGolangCILint(body []byte) error {
 
 	var hasGitHubActions bool
 	var hasGoMod bool
-	var hasGolangCIActionPattern bool
 	for _, update := range cfg.Updates {
 		switch update.PackageEcosystem {
 		case "github-actions":
 			if update.Directory == "/" {
 				hasGitHubActions = true
-			}
-			for _, group := range update.Groups {
-				for _, pattern := range group.Patterns {
-					if pattern == "golangci/golangci-lint-action" {
-						hasGolangCIActionPattern = true
-					}
+				if rootGitHubActionsUpdateCoversGolangCI(update) {
+					return validateDependabotHasGoModRoot(cfg)
 				}
 			}
 		case "gomod":
@@ -106,11 +129,28 @@ func validateDependabotCoversCIAndGolangCILint(body []byte) error {
 	if !hasGitHubActions {
 		return fmt.Errorf("dependabot must update GitHub Actions pins from directory /")
 	}
-	if !hasGolangCIActionPattern {
-		return fmt.Errorf("dependabot github-actions groups must explicitly pattern-match golangci/golangci-lint-action")
-	}
 	if !hasGoMod {
 		return fmt.Errorf("dependabot must update Go module pins from directory /")
 	}
-	return nil
+	return fmt.Errorf("dependabot root github-actions groups must explicitly pattern-match golangci/golangci-lint-action")
+}
+
+func rootGitHubActionsUpdateCoversGolangCI(update dependabotUpdate) bool {
+	for _, group := range update.Groups {
+		for _, pattern := range group.Patterns {
+			if pattern == "golangci/golangci-lint-action" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func validateDependabotHasGoModRoot(cfg dependabotConfig) error {
+	for _, update := range cfg.Updates {
+		if update.PackageEcosystem == "gomod" && update.Directory == "/" {
+			return nil
+		}
+	}
+	return fmt.Errorf("dependabot must update Go module pins from directory /")
 }

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -1,14 +1,16 @@
 package archtest
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGolangCILintVersionPinnedToPatch(t *testing.T) {
@@ -28,13 +30,87 @@ func TestDependabotCoversCIAndGolangCILint(t *testing.T) {
 	body, err := os.ReadFile(filepath.Join(root, ".github", "dependabot.yml"))
 	require.NoError(t, err, ".github/dependabot.yml must exist")
 
-	content := string(body)
-	assert.Contains(t, content, `package-ecosystem: "github-actions"`,
-		"dependabot must update GitHub Actions pins")
-	assert.Contains(t, content, `package-ecosystem: "gomod"`,
-		"dependabot must update Go module pins")
-	assert.True(t,
-		strings.Contains(content, "golangci/golangci-lint-action") ||
-			strings.Contains(content, "golangci-lint"),
-		"dependabot config must explicitly cover golangci-lint maintenance")
+	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body))
+}
+
+func TestDependabotCoversCIAndGolangCILintRejectsGroupNameOnly(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      golangci-lint:
+        patterns:
+          - "actions/*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`)
+	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
+		"group names must not satisfy the guard unless a pattern covers the action")
+}
+
+type dependabotConfig struct {
+	Version int                `yaml:"version"`
+	Updates []dependabotUpdate `yaml:"updates"`
+}
+
+type dependabotUpdate struct {
+	PackageEcosystem string                     `yaml:"package-ecosystem"`
+	Directory        string                     `yaml:"directory"`
+	Schedule         dependabotSchedule         `yaml:"schedule"`
+	Groups           map[string]dependabotGroup `yaml:"groups"`
+}
+
+type dependabotSchedule struct {
+	Interval string `yaml:"interval"`
+}
+
+type dependabotGroup struct {
+	Patterns []string `yaml:"patterns"`
+}
+
+func validateDependabotCoversCIAndGolangCILint(body []byte) error {
+	var cfg dependabotConfig
+	dec := yaml.NewDecoder(bytes.NewReader(body))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		return fmt.Errorf("parse dependabot.yml: %w", err)
+	}
+
+	var hasGitHubActions bool
+	var hasGoMod bool
+	var hasGolangCIActionPattern bool
+	for _, update := range cfg.Updates {
+		switch update.PackageEcosystem {
+		case "github-actions":
+			if update.Directory == "/" {
+				hasGitHubActions = true
+			}
+			for _, group := range update.Groups {
+				for _, pattern := range group.Patterns {
+					if pattern == "golangci/golangci-lint-action" {
+						hasGolangCIActionPattern = true
+					}
+				}
+			}
+		case "gomod":
+			if update.Directory == "/" {
+				hasGoMod = true
+			}
+		}
+	}
+	if !hasGitHubActions {
+		return fmt.Errorf("dependabot must update GitHub Actions pins from directory /")
+	}
+	if !hasGolangCIActionPattern {
+		return fmt.Errorf("dependabot github-actions groups must explicitly pattern-match golangci/golangci-lint-action")
+	}
+	if !hasGoMod {
+		return fmt.Errorf("dependabot must update Go module pins from directory /")
+	}
+	return nil
 }

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -1,0 +1,40 @@
+package archtest
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGolangCILintVersionPinnedToPatch(t *testing.T) {
+	root := findModuleRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "_build-lint.yml"))
+	require.NoError(t, err)
+
+	re := regexp.MustCompile(`(?m)^\s*version:\s*(v[0-9]+\.[0-9]+(?:\.[0-9]+)?)\s*$`)
+	matches := re.FindStringSubmatch(string(body))
+	require.Len(t, matches, 2, "golangci-lint action version input must be present")
+	assert.Regexp(t, regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`), matches[1],
+		"golangci-lint must be pinned to patch version, not only major.minor")
+}
+
+func TestDependabotCoversCIAndGolangCILint(t *testing.T) {
+	root := findModuleRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, ".github", "dependabot.yml"))
+	require.NoError(t, err, ".github/dependabot.yml must exist")
+
+	content := string(body)
+	assert.Contains(t, content, `package-ecosystem: "github-actions"`,
+		"dependabot must update GitHub Actions pins")
+	assert.Contains(t, content, `package-ecosystem: "gomod"`,
+		"dependabot must update Go module pins")
+	assert.True(t,
+		strings.Contains(content, "golangci/golangci-lint-action") ||
+			strings.Contains(content, "golangci-lint"),
+		"dependabot config must explicitly cover golangci-lint maintenance")
+}

--- a/tools/archtest/integration_guard_test.go
+++ b/tools/archtest/integration_guard_test.go
@@ -1,0 +1,64 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVaultIntegrationContainerFailuresFailFast(t *testing.T) {
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "adapters", "vault", "integration_test.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err)
+
+	fn := findFuncDecl(file, "startVaultContainer")
+	require.NotNil(t, fn, "startVaultContainer helper must exist")
+
+	var hasDockerPrecheck bool
+	var skipCalls []string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if selectorName(call.Fun) == "RequireDocker" {
+			hasDockerPrecheck = true
+		}
+		switch selectorName(call.Fun) {
+		case "Skip", "Skipf", "SkipNow":
+			skipCalls = append(skipCalls, fset.Position(call.Pos()).String())
+		}
+		return true
+	})
+
+	assert.True(t, hasDockerPrecheck, "startVaultContainer must explicitly skip only when Docker is unavailable")
+	assert.Empty(t, skipCalls, "Vault container startup/address failures must fail-fast, not skip")
+}
+
+func findFuncDecl(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+func selectorName(expr ast.Expr) string {
+	switch x := expr.(type) {
+	case *ast.SelectorExpr:
+		return x.Sel.Name
+	case *ast.Ident:
+		return x.Name
+	default:
+		return ""
+	}
+}

--- a/tools/archtest/managed_resource_contract_test.go
+++ b/tools/archtest/managed_resource_contract_test.go
@@ -1,8 +1,12 @@
 package archtest
 
 import (
+	"go/ast"
+	"go/constant"
 	"go/types"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -98,6 +102,24 @@ func TestAdaptersExportedTypesManagedResourceOrOptOut(t *testing.T) {
 	assert.Empty(t, violations, "A54 ManagedResource contract violations")
 }
 
+func TestAdapterManagedResourceCheckerNamesUseReadySuffix(t *testing.T) {
+	root := findModuleRoot(t)
+	modulePath := readModulePath(t, root)
+	pkgs := loadTypedPackages(t, root, "./adapters/...")
+
+	var violations []string
+	for _, pkg := range pkgs {
+		adapterPkg, ok := strings.CutPrefix(pkg.PkgPath, modulePath+"/adapters/")
+		if !ok || strings.Contains(adapterPkg, "/") {
+			continue
+		}
+		violations = append(violations, adapterCheckerNameViolations(pkg, "adapters/"+adapterPkg)...)
+	}
+
+	sort.Strings(violations)
+	assert.Empty(t, violations, "adapter ManagedResource ready probes must use stable snake_case names ending in _ready")
+}
+
 func collectAdapterExportedTypes(pkgs []*packages.Package, modulePath string) []adapterExportedType {
 	adapterPrefix := modulePath + "/adapters/"
 	var out []adapterExportedType
@@ -148,4 +170,45 @@ func implementsManagedResource(typ types.Type, managedResource *types.Interface)
 		return true
 	}
 	return types.Implements(types.NewPointer(typ), managedResource)
+}
+
+var adapterReadyProbeNamePattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:_[a-z0-9]+)*_ready$`)
+
+func adapterCheckerNameViolations(pkg *packages.Package, rel string) []string {
+	var violations []string
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "Checkers" || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				continue
+			}
+			recv := receiverTypeName(fn.Recv.List[0].Type)
+			if recv == "" || !ast.IsExported(recv) {
+				continue
+			}
+			for _, name := range checkerNamesFromFunc(pkg.TypesInfo, fn) {
+				if !adapterReadyProbeNamePattern.MatchString(name) {
+					violations = append(violations, rel+"."+recv+" Checkers probe "+strconv.Quote(name)+" must be snake_case and end with _ready")
+				}
+			}
+		}
+	}
+	return violations
+}
+
+func checkerNamesFromFunc(info *types.Info, fn *ast.FuncDecl) []string {
+	var names []string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		kv, ok := n.(*ast.KeyValueExpr)
+		if !ok {
+			return true
+		}
+		tv, ok := info.Types[kv.Key]
+		if !ok || tv.Value == nil || tv.Value.Kind() != constant.String {
+			return true
+		}
+		names = append(names, constant.StringVal(tv.Value))
+		return true
+	})
+	return names
 }

--- a/tools/archtest/managed_resource_contract_test.go
+++ b/tools/archtest/managed_resource_contract_test.go
@@ -1,0 +1,176 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type adapterExportedType struct {
+	ID      string
+	Name    string
+	Methods map[string]struct{}
+}
+
+var adapterManagedResourceOptOut = map[string]string{
+	"adapters/circuitbreaker.Adapter":          "stateless-adapter: no owned external connection or background worker",
+	"adapters/circuitbreaker.Config":           "config: construction input value",
+	"adapters/circuitbreaker.Counts":           "value-object: breaker statistics snapshot",
+	"adapters/circuitbreaker.State":            "value-object: breaker enum",
+	"adapters/oidc.Adapter":                    "stateless-adapter: wraps OIDC provider calls without owned lifecycle",
+	"adapters/oidc.Config":                     "config: construction input value",
+	"adapters/otel.MessagingChannelStatter":    "value-object: statter config for external metric collection",
+	"adapters/otel.MetricProvider":             "stateless-adapter: emits metrics through caller-owned SDK/provider",
+	"adapters/otel.Tracer":                     "stateless-adapter: tracer facade, provider lifecycle is caller-owned",
+	"adapters/otel.TracerConfig":               "config: construction input value",
+	"adapters/postgres.Config":                 "config: construction input value",
+	"adapters/postgres.InvalidIndex":           "value-object: schema validation diagnostic",
+	"adapters/postgres.MigrationDirection":     "value-object: migration enum",
+	"adapters/postgres.MigrationStatus":        "value-object: migration diagnostic snapshot",
+	"adapters/postgres.Migrator":               "subresource-not-owner: uses caller-owned pool, no independent lifecycle",
+	"adapters/postgres.OutboxWriter":           "stateless-adapter: writes through ctx-bound transaction",
+	"adapters/postgres.PGOutboxStore":          "subresource-not-owner: storage facade over caller-owned pool",
+	"adapters/postgres.PGRefreshStore":         "subresource-not-owner: storage facade over caller-owned pool",
+	"adapters/postgres.Pool":                   "subresource-not-owner: wrapped by PGResource for ManagedResource wiring",
+	"adapters/postgres.PoolStats":              "value-object: pool diagnostic snapshot",
+	"adapters/postgres.RowScanner":             "interface: query row abstraction, not a resource",
+	"adapters/postgres.TxManager":              "subresource-not-owner: transaction facade over caller-owned pool",
+	"adapters/prometheus.HookObserver":         "stateless-adapter: observes lifecycle events through caller-owned registry",
+	"adapters/prometheus.HookObserverConfig":   "config: construction input value",
+	"adapters/prometheus.MetricProvider":       "stateless-adapter: metrics facade over caller-owned registry",
+	"adapters/prometheus.MetricProviderConfig": "config: construction input value",
+	"adapters/rabbitmq.AMQPChannel":            "interface: amqp channel abstraction, not a top-level resource",
+	"adapters/rabbitmq.AMQPConnection":         "interface: amqp connection abstraction, not exported owner type",
+	"adapters/rabbitmq.Config":                 "config: construction input value",
+	"adapters/rabbitmq.ConnectionOption":       "config: functional option",
+	"adapters/rabbitmq.ConnectionPhase":        "value-object: lifecycle enum",
+	"adapters/rabbitmq.ConnectionState":        "value-object: structured diagnostic snapshot",
+	"adapters/rabbitmq.DialFunc":               "config: injected dial function",
+	"adapters/rabbitmq.PoolStats":              "value-object: channel-pool diagnostic snapshot",
+	"adapters/rabbitmq.Publisher":              "subresource-not-owner: uses caller-owned Connection",
+	"adapters/rabbitmq.Subscriber":             "subresource-not-owner: uses caller-owned Connection",
+	"adapters/rabbitmq.SubscriberConfig":       "config: construction input value",
+	"adapters/ratelimit.Config":                "config: construction input value",
+	"adapters/ratelimit.Limiter":               "close-only-resource: in-memory limiter has no readiness or worker surface",
+	"adapters/redis.Cache":                     "subresource-not-owner: uses caller-owned Redis Client",
+	"adapters/redis.Client":                    "close-only-resource: health/close are wired explicitly; no worker/checker bundle yet",
+	"adapters/redis.Config":                    "config: construction input value",
+	"adapters/redis.IdempotencyClaimer":        "subresource-not-owner: uses caller-owned Redis Client",
+	"adapters/redis.Mode":                      "value-object: Redis topology enum",
+	"adapters/redis.NonceStore":                "subresource-not-owner: uses caller-owned Redis Client",
+	"adapters/redis.PoolStats":                 "value-object: pool diagnostic snapshot",
+	"adapters/redis.RedisDriver":               "subresource-not-owner: distlock driver over caller-owned Redis Client",
+	"adapters/s3.Client":                       "stateless-adapter: AWS SDK client has no GoCell readiness/worker contract",
+	"adapters/s3.Config":                       "config: construction input value",
+	"adapters/vault.AuthMethod":                "interface: authentication strategy, not a resource",
+	"adapters/vault.AuthResult":                "value-object: auth result",
+	"adapters/vault.Method":                    "value-object: auth method enum",
+	"adapters/vault.SecretIDProvider":          "interface: secret-id source, not a resource",
+	"adapters/vault.TokenRenewer":              "interface: optional renewal capability, not a resource",
+	"adapters/vault.VaultClient":               "interface: Vault API subset, not an owner type",
+	"adapters/websocket.Conn":                  "subresource-not-owner: individual accepted connection lifecycle is handler-owned",
+	"adapters/websocket.UpgradeConfig":         "config: construction input value",
+}
+
+func TestAdaptersExportedTypesManagedResourceOrOptOut(t *testing.T) {
+	root := findModuleRoot(t)
+	types := collectAdapterExportedTypes(t, filepath.Join(root, "adapters"))
+
+	var violations []string
+	for _, typ := range types {
+		if reason := adapterManagedResourceOptOut[typ.ID]; reason != "" {
+			continue
+		}
+		if !hasMethods(typ.Methods, "Checkers", "Worker", "Close") {
+			violations = append(violations, typ.ID+" must implement lifecycle.ManagedResource or be listed in adapterManagedResourceOptOut")
+		}
+	}
+
+	sort.Strings(violations)
+	assert.Empty(t, violations, "A54 ManagedResource contract violations")
+}
+
+func collectAdapterExportedTypes(t *testing.T, adapterRoot string) []adapterExportedType {
+	t.Helper()
+	entries, err := os.ReadDir(adapterRoot)
+	require.NoError(t, err)
+
+	var out []adapterExportedType
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pkgDir := filepath.Join(adapterRoot, entry.Name())
+		rel := filepath.ToSlash(filepath.Join("adapters", entry.Name()))
+		types := map[string]*adapterExportedType{}
+
+		files, err := os.ReadDir(pkgDir)
+		require.NoError(t, err)
+		for _, file := range files {
+			if file.IsDir() || !strings.HasSuffix(file.Name(), ".go") || strings.HasSuffix(file.Name(), "_test.go") {
+				continue
+			}
+			parseAdapterTypeFile(t, filepath.Join(pkgDir, file.Name()), rel, types)
+		}
+		for _, typ := range types {
+			out = append(out, *typ)
+		}
+	}
+	return out
+}
+
+func parseAdapterTypeFile(t *testing.T, path, rel string, types map[string]*adapterExportedType) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err)
+
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.GenDecl:
+			if d.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range d.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !ast.IsExported(ts.Name.Name) {
+					continue
+				}
+				id := rel + "." + ts.Name.Name
+				if types[id] == nil {
+					types[id] = &adapterExportedType{ID: id, Name: ts.Name.Name, Methods: map[string]struct{}{}}
+				}
+			}
+		case *ast.FuncDecl:
+			if d.Recv == nil || len(d.Recv.List) == 0 || !d.Name.IsExported() {
+				continue
+			}
+			recv := receiverTypeName(d.Recv.List[0].Type)
+			if recv == "" || !ast.IsExported(recv) {
+				continue
+			}
+			id := rel + "." + recv
+			if types[id] == nil {
+				types[id] = &adapterExportedType{ID: id, Name: recv, Methods: map[string]struct{}{}}
+			}
+			types[id].Methods[d.Name.Name] = struct{}{}
+		}
+	}
+}
+
+func hasMethods(methods map[string]struct{}, names ...string) bool {
+	for _, name := range names {
+		if _, ok := methods[name]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/archtest/managed_resource_contract_test.go
+++ b/tools/archtest/managed_resource_contract_test.go
@@ -1,23 +1,20 @@
 package archtest
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"path/filepath"
+	"go/types"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 type adapterExportedType struct {
-	ID      string
-	Name    string
-	Methods map[string]struct{}
+	ID   string
+	Name string
+	Type types.Type
 }
 
 var adapterManagedResourceOptOut = map[string]string{
@@ -82,14 +79,17 @@ var adapterManagedResourceOptOut = map[string]string{
 
 func TestAdaptersExportedTypesManagedResourceOrOptOut(t *testing.T) {
 	root := findModuleRoot(t)
-	types := collectAdapterExportedTypes(t, filepath.Join(root, "adapters"))
+	modulePath := readModulePath(t, root)
+	pkgs := loadTypedPackages(t, root, "./kernel/lifecycle", "./adapters/...")
+	managedResource := managedResourceInterface(t, pkgs, modulePath)
+	adapterTypes := collectAdapterExportedTypes(pkgs, modulePath)
 
 	var violations []string
-	for _, typ := range types {
+	for _, typ := range adapterTypes {
 		if reason := adapterManagedResourceOptOut[typ.ID]; reason != "" {
 			continue
 		}
-		if !hasMethods(typ.Methods, "Checkers", "Worker", "Close") {
+		if !implementsManagedResource(typ.Type, managedResource) {
 			violations = append(violations, typ.ID+" must implement lifecycle.ManagedResource or be listed in adapterManagedResourceOptOut")
 		}
 	}
@@ -98,79 +98,54 @@ func TestAdaptersExportedTypesManagedResourceOrOptOut(t *testing.T) {
 	assert.Empty(t, violations, "A54 ManagedResource contract violations")
 }
 
-func collectAdapterExportedTypes(t *testing.T, adapterRoot string) []adapterExportedType {
-	t.Helper()
-	entries, err := os.ReadDir(adapterRoot)
-	require.NoError(t, err)
-
+func collectAdapterExportedTypes(pkgs []*packages.Package, modulePath string) []adapterExportedType {
+	adapterPrefix := modulePath + "/adapters/"
 	var out []adapterExportedType
-	for _, entry := range entries {
-		if !entry.IsDir() {
+	for _, pkg := range pkgs {
+		adapterPkg, ok := strings.CutPrefix(pkg.PkgPath, adapterPrefix)
+		if !ok || strings.Contains(adapterPkg, "/") {
 			continue
 		}
-		pkgDir := filepath.Join(adapterRoot, entry.Name())
-		rel := filepath.ToSlash(filepath.Join("adapters", entry.Name()))
-		types := map[string]*adapterExportedType{}
-
-		files, err := os.ReadDir(pkgDir)
-		require.NoError(t, err)
-		for _, file := range files {
-			if file.IsDir() || !strings.HasSuffix(file.Name(), ".go") || strings.HasSuffix(file.Name(), "_test.go") {
+		scope := pkg.Types.Scope()
+		for _, name := range scope.Names() {
+			obj, ok := scope.Lookup(name).(*types.TypeName)
+			if !ok || !obj.Exported() {
 				continue
 			}
-			parseAdapterTypeFile(t, filepath.Join(pkgDir, file.Name()), rel, types)
-		}
-		for _, typ := range types {
-			out = append(out, *typ)
+			out = append(out, adapterExportedType{
+				ID:   "adapters/" + adapterPkg + "." + name,
+				Name: name,
+				Type: obj.Type(),
+			})
 		}
 	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
 	return out
 }
 
-func parseAdapterTypeFile(t *testing.T, path, rel string, types map[string]*adapterExportedType) {
+func managedResourceInterface(t *testing.T, pkgs []*packages.Package, modulePath string) *types.Interface {
 	t.Helper()
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, path, nil, 0)
-	require.NoError(t, err)
-
-	for _, decl := range f.Decls {
-		switch d := decl.(type) {
-		case *ast.GenDecl:
-			if d.Tok != token.TYPE {
-				continue
-			}
-			for _, spec := range d.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || !ast.IsExported(ts.Name.Name) {
-					continue
-				}
-				id := rel + "." + ts.Name.Name
-				if types[id] == nil {
-					types[id] = &adapterExportedType{ID: id, Name: ts.Name.Name, Methods: map[string]struct{}{}}
-				}
-			}
-		case *ast.FuncDecl:
-			if d.Recv == nil || len(d.Recv.List) == 0 || !d.Name.IsExported() {
-				continue
-			}
-			recv := receiverTypeName(d.Recv.List[0].Type)
-			if recv == "" || !ast.IsExported(recv) {
-				continue
-			}
-			id := rel + "." + recv
-			if types[id] == nil {
-				types[id] = &adapterExportedType{ID: id, Name: recv, Methods: map[string]struct{}{}}
-			}
-			types[id].Methods[d.Name.Name] = struct{}{}
+	for _, pkg := range pkgs {
+		if pkg.PkgPath != modulePath+"/kernel/lifecycle" {
+			continue
 		}
+		obj := pkg.Types.Scope().Lookup("ManagedResource")
+		require.NotNil(t, obj, "kernel/lifecycle.ManagedResource not found")
+		named, ok := obj.Type().(*types.Named)
+		require.True(t, ok, "ManagedResource type = %T, want *types.Named", obj.Type())
+		iface, ok := named.Underlying().(*types.Interface)
+		require.True(t, ok, "ManagedResource underlying type = %T, want *types.Interface", named.Underlying())
+		return iface.Complete()
 	}
+	require.FailNow(t, "kernel/lifecycle package not loaded")
+	return nil
 }
 
-func hasMethods(methods map[string]struct{}, names ...string) bool {
-	for _, name := range names {
-		if _, ok := methods[name]; !ok {
-			return false
-		}
+func implementsManagedResource(typ types.Type, managedResource *types.Interface) bool {
+	if types.Implements(typ, managedResource) {
+		return true
 	}
-	return true
+	return types.Implements(types.NewPointer(typ), managedResource)
 }

--- a/tools/archtest/managed_resource_contract_test.go
+++ b/tools/archtest/managed_resource_contract_test.go
@@ -105,12 +105,15 @@ func TestAdaptersExportedTypesManagedResourceOrOptOut(t *testing.T) {
 func TestAdapterManagedResourceCheckerNamesUseReadySuffix(t *testing.T) {
 	root := findModuleRoot(t)
 	modulePath := readModulePath(t, root)
-	pkgs := loadTypedPackages(t, root, "./adapters/...")
+	pkgs := loadTypedPackages(t, root, "./adapters/...", "./cmd/corebundle")
 
 	var violations []string
 	for _, pkg := range pkgs {
 		adapterPkg, ok := strings.CutPrefix(pkg.PkgPath, modulePath+"/adapters/")
 		if !ok || strings.Contains(adapterPkg, "/") {
+			if pkg.PkgPath == modulePath+"/cmd/corebundle" {
+				violations = append(violations, healthCheckerCallNameViolations(pkg, "cmd/corebundle")...)
+			}
 			continue
 		}
 		violations = append(violations, adapterCheckerNameViolations(pkg, "adapters/"+adapterPkg)...)
@@ -211,4 +214,33 @@ func checkerNamesFromFunc(info *types.Info, fn *ast.FuncDecl) []string {
 		return true
 	})
 	return names
+}
+
+func healthCheckerCallNameViolations(pkg *packages.Package, rel string) []string {
+	var violations []string
+	for _, file := range pkg.Syntax {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || selectorName(call.Fun) != "WithHealthChecker" || len(call.Args) == 0 {
+				return true
+			}
+			name, ok := constStringValue(pkg.TypesInfo, call.Args[0])
+			if !ok {
+				return true
+			}
+			if !adapterReadyProbeNamePattern.MatchString(name) {
+				violations = append(violations, rel+" bootstrap.WithHealthChecker probe "+strconv.Quote(name)+" must be snake_case and end with _ready")
+			}
+			return true
+		})
+	}
+	return violations
+}
+
+func constStringValue(info *types.Info, expr ast.Expr) (string, bool) {
+	tv, ok := info.Types[expr]
+	if !ok || tv.Value == nil || tv.Value.Kind() != constant.String {
+		return "", false
+	}
+	return constant.StringVal(tv.Value), true
 }


### PR DESCRIPTION
## Summary

Implements A54 from `docs/plans/202604252100-026-post-v1.0-cleanup-plan.md`:

- formalizes the ManagedResource contract with lifecycle documentation and archtest coverage
- adds structured RabbitMQ connection diagnostics, sanitized reconnect metadata, and a wiring example
- exposes Vault transit cached key version as a Prometheus metric and registers provider metrics through corebundle
- adds Vault Kubernetes auth login coverage using a projected service account JWT fixture
- pins testcontainer images by digest and adds CI/dependabot guardrails for golangci-lint patch versions
- documents readyz probe naming expectations and completes the A54 TOCTOU audit

## TOCTOU audit

Reviewed create/write paths with `rg` for `OpenFile(...O_CREATE...)` and `os.WriteFile`:

- secret credential creation already uses exclusive create/no-follow protections where supported
- Windows credential creation uses exclusive create plus DACL handling; no direct `O_NOFOLLOW` equivalent
- production `os.WriteFile` hits are generated scaffold/index files with intentional overwrite semantics
- remaining hits are tests or temporary fixtures

## Verification

- `go build ./...`
- `go test ./...`
- `go run ./cmd/gocell validate --strict`
- `go run ./cmd/gocell verify journey --active`
- `go run ./cmd/gocell check contract-health`
- `go vet ./...`
- `go run ./cmd/gocell check unconditional-skip ./...`
- `go test -tags=integration ./adapters/vault ./adapters/rabbitmq -count=1 -timeout 15m`
- `golangci-lint run ./adapters/rabbitmq/... ./adapters/vault/... ./cmd/corebundle/... ./kernel/lifecycle/... ./tests/testutil/... ./tools/archtest/...`
