### PR TITLE
ci: .githooks/pre-push for verify-generated drift gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# pre-push: run hack/verify-generated.sh to catch SoT/generated drift before CI.
+#
+# Enable:    git config core.hooksPath .githooks
+# Disable:   git config --unset core.hooksPath
+# Bypass:    VERIFY_SKIP=generated git push
+#
+# Bypass envvar mirrors hack/make-rules/verify.sh — same convention as `make verify`.
+set -euo pipefail
+
+if [[ ",${VERIFY_SKIP:-}," == *",generated,"* ]]; then
+    echo "pre-push: VERIFY_SKIP=generated set, skipping" >&2
+    exit 0
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+exec bash hack/verify-generated.sh


### PR DESCRIPTION
## Summary

新增 `.githooks/pre-push`，本地拦 generated/SoT 漂移，避免到 CI 才暴露（~3 分钟反馈 → ~3 秒）。

最近 100 次 CI run 失败 12 次，根因之一是改了 cell.yaml/contract.yaml 但 push 前忘 `make generate`。把这一类下沉到 pre-push 后，CI noise 进一步收敛，作者拿到 fast feedback。

## Design

- **单文件，零依赖**：仅新增 `.githooks/pre-push`。无 Makefile target、无 ADR、无 README 改动。文件 header comment 自包含使用说明。
- **opt-in**：用户/团队自行 `git config core.hooksPath .githooks` 启用；不启用不影响（CI 仍守门）。
- **复用现有约定**：bypass envvar `VERIFY_SKIP=generated` 与 `hack/make-rules/verify.sh` 同名，单一绕过开关。
- **`exec`** `verify-generated.sh`：底层错误码 + stderr 直接成为 hook 输出，不重复包装。
- **pre-push 而非 pre-commit**：对齐 CI 失败窗口，不打断频繁 wip commit。

## Verified locally

- shellcheck 通过
- 干净树 → exit 0（~2.5s wall）
- 制造 artifact drift → exit 1，drift hint 原样冒泡（"run 'make generate' and commit the result"）
- `VERIFY_SKIP=generated git push` → 跳过并打印 "VERIFY_SKIP=generated set, skipping"
- `VERIFY_SKIP=ungenerated` / `othergated` → 不误触发跳过（token 边界 `,generated,` 隔离）
- dogfood：本 PR push 时 hook 自身被触发并通过

## Test plan

- [x] Hook 文件可执行位 + shellcheck 0 issue
- [x] verify-generated.sh 干净 / drift / bypass 三路径行为
- [x] CI 全绿（不动任何 workflow，应零影响）

## Refs

- 触发：PR #363 review 末尾讨论 — "为什么最近 CI 老是失败"分析得出 verify-generated 漂移是头部失败模式之一
- 不合并 backlog `PR332-VERIFY-GENERATED-REMEDIATION-DRIFT-01`：drift-aware hint 文案改造与 hook 安装机制正交，留给 PR332 单独做

🤖 Generated with [Claude Code](https://claude.com/claude-code)