### PR TITLE
PR-CI-0 VERIFY-ENTRYPOINT-01 — make verify K8s-style entry

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -133,26 +133,14 @@ jobs:
       - name: Test
         run: go test ${{ matrix.race && '-race' || '' }} -covermode=atomic -coverprofile=coverage-shard-${{ matrix.shard }}.out ${{ matrix.pkgs }} -count=1 -timeout 5m
 
-      - name: Validate metadata
-        if: matrix.static_checks
-        # --strict gates metadata promotion rules, including active journey
-        # checkRefs resolving to real executable tests.
-        run: go run ./cmd/gocell validate --strict
-
-      - name: Verify active journeys
-        if: matrix.static_checks
-        run: go run ./cmd/gocell verify journey --active
-
-      - name: Check contract health
-        if: matrix.static_checks
-        run: go run ./cmd/gocell check contract-health
-
-      - name: Check unconditional t.Skip
-        if: matrix.static_checks
-        run: go run ./cmd/gocell check unconditional-skip ./...
-
-      # NOTE: Example metadata may live under examples/*/cells and examples/*/contracts.
-      # The main `gocell validate` step above already covers it.
+      # Static governance gates (validate --strict, verify journey, check
+      # contract-health, check unconditional-skip, examples internal-import
+      # ban) are owned by the dedicated Governance Strict workflow
+      # (.github/workflows/governance.yml → `make verify`). Running them
+      # here would duplicate work and create two paths to update whenever a
+      # gate is added. archtest layer/cell-internal guards remain covered by
+      # the kernel shard's Test step via ./tools/... in matrix.pkgs and are
+      # additionally re-run inside `make verify` (cheap, < 30s).
 
       # Compile-verify e2e package even when integration-test job is skipped.
       # The e2e build tag gates runtime behaviour; this step ensures type/import
@@ -160,19 +148,6 @@ jobs:
       - name: Vet e2e package (compile verification)
         if: matrix.static_checks
         run: go vet -tags=e2e ./tests/e2e/...
-
-      - name: Check layering — examples no internal imports
-        if: matrix.static_checks
-        run: |
-          if grep -rn --include='*.go' "github.com/ghbvf/gocell/cells/.*/internal" examples/ 2>/dev/null; then
-            echo "FAIL: examples/ imports root cells/*/internal/"
-            exit 1
-          fi
-          if grep -rn --include='*.go' "github.com/ghbvf/gocell/adapters/.*/internal" examples/ 2>/dev/null; then
-            echo "FAIL: examples/ imports adapters/*/internal/"
-            exit 1
-          fi
-          echo "PASS: no internal import violations"
 
       # NOTE: Kernel coverage gate re-runs `go test -cover ./kernel/...`
       # deliberately — it is not a duplicate of the Test step. The gate requires

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -6,9 +6,15 @@ on:
   pull_request:
     branches: [develop, main, 'release/**']
 
+# Governance Strict is the K8s-style `make verify` runner — it discovers and
+# executes every hack/verify-*.sh gate in deterministic order, accumulating
+# failures. Adding a new gate is a single new file under hack/; this workflow
+# never needs to change.
+# ref: kubernetes/kubernetes hack/make-rules/verify.sh
+
 jobs:
-  gocell-validate-strict:
-    name: gocell validate --strict
+  verify:
+    name: make verify
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -18,27 +24,5 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: go.sum
 
-      - name: Validate metadata (strict)
-        run: go run ./cmd/gocell validate --strict
-
-      - name: Verify active journeys
-        run: go run ./cmd/gocell verify journey --active
-
-      - name: Scaffold rejects kebab slice names
-        run: |
-          set +e
-          result=$(go run ./cmd/gocell scaffold slice --id=test-slice --cell=accesscore 2>&1)
-          exit_code=$?
-          set -e
-          echo "scaffold exit code: $exit_code"
-          echo "scaffold output: $result"
-          if [ "$exit_code" -eq 0 ]; then
-            echo "FAIL: scaffold exited 0 but should have rejected kebab slice name"
-            exit 1
-          fi
-          if echo "$result" | grep -q "must not contain"; then
-            echo "PASS: scaffold correctly rejects kebab slice name"
-          else
-            echo "FAIL: scaffold rejected (exit $exit_code) but error message did not contain 'must not contain'"
-            exit 1
-          fi
+      - name: make verify
+        run: make verify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check-build test validate generate cover clean \
+.PHONY: build check-build test verify validate generate cover clean \
         up down \
         test-integration \
         test-examples-smoke \
@@ -20,6 +20,13 @@ check-build:
 
 test:
 	go test ./... -count=1
+
+# verify discovers and runs every hack/verify-*.sh in deterministic order,
+# accumulating failures. Single entry point for static governance gates
+# (validate --strict, archtest, contract-health, journey, etc.).
+# ref: kubernetes/kubernetes hack/make-rules/verify.sh
+verify:
+	bash hack/make-rules/verify.sh
 
 validate:
 	go run ./cmd/gocell validate

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,40 @@
+# hack/
+
+Static governance gates that `make verify` (alias: `bash hack/make-rules/verify.sh`)
+discovers and runs in deterministic order. Adopted from Kubernetes'
+`hack/verify-*` convention so adding a new gate is a single file, never a
+change to the driver.
+
+## Layout
+
+- `make-rules/verify.sh` — entry point. Globs `hack/verify-*.sh`, runs each,
+  accumulates failures, exits 1 if any failed.
+- `lib/util.sh` — shared logging helpers (`gocell::log::status`,
+  `gocell::log::error`).
+- `verify-*.sh` — individual gates. Each script is independently runnable
+  (`bash hack/verify-X.sh`) and exits non-zero on failure.
+
+## Adding a new gate
+
+1. Create `hack/verify-<name>.sh` with shebang `#!/usr/bin/env bash` and
+   `set -euo pipefail`.
+2. `cd "$(dirname "${BASH_SOURCE[0]}")/.."` so the script runs from repo root
+   regardless of caller's CWD.
+3. Make it executable: `chmod +x hack/verify-<name>.sh`.
+4. Verify locally: `make verify`. The new gate will be picked up automatically.
+
+There is no allow-list, opt-in flag, or violations baseline. Gates are either
+zero-tolerance or paired with an ADR-pinned permanent allow-list that the gate
+itself enforces.
+
+## Existing gates
+
+| Script | Enforces |
+|---|---|
+| `verify-archtest.sh` | `tools/archtest/*` (LAYER-*, AUTH-*, SEC-FAIL-CLOSED-*, ERROR-FIRST-API-01, META-*, ADV-06) |
+| `verify-contract-health.sh` | `gocell check contract-health` (CH-*) |
+| `verify-examples-import.sh` | `examples/` must not import `cells/*/internal/` or `adapters/*/internal/` |
+| `verify-govalidate.sh` | `gocell validate --strict` (FMT, ADV, REF, LAYER, VERIFY, CONTRACT-CONSISTENCY) |
+| `verify-journey.sh` | `gocell verify journey --active` (active journeys carry executable auto checks) |
+| `verify-scaffold-reject.sh` | `gocell scaffold slice` rejects kebab-case names |
+| `verify-unconditional-skip.sh` | no `t.Skip` without a runtime predicate |

--- a/hack/README.md
+++ b/hack/README.md
@@ -20,7 +20,9 @@ change to the driver.
    `set -euo pipefail`.
 2. `cd "$(dirname "${BASH_SOURCE[0]}")/.."` so the script runs from repo root
    regardless of caller's CWD.
-3. Make it executable: `chmod +x hack/verify-<name>.sh`.
+3. `chmod +x hack/verify-<name>.sh` so the file can be invoked directly
+   (`./hack/verify-<name>.sh`) for ad-hoc debugging. The driver itself runs
+   each gate via `bash <script>` and does not depend on the executable bit.
 4. Verify locally: `make verify`. The new gate will be picked up automatically.
 
 There is no allow-list, opt-in flag, or violations baseline. Gates are either

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Shared logging helpers for hack/verify-*.sh scripts.
+
+gocell::log::status() {
+    printf '+++ [%s] %s\n' "$(date +%H:%M:%S)" "$*"
+}
+
+gocell::log::error() {
+    printf '!!! [%s] %s\n' "$(date +%H:%M:%S)" "$*" >&2
+}

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# verify.sh runs every hack/verify-*.sh script in deterministic order and
+# accumulates failures. Mirrors Kubernetes' hack/make-rules/verify.sh: a glob
+# discovery model so adding a new gate only needs a new hack/verify-X.sh file,
+# never a change to this driver.
+#
+# ref: kubernetes/kubernetes hack/make-rules/verify.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+# shellcheck source=../lib/util.sh
+source "${ROOT}/hack/lib/util.sh"
+
+scripts=()
+while IFS= read -r f; do
+    scripts+=("${f}")
+done < <(find hack -maxdepth 1 -name 'verify-*.sh' -type f | sort)
+
+if [[ ${#scripts[@]} -eq 0 ]]; then
+    gocell::log::error "no hack/verify-*.sh scripts found"
+    exit 1
+fi
+
+fails=()
+for script in "${scripts[@]}"; do
+    name="$(basename "${script}")"
+    gocell::log::status "Running ${name}"
+    if ! bash "${script}"; then
+        fails+=("${name}")
+        gocell::log::status "FAIL: ${name}"
+    else
+        gocell::log::status "PASS: ${name}"
+    fi
+done
+
+if [[ ${#fails[@]} -gt 0 ]]; then
+    gocell::log::error "verify failures (${#fails[@]}):"
+    printf '  - %s\n' "${fails[@]}" >&2
+    exit 1
+fi
+
+gocell::log::status "All ${#scripts[@]} verify gates passed."

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -24,17 +24,41 @@ if [[ ${#scripts[@]} -eq 0 ]]; then
     exit 1
 fi
 
+declare -a results=()
 fails=()
 for script in "${scripts[@]}"; do
     name="$(basename "${script}")"
     gocell::log::status "Running ${name}"
     if ! bash "${script}"; then
         fails+=("${name}")
+        results+=("${name}|FAIL")
         gocell::log::status "FAIL: ${name}"
     else
+        results+=("${name}|PASS")
         gocell::log::status "PASS: ${name}"
     fi
 done
+
+# When invoked under GitHub Actions, write a per-gate status table to the job
+# summary so reviewers can see which gate failed without expanding the step
+# log. Mirrors the gate-level summary that Kubernetes emits via juLog/JUnit.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "## make verify gates"
+        echo
+        echo "| Gate | Status |"
+        echo "| --- | --- |"
+        for entry in "${results[@]}"; do
+            gate="${entry%|*}"
+            status="${entry##*|}"
+            if [[ "${status}" == "PASS" ]]; then
+                echo "| \`${gate}\` | ✅ PASS |"
+            else
+                echo "| \`${gate}\` | ❌ FAIL |"
+            fi
+        done
+    } >> "${GITHUB_STEP_SUMMARY}"
+fi
 
 if [[ ${#fails[@]} -gt 0 ]]; then
     gocell::log::error "verify failures (${#fails[@]}):"

--- a/hack/verify-archtest.sh
+++ b/hack/verify-archtest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# verify-archtest runs the architectural unit-test suite (LAYER-*, AUTH-*,
+# SEC-FAIL-CLOSED-*, ERROR-FIRST-API-01, META-QUERYPARAM-DRIFT, ADV-06, etc.).
+# Race detector is enabled because several archtest helpers use packages.Load
+# concurrently.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+go test ./tools/archtest/... -race -count=1

--- a/hack/verify-contract-health.sh
+++ b/hack/verify-contract-health.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# verify-contract-health runs `gocell check contract-health` to enforce
+# contract metadata health rules (CH-*).
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+go run ./cmd/gocell check contract-health

--- a/hack/verify-examples-import.sh
+++ b/hack/verify-examples-import.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# verify-examples-import enforces that examples/ never imports cells/*/internal/
+# or adapters/*/internal/ — example cells must consume their dependencies only
+# through public APIs.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+fail=0
+if grep -rn --include='*.go' "github.com/ghbvf/gocell/cells/.*/internal" examples/ 2>/dev/null; then
+    echo "FAIL: examples/ imports cells/*/internal/" >&2
+    fail=1
+fi
+if grep -rn --include='*.go' "github.com/ghbvf/gocell/adapters/.*/internal" examples/ 2>/dev/null; then
+    echo "FAIL: examples/ imports adapters/*/internal/" >&2
+    fail=1
+fi
+exit "${fail}"

--- a/hack/verify-govalidate.sh
+++ b/hack/verify-govalidate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# verify-govalidate runs `gocell validate --strict` to enforce metadata
+# governance rules (FMT, ADV, REF, LAYER, VERIFY, CH, CONTRACT-CONSISTENCY).
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+go run ./cmd/gocell validate --strict

--- a/hack/verify-journey.sh
+++ b/hack/verify-journey.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# verify-journey checks that all active journeys carry at least one auto check
+# and that referenced check targets resolve to executable tests.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+go run ./cmd/gocell verify journey --active

--- a/hack/verify-scaffold-reject.sh
+++ b/hack/verify-scaffold-reject.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# verify-scaffold-reject asserts that `gocell scaffold slice` rejects kebab-case
+# slice names (FMT-16 enforced at scaffold time, not just at validate).
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+set +e
+output=$(go run ./cmd/gocell scaffold slice --id=test-slice --cell=accesscore 2>&1)
+exit_code=$?
+set -e
+
+if [[ ${exit_code} -eq 0 ]]; then
+    echo "FAIL: scaffold exited 0 but should have rejected kebab slice name" >&2
+    echo "${output}" >&2
+    exit 1
+fi
+
+if ! grep -q "must not contain" <<<"${output}"; then
+    echo "FAIL: scaffold rejected (exit ${exit_code}) but error message did not contain 'must not contain'" >&2
+    echo "${output}" >&2
+    exit 1
+fi

--- a/hack/verify-unconditional-skip.sh
+++ b/hack/verify-unconditional-skip.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# verify-unconditional-skip rejects test files whose t.Skip is unconditional —
+# any blanket skip is a hidden disabled test and must be either deleted or
+# guarded with a runtime predicate.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+go run ./cmd/gocell check unconditional-skip ./...


### PR DESCRIPTION
## Summary

K8s 风格 `make verify` 统一入口落地。新增 `hack/verify-*.sh` 7 个 gate + glob 自动发现 driver，governance.yml 收敛为单 step `make verify`，`_build-lint.yml` 删去 4 个与 governance 重复的 step + layering grep step。

ref: kubernetes/kubernetes [hack/make-rules/verify.sh](https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/make-rules/verify.sh)

新增的 7 个 verify 维度：
- `verify-archtest.sh` — `tools/archtest/*` 层守护（LAYER-*, AUTH-*, SEC-FAIL-CLOSED-*, ERROR-FIRST-API-01, META-*, ADV-06）
- `verify-contract-health.sh` — `gocell check contract-health`（CH-*）
- `verify-examples-import.sh` — examples/ 不得 import cells/*/internal/ 或 adapters/*/internal/
- `verify-govalidate.sh` — `gocell validate --strict`（FMT, ADV, REF, LAYER, VERIFY, CONTRACT-CONSISTENCY）
- `verify-journey.sh` — `gocell verify journey --active`
- `verify-scaffold-reject.sh` — `gocell scaffold slice` 拒绝 kebab-case 名
- `verify-unconditional-skip.sh` — 无条件 t.Skip 拦截

## 设计要点

- **glob 自动发现**：`hack/make-rules/verify.sh` 遍历 `hack/verify-*.sh`，新增 gate 只需增文件不动 driver
- **fail-accumulate**：所有 gate 跑完累积 exit code，不 fail-fast
- **不留双路径**：`_build-lint.yml` 4 个 verify 类 step + layering grep step 全部移到 hack/，仅保留 build/vet/lint/test/coverage/kernel-cov-gate/vet-e2e
- **archtest 重叠可接受**：kernel shard 的 \`./tools/...\` Test step 仍跑 archtest（matrix 覆盖率），\`make verify\` 也跑 archtest（< 30s 自包含独立运行）

参见 [docs/plans/202604272358-2-2-ci-batch2-k8s-verify.md](../blob/codex/refactor/502-pr-ci-0-verify-entrypoint/docs/plans/202604272358-2-2-ci-batch2-k8s-verify.md) Phase 0。

Refs: PR-CI-0 VERIFY-ENTRYPOINT-01

## Test plan

- [x] \`make verify\` 全绿（7/7 gates pass，本地耗时 ~5s after warm cache）
- [x] \`go build ./...\` 通过
- [x] \`go vet ./...\` 通过
- [ ] CI \`Governance Strict\` workflow 单 step \`make verify\` 通过
- [ ] CI \`Build / Lint / Test\` 删除的 4 个 step 由 \`Governance Strict\` 完整覆盖（无遗漏）