### PR TITLE
PR-A46: require internal listener service-token guard

### DIFF
--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -125,7 +125,8 @@ func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.C
 		// baseURL is constructed from InternalHTTPAddr. If the addr is a port-only
 		// string (e.g. ":9090") we resolve to loopback; if host:port, prepend scheme.
 		// The HMAC ring from InternalGuard is reused for outbound service-token signing.
-		// In dev mode (InternalGuard == nil) the configreceive slice runs in log-only mode.
+		// If tests construct SharedDeps without InternalGuard, configreceive stays
+		// in log-only mode.
 		internalBaseURL := internalAddrToBaseURL(shared.InternalHTTPAddr)
 		if shared.InternalGuard != nil {
 			accessOpts = append(accessOpts,

--- a/cmd/corebundle/auth_integration_test.go
+++ b/cmd/corebundle/auth_integration_test.go
@@ -106,7 +106,7 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(2*time.Second),
 	)
@@ -531,8 +531,7 @@ func TestAuthWiring_HealthListener_PrimaryDoesNotServeHealthz(t *testing.T) {
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 			bootstrap.WithListenerNet(primaryLn)),
-		bootstrap.WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}},
-			bootstrap.WithListenerNet(internalLn)),
+		withCorebundleTestInternalListener(t, internalLn),
 		// HealthListener declared explicitly — /healthz, /readyz move here.
 		bootstrap.WithListener(cell.HealthListener, healthLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}},
 			bootstrap.WithListenerNet(healthLn)),

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -49,37 +49,13 @@ func durabilityModeForTopology(topo bootstrap.Topology) cell.DurabilityMode {
 	return cell.DurabilityDemo
 }
 
-// defaultRuntimeOptions constructs the ordered bootstrap.Option slice from the
-// shared cross-cutting deps, a pre-built assembly, a ConsumerBase, a metrics
-// handler, and the adapter info map. Called by run() after BuildApp returns.
-//
-// PGResource options are contributed per-Cell by CellModule.Provide (via
-// BuildApp opts). This function covers only the cross-cutting concerns:
-// HTTP addr, publisher/subscriber, public/exempt endpoints, metrics, etc.
-func defaultRuntimeOptions(
+func runtimeBaseOptions(
 	shared *SharedDeps,
 	asm *assembly.CoreAssembly,
 	consumerBase *outbox.ConsumerBase,
 	metricsHandler http.Handler,
 	adapterInfo map[string]string,
 ) []bootstrap.Option {
-	// PR-A14b: three-listener topology — primary (business routes + JWT auth),
-	// internal (/internal/v1/* + service-token auth), health (/healthz /readyz
-	// /metrics on a dedicated port).
-	//
-	// Primary listener: AuthJWTFromAssembly discovers IntentTokenVerifier from
-	// accesscore post-Init (lazy phase4 resolution, fail-closed).
-	// Internal listener: AuthServiceToken from InternalGuard. Guard is always
-	// non-nil when InternalHTTPAddr is set: SharedDeps.Validate enforces this
-	// for production topologies, and tests either supply a guard or leave the
-	// addr empty (skipping listener registration entirely).
-	// Health listener: framework-owned /healthz, /readyz, /metrics route groups;
-	// when shared.VerboseToken is set, the health handler's strict-gate path
-	// (WithReadyzVerboseToken → SetVerboseToken) requires a matching X-Readyz-Token
-	// for ?verbose=true requests; mismatches return 401 ErrReadyzVerboseDenied.
-	//
-	// ref: go-kratos/kratos app.go — per-server option pattern.
-
 	healthRouteOpts := []bootstrap.HealthRouteGroupOption{
 		bootstrap.WithMetricsHandler(metricsHandler),
 	}
@@ -105,32 +81,54 @@ func defaultRuntimeOptions(
 		bootstrap.WithHealthRoutes(healthRouteOpts...),
 		bootstrap.WithMetricsProvider(shared.PromStack.metricProvider),
 	}
-	// Primary listener carries the JWT auth plan. AuthJWTFromAssembly
-	// resolves an IntentTokenVerifier from an authProvider cell during phase4.
-	// Tests that pre-bind their own listener still go through this path —
-	// they inject the same listener via extra bootstrap.WithListener options downstream.
+	if shared.RedisClient != nil {
+		opts = append(opts,
+			bootstrap.WithHealthChecker("redis_ready", shared.RedisClient.Health),
+			bootstrap.WithManagedCloser(shared.RedisClient),
+		)
+	}
+	return opts
+}
+
+// defaultRuntimeOptions constructs the ordered bootstrap.Option slice from the
+// shared cross-cutting deps, a pre-built assembly, a ConsumerBase, a metrics
+// handler, and the adapter info map. Called by run() after BuildApp returns.
+//
+// PGResource options are contributed per-Cell by CellModule.Provide (via
+// BuildApp opts). This function covers only the cross-cutting concerns:
+// HTTP addr, publisher/subscriber, public/exempt endpoints, metrics, etc.
+func defaultRuntimeOptions(
+	shared *SharedDeps,
+	asm *assembly.CoreAssembly,
+	consumerBase *outbox.ConsumerBase,
+	metricsHandler http.Handler,
+	adapterInfo map[string]string,
+) []bootstrap.Option {
+	// PR-A14b: three-listener topology — primary (business routes + JWT auth),
+	// internal (/internal/v1/* + service-token auth), health (/healthz /readyz
+	// /metrics on a dedicated port).
+	//
+	// Primary listener: AuthJWTFromAssembly discovers IntentTokenVerifier from
+	// accesscore post-Init (lazy phase4 resolution, fail-closed).
+	// Internal listener: AuthServiceToken from InternalGuard. The listener is
+	// always registered in the runtime path; SharedDeps.Validate requires both
+	// InternalHTTPAddr and InternalGuard before run() reaches this point.
+	// Health listener: framework-owned /healthz, /readyz, /metrics route groups;
+	// when shared.VerboseToken is set, the health handler's strict-gate path
+	// (WithReadyzVerboseToken → SetVerboseToken) requires a matching X-Readyz-Token
+	// for ?verbose=true requests; mismatches return 401 ErrReadyzVerboseDenied.
+	//
+	// ref: go-kratos/kratos app.go — per-server option pattern.
+	opts := runtimeBaseOptions(shared, asm, consumerBase, metricsHandler, adapterInfo)
 	if shared.PrimaryHTTPAddr != "" {
 		opts = append(opts, bootstrap.WithListener(
 			cell.PrimaryListener, shared.PrimaryHTTPAddr,
 			[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
 		))
 	}
-	if shared.InternalHTTPAddr != "" {
-		opts = append(opts, bootstrap.WithListener(cell.InternalListener, shared.InternalHTTPAddr, buildInternalAuthChain(shared.InternalGuard)))
-	}
-	// B2: HealthListener is required when a metrics handler is configured.
-	// Production PodIP/Service probes set GOCELL_HTTP_HEALTH_ADDR to a
-	// reachable bind; same-netns deployments explicitly waive loopback via
-	// GOCELL_HTTP_HEALTH_LOCAL_ONLY=1.
-	// Tests inject their own HealthListener via extra bootstrap.WithListener options.
+	opts = append(opts, bootstrap.WithListener(cell.InternalListener, shared.InternalHTTPAddr, buildInternalAuthChain(shared.InternalGuard)))
 	if shared.HealthHTTPAddr != "" {
 		opts = append(opts, bootstrap.WithListener(cell.HealthListener, shared.HealthHTTPAddr, []cell.ListenerAuth{cell.AuthNone{}}))
-	}
-	if shared.RedisClient != nil {
-		opts = append(opts,
-			bootstrap.WithHealthChecker("redis_ready", shared.RedisClient.Health),
-			bootstrap.WithManagedCloser(shared.RedisClient),
-		)
 	}
 	return opts
 }

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -135,6 +135,8 @@ func TestBuildConsumerBase_NilSharedDepsErrors(t *testing.T) {
 
 func TestDefaultRuntimeOptions_IncludesRedisHealthAndCloser(t *testing.T) {
 	shared := buildTestSharedDeps(t)
+	shared.InternalHTTPAddr = "127.0.0.1:0"
+	shared.InternalGuard = newTestInternalGuard(t)
 	asm := assembly.New(assembly.Config{ID: "test-redis-options", DurabilityMode: cell.DurabilityDemo})
 	cb, err := buildConsumerBase(shared)
 	require.NoError(t, err)
@@ -237,13 +239,14 @@ func buildTestSharedDeps(t *testing.T) *SharedDeps {
 		EventBus:            eb,
 		ConsumerClaimer:     idempotency.NewInMemClaimer(),
 		ConsumerClaimerKind: consumerClaimerKindInMemory,
+		InternalHTTPAddr:    "127.0.0.1:9090",
+		InternalGuard:       newTestInternalGuard(t),
 		// PR-A35: verbose endpoint is gated in every mode. Memory/dev tests
 		// just waive it — nothing here exercises the verbose body.
 		VerboseDisabled: true,
-		// PR-A14a: PrimaryHTTPAddr/InternalHTTPAddr left empty. Tests that
-		// drive the full BuildApp path must inject listeners via
-		// WithPrimaryListener + WithInternalListener so bind addrs are
-		// unused; phase0 accepts either an addr or a listener per side.
+		// Tests that drive the full BuildApp path inject pre-bound listeners via
+		// runtimeBaseOptions + WithListener, so SharedDeps listener addresses are
+		// not used by those helpers.
 	}
 }
 
@@ -277,16 +280,16 @@ func newValidatedSharedDeps(t *testing.T, topo bootstrap.Topology) *SharedDeps {
 		EventBus:            eventbus.New(),
 		ConsumerClaimer:     idempotency.NewInMemClaimer(),
 		ConsumerClaimerKind: consumerClaimerKindInMemory,
+		InternalHTTPAddr:    "127.0.0.1:9090",
+		InternalGuard:       newTestInternalGuard(t),
 		HealthHTTPAddr:      ":9091",
 		// PR-A35: verbose endpoint is now gated in every mode. A test-time
 		// token keeps the dev baseline valid; prod tests override via the
 		// mutate callback when they want to exercise the missing-token path.
 		VerboseToken: "test-verbose",
-		// PR-A14a: addrs intentionally empty; tests drive via listener injection.
 	}
 	if topo.RequireProductionControlPlane() {
 		deps.MetricsToken = "test-metrics"
-		deps.InternalGuard = newTestInternalGuard(t)
 	}
 	if topo.StorageBackend == "postgres" {
 		t.Setenv("GOCELL_CONFIGCORE_MASTER_KEY", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
@@ -360,7 +363,7 @@ func buildBootstrapFromShared(t *testing.T, shared *SharedDeps, primaryLn net.Li
 	}
 
 	adapterInfo := adapterInfoForSharedDeps(shared)
-	opts := defaultRuntimeOptions(shared, asm, consumerBase, metricsHandler, adapterInfo)
+	opts := runtimeBaseOptions(shared, asm, consumerBase, metricsHandler, adapterInfo)
 	opts = append(opts, cellOpts...)
 	// Primary listener carries the JWT policy resolved from the assembly. F3
 	// round-3: this is the single source of truth for JWT auth — there is no

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -375,6 +375,16 @@ func buildBootstrapFromShared(t *testing.T, shared *SharedDeps, primaryLn net.Li
 	return bootstrap.New(opts...), nil
 }
 
+func withCorebundleTestInternalListener(t *testing.T, ln net.Listener) bootstrap.Option {
+	t.Helper()
+	return bootstrap.WithListener(
+		cell.InternalListener,
+		ln.Addr().String(),
+		buildInternalAuthChain(newTestInternalGuard(t)),
+		bootstrap.WithListenerNet(ln),
+	)
+}
+
 func TestAdapterInfoForSharedDeps_IncludesReplayState(t *testing.T) {
 	shared := newValidatedSharedDeps(t, bootstrap.Topology{
 		StorageBackend:            "postgres",
@@ -568,7 +578,7 @@ func TestBuildBootstrap_MemoryTopology(t *testing.T) {
 	healthLn := newCorebundleLocalListener(t)
 
 	app, err := buildBootstrapFromShared(t, shared, ln,
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithListener(cell.HealthListener, healthLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(healthLn)))
 	require.NoError(t, err)
 	require.NotNil(t, app)
@@ -620,7 +630,7 @@ func TestBuildBootstrap_PostgresTopology_FakePGResource(t *testing.T) {
 	healthLn := newCorebundleLocalListener(t)
 
 	app, err := buildBootstrapFromShared(t, shared, ln,
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithListener(cell.HealthListener, healthLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(healthLn)),
 		bootstrap.WithManagedResource(fakePG),
 	)
@@ -656,7 +666,7 @@ func TestBuildBootstrap_AssemblyHasAllCells(t *testing.T) {
 	healthLn := newCorebundleLocalListener(t)
 
 	app, err := buildBootstrapFromShared(t, shared, ln,
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithListener(cell.HealthListener, healthLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(healthLn)))
 	require.NoError(t, err)
 

--- a/cmd/corebundle/controlplane.go
+++ b/cmd/corebundle/controlplane.go
@@ -48,8 +48,8 @@ func (g *internalGuard) NonceStore() auth.NonceStore { return g.nonceStore }
 // startup but cannot know the topology, so the operator is responsible for
 // matching store class to pod count.
 //
-// ref: Kubernetes kube-apiserver service-account verification — guard only when
-// key material is present; no guard is better than a broken guard.
+// ref: Kubernetes kube-apiserver service-account verification — require key
+// material before installing an authentication guard.
 // ref: gorilla/securecookie — replay protection defaults on, not opt-in.
 func internalGuardFromEnv(adapterMode string, store auth.NonceStore) (*internalGuard, error) {
 	secret := os.Getenv(auth.EnvServiceSecret)

--- a/cmd/corebundle/controlplane_guard_test.go
+++ b/cmd/corebundle/controlplane_guard_test.go
@@ -1,8 +1,7 @@
 // Tests for controlplane service-token guard wiring (C6).
 //
 // internalGuardFromEnv returns a ServiceTokenMiddleware guard when
-// GOCELL_SERVICE_SECRET is set. In real mode, missing secret is a hard error.
-// In dev mode, missing secret disables the guard (returns nil, nil).
+// GOCELL_SERVICE_SECRET is set. Missing secret is a hard error in every mode.
 package main
 
 import (

--- a/cmd/corebundle/demo_keys_test.go
+++ b/cmd/corebundle/demo_keys_test.go
@@ -48,8 +48,8 @@ func TestDevDefaults_AreAllInWellKnownDemoKeys(t *testing.T) {
 	// The dev defaults currently wired in cell modules. Keep this list in sync
 	// with loadSecret / buildCursorCodec call sites (audit_module.go,
 	// config_module.go, access_module.go) when they change.
-	// Note: GOCELL_SERVICE_SECRET has no dev-default (empty disables the guard
-	// in dev mode); rejectDemoKey is called directly in internalGuardFromEnv.
+	// Note: GOCELL_SERVICE_SECRET has no dev-default; it is required in every
+	// mode and rejectDemoKey is called directly in internalGuardFromEnv.
 	devDefaults := []string{
 		"dev-hmac-key-replace-in-prod!!!!", // buildHMACKey("GOCELL_AUDITCORE_HMAC_KEY", ...)
 		"corebundle-audit-cursor-key-32b!", // buildCursorCodec(... LoadCursorKeys("AUDITCORE") ...)

--- a/cmd/corebundle/metrics_wiring_integration_test.go
+++ b/cmd/corebundle/metrics_wiring_integration_test.go
@@ -42,7 +42,7 @@ func TestR2_MetricsCollector_RecordsHTTPRequests(t *testing.T) {
 	healthLn := newCorebundleLocalListener(t)
 
 	app, err := buildBootstrapFromShared(t, shared, ln,
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithListener(cell.HealthListener, healthLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(healthLn)))
 	require.NoError(t, err)
 	require.NotNil(t, app)

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -226,7 +226,7 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 	baseOpts := []bootstrap.Option{
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(3 * time.Second),
 		// F3: public routes (login, refresh) and PasswordResetExempt routes
@@ -585,7 +585,7 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 	baseOpts := []bootstrap.Option{
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(3 * time.Second),
 	}

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -99,7 +99,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 	app := bootstrap.New(
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithListener(cell.PrimaryListener, ln.Addr().String(), []cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)}, bootstrap.WithListenerNet(ln)),
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithShutdownTimeout(2*time.Second),
 	)

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -238,6 +238,7 @@ func (d *SharedDeps) Validate() error {
 	errs := d.validateCore()
 	errs = append(errs, d.validateVerboseEndpoint()...)
 	errs = append(errs, d.validateHealthReachability()...)
+	errs = append(errs, d.validateInternalListenerGuard()...)
 	errs = append(errs, d.validateControlPlane()...)
 	return errors.Join(errs...)
 }
@@ -346,6 +347,9 @@ func (d *SharedDeps) validateControlPlane() []error {
 				"InMemoryNonceStore (single pod) or a shared store (multi-pod) "+
 				"via WithServiceTokenNonceStore"))
 	} else if kind == auth.NonceStoreKindInMemory && !d.Topology.SinglePodReplayProtection && d.Topology.RequireProductionControlPlane() {
+		slog.Warn("controlplane: in-memory nonce store rejected for multi-pod deployment",
+			slog.String("nonce_store_kind", string(kind)),
+			slog.String("hint", "set GOCELL_SINGLE_POD=1 for single-pod deployments or configure a distributed NonceStore"))
 		errs = append(errs, errcode.New(errcode.ErrControlplaneNonceStoreMissing,
 			"in-memory nonce store requires GOCELL_SINGLE_POD=1 (single-pod deployments) "+
 				"or a distributed store via WithServiceTokenNonceStore (multi-pod); "+
@@ -357,6 +361,15 @@ func (d *SharedDeps) validateControlPlane() []error {
 				"outbox idempotency claimer; set "+envRedisAddr+" or run with GOCELL_SINGLE_POD=1"))
 	}
 	return errs
+}
+
+func (d *SharedDeps) validateInternalListenerGuard() []error {
+	if d.InternalHTTPAddr == "" || d.InternalGuard != nil {
+		return nil
+	}
+	return []error{errcode.New(errcode.ErrControlplaneServiceSecretMissing,
+		"SharedDeps.InternalGuard must be set when SharedDeps.InternalHTTPAddr is non-empty "+
+			"to protect /internal/v1/*; set GOCELL_SERVICE_SECRET or clear GOCELL_HTTP_INTERNAL_ADDR")}
 }
 
 func (d *SharedDeps) validateHealthReachability() []error {

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -476,9 +476,9 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*SharedDeps, error) {
 	}
 	internalAddr := os.Getenv("GOCELL_HTTP_INTERNAL_ADDR")
 	if internalAddr == "" {
-		// Default to loopback so a dev-mode deployment without a
-		// service-token guard is not trivially reachable across the
-		// network. Operators binding to an internal VPC interface must set
+		// Default to loopback for local development; startup still requires
+		// GOCELL_SERVICE_SECRET so the listener is service-token guarded in
+		// every mode. Operators binding to an internal VPC interface must set
 		// GOCELL_HTTP_INTERNAL_ADDR explicitly.
 		internalAddr = "127.0.0.1:9090"
 	}

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -78,8 +78,8 @@ type SharedDeps struct {
 	ConsumerClaimerKind consumerClaimerKind
 
 	// InternalGuard is the service-token guard protecting /internal/v1/*.
-	// Required whenever InternalHTTPAddr is non-empty; internalGuardFromEnv
-	// rejects an empty GOCELL_SERVICE_SECRET in every adapter mode.
+	// Required in every mode; internalGuardFromEnv rejects an empty
+	// GOCELL_SERVICE_SECRET before runtime listener wiring.
 	//
 	// Held as a typed value (rather than a bare middleware closure) so
 	// validateControlPlane can inspect the backing NonceStore and reject
@@ -364,12 +364,15 @@ func (d *SharedDeps) validateControlPlane() []error {
 }
 
 func (d *SharedDeps) validateInternalListenerGuard() []error {
-	if d.InternalHTTPAddr == "" || d.InternalGuard != nil {
+	if d.InternalHTTPAddr == "" {
+		return []error{errcode.New(errcode.ErrValidationFailed,
+			"SharedDeps.InternalHTTPAddr must be set; the internal listener is always enabled and protected by GOCELL_SERVICE_SECRET")}
+	}
+	if d.InternalGuard != nil {
 		return nil
 	}
 	return []error{errcode.New(errcode.ErrControlplaneServiceSecretMissing,
-		"SharedDeps.InternalGuard must be set when SharedDeps.InternalHTTPAddr is non-empty "+
-			"to protect /internal/v1/*; set GOCELL_SERVICE_SECRET or clear GOCELL_HTTP_INTERNAL_ADDR")}
+		"SharedDeps.InternalGuard must be set to protect /internal/v1/*; set GOCELL_SERVICE_SECRET")}
 }
 
 func (d *SharedDeps) validateHealthReachability() []error {
@@ -437,6 +440,27 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*SharedDeps, error) {
 
 	eb := eventbus.New()
 
+	primaryAddr := os.Getenv("GOCELL_HTTP_PRIMARY_ADDR")
+	if primaryAddr == "" {
+		primaryAddr = ":8080"
+	}
+	internalAddr := os.Getenv("GOCELL_HTTP_INTERNAL_ADDR")
+	if internalAddr == "" {
+		// Default to loopback for local development; startup still requires
+		// GOCELL_SERVICE_SECRET so the listener is service-token guarded in
+		// every mode. Operators binding to an internal VPC interface must set
+		// GOCELL_HTTP_INTERNAL_ADDR explicitly.
+		internalAddr = "127.0.0.1:9090"
+	}
+	healthAddr := os.Getenv("GOCELL_HTTP_HEALTH_ADDR")
+	if healthAddr == "" {
+		// Separate loopback port for local /healthz /readyz /metrics access.
+		// Real-mode PodIP/Service probes must set a Pod-reachable bind such as
+		// :9091, or explicitly opt into same-netns access with
+		// GOCELL_HTTP_HEALTH_LOCAL_ONLY=1.
+		healthAddr = "127.0.0.1:9091"
+	}
+
 	internalGuard, err := internalGuardFromEnv(adapterMode, replay.NonceStore)
 	if err != nil {
 		return nil, err
@@ -468,28 +492,6 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*SharedDeps, error) {
 			slog.Warn("GOCELL_HTTP_ADDR is no longer consumed (PR-A14a dual-listener); set GOCELL_HTTP_PRIMARY_ADDR and GOCELL_HTTP_INTERNAL_ADDR instead",
 				slog.String("legacy_value", legacy))
 		}
-	}
-
-	primaryAddr := os.Getenv("GOCELL_HTTP_PRIMARY_ADDR")
-	if primaryAddr == "" {
-		primaryAddr = ":8080"
-	}
-	internalAddr := os.Getenv("GOCELL_HTTP_INTERNAL_ADDR")
-	if internalAddr == "" {
-		// Default to loopback for local development; startup still requires
-		// GOCELL_SERVICE_SECRET so the listener is service-token guarded in
-		// every mode. Operators binding to an internal VPC interface must set
-		// GOCELL_HTTP_INTERNAL_ADDR explicitly.
-		internalAddr = "127.0.0.1:9090"
-	}
-
-	healthAddr := os.Getenv("GOCELL_HTTP_HEALTH_ADDR")
-	if healthAddr == "" {
-		// Separate loopback port for local /healthz /readyz /metrics access.
-		// Real-mode PodIP/Service probes must set a Pod-reachable bind such as
-		// :9091, or explicitly opt into same-netns access with
-		// GOCELL_HTTP_HEALTH_LOCAL_ONLY=1.
-		healthAddr = "127.0.0.1:9091"
 	}
 
 	deps := &SharedDeps{

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -78,8 +78,8 @@ type SharedDeps struct {
 	ConsumerClaimerKind consumerClaimerKind
 
 	// InternalGuard is the service-token guard protecting /internal/v1/*.
-	// Required when Topology.RequireProductionControlPlane() is true; nil in
-	// dev mode (empty GOCELL_SERVICE_SECRET).
+	// Required whenever InternalHTTPAddr is non-empty; internalGuardFromEnv
+	// rejects an empty GOCELL_SERVICE_SECRET in every adapter mode.
 	//
 	// Held as a typed value (rather than a bare middleware closure) so
 	// validateControlPlane can inspect the backing NonceStore and reject

--- a/cmd/corebundle/shared_deps_test.go
+++ b/cmd/corebundle/shared_deps_test.go
@@ -174,7 +174,7 @@ func TestSharedDeps_Validate_RealModeRejectsLoopbackHealthAddrWithoutLocalOnlyWa
 	}
 }
 
-func TestSharedDeps_Validate_InternalAddrRequiresGuardInAllModes(t *testing.T) {
+func TestSharedDeps_Validate_InternalListenerRequiresAddrAndGuardInAllModes(t *testing.T) {
 	tests := []struct {
 		name string
 		topo bootstrap.Topology
@@ -186,15 +186,24 @@ func TestSharedDeps_Validate_InternalAddrRequiresGuardInAllModes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			deps := newValidatedSharedDeps(t, tc.topo)
-			deps.InternalHTTPAddr = "127.0.0.1:9090"
-			deps.InternalGuard = nil
 
+			deps.InternalHTTPAddr = ""
 			err := deps.Validate()
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "InternalHTTPAddr")
+			assert.Contains(t, err.Error(), "must be set")
+
+			deps = newValidatedSharedDeps(t, tc.topo)
+			deps.InternalHTTPAddr = "127.0.0.1:9090"
+			deps.InternalGuard = nil
+
+			err = deps.Validate()
+
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), "InternalGuard")
 			assert.Contains(t, err.Error(), "/internal/v1/*")
+			assert.NotContains(t, err.Error(), "clear GOCELL_HTTP_INTERNAL_ADDR")
 		})
 	}
 }

--- a/cmd/corebundle/shared_deps_test.go
+++ b/cmd/corebundle/shared_deps_test.go
@@ -174,6 +174,54 @@ func TestSharedDeps_Validate_RealModeRejectsLoopbackHealthAddrWithoutLocalOnlyWa
 	}
 }
 
+func TestSharedDeps_Validate_InternalAddrRequiresGuardInAllModes(t *testing.T) {
+	tests := []struct {
+		name string
+		topo bootstrap.Topology
+	}{
+		{name: "dev", topo: bootstrap.Topology{StorageBackend: "memory", AdapterMode: ""}},
+		{name: "real", topo: bootstrap.Topology{StorageBackend: "postgres", AdapterMode: "real", SinglePodReplayProtection: true}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := newValidatedSharedDeps(t, tc.topo)
+			deps.InternalHTTPAddr = "127.0.0.1:9090"
+			deps.InternalGuard = nil
+
+			err := deps.Validate()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "InternalHTTPAddr")
+			assert.Contains(t, err.Error(), "InternalGuard")
+			assert.Contains(t, err.Error(), "/internal/v1/*")
+		})
+	}
+}
+
+func TestSharedDeps_Validate_RealMultiPodInMemoryNonceStore_LogsWarnAndErrors(t *testing.T) {
+	topo := bootstrap.Topology{
+		StorageBackend:            "postgres",
+		AdapterMode:               "real",
+		SinglePodReplayProtection: false,
+	}
+	deps := newValidatedSharedDeps(t, topo)
+
+	buf, restore := captureSlogWarnLines(t)
+	t.Cleanup(restore)
+
+	err := deps.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GOCELL_SINGLE_POD=1")
+	out := buf.String()
+	assert.Contains(t, out, "in-memory nonce store rejected")
+	assert.Contains(t, out, "multi-pod")
+	assert.Contains(t, out, "nonce_store_kind")
+	assert.Contains(t, out, string(auth.NonceStoreKindInMemory))
+	assert.Contains(t, out, "GOCELL_SINGLE_POD=1")
+}
+
 func TestLoadSharedDepsFromEnv_RealModeAllowsDefaultLoopbackHealthWithLocalOnlyWaiver(t *testing.T) {
 	privPEM, pubPEM := generateTestPEM(t)
 	t.Setenv("GOCELL_ADAPTER_MODE", "real")

--- a/cmd/corebundle/vault_readiness_wiring_test.go
+++ b/cmd/corebundle/vault_readiness_wiring_test.go
@@ -106,7 +106,7 @@ func buildBootstrapWithFakeKeyProvider(t *testing.T, shared *SharedDeps, kp kcry
 	}
 
 	adapterInfo := adapterInfoForSharedDeps(shared)
-	opts := defaultRuntimeOptions(shared, asm, consumerBase, metricsHandler, adapterInfo)
+	opts := runtimeBaseOptions(shared, asm, consumerBase, metricsHandler, adapterInfo)
 	opts = append(opts, cellOpts...)
 	opts = append(opts, bootstrap.WithListener(
 		cell.PrimaryListener,

--- a/cmd/corebundle/vault_readiness_wiring_test.go
+++ b/cmd/corebundle/vault_readiness_wiring_test.go
@@ -143,7 +143,7 @@ func TestA19_ConfigCoreModule_RegistersKeyProviderReadiness(t *testing.T) {
 
 	healthLn := newCorebundleLocalListener(t)
 	app, err := buildBootstrapWithFakeKeyProvider(t, shared, kp, ln,
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithListener(cell.HealthListener, healthLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(healthLn)))
 	require.NoError(t, err)
 	require.NotNil(t, app)
@@ -214,7 +214,7 @@ func TestA19_ConfigCoreModule_KeyProviderReady(t *testing.T) {
 
 	healthLn2 := newCorebundleLocalListener(t)
 	app, err := buildBootstrapWithFakeKeyProvider(t, shared, kp, ln,
-		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(newCorebundleLocalListener(t))),
+		withCorebundleTestInternalListener(t, newCorebundleLocalListener(t)),
 		bootstrap.WithListener(cell.HealthListener, healthLn2.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, bootstrap.WithListenerNet(healthLn2)))
 	require.NoError(t, err)
 

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -134,7 +134,7 @@ Substitute `<keyname>` with the value of `GOCELL_VAULT_TRANSIT_KEY` (default `go
 | Variable | Purpose | Default | Accepted Values |
 |---|---|---|---|
 | `GOCELL_HTTP_PRIMARY_ADDR` | Primary listener bind address (public / API) | `:8080` | Any `host:port` accepted by `net.Listen("tcp", …)`. Use `0.0.0.0:8080` or a specific interface in production. |
-| `GOCELL_HTTP_INTERNAL_ADDR` | Internal listener bind address (`/internal/v1/*`) | `127.0.0.1:9090` | Same format as primary. **Default is loopback** so a dev deployment without a service-token guard is not trivially reachable across the network. Production deployments binding to an internal VPC interface (e.g. `10.0.0.10:9090`) must set this variable explicitly so service-token / mTLS enforcement is the primary defence. |
+| `GOCELL_HTTP_INTERNAL_ADDR` | Internal listener bind address (`/internal/v1/*`) | `127.0.0.1:9090` | Same format as primary. **Default is loopback** for local development; startup still requires `GOCELL_SERVICE_SECRET` so the internal listener is service-token guarded in every mode. Production deployments binding to an internal VPC interface (e.g. `10.0.0.10:9090`) must set this variable explicitly. |
 | `GOCELL_HTTP_HEALTH_ADDR` | Health listener bind address (`/healthz`, `/readyz`, `/metrics`) | `127.0.0.1:9091` | Same format as primary. Default is local/dev only. Use `:9091` or another Pod-reachable address for kubelet HTTP probes and Prometheus PodIP/Service scrapes. |
 | `GOCELL_HTTP_HEALTH_LOCAL_ONLY` | Explicit waiver for loopback health listener in `GOCELL_ADAPTER_MODE=real` | unset | Set to `1` only when health/metrics are reached from the same network namespace, such as local dev, same-Pod sidecar, or exec-probe style checks. |
 

--- a/kernel/cell/auth_plan.go
+++ b/kernel/cell/auth_plan.go
@@ -25,6 +25,8 @@ package cell
 import (
 	"fmt"
 	"sync/atomic"
+
+	"github.com/ghbvf/gocell/pkg/validation"
 )
 
 // MinHMACKeyBytes is the minimum byte length required for HMAC secrets used by
@@ -103,7 +105,7 @@ type AuthJWT struct {
 // NewAuthJWT constructs an AuthJWT plan. Returns an error when v is nil so the
 // caller can decide between fail-fast (use MustNewAuthJWT) and graceful refusal.
 func NewAuthJWT(v IntentTokenVerifier) (AuthJWT, error) {
-	if v == nil {
+	if validation.IsNilInterface(v) {
 		return AuthJWT{}, fmt.Errorf("cell: NewAuthJWT verifier must not be nil; use NewAuthJWTFromAssembly(asm) to discover from an authProvider cell")
 	}
 	return AuthJWT{Verifier: v}, nil
@@ -169,7 +171,7 @@ type AuthJWTFromAssembly struct {
 // error when asm is nil; use MustNewAuthJWTFromAssembly for fail-fast static
 // wiring.
 func NewAuthJWTFromAssembly(asm AssemblyRef) (AuthJWTFromAssembly, error) {
-	if asm == nil {
+	if validation.IsNilInterface(asm) {
 		return AuthJWTFromAssembly{}, fmt.Errorf("cell: NewAuthJWTFromAssembly assembly must not be nil")
 	}
 	return AuthJWTFromAssembly{
@@ -271,10 +273,10 @@ type AuthServiceToken struct {
 //
 // Use MustNewAuthServiceToken for fail-fast static wiring at composition root.
 func NewAuthServiceToken(store NonceStore, ring HMACKeyring) (AuthServiceToken, error) {
-	if store == nil {
+	if validation.IsNilInterface(store) {
 		return AuthServiceToken{}, fmt.Errorf("cell: NewAuthServiceToken store must not be nil")
 	}
-	if ring == nil {
+	if validation.IsNilInterface(ring) {
 		return AuthServiceToken{}, fmt.Errorf("cell: NewAuthServiceToken ring must not be nil")
 	}
 	if got := len(ring.Current()); got < MinHMACKeyBytes {

--- a/kernel/cell/auth_plan.go
+++ b/kernel/cell/auth_plan.go
@@ -265,11 +265,13 @@ type AuthServiceToken struct {
 }
 
 // NewAuthServiceToken constructs an AuthServiceToken plan. Returns an error if
-// either argument is nil or if ring.Current() returns fewer than MinHMACKeyBytes
-// bytes — both are required for a properly guarded internal listener; a short
-// HMAC secret silently weakens MAC strength and is rejected at construction time
-// (NIST SP 800-107 §5.3.4 — HMAC key length must match underlying hash
-// security strength: 256-bit / 32-byte for HMAC-SHA-256).
+// either argument is nil, if store.Kind() is NonceStoreKindNoop, or if
+// ring.Current() returns fewer than MinHMACKeyBytes bytes. A service-token plan
+// is a replay-safe internal-listener guard; NoopNonceStore explicitly disables
+// replay defense and is therefore not a valid AuthServiceToken dependency.
+// A short HMAC secret silently weakens MAC strength and is rejected at
+// construction time (NIST SP 800-107 §5.3.4 — HMAC key length must match
+// underlying hash security strength: 256-bit / 32-byte for HMAC-SHA-256).
 //
 // Use MustNewAuthServiceToken for fail-fast static wiring at composition root.
 func NewAuthServiceToken(store NonceStore, ring HMACKeyring) (AuthServiceToken, error) {
@@ -278,6 +280,9 @@ func NewAuthServiceToken(store NonceStore, ring HMACKeyring) (AuthServiceToken, 
 	}
 	if validation.IsNilInterface(ring) {
 		return AuthServiceToken{}, fmt.Errorf("cell: NewAuthServiceToken ring must not be nil")
+	}
+	if store.Kind() == NonceStoreKindNoop {
+		return AuthServiceToken{}, fmt.Errorf("cell: NewAuthServiceToken store must not be NonceStoreKindNoop; service-token guards require replay protection")
 	}
 	if got := len(ring.Current()); got < MinHMACKeyBytes {
 		return AuthServiceToken{}, fmt.Errorf(

--- a/kernel/cell/auth_plan_test.go
+++ b/kernel/cell/auth_plan_test.go
@@ -163,6 +163,19 @@ func TestNewAuthServiceToken_TypedNilRingReturnsError(t *testing.T) {
 	}
 }
 
+func TestNewAuthServiceToken_RejectsNoopNonceStore(t *testing.T) {
+	t.Parallel()
+
+	_, err := cell.NewAuthServiceToken(&stubNoopNonceStore{}, &stubHMACKeyring{})
+
+	if err == nil {
+		t.Fatal("expected error for noop nonce store, got nil")
+	}
+	if !strings.Contains(err.Error(), "NonceStoreKindNoop") {
+		t.Errorf("error message must mention NonceStoreKindNoop: %q", err.Error())
+	}
+}
+
 func TestMustNewAuthServiceToken_NilStorePanics(t *testing.T) {
 	t.Parallel()
 	defer func() {
@@ -281,7 +294,15 @@ func (s *stubNonceStore) CheckAndMark(_ context.Context, _ string) error {
 	return nil
 }
 
-func (s *stubNonceStore) Kind() cell.NonceStoreKind { return cell.NonceStoreKindNoop }
+func (s *stubNonceStore) Kind() cell.NonceStoreKind { return cell.NonceStoreKindInMemory }
+
+type stubNoopNonceStore struct{}
+
+func (s *stubNoopNonceStore) CheckAndMark(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *stubNoopNonceStore) Kind() cell.NonceStoreKind { return cell.NonceStoreKindNoop }
 
 // stubHMACKeyring satisfies cell.HMACKeyring.
 type stubHMACKeyring struct{}

--- a/kernel/cell/auth_plan_test.go
+++ b/kernel/cell/auth_plan_test.go
@@ -90,6 +90,14 @@ func TestNewAuthJWT_NilReturnsError(t *testing.T) {
 	}
 }
 
+func TestNewAuthJWT_TypedNilReturnsError(t *testing.T) {
+	t.Parallel()
+	var verifier *stubVerifier
+	if _, err := cell.NewAuthJWT(verifier); err == nil {
+		t.Error("expected error for typed-nil verifier, got nil")
+	}
+}
+
 func TestMustNewAuthJWT_NilPanics(t *testing.T) {
 	t.Parallel()
 	defer func() {
@@ -104,6 +112,14 @@ func TestNewAuthJWTFromAssembly_NilReturnsError(t *testing.T) {
 	t.Parallel()
 	if _, err := cell.NewAuthJWTFromAssembly(nil); err == nil { //nolint:staticcheck // SA1012: deliberate nil arg
 		t.Error("expected error for nil assembly, got nil")
+	}
+}
+
+func TestNewAuthJWTFromAssembly_TypedNilReturnsError(t *testing.T) {
+	t.Parallel()
+	var asm *stubAssemblyRef
+	if _, err := cell.NewAuthJWTFromAssembly(asm); err == nil {
+		t.Error("expected error for typed-nil assembly, got nil")
 	}
 }
 
@@ -124,10 +140,26 @@ func TestNewAuthServiceToken_NilStoreReturnsError(t *testing.T) {
 	}
 }
 
+func TestNewAuthServiceToken_TypedNilStoreReturnsError(t *testing.T) {
+	t.Parallel()
+	var store *stubNonceStore
+	if _, err := cell.NewAuthServiceToken(store, &stubHMACKeyring{}); err == nil {
+		t.Error("expected error for typed-nil store, got nil")
+	}
+}
+
 func TestNewAuthServiceToken_NilRingReturnsError(t *testing.T) {
 	t.Parallel()
 	if _, err := cell.NewAuthServiceToken(&stubNonceStore{}, nil); err == nil {
 		t.Error("expected error for nil ring, got nil")
+	}
+}
+
+func TestNewAuthServiceToken_TypedNilRingReturnsError(t *testing.T) {
+	t.Parallel()
+	var ring *stubHMACKeyring
+	if _, err := cell.NewAuthServiceToken(&stubNonceStore{}, ring); err == nil {
+		t.Error("expected error for typed-nil ring, got nil")
 	}
 }
 

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/validation"
 )
 
 const (
@@ -90,7 +91,7 @@ func WithServiceTokenClock(fn func() time.Time) ServiceTokenOption {
 // propagating a nil interface through the authenticator pipeline.
 func WithServiceTokenNonceStore(ns NonceStore) ServiceTokenOption {
 	return func(c *serviceTokenConfig) {
-		if ns == nil {
+		if validation.IsNilInterface(ns) {
 			return
 		}
 		c.nonceStore = ns
@@ -209,7 +210,7 @@ func ServiceTokenMiddleware(ring cell.HMACKeyring, opts ...ServiceTokenOption) f
 		o(&cfg)
 	}
 
-	if ring == nil {
+	if validation.IsNilInterface(ring) {
 		return func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				cfg.metrics.recordServiceVerify("failure", "internal")

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -299,6 +299,19 @@ func TestServiceTokenMiddleware_NilRing(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+func TestServiceTokenMiddleware_TypedNilRing(t *testing.T) {
+	var ring *HMACKeyRing
+	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 // shortKeyringStub returns a sub-MinHMACKeyBytes secret to exercise the
 // defense-in-depth strength check inside ServiceTokenMiddleware (PR269 round-3
 // F5). cell.NewAuthServiceToken would normally reject this at construction

--- a/runtime/bootstrap/auth_plan_apply_test.go
+++ b/runtime/bootstrap/auth_plan_apply_test.go
@@ -34,6 +34,11 @@ type applyStubNonceStore struct{}
 func (s *applyStubNonceStore) CheckAndMark(_ context.Context, _ string) error { return nil }
 func (s *applyStubNonceStore) Kind() cell.NonceStoreKind                      { return cell.NonceStoreKindInMemory }
 
+type applyNoopNonceStore struct{}
+
+func (s *applyNoopNonceStore) CheckAndMark(_ context.Context, _ string) error { return nil }
+func (s *applyNoopNonceStore) Kind() cell.NonceStoreKind                      { return cell.NonceStoreKindNoop }
+
 // applyStubHMACKeyring satisfies cell.HMACKeyring.
 type applyStubHMACKeyring struct{}
 

--- a/runtime/bootstrap/auth_plan_describe.go
+++ b/runtime/bootstrap/auth_plan_describe.go
@@ -70,6 +70,20 @@ func chainContainsAuthMTLS(chain []cell.ListenerAuth) bool {
 	return false
 }
 
+// chainContainsInternalGuard reports whether the listener chain has the
+// service-token guard required for /internal/v1/* routes. JWT is intentionally
+// excluded: internal routes use service-token auth so RoleInternalAdmin can be
+// injected for route policies. AuthMTLS may be layered with service-token, but
+// mTLS alone does not currently establish an internal admin principal.
+func chainContainsInternalGuard(chain []cell.ListenerAuth) bool {
+	for _, p := range chain {
+		if _, ok := p.(cell.AuthServiceToken); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // explicitAuthNone reports whether the chain contains at least one AuthNone
 // entry, distinguishing a deliberate AuthNone{} from a nil/empty chain omission.
 // Used by the OPS-07 non-loopback Warn log to help operators distinguish

--- a/runtime/bootstrap/auth_plan_validate.go
+++ b/runtime/bootstrap/auth_plan_validate.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
 )
 
 // validateAuthPlanAssemblyMatch enforces the single-assembly invariant:
@@ -114,6 +115,77 @@ func (b *Bootstrap) validateAuthChainJWTSingleton() error {
 		if err := checkJWTSingleton(ref.String(), cfg.authChain); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// validateAuthNoneExclusive rejects chains that mix AuthNone with real auth
+// plans. AuthNone is an explicit no-auth declaration, not a decoration; mixing
+// it with guards makes startup logs and reviews ambiguous.
+func (b *Bootstrap) validateAuthNoneExclusive() error {
+	for ref, cfg := range b.listenerConfigs {
+		hasNone := false
+		hasGuard := false
+		for _, plan := range cfg.authChain {
+			if _, ok := plan.(cell.AuthNone); ok {
+				hasNone = true
+				continue
+			}
+			hasGuard = true
+		}
+		if hasNone && hasGuard {
+			return errcode.New(errcode.ErrCellInvalidConfig,
+				fmt.Sprintf("listener %q: AuthNone cannot be mixed with other ListenerAuth plans; "+
+					"use []cell.ListenerAuth{cell.AuthNone{}} only for no-auth listeners or remove AuthNone from protected chains",
+					ref.String()))
+		}
+	}
+	return nil
+}
+
+// validateAuthServiceTokenPlans catches malformed AuthServiceToken literals at
+// phase0. The public constructor already enforces these invariants, but direct
+// struct literals can otherwise reach phase5 and fail inside HTTP middleware
+// assembly rather than at the option boundary.
+func (b *Bootstrap) validateAuthServiceTokenPlans() error {
+	for ref, cfg := range b.listenerConfigs {
+		seen := 0
+		for i, plan := range cfg.authChain {
+			p, ok := plan.(cell.AuthServiceToken)
+			if !ok {
+				continue
+			}
+			seen++
+			if seen > 1 {
+				return errcode.New(errcode.ErrCellInvalidConfig,
+					fmt.Sprintf("listener %q: at most one AuthServiceToken plan allowed in authChain",
+						ref.String()))
+			}
+			if err := validateAuthServiceTokenPlan(ref.String(), i, p); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateAuthServiceTokenPlan(listener string, position int, p cell.AuthServiceToken) error {
+	if validation.IsNilInterface(p.Store) {
+		return errcode.New(errcode.ErrCellInvalidConfig,
+			fmt.Sprintf("listener %q: AuthServiceToken at position %d Store must not be nil; "+
+				"construct it with cell.NewAuthServiceToken(store, ring)",
+				listener, position))
+	}
+	if validation.IsNilInterface(p.Ring) {
+		return errcode.New(errcode.ErrCellInvalidConfig,
+			fmt.Sprintf("listener %q: AuthServiceToken at position %d Ring must not be nil; "+
+				"construct it with cell.NewAuthServiceToken(store, ring)",
+				listener, position))
+	}
+	if got := len(p.Ring.Current()); got < cell.MinHMACKeyBytes {
+		return errcode.New(errcode.ErrCellInvalidConfig,
+			fmt.Sprintf("listener %q: AuthServiceToken at position %d Ring.Current() returned %d bytes, minimum is %d",
+				listener, position, got, cell.MinHMACKeyBytes))
 	}
 	return nil
 }

--- a/runtime/bootstrap/auth_plan_validate.go
+++ b/runtime/bootstrap/auth_plan_validate.go
@@ -173,13 +173,19 @@ func validateAuthServiceTokenPlan(listener string, position int, p cell.AuthServ
 	if validation.IsNilInterface(p.Store) {
 		return errcode.New(errcode.ErrCellInvalidConfig,
 			fmt.Sprintf("listener %q: AuthServiceToken at position %d Store must not be nil; "+
-				"construct it with cell.NewAuthServiceToken(store, ring)",
+				"construct it with cell.MustNewAuthServiceToken(store, ring)",
 				listener, position))
 	}
 	if validation.IsNilInterface(p.Ring) {
 		return errcode.New(errcode.ErrCellInvalidConfig,
 			fmt.Sprintf("listener %q: AuthServiceToken at position %d Ring must not be nil; "+
-				"construct it with cell.NewAuthServiceToken(store, ring)",
+				"construct it with cell.MustNewAuthServiceToken(store, ring)",
+				listener, position))
+	}
+	if p.Store.Kind() == cell.NonceStoreKindNoop {
+		return errcode.New(errcode.ErrCellInvalidConfig,
+			fmt.Sprintf("listener %q: AuthServiceToken at position %d Store must not be NonceStoreKindNoop; "+
+				"service-token guards require replay protection",
 				listener, position))
 	}
 	if got := len(p.Ring.Current()); got < cell.MinHMACKeyBytes {

--- a/runtime/bootstrap/auth_plan_validate_test.go
+++ b/runtime/bootstrap/auth_plan_validate_test.go
@@ -223,6 +223,97 @@ func TestValidateAuthPlanMTLSBindings(t *testing.T) {
 	// longer exists; mTLS bindings are validated only at listener scope.
 }
 
+func TestValidateAuthNoneExclusive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		chain   []cell.ListenerAuth
+		wantErr bool
+	}{
+		{name: "AuthNone alone accepted", chain: []cell.ListenerAuth{cell.AuthNone{}}},
+		{name: "guard alone accepted", chain: []cell.ListenerAuth{cell.AuthMTLS{}}},
+		{name: "AuthNone mixed with guard rejected", chain: []cell.ListenerAuth{cell.AuthNone{}, cell.AuthMTLS{}}, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := bootstrapWithListener(cell.PrimaryListener, tc.chain, nil)
+
+			err := b.validateAuthNoneExclusive()
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "AuthNone cannot be mixed")
+			assert.Contains(t, err.Error(), cell.PrimaryListener.String())
+		})
+	}
+}
+
+func TestValidateAuthServiceTokenPlans(t *testing.T) {
+	t.Parallel()
+
+	validPlan := cell.MustNewAuthServiceToken(&applyStubNonceStore{}, &applyStubHMACKeyring{})
+
+	tests := []struct {
+		name    string
+		chain   []cell.ListenerAuth
+		wantErr string
+	}{
+		{
+			name:  "accepts one service token",
+			chain: []cell.ListenerAuth{validPlan},
+		},
+		{
+			name:  "accepts mtls plus one service token",
+			chain: []cell.ListenerAuth{cell.AuthMTLS{}, validPlan},
+		},
+		{
+			name: "rejects duplicate service token",
+			chain: []cell.ListenerAuth{
+				validPlan,
+				validPlan,
+			},
+			wantErr: "at most one AuthServiceToken",
+		},
+		{
+			name: "rejects nil nonce store",
+			chain: []cell.ListenerAuth{
+				cell.AuthServiceToken{Store: nil, Ring: &applyStubHMACKeyring{}},
+			},
+			wantErr: "Store must not be nil",
+		},
+		{
+			name: "rejects nil keyring",
+			chain: []cell.ListenerAuth{
+				cell.AuthServiceToken{Store: &applyStubNonceStore{}, Ring: nil},
+			},
+			wantErr: "Ring must not be nil",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := bootstrapWithListener(cell.InternalListener, tc.chain, nil)
+
+			err := b.validateAuthServiceTokenPlans()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Contains(t, err.Error(), cell.InternalListener.String())
+		})
+	}
+}
+
 // ─── TestCheckJWTSingleton (unit test of inner helper) ───────────────────────
 
 func TestCheckJWTSingleton(t *testing.T) {

--- a/runtime/bootstrap/auth_plan_validate_test.go
+++ b/runtime/bootstrap/auth_plan_validate_test.go
@@ -294,6 +294,13 @@ func TestValidateAuthServiceTokenPlans(t *testing.T) {
 			},
 			wantErr: "Ring must not be nil",
 		},
+		{
+			name: "rejects noop nonce store literal",
+			chain: []cell.ListenerAuth{
+				cell.AuthServiceToken{Store: &applyNoopNonceStore{}, Ring: &applyStubHMACKeyring{}},
+			},
+			wantErr: "NonceStoreKindNoop",
+		},
 	}
 
 	for _, tc := range tests {

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -27,6 +27,7 @@ import (
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/config"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -151,6 +152,12 @@ func (b *Bootstrap) phase0ValidateOptions() error {
 		return err
 	}
 	if err := b.validateAuthChainJWTSingleton(); err != nil {
+		return err
+	}
+	if err := b.validateAuthNoneExclusive(); err != nil {
+		return err
+	}
+	if err := b.validateAuthServiceTokenPlans(); err != nil {
 		return err
 	}
 	// PR-A14b: validate declarative listener configs last — other option
@@ -698,8 +705,45 @@ func (b *Bootstrap) phase5FinalizeAllRouters(routers map[cell.ListenerRef]*route
 		if err := rtr.FinalizeAuth(); err != nil {
 			return fmt.Errorf("bootstrap: %s router finalize auth: %w", ref.String(), err)
 		}
+		if err := b.validateInternalGuardForDeclaredRoutes(ref, rtr); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// validateInternalGuardForDeclaredRoutes enforces the internal-listener
+// trust boundary once route metadata has been collected. Declaring a
+// /internal/v1/* route means the listener must carry a concrete transport
+// guard; AuthNone is acceptable only for listeners with no internal routes.
+func (b *Bootstrap) validateInternalGuardForDeclaredRoutes(ref cell.ListenerRef, rtr *router.Router) error {
+	if ref != cell.InternalListener {
+		return nil
+	}
+	cfg, ok := b.listenerConfigs[ref]
+	if !ok || chainContainsInternalGuard(cfg.authChain) {
+		return nil
+	}
+	internalRoutes := declaredInternalRoutes(rtr)
+	if len(internalRoutes) == 0 {
+		return nil
+	}
+	sort.Strings(internalRoutes)
+	return errcode.New(errcode.ErrCellInvalidConfig,
+		fmt.Sprintf("bootstrap: internal listener has %d /internal/v1/* route(s) declared without an internal guard: [%s]; "+
+			"set bootstrap.WithListener(cell.InternalListener, ..., []cell.ListenerAuth{cell.NewAuthServiceToken(store, ring)}) "+
+			"and optionally layer cell.AuthMTLS{} with verified client TLS",
+			len(internalRoutes), strings.Join(internalRoutes, ", ")))
+}
+
+func declaredInternalRoutes(rtr *router.Router) []string {
+	var routes []string
+	for _, meta := range rtr.DeclaredAuthMetas() {
+		if meta.IsInternal() {
+			routes = append(routes, meta.Method+" "+meta.Path)
+		}
+	}
+	return routes
 }
 
 // validateAuthVerifierForDeclaredRoutes ensures protected routes mounted on a

--- a/runtime/bootstrap/bootstrap_phases.go
+++ b/runtime/bootstrap/bootstrap_phases.go
@@ -731,7 +731,7 @@ func (b *Bootstrap) validateInternalGuardForDeclaredRoutes(ref cell.ListenerRef,
 	sort.Strings(internalRoutes)
 	return errcode.New(errcode.ErrCellInvalidConfig,
 		fmt.Sprintf("bootstrap: internal listener has %d /internal/v1/* route(s) declared without an internal guard: [%s]; "+
-			"set bootstrap.WithListener(cell.InternalListener, ..., []cell.ListenerAuth{cell.NewAuthServiceToken(store, ring)}) "+
+			"set bootstrap.WithListener(cell.InternalListener, ..., []cell.ListenerAuth{cell.MustNewAuthServiceToken(store, ring)}) "+
 			"and optionally layer cell.AuthMTLS{} with verified client TLS",
 			len(internalRoutes), strings.Join(internalRoutes, ", ")))
 }

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -4006,7 +4006,8 @@ func TestBootstrap_Phase5_FinalizeFailure_OnInternalListener(t *testing.T) {
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}),
-		WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}),
+		WithListener(cell.InternalListener, "127.0.0.1:0",
+			[]cell.ListenerAuth{cell.MustNewAuthServiceToken(&stubNonceStore{}, &stubHMACKeyring{})}),
 		WithShutdownTimeout(time.Second),
 	)
 

--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strings"
 	"sync"
@@ -63,6 +64,28 @@ func (c *dualListenerCell) RouteGroups() []cell.RouteGroup {
 	}
 }
 
+func testInternalAuthChain(t *testing.T) ([]cell.ListenerAuth, *auth.HMACKeyRing) {
+	t.Helper()
+	ring, err := auth.NewHMACKeyRing([]byte("test-service-token-secret-32-bytes"), nil)
+	require.NoError(t, err)
+	store, err := auth.NewInMemoryNonceStore(auth.ServiceTokenNonceTTL)
+	require.NoError(t, err)
+	return []cell.ListenerAuth{cell.MustNewAuthServiceToken(store, ring)}, ring
+}
+
+func getWithServiceToken(t *testing.T, rawURL string, ring *auth.HMACKeyRing) *http.Response {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "ServiceToken "+
+		auth.GenerateServiceToken(ring, http.MethodGet, parsed.Path, parsed.RawQuery, time.Now()))
+	resp, err := testHTTPClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
 // TestDualListener_PrimaryReturns404ForInternalPrefix is the core acceptance
 // test for PR-A14a: hitting /internal/v1/* on the primary listener must
 // yield 404, proving port-level physical isolation. The route IS registered
@@ -84,11 +107,12 @@ func TestDualListener_PrimaryReturns404ForInternalPrefix(t *testing.T) {
 	)
 	asm := assembly.New(assembly.Config{ID: "dual-primary-404", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(c))
+	internalAuthChain, internalRing := testInternalAuthChain(t)
 
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
-		WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(internalLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
 		WithShutdownTimeout(2*time.Second),
 	)
 
@@ -120,8 +144,7 @@ func TestDualListener_PrimaryReturns404ForInternalPrefix(t *testing.T) {
 
 	t.Run("internal_404s_public_prefix", func(t *testing.T) {
 		// internal:port + /api/v1/* → 404
-		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/api/v1/test/ping", internalAddr))
-		require.NoError(t, err)
+		resp := getWithServiceToken(t, fmt.Sprintf("http://%s/api/v1/test/ping", internalAddr), internalRing)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode,
 			"internal listener must 404 on /api/v1/*")
@@ -131,8 +154,7 @@ func TestDualListener_PrimaryReturns404ForInternalPrefix(t *testing.T) {
 
 	t.Run("internal_404s_infra_endpoints", func(t *testing.T) {
 		for _, p := range []string{"/healthz", "/readyz", "/metrics", "/"} {
-			resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s%s", internalAddr, p))
-			require.NoError(t, err)
+			resp := getWithServiceToken(t, fmt.Sprintf("http://%s%s", internalAddr, p), internalRing)
 			resp.Body.Close()
 			assert.Equal(t, http.StatusNotFound, resp.StatusCode,
 				"internal listener must 404 on infra path %q", p)
@@ -148,8 +170,7 @@ func TestDualListener_PrimaryReturns404ForInternalPrefix(t *testing.T) {
 	})
 
 	t.Run("internal_routes_internal_business", func(t *testing.T) {
-		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/internal/v1/admin/ping", internalAddr))
-		require.NoError(t, err)
+		resp := getWithServiceToken(t, fmt.Sprintf("http://%s/internal/v1/admin/ping", internalAddr), internalRing)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, int64(1), internalHits.Load())
@@ -166,11 +187,11 @@ func TestDualListener_PrimaryReturns404ForInternalPrefix(t *testing.T) {
 
 // TestDualListener_InternalRoutesAccessibleWithoutJWT verifies that the
 // InternalListener router does NOT install JWT auth (no auth verifier on
-// internal listener — service-token protection is the caller's responsibility
-// via a cell.Policy on the InternalListener declaration).
+// internal listener). A ServiceToken guards the listener and injects the
+// internal service principal used by route policies.
 //
 // PR-A14b: WithInternalMiddleware was deleted. Internal listener middleware
-// must now be applied via cell.Policy in WithListener or per-group policy.
+// must now be applied through the listener auth chain.
 func TestDualListener_InternalRoutesAccessibleWithoutJWT(t *testing.T) {
 	primaryLn := newLocalListener(t)
 	internalLn := newLocalListener(t)
@@ -188,11 +209,12 @@ func TestDualListener_InternalRoutesAccessibleWithoutJWT(t *testing.T) {
 	)
 	asm := assembly.New(assembly.Config{ID: "dual-nojwt-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(c))
+	internalAuthChain, internalRing := testInternalAuthChain(t)
 
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
-		WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(internalLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
 		WithShutdownTimeout(2*time.Second),
 	)
 
@@ -211,13 +233,13 @@ func TestDualListener_InternalRoutesAccessibleWithoutJWT(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
 
-	// Internal endpoint is reachable without a JWT (no auth verifier on internal listener).
-	t.Run("internal_accessible_without_token", func(t *testing.T) {
-		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/internal/v1/admin/ping", internalAddr))
-		require.NoError(t, err)
+	// Internal endpoint is reachable with a ServiceToken and without a JWT
+	// bearer. The internal listener must not install the public JWT verifier.
+	t.Run("internal_accessible_with_service_token_without_jwt", func(t *testing.T) {
+		resp := getWithServiceToken(t, fmt.Sprintf("http://%s/internal/v1/admin/ping", internalAddr), internalRing)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode,
-			"internal listener must NOT require JWT (service-token auth is caller-side policy)")
+			"internal listener must NOT require JWT; ServiceToken is the internal transport guard")
 		assert.Equal(t, int64(1), internalHits.Load())
 	})
 
@@ -350,11 +372,12 @@ func TestDualListener_ShutdownClosesBothServersNoGoroutineLeak(t *testing.T) {
 	)
 	asm := assembly.New(assembly.Config{ID: "shutdown-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(c))
+	internalAuthChain, _ := testInternalAuthChain(t)
 
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
-		WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(internalLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
 		WithShutdownTimeout(2*time.Second),
 	)
 
@@ -415,11 +438,12 @@ func TestTripleListener_ShutdownNoGoroutineLeak(t *testing.T) {
 	)
 	asm := assembly.New(assembly.Config{ID: "triple-shutdown-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(c))
+	internalAuthChain, _ := testInternalAuthChain(t)
 
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
-		WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(internalLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
 		WithListener(cell.HealthListener, healthLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(healthLn)),
 		WithShutdownTimeout(2*time.Second),
 	)
@@ -681,11 +705,12 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 	)
 	asm := assembly.New(assembly.Config{ID: "race-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(c))
+	internalAuthChain, _ := testInternalAuthChain(t)
 
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
-		WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(internalLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
 		WithShutdownTimeout(2*time.Second),
 	)
 
@@ -864,11 +889,12 @@ func TestAuthWiring_InternalGuard_WaitsForInternalListenerReady(t *testing.T) {
 	)
 	asm := assembly.New(assembly.Config{ID: "auth-wiring-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(c))
+	internalAuthChain, internalRing := testInternalAuthChain(t)
 
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
-		WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(internalLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
 		WithShutdownTimeout(2*time.Second),
 	)
 
@@ -889,8 +915,7 @@ func TestAuthWiring_InternalGuard_WaitsForInternalListenerReady(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond, "primary listener did not become ready")
 
 	// Internal listener must also be reachable by the time primary is healthy.
-	resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/internal/v1/admin/ping", internalAddr))
-	require.NoError(t, err)
+	resp := getWithServiceToken(t, fmt.Sprintf("http://%s/internal/v1/admin/ping", internalAddr), internalRing)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode,
 		"internal listener must be reachable after primary becomes healthy")
@@ -921,11 +946,12 @@ func TestShutdown_NumGoroutineBaseline_AfterServerStable(t *testing.T) {
 	)
 	asm := assembly.New(assembly.Config{ID: "goroutine-baseline-test", DurabilityMode: cell.DurabilityDemo})
 	require.NoError(t, asm.Register(c))
+	internalAuthChain, _ := testInternalAuthChain(t)
 
 	b := New(
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
-		WithListener(cell.InternalListener, internalLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(internalLn)),
+		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
 		WithShutdownTimeout(2*time.Second),
 	)
 

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -1047,6 +1047,92 @@ func TestBootstrap_Phase5_FinalizeAuthCalledTwice_ReturnsLabeledError(t *testing
 	_ = s // s is built for test hygiene (health handler initialisation).
 }
 
+func TestBootstrap_Phase5_InternalRoutesRequireGuard(t *testing.T) {
+	b := New(WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthNone{}}))
+	rtr := buildRouter(t, cell.InternalListener)
+	require.NoError(t, rtr.DeclareAuthMeta(cell.AuthRouteMeta{
+		Method: "POST",
+		Path:   "/internal/v1/access/roles/assign",
+	}))
+
+	err := b.phase5FinalizeAllRouters(map[cell.ListenerRef]*router.Router{
+		cell.InternalListener: rtr,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "internal listener")
+	assert.Contains(t, err.Error(), "AuthServiceToken")
+	assert.Contains(t, err.Error(), "AuthMTLS")
+	assert.Contains(t, err.Error(), "bootstrap.WithListener")
+}
+
+func TestBootstrap_Phase5_InternalRoutesRejectJWTOnlyGuard(t *testing.T) {
+	b := New(WithListener(cell.InternalListener, "127.0.0.1:0",
+		[]cell.ListenerAuth{cell.MustNewAuthJWT(&stubIntentTokenVerifier{})}))
+	rtr := buildRouter(t, cell.InternalListener)
+	require.NoError(t, rtr.DeclareAuthMeta(cell.AuthRouteMeta{
+		Method: "POST",
+		Path:   "/internal/v1/access/roles/assign",
+	}))
+
+	err := b.phase5FinalizeAllRouters(map[cell.ListenerRef]*router.Router{
+		cell.InternalListener: rtr,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "internal guard")
+	assert.Contains(t, err.Error(), "AuthServiceToken")
+	assert.Contains(t, err.Error(), "AuthMTLS")
+}
+
+func TestBootstrap_Phase5_InternalRoutesRejectMTLSOnlyGuard(t *testing.T) {
+	b := New(WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthMTLS{}}))
+	rtr := buildRouter(t, cell.InternalListener)
+	require.NoError(t, rtr.DeclareAuthMeta(cell.AuthRouteMeta{
+		Method: "POST",
+		Path:   "/internal/v1/access/roles/assign",
+	}))
+
+	err := b.phase5FinalizeAllRouters(map[cell.ListenerRef]*router.Router{
+		cell.InternalListener: rtr,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AuthServiceToken")
+}
+
+func TestBootstrap_Phase5_InternalRoutesAcceptServiceTokenGuard(t *testing.T) {
+	plan := cell.MustNewAuthServiceToken(&stubNonceStore{}, &stubHMACKeyring{})
+	b := New(WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{plan}))
+	rtr := buildRouter(t, cell.InternalListener)
+	require.NoError(t, rtr.DeclareAuthMeta(cell.AuthRouteMeta{
+		Method: "POST",
+		Path:   "/internal/v1/access/roles/assign",
+	}))
+
+	err := b.phase5FinalizeAllRouters(map[cell.ListenerRef]*router.Router{
+		cell.InternalListener: rtr,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestBootstrap_Phase5_InternalRoutesAcceptLayeredInternalGuards(t *testing.T) {
+	plan := cell.MustNewAuthServiceToken(&stubNonceStore{}, &stubHMACKeyring{})
+	b := New(WithListener(cell.InternalListener, "127.0.0.1:0", []cell.ListenerAuth{cell.AuthMTLS{}, plan}))
+	rtr := buildRouter(t, cell.InternalListener)
+	require.NoError(t, rtr.DeclareAuthMeta(cell.AuthRouteMeta{
+		Method: "POST",
+		Path:   "/internal/v1/access/roles/assign",
+	}))
+
+	err := b.phase5FinalizeAllRouters(map[cell.ListenerRef]*router.Router{
+		cell.InternalListener: rtr,
+	})
+
+	require.NoError(t, err)
+}
+
 // ---------------------------------------------------------------------------
 // Path3 TLS phase0 三连
 // ---------------------------------------------------------------------------

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -1009,7 +1009,7 @@ func (s *stubNonceStore) CheckAndMark(_ context.Context, _ string) error {
 }
 
 func (s *stubNonceStore) Kind() cell.NonceStoreKind {
-	return cell.NonceStoreKindNoop
+	return cell.NonceStoreKindInMemory
 }
 
 type stubHMACKeyring struct{}

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -238,18 +238,129 @@ func findInternalListenerAuthNoneChain(path string) ([]int, error) {
 		return nil, err
 	}
 	var lines []int
+	facts := collectAuthNoneChainFacts(f)
 	ast.Inspect(f, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok || !isWithListenerCall(call) || len(call.Args) < 3 {
 			return true
 		}
-		if !isInternalListenerRef(call.Args[0]) || !chainLiteralContainsAuthNone(call.Args[2]) {
+		if !isInternalListenerRef(call.Args[0]) || !chainExprContainsAuthNone(call.Args[2], facts) {
 			return true
 		}
 		lines = append(lines, fset.Position(call.Lparen).Line)
 		return true
 	})
 	return lines, nil
+}
+
+type authNoneChainFacts struct {
+	vars  map[string]bool
+	funcs map[string]bool
+}
+
+func collectAuthNoneChainFacts(f *ast.File) authNoneChainFacts {
+	facts := authNoneChainFacts{
+		vars:  make(map[string]bool),
+		funcs: make(map[string]bool),
+	}
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
+		}
+		for _, stmt := range fn.Body.List {
+			ret, ok := stmt.(*ast.ReturnStmt)
+			if !ok {
+				continue
+			}
+			for _, result := range ret.Results {
+				if chainLiteralContainsAuthNone(result) {
+					facts.funcs[fn.Name.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.ValueSpec:
+			for i, name := range stmt.Names {
+				if authNoneRHSAt(stmt.Values, i) {
+					facts.vars[name.Name] = true
+				}
+			}
+		case *ast.AssignStmt:
+			for i, lhs := range stmt.Lhs {
+				id, ok := lhs.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				if authNoneRHSAt(stmt.Rhs, i) {
+					facts.vars[id.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	return facts
+}
+
+func authNoneRHSAt(rhs []ast.Expr, idx int) bool {
+	if len(rhs) == 0 {
+		return false
+	}
+	if len(rhs) == 1 {
+		return chainLiteralContainsAuthNone(rhs[0])
+	}
+	if idx >= len(rhs) {
+		return false
+	}
+	return chainLiteralContainsAuthNone(rhs[idx])
+}
+
+func chainExprContainsAuthNone(expr ast.Expr, facts authNoneChainFacts) bool {
+	if chainLiteralContainsAuthNone(expr) {
+		return true
+	}
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return facts.vars[e.Name]
+	case *ast.CallExpr:
+		id, ok := e.Fun.(*ast.Ident)
+		return ok && facts.funcs[id.Name]
+	default:
+		return false
+	}
+}
+
+func TestFindInternalListenerAuthNoneChain_CatchesLiteralVarAndHelper(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	src := `package main
+
+import (
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/runtime/bootstrap"
+)
+
+func main() {
+	chain := []cell.ListenerAuth{cell.AuthNone{}}
+	bootstrap.WithListener(cell.InternalListener, ":9090", chain)
+	bootstrap.WithListener(cell.InternalListener, ":9091", insecureInternalAuth())
+}
+
+func insecureInternalAuth() []cell.ListenerAuth {
+	return []cell.ListenerAuth{cell.AuthNone{}}
+}
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	lines, err := findInternalListenerAuthNoneChain(path)
+
+	require.NoError(t, err)
+	assert.Len(t, lines, 2)
 }
 
 func isWithListenerCall(call *ast.CallExpr) bool {

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -14,6 +14,8 @@ package archtest
 //       opts.InsecureSkipVerify = true.
 //   05  example docker compose credentials must come from environment
 //       interpolation, not committed literal values.
+//   06  internal listener guard: production WithListener calls must not wire
+//       cell.InternalListener with a literal AuthNone chain.
 //
 // ref: tools/archtest/auth_authtest_boundary_test.go — 4 sub-test pattern
 
@@ -37,6 +39,7 @@ const (
 	secFailClosed03 = "SEC-FAIL-CLOSED-03"
 	secFailClosed04 = "SEC-FAIL-CLOSED-04"
 	secFailClosed05 = "SEC-FAIL-CLOSED-05"
+	secFailClosed06 = "SEC-FAIL-CLOSED-06"
 )
 
 func TestSecurityDefaults(t *testing.T) {
@@ -60,6 +63,10 @@ func TestSecurityDefaults(t *testing.T) {
 
 	t.Run(secFailClosed05+"_example_compose_credentials_from_env", func(t *testing.T) {
 		testSEC05ExampleComposeCredentialsFromEnv(t, root)
+	})
+
+	t.Run(secFailClosed06+"_internal_listener_must_not_use_authnone", func(t *testing.T) {
+		testSEC06InternalListenerMustNotUseAuthNone(t, root)
 	})
 }
 
@@ -177,6 +184,110 @@ func findWithListenerNilAuthChain(path string) ([]int, error) {
 		return true
 	})
 	return lines, nil
+}
+
+func testSEC06InternalListenerMustNotUseAuthNone(t *testing.T, root string) {
+	t.Helper()
+
+	var scanFiles []string
+	bundleDir := filepath.Join(root, "cmd", "corebundle")
+	bundleFiles, err := findProductionGoFilesInDir(bundleDir)
+	require.NoError(t, err, "reading cmd/corebundle")
+	scanFiles = append(scanFiles, bundleFiles...)
+
+	examplesDir := filepath.Join(root, "examples")
+	err = filepath.WalkDir(examplesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Base(path) == "main.go" {
+			scanFiles = append(scanFiles, path)
+		}
+		return nil
+	})
+	require.NoError(t, err, "reading examples")
+
+	var violations []string
+	for _, f := range scanFiles {
+		hits, err := findInternalListenerAuthNoneChain(f)
+		require.NoErrorf(t, err, "scanning %s", f)
+		rel, _ := filepath.Rel(root, f)
+		rel = filepath.ToSlash(rel)
+		for _, line := range hits {
+			violations = append(violations, fmt.Sprintf("%s:%d: InternalListener uses AuthNone literal (SEC-FAIL-CLOSED-06)", rel, line))
+		}
+	}
+
+	if len(violations) > 0 {
+		for _, v := range violations {
+			t.Logf("%s violation: %s", secFailClosed06, v)
+		}
+	}
+	assert.Empty(t, violations,
+		"production InternalListener declarations must use guarded auth chains, not a literal AuthNone chain")
+}
+
+func findInternalListenerAuthNoneChain(path string) ([]int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	var lines []int
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isWithListenerCall(call) || len(call.Args) < 3 {
+			return true
+		}
+		if !isInternalListenerRef(call.Args[0]) || !chainLiteralContainsAuthNone(call.Args[2]) {
+			return true
+		}
+		lines = append(lines, fset.Position(call.Lparen).Line)
+		return true
+	})
+	return lines, nil
+}
+
+func isWithListenerCall(call *ast.CallExpr) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return fn.Sel.Name == "WithListener"
+	case *ast.Ident:
+		return fn.Name == "WithListener"
+	default:
+		return false
+	}
+}
+
+func isInternalListenerRef(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "InternalListener"
+}
+
+func chainLiteralContainsAuthNone(expr ast.Expr) bool {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return false
+	}
+	for _, elt := range lit.Elts {
+		if isAuthNoneComposite(elt) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAuthNoneComposite(expr ast.Expr) bool {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return false
+	}
+	sel, ok := lit.Type.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "AuthNone"
 }
 
 // testSEC03AdapterTLSValidation verifies that adapters/redis, adapters/vault,


### PR DESCRIPTION
## Summary
- fail closed when `cell.InternalListener` declares `/internal/v1/*` routes without a replay-safe `cell.AuthServiceToken` guard
- validate ambiguous or malformed auth plans earlier: mixed `AuthNone`, duplicate service-token plans, nil/typed-nil stores and keyrings, short rings, and `NonceStoreKindNoop`
- make corebundle require `SharedDeps.InternalHTTPAddr` + `SharedDeps.InternalGuard`, always register the internal listener in the runtime path, add SEC-FAIL-CLOSED-06 coverage, and align operator guidance

Refs: PR-A46
ref: Uber Fx `app.go` / `lifecycle.go`, Kratos `transport/http/server.go` / auth middleware, Go Micro auth rules

## Review / Fix
- L3 reviewer pass completed
- Cx1: none in first reviewer pass
- Cx2: `/fix` second-pass findings fixed in `ccd028e3`
  - reject `NonceStoreKindNoop` as an `AuthServiceToken` dependency in constructor and phase0 literal validation
  - remove contradictory `GOCELL_HTTP_INTERNAL_ADDR` clear/disable recovery path; internal listener is always enabled in runtime wiring
  - unify static wiring hints on `cell.MustNewAuthServiceToken(store, ring)`
  - extend SEC-FAIL-CLOSED-06 to catch local variable and simple helper AuthNone chains
- Cx3: reviewer wording/DX cleanup fixed in `9c52eefa`
- Cx3: second-pass stale guard-bypass wording cleanup fixed in `ea7bde9a`

## Test plan
- [x] failing repro tests added first for Noop store, internal addr/guard contract, and archtest helper detection
- [x] `go test ./kernel/cell -run 'TestNewAuthServiceToken_RejectsNoopNonceStore'`
- [x] `go test ./runtime/bootstrap -run 'TestValidateAuthServiceTokenPlans|TestBootstrap_Phase5_InternalRoutes'`
- [x] `go test ./cmd/corebundle -run 'TestSharedDeps_Validate_InternalListenerRequiresAddrAndGuardInAllModes|TestDefaultRuntimeOptions_IncludesRedisHealthAndCloser|TestBuildBootstrap'`
- [x] `go test ./tools/archtest -run 'TestFindInternalListenerAuthNoneChain_CatchesLiteralVarAndHelper|TestSecurityDefaults'`
- [x] `go test ./kernel/cell ./runtime/bootstrap ./cmd/corebundle ./tools/archtest`
- [x] `golangci-lint run ./kernel/cell ./runtime/bootstrap ./cmd/corebundle ./tools/archtest`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `make verify`
