### PR TITLE
refactor(accesscore): polish initial admin facade

### DIFF
--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -160,16 +160,6 @@ func WithRefreshMetricsProvider(p metrics.Provider) Option {
 	return func(c *AccessCore) { c.metricsProvider = p }
 }
 
-// ResolveBootstrapCredentialPath returns the credential file path using the
-// same resolution logic as the internal Bootstrapper: stateDir overrides
-// GOCELL_STATE_DIR, which overrides the platform default state directory.
-//
-// This is the canonical path helper for cmd/corebundle startup logging so
-// that the logged path always matches the file the bootstrapper writes (P2-6).
-func ResolveBootstrapCredentialPath(stateDir string) (string, error) {
-	return initialadmin.ResolveCredentialPath(stateDir)
-}
-
 // WithInMemoryDefaults configures in-memory repositories for development
 // and testing. Not suitable for production use.
 func WithInMemoryDefaults() Option {

--- a/cells/accesscore/initialadmin/bootstrap.go
+++ b/cells/accesscore/initialadmin/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/worker"
 )
 
@@ -75,16 +76,17 @@ type bootstrapper struct {
 // values are invalid.
 func newBootstrapper(deps BootstrapDeps, cfg bootstrapConfig) (*bootstrapper, error) {
 	if deps.UserRepo == nil {
-		return nil, fmt.Errorf("initialadmin: bootstrapper requires UserRepo")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "initialadmin: bootstrapper requires UserRepo")
 	}
 	if deps.RoleRepo == nil {
-		return nil, fmt.Errorf("initialadmin: bootstrapper requires RoleRepo")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "initialadmin: bootstrapper requires RoleRepo")
 	}
 	if deps.Logger == nil {
-		return nil, fmt.Errorf("initialadmin: bootstrapper requires Logger")
+		return nil, errcode.New(errcode.ErrCellInvalidConfig, "initialadmin: bootstrapper requires Logger")
 	}
 	if cfg.TTL < 0 {
-		return nil, fmt.Errorf("initialadmin: bootstrapper TTL must be non-negative, got %s", cfg.TTL)
+		return nil, errcode.New(errcode.ErrCellInvalidConfig,
+			fmt.Sprintf("initialadmin: bootstrapper TTL must be non-negative, got %s", cfg.TTL))
 	}
 
 	// Apply defaults.

--- a/cells/accesscore/initialadmin/bootstrap.go
+++ b/cells/accesscore/initialadmin/bootstrap.go
@@ -96,7 +96,8 @@ func newBootstrapper(deps BootstrapDeps, cfg bootstrapConfig) (*bootstrapper, er
 	if cfg.CredentialPath == "" {
 		resolved, resolveErr := ResolveCredentialPath("")
 		if resolveErr != nil {
-			return nil, resolveErr
+			return nil, errcode.Wrap(errcode.ErrCellInvalidConfig,
+				"initialadmin: resolve credential path", resolveErr)
 		}
 		cfg.CredentialPath = resolved
 	}

--- a/cells/accesscore/initialadmin/bootstrap_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_test.go
@@ -491,6 +491,9 @@ func TestBootstrap_NewBootstrapperValidatesInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := newBootstrapper(tt.deps, tt.cfg)
 			require.Error(t, err)
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec), "expected errcode.Error, got %T: %v", err, err)
+			assert.Equal(t, errcode.ErrCellInvalidConfig, ec.Code)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}

--- a/cells/accesscore/initialadmin/bootstrap_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_test.go
@@ -460,6 +460,7 @@ func TestBootstrap_NewBootstrapperValidatesInput(t *testing.T) {
 		deps    BootstrapDeps
 		cfg     bootstrapConfig
 		wantErr string
+		envDir  string
 	}{
 		{
 			name:    "nil userRepo",
@@ -485,10 +486,20 @@ func TestBootstrap_NewBootstrapperValidatesInput(t *testing.T) {
 			cfg:     bootstrapConfig{TTL: -time.Minute},
 			wantErr: "TTL",
 		},
+		{
+			name:    "relative env credential path",
+			deps:    BootstrapDeps{UserRepo: validUserRepo, RoleRepo: validRoleRepo, Logger: logger},
+			cfg:     bootstrapConfig{},
+			wantErr: "absolute",
+			envDir:  "relative/path",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.envDir != "" {
+				t.Setenv("GOCELL_STATE_DIR", tt.envDir)
+			}
 			_, err := newBootstrapper(tt.deps, tt.cfg)
 			require.Error(t, err)
 			var ec *errcode.Error

--- a/cells/accesscore/initialadmin/lifecycle.go
+++ b/cells/accesscore/initialadmin/lifecycle.go
@@ -182,6 +182,11 @@ func (l *Lifecycle) start(ctx context.Context) error {
 		return fmt.Errorf("initialadmin: ensure: %w", err)
 	}
 	adminWorker := adminResult.Cleaner
+	if adminWorker != nil {
+		logger.InfoContext(ctx, "initialadmin: initial admin credentials written",
+			slog.String("event", "initial_admin_credentials_written"),
+			slog.String("cred_path", bs.cfg.CredentialPath))
+	}
 
 	// Priority identical to old behaviour: adminWorker > sweepCleaner.
 	var result worker.Worker

--- a/cells/accesscore/initialadmin/lifecycle_test.go
+++ b/cells/accesscore/initialadmin/lifecycle_test.go
@@ -158,6 +158,41 @@ func TestLifecycle_StartWithBind_FirstRun_CreatesAdmin(t *testing.T) {
 	assert.NotEmpty(t, user.ID)
 }
 
+func TestLifecycle_StartWithBind_LogsEffectiveCredentialPathAfterWrite(t *testing.T) {
+	dir := t.TempDir()
+	credPath := filepath.Join(dir, "custom_admin_password")
+	logger := slog.New(&capturingHandlerCross{})
+	deps := BootstrapDeps{
+		UserRepo: mem.NewUserRepository(),
+		RoleRepo: mem.NewRoleRepository(),
+		Logger:   logger,
+	}
+	l := NewLifecycle(
+		WithCredentialPath(credPath),
+		WithTTL(time.Hour),
+		WithPasswordHasher(BcryptHasher{Cost: 4}),
+		WithScheduler(newFakeSchedulerCross()),
+		withPasswordSource(newFixedPasswordSourceCross()),
+	)
+	l.Bind(deps, logger)
+
+	require.NoError(t, l.Hook().OnStart(context.Background()))
+
+	handler := logger.Handler().(*capturingHandlerCross)
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	var found bool
+	for _, rec := range handler.records {
+		if rec.attrs["event"] != "initial_admin_credentials_written" {
+			continue
+		}
+		found = true
+		assert.Equal(t, credPath, rec.attrs["cred_path"])
+		assert.NotContains(t, rec.message, "admin_changeme")
+	}
+	assert.True(t, found, "expected lifecycle to log written credential path")
+}
+
 // ---------------------------------------------------------------------------
 // 5. start with Bind (repeat run) — admin already exists, no cleaner
 // ---------------------------------------------------------------------------
@@ -331,6 +366,24 @@ func TestLifecycle_StartFail_CleanerRemainsNil(t *testing.T) {
 
 	// stop must be safe even when start failed.
 	assert.NoError(t, hook.OnStop(context.Background()))
+}
+
+func TestLifecycle_StartFail_RelativeStateDirReturnsInvalidConfigError(t *testing.T) {
+	t.Setenv("GOCELL_STATE_DIR", "relative/path")
+	l := NewLifecycle(
+		WithTTL(time.Hour),
+		WithPasswordHasher(BcryptHasher{Cost: 4}),
+		withPasswordSource(newFixedPasswordSourceCross()),
+	)
+	deps := makeLifecycleDeps(t)
+	l.Bind(deps, deps.Logger)
+
+	err := l.Hook().OnStart(context.Background())
+
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec), "expected errcode.Error, got %T: %v", err, err)
+	assert.Equal(t, errcode.ErrCellInvalidConfig, ec.Code)
 }
 
 // ---------------------------------------------------------------------------

--- a/cells/accesscore/initialadmin/sweep.go
+++ b/cells/accesscore/initialadmin/sweep.go
@@ -151,7 +151,12 @@ func sweep(ctx context.Context, cfg sweepConfig) (sweepResult, error) {
 
 func resolveSweepCredentialPath(credentialPath string) (string, error) {
 	if credentialPath == "" {
-		return ResolveCredentialPath("")
+		resolved, err := ResolveCredentialPath("")
+		if err != nil {
+			return "", errcode.Wrap(errcode.ErrCellInvalidConfig,
+				"initialadmin: resolve credential path", err)
+		}
+		return resolved, nil
 	}
 	cleaned := filepath.Clean(credentialPath)
 	if !filepath.IsAbs(cleaned) {

--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -78,6 +78,7 @@ func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.C
 	slog.Info("accesscore: admin provision mode resolved",
 		slog.String("mode", string(mode)),
 		slog.Bool("force_bootstrap", m.ForceBootstrap))
+	logInitialAdminCredPath(mode)
 
 	// Cursor codec for accesscore: read env via LoadCursorKeys then build.
 	accessPrimary, accessPrevious := LoadCursorKeys("ACCESSCORE")

--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -78,7 +78,6 @@ func (m AccessCoreModule) Provide(_ context.Context, shared *SharedDeps) (cell.C
 	slog.Info("accesscore: admin provision mode resolved",
 		slog.String("mode", string(mode)),
 		slog.Bool("force_bootstrap", m.ForceBootstrap))
-	logInitialAdminCredPath(mode)
 
 	// Cursor codec for accesscore: read env via LoadCursorKeys then build.
 	accessPrimary, accessPrevious := LoadCursorKeys("ACCESSCORE")

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -9,7 +9,7 @@ import (
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	adaptervault "github.com/ghbvf/gocell/adapters/vault"
-	accesscore "github.com/ghbvf/gocell/cells/accesscore"
+	"github.com/ghbvf/gocell/cells/accesscore/initialadmin"
 	configcore "github.com/ghbvf/gocell/cells/configcore"
 	configpg "github.com/ghbvf/gocell/cells/configcore/postgres"
 	"github.com/ghbvf/gocell/kernel/assembly"
@@ -384,12 +384,14 @@ func buildConfigCorePGStorage(pool *adapterpg.Pool, cfg ConfigCoreModuleConfig) 
 }
 
 // logInitialAdminCredPath emits a startup info log so operators know where to
-// find the initial admin credential on first run. Uses
-// accesscore.ResolveBootstrapCredentialPath so the logged path always matches
-// the path actually written by the bootstrapper (P2-6: no duplicated path
-// resolution logic).
-func logInitialAdminCredPath() {
-	credPath, err := accesscore.ResolveBootstrapCredentialPath("")
+// find the initial admin credential when bootstrap mode is active. Interactive
+// mode does not write a credential file, so it intentionally skips path
+// resolution and avoids warning on GOCELL_STATE_DIR values it will not use.
+func logInitialAdminCredPath(mode adminProvisionMode) {
+	if mode != adminProvisionModeBootstrap {
+		return
+	}
+	credPath, err := initialadmin.ResolveCredentialPath("")
 	if err != nil {
 		// GOCELL_STATE_DIR is not absolute — the bootstrapper will fail-fast too,
 		// so log the error here and let the user fix the config.

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -9,7 +9,6 @@ import (
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	adaptervault "github.com/ghbvf/gocell/adapters/vault"
-	"github.com/ghbvf/gocell/cells/accesscore/initialadmin"
 	configcore "github.com/ghbvf/gocell/cells/configcore"
 	configpg "github.com/ghbvf/gocell/cells/configcore/postgres"
 	"github.com/ghbvf/gocell/kernel/assembly"
@@ -381,26 +380,6 @@ func buildConfigCorePGStorage(pool *adapterpg.Pool, cfg ConfigCoreModuleConfig) 
 		return nil, nil, fmt.Errorf("configcore PG repository wiring: %w", err)
 	}
 	return pgRes, storageOpt, nil
-}
-
-// logInitialAdminCredPath emits a startup info log so operators know where to
-// find the initial admin credential when bootstrap mode is active. Interactive
-// mode does not write a credential file, so it intentionally skips path
-// resolution and avoids warning on GOCELL_STATE_DIR values it will not use.
-func logInitialAdminCredPath(mode adminProvisionMode) {
-	if mode != adminProvisionModeBootstrap {
-		return
-	}
-	credPath, err := initialadmin.ResolveCredentialPath("")
-	if err != nil {
-		// GOCELL_STATE_DIR is not absolute — the bootstrapper will fail-fast too,
-		// so log the error here and let the user fix the config.
-		slog.Warn("corebundle: invalid GOCELL_STATE_DIR; initial admin credential path unresolvable",
-			slog.Any("error", err))
-		return
-	}
-	slog.Info("corebundle: starting; if first run, initial admin credentials are written to "+credPath,
-		slog.String("cred_path", credPath))
 }
 
 // buildConsumerBase constructs ConsumerBase from the topology-selected

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -84,20 +84,44 @@ func TestBuildAssembly_RegisterError(t *testing.T) {
 // logInitialAdminCredPath coverage
 // ---------------------------------------------------------------------------
 
-// TestLogInitialAdminCredPath_InvalidStateDir verifies that logInitialAdminCredPath
-// emits a warning (and does not panic) when GOCELL_STATE_DIR is set to a
-// relative path (which ResolveBootstrapCredentialPath rejects as unsafe).
-func TestLogInitialAdminCredPath_InvalidStateDir(t *testing.T) {
+// TestLogInitialAdminCredPath_InteractiveSkipsPathResolution verifies that
+// interactive admin provisioning does not advertise or validate the bootstrap
+// credential path.
+func TestLogInitialAdminCredPath_InteractiveSkipsPathResolution(t *testing.T) {
+	buf, restore := captureSlogInfoLines(t)
+	t.Cleanup(restore)
+
 	t.Setenv("GOCELL_STATE_DIR", "relative/not/absolute")
-	// Must not panic; warning is logged but not surfaced as an error.
-	require.NotPanics(t, func() { logInitialAdminCredPath() })
+	require.NotPanics(t, func() { logInitialAdminCredPath(adminProvisionModeInteractive) })
+
+	logs := buf.String()
+	assert.NotContains(t, logs, "initial admin credential")
+	assert.NotContains(t, logs, "GOCELL_STATE_DIR")
+}
+
+// TestLogInitialAdminCredPath_BootstrapInvalidStateDirWarns verifies that
+// bootstrap mode still warns when the credential path cannot be resolved.
+func TestLogInitialAdminCredPath_BootstrapInvalidStateDirWarns(t *testing.T) {
+	buf, restore := captureSlogInfoLines(t)
+	t.Cleanup(restore)
+
+	t.Setenv("GOCELL_STATE_DIR", "relative/not/absolute")
+	require.NotPanics(t, func() { logInitialAdminCredPath(adminProvisionModeBootstrap) })
+
+	logs := buf.String()
+	assert.Contains(t, logs, "invalid GOCELL_STATE_DIR")
 }
 
 // TestLogInitialAdminCredPath_ValidStateDir verifies that logInitialAdminCredPath
 // runs without panic when GOCELL_STATE_DIR is a valid absolute path.
 func TestLogInitialAdminCredPath_ValidStateDir(t *testing.T) {
+	buf, restore := captureSlogInfoLines(t)
+	t.Cleanup(restore)
+
 	t.Setenv("GOCELL_STATE_DIR", t.TempDir())
-	require.NotPanics(t, func() { logInitialAdminCredPath() })
+	require.NotPanics(t, func() { logInitialAdminCredPath(adminProvisionModeBootstrap) })
+
+	assert.Contains(t, buf.String(), "initial admin credentials are written")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -80,48 +80,23 @@ func TestBuildAssembly_RegisterError(t *testing.T) {
 		"error must mention the duplicate cell ID so operators can diagnose the conflict")
 }
 
-// ---------------------------------------------------------------------------
-// logInitialAdminCredPath coverage
-// ---------------------------------------------------------------------------
-
-// TestLogInitialAdminCredPath_InteractiveSkipsPathResolution verifies that
-// interactive admin provisioning does not advertise or validate the bootstrap
-// credential path.
-func TestLogInitialAdminCredPath_InteractiveSkipsPathResolution(t *testing.T) {
+// TestAccessCoreModule_BootstrapProvideDoesNotAdvertiseCredentialPath verifies
+// wiring does not promise a credential file before lifecycle execution owns the
+// effective config and outcome.
+func TestAccessCoreModule_BootstrapProvideDoesNotAdvertiseCredentialPath(t *testing.T) {
 	buf, restore := captureSlogInfoLines(t)
 	t.Cleanup(restore)
 
-	t.Setenv("GOCELL_STATE_DIR", "relative/not/absolute")
-	require.NotPanics(t, func() { logInitialAdminCredPath(adminProvisionModeInteractive) })
+	shared := buildTestSharedDeps(t)
+	t.Setenv(AdminProvisionModeEnv, "bootstrap")
+
+	_, _, _, err := AccessCoreModule{InitialAdminOpts: fastAdminBootstrapOpts()}.Provide(context.Background(), shared)
+	require.NoError(t, err)
 
 	logs := buf.String()
+	assert.Contains(t, logs, "admin provision mode resolved")
 	assert.NotContains(t, logs, "initial admin credential")
-	assert.NotContains(t, logs, "GOCELL_STATE_DIR")
-}
-
-// TestLogInitialAdminCredPath_BootstrapInvalidStateDirWarns verifies that
-// bootstrap mode still warns when the credential path cannot be resolved.
-func TestLogInitialAdminCredPath_BootstrapInvalidStateDirWarns(t *testing.T) {
-	buf, restore := captureSlogInfoLines(t)
-	t.Cleanup(restore)
-
-	t.Setenv("GOCELL_STATE_DIR", "relative/not/absolute")
-	require.NotPanics(t, func() { logInitialAdminCredPath(adminProvisionModeBootstrap) })
-
-	logs := buf.String()
-	assert.Contains(t, logs, "invalid GOCELL_STATE_DIR")
-}
-
-// TestLogInitialAdminCredPath_ValidStateDir verifies that logInitialAdminCredPath
-// runs without panic when GOCELL_STATE_DIR is a valid absolute path.
-func TestLogInitialAdminCredPath_ValidStateDir(t *testing.T) {
-	buf, restore := captureSlogInfoLines(t)
-	t.Cleanup(restore)
-
-	t.Setenv("GOCELL_STATE_DIR", t.TempDir())
-	require.NotPanics(t, func() { logInitialAdminCredPath(adminProvisionModeBootstrap) })
-
-	assert.Contains(t, buf.String(), "initial admin credentials are written")
+	assert.NotContains(t, logs, "cred_path")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/corebundle/main.go
+++ b/cmd/corebundle/main.go
@@ -96,7 +96,6 @@ func run(ctx context.Context) error {
 		slog.String("outbox_consumer_claimer", adapterInfo["outbox_consumer_claimer"]))
 
 	logSinglePodNonceStoreAcknowledgement(shared)
-	logInitialAdminCredPath()
 
 	opts := defaultRuntimeOptions(shared, asm, consumerBase, metricsHandler, adapterInfo)
 	opts = append(opts, cellOpts...)

--- a/examples/ssobff/main.go
+++ b/examples/ssobff/main.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	accesscore "github.com/ghbvf/gocell/cells/accesscore"
-	"github.com/ghbvf/gocell/cells/accesscore/initialadmin"
 	auditcore "github.com/ghbvf/gocell/cells/auditcore"
 	configcore "github.com/ghbvf/gocell/cells/configcore"
 	"github.com/ghbvf/gocell/kernel/assembly"
@@ -199,21 +198,12 @@ func main() {
 		// Bootstrap phase3b auto-discovers LifecycleHooks() from accesscore.
 	)
 
-	// Pass "" so per-OS platform defaults in ResolveCredentialPath kick in.
-	// Override with GOCELL_STATE_DIR to redirect to a custom directory.
-	credPath, err := initialadmin.ResolveCredentialPath(os.Getenv("GOCELL_STATE_DIR"))
-	if err != nil {
-		logger.Warn("ssobff: failed to resolve bootstrap credential path",
-			slog.Any("error", err))
-		credPath = "<unresolved>"
-	}
-	logger.Info("ssobff: starting; if first run, initial admin credentials are written to cred_path",
+	logger.Info("ssobff: starting",
 		slog.String("mode", "in-memory"),
 		slog.Int("cells", 3),
 		slog.String("primary_addr", primaryAddr),
 		slog.String("internal_addr", internalAddr),
 		slog.String("health_addr", healthAddr),
-		slog.String("cred_path", credPath),
 	)
 	if err := app.Run(ctx); err != nil {
 		logger.Error("ssobff: application exited with error", slog.Any("error", err))

--- a/examples/ssobff/main.go
+++ b/examples/ssobff/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	accesscore "github.com/ghbvf/gocell/cells/accesscore"
+	"github.com/ghbvf/gocell/cells/accesscore/initialadmin"
 	auditcore "github.com/ghbvf/gocell/cells/auditcore"
 	configcore "github.com/ghbvf/gocell/cells/configcore"
 	"github.com/ghbvf/gocell/kernel/assembly"
@@ -198,9 +199,9 @@ func main() {
 		// Bootstrap phase3b auto-discovers LifecycleHooks() from accesscore.
 	)
 
-	// Pass "" so per-OS platform defaults in ResolveBootstrapCredentialPath kick in.
+	// Pass "" so per-OS platform defaults in ResolveCredentialPath kick in.
 	// Override with GOCELL_STATE_DIR to redirect to a custom directory.
-	credPath, err := accesscore.ResolveBootstrapCredentialPath(os.Getenv("GOCELL_STATE_DIR"))
+	credPath, err := initialadmin.ResolveCredentialPath(os.Getenv("GOCELL_STATE_DIR"))
 	if err != nil {
 		logger.Warn("ssobff: failed to resolve bootstrap credential path",
 			slog.Any("error", err))

--- a/runtime/bootstrap/lifecycle.go
+++ b/runtime/bootstrap/lifecycle.go
@@ -286,6 +286,17 @@ func (lc *lifecycle) runHook(ctx context.Context, h Hook, isStart bool) error {
 		return err
 	}
 
+	if isStart && hookTimeout > 0 {
+		threshold := hookTimeout * 8 / 10
+		if elapsed >= threshold {
+			attrs := append(hookIdentityAttrs(h),
+				slog.Duration("elapsed", elapsed),
+				slog.Duration("timeout", hookTimeout),
+				slog.Duration("threshold", threshold))
+			lc.logger.LogAttrs(ctx, slog.LevelWarn, "hook.start_slow", attrs...)
+		}
+	}
+
 	okAttrs := append(hookIdentityAttrs(h), slog.Duration("elapsed", elapsed))
 	lc.logger.LogAttrs(ctx, slog.LevelInfo, okMsg, okAttrs...)
 	return nil

--- a/runtime/bootstrap/lifecycle_test.go
+++ b/runtime/bootstrap/lifecycle_test.go
@@ -546,20 +546,7 @@ func TestLifecycle_OnStartNearTimeoutWarns(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	var slow map[string]any
-	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte{'\n'}) {
-		if len(line) == 0 {
-			continue
-		}
-		var rec map[string]any
-		if err := json.Unmarshal(line, &rec); err != nil {
-			t.Fatalf("bad log line %q: %v", line, err)
-		}
-		if rec["msg"] == "hook.start_slow" {
-			slow = rec
-			break
-		}
-	}
+	slow := findLifecycleLogRecord(t, &buf, "hook.start_slow")
 	if slow == nil {
 		t.Fatalf("expected hook.start_slow warning, got logs=%s", buf.String())
 	}

--- a/runtime/bootstrap/lifecycle_test.go
+++ b/runtime/bootstrap/lifecycle_test.go
@@ -523,3 +523,134 @@ func TestLifecycle_OmitsCellLabel_WhenCellIDEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestLifecycle_OnStartNearTimeoutWarns(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	lc := NewLifecycle(LifecycleConfig{
+		DefaultStartTimeout: 20 * time.Millisecond,
+		Logger:              logger,
+	})
+	if err := lc.Append(Hook{
+		CellID: "accesscore",
+		Name:   "accesscore.initial-admin-bootstrap",
+		OnStart: func(_ context.Context) error {
+			time.Sleep(18 * time.Millisecond)
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := lc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var slow map[string]any
+	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("bad log line %q: %v", line, err)
+		}
+		if rec["msg"] == "hook.start_slow" {
+			slow = rec
+			break
+		}
+	}
+	if slow == nil {
+		t.Fatalf("expected hook.start_slow warning, got logs=%s", buf.String())
+	}
+	if slow["level"] != "WARN" {
+		t.Fatalf("hook.start_slow level mismatch: %v", slow)
+	}
+	if slow["cell"] != "accesscore" {
+		t.Fatalf("hook.start_slow cell mismatch: %v", slow)
+	}
+	if slow["name"] != "accesscore.initial-admin-bootstrap" {
+		t.Fatalf("hook.start_slow name mismatch: %v", slow)
+	}
+	for _, key := range []string{"elapsed", "timeout", "threshold"} {
+		if _, ok := slow[key]; !ok {
+			t.Fatalf("hook.start_slow missing %s: %v", key, slow)
+		}
+	}
+}
+
+func TestLifecycle_OnStartNearTimeoutWarnsWithoutCellID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	lc := NewLifecycle(LifecycleConfig{
+		DefaultStartTimeout: 20 * time.Millisecond,
+		Logger:              logger,
+	})
+	if err := lc.Append(Hook{
+		Name: "composition-root.hook",
+		OnStart: func(_ context.Context) error {
+			time.Sleep(18 * time.Millisecond)
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := lc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	slow := findLifecycleLogRecord(t, &buf, "hook.start_slow")
+	if slow == nil {
+		t.Fatalf("expected hook.start_slow warning, got logs=%s", buf.String())
+	}
+	if slow["name"] != "composition-root.hook" {
+		t.Fatalf("hook.start_slow name mismatch: %v", slow)
+	}
+	if _, hasCell := slow["cell"]; hasCell {
+		t.Fatalf("hook.start_slow must omit empty cell label: %v", slow)
+	}
+}
+
+func TestLifecycle_NegativeStartTimeoutSkipsSlowWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	lc := NewLifecycle(LifecycleConfig{
+		DefaultStartTimeout: 1 * time.Nanosecond,
+		Logger:              logger,
+	})
+	if err := lc.Append(Hook{
+		Name: "no-deadline",
+		OnStart: func(_ context.Context) error {
+			time.Sleep(time.Millisecond)
+			return nil
+		},
+		StartTimeout: -1,
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := lc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if rec := findLifecycleLogRecord(t, &buf, "hook.start_slow"); rec != nil {
+		t.Fatalf("negative StartTimeout must skip hook.start_slow, got %v", rec)
+	}
+}
+
+func findLifecycleLogRecord(t *testing.T, buf *bytes.Buffer, msg string) map[string]any {
+	t.Helper()
+	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("bad log line %q: %v", line, err)
+		}
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	return nil
+}

--- a/tools/archtest/accesscore_facade_test.go
+++ b/tools/archtest/accesscore_facade_test.go
@@ -24,15 +24,7 @@ func TestAccessCoreFacadePolishA61Guard(t *testing.T) {
 	t.Run("R9_no_bootstrap_credential_path_facade", func(t *testing.T) {
 		var violations []string
 
-		accesscoreCell := filepath.Join(root, "cells", "accesscore", "cell.go")
-		file, err := parser.ParseFile(fset, accesscoreCell, nil, parser.SkipObjectResolution)
-		require.NoError(t, err)
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if ok && fn.Recv == nil && fn.Name.Name == "ResolveBootstrapCredentialPath" {
-				violations = append(violations, relPath(t, root, accesscoreCell)+": exported facade ResolveBootstrapCredentialPath must be deleted")
-			}
-		}
+		violations = append(violations, scanAccesscoreFacadeDeclarations(t, fset, root)...)
 
 		for _, dir := range []string{"cmd", "examples"} {
 			violations = append(violations, scanResolveBootstrapCredentialPathCalls(t, fset, root, filepath.Join(root, dir))...)
@@ -40,6 +32,29 @@ func TestAccessCoreFacadePolishA61Guard(t *testing.T) {
 
 		assert.Empty(t, violations, strings.Join(violations, "\n"))
 	})
+}
+
+func scanAccesscoreFacadeDeclarations(t *testing.T, fset *token.FileSet, root string) []string {
+	t.Helper()
+	var violations []string
+	accesscoreDir := filepath.Join(root, "cells", "accesscore")
+	entries, err := os.ReadDir(accesscoreDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(accesscoreDir, entry.Name())
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		require.NoError(t, parseErr)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Recv == nil && fn.Name.Name == "ResolveBootstrapCredentialPath" {
+				violations = append(violations, relPath(t, root, path)+": exported facade ResolveBootstrapCredentialPath must be deleted")
+			}
+		}
+	}
+	return violations
 }
 
 func scanResolveBootstrapCredentialPathCalls(t *testing.T, fset *token.FileSet, root, dir string) []string {

--- a/tools/archtest/accesscore_facade_test.go
+++ b/tools/archtest/accesscore_facade_test.go
@@ -1,0 +1,88 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccessCoreFacadePolishA61Guard locks A61's no-shim decision: the
+// initialadmin credential-path resolver is owned by the initialadmin package,
+// and accesscore must not grow a thin top-level forwarding API again.
+func TestAccessCoreFacadePolishA61Guard(t *testing.T) {
+	root := findModuleRoot(t)
+	fset := token.NewFileSet()
+
+	t.Run("R9_no_bootstrap_credential_path_facade", func(t *testing.T) {
+		var violations []string
+
+		accesscoreCell := filepath.Join(root, "cells", "accesscore", "cell.go")
+		file, err := parser.ParseFile(fset, accesscoreCell, nil, parser.SkipObjectResolution)
+		require.NoError(t, err)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Recv == nil && fn.Name.Name == "ResolveBootstrapCredentialPath" {
+				violations = append(violations, relPath(t, root, accesscoreCell)+": exported facade ResolveBootstrapCredentialPath must be deleted")
+			}
+		}
+
+		for _, dir := range []string{"cmd", "examples"} {
+			violations = append(violations, scanResolveBootstrapCredentialPathCalls(t, fset, root, filepath.Join(root, dir))...)
+		}
+
+		assert.Empty(t, violations, strings.Join(violations, "\n"))
+	})
+}
+
+func scanResolveBootstrapCredentialPathCalls(t *testing.T, fset *token.FileSet, root, dir string) []string {
+	t.Helper()
+	var violations []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "generated", "testdata", "vendor", "worktrees":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "ResolveBootstrapCredentialPath" {
+				return true
+			}
+			pos := fset.Position(sel.Sel.Pos())
+			violations = append(violations,
+				relPath(t, root, path)+":"+strconv.Itoa(pos.Line)+": call initialadmin.ResolveCredentialPath directly")
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+	return violations
+}
+
+func relPath(t *testing.T, root, path string) string {
+	t.Helper()
+	rel, err := filepath.Rel(root, path)
+	require.NoError(t, err)
+	return filepath.ToSlash(rel)
+}


### PR DESCRIPTION
Summary
- Remove the thin accesscore.ResolveBootstrapCredentialPath facade and route callers to initialadmin.ResolveCredentialPath directly.
- Limit corebundle credential-path startup logging to bootstrap admin provision mode.
- Return ErrCellInvalidConfig for initialadmin bootstrapper config validation failures.
- Warn on successful but slow lifecycle OnStart hooks at 80% of the effective timeout.

Refs: A61, A5a-R9, A5a-R10, A5a-R11

Reference
- ref: uber-go/fx internal/lifecycle/lifecycle.go (Hook ordering and lifecycle runtime)
- ref: kubernetes/kubernetes pkg/kubelet/lifecycle/handlers.go (structured lifecycle hook identity)
- ref: go-kratos/kratos errors/errors.go (structured code/message error model)

Test plan
- [x] go test ./tools/archtest -run TestAccessCoreFacadePolishA61Guard -count=1
- [x] go test ./cells/accesscore/initialadmin -run TestBootstrap_NewBootstrapperValidatesInput -count=1
- [x] go test ./runtime/bootstrap -run TestLifecycle_OnStartNearTimeoutWarns -count=1
- [x] go test ./cmd/corebundle -run TestLogInitialAdminCredPath -count=1
- [x] go build ./...
- [x] go test ./...
- [x] golangci-lint run ./cells/accesscore/... ./runtime/bootstrap ./cmd/corebundle ./examples/ssobff ./tools/archtest