### PR TITLE
refactor(security): A3 wrapper redactor fail-closed default + delete opt-out wiring

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -14,6 +14,21 @@
 - 禁止 Debug 级别 dump 完整请求/响应 body（生产中泄漏敏感信息）
 - 错误日志必须包含结构化关联字段（`execution_id`、`policy_id` 等），禁止裸 `slog.Error("failed")`
 
+## Span Error Redaction（fail-closed by default）
+
+`kernel/wrapper.WrapConsumer` 与 `runtime/http/middleware.Recovery` 把所有写入 `span.RecordError` 的 error 文本无条件经过 `pkg/redaction.RedactError`。**没有调用方 opt-out**（无 `WithConsumerErrorRedactor` / `WithErrorRedactor` / `bootstrap.WithErrorRedactor` 等 wiring）。dev/debug 需要原始 error 文本走 `slog` 结构化字段，trace span 仅用于运维关联。
+
+默认 mask `key=value` / `key: value` 形式中的下列敏感 key（value 段替换为 `<REDACTED>`，保留原 key 与大小写）：
+
+```
+password | passwd | pwd | secret | token | api[_-]?key | authorization | bearer
+private[_-]?key | signing[_-]?key | dsn | connection[_ ]?string
+```
+
+`runtime/outbox.SanitizeError`（last_error 列存储）也走同一份 regex（`pkg/redaction`），确保单源治理。
+
+ref: hashicorp/vault `audit log_raw=false` 默认；golang/go `net/url.URL.Redacted()` 硬编替换。ADR `docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md` §8。
+
 ## Readyz Probe 命名
 
 - Adapter readiness probe 使用 stable snake_case，并以后缀 `_ready` 表示依赖可用性，例如 `rabbitmq_ready`、`vault_transit_ready`。

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -25,6 +25,8 @@ password | passwd | pwd | secret | token | api[_-]?key | authorization | bearer
 private[_-]?key | signing[_-]?key | dsn | connection[_ ]?string
 ```
 
+Value boundary fail-closed：每个 pattern 一直消耗到下一个空白（authorization 到换行）。`,` 与 `;` **不**作 value 边界——secret 可能含这些字符（ODBC `Pwd=a;b;c`、base64url JWT），停在 `,`/`;` 会泄漏后续字节。代价：同一行 `password="abc",user="alice"` 中 `user="alice"` 一并被 mask；co-located 字段通常本身是 PII 或可从 `slog` 结构化字段副本恢复，over-mask 是 fail-closed 的接受代价。
+
 `runtime/outbox.SanitizeError`（last_error 列存储）也走同一份 regex（`pkg/redaction`），确保单源治理。
 
 ref: hashicorp/vault `audit log_raw=false` 默认；golang/go `net/url.URL.Redacted()` 硬编替换。ADR `docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md` §8。

--- a/docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md
+++ b/docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md
@@ -157,9 +157,10 @@ types that observe traffic:
   contract attributes to the span via `wrapper.AttrCarrier`.
 - `runtime/eventrouter.Router` stores contract identity on
   `outbox.Subscription`; it does not carry the live tracer. The
-  bootstrap-owned `ContractTracingMiddleware` receives the tracer and
-  error redactor explicitly, consumes that identity, and wraps the
-  subscription with `WrapConsumer` outside ConsumerBase.
+  bootstrap-owned `ContractTracingMiddleware` receives only the tracer
+  (error redaction is hardcoded inside `WrapConsumer` via `pkg/redaction` —
+  see §8), consumes the contract identity, and wraps the subscription with
+  `WrapConsumer` outside ConsumerBase.
 - `runtime/bootstrap` threads the `Bootstrap.wrapperTracer` (captured
   by `WithTracer`) into both `router.WithTracer` (phase7) and
   `ContractTracingMiddleware` (phase6). No process-wide `SetTracer` is
@@ -277,23 +278,59 @@ ref: open-telemetry/opentelemetry-go-contrib otelhttp — "one
 middleware one span" invariant; route metadata is bound post-routing
 via chi RouteContext.
 
-### 8. Error Redaction Hook — `WrapConsumer(...,WithConsumerErrorRedactor)` (round 4 F5)
+### 8. Error Redaction — fail-closed default, no caller wiring (revised 2026-05-04)
 
-`wrapper.ErrorRedactor` is a `func(error) error` that `WrapConsumer`
-applies to every error it records on a span (Requeue/Reject
-dispositions + handler panics). `bootstrap.WithErrorRedactor` sets
-the process-wide redactor; bootstrap passes it to
-`eventrouter.ContractTracingMiddleware`, which attaches it to every
-contract-bound `WrapConsumer` invocation. Default is the identity
-(no scrubbing), matching OTel's default; deployments in regulated
-environments plug a redactor to strip SQL fragments / token
-carriers / PII from error strings before they reach the trace
-backend.
+`WrapConsumer` and `runtime/http/middleware.Recovery` both pass every
+error reaching `span.RecordError` through `pkg/redaction.RedactError`
+unconditionally. There is **no** `ErrorRedactor` type, no
+`WithConsumerErrorRedactor` / `WithErrorRedactor` option, no
+`bootstrap.WithErrorRedactor`, and no caller-side opt-out. The default
+masks `key=value` / `key: value` substrings of the form
+`password|passwd|pwd|secret|token|api[_-]?key|authorization|bearer|`
+`private[_-]?key|signing[_-]?key|dsn|connection[_ ]?string` —
+emitting `<REDACTED>` in place of the value while preserving the key
+so operators still get a recognizable signal.
 
-Consumer-only for now — `middleware.Tracing` does not call
-`span.RecordError` today (it relies on status-code classification),
-so an HTTP-side redactor is unnecessary. Should that change, the
-same hook is easy to thread through `middleware.WithErrorRedactor`.
+Why hardcoded:
+
+- **fail-closed defaults**: cell-native deployments cannot assume
+  downstream OTel collectors are configured with the
+  `redactionprocessor`; the regression cost (one secret in trace
+  backend) far outweighs the marginal flexibility of an opt-out hook.
+- **no business consumer**: prior to this revision, `grep -r
+  WithConsumerErrorRedactor` returned zero call sites. The plumbing
+  layer (5 wiring functions across kernel/runtime/bootstrap) protected
+  a pure default-path with no real overrides.
+- **observability isn't the place for raw error text**: dev / debug
+  workflows that need the unredacted message read it from the
+  structured `slog` field (the error logging convention requires that
+  every error reaches slog with full context); the trace span is for
+  ops correlation, not forensic detail.
+
+Coverage:
+
+- `kernel/wrapper.WrapConsumer` Requeue / Reject / invalid disposition
+  branches → `recordErr` → `redaction.RedactError` → `span.RecordError`
+- `kernel/wrapper.recoverAndFinish` panic path → same redaction →
+  `span.RecordError`
+- `runtime/http/middleware.recordPanicOnActiveSpan` (used by
+  `Recovery`) → same redaction → `span.RecordError`
+- `runtime/outbox.SanitizeError` (last-error column on outbox row)
+  delegates to `pkg/redaction` so the regex is single-sourced
+
+Future evolution: callers needing per-value safe markers (e.g.
+"this `error` is known free of PII, do not redact") should adopt the
+CockroachDB `SafeValue` interface pattern in a follow-up PR. That is
+type-driven (`type SafeError string`) and remains compatible with
+hardcoded default — it is opt-in safety annotation, not opt-out
+redaction.
+
+ref: hashicorp/vault audit/entry_formatter.go (`log_raw=false` default,
+operator-only opt-out via config, no caller API).
+ref: golang/go src/net/url/url.go `URL.Redacted()` (hardcoded `xxxxx`
+substitution, no opt-out — caller chooses `String()` vs `Redacted()`
+at the call site).
+ref: cockroachdb/redact (`SafeValue` marker, future direction).
 
 ### 9. Governance rules: FMT-18 + FMT-19 (round 4)
 
@@ -455,10 +492,12 @@ cleanup also closed:
   migrated to `auth.Mount(Route{Contract: ...})` and
   `AddContractHandler(spec, handler, consumerGroup)`; legacy shim APIs
   were deleted.
-- `PR-A11-SEC HTTP-SPAN-ERROR-REDACT-01` — `middleware.Tracing` now
-  accepts `WithErrorRedactor`; `Recovery` records redacted panic errors
-  on the active HTTP span, and `bootstrap.WithErrorRedactor` threads the
-  same hook to HTTP and consumer tracing.
+- `PR-A11-SEC HTTP-SPAN-ERROR-REDACT-01` — `middleware.Tracing` records
+  redacted panic errors on the active HTTP span via `Recovery`. The
+  redactor wiring (`WithErrorRedactor` / `bootstrap.WithErrorRedactor`)
+  was subsequently deleted (refactor/512); redaction is now hardcoded
+  through `pkg/redaction.RedactError` with no caller-side opt-out — see
+  §8 above.
 
 `PR-A11-B` (consumer WrapConsumer wiring) landed in round 3.
 `PR-A11-V` (FMT-17 cross-check) landed as FMT-18 in round 4.

--- a/docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md
+++ b/docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md
@@ -291,6 +291,17 @@ masks `key=value` / `key: value` substrings of the form
 emitting `<REDACTED>` in place of the value while preserving the key
 so operators still get a recognizable signal.
 
+Value boundary is fail-closed: every pattern consumes up to the next
+whitespace (or `\n` for `authorization`). `,` and `;` are NOT treated
+as boundaries even though doing so would preserve more co-located
+context, because fail-closed redaction cannot assume secrets are free
+of those characters (e.g. `Pwd=secret;next=...` ODBC blocks, base64url
+JWT values that happen to embed punctuation). The accepted trade-off:
+a same-line `password="abc",user="alice"` masks `user="alice"` too —
+co-located fields are typically PII or recoverable from the matching
+slog structured-field copy of the error, so over-masking is the
+cheaper failure mode than leaking the secret suffix.
+
 Why hardcoded:
 
 - **fail-closed defaults**: cell-native deployments cannot assume

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -70,7 +70,7 @@ explicit through a `Must*` wrapper.
 
 | # | Function | Justification |
 |---|---|---|
-| 1 | `kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor` | Middle of a `defer recover()` chain that re-panics so the outer `runtime/http/middleware.Recovery` middleware can record + serialize the panic. Refactoring it to return error would dismantle the entire recover propagation idiom and force every wrapped consumer to pre-route panics through a synthetic error path before Go's runtime gets the chance. |
+| 1 | `kernel/wrapper/lifecycle.go::recoverAndFinish` | Middle of a `defer recover()` chain that re-panics so the outer `runtime/http/middleware.Recovery` middleware can record + serialize the panic. Refactoring it to return error would dismantle the entire recover propagation idiom and force every wrapped consumer to pre-route panics through a synthetic error path before Go's runtime gets the chance. |
 | 2 | `runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure` | Middle of a `defer recover()` chain that first reports the handler panic as a circuit-breaker failure, then re-panics so the outer `Recovery` middleware remains the single panic-to-HTTP and panic-to-tracing boundary. Swallowing the panic here would bypass `Recovery` and lose panic span recording in the normal router chain. |
 | 3 | `adapters/postgres/tx_manager.go::repanicAfterTopLevelTxRollback` | Top-level transaction panic path must rollback the open pgx transaction before preserving the caller's original panic semantics. Returning an error would swallow programmer/runtime panics from the callback and change `RunInTx`'s transaction-safety contract. |
 | 4 | `adapters/postgres/tx_manager.go::repanicAfterSavepointRollback` | Nested transaction panic path must rollback to the savepoint before preserving the caller's original panic semantics. Returning an error would swallow programmer/runtime panics from the callback and make nested and top-level transactions diverge. |
@@ -174,7 +174,7 @@ Hardcoded in `tools/archtest/panic_registered_test.go`:
 
 ```go
 var architecturalPanicWhitelist = map[string]string{
-    "kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor": "re-panics from defer recover so outer Recovery middleware can serialize the panic",
+    "kernel/wrapper/lifecycle.go::recoverAndFinish": "re-panics from defer recover so outer Recovery middleware can serialize the panic",
     "runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure": "re-panics from defer recover after reporting circuit-breaker failure",
     "adapters/postgres/tx_manager.go::repanicAfterTopLevelTxRollback": "re-panics after top-level transaction rollback so caller panic semantics are preserved",
     "adapters/postgres/tx_manager.go::repanicAfterSavepointRollback": "re-panics after savepoint rollback so nested transaction panic semantics are preserved",

--- a/docs/backlog1.md
+++ b/docs/backlog1.md
@@ -37,9 +37,13 @@
 | **SEC-TLS-REAL-MODE-01** | ✅ 已完成（PR #297/#301） | `adapters/redis/client.go:175` + `adapters/vault/transit_provider.go:756` + `adapters/s3/s3.go:55` | real mode 强制 TLS/HTTPS；非加密 endpoint startup fail-fast；写新 errcode `ERR_ADAPTER_INSECURE_TRANSPORT` |
 | **SEC-WEBSOCKET-DEFAULT-01** | ✅ 已完成（PR #297/#301） | `adapters/websocket/handler.go:37,57` | origins 默认拒绝 + 显式 dev opt-in；注册失败分支主动 `conn.Close()` |
 | **SEC-CONTROLPLANE-ADDRBOUND-01** | ✅ 已完成（PR #297） | `cmd/corebundle/controlplane.go:58` + `cmd/corebundle/bundle.go:117` | 安全强约束改地址驱动（非回环 → 必须 auth chain），不再绑 adapter mode；mode dev + 0.0.0.0 监听亦必须 fail-fast |
-| **SEC-WRAPPER-REDACTOR-DEFAULT-01** | ⬜ 待处理 | `kernel/wrapper/consumer.go:43` + `kernel/wrapper/lifecycle.go:34` | wrapper redactor 默认改最小脱敏（不再 identity）；关闭脱敏改受控 option `WithRedactorDisabled(devOnly)` |
+| **SEC-WRAPPER-REDACTOR-DEFAULT-01** | ✅ 已完成（PR #366 refactor/512） | `kernel/wrapper/consumer.go` + `kernel/wrapper/lifecycle.go` + `pkg/redaction/` | 默认改 fail-closed `pkg/redaction.RedactError` 硬编；删整条 opt-out wiring（`ErrorRedactor` type / `WithConsumerErrorRedactor` / `bootstrap.WithErrorRedactor` / `middleware.WithErrorRedactor` / `Bootstrap.errorRedactor` / `ContractTracingMiddleware` 第二参）— 比原方案更激进（比 `WithRedactorDisabled(devOnly)` 走得更远），对齐 Vault `log_raw=false` + Go stdlib `URL.Redacted()` 哲学 |
 
-**对标**：Vault server `tls_disable` 显式拒绝 production；Envoy `route.config.virtual_hosts[].typed_per_filter_config` 默认拒绝；K8s `--insecure-port=0` 默认行为
+**对标**：Vault server `tls_disable` 显式拒绝 production；Envoy `route.config.virtual_hosts[].typed_per_filter_config` 默认拒绝；K8s `--insecure-port=0` 默认行为；Vault `audit log_raw=false` 默认硬编 + Go stdlib `URL.Redacted()` 无 opt-out（PR #366 实施版）
+
+### Follow-up（PR #366 reviewer registered）
+
+- **SPAN-RECORD-ERROR-REDACT-ARCHTEST-01** (Cx3, OUT_OF_SCOPE) — 静态守 `kernel/wrapper` + `runtime/http/middleware` 内 `span.RecordError(...)` 调用必须经 `redaction.RedactError(...)` 包装。当前 wiring 已删除、调用点固定为 3 处（consumer.go / lifecycle.go / tracing.go），未来新增 `RecordError` 调用绕过 redaction 不会被 CI 拦截。触发条件：第 4 处 `span.RecordError` 调用引入时同步加 archtest；或任何 reviewer 发现 redaction bypass 时立刻补。 | `tools/archtest/span_record_error_test.go`（新增）+ AST scan
 
 ---
 

--- a/docs/backlog1.md
+++ b/docs/backlog1.md
@@ -43,7 +43,7 @@
 
 ### Follow-up（PR #366 reviewer registered）
 
-- **SPAN-RECORD-ERROR-REDACT-ARCHTEST-01** (Cx3, OUT_OF_SCOPE) — 静态守 `kernel/wrapper` + `runtime/http/middleware` 内 `span.RecordError(...)` 调用必须经 `redaction.RedactError(...)` 包装。当前 wiring 已删除、调用点固定为 3 处（consumer.go / lifecycle.go / tracing.go），未来新增 `RecordError` 调用绕过 redaction 不会被 CI 拦截。触发条件：第 4 处 `span.RecordError` 调用引入时同步加 archtest；或任何 reviewer 发现 redaction bypass 时立刻补。 | `tools/archtest/span_record_error_test.go`（新增）+ AST scan
+- **SPAN-RECORD-ERROR-REDACT-ARCHTEST-01** ✅ 已完成（PR #366 同 PR 增量）— `tools/archtest/span_record_error_redact_test.go` 纯 AST scan：扫 `kernel/wrapper/` + `runtime/http/middleware/` 非测试 .go 文件，断言每个 `span.RecordError(...)` 调用首参必须 inline `redaction.RedactError(...)`；附 fixture compliant/violates 自验证。在 PR fix 增量过程中即抓出 `tracing.go:306` 一处中间变量持有 redact 结果的旁路，已 inline 修复。
 
 ---
 

--- a/kernel/wrapper/consumer.go
+++ b/kernel/wrapper/consumer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
 // Re-export outbox types so wrapper callers do not need to import kernel/outbox
@@ -34,37 +35,6 @@ const (
 // callers do not need to import kernel/outbox for the type.
 type ConsumerFunc = outbox.EntryHandler
 
-// ErrorRedactor transforms an error before it is recorded on a span. Return
-// the original err unchanged to disable redaction for a given error; return
-// a replacement error (with sanitized message) to strip sensitive payload
-// fragments (SQL snippets, token carriers, raw PII, ...) from observability
-// backends.
-//
-// The default redactor used by WrapConsumer / middleware.Tracing when none
-// is supplied is the identity — error text reaches the span verbatim, which
-// matches OTel's default semantic. Operators who need scrub rules either
-// (a) inject a redactor via the relevant Option or bootstrap wiring, or
-// (b) rely on the OTel collector / adapter pipeline to scrub at export
-// time.
-type ErrorRedactor func(error) error
-
-// ConsumerOption configures WrapConsumer at registration time.
-type ConsumerOption func(*consumerConfig)
-
-type consumerConfig struct {
-	redactor ErrorRedactor
-}
-
-// WithConsumerErrorRedactor installs an ErrorRedactor on this WrapConsumer
-// invocation. A nil fn is a no-op (identity redaction remains).
-func WithConsumerErrorRedactor(fn ErrorRedactor) ConsumerOption {
-	return func(c *consumerConfig) {
-		if fn != nil {
-			c.redactor = fn
-		}
-	}
-}
-
 func defaultEventSpanName(spec ContractSpec) string {
 	return "CONSUME " + spec.Topic
 }
@@ -87,14 +57,18 @@ func defaultEventSpanName(spec ContractSpec) string {
 //
 // spec must have Kind == "event" and Topic set; fn must be non-nil.
 //
-// WithConsumerErrorRedactor allows callers to scrub error text before it
-// reaches span.RecordError (F5 / round-4). Applied uniformly to the three
-// RecordError call sites below (Requeue/Reject disposition + panic path).
+// Error redaction is hardcoded to pkg/redaction.RedactError before any
+// span.RecordError call, so sensitive substrings (password=, token=,
+// Authorization: Bearer …) never reach the trace backend. There is no
+// caller-side opt-out — dev / test surfaces that need raw error text read
+// it from slog structured fields instead.
+// ref: hashicorp/vault audit/entry_formatter.go (log_raw=false default)
+// ref: golang/go src/net/url/url.go URL.Redacted()
 //
 // Returns a non-nil error when fn is nil, spec.Kind != "event", or
 // spec.Validate fails. Callers that want to fail-fast at composition time
 // should use MustWrapConsumer.
-func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...ConsumerOption) (ConsumerFunc, error) {
+func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc) (ConsumerFunc, error) {
 	if fn == nil {
 		return nil, fmt.Errorf("wrapper.WrapConsumer: fn must not be nil")
 	}
@@ -106,11 +80,6 @@ func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...Consume
 	}
 	if tr == nil {
 		tr = NoopTracer{}
-	}
-
-	cfg := consumerConfig{redactor: identityRedactor}
-	for _, o := range opts {
-		o(&cfg)
 	}
 
 	baseAttrs := []Attr{
@@ -125,7 +94,7 @@ func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...Consume
 		ctx = ctxkeys.WithContractID(ctx, spec.ID)
 		ctx, span := tr.Start(ctx, defaultEventSpanName(spec))
 		span.SetAttributes(baseAttrs...)
-		defer func() { recoverAndFinishWithRedactor(span, recover(), cfg.redactor) }()
+		defer func() { recoverAndFinish(span, recover()) }()
 
 		res = fn(ctx, entry)
 
@@ -134,10 +103,10 @@ func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...Consume
 			span.SetStatus(StatusOK, "")
 		case outbox.DispositionRequeue:
 			span.SetStatus(StatusError, "requeue")
-			recordErrRedacted(span, cfg.redactor, res.Err, "consumer returned Requeue without error")
+			recordErr(span, res.Err, "consumer returned Requeue without error")
 		case outbox.DispositionReject:
 			span.SetStatus(StatusError, "reject")
-			recordErrRedacted(span, cfg.redactor, res.Err, "consumer returned Reject without error")
+			recordErr(span, res.Err, "consumer returned Reject without error")
 		default:
 			// Invalid disposition — tested in kernel/outbox; we mark the
 			// span as error AND record an error event so ops see both the
@@ -145,7 +114,7 @@ func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...Consume
 			// Requeue/Reject branches. Result is left untouched for
 			// downstream downgrade logic.
 			span.SetStatus(StatusError, "invalid disposition")
-			recordErrRedacted(span, cfg.redactor, res.Err,
+			recordErr(span, res.Err,
 				fmt.Sprintf("consumer returned invalid disposition %d", res.Disposition))
 		}
 		span.End()
@@ -157,24 +126,21 @@ func WrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...Consume
 // It panics when WrapConsumer returns an error. Suitable for static wiring
 // where the spec is a build-time literal; use WrapConsumer directly when the
 // spec is data-driven.
-func MustWrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc, opts ...ConsumerOption) ConsumerFunc {
-	c, err := WrapConsumer(tr, spec, fn, opts...)
+func MustWrapConsumer(tr Tracer, spec ContractSpec, fn ConsumerFunc) ConsumerFunc {
+	c, err := WrapConsumer(tr, spec, fn)
 	if err != nil {
 		panic(err.Error())
 	}
 	return c
 }
 
-// identityRedactor is the default — passes errors through unchanged.
-func identityRedactor(err error) error { return err }
-
-// recordErrRedacted calls span.RecordError on the redacted form of err,
-// falling back to a synthetic "missing error" message (itself redacted) so
-// ops still get a recognizable event in the span even when a handler
-// misbehaves by returning a non-Ack disposition with a nil error.
-func recordErrRedacted(span Span, redact ErrorRedactor, err error, fallbackMsg string) {
+// recordErr calls span.RecordError on the redacted form of err, falling back
+// to a synthetic "missing error" message (itself redacted) so ops still get
+// a recognizable event in the span even when a handler misbehaves by
+// returning a non-Ack disposition with a nil error.
+func recordErr(span Span, err error, fallbackMsg string) {
 	if err == nil {
 		err = errors.New(fallbackMsg)
 	}
-	span.RecordError(redact(err))
+	span.RecordError(redaction.RedactError(err))
 }

--- a/kernel/wrapper/consumer_test.go
+++ b/kernel/wrapper/consumer_test.go
@@ -3,6 +3,7 @@ package wrapper_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -70,38 +71,48 @@ func TestWrapConsumer_MarksErrorOnRequeue(t *testing.T) {
 	}
 }
 
-func TestWrapConsumer_RedactsDispositionErrors(t *testing.T) {
+// TestWrapConsumer_DefaultRedactsSensitiveValueOnSpan verifies that error
+// text reaching span.RecordError is hardcoded through pkg/redaction.RedactError;
+// no caller-side opt-out exists. ref: hashicorp/vault audit log_raw=false.
+func TestWrapConsumer_DefaultRedactsSensitiveValueOnSpan(t *testing.T) {
 	tr := &spyTracer{}
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
-		return outbox.HandleResult{Disposition: outbox.DispositionRequeue, Err: errors.New("raw token")}
+		return outbox.HandleResult{
+			Disposition: outbox.DispositionRequeue,
+			Err:         errors.New("upstream rejected: token=hunter2-leak-sentinel-9f3"),
+		}
 	}
-	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner, wrapper.WithConsumerErrorRedactor(func(error) error {
-		return errors.New("redacted")
-	}))
-	res := w(context.Background(), outbox.Entry{})
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
+	_ = w(context.Background(), outbox.Entry{})
 
-	if res.Disposition != outbox.DispositionRequeue {
-		t.Errorf("want Requeue, got %v", res.Disposition)
-	}
 	span := tr.only(t)
-	if len(span.errs) != 1 || span.errs[0].Error() != "redacted" {
-		t.Errorf("redacted error not recorded, got %v", span.errs)
+	if len(span.errs) != 1 {
+		t.Fatalf("want 1 RecordError, got %d", len(span.errs))
+	}
+	got := span.errs[0].Error()
+	if strings.Contains(got, "hunter2-leak-sentinel-9f3") {
+		t.Errorf("span recorded raw secret value: %q", got)
+	}
+	if !strings.Contains(got, "<REDACTED>") {
+		t.Errorf("span recorded msg missing <REDACTED> mask: %q", got)
 	}
 }
 
-func TestWrapConsumer_RedactsMissingDispositionErrorFallback(t *testing.T) {
+// TestWrapConsumer_RecordsFallbackOnNilDispositionError verifies the
+// synthetic fallback message used when a non-Ack disposition arrives with
+// nil Err. The fallback itself goes through redaction (its content has no
+// sensitive substring, so redaction is a no-op).
+func TestWrapConsumer_RecordsFallbackOnNilDispositionError(t *testing.T) {
 	tr := &spyTracer{}
 	inner := func(ctx context.Context, e outbox.Entry) outbox.HandleResult {
 		return outbox.HandleResult{Disposition: outbox.DispositionReject}
 	}
-	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner, wrapper.WithConsumerErrorRedactor(func(err error) error {
-		return errors.New("safe: " + err.Error())
-	}))
+	w := wrapper.MustWrapConsumer(tr, eventSpec(), inner)
 	_ = w(context.Background(), outbox.Entry{})
 
 	span := tr.only(t)
-	if len(span.errs) != 1 || span.errs[0].Error() != "safe: consumer returned Reject without error" {
-		t.Errorf("redacted fallback error not recorded, got %v", span.errs)
+	if len(span.errs) != 1 || span.errs[0].Error() != "consumer returned Reject without error" {
+		t.Errorf("want fallback message, got %v", span.errs)
 	}
 }
 

--- a/kernel/wrapper/lifecycle.go
+++ b/kernel/wrapper/lifecycle.go
@@ -1,23 +1,24 @@
 package wrapper
 
-import "fmt"
+import (
+	"fmt"
 
-// recoverAndFinishWithRedactor is the shared span-teardown helper for
-// WrapConsumer's panic path. It must be called from within a deferred
-// closure so that recover() captures the in-flight panic.
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// recoverAndFinish is the shared span-teardown helper for WrapConsumer's
+// panic path. It must be called from within a deferred closure so that
+// recover() captures the in-flight panic.
 //
 // Behavior:
 //   - rec == nil  → no-op (normal path; caller is responsible for span.End).
-//   - rec != nil  → SetStatus(Error, "panic") + RecordError(redact(err))
+//   - rec != nil  → SetStatus(Error, "panic") + RecordError(redaction.RedactError(err))
 //   - span.End + re-panic.
 //
 // Re-panicking preserves the original stack for outer Recovery middleware /
-// runSubscribe goroutine supervisors.
-//
-// redact applies the caller's ErrorRedactor to whatever error surface the
-// panic produced (err-typed panic → err; any other value → wrapped via
-// fmt.Errorf). Pass identityRedactor when redaction is disabled.
-func recoverAndFinishWithRedactor(span Span, rec any, redact ErrorRedactor) {
+// runSubscribe goroutine supervisors. Redaction is hardcoded — see
+// pkg/redaction for the fail-closed rationale.
+func recoverAndFinish(span Span, rec any) {
 	if rec == nil {
 		return
 	}
@@ -28,10 +29,7 @@ func recoverAndFinishWithRedactor(span Span, rec any, redact ErrorRedactor) {
 	} else {
 		err = fmt.Errorf("panic: %v", rec)
 	}
-	if redact == nil {
-		redact = identityRedactor
-	}
-	span.RecordError(redact(err))
+	span.RecordError(redaction.RedactError(err))
 	span.End()
 	panic(rec)
 }

--- a/pkg/redaction/redaction.go
+++ b/pkg/redaction/redaction.go
@@ -21,21 +21,37 @@ import (
 // Mask is the literal substituted in place of redacted values.
 const Mask = "<REDACTED>"
 
+// Value-boundary policy across all three patterns: consume up to the next
+// whitespace (or newline for authorization). NEVER stop at `,` or `;` even
+// though doing so would preserve more context — fail-closed cannot assume
+// secrets are free of those characters. A base64url JWT plus padding, an
+// ODBC `Pwd=a;b;c` block embedded inside a larger DSN, or a comma-separated
+// secret value would otherwise leak the suffix.
+//
+// Trade-off: a JSON-style error like
+// `{"password":"abc","user":"alice"}` masks the entire trailing slice
+// (`"abc","user":"alice"}`) instead of just the secret. Co-located
+// fields — usernames, timestamps, surrounding JSON — are typically PII or
+// recoverable from the slog structured-field copy of the same error, so
+// the over-mask is the cheaper failure mode.
+
 // authorizationPattern handles HTTP `Authorization` header form where the
 // value is `Bearer <token>` / `Basic <b64>` (whitespace-separated). value
-// extends to end of line / `;` so the trailing token is not leaked. Order
-// matters: authorization is applied before defaultPattern so the latter does
-// not partially eat `Authorization: Bearer` and leave the real token bare.
+// extends to end of line so a trailing `;`-suffixed token (rare but not
+// impossible inside an opaque bearer) is not leaked. Order matters:
+// authorization is applied before defaultPattern so the latter does not
+// partially eat `Authorization: Bearer` and leave the real token bare.
 var authorizationPattern = regexp.MustCompile(
-	`(?i)(authorization)\s*[:=]\s*[^\r\n;]+`,
+	`(?i)(authorization)\s*[:=]\s*[^\r\n]+`,
 )
 
 // connectionStringPattern handles ODBC / SQL Server connection strings where
 // `;` separates fields (e.g. `Server=foo;Pwd=bar;Database=baz`). value
-// extends to whitespace / comma so the entire embedded credential block is
-// scrubbed at once.
+// extends to whitespace so the entire embedded credential block is
+// scrubbed at once even when the string itself contains `,` (e.g. SQL
+// Server `Server=host,1433;Pwd=secret`).
 var connectionStringPattern = regexp.MustCompile(
-	`(?i)(connection[_ ]?string)\s*[:=]\s*[^\s,]+`,
+	`(?i)(connection[_ ]?string)\s*[:=]\s*\S+`,
 )
 
 // defaultPattern matches single-token `key=value` / `key: value` forms.
@@ -45,14 +61,14 @@ var connectionStringPattern = regexp.MustCompile(
 // (SQL Server / ODBC 连接字符串 password 缩写).
 //
 // dsn 保留：PG 连接错误 message 常含完整 DSN（含明文密码 postgres://u:pwd@host），
-// 是真实泄漏面。dsn 的 value 在 PG 风格里是单 URL（无 `;`），保持单词边界足够。
+// 是真实泄漏面。
 //
 // pwd false-positive 已知：日志里出现 `pwd=/home/user` 形式（如打印工作目录）
 // 会被 mask。这是 fail-closed 的代价 — 取舍偏向「宁可掩盖目录也不泄漏 SQL
 // Server `Pwd=secret`」。dev 调试需要原始 working directory 时走 slog 结构化字段
 // (e.g. `slog.String("workdir", v)`)，不靠 trace span。
 var defaultPattern = regexp.MustCompile(
-	`(?i)(password|passwd|pwd|secret|token|api[_-]?key|bearer|private[_-]?key|signing[_-]?key|dsn)\s*[:=]\s*[^\s;,]+`,
+	`(?i)(password|passwd|pwd|secret|token|api[_-]?key|bearer|private[_-]?key|signing[_-]?key|dsn)\s*[:=]\s*\S+`,
 )
 
 // allPatterns runs in order. ORDER IS A CORRECTNESS CONSTRAINT, not a

--- a/pkg/redaction/redaction.go
+++ b/pkg/redaction/redaction.go
@@ -46,13 +46,22 @@ var connectionStringPattern = regexp.MustCompile(
 //
 // dsn 保留：PG 连接错误 message 常含完整 DSN（含明文密码 postgres://u:pwd@host），
 // 是真实泄漏面。dsn 的 value 在 PG 风格里是单 URL（无 `;`），保持单词边界足够。
+//
+// pwd false-positive 已知：日志里出现 `pwd=/home/user` 形式（如打印工作目录）
+// 会被 mask。这是 fail-closed 的代价 — 取舍偏向「宁可掩盖目录也不泄漏 SQL
+// Server `Pwd=secret`」。dev 调试需要原始 working directory 时走 slog 结构化字段
+// (e.g. `slog.String("workdir", v)`)，不靠 trace span。
 var defaultPattern = regexp.MustCompile(
 	`(?i)(password|passwd|pwd|secret|token|api[_-]?key|bearer|private[_-]?key|signing[_-]?key|dsn)\s*[:=]\s*[^\s;,]+`,
 )
 
-// allPatterns runs in order; earlier patterns get first crack at overlapping
-// keywords (e.g. `authorization` consumes its full HTTP value before
-// `defaultPattern` runs).
+// allPatterns runs in order. ORDER IS A CORRECTNESS CONSTRAINT, not a
+// performance optimization: `authorizationPattern` must consume the full
+// `Authorization: Bearer <token>` line before `defaultPattern` runs,
+// otherwise `defaultPattern` would match `bearer=` and stop after the
+// `Bearer` literal — leaving the real token bare. Likewise
+// `connectionStringPattern` consumes the entire ODBC `Server=...;Pwd=...`
+// block before `defaultPattern` walks the residue.
 var allPatterns = []*regexp.Regexp{
 	authorizationPattern,
 	connectionStringPattern,
@@ -71,6 +80,12 @@ func RedactString(s string) string {
 
 // maskAfterSeparator returns the prefix up to and including the `=` or `:`
 // separator (and any trailing whitespace) followed by Mask.
+//
+// Byte-level traversal is safe: every key in the patterns above is ASCII,
+// and the separators (`=` 0x3D, `:` 0x3A, ` ` 0x20, `\t` 0x09) are all
+// single-byte ASCII characters that cannot appear as UTF-8 continuation
+// bytes (0x80–0xBF). If the keyword set is ever extended to include
+// non-ASCII letters, switch to a rune-aware scan.
 func maskAfterSeparator(match string) string {
 	for i := 0; i < len(match); i++ {
 		r := match[i]

--- a/pkg/redaction/redaction.go
+++ b/pkg/redaction/redaction.go
@@ -1,0 +1,114 @@
+// Package redaction provides fail-closed scrubbing of sensitive substrings in
+// error messages and free-form strings before they reach observability backends
+// (OTel span attributes, audit logs, last_error storage columns).
+//
+// 哲学：默认硬编 fail-closed，无调用方 opt-out wiring。dev 调试需要原始 error
+// 文本时，从 slog 结构化字段获取（错误日志规范要求结构化关联字段），不靠 trace
+// backend。与 hashicorp/vault audit log_raw=false 默认 / golang/go net/url
+// URL.Redacted() 哲学一致；OTel SDK / Kratos / Watermill 默认 identity 直通是
+// 反例，cell-native 底座不能假设下游一定有 OTel collector redactionprocessor。
+//
+// ref: hashicorp/vault audit/entry_formatter.go (log_raw=false default)
+// ref: golang/go src/net/url/url.go URL.Redacted()
+package redaction
+
+import (
+	"errors"
+	"regexp"
+	"unicode/utf8"
+)
+
+// Mask is the literal substituted in place of redacted values.
+const Mask = "<REDACTED>"
+
+// authorizationPattern handles HTTP `Authorization` header form where the
+// value is `Bearer <token>` / `Basic <b64>` (whitespace-separated). value
+// extends to end of line / `;` so the trailing token is not leaked. Order
+// matters: authorization is applied before defaultPattern so the latter does
+// not partially eat `Authorization: Bearer` and leave the real token bare.
+var authorizationPattern = regexp.MustCompile(
+	`(?i)(authorization)\s*[:=]\s*[^\r\n;]+`,
+)
+
+// connectionStringPattern handles ODBC / SQL Server connection strings where
+// `;` separates fields (e.g. `Server=foo;Pwd=bar;Database=baz`). value
+// extends to whitespace / comma so the entire embedded credential block is
+// scrubbed at once.
+var connectionStringPattern = regexp.MustCompile(
+	`(?i)(connection[_ ]?string)\s*[:=]\s*[^\s,]+`,
+)
+
+// defaultPattern matches single-token `key=value` / `key: value` forms.
+//
+// 字段集 = outbox 历史集 (password/passwd/secret/token/dsn) + wrapper attack
+// surface (api[_-]?key / bearer / private[_-]?key / signing[_-]?key) + pwd
+// (SQL Server / ODBC 连接字符串 password 缩写).
+//
+// dsn 保留：PG 连接错误 message 常含完整 DSN（含明文密码 postgres://u:pwd@host），
+// 是真实泄漏面。dsn 的 value 在 PG 风格里是单 URL（无 `;`），保持单词边界足够。
+var defaultPattern = regexp.MustCompile(
+	`(?i)(password|passwd|pwd|secret|token|api[_-]?key|bearer|private[_-]?key|signing[_-]?key|dsn)\s*[:=]\s*[^\s;,]+`,
+)
+
+// allPatterns runs in order; earlier patterns get first crack at overlapping
+// keywords (e.g. `authorization` consumes its full HTTP value before
+// `defaultPattern` runs).
+var allPatterns = []*regexp.Regexp{
+	authorizationPattern,
+	connectionStringPattern,
+	defaultPattern,
+}
+
+// RedactString masks sensitive `key=value` / `key: value` substrings in s,
+// preserving the original key (case + separator) and replacing only the
+// value portion with Mask.
+func RedactString(s string) string {
+	for _, p := range allPatterns {
+		s = p.ReplaceAllStringFunc(s, maskAfterSeparator)
+	}
+	return s
+}
+
+// maskAfterSeparator returns the prefix up to and including the `=` or `:`
+// separator (and any trailing whitespace) followed by Mask.
+func maskAfterSeparator(match string) string {
+	for i := 0; i < len(match); i++ {
+		r := match[i]
+		if r == '=' || r == ':' {
+			j := i + 1
+			for j < len(match) && (match[j] == ' ' || match[j] == '\t') {
+				j++
+			}
+			return match[:j] + Mask
+		}
+	}
+	// Unreachable: every pattern requires a `:` or `=` between key and value.
+	return match
+}
+
+// TruncateString truncates s to maxLen runes, preserving valid UTF-8.
+// A non-positive maxLen is a no-op (return input as-is).
+func TruncateString(s string, maxLen int) string {
+	if maxLen <= 0 || utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxLen])
+}
+
+// RedactError returns an error whose Error() text has sensitive substrings
+// masked. nil → nil. When no substitution occurs the original err is returned
+// unchanged so errors.Is/As chains are preserved. When substitution occurs
+// the returned error is a fresh errors.New — the chain breaks; that is the
+// intentional trade-off for telemetry safety.
+func RedactError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	red := RedactString(msg)
+	if red == msg {
+		return err
+	}
+	return errors.New(red)
+}

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -48,12 +48,20 @@ func TestRedactString(t *testing.T) {
 			want: "Authorization: <REDACTED>",
 		},
 		{
-			// authorizationPattern stops at `;` so trailing context after a
-			// semicolon survives — verifies the pattern's value-boundary
-			// invariant (3-pattern split correctness).
-			name: "authorization_semicolonBoundary",
+			// authorizationPattern stops at end-of-line, NOT at `;`. A `;`
+			// inside an opaque bearer token must not leak the suffix —
+			// over-masking the same-line `trace_id=1` is the accepted
+			// fail-closed cost.
+			name: "authorization_semicolonInValue_noLeak",
 			in:   "Authorization: Bearer abc.def.ghi; trace_id=1",
-			want: "Authorization: <REDACTED>; trace_id=1",
+			want: "Authorization: <REDACTED>",
+		},
+		{
+			// Multi-line: only the Authorization line is masked; the next
+			// header line survives because the boundary is `\n`.
+			name: "authorization_newlineBoundary",
+			in:   "Authorization: Bearer abc.def.ghi\nContent-Type: json",
+			want: "Authorization: <REDACTED>\nContent-Type: json",
 		},
 		{
 			name: "bearer_keyEqValue",
@@ -135,6 +143,32 @@ func TestRedactString(t *testing.T) {
 			name: "multipleKeys",
 			in:   "password=a token=b",
 			want: "password=<REDACTED> token=<REDACTED>",
+		},
+		{
+			// fail-closed: a `,` inside the secret value must NOT terminate
+			// the redacted span — otherwise `def` (the suffix of the
+			// original secret) would leak past the mask.
+			name: "password_commaInValue_noLeak",
+			in:   "password=abc,def next=ok",
+			want: "password=<REDACTED> next=ok",
+		},
+		{
+			// fail-closed: same for `;` inside the value.
+			name: "token_semicolonInValue_noLeak",
+			in:   "token=abc;def next=ok",
+			want: "token=<REDACTED> next=ok",
+		},
+		{
+			// Documents the over-mask trade-off: when a key=value field is
+			// followed by `,key2=value2` with no whitespace between, the
+			// fail-closed `\S+` boundary swallows both fields. This is the
+			// accepted cost — losing user="alice" context here is cheaper
+			// than risking a `,`-suffixed secret leaking past the mask.
+			// Callers needing the trailing field intact must emit a space
+			// between fields, or use slog structured fields instead.
+			name: "commaSeparatedFields_overMask_documented",
+			in:   `password="abc",user="alice"`,
+			want: `password=<REDACTED>`,
 		},
 		{
 			name: "noMatch_passthrough",

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -27,6 +27,17 @@ func TestRedactString(t *testing.T) {
 			want: "passwd=<REDACTED> something",
 		},
 		{
+			// pwd is a known false-positive trigger: a log emitting
+			// `pwd=/home/user` (working dir) gets masked. This is the
+			// intentional fail-closed cost — masking a directory path is
+			// preferable to leaking SQL Server `Pwd=secret`. Documented
+			// behavior, not a bug. dev workflows needing raw working dir
+			// should use slog structured fields instead.
+			name: "pwd_workdir_falsePositive_documented",
+			in:   "starting worker pwd=/home/user/app",
+			want: "starting worker pwd=<REDACTED>",
+		},
+		{
 			name: "token_keyEqValue",
 			in:   "upstream 401: token=eyJhbGc.foo",
 			want: "upstream 401: token=<REDACTED>",
@@ -35,6 +46,14 @@ func TestRedactString(t *testing.T) {
 			name: "authorization_colonSpace",
 			in:   "Authorization: Bearer abc.def.ghi",
 			want: "Authorization: <REDACTED>",
+		},
+		{
+			// authorizationPattern stops at `;` so trailing context after a
+			// semicolon survives — verifies the pattern's value-boundary
+			// invariant (3-pattern split correctness).
+			name: "authorization_semicolonBoundary",
+			in:   "Authorization: Bearer abc.def.ghi; trace_id=1",
+			want: "Authorization: <REDACTED>; trace_id=1",
 		},
 		{
 			name: "bearer_keyEqValue",
@@ -46,15 +65,26 @@ func TestRedactString(t *testing.T) {
 			in:   "secret=topsecret",
 			want: "secret=<REDACTED>",
 		},
-		{ //nolint:gosec // G101 false positive: synthetic DSN fixture demonstrates redaction of scheme://user:pwd@ form
+		{
+			// dsn= field redaction: the entire URL value is masked. The
+			// fixture uses a credential-free URL so gosec G101 does not flag
+			// the literal; the redaction itself does not depend on whether
+			// user:pass is embedded — the `dsn=` key is the trigger.
 			name: "dsn_postgres",
-			in:   "connect failed: dsn=postgres://USR:PWD@h/db trailing",
+			in:   "connect failed: dsn=postgres://h/db?sslmode=require trailing",
 			want: "connect failed: dsn=<REDACTED> trailing",
 		},
 		{
 			name: "connection_string_underscore",
 			in:   "connection_string=Server=foo;Pwd=bar",
 			want: "connection_string=<REDACTED>",
+		},
+		{
+			// connectionStringPattern stops at whitespace so trailing log
+			// context survives. Verifies boundary stays at ` ` not `;`.
+			name: "connection_string_whitespaceBoundary",
+			in:   "connection_string=Server=foo;Pwd=bar trailing_ctx=ok",
+			want: "connection_string=<REDACTED> trailing_ctx=ok",
 		},
 		{
 			name: "connection_space",

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -1,0 +1,217 @@
+package redaction_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+func TestRedactString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "password_keyEqValue",
+			in:   "login failed: password=hunter2 user=alice",
+			want: "login failed: password=<REDACTED> user=alice",
+		},
+		{
+			name: "passwd_alias",
+			in:   "passwd=secret123 something",
+			want: "passwd=<REDACTED> something",
+		},
+		{
+			name: "token_keyEqValue",
+			in:   "upstream 401: token=eyJhbGc.foo",
+			want: "upstream 401: token=<REDACTED>",
+		},
+		{
+			name: "authorization_colonSpace",
+			in:   "Authorization: Bearer abc.def.ghi",
+			want: "Authorization: <REDACTED>",
+		},
+		{
+			name: "bearer_keyEqValue",
+			in:   "bearer=abc.def.ghi end",
+			want: "bearer=<REDACTED> end",
+		},
+		{
+			name: "secret_simple",
+			in:   "secret=topsecret",
+			want: "secret=<REDACTED>",
+		},
+		{ //nolint:gosec // G101 false positive: synthetic DSN fixture demonstrates redaction of scheme://user:pwd@ form
+			name: "dsn_postgres",
+			in:   "connect failed: dsn=postgres://USR:PWD@h/db trailing",
+			want: "connect failed: dsn=<REDACTED> trailing",
+		},
+		{
+			name: "connection_string_underscore",
+			in:   "connection_string=Server=foo;Pwd=bar",
+			want: "connection_string=<REDACTED>",
+		},
+		{
+			name: "connection_space",
+			in:   "connection string=somevalue trailing",
+			want: "connection string=<REDACTED> trailing",
+		},
+		{
+			name: "apiKey_camel",
+			in:   "apikey=abc123",
+			want: "apikey=<REDACTED>",
+		},
+		{
+			name: "apiKey_underscore",
+			in:   "api_key=abc123",
+			want: "api_key=<REDACTED>",
+		},
+		{
+			name: "apiKey_hyphen",
+			in:   "api-key=abc123",
+			want: "api-key=<REDACTED>",
+		},
+		{
+			name: "privateKey_underscore",
+			in:   "private_key=MIIEvQIBADANBg",
+			want: "private_key=<REDACTED>",
+		},
+		{
+			name: "privateKey_hyphen",
+			in:   "private-key=MIIEvQ",
+			want: "private-key=<REDACTED>",
+		},
+		{
+			name: "signing_key",
+			in:   "signing_key=topsecret",
+			want: "signing_key=<REDACTED>",
+		},
+		{
+			name: "caseInsensitive_upper",
+			in:   "PASSWORD=abc",
+			want: "PASSWORD=<REDACTED>",
+		},
+		{
+			name: "caseInsensitive_mixed",
+			in:   "Token=xyz",
+			want: "Token=<REDACTED>",
+		},
+		{
+			name: "multipleKeys",
+			in:   "password=a token=b",
+			want: "password=<REDACTED> token=<REDACTED>",
+		},
+		{
+			name: "noMatch_passthrough",
+			in:   "plain validation error: field foo missing",
+			want: "plain validation error: field foo missing",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := redaction.RedactString(tc.in)
+			if got != tc.want {
+				t.Errorf("RedactString(%q):\n  got:  %q\n  want: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactString_DoesNotLeakSensitiveValue(t *testing.T) {
+	t.Parallel()
+	const secret = "hunter2-very-unique-token"
+	out := redaction.RedactString("login: password=" + secret + " end")
+	if strings.Contains(out, secret) {
+		t.Errorf("redacted output still contains secret value: %q", out)
+	}
+}
+
+func TestRedactError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_in_nil_out", func(t *testing.T) {
+		t.Parallel()
+		if got := redaction.RedactError(nil); got != nil {
+			t.Errorf("RedactError(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("noChange_returnsSameInstance", func(t *testing.T) {
+		t.Parallel()
+		err := errors.New("plain validation error")
+		got := redaction.RedactError(err)
+		if got != err {
+			t.Errorf("RedactError(plain) returned different instance; identity must be preserved when nothing changes")
+		}
+	})
+
+	t.Run("redacted_returnsNewInstance", func(t *testing.T) {
+		t.Parallel()
+		original := errors.New("password=hunter2")
+		got := redaction.RedactError(original)
+		if got == original {
+			t.Fatal("RedactError(sensitive) returned same instance; expected a new error with masked text")
+		}
+		if got.Error() != "password=<REDACTED>" {
+			t.Errorf("redacted msg = %q, want %q", got.Error(), "password=<REDACTED>")
+		}
+	})
+
+	t.Run("redacted_doesNotLeak", func(t *testing.T) {
+		t.Parallel()
+		const secret = "uniqueLeakSentinel-9f3"
+		err := errors.New("upstream: token=" + secret)
+		got := redaction.RedactError(err)
+		if strings.Contains(got.Error(), secret) {
+			t.Errorf("redacted error still leaks secret: %q", got.Error())
+		}
+	})
+}
+
+func TestTruncateString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{name: "short_passthrough", in: "hello", maxLen: 100, want: "hello"},
+		{name: "long_truncate", in: "hello world", maxLen: 5, want: "hello"},
+		{name: "exact_passthrough", in: "hello", maxLen: 5, want: "hello"},
+		{name: "unicode_runeBoundary", in: "你好世界", maxLen: 3, want: "你好世"},
+		{name: "zeroMax_passthrough", in: "hello", maxLen: 0, want: "hello"},
+		{name: "negativeMax_passthrough", in: "hello", maxLen: -1, want: "hello"},
+		{name: "empty", in: "", maxLen: 5, want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := redaction.TruncateString(tc.in, tc.maxLen)
+			if got != tc.want {
+				t.Errorf("TruncateString(%q, %d):\n  got:  %q\n  want: %q", tc.in, tc.maxLen, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMask_ConstantValue(t *testing.T) {
+	t.Parallel()
+	if redaction.Mask != "<REDACTED>" {
+		t.Errorf("Mask = %q, want %q", redaction.Mask, "<REDACTED>")
+	}
+}

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/config"
 	"github.com/ghbvf/gocell/runtime/http/router"
@@ -84,7 +83,6 @@ type Bootstrap struct {
 	routerOpts            []router.Option
 	healthRouteGroupOpts  []HealthRouteGroupOption
 	wrapperTracer         tracing.Tracer
-	errorRedactor         wrapper.ErrorRedactor
 	circuitBreakerNil     bool
 	healthCheckers        []namedChecker
 	adapterInfo           map[string]string

--- a/runtime/bootstrap/options_http.go
+++ b/runtime/bootstrap/options_http.go
@@ -4,8 +4,8 @@ package bootstrap
 // health, and middleware setup.
 //
 // Covers: WithRouterOptions, WithTracer, WithRateLimiter, WithCircuitBreaker,
-// WithSecurityHeadersOptions, WithErrorRedactor, WithHealthChecker,
-// WithReadyzDeadline, WithAdapterInfo, WithHealthRoutes.
+// WithSecurityHeadersOptions, WithHealthChecker, WithReadyzDeadline,
+// WithAdapterInfo, WithHealthRoutes.
 //
 // Note: WithRateLimiter and WithCircuitBreaker also append to b.closers (lifecycle teardown).
 //
@@ -18,7 +18,6 @@ import (
 
 	kerneldepgraph "github.com/ghbvf/gocell/kernel/depgraph"
 	"github.com/ghbvf/gocell/kernel/metadata"
-	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
@@ -111,22 +110,6 @@ func WithCircuitBreaker(cb middleware.Allower) Option {
 func WithSecurityHeadersOptions(opts ...middleware.SecurityHeadersOption) Option {
 	return func(b *Bootstrap) {
 		b.routerOpts = append(b.routerOpts, router.WithSecurityHeadersOptions(opts...))
-	}
-}
-
-// WithErrorRedactor installs a wrapper.ErrorRedactor that scrubs error text
-// before it reaches span.RecordError on HTTP request spans and consumer-side
-// CONSUME spans. A nil fn disables redaction (identity semantics).
-//
-// Use when strict source-side sanitisation is required (regulated
-// environments); otherwise leave unset and let the OTel span processor /
-// exporter filter handle scrubbing at export time.
-func WithErrorRedactor(fn wrapper.ErrorRedactor) Option {
-	return func(b *Bootstrap) {
-		if fn != nil {
-			b.errorRedactor = fn
-			b.routerOpts = append(b.routerOpts, router.WithTracingOptions(middleware.WithErrorRedactor(fn)))
-		}
 	}
 }
 

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -53,7 +53,7 @@ func (b *Bootstrap) buildEventRouter(sub outbox.Subscriber) *eventrouter.Router 
 	// middleware here. ContractTracingMiddleware therefore observes a
 	// ctx already populated with entry.Observability fields.
 	mws := []outbox.SubscriptionMiddleware{
-		eventrouter.ContractTracingMiddleware(b.wrapperTracer, b.errorRedactor),
+		eventrouter.ContractTracingMiddleware(b.wrapperTracer),
 	}
 	mws = append(mws, b.consumerMiddleware...)
 

--- a/runtime/eventrouter/add_contract_handler_test.go
+++ b/runtime/eventrouter/add_contract_handler_test.go
@@ -147,7 +147,7 @@ func TestContractTracingMiddleware_WrapsWithContractSpan(t *testing.T) {
 	// Drive one entry through the middleware position used by bootstrap:
 	// contract tracing sits outside the stored business handler.
 	sub := r.handlers[0].subscription()
-	wrapped := ContractTracingMiddleware(tr, nil)(sub, r.handlers[0].handler)
+	wrapped := ContractTracingMiddleware(tr)(sub, r.handlers[0].handler)
 	res := wrapped(context.Background(), outbox.Entry{EventType: "event.config.entry-upserted.v1"})
 	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 	assert.True(t, inner, "inner handler must run")
@@ -186,7 +186,7 @@ func TestContractTracingMiddleware_CoversDownstreamShortCircuit(t *testing.T) {
 		}
 	}
 
-	wrapped := ContractTracingMiddleware(tr, nil)(sub, shortCircuit(sub, business))
+	wrapped := ContractTracingMiddleware(tr)(sub, shortCircuit(sub, business))
 	res := wrapped(context.Background(), outbox.Entry{EventType: "event.config.entry-upserted.v1"})
 
 	assert.Equal(t, outbox.DispositionRequeue, res.Disposition)
@@ -218,7 +218,7 @@ func TestContractTracingMiddleware_PanicsOnEmptyContractID(t *testing.T) {
 		require.NotNil(t, r, "empty ContractID must panic at middleware construction")
 	}()
 
-	_ = ContractTracingMiddleware(wrapper.NoopTracer{}, nil)(sub,
+	_ = ContractTracingMiddleware(wrapper.NoopTracer{})(sub,
 		func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			return outbox.HandleResult{Disposition: outbox.DispositionAck}
 		})

--- a/runtime/eventrouter/contract_middleware.go
+++ b/runtime/eventrouter/contract_middleware.go
@@ -21,7 +21,10 @@ import (
 // WrapConsumer panics at construction time. The outbox.SubscriptionMiddleware
 // closure has no error-return path; MustWrapConsumer matches the contract
 // while keeping the spec-validation defense in depth.
-func ContractTracingMiddleware(tr wrapper.Tracer, redactor wrapper.ErrorRedactor) outbox.SubscriptionMiddleware {
+//
+// Error redaction is hardcoded inside wrapper.WrapConsumer (pkg/redaction);
+// this middleware does not pipe a redactor — there is no caller-side opt-out.
+func ContractTracingMiddleware(tr wrapper.Tracer) outbox.SubscriptionMiddleware {
 	return func(sub outbox.Subscription, next outbox.EntryHandler) outbox.EntryHandler {
 		spec := wrapper.ContractSpec{
 			ID:        sub.ContractID,
@@ -29,10 +32,6 @@ func ContractTracingMiddleware(tr wrapper.Tracer, redactor wrapper.ErrorRedactor
 			Transport: sub.ContractTransport,
 			Topic:     sub.Topic,
 		}
-		var opts []wrapper.ConsumerOption
-		if redactor != nil {
-			opts = append(opts, wrapper.WithConsumerErrorRedactor(redactor))
-		}
-		return wrapper.MustWrapConsumer(tr, spec, next, opts...)
+		return wrapper.MustWrapConsumer(tr, spec, next)
 	}
 }

--- a/runtime/http/middleware/tracing.go
+++ b/runtime/http/middleware/tracing.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/redaction"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
 )
 
@@ -25,7 +26,6 @@ type ContractAttrsResolver func(method, path string) ([]wrapper.Attr, bool)
 type tracingConfig struct {
 	publicEndpointFn func(*http.Request) bool
 	skipFn           func(*http.Request) bool
-	errorRedactor    wrapper.ErrorRedactor
 	contractAttrs    ContractAttrsResolver
 }
 
@@ -53,17 +53,6 @@ func WithProbeFilter(pred func(*http.Request) bool) TracingOption {
 	return func(c *tracingConfig) {
 		if pred != nil {
 			c.skipFn = pred
-		}
-	}
-}
-
-// WithErrorRedactor installs a redactor for errors recorded on the active
-// HTTP span. Recovery uses the recorder installed by Tracing to attach panic
-// errors to the span without leaking raw panic text into the tracing backend.
-func WithErrorRedactor(fn wrapper.ErrorRedactor) TracingOption {
-	return func(c *tracingConfig) {
-		if fn != nil {
-			c.errorRedactor = fn
 		}
 	}
 }
@@ -180,7 +169,7 @@ func serveSpanned(tracer tracing.Tracer, cfg tracingConfig, next http.Handler, w
 	// Start span with tentative name using raw path.
 	// After routing, the span is renamed to use the route pattern.
 	ctx, span := tracer.Start(ctx, r.Method+" "+r.URL.Path)
-	ctx = withSpanErrorRecorder(ctx, span, cfg.errorRedactor)
+	ctx = withSpanErrorRecorder(ctx, span)
 	defer span.End()
 
 	// Record linked remote context for public endpoints.
@@ -296,26 +285,24 @@ func attrString(attrs []wrapper.Attr, key string) string {
 }
 
 type spanErrorRecorder struct {
-	span     tracing.Span
-	redactor wrapper.ErrorRedactor
+	span tracing.Span
 }
 
 type spanErrorRecorderKey struct{}
 
-func withSpanErrorRecorder(ctx context.Context, span tracing.Span, redactor wrapper.ErrorRedactor) context.Context {
-	return context.WithValue(ctx, spanErrorRecorderKey{}, spanErrorRecorder{span: span, redactor: redactor})
+func withSpanErrorRecorder(ctx context.Context, span tracing.Span) context.Context {
+	return context.WithValue(ctx, spanErrorRecorderKey{}, spanErrorRecorder{span: span})
 }
 
+// recordPanicOnActiveSpan attaches a panic to the active HTTP span. The
+// panic message is hardcoded through pkg/redaction.RedactError before
+// span.RecordError; there is no caller-side opt-out (see pkg/redaction).
 func recordPanicOnActiveSpan(ctx context.Context, rec any) {
 	r, ok := ctx.Value(spanErrorRecorderKey{}).(spanErrorRecorder)
 	if !ok || r.span == nil || rec == nil {
 		return
 	}
-	err := panicAsError(rec)
-	if r.redactor != nil {
-		err = r.redactor(err)
-	}
-	if err != nil {
+	if err := redaction.RedactError(panicAsError(rec)); err != nil {
 		r.span.RecordError(err)
 	}
 	tracing.SpanSetStatus(r.span, true, "panic")

--- a/runtime/http/middleware/tracing.go
+++ b/runtime/http/middleware/tracing.go
@@ -297,13 +297,16 @@ func withSpanErrorRecorder(ctx context.Context, span tracing.Span) context.Conte
 // recordPanicOnActiveSpan attaches a panic to the active HTTP span. The
 // panic message is hardcoded through pkg/redaction.RedactError before
 // span.RecordError; there is no caller-side opt-out (see pkg/redaction).
+//
+// The redaction call is inlined as the RecordError argument so the
+// SPAN-RECORD-ERROR-REDACT-01 archtest gate can statically verify the wrap.
 func recordPanicOnActiveSpan(ctx context.Context, rec any) {
 	r, ok := ctx.Value(spanErrorRecorderKey{}).(spanErrorRecorder)
 	if !ok || r.span == nil || rec == nil {
 		return
 	}
-	if err := redaction.RedactError(panicAsError(rec)); err != nil {
-		r.span.RecordError(err)
+	if err := panicAsError(rec); err != nil {
+		r.span.RecordError(redaction.RedactError(err))
 	}
 	tracing.SpanSetStatus(r.span, true, "panic")
 }

--- a/runtime/http/middleware/tracing_test.go
+++ b/runtime/http/middleware/tracing_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -451,12 +450,14 @@ func TestTracing_4xxNoErrorSpanStatus_NoCancelAttr(t *testing.T) {
 		"client.cancel.reason must be 499-only, not generic 4xx")
 }
 
-func TestTracing_RecoveryRecordsRedactedPanicError(t *testing.T) {
+// TestTracing_RecoveryRedactsPanicErrorByDefault verifies that the panic
+// path runs through pkg/redaction.RedactError without any caller-side opt-out
+// (kernel/wrapper hardcoded fail-closed). Sensitive substrings recorded on
+// the span are masked before reaching the trace backend.
+func TestTracing_RecoveryRedactsPanicErrorByDefault(t *testing.T) {
 	spy := &spyTracer{}
-	handler := Tracing(spy, WithErrorRedactor(func(error) error {
-		return errors.New("redacted panic")
-	}))(Recovery(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		panic("raw secret token")
+	handler := Tracing(spy)(Recovery(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("upstream failed: token=hunter2-leak-sentinel-9f3")
 	})))
 
 	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
@@ -466,7 +467,14 @@ func TestTracing_RecoveryRecordsRedactedPanicError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	spans := spy.Spans()
 	require.Len(t, spans, 1)
-	assert.Equal(t, "redacted panic", spans[0].Attr("_recorded_error"))
+
+	recorded, _ := spans[0].Attr("_recorded_error").(string)
+	require.NotEmpty(t, recorded, "expected _recorded_error attr on span")
+	assert.NotContains(t, recorded, "hunter2-leak-sentinel-9f3",
+		"raw panic secret leaked to span: %q", recorded)
+	assert.Contains(t, recorded, "<REDACTED>",
+		"redaction mask missing from recorded panic: %q", recorded)
+
 	assert.Equal(t, true, spans[0].Attr("_status_error"))
 	assert.Equal(t, "Internal Server Error", spans[0].Attr("_status_desc"))
 }

--- a/runtime/outbox/errors.go
+++ b/runtime/outbox/errors.go
@@ -1,36 +1,23 @@
 package outbox
 
-import (
-	"regexp"
-	"unicode/utf8"
-)
+import "github.com/ghbvf/gocell/pkg/redaction"
 
 // ---------------------------------------------------------------------------
 // Error sanitization helpers
 // ---------------------------------------------------------------------------
 // Shared by runtime/outbox (relay) and adapters/postgres (outbox_store).
-// Exported so that adapters can call outbox.SanitizeError without duplicating
-// the regexp and truncation logic.
-
-// sensitivePatterns matches common sensitive substrings in error messages
-// (connection strings, hostnames, credentials) to redact before storage.
-var sensitivePatterns = regexp.MustCompile(
-	`(?i)(password|passwd|secret|token|dsn|connection[_ ]?string)=[^\s;,]+`,
-)
+// Delegates the actual scrub + truncate work to pkg/redaction so the regex
+// (sensitive key set, value-boundary handling) is single-sourced with
+// kernel/wrapper's hardcoded fail-closed redactor. ref: pkg/redaction.
 
 // TruncateError truncates an error message to maxLen runes, preserving valid
-// UTF-8 (avoids splitting multi-byte characters at byte boundaries).
+// UTF-8. Negative or zero maxLen is a no-op.
 func TruncateError(msg string, maxLen int) string {
-	if utf8.RuneCountInString(msg) <= maxLen {
-		return msg
-	}
-	runes := []rune(msg)
-	return string(runes[:maxLen])
+	return redaction.TruncateString(msg, maxLen)
 }
 
-// SanitizeError truncates and redacts sensitive patterns from an error message
-// before storing it in a last_error column.
+// SanitizeError redacts sensitive substrings then truncates to maxLen runes
+// before storing in a last_error column.
 func SanitizeError(errMsg string, maxLen int) string {
-	redacted := sensitivePatterns.ReplaceAllString(errMsg, "$1=<REDACTED>")
-	return TruncateError(redacted, maxLen)
+	return redaction.TruncateString(redaction.RedactString(errMsg), maxLen)
 }

--- a/runtime/outbox/errors_test.go
+++ b/runtime/outbox/errors_test.go
@@ -1,0 +1,63 @@
+package outbox
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSanitizeError_RedactThenTruncateOrder verifies the operation order:
+// redaction runs first, then truncation. This matters when a sensitive value
+// would otherwise span the truncation boundary — redact-first guarantees the
+// `<REDACTED>` token replaces the value cleanly, while truncate-first could
+// chop the value mid-string and let the `<REDACTED>` boundary mismatch.
+func TestSanitizeError_RedactThenTruncateOrder(t *testing.T) {
+	t.Parallel()
+	// 50 chars of preamble + sensitive token; truncate to 70 chars so the
+	// raw value would have been cut, but the redacted form fits cleanly.
+	preamble := strings.Repeat("x", 50)
+	got := SanitizeError(preamble+" token=very-long-leak-sentinel-value-9f3", 70)
+	if strings.Contains(got, "very-long-leak-sentinel-value-9f3") {
+		t.Errorf("raw secret leaked through SanitizeError: %q", got)
+	}
+	if !strings.Contains(got, "<REDACTED>") {
+		t.Errorf("redaction mask missing in SanitizeError output: %q", got)
+	}
+}
+
+// TestSanitizeError_PassThroughWhenSafeAndShort verifies the no-op path:
+// short, non-sensitive messages are returned essentially unchanged
+// (modulo regex non-match → identity, truncate non-trigger → identity).
+func TestSanitizeError_PassThroughWhenSafeAndShort(t *testing.T) {
+	t.Parallel()
+	const msg = "validation failed: field 'email' missing"
+	if got := SanitizeError(msg, 1000); got != msg {
+		t.Errorf("expected pass-through, got %q", got)
+	}
+}
+
+// TestTruncateError_ZeroOrNegativeMaxIsNoOp documents that maxLen ≤ 0 is a
+// no-op so callers passing an unbounded buffer flag (or arithmetic that
+// underflows to a negative) get the input back rather than a panic.
+func TestTruncateError_ZeroOrNegativeMaxIsNoOp(t *testing.T) {
+	t.Parallel()
+	const msg = "any message"
+	if got := TruncateError(msg, 0); got != msg {
+		t.Errorf("maxLen=0 must be no-op, got %q", got)
+	}
+	if got := TruncateError(msg, -1); got != msg {
+		t.Errorf("maxLen<0 must be no-op, got %q", got)
+	}
+}
+
+// TestSanitizeError_TruncateAtRuneBoundary verifies UTF-8 safety: an ASCII
+// truncation should not split multi-byte characters. The redaction layer
+// uses ASCII keys so it does not introduce any new multi-byte chars itself,
+// but the residue (non-redacted Chinese context, etc.) must still truncate
+// at rune boundaries.
+func TestSanitizeError_TruncateAtRuneBoundary(t *testing.T) {
+	t.Parallel()
+	got := SanitizeError("错误消息测试用例", 4)
+	if got != "错误消息" {
+		t.Errorf("UTF-8 truncate not at rune boundary: %q", got)
+	}
+}

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -23,8 +23,8 @@ package archtest
 //     are by definition fatal)
 //
 // Function-level whitelist (architectural panic permitted):
-//   - kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor — middle
-//     of a `defer recover()` chain that re-panics so the outer Recovery
+//   - kernel/wrapper/lifecycle.go::recoverAndFinish — middle of a
+//     `defer recover()` chain that re-panics so the outer Recovery
 //     middleware can record + serialize the panic. Refactoring it to
 //     error would dismantle the entire recover propagation idiom. Any
 //     OTHER error-less function in lifecycle.go that contains panic() is

--- a/tools/archtest/panic_registered_test.go
+++ b/tools/archtest/panic_registered_test.go
@@ -21,7 +21,7 @@ const rulePanicRegistered01 = "PANIC-REGISTERED-01"
 // "<rel-path>::<Receiver>.<methodName>" to an ADR-pinned justification. Keep
 // this map exactly aligned with docs/architecture/202604270030-architectural-panic-whitelist.md.
 var architecturalPanicWhitelist = map[string]string{
-	"kernel/wrapper/lifecycle.go::recoverAndFinishWithRedactor": "re-panics from defer recover" +
+	"kernel/wrapper/lifecycle.go::recoverAndFinish": "re-panics from defer recover" +
 		" so outer Recovery middleware can serialize the panic",
 	"runtime/http/middleware/circuit_breaker.go::repanicAfterBreakerFailure": "re-panics from defer recover" +
 		" after reporting circuit-breaker failure",

--- a/tools/archtest/span_record_error_redact_test.go
+++ b/tools/archtest/span_record_error_redact_test.go
@@ -1,0 +1,240 @@
+// SPAN-RECORD-ERROR-REDACT-01 — every span.RecordError(...) call inside
+// kernel/wrapper/ and runtime/http/middleware/ must wrap its argument with
+// pkg/redaction.RedactError(...). Hardcoded fail-closed redaction has no
+// caller-side opt-out (see ADR §8); this gate ensures future additions of
+// `RecordError` do not silently bypass the redactor.
+//
+// Detection (pure AST, no go/types — scope is two directories, three known
+// call sites; loader cost is unwarranted):
+//  1. Walk every non-test .go file in the two directories.
+//  2. For each file, locate the import path `github.com/ghbvf/gocell/pkg/redaction`
+//     and record its local name (default `redaction`, or alias).
+//  3. Find every `*ast.CallExpr` whose Fun is a `*ast.SelectorExpr` with
+//     `Sel.Name == "RecordError"`.
+//  4. Assert the first argument is a `*ast.CallExpr` whose Fun is a
+//     `*ast.SelectorExpr` with `X.(*ast.Ident).Name == <redaction local name>`
+//     and `Sel.Name == "RedactError"`.
+//
+// Test files are skipped — spy/mock spans in *_test.go intentionally inspect
+// raw error values and have no observability surface.
+//
+// ref: ADR docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md §8
+// ref: docs/backlog1.md §2.1 SPAN-RECORD-ERROR-REDACT-ARCHTEST-01
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const redactionImportPath = `"github.com/ghbvf/gocell/pkg/redaction"`
+
+// spanRecordErrorScanDirs lists the directories whose non-test .go files
+// must route every RecordError call through redaction.RedactError.
+//
+// New directories should be added here whenever a new package starts
+// emitting span.RecordError on a production code path.
+var spanRecordErrorScanDirs = []string{
+	"kernel/wrapper",
+	"runtime/http/middleware",
+}
+
+// redactionLocalName returns the local identifier used in file to refer to
+// the redaction package (default "redaction" for an unnamed import; alias
+// otherwise). Returns "" when the file does not import pkg/redaction at all
+// — in that case any RecordError call is automatically a violation, since
+// it cannot possibly invoke redaction.RedactError.
+func redactionLocalName(file *ast.File) string {
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		if imp.Path.Value != redactionImportPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		return "redaction"
+	}
+	return ""
+}
+
+// isRedactErrorCall reports whether expr is a call of the form
+// `<redactionLocal>.RedactError(...)`.
+func isRedactErrorCall(expr ast.Expr, redactionLocal string) bool {
+	if redactionLocal == "" {
+		return false
+	}
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	if sel.Sel == nil || sel.Sel.Name != "RedactError" {
+		return false
+	}
+	xIdent, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return xIdent.Name == redactionLocal
+}
+
+// scanSpanRecordErrorFile walks file and reports every `*.RecordError(...)`
+// call whose first argument is not `<redaction>.RedactError(...)`.
+func scanSpanRecordErrorFile(fset *token.FileSet, file *ast.File, rel string) []string {
+	redactionLocal := redactionLocalName(file)
+
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "RecordError" {
+			return true
+		}
+		// Bare `RecordError()` with no arg — only legal in tests; in prod
+		// code this is structurally wrong (RecordError requires error arg).
+		if len(call.Args) == 0 {
+			return true
+		}
+		if isRedactErrorCall(call.Args[0], redactionLocal) {
+			return true
+		}
+		line := fset.Position(call.Pos()).Line
+		out = append(out, fmt.Sprintf(
+			"%s:%d: span.RecordError(...) first arg must be redaction.RedactError(...) "+
+				"— hardcoded fail-closed redaction has no caller-side opt-out (ADR §8)",
+			rel, line))
+		return true
+	})
+	return out
+}
+
+// scanSpanRecordErrorDir walks every non-test .go file under root/dir and
+// returns SPAN-RECORD-ERROR-REDACT-01 violations.
+func scanSpanRecordErrorDir(t *testing.T, root, dir string) []string {
+	t.Helper()
+	abs := filepath.Join(root, dir)
+	var out []string
+
+	err := filepath.WalkDir(abs, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		out = append(out, scanSpanRecordErrorFile(fset, file, rel)...)
+		return nil
+	})
+	require.NoError(t, err, "walk %s", abs)
+	return out
+}
+
+// TestSpanRecordErrorRedacted enforces SPAN-RECORD-ERROR-REDACT-01.
+func TestSpanRecordErrorRedacted(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	var violations []string
+	for _, dir := range spanRecordErrorScanDirs {
+		violations = append(violations, scanSpanRecordErrorDir(t, root, dir)...)
+	}
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Log(v)
+	}
+	assert.Empty(t, violations,
+		"SPAN-RECORD-ERROR-REDACT-01: every span.RecordError(...) call in "+
+			"kernel/wrapper/ and runtime/http/middleware/ must wrap its first "+
+			"argument with pkg/redaction.RedactError(...). "+
+			"ref: docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md §8")
+}
+
+// runSpanRecordErrorFixtureScan parses fixture .go files (non-test, no module
+// load) and reports violations relative to fixtureDir.
+func runSpanRecordErrorFixtureScan(t *testing.T, fixtureDir string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(fixtureDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		rel, relErr := filepath.Rel(fixtureDir, path)
+		if relErr != nil {
+			rel = path
+		}
+		out = append(out, scanSpanRecordErrorFile(fset, file, rel)...)
+		return nil
+	})
+	require.NoError(t, err, "walk fixture %s", fixtureDir)
+	sort.Strings(out)
+	return out
+}
+
+// TestSpanRecordErrorRedactedFixtures verifies the AST scanner via static
+// regression cases (compliant: 0 violations, violates: 1 violation).
+func TestSpanRecordErrorRedactedFixtures(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	base := filepath.Join(root, "tools", "archtest", "testdata", "span_record_error_fixtures")
+
+	cases := []struct {
+		pkg           string
+		wantViolCount int
+	}{
+		{"compliant", 0},
+		{"violates", 1},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.pkg, func(t *testing.T) {
+			t.Parallel()
+			got := runSpanRecordErrorFixtureScan(t, filepath.Join(base, tc.pkg))
+			assert.Equal(t, tc.wantViolCount, len(got),
+				"fixture %s: expected %d violation(s), got %d: %v",
+				tc.pkg, tc.wantViolCount, len(got), got)
+		})
+	}
+}

--- a/tools/archtest/testdata/span_record_error_fixtures/compliant/recorder.go
+++ b/tools/archtest/testdata/span_record_error_fixtures/compliant/recorder.go
@@ -1,0 +1,23 @@
+// Package compliant is a fixture for SPAN-RECORD-ERROR-REDACT-01 positive
+// case: every span.RecordError call wraps its argument with
+// redaction.RedactError. Parsed by archtest; not intended to compile.
+package compliant
+
+import "github.com/ghbvf/gocell/pkg/redaction"
+
+// Span mirrors the wrapper.Span shape used by archtest fixture scanning.
+type Span interface {
+	RecordError(error)
+}
+
+// RecordWithRedaction is the canonical compliant pattern.
+func RecordWithRedaction(span Span, err error) {
+	span.RecordError(redaction.RedactError(err))
+}
+
+// RecordWithRedactionAndOtherCall verifies the scanner only flags the
+// RecordError call site, not unrelated calls in the same function.
+func RecordWithRedactionAndOtherCall(span Span, err error) {
+	_ = err.Error()
+	span.RecordError(redaction.RedactError(err))
+}

--- a/tools/archtest/testdata/span_record_error_fixtures/violates/recorder.go
+++ b/tools/archtest/testdata/span_record_error_fixtures/violates/recorder.go
@@ -1,0 +1,17 @@
+// Package violates is a fixture for SPAN-RECORD-ERROR-REDACT-01 negative
+// case: span.RecordError is called with a raw error (no redaction wrap),
+// which the scanner must report as a violation. Parsed by archtest; not
+// intended to compile.
+package violates
+
+// Span mirrors the wrapper.Span shape used by archtest fixture scanning.
+type Span interface {
+	RecordError(error)
+}
+
+// RecordRaw is the canonical violation pattern: span.RecordError(err)
+// without redaction.RedactError wrapping. Bypasses the fail-closed
+// redaction guarantee documented in ADR §8.
+func RecordRaw(span Span, err error) {
+	span.RecordError(err)
+}


### PR DESCRIPTION
## Summary

`kernel/wrapper.WrapConsumer` 与 `runtime/http/middleware.Recovery` 改为默认硬编通过 `pkg/redaction.RedactError` 脱敏所有写入 `span.RecordError` 的 error 文本，**删除整条调用方 opt-out wiring**：`ErrorRedactor` 类型、`WithConsumerErrorRedactor` / `bootstrap.WithErrorRedactor` / `middleware.WithErrorRedactor` 三个 option、`Bootstrap.errorRedactor` 字段、`ContractTracingMiddleware` 第 2 参数。

`grep -r WithConsumerErrorRedactor` 在删除前为零业务调用方——整条 wiring 仅保护一条 default 路径。

## Why fail-closed default

参照 fail-closed redaction by default 的范式（**非** OTel/Kratos/Watermill 主流 fail-open 范式）：

- **HashiCorp Vault** `audit/entry_formatter.go`：`log_raw=false` 硬编默认，opt-out 仅由操作员 config 提供（非调用方 API）
- **Go stdlib** `net/url/url.go URL.Redacted()`：硬编 `xxxxx` 替换，**无任何 opt-out**
- **GoCell 决策**：cell-native 底座不能假设下游一定有 OTel collector redactionprocessor，最近端硬编是防御深度的最优位置

## Changes

| 文件 | 改动 |
|------|------|
| `pkg/redaction/redaction.go`（新建） | `RedactString` / `RedactError` / `TruncateString` + 3 段 regex 模式（authorization 行级 / connection_string 不停在 `;` / default 单词边界） |
| `pkg/redaction/redaction_test.go`（新建） | 30+ table-driven 用例覆盖单字段 / 多字段 / case-insensitive / unicode / 真实泄漏断言 |
| `kernel/wrapper/consumer.go` | 删 `ErrorRedactor` / `ConsumerOption` / `consumerConfig` / `WithConsumerErrorRedactor` / `identityRedactor`；`WrapConsumer` 签名简化（无 opts）；`recordErr` 硬编 `redaction.RedactError` |
| `kernel/wrapper/lifecycle.go` | `recoverAndFinishWithRedactor` → `recoverAndFinish`，硬编 redaction |
| `runtime/eventrouter/contract_middleware.go` | `ContractTracingMiddleware(tr, redactor)` → `ContractTracingMiddleware(tr)` |
| `runtime/bootstrap/bootstrap.go` | 删 `errorRedactor` 字段 + `wrapper` import |
| `runtime/bootstrap/options_http.go` | 删 `WithErrorRedactor` option |
| `runtime/bootstrap/phases_events.go` | 适配 `ContractTracingMiddleware` 单参 |
| `runtime/http/middleware/tracing.go` | 删 `WithErrorRedactor` / `tracingConfig.errorRedactor` / `spanErrorRecorder.redactor`；`recordPanicOnActiveSpan` 硬编 redaction |
| `runtime/outbox/errors.go` | `SanitizeError` 改用 `pkg/redaction`（消除重复 regex） |
| ADR `202604242030-adr-kernel-wrapper-contract-observability.md` §8 | 重写：fail-closed default + 删 wiring 决策 |
| ADR `202604270030-architectural-panic-whitelist.md` | 更名 panic 白名单条目 |
| `.claude/rules/gocell/observability.md` | 加 "Span Error Redaction" 节 |
| 测试 + archtest | 删 `WithConsumerErrorRedactor` 测试场景；新增 fail-closed 默认行为断言 |

净 delta: **-198 / +189 LOC**（不含 pkg/redaction 新增）。

## 字段集

```
password | passwd | pwd | secret | token | api[_-]?key | authorization | bearer
private[_-]?key | signing[_-]?key | dsn | connection[_ ]?string
```

`[_-]?` 覆盖横线变体（api-key / private-key），`connection[_ ]?string` 覆盖下划线/空格分隔，`pwd` 覆盖 SQL Server / ODBC 风格连接字符串。

## Refs

- A3 / 027 PR-SEC-1 / backlog1 §2.1 SEC-WRAPPER-REDACTOR-DEFAULT-01

ref: hashicorp/vault audit/entry_formatter.go (log_raw=false default, no caller API opt-out)
ref: golang/go src/net/url/url.go URL.Redacted() (hardcoded mask, no opt-out)
ref: cockroachdb/redact (SafeValue marker, future direction, not in scope)

## Test plan

- [x] `go test ./pkg/redaction/...` — 30+ table-driven cases pass
- [x] `go test ./kernel/wrapper/...` — 默认脱敏断言 + 现有测试全过
- [x] `go test ./runtime/eventrouter/...` `./runtime/http/middleware/...` `./runtime/bootstrap/...` `./runtime/outbox/...` — wiring 删除后全过
- [x] `go test ./tools/archtest/...` — PANIC-REGISTERED-01 / ERROR-FIRST-API-01 panic 白名单同步更新
- [x] `go test ./...` — 全仓 0 FAIL
- [x] `golangci-lint run ./...` — 0 issues
- [x] `grep -r ErrorRedactor\\|WithErrorRedactor` Go 代码层零残留（仅文档说明已删除 API 时引用）
- [x] 行为断言：`password=hunter2` / `Authorization: Bearer abc.def.ghi` / `dsn=postgres://USR:PWD@h/db` 输出含 `<REDACTED>`，**不**含原值

🤖 Generated with [Claude Code](https://claude.com/claude-code)