### PR TITLE
refactor(ci): enforce registered production panics

### DIFF
--- a/adapters/postgres/embed.go
+++ b/adapters/postgres/embed.go
@@ -14,12 +14,10 @@ var migrationsFS embed.FS
 // file entries are directly accessible (e.g. "001_create_outbox_entries.up.sql"
 // rather than "migrations/001_create_outbox_entries.up.sql").
 // Callers can pass the result directly to NewMigrator.
-func MigrationsFS() fs.FS {
+func MigrationsFS() (fs.FS, error) {
 	sub, err := fs.Sub(migrationsFS, "migrations")
 	if err != nil {
-		// This can only fail if the embedded path is wrong, which is a build-
-		// time guarantee. Panic is acceptable here.
-		panic("postgres: embedded migrations sub-directory not found: " + err.Error())
+		return nil, err
 	}
-	return sub
+	return sub, nil
 }

--- a/adapters/postgres/embed.go
+++ b/adapters/postgres/embed.go
@@ -13,7 +13,8 @@ var migrationsFS embed.FS
 // MigrationsFS returns an fs.FS rooted at the migrations/ directory so that
 // file entries are directly accessible (e.g. "001_create_outbox_entries.up.sql"
 // rather than "migrations/001_create_outbox_entries.up.sql").
-// Callers can pass the result directly to NewMigrator.
+// Callers must handle the returned error before passing the filesystem to
+// NewMigrator.
 func MigrationsFS() (fs.FS, error) {
 	sub, err := fs.Sub(migrationsFS, "migrations")
 	if err != nil {

--- a/adapters/postgres/embed_test.go
+++ b/adapters/postgres/embed_test.go
@@ -1,0 +1,15 @@
+package postgres
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testMigrationsFS(t testing.TB) fs.FS {
+	t.Helper()
+	fsys, err := MigrationsFS()
+	require.NoError(t, err)
+	return fsys
+}

--- a/adapters/postgres/integration_test.go
+++ b/adapters/postgres/integration_test.go
@@ -181,7 +181,7 @@ func TestIntegration_Migrator(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "NewMigrator should succeed")
 
 	t.Run("up", func(t *testing.T) {
@@ -259,7 +259,7 @@ func TestIntegration_OutboxWriter(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply migrations so the outbox_entries table exists.
-	migrator, mErr := NewMigrator(pool, MigrationsFS(), "schema_migrations")
+	migrator, mErr := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
 	require.NoError(t, mErr, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
@@ -359,7 +359,7 @@ func TestMigrator_Applies004_WithConcurrentlyIndexes(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_004")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_004")
 	require.NoError(t, err)
 
 	// First Up: applies all 5 migrations including 004.
@@ -411,7 +411,7 @@ func TestMigration004_StructuralAssertions(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_struct")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_struct")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations")
 
@@ -471,7 +471,7 @@ func TestMigration006_ConfigVersionsConfigIDIndex(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_006")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_006")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations including 006")
 
@@ -524,7 +524,7 @@ func TestMigrator_Up_RefusesIfInvalidIndexExists(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply all migrations so tables and indexes exist.
-	prep, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_guard_prep")
+	prep, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_guard_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "preparatory Up() must succeed")
 
@@ -544,7 +544,7 @@ func TestMigrator_Up_RefusesIfInvalidIndexExists(t *testing.T) {
 	// Construct a fresh migrator using the same pool (with invalid index present).
 	// Use a new tracking table so Up() attempts to run from scratch (pre-check
 	// fires before any migration runs).
-	migrator2, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_guard_test")
+	migrator2, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_guard_test")
 	require.NoError(t, err)
 
 	// Up() must return an error: refusing to migrate due to invalid indexes.

--- a/adapters/postgres/migrator_test.go
+++ b/adapters/postgres/migrator_test.go
@@ -120,9 +120,9 @@ func TestValidateIdentifier(t *testing.T) {
 }
 
 func TestMigrationsFS_SubDirectory(t *testing.T) {
-	// Verify that MigrationsFS() returns a valid FS with goose-annotated files
+	// Verify that testMigrationsFS(t) returns a valid FS with goose-annotated files
 	// accessible at the root level (not under migrations/).
-	mfs := MigrationsFS()
+	mfs := testMigrationsFS(t)
 	require.NotNil(t, mfs)
 
 	entries, err := fs.ReadDir(mfs, ".")

--- a/adapters/postgres/outbox_store_integration_test.go
+++ b/adapters/postgres/outbox_store_integration_test.go
@@ -27,7 +27,7 @@ func TestPGOutboxStore_ConformanceSuite(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_store_conformance")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_store_conformance")
 	require.NoError(t, err, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
@@ -51,7 +51,7 @@ func TestPGOutboxStore_RelayPublishesRollbackStateBeforeAudit(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_store_order")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_store_order")
 	require.NoError(t, err, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -118,7 +119,7 @@ func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Cl
 	if pool == nil {
 		return nil, fmt.Errorf("postgres.NewRefreshStore: pool must not be nil")
 	}
-	if clock == nil {
+	if validation.IsNilInterface(clock) {
 		return nil, fmt.Errorf("postgres.NewRefreshStore: clock must not be nil")
 	}
 	if policy.MaxAge <= 0 {
@@ -127,7 +128,7 @@ func NewRefreshStore(pool *pgxpool.Pool, policy refresh.Policy, clock refresh.Cl
 	if policy.ReuseInterval < 0 {
 		return nil, fmt.Errorf("postgres.NewRefreshStore: policy.ReuseInterval must not be negative")
 	}
-	if randReader == nil {
+	if validation.IsNilInterface(randReader) {
 		randReader = rand.Reader
 	}
 	return &PGRefreshStore{

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -29,7 +29,7 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 		t.Helper()
 
 		p := isolatedSchemaPool(t, ctx, base)
-		migrator, err := NewMigrator(p, MigrationsFS(), "schema_migrations")
+		migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations")
 		require.NoError(t, err)
 		require.NoError(t, migrator.Up(ctx))
 
@@ -79,7 +79,7 @@ func TestMigration012_StructuralAssertions(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_012_struct")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_012_struct")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations through 012")
 
@@ -181,7 +181,7 @@ func TestPGRefreshStore_DMLState(t *testing.T) {
 
 	ctx := context.Background()
 	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, MigrationsFS(), "schema_migrations_dml_state")
+	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_dml_state")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 
@@ -262,7 +262,7 @@ func TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback(t *testing.T) {
 
 	ctx := context.Background()
 	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, MigrationsFS(), "schema_migrations_reuse_ambient")
+	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_reuse_ambient")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 
@@ -293,7 +293,7 @@ func TestPGRefreshStore_SessionLockRejectsChildValidatedBeforeCascade(t *testing
 
 	ctx := context.Background()
 	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, MigrationsFS(), "schema_migrations_reuse_lock")
+	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_reuse_lock")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 

--- a/adapters/postgres/refresh_store_test.go
+++ b/adapters/postgres/refresh_store_test.go
@@ -13,6 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errTypedNilRefreshReaderUsed = errors.New("typed nil refresh reader should have been defaulted")
+
+type typedNilRefreshClock struct{}
+
+func (*typedNilRefreshClock) Now() time.Time {
+	return time.Now()
+}
+
+type typedNilRefreshReader struct{}
+
+func (*typedNilRefreshReader) Read([]byte) (int, error) {
+	return 0, errTypedNilRefreshReaderUsed
+}
+
 // ---------------------------------------------------------------------------
 // NewRefreshStore constructor validation
 // ---------------------------------------------------------------------------
@@ -32,6 +46,12 @@ func TestNewRefreshStore_ReturnsErrorOnInvalidArgs(t *testing.T) {
 
 	t.Run("nil_clock", func(t *testing.T) {
 		_, err := NewRefreshStore(dummyPool, validPolicy, nil, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("typed_nil_clock", func(t *testing.T) {
+		var clock *typedNilRefreshClock
+		_, err := NewRefreshStore(dummyPool, validPolicy, clock, nil)
 		assert.Error(t, err)
 	})
 
@@ -71,6 +91,18 @@ func TestNewRefreshStore_NilRandReader_UsesDefault(t *testing.T) {
 	s, err := NewRefreshStore(dummyPool, validPolicy, validClock, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, s.rand, "rand field must be non-nil after constructor")
+}
+
+func TestNewRefreshStore_TypedNilRandReader_UsesDefault(t *testing.T) {
+	dummyPool := new(pgxpool.Pool)
+	validClock := storetest.NewFakeClock(time.Now())
+	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
+	var reader *typedNilRefreshReader
+
+	s, err := NewRefreshStore(dummyPool, validPolicy, validClock, reader)
+	require.NoError(t, err)
+	_, _, err = s.generatePair()
+	require.NoError(t, err)
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/postgres/schema_guard_integration_test.go
+++ b/adapters/postgres/schema_guard_integration_test.go
@@ -19,12 +19,12 @@ func TestVerifyExpectedVersion_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply all migrations first.
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
 	// VerifyExpectedVersion should pass: DB version == FS max version.
-	err = VerifyExpectedVersion(ctx, pool, MigrationsFS(), "schema_migrations")
+	err = VerifyExpectedVersion(ctx, pool, testMigrationsFS(t), "schema_migrations")
 	assert.NoError(t, err, "VerifyExpectedVersion should return nil after full Up()")
 }
 
@@ -39,7 +39,7 @@ func TestDetectInvalidIndexes_WithInjectedInvalid(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply migrations to create tables/indexes.
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_invalid_idx")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_invalid_idx")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
@@ -88,12 +88,12 @@ func TestVerifyExpectedVersion_DBAhead_Integration(t *testing.T) {
 	const tbl = "schema_migrations_ahead"
 
 	// Apply all migrations.
-	migrator, err := NewMigrator(pool, MigrationsFS(), tbl)
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), tbl)
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "initial Up() must succeed")
 
 	// Determine the expected (FS max) version.
-	expected, err := ExpectedVersion(MigrationsFS())
+	expected, err := ExpectedVersion(testMigrationsFS(t))
 	require.NoError(t, err)
 	require.Greater(t, expected, int64(0), "test requires at least 1 migration")
 
@@ -105,7 +105,7 @@ func TestVerifyExpectedVersion_DBAhead_Integration(t *testing.T) {
 	require.NoError(t, execErr, "inserting extra version record must succeed")
 
 	// VerifyExpectedVersion must now return a schema mismatch error (DB ahead).
-	err = VerifyExpectedVersion(ctx, pool, MigrationsFS(), tbl)
+	err = VerifyExpectedVersion(ctx, pool, testMigrationsFS(t), tbl)
 	require.Error(t, err, "should return error when DB version is ahead of binary")
 	assert.Contains(t, err.Error(), "schema version mismatch",
 		"error message should mention schema version mismatch")
@@ -121,12 +121,12 @@ func TestVerifyExpectedVersion_DBLagged_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply all migrations.
-	migrator, err := NewMigrator(pool, MigrationsFS(), "schema_migrations_lagged")
+	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_lagged")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "initial Up() must succeed")
 
 	// Determine the current max version so we can delete newer records.
-	expected, err := ExpectedVersion(MigrationsFS())
+	expected, err := ExpectedVersion(testMigrationsFS(t))
 	require.NoError(t, err)
 	require.Greater(t, expected, int64(3),
 		"test requires at least 4 migrations to simulate lag")
@@ -137,7 +137,7 @@ func TestVerifyExpectedVersion_DBLagged_Integration(t *testing.T) {
 	require.NoError(t, execErr, "deleting version records should succeed")
 
 	// VerifyExpectedVersion must now return a schema mismatch error.
-	err = VerifyExpectedVersion(ctx, pool, MigrationsFS(), "schema_migrations_lagged")
+	err = VerifyExpectedVersion(ctx, pool, testMigrationsFS(t), "schema_migrations_lagged")
 	require.Error(t, err, "should return error when DB is lagged")
 	assert.Contains(t, err.Error(), "schema version mismatch",
 		"error message should mention schema version mismatch")

--- a/adapters/postgres/schema_guard_test.go
+++ b/adapters/postgres/schema_guard_test.go
@@ -38,7 +38,7 @@ func TestExpectedVersion_FromEmbedFS(t *testing.T) {
 	// Use the real embedded migrations FS to verify max version detection works.
 	// This is a contract test: if a new migration is added, this test
 	// automatically uses the new max.
-	fsys := MigrationsFS()
+	fsys := testMigrationsFS(t)
 	v, err := ExpectedVersion(fsys)
 	require.NoError(t, err)
 	// Currently 13 migrations (001-013).

--- a/adapters/postgres/tx_manager.go
+++ b/adapters/postgres/tx_manager.go
@@ -95,7 +95,7 @@ func (tm *TxManager) RunInTx(ctx context.Context, fn func(ctx context.Context) e
 					slog.String("rollback_error", rbErr.Error()),
 				)
 			}
-			panic(r)
+			repanicAfterTopLevelTxRollback(r)
 		}
 	}()
 
@@ -139,7 +139,7 @@ func (tm *TxManager) runInSavepoint(ctx context.Context, tx pgx.Tx, fn func(ctx 
 					slog.String("rollback_error", rbErr.Error()),
 				)
 			}
-			panic(r)
+			repanicAfterSavepointRollback(r)
 		}
 	}()
 
@@ -159,4 +159,12 @@ func (tm *TxManager) runInSavepoint(ctx context.Context, tx pgx.Tx, fn func(ctx 
 		return errcode.Wrap(ErrAdapterPGQuery, fmt.Sprintf("postgres: release savepoint %s", spName), err)
 	}
 	return nil
+}
+
+func repanicAfterTopLevelTxRollback(recovered any) {
+	panic(recovered)
+}
+
+func repanicAfterSavepointRollback(recovered any) {
+	panic(recovered)
 }

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -34,14 +34,13 @@ func (c UpgradeConfig) Validate() error {
 }
 
 // UpgradeHandler returns an http.Handler that upgrades HTTP connections to
-// WebSocket and registers them with the Hub. Panics at construction time if
-// cfg.AllowedOrigins is empty — SEC-FAIL-CLOSED: the previous behaviour of
-// silently setting InsecureSkipVerify=true for empty origins is removed.
-// Callers at the composition root will observe the panic immediately at
-// startup rather than silently accepting connections from all origins.
-func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) http.Handler {
+// WebSocket and registers them with the Hub. It rejects an empty
+// cfg.AllowedOrigins at construction time — SEC-FAIL-CLOSED: the previous
+// behaviour of silently setting InsecureSkipVerify=true for empty origins is
+// removed.
+func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 	if err := cfg.Validate(); err != nil {
-		panic(err)
+		return nil, err
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !hub.IsRunning() {
@@ -85,7 +84,16 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) http.Handler {
 			slog.String("conn_id", connID),
 			slog.String("remote_addr", r.RemoteAddr),
 		)
-	})
+	}), nil
+}
+
+// MustUpgradeHandler is the static-wiring variant of UpgradeHandler.
+func MustUpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) http.Handler {
+	handler, err := UpgradeHandler(hub, cfg)
+	if err != nil {
+		panic(err)
+	}
+	return handler
 }
 
 func logUpgradeFailure(r *http.Request, err error) {

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -41,11 +41,16 @@ func (c UpgradeConfig) Validate() error {
 }
 
 // UpgradeHandler returns an http.Handler that upgrades HTTP connections to
-// WebSocket and registers them with the Hub. It rejects an empty
-// cfg.AllowedOrigins at construction time — SEC-FAIL-CLOSED: the previous
-// behaviour of silently setting InsecureSkipVerify=true for empty origins is
-// removed.
+// WebSocket and registers them with the Hub. It rejects a nil hub or an
+// invalid cfg at construction time — error-first fail-fast — so static-wiring
+// mistakes surface at composition root instead of the first HTTP request
+// (PR-MODE-6.1). SEC-FAIL-CLOSED: the previous behaviour of silently setting
+// InsecureSkipVerify=true for empty origins is removed.
 func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
+	if hub == nil {
+		return nil, errcode.New(errcode.ErrWebsocketHubMissing,
+			"websocket: UpgradeHandler hub must not be nil (fail-fast at wire time)")
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 
 	"nhooyr.io/websocket"
 
@@ -16,9 +17,9 @@ import (
 // UpgradeConfig configures the WebSocket upgrade handler.
 type UpgradeConfig struct {
 	// AllowedOrigins is a list of allowed origin patterns for the upgrade.
-	// Must be non-empty — the handler is fail-closed and panics at construction
-	// time if AllowedOrigins is nil or empty. Use []string{"*"} only in
-	// development environments where origin checking is intentionally disabled.
+	// It must be non-empty and must not contain the full wildcard "*". The
+	// error-returning UpgradeHandler rejects invalid configuration; the
+	// MustUpgradeHandler composition-root helper panics on the same error.
 	AllowedOrigins []string
 }
 
@@ -28,7 +29,13 @@ type UpgradeConfig struct {
 func (c UpgradeConfig) Validate() error {
 	if len(c.AllowedOrigins) == 0 {
 		return errcode.New(errcode.ErrWebsocketOriginsMissing,
-			"websocket: UpgradeConfig.AllowedOrigins must be non-empty; use [\"*\"] only in dev (fail-closed)")
+			"websocket: UpgradeConfig.AllowedOrigins must be non-empty (fail-closed)")
+	}
+	for _, origin := range c.AllowedOrigins {
+		if pattern := strings.TrimSpace(origin); pattern == "" || pattern == "*" {
+			return errcode.New(errcode.ErrWebsocketOriginsInvalid,
+				"websocket: UpgradeConfig.AllowedOrigins must use explicit host patterns; wildcard * is forbidden")
+		}
 	}
 	return nil
 }

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -443,6 +443,32 @@ func TestUpgradeHandler_RejectsEmptyOrigins(t *testing.T) {
 	})
 }
 
+// TestUpgradeHandler_RejectsNilHub verifies that constructing UpgradeHandler
+// with a nil *rtws.Hub fails fast at composition time with
+// ErrWebsocketHubMissing rather than deferring the failure to the first
+// HTTP request — error-first construction contract (PR-MODE-6.1).
+func TestUpgradeHandler_RejectsNilHub(t *testing.T) {
+	handler, err := adapterws.UpgradeHandler(nil, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"example.com"},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, handler)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrWebsocketHubMissing, ec.Code)
+}
+
+// TestMustUpgradeHandler_PanicsOnNilHub locks the static-wiring twin: a nil
+// hub must surface as a panic at composition root, not at request time.
+func TestMustUpgradeHandler_PanicsOnNilHub(t *testing.T) {
+	require.Panics(t, func() {
+		_ = adapterws.MustUpgradeHandler(nil, adapterws.UpgradeConfig{
+			AllowedOrigins: []string{"example.com"},
+		})
+	})
+}
+
 func TestUpgradeHandler_RejectsWildcardOrigin(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(), nil)
 

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -55,7 +55,7 @@ func setupTestHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, *httpte
 
 	mux := http.NewServeMux()
 	// Use explicit AllowedOrigins; empty origins will be rejected after SEC-FAIL-CLOSED-04.
-	mux.Handle("/ws", adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"*"},
 	}))
 
@@ -70,6 +70,13 @@ func setupTestHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, *httpte
 	})
 
 	return hub, server
+}
+
+func requireUpgradeHandler(t testing.TB, hub *rtws.Hub, cfg adapterws.UpgradeConfig) http.Handler {
+	t.Helper()
+	handler, err := adapterws.UpgradeHandler(hub, cfg)
+	require.NoError(t, err)
+	return handler
 }
 
 func dialWS(t *testing.T, serverURL string) *websocket.Conn {
@@ -122,7 +129,7 @@ func TestUpgradeHandler_NonHijackerFailsBeforeAccept(t *testing.T) {
 		<-startErr
 	})
 
-	handler := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"*"},
 	})
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
@@ -327,7 +334,7 @@ func TestUpgradeHandler_AllowedOrigins(t *testing.T) {
 	cfg := rtws.DefaultHubConfig()
 	hub := rtws.NewHub(cfg, nil)
 
-	handler := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"example.com"},
 	})
 
@@ -392,7 +399,7 @@ func TestUpgradeHandler_HubNotRunning_503(t *testing.T) {
 	// Hub intentionally NOT started.
 
 	// AllowedOrigins is required post-SEC-FAIL-CLOSED-04; use a valid value.
-	handler := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"example.com"},
 	})
 
@@ -405,51 +412,33 @@ func TestUpgradeHandler_HubNotRunning_503(t *testing.T) {
 }
 
 // TestUpgradeHandler_RejectsEmptyOrigins verifies that constructing an
-// UpgradeConfig with nil AllowedOrigins panics at construction time with an
-// *errcode.Error (SEC-FAIL-CLOSED). The recover block asserts the panic value
-// carries errcode.ErrWebsocketOriginsMissing so that recover chains can
-// errors.As on the recovered value.
+// UpgradeConfig with nil AllowedOrigins returns an *errcode.Error
+// (SEC-FAIL-CLOSED).
 //
 // Positive case: AllowedOrigins: []string{"example.com"} must not panic.
 func TestUpgradeHandler_RejectsEmptyOrigins(t *testing.T) {
 	cfg := rtws.DefaultHubConfig()
 
-	t.Run("empty origins — expect construction panic with *errcode.Error", func(t *testing.T) {
+	t.Run("empty origins — expect construction error with *errcode.Error", func(t *testing.T) {
 		hub := rtws.NewHub(cfg, nil)
 
-		var panicVal any
-		panicked := func() (didPanic bool) {
-			defer func() {
-				if r := recover(); r != nil {
-					panicVal = r
-					didPanic = true
-				}
-			}()
-			_ = adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{AllowedOrigins: nil})
-			return false
-		}()
-
-		if !panicked {
-			t.Fatal("UpgradeHandler with nil AllowedOrigins must panic at construction time")
-		}
-		// The panic value must be an *errcode.Error so recover chains can errors.As on it.
-		ec, ok := panicVal.(*errcode.Error)
-		if !ok {
-			t.Errorf("panic value must be *errcode.Error; got %T: %v", panicVal, panicVal)
-			return
-		}
+		handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{AllowedOrigins: nil})
+		require.Error(t, err)
+		assert.Nil(t, handler)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
 		if ec.Code != errcode.ErrWebsocketOriginsMissing {
-			t.Errorf("panic *errcode.Error must have code ErrWebsocketOriginsMissing; got %q", ec.Code)
+			t.Errorf("error code must be ErrWebsocketOriginsMissing; got %q", ec.Code)
 		}
 	})
 
 	t.Run("explicit allowed origins — ok", func(t *testing.T) {
 		hub := rtws.NewHub(cfg, nil)
 
-		// Must not panic; construction with valid origins must succeed.
-		handler := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+		handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
 			AllowedOrigins: []string{"example.com"},
 		})
+		require.NoError(t, err)
 		require.NotNil(t, handler)
 	})
 }

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -460,13 +460,40 @@ func TestUpgradeHandler_RejectsNilHub(t *testing.T) {
 }
 
 // TestMustUpgradeHandler_PanicsOnNilHub locks the static-wiring twin: a nil
-// hub must surface as a panic at composition root, not at request time.
+// hub must surface as a panic at composition root, not at request time, and
+// the panic value must be a typed *errcode.Error carrying ErrWebsocketHubMissing
+// so a recovery-based composition root can report the precise misconfiguration.
 func TestMustUpgradeHandler_PanicsOnNilHub(t *testing.T) {
-	require.Panics(t, func() {
-		_ = adapterws.MustUpgradeHandler(nil, adapterws.UpgradeConfig{
-			AllowedOrigins: []string{"example.com"},
-		})
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "MustUpgradeHandler must panic on nil hub")
+		err, ok := r.(error)
+		require.True(t, ok, "panic value must be an error, got %T", r)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		assert.Equal(t, errcode.ErrWebsocketHubMissing, ec.Code)
+	}()
+	_ = adapterws.MustUpgradeHandler(nil, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"example.com"},
 	})
+	t.Fatal("expected MustUpgradeHandler to panic, got none")
+}
+
+// TestUpgradeHandler_NilHubTakesPriorityOverOrigins locks the diagnostic order:
+// when both hub and cfg are invalid, the caller sees ErrWebsocketHubMissing
+// first. Reordering the checks in UpgradeHandler would silently change which
+// errcode operators see for misconfigured wiring.
+func TestUpgradeHandler_NilHubTakesPriorityOverOrigins(t *testing.T) {
+	handler, err := adapterws.UpgradeHandler(nil, adapterws.UpgradeConfig{
+		AllowedOrigins: nil,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, handler)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrWebsocketHubMissing, ec.Code,
+		"nil hub must be diagnosed before invalid origins")
 }
 
 func TestUpgradeHandler_RejectsWildcardOrigin(t *testing.T) {

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -56,7 +56,7 @@ func setupTestHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, *httpte
 	mux := http.NewServeMux()
 	// Use explicit AllowedOrigins; empty origins will be rejected after SEC-FAIL-CLOSED-04.
 	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
-		AllowedOrigins: []string{"*"},
+		AllowedOrigins: []string{"example.com"},
 	}))
 
 	server := httptest.NewServer(mux)
@@ -130,7 +130,7 @@ func TestUpgradeHandler_NonHijackerFailsBeforeAccept(t *testing.T) {
 	})
 
 	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
-		AllowedOrigins: []string{"*"},
+		AllowedOrigins: []string{"example.com"},
 	})
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
 	req.Header.Set("Connection", "Upgrade")
@@ -440,5 +440,28 @@ func TestUpgradeHandler_RejectsEmptyOrigins(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, handler)
+	})
+}
+
+func TestUpgradeHandler_RejectsWildcardOrigin(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(), nil)
+
+	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"*"},
+	})
+	require.Error(t, err)
+	assert.Nil(t, handler)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrWebsocketOriginsInvalid, ec.Code)
+}
+
+func TestMustUpgradeHandler_PanicsOnInvalidConfig(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(), nil)
+
+	require.Panics(t, func() {
+		_ = adapterws.MustUpgradeHandler(hub, adapterws.UpgradeConfig{
+			AllowedOrigins: []string{"*"},
+		})
 	})
 }

--- a/adapters/websocket/integration_test.go
+++ b/adapters/websocket/integration_test.go
@@ -36,9 +36,8 @@ func setupIntegrationHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, 
 	mux := http.NewServeMux()
 	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		// SEC-FAIL-CLOSED (PR-MODE-1): empty AllowedOrigins returns an error; the
-		// integration test exercises a loopback httptest.Server, so any origin
-		// pattern that matches `127.0.0.1` is acceptable.
-		AllowedOrigins: []string{"*"},
+		// integration test does not set Origin, so a narrow host pattern is enough.
+		AllowedOrigins: []string{"example.com"},
 	}))
 	server := httptest.NewServer(mux)
 

--- a/adapters/websocket/integration_test.go
+++ b/adapters/websocket/integration_test.go
@@ -34,8 +34,8 @@ func setupIntegrationHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, 
 	require.Eventually(t, func() bool { return hub.IsRunning() }, 2*time.Second, time.Millisecond)
 
 	mux := http.NewServeMux()
-	mux.Handle("/ws", adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
-		// SEC-FAIL-CLOSED (PR-MODE-1): empty AllowedOrigins now panics; the
+	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
+		// SEC-FAIL-CLOSED (PR-MODE-1): empty AllowedOrigins returns an error; the
 		// integration test exercises a loopback httptest.Server, so any origin
 		// pattern that matches `127.0.0.1` is acceptable.
 		AllowedOrigins: []string{"*"},

--- a/cells/accesscore/internal/dto/config_event_decoder_test.go
+++ b/cells/accesscore/internal/dto/config_event_decoder_test.go
@@ -47,7 +47,7 @@ func TestDecodeEntryUpserted(t *testing.T) {
 // JSON Schema at contracts/event/config/entry-upserted/v1/payload.schema.json.
 // This alignment test catches decoder/schema drift early.
 func TestDecodeEntryUpserted_AlignedWithContractSchema(t *testing.T) {
-	c := contracttest.LoadByID(t, contracttest.ContractsRoot(), "event.config.entry-upserted.v1")
+	c := contracttest.LoadByID(t, contracttest.ContractsRoot(t), "event.config.entry-upserted.v1")
 
 	validCases := []struct {
 		name    string
@@ -118,7 +118,7 @@ func TestDecodeEntryDeleted(t *testing.T) {
 // valid payload accepted by DecodeEntryDeleted also passes the canonical
 // JSON Schema at contracts/event/config/entry-deleted/v1/payload.schema.json.
 func TestDecodeEntryDeleted_AlignedWithContractSchema(t *testing.T) {
-	c := contracttest.LoadByID(t, contracttest.ContractsRoot(), "event.config.entry-deleted.v1")
+	c := contracttest.LoadByID(t, contracttest.ContractsRoot(t), "event.config.entry-deleted.v1")
 
 	validCases := []struct {
 		name    string

--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -127,7 +127,7 @@ func createUserForContractTest(t *testing.T, handler http.Handler, contract *con
 }
 
 func TestHttpAuthUserCreateV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	handler := setupContractHandler(t)
 
@@ -143,7 +143,7 @@ func TestHttpAuthUserCreateV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthUserGetV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.get.v1")
 	handler := setupContractHandler(t)
@@ -159,7 +159,7 @@ func TestHttpAuthUserGetV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthUserUpdateV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.update.v1")
 	handler := setupContractHandler(t)
@@ -178,7 +178,7 @@ func TestHttpAuthUserUpdateV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthUserPatchV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.patch.v1")
 	handler := setupContractHandler(t)
@@ -202,7 +202,7 @@ func TestHttpAuthUserPatchV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthUserDeleteV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	deleteContract := contracttest.LoadByID(t, root, "http.auth.user.delete.v1")
 	handler := setupContractHandler(t)
@@ -220,7 +220,7 @@ func TestHttpAuthUserDeleteV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthUserLockV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.lock.v1")
 	handler := setupContractHandler(t)
@@ -236,7 +236,7 @@ func TestHttpAuthUserLockV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthUserUnlockV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	lockContract := contracttest.LoadByID(t, root, "http.auth.user.lock.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.unlock.v1")
@@ -262,7 +262,7 @@ func TestHttpAuthUserUnlockV1Serve(t *testing.T) {
 // --- Event contract tests with real handler output ---
 
 func TestEventUserCreatedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "event.user.created.v1")
 	handler, writer := setupContractHandlerWithOutbox(t)
@@ -278,7 +278,7 @@ func TestEventUserCreatedV1Publish(t *testing.T) {
 }
 
 func TestEventUserLockedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	lockContract := contracttest.LoadByID(t, root, "http.auth.user.lock.v1")
 	c := contracttest.LoadByID(t, root, "event.user.locked.v1")
@@ -303,7 +303,7 @@ func TestEventUserLockedV1Publish(t *testing.T) {
 }
 
 func TestEventUserUpdatedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	updateContract := contracttest.LoadByID(t, root, "http.auth.user.update.v1")
 	c := contracttest.LoadByID(t, root, "event.user.updated.v1")
@@ -328,7 +328,7 @@ func TestEventUserUpdatedV1Publish(t *testing.T) {
 }
 
 func TestEventUserDeletedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	deleteContract := contracttest.LoadByID(t, root, "http.auth.user.delete.v1")
 	c := contracttest.LoadByID(t, root, "event.user.deleted.v1")
@@ -352,7 +352,7 @@ func TestEventUserDeletedV1Publish(t *testing.T) {
 }
 
 func TestEventUserUnlockedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	lockContract := contracttest.LoadByID(t, root, "http.auth.user.lock.v1")
 	unlockContract := contracttest.LoadByID(t, root, "http.auth.user.unlock.v1")
@@ -387,7 +387,7 @@ func TestEventUserUnlockedV1Publish(t *testing.T) {
 // --- #22 DELETE-NOCONTENT-01: 204 semantic negative test ---
 
 func TestHttpAuthUserDeleteV1Serve_RejectsBodyOn204(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.user.delete.v1")
 
 	// Fabricate a buggy 204 response with a body to prove the contract catches it.
@@ -424,7 +424,7 @@ func (c *capturingTB) Fatal(args ...any)                 { c.errored = true }
 // ---------------------------------------------------------------------------
 
 func TestHttpAuthUserChangePasswordV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	createContract := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 	c := contracttest.LoadByID(t, root, "http.auth.user.change-password.v1")
 
@@ -482,7 +482,7 @@ func TestHttpAuthUserChangePasswordV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthUserCreateV1_RequirePasswordResetField(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.user.create.v1")
 
 	// requirePasswordReset is optional — should be accepted (password ≥ 8 chars per FMT-25).
@@ -492,7 +492,7 @@ func TestHttpAuthUserCreateV1_RequirePasswordResetField(t *testing.T) {
 }
 
 func TestHttpAuthUserPatchV1_RequirePasswordResetField(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.user.patch.v1")
 
 	// requirePasswordReset as a bool patch field — should be accepted.

--- a/cells/accesscore/slices/rbacassign/contract_test.go
+++ b/cells/accesscore/slices/rbacassign/contract_test.go
@@ -41,7 +41,7 @@ func newContractHandler() http.Handler {
 }
 
 func TestHttpAuthRoleAssignV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.role.assign.v1")
 	handler := newContractHandler()
 
@@ -65,7 +65,7 @@ func TestHttpAuthRoleAssignV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthRoleRevokeV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.role.revoke.v1")
 	handler := newContractHandler()
 
@@ -92,7 +92,7 @@ func TestHttpAuthRoleRevokeV1Serve(t *testing.T) {
 // event.role.assigned.v1 payload JSON Schema.
 // Full contract coverage is tracked as S8-FOLLOWUP (VERIFY-01 waiver expiry 2026-07-01).
 func TestContract_EventRoleAssignedV1_Publish_PayloadValid(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.role.assigned.v1")
 
 	evt := dto.RoleChangedEvent{UserID: "u1", RoleID: "admin", Action: dto.ActionAssigned}
@@ -111,7 +111,7 @@ func TestContract_EventRoleAssignedV1_Publish_PayloadValid(t *testing.T) {
 // event.role.revoked.v1 payload JSON Schema.
 // Full contract coverage is tracked as S8-FOLLOWUP (VERIFY-01 waiver expiry 2026-07-01).
 func TestContract_EventRoleRevokedV1_Publish_PayloadValid(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.role.revoked.v1")
 
 	evt := dto.RoleChangedEvent{UserID: "u1", RoleID: "admin", Action: dto.ActionRevoked}

--- a/cells/accesscore/slices/rbaccheck/contract_test.go
+++ b/cells/accesscore/slices/rbaccheck/contract_test.go
@@ -81,7 +81,7 @@ func decodeRoleListPage(t *testing.T, rec *httptest.ResponseRecorder) roleListPa
 }
 
 func TestHttpAuthRoleListV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.role.list.v1")
 	h := newContractRBACHandler()
 
@@ -141,7 +141,7 @@ func TestHttpAuthRoleListV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthRoleCheckV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.role.check.v1")
 	h := newContractRBACHandler()
 

--- a/cells/accesscore/slices/sessionlogin/contract_test.go
+++ b/cells/accesscore/slices/sessionlogin/contract_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHttpAuthLoginV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.login.v1")
 
 	c.ValidateRequest(t, []byte(`{"username":"alice","password":"secret12"}`))
@@ -38,7 +38,7 @@ func TestHttpAuthLoginV1Serve(t *testing.T) {
 }
 
 func TestEventSessionCreatedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.session.created.v1")
 
 	c.ValidatePayload(t, []byte(`{"sessionId":"sess-1","userId":"usr-1"}`))

--- a/cells/accesscore/slices/sessionlogout/contract_test.go
+++ b/cells/accesscore/slices/sessionlogout/contract_test.go
@@ -63,7 +63,7 @@ func seedContractSession(repo *mem.SessionRepository) string {
 // --- HTTP contract test (S1-F1) ---
 
 func TestHttpAuthSessionDeleteV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.session.delete.v1")
 
 	sessionRepo := mem.NewSessionRepository()
@@ -89,7 +89,7 @@ func TestHttpAuthSessionDeleteV1Serve(t *testing.T) {
 // --- Event contract test ---
 
 func TestEventSessionRevokedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.session.revoked.v1")
 
 	sessionRepo := mem.NewSessionRepository()
@@ -123,7 +123,7 @@ func TestEventSessionRevokedV1Publish(t *testing.T) {
 // contract_test.go — together they cover both halves of the contract, which
 // is why the slice.yaml waiver for VERIFY-01 no longer applies.
 func TestContract_EventRoleAssignedV1_Subscribe_PayloadValid(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.role.assigned.v1")
 
 	repo := mem.NewSessionRepository()
@@ -146,7 +146,7 @@ func TestContract_EventRoleAssignedV1_Subscribe_PayloadValid(t *testing.T) {
 // TestContract_EventRoleRevokedV1_Subscribe_PayloadValid mirrors the assigned
 // test for the revoked topic.
 func TestContract_EventRoleRevokedV1_Subscribe_PayloadValid(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.role.revoked.v1")
 
 	repo := mem.NewSessionRepository()

--- a/cells/accesscore/slices/sessionrefresh/contract_test.go
+++ b/cells/accesscore/slices/sessionrefresh/contract_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHttpAuthRefreshV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.refresh.v1")
 
 	c.ValidateRequest(t, []byte(`{"refreshToken":"old-token-with-min-len20"}`))

--- a/cells/accesscore/slices/setup/contract_test.go
+++ b/cells/accesscore/slices/setup/contract_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestHttpAuthSetupStatusV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.setup.status.v1")
 
 	c.ValidateResponse(t, []byte(`{"data":{"hasAdmin":false}}`))
@@ -68,7 +68,7 @@ func TestHttpAuthSetupStatusV1Serve(t *testing.T) {
 }
 
 func TestHttpAuthSetupAdminV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.auth.setup.admin.v1")
 
 	c.ValidateRequest(t, []byte(`{"username":"root","email":"root@local","password":"SecretPass!23"}`))
@@ -186,7 +186,7 @@ func TestHttpAuthSetupAdminV1Serve(t *testing.T) {
 // real handler path and assert the emitted outbox entry's payload + headers
 // both satisfy the event contract.
 func TestEventUserCreatedV1Publish_FromSetup(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.user.created.v1")
 
 	w := &stubWriter{}

--- a/cells/accesscore/slices/setup/service.go
+++ b/cells/accesscore/slices/setup/service.go
@@ -265,11 +265,15 @@ func (s *Service) provisionAndMaybeEmit(ctx context.Context, in CreateAdminInput
 // not embedded on the wire — contract is the single source of truth for
 // endpoint paths.
 func setupRetiredError() error {
-	return errcode.WithDetails(
+	detailed, err := errcode.WithDetails(
 		errcode.New(errcode.ErrSetupAlreadyInitialized,
 			"first-run admin already provisioned; this endpoint is retired"),
 		map[string]any{"nextAction": "login"},
 	)
+	if err != nil {
+		return err
+	}
+	return detailed
 }
 
 func (s *Service) publishUserCreated(ctx context.Context, user *domain.User) error {

--- a/cells/auditcore/slices/auditappend/contract_test.go
+++ b/cells/auditcore/slices/auditappend/contract_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEventAuditAppendedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.audit.appended.v1")
 
 	c.ValidatePayload(t, []byte(`{"auditEntryId":"audit-001","eventType":"session.created"}`))
@@ -17,7 +17,7 @@ func TestEventAuditAppendedV1Publish(t *testing.T) {
 }
 
 func TestEventSessionCreatedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.session.created.v1")
 
 	c.ValidatePayload(t, []byte(`{"sessionId":"s-1","userId":"u-1"}`))
@@ -25,7 +25,7 @@ func TestEventSessionCreatedV1Subscribe(t *testing.T) {
 }
 
 func TestEventSessionRevokedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.session.revoked.v1")
 
 	c.ValidatePayload(t, []byte(`{"sessionId":"sess-1","userId":"usr-1"}`))
@@ -33,7 +33,7 @@ func TestEventSessionRevokedV1Subscribe(t *testing.T) {
 }
 
 func TestEventUserCreatedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.user.created.v1")
 
 	c.ValidatePayload(t, []byte(`{"userId":"usr-1","username":"alice","actorId":"admin-1"}`))
@@ -44,7 +44,7 @@ func TestEventUserCreatedV1Subscribe(t *testing.T) {
 }
 
 func TestEventUserLockedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.user.locked.v1")
 
 	// actorId required since G.1 + G.6 migration
@@ -54,7 +54,7 @@ func TestEventUserLockedV1Subscribe(t *testing.T) {
 }
 
 func TestEventConfigEntryUpsertedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.entry-upserted.v1")
 
 	// actorId required since G.2 migration
@@ -67,7 +67,7 @@ func TestEventConfigEntryUpsertedV1Subscribe(t *testing.T) {
 }
 
 func TestEventConfigEntryDeletedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.entry-deleted.v1")
 
 	// Valid: key + version + actorId required (G.2 migration).
@@ -87,7 +87,7 @@ func TestEventConfigEntryDeletedV1Subscribe(t *testing.T) {
 }
 
 func TestEventConfigVersionPublishedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.version-published.v1")
 
 	// actorId required since G.2 migration
@@ -98,7 +98,7 @@ func TestEventConfigVersionPublishedV1Subscribe(t *testing.T) {
 }
 
 func TestEventConfigRollbackV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.rollback.v1")
 
 	// actorId required since G.2 migration

--- a/cells/auditcore/slices/auditquery/contract_test.go
+++ b/cells/auditcore/slices/auditquery/contract_test.go
@@ -41,7 +41,7 @@ func newContractQueryHandler(entries ...*domain.AuditEntry) http.Handler {
 }
 
 func TestHttpAuditListV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.audit.list.v1")
 
 	h := newContractQueryHandler(&domain.AuditEntry{
@@ -58,7 +58,7 @@ func TestHttpAuditListV1Serve(t *testing.T) {
 }
 
 func TestHttpAuditListV1Serve_Empty(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.audit.list.v1")
 
 	h := newContractQueryHandler()
@@ -73,7 +73,7 @@ func TestHttpAuditListV1Serve_Empty(t *testing.T) {
 }
 
 func TestHttpAuditListV1_QueryParamsMetadata(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.audit.list.v1")
 	if c.HTTP == nil {
 		t.Fatal("HTTP transport metadata should be loaded")

--- a/cells/auditcore/slices/auditverify/contract_test.go
+++ b/cells/auditcore/slices/auditverify/contract_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEventAuditIntegrityVerifiedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.audit.integrity-verified.v1")
 
 	c.ValidatePayload(t, []byte(`{"valid":true,"firstInvalidIndex":0,"entriesChecked":100}`))

--- a/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
@@ -45,7 +45,7 @@ func setupConfigPG(t *testing.T) (*ConfigRepository, *adapterpg.TxManager, func(
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -304,7 +304,7 @@ func setupConfigPGEncrypted(t *testing.T) (*ConfigRepository, *adapterpg.TxManag
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 

--- a/cells/configcore/internal/adapters/postgres/flag_restart_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/flag_restart_integration_test.go
@@ -39,7 +39,7 @@ func setupFlagPG(t *testing.T) (*FlagRepository, *adapterpg.TxManager, func()) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 

--- a/cells/configcore/internal/adapters/postgres/postgres_helpers_test.go
+++ b/cells/configcore/internal/adapters/postgres/postgres_helpers_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package postgres
+
+import (
+	"io/fs"
+	"testing"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func testAdapterMigrationsFS(t testing.TB) fs.FS {
+	t.Helper()
+	fsys, err := adapterpg.MigrationsFS()
+	require.NoError(t, err)
+	return fsys
+}

--- a/cells/configcore/slices/configpublish/contract_test.go
+++ b/cells/configcore/slices/configpublish/contract_test.go
@@ -56,7 +56,7 @@ func newContractMux(svc *Service) http.Handler {
 // --- HTTP contract test ---
 
 func TestHttpConfigPublishV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.publish.v1")
 	svc, repo, _ := newContractService(t)
 	seedContractEntry(repo, "app.name", "value")
@@ -77,7 +77,7 @@ func TestHttpConfigPublishV1Serve(t *testing.T) {
 }
 
 func TestHttpConfigRollbackV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.rollback.v1")
 	svc, repo, _ := newContractService(t)
 	seedContractEntry(repo, "app.name", "value")
@@ -119,7 +119,7 @@ type errEnvelope struct {
 // validates the response body shape against the contract's declared error schema
 // and asserts the exact error code emitted by the real auth chain.
 func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.publish.v1")
 	svc, _, _ := newContractService(t)
 	mux := newContractMux(svc)
@@ -162,7 +162,7 @@ func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 // TestHttpConfigRollbackV1_Serve_Unauthorized mirrors the publish unauthorized test
 // for the rollback endpoint, asserting real error codes from the RequireAnyRole chain.
 func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.rollback.v1")
 	svc, _, _ := newContractService(t)
 	mux := newContractMux(svc)
@@ -201,7 +201,7 @@ func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 // --- Event contract tests ---
 
 func TestEventConfigVersionPublishedV1Publish(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.version-published.v1")
 	svc, repo, writer := newContractService(t)
 	seedContractEntry(repo, "app.name", "value")
@@ -220,7 +220,7 @@ func TestEventConfigVersionPublishedV1Publish(t *testing.T) {
 }
 
 func TestEventConfigRollbackV1Publish_RollbackEmitsStateThenAudit(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	upserted := contracttest.LoadByID(t, root, "event.config.entry-upserted.v1")
 	rollback := contracttest.LoadByID(t, root, "event.config.rollback.v1")
 	svc, repo, writer := newContractService(t)

--- a/cells/configcore/slices/configpublish/postgres_helpers_test.go
+++ b/cells/configcore/slices/configpublish/postgres_helpers_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package configpublish
+
+import (
+	"io/fs"
+	"testing"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func testAdapterMigrationsFS(t testing.TB) fs.FS {
+	t.Helper()
+	fsys, err := adapterpg.MigrationsFS()
+	require.NoError(t, err)
+	return fsys
+}

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -63,7 +63,7 @@ func setupPublishBundle(t *testing.T) (publishServiceBundle, func()) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 
@@ -227,7 +227,7 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 		}
 	}()
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 

--- a/cells/configcore/slices/configread/contract_test.go
+++ b/cells/configcore/slices/configread/contract_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestHttpConfigGetV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.get.v1")
 
 	// Lock the wire-level contract: drift in contract.yaml method/path would
@@ -46,7 +46,7 @@ func TestHttpConfigGetV1Serve(t *testing.T) {
 }
 
 func TestHttpConfigListV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.list.v1")
 
 	require.NotNil(t, c.HTTP, "http.config.list.v1 must declare endpoints.http")
@@ -165,7 +165,7 @@ func servicePrincipal(subject string, roles []string) *auth.Principal {
 // without the admin role are rejected with 403 ERR_AUTH_FORBIDDEN. The
 // happy-path response shape is locked by TestHttpConfigGetV1Serve.
 func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.get.v1")
 	h, _ := setupHandler()
 	runAuthzCases(t, h, c, http.MethodGet, configBasePath+"/some-key", []authzCase{
@@ -179,7 +179,7 @@ func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
 // single-entry GET semantics. The base path's trailing slash matches the
 // production registration in cell_routes.go (mux.Route("/config", ...)).
 func TestHttpConfigListV1_AuthzNegative(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.list.v1")
 	h, _ := setupHandler()
 	runAuthzCases(t, h, c, http.MethodGet, configBasePath+"/", []authzCase{
@@ -207,7 +207,7 @@ func TestHttpConfigListV1_AuthzNegative(t *testing.T) {
 // right fit for token-chain coverage; this slice-local test does not
 // replace it.
 func TestHttpConfigInternalGetV1_PolicyDefenceInDepth(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.internal.get.v1")
 	h := setupInternalHandler()
 	runAuthzCases(t, h, c, http.MethodGet, "/internal/v1/config/some-key", []authzCase{

--- a/cells/configcore/slices/configsubscribe/contract_test.go
+++ b/cells/configcore/slices/configsubscribe/contract_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEventConfigEntryUpsertedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.entry-upserted.v1")
 
 	// Metadata-only schema: key + version + actorId; no value field.
@@ -34,7 +34,7 @@ func TestEventConfigEntryUpsertedV1Subscribe(t *testing.T) {
 }
 
 func TestEventConfigEntryDeletedV1Subscribe(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.entry-deleted.v1")
 
 	// Valid: key + version + actorId (metadata-only + tombstone protection).

--- a/cells/configcore/slices/configwrite/contract_test.go
+++ b/cells/configcore/slices/configwrite/contract_test.go
@@ -48,7 +48,7 @@ func newContractMux(svc *Service) http.Handler {
 // --- HTTP contract test ---
 
 func TestHttpConfigWriteV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.write.v1")
 	svc, _, _ := newContractService(t)
 
@@ -111,7 +111,7 @@ func TestHttpConfigWriteV1_AuthzNegative(t *testing.T) {
 // --- Event contract tests ---
 
 func TestEventConfigEntryUpsertedV1Publish_Create(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.entry-upserted.v1")
 	svc, _, writer := newContractService(t)
 
@@ -135,7 +135,7 @@ func TestEventConfigEntryUpsertedV1Publish_Create(t *testing.T) {
 }
 
 func TestEventConfigEntryUpsertedV1Publish_Update(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.entry-upserted.v1")
 	svc, _, writer := newContractService(t)
 
@@ -154,7 +154,7 @@ func TestEventConfigEntryUpsertedV1Publish_Update(t *testing.T) {
 }
 
 func TestEventConfigEntryDeletedV1Publish_Delete(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "event.config.entry-deleted.v1")
 	svc, _, writer := newContractService(t)
 

--- a/cells/configcore/slices/configwrite/postgres_helpers_test.go
+++ b/cells/configcore/slices/configwrite/postgres_helpers_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package configwrite
+
+import (
+	"io/fs"
+	"testing"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func testAdapterMigrationsFS(t testing.TB) fs.FS {
+	t.Helper()
+	fsys, err := adapterpg.MigrationsFS()
+	require.NoError(t, err)
+	return fsys
+}

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -59,7 +59,7 @@ func setupWriteService(t *testing.T) (writeBundle, func()) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 
@@ -210,7 +210,7 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 		}
 	}()
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 

--- a/cells/configcore/slices/featureflag/contract_test.go
+++ b/cells/configcore/slices/featureflag/contract_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHttpConfigFlagsListV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.flags.list.v1")
 
 	// PR-CFG-C contract-as-auth-truth: route is admin-gated.
@@ -24,7 +24,7 @@ func TestHttpConfigFlagsListV1Serve(t *testing.T) {
 }
 
 func TestHttpConfigFlagsGetV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.flags.get.v1")
 
 	_, has403 := c.HTTP.Responses[403]
@@ -39,7 +39,7 @@ func TestHttpConfigFlagsGetV1Serve(t *testing.T) {
 }
 
 func TestHttpConfigFlagsEvaluateV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.flags.evaluate.v1")
 
 	_, has403 := c.HTTP.Responses[403]

--- a/cells/configcore/slices/flagwrite/contract_test.go
+++ b/cells/configcore/slices/flagwrite/contract_test.go
@@ -51,7 +51,7 @@ func newContractService(t *testing.T) *Service {
 // --- Create contract test ---
 
 func TestHttpConfigFlagsCreateV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.flags.create.v1")
 	svc := newContractService(t)
 	mux := newContractMux(svc)
@@ -72,7 +72,7 @@ func TestHttpConfigFlagsCreateV1Serve(t *testing.T) {
 // --- Update contract test ---
 
 func TestHttpConfigFlagsUpdateV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.flags.update.v1")
 	svc := newContractService(t)
 
@@ -134,7 +134,7 @@ func TestHttpConfigFlagsUpdateV1Serve(t *testing.T) {
 // --- Toggle contract test ---
 
 func TestHttpConfigFlagsToggleV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.flags.toggle.v1")
 	svc := newContractService(t)
 
@@ -160,7 +160,7 @@ func TestHttpConfigFlagsToggleV1Serve(t *testing.T) {
 // --- Delete contract test ---
 
 func TestHttpConfigFlagsDeleteV1Serve(t *testing.T) {
-	root := contracttest.ContractsRoot()
+	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.flags.delete.v1")
 	svc := newContractService(t)
 

--- a/cmd/corebundle/buildapp_env_integration_test.go
+++ b/cmd/corebundle/buildapp_env_integration_test.go
@@ -22,7 +22,7 @@ func applyMigrationsForMain(t *testing.T, ctx context.Context, dsn string) {
 	t.Helper()
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err, "migration prep pool must open")
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "NewMigrator must succeed")
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations")
 	_ = pool.Close(ctx)

--- a/cmd/corebundle/bundle.go
+++ b/cmd/corebundle/bundle.go
@@ -300,9 +300,9 @@ func buildConfigCoreOpts(ctx context.Context, cfg ConfigCoreModuleConfig) (Confi
 			return ConfigCoreModuleResult{}, fmt.Errorf("configcore PG pool: %w", err)
 		}
 		// A12: fail-fast on schema version mismatch.
-		if schemaErr := adapterpg.VerifyExpectedVersion(ctx, pool, adapterpg.MigrationsFS()); schemaErr != nil {
+		if schemaErr := verifyConfigCorePGSchema(ctx, pool); schemaErr != nil {
 			_ = pool.Close(ctx)
-			return ConfigCoreModuleResult{}, fmt.Errorf("configcore PG schema guard: %w", schemaErr)
+			return ConfigCoreModuleResult{}, schemaErr
 		}
 		// A4: warn on INVALID indexes (non-fatal).
 		if invalid, detectErr := adapterpg.DetectInvalidIndexes(ctx, pool); detectErr != nil {
@@ -363,6 +363,17 @@ func buildConfigCoreOpts(ctx context.Context, cfg ConfigCoreModuleConfig) (Confi
 		return ConfigCoreModuleResult{}, errcode.New(errcode.ErrValidationFailed,
 			fmt.Sprintf("buildConfigCoreOpts: unexpected StorageBackend %q (topology validation bypass)", cfg.Topology.StorageBackend))
 	}
+}
+
+func verifyConfigCorePGSchema(ctx context.Context, pool *adapterpg.Pool) error {
+	migrationsFS, err := adapterpg.MigrationsFS()
+	if err != nil {
+		return fmt.Errorf("configcore PG migrations fs: %w", err)
+	}
+	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS); err != nil {
+		return fmt.Errorf("configcore PG schema guard: %w", err)
+	}
+	return nil
 }
 
 func buildConfigCorePGStorage(pool *adapterpg.Pool, cfg ConfigCoreModuleConfig) (kernellifecycle.ManagedResource, configcore.Option, error) {

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -62,7 +62,7 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMatched(t *testing.T) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err, "pool for migration prep must succeed")
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "NewMigrator must succeed")
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations")
 	_ = pool.Close(ctx)
@@ -103,7 +103,7 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMismatch(t *testing.T) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err, "pool for migration prep must succeed")
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "NewMigrator must succeed")
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations initially")
 

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -110,7 +110,7 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 
 	migrationPool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: pgConnStr})
 	require.NoError(t, err, "create migration PG pool")
-	migrator, err := adapterpg.NewMigrator(migrationPool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(migrationPool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "create migrator")
 	require.NoError(t, migrator.Up(ctx), "run migrations")
 	_ = migrationPool.Close(ctx)
@@ -468,7 +468,7 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 
 	migrationPool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: pgConnStr})
 	require.NoError(t, err, "create migration PG pool")
-	migrator, err := adapterpg.NewMigrator(migrationPool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(migrationPool, testAdapterMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "create migrator")
 	require.NoError(t, migrator.Up(ctx), "run migrations")
 	_ = migrationPool.Close(ctx)

--- a/cmd/corebundle/postgres_helpers_test.go
+++ b/cmd/corebundle/postgres_helpers_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package main
+
+import (
+	"io/fs"
+	"testing"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func testAdapterMigrationsFS(t testing.TB) fs.FS {
+	t.Helper()
+	fsys, err := adapterpg.MigrationsFS()
+	require.NoError(t, err)
+	return fsys
+}

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -62,16 +62,18 @@ cancellation. Modelled as `kworker.ErrWorkerExitedEarly` so callers can
 `errors.Is`-detect the abnormal signal — not strictly part of the panic
 refactor, but bundled for the same "fail loudly, propagate errors" theme.
 
-### 4. Hardcoded ADR-pinned whitelist (2 functions)
+### 4. Hardcoded ADR-pinned whitelist (4 functions)
 
-The archtest holds **two** function-level whitelist entries. Every other panic
-in the scoped files is either refactored, renamed, or in an `init()` function
-(auto-exempt).
+The archtest holds **four** function-level whitelist entries. Every other
+production panic is either refactored into an error-returning API or made
+explicit through a `Must*` wrapper.
 
 | # | Function | Justification |
 |---|---|---|
 | 1 | `kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor` | Middle of a `defer recover()` chain that re-panics so the outer `runtime/http/middleware.Recovery` middleware can record + serialize the panic. Refactoring it to return error would dismantle the entire recover propagation idiom and force every wrapped consumer to pre-route panics through a synthetic error path before Go's runtime gets the chance. |
 | 2 | `runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure` | Middle of a `defer recover()` chain that first reports the handler panic as a circuit-breaker failure, then re-panics so the outer `Recovery` middleware remains the single panic-to-HTTP and panic-to-tracing boundary. Swallowing the panic here would bypass `Recovery` and lose panic span recording in the normal router chain. |
+| 3 | `adapters/postgres/tx_manager.go::repanicAfterTopLevelTxRollback` | Top-level transaction panic path must rollback the open pgx transaction before preserving the caller's original panic semantics. Returning an error would swallow programmer/runtime panics from the callback and change `RunInTx`'s transaction-safety contract. |
+| 4 | `adapters/postgres/tx_manager.go::repanicAfterSavepointRollback` | Nested transaction panic path must rollback to the savepoint before preserving the caller's original panic semantics. Returning an error would swallow programmer/runtime panics from the callback and make nested and top-level transactions diverge. |
 
 ### 5. Auto-exempt categories
 
@@ -82,9 +84,6 @@ in the scoped files is either refactored, renamed, or in an `init()` function
   `MustMarshalDirectEnvelope` (renamed from non-Must form), plus
   pre-existing `MustValidateLabels`, `MustRegister`, `MustNewTestKeyProvider`,
   `MustCookieSession`, etc.
-- **`func init()`**: Init cannot return error; package-level invariant
-  violations are by definition fatal. Example: `adapters/postgres/embed.go`
-  embedded migrations subdir loading.
 
 ### 6. PR-MODE-6.1 scope expansion
 
@@ -152,14 +151,14 @@ that construct a single static `cell.NewAuthJWTFromAssembly(asm)` continue
 to write `cell.MustNewAuthJWTFromAssembly(asm)` with no error-handling
 boilerplate.
 
-### Why minimum (2) whitelist?
+### Why minimum (4) whitelist?
 
 Each whitelist entry is a future regression risk: a new contributor sees
 "there are some panics here, panicking must be OK" and adds another. The
 review loop catches new architectural panic claims via the ADR, not via
-the archtest list. By keeping the whitelist to **only** defer-recover-re-panic
-helpers (which are structurally not refactorable to error returns), we maximize
-the "panic in error-less function = bug" signal.
+the archtest list. By keeping the whitelist to **only** re-panic propagation
+helpers that preserve an already in-flight panic after mandatory cleanup or
+recording, we maximize the "panic outside Must* = bug" signal.
 
 The previous design (5 entries) was rejected: outbox crypto/rand failures
 and envelope marshal invariants were absorbable as either error
@@ -172,18 +171,22 @@ wiring.
 
 ### Whitelist mechanics
 
-Hardcoded in `tools/archtest/error_first_test.go`:
+Hardcoded in `tools/archtest/panic_registered_test.go`:
 
 ```go
-var errorFirstWhitelistedFunctions = map[string]string{
+var architecturalPanicWhitelist = map[string]string{
     "kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor": "re-panics from defer recover so outer Recovery middleware can serialize the panic",
     "runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure": "re-panics from defer recover after reporting circuit-breaker failure",
+    "adapters/postgres/tx_manager.go::repanicAfterTopLevelTxRollback": "re-panics after top-level transaction rollback so caller panic semantics are preserved",
+    "adapters/postgres/tx_manager.go::repanicAfterSavepointRollback": "re-panics after savepoint rollback so nested transaction panic semantics are preserved",
 }
 ```
 
 To add an entry: open a PR, update this ADR's §4 table with a new row,
-update the map. Reviewer must reject any whitelist addition that's
-absorbable as `Must*` rename or error propagation.
+update the map. `PANIC-REGISTERED-01` parses the ADR table and fails unless
+the table and map are exactly equal, every map entry is used by a real panic,
+and the whitelist stays at five entries or fewer. Reviewer must reject any
+whitelist addition that's absorbable as `Must*` rename or error propagation.
 
 ### Trade-offs
 

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -185,8 +185,9 @@ var architecturalPanicWhitelist = map[string]string{
 To add an entry: open a PR, update this ADR's §4 table with a new row,
 update the map. `PANIC-REGISTERED-01` parses the ADR table and fails unless
 the table and map are exactly equal, every map entry is used by a real panic,
-and the whitelist stays at five entries or fewer. Reviewer must reject any
-whitelist addition that's absorbable as `Must*` rename or error propagation.
+and the whitelist contains exactly the four approved permanent entries.
+Reviewer must reject any whitelist addition that's absorbable as `Must*`
+rename or error propagation.
 
 ### Trade-offs
 

--- a/examples/iotdevice/cells/devicecell/slices/devicecommand/contract_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommand/contract_test.go
@@ -44,7 +44,7 @@ func newContractCommandHandler() (http.Handler, *mem.DeviceRepository, *commandt
 // --- HTTP contract tests (real handler) ---
 
 func TestHttpDeviceCommandEnqueueV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.command.enqueue.v1")
 
 	handler, devRepo, _ := newContractCommandHandler()
@@ -67,7 +67,7 @@ func TestHttpDeviceCommandEnqueueV1Serve(t *testing.T) {
 }
 
 func TestHttpDeviceCommandDequeueV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.command.dequeue.v1")
 
 	handler, devRepo, q := newContractCommandHandler()
@@ -87,7 +87,7 @@ func TestHttpDeviceCommandDequeueV1Serve(t *testing.T) {
 }
 
 func TestHttpDeviceCommandAckV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.command.ack.v1")
 
 	handler, devRepo, q := newContractCommandHandler()
@@ -114,7 +114,7 @@ func TestHttpDeviceCommandAckV1Serve(t *testing.T) {
 }
 
 func TestHttpDeviceCommandReportV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.command.report.v1")
 
 	handler, devRepo, q := newContractCommandHandler()
@@ -136,7 +136,7 @@ func TestHttpDeviceCommandReportV1Serve(t *testing.T) {
 }
 
 func TestHttpDeviceCommandExtendLeaseV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.command.extend-lease.v1")
 
 	handler, devRepo, q := newContractCommandHandler()
@@ -164,7 +164,7 @@ func TestHttpDeviceCommandExtendLeaseV1Serve(t *testing.T) {
 }
 
 func TestHttpInternalDeviceCommandsListV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.internal.devicecommands.list.v1")
 
 	handler, devRepo, q := newContractCommandHandler()
@@ -185,7 +185,7 @@ func TestHttpInternalDeviceCommandsListV1Serve(t *testing.T) {
 // --- Command-kind contract tests (schema validation) ---
 
 func TestCommandDeviceCommandEnqueueV1Handle(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "command.device-command.enqueue.v1")
 
 	// payload required; commandType optional
@@ -196,7 +196,7 @@ func TestCommandDeviceCommandEnqueueV1Handle(t *testing.T) {
 }
 
 func TestCommandDeviceCommandDequeueV1Handle(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "command.device-command.dequeue.v1")
 
 	c.ValidateResponse(t, []byte(`{"data":[{"id":"cmd-1","deviceId":"d-1","commandType":"reboot","payload":"reboot","status":"sent","attempt":1,"createdAt":"2026-01-01T00:00:00Z","sentAt":"2026-01-01T00:00:01Z"}]}`))
@@ -204,7 +204,7 @@ func TestCommandDeviceCommandDequeueV1Handle(t *testing.T) {
 }
 
 func TestCommandDeviceCommandAckV1Handle(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "command.device-command.ack.v1")
 
 	c.ValidateRequest(t, []byte(`{"reason":"success"}`))
@@ -217,7 +217,7 @@ func TestCommandDeviceCommandAckV1Handle(t *testing.T) {
 }
 
 func TestCommandDeviceCommandReportV1Handle(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "command.device-command.report.v1")
 
 	c.ValidateRequest(t, []byte(`{}`))
@@ -227,7 +227,7 @@ func TestCommandDeviceCommandReportV1Handle(t *testing.T) {
 }
 
 func TestCommandDeviceCommandExtendLeaseV1Handle(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "command.device-command.extend-lease.v1")
 
 	c.ValidateRequest(t, []byte(`{"extensionSeconds":60}`))

--- a/examples/iotdevice/cells/devicecell/slices/devicelist/contract_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicelist/contract_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestSpecDeviceListMatchesContract(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.list.v1")
 	require.NotNil(t, c.HTTP)
 	require.Equal(t, c.ID, specDeviceListSlice.ID)
@@ -73,7 +73,7 @@ func decodeDeviceListPage(t *testing.T, rec *httptest.ResponseRecorder) deviceLi
 }
 
 func TestHttpDeviceListV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.list.v1")
 	h := newContractDeviceListHandler(t)
 
@@ -133,7 +133,7 @@ func TestHttpDeviceListV1Serve(t *testing.T) {
 }
 
 func TestDeviceListContractSpecMatchesContract(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.list.v1")
 	if c.HTTP == nil {
 		t.Fatal("http.device.list.v1 must declare HTTP transport metadata")

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/contract_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/contract_test.go
@@ -48,7 +48,7 @@ func newContractHandler() (http.Handler, *recordingPublisher) {
 }
 
 func TestSpecDeviceRegisterMatchesContract(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.register.v1")
 	require.NotNil(t, c.HTTP)
 	require.Equal(t, c.ID, specDeviceRegister.ID)
@@ -57,7 +57,7 @@ func TestSpecDeviceRegisterMatchesContract(t *testing.T) {
 }
 
 func TestHttpDeviceRegisterV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.register.v1")
 	h, _ := newContractHandler()
 
@@ -72,7 +72,7 @@ func TestHttpDeviceRegisterV1Serve(t *testing.T) {
 }
 
 func TestEventDeviceRegisteredV1Publish(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	httpContract := contracttest.LoadByID(t, root, "http.device.register.v1")
 	c := contracttest.LoadByID(t, root, "event.device-registered.v1")
 	h, pub := newContractHandler()

--- a/examples/iotdevice/cells/devicecell/slices/devicestatus/contract_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicestatus/contract_test.go
@@ -28,7 +28,7 @@ func newContractHandler() http.Handler {
 }
 
 func TestSpecDeviceStatusMatchesContract(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.status.v1")
 	require.NotNil(t, c.HTTP)
 	require.Equal(t, c.ID, specDeviceStatus.ID)
@@ -37,7 +37,7 @@ func TestSpecDeviceStatusMatchesContract(t *testing.T) {
 }
 
 func TestHttpDeviceStatusV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.status.v1")
 	h := newContractHandler()
 
@@ -51,7 +51,7 @@ func TestHttpDeviceStatusV1Serve(t *testing.T) {
 }
 
 func TestHttpDeviceStatusV1Serve_NotFound(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("iotdevice")
+	root := contracttest.ExampleContractsRoot(t, "iotdevice")
 	c := contracttest.LoadByID(t, root, "http.device.status.v1")
 	h := newContractHandler()
 

--- a/examples/todoorder/cells/ordercell/slices/ordercreate/contract_test.go
+++ b/examples/todoorder/cells/ordercell/slices/ordercreate/contract_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestSpecOrderCreateMatchesContract(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("todoorder")
+	root := contracttest.ExampleContractsRoot(t, "todoorder")
 	c := contracttest.LoadByID(t, root, "http.order.create.v1")
 	require.NotNil(t, c.HTTP)
 	require.Equal(t, c.ID, specOrderCreate.ID)
@@ -33,7 +33,7 @@ func newContractHandler(t testing.TB) (http.Handler, *recordingWriter) {
 }
 
 func TestHttpOrderCreateV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("todoorder")
+	root := contracttest.ExampleContractsRoot(t, "todoorder")
 	c := contracttest.LoadByID(t, root, "http.order.create.v1")
 	h, _ := newContractHandler(t)
 
@@ -48,7 +48,7 @@ func TestHttpOrderCreateV1Serve(t *testing.T) {
 }
 
 func TestEventOrderCreatedV1Publish(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("todoorder")
+	root := contracttest.ExampleContractsRoot(t, "todoorder")
 	httpContract := contracttest.LoadByID(t, root, "http.order.create.v1")
 	c := contracttest.LoadByID(t, root, "event.order-created.v1")
 	h, writer := newContractHandler(t)

--- a/examples/todoorder/cells/ordercell/slices/orderquery/contract_test.go
+++ b/examples/todoorder/cells/ordercell/slices/orderquery/contract_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestSpecOrderQueryMatchesContracts(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("todoorder")
+	root := contracttest.ExampleContractsRoot(t, "todoorder")
 
 	get := contracttest.LoadByID(t, root, "http.order.get.v1")
 	require.NotNil(t, get.HTTP)
@@ -51,7 +51,7 @@ func newContractQueryHandler(orders ...*domain.Order) http.Handler {
 }
 
 func TestHttpOrderGetV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("todoorder")
+	root := contracttest.ExampleContractsRoot(t, "todoorder")
 	c := contracttest.LoadByID(t, root, "http.order.get.v1")
 	h := newContractQueryHandler(&domain.Order{
 		ID:        "ord-contract-get",
@@ -67,7 +67,7 @@ func TestHttpOrderGetV1Serve(t *testing.T) {
 }
 
 func TestHttpOrderListV1Serve(t *testing.T) {
-	root := contracttest.ExampleContractsRoot("todoorder")
+	root := contracttest.ExampleContractsRoot(t, "todoorder")
 	c := contracttest.LoadByID(t, root, "http.order.list.v1")
 	h := newContractQueryHandler(
 		&domain.Order{ID: "ord-a", Item: "widget", Status: "pending", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},

--- a/hack/README.md
+++ b/hack/README.md
@@ -39,5 +39,6 @@ itself enforces.
 | `verify-generated.sh` | generated `boundary.yaml` and `metrics-schema.yaml` are up to date |
 | `verify-govalidate.sh` | `gocell validate --strict` (FMT, ADV, REF, LAYER, VERIFY, CONTRACT-CONSISTENCY) |
 | `verify-journey.sh` | `gocell verify journey --active` (active journeys carry executable auto checks) |
+| `verify-panic-registered.sh` | `PANIC-REGISTERED-01`: production `panic()` calls must be `Must*` or ADR-registered |
 | `verify-scaffold-reject.sh` | `gocell scaffold slice` rejects kebab-case names |
 | `verify-unconditional-skip.sh` | no `t.Skip` without a runtime predicate |

--- a/hack/verify-panic-registered.sh
+++ b/hack/verify-panic-registered.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# verify-panic-registered enforces PANIC-REGISTERED-01: production panic()
+# calls must be either inside Must* functions or ADR-registered permanent
+# exceptions.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+go test ./tools/archtest/... -run 'TestPanicRegistered' -count=1

--- a/kernel/governance/rules_http_response_alignment_test.go
+++ b/kernel/governance/rules_http_response_alignment_test.go
@@ -212,7 +212,7 @@ func h(w http.ResponseWriter, r *http.Request) {
 			name: "errcode.WithDetails wrapping inner New: inner code is found",
 			handlerSrc: `
 func h(w http.ResponseWriter, r *http.Request) {
-	_ = errcode.WithDetails(errcode.New(errcode.ErrAuthUserNotFound, "x"), nil)
+	_, _ = errcode.WithDetails(errcode.New(errcode.ErrAuthUserNotFound, "x"), nil)
 }
 `,
 			responses: map[int]contracts.HTTPResponse{
@@ -224,7 +224,7 @@ func h(w http.ResponseWriter, r *http.Request) {
 			name: "errcode.WithDetails inner code missing from contract",
 			handlerSrc: `
 func h(w http.ResponseWriter, r *http.Request) {
-	_ = errcode.WithDetails(errcode.New(errcode.ErrAuthUserNotFound, "x"), nil)
+	_, _ = errcode.WithDetails(errcode.New(errcode.ErrAuthUserNotFound, "x"), nil)
 }
 `,
 			responses: map[int]contracts.HTTPResponse{

--- a/pkg/contracttest/contracttest.go
+++ b/pkg/contracttest/contracttest.go
@@ -8,7 +8,7 @@
 // Usage:
 //
 //	func TestHttpAuthUserCreateV1Serve(t *testing.T) {
-//	    c := contracttest.LoadByID(t, contracttest.ContractsRoot(), "http.auth.user.create.v1")
+//	    c := contracttest.LoadByID(t, contracttest.ContractsRoot(t), "http.auth.user.create.v1")
 //	    c.ValidateRequest(t, []byte(`{"username":"alice","email":"a@b.com","password":"s"}`))
 //	    c.ValidateResponse(t, []byte(`{"data":{"id":"u-1","username":"alice",...}}`))
 //	    c.MustRejectRequest(t, []byte(`{"extra":"field"}`))
@@ -72,20 +72,23 @@ type endpointsYAML struct {
 
 // ContractsRoot returns the absolute path to the contracts/ directory,
 // derived from the source location of this package.
-func ContractsRoot() string {
-	return filepath.Join(projectRoot(), "contracts")
+func ContractsRoot(t testing.TB) string {
+	t.Helper()
+	return filepath.Join(projectRoot(t), "contracts")
 }
 
 // ExampleContractsRoot returns the absolute path to an example's contracts/
 // directory. The example name is the directory under examples/.
-func ExampleContractsRoot(example string) string {
-	return filepath.Join(projectRoot(), "examples", example, "contracts")
+func ExampleContractsRoot(t testing.TB, example string) string {
+	t.Helper()
+	return filepath.Join(projectRoot(t), "examples", example, "contracts")
 }
 
-func projectRoot() string {
+func projectRoot(t testing.TB) string {
+	t.Helper()
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
-		panic("contracttest: runtime.Caller failed")
+		t.Fatalf("contracttest: runtime.Caller failed")
 	}
 	// thisFile = .../pkg/contracttest/contracttest.go
 	return filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))

--- a/pkg/contracttest/contracttest_test.go
+++ b/pkg/contracttest/contracttest_test.go
@@ -76,7 +76,7 @@ func TestLoadByID(t *testing.T) {
 }
 
 func TestExampleContractsRoot(t *testing.T) {
-	root := ExampleContractsRoot("todoorder")
+	root := ExampleContractsRoot(t, "todoorder")
 	wantSuffix := filepath.Join("examples", "todoorder", "contracts")
 	if !strings.HasSuffix(root, wantSuffix) {
 		t.Fatalf("ExampleContractsRoot suffix = %q, want %q", root, wantSuffix)
@@ -269,12 +269,12 @@ func TestValidateRequest_NoSchema(t *testing.T) {
 }
 
 func TestContractsRoot(t *testing.T) {
-	root := ContractsRoot()
+	root := ContractsRoot(t)
 	if !filepath.IsAbs(root) {
-		t.Errorf("ContractsRoot() returned non-absolute path: %s", root)
+		t.Errorf("ContractsRoot(t) returned non-absolute path: %s", root)
 	}
 	if filepath.Base(root) != "contracts" {
-		t.Errorf("ContractsRoot() should end with 'contracts', got: %s", root)
+		t.Errorf("ContractsRoot(t) should end with 'contracts', got: %s", root)
 	}
 }
 

--- a/pkg/contracttest/error_response_test.go
+++ b/pkg/contracttest/error_response_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 // errorTestContractsRoot returns the path to testdata contracts for error response tests.
-func errorTestContractsRoot() string {
+func errorTestContractsRoot(t testing.TB) string {
+	t.Helper()
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
-		panic("contracttest: runtime.Caller failed")
+		t.Fatalf("contracttest: runtime.Caller failed")
 	}
 	return filepath.Join(filepath.Dir(thisFile), "testdata", "contracts")
 }
@@ -67,7 +68,7 @@ func TestValidateErrorResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := LoadByID(t, errorTestContractsRoot(), tt.contractID)
+			c := LoadByID(t, errorTestContractsRoot(t), tt.contractID)
 			mockT := &mockTB{}
 			c.ValidateErrorResponse(mockT, tt.status, tt.body)
 			if tt.wantFail && !mockT.failed {

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -176,7 +176,7 @@ const (
 	//
 	// Example:
 	//
-	//	adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+	//	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
 	//	    AllowedOrigins: []string{"https://example.com"},
 	//	})
 	//
@@ -535,10 +535,9 @@ func Wrap(code Code, message string, cause error) *Error {
 // WithDetails returns a shallow copy of err with the provided details merged in.
 // If err.Details is nil a new map is allocated; existing keys are preserved
 // unless overwritten by the supplied details.
-// It panics if err is nil — callers must not pass a nil *Error.
-func WithDetails(err *Error, details map[string]any) *Error {
+func WithDetails(err *Error, details map[string]any) (*Error, error) {
 	if err == nil {
-		panic("errcode: WithDetails called with nil *Error")
+		return nil, New(ErrInternal, "errcode: WithDetails called with nil *Error")
 	}
 	merged := make(map[string]any, len(err.Details)+len(details))
 	maps.Copy(merged, err.Details)
@@ -550,5 +549,5 @@ func WithDetails(err *Error, details map[string]any) *Error {
 		Details:         merged,
 		Cause:           err.Cause,
 		Category:        err.Category,
-	}
+	}, nil
 }

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -170,9 +170,8 @@ const (
 	ErrWSMaxConns       Code = "ERR_WS_MAX_CONNS"
 	// ErrWebsocketOriginsMissing signals that an UpgradeHandler was constructed
 	// with an empty AllowedOrigins list. The handler rejects construction
-	// fail-fast rather than silently enabling InsecureSkipVerify=true, which
-	// would accept connections from any origin. Operators must supply at least
-	// one origin pattern (use []string{"*"} only in development).
+	// fail-fast rather than silently accepting connections from any origin.
+	// Operators must supply at least one explicit origin host pattern.
 	//
 	// Example:
 	//
@@ -182,6 +181,10 @@ const (
 	//
 	// ref: docs/plans/202604270020-1-2-ci-3-claude-ship-reactive-bachman.md PR-MODE-1
 	ErrWebsocketOriginsMissing Code = "ERR_WEBSOCKET_ORIGINS_MISSING"
+	// ErrWebsocketOriginsInvalid signals that AllowedOrigins contains a pattern
+	// that would disable browser Origin protection, such as the full wildcard
+	// "*".
+	ErrWebsocketOriginsInvalid Code = "ERR_WEBSOCKET_ORIGINS_INVALID"
 
 	// Outbox envelope error codes.
 	// ErrEnvelopeSchema signals that an inbound wire message does not conform

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -185,6 +185,18 @@ const (
 	// that would disable browser Origin protection, such as the full wildcard
 	// "*".
 	ErrWebsocketOriginsInvalid Code = "ERR_WEBSOCKET_ORIGINS_INVALID"
+	// ErrWebsocketHubMissing signals that UpgradeHandler was constructed with
+	// a nil *rtws.Hub. Composition-time fail-fast — letting nil through would
+	// defer the failure until the first HTTP request, violating the
+	// error-first construction contract (PR-MODE-6.1).
+	//
+	// Example:
+	//
+	//	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+	//	    AllowedOrigins: []string{"https://example.com"},
+	//	})
+	//	if hub == nil { /* err.Code == ErrWebsocketHubMissing */ }
+	ErrWebsocketHubMissing Code = "ERR_WEBSOCKET_HUB_MISSING"
 
 	// Outbox envelope error codes.
 	// ErrEnvelopeSchema signals that an inbound wire message does not conform

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -192,10 +192,11 @@ const (
 	//
 	// Example:
 	//
-	//	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+	//	handler, err := adapterws.UpgradeHandler(nil, adapterws.UpgradeConfig{
 	//	    AllowedOrigins: []string{"https://example.com"},
 	//	})
-	//	if hub == nil { /* err.Code == ErrWebsocketHubMissing */ }
+	//	var ec *errcode.Error
+	//	if errors.As(err, &ec) && ec.Code == errcode.ErrWebsocketHubMissing { /* misconfig */ }
 	ErrWebsocketHubMissing Code = "ERR_WEBSOCKET_HUB_MISSING"
 
 	// Outbox envelope error codes.

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -111,7 +112,7 @@ func TestWithDetails(t *testing.T) {
 		},
 		{
 			name: "merge details preserving and overwriting",
-			base: WithDetails(
+			base: withDetailsForTest(t,
 				New(ErrMetadataInvalid, "invalid"),
 				map[string]any{"field": "owner", "line": 10},
 			),
@@ -129,7 +130,8 @@ func TestWithDetails(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := WithDetails(tt.base, tt.details)
+			result, err := WithDetails(tt.base, tt.details)
+			require.NoError(t, err)
 
 			// WithDetails returns a new Error; original is unmodified.
 			assert.NotSame(t, tt.base, result)
@@ -141,14 +143,18 @@ func TestWithDetails(t *testing.T) {
 }
 
 func TestWithDetails_NilError(t *testing.T) {
-	assert.PanicsWithValue(t, "errcode: WithDetails called with nil *Error", func() {
-		WithDetails(nil, map[string]any{"key": "val"})
-	})
+	result, err := WithDetails(nil, map[string]any{"key": "val"})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	var ec *Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, ErrInternal, ec.Code)
 }
 
 func TestWithDetailsDDoesNotMutateOriginal(t *testing.T) {
-	original := WithDetails(New(ErrAssemblyNotFound, "not found"), map[string]any{"key": "val"})
-	_ = WithDetails(original, map[string]any{"extra": "data"})
+	original := withDetailsForTest(t, New(ErrAssemblyNotFound, "not found"), map[string]any{"key": "val"})
+	_, err := WithDetails(original, map[string]any{"extra": "data"})
+	require.NoError(t, err)
 
 	// Original must be unchanged.
 	assert.Equal(t, map[string]any{"key": "val"}, original.Details)
@@ -247,12 +253,20 @@ func TestWrap_InternalMessageEmpty(t *testing.T) {
 
 func TestWithDetails_PreservesInternalMessage(t *testing.T) {
 	original := Safe(ErrInternal, "internal server error", "pool exhausted")
-	result := WithDetails(original, map[string]any{"host": "db-1"})
+	result, err := WithDetails(original, map[string]any{"host": "db-1"})
+	require.NoError(t, err)
 
 	assert.Equal(t, "pool exhausted", result.InternalMessage,
 		"WithDetails must preserve InternalMessage")
 	assert.Equal(t, "internal server error", result.Message)
 	assert.Equal(t, map[string]any{"host": "db-1"}, result.Details)
+}
+
+func withDetailsForTest(t testing.TB, base *Error, details map[string]any) *Error {
+	t.Helper()
+	detailed, err := WithDetails(base, details)
+	require.NoError(t, err)
+	return detailed
 }
 
 func TestSentinelCodes(t *testing.T) {

--- a/pkg/errcode/status.go
+++ b/pkg/errcode/status.go
@@ -197,6 +197,7 @@ var codeToStatus = map[Code]int{
 	ErrAdapterEndpointNotTLS:    http.StatusInternalServerError,
 	ErrListenerAuthChainMissing: http.StatusInternalServerError,
 	ErrWebsocketOriginsMissing:  http.StatusInternalServerError,
+	ErrWebsocketOriginsInvalid:  http.StatusInternalServerError,
 
 	// --- Auth replay / nonce-store codes ---
 	// ErrAuthReplayDetected is a security signal: the nonce has already been

--- a/pkg/errcode/status.go
+++ b/pkg/errcode/status.go
@@ -198,6 +198,7 @@ var codeToStatus = map[Code]int{
 	ErrListenerAuthChainMissing: http.StatusInternalServerError,
 	ErrWebsocketOriginsMissing:  http.StatusInternalServerError,
 	ErrWebsocketOriginsInvalid:  http.StatusInternalServerError,
+	ErrWebsocketHubMissing:      http.StatusInternalServerError,
 
 	// --- Auth replay / nonce-store codes ---
 	// ErrAuthReplayDetected is a security signal: the nonce has already been

--- a/pkg/httputil/decode.go
+++ b/pkg/httputil/decode.go
@@ -62,42 +62,27 @@ func decodeJSON(r *http.Request, dst any, strict bool) error {
 		if isMaxBytesError(err) {
 			return errcode.New(errcode.ErrBodyTooLarge, "request body too large")
 		}
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrValidationFailed, msgInvalidRequestBody),
-			map[string]any{"reason": "trailing content after JSON value"},
-		)
+		return validationFailedWithDetails(map[string]any{"reason": "trailing content after JSON value"})
 	}
 	return nil
 }
 
-func classifyDecodeError(err error) *errcode.Error {
+func classifyDecodeError(err error) error {
 	switch {
 	case errors.Is(err, io.EOF):
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrValidationFailed, msgInvalidRequestBody),
-			map[string]any{"reason": "empty body"},
-		)
+		return validationFailedWithDetails(map[string]any{"reason": "empty body"})
 	case errors.Is(err, io.ErrUnexpectedEOF):
-		return errcode.WithDetails(
-			errcode.New(errcode.ErrValidationFailed, msgInvalidRequestBody),
-			map[string]any{"reason": "malformed JSON"},
-		)
+		return validationFailedWithDetails(map[string]any{"reason": "malformed JSON"})
 	case isMaxBytesError(err):
 		return errcode.New(errcode.ErrBodyTooLarge, "request body too large")
 	default:
 		var syntaxErr *json.SyntaxError
 		if errors.As(err, &syntaxErr) {
-			return errcode.WithDetails(
-				errcode.New(errcode.ErrValidationFailed, msgInvalidRequestBody),
-				map[string]any{"reason": "malformed JSON", "offset": syntaxErr.Offset},
-			)
+			return validationFailedWithDetails(map[string]any{"reason": "malformed JSON", "offset": syntaxErr.Offset})
 		}
 		var typeErr *json.UnmarshalTypeError
 		if errors.As(err, &typeErr) {
-			return errcode.WithDetails(
-				errcode.New(errcode.ErrValidationFailed, msgInvalidRequestBody),
-				map[string]any{"reason": "type mismatch", "field": typeErr.Field},
-			)
+			return validationFailedWithDetails(map[string]any{"reason": "type mismatch", "field": typeErr.Field})
 		}
 		// Go's json.Decoder.DisallowUnknownFields() produces:
 		//   fmt.Errorf("json: unknown field %q", key)
@@ -105,13 +90,21 @@ func classifyDecodeError(err error) *errcode.Error {
 		// Guard test: TestDecodeJSON_GoStdlibUnknownFieldFormat.
 		if after, ok := strings.CutPrefix(err.Error(), unknownFieldPrefix); ok {
 			field := strings.Trim(after, `"`)
-			return errcode.WithDetails(
-				errcode.New(errcode.ErrValidationFailed, msgInvalidRequestBody),
-				map[string]any{"reason": "unknown field", "field": field},
-			)
+			return validationFailedWithDetails(map[string]any{"reason": "unknown field", "field": field})
 		}
 		return errcode.Wrap(errcode.ErrInternal, "internal server error", err)
 	}
+}
+
+func validationFailedWithDetails(details map[string]any) error {
+	detailed, err := errcode.WithDetails(
+		errcode.New(errcode.ErrValidationFailed, msgInvalidRequestBody),
+		details,
+	)
+	if err != nil {
+		return err
+	}
+	return detailed
 }
 
 func isMaxBytesError(err error) bool {

--- a/pkg/httputil/response_test.go
+++ b/pkg/httputil/response_test.go
@@ -380,7 +380,7 @@ func TestWriteDomainError_PlainError(t *testing.T) {
 }
 
 func TestWriteDomainError_WithDetails(t *testing.T) {
-	ecErr := errcode.WithDetails(
+	ecErr := errWithDetails(t,
 		errcode.New(errcode.ErrValidationFailed, "field missing"),
 		map[string]any{"field": "email"},
 	)
@@ -419,7 +419,7 @@ func TestWriteDomainError_5xx_HidesMessage(t *testing.T) {
 		},
 		{
 			name:     "500 with Details - still hides message and code",
-			err:      errcode.WithDetails(errcode.New(errcode.ErrBusClosed, "bus is closed"), map[string]any{"bus": "main"}),
+			err:      errWithDetails(t, errcode.New(errcode.ErrBusClosed, "bus is closed"), map[string]any{"bus": "main"}),
 			wantCode: string(errcode.ErrInternal),
 			wantMsg:  "internal server error",
 		},
@@ -605,7 +605,7 @@ func TestWriteDecodeError_Details(t *testing.T) {
 	}{
 		{
 			name: "4xx with details passes through",
-			err: errcode.WithDetails(
+			err: errWithDetails(t,
 				errcode.New(errcode.ErrValidationFailed, "invalid request body"),
 				map[string]any{"reason": "empty body"},
 			),
@@ -622,7 +622,7 @@ func TestWriteDecodeError_Details(t *testing.T) {
 		},
 		{
 			name: "unknown field includes field name",
-			err: errcode.WithDetails(
+			err: errWithDetails(t,
 				errcode.New(errcode.ErrValidationFailed, "invalid request body"),
 				map[string]any{"reason": "unknown field", "field": "foo"},
 			),
@@ -632,7 +632,7 @@ func TestWriteDecodeError_Details(t *testing.T) {
 		},
 		{
 			name: "413 with details passes through",
-			err: errcode.WithDetails(
+			err: errWithDetails(t,
 				errcode.New(errcode.ErrBodyTooLarge, "request body too large"),
 				map[string]any{"maxBytes": float64(1048576)},
 			),
@@ -642,7 +642,7 @@ func TestWriteDecodeError_Details(t *testing.T) {
 		},
 		{
 			name: "5xx details masked",
-			err: errcode.WithDetails(
+			err: errWithDetails(t,
 				errcode.New(errcode.ErrConfigDecryptFailed, "decrypt failed"),
 				map[string]any{"host": "db-3"},
 			),
@@ -1238,4 +1238,11 @@ func TestCodeToStatus_Exhaustive(t *testing.T) {
 		got := MapCodeToStatus(tc.code)
 		assert.Equal(t, tc.want, got, "MapCodeToStatus(%q)", tc.code)
 	}
+}
+
+func errWithDetails(t testing.TB, base *errcode.Error, details map[string]any) error {
+	t.Helper()
+	detailed, err := errcode.WithDetails(base, details)
+	require.NoError(t, err)
+	return detailed
 }

--- a/pkg/idutil/id.go
+++ b/pkg/idutil/id.go
@@ -48,14 +48,15 @@ func IsSafeID(s string) bool {
 
 // NewUUID generates a UUID v4 string using crypto/rand.
 // crypto/rand.Read always succeeds in Go 1.24+; it calls runtime.fatal
-// on OS entropy failure rather than returning an error.
-func NewUUID() string {
+// on OS entropy failure rather than returning an error, but the error return
+// keeps callers honest if that contract changes.
+func NewUUID() (string, error) {
 	var buf [16]byte
 	if _, err := rand.Read(buf[:]); err != nil {
-		panic("idutil: crypto/rand.Read failed: " + err.Error())
+		return "", fmt.Errorf("idutil: crypto/rand.Read: %w", err)
 	}
 	buf[6] = (buf[6] & 0x0f) | 0x40 // version 4
 	buf[8] = (buf[8] & 0x3f) | 0x80 // variant 10
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16]), nil
 }

--- a/pkg/idutil/id_test.go
+++ b/pkg/idutil/id_test.go
@@ -58,7 +58,8 @@ func TestMaxMetadataIDLen(t *testing.T) {
 }
 
 func TestNewUUID_Format(t *testing.T) {
-	id := NewUUID()
+	id, err := NewUUID()
+	require.NoError(t, err)
 	assert.Len(t, id, 36, "UUID must be 36 chars: 8-4-4-4-12")
 
 	// Dash positions: 8, 13, 18, 23
@@ -77,7 +78,8 @@ func TestNewUUID_Format(t *testing.T) {
 func TestNewUUID_Uniqueness(t *testing.T) {
 	seen := make(map[string]struct{}, 1000)
 	for range 1000 {
-		id := NewUUID()
+		id, err := NewUUID()
+		require.NoError(t, err)
 		_, dup := seen[id]
 		require.False(t, dup, "duplicate UUID: %s", id)
 		seen[id] = struct{}{}
@@ -86,7 +88,8 @@ func TestNewUUID_Uniqueness(t *testing.T) {
 
 func TestNewUUID_PassesIsSafeID(t *testing.T) {
 	for range 100 {
-		id := NewUUID()
+		id, err := NewUUID()
+		require.NoError(t, err)
 		assert.True(t, IsSafeID(id), "generated UUID %q must pass IsSafeID", id)
 		assert.LessOrEqual(t, len(id), MaxHTTPIDLen)
 	}

--- a/pkg/query/cursor.go
+++ b/pkg/query/cursor.go
@@ -178,25 +178,33 @@ const cursorInvalidMsg = "invalid cursor; restart from first page (client should
 // cursorInvalid returns a standardized cursor error with a stable client-facing
 // message and diagnostic reason in the details field. The reason is also set as
 // InternalMessage so it appears in server-side logs via Error().
-func cursorInvalid(reason string) *errcode.Error {
-	return errcode.WithDetails(
+func cursorInvalid(reason string) error {
+	detailed, err := errcode.WithDetails(
 		errcode.Safe(errcode.ErrCursorInvalid, cursorInvalidMsg, reason),
 		map[string]any{"reason": reason})
+	if err != nil {
+		return err
+	}
+	return detailed
 }
 
 // cursorInvalidExtra returns a standardized cursor error with extra diagnostic
 // key-value pairs merged into the details alongside the reason.
 // The "reason" key is set after merging extra, so callers cannot accidentally
 // overwrite it.
-func cursorInvalidExtra(reason string, extra map[string]any) *errcode.Error {
+func cursorInvalidExtra(reason string, extra map[string]any) error {
 	details := make(map[string]any, len(extra)+1)
 	for k, v := range extra {
 		details[k] = v
 	}
 	details["reason"] = reason // set last — cannot be overwritten by extra
-	return errcode.WithDetails(
+	detailed, err := errcode.WithDetails(
 		errcode.Safe(errcode.ErrCursorInvalid, cursorInvalidMsg, reason),
 		details)
+	if err != nil {
+		return err
+	}
+	return detailed
 }
 
 // ValidateCursorScope checks that the decoded cursor carries the expected sort

--- a/runtime/auth/guard_test.go
+++ b/runtime/auth/guard_test.go
@@ -99,7 +99,9 @@ func TestRequirePolicy_LegacySecuredBehavior(t *testing.T) {
 			w := httptest.NewRecorder()
 			r := buildRequest(TestContext("user-1", []string{"admin"}))
 
-			h := RequirePolicy(tc.policy)(inner)
+			middleware, err := RequirePolicy(tc.policy)
+			require.NoError(t, err)
+			h := middleware(inner)
 			h.ServeHTTP(w, r)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -113,12 +115,14 @@ func TestRequirePolicy_LegacySecuredBehavior(t *testing.T) {
 	}
 }
 
-// TestRequirePolicy_NilPolicy_Panics verifies that passing a nil policy to
-// RequirePolicy panics immediately at wrap time, making misuse detectable at
-// startup/test rather than silently skipping authorization at request time.
-func TestRequirePolicy_NilPolicy_Panics(t *testing.T) {
-	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
-	require.Panics(t, func() { RequirePolicy(nil)(inner) })
+// TestRequirePolicy_NilPolicy_ReturnsError verifies that passing a nil policy
+// to RequirePolicy is rejected at wrap time rather than silently skipping
+// authorization at request time.
+func TestRequirePolicy_NilPolicy_ReturnsError(t *testing.T) {
+	middleware, err := RequirePolicy(nil)
+	require.Error(t, err)
+	assert.Nil(t, middleware)
+	assert.Contains(t, err.Error(), "policy must not be nil")
 }
 
 // --- TestAuthenticated ---

--- a/runtime/auth/mount_support.go
+++ b/runtime/auth/mount_support.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/httputil"
@@ -29,16 +30,13 @@ var validRouteMethods = map[string]bool{
 // error via httputil.WriteDomainError and short-circuits the chain; on
 // success it delegates to next.
 //
-// A nil policy panics at wrap time — failing fast during startup/test is
-// preferred over silently skipping authorization at request time.
-//
 // ref: grpc-ecosystem/go-grpc-middleware auth.UnaryServerInterceptor —
 // policy is declared at registration time, not inside the handler body.
 // ref: go-chi/jwtauth Authenticator — short-circuit pattern with response
 // written inside the guard.
-func RequirePolicy(p Policy) func(http.Handler) http.Handler {
+func RequirePolicy(p Policy) (func(http.Handler) http.Handler, error) {
 	if p == nil {
-		panic("auth.RequirePolicy: policy must not be nil")
+		return nil, fmt.Errorf("auth.RequirePolicy: policy must not be nil")
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,5 +46,5 @@ func RequirePolicy(p Policy) func(http.Handler) http.Handler {
 			}
 			next.ServeHTTP(w, r)
 		})
-	}
+	}, nil
 }

--- a/runtime/auth/refresh/memstore/store.go
+++ b/runtime/auth/refresh/memstore/store.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/google/uuid"
 )
@@ -71,7 +72,7 @@ type store struct {
 // policy.ReuseInterval is negative. If randReader is nil, crypto/rand.Reader
 // is used.
 func New(policy refresh.Policy, clock refresh.Clock, randReader io.Reader) (refresh.Store, error) {
-	if clock == nil {
+	if validation.IsNilInterface(clock) {
 		return nil, errcode.New(errcode.ErrValidationFailed, "memstore.New: clock must not be nil")
 	}
 	if policy.MaxAge <= 0 {
@@ -80,7 +81,7 @@ func New(policy refresh.Policy, clock refresh.Clock, randReader io.Reader) (refr
 	if policy.ReuseInterval < 0 {
 		return nil, errcode.New(errcode.ErrValidationFailed, "memstore.New: policy.ReuseInterval must not be negative")
 	}
-	if randReader == nil {
+	if validation.IsNilInterface(randReader) {
 		randReader = rand.Reader
 	}
 	return &store{policy: policy, clock: clock, rand: randReader}, nil

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -1,6 +1,8 @@
 package memstore_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -12,6 +14,20 @@ import (
 
 // baseTime is the synthetic epoch for all FakeClocks in this test file.
 var baseTime = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+var errTypedNilReaderUsed = errors.New("typed nil reader should have been defaulted")
+
+type typedNilClock struct{}
+
+func (*typedNilClock) Now() time.Time {
+	return baseTime
+}
+
+type typedNilReader struct{}
+
+func (*typedNilReader) Read([]byte) (int, error) {
+	return 0, errTypedNilReaderUsed
+}
 
 // TestMemStoreContract runs the full C1-C7 contract test suite (T1-T12) against
 // the in-memory store. In the TDD red phase the memstore stubs return nil/nil,
@@ -57,6 +73,33 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 			require.Nil(t, store)
 		})
 	}
+}
+
+func TestNewRejectsTypedNilClock(t *testing.T) {
+	var clock *typedNilClock
+	store, err := memstore.New(
+		refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour},
+		clock,
+		nil,
+	)
+	require.Error(t, err)
+	require.Nil(t, store)
+}
+
+func TestNewDefaultsTypedNilRandReader(t *testing.T) {
+	clock := storetest.NewFakeClock(baseTime)
+	var reader *typedNilReader
+
+	store, err := memstore.New(
+		refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour},
+		clock,
+		reader,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	_, _, err = store.Issue(context.Background(), "session-1", "subject-1")
+	require.NoError(t, err)
 }
 
 func TestMustNewPanicsOnInvalidConfig(t *testing.T) {

--- a/runtime/auth/route.go
+++ b/runtime/auth/route.go
@@ -97,7 +97,11 @@ func Mount(mux cell.RouteHandler, r Route) error {
 
 	handler := r.Handler
 	if r.Policy != nil {
-		handler = RequirePolicy(r.Policy)(handler)
+		middleware, err := RequirePolicy(r.Policy)
+		if err != nil {
+			return fmt.Errorf("auth.Mount: %w", err)
+		}
+		handler = middleware(handler)
 	}
 	// wrapper.HTTPHandler is a pure ctx contributor (round-4) — it writes
 	// ContractID + contract attrs into ctx so the outer middleware.Tracing

--- a/runtime/auth/route_test.go
+++ b/runtime/auth/route_test.go
@@ -227,10 +227,11 @@ func TestMustMount_PanicsOnNilHandler(t *testing.T) {
 	MustMount(newCaptureMux(), Route{Contract: loginContractSpec()})
 }
 
-func TestRequirePolicy_NilPanics(t *testing.T) {
-	assert.PanicsWithValue(t, "auth.RequirePolicy: policy must not be nil", func() {
-		RequirePolicy(nil)
-	})
+func TestRequirePolicy_NilReturnsError(t *testing.T) {
+	middleware, err := RequirePolicy(nil)
+	require.Error(t, err)
+	assert.Nil(t, middleware)
+	assert.Contains(t, err.Error(), "policy must not be nil")
 }
 
 // prefixedCaptureMux is a test double that extends captureMux with a fixed

--- a/runtime/distlock/locker.go
+++ b/runtime/distlock/locker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
 )
 
 // Locker acquires named distributed locks.
@@ -100,7 +101,7 @@ type lockerImpl struct {
 //
 // ref: plan "共享 manager goroutine" section
 func New(driver Driver, opts ...Option) (Locker, error) {
-	if driver == nil {
+	if validation.IsNilInterface(driver) {
 		return nil, errcode.New(errcode.ErrValidationFailed, "distlock.New: driver must not be nil")
 	}
 	cfg := defaultConfig()

--- a/runtime/distlock/locker_test.go
+++ b/runtime/distlock/locker_test.go
@@ -33,6 +33,20 @@ func newTestLocker(fc *locktest.FakeClock, fd *locktest.FakeDriver) distlock.Loc
 	return distlock.MustNew(fd, distlock.WithClock(fc))
 }
 
+type typedNilDriver struct{}
+
+func (*typedNilDriver) SetNX(context.Context, string, string, time.Duration) (bool, error) {
+	return false, nil
+}
+
+func (*typedNilDriver) Renew(context.Context, string, string, time.Duration) (bool, error) {
+	return false, nil
+}
+
+func (*typedNilDriver) Release(context.Context, string, string) error {
+	return nil
+}
+
 // waitForRenewL waits for Renew count using the locker's manager RenewNotify.
 func waitForRenewL(t *testing.T, l distlock.Locker, fd *locktest.FakeDriver, want int) {
 	t.Helper()
@@ -699,6 +713,17 @@ func TestLocker_New_PanicsOnNilDriver(t *testing.T) {
 		}
 	}()
 	_ = distlock.MustNew(nil)
+}
+
+func TestLocker_New_ReturnsErrorOnTypedNilDriver(t *testing.T) {
+	var driver *typedNilDriver
+	locker, err := distlock.New(driver)
+	if err == nil {
+		t.Fatal("New(typed nil driver) should return error")
+	}
+	if locker != nil {
+		t.Fatalf("New(typed nil driver) locker = %T, want nil", locker)
+	}
 }
 
 // TestLocker_New_PanicsOnInvalidRenewFraction verifies fail-fast validation in New().

--- a/runtime/http/health/wrap.go
+++ b/runtime/http/health/wrap.go
@@ -25,11 +25,9 @@ import (
 //     A pathological probe that calls select{}/for{} still leaks its
 //     goroutine, but the outer contract is structurally preserved so the
 //     aggregator is unaffected and the watcher records the event.
-//   - Panics inside fn propagate out of the goroutine and are surfaced to the
-//     outer call site when the race is won by the probe; runOneProbe's
-//     recover fence catches them just as it would for a non-wrapped Checker.
-//     When the race is won by ctx, a late panic is logged via the watcher
-//     rather than silently discarded.
+//   - Panics inside fn are converted into an unhealthy probe error and logged
+//     when the race is won by the probe. When the race is won by ctx, a late
+//     panic is logged via the watcher rather than silently discarded.
 //
 // wrapCtxSafe intentionally carries no time budget — the only "deadline"
 // relevant here is whatever the caller puts on ctx. Runtime callers
@@ -87,11 +85,18 @@ func wrapCtxSafe(fn Checker) Checker {
 			return ctx.Err()
 		case o := <-done:
 			if o.panicV != nil {
-				return fmt.Errorf("panic: %v", o.panicV)
+				return probePanicError(o.panicV)
 			}
 			return o.err
 		}
 	}
+}
+
+func probePanicError(panicV any) error {
+	slog.Warn("health: probe panicked",
+		slog.Any("panic", panicV),
+	)
+	return fmt.Errorf("panic: %v", panicV)
 }
 
 // watchLateProbeOutcome runs in its own goroutine after the outer Checker

--- a/runtime/http/health/wrap.go
+++ b/runtime/http/health/wrap.go
@@ -87,7 +87,7 @@ func wrapCtxSafe(fn Checker) Checker {
 			return ctx.Err()
 		case o := <-done:
 			if o.panicV != nil {
-				panic(o.panicV)
+				return fmt.Errorf("panic: %v", o.panicV)
 			}
 			return o.err
 		}

--- a/runtime/http/health/wrap_test.go
+++ b/runtime/http/health/wrap_test.go
@@ -94,16 +94,16 @@ func TestWrapCtxSafe_PropagatesError_WhenInnerReturnsFirst(t *testing.T) {
 	}
 }
 
-// TestWrapCtxSafe_PanicBubbles verifies a panic inside inner fn bubbles out
-// to the wrapped call site so that the outer recover fence in runOneProbe
-// can catch it just as it would for an unwrapped Checker.
-func TestWrapCtxSafe_PanicBubbles(t *testing.T) {
+// TestWrapCtxSafe_PanicBecomesError verifies a panic inside inner fn is
+// converted into an unhealthy probe error instead of re-panicking through the
+// wrapper.
+func TestWrapCtxSafe_PanicBecomesError(t *testing.T) {
 	wrapped := wrapCtxSafe(func(_ context.Context) error {
 		panic("boom")
 	})
-	assert.PanicsWithValue(t, "boom", func() {
-		_ = wrapped(context.Background())
-	})
+	err := wrapped(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panic: boom")
 }
 
 // TestWrapCtxSafe_NilInput ensures defensive wrapping of nil returns a

--- a/runtime/http/health/wrap_test.go
+++ b/runtime/http/health/wrap_test.go
@@ -1,8 +1,10 @@
 package health
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -94,16 +96,23 @@ func TestWrapCtxSafe_PropagatesError_WhenInnerReturnsFirst(t *testing.T) {
 	}
 }
 
-// TestWrapCtxSafe_PanicBecomesError verifies a panic inside inner fn is
-// converted into an unhealthy probe error instead of re-panicking through the
-// wrapper.
-func TestWrapCtxSafe_PanicBecomesError(t *testing.T) {
+// TestWrapCtxSafe_PanicBecomesErrorAndLogs verifies a panic inside inner fn is
+// converted into an unhealthy probe error and logged instead of re-panicking
+// through the wrapper.
+func TestWrapCtxSafe_PanicBecomesErrorAndLogs(t *testing.T) {
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
 	wrapped := wrapCtxSafe(func(_ context.Context) error {
 		panic("boom")
 	})
 	err := wrapped(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "panic: boom")
+	assert.Contains(t, logs.String(), "health: probe panicked")
+	assert.Contains(t, logs.String(), "boom")
 }
 
 // TestWrapCtxSafe_NilInput ensures defensive wrapping of nil returns a

--- a/runtime/http/middleware/request_id.go
+++ b/runtime/http/middleware/request_id.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/idutil"
 )
 
@@ -19,14 +21,12 @@ const headerRequestID = "X-Request-Id"
 // tracing correlation. The ID is echoed back in the response header.
 func RequestID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := r.Header.Get(headerRequestID)
-		if id == "" || len(id) > idutil.MaxHTTPIDLen || !idutil.IsSafeID(id) {
-			id = idutil.NewUUID()
+		id, err := requestIDFromHeader(r.Header.Get(headerRequestID))
+		if err != nil {
+			httputil.WriteDomainError(r.Context(), w, err)
+			return
 		}
-		w.Header().Set(headerRequestID, id)
-		ctx := ctxkeys.WithRequestID(r.Context(), id)
-		ctx = ctxkeys.WithCorrelationID(ctx, id)
-		next.ServeHTTP(w, r.WithContext(ctx))
+		serveWithRequestID(w, r, next, id)
 	})
 }
 
@@ -58,22 +58,41 @@ func RequestIDWithOptions(opts ...RequestIDOption) func(http.Handler) http.Handl
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			isPublic := cfg.publicEndpointFn != nil && cfg.publicEndpointFn(r)
-
-			var id string
-			if isPublic {
-				id = idutil.NewUUID()
-			} else {
-				id = r.Header.Get(headerRequestID)
-				if id == "" || len(id) > idutil.MaxHTTPIDLen || !idutil.IsSafeID(id) {
-					id = idutil.NewUUID()
-				}
+			id, err := requestIDForRequest(r, cfg)
+			if err != nil {
+				httputil.WriteDomainError(r.Context(), w, err)
+				return
 			}
-
-			w.Header().Set(headerRequestID, id)
-			ctx := ctxkeys.WithRequestID(r.Context(), id)
-			ctx = ctxkeys.WithCorrelationID(ctx, id)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			serveWithRequestID(w, r, next, id)
 		})
 	}
+}
+
+func requestIDForRequest(r *http.Request, cfg requestIDConfig) (string, error) {
+	if cfg.publicEndpointFn != nil && cfg.publicEndpointFn(r) {
+		return newRequestID()
+	}
+	return requestIDFromHeader(r.Header.Get(headerRequestID))
+}
+
+func requestIDFromHeader(id string) (string, error) {
+	if id == "" || len(id) > idutil.MaxHTTPIDLen || !idutil.IsSafeID(id) {
+		return newRequestID()
+	}
+	return id, nil
+}
+
+func newRequestID() (string, error) {
+	id, err := idutil.NewUUID()
+	if err != nil {
+		return "", errcode.Wrap(errcode.ErrInternal, "request id: generate uuid", err)
+	}
+	return id, nil
+}
+
+func serveWithRequestID(w http.ResponseWriter, r *http.Request, next http.Handler, id string) {
+	w.Header().Set(headerRequestID, id)
+	ctx := ctxkeys.WithRequestID(r.Context(), id)
+	ctx = ctxkeys.WithCorrelationID(ctx, id)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/tests/integration/outbox_failure_paths_test.go
+++ b/tests/integration/outbox_failure_paths_test.go
@@ -217,7 +217,7 @@ func runRelay(t *testing.T, relay *outboxruntime.Relay) (stop func()) {
 func setupPGOnly(t *testing.T) (*postgres.Pool, func()) {
 	t.Helper()
 	pool, cleanup := setupPostgresContainer(t)
-	migrator, err := postgres.NewMigrator(pool, postgres.MigrationsFS(), "schema_migrations")
+	migrator, err := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "NewMigrator")
 	require.NoError(t, migrator.Up(context.Background()), "migrations must apply")
 	return pool, cleanup

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -204,7 +204,7 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 	// ---------------------------------------------------------------
 	// Step 2: Run migrations to create outbox_entries table.
 	// ---------------------------------------------------------------
-	migrator, mErr := postgres.NewMigrator(pool, postgres.MigrationsFS(), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
 	require.NoError(t, mErr, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
@@ -467,7 +467,7 @@ func TestIntegration_OutboxFullChain_NoTrace(t *testing.T) {
 	// ---------------------------------------------------------------
 	// Step 2: Run migrations.
 	// ---------------------------------------------------------------
-	migrator, mErr := postgres.NewMigrator(pool, postgres.MigrationsFS(), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
 	require.NoError(t, mErr, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
@@ -642,7 +642,7 @@ func TestIntegration_OutboxWriteRelayMockPublisher(t *testing.T) {
 	defer cleanup()
 
 	// Run migrations.
-	migrator, mErr := postgres.NewMigrator(pool, postgres.MigrationsFS(), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
 	require.NoError(t, mErr, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
@@ -729,7 +729,7 @@ func TestIntegration_OutboxObservability_ZeroRoundtrip(t *testing.T) {
 	pool, cleanup := setupPostgresContainer(t)
 	defer cleanup()
 
-	migrator, mErr := postgres.NewMigrator(pool, postgres.MigrationsFS(), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
 	require.NoError(t, mErr)
 	require.NoError(t, migrator.Up(ctx))
 

--- a/tests/integration/postgres_helpers_test.go
+++ b/tests/integration/postgres_helpers_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package integration
+
+import (
+	"io/fs"
+	"testing"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func testPostgresMigrationsFS(t testing.TB) fs.FS {
+	t.Helper()
+	fsys, err := adapterpg.MigrationsFS()
+	require.NoError(t, err)
+	return fsys
+}

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -5,10 +5,16 @@ package archtest
 //     exported and unexported function declarations whose return signature
 //     does NOT include an error MUST NOT contain a `panic(...)` call in the
 //     function body.
-//   - ERROR-FIRST-TYPED-NIL-01: error-returning New* constructors in the same
-//     file scope must validate interface dependencies with
-//     validation.IsNilInterface so typed-nil implementations fail at construction
-//     time, or are normalized through the constructor's optional-default path.
+//   - ERROR-FIRST-TYPED-NIL-01: error-returning New* constructors in the
+//     enrolled file scope must nil-guard each nil-able dependency parameter at
+//     construction time. Interface params must be guarded with
+//     validation.IsNilInterface(p) (typed-nil defeat); pointer / map / chan /
+//     func params may use p == nil. The guard must appear as the if-Cond
+//     (top-level || branches accepted; && / unary ! rejected) with a
+//     then-branch that returns or assigns p (defaulting). FuncLit bodies are
+//     stop-descend — deferred returns inside goroutines / closures do not
+//     satisfy the constructor's outer fail-fast contract. Slice and generic
+//     type-parameter params are intentionally outside scope.
 //
 // Auto-exemptions:
 //   - Function name starts with "Must" (Go community convention for the
@@ -141,8 +147,9 @@ func TestErrorFirstTypedNil01(t *testing.T) {
 		}
 	}
 	assert.Empty(t, violations,
-		"%s: error-first constructors must validate interface dependencies with "+
-			"validation.IsNilInterface(param), so typed-nil implementations fail at construction time",
+		"%s: error-first constructors must guard each nil-able dependency at construction time. "+
+			"Interface params: validation.IsNilInterface(p); pointer/map/chan/func params: p == nil. "+
+			"Guard must be the if-Cond (top-level || allowed) with then doing return or assignment to p.",
 		ruleErrorFirstTypedNil01)
 }
 
@@ -207,6 +214,139 @@ type Service struct{}`,
 			src: `package p
 type Dep interface{ Do() }
 func Build(dep Dep) (*Service, error) {
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "negative: IsNilInterface result discarded fails",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	_ = validation.IsNilInterface(dep)
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{4},
+		},
+		{
+			name: "negative: IsNilInterface inside non-if call fails",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+func sink(bool) {}
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	sink(validation.IsNilInterface(dep))
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{5},
+		},
+		{
+			name: "negative: if cond matches but then neither returns nor assigns dep",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	if validation.IsNilInterface(dep) {
+		_ = 1
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{4},
+		},
+		{
+			name: "negative: then handles nil only inside goroutine FuncLit fails",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	if validation.IsNilInterface(dep) {
+		go func() { _ = 1 }()
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{4},
+		},
+		{
+			name: "negative: && compound does not fail-fast on nil dep",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep, strict bool) (*Service, error) {
+	if validation.IsNilInterface(dep) && strict {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{4},
+		},
+		{
+			name: "positive: pointer dependency with == nil guard passes",
+			src: `package p
+type Pool struct{}
+func New(pool *Pool) (*Service, error) {
+	if pool == nil {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "positive: || compound IsNilInterface with return passes",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep, strict bool) (*Service, error) {
+	if validation.IsNilInterface(dep) || strict {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "positive: map dependency with == nil guard passes",
+			src: `package p
+func New(routes map[string]int) (*Service, error) {
+	if routes == nil {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "positive: chan dependency with == nil guard passes",
+			src: `package p
+func New(events chan int) (*Service, error) {
+	if events == nil {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "positive: func dependency with == nil guard passes",
+			src: `package p
+func New(handler func() error) (*Service, error) {
+	if handler == nil {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "positive: slice dependency is not in nil-able rule scope",
+			src: `package p
+func New(items []int) (*Service, error) {
 	return &Service{}, nil
 }
 type Service struct{}`,
@@ -314,15 +454,15 @@ func scanTypedNilGuardsInFile(fset *token.FileSet, info *types.Info, file *ast.F
 		if !ok || fd.Body == nil || !isErrorFirstConstructor(fd) {
 			continue
 		}
-		for _, paramName := range interfaceParamNames(info, fd) {
-			if hasValidationIsNilInterfaceGuard(fd.Body, paramName) {
+		for _, param := range nillableDependencyParams(info, fd) {
+			if hasNilGuard(fd.Body, param.name, param.kind) {
 				continue
 			}
 			violations = append(violations, errorFirstViolation{
 				File:     rel,
 				Line:     fset.Position(fd.Pos()).Line,
 				FuncName: fd.Name.Name,
-				Reason:   "interface dependency " + paramName + " is not validated with validation.IsNilInterface",
+				Reason:   "nil-able dependency " + param.name + " is not guarded at construction time",
 			})
 		}
 	}
@@ -356,57 +496,185 @@ func isErrorFirstConstructor(fd *ast.FuncDecl) bool {
 		signatureReturnsError(fd.Type.Results)
 }
 
-func interfaceParamNames(info *types.Info, fd *ast.FuncDecl) []string {
+// paramKind classifies how a function parameter is nil-able for the purposes
+// of ERROR-FIRST-TYPED-NIL-01. Slices are intentionally excluded: nil slice
+// is safe to read (len/range) and treating it as a guard target would produce
+// false positives for every []T parameter. Generic type parameters are also
+// excluded — there is no enforced-scope code using them, and their nil-ability
+// depends on the constraint, not the syntactic form.
+type paramKind int
+
+const (
+	paramNone paramKind = iota
+	paramInterface
+	paramPointerOrNillableConcrete
+)
+
+// paramRef pairs a parameter name with its kind so the rule can pick the
+// right guard form per kind (IsNilInterface for interfaces; == nil acceptable
+// for pointer / map / chan / func).
+type paramRef struct {
+	name string
+	kind paramKind
+}
+
+// nillableParamKind returns the paramKind for a Go type, or paramNone if the
+// type is outside the rule's scope.
+func nillableParamKind(t types.Type) paramKind {
+	if t == nil {
+		return paramNone
+	}
+	switch t.Underlying().(type) {
+	case *types.Interface:
+		return paramInterface
+	case *types.Pointer, *types.Map, *types.Chan, *types.Signature:
+		return paramPointerOrNillableConcrete
+	}
+	return paramNone
+}
+
+// nillableDependencyParams returns the named, nil-able parameters of fd.
+func nillableDependencyParams(info *types.Info, fd *ast.FuncDecl) []paramRef {
 	if info == nil || fd.Type.Params == nil {
 		return nil
 	}
-	var names []string
+	var out []paramRef
 	for _, field := range fd.Type.Params.List {
-		if !isInterfaceType(info.TypeOf(field.Type)) {
+		kind := nillableParamKind(info.TypeOf(field.Type))
+		if kind == paramNone {
 			continue
 		}
 		for _, name := range field.Names {
 			if name.Name == "_" {
 				continue
 			}
-			names = append(names, name.Name)
+			out = append(out, paramRef{name: name.Name, kind: kind})
 		}
 	}
-	return names
+	return out
 }
 
-func isInterfaceType(typ types.Type) bool {
-	if typ == nil {
-		return false
-	}
-	_, ok := typ.Underlying().(*types.Interface)
-	return ok
-}
-
-func hasValidationIsNilInterfaceGuard(body *ast.BlockStmt, paramName string) bool {
+// hasNilGuard returns true if body contains an IfStmt whose Cond is a nil
+// check on paramName AND whose Then-branch surfaces the nil case (return or
+// assignment to paramName for defaulting). Goroutine / closure FuncLit bodies
+// are stop-descend: a deferred return inside a closure does not satisfy the
+// constructor's outer fail-fast contract.
+func hasNilGuard(body *ast.BlockStmt, paramName string, kind paramKind) bool {
 	found := false
 	ast.Inspect(body, func(n ast.Node) bool {
 		if found {
 			return false
 		}
-		call, ok := n.(*ast.CallExpr)
-		if !ok || len(call.Args) != 1 {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
 			return true
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "IsNilInterface" {
+		if !condMatchesNilCheck(ifStmt.Cond, paramName, kind) {
 			return true
 		}
-		pkgIdent, ok := sel.X.(*ast.Ident)
-		if !ok || pkgIdent.Name != "validation" {
-			return true
-		}
-		argIdent, ok := call.Args[0].(*ast.Ident)
-		if !ok || argIdent.Name != paramName {
+		if !thenReturnsOrAssigns(ifStmt.Body, paramName) {
 			return true
 		}
 		found = true
 		return false
+	})
+	return found
+}
+
+// condMatchesNilCheck returns true if expr nil-checks paramName, either as a
+// leaf or as a leaf of a top-level || (LOR) chain. && (LAND) and unary ! are
+// rejected: && lets nil flow past, and ! inverts the fail-fast direction.
+//
+// Leaf forms:
+//   - validation.IsNilInterface(paramName)             (any kind)
+//   - paramName == nil / nil == paramName              (paramPointerOrNillableConcrete only)
+//
+// Interface params reject == nil because typed-nil ((*Concrete)(nil) cast to
+// interface) bypasses the comparison; only IsNilInterface defeats it.
+func condMatchesNilCheck(expr ast.Expr, paramName string, kind paramKind) bool {
+	switch e := expr.(type) {
+	case *ast.ParenExpr:
+		return condMatchesNilCheck(e.X, paramName, kind)
+	case *ast.BinaryExpr:
+		if e.Op == token.LOR {
+			return condMatchesNilCheck(e.X, paramName, kind) ||
+				condMatchesNilCheck(e.Y, paramName, kind)
+		}
+		if e.Op == token.EQL && kind == paramPointerOrNillableConcrete {
+			return isNilEquality(e, paramName)
+		}
+		return false
+	case *ast.CallExpr:
+		return isValidationIsNilInterfaceCall(e, paramName)
+	}
+	return false
+}
+
+// isNilEquality returns true if e is `paramName == nil` or `nil == paramName`.
+func isNilEquality(e *ast.BinaryExpr, paramName string) bool {
+	if e.Op != token.EQL {
+		return false
+	}
+	if isIdentNamed(e.X, paramName) && isNilIdent(e.Y) {
+		return true
+	}
+	if isIdentNamed(e.Y, paramName) && isNilIdent(e.X) {
+		return true
+	}
+	return false
+}
+
+func isIdentNamed(e ast.Expr, name string) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == name
+}
+
+// isValidationIsNilInterfaceCall returns true if call is exactly
+// validation.IsNilInterface(paramName) — single argument, named param, fixed
+// selector path. Aliasing the validation package is not currently used in the
+// repo and would be a deliberate workaround.
+func isValidationIsNilInterfaceCall(call *ast.CallExpr, paramName string) bool {
+	if len(call.Args) != 1 {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "IsNilInterface" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "validation" {
+		return false
+	}
+	arg, ok := call.Args[0].(*ast.Ident)
+	return ok && arg.Name == paramName
+}
+
+// thenReturnsOrAssigns returns true if body contains a top-level (non-FuncLit)
+// ReturnStmt or an AssignStmt whose LHS includes paramName (defaulting). The
+// FuncLit stop-descend prevents `if cond { go func() { return }() }` from
+// satisfying the constructor's outer contract.
+func thenReturnsOrAssigns(body *ast.BlockStmt, paramName string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if _, isFuncLit := n.(*ast.FuncLit); isFuncLit {
+			return false
+		}
+		switch s := n.(type) {
+		case *ast.ReturnStmt:
+			found = true
+			return false
+		case *ast.AssignStmt:
+			for _, lhs := range s.Lhs {
+				if isIdentNamed(lhs, paramName) {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
 	})
 	return found
 }

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -351,6 +351,52 @@ func New(items []int) (*Service, error) {
 }
 type Service struct{}`,
 		},
+		{
+			name: "negative: then handles nil only inside defer FuncLit fails",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	if validation.IsNilInterface(dep) {
+		defer func() { _ = 1 }()
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{4},
+		},
+		{
+			name: "negative: aliased validation pkg is not recognized as guard (known-gap)",
+			src: `package p
+var val = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	if val.IsNilInterface(dep) {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{4},
+		},
+		{
+			name: "positive: unnamed (type-only) param is intentionally outside rule scope",
+			src: `package p
+type Dep interface{ Do() }
+func New(Dep) (*Service, error) {
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "positive: blank-name (_) param is intentionally outside rule scope",
+			src: `package p
+type Dep interface{ Do() }
+func New(_ Dep) (*Service, error) {
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -534,6 +580,11 @@ func nillableParamKind(t types.Type) paramKind {
 }
 
 // nillableDependencyParams returns the named, nil-able parameters of fd.
+// Unnamed (type-only) parameters like `func New(Dep) (*S, error)` are
+// intentionally skipped — they cannot be referred to in a guard expression,
+// so the rule has no symbol to verify; constructors that require such a
+// parameter for ergonomic reasons should name it (`func New(_ Dep)` is also
+// skipped on purpose because `_` is unaddressable).
 func nillableDependencyParams(info *types.Info, fd *ast.FuncDecl) []paramRef {
 	if info == nil || fd.Type.Params == nil {
 		return nil
@@ -631,8 +682,14 @@ func isIdentNamed(e ast.Expr, name string) bool {
 
 // isValidationIsNilInterfaceCall returns true if call is exactly
 // validation.IsNilInterface(paramName) — single argument, named param, fixed
-// selector path. Aliasing the validation package is not currently used in the
-// repo and would be a deliberate workaround.
+// selector path on the unaliased "validation" identifier.
+//
+// known-gap: aliased imports (e.g. `import val "github.com/.../pkg/validation"`
+// + `val.IsNilInterface(p)`) are not recognized as a guard; the alias would
+// surface as a violation report. This is by design — every IsNilInterface
+// call in the enrolled scope uses the unaliased package, and matching aliases
+// would require types.Info-level package resolution that adds cost without
+// covering a real-world need.
 func isValidationIsNilInterfaceCall(call *ast.CallExpr, paramName string) bool {
 	if len(call.Args) != 1 {
 		return false

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -87,16 +87,6 @@ var errorFirstEnforcedFiles = []string{
 	"adapters/postgres/refresh_store.go",
 }
 
-// errorFirstWhitelistedFunctions maps "<rel-path>::<funcName>" to a
-// justification. The rule SCANS the file but skips only the listed function;
-// any other error-less function in the same file that contains panic() is
-// still reported as a violation. ADR-pinned in
-// docs/architecture/202604270030-architectural-panic-whitelist.md (§4).
-var errorFirstWhitelistedFunctions = map[string]string{
-	"kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor":              "re-panics from defer recover so outer Recovery middleware can serialize the panic",
-	"runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure": "re-panics from defer recover after reporting circuit-breaker failure",
-}
-
 // errorFirstViolation describes a single ERROR-FIRST-API-01 violation.
 type errorFirstViolation struct {
 	File     string // relative slash path from module root
@@ -213,7 +203,7 @@ func scanFileForErrorFirstViolations(t *testing.T, abs, rel string) []errorFirst
 			continue
 		}
 		whitelistKey := rel + "::" + fd.Name.Name
-		if _, whitelisted := errorFirstWhitelistedFunctions[whitelistKey]; whitelisted {
+		if _, whitelisted := architecturalPanicWhitelist[whitelistKey]; whitelisted {
 			continue
 		}
 		findPanicCalls(fd.Body, func(callPos token.Pos) {

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -1,9 +1,14 @@
 package archtest
 
-// error_first_test.go enforces ERROR-FIRST-API-01: in the explicitly enrolled
-// files (PR-MODE-6 scope), exported and unexported function declarations whose
-// return signature does NOT include an error MUST NOT contain a `panic(...)`
-// call in the function body.
+// error_first_test.go enforces:
+//   - ERROR-FIRST-API-01: in the explicitly enrolled files (PR-MODE-6 scope),
+//     exported and unexported function declarations whose return signature
+//     does NOT include an error MUST NOT contain a `panic(...)` call in the
+//     function body.
+//   - ERROR-FIRST-TYPED-NIL-01: error-returning New* constructors in the same
+//     file scope must validate interface dependencies with
+//     validation.IsNilInterface so typed-nil implementations fail at construction
+//     time, or are normalized through the constructor's optional-default path.
 //
 // Auto-exemptions:
 //   - Function name starts with "Must" (Go community convention for the
@@ -47,12 +52,16 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
+	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 const ruleErrorFirstAPI01 = "ERROR-FIRST-API-01"
@@ -95,43 +104,6 @@ type errorFirstViolation struct {
 	Reason   string
 }
 
-type typedNilConstructorRule struct {
-	File       string
-	FuncName   string
-	ParamNames []string
-}
-
-var typedNilConstructorRules = []typedNilConstructorRule{
-	{
-		File:     "cells/accesscore/slices/sessionlogin/service.go",
-		FuncName: "NewService",
-		ParamNames: []string{
-			"userRepo",
-			"sessionRepo",
-			"roleRepo",
-			"refreshStore",
-		},
-	},
-	{
-		File:     "cells/accesscore/slices/sessionrefresh/service.go",
-		FuncName: "NewService",
-		ParamNames: []string{
-			"sessionRepo",
-			"roleRepo",
-			"userRepo",
-			"refreshStore",
-		},
-	},
-	{
-		File:     "cells/accesscore/slices/sessionlogout/service.go",
-		FuncName: "NewService",
-		ParamNames: []string{
-			"sessionRepo",
-			"refreshStore",
-		},
-	},
-}
-
 // TestErrorFirstAPI01 walks the enforced file list and reports panic() calls
 // inside error-less function declarations.
 func TestErrorFirstAPI01(t *testing.T) {
@@ -160,11 +132,7 @@ func TestErrorFirstAPI01(t *testing.T) {
 func TestErrorFirstTypedNil01(t *testing.T) {
 	root := findModuleRoot(t)
 
-	var violations []errorFirstViolation
-	for _, rule := range typedNilConstructorRules {
-		abs := filepath.Join(root, filepath.FromSlash(rule.File))
-		violations = append(violations, scanConstructorForTypedNilGuards(t, abs, rule)...)
-	}
+	violations := scanErrorFirstConstructorsForTypedNilGuards(t, root)
 
 	if len(violations) > 0 {
 		t.Logf("%s: %d violation(s):", ruleErrorFirstTypedNil01, len(violations))
@@ -176,6 +144,97 @@ func TestErrorFirstTypedNil01(t *testing.T) {
 		"%s: error-first constructors must validate interface dependencies with "+
 			"validation.IsNilInterface(param), so typed-nil implementations fail at construction time",
 		ruleErrorFirstTypedNil01)
+}
+
+func TestErrorFirstTypedNilScannerFixtures(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantLines []int
+	}{
+		{
+			name: "constructor interface param without IsNilInterface fails",
+			src: `package p
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	if dep == nil {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+			wantLines: []int{3},
+		},
+		{
+			name: "constructor interface param with IsNilInterface passes",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Dep interface{ Do() }
+func New(dep Dep) (*Service, error) {
+	if validation.IsNilInterface(dep) {
+		return nil, nil
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "optional interface param default with IsNilInterface passes",
+			src: `package p
+var validation = struct{ IsNilInterface func(any) bool }{}
+type Reader interface{ Read([]byte) (int, error) }
+type defaultReader struct{}
+func (defaultReader) Read([]byte) (int, error) { return 0, nil }
+func New(reader Reader) (*Service, error) {
+	if validation.IsNilInterface(reader) {
+		reader = defaultReader{}
+	}
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+		{
+			name: "non error returning constructor is outside error-first typed-nil rule",
+			src: `package p
+type Dep interface{ Do() }
+func New(dep Dep) *Service {
+	return &Service{}
+}
+type Service struct{}`,
+		},
+		{
+			name: "non constructor function is outside typed-nil rule",
+			src: `package p
+type Dep interface{ Do() }
+func Build(dep Dep) (*Service, error) {
+	return &Service{}, nil
+}
+type Service struct{}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "p.go", tc.src, parser.SkipObjectResolution|parser.ParseComments)
+			require.NoError(t, err)
+			info := types.Info{
+				Types: map[ast.Expr]types.TypeAndValue{},
+				Defs:  map[*ast.Ident]types.Object{},
+				Uses:  map[*ast.Ident]types.Object{},
+			}
+			conf := types.Config{Importer: nil}
+			_, err = conf.Check("p", fset, []*ast.File{file}, &info)
+			require.NoError(t, err)
+
+			violations := scanTypedNilGuardsInFile(fset, &info, file, "p.go")
+			var gotLines []int
+			for _, v := range violations {
+				gotLines = append(gotLines, v.Line)
+			}
+			assert.Equal(t, tc.wantLines, gotLines)
+		})
+	}
 }
 
 // scanFileForErrorFirstViolations parses a single Go source file and returns
@@ -218,36 +277,110 @@ func scanFileForErrorFirstViolations(t *testing.T, abs, rel string) []errorFirst
 	return violations
 }
 
-func scanConstructorForTypedNilGuards(t *testing.T, abs string, rule typedNilConstructorRule) []errorFirstViolation {
+func scanErrorFirstConstructorsForTypedNilGuards(t *testing.T, root string) []errorFirstViolation {
 	t.Helper()
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, abs, nil, parser.SkipObjectResolution|parser.ParseComments)
-	require.NoErrorf(t, err, "%s: parse failed", rule.File)
+	pkgs, errs, err := typeseval.LoadPackages(root, errorFirstPackagePatterns()...)
+	require.NoError(t, err, "packages.Load")
+	require.Empty(t, errs, "packages.Load type errors")
 
-	var target *ast.FuncDecl
-	for _, decl := range file.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok || fd.Body == nil || fd.Name.Name != rule.FuncName {
-			continue
-		}
-		target = fd
-		break
-	}
-	require.NotNilf(t, target, "%s: expected function %s", rule.File, rule.FuncName)
-
+	enforced := errorFirstEnforcedFileMap(root)
 	var violations []errorFirstViolation
-	for _, paramName := range rule.ParamNames {
-		if hasValidationIsNilInterfaceGuard(target.Body, paramName) {
-			continue
-		}
-		violations = append(violations, errorFirstViolation{
-			File:     rule.File,
-			Line:     fset.Position(target.Pos()).Line,
-			FuncName: rule.FuncName,
-			Reason:   "interface dependency " + paramName + " is not validated with validation.IsNilInterface",
-		})
+	for _, pkg := range pkgs {
+		violations = append(violations, scanTypedNilGuardsInPackage(pkg, enforced)...)
 	}
 	return violations
+}
+
+func scanTypedNilGuardsInPackage(pkg *packages.Package, enforced map[string]string) []errorFirstViolation {
+	var violations []errorFirstViolation
+	for i, file := range pkg.Syntax {
+		if i >= len(pkg.CompiledGoFiles) {
+			continue
+		}
+		abs := filepath.Clean(pkg.CompiledGoFiles[i])
+		rel, ok := enforced[abs]
+		if !ok {
+			continue
+		}
+		violations = append(violations, scanTypedNilGuardsInFile(pkg.Fset, pkg.TypesInfo, file, rel)...)
+	}
+	return violations
+}
+
+func scanTypedNilGuardsInFile(fset *token.FileSet, info *types.Info, file *ast.File, rel string) []errorFirstViolation {
+	var violations []errorFirstViolation
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil || !isErrorFirstConstructor(fd) {
+			continue
+		}
+		for _, paramName := range interfaceParamNames(info, fd) {
+			if hasValidationIsNilInterfaceGuard(fd.Body, paramName) {
+				continue
+			}
+			violations = append(violations, errorFirstViolation{
+				File:     rel,
+				Line:     fset.Position(fd.Pos()).Line,
+				FuncName: fd.Name.Name,
+				Reason:   "interface dependency " + paramName + " is not validated with validation.IsNilInterface",
+			})
+		}
+	}
+	return violations
+}
+
+func errorFirstPackagePatterns() []string {
+	dirs := make(map[string]struct{})
+	for _, rel := range errorFirstEnforcedFiles {
+		dirs[filepath.Dir(filepath.FromSlash(rel))] = struct{}{}
+	}
+	patterns := make([]string, 0, len(dirs))
+	for dir := range dirs {
+		patterns = append(patterns, "./"+filepath.ToSlash(dir))
+	}
+	sort.Strings(patterns)
+	return patterns
+}
+
+func errorFirstEnforcedFileMap(root string) map[string]string {
+	out := make(map[string]string, len(errorFirstEnforcedFiles))
+	for _, rel := range errorFirstEnforcedFiles {
+		out[filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))] = rel
+	}
+	return out
+}
+
+func isErrorFirstConstructor(fd *ast.FuncDecl) bool {
+	return fd.Recv == nil &&
+		strings.HasPrefix(fd.Name.Name, "New") &&
+		signatureReturnsError(fd.Type.Results)
+}
+
+func interfaceParamNames(info *types.Info, fd *ast.FuncDecl) []string {
+	if info == nil || fd.Type.Params == nil {
+		return nil
+	}
+	var names []string
+	for _, field := range fd.Type.Params.List {
+		if !isInterfaceType(info.TypeOf(field.Type)) {
+			continue
+		}
+		for _, name := range field.Names {
+			if name.Name == "_" {
+				continue
+			}
+			names = append(names, name.Name)
+		}
+	}
+	return names
+}
+
+func isInterfaceType(typ types.Type) bool {
+	if typ == nil {
+		return false
+	}
+	_, ok := typ.Underlying().(*types.Interface)
+	return ok
 }
 
 func hasValidationIsNilInterfaceGuard(body *ast.BlockStmt, paramName string) bool {

--- a/tools/archtest/panic_registered_test.go
+++ b/tools/archtest/panic_registered_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -31,6 +32,12 @@ type panicRegisteredViolation struct {
 	Line     int
 	FuncName string
 	Reason   string
+}
+
+type panicRegisteredScope struct {
+	FuncName     string
+	AllowMust    bool
+	WhitelistKey string
 }
 
 func TestPanicRegistered(t *testing.T) {
@@ -91,6 +98,24 @@ type T struct{}
 func (*T) MustNew() {
 	panic("boom")
 }`,
+		},
+		{
+			name: "package initializer panic fails",
+			src: `package p
+var _ = func() string {
+	panic("boom")
+}()`,
+			wantLines: []int{3},
+		},
+		{
+			name: "nested function literal panic under Must function fails",
+			src: `package p
+func MustNew() func() {
+	return func() {
+		panic("boom")
+	}
+}`,
+			wantLines: []int{4},
 		},
 		{
 			name: "init panic is not auto exempt",
@@ -197,37 +222,91 @@ func scanPanicRegisteredAST(
 	usedWhitelist map[string]bool,
 ) []panicRegisteredViolation {
 	var violations []panicRegisteredViolation
-	for _, decl := range file.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok || fd.Body == nil {
-			continue
+	var scopes []panicRegisteredScope
+	var pushedScopes []bool
+	funcLitCount := 0
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			if len(pushedScopes) == 0 {
+				return true
+			}
+			didPush := pushedScopes[len(pushedScopes)-1]
+			pushedScopes = pushedScopes[:len(pushedScopes)-1]
+			if didPush {
+				scopes = scopes[:len(scopes)-1]
+			}
+			return true
 		}
-		var panicPositions []token.Pos
-		findPanicCalls(fd.Body, func(callPos token.Pos) {
-			panicPositions = append(panicPositions, callPos)
-		})
-		if len(panicPositions) == 0 {
-			continue
-		}
-		if strings.HasPrefix(fd.Name.Name, "Must") {
-			continue
-		}
-		funcName := panicRegisteredFuncName(fd)
-		key := rel + "::" + funcName
-		if _, ok := whitelist[key]; ok {
-			usedWhitelist[key] = true
-			continue
-		}
-		for _, pos := range panicPositions {
-			violations = append(violations, panicRegisteredViolation{
-				File:     rel,
-				Line:     fset.Position(pos).Line,
-				FuncName: funcName,
-				Reason:   "panic() is neither in a Must* function nor registered in the architectural panic ADR",
+
+		didPush := false
+		switch node := n.(type) {
+		case *ast.FuncDecl:
+			funcName := panicRegisteredFuncName(node)
+			scopes = append(scopes, panicRegisteredScope{
+				FuncName:     funcName,
+				AllowMust:    strings.HasPrefix(node.Name.Name, "Must"),
+				WhitelistKey: rel + "::" + funcName,
 			})
+			didPush = true
+		case *ast.FuncLit:
+			funcLitCount++
+			scopes = append(scopes, panicRegisteredScope{
+				FuncName: panicRegisteredFuncLiteralName(scopes, funcLitCount),
+			})
+			didPush = true
+		case *ast.CallExpr:
+			if isPanicCallExpr(node) {
+				violations = appendPanicRegisteredViolation(violations, fset, rel, node.Pos(), scopes, whitelist, usedWhitelist)
+			}
+		}
+		pushedScopes = append(pushedScopes, didPush)
+		return true
+	})
+	return violations
+}
+
+func appendPanicRegisteredViolation(
+	violations []panicRegisteredViolation,
+	fset *token.FileSet,
+	rel string,
+	pos token.Pos,
+	scopes []panicRegisteredScope,
+	whitelist map[string]string,
+	usedWhitelist map[string]bool,
+) []panicRegisteredViolation {
+	scope := panicRegisteredScope{FuncName: "<package initializer>"}
+	if len(scopes) > 0 {
+		scope = scopes[len(scopes)-1]
+	}
+	if scope.AllowMust {
+		return violations
+	}
+	if scope.WhitelistKey != "" {
+		if _, ok := whitelist[scope.WhitelistKey]; ok {
+			usedWhitelist[scope.WhitelistKey] = true
+			return violations
 		}
 	}
-	return violations
+	return append(violations, panicRegisteredViolation{
+		File:     rel,
+		Line:     fset.Position(pos).Line,
+		FuncName: scope.FuncName,
+		Reason:   "panic() is neither in a Must* function nor registered in the architectural panic ADR",
+	})
+}
+
+func panicRegisteredFuncLiteralName(scopes []panicRegisteredScope, index int) string {
+	parent := "<package>"
+	if len(scopes) > 0 {
+		parent = scopes[len(scopes)-1].FuncName
+	}
+	return parent + ".func" + strconv.Itoa(index)
+}
+
+func isPanicCallExpr(call *ast.CallExpr) bool {
+	ident, ok := call.Fun.(*ast.Ident)
+	return ok && ident.Name == "panic"
 }
 
 func skipPanicRegisteredDir(root, path, name string) bool {
@@ -259,8 +338,8 @@ func assertPanicWhitelistMatchesADR(t *testing.T, root string, usedWhitelist map
 
 	assert.Equal(t, adrKeys, goKeys,
 		"%s: ADR whitelist table must exactly match architecturalPanicWhitelist", rulePanicRegistered01)
-	assert.LessOrEqual(t, len(goKeys), 5,
-		"%s: architectural panic whitelist must stay small and permanent", rulePanicRegistered01)
+	assert.Equal(t, 4, len(goKeys),
+		"%s: architectural panic whitelist must contain exactly the ADR-approved permanent entries", rulePanicRegistered01)
 
 	var unused []string
 	for _, key := range goKeys {

--- a/tools/archtest/panic_registered_test.go
+++ b/tools/archtest/panic_registered_test.go
@@ -1,0 +1,322 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const rulePanicRegistered01 = "PANIC-REGISTERED-01"
+
+// architecturalPanicWhitelist maps "<rel-path>::<funcName>" or
+// "<rel-path>::<Receiver>.<methodName>" to an ADR-pinned justification. Keep
+// this map exactly aligned with docs/architecture/202604270030-architectural-panic-whitelist.md.
+var architecturalPanicWhitelist = map[string]string{
+	"kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor":              "re-panics from defer recover so outer Recovery middleware can serialize the panic",
+	"runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure": "re-panics from defer recover after reporting circuit-breaker failure",
+	"adapters/postgres/tx_manager.go::repanicAfterTopLevelTxRollback":        "re-panics after top-level transaction rollback so caller panic semantics are preserved",
+	"adapters/postgres/tx_manager.go::repanicAfterSavepointRollback":         "re-panics after savepoint rollback so nested transaction panic semantics are preserved",
+}
+
+type panicRegisteredViolation struct {
+	File     string
+	Line     int
+	FuncName string
+	Reason   string
+}
+
+func TestPanicRegistered(t *testing.T) {
+	root := findModuleRoot(t)
+
+	violations, usedWhitelist, err := scanRootForPanicRegisteredViolations(root, architecturalPanicWhitelist)
+	require.NoError(t, err)
+	assertPanicWhitelistMatchesADR(t, root, usedWhitelist)
+
+	if len(violations) > 0 {
+		t.Logf("%s: %d violation(s):", rulePanicRegistered01, len(violations))
+		for _, v := range violations {
+			t.Logf("  %s:%d  %s — %s", v.File, v.Line, v.FuncName, v.Reason)
+		}
+	}
+	assert.Empty(t, violations,
+		"%s: production panic() calls must be either inside Must* functions or ADR-registered permanent exceptions",
+		rulePanicRegistered01)
+}
+
+func TestPanicRegisteredScannerFixtures(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		rel       string
+		whitelist map[string]string
+		wantLines []int
+		wantUsed  []string
+	}{
+		{
+			name: "ordinary function panic fails",
+			src: `package p
+func New() {
+	panic("boom")
+}`,
+			wantLines: []int{3},
+		},
+		{
+			name: "nested function literal panic fails under non Must function",
+			src: `package p
+func New() {
+	fn := func() { panic("boom") }
+	fn()
+}`,
+			wantLines: []int{3},
+		},
+		{
+			name: "Must function panic passes",
+			src: `package p
+func MustNew() {
+	panic("boom")
+}`,
+		},
+		{
+			name: "Must method panic passes",
+			src: `package p
+type T struct{}
+func (*T) MustNew() {
+	panic("boom")
+}`,
+		},
+		{
+			name: "init panic is not auto exempt",
+			src: `package p
+func init() {
+	panic("boom")
+}`,
+			wantLines: []int{3},
+		},
+		{
+			name: "recover re panic is not auto exempt",
+			src: `package p
+func Run() {
+	defer func() {
+		if r := recover(); r != nil {
+			panic(r)
+		}
+	}()
+}`,
+			wantLines: []int{5},
+		},
+		{
+			name: "ADR whitelisted function passes and marks whitelist used",
+			src: `package p
+func registered() {
+	panic("boom")
+}`,
+			rel: "runtime/example.go",
+			whitelist: map[string]string{
+				"runtime/example.go::registered": "fixture",
+			},
+			wantUsed: []string{"runtime/example.go::registered"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rel := tc.rel
+			if rel == "" {
+				rel = "p/p.go"
+			}
+			whitelist := tc.whitelist
+			if whitelist == nil {
+				whitelist = map[string]string{}
+			}
+			violations, used := scanSourceForPanicRegisteredViolations(t, tc.src, rel, whitelist)
+			var gotLines []int
+			for _, v := range violations {
+				gotLines = append(gotLines, v.Line)
+			}
+			assert.Equal(t, tc.wantLines, gotLines)
+			assert.Equal(t, sortedStrings(tc.wantUsed), sortedStrings(mapKeys(used)))
+		})
+	}
+}
+
+func scanSourceForPanicRegisteredViolations(t *testing.T, src, rel string, whitelist map[string]string) ([]panicRegisteredViolation, map[string]bool) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, rel, src, parser.SkipObjectResolution|parser.ParseComments)
+	require.NoError(t, err)
+	used := map[string]bool{}
+	return scanPanicRegisteredAST(fset, file, rel, whitelist, used), used
+}
+
+func scanRootForPanicRegisteredViolations(root string, whitelist map[string]string) ([]panicRegisteredViolation, map[string]bool, error) {
+	usedWhitelist := map[string]bool{}
+	var violations []panicRegisteredViolation
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipPanicRegisteredDir(root, path, d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution|parser.ParseComments)
+		if err != nil {
+			return err
+		}
+		violations = append(violations, scanPanicRegisteredAST(fset, file, rel, whitelist, usedWhitelist)...)
+		return nil
+	})
+	return violations, usedWhitelist, err
+}
+
+func scanPanicRegisteredAST(
+	fset *token.FileSet,
+	file *ast.File,
+	rel string,
+	whitelist map[string]string,
+	usedWhitelist map[string]bool,
+) []panicRegisteredViolation {
+	var violations []panicRegisteredViolation
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		var panicPositions []token.Pos
+		findPanicCalls(fd.Body, func(callPos token.Pos) {
+			panicPositions = append(panicPositions, callPos)
+		})
+		if len(panicPositions) == 0 {
+			continue
+		}
+		if strings.HasPrefix(fd.Name.Name, "Must") {
+			continue
+		}
+		funcName := panicRegisteredFuncName(fd)
+		key := rel + "::" + funcName
+		if _, ok := whitelist[key]; ok {
+			usedWhitelist[key] = true
+			continue
+		}
+		for _, pos := range panicPositions {
+			violations = append(violations, panicRegisteredViolation{
+				File:     rel,
+				Line:     fset.Position(pos).Line,
+				FuncName: funcName,
+				Reason:   "panic() is neither in a Must* function nor registered in the architectural panic ADR",
+			})
+		}
+	}
+	return violations
+}
+
+func skipPanicRegisteredDir(root, path, name string) bool {
+	switch name {
+	case ".git", "vendor", "worktrees", "generated", "node_modules", "testdata":
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return filepath.ToSlash(rel) == "tools/archtest"
+}
+
+func panicRegisteredFuncName(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return fd.Name.Name
+	}
+	if recv := receiverTypeName(fd.Recv.List[0].Type); recv != "" {
+		return recv + "." + fd.Name.Name
+	}
+	return fd.Name.Name
+}
+
+func assertPanicWhitelistMatchesADR(t *testing.T, root string, usedWhitelist map[string]bool) {
+	t.Helper()
+	goKeys := sortedStrings(mapKeys(architecturalPanicWhitelist))
+	adrKeys := sortedStrings(readPanicWhitelistKeysFromADR(t, root))
+
+	assert.Equal(t, adrKeys, goKeys,
+		"%s: ADR whitelist table must exactly match architecturalPanicWhitelist", rulePanicRegistered01)
+	assert.LessOrEqual(t, len(goKeys), 5,
+		"%s: architectural panic whitelist must stay small and permanent", rulePanicRegistered01)
+
+	var unused []string
+	for _, key := range goKeys {
+		if !usedWhitelist[key] {
+			unused = append(unused, key)
+		}
+	}
+	assert.Empty(t, unused,
+		"%s: stale architectural panic whitelist entries must be removed from code and ADR", rulePanicRegistered01)
+}
+
+func readPanicWhitelistKeysFromADR(t *testing.T, root string) []string {
+	t.Helper()
+	path := filepath.Join(root, "docs", "architecture", "202604270030-architectural-panic-whitelist.md")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var keys []string
+	inSection := false
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case strings.HasPrefix(line, "### 4. Hardcoded ADR-pinned whitelist"):
+			inSection = true
+			continue
+		case inSection && strings.HasPrefix(line, "### "):
+			return keys
+		case !inSection:
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "|") || strings.Contains(trimmed, "---") || strings.Contains(trimmed, "Function") {
+			continue
+		}
+		cols := strings.Split(strings.Trim(trimmed, "|"), "|")
+		if len(cols) < 2 {
+			continue
+		}
+		key := strings.TrimSpace(cols[1])
+		key = strings.Trim(key, "`")
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func mapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/tools/pg-migrate/main.go
+++ b/tools/pg-migrate/main.go
@@ -39,7 +39,12 @@ func main() {
 	}
 	defer func() { _ = pool.Close(ctx) }()
 
-	migrator, err := adapterpg.NewMigrator(pool, adapterpg.MigrationsFS(), "schema_migrations")
+	migrationsFS, err := adapterpg.MigrationsFS()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pg-migrate: migrations fs: %v\n", err)
+		os.Exit(1)
+	}
+	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pg-migrate: build migrator: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Summary
- Add PANIC-REGISTERED-01 archtest plus a make verify gate requiring production panic() calls to be Must* or ADR-registered.
- Refactor former production panic sites to error-returning APIs or explicit Must wrappers; keep only four ADR-pinned re-panic cleanup/recording helpers.
- Update callers, tests, and docs for NewUUID, WithDetails, MigrationsFS, UpgradeHandler, RequirePolicy, and contracttest root helpers.
- Address L4 review gaps: package-level/closure panic scanning, exact four-entry ADR whitelist, wildcard WebSocket origin rejection, and health probe panic logging.
- Enforce ERROR-FIRST-TYPED-NIL-01 with a go/types archtest scanner across enrolled error-first constructors, and harden distlock, refresh memstore, and PostgreSQL refresh store constructors against typed-nil dependencies.

Refs: PR-CI-5

ref: docs/architecture/202604270030-architectural-panic-whitelist.md

Test plan
- [x] go test ./tools/archtest/... -run TestPanicRegistered -count=1
- [x] go test ./runtime/distlock ./runtime/auth/refresh/memstore ./adapters/postgres ./tools/archtest -count=1
- [x] bash hack/verify-archtest.sh
- [x] go test ./... -count=1
- [x] go build ./...
- [x] golangci-lint run ./...
- [x] make verify
- [x] go test -tags=integration ./adapters/... ./tests/integration/... -timeout 15m