### PR TITLE
PR-MODE-6.1 nil error-first cleanup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,15 @@ linters:
   # gosimple is part of staticcheck in v2.
   enable:
     - gocognit
+    - nilerr
+    - nilnesserr
+    - nilnil
 
   settings:
     gocognit:
       min-complexity: 15 # project rule: ≤ 15, flag at 15+
+    nilnil:
+      only-two: false
 
   exclusions:
     rules:

--- a/adapters/postgres/outbox_mock_test.go
+++ b/adapters/postgres/outbox_mock_test.go
@@ -136,7 +136,7 @@ func (t *mockRelayTx) CopyFrom(_ context.Context, _ pgx.Identifier, _ []string, 
 func (t *mockRelayTx) SendBatch(_ context.Context, _ *pgx.Batch) pgx.BatchResults { return nil }
 func (t *mockRelayTx) LargeObjects() pgx.LargeObjects                             { return pgx.LargeObjects{} }
 func (t *mockRelayTx) Prepare(_ context.Context, _ string, _ string) (*pgconn.StatementDescription, error) {
-	return nil, nil
+	return &pgconn.StatementDescription{}, nil
 }
 func (t *mockRelayTx) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	return t.db.Exec(ctx, sql, args...)
@@ -257,7 +257,7 @@ func (t *mockRelayTxIterErr) CopyFrom(_ context.Context, _ pgx.Identifier, _ []s
 func (t *mockRelayTxIterErr) SendBatch(_ context.Context, _ *pgx.Batch) pgx.BatchResults { return nil }
 func (t *mockRelayTxIterErr) LargeObjects() pgx.LargeObjects                             { return pgx.LargeObjects{} }
 func (t *mockRelayTxIterErr) Prepare(_ context.Context, _ string, _ string) (*pgconn.StatementDescription, error) {
-	return nil, nil
+	return &pgconn.StatementDescription{}, nil
 }
 func (t *mockRelayTxIterErr) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	return t.db.Exec(ctx, sql, args...)

--- a/adapters/redis/doc.go
+++ b/adapters/redis/doc.go
@@ -24,7 +24,7 @@
 //
 //	rdb := goredis.NewClient(&goredis.Options{Addr: "localhost:6379"})
 //	driver := redis.NewRedisDriver(rdb)
-//	locker := distlock.New(driver,
+//	locker := distlock.MustNew(driver,
 //	    distlock.WithRenewFraction(0.5),
 //	    distlock.WithReleaseTimeout(5*time.Second),
 //	)

--- a/adapters/redis/idempotency.go
+++ b/adapters/redis/idempotency.go
@@ -151,7 +151,7 @@ func (c *IdempotencyClaimer) Claim(ctx context.Context, key string, leaseTTL, do
 
 	switch code {
 	case 0:
-		return idempotency.ClaimDone, nil, nil
+		return idempotency.ClaimDone, idempotency.NonAcquiredReceipt(), nil
 	case 1:
 		r := &redisReceipt{
 			rdb:      c.rdb,
@@ -162,7 +162,7 @@ func (c *IdempotencyClaimer) Claim(ctx context.Context, key string, leaseTTL, do
 		}
 		return idempotency.ClaimAcquired, r, nil
 	default:
-		return idempotency.ClaimBusy, nil, nil
+		return idempotency.ClaimBusy, idempotency.NonAcquiredReceipt(), nil
 	}
 }
 

--- a/adapters/redis/idempotency_test.go
+++ b/adapters/redis/idempotency_test.go
@@ -48,7 +48,8 @@ func TestIdempotencyClaimer_Claim_Done(t *testing.T) {
 	state, receipt, err := claimer.Claim(ctx, "idem:claim:2", 5*time.Minute, 24*time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimDone, state)
-	assert.Nil(t, receipt)
+	assert.NotNil(t, receipt)
+	assert.ErrorIs(t, receipt.Commit(ctx), idempotency.ErrNoClaimLease)
 }
 
 func TestIdempotencyClaimer_Claim_Busy(t *testing.T) {
@@ -64,7 +65,8 @@ func TestIdempotencyClaimer_Claim_Busy(t *testing.T) {
 	state, receipt, err := claimer.Claim(ctx, "idem:claim:3", 5*time.Minute, 24*time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimBusy, state)
-	assert.Nil(t, receipt)
+	assert.NotNil(t, receipt)
+	assert.ErrorIs(t, receipt.Release(ctx), idempotency.ErrNoClaimLease)
 }
 
 func TestIdempotencyClaimer_Receipt_Commit(t *testing.T) {
@@ -132,7 +134,7 @@ func TestIdempotencyClaimer_After_Commit_Claim_Returns_Done(t *testing.T) {
 	state, receipt2, err := claimer.Claim(ctx, "idem:full:1", 5*time.Minute, 24*time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimDone, state)
-	assert.Nil(t, receipt2)
+	assert.NotNil(t, receipt2)
 }
 
 func TestIdempotencyClaimer_After_Release_Claim_Reacquires(t *testing.T) {
@@ -361,7 +363,7 @@ func TestIdempotencyClaimer_Claim_Concurrent_OneAcquiredOneBusy(t *testing.T) {
 			assert.NotNil(t, r.receipt, "ClaimAcquired must return a non-nil receipt")
 		case idempotency.ClaimBusy:
 			busy++
-			assert.Nil(t, r.receipt, "ClaimBusy must return nil receipt")
+			assert.NotNil(t, r.receipt, "ClaimBusy must return a non-acquired receipt")
 		default:
 			t.Fatalf("unexpected ClaimState %d", r.state)
 		}

--- a/adapters/redis/integration_test.go
+++ b/adapters/redis/integration_test.go
@@ -128,7 +128,7 @@ func TestIntegration_IdempotencyClaimer(t *testing.T) {
 	state, receipt2, err := claimer.Claim(ctx, key, 5*time.Minute, 10*time.Second)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimDone, state)
-	assert.Nil(t, receipt2)
+	assert.NotNil(t, receipt2)
 }
 
 // TestIntegration_RedisDriver_SetNX_Contention verifies that a second SetNX

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -1383,9 +1383,7 @@ func (f *fakeTokenRenewer) NewLifetimeWatcher(_ *vaultapi.LifetimeWatcherInput) 
 	if f.newWatcherErr != nil {
 		return nil, f.newWatcherErr
 	}
-	// Return nil watcher — caller (initTokenRenewal) will panic if it dereferences it.
-	// Tests that exercise the happy path must not call this.
-	return nil, nil
+	return nil, fmt.Errorf("test fake: NewLifetimeWatcher called without configured result")
 }
 
 // TestInitTokenRenewal_LookupFails_ReturnsAuthError verifies that a

--- a/cells/accesscore/auth_integration_test.go
+++ b/cells/accesscore/auth_integration_test.go
@@ -125,7 +125,7 @@ func loginAndGetPair(t *testing.T, opts ...loginOption) loginResult {
 	require.NoError(t, err)
 
 	intClock := storetest.NewFakeClock(time.Now())
-	intRefreshStore := refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, intClock, nil)
+	intRefreshStore := refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, intClock, nil)
 
 	ks, _, _ := auth.MustNewTestKeySet()
 
@@ -161,7 +161,7 @@ func loginAndGetPair(t *testing.T, opts ...loginOption) loginResult {
 		DurabilityMode: cell.DurabilityDemo,
 	}))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Listener == cell.PrimaryListener {
 			if rg.Prefix != "" {
@@ -236,7 +236,7 @@ func TestAuthIntent_AccessTokenBlockedAtRefreshPath(t *testing.T) {
 	// Build a refresh-service that mirrors production wiring.
 	// After the opaque-store rewrite, ParseOpaque rejects the JWT (wrong
 	// selector/verifier format) → refresh.ErrRejected → ErrAuthRefreshFailed.
-	refreshSvc := sessionrefresh.NewService(
+	refreshSvc := sessionrefresh.MustNewService(
 		fx.Cell.sessionRepo, fx.Cell.roleRepo, fx.Cell.userRepo, fx.Cell.refreshStore, fx.Cell.jwtIssuer, slog.Default(),
 	)
 
@@ -256,7 +256,7 @@ func TestAuthIntent_RefreshTokenSucceedsAtRefreshPath(t *testing.T) {
 	// real login flow, so fx.Cell.sessionRepo already has one).
 	require.NotNil(t, fx.Cell.sessionRepo, "session repo must be wired")
 
-	refreshSvc := sessionrefresh.NewService(
+	refreshSvc := sessionrefresh.MustNewService(
 		fx.Cell.sessionRepo, fx.Cell.roleRepo, fx.Cell.userRepo, fx.Cell.refreshStore, fx.Cell.jwtIssuer, slog.Default(),
 	)
 

--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -177,7 +177,7 @@ func WithInMemoryDefaults() Option {
 		c.userRepo = mem.NewUserRepository()
 		c.sessionRepo = mem.NewSessionRepository()
 		c.roleRepo = mem.NewRoleRepository()
-		c.refreshStore = refreshmem.New(defaultRefreshPolicy, realClock{}, nil)
+		c.refreshStore = refreshmem.MustNew(defaultRefreshPolicy, realClock{}, nil)
 	}
 }
 

--- a/cells/accesscore/cell_init.go
+++ b/cells/accesscore/cell_init.go
@@ -136,7 +136,10 @@ func (c *AccessCore) initSlices() error {
 	// session-login must be constructed before identity-manage because
 	// ChangePassword injects loginSvc as the TokenIssuer.
 	loginOpts := []sessionlogin.Option{sessionlogin.WithEmitter(c.emitter), sessionlogin.WithTxManager(c.txRunner)}
-	loginSvc := sessionlogin.NewService(c.userRepo, c.sessionRepo, c.roleRepo, c.refreshStore, c.jwtIssuer, c.logger, loginOpts...)
+	loginSvc, err := sessionlogin.NewService(c.userRepo, c.sessionRepo, c.roleRepo, c.refreshStore, c.jwtIssuer, c.logger, loginOpts...)
+	if err != nil {
+		return err
+	}
 	c.loginHandler = sessionlogin.NewHandler(loginSvc)
 	c.AddSlice(cell.NewBaseSlice("sessionlogin", "accesscore", cell.L2))
 
@@ -158,14 +161,20 @@ func (c *AccessCore) initSlices() error {
 	// rotation. No JWT verifier is needed — the opaque wire format is
 	// validated by the store itself; any malformed input (including an
 	// access JWT replay attempt) returns ErrRejected.
-	refreshSvc := sessionrefresh.NewService(c.sessionRepo, c.roleRepo, c.userRepo, c.refreshStore, c.jwtIssuer, c.logger)
+	refreshSvc, err := sessionrefresh.NewService(c.sessionRepo, c.roleRepo, c.userRepo, c.refreshStore, c.jwtIssuer, c.logger)
+	if err != nil {
+		return err
+	}
 	c.refreshHandler = sessionrefresh.NewHandler(refreshSvc)
 	c.AddSlice(cell.NewBaseSlice("sessionrefresh", "accesscore", cell.L1))
 
 	// session-logout — cascades revocation to refresh.Store so logout
 	// invalidates the full refresh chain, not just the access session.
 	logoutOpts := []sessionlogout.Option{sessionlogout.WithEmitter(c.emitter), sessionlogout.WithTxManager(c.txRunner)}
-	logoutSvc := sessionlogout.NewService(c.sessionRepo, c.refreshStore, c.logger, logoutOpts...)
+	logoutSvc, err := sessionlogout.NewService(c.sessionRepo, c.refreshStore, c.logger, logoutOpts...)
+	if err != nil {
+		return err
+	}
 	c.logoutHandler = sessionlogout.NewHandler(logoutSvc)
 	c.AddSlice(cell.NewBaseSlice("sessionlogout", "accesscore", cell.L2))
 

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -83,7 +83,7 @@ func mustCursorCodec() *query.CursorCodec {
 
 func newTestRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 func newTestCell() *AccessCore {
@@ -419,7 +419,7 @@ func TestAccessCore_Init_DurableMode_UsesProdRBACRunMode(t *testing.T) {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Listener == cell.PrimaryListener {
 			r.Route(rg.Prefix, func(sub cell.RouteMux) { rg.Register(sub) })
@@ -498,8 +498,8 @@ func initCellWithRouters(t *testing.T) *cellTestRouters {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	primary := router.New()
-	internal := router.New()
+	primary := router.MustNew()
+	internal := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		switch rg.Listener {
 		case cell.PrimaryListener:
@@ -756,7 +756,7 @@ func TestAccessCore_SessionRevocation_E2E(t *testing.T) {
 	require.NoError(t, userRepo.Create(ctx, user))
 
 	// Login via HTTP handler to simulate real flow.
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Listener == cell.PrimaryListener {
 			if rg.Prefix != "" {
@@ -838,7 +838,7 @@ func TestAccessCore_RefreshTokenRevocation_E2E(t *testing.T) {
 	require.NoError(t, userRepo.Create(ctx, user))
 
 	// Login via HTTP.
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Listener == cell.PrimaryListener {
 			if rg.Prefix != "" {
@@ -1002,7 +1002,7 @@ func TestAccessCore_PasswordResetExempt_PropagatesViaRouter(t *testing.T) {
 		DurabilityMode: cell.DurabilityDemo,
 	}))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Listener == cell.PrimaryListener {
 			if rg.Prefix != "" {

--- a/cells/accesscore/initialadmin/bootstrap.go
+++ b/cells/accesscore/initialadmin/bootstrap.go
@@ -137,31 +137,31 @@ func newBootstrapper(deps BootstrapDeps, cfg bootstrapConfig) (*bootstrapper, er
 // sweep (P1-16) is intentionally NOT called here — it is scheduled independently
 // at the composition root via SweepHook so that orphan cred files are cleaned
 // even when adminExists==true causes ensureAdmin to return early.
-func (b *bootstrapper) ensureAdmin(ctx context.Context) (worker.Worker, error) {
+func (b *bootstrapper) ensureAdmin(ctx context.Context) (ensureAdminResult, error) {
 	// Pre-flight: fail fast if admin already exists (no credfile probe needed).
 	exists, err := b.provisioner.Status(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("initialadmin: check status: %w", err)
+		return ensureAdminResult{}, fmt.Errorf("initialadmin: check status: %w", err)
 	}
 	if exists {
-		return nil, nil
+		return ensureAdminResult{}, nil
 	}
 
 	// Pre-flight: verify the credential directory is writable before creating
 	// the admin user. This catches permission issues at startup time rather
 	// than after user creation (P1-6 fix).
 	if err := b.probeWriteable(); err != nil {
-		return nil, fmt.Errorf("initial admin bootstrap: credential dir not writable: %w", err)
+		return ensureAdminResult{}, fmt.Errorf("initial admin bootstrap: credential dir not writable: %w", err)
 	}
 
 	// Generate and hash password (plaintext discarded after this call).
 	password, hash, err := b.generateAndHash()
 	if err != nil {
-		return nil, err
+		return ensureAdminResult{}, err
 	}
 
 	// Delegate race-safe persistence to adminprovision.
-	user, outcome, err := b.provisioner.Ensure(ctx, adminprovision.ProvisionInput{
+	result, err := b.provisioner.Ensure(ctx, adminprovision.ProvisionInput{
 		Username:     b.cfg.Username,
 		Email:        b.cfg.Username + "@gocell.local",
 		PasswordHash: hash,
@@ -169,26 +169,26 @@ func (b *bootstrapper) ensureAdmin(ctx context.Context) (worker.Worker, error) {
 		Source:       domain.UserSourceBootstrap,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("initialadmin: ensure: %w", err)
+		return ensureAdminResult{}, fmt.Errorf("initialadmin: ensure: %w", err)
 	}
-	switch outcome {
+	switch result.Outcome {
 	case adminprovision.OutcomeAlreadyExists, adminprovision.OutcomeRaceSkipped:
 		// Concurrent replica / prior bootstrap won the race. Silent skip.
-		return nil, nil
+		return ensureAdminResult{}, nil
 	case adminprovision.OutcomeCreated, adminprovision.OutcomeOrphanRecovered:
 		// Fall through to credfile write.
 	default:
-		return nil, fmt.Errorf("initialadmin: unexpected provision outcome %d", outcome)
+		return ensureAdminResult{}, fmt.Errorf("initialadmin: unexpected provision outcome %d", result.Outcome)
 	}
 
 	// Write credential file. On failure, compensate the user/role writes so
 	// the next startup can self-heal (adminExists==false again).
 	cleaner, werr := b.writeFileAndMakeCleaner(password)
 	if werr != nil {
-		b.provisioner.Compensate(ctx, user.ID)
-		return nil, werr
+		b.provisioner.Compensate(ctx, result.User.ID)
+		return ensureAdminResult{}, werr
 	}
-	return cleaner, nil
+	return ensureAdminResult{Cleaner: cleaner}, nil
 }
 
 // probeWriteable verifies the credential file directory is writable by creating

--- a/cells/accesscore/initialadmin/bootstrap_branches_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_branches_test.go
@@ -157,14 +157,14 @@ func TestMaybeMacOSHint_Darwin(t *testing.T) {
 // sweep branch coverage
 // ---------------------------------------------------------------------------
 
-// TestSweep_NonAbsoluteStateDir_ReturnsError verifies that a relative StateDir
-// is treated as a configuration error and returned immediately.
-func TestSweep_NonAbsoluteStateDir_ReturnsError(t *testing.T) {
+// TestSweep_NonAbsoluteCredentialPath_ReturnsError verifies that a relative
+// CredentialPath is treated as a configuration error and returned immediately.
+func TestSweep_NonAbsoluteCredentialPath_ReturnsError(t *testing.T) {
 	_, err := sweep(context.Background(), sweepConfig{
-		StateDir: "relative/path",
-		Logger:   nil, // nil falls back to slog.Default
+		CredentialPath: "relative/path",
+		Logger:         nil, // nil falls back to slog.Default
 	})
-	require.Error(t, err, "non-absolute StateDir must return an error")
+	require.Error(t, err, "non-absolute CredentialPath must return an error")
 	assert.Contains(t, err.Error(), "absolute")
 }
 

--- a/cells/accesscore/initialadmin/bootstrap_crossplatform_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_crossplatform_test.go
@@ -49,8 +49,9 @@ func TestBootstrapper_FullFlow_OnCurrentOS(t *testing.T) {
 	bs, err := newBootstrapper(deps, cfg)
 	require.NoError(t, err)
 
-	cleaner, err := bs.ensureAdmin(context.Background())
+	result, err := bs.ensureAdmin(context.Background())
 	require.NoError(t, err)
+	cleaner := result.Cleaner
 	assert.NotNil(t, cleaner, "expected non-nil cleaner on first bootstrap")
 
 	// Credential file must exist.

--- a/cells/accesscore/initialadmin/bootstrap_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_test.go
@@ -156,8 +156,9 @@ func TestBootstrap_FirstRun_CreatesUserAndWritesFile(t *testing.T) {
 	bs, err := newBootstrapper(deps, cfg)
 	require.NoError(t, err)
 
-	cleaner, err := bs.ensureAdmin(context.Background())
+	result, err := bs.ensureAdmin(context.Background())
 	require.NoError(t, err)
+	cleaner := result.Cleaner
 	assert.NotNil(t, cleaner, "ensureAdmin must return a non-nil cleaner on first bootstrap")
 
 	// Credential file must exist.
@@ -219,8 +220,9 @@ func TestBootstrap_SkipsWhenAdminExists(t *testing.T) {
 	bs, err := newBootstrapper(deps, cfg)
 	require.NoError(t, err)
 
-	cleaner, runErr := bs.ensureAdmin(context.Background())
+	result, runErr := bs.ensureAdmin(context.Background())
 	require.NoError(t, runErr)
+	cleaner := result.Cleaner
 	assert.Nil(t, cleaner, "cleaner must be nil when admin already exists")
 
 	// Credential file must NOT be created.
@@ -248,8 +250,9 @@ func TestBootstrap_PgRaceDuplicateUserSilentSkip(t *testing.T) {
 	bs, err := newBootstrapper(deps, cfg)
 	require.NoError(t, err)
 
-	cleaner, runErr := bs.ensureAdmin(context.Background())
+	result, runErr := bs.ensureAdmin(context.Background())
 	require.NoError(t, runErr, "PG race duplicate should result in silent skip, not error")
+	cleaner := result.Cleaner
 	assert.Nil(t, cleaner, "cleaner must be nil on silent skip")
 
 	// Credential file must NOT be created.
@@ -354,8 +357,9 @@ func TestBootstrap_OrphanUserRecoveryResumesAssign(t *testing.T) {
 	bs, err := newBootstrapper(deps, cfg)
 	require.NoError(t, err)
 
-	cleaner, runErr := bs.ensureAdmin(context.Background())
+	result, runErr := bs.ensureAdmin(context.Background())
 	require.NoError(t, runErr, "bootstrap must recover from the orphan-user state, not wedge")
+	cleaner := result.Cleaner
 	assert.NotNil(t, cleaner, "cleaner must be returned after successful recovery")
 
 	// The recovered user must keep the ORIGINAL id (we resumed the existing

--- a/cells/accesscore/initialadmin/bootstrap_unsupported.go
+++ b/cells/accesscore/initialadmin/bootstrap_unsupported.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/worker"
 )
 
 // errUnsupportedPlatform is returned by bootstrapper.ensureAdmin on platforms
@@ -49,6 +48,6 @@ func newBootstrapper(_ BootstrapDeps, _ bootstrapConfig) (*bootstrapper, error) 
 }
 
 // ensureAdmin always returns errUnsupportedPlatform on unsupported platforms.
-func (b *bootstrapper) ensureAdmin(_ context.Context) (worker.Worker, error) {
-	return nil, errUnsupportedPlatform
+func (b *bootstrapper) ensureAdmin(_ context.Context) (ensureAdminResult, error) {
+	return ensureAdminResult{}, errUnsupportedPlatform
 }

--- a/cells/accesscore/initialadmin/cleaner.go
+++ b/cells/accesscore/initialadmin/cleaner.go
@@ -117,15 +117,18 @@ func (c *cleaner) Start(ctx context.Context) error {
 	// not from the current process start time.
 	remaining, err := c.resolveRemaining()
 	if err != nil {
-		// File missing — operator already removed it or it never existed.
-		c.logger.Info("initial admin credential file not found; no cleanup needed",
-			slog.String("event", "initial_admin_credential_expired"),
-			slog.String("path", c.path),
-		)
-		c.mu.Lock()
-		c.state = stateStopped
-		c.mu.Unlock()
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			// File missing — operator already removed it or it never existed.
+			c.logger.Info("initial admin credential file not found; no cleanup needed",
+				slog.String("event", "initial_admin_credential_expired"),
+				slog.String("path", c.path),
+			)
+			c.mu.Lock()
+			c.state = stateStopped
+			c.mu.Unlock()
+			return nil
+		}
+		return fmt.Errorf("initialadmin: resolve credential expiry: %w", err)
 	}
 
 	c.mu.Lock()

--- a/cells/accesscore/initialadmin/ensure_result.go
+++ b/cells/accesscore/initialadmin/ensure_result.go
@@ -1,0 +1,11 @@
+package initialadmin
+
+import "github.com/ghbvf/gocell/runtime/worker"
+
+type ensureAdminResult struct {
+	Cleaner worker.Worker
+}
+
+type sweepResult struct {
+	Cleaner worker.Worker
+}

--- a/cells/accesscore/initialadmin/lifecycle.go
+++ b/cells/accesscore/initialadmin/lifecycle.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -151,15 +150,11 @@ func (l *Lifecycle) start(ctx context.Context) error {
 	// cleaner worker that will remove the file after its remaining TTL. This
 	// closes the runtime window where a fresh orphan file would otherwise persist
 	// until the next process restart (P1-16 full fix).
-	var sweepStateDir string
-	if cfg.CredentialPath != "" {
-		sweepStateDir = filepath.Dir(cfg.CredentialPath)
-	}
 	sweepResult, err := sweep(ctx, sweepConfig{
-		StateDir:  sweepStateDir,
-		Clock:     cfg.Clock,
-		Scheduler: cfg.Scheduler,
-		Logger:    logger,
+		CredentialPath: cfg.CredentialPath,
+		Clock:          cfg.Clock,
+		Scheduler:      cfg.Scheduler,
+		Logger:         logger,
 	})
 	if err != nil {
 		return fmt.Errorf("initialadmin: sweep: %w", err)

--- a/cells/accesscore/initialadmin/lifecycle.go
+++ b/cells/accesscore/initialadmin/lifecycle.go
@@ -155,7 +155,7 @@ func (l *Lifecycle) start(ctx context.Context) error {
 	if cfg.CredentialPath != "" {
 		sweepStateDir = filepath.Dir(cfg.CredentialPath)
 	}
-	sweepCleaner, err := sweep(ctx, sweepConfig{
+	sweepResult, err := sweep(ctx, sweepConfig{
 		StateDir:  sweepStateDir,
 		Clock:     cfg.Clock,
 		Scheduler: cfg.Scheduler,
@@ -164,6 +164,7 @@ func (l *Lifecycle) start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("initialadmin: sweep: %w", err)
 	}
+	sweepCleaner := sweepResult.Cleaner
 
 	bs, err := newBootstrapper(BootstrapDeps{
 		UserRepo: deps.UserRepo,
@@ -181,10 +182,11 @@ func (l *Lifecycle) start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("initialadmin: construct: %w", err)
 	}
-	adminWorker, err := bs.ensureAdmin(ctx)
+	adminResult, err := bs.ensureAdmin(ctx)
 	if err != nil {
 		return fmt.Errorf("initialadmin: ensure: %w", err)
 	}
+	adminWorker := adminResult.Cleaner
 
 	// Priority identical to old behaviour: adminWorker > sweepCleaner.
 	var result worker.Worker

--- a/cells/accesscore/initialadmin/lifecycle_test.go
+++ b/cells/accesscore/initialadmin/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -206,6 +207,61 @@ func TestLifecycle_StartWithBind_RepeatRun_AdminExists_NoCleaner(t *testing.T) {
 	hasCleaner := l.cleaner != nil
 	l.mu.Unlock()
 	assert.False(t, hasCleaner, "no cleaner expected when admin already exists and no orphan file")
+}
+
+func TestLifecycle_StartWithCustomCredentialPath_SweepsExactFile(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	customCredPath := filepath.Join(dir, "custom_admin_password")
+	defaultCredPath := filepath.Join(dir, "initial_admin_password")
+
+	opts := []LifecycleOption{
+		WithCredentialPath(customCredPath),
+		WithTTL(time.Hour),
+		WithClock(&fakeClock{t: now}),
+		WithPasswordHasher(BcryptHasher{Cost: 4}),
+		WithScheduler(newFakeSchedulerCross()),
+		withPasswordSource(newFixedPasswordSourceCross()),
+	}
+	l := NewLifecycle(opts...)
+
+	deps := makeLifecycleDeps(t)
+	logger := deps.Logger
+
+	bs, err := newBootstrapper(BootstrapDeps{
+		UserRepo: deps.UserRepo,
+		RoleRepo: deps.RoleRepo,
+		Logger:   logger,
+		Clock:    l.cfg.Clock,
+	}, bootstrapConfig{
+		CredentialPath: customCredPath,
+		TTL:            l.cfg.TTL,
+		PasswordSource: newFixedPasswordSourceCross(),
+		Scheduler:      l.cfg.Scheduler,
+		Hasher:         l.cfg.Hasher,
+	})
+	require.NoError(t, err)
+	firstResult, err := bs.ensureAdmin(context.Background())
+	require.NoError(t, err)
+	if firstResult.Cleaner != nil {
+		require.NoError(t, firstResult.Cleaner.Stop(context.Background()))
+	}
+	require.NoError(t, removeCredentialFile(customCredPath))
+
+	require.NoError(t, writeCredentialFile(customCredPath, credentialPayload{
+		Username:    "admin",
+		Password:    "secret",
+		GeneratedAt: now.Add(-2 * time.Hour),
+		ExpiresAt:   now.Add(-time.Hour),
+	}))
+
+	l.Bind(deps, logger)
+	require.NoError(t, l.Hook().OnStart(context.Background()))
+
+	_, err = os.Stat(customCredPath)
+	assert.True(t, os.IsNotExist(err), "expired custom credential path must be swept; got %v", err)
+	_, err = os.Stat(defaultCredPath)
+	assert.True(t, os.IsNotExist(err), "sweep must not synthesize or target the default basename")
 }
 
 // ---------------------------------------------------------------------------

--- a/cells/accesscore/initialadmin/lifecycle_test.go
+++ b/cells/accesscore/initialadmin/lifecycle_test.go
@@ -182,8 +182,9 @@ func TestLifecycle_StartWithBind_RepeatRun_AdminExists_NoCleaner(t *testing.T) {
 		Hasher:         l.cfg.Hasher,
 	})
 	require.NoError(t, err)
-	firstWorker, err := bs.ensureAdmin(context.Background())
+	firstResult, err := bs.ensureAdmin(context.Background())
 	require.NoError(t, err)
+	firstWorker := firstResult.Cleaner
 	// Stop the first cleaner so its credential file TTL doesn't interfere.
 	if firstWorker != nil {
 		require.NoError(t, firstWorker.Stop(context.Background()))

--- a/cells/accesscore/initialadmin/sweep.go
+++ b/cells/accesscore/initialadmin/sweep.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -19,10 +20,10 @@ import (
 
 // sweepConfig parameterises startup-time credential sweep.
 type sweepConfig struct {
-	// StateDir is the directory to scan (typically $GOCELL_STATE_DIR).
-	// An empty string falls back to ResolveCredentialPath("") semantics
-	// (GOCELL_STATE_DIR env var → /run/gocell/initial_admin_password).
-	StateDir string
+	// CredentialPath is the exact credential file to sweep. An empty string
+	// falls back to ResolveCredentialPath("") semantics (GOCELL_STATE_DIR env var
+	// → /run/gocell/initial_admin_password).
+	CredentialPath string
 	// Clock supplies "now" for expiry comparison. nil → realClock{}.
 	Clock Clock
 	// Scheduler is used when constructing the returned cleaner worker. nil → realScheduler{}.
@@ -37,7 +38,7 @@ type sweepConfig struct {
 // runs and removes them if they have expired.
 //
 // Algorithm:
-//  1. Resolve the credential file path (ResolveCredentialPath or StateDir).
+//  1. Resolve the credential file path (CredentialPath or ResolveCredentialPath("")).
 //  2. File absent → no-op, return (nil, nil).
 //  3. Read expires_at. Parse failure → slog.Error + return (nil, nil) (file
 //     retained; never delete unknown formats to guard against false positives).
@@ -51,8 +52,8 @@ type sweepConfig struct {
 //
 // sweep never blocks startup: non-ENOENT FS errors are logged at Error and
 // the function returns (nil, nil) so the caller can proceed. The only exception
-// is a misconfigured StateDir (non-absolute path), which is a programmer error
-// surfaced as a returned error so it fails fast.
+// is a misconfigured CredentialPath (non-absolute path), which is a programmer
+// error surfaced as a returned error so it fails fast.
 //
 // Conflict note: when adminExists==false AND a fresh orphan file exists, sweep
 // retains the file and returns a cleaner, but ensureAdmin will subsequently
@@ -68,9 +69,8 @@ func sweep(ctx context.Context, cfg sweepConfig) (sweepResult, error) {
 		clk = realClock{}
 	}
 
-	credPath, err := ResolveCredentialPath(cfg.StateDir)
+	credPath, err := resolveSweepCredentialPath(cfg.CredentialPath)
 	if err != nil {
-		// Non-absolute StateDir is a configuration error — fail fast.
 		return sweepResult{}, err
 	}
 
@@ -147,4 +147,16 @@ func sweep(ctx context.Context, cfg sweepConfig) (sweepResult, error) {
 		return sweepResult{}, nil
 	}
 	return sweepResult{Cleaner: cleaner}, nil
+}
+
+func resolveSweepCredentialPath(credentialPath string) (string, error) {
+	if credentialPath == "" {
+		return ResolveCredentialPath("")
+	}
+	cleaned := filepath.Clean(credentialPath)
+	if !filepath.IsAbs(cleaned) {
+		return "", errcode.New(errcode.ErrCellInvalidConfig,
+			"initialadmin: credential path must be absolute")
+	}
+	return cleaned, nil
 }

--- a/cells/accesscore/initialadmin/sweep.go
+++ b/cells/accesscore/initialadmin/sweep.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/worker"
 )
 
 // sweep intentionally does not depend on ports.UserRepository — credential
@@ -60,7 +59,7 @@ type sweepConfig struct {
 // attempt to write a new credential file and fail with errCredFileExists. This
 // is a rare bootstrap-interruption scenario not covered by P1-16; it surfaces
 // as an ensureAdmin error and requires operator intervention.
-func sweep(ctx context.Context, cfg sweepConfig) (worker.Worker, error) {
+func sweep(ctx context.Context, cfg sweepConfig) (sweepResult, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
@@ -72,14 +71,14 @@ func sweep(ctx context.Context, cfg sweepConfig) (worker.Worker, error) {
 	credPath, err := ResolveCredentialPath(cfg.StateDir)
 	if err != nil {
 		// Non-absolute StateDir is a configuration error — fail fast.
-		return nil, err
+		return sweepResult{}, err
 	}
 
 	expiresAt, err := readCredentialExpiresAt(credPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// No file — nothing to sweep.
-			return nil, nil
+			return sweepResult{}, nil
 		}
 		// Unreadable file or parse error: log and continue startup (don't delete).
 		// Attach failure_kind so operators can distinguish permission errors from
@@ -96,7 +95,7 @@ func sweep(ctx context.Context, cfg sweepConfig) (worker.Worker, error) {
 			slog.String("failure_kind", failureKind),
 			slog.Any("error", errcode.WrapInfra(errcode.ErrInternal, "sweep: read cred file", err)),
 		)
-		return nil, nil
+		return sweepResult{}, nil
 	}
 
 	now := clk.Now()
@@ -108,14 +107,14 @@ func sweep(ctx context.Context, cfg sweepConfig) (worker.Worker, error) {
 				slog.String("file_path", credPath),
 				slog.Any("error", errcode.WrapInfra(errcode.ErrInternal, "sweep: remove cred file", removeErr)),
 			)
-			return nil, nil
+			return sweepResult{}, nil
 		}
 		cfg.Logger.InfoContext(ctx, "sweep: removed expired credential file",
 			slog.String("event", "initial_admin_credential_swept"),
 			slog.String("file_path", credPath),
 			slog.Time("expires_at", expiresAt),
 		)
-		return nil, nil
+		return sweepResult{}, nil
 	}
 
 	// Not expired — re-register a cleaner worker so the runtime cleans up after
@@ -145,7 +144,7 @@ func sweep(ctx context.Context, cfg sweepConfig) (worker.Worker, error) {
 			slog.String("file_path", credPath),
 			slog.Any("error", err),
 		)
-		return nil, nil
+		return sweepResult{}, nil
 	}
-	return cleaner, nil
+	return sweepResult{Cleaner: cleaner}, nil
 }

--- a/cells/accesscore/initialadmin/sweep_test.go
+++ b/cells/accesscore/initialadmin/sweep_test.go
@@ -92,13 +92,14 @@ func TestSweep_NoFile_NoOp(t *testing.T) {
 	logger, cap := newBootstrapCapturingLogger()
 	now := time.Now()
 
-	w, err := sweep(context.Background(), sweepConfig{
+	result, err := sweep(context.Background(), sweepConfig{
 		StateDir: dir,
 		Clock:    fixedClock{now: now},
 		Logger:   logger,
 	})
 
 	require.NoError(t, err)
+	w := result.Cleaner
 	assert.Nil(t, w, "no worker expected when file does not exist")
 
 	cap.mu.Lock()
@@ -115,13 +116,14 @@ func TestSweep_ExpiredFile_Removed(t *testing.T) {
 
 	credPath := writeExpiredCredFile(t, dir, now)
 
-	w, err := sweep(context.Background(), sweepConfig{
+	result, err := sweep(context.Background(), sweepConfig{
 		StateDir: dir,
 		Clock:    fixedClock{now: now},
 		Logger:   logger,
 	})
 
 	require.NoError(t, err)
+	w := result.Cleaner
 	assert.Nil(t, w, "no worker expected when expired file is removed")
 
 	// File must be gone.
@@ -145,13 +147,14 @@ func TestSweep_FreshFile_Retained(t *testing.T) {
 
 	credPath := writeFreshCredFile(t, dir, now)
 
-	w, err := sweep(context.Background(), sweepConfig{
+	result, err := sweep(context.Background(), sweepConfig{
 		StateDir: dir,
 		Clock:    fixedClock{now: now},
 		Logger:   logger,
 	})
 
 	require.NoError(t, err)
+	w := result.Cleaner
 
 	// File must be retained.
 	_, statErr := os.Stat(credPath)
@@ -178,13 +181,14 @@ func TestSweep_FreshFile_ReturnsCleanerWorker(t *testing.T) {
 
 	// Use a manual scheduler so the timer never fires during the test.
 	sched := &manualScheduler{}
-	w, err := sweep(context.Background(), sweepConfig{
+	result, err := sweep(context.Background(), sweepConfig{
 		StateDir:  dir,
 		Clock:     fixedClock{now: now},
 		Scheduler: sched,
 		Logger:    logger,
 	})
 	require.NoError(t, err)
+	w := result.Cleaner
 	require.NotNil(t, w, "worker must be non-nil for fresh file")
 
 	// Stop before Start is idempotent (cleaner.state transitions to Stopped).
@@ -210,13 +214,14 @@ func TestSweep_UnreadableFile_LogErrorContinue(t *testing.T) {
 		_ = os.Chmod(credPath, 0o600)
 	})
 
-	w, err := sweep(context.Background(), sweepConfig{
+	result, err := sweep(context.Background(), sweepConfig{
 		StateDir: dir,
 		Clock:    fixedClock{now: now},
 		Logger:   logger,
 	})
 
 	require.NoError(t, err, "sweep must not return error even when file is unreadable")
+	w := result.Cleaner
 	assert.Nil(t, w, "no worker expected when file is unreadable")
 
 	// Must have at least one Error-level log.
@@ -239,13 +244,14 @@ func TestSweep_StateDirNotExist_NoError(t *testing.T) {
 	logger, cap := newBootstrapCapturingLogger()
 	now := time.Now()
 
-	w, err := sweep(context.Background(), sweepConfig{
+	result, err := sweep(context.Background(), sweepConfig{
 		StateDir: dir,
 		Clock:    fixedClock{now: now},
 		Logger:   logger,
 	})
 
 	require.NoError(t, err)
+	w := result.Cleaner
 	assert.Nil(t, w, "no worker expected when StateDir does not exist")
 
 	cap.mu.Lock()
@@ -266,13 +272,14 @@ func TestSweep_MalformedExpiresAt_LogErrorContinue(t *testing.T) {
 
 	credPath := writeMalformedCredFile(t, dir)
 
-	w, err := sweep(context.Background(), sweepConfig{
+	result, err := sweep(context.Background(), sweepConfig{
 		StateDir: dir,
 		Clock:    fixedClock{now: now},
 		Logger:   logger,
 	})
 
 	require.NoError(t, err, "malformed expires_at must not block startup")
+	w := result.Cleaner
 	assert.Nil(t, w, "no worker expected when expires_at is malformed")
 
 	// File must be retained (never delete unknown formats).

--- a/cells/accesscore/initialadmin/sweep_test.go
+++ b/cells/accesscore/initialadmin/sweep_test.go
@@ -93,9 +93,9 @@ func TestSweep_NoFile_NoOp(t *testing.T) {
 	now := time.Now()
 
 	result, err := sweep(context.Background(), sweepConfig{
-		StateDir: dir,
-		Clock:    fixedClock{now: now},
-		Logger:   logger,
+		CredentialPath: filepath.Join(dir, "initial_admin_password"),
+		Clock:          fixedClock{now: now},
+		Logger:         logger,
 	})
 
 	require.NoError(t, err)
@@ -117,9 +117,9 @@ func TestSweep_ExpiredFile_Removed(t *testing.T) {
 	credPath := writeExpiredCredFile(t, dir, now)
 
 	result, err := sweep(context.Background(), sweepConfig{
-		StateDir: dir,
-		Clock:    fixedClock{now: now},
-		Logger:   logger,
+		CredentialPath: credPath,
+		Clock:          fixedClock{now: now},
+		Logger:         logger,
 	})
 
 	require.NoError(t, err)
@@ -148,9 +148,9 @@ func TestSweep_FreshFile_Retained(t *testing.T) {
 	credPath := writeFreshCredFile(t, dir, now)
 
 	result, err := sweep(context.Background(), sweepConfig{
-		StateDir: dir,
-		Clock:    fixedClock{now: now},
-		Logger:   logger,
+		CredentialPath: credPath,
+		Clock:          fixedClock{now: now},
+		Logger:         logger,
 	})
 
 	require.NoError(t, err)
@@ -182,10 +182,10 @@ func TestSweep_FreshFile_ReturnsCleanerWorker(t *testing.T) {
 	// Use a manual scheduler so the timer never fires during the test.
 	sched := &manualScheduler{}
 	result, err := sweep(context.Background(), sweepConfig{
-		StateDir:  dir,
-		Clock:     fixedClock{now: now},
-		Scheduler: sched,
-		Logger:    logger,
+		CredentialPath: filepath.Join(dir, "initial_admin_password"),
+		Clock:          fixedClock{now: now},
+		Scheduler:      sched,
+		Logger:         logger,
 	})
 	require.NoError(t, err)
 	w := result.Cleaner
@@ -215,9 +215,9 @@ func TestSweep_UnreadableFile_LogErrorContinue(t *testing.T) {
 	})
 
 	result, err := sweep(context.Background(), sweepConfig{
-		StateDir: dir,
-		Clock:    fixedClock{now: now},
-		Logger:   logger,
+		CredentialPath: credPath,
+		Clock:          fixedClock{now: now},
+		Logger:         logger,
 	})
 
 	require.NoError(t, err, "sweep must not return error even when file is unreadable")
@@ -237,28 +237,29 @@ func TestSweep_UnreadableFile_LogErrorContinue(t *testing.T) {
 	assert.True(t, hasError, "expected Error-level log when file is unreadable")
 }
 
-// TestSweep_StateDirNotExist_NoError verifies that a non-existent StateDir
-// is treated as "no file" (normal state), returning (nil, nil) without error logs.
-func TestSweep_StateDirNotExist_NoError(t *testing.T) {
+// TestSweep_CredentialPathParentNotExist_NoError verifies that a credential
+// path under a non-existent directory is treated as "no file" (normal state),
+// returning (nil, nil) without error logs.
+func TestSweep_CredentialPathParentNotExist_NoError(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nonexistent-subdir")
 	logger, cap := newBootstrapCapturingLogger()
 	now := time.Now()
 
 	result, err := sweep(context.Background(), sweepConfig{
-		StateDir: dir,
-		Clock:    fixedClock{now: now},
-		Logger:   logger,
+		CredentialPath: filepath.Join(dir, "initial_admin_password"),
+		Clock:          fixedClock{now: now},
+		Logger:         logger,
 	})
 
 	require.NoError(t, err)
 	w := result.Cleaner
-	assert.Nil(t, w, "no worker expected when StateDir does not exist")
+	assert.Nil(t, w, "no worker expected when credential path does not exist")
 
 	cap.mu.Lock()
 	defer cap.mu.Unlock()
 	for _, r := range cap.records {
 		assert.NotEqual(t, slog.LevelError, r.level,
-			"no Error log expected when StateDir does not exist; got: %v", r)
+			"no Error log expected when credential path does not exist; got: %v", r)
 	}
 }
 
@@ -273,9 +274,9 @@ func TestSweep_MalformedExpiresAt_LogErrorContinue(t *testing.T) {
 	credPath := writeMalformedCredFile(t, dir)
 
 	result, err := sweep(context.Background(), sweepConfig{
-		StateDir: dir,
-		Clock:    fixedClock{now: now},
-		Logger:   logger,
+		CredentialPath: credPath,
+		Clock:          fixedClock{now: now},
+		Logger:         logger,
 	})
 
 	require.NoError(t, err, "malformed expires_at must not block startup")

--- a/cells/accesscore/initialadmin/sweep_test.go
+++ b/cells/accesscore/initialadmin/sweep_test.go
@@ -137,6 +137,33 @@ func TestSweep_ExpiredFile_Removed(t *testing.T) {
 	assert.Equal(t, slog.LevelInfo, rec.level, "expected Info level log")
 }
 
+func TestSweep_EmptyCredentialPathUsesDefaultResolver(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GOCELL_STATE_DIR", dir)
+	logger, _ := newBootstrapCapturingLogger()
+	now := time.Now()
+	credPath := writeExpiredCredFile(t, dir, now)
+
+	result, err := sweep(context.Background(), sweepConfig{
+		Clock:  fixedClock{now: now},
+		Logger: logger,
+	})
+
+	require.NoError(t, err)
+	assert.Nil(t, result.Cleaner)
+	_, statErr := os.Stat(credPath)
+	assert.True(t, isNotExist(statErr), "empty CredentialPath must sweep the resolved default credential file")
+}
+
+func TestSweep_RelativeCredentialPathReturnsError(t *testing.T) {
+	result, err := sweep(context.Background(), sweepConfig{
+		CredentialPath: "relative/initial_admin_password",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, result.Cleaner)
+}
+
 // TestSweep_FreshFile_Retained verifies that a non-expired credential file is
 // left untouched and a non-nil cleaner worker is returned for runtime cleanup
 // (P1-16 full fix: fresh orphan files must not persist until next restart).

--- a/cells/accesscore/initialadmin/sweep_unsupported.go
+++ b/cells/accesscore/initialadmin/sweep_unsupported.go
@@ -5,8 +5,6 @@ package initialadmin
 import (
 	"context"
 	"log/slog"
-
-	"github.com/ghbvf/gocell/runtime/worker"
 )
 
 // sweepConfig parameterises startup-time credential sweep.
@@ -24,6 +22,6 @@ type sweepConfig struct {
 
 // sweep is a no-op on non-unix platforms.
 // Credential file operations are only supported on unix.
-func sweep(_ context.Context, _ sweepConfig) (worker.Worker, error) {
-	return nil, nil
+func sweep(_ context.Context, _ sweepConfig) (sweepResult, error) {
+	return sweepResult{}, nil
 }

--- a/cells/accesscore/initialadmin/sweep_unsupported.go
+++ b/cells/accesscore/initialadmin/sweep_unsupported.go
@@ -10,8 +10,8 @@ import (
 // sweepConfig parameterises startup-time credential sweep.
 // On non-unix platforms, sweep is a no-op stub.
 type sweepConfig struct {
-	// StateDir is the directory to scan (typically $GOCELL_STATE_DIR).
-	StateDir string
+	// CredentialPath is the exact credential file to sweep.
+	CredentialPath string
 	// Clock supplies "now" for expiry comparison. nil → realClock{}.
 	Clock Clock
 	// Scheduler is used when constructing the returned cleaner worker. nil → realScheduler{}.

--- a/cells/accesscore/internal/adminprovision/provisioner.go
+++ b/cells/accesscore/internal/adminprovision/provisioner.go
@@ -54,6 +54,12 @@ type ProvisionInput struct {
 	Source       domain.UserSource
 }
 
+// ProvisionResult holds the successful outcome of Ensure.
+type ProvisionResult struct {
+	User    *domain.User
+	Outcome ProvisionOutcome
+}
+
 // UUIDGenerator returns a fresh UUID string. Injected for deterministic tests.
 type UUIDGenerator func() string
 
@@ -130,12 +136,12 @@ func (p *Provisioner) Status(ctx context.Context) (bool, error) {
 //  4. AssignToUser(user, admin) — idempotent per port contract.
 //  5. Mark the provisioning row complete so future duplicate usernames cannot
 //     be reclaimed after the first-admin sequence is done.
-func (p *Provisioner) Ensure(ctx context.Context, in ProvisionInput) (*domain.User, ProvisionOutcome, error) {
+func (p *Provisioner) Ensure(ctx context.Context, in ProvisionInput) (ProvisionResult, error) {
 	if len(in.PasswordHash) == 0 {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: PasswordHash is required")
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: PasswordHash is required")
 	}
 	if !domain.ValidAdminProvisionSource(in.Source) {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: Source must be setup or bootstrap")
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: Source must be setup or bootstrap")
 	}
 
 	// Serialize the fast-path → Create → Assign sequence so two concurrent
@@ -147,35 +153,35 @@ func (p *Provisioner) Ensure(ctx context.Context, in ProvisionInput) (*domain.Us
 	// 1. Fast path.
 	exists, err := p.Status(ctx)
 	if err != nil {
-		return nil, OutcomeUnknown, err
+		return ProvisionResult{Outcome: OutcomeUnknown}, err
 	}
 	if exists {
 		p.logger.Debug("admin provision skipped: admin already exists",
 			slog.String("event", "admin_provision_skip"))
-		return nil, OutcomeAlreadyExists, nil
+		return ProvisionResult{Outcome: OutcomeAlreadyExists}, nil
 	}
 
 	// 2. Ensure admin role.
 	if err := p.ensureAdminRole(ctx); err != nil {
-		return nil, OutcomeUnknown, err
+		return ProvisionResult{Outcome: OutcomeUnknown}, err
 	}
 
 	// 3. Persist user (with race / orphan detection).
-	user, outcome, err := p.createUserOrRecover(ctx, in)
-	if err != nil || outcome == OutcomeRaceSkipped {
-		return nil, outcome, err
+	result, err := p.createUserOrRecover(ctx, in)
+	if err != nil || result.Outcome == OutcomeRaceSkipped {
+		return result, err
 	}
 
 	// 4. Assign admin role (idempotent).
-	if _, err := p.roleRepo.AssignToUser(ctx, user.ID, domain.RoleAdmin); err != nil {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: assign admin role: %w", err)
+	if _, err := p.roleRepo.AssignToUser(ctx, result.User.ID, domain.RoleAdmin); err != nil {
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: assign admin role: %w", err)
 	}
-	if err := p.markProvisionComplete(ctx, user); err != nil {
-		p.rollbackAssignedAdmin(ctx, user.ID)
-		return nil, OutcomeUnknown, err
+	if err := p.markProvisionComplete(ctx, result.User); err != nil {
+		p.rollbackAssignedAdmin(ctx, result.User.ID)
+		return ProvisionResult{Outcome: OutcomeUnknown}, err
 	}
 
-	return user, outcome, nil
+	return result, nil
 }
 
 // Compensate best-effort removes the admin role assignment and user row after
@@ -219,14 +225,14 @@ func (p *Provisioner) ensureAdminRole(ctx context.Context) error {
 
 // createUserOrRecover persists a new admin user or resumes orphan recovery.
 // Return convention:
-//   - (user, OutcomeCreated, nil)          — fresh row persisted
-//   - (user, OutcomeOrphanRecovered, nil)  — existing orphan row reclaimed
-//   - (nil, OutcomeRaceSkipped, nil)       — concurrent replica finished first
-//   - (nil, OutcomeUnknown, err)           — infra error
-func (p *Provisioner) createUserOrRecover(ctx context.Context, in ProvisionInput) (*domain.User, ProvisionOutcome, error) {
+//   - {User:user, Outcome:OutcomeCreated}, nil         — fresh row persisted
+//   - {User:user, Outcome:OutcomeOrphanRecovered}, nil — existing orphan row reclaimed
+//   - {Outcome:OutcomeRaceSkipped}, nil                — concurrent replica finished first
+//   - {Outcome:OutcomeUnknown}, err                    — infra error
+func (p *Provisioner) createUserOrRecover(ctx context.Context, in ProvisionInput) (ProvisionResult, error) {
 	user, err := domain.NewUser(in.Username, in.Email, string(in.PasswordHash))
 	if err != nil {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: construct user: %w", err)
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: construct user: %w", err)
 	}
 	user.ID = p.newID()
 	user.MarkProvisionPending(in.Source)
@@ -236,36 +242,36 @@ func (p *Provisioner) createUserOrRecover(ctx context.Context, in ProvisionInput
 
 	createErr := p.userRepo.Create(ctx, user)
 	if createErr == nil {
-		return user, OutcomeCreated, nil
+		return ProvisionResult{User: user, Outcome: OutcomeCreated}, nil
 	}
 
 	var ecErr *errcode.Error
 	if !errors.As(createErr, &ecErr) || ecErr.Code != errcode.ErrAuthUserDuplicate {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: create user: %w", createErr)
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: create user: %w", createErr)
 	}
 
 	// Duplicate — race or orphan recovery.
 	recount, err := p.roleRepo.CountByRole(ctx, domain.RoleAdmin)
 	if err != nil {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: recount after duplicate user: %w", err)
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: recount after duplicate user: %w", err)
 	}
 	if recount > 0 {
 		p.logger.Debug("admin provision: duplicate user creation race; admin already exists",
 			slog.String("event", "admin_provision_race"))
-		return nil, OutcomeRaceSkipped, nil
+		return ProvisionResult{Outcome: OutcomeRaceSkipped}, nil
 	}
 
 	// Orphan recovery.
 	existing, err := p.userRepo.GetByUsername(ctx, in.Username)
 	if err != nil {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: lookup orphan user: %w", err)
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: lookup orphan user: %w", err)
 	}
 	if !existing.IsRecoverableProvisionOrphan(in.Source) {
 		p.logger.Warn("admin provision: duplicate username is not a recoverable orphan",
 			slog.String("event", "admin_provision_duplicate_rejected"),
 			slog.String("user_id", existing.ID),
 			slog.String("source", string(existing.CreationSource)))
-		return nil, OutcomeUnknown, errcode.NewDomain(errcode.ErrAuthUserDuplicate,
+		return ProvisionResult{Outcome: OutcomeUnknown}, errcode.NewDomain(errcode.ErrAuthUserDuplicate,
 			"admin provisioning username already exists")
 	}
 	// Orphan recovery must fully reassert the caller's RequireReset intent,
@@ -277,12 +283,12 @@ func (p *Provisioner) createUserOrRecover(ctx context.Context, in ProvisionInput
 	existing.PasswordHash = string(in.PasswordHash)
 	existing.PasswordResetRequired = in.RequireReset
 	if err := p.userRepo.Update(ctx, existing); err != nil {
-		return nil, OutcomeUnknown, fmt.Errorf("adminprovision: reset orphan credentials: %w", err)
+		return ProvisionResult{Outcome: OutcomeUnknown}, fmt.Errorf("adminprovision: reset orphan credentials: %w", err)
 	}
 	p.logger.Info("admin provision: resuming orphan-user recovery",
 		slog.String("event", "admin_provision_orphan_recover"),
 		slog.String("user_id", existing.ID))
-	return existing, OutcomeOrphanRecovered, nil
+	return ProvisionResult{User: existing, Outcome: OutcomeOrphanRecovered}, nil
 }
 
 func (p *Provisioner) markProvisionComplete(ctx context.Context, user *domain.User) error {

--- a/cells/accesscore/internal/adminprovision/provisioner_test.go
+++ b/cells/accesscore/internal/adminprovision/provisioner_test.go
@@ -42,6 +42,15 @@ func stdInput() adminprovision.ProvisionInput {
 	}
 }
 
+func ensureForTest(
+	p *adminprovision.Provisioner,
+	ctx context.Context,
+	in adminprovision.ProvisionInput,
+) (*domain.User, adminprovision.ProvisionOutcome, error) {
+	result, err := p.Ensure(ctx, in)
+	return result.User, result.Outcome, err
+}
+
 // --- NewProvisioner -------------------------------------------------------
 
 func TestNewProvisioner_NilDependency_ReturnsError(t *testing.T) {
@@ -100,7 +109,7 @@ func TestProvisioner_Ensure_FreshSystem_CreatesUserAndRole(t *testing.T) {
 	roleRepo := mem.NewRoleRepository()
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("00000000-0000-4000-8000-000000000001"))
 
-	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	user, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.NoError(t, err)
 	assert.Equal(t, adminprovision.OutcomeCreated, outcome)
 	require.NotNil(t, user)
@@ -124,7 +133,7 @@ func TestProvisioner_Ensure_AdminExists_FastPathSkipsNoWrites(t *testing.T) {
 	counting := &countingUserRepo{UserRepository: userRepo}
 	p := newProvisioner(t, counting, roleRepo, fixedUUID("x"))
 
-	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	user, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.NoError(t, err)
 	assert.Equal(t, adminprovision.OutcomeAlreadyExists, outcome)
 	assert.Nil(t, user)
@@ -138,7 +147,7 @@ func TestProvisioner_Ensure_RaceSkipped_NoCreatedUserReturned(t *testing.T) {
 	roleRepo := &scriptedRoleRepo{counts: []int{0, 1}}
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
 
-	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	user, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.NoError(t, err)
 	assert.Equal(t, adminprovision.OutcomeRaceSkipped, outcome)
 	assert.Nil(t, user)
@@ -160,7 +169,7 @@ func TestProvisioner_Ensure_OrphanRecovered_ResumesAssignment(t *testing.T) {
 	roleRepo := mem.NewRoleRepository()
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
 
-	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	user, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.NoError(t, err)
 	assert.Equal(t, adminprovision.OutcomeOrphanRecovered, outcome)
 	require.NotNil(t, user)
@@ -187,7 +196,7 @@ func TestProvisioner_Ensure_DuplicateIdentityUser_ReturnsConflictWithoutTakeover
 	roleRepo := mem.NewRoleRepository()
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
 
-	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	user, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Nil(t, user)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
@@ -222,7 +231,7 @@ func TestProvisioner_Ensure_DuplicateDifferentSource_ReturnsConflictWithoutTakeo
 	in := stdInput()
 	in.Source = domain.UserSourceSetup
 	in.RequireReset = false
-	user, outcome, err := p.Ensure(context.Background(), in)
+	user, outcome, err := ensureForTest(p, context.Background(), in)
 	require.Error(t, err)
 	assert.Nil(t, user)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
@@ -252,7 +261,7 @@ func TestProvisioner_Ensure_OrphanUpdateFails_Surfaced(t *testing.T) {
 
 	roleRepo := mem.NewRoleRepository()
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
-	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	_, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 	assert.ErrorContains(t, err, "reset orphan credentials")
@@ -264,7 +273,7 @@ func TestProvisioner_Ensure_OrphanLookupFails_Surfaced(t *testing.T) {
 	userRepo := &orphanLookupFailRepo{duplicateUserRepo: duplicateUserRepo{}, lookupErr: errors.New("lookup failed")}
 	roleRepo := &scriptedRoleRepo{counts: []int{0, 0}}
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
-	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	_, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 	assert.ErrorContains(t, err, "lookup orphan user")
@@ -275,7 +284,7 @@ func TestProvisioner_Ensure_RecountAfterDuplicateFails_Surfaced(t *testing.T) {
 	userRepo := &duplicateUserRepo{}
 	roleRepo := &recountErrRoleRepo{firstCount: 0, recountErr: errors.New("recount failed")}
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("x"))
-	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	_, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 	assert.ErrorContains(t, err, "recount after duplicate user")
@@ -284,7 +293,7 @@ func TestProvisioner_Ensure_RecountAfterDuplicateFails_Surfaced(t *testing.T) {
 func TestProvisioner_Ensure_RoleRepoCountError_Surfaced(t *testing.T) {
 	roleRepo := &errRoleRepo{countErr: errors.New("boom")}
 	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
-	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	_, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 }
@@ -292,7 +301,7 @@ func TestProvisioner_Ensure_RoleRepoCountError_Surfaced(t *testing.T) {
 func TestProvisioner_Ensure_RoleCreateNonDuplicateError_Surfaced(t *testing.T) {
 	roleRepo := &errRoleRepo{createErr: errors.New("pg down")}
 	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
-	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	_, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 	assert.ErrorContains(t, err, "ensure admin role")
@@ -305,7 +314,7 @@ func TestProvisioner_Ensure_RoleCreateDuplicate_Tolerated(t *testing.T) {
 	require.NoError(t, roleRepo.Create(context.Background(), role))
 
 	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
-	user, outcome, err := p.Ensure(context.Background(), stdInput())
+	user, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.NoError(t, err)
 	assert.Equal(t, adminprovision.OutcomeCreated, outcome)
 	require.NotNil(t, user)
@@ -314,7 +323,7 @@ func TestProvisioner_Ensure_RoleCreateDuplicate_Tolerated(t *testing.T) {
 func TestProvisioner_Ensure_UserCreateInfraError_Surfaced(t *testing.T) {
 	userRepo := &errUserRepo{createErr: errors.New("db down")}
 	p := newProvisioner(t, userRepo, mem.NewRoleRepository(), fixedUUID("x"))
-	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	_, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 	assert.ErrorContains(t, err, "create user")
@@ -323,7 +332,7 @@ func TestProvisioner_Ensure_UserCreateInfraError_Surfaced(t *testing.T) {
 func TestProvisioner_Ensure_AssignToUserError_Surfaced(t *testing.T) {
 	roleRepo := &errRoleRepo{assignErr: errors.New("fk violation")}
 	p := newProvisioner(t, mem.NewUserRepository(), roleRepo, fixedUUID("x"))
-	_, outcome, err := p.Ensure(context.Background(), stdInput())
+	_, outcome, err := ensureForTest(p, context.Background(), stdInput())
 	require.Error(t, err)
 	assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 	assert.ErrorContains(t, err, "assign admin role")
@@ -340,7 +349,7 @@ func TestProvisioner_Ensure_InvalidInput_Errors(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, outcome, err := p.Ensure(context.Background(), tc.in)
+			_, outcome, err := ensureForTest(p, context.Background(), tc.in)
 			require.Error(t, err)
 			assert.Equal(t, adminprovision.OutcomeUnknown, outcome)
 		})
@@ -353,7 +362,7 @@ func TestProvisioner_Compensate_RemovesRoleAndUser(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	roleRepo := mem.NewRoleRepository()
 	p := newProvisioner(t, userRepo, roleRepo, fixedUUID("zzz"))
-	user, _, err := p.Ensure(context.Background(), stdInput())
+	user, _, err := ensureForTest(p, context.Background(), stdInput())
 	require.NoError(t, err)
 	require.NotNil(t, user)
 
@@ -454,7 +463,7 @@ func (r *scriptedRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, 
 	return true, nil
 }
 func (r *scriptedRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
-	return nil, nil
+	return &domain.Role{ID: id}, nil
 }
 func (r *scriptedRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
 	return nil, nil
@@ -485,7 +494,7 @@ func (r *errRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleI
 	return true, nil
 }
 func (r *errRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
-	return nil, nil
+	return &domain.Role{ID: id}, nil
 }
 func (r *errRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
 	return nil, nil

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -98,12 +98,12 @@ func newE2EFixture() *e2eFixture {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	roleRepo := mem.NewRoleRepository()
-	refreshStore := refreshmem.New(
+	refreshStore := refreshmem.MustNew(
 		refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour},
 		realClock{}, nil,
 	)
 
-	loginSvc := sessionlogin.NewService(
+	loginSvc := sessionlogin.MustNewService(
 		userRepo, sessionRepo, roleRepo, refreshStore, e2eIssuer, slog.Default(),
 	)
 

--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -27,7 +27,7 @@ import (
 
 func newIdentityRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 // testPassword is a deterministic credential used only in contract tests.

--- a/cells/accesscore/slices/identitymanage/handler.go
+++ b/cells/accesscore/slices/identitymanage/handler.go
@@ -255,41 +255,41 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	input := UpdateInput{ID: id}
-	name, err := decodePatchString(req.Name, "name")
+	name, hasName, err := decodePatchString(req.Name, "name")
 	if err != nil {
 		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
 			string(errcode.ErrValidationFailed), err.Error())
 		return
 	}
-	if name != nil {
-		input.Name = name
+	if hasName {
+		input.Name = &name
 	}
-	email, err := decodePatchString(req.Email, "email")
+	email, hasEmail, err := decodePatchString(req.Email, "email")
 	if err != nil {
 		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
 			string(errcode.ErrValidationFailed), err.Error())
 		return
 	}
-	if email != nil {
-		input.Email = email
+	if hasEmail {
+		input.Email = &email
 	}
-	status, err := decodePatchString(req.Status, "status")
+	status, hasStatus, err := decodePatchString(req.Status, "status")
 	if err != nil {
 		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
 			string(errcode.ErrValidationFailed), err.Error())
 		return
 	}
-	if status != nil {
-		input.Status = status
+	if hasStatus {
+		input.Status = &status
 	}
-	requirePasswordReset, err := decodePatchBool(req.RequirePasswordReset, "requirePasswordReset")
+	requirePasswordReset, hasRequirePasswordReset, err := decodePatchBool(req.RequirePasswordReset, "requirePasswordReset")
 	if err != nil {
 		httputil.WriteError(r.Context(), w, http.StatusBadRequest,
 			string(errcode.ErrValidationFailed), err.Error())
 		return
 	}
-	if requirePasswordReset != nil {
-		input.RequirePasswordReset = requirePasswordReset
+	if hasRequirePasswordReset {
+		input.RequirePasswordReset = &requirePasswordReset
 	}
 
 	user, err := h.svc.Update(r.Context(), input)
@@ -300,32 +300,32 @@ func (h *Handler) handlePatch(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": toUserResponse(user)})
 }
 
-func decodePatchString(raw json.RawMessage, field string) (*string, error) {
+func decodePatchString(raw json.RawMessage, field string) (string, bool, error) {
 	if len(raw) == 0 {
-		return nil, nil
+		return "", false, nil
 	}
 	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
-		return nil, fmt.Errorf("field '%s' must be a string", field)
+		return "", false, fmt.Errorf("field '%s' must be a string", field)
 	}
 	var value string
 	if err := json.Unmarshal(raw, &value); err != nil {
-		return nil, fmt.Errorf("field '%s' must be a string: %w", field, err)
+		return "", false, fmt.Errorf("field '%s' must be a string: %w", field, err)
 	}
-	return &value, nil
+	return value, true, nil
 }
 
-func decodePatchBool(raw json.RawMessage, field string) (*bool, error) {
+func decodePatchBool(raw json.RawMessage, field string) (bool, bool, error) {
 	if len(raw) == 0 {
-		return nil, nil
+		return false, false, nil
 	}
 	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
-		return nil, fmt.Errorf("field '%s' must be a boolean", field)
+		return false, false, fmt.Errorf("field '%s' must be a boolean", field)
 	}
 	var value bool
 	if err := json.Unmarshal(raw, &value); err != nil {
-		return nil, fmt.Errorf("field '%s' must be a boolean: %w", field, err)
+		return false, false, fmt.Errorf("field '%s' must be a boolean: %w", field, err)
 	}
-	return &value, nil
+	return value, true, nil
 }
 
 func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {

--- a/cells/accesscore/slices/identitymanage/handler_test.go
+++ b/cells/accesscore/slices/identitymanage/handler_test.go
@@ -32,7 +32,7 @@ const invalidUUID = "not-a-uuid-string"
 
 func newHandlerIdentityRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 // handlerStubIssuer is a minimal TokenIssuer stub used by handler tests that

--- a/cells/accesscore/slices/identitymanage/refresh_cascade_test.go
+++ b/cells/accesscore/slices/identitymanage/refresh_cascade_test.go
@@ -25,7 +25,7 @@ func newCascadeStore(t *testing.T) (refresh.Store, *storetest.FakeClock) {
 	t.Helper()
 	clock := storetest.NewFakeClock(time.Now())
 	policy := refresh.Policy{ReuseInterval: 100 * time.Millisecond, MaxAge: time.Hour}
-	return refreshmem.New(policy, clock, nil), clock
+	return refreshmem.MustNew(policy, clock, nil), clock
 }
 
 func TestService_Lock_RevokesRefreshChain(t *testing.T) {

--- a/cells/accesscore/slices/sessionlogin/handler_test.go
+++ b/cells/accesscore/slices/sessionlogin/handler_test.go
@@ -29,7 +29,7 @@ const loginPath = "/api/v1/access/sessions/login"
 
 func newHandlerRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 // setup wires the slice handler onto a celltest mux via RegisterRoutes — the
@@ -45,7 +45,7 @@ func setup() http.Handler {
 	}
 	_ = userRepo.Create(context.Background(), user)
 
-	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(), newHandlerRefreshStore(), testIssuer, slog.Default())
+	svc := MustNewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(), newHandlerRefreshStore(), testIssuer, slog.Default())
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux

--- a/cells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogin/outbox_test.go
@@ -22,7 +22,7 @@ import (
 
 func newOutboxRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 // --- stubs ---
@@ -56,7 +56,7 @@ func seedUserDirect(repo *mem.UserRepository, username, passwordHash string) {
 func TestService_WithEmitter(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(),
+	svc := MustNewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(),
 		newOutboxRefreshStore(), testIssuer, slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
@@ -72,7 +72,7 @@ func TestService_WithEmitter(t *testing.T) {
 func TestService_WithTxManager(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	tx := &stubTxRunner{}
-	svc := NewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(),
+	svc := MustNewService(userRepo, mem.NewSessionRepository(), mem.NewRoleRepository(),
 		newOutboxRefreshStore(), testIssuer, slog.Default(), WithTxManager(tx))
 
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)

--- a/cells/accesscore/slices/sessionlogin/service.go
+++ b/cells/accesscore/slices/sessionlogin/service.go
@@ -63,16 +63,16 @@ func NewService(
 	logger *slog.Logger,
 	opts ...Option,
 ) (*Service, error) {
-	if userRepo == nil {
+	if validation.IsNilInterface(userRepo) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: userRepo must not be nil")
 	}
-	if sessionRepo == nil {
+	if validation.IsNilInterface(sessionRepo) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: sessionRepo must not be nil")
 	}
-	if roleRepo == nil {
+	if validation.IsNilInterface(roleRepo) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: roleRepo must not be nil")
 	}
-	if refreshStore == nil {
+	if validation.IsNilInterface(refreshStore) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: refreshStore must not be nil")
 	}
 	if issuer == nil {

--- a/cells/accesscore/slices/sessionlogin/service.go
+++ b/cells/accesscore/slices/sessionlogin/service.go
@@ -62,21 +62,21 @@ func NewService(
 	issuer *auth.JWTIssuer,
 	logger *slog.Logger,
 	opts ...Option,
-) *Service {
+) (*Service, error) {
 	if userRepo == nil {
-		panic("sessionlogin.NewService: userRepo must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: userRepo must not be nil")
 	}
 	if sessionRepo == nil {
-		panic("sessionlogin.NewService: sessionRepo must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: sessionRepo must not be nil")
 	}
 	if roleRepo == nil {
-		panic("sessionlogin.NewService: roleRepo must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: roleRepo must not be nil")
 	}
 	if refreshStore == nil {
-		panic("sessionlogin.NewService: refreshStore must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: refreshStore must not be nil")
 	}
 	if issuer == nil {
-		panic("sessionlogin.NewService: issuer must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogin.NewService: issuer must not be nil")
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -93,6 +93,23 @@ func NewService(
 	}
 	for _, o := range opts {
 		o(s)
+	}
+	return s, nil
+}
+
+// MustNewService is the static-wiring variant of NewService.
+func MustNewService(
+	userRepo ports.UserRepository,
+	sessionRepo ports.SessionRepository,
+	roleRepo ports.RoleRepository,
+	refreshStore refresh.Store,
+	issuer *auth.JWTIssuer,
+	logger *slog.Logger,
+	opts ...Option,
+) *Service {
+	s, err := NewService(userRepo, sessionRepo, roleRepo, refreshStore, issuer, logger, opts...)
+	if err != nil {
+		panic(err.Error())
 	}
 	return s
 }

--- a/cells/accesscore/slices/sessionlogin/service_test.go
+++ b/cells/accesscore/slices/sessionlogin/service_test.go
@@ -37,6 +37,10 @@ func (s failingIssueRefreshStore) Issue(context.Context, string, string) (string
 	return "", nil, s.err
 }
 
+type typedNilRefreshStore struct {
+	refresh.Store
+}
+
 type trackingSessionRepo struct {
 	*mem.SessionRepository
 	created []string
@@ -97,6 +101,57 @@ func newTestService() (*Service, *mem.UserRepository) {
 	sessionRepo := mem.NewSessionRepository()
 	roleRepo := mem.NewRoleRepository()
 	return MustNewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default()), userRepo
+}
+
+func TestNewService_RejectsTypedNilDependencies(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	sessionRepo := mem.NewSessionRepository()
+	roleRepo := mem.NewRoleRepository()
+	refreshStore := newTestRefreshStore()
+
+	cases := []struct {
+		name string
+		run  func() (*Service, error)
+	}{
+		{
+			name: "typed nil userRepo",
+			run: func() (*Service, error) {
+				var typedNil *mem.UserRepository
+				return NewService(typedNil, sessionRepo, roleRepo, refreshStore, testIssuer, slog.Default())
+			},
+		},
+		{
+			name: "typed nil sessionRepo",
+			run: func() (*Service, error) {
+				var typedNil *mem.SessionRepository
+				return NewService(userRepo, typedNil, roleRepo, refreshStore, testIssuer, slog.Default())
+			},
+		},
+		{
+			name: "typed nil roleRepo",
+			run: func() (*Service, error) {
+				var typedNil *mem.RoleRepository
+				return NewService(userRepo, sessionRepo, typedNil, refreshStore, testIssuer, slog.Default())
+			},
+		},
+		{
+			name: "typed nil refreshStore",
+			run: func() (*Service, error) {
+				var typedNil *typedNilRefreshStore
+				return NewService(userRepo, sessionRepo, roleRepo, typedNil, testIssuer, slog.Default())
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.run()
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.ErrCellInvalidConfig, ec.Code)
+		})
+	}
 }
 
 // seedUser creates a user with a bcrypt-hashed password.

--- a/cells/accesscore/slices/sessionlogin/service_test.go
+++ b/cells/accesscore/slices/sessionlogin/service_test.go
@@ -25,7 +25,7 @@ import (
 
 func newTestRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 type failingIssueRefreshStore struct {
@@ -96,7 +96,7 @@ func newTestService() (*Service, *mem.UserRepository) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	roleRepo := mem.NewRoleRepository()
-	return NewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default()), userRepo
+	return MustNewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default()), userRepo
 }
 
 // seedUser creates a user with a bcrypt-hashed password.
@@ -180,7 +180,7 @@ func TestService_Login_RefreshStoreUnavailableReturnsInfraAndNoOrphanSession(t *
 	sessionRepo := &trackingSessionRepo{SessionRepository: mem.NewSessionRepository()}
 	roleRepo := mem.NewRoleRepository()
 	store := failingIssueRefreshStore{Store: newTestRefreshStore(), err: fmt.Errorf("refresh db down")}
-	svc := NewService(userRepo, sessionRepo, roleRepo, store, testIssuer, slog.Default())
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, store, testIssuer, slog.Default())
 	seedUser(userRepo, "refresh-down", "pass123")
 
 	pair, err := svc.Login(context.Background(), LoginInput{Username: "refresh-down", Password: "pass123"})
@@ -289,7 +289,7 @@ func TestService_IssueForUser_SessionPersisted(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := mem.NewSessionRepository()
 	roleRepo := mem.NewRoleRepository()
-	svc := NewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default())
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default())
 	seedUser(userRepo, "issue-persist", "pass123")
 
 	u, err := userRepo.GetByUsername(context.Background(), "issue-persist")
@@ -313,7 +313,7 @@ func TestService_IssueForUser_RefreshStoreUnavailableReturnsInfraAndNoOrphanSess
 	sessionRepo := &trackingSessionRepo{SessionRepository: mem.NewSessionRepository()}
 	roleRepo := mem.NewRoleRepository()
 	store := failingIssueRefreshStore{Store: newTestRefreshStore(), err: fmt.Errorf("refresh db down")}
-	svc := NewService(userRepo, sessionRepo, roleRepo, store, testIssuer, slog.Default())
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, store, testIssuer, slog.Default())
 	seedUser(userRepo, "issue-refresh-down", "pass123")
 	u, err := userRepo.GetByUsername(context.Background(), "issue-refresh-down")
 	require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestService_Login_RoleFetchFailure_AbortsLogin(t *testing.T) {
 	seedUser(userRepo, "role-outage", "pass123")
 
 	emitter := &countingEmitter{}
-	svc := NewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default(), WithEmitter(emitter))
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default(), WithEmitter(emitter))
 
 	pair, err := svc.Login(context.Background(), LoginInput{Username: "role-outage", Password: "pass123"})
 	require.Error(t, err, "Login must fail when role fetch fails")
@@ -437,7 +437,7 @@ func TestService_IssueForUser_RoleFetchFailure_AbortsIssue(t *testing.T) {
 	u, err := userRepo.GetByUsername(context.Background(), "issue-outage")
 	require.NoError(t, err)
 
-	svc := NewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default())
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default())
 
 	pair, err := svc.IssueForUser(context.Background(), u.ID)
 	require.Error(t, err, "IssueForUser must fail when role fetch fails")
@@ -473,7 +473,7 @@ func TestService_Login_PublishError_DoesNotFailLogin(t *testing.T) {
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
 	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
-	svc := NewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default(), WithEmitter(emitter))
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default(), WithEmitter(emitter))
 
 	pair, err := svc.Login(context.Background(), LoginInput{Username: "pub-err", Password: "pass123"})
 	require.NoError(t, err, "publish failure in demo mode should not fail login")
@@ -492,7 +492,7 @@ func TestService_IssueForUser_EmitsSessionCreated(t *testing.T) {
 	require.NoError(t, err)
 
 	emitter := &countingEmitter{}
-	svc := NewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default(), WithEmitter(emitter))
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, newTestRefreshStore(), testIssuer, slog.Default(), WithEmitter(emitter))
 
 	pair, err := svc.IssueForUser(context.Background(), u.ID)
 	require.NoError(t, err)

--- a/cells/accesscore/slices/sessionlogout/contract_test.go
+++ b/cells/accesscore/slices/sessionlogout/contract_test.go
@@ -27,7 +27,7 @@ import (
 
 func newContractRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 // --- contract test doubles ---
@@ -68,7 +68,7 @@ func TestHttpAuthSessionDeleteV1Serve(t *testing.T) {
 
 	sessionRepo := mem.NewSessionRepository()
 	sessID := seedContractSession(sessionRepo)
-	svc := NewService(sessionRepo, newContractRefreshStore(), slog.Default(),
+	svc := MustNewService(sessionRepo, newContractRefreshStore(), slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, &recordingWriter{})), WithTxManager(noopTxRunner{}))
 
 	mux := http.NewServeMux()
@@ -94,7 +94,7 @@ func TestEventSessionRevokedV1Publish(t *testing.T) {
 
 	sessionRepo := mem.NewSessionRepository()
 	writer := &recordingWriter{}
-	svc := NewService(sessionRepo, newContractRefreshStore(), slog.Default(),
+	svc := MustNewService(sessionRepo, newContractRefreshStore(), slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, writer)), WithTxManager(noopTxRunner{}))
 
 	sessID := seedContractSession(sessionRepo)
@@ -172,7 +172,7 @@ func TestService_Logout_OutboxWriteError(t *testing.T) {
 	sessionRepo := mem.NewSessionRepository()
 	seedContractSession(sessionRepo)
 	failWriter := &recordingWriter{err: errors.New("outbox unavailable")}
-	svc := NewService(sessionRepo, newContractRefreshStore(), slog.Default(),
+	svc := MustNewService(sessionRepo, newContractRefreshStore(), slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, failWriter)), WithTxManager(noopTxRunner{}))
 
 	err := svc.Logout(context.Background(), testutil.TestID("sess-1"), testutil.TestID("usr-1"))

--- a/cells/accesscore/slices/sessionlogout/handler_test.go
+++ b/cells/accesscore/slices/sessionlogout/handler_test.go
@@ -30,7 +30,7 @@ const (
 
 func newHandlerLogoutRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 // setup wires the slice handler onto a celltest mux via RegisterRoutes — the
@@ -45,7 +45,7 @@ func setup() http.Handler {
 	other.ID = testutil.TestID("sess-victim")
 	_ = sessionRepo.Create(context.Background(), other)
 
-	svc := NewService(sessionRepo, newHandlerLogoutRefreshStore(), slog.Default())
+	svc := MustNewService(sessionRepo, newHandlerLogoutRefreshStore(), slog.Default())
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux

--- a/cells/accesscore/slices/sessionlogout/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogout/outbox_test.go
@@ -34,7 +34,7 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 func TestService_WithEmitter(t *testing.T) {
 	repo := mem.NewSessionRepository()
 	ow := &stubOutboxWriter{}
-	svc := NewService(repo, newLogoutRefreshStore(), slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
+	svc := MustNewService(repo, newLogoutRefreshStore(), slog.Default(), WithEmitter(testoutbox.MustEmitter(t, ow)))
 
 	seedSession(repo, "sess-1", "usr-1")
 
@@ -47,7 +47,7 @@ func TestService_WithEmitter(t *testing.T) {
 func TestService_WithTxManager(t *testing.T) {
 	repo := mem.NewSessionRepository()
 	tx := &stubTxRunner{}
-	svc := NewService(repo, newLogoutRefreshStore(), slog.Default(), WithTxManager(tx))
+	svc := MustNewService(repo, newLogoutRefreshStore(), slog.Default(), WithTxManager(tx))
 
 	seedSession(repo, "sess-1", "usr-1")
 
@@ -59,7 +59,7 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	repo := mem.NewSessionRepository()
 	ow := &stubOutboxWriter{}
 	tx := &stubTxRunner{}
-	svc := NewService(repo, newLogoutRefreshStore(), slog.Default(),
+	svc := MustNewService(repo, newLogoutRefreshStore(), slog.Default(),
 		WithEmitter(testoutbox.MustEmitter(t, ow)), WithTxManager(tx))
 
 	seedSession(repo, "sess-1", "usr-1")

--- a/cells/accesscore/slices/sessionlogout/refresh_cascade_test.go
+++ b/cells/accesscore/slices/sessionlogout/refresh_cascade_test.go
@@ -23,7 +23,7 @@ import (
 func newCascadeStore(t *testing.T) refresh.Store {
 	t.Helper()
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 100 * time.Millisecond, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 100 * time.Millisecond, MaxAge: time.Hour}, clock, nil)
 }
 
 func TestService_Logout_RevokesRefreshChain(t *testing.T) {
@@ -45,7 +45,7 @@ func TestService_Logout_RevokesRefreshChain(t *testing.T) {
 	wire, _, err := refreshStore.Issue(ctx, sessionID, userID)
 	require.NoError(t, err)
 
-	svc := NewService(sessionRepo, refreshStore, slog.Default())
+	svc := MustNewService(sessionRepo, refreshStore, slog.Default())
 	require.NoError(t, svc.Logout(ctx, sessionID, userID))
 
 	_, _, err = refreshStore.Rotate(ctx, wire)
@@ -76,7 +76,7 @@ func TestService_LogoutUser_RevokesAllRefreshChains(t *testing.T) {
 	otherWire, _, err := refreshStore.Issue(ctx, "sess-other", "other-user")
 	require.NoError(t, err)
 
-	svc := NewService(sessionRepo, refreshStore, slog.Default())
+	svc := MustNewService(sessionRepo, refreshStore, slog.Default())
 	require.NoError(t, svc.LogoutUser(ctx, userID))
 
 	_, _, err = refreshStore.Rotate(ctx, wire1)

--- a/cells/accesscore/slices/sessionlogout/service.go
+++ b/cells/accesscore/slices/sessionlogout/service.go
@@ -50,12 +50,12 @@ func NewService(
 	refreshStore refresh.Store,
 	logger *slog.Logger,
 	opts ...Option,
-) *Service {
+) (*Service, error) {
 	if sessionRepo == nil {
-		panic("sessionlogout.NewService: sessionRepo must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogout.NewService: sessionRepo must not be nil")
 	}
 	if refreshStore == nil {
-		panic("sessionlogout.NewService: refreshStore must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogout.NewService: refreshStore must not be nil")
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -69,6 +69,20 @@ func NewService(
 	}
 	for _, o := range opts {
 		o(s)
+	}
+	return s, nil
+}
+
+// MustNewService is the static-wiring variant of NewService.
+func MustNewService(
+	sessionRepo ports.SessionRepository,
+	refreshStore refresh.Store,
+	logger *slog.Logger,
+	opts ...Option,
+) *Service {
+	s, err := NewService(sessionRepo, refreshStore, logger, opts...)
+	if err != nil {
+		panic(err.Error())
 	}
 	return s
 }

--- a/cells/accesscore/slices/sessionlogout/service.go
+++ b/cells/accesscore/slices/sessionlogout/service.go
@@ -51,10 +51,10 @@ func NewService(
 	logger *slog.Logger,
 	opts ...Option,
 ) (*Service, error) {
-	if sessionRepo == nil {
+	if validation.IsNilInterface(sessionRepo) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogout.NewService: sessionRepo must not be nil")
 	}
-	if refreshStore == nil {
+	if validation.IsNilInterface(refreshStore) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionlogout.NewService: refreshStore must not be nil")
 	}
 	if logger == nil {

--- a/cells/accesscore/slices/sessionlogout/service_test.go
+++ b/cells/accesscore/slices/sessionlogout/service_test.go
@@ -21,12 +21,12 @@ import (
 
 func newLogoutRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 func newTestService() (*Service, *mem.SessionRepository) {
 	repo := mem.NewSessionRepository()
-	return NewService(repo, newLogoutRefreshStore(), slog.Default()), repo
+	return MustNewService(repo, newLogoutRefreshStore(), slog.Default()), repo
 }
 
 func seedSession(repo *mem.SessionRepository, id, userID string) {
@@ -135,7 +135,7 @@ func TestService_Logout_PublishError_DoesNotFailLogout(t *testing.T) {
 	fp := failingPublisher{err: fmt.Errorf("broker unavailable")}
 	emitter, err := outbox.NewDirectEmitter(fp, outbox.DirectPublishFailOpen, metrics.NopProvider{}, "accesscore", outbox.WithLogger(slog.Default()))
 	require.NoError(t, err)
-	svc := NewService(repo, newLogoutRefreshStore(), slog.Default(), WithEmitter(emitter))
+	svc := MustNewService(repo, newLogoutRefreshStore(), slog.Default(), WithEmitter(emitter))
 
 	err = svc.Logout(context.Background(), "sess-pub", "usr-1")
 	require.NoError(t, err, "publish failure in demo mode should not fail logout")

--- a/cells/accesscore/slices/sessionlogout/service_test.go
+++ b/cells/accesscore/slices/sessionlogout/service_test.go
@@ -24,9 +24,48 @@ func newLogoutRefreshStore() refresh.Store {
 	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
+type typedNilRefreshStore struct {
+	refresh.Store
+}
+
 func newTestService() (*Service, *mem.SessionRepository) {
 	repo := mem.NewSessionRepository()
 	return MustNewService(repo, newLogoutRefreshStore(), slog.Default()), repo
+}
+
+func TestNewService_RejectsTypedNilDependencies(t *testing.T) {
+	sessionRepo := mem.NewSessionRepository()
+	refreshStore := newLogoutRefreshStore()
+
+	cases := []struct {
+		name string
+		run  func() (*Service, error)
+	}{
+		{
+			name: "typed nil sessionRepo",
+			run: func() (*Service, error) {
+				var typedNil *mem.SessionRepository
+				return NewService(typedNil, refreshStore, slog.Default())
+			},
+		},
+		{
+			name: "typed nil refreshStore",
+			run: func() (*Service, error) {
+				var typedNil *typedNilRefreshStore
+				return NewService(sessionRepo, typedNil, slog.Default())
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.run()
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.ErrCellInvalidConfig, ec.Code)
+		})
+	}
 }
 
 func seedSession(repo *mem.SessionRepository, id, userID string) {

--- a/cells/accesscore/slices/sessionrefresh/handler_test.go
+++ b/cells/accesscore/slices/sessionrefresh/handler_test.go
@@ -48,7 +48,7 @@ func setup() (http.Handler, string) {
 	u.ID = "usr-1"
 	_ = userRepo.Create(context.Background(), u)
 
-	svc := NewService(sessionRepo, mem.NewRoleRepository(), userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, mem.NewRoleRepository(), userRepo, refreshStore, testIssuer, slog.Default())
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 	return mux, wireToken
@@ -191,7 +191,7 @@ func TestHandleRefresh_RefreshStoreUnavailable_Returns503(t *testing.T) {
 	sessionRepo := mem.NewSessionRepository()
 	userRepo := mem.NewUserRepository()
 	store := unavailableRefreshStore{Store: newTestRefreshStore()}
-	svc := NewService(sessionRepo, mem.NewRoleRepository(), userRepo, store, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, mem.NewRoleRepository(), userRepo, store, testIssuer, slog.Default())
 	mux := celltest.NewTestMux()
 	NewHandler(svc).RegisterRoutes(mux)
 

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -53,21 +53,21 @@ func NewService(
 	issuer *auth.JWTIssuer,
 	logger *slog.Logger,
 	opts ...Option,
-) *Service {
+) (*Service, error) {
 	if sessionRepo == nil {
-		panic("sessionrefresh.NewService: sessionRepo must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: sessionRepo must not be nil")
 	}
 	if roleRepo == nil {
-		panic("sessionrefresh.NewService: roleRepo must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: roleRepo must not be nil")
 	}
 	if userRepo == nil {
-		panic("sessionrefresh.NewService: userRepo must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: userRepo must not be nil")
 	}
 	if refreshStore == nil {
-		panic("sessionrefresh.NewService: refreshStore must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: refreshStore must not be nil")
 	}
 	if issuer == nil {
-		panic("sessionrefresh.NewService: issuer must not be nil")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: issuer must not be nil")
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -82,6 +82,23 @@ func NewService(
 	}
 	for _, o := range opts {
 		o(s)
+	}
+	return s, nil
+}
+
+// MustNewService is the static-wiring variant of NewService.
+func MustNewService(
+	sessionRepo ports.SessionRepository,
+	roleRepo ports.RoleRepository,
+	userRepo ports.UserRepository,
+	refreshStore refresh.Store,
+	issuer *auth.JWTIssuer,
+	logger *slog.Logger,
+	opts ...Option,
+) *Service {
+	s, err := NewService(sessionRepo, roleRepo, userRepo, refreshStore, issuer, logger, opts...)
+	if err != nil {
+		panic(err.Error())
 	}
 	return s
 }

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -54,16 +54,16 @@ func NewService(
 	logger *slog.Logger,
 	opts ...Option,
 ) (*Service, error) {
-	if sessionRepo == nil {
+	if validation.IsNilInterface(sessionRepo) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: sessionRepo must not be nil")
 	}
-	if roleRepo == nil {
+	if validation.IsNilInterface(roleRepo) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: roleRepo must not be nil")
 	}
-	if userRepo == nil {
+	if validation.IsNilInterface(userRepo) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: userRepo must not be nil")
 	}
-	if refreshStore == nil {
+	if validation.IsNilInterface(refreshStore) {
 		return nil, errcode.New(errcode.ErrCellInvalidConfig, "sessionrefresh.NewService: refreshStore must not be nil")
 	}
 	if issuer == nil {

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -46,6 +46,10 @@ func newTestRefreshStore() refresh.Store {
 	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
+type typedNilRefreshStore struct {
+	refresh.Store
+}
+
 // TestNewService_IssuerDefaultAudienceWrittenOnRefresh verifies that the
 // sessionrefresh Service issues tokens with the audience configured in the
 // issuer (Registry path), without caching audience separately (S31).
@@ -113,6 +117,57 @@ func newTestServiceWithUserRepo() (*Service, *mem.SessionRepository, *mem.UserRe
 	refreshStore := newTestRefreshStore()
 	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 	return svc, sessionRepo, userRepo
+}
+
+func TestNewService_RejectsTypedNilDependencies(t *testing.T) {
+	sessionRepo := mem.NewSessionRepository()
+	roleRepo := mem.NewRoleRepository()
+	userRepo := mem.NewUserRepository()
+	refreshStore := newTestRefreshStore()
+
+	cases := []struct {
+		name string
+		run  func() (*Service, error)
+	}{
+		{
+			name: "typed nil sessionRepo",
+			run: func() (*Service, error) {
+				var typedNil *mem.SessionRepository
+				return NewService(typedNil, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+			},
+		},
+		{
+			name: "typed nil roleRepo",
+			run: func() (*Service, error) {
+				var typedNil *mem.RoleRepository
+				return NewService(sessionRepo, typedNil, userRepo, refreshStore, testIssuer, slog.Default())
+			},
+		},
+		{
+			name: "typed nil userRepo",
+			run: func() (*Service, error) {
+				var typedNil *mem.UserRepository
+				return NewService(sessionRepo, roleRepo, typedNil, refreshStore, testIssuer, slog.Default())
+			},
+		},
+		{
+			name: "typed nil refreshStore",
+			run: func() (*Service, error) {
+				var typedNil *typedNilRefreshStore
+				return NewService(sessionRepo, roleRepo, userRepo, typedNil, testIssuer, slog.Default())
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.run()
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.ErrCellInvalidConfig, ec.Code)
+		})
+	}
 }
 
 // issueTestWireToken creates a session + issues a wire token from the refreshStore.

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -43,7 +43,7 @@ func init() {
 
 func newTestRefreshStore() refresh.Store {
 	clock := storetest.NewFakeClock(time.Now())
-	return refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	return refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
 }
 
 // TestNewService_IssuerDefaultAudienceWrittenOnRefresh verifies that the
@@ -99,8 +99,8 @@ func newTestServiceWithClock(seedUsers ...string) (*Service, *mem.SessionReposit
 		_ = userRepo.Create(context.Background(), u)
 	}
 	clock := storetest.NewFakeClock(time.Now())
-	refreshStore := refreshmem.New(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	refreshStore := refreshmem.MustNew(refresh.Policy{ReuseInterval: 2 * time.Second, MaxAge: time.Hour}, clock, nil)
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 	return svc, sessionRepo, refreshStore, clock
 }
 
@@ -111,7 +111,7 @@ func newTestServiceWithUserRepo() (*Service, *mem.SessionRepository, *mem.UserRe
 	roleRepo := mem.NewRoleRepository()
 	userRepo := mem.NewUserRepository()
 	refreshStore := newTestRefreshStore()
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 	return svc, sessionRepo, userRepo
 }
 
@@ -167,7 +167,7 @@ func TestService_Refresh_RoleFetchFailure_AbortsRefresh(t *testing.T) {
 	require.NoError(t, userRepo.Create(context.Background(), u))
 
 	refreshStore := newTestRefreshStore()
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 
 	sess, err := domain.NewSession("usr-rolefail", "at", time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -391,7 +391,7 @@ func TestService_Refresh_SessionAwareVerifier(t *testing.T) {
 	require.NoError(t, userRepo.Create(context.Background(), seedUser))
 
 	refreshStore := newTestRefreshStore()
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 
 	sess, err := domain.NewSession("usr-sa", "at", time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -426,7 +426,7 @@ func TestRefresh_FailClosedWhenUserUnavailable(t *testing.T) {
 	roleRepo := mem.NewRoleRepository()
 	userRepo := mem.NewUserRepository() // intentionally empty — GetByID returns error
 	refreshStore := newTestRefreshStore()
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 
 	sess, err := domain.NewSession("usr-missing", "at", time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -456,7 +456,7 @@ func TestRefresh_FlagPropagatesFromCurrentUser_AfterClear(t *testing.T) {
 
 	// Recreate with a known refreshStore so we can issue and rotate wire tokens.
 	refreshStore := newTestRefreshStore()
-	svc2 := NewService(sessionRepo, mem.NewRoleRepository(), userRepo, refreshStore, testIssuer, slog.Default())
+	svc2 := MustNewService(sessionRepo, mem.NewRoleRepository(), userRepo, refreshStore, testIssuer, slog.Default())
 
 	sess, _ := domain.NewSession("usr-ref-clear", "at", time.Now().Add(time.Hour))
 	sess.ID = "sess-ref-clear"
@@ -491,7 +491,7 @@ func TestRefresh_FlagStillSetWhenUserNotChanged(t *testing.T) {
 	require.NoError(t, userRepo.Create(context.Background(), user))
 
 	refreshStore := newTestRefreshStore()
-	svc := NewService(sessionRepo, mem.NewRoleRepository(), userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, mem.NewRoleRepository(), userRepo, refreshStore, testIssuer, slog.Default())
 
 	sess, _ := domain.NewSession("usr-ref-reset", "at", time.Now().Add(time.Hour))
 	sess.ID = "sess-ref-reset"
@@ -523,7 +523,7 @@ func TestService_Refresh_InfraErrorOnSessionLookup(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 
 	refreshStore := newTestRefreshStore()
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 
 	// Issue a wire token but don't seed the session — GetByID will return infraErr.
 	wireToken, _, err := refreshStore.Issue(context.Background(), "sess-infra", "usr-infra")
@@ -590,7 +590,7 @@ func TestService_Refresh_SessionNotFound_CascadeRevokes(t *testing.T) {
 
 	spy := &spyRefreshStore{Store: innerStore}
 	sessionRepo := &sessionNotFoundRepo{notFoundErr: notFoundErr}
-	svc := NewService(sessionRepo, roleRepo, userRepo, spy, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, spy, testIssuer, slog.Default())
 
 	pair, err := svc.Refresh(context.Background(), wireToken)
 	require.Error(t, err, "session-not-found must cause Refresh to fail")
@@ -614,7 +614,7 @@ func TestService_Refresh_CascadeRevokeFailure_ReturnsRefreshUnavailable(t *testi
 		err:   errcode.NewInfra(errcode.ErrInternal, "refresh store down"),
 	}
 	sessionRepo := &sessionNotFoundRepo{notFoundErr: notFoundErr}
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 
 	pair, err := svc.Refresh(context.Background(), wireToken)
 	require.Error(t, err)
@@ -646,7 +646,7 @@ func TestService_Refresh_SessionUpdateInfraFailure_DoesNotRotate(t *testing.T) {
 	require.NoError(t, userRepo.Create(context.Background(), user))
 
 	refreshStore := newTestRefreshStore()
-	svc := NewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
 	sess, err := domain.NewSession("usr-update-infra", "at", time.Now().Add(time.Hour))
 	require.NoError(t, err)
 	sess.ID = "sess-update-infra"
@@ -679,7 +679,7 @@ func TestService_Refresh_SessionUpdateNotFound_CascadeRevokesAndRejects(t *testi
 
 	innerStore := newTestRefreshStore()
 	spy := &spyRefreshStore{Store: innerStore}
-	svc := NewService(sessionRepo, roleRepo, userRepo, spy, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, spy, testIssuer, slog.Default())
 	sess, err := domain.NewSession("usr-update-missing", "at", time.Now().Add(time.Hour))
 	require.NoError(t, err)
 	sess.ID = "sess-update-missing"
@@ -711,7 +711,7 @@ func TestService_Refresh_RejectionMessagesAreUniform(t *testing.T) {
 			build: func(t *testing.T) (*Service, string) {
 				t.Helper()
 				_, _, innerStore, wireToken := issueTestWireToken(t, "usr-uniform-notfound", "sess-uniform-notfound")
-				svc := NewService(
+				svc := MustNewService(
 					&sessionNotFoundRepo{notFoundErr: errcode.NewDomain(errcode.ErrSessionNotFound, "session not found")},
 					mem.NewRoleRepository(),
 					mem.NewUserRepository(),
@@ -743,7 +743,7 @@ func TestService_Refresh_RejectionMessagesAreUniform(t *testing.T) {
 				t.Helper()
 				sessionRepo := mem.NewSessionRepository()
 				refreshStore := newTestRefreshStore()
-				svc := NewService(sessionRepo, mem.NewRoleRepository(), mem.NewUserRepository(), refreshStore, testIssuer, slog.Default())
+				svc := MustNewService(sessionRepo, mem.NewRoleRepository(), mem.NewUserRepository(), refreshStore, testIssuer, slog.Default())
 				sess, err := domain.NewSession("usr-uniform-missing", "at", time.Now().Add(time.Hour))
 				require.NoError(t, err)
 				sess.ID = "sess-uniform-missing"
@@ -781,7 +781,7 @@ func TestService_Refresh_CascadeRejectionReasonIsLogged(t *testing.T) {
 			build: func(t *testing.T, logger *slog.Logger) (*Service, string) {
 				t.Helper()
 				_, _, innerStore, wireToken := issueTestWireToken(t, "usr-log-notfound", "sess-log-notfound")
-				svc := NewService(
+				svc := MustNewService(
 					&sessionNotFoundRepo{notFoundErr: errcode.NewDomain(errcode.ErrSessionNotFound, "session not found")},
 					mem.NewRoleRepository(),
 					mem.NewUserRepository(),
@@ -889,7 +889,7 @@ func TestRefresh_RotateFailure_ReturnsRefreshUnavailable(t *testing.T) {
 		Store: innerStore,
 		err:   errcode.NewInfra(errcode.ErrInternal, "rotate store down"),
 	}
-	svc2 := NewService(sessionRepo, roleRepo, userRepo, failStore, testIssuer, slog.Default())
+	svc2 := MustNewService(sessionRepo, roleRepo, userRepo, failStore, testIssuer, slog.Default())
 
 	pair, err := svc2.Refresh(context.Background(), wireToken)
 	require.Error(t, err)
@@ -922,7 +922,7 @@ func TestRefresh_RotateMismatch_CascadeRevoke_ReturnsRejected(t *testing.T) {
 	spy := &spyRefreshStore{Store: innerStore}
 	// Override Rotate to return a token with wrong SessionID.
 	mismatchStore := rotateMismatchRefreshStore{Store: spy, rotatedSessionID: "wrong-session", rotatedSubjectID: "usr-mismatch"}
-	svc2 := NewService(sessionRepo, roleRepo, userRepo, mismatchStore, testIssuer, slog.Default())
+	svc2 := MustNewService(sessionRepo, roleRepo, userRepo, mismatchStore, testIssuer, slog.Default())
 
 	pair, err := svc2.Refresh(context.Background(), wireToken)
 	require.Error(t, err)
@@ -963,7 +963,7 @@ func TestRefresh_RotateMismatch_CascadeRevokeFails_PropagatesErr(t *testing.T) {
 	// rotateMismatchRefreshStore wraps revokeErrStore so Rotate returns mismatch
 	// but RevokeSession delegates to revokeErrStore and fails.
 	mismatchStore := rotateMismatchRefreshStore{Store: revokeErrStore, rotatedSessionID: "tampered-session", rotatedSubjectID: "usr-mismatch-revoke-fail"}
-	svc := NewService(sessionRepo, roleRepo, userRepo, mismatchStore, testIssuer, slog.Default())
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, mismatchStore, testIssuer, slog.Default())
 
 	pair, err := svc.Refresh(context.Background(), wireToken)
 	require.Error(t, err)

--- a/cells/accesscore/slices/setup/service.go
+++ b/cells/accesscore/slices/setup/service.go
@@ -227,7 +227,7 @@ func isPrintableASCII(s string) bool {
 // Extracted from CreateAdmin to keep CreateAdmin under the cognitive-complexity
 // ceiling after adding the pre-bcrypt Status fast-path.
 func (s *Service) provisionAndMaybeEmit(ctx context.Context, in CreateAdminInput, hash []byte) (*domain.User, error) {
-	user, outcome, err := s.provisioner.Ensure(ctx, adminprovision.ProvisionInput{
+	result, err := s.provisioner.Ensure(ctx, adminprovision.ProvisionInput{
 		Username:     in.Username,
 		Email:        in.Email,
 		PasswordHash: hash,
@@ -237,24 +237,24 @@ func (s *Service) provisionAndMaybeEmit(ctx context.Context, in CreateAdminInput
 	if err != nil {
 		return nil, fmt.Errorf("setup: ensure admin: %w", err)
 	}
-	switch outcome {
+	switch result.Outcome {
 	case adminprovision.OutcomeAlreadyExists, adminprovision.OutcomeRaceSkipped:
 		return nil, setupRetiredError()
 	case adminprovision.OutcomeCreated:
-		if err := s.publishUserCreated(ctx, user); err != nil {
+		if err := s.publishUserCreated(ctx, result.User); err != nil {
 			return nil, err
 		}
 	case adminprovision.OutcomeOrphanRecovered:
 		s.logger.Warn("setup: orphan user recovered; emitting user.created",
 			slog.String("event", "setup_orphan_recover"),
-			slog.String("user_id", user.ID))
-		if err := s.publishUserCreated(ctx, user); err != nil {
+			slog.String("user_id", result.User.ID))
+		if err := s.publishUserCreated(ctx, result.User); err != nil {
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("setup: unexpected provision outcome %d", outcome)
+		return nil, fmt.Errorf("setup: unexpected provision outcome %d", result.Outcome)
 	}
-	return user, nil
+	return result.User, nil
 }
 
 // setupRetiredError is returned when the first-run admin already exists. It

--- a/cells/accesscore/slices/setup/service_test.go
+++ b/cells/accesscore/slices/setup/service_test.go
@@ -508,7 +508,7 @@ func (r *countErrRoleRepo) RemoveFromUserIfNotLast(_ context.Context, _, _ strin
 	return true, nil
 }
 func (r *countErrRoleRepo) GetByID(_ context.Context, _ string) (*domain.Role, error) {
-	return nil, nil
+	return &domain.Role{ID: domain.RoleAdmin}, nil
 }
 func (r *countErrRoleRepo) ListByUserID(_ context.Context, _ string, _ query.ListParams) ([]*domain.Role, error) {
 	return nil, nil

--- a/cells/auditcore/cell_test.go
+++ b/cells/auditcore/cell_test.go
@@ -335,7 +335,7 @@ func TestAuditCore_RouteQueryEntries(t *testing.T) {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		r.Route(rg.Prefix, func(sub cell.RouteMux) { rg.Register(sub) })
 	}
@@ -429,7 +429,7 @@ func TestAuditCore_Wiring_StaleCursor_DemoVsDurable(t *testing.T) {
 				DurabilityMode: tc.mode,
 			}))
 
-			r := router.New()
+			r := router.MustNew()
 			for _, rg := range c.RouteGroups() {
 				r.Route(rg.Prefix, func(sub cell.RouteMux) { rg.Register(sub) })
 			}

--- a/cells/configcore/cell_test.go
+++ b/cells/configcore/cell_test.go
@@ -280,7 +280,7 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Prefix != "" {
 			r.Route(rg.Prefix, func(sub cell.RouteMux) { rg.Register(sub) })
@@ -473,7 +473,7 @@ func TestConfigCore_CrossSliceCursorRejection_Reverse(t *testing.T) {
 	deps := cell.Dependencies{Config: make(map[string]any), DurabilityMode: cell.DurabilityDemo}
 	require.NoError(t, c.Init(ctx, deps))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Prefix != "" {
 			r.Route(rg.Prefix, func(sub cell.RouteMux) { rg.Register(sub) })

--- a/cmd/corebundle/app_test.go
+++ b/cmd/corebundle/app_test.go
@@ -130,14 +130,15 @@ func TestBuildApp_EmptyModuleList(t *testing.T) {
 	assert.Empty(t, opts)
 }
 
-// nilCellModule is a CellModule whose Provide always returns (nil, nil, nil, nil).
+// nilCellModule is a CellModule whose Provide always returns a nil Cell.
 // It is used to test that BuildApp rejects nil Cell returns as a fail-fast error.
 type nilCellModule struct{}
 
 func (m nilCellModule) ID() string { return "nil-cell-module" }
 
 func (m nilCellModule) Provide(_ context.Context, _ *SharedDeps) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
-	return nil, nil, nil, nil
+	var nilCell cell.Cell
+	return nilCell, []bootstrap.Option{}, []kernellifecycle.ManagedResource{}, nil
 }
 
 var _ CellModule = nilCellModule{}

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -221,16 +221,18 @@ func keyProviderToTransformer(kp kcrypto.KeyProvider) kcrypto.ValueTransformer {
 
 type noKeyProvider struct{}
 
+const noKeyProviderConfiguredMessage = "configcore: no key provider configured"
+
 func (noKeyProvider) Current(context.Context) (kcrypto.KeyHandle, error) {
-	return nil, errcode.New(errcode.ErrConfigKeyMissing, "configcore: no key provider configured")
+	return nil, errcode.New(errcode.ErrConfigKeyMissing, noKeyProviderConfiguredMessage)
 }
 
 func (noKeyProvider) ByID(context.Context, string) (kcrypto.KeyHandle, error) {
-	return nil, errcode.New(errcode.ErrConfigKeyMissing, "configcore: no key provider configured")
+	return nil, errcode.New(errcode.ErrConfigKeyMissing, noKeyProviderConfiguredMessage)
 }
 
 func (noKeyProvider) Rotate(context.Context) (string, error) {
-	return "", errcode.New(errcode.ErrConfigKeyMissing, "configcore: no key provider configured")
+	return "", errcode.New(errcode.ErrConfigKeyMissing, noKeyProviderConfiguredMessage)
 }
 
 func isNoKeyProvider(kp kcrypto.KeyProvider) bool {

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -146,8 +146,8 @@ func buildInternalAuthChain(guard *internalGuard) []cell.ListenerAuth {
 // masterKey, and prevMasterKey (all pre-read from per-cell env by the caller).
 //
 // Supported providerName values: "local-aes", "vault-transit".
-// In memory mode (empty providerName) nil is returned (no encryption;
-// NoopTransformer via keyProviderToTransformer).
+// In memory mode (empty providerName) a no-key sentinel is returned (no
+// encryption; NoopTransformer via keyProviderToTransformer).
 // In postgres mode (empty providerName) the function fails-fast: sensitive-value
 // encryption is a production security invariant; silently wiring NoopTransformer
 // would defeat the stated threat model (see docs/architecture/202604191800-adr-config-value-encryption.md).
@@ -174,7 +174,7 @@ func buildKeyProvider(storageBackend, adapterMode, providerName, masterKey, prev
 					"Silent NoopTransformer fallback is disabled because it would persist "+
 					"sensitive values unencrypted.")
 		}
-		return nil, nil
+		return noKeyProvider{}, nil
 	}
 	switch providerName {
 	case "local-aes":
@@ -210,12 +210,32 @@ func buildKeyProvider(storageBackend, adapterMode, providerName, masterKey, prev
 }
 
 // keyProviderToTransformer wraps a KeyProvider in a ValueTransformer.
-// When kp is nil (no encryption configured), returns NoopTransformer.
+// When kp is nil or the no-key sentinel (no encryption configured), returns
+// NoopTransformer.
 func keyProviderToTransformer(kp kcrypto.KeyProvider) kcrypto.ValueTransformer {
-	if kp == nil {
+	if kp == nil || isNoKeyProvider(kp) {
 		return crypto.NoopTransformer{}
 	}
 	return crypto.NewValueTransformer(kp)
+}
+
+type noKeyProvider struct{}
+
+func (noKeyProvider) Current(context.Context) (kcrypto.KeyHandle, error) {
+	return nil, errcode.New(errcode.ErrConfigKeyMissing, "configcore: no key provider configured")
+}
+
+func (noKeyProvider) ByID(context.Context, string) (kcrypto.KeyHandle, error) {
+	return nil, errcode.New(errcode.ErrConfigKeyMissing, "configcore: no key provider configured")
+}
+
+func (noKeyProvider) Rotate(context.Context) (string, error) {
+	return "", errcode.New(errcode.ErrConfigKeyMissing, "configcore: no key provider configured")
+}
+
+func isNoKeyProvider(kp kcrypto.KeyProvider) bool {
+	_, ok := kp.(noKeyProvider)
+	return ok
 }
 
 // ConfigCoreModuleConfig bundles the inputs for buildConfigCoreOpts so that

--- a/cmd/corebundle/key_provider_test.go
+++ b/cmd/corebundle/key_provider_test.go
@@ -16,13 +16,13 @@ const validMasterKeyHex = "aabbccddeeff00112233445566778899aabbccddeeff001122334
 // demoMasterKeyHex is the well-known demo key shipped in test fixtures.
 const demoMasterKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-// TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNil verifies that in memory
-// storage mode, an empty providerName leads to nil (which the caller
-// maps to NoopTransformer). No encryption is required for in-memory storage.
-func TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNil(t *testing.T) {
+// TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNoKey verifies that in memory
+// storage mode, an empty providerName leads to the no-key sentinel (which the
+// caller maps to NoopTransformer). No encryption is required for in-memory storage.
+func TestBuildKeyProvider_MemoryMode_NoEnv_ReturnsNoKey(t *testing.T) {
 	kp, err := buildKeyProvider("memory", "", "", "", "")
 	require.NoError(t, err)
-	assert.Nil(t, kp, "memory mode + empty provider should return nil (no provider)")
+	assert.True(t, isNoKeyProvider(kp), "memory mode + empty provider should return no-key sentinel")
 }
 
 // TestBuildKeyProvider_PostgresMode_NoEnv_FailsFast verifies that postgres

--- a/cmd/corebundle/redis.go
+++ b/cmd/corebundle/redis.go
@@ -24,6 +24,10 @@ type redisNonceStoreFactory func(*adapterredis.Client, time.Duration) (auth.Nonc
 type redisConsumerClaimerFactory func(*adapterredis.Client) idempotency.Claimer
 type redisClientFactory func(context.Context, adapterredis.Config) (*adapterredis.Client, error)
 
+type redisClientResult struct {
+	Client *adapterredis.Client
+}
+
 var (
 	newRedisClient     redisClientFactory     = adapterredis.NewClient
 	newRedisNonceStore redisNonceStoreFactory = func(client *adapterredis.Client, ttl time.Duration) (auth.NonceStore, error) {
@@ -74,19 +78,19 @@ func loadRedisConfigFromEnv(topo bootstrap.Topology) (adapterredis.Config, bool,
 	}, true, nil
 }
 
-func buildRedisClient(ctx context.Context, topo bootstrap.Topology) (*adapterredis.Client, error) {
+func buildRedisClient(ctx context.Context, topo bootstrap.Topology) (redisClientResult, error) {
 	cfg, configured, err := loadRedisConfigFromEnv(topo)
 	if err != nil {
-		return nil, err
+		return redisClientResult{}, err
 	}
 	if !configured {
-		return nil, nil
+		return redisClientResult{}, nil
 	}
 	client, err := newRedisClient(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("build Redis client: %w", err)
+		return redisClientResult{}, fmt.Errorf("build Redis client: %w", err)
 	}
-	return client, nil
+	return redisClientResult{Client: client}, nil
 }
 
 func buildServiceNonceStore(topo bootstrap.Topology, client *adapterredis.Client) (auth.NonceStore, error) {

--- a/cmd/corebundle/redis_test.go
+++ b/cmd/corebundle/redis_test.go
@@ -95,10 +95,10 @@ func TestLoadRedisConfigFromEnv_InvalidDBFailFast(t *testing.T) {
 func TestBuildRedisClient_NotConfiguredReturnsNil(t *testing.T) {
 	t.Setenv(envRedisAddr, "")
 
-	client, err := buildRedisClient(context.Background(), bootstrap.Topology{AdapterMode: "dev"})
+	result, err := buildRedisClient(context.Background(), bootstrap.Topology{AdapterMode: "dev"})
 
 	require.NoError(t, err)
-	assert.Nil(t, client)
+	assert.Nil(t, result.Client)
 }
 
 func TestBuildRedisClient_UsesConfiguredFactory(t *testing.T) {
@@ -111,9 +111,10 @@ func TestBuildRedisClient_UsesConfiguredFactory(t *testing.T) {
 		return new(adapterredis.Client), nil
 	})
 
-	client, err := buildRedisClient(context.Background(), bootstrap.Topology{AdapterMode: "dev"})
+	result, err := buildRedisClient(context.Background(), bootstrap.Topology{AdapterMode: "dev"})
 
 	require.NoError(t, err)
+	client := result.Client
 	require.NotNil(t, client)
 	assert.Equal(t, "redis:6379", gotCfg.Addr)
 	assert.Equal(t, "secret", gotCfg.Password)
@@ -126,10 +127,10 @@ func TestBuildRedisClient_FactoryErrorWrapped(t *testing.T) {
 		return nil, errRedisTestFactory
 	})
 
-	client, err := buildRedisClient(context.Background(), bootstrap.Topology{AdapterMode: "dev"})
+	result, err := buildRedisClient(context.Background(), bootstrap.Topology{AdapterMode: "dev"})
 
 	require.Error(t, err)
-	assert.Nil(t, client)
+	assert.Nil(t, result.Client)
 	assert.ErrorIs(t, err, errRedisTestFactory)
 	assert.Contains(t, err.Error(), "build Redis client")
 }
@@ -273,5 +274,5 @@ func (fakeDistributedNonceStore) Kind() auth.NonceStoreKind {
 type fakeDistributedClaimer struct{}
 
 func (fakeDistributedClaimer) Claim(context.Context, string, time.Duration, time.Duration) (idempotency.ClaimState, idempotency.Receipt, error) {
-	return idempotency.ClaimDone, nil, nil
+	return idempotency.ClaimDone, idempotency.NonAcquiredReceipt(), nil
 }

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -133,10 +133,11 @@ type sharedReplayDeps struct {
 }
 
 func buildSharedReplayDeps(ctx context.Context, topo bootstrap.Topology) (sharedReplayDeps, error) {
-	redisClient, err := buildRedisClient(ctx, topo)
+	redisResult, err := buildRedisClient(ctx, topo)
 	if err != nil {
 		return sharedReplayDeps{}, err
 	}
+	redisClient := redisResult.Client
 	loaded := false
 	defer func() {
 		if !loaded {

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -62,15 +62,16 @@ cancellation. Modelled as `kworker.ErrWorkerExitedEarly` so callers can
 `errors.Is`-detect the abnormal signal — not strictly part of the panic
 refactor, but bundled for the same "fail loudly, propagate errors" theme.
 
-### 4. Hardcoded ADR-pinned whitelist (1 file)
+### 4. Hardcoded ADR-pinned whitelist (2 functions)
 
-The archtest holds **one** file-level whitelist entry. Every other panic
-in the scoped files is either refactored, renamed, or in an `init()`
-function (auto-exempt).
+The archtest holds **two** function-level whitelist entries. Every other panic
+in the scoped files is either refactored, renamed, or in an `init()` function
+(auto-exempt).
 
-| # | File | Justification |
+| # | Function | Justification |
 |---|---|---|
-| 1 | `kernel/wrapper/lifecycle.go` | `recoverAndFinishWithRedactor` is the middle of a `defer recover()` chain that re-panics so the outer `runtime/http/middleware.Recovery` middleware can record + serialize the panic. Refactoring it to return error would dismantle the entire recover propagation idiom and force every wrapped consumer to pre-route panics through a synthetic error path before Go's runtime gets the chance. |
+| 1 | `kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor` | Middle of a `defer recover()` chain that re-panics so the outer `runtime/http/middleware.Recovery` middleware can record + serialize the panic. Refactoring it to return error would dismantle the entire recover propagation idiom and force every wrapped consumer to pre-route panics through a synthetic error path before Go's runtime gets the chance. |
+| 2 | `runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure` | Middle of a `defer recover()` chain that first reports the handler panic as a circuit-breaker failure, then re-panics so the outer `Recovery` middleware remains the single panic-to-HTTP and panic-to-tracing boundary. Swallowing the panic here would bypass `Recovery` and lose panic span recording in the normal router chain. |
 
 ### 5. Auto-exempt categories
 
@@ -87,8 +88,10 @@ function (auto-exempt).
 
 ### 6. PR-MODE-6.1 scope expansion
 
-PR-MODE-6.1 closes the remaining nil/error-first candidates without adding
-an architectural whitelist entry:
+PR-MODE-6.1 closes the remaining nil/error-first candidates without adding a
+router whitelist entry. It adds one narrow circuit-breaker re-panic whitelist
+after review found that swallowing handler panics before `Recovery` regressed
+tracing semantics.
 
 - `.golangci.yml` enables `nilerr`, `nilnesserr`, and `nilnil` with
   `nilnil.only-two: false`, so multi-return success sentinels like
@@ -149,20 +152,20 @@ that construct a single static `cell.NewAuthJWTFromAssembly(asm)` continue
 to write `cell.MustNewAuthJWTFromAssembly(asm)` with no error-handling
 boilerplate.
 
-### Why minimum (1) whitelist?
+### Why minimum (2) whitelist?
 
 Each whitelist entry is a future regression risk: a new contributor sees
 "there are some panics here, panicking must be OK" and adds another. The
 review loop catches new architectural panic claims via the ADR, not via
-the archtest list. By keeping the whitelist to **just** the
-defer-recover-re-panic case (which is structurally not refactorable), we
-maximize the "panic in error-less function = bug" signal.
+the archtest list. By keeping the whitelist to **only** defer-recover-re-panic
+helpers (which are structurally not refactorable to error returns), we maximize
+the "panic in error-less function = bug" signal.
 
 The previous design (5 entries) was rejected: outbox crypto/rand failures
 and envelope marshal invariants were absorbable as either error
 propagation (entry_id, idempotency) or `Must*` rename (envelope), so they
 moved out of the whitelist. PR-MODE-6.1 also rejected adding the HTTP router
-as a second whitelist entry: router construction, auth metadata declaration,
+as a whitelist entry: router construction, auth metadata declaration,
 and unfinalized auth state now surface through errors or fail-closed HTTP
 responses, while `MustNew` remains the explicit panic wrapper for static
 wiring.
@@ -172,8 +175,9 @@ wiring.
 Hardcoded in `tools/archtest/error_first_test.go`:
 
 ```go
-var errorFirstWhitelistedFiles = map[string]string{
-    "kernel/wrapper/lifecycle.go": "recoverAndFinishWithRedactor re-panics from defer recover",
+var errorFirstWhitelistedFunctions = map[string]string{
+    "kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor": "re-panics from defer recover so outer Recovery middleware can serialize the panic",
+    "runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure": "re-panics from defer recover after reporting circuit-breaker failure",
 }
 ```
 

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -93,6 +93,10 @@ an architectural whitelist entry:
 - `.golangci.yml` enables `nilerr`, `nilnesserr`, and `nilnil` with
   `nilnil.only-two: false`, so multi-return success sentinels like
   `nil, ..., nil` are rejected.
+- `tools/archtest/error_first_test.go` adds `ERROR-FIRST-TYPED-NIL-01`:
+  enrolled error-first constructors with interface dependencies must validate
+  those dependencies through `validation.IsNilInterface(param)`, not only
+  `param == nil`.
 - `runtime/distlock/locker.go::New`,
   `runtime/auth/refresh/memstore/store.go::New`, and the accesscore
   session login/refresh/logout `NewService` constructors now return
@@ -107,7 +111,8 @@ an architectural whitelist entry:
   instead of panicking. No router whitelist entry was added.
 - `kernel/persistence.NoopTxRunner.RunInTx(nil)`,
   `command.ActiveScanner.GetCommand` not-found handling,
-  `adminprovision.Ensure`, initial-admin cleanup, governance helpers,
+  `adminprovision.Ensure`, initial-admin cleanup (including exact custom
+  credential-path sweep), governance helpers,
   archtest AST helpers, and `tools/nogo/unconditionalskip` were adjusted so
   nil no longer encodes success or silently hides parse/walk failures.
 
@@ -209,8 +214,9 @@ Completed in PR-MODE-6.1:
   without adding a router whitelist entry.
 - `cells/accesscore/slices/sessionlogin/service.go::NewService`,
   `sessionrefresh/service.go::NewService`, and
-  `sessionlogout/service.go::NewService` — nil dependency checks now return
-  errors with `MustNewService` wrappers.
+  `sessionlogout/service.go::NewService` — nil and typed-nil dependency
+  checks now return errors with `MustNewService` wrappers, enforced by
+  `ERROR-FIRST-TYPED-NIL-01`.
 
 Remaining watchlist:
 

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -3,6 +3,7 @@
 > Date: 2026-04-27
 > Status: Accepted
 > Context PR: PR-MODE-6 ERROR-FIRST-API (refactor/555-pr-mode-6-error-first-api)
+> Scope update: PR-MODE-6.1 Nil / Error-First full cleanup
 > Tag: ERROR-FIRST-API-01
 
 ## Context
@@ -20,8 +21,8 @@ crash dumps for what should be structured 4xx/5xx responses.
 PR-MODE-6 introduces the `tools/archtest/error_first_test.go::TestErrorFirstAPI01`
 rule: **error-less function declarations in the enrolled file scope MUST NOT
 contain `panic(...)` calls**. Auto-exemptions: `Must*`-prefixed names and
-`func init()`. The rule scans 13 enrolled files (the parent plan's PR-MODE-6
-scope). Future PRs may extend the scope; the path forward is in §Roadmap.
+`func init()`. PR-MODE-6.1 expands the rule to 23 enrolled files, including
+the remaining nil/error-first roadmap files and `runtime/http/router/router.go`.
 
 ## Decision
 
@@ -84,6 +85,32 @@ function (auto-exempt).
   violations are by definition fatal. Example: `adapters/postgres/embed.go`
   embedded migrations subdir loading.
 
+### 6. PR-MODE-6.1 scope expansion
+
+PR-MODE-6.1 closes the remaining nil/error-first candidates without adding
+an architectural whitelist entry:
+
+- `.golangci.yml` enables `nilerr`, `nilnesserr`, and `nilnil` with
+  `nilnil.only-two: false`, so multi-return success sentinels like
+  `nil, ..., nil` are rejected.
+- `runtime/distlock/locker.go::New`,
+  `runtime/auth/refresh/memstore/store.go::New`, and the accesscore
+  session login/refresh/logout `NewService` constructors now return
+  `(..., error)` with `Must*` wrappers for static wiring and test setup.
+- `runtime/http/middleware/circuit_breaker.go::CircuitBreaker`,
+  `runtime/http/health/health.go::RegisterChecker`, and
+  `runtime/http/router/router.go::New` / `NewForListener` return errors
+  for nil, typed-nil, duplicate, and invalid configuration paths.
+- `runtime/http/router/router.go` is now in the archtest scope. Auth metadata
+  declaration returns errors, `auth.Mount` propagates them, and a router with
+  declared auth metadata but missing `FinalizeAuth` fails closed with HTTP 500
+  instead of panicking. No router whitelist entry was added.
+- `kernel/persistence.NoopTxRunner.RunInTx(nil)`,
+  `command.ActiveScanner.GetCommand` not-found handling,
+  `adminprovision.Ensure`, initial-admin cleanup, governance helpers,
+  archtest AST helpers, and `tools/nogo/unconditionalskip` were adjusted so
+  nil no longer encodes success or silently hides parse/walk failures.
+
 ## Rationale
 
 ### Why error-first over Must-renaming for 28+ sites?
@@ -129,11 +156,11 @@ maximize the "panic in error-less function = bug" signal.
 The previous design (5 entries) was rejected: outbox crypto/rand failures
 and envelope marshal invariants were absorbable as either error
 propagation (entry_id, idempotency) or `Must*` rename (envelope), so they
-moved out of the whitelist. The HTTP router state machine (`runtime/http/router/router.go`,
-5 panics across `FinalizeAuth`/`Mount`/state transitions) is **out of
-scope for the archtest**: that file is not in the enrolled list yet.
-PR-MODE-6.1 (scope expansion) may add it later, alongside a router refactor
-or its own whitelist entry.
+moved out of the whitelist. PR-MODE-6.1 also rejected adding the HTTP router
+as a second whitelist entry: router construction, auth metadata declaration,
+and unfinalized auth state now surface through errors or fail-closed HTTP
+responses, while `MustNew` remains the explicit panic wrapper for static
+wiring.
 
 ### Whitelist mechanics
 
@@ -166,32 +193,30 @@ absorbable as `Must*` rename or error propagation.
 
 ## Roadmap
 
-Future PR-MODE-6.1 candidates for archtest scope expansion (each costs
-its own refactor + propagation pass):
+Completed in PR-MODE-6.1:
 
-- `kernel/persistence/tx.go::RunInTx` — single panic on nil fn, easy
-  refactor to error.
+- `kernel/persistence/tx.go::RunInTx` — nil callback now returns an explicit
+  error.
+- `runtime/distlock/locker.go::New` — config validation now returns error
+  with `MustNew` for static wiring.
+- `runtime/auth/refresh/memstore/store.go::New` — policy/clock/random source
+  validation now returns error with `MustNew`.
+- `runtime/http/middleware/circuit_breaker.go` — nil and typed-nil Allower
+  validation now returns error with `MustCircuitBreaker`.
+- `runtime/http/health/health.go::RegisterChecker` — nil checker and
+  duplicate-name validation now return error with `MustRegisterChecker`.
+- `runtime/http/router/router.go` — added to archtest scope and refactored
+  without adding a router whitelist entry.
+- `cells/accesscore/slices/sessionlogin/service.go::NewService`,
+  `sessionrefresh/service.go::NewService`, and
+  `sessionlogout/service.go::NewService` — nil dependency checks now return
+  errors with `MustNewService` wrappers.
+
+Remaining watchlist:
+
 - `kernel/observability/metrics/metrics.go` — already auto-exempt via
   `MustRegister` prefix, but worth confirming the pattern holds when new
   metrics are added.
-- `runtime/distlock/locker.go::New` — 5 config-validation panics; refactor
-  + propagation to `cmd/corebundle` distlock wiring.
-- `runtime/auth/refresh/memstore/store.go::New` — 3 config-validation
-  panics; analogue of `adapters/postgres/refresh_store.go`.
-- `runtime/http/middleware/circuit_breaker.go` — Allower nil check + re-panic.
-- `runtime/http/health/health.go::Register` — nil-checker / duplicate-name
-  panics.
-- `runtime/http/router/router.go` — state-machine post-conditions (5 sites:
-  lines 128/345/415/581/593). **Decision pending PR-MODE-6.1**: the most
-  likely outcome is to whitelist as architectural (these are internal
-  invariants validated upstream by `auth.Mount`, not caller-facing
-  preconditions), bringing the whitelist count from 1 → 2. Alternative is
-  a `FinalizeAuth` API refactor that bubbles the invariant errors to
-  bootstrap; rejected for this PR because the panic semantics already
-  match `auth.Mount`'s contract (startup-fatal). Track via PR-MODE-6.1
-  scope expansion, not as ad-hoc backlog.
-- `cells/accesscore/slices/sessionlogin/service.go::NewService` — 7 nil-check
-  panics; the cells-layer first foothold for the rule.
 
 Order suggestion: each PR adds 1-3 files to `errorFirstEnforcedFiles`
 in the archtest, refactors the corresponding panics, and updates this
@@ -208,3 +233,6 @@ ADR's §Roadmap to mark the file done.
   the `MustNewEntryID` decision.
 - `Must*` convention: `regexp.MustCompile`, `template.Must`,
   `kubernetes/client-go MustGetSelfLink`.
+- Go `nilness` analyzer; `golangci-lint` `nilnil` settings.
+- Kratos middleware constructors and Kubernetes client-go resourcelock
+  constructor error patterns.

--- a/examples/iotdevice/cells/devicecell/cell_test.go
+++ b/examples/iotdevice/cells/devicecell/cell_test.go
@@ -165,7 +165,7 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	}
 	require.NoError(t, c.Init(ctx, deps))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Listener == cell.PrimaryListener {
 			if rg.Prefix != "" {

--- a/examples/iotdevice/cells/devicecell/slices/devicecommand/handler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommand/handler.go
@@ -284,12 +284,6 @@ func (h *Handler) writeCommand(w http.ResponseWriter, r *http.Request, cmdID str
 		httputil.WriteDomainError(r.Context(), w, err)
 		return
 	}
-	if entry == nil {
-		httputil.WriteError(r.Context(), w, http.StatusInternalServerError,
-			string(errcode.ErrInternal),
-			"devicecommand: ack succeeded but entry not found")
-		return
-	}
 
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": toCommandResponse(*entry)})
 }

--- a/examples/iotdevice/cells/devicecell/slices/devicecommand/service.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommand/service.go
@@ -298,10 +298,6 @@ func (s *Service) getOwnedCommand(ctx context.Context, deviceID, cmdID string) (
 	if err != nil {
 		return nil, fmt.Errorf("device-command: get command: %w", err)
 	}
-	if e == nil {
-		return nil, errcode.New(errcode.ErrCommandNotFound,
-			fmt.Sprintf("device-command: command %q not found", cmdID))
-	}
 
 	if e.DeviceID != deviceID {
 		return nil, errcode.New(errcode.ErrAuthForbidden,

--- a/examples/ssobff/walkthrough_test.go
+++ b/examples/ssobff/walkthrough_test.go
@@ -260,7 +260,7 @@ func buildWalkthroughServer(t *testing.T, stateDir string, capHandler *capturing
 	// here too — auth.MustMount(Public:true) on /internal paths still works because
 	// the matcher fires before AuthMiddleware and the test never exercises a
 	// JWT-only internal route.
-	r := router.New(
+	r := router.MustNew(
 		router.WithAuthMiddleware(ac.TokenVerifier()),
 	)
 	mountAllRouteGroups(r, ac, auc, cc)

--- a/examples/todoorder/cells/ordercell/cell_test.go
+++ b/examples/todoorder/cells/ordercell/cell_test.go
@@ -258,7 +258,7 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	ctx := context.Background()
 	require.NoError(t, c.Init(ctx, newTestDeps()))
 
-	r := router.New()
+	r := router.MustNew()
 	for _, rg := range c.RouteGroups() {
 		if rg.Listener == cell.PrimaryListener {
 			if rg.Prefix != "" {

--- a/kernel/cell/celltest/mux.go
+++ b/kernel/cell/celltest/mux.go
@@ -70,11 +70,12 @@ func (m *TestMux) Prefix() string {
 
 // DeclareAuthMeta records an auth route declaration.
 // Sub-muxes compose their prefix with meta.Path before forwarding to root.
-func (m *TestMux) DeclareAuthMeta(meta cell.AuthRouteMeta) {
+func (m *TestMux) DeclareAuthMeta(meta cell.AuthRouteMeta) error {
 	if m.prefix != "" {
 		meta.Path = path.Clean(m.prefix + meta.Path)
 	}
 	m.root.authMetas = append(m.root.authMetas, meta)
+	return nil
 }
 
 // DeclaredAuthMetas returns a copy of all auth metadata recorded on this root

--- a/kernel/cell/registrar.go
+++ b/kernel/cell/registrar.go
@@ -170,7 +170,7 @@ func (m AuthRouteMeta) IsInternal() bool {
 // This keeps kernel/cell free of runtime/auth dependencies while still
 // letting the Router and TestMux aggregate per-route auth context.
 type AuthRouteDeclarer interface {
-	DeclareAuthMeta(meta AuthRouteMeta)
+	DeclareAuthMeta(meta AuthRouteMeta) error
 }
 
 // HTTPContractDeclarer is implemented by aggregators that want to receive the
@@ -178,7 +178,7 @@ type AuthRouteDeclarer interface {
 // this metadata when available so outer runtime middleware can annotate spans
 // even when pre-handler middleware short-circuits before wrapper.HTTPHandler.
 type HTTPContractDeclarer interface {
-	DeclareHTTPContract(spec wrapper.ContractSpec)
+	DeclareHTTPContract(spec wrapper.ContractSpec) error
 }
 
 // EventRouter declares event subscriptions. Cells call AddContractHandler

--- a/kernel/cell/registrar_test.go
+++ b/kernel/cell/registrar_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -413,8 +414,9 @@ type collectingDeclarer struct {
 	metas []AuthRouteMeta
 }
 
-func (c *collectingDeclarer) DeclareAuthMeta(m AuthRouteMeta) {
+func (c *collectingDeclarer) DeclareAuthMeta(m AuthRouteMeta) error {
 	c.metas = append(c.metas, m)
+	return nil
 }
 
 var _ AuthRouteDeclarer = (*collectingDeclarer)(nil)
@@ -520,8 +522,8 @@ func TestAuthRouteDeclarer_InterfaceAssertion(t *testing.T) {
 
 	// The collecting stub satisfies the interface.
 	var d AuthRouteDeclarer = &collectingDeclarer{}
-	d.DeclareAuthMeta(AuthRouteMeta{Method: "POST", Path: "/x", Public: true})
-	d.DeclareAuthMeta(AuthRouteMeta{Method: "GET", Path: "/y"})
+	require.NoError(t, d.DeclareAuthMeta(AuthRouteMeta{Method: "POST", Path: "/x", Public: true}))
+	require.NoError(t, d.DeclareAuthMeta(AuthRouteMeta{Method: "GET", Path: "/y"}))
 
 	got := d.(*collectingDeclarer).metas
 	assert.Len(t, got, 2)

--- a/kernel/command/commandtest/inmem.go
+++ b/kernel/command/commandtest/inmem.go
@@ -339,7 +339,7 @@ func (q *InMemQueue) GetCommand(_ context.Context, id string) (*command.Entry, e
 
 	e, ok := q.entries[id]
 	if !ok {
-		return nil, nil
+		return nil, errcode.NewDomain(errcode.ErrCommandNotFound, "commandtest: command not found: "+id)
 	}
 	cp := *e
 	return &cp, nil

--- a/kernel/command/commandtest/inmem_test.go
+++ b/kernel/command/commandtest/inmem_test.go
@@ -546,8 +546,11 @@ func TestInMemQueue_GetCommand_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	got, err := q.GetCommand(ctx, "cmd-nonexistent")
-	require.NoError(t, err)
-	assert.Nil(t, got, "GetCommand on missing id must return (nil, nil)")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, errcode.ErrCommandNotFound, ecErr.Code)
 }
 
 func TestInMemQueue_ScanActive_Filtering(t *testing.T) {

--- a/kernel/command/ports.go
+++ b/kernel/command/ports.go
@@ -40,6 +40,6 @@ type ActiveScanner interface {
 	// CreatedAt ascending (FIFO). Implementations MAY impose an adapter-level
 	// result cap but MUST document it.
 	ScanActive(ctx context.Context, filter ScanFilter) ([]Entry, error)
-	// GetCommand returns a single command by ID. Returns (nil, nil) when not found.
+	// GetCommand returns a single command by ID. Returns ErrCommandNotFound when not found.
 	GetCommand(ctx context.Context, id string) (*Entry, error)
 }

--- a/kernel/command/ports_test.go
+++ b/kernel/command/ports_test.go
@@ -21,7 +21,7 @@ func (m *mockActiveScanner) ScanActive(_ context.Context, _ ScanFilter) ([]Entry
 	return nil, nil
 }
 func (m *mockActiveScanner) GetCommand(_ context.Context, _ string) (*Entry, error) {
-	return nil, nil
+	return &Entry{}, nil
 }
 
 var _ ActiveScanner = (*mockActiveScanner)(nil)

--- a/kernel/command/sweeper_test.go
+++ b/kernel/command/sweeper_test.go
@@ -209,7 +209,7 @@ func (r *mockScanner) ScanActive(_ context.Context, filter command.ScanFilter) (
 }
 
 func (r *mockScanner) GetCommand(_ context.Context, _ string) (*command.Entry, error) {
-	return nil, nil
+	return &command.Entry{}, nil
 }
 
 // mockAckQueue records Queue.Ack calls; other Queue methods are unused in

--- a/kernel/crypto/key_provider_test.go
+++ b/kernel/crypto/key_provider_test.go
@@ -14,9 +14,11 @@ import (
 // fakeProvider is a minimal KeyProvider for compile-time assertions only.
 type fakeProvider struct{}
 
-func (fakeProvider) Current(_ context.Context) (kcrypto.KeyHandle, error)        { return nil, nil }
-func (fakeProvider) ByID(_ context.Context, _ string) (kcrypto.KeyHandle, error) { return nil, nil }
-func (fakeProvider) Rotate(_ context.Context) (string, error)                    { return "", nil }
+func (fakeProvider) Current(_ context.Context) (kcrypto.KeyHandle, error) { return fakeHandle{}, nil }
+func (fakeProvider) ByID(_ context.Context, _ string) (kcrypto.KeyHandle, error) {
+	return fakeHandle{}, nil
+}
+func (fakeProvider) Rotate(_ context.Context) (string, error) { return "", nil }
 
 // fakeHandle is a minimal KeyHandle for compile-time assertions only.
 type fakeHandle struct{}

--- a/kernel/governance/rules_consistency.go
+++ b/kernel/governance/rules_consistency.go
@@ -359,14 +359,26 @@ func scanSliceEmitTopics(root string, ref sliceRef, fileForError string) (map[st
 	var results []ValidationResult
 
 	cellDir := filepath.Join(root, "cells", ref.cellID)
-	pkgConsts := buildPkgConsts(cellDir)
+	pkgConsts, constResults := buildPkgConsts(cellDir, fileForError)
+	results = append(results, constResults...)
 	sliceDir := filepath.Join(root, filepath.FromSlash(ref.dir))
 	if _, err := os.Stat(sliceDir); err != nil {
 		return topics, results
 	}
 
 	fset := token.NewFileSet()
-	allFiles := collectParsedFiles(fset, sliceDir)
+	allFiles, err := collectParsedFiles(fset, sliceDir)
+	if err != nil {
+		results = append(results, ValidationResult{
+			Code:      codeContractConsistencyEmit01,
+			Severity:  SeverityError,
+			IssueType: IssueInvalid,
+			File:      fileForError,
+			Field:     "triggers",
+			Message:   fmt.Sprintf("cannot scan emitted topics in %s/%s: %v", ref.cellID, ref.sliceID, err),
+		})
+		return topics, results
+	}
 	helperMap := buildHelperEmitMap(allFiles, pkgConsts)
 
 	for _, f := range allFiles {
@@ -386,11 +398,11 @@ type parsedFile struct {
 
 // collectParsedFiles walks slicesDir and parses all non-test Go files,
 // returning their ASTs paired with file-level const maps.
-func collectParsedFiles(fset *token.FileSet, slicesDir string) []parsedFile {
+func collectParsedFiles(fset *token.FileSet, slicesDir string) ([]parsedFile, error) {
 	var files []parsedFile
-	_ = filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(slicesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil
+			return err
 		}
 		if d.IsDir() {
 			if n := d.Name(); n == "mem" || n == "testdata" {
@@ -403,7 +415,7 @@ func collectParsedFiles(fset *token.FileSet, slicesDir string) []parsedFile {
 		}
 		f, parseErr := parser.ParseFile(fset, path, nil, 0)
 		if parseErr != nil {
-			return nil
+			return parseErr
 		}
 		files = append(files, parsedFile{
 			ast:         f,
@@ -413,7 +425,7 @@ func collectParsedFiles(fset *token.FileSet, slicesDir string) []parsedFile {
 		})
 		return nil
 	})
-	return files
+	return files, err
 }
 
 // helperEmitFunc describes a same-package helper function whose body contains a
@@ -1238,8 +1250,9 @@ func dynamicTopicResult(expr ast.Expr, fset *token.FileSet, root, message string
 
 // buildPkgConsts scans internal/dto and internal/domain under cellDir
 // for string constants and returns a map of pkgIdent → constName → stringValue.
-func buildPkgConsts(cellDir string) cellPkgConsts {
+func buildPkgConsts(cellDir, fileForError string) (cellPkgConsts, []ValidationResult) {
 	pkgConsts := cellPkgConsts{}
+	var results []ValidationResult
 	for _, sub := range []string{"internal/dto", "internal/domain"} {
 		dir := filepath.Join(cellDir, sub)
 		if _, err := os.Stat(dir); err != nil {
@@ -1250,16 +1263,28 @@ func buildPkgConsts(cellDir string) cellPkgConsts {
 		if pkgConsts[pkgIdent] == nil {
 			pkgConsts[pkgIdent] = pkgConstMap{}
 		}
-		parseGoDir(dir, pkgConsts[pkgIdent])
+		if err := parseGoDir(dir, pkgConsts[pkgIdent]); err != nil {
+			results = append(results, ValidationResult{
+				Code:      codeContractConsistencyEmit01,
+				Severity:  SeverityError,
+				IssueType: IssueInvalid,
+				File:      fileForError,
+				Field:     "triggers",
+				Message:   fmt.Sprintf("cannot scan constants in %s: %v", filepath.ToSlash(dir), err),
+			})
+		}
 	}
-	return pkgConsts
+	return pkgConsts, results
 }
 
 // parseGoDir parses all non-test Go files in dir and extracts string const declarations.
-func parseGoDir(dir string, consts pkgConstMap) {
+func parseGoDir(dir string, consts pkgConstMap) error {
 	fset := token.NewFileSet()
-	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
 			return nil
 		}
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
@@ -1267,7 +1292,7 @@ func parseGoDir(dir string, consts pkgConstMap) {
 		}
 		f, parseErr := parser.ParseFile(fset, path, nil, 0)
 		if parseErr != nil {
-			return nil
+			return parseErr
 		}
 		extractStringConsts(f, consts)
 		return nil

--- a/kernel/governance/rules_docs.go
+++ b/kernel/governance/rules_docs.go
@@ -167,7 +167,10 @@ func (v *Validator) walkDocNamingInclude(include string, exclude []string, seen 
 		return nil
 	}
 	err := filepath.WalkDir(baseAbs, func(abs string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
 			return nil
 		}
 		v.addDocNamingTarget(abs, exclude, seen)

--- a/kernel/idempotency/idempotency.go
+++ b/kernel/idempotency/idempotency.go
@@ -13,6 +13,10 @@ import (
 // Callers MUST stop business logic on this error and proceed to Release.
 var ErrLeaseExpired = errors.New("idempotency: processing lease expired")
 
+// ErrNoClaimLease indicates Receipt methods were called for a Claim result
+// that did not acquire a processing lease.
+var ErrNoClaimLease = errors.New("idempotency: no acquired claim lease")
+
 // DefaultTTL is the standard idempotency key TTL per the EventBus specification.
 const DefaultTTL = 24 * time.Hour
 
@@ -45,6 +49,27 @@ type Receipt interface {
 	// Returns ErrLeaseExpired if the lease is no longer held (fencing failure)
 	// or wraps the underlying backend error otherwise.
 	Extend(ctx context.Context, ttl time.Duration) error
+}
+
+// NonAcquiredReceipt returns a sentinel receipt for ClaimDone and ClaimBusy.
+// Callers must branch on ClaimState and ignore this receipt unless the state is
+// ClaimAcquired; if misused, its methods return ErrNoClaimLease.
+func NonAcquiredReceipt() Receipt {
+	return nonAcquiredReceipt{}
+}
+
+type nonAcquiredReceipt struct{}
+
+func (nonAcquiredReceipt) Commit(context.Context) error {
+	return ErrNoClaimLease
+}
+
+func (nonAcquiredReceipt) Release(context.Context) error {
+	return ErrNoClaimLease
+}
+
+func (nonAcquiredReceipt) Extend(context.Context, time.Duration) error {
+	return ErrNoClaimLease
 }
 
 // ---------------------------------------------------------------------------
@@ -88,8 +113,8 @@ type Claimer interface {
 	//
 	// Returns:
 	//   - (ClaimAcquired, receipt, nil) — caller should process, then Commit or Release.
-	//   - (ClaimDone, nil, nil) — already processed; caller should Ack.
-	//   - (ClaimBusy, nil, nil) — another consumer is processing; caller should Requeue.
+	//   - (ClaimDone, NonAcquiredReceipt(), nil) — already processed; caller should Ack.
+	//   - (ClaimBusy, NonAcquiredReceipt(), nil) — another consumer is processing; caller should Requeue.
 	//   - (_, nil, err) — infrastructure error.
 	Claim(ctx context.Context, key string, leaseTTL, doneTTL time.Duration) (ClaimState, Receipt, error)
 }

--- a/kernel/idempotency/idempotency_test.go
+++ b/kernel/idempotency/idempotency_test.go
@@ -53,6 +53,14 @@ func TestReceipt_CommitRelease(t *testing.T) {
 	assert.NoError(t, receipt.Release(context.Background()))
 }
 
+func TestNonAcquiredReceipt_ReturnsLeaseError(t *testing.T) {
+	receipt := NonAcquiredReceipt()
+	require.NotNil(t, receipt)
+	assert.ErrorIs(t, receipt.Commit(context.Background()), ErrNoClaimLease)
+	assert.ErrorIs(t, receipt.Release(context.Background()), ErrNoClaimLease)
+	assert.ErrorIs(t, receipt.Extend(context.Background(), time.Minute), ErrNoClaimLease)
+}
+
 // --- DefaultLeaseTTL Test ---
 
 func TestDefaultLeaseTTL(t *testing.T) {
@@ -86,7 +94,7 @@ func TestInMemClaimer_Claim_Done(t *testing.T) {
 	state, r2, err := c.Claim(ctx, "key-done", 5*time.Minute, 24*time.Hour)
 	assert.NoError(t, err)
 	assert.Equal(t, ClaimDone, state)
-	assert.Nil(t, r2)
+	assert.NotNil(t, r2)
 }
 
 func TestInMemClaimer_Claim_Busy(t *testing.T) {
@@ -102,7 +110,7 @@ func TestInMemClaimer_Claim_Busy(t *testing.T) {
 	state2, r2, err2 := c.Claim(ctx, "key-busy", 5*time.Minute, 24*time.Hour)
 	assert.NoError(t, err2)
 	assert.Equal(t, ClaimBusy, state2)
-	assert.Nil(t, r2)
+	assert.NotNil(t, r2)
 }
 
 func TestInMemClaimer_Claim_ExpiredLease_ReacquiredBySecond(t *testing.T) {

--- a/kernel/idempotency/inmem.go
+++ b/kernel/idempotency/inmem.go
@@ -64,9 +64,9 @@ func (c *InMemClaimer) Claim(_ context.Context, key string, leaseTTL, doneTTL ti
 	if existing, ok := c.entries[key]; ok {
 		if now.Before(existing.expiresAt) {
 			if existing.state == ClaimDone {
-				return ClaimDone, nil, nil
+				return ClaimDone, NonAcquiredReceipt(), nil
 			}
-			return ClaimBusy, nil, nil
+			return ClaimBusy, NonAcquiredReceipt(), nil
 		}
 		// Expired entry — drop and fall through to fresh acquisition.
 		delete(c.entries, key)

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -182,7 +182,7 @@ func (p *Parser) parseCell(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if err != nil {
 		return err
 	}
-	if node != nil {
+	if shouldCacheFileNode(node) {
 		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
@@ -215,7 +215,7 @@ func (p *Parser) parseSlice(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if err != nil {
 		return err
 	}
-	if node != nil {
+	if shouldCacheFileNode(node) {
 		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
@@ -263,7 +263,7 @@ func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if err != nil {
 		return err
 	}
-	if node != nil {
+	if shouldCacheFileNode(node) {
 		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
@@ -291,7 +291,7 @@ func (p *Parser) parseJourney(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if err != nil {
 		return err
 	}
-	if node != nil {
+	if shouldCacheFileNode(node) {
 		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
@@ -313,7 +313,7 @@ func (p *Parser) parseAssembly(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if err != nil {
 		return err
 	}
-	if node != nil {
+	if shouldCacheFileNode(node) {
 		pm.fileNodes[path] = node
 	}
 	if m.ID == "" {
@@ -340,7 +340,7 @@ func (p *Parser) parseStatusBoard(fsys fs.FS, path string, pm *ProjectMeta) erro
 	if err != nil {
 		return err
 	}
-	if node != nil {
+	if shouldCacheFileNode(node) {
 		pm.fileNodes[path] = node
 	}
 	pm.StatusBoard = entries
@@ -353,7 +353,7 @@ func (p *Parser) parseActors(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if err != nil {
 		return err
 	}
-	if node != nil {
+	if shouldCacheFileNode(node) {
 		pm.fileNodes[path] = node
 	}
 	pm.Actors = actors
@@ -378,10 +378,11 @@ const maxMetadataFileSize = 1 << 20 // 1 MiB
 //     source Decoder (see yaml.go func (n *Node) Decode), so we re-parse the
 //     bytes rather than calling root.Decode(out).
 //
-// Empty / whitespace-only files are treated as "no content" and return
-// (nil, nil) to preserve the original behaviour of empty actors.yaml or
-// status-board.yaml. Multi-document files are rejected. Files larger than
-// maxMetadataFileSize are rejected before decoding (see that constant).
+// Empty / whitespace-only files are treated as "no content" and return an
+// empty document node to preserve the original behaviour of empty actors.yaml
+// or status-board.yaml without encoding success as nil data. Multi-document
+// files are rejected. Files larger than maxMetadataFileSize are rejected before
+// decoding (see that constant).
 func unmarshalFile(fsys fs.FS, path string, out any) (*yaml.Node, error) {
 	data, err := fs.ReadFile(fsys, path)
 	if err != nil {
@@ -398,7 +399,7 @@ func unmarshalFile(fsys fs.FS, path string, out any) (*yaml.Node, error) {
 	dec1 := yaml.NewDecoder(bytes.NewReader(data))
 	if err := dec1.Decode(&root); err != nil {
 		if err == io.EOF {
-			return nil, nil
+			return emptyYAMLDocumentNode(), nil
 		}
 		return nil, errcode.Wrap(errcode.ErrMetadataInvalid,
 			fmt.Sprintf("parse %s", path), err)
@@ -427,4 +428,12 @@ func unmarshalFile(fsys fs.FS, path string, out any) (*yaml.Node, error) {
 	}
 
 	return &root, nil
+}
+
+func emptyYAMLDocumentNode() *yaml.Node {
+	return &yaml.Node{Kind: yaml.DocumentNode}
+}
+
+func shouldCacheFileNode(node *yaml.Node) bool {
+	return node != nil && (node.Kind != yaml.DocumentNode || len(node.Content) != 0)
 }

--- a/kernel/persistence/tx.go
+++ b/kernel/persistence/tx.go
@@ -3,7 +3,10 @@
 // adapters/postgres) and consumed by cells via dependency injection.
 package persistence
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // TxRunner executes fn within a database transaction. The transaction
 // is embedded in the context so that participants (e.g., outbox.Writer)
@@ -20,10 +23,11 @@ type TxRunner interface {
 type NoopTxRunner struct{}
 
 // RunInTx calls fn with the provided context (no transaction wrapping).
-// Panics if fn is nil (programming error, ref: net/http.HandleFunc, database/sql.Register).
+// Returns an error when fn is nil so callers can propagate wiring mistakes
+// through their normal startup or request error path.
 func (NoopTxRunner) RunInTx(ctx context.Context, fn func(ctx context.Context) error) error {
 	if fn == nil {
-		panic("persistence: nil fn passed to RunInTx")
+		return fmt.Errorf("persistence: nil fn passed to RunInTx")
 	}
 	return fn(ctx)
 }

--- a/kernel/persistence/tx_test.go
+++ b/kernel/persistence/tx_test.go
@@ -31,10 +31,10 @@ func TestNoopTxRunner_PropagatesError(t *testing.T) {
 	assert.ErrorIs(t, got, want)
 }
 
-func TestNoopTxRunner_NilFnPanics(t *testing.T) {
-	assert.PanicsWithValue(t, "persistence: nil fn passed to RunInTx", func() {
-		_ = NoopTxRunner{}.RunInTx(context.Background(), nil)
-	})
+func TestNoopTxRunner_NilFnReturnsError(t *testing.T) {
+	err := NoopTxRunner{}.RunInTx(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil fn")
 }
 
 func TestNoopTxRunner_Noop(t *testing.T) {
@@ -79,12 +79,12 @@ func TestRunnerOrNoop_RealRunnerReturnedUnchanged(t *testing.T) {
 	assert.Equal(t, 1, real.calls)
 }
 
-func TestRunnerOrNoop_NilFallbackPreservesNilFnPanic(t *testing.T) {
+func TestRunnerOrNoop_NilFallbackPreservesNilFnError(t *testing.T) {
 	runner := RunnerOrNoop(nil)
 
-	assert.PanicsWithValue(t, "persistence: nil fn passed to RunInTx", func() {
-		_ = runner.RunInTx(context.Background(), nil)
-	})
+	err := runner.RunInTx(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil fn")
 }
 
 type recordingTxRunner struct {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -7,6 +7,7 @@ package validation
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
@@ -53,4 +54,22 @@ func RequireNotBlank(code errcode.Code, fields ...NamedValue) error {
 		}
 	}
 	return nil
+}
+
+// IsNilInterface reports whether v is nil or a typed-nil interface value.
+//
+// Use this at construction boundaries for interface dependencies. A plain
+// `dep == nil` check misses values such as `var dep *Repo; New(dep)` because
+// the interface carries a non-nil concrete type descriptor.
+func IsNilInterface(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
+type nilInterfaceSample struct{}
+
+type nilInterfaceMarker interface{ Marker() }
+
+type nilInterfaceImpl struct{}
+
+func (*nilInterfaceImpl) Marker() {}
+
 // assertValidationResult is a t.Helper that validates the outcome of a
 // RequireNotBlank call. When wantMessage is empty it asserts nil error;
 // otherwise it asserts a *errcode.Error with the expected code and message.
@@ -31,6 +39,43 @@ func assertValidationResult(t *testing.T, err error, wantCode errcode.Code, want
 	}
 	if ec.Message != wantMessage {
 		t.Errorf("message = %q, want %q", ec.Message, wantMessage)
+	}
+}
+
+func TestIsNilInterface(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   any
+		want bool
+	}{
+		{name: "bare nil", in: nil, want: true},
+		{name: "typed nil pointer", in: (*nilInterfaceSample)(nil), want: true},
+		{name: "typed nil map", in: map[string]string(nil), want: true},
+		{name: "typed nil slice", in: []string(nil), want: true},
+		{name: "typed nil func", in: (func())(nil), want: true},
+		{name: "non nil pointer", in: &nilInterfaceSample{}, want: false},
+		{name: "non nil map", in: map[string]string{}, want: false},
+		{name: "non nil slice", in: []string{}, want: false},
+		{name: "non nil string", in: "x", want: false},
+		{name: "zero struct", in: nilInterfaceSample{}, want: false},
+	}
+
+	var typedNil nilInterfaceMarker = (*nilInterfaceImpl)(nil)
+	tests = append(tests, struct {
+		name string
+		in   any
+		want bool
+	}{name: "typed nil interface", in: typedNil, want: true})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := validation.IsNilInterface(tt.in); got != tt.want {
+				t.Fatalf("IsNilInterface() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -2,9 +2,9 @@
 //
 // An Authenticator inspects an *http.Request and returns one of three outcomes:
 //
-//	(p, true, nil)    — credential present and valid; caller stops the chain.
-//	(nil, false, nil) — credential absent; caller should try the next authenticator.
-//	(nil, false, err) — credential present but invalid; caller MUST NOT fall through.
+//	(p, true, nil)                 — credential present and valid; caller stops the chain.
+//	(absentPrincipal(), false, nil) — credential absent; caller should try the next authenticator.
+//	(nil, false, err)              — credential present but invalid; caller MUST NOT fall through.
 //
 // ref: kubernetes/apiserver pkg/authentication/request/union/union.go (FailOnError=true)
 package auth
@@ -31,6 +31,10 @@ type AuthenticatorFunc func(r *http.Request) (*Principal, bool, error)
 // Authenticate implements Authenticator.
 func (f AuthenticatorFunc) Authenticate(r *http.Request) (*Principal, bool, error) {
 	return f(r)
+}
+
+func absentPrincipal() *Principal {
+	return &Principal{}
 }
 
 // UnionAuthenticator tries each child in order and returns the first successful
@@ -61,7 +65,7 @@ func (u *UnionAuthenticator) Authenticate(r *http.Request) (*Principal, bool, er
 		}
 		// Credential absent — try the next authenticator.
 	}
-	return nil, false, nil
+	return absentPrincipal(), false, nil
 }
 
 // NewJWTAuthenticator returns an Authenticator that extracts a Bearer token
@@ -69,9 +73,9 @@ func (u *UnionAuthenticator) Authenticate(r *http.Request) (*Principal, bool, er
 //
 // Outcomes:
 //
-//	(p, true, nil)    — token present and valid; Principal populated from claims.
-//	(nil, false, nil) — no Authorization header, or non-Bearer scheme (let Union continue).
-//	(nil, false, err) — Bearer token present but VerifyIntent rejected it (short-circuit).
+//	(p, true, nil)                 — token present and valid; Principal populated from claims.
+//	(absentPrincipal(), false, nil) — no Authorization header, or non-Bearer scheme (let Union continue).
+//	(nil, false, err)              — Bearer token present but VerifyIntent rejected it (short-circuit).
 //
 // ref: kubernetes/apiserver pkg/authentication/request/bearertoken/bearertoken.go
 func NewJWTAuthenticator(v IntentTokenVerifier) Authenticator {
@@ -79,7 +83,7 @@ func NewJWTAuthenticator(v IntentTokenVerifier) Authenticator {
 		token := extractBearerToken(r)
 		if token == "" {
 			// No Bearer credential — absent, let the Union try the next authenticator.
-			return nil, false, nil
+			return absentPrincipal(), false, nil
 		}
 		claims, err := v.VerifyIntent(r.Context(), token, TokenIntentAccess)
 		if err != nil {
@@ -121,9 +125,9 @@ func jwtClaimsToPrincipal(c Claims) *Principal {
 //
 // Outcomes:
 //
-//	(p, true, nil)    — ServiceToken header present and valid.
-//	(nil, false, nil) — no Authorization header, or non-"ServiceToken" scheme.
-//	(nil, false, err) — ServiceToken present but validation failed (expired, bad MAC, replay).
+//	(p, true, nil)                 — ServiceToken header present and valid.
+//	(absentPrincipal(), false, nil) — no Authorization header, or non-"ServiceToken" scheme.
+//	(nil, false, err)              — ServiceToken present but validation failed (expired, bad MAC, replay).
 //
 // Options reuse ServiceTokenOption so callers share the same clock/nonce/metrics
 // injection points as ServiceTokenMiddleware.
@@ -142,12 +146,12 @@ func NewServiceTokenAuthenticator(ring cell.HMACKeyring, opts ...ServiceTokenOpt
 	return AuthenticatorFunc(func(r *http.Request) (*Principal, bool, error) {
 		raw := r.Header.Get("Authorization")
 		if raw == "" {
-			return nil, false, nil
+			return absentPrincipal(), false, nil
 		}
 		scheme, payload, ok := strings.Cut(raw, " ")
 		if !ok || !strings.EqualFold(scheme, "ServiceToken") {
 			// Bearer or other scheme — absent for this authenticator.
-			return nil, false, nil
+			return absentPrincipal(), false, nil
 		}
 		payload = strings.TrimSpace(payload)
 		if err := verifyServiceTokenPayload(ring, payload, cfg, r); err != nil {

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -127,8 +127,8 @@ func TestUnionAuthenticator_EmptyChildren(t *testing.T) {
 	if ok {
 		t.Error("expected ok=false with no children")
 	}
-	if got != nil {
-		t.Errorf("expected nil principal, got %v", got)
+	if got == nil {
+		t.Error("expected absent principal sentinel")
 	}
 }
 
@@ -144,8 +144,8 @@ func TestUnionAuthenticator_AllAbsent(t *testing.T) {
 	if ok {
 		t.Error("expected ok=false when all absent")
 	}
-	if got != nil {
-		t.Errorf("expected nil principal, got %v", got)
+	if got == nil {
+		t.Error("expected absent principal sentinel")
 	}
 	if first.calls != 1 {
 		t.Errorf("first should be called once, got %d", first.calls)
@@ -186,8 +186,8 @@ func TestJWTAuthenticator_NoAuthHeader_Absent(t *testing.T) {
 	if ok {
 		t.Fatal("expected ok=false (absent credential)")
 	}
-	if p != nil {
-		t.Fatalf("expected nil principal, got %v", p)
+	if p == nil {
+		t.Fatal("expected absent principal sentinel")
 	}
 }
 
@@ -202,8 +202,8 @@ func TestJWTAuthenticator_NonBearerScheme_Absent(t *testing.T) {
 	if ok {
 		t.Fatal("expected ok=false for non-Bearer scheme")
 	}
-	if p != nil {
-		t.Fatalf("expected nil principal, got %v", p)
+	if p == nil {
+		t.Fatal("expected absent principal sentinel")
 	}
 }
 
@@ -235,7 +235,7 @@ func TestJWTAuthenticator_IntentMismatch_Error(t *testing.T) {
 		t.Fatal("expected ok=false on intent mismatch")
 	}
 	if p != nil {
-		t.Fatalf("expected nil principal, got %v", p)
+		t.Fatalf("expected nil principal on error, got %v", p)
 	}
 }
 
@@ -327,8 +327,8 @@ func TestServiceTokenAuthenticator_NoHeader_Absent(t *testing.T) {
 	if ok {
 		t.Fatal("expected ok=false (absent credential)")
 	}
-	if p != nil {
-		t.Fatalf("expected nil principal, got %v", p)
+	if p == nil {
+		t.Fatal("expected absent principal sentinel")
 	}
 }
 
@@ -344,8 +344,8 @@ func TestServiceTokenAuthenticator_BearerSchemeIgnored_Absent(t *testing.T) {
 	if ok {
 		t.Fatal("expected ok=false: Bearer scheme must be absent for ServiceToken authenticator")
 	}
-	if p != nil {
-		t.Fatalf("expected nil principal, got %v", p)
+	if p == nil {
+		t.Fatal("expected absent principal sentinel")
 	}
 }
 
@@ -529,7 +529,7 @@ func TestJWTAuthenticator_EmptySubject_Error(t *testing.T) {
 
 // TestUnionAuthenticator_BearerAndServiceToken_NoCrossBleed verifies that when
 // Union(JWT, ServiceToken) receives "Authorization: ServiceToken <payload>",
-// the JWT authenticator returns absent (nil, false, nil) — because it sees a
+// the JWT authenticator returns absent (non-nil sentinel, false, nil) — because it sees a
 // non-Bearer scheme — and the ServiceToken authenticator validates the
 // credential and returns a valid Principal. No cross-bleed between the two.
 func TestUnionAuthenticator_BearerAndServiceToken_NoCrossBleed(t *testing.T) {

--- a/runtime/auth/config/registry_test.go
+++ b/runtime/auth/config/registry_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"errors"
+	"math/big"
 	"os"
 	"testing"
 	"time"
@@ -25,9 +26,11 @@ import (
 // It satisfies both auth.SigningKeyProvider and auth.VerificationKeyStore.
 type stubKeySet struct{}
 
-func (s *stubKeySet) SigningKey() *rsa.PrivateKey                     { return nil }
-func (s *stubKeySet) SigningKeyID() string                            { return "stub-kid" }
-func (s *stubKeySet) PublicKeyByKID(_ string) (*rsa.PublicKey, error) { return nil, nil }
+func (s *stubKeySet) SigningKey() *rsa.PrivateKey { return nil }
+func (s *stubKeySet) SigningKeyID() string        { return "stub-kid" }
+func (s *stubKeySet) PublicKeyByKID(_ string) (*rsa.PublicKey, error) {
+	return &rsa.PublicKey{N: big.NewInt(1), E: 65537}, nil
+}
 
 // TestNew_RealMode_IssuerRequired verifies that RealMode=true requires a non-empty Issuer.
 func TestNew_RealMode_IssuerRequired(t *testing.T) {

--- a/runtime/auth/refresh/memstore/store.go
+++ b/runtime/auth/refresh/memstore/store.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/google/uuid"
 )
@@ -66,22 +67,32 @@ type store struct {
 
 // New constructs an in-memory refresh.Store.
 //
-// clock must not be nil. policy.MaxAge must be positive; policy.ReuseInterval
-// must not be negative. If randReader is nil, crypto/rand.Reader is used.
-func New(policy refresh.Policy, clock refresh.Clock, randReader io.Reader) refresh.Store {
+// Returns an error when clock is nil, policy.MaxAge is not positive, or
+// policy.ReuseInterval is negative. If randReader is nil, crypto/rand.Reader
+// is used.
+func New(policy refresh.Policy, clock refresh.Clock, randReader io.Reader) (refresh.Store, error) {
 	if clock == nil {
-		panic("memstore.New: clock must not be nil")
+		return nil, errcode.New(errcode.ErrValidationFailed, "memstore.New: clock must not be nil")
 	}
 	if policy.MaxAge <= 0 {
-		panic("memstore.New: policy.MaxAge must be positive")
+		return nil, errcode.New(errcode.ErrValidationFailed, "memstore.New: policy.MaxAge must be positive")
 	}
 	if policy.ReuseInterval < 0 {
-		panic("memstore.New: policy.ReuseInterval must not be negative")
+		return nil, errcode.New(errcode.ErrValidationFailed, "memstore.New: policy.ReuseInterval must not be negative")
 	}
 	if randReader == nil {
 		randReader = rand.Reader
 	}
-	return &store{policy: policy, clock: clock, rand: randReader}
+	return &store{policy: policy, clock: clock, rand: randReader}, nil
+}
+
+// MustNew is the static-wiring variant of New.
+func MustNew(policy refresh.Policy, clock refresh.Clock, randReader io.Reader) refresh.Store {
+	store, err := New(policy, clock, randReader)
+	if err != nil {
+		panic(err.Error())
+	}
+	return store
 }
 
 func (s *store) generatePair() (selector []byte, verifier []byte, err error) {

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
+	"github.com/stretchr/testify/require"
 )
 
 // baseTime is the synthetic epoch for all FakeClocks in this test file.
@@ -21,5 +22,45 @@ func TestMemStoreContract(t *testing.T) {
 		// Pass nil for rand so memstore falls back to crypto/rand (fine for
 		// the red phase; B3 may inject a deterministic reader for hermeticity).
 		return memstore.MustNew(policy, clock, nil), clock
+	})
+}
+
+func TestNewRejectsInvalidConfig(t *testing.T) {
+	clock := storetest.NewFakeClock(baseTime)
+
+	tests := []struct {
+		name   string
+		policy refresh.Policy
+		clock  refresh.Clock
+	}{
+		{
+			name:   "nil clock",
+			policy: refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour},
+			clock:  nil,
+		},
+		{
+			name:   "non-positive max age",
+			policy: refresh.Policy{ReuseInterval: time.Second},
+			clock:  clock,
+		},
+		{
+			name:   "negative reuse interval",
+			policy: refresh.Policy{ReuseInterval: -time.Second, MaxAge: time.Hour},
+			clock:  clock,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := memstore.New(tc.policy, tc.clock, nil)
+			require.Error(t, err)
+			require.Nil(t, store)
+		})
+	}
+}
+
+func TestMustNewPanicsOnInvalidConfig(t *testing.T) {
+	require.Panics(t, func() {
+		memstore.MustNew(refresh.Policy{}, nil, nil)
 	})
 }

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -20,6 +20,6 @@ func TestMemStoreContract(t *testing.T) {
 		clock := storetest.NewFakeClock(baseTime)
 		// Pass nil for rand so memstore falls back to crypto/rand (fine for
 		// the red phase; B3 may inject a deterministic reader for hermeticity).
-		return memstore.New(policy, clock, nil), clock
+		return memstore.MustNew(policy, clock, nil), clock
 	})
 }

--- a/runtime/auth/route.go
+++ b/runtime/auth/route.go
@@ -115,15 +115,19 @@ func Mount(mux cell.RouteHandler, r Route) error {
 		// declarer.DeclareAuthMeta's Path is the sub-route-relative path;
 		// chiRouterAdapter recomposes it with its prefix on its way up to
 		// the top-level Router.
-		declarer.DeclareAuthMeta(cell.AuthRouteMeta{
+		if err := declarer.DeclareAuthMeta(cell.AuthRouteMeta{
 			Method:              r.Contract.Method,
 			Path:                cleanedRel,
 			Public:              r.Public,
 			PasswordResetExempt: r.PasswordResetExempt,
-		})
+		}); err != nil {
+			return fmt.Errorf("auth.Mount: declare auth metadata: %w", err)
+		}
 	}
 	if declarer, ok := mux.(cell.HTTPContractDeclarer); ok {
-		declarer.DeclareHTTPContract(r.Contract)
+		if err := declarer.DeclareHTTPContract(r.Contract); err != nil {
+			return fmt.Errorf("auth.Mount: declare HTTP contract metadata: %w", err)
+		}
 	}
 	return nil
 }

--- a/runtime/auth/route.go
+++ b/runtime/auth/route.go
@@ -109,7 +109,6 @@ func Mount(mux cell.RouteHandler, r Route) error {
 	handler = wrapped
 
 	cleanedRel := path.Clean(relPath)
-	mux.Handle(r.Contract.Method+" "+cleanedRel, handler)
 
 	if declarer, ok := mux.(cell.AuthRouteDeclarer); ok {
 		// declarer.DeclareAuthMeta's Path is the sub-route-relative path;
@@ -129,6 +128,8 @@ func Mount(mux cell.RouteHandler, r Route) error {
 			return fmt.Errorf("auth.Mount: declare HTTP contract metadata: %w", err)
 		}
 	}
+
+	mux.Handle(r.Contract.Method+" "+cleanedRel, handler)
 	return nil
 }
 

--- a/runtime/auth/route_test.go
+++ b/runtime/auth/route_test.go
@@ -23,8 +23,9 @@ func newCaptureMux() *captureMux { return &captureMux{ServeMux: http.NewServeMux
 
 func (m *captureMux) Handle(pattern string, h http.Handler) { m.ServeMux.Handle(pattern, h) }
 
-func (m *captureMux) DeclareAuthMeta(meta cell.AuthRouteMeta) {
+func (m *captureMux) DeclareAuthMeta(meta cell.AuthRouteMeta) error {
 	m.metas = append(m.metas, meta)
+	return nil
 }
 
 var (
@@ -148,8 +149,9 @@ func (m *prefixedCaptureMux) Handle(pattern string, h http.Handler) {
 	m.ServeMux.Handle(pattern, h)
 }
 
-func (m *prefixedCaptureMux) DeclareAuthMeta(meta cell.AuthRouteMeta) {
+func (m *prefixedCaptureMux) DeclareAuthMeta(meta cell.AuthRouteMeta) error {
 	m.metas = append(m.metas, meta)
+	return nil
 }
 
 func (m *prefixedCaptureMux) Prefix() string { return m.prefix }

--- a/runtime/auth/route_test.go
+++ b/runtime/auth/route_test.go
@@ -33,6 +33,29 @@ var (
 	_ cell.AuthRouteDeclarer = (*captureMux)(nil)
 )
 
+type failingDeclareMux struct {
+	*http.ServeMux
+	handleCalls int
+}
+
+func newFailingDeclareMux() *failingDeclareMux {
+	return &failingDeclareMux{ServeMux: http.NewServeMux()}
+}
+
+func (m *failingDeclareMux) Handle(pattern string, h http.Handler) {
+	m.handleCalls++
+	m.ServeMux.Handle(pattern, h)
+}
+
+func (m *failingDeclareMux) DeclareAuthMeta(cell.AuthRouteMeta) error {
+	return assert.AnError
+}
+
+var (
+	_ cell.RouteHandler      = (*failingDeclareMux)(nil)
+	_ cell.AuthRouteDeclarer = (*failingDeclareMux)(nil)
+)
+
 var noopHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 
 func loginContractSpec() wrapper.ContractSpec {
@@ -78,6 +101,20 @@ func TestMount_WritesContractIDIntoContext(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/v1/access/sessions/login", nil)
 	mux.ServeHTTP(httptest.NewRecorder(), req)
 	assert.Equal(t, "http.auth.login.v1", seen)
+}
+
+func TestMount_DeclareAuthMetaErrorDoesNotRegisterRoute(t *testing.T) {
+	mux := newFailingDeclareMux()
+
+	err := Mount(mux, Route{
+		Contract: loginContractSpec(),
+		Handler:  noopHandler,
+		Public:   true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declare auth metadata")
+	assert.Zero(t, mux.handleCalls, "Mount must validate and declare metadata before registering the route")
 }
 
 func TestMount_ReturnsErrorOnMissingContractID(t *testing.T) {

--- a/runtime/auth/route_test.go
+++ b/runtime/auth/route_test.go
@@ -56,6 +56,29 @@ var (
 	_ cell.AuthRouteDeclarer = (*failingDeclareMux)(nil)
 )
 
+type failingContractDeclareMux struct {
+	*http.ServeMux
+	handleCalls int
+}
+
+func newFailingContractDeclareMux() *failingContractDeclareMux {
+	return &failingContractDeclareMux{ServeMux: http.NewServeMux()}
+}
+
+func (m *failingContractDeclareMux) Handle(pattern string, h http.Handler) {
+	m.handleCalls++
+	m.ServeMux.Handle(pattern, h)
+}
+
+func (m *failingContractDeclareMux) DeclareHTTPContract(wrapper.ContractSpec) error {
+	return assert.AnError
+}
+
+var (
+	_ cell.RouteHandler         = (*failingContractDeclareMux)(nil)
+	_ cell.HTTPContractDeclarer = (*failingContractDeclareMux)(nil)
+)
+
 var noopHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 
 func loginContractSpec() wrapper.ContractSpec {
@@ -115,6 +138,47 @@ func TestMount_DeclareAuthMetaErrorDoesNotRegisterRoute(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "declare auth metadata")
 	assert.Zero(t, mux.handleCalls, "Mount must validate and declare metadata before registering the route")
+}
+
+func TestMount_DeclareHTTPContractErrorDoesNotRegisterRoute(t *testing.T) {
+	mux := newFailingContractDeclareMux()
+
+	err := Mount(mux, Route{
+		Contract: loginContractSpec(),
+		Handler:  noopHandler,
+		Public:   true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declare HTTP contract metadata")
+	assert.Zero(t, mux.handleCalls, "Mount must declare HTTP contract metadata before registering the route")
+}
+
+func TestMount_AppliesPolicyBeforeHandler(t *testing.T) {
+	mux := newCaptureMux()
+	policyCalled := false
+	handlerCalled := false
+
+	err := Mount(mux, Route{
+		Contract: loginContractSpec(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			handlerCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		Policy: func(_ *http.Request) error {
+			policyCalled = true
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/api/v1/access/sessions/login", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.True(t, policyCalled)
+	assert.True(t, handlerCalled)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestMount_ReturnsErrorOnMissingContractID(t *testing.T) {

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -614,8 +614,8 @@ type Bootstrap struct {
 	// --- metrics provider + auto-wired HTTP collector ---
 	metricsProvider    kernelmetrics.Provider
 	httpCollector      metricsmiddleware.Collector // cached auto-wired HTTP collector (created once, shared across listeners)
-	shutdownMet        *shutdownMetrics            // nil only when provider is nil
-	shutdownMetricsErr error                       // non-nil when metric registration failed in New
+	shutdownMet        *shutdownMetrics
+	shutdownMetricsErr error // non-nil when metric registration failed in New
 
 	// --- run state ---
 	runOnce sync.Once
@@ -726,8 +726,7 @@ func New(opts ...Option) *Bootstrap {
 		reg(b.lifecycle)
 	}
 	// Register shutdown metrics against the (potentially Nop) provider.
-	// newShutdownMetrics returns (nil, nil) for NopProvider — that is the
-	// correct "disabled" state; nil *shutdownMetrics is safe to call.
+	// newShutdownMetrics returns a disabled metrics object for a nil provider.
 	m, err := newShutdownMetrics(b.metricsProvider)
 	if err != nil {
 		// Store error; phase0 will surface it before any component starts.

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -92,7 +92,9 @@ func (s *phaseState) registerHealthChecker(name string, fn func(context.Context)
 	if _, exists := s.registeredCheckers[name]; exists {
 		return fmt.Errorf("bootstrap: duplicate health checker %q", name)
 	}
-	s.hh.RegisterChecker(name, fn)
+	if err := s.hh.RegisterChecker(name, fn); err != nil {
+		return err
+	}
 	s.registeredCheckers[name] = struct{}{}
 	return nil
 }

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -206,7 +206,7 @@ func TestPhase0_AcceptsAuthMTLSWithProperTLS(t *testing.T) {
 		// GetCertificate provides the server-side certificate at handshake time.
 		// Without at least one cert source, the TLS sanity check (Wave B) rejects
 		// the config because no TLS handshake can complete.
-		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) { return nil, nil },
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) { return &tls.Certificate{}, nil },
 	}
 	b := New(
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}),
@@ -1103,7 +1103,7 @@ func TestPhase0_TLSConfigWithGetCertificate_Accepted(t *testing.T) {
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}},
 			WithListenerTLS(&tls.Config{
 				GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-					return nil, nil
+					return &tls.Certificate{}, nil
 				},
 			})),
 	)

--- a/runtime/bootstrap/shutdown_metrics.go
+++ b/runtime/bootstrap/shutdown_metrics.go
@@ -71,6 +71,8 @@ var defaultShutdownBuckets = []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5
 // Provider at construction time, matching the "register at start-up" pattern
 // used by relay_collector.go and the kernel hook dispatcher.
 type shutdownMetrics struct {
+	disabled bool
+
 	// phaseEntries counts each phase transition. Using a CounterVec (not a
 	// Gauge) because the kernel Provider interface does not expose Gauge.
 	// A counter-per-phase lets SREs detect missing phase entries (stuck
@@ -91,8 +93,8 @@ type shutdownMetrics struct {
 }
 
 // newShutdownMetrics registers shutdown metrics on p and returns a
-// *shutdownMetrics. Returns (nil, nil) when p is nil, which disables
-// all metric emission while leaving phase10 behaviour unchanged.
+// *shutdownMetrics. A nil Provider returns a disabled metrics object, which
+// leaves phase10 behaviour unchanged without encoding success as nil data.
 //
 // An error is returned only when the Provider itself fails to register a
 // metric family (typically a duplicate name in the same registry). Callers
@@ -102,7 +104,7 @@ type shutdownMetrics struct {
 // pattern for metric registration.
 func newShutdownMetrics(p kernelmetrics.Provider) (*shutdownMetrics, error) {
 	if p == nil {
-		return nil, nil
+		return &shutdownMetrics{disabled: true}, nil
 	}
 
 	// Track registered collectors for rollback on partial failure.
@@ -154,7 +156,7 @@ func newShutdownMetrics(p kernelmetrics.Provider) (*shutdownMetrics, error) {
 // recordPhaseEntry increments the phase-entry counter for the given phase
 // label. No-op on nil receiver.
 func (m *shutdownMetrics) recordPhaseEntry(phase string) {
-	if m == nil {
+	if m == nil || m.disabled {
 		return
 	}
 	m.phaseEntries.With(kernelmetrics.Labels{"phase": phase}).Inc()
@@ -163,7 +165,7 @@ func (m *shutdownMetrics) recordPhaseEntry(phase string) {
 // observePhaseDuration records the duration of a shutdown phase. No-op on
 // nil receiver.
 func (m *shutdownMetrics) observePhaseDuration(phase string, d time.Duration) {
-	if m == nil {
+	if m == nil || m.disabled {
 		return
 	}
 	m.phaseDuration.With(kernelmetrics.Labels{"phase": phase}).Observe(d.Seconds())
@@ -172,7 +174,7 @@ func (m *shutdownMetrics) observePhaseDuration(phase string, d time.Duration) {
 // countOutcome increments the shutdown outcome counter. outcome must be one of
 // "success", "timeout", "teardown_error", or "signal_error". No-op on nil receiver.
 func (m *shutdownMetrics) countOutcome(outcome string) {
-	if m == nil {
+	if m == nil || m.disabled {
 		return
 	}
 	m.shutdownTotal.With(kernelmetrics.Labels{"outcome": outcome}).Inc()

--- a/runtime/bootstrap/shutdown_metrics_test.go
+++ b/runtime/bootstrap/shutdown_metrics_test.go
@@ -515,13 +515,14 @@ func TestShutdownMetrics_NilSafe(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 7: newShutdownMetrics with nil provider returns nil
+// Test 7: newShutdownMetrics with nil provider returns disabled metrics
 // ---------------------------------------------------------------------------
 
 func TestNewShutdownMetrics_NilProvider(t *testing.T) {
 	m, err := newShutdownMetrics(nil)
 	require.NoError(t, err)
-	assert.Nil(t, m, "nil provider must return nil shutdownMetrics")
+	require.NotNil(t, m, "nil provider must return a disabled shutdownMetrics")
+	assert.True(t, m.disabled)
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/crypto/value_transformer_test.go
+++ b/runtime/crypto/value_transformer_test.go
@@ -234,7 +234,10 @@ func (p *singleHandleProvider) Current(_ context.Context) (crypto.KeyHandle, err
 }
 
 func (p *singleHandleProvider) ByID(_ context.Context, _ string) (crypto.KeyHandle, error) {
-	return nil, nil
+	if p.handle == nil {
+		return nil, errors.New("test provider: missing handle")
+	}
+	return p.handle, nil
 }
 
 func (p *singleHandleProvider) Rotate(_ context.Context) (string, error) {

--- a/runtime/distlock/locker.go
+++ b/runtime/distlock/locker.go
@@ -85,7 +85,7 @@ type lockerImpl struct {
 
 // New creates a Locker backed by the given Driver.
 //
-// Panics if driver is nil or if any configuration parameter is out of range:
+// Returns an error if driver is nil or if any configuration parameter is out of range:
 //   - renewFraction must be in (0, 1)
 //   - driftFactor must be in [0, 1)
 //   - releaseTimeout must be > 0
@@ -99,41 +99,53 @@ type lockerImpl struct {
 // N active locks = 1 manager goroutine + O(N) heap.
 //
 // ref: plan "共享 manager goroutine" section
-func New(driver Driver, opts ...Option) Locker {
+func New(driver Driver, opts ...Option) (Locker, error) {
 	if driver == nil {
-		panic("distlock.New: driver must not be nil")
+		return nil, errcode.New(errcode.ErrValidationFailed, "distlock.New: driver must not be nil")
 	}
 	cfg := defaultConfig()
 	for _, o := range opts {
 		o(&cfg)
 	}
-	validateConfig(cfg)
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
 	return &lockerImpl{
 		mgr: newManager(driver, cfg),
 		cfg: cfg,
-	}
+	}, nil
 }
 
-// validateConfig panics if any configuration parameter is outside its valid
-// range. Called once in New() after all options have been applied so that
+// MustNew is the static-wiring variant of New.
+func MustNew(driver Driver, opts ...Option) Locker {
+	l, err := New(driver, opts...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return l
+}
+
+// validateConfig returns an error if any configuration parameter is outside its
+// valid range. Called once in New() after all options have been applied so that
 // defaults are in effect before validation runs.
-func validateConfig(cfg config) {
+func validateConfig(cfg config) error {
 	if cfg.renewFraction <= 0 || cfg.renewFraction >= 1 || math.IsNaN(cfg.renewFraction) {
-		panic("distlock.New: invalid configuration: renewFraction must be in (0, 1), got " +
+		return errcode.New(errcode.ErrValidationFailed, "distlock.New: invalid configuration: renewFraction must be in (0, 1), got "+
 			fmt.Sprintf("%v", cfg.renewFraction))
 	}
 	if cfg.driftFactor < 0 || cfg.driftFactor >= 1 || math.IsNaN(cfg.driftFactor) {
-		panic("distlock.New: invalid configuration: driftFactor must be in [0, 1), got " +
+		return errcode.New(errcode.ErrValidationFailed, "distlock.New: invalid configuration: driftFactor must be in [0, 1), got "+
 			fmt.Sprintf("%v", cfg.driftFactor))
 	}
 	if cfg.releaseTimeout <= 0 {
-		panic("distlock.New: invalid configuration: releaseTimeout must be > 0, got " +
+		return errcode.New(errcode.ErrValidationFailed, "distlock.New: invalid configuration: releaseTimeout must be > 0, got "+
 			fmt.Sprintf("%v", cfg.releaseTimeout))
 	}
 	if cfg.maxRenewAttempts < 1 {
-		panic("distlock.New: invalid configuration: maxRenewAttempts must be ≥ 1, got " +
+		return errcode.New(errcode.ErrValidationFailed, "distlock.New: invalid configuration: maxRenewAttempts must be ≥ 1, got "+
 			fmt.Sprintf("%v", cfg.maxRenewAttempts))
 	}
+	return nil
 }
 
 // Acquire implements Locker.

--- a/runtime/distlock/locker_test.go
+++ b/runtime/distlock/locker_test.go
@@ -30,7 +30,7 @@ func mgr(l distlock.Locker) *distlock.Manager {
 
 // newTestLocker constructs a Locker backed by FakeDriver + FakeClock.
 func newTestLocker(fc *locktest.FakeClock, fd *locktest.FakeDriver) distlock.Locker {
-	return distlock.New(fd, distlock.WithClock(fc))
+	return distlock.MustNew(fd, distlock.WithClock(fc))
 }
 
 // waitForRenewL waits for Renew count using the locker's manager RenewNotify.
@@ -127,7 +127,7 @@ func TestLocker_TC3_RenewError_LockLost(t *testing.T) {
 	fc := locktest.NewFakeClock(time.Time{})
 	fd := locktest.NewFakeDriver()
 	// Use maxRenewAttempts=1 so a single injected error exhausts the budget.
-	l := distlock.New(fd,
+	l := distlock.MustNew(fd,
 		distlock.WithClock(fc),
 		distlock.WithMaxRenewAttempts(1),
 	)
@@ -573,7 +573,7 @@ func TestLocker_TC12_DriftFactor(t *testing.T) {
 
 	const driftFactor = 0.01
 	const renewFraction = 0.5
-	l := distlock.New(fd,
+	l := distlock.MustNew(fd,
 		distlock.WithClock(fc),
 		distlock.WithDriftFactor(driftFactor),
 		distlock.WithRenewFraction(renewFraction),
@@ -698,7 +698,7 @@ func TestLocker_New_PanicsOnNilDriver(t *testing.T) {
 			t.Error("New(nil) should panic")
 		}
 	}()
-	_ = distlock.New(nil)
+	_ = distlock.MustNew(nil)
 }
 
 // TestLocker_New_PanicsOnInvalidRenewFraction verifies fail-fast validation in New().
@@ -721,7 +721,7 @@ func TestLocker_New_PanicsOnInvalidRenewFraction(t *testing.T) {
 					t.Errorf("New with renewFraction=%v should panic", tc.fraction)
 				}
 			}()
-			_ = distlock.New(fd, distlock.WithRenewFraction(tc.fraction))
+			_ = distlock.MustNew(fd, distlock.WithRenewFraction(tc.fraction))
 		})
 	}
 }
@@ -744,7 +744,7 @@ func TestLocker_New_PanicsOnInvalidDriftFactor(t *testing.T) {
 					t.Errorf("New with driftFactor=%v should panic", tc.factor)
 				}
 			}()
-			_ = distlock.New(fd, distlock.WithDriftFactor(tc.factor))
+			_ = distlock.MustNew(fd, distlock.WithDriftFactor(tc.factor))
 		})
 	}
 }
@@ -766,7 +766,7 @@ func TestLocker_New_PanicsOnNonPositiveReleaseTimeout(t *testing.T) {
 					t.Errorf("New with releaseTimeout=%v should panic", tc.timeout)
 				}
 			}()
-			_ = distlock.New(fd, distlock.WithReleaseTimeout(tc.timeout))
+			_ = distlock.MustNew(fd, distlock.WithReleaseTimeout(tc.timeout))
 		})
 	}
 }
@@ -859,7 +859,7 @@ func TestLocker_ConcurrentRelease(t *testing.T) {
 func TestLocker_ExtremeTTL_LongDuration(t *testing.T) {
 	fc := locktest.NewFakeClock(time.Time{})
 	fd := locktest.NewFakeDriverWithClock(fc.Now)
-	l := distlock.New(fd,
+	l := distlock.MustNew(fd,
 		distlock.WithClock(fc),
 		distlock.WithRenewFraction(0.5),
 	)
@@ -890,7 +890,7 @@ func TestLocker_ExtremeTTL_LongDuration(t *testing.T) {
 func TestLocker_ExtremeTTL_ShortDuration(t *testing.T) {
 	fc := locktest.NewFakeClock(time.Time{})
 	fd := locktest.NewFakeDriverWithClock(fc.Now)
-	l := distlock.New(fd,
+	l := distlock.MustNew(fd,
 		distlock.WithClock(fc),
 		distlock.WithRenewFraction(0.5),
 	)
@@ -1069,7 +1069,7 @@ func TestLocker_WithMaxRenewAttempts_Validation(t *testing.T) {
 					t.Errorf("New with maxRenewAttempts=%d should panic", tc.n)
 				}
 			}()
-			_ = distlock.New(fd, distlock.WithMaxRenewAttempts(tc.n))
+			_ = distlock.MustNew(fd, distlock.WithMaxRenewAttempts(tc.n))
 		})
 	}
 }

--- a/runtime/distlock/manager_test.go
+++ b/runtime/distlock/manager_test.go
@@ -66,7 +66,7 @@ func TestManager_HeapOrder(t *testing.T) {
 	fd := locktest.NewFakeDriver()
 	fd.WithClock(fc.Now)
 
-	l := distlock.New(fd,
+	l := distlock.MustNew(fd,
 		distlock.WithClock(fc),
 		distlock.WithRenewFraction(0.5),
 	)
@@ -127,7 +127,7 @@ func TestManager_HeapOrder(t *testing.T) {
 func TestManager_Lifecycle_LazyStart(t *testing.T) {
 	fc := locktest.NewFakeClock(time.Time{})
 	fd := locktest.NewFakeDriver()
-	l := distlock.New(fd, distlock.WithClock(fc))
+	l := distlock.MustNew(fd, distlock.WithClock(fc))
 
 	_, release, err := l.Acquire(context.Background(), "lifecycle-key", 10*time.Second)
 	if err != nil {
@@ -154,7 +154,7 @@ func TestManager_Lifecycle_LazyStart(t *testing.T) {
 func TestManager_SnapshotLocks(t *testing.T) {
 	fc := locktest.NewFakeClock(time.Time{})
 	fd := locktest.NewFakeDriver()
-	l := distlock.New(fd, distlock.WithClock(fc))
+	l := distlock.MustNew(fd, distlock.WithClock(fc))
 
 	if mgr(l).Snapshot().Locks != 0 {
 		t.Errorf("SnapshotLocks: initial count should be 0")

--- a/runtime/distlock/token_test.go
+++ b/runtime/distlock/token_test.go
@@ -22,7 +22,7 @@ func TestRandomToken_LengthAndUniqueness(t *testing.T) {
 
 	fc := locktest.NewFakeClock(time.Time{})
 	fd := locktest.NewFakeDriver()
-	l := distlock.New(fd, distlock.WithClock(fc))
+	l := distlock.MustNew(fd, distlock.WithClock(fc))
 
 	tokens := make(map[string]bool, n)
 	releases := make([]func() error, 0, n)

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -151,24 +151,30 @@ func New(asm *assembly.CoreAssembly, opts ...Option) *Handler {
 	return h
 }
 
-// RegisterChecker adds a named readiness checker. It panics if a checker with
-// the same name is already registered (fail-fast at startup, matching Go
-// convention for registration functions like http.HandleFunc). Passing a nil
-// fn also panics for the same reason.
+// RegisterChecker adds a named readiness checker. It returns an error when a
+// checker with the same name is already registered or when fn is nil.
 //
 // The supplied function is wrapped with wrapCtxSafe before being stored, so
 // the effective Checker honours ctx.Done regardless of the inner
 // implementation's cooperativeness. See wrapCtxSafe for the full contract.
-func (h *Handler) RegisterChecker(name string, fn Checker) {
+func (h *Handler) RegisterChecker(name string, fn Checker) error {
 	if fn == nil {
-		panic(fmt.Sprintf("health: nil checker for %q", name))
+		return fmt.Errorf("health: nil checker for %q", name)
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if _, exists := h.checkers[name]; exists {
-		panic(fmt.Sprintf("health: duplicate checker name %q", name))
+		return fmt.Errorf("health: duplicate checker name %q", name)
 	}
 	h.checkers[name] = wrapCtxSafe(fn)
+	return nil
+}
+
+// MustRegisterChecker is the static-wiring variant of RegisterChecker.
+func (h *Handler) MustRegisterChecker(name string, fn Checker) {
+	if err := h.RegisterChecker(name, fn); err != nil {
+		panic(err.Error())
+	}
 }
 
 // SetVerboseToken sets a bearer token that must be provided via the

--- a/runtime/http/health/health_test.go
+++ b/runtime/http/health/health_test.go
@@ -443,6 +443,25 @@ func TestRegisterChecker_DuplicateReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), `duplicate checker name "db"`)
 }
 
+func TestRegisterChecker_NilCheckerReturnsError(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
+	h := New(asm)
+
+	err := h.RegisterChecker("db", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `nil checker for "db"`)
+}
+
+func TestMustRegisterChecker_PanicsOnError(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
+	h := New(asm)
+
+	require.Panics(t, func() {
+		h.MustRegisterChecker("db", nil)
+	})
+}
+
 func TestReadyz_ShuttingDown_Returns503(t *testing.T) {
 	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Start(context.Background()))

--- a/runtime/http/health/health_test.go
+++ b/runtime/http/health/health_test.go
@@ -433,14 +433,14 @@ func TestReadyzVerboseQueryParsing(t *testing.T) {
 	}
 }
 
-func TestRegisterChecker_DuplicatePanics(t *testing.T) {
+func TestRegisterChecker_DuplicateReturnsError(t *testing.T) {
 	asm := assembly.New(assembly.Config{ID: "test", DurabilityMode: cell.DurabilityDemo})
 	h := New(asm)
-	h.RegisterChecker("db", func(_ context.Context) error { return nil })
+	require.NoError(t, h.RegisterChecker("db", func(_ context.Context) error { return nil }))
 
-	assert.PanicsWithValue(t, `health: duplicate checker name "db"`, func() {
-		h.RegisterChecker("db", func(_ context.Context) error { return nil })
-	})
+	err := h.RegisterChecker("db", func(_ context.Context) error { return nil })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate checker name "db"`)
 }
 
 func TestReadyz_ShuttingDown_Returns503(t *testing.T) {

--- a/runtime/http/middleware/circuit_breaker.go
+++ b/runtime/http/middleware/circuit_breaker.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"net/http"
 	"reflect"
-	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -131,26 +130,16 @@ func circuitBreakerServe(cb Allower, next http.Handler, w http.ResponseWriter, r
 
 	state, w, r := ensureRecorder(w, r)
 
-	// Use recover to guarantee done(err) on panic, then write the same
-	// structured 500 body Recovery would produce.
-	// Without this, a standalone breaker (no Recovery middleware) would
-	// see the default status 200 and record success for a crashing handler.
+	// Recover only long enough to report a breaker failure, then re-panic so
+	// the outer Recovery middleware remains the single panic-to-HTTP and
+	// panic-to-tracing boundary.
 	//
 	// ref: sony/gobreaker — Execute treats panic as failure
 	// ref: go-kit/kit circuitbreaker — panic paths count as failed calls
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			done(errServerFailure)
-			slog.ErrorContext(r.Context(), "circuitbreaker: downstream handler panic",
-				slog.Any("panic", recovered),
-				slog.String("stack", string(debug.Stack())),
-				slog.String("method", r.Method),
-				slog.String("path", r.URL.Path))
-			if !state.Committed() {
-				httputil.WriteError(r.Context(), w, http.StatusInternalServerError,
-					string(errcode.ErrInternal), "internal server error")
-			}
-			return
+			repanicAfterBreakerFailure(recovered)
 		}
 		if state.Status() >= 500 {
 			done(errServerFailure)
@@ -160,6 +149,14 @@ func circuitBreakerServe(cb Allower, next http.Handler, w http.ResponseWriter, r
 	}()
 
 	next.ServeHTTP(w, r)
+}
+
+// repanicAfterBreakerFailure is the narrow architectural re-panic point used by
+// CircuitBreaker after it has reported handler panics as breaker failures. It
+// preserves the in-flight panic for the outer Recovery middleware, which owns
+// panic logging, tracing, and HTTP 500 serialization.
+func repanicAfterBreakerFailure(recovered any) {
+	panic(recovered)
 }
 
 // ensureRecorder returns the existing RecorderState from context, or creates a

--- a/runtime/http/middleware/circuit_breaker.go
+++ b/runtime/http/middleware/circuit_breaker.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"reflect"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -80,7 +81,7 @@ func IsTypedNilAllower(cb Allower) bool {
 // failure, everything else = success).
 //
 // The done callback is invoked via defer to guarantee it is called even when
-// the downstream handler panics (the panic is re-raised after reporting).
+// the downstream handler panics.
 //
 // The middleware reuses an existing RecorderState from context (created by the
 // Recorder middleware). If none exists, it creates its own so it remains
@@ -88,15 +89,25 @@ func IsTypedNilAllower(cb Allower) bool {
 //
 // ref: sony/gobreaker — TwoStepCircuitBreaker for HTTP request protection
 // ref: go-kit/kit circuitbreaker — middleware wrapping pattern
-func CircuitBreaker(cb Allower) func(http.Handler) http.Handler {
-	if cb == nil {
-		panic("middleware: Allower must not be nil")
+func CircuitBreaker(cb Allower) (func(http.Handler) http.Handler, error) {
+	if cb == nil || IsTypedNilAllower(cb) {
+		return nil, errcode.New(errcode.ErrValidationFailed, "middleware: Allower must not be nil")
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			circuitBreakerServe(cb, next, w, r)
 		})
+	}, nil
+}
+
+// MustCircuitBreaker is the composition-root fail-fast variant of
+// CircuitBreaker.
+func MustCircuitBreaker(cb Allower) func(http.Handler) http.Handler {
+	mw, err := CircuitBreaker(cb)
+	if err != nil {
+		panic(err.Error())
 	}
+	return mw
 }
 
 // circuitBreakerServe is the per-request handler for the CircuitBreaker
@@ -120,18 +131,26 @@ func circuitBreakerServe(cb Allower, next http.Handler, w http.ResponseWriter, r
 
 	state, w, r := ensureRecorder(w, r)
 
-	// Use recover to guarantee done(err) on panic, then re-panic.
+	// Use recover to guarantee done(err) on panic, then write the same
+	// structured 500 body Recovery would produce.
 	// Without this, a standalone breaker (no Recovery middleware) would
 	// see the default status 200 and record success for a crashing handler.
-	// With Recovery in the chain, Recovery catches first and writes 500,
-	// so recover() here returns nil and we fall through to status-based logic.
 	//
 	// ref: sony/gobreaker — Execute treats panic as failure
-	// ref: go-kit/kit circuitbreaker — panic propagates after failure recording
+	// ref: go-kit/kit circuitbreaker — panic paths count as failed calls
 	defer func() {
-		if p := recover(); p != nil {
+		if recovered := recover(); recovered != nil {
 			done(errServerFailure)
-			panic(p)
+			slog.ErrorContext(r.Context(), "circuitbreaker: downstream handler panic",
+				slog.Any("panic", recovered),
+				slog.String("stack", string(debug.Stack())),
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path))
+			if !state.Committed() {
+				httputil.WriteError(r.Context(), w, http.StatusInternalServerError,
+					string(errcode.ErrInternal), "internal server error")
+			}
+			return
 		}
 		if state.Status() >= 500 {
 			done(errServerFailure)

--- a/runtime/http/middleware/circuit_breaker_test.go
+++ b/runtime/http/middleware/circuit_breaker_test.go
@@ -99,14 +99,32 @@ func TestCircuitBreaker_HandlerPanic_DoneStillCalled(t *testing.T) {
 	ctx := WithRecorderState(req.Context(), state)
 	req = req.WithContext(ctx)
 
-	assert.NotPanics(t, func() {
+	assert.PanicsWithValue(t, "handler panic test", func() {
 		handler.ServeHTTP(wrapped, req)
-	}, "panic must be converted into structured 500")
+	}, "circuit breaker must re-panic so outer Recovery can observe the panic")
 
 	require.True(t, cb.doneInvoked, "done callback must be invoked even when handler panics")
 	require.NotNil(t, cb.doneErr)
 	assert.Error(t, *cb.doneErr,
 		"panic must always be recorded as failure, regardless of status code")
+}
+
+func TestCircuitBreaker_WithRecovery_HandlerPanic_RecoveryWrites500(t *testing.T) {
+	cb := &mockBreaker{}
+	handler := Recorder(Recovery(MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		panic("handler panic test")
+	}))))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	assert.NotPanics(t, func() {
+		handler.ServeHTTP(rec, req)
+	}, "outer Recovery must remain responsible for converting panic to HTTP 500")
+
+	require.True(t, cb.doneInvoked, "done callback must be invoked even when handler panics")
+	require.NotNil(t, cb.doneErr)
+	assert.Error(t, *cb.doneErr)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 

--- a/runtime/http/middleware/circuit_breaker_test.go
+++ b/runtime/http/middleware/circuit_breaker_test.go
@@ -198,6 +198,12 @@ func TestCircuitBreaker_NilBreaker_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMustCircuitBreaker_NilBreaker_Panics(t *testing.T) {
+	require.Panics(t, func() {
+		MustCircuitBreaker(nil)
+	})
+}
+
 // TestIsTypedNilAllower verifies that IsTypedNilAllower detects typed-nil
 // pointers wrapped in an Allower interface value.
 func TestIsTypedNilAllower(t *testing.T) {

--- a/runtime/http/middleware/circuit_breaker_test.go
+++ b/runtime/http/middleware/circuit_breaker_test.go
@@ -30,7 +30,7 @@ func (m *mockBreaker) Allow() (bool, func(error)) {
 
 func TestCircuitBreaker_Closed_PassesThrough(t *testing.T) {
 	cb := &mockBreaker{}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -51,7 +51,7 @@ func TestCircuitBreaker_Closed_PassesThrough(t *testing.T) {
 
 func TestCircuitBreaker_Open_Returns503(t *testing.T) {
 	cb := &mockBreaker{open: true}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called when circuit is open")
 	}))
 
@@ -73,7 +73,7 @@ func TestCircuitBreaker_Open_Returns503(t *testing.T) {
 
 func TestCircuitBreaker_Standalone_NoRecorderState(t *testing.T) {
 	cb := &mockBreaker{}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -89,7 +89,7 @@ func TestCircuitBreaker_Standalone_NoRecorderState(t *testing.T) {
 
 func TestCircuitBreaker_HandlerPanic_DoneStillCalled(t *testing.T) {
 	cb := &mockBreaker{}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		panic("handler panic test")
 	}))
 
@@ -99,19 +99,20 @@ func TestCircuitBreaker_HandlerPanic_DoneStillCalled(t *testing.T) {
 	ctx := WithRecorderState(req.Context(), state)
 	req = req.WithContext(ctx)
 
-	assert.Panics(t, func() {
+	assert.NotPanics(t, func() {
 		handler.ServeHTTP(wrapped, req)
-	}, "panic must propagate")
+	}, "panic must be converted into structured 500")
 
 	require.True(t, cb.doneInvoked, "done callback must be invoked even when handler panics")
 	require.NotNil(t, cb.doneErr)
 	assert.Error(t, *cb.doneErr,
 		"panic must always be recorded as failure, regardless of status code")
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestCircuitBreaker_HandlerError5xx_ReportsFalse(t *testing.T) {
 	cb := &mockBreaker{}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
@@ -130,7 +131,7 @@ func TestCircuitBreaker_HandlerError5xx_ReportsFalse(t *testing.T) {
 
 func TestCircuitBreaker_HandlerError4xx_ReportsTrue(t *testing.T) {
 	cb := &mockBreaker{}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
 
@@ -163,7 +164,7 @@ func TestCircuitBreaker_Open_RetryAfterHeader(t *testing.T) {
 		mockBreaker: mockBreaker{open: true},
 		retryAfter:  30 * time.Second,
 	}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
 
@@ -178,7 +179,7 @@ func TestCircuitBreaker_Open_RetryAfterHeader(t *testing.T) {
 
 func TestCircuitBreaker_Open_NoRetryAfterWithoutInterface(t *testing.T) {
 	cb := &mockBreaker{open: true}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
 
@@ -191,10 +192,10 @@ func TestCircuitBreaker_Open_NoRetryAfterWithoutInterface(t *testing.T) {
 		"Retry-After must not be set when policy does not implement CircuitBreakerRetryAfter")
 }
 
-func TestCircuitBreaker_NilBreaker_Panics(t *testing.T) {
-	assert.Panics(t, func() {
-		CircuitBreaker(nil)
-	}, "nil Allower must panic at construction time")
+func TestCircuitBreaker_NilBreaker_ReturnsError(t *testing.T) {
+	mw, err := CircuitBreaker(nil)
+	assert.Nil(t, mw)
+	assert.Error(t, err)
 }
 
 // TestIsTypedNilAllower verifies that IsTypedNilAllower detects typed-nil
@@ -238,7 +239,7 @@ func TestAllower_ISP(t *testing.T) {
 	var _ Allower = (*allowerOnly)(nil) // compile-time check
 
 	cb := &allowerOnly{mockBreaker: mockBreaker{open: true}}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not reach handler")
 	}))
 
@@ -254,7 +255,7 @@ func TestAllower_ISP(t *testing.T) {
 func TestCircuitBreaker_204_ReportsSuccess(t *testing.T) {
 	// 204 No Content is a success status; done must receive nil error.
 	cb := &mockBreaker{}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
@@ -283,7 +284,7 @@ func TestCircuitBreaker_3xx_ReportsSuccess(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cb := &mockBreaker{}
-			handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tc.code)
 			}))
 
@@ -331,7 +332,7 @@ func TestCircuitBreaker_StateMachineTransition_AllowDoneAllow(t *testing.T) {
 	sb := &statefulMockBreaker{}
 
 	// First request: circuit closed, handler returns 500, done receives non-nil error.
-	handler1 := CircuitBreaker(sb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler1 := MustCircuitBreaker(sb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	rec1 := httptest.NewRecorder()
@@ -347,7 +348,7 @@ func TestCircuitBreaker_StateMachineTransition_AllowDoneAllow(t *testing.T) {
 	assert.Error(t, *sb.doneErr, "5xx must pass non-nil error to done")
 
 	// Second request: same breaker instance is now open — must return 503.
-	handler2 := CircuitBreaker(sb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler2 := MustCircuitBreaker(sb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler must not be called when circuit is open")
 	}))
 	rec2 := httptest.NewRecorder()
@@ -372,7 +373,7 @@ func (n *nilDoneBreaker) Allow() (bool, func(error)) {
 // 200) without panicking.
 func TestCircuitBreaker_AllowerReturnsNilDone_NoPanic(t *testing.T) {
 	cb := &nilDoneBreaker{}
-	handler := CircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := MustCircuitBreaker(cb)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/runtime/http/middleware/real_ip.go
+++ b/runtime/http/middleware/real_ip.go
@@ -64,7 +64,7 @@ func newProxyCheckerStrict(proxies []string) (*proxyChecker, error) {
 
 // ValidateTrustedProxies validates all entries and returns the constructed
 // proxyChecker for reuse. Returns a descriptive error for the first invalid
-// entry. Used by router.New() for fail-fast validation at construction time,
+// entry. Used by router.MustNew() for fail-fast validation at construction time,
 // eliminating the need to parse proxies twice (once to validate, once to use).
 //
 // ref: gin-gonic/gin — SetTrustedProxies validates eagerly at config time

--- a/runtime/http/router/adapter_test.go
+++ b/runtime/http/router/adapter_test.go
@@ -11,18 +11,18 @@ import (
 )
 
 func TestWithBodyLimit(t *testing.T) {
-	r := New(WithBodyLimit(1024))
+	r := MustNew(WithBodyLimit(1024))
 	assert.Equal(t, int64(1024), r.bodyLimit)
 }
 
 func TestWithTrustedProxies(t *testing.T) {
 	proxies := []string{"10.0.0.0/8", "192.168.1.1"}
-	r := New(WithTrustedProxies(proxies))
+	r := MustNew(WithTrustedProxies(proxies))
 	assert.Equal(t, proxies, r.trustedProxies)
 }
 
 func TestWithTrustedProxies_Integration(t *testing.T) {
-	r := New(WithTrustedProxies([]string{"10.0.0.0/8"}))
+	r := MustNew(WithTrustedProxies([]string{"10.0.0.0/8"}))
 
 	var gotIP string
 	r.Handle("GET /check-ip", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -44,13 +44,13 @@ func TestWithTrustedProxies_Integration(t *testing.T) {
 
 func TestRouter_Handler(t *testing.T) {
 	// PR-A14b: each Router has a single Handler() serving its listener's mux.
-	r := New()
+	r := MustNew()
 	assert.NotNil(t, r.Handler())
 	assert.Equal(t, r.mux, r.Handler())
 }
 
 func TestRouteGroup_Route(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Route("/api", func(mux kcell.RouteMux) {
 		mux.Route("/v2", func(sub kcell.RouteMux) {
 			sub.Handle("/ping", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -68,7 +68,7 @@ func TestRouteGroup_Route(t *testing.T) {
 }
 
 func TestRouteGroup_Mount(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Route("/api", func(mux kcell.RouteMux) {
 		subHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -84,7 +84,7 @@ func TestRouteGroup_Mount(t *testing.T) {
 }
 
 func TestRouteGroup_Group(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Route("/api", func(mux kcell.RouteMux) {
 		mux.Group(func(sub kcell.RouteMux) {
 			sub.Handle("/grouped", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -101,7 +101,7 @@ func TestRouteGroup_Group(t *testing.T) {
 }
 
 func TestRouteGroup_With(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Route("/api", func(mux kcell.RouteMux) {
 		authed := mux.With(func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +122,7 @@ func TestRouteGroup_With(t *testing.T) {
 }
 
 func TestWith(t *testing.T) {
-	r := New()
+	r := MustNew()
 	authed := r.With(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.Header().Set("X-Root", "yes")

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
+	"reflect"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -25,6 +26,8 @@ import (
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
@@ -124,11 +127,25 @@ func WithCircuitBreaker(cb middleware.Allower) Option {
 // ref: go-kratos/kratos — auth middleware at service level with selector-based bypass
 // ref: go-zero — per-route WithJwt() opt-in auth
 func WithAuthMiddleware(verifier auth.IntentTokenVerifier) Option {
-	if verifier == nil {
-		panic("router: WithAuthMiddleware requires a non-nil IntentTokenVerifier")
-	}
 	return func(r *Router) {
+		if isNilIntentTokenVerifier(verifier) {
+			r.authVerifierNil = true
+			return
+		}
 		r.authVerifier = verifier
+	}
+}
+
+func isNilIntentTokenVerifier(verifier auth.IntentTokenVerifier) bool {
+	if verifier == nil {
+		return true
+	}
+	v := reflect.ValueOf(verifier)
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return v.IsNil()
+	default:
+		return false
 	}
 }
 
@@ -270,6 +287,7 @@ type Router struct {
 	circuitBreaker      middleware.Allower
 	circuitBreakerNil   bool
 	authVerifier        auth.IntentTokenVerifier
+	authVerifierNil     bool
 	authMetrics         *auth.AuthMetrics
 	securityHeadersOpts []middleware.SecurityHeadersOption
 	bodyLimit           int64
@@ -334,31 +352,24 @@ func earlyResponderMiddleware(er earlyResponder) func(http.Handler) http.Handler
 const internalPathPrefix = kcell.InternalPathPrefix
 
 // New creates a Router with default middleware and optional configuration.
-// Convenience wrapper around NewForListener using cell.PrimaryListener and
-// no default policy (PolicyNone semantics: observability only, no auth).
-//
-// It panics if the configuration is invalid.
-// Use NewE for an error-returning variant suitable for managed startup.
-func New(opts ...Option) *Router {
-	r, err := NewE(opts...)
-	if err != nil {
-		panic(err)
-	}
-	return r
-}
-
-// NewE creates a Router with default middleware and optional configuration.
-// Unlike New, it returns an error instead of panicking on invalid
-// configuration, making it suitable for Bootstrap.Run and other managed
-// startup sequences.
+// It returns an error when configuration is invalid.
 //
 // The resulting Router serves the zero-value ListenerRef (no listener
 // affinity). For production use call NewForListener instead.
 //
 // ref: gin-gonic/gin — SetTrustedProxies returns error at config time
 // ref: uber-go/fx — startup failures return error, trigger rollback
-func NewE(opts ...Option) (*Router, error) {
+func New(opts ...Option) (*Router, error) {
 	return NewForListener(kcell.ListenerRef{}, opts...)
+}
+
+// MustNew is the composition-root fail-fast variant of New.
+func MustNew(opts ...Option) *Router {
+	r, err := New(opts...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return r
 }
 
 // NewForListener builds a Router for a specific listener. Listener-level
@@ -392,13 +403,18 @@ func NewForListener(ref kcell.ListenerRef, opts ...Option) (*Router, error) {
 	if r.circuitBreakerNil {
 		return nil, fmt.Errorf("router: circuit breaker must not be nil")
 	}
+	if r.authVerifierNil {
+		return nil, fmt.Errorf("router: auth middleware verifier must not be nil")
+	}
 
 	realIPMW, err := r.buildRealIPMiddleware()
 	if err != nil {
 		return nil, err
 	}
 
-	r.buildMux(realIPMW)
+	if err := r.buildMux(realIPMW); err != nil {
+		return nil, err
+	}
 	return r, nil
 }
 
@@ -408,11 +424,16 @@ func NewForListener(ref kcell.ListenerRef, opts ...Option) (*Router, error) {
 func (r *Router) Handler() http.Handler { return r.mux }
 
 // ServeHTTP delegates to the router's mux, making Router drop-in compatible
-// with http.Handler. Panics if FinalizeAuth has not been called when auth route
-// metadata has been declared.
+// with http.Handler. If auth route metadata was declared but FinalizeAuth was
+// not called, ServeHTTP fails closed with 500 instead of serving routes with
+// incomplete auth state.
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if len(r.declaredAuthMetas) > 0 && !r.authFinalized {
-		panic("router: FinalizeAuth must be called before ServeHTTP when auth route metadata has been declared")
+		slog.ErrorContext(req.Context(), "router: FinalizeAuth must be called before ServeHTTP",
+			slog.Int("declared_auth_routes", len(r.declaredAuthMetas)))
+		httputil.WriteError(req.Context(), w, http.StatusInternalServerError,
+			string(errcode.ErrInternal), "internal server error")
+		return
 	}
 	r.mux.ServeHTTP(w, req)
 }
@@ -440,7 +461,7 @@ func (r *Router) buildRealIPMiddleware() (func(http.Handler) http.Handler, error
 //	RequestID → RealIP → Recorder → [Tracing] → AccessLog → [Metrics]
 //	→ Recovery → SecurityHeaders → [earlyResponders] → [defaultMiddleware]
 //	→ [RateLimit] → [CircuitBreaker] → [Auth] → BodyLimit → handlers
-func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) {
+func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	// Lazy public predicate so Tracing/RequestID honour public routes declared
 	// later via auth.Mount / FinalizeAuth.
 	lazyPublic := func(req *http.Request) bool {
@@ -501,12 +522,17 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) {
 		r.mux.Use(middleware.RateLimit(r.rateLimiter))
 	}
 	if r.circuitBreaker != nil {
-		r.mux.Use(middleware.CircuitBreaker(r.circuitBreaker))
+		cb, err := middleware.CircuitBreaker(r.circuitBreaker)
+		if err != nil {
+			return fmt.Errorf("router: circuit breaker middleware: %w", err)
+		}
+		r.mux.Use(cb)
 	}
 	if r.authVerifier != nil {
 		r.mux.Use(auth.AuthMiddleware(r.authVerifier, r.buildAuthOpts()...))
 	}
 	r.mux.Use(middleware.BodyLimit(r.bodyLimit))
+	return nil
 }
 
 // buildAuthOpts constructs the AuthOption slice for the auth middleware.
@@ -574,27 +600,29 @@ func (r *Router) With(mw ...func(http.Handler) http.Handler) kcell.RouteMux {
 // compiles the accumulated metas into matchers that the AuthMiddleware reads
 // via lazy closures installed in buildAuthOpts.
 //
-// Panics if called after FinalizeAuth — all declarations must precede the
-// compile step.
-func (r *Router) DeclareAuthMeta(m kcell.AuthRouteMeta) {
+// Returns an error if called after FinalizeAuth — all declarations must precede
+// the compile step.
+func (r *Router) DeclareAuthMeta(m kcell.AuthRouteMeta) error {
 	if r.authFinalized {
-		panic(fmt.Sprintf(
+		return fmt.Errorf(
 			"router: DeclareAuthMeta called after FinalizeAuth — route %s %s must be declared before FinalizeAuth",
-			m.Method, m.Path))
+			m.Method, m.Path)
 	}
 	r.declaredAuthMetas = append(r.declaredAuthMetas, m)
+	return nil
 }
 
 // DeclareHTTPContract implements cell.HTTPContractDeclarer. It stores the
 // route contract metadata separately from auth metadata so Tracing can tag
 // spans for requests rejected before reaching wrapper.HTTPHandler.
-func (r *Router) DeclareHTTPContract(spec wrapper.ContractSpec) {
+func (r *Router) DeclareHTTPContract(spec wrapper.ContractSpec) error {
 	if r.authFinalized {
-		panic(fmt.Sprintf(
+		return fmt.Errorf(
 			"router: DeclareHTTPContract called after FinalizeAuth — route %s %s must be declared before FinalizeAuth",
-			spec.Method, spec.Path))
+			spec.Method, spec.Path)
 	}
 	r.declaredHTTPContracts = append(r.declaredHTTPContracts, spec)
+	return nil
 }
 
 // FinalizeAuth compiles all accumulated AuthRouteMeta declarations into
@@ -944,26 +972,27 @@ func (a *chiRouterAdapter) With(mw ...func(http.Handler) http.Handler) kcell.Rou
 
 // DeclareAuthMeta composes the adapter's mount prefix with the declared path
 // before handing the metadata off to the Router.
-func (a *chiRouterAdapter) DeclareAuthMeta(m kcell.AuthRouteMeta) {
+func (a *chiRouterAdapter) DeclareAuthMeta(m kcell.AuthRouteMeta) error {
 	if a.declarer == nil {
-		return
+		return nil
 	}
 	if a.prefix != "" {
 		m.Path = joinPrefix(a.prefix, m.Path)
 	}
-	a.declarer.DeclareAuthMeta(m)
+	return a.declarer.DeclareAuthMeta(m)
 }
 
 // DeclareHTTPContract forwards the route's full ContractSpec to the
 // Router-rooted declarer. ContractSpec.Path is already the canonical full
 // path, so unlike AuthRouteMeta it is not composed with the chi prefix.
-func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) {
+func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error {
 	if a.declarer == nil {
-		return
+		return nil
 	}
 	if declarer, ok := a.declarer.(kcell.HTTPContractDeclarer); ok {
-		declarer.DeclareHTTPContract(spec)
+		return declarer.DeclareHTTPContract(spec)
 	}
+	return nil
 }
 
 // joinPrefix composes a parent mount prefix with a child pattern/path,

--- a/runtime/http/router/router_authmeta_test.go
+++ b/runtime/http/router/router_authmeta_test.go
@@ -50,7 +50,7 @@ var okHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 // ---------------------------------------------------------------------------
 
 func TestAuthDeclare_NestedRoute_ForwardsWithPrefix(t *testing.T) {
-	r := New()
+	r := MustNew()
 
 	// Cells commonly register routes under nested mux.Route scopes:
 	//   mux.Route("/api/v1", func(v1) { v1.Route("/access", func(a) {
@@ -82,12 +82,12 @@ func TestAuthDeclare_NestedRoute_ForwardsWithPrefix(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDeclareAuthMeta_Accumulates(t *testing.T) {
-	r := New()
+	r := MustNew()
 	m1 := kcell.AuthRouteMeta{Method: "GET", Path: "/a", Public: true}
 	m2 := kcell.AuthRouteMeta{Method: "POST", Path: "/b", PasswordResetExempt: true}
 
-	r.DeclareAuthMeta(m1)
-	r.DeclareAuthMeta(m2)
+	require.NoError(t, r.DeclareAuthMeta(m1))
+	require.NoError(t, r.DeclareAuthMeta(m2))
 
 	require.Len(t, r.declaredAuthMetas, 2)
 	assert.Equal(t, m1, r.declaredAuthMetas[0])
@@ -99,7 +99,7 @@ func TestDeclareAuthMeta_Accumulates(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestFinalizeAuth_EmptyDeclaration_NoOp(t *testing.T) {
-	r := New()
+	r := MustNew()
 	err := r.FinalizeAuth()
 	require.NoError(t, err)
 	assert.True(t, r.authFinalized)
@@ -129,10 +129,10 @@ func TestFinalizeAuth_InternalPathOnPrimary_Rejected(t *testing.T) {
 	r, err := NewForListener(kcell.PrimaryListener)
 	require.NoError(t, err)
 	// Declare an internal-path meta directly (auth.Route no longer has Delegated).
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{
+	require.NoError(t, r.DeclareAuthMeta(kcell.AuthRouteMeta{
 		Method: "POST",
 		Path:   "/internal/v1/devices/cmd",
-	})
+	}))
 	err = r.FinalizeAuth()
 	require.Error(t, err, "FinalizeAuth must reject /internal/v1/* on PrimaryListener")
 	assert.Contains(t, err.Error(), "must be mounted on InternalListener")
@@ -142,10 +142,10 @@ func TestFinalizeAuth_InternalPathOnPrimary_Rejected(t *testing.T) {
 func TestFinalizeAuth_InternalPathOnHealth_Rejected(t *testing.T) {
 	r, err := NewForListener(kcell.HealthListener)
 	require.NoError(t, err)
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{
+	require.NoError(t, r.DeclareAuthMeta(kcell.AuthRouteMeta{
 		Method: "GET",
 		Path:   "/internal/v1/probe",
-	})
+	}))
 	err = r.FinalizeAuth()
 	require.Error(t, err, "FinalizeAuth must reject /internal/v1/* on HealthListener")
 	assert.Contains(t, err.Error(), "must be mounted on InternalListener")
@@ -163,10 +163,10 @@ func TestFinalizeAuth_InternalPathOnInternal_Accepted(t *testing.T) {
 }
 
 func TestFinalizeAuth_InternalPathOnZeroRef_Accepted(t *testing.T) {
-	// Unit-test routers built via New() / NewE() have a zero-value ListenerRef;
+	// Unit-test routers built via New() / New() have a zero-value ListenerRef;
 	// the consistency check skips the listener-identity rule for that case so
 	// existing test fixtures stay valid.
-	r := New()
+	r := MustNew()
 	auth.MustMount(r, auth.Route{
 		Contract: testHTTPContract("GET", "/internal/v1/probe"),
 		Handler:  okHandler,
@@ -179,7 +179,7 @@ func TestFinalizeAuth_NoVerifier_EmitsWarn_ByDefault(t *testing.T) {
 	buf, restore := captureSlogWarn(t)
 	defer restore()
 
-	r := New() // no AuthMiddleware, no suppression
+	r := MustNew() // no AuthMiddleware, no suppression
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/healthz"), Handler: okHandler, Public: true})
 	require.NoError(t, r.FinalizeAuth())
 
@@ -192,7 +192,7 @@ func TestFinalizeAuth_NoVerifier_SuppressedWarn_NoOutput(t *testing.T) {
 	defer restore()
 
 	// Mirrors how bootstrap wires HealthListener routers post-R2-11.
-	r, err := NewE(WithSuppressNoAuthVerifierWarn())
+	r, err := New(WithSuppressNoAuthVerifierWarn())
 	require.NoError(t, err)
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/healthz"), Handler: okHandler, Public: true})
 	require.NoError(t, r.FinalizeAuth())
@@ -207,7 +207,7 @@ func TestFinalizeAuth_NoVerifier_SuppressedWarn_NoOutput(t *testing.T) {
 
 func TestFinalizeAuth_PublicMeta_BypassesAuth(t *testing.T) {
 	verifier := &authMetaVerifier{err: assert.AnError} // should not be called for public
-	r, err := NewE(WithAuthMiddleware(verifier))
+	r, err := New(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
@@ -236,7 +236,7 @@ func TestFinalizeAuth_PasswordResetExempt_Meta(t *testing.T) {
 	verifier := &authMetaVerifier{
 		claims: auth.Claims{Subject: "usr-1", PasswordResetRequired: true},
 	}
-	r, err := NewE(WithAuthMiddleware(verifier))
+	r, err := New(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
@@ -269,9 +269,9 @@ func TestFinalizeAuth_PasswordResetExempt_Meta(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestFinalizeAuth_DuplicateMeta_ReturnsError(t *testing.T) {
-	r := New()
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/dup", Public: true})
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/dup", Public: true})
+	r := MustNew()
+	require.NoError(t, r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/dup", Public: true}))
+	require.NoError(t, r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/dup", Public: true}))
 
 	err := r.FinalizeAuth()
 	require.Error(t, err)
@@ -279,16 +279,16 @@ func TestFinalizeAuth_DuplicateMeta_ReturnsError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// DeclareAuthMeta after FinalizeAuth panics
+// DeclareAuthMeta after FinalizeAuth returns an error
 // ---------------------------------------------------------------------------
 
-func TestDeclareAuthMeta_AfterFinalized_Panics(t *testing.T) {
-	r := New()
+func TestDeclareAuthMeta_AfterFinalized_ReturnsError(t *testing.T) {
+	r := MustNew()
 	require.NoError(t, r.FinalizeAuth())
 
-	assert.Panics(t, func() {
-		r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/late", Public: true})
-	}, "DeclareAuthMeta after FinalizeAuth must panic")
+	err := r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/late", Public: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DeclareAuthMeta called after FinalizeAuth")
 }
 
 // ---------------------------------------------------------------------------
@@ -296,7 +296,7 @@ func TestDeclareAuthMeta_AfterFinalized_Panics(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestFinalizeAuth_CalledTwice_ReturnsError(t *testing.T) {
-	r := New()
+	r := MustNew()
 	require.NoError(t, r.FinalizeAuth())
 
 	err := r.FinalizeAuth()
@@ -312,7 +312,7 @@ func TestFinalizeAuth_HintDerivedFromPostExemptMeta(t *testing.T) {
 	verifier := &authMetaVerifier{
 		claims: auth.Claims{Subject: "usr-1", PasswordResetRequired: true},
 	}
-	r, err := NewE(WithAuthMiddleware(verifier))
+	r, err := New(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
@@ -344,7 +344,7 @@ func TestFinalizeAuth_MultipleDeclaredPublic_ORMerged(t *testing.T) {
 	// Both declared-public-a and declared-public-b should bypass auth;
 	// /protected must still require a token.
 	verifier := &authMetaVerifier{err: assert.AnError}
-	r, err := NewE(WithAuthMiddleware(verifier))
+	r, err := New(WithAuthMiddleware(verifier))
 	require.NoError(t, err)
 
 	// Use auth.Mount so every registered route has a corresponding auth declaration.
@@ -373,28 +373,23 @@ func TestFinalizeAuth_MultipleDeclaredPublic_ORMerged(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// F3: ServeHTTP panics when metas declared but FinalizeAuth not called
+// F3: ServeHTTP fails closed when metas declared but FinalizeAuth not called
 // ---------------------------------------------------------------------------
 
-func TestServeHTTP_AuthMetasWithoutFinalize_Panics(t *testing.T) {
-	r := New()
+func TestServeHTTP_AuthMetasWithoutFinalize_FailsClosed(t *testing.T) {
+	r := MustNew()
 	r.Handle("/guarded", okHandler)
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/guarded", Public: true})
+	require.NoError(t, r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/guarded", Public: true}))
 	// FinalizeAuth intentionally NOT called.
 
-	assert.PanicsWithValue(t,
-		"router: FinalizeAuth must be called before ServeHTTP when auth route metadata has been declared",
-		func() {
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/guarded", nil)
-			r.ServeHTTP(rec, req)
-		},
-		"ServeHTTP must panic when metas are declared but FinalizeAuth was not called",
-	)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/guarded", nil)
+	require.NotPanics(t, func() { r.ServeHTTP(rec, req) })
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestServeHTTP_NoMetas_NoFinalize_OK(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Handle("/hello", okHandler)
 	// No auth.Mount calls, no FinalizeAuth — should work fine.
 
@@ -418,8 +413,8 @@ func TestFinalizeAuth_NoVerifier_LogsWarning(t *testing.T) {
 	slog.SetDefault(logger)
 	defer slog.SetDefault(prev)
 
-	r := New() // no WithAuthMiddleware
-	r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/public-route", Public: true})
+	r := MustNew() // no WithAuthMiddleware
+	require.NoError(t, r.DeclareAuthMeta(kcell.AuthRouteMeta{Method: "GET", Path: "/public-route", Public: true}))
 	require.NoError(t, r.FinalizeAuth())
 
 	logged := buf.String()
@@ -480,7 +475,7 @@ func TestFinalizeAuth_RejectsNonInternalPathOnInternalListener(t *testing.T) {
 func TestFinalizeAuth_PolicyCoverage_DetectsMissingPolicy(t *testing.T) {
 	// A route registered via raw Handle without auth.Mount must cause
 	// FinalizeAuth to return an error listing the uncovered route.
-	r, err := NewE(WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}))
+	r, err := New(WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}))
 	require.NoError(t, err)
 
 	// /unguarded is registered without auth.Mount — coverage violation.
@@ -497,7 +492,7 @@ func TestFinalizeAuth_PolicyCoverage_DetectsMissingPolicy(t *testing.T) {
 
 func TestFinalizeAuth_PolicyCoverage_AllDeclaredOK(t *testing.T) {
 	// All registered routes have auth.Mount — FinalizeAuth must succeed.
-	r, err := NewE(WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}))
+	r, err := New(WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}))
 	require.NoError(t, err)
 
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract("GET", "/api/v1/items"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}), Policy: authtest.RequireAuthenticated()})
@@ -510,7 +505,7 @@ func TestFinalizeAuth_PolicyCoverage_AllDeclaredOK(t *testing.T) {
 func TestFinalizeAuth_PolicyCoverage_WhitelistExempts(t *testing.T) {
 	// Routes matching WithPolicyCoverageWhitelist patterns are exempt from
 	// coverage enforcement even when registered via raw Handle.
-	r, err := NewE(
+	r, err := New(
 		WithPolicyCoverageWhitelist([]string{"/debug/*"}),
 		WithAuthMiddleware(&authMetaVerifier{err: assert.AnError}),
 	)

--- a/runtime/http/router/router_contract_test.go
+++ b/runtime/http/router/router_contract_test.go
@@ -72,7 +72,7 @@ func TestMount_PrefixStripping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := New()
+			r := MustNew()
 
 			sub := chi.NewRouter()
 			body := tt.wantBody
@@ -97,7 +97,7 @@ func TestMount_PrefixStripping(t *testing.T) {
 // --- Mount Middleware Inheritance -------------------------------------------
 
 func TestMount_MiddlewareInheritance(t *testing.T) {
-	r := New() // New() applies default middleware (RequestID, SecurityHeaders, etc.)
+	r := MustNew() // New() applies default middleware (RequestID, SecurityHeaders, etc.)
 
 	sub := chi.NewRouter()
 	sub.Get("/resource", func(w http.ResponseWriter, _ *http.Request) {
@@ -122,7 +122,7 @@ func TestMount_MiddlewareInheritance(t *testing.T) {
 func TestWith_ScopedMiddleware(t *testing.T) {
 	// With() returns a new RouteMux that applies additional middleware only
 	// to routes registered through it, without affecting the parent.
-	r := New()
+	r := MustNew()
 
 	marker := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -163,7 +163,7 @@ func TestRoute_PrefixStripping(t *testing.T) {
 	// prefix.  Registering "GET /users" inside Route("/api/v1", ...) means
 	// a request to /api/v1/users reaches the handler.
 
-	r := New()
+	r := MustNew()
 
 	var handlerCalled bool
 	r.Route("/api/v1", func(mux cell.RouteMux) {
@@ -193,7 +193,7 @@ func TestRoute_PrefixStripping(t *testing.T) {
 // --- Group No Prefix Change ------------------------------------------------
 
 func TestGroup_NoPrefixChange(t *testing.T) {
-	r := New()
+	r := MustNew()
 
 	var handlerCalled bool
 	r.Group(func(mux cell.RouteMux) {
@@ -218,7 +218,7 @@ func TestGroup_NoPrefixChange(t *testing.T) {
 func TestGroup_MiddlewareIsolation(t *testing.T) {
 	// Middleware applied via With() inside a Group must not leak to handlers
 	// outside the group.
-	r := New()
+	r := MustNew()
 
 	marker := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -257,7 +257,7 @@ func TestGroup_MiddlewareIsolation(t *testing.T) {
 // --- 404 / 405 Table-Driven -----------------------------------------------
 
 func TestRouter_NotFound(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Handle("GET /exists", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -284,7 +284,7 @@ func TestRouter_NotFound(t *testing.T) {
 }
 
 func TestRouter_MethodNotAllowed(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Handle("POST /submit", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -317,7 +317,7 @@ func TestRouter_MethodNotAllowed(t *testing.T) {
 // --- Subtree 404 / 405 ----------------------------------------------------
 
 func TestRoute_NotFoundAndMethodNotAllowed(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Route("/api", func(mux cell.RouteMux) {
 		mux.Handle("GET /users", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -352,7 +352,7 @@ func TestRoute_NotFoundAndMethodNotAllowed(t *testing.T) {
 }
 
 func TestMount_NotFoundAndMethodNotAllowed(t *testing.T) {
-	r := New()
+	r := MustNew()
 	sub := chi.NewRouter()
 	sub.Get("/items", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -389,7 +389,7 @@ func TestMount_NotFoundAndMethodNotAllowed(t *testing.T) {
 // --- Nested Mount ----------------------------------------------------------
 
 func TestMount_Nested(t *testing.T) {
-	r := New()
+	r := MustNew()
 
 	// Inner sub-router mounted at /v1 inside the outer sub-router at /api.
 	// The handler's pattern is relative to the innermost mount point.
@@ -436,7 +436,7 @@ func TestMount_Nested(t *testing.T) {
 // --- Mount with Route Params -----------------------------------------------
 
 func TestMount_WithRouteParams(t *testing.T) {
-	r := New()
+	r := MustNew()
 
 	sub := chi.NewRouter()
 	sub.Get("/{id}", func(w http.ResponseWriter, req *http.Request) {
@@ -472,7 +472,7 @@ func TestMount_WithRouteParams(t *testing.T) {
 // --- Metrics Endpoint Opt-In -------------------------------------------------
 
 func TestMetricsEndpoint_NotExposedByDefault(t *testing.T) {
-	r := New()
+	r := MustNew()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	r.ServeHTTP(rec, req)
@@ -485,7 +485,7 @@ func TestMetricsEndpoint_CollectorOnly_NotExposed(t *testing.T) {
 	// a /metrics HTTP endpoint. Adopts Prometheus/Kratos separation of
 	// "collect" vs "serve".
 	mc := metrics.NewInMemoryCollector()
-	r := New(WithMetricsCollector(mc))
+	r := MustNew(WithMetricsCollector(mc))
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	r.ServeHTTP(rec, req)
@@ -497,7 +497,7 @@ func TestMetricsEndpoint_CollectorOnly_NotExposed(t *testing.T) {
 // served by a primary-listener router. Metrics endpoints belong exclusively
 // on the HealthListener via bootstrap.HealthRouteGroups.
 func TestMetricsEndpoint_NotOnPrimaryListener(t *testing.T) {
-	r := New() // PrimaryListener router; no health/metrics handler registered
+	r := MustNew() // PrimaryListener router; no health/metrics handler registered
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	r.ServeHTTP(rec, req)

--- a/runtime/http/router/router_dual_mux_test.go
+++ b/runtime/http/router/router_dual_mux_test.go
@@ -183,7 +183,7 @@ func TestPerListener_PrimaryRouter_WithAuthMiddleware_Enforces(t *testing.T) {
 // /internal/v1/* route declared on a zero-ref router (unit-test scenario)
 // passes FinalizeAuth — the listener-identity check is skipped for zero-ref.
 func TestDualMux_FinalizeAuth_InternalPathOnZeroRefAccepted(t *testing.T) {
-	rtr, err := NewE()
+	rtr, err := New()
 	require.NoError(t, err)
 
 	// Zero-ref router: listener-identity check is skipped.
@@ -199,7 +199,7 @@ func TestDualMux_FinalizeAuth_InternalPathOnZeroRefAccepted(t *testing.T) {
 // TestDualMux_FinalizeAuth_AcceptsConsistentDeclarations confirms the happy
 // path: internal /internal/v1/* and public /api/v1/* routes both pass.
 func TestDualMux_FinalizeAuth_AcceptsConsistentDeclarations(t *testing.T) {
-	rtr, err := NewE(WithPolicyCoverageWhitelist([]string{
+	rtr, err := New(WithPolicyCoverageWhitelist([]string{
 		"/internal/v1/*",
 		"/api/v1/*",
 	}))

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -51,7 +51,7 @@ func findAccessLogEntry(logs []byte, wantPath string) (map[string]any, bool) {
 }
 
 func TestRouterImplementsRouteMux(t *testing.T) {
-	r := New()
+	r := MustNew()
 	var mux cell.RouteMux = r
 	assert.NotNil(t, mux)
 }
@@ -108,7 +108,7 @@ func TestMetricsEndpoint(t *testing.T) {
 }
 
 func TestHandleAndServe(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Handle("/test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"data":"ok"}`))
@@ -121,7 +121,7 @@ func TestHandleAndServe(t *testing.T) {
 }
 
 func TestRouteGroup(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Route("/api/v1", func(mux cell.RouteMux) {
 		mux.Handle("/ping", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -136,7 +136,7 @@ func TestRouteGroup(t *testing.T) {
 }
 
 func TestGroup(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Group(func(mux cell.RouteMux) {
 		mux.Handle("/grouped", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -150,7 +150,7 @@ func TestGroup(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	r := New()
+	r := MustNew()
 	subRouter := chi.NewRouter()
 	subRouter.Get("/hello", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -177,7 +177,7 @@ func TestRouterChain_WebSocketUpgrade(t *testing.T) {
 		c.CloseNow() //nolint:staticcheck
 	})
 
-	r := New()
+	r := MustNew()
 	r.Mount("/ws", upgrader)
 
 	srv := httptest.NewServer(r)
@@ -200,7 +200,7 @@ func TestPanicRequestRecordedInAccessLog(t *testing.T) {
 	slog.SetDefault(logger)
 	defer slog.SetDefault(original)
 
-	r := New()
+	r := MustNew()
 	r.Handle("/boom", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		panic("access log panic test")
 	}))
@@ -218,7 +218,7 @@ func TestPanicRequestRecordedInAccessLog(t *testing.T) {
 
 func TestPanicRequestRecordedInMetrics(t *testing.T) {
 	mc := metrics.NewInMemoryCollector()
-	r := New(WithMetricsCollector(mc))
+	r := MustNew(WithMetricsCollector(mc))
 	r.Handle("/boom", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		panic("metrics panic test")
 	}))
@@ -242,7 +242,7 @@ func TestNormalRequestUnchanged(t *testing.T) {
 	slog.SetDefault(logger)
 	defer slog.SetDefault(original)
 
-	r := New(WithMetricsCollector(mc))
+	r := MustNew(WithMetricsCollector(mc))
 	r.Handle("/ok", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"data":"ok"}`))
@@ -267,7 +267,7 @@ func TestNormalRequestUnchanged(t *testing.T) {
 }
 
 func TestDefaultMiddlewareApplied(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Handle("/mid-test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -285,34 +285,34 @@ func TestDefaultMiddlewareApplied(t *testing.T) {
 
 // --- Trusted proxy fail-fast validation ---
 
-func TestNewE_InvalidTrustedProxies_ReturnsError(t *testing.T) {
-	r, err := NewE(WithTrustedProxies([]string{"not-an-ip"}))
+func TestNew_InvalidTrustedProxies_ReturnsError(t *testing.T) {
+	r, err := New(WithTrustedProxies([]string{"not-an-ip"}))
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.Contains(t, err.Error(), "not-an-ip")
 	assert.Contains(t, err.Error(), "router")
 }
 
-func TestNewE_ValidTrustedProxies(t *testing.T) {
-	r, err := NewE(WithTrustedProxies([]string{"192.168.1.1", "10.0.0.0/8"}))
+func TestNew_ValidTrustedProxies(t *testing.T) {
+	r, err := New(WithTrustedProxies([]string{"192.168.1.1", "10.0.0.0/8"}))
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
 
-func TestNewE_NilTrustedProxies(t *testing.T) {
-	r, err := NewE(WithTrustedProxies(nil))
+func TestNew_NilTrustedProxies(t *testing.T) {
+	r, err := New(WithTrustedProxies(nil))
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
 
-func TestNew_InvalidTrustedProxies_Panics(t *testing.T) {
-	// New is the panic-wrapper over NewE — convenience for non-bootstrap callers.
+func TestMustNew_InvalidTrustedProxies_Panics(t *testing.T) {
+	// MustNew is the panic-wrapper over New — convenience for static wiring.
 	assert.Panics(t, func() {
-		New(WithTrustedProxies([]string{"not-an-ip"}))
-	}, "router.New must panic when trusted proxies contain an invalid entry")
+		MustNew(WithTrustedProxies([]string{"not-an-ip"}))
+	}, "router.MustNew must panic when trusted proxies contain an invalid entry")
 }
 
-func TestNew_InvalidTrustedProxies_PanicMessage(t *testing.T) {
+func TestMustNew_InvalidTrustedProxies_PanicMessage(t *testing.T) {
 	defer func() {
 		r := recover()
 		require.NotNil(t, r)
@@ -320,25 +320,23 @@ func TestNew_InvalidTrustedProxies_PanicMessage(t *testing.T) {
 		assert.Contains(t, msg, "not-an-ip")
 		assert.Contains(t, msg, "router")
 	}()
-	New(WithTrustedProxies([]string{"192.168.1.1", "not-an-ip"}))
+	MustNew(WithTrustedProxies([]string{"192.168.1.1", "not-an-ip"}))
 }
 
-func TestNew_PanicPreservesErrorChain(t *testing.T) {
+func TestMustNew_PanicsOnError(t *testing.T) {
 	defer func() {
 		r := recover()
 		require.NotNil(t, r)
-		err, ok := r.(error)
-		require.True(t, ok, "panic value must be an error, got %T", r)
-		assert.ErrorContains(t, err, "router")
+		assert.Contains(t, fmt.Sprintf("%v", r), "router")
 	}()
-	New(WithTrustedProxies([]string{"not-an-ip"}))
+	MustNew(WithTrustedProxies([]string{"not-an-ip"}))
 }
 
 // --- Tracing wiring ---
 
 func TestWithTracer_TracingMiddlewareActive(t *testing.T) {
 	tracer := tracing.NewTracer("test-router-tracer")
-	r := New(WithTracer(tracer))
+	r := MustNew(WithTracer(tracer))
 
 	var gotTraceID string
 	r.Handle("/traced", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -359,7 +357,7 @@ func TestWithTracer_TracingMiddlewareActive(t *testing.T) {
 
 func TestWithTracer_InternalContractRouteTraced(t *testing.T) {
 	tracer := &routerSpyTracer{}
-	r := New(WithTracer(tracer))
+	r := MustNew(WithTracer(tracer))
 
 	auth.MustMount(r, auth.Route{
 		Contract: testHTTPContract(http.MethodGet, "/internal/v1/rbac/check"),
@@ -382,7 +380,7 @@ func TestWithTracer_InternalContractRouteTraced(t *testing.T) {
 
 func TestWithTracer_ExtractsUpstreamTraceparent(t *testing.T) {
 	tracer := tracing.NewTracer("test-router-tracer")
-	r := New(WithTracer(tracer))
+	r := MustNew(WithTracer(tracer))
 
 	var gotTraceID string
 	r.Handle("/traced-upstream", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -404,7 +402,7 @@ func TestWithTracer_ExtractsUpstreamTraceparent(t *testing.T) {
 
 func TestWithTracingOptions_PublicEndpointNewRoot(t *testing.T) {
 	tracer := tracing.NewTracer("test-public")
-	r := New(
+	r := MustNew(
 		WithTracer(tracer),
 		WithTracingOptions(middleware.WithPublicEndpointFn(func(req *http.Request) bool {
 			return req.URL.Path == "/public"
@@ -443,7 +441,7 @@ func TestWithTracingOptions_PublicEndpointNewRoot(t *testing.T) {
 }
 
 func TestNoTracer_NoTraceID(t *testing.T) {
-	r := New() // no WithTracer
+	r := MustNew() // no WithTracer
 
 	var hasTraceID bool
 	r.Handle("/no-trace", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -467,7 +465,7 @@ func TestWithTracer_TraceIDInAccessLog(t *testing.T) {
 	defer slog.SetDefault(original)
 
 	tracer := tracing.NewTracer("log-test")
-	r := New(WithTracer(tracer))
+	r := MustNew(WithTracer(tracer))
 	r.Handle("/log-trace", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -489,7 +487,7 @@ func TestAccessLog_IncludesRealIP(t *testing.T) {
 	slog.SetDefault(logger)
 	defer slog.SetDefault(original)
 
-	r := New(WithTrustedProxies([]string{"127.0.0.1"}))
+	r := MustNew(WithTrustedProxies([]string{"127.0.0.1"}))
 	r.Handle("/real-ip-test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -511,7 +509,7 @@ func TestAccessLog_IncludesRealIP(t *testing.T) {
 
 func TestWithTracer_PanicRequestTraced(t *testing.T) {
 	tracer := tracing.NewTracer("panic-trace-test")
-	r := New(WithTracer(tracer))
+	r := MustNew(WithTracer(tracer))
 	r.Handle("/boom-traced", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		panic("tracing panic test")
 	}))
@@ -527,7 +525,7 @@ func TestWithTracer_PanicRequestTraced(t *testing.T) {
 func TestWithTracer_PanicRequestRecordedInMetrics(t *testing.T) {
 	mc := metrics.NewInMemoryCollector()
 	tracer := tracing.NewTracer("metrics-panic-test")
-	r := New(WithTracer(tracer), WithMetricsCollector(mc))
+	r := MustNew(WithTracer(tracer), WithMetricsCollector(mc))
 	r.Handle("/boom-full", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		panic("full chain panic test")
 	}))
@@ -558,7 +556,7 @@ func (l *routerTestLimiter) Allow(key string) bool {
 
 func TestWithRateLimiter_InDefaultChain(t *testing.T) {
 	limiter := &routerTestLimiter{allow: true}
-	r := New(WithRateLimiter(limiter))
+	r := MustNew(WithRateLimiter(limiter))
 	r.Handle("/rl-test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -573,7 +571,7 @@ func TestWithRateLimiter_InDefaultChain(t *testing.T) {
 
 func TestWithRateLimiter_Rejected_Returns429(t *testing.T) {
 	limiter := &routerTestLimiter{allow: false}
-	r := New(WithRateLimiter(limiter))
+	r := MustNew(WithRateLimiter(limiter))
 	r.Handle("/rl-reject", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called when rate limited")
 	}))
@@ -593,7 +591,7 @@ func TestWithRateLimiter_Rejected_Returns429(t *testing.T) {
 func TestWithTracer_RateLimitedContractRouteTagged(t *testing.T) {
 	limiter := &routerTestLimiter{allow: false}
 	tracer := &routerSpyTracer{}
-	r := New(WithRateLimiter(limiter), WithTracer(tracer))
+	r := MustNew(WithRateLimiter(limiter), WithTracer(tracer))
 	auth.MustMount(r, auth.Route{
 		Contract: testHTTPContract(http.MethodGet, "/api/v1/rl-contract/{id}"),
 		Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -632,7 +630,7 @@ func (b *routerTestBreaker) Allow() (bool, func(error)) {
 
 func TestWithCircuitBreaker_InDefaultChain(t *testing.T) {
 	breaker := &routerTestBreaker{}
-	r := New(WithCircuitBreaker(breaker))
+	r := MustNew(WithCircuitBreaker(breaker))
 	r.Handle("/cb-test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -647,7 +645,7 @@ func TestWithCircuitBreaker_InDefaultChain(t *testing.T) {
 
 func TestWithCircuitBreaker_Open_Returns503(t *testing.T) {
 	breaker := &routerTestBreaker{allowErr: fmt.Errorf("circuit breaker is open")}
-	r := New(WithCircuitBreaker(breaker))
+	r := MustNew(WithCircuitBreaker(breaker))
 	r.Handle("/cb-reject", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called when circuit is open")
 	}))
@@ -667,7 +665,7 @@ func TestWithCircuitBreaker_Open_Returns503(t *testing.T) {
 func TestWithCircuitBreaker_NilInterface_Error(t *testing.T) {
 	// A bare nil interface value must cause NewE to return an error so that
 	// Bootstrap.Run fails fast instead of silently skipping CB protection.
-	_, err := NewE(WithCircuitBreaker(nil))
+	_, err := New(WithCircuitBreaker(nil))
 	require.Error(t, err, "nil interface Allower must return error from NewE")
 	assert.Contains(t, err.Error(), "circuit breaker")
 }
@@ -677,7 +675,7 @@ func TestWithCircuitBreaker_TypedNilPointer_Error(t *testing.T) {
 	// value is non-nil but the underlying pointer is nil, so calling Allow()
 	// on it would panic at runtime.
 	var cb *routerTestBreaker // typed nil
-	_, err := NewE(WithCircuitBreaker(cb))
+	_, err := New(WithCircuitBreaker(cb))
 	require.Error(t, err, "typed-nil Allower must return error from NewE")
 	assert.Contains(t, err.Error(), "circuit breaker")
 }
@@ -696,7 +694,7 @@ func TestInfraEndpoints_BypassRateLimiter(t *testing.T) {
 
 	hh := health.New(asm)
 	// Primary router rejects ALL traffic via rate limiter.
-	primaryRtr := New(WithRateLimiter(&routerTestLimiter{allow: false}))
+	primaryRtr := MustNew(WithRateLimiter(&routerTestLimiter{allow: false}))
 	primaryRtr.Handle("/api/v1/biz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should be rate-limited")
 	}))
@@ -732,7 +730,7 @@ func TestInfraEndpoints_BypassCircuitBreaker(t *testing.T) {
 
 	hh := health.New(asm)
 	// Primary router rejects ALL traffic via open circuit breaker.
-	primaryRtr := New(WithCircuitBreaker(&routerTestBreaker{allowErr: fmt.Errorf("open")}))
+	primaryRtr := MustNew(WithCircuitBreaker(&routerTestBreaker{allowErr: fmt.Errorf("open")}))
 	primaryRtr.Handle("/api/v1/biz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should be circuit-broken")
 	}))
@@ -760,7 +758,7 @@ func TestMetrics_Records429And503(t *testing.T) {
 	mc := metrics.NewInMemoryCollector()
 	limiter := &routerTestLimiter{allow: false}
 	breaker := &routerTestBreaker{allowErr: fmt.Errorf("open")}
-	r := New(
+	r := MustNew(
 		WithMetricsCollector(mc),
 		WithRateLimiter(limiter),
 		WithCircuitBreaker(breaker),
@@ -816,7 +814,7 @@ func TestWithAuthMiddleware_ProtectedRoute_NoToken_Returns401(t *testing.T) {
 	verifier := &routerTestVerifier{
 		claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}},
 	}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 	r.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called without auth token")
 	}))
@@ -837,7 +835,7 @@ func TestWithAuthMiddleware_ProtectedRoute_ValidToken_Returns200(t *testing.T) {
 	verifier := &routerTestVerifier{
 		claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}},
 	}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 
 	var gotSubject string
 	r.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -861,7 +859,7 @@ func TestWithAuthMiddleware_PublicEndpoint_SkipsAuth(t *testing.T) {
 	verifier := &routerTestVerifier{
 		err: fmt.Errorf("should not be called"),
 	}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 
 	loginHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -892,7 +890,7 @@ func TestWithAuthMiddleware_InfraEndpoints_BypassAuth(t *testing.T) {
 		err: fmt.Errorf("all tokens rejected"),
 	}
 	// Primary router has auth that rejects everything.
-	primaryRtr := New(WithAuthMiddleware(verifier))
+	primaryRtr := MustNew(WithAuthMiddleware(verifier))
 	primaryRtr.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -923,7 +921,7 @@ func TestWithAuthMiddleware_ChainOrder_RateLimitBeforeAuth(t *testing.T) {
 	verifier := &routerTestVerifier{
 		err: fmt.Errorf("should not be called"),
 	}
-	r := New(WithRateLimiter(limiter), WithAuthMiddleware(verifier))
+	r := MustNew(WithRateLimiter(limiter), WithAuthMiddleware(verifier))
 	r.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
@@ -940,7 +938,7 @@ func TestWithAuthMiddleware_InvalidToken_Returns401(t *testing.T) {
 	verifier := &routerTestVerifier{
 		err: fmt.Errorf("token expired"),
 	}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 	r.Handle("/api/v1/data", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called with invalid token")
 	}))
@@ -958,14 +956,15 @@ func TestWithAuthMiddleware_InvalidToken_Returns401(t *testing.T) {
 	assert.Equal(t, "ERR_AUTH_UNAUTHORIZED", errObj["code"])
 }
 
-func TestWithAuthMiddleware_NilVerifier_Panics(t *testing.T) {
-	assert.Panics(t, func() {
-		WithAuthMiddleware(nil)
-	}, "WithAuthMiddleware must panic when verifier is nil")
+func TestWithAuthMiddleware_NilVerifier_ReturnsNewError(t *testing.T) {
+	r, err := New(WithAuthMiddleware(nil))
+	require.Error(t, err)
+	assert.Nil(t, r)
+	assert.Contains(t, err.Error(), "auth middleware verifier must not be nil")
 }
 
 func TestWithRequestIDOptions_PublicEndpoint(t *testing.T) {
-	r := New(
+	r := MustNew(
 		WithRequestIDOptions(middleware.WithReqIDPublicEndpointFn(func(req *http.Request) bool {
 			return req.URL.Path == "/public"
 		})),
@@ -1006,7 +1005,7 @@ func TestWithRequestIDOptions_PublicEndpoint(t *testing.T) {
 func TestDeclareAuth_AuthBypass(t *testing.T) {
 	// F3: public routes declared via auth.MustMount(Public:true) bypass JWT check.
 	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}}}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 
 	var reached bool
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { reached = true; w.WriteHeader(http.StatusOK) }), Public: true})
@@ -1023,7 +1022,7 @@ func TestDeclareAuth_AuthBypass(t *testing.T) {
 func TestDeclareAuth_AuthBypass_MethodMismatch_Returns401(t *testing.T) {
 	// POST /api/v1/auth/login is public; GET must still require auth.
 	verifier := &routerTestVerifier{err: fmt.Errorf("should not be called")}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
 	// Register GET with a policy so it is covered by policy enforcement;
@@ -1046,7 +1045,7 @@ func TestDeclareAuth_TracingNewRoot(t *testing.T) {
 	// PR-A14a: /internal is whitelisted from policy coverage (raw r.Handle)
 	// so the non-public route runs without an auth gate.
 	tracer := tracing.NewTracer("test-combined")
-	r := New(
+	r := MustNew(
 		WithTracer(tracer),
 		WithPolicyCoverageWhitelist([]string{"/internal/*"}),
 	)
@@ -1084,7 +1083,7 @@ func TestDeclareAuth_RequestIDRejectsClient(t *testing.T) {
 	// F3: public routes reject client-supplied X-Request-Id.
 	// PR-A14a: /internal is whitelisted from policy coverage (raw r.Handle)
 	// so the non-public route runs without an auth gate.
-	r := New(WithPolicyCoverageWhitelist([]string{"/internal/*"}))
+	r := MustNew(WithPolicyCoverageWhitelist([]string{"/internal/*"}))
 
 	var publicID, internalID string
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/public"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1115,7 +1114,7 @@ func TestDeclareAuth_RequestIDRejectsClient(t *testing.T) {
 func TestDeclareAuth_ProtectedStillRequiresAuth(t *testing.T) {
 	// F3: only declared public routes bypass auth; others still require a token.
 	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1", Roles: []string{"admin"}}}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
 	// /api/v1/data is protected — declared with a policy to satisfy coverage enforcement.
@@ -1136,7 +1135,7 @@ func TestDeclareAuth_UserTracingOptions_FineGrained(t *testing.T) {
 	// auth.Mount / FinalizeAuth is consulted for auth + RequestID; the explicit
 	// WithTracingOptions fn controls trace root creation.
 	tracer := tracing.NewTracer("test-combined-fine")
-	r := New(
+	r := MustNew(
 		WithTracer(tracer),
 		WithTracingOptions(middleware.WithPublicEndpointFn(func(req *http.Request) bool {
 			return req.URL.Path == "/fine-grained-public"
@@ -1154,7 +1153,7 @@ func TestDeclareAuth_UserTracingOptions_FineGrained(t *testing.T) {
 	var publicTraceID, fineTraceID string
 	// Re-register with trace capture (FinalizeAuth already called; use r.Handle for non-declared routes).
 	// Instead, rebuild using a fresh router that captures trace IDs inline.
-	r2 := New(
+	r2 := MustNew(
 		WithTracer(tracer),
 		WithTracingOptions(middleware.WithPublicEndpointFn(func(req *http.Request) bool {
 			return req.URL.Path == "/fine-grained-public"
@@ -1200,7 +1199,7 @@ func TestDeclareAuth_UserTracingOptions_FineGrained(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestWithSecurityHeadersOptions_CustomHSTS(t *testing.T) {
-	r := New(
+	r := MustNew(
 		WithSecurityHeadersOptions(
 			middleware.WithHSTSIncludeSubDomains(),
 			middleware.WithHSTSPreload(),
@@ -1222,7 +1221,7 @@ func TestWithSecurityHeadersOptions_CustomHSTS(t *testing.T) {
 }
 
 func TestWithSecurityHeadersOptions_DefaultHSTS(t *testing.T) {
-	r := New()
+	r := MustNew()
 	r.Handle("/default-hsts", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -1247,7 +1246,7 @@ func TestDeclareAuth_NoPublicDecls_TracingUnchanged(t *testing.T) {
 	// auth.Mount) so the route runs without any auth gate and the tracing
 	// context is captured unconditionally.
 	tracer := tracing.NewTracer("test-empty")
-	r := New(
+	r := MustNew(
 		WithTracer(tracer),
 		WithPolicyCoverageWhitelist([]string{"/test/*"}),
 	)
@@ -1271,7 +1270,7 @@ func TestDeclareAuth_NoPublicDecls_TracingUnchanged(t *testing.T) {
 
 func TestDeclareAuth_PathNormalization(t *testing.T) {
 	// auth.Mount normalises paths via path.Clean: "/api/v1//login" → "/api/v1/login".
-	r := New()
+	r := MustNew()
 
 	var gotID string
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodGet, "/api/v1//login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1295,7 +1294,7 @@ func TestDeclareAuth_MethodAware_GETDoesNotBypassForPOSTOnly(t *testing.T) {
 	verifier := &routerTestVerifier{
 		claims: auth.Claims{Subject: "user-1"},
 	}
-	r := New(WithAuthMiddleware(verifier))
+	r := MustNew(WithAuthMiddleware(verifier))
 
 	auth.MustMount(r, auth.Route{Contract: testHTTPContract(http.MethodPost, "/api/v1/auth/login"), Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), Public: true})
 	// Register the GET handler with a policy so it is covered by policy enforcement;
@@ -1317,30 +1316,27 @@ func TestDeclareAuth_MethodAware_GETDoesNotBypassForPOSTOnly(t *testing.T) {
 		"GET must require auth when only POST is declared public")
 }
 
-// TestRouter_ServeHTTP_NoFinalizeAuth_Panics asserts that calling ServeHTTP
+// TestRouter_ServeHTTP_NoFinalizeAuth_FailsClosed asserts that calling ServeHTTP
 // on a router that has auth route metadata declared but FinalizeAuth has NOT
-// been called results in a panic with the expected message.
+// been called returns a 500 response.
 //
 // This is the safety guard that prevents a mis-wired bootstrap from silently
 // skipping the auth compilation step (FinalizeAuth) and serving requests
 // without the compiled public/PasswordResetExempt matchers in place.
-func TestRouter_ServeHTTP_NoFinalizeAuth_Panics(t *testing.T) {
-	r := New()
+func TestRouter_ServeHTTP_NoFinalizeAuth_FailsClosed(t *testing.T) {
+	r := MustNew()
 
 	// Declare auth metadata without calling FinalizeAuth — this is the
 	// mis-wired state the guard is designed to detect.
-	r.DeclareAuthMeta(cell.AuthRouteMeta{
+	require.NoError(t, r.DeclareAuthMeta(cell.AuthRouteMeta{
 		Method: "GET",
 		Path:   "/api/v1/probe",
 		Public: true,
-	})
+	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/probe", nil)
 	rec := httptest.NewRecorder()
 
-	assert.PanicsWithValue(t,
-		"router: FinalizeAuth must be called before ServeHTTP when auth route metadata has been declared",
-		func() { r.ServeHTTP(rec, req) },
-		"ServeHTTP must panic when FinalizeAuth has not been called after DeclareAuthMeta",
-	)
+	require.NotPanics(t, func() { r.ServeHTTP(rec, req) })
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/adapters/rabbitmq"
 	"github.com/ghbvf/gocell/adapters/redis"
@@ -18,6 +17,7 @@ import (
 	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/tests/testutil"
 	"github.com/google/uuid"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -410,7 +410,8 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 	state, receipt2, err := claimer.Claim(ctx, idemKey, idempotency.DefaultLeaseTTL, idempotency.DefaultTTL)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimDone, state, "same idempotency key should be detected as done")
-	assert.Nil(t, receipt2, "ClaimDone should not return a Receipt")
+	require.NotNil(t, receipt2, "ClaimDone should return a non-acquired receipt")
+	assert.ErrorIs(t, receipt2.Commit(ctx), idempotency.ErrNoClaimLease)
 
 	// ---------------------------------------------------------------
 	// Step 12: Verify a fresh key is NOT detected as processed.

--- a/tools/archtest/auth_authtest_boundary_test.go
+++ b/tools/archtest/auth_authtest_boundary_test.go
@@ -188,9 +188,7 @@ func parseImports(path string) ([]string, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, path, data, parser.ImportsOnly|parser.SkipObjectResolution)
 	if err != nil {
-		// Return a best-effort result from raw scanning on parse failure so a
-		// single malformed file does not abort the entire walk.
-		return rawScanImports(data, path), nil
+		return rawScanImports(data, path), err
 	}
 	var imports []string
 	for _, imp := range f.Imports {
@@ -205,9 +203,8 @@ func parseImports(path string) ([]string, error) {
 // pkgIdent and the selector matches selName. Comments and string literals do
 // not match because they are not represented as ast.CallExpr nodes — the entire
 // point of moving rule A from text grep to AST detection is to avoid those
-// false positives. On parse failure the file is skipped (returns nil, nil) —
-// AST cannot reason about a malformed file, and the parser failure itself is
-// surfaced by go vet / build steps.
+// false positives. Parse failures are returned to make malformed files fail
+// the archtest directly.
 func findCallExpr(path, pkgIdent, selName string) ([]int, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -216,7 +213,7 @@ func findCallExpr(path, pkgIdent, selName string) ([]int, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	var lines []int
 	ast.Inspect(f, func(n ast.Node) bool {

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -52,6 +52,7 @@ import (
 )
 
 const ruleErrorFirstAPI01 = "ERROR-FIRST-API-01"
+const ruleErrorFirstTypedNil01 = "ERROR-FIRST-TYPED-NIL-01"
 
 // errorFirstEnforcedFiles are the relative paths (from module root) of files
 // whose declarations must satisfy ERROR-FIRST-API-01. Slash-separated for
@@ -99,6 +100,43 @@ type errorFirstViolation struct {
 	Reason   string
 }
 
+type typedNilConstructorRule struct {
+	File       string
+	FuncName   string
+	ParamNames []string
+}
+
+var typedNilConstructorRules = []typedNilConstructorRule{
+	{
+		File:     "cells/accesscore/slices/sessionlogin/service.go",
+		FuncName: "NewService",
+		ParamNames: []string{
+			"userRepo",
+			"sessionRepo",
+			"roleRepo",
+			"refreshStore",
+		},
+	},
+	{
+		File:     "cells/accesscore/slices/sessionrefresh/service.go",
+		FuncName: "NewService",
+		ParamNames: []string{
+			"sessionRepo",
+			"roleRepo",
+			"userRepo",
+			"refreshStore",
+		},
+	},
+	{
+		File:     "cells/accesscore/slices/sessionlogout/service.go",
+		FuncName: "NewService",
+		ParamNames: []string{
+			"sessionRepo",
+			"refreshStore",
+		},
+	},
+}
+
 // TestErrorFirstAPI01 walks the enforced file list and reports panic() calls
 // inside error-less function declarations.
 func TestErrorFirstAPI01(t *testing.T) {
@@ -122,6 +160,27 @@ func TestErrorFirstAPI01(t *testing.T) {
 			"rename to Must*, or add an ADR-justified file-level whitelist entry "+
 			"(see docs/architecture/202604270030-architectural-panic-whitelist.md)",
 		ruleErrorFirstAPI01)
+}
+
+func TestErrorFirstTypedNil01(t *testing.T) {
+	root := findModuleRoot(t)
+
+	var violations []errorFirstViolation
+	for _, rule := range typedNilConstructorRules {
+		abs := filepath.Join(root, filepath.FromSlash(rule.File))
+		violations = append(violations, scanConstructorForTypedNilGuards(t, abs, rule)...)
+	}
+
+	if len(violations) > 0 {
+		t.Logf("%s: %d violation(s):", ruleErrorFirstTypedNil01, len(violations))
+		for _, v := range violations {
+			t.Logf("  %s:%d  %s — %s", v.File, v.Line, v.FuncName, v.Reason)
+		}
+	}
+	assert.Empty(t, violations,
+		"%s: error-first constructors must validate interface dependencies with "+
+			"validation.IsNilInterface(param), so typed-nil implementations fail at construction time",
+		ruleErrorFirstTypedNil01)
 }
 
 // scanFileForErrorFirstViolations parses a single Go source file and returns
@@ -162,6 +221,66 @@ func scanFileForErrorFirstViolations(t *testing.T, abs, rel string) []errorFirst
 		})
 	}
 	return violations
+}
+
+func scanConstructorForTypedNilGuards(t *testing.T, abs string, rule typedNilConstructorRule) []errorFirstViolation {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, abs, nil, parser.SkipObjectResolution|parser.ParseComments)
+	require.NoErrorf(t, err, "%s: parse failed", rule.File)
+
+	var target *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil || fd.Name.Name != rule.FuncName {
+			continue
+		}
+		target = fd
+		break
+	}
+	require.NotNilf(t, target, "%s: expected function %s", rule.File, rule.FuncName)
+
+	var violations []errorFirstViolation
+	for _, paramName := range rule.ParamNames {
+		if hasValidationIsNilInterfaceGuard(target.Body, paramName) {
+			continue
+		}
+		violations = append(violations, errorFirstViolation{
+			File:     rule.File,
+			Line:     fset.Position(target.Pos()).Line,
+			FuncName: rule.FuncName,
+			Reason:   "interface dependency " + paramName + " is not validated with validation.IsNilInterface",
+		})
+	}
+	return violations
+}
+
+func hasValidationIsNilInterfaceGuard(body *ast.BlockStmt, paramName string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "IsNilInterface" {
+			return true
+		}
+		pkgIdent, ok := sel.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "validation" {
+			return true
+		}
+		argIdent, ok := call.Args[0].(*ast.Ident)
+		if !ok || argIdent.Name != paramName {
+			return true
+		}
+		found = true
+		return false
+	})
+	return found
 }
 
 // isInitFunc returns true if fd is `func init()` (no receiver, no params, no

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -18,6 +18,10 @@ package archtest
 //     error would dismantle the entire recover propagation idiom. Any
 //     OTHER error-less function in lifecycle.go that contains panic() is
 //     still reported as a violation.
+//   - runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure —
+//     middle of a `defer recover()` chain that records breaker failure before
+//     re-panicking so the outer Recovery middleware remains the single
+//     panic-to-HTTP and panic-to-tracing boundary.
 //
 // Enforced file scope (PR-MODE-6 + PR-MODE-6.1):
 //   - kernel/wrapper/handler.go, consumer.go, spec.go, lifecycle.go (whitelisted)
@@ -89,7 +93,8 @@ var errorFirstEnforcedFiles = []string{
 // still reported as a violation. ADR-pinned in
 // docs/architecture/202604270030-architectural-panic-whitelist.md (§4).
 var errorFirstWhitelistedFunctions = map[string]string{
-	"kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor": "re-panics from defer recover so outer Recovery middleware can serialize the panic",
+	"kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor":              "re-panics from defer recover so outer Recovery middleware can serialize the panic",
+	"runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure": "re-panics from defer recover after reporting circuit-breaker failure",
 }
 
 // errorFirstViolation describes a single ERROR-FIRST-API-01 violation.

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -19,19 +19,25 @@ package archtest
 //     OTHER error-less function in lifecycle.go that contains panic() is
 //     still reported as a violation.
 //
-// Enforced file scope (PR-MODE-6):
+// Enforced file scope (PR-MODE-6 + PR-MODE-6.1):
 //   - kernel/wrapper/handler.go, consumer.go, spec.go, lifecycle.go (whitelisted)
 //   - kernel/cell/auth_plan.go
 //   - kernel/outbox/entry_id.go, envelope.go
 //   - kernel/idempotency/inmem.go
 //   - kernel/worker/worker.go
-//   - runtime/eventrouter/router.go
+//   - runtime/eventrouter/router.go, contract_middleware.go
 //   - runtime/auth/route.go
 //   - runtime/worker/worker.go
+//   - runtime/distlock/locker.go
+//   - runtime/auth/refresh/memstore/store.go
+//   - runtime/http/middleware/circuit_breaker.go
+//   - runtime/http/health/health.go
+//   - runtime/http/router/router.go
+//   - kernel/persistence/tx.go
+//   - cells/accesscore/slices/sessionlogin/service.go
+//   - cells/accesscore/slices/sessionrefresh/service.go
+//   - cells/accesscore/slices/sessionlogout/service.go
 //   - adapters/postgres/refresh_store.go
-//
-// Future PRs may extend the scope; see
-// docs/architecture/202604270030-architectural-panic-whitelist.md §Roadmap.
 
 import (
 	"go/ast"
@@ -64,6 +70,15 @@ var errorFirstEnforcedFiles = []string{
 	"runtime/eventrouter/contract_middleware.go",
 	"runtime/auth/route.go",
 	"runtime/worker/worker.go",
+	"runtime/distlock/locker.go",
+	"runtime/auth/refresh/memstore/store.go",
+	"runtime/http/middleware/circuit_breaker.go",
+	"runtime/http/health/health.go",
+	"runtime/http/router/router.go",
+	"kernel/persistence/tx.go",
+	"cells/accesscore/slices/sessionlogin/service.go",
+	"cells/accesscore/slices/sessionrefresh/service.go",
+	"cells/accesscore/slices/sessionlogout/service.go",
 	"adapters/postgres/refresh_store.go",
 }
 

--- a/tools/archtest/event_camelcase_test.go
+++ b/tools/archtest/event_camelcase_test.go
@@ -150,8 +150,7 @@ func scanDTOJSONTagsCamelCase(root, path string) ([]string, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
 	if err != nil {
-		// Best-effort: parse failure surfaces via go build, not archtest.
-		return nil, nil
+		return nil, err
 	}
 
 	rel, _ := filepath.Rel(root, path)

--- a/tools/archtest/health_aggregation_test.go
+++ b/tools/archtest/health_aggregation_test.go
@@ -87,8 +87,7 @@ func collectTypeMethods(t *testing.T, root string) *typeMethodSet {
 
 		f, parseErr := parser.ParseFile(fset, path, nil, 0)
 		if parseErr != nil {
-			// Skip unparseable files — they'll surface in go build.
-			return nil
+			return parseErr
 		}
 
 		for _, decl := range f.Decls {

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -144,7 +144,7 @@ func findWithListenerNilAuthChain(path string) ([]int, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
 	if err != nil {
-		return nil, nil // tolerate parse errors (build step handles them)
+		return nil, err
 	}
 	var lines []int
 	ast.Inspect(f, func(n ast.Node) bool {
@@ -282,7 +282,7 @@ func findInsecureSkipVerifyAssign(path string) ([]int, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	var lines []int
 	ast.Inspect(f, func(n ast.Node) bool {

--- a/tools/nogo/unconditionalskip/analyzer.go
+++ b/tools/nogo/unconditionalskip/analyzer.go
@@ -13,6 +13,7 @@ package unconditionalskip
 import (
 	"go/ast"
 	"go/types"
+	"reflect"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
@@ -22,14 +23,17 @@ import (
 // Analyzer is the exported analysis.Analyzer that can be embedded into nogo
 // rule sets or run via singlechecker.Main.
 var Analyzer = &analysis.Analyzer{
-	Name:     "unconditionalskip",
-	Doc:      "reports test functions whose first statement is an unconditional t.Skip/t.Skipf/t.SkipNow",
-	URL:      "https://github.com/ghbvf/gocell/tools/nogo/unconditionalskip",
-	Requires: []*analysis.Analyzer{inspect.Analyzer},
-	Run:      run,
+	Name:       "unconditionalskip",
+	Doc:        "reports test functions whose first statement is an unconditional t.Skip/t.Skipf/t.SkipNow",
+	URL:        "https://github.com/ghbvf/gocell/tools/nogo/unconditionalskip",
+	Requires:   []*analysis.Analyzer{inspect.Analyzer},
+	Run:        run,
+	ResultType: reflect.TypeOf(result{}),
 }
 
 const diagMessage = "unconditional t.Skip — wrap in if-condition or remove the test"
+
+type result struct{}
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
@@ -50,7 +54,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		checkBody(pass, fn.Body)
 	})
 
-	return nil, nil
+	return result{}, nil
 }
 
 // isTestOrBenchmark reports whether fn is a top-level test or benchmark


### PR DESCRIPTION
## Summary

PR-MODE-6.1 full nil / error-first cleanup.

- Enables `nilerr`, `nilnesserr`, and `nilnil` with `nilnil.only-two: false`.
- Expands `ERROR-FIRST-API-01` archtest coverage to the remaining nil / panic roadmap files, including `runtime/http/router/router.go`.
- Migrates distlock, refresh memstore, session services, circuit breaker, health checker registration, router auth metadata, and router constructors to error-first APIs with explicit `Must*` wrappers for static wiring.
- Removes nil-success return semantics across command lookup, admin provisioning, initial admin cleanup/sweep, governance/archtest parsing helpers, idempotency claim states, and related test fakes.
- Adds `ERROR-FIRST-TYPED-NIL-01` so CI enforces typed-nil guards on session service constructors.
- Updates the architectural panic whitelist ADR to mark PR-MODE-6.1 roadmap items complete and records the narrow circuit-breaker re-panic exception; router still has no whitelist entry.

## Review Fixes

- Preserves exact custom `CredentialPath` identity through initialadmin sweep and covers non-default filenames.
- Rejects typed-nil session dependencies before storing them.
- Makes `auth.Mount` declare auth / HTTP metadata before route registration, with regression tests for declaration failures.
- Keeps `CircuitBreaker` from swallowing handler panics: it records breaker failure, then re-panics so outer `Recovery` remains responsible for panic logging, tracing, and HTTP 500 serialization.
- Adds focused coverage for nil cleanup guard paths, memstore constructor errors, `MustCircuitBreaker`, and health checker error wrappers.

## Verification

Local:

- `go build ./...`
- `go test ./... -count=1`
- `go test ./tools/archtest/... -race -count=1`
- `go run ./cmd/gocell validate --strict`
- `golangci-lint run ./...`
- `go test -tags=integration ./cmd/corebundle/... ./adapters/... -timeout 15m`

CI on head `0a661a3a`:

- GitHub Actions: all required PR checks green.
- SonarCloud Code Analysis: green; new-code coverage `83.565%` (`59` uncovered / `359` coverable lines).
- Sub-agent review after CI found one P1 in circuit-breaker panic handling; fixed in `bee0d530` and revalidated.