### PR TITLE
fix(kernel/assembly): close startInternal snapshots race + lock archtest

### DIFF
--- a/docs/product/roadmap/202605042400-002-外部消费者dx优化-目录结构与脚手架.md
+++ b/docs/product/roadmap/202605042400-002-外部消费者dx优化-目录结构与脚手架.md
@@ -263,7 +263,7 @@ v1.1 P1 ship 后 + 029 K#09 ship 后：
 ### 6.1 形态 A · 单 cell 库
 
 ```
-my-cell/                                     module: github.com/myorg/my-cell
+mycell/                                      module: github.com/myorg/mycell
 ├── go.mod                                   require github.com/ghbvf/gocell vX.Y.Z
 ├── go.sum
 ├── README.md

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -354,9 +354,13 @@ func (a *CoreAssembly) StartWithConfig(ctx context.Context, cfgMap map[string]an
 func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any) error {
 	a.mu.Lock()
 	if a.state != stateStopped {
+		// Snapshot the offending state inside the lock so the error message
+		// reflects the value we observed at the guard, not whatever a racing
+		// Stop()/Start() goroutine writes after we release a.mu.
+		s := a.state
 		a.mu.Unlock()
 		return errcode.New(errcode.ErrValidationFailed,
-			fmt.Sprintf("assembly %q: cannot start in state %d", a.id, a.state))
+			fmt.Sprintf("assembly %q: cannot start in state %d", a.id, s))
 	}
 	a.state = stateStarting
 	a.mu.Unlock()
@@ -382,6 +386,13 @@ func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any)
 	// Init or Start path cannot mutate the config seen by another cell.
 	// ref: spf13/viper AllSettings() returns a deep copy for the same reason;
 	//      k8s client-go DeepCopyObject — each consumer owns its own value.
+	//
+	// Snapshots are accumulated into a local map and published to a.snapshots
+	// under a.mu only after every cell.Init succeeds. Writing the shared map
+	// inside the loop without the lock would race with concurrent Snapshots()
+	// readers — Go runtime treats concurrent map read/write as fatal.
+	// ref: PR-V1-030-K01 (review G1-01).
+	localSnaps := make(map[string]cell.RegistrySnapshot, len(a.cells))
 	for _, c := range a.cells {
 		recorder := cell.NewRegistryRecorder(cloneConfigMap(cfgMap), a.cfg.DurabilityMode)
 		if err := c.Init(ctx, recorder); err != nil {
@@ -392,8 +403,11 @@ func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any)
 			return errcode.Wrap(errcode.ErrValidationFailed,
 				fmt.Sprintf("assembly: init cell %q", c.ID()), err)
 		}
-		a.snapshots[c.ID()] = recorder.Snapshot()
+		localSnaps[c.ID()] = recorder.Snapshot()
 	}
+	a.mu.Lock()
+	a.snapshots = localSnaps
+	a.mu.Unlock()
 
 	// Phase 2: Start cells in order with lifecycle hooks.
 	// For each cell: BeforeStart → Start → AfterStart.

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -357,10 +357,10 @@ func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any)
 		// Snapshot the offending state inside the lock so the error message
 		// reflects the value we observed at the guard, not whatever a racing
 		// Stop()/Start() goroutine writes after we release a.mu.
-		s := a.state
+		observedState := a.state
 		a.mu.Unlock()
 		return errcode.New(errcode.ErrValidationFailed,
-			fmt.Sprintf("assembly %q: cannot start in state %d", a.id, s))
+			fmt.Sprintf("assembly %q: cannot start in state %d", a.id, observedState))
 	}
 	a.state = stateStarting
 	a.mu.Unlock()
@@ -396,9 +396,11 @@ func (a *CoreAssembly) startInternal(ctx context.Context, cfgMap map[string]any)
 	for _, c := range a.cells {
 		recorder := cell.NewRegistryRecorder(cloneConfigMap(cfgMap), a.cfg.DurabilityMode)
 		if err := c.Init(ctx, recorder); err != nil {
+			// a.snapshots is untouched until the post-loop publish below, so
+			// the failure path only needs to roll the state back. localSnaps
+			// goes out of scope and is reclaimed.
 			a.mu.Lock()
 			a.state = stateStopped
-			a.snapshots = make(map[string]cell.RegistrySnapshot)
 			a.mu.Unlock()
 			return errcode.Wrap(errcode.ErrValidationFailed,
 				fmt.Sprintf("assembly: init cell %q", c.ID()), err)

--- a/kernel/assembly/snapshots_race_test.go
+++ b/kernel/assembly/snapshots_race_test.go
@@ -69,14 +69,20 @@ func TestAssembly_StartConcurrentSnapshots_RaceDetector(t *testing.T) {
 	}()
 
 	// Spin up readers that bash Snapshots() while Phase 1 is mid-flight.
+	// Each reader signals on `ready` once it has called Snapshots() at least
+	// once; the main goroutine waits for all readers to confirm before
+	// unblocking Phase 1. This guarantees the race window deterministically,
+	// independent of CI runner scheduling latency (no timing-based sleep).
 	const readers = 8
 	const reads = 20
+	ready := make(chan struct{}, readers)
+	stop := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(readers)
-	stop := make(chan struct{})
 	for r := 0; r < readers; r++ {
 		go func() {
 			defer wg.Done()
+			firstDone := false
 			for i := 0; i < reads; i++ {
 				select {
 				case <-stop:
@@ -84,14 +90,22 @@ func TestAssembly_StartConcurrentSnapshots_RaceDetector(t *testing.T) {
 				default:
 				}
 				_ = a.Snapshots()
+				if !firstDone {
+					ready <- struct{}{}
+					firstDone = true
+				}
 				time.Sleep(testtime.D1ms) //archtest:allow:test-sleep yield between Snapshots() reads to widen the race window vs. Phase 1 writer
 			}
 		}()
 	}
 
-	// Hold readers in a hot loop briefly so Phase 1 has time to write at least
-	// one cell snapshot before unblocking.
-	time.Sleep(testtime.D30ms) //archtest:allow:test-sleep let reader goroutines reach Snapshots() before Phase 1 unblocks
+	// Wait until every reader has invoked Snapshots() at least once. After
+	// this point Phase 1 has either already raced (under -race) or is poised
+	// to race the moment cell.Init returns and the original buggy code path
+	// would have written a.snapshots without the lock.
+	for r := 0; r < readers; r++ {
+		<-ready
+	}
 	close(initGate)
 
 	startErr := <-startDone

--- a/kernel/assembly/snapshots_race_test.go
+++ b/kernel/assembly/snapshots_race_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 // TestAssembly_StartConcurrentSnapshots_RaceDetector exercises the path that
@@ -83,14 +84,14 @@ func TestAssembly_StartConcurrentSnapshots_RaceDetector(t *testing.T) {
 				default:
 				}
 				_ = a.Snapshots()
-				time.Sleep(time.Millisecond)
+				time.Sleep(testtime.D1ms) //archtest:allow:test-sleep yield between Snapshots() reads to widen the race window vs. Phase 1 writer
 			}
 		}()
 	}
 
 	// Hold readers in a hot loop briefly so Phase 1 has time to write at least
 	// one cell snapshot before unblocking.
-	time.Sleep(30 * time.Millisecond)
+	time.Sleep(testtime.D30ms) //archtest:allow:test-sleep let reader goroutines reach Snapshots() before Phase 1 unblocks
 	close(initGate)
 
 	startErr := <-startDone

--- a/kernel/assembly/snapshots_race_test.go
+++ b/kernel/assembly/snapshots_race_test.go
@@ -1,0 +1,167 @@
+package assembly
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// TestAssembly_StartConcurrentSnapshots_RaceDetector exercises the path that
+// PR-V1-030-K01 fixes: during startInternal Phase 1 (Init loop), `a.snapshots`
+// must not be written without holding `a.mu`. Concurrent calls to Snapshots()
+// hold the lock and read the map; an unlocked write from Phase 1 is a fatal
+// map race under Go's runtime detector and triggers reliably under `go test
+// -race`.
+//
+// Setup: register N cells. The last one parks in Init until `initGate` closes,
+// holding Phase 1 mid-flight. Reader goroutines repeatedly call Snapshots(),
+// hammering the map while earlier cells' snapshots have already been recorded.
+//
+// Expected:
+//   - Pre-fix:  fatal "concurrent map read and map write" under -race.
+//   - Post-fix: passes — Phase 1 collects into a local map and assigns under
+//     `a.mu` once after Init completes.
+//
+// CI race gate: .github/workflows/test-race.yml runs `go test -race
+// ./kernel/...`, so this test is auto-covered. Without -race it may pass on
+// lucky scheduling; the gate is the contract.
+func TestAssembly_StartConcurrentSnapshots_RaceDetector(t *testing.T) {
+	a := newTestAssembly(t, Config{
+		ID:             "race-snapshots",
+		DurabilityMode: cell.DurabilityDemo,
+		Clock:          clock.Real(),
+	})
+
+	// Pre-register 3 fast cells so Phase 1 will populate a.snapshots
+	// before reaching the blocking last cell. This guarantees readers see
+	// a non-empty map mid-Init when they race against the write site.
+	for i := 0; i < 3; i++ {
+		id := "fast-" + string(rune('a'+i))
+		require.NoError(t, a.Register(cell.MustNewBaseCell(&metadata.CellMeta{
+			ID: id, Type: "core", ConsistencyLevel: "L0",
+		})))
+	}
+
+	// Last cell parks Init until initGate is closed.
+	initGate := make(chan struct{})
+	require.NoError(t, a.Register(&configMutatingCell{
+		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{
+			ID: "blocking", Type: "core", ConsistencyLevel: "L0",
+		}),
+		onInit: func(_ cell.Registry) error {
+			<-initGate
+			return nil
+		},
+	}))
+
+	// Kick off Start in a goroutine; it will park inside Phase 1 at "blocking".
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- a.Start(context.Background())
+	}()
+
+	// Spin up readers that bash Snapshots() while Phase 1 is mid-flight.
+	const readers = 8
+	const reads = 20
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	stop := make(chan struct{})
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < reads; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = a.Snapshots()
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+
+	// Hold readers in a hot loop briefly so Phase 1 has time to write at least
+	// one cell snapshot before unblocking.
+	time.Sleep(30 * time.Millisecond)
+	close(initGate)
+
+	startErr := <-startDone
+	close(stop)
+	wg.Wait()
+
+	require.NoError(t, startErr, "Start must succeed once Phase 1 unblocks")
+
+	// Cleanup: stop assembly so registered cells transition cleanly. Stop
+	// failure is non-fatal for this test (the focus is Start-time race).
+	_ = a.Stop(context.Background())
+}
+
+// TestAssembly_ConcurrentStartStop_RaceDetector exercises the assembly state
+// machine under concurrent Start/Stop attempts plus concurrent reads of
+// Snapshots() and Health(). G1-17 (review 20260504) noted this gap: state
+// transitions guarded by sync.Mutex were not exercised under -race.
+//
+// Expected: state guards reject re-entrant Start/Stop with errors (no fatal),
+// and there is no data race on a.snapshots or a.state.
+//
+// Pre-fix: combined with the Phase 1 race, this stress test can also surface
+// the same map race when a Start collides with a concurrent Snapshots() reader.
+// Post-fix: passes cleanly.
+func TestAssembly_ConcurrentStartStop_RaceDetector(t *testing.T) {
+	a := newTestAssembly(t, Config{
+		ID:             "race-startstop",
+		DurabilityMode: cell.DurabilityDemo,
+		Clock:          clock.Real(),
+	})
+
+	for i := 0; i < 3; i++ {
+		id := "c-" + string(rune('a'+i))
+		require.NoError(t, a.Register(cell.MustNewBaseCell(&metadata.CellMeta{
+			ID: id, Type: "core", ConsistencyLevel: "L0",
+		})))
+	}
+
+	const writers = 4
+	const readers = 4
+	const iterations = 25
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	// Writers: alternate Start / Stop; the state machine must reject
+	// invalid transitions without data races.
+	for w := 0; w < writers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_ = a.Start(context.Background())
+				_ = a.Stop(context.Background())
+			}
+		}()
+	}
+
+	// Readers: hammer Snapshots() and Health() — both must be safe under
+	// any state transition.
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations*4; i++ {
+				_ = a.Snapshots()
+				_ = a.Health()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Final teardown: drive to stopped state regardless of last writer.
+	_ = a.Stop(context.Background())
+}

--- a/tools/archtest/assembly_snapshots_locked_test.go
+++ b/tools/archtest/assembly_snapshots_locked_test.go
@@ -1,0 +1,444 @@
+// ASSEMBLY-SNAPSHOTS-LOCKED-01 — invariant gate.
+//
+// Invariant: every write to *CoreAssembly.snapshots in kernel/assembly/
+// production code must be lexically inside a Lock()/Unlock() critical section
+// on the receiver's mu. Detection prevents regression of the fatal map race
+// fixed in PR-V1-030-K01-ASSEMBLY-SNAPSHOTS-RACE-FIX (G1-01, review
+// 20260504): Phase 1 of startInternal previously wrote a.snapshots[c.ID()]
+// without holding a.mu, racing against Snapshots() readers that hold a.mu.
+//
+// Detection model: walk every FuncDecl/FuncLit body in kernel/assembly/*.go
+// (production only) maintaining a `lockDepth` counter. Lock() increments,
+// Unlock() decrements; `defer Unlock()` does NOT decrement (the lock is held
+// until function exit). Composite literal initializers (`&CoreAssembly{...
+// snapshots: make(...)}`) are NOT writes — single-threaded constructor-time
+// initialization is exempt by construction.
+//
+// Flagged statements (when lockDepth == 0):
+//   - assignments where any LHS is `<x>.snapshots[...]` (per-key write)
+//   - assignments where any LHS is `<x>.snapshots`     (whole-map replace)
+//   - calls to delete(<x>.snapshots, ...)              (per-key remove)
+//
+// Reads of a.snapshots (range, len, indexed read) are not flagged — readers
+// already hold the lock in Snapshots(); only racy writers cause map races.
+//
+// Allow-list: none. New() initializes via composite literal which is not an
+// AssignStmt; the gate naturally exempts it without an explicit allow-list.
+package archtest_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const ruleAssemblySnapshotsLocked01 = "ASSEMBLY-SNAPSHOTS-LOCKED-01"
+
+// TestAssemblySnapshotsLocked enforces ASSEMBLY-SNAPSHOTS-LOCKED-01 by walking
+// every production .go file under kernel/assembly/ and flagging unlocked
+// writes to *.snapshots.
+func TestAssemblySnapshotsLocked(t *testing.T) {
+	root := asnFindModuleRoot(t)
+	files, err := asnFindAssemblyProductionGoFiles(root)
+	if err != nil {
+		t.Fatalf("walking kernel/assembly/: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no production .go files found under kernel/assembly/")
+	}
+
+	var violations []string
+	for _, path := range files {
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+		vs, err := asnCheckFile(path, rel)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", rel, err)
+		}
+		violations = append(violations, vs...)
+	}
+
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Errorf("%s", v)
+	}
+}
+
+// TestAssemblySnapshotsLocked_DetectsViolation is a self-test ensuring the
+// detector flags an unlocked write. Without this guard a buggy detector
+// could silently pass and let the original race regress.
+func TestAssemblySnapshotsLocked_DetectsViolation(t *testing.T) {
+	src := `package x
+type A struct { snapshots map[string]int }
+func (a *A) bug() {
+    a.snapshots["k"] = 1
+}`
+	vs, err := asnCheckSource("<fixture-bug>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) == 0 {
+		t.Error("detector did not flag unlocked a.snapshots[k] = ...")
+	}
+}
+
+// TestAssemblySnapshotsLocked_DetectsWholeMapWrite verifies whole-map
+// replacement (`a.snapshots = ...`) outside a lock is flagged.
+func TestAssemblySnapshotsLocked_DetectsWholeMapWrite(t *testing.T) {
+	src := `package x
+type A struct { snapshots map[string]int }
+func (a *A) bug() {
+    a.snapshots = map[string]int{}
+}`
+	vs, err := asnCheckSource("<fixture-whole>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) == 0 {
+		t.Error("detector did not flag unlocked whole-map write a.snapshots = ...")
+	}
+}
+
+// TestAssemblySnapshotsLocked_DetectsUnlockedDelete verifies that an unlocked
+// delete(a.snapshots, k) is flagged.
+func TestAssemblySnapshotsLocked_DetectsUnlockedDelete(t *testing.T) {
+	src := `package x
+type A struct { snapshots map[string]int }
+func (a *A) bug() {
+    delete(a.snapshots, "k")
+}`
+	vs, err := asnCheckSource("<fixture-delete>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) == 0 {
+		t.Error("detector did not flag unlocked delete(a.snapshots, ...)")
+	}
+}
+
+// TestAssemblySnapshotsLocked_AllowsLockedWrite verifies the detector treats
+// writes inside a Lock()/Unlock() pair as compliant.
+func TestAssemblySnapshotsLocked_AllowsLockedWrite(t *testing.T) {
+	src := `package x
+import "sync"
+type A struct {
+    mu        sync.Mutex
+    snapshots map[string]int
+}
+func (a *A) ok() {
+    a.mu.Lock()
+    a.snapshots["k"] = 1
+    a.mu.Unlock()
+}`
+	vs, err := asnCheckSource("<fixture-locked>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) != 0 {
+		t.Errorf("expected no violations for locked write, got: %v", vs)
+	}
+}
+
+// TestAssemblySnapshotsLocked_AllowsDeferUnlock verifies that
+// `defer a.mu.Unlock()` keeps the lock held for the remainder of the body.
+func TestAssemblySnapshotsLocked_AllowsDeferUnlock(t *testing.T) {
+	src := `package x
+import "sync"
+type A struct {
+    mu        sync.Mutex
+    snapshots map[string]int
+}
+func (a *A) ok() {
+    a.mu.Lock()
+    defer a.mu.Unlock()
+    a.snapshots["k"] = 1
+    delete(a.snapshots, "x")
+    a.snapshots = map[string]int{}
+}`
+	vs, err := asnCheckSource("<fixture-defer>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) != 0 {
+		t.Errorf("expected no violations for defer-unlock pattern, got: %v", vs)
+	}
+}
+
+// TestAssemblySnapshotsLocked_AllowsCompositeLiteralInit verifies that struct
+// literal initialization (`&A{snapshots: make(...)}`) is not flagged. This is
+// how New() seeds the field without requiring a lock.
+func TestAssemblySnapshotsLocked_AllowsCompositeLiteralInit(t *testing.T) {
+	src := `package x
+type A struct { snapshots map[string]int }
+func New() *A {
+    return &A{snapshots: map[string]int{}}
+}`
+	vs, err := asnCheckSource("<fixture-init>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) != 0 {
+		t.Errorf("expected no violations for composite-literal init, got: %v", vs)
+	}
+}
+
+// TestAssemblySnapshotsLocked_AllowsLockedWriteInsideIf verifies that locks
+// taken inside a nested block (e.g. an if-error path) are tracked correctly.
+func TestAssemblySnapshotsLocked_AllowsLockedWriteInsideIf(t *testing.T) {
+	src := `package x
+import "sync"
+type A struct {
+    mu        sync.Mutex
+    snapshots map[string]int
+}
+func (a *A) ok(err error) {
+    if err != nil {
+        a.mu.Lock()
+        a.snapshots = map[string]int{}
+        a.mu.Unlock()
+        return
+    }
+}`
+	vs, err := asnCheckSource("<fixture-if>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) != 0 {
+		t.Errorf("expected no violations for if-body locked write, got: %v", vs)
+	}
+}
+
+// asnCheckFile parses a single file and returns ASSEMBLY-SNAPSHOTS-LOCKED-01
+// violations.
+func asnCheckFile(path, rel string) ([]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	return asnCheckAST(fset, f, rel), nil
+}
+
+// asnCheckSource parses a Go source string and returns violations. label is
+// used in violation messages in place of a file path.
+func asnCheckSource(label, src string) ([]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, label, src, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	return asnCheckAST(fset, f, label), nil
+}
+
+func asnCheckAST(fset *token.FileSet, f *ast.File, label string) []string {
+	var violations []string
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		violations = append(violations, asnScanStmts(fset, fn.Body.List, 0, label)...)
+	}
+	return violations
+}
+
+// asnScanStmts walks a flat list of statements with `lockDepth` counter,
+// recursing into nested blocks while preserving the parent's lock state.
+// Lock() increments depth; Unlock() decrements; defer Unlock() does not
+// affect depth (the lock is held until the function returns, after every
+// statement in the body has executed).
+func asnScanStmts(fset *token.FileSet, stmts []ast.Stmt, lockDepth int, label string) []string {
+	var violations []string
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			switch {
+			case asnIsLockCall(s.X):
+				lockDepth++
+			case asnIsUnlockCall(s.X):
+				lockDepth--
+			default:
+				if line, ok := asnUnlockedDeleteSnapshots(s.X, fset, lockDepth); ok {
+					violations = append(violations, asnViolation(label, line))
+				}
+			}
+		case *ast.DeferStmt:
+			// `defer a.mu.Unlock()` keeps the lock held for the rest of the
+			// body; do not change lockDepth here.
+		case *ast.AssignStmt:
+			if line, ok := asnUnlockedSnapshotsWrite(s, fset, lockDepth); ok {
+				violations = append(violations, asnViolation(label, line))
+			}
+		case *ast.IfStmt:
+			if s.Body != nil {
+				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
+			}
+			if s.Else != nil {
+				violations = append(violations, asnScanStmts(fset, []ast.Stmt{s.Else}, lockDepth, label)...)
+			}
+		case *ast.ForStmt:
+			if s.Body != nil {
+				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
+			}
+		case *ast.RangeStmt:
+			if s.Body != nil {
+				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
+			}
+		case *ast.BlockStmt:
+			violations = append(violations, asnScanStmts(fset, s.List, lockDepth, label)...)
+		case *ast.SwitchStmt:
+			if s.Body != nil {
+				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
+			}
+		case *ast.TypeSwitchStmt:
+			if s.Body != nil {
+				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
+			}
+		case *ast.CaseClause:
+			violations = append(violations, asnScanStmts(fset, s.Body, lockDepth, label)...)
+		case *ast.SelectStmt:
+			if s.Body != nil {
+				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
+			}
+		case *ast.CommClause:
+			violations = append(violations, asnScanStmts(fset, s.Body, lockDepth, label)...)
+		}
+	}
+	return violations
+}
+
+// asnIsLockCall returns true if expr is `<x>.mu.Lock()`.
+func asnIsLockCall(expr ast.Expr) bool {
+	return asnIsMuMethodCall(expr, "Lock")
+}
+
+// asnIsUnlockCall returns true if expr is `<x>.mu.Unlock()`.
+func asnIsUnlockCall(expr ast.Expr) bool {
+	return asnIsMuMethodCall(expr, "Unlock")
+}
+
+// asnIsMuMethodCall returns true if expr is a call of form `<x>.mu.<methodName>()`.
+// The .mu suffix limits matches to mutex-shaped accesses; reflection-style
+// false positives on identically named methods are not a concern in
+// kernel/assembly/.
+func asnIsMuMethodCall(expr ast.Expr, methodName string) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != methodName {
+		return false
+	}
+	inner, ok := sel.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return inner.Sel.Name == "mu"
+}
+
+// asnUnlockedSnapshotsWrite returns (line, true) when assign's LHS targets
+// `<x>.snapshots` or `<x>.snapshots[...]` and lockDepth == 0.
+func asnUnlockedSnapshotsWrite(assign *ast.AssignStmt, fset *token.FileSet, lockDepth int) (int, bool) {
+	if lockDepth > 0 {
+		return 0, false
+	}
+	for _, lhs := range assign.Lhs {
+		if asnIsSnapshotsTarget(lhs) {
+			return fset.Position(assign.Pos()).Line, true
+		}
+	}
+	return 0, false
+}
+
+// asnUnlockedDeleteSnapshots returns (line, true) when expr is
+// `delete(<x>.snapshots, ...)` and lockDepth == 0.
+func asnUnlockedDeleteSnapshots(expr ast.Expr, fset *token.FileSet, lockDepth int) (int, bool) {
+	if lockDepth > 0 {
+		return 0, false
+	}
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return 0, false
+	}
+	id, ok := call.Fun.(*ast.Ident)
+	if !ok || id.Name != "delete" || len(call.Args) == 0 {
+		return 0, false
+	}
+	if asnIsSnapshotsTarget(call.Args[0]) {
+		return fset.Position(call.Pos()).Line, true
+	}
+	return 0, false
+}
+
+// asnIsSnapshotsTarget reports whether expr is a SelectorExpr `<x>.snapshots`
+// (whole-map) or an IndexExpr whose collection is `<x>.snapshots` (per-key).
+func asnIsSnapshotsTarget(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "snapshots"
+	case *ast.IndexExpr:
+		if sel, ok := e.X.(*ast.SelectorExpr); ok {
+			return sel.Sel.Name == "snapshots"
+		}
+	}
+	return false
+}
+
+// asnViolation formats an ASSEMBLY-SNAPSHOTS-LOCKED-01 violation message.
+func asnViolation(file string, line int) string {
+	return ruleAssemblySnapshotsLocked01 + ": " + file + ":" + strconv.Itoa(line) +
+		": write to *.snapshots without holding mu.Lock(); wrap with " +
+		"a.mu.Lock()/a.mu.Unlock() (or rely on defer Unlock). " +
+		"ref: PR-V1-030-K01-ASSEMBLY-SNAPSHOTS-RACE-FIX, G1-01"
+}
+
+// asnFindModuleRoot walks up from CWD to locate go.mod.
+func asnFindModuleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found walking up from working directory")
+		}
+		dir = parent
+	}
+}
+
+// asnFindAssemblyProductionGoFiles returns all non-test .go files under
+// kernel/assembly/.
+func asnFindAssemblyProductionGoFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(filepath.Join(root, "kernel", "assembly"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", "worktrees", "testdata", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	sort.Strings(files)
+	return files, err
+}

--- a/tools/archtest/assembly_snapshots_locked_test.go
+++ b/tools/archtest/assembly_snapshots_locked_test.go
@@ -7,11 +7,14 @@
 // 20260504): Phase 1 of startInternal previously wrote a.snapshots[c.ID()]
 // without holding a.mu, racing against Snapshots() readers that hold a.mu.
 //
-// Detection model: walk every FuncDecl/FuncLit body in kernel/assembly/*.go
-// (production only) maintaining a `lockDepth` counter. Lock() increments,
+// Detection model: walk every FuncDecl and FuncLit body in kernel/assembly/
+// production .go files maintaining a `lockDepth` counter. Lock() increments,
 // Unlock() decrements; `defer Unlock()` does NOT decrement (the lock is held
-// until function exit). Composite literal initializers (`&CoreAssembly{...
-// snapshots: make(...)}`) are NOT writes — single-threaded constructor-time
+// until function exit). Each FuncLit (closure / goroutine literal) gets a
+// fresh `lockDepth=0` because it has its own lock-scope at runtime — a write
+// inside a `go func() { ... }()` does not inherit the caller's locked
+// section. Composite literal initializers (`&CoreAssembly{...snapshots:
+// make(...)}`) are NOT writes — single-threaded constructor-time
 // initialization is exempt by construction.
 //
 // Flagged statements (when lockDepth == 0):
@@ -21,6 +24,15 @@
 //
 // Reads of a.snapshots (range, len, indexed read) are not flagged — readers
 // already hold the lock in Snapshots(); only racy writers cause map races.
+//
+// Known limitation: the lockDepth model is approximate. Pathological mixes of
+// `defer Unlock()` followed by an explicit `Unlock()` later in the same
+// function (double-unlock — undefined runtime behavior anyway) leave the
+// counter at 1 and admit a subsequent write as compliant. Production code in
+// kernel/assembly/ avoids that pattern; if it ever appears, prefer fixing the
+// double-unlock over expanding this detector. The kernel rule is "balanced
+// Lock/Unlock pairs"; this gate is a best-effort static surface against
+// regression of the K-01 race, not a full mutex-state interpreter.
 //
 // Allow-list: none. New() initializes via composite literal which is not an
 // AssignStmt; the gate naturally exempts it without an explicit allow-list.
@@ -188,6 +200,55 @@ func New() *A {
 	}
 }
 
+// TestAssemblySnapshotsLocked_DetectsViolationInGoroutineFuncLit verifies
+// the FuncLit walk: a goroutine whose body writes a.snapshots without
+// holding the lock must be flagged, even though the surrounding outer
+// function may itself hold the lock — the goroutine runs in an independent
+// scheduling context where the caller's mutex is not held.
+func TestAssemblySnapshotsLocked_DetectsViolationInGoroutineFuncLit(t *testing.T) {
+	src := `package x
+import "sync"
+type A struct {
+    mu        sync.Mutex
+    snapshots map[string]int
+}
+func (a *A) outer() {
+    a.mu.Lock()
+    defer a.mu.Unlock()
+    go func() {
+        a.snapshots["k"] = 1
+    }()
+}`
+	vs, err := asnCheckSource("<fixture-funclit>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) == 0 {
+		t.Error("detector did not flag unlocked write inside goroutine FuncLit")
+	}
+}
+
+// TestAssemblySnapshotsLocked_DetectsViolationInIfInit verifies the Init
+// clause of an IfStmt is scanned. `if a.snapshots = ...; cond {}` is a
+// rare-but-legal pattern, and a write hidden there must not be a blind
+// spot.
+func TestAssemblySnapshotsLocked_DetectsViolationInIfInit(t *testing.T) {
+	src := `package x
+type A struct { snapshots map[string]int }
+func (a *A) bug(m map[string]int) {
+    if a.snapshots = m; len(a.snapshots) > 0 {
+        return
+    }
+}`
+	vs, err := asnCheckSource("<fixture-ifinit>", src)
+	if err != nil {
+		t.Fatalf("asnCheckSource: %v", err)
+	}
+	if len(vs) == 0 {
+		t.Error("detector did not flag unlocked write hidden in IfStmt.Init")
+	}
+}
+
 // TestAssemblySnapshotsLocked_AllowsLockedWriteInsideIf verifies that locks
 // taken inside a nested block (e.g. an if-error path) are tracked correctly.
 func TestAssemblySnapshotsLocked_AllowsLockedWriteInsideIf(t *testing.T) {
@@ -245,6 +306,19 @@ func asnCheckAST(fset *token.FileSet, f *ast.File, label string) []string {
 		}
 		violations = append(violations, asnScanStmts(fset, fn.Body.List, 0, label)...)
 	}
+	// Independently inspect every FuncLit (closure / goroutine body / inline
+	// callback). A FuncLit owns its lock scope: writes inside a closure do
+	// not inherit the caller's lockDepth, so each starts fresh at 0. The
+	// outer ast.Walk catches FuncLits anywhere in the file (top-level decls,
+	// nested calls, struct field initializers, ...).
+	ast.Inspect(f, func(n ast.Node) bool {
+		fl, ok := n.(*ast.FuncLit)
+		if !ok || fl.Body == nil {
+			return true
+		}
+		violations = append(violations, asnScanStmts(fset, fl.Body.List, 0, label)...)
+		return true
+	})
 	return violations
 }
 
@@ -276,6 +350,12 @@ func asnScanStmts(fset *token.FileSet, stmts []ast.Stmt, lockDepth int, label st
 				violations = append(violations, asnViolation(label, line))
 			}
 		case *ast.IfStmt:
+			// IfStmt.Init carries `if x := f(); ...` declarations or the
+			// rare `if x = ...; ...` assignment. Scan it so writes hidden
+			// in the init clause aren't a blind spot.
+			if s.Init != nil {
+				violations = append(violations, asnScanStmts(fset, []ast.Stmt{s.Init}, lockDepth, label)...)
+			}
 			if s.Body != nil {
 				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
 			}
@@ -283,6 +363,12 @@ func asnScanStmts(fset *token.FileSet, stmts []ast.Stmt, lockDepth int, label st
 				violations = append(violations, asnScanStmts(fset, []ast.Stmt{s.Else}, lockDepth, label)...)
 			}
 		case *ast.ForStmt:
+			if s.Init != nil {
+				violations = append(violations, asnScanStmts(fset, []ast.Stmt{s.Init}, lockDepth, label)...)
+			}
+			if s.Post != nil {
+				violations = append(violations, asnScanStmts(fset, []ast.Stmt{s.Post}, lockDepth, label)...)
+			}
 			if s.Body != nil {
 				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
 			}
@@ -293,10 +379,16 @@ func asnScanStmts(fset *token.FileSet, stmts []ast.Stmt, lockDepth int, label st
 		case *ast.BlockStmt:
 			violations = append(violations, asnScanStmts(fset, s.List, lockDepth, label)...)
 		case *ast.SwitchStmt:
+			if s.Init != nil {
+				violations = append(violations, asnScanStmts(fset, []ast.Stmt{s.Init}, lockDepth, label)...)
+			}
 			if s.Body != nil {
 				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
 			}
 		case *ast.TypeSwitchStmt:
+			if s.Init != nil {
+				violations = append(violations, asnScanStmts(fset, []ast.Stmt{s.Init}, lockDepth, label)...)
+			}
 			if s.Body != nil {
 				violations = append(violations, asnScanStmts(fset, s.Body.List, lockDepth, label)...)
 			}


### PR DESCRIPTION
## Summary

Close the **P0 fatal map race** (G1-01) where `startInternal` Phase 1 wrote `a.snapshots` without holding `a.mu`, racing locked iteration in `Snapshots()`. Go runtime treats concurrent map read/write as fatal — any monitoring/health aggregator calling `Snapshots()` during `Start()` could tear down the process.

- **Phase 1 fix**: collect into a function-local `localSnaps`, publish to `a.snapshots` under `a.mu` once after every `cell.Init` succeeds.
- **State-format fix**: `startInternal` "cannot start in state %d" used to read `a.state` after `Unlock()`. Surfaced by the new G1-17 ConcurrentStartStop test; now snapshots state inside the lock.
- **Static guard**: new `ASSEMBLY-SNAPSHOTS-LOCKED-01` archtest flags any unlocked write/delete to `*.snapshots` in `kernel/assembly/` (lexical lockDepth walk; defer-Unlock aware; composite-literal init exempt).
- **G1-17**: `TestAssembly_ConcurrentStartStop_RaceDetector` covers the missing race-detector coverage on the assembly state machine.

## TDD trail

- W0 (`ca86f692`): RED commit — both race tests + archtest fail on develop.
  - archtest: `kernel/assembly/assembly.go:395: write to *.snapshots without holding mu.Lock()`
  - `-race`: 4 data races (Phase 1 map race + state-read-after-unlock).
- W1 (`f4ca4fab`): GREEN — assembly.go fix; race tests + archtest all pass.

## Refs

- `Refs: PR-V1-030-K01-ASSEMBLY-SNAPSHOTS-RACE-FIX`
- `Source: docs/reviews/20260504-kernel-group1-cell-assembly-lifecycle-registry-worker.md` G1-01 / G1-17
- Roadmap: `docs/plans/202605011500-029-master-roadmap.md` L249 (N1)
- `ref: kubernetes pkg/util/sets` — local-collect-then-publish
- `ref: golang sync.Mutex` — capture shared state inside the critical section

## Test plan

- [x] `go test -race ./kernel/assembly/...` — green (was: 4 races on develop)
- [x] `go test ./tools/archtest/...` — green incl. `ASSEMBLY-SNAPSHOTS-LOCKED-01`
- [x] `go test -race ./kernel/... ./runtime/... ./pkg/...` — green
- [x] `go test ./...` — green (full repo)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI race gate (`.github/workflows/test-race.yml`) green on PR

## Out of scope (from 029 roadmap)

- G-04 KERNEL-INTERNAL-DAG-GUARD archtest — separately tracked as K#01 FU.
- G1-02..G1-15 — separately tracked as N2/N3/N4/N5/G-05/R-01/R-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)