### PR TITLE
PR-A55: close adapter integration skip gaps

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -232,7 +232,10 @@ jobs:
         # that never started in this job. Compile-time tag regressions
         # for the smoke / encryption packages remain covered by the e2e
         # job's `go test -tags=e2e ./tests/e2e/...`.
-        run: go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/... ./tests/integration/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m
+        # tests/testutil owns shared testcontainer startup helpers; include it
+        # so new non-test helper code is covered by its own integration
+        # contract tests instead of relying on downstream packages.
+        run: go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/... ./tests/integration/... ./tests/testutil/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m
 
       - name: OTel collector smoke
         env:

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -234,11 +234,13 @@ jobs:
         # job's `go test -tags=e2e ./tests/e2e/...`.
         run: go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/... ./tests/integration/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m
 
-      - name: OTel collector compile gate
-        # The real collector round-trip is nightly/manual only. This compile
-        # gate keeps the otelcollector build-tag file from drifting on PRs
-        # without starting the heavy collector container.
-        run: go test -tags=integration,otelcollector ./adapters/otel/... -run '^$' -count=1 -timeout 2m
+      - name: OTel collector smoke
+        env:
+          GOCELL_TEST_DOCKER_REQUIRED: "1"
+        # Keep the PR/push gate focused on the single real OTLP/gRPC collector
+        # round-trip. The nightly/manual workflow still runs the full package
+        # under the same tags as a compatibility patrol.
+        run: go test -tags=integration,otelcollector ./adapters/otel/... -run '^TestNewTracer_ExportsSpanToOTLPCollector$' -count=1 -timeout 10m
 
       - name: Upload integration coverage profile
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -206,6 +206,8 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Integration tests (testcontainers)
+        env:
+          GOCELL_TEST_DOCKER_REQUIRED: "1"
         # cmd/corebundle contains e2e outbox integration tests (outbox_e2e_integration_test.go)
         # that require PG testcontainers. Include it so A11 + F1 regression guards run in CI.
         # examples/ssobff carries the end-to-end walkthrough test (AUTH-SETUP-01
@@ -231,6 +233,12 @@ jobs:
         # for the smoke / encryption packages remain covered by the e2e
         # job's `go test -tags=e2e ./tests/e2e/...`.
         run: go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/... ./tests/integration/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m
+
+      - name: OTel collector compile gate
+        # The real collector round-trip is nightly/manual only. This compile
+        # gate keeps the otelcollector build-tag file from drifting on PRs
+        # without starting the heavy collector container.
+        run: go test -tags=integration,otelcollector ./adapters/otel/... -run '^$' -count=1 -timeout 2m
 
       - name: Upload integration coverage profile
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/otel-collector-nightly.yml
+++ b/.github/workflows/otel-collector-nightly.yml
@@ -1,0 +1,40 @@
+name: OTel Collector Nightly
+
+on:
+  schedule:
+    - cron: '17 18 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: otel-collector-nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  otel-collector:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GOCELL_TEST_DOCKER_REQUIRED: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: go.sum
+
+      - name: OTLP collector compatibility
+        run: |
+          set -o pipefail
+          go test -json -v -tags=integration,otelcollector ./adapters/otel/... -count=1 -timeout 10m 2>&1 | tee otel-collector-nightly.json
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: otel-collector-nightly-logs
+          path: otel-collector-nightly.json
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,12 @@ down:
 
 # ---------------------------------------------------------------------------
 # Integration tests  (T08)
-# Boots all services, runs adapter-level tests, tears down.
+# Testcontainers self-provisions required services. GOCELL_TEST_DOCKER_REQUIRED
+# makes Docker provider failures fail fast instead of producing local skips.
 # ---------------------------------------------------------------------------
 
 test-integration:
-	docker compose up -d --wait
-	go test ./adapters/... ./tests/integration/... -tags=integration -count=1 -v
-	docker compose down
+	GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration,e2e ./adapters/... ./tests/integration/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m -v
 
 # ---------------------------------------------------------------------------
 # examples/ssobff startup smoke

--- a/adapters/otel/integration_test.go
+++ b/adapters/otel/integration_test.go
@@ -1,0 +1,114 @@
+//go:build integration && otelcollector
+
+package otel_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	gcotel "github.com/ghbvf/gocell/adapters/otel"
+	"github.com/ghbvf/gocell/tests/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const collectorConfig = `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+`
+
+func TestNewTracer_ExportsSpanToOTLPCollector(t *testing.T) {
+	testutil.RequireDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        testutil.OTelCollectorImage,
+			ExposedPorts: []string{"4317/tcp"},
+			Cmd:          []string{"--config=/etc/otelcol/config.yaml"},
+			HostConfigModifier: func(hostConfig *dockercontainer.HostConfig) {
+				hostConfig.PortBindings = nat.PortMap{
+					nat.Port("4317/tcp"): []nat.PortBinding{
+						{
+							HostIP:   "127.0.0.1",
+							HostPort: "0",
+						},
+					},
+				}
+			},
+			Files: []testcontainers.ContainerFile{
+				{
+					Reader:            strings.NewReader(collectorConfig),
+					ContainerFilePath: "/etc/otelcol/config.yaml",
+					FileMode:          0o644,
+				},
+			},
+			WaitingFor: wait.ForListeningPort(nat.Port("4317/tcp")).
+				WithStartupTimeout(time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err, "start otel collector")
+	t.Cleanup(func() {
+		require.NoError(t, container.Terminate(context.Background()), "terminate otel collector")
+	})
+
+	endpoint, err := container.PortEndpoint(ctx, nat.Port("4317/tcp"), "")
+	require.NoError(t, err, "get collector OTLP endpoint")
+
+	tracer, shutdown, err := gcotel.NewTracer(ctx, gcotel.TracerConfig{
+		ServiceName:      "gocell-otel-integration",
+		ExporterEndpoint: endpoint,
+		Insecure:         true,
+	})
+	require.NoError(t, err, "create OTLP tracer")
+
+	_, span := tracer.Start(context.Background(), "otelcollector-round-trip")
+	span.End()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	require.NoError(t, shutdown(shutdownCtx), "flush span to collector")
+
+	waitForCollectorLog(t, container, "otelcollector-round-trip")
+}
+
+func waitForCollectorLog(t *testing.T, container testcontainers.Container, want string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var lastLogs string
+	for time.Now().Before(deadline) {
+		logs, err := container.Logs(context.Background())
+		require.NoError(t, err, "read collector logs")
+		buf, err := io.ReadAll(logs)
+		require.NoError(t, err, "drain collector logs")
+		require.NoError(t, logs.Close(), "close collector logs")
+		lastLogs = string(buf)
+		if strings.Contains(lastLogs, want) {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("collector logs did not contain %q; logs:\n%s", want, lastLogs)
+}

--- a/adapters/postgres/pool_test.go
+++ b/adapters/postgres/pool_test.go
@@ -3,10 +3,11 @@ package postgres
 import (
 	"context"
 	"encoding/json"
-	"os"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,15 +137,18 @@ func TestPool_Stats_NotInitialized(t *testing.T) {
 }
 
 func TestNewPool_UnreachableHost(t *testing.T) {
-	if os.Getenv("PG_INTEGRATION") == "" {
-		t.Skip("skipping integration test; set PG_INTEGRATION=1 to run")
-	}
-	_, err := NewPool(t.Context(), Config{
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	_, err := NewPool(ctx, Config{
 		DSN:      "postgres://nobody:nopass@127.0.0.1:1/nonexistent",
 		MaxConns: 1,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ERR_ADAPTER_PG_CONNECT")
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec), "NewPool unreachable error must be structured errcode: %v", err)
+	assert.Equal(t, ErrAdapterPGConnect, ec.Code)
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -29,6 +29,8 @@ import (
 // ~5-7s more expensive.
 func startRabbitMQDedicatedContainer(t *testing.T, config Config) (*Connection, *tcrabbitmq.RabbitMQContainer, func()) {
 	t.Helper()
+	testutil.RequireDocker(t)
+
 	ctx := context.Background()
 
 	container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -29,12 +29,10 @@ import (
 // ~5-7s more expensive.
 func startRabbitMQDedicatedContainer(t *testing.T, config Config) (*Connection, *tcrabbitmq.RabbitMQContainer, func()) {
 	t.Helper()
-	testutil.RequireDocker(t)
 
 	ctx := context.Background()
 
-	container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
-	require.NoError(t, err, "start dedicated rabbitmq container")
+	container := testutil.StartRabbitMQContainer(t, ctx)
 
 	amqpURL, err := container.AmqpURL(ctx)
 	require.NoError(t, err, "get dedicated rabbitmq amqp url")

--- a/adapters/rabbitmq/testmain_integration_test.go
+++ b/adapters/rabbitmq/testmain_integration_test.go
@@ -44,6 +44,8 @@ var (
 // per-test Connection with its own cleanup.
 func sharedBrokerURL(t *testing.T) string {
 	t.Helper()
+	testutil.RequireDocker(t)
+
 	sharedBrokerOnce.Do(func() {
 		ctx := context.Background()
 		// tcrabbitmq.Run's default wait strategy only watches for the

--- a/adapters/rabbitmq/testmain_integration_test.go
+++ b/adapters/rabbitmq/testmain_integration_test.go
@@ -9,12 +9,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
-
-	"github.com/docker/go-connections/nat"
-	"github.com/testcontainers/testcontainers-go"
-	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/ghbvf/gocell/tests/testutil"
 )
@@ -44,22 +38,10 @@ var (
 // per-test Connection with its own cleanup.
 func sharedBrokerURL(t *testing.T) string {
 	t.Helper()
-	testutil.RequireDocker(t)
 
 	sharedBrokerOnce.Do(func() {
 		ctx := context.Background()
-		// tcrabbitmq.Run's default wait strategy only watches for the
-		// "Server startup complete" log pattern. On Docker Desktop for Mac
-		// the port forwarder can lag behind that signal, causing AmqpURL /
-		// PortEndpoint to return `port "5672/tcp" not found` for a brief
-		// window. Add an explicit port-listening wait so the container is
-		// not considered ready until the mapped port is actually reachable.
-		container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage,
-			testcontainers.WithAdditionalWaitStrategy(
-				wait.ForListeningPort(nat.Port(tcrabbitmq.DefaultAMQPPort)).
-					WithStartupTimeout(30*time.Second),
-			),
-		)
+		container, err := testutil.StartRabbitMQContainerE(t, ctx)
 		if err != nil {
 			sharedBrokerInitErr = fmt.Errorf("start shared rabbitmq container: %w", err)
 			return

--- a/adapters/redis/integration_test.go
+++ b/adapters/redis/integration_test.go
@@ -23,6 +23,8 @@ import (
 // connected Client plus a cleanup function.
 func startRedis(t *testing.T) (*Client, func()) {
 	t.Helper()
+	testutil.RequireDocker(t)
+
 	ctx := context.Background()
 
 	container, err := tcredis.Run(ctx, testutil.RedisImage)

--- a/cmd/corebundle/outbox_wiring_integration_test.go
+++ b/cmd/corebundle/outbox_wiring_integration_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
@@ -17,18 +16,17 @@ import (
 
 // TestBuildConfigCoreOpts_PGMode_ManagedResourceNonNil asserts that postgres mode
 // produces a non-nil ManagedResource (pool) and a non-empty bootstrapOpts slice
-// carrying WithManagedResource(relay). This test requires a running PostgreSQL
-// instance (GOCELL_CONFIGCORE_DATABASE_URL must be set).
+// carrying WithManagedResource(relay). The test self-provisions PostgreSQL via
+// testcontainers so CI cannot go green by omitting external DSN configuration.
 //
 // The relay is now registered independently via bootstrapOpts rather than
 // carried inside PGResource.Worker() — PGResource wraps only the pool.
 func TestBuildConfigCoreOpts_PGMode_ManagedResourceNonNil(t *testing.T) {
-	pgDSN, ok := os.LookupEnv("GOCELL_CONFIGCORE_DATABASE_URL")
-	if !ok || pgDSN == "" {
-		t.Skip("GOCELL_CONFIGCORE_DATABASE_URL not set; skipping PG-mode relay wiring integration test")
-	}
-
 	ctx := context.Background()
+	pgDSN, cleanup := setupPostgresForMain(t)
+	defer cleanup()
+	applyMigrationsForMain(t, ctx, pgDSN)
+
 	topo := bootstrap.Topology{StorageBackend: "postgres", AdapterMode: "real"}
 	pgCfg := adapterpg.Config{DSN: pgDSN}
 	result, err := buildConfigCoreOpts(ctx, ConfigCoreModuleConfig{

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -272,22 +272,38 @@ Integration tests verify adapter behaviour against real infrastructure. They use
 
 1. Create `integration_test.go` in your Cell or adapter package.
 2. Add `//go:build integration` as the first line.
-3. Read infrastructure addresses from environment variables (see `docs/guides/integration-testing.md`).
-4. Each test should be self-contained: create its own resources, run assertions, then clean up.
+3. Start required infrastructure with testcontainers and call `testutil.RequireDocker(t)` before the first container start.
+4. Pass container-returned DSNs directly into the adapter or Cell under test; do not skip on missing external DSN environment variables.
+5. Each test should be self-contained: create its own resources, run assertions, then clean up.
 
 ```go
 //go:build integration
 
 package mycell
 
-import "testing"
+import (
+    "context"
+    "testing"
+
+    "github.com/ghbvf/gocell/tests/testutil"
+    tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+)
 
 func TestIntegration_MyCellSmoke(t *testing.T) {
-    // Boot cell with real adapters
-    c := NewMyCell(
-        WithPostgresRepo(realRepo),
-    )
+    testutil.RequireDocker(t)
+
     ctx := context.Background()
+    container, err := tcpostgres.Run(ctx, testutil.PostgresImage)
+    require.NoError(t, err)
+    t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+    dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+    require.NoError(t, err)
+
+    repo := newPostgresRepo(dsn)
+    c := NewMyCell(
+        WithPostgresRepo(repo),
+    )
     deps := cell.Dependencies{...}
 
     require.NoError(t, c.Init(ctx, deps))
@@ -302,9 +318,8 @@ func TestIntegration_MyCellSmoke(t *testing.T) {
 ### Running
 
 ```bash
-docker compose up -d          # boot infrastructure
-go test -tags integration ./adapters/postgres/... -count=1 -v
-go test -tags integration ./tests/integration/... -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./adapters/postgres/... -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./tests/integration/... -count=1 -v
 ```
 
 See `docs/guides/integration-testing.md` for full details and environment variable reference.

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -8,27 +8,39 @@ All integration test files use the `//go:build integration` build tag so they ar
 
 ## Prerequisites
 
-```bash
-docker compose up -d          # boots all infra services
-docker compose ps             # verify all services are healthy
-```
+Start the local Docker daemon. Integration tests use testcontainers and
+self-provision PostgreSQL, Redis, RabbitMQ, Vault, and similar dependencies per
+test. Do not start the repository root `docker-compose.yml` for the
+testcontainer-backed integration suite.
 
-The `docker-compose.yml` at the repository root defines the required services.
+Use strict mode when a run must fail if Docker is unavailable:
+
+```bash
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./adapters/postgres/... -count=1
+```
 
 ## Running Integration Tests
 
 ### All integration tests
 
 ```bash
-go test -tags integration ./... -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration,e2e \
+  ./adapters/... \
+  ./tests/integration/... \
+  ./tests/e2e/internal/... \
+  ./cmd/corebundle/... \
+  ./examples/ssobff/... \
+  ./cells/accesscore/slices/identitymanage/... \
+  ./runtime/bootstrap/... \
+  -count=1 -timeout 15m -v
 ```
 
 ### Single adapter
 
 ```bash
-go test -tags integration ./adapters/postgres/... -count=1 -v
-go test -tags integration ./adapters/redis/...    -count=1 -v
-go test -tags integration ./adapters/rabbitmq/... -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./adapters/postgres/... -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./adapters/redis/...    -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./adapters/rabbitmq/... -count=1 -v
 go test -tags integration ./adapters/websocket/... -count=1 -v
 # adapters/oidc and adapters/s3 are thin SDK wrappers with unit tests only.
 ```
@@ -36,13 +48,23 @@ go test -tags integration ./adapters/websocket/... -count=1 -v
 ### Journey tests only
 
 ```bash
-go test -tags integration ./tests/integration/... -run TestJourney -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./tests/integration/... -run TestJourney -count=1 -v
 ```
 
 ### Assembly tests only
 
 ```bash
-go test -tags integration ./tests/integration/... -run TestAssembly -count=1 -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./tests/integration/... -run TestAssembly -count=1 -v
+```
+
+### OTel collector protocol test
+
+The OpenTelemetry Collector round-trip test is intentionally heavier than the
+regular PR integration suite. Run it locally or through the nightly/manual CI
+workflow:
+
+```bash
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration,otelcollector ./adapters/otel/... -count=1 -timeout 10m -v
 ```
 
 ## Test File Conventions
@@ -56,40 +78,57 @@ go test -tags integration ./tests/integration/... -run TestAssembly -count=1 -v
 ## Writing a New Integration Test
 
 1. Add `//go:build integration` as the first line (before `package`).
-2. Conditional skip pattern: wrap `t.Skip` in an environment or build-tag guard so it never runs unconditionally:
+2. If the test starts any testcontainer, call `testutil.RequireDocker(t)` before
+   `testcontainers.GenericContainer` or any `testcontainers-go/modules/* Run`
+   call:
 
    ```go
-   if testing.Short() || os.Getenv("GOCELL_PG_DSN") == "" {
-       t.Skip("requires PG_DSN")
+   func setupPostgres(t *testing.T) {
+       t.Helper()
+       testutil.RequireDocker(t)
+       container, err := tcpostgres.Run(context.Background(), testutil.PostgresImage)
+       require.NoError(t, err)
+       t.Cleanup(func() { _ = container.Terminate(context.Background()) })
    }
    ```
 
-   Permanent stub tests (will never run) MUST be deleted, not marked `t.Skip` — run `gocell check unconditional-skip ./...` to detect violations; analyzer at `tools/nogo/unconditionalskip`.
-3. Read connection parameters from environment variables (e.g., `GOCELL_CONFIGCORE_DATABASE_URL`, `GOCELL_REDIS_ADDR`). Most integration tests start their own testcontainer and pass the DSN directly; see `cmd/corebundle/main_integration_test.go` for the pattern.
+   Local runs self-skip only when Docker is unavailable. CI and ship runs set
+   `GOCELL_TEST_DOCKER_REQUIRED=1`, so Docker provider failures fail the test
+   instead of producing false green.
+3. Do not gate testcontainer-backed tests on DSN/address environment variables
+   or `t.Skip` for missing external services. Start the container in the test
+   and pass its DSN directly; see `cmd/corebundle/main_integration_test.go` for
+   the pattern.
 4. Each test must be self-contained: create its own schema/queue/bucket, run assertions, then clean up.
 5. Use `t.Parallel()` only when tests do not share mutable state (e.g., separate database schemas).
 
+Permanent stub tests (will never run) MUST be deleted, not marked `t.Skip` —
+run `gocell check unconditional-skip ./...` to detect violations; analyzer at
+`tools/nogo/unconditionalskip`.
+
 ## Environment Variables
 
-> Defaults below describe the local docker-compose / testcontainer dev loop. **Never reuse these values in production** — they are public dev fixtures (e.g. RabbitMQ `guest:guest`, MinIO `minioadmin:minioadmin`) and will fail security scans. CI provides real values via secrets.
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GOCELL_TEST_DOCKER_REQUIRED` | unset | Set to `1` in CI or local ship runs to fail when the Docker provider is unhealthy. Leave unset for local self-skip when Docker is not running. |
 
-| Variable | Default (local dev only) | Description |
-|----------|--------------------------|-------------|
-| `GOCELL_CONFIGCORE_DATABASE_URL` | (testcontainer; see test setup) | PostgreSQL DSN for configcore integration tests. Most tests start their own container and pass DSN directly. |
-| `GOCELL_REDIS_ADDR` | `localhost:6379` | Redis address |
-| `GOCELL_AMQP_URL` | (set from CI secret; local docker-compose default uses public `guest:guest@localhost:5672`) | RabbitMQ connection URL |
-| `GOCELL_S3_ENDPOINT` | `http://localhost:9000` | MinIO / S3 endpoint |
-| `GOCELL_S3_ACCESS_KEY` | (set from CI secret; local docker-compose default is the public `minioadmin` fixture) | S3 access key |
-| `GOCELL_S3_SECRET_KEY` | (set from CI secret; local docker-compose default is the public `minioadmin` fixture) | S3 secret key |
-| `GOCELL_OIDC_ISSUER` | `http://localhost:8080/realms/gocell` | OIDC issuer URL |
+Service DSNs such as PostgreSQL, Redis, RabbitMQ, Vault, and OTel Collector are
+test-owned values returned by testcontainers. Do not require developers or CI to
+preconfigure them for the integration suite.
 
 ## CI Pipeline
 
-Integration tests run in a separate CI stage after unit tests pass. The pipeline:
+Integration tests run in a separate CI stage with strict Docker mode. The
+pipeline:
 
-1. Boots Docker Compose services via `docker compose up -d --wait`.
-2. Runs `go test -tags integration ./... -count=1`.
-3. Tears down services via `docker compose down`.
+1. Sets `GOCELL_TEST_DOCKER_REQUIRED=1`.
+2. Runs the testcontainer-backed `go test -tags=integration,e2e ...` package
+   set.
+3. Uploads the integration coverage profile.
+
+The OTel Collector real protocol test runs in a separate nightly/manual workflow
+with `-tags=integration,otelcollector`; PR CI compile-checks that build tag with
+`-run '^$'` but does not start the collector container.
 
 See `scripts/healthcheck-verify.sh` for the health-check gate that precedes integration tests.
 

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -59,13 +59,16 @@ GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags integration ./tests/integration/... 
 
 ### OTel collector protocol test
 
-The OpenTelemetry Collector round-trip test is intentionally heavier than the
-regular PR integration suite. Run it locally or through the nightly/manual CI
-workflow:
+PR and push CI run the minimal real OpenTelemetry Collector round-trip smoke.
+Run the same check locally with:
 
 ```bash
-GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration,otelcollector ./adapters/otel/... -count=1 -timeout 10m -v
+GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration,otelcollector ./adapters/otel/... \
+  -run '^TestNewTracer_ExportsSpanToOTLPCollector$' -count=1 -timeout 10m -v
 ```
+
+The nightly/manual workflow runs the full `./adapters/otel/...` package under
+the same tags as a supplemental compatibility patrol.
 
 ## Test File Conventions
 
@@ -126,9 +129,9 @@ pipeline:
    set.
 3. Uploads the integration coverage profile.
 
-The OTel Collector real protocol test runs in a separate nightly/manual workflow
-with `-tags=integration,otelcollector`; PR CI compile-checks that build tag with
-`-run '^$'` but does not start the collector container.
+The OTel Collector real protocol smoke runs in PR/push CI with
+`-tags=integration,otelcollector`; the nightly/manual workflow runs the broader
+package under the same tags.
 
 See `scripts/healthcheck-verify.sh` for the health-check gate that precedes integration tests.
 

--- a/docs/reviews/202604280302-pr320-a55-six-seat-review.md
+++ b/docs/reviews/202604280302-pr320-a55-six-seat-review.md
@@ -1,0 +1,41 @@
+# PR #320 A55 six-seat review
+
+## Preflight
+
+- repo: `ghbvf/gocell`
+- reviewTargetType: `pr`
+- pr: `#320`
+- base...head: `develop(671208ca)...codex/205-a55-adapter-tskip-backfill(4a819a65)`
+- changedFiles: 14 files
+- evidenceSource: GitHub API + local `git diff origin/develop...HEAD`
+- consistencyCheck: PASS (`api-files=14`, `local-files=14`)
+
+## Reviewer seats
+
+| Seat | Agent | Result |
+|------|-------|--------|
+| Architecture | Gauss | Found Docker strict-mode ambiguity, missing PR compile gate for `otelcollector`, and archtest coverage risk. |
+| Security | Hegel | Found OTel collector host port binding should be loopback-only; also noted tag-only images in existing e2e compose as out of scope. |
+| Testing / Regression | Laplace | Found missing PR compile coverage for OTel collector tag and hard-coded archtest file list. |
+| Ops / CI | Descartes | Found strict Docker health should be bounded, nightly should have timeout/concurrency/log artifacts, and OTel tag needs PR compile gate. |
+| Maintainability / DX | Singer | Found hard-coded archtest alias/path logic and string-literal parsing via `strings.Trim`. |
+| Product / DX | Einstein | Found Makefile/docs still documented the old compose/env-gated integration model. |
+
+## Consolidated findings
+
+| ID | Priority | Complexity | Scope | Decision |
+|----|----------|------------|-------|----------|
+| PR320-A55-R1 | P2 | Cx1/Cx2 | In scope | Fix Docker strict mode to require explicit `GOCELL_TEST_DOCKER_REQUIRED=1`, bound provider health checks, and emit actionable failure text. |
+| PR320-A55-R2 | P2 | Cx1/Cx2 | In scope | Add PR CI compile-only gate for `integration,otelcollector`; do not run the heavy collector round-trip on PRs. |
+| PR320-A55-R3 | P2 | Cx1/Cx2 | In scope | Rewrite archtest testcontainer guard as repo-wide AST/import scan and parse string literals with `strconv.Unquote`. |
+| PR320-A55-R4 | P2 | Cx1 | In scope | Bind the OTel collector exposed port to `127.0.0.1:0` instead of relying on default host bindings. |
+| PR320-A55-R5 | P2 | Cx1 | In scope | Add nightly workflow timeout, concurrency, JSON test log capture, and failure artifact upload. |
+| PR320-A55-R6 | P2 | Cx1/Cx2 | In scope | Update `make test-integration` and docs to the testcontainers self-provision model; remove compose/env-gated guidance. |
+| PR320-A55-R7 | P2 | Cx2 | Out of scope | Existing `tests/e2e` compose/Dockerfile tag-only images are not part of A55 adapter integration skip cleanup; leave for separate hardening PR. |
+
+## Explicit adjudication
+
+- P0/P1: none.
+- Full OTel collector execution in PR CI: rejected. The PR plan explicitly says the real collector protocol test is nightly/manual only; the accepted fix is compile-only PR coverage with `-run '^$'`.
+- Archtest was reported once as Cx3 by architecture, but multiple seats classified the same gap as Cx2 and it was directly actionable, so it is fixed in this PR.
+- The previously missing formal reviewer artifact is this document; the in-scope Cx1/Cx2 findings above are tracked and fixed in the follow-up patch.

--- a/docs/reviews/202604280302-pr320-a55-six-seat-review.md
+++ b/docs/reviews/202604280302-pr320-a55-six-seat-review.md
@@ -14,10 +14,10 @@
 
 | Seat | Agent | Result |
 |------|-------|--------|
-| Architecture | Gauss | Found Docker strict-mode ambiguity, missing PR compile gate for `otelcollector`, and archtest coverage risk. |
+| Architecture | Gauss | Found Docker strict-mode ambiguity, missing PR collector gate for `otelcollector`, and archtest coverage risk. |
 | Security | Hegel | Found OTel collector host port binding should be loopback-only; also noted tag-only images in existing e2e compose as out of scope. |
-| Testing / Regression | Laplace | Found missing PR compile coverage for OTel collector tag and hard-coded archtest file list. |
-| Ops / CI | Descartes | Found strict Docker health should be bounded, nightly should have timeout/concurrency/log artifacts, and OTel tag needs PR compile gate. |
+| Testing / Regression | Laplace | Found missing PR coverage for the OTel collector smoke and hard-coded archtest file list. |
+| Ops / CI | Descartes | Found strict Docker health should be bounded, nightly should have timeout/concurrency/log artifacts, and OTel tag needs a PR gate. |
 | Maintainability / DX | Singer | Found hard-coded archtest alias/path logic and string-literal parsing via `strings.Trim`. |
 | Product / DX | Einstein | Found Makefile/docs still documented the old compose/env-gated integration model. |
 
@@ -26,16 +26,18 @@
 | ID | Priority | Complexity | Scope | Decision |
 |----|----------|------------|-------|----------|
 | PR320-A55-R1 | P2 | Cx1/Cx2 | In scope | Fix Docker strict mode to require explicit `GOCELL_TEST_DOCKER_REQUIRED=1`, bound provider health checks, and emit actionable failure text. |
-| PR320-A55-R2 | P2 | Cx1/Cx2 | In scope | Add PR CI compile-only gate for `integration,otelcollector`; do not run the heavy collector round-trip on PRs. |
+| PR320-A55-R2 | P1 | Cx1/Cx2 | In scope | Run the minimal real OTel Collector smoke in PR/push CI with `integration,otelcollector`; keep nightly/manual as supplemental patrol. |
 | PR320-A55-R3 | P2 | Cx1/Cx2 | In scope | Rewrite archtest testcontainer guard as repo-wide AST/import scan and parse string literals with `strconv.Unquote`. |
 | PR320-A55-R4 | P2 | Cx1 | In scope | Bind the OTel collector exposed port to `127.0.0.1:0` instead of relying on default host bindings. |
 | PR320-A55-R5 | P2 | Cx1 | In scope | Add nightly workflow timeout, concurrency, JSON test log capture, and failure artifact upload. |
 | PR320-A55-R6 | P2 | Cx1/Cx2 | In scope | Update `make test-integration` and docs to the testcontainers self-provision model; remove compose/env-gated guidance. |
+| PR320-A55-R8 | P2 | Cx3 | In scope | Route all RabbitMQ testcontainers through one shared startup helper with the same AMQP/HTTP port readiness contract. |
 | PR320-A55-R7 | P2 | Cx2 | Out of scope | Existing `tests/e2e` compose/Dockerfile tag-only images are not part of A55 adapter integration skip cleanup; leave for separate hardening PR. |
 
 ## Explicit adjudication
 
 - P0/P1: none.
-- Full OTel collector execution in PR CI: rejected. The PR plan explicitly says the real collector protocol test is nightly/manual only; the accepted fix is compile-only PR coverage with `-run '^$'`.
+- Full OTel collector package execution in PR CI: rejected. The accepted gate is the single real OTLP/gRPC smoke `TestNewTracer_ExportsSpanToOTLPCollector`; the broader package run stays nightly/manual.
 - Archtest was reported once as Cx3 by architecture, but multiple seats classified the same gap as Cx2 and it was directly actionable, so it is fixed in this PR.
+- The RabbitMQ readiness regression was confirmed after the first review artifact. The fix centralizes `tcrabbitmq.Run` in `tests/testutil.StartRabbitMQContainer` and expands the archtest guard to non-test Go helpers so that startup contract cannot drift again.
 - The previously missing formal reviewer artifact is this document; the in-scope Cx1/Cx2 findings above are tracked and fixed in the follow-up patch.

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
-	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
 	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -69,12 +68,10 @@ func setupPostgresContainer(t *testing.T) (*postgres.Pool, func()) {
 
 func setupRabbitMQContainer(t *testing.T) (*rabbitmq.Connection, func()) {
 	t.Helper()
-	testutil.RequireDocker(t)
 
 	ctx := context.Background()
 
-	container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
-	require.NoError(t, err, "start rabbitmq container")
+	container := testutil.StartRabbitMQContainer(t, ctx)
 
 	amqpURL, err := container.AmqpURL(ctx)
 	require.NoError(t, err, "get rabbitmq amqp url")

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -37,6 +37,8 @@ type queueInspector interface {
 
 func setupPostgresContainer(t *testing.T) (*postgres.Pool, func()) {
 	t.Helper()
+	testutil.RequireDocker(t)
+
 	ctx := context.Background()
 
 	container, err := tcpostgres.Run(ctx, testutil.PostgresImage,
@@ -67,6 +69,8 @@ func setupPostgresContainer(t *testing.T) (*postgres.Pool, func()) {
 
 func setupRabbitMQContainer(t *testing.T) (*rabbitmq.Connection, func()) {
 	t.Helper()
+	testutil.RequireDocker(t)
+
 	ctx := context.Background()
 
 	container, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
@@ -95,6 +99,8 @@ func setupRabbitMQContainer(t *testing.T) (*rabbitmq.Connection, func()) {
 
 func setupRedisContainer(t *testing.T) (*redis.Client, func()) {
 	t.Helper()
+	testutil.RequireDocker(t)
+
 	ctx := context.Background()
 
 	container, err := tcredis.Run(ctx, testutil.RedisImage)

--- a/tests/integration/shutdown_e2e_test.go
+++ b/tests/integration/shutdown_e2e_test.go
@@ -53,17 +53,19 @@ import (
 // running against the same broker.
 func startShutdownTestBroker(t *testing.T) (amqpURL, mgmtURL string, container *tcrabbitmq.RabbitMQContainer, cleanup func()) {
 	t.Helper()
-	testutil.RequireDocker(t)
 
 	ctx := context.Background()
-	c, err := tcrabbitmq.Run(ctx, testutil.RabbitMQImage)
-	require.NoError(t, err, "start rabbitmq container for shutdown e2e")
+	c := testutil.StartRabbitMQContainer(t, ctx)
 
 	amqp, err := c.AmqpURL(ctx)
 	require.NoError(t, err, "get amqp url")
 
-	mgmt, err := c.HttpURL(ctx)
-	require.NoError(t, err, "get management http url")
+	var mgmt string
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		var httpErr error
+		mgmt, httpErr = c.HttpURL(ctx)
+		require.NoError(collect, httpErr, "get management http url")
+	}, 10*time.Second, 100*time.Millisecond, "management http url should be mapped")
 
 	cleanup = func() {
 		if termErr := c.Terminate(ctx); termErr != nil {

--- a/tests/testutil/docker.go
+++ b/tests/testutil/docker.go
@@ -3,42 +3,64 @@ package testutil
 
 import (
 	"context"
-	"net"
+	"fmt"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
-// RequireDocker skips t if Docker is not available in the test environment.
-// Integration tests that use testcontainers must call this at the top of the
-// test (or setup helper) so they self-skip in CI environments without Docker.
-//
-// Detection strategy:
-//  1. DOCKER_HOST env var — if set and non-empty, assume Docker is available.
-//  2. Default Unix socket /var/run/docker.sock — try a 1-second TCP dial.
-//
-// This avoids importing the Docker client SDK while remaining correct for the
-// common CI cases (socket present or DOCKER_HOST set).
-func RequireDocker(t *testing.T) {
-	t.Helper()
-	if dockerAvailable() {
-		return
-	}
-	t.Skip("docker not available; skipping integration test")
+const dockerProviderHealthTimeout = 10 * time.Second
+
+type dockerHealthProvider interface {
+	Health(context.Context) error
 }
 
-// dockerAvailable returns true when Docker appears reachable.
-func dockerAvailable() bool {
-	if host := os.Getenv("DOCKER_HOST"); host != "" {
-		return true
+var (
+	getDockerProvider = func() (dockerHealthProvider, error) {
+		return testcontainers.ProviderDocker.GetProvider()
 	}
-	// Try the default Unix socket via a short-lived TCP dial.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", "/var/run/docker.sock")
+	skipIfDockerProviderUnhealthy = testcontainers.SkipIfProviderIsNotHealthy
+)
+
+// RequireDocker skips t if Docker is not available in a local test environment.
+// Integration tests that use testcontainers must call this at the top of the
+// test (or setup helper) so local runs self-skip when Docker is unavailable.
+//
+// Set GOCELL_TEST_DOCKER_REQUIRED=1 in CI jobs where Docker-backed integration
+// tests are mandatory. In that mode an unavailable provider is a test failure,
+// not a skip, so CI cannot go green without executing the integration path.
+func RequireDocker(t *testing.T) {
+	t.Helper()
+	if dockerRequired() {
+		ctx, cancel := context.WithTimeout(context.Background(), dockerProviderHealthTimeout)
+		defer cancel()
+		if err := dockerProviderHealth(ctx); err != nil {
+			t.Fatal(requireDockerFailureMessage(err))
+		}
+		return
+	}
+
+	skipIfDockerProviderUnhealthy(t)
+}
+
+func dockerRequired() bool {
+	return os.Getenv("GOCELL_TEST_DOCKER_REQUIRED") == "1"
+}
+
+func dockerProviderHealth(ctx context.Context) error {
+	provider, err := getDockerProvider()
 	if err != nil {
-		return false
+		return err
 	}
-	_ = conn.Close()
-	return true
+	return provider.Health(ctx)
+}
+
+func requireDockerFailureMessage(err error) string {
+	return fmt.Sprintf(
+		"docker provider required by GOCELL_TEST_DOCKER_REQUIRED=1 but unhealthy or unavailable (DOCKER_HOST=%q): %v; start Docker or unset GOCELL_TEST_DOCKER_REQUIRED for local self-skip",
+		os.Getenv("DOCKER_HOST"),
+		err,
+	)
 }

--- a/tests/testutil/docker_test.go
+++ b/tests/testutil/docker_test.go
@@ -1,0 +1,139 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/testcontainers/testcontainers-go"
+)
+
+type fakeDockerProvider struct {
+	healthErr error
+}
+
+func (p fakeDockerProvider) Health(context.Context) error {
+	return p.healthErr
+}
+
+func TestDockerRequiredEnv(t *testing.T) {
+	t.Setenv("GOCELL_TEST_DOCKER_REQUIRED", "")
+	t.Setenv("CI", "")
+	if dockerRequired() {
+		t.Fatal("dockerRequired() = true with no env, want false")
+	}
+
+	t.Setenv("GOCELL_TEST_DOCKER_REQUIRED", "1")
+	if !dockerRequired() {
+		t.Fatal("dockerRequired() = false with GOCELL_TEST_DOCKER_REQUIRED=1")
+	}
+
+	t.Setenv("GOCELL_TEST_DOCKER_REQUIRED", "")
+	t.Setenv("CI", "true")
+	if dockerRequired() {
+		t.Fatal("dockerRequired() = true with CI=true, want explicit GOCELL_TEST_DOCKER_REQUIRED only")
+	}
+}
+
+func TestDockerProviderHealth(t *testing.T) {
+	t.Run("healthy", func(t *testing.T) {
+		restoreDockerProvider(t, func() (dockerHealthProvider, error) {
+			return fakeDockerProvider{}, nil
+		})
+
+		if err := dockerProviderHealth(context.Background()); err != nil {
+			t.Fatalf("dockerProviderHealth() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		providerErr := errors.New("provider unavailable")
+		restoreDockerProvider(t, func() (dockerHealthProvider, error) {
+			return nil, providerErr
+		})
+
+		if err := dockerProviderHealth(context.Background()); !errors.Is(err, providerErr) {
+			t.Fatalf("dockerProviderHealth() error = %v, want %v", err, providerErr)
+		}
+	})
+
+	t.Run("health error", func(t *testing.T) {
+		healthErr := errors.New("provider unhealthy")
+		restoreDockerProvider(t, func() (dockerHealthProvider, error) {
+			return fakeDockerProvider{healthErr: healthErr}, nil
+		})
+
+		if err := dockerProviderHealth(context.Background()); !errors.Is(err, healthErr) {
+			t.Fatalf("dockerProviderHealth() error = %v, want %v", err, healthErr)
+		}
+	})
+}
+
+func TestDockerProviderHealth_DefaultProviderWhenAvailable(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	if err := dockerProviderHealth(context.Background()); err != nil {
+		t.Fatalf("dockerProviderHealth() with default provider error = %v, want nil", err)
+	}
+}
+
+func TestRequireDocker(t *testing.T) {
+	t.Run("strict checks provider health", func(t *testing.T) {
+		t.Setenv("GOCELL_TEST_DOCKER_REQUIRED", "1")
+		restoreDockerProvider(t, func() (dockerHealthProvider, error) {
+			return fakeDockerProvider{}, nil
+		})
+
+		RequireDocker(t)
+	})
+
+	t.Run("local delegates to testcontainers skip helper", func(t *testing.T) {
+		t.Setenv("GOCELL_TEST_DOCKER_REQUIRED", "")
+		t.Setenv("CI", "")
+		var called bool
+		restoreDockerSkip(t, func(*testing.T) {
+			called = true
+		})
+
+		RequireDocker(t)
+		if !called {
+			t.Fatal("RequireDocker() did not delegate to skip helper")
+		}
+	})
+}
+
+func TestRequireDockerFailureMessage(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "unix:///tmp/docker.sock")
+
+	message := requireDockerFailureMessage(errors.New("daemon down"))
+	for _, want := range []string{
+		"GOCELL_TEST_DOCKER_REQUIRED=1",
+		`DOCKER_HOST="unix:///tmp/docker.sock"`,
+		"daemon down",
+		"start Docker",
+		"local self-skip",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("requireDockerFailureMessage() = %q, want substring %q", message, want)
+		}
+	}
+}
+
+func restoreDockerProvider(t *testing.T, provider func() (dockerHealthProvider, error)) {
+	t.Helper()
+	previous := getDockerProvider
+	getDockerProvider = provider
+	t.Cleanup(func() {
+		getDockerProvider = previous
+	})
+}
+
+func restoreDockerSkip(t *testing.T, skip func(*testing.T)) {
+	t.Helper()
+	previous := skipIfDockerProviderUnhealthy
+	skipIfDockerProviderUnhealthy = skip
+	t.Cleanup(func() {
+		skipIfDockerProviderUnhealthy = previous
+	})
+}

--- a/tests/testutil/images.go
+++ b/tests/testutil/images.go
@@ -9,8 +9,9 @@ package testutil
 // for the exact tag, run `go test ./tests/testutil/...` to verify the format,
 // then run integration tests.
 const (
-	PostgresImage = "postgres:15.13-alpine@sha256:1414298ea93186123a6dcf872f778ba3bd2347edcbd2f31aa7bb2d9814ff5393"
-	RedisImage    = "redis:7.4.2-alpine@sha256:02419de7eddf55aa5bcf49efb74e88fa8d931b4d77c07eff8a6b2144472b6952"
-	RabbitMQImage = "rabbitmq:3.12.14-management-alpine@sha256:0b44fbcc3a4bf22d00090f1353127577dbe1fcb109c41669733a9d7ecf6c3a78"
-	VaultImage    = "hashicorp/vault:1.17@sha256:74a4ab138ab5d64725e89cd9a9c73f7040c7fe49e98b71697b275ca9a69919df"
+	PostgresImage      = "postgres:15.13-alpine@sha256:1414298ea93186123a6dcf872f778ba3bd2347edcbd2f31aa7bb2d9814ff5393"
+	RedisImage         = "redis:7.4.2-alpine@sha256:02419de7eddf55aa5bcf49efb74e88fa8d931b4d77c07eff8a6b2144472b6952"
+	RabbitMQImage      = "rabbitmq:3.12.14-management-alpine@sha256:0b44fbcc3a4bf22d00090f1353127577dbe1fcb109c41669733a9d7ecf6c3a78"
+	VaultImage         = "hashicorp/vault:1.17@sha256:74a4ab138ab5d64725e89cd9a9c73f7040c7fe49e98b71697b275ca9a69919df"
+	OTelCollectorImage = "otel/opentelemetry-collector:0.123.0@sha256:e5e4a13f0ea98e7ca1d1d809be040180540146888d0d764abd4e1277cba87350"
 )

--- a/tests/testutil/images_test.go
+++ b/tests/testutil/images_test.go
@@ -13,10 +13,11 @@ var imagePinnedByDigest = regexp.MustCompile(`^[a-z0-9./-]+:\d+\.\d+(\.\d+)?[a-z
 // use tag+digest pinning, not floating tags like "postgres:15-alpine".
 func TestContainerImagesPinned(t *testing.T) {
 	images := map[string]string{
-		"PostgresImage": PostgresImage,
-		"RedisImage":    RedisImage,
-		"RabbitMQImage": RabbitMQImage,
-		"VaultImage":    VaultImage,
+		"PostgresImage":      PostgresImage,
+		"RedisImage":         RedisImage,
+		"RabbitMQImage":      RabbitMQImage,
+		"VaultImage":         VaultImage,
+		"OTelCollectorImage": OTelCollectorImage,
 	}
 	for name, image := range images {
 		t.Run(name, func(t *testing.T) {
@@ -37,6 +38,7 @@ func TestContainerImagesPinned_RejectsFloating(t *testing.T) {
 		"rabbitmq:3-management-alpine",
 		"rabbitmq:3.12.14-management-alpine",
 		"hashicorp/vault:1.17",
+		"otel/opentelemetry-collector:0.123.0",
 	}
 
 	for _, img := range floating {

--- a/tests/testutil/rabbitmq_integration.go
+++ b/tests/testutil/rabbitmq_integration.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const rabbitMQStartupTimeout = 30 * time.Second
+
+// StartRabbitMQContainer starts a RabbitMQ testcontainer with the shared
+// readiness contract used by all integration tests.
+func StartRabbitMQContainer(t *testing.T, ctx context.Context) *tcrabbitmq.RabbitMQContainer {
+	t.Helper()
+	container, err := StartRabbitMQContainerE(t, ctx)
+	require.NoError(t, err, "start rabbitmq container")
+	return container
+}
+
+func StartRabbitMQContainerE(t *testing.T, ctx context.Context) (*tcrabbitmq.RabbitMQContainer, error) {
+	t.Helper()
+	RequireDocker(t)
+
+	return tcrabbitmq.Run(ctx, RabbitMQImage,
+		testcontainers.WithAdditionalWaitStrategy(
+			wait.ForListeningPort(nat.Port(tcrabbitmq.DefaultAMQPPort)).
+				WithStartupTimeout(rabbitMQStartupTimeout),
+		),
+	)
+}

--- a/tests/testutil/rabbitmq_integration_test.go
+++ b/tests/testutil/rabbitmq_integration_test.go
@@ -1,0 +1,22 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartRabbitMQContainer_StartsReadyAMQP(t *testing.T) {
+	ctx := context.Background()
+	container := StartRabbitMQContainer(t, ctx)
+	t.Cleanup(func() {
+		require.NoError(t, container.Terminate(ctx), "terminate rabbitmq container")
+	})
+
+	amqpURL, err := container.AmqpURL(ctx)
+	require.NoError(t, err, "get rabbitmq amqp url")
+	require.NotEmpty(t, amqpURL)
+}

--- a/tools/archtest/integration_guard_test.go
+++ b/tools/archtest/integration_guard_test.go
@@ -116,7 +116,7 @@ func collectTestcontainerDockerGuardFindings(t *testing.T, root string) []string
 		if skipDir := dockerGuardSkipDir(d); skipDir {
 			return filepath.SkipDir
 		}
-		if d.IsDir() || !isGoTestFile(path) {
+		if d.IsDir() || !isGoSourceFile(path) {
 			return nil
 		}
 
@@ -143,8 +143,8 @@ func dockerGuardSkipDir(d fs.DirEntry) bool {
 	}
 }
 
-func isGoTestFile(path string) bool {
-	return filepath.Ext(path) == ".go" && strings.HasSuffix(path, "_test.go")
+func isGoSourceFile(path string) bool {
+	return filepath.Ext(path) == ".go"
 }
 
 func testcontainerDockerGuardFindingsForFile(path string) ([]string, error) {

--- a/tools/archtest/integration_guard_test.go
+++ b/tools/archtest/integration_guard_test.go
@@ -4,7 +4,10 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +45,187 @@ func TestVaultIntegrationContainerFailuresFailFast(t *testing.T) {
 	assert.Empty(t, skipCalls, "Vault container startup/address failures must fail-fast, not skip")
 }
 
+func TestPostgresUnreachableHostIsNotEnvGated(t *testing.T) {
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "adapters", "postgres", "pool_test.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err)
+
+	fn := findFuncDecl(file, "TestNewPool_UnreachableHost")
+	require.NotNil(t, fn, "TestNewPool_UnreachableHost must exist")
+
+	var findings []string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch selectorName(call.Fun) {
+		case "Skip", "Skipf", "SkipNow":
+			findings = append(findings, fset.Position(call.Pos()).String()+": unreachable-host test must not skip")
+		case "LookupEnv", "Getenv":
+			findings = append(findings, fset.Position(call.Pos()).String()+": unreachable-host test must not depend on env")
+		}
+		return true
+	})
+
+	assert.Empty(t, findings)
+}
+
+func TestCorebundleOutboxWiringDoesNotUseExternalDSNGate(t *testing.T) {
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "cmd", "corebundle", "outbox_wiring_integration_test.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err)
+
+	var findings []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch selectorName(call.Fun) {
+		case "Skip", "Skipf", "SkipNow":
+			findings = append(findings, fset.Position(call.Pos()).String()+": corebundle wiring test must self-provision dependencies")
+		case "LookupEnv", "Getenv":
+			if len(call.Args) == 1 && archStringLiteralValue(call.Args[0]) == "GOCELL_CONFIGCORE_DATABASE_URL" {
+				findings = append(findings, fset.Position(call.Pos()).String()+": corebundle wiring test must not require external GOCELL_CONFIGCORE_DATABASE_URL")
+			}
+		}
+		return true
+	})
+
+	assert.Empty(t, findings)
+}
+
+func TestTestcontainerHelpersRequireDockerBeforeRun(t *testing.T) {
+	root := findModuleRoot(t)
+	findings := collectTestcontainerDockerGuardFindings(t, root)
+	assert.Empty(t, findings)
+}
+
+func collectTestcontainerDockerGuardFindings(t *testing.T, root string) []string {
+	t.Helper()
+	var findings []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if skipDir := dockerGuardSkipDir(d); skipDir {
+			return filepath.SkipDir
+		}
+		if d.IsDir() || !isGoTestFile(path) {
+			return nil
+		}
+
+		fileFindings, err := testcontainerDockerGuardFindingsForFile(path)
+		if err != nil {
+			return err
+		}
+		findings = append(findings, fileFindings...)
+		return nil
+	})
+	require.NoError(t, err)
+	return findings
+}
+
+func dockerGuardSkipDir(d fs.DirEntry) bool {
+	if !d.IsDir() {
+		return false
+	}
+	switch d.Name() {
+	case ".git", "vendor", "generated", "worktrees":
+		return true
+	default:
+		return false
+	}
+}
+
+func isGoTestFile(path string) bool {
+	return filepath.Ext(path) == ".go" && strings.HasSuffix(path, "_test.go")
+}
+
+func testcontainerDockerGuardFindingsForFile(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	aliases := testcontainerAliasesFor(file)
+	if len(aliases.core)+len(aliases.modules) == 0 {
+		return nil, nil
+	}
+
+	var findings []string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if finding := testcontainerDockerGuardFindingForFunc(fset, fn, aliases); finding != "" {
+			findings = append(findings, finding)
+		}
+	}
+	return findings, nil
+}
+
+func testcontainerDockerGuardFindingForFunc(
+	fset *token.FileSet,
+	fn *ast.FuncDecl,
+	aliases testcontainerAliases,
+) string {
+	runPos := firstTestcontainerRunPos(fn.Body, aliases)
+	if !runPos.IsValid() {
+		return ""
+	}
+	requireDockerPos := firstSelectorCallPos(fn.Body, "RequireDocker")
+	if requireDockerPos.IsValid() && requireDockerPos < runPos {
+		return ""
+	}
+	return fset.Position(runPos).String() +
+		": " + fn.Name.Name + " must call testutil.RequireDocker(t) before starting a testcontainer"
+}
+
+type testcontainerAliases struct {
+	core    map[string]struct{}
+	modules map[string]struct{}
+}
+
+func testcontainerAliasesFor(file *ast.File) testcontainerAliases {
+	aliases := testcontainerAliases{
+		core:    map[string]struct{}{},
+		modules: map[string]struct{}{},
+	}
+	for _, imp := range file.Imports {
+		path := archStringLiteralValue(imp.Path)
+		switch {
+		case path == "github.com/testcontainers/testcontainers-go":
+			if name := importSelectorName(imp, "testcontainers"); name != "" {
+				aliases.core[name] = struct{}{}
+			}
+		case strings.HasPrefix(path, "github.com/testcontainers/testcontainers-go/modules/"):
+			if name := importSelectorName(imp, filepath.Base(path)); name != "" {
+				aliases.modules[name] = struct{}{}
+			}
+		}
+	}
+	return aliases
+}
+
+func importSelectorName(imp *ast.ImportSpec, defaultName string) string {
+	if imp.Name == nil {
+		return defaultName
+	}
+	switch imp.Name.Name {
+	case ".", "_":
+		return ""
+	default:
+		return imp.Name.Name
+	}
+}
+
 func findFuncDecl(file *ast.File, name string) *ast.FuncDecl {
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
@@ -50,6 +234,76 @@ func findFuncDecl(file *ast.File, name string) *ast.FuncDecl {
 		}
 	}
 	return nil
+}
+
+func firstTestcontainerRunPos(body *ast.BlockStmt, aliases testcontainerAliases) token.Pos {
+	var out token.Pos
+	ast.Inspect(body, func(n ast.Node) bool {
+		if out.IsValid() {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isTestcontainerRun(call.Fun, aliases) {
+			out = call.Pos()
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+func isTestcontainerRun(expr ast.Expr, aliases testcontainerAliases) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	if sel.Sel.Name == "GenericContainer" {
+		_, ok := aliases.core[ident.Name]
+		return ok
+	}
+	if sel.Sel.Name != "Run" {
+		return false
+	}
+	_, ok = aliases.modules[ident.Name]
+	return ok
+}
+
+func firstSelectorCallPos(body *ast.BlockStmt, name string) token.Pos {
+	var out token.Pos
+	ast.Inspect(body, func(n ast.Node) bool {
+		if out.IsValid() {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if selectorName(call.Fun) == name {
+			out = call.Pos()
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+func archStringLiteralValue(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok {
+		return ""
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return ""
+	}
+	return value
 }
 
 func selectorName(expr ast.Expr) string {


### PR DESCRIPTION
## Summary
- Remove adapter integration false-green skips for Postgres, Vault-related Docker checks, and corebundle outbox wiring.
- Add strict Docker provider health handling, repo-wide RequireDocker arch guards before testcontainer startup, and docs/Makefile cleanup for the testcontainers model.
- Add pinned OpenTelemetry Collector image, real OTLP/gRPC collector integration test, loopback-only port binding, PR/push OTel collector smoke gate, and nightly/manual workflow diagnostics.
- Converge RabbitMQ integration testcontainers through one shared startup helper so shared, dedicated, full-chain, shutdown, and helper contract tests use the same AMQP readiness contract.

## Formal review
- Six-seat reviewer artifact: `docs/reviews/202604280302-pr320-a55-six-seat-review.md`
- Follow-up `/fix` findings addressed in this PR:
  - P1: PR/push no longer compile-checks `otelcollector` only; it runs `TestNewTracer_ExportsSpanToOTLPCollector` against a real Collector with Docker required.
  - P2: RabbitMQ testcontainer startup is centralized in `tests/testutil.StartRabbitMQContainer`.
  - P2: the testcontainer guard now scans all Go source files, including non-test shared helpers.
- Full OTel package execution remains nightly/manual as supplemental coverage; PR/push runs the minimal real smoke.

## Verification
- `go test ./tools/archtest ./tests/testutil ./adapters/postgres ./adapters/vault ./adapters/otel -count=1`
- `GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration,otelcollector ./adapters/otel/... -count=1 -timeout 10m`
- `GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration ./adapters/rabbitmq/... -run 'TestRabbitMQ_Conformance|TestIntegration_ConnectionRecovery|TestIntegration_ConnectionHealth|TestIntegration_DLXBrokerNative' -count=1 -timeout 10m`
- `GOCELL_TEST_DOCKER_REQUIRED=1 go test -p=1 -tags=integration ./tests/integration/... -run 'TestIntegration_OutboxFullChain|TestE2E_ShutdownBarrier' -count=1 -timeout 15m`
- `GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration ./adapters/postgres/... ./adapters/vault/... ./cmd/corebundle/... -count=1 -timeout 15m`
- `GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration ./tests/testutil/... -count=1 -timeout 10m`
- `GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/... ./tests/integration/... ./tests/testutil/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m`
- `go build ./...`
- `go test ./...`
- `golangci-lint run ./tools/archtest/... ./tests/testutil/... ./adapters/rabbitmq/... ./tests/integration/... ./adapters/otel/...` -> `0 issues`
- `actionlint .github/workflows/_build-lint.yml`
