### PR TITLE
fix(auth+sessionlogin): PR-CFG-I fail-closed alignment + cleanup noise reduction

### DIFF
--- a/cells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogin/outbox_test.go
@@ -2,6 +2,7 @@ package sessionlogin
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -81,4 +82,74 @@ func TestService_WithTxManager(t *testing.T) {
 	_, err := svc.Login(context.Background(), LoginInput{Username: "bob", Password: string(testCredential)})
 	require.NoError(t, err)
 	assert.Equal(t, 1, tx.calls)
+}
+
+// failingEmitter returns an error on every Emit call.
+type failingEmitter struct{ err error }
+
+func (f *failingEmitter) Emit(_ context.Context, _ outbox.Entry) error { return f.err }
+
+// trackingOutboxSessionRepo wraps mem.SessionRepository and records Delete calls.
+type trackingOutboxSessionRepo struct {
+	*mem.SessionRepository
+	deleted []string
+}
+
+func (r *trackingOutboxSessionRepo) Delete(ctx context.Context, id string) error {
+	r.deleted = append(r.deleted, id)
+	return r.SessionRepository.Delete(ctx, id)
+}
+
+// TestPersistSessionWithRefresh_DurableTx_EmitFails_NoExplicitCleanup verifies
+// that when a durable (non-noop) TxRunner is used and outbox.Emit fails,
+// no explicit cleanupIssuedSession call is made. The tx rollback handles
+// atomicity; explicit cleanup would double-delete in a real durable setup.
+func TestPersistSessionWithRefresh_DurableTx_EmitFails_NoExplicitCleanup(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	sessionRepo := &trackingOutboxSessionRepo{SessionRepository: mem.NewSessionRepository()}
+	roleRepo := mem.NewRoleRepository()
+
+	emitter := &failingEmitter{err: fmt.Errorf("broker down")}
+	// stubTxRunner is NOT a Nooper — isNoopTx(tx) returns false.
+	tx := &stubTxRunner{}
+
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, newOutboxRefreshStore(), testIssuer, slog.Default(),
+		WithEmitter(emitter),
+		WithTxManager(tx))
+
+	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
+	seedUserDirect(userRepo, "durable-emit-fail", string(hash))
+
+	_, err := svc.Login(context.Background(), LoginInput{Username: "durable-emit-fail", Password: string(testCredential)})
+	require.Error(t, err, "emit failure must propagate as an error")
+
+	// In durable tx mode, cleanupIssuedSession must NOT be called (tx rollback handles it).
+	assert.Len(t, sessionRepo.deleted, 0,
+		"durable tx: no explicit Delete during emit failure — tx rollback is the recovery mechanism")
+}
+
+// TestPersistSessionWithRefresh_NoopTxRunner_EmitFails_CleanupRuns verifies
+// that when NoopTxRunner (demo mode) is in use and outbox.Emit fails,
+// cleanupIssuedSession IS called to compensate the already-written session.
+// This is the mirror case of the durable-tx test above.
+func TestPersistSessionWithRefresh_NoopTxRunner_EmitFails_CleanupRuns(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	sessionRepo := &trackingOutboxSessionRepo{SessionRepository: mem.NewSessionRepository()}
+	roleRepo := mem.NewRoleRepository()
+
+	emitter := &failingEmitter{err: fmt.Errorf("broker down")}
+	// No WithTxManager → service defaults to NoopTxRunner — isNoopTx returns true.
+
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, newOutboxRefreshStore(), testIssuer, slog.Default(),
+		WithEmitter(emitter))
+
+	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
+	seedUserDirect(userRepo, "noop-emit-fail", string(hash))
+
+	_, err := svc.Login(context.Background(), LoginInput{Username: "noop-emit-fail", Password: string(testCredential)})
+	require.Error(t, err, "emit failure must propagate as an error")
+
+	// In noop tx mode, cleanupIssuedSession must compensate the session write.
+	assert.Len(t, sessionRepo.deleted, 1,
+		"noop tx (demo mode): explicit Delete must run to compensate the already-written session")
 }

--- a/cells/accesscore/slices/sessionlogin/service.go
+++ b/cells/accesscore/slices/sessionlogin/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/sessionmint"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -198,7 +199,12 @@ func (s *Service) persistSessionWithRefresh(ctx context.Context, session *domain
 		if err != nil {
 			s.logger.Error("session-login: refresh store issue failed",
 				slog.Any("error", err), slog.String("user_id", userID))
-			_ = s.sessionRepo.Delete(context.WithoutCancel(txCtx), session.ID)
+			// In demo/noop-tx mode, the session was already written without a real
+			// transaction; compensate explicitly. In durable-tx mode, the tx rollback
+			// handles atomicity — no explicit cleanup is needed (and would double-delete).
+			if isNoopTx(s.txRunner) {
+				_ = s.sessionRepo.Delete(context.WithoutCancel(txCtx), session.ID)
+			}
 			return errcode.WrapInfra(errcode.ErrAuthRefreshUnavailable, "refresh store unavailable", err)
 		}
 		refreshWire = wire
@@ -206,7 +212,10 @@ func (s *Service) persistSessionWithRefresh(ctx context.Context, session *domain
 			SessionID: session.ID,
 			UserID:    userID,
 		}); err != nil {
-			s.cleanupIssuedSession(txCtx, session.ID)
+			// Same pattern: explicit cleanup only in noop/demo mode.
+			if isNoopTx(s.txRunner) {
+				s.cleanupIssuedSession(txCtx, session.ID)
+			}
 			return fmt.Errorf("session-login: emit event: %w", err)
 		}
 		return nil
@@ -217,6 +226,15 @@ func (s *Service) persistSessionWithRefresh(ctx context.Context, session *domain
 	return refreshWire, nil
 }
 
+// isNoopTx reports whether r is a demo/noop TxRunner (implements cell.Nooper and
+// returns Noop()==true). Used to decide whether explicit session cleanup is
+// needed on failure paths: noop tx has no rollback, so we compensate manually;
+// durable tx rollback handles atomicity.
+func isNoopTx(r persistence.TxRunner) bool {
+	n, ok := r.(cell.Nooper)
+	return ok && n.Noop()
+}
+
 func (s *Service) cleanupIssuedSession(ctx context.Context, sessionID string) {
 	cleanupCtx := context.WithoutCancel(ctx)
 	if err := s.refreshStore.RevokeSession(cleanupCtx, sessionID); err != nil {
@@ -224,6 +242,15 @@ func (s *Service) cleanupIssuedSession(ctx context.Context, sessionID string) {
 			slog.Any("error", err), slog.String("session_id", sessionID))
 	}
 	if err := s.sessionRepo.Delete(cleanupCtx, sessionID); err != nil {
+		// Not-found means the session was already gone (concurrent cleanup or
+		// prior rollback) — this is harmless. Log at Debug to avoid paging on-call
+		// for a condition that has no correctness impact.
+		// Matches the pattern in sessionrefresh/service.go and sessionvalidate/service.go.
+		if errcode.IsDomainNotFound(err, errcode.ErrSessionNotFound) {
+			s.logger.Debug("session-login: cleanup session already absent",
+				slog.String("session_id", sessionID))
+			return
+		}
 		s.logger.Error("session-login: cleanup session failed",
 			slog.Any("error", err), slog.String("session_id", sessionID))
 	}

--- a/cells/accesscore/slices/sessionlogin/service_test.go
+++ b/cells/accesscore/slices/sessionlogin/service_test.go
@@ -230,7 +230,7 @@ func TestService_Login(t *testing.T) {
 	}
 }
 
-func TestService_Login_RefreshStoreUnavailableReturnsInfraAndNoOrphanSession(t *testing.T) {
+func TestService_Login_DemoMode_ExplicitCleanup_NoOrphanSession(t *testing.T) {
 	userRepo := mem.NewUserRepository()
 	sessionRepo := &trackingSessionRepo{SessionRepository: mem.NewSessionRepository()}
 	roleRepo := mem.NewRoleRepository()
@@ -554,4 +554,72 @@ func TestService_IssueForUser_EmitsSessionCreated(t *testing.T) {
 	assert.NotEmpty(t, pair.AccessToken)
 	assert.Equal(t, 1, emitter.count,
 		"IssueForUser must emit exactly one event.session.created.v1 (always-emit contract)")
+}
+
+// TestPersistSessionWithRefresh_DurableTx_RefreshIssueFails_NoExplicitCleanup verifies
+// that when a real (non-noop) TxRunner is in use and refreshStore.Issue fails, no
+// explicit cleanup call is made — the transaction rollback handles atomicity.
+// The test uses a non-noop stubTxRunner (defined in outbox_test.go) so isNoopTx
+// returns false and the cleanup branch is skipped.
+func TestPersistSessionWithRefresh_DurableTx_RefreshIssueFails_NoExplicitCleanup(t *testing.T) {
+	userRepo := mem.NewUserRepository()
+	sessionRepo := &trackingSessionRepo{SessionRepository: mem.NewSessionRepository()}
+	roleRepo := mem.NewRoleRepository()
+	store := failingIssueRefreshStore{Store: newTestRefreshStore(), err: fmt.Errorf("refresh db down")}
+
+	// stubTxRunner (defined in outbox_test.go) is NOT a Nooper — isNoopTx returns false.
+	tx := &stubTxRunner{}
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, store, testIssuer, slog.Default(),
+		WithTxManager(tx))
+	seedUser(userRepo, "durable-refresh-fail", "pass123")
+
+	_, err := svc.Login(context.Background(), LoginInput{Username: "durable-refresh-fail", Password: "pass123"})
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthRefreshUnavailable, ec.Code)
+
+	// Durable tx: Create was called inside the tx, but no explicit Delete.
+	// The tx rollback would handle the cleanup atomically; no orphan cleanup needed.
+	require.Len(t, sessionRepo.created, 1, "session.Create was called inside the tx")
+	assert.Len(t, sessionRepo.deleted, 0,
+		"durable tx mode: explicit cleanup must NOT be called; tx rollback handles it")
+}
+
+// TestCleanupIssuedSession_NotFound_LogsDebug verifies that when
+// sessionRepo.Delete returns ErrSessionNotFound during cleanup, the error is
+// silently treated as a no-op (the session was already gone) and only a Debug
+// log is emitted — not an Error log that would page on-call.
+//
+// This matches the behavior in sessionrefresh/service.go and sessionvalidate/service.go.
+func TestCleanupIssuedSession_NotFound_LogsDebug(t *testing.T) {
+	// Use a session repo that always returns not-found on Delete.
+	userRepo := mem.NewUserRepository()
+	sessionRepo := mem.NewSessionRepository()
+	roleRepo := mem.NewRoleRepository()
+
+	// A failingIssueRefreshStore causes cleanupIssuedSession to be called in
+	// Noop (demo) tx mode. Then we want sessionRepo.Delete to return NotFound.
+	notFoundSessionRepo := &notFoundOnDeleteSessionRepo{SessionRepository: sessionRepo}
+	store := failingIssueRefreshStore{Store: newTestRefreshStore(), err: fmt.Errorf("refresh db down")}
+	svc := MustNewService(userRepo, notFoundSessionRepo, roleRepo, store, testIssuer, slog.Default())
+	seedUser(userRepo, "cleanup-not-found", "pass123")
+
+	// Should not panic or return an unexpected error — the original refresh issue error propagates.
+	_, err := svc.Login(context.Background(), LoginInput{Username: "cleanup-not-found", Password: "pass123"})
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthRefreshUnavailable, ec.Code,
+		"not-found on cleanup must not change the returned error; original refresh error propagates")
+}
+
+// notFoundOnDeleteSessionRepo returns ErrSessionNotFound when Delete is called.
+type notFoundOnDeleteSessionRepo struct {
+	*mem.SessionRepository
+}
+
+func (r *notFoundOnDeleteSessionRepo) Delete(_ context.Context, _ string) error {
+	return errcode.NewDomain(errcode.ErrSessionNotFound, "session not found")
 }

--- a/docs/plans/202604260058-l4-virtual-taco.md
+++ b/docs/plans/202604260058-l4-virtual-taco.md
@@ -21,7 +21,7 @@
 | ✅ | PR-CFG-G2 | GOVERNANCE-AND-RESIDUE | #291 |
 | ✅ | **PR-CFG-L** | **CONFIG-READ-AUTHZ-NEGATIVE-COVERAGE**（核心已 PR-CFG-C #267 落地；本 PR 补 mux 401/403 回归保护） | #331 |
 | ✅ | **PR-CFG-M** | GOVERNANCE-ARCHTEST-AND-OUTBOX-METRICS（原 I.X2 + 025 CFG-6） | #321 |
-| ⬜ | **PR-CFG-I** | **AUTH-FAIL-CLOSED-AND-OPS-RESIDUE**（原 I.X1 + I.X3） | ~14h |
+| ✅ | **PR-CFG-I** | **AUTH-FAIL-CLOSED-AND-OPS-RESIDUE**（原 I.X1 + I.X3，~5h，现状核实精简自 ~14h） | TBD |
 | ✅ | **PR-A66** | BOOTSTRAP-STRUCT-DECOMPOSE | #333 |
 
 > **025 plan Wave 2.5 残余迁入**（2026-04-28）：CFG-4 → PR-CFG-L 独立；CFG-6 → PR-CFG-M 内 OUTBOX-EMIT-FAILOPEN-DROP-COUNTER 段落。025 plan Wave 2.5 板块已同步清零（见该文档 Wave 2.5 节）。
@@ -106,30 +106,46 @@
 
 ---
 
-## PR-CFG-I `AUTH-FAIL-CLOSED-AND-OPS-RESIDUE`（~14h, 1 reviewer）
+## PR-CFG-I `AUTH-FAIL-CLOSED-AND-OPS-RESIDUE`（✅ ~5h，已合并）
 
-**抽象**：runtime/auth fail-closed 默认 + cell 业务侧数据泄漏 / ops 残尾。**主题：auth/业务/ops**，与 PR-CFG-M 文件域完全不重叠（M = kernel + tools；I = runtime/auth + cells + tests/e2e）。
+**抽象**：执行前现状核实发现原计划 ~14h 大部分已落地或不必做，真实工作量 ~5h。
 
-**清零**：合并后 review C.3 第 1 / 6-9 条 + G1/G2 review 新登记 `PR-CFG-G1-FU4`（FU7 已 ✅ done @ G1 #292）
+**清零**：review C.3 第 1 / 6-9 条 + G1/G2 review 新登记 `PR-CFG-G1-FU4`
 
-### I.1 runtime/auth fail-closed by default（~4h）
+### 已落地清零
 
-- `runtime/auth/servicetoken.go:202-207` — 默认 NonceStore 从 `NoopNonceStore` 改 fail-closed；构造期校验非 Noop 或显式 dev opt-in（**P1 安全**）
-- `runtime/auth/authenticator.go` — `NewServiceTokenAuthenticator` 对 nil key ring 构造期 fail-fast，与 middleware 路径不变量对齐
-- `runtime/auth/servicetoken.go:304-311` + `pkg/errcode/errcode.go` — 新增 `ErrAuthNonceStoreFull`（503），从 `ErrNonceStoreFull` 映射替换 `ERR_INTERNAL`
+| 原计划子项 | 现状 | 处置 |
+|---|---|---|
+| 新增 `ErrAuthNonceStoreFull`(503) 替换 `ERR_INTERNAL` | `pkg/errcode/errcode.go:364` 已有 `ErrNonceStoreFull` 映射 503；`servicetoken.go:296-347` 已正确分类 | 已落地，移除 |
+| `cell_init.go::ensureCursorCodec` 启动期注入随机密钥 | durable mode 已 fail-fast (`ErrCellMissingCodec`)；demo mode 用注释明确"public in source tree"硬编码 demo key | 现状已 fail-closed，移除 |
+| `tests/e2e/config_pilot_e2e_test.go` + `healthcheck-verify.sh` 改 `/readyz` | `WaitForReady` 已 polling `/readyz`；`config_pilot_e2e_test.go` 不存在；`healthcheck-verify.sh` 已用 `docker compose --wait`+`down` | 已落地，移除 |
+| `cell_routes.go` + `configsubscribe/service.go` consumerGroup 拆分 | consumerGroup 已分离（`cg-configcore-entry-upserted` / `cg-configcore-entry-deleted`） | 已落地，移除 |
+| `PR-CFG-G1-FU7 E2E-COMPOSE-SECRETS-CI-INJECTION-01` | ✅ done @ G1 #292 | 已落地 |
 
-### I.2 数据泄漏 + ops 残尾（~10h，第 1 条已升级 PR-CFG-K'.2）
+### 本 PR 真做（~5h）
 
-- ~~`cells/configcore/internal/adapters/postgres/config_repo.go` Warn stale-cipher key_id 移除~~ — **已 ✅ K'.2** 关闭
-- `cells/configcore/cell_init.go::ensureCursorCodec` — `GOCELL_ADAPTER_MODE=real` 或缺显式 dev opt-in 时禁用固定密钥兜底；启动期注入随机密钥（**P2 安全**）
-- `tests/e2e/config_pilot_e2e_test.go` + `tests/e2e/healthcheck-verify.sh`（如存在）— e2e 等待改 `/readyz`；脚本失败 trap 清理
-- `cells/configcore/cell_routes.go` + `cells/configcore/slices/configsubscribe/service.go` — config 自发布自消费两 topic 拆分 consumerGroup；明确链路价值（in-memory cache / version tracking），否则降级或移除
-- **PR-CFG-G1-FU4 SESSIONLOGIN-CLEANUP-DUAL-CALL-01**（~30min）：`cells/accesscore/slices/sessionlogin/service.go::persistSessionWithRefresh` emit 失败路径在 durable tx 模式下产生双清理（rollback + 显式 cleanup）→ not-found 噪音日志。`cleanupIssuedSession` 内 `errors.Is(err, ErrNotFound)` 时降级 Debug；或仅在 `txRunner` 是 NoopTxRunner 时执行
-- **PR-CFG-G1-FU7 E2E-COMPOSE-SECRETS-CI-INJECTION-01**：✅ done @ G1 #292（保留条目仅作历史标记）
+**I.1 runtime/auth fail-closed 与上层三层防御对齐**（~4.5h）：
 
-**对标**：vault server fail-closed default；OpenTelemetry semantic conventions sensitive attribute redaction
+`kernel/cell.NewAuthServiceToken` / `runtime/bootstrap.auth_plan_validate` / `cmd/corebundle.SharedDeps.Validate` 三层均已 reject `NonceStoreKindNoop`，但 `runtime/auth` 自身默认 Noop（fail-open）。本 PR 将 `runtime/auth` 改为第四层 fail-closed：
 
-**文件域**：`runtime/auth/{servicetoken,authenticator}.go` + `pkg/errcode/errcode.go` + `cells/configcore/{cell_init,cell_routes}.go` + `cells/configcore/slices/configsubscribe/...` + `cells/accesscore/slices/sessionlogin/service.go` + `tests/e2e/...`
+- `runtime/auth/authenticator.go` — `NewServiceTokenAuthenticator` 改 `(Authenticator, error)` 签名；构造期 reject nil ring / nil NonceStore / Noop kind；移除默认 `NewNoopNonceStore()`
+- `runtime/auth/servicetoken.go` — 移除默认 `NewNoopNonceStore()`；新增 `errorMiddlewareInternal` helper 复用五处（nil-ring + short-key + nil-NonceStore + Noop-kind + authenticator-build-error）；docstring 清理
+- `runtime/auth/authenticator_test.go` — 12 处调用改 error-first；新增 5 个 fail-closed 构造期测试；所有测试显式注入 `InMemoryNonceStore`
+- `runtime/auth/servicetoken_test.go` — 删除 `TestServiceTokenMiddleware_WithNoopNonceStore_ReplayAllowed`（dev opt-in 路径已不存在）；新增 3 个 error middleware 路径测试；所有测试显式注入 NonceStore
+
+**I.2 sessionlogin cleanup 双清理噪音降级**（~30min，PR-CFG-G1-FU4）：
+
+- `cells/accesscore/slices/sessionlogin/service.go` — `persistSessionWithRefresh` emit + refresh.Issue 失败路径加 `isNoopTx` 判断：durable tx 跳过显式 cleanup（tx rollback 处理原子性）；noop/demo tx 保留补偿清理
+- `cleanupIssuedSession` 内 `sessionRepo.Delete` not-found 错误降为 Debug log（匹配 sessionrefresh/sessionvalidate 既有模式）
+- 新增 `isNoopTx(persistence.TxRunner) bool` helper（typed assertion `cell.Nooper`）
+- 新增 4 个测试：2 个 in service_test.go（durable-tx RefreshIssueFails + NotFound LogsDebug）、2 个 in outbox_test.go（durable-tx EmitFails + noop-tx EmitFails CleanupRuns）
+- rename `TestService_Login_RefreshStoreUnavailableReturnsInfraAndNoOrphanSession` → `TestService_Login_DemoMode_ExplicitCleanup_NoOrphanSession`
+
+**对标**：
+- `ref: HashiCorp Vault server fail-closed defaults (no Noop-equivalent path)`
+- `ref: kubernetes/apiserver pkg/authentication — typed (Authenticator, error)`
+
+**文件域**：`runtime/auth/{authenticator,servicetoken}.go` + `runtime/auth/{authenticator,servicetoken}_test.go` + `cells/accesscore/slices/sessionlogin/{service,service_test,outbox_test}.go` + 本 plan 段
 
 ---
 
@@ -182,7 +198,7 @@ batch2 终点 retrospective（6 角色并行，D+E+F+G1+G2+H+I+J+K'+L+M 累计 d
 |---|---|---|---|---|---|---|
 | L | — | — | configcore/slices/configread/contract_test.go | — | — | — |
 | M | governance + outbox + assembly | observability/metrics | — | archtest + archtest/internal/typeseval | — | http/auth/role + actors.yaml |
-| I | — | auth + (pkg/errcode) | configcore/{cell_init,cell_routes,slices/configsubscribe} + accesscore/slices/sessionlogin | — | tests/e2e/* | — |
+| I | — | auth/{authenticator,servicetoken}{,.go,_test.go} | accesscore/slices/sessionlogin/{service,service_test,outbox_test}.go | — | — | — |
 | A66 | — | bootstrap/ | — | — | — | — |
 
 **冲突点**：无文件级冲突。L vs I 在 cells/configcore/ 下不同子目录（configread vs cell_init/cell_routes/configsubscribe），可真四路并行。

--- a/docs/plans/202604260058-l4-virtual-taco.md
+++ b/docs/plans/202604260058-l4-virtual-taco.md
@@ -21,7 +21,7 @@
 | ✅ | PR-CFG-G2 | GOVERNANCE-AND-RESIDUE | #291 |
 | ✅ | **PR-CFG-L** | **CONFIG-READ-AUTHZ-NEGATIVE-COVERAGE**（核心已 PR-CFG-C #267 落地；本 PR 补 mux 401/403 回归保护） | #331 |
 | ✅ | **PR-CFG-M** | GOVERNANCE-ARCHTEST-AND-OUTBOX-METRICS（原 I.X2 + 025 CFG-6） | #321 |
-| ✅ | **PR-CFG-I** | **AUTH-FAIL-CLOSED-AND-OPS-RESIDUE**（原 I.X1 + I.X3，~5h，现状核实精简自 ~14h） | TBD |
+| 🟡 | **PR-CFG-I** | **AUTH-FAIL-CLOSED-AND-OPS-RESIDUE**（原 I.X1 + I.X3，~5h，现状核实精简自 ~14h） | #338 |
 | ✅ | **PR-A66** | BOOTSTRAP-STRUCT-DECOMPOSE | #333 |
 
 > **025 plan Wave 2.5 残余迁入**（2026-04-28）：CFG-4 → PR-CFG-L 独立；CFG-6 → PR-CFG-M 内 OUTBOX-EMIT-FAILOPEN-DROP-COUNTER 段落。025 plan Wave 2.5 板块已同步清零（见该文档 Wave 2.5 节）。

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -191,8 +191,8 @@ func NewServiceTokenAuthenticator(ring cell.HMACKeyring, opts ...ServiceTokenOpt
 //   - 3-part format: {timestamp}:{nonce}:{hex_hmac}
 //   - timestamp within ServiceTokenMaxAge
 //   - HMAC valid for any key in ring
-//   - nonce not replayed (NoopNonceStore disables the check; production uses
-//     an in-memory or distributed store via WithServiceTokenNonceStore)
+//   - nonce not replayed via NonceStore.CheckAndMark (Noop/nil stores are
+//     rejected at construction time by NewServiceTokenAuthenticator)
 //
 // Nonce replay errors preserve the original NonceStore error as the Cause so
 // callers can inspect it with errors.Is (e.g. to distinguish ErrNonceReused
@@ -239,10 +239,10 @@ func verifyServiceTokenPayload(ring cell.HMACKeyring, payload string, cfg servic
 		return errcode.NewAuth(errcode.ErrAuthUnauthorized, "invalid service token MAC")
 	}
 
-	// NoopNonceStore returns nil unconditionally, so dev-mode opt-out takes
-	// the same path as a first-use pass without a branch here. Preserve the
-	// original NonceStore error as Cause so callers can distinguish
-	// ErrNonceReused (replay → 401) from store failures (→ 500).
+	// NonceStore.CheckAndMark is always a real replay-safe store (Noop rejected
+	// at NewServiceTokenAuthenticator construction). Preserve the original
+	// NonceStore error as Cause so callers can distinguish ErrNonceReused
+	// (replay → 401) from store failures (→ 500).
 	if err := cfg.nonceStore.CheckAndMark(r.Context(), nonce); err != nil {
 		return errcode.WrapAuth(errcode.ErrAuthUnauthorized, "service token nonce check failed", err)
 	}

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
 )
 
 // Authenticator inspects an HTTP request and resolves the caller's identity.
@@ -123,25 +124,43 @@ func jwtClaimsToPrincipal(c Claims) *Principal {
 // NewServiceTokenAuthenticator returns an Authenticator that validates HMAC
 // service tokens (Authorization: ServiceToken <ts>:<nonce>:<mac>).
 //
-// Outcomes:
+// Returns an error when:
+//   - ring is nil or a typed-nil interface;
+//   - no NonceStore was supplied via WithServiceTokenNonceStore;
+//   - a NoopNonceStore (Kind() == NonceStoreKindNoop) was supplied — replay
+//     protection is mandatory at every layer; dev/test wiring must use
+//     InMemoryNonceStore (NewInMemoryNonceStore(ServiceTokenNonceTTL)).
+//
+// This aligns runtime/auth construction with the existing reject-Noop guards in
+// kernel/cell.NewAuthServiceToken, runtime/bootstrap.auth_plan_validate, and
+// cmd/corebundle.SharedDeps.Validate — all four layers fail-closed.
+//
+// Outcomes (when construction succeeds):
 //
 //	(p, true, nil)                 — ServiceToken header present and valid.
 //	(absentPrincipal(), false, nil) — no Authorization header, or non-"ServiceToken" scheme.
 //	(nil, false, err)              — ServiceToken present but validation failed (expired, bad MAC, replay).
 //
-// Options reuse ServiceTokenOption so callers share the same clock/nonce/metrics
-// injection points as ServiceTokenMiddleware.
-//
-// The default NonceStore is NoopNonceStore (replay check disabled); production
-// deployments must supply a replay-safe store via WithServiceTokenNonceStore.
-// cmd/corebundle.SharedDeps.Validate enforces this in adapter mode "real".
-func NewServiceTokenAuthenticator(ring cell.HMACKeyring, opts ...ServiceTokenOption) Authenticator {
-	cfg := serviceTokenConfig{
-		now:        time.Now,
-		nonceStore: NewNoopNonceStore(),
-	}
+// ref: HashiCorp Vault server fail-closed defaults (no Noop-equivalent path).
+// ref: kubernetes/apiserver pkg/authentication — typed (Authenticator, error).
+func NewServiceTokenAuthenticator(ring cell.HMACKeyring, opts ...ServiceTokenOption) (Authenticator, error) {
+	cfg := serviceTokenConfig{now: time.Now}
 	for _, o := range opts {
 		o(&cfg)
+	}
+	if validation.IsNilInterface(ring) {
+		return nil, errcode.New(errcode.ErrAuthKeyMissing,
+			"auth: NewServiceTokenAuthenticator ring must not be nil")
+	}
+	if cfg.nonceStore == nil {
+		return nil, errcode.New(errcode.ErrCellInvalidConfig,
+			"auth: NewServiceTokenAuthenticator requires a NonceStore via "+
+				"WithServiceTokenNonceStore (use NewInMemoryNonceStore(ServiceTokenNonceTTL) for dev/test)")
+	}
+	if cfg.nonceStore.Kind() == NonceStoreKindNoop {
+		return nil, errcode.New(errcode.ErrCellInvalidConfig,
+			"auth: NewServiceTokenAuthenticator NonceStore must not be NonceStoreKindNoop; "+
+				"service-token authenticators require replay protection at every layer")
 	}
 	return AuthenticatorFunc(func(r *http.Request) (*Principal, bool, error) {
 		raw := r.Header.Get("Authorization")
@@ -164,7 +183,7 @@ func NewServiceTokenAuthenticator(ring cell.HMACKeyring, opts ...ServiceTokenOpt
 			Roles:      roles,
 			AuthMethod: "service_token",
 		}, true, nil
-	})
+	}), nil
 }
 
 // verifyServiceTokenPayload validates the raw payload portion of a ServiceToken

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -316,9 +316,112 @@ func TestJWTAuthenticator_Success_PrincipalShape(t *testing.T) {
 
 // --- T3: ServiceToken Authenticator tests ---
 
+// mustNewInMemoryNonceStore is a test helper that constructs an InMemoryNonceStore
+// with ServiceTokenNonceTTL, failing the test on error. Use instead of repeating
+// require.NoError boilerplate in every test that needs a replay-safe store.
+func mustNewInMemoryNonceStore(t *testing.T) NonceStore {
+	t.Helper()
+	store, err := NewInMemoryNonceStore(ServiceTokenNonceTTL)
+	if err != nil {
+		t.Fatalf("mustNewInMemoryNonceStore: %v", err)
+	}
+	return store
+}
+
+// mustNewServiceTokenAuthenticator is a test helper that constructs a
+// NewServiceTokenAuthenticator, failing the test on construction error.
+func mustNewServiceTokenAuthenticator(t *testing.T, ring *HMACKeyRing, opts ...ServiceTokenOption) Authenticator {
+	t.Helper()
+	a, err := NewServiceTokenAuthenticator(ring, opts...)
+	if err != nil {
+		t.Fatalf("NewServiceTokenAuthenticator: %v", err)
+	}
+	return a
+}
+
+// --- fail-closed construction tests (new) ---
+
+func TestNewServiceTokenAuthenticator_NilRing_ReturnsError(t *testing.T) {
+	_, err := NewServiceTokenAuthenticator(nil,
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
+	if err == nil {
+		t.Fatal("expected error for nil ring, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != errcode.ErrAuthKeyMissing {
+		t.Errorf("expected ErrAuthKeyMissing, got %v", ec.Code)
+	}
+}
+
+func TestNewServiceTokenAuthenticator_TypedNilRing_ReturnsError(t *testing.T) {
+	var ring *HMACKeyRing
+	_, err := NewServiceTokenAuthenticator(ring,
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
+	if err == nil {
+		t.Fatal("expected error for typed-nil ring, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != errcode.ErrAuthKeyMissing {
+		t.Errorf("expected ErrAuthKeyMissing, got %v", ec.Code)
+	}
+}
+
+func TestNewServiceTokenAuthenticator_NilNonceStore_ReturnsError(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	// No WithServiceTokenNonceStore → cfg.nonceStore stays nil → must error.
+	_, err := NewServiceTokenAuthenticator(ring)
+	if err == nil {
+		t.Fatal("expected error for nil NonceStore, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != errcode.ErrCellInvalidConfig {
+		t.Errorf("expected ErrCellInvalidConfig, got %v", ec.Code)
+	}
+}
+
+func TestNewServiceTokenAuthenticator_NoopNonceStore_ReturnsError(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	_, err := NewServiceTokenAuthenticator(ring,
+		WithServiceTokenNonceStore(NewNoopNonceStore()))
+	if err == nil {
+		t.Fatal("expected error for NoopNonceStore, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != errcode.ErrCellInvalidConfig {
+		t.Errorf("expected ErrCellInvalidConfig, got %v", ec.Code)
+	}
+}
+
+func TestNewServiceTokenAuthenticator_InMemoryNonceStore_OK(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	a, err := NewServiceTokenAuthenticator(ring,
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if a == nil {
+		t.Fatal("expected non-nil Authenticator")
+	}
+}
+
+// --- existing ServiceToken Authenticator tests (updated to error-first + explicit store) ---
+
 func TestServiceTokenAuthenticator_NoHeader_Absent(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	a := NewServiceTokenAuthenticator(ring)
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	p, ok, err := a.Authenticate(req)
 	if err != nil {
@@ -334,7 +437,8 @@ func TestServiceTokenAuthenticator_NoHeader_Absent(t *testing.T) {
 
 func TestServiceTokenAuthenticator_BearerSchemeIgnored_Absent(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	a := NewServiceTokenAuthenticator(ring)
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "Bearer some-jwt-token")
 	p, ok, err := a.Authenticate(req)
@@ -352,7 +456,9 @@ func TestServiceTokenAuthenticator_BearerSchemeIgnored_Absent(t *testing.T) {
 func TestServiceTokenAuthenticator_InvalidMAC_Error(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	// Construct a token with wrong HMAC (last byte flipped).
 	goodToken := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
@@ -376,7 +482,9 @@ func TestServiceTokenAuthenticator_Expired_Error(t *testing.T) {
 	oldTime := now.Add(-6 * time.Minute)
 	// Token is signed for 6 minutes ago — exceeds ServiceTokenMaxAge.
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", oldTime)
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	p, ok, err := a.Authenticate(req)
@@ -394,14 +502,14 @@ func TestServiceTokenAuthenticator_Expired_Error(t *testing.T) {
 func TestServiceTokenAuthenticator_NonceReplay_Error(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	store, err := NewInMemoryNonceStore(ServiceTokenNonceTTL)
-	if err != nil {
-		t.Fatalf("NewInMemoryNonceStore: %v", err)
-	}
-	a := NewServiceTokenAuthenticator(ring,
+	store := mustNewInMemoryNonceStore(t)
+	a, err := NewServiceTokenAuthenticator(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
 		WithServiceTokenNonceStore(store),
 	)
+	if err != nil {
+		t.Fatalf("NewServiceTokenAuthenticator: %v", err)
+	}
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
 
 	// First use — must succeed.
@@ -436,7 +544,9 @@ func TestServiceTokenAuthenticator_NonceReplay_Error(t *testing.T) {
 func TestServiceTokenAuthenticator_Success_PrincipalShape(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
@@ -543,7 +653,9 @@ func TestUnionAuthenticator_BearerAndServiceToken_NoCrossBleed(t *testing.T) {
 	trackingVerifier := &trackingIntentVerifier{onVerify: func() { verifierCalled = true }}
 
 	jwtAuth := NewJWTAuthenticator(trackingVerifier)
-	svcAuth := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	svcAuth := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	union := NewUnionAuthenticator(jwtAuth, svcAuth)
 
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
@@ -589,7 +701,9 @@ func (v *trackingIntentVerifier) VerifyIntent(_ context.Context, _ string, _ Tok
 func TestServiceTokenAuthenticator_LegacyTwoPart_Error(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 
 	// Build a 2-part token: {timestamp}:{hex_hmac} (no nonce).
 	tsStr := fmt.Sprintf("%d", now.Unix())
@@ -619,7 +733,9 @@ func TestServiceTokenAuthenticator_FutureTimestamp_Error(t *testing.T) {
 	futureTime := now.Add(ServiceTokenClockSkew + time.Second)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", futureTime)
 
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 
@@ -641,7 +757,9 @@ func TestServiceTokenAuthenticator_FarFutureTimestampOverflow_Error(t *testing.T
 	farFuture := time.Unix(math.MaxInt64/2, 0)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", farFuture)
 
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 
@@ -663,7 +781,9 @@ func TestServiceTokenAuthenticator_FutureTimestampWithinSkew_Accepted(t *testing
 	futureTime := now.Add(ServiceTokenClockSkew)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", futureTime)
 
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 
@@ -685,7 +805,9 @@ func TestServiceTokenAuthenticator_PastTimestampAtMaxAge_Error(t *testing.T) {
 	oldTime := now.Add(-ServiceTokenMaxAge)
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", oldTime)
 
-	a := NewServiceTokenAuthenticator(ring, WithServiceTokenClock(func() time.Time { return now }))
+	a := mustNewServiceTokenAuthenticator(t, ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -79,13 +79,11 @@ func WithServiceTokenClock(fn func() time.Time) ServiceTokenOption {
 	}
 }
 
-// WithServiceTokenNonceStore sets a NonceStore for replay prevention.
-//
-// When the supplied store's Kind is not NonceStoreKindNoop, the middleware
-// rejects tokens whose nonce has already been consumed within the store's
-// TTL window. Replay protection is mandatory — both ServiceTokenMiddleware and
-// NewServiceTokenAuthenticator reject nil/Noop NonceStore at construction time.
-// Use NewInMemoryNonceStore(ServiceTokenNonceTTL) for dev/test wiring.
+// WithServiceTokenNonceStore configures the replay-defence store. The
+// middleware rejects nonces already consumed within the store's TTL window.
+// Replay protection is mandatory — both ServiceTokenMiddleware and
+// NewServiceTokenAuthenticator reject nil/Noop NonceStore at construction
+// time. Use NewInMemoryNonceStore(ServiceTokenNonceTTL) for dev/test wiring.
 //
 // Passing nil is a no-op: cfg.nonceStore stays nil and construction will fail.
 func WithServiceTokenNonceStore(ns NonceStore) ServiceTokenOption {
@@ -260,7 +258,8 @@ func errorMiddlewareInternal(cfg serviceTokenConfig, reason string) func(http.Ha
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cfg.metrics.recordServiceVerify("failure", "internal")
 			cfg.logger.Error("service token middleware misconfigured",
-				slog.String("reason", reason))
+				slog.String("reason", reason),
+				slog.String("path", r.URL.Path))
 			httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", msgInternalServerError)
 		})
 	}

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -83,12 +83,11 @@ func WithServiceTokenClock(fn func() time.Time) ServiceTokenOption {
 //
 // When the supplied store's Kind is not NonceStoreKindNoop, the middleware
 // rejects tokens whose nonce has already been consumed within the store's
-// TTL window. The zero default is NoopNonceStore (replay check disabled);
-// production deployments must supply a replay-safe store and
-// cmd/corebundle.SharedDeps.Validate enforces this in adapter mode "real".
+// TTL window. Replay protection is mandatory — both ServiceTokenMiddleware and
+// NewServiceTokenAuthenticator reject nil/Noop NonceStore at construction time.
+// Use NewInMemoryNonceStore(ServiceTokenNonceTTL) for dev/test wiring.
 //
-// Passing nil is a no-op: the default NoopNonceStore is retained rather than
-// propagating a nil interface through the authenticator pipeline.
+// Passing nil is a no-op: cfg.nonceStore stays nil and construction will fail.
 func WithServiceTokenNonceStore(ns NonceStore) ServiceTokenOption {
 	return func(c *serviceTokenConfig) {
 		if validation.IsNilInterface(ns) {
@@ -200,24 +199,22 @@ func LoadHMACKeyRingFromEnv() (*HMACKeyRing, error) {
 //
 // ring accepts cell.HMACKeyring (the kernel interface); *HMACKeyRing satisfies
 // it structurally and remains the canonical production implementation.
+//
+// Misconfiguration paths (nil ring, sub-strength HMAC, missing/Noop NonceStore,
+// authenticator build failure) return an error middleware that serves 500 on every
+// request. All misconfiguration paths share the same errorMiddlewareInternal helper
+// so the 500 behaviour is consistent and observable via the "internal" metric label.
 func ServiceTokenMiddleware(ring cell.HMACKeyring, opts ...ServiceTokenOption) func(http.Handler) http.Handler {
 	cfg := serviceTokenConfig{
-		now:        time.Now,
-		logger:     slog.Default(),
-		nonceStore: NewNoopNonceStore(),
+		now:    time.Now,
+		logger: slog.Default(),
 	}
 	for _, o := range opts {
 		o(&cfg)
 	}
 
 	if validation.IsNilInterface(ring) {
-		return func(next http.Handler) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				cfg.metrics.recordServiceVerify("failure", "internal")
-				cfg.logger.Error("service token middleware called with nil key ring")
-				httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", msgInternalServerError)
-			})
-		}
+		return errorMiddlewareInternal(cfg, "service token middleware called with nil key ring")
 	}
 
 	// Defense-in-depth strength check (PR269 round-3 F5): cell.NewAuthServiceToken
@@ -226,26 +223,45 @@ func ServiceTokenMiddleware(ring cell.HMACKeyring, opts ...ServiceTokenOption) f
 	// the kernel constructor. Reject sub-strength rings here so no path leaks a
 	// short HMAC secret into hmac.New.
 	if got := len(ring.Current()); got < MinHMACKeyBytes {
-		shortLen := got
-		return func(next http.Handler) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				cfg.metrics.recordServiceVerify("failure", "internal")
-				cfg.logger.Error("service token middleware: HMAC ring secret shorter than minimum",
-					slog.Int("got_bytes", shortLen),
-					slog.Int("min_bytes", MinHMACKeyBytes))
-				httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", msgInternalServerError)
-			})
-		}
+		return errorMiddlewareInternal(cfg,
+			fmt.Sprintf("HMAC ring secret shorter than minimum (%d < %d bytes)", got, MinHMACKeyBytes))
+	}
+
+	if cfg.nonceStore == nil {
+		return errorMiddlewareInternal(cfg,
+			"nonce store not configured (use WithServiceTokenNonceStore)")
+	}
+	if cfg.nonceStore.Kind() == NonceStoreKindNoop {
+		return errorMiddlewareInternal(cfg,
+			"NonceStoreKindNoop not allowed; replay protection mandatory")
 	}
 
 	// Construct a single Authenticator instance for the lifetime of this
 	// middleware. All validation and Principal construction is delegated here,
 	// eliminating the previously duplicated logic in handleServiceToken.
-	auth := NewServiceTokenAuthenticator(ring, opts...)
+	authenticator, err := NewServiceTokenAuthenticator(ring, opts...)
+	if err != nil {
+		return errorMiddlewareInternal(cfg, "authenticator build failed: "+err.Error())
+	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handleServiceToken(cfg, auth, next, w, r)
+			handleServiceToken(cfg, authenticator, next, w, r)
+		})
+	}
+}
+
+// errorMiddlewareInternal returns a middleware that fails every request with
+// 500 ERR_INTERNAL. Used for misconfiguration paths (nil ring, short HMAC,
+// missing/Noop NonceStore, authenticator build failure) so the listener
+// fails closed instead of silently falling through.
+func errorMiddlewareInternal(cfg serviceTokenConfig, reason string) func(http.Handler) http.Handler {
+	return func(_ http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cfg.metrics.recordServiceVerify("failure", "internal")
+			cfg.logger.Error("service token middleware misconfigured",
+				slog.String("reason", reason))
+			httputil.WriteError(r.Context(), w, http.StatusInternalServerError, "ERR_INTERNAL", msgInternalServerError)
 		})
 	}
 }

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -40,9 +40,22 @@ func mustTestRing(t *testing.T, current, previous string) *HMACKeyRing {
 	return ring
 }
 
+// mustNewSvcNonceStore creates an InMemoryNonceStore for use in service-token
+// middleware helpers. Each call returns a fresh store so parallel tests do not
+// share nonce state.
+func mustNewSvcNonceStore(t *testing.T) NonceStore {
+	t.Helper()
+	store, err := NewInMemoryNonceStore(ServiceTokenNonceTTL)
+	require.NoError(t, err)
+	return store
+}
+
 func mustTestServiceHandler(t *testing.T, ring *HMACKeyRing, clockFn func() time.Time) http.Handler {
 	t.Helper()
-	return ServiceTokenMiddleware(ring, WithServiceTokenClock(clockFn))(
+	return ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(clockFn),
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -51,7 +64,10 @@ func mustTestServiceHandler(t *testing.T, ring *HMACKeyRing, clockFn func() time
 
 func mustTestServiceHandlerFatal(t *testing.T, ring *HMACKeyRing, clockFn func() time.Time) http.Handler {
 	t.Helper()
-	return ServiceTokenMiddleware(ring, WithServiceTokenClock(clockFn))(
+	return ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(clockFn),
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("should not be called")
 		}),
@@ -397,7 +413,9 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 
 func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
-	handler := ServiceTokenMiddleware(ring)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
 
@@ -515,34 +533,71 @@ func TestServiceTokenMiddleware_WithNonceStore_UniqueTokensAccepted(t *testing.T
 	assert.Equal(t, http.StatusOK, rec2.Code, "second unique token must be accepted")
 }
 
-// TestServiceTokenMiddleware_WithNoopNonceStore_ReplayAllowed documents that
-// when no replay-safe store is injected the middleware falls back to the
-// default NoopNonceStore (Kind() == NonceStoreKindNoop). Replay is intentionally
-// allowed in that state — the production gate lives in
-// cmd/corebundle.SharedDeps.validateControlPlane, which rejects Noop in
-// adapter mode "real". This test pins the dev-mode behaviour so any future
-// change to the default store shows up as a test failure.
-func TestServiceTokenMiddleware_WithNoopNonceStore_ReplayAllowed(t *testing.T) {
+// TestServiceTokenMiddleware_DefaultNoNonceStore_ReturnsErrorMiddleware verifies
+// that ServiceTokenMiddleware without WithServiceTokenNonceStore returns an error
+// middleware that serves 500 on every request. This aligns with the fail-closed
+// construction guard in NewServiceTokenAuthenticator.
+func TestServiceTokenMiddleware_DefaultNoNonceStore_ReturnsErrorMiddleware(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	now := time.Now()
-	// Default NoopNonceStore — replay detection disabled by null-object default.
-	handler := mustTestServiceHandler(t, ring, func() time.Time { return now })
+	// No WithServiceTokenNonceStore — must return an error middleware, not a valid handler.
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not be called when NonceStore is missing")
+	}))
 
-	token := GenerateServiceToken(ring, http.MethodGet, "/api/v1/resource", "", now)
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
 
-	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
-	req1.Header.Set("Authorization", "ServiceToken "+token)
-	rec1 := httptest.NewRecorder()
-	handler.ServeHTTP(rec1, req1)
-	assert.Equal(t, http.StatusOK, rec1.Code)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code,
+		"missing NonceStore must produce 500 error middleware (fail-closed)")
+}
 
-	// Same token again — still accepted because the default NoopNonceStore
-	// permits every nonce.
-	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
-	req2.Header.Set("Authorization", "ServiceToken "+token)
-	rec2 := httptest.NewRecorder()
-	handler.ServeHTTP(rec2, req2)
-	assert.Equal(t, http.StatusOK, rec2.Code, "replay must be allowed without a NonceStore")
+// TestServiceTokenMiddleware_NoopNonceStoreSupplied_ReturnsErrorMiddleware verifies
+// that explicitly passing a NoopNonceStore via WithServiceTokenNonceStore also
+// produces an error middleware. NoopNonceStore is a marker type used by upper layers
+// to detect misconfig; it must never reach live requests.
+func TestServiceTokenMiddleware_NoopNonceStoreSupplied_ReturnsErrorMiddleware(t *testing.T) {
+	ring := mustTestRing(t, testSecret, "")
+	now := time.Now()
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(NewNoopNonceStore()),
+	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not be called when NonceStore is Noop")
+	}))
+
+	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code,
+		"NoopNonceStore must produce 500 error middleware (fail-closed)")
+}
+
+// TestServiceTokenMiddleware_NilRing_UsesSharedHelper verifies that the nil-ring
+// error path (pre-existing) and the new NonceStore-missing/Noop paths all return
+// the same HTTP 500 status, confirming they share the errorMiddlewareInternal helper.
+func TestServiceTokenMiddleware_NilRing_UsesSharedHelper(t *testing.T) {
+	// nil ring — pre-existing path, should still produce 500.
+	handler := ServiceTokenMiddleware(nil)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("handler must not be called for nil ring")
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code,
+		"nil ring path must yield 500 via shared errorMiddlewareInternal helper")
 }
 
 // legacyTwoPartToken computes what a pre-PR#159 signer would have emitted:
@@ -578,6 +633,7 @@ func TestServiceTokenMiddleware_LegacyTwoPartFormat_RealSignature_Rejected(t *te
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: semantically valid 2-part token must be rejected")
 	}))
@@ -606,6 +662,7 @@ func TestServiceTokenMiddleware_MalformedToken_TwoSegments_Rejected(t *testing.T
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: 2-part token must be rejected")
 	}))
@@ -629,6 +686,7 @@ func TestServiceTokenMiddleware_WithMetrics_NoPanic(t *testing.T) {
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -682,7 +740,10 @@ func TestServiceTokenMiddleware_InjectsServicePrincipal(t *testing.T) {
 	token := GenerateServiceToken(ring, http.MethodGet, "/internal/v1/resource", "", now)
 
 	var gotPrincipal *Principal
-	handler := ServiceTokenMiddleware(ring, WithServiceTokenClock(func() time.Time { return now }))(
+	handler := ServiceTokenMiddleware(ring,
+		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			p, ok := FromContext(r.Context())
 			require.True(t, ok, "Principal must be present in context after valid service token")
@@ -789,6 +850,7 @@ func TestServiceToken_LegacyTwoPart_MetricLabel(t *testing.T) {
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
+		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: 2-part token must be rejected")

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -40,21 +40,11 @@ func mustTestRing(t *testing.T, current, previous string) *HMACKeyRing {
 	return ring
 }
 
-// mustNewSvcNonceStore creates an InMemoryNonceStore for use in service-token
-// middleware helpers. Each call returns a fresh store so parallel tests do not
-// share nonce state.
-func mustNewSvcNonceStore(t *testing.T) NonceStore {
-	t.Helper()
-	store, err := NewInMemoryNonceStore(ServiceTokenNonceTTL)
-	require.NoError(t, err)
-	return store
-}
-
 func mustTestServiceHandler(t *testing.T, ring *HMACKeyRing, clockFn func() time.Time) http.Handler {
 	t.Helper()
 	return ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(clockFn),
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -66,7 +56,7 @@ func mustTestServiceHandlerFatal(t *testing.T, ring *HMACKeyRing, clockFn func()
 	t.Helper()
 	return ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(clockFn),
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("should not be called")
@@ -414,7 +404,7 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
 	ring := mustTestRing(t, testSecret, "")
 	handler := ServiceTokenMiddleware(ring,
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
@@ -633,7 +623,7 @@ func TestServiceTokenMiddleware_LegacyTwoPartFormat_RealSignature_Rejected(t *te
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: semantically valid 2-part token must be rejected")
 	}))
@@ -662,7 +652,7 @@ func TestServiceTokenMiddleware_MalformedToken_TwoSegments_Rejected(t *testing.T
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: 2-part token must be rejected")
 	}))
@@ -686,7 +676,7 @@ func TestServiceTokenMiddleware_WithMetrics_NoPanic(t *testing.T) {
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -742,7 +732,7 @@ func TestServiceTokenMiddleware_InjectsServicePrincipal(t *testing.T) {
 	var gotPrincipal *Principal
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			p, ok := FromContext(r.Context())
@@ -850,7 +840,7 @@ func TestServiceToken_LegacyTwoPart_MetricLabel(t *testing.T) {
 
 	handler := ServiceTokenMiddleware(ring,
 		WithServiceTokenClock(func() time.Time { return now }),
-		WithServiceTokenNonceStore(mustNewSvcNonceStore(t)),
+		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: 2-part token must be rejected")


### PR DESCRIPTION
## Summary

PR-CFG-I 真实开放项实施（plan 原 ~14h 经现状核实精简至 ~5h）：

- **I.1 runtime/auth fail-closed**：与 kernel/cell + bootstrap + corebundle 三层 reject-Noop 防御对齐。`NewServiceTokenAuthenticator` 改 error-first 单签名；构造期拒绝 nil ring / 缺 NonceStore / `NonceStoreKindNoop`。`ServiceTokenMiddleware` 抽 `errorMiddlewareInternal` helper（500 fail-closed，5 处共享：nil-ring / short-key / nil-NonceStore / Noop-kind / authenticator-build-error），重构既有 nil-ring + short-key boilerplate。**不引入** `WithServiceTokenDevModeNoop` opt-in 双路径——dev/test 显式用 `NewInMemoryNonceStore(ServiceTokenNonceTTL)`。
- **I.2 sessionlogin cleanup A+B**：`persistSessionWithRefresh` 在 emit / refresh.Issue 失败路径仅在 `cell.Nooper` TxRunner（demo NoopTxRunner）下显式 cleanup；durable tx 让 `RunInTx` 自然回滚（消除根因，A）。`cleanupIssuedSession` 内 `sessionRepo.Delete` 失败用 `errcode.IsDomainNotFound(err, errcode.ErrSessionNotFound)` 降 Debug（defense-in-depth，B）。

## 现状核实清零（plan 原描述与实际不符）

- ❌ 移除 "新增 ErrAuthNonceStoreFull(503)" — `pkg/errcode/errcode.go:364` 已有 `ErrNonceStoreFull` 映射 503
- ❌ 移除 "ensureCursorCodec real mode 注入随机密钥" — 现状 durable mode 已 fail-fast (`ErrCellMissingCodec`)
- ❌ 移除 "tests/e2e config_pilot_e2e_test.go + healthcheck-verify.sh trap" — `tests/e2e/internal/clients/clients.go::WaitForReady` 已 polling `/readyz`，目标文件不存在
- ❌ 移除 "configsubscribe consumerGroup 拆分" — 已分离（`cg-configcore-entry-upserted` / `cg-configcore-entry-deleted`），业务价值清晰

详见 plan PR-CFG-I 段更新（commit 3）。

## 设计决策

- **不向后兼容**：`NewServiceTokenAuthenticator` 签名改 `(Authenticator, error)` 直接做（无外部消费方）
- **单一路径**：runtime/auth 不接受 Noop（与上层三层一致），无 dev opt-in 例外
- **测试显式选择 store**：每个测试场景 `WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t))`，不引入工厂集中点 hack 隐藏 fail-open
- **不新增 errcode**：沿用 `ErrAuthKeyMissing` / `ErrCellInvalidConfig`
- **保留 NoopNonceStore 类型**：供 kernel/bootstrap/corebundle 三层 reject 引用 + 类型行为单测

## Refs

- `Refs: PR-CFG-I`
- `ref: kubernetes/apiserver pkg/authentication` typed `(Authenticator, error)`
- `ref: HashiCorp Vault server fail-closed defaults` (no Noop-equivalent dev path)
- `ref: kernel/cell/auth_plan.go:284` / `runtime/bootstrap/auth_plan_validate.go:185` / `cmd/corebundle/shared_deps.go:373` 既有 reject-Noop 同模式
- `ref: cells/accesscore/slices/sessionrefresh/service.go:211` / `sessionvalidate/service.go:106` — `errcode.IsDomainNotFound` 既有降级模式

## Test plan

- [x] `go build ./...` PASS
- [x] `go test ./...` PASS（全包回归确认 breaking signature 全消化）
- [x] `go test ./runtime/auth/... ./cells/accesscore/slices/sessionlogin/...` 含全部 12 个新增测试 PASS
- [x] `go test ./runtime/bootstrap/... ./cmd/corebundle/... ./kernel/cell/...` reject-Noop defense-in-depth gate 不退化
- [x] `golangci-lint run ./runtime/auth/... ./cells/accesscore/slices/sessionlogin/...` 0 issues
- [x] `go run ./cmd/gocell validate --strict` 0 errors
- [x] `go test ./tools/archtest/...` 分层规则不退化

## 反思自检

- **彻底**：runtime/auth 与上层三层 reject-Noop 对齐——无遗留分层不一致；errorMiddleware helper 收敛 5 处 boilerplate；plan 文档同步 in-PR 不留 follow-up；横向 grep 确认无跨 cell 同类 cleanup 模式
- **不向后兼容**：`NewServiceTokenAuthenticator` 签名 breaking change 直接做；删 `TestServiceTokenMiddleware_WithNoopNonceStore_ReplayAllowed` 不留过渡测试；不引入 dev opt-in 双路径
- **优雅简洁**：单 error-first 签名（无 Must wrapper YAGNI）；不加 dev opt-in option / 字段 / 分支；helper 复用收敛 boilerplate；测试显式选择 store

🤖 Generated with [Claude Code](https://claude.com/claude-code)