### PR TITLE
test(configcore): PR-CFG-L authz-negative coverage for read endpoints

### DIFF
--- a/cells/configcore/slices/configread/contract_test.go
+++ b/cells/configcore/slices/configread/contract_test.go
@@ -70,52 +70,24 @@ func TestHttpConfigListV1Serve(t *testing.T) {
 	c.MustRejectResponse(t, []byte(`{"data":[{"id":"c-1","key":"app.name","value":"myapp","version":1,"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}],"nextCursor":"","hasMore":false}`))
 }
 
-// authzCase models a row in the authz negative-test tables. injectAuth=false
-// produces an anonymous request (no Principal in context) — the Mount's
-// auth.AnyRole policy short-circuits to ErrAuthUnauthorized before role
-// inspection. injectAuth=true with a non-admin role exercises the
-// "authenticated-but-unauthorized" branch and produces ErrAuthForbidden.
+// authzCase models a row in the runtime mux authz negative-test tables.
+// principal=nil produces an anonymous request — the Mount's auth.AnyRole
+// policy short-circuits to ErrAuthUnauthorized before role inspection.
+// A non-nil principal exercises the authenticated-but-unauthorized branch
+// (any role mismatch returns ErrAuthForbidden via principalHasAnyRole).
 type authzCase struct {
 	name        string
-	injectAuth  bool
-	subject     string
-	roles       []string
+	principal   *auth.Principal
 	wantStatus  int
 	wantErrCode string
-}
-
-// runAuthzCases drives a table of authz cases through h with the given
-// request — extracted to avoid duplicating the same recorder/decode/assert
-// dance across the three negative tests.
-func runAuthzCases(t *testing.T, h http.Handler, method, target string, cases []authzCase) {
-	t.Helper()
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(method, target, nil)
-			if tc.injectAuth {
-				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
-			}
-			h.ServeHTTP(rec, req)
-			assert.Equal(t, tc.wantStatus, rec.Code)
-			var resp struct {
-				Error struct {
-					Code string `json:"code"`
-				} `json:"error"`
-			}
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-			assert.Equal(t, tc.wantErrCode, resp.Error.Code)
-		})
-	}
 }
 
 // setupInternalHandler wires the handler onto a celltest mux via
 // RegisterInternalRoutes — nested under /internal/v1/config to mirror the
 // production cell_routes.go InternalListener layout. The internal route
 // applies auth.AnyRole(auth.RoleInternalAdmin); a request without a
-// Principal must surface as 401 (listener service-token chain absent in
-// this in-process test) and a service principal without RoleInternalAdmin
-// must surface as 403 — the same Policy that production runs.
+// Principal must surface as 401 and a service principal without
+// RoleInternalAdmin must surface as 403 — the same Policy production runs.
 func setupInternalHandler() http.Handler {
 	repo := mem.NewConfigRepository()
 	codec, _ := query.NewCursorCodec([]byte("gocell-demo-cursor-key-32bytes!!"))
@@ -130,17 +102,65 @@ func setupInternalHandler() http.Handler {
 	return mux
 }
 
+// runAuthzCases drives a table of authz cases through h with the given
+// request. The single helper covers all three negative tests — primary
+// list/get and internal get — by accepting an optional pre-built principal,
+// keeping the assertion shape identical across listeners.
+func runAuthzCases(t *testing.T, h http.Handler, method, target string, cases []authzCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(method, target, nil)
+			if tc.principal != nil {
+				req = req.WithContext(auth.WithPrincipal(req.Context(), tc.principal))
+			}
+			h.ServeHTTP(rec, req)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			var resp struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tc.wantErrCode, resp.Error.Code)
+		})
+	}
+}
+
+// userPrincipal builds a PrincipalUser for table-driven authz cases. Mirrors
+// auth.TestContext but exposes the *Principal so it can be embedded in the
+// authzCase struct alongside service principals.
+func userPrincipal(subject string, roles []string) *auth.Principal {
+	return &auth.Principal{
+		Kind:       auth.PrincipalUser,
+		Subject:    subject,
+		Roles:      append([]string(nil), roles...),
+		AuthMethod: "test",
+	}
+}
+
+// servicePrincipal builds a PrincipalService for the internal listener
+// authz cases — paired with userPrincipal for symmetry.
+func servicePrincipal(subject string, roles []string) *auth.Principal {
+	return &auth.Principal{
+		Kind:       auth.PrincipalService,
+		Subject:    subject,
+		Roles:      append([]string(nil), roles...),
+		AuthMethod: "test",
+	}
+}
+
 // TestHttpConfigGetV1_AuthzNegative locks the runtime auth-guard contract
 // for the admin-gated GET /api/v1/config/{key}: anonymous requests are
 // rejected with 401 ERR_AUTH_UNAUTHORIZED, and authenticated principals
 // without the admin role are rejected with 403 ERR_AUTH_FORBIDDEN. The
-// happy-path response shape is locked separately by TestHttpConfigGetV1Serve
-// via contract schema validation.
+// happy-path response shape is locked by TestHttpConfigGetV1Serve.
 func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
 	h, _ := setupHandler()
 	runAuthzCases(t, h, http.MethodGet, configBasePath+"/some-key", []authzCase{
-		{"no_auth", false, "", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", true, "user-1", []string{"viewer"}, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"no_auth", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})
 }
 
@@ -151,8 +171,8 @@ func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
 func TestHttpConfigListV1_AuthzNegative(t *testing.T) {
 	h, _ := setupHandler()
 	runAuthzCases(t, h, http.MethodGet, configBasePath+"/", []authzCase{
-		{"no_auth", false, "", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", true, "user-1", []string{"viewer"}, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"no_auth", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})
 }
 
@@ -160,45 +180,11 @@ func TestHttpConfigListV1_AuthzNegative(t *testing.T) {
 // for the internal-listener GET /internal/v1/config/{key}: a missing
 // principal produces 401 (defence-in-depth alongside the listener's
 // service-token chain), and a service principal lacking RoleInternalAdmin
-// produces 403. The service-principal pattern matches runtime/auth/authz_test.go's
-// PrincipalService cases (cell handlers see Principal regardless of source).
+// produces 403. The service-principal pattern matches runtime/auth/authz_test.go.
 func TestHttpConfigInternalGetV1_AuthzNegative(t *testing.T) {
 	h := setupInternalHandler()
-	target := "/internal/v1/config/some-key"
-
-	// Anonymous: no Principal in context.
-	t.Run("no_principal", func(t *testing.T) {
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, target, nil)
-		h.ServeHTTP(rec, req)
-		assert.Equal(t, http.StatusUnauthorized, rec.Code)
-		var resp struct {
-			Error struct {
-				Code string `json:"code"`
-			} `json:"error"`
-		}
-		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Equal(t, "ERR_AUTH_UNAUTHORIZED", resp.Error.Code)
-	})
-
-	// Service principal without RoleInternalAdmin: authenticated but unauthorized.
-	t.Run("service_principal_without_role", func(t *testing.T) {
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, target, nil)
-		ctx := auth.WithPrincipal(req.Context(), &auth.Principal{
-			Kind:       auth.PrincipalService,
-			Subject:    "svc-x",
-			Roles:      []string{},
-			AuthMethod: "test",
-		})
-		h.ServeHTTP(rec, req.WithContext(ctx))
-		assert.Equal(t, http.StatusForbidden, rec.Code)
-		var resp struct {
-			Error struct {
-				Code string `json:"code"`
-			} `json:"error"`
-		}
-		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Equal(t, "ERR_AUTH_FORBIDDEN", resp.Error.Code)
+	runAuthzCases(t, h, http.MethodGet, "/internal/v1/config/some-key", []authzCase{
+		{"no_principal", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"service_principal_without_role", servicePrincipal("svc-x", nil), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})
 }

--- a/cells/configcore/slices/configread/contract_test.go
+++ b/cells/configcore/slices/configread/contract_test.go
@@ -1,9 +1,18 @@
 package configread
 
 import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
+	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/pkg/contracttest"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,4 +68,137 @@ func TestHttpConfigListV1Serve(t *testing.T) {
 	c.MustRejectResponse(t, []byte(`{"data":[]}`))
 	// Missing sensitive field must be rejected (schema requires it for each item).
 	c.MustRejectResponse(t, []byte(`{"data":[{"id":"c-1","key":"app.name","value":"myapp","version":1,"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}],"nextCursor":"","hasMore":false}`))
+}
+
+// authzCase models a row in the authz negative-test tables. injectAuth=false
+// produces an anonymous request (no Principal in context) — the Mount's
+// auth.AnyRole policy short-circuits to ErrAuthUnauthorized before role
+// inspection. injectAuth=true with a non-admin role exercises the
+// "authenticated-but-unauthorized" branch and produces ErrAuthForbidden.
+type authzCase struct {
+	name        string
+	injectAuth  bool
+	subject     string
+	roles       []string
+	wantStatus  int
+	wantErrCode string
+}
+
+// runAuthzCases drives a table of authz cases through h with the given
+// request — extracted to avoid duplicating the same recorder/decode/assert
+// dance across the three negative tests.
+func runAuthzCases(t *testing.T, h http.Handler, method, target string, cases []authzCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(method, target, nil)
+			if tc.injectAuth {
+				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+			}
+			h.ServeHTTP(rec, req)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			var resp struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tc.wantErrCode, resp.Error.Code)
+		})
+	}
+}
+
+// setupInternalHandler wires the handler onto a celltest mux via
+// RegisterInternalRoutes — nested under /internal/v1/config to mirror the
+// production cell_routes.go InternalListener layout. The internal route
+// applies auth.AnyRole(auth.RoleInternalAdmin); a request without a
+// Principal must surface as 401 (listener service-token chain absent in
+// this in-process test) and a service principal without RoleInternalAdmin
+// must surface as 403 — the same Policy that production runs.
+func setupInternalHandler() http.Handler {
+	repo := mem.NewConfigRepository()
+	codec, _ := query.NewCursorCodec([]byte("gocell-demo-cursor-key-32bytes!!"))
+	svc, err := NewService(repo, codec, slog.Default(), query.RunModeProd)
+	if err != nil {
+		panic(err)
+	}
+	mux := celltest.NewTestMux()
+	mux.Route("/internal/v1/config", func(sub kcell.RouteMux) {
+		_ = NewHandler(svc).RegisterInternalRoutes(sub)
+	})
+	return mux
+}
+
+// TestHttpConfigGetV1_AuthzNegative locks the runtime auth-guard contract
+// for the admin-gated GET /api/v1/config/{key}: anonymous requests are
+// rejected with 401 ERR_AUTH_UNAUTHORIZED, and authenticated principals
+// without the admin role are rejected with 403 ERR_AUTH_FORBIDDEN. The
+// happy-path response shape is locked separately by TestHttpConfigGetV1Serve
+// via contract schema validation.
+func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
+	h, _ := setupHandler()
+	runAuthzCases(t, h, http.MethodGet, configBasePath+"/some-key", []authzCase{
+		{"no_auth", false, "", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", true, "user-1", []string{"viewer"}, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+	})
+}
+
+// TestHttpConfigListV1_AuthzNegative locks the runtime auth-guard contract
+// for the admin-gated GET /api/v1/config/ list endpoint, mirroring the
+// single-entry GET semantics. The base path's trailing slash matches the
+// production registration in cell_routes.go (mux.Route("/config", ...)).
+func TestHttpConfigListV1_AuthzNegative(t *testing.T) {
+	h, _ := setupHandler()
+	runAuthzCases(t, h, http.MethodGet, configBasePath+"/", []authzCase{
+		{"no_auth", false, "", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"non_admin", true, "user-1", []string{"viewer"}, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+	})
+}
+
+// TestHttpConfigInternalGetV1_AuthzNegative locks the auth-guard contract
+// for the internal-listener GET /internal/v1/config/{key}: a missing
+// principal produces 401 (defence-in-depth alongside the listener's
+// service-token chain), and a service principal lacking RoleInternalAdmin
+// produces 403. The service-principal pattern matches runtime/auth/authz_test.go's
+// PrincipalService cases (cell handlers see Principal regardless of source).
+func TestHttpConfigInternalGetV1_AuthzNegative(t *testing.T) {
+	h := setupInternalHandler()
+	target := "/internal/v1/config/some-key"
+
+	// Anonymous: no Principal in context.
+	t.Run("no_principal", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		h.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, "ERR_AUTH_UNAUTHORIZED", resp.Error.Code)
+	})
+
+	// Service principal without RoleInternalAdmin: authenticated but unauthorized.
+	t.Run("service_principal_without_role", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		ctx := auth.WithPrincipal(req.Context(), &auth.Principal{
+			Kind:       auth.PrincipalService,
+			Subject:    "svc-x",
+			Roles:      []string{},
+			AuthMethod: "test",
+		})
+		h.ServeHTTP(rec, req.WithContext(ctx))
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		var resp struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, "ERR_AUTH_FORBIDDEN", resp.Error.Code)
+	})
 }

--- a/cells/configcore/slices/configread/contract_test.go
+++ b/cells/configcore/slices/configread/contract_test.go
@@ -106,7 +106,13 @@ func setupInternalHandler() http.Handler {
 // request. The single helper covers all three negative tests — primary
 // list/get and internal get — by accepting an optional pre-built principal,
 // keeping the assertion shape identical across listeners.
-func runAuthzCases(t *testing.T, h http.Handler, method, target string, cases []authzCase) {
+//
+// In addition to status + error.code, the recorded body is validated
+// against the contract's declared 4xx schemaRef so that drift in the
+// shared error envelope (message / details / request_id presence) or in
+// contract.yaml's responses[<status>] declaration is caught here, not
+// only in upstream contract conformance tooling.
+func runAuthzCases(t *testing.T, h http.Handler, c *contracttest.Contract, method, target string, cases []authzCase) {
 	t.Helper()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -117,13 +123,15 @@ func runAuthzCases(t *testing.T, h http.Handler, method, target string, cases []
 			}
 			h.ServeHTTP(rec, req)
 			assert.Equal(t, tc.wantStatus, rec.Code)
+			body := rec.Body.Bytes()
 			var resp struct {
 				Error struct {
 					Code string `json:"code"`
 				} `json:"error"`
 			}
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.NoError(t, json.Unmarshal(body, &resp))
 			assert.Equal(t, tc.wantErrCode, resp.Error.Code)
+			c.ValidateErrorResponse(t, tc.wantStatus, body)
 		})
 	}
 }
@@ -157,8 +165,10 @@ func servicePrincipal(subject string, roles []string) *auth.Principal {
 // without the admin role are rejected with 403 ERR_AUTH_FORBIDDEN. The
 // happy-path response shape is locked by TestHttpConfigGetV1Serve.
 func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.config.get.v1")
 	h, _ := setupHandler()
-	runAuthzCases(t, h, http.MethodGet, configBasePath+"/some-key", []authzCase{
+	runAuthzCases(t, h, c, http.MethodGet, configBasePath+"/some-key", []authzCase{
 		{"no_auth", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
 		{"non_admin", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})
@@ -169,21 +179,38 @@ func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
 // single-entry GET semantics. The base path's trailing slash matches the
 // production registration in cell_routes.go (mux.Route("/config", ...)).
 func TestHttpConfigListV1_AuthzNegative(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.config.list.v1")
 	h, _ := setupHandler()
-	runAuthzCases(t, h, http.MethodGet, configBasePath+"/", []authzCase{
+	runAuthzCases(t, h, c, http.MethodGet, configBasePath+"/", []authzCase{
 		{"no_auth", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
 		{"non_admin", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})
 }
 
-// TestHttpConfigInternalGetV1_AuthzNegative locks the auth-guard contract
-// for the internal-listener GET /internal/v1/config/{key}: a missing
-// principal produces 401 (defence-in-depth alongside the listener's
-// service-token chain), and a service principal lacking RoleInternalAdmin
-// produces 403. The service-principal pattern matches runtime/auth/authz_test.go.
-func TestHttpConfigInternalGetV1_AuthzNegative(t *testing.T) {
+// TestHttpConfigInternalGetV1_PolicyDefenceInDepth locks the route-level
+// Policy guard on /internal/v1/config/{key} as a defence-in-depth layer
+// behind the listener's service-token authn chain, NOT the listener-level
+// "missing or invalid service token" path declared by the contract — that
+// path involves token parsing, nonce replay, and PrincipalService
+// injection wired by composition root (cmd/corebundle.internalGuardFromEnv +
+// runtime/auth.NewServiceTokenAuthenticator) and is exercised end-to-end
+// in integration tests, not here. This test asserts:
+//   - missing Principal → 401 (the route-policy short-circuit when the
+//     listener auth chain failed to inject a Principal — guards against a
+//     wiring regression that lets an unauth request reach the route)
+//   - PrincipalService without RoleInternalAdmin → 403 (guards against a
+//     downgrade of the route Policy to a weaker guard like AnyRole(any))
+//
+// The package-level TestMux (kernel/cell/celltest/mux.go) is intentionally
+// scoped to route-policy semantics, so a real bundle.Run harness is the
+// right fit for token-chain coverage; this slice-local test does not
+// replace it.
+func TestHttpConfigInternalGetV1_PolicyDefenceInDepth(t *testing.T) {
+	root := contracttest.ContractsRoot()
+	c := contracttest.LoadByID(t, root, "http.config.internal.get.v1")
 	h := setupInternalHandler()
-	runAuthzCases(t, h, http.MethodGet, "/internal/v1/config/some-key", []authzCase{
+	runAuthzCases(t, h, c, http.MethodGet, "/internal/v1/config/some-key", []authzCase{
 		{"no_principal", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
 		{"service_principal_without_role", servicePrincipal("svc-x", nil), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})

--- a/docs/plans/202604260058-l4-virtual-taco.md
+++ b/docs/plans/202604260058-l4-virtual-taco.md
@@ -19,7 +19,7 @@
 | ✅ | PR-CFG-K' | CTXCANCEL-LOCK-AND-REDACT | #287 |
 | ✅ | PR-CFG-G1 | DATAFLOW-AND-PG（含 G.9 自闭环 FU1/FU2/FU5） | #292 |
 | ✅ | PR-CFG-G2 | GOVERNANCE-AND-RESIDUE | #291 |
-| ⬜ | **PR-CFG-L** | **CONFIG-READ-ADMIN-GATE-AND-SCHEMA**（来自 025 CFG-4，🔴 P1 安全） | ~1d |
+| 🟡 | **PR-CFG-L** | **CONFIG-READ-AUTHZ-NEGATIVE-COVERAGE**（核心已 PR-CFG-C #267 落地；本 PR 补 mux 401/403 回归保护） | ~2.5h |
 | ✅ | **PR-CFG-M** | GOVERNANCE-ARCHTEST-AND-OUTBOX-METRICS（原 I.X2 + 025 CFG-6） | ~12.5h |
 | ⬜ | **PR-CFG-I** | **AUTH-FAIL-CLOSED-AND-OPS-RESIDUE**（原 I.X1 + I.X3） | ~14h |
 | ⬜ | **PR-A66** | BOOTSTRAP-STRUCT-DECOMPOSE | ~1d |
@@ -30,32 +30,44 @@
 
 ---
 
-## PR-CFG-L `CONFIG-READ-ADMIN-GATE-AND-SCHEMA`（~1d, 1 reviewer，🔴 P1 安全独占审）
+## PR-CFG-L `CONFIG-READ-AUTHZ-NEGATIVE-COVERAGE`（~2.5h, 1 reviewer）
 
-**抽象**：configcore 读路径 metadata 管控收口。`GET /api/v1/config/`（list）与 `GET /api/v1/config/{key}`（get）当前挂在默认 listener auth chain 下（`auth.Authenticated()` 等价语义），任何已登录用户都能枚举 key 列表 + 读 sensitive 元数据；HTTP response schema 未声明 `sensitive: bool` 但真实 DTO 已写——contract-first 调用方误判线上响应非法。本 PR admin gate + schema 显式声明 sensitive + contract_test 负向断言三处同 PR 校齐。
+**抽象**：configcore 读路径 admin gate 的运行时 mux 401/403 回归保护硬化。原计划 ~1d 范围在执行前现状核实时**全部落空**——核心改动（admin gate / schema sensitive 必填 / DTO 无 omitempty / contract.yaml 401+403 / contract_test schema 缺字段拒绝）已通过 PR-CFG-C #267 一并落地。本 PR 只补 configread 缺失的运行时 mux 端到端 401/403 表驱动断言（configwrite 已自带 `TestHttpConfigWriteV1_AuthzNegative` 同款，configread 没有），把现状钉成回归保护。
 
-**清零**：025 PR-CFG-4 全条目（🔴 P1 安全数据泄漏）
+**清零**：025 PR-CFG-4 全条目（🔴 P1 安全数据泄漏）已由 PR-CFG-C #267 实施；本 PR 关闭其测试覆盖残尾。
 
-**前置**：#267 PR-CFG-C 已铺好 `runtime/auth/authtest` 基底，本 PR 直接复用。
+**前置**：#267 PR-CFG-C 已落地 admin gate + schema + DTO + contract_test schema 拒绝；本 PR 在其基础上补 mux 运行时层断言。
 
-**改动**：
+**已落地（develop @ b8fd0578 现状核实）**：
+- ✅ `cells/configcore/slices/configread/handler.go:50-65` — 两条 GET `Policy: auth.AnyRole(dto.RoleAdmin)`
+- ✅ `handler.go:75-84` — `RegisterInternalRoutes` 显式 `Policy: auth.AnyRole(auth.RoleInternalAdmin)`
+- ✅ `contracts/http/config/{get,list}/v1/response.schema.json` — `sensitive: boolean` 必填
+- ✅ `cells/configcore/internal/dto/config_entry.go:16-37` — DTO `Sensitive bool` 无 omitempty
+- ✅ `contracts/http/config/{get,list}/v1/contract.yaml:24-35` — 401 + 403 声明 + `ERR_AUTH_FORBIDDEN`
+- ✅ `cells/configcore/slices/configread/contract_test.go:25,36,50,61` — `ValidateErrorResponse(403)` + 缺 sensitive 字段 `MustRejectResponse`
 
-- `cells/configcore/slices/configread/handler.go::RegisterRoutes` — 两条 GET 在 `auth.Mount` 处加 `Policy: auth.AnyRole(auth.RoleAdmin)`；同步 `RegisterInternalRoutes`（internal listener service-token chain 已是 admin 等价，但显式 Policy 保留 PR-A14a 一致性）
-- `contracts/http/config/get/v1/response.schema.json` — 顶层 `properties.data.properties.sensitive: {"type": "boolean"}` + `required: [..., "sensitive"]`
-- `contracts/http/config/list/v1/response.schema.json` — `items.properties.sensitive` 同款声明
-- `cells/configcore/slices/configread/service.go` — DTO converter 必填 `sensitive`，删任何 omitempty
-- `cells/configcore/slices/configread/contract_test.go` — `MustRejectResponse` 负向断言（缺 sensitive 字段的响应应 schema 校验失败 + 普通用户调用应 403）
+**本 PR 真做（~2h 测试 + ~30min 文档）**：
+- `cells/configcore/slices/configread/contract_test.go` — 新增三个表驱动 mux negative 测试（共享 `runAuthzCases` helper + `setupInternalHandler` 工厂，复用同包既有 `setupHandler`/`asAdmin`）：
+  - `TestHttpConfigGetV1_AuthzNegative` — `GET /api/v1/config/{key}`：no_auth → 401 `ERR_AUTH_UNAUTHORIZED`；viewer role → 403 `ERR_AUTH_FORBIDDEN`
+  - `TestHttpConfigListV1_AuthzNegative` — `GET /api/v1/config/`：同上
+  - `TestHttpConfigInternalGetV1_AuthzNegative` — `GET /internal/v1/config/{key}`：no_principal → 401；service principal w/o RoleInternalAdmin → 403
+- 本 plan 段：纠正原描述（核心已落地、错误码 `ERR_AUTH_FORBIDDEN` 而非 `ERR_AUTH_INSUFFICIENT_ROLE`、工时 ~1d → ~2.5h）
 
-**对标**：Vault KV v2 `data` vs `metadata` 路径分离授权；K8s RBAC ConfigMap/Secret 默认不进 `view`；Consul KV keys 枚举与 metadata/value 读取分离。
+**对标**：`cells/configcore/slices/configwrite/contract_test.go:74-109` `TestHttpConfigWriteV1_AuthzNegative` 表驱动模式（同仓库范本，复用 `auth.TestContext` + `celltest.NewTestMux` + httptest）。
 
 **回归断言**：
-- 普通 user JWT 调 `GET /api/v1/config/` → 403 `ERR_AUTH_INSUFFICIENT_ROLE`
-- admin JWT 调同端点 → 200 + `data[].sensitive` 必现
-- contract_test 删响应中 `sensitive` 字段 → schema 校验失败
+- 普通 user（roles=`["viewer"]`）的合法 Principal 调 `GET /api/v1/config/` 或 `/{key}` → 403 + `ERR_AUTH_FORBIDDEN`
+- 无 Principal 调同端点 → 401 + `ERR_AUTH_UNAUTHORIZED`
+- internal endpoint：service principal 无 `RoleInternalAdmin` → 403 + `ERR_AUTH_FORBIDDEN`
+- 既有 contract_test 删响应中 `sensitive` 字段 → schema 校验失败（保持绿）
 
-**不做**：不动 `/internal/v1/config/{key}` refetch 端点 auth（service-token + RoleInternalAdmin 已是更强守卫，G1 G.3 已落地）；不动 write/publish 端点 auth；不引入新 errcode。
+**不做**：
+- 不动正文代码（handler.go / service.go / cell_routes.go / schema/contract yaml / DTO）
+- 不引入新 errcode（plan 原描述的 `ERR_AUTH_INSUFFICIENT_ROLE` 与现状不一致，纠正为 `ERR_AUTH_FORBIDDEN`）
+- 不补 e2e non-admin 反向断言：admin gate 是 *Policy 层* 守卫，唯一回归路径是「合法 JWT 的 roles 不含 admin → Policy 拒绝」，contract_test 用 `auth.TestContext` 注入合法非 admin Principal 与 e2e 跨进程 JWT 验签到达**同一份** Policy 是等价回归路径；新增 `bootstrap-non-admin.sh` + workflow step + `clients.NonAdminToken` helper + 新 e2e 测试包仅为单条「viewer → 403」断言增加平行基础设施，违反「不造平行结构」原则
+- 不动 `cells/configcore/slices/configwrite/contract_test.go`（已自带 AuthzNegative）
 
-**文件域**：`cells/configcore/slices/configread/{handler,service,contract_test}.go` + `contracts/http/config/{get,list}/v1/response.schema.json`。**不触** `cells/configcore/cell_routes.go`（auth.Mount Policy 在 readHandler 内部；现核 develop @ 34499ef5）。
+**文件域**：`cells/configcore/slices/configread/contract_test.go` + 本 plan 段。**不触** `handler.go` / `service.go` / `cell_routes.go` / `contracts/http/config/...` / 任何 e2e 文件。
 
 ---
 
@@ -147,9 +159,10 @@
 G1 + G2 已合（develop @ 34499ef5）
    ↓
 batch2.4（四路并行可行，文件域全不重叠）：
-  ├─ PR-CFG-L  CONFIG-READ-ADMIN-GATE-AND-SCHEMA          (~1d,   1 reviewer) 🔴 P1 安全独占审
-  │     文件域：cells/configcore/slices/configread/ + contracts/http/config/{get,list}
-  │     建议先合（最短链 + 安全优先）
+  ├─ PR-CFG-L  CONFIG-READ-AUTHZ-NEGATIVE-COVERAGE        (~2.5h, 1 reviewer)
+  │     文件域：cells/configcore/slices/configread/contract_test.go
+  │     现状：核心已 PR-CFG-C #267 落地；本 PR 补 mux 401/403 回归保护 + plan 段纠错
+  │     建议先合（size 最小，无文件冲突风险）
   ├─ PR-CFG-M  GOVERNANCE-ARCHTEST-AND-OUTBOX-METRICS     (~16h,  1 reviewer)
   │     文件域：kernel/governance + kernel/outbox + tools/archtest + runtime/observability/metrics
   │     吸收：G1-FU6 / G2-FU1 / PR238-FU2 / FU2-static / DEFER-3 / 025 CFG-6
@@ -167,7 +180,7 @@ batch2 终点 retrospective（6 角色并行，D+E+F+G1+G2+H+I+J+K'+L+M 累计 d
 
 | PR | kernel/ | runtime/ | cells/ | tools/ | tests/e2e | contracts/ |
 |---|---|---|---|---|---|---|
-| L | — | — | configcore/slices/configread/ | — | — | http/config/{get,list} |
+| L | — | — | configcore/slices/configread/contract_test.go | — | — | — |
 | M | governance + outbox + assembly | observability/metrics | — | archtest + archtest/internal/typeseval | — | http/auth/role + actors.yaml |
 | I | — | auth + (pkg/errcode) | configcore/{cell_init,cell_routes,slices/configsubscribe} + accesscore/slices/sessionlogin | — | tests/e2e/* | — |
 | A66 | — | bootstrap/ | — | — | — | — |
@@ -179,7 +192,7 @@ batch2 终点 retrospective（6 角色并行，D+E+F+G1+G2+H+I+J+K'+L+M 累计 d
 ## 6 角色 review 投放（剩余）
 
 - **PR-CFG-L, M, I, A66（各 1 reviewer）**：六维度全覆盖单 reviewer
-  - L 必须包含 security 维度（🔴 P1 安全）
+  - L review 重点：测试覆盖完整性（401/403 双路径 + primary/internal 两 listener）+ 与 PR-CFG-C #267 既有 auth-truth 契约的一致性
   - M 必须包含 architect + observability 维度（治理 + metrics）
 - **batch2 终点 retrospective**：6 角色并行（D+E+F+G1+G2+H+I+J+K'+L+M 累计 diff）
 
@@ -196,8 +209,10 @@ go run ./cmd/gocell validate --strict                              # 0 errors
 go test ./tools/archtest/...
 
 # PR-CFG-L
-go test ./cells/configcore/slices/configread/...                   # contract_test 负向断言
-# 普通 user JWT → 403；admin JWT → 200 + sensitive 必现
+go test ./cells/configcore/slices/configread/...                   # 含三个 *_AuthzNegative 表驱动函数
+# - GET/{key}：no_auth → 401 ERR_AUTH_UNAUTHORIZED；viewer → 403 ERR_AUTH_FORBIDDEN
+# - GET /：同上
+# - internal GET/{key}：no_principal → 401；service principal w/o RoleInternalAdmin → 403
 
 # PR-CFG-M
 go test ./kernel/governance/... ./kernel/outbox/... ./tools/archtest/...
@@ -232,7 +247,7 @@ go build ./runtime/bootstrap/... && go test ./runtime/bootstrap/...
 1. `git fetch && git pull --rebase`（已 @ 34499ef5；G1 #292 / G2 #291 已合）
 2. **四路并行**起 PR-CFG-L + PR-CFG-M + PR-CFG-I + PR-A66 worktree（文件域全不重叠，已逐一核对）
 3. 顺序约束：
-   - L 建议**先合**（🔴 安全 + 最短链 ~1d）
+   - L 建议**先合**（size 最小 ~2.5h，文件域 = configread/contract_test.go 单文件 + 本 plan 段）
    - M / I / A66 文件域全互不相交，可真并行
 4. 每 worktree push 前 `golangci-lint 0 issues` + 对应 scope 真跑
 5. CI 状态用 `gh pr checks <num>` 单次查询，不循环

--- a/docs/plans/202604260058-l4-virtual-taco.md
+++ b/docs/plans/202604260058-l4-virtual-taco.md
@@ -47,18 +47,18 @@
 - ✅ `cells/configcore/slices/configread/contract_test.go:25,36,50,61` — `ValidateErrorResponse(403)` + 缺 sensitive 字段 `MustRejectResponse`
 
 **本 PR 真做（~2h 测试 + ~30min 文档）**：
-- `cells/configcore/slices/configread/contract_test.go` — 新增三个表驱动 mux negative 测试（共享 `runAuthzCases` helper + `setupInternalHandler` 工厂，复用同包既有 `setupHandler`/`asAdmin`）：
+- `cells/configcore/slices/configread/contract_test.go` — 新增三个表驱动 mux negative 测试（共享 `runAuthzCases` helper + `setupInternalHandler` 工厂，复用同包既有 `setupHandler`/`asAdmin`）。helper 内部除了 status + `error.code` 断言，还调 `Contract.ValidateErrorResponse(t, status, body)` 校验完整 4xx envelope schema（防 message/details 漂移与 contract.yaml `responses[401|403]` 漂移）：
   - `TestHttpConfigGetV1_AuthzNegative` — `GET /api/v1/config/{key}`：no_auth → 401 `ERR_AUTH_UNAUTHORIZED`；viewer role → 403 `ERR_AUTH_FORBIDDEN`
   - `TestHttpConfigListV1_AuthzNegative` — `GET /api/v1/config/`：同上
-  - `TestHttpConfigInternalGetV1_AuthzNegative` — `GET /internal/v1/config/{key}`：no_principal → 401；service principal w/o RoleInternalAdmin → 403
-- 本 plan 段：纠正原描述（核心已落地、错误码 `ERR_AUTH_FORBIDDEN` 而非 `ERR_AUTH_INSUFFICIENT_ROLE`、工时 ~1d → ~2.5h）
+  - `TestHttpConfigInternalGetV1_PolicyDefenceInDepth` — `GET /internal/v1/config/{key}`：**仅锁 route-level Policy 防御**（PrincipalService w/o `RoleInternalAdmin` → 403；missing Principal → 401），**不验证** contract 文案声明的 listener-level "missing/invalid service token" 路径（token parsing / nonce replay / PrincipalService 注入由 composition root `cmd/corebundle.internalGuardFromEnv` + `runtime/auth.NewServiceTokenAuthenticator` wiring，端到端覆盖应在 integration test 用真实 bundle harness 完成）
+- 本 plan 段：纠正原描述（核心已落地、错误码 `ERR_AUTH_FORBIDDEN` 而非 `ERR_AUTH_INSUFFICIENT_ROLE`、工时 ~1d → ~2.5h、internal test 语义降级为 policy-level defence-in-depth）
 
 **对标**：`cells/configcore/slices/configwrite/contract_test.go:74-109` `TestHttpConfigWriteV1_AuthzNegative` 表驱动模式（同仓库范本，复用 `auth.TestContext` + `celltest.NewTestMux` + httptest）。
 
 **回归断言**：
-- 普通 user（roles=`["viewer"]`）的合法 Principal 调 `GET /api/v1/config/` 或 `/{key}` → 403 + `ERR_AUTH_FORBIDDEN`
-- 无 Principal 调同端点 → 401 + `ERR_AUTH_UNAUTHORIZED`
-- internal endpoint：service principal 无 `RoleInternalAdmin` → 403 + `ERR_AUTH_FORBIDDEN`
+- 普通 user（roles=`["viewer"]`）的合法 Principal 调 `GET /api/v1/config/` 或 `/{key}` → 403 + `ERR_AUTH_FORBIDDEN` + 响应 body 通过 `error-response-v1.schema.json` 校验
+- 无 Principal 调同端点 → 401 + `ERR_AUTH_UNAUTHORIZED` + body 通过共享错误 envelope schema
+- internal endpoint（policy-level defence-in-depth）：service principal 无 `RoleInternalAdmin` → 403 + envelope schema；missing Principal → 401 + envelope schema
 - 既有 contract_test 删响应中 `sensitive` 字段 → schema 校验失败（保持绿）
 
 **不做**：
@@ -209,10 +209,11 @@ go run ./cmd/gocell validate --strict                              # 0 errors
 go test ./tools/archtest/...
 
 # PR-CFG-L
-go test ./cells/configcore/slices/configread/...                   # 含三个 *_AuthzNegative 表驱动函数
-# - GET/{key}：no_auth → 401 ERR_AUTH_UNAUTHORIZED；viewer → 403 ERR_AUTH_FORBIDDEN
+go test ./cells/configcore/slices/configread/...                   # 含三个表驱动 negative 函数
+# - GET/{key}：no_auth → 401 ERR_AUTH_UNAUTHORIZED；viewer → 403 ERR_AUTH_FORBIDDEN（含 envelope schema）
 # - GET /：同上
-# - internal GET/{key}：no_principal → 401；service principal w/o RoleInternalAdmin → 403
+# - internal GET/{key}（policy defence-in-depth）：no_principal → 401；service principal w/o RoleInternalAdmin → 403
+# 三个测试都会调 Contract.ValidateErrorResponse 校验完整 error envelope schema
 
 # PR-CFG-M
 go test ./kernel/governance/... ./kernel/outbox/... ./tools/archtest/...


### PR DESCRIPTION
## Summary

PR-CFG-L 原描述的核心改动（admin gate / schema sensitive / DTO no-omitempty / contract.yaml 401+403 / contract_test schema 缺字段拒绝）已通过 **#267 PR-CFG-C** 全部落地。本 PR 只补 configread 缺失的**运行时 mux 401/403 端到端表驱动断言**——configwrite 已自带 `TestHttpConfigWriteV1_AuthzNegative` 同款，configread 没有。把 admin gate 现状钉成回归保护：

- `TestHttpConfigGetV1_AuthzNegative` — `GET /api/v1/config/{key}`：no_auth → 401 `ERR_AUTH_UNAUTHORIZED`；viewer role → 403 `ERR_AUTH_FORBIDDEN`
- `TestHttpConfigListV1_AuthzNegative` — `GET /api/v1/config/`：同上
- `TestHttpConfigInternalGetV1_AuthzNegative` — `GET /internal/v1/config/{key}`：no_principal → 401；service principal w/o `RoleInternalAdmin` → 403

errcode 沿用 `ERR_AUTH_FORBIDDEN`（`pkg/errcode/errcode.go:29`），不引新错误码。

## 改动文件域

- `cells/configcore/slices/configread/contract_test.go`（+142 行测试 + helper）
- `docs/plans/202604260058-l4-virtual-taco.md`（PR-CFG-L 段纠错：核心已落地、错误码 `ERR_AUTH_FORBIDDEN` 而非 `ERR_AUTH_INSUFFICIENT_ROLE`、工时 ~1d → ~2.5h）

## 不做

- 不动正文代码（handler.go / service.go / cell_routes.go / schema/contract yaml / DTO）
- 不引入新 errcode
- 不补 e2e non-admin 反向断言：admin gate 是 *Policy 层* 守卫，contract_test 用 `auth.TestContext` 注入合法非 admin Principal 与 e2e 跨进程 JWT 验签到达**同一份** Policy 是等价回归路径；新增 `bootstrap-non-admin.sh` + workflow step + `clients.NonAdminToken` helper + 新 e2e 测试包仅为单条「viewer → 403」断言增加平行基础设施，违反「不造平行结构」原则

ref: `cells/configcore/slices/configwrite/contract_test.go` `TestHttpConfigWriteV1_AuthzNegative`

Refs: `docs/plans/202604260058-l4-virtual-taco.md` PR-CFG-L

## Test plan

- [x] `go build ./...` 全包绿
- [x] `go test ./cells/configcore/...` 全包绿（含三个新 `*_AuthzNegative`）
- [x] `golangci-lint run ./cells/configcore/slices/configread/...` 0 issues
- [x] `go run ./cmd/gocell validate --strict` 0 errors / 0 warnings
- [ ] CI 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)