### PR TITLE
refactor(http): drop go-chi/chi for stdlib net/http (Go 1.25)

### DIFF
--- a/.claude/rules/gocell/runtime-api.md
+++ b/.claude/rules/gocell/runtime-api.md
@@ -12,9 +12,9 @@ paths:
 
 每个 Cell 在 `Init(ctx, reg)` 中通过 `reg.RouteGroup(...)` 声明路由组。
 每个路由组指定目标 listener、URL 前缀、以及注册回调（`Register func(mux cell.RouteMux) error` — PR-MODE-6: error-first 链路，phase5 把 Register 的错误连同 cell+listener+prefix 上下文 wrap 后冒泡到 `Bootstrap.Run`）。
-Bootstrap 在 phase5 drain 所有 `RegistrySnapshot.RouteGroups` 并挂载到对应 listener 的 chi.Mux 上。
+Bootstrap 在 phase5 drain 所有 `RegistrySnapshot.RouteGroups` 并挂载到对应 listener 的 stdlib `*http.ServeMux` 上。
 
-每条业务路由通过 `auth.Mount(mux, auth.Route{...})` 注册（**不是** `auth.Declare`/`auth.RouteDecl` —— 这两个旧符号已删除）。`auth.Route.Contract` 是 `wrapper.ContractSpec`，承载 method+path+contract id；Mount 自动 strip listener prefix、注册 chi handler、转发 AuthRouteMeta 给 FinalizeAuth。Mount 返回 `error`（PR-MODE-6 ERROR-FIRST-API）；`auth.MustMount` 是 composition-root fail-fast 包装，但 **slice handler 内部应直接用 `auth.Mount` + 错误传播**，让错误一路冒泡到 phase5。
+每条业务路由通过 `auth.Mount(mux, auth.Route{...})` 注册（**不是** `auth.Declare`/`auth.RouteDecl` —— 这两个旧符号已删除）。`auth.Route.Contract` 是 `wrapper.ContractSpec`，承载 method+path+contract id；Mount 自动 strip listener prefix、注册 ServeMux handler（`METHOD /path` 形式）、转发 AuthRouteMeta 给 FinalizeAuth。Mount 返回 `error`（PR-MODE-6 ERROR-FIRST-API）；`auth.MustMount` 是 composition-root fail-fast 包装，但 **slice handler 内部应直接用 `auth.Mount` + 错误传播**，让错误一路冒泡到 phase5。
 
 ```go
 // Slice handler — RegisterRoutes 返回 error，使用 auth.Mount + 错误传播
@@ -182,7 +182,7 @@ bootstrap.WithListener(WebhookListener, ":8090",
 
 ### 三 listener 分流（PR-A14b）
 
-Bootstrap 为每个声明的 listener 构建独立的 `*router.Router`（内含独立 chi.Mux）：
+Bootstrap 为每个声明的 listener 构建独立的 `*router.Router`（内含独立 `*http.ServeMux`）：
 
 - **primary**：挂 `/api/v1/*` 业务路由；JWT AuthMiddleware（来自 `[]cell.ListenerAuth` 中的 AuthJWT/AuthJWTFromAssembly）。primary listener 显式 404 所有 `/internal/v1/*` 请求，实现端口级物理隔离。
 - **internal**：仅挂 `/internal/v1/*` 路由；AuthServiceToken / AuthMTLS 策略，无 JWT 中间件。

--- a/docs/design/capability-inventory.md
+++ b/docs/design/capability-inventory.md
@@ -112,7 +112,7 @@
 - 实现 `outbox.Publisher` + `outbox.Subscriber`
 
 ### 3.5 http/router — HTTP 路由
-- chi-based `Router` — Handle/Route/Mount/Group
+- stdlib `net/http.ServeMux`-based `Router` — Handle/Route/Mount/Group
 - 实现 `cell.RouteMux` 接口
 
 ### 3.6 http/health — 健康检查
@@ -321,7 +321,6 @@ Adapters: internal/mem + internal/adapters/postgres (ConfigRepository PG)
 ### 外部依赖（直接）
 | 依赖 | 用途 |
 |------|------|
-| go-chi/chi/v5 | HTTP 路由 |
 | golang-jwt/jwt/v5 | JWT 签发/验证 |
 | jackc/pgx/v5 | PostgreSQL 驱动 |
 | redis/go-redis/v9 | Redis 客户端 |

--- a/docs/design/master-plan.md
+++ b/docs/design/master-plan.md
@@ -292,7 +292,7 @@ runtime/
 │   ├── middleware/         # request_id / real_ip / recovery / access_log /
 │   │                      # security_headers / body_limit / rate_limit
 │   ├── health/            # liveness + readiness
-│   └── router/            # chi-based
+│   └── router/            # stdlib net/http.ServeMux-based
 ├── auth/
 │   ├── jwt/               # RS256 钉扎
 │   ├── servicetoken/      # 服务间认证

--- a/docs/ops/listener-topology.md
+++ b/docs/ops/listener-topology.md
@@ -1,8 +1,8 @@
 # GoCell Three-Listener Topology (PR-A14b / PR262)
 
 GoCell runs three independent HTTP listeners. Each listener has a dedicated
-`chi.Mux` root and a typed `[]cell.ListenerAuth` chain — no route leaks between
-ports, no string-based auth dispatch.
+stdlib `*http.ServeMux` root and a typed `[]cell.ListenerAuth` chain — no
+route leaks between ports, no string-based auth dispatch.
 
 ## Topology Diagram
 

--- a/docs/references/framework-comparison.md
+++ b/docs/references/framework-comparison.md
@@ -60,7 +60,7 @@ goal:      slice.yaml 归属/职责/约束声明参考 Container spec；gocell v
 ```
 primary:   go-kratos/kratos    → middleware/（链式组合、transport 抽象）
 secondary: zeromicro/go-zero   → rest/handler/（内置中间件集）
-goal:      chi-based，但参考 Kratos 的 middleware.Handler 签名设计
+goal:      stdlib net/http.ServeMux + 自实现 chain helper，参考 Kratos 的 middleware.Handler 签名设计
 ```
 
 ### runtime/config/ — 配置加载 + 热更新
@@ -156,7 +156,7 @@ ref PR: PR-A20（AL-02 DISTLOCK-RUNTIME-ABSTRACT-01，refactor/531）；
 | adapters/postgres | `jackc/pgx/v5` | `jackc/pgx` | 连接池、事务隔离、pgxpool 生命周期 |
 | adapters/redis | `redis/go-redis/v9` | `redis/go-redis` | Pipeline/Tx、Pub/Sub 重连 |
 | adapters/rabbitmq | `rabbitmq/amqp091-go` | `rabbitmq/amqp091-go` | Channel 不跨 goroutine、重连、Confirm |
-| runtime/http | `go-chi/chi/v5` | `go-chi/chi` | 中间件顺序、RouteContext |
+| runtime/http | stdlib `net/http.ServeMux` (Go 1.22+) | — (no third-party router) | 中间件顺序、route-pattern recorder（mux.Handler + ServeHTTP 双 pass） |
 | runtime/auth/jwt | `golang-jwt/jwt/v5` | `golang-jwt/jwt` | SigningMethod、Claims、kid |
 | adapters/oidc | `coreos/go-oidc/v3` | `coreos/go-oidc` | Provider 缓存、JWKS 刷新 |
 | adapters/s3 | `aws/aws-sdk-go-v2` | `aws/aws-sdk-go-v2` | Retry、Context 超时 |

--- a/examples/todoorder/cells/ordercell/slices/orderquery/contract_test.go
+++ b/examples/todoorder/cells/ordercell/slices/orderquery/contract_test.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/go-chi/chi/v5"
 
 	"github.com/ghbvf/gocell/examples/todoorder/cells/ordercell/internal/domain"
 	"github.com/ghbvf/gocell/examples/todoorder/cells/ordercell/internal/mem"
@@ -43,13 +42,14 @@ func TestHttpOrderGetV1Serve(t *testing.T) {
 	})
 	h := getv1.NewHandler(svc, nil)
 
-	// chi.URLParam relies on chi route context; tests must mount through chi.NewRouter().
-	r := chi.NewRouter()
-	r.Get("/api/v1/orders/{id}", h.ServeHTTP)
+	// r.PathValue relies on stdlib ServeMux pattern routing; mount through
+	// http.NewServeMux so the {id} placeholder is populated.
+	mux := http.NewServeMux()
+	mux.Handle(c.HTTP.Method+" "+c.HTTP.Path, h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, strings.Replace(c.HTTP.Path, "{id}", "ord-contract-get", 1), nil)
-	r.ServeHTTP(rec, req)
+	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 }
 

--- a/generated/contracts/http/order/get/v1/handler_gen.go
+++ b/generated/contracts/http/order/get/v1/handler_gen.go
@@ -6,8 +6,6 @@ package get
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -54,7 +52,7 @@ func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	req := &Request{}
 	{
-		v := chi.URLParam(r, "id")
+		v := r.PathValue("id")
 		if len(v) < 1 {
 			httputil.WriteDomainError(r.Context(), w, errcode.New(errcode.ErrValidationFailed, "id: value too short"))
 			return

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/fsnotify/fsnotify v1.10.0
-	github.com/go-chi/chi/v5 v5.2.5
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
 github.com/fsnotify/fsnotify v1.10.0/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
-github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
-github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -36,7 +36,7 @@ import (
 // router, and finalizes auth on the primary router.
 //
 // PR-A14b: replaces the single-router phase5BuildHTTPRouter. Each listener
-// now gets its own chi.Mux root with a policy applied at build time.
+// now gets its own stdlib *http.ServeMux root with a policy applied at build time.
 //
 // ref: go-kratos/kratos app.go — per-server middleware at build time.
 func (b *Bootstrap) phase5BuildRouters(ctx context.Context, s *phaseState) error {

--- a/runtime/http/middleware/access_log.go
+++ b/runtime/http/middleware/access_log.go
@@ -60,7 +60,7 @@ func logAccessRequest(start time.Time, r *http.Request, state *RecorderState, cl
 	// from user-controlled request data into structured log calls.
 	method := logutil.Sanitize(r.Method)
 	path := logutil.Sanitize(r.URL.Path)
-	route := RoutePatternFromCtx(r.Context())
+	route := RouteFor(r.Context(), r.Method, r.URL.Path)
 	ctx := r.Context()
 	safeObserve(slog.Default(), func() {
 		slog.Info("http request", accessLogAttrs(start, method, path, route, state, ctx, clk)...)

--- a/runtime/http/middleware/metrics.go
+++ b/runtime/http/middleware/metrics.go
@@ -3,33 +3,11 @@ package middleware
 import (
 	"log/slog"
 	"net/http"
-	"strings"
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
-
-// RoutePatternResolver maps a concrete request to a low-cardinality route
-// pattern when chi did not reach a matched endpoint handler.
-type RoutePatternResolver func(method, path string) (string, bool)
-
-// MetricsOption configures the Metrics middleware.
-type MetricsOption func(*metricsConfig)
-
-type metricsConfig struct {
-	routeResolver RoutePatternResolver
-}
-
-// WithRoutePatternResolver installs a fallback route resolver for pre-handler
-// rejects such as auth, rate-limit, circuit-breaker, body-limit, and 405.
-func WithRoutePatternResolver(fn RoutePatternResolver) MetricsOption {
-	return func(c *metricsConfig) {
-		if fn != nil {
-			c.routeResolver = fn
-		}
-	}
-}
 
 // Metrics returns an HTTP middleware that records request count and duration
 // using the provided Collector. A clock must be provided; use clock.Real() at
@@ -43,17 +21,19 @@ func WithRoutePatternResolver(fn RoutePatternResolver) MetricsOption {
 // Router-owned root attribution installs that key before short-circuiting
 // protection middleware. Absence means framework/runtime traffic and records
 // as RuntimeCellIDSentinel.
-func Metrics(collector metrics.Collector, clk clock.Clock, opts ...MetricsOption) func(http.Handler) http.Handler {
-	return metricsWithClock(collector, clk, opts...)
+//
+// Route label resolution uses RouteFor, which reads the dispatch-time
+// recorder first and then falls back to the RouteResolver injected by the
+// router via WithRouteResolver. This means Metrics, AccessLog, and Tracing
+// all see the same route label even on reject paths (auth, rate limit,
+// circuit breaker, body limit, 405).
+func Metrics(collector metrics.Collector, clk clock.Clock) func(http.Handler) http.Handler {
+	return metricsWithClock(collector, clk)
 }
 
 // metricsWithClock is the clock-injectable variant used by Metrics and tests.
-func metricsWithClock(collector metrics.Collector, clk clock.Clock, opts ...MetricsOption) func(http.Handler) http.Handler {
+func metricsWithClock(collector metrics.Collector, clk clock.Clock) func(http.Handler) http.Handler {
 	clock.MustHaveClock(clk, "middleware.Metrics")
-	var cfg metricsConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := clk.Now()
@@ -68,7 +48,7 @@ func metricsWithClock(collector metrics.Collector, clk clock.Clock, opts ...Metr
 			next.ServeHTTP(w, r)
 
 			safeObserve(slog.Default(), func() {
-				route := finalMetricsRoute(r, cfg)
+				route := RouteFor(r.Context(), r.Method, r.URL.Path)
 				cellID := RuntimeCellIDSentinel
 				if v, ok := ctxkeys.CellIDFrom(r.Context()); ok && v != "" {
 					cellID = v
@@ -77,17 +57,4 @@ func metricsWithClock(collector metrics.Collector, clk clock.Clock, opts ...Metr
 			})
 		})
 	}
-}
-
-func finalMetricsRoute(r *http.Request, cfg metricsConfig) string {
-	route := RoutePatternFromCtx(r.Context())
-	if cfg.routeResolver == nil {
-		return route
-	}
-	if resolved, ok := cfg.routeResolver(r.Method, r.URL.Path); ok && resolved != "" {
-		if route == "unmatched" || strings.HasSuffix(route, "/*") {
-			return resolved
-		}
-	}
-	return route
 }

--- a/runtime/http/middleware/metrics_test.go
+++ b/runtime/http/middleware/metrics_test.go
@@ -85,16 +85,27 @@ func TestMetrics_Standalone(t *testing.T) {
 }
 
 func TestMetrics_RouteResolverFallback(t *testing.T) {
+	// RouteFor falls back to the RouteResolver injected via WithRouteResolver,
+	// so Metrics sees the template pattern even on reject paths (no dispatch
+	// recorder populated). The resolver is injected into the request context
+	// before the Metrics middleware runs — mirroring what the router does via
+	// patternRecorderMiddleware + WithRouteResolver.
 	c := metrics.NewInMemoryCollector()
-	handler := Metrics(c, clock.Real(), WithRoutePatternResolver(func(method, path string) (string, bool) {
+	resolver := RouteResolver(func(method, path string) (string, bool) {
 		assert.Equal(t, http.MethodGet, method)
 		assert.Equal(t, "/api/v1/access/users/42", path)
 		return "/api/v1/access/users/{id}", true
-	}))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	})
+	handler := Metrics(c, clock.Real())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/access/users/42", nil)
+	// Inject resolver into context (simulates what the router does).
+	ctx := WithRoutePatternRecorder(req.Context())
+	ctx = WithRouteResolver(ctx, resolver)
+	req = req.WithContext(ctx)
+
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/runtime/http/middleware/metrics_test.go
+++ b/runtime/http/middleware/metrics_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -124,31 +123,34 @@ func TestMetrics_MultipleRequests(t *testing.T) {
 func TestMetrics_ReadsCellIDFromContext(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
-	r := chi.NewRouter()
-	r.Use(
-		Recorder,
-		CellAttribution(func(_, path string) (string, bool) {
-			switch path {
-			case "/api/v1/users/42":
-				return "accesscore", true
-			case "/api/v1/audit/99":
-				return "auditcore", true
-			default:
-				return "", false
-			}
-		}),
-		Metrics(c, clock.Real()),
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{
+			Recorder,
+			CellAttribution(func(_, path string) (string, bool) {
+				switch path {
+				case "/api/v1/users/42":
+					return "accesscore", true
+				case "/api/v1/audit/99":
+					return "auditcore", true
+				default:
+					return "", false
+				}
+			}),
+			Metrics(c, clock.Real()),
+		},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /api/v1/users/{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			mux.Handle("GET /api/v1/audit/{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			// One unmatched request — falls through with the sentinel.
+			mux.Handle("GET /orphan-but-matched", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
 	)
-	r.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	r.Get("/api/v1/audit/{id}", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	// One unmatched request — falls through with the sentinel.
-	r.Get("/orphan-but-matched", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
 
 	for _, tc := range []struct{ method, path string }{
 		{http.MethodGet, "/api/v1/users/42"},
@@ -157,7 +159,7 @@ func TestMetrics_ReadsCellIDFromContext(t *testing.T) {
 		{http.MethodGet, "/totally-missing"},
 	} {
 		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+		handler.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
 	}
 
 	snap := c.Snapshot()
@@ -172,31 +174,34 @@ func TestMetrics_ReadsCellIDFromContext(t *testing.T) {
 	}
 }
 
-// --- Chi-integrated tests (route pattern extraction) ---
+// --- Mux-integrated tests (route pattern extraction) ---
 
 func TestMetrics_RoutePatternCollapse(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
-	r := chi.NewRouter()
-	r.Use(
-		Recorder,
-		CellAttribution(func(_, path string) (string, bool) {
-			if path != "" {
-				return "test-cell", true
-			}
-			return "", false
-		}),
-		Metrics(c, clock.Real()),
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{
+			Recorder,
+			CellAttribution(func(_, path string) (string, bool) {
+				if path != "" {
+					return "test-cell", true
+				}
+				return "", false
+			}),
+			Metrics(c, clock.Real()),
+		},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /api/v1/users/{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
 	)
-	r.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
 
 	// Hit with different path parameters — all should collapse to one metric key.
 	for _, id := range []string{"1", "2", "100", "abc"} {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+id, nil)
 		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
+		handler.ServeHTTP(rec, req)
 		assert.Equal(t, http.StatusOK, rec.Code)
 	}
 
@@ -211,18 +216,21 @@ func TestMetrics_RoutePatternCollapse(t *testing.T) {
 func TestMetrics_UnmatchedRouteUsesSentinel(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
-	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
-	r.Get("/exists", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{Recorder, Metrics(c, clock.Real())},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /exists", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
+	)
 
 	// Hit random 404 paths — all should collapse to "unmatched" under
 	// cell="_runtime" (no root attribution resolved a cell).
 	for _, path := range []string{"/random1", "/random2", "/attack-path"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
+		handler.ServeHTTP(rec, req)
 	}
 
 	snap := c.Snapshot()
@@ -231,47 +239,53 @@ func TestMetrics_UnmatchedRouteUsesSentinel(t *testing.T) {
 		"unmatched routes must all map to sentinel 'unmatched' label under cell=_runtime")
 }
 
-func TestMetrics_ChiStaticRoute(t *testing.T) {
+func TestMetrics_StaticRoute(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
-	r := chi.NewRouter()
-	r.Use(Recorder, Metrics(c, clock.Real()))
-	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{Recorder, Metrics(c, clock.Real())},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /healthz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
+	)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
 	key := requestKey("_runtime", http.MethodGet, "/healthz", http.StatusOK)
 	assert.Equal(t, int64(1), snap.RequestCounts[key])
 }
 
-func TestMetrics_ChiNestedRoutes(t *testing.T) {
+func TestMetrics_NestedRoutes(t *testing.T) {
 	c := metrics.NewInMemoryCollector()
 
-	r := chi.NewRouter()
-	r.Use(
-		Recorder,
-		CellAttribution(func(_, path string) (string, bool) {
-			if path != "" {
-				return "test-cell", true
-			}
-			return "", false
-		}),
-		Metrics(c, clock.Real()),
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{
+			Recorder,
+			CellAttribution(func(_, path string) (string, bool) {
+				if path != "" {
+					return "test-cell", true
+				}
+				return "", false
+			}),
+			Metrics(c, clock.Real()),
+		},
+		func(mux *http.ServeMux) {
+			// stdlib ServeMux uses fully-qualified patterns; nesting collapses
+			// to a single pattern at registration time.
+			mux.Handle("GET /api/v1/orders/{orderID}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
 	)
-	r.Route("/api/v1", func(r chi.Router) {
-		r.Get("/orders/{orderID}", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
-	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/42", nil)
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	snap := c.Snapshot()
 	key := requestKey("test-cell", http.MethodGet, "/api/v1/orders/{orderID}", http.StatusOK)

--- a/runtime/http/middleware/route_pattern.go
+++ b/runtime/http/middleware/route_pattern.go
@@ -1,3 +1,20 @@
+// route_pattern.go shares a request-scoped *patternRecorder between
+// runtime/http/router (which writes the matched ServeMux pattern via
+// RecordRoutePattern in the dispatch wrapper) and observability middleware
+// (which reads it through RoutePatternFromCtx after next.ServeHTTP returns).
+//
+// The recorder lives in this package — not in router/ — for two reasons:
+//  1. Tracing / AccessLog / Metrics already live here and read the value;
+//     keeping the accessor next to the readers avoids an import cycle that
+//     would otherwise force router → middleware → router.
+//  2. The mutable-container-via-context shape is local to the observability
+//     contract; router only owns the writer (the dispatch wrapper) and is
+//     free to evolve independently.
+//
+// Recorder writes happen exactly once per request inside the router's
+// patternRecordingMux; reads happen many times (one per observing
+// middleware) but always after dispatch has returned, so no synchronization
+// is required.
 package middleware
 
 import "context"

--- a/runtime/http/middleware/route_pattern.go
+++ b/runtime/http/middleware/route_pattern.go
@@ -1,7 +1,7 @@
 // route_pattern.go shares a request-scoped *patternRecorder between
 // runtime/http/router (which writes the matched ServeMux pattern via
 // RecordRoutePattern in the dispatch wrapper) and observability middleware
-// (which reads it through RoutePatternFromCtx after next.ServeHTTP returns).
+// (which reads it through RouteFor after next.ServeHTTP returns).
 //
 // The recorder lives in this package — not in router/ — for two reasons:
 //  1. Tracing / AccessLog / Metrics already live here and read the value;
@@ -15,6 +15,12 @@
 // patternRecordingMux; reads happen many times (one per observing
 // middleware) but always after dispatch has returned, so no synchronization
 // is required.
+//
+// Short-circuit paths (auth reject, rate limit, circuit breaker, body limit,
+// 405) complete before patternRecordingMux runs, so the recorder is still
+// empty. The router injects a RouteResolver via WithRouteResolver so RouteFor
+// can fall back to it and all three observability layers (Metrics, AccessLog,
+// Tracing) see a consistent, non-"unmatched" label on those paths.
 package middleware
 
 import "context"
@@ -52,15 +58,51 @@ func RecordRoutePattern(ctx context.Context, pattern string) {
 	}
 }
 
-// RoutePatternFromCtx extracts the matched route pattern recorded for the
-// current request. Must be called AFTER next.ServeHTTP returns — the recorder
-// is populated only once dispatch has selected a registered handler.
+// RouteResolver maps a concrete (method, urlPath) to a low-cardinality route
+// pattern. Routers inject one via WithRouteResolver before the observability
+// middleware chain runs so RouteFor can recover the pattern on requests
+// rejected before dispatch (auth, rate limit, circuit breaker, body limit,
+// 405). Returns ok=false when the request does not match any registered route.
+type RouteResolver func(method, urlPath string) (pattern string, ok bool)
+
+type routeResolverKey struct{}
+
+// WithRouteResolver returns a copy of ctx carrying fn as the shared
+// router-supplied route resolver. Called once per request by the router root
+// before observability middleware runs.
+func WithRouteResolver(ctx context.Context, fn RouteResolver) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, routeResolverKey{}, fn)
+}
+
+// RouteResolverFrom retrieves the resolver installed by WithRouteResolver,
+// or nil when none is registered (e.g. a middleware unit test that builds
+// a chain without the router).
+func RouteResolverFrom(ctx context.Context) RouteResolver {
+	if fn, ok := ctx.Value(routeResolverKey{}).(RouteResolver); ok {
+		return fn
+	}
+	return nil
+}
+
+// RouteFor returns the matched route pattern for the current request. It reads
+// the dispatch-time recorder first, then falls back to the router-supplied
+// RouteResolver (typically populated for short-circuit rejections that returned
+// before patternRecordingMux ran). Returns UnmatchedRoute when neither source
+// produces a non-empty pattern.
 //
-// Returns UnmatchedRoute when no recorder is installed or the pattern is
-// empty (404 / unmatched requests).
-func RoutePatternFromCtx(ctx context.Context) string {
+// Tracing / AccessLog / Metrics share this single accessor so their route
+// labels stay consistent on reject paths.
+func RouteFor(ctx context.Context, method, urlPath string) string {
 	if rec, ok := ctx.Value(patternRecorderKey{}).(*patternRecorder); ok && rec.pattern != "" {
 		return rec.pattern
+	}
+	if resolver := RouteResolverFrom(ctx); resolver != nil {
+		if p, ok := resolver(method, urlPath); ok && p != "" {
+			return p
+		}
 	}
 	return UnmatchedRoute
 }

--- a/runtime/http/middleware/route_pattern.go
+++ b/runtime/http/middleware/route_pattern.go
@@ -1,43 +1,49 @@
 package middleware
 
-import (
-	"context"
+import "context"
 
-	"github.com/go-chi/chi/v5"
-)
-
-// UnmatchedRoute is the sentinel route label used when a request does not match
-// any registered route (e.g. 404). Using a fixed string prevents random paths
-// from creating unbounded metric/span cardinality.
+// UnmatchedRoute is the sentinel route label used when a request does not
+// match any registered route (e.g. 404). Using a fixed string prevents random
+// paths from creating unbounded metric/span cardinality.
 //
 // ref: slok/go-http-metrics — explicit handlerID pattern for 404 fallback
 const UnmatchedRoute = "unmatched"
 
-// RoutePatternFromCtx extracts the chi route pattern from ctx.
-// Must be called AFTER next.ServeHTTP() — chi only populates RoutePattern
-// during routing.
+// patternRecorder is a mutable container shared via request context. The
+// router's outermost middleware installs it (WithRoutePatternRecorder); the
+// router's innermost dispatch wrapper writes the matched ServeMux pattern
+// (RecordRoutePattern) before invoking the leaf handler. All middleware in
+// between can read the result after their next.ServeHTTP returns.
+type patternRecorder struct {
+	pattern string
+}
+
+type patternRecorderKey struct{}
+
+// WithRoutePatternRecorder returns a copy of ctx carrying a fresh, empty
+// recorder. Called once per request by the router root.
+func WithRoutePatternRecorder(ctx context.Context) context.Context {
+	return context.WithValue(ctx, patternRecorderKey{}, &patternRecorder{})
+}
+
+// RecordRoutePattern stores the matched ServeMux pattern in the recorder
+// previously installed by WithRoutePatternRecorder. No-op if no recorder is
+// present (e.g. unit tests that exercise a middleware without the router).
+func RecordRoutePattern(ctx context.Context, pattern string) {
+	if rec, ok := ctx.Value(patternRecorderKey{}).(*patternRecorder); ok {
+		rec.pattern = pattern
+	}
+}
+
+// RoutePatternFromCtx extracts the matched route pattern recorded for the
+// current request. Must be called AFTER next.ServeHTTP returns — the recorder
+// is populated only once dispatch has selected a registered handler.
 //
-// ADR: This function introduces a direct chi dependency into the middleware
-// package. This is a deliberate trade-off: chi.RouteContext is a shared
-// pointer set by the router before middleware executes, so the pattern is
-// only accessible through chi's context key. Moving this to router/ would
-// require an extra context key round-trip (router injects, middleware reads)
-// with no real decoupling benefit — the middleware package already lives
-// under runtime/http/ which is chi-specific. If GoCell ever swaps routers,
-// this single accessor is the only file that needs updating.
-//
-// Returns UnmatchedRoute when no chi routing context exists or the pattern
-// is empty (404 / unmatched requests).
-//
-// ref: go-chi/chi context.go — RoutePattern() joins RoutePatterns after routing
+// Returns UnmatchedRoute when no recorder is installed or the pattern is
+// empty (404 / unmatched requests).
 func RoutePatternFromCtx(ctx context.Context) string {
-	rctx := chi.RouteContext(ctx)
-	if rctx == nil {
-		return UnmatchedRoute
+	if rec, ok := ctx.Value(patternRecorderKey{}).(*patternRecorder); ok && rec.pattern != "" {
+		return rec.pattern
 	}
-	pattern := rctx.RoutePattern()
-	if pattern == "" {
-		return UnmatchedRoute
-	}
-	return pattern
+	return UnmatchedRoute
 }

--- a/runtime/http/middleware/route_pattern_helper_test.go
+++ b/runtime/http/middleware/route_pattern_helper_test.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// buildTestServer mirrors runtime/http/router.Router.Handler so middleware
+// tests can exercise route-pattern propagation without pulling in the router
+// package (and therefore avoid an import cycle). The composition is:
+//
+//	WithRoutePatternRecorder → mws (in order) → dispatchWithPatternRecording → mux
+//
+// Tests register handlers on mux using stdlib 1.22+ patterns
+// ("METHOD /path/{param}"); dispatchWithPatternRecording fills the recorder
+// so middleware reading RoutePatternFromCtx after next.ServeHTTP returns
+// observes the matched pattern.
+func buildTestServer(mws []func(http.Handler) http.Handler, register func(mux *http.ServeMux)) http.Handler {
+	mux := http.NewServeMux()
+	register(mux)
+
+	var inner http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, pattern := mux.Handler(r); pattern != "" {
+			if idx := strings.IndexByte(pattern, ' '); idx >= 0 {
+				pattern = pattern[idx+1:]
+			}
+			RecordRoutePattern(r.Context(), pattern)
+		}
+		mux.ServeHTTP(w, r)
+	})
+
+	for i := len(mws) - 1; i >= 0; i-- {
+		inner = mws[i](inner)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := WithRoutePatternRecorder(r.Context())
+		inner.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/runtime/http/middleware/route_pattern_test.go
+++ b/runtime/http/middleware/route_pattern_test.go
@@ -6,11 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRoutePattern_WithChiRouter(t *testing.T) {
+func TestRoutePattern_RecordedFromServeMux(t *testing.T) {
 	tests := []struct {
 		name        string
 		pattern     string
@@ -19,50 +18,45 @@ func TestRoutePattern_WithChiRouter(t *testing.T) {
 	}{
 		{
 			name:        "static path",
-			pattern:     "/api/v1/health",
+			pattern:     "GET /api/v1/health",
 			requestPath: "/api/v1/health",
 			wantRoute:   "/api/v1/health",
 		},
 		{
 			name:        "single param",
-			pattern:     "/api/v1/users/{id}",
+			pattern:     "GET /api/v1/users/{id}",
 			requestPath: "/api/v1/users/123",
 			wantRoute:   "/api/v1/users/{id}",
 		},
 		{
 			name:        "multiple params",
-			pattern:     "/api/v1/users/{userID}/posts/{postID}",
+			pattern:     "GET /api/v1/users/{userID}/posts/{postID}",
 			requestPath: "/api/v1/users/42/posts/99",
 			wantRoute:   "/api/v1/users/{userID}/posts/{postID}",
-		},
-		{
-			name:        "wildcard",
-			pattern:     "/files/*",
-			requestPath: "/files/a/b/c.txt",
-			wantRoute:   "/files/*",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// RoutePatternFromCtx only works when middleware is inside the chi
-			// router (via r.Use), because chi sets RouteContext on a request
-			// copy. This is the actual usage pattern in router.go.
 			var captured string
-			r := chi.NewRouter()
-			r.Use(func(next http.Handler) http.Handler {
+			capture := func(next http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 					next.ServeHTTP(w, req)
 					captured = RoutePatternFromCtx(req.Context())
 				})
-			})
-			r.Get(tt.pattern, func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			})
+			}
+			handler := buildTestServer(
+				[]func(http.Handler) http.Handler{capture},
+				func(mux *http.ServeMux) {
+					mux.Handle(tt.pattern, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusOK)
+					}))
+				},
+			)
 
 			req := httptest.NewRequest(http.MethodGet, tt.requestPath, nil)
 			rec := httptest.NewRecorder()
-			r.ServeHTTP(rec, req)
+			handler.ServeHTTP(rec, req)
 
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.Equal(t, tt.wantRoute, captured)
@@ -72,20 +66,24 @@ func TestRoutePattern_WithChiRouter(t *testing.T) {
 
 func TestRoutePattern_UnmatchedRoute(t *testing.T) {
 	var captured string
-	r := chi.NewRouter()
-	r.Use(func(next http.Handler) http.Handler {
+	capture := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			next.ServeHTTP(w, req)
 			captured = RoutePatternFromCtx(req.Context())
 		})
-	})
-	r.Get("/exists", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	}
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{capture},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /exists", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
+	)
 
 	req := httptest.NewRequest(http.MethodGet, "/does-not-exist", nil)
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, UnmatchedRoute, captured)
 }
@@ -95,27 +93,25 @@ func TestRoutePattern_NilContext(t *testing.T) {
 	assert.Equal(t, UnmatchedRoute, got)
 }
 
-func TestRoutePattern_MiddlewareInsideChiRouter(t *testing.T) {
-	// When middleware is registered via r.Use(), chi has already set
-	// RouteContext on the request before calling middleware. The RouteContext
-	// is a pointer, so RoutePatterns populated during routing are visible
-	// in the middleware after next.ServeHTTP().
+func TestRoutePattern_RecorderInstalledByOuterMiddleware(t *testing.T) {
+	// Regression test: without the outer pattern-recorder middleware, the
+	// dispatch wrapper has nowhere to write and middleware sees the
+	// sentinel — confirming the recorder is the single source of truth.
 	var captured string
-	r := chi.NewRouter()
-	r.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			next.ServeHTTP(w, req)
-			captured = RoutePatternFromCtx(req.Context())
-		})
-	})
-	r.Get("/api/v1/devices/{id}", func(w http.ResponseWriter, _ *http.Request) {
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/devices/{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
+	}))
+	bare := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mux.ServeHTTP(w, r)
+		captured = RoutePatternFromCtx(r.Context())
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices/abc", nil)
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, req)
+	bare.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "/api/v1/devices/{id}", captured)
+	assert.Equal(t, UnmatchedRoute, captured,
+		"without WithRoutePatternRecorder + dispatch wrapper, RoutePatternFromCtx returns sentinel")
 }

--- a/runtime/http/middleware/route_pattern_test.go
+++ b/runtime/http/middleware/route_pattern_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRoutePattern_RecordedFromServeMux(t *testing.T) {
+func TestRouteFor_RecordedFromServeMux(t *testing.T) {
 	tests := []struct {
 		name        string
 		pattern     string
@@ -42,7 +42,7 @@ func TestRoutePattern_RecordedFromServeMux(t *testing.T) {
 			capture := func(next http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 					next.ServeHTTP(w, req)
-					captured = RoutePatternFromCtx(req.Context())
+					captured = RouteFor(req.Context(), req.Method, req.URL.Path)
 				})
 			}
 			handler := buildTestServer(
@@ -64,12 +64,12 @@ func TestRoutePattern_RecordedFromServeMux(t *testing.T) {
 	}
 }
 
-func TestRoutePattern_UnmatchedRoute(t *testing.T) {
+func TestRouteFor_UnmatchedRoute(t *testing.T) {
 	var captured string
 	capture := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			next.ServeHTTP(w, req)
-			captured = RoutePatternFromCtx(req.Context())
+			captured = RouteFor(req.Context(), req.Method, req.URL.Path)
 		})
 	}
 	handler := buildTestServer(
@@ -88,12 +88,12 @@ func TestRoutePattern_UnmatchedRoute(t *testing.T) {
 	assert.Equal(t, UnmatchedRoute, captured)
 }
 
-func TestRoutePattern_NilContext(t *testing.T) {
-	got := RoutePatternFromCtx(context.Background())
+func TestRouteFor_NilContext(t *testing.T) {
+	got := RouteFor(context.Background(), http.MethodGet, "/any")
 	assert.Equal(t, UnmatchedRoute, got)
 }
 
-func TestRoutePattern_RecorderInstalledByOuterMiddleware(t *testing.T) {
+func TestRouteFor_RecorderInstalledByOuterMiddleware(t *testing.T) {
 	// Regression test: without the outer pattern-recorder middleware, the
 	// dispatch wrapper has nowhere to write and middleware sees the
 	// sentinel — confirming the recorder is the single source of truth.
@@ -104,7 +104,7 @@ func TestRoutePattern_RecorderInstalledByOuterMiddleware(t *testing.T) {
 	}))
 	bare := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mux.ServeHTTP(w, r)
-		captured = RoutePatternFromCtx(r.Context())
+		captured = RouteFor(r.Context(), r.Method, r.URL.Path)
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices/abc", nil)
@@ -113,5 +113,51 @@ func TestRoutePattern_RecorderInstalledByOuterMiddleware(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, UnmatchedRoute, captured,
-		"without WithRoutePatternRecorder + dispatch wrapper, RoutePatternFromCtx returns sentinel")
+		"without WithRoutePatternRecorder + dispatch wrapper, RouteFor returns sentinel")
+}
+
+func TestRouteFor_FallbackToRouteResolver(t *testing.T) {
+	// RouteFor must fall back to RouteResolver when the dispatch-time
+	// recorder has no pattern (short-circuit reject before dispatch).
+	resolver := RouteResolver(func(method, urlPath string) (string, bool) {
+		if method == http.MethodGet && urlPath == "/api/v1/users/42" {
+			return "/api/v1/users/{id}", true
+		}
+		return "", false
+	})
+
+	ctx := WithRoutePatternRecorder(context.Background())
+	ctx = WithRouteResolver(ctx, resolver)
+
+	// Recorder is empty (short-circuit happened before dispatch).
+	got := RouteFor(ctx, http.MethodGet, "/api/v1/users/42")
+	assert.Equal(t, "/api/v1/users/{id}", got,
+		"RouteFor must fall back to RouteResolver when recorder is empty")
+}
+
+func TestRouteFor_RecorderTakesPrecedenceOverResolver(t *testing.T) {
+	// The dispatch-time recorder value must take priority over the resolver.
+	resolver := RouteResolver(func(_, _ string) (string, bool) {
+		return "/wrong/pattern", true
+	})
+
+	ctx := WithRoutePatternRecorder(context.Background())
+	ctx = WithRouteResolver(ctx, resolver)
+	RecordRoutePattern(ctx, "/correct/pattern")
+
+	got := RouteFor(ctx, http.MethodGet, "/correct/123")
+	assert.Equal(t, "/correct/pattern", got,
+		"recorder value must take precedence over RouteResolver")
+}
+
+func TestRouteFor_ResolverReturnsUnmatchedWhenNoMatch(t *testing.T) {
+	resolver := RouteResolver(func(_, _ string) (string, bool) {
+		return "", false
+	})
+
+	ctx := WithRoutePatternRecorder(context.Background())
+	ctx = WithRouteResolver(ctx, resolver)
+
+	got := RouteFor(ctx, http.MethodGet, "/no-match")
+	assert.Equal(t, UnmatchedRoute, got)
 }

--- a/runtime/http/middleware/tracing.go
+++ b/runtime/http/middleware/tracing.go
@@ -267,7 +267,7 @@ func finalRouteAndContractAttrs(
 	carrier *wrapper.AttrCarrier,
 	cfg tracingConfig,
 ) (string, []wrapper.Attr) {
-	route := RoutePatternFromCtx(r.Context())
+	route := RouteFor(r.Context(), r.Method, r.URL.Path)
 	if len(carrier.Attrs) > 0 {
 		return route, carrier.Attrs
 	}

--- a/runtime/http/middleware/tracing_test.go
+++ b/runtime/http/middleware/tracing_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -212,17 +211,20 @@ func (st *spyTracer) Spans() []*spySpan {
 func TestTracing_SpanRenamedToRoutePattern(t *testing.T) {
 	spy := &spyTracer{}
 
-	r := chi.NewRouter()
-	r.Use(Tracing(spy))
-	r.Get("/api/v1/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{Tracing(spy)},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /api/v1/users/{id}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
+	)
 
 	// Hit with different IDs — all spans should be renamed to the route pattern.
 	for _, id := range []string{"1", "42", "abc"} {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/"+id, nil)
 		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
+		handler.ServeHTTP(rec, req)
 		assert.Equal(t, http.StatusOK, rec.Code)
 	}
 
@@ -239,15 +241,18 @@ func TestTracing_SpanRenamedToRoutePattern(t *testing.T) {
 func TestTracing_UnmatchedRouteSpanName(t *testing.T) {
 	spy := &spyTracer{}
 
-	r := chi.NewRouter()
-	r.Use(Tracing(spy))
-	r.Get("/exists", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{Tracing(spy)},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /exists", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		},
+	)
 
 	req := httptest.NewRequest(http.MethodGet, "/random-404-path", nil)
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	spans := spy.Spans()
 	require.Len(t, spans, 1)
@@ -259,15 +264,18 @@ func TestTracing_UnmatchedRouteSpanName(t *testing.T) {
 func TestTracing_HttpRouteAttribute(t *testing.T) {
 	spy := &spyTracer{}
 
-	r := chi.NewRouter()
-	r.Use(Tracing(spy))
-	r.Get("/api/v1/orders/{orderID}", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusCreated)
-	})
+	handler := buildTestServer(
+		[]func(http.Handler) http.Handler{Tracing(spy)},
+		func(mux *http.ServeMux) {
+			mux.Handle("GET /api/v1/orders/{orderID}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+			}))
+		},
+	)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/999", nil)
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	spans := spy.Spans()
 	require.Len(t, spans, 1)

--- a/runtime/http/router/adapter_test.go
+++ b/runtime/http/router/adapter_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,9 +47,18 @@ func TestWithTrustedProxies_Integration(t *testing.T) {
 
 func TestRouter_Handler(t *testing.T) {
 	// PR-A14b: each Router has a single Handler() serving its listener's mux.
+	// The composed handler wraps the ServeMux with the listener-root middleware
+	// chain, so it is not pointer-equal to r.mux — but it must be non-nil and
+	// reused across calls so http.Server hands the same handler to every
+	// connection (cached lazily on first call).
 	r := MustNew(WithRouterClock(clock.Real()))
-	assert.NotNil(t, r.Handler())
-	assert.Equal(t, r.mux, r.Handler())
+	first := r.Handler()
+	assert.NotNil(t, first)
+	assert.NotNil(t, r.mux)
+	assert.Equal(t,
+		reflect.ValueOf(first).Pointer(),
+		reflect.ValueOf(r.Handler()).Pointer(),
+		"Handler() must return the same composed handler on each call")
 }
 
 func TestRouteGroup_Route(t *testing.T) {

--- a/runtime/http/router/adapter_test.go
+++ b/runtime/http/router/adapter_test.go
@@ -3,7 +3,6 @@ package router
 import (
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,14 +49,12 @@ func TestRouter_Handler(t *testing.T) {
 	// The composed handler wraps the ServeMux with the listener-root middleware
 	// chain, so it is not pointer-equal to r.mux — but it must be non-nil and
 	// reused across calls so http.Server hands the same handler to every
-	// connection (cached lazily on first call).
+	// connection (built eagerly by composeHandler during NewForListener).
 	r := MustNew(WithRouterClock(clock.Real()))
 	first := r.Handler()
 	assert.NotNil(t, first)
 	assert.NotNil(t, r.mux)
-	assert.Equal(t,
-		reflect.ValueOf(first).Pointer(),
-		reflect.ValueOf(r.Handler()).Pointer(),
+	assert.True(t, first == r.Handler(),
 		"Handler() must return the same composed handler on each call")
 }
 

--- a/runtime/http/router/policy_coverage.go
+++ b/runtime/http/router/policy_coverage.go
@@ -8,7 +8,7 @@ import (
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 )
 
-// routeKey is a (method, path) pair from the chi router tree.
+// routeKey is a (method, path) pair from the router's routePatterns table.
 type routeKey struct {
 	Method string
 	Path   string

--- a/runtime/http/router/policy_coverage_test.go
+++ b/runtime/http/router/policy_coverage_test.go
@@ -12,7 +12,7 @@ import (
 func TestVerifyPolicyCoverage(t *testing.T) {
 	tests := []struct {
 		name        string
-		routes      []routeKey            // registered routes from chi.Walk
+		routes      []routeKey            // registered routes from router.routePatterns
 		metas       []kcell.AuthRouteMeta // declared auth metas
 		whitelist   []string              // whitelist patterns
 		wantErr     bool

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -93,14 +93,17 @@ func stripPatternMethod(pattern string) string {
 	return pattern
 }
 
-// patternRecorderMiddleware installs an empty *patternRecorder into ctx so
-// the dispatch wrapper has somewhere to write the matched pattern. Must be
-// the outermost middleware so all observability layers can read the result
-// after next.ServeHTTP returns.
-func patternRecorderMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := middleware.WithRoutePatternRecorder(r.Context())
-		next.ServeHTTP(w, r.WithContext(ctx))
+// patternRecorderMiddleware installs both the request-scoped *patternRecorder
+// (so the dispatch wrapper has somewhere to write the matched pattern) AND the
+// router's own resolveHTTPRoutePattern as the shared RouteResolver fallback
+// (so observability middleware that runs after a short-circuit reject still
+// gets a non-"unmatched" route label). Must be the outermost middleware so
+// every observing layer sees the same context.
+func (r *Router) patternRecorderMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := middleware.WithRoutePatternRecorder(req.Context())
+		ctx = middleware.WithRouteResolver(ctx, r.resolveHTTPRoutePattern)
+		next.ServeHTTP(w, req.WithContext(ctx))
 	})
 }
 
@@ -551,11 +554,12 @@ func NewForListener(ref kcell.ListenerRef, opts ...Option) (*Router, error) {
 //
 // The composition (outer → inner) is:
 //
-//	patternRecorderMiddleware → r.middlewares (in declaration order) →
+//	r.patternRecorderMiddleware → r.middlewares (in declaration order) →
 //	  patternRecordingMux → *http.ServeMux → leaf handler
 //
-// patternRecorderMiddleware installs the *patternRecorder so observability
-// layers can read the matched route pattern after next.ServeHTTP returns.
+// r.patternRecorderMiddleware installs the *patternRecorder and injects the
+// router's route resolver so all observability layers see a consistent route
+// label even on short-circuit reject paths (auth, rate limit, 405).
 // patternRecordingMux fills the recorder by asking ServeMux.Handler for the
 // matched pattern before dispatching the leaf handler.
 //
@@ -642,11 +646,7 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	}
 	r.use(middleware.AccessLog(r.clock))
 	if r.metricsCollector != nil {
-		r.use(middleware.Metrics(
-			r.metricsCollector,
-			r.clock,
-			middleware.WithRoutePatternResolver(r.resolveHTTPRoutePattern),
-		))
+		r.use(middleware.Metrics(r.metricsCollector, r.clock))
 	}
 	r.use(
 		middleware.Recovery,
@@ -698,7 +698,7 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 func (r *Router) composeHandler() {
 	dispatcher := &patternRecordingMux{mux: r.mux}
 	all := make([]Middleware, 0, len(r.middlewares)+1)
-	all = append(all, patternRecorderMiddleware)
+	all = append(all, r.patternRecorderMiddleware)
 	all = append(all, r.middlewares...)
 	r.handler = &composedHandler{h: chain(http.Handler(dispatcher), all...)}
 }
@@ -1508,14 +1508,7 @@ func (a *nativeMuxAdapter) Handle(pattern string, handler http.Handler) {
 	}
 	method, routePath := splitHandlePattern(pattern)
 	if routePath != "" {
-		fullPath := joinPrefix(a.prefix, routePath)
-		if a.owner != nil && !a.owner.markMuxHandler(method, fullPath) {
-			// Duplicate registration — defer to FinalizeAuth for the
-			// user-visible error. See Router.Handle for context.
-			return
-		}
-		if err := a.recordOwnedRoute(method, routePath); err != nil {
-			a.setRegistrationErr(err)
+		if ok := a.registerRoutePath(method, routePath); !ok {
 			return
 		}
 	}
@@ -1531,6 +1524,35 @@ func (a *nativeMuxAdapter) Handle(pattern string, handler http.Handler) {
 	if a.prefix != "" && routePath == "/" {
 		a.mux.Handle(combineEndSlashPattern(a.prefix, method), handler)
 	}
+}
+
+// registerRoutePath enforces route ownership and ServeMux dedup for a single
+// (method, routePath) pair. Returns true when the caller should proceed with
+// mux.Handle; returns false when the registration should be skipped (duplicate
+// same-cell path) or has recorded an error (cross-cell path conflict).
+//
+// Ordering contract:
+//  1. Cross-cell ownership check first — duplicate path from a different cell
+//     must fail-fast even when the mux would silently drop the second call.
+//  2. ServeMux dedup — same-cell second registration is silently dropped;
+//     FinalizeAuth.partitionAuthMetas is the structured signal for that case.
+//  3. Route pattern recorded only after both checks pass.
+func (a *nativeMuxAdapter) registerRoutePath(method, routePath string) bool {
+	if a.owner == nil {
+		return true
+	}
+	fullPath := joinPrefix(a.prefix, routePath)
+	if a.cellID != "" {
+		if err := a.owner.recordOwnedRoutePath(a.cellID, fullPath); err != nil {
+			a.setRegistrationErr(err)
+			return false
+		}
+	}
+	if !a.owner.markMuxHandler(method, fullPath) {
+		return false
+	}
+	a.owner.recordRoutePattern(method, fullPath)
+	return true
 }
 
 func (a *nativeMuxAdapter) Route(pattern string, fn func(kcell.RouteMux)) {
@@ -1639,21 +1661,6 @@ func (a *nativeMuxAdapter) recordOwnedPrefix(prefix string) error {
 		return nil
 	}
 	return a.owner.recordOwnedPrefix(a.cellID, prefix)
-}
-
-func (a *nativeMuxAdapter) recordOwnedRoute(method, routePath string) error {
-	if a.owner == nil {
-		return nil
-	}
-	fullPath := joinPrefix(a.prefix, routePath)
-	a.owner.recordRoutePattern(method, fullPath)
-	if a.cellID == "" {
-		return nil
-	}
-	if err := a.owner.recordOwnedRoutePath(a.cellID, fullPath); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (a *nativeMuxAdapter) setRegistrationErr(err error) {

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -1494,6 +1494,14 @@ func (a *nativeMuxAdapter) Handle(pattern string, handler http.Handler) {
 		handler = chain(handler, a.middlewares...)
 	}
 	a.mux.Handle(combineHandlePattern(a.prefix, pattern), handler)
+	// When the child path is the bare slash, also register the trailing-
+	// slash variant via the "{$}" no-subtree end-slash form (Go 1.22+) so
+	// callers that send "/prefix/" still match the same handler without
+	// introducing a subtree pattern that would conflict with sibling
+	// "/prefix/{id}" wildcards.
+	if a.prefix != "" && routePath == "/" {
+		a.mux.Handle(combineEndSlashPattern(a.prefix, method), handler)
+	}
 }
 
 func (a *nativeMuxAdapter) Route(pattern string, fn func(kcell.RouteMux)) {
@@ -1642,19 +1650,32 @@ func (a *nativeMuxAdapter) hasRegistrationErr() bool {
 // applied to the path component only, and the optional method is preserved
 // verbatim. Empty prefix returns the original pattern.
 //
-// When the child path is the bare slash ("/"), the result is registered as
-// the subtree of the parent prefix (trailing slash) so requests to the
-// prefix and any deeper path still hit the registered handler — chi's
-// "Route(prefix) + Handle('/', h)" semantics.
+// When the child path is the bare slash ("/"), the result is the parent
+// prefix exact (no trailing slash). Registering as a subtree ("/users/")
+// would conflict with sibling wildcard patterns like "/users/{id}" — stdlib
+// panics during the second registration because both could match the same
+// request and neither is strictly more specific. Contract.Path is the
+// canonical wire path (no trailing slash), so the exact form is what every
+// HTTP client targets in practice.
 func combineHandlePattern(prefix, pattern string) string {
 	if prefix == "" {
 		return pattern
 	}
 	method, routePath := splitHandlePattern(pattern)
 	full := joinPrefix(prefix, routePath)
-	if routePath == "/" {
-		full = strings.TrimSuffix(full, "/") + "/"
+	if method == "" {
+		return full
 	}
+	return method + " " + full
+}
+
+// combineEndSlashPattern returns the "/prefix/{$}" pattern used to match the
+// trailing-slash form of the bare prefix without the subtree side-effects of
+// "/prefix/" (which would conflict with sibling "/prefix/{id}" wildcards).
+// Stdlib's "{$}" wildcard (Go 1.22+) matches only the empty trailing
+// segment, so it does not collide with single-segment wildcards like "{id}".
+func combineEndSlashPattern(prefix, method string) string {
+	full := strings.TrimSuffix(prefix, "/") + "/{$}"
 	if method == "" {
 		return full
 	}

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -1508,7 +1508,7 @@ func (a *nativeMuxAdapter) Handle(pattern string, handler http.Handler) {
 	}
 	method, routePath := splitHandlePattern(pattern)
 	if routePath != "" {
-		if ok := a.registerRoutePath(method, routePath); !ok {
+		if !a.registerRoutePath(method, routePath) {
 			return
 		}
 	}

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -742,6 +742,10 @@ func (r *Router) markMuxHandler(method, routePath string) bool {
 		r.muxHandlers = make(map[string]bool)
 	}
 	if r.muxHandlers[key] {
+		slog.Warn("router: duplicate ServeMux registration skipped",
+			"method", strings.ToUpper(method),
+			"path", cleanRoutePath(routePath),
+		)
 		return false
 	}
 	r.muxHandlers[key] = true
@@ -812,7 +816,13 @@ func mountBareHandler(handler http.Handler) http.Handler {
 func mountPatternRecorder(prefix string, handler http.Handler) http.Handler {
 	subMux, ok := handler.(*http.ServeMux)
 	if !ok {
-		return handler
+		// Non-ServeMux handlers have opaque internal routing; record the mount
+		// prefix as the best available route label so metrics do not fall back
+		// to "unmatched".
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			middleware.RecordRoutePattern(r.Context(), prefix+"/")
+			handler.ServeHTTP(w, r)
+		})
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, inner := subMux.Handler(r)

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -58,11 +58,28 @@ type patternRecordingMux struct {
 }
 
 func (p *patternRecordingMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h, pattern := p.mux.Handler(r)
-	if pattern != "" {
-		middleware.RecordRoutePattern(r.Context(), pattern)
+	// Two-pass dispatch: (*ServeMux).Handler returns the matched pattern but
+	// does NOT populate the request's {param} PathValues — those are written
+	// by (*ServeMux).ServeHTTP when it constructs the dispatched request.
+	// Read the pattern first for the observability recorder, then let
+	// ServeHTTP perform the actual dispatch so r.PathValue keeps working
+	// inside leaf handlers.
+	if _, pattern := p.mux.Handler(r); pattern != "" {
+		middleware.RecordRoutePattern(r.Context(), stripPatternMethod(pattern))
 	}
-	h.ServeHTTP(w, r)
+	p.mux.ServeHTTP(w, r)
+}
+
+// stripPatternMethod drops the leading "METHOD " prefix from a ServeMux 1.22+
+// pattern so the recorded route stays method-agnostic. Tracing, AccessLog,
+// and Metrics compose the method with the route as they emit, so keeping the
+// recorded value path-only avoids double-prefixing in span names like
+// "GET GET /api/v1/users/{id}".
+func stripPatternMethod(pattern string) string {
+	if idx := strings.IndexByte(pattern, ' '); idx >= 0 {
+		return pattern[idx+1:]
+	}
+	return pattern
 }
 
 // patternRecorderMiddleware installs an empty *patternRecorder into ctx so
@@ -323,7 +340,8 @@ func WithDefaultMiddleware(mws ...func(http.Handler) http.Handler) Option {
 //
 // ref: go-kratos/kratos transport/http/server.go — per-server middleware
 // ref: net/http.ServeMux — one ServeMux root per listener; method+pattern
-//      routing (Go 1.22+).
+//
+//	routing (Go 1.22+).
 type Router struct {
 	ref kcell.ListenerRef // which listener this router serves
 	mux *http.ServeMux    // single ServeMux root; observability + auth wrap it
@@ -336,6 +354,13 @@ type Router struct {
 	// pattern-recording dispatch wrapper. Reset only when the chain changes
 	// (currently only during NewForListener).
 	handler http.Handler
+	// muxHandlers tracks (method, path) pairs that have been registered on
+	// the underlying ServeMux. Stdlib panics on a second registration of the
+	// same pattern, so duplicate Handle calls are silently dropped here so
+	// FinalizeAuth's structured duplicate-route error remains the canonical
+	// signal — preserving the chi-era contract where duplicate auth.Mount
+	// surfaces as a metadata error during phase5.
+	muxHandlers map[string]bool
 
 	// configuration fields (read during build)
 	metricsCollector    metrics.Collector
@@ -689,8 +714,38 @@ func (r *Router) buildAuthOpts() []auth.AuthOption {
 // "/path"). The handler is registered directly on the underlying ServeMux
 // without any extra middleware wrap; root-level middleware (observability,
 // auth, body-limit, etc.) is composed by Router.Handler.
+//
+// Each registration is mirrored into routePatterns so policy coverage and
+// route-pattern resolution see the same routes that ServeMux dispatches to.
+// Duplicate registrations are tracked separately (muxHandlers) so the second
+// call drops at the mux layer — FinalizeAuth's structured error is the
+// canonical user-visible signal for duplicate auth.Mount.
 func (r *Router) Handle(pattern string, handler http.Handler) {
-	r.mux.Handle(pattern, handler)
+	method, routePath := splitHandlePattern(pattern)
+	if routePath == "" {
+		r.mux.Handle(pattern, handler)
+		return
+	}
+	if r.markMuxHandler(method, routePath) {
+		r.recordRoutePattern(method, routePath)
+		r.mux.Handle(pattern, handler)
+	}
+}
+
+// markMuxHandler records that (method, path) was passed to the underlying
+// ServeMux and returns true on the first registration. Subsequent calls for
+// the same key return false so the caller can skip mux.Handle and avoid
+// stdlib's duplicate-pattern panic.
+func (r *Router) markMuxHandler(method, routePath string) bool {
+	key := strings.ToUpper(method) + "\x00" + cleanRoutePath(routePath)
+	if r.muxHandlers == nil {
+		r.muxHandlers = make(map[string]bool)
+	}
+	if r.muxHandlers[key] {
+		return false
+	}
+	r.muxHandlers[key] = true
+	return true
 }
 
 // Group creates a sub-scope, implementing cell.RouteMux. The returned adapter
@@ -714,14 +769,61 @@ func (r *Router) Route(pattern string, fn func(kcell.RouteMux)) {
 // Mount attaches an http.Handler under the given prefix. Stdlib ServeMux
 // requires sub-tree patterns to end in "/"; the trailing slash is added
 // implicitly. The handler sees the request path with the prefix stripped.
+//
+// Both the bare prefix ("/api") and the sub-tree ("/api/...") are registered
+// so requests that hit the mount root without a trailing slash still reach
+// the inner handler's "/" registration instead of stdlib's 301 redirect.
 func (r *Router) Mount(prefix string, handler http.Handler) {
 	canonical := strings.TrimSuffix(prefix, "/")
 	if canonical == "" {
-		// Mount at root: ServeMux dispatches everything to the handler.
 		r.mux.Handle("/", handler)
 		return
 	}
-	r.mux.Handle(canonical+"/", http.StripPrefix(canonical, handler))
+	recorded := mountPatternRecorder(canonical, handler)
+	r.mux.Handle(canonical+"/", http.StripPrefix(canonical, recorded))
+	r.mux.Handle(canonical, mountBareHandler(recorded))
+}
+
+// mountBareHandler rewrites the request path to "/" before dispatching to the
+// inner mount handler so a "GET /" registration inside the inner handler
+// still matches when the outer request path equals the mount prefix exactly
+// (e.g. "/api" with mount prefix "/api"). Without this rewrite stdlib
+// ServeMux issues a 301 redirect to "/api/".
+func mountBareHandler(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req2 := req.Clone(req.Context())
+		req2.URL.Path = "/"
+		if req.URL.RawPath != "" {
+			req2.URL.RawPath = "/"
+		}
+		handler.ServeHTTP(w, req2)
+	})
+}
+
+// mountPatternRecorder upgrades a *http.ServeMux mount handler so it writes
+// the matched-inner pattern composed with the mount prefix into the
+// request-scoped *patternRecorder. This recovers chi's "Mount + sub-route =
+// composed full pattern" semantics for observability — without this wrap
+// the outer dispatch only records the mount subtree pattern (e.g. "/api/")
+// and metrics/tracing/access-log lose route granularity for mounted cells.
+//
+// Non-ServeMux handlers are returned unchanged: their internal routing is
+// opaque, so the outer mount-subtree pattern is the best label available.
+func mountPatternRecorder(prefix string, handler http.Handler) http.Handler {
+	subMux, ok := handler.(*http.ServeMux)
+	if !ok {
+		return handler
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, inner := subMux.Handler(r)
+		if inner != "" {
+			if idx := strings.IndexByte(inner, ' '); idx >= 0 {
+				inner = inner[idx+1:]
+			}
+			middleware.RecordRoutePattern(r.Context(), prefix+inner)
+		}
+		subMux.ServeHTTP(w, r)
+	})
 }
 
 // With returns a new RouteMux that applies the given middleware to routes
@@ -1049,10 +1151,24 @@ func (r *Router) recordRoutePattern(method, routePath string) {
 	if routePath == "" {
 		return
 	}
-	r.routePatterns = append(r.routePatterns, registeredRoutePattern{
-		method: strings.ToUpper(method),
-		path:   routePath,
-	})
+	method = strings.ToUpper(method)
+	if method != "" {
+		r.routePatterns = append(r.routePatterns, registeredRoutePattern{
+			method: method,
+			path:   routePath,
+		})
+		return
+	}
+	// stdlib ServeMux treats method-less patterns as matching every HTTP
+	// method. Mirror chi.Walk semantics: emit one entry per business method
+	// so policy coverage and route-pattern resolution can reason about each
+	// (method, path) pair independently.
+	for m := range businessMethods {
+		r.routePatterns = append(r.routePatterns, registeredRoutePattern{
+			method: m,
+			path:   routePath,
+		})
+	}
 }
 
 // not404Handler writes a 404 JSON body. Used when a primary-listener router
@@ -1353,6 +1469,12 @@ func (a *nativeMuxAdapter) Handle(pattern string, handler http.Handler) {
 	}
 	method, routePath := splitHandlePattern(pattern)
 	if routePath != "" {
+		fullPath := joinPrefix(a.prefix, routePath)
+		if a.owner != nil && !a.owner.markMuxHandler(method, fullPath) {
+			// Duplicate registration — defer to FinalizeAuth for the
+			// user-visible error. See Router.Handle for context.
+			return
+		}
 		if err := a.recordOwnedRoute(method, routePath); err != nil {
 			a.setRegistrationErr(err)
 			return
@@ -1402,7 +1524,9 @@ func (a *nativeMuxAdapter) Mount(pattern string, handler http.Handler) {
 		a.mux.Handle("/", handler)
 		return
 	}
-	a.mux.Handle(canonical+"/", http.StripPrefix(canonical, handler))
+	recorded := mountPatternRecorder(canonical, handler)
+	a.mux.Handle(canonical+"/", http.StripPrefix(canonical, recorded))
+	a.mux.Handle(canonical, mountBareHandler(recorded))
 }
 
 func (a *nativeMuxAdapter) Group(fn func(kcell.RouteMux)) {
@@ -1507,12 +1631,20 @@ func (a *nativeMuxAdapter) hasRegistrationErr() bool {
 // pattern. Input pattern follows the "[METHOD ]/path" form; the prefix is
 // applied to the path component only, and the optional method is preserved
 // verbatim. Empty prefix returns the original pattern.
+//
+// When the child path is the bare slash ("/"), the result is registered as
+// the subtree of the parent prefix (trailing slash) so requests to the
+// prefix and any deeper path still hit the registered handler — chi's
+// "Route(prefix) + Handle('/', h)" semantics.
 func combineHandlePattern(prefix, pattern string) string {
 	if prefix == "" {
 		return pattern
 	}
 	method, routePath := splitHandlePattern(pattern)
 	full := joinPrefix(prefix, routePath)
+	if routePath == "/" {
+		full = strings.TrimSuffix(full, "/") + "/"
+	}
 	if method == "" {
 		return full
 	}

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -47,6 +47,17 @@ func chain(h http.Handler, mws ...Middleware) http.Handler {
 	return h
 }
 
+// composedHandler wraps the listener-root chain as a struct pointer so that
+// the http.Handler interface value stored in Router.handler has a comparable
+// (pointer) dynamic type. This allows Handler() callers to use == to confirm
+// they receive the same instance across multiple calls — which http.HandlerFunc
+// (the type returned by chain) does not support.
+type composedHandler struct{ h http.Handler }
+
+func (c *composedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c.h.ServeHTTP(w, r)
+}
+
 // patternRecordingMux is the innermost dispatch wrapper. It calls
 // (*http.ServeMux).Handler explicitly to recover the matched pattern, writes
 // it into the request-scoped recorder installed by patternRecorderMiddleware,
@@ -350,9 +361,9 @@ type Router struct {
 	// declaration order: the first entry is outermost. buildMux populates it
 	// via r.use(...) so archtest can statically assert ordering.
 	middlewares []Middleware
-	// handler is the lazily-built composition of middlewares around the
-	// pattern-recording dispatch wrapper. Reset only when the chain changes
-	// (currently only during NewForListener).
+	// handler is the eagerly-built composition of middlewares around the
+	// pattern-recording dispatch wrapper. Set once by composeHandler at the
+	// end of buildMux; immutable afterwards.
 	handler http.Handler
 	// muxHandlers tracks (method, path) pairs that have been registered on
 	// the underlying ServeMux. Stdlib panics on a second registration of the
@@ -547,16 +558,13 @@ func NewForListener(ref kcell.ListenerRef, opts ...Option) (*Router, error) {
 // layers can read the matched route pattern after next.ServeHTTP returns.
 // patternRecordingMux fills the recorder by asking ServeMux.Handler for the
 // matched pattern before dispatching the leaf handler.
-func (r *Router) Handler() http.Handler {
-	if r.handler == nil {
-		dispatcher := &patternRecordingMux{mux: r.mux}
-		all := make([]Middleware, 0, len(r.middlewares)+1)
-		all = append(all, patternRecorderMiddleware)
-		all = append(all, r.middlewares...)
-		r.handler = chain(http.Handler(dispatcher), all...)
-	}
-	return r.handler
-}
+//
+// The handler is built eagerly by composeHandler at the end of buildMux
+// (called from NewForListener), so Handler() is a plain getter and safe to
+// call concurrently after construction.
+// Handler returns the listener's composed http.Handler. Built once at
+// construction by composeHandler; safe to call concurrently afterwards.
+func (r *Router) Handler() http.Handler { return r.handler }
 
 // ServeHTTP delegates to the router's composed handler, making Router drop-in
 // compatible with http.Handler. If auth route metadata was declared but
@@ -680,7 +688,19 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 		r.use(auth.AuthMiddleware(r.authVerifier, r.buildAuthOpts()...))
 	}
 	r.use(middleware.BodyLimit(r.bodyLimit))
+	r.composeHandler()
 	return nil
+}
+
+// composeHandler builds the listener-root chain handler once buildMux has
+// settled the middleware stack. NewForListener calls it after the final
+// r.use(...); Handler() is then a plain getter.
+func (r *Router) composeHandler() {
+	dispatcher := &patternRecordingMux{mux: r.mux}
+	all := make([]Middleware, 0, len(r.middlewares)+1)
+	all = append(all, patternRecorderMiddleware)
+	all = append(all, r.middlewares...)
+	r.handler = &composedHandler{h: chain(http.Handler(dispatcher), all...)}
 }
 
 // buildAuthOpts constructs the AuthOption slice for the auth middleware.
@@ -770,6 +790,22 @@ func (r *Router) Route(pattern string, fn func(kcell.RouteMux)) {
 	fn(sub)
 }
 
+// registerMount installs handler under prefix on mux with chi-equivalent
+// no-redirect semantics: the bare path matches via mountBareHandler (path
+// rewritten to "/") and the subtree pattern carries the rest. mountPatternRecorder
+// upgrades *http.ServeMux handlers so the recorded route stays
+// "prefix + inner pattern" instead of just the subtree prefix.
+func registerMount(mux *http.ServeMux, prefix string, handler http.Handler) {
+	canonical := strings.TrimSuffix(prefix, "/")
+	if canonical == "" {
+		mux.Handle("/", handler)
+		return
+	}
+	recorded := mountPatternRecorder(canonical, handler)
+	mux.Handle(canonical+"/", http.StripPrefix(canonical, recorded))
+	mux.Handle(canonical, mountBareHandler(recorded))
+}
+
 // Mount attaches an http.Handler under the given prefix. Stdlib ServeMux
 // requires sub-tree patterns to end in "/"; the trailing slash is added
 // implicitly. The handler sees the request path with the prefix stripped.
@@ -778,14 +814,7 @@ func (r *Router) Route(pattern string, fn func(kcell.RouteMux)) {
 // so requests that hit the mount root without a trailing slash still reach
 // the inner handler's "/" registration instead of stdlib's 301 redirect.
 func (r *Router) Mount(prefix string, handler http.Handler) {
-	canonical := strings.TrimSuffix(prefix, "/")
-	if canonical == "" {
-		r.mux.Handle("/", handler)
-		return
-	}
-	recorded := mountPatternRecorder(canonical, handler)
-	r.mux.Handle(canonical+"/", http.StripPrefix(canonical, recorded))
-	r.mux.Handle(canonical, mountBareHandler(recorded))
+	registerMount(r.mux, prefix, handler)
 }
 
 // mountBareHandler rewrites the request path to "/" before dispatching to the
@@ -1534,17 +1563,10 @@ func (a *nativeMuxAdapter) Mount(pattern string, handler http.Handler) {
 		a.setRegistrationErr(err)
 		return
 	}
-	canonical := strings.TrimSuffix(fullPrefix, "/")
 	if len(a.middlewares) > 0 {
 		handler = chain(handler, a.middlewares...)
 	}
-	if canonical == "" {
-		a.mux.Handle("/", handler)
-		return
-	}
-	recorded := mountPatternRecorder(canonical, handler)
-	a.mux.Handle(canonical+"/", http.StripPrefix(canonical, recorded))
-	a.mux.Handle(canonical, mountBareHandler(recorded))
+	registerMount(a.mux, fullPrefix, handler)
 }
 
 func (a *nativeMuxAdapter) Group(fn func(kcell.RouteMux)) {

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -1,13 +1,14 @@
-// Package router provides a chi-based HTTP router that implements
-// kernel/cell.RouteMux with default observability middleware. Each Router
-// instance wraps a single chi.Mux root for ONE physical listener. Bootstrap
-// builds one Router per declared listener (primary / internal / health) and
-// applies the listener's default Policy before any routes are registered.
+// Package router provides an HTTP router that implements kernel/cell.RouteMux
+// with default observability middleware. Each Router instance wraps a single
+// stdlib *http.ServeMux for ONE physical listener. Bootstrap builds one Router
+// per declared listener (primary / internal / health) and applies the
+// listener's default Policy before any routes are registered.
 //
-// ref: go-chi/chi/v5 — Mux pattern (Group, Mount, Route, Use)
-// Adopted: chi.NewRouter as the underlying multiplexer, one per listener.
-// Deviated: wrapped behind kernel/cell.RouteMux interface so Cells remain
-// decoupled from any specific router library.
+// ref: net/http.ServeMux (Go 1.22+) — method+pattern routing, automatic 405,
+// automatic HEAD-from-GET, r.PathValue for path params.
+// Adopted: stdlib ServeMux as the underlying multiplexer, one per listener.
+// Wrapped behind kernel/cell.RouteMux interface so Cells remain decoupled from
+// the multiplexer choice.
 //
 // ref: go-kratos/kratos transport/http/server.go — per-server middleware
 // Adopted: policy applied at server build time; observability baked in.
@@ -21,8 +22,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
-
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/wrapper"
@@ -34,6 +33,48 @@ import (
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 	"github.com/ghbvf/gocell/runtime/observability/tracing"
 )
+
+// Middleware is the standard net/http middleware shape used throughout the
+// router and its adapters.
+type Middleware = func(http.Handler) http.Handler
+
+// chain composes mws around h so the first mw runs outermost. An empty mws
+// returns h unchanged.
+func chain(h http.Handler, mws ...Middleware) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
+}
+
+// patternRecordingMux is the innermost dispatch wrapper. It calls
+// (*http.ServeMux).Handler explicitly to recover the matched pattern, writes
+// it into the request-scoped recorder installed by patternRecorderMiddleware,
+// then dispatches. Stdlib's ServeMux only stores the pattern on the
+// *http.Request after dispatch; using Handler(req) lifts the pattern up to
+// every middleware in the chain via the shared *patternRecorder.
+type patternRecordingMux struct {
+	mux *http.ServeMux
+}
+
+func (p *patternRecordingMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h, pattern := p.mux.Handler(r)
+	if pattern != "" {
+		middleware.RecordRoutePattern(r.Context(), pattern)
+	}
+	h.ServeHTTP(w, r)
+}
+
+// patternRecorderMiddleware installs an empty *patternRecorder into ctx so
+// the dispatch wrapper has somewhere to write the matched pattern. Must be
+// the outermost middleware so all observability layers can read the result
+// after next.ServeHTTP returns.
+func patternRecorderMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := middleware.WithRoutePatternRecorder(r.Context())
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
 
 // Compile-time checks.
 var _ kcell.RouteMux = (*Router)(nil)
@@ -271,7 +312,7 @@ func WithDefaultMiddleware(mws ...func(http.Handler) http.Handler) Option {
 	}
 }
 
-// Router wraps a single chi.Mux root for ONE physical listener.
+// Router wraps a single *http.ServeMux root for ONE physical listener.
 // The observability middleware chain is baked in at construction time, and
 // the listener's default Policy is applied as an inner layer before any
 // cell routes are registered.
@@ -281,10 +322,20 @@ func WithDefaultMiddleware(mws ...func(http.Handler) http.Handler) Option {
 // by this per-listener model.
 //
 // ref: go-kratos/kratos transport/http/server.go — per-server middleware
-// ref: go-chi/chi mux.go — one chi.Mux root per listener
+// ref: net/http.ServeMux — one ServeMux root per listener; method+pattern
+//      routing (Go 1.22+).
 type Router struct {
 	ref kcell.ListenerRef // which listener this router serves
-	mux *chi.Mux          // single chi.Mux root; observability + auth already applied
+	mux *http.ServeMux    // single ServeMux root; observability + auth wrap it
+
+	// middlewares is the listener-root chain wrapping mux. Order matches
+	// declaration order: the first entry is outermost. buildMux populates it
+	// via r.use(...) so archtest can statically assert ordering.
+	middlewares []Middleware
+	// handler is the lazily-built composition of middlewares around the
+	// pattern-recording dispatch wrapper. Reset only when the chain changes
+	// (currently only during NewForListener).
+	handler http.Handler
 
 	// configuration fields (read during build)
 	metricsCollector    metrics.Collector
@@ -369,7 +420,7 @@ type routeMatchRank struct {
 	length         int
 }
 
-// earlyResponderMiddleware turns an earlyResponder into a chi middleware that
+// earlyResponderMiddleware turns an earlyResponder into a middleware that
 // short-circuits when the predicate matches.
 func earlyResponderMiddleware(er earlyResponder) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -423,12 +474,12 @@ func MustNew(opts ...Option) *Router {
 //	→ [RateLimit] → [CircuitBreaker] → [Auth] → BodyLimit → handlers
 //
 // ref: go-kratos/kratos app.go WithServer + errgroup (adopted)
-// ref: go-chi/chi mux.go (one chi.Mux per listener)
+// ref: net/http.ServeMux (one ServeMux per listener)
 // ref: kubernetes/kubernetes apiserver/server/genericapiserver.go (rejected single-listener)
 func NewForListener(ref kcell.ListenerRef, opts ...Option) (*Router, error) {
 	r := &Router{
 		ref:       ref,
-		mux:       chi.NewRouter(),
+		mux:       http.NewServeMux(),
 		bodyLimit: middleware.DefaultBodyLimit,
 	}
 	for _, o := range opts {
@@ -461,12 +512,31 @@ func NewForListener(ref kcell.ListenerRef, opts ...Option) (*Router, error) {
 // Handler returns the http.Handler for this listener's router. This is the
 // handler to pass to http.Server. Unlike the legacy PublicHandler()/
 // InternalHandler(), each listener now has exactly one Handler().
-func (r *Router) Handler() http.Handler { return r.mux }
+//
+// The composition (outer → inner) is:
+//
+//	patternRecorderMiddleware → r.middlewares (in declaration order) →
+//	  patternRecordingMux → *http.ServeMux → leaf handler
+//
+// patternRecorderMiddleware installs the *patternRecorder so observability
+// layers can read the matched route pattern after next.ServeHTTP returns.
+// patternRecordingMux fills the recorder by asking ServeMux.Handler for the
+// matched pattern before dispatching the leaf handler.
+func (r *Router) Handler() http.Handler {
+	if r.handler == nil {
+		dispatcher := &patternRecordingMux{mux: r.mux}
+		all := make([]Middleware, 0, len(r.middlewares)+1)
+		all = append(all, patternRecorderMiddleware)
+		all = append(all, r.middlewares...)
+		r.handler = chain(http.Handler(dispatcher), all...)
+	}
+	return r.handler
+}
 
-// ServeHTTP delegates to the router's mux, making Router drop-in compatible
-// with http.Handler. If auth route metadata was declared but FinalizeAuth was
-// not called, ServeHTTP fails closed with 500 instead of serving routes with
-// incomplete auth state.
+// ServeHTTP delegates to the router's composed handler, making Router drop-in
+// compatible with http.Handler. If auth route metadata was declared but
+// FinalizeAuth was not called, ServeHTTP fails closed with 500 instead of
+// serving routes with incomplete auth state.
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if len(r.declaredAuthMetas) > 0 && !r.authFinalized {
 		slog.ErrorContext(req.Context(), "router: FinalizeAuth must be called before ServeHTTP",
@@ -475,7 +545,14 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			string(errcode.ErrInternal), "internal server error")
 		return
 	}
-	r.mux.ServeHTTP(w, req)
+	r.Handler().ServeHTTP(w, req)
+}
+
+// use appends middlewares to the router-root chain. Each call appends in
+// declaration order; the first registered middleware ends up outermost (after
+// patternRecorderMiddleware, which is always installed first by Handler).
+func (r *Router) use(mws ...Middleware) {
+	r.middlewares = append(r.middlewares, mws...)
 }
 
 // buildRealIPMiddleware constructs the RealIP middleware, validating trusted
@@ -520,7 +597,7 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	r.requestIDOpts = append([]middleware.RequestIDOption{middleware.WithReqIDPublicEndpointFn(lazyPublic)}, r.requestIDOpts...)
 
 	// --- Observability layer ---
-	r.mux.Use(
+	r.use(
 		middleware.ListenerContext(r.ref.String()),
 		middleware.RequestIDWithOptions(r.requestIDOpts...),
 		realIPMW,
@@ -528,17 +605,17 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 		middleware.CellAttribution(r.resolveCellID),
 	)
 	if r.tracer != nil {
-		r.mux.Use(middleware.Tracing(r.tracer, r.tracingOpts...))
+		r.use(middleware.Tracing(r.tracer, r.tracingOpts...))
 	}
-	r.mux.Use(middleware.AccessLog(r.clock))
+	r.use(middleware.AccessLog(r.clock))
 	if r.metricsCollector != nil {
-		r.mux.Use(middleware.Metrics(
+		r.use(middleware.Metrics(
 			r.metricsCollector,
 			r.clock,
 			middleware.WithRoutePatternResolver(r.resolveHTTPRoutePattern),
 		))
 	}
-	r.mux.Use(
+	r.use(
 		middleware.Recovery,
 		middleware.SecurityHeadersWithOptions(r.securityHeadersOpts...),
 	)
@@ -551,7 +628,7 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	// registering routes under that prefix. The predicate is the only
 	// surface that can match — no per-route policy is consulted.
 	for _, er := range r.earlyResponders {
-		r.mux.Use(earlyResponderMiddleware(er))
+		r.use(earlyResponderMiddleware(er))
 	}
 
 	// --- Default middleware layer (listener-level auth guards from AuthPlan chain) ---
@@ -560,24 +637,24 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	// applyListenerAuthChain. Applied AFTER early-responders so framework
 	// isolation contracts fire before the auth gate.
 	if len(r.defaultMiddleware) > 0 {
-		r.mux.Use(r.defaultMiddleware...)
+		r.use(r.defaultMiddleware...)
 	}
 
 	// --- Protection chain (per-router options) ---
 	if r.rateLimiter != nil {
-		r.mux.Use(middleware.RateLimit(r.rateLimiter))
+		r.use(middleware.RateLimit(r.rateLimiter))
 	}
 	if r.circuitBreaker != nil {
 		cb, err := middleware.CircuitBreaker(r.circuitBreaker)
 		if err != nil {
 			return fmt.Errorf("router: circuit breaker middleware: %w", err)
 		}
-		r.mux.Use(cb)
+		r.use(cb)
 	}
 	if r.authVerifier != nil {
-		r.mux.Use(auth.AuthMiddleware(r.authVerifier, r.buildAuthOpts()...))
+		r.use(auth.AuthMiddleware(r.authVerifier, r.buildAuthOpts()...))
 	}
-	r.mux.Use(middleware.BodyLimit(r.bodyLimit))
+	r.use(middleware.BodyLimit(r.bodyLimit))
 	return nil
 }
 
@@ -608,44 +685,75 @@ func (r *Router) buildAuthOpts() []auth.AuthOption {
 }
 
 // Handle registers a handler for the given pattern, implementing cell.RouteMux.
+// pattern follows the stdlib ServeMux 1.22 form ("METHOD /path/{param}" or
+// "/path"). The handler is registered directly on the underlying ServeMux
+// without any extra middleware wrap; root-level middleware (observability,
+// auth, body-limit, etc.) is composed by Router.Handler.
 func (r *Router) Handle(pattern string, handler http.Handler) {
 	r.mux.Handle(pattern, handler)
 }
 
-// Group creates a sub-scope, implementing cell.RouteMux.
+// Group creates a sub-scope, implementing cell.RouteMux. The returned adapter
+// shares the same underlying ServeMux as the parent. Group is a structural
+// helper for clustering related route registrations; it does not introduce
+// its own middleware scope (use With for that).
 func (r *Router) Group(fn func(kcell.RouteMux)) {
-	r.mux.Group(func(cr chi.Router) {
-		sub := &chiRouterAdapter{cr: cr, declarer: r}
-		fn(sub)
-	})
+	sub := r.newAdapter("", nil)
+	fn(sub)
 }
 
-// Route mounts a sub-router under the given pattern. The adapter carries
-// both the chi sub-router and a reference to the Router-rooted declarer so
-// that auth.Mount called on a nested sub-mux composes the mount prefix
-// with the declared path and forwards AuthRouteMeta to the top-level Router.
+// Route mounts a sub-router under the given prefix. The adapter carries both
+// the prefix and a reference to the Router-rooted declarer so that auth.Mount
+// called on a nested sub-mux composes the mount prefix with the declared path
+// and forwards AuthRouteMeta to the top-level Router.
 func (r *Router) Route(pattern string, fn func(kcell.RouteMux)) {
-	r.mux.Route(pattern, func(cr chi.Router) {
-		sub := &chiRouterAdapter{cr: cr, prefix: pattern, declarer: r}
-		fn(sub)
-	})
+	sub := r.newAdapter(pattern, nil)
+	fn(sub)
 }
 
-// Mount attaches an http.Handler under the given prefix.
+// Mount attaches an http.Handler under the given prefix. Stdlib ServeMux
+// requires sub-tree patterns to end in "/"; the trailing slash is added
+// implicitly. The handler sees the request path with the prefix stripped.
 func (r *Router) Mount(prefix string, handler http.Handler) {
-	r.mux.Mount(prefix, handler)
+	canonical := strings.TrimSuffix(prefix, "/")
+	if canonical == "" {
+		// Mount at root: ServeMux dispatches everything to the handler.
+		r.mux.Handle("/", handler)
+		return
+	}
+	r.mux.Handle(canonical+"/", http.StripPrefix(canonical, handler))
 }
 
 // With returns a new RouteMux that applies the given middleware to routes
-// registered through it, without modifying the receiver.
+// registered through it, without modifying the receiver. Each subsequent
+// Handle on the returned adapter wraps the handler with the captured chain
+// before registering on the shared ServeMux.
 func (r *Router) With(mw ...func(http.Handler) http.Handler) kcell.RouteMux {
-	return &chiRouterAdapter{cr: r.mux.With(mw...), declarer: r}
+	return r.newAdapter("", mw)
+}
+
+// newAdapter builds a fresh nativeMuxAdapter rooted at this Router. prefix
+// composes with auth.Mount paths declared inside the adapter; mws is the
+// per-adapter middleware chain that wraps each Handle/Mount registration.
+func (r *Router) newAdapter(prefix string, mws []Middleware) *nativeMuxAdapter {
+	var mwsCopy []Middleware
+	if len(mws) > 0 {
+		mwsCopy = append([]Middleware(nil), mws...)
+	}
+	return &nativeMuxAdapter{
+		mux:         r.mux,
+		prefix:      prefix,
+		middlewares: mwsCopy,
+		declarer:    r,
+		owner:       r,
+	}
 }
 
 // MountRouteGroup mounts a cell RouteGroup and records its HTTP namespace
 // ownership for root-level observability. Cell ownership is resolved before
 // protection middleware, so auth/rate-limit/circuit-breaker/body-limit rejects
-// and chi 405s receive the same cell label as successful handler executions.
+// and ServeMux 405 responses all receive the same cell label as successful
+// handler executions.
 func (r *Router) MountRouteGroup(rg kcell.RouteGroup) error {
 	if rg.Register == nil {
 		return fmt.Errorf("router: RouteGroup for listener %q has nil Register function", rg.Listener.String())
@@ -656,42 +764,18 @@ func (r *Router) MountRouteGroup(rg kcell.RouteGroup) error {
 		}
 	}
 
-	var registerErr error
 	var adapterErr error
-	if rg.Prefix != "" {
-		r.mux.Route(rg.Prefix, func(cr chi.Router) {
-			if len(rg.Middleware) > 0 {
-				cr = cr.With(rg.Middleware...)
-			}
-			sub := &chiRouterAdapter{
-				cr:       cr,
-				prefix:   rg.Prefix,
-				declarer: r,
-				owner:    r,
-				cellID:   rg.CellID,
-				err:      &adapterErr,
-			}
-			registerErr = rg.Register(sub)
-		})
-		if registerErr != nil {
-			return registerErr
-		}
-		return adapterErr
+	sub := &nativeMuxAdapter{
+		mux:         r.mux,
+		prefix:      rg.Prefix,
+		middlewares: append([]Middleware(nil), rg.Middleware...),
+		declarer:    r,
+		owner:       r,
+		cellID:      rg.CellID,
+		err:         &adapterErr,
 	}
-
-	cr := chi.Router(r.mux)
-	if len(rg.Middleware) > 0 {
-		cr = r.mux.With(rg.Middleware...)
-	}
-	registerErr = rg.Register(&chiRouterAdapter{
-		cr:       cr,
-		declarer: r,
-		owner:    r,
-		cellID:   rg.CellID,
-		err:      &adapterErr,
-	})
-	if registerErr != nil {
-		return registerErr
+	if err := rg.Register(sub); err != nil {
+		return err
 	}
 	return adapterErr
 }
@@ -826,15 +910,19 @@ func (r *Router) verifyInternalRouteAffinity() error {
 	return nil
 }
 
-// enumerateRoutes walks the single mux and returns all registered (method, path) pairs.
+// enumerateRoutes returns all registered (method, path) pairs collected via
+// recordRoutePattern during route registration. This replaces the prior
+// chi.Walk traversal: stdlib ServeMux exposes no public route-iteration API,
+// so the router is the sole source of truth for registered patterns.
 func (r *Router) enumerateRoutes() []routeKey {
-	var routes []routeKey
-	collect := func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
-		routes = append(routes, routeKey{Method: method, Path: route})
+	if len(r.routePatterns) == 0 {
 		return nil
 	}
-	_ = chi.Walk(r.mux, collect)
-	return routes
+	out := make([]routeKey, 0, len(r.routePatterns))
+	for _, p := range r.routePatterns {
+		out = append(out, routeKey{Method: p.method, Path: p.path})
+	}
+	return out
 }
 
 // authMetaPartition holds the categorized results of partitionAuthMetas.
@@ -987,9 +1075,9 @@ func not404Handler(w http.ResponseWriter, r *http.Request) {
 // contract — primary listener never reveals that /internal/v1/* routes
 // exist — does not depend on a JWT public-matcher exemption.
 //
-// PR-258 RES-5 narrowing: replaces the prior chi.Handle("/internal/v1/*",
-// 404) + WithPublicPathPrefix("/internal/v1/") + frameworkPrimaryWhitelist
-// triple-mechanism. The new model has a single surface: the predicate.
+// PR-258 RES-5 narrowing: replaces the prior listener-mux Handle 404 +
+// WithPublicPathPrefix("/internal/v1/") + frameworkPrimaryWhitelist triple-
+// mechanism. The new model has a single surface: the predicate.
 func InternalPrefixIsolationResponder() Option {
 	bare := strings.TrimSuffix(internalPathPrefix, "/")
 	predicate := func(r *http.Request) bool {
@@ -1231,45 +1319,52 @@ func orMergeMethodPath(a, b func(method, urlPath string) bool) func(string, stri
 	}
 }
 
-// chiRouterAdapter wraps chi.Router to implement cell.RouteMux. prefix is the
-// mount prefix the adapter inherited from its parent Route; declarer points to
-// the Router-rooted AuthRouteDeclarer so nested auth.Mount calls propagate
-// metadata with the fully-composed path.
-type chiRouterAdapter struct {
-	cr       chi.Router
-	prefix   string
-	declarer kcell.AuthRouteDeclarer
-	owner    *Router
-	cellID   string
-	err      *error
+// nativeMuxAdapter implements cell.RouteMux on top of stdlib *http.ServeMux.
+//
+// All adapters under the same Router share a single ServeMux pointer; prefix
+// composition and middleware chains are tracked per adapter and applied at
+// Handle time. declarer points to the Router-rooted AuthRouteDeclarer so
+// nested auth.Mount calls propagate metadata with the fully-composed path.
+type nativeMuxAdapter struct {
+	mux         *http.ServeMux
+	prefix      string
+	middlewares []Middleware
+	declarer    kcell.AuthRouteDeclarer
+	owner       *Router
+	cellID      string
+	err         *error
 }
 
-// Compile-time checks: chiRouterAdapter forwards AuthRouteMeta + declares
-// its mount prefix so auth.Mount can derive chi-relative registration paths
+// Compile-time checks: nativeMuxAdapter forwards AuthRouteMeta + declares its
+// mount prefix so auth.Mount can derive ServeMux-relative registration paths
 // from fully-qualified Contract.Path literals.
-var _ kcell.AuthRouteDeclarer = (*chiRouterAdapter)(nil)
-var _ kcell.Prefixer = (*chiRouterAdapter)(nil)
-var _ kcell.HTTPContractDeclarer = (*chiRouterAdapter)(nil)
+var _ kcell.AuthRouteDeclarer = (*nativeMuxAdapter)(nil)
+var _ kcell.Prefixer = (*nativeMuxAdapter)(nil)
+var _ kcell.HTTPContractDeclarer = (*nativeMuxAdapter)(nil)
 
-// Prefix returns the sub-route mount prefix this adapter inherited from
-// its parent Route. An empty prefix means the adapter sits directly under
-// the Router (Group / top-level) and contributes no path composition.
-func (a *chiRouterAdapter) Prefix() string { return a.prefix }
+// Prefix returns the sub-route mount prefix this adapter inherited from its
+// parent Route. An empty prefix means the adapter sits directly under the
+// Router (Group / top-level) and contributes no path composition.
+func (a *nativeMuxAdapter) Prefix() string { return a.prefix }
 
-func (a *chiRouterAdapter) Handle(pattern string, handler http.Handler) {
+func (a *nativeMuxAdapter) Handle(pattern string, handler http.Handler) {
 	if a.hasRegistrationErr() {
 		return
 	}
-	if method, routePath := splitHandlePattern(pattern); routePath != "" {
+	method, routePath := splitHandlePattern(pattern)
+	if routePath != "" {
 		if err := a.recordOwnedRoute(method, routePath); err != nil {
 			a.setRegistrationErr(err)
 			return
 		}
 	}
-	a.cr.Handle(pattern, handler)
+	if len(a.middlewares) > 0 {
+		handler = chain(handler, a.middlewares...)
+	}
+	a.mux.Handle(combineHandlePattern(a.prefix, pattern), handler)
 }
 
-func (a *chiRouterAdapter) Route(pattern string, fn func(kcell.RouteMux)) {
+func (a *nativeMuxAdapter) Route(pattern string, fn func(kcell.RouteMux)) {
 	if a.hasRegistrationErr() {
 		return
 	}
@@ -1278,47 +1373,72 @@ func (a *chiRouterAdapter) Route(pattern string, fn func(kcell.RouteMux)) {
 		a.setRegistrationErr(err)
 		return
 	}
-	a.cr.Route(pattern, func(cr chi.Router) {
-		sub := &chiRouterAdapter{
-			cr:       cr,
-			prefix:   fullPrefix,
-			declarer: a.declarer,
-			owner:    a.owner,
-			cellID:   a.cellID,
-			err:      a.err,
-		}
-		fn(sub)
-	})
+	sub := &nativeMuxAdapter{
+		mux:         a.mux,
+		prefix:      fullPrefix,
+		middlewares: append([]Middleware(nil), a.middlewares...),
+		declarer:    a.declarer,
+		owner:       a.owner,
+		cellID:      a.cellID,
+		err:         a.err,
+	}
+	fn(sub)
 }
 
-func (a *chiRouterAdapter) Mount(pattern string, handler http.Handler) {
+func (a *nativeMuxAdapter) Mount(pattern string, handler http.Handler) {
 	if a.hasRegistrationErr() {
 		return
 	}
-	if err := a.recordOwnedPrefix(joinPrefix(a.prefix, pattern)); err != nil {
+	fullPrefix := joinPrefix(a.prefix, pattern)
+	if err := a.recordOwnedPrefix(fullPrefix); err != nil {
 		a.setRegistrationErr(err)
 		return
 	}
-	a.cr.Mount(pattern, handler)
+	canonical := strings.TrimSuffix(fullPrefix, "/")
+	if len(a.middlewares) > 0 {
+		handler = chain(handler, a.middlewares...)
+	}
+	if canonical == "" {
+		a.mux.Handle("/", handler)
+		return
+	}
+	a.mux.Handle(canonical+"/", http.StripPrefix(canonical, handler))
 }
 
-func (a *chiRouterAdapter) Group(fn func(kcell.RouteMux)) {
+func (a *nativeMuxAdapter) Group(fn func(kcell.RouteMux)) {
 	if a.hasRegistrationErr() {
 		return
 	}
-	a.cr.Group(func(cr chi.Router) {
-		sub := &chiRouterAdapter{cr: cr, prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID, err: a.err}
-		fn(sub)
-	})
+	sub := &nativeMuxAdapter{
+		mux:         a.mux,
+		prefix:      a.prefix,
+		middlewares: append([]Middleware(nil), a.middlewares...),
+		declarer:    a.declarer,
+		owner:       a.owner,
+		cellID:      a.cellID,
+		err:         a.err,
+	}
+	fn(sub)
 }
 
-func (a *chiRouterAdapter) With(mw ...func(http.Handler) http.Handler) kcell.RouteMux {
-	return &chiRouterAdapter{cr: a.cr.With(mw...), prefix: a.prefix, declarer: a.declarer, owner: a.owner, cellID: a.cellID, err: a.err}
+func (a *nativeMuxAdapter) With(mw ...func(http.Handler) http.Handler) kcell.RouteMux {
+	merged := make([]Middleware, 0, len(a.middlewares)+len(mw))
+	merged = append(merged, a.middlewares...)
+	merged = append(merged, mw...)
+	return &nativeMuxAdapter{
+		mux:         a.mux,
+		prefix:      a.prefix,
+		middlewares: merged,
+		declarer:    a.declarer,
+		owner:       a.owner,
+		cellID:      a.cellID,
+		err:         a.err,
+	}
 }
 
 // DeclareAuthMeta composes the adapter's mount prefix with the declared path
 // before handing the metadata off to the Router.
-func (a *chiRouterAdapter) DeclareAuthMeta(m kcell.AuthRouteMeta) error {
+func (a *nativeMuxAdapter) DeclareAuthMeta(m kcell.AuthRouteMeta) error {
 	if a.declarer == nil {
 		return nil
 	}
@@ -1330,8 +1450,8 @@ func (a *chiRouterAdapter) DeclareAuthMeta(m kcell.AuthRouteMeta) error {
 
 // DeclareHTTPContract forwards the route's full ContractSpec to the
 // Router-rooted declarer. ContractSpec.Path is already the canonical full
-// path, so unlike AuthRouteMeta it is not composed with the chi prefix.
-func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error {
+// path, so unlike AuthRouteMeta it is not composed with the adapter prefix.
+func (a *nativeMuxAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error {
 	if a.owner != nil {
 		a.owner.recordRoutePattern(spec.Method, spec.Path)
 		if a.cellID != "" {
@@ -1350,14 +1470,14 @@ func (a *chiRouterAdapter) DeclareHTTPContract(spec wrapper.ContractSpec) error 
 	return nil
 }
 
-func (a *chiRouterAdapter) recordOwnedPrefix(prefix string) error {
+func (a *nativeMuxAdapter) recordOwnedPrefix(prefix string) error {
 	if a.owner == nil || a.cellID == "" {
 		return nil
 	}
 	return a.owner.recordOwnedPrefix(a.cellID, prefix)
 }
 
-func (a *chiRouterAdapter) recordOwnedRoute(method, routePath string) error {
+func (a *nativeMuxAdapter) recordOwnedRoute(method, routePath string) error {
 	if a.owner == nil {
 		return nil
 	}
@@ -1372,15 +1492,31 @@ func (a *chiRouterAdapter) recordOwnedRoute(method, routePath string) error {
 	return nil
 }
 
-func (a *chiRouterAdapter) setRegistrationErr(err error) {
+func (a *nativeMuxAdapter) setRegistrationErr(err error) {
 	if err == nil || a.err == nil || *a.err != nil {
 		return
 	}
 	*a.err = err
 }
 
-func (a *chiRouterAdapter) hasRegistrationErr() bool {
+func (a *nativeMuxAdapter) hasRegistrationErr() bool {
 	return a.err != nil && *a.err != nil
+}
+
+// combineHandlePattern composes the adapter's prefix into a stdlib ServeMux
+// pattern. Input pattern follows the "[METHOD ]/path" form; the prefix is
+// applied to the path component only, and the optional method is preserved
+// verbatim. Empty prefix returns the original pattern.
+func combineHandlePattern(prefix, pattern string) string {
+	if prefix == "" {
+		return pattern
+	}
+	method, routePath := splitHandlePattern(pattern)
+	full := joinPrefix(prefix, routePath)
+	if method == "" {
+		return full
+	}
+	return method + " " + full
 }
 
 // joinPrefix composes a parent mount prefix with a child pattern/path,

--- a/runtime/http/router/router_contract_test.go
+++ b/runtime/http/router/router_contract_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,9 +16,9 @@ import (
 // ---------------------------------------------------------------------------
 // Contract tests for Mount / Route / Group behavior.
 //
-// These tests document the routing contract that any future router
-// implementation must satisfy.  They exercise chi-backed behavior today and
-// serve as a regression safety net for router replacement.
+// These tests document the routing contract that the router must satisfy on
+// top of stdlib net/http.ServeMux. They exercise the prefix/strip semantics
+// of Mount and the method+pattern matching guarantees of stdlib 1.22+.
 // ---------------------------------------------------------------------------
 
 // --- Mount Prefix Stripping ------------------------------------------------
@@ -74,12 +73,12 @@ func TestMount_PrefixStripping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := MustNew(WithRouterClock(clock.Real()))
 
-			sub := chi.NewRouter()
+			sub := http.NewServeMux()
 			body := tt.wantBody
-			sub.Get(tt.subPattern, func(w http.ResponseWriter, _ *http.Request) {
+			sub.Handle("GET "+tt.subPattern, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(body))
-			})
+			}))
 			r.Mount(tt.mountPrefix, sub)
 
 			rec := httptest.NewRecorder()
@@ -99,10 +98,10 @@ func TestMount_PrefixStripping(t *testing.T) {
 func TestMount_MiddlewareInheritance(t *testing.T) {
 	r := MustNew(WithRouterClock(clock.Real())) // New() applies default middleware (RequestID, SecurityHeaders, etc.)
 
-	sub := chi.NewRouter()
-	sub.Get("/resource", func(w http.ResponseWriter, _ *http.Request) {
+	sub := http.NewServeMux()
+	sub.Handle("GET /resource", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	})
+	}))
 	r.Mount("/api", sub)
 
 	rec := httptest.NewRecorder()
@@ -353,10 +352,10 @@ func TestRoute_NotFoundAndMethodNotAllowed(t *testing.T) {
 
 func TestMount_NotFoundAndMethodNotAllowed(t *testing.T) {
 	r := MustNew(WithRouterClock(clock.Real()))
-	sub := chi.NewRouter()
-	sub.Get("/items", func(w http.ResponseWriter, _ *http.Request) {
+	sub := http.NewServeMux()
+	sub.Handle("GET /items", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	})
+	}))
 	r.Mount("/store", sub)
 
 	tests := []struct {
@@ -391,20 +390,26 @@ func TestMount_NotFoundAndMethodNotAllowed(t *testing.T) {
 func TestMount_Nested(t *testing.T) {
 	r := MustNew(WithRouterClock(clock.Real()))
 
-	// Inner sub-router mounted at /v1 inside the outer sub-router at /api.
-	// The handler's pattern is relative to the innermost mount point.
-	inner := chi.NewRouter()
-	inner.Get("/resource", func(w http.ResponseWriter, _ *http.Request) {
+	// Inner sub-mux is mounted at /v1 inside an outer sub-mux at /api. The
+	// inner handler patterns are relative to the innermost mount point — once
+	// outer's StripPrefix peels /api and inner's StripPrefix peels /v1, a
+	// request to /api/v1/resource lands at /resource on the inner mux.
+	inner := http.NewServeMux()
+	inner.Handle("GET /resource", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("inner-resource"))
-	})
-	inner.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+	}))
+	inner.Handle("GET /", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("inner-root"))
-	})
+	}))
 
-	outer := chi.NewRouter()
-	outer.Mount("/v1", inner)
+	outer := http.NewServeMux()
+	// Same Mount semantics as Router.Mount, applied to a stdlib outer mux:
+	// register the subtree (/v1/) and the bare prefix (/v1) with the inner
+	// path rewritten to "/" so inner.GET / matches /api/v1.
+	outer.Handle("/v1/", http.StripPrefix("/v1", inner))
+	outer.Handle("/v1", mountBareHandler(inner))
 
 	r.Mount("/api", outer)
 
@@ -438,12 +443,12 @@ func TestMount_Nested(t *testing.T) {
 func TestMount_WithRouteParams(t *testing.T) {
 	r := MustNew(WithRouterClock(clock.Real()))
 
-	sub := chi.NewRouter()
-	sub.Get("/{id}", func(w http.ResponseWriter, req *http.Request) {
-		id := chi.URLParam(req, "id")
+	sub := http.NewServeMux()
+	sub.Handle("GET /{id}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		id := req.PathValue("id")
 		w.Header().Set("X-Param-ID", id)
 		w.WriteHeader(http.StatusOK)
-	})
+	}))
 	r.Mount("/users", sub)
 
 	tests := []struct {

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -1833,6 +1833,114 @@ func TestRouter_DispatchPopulatesPathValue(t *testing.T) {
 	assert.Equal(t, "42", capturedID, "patternRecordingMux must propagate PathValue to leaf handler")
 }
 
+// TestRouter_RawHandle_DuplicateAcrossCells_FailsFast verifies the P1 fix:
+// nativeMuxAdapter.Handle must run the cross-cell ownership check BEFORE the
+// ServeMux dedup (markMuxHandler). Without this ordering, the second cell's
+// duplicate registration is silently swallowed instead of failing fast.
+func TestRouter_RawHandle_DuplicateAcrossCells_FailsFast(t *testing.T) {
+	r := MustNew(WithRouterClock(clock.Real()))
+
+	// cell-a registers GET /api/v1/shared/foo
+	err := r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/shared",
+		CellID:   "cell-a",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /foo", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			return nil
+		},
+	})
+	require.NoError(t, err, "first RouteGroup registration must succeed")
+
+	// cell-b tries to register the same path — must be rejected.
+	err = r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/shared",
+		CellID:   "cell-b",
+		Register: func(mux cell.RouteMux) error {
+			mux.Handle("GET /foo", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			return nil
+		},
+	})
+	require.Error(t, err, "second RouteGroup with duplicate path from a different cell must fail")
+	assert.Contains(t, err.Error(), "duplicate route ownership",
+		"error must mention duplicate route ownership")
+}
+
+// TestRouter_RejectPath_RouteLabelConsistent verifies the P2 fix: all three
+// observability layers (metrics, access log, tracing) report the same
+// low-cardinality route pattern even when the request is rejected before
+// dispatch (e.g. 401 from JWT auth middleware).
+func TestRouter_RejectPath_RouteLabelConsistent(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	spy := &routerSpyTracer{}
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+	original := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(original)
+
+	verifier := &routerTestVerifier{
+		claims: auth.Claims{Subject: "user-1"},
+	}
+	r := MustNew(
+		WithRouterClock(clock.Real()),
+		WithMetricsCollector(mc),
+		WithTracer(spy),
+		WithAuthMiddleware(verifier),
+	)
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   "/api/v1/reject",
+		CellID:   "rejectcell",
+		Register: func(mux cell.RouteMux) error {
+			return auth.Mount(mux, auth.Route{
+				Contract: testHTTPContract(http.MethodGet, "/api/v1/reject/items/{id}"),
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					t.Fatal("handler must not run when auth rejects")
+				}),
+			})
+		},
+	}))
+	require.NoError(t, r.FinalizeAuth())
+
+	// Request without a token — auth rejects before dispatch, so the
+	// dispatch-time recorder never fires.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/reject/items/99", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	wantRoute := "/api/v1/reject/items/{id}"
+
+	// 1) Metrics route label must be the template, not "unmatched".
+	snap := mc.Snapshot()
+	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
+		"rejectcell", http.MethodGet, wantRoute, http.StatusUnauthorized,
+	)], "metrics route label must be the template on auth-reject path")
+	assert.Equal(t, int64(0), snap.RequestCounts[routerRequestKey(
+		"rejectcell", http.MethodGet, "unmatched", http.StatusUnauthorized,
+	)], "metrics route label must NOT be 'unmatched' on a registered path")
+
+	// 2) Access log route field must be the template, not "unmatched".
+	entry, found := findAccessLogEntry(logBuf.Bytes(), "/api/v1/reject/items/99")
+	require.True(t, found, "access log entry must exist for the rejected request")
+	assert.Equal(t, wantRoute, entry["route"],
+		"access log route field must be the template on auth-reject path")
+
+	// 3) Tracing span http.route attribute must be the template.
+	// The spy tracer collects spans; the Tracing middleware emits one per request.
+	spans := spy.spans
+	require.NotEmpty(t, spans, "tracing span must be emitted")
+	assert.Equal(t, wantRoute, spans[0].Attr("http.route"),
+		"tracing http.route attribute must be the template on auth-reject path")
+}
+
 // TestMountRouteGroup_NonServeMuxHandler_RouteLabelDegrades asserts that
 // mounting a plain http.HandlerFunc (not *http.ServeMux) records the mount
 // prefix as the route label instead of falling back to "unmatched".

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -1808,3 +1808,61 @@ func TestRouter_ServeHTTP_NoFinalizeAuth_FailsClosed(t *testing.T) {
 	require.NotPanics(t, func() { r.ServeHTTP(rec, req) })
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// TestRouter_DispatchPopulatesPathValue asserts that stdlib ServeMux path
+// parameters are still accessible via req.PathValue inside the leaf handler
+// after patternRecordingMux double-dispatch.
+func TestRouter_DispatchPopulatesPathValue(t *testing.T) {
+	r := MustNew(
+		WithRouterClock(clock.Real()),
+		WithPolicyCoverageWhitelist([]string{"/api/v1/users/*"}),
+	)
+
+	var capturedID string
+	r.Handle("GET /api/v1/users/{id}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		capturedID = req.PathValue("id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	require.NoError(t, r.FinalizeAuth())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/42", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "42", capturedID, "patternRecordingMux must propagate PathValue to leaf handler")
+}
+
+// TestMountRouteGroup_NonServeMuxHandler_RouteLabelDegrades asserts that
+// mounting a plain http.HandlerFunc (not *http.ServeMux) records the mount
+// prefix as the route label instead of falling back to "unmatched".
+func TestMountRouteGroup_NonServeMuxHandler_RouteLabelDegrades(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	r := MustNew(WithRouterClock(clock.Real()), WithMetricsCollector(mc))
+
+	require.NoError(t, r.MountRouteGroup(cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		CellID:   "legacycell",
+		Register: func(mux cell.RouteMux) error {
+			mux.Mount("/legacy", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			return nil
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/legacy/anything", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	snap := mc.Snapshot()
+	// Route label must be the mount prefix form, not "unmatched", and must not
+	// be a sub-path-granularity pattern (non-ServeMux internal routing is opaque).
+	key := routerRequestKey("legacycell", http.MethodGet, "/legacy/", http.StatusOK)
+	assert.Equal(t, int64(1), snap.RequestCounts[key],
+		"non-ServeMux mount must degrade to mount-prefix route label, not 'unmatched'")
+	unmatchedKey := routerRequestKey("legacycell", http.MethodGet, "unmatched", http.StatusOK)
+	assert.Equal(t, int64(0), snap.RequestCounts[unmatchedKey],
+		"route label must not be 'unmatched' for a mounted non-ServeMux handler")
+}

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/coder/websocket"
-	"github.com/go-chi/chi/v5"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -486,10 +485,10 @@ func TestMountRouteGroup_CellAttribution_RawMountPrefix(t *testing.T) {
 		Listener: cell.PrimaryListener,
 		CellID:   "mountcell",
 		Register: func(mux cell.RouteMux) error {
-			sub := chi.NewRouter()
-			sub.Get("/ok", func(w http.ResponseWriter, _ *http.Request) {
+			sub := http.NewServeMux()
+			sub.Handle("GET /ok", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusNoContent)
-			})
+			}))
 			mux.Mount("/mounted", sub)
 			return nil
 		},
@@ -522,11 +521,11 @@ func TestGroup(t *testing.T) {
 
 func TestMount(t *testing.T) {
 	r := MustNew(WithRouterClock(clock.Real()))
-	subRouter := chi.NewRouter()
-	subRouter.Get("/hello", func(w http.ResponseWriter, _ *http.Request) {
+	subMux := http.NewServeMux()
+	subMux.Handle("GET /hello", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	})
-	r.Mount("/sub", subRouter)
+	}))
+	r.Mount("/sub", subMux)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/sub/hello", nil)

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -146,7 +146,7 @@ func TestHTTPMetricsLabelRouterAttribution01(t *testing.T) {
 			rememberFirstPos(&authPos, call.Pos())
 		case isSelectorCall(call, "middleware", "BodyLimit"):
 			rememberFirstPos(&bodyLimitPos, call.Pos())
-		case isMuxUseWithDefaultMiddleware(call):
+		case isRouterUseWithDefaultMiddleware(call):
 			rememberFirstPos(&defaultMWPos, call.Pos())
 		}
 		return true
@@ -347,7 +347,7 @@ func selectorQualifier(expr ast.Expr) string {
 	}
 }
 
-func isMuxUseWithDefaultMiddleware(call *ast.CallExpr) bool {
+func isRouterUseWithDefaultMiddleware(call *ast.CallExpr) bool {
 	if !isSelectorCall(call, "r", "use") {
 		return false
 	}

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -348,7 +348,7 @@ func selectorQualifier(expr ast.Expr) string {
 }
 
 func isMuxUseWithDefaultMiddleware(call *ast.CallExpr) bool {
-	if !isSelectorCall(call, "r.mux", "Use") {
+	if !isSelectorCall(call, "r", "use") {
 		return false
 	}
 	for _, arg := range call.Args {

--- a/tools/codegen/contractgen/templates/handler.tmpl
+++ b/tools/codegen/contractgen/templates/handler.tmpl
@@ -7,10 +7,6 @@ import (
 {{- if and (not .Endpoint.IsPagination) (hasQueryNumeric .Endpoint.QueryParams)}}
 	"strconv"
 {{- end}}
-{{- if hasPathParams .Endpoint}}
-
-	"github.com/go-chi/chi/v5"
-{{- end}}
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/wrapper"
@@ -59,7 +55,7 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	req := &Request{}
 {{- range .Endpoint.PathParams}}
 	{
-		v := chi.URLParam(r, "{{.Name}}")
+		v := r.PathValue("{{.Name}}")
 {{- if hasMinLength .MinLength}}
 		if len(v) < {{derefInt .MinLength}} {
 			httputil.WriteDomainError(r.Context(), w, errcode.New(errcode.ErrValidationFailed, "{{.Name}}: value too short"))

--- a/tools/codegen/contractgen/testdata/golden/http_order_get_v1_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/http_order_get_v1_handler_gen_go.golden
@@ -6,8 +6,6 @@ package get
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -54,7 +52,7 @@ func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	req := &Request{}
 	{
-		v := chi.URLParam(r, "id")
+		v := r.PathValue("id")
 		if len(v) < 1 {
 			httputil.WriteDomainError(r.Context(), w, errcode.New(errcode.ErrValidationFailed, "id: value too short"))
 			return

--- a/tools/codegen/contractgen/testdata/golden/synth_http_full_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_http_full_handler_gen_go.golden
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -55,7 +53,7 @@ func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	req := &Request{}
 	{
-		v := chi.URLParam(r, "id")
+		v := r.PathValue("id")
 		if len(v) < 1 {
 			httputil.WriteDomainError(r.Context(), w, errcode.New(errcode.ErrValidationFailed, "id: value too short"))
 			return

--- a/tools/codegen/contractgen/testdata/golden/synth_http_keyword_conflict_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_http_keyword_conflict_handler_gen_go.golden
@@ -6,8 +6,6 @@ package configdelete
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -54,7 +52,7 @@ func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	req := &Request{}
 	{
-		v := chi.URLParam(r, "key")
+		v := r.PathValue("key")
 		if len(v) < 1 {
 			httputil.WriteDomainError(r.Context(), w, errcode.New(errcode.ErrValidationFailed, "key: value too short"))
 			return


### PR DESCRIPTION
## Summary

Replace `github.com/go-chi/chi/v5` with stdlib `net/http.ServeMux` end-to-end. Runtime, codegen template, generated handlers, archtest, fixtures, docs and `go.mod` are all migrated in a single PR — no chi imports remain in the tree, `go mod why github.com/go-chi/chi/v5` reports the package is no longer needed.

Go 1.25.9 is the new floor: stdlib supports method+pattern routing (1.22+) and `r.PathValue` (1.22+), so the project's wrapper layer (`pkg/httputil` / `runtime/auth/guard.go`) — which had already standardised on `r.PathValue` before this PR — needs no further change.

### Architectural notes

- `runtime/http/router.Router` now wraps `*http.ServeMux`. Listener-root middleware lives on `Router.middlewares` and is composed lazily by `Router.Handler()` around a `patternRecordingMux` dispatch wrapper.
- `patternRecordingMux` does a two-pass dispatch: `(*ServeMux).Handler` is called first to recover the matched pattern (ServeMux's path-only `/api/v1/users/{id}` form, with the leading `METHOD ` prefix stripped) and write it to the request-scoped `*patternRecorder`; then `(*ServeMux).ServeHTTP` performs the actual dispatch so `r.PathValue` sees populated values inside leaf handlers.
- `RoutePatternFromCtx` reads the recorder so Tracing / AccessLog / Metrics keep their existing post-`next.ServeHTTP` semantics. Outermost `patternRecorderMiddleware` installs the recorder so every middleware in the chain observes the same pattern after `next` returns.
- `nativeMuxAdapter` replaces `chiRouterAdapter`. Prefix accumulation + per-adapter middleware chain wraps each `Handle`/`Mount` registration on the shared ServeMux. `Mount` registers both the bare prefix and the trailing-slash subtree (with a path-rewriting `mountBareHandler`) to preserve chi's "no 301 redirect for `/api`" behaviour.
- `mountPatternRecorder` upgrades `*http.ServeMux` mount handlers so the recorded route is `prefix + inner pattern` instead of just the subtree prefix, retaining the per-route metric label granularity for cell mounts.
- `Router.muxHandlers` tracks actual ServeMux registrations independently of `routePatterns`. Stdlib ServeMux panics on duplicate `(method, path)` registrations; this PR drops the second mux.Handle call so `FinalizeAuth`'s structured "duplicate auth declaration" error remains the canonical user-visible signal.
- `recordRoutePattern` fans method-less `Handle` calls into all business methods so `policy_coverage` and the resolver still see per-method entries (mirroring chi.Walk semantics).
- `enumerateRoutes` now returns `Router.routePatterns` directly — chi.Walk was the only public API exposing the registered route tree and stdlib has no equivalent.

### Refs

- archtest: `tools/archtest/http_metrics_label_test.go::ROUTER-ATTRIBUTION-01` updated to assert `r.use(...)` instead of `r.mux.Use(...)`.
- codegen: `tools/codegen/contractgen/templates/handler.tmpl` drops the chi import; path params use `r.PathValue("...")`. Three goldens regenerated; `generated/contracts/http/order/get/v1/handler_gen.go` regenerated.
- example fixture: `examples/todoorder/cells/ordercell/slices/orderquery/contract_test.go` mounts via stdlib `http.NewServeMux`.
- middleware tests: shared `buildTestServer` helper in `runtime/http/middleware/route_pattern_helper_test.go` mirrors `Router.Handler` wiring without an import cycle.
- active docs synced: `.claude/rules/gocell/runtime-api.md`, `docs/ops/listener-topology.md`, `docs/design/capability-inventory.md`, `docs/design/master-plan.md`, `docs/references/framework-comparison.md`.

### ref

- ref: net/http.ServeMux (Go 1.22+) — method+pattern routing, automatic 405, automatic HEAD-from-GET, r.PathValue
- ref: net/http.Request.Pattern (Go 1.23+) — observed but not used; leaf-only field, not safe in middleware after `r.WithContext` rewrites Request

## Test plan

- [x] `go build ./...` — green
- [x] `go test ./...` — green (all packages)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `grep -rn '"github.com/go-chi/chi'` across `*.go` / `*.tmpl` / `*.golden` — empty
- [x] `go mod why github.com/go-chi/chi/v5` — "main module does not need package"
- [x] archtest `ROUTER-ATTRIBUTION-01` GREEN with new `r.use(...)` matcher
- [x] codegen golden regeneration verified (3 files); regenerated `handler_gen.go` matches the new template
- [x] pre-push generated-artifact gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)