### PR TITLE
refactor(metrics): per-cell HTTP labels via RouteGroup.CellID (D1)

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -24,9 +24,9 @@
 
 `http_requests_total` 与 `http_request_duration_seconds` 的 `cell` label 表示请求落入的 cell：
 
-- **业务请求**：`cell=<cellID>` — 由 `bootstrap.mountOneRouteGroup` 在挂载 `RouteGroup` 时把 `WithCellIDContext(rg.CellID)` 注入到 chi sub-mux，使该 group 内的所有 handler 在请求 ctx 看到具体 cellID（来源 = K#02 `phase5CollectRouteGroups` 自动填充的 `RouteGroup.CellID`）。
-- **框架/未匹配请求**：`cell="_runtime"` 哨兵 — 由 `runtime/http/middleware/metrics.go` 在 listener root mux 上的 `Metrics` 中间件内部 seed（用 `RuntimeCellIDSentinel` 常量），覆盖 `/healthz`、`/readyz`、`/metrics` 自身、404 等所有未落入业务 RouteGroup 的请求。
+- **业务请求**：`cell=<cellID>` — 由 `runtime/http/router.Router.MountRouteGroup` 记录 `RouteGroup.CellID` 与 HTTP namespace 的 ownership，listener-root `CellAttribution` middleware 在 tracing/access-log/metrics/protection 之前写入 `kernel/ctxkeys.CellID`。成功 handler、auth/rate-limit/circuit-breaker/body-limit 前置拒绝、chi 405 都必须使用同一 cell。
+- **框架/未匹配请求**：`cell="_runtime"` 哨兵 — `runtime/http/middleware.Metrics` 在 `ctxkeys.CellID` 缺失时使用 `RuntimeCellIDSentinel`，覆盖 `/healthz`、`/readyz`、`/metrics` 自身、listener 外 404 等所有未落入业务 RouteGroup 的请求。
 
-实现采用 chi `RouteContext` 同款 mutable-pointer 模式：`Metrics` 中间件在 ctx 注入 `*cellIDState{cellID: "_runtime"}`，sub-mux 的 `WithCellIDContext` mutate 该指针的 `cellID` 字段；`Metrics` 在 `next.ServeHTTP` 返回后从同一指针读取，因此 root 层 recorder 看到的是 sub-mux 写入的最终值。这是因为 chi sub-mux 的 `r.WithContext(WithValue(...))` 仅对 child chain 可见，root middleware 的 ctx 不会被自动更新；mutable pointer 恰好解决这个 detached-context 问题。
+`RouteGroup.Prefix` 非空时按 path segment 前缀归属；`Prefix == ""` 不表示拥有整个 listener，而是从该 RouteGroup 内实际注册的 `Route` / `Handle` / `Mount` / `auth.Mount` 合同路径派生归属。重叠 namespace 按最长前缀/最长模板胜出。
 
-`metrics` 中间件读取 `cs.cellID` — 不再读 `ctxkeys`，无 fallback 分支。dashboards / alert 直接 match `cell="_runtime"` 表达框架流量。回退由 `tools/archtest/http_metrics_label_test.go` 4 条 archtest 守护：CTXSOURCE（cellIDState 模式）/ NO-ASSEMBLY-DERIVE / NO-CONFIG-CELLID / RUNTIME-SENTINEL（哨兵字面量）。
+`metrics` 中间件只读取 `ctxkeys.CellIDFrom`，缺失时使用 `_runtime`。route label 对前置拒绝使用 router 的 route-template fallback resolver，避免业务路径拒绝被记为 `route="unmatched"`。回退由 `tools/archtest/http_metrics_label_test.go` 守护：CTXSOURCE / ROUTER-ATTRIBUTION / NO-ASSEMBLY-DERIVE / NO-CONFIG-CELLID / RUNTIME-SENTINEL。

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -19,3 +19,14 @@
 - Adapter readiness probe 使用 stable snake_case，并以后缀 `_ready` 表示依赖可用性，例如 `rabbitmq_ready`、`vault_transit_ready`。
 - 一个 adapter 只有单一外部依赖时，禁止同时暴露多个同义 ready probe；多角色 worker 可用 `component-role` 拆分不同失败域。
 - probe 名是运维契约；改名必须同步 dashboard / alert / 文档，并用 archtest 或单测锁定。
+
+## HTTP Metrics `cell` Label
+
+`http_requests_total` 与 `http_request_duration_seconds` 的 `cell` label 表示请求落入的 cell：
+
+- **业务请求**：`cell=<cellID>` — 由 `bootstrap.mountOneRouteGroup` 在挂载 `RouteGroup` 时把 `WithCellIDContext(rg.CellID)` 注入到 chi sub-mux，使该 group 内的所有 handler 在请求 ctx 看到具体 cellID（来源 = K#02 `phase5CollectRouteGroups` 自动填充的 `RouteGroup.CellID`）。
+- **框架/未匹配请求**：`cell="_runtime"` 哨兵 — 由 `runtime/http/router.go` 在 listener root mux 上安装 `WithCellIDContext("_runtime")`（在 `Metrics` 中间件之前），覆盖 `/healthz`、`/readyz`、`/metrics`、404 等所有未落入业务 RouteGroup 的请求。
+
+`router` 是单一注入点，`bootstrap` 仅做 group 级覆盖；运行时顺序「root → group」配合 `context.WithValue` 后写优先，business cellID 自动覆盖 `_runtime`。
+
+`metrics` 中间件用 `ctxkeys.MustCellIDFrom(r.Context())` 读取 cellID — 缺失即 panic（safeObserve 吞掉 panic 但不录入 metric），保证「无 fallback 静默打错 label」。回退由 `tools/archtest/http_metrics_label_test.go` 4 条 archtest 守护：CTXSOURCE / NO-ASSEMBLY-DERIVE / NO-CONFIG-CELLID / LISTENER-ROOT-RUNTIME。

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -25,8 +25,8 @@
 `http_requests_total` 与 `http_request_duration_seconds` 的 `cell` label 表示请求落入的 cell：
 
 - **业务请求**：`cell=<cellID>` — 由 `bootstrap.mountOneRouteGroup` 在挂载 `RouteGroup` 时把 `WithCellIDContext(rg.CellID)` 注入到 chi sub-mux，使该 group 内的所有 handler 在请求 ctx 看到具体 cellID（来源 = K#02 `phase5CollectRouteGroups` 自动填充的 `RouteGroup.CellID`）。
-- **框架/未匹配请求**：`cell="_runtime"` 哨兵 — 由 `runtime/http/router.go` 在 listener root mux 上安装 `WithCellIDContext("_runtime")`（在 `Metrics` 中间件之前），覆盖 `/healthz`、`/readyz`、`/metrics`、404 等所有未落入业务 RouteGroup 的请求。
+- **框架/未匹配请求**：`cell="_runtime"` 哨兵 — 由 `runtime/http/middleware/metrics.go` 在 listener root mux 上的 `Metrics` 中间件内部 seed（用 `RuntimeCellIDSentinel` 常量），覆盖 `/healthz`、`/readyz`、`/metrics` 自身、404 等所有未落入业务 RouteGroup 的请求。
 
-`router` 是单一注入点，`bootstrap` 仅做 group 级覆盖；运行时顺序「root → group」配合 `context.WithValue` 后写优先，business cellID 自动覆盖 `_runtime`。
+实现采用 chi `RouteContext` 同款 mutable-pointer 模式：`Metrics` 中间件在 ctx 注入 `*cellIDState{cellID: "_runtime"}`，sub-mux 的 `WithCellIDContext` mutate 该指针的 `cellID` 字段；`Metrics` 在 `next.ServeHTTP` 返回后从同一指针读取，因此 root 层 recorder 看到的是 sub-mux 写入的最终值。这是因为 chi sub-mux 的 `r.WithContext(WithValue(...))` 仅对 child chain 可见，root middleware 的 ctx 不会被自动更新；mutable pointer 恰好解决这个 detached-context 问题。
 
-`metrics` 中间件用 `ctxkeys.MustCellIDFrom(r.Context())` 读取 cellID — 缺失即 panic（safeObserve 吞掉 panic 但不录入 metric），保证「无 fallback 静默打错 label」。回退由 `tools/archtest/http_metrics_label_test.go` 4 条 archtest 守护：CTXSOURCE / NO-ASSEMBLY-DERIVE / NO-CONFIG-CELLID / LISTENER-ROOT-RUNTIME。
+`metrics` 中间件读取 `cs.cellID` — 不再读 `ctxkeys`，无 fallback 分支。dashboards / alert 直接 match `cell="_runtime"` 表达框架流量。回退由 `tools/archtest/http_metrics_label_test.go` 4 条 archtest 守护：CTXSOURCE（cellIDState 模式）/ NO-ASSEMBLY-DERIVE / NO-CONFIG-CELLID / RUNTIME-SENTINEL（哨兵字面量）。

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -27,6 +27,12 @@
 - **业务请求**：`cell=<cellID>` — 由 `runtime/http/router.Router.MountRouteGroup` 记录 `RouteGroup.CellID` 与 HTTP namespace 的 ownership，listener-root `CellAttribution` middleware 在 tracing/access-log/metrics/protection 之前写入 `kernel/ctxkeys.CellID`。成功 handler、auth/rate-limit/circuit-breaker/body-limit 前置拒绝、chi 405 都必须使用同一 cell。
 - **框架/未匹配请求**：`cell="_runtime"` 哨兵 — `runtime/http/middleware.Metrics` 在 `ctxkeys.CellID` 缺失时使用 `RuntimeCellIDSentinel`，覆盖 `/healthz`、`/readyz`、`/metrics` 自身、listener 外 404 等所有未落入业务 RouteGroup 的请求。
 
-`RouteGroup.Prefix` 非空时按 path segment 前缀归属；`Prefix == ""` 不表示拥有整个 listener，而是从该 RouteGroup 内实际注册的 `Route` / `Handle` / `Mount` / `auth.Mount` 合同路径派生归属。重叠 namespace 按最长前缀/最长模板胜出。
+`RouteGroup.Prefix` 非空时按 path segment 前缀归属；`Prefix == ""` 不表示拥有整个 listener，而是从该 RouteGroup 内实际注册的 `Route` / `Handle` / `Mount` / `auth.Mount` 合同路径派生归属。重叠 namespace 按最长前缀/最长模板胜出；同一 listener 内跨 cell 声明完全相同的 owner path/template 必须 fail-fast，不能靠注册顺序抢占。
 
 `metrics` 中间件只读取 `ctxkeys.CellIDFrom`，缺失时使用 `_runtime`。route label 对前置拒绝使用 router 的 route-template fallback resolver，避免业务路径拒绝被记为 `route="unmatched"`。回退由 `tools/archtest/http_metrics_label_test.go` 守护：CTXSOURCE / ROUTER-ATTRIBUTION / NO-ASSEMBLY-DERIVE / NO-CONFIG-CELLID / RUNTIME-SENTINEL。
+
+迁移 / 运维约束：
+
+- 不做代码侧 backward-compat / double-write：禁止恢复 `ProviderCollectorConfig.CellID`、assembly/default 推导、旧 label 复制，或同时写新旧 HTTP 指标序列。
+- `cell` 是粗粒度 owner 维度，不是 slice / contract / tenant / user 维度；业务 SLO / 告警默认过滤 `cell!="_runtime"`，运行时探针与未匹配流量排查使用 `cell="_runtime"`。
+- 旧 dashboard / alert 需要过渡时，在 Prometheus 侧用 recording rule 聚合新序列；remote-write 或业务专用 Prometheus 需要降噪时，用 metric relabel drop `_runtime` 序列。示例见 `docs/ops/alerting-rules.md`。

--- a/.claude/rules/gocell/runtime-api.md
+++ b/.claude/rules/gocell/runtime-api.md
@@ -47,7 +47,7 @@ func (c *AccessCore) Init(ctx context.Context, reg cell.Registry) error {
         Register: func(mux cell.RouteMux) error {
             // mux.Route 的 callback 仍是 func(RouteMux) 无 error 返回，
             // 用 outer-variable closure 捕获 slice 错误并通过 Register 返回
-            // 给 phase5。bootstrap/mountOneRouteGroup 用同样模式。
+            // 给 phase5。Router.MountRouteGroup 用同样模式。
             var firstErr error
             captureErr := func(err error) {
                 if err != nil && firstErr == nil {

--- a/adapters/prometheus/exposition_test.go
+++ b/adapters/prometheus/exposition_test.go
@@ -67,14 +67,12 @@ func expose(t *testing.T, reg *prom.Registry) string {
 // is an immediate Grafana regression.
 func TestPrometheusExposition_HTTPCollector_FamiliesAndLabels(t *testing.T) {
 	p, reg := newProvider(t)
-	c, err := runtimemetrics.NewProviderCollector(p, runtimemetrics.ProviderCollectorConfig{
-		CellID: "test-cell",
-	})
+	c, err := runtimemetrics.NewProviderCollector(p, runtimemetrics.ProviderCollectorConfig{})
 	if err != nil {
 		t.Fatalf("NewProviderCollector: %v", err)
 	}
-	c.RecordRequest("GET", "/api/v1/users", 200, 0.15)
-	c.RecordRequest("POST", "/api/v1/users", 201, 0.05)
+	c.RecordRequest("test-cell", "GET", "/api/v1/users", 200, 0.15)
+	c.RecordRequest("test-cell", "POST", "/api/v1/users", 201, 0.05)
 
 	body := expose(t, reg)
 

--- a/cells/auditcore/cell.go
+++ b/cells/auditcore/cell.go
@@ -259,7 +259,21 @@ func (c *AuditCore) Init(ctx context.Context, reg cell.Registry) error {
 		},
 	})
 
-	// Register event subscriptions.
+	if err := c.registerAuditAppendSubscriptions(reg); err != nil {
+		return err
+	}
+
+	// Register health probes (emitter fail-open rate checker).
+	if hc, ok := c.emitter.(cell.HealthProber); ok {
+		for k, v := range hc.Probes() {
+			reg.Health(k, v)
+		}
+	}
+
+	return nil
+}
+
+func (c *AuditCore) registerAuditAppendSubscriptions(reg cell.Registry) error {
 	handler := c.appendSvc.HandleEvent
 	for _, topic := range auditappend.Topics {
 		spec, ok := auditAppendSpecs[topic]
@@ -272,14 +286,6 @@ func (c *AuditCore) Init(ctx context.Context, reg cell.Registry) error {
 			return fmt.Errorf("auditcore: subscribe %s: %w", topic, err)
 		}
 	}
-
-	// Register health probes (emitter fail-open rate checker).
-	if hc, ok := c.emitter.(cell.HealthProber); ok {
-		for k, v := range hc.Probes() {
-			reg.Health(k, v)
-		}
-	}
-
 	return nil
 }
 

--- a/cmd/corebundle/metrics_wiring_integration_test.go
+++ b/cmd/corebundle/metrics_wiring_integration_test.go
@@ -92,8 +92,18 @@ func TestR2_MetricsCollector_RecordsHTTPRequests(t *testing.T) {
 			"This verifies the full wiring chain: WithMetricsProvider → autoWireHTTPMetricsCollector "+
 			"→ router.WithMetricsCollector → middleware.Metrics → RecordRequest → Prometheus registry. "+
 			"Got /metrics body (first 400 chars): %s", truncateMetrics(bodyStr, 400))
-	assert.Contains(t, bodyStr, `cell="corebundle"`,
-		"R2: /metrics output must have cell=\"corebundle\" label (proves auto-wire derives cell label from assembly ID). "+
+	// HTTP-METRICS-LABEL-REALIGN: requests that do not match any cell-owned
+	// RouteGroup must be labelled with the framework "_runtime" sentinel
+	// (installed by router.go), not with the assembly ID. The /healthz hit on
+	// PrimaryListener does not match any RouteGroup (HealthListener carries
+	// /healthz on its own router), so it falls through to the sentinel layer.
+	assert.Contains(t, bodyStr, `cell="_runtime"`,
+		"R2: /metrics output must label framework-owned requests cell=\"_runtime\" "+
+			"(installed by router.go on every listener-root mux). "+
+			"Got /metrics body (first 400 chars): %s", truncateMetrics(bodyStr, 400))
+	assert.NotContains(t, bodyStr, `cell="corebundle"`,
+		"R2: post HTTP-METRICS-LABEL-REALIGN, the assembly ID must not leak into the cell label. "+
+			"A regression that re-derives cellID from b.assemblyID would fail here. "+
 			"Got /metrics body (first 400 chars): %s", truncateMetrics(bodyStr, 400))
 }
 

--- a/cmd/corebundle/metrics_wiring_integration_test.go
+++ b/cmd/corebundle/metrics_wiring_integration_test.go
@@ -66,11 +66,19 @@ func TestR2_MetricsCollector_RecordsHTTPRequests(t *testing.T) {
 	// Wait until the health listener is healthy before firing measurement requests.
 	waitForHealthy(t, healthAddr)
 
-	// Fire a request to the primary listener — this traverses outerMux which
-	// includes the Metrics middleware wired by autoWireHTTPMetricsCollector. The
-	// request is counted against the Prometheus registry backing the auto-wired
-	// collector. Use /healthz on primary (fallback: not found, still traverses
-	// outerMux) — any path will trigger the Metrics middleware.
+	// Fire a real business request to the primary listener. /setup/status is a
+	// public accesscore endpoint, so it exercises the positive e2e path where
+	// phase5 stamps accesscore onto the RouteGroup and router attribution carries
+	// that cell label into the metrics collector.
+	businessResp, err := http.Get("http://" + primaryAddr + "/api/v1/access/setup/status")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, businessResp.StatusCode)
+	businessResp.Body.Close()
+
+	// Fire a request to the primary listener that does not match any cell-owned
+	// RouteGroup. It still traverses outerMux, including the Metrics middleware
+	// wired by autoWireHTTPMetricsCollector, but must keep the framework
+	// "_runtime" sentinel rather than deriving a label from the assembly ID.
 	resp, err := http.Get("http://" + primaryAddr + "/healthz")
 	require.NoError(t, err)
 	resp.Body.Close()
@@ -91,6 +99,9 @@ func TestR2_MetricsCollector_RecordsHTTPRequests(t *testing.T) {
 		"R2: /metrics output must contain http_requests_total{ after at least one request. "+
 			"This verifies the full wiring chain: WithMetricsProvider → autoWireHTTPMetricsCollector "+
 			"→ router.WithMetricsCollector → middleware.Metrics → RecordRequest → Prometheus registry. "+
+			"Got /metrics body (first 400 chars): %s", truncateMetrics(bodyStr, 400))
+	assert.Contains(t, bodyStr, `http_requests_total{cell="accesscore",method="GET",route="/api/v1/access/setup/status",status="200"}`,
+		"R2: /metrics output must label a real accesscore business request cell=\"accesscore\". "+
 			"Got /metrics body (first 400 chars): %s", truncateMetrics(bodyStr, 400))
 	// HTTP-METRICS-LABEL-REALIGN: requests that do not match any cell-owned
 	// RouteGroup must be labelled with the framework "_runtime" sentinel

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -12,6 +12,58 @@
 
 ---
 
+## HTTP Metrics `cell` Label 迁移 / Runbook
+
+HTTP 指标 `gocell_http_requests_total` 与 `gocell_http_request_duration_seconds` 的
+`cell` label 现在表示请求归属的粗粒度 cell owner，由 router root attribution 从
+`RouteGroup.CellID` / HTTP namespace 写入。collector 不再从 assembly/config/default
+推导 cell，也不做旧 label / 新 label 的 double-write。
+
+`cell="_runtime"` 是运行时哨兵，不代表业务 cell 或错误状态。它覆盖没有落入任何
+cell-owned RouteGroup 的请求，例如 `/healthz`、`/readyz`、`/metrics`、listener 外 404、
+framework isolation 404，以及未归属 listener 的流量。业务 RouteGroup namespace 内的
+auth / rate-limit / circuit-breaker / body-limit 前置拒绝和 chi 405 应继续归属对应业务
+cell。
+
+推荐过滤：
+
+- 业务 SLO / 业务错误率 / cell dashboard：`{cell!="_runtime"}`
+- 运行时探针、scrape 自身、未匹配流量排查：`{cell="_runtime"}`
+- listener 总流量 / 容量评估：不过滤 `cell`
+
+Prometheus 侧过渡建议：
+
+```yaml
+groups:
+- name: gocell-http-metrics-cell-label
+  rules:
+  - record: gocell:http_requests:rate5m_by_cell_route_status
+    expr: |
+      sum by (cell, method, route, status) (
+        rate(gocell_http_requests_total{cell!="_runtime"}[5m])
+      )
+  - record: gocell:http_request_duration:p95_by_cell_route
+    expr: |
+      histogram_quantile(
+        0.95,
+        sum by (le, cell, route) (
+          rate(gocell_http_request_duration_seconds_bucket{cell!="_runtime"}[5m])
+        )
+      )
+```
+
+remote-write 或业务专用 Prometheus 若不需要 runtime series，可在 scrape 侧丢弃
+`_runtime`，避免在代码里恢复兼容写入：
+
+```yaml
+metric_relabel_configs:
+- source_labels: [__name__, cell]
+  regex: 'gocell_http_(requests_total|request_duration_seconds(_bucket|_sum|_count)?);_runtime'
+  action: drop
+```
+
+---
+
 ## Outbox 可观测性
 
 ### OutboxEmitFailOpenDropped

--- a/kernel/ctxkeys/keys.go
+++ b/kernel/ctxkeys/keys.go
@@ -27,6 +27,22 @@ func CellIDFrom(ctx context.Context) (string, bool) {
 	return v, ok
 }
 
+// MustCellIDFrom returns the cell ID from ctx or panics when the value is
+// missing or empty. Callers running under HTTP middleware that should always
+// observe an upstream-injected cell ID — for example the runtime/http/middleware
+// metrics recorder running behind the bootstrap-installed cell-id chain — use
+// this helper instead of branching on a fallback. A panic here indicates that
+// the bootstrap injection chain has been bypassed, which is a framework bug
+// rather than a user-facing condition; let it surface so an archtest catches
+// it before the binary ships.
+func MustCellIDFrom(ctx context.Context) string {
+	v, ok := CellIDFrom(ctx)
+	if !ok || v == "" {
+		panic("ctxkeys: cell ID missing from context (bootstrap must inject before downstream middleware reads it)")
+	}
+	return v
+}
+
 // WithSliceID returns a new context carrying the given slice ID.
 func WithSliceID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, SliceID, id)

--- a/kernel/ctxkeys/keys.go
+++ b/kernel/ctxkeys/keys.go
@@ -27,22 +27,6 @@ func CellIDFrom(ctx context.Context) (string, bool) {
 	return v, ok
 }
 
-// MustCellIDFrom returns the cell ID from ctx or panics when the value is
-// missing or empty. Callers running under HTTP middleware that should always
-// observe an upstream-injected cell ID — for example the runtime/http/middleware
-// metrics recorder running behind the bootstrap-installed cell-id chain — use
-// this helper instead of branching on a fallback. A panic here indicates that
-// the bootstrap injection chain has been bypassed, which is a framework bug
-// rather than a user-facing condition; let it surface so an archtest catches
-// it before the binary ships.
-func MustCellIDFrom(ctx context.Context) string {
-	v, ok := CellIDFrom(ctx)
-	if !ok || v == "" {
-		panic("ctxkeys: cell ID missing from context (bootstrap must inject before downstream middleware reads it)")
-	}
-	return v
-}
-
 // WithSliceID returns a new context carrying the given slice ID.
 func WithSliceID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, SliceID, id)

--- a/kernel/ctxkeys/keys_test.go
+++ b/kernel/ctxkeys/keys_test.go
@@ -134,6 +134,24 @@ func TestFromMissingKey(t *testing.T) {
 	}
 }
 
+func TestMustCellIDFrom(t *testing.T) {
+	t.Run("returns id when present", func(t *testing.T) {
+		ctx := WithCellID(context.Background(), "accesscore")
+		assert.Equal(t, "accesscore", MustCellIDFrom(ctx))
+	})
+	t.Run("panics when key absent", func(t *testing.T) {
+		assert.PanicsWithValue(t,
+			"ctxkeys: cell ID missing from context (bootstrap must inject before downstream middleware reads it)",
+			func() { MustCellIDFrom(context.Background()) })
+	})
+	t.Run("panics when value is empty string", func(t *testing.T) {
+		ctx := WithCellID(context.Background(), "")
+		assert.PanicsWithValue(t,
+			"ctxkeys: cell ID missing from context (bootstrap must inject before downstream middleware reads it)",
+			func() { MustCellIDFrom(ctx) })
+	})
+}
+
 func TestMultipleKeysInSameContext(t *testing.T) {
 	ctx := context.Background()
 	ctx = WithCellID(ctx, "accesscore")

--- a/kernel/ctxkeys/keys_test.go
+++ b/kernel/ctxkeys/keys_test.go
@@ -134,24 +134,6 @@ func TestFromMissingKey(t *testing.T) {
 	}
 }
 
-func TestMustCellIDFrom(t *testing.T) {
-	t.Run("returns id when present", func(t *testing.T) {
-		ctx := WithCellID(context.Background(), "accesscore")
-		assert.Equal(t, "accesscore", MustCellIDFrom(ctx))
-	})
-	t.Run("panics when key absent", func(t *testing.T) {
-		assert.PanicsWithValue(t,
-			"ctxkeys: cell ID missing from context (bootstrap must inject before downstream middleware reads it)",
-			func() { MustCellIDFrom(context.Background()) })
-	})
-	t.Run("panics when value is empty string", func(t *testing.T) {
-		ctx := WithCellID(context.Background(), "")
-		assert.PanicsWithValue(t,
-			"ctxkeys: cell ID missing from context (bootstrap must inject before downstream middleware reads it)",
-			func() { MustCellIDFrom(ctx) })
-	})
-}
-
 func TestMultipleKeysInSameContext(t *testing.T) {
 	ctx := context.Background()
 	ctx = WithCellID(ctx, "accesscore")

--- a/runtime/bootstrap/metrics_wiring_test.go
+++ b/runtime/bootstrap/metrics_wiring_test.go
@@ -223,6 +223,8 @@ func TestAutoWire_CellLabel_FromCtxArg(t *testing.T) {
 		"RecordRequest must emit cell=_runtime for the second call")
 	assert.Equal(t, float64(0), reqs.totalForLabel("cell", "my-service"),
 		"a regression that derived cell from assembly ID would fail here")
+	assert.Equal(t, float64(0), reqs.totalForLabel("cell", "default"),
+		"a regression to the legacy default fallback would fail here")
 
 	dur := p.histogram("http_request_duration_seconds")
 	require.NotNil(t, dur)

--- a/runtime/bootstrap/metrics_wiring_test.go
+++ b/runtime/bootstrap/metrics_wiring_test.go
@@ -193,81 +193,41 @@ func TestBootstrap_NoMetricsProvider_NoAutoWire(t *testing.T) {
 	assert.Len(t, opts, 0, "NopProvider must not add any router options")
 }
 
-// TestAutoWire_CellLabel_FromExplicitAssemblyID verifies that WithAssemblyID
-// flows all the way through to the cell label emitted on every RecordRequest
-// call, not just to metric registration. The previous test only proved that
-// http_requests_total was registered — a regression that hard-coded
-// cell="default" inside RecordRequest would still pass that weaker assertion.
-//
-// finding 2 (PR-A66 round-2): close the cell-label behavior gap.
-func TestAutoWire_CellLabel_FromExplicitAssemblyID(t *testing.T) {
+// TestAutoWire_CellLabel_FromCtxArg verifies that the cell label emitted on
+// each RecordRequest call is whatever is passed as the cellID argument — not
+// a global derived from assembly ID. This pins the
+// HTTP-METRICS-LABEL-REALIGN contract: the collector is provider-neutral and
+// the cell identity flows from the request ctx (via Metrics middleware), not
+// from collector construction.
+func TestAutoWire_CellLabel_FromCtxArg(t *testing.T) {
 	t.Parallel()
 	p := newFakeMetricsProvider()
+	// WithAssemblyID is irrelevant to metrics labels post-realign; use it to
+	// prove the assembly ID does not leak into the cell label.
 	b := New(WithClock(clock.Real()), WithMetricsProvider(p), WithAssemblyID("my-service"))
 
 	_, err := b.autoWireHTTPMetricsCollector(nil)
 	require.NoError(t, err)
 	require.NotNil(t, b.httpCollector, "autoWire must cache collector on b.httpCollector")
 
-	// Drive a real RecordRequest through the wired collector. This is the
-	// step the original spy could not exercise: cell label is set per-call,
-	// not per-registration.
-	b.httpCollector.RecordRequest("GET", "/api/v1/users", 200, 0.05)
+	// Driving distinct cellIDs proves the collector does not cache one;
+	// each call emits the cellID it was given.
+	b.httpCollector.RecordRequest("accesscore", "GET", "/api/v1/users", 200, 0.05)
+	b.httpCollector.RecordRequest("_runtime", "GET", "/healthz", 200, 0.001)
 
 	reqs := p.counter("http_requests_total")
 	require.NotNil(t, reqs, "http_requests_total must be registered")
-	assert.Equal(t, float64(1), reqs.totalForLabel("cell", "my-service"),
-		"RecordRequest must emit cell=my-service")
-	assert.Equal(t, float64(0), reqs.totalForLabel("cell", "default"),
-		"a regression that hard-codes cell=default would fail here")
+	assert.Equal(t, float64(1), reqs.totalForLabel("cell", "accesscore"),
+		"RecordRequest must emit cell=accesscore for the first call")
+	assert.Equal(t, float64(1), reqs.totalForLabel("cell", "_runtime"),
+		"RecordRequest must emit cell=_runtime for the second call")
+	assert.Equal(t, float64(0), reqs.totalForLabel("cell", "my-service"),
+		"a regression that derived cell from assembly ID would fail here")
 
 	dur := p.histogram("http_request_duration_seconds")
 	require.NotNil(t, dur)
-	assert.NotEmpty(t, dur.observationsForLabel("cell", "my-service"),
-		"duration histogram must also carry cell=my-service")
-}
-
-// TestAutoWire_CellLabel_DerivedFromAssembly verifies that omitting
-// WithAssemblyID but supplying WithAssembly(asm) makes asm.ID() the cell
-// label — not "default" and not the empty string.
-func TestAutoWire_CellLabel_DerivedFromAssembly(t *testing.T) {
-	t.Parallel()
-	p := newFakeMetricsProvider()
-	asm := assembly.New(assembly.Config{ID: "asm-id-x", DurabilityMode: cell.DurabilityDemo, Clock: clock.Real()})
-	t.Cleanup(asm.Shutdown)
-
-	b := New(WithClock(clock.Real()), WithMetricsProvider(p), WithAssembly(asm))
-
-	_, err := b.autoWireHTTPMetricsCollector(nil)
-	require.NoError(t, err)
-	require.NotNil(t, b.httpCollector)
-	b.httpCollector.RecordRequest("POST", "/api/v1/items", 201, 0.01)
-
-	reqs := p.counter("http_requests_total")
-	require.NotNil(t, reqs)
-	assert.Equal(t, float64(1), reqs.totalForLabel("cell", "asm-id-x"),
-		"cell label must be derived from assembly ID when WithAssemblyID is not set")
-	assert.Equal(t, float64(0), reqs.totalForLabel("cell", "default"),
-		"must not fall back to default when an assembly is wired")
-}
-
-// TestAutoWire_CellLabel_DefaultsWhenNeitherSet pins the no-config fallback
-// so a future change can't silently switch the default. Operators rely on
-// "default" as the sentinel that signals "no assembly identity wired".
-func TestAutoWire_CellLabel_DefaultsWhenNeitherSet(t *testing.T) {
-	t.Parallel()
-	p := newFakeMetricsProvider()
-	b := New(WithClock(clock.Real()), WithMetricsProvider(p))
-
-	_, err := b.autoWireHTTPMetricsCollector(nil)
-	require.NoError(t, err)
-	require.NotNil(t, b.httpCollector)
-	b.httpCollector.RecordRequest("GET", "/healthz", 200, 0.001)
-
-	reqs := p.counter("http_requests_total")
-	require.NotNil(t, reqs)
-	assert.Equal(t, float64(1), reqs.totalForLabel("cell", "default"),
-		"with no WithAssemblyID and no WithAssembly, the cell label must default to 'default'")
+	assert.NotEmpty(t, dur.observationsForLabel("cell", "accesscore"),
+		"duration histogram must also carry cell=accesscore for the first observation")
 }
 
 // TestAutoWireHTTPMetricsCollector_Conflict verifies that when the provider

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -17,6 +17,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/http/health"
+	httpmiddleware "github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	metricsmiddleware "github.com/ghbvf/gocell/runtime/observability/metrics"
 )
@@ -176,10 +178,22 @@ func (b *Bootstrap) phase5MountRouteGroups(routers map[cell.ListenerRef]*router.
 // declare their routes on a different listener). Listener-level authChain is
 // already installed by router.WithDefaultMiddleware; group Middleware runs
 // after that chain at request time (chi sub-mux With order).
+//
+// HTTP-METRICS-LABEL-REALIGN: when rg.CellID is populated by phase5 (every
+// cell-owned RouteGroup), prepend WithCellIDContext(rg.CellID) so the cell
+// identity overrides the listener-root "_runtime" sentinel inside this
+// sub-mux. The chi sub-mux With order is "outer to inner", so a value
+// written here lands later than the root middleware's WithValue and wins.
+// rg.CellID == "" only happens for framework-owned health groups before
+// phase5 stamps them; we leave them on the root sentinel by skipping
+// injection rather than emitting cell="" (an ambiguous label).
 func (b *Bootstrap) mountOneRouteGroup(rtr *router.Router, rg cell.RouteGroup, _ int) error {
 	register := rg.Register
-	if len(rg.Middleware) > 0 {
-		mws := rg.Middleware
+	mws := rg.Middleware
+	if rg.CellID != "" {
+		mws = append([]func(http.Handler) http.Handler{httpmiddleware.WithCellIDContext(rg.CellID)}, mws...)
+	}
+	if len(mws) > 0 {
 		inner := register
 		register = func(sub cell.RouteMux) error {
 			return inner(sub.With(mws...))
@@ -378,6 +392,13 @@ func (b *Bootstrap) buildListenerRouterOpts(_ *phaseState, ref cell.ListenerRef,
 // collector construction will fail with a duplicate-name error. The error is
 // wrapped with an actionable message that tells operators which side to remove.
 //
+// HTTP-METRICS-LABEL-REALIGN: cell labels are no longer derived globally here.
+// router installs WithCellIDContext("_runtime") at the listener-root layer and
+// mountOneRouteGroup overrides it per-cell at the route-group layer; the
+// recorded cell label is the value present in the request context when
+// middleware.Metrics fires. This collector is provider-neutral and labels each
+// observation from its RecordRequest cellID argument.
+//
 // ref: runtime/observability/metrics.NewProviderCollector — provider-neutral
 // HTTP collector that records http_requests_total + http_request_duration_seconds.
 func (b *Bootstrap) autoWireHTTPMetricsCollector(opts []router.Option) ([]router.Option, error) {
@@ -394,21 +415,7 @@ func (b *Bootstrap) autoWireHTTPMetricsCollector(opts []router.Option) ([]router
 	// share the same collector and do not attempt to re-register Prometheus
 	// counters/histograms with the same names.
 	if b.httpCollector == nil {
-		// Derive cell ID from the most specific source available:
-		//  1. Explicit WithAssemblyID — caller's intent takes precedence.
-		//  2. Pre-built assembly's ID (b.assemblyCore.ID()) — avoids requiring callers
-		//     to repeat the assembly ID when using WithAssembly(asm).
-		//  3. Fallback "default" — matches the ID used by the auto-built assembly.
-		cellID := b.assemblyID
-		if cellID == "" && b.assemblyCore != nil {
-			cellID = b.assemblyCore.ID()
-		}
-		if cellID == "" {
-			cellID = "default"
-		}
-		collector, err := metricsmiddleware.NewProviderCollector(b.metricsProvider, metricsmiddleware.ProviderCollectorConfig{
-			CellID: cellID,
-		})
+		collector, err := metricsmiddleware.NewProviderCollector(b.metricsProvider, metricsmiddleware.ProviderCollectorConfig{})
 		if err != nil {
 			return nil, fmt.Errorf(
 				"bootstrap: metrics auto-wire conflict: WithMetricsProvider already constructs the HTTP collector; "+

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -181,11 +181,12 @@ func (b *Bootstrap) phase5MountRouteGroups(routers map[cell.ListenerRef]*router.
 //
 // HTTP-METRICS-LABEL-REALIGN: when rg.CellID is populated by phase5 (every
 // cell-owned RouteGroup), prepend WithCellIDContext(rg.CellID) so the cell
-// identity overrides the listener-root "_runtime" sentinel inside this
-// sub-mux. The chi sub-mux With order is "outer to inner", so a value
-// written here lands later than the root middleware's WithValue and wins.
-// rg.CellID == "" only happens for framework-owned health groups before
-// phase5 stamps them; we leave them on the root sentinel by skipping
+// identity overrides the framework "_runtime" sentinel that
+// middleware.Metrics seeds into the in-flight cellIDState. WithCellIDContext
+// mutates that mutable state pointer (chi-style RouteContext pattern), so
+// the root-mux recorder reads the per-cell value after next.ServeHTTP
+// returns. rg.CellID == "" only happens for framework-owned health groups
+// before phase5 stamps them; we leave them on the sentinel by skipping
 // injection rather than emitting cell="" (an ambiguous label).
 func (b *Bootstrap) mountOneRouteGroup(rtr *router.Router, rg cell.RouteGroup, _ int) error {
 	register := rg.Register
@@ -393,11 +394,13 @@ func (b *Bootstrap) buildListenerRouterOpts(_ *phaseState, ref cell.ListenerRef,
 // wrapped with an actionable message that tells operators which side to remove.
 //
 // HTTP-METRICS-LABEL-REALIGN: cell labels are no longer derived globally here.
-// router installs WithCellIDContext("_runtime") at the listener-root layer and
-// mountOneRouteGroup overrides it per-cell at the route-group layer; the
-// recorded cell label is the value present in the request context when
-// middleware.Metrics fires. This collector is provider-neutral and labels each
-// observation from its RecordRequest cellID argument.
+// middleware.Metrics seeds a mutable cellIDState with RuntimeCellIDSentinel
+// at the listener-root layer; bootstrap.mountOneRouteGroup installs
+// WithCellIDContext on each cell-owned RouteGroup to mutate that state with
+// the cell's ID. The recorded cell label is the value resolved into the
+// state by the time middleware.Metrics fires after next.ServeHTTP returns.
+// This collector is provider-neutral and labels each observation from its
+// RecordRequest cellID argument.
 //
 // ref: runtime/observability/metrics.NewProviderCollector — provider-neutral
 // HTTP collector that records http_requests_total + http_request_duration_seconds.

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -5,7 +5,7 @@ package bootstrap
 //
 // Covers:
 //   - phase5BuildRouters / phase5InitHealthHandler / phase5BuildPerListenerRouters
-//   - phase5CollectRouteGroups / phase5MountRouteGroups / mountOneRouteGroup
+//   - phase5CollectRouteGroups / phase5MountRouteGroups
 //   - phase5FinalizeAllRouters
 //   - validateInternalGuardForDeclaredRoutes / declaredInternalRoutes
 //   - validateAuthVerifierForDeclaredRoutes
@@ -17,7 +17,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"net/http"
 	"sort"
 	"strings"
 
@@ -26,7 +25,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/http/health"
-	httpmiddleware "github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	metricsmiddleware "github.com/ghbvf/gocell/runtime/observability/metrics"
 )
@@ -160,7 +158,7 @@ func (b *Bootstrap) phase5MountRouteGroups(routers map[cell.ListenerRef]*router.
 		if rg.Register == nil {
 			return fmt.Errorf("bootstrap: RouteGroup for listener %q has nil Register function", rg.Listener.String())
 		}
-		if err := b.mountOneRouteGroup(rtr, rg, i); err != nil {
+		if err := rtr.MountRouteGroup(rg); err != nil {
 			cellID := rg.CellID
 			if cellID == "" {
 				cellID = "<framework>"
@@ -170,52 +168,6 @@ func (b *Bootstrap) phase5MountRouteGroups(routers map[cell.ListenerRef]*router.
 		}
 	}
 	return nil
-}
-
-// mountOneRouteGroup mounts a single RouteGroup on its router and applies any
-// non-auth Middleware in declaration order. PR269 round-3: group-level auth is
-// gone — auth scheme is a listener concern (cells that need a different scheme
-// declare their routes on a different listener). Listener-level authChain is
-// already installed by router.WithDefaultMiddleware; group Middleware runs
-// after that chain at request time (chi sub-mux With order).
-//
-// HTTP-METRICS-LABEL-REALIGN: when rg.CellID is populated by phase5 (every
-// cell-owned RouteGroup), prepend WithCellIDContext(rg.CellID) so the cell
-// identity overrides the framework "_runtime" sentinel that
-// middleware.Metrics seeds into the in-flight cellIDState. WithCellIDContext
-// mutates that mutable state pointer (chi-style RouteContext pattern), so
-// the root-mux recorder reads the per-cell value after next.ServeHTTP
-// returns. rg.CellID == "" only happens for framework-owned health groups
-// before phase5 stamps them; we leave them on the sentinel by skipping
-// injection rather than emitting cell="" (an ambiguous label).
-func (b *Bootstrap) mountOneRouteGroup(rtr *router.Router, rg cell.RouteGroup, _ int) error {
-	register := rg.Register
-	mws := rg.Middleware
-	if rg.CellID != "" {
-		mws = append([]func(http.Handler) http.Handler{httpmiddleware.WithCellIDContext(rg.CellID)}, mws...)
-	}
-	if len(mws) > 0 {
-		inner := register
-		register = func(sub cell.RouteMux) error {
-			return inner(sub.With(mws...))
-		}
-	}
-	var registerErr error
-	if rg.Prefix != "" {
-		// rtr.Route signature is from cell.RouteMux which still takes a no-error
-		// closure; capture the Register error via the outer variable so it
-		// surfaces to the phase5 walker. rtr.Route is synchronous (chi.Mux
-		// builds the sub-tree before returning) so registerErr is read after
-		// the closure exits — no data race on the outer variable.
-		rtr.Route(rg.Prefix, func(sub cell.RouteMux) {
-			if err := register(sub); err != nil {
-				registerErr = err
-			}
-		})
-	} else {
-		registerErr = register(rtr)
-	}
-	return registerErr
 }
 
 // phase5FinalizeAllRouters installs /internal/v1/* isolation on the primary
@@ -393,14 +345,9 @@ func (b *Bootstrap) buildListenerRouterOpts(_ *phaseState, ref cell.ListenerRef,
 // collector construction will fail with a duplicate-name error. The error is
 // wrapped with an actionable message that tells operators which side to remove.
 //
-// HTTP-METRICS-LABEL-REALIGN: cell labels are no longer derived globally here.
-// middleware.Metrics seeds a mutable cellIDState with RuntimeCellIDSentinel
-// at the listener-root layer; bootstrap.mountOneRouteGroup installs
-// WithCellIDContext on each cell-owned RouteGroup to mutate that state with
-// the cell's ID. The recorded cell label is the value resolved into the
-// state by the time middleware.Metrics fires after next.ServeHTTP returns.
-// This collector is provider-neutral and labels each observation from its
-// RecordRequest cellID argument.
+// HTTP-METRICS-LABEL-REALIGN: cell labels are resolved by router-owned root
+// attribution from RouteGroup ownership. This collector is provider-neutral
+// and labels each observation from its RecordRequest cellID argument.
 //
 // ref: runtime/observability/metrics.NewProviderCollector — provider-neutral
 // HTTP collector that records http_requests_total + http_request_duration_seconds.

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -97,22 +97,15 @@ func TestPhase5CollectRouteGroups_HealthListenerPresent_PreservesHealthListener(
 	}
 }
 
-// --- mountOneRouteGroup: per-cell metrics label propagation ---
+// --- phase5MountRouteGroups: per-cell metrics label propagation ---
 
-// TestMountOneRouteGroup_PerCellMetricsLabel pins the bootstrap-level
+// TestPhase5MountRouteGroups_PerCellMetricsLabel pins the bootstrap-level
 // contract for HTTP-METRICS-LABEL-REALIGN: when two RouteGroups with
 // different CellID values are mounted on the same router, requests
 // landing in each subtree must produce metrics observations carrying
-// that group's CellID — not the listener-root "_runtime" sentinel and
+// that group's CellID — not the framework "_runtime" sentinel and
 // not a global value derived from assembly identity.
-//
-// This is the unit-test counterpart to the build-tag-gated integration
-// test in cmd/corebundle/metrics_wiring_integration_test.go: it runs
-// during ordinary `go test ./...` and exercises mountOneRouteGroup
-// directly rather than the full Run() lifecycle, so a regression that
-// dropped the per-group WithCellIDContext prepend (e.g. by removing the
-// rg.CellID != "" branch) is caught at unit-test time.
-func TestMountOneRouteGroup_PerCellMetricsLabel(t *testing.T) {
+func TestPhase5MountRouteGroups_PerCellMetricsLabel(t *testing.T) {
 	t.Parallel()
 	mc := metrics.NewInMemoryCollector()
 	rtr, err := router.NewForListener(cell.PrimaryListener,
@@ -147,10 +140,9 @@ func TestMountOneRouteGroup_PerCellMetricsLabel(t *testing.T) {
 			},
 		},
 	}
-	for i, rg := range groups {
-		require.NoError(t, b.mountOneRouteGroup(rtr, rg, i),
-			"mounting RouteGroup %d (cell=%s) must succeed", i, rg.CellID)
-	}
+	require.NoError(t, b.phase5MountRouteGroups(map[cell.ListenerRef]*router.Router{
+		cell.PrimaryListener: rtr,
+	}, groups))
 
 	// Drive one request into each subtree.
 	for _, tc := range []struct{ method, path string }{
@@ -162,19 +154,17 @@ func TestMountOneRouteGroup_PerCellMetricsLabel(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code, "%s %s must reach the cell handler", tc.method, tc.path)
 	}
 
-	// And one request that does NOT match either RouteGroup. The router
-	// installs WithCellIDContext("_runtime") at the listener-root mux
-	// level; an unmatched request should be labeled with that sentinel,
-	// proving the fallback layer remains in place.
+	// And one request that does NOT match either RouteGroup. It should be
+	// labeled with the framework sentinel, proving the fallback remains in place.
 	rec := httptest.NewRecorder()
 	rtr.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/orphan", nil))
 	require.Equal(t, http.StatusNotFound, rec.Code)
 
 	snap := mc.Snapshot()
-	wantKeys := []string{
-		"accesscore GET /api/v1/access/sessions 200",
-		"auditcore GET /api/v1/audit/events 200",
-		"_runtime GET unmatched 404",
+	wantKeys := []metrics.RequestKey{
+		{Cell: "accesscore", Method: http.MethodGet, Route: "/api/v1/access/sessions", Status: http.StatusOK},
+		{Cell: "auditcore", Method: http.MethodGet, Route: "/api/v1/audit/events", Status: http.StatusOK},
+		{Cell: "_runtime", Method: http.MethodGet, Route: "unmatched", Status: http.StatusNotFound},
 	}
 	for _, key := range wantKeys {
 		assert.Equalf(t, int64(1), snap.RequestCounts[key],
@@ -186,7 +176,7 @@ func TestMountOneRouteGroup_PerCellMetricsLabel(t *testing.T) {
 	// fallback must NOT appear — neither path should leak into metrics.
 	for _, forbidden := range []string{"phase5-test", "default"} {
 		for key := range snap.RequestCounts {
-			assert.NotContainsf(t, key, forbidden+" ",
+			assert.NotEqualf(t, forbidden, key.Cell,
 				"cell label %q must not appear in metrics snapshot (regression to global cellID derivation)", forbidden)
 		}
 	}

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -139,6 +139,18 @@ func TestPhase5MountRouteGroups_PerCellMetricsLabel(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			Listener: cell.PrimaryListener,
+			Prefix:   "/framework",
+			// CellID intentionally empty: framework-owned RouteGroups should
+			// serve real matched routes but record metrics under _runtime.
+			Register: func(mux cell.RouteMux) error {
+				mux.Handle("GET /ping", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}))
+				return nil
+			},
+		},
 	}
 	require.NoError(t, b.phase5MountRouteGroups(map[cell.ListenerRef]*router.Router{
 		cell.PrimaryListener: rtr,
@@ -154,9 +166,21 @@ func TestPhase5MountRouteGroups_PerCellMetricsLabel(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code, "%s %s must reach the cell handler", tc.method, tc.path)
 	}
 
+	// A registered RouteGroup without CellID is a matched framework-owned route,
+	// not an unmatched 404. It must still record under the _runtime sentinel.
+	rec := httptest.NewRecorder()
+	rtr.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/framework/ping", nil))
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Method mismatches on framework-owned RouteGroups should keep _runtime but
+	// still use the route-template fallback rather than route="unmatched".
+	rec = httptest.NewRecorder()
+	rtr.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/framework/ping", nil))
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+
 	// And one request that does NOT match either RouteGroup. It should be
 	// labeled with the framework sentinel, proving the fallback remains in place.
-	rec := httptest.NewRecorder()
+	rec = httptest.NewRecorder()
 	rtr.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/orphan", nil))
 	require.Equal(t, http.StatusNotFound, rec.Code)
 
@@ -164,6 +188,8 @@ func TestPhase5MountRouteGroups_PerCellMetricsLabel(t *testing.T) {
 	wantKeys := []metrics.RequestKey{
 		{Cell: "accesscore", Method: http.MethodGet, Route: "/api/v1/access/sessions", Status: http.StatusOK},
 		{Cell: "auditcore", Method: http.MethodGet, Route: "/api/v1/audit/events", Status: http.StatusOK},
+		{Cell: "_runtime", Method: http.MethodGet, Route: "/framework/ping", Status: http.StatusNoContent},
+		{Cell: "_runtime", Method: http.MethodPost, Route: "/framework/ping", Status: http.StatusMethodNotAllowed},
 		{Cell: "_runtime", Method: http.MethodGet, Route: "unmatched", Status: http.StatusNotFound},
 	}
 	for _, key := range wantKeys {

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/ghbvf/gocell/runtime/config"
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/http/router"
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
 // --- phase5CollectRouteGroups: HealthListener fallback tests (R2-07) ---
@@ -91,6 +94,101 @@ func TestPhase5CollectRouteGroups_HealthListenerPresent_PreservesHealthListener(
 	for i, rg := range groups {
 		assert.Equal(t, cell.HealthListener, rg.Listener,
 			"group[%d]: with HealthListener declared, framework health groups must stay on HealthListener (no fallback remap)", i)
+	}
+}
+
+// --- mountOneRouteGroup: per-cell metrics label propagation ---
+
+// TestMountOneRouteGroup_PerCellMetricsLabel pins the bootstrap-level
+// contract for HTTP-METRICS-LABEL-REALIGN: when two RouteGroups with
+// different CellID values are mounted on the same router, requests
+// landing in each subtree must produce metrics observations carrying
+// that group's CellID — not the listener-root "_runtime" sentinel and
+// not a global value derived from assembly identity.
+//
+// This is the unit-test counterpart to the build-tag-gated integration
+// test in cmd/corebundle/metrics_wiring_integration_test.go: it runs
+// during ordinary `go test ./...` and exercises mountOneRouteGroup
+// directly rather than the full Run() lifecycle, so a regression that
+// dropped the per-group WithCellIDContext prepend (e.g. by removing the
+// rg.CellID != "" branch) is caught at unit-test time.
+func TestMountOneRouteGroup_PerCellMetricsLabel(t *testing.T) {
+	t.Parallel()
+	mc := metrics.NewInMemoryCollector()
+	rtr, err := router.NewForListener(cell.PrimaryListener,
+		router.WithRouterClock(clock.Real()),
+		router.WithMetricsCollector(mc),
+	)
+	require.NoError(t, err)
+
+	b := New(WithClock(clock.Real()))
+
+	groups := []cell.RouteGroup{
+		{
+			Listener: cell.PrimaryListener,
+			Prefix:   "/api/v1/access",
+			CellID:   "accesscore",
+			Register: func(mux cell.RouteMux) error {
+				mux.Handle("/sessions", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+				return nil
+			},
+		},
+		{
+			Listener: cell.PrimaryListener,
+			Prefix:   "/api/v1/audit",
+			CellID:   "auditcore",
+			Register: func(mux cell.RouteMux) error {
+				mux.Handle("/events", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+				return nil
+			},
+		},
+	}
+	for i, rg := range groups {
+		require.NoError(t, b.mountOneRouteGroup(rtr, rg, i),
+			"mounting RouteGroup %d (cell=%s) must succeed", i, rg.CellID)
+	}
+
+	// Drive one request into each subtree.
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/v1/access/sessions"},
+		{http.MethodGet, "/api/v1/audit/events"},
+	} {
+		rec := httptest.NewRecorder()
+		rtr.Handler().ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+		require.Equal(t, http.StatusOK, rec.Code, "%s %s must reach the cell handler", tc.method, tc.path)
+	}
+
+	// And one request that does NOT match either RouteGroup. The router
+	// installs WithCellIDContext("_runtime") at the listener-root mux
+	// level; an unmatched request should be labeled with that sentinel,
+	// proving the fallback layer remains in place.
+	rec := httptest.NewRecorder()
+	rtr.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/orphan", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	snap := mc.Snapshot()
+	wantKeys := []string{
+		"accesscore GET /api/v1/access/sessions 200",
+		"auditcore GET /api/v1/audit/events 200",
+		"_runtime GET unmatched 404",
+	}
+	for _, key := range wantKeys {
+		assert.Equalf(t, int64(1), snap.RequestCounts[key],
+			"want exactly one observation under %q; full snapshot=%v", key, snap.RequestCounts)
+	}
+
+	// Negative assertion: the assembly-derived "phase5-test" cellID
+	// (from buildPhase5State, were it used) and the legacy "default"
+	// fallback must NOT appear — neither path should leak into metrics.
+	for _, forbidden := range []string{"phase5-test", "default"} {
+		for key := range snap.RequestCounts {
+			assert.NotContainsf(t, key, forbidden+" ",
+				"cell label %q must not appear in metrics snapshot (regression to global cellID derivation)", forbidden)
+		}
 	}
 }
 

--- a/runtime/http/middleware/access_log.go
+++ b/runtime/http/middleware/access_log.go
@@ -7,15 +7,16 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	kctxkeys "github.com/ghbvf/gocell/kernel/ctxkeys"
+	pkgctxkeys "github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/logutil"
 )
 
 // AccessLog returns an HTTP middleware that logs structured request/response
 // information via slog.Info. A clock must be provided; use clock.Real() at the
 // composition root.
-// Fields: method, path, route, status, duration_ms, listener, request_id,
-// correlation_id, trace_id, real_ip. The listener field is emitted only when
+// Fields: method, path, route, status, duration_ms, listener, cell_id,
+// request_id, correlation_id, trace_id, real_ip. The listener field is emitted only when
 // the router annotated the request with a non-empty physical listener name.
 //
 // ref: go-zero rest/handler/loghandler.go — structured request logging with trace context
@@ -77,10 +78,11 @@ func accessLogAttrs(start time.Time, method, path, route string, state *Recorder
 
 func appendAccessLogContextAttrs(attrs []any, ctx context.Context) []any {
 	attrs = appendAccessLogAttrFrom(ctx, attrs, "listener", listenerFromContext)
-	attrs = appendAccessLogAttrFrom(ctx, attrs, "request_id", ctxkeys.RequestIDFrom)
-	attrs = appendAccessLogAttrFrom(ctx, attrs, "correlation_id", ctxkeys.CorrelationIDFrom)
-	attrs = appendAccessLogAttrFrom(ctx, attrs, "trace_id", ctxkeys.TraceIDFrom)
-	attrs = appendAccessLogAttrFrom(ctx, attrs, "real_ip", ctxkeys.RealIPFrom)
+	attrs = appendAccessLogAttrFrom(ctx, attrs, "cell_id", kctxkeys.CellIDFrom)
+	attrs = appendAccessLogAttrFrom(ctx, attrs, "request_id", pkgctxkeys.RequestIDFrom)
+	attrs = appendAccessLogAttrFrom(ctx, attrs, "correlation_id", pkgctxkeys.CorrelationIDFrom)
+	attrs = appendAccessLogAttrFrom(ctx, attrs, "trace_id", pkgctxkeys.TraceIDFrom)
+	attrs = appendAccessLogAttrFrom(ctx, attrs, "real_ip", pkgctxkeys.RealIPFrom)
 	return attrs
 }
 

--- a/runtime/http/middleware/access_log_test.go
+++ b/runtime/http/middleware/access_log_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	kctxkeys "github.com/ghbvf/gocell/kernel/ctxkeys"
+	pkgctxkeys "github.com/ghbvf/gocell/pkg/ctxkeys"
 )
 
 func TestAccessLog_LogsFields(t *testing.T) {
@@ -30,8 +31,8 @@ func TestAccessLog_LogsFields(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
 	// Simulate request_id already in context
-	ctx := ctxkeys.WithRequestID(req.Context(), "req-123")
-	ctx = ctxkeys.WithCorrelationID(ctx, "corr-123")
+	ctx := pkgctxkeys.WithRequestID(req.Context(), "req-123")
+	ctx = pkgctxkeys.WithCorrelationID(ctx, "corr-123")
 	req = req.WithContext(ctx)
 
 	rec := httptest.NewRecorder()
@@ -113,7 +114,7 @@ func TestAccessLog_TraceID_WhenSet(t *testing.T) {
 	handler := Recorder(AccessLog(clock.Real())(inner))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	ctx := ctxkeys.WithTraceID(req.Context(), "abc123trace")
+	ctx := pkgctxkeys.WithTraceID(req.Context(), "abc123trace")
 	req = req.WithContext(ctx)
 
 	rec := httptest.NewRecorder()
@@ -122,6 +123,28 @@ func TestAccessLog_TraceID_WhenSet(t *testing.T) {
 	var logEntry map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
 	assert.Equal(t, "abc123trace", logEntry["trace_id"])
+}
+
+func TestAccessLog_CellID_WhenSet(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	original := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(original)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := Recorder(AccessLog(clock.Real())(inner))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/users", nil)
+	req = req.WithContext(kctxkeys.WithCellID(req.Context(), "accesscore"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var logEntry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
+	assert.Equal(t, "accesscore", logEntry["cell_id"])
 }
 
 func TestAccessLog_Listener_WhenSet(t *testing.T) {

--- a/runtime/http/middleware/cell_id.go
+++ b/runtime/http/middleware/cell_id.go
@@ -1,101 +1,34 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
 )
 
 // RuntimeCellIDSentinel is the framework "owner" used as the cell label for
-// requests that do not match any cell-owned RouteGroup (healthz, readyz, the
-// metrics endpoint itself, unmatched 404s, listeners with no business
-// RouteGroup attached). The string is part of the operator-visible Prometheus
-// label space, so dashboards / alert rules can match `cell="_runtime"` for
-// framework traffic.
+// requests that do not belong to any cell-owned HTTP namespace.
 const RuntimeCellIDSentinel = "_runtime"
 
-// cellIDState holds the cell identity for the current in-flight request. It
-// is intentionally a pointer to a mutable struct rather than a string-valued
-// context value so that metrics middleware running on the *root* mux can
-// observe a value written by sub-mux middleware after chi dispatch — see
-// chi's RouteContext for the same pattern.
-//
-// Why mutable state rather than ctxkeys.WithCellID alone: chi sub-mux
-// middleware that calls r.WithContext(WithValue(ctx, CellID, x)) only
-// affects the *child* call chain. Middleware further out (root-mux
-// metrics) keeps its own ctx and would read the stale outer value. By
-// storing a *cellIDState in ctx at the root and having sub-mux middleware
-// mutate the embedded field instead of replacing the ctx, the metrics
-// recorder sees the cell-resolved value when it fires after next.ServeHTTP
-// returns.
-type cellIDState struct {
-	cellID string
-}
+// CellResolver maps a concrete request to the owning cell ID.
+type CellResolver func(method, path string) (string, bool)
 
-type cellIDStateKeyT struct{}
-
-var cellIDStateKey = cellIDStateKeyT{}
-
-// withCellIDState attaches a fresh cellIDState (initialized to the supplied
-// sentinel) to ctx. Used by middleware.Metrics at the listener-root layer.
-func withCellIDState(ctx context.Context, sentinel string) (context.Context, *cellIDState) {
-	cs := &cellIDState{cellID: sentinel}
-	return context.WithValue(ctx, cellIDStateKey, cs), cs
-}
-
-// cellIDStateFrom retrieves the in-flight cellIDState attached by Metrics
-// at the listener-root layer. Returns nil when no metrics layer is upstream
-// (e.g. middleware tested in isolation without a router) — callers must
-// handle the nil case rather than dereferencing.
-func cellIDStateFrom(ctx context.Context) *cellIDState {
-	if cs, ok := ctx.Value(cellIDStateKey).(*cellIDState); ok {
-		return cs
-	}
-	return nil
-}
-
-// WithCellIDContext returns an HTTP middleware that records a cell identity
-// for the current request in two channels:
-//
-//   - It writes ctxkeys.CellID via context.WithValue, so handlers and
-//     downstream middleware (logging, tracing) read the cell ID through the
-//     usual ctxkeys.CellIDFrom helper.
-//   - It mutates the *cellIDState attached upstream by middleware.Metrics
-//     so the root-mux recorder, which fires *after* this sub-mux middleware
-//     returns, observes the per-cell value rather than the sentinel
-//     installed at the listener-root.
-//
-// bootstrap.mountOneRouteGroup installs this middleware on every cell-owned
-// RouteGroup with the cell's CellID; framework-owned routes (healthz / readyz
-// / the metrics endpoint itself / unmatched paths) leave the metrics
-// recorder's default sentinel in place.
-//
-// Empty-cellID guard: an empty cellID is silently ignored on the metrics
-// state — the upstream sentinel survives so dashboards keep matching the
-// framework label. The ctxkeys side is also skipped so logging/tracing do
-// not record a misleading empty cell ID. PANIC-REGISTERED-01 (ADR) prohibits
-// fail-fast panic at this layer, and bootstrap.mountOneRouteGroup already
-// guards rg.CellID != "" before installing this middleware, so the only way
-// to reach the empty branch is a future caller that constructs the handler
-// directly — that caller's mistake should not corrupt the cell label space.
-//
-// ref: go-chi/chi RouteContext — same mutable-pointer pattern for letting
-// outer middleware observe a value resolved by sub-mux dispatch.
-// ref: kubernetes apiserver pkg/endpoints/metrics/metrics.go — component
-// label captured at registration time as a constant.
-func WithCellIDContext(cellID string) func(http.Handler) http.Handler {
+// CellAttribution writes the owning cell ID into request context before
+// protection middleware can short-circuit. Requests with no resolved cell keep
+// an absent ctx key; Metrics converts absence to RuntimeCellIDSentinel.
+func CellAttribution(resolve CellResolver) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-			if cellID == "" {
+			if resolve == nil {
 				next.ServeHTTP(w, r)
 				return
 			}
-			if cs := cellIDStateFrom(ctx); cs != nil {
-				cs.cellID = cellID
+			cellID, ok := resolve(r.Method, r.URL.Path)
+			if !ok || cellID == "" {
+				next.ServeHTTP(w, r)
+				return
 			}
-			next.ServeHTTP(w, r.WithContext(ctxkeys.WithCellID(ctx, cellID)))
+			next.ServeHTTP(w, r.WithContext(ctxkeys.WithCellID(r.Context(), cellID)))
 		})
 	}
 }

--- a/runtime/http/middleware/cell_id.go
+++ b/runtime/http/middleware/cell_id.go
@@ -1,32 +1,88 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
 )
 
-// WithCellIDContext returns an HTTP middleware that injects a cell identity
-// into the request context using ctxkeys.WithCellID. Bootstrap installs one
-// instance per listener (with the framework "_runtime" sentinel) and one per
-// RouteGroup (with the cell's actual ID); group-level installation runs after
-// listener-level installation, so the per-cell value overrides the runtime
-// sentinel for any request that lands inside a registered RouteGroup.
+// RuntimeCellIDSentinel is the framework "owner" used as the cell label for
+// requests that do not match any cell-owned RouteGroup (healthz, readyz, the
+// metrics endpoint itself, unmatched 404s, listeners with no business
+// RouteGroup attached). The string is part of the operator-visible Prometheus
+// label space, so dashboards / alert rules can match `cell="_runtime"` for
+// framework traffic.
+const RuntimeCellIDSentinel = "_runtime"
+
+// cellIDState holds the cell identity for the current in-flight request. It
+// is intentionally a pointer to a mutable struct rather than a string-valued
+// context value so that metrics middleware running on the *root* mux can
+// observe a value written by sub-mux middleware after chi dispatch — see
+// chi's RouteContext for the same pattern.
 //
-// Callers must supply a non-empty cellID; both call sites (router.go literal
-// "_runtime" and bootstrap.mountOneRouteGroup guarded by rg.CellID != "")
-// already enforce that. The downstream invariant — that ctxkeys.MustCellIDFrom
-// always finds a non-empty value — is locked by HTTP-METRICS-LABEL-LISTENER-
-// ROOT-RUNTIME-01 archtest and by middleware.Metrics's own panic on missing
-// ctx.
+// Why mutable state rather than ctxkeys.WithCellID alone: chi sub-mux
+// middleware that calls r.WithContext(WithValue(ctx, CellID, x)) only
+// affects the *child* call chain. Middleware further out (root-mux
+// metrics) keeps its own ctx and would read the stale outer value. By
+// storing a *cellIDState in ctx at the root and having sub-mux middleware
+// mutate the embedded field instead of replacing the ctx, the metrics
+// recorder sees the cell-resolved value when it fires after next.ServeHTTP
+// returns.
+type cellIDState struct {
+	cellID string
+}
+
+type cellIDStateKeyT struct{}
+
+var cellIDStateKey = cellIDStateKeyT{}
+
+// withCellIDState attaches a fresh cellIDState (initialized to the supplied
+// sentinel) to ctx. Used by middleware.Metrics at the listener-root layer.
+func withCellIDState(ctx context.Context, sentinel string) (context.Context, *cellIDState) {
+	cs := &cellIDState{cellID: sentinel}
+	return context.WithValue(ctx, cellIDStateKey, cs), cs
+}
+
+// cellIDStateFrom retrieves the in-flight cellIDState attached by Metrics
+// at the listener-root layer. Returns nil when no metrics layer is upstream
+// (e.g. middleware tested in isolation without a router) — callers must
+// handle the nil case rather than dereferencing.
+func cellIDStateFrom(ctx context.Context) *cellIDState {
+	if cs, ok := ctx.Value(cellIDStateKey).(*cellIDState); ok {
+		return cs
+	}
+	return nil
+}
+
+// WithCellIDContext returns an HTTP middleware that records a cell identity
+// for the current request in two channels:
 //
-// ref: kubernetes/kubernetes apiserver/pkg/endpoints/metrics/metrics.go —
-// component label captured at registration time as a constant, not derived
-// from the request.
+//   - It writes ctxkeys.CellID via context.WithValue, so handlers and
+//     downstream middleware (logging, tracing) read the cell ID through the
+//     usual ctxkeys.CellIDFrom helper.
+//   - It mutates the *cellIDState attached upstream by middleware.Metrics
+//     so the root-mux recorder, which fires *after* this sub-mux middleware
+//     returns, observes the per-cell value rather than the sentinel
+//     installed at the listener-root.
+//
+// bootstrap.mountOneRouteGroup installs this middleware on every cell-owned
+// RouteGroup with the cell's CellID; framework-owned routes (healthz / readyz
+// / the metrics endpoint itself / unmatched paths) leave the metrics
+// recorder's default sentinel in place.
+//
+// ref: go-chi/chi RouteContext — same mutable-pointer pattern for letting
+// outer middleware observe a value resolved by sub-mux dispatch.
+// ref: kubernetes apiserver pkg/endpoints/metrics/metrics.go — component
+// label captured at registration time as a constant.
 func WithCellIDContext(cellID string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r.WithContext(ctxkeys.WithCellID(r.Context(), cellID)))
+			ctx := r.Context()
+			if cs := cellIDStateFrom(ctx); cs != nil {
+				cs.cellID = cellID
+			}
+			next.ServeHTTP(w, r.WithContext(ctxkeys.WithCellID(ctx, cellID)))
 		})
 	}
 }

--- a/runtime/http/middleware/cell_id.go
+++ b/runtime/http/middleware/cell_id.go
@@ -71,6 +71,15 @@ func cellIDStateFrom(ctx context.Context) *cellIDState {
 // / the metrics endpoint itself / unmatched paths) leave the metrics
 // recorder's default sentinel in place.
 //
+// Empty-cellID guard: an empty cellID is silently ignored on the metrics
+// state — the upstream sentinel survives so dashboards keep matching the
+// framework label. The ctxkeys side is also skipped so logging/tracing do
+// not record a misleading empty cell ID. PANIC-REGISTERED-01 (ADR) prohibits
+// fail-fast panic at this layer, and bootstrap.mountOneRouteGroup already
+// guards rg.CellID != "" before installing this middleware, so the only way
+// to reach the empty branch is a future caller that constructs the handler
+// directly — that caller's mistake should not corrupt the cell label space.
+//
 // ref: go-chi/chi RouteContext — same mutable-pointer pattern for letting
 // outer middleware observe a value resolved by sub-mux dispatch.
 // ref: kubernetes apiserver pkg/endpoints/metrics/metrics.go — component
@@ -79,6 +88,10 @@ func WithCellIDContext(cellID string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+			if cellID == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
 			if cs := cellIDStateFrom(ctx); cs != nil {
 				cs.cellID = cellID
 			}

--- a/runtime/http/middleware/cell_id.go
+++ b/runtime/http/middleware/cell_id.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/ghbvf/gocell/kernel/ctxkeys"
+)
+
+// WithCellIDContext returns an HTTP middleware that injects a cell identity
+// into the request context using ctxkeys.WithCellID. Bootstrap installs one
+// instance per listener (with the framework "_runtime" sentinel) and one per
+// RouteGroup (with the cell's actual ID); group-level installation runs after
+// listener-level installation, so the per-cell value overrides the runtime
+// sentinel for any request that lands inside a registered RouteGroup.
+//
+// Callers must supply a non-empty cellID; both call sites (router.go literal
+// "_runtime" and bootstrap.mountOneRouteGroup guarded by rg.CellID != "")
+// already enforce that. The downstream invariant — that ctxkeys.MustCellIDFrom
+// always finds a non-empty value — is locked by HTTP-METRICS-LABEL-LISTENER-
+// ROOT-RUNTIME-01 archtest and by middleware.Metrics's own panic on missing
+// ctx.
+//
+// ref: kubernetes/kubernetes apiserver/pkg/endpoints/metrics/metrics.go —
+// component label captured at registration time as a constant, not derived
+// from the request.
+func WithCellIDContext(cellID string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(ctxkeys.WithCellID(r.Context(), cellID)))
+		})
+	}
+}

--- a/runtime/http/middleware/cell_id_test.go
+++ b/runtime/http/middleware/cell_id_test.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ghbvf/gocell/kernel/ctxkeys"
+)
+
+func TestWithCellIDContext_InjectsCellIDIntoCtx(t *testing.T) {
+	var observed string
+	handler := WithCellIDContext("accesscore")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = ctxkeys.MustCellIDFrom(r.Context())
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil))
+
+	assert.Equal(t, "accesscore", observed)
+}
+
+func TestWithCellIDContext_GroupOverridesRoot(t *testing.T) {
+	// Listener-root middleware (_runtime sentinel) wraps the route-group
+	// middleware (cell ID), which wraps the handler. The handler must
+	// observe the route-group cell ID — the inner WithValue overrides the
+	// outer one for the same key.
+	var observed string
+	final := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = ctxkeys.MustCellIDFrom(r.Context())
+	})
+	chain := WithCellIDContext("_runtime")(WithCellIDContext("accesscore")(final))
+
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil))
+
+	assert.Equal(t, "accesscore", observed)
+}
+
+func TestWithCellIDContext_RuntimeSentinelReachesUnmatchedHandler(t *testing.T) {
+	// When only the listener-root layer is installed (no RouteGroup matched),
+	// the handler still observes a non-empty cell ID — the framework sentinel.
+	var observed string
+	handler := WithCellIDContext("_runtime")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = ctxkeys.MustCellIDFrom(r.Context())
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	assert.Equal(t, "_runtime", observed)
+}
+
+func TestWithCellIDContext_EmptyCellIDInjectsEmptyValue(t *testing.T) {
+	// WithCellIDContext does not validate cellID — both call sites
+	// (router.go literal "_runtime" and bootstrap.mountOneRouteGroup
+	// guarded by rg.CellID != "") already enforce non-empty. The
+	// downstream consumer middleware.Metrics calls MustCellIDFrom and
+	// panics on empty value — that is the single fail-fast point. This
+	// test pins the lightweight constructor contract: empty in, empty
+	// out, no early panic.
+	var observed string
+	final := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		v, _ := ctxkeys.CellIDFrom(r.Context())
+		observed = v
+	})
+	chain := WithCellIDContext("")(final)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, "", observed)
+}

--- a/runtime/http/middleware/cell_id_test.go
+++ b/runtime/http/middleware/cell_id_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,101 +10,31 @@ import (
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
 )
 
-func TestWithCellIDContext_WritesCtxkey(t *testing.T) {
-	// The sub-mux WithCellIDContext middleware must update ctxkeys.CellID so
-	// downstream logging/tracing observes the cell ID inside the handler.
-	var observed string
-	handler := WithCellIDContext("accesscore")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		v, _ := ctxkeys.CellIDFrom(r.Context())
-		observed = v
+func TestCellAttribution_WritesCtxkey(t *testing.T) {
+	handler := CellAttribution(func(method, path string) (string, bool) {
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/api/v1/access/users", path)
+		return "accesscore", true
+	})(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		v, ok := ctxkeys.CellIDFrom(r.Context())
+		assert.True(t, ok)
+		assert.Equal(t, "accesscore", v)
 	}))
 
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil))
-
-	assert.Equal(t, "accesscore", observed)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/access/users", nil))
 }
 
-func TestWithCellIDContext_MutatesCellIDStateForOuterMetrics(t *testing.T) {
-	// Recreate the production layout: an outer middleware seeds *cellIDState
-	// with RuntimeCellIDSentinel (the analog of metrics.Metrics on the
-	// listener-root mux); a sub-mux WithCellIDContext mutates the same
-	// pointer; the outer middleware reads the resolved value after next.
-	var resolved string
-	outer := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, cs := withCellIDState(r.Context(), RuntimeCellIDSentinel)
-			next.ServeHTTP(w, r.WithContext(ctx))
-			resolved = cs.cellID
-		})
-	}
-	final := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
-	chain := outer(WithCellIDContext("accesscore")(final))
-
-	rec := httptest.NewRecorder()
-	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil))
-
-	assert.Equal(t, "accesscore", resolved,
-		"outer (root-mux) middleware must observe the cell ID written by the inner (sub-mux) layer; "+
-			"this is the chi-style mutable-pointer pattern that the metrics recorder depends on")
-}
-
-func TestWithCellIDContext_NoUpstreamStateIsNop(t *testing.T) {
-	// When there is no metrics layer upstream (e.g. a unit test exercises
-	// WithCellIDContext alone), mutating the absent state must not panic and
-	// the ctxkeys write must still happen so logging/tracing keeps working.
-	var seen string
-	handler := WithCellIDContext("accesscore")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		v, _ := ctxkeys.CellIDFrom(r.Context())
-		seen = v
+func TestCellAttribution_UnresolvedLeavesCtxkeyAbsent(t *testing.T) {
+	handler := CellAttribution(func(string, string) (string, bool) {
+		return "", false
+	})(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, ok := ctxkeys.CellIDFrom(r.Context())
+		assert.False(t, ok)
 	}))
 
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-
-	assert.Equal(t, "accesscore", seen)
-}
-
-func TestCellIDStateFrom_ReturnsNilWhenUnattached(t *testing.T) {
-	assert.Nil(t, cellIDStateFrom(context.Background()),
-		"cellIDStateFrom must return nil when no metrics layer attached the state — "+
-			"callers must handle this rather than dereference unconditionally")
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/healthz", nil))
 }
 
 func TestRuntimeCellIDSentinel_IsExportedConstant(t *testing.T) {
-	// Pin the sentinel value: dashboards / alerts match against this literal,
-	// and the archtest pulls it directly from this constant.
 	assert.Equal(t, "_runtime", RuntimeCellIDSentinel)
-}
-
-func TestWithCellIDContext_EmptyCellIDPreservesSentinel(t *testing.T) {
-	// An empty cellID at this layer is a programming error (bootstrap guards
-	// rg.CellID != "" before installing). The middleware silently skips both
-	// the cellIDState mutation and the ctxkeys write so a future caller that
-	// constructs the handler directly with an empty value cannot corrupt the
-	// metrics label space — the upstream sentinel survives, and downstream
-	// logging/tracing do not record a misleading empty cell ID.
-	var sentinel string
-	outer := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, cs := withCellIDState(r.Context(), RuntimeCellIDSentinel)
-			next.ServeHTTP(w, r.WithContext(ctx))
-			sentinel = cs.cellID
-		})
-	}
-	var observedCtxkey string
-	var observedCtxkeyOK bool
-	final := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		observedCtxkey, observedCtxkeyOK = ctxkeys.CellIDFrom(r.Context())
-	})
-	chain := outer(WithCellIDContext("")(final))
-
-	rec := httptest.NewRecorder()
-	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-
-	assert.Equal(t, RuntimeCellIDSentinel, sentinel,
-		"empty cellID must not overwrite the metrics sentinel — dashboards rely on _runtime for framework traffic")
-	assert.False(t, observedCtxkeyOK,
-		"empty cellID must not write to ctxkeys — logging/tracing must not record an empty cell ID")
-	assert.Equal(t, "", observedCtxkey)
 }

--- a/runtime/http/middleware/cell_id_test.go
+++ b/runtime/http/middleware/cell_id_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,10 +11,13 @@ import (
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
 )
 
-func TestWithCellIDContext_InjectsCellIDIntoCtx(t *testing.T) {
+func TestWithCellIDContext_WritesCtxkey(t *testing.T) {
+	// The sub-mux WithCellIDContext middleware must update ctxkeys.CellID so
+	// downstream logging/tracing observes the cell ID inside the handler.
 	var observed string
 	handler := WithCellIDContext("accesscore")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		observed = ctxkeys.MustCellIDFrom(r.Context())
+		v, _ := ctxkeys.CellIDFrom(r.Context())
+		observed = v
 	}))
 
 	rec := httptest.NewRecorder()
@@ -22,52 +26,54 @@ func TestWithCellIDContext_InjectsCellIDIntoCtx(t *testing.T) {
 	assert.Equal(t, "accesscore", observed)
 }
 
-func TestWithCellIDContext_GroupOverridesRoot(t *testing.T) {
-	// Listener-root middleware (_runtime sentinel) wraps the route-group
-	// middleware (cell ID), which wraps the handler. The handler must
-	// observe the route-group cell ID — the inner WithValue overrides the
-	// outer one for the same key.
-	var observed string
-	final := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		observed = ctxkeys.MustCellIDFrom(r.Context())
-	})
-	chain := WithCellIDContext("_runtime")(WithCellIDContext("accesscore")(final))
+func TestWithCellIDContext_MutatesCellIDStateForOuterMetrics(t *testing.T) {
+	// Recreate the production layout: an outer middleware seeds *cellIDState
+	// with RuntimeCellIDSentinel (the analog of metrics.Metrics on the
+	// listener-root mux); a sub-mux WithCellIDContext mutates the same
+	// pointer; the outer middleware reads the resolved value after next.
+	var resolved string
+	outer := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, cs := withCellIDState(r.Context(), RuntimeCellIDSentinel)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			resolved = cs.cellID
+		})
+	}
+	final := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+	chain := outer(WithCellIDContext("accesscore")(final))
 
 	rec := httptest.NewRecorder()
 	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil))
 
-	assert.Equal(t, "accesscore", observed)
+	assert.Equal(t, "accesscore", resolved,
+		"outer (root-mux) middleware must observe the cell ID written by the inner (sub-mux) layer; "+
+			"this is the chi-style mutable-pointer pattern that the metrics recorder depends on")
 }
 
-func TestWithCellIDContext_RuntimeSentinelReachesUnmatchedHandler(t *testing.T) {
-	// When only the listener-root layer is installed (no RouteGroup matched),
-	// the handler still observes a non-empty cell ID — the framework sentinel.
-	var observed string
-	handler := WithCellIDContext("_runtime")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		observed = ctxkeys.MustCellIDFrom(r.Context())
+func TestWithCellIDContext_NoUpstreamStateIsNop(t *testing.T) {
+	// When there is no metrics layer upstream (e.g. a unit test exercises
+	// WithCellIDContext alone), mutating the absent state must not panic and
+	// the ctxkeys write must still happen so logging/tracing keeps working.
+	var seen string
+	handler := WithCellIDContext("accesscore")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		v, _ := ctxkeys.CellIDFrom(r.Context())
+		seen = v
 	}))
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
-	assert.Equal(t, "_runtime", observed)
+	assert.Equal(t, "accesscore", seen)
 }
 
-func TestWithCellIDContext_EmptyCellIDInjectsEmptyValue(t *testing.T) {
-	// WithCellIDContext does not validate cellID — both call sites
-	// (router.go literal "_runtime" and bootstrap.mountOneRouteGroup
-	// guarded by rg.CellID != "") already enforce non-empty. The
-	// downstream consumer middleware.Metrics calls MustCellIDFrom and
-	// panics on empty value — that is the single fail-fast point. This
-	// test pins the lightweight constructor contract: empty in, empty
-	// out, no early panic.
-	var observed string
-	final := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		v, _ := ctxkeys.CellIDFrom(r.Context())
-		observed = v
-	})
-	chain := WithCellIDContext("")(final)
-	rec := httptest.NewRecorder()
-	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-	assert.Equal(t, "", observed)
+func TestCellIDStateFrom_ReturnsNilWhenUnattached(t *testing.T) {
+	assert.Nil(t, cellIDStateFrom(context.Background()),
+		"cellIDStateFrom must return nil when no metrics layer attached the state — "+
+			"callers must handle this rather than dereference unconditionally")
+}
+
+func TestRuntimeCellIDSentinel_IsExportedConstant(t *testing.T) {
+	// Pin the sentinel value: dashboards / alerts match against this literal,
+	// and the archtest pulls it directly from this constant.
+	assert.Equal(t, "_runtime", RuntimeCellIDSentinel)
 }

--- a/runtime/http/middleware/cell_id_test.go
+++ b/runtime/http/middleware/cell_id_test.go
@@ -77,3 +77,35 @@ func TestRuntimeCellIDSentinel_IsExportedConstant(t *testing.T) {
 	// and the archtest pulls it directly from this constant.
 	assert.Equal(t, "_runtime", RuntimeCellIDSentinel)
 }
+
+func TestWithCellIDContext_EmptyCellIDPreservesSentinel(t *testing.T) {
+	// An empty cellID at this layer is a programming error (bootstrap guards
+	// rg.CellID != "" before installing). The middleware silently skips both
+	// the cellIDState mutation and the ctxkeys write so a future caller that
+	// constructs the handler directly with an empty value cannot corrupt the
+	// metrics label space — the upstream sentinel survives, and downstream
+	// logging/tracing do not record a misleading empty cell ID.
+	var sentinel string
+	outer := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, cs := withCellIDState(r.Context(), RuntimeCellIDSentinel)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			sentinel = cs.cellID
+		})
+	}
+	var observedCtxkey string
+	var observedCtxkeyOK bool
+	final := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observedCtxkey, observedCtxkeyOK = ctxkeys.CellIDFrom(r.Context())
+	})
+	chain := outer(WithCellIDContext("")(final))
+
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.Equal(t, RuntimeCellIDSentinel, sentinel,
+		"empty cellID must not overwrite the metrics sentinel — dashboards rely on _runtime for framework traffic")
+	assert.False(t, observedCtxkeyOK,
+		"empty cellID must not write to ctxkeys — logging/tracing must not record an empty cell ID")
+	assert.Equal(t, "", observedCtxkey)
+}

--- a/runtime/http/middleware/metrics.go
+++ b/runtime/http/middleware/metrics.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
@@ -17,13 +16,15 @@ import (
 // middleware), Metrics reuses it. Otherwise it creates its own to
 // remain usable as a standalone middleware.
 //
-// The cell identity stamped on every emitted observation is read from the
-// request context via ctxkeys.MustCellIDFrom — bootstrap installs
-// WithCellIDContext middleware at the listener-root layer (with the framework
-// "_runtime" sentinel) and at the route-group layer (with each cell's ID), so
-// the value is always present on requests that reach this middleware. A
-// missing value indicates a framework wiring bug; the panic surfaces it at
-// startup or in tests rather than silently emitting metrics under a fallback.
+// Cell-label resolution: this middleware attaches a *cellIDState seeded with
+// RuntimeCellIDSentinel to the request context before invoking next. Any
+// downstream WithCellIDContext middleware (installed by
+// bootstrap.mountOneRouteGroup on a chi sub-mux) mutates that state to its
+// cell's ID. After next returns the recorder reads the resolved value from
+// the same struct — chi's RouteContext uses the same mutable-pointer pattern
+// so outer middleware can observe values written by sub-mux dispatch.
+// Framework-owned paths (healthz, readyz, /metrics, unmatched 404s,
+// listeners with no business RouteGroup) keep the sentinel.
 func Metrics(collector metrics.Collector, clk clock.Clock) func(http.Handler) http.Handler {
 	return metricsWithClock(collector, clk)
 }
@@ -42,12 +43,12 @@ func metricsWithClock(collector metrics.Collector, clk clock.Clock) func(http.Ha
 				w = wrapped
 			}
 
-			next.ServeHTTP(w, r)
+			ctx, cs := withCellIDState(r.Context(), RuntimeCellIDSentinel)
+			next.ServeHTTP(w, r.WithContext(ctx))
 
 			safeObserve(slog.Default(), func() {
 				route := RoutePatternFromCtx(r.Context())
-				cellID := ctxkeys.MustCellIDFrom(r.Context())
-				collector.RecordRequest(cellID, r.Method, route, state.Status(), clk.Since(start).Seconds())
+				collector.RecordRequest(cs.cellID, r.Method, route, state.Status(), clk.Since(start).Seconds())
 			})
 		})
 	}

--- a/runtime/http/middleware/metrics.go
+++ b/runtime/http/middleware/metrics.go
@@ -3,10 +3,33 @@ package middleware
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
+
+// RoutePatternResolver maps a concrete request to a low-cardinality route
+// pattern when chi did not reach a matched endpoint handler.
+type RoutePatternResolver func(method, path string) (string, bool)
+
+// MetricsOption configures the Metrics middleware.
+type MetricsOption func(*metricsConfig)
+
+type metricsConfig struct {
+	routeResolver RoutePatternResolver
+}
+
+// WithRoutePatternResolver installs a fallback route resolver for pre-handler
+// rejects such as auth, rate-limit, circuit-breaker, body-limit, and 405.
+func WithRoutePatternResolver(fn RoutePatternResolver) MetricsOption {
+	return func(c *metricsConfig) {
+		if fn != nil {
+			c.routeResolver = fn
+		}
+	}
+}
 
 // Metrics returns an HTTP middleware that records request count and duration
 // using the provided Collector. A clock must be provided; use clock.Real() at
@@ -16,22 +39,21 @@ import (
 // middleware), Metrics reuses it. Otherwise it creates its own to
 // remain usable as a standalone middleware.
 //
-// Cell-label resolution: this middleware attaches a *cellIDState seeded with
-// RuntimeCellIDSentinel to the request context before invoking next. Any
-// downstream WithCellIDContext middleware (installed by
-// bootstrap.mountOneRouteGroup on a chi sub-mux) mutates that state to its
-// cell's ID. After next returns the recorder reads the resolved value from
-// the same struct — chi's RouteContext uses the same mutable-pointer pattern
-// so outer middleware can observe values written by sub-mux dispatch.
-// Framework-owned paths (healthz, readyz, /metrics, unmatched 404s,
-// listeners with no business RouteGroup) keep the sentinel.
-func Metrics(collector metrics.Collector, clk clock.Clock) func(http.Handler) http.Handler {
-	return metricsWithClock(collector, clk)
+// Cell-label resolution reads kernel/ctxkeys.CellID from request context.
+// Router-owned root attribution installs that key before short-circuiting
+// protection middleware. Absence means framework/runtime traffic and records
+// as RuntimeCellIDSentinel.
+func Metrics(collector metrics.Collector, clk clock.Clock, opts ...MetricsOption) func(http.Handler) http.Handler {
+	return metricsWithClock(collector, clk, opts...)
 }
 
 // metricsWithClock is the clock-injectable variant used by Metrics and tests.
-func metricsWithClock(collector metrics.Collector, clk clock.Clock) func(http.Handler) http.Handler {
+func metricsWithClock(collector metrics.Collector, clk clock.Clock, opts ...MetricsOption) func(http.Handler) http.Handler {
 	clock.MustHaveClock(clk, "middleware.Metrics")
+	var cfg metricsConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := clk.Now()
@@ -43,13 +65,29 @@ func metricsWithClock(collector metrics.Collector, clk clock.Clock) func(http.Ha
 				w = wrapped
 			}
 
-			ctx, cs := withCellIDState(r.Context(), RuntimeCellIDSentinel)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			next.ServeHTTP(w, r)
 
 			safeObserve(slog.Default(), func() {
-				route := RoutePatternFromCtx(r.Context())
-				collector.RecordRequest(cs.cellID, r.Method, route, state.Status(), clk.Since(start).Seconds())
+				route := finalMetricsRoute(r, cfg)
+				cellID := RuntimeCellIDSentinel
+				if v, ok := ctxkeys.CellIDFrom(r.Context()); ok && v != "" {
+					cellID = v
+				}
+				collector.RecordRequest(cellID, r.Method, route, state.Status(), clk.Since(start).Seconds())
 			})
 		})
 	}
+}
+
+func finalMetricsRoute(r *http.Request, cfg metricsConfig) string {
+	route := RoutePatternFromCtx(r.Context())
+	if cfg.routeResolver == nil {
+		return route
+	}
+	if resolved, ok := cfg.routeResolver(r.Method, r.URL.Path); ok && resolved != "" {
+		if route == "unmatched" || strings.HasSuffix(route, "/*") {
+			return resolved
+		}
+	}
+	return route
 }

--- a/runtime/http/middleware/metrics.go
+++ b/runtime/http/middleware/metrics.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
@@ -15,6 +16,14 @@ import (
 // When a RecorderState exists in the context (created by the Recorder
 // middleware), Metrics reuses it. Otherwise it creates its own to
 // remain usable as a standalone middleware.
+//
+// The cell identity stamped on every emitted observation is read from the
+// request context via ctxkeys.MustCellIDFrom — bootstrap installs
+// WithCellIDContext middleware at the listener-root layer (with the framework
+// "_runtime" sentinel) and at the route-group layer (with each cell's ID), so
+// the value is always present on requests that reach this middleware. A
+// missing value indicates a framework wiring bug; the panic surfaces it at
+// startup or in tests rather than silently emitting metrics under a fallback.
 func Metrics(collector metrics.Collector, clk clock.Clock) func(http.Handler) http.Handler {
 	return metricsWithClock(collector, clk)
 }
@@ -37,7 +46,8 @@ func metricsWithClock(collector metrics.Collector, clk clock.Clock) func(http.Ha
 
 			safeObserve(slog.Default(), func() {
 				route := RoutePatternFromCtx(r.Context())
-				collector.RecordRequest(r.Method, route, state.Status(), clk.Since(start).Seconds())
+				cellID := ctxkeys.MustCellIDFrom(r.Context())
+				collector.RecordRequest(cellID, r.Method, route, state.Status(), clk.Since(start).Seconds())
 			})
 		})
 	}

--- a/runtime/http/middleware/metrics_test.go
+++ b/runtime/http/middleware/metrics_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
+func requestKey(cell, method, route string, status int) metrics.RequestKey {
+	return metrics.RequestKey{Cell: cell, Method: method, Route: route, Status: status}
+}
+
 // --- Standalone tests (no chi router → route = "unmatched") ---
 
 func TestMetrics_RecordsMetrics(t *testing.T) {
@@ -27,9 +31,7 @@ func TestMetrics_RecordsMetrics(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, rec.Code)
 
 	snap := c.Snapshot()
-	// No upstream WithCellIDContext layer — Metrics seeds its own state with
-	// RuntimeCellIDSentinel and reads back the same value.
-	key := "_runtime POST unmatched 201"
+	key := requestKey("_runtime", http.MethodPost, "unmatched", http.StatusCreated)
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -44,7 +46,7 @@ func TestMetrics_DefaultStatus200(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	key := "_runtime GET unmatched 200"
+	key := requestKey("_runtime", http.MethodGet, "unmatched", http.StatusOK)
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -62,7 +64,7 @@ func TestMetrics_PanicRecordsStatus500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	snap := c.Snapshot()
-	key := "_runtime GET unmatched 500"
+	key := requestKey("_runtime", http.MethodGet, "unmatched", http.StatusInternalServerError)
 	assert.Equal(t, int64(1), snap.RequestCounts[key], "panic request must be recorded as status 500 in metrics")
 }
 
@@ -79,7 +81,26 @@ func TestMetrics_Standalone(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, rec.Code)
 
 	snap := c.Snapshot()
-	key := "_runtime POST unmatched 202"
+	key := requestKey("_runtime", http.MethodPost, "unmatched", http.StatusAccepted)
+	assert.Equal(t, int64(1), snap.RequestCounts[key])
+}
+
+func TestMetrics_RouteResolverFallback(t *testing.T) {
+	c := metrics.NewInMemoryCollector()
+	handler := Metrics(c, clock.Real(), WithRoutePatternResolver(func(method, path string) (string, bool) {
+		assert.Equal(t, http.MethodGet, method)
+		assert.Equal(t, "/api/v1/access/users/42", path)
+		return "/api/v1/access/users/{id}", true
+	}))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/users/42", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	snap := c.Snapshot()
+	key := requestKey("_runtime", http.MethodGet, "/api/v1/access/users/{id}", http.StatusUnauthorized)
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -96,31 +117,33 @@ func TestMetrics_MultipleRequests(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	key := "_runtime GET unmatched 200"
+	key := requestKey("_runtime", http.MethodGet, "unmatched", http.StatusOK)
 	assert.Equal(t, int64(5), snap.RequestCounts[key])
 }
 
-// TestMetrics_SubMuxOverridesRuntimeSentinel pins the "single injection /
-// two-layer override" contract: Metrics installs a *cellIDState seeded with
-// RuntimeCellIDSentinel; a downstream WithCellIDContext (analogous to
-// bootstrap.mountOneRouteGroup at the chi sub-mux layer) mutates the same
-// pointer; the recorder sees the per-cell value, not the sentinel.
-func TestMetrics_SubMuxOverridesRuntimeSentinel(t *testing.T) {
+func TestMetrics_ReadsCellIDFromContext(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
-	r.Group(func(sub chi.Router) {
-		sub.Use(WithCellIDContext("accesscore"))
-		sub.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
+	r.Use(
+		Recorder,
+		CellAttribution(func(_ string, path string) (string, bool) {
+			switch path {
+			case "/api/v1/users/42":
+				return "accesscore", true
+			case "/api/v1/audit/99":
+				return "auditcore", true
+			default:
+				return "", false
+			}
+		}),
+		Metrics(c, clock.Real()),
+	)
+	r.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
 	})
-	r.Group(func(sub chi.Router) {
-		sub.Use(WithCellIDContext("auditcore"))
-		sub.Get("/api/v1/audit/{id}", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
+	r.Get("/api/v1/audit/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
 	})
 	// One unmatched request — falls through with the sentinel.
 	r.Get("/orphan-but-matched", func(w http.ResponseWriter, _ *http.Request) {
@@ -138,11 +161,11 @@ func TestMetrics_SubMuxOverridesRuntimeSentinel(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	for _, key := range []string{
-		"accesscore GET /api/v1/users/{id} 200",
-		"auditcore GET /api/v1/audit/{id} 200",
-		"_runtime GET /orphan-but-matched 200",
-		"_runtime GET unmatched 404",
+	for _, key := range []metrics.RequestKey{
+		requestKey("accesscore", http.MethodGet, "/api/v1/users/{id}", http.StatusOK),
+		requestKey("auditcore", http.MethodGet, "/api/v1/audit/{id}", http.StatusOK),
+		requestKey("_runtime", http.MethodGet, "/orphan-but-matched", http.StatusOK),
+		requestKey("_runtime", http.MethodGet, "unmatched", http.StatusNotFound),
 	} {
 		assert.Equalf(t, int64(1), snap.RequestCounts[key],
 			"want exactly one observation under %q; full snapshot=%v", key, snap.RequestCounts)
@@ -155,12 +178,18 @@ func TestMetrics_RoutePatternCollapse(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
-	r.Group(func(sub chi.Router) {
-		sub.Use(WithCellIDContext("test-cell"))
-		sub.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
+	r.Use(
+		Recorder,
+		CellAttribution(func(_ string, path string) (string, bool) {
+			if path != "" {
+				return "test-cell", true
+			}
+			return "", false
+		}),
+		Metrics(c, clock.Real()),
+	)
+	r.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
 	})
 
 	// Hit with different path parameters — all should collapse to one metric key.
@@ -172,7 +201,7 @@ func TestMetrics_RoutePatternCollapse(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	key := "test-cell GET /api/v1/users/{id} 200"
+	key := requestKey("test-cell", http.MethodGet, "/api/v1/users/{id}", http.StatusOK)
 	assert.Equal(t, int64(4), snap.RequestCounts[key],
 		"parameterized routes must collapse to route pattern, not actual path")
 	assert.Len(t, snap.RequestCounts, 1,
@@ -188,8 +217,8 @@ func TestMetrics_UnmatchedRouteUsesSentinel(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	// Hit random 404 paths — all should collapse to "unmatched" sentinel
-	// under cell="_runtime" (no sub-mux WithCellIDContext fired).
+	// Hit random 404 paths — all should collapse to "unmatched" under
+	// cell="_runtime" (no root attribution resolved a cell).
 	for _, path := range []string{"/random1", "/random2", "/attack-path"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rec := httptest.NewRecorder()
@@ -197,7 +226,7 @@ func TestMetrics_UnmatchedRouteUsesSentinel(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	key := "_runtime GET unmatched 404"
+	key := requestKey("_runtime", http.MethodGet, "unmatched", http.StatusNotFound)
 	assert.Equal(t, int64(3), snap.RequestCounts[key],
 		"unmatched routes must all map to sentinel 'unmatched' label under cell=_runtime")
 }
@@ -216,9 +245,7 @@ func TestMetrics_ChiStaticRoute(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	// /healthz on a router with no per-route WithCellIDContext keeps the
-	// listener-root sentinel — this is the framework-owned probe path.
-	key := "_runtime GET /healthz 200"
+	key := requestKey("_runtime", http.MethodGet, "/healthz", http.StatusOK)
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -226,9 +253,17 @@ func TestMetrics_ChiNestedRoutes(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
+	r.Use(
+		Recorder,
+		CellAttribution(func(_ string, path string) (string, bool) {
+			if path != "" {
+				return "test-cell", true
+			}
+			return "", false
+		}),
+		Metrics(c, clock.Real()),
+	)
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Use(WithCellIDContext("test-cell"))
 		r.Get("/orders/{orderID}", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -239,7 +274,7 @@ func TestMetrics_ChiNestedRoutes(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	key := "test-cell GET /api/v1/orders/{orderID} 200"
+	key := requestKey("test-cell", http.MethodGet, "/api/v1/orders/{orderID}", http.StatusOK)
 	assert.Equal(t, int64(1), snap.RequestCounts[key],
 		"nested routes must produce combined route pattern under the per-cell label")
 }

--- a/runtime/http/middleware/metrics_test.go
+++ b/runtime/http/middleware/metrics_test.go
@@ -12,13 +12,22 @@ import (
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
+// withTestCellID wraps a handler chain with the cell-id context middleware
+// the bootstrap layer installs in production. Tests that exercise Metrics
+// directly need this so MustCellIDFrom does not panic — the contract under
+// test is "given a request with cell id in ctx, RecordRequest receives it",
+// not "Metrics tolerates missing ctx".
+func withTestCellID(cellID string, h http.Handler) http.Handler {
+	return WithCellIDContext(cellID)(h)
+}
+
 // --- Standalone tests (no chi router → route = "unmatched") ---
 
 func TestMetrics_RecordsMetrics(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-	})))
+	}))))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
 	rec := httptest.NewRecorder()
@@ -28,30 +37,31 @@ func TestMetrics_RecordsMetrics(t *testing.T) {
 
 	snap := c.Snapshot()
 	// Without chi router, route pattern falls back to "unmatched".
-	key := "POST unmatched 201"
+	key := "test-cell POST unmatched 201"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
 func TestMetrics_DefaultStatus200(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("ok"))
-	})))
+	}))))
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	key := "GET unmatched 200"
+	key := "test-cell GET unmatched 200"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
 func TestMetrics_PanicRecordsStatus500(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Recorder(Metrics(c, clock.Real())(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	panicHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("boom")
-	}))))
+	})
+	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(Recovery(panicHandler))))
 
 	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
 	rec := httptest.NewRecorder()
@@ -60,15 +70,15 @@ func TestMetrics_PanicRecordsStatus500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	snap := c.Snapshot()
-	key := "GET unmatched 500"
+	key := "test-cell GET unmatched 500"
 	assert.Equal(t, int64(1), snap.RequestCounts[key], "panic request must be recorded as status 500 in metrics")
 }
 
 func TestMetrics_Standalone(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := withTestCellID("test-cell", Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
-	}))
+	})))
 
 	req := httptest.NewRequest(http.MethodPost, "/jobs", nil)
 	rec := httptest.NewRecorder()
@@ -77,15 +87,15 @@ func TestMetrics_Standalone(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, rec.Code)
 
 	snap := c.Snapshot()
-	key := "POST unmatched 202"
+	key := "test-cell POST unmatched 202"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
 func TestMetrics_MultipleRequests(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	})))
+	}))))
 
 	for range 5 {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -94,8 +104,51 @@ func TestMetrics_MultipleRequests(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	key := "GET unmatched 200"
+	key := "test-cell GET unmatched 200"
 	assert.Equal(t, int64(5), snap.RequestCounts[key])
+}
+
+// TestMetrics_CellIDFromCtxFlowsToCollector verifies the contract that the
+// per-request cell id from ctx (installed upstream by WithCellIDContext)
+// reaches the Collector — not a global, not a constant, not a fallback.
+func TestMetrics_CellIDFromCtxFlowsToCollector(t *testing.T) {
+	c := metrics.NewInMemoryCollector()
+
+	for _, cellID := range []string{"accesscore", "auditcore", "_runtime"} {
+		handler := withTestCellID(cellID, Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))))
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+	}
+
+	snap := c.Snapshot()
+	for _, cellID := range []string{"accesscore", "auditcore", "_runtime"} {
+		key := cellID + " GET unmatched 200"
+		assert.Equal(t, int64(1), snap.RequestCounts[key], "missing key %q in %v", key, snap.RequestCounts)
+	}
+}
+
+// TestMetrics_PanicsWhenCellIDMissing locks the fail-fast contract: if a
+// request reaches the Metrics middleware without a cell id in ctx (i.e. the
+// listener-root WithCellIDContext sentinel layer was bypassed), the recorder
+// must panic so framework wiring bugs surface immediately, instead of being
+// swallowed by safeObserve and silently emitting metrics under a fallback.
+func TestMetrics_PanicsWhenCellIDMissing(t *testing.T) {
+	c := metrics.NewInMemoryCollector()
+	// No WithCellIDContext wrapper — this is the bug scenario.
+	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req) // safeObserve recovers the panic; assert no record was emitted
+
+	snap := c.Snapshot()
+	assert.Empty(t, snap.RequestCounts,
+		"missing cell id in ctx must abort RecordRequest (no fallback emission); got %v", snap.RequestCounts)
 }
 
 // --- Chi-integrated tests (route pattern extraction) ---
@@ -104,7 +157,7 @@ func TestMetrics_RoutePatternCollapse(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
+	r.Use(WithCellIDContext("test-cell"), Recorder, Metrics(c, clock.Real()))
 	r.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -118,7 +171,7 @@ func TestMetrics_RoutePatternCollapse(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	key := "GET /api/v1/users/{id} 200"
+	key := "test-cell GET /api/v1/users/{id} 200"
 	assert.Equal(t, int64(4), snap.RequestCounts[key],
 		"parameterized routes must collapse to route pattern, not actual path")
 	assert.Len(t, snap.RequestCounts, 1,
@@ -129,12 +182,13 @@ func TestMetrics_UnmatchedRouteUsesSentinel(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
+	r.Use(WithCellIDContext("_runtime"), Recorder, Metrics(c, clock.Real()))
 	r.Get("/exists", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	// Hit random 404 paths — all should collapse to "unmatched" sentinel.
+	// Hit random 404 paths — all should collapse to "unmatched" sentinel and
+	// carry the framework "_runtime" cell id (no RouteGroup matched).
 	for _, path := range []string{"/random1", "/random2", "/attack-path"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rec := httptest.NewRecorder()
@@ -142,16 +196,16 @@ func TestMetrics_UnmatchedRouteUsesSentinel(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	key := "GET unmatched 404"
+	key := "_runtime GET unmatched 404"
 	assert.Equal(t, int64(3), snap.RequestCounts[key],
-		"unmatched routes must all map to sentinel 'unmatched' label")
+		"unmatched routes must all map to sentinel 'unmatched' label under cell=_runtime")
 }
 
 func TestMetrics_ChiStaticRoute(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
+	r.Use(WithCellIDContext("test-cell"), Recorder, Metrics(c, clock.Real()))
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -161,7 +215,7 @@ func TestMetrics_ChiStaticRoute(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	key := "GET /healthz 200"
+	key := "test-cell GET /healthz 200"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -169,7 +223,7 @@ func TestMetrics_ChiNestedRoutes(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
+	r.Use(WithCellIDContext("test-cell"), Recorder, Metrics(c, clock.Real()))
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Get("/orders/{orderID}", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -181,7 +235,7 @@ func TestMetrics_ChiNestedRoutes(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	key := "GET /api/v1/orders/{orderID} 200"
+	key := "test-cell GET /api/v1/orders/{orderID} 200"
 	assert.Equal(t, int64(1), snap.RequestCounts[key],
 		"nested routes must produce combined route pattern")
 }

--- a/runtime/http/middleware/metrics_test.go
+++ b/runtime/http/middleware/metrics_test.go
@@ -127,7 +127,7 @@ func TestMetrics_ReadsCellIDFromContext(t *testing.T) {
 	r := chi.NewRouter()
 	r.Use(
 		Recorder,
-		CellAttribution(func(_ string, path string) (string, bool) {
+		CellAttribution(func(_, path string) (string, bool) {
 			switch path {
 			case "/api/v1/users/42":
 				return "accesscore", true
@@ -180,7 +180,7 @@ func TestMetrics_RoutePatternCollapse(t *testing.T) {
 	r := chi.NewRouter()
 	r.Use(
 		Recorder,
-		CellAttribution(func(_ string, path string) (string, bool) {
+		CellAttribution(func(_, path string) (string, bool) {
 			if path != "" {
 				return "test-cell", true
 			}
@@ -255,7 +255,7 @@ func TestMetrics_ChiNestedRoutes(t *testing.T) {
 	r := chi.NewRouter()
 	r.Use(
 		Recorder,
-		CellAttribution(func(_ string, path string) (string, bool) {
+		CellAttribution(func(_, path string) (string, bool) {
 			if path != "" {
 				return "test-cell", true
 			}

--- a/runtime/http/middleware/metrics_test.go
+++ b/runtime/http/middleware/metrics_test.go
@@ -12,22 +12,13 @@ import (
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
-// withTestCellID wraps a handler chain with the cell-id context middleware
-// the bootstrap layer installs in production. Tests that exercise Metrics
-// directly need this so MustCellIDFrom does not panic — the contract under
-// test is "given a request with cell id in ctx, RecordRequest receives it",
-// not "Metrics tolerates missing ctx".
-func withTestCellID(cellID string, h http.Handler) http.Handler {
-	return WithCellIDContext(cellID)(h)
-}
-
 // --- Standalone tests (no chi router → route = "unmatched") ---
 
 func TestMetrics_RecordsMetrics(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-	}))))
+	})))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
 	rec := httptest.NewRecorder()
@@ -36,23 +27,24 @@ func TestMetrics_RecordsMetrics(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, rec.Code)
 
 	snap := c.Snapshot()
-	// Without chi router, route pattern falls back to "unmatched".
-	key := "test-cell POST unmatched 201"
+	// No upstream WithCellIDContext layer — Metrics seeds its own state with
+	// RuntimeCellIDSentinel and reads back the same value.
+	key := "_runtime POST unmatched 201"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
 func TestMetrics_DefaultStatus200(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
-	}))))
+	})))
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	key := "test-cell GET unmatched 200"
+	key := "_runtime GET unmatched 200"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -61,7 +53,7 @@ func TestMetrics_PanicRecordsStatus500(t *testing.T) {
 	panicHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("boom")
 	})
-	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(Recovery(panicHandler))))
+	handler := Recorder(Metrics(c, clock.Real())(Recovery(panicHandler)))
 
 	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
 	rec := httptest.NewRecorder()
@@ -70,15 +62,15 @@ func TestMetrics_PanicRecordsStatus500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	snap := c.Snapshot()
-	key := "test-cell GET unmatched 500"
+	key := "_runtime GET unmatched 500"
 	assert.Equal(t, int64(1), snap.RequestCounts[key], "panic request must be recorded as status 500 in metrics")
 }
 
 func TestMetrics_Standalone(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := withTestCellID("test-cell", Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
-	})))
+	}))
 
 	req := httptest.NewRequest(http.MethodPost, "/jobs", nil)
 	rec := httptest.NewRecorder()
@@ -87,15 +79,15 @@ func TestMetrics_Standalone(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, rec.Code)
 
 	snap := c.Snapshot()
-	key := "test-cell POST unmatched 202"
+	key := "_runtime POST unmatched 202"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
 func TestMetrics_MultipleRequests(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
-	handler := withTestCellID("test-cell", Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))))
+	})))
 
 	for range 5 {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -104,51 +96,57 @@ func TestMetrics_MultipleRequests(t *testing.T) {
 	}
 
 	snap := c.Snapshot()
-	key := "test-cell GET unmatched 200"
+	key := "_runtime GET unmatched 200"
 	assert.Equal(t, int64(5), snap.RequestCounts[key])
 }
 
-// TestMetrics_CellIDFromCtxFlowsToCollector verifies the contract that the
-// per-request cell id from ctx (installed upstream by WithCellIDContext)
-// reaches the Collector — not a global, not a constant, not a fallback.
-func TestMetrics_CellIDFromCtxFlowsToCollector(t *testing.T) {
+// TestMetrics_SubMuxOverridesRuntimeSentinel pins the "single injection /
+// two-layer override" contract: Metrics installs a *cellIDState seeded with
+// RuntimeCellIDSentinel; a downstream WithCellIDContext (analogous to
+// bootstrap.mountOneRouteGroup at the chi sub-mux layer) mutates the same
+// pointer; the recorder sees the per-cell value, not the sentinel.
+func TestMetrics_SubMuxOverridesRuntimeSentinel(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
-	for _, cellID := range []string{"accesscore", "auditcore", "_runtime"} {
-		handler := withTestCellID(cellID, Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	r := chi.NewRouter()
+	r.Use(Recorder, Metrics(c, clock.Real()))
+	r.Group(func(sub chi.Router) {
+		sub.Use(WithCellIDContext("accesscore"))
+		sub.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		}))))
-		req := httptest.NewRequest(http.MethodGet, "/x", nil)
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-	}
-
-	snap := c.Snapshot()
-	for _, cellID := range []string{"accesscore", "auditcore", "_runtime"} {
-		key := cellID + " GET unmatched 200"
-		assert.Equal(t, int64(1), snap.RequestCounts[key], "missing key %q in %v", key, snap.RequestCounts)
-	}
-}
-
-// TestMetrics_PanicsWhenCellIDMissing locks the fail-fast contract: if a
-// request reaches the Metrics middleware without a cell id in ctx (i.e. the
-// listener-root WithCellIDContext sentinel layer was bypassed), the recorder
-// must panic so framework wiring bugs surface immediately, instead of being
-// swallowed by safeObserve and silently emitting metrics under a fallback.
-func TestMetrics_PanicsWhenCellIDMissing(t *testing.T) {
-	c := metrics.NewInMemoryCollector()
-	// No WithCellIDContext wrapper — this is the bug scenario.
-	handler := Recorder(Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		})
+	})
+	r.Group(func(sub chi.Router) {
+		sub.Use(WithCellIDContext("auditcore"))
+		sub.Get("/api/v1/audit/{id}", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+	})
+	// One unmatched request — falls through with the sentinel.
+	r.Get("/orphan-but-matched", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	})))
+	})
 
-	req := httptest.NewRequest(http.MethodGet, "/x", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req) // safeObserve recovers the panic; assert no record was emitted
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/v1/users/42"},
+		{http.MethodGet, "/api/v1/audit/99"},
+		{http.MethodGet, "/orphan-but-matched"},
+		{http.MethodGet, "/totally-missing"},
+	} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+	}
 
 	snap := c.Snapshot()
-	assert.Empty(t, snap.RequestCounts,
-		"missing cell id in ctx must abort RecordRequest (no fallback emission); got %v", snap.RequestCounts)
+	for _, key := range []string{
+		"accesscore GET /api/v1/users/{id} 200",
+		"auditcore GET /api/v1/audit/{id} 200",
+		"_runtime GET /orphan-but-matched 200",
+		"_runtime GET unmatched 404",
+	} {
+		assert.Equalf(t, int64(1), snap.RequestCounts[key],
+			"want exactly one observation under %q; full snapshot=%v", key, snap.RequestCounts)
+	}
 }
 
 // --- Chi-integrated tests (route pattern extraction) ---
@@ -157,9 +155,12 @@ func TestMetrics_RoutePatternCollapse(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(WithCellIDContext("test-cell"), Recorder, Metrics(c, clock.Real()))
-	r.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
+	r.Use(Recorder, Metrics(c, clock.Real()))
+	r.Group(func(sub chi.Router) {
+		sub.Use(WithCellIDContext("test-cell"))
+		sub.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
 	})
 
 	// Hit with different path parameters — all should collapse to one metric key.
@@ -182,13 +183,13 @@ func TestMetrics_UnmatchedRouteUsesSentinel(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(WithCellIDContext("_runtime"), Recorder, Metrics(c, clock.Real()))
+	r.Use(Recorder, Metrics(c, clock.Real()))
 	r.Get("/exists", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	// Hit random 404 paths — all should collapse to "unmatched" sentinel and
-	// carry the framework "_runtime" cell id (no RouteGroup matched).
+	// Hit random 404 paths — all should collapse to "unmatched" sentinel
+	// under cell="_runtime" (no sub-mux WithCellIDContext fired).
 	for _, path := range []string{"/random1", "/random2", "/attack-path"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rec := httptest.NewRecorder()
@@ -205,7 +206,7 @@ func TestMetrics_ChiStaticRoute(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(WithCellIDContext("test-cell"), Recorder, Metrics(c, clock.Real()))
+	r.Use(Recorder, Metrics(c, clock.Real()))
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -215,7 +216,9 @@ func TestMetrics_ChiStaticRoute(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
-	key := "test-cell GET /healthz 200"
+	// /healthz on a router with no per-route WithCellIDContext keeps the
+	// listener-root sentinel — this is the framework-owned probe path.
+	key := "_runtime GET /healthz 200"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -223,8 +226,9 @@ func TestMetrics_ChiNestedRoutes(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
 	r := chi.NewRouter()
-	r.Use(WithCellIDContext("test-cell"), Recorder, Metrics(c, clock.Real()))
+	r.Use(Recorder, Metrics(c, clock.Real()))
 	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(WithCellIDContext("test-cell"))
 		r.Get("/orders/{orderID}", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -237,5 +241,5 @@ func TestMetrics_ChiNestedRoutes(t *testing.T) {
 	snap := c.Snapshot()
 	key := "test-cell GET /api/v1/orders/{orderID} 200"
 	assert.Equal(t, int64(1), snap.RequestCounts[key],
-		"nested routes must produce combined route pattern")
+		"nested routes must produce combined route pattern under the per-cell label")
 }

--- a/runtime/http/middleware/safe_observe_test.go
+++ b/runtime/http/middleware/safe_observe_test.go
@@ -24,9 +24,10 @@ func TestSafeObserve_PanicDoesNotPropagate(t *testing.T) {
 
 func TestMetrics_CollectorPanicDoesNotCrash(t *testing.T) {
 	// A collector that panics in RecordRequest must not crash the request.
-	handler := Recorder(Metrics(&panicCollector{}, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	})))
+	})
+	handler := WithCellIDContext("test-cell")(Recorder(Metrics(&panicCollector{}, clock.Real())(okHandler)))
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -50,7 +51,7 @@ func TestAccessLog_PanicDoesNotCrash(t *testing.T) {
 // panicCollector implements metrics.Collector but panics on RecordRequest.
 type panicCollector struct{}
 
-func (p *panicCollector) RecordRequest(_, _ string, _ int, _ float64) {
+func (p *panicCollector) RecordRequest(_, _, _ string, _ int, _ float64) {
 	panic("collector panic in RecordRequest")
 }
 

--- a/runtime/http/middleware/safe_observe_test.go
+++ b/runtime/http/middleware/safe_observe_test.go
@@ -27,7 +27,7 @@ func TestMetrics_CollectorPanicDoesNotCrash(t *testing.T) {
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := WithCellIDContext("test-cell")(Recorder(Metrics(&panicCollector{}, clock.Real())(okHandler)))
+	handler := Recorder(Metrics(&panicCollector{}, clock.Real())(okHandler))
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -506,17 +506,13 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	}
 	r.mux.Use(middleware.AccessLog(r.clock))
 	if r.metricsCollector != nil {
-		// HTTP-METRICS-LABEL-REALIGN: install the framework-sentinel cell-id
-		// context BEFORE Metrics so any request reaching this listener — health
-		// probes, unmatched 404s, listeners with no business RouteGroup mounted
-		// — is labeled cell="_runtime". RouteGroup-level WithCellIDContext
-		// installed by bootstrap.mountOneRouteGroup runs *after* this layer
-		// inside the chi sub-mux, overriding the sentinel for business routes.
-		// This is the only listener-root injection point — bootstrap does not
-		// install another tier on the root mux.
-		// ref: kubernetes apiserver pkg/endpoints/metrics/metrics.go —
-		// component label captured at registration time.
-		r.mux.Use(middleware.WithCellIDContext("_runtime"))
+		// HTTP-METRICS-LABEL-REALIGN: middleware.Metrics attaches its own
+		// mutable *cellIDState seeded with the framework "_runtime"
+		// sentinel; bootstrap.mountOneRouteGroup installs
+		// WithCellIDContext on each cell-owned sub-mux to mutate that
+		// state. The recorder fires after next.ServeHTTP returns, so it
+		// observes whichever value won — sentinel for framework routes,
+		// the cell ID for business routes.
 		r.mux.Use(middleware.Metrics(r.metricsCollector, r.clock))
 	}
 	r.mux.Use(

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -1016,7 +1016,7 @@ func (r *Router) resolveHTTPContractAttrs(method, urlPath string) ([]wrapper.Att
 	return nil, false
 }
 
-func (r *Router) resolveCellID(_ string, urlPath string) (string, bool) {
+func (r *Router) resolveCellID(_, urlPath string) (string, bool) {
 	urlPath = cleanRoutePath(urlPath)
 	bestCell := ""
 	var bestScore routeMatchRank

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -362,6 +362,13 @@ type registeredRoutePattern struct {
 	path   string
 }
 
+type routeMatchRank struct {
+	staticSegments int
+	paramSegments  int
+	depth          int
+	length         int
+}
+
 // earlyResponderMiddleware turns an earlyResponder into a chi middleware that
 // short-circuits when the predicate matches.
 func earlyResponderMiddleware(er earlyResponder) func(http.Handler) http.Handler {
@@ -1012,13 +1019,13 @@ func (r *Router) resolveHTTPContractAttrs(method, urlPath string) ([]wrapper.Att
 func (r *Router) resolveCellID(_ string, urlPath string) (string, bool) {
 	urlPath = cleanRoutePath(urlPath)
 	bestCell := ""
-	bestScore := -1
+	var bestScore routeMatchRank
 
 	for _, route := range r.ownedRoutes {
 		if !routePatternMatches(route.path, urlPath) {
 			continue
 		}
-		if score := routeMatchScore(route.path); score > bestScore {
+		if score := routeMatchScore(route.path); routeMatchScoreGreater(score, bestScore) {
 			bestScore = score
 			bestCell = route.cellID
 		}
@@ -1027,7 +1034,7 @@ func (r *Router) resolveCellID(_ string, urlPath string) (string, bool) {
 		if !segmentPrefixMatches(urlPath, prefix.prefix) {
 			continue
 		}
-		if score := routeMatchScore(prefix.prefix); score > bestScore {
+		if score := routeMatchScore(prefix.prefix); routeMatchScoreGreater(score, bestScore) {
 			bestScore = score
 			bestCell = prefix.cellID
 		}
@@ -1051,7 +1058,7 @@ func (r *Router) resolveHTTPRoutePattern(method, urlPath string) (string, bool) 
 func (r *Router) resolveRegisteredRoutePattern(method, urlPath string, requireMethod bool) (string, bool) {
 	urlPath = cleanRoutePath(urlPath)
 	bestRoute := ""
-	bestScore := -1
+	var bestScore routeMatchRank
 	for _, route := range r.routePatterns {
 		if requireMethod && !routeMethodMatches(route.method, method) {
 			continue
@@ -1059,7 +1066,7 @@ func (r *Router) resolveRegisteredRoutePattern(method, urlPath string, requireMe
 		if !routePatternMatches(route.path, urlPath) {
 			continue
 		}
-		if score := routeMatchScore(route.path); score > bestScore {
+		if score := routeMatchScore(route.path); routeMatchScoreGreater(score, bestScore) {
 			bestScore = score
 			bestRoute = route.path
 		}
@@ -1070,7 +1077,7 @@ func (r *Router) resolveRegisteredRoutePattern(method, urlPath string, requireMe
 func (r *Router) resolveContractRoutePattern(method, urlPath string, requireMethod bool) (string, bool) {
 	urlPath = cleanRoutePath(urlPath)
 	bestRoute := ""
-	bestScore := -1
+	var bestScore routeMatchRank
 	for _, spec := range r.declaredHTTPContracts {
 		if requireMethod && !contractMethodMatches(spec.Method, method) {
 			continue
@@ -1079,7 +1086,7 @@ func (r *Router) resolveContractRoutePattern(method, urlPath string, requireMeth
 		if !routePatternMatches(routePath, urlPath) {
 			continue
 		}
-		if score := routeMatchScore(routePath); score > bestScore {
+		if score := routeMatchScore(routePath); routeMatchScoreGreater(score, bestScore) {
 			bestScore = score
 			bestRoute = routePath
 		}
@@ -1134,8 +1141,42 @@ func segmentPrefixMatches(concrete, prefix string) bool {
 	return concrete == prefix || strings.HasPrefix(concrete, prefix+"/")
 }
 
-func routeMatchScore(routePath string) int {
-	return len(cleanRoutePath(routePath))
+func routeMatchScore(routePath string) routeMatchRank {
+	routePath = cleanRoutePath(routePath)
+	rank := routeMatchRank{length: len(routePath)}
+	for _, segment := range routeSegments(routePath) {
+		if segment == "*" || segment == "" {
+			continue
+		}
+		rank.depth++
+		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
+			rank.paramSegments++
+			continue
+		}
+		rank.staticSegments++
+	}
+	return rank
+}
+
+func routeMatchScoreGreater(candidate, current routeMatchRank) bool {
+	if candidate.staticSegments != current.staticSegments {
+		return candidate.staticSegments > current.staticSegments
+	}
+	if candidate.paramSegments != current.paramSegments {
+		return candidate.paramSegments > current.paramSegments
+	}
+	if candidate.depth != current.depth {
+		return candidate.depth > current.depth
+	}
+	return candidate.length > current.length
+}
+
+func routeSegments(routePath string) []string {
+	trimmed := strings.Trim(cleanRoutePath(routePath), "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
 }
 
 func splitHandlePattern(pattern string) (method, routePath string) {

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -506,6 +506,17 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	}
 	r.mux.Use(middleware.AccessLog(r.clock))
 	if r.metricsCollector != nil {
+		// HTTP-METRICS-LABEL-REALIGN: install the framework-sentinel cell-id
+		// context BEFORE Metrics so any request reaching this listener — health
+		// probes, unmatched 404s, listeners with no business RouteGroup mounted
+		// — is labeled cell="_runtime". RouteGroup-level WithCellIDContext
+		// installed by bootstrap.mountOneRouteGroup runs *after* this layer
+		// inside the chi sub-mux, overriding the sentinel for business routes.
+		// This is the only listener-root injection point — bootstrap does not
+		// install another tier on the root mux.
+		// ref: kubernetes apiserver pkg/endpoints/metrics/metrics.go —
+		// component label captured at registration time.
+		r.mux.Use(middleware.WithCellIDContext("_runtime"))
 		r.mux.Use(middleware.Metrics(r.metricsCollector, r.clock))
 	}
 	r.mux.Use(

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -314,7 +314,8 @@ type Router struct {
 	// by auth.Mount. Tracing uses these as a fallback when upstream middleware
 	// short-circuits before wrapper.HTTPHandler can contribute attrs.
 	declaredHTTPContracts      []wrapper.ContractSpec
-	ownedRoutes                []ownedRoutePattern
+	ownedRoutes                []ownedRoutePath
+	routePatterns              []registeredRoutePattern
 	ownedPrefixes              []ownedRoutePrefix
 	passwordResetExemptMatcher func(method, urlPath string) bool
 	derivedHint                string
@@ -346,15 +347,19 @@ type earlyResponder struct {
 	handler   http.HandlerFunc
 }
 
-type ownedRoutePattern struct {
-	method string
+type ownedRoutePrefix struct {
+	prefix string
+	cellID string
+}
+
+type ownedRoutePath struct {
 	path   string
 	cellID string
 }
 
-type ownedRoutePrefix struct {
-	prefix string
-	cellID string
+type registeredRoutePattern struct {
+	method string
+	path   string
 }
 
 // earlyResponderMiddleware turns an earlyResponder into a chi middleware that
@@ -639,10 +644,13 @@ func (r *Router) MountRouteGroup(rg kcell.RouteGroup) error {
 		return fmt.Errorf("router: RouteGroup for listener %q has nil Register function", rg.Listener.String())
 	}
 	if rg.CellID != "" && rg.Prefix != "" {
-		r.recordOwnedPrefix(rg.CellID, rg.Prefix)
+		if err := r.recordOwnedPrefix(rg.CellID, rg.Prefix); err != nil {
+			return err
+		}
 	}
 
 	var registerErr error
+	var adapterErr error
 	if rg.Prefix != "" {
 		r.mux.Route(rg.Prefix, func(cr chi.Router) {
 			if len(rg.Middleware) > 0 {
@@ -654,22 +662,31 @@ func (r *Router) MountRouteGroup(rg kcell.RouteGroup) error {
 				declarer: r,
 				owner:    r,
 				cellID:   rg.CellID,
+				err:      &adapterErr,
 			}
 			registerErr = rg.Register(sub)
 		})
-		return registerErr
+		if registerErr != nil {
+			return registerErr
+		}
+		return adapterErr
 	}
 
 	cr := chi.Router(r.mux)
 	if len(rg.Middleware) > 0 {
 		cr = r.mux.With(rg.Middleware...)
 	}
-	return rg.Register(&chiRouterAdapter{
+	registerErr = rg.Register(&chiRouterAdapter{
 		cr:       cr,
 		declarer: r,
 		owner:    r,
 		cellID:   rg.CellID,
+		err:      &adapterErr,
 	})
+	if registerErr != nil {
+		return registerErr
+	}
+	return adapterErr
 }
 
 // DeclareAuthMeta implements cell.AuthRouteDeclarer. It accumulates auth route
@@ -892,23 +909,54 @@ func (r *Router) DeclaredAuthMetas() []kcell.AuthRouteMeta {
 	return out
 }
 
-func (r *Router) recordOwnedPrefix(cellID, prefix string) {
+func (r *Router) recordOwnedPrefix(cellID, prefix string) error {
 	if cellID == "" || strings.TrimSpace(prefix) == "" {
-		return
+		return nil
 	}
 	prefix = cleanRoutePath(prefix)
+	for _, owned := range r.ownedPrefixes {
+		if owned.prefix != prefix {
+			continue
+		}
+		if owned.cellID == cellID {
+			return nil
+		}
+		return fmt.Errorf(
+			"router: duplicate route ownership for path %q: cell %q already owns it, cell %q cannot also own it",
+			prefix, owned.cellID, cellID)
+	}
 	r.ownedPrefixes = append(r.ownedPrefixes, ownedRoutePrefix{prefix: prefix, cellID: cellID})
+	return nil
 }
 
-func (r *Router) recordOwnedRoutePattern(cellID, method, routePath string) {
+func (r *Router) recordOwnedRoutePath(cellID, routePath string) error {
 	routePath = cleanRoutePath(routePath)
 	if cellID == "" || routePath == "" {
+		return nil
+	}
+	for _, owned := range r.ownedRoutes {
+		if owned.path != routePath {
+			continue
+		}
+		if owned.cellID == cellID {
+			return nil
+		}
+		return fmt.Errorf(
+			"router: duplicate route ownership for path %q: cell %q already owns it, cell %q cannot also own it",
+			routePath, owned.cellID, cellID)
+	}
+	r.ownedRoutes = append(r.ownedRoutes, ownedRoutePath{path: routePath, cellID: cellID})
+	return nil
+}
+
+func (r *Router) recordRoutePattern(method, routePath string) {
+	routePath = cleanRoutePath(routePath)
+	if routePath == "" {
 		return
 	}
-	r.ownedRoutes = append(r.ownedRoutes, ownedRoutePattern{
+	r.routePatterns = append(r.routePatterns, registeredRoutePattern{
 		method: strings.ToUpper(method),
 		path:   routePath,
-		cellID: cellID,
 	})
 }
 
@@ -988,23 +1036,23 @@ func (r *Router) resolveCellID(_ string, urlPath string) (string, bool) {
 }
 
 func (r *Router) resolveHTTPRoutePattern(method, urlPath string) (string, bool) {
-	if route, ok := r.resolveOwnedRoutePattern(method, urlPath, true); ok {
+	if route, ok := r.resolveRegisteredRoutePattern(method, urlPath, true); ok {
 		return route, true
 	}
 	if route, ok := r.resolveContractRoutePattern(method, urlPath, true); ok {
 		return route, true
 	}
-	if route, ok := r.resolveOwnedRoutePattern(method, urlPath, false); ok {
+	if route, ok := r.resolveRegisteredRoutePattern(method, urlPath, false); ok {
 		return route, true
 	}
 	return r.resolveContractRoutePattern(method, urlPath, false)
 }
 
-func (r *Router) resolveOwnedRoutePattern(method, urlPath string, requireMethod bool) (string, bool) {
+func (r *Router) resolveRegisteredRoutePattern(method, urlPath string, requireMethod bool) (string, bool) {
 	urlPath = cleanRoutePath(urlPath)
 	bestRoute := ""
 	bestScore := -1
-	for _, route := range r.ownedRoutes {
+	for _, route := range r.routePatterns {
 		if requireMethod && !routeMethodMatches(route.method, method) {
 			continue
 		}
@@ -1152,6 +1200,7 @@ type chiRouterAdapter struct {
 	declarer kcell.AuthRouteDeclarer
 	owner    *Router
 	cellID   string
+	err      *error
 }
 
 // Compile-time checks: chiRouterAdapter forwards AuthRouteMeta + declares
@@ -1167,41 +1216,63 @@ var _ kcell.HTTPContractDeclarer = (*chiRouterAdapter)(nil)
 func (a *chiRouterAdapter) Prefix() string { return a.prefix }
 
 func (a *chiRouterAdapter) Handle(pattern string, handler http.Handler) {
+	if a.hasRegistrationErr() {
+		return
+	}
 	if method, routePath := splitHandlePattern(pattern); routePath != "" {
-		a.recordOwnedRoute(method, routePath)
+		if err := a.recordOwnedRoute(method, routePath); err != nil {
+			a.setRegistrationErr(err)
+			return
+		}
 	}
 	a.cr.Handle(pattern, handler)
 }
 
 func (a *chiRouterAdapter) Route(pattern string, fn func(kcell.RouteMux)) {
+	if a.hasRegistrationErr() {
+		return
+	}
+	fullPrefix := joinPrefix(a.prefix, pattern)
+	if err := a.recordOwnedPrefix(fullPrefix); err != nil {
+		a.setRegistrationErr(err)
+		return
+	}
 	a.cr.Route(pattern, func(cr chi.Router) {
-		fullPrefix := joinPrefix(a.prefix, pattern)
-		a.recordOwnedPrefix(fullPrefix)
 		sub := &chiRouterAdapter{
 			cr:       cr,
 			prefix:   fullPrefix,
 			declarer: a.declarer,
 			owner:    a.owner,
 			cellID:   a.cellID,
+			err:      a.err,
 		}
 		fn(sub)
 	})
 }
 
 func (a *chiRouterAdapter) Mount(pattern string, handler http.Handler) {
-	a.recordOwnedPrefix(joinPrefix(a.prefix, pattern))
+	if a.hasRegistrationErr() {
+		return
+	}
+	if err := a.recordOwnedPrefix(joinPrefix(a.prefix, pattern)); err != nil {
+		a.setRegistrationErr(err)
+		return
+	}
 	a.cr.Mount(pattern, handler)
 }
 
 func (a *chiRouterAdapter) Group(fn func(kcell.RouteMux)) {
+	if a.hasRegistrationErr() {
+		return
+	}
 	a.cr.Group(func(cr chi.Router) {
-		sub := &chiRouterAdapter{cr: cr, prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID}
+		sub := &chiRouterAdapter{cr: cr, prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID, err: a.err}
 		fn(sub)
 	})
 }
 
 func (a *chiRouterAdapter) With(mw ...func(http.Handler) http.Handler) kcell.RouteMux {
-	return &chiRouterAdapter{cr: a.cr.With(mw...), prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID}
+	return &chiRouterAdapter{cr: a.cr.With(mw...), prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID, err: a.err}
 }
 
 // DeclareAuthMeta composes the adapter's mount prefix with the declared path
@@ -1220,8 +1291,14 @@ func (a *chiRouterAdapter) DeclareAuthMeta(m kcell.AuthRouteMeta) error {
 // Router-rooted declarer. ContractSpec.Path is already the canonical full
 // path, so unlike AuthRouteMeta it is not composed with the chi prefix.
 func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error {
-	if a.owner != nil && a.cellID != "" {
-		a.owner.recordOwnedRoutePattern(a.cellID, spec.Method, spec.Path)
+	if a.owner != nil {
+		a.owner.recordRoutePattern(spec.Method, spec.Path)
+		if a.cellID != "" {
+			if err := a.owner.recordOwnedRoutePath(a.cellID, spec.Path); err != nil {
+				a.setRegistrationErr(err)
+				return err
+			}
+		}
 	}
 	if a.declarer == nil {
 		return nil
@@ -1232,18 +1309,37 @@ func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error 
 	return nil
 }
 
-func (a *chiRouterAdapter) recordOwnedPrefix(prefix string) {
+func (a *chiRouterAdapter) recordOwnedPrefix(prefix string) error {
 	if a.owner == nil || a.cellID == "" {
-		return
+		return nil
 	}
-	a.owner.recordOwnedPrefix(a.cellID, prefix)
+	return a.owner.recordOwnedPrefix(a.cellID, prefix)
 }
 
-func (a *chiRouterAdapter) recordOwnedRoute(method, routePath string) {
-	if a.owner == nil || a.cellID == "" {
+func (a *chiRouterAdapter) recordOwnedRoute(method, routePath string) error {
+	if a.owner == nil {
+		return nil
+	}
+	fullPath := joinPrefix(a.prefix, routePath)
+	a.owner.recordRoutePattern(method, fullPath)
+	if a.cellID == "" {
+		return nil
+	}
+	if err := a.owner.recordOwnedRoutePath(a.cellID, fullPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *chiRouterAdapter) setRegistrationErr(err error) {
+	if err == nil || a.err == nil || *a.err != nil {
 		return
 	}
-	a.owner.recordOwnedRoutePattern(a.cellID, method, joinPrefix(a.prefix, routePath))
+	*a.err = err
+}
+
+func (a *chiRouterAdapter) hasRegistrationErr() bool {
+	return a.err != nil && *a.err != nil
 }
 
 // joinPrefix composes a parent mount prefix with a child pattern/path,

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -90,7 +90,7 @@ func WithRequestIDOptions(opts ...middleware.RequestIDOption) Option {
 }
 
 // WithRateLimiter enables per-IP rate limiting in the default middleware chain.
-// When provided, the rate limiter is placed after AccessLog and before Metrics.
+// When provided, the rate limiter is placed after observability and before auth.
 //
 // ref: go-zero — rate limiting as default middleware when configured
 func WithRateLimiter(rl middleware.RateLimiter) Option {
@@ -314,6 +314,8 @@ type Router struct {
 	// by auth.Mount. Tracing uses these as a fallback when upstream middleware
 	// short-circuits before wrapper.HTTPHandler can contribute attrs.
 	declaredHTTPContracts      []wrapper.ContractSpec
+	ownedRoutes                []ownedRoutePattern
+	ownedPrefixes              []ownedRoutePrefix
 	passwordResetExemptMatcher func(method, urlPath string) bool
 	derivedHint                string
 
@@ -342,6 +344,17 @@ type Router struct {
 type earlyResponder struct {
 	predicate func(*http.Request) bool
 	handler   http.HandlerFunc
+}
+
+type ownedRoutePattern struct {
+	method string
+	path   string
+	cellID string
+}
+
+type ownedRoutePrefix struct {
+	prefix string
+	cellID string
 }
 
 // earlyResponderMiddleware turns an earlyResponder into a chi middleware that
@@ -393,7 +406,7 @@ func MustNew(opts ...Option) *Router {
 //
 // The middleware chain is:
 //
-//	ListenerContext → RequestID → RealIP → Recorder → [Tracing] → AccessLog → [Metrics]
+//	ListenerContext → RequestID → RealIP → Recorder → CellAttribution → [Tracing] → AccessLog → [Metrics]
 //	→ Recovery → SecurityHeaders → [earlyResponders] → [defaultMiddleware]
 //	→ [RateLimit] → [CircuitBreaker] → [Auth] → BodyLimit → handlers
 //
@@ -473,7 +486,7 @@ func (r *Router) buildRealIPMiddleware() (func(http.Handler) http.Handler, error
 //
 // Chain order (outer to inner):
 //
-//	ListenerContext → RequestID → RealIP → Recorder → [Tracing] → AccessLog → [Metrics]
+//	ListenerContext → RequestID → RealIP → Recorder → CellAttribution → [Tracing] → AccessLog → [Metrics]
 //	→ Recovery → SecurityHeaders → [earlyResponders] → [defaultMiddleware]
 //	→ [RateLimit] → [CircuitBreaker] → [Auth] → BodyLimit → handlers
 func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
@@ -500,20 +513,18 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 		middleware.RequestIDWithOptions(r.requestIDOpts...),
 		realIPMW,
 		middleware.Recorder,
+		middleware.CellAttribution(r.resolveCellID),
 	)
 	if r.tracer != nil {
 		r.mux.Use(middleware.Tracing(r.tracer, r.tracingOpts...))
 	}
 	r.mux.Use(middleware.AccessLog(r.clock))
 	if r.metricsCollector != nil {
-		// HTTP-METRICS-LABEL-REALIGN: middleware.Metrics attaches its own
-		// mutable *cellIDState seeded with the framework "_runtime"
-		// sentinel; bootstrap.mountOneRouteGroup installs
-		// WithCellIDContext on each cell-owned sub-mux to mutate that
-		// state. The recorder fires after next.ServeHTTP returns, so it
-		// observes whichever value won — sentinel for framework routes,
-		// the cell ID for business routes.
-		r.mux.Use(middleware.Metrics(r.metricsCollector, r.clock))
+		r.mux.Use(middleware.Metrics(
+			r.metricsCollector,
+			r.clock,
+			middleware.WithRoutePatternResolver(r.resolveHTTPRoutePattern),
+		))
 	}
 	r.mux.Use(
 		middleware.Recovery,
@@ -617,6 +628,48 @@ func (r *Router) Mount(prefix string, handler http.Handler) {
 // registered through it, without modifying the receiver.
 func (r *Router) With(mw ...func(http.Handler) http.Handler) kcell.RouteMux {
 	return &chiRouterAdapter{cr: r.mux.With(mw...), declarer: r}
+}
+
+// MountRouteGroup mounts a cell RouteGroup and records its HTTP namespace
+// ownership for root-level observability. Cell ownership is resolved before
+// protection middleware, so auth/rate-limit/circuit-breaker/body-limit rejects
+// and chi 405s receive the same cell label as successful handler executions.
+func (r *Router) MountRouteGroup(rg kcell.RouteGroup) error {
+	if rg.Register == nil {
+		return fmt.Errorf("router: RouteGroup for listener %q has nil Register function", rg.Listener.String())
+	}
+	if rg.CellID != "" && rg.Prefix != "" {
+		r.recordOwnedPrefix(rg.CellID, rg.Prefix)
+	}
+
+	var registerErr error
+	if rg.Prefix != "" {
+		r.mux.Route(rg.Prefix, func(cr chi.Router) {
+			if len(rg.Middleware) > 0 {
+				cr = cr.With(rg.Middleware...)
+			}
+			sub := &chiRouterAdapter{
+				cr:       cr,
+				prefix:   rg.Prefix,
+				declarer: r,
+				owner:    r,
+				cellID:   rg.CellID,
+			}
+			registerErr = rg.Register(sub)
+		})
+		return registerErr
+	}
+
+	cr := chi.Router(r.mux)
+	if len(rg.Middleware) > 0 {
+		cr = r.mux.With(rg.Middleware...)
+	}
+	return rg.Register(&chiRouterAdapter{
+		cr:       cr,
+		declarer: r,
+		owner:    r,
+		cellID:   rg.CellID,
+	})
 }
 
 // DeclareAuthMeta implements cell.AuthRouteDeclarer. It accumulates auth route
@@ -839,6 +892,26 @@ func (r *Router) DeclaredAuthMetas() []kcell.AuthRouteMeta {
 	return out
 }
 
+func (r *Router) recordOwnedPrefix(cellID, prefix string) {
+	if cellID == "" || strings.TrimSpace(prefix) == "" {
+		return
+	}
+	prefix = cleanRoutePath(prefix)
+	r.ownedPrefixes = append(r.ownedPrefixes, ownedRoutePrefix{prefix: prefix, cellID: cellID})
+}
+
+func (r *Router) recordOwnedRoutePattern(cellID, method, routePath string) {
+	routePath = cleanRoutePath(routePath)
+	if cellID == "" || routePath == "" {
+		return
+	}
+	r.ownedRoutes = append(r.ownedRoutes, ownedRoutePattern{
+		method: strings.ToUpper(method),
+		path:   routePath,
+		cellID: cellID,
+	})
+}
+
 // not404Handler writes a 404 JSON body. Used when a primary-listener router
 // needs an explicit 404 for /internal/v1/* paths.
 // Exported for bootstrap's phase5 to install as a route group on the primary
@@ -888,11 +961,102 @@ func (r *Router) resolveHTTPContractAttrs(method, urlPath string) ([]wrapper.Att
 	return nil, false
 }
 
+func (r *Router) resolveCellID(_ string, urlPath string) (string, bool) {
+	urlPath = cleanRoutePath(urlPath)
+	bestCell := ""
+	bestScore := -1
+
+	for _, route := range r.ownedRoutes {
+		if !routePatternMatches(route.path, urlPath) {
+			continue
+		}
+		if score := routeMatchScore(route.path); score > bestScore {
+			bestScore = score
+			bestCell = route.cellID
+		}
+	}
+	for _, prefix := range r.ownedPrefixes {
+		if !segmentPrefixMatches(urlPath, prefix.prefix) {
+			continue
+		}
+		if score := routeMatchScore(prefix.prefix); score > bestScore {
+			bestScore = score
+			bestCell = prefix.cellID
+		}
+	}
+	return bestCell, bestCell != ""
+}
+
+func (r *Router) resolveHTTPRoutePattern(method, urlPath string) (string, bool) {
+	if route, ok := r.resolveOwnedRoutePattern(method, urlPath, true); ok {
+		return route, true
+	}
+	if route, ok := r.resolveContractRoutePattern(method, urlPath, true); ok {
+		return route, true
+	}
+	if route, ok := r.resolveOwnedRoutePattern(method, urlPath, false); ok {
+		return route, true
+	}
+	return r.resolveContractRoutePattern(method, urlPath, false)
+}
+
+func (r *Router) resolveOwnedRoutePattern(method, urlPath string, requireMethod bool) (string, bool) {
+	urlPath = cleanRoutePath(urlPath)
+	bestRoute := ""
+	bestScore := -1
+	for _, route := range r.ownedRoutes {
+		if requireMethod && !routeMethodMatches(route.method, method) {
+			continue
+		}
+		if !routePatternMatches(route.path, urlPath) {
+			continue
+		}
+		if score := routeMatchScore(route.path); score > bestScore {
+			bestScore = score
+			bestRoute = route.path
+		}
+	}
+	return bestRoute, bestRoute != ""
+}
+
+func (r *Router) resolveContractRoutePattern(method, urlPath string, requireMethod bool) (string, bool) {
+	urlPath = cleanRoutePath(urlPath)
+	bestRoute := ""
+	bestScore := -1
+	for _, spec := range r.declaredHTTPContracts {
+		if requireMethod && !contractMethodMatches(spec.Method, method) {
+			continue
+		}
+		routePath := cleanRoutePath(spec.Path)
+		if !routePatternMatches(routePath, urlPath) {
+			continue
+		}
+		if score := routeMatchScore(routePath); score > bestScore {
+			bestScore = score
+			bestRoute = routePath
+		}
+	}
+	return bestRoute, bestRoute != ""
+}
+
+func routeMethodMatches(routeMethod, requestMethod string) bool {
+	return routeMethod == "" || contractMethodMatches(routeMethod, requestMethod)
+}
+
 func contractMethodMatches(contractMethod, requestMethod string) bool {
 	return contractMethod == requestMethod || (contractMethod == http.MethodGet && requestMethod == http.MethodHead)
 }
 
 func contractPathMatches(template, concrete string) bool {
+	return routePatternMatches(template, concrete)
+}
+
+func routePatternMatches(template, concrete string) bool {
+	template = cleanRoutePath(template)
+	concrete = cleanRoutePath(concrete)
+	if strings.HasSuffix(template, "/*") {
+		return segmentPrefixMatches(concrete, strings.TrimSuffix(template, "/*"))
+	}
 	tParts := strings.Split(strings.Trim(template, "/"), "/")
 	cParts := strings.Split(strings.Trim(concrete, "/"), "/")
 	if len(tParts) != len(cParts) {
@@ -911,6 +1075,41 @@ func contractPathMatches(template, concrete string) bool {
 		}
 	}
 	return true
+}
+
+func segmentPrefixMatches(concrete, prefix string) bool {
+	concrete = cleanRoutePath(concrete)
+	prefix = cleanRoutePath(prefix)
+	if prefix == "/" {
+		return true
+	}
+	return concrete == prefix || strings.HasPrefix(concrete, prefix+"/")
+}
+
+func routeMatchScore(routePath string) int {
+	return len(cleanRoutePath(routePath))
+}
+
+func splitHandlePattern(pattern string) (method, routePath string) {
+	fields := strings.Fields(pattern)
+	if len(fields) >= 2 {
+		return strings.ToUpper(fields[0]), fields[1]
+	}
+	return "", pattern
+}
+
+func cleanRoutePath(routePath string) string {
+	if routePath == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(routePath, "/") {
+		routePath = "/" + routePath
+	}
+	cleaned := path.Clean(routePath)
+	if cleaned == "." {
+		return "/"
+	}
+	return cleaned
 }
 
 func httpContractAttrs(spec wrapper.ContractSpec) []wrapper.Attr {
@@ -951,6 +1150,8 @@ type chiRouterAdapter struct {
 	cr       chi.Router
 	prefix   string
 	declarer kcell.AuthRouteDeclarer
+	owner    *Router
+	cellID   string
 }
 
 // Compile-time checks: chiRouterAdapter forwards AuthRouteMeta + declares
@@ -966,33 +1167,41 @@ var _ kcell.HTTPContractDeclarer = (*chiRouterAdapter)(nil)
 func (a *chiRouterAdapter) Prefix() string { return a.prefix }
 
 func (a *chiRouterAdapter) Handle(pattern string, handler http.Handler) {
+	if method, routePath := splitHandlePattern(pattern); routePath != "" {
+		a.recordOwnedRoute(method, routePath)
+	}
 	a.cr.Handle(pattern, handler)
 }
 
 func (a *chiRouterAdapter) Route(pattern string, fn func(kcell.RouteMux)) {
 	a.cr.Route(pattern, func(cr chi.Router) {
+		fullPrefix := joinPrefix(a.prefix, pattern)
+		a.recordOwnedPrefix(fullPrefix)
 		sub := &chiRouterAdapter{
 			cr:       cr,
-			prefix:   joinPrefix(a.prefix, pattern),
+			prefix:   fullPrefix,
 			declarer: a.declarer,
+			owner:    a.owner,
+			cellID:   a.cellID,
 		}
 		fn(sub)
 	})
 }
 
 func (a *chiRouterAdapter) Mount(pattern string, handler http.Handler) {
+	a.recordOwnedPrefix(joinPrefix(a.prefix, pattern))
 	a.cr.Mount(pattern, handler)
 }
 
 func (a *chiRouterAdapter) Group(fn func(kcell.RouteMux)) {
 	a.cr.Group(func(cr chi.Router) {
-		sub := &chiRouterAdapter{cr: cr, prefix: a.prefix, declarer: a.declarer}
+		sub := &chiRouterAdapter{cr: cr, prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID}
 		fn(sub)
 	})
 }
 
 func (a *chiRouterAdapter) With(mw ...func(http.Handler) http.Handler) kcell.RouteMux {
-	return &chiRouterAdapter{cr: a.cr.With(mw...), prefix: a.prefix, declarer: a.declarer}
+	return &chiRouterAdapter{cr: a.cr.With(mw...), prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID}
 }
 
 // DeclareAuthMeta composes the adapter's mount prefix with the declared path
@@ -1011,6 +1220,9 @@ func (a *chiRouterAdapter) DeclareAuthMeta(m kcell.AuthRouteMeta) error {
 // Router-rooted declarer. ContractSpec.Path is already the canonical full
 // path, so unlike AuthRouteMeta it is not composed with the chi prefix.
 func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error {
+	if a.owner != nil && a.cellID != "" {
+		a.owner.recordOwnedRoutePattern(a.cellID, spec.Method, spec.Path)
+	}
 	if a.declarer == nil {
 		return nil
 	}
@@ -1018,6 +1230,20 @@ func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error 
 		return declarer.DeclareHTTPContract(spec)
 	}
 	return nil
+}
+
+func (a *chiRouterAdapter) recordOwnedPrefix(prefix string) {
+	if a.owner == nil || a.cellID == "" {
+		return
+	}
+	a.owner.recordOwnedPrefix(a.cellID, prefix)
+}
+
+func (a *chiRouterAdapter) recordOwnedRoute(method, routePath string) {
+	if a.owner == nil || a.cellID == "" {
+		return
+	}
+	a.owner.recordOwnedRoutePattern(a.cellID, method, joinPrefix(a.prefix, routePath))
 }
 
 // joinPrefix composes a parent mount prefix with a child pattern/path,

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -179,6 +179,100 @@ func TestMountRouteGroup_CellAttribution_PrefixRejectsAnd405(t *testing.T) {
 	)])
 }
 
+func TestMountRouteGroup_CellOwnership_DuplicatePathTemplateAcrossCellsFails(t *testing.T) {
+	r := MustNew(WithRouterClock(clock.Real()))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1",
+		CellID:   "accesscore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /users/{id}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			return nil
+		},
+	}))
+
+	err := r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "",
+		CellID:   "auditcore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("POST /api/v1/users/{id}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			return nil
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate route ownership")
+	assert.Contains(t, err.Error(), "/api/v1/users/{id}")
+	assert.Contains(t, err.Error(), "accesscore")
+	assert.Contains(t, err.Error(), "auditcore")
+}
+
+func TestMountRouteGroup_CellOwnership_DuplicatePathTemplateSameCellAllowed(t *testing.T) {
+	r := MustNew(WithRouterClock(clock.Real()))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1",
+		CellID:   "accesscore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /users/{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			return nil
+		},
+	}))
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "",
+		CellID:   "accesscore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("POST /api/v1/users/{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+			}))
+			return nil
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/42", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/users/42", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestMountRouteGroup_CellAttribution_MethodNotAllowedUsesPathOwnership(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/devices",
+		CellID:   "devicecell",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			return nil
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/abc", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"devicecell", http.MethodPost, "/api/v1/devices/{id}", http.StatusMethodNotAllowed,
+	)])
+}
+
 func TestMountRouteGroup_CellAttribution_AuthReject(t *testing.T) {
 	mc := metrics.NewInMemoryCollector()
 	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1"}}

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -273,6 +273,46 @@ func TestMountRouteGroup_CellAttribution_MethodNotAllowedUsesPathOwnership(t *te
 	)])
 }
 
+func TestMountRouteGroup_CellAttribution_StaticPathBeatsGenericTemplate(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	limiter := &routerTestLimiter{allow: false}
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc), WithRateLimiter(limiter))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		CellID:   "genericcore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /api/v1/{resource}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("handler must not run when rate limiter rejects")
+			}))
+			return nil
+		},
+	}))
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		CellID:   "accesscore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /api/v1/users", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("handler must not run when rate limiter rejects")
+			}))
+			return nil
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"accesscore", http.MethodGet, "/api/v1/users", http.StatusTooManyRequests,
+	)])
+	assert.Equal(t, int64(0), snap.RequestCounts[routerRequestKey(
+		"genericcore", http.MethodGet, "/api/v1/{resource}", http.StatusTooManyRequests,
+	)])
+}
+
 func TestMountRouteGroup_CellAttribution_AuthReject(t *testing.T) {
 	mc := metrics.NewInMemoryCollector()
 	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1"}}

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -52,6 +52,10 @@ func findAccessLogEntry(logs []byte, wantPath string) (map[string]any, bool) {
 	return nil, false
 }
 
+func routerRequestKey(cellID, method, route string, status int) metrics.RequestKey {
+	return metrics.RequestKey{Cell: cellID, Method: method, Route: route, Status: status}
+}
+
 func TestRouterImplementsRouteMux(t *testing.T) {
 	r := MustNew(WithRouterClock(clock.Real()))
 	var mux cell.RouteMux = r
@@ -135,6 +139,236 @@ func TestRouteGroup(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMountRouteGroup_CellAttribution_PrefixRejectsAnd405(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	limiter := &routerTestLimiter{allow: false}
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc), WithRateLimiter(limiter))
+
+	err := r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/access",
+		CellID:   "accesscore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /users/{id}", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("handler must not run when rate limiter rejects")
+			}))
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/users/42", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	limiter.allow = true
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/access/users/42", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"accesscore", http.MethodGet, "/api/v1/access/users/{id}", http.StatusTooManyRequests,
+	)])
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"accesscore", http.MethodPost, "/api/v1/access/users/{id}", http.StatusMethodNotAllowed,
+	)])
+}
+
+func TestMountRouteGroup_CellAttribution_AuthReject(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	verifier := &routerTestVerifier{claims: auth.Claims{Subject: "user-1"}}
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc), WithAuthMiddleware(verifier))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/secure",
+		CellID:   "accesscore",
+		Register: func(mux cell.RouteMux) error {
+			return auth.Mount(mux, auth.Route{
+				Contract: testHTTPContract(http.MethodGet, "/api/v1/secure/{id}"),
+				Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					t.Fatal("handler must not run when auth rejects")
+				}),
+				Policy: authtest.RequireAuthenticated(),
+			})
+		},
+	}))
+	require.NoError(t, r.FinalizeAuth())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secure/42", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"accesscore", http.MethodGet, "/api/v1/secure/{id}", http.StatusUnauthorized,
+	)])
+}
+
+func TestMountRouteGroup_CellAttribution_CircuitBreakerReject(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	breaker := &routerTestBreaker{allowErr: fmt.Errorf("open")}
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc), WithCircuitBreaker(breaker))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/cb",
+		CellID:   "auditcore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /events", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("handler must not run when circuit breaker rejects")
+			}))
+			return nil
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cb/events", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"auditcore", http.MethodGet, "/api/v1/cb/events", http.StatusServiceUnavailable,
+	)])
+}
+
+func TestMountRouteGroup_CellAttribution_BodyLimitReject(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc), WithBodyLimit(4))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/upload",
+		CellID:   "configcore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("POST /blob", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("handler must not run when body limit rejects")
+			}))
+			return nil
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/upload/blob", strings.NewReader("too-large"))
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"configcore", http.MethodPost, "/api/v1/upload/blob", http.StatusRequestEntityTooLarge,
+	)])
+}
+
+func TestMountRouteGroup_CellAttribution_EmptyPrefixNestedRoutes(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc))
+
+	err := r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		CellID:   "devicecell",
+		Register: func(mux cell.RouteMux) error {
+			mux.Route("/api/v1/devices", func(devices cell.RouteMux) {
+				devices.Handle("GET /{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			})
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices/abc", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/outside", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"devicecell", http.MethodGet, "/api/v1/devices/{id}", http.StatusOK,
+	)])
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"_runtime", http.MethodGet, "unmatched", http.StatusNotFound,
+	)])
+}
+
+func TestMountRouteGroup_CellAttribution_LongestPrefixWins(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	limiter := &routerTestLimiter{allow: false}
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc), WithRateLimiter(limiter))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1",
+		CellID:   "configcore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /config", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			return nil
+		},
+	}))
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/access",
+		CellID:   "accesscore",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /users", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			return nil
+		},
+	}))
+
+	for _, path := range []string{"/api/v1/config", "/api/v1/access/users"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	}
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"configcore", http.MethodGet, "/api/v1/config", http.StatusTooManyRequests,
+	)])
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"accesscore", http.MethodGet, "/api/v1/access/users", http.StatusTooManyRequests,
+	)])
+}
+
+func TestMountRouteGroup_CellAttribution_RawMountPrefix(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		CellID:   "mountcell",
+		Register: func(mux cell.RouteMux) error {
+			sub := chi.NewRouter()
+			sub.Get("/ok", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+			mux.Mount("/mounted", sub)
+			return nil
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/mounted/ok", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"mountcell", http.MethodGet, "/mounted/ok", http.StatusNoContent,
+	)])
 }
 
 func TestGroup(t *testing.T) {
@@ -236,7 +470,7 @@ func TestPanicRequestRecordedInMetrics(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	snap := mc.Snapshot()
-	key := "_runtime GET /boom 500"
+	key := routerRequestKey("_runtime", http.MethodGet, "/boom", http.StatusInternalServerError)
 	assert.Equal(t, int64(1), snap.RequestCounts[key],
 		"metrics must record panic request as status 500 under cell=_runtime (router-installed sentinel)")
 }
@@ -270,7 +504,7 @@ func TestNormalRequestUnchanged(t *testing.T) {
 	// Verify metrics recorded status 200 under the listener-root sentinel
 	// (no RouteGroup means no per-cell override fired).
 	snap := mc.Snapshot()
-	key := "_runtime GET /ok 200"
+	key := routerRequestKey("_runtime", http.MethodGet, "/ok", http.StatusOK)
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -580,7 +814,7 @@ func TestWithTracer_PanicRequestRecordedInMetrics(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	snap := mc.Snapshot()
-	key := "_runtime GET /boom-full 500"
+	key := routerRequestKey("_runtime", http.MethodGet, "/boom-full", http.StatusInternalServerError)
 	assert.Equal(t, int64(1), snap.RequestCounts[key],
 		"metrics must record panic request as 500 even with tracing in chain (cell=_runtime — router sentinel)")
 }
@@ -827,10 +1061,10 @@ func TestMetrics_Records429And503(t *testing.T) {
 	snap := mc.Snapshot()
 	found429, found503 := false, false
 	for key, count := range snap.RequestCounts {
-		if strings.Contains(key, "429") && count > 0 {
+		if key.Status == http.StatusTooManyRequests && count > 0 {
 			found429 = true
 		}
-		if strings.Contains(key, "503") && count > 0 {
+		if key.Status == http.StatusServiceUnavailable && count > 0 {
 			found503 = true
 		}
 	}

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -236,8 +236,9 @@ func TestPanicRequestRecordedInMetrics(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	snap := mc.Snapshot()
-	key := "GET /boom 500"
-	assert.Equal(t, int64(1), snap.RequestCounts[key], "metrics must record panic request as status 500")
+	key := "_runtime GET /boom 500"
+	assert.Equal(t, int64(1), snap.RequestCounts[key],
+		"metrics must record panic request as status 500 under cell=_runtime (router-installed sentinel)")
 }
 
 func TestNormalRequestUnchanged(t *testing.T) {
@@ -266,9 +267,10 @@ func TestNormalRequestUnchanged(t *testing.T) {
 	require.True(t, found, "access log entry must exist")
 	assert.Equal(t, float64(200), entry["status"])
 
-	// Verify metrics recorded status 200.
+	// Verify metrics recorded status 200 under the listener-root sentinel
+	// (no RouteGroup means no per-cell override fired).
 	snap := mc.Snapshot()
-	key := "GET /ok 200"
+	key := "_runtime GET /ok 200"
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
@@ -578,9 +580,9 @@ func TestWithTracer_PanicRequestRecordedInMetrics(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	snap := mc.Snapshot()
-	key := "GET /boom-full 500"
+	key := "_runtime GET /boom-full 500"
 	assert.Equal(t, int64(1), snap.RequestCounts[key],
-		"metrics must record panic request as 500 even with tracing in chain")
+		"metrics must record panic request as 500 even with tracing in chain (cell=_runtime — router sentinel)")
 }
 
 // --- Rate limiter wiring ---

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -8,7 +8,6 @@ package metrics
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sort"
 	"sync"
@@ -23,38 +22,43 @@ type Collector interface {
 	//
 	// cellID identifies the cell that owns the matched RouteGroup, or
 	// "_runtime" for framework-owned paths (healthz/readyz/metrics, unmatched
-	// 404s, listeners with no business RouteGroup attached). Bootstrap
-	// installs ctx-injecting middleware at both the listener-root and route-
-	// group layers so the value is always present at the time middleware
-	// invokes RecordRequest; see runtime/http/middleware.WithCellIDContext.
+	// 404s, listeners with no business RouteGroup attached). The router root
+	// resolves this ownership before protection middleware can short-circuit.
 	RecordRequest(cellID, method, route string, status int, durationSeconds float64)
+}
+
+// RequestKey identifies one low-cardinality HTTP request metric series.
+type RequestKey struct {
+	Cell   string
+	Method string
+	Route  string
+	Status int
 }
 
 // Snapshot is a point-in-time view of recorded metrics.
 type Snapshot struct {
-	// Key is "method route status" (e.g. "GET /api/v1/users/{id} 200").
-	RequestCounts  map[string]int64
-	DurationSumsMs map[string]int64
+	RequestCounts  map[RequestKey]int64
+	DurationSumsMs map[RequestKey]int64
 }
 
 // InMemoryCollector is a simple in-memory metrics collector for development
 // and testing. It records request counts and cumulative duration.
 type InMemoryCollector struct {
 	mu        sync.RWMutex
-	counts    map[string]*atomic.Int64
-	durations map[string]*atomic.Int64 // cumulative duration in microseconds
+	counts    map[RequestKey]*atomic.Int64
+	durations map[RequestKey]*atomic.Int64 // cumulative duration in microseconds
 }
 
 // NewInMemoryCollector creates an InMemoryCollector.
 func NewInMemoryCollector() *InMemoryCollector {
 	return &InMemoryCollector{
-		counts:    make(map[string]*atomic.Int64),
-		durations: make(map[string]*atomic.Int64),
+		counts:    make(map[RequestKey]*atomic.Int64),
+		durations: make(map[RequestKey]*atomic.Int64),
 	}
 }
 
-func metricKey(cellID, method, route string, status int) string {
-	return fmt.Sprintf("%s %s %s %d", cellID, method, route, status)
+func metricKey(cellID, method, route string, status int) RequestKey {
+	return RequestKey{Cell: cellID, Method: method, Route: route, Status: status}
 }
 
 // RecordRequest records a completed HTTP request.
@@ -89,8 +93,8 @@ func (c *InMemoryCollector) Snapshot() Snapshot {
 	defer c.mu.RUnlock()
 
 	snap := Snapshot{
-		RequestCounts:  make(map[string]int64, len(c.counts)),
-		DurationSumsMs: make(map[string]int64, len(c.durations)),
+		RequestCounts:  make(map[RequestKey]int64, len(c.counts)),
+		DurationSumsMs: make(map[RequestKey]int64, len(c.durations)),
 	}
 	for k, v := range c.counts {
 		snap.RequestCounts[k] = v.Load()
@@ -120,24 +124,27 @@ func (c *InMemoryCollector) Handler() http.Handler {
 		}
 
 		var entries []entry
-		for k, count := range snap.RequestCounts {
-			var cell, method, route string
-			var status int
-			_, _ = fmt.Sscanf(k, "%s %s %s %d", &cell, &method, &route, &status)
+		for key, count := range snap.RequestCounts {
 			entries = append(entries, entry{
-				Cell:       cell,
-				Method:     method,
-				Route:      route,
-				Status:     status,
+				Cell:       key.Cell,
+				Method:     key.Method,
+				Route:      key.Route,
+				Status:     key.Status,
 				Count:      count,
-				DurationMs: snap.DurationSumsMs[k],
+				DurationMs: snap.DurationSumsMs[key],
 			})
 		}
 		sort.Slice(entries, func(i, j int) bool {
 			if entries[i].Cell != entries[j].Cell {
 				return entries[i].Cell < entries[j].Cell
 			}
-			return entries[i].Route < entries[j].Route
+			if entries[i].Route != entries[j].Route {
+				return entries[i].Route < entries[j].Route
+			}
+			if entries[i].Method != entries[j].Method {
+				return entries[i].Method < entries[j].Method
+			}
+			return entries[i].Status < entries[j].Status
 		})
 
 		// Use the unified list response envelope ({"data": [...]}) consistent

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -20,7 +20,14 @@ type Collector interface {
 	// RecordRequest records a completed HTTP request with the given labels.
 	// route is the route pattern (e.g. "/api/v1/users/{id}"), not the actual
 	// request path. Using route patterns prevents metric cardinality explosion.
-	RecordRequest(method, route string, status int, durationSeconds float64)
+	//
+	// cellID identifies the cell that owns the matched RouteGroup, or
+	// "_runtime" for framework-owned paths (healthz/readyz/metrics, unmatched
+	// 404s, listeners with no business RouteGroup attached). Bootstrap
+	// installs ctx-injecting middleware at both the listener-root and route-
+	// group layers so the value is always present at the time middleware
+	// invokes RecordRequest; see runtime/http/middleware.WithCellIDContext.
+	RecordRequest(cellID, method, route string, status int, durationSeconds float64)
 }
 
 // Snapshot is a point-in-time view of recorded metrics.
@@ -46,13 +53,13 @@ func NewInMemoryCollector() *InMemoryCollector {
 	}
 }
 
-func metricKey(method, route string, status int) string {
-	return fmt.Sprintf("%s %s %d", method, route, status)
+func metricKey(cellID, method, route string, status int) string {
+	return fmt.Sprintf("%s %s %s %d", cellID, method, route, status)
 }
 
 // RecordRequest records a completed HTTP request.
-func (c *InMemoryCollector) RecordRequest(method, route string, status int, durationSeconds float64) {
-	key := metricKey(method, route, status)
+func (c *InMemoryCollector) RecordRequest(cellID, method, route string, status int, durationSeconds float64) {
+	key := metricKey(cellID, method, route, status)
 
 	c.mu.RLock()
 	cnt, cntOK := c.counts[key]
@@ -104,6 +111,7 @@ func (c *InMemoryCollector) Handler() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 
 		type entry struct {
+			Cell       string `json:"cell"`
 			Method     string `json:"method"`
 			Route      string `json:"route"`
 			Status     int    `json:"status"`
@@ -113,10 +121,11 @@ func (c *InMemoryCollector) Handler() http.Handler {
 
 		var entries []entry
 		for k, count := range snap.RequestCounts {
-			var method, route string
+			var cell, method, route string
 			var status int
-			_, _ = fmt.Sscanf(k, "%s %s %d", &method, &route, &status)
+			_, _ = fmt.Sscanf(k, "%s %s %s %d", &cell, &method, &route, &status)
 			entries = append(entries, entry{
+				Cell:       cell,
 				Method:     method,
 				Route:      route,
 				Status:     status,
@@ -124,7 +133,12 @@ func (c *InMemoryCollector) Handler() http.Handler {
 				DurationMs: snap.DurationSumsMs[k],
 			})
 		}
-		sort.Slice(entries, func(i, j int) bool { return entries[i].Route < entries[j].Route })
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].Cell != entries[j].Cell {
+				return entries[i].Cell < entries[j].Cell
+			}
+			return entries[i].Route < entries[j].Route
+		})
 
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"metrics": entries,

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -20,10 +20,15 @@ type Collector interface {
 	// route is the route pattern (e.g. "/api/v1/users/{id}"), not the actual
 	// request path. Using route patterns prevents metric cardinality explosion.
 	//
-	// cellID identifies the cell that owns the matched RouteGroup, or
-	// "_runtime" for framework-owned paths (healthz/readyz/metrics, unmatched
-	// 404s, listeners with no business RouteGroup attached). The router root
-	// resolves this ownership before protection middleware can short-circuit.
+	// cellID is the coarse owner dimension for the request. It is supplied by
+	// the caller, normally runtime/http/router's root CellAttribution
+	// middleware, from RouteGroup ownership before protection middleware can
+	// short-circuit. It is not inferred by the collector from assembly,
+	// config, route path, tenant, slice, or contract metadata.
+	//
+	// Use the owning cell ID for cell-owned RouteGroups, or "_runtime" for
+	// framework-owned paths (healthz/readyz/metrics, unmatched 404s, listeners
+	// with no business RouteGroup attached).
 	RecordRequest(cellID, method, route string, status int, durationSeconds float64)
 }
 

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -140,8 +140,12 @@ func (c *InMemoryCollector) Handler() http.Handler {
 			return entries[i].Route < entries[j].Route
 		})
 
+		// Use the unified list response envelope ({"data": [...]}) consistent
+		// with .claude/rules/gocell/api-versioning.md and the other HTTP list
+		// endpoints. Inherited "metrics" wrapper would have left this dev/test
+		// handler the only inconsistent shape on the metrics surface.
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"metrics": entries,
+			"data": entries,
 		})
 	})
 }

--- a/runtime/observability/metrics/collector_test.go
+++ b/runtime/observability/metrics/collector_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestInMemoryCollector_Handler(t *testing.T) {
 	c := NewInMemoryCollector()
-	c.RecordRequest(http.MethodGet, "/api", 200, 0.05)
-	c.RecordRequest(http.MethodGet, "/api", 200, 0.03)
-	c.RecordRequest(http.MethodPost, "/api", 201, 0.1)
+	c.RecordRequest("accesscore", http.MethodGet, "/api", 200, 0.05)
+	c.RecordRequest("accesscore", http.MethodGet, "/api", 200, 0.03)
+	c.RecordRequest("accesscore", http.MethodPost, "/api", 201, 0.1)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -35,12 +35,22 @@ func TestInMemoryCollector_Handler(t *testing.T) {
 
 func TestInMemoryCollector_Snapshot(t *testing.T) {
 	c := NewInMemoryCollector()
-	c.RecordRequest("GET", "/a", 200, 0.001)
-	c.RecordRequest("GET", "/a", 200, 0.002)
+	c.RecordRequest("accesscore", "GET", "/a", 200, 0.001)
+	c.RecordRequest("accesscore", "GET", "/a", 200, 0.002)
 
 	snap := c.Snapshot()
-	assert.Equal(t, int64(2), snap.RequestCounts["GET /a 200"])
-	assert.True(t, snap.DurationSumsMs["GET /a 200"] >= 0)
+	assert.Equal(t, int64(2), snap.RequestCounts["accesscore GET /a 200"])
+	assert.True(t, snap.DurationSumsMs["accesscore GET /a 200"] >= 0)
+}
+
+func TestInMemoryCollector_PerCellSeparation(t *testing.T) {
+	c := NewInMemoryCollector()
+	c.RecordRequest("accesscore", "GET", "/api/v1/sessions", 200, 0.001)
+	c.RecordRequest("auditcore", "GET", "/api/v1/sessions", 200, 0.002)
+
+	snap := c.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts["accesscore GET /api/v1/sessions 200"])
+	assert.Equal(t, int64(1), snap.RequestCounts["auditcore GET /api/v1/sessions 200"])
 }
 
 // Verify interface compliance at compile time.

--- a/runtime/observability/metrics/collector_test.go
+++ b/runtime/observability/metrics/collector_test.go
@@ -13,9 +13,11 @@ import (
 
 func TestInMemoryCollector_Handler(t *testing.T) {
 	c := NewInMemoryCollector()
+	c.RecordRequest("auditcore", http.MethodPost, "/z", 500, 0.004)
+	c.RecordRequest("accesscore", http.MethodPost, "/api", 201, 0.1)
 	c.RecordRequest("accesscore", http.MethodGet, "/api", 200, 0.05)
 	c.RecordRequest("accesscore", http.MethodGet, "/api", 200, 0.03)
-	c.RecordRequest("accesscore", http.MethodPost, "/api", 201, 0.1)
+	c.RecordRequest("accesscore", http.MethodGet, "/admin", 404, 0.002)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -26,11 +28,24 @@ func TestInMemoryCollector_Handler(t *testing.T) {
 	body, err := io.ReadAll(rec.Body)
 	require.NoError(t, err)
 
-	var result map[string]any
+	type entry struct {
+		Cell       string `json:"cell"`
+		Method     string `json:"method"`
+		Route      string `json:"route"`
+		Status     int    `json:"status"`
+		Count      int64  `json:"count"`
+		DurationMs int64  `json:"duration_sum_ms"`
+	}
+	var result struct {
+		Data []entry `json:"data"`
+	}
 	require.NoError(t, json.Unmarshal(body, &result))
-	entries, ok := result["data"].([]any)
-	require.True(t, ok, "Handler must wrap list payloads under the unified \"data\" key")
-	assert.Len(t, entries, 2) // GET /api 200 and POST /api 201
+	assert.Equal(t, []entry{
+		{Cell: "accesscore", Method: http.MethodGet, Route: "/admin", Status: 404, Count: 1, DurationMs: 2},
+		{Cell: "accesscore", Method: http.MethodGet, Route: "/api", Status: 200, Count: 2, DurationMs: 80},
+		{Cell: "accesscore", Method: http.MethodPost, Route: "/api", Status: 201, Count: 1, DurationMs: 100},
+		{Cell: "auditcore", Method: http.MethodPost, Route: "/z", Status: 500, Count: 1, DurationMs: 4},
+	}, result.Data, "Handler must emit typed request keys sorted by cell, route, method, status")
 }
 
 func TestInMemoryCollector_Snapshot(t *testing.T) {

--- a/runtime/observability/metrics/collector_test.go
+++ b/runtime/observability/metrics/collector_test.go
@@ -28,8 +28,8 @@ func TestInMemoryCollector_Handler(t *testing.T) {
 
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(body, &result))
-	entries, ok := result["metrics"].([]any)
-	require.True(t, ok)
+	entries, ok := result["data"].([]any)
+	require.True(t, ok, "Handler must wrap list payloads under the unified \"data\" key")
 	assert.Len(t, entries, 2) // GET /api 200 and POST /api 201
 }
 

--- a/runtime/observability/metrics/collector_test.go
+++ b/runtime/observability/metrics/collector_test.go
@@ -39,8 +39,9 @@ func TestInMemoryCollector_Snapshot(t *testing.T) {
 	c.RecordRequest("accesscore", "GET", "/a", 200, 0.002)
 
 	snap := c.Snapshot()
-	assert.Equal(t, int64(2), snap.RequestCounts["accesscore GET /a 200"])
-	assert.True(t, snap.DurationSumsMs["accesscore GET /a 200"] >= 0)
+	key := RequestKey{Cell: "accesscore", Method: "GET", Route: "/a", Status: 200}
+	assert.Equal(t, int64(2), snap.RequestCounts[key])
+	assert.True(t, snap.DurationSumsMs[key] >= 0)
 }
 
 func TestInMemoryCollector_PerCellSeparation(t *testing.T) {
@@ -49,8 +50,12 @@ func TestInMemoryCollector_PerCellSeparation(t *testing.T) {
 	c.RecordRequest("auditcore", "GET", "/api/v1/sessions", 200, 0.002)
 
 	snap := c.Snapshot()
-	assert.Equal(t, int64(1), snap.RequestCounts["accesscore GET /api/v1/sessions 200"])
-	assert.Equal(t, int64(1), snap.RequestCounts["auditcore GET /api/v1/sessions 200"])
+	assert.Equal(t, int64(1), snap.RequestCounts[RequestKey{
+		Cell: "accesscore", Method: "GET", Route: "/api/v1/sessions", Status: 200,
+	}])
+	assert.Equal(t, int64(1), snap.RequestCounts[RequestKey{
+		Cell: "auditcore", Method: "GET", Route: "/api/v1/sessions", Status: 200,
+	}])
 }
 
 // Verify interface compliance at compile time.

--- a/runtime/observability/metrics/provider_collector.go
+++ b/runtime/observability/metrics/provider_collector.go
@@ -15,10 +15,9 @@ var DefaultDurationBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5
 
 // ProviderCollectorConfig configures NewProviderCollector.
 //
-// Cell identity is not part of this config — it is derived per request via
-// runtime/http/middleware.WithCellIDContext (installed by bootstrap at the
-// listener-root and route-group layers) and supplied through RecordRequest's
-// cellID argument. See D1 HTTP-METRICS-LABEL-REALIGN.
+// Cell identity is not part of this config — it is derived per request by
+// router-owned root attribution and supplied through RecordRequest's cellID
+// argument. See D1 HTTP-METRICS-LABEL-REALIGN.
 type ProviderCollectorConfig struct {
 	// DurationBuckets overrides DefaultDurationBuckets; zero value uses defaults.
 	DurationBuckets []float64

--- a/runtime/observability/metrics/provider_collector.go
+++ b/runtime/observability/metrics/provider_collector.go
@@ -13,13 +13,13 @@ import (
 // dashboards valid after the migration to the provider-neutral surface.
 var DefaultDurationBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
 
-// ProviderCollectorConfig configures NewProviderCollector. Zero-value
-// defaults produce the equivalent of the legacy Prometheus collector:
-// same metric names ("http_requests_total", "http_request_duration_seconds")
-// and the same DefaultDurationBuckets.
+// ProviderCollectorConfig configures NewProviderCollector.
+//
+// Cell identity is not part of this config — it is derived per request via
+// runtime/http/middleware.WithCellIDContext (installed by bootstrap at the
+// listener-root and route-group layers) and supplied through RecordRequest's
+// cellID argument. See D1 HTTP-METRICS-LABEL-REALIGN.
 type ProviderCollectorConfig struct {
-	// CellID labels every recorded observation (cell="{id}"). Required.
-	CellID string
 	// DurationBuckets overrides DefaultDurationBuckets; zero value uses defaults.
 	DurationBuckets []float64
 }
@@ -28,7 +28,6 @@ type ProviderCollectorConfig struct {
 // metrics.Provider. The Provider owns registry ownership; this collector
 // only records observations.
 type providerCollector struct {
-	cellID   string
 	requests kernelmetrics.CounterVec
 	duration kernelmetrics.HistogramVec
 }
@@ -45,10 +44,6 @@ func NewProviderCollector(p kernelmetrics.Provider, cfg ProviderCollectorConfig)
 	if p == nil {
 		return nil, errcode.New(errcode.ErrObservabilityConfigInvalid,
 			"runtime/observability/metrics: Provider is required")
-	}
-	if cfg.CellID == "" {
-		return nil, errcode.New(errcode.ErrObservabilityConfigInvalid,
-			"runtime/observability/metrics: CellID is required")
 	}
 	if len(cfg.DurationBuckets) == 0 {
 		cfg.DurationBuckets = DefaultDurationBuckets
@@ -74,19 +69,19 @@ func NewProviderCollector(p kernelmetrics.Provider, cfg ProviderCollectorConfig)
 			"(likely duplicate — another collector on this Provider may already own the name): %w", err)
 	}
 
-	return &providerCollector{cellID: cfg.CellID, requests: reqs, duration: dur}, nil
+	return &providerCollector{requests: reqs, duration: dur}, nil
 }
 
 // RecordRequest emits an increment on http_requests_total and a sample on
 // http_request_duration_seconds, labeled identically. Status is stringified
 // once per call because Provider.CounterVec/HistogramVec expect string
 // labels uniformly (avoids adapter-specific type conversions).
-func (c *providerCollector) RecordRequest(method, route string, status int, durationSeconds float64) {
+func (c *providerCollector) RecordRequest(cellID, method, route string, status int, durationSeconds float64) {
 	labels := kernelmetrics.Labels{
 		"method": method,
 		"route":  route,
 		"status": strconv.Itoa(status),
-		"cell":   c.cellID,
+		"cell":   cellID,
 	}
 	c.requests.With(labels).Inc()
 	c.duration.With(labels).Observe(durationSeconds)

--- a/runtime/observability/metrics/provider_collector_test.go
+++ b/runtime/observability/metrics/provider_collector_test.go
@@ -8,32 +8,29 @@ import (
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
-func TestProviderCollector_RejectsMissingDeps(t *testing.T) {
-	if _, err := metrics.NewProviderCollector(nil, metrics.ProviderCollectorConfig{CellID: "x"}); err == nil {
+func TestProviderCollector_RejectsNilProvider(t *testing.T) {
+	if _, err := metrics.NewProviderCollector(nil, metrics.ProviderCollectorConfig{}); err == nil {
 		t.Fatal("nil Provider must be rejected")
-	}
-	if _, err := metrics.NewProviderCollector(kernelmetrics.NopProvider{}, metrics.ProviderCollectorConfig{}); err == nil {
-		t.Fatal("empty CellID must be rejected")
 	}
 }
 
 func TestProviderCollector_NopProviderNoPanic(t *testing.T) {
-	c, err := metrics.NewProviderCollector(kernelmetrics.NopProvider{}, metrics.ProviderCollectorConfig{CellID: "dev"})
+	c, err := metrics.NewProviderCollector(kernelmetrics.NopProvider{}, metrics.ProviderCollectorConfig{})
 	if err != nil {
 		t.Fatalf("NewProviderCollector: %v", err)
 	}
 	// Recording through the Nop provider must not panic.
-	c.RecordRequest("GET", "/api/v1/users", 200, 0.05)
-	c.RecordRequest("POST", "/api/v1/users", 201, 0.12)
+	c.RecordRequest("dev", "GET", "/api/v1/users", 200, 0.05)
+	c.RecordRequest("dev", "POST", "/api/v1/users", 201, 0.12)
 }
 
-func TestProviderCollector_EmitsExpectedLabels(t *testing.T) {
+func TestProviderCollector_EmitsCellLabelFromArg(t *testing.T) {
 	p := newSpyProvider()
-	c, err := metrics.NewProviderCollector(p, metrics.ProviderCollectorConfig{CellID: "accesscore"})
+	c, err := metrics.NewProviderCollector(p, metrics.ProviderCollectorConfig{})
 	if err != nil {
 		t.Fatalf("NewProviderCollector: %v", err)
 	}
-	c.RecordRequest("GET", "/api/v1/sessions", 200, 0.01)
+	c.RecordRequest("accesscore", "GET", "/api/v1/sessions", 200, 0.01)
 
 	ops := p.counterOps["http_requests_total"]
 	if len(ops) != 1 {
@@ -49,6 +46,33 @@ func TestProviderCollector_EmitsExpectedLabels(t *testing.T) {
 	for k, v := range wants {
 		if got[k] != v {
 			t.Errorf("label %s = %q, want %q (all=%v)", k, got[k], v, got)
+		}
+	}
+}
+
+func TestProviderCollector_PerCallCellLabel(t *testing.T) {
+	// Two calls with different cellID values must yield two distinct label sets;
+	// no global / cached cellID can leak between calls.
+	p := newSpyProvider()
+	c, err := metrics.NewProviderCollector(p, metrics.ProviderCollectorConfig{})
+	if err != nil {
+		t.Fatalf("NewProviderCollector: %v", err)
+	}
+	c.RecordRequest("accesscore", "GET", "/api/v1/sessions", 200, 0.01)
+	c.RecordRequest("auditcore", "GET", "/api/v1/audit", 200, 0.02)
+	c.RecordRequest("_runtime", "GET", "/healthz", 200, 0.001)
+
+	ops := p.counterOps["http_requests_total"]
+	if len(ops) != 3 {
+		t.Fatalf("want 3 counter ops, got %d", len(ops))
+	}
+	cells := map[string]bool{}
+	for _, op := range ops {
+		cells[op.labels["cell"]] = true
+	}
+	for _, want := range []string{"accesscore", "auditcore", "_runtime"} {
+		if !cells[want] {
+			t.Errorf("missing cell label %q in %v", want, cells)
 		}
 	}
 }

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -1,37 +1,9 @@
 package archtest
 
-// http_metrics_label_test.go enforces the four invariants of the
-// HTTP-METRICS-LABEL-REALIGN contract (D1, 2026-05-04):
-//
-//   - HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01:
-//     runtime/http/middleware/metrics.go must read the cell label from the
-//     in-flight cellIDState via withCellIDState/cs.cellID — chi-style mutable
-//     pointer pattern that lets sub-mux WithCellIDContext middleware override
-//     the sentinel set at the listener root. A revert that pulls cellID from
-//     a struct field, adds a string-valued ctxkeys read on the wrong layer,
-//     or branches on a fallback would silently erode the per-request label
-//     guarantee; this rule blocks it.
-//
-//   - HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01:
-//     runtime/bootstrap/phases_http.go must not derive any metrics cellID from
-//     b.assemblyID, b.assemblyCore.ID(), or the literal "default". Pre-realign
-//     code did exactly this and broke multi-cell assembly attribution; the new
-//     contract is "cellID flows from RouteGroup.CellID via mutable state,
-//     never from assembly identity".
-//
-//   - HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01:
-//     runtime/observability/metrics.ProviderCollectorConfig must not contain a
-//     CellID field. Holding cellID on the collector instance rather than per
-//     RecordRequest call is the architectural pattern this PR removes.
-//
-//   - HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01:
-//     runtime/http/middleware/metrics.go must seed the cellIDState with
-//     RuntimeCellIDSentinel ("_runtime"), so framework-owned requests
-//     (healthz / readyz / metrics endpoint / unmatched 404s) emit the
-//     framework label rather than an empty value or a per-listener guess.
-//
-// All four rules use go/ast so reorderings, alias renames, and indirect
-// imports are detected even without changing the surface API.
+// http_metrics_label_test.go enforces the HTTP-METRICS-LABEL-REALIGN
+// contract (D1, 2026-05-04): cell identity is a router-root request
+// attribution concern, not a metrics collector constructor field and not a
+// RouteGroup handler-middleware side effect.
 
 import (
 	"go/ast"
@@ -45,74 +17,88 @@ import (
 )
 
 const (
-	ruleHTTPMetricsLabelCtxSource01      = "HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01"
-	ruleHTTPMetricsLabelNoAssemblyDerive = "HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01"
-	ruleHTTPMetricsLabelNoConfigCellID   = "HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01"
-	ruleHTTPMetricsLabelRuntimeSentinel  = "HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01"
-
-	httpMetricsRuntimeSentinelLiteral = `"_runtime"`
+	ruleHTTPMetricsLabelCtxSource01       = "HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01"
+	ruleHTTPMetricsLabelNoAssemblyDerive  = "HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01"
+	ruleHTTPMetricsLabelNoConfigCellID    = "HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01"
+	ruleHTTPMetricsLabelRuntimeSentinel   = "HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01"
+	ruleHTTPMetricsLabelRouterAttribution = "HTTP-METRICS-LABEL-ROUTER-ATTRIBUTION-01"
 )
 
-// TestHTTPMetricsLabelCellIDCtxSource01 verifies metrics.go uses the chi-style
-// mutable cellIDState pattern: a call to withCellIDState(...) seeds the per-
-// request struct, and the recorder reads the resolved cellID from that
-// struct's field. Plain ctxkeys reads on the listener-root layer would miss
-// values written by sub-mux WithCellIDContext middleware (chi child contexts
-// are detached from the parent), so this rule pins the correct mechanism.
 func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 	root := findModuleRoot(t)
 	target := filepath.Join(root, "runtime", "http", "middleware", "metrics.go")
-	rel, _ := filepath.Rel(root, target)
-	rel = filepath.ToSlash(rel)
+	rel := slashRel(t, root, target)
 
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
 	require.NoErrorf(t, err, "%s: parse failed", rel)
 
-	var (
-		callsWithCellIDState bool
-		readsCellIDStateFld  bool
-	)
+	oldStateHelper := "with" + "Cell" + "IDState"
+	var readsCtxCellID, usesRuntimeSentinel, callsOldState bool
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.CallExpr:
-			if id, ok := v.Fun.(*ast.Ident); ok && id.Name == "withCellIDState" {
-				callsWithCellIDState = true
+			if id, ok := v.Fun.(*ast.Ident); ok && id.Name == oldStateHelper {
+				callsOldState = true
 			}
-		case *ast.SelectorExpr:
-			// Detect any access of `something.cellID` — typically `cs.cellID`
-			// inside the safeObserve closure that hands the resolved label
-			// to collector.RecordRequest.
-			if v.Sel.Name == "cellID" {
-				readsCellIDStateFld = true
+			if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "CellIDFrom" {
+				readsCtxCellID = true
+			}
+		case *ast.Ident:
+			if v.Name == "RuntimeCellIDSentinel" {
+				usesRuntimeSentinel = true
 			}
 		}
 		return true
 	})
 
-	assert.Truef(t, callsWithCellIDState,
-		"%s: %s — middleware.Metrics must call withCellIDState(...) to seed the "+
-			"per-request mutable cell-id container; only this layer can be observed by "+
-			"sub-mux WithCellIDContext mutations after next.ServeHTTP returns",
+	assert.Truef(t, readsCtxCellID,
+		"%s: %s — middleware.Metrics must read cell labels from kernel/ctxkeys.CellIDFrom",
 		rel, ruleHTTPMetricsLabelCtxSource01)
-	assert.Truef(t, readsCellIDStateFld,
-		"%s: %s — middleware.Metrics must read the resolved label via cs.cellID; "+
-			"reading ctxkeys.CellIDFrom on the listener-root layer would miss the per-cell "+
-			"override written into a chi sub-mux child context",
+	assert.Truef(t, usesRuntimeSentinel,
+		"%s: %s — middleware.Metrics must default missing cell context to RuntimeCellIDSentinel",
+		rel, ruleHTTPMetricsLabelRuntimeSentinel)
+	assert.Falsef(t, callsOldState,
+		"%s: %s — old mutable cell helper is deleted; cell attribution must happen at router root",
 		rel, ruleHTTPMetricsLabelCtxSource01)
 }
 
-// TestHTTPMetricsLabelNoAssemblyDerive01 ensures phases_http.go does not
-// derive a metrics cellID from assembly identity. Specifically, no token
-// inside this file may reference `assemblyID`, `assemblyCore.ID`, or the
-// literal "default" *as the cellID source*. We assert structurally on the
-// prior derivation idiom (b.assemblyID / b.assemblyCore.ID() / "default")
-// being absent from the autoWireHTTPMetricsCollector function body.
+func TestHTTPMetricsLabelRouterAttribution01(t *testing.T) {
+	root := findModuleRoot(t)
+	target := filepath.Join(root, "runtime", "http", "router", "router.go")
+	rel := slashRel(t, root, target)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "%s: parse failed", rel)
+
+	var hasCellAttribution, hasMountRouteGroup bool
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.CallExpr:
+			if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "CellAttribution" {
+				hasCellAttribution = true
+			}
+		case *ast.FuncDecl:
+			if v.Recv != nil && v.Name.Name == "MountRouteGroup" {
+				hasMountRouteGroup = true
+			}
+		}
+		return true
+	})
+
+	assert.Truef(t, hasCellAttribution,
+		"%s: %s — router root must install middleware.CellAttribution before protection middleware",
+		rel, ruleHTTPMetricsLabelRouterAttribution)
+	assert.Truef(t, hasMountRouteGroup,
+		"%s: %s — RouteGroup mounting must be owned by runtime/http/router, not bootstrap helpers",
+		rel, ruleHTTPMetricsLabelRouterAttribution)
+}
+
 func TestHTTPMetricsLabelNoAssemblyDerive01(t *testing.T) {
 	root := findModuleRoot(t)
 	target := filepath.Join(root, "runtime", "bootstrap", "phases_http.go")
-	rel, _ := filepath.Rel(root, target)
-	rel = filepath.ToSlash(rel)
+	rel := slashRel(t, root, target)
 
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
@@ -121,22 +107,14 @@ func TestHTTPMetricsLabelNoAssemblyDerive01(t *testing.T) {
 	var fn *ast.FuncDecl
 	for _, decl := range file.Decls {
 		f, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		if f.Name.Name == "autoWireHTTPMetricsCollector" {
+		if ok && f.Name.Name == "autoWireHTTPMetricsCollector" {
 			fn = f
 			break
 		}
 	}
 	require.NotNilf(t, fn, "%s: autoWireHTTPMetricsCollector func not found", rel)
 
-	var (
-		referencesAssemblyID      bool
-		referencesAssemblyCoreID  bool
-		referencesDefaultLiteral  bool
-		referencesProviderCellKey bool
-	)
+	var referencesAssemblyID, referencesAssemblyCoreID, referencesDefaultLiteral, referencesProviderCellKey bool
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.SelectorExpr:
@@ -161,33 +139,23 @@ func TestHTTPMetricsLabelNoAssemblyDerive01(t *testing.T) {
 	})
 
 	assert.Falsef(t, referencesAssemblyID,
-		"%s: %s — autoWireHTTPMetricsCollector must not reference b.assemblyID; "+
-			"cell label originates from request ctx, not assembly identity",
+		"%s: %s — autoWireHTTPMetricsCollector must not reference b.assemblyID as a cell label source",
 		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
 	assert.Falsef(t, referencesAssemblyCoreID,
-		"%s: %s — autoWireHTTPMetricsCollector must not call b.assemblyCore.ID() "+
-			"as a cellID source",
+		"%s: %s — autoWireHTTPMetricsCollector must not call b.assemblyCore.ID() as a cell label source",
 		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
 	assert.Falsef(t, referencesDefaultLiteral,
-		`%s: %s — autoWireHTTPMetricsCollector must not use literal "default" as a `+
-			"fallback cellID; framework-owned routes use the _runtime sentinel "+
-			"installed by router.go",
+		`%s: %s — autoWireHTTPMetricsCollector must not use literal "default" as a fallback cell label`,
 		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
 	assert.Falsef(t, referencesProviderCellKey,
-		"%s: %s — ProviderCollectorConfig{CellID: ...} field assignment is forbidden; "+
-			"the field has been removed and cellID is now a per-call argument to RecordRequest",
+		"%s: %s — ProviderCollectorConfig{CellID: ...} is forbidden; cellID is per request",
 		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
 }
 
-// TestHTTPMetricsLabelNoConfigCellID01 verifies the ProviderCollectorConfig
-// struct does not declare a CellID field. Defending against revert is
-// important because pre-realign call sites pattern-matched on this exact
-// shape and a re-introduction would silently break per-cell labeling.
 func TestHTTPMetricsLabelNoConfigCellID01(t *testing.T) {
 	root := findModuleRoot(t)
 	target := filepath.Join(root, "runtime", "observability", "metrics", "provider_collector.go")
-	rel, _ := filepath.Rel(root, target)
-	rel = filepath.ToSlash(rel)
+	rel := slashRel(t, root, target)
 
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
@@ -219,63 +187,13 @@ func TestHTTPMetricsLabelNoConfigCellID01(t *testing.T) {
 		return true
 	})
 	assert.Falsef(t, hasCellIDField,
-		"%s: %s — ProviderCollectorConfig must not declare a CellID field; "+
-			"cellID is supplied per call to RecordRequest, not at constructor time",
+		"%s: %s — ProviderCollectorConfig must not declare CellID; cellID is supplied per RecordRequest",
 		rel, ruleHTTPMetricsLabelNoConfigCellID)
 }
 
-// TestHTTPMetricsLabelRuntimeSentinel01 verifies metrics.go contains the
-// "_runtime" string literal in a withCellIDState call — proving the recorder
-// seeds its mutable cell-id state with the framework sentinel rather than an
-// empty value or a per-listener guess. A regression that drops the sentinel
-// would leave framework-owned requests (healthz, readyz, /metrics, unmatched
-// 404s) emitting an empty cell label, breaking dashboards that match
-// `cell="_runtime"` for framework traffic.
-//
-// The walk is structurally pinned: the literal must appear as an argument
-// to a call to withCellIDState, not just somewhere in the file (e.g. a
-// comment, an unrelated helper, an unused constant).
-func TestHTTPMetricsLabelRuntimeSentinel01(t *testing.T) {
-	root := findModuleRoot(t)
-	target := filepath.Join(root, "runtime", "http", "middleware", "metrics.go")
-	rel, _ := filepath.Rel(root, target)
-	rel = filepath.ToSlash(rel)
-
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
-	require.NoErrorf(t, err, "%s: parse failed", rel)
-
-	seedsRuntimeSentinel := false
-	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		// Match `withCellIDState(<ctx>, RuntimeCellIDSentinel)` —
-		// either a bare identifier or a selector. Permitting either
-		// keeps the rule resilient to package-internal vs imported
-		// usage changes.
-		id, ok := call.Fun.(*ast.Ident)
-		if !ok || id.Name != "withCellIDState" {
-			return true
-		}
-		for _, arg := range call.Args {
-			switch v := arg.(type) {
-			case *ast.Ident:
-				if v.Name == "RuntimeCellIDSentinel" {
-					seedsRuntimeSentinel = true
-				}
-			case *ast.BasicLit:
-				if v.Kind == token.STRING && v.Value == httpMetricsRuntimeSentinelLiteral {
-					seedsRuntimeSentinel = true
-				}
-			}
-		}
-		return true
-	})
-
-	assert.Truef(t, seedsRuntimeSentinel,
-		`%s: %s — middleware.Metrics must seed withCellIDState with RuntimeCellIDSentinel `+
-			`(or the literal "_runtime"); without it, framework-owned routes emit an empty cell label`,
-		rel, ruleHTTPMetricsLabelRuntimeSentinel)
+func slashRel(t *testing.T, root, target string) string {
+	t.Helper()
+	rel, err := filepath.Rel(root, target)
+	require.NoError(t, err)
+	return filepath.ToSlash(rel)
 }

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -4,33 +4,31 @@ package archtest
 // HTTP-METRICS-LABEL-REALIGN contract (D1, 2026-05-04):
 //
 //   - HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01:
-//     runtime/http/middleware/metrics.go must read the cell label from ctx via
-//     ctxkeys.MustCellIDFrom — proving there is no fallback branch and no
-//     instance-level cellID. A revert that pulls cellID from a struct field or
-//     adds an `if cellID == "" { cellID = "_runtime" }` fallback would silently
-//     erode the per-request label guarantee; this rule blocks it.
+//     runtime/http/middleware/metrics.go must read the cell label from the
+//     in-flight cellIDState via withCellIDState/cs.cellID — chi-style mutable
+//     pointer pattern that lets sub-mux WithCellIDContext middleware override
+//     the sentinel set at the listener root. A revert that pulls cellID from
+//     a struct field, adds a string-valued ctxkeys read on the wrong layer,
+//     or branches on a fallback would silently erode the per-request label
+//     guarantee; this rule blocks it.
 //
 //   - HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01:
 //     runtime/bootstrap/phases_http.go must not derive any metrics cellID from
 //     b.assemblyID, b.assemblyCore.ID(), or the literal "default". Pre-realign
 //     code did exactly this and broke multi-cell assembly attribution; the new
-//     contract is "cellID flows from RouteGroup.CellID via ctx, never from
-//     assembly identity".
+//     contract is "cellID flows from RouteGroup.CellID via mutable state,
+//     never from assembly identity".
 //
 //   - HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01:
 //     runtime/observability/metrics.ProviderCollectorConfig must not contain a
 //     CellID field. Holding cellID on the collector instance rather than per
 //     RecordRequest call is the architectural pattern this PR removes.
 //
-//   - HTTP-METRICS-LABEL-LISTENER-ROOT-RUNTIME-01:
-//     runtime/http/router/router.go must install
-//     middleware.WithCellIDContext("_runtime") before middleware.Metrics on the
-//     listener root mux. This is the *single* listener-root sentinel injection
-//     point — bootstrap and other layers no longer inject any fallback. If
-//     this call is removed or moved (e.g. someone tries to install the
-//     sentinel inside bootstrap or inside Metrics itself), unmatched and
-//     framework-owned requests would emit an empty cell label, breaking
-//     dashboards.
+//   - HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01:
+//     runtime/http/middleware/metrics.go must seed the cellIDState with
+//     RuntimeCellIDSentinel ("_runtime"), so framework-owned requests
+//     (healthz / readyz / metrics endpoint / unmatched 404s) emit the
+//     framework label rather than an empty value or a per-listener guess.
 //
 // All four rules use go/ast so reorderings, alias renames, and indirect
 // imports are detected even without changing the surface API.
@@ -40,7 +38,6 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,14 +48,17 @@ const (
 	ruleHTTPMetricsLabelCtxSource01      = "HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01"
 	ruleHTTPMetricsLabelNoAssemblyDerive = "HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01"
 	ruleHTTPMetricsLabelNoConfigCellID   = "HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01"
-	ruleHTTPMetricsLabelListenerRoot     = "HTTP-METRICS-LABEL-LISTENER-ROOT-RUNTIME-01"
+	ruleHTTPMetricsLabelRuntimeSentinel  = "HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01"
 
 	httpMetricsRuntimeSentinelLiteral = `"_runtime"`
 )
 
-// TestHTTPMetricsLabelCellIDCtxSource01 verifies metrics.go calls
-// ctxkeys.MustCellIDFrom(r.Context()) — i.e. cell label originates from ctx,
-// not from a struct field, fallback default, or local computation.
+// TestHTTPMetricsLabelCellIDCtxSource01 verifies metrics.go uses the chi-style
+// mutable cellIDState pattern: a call to withCellIDState(...) seeds the per-
+// request struct, and the recorder reads the resolved cellID from that
+// struct's field. Plain ctxkeys reads on the listener-root layer would miss
+// values written by sub-mux WithCellIDContext middleware (chi child contexts
+// are detached from the parent), so this rule pins the correct mechanism.
 func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 	root := findModuleRoot(t)
 	target := filepath.Join(root, "runtime", "http", "middleware", "metrics.go")
@@ -69,37 +69,36 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
 	require.NoErrorf(t, err, "%s: parse failed", rel)
 
-	importsCtxkeys := false
-	for _, imp := range file.Imports {
-		if strings.Trim(imp.Path.Value, `"`) == "github.com/ghbvf/gocell/kernel/ctxkeys" {
-			importsCtxkeys = true
-			break
-		}
-	}
-	assert.Truef(t, importsCtxkeys,
-		"%s: %s — file must import kernel/ctxkeys to read the cell label from request context",
-		rel, ruleHTTPMetricsLabelCtxSource01)
-
-	callsMustCellIDFrom := false
+	var (
+		callsWithCellIDState bool
+		readsCellIDStateFld  bool
+	)
 	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
+		switch v := n.(type) {
+		case *ast.CallExpr:
+			if id, ok := v.Fun.(*ast.Ident); ok && id.Name == "withCellIDState" {
+				callsWithCellIDState = true
+			}
+		case *ast.SelectorExpr:
+			// Detect any access of `something.cellID` — typically `cs.cellID`
+			// inside the safeObserve closure that hands the resolved label
+			// to collector.RecordRequest.
+			if v.Sel.Name == "cellID" {
+				readsCellIDStateFld = true
+			}
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		if sel.Sel.Name != "MustCellIDFrom" {
-			return true
-		}
-		callsMustCellIDFrom = true
-		return false
+		return true
 	})
-	assert.Truef(t, callsMustCellIDFrom,
-		"%s: %s — middleware.Metrics must call ctxkeys.MustCellIDFrom(...) "+
-			"to obtain the cell label; a fallback branch or instance-level cellID "+
-			"silently undermines the per-request labeling contract",
+
+	assert.Truef(t, callsWithCellIDState,
+		"%s: %s — middleware.Metrics must call withCellIDState(...) to seed the "+
+			"per-request mutable cell-id container; only this layer can be observed by "+
+			"sub-mux WithCellIDContext mutations after next.ServeHTTP returns",
+		rel, ruleHTTPMetricsLabelCtxSource01)
+	assert.Truef(t, readsCellIDStateFld,
+		"%s: %s — middleware.Metrics must read the resolved label via cs.cellID; "+
+			"reading ctxkeys.CellIDFrom on the listener-root layer would miss the per-cell "+
+			"override written into a chi sub-mux child context",
 		rel, ruleHTTPMetricsLabelCtxSource01)
 }
 
@@ -225,13 +224,20 @@ func TestHTTPMetricsLabelNoConfigCellID01(t *testing.T) {
 		rel, ruleHTTPMetricsLabelNoConfigCellID)
 }
 
-// TestHTTPMetricsLabelListenerRootRuntime01 verifies router.go installs
-// middleware.WithCellIDContext("_runtime") immediately before
-// middleware.Metrics on the listener root mux. The order matters: cell-id
-// must populate ctx before Metrics tries to read it.
-func TestHTTPMetricsLabelListenerRootRuntime01(t *testing.T) {
+// TestHTTPMetricsLabelRuntimeSentinel01 verifies metrics.go contains the
+// "_runtime" string literal in a withCellIDState call — proving the recorder
+// seeds its mutable cell-id state with the framework sentinel rather than an
+// empty value or a per-listener guess. A regression that drops the sentinel
+// would leave framework-owned requests (healthz, readyz, /metrics, unmatched
+// 404s) emitting an empty cell label, breaking dashboards that match
+// `cell="_runtime"` for framework traffic.
+//
+// The walk is structurally pinned: the literal must appear as an argument
+// to a call to withCellIDState, not just somewhere in the file (e.g. a
+// comment, an unrelated helper, an unused constant).
+func TestHTTPMetricsLabelRuntimeSentinel01(t *testing.T) {
 	root := findModuleRoot(t)
-	target := filepath.Join(root, "runtime", "http", "router", "router.go")
+	target := filepath.Join(root, "runtime", "http", "middleware", "metrics.go")
 	rel, _ := filepath.Rel(root, target)
 	rel = filepath.ToSlash(rel)
 
@@ -239,62 +245,37 @@ func TestHTTPMetricsLabelListenerRootRuntime01(t *testing.T) {
 	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
 	require.NoErrorf(t, err, "%s: parse failed", rel)
 
-	// Walk the AST collecting every middleware.WithCellIDContext("_runtime")
-	// and middleware.Metrics(...) call. Then assert (a) the WithCellIDContext
-	// call exists with literal "_runtime", and (b) it precedes the Metrics
-	// call within the same statement list.
-	type callRef struct {
-		name string
-		pos  token.Pos
-		arg0 string
-	}
-	var calls []callRef
-
+	seedsRuntimeSentinel := false
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
+		// Match `withCellIDState(<ctx>, RuntimeCellIDSentinel)` —
+		// either a bare identifier or a selector. Permitting either
+		// keeps the rule resilient to package-internal vs imported
+		// usage changes.
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || id.Name != "withCellIDState" {
 			return true
 		}
-		switch sel.Sel.Name {
-		case "WithCellIDContext", "Metrics":
-			ref := callRef{name: sel.Sel.Name, pos: call.Pos()}
-			if len(call.Args) > 0 {
-				if lit, ok := call.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
-					ref.arg0 = lit.Value
+		for _, arg := range call.Args {
+			switch v := arg.(type) {
+			case *ast.Ident:
+				if v.Name == "RuntimeCellIDSentinel" {
+					seedsRuntimeSentinel = true
+				}
+			case *ast.BasicLit:
+				if v.Kind == token.STRING && v.Value == httpMetricsRuntimeSentinelLiteral {
+					seedsRuntimeSentinel = true
 				}
 			}
-			calls = append(calls, ref)
 		}
 		return true
 	})
 
-	var sentinelPos, metricsPos token.Pos
-	for _, c := range calls {
-		if c.name == "WithCellIDContext" && c.arg0 == httpMetricsRuntimeSentinelLiteral {
-			if sentinelPos == token.NoPos || c.pos < sentinelPos {
-				sentinelPos = c.pos
-			}
-		}
-		if c.name == "Metrics" {
-			if metricsPos == token.NoPos || c.pos < metricsPos {
-				metricsPos = c.pos
-			}
-		}
-	}
-
-	require.NotEqualf(t, token.NoPos, sentinelPos,
-		`%s: %s — router.go must call middleware.WithCellIDContext("_runtime") on the listener root mux`,
-		rel, ruleHTTPMetricsLabelListenerRoot)
-	require.NotEqualf(t, token.NoPos, metricsPos,
-		"%s: %s — router.go must call middleware.Metrics on the listener root mux",
-		rel, ruleHTTPMetricsLabelListenerRoot)
-
-	assert.Lessf(t, int(sentinelPos), int(metricsPos),
-		`%s: %s — middleware.WithCellIDContext("_runtime") must appear before middleware.Metrics `+
-			"so the sentinel populates request ctx before the recorder reads it",
-		rel, ruleHTTPMetricsLabelListenerRoot)
+	assert.Truef(t, seedsRuntimeSentinel,
+		`%s: %s — middleware.Metrics must seed withCellIDState with RuntimeCellIDSentinel `+
+			`(or the literal "_runtime"); without it, framework-owned routes emit an empty cell label`,
+		rel, ruleHTTPMetricsLabelRuntimeSentinel)
 }

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -33,20 +33,52 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
 	require.NoErrorf(t, err, "%s: parse failed", rel)
 
+	fn := findHTTPMetricsFuncDecl(t, file, "metricsWithClock")
+	metricsPath := narrowestFuncLitWithCollectorRecordRequest(fn.Body)
+	require.NotNilf(t, metricsPath,
+		"%s: %s — metricsWithClock must record HTTP metrics through collector.RecordRequest",
+		rel, ruleHTTPMetricsLabelCtxSource01)
+
 	oldStateHelper := "with" + "Cell" + "IDState"
-	var readsCtxCellID, usesRuntimeSentinel, callsOldState bool
-	ast.Inspect(file, func(n ast.Node) bool {
+	var callsOldState bool
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == oldStateHelper {
+			callsOldState = true
+		}
+		return true
+	})
+
+	var (
+		readsCtxCellID      bool
+		usesRuntimeSentinel bool
+		recordUsesCellIDArg bool
+		ctxCellIDPos        token.Pos
+		runtimeSentinelPos  token.Pos
+		recordRequestPos    token.Pos
+	)
+	ast.Inspect(metricsPath.Body, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.CallExpr:
-			if id, ok := v.Fun.(*ast.Ident); ok && id.Name == oldStateHelper {
-				callsOldState = true
-			}
-			if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "CellIDFrom" {
+			if isSelectorCall(v, "ctxkeys", "CellIDFrom") {
 				readsCtxCellID = true
+				rememberFirstPos(&ctxCellIDPos, v.Pos())
+			}
+			if isSelectorCall(v, "collector", "RecordRequest") {
+				recordRequestPos = v.Pos()
+				if len(v.Args) > 0 {
+					if id, ok := v.Args[0].(*ast.Ident); ok && id.Name == "cellID" {
+						recordUsesCellIDArg = true
+					}
+				}
 			}
 		case *ast.Ident:
 			if v.Name == "RuntimeCellIDSentinel" {
 				usesRuntimeSentinel = true
+				rememberFirstPos(&runtimeSentinelPos, v.Pos())
 			}
 		}
 		return true
@@ -56,7 +88,16 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 		"%s: %s — middleware.Metrics must read cell labels from kernel/ctxkeys.CellIDFrom",
 		rel, ruleHTTPMetricsLabelCtxSource01)
 	assert.Truef(t, usesRuntimeSentinel,
-		"%s: %s — middleware.Metrics must default missing cell context to RuntimeCellIDSentinel",
+		"%s: %s — middleware.Metrics must default missing cell context to RuntimeCellIDSentinel in the RecordRequest path",
+		rel, ruleHTTPMetricsLabelRuntimeSentinel)
+	assert.Truef(t, recordUsesCellIDArg,
+		"%s: %s — collector.RecordRequest must receive the ctx-derived cellID variable, not a constructor/config value",
+		rel, ruleHTTPMetricsLabelCtxSource01)
+	assert.Truef(t, ctxCellIDPos.IsValid() && recordRequestPos.IsValid() && ctxCellIDPos < recordRequestPos,
+		"%s: %s — ctxkeys.CellIDFrom must feed the metrics path before collector.RecordRequest",
+		rel, ruleHTTPMetricsLabelCtxSource01)
+	assert.Truef(t, runtimeSentinelPos.IsValid() && recordRequestPos.IsValid() && runtimeSentinelPos < recordRequestPos,
+		"%s: %s — RuntimeCellIDSentinel must be the fallback before collector.RecordRequest",
 		rel, ruleHTTPMetricsLabelRuntimeSentinel)
 	assert.Falsef(t, callsOldState,
 		"%s: %s — old mutable cell helper is deleted; cell attribution must happen at router root",
@@ -72,27 +113,66 @@ func TestHTTPMetricsLabelRouterAttribution01(t *testing.T) {
 	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
 	require.NoErrorf(t, err, "%s: parse failed", rel)
 
-	var hasCellAttribution, hasMountRouteGroup bool
-	ast.Inspect(file, func(n ast.Node) bool {
-		switch v := n.(type) {
-		case *ast.CallExpr:
-			if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "CellAttribution" {
-				hasCellAttribution = true
-			}
-		case *ast.FuncDecl:
-			if v.Recv != nil && v.Name.Name == "MountRouteGroup" {
-				hasMountRouteGroup = true
-			}
+	buildMux := findHTTPMetricsFuncDecl(t, file, "buildMux")
+	mountRouteGroup := findHTTPMetricsFuncDecl(t, file, "MountRouteGroup")
+	require.NotNilf(t, mountRouteGroup,
+		"%s: %s — RouteGroup mounting must be owned by runtime/http/router, not bootstrap helpers",
+		rel, ruleHTTPMetricsLabelRouterAttribution)
+
+	var (
+		cellAttributionPos token.Pos
+		metricsPos         token.Pos
+		defaultMWPos       token.Pos
+		rateLimitPos       token.Pos
+		circuitBreakerPos  token.Pos
+		authPos            token.Pos
+		bodyLimitPos       token.Pos
+	)
+	ast.Inspect(buildMux.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch {
+		case isSelectorCall(call, "middleware", "CellAttribution"):
+			rememberFirstPos(&cellAttributionPos, call.Pos())
+		case isSelectorCall(call, "middleware", "Metrics"):
+			rememberFirstPos(&metricsPos, call.Pos())
+		case isSelectorCall(call, "middleware", "RateLimit"):
+			rememberFirstPos(&rateLimitPos, call.Pos())
+		case isSelectorCall(call, "middleware", "CircuitBreaker"):
+			rememberFirstPos(&circuitBreakerPos, call.Pos())
+		case isSelectorCall(call, "auth", "AuthMiddleware"):
+			rememberFirstPos(&authPos, call.Pos())
+		case isSelectorCall(call, "middleware", "BodyLimit"):
+			rememberFirstPos(&bodyLimitPos, call.Pos())
+		case isMuxUseWithDefaultMiddleware(call):
+			rememberFirstPos(&defaultMWPos, call.Pos())
 		}
 		return true
 	})
 
-	assert.Truef(t, hasCellAttribution,
-		"%s: %s — router root must install middleware.CellAttribution before protection middleware",
+	require.Truef(t, cellAttributionPos.IsValid(),
+		"%s: %s — buildMux must install middleware.CellAttribution at router root",
 		rel, ruleHTTPMetricsLabelRouterAttribution)
-	assert.Truef(t, hasMountRouteGroup,
-		"%s: %s — RouteGroup mounting must be owned by runtime/http/router, not bootstrap helpers",
-		rel, ruleHTTPMetricsLabelRouterAttribution)
+	for _, check := range []struct {
+		name string
+		pos  token.Pos
+	}{
+		{name: "middleware.Metrics", pos: metricsPos},
+		{name: "r.defaultMiddleware", pos: defaultMWPos},
+		{name: "middleware.RateLimit", pos: rateLimitPos},
+		{name: "middleware.CircuitBreaker", pos: circuitBreakerPos},
+		{name: "auth.AuthMiddleware", pos: authPos},
+		{name: "middleware.BodyLimit", pos: bodyLimitPos},
+	} {
+		assert.Truef(t, check.pos.IsValid(),
+			"%s: %s — buildMux must wire %s in the router chain",
+			rel, ruleHTTPMetricsLabelRouterAttribution, check.name)
+		assert.Truef(t, check.pos.IsValid() && cellAttributionPos < check.pos,
+			"%s: %s — middleware.CellAttribution must be installed before %s so short-circuits keep the owning cell label",
+			rel, ruleHTTPMetricsLabelRouterAttribution, check.name)
+	}
 }
 
 func TestHTTPMetricsLabelNoAssemblyDerive01(t *testing.T) {
@@ -196,4 +276,91 @@ func slashRel(t *testing.T, root, target string) string {
 	rel, err := filepath.Rel(root, target)
 	require.NoError(t, err)
 	return filepath.ToSlash(rel)
+}
+
+func findHTTPMetricsFuncDecl(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	require.Failf(t, "function not found", "expected function %s", name)
+	return nil
+}
+
+func narrowestFuncLitWithCollectorRecordRequest(root ast.Node) *ast.FuncLit {
+	var best *ast.FuncLit
+	ast.Inspect(root, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncLit)
+		if !ok {
+			return true
+		}
+		if !containsCollectorRecordRequest(fn.Body) {
+			return true
+		}
+		if best == nil || fn.End()-fn.Pos() < best.End()-best.Pos() {
+			best = fn
+		}
+		return true
+	})
+	return best
+}
+
+func containsCollectorRecordRequest(root ast.Node) bool {
+	found := false
+	ast.Inspect(root, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if ok && isSelectorCall(call, "collector", "RecordRequest") {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isSelectorCall(call *ast.CallExpr, qualifier, method string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return selectorQualifier(sel.X) == qualifier && sel.Sel.Name == method
+}
+
+func selectorQualifier(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		left := selectorQualifier(v.X)
+		if left == "" {
+			return v.Sel.Name
+		}
+		return left + "." + v.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func isMuxUseWithDefaultMiddleware(call *ast.CallExpr) bool {
+	if !isSelectorCall(call, "r.mux", "Use") {
+		return false
+	}
+	for _, arg := range call.Args {
+		if selectorQualifier(arg) == "r.defaultMiddleware" {
+			return true
+		}
+	}
+	return false
+}
+
+func rememberFirstPos(dst *token.Pos, pos token.Pos) {
+	if !dst.IsValid() || pos < *dst {
+		*dst = pos
+	}
 }

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -1,0 +1,300 @@
+package archtest
+
+// http_metrics_label_test.go enforces the four invariants of the
+// HTTP-METRICS-LABEL-REALIGN contract (D1, 2026-05-04):
+//
+//   - HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01:
+//     runtime/http/middleware/metrics.go must read the cell label from ctx via
+//     ctxkeys.MustCellIDFrom — proving there is no fallback branch and no
+//     instance-level cellID. A revert that pulls cellID from a struct field or
+//     adds an `if cellID == "" { cellID = "_runtime" }` fallback would silently
+//     erode the per-request label guarantee; this rule blocks it.
+//
+//   - HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01:
+//     runtime/bootstrap/phases_http.go must not derive any metrics cellID from
+//     b.assemblyID, b.assemblyCore.ID(), or the literal "default". Pre-realign
+//     code did exactly this and broke multi-cell assembly attribution; the new
+//     contract is "cellID flows from RouteGroup.CellID via ctx, never from
+//     assembly identity".
+//
+//   - HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01:
+//     runtime/observability/metrics.ProviderCollectorConfig must not contain a
+//     CellID field. Holding cellID on the collector instance rather than per
+//     RecordRequest call is the architectural pattern this PR removes.
+//
+//   - HTTP-METRICS-LABEL-LISTENER-ROOT-RUNTIME-01:
+//     runtime/http/router/router.go must install
+//     middleware.WithCellIDContext("_runtime") before middleware.Metrics on the
+//     listener root mux. This is the *single* listener-root sentinel injection
+//     point — bootstrap and other layers no longer inject any fallback. If
+//     this call is removed or moved (e.g. someone tries to install the
+//     sentinel inside bootstrap or inside Metrics itself), unmatched and
+//     framework-owned requests would emit an empty cell label, breaking
+//     dashboards.
+//
+// All four rules use go/ast so reorderings, alias renames, and indirect
+// imports are detected even without changing the surface API.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ruleHTTPMetricsLabelCtxSource01      = "HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01"
+	ruleHTTPMetricsLabelNoAssemblyDerive = "HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01"
+	ruleHTTPMetricsLabelNoConfigCellID   = "HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01"
+	ruleHTTPMetricsLabelListenerRoot     = "HTTP-METRICS-LABEL-LISTENER-ROOT-RUNTIME-01"
+
+	httpMetricsRuntimeSentinelLiteral = `"_runtime"`
+)
+
+// TestHTTPMetricsLabelCellIDCtxSource01 verifies metrics.go calls
+// ctxkeys.MustCellIDFrom(r.Context()) — i.e. cell label originates from ctx,
+// not from a struct field, fallback default, or local computation.
+func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
+	root := findModuleRoot(t)
+	target := filepath.Join(root, "runtime", "http", "middleware", "metrics.go")
+	rel, _ := filepath.Rel(root, target)
+	rel = filepath.ToSlash(rel)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "%s: parse failed", rel)
+
+	importsCtxkeys := false
+	for _, imp := range file.Imports {
+		if strings.Trim(imp.Path.Value, `"`) == "github.com/ghbvf/gocell/kernel/ctxkeys" {
+			importsCtxkeys = true
+			break
+		}
+	}
+	assert.Truef(t, importsCtxkeys,
+		"%s: %s — file must import kernel/ctxkeys to read the cell label from request context",
+		rel, ruleHTTPMetricsLabelCtxSource01)
+
+	callsMustCellIDFrom := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name != "MustCellIDFrom" {
+			return true
+		}
+		callsMustCellIDFrom = true
+		return false
+	})
+	assert.Truef(t, callsMustCellIDFrom,
+		"%s: %s — middleware.Metrics must call ctxkeys.MustCellIDFrom(...) "+
+			"to obtain the cell label; a fallback branch or instance-level cellID "+
+			"silently undermines the per-request labeling contract",
+		rel, ruleHTTPMetricsLabelCtxSource01)
+}
+
+// TestHTTPMetricsLabelNoAssemblyDerive01 ensures phases_http.go does not
+// derive a metrics cellID from assembly identity. Specifically, no token
+// inside this file may reference `assemblyID`, `assemblyCore.ID`, or the
+// literal "default" *as the cellID source*. We assert structurally on the
+// prior derivation idiom (b.assemblyID / b.assemblyCore.ID() / "default")
+// being absent from the autoWireHTTPMetricsCollector function body.
+func TestHTTPMetricsLabelNoAssemblyDerive01(t *testing.T) {
+	root := findModuleRoot(t)
+	target := filepath.Join(root, "runtime", "bootstrap", "phases_http.go")
+	rel, _ := filepath.Rel(root, target)
+	rel = filepath.ToSlash(rel)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "%s: parse failed", rel)
+
+	var fn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		f, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if f.Name.Name == "autoWireHTTPMetricsCollector" {
+			fn = f
+			break
+		}
+	}
+	require.NotNilf(t, fn, "%s: autoWireHTTPMetricsCollector func not found", rel)
+
+	var (
+		referencesAssemblyID      bool
+		referencesAssemblyCoreID  bool
+		referencesDefaultLiteral  bool
+		referencesProviderCellKey bool
+	)
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.SelectorExpr:
+			if id, ok := v.X.(*ast.Ident); ok && id.Name == "b" && v.Sel.Name == "assemblyID" {
+				referencesAssemblyID = true
+			}
+			if call, ok := v.X.(*ast.SelectorExpr); ok {
+				if id, ok := call.X.(*ast.Ident); ok && id.Name == "b" && call.Sel.Name == "assemblyCore" && v.Sel.Name == "ID" {
+					referencesAssemblyCoreID = true
+				}
+			}
+		case *ast.BasicLit:
+			if v.Kind == token.STRING && v.Value == `"default"` {
+				referencesDefaultLiteral = true
+			}
+		case *ast.KeyValueExpr:
+			if id, ok := v.Key.(*ast.Ident); ok && id.Name == "CellID" {
+				referencesProviderCellKey = true
+			}
+		}
+		return true
+	})
+
+	assert.Falsef(t, referencesAssemblyID,
+		"%s: %s — autoWireHTTPMetricsCollector must not reference b.assemblyID; "+
+			"cell label originates from request ctx, not assembly identity",
+		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
+	assert.Falsef(t, referencesAssemblyCoreID,
+		"%s: %s — autoWireHTTPMetricsCollector must not call b.assemblyCore.ID() "+
+			"as a cellID source",
+		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
+	assert.Falsef(t, referencesDefaultLiteral,
+		`%s: %s — autoWireHTTPMetricsCollector must not use literal "default" as a `+
+			"fallback cellID; framework-owned routes use the _runtime sentinel "+
+			"installed by router.go",
+		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
+	assert.Falsef(t, referencesProviderCellKey,
+		"%s: %s — ProviderCollectorConfig{CellID: ...} field assignment is forbidden; "+
+			"the field has been removed and cellID is now a per-call argument to RecordRequest",
+		rel, ruleHTTPMetricsLabelNoAssemblyDerive)
+}
+
+// TestHTTPMetricsLabelNoConfigCellID01 verifies the ProviderCollectorConfig
+// struct does not declare a CellID field. Defending against revert is
+// important because pre-realign call sites pattern-matched on this exact
+// shape and a re-introduction would silently break per-cell labeling.
+func TestHTTPMetricsLabelNoConfigCellID01(t *testing.T) {
+	root := findModuleRoot(t)
+	target := filepath.Join(root, "runtime", "observability", "metrics", "provider_collector.go")
+	rel, _ := filepath.Rel(root, target)
+	rel = filepath.ToSlash(rel)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "%s: parse failed", rel)
+
+	hasCellIDField := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		decl, ok := n.(*ast.GenDecl)
+		if !ok || decl.Tok != token.TYPE {
+			return true
+		}
+		for _, spec := range decl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != "ProviderCollectorConfig" {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			for _, f := range st.Fields.List {
+				for _, name := range f.Names {
+					if name.Name == "CellID" {
+						hasCellIDField = true
+					}
+				}
+			}
+		}
+		return true
+	})
+	assert.Falsef(t, hasCellIDField,
+		"%s: %s — ProviderCollectorConfig must not declare a CellID field; "+
+			"cellID is supplied per call to RecordRequest, not at constructor time",
+		rel, ruleHTTPMetricsLabelNoConfigCellID)
+}
+
+// TestHTTPMetricsLabelListenerRootRuntime01 verifies router.go installs
+// middleware.WithCellIDContext("_runtime") immediately before
+// middleware.Metrics on the listener root mux. The order matters: cell-id
+// must populate ctx before Metrics tries to read it.
+func TestHTTPMetricsLabelListenerRootRuntime01(t *testing.T) {
+	root := findModuleRoot(t)
+	target := filepath.Join(root, "runtime", "http", "router", "router.go")
+	rel, _ := filepath.Rel(root, target)
+	rel = filepath.ToSlash(rel)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "%s: parse failed", rel)
+
+	// Walk the AST collecting every middleware.WithCellIDContext("_runtime")
+	// and middleware.Metrics(...) call. Then assert (a) the WithCellIDContext
+	// call exists with literal "_runtime", and (b) it precedes the Metrics
+	// call within the same statement list.
+	type callRef struct {
+		name string
+		pos  token.Pos
+		arg0 string
+	}
+	var calls []callRef
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "WithCellIDContext", "Metrics":
+			ref := callRef{name: sel.Sel.Name, pos: call.Pos()}
+			if len(call.Args) > 0 {
+				if lit, ok := call.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					ref.arg0 = lit.Value
+				}
+			}
+			calls = append(calls, ref)
+		}
+		return true
+	})
+
+	var sentinelPos, metricsPos token.Pos
+	for _, c := range calls {
+		if c.name == "WithCellIDContext" && c.arg0 == httpMetricsRuntimeSentinelLiteral {
+			if sentinelPos == token.NoPos || c.pos < sentinelPos {
+				sentinelPos = c.pos
+			}
+		}
+		if c.name == "Metrics" {
+			if metricsPos == token.NoPos || c.pos < metricsPos {
+				metricsPos = c.pos
+			}
+		}
+	}
+
+	require.NotEqualf(t, token.NoPos, sentinelPos,
+		`%s: %s — router.go must call middleware.WithCellIDContext("_runtime") on the listener root mux`,
+		rel, ruleHTTPMetricsLabelListenerRoot)
+	require.NotEqualf(t, token.NoPos, metricsPos,
+		"%s: %s — router.go must call middleware.Metrics on the listener root mux",
+		rel, ruleHTTPMetricsLabelListenerRoot)
+
+	assert.Lessf(t, int(sentinelPos), int(metricsPos),
+		`%s: %s — middleware.WithCellIDContext("_runtime") must appear before middleware.Metrics `+
+			"so the sentinel populates request ctx before the recorder reads it",
+		rel, ruleHTTPMetricsLabelListenerRoot)
+}


### PR DESCRIPTION
## Summary

- Replaces RouteGroup-handler side-effect attribution with router-owned root-chain HTTP cell attribution.
- Adds `Router.MountRouteGroup(rg cell.RouteGroup) error`; bootstrap now only collects RouteGroups and wraps mount errors.
- Router records segment-aware RouteGroup ownership and resolves longest matching business namespace before protection middleware can short-circuit.
- Empty `RouteGroup.Prefix` no longer claims the whole listener; ownership is derived from nested `Route`, `Handle`, `Mount`, and declared HTTP contracts.
- `Metrics` reads `kernel/ctxkeys.CellID` directly, defaults missing attribution to `_runtime`, and uses router route-pattern fallback for pre-handler rejects.
- Removes the old mutable `cellIDState` / `WithCellIDContext` path entirely.
- `InMemoryCollector` uses typed request keys instead of parsing string-concatenated keys.
- Access logs include `cell_id`, aligned with the same context attribution path.

## Final Review Fixes

- Cell attribution is path/namespace ownership, not method ownership. Method-aware route patterns remain only for the route label resolver and 405 fallback.
- Cross-cell duplicate ownership of the same cleaned owner path/template now fails during route registration instead of relying on registration order.
- Route ownership ranking now prefers static segments over parameter templates, then deeper/more specific routes, so generic templates cannot steal attribution from exact static routes.
- Corebundle integration verifies both `cell="accesscore"` for a real business request and `cell="_runtime"` for framework/unmatched traffic.
- Framework-owned `CellID == ""` RouteGroups are covered, including matched routes and 405 fallback under `_runtime`.
- Ops docs state there is no code-side backward-compat/double-write; Prometheus-side recording/drop examples are provided for migration.
- Archtests inspect `metricsWithClock` and `buildMux` function bodies and verify attribution ordering before metrics/protection middleware.
- Sonar maintainability findings are cleared: consecutive same-type parameters are grouped and the pre-existing `auditcore.Init` cognitive-complexity finding is reduced by extracting subscription registration.

## Behavioral Coverage

- Business-path rejects before handler execution are attributed to the owning cell: auth, rate-limit, circuit-breaker, body-limit, and RouteGroup 405.
- Framework routes and listener-outside unknown paths remain `cell="_runtime"`.
- Overlapping business prefixes use longest segment-aware prefix match; exact cross-cell owner ties fail fast.
- Raw routes/mounts inside a RouteGroup are covered by router ownership recording.

## Removed Legacy Surface

- `middleware.WithCellIDContext`
- `withCellIDState`
- `cellIDStateFrom`
- mutable `cellIDState`
- bootstrap-local `mountOneRouteGroup` cell middleware injection

## Open Source References

- ref: Kubernetes apiserver metrics has explicit early-termination recording for self-defense failures such as throttling/timeouts, so rejects are first-class metric events, not only handler completions.
- ref: Prometheus `promhttp` supports both curried stable labels and context-derived dynamic labels; this PR uses a bounded context-derived `cell` value resolved before downstream middleware.
- ref: chi and gorilla/mux separate path/resource matching from method matching; this PR follows that split by making cell attribution path ownership while keeping route labels method-aware.

## Test Plan

- [x] `rg -n "WithCellIDContext|cellIDState|mountOneRouteGroup|withCellIDState|cs\\.cellID" runtime tools .claude cmd adapters --glob '*.go' --glob '*.md'` returns no matches
- [x] `go test -count=1 ./runtime/http/router ./runtime/bootstrap ./runtime/observability/metrics ./tools/archtest`
- [x] `go test -count=1 ./runtime/http/middleware ./runtime/http/router ./cells/auditcore`
- [x] `go test -tags=integration -count=1 ./cmd/corebundle -run TestR2_MetricsCollector_RecordsHTTPRequests`
- [x] `go test -race -count=1 ./runtime/http/middleware ./runtime/http/router ./runtime/bootstrap ./runtime/observability/metrics ./cells/auditcore`
- [x] `go test -count=1 ./...`
- [x] `go build ./...`
- [x] `golangci-lint run ./...` (`0 issues`)
- [x] `golangci-lint run --new-from-rev=origin/develop ./...` (`0 issues`)
- [x] GitHub PR checks all pass

## Refs

- D1 PR-V1-METRICS-CELL-LABEL · HTTP-METRICS-LABEL-REALIGN
- PR #359 review follow-up: route-owned attribution for pre-handler business rejects