### PR TITLE
ci(shell-safety): G4 SHELL-SAFETY-01 — strict mode + verify gate + CodeQL manual build

### DIFF
--- a/.github/workflows/security-static.yml
+++ b/.github/workflows/security-static.yml
@@ -68,6 +68,9 @@ jobs:
           build-mode: manual
 
       - name: Build (CodeQL trace)
+        # Root `./...` does not recurse into nested modules under
+        # tools/archtest/testdata/, so the deliberately-broken fixtures stay
+        # out of the extractor trace.
         run: go build ./...
 
       - name: Analyze

--- a/.github/workflows/security-static.yml
+++ b/.github/workflows/security-static.yml
@@ -58,9 +58,17 @@ jobs:
         with:
           languages: go
           queries: security-extended
+          # Manual build mode: Autobuild walks the tree and tries to build every
+          # go.mod it finds, including the 37 deliberately-broken fixture modules
+          # under tools/archtest/testdata/ (used by archtest to verify violation
+          # detection). That triggered "Go files were found but not processed" on
+          # the Code Scanning dashboard. `go build ./...` from the root module
+          # does not recurse into nested modules, so the fixtures are skipped
+          # cleanly and the extractor traces only the main module.
+          build-mode: manual
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+      - name: Build (CodeQL trace)
+        run: go build ./...
 
       - name: Analyze
         # Upload-only: PR blocking is via repo Code Scanning branch protection

--- a/hack/verify-shell-safety.sh
+++ b/hack/verify-shell-safety.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# verify-shell-safety: enforce strict mode (`set -euo pipefail`) on project-owned
+# shell scripts so silent CI failures cannot recur.
+#
+# Why: bash defaults swallow command failures (`set +e`), unset variables
+# (`set +u`), and pipeline mid-failures (no `pipefail`). A CI step that just
+# `bash some-script.sh` would log a red error and still exit 0. `set -euo
+# pipefail` is the one-line floor that turns those into hard failures.
+#
+# Scope:
+#   - Scans scripts/, hack/, tests/ for *.sh
+#   - Excludes hack/lib/ (sourced libraries; setting strict-mode there would
+#     pollute the caller's shell)
+#   - Excludes this verifier itself (its own check is its `set -euo pipefail`
+#     on line 19)
+#   - Does NOT scan .specify/ (upstream spec-kit artifacts; would be clobbered
+#     on next sync)
+#
+# Rule: shebang + first 30 lines must contain top-level `set ... -e`, `set ... -u`,
+# and `pipefail` (any order, multi-line splits accepted; matches must start at
+# line head — not nested inside a function — but all three flags required).
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+scan_dirs=("scripts" "hack" "tests")
+exclude_patterns=("hack/lib/" "hack/verify-shell-safety.sh")
+
+fail=0
+checked=0
+
+while IFS= read -r script; do
+  skip=0
+  for pat in "${exclude_patterns[@]}"; do
+    case "$script" in
+      *"$pat"*) skip=1; break ;;
+    esac
+  done
+  (( skip )) && continue
+
+  checked=$((checked + 1))
+  head_block=$(head -n 30 "$script")
+  if ! grep -qE '^set[[:space:]]+-[a-zA-Z]*e' <<<"$head_block" \
+     || ! grep -qE '^set[[:space:]]+-[a-zA-Z]*u' <<<"$head_block" \
+     || ! grep -qE 'pipefail' <<<"$head_block"; then
+    printf 'FAIL: %s missing `set -euo pipefail` in first 30 lines\n' "$script" >&2
+    fail=1
+  fi
+done < <(find "${scan_dirs[@]}" -type f -name '*.sh' 2>/dev/null | sort)
+
+if (( fail )); then
+  echo "" >&2
+  echo "Add 'set -euo pipefail' immediately after the shebang line." >&2
+  echo "Library files that are sourced (not executed) belong in hack/lib/." >&2
+  exit 1
+fi
+
+printf 'OK (%d scripts checked)\n' "$checked"

--- a/hack/verify-shell-safety.sh
+++ b/hack/verify-shell-safety.sh
@@ -41,9 +41,11 @@ while IFS= read -r script; do
 
   checked=$((checked + 1))
   head_block=$(head -n 30 "$script")
+  # All three checks anchor at line head (`^set`) so `pipefail` mentioned in a
+  # comment or string cannot satisfy the gate.
   if ! grep -qE '^set[[:space:]]+-[a-zA-Z]*e' <<<"$head_block" \
      || ! grep -qE '^set[[:space:]]+-[a-zA-Z]*u' <<<"$head_block" \
-     || ! grep -qE 'pipefail' <<<"$head_block"; then
+     || ! grep -qE '^set[[:space:]].*pipefail' <<<"$head_block"; then
     printf 'FAIL: %s missing `set -euo pipefail` in first 30 lines\n' "$script" >&2
     fail=1
   fi

--- a/scripts/seed-test-data.sh
+++ b/scripts/seed-test-data.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # Seed test data for integration tests
 # Usage: ./scripts/seed-test-data.sh
 echo "Phase 3 seed data: use Go test helpers in adapters/*_integration_test.go"


### PR DESCRIPTION
## Summary

- `scripts/seed-test-data.sh`：补 `set -euo pipefail`，避免 CI 静默吞错（roadmap 029 G4 / SHELL-SAFETY-01 / 027#22 主线）
- 新增 `hack/verify-shell-safety.sh` verify gate，扫 `scripts/ hack/ tests/` 下 `*.sh`，要求顶部 30 行内出现 `set -euo pipefail`；排除 `hack/lib/`（库文件，被 source 调用，加 strict mode 会污染 caller shell）和验证器自身。`hack/make-rules/verify.sh` glob 自动发现，无需改 driver。
- `.github/workflows/security-static.yml` CodeQL 步骤从 Autobuild 切到 `build-mode: manual` + `go build ./...`。Autobuild 扫到 38 个 go.mod（含 `tools/archtest/testdata/` 下 37 个故意违规的 fixture mini-module）后挨个尝试 build，触发 Code Scanning dashboard 的 "Go files were found but not processed"；根 `go build ./...` 不递归进嵌套 module，fixtures 自动跳过。

## 不在范围（明确切割）

- `.specify/scripts/bash/*.sh`（spec-kit 上游产物）：不动；verify gate 不扫 `.specify/`
- `hack/lib/util.sh`（库文件）：不动
- shellcheck 集成：超 G4 范围，留作后续

Refs: roadmap 029 G4 / SHELL-SAFETY-01 / 027#22

## Test plan

- [x] `bash hack/verify-shell-safety.sh` → `OK (17 scripts checked)` exit 0
- [x] 反向断言：未补 strict mode 时 → FAIL 列出 `scripts/seed-test-data.sh`
- [x] `bash hack/make-rules/verify.sh` → `All 13 verify gates passed.`（含新增 verify-shell-safety）
- [x] `bash hack/verify-supply-chain-clean.sh` → OK（CodeQL workflow 改动不命中 bypass-pattern）
- [x] `go build ./...` → exit 0（CodeQL manual mode 等价命令本地通过）
- [x] `golangci-lint run ./...` → 0 issues
- [ ] CI: governance + Security · Static Analysis 全绿