### PR TITLE
refactor(ci): G8 PR-V11-CI-LINT-BATCH-4 — enable gofumpt + repo-wide reformat

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -514,6 +514,7 @@ linters:
 formatters:
   enable:
     - gofmt
+    - gofumpt
     - goimports
   settings:
     goimports:

--- a/adapters/circuitbreaker/gobreaker_test.go
+++ b/adapters/circuitbreaker/gobreaker_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 // Compile-time checks: Adapter implements Allower and CircuitBreakerRetryAfter.
-var _ middleware.Allower = (*Adapter)(nil)
-var _ middleware.CircuitBreakerRetryAfter = (*Adapter)(nil)
+var (
+	_ middleware.Allower                  = (*Adapter)(nil)
+	_ middleware.CircuitBreakerRetryAfter = (*Adapter)(nil)
+)
 
 // mustNew creates an Adapter, failing the test on error.
 func mustNew(t *testing.T, cfg Config) *Adapter {

--- a/adapters/otel/integration_test.go
+++ b/adapters/otel/integration_test.go
@@ -10,14 +10,15 @@ import (
 	"testing"
 	"time"
 
-	gcotel "github.com/ghbvf/gocell/adapters/otel"
-	"github.com/ghbvf/gocell/pkg/testutil/testtime"
-	"github.com/ghbvf/gocell/tests/testutil"
 	dockercontainer "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+
+	gcotel "github.com/ghbvf/gocell/adapters/otel"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/tests/testutil"
 )
 
 const collectorConfig = `

--- a/adapters/postgres/integration_test.go
+++ b/adapters/postgres/integration_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/tests/testutil"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/tests/testutil"
 )
 
 // setupPostgres starts a PostgreSQL container via testcontainers and returns a

--- a/adapters/postgres/outbox_mock_test.go
+++ b/adapters/postgres/outbox_mock_test.go
@@ -139,9 +139,11 @@ func (t *mockRelayTx) LargeObjects() pgx.LargeObjects                           
 func (t *mockRelayTx) Prepare(_ context.Context, _ string, _ string) (*pgconn.StatementDescription, error) {
 	return &pgconn.StatementDescription{}, nil
 }
+
 func (t *mockRelayTx) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	return t.db.Exec(ctx, sql, args...)
 }
+
 func (t *mockRelayTx) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
 	return t.db.Query(ctx, sql, args...)
 }
@@ -260,9 +262,11 @@ func (t *mockRelayTxIterErr) LargeObjects() pgx.LargeObjects                    
 func (t *mockRelayTxIterErr) Prepare(_ context.Context, _ string, _ string) (*pgconn.StatementDescription, error) {
 	return &pgconn.StatementDescription{}, nil
 }
+
 func (t *mockRelayTxIterErr) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	return t.db.Exec(ctx, sql, args...)
 }
+
 func (t *mockRelayTxIterErr) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
 	return t.db.Query(ctx, sql, args...)
 }

--- a/adapters/postgres/outbox_store_integration_test.go
+++ b/adapters/postgres/outbox_store_integration_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/kernel/clock"
 	kout "github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	rout "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestPGOutboxStore_ConformanceSuite verifies that PGOutboxStore satisfies the

--- a/adapters/postgres/outbox_writer.go
+++ b/adapters/postgres/outbox_writer.go
@@ -19,8 +19,10 @@ import (
 const allZeroUUID = "00000000-0000-0000-0000-000000000000"
 
 // Compile-time interface checks.
-var _ outbox.Writer = (*OutboxWriter)(nil)
-var _ outbox.BatchWriter = (*OutboxWriter)(nil)
+var (
+	_ outbox.Writer      = (*OutboxWriter)(nil)
+	_ outbox.BatchWriter = (*OutboxWriter)(nil)
+)
 
 // OutboxWriter writes outbox entries within a PostgreSQL transaction.
 // It relies on TxFromContext to obtain the current transaction, ensuring

--- a/adapters/postgres/refresh_store_test.go
+++ b/adapters/postgres/refresh_store_test.go
@@ -29,12 +29,15 @@ func (*typedNilRefreshClock) Until(t time.Time) time.Duration { return time.Unti
 func (*typedNilRefreshClock) NewTimerAt(t time.Time) clock.Timer {
 	return clock.Real().NewTimerAt(t)
 }
+
 func (*typedNilRefreshClock) NewTicker(d time.Duration) clock.Ticker {
 	return clock.Real().NewTicker(d)
 }
+
 func (*typedNilRefreshClock) AfterFunc(t time.Time, fn func()) clock.Timer {
 	return clock.Real().AfterFunc(t, fn)
 }
+
 func (*typedNilRefreshClock) Sleep(ctx context.Context, t time.Time) error {
 	return clock.Real().Sleep(ctx, t)
 }

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -538,6 +538,7 @@ type singletonCounter struct{ val float64 }
 func (s singletonCounter) Describe(ch chan<- *prom.Desc) {
 	ch <- prom.NewDesc("singleton", "test helper", nil, nil)
 }
+
 func (s singletonCounter) Collect(ch chan<- prom.Metric) {
 	ch <- prom.MustNewConstMetric(prom.NewDesc("singleton", "test helper", nil, nil), prom.CounterValue, s.val)
 }

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -649,19 +649,31 @@ func TestConnection_BackoffDelay(t *testing.T) {
 		minDelay time.Duration
 		maxDelay time.Duration // hard cap: never exceeds ReconnectMaxBackoff (30s)
 	}{
-		{name: "attempt 0", attempt: 0,
-			minDelay: testtime.D750ms, maxDelay: rabbitmqD1250ms},
-		{name: "attempt 1", attempt: 1,
-			minDelay: rabbitmqD1500ms, maxDelay: rabbitmqD2500ms},
-		{name: "attempt 2", attempt: 2,
-			minDelay: testtime.D3s, maxDelay: testtime.EventuallyLong},
+		{
+			name: "attempt 0", attempt: 0,
+			minDelay: testtime.D750ms, maxDelay: rabbitmqD1250ms,
+		},
+		{
+			name: "attempt 1", attempt: 1,
+			minDelay: rabbitmqD1500ms, maxDelay: rabbitmqD2500ms,
+		},
+		{
+			name: "attempt 2", attempt: 2,
+			minDelay: testtime.D3s, maxDelay: testtime.EventuallyLong,
+		},
 		// Capped region: jitter on MaxBackoff → [0.75*30s, 30s] = [22.5s, 30s].
-		{name: "attempt 10 (capped)", attempt: 10,
-			minDelay: rabbitmqD22500ms, maxDelay: testtime.D30s},
-		{name: "attempt 34 (overflow guard)", attempt: 34,
-			minDelay: rabbitmqD22500ms, maxDelay: testtime.D30s},
-		{name: "attempt 100 (far overflow)", attempt: 100,
-			minDelay: rabbitmqD22500ms, maxDelay: testtime.D30s},
+		{
+			name: "attempt 10 (capped)", attempt: 10,
+			minDelay: rabbitmqD22500ms, maxDelay: testtime.D30s,
+		},
+		{
+			name: "attempt 34 (overflow guard)", attempt: 34,
+			minDelay: rabbitmqD22500ms, maxDelay: testtime.D30s,
+		},
+		{
+			name: "attempt 100 (far overflow)", attempt: 100,
+			minDelay: rabbitmqD22500ms, maxDelay: testtime.D30s,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2289,6 +2301,7 @@ func (s *stubSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *stubSubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.SubscriberHandler) error {
 	if s.onSubscribe != nil {
 		return s.onSubscribe(ctx, sub.Topic, handler)

--- a/adapters/redis/integration_test.go
+++ b/adapters/redis/integration_test.go
@@ -9,15 +9,16 @@ import (
 	"testing"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
+
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/distlock"
 	"github.com/ghbvf/gocell/runtime/distlock/locktest"
 	"github.com/ghbvf/gocell/tests/testutil"
-	goredis "github.com/redis/go-redis/v9"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
 )
 
 // startRedis launches a testcontainers Redis instance and returns a

--- a/adapters/vault/integration_test.go
+++ b/adapters/vault/integration_test.go
@@ -17,12 +17,13 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 	vaultcontainer "github.com/testcontainers/testcontainers-go/modules/vault"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	vaultadapter "github.com/ghbvf/gocell/adapters/vault"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // startVaultContainer starts a Vault dev-mode container for integration tests.

--- a/adapters/vault/readiness_test.go
+++ b/adapters/vault/readiness_test.go
@@ -11,12 +11,13 @@ import (
 
 	vaultapi "github.com/hashicorp/vault/api"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	vaultadapter "github.com/ghbvf/gocell/adapters/vault"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const vaultReadinessCtxTimeout = 600 * time.Millisecond

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -443,8 +443,10 @@ func (w *tokenRenewalWorker) Stop(_ context.Context) error {
 
 // Compile-time interface assertions — fail at build time if the scaffold drifts
 // from the kernel/crypto contracts.
-var _ kcrypto.KeyProvider = (*TransitKeyProvider)(nil)
-var _ kcrypto.KeyHandle = (*vaultTransitHandle)(nil)
+var (
+	_ kcrypto.KeyProvider = (*TransitKeyProvider)(nil)
+	_ kcrypto.KeyHandle   = (*vaultTransitHandle)(nil)
+)
 
 // ---------------------------------------------------------------------------
 // vaultTransitHandle

--- a/adapters/websocket/integration_test.go
+++ b/adapters/websocket/integration_test.go
@@ -4,6 +4,9 @@ package websocket_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -17,10 +20,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"net/http"
-	"net/http/httptest"
-	"strings"
 )
 
 // setupIntegrationHub creates a running Hub + httptest server for integration tests.

--- a/cells/accesscore/auth_integration_test.go
+++ b/cells/accesscore/auth_integration_test.go
@@ -25,6 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
@@ -45,9 +49,6 @@ import (
 	refreshmem "github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
 	"github.com/ghbvf/gocell/runtime/http/router"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // seedAdminPasswordHash caches the bcrypt hash for the seed admin password

--- a/cells/accesscore/auth_refresh_aud_integration_test.go
+++ b/cells/accesscore/auth_refresh_aud_integration_test.go
@@ -19,10 +19,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 func TestAuthIntegration_RefreshAccessTokenAudienceDrift(t *testing.T) {

--- a/cells/accesscore/cell_initialadmin_unsupported_test.go
+++ b/cells/accesscore/cell_initialadmin_unsupported_test.go
@@ -7,13 +7,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // newUnsupportedTestReg mirrors the unix newTestReg helper without the unix build tag.

--- a/cells/accesscore/initialadmin/bootstrap_branches_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_branches_test.go
@@ -42,24 +42,31 @@ func (r *errRoleRepo) CountByRole(ctx context.Context, roleID string) (int, erro
 	}
 	return r.inner.CountByRole(ctx, roleID)
 }
+
 func (r *errRoleRepo) Create(ctx context.Context, role *domain.Role) error {
 	return r.inner.Create(ctx, role)
 }
+
 func (r *errRoleRepo) AssignToUser(ctx context.Context, userID, roleID string) (bool, error) {
 	return r.inner.AssignToUser(ctx, userID, roleID)
 }
+
 func (r *errRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
 	return r.inner.GetByID(ctx, id)
 }
+
 func (r *errRoleRepo) GetByUserID(ctx context.Context, userID string) ([]*domain.Role, error) {
 	return r.inner.GetByUserID(ctx, userID)
 }
+
 func (r *errRoleRepo) RemoveFromUser(_ context.Context, _, _ string) error {
 	return r.removeFromUserErr
 }
+
 func (r *errRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
 	return r.inner.RemoveFromUserIfNotLast(ctx, userID, roleID)
 }
+
 func (r *errRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
 	return r.inner.GetByUserID(ctx, userID)
 }
@@ -76,18 +83,22 @@ type errUserRepo struct {
 func (r *errUserRepo) Create(ctx context.Context, user *domain.User) error {
 	return r.inner.Create(ctx, user)
 }
+
 func (r *errUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
 	return r.inner.GetByID(ctx, id)
 }
+
 func (r *errUserRepo) GetByUsername(_ context.Context, _ string) (*domain.User, error) {
 	if r.getByUsernameErr != nil {
 		return nil, r.getByUsernameErr
 	}
 	return nil, fmt.Errorf("not configured")
 }
+
 func (r *errUserRepo) Update(ctx context.Context, user *domain.User) error {
 	return r.inner.Update(ctx, user)
 }
+
 func (r *errUserRepo) Delete(_ context.Context, _ string) error {
 	return r.deleteErr
 }
@@ -103,15 +114,19 @@ type errOnUpdateUserRepo struct {
 func (r *errOnUpdateUserRepo) Create(ctx context.Context, user *domain.User) error {
 	return r.inner.Create(ctx, user)
 }
+
 func (r *errOnUpdateUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
 	return r.inner.GetByID(ctx, id)
 }
+
 func (r *errOnUpdateUserRepo) GetByUsername(ctx context.Context, u string) (*domain.User, error) {
 	return r.inner.GetByUsername(ctx, u)
 }
+
 func (r *errOnUpdateUserRepo) Update(_ context.Context, _ *domain.User) error {
 	return r.updateErr
 }
+
 func (r *errOnUpdateUserRepo) Delete(ctx context.Context, id string) error {
 	return r.inner.Delete(ctx, id)
 }

--- a/cells/accesscore/initialadmin/bootstrap_test.go
+++ b/cells/accesscore/initialadmin/bootstrap_test.go
@@ -95,15 +95,19 @@ type duplicateUserRepo struct {
 func (r *duplicateUserRepo) Create(_ context.Context, _ *domain.User) error {
 	return errcode.New(errcode.KindConflict, errcode.ErrAuthUserDuplicate, "username already exists")
 }
+
 func (r *duplicateUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
 	return r.inner.GetByID(ctx, id)
 }
+
 func (r *duplicateUserRepo) GetByUsername(ctx context.Context, u string) (*domain.User, error) {
 	return r.inner.GetByUsername(ctx, u)
 }
+
 func (r *duplicateUserRepo) Update(ctx context.Context, user *domain.User) error {
 	return r.inner.Update(ctx, user)
 }
+
 func (r *duplicateUserRepo) Delete(ctx context.Context, id string) error {
 	return r.inner.Delete(ctx, id)
 }
@@ -125,24 +129,31 @@ func (r *countingRoleRepo) CountByRole(ctx context.Context, roleID string) (int,
 	}
 	return r.inner.CountByRole(ctx, roleID)
 }
+
 func (r *countingRoleRepo) Create(ctx context.Context, role *domain.Role) error {
 	return r.inner.Create(ctx, role)
 }
+
 func (r *countingRoleRepo) AssignToUser(ctx context.Context, userID, roleID string) (bool, error) {
 	return r.inner.AssignToUser(ctx, userID, roleID)
 }
+
 func (r *countingRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
 	return r.inner.GetByID(ctx, id)
 }
+
 func (r *countingRoleRepo) GetByUserID(ctx context.Context, userID string) ([]*domain.Role, error) {
 	return r.inner.GetByUserID(ctx, userID)
 }
+
 func (r *countingRoleRepo) RemoveFromUser(ctx context.Context, userID, roleID string) error {
 	return r.inner.RemoveFromUser(ctx, userID, roleID)
 }
+
 func (r *countingRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
 	return r.inner.RemoveFromUserIfNotLast(ctx, userID, roleID)
 }
+
 func (r *countingRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
 	return r.inner.GetByUserID(ctx, userID)
 }

--- a/cells/accesscore/initialadmin/platform_unsupported_test.go
+++ b/cells/accesscore/initialadmin/platform_unsupported_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 func TestPlatformSupported_ReturnsErrcode(t *testing.T) {

--- a/cells/accesscore/initialadmin/sweep_test.go
+++ b/cells/accesscore/initialadmin/sweep_test.go
@@ -30,12 +30,15 @@ func (c fixedClock) Until(t time.Time) time.Duration { return t.Sub(c.now) }
 func (c fixedClock) NewTimerAt(_ time.Time) kernelclock.Timer {
 	panic("fixedClock.NewTimerAt not implemented")
 }
+
 func (c fixedClock) NewTicker(_ time.Duration) kernelclock.Ticker {
 	panic("fixedClock.NewTicker not implemented")
 }
+
 func (c fixedClock) AfterFunc(_ time.Time, _ func()) kernelclock.Timer {
 	panic("fixedClock.AfterFunc not implemented")
 }
+
 func (c fixedClock) Sleep(_ context.Context, _ time.Time) error {
 	panic("fixedClock.Sleep not implemented")
 }

--- a/cells/accesscore/internal/adminprovision/provisioner_test.go
+++ b/cells/accesscore/internal/adminprovision/provisioner_test.go
@@ -428,9 +428,11 @@ type duplicateUserRepo struct{}
 func (r *duplicateUserRepo) Create(ctx context.Context, u *domain.User) error {
 	return errcode.New(errcode.KindConflict, errcode.ErrAuthUserDuplicate, "duplicate")
 }
+
 func (r *duplicateUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
 	return nil, errors.New("not expected on race path")
 }
+
 func (r *duplicateUserRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
 	u, _ := domain.NewUser(username, username+"@x", "$2a$10$hashold", time.Now())
 	u.ID = "usr-orphan"
@@ -452,6 +454,7 @@ func (r *scriptedRoleRepo) AssignToUser(ctx context.Context, userID, roleID stri
 	r.assignCalled = true
 	return true, nil
 }
+
 func (r *scriptedRoleRepo) CountByRole(ctx context.Context, roleID string) (int, error) {
 	if r.i >= len(r.counts) {
 		return r.counts[len(r.counts)-1], nil
@@ -460,18 +463,23 @@ func (r *scriptedRoleRepo) CountByRole(ctx context.Context, roleID string) (int,
 	r.i++
 	return v, nil
 }
+
 func (r *scriptedRoleRepo) GetByUserID(ctx context.Context, userID string) ([]*domain.Role, error) {
 	return nil, nil
 }
+
 func (r *scriptedRoleRepo) RemoveFromUser(ctx context.Context, userID, roleID string) error {
 	return nil
 }
+
 func (r *scriptedRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
 	return true, nil
 }
+
 func (r *scriptedRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
 	return &domain.Role{ID: id}, nil
 }
+
 func (r *scriptedRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
 	return nil, nil
 }
@@ -488,21 +496,27 @@ func (r *errRoleRepo) Create(ctx context.Context, role *domain.Role) error { ret
 func (r *errRoleRepo) AssignToUser(ctx context.Context, userID, roleID string) (bool, error) {
 	return false, r.assignErr
 }
+
 func (r *errRoleRepo) CountByRole(ctx context.Context, roleID string) (int, error) {
 	return 0, r.countErr
 }
+
 func (r *errRoleRepo) GetByUserID(ctx context.Context, userID string) ([]*domain.Role, error) {
 	return nil, nil
 }
+
 func (r *errRoleRepo) RemoveFromUser(ctx context.Context, userID, roleID string) error {
 	return r.removeErr
 }
+
 func (r *errRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
 	return true, nil
 }
+
 func (r *errRoleRepo) GetByID(ctx context.Context, id string) (*domain.Role, error) {
 	return &domain.Role{ID: id}, nil
 }
+
 func (r *errRoleRepo) ListByUserID(ctx context.Context, userID string, params query.ListParams) ([]*domain.Role, error) {
 	return nil, nil
 }
@@ -516,9 +530,11 @@ type updateFailUserRepo struct {
 func (r *updateFailUserRepo) Create(ctx context.Context, u *domain.User) error {
 	return errcode.New(errcode.KindConflict, errcode.ErrAuthUserDuplicate, "duplicate")
 }
+
 func (r *updateFailUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
 	return r.inner.GetByID(ctx, id)
 }
+
 func (r *updateFailUserRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
 	return r.inner.GetByUsername(ctx, username)
 }
@@ -561,6 +577,7 @@ func (r *errUserRepo) Create(ctx context.Context, u *domain.User) error { return
 func (r *errUserRepo) GetByID(ctx context.Context, id string) (*domain.User, error) {
 	return nil, errors.New("not seeded")
 }
+
 func (r *errUserRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
 	return nil, errors.New("not seeded")
 }

--- a/cells/accesscore/internal/dto/token_pair_test.go
+++ b/cells/accesscore/internal/dto/token_pair_test.go
@@ -14,17 +14,27 @@ func TestToTokenPairResponse(t *testing.T) {
 		in   TokenPair
 		want TokenPairResponse
 	}{
-		{"all fields populated",
-			TokenPair{AccessToken: "at", RefreshToken: "rt", ExpiresAt: expires,
-				SessionID: "sess-1", UserID: "usr-1", PasswordResetRequired: true},
-			TokenPairResponse{AccessToken: "at", RefreshToken: "rt", ExpiresAt: expires,
-				SessionID: "sess-1", UserID: "usr-1", PasswordResetRequired: true}},
-		{"zero value pair",
+		{
+			"all fields populated",
+			TokenPair{
+				AccessToken: "at", RefreshToken: "rt", ExpiresAt: expires,
+				SessionID: "sess-1", UserID: "usr-1", PasswordResetRequired: true,
+			},
+			TokenPairResponse{
+				AccessToken: "at", RefreshToken: "rt", ExpiresAt: expires,
+				SessionID: "sess-1", UserID: "usr-1", PasswordResetRequired: true,
+			},
+		},
+		{
+			"zero value pair",
 			TokenPair{},
-			TokenPairResponse{}},
-		{"reset flag false defaults preserved",
+			TokenPairResponse{},
+		},
+		{
+			"reset flag false defaults preserved",
 			TokenPair{AccessToken: "x", RefreshToken: "y", ExpiresAt: expires, SessionID: "s", UserID: "u", PasswordResetRequired: false},
-			TokenPairResponse{AccessToken: "x", RefreshToken: "y", ExpiresAt: expires, SessionID: "s", UserID: "u", PasswordResetRequired: false}},
+			TokenPairResponse{AccessToken: "x", RefreshToken: "y", ExpiresAt: expires, SessionID: "s", UserID: "u", PasswordResetRequired: false},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cells/accesscore/internal/sessionmint/sessionmint_test.go
+++ b/cells/accesscore/internal/sessionmint/sessionmint_test.go
@@ -45,6 +45,7 @@ type stubRoleRepo struct {
 func (s *stubRoleRepo) GetByID(_ context.Context, _ string) (*domain.Role, error) {
 	panic("unused")
 }
+
 func (s *stubRoleRepo) GetByUserID(_ context.Context, _ string) ([]*domain.Role, error) {
 	return s.roles, s.err
 }

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -28,6 +28,9 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
@@ -41,8 +44,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	refreshmem "github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // e2eTestKeySet holds a key pair shared across the e2e test.

--- a/cells/accesscore/slices/setup/service_test.go
+++ b/cells/accesscore/slices/setup/service_test.go
@@ -531,9 +531,11 @@ func (r *countErrRoleRepo) RemoveFromUser(_ context.Context, _, _ string) error 
 func (r *countErrRoleRepo) RemoveFromUserIfNotLast(_ context.Context, _, _ string) (bool, error) {
 	return true, nil
 }
+
 func (r *countErrRoleRepo) GetByID(_ context.Context, _ string) (*domain.Role, error) {
 	return &domain.Role{ID: auth.RoleAdmin}, nil
 }
+
 func (r *countErrRoleRepo) ListByUserID(_ context.Context, _ string, _ query.ListParams) ([]*domain.Role, error) {
 	return nil, nil
 }

--- a/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -189,8 +189,10 @@ func TestEncrypt_GetByKey_SensitiveDecryptsValue(t *testing.T) {
 		queryRowResult: &mockRow{
 			// Row columns: id, key, value, sensitive, version, created_at, updated_at,
 			//             value_cipher, value_key_id, value_edk, value_nonce
-			values: []any{"cfg-1", "db_password", "", true, 1, now, now,
-				ct, keyID, edk, nonce},
+			values: []any{
+				"cfg-1", "db_password", "", true, 1, now, now,
+				ct, keyID, edk, nonce,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -210,8 +212,10 @@ func TestEncrypt_GetByKey_SensitiveDecryptFailed_FailClosed(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "db_password", "", true, 1, now, now,
-				[]byte("someciphertext"), "local-aes-v1", []byte("edk"), []byte("nonce")},
+			values: []any{
+				"cfg-1", "db_password", "", true, 1, now, now,
+				[]byte("someciphertext"), "local-aes-v1", []byte("edk"), []byte("nonce"),
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -242,8 +246,10 @@ func TestEncrypt_GetByKey_SensitiveStaleKey(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "old_key", "", true, 1, now, now,
-				ct, oldKeyID, edk, nonce},
+			values: []any{
+				"cfg-1", "old_key", "", true, 1, now, now,
+				ct, oldKeyID, edk, nonce,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -265,8 +271,10 @@ func TestEncrypt_GetByKey_NonSensitive_NoDecryption(t *testing.T) {
 	db := &mockDB{
 		queryRowResult: &mockRow{
 			// value_cipher is nil → non-sensitive path
-			values: []any{"cfg-1", "app.name", "GoCell", false, 1, now, now,
-				nil, nil, nil, nil},
+			values: []any{
+				"cfg-1", "app.name", "GoCell", false, 1, now, now,
+				nil, nil, nil, nil,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -347,8 +355,10 @@ func TestEncrypt_GetVersion_SensitiveDecryptsValue(t *testing.T) {
 		queryRowResult: &mockRow{
 			// id, config_id, version, value, sensitive, published_at,
 			// value_cipher, value_key_id, value_edk, value_nonce
-			values: []any{"cv-1", "cfg-1", 1, "", true, &now,
-				ct, keyID, edk, nonce},
+			values: []any{
+				"cv-1", "cfg-1", 1, "", true, &now,
+				ct, keyID, edk, nonce,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -369,8 +379,10 @@ func TestConfigRepo_GetByKey_Sensitive_LegacyPlaintext_ReturnsErr(t *testing.T) 
 	db := &mockDB{
 		queryRowResult: &mockRow{
 			// Simulate legacy row: sensitive=true, value_cipher=nil, value_key_id=nil
-			values: []any{"cfg-1", "db_password", "legacy-plaintext", true, 1, now, now,
-				nil, nil, nil, nil},
+			values: []any{
+				"cfg-1", "db_password", "legacy-plaintext", true, 1, now, now,
+				nil, nil, nil, nil,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -407,8 +419,10 @@ func TestConfigRepo_Decrypt_AADMismatch_FailsClosed(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "db_password", "", true, 1, now, now,
-				ct, keyID, wrongEDK, nonce},
+			values: []any{
+				"cfg-1", "db_password", "", true, 1, now, now,
+				ct, keyID, wrongEDK, nonce,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -437,8 +451,10 @@ func TestGetByKey_Sensitive_EmptyValueCipher_LegacyPlaintext(t *testing.T) {
 	// value_cipher is nil, value_key_id is nil → legacy plaintext path.
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "secret_key", "plaintext-not-encrypted", true, 1, now, now,
-				nil, nil, nil, nil},
+			values: []any{
+				"cfg-1", "secret_key", "plaintext-not-encrypted", true, 1, now, now,
+				nil, nil, nil, nil,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -477,8 +493,10 @@ func TestCurrentKeyID_ProviderReturnsError(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "my_key", "", true, 1, now, now,
-				ct, keyID, edk, nonce},
+			values: []any{
+				"cfg-1", "my_key", "", true, 1, now, now,
+				ct, keyID, edk, nonce,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -507,8 +525,10 @@ func TestGetByKey_Sensitive_StaleKey_DifferentStoredAndCurrentKeyID(t *testing.T
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "cfg_key", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce},
+			values: []any{
+				"cfg-1", "cfg_key", "", true, 1, now, now,
+				ct, storedKeyID, edk, nonce,
+			},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -563,8 +583,10 @@ func TestGetByKey_StaleKey_EmitsWarn(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "api_secret", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce},
+			values: []any{
+				"cfg-1", "api_secret", "", true, 1, now, now,
+				ct, storedKeyID, edk, nonce,
+			},
 		},
 	}
 
@@ -603,8 +625,10 @@ func TestGetByKey_FreshKey_NoWarn(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "fresh_key", "", true, 1, now, now,
-				ct, keyID, edk, nonce},
+			values: []any{
+				"cfg-1", "fresh_key", "", true, 1, now, now,
+				ct, keyID, edk, nonce,
+			},
 		},
 	}
 
@@ -681,8 +705,10 @@ func TestGetByKey_StaleKey_OnStaleCipherCallback(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "cb_key", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce},
+			values: []any{
+				"cfg-1", "cb_key", "", true, 1, now, now,
+				ct, storedKeyID, edk, nonce,
+			},
 		},
 	}
 
@@ -879,8 +905,10 @@ func TestWithOnStaleCipher_Option(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "opt_key", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce},
+			values: []any{
+				"cfg-1", "opt_key", "", true, 1, now, now,
+				ct, storedKeyID, edk, nonce,
+			},
 		},
 	}
 
@@ -1034,8 +1062,10 @@ func TestGetByKey_FreshKey_OnStaleCipherCallback_NotCalled(t *testing.T) {
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "fresh_cb_key", "", true, 1, now, now,
-				ct, keyID, edk, nonce},
+			values: []any{
+				"cfg-1", "fresh_cb_key", "", true, 1, now, now,
+				ct, keyID, edk, nonce,
+			},
 		},
 	}
 

--- a/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_integration_test.go
@@ -8,6 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -16,11 +22,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 // setupConfigPG spins up a PostgreSQL container, applies all migrations

--- a/cells/configcore/internal/adapters/postgres/flag_ctx_cancel_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/flag_ctx_cancel_integration_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
-	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
 )
 
 // TestFlagWrite_CtxCancel_PGTxRollback verifies that when the context is

--- a/cells/configcore/internal/adapters/postgres/flag_repo_test.go
+++ b/cells/configcore/internal/adapters/postgres/flag_repo_test.go
@@ -145,9 +145,11 @@ type capturingDB struct {
 func (d *capturingDB) Exec(_ context.Context, _ string, _ ...any) (int64, error) {
 	return 1, nil
 }
+
 func (d *capturingDB) Query(_ context.Context, _ string, _ ...any) (Rows, error) {
 	return &mockRowSet{}, nil
 }
+
 func (d *capturingDB) QueryRow(_ context.Context, sql string, _ ...any) Row {
 	d.queryRowSQL = sql
 	if d.queryRowResult == nil {

--- a/cells/configcore/internal/adapters/postgres/flag_restart_integration_test.go
+++ b/cells/configcore/internal/adapters/postgres/flag_restart_integration_test.go
@@ -7,14 +7,15 @@ import (
 	"testing"
 	"time"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
-	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
-	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/tests/testutil"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/tests/testutil"
 )
 
 // setupFlagPG spins up a PostgreSQL container, applies all migrations

--- a/cells/configcore/internal/adapters/postgres/postgres_helpers_test.go
+++ b/cells/configcore/internal/adapters/postgres/postgres_helpers_test.go
@@ -6,8 +6,9 @@ import (
 	"io/fs"
 	"testing"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 )
 
 func testAdapterMigrationsFS(t testing.TB) fs.FS {

--- a/cells/configcore/slices/configpublish/postgres_helpers_test.go
+++ b/cells/configcore/slices/configpublish/postgres_helpers_test.go
@@ -6,8 +6,9 @@ import (
 	"io/fs"
 	"testing"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 )
 
 func testAdapterMigrationsFS(t testing.TB) fs.FS {

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -9,6 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	cellpg "github.com/ghbvf/gocell/cells/configcore/internal/adapters/postgres"
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
@@ -18,11 +24,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 // adminIntegCtx returns a context carrying an admin principal for integration

--- a/cells/configcore/slices/configwrite/postgres_helpers_test.go
+++ b/cells/configcore/slices/configwrite/postgres_helpers_test.go
@@ -6,8 +6,9 @@ import (
 	"io/fs"
 	"testing"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 )
 
 func testAdapterMigrationsFS(t testing.TB) fs.FS {

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -5,9 +5,15 @@ package configwrite
 import (
 	"context"
 	"errors"
-	"github.com/ghbvf/gocell/cells/internal/testoutbox"
 	"log/slog"
 	"testing"
+
+	"github.com/ghbvf/gocell/cells/internal/testoutbox"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	cellpg "github.com/ghbvf/gocell/cells/configcore/internal/adapters/postgres"
@@ -18,10 +24,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 // adminIntegCtx returns a context carrying an admin principal for integration

--- a/cmd/corebundle/auth_integration_test.go
+++ b/cmd/corebundle/auth_integration_test.go
@@ -13,6 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	accesscore "github.com/ghbvf/gocell/cells/accesscore"
 	auditcore "github.com/ghbvf/gocell/cells/auditcore"
 	configcore "github.com/ghbvf/gocell/cells/configcore"
@@ -27,8 +30,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // noopTxRunner executes fn directly without a real transaction.

--- a/cmd/corebundle/buildapp_env_integration_test.go
+++ b/cmd/corebundle/buildapp_env_integration_test.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"testing"
 
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth"
-	prom "github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // applyMigrationsForMain applies all schema migrations to the given DSN using

--- a/cmd/corebundle/config_event_metrics_wiring_test.go
+++ b/cmd/corebundle/config_event_metrics_wiring_test.go
@@ -157,6 +157,7 @@ func (c *captureSubscriberHandler) Ready(_ outbox.Subscription) <-chan struct{} 
 	close(ch)
 	return ch
 }
+
 func (c *captureSubscriberHandler) Subscribe(_ context.Context, _ outbox.Subscription, h outbox.SubscriberHandler) error {
 	if c.onSubscribe != nil {
 		c.onSubscribe(h)

--- a/cmd/corebundle/jwt_aud_integration_test.go
+++ b/cmd/corebundle/jwt_aud_integration_test.go
@@ -11,11 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestBuildJWTDeps_VerifierEnforcesAudience verifies that the JWTVerifier returned

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -13,6 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/clock"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -20,9 +24,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 // setupPostgresForMain starts a PostgreSQL container and returns the DSN

--- a/cmd/corebundle/metrics_wiring_integration_test.go
+++ b/cmd/corebundle/metrics_wiring_integration_test.go
@@ -11,11 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestR2_MetricsCollector_RecordsHTTPRequests is the R2 wiring integration test.

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -42,6 +42,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	accesscore "github.com/ghbvf/gocell/cells/accesscore"
 	"github.com/ghbvf/gocell/cells/accesscore/configgetter"
@@ -59,9 +63,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 const (

--- a/cmd/corebundle/outbox_wiring_integration_test.go
+++ b/cmd/corebundle/outbox_wiring_integration_test.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/crypto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestBuildConfigCoreOpts_PGMode_ManagedResourceNonNil asserts that postgres mode

--- a/cmd/corebundle/postgres_helpers_test.go
+++ b/cmd/corebundle/postgres_helpers_test.go
@@ -6,8 +6,9 @@ import (
 	"io/fs"
 	"testing"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 )
 
 func testAdapterMigrationsFS(t testing.TB) fs.FS {

--- a/cmd/corebundle/redis.go
+++ b/cmd/corebundle/redis.go
@@ -21,9 +21,11 @@ const (
 	envRedisDB       = "GOCELL_REDIS_DB"
 )
 
-type redisNonceStoreFactory func(*adapterredis.Client, time.Duration) (auth.NonceStore, error)
-type redisConsumerClaimerFactory func(*adapterredis.Client) idempotency.Claimer
-type redisClientFactory func(context.Context, adapterredis.Config) (*adapterredis.Client, error)
+type (
+	redisNonceStoreFactory      func(*adapterredis.Client, time.Duration) (auth.NonceStore, error)
+	redisConsumerClaimerFactory func(*adapterredis.Client) idempotency.Claimer
+	redisClientFactory          func(context.Context, adapterredis.Config) (*adapterredis.Client, error)
+)
 
 type redisClientResult struct {
 	Client *adapterredis.Client

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -570,8 +570,10 @@ func TestRunScaffoldContract_DryRun_NoFileWritten(t *testing.T) {
 	dir := setupProject(t, "contracts")
 
 	out := captureStdout(t, func() {
-		err := runScaffoldWithRoot(dir, []string{"contract",
-			"--id=http.dry.test.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
+		err := runScaffoldWithRoot(dir, []string{
+			"contract",
+			"--id=http.dry.test.v1", "--kind=http", "--owner=some-cell", "--dry-run",
+		})
 		require.NoError(t, err)
 	})
 
@@ -585,8 +587,10 @@ func TestRunScaffoldJourney_DryRun_NoFileWritten(t *testing.T) {
 	dir := setupProject(t, "journeys")
 
 	out := captureStdout(t, func() {
-		err := runScaffoldWithRoot(dir, []string{"journey",
-			"--id=J-dry", "--goal=test goal", "--team=squad", "--cells=a,b", "--dry-run"})
+		err := runScaffoldWithRoot(dir, []string{
+			"journey",
+			"--id=J-dry", "--goal=test goal", "--team=squad", "--cells=a,b", "--dry-run",
+		})
 		require.NoError(t, err)
 	})
 
@@ -756,8 +760,10 @@ func TestRunScaffoldCell_DryRun_DetectsConflict(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(target, "cell.yaml"),
 		[]byte("id: conflict-cell\n"), 0o644))
 
-	err := runScaffoldWithRoot(dir, []string{"cell",
-		"--id=conflict-cell", "--team=squad", "--role=cell-owner", "--dry-run"})
+	err := runScaffoldWithRoot(dir, []string{
+		"cell",
+		"--id=conflict-cell", "--team=squad", "--role=cell-owner", "--dry-run",
+	})
 	require.Error(t, err, "dry-run must still surface conflicts")
 }
 
@@ -770,8 +776,10 @@ func TestRunScaffoldSlice_DryRun_DetectsConflict(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sliceDir, "slice.yaml"),
 		[]byte("id: conflict-slice\n"), 0o644))
 
-	err := runScaffoldWithRoot(dir, []string{"slice",
-		"--id=conflict-slice", "--cell=my-cell", "--dry-run"})
+	err := runScaffoldWithRoot(dir, []string{
+		"slice",
+		"--id=conflict-slice", "--cell=my-cell", "--dry-run",
+	})
 	require.Error(t, err, "dry-run must still surface slice conflicts")
 }
 
@@ -782,8 +790,10 @@ func TestRunScaffoldContract_DryRun_DetectsConflict(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(contractDir, "contract.yaml"),
 		[]byte("id: http.conflict.api.v1\n"), 0o644))
 
-	err := runScaffoldWithRoot(dir, []string{"contract",
-		"--id=http.conflict.api.v1", "--kind=http", "--owner=some-cell", "--dry-run"})
+	err := runScaffoldWithRoot(dir, []string{
+		"contract",
+		"--id=http.conflict.api.v1", "--kind=http", "--owner=some-cell", "--dry-run",
+	})
 	require.Error(t, err, "dry-run must still surface contract conflicts")
 }
 
@@ -792,7 +802,9 @@ func TestRunScaffoldJourney_DryRun_DetectsConflict(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "journeys", "J-conflict.yaml"),
 		[]byte("id: J-conflict\n"), 0o644))
 
-	err := runScaffoldWithRoot(dir, []string{"journey",
-		"--id=conflict", "--goal=test goal", "--team=squad", "--cells=a", "--dry-run"})
+	err := runScaffoldWithRoot(dir, []string{
+		"journey",
+		"--id=conflict", "--goal=test goal", "--team=squad", "--cells=a", "--dry-run",
+	})
 	require.Error(t, err, "dry-run must still surface journey conflicts")
 }

--- a/docs/plans/202605011500-029-master-roadmap.md
+++ b/docs/plans/202605011500-029-master-roadmap.md
@@ -147,7 +147,7 @@
 >
 > **D6 状态**：✅ 已完成（refactor/503-prod-clock-injection）。G9 触发条件随之解锁——D6 后 TTL 类 sleep 已可由 `clockmock.Advance` 消除，G9 可设激进 threshold（建议 2s）+ allowlist 兜底 OS-sync/sleep-即-SUT 类残余。
 
-### Track G · CI / lint / governance（10 PR / 残余 16h dev + 8h review；G1/G2/G4/G5/G6/G7 ✅；G8 仅 gofumpt 待；G3/G9/G11 待）
+### Track G · CI / lint / governance（10 PR / 残余 16h dev + 8h review；G1/G2/G4/G5/G6/G7/G8 ✅；G3/G9/G11 待）
 
 | # | PR | 来源 | 问题 | 方案 | ship | 工时 |
 |---|---|---|---|---|:-:|---|
@@ -158,7 +158,7 @@
 | G5 | ✅ PR#353（5b08d41b）PR-CI-3-V1-RESPONSE-EVOLVE | FMT-20 / 027#23 | v1 响应 schema 30 处顶层 `additionalProperties` 不放宽，新增字段需 v2 | ADR `202605031600-adr-v1-schema-evolution.md` + FMT-20 收窄到 request-only（lenient response/event, strict request）+ 30 response/event schema 放宽 + `B2-C-08` cell event decoder `DisallowUnknownFields` 同步关闭 | ✅ done | 13h + 6h |
 | G6 | ✅ PR#346（cd0f8b30）PR-CI-4-TEST-TIME-LITERAL-01 | TEST-NO-SLEEP-01 / 027#24 + 2026-05-01 explore 调研 | ✅ 一级 6 family + Eventually 字面量全部收口；`tools/archtest/test_time_literal_test.go` + `hack/verify-test-time-literal.sh` + CI gate 已 ship | — | ✅ done；衍生 G9/D6 见对应行 |
 | G7 | ✅ PR#347（588376d5）PR-V11-CI-LINT-BATCH-3 全收 | ci-governance B3 / 028 B3-5 | ✅ gosec PR#342 + revive PR#347 全部 ship；gosec 残余 G401/G104 视生产 finding 量评估，当前 unexclude 状态（finding=0 则不必解封）| — | ✅ done |
-| G8 | ⚠️ 残余 PR-V11-CI-LINT-BATCH-4 | ci-governance B4 / 028 B3-6 | ✅ gocritic PR#342 + nolintlint PR#344 已 ship；残余仅 `gofumpt`（一次性全仓 reformat，无逻辑改动）| gofumpt 全仓 reformat + CI 强制 | L1 | 1h + 1h |
+| G8 | ✅ PR-V11-CI-LINT-BATCH-4（refactor/516-ci-lint-batch4-gofumpt）| ci-governance B4 / 028 B3-6 | ✅ gocritic PR#342 + nolintlint PR#344 + gofumpt 全仓 reformat 全部 ship；`.golangci.yml` `formatters.enable += gofumpt` + `golangci-lint fmt` 一次性 reformat 98 文件（合并 `var(...)`/`type(...)` 块、跨行 `lhs =\n  rhs` 收一行），4 处合并后超 lll 140 改用多行 struct literal；CI `golangci-lint run` v2 自动校验 formatter | — | ✅ done |
 | G9 | PR-V11-SLOW-TEST-BUDGET | G6 衍生（2026-05-01）| D6 已 ship，TTL/lease/expiry 类 sleep 已可由 `clockmock.Advance` 消除；残余 ~50 处 sleep 是 OS-sync（fsnotify/goroutine 阻塞观察）+ sleep-即-SUT（debounce 窗口/负测）两类不可消除；无单测 wall-time 阈值则慢测漂移无感知 | `tools/slowgate/` 二进制 + CI step `go test -json \| slowgate --threshold 2s --allowlist <list>`；allowlist 从残余 `//archtest:allow:test-sleep` 反推 OS-sync/sleep-即-SUT 测试名 | L2 | 4h + 2h | 触发条件：D6 合入后即可起 |
 | G11 | PR-V1-TEST-GATE-CLOSURE | P3-TD-02/P4-TD-08/P4-TD-11（tech-debt 核验）| `adapters/postgres` 包无覆盖率门禁阈值，CI 仅采集不阻断；Migrator.Down v=0 重复调用回归锁不足 | `adapters/postgres` 包级覆盖率 gate ≥ 60%（渐进，对齐 kernel/ 90% 路线）+ workflow 阻断步骤；补 Migrator.Down v=0 幂等回归测试（多次调用不报错、RowsAffected==0 正确处理）| L1 | 4h + 2h |
 

--- a/examples/ssobff/walkthrough_test.go
+++ b/examples/ssobff/walkthrough_test.go
@@ -36,11 +36,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const walkthroughServiceSecret = "walkthrough-service-token-secret-32b"

--- a/examples/todoorder/cells/ordercell/slices/orderquery/service.go
+++ b/examples/todoorder/cells/ordercell/slices/orderquery/service.go
@@ -14,8 +14,10 @@ import (
 )
 
 // Compile-time assertions: Service implements both generated interfaces.
-var _ getv1.Service = (*Service)(nil)
-var _ listv1.Service = (*Service)(nil)
+var (
+	_ getv1.Service  = (*Service)(nil)
+	_ listv1.Service = (*Service)(nil)
+)
 
 // orderSort defines the default sort for order listings.
 var orderSort = []query.SortColumn{

--- a/kernel/assembly/generator_fingerprint_test.go
+++ b/kernel/assembly/generator_fingerprint_test.go
@@ -168,8 +168,7 @@ func TestSourceFingerprint_StructuralChangesDetected(t *testing.T) {
 			p.Contracts["http.auth.login.v1"].Endpoints.HTTP.SuccessStatus = 201
 		}},
 		{"http response keys add", func(p *metadata.ProjectMeta) {
-			p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[413] =
-				metadata.HTTPResponseMeta{Description: "too big"}
+			p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[413] = metadata.HTTPResponseMeta{Description: "too big"}
 		}},
 		{"http response keys remove", func(p *metadata.ProjectMeta) {
 			delete(p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses, 400)
@@ -319,8 +318,10 @@ func TestSourceFingerprint_ResponseSchemaFileContentChange(t *testing.T) {
 
 	p := fingerprintProject()
 	p.Contracts["http.auth.login.v1"].Dir = filepath.ToSlash(filepath.Join("contracts", "http", "auth", "login", "v1"))
-	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] =
-		metadata.HTTPResponseMeta{Description: "bad", SchemaRef: "error.schema.json"}
+	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] = metadata.HTTPResponseMeta{
+		Description: "bad",
+		SchemaRef:   "error.schema.json",
+	}
 
 	baseline := computeFingerprintWithRoot(t, p, root)
 	require.NoError(t, os.WriteFile(schemaPath, []byte(`{"version":2}`), 0o644))
@@ -333,8 +334,10 @@ func TestSourceFingerprint_ResponseSchemaMissingFileFailsLoudly(t *testing.T) {
 	root := t.TempDir()
 	p := fingerprintProject()
 	p.Contracts["http.auth.login.v1"].Dir = "contracts/http/auth/login/v1"
-	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] =
-		metadata.HTTPResponseMeta{Description: "bad", SchemaRef: "missing-error.schema.json"}
+	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] = metadata.HTTPResponseMeta{
+		Description: "bad",
+		SchemaRef:   "missing-error.schema.json",
+	}
 
 	gen := NewGenerator(p, "github.com/ghbvf/gocell", root)
 	_, err := gen.GenerateBoundary("ssobff")
@@ -352,8 +355,10 @@ func TestSourceFingerprint_ResponseSchemaPathEscapeFailsClosed(t *testing.T) {
 
 	p := fingerprintProject()
 	p.Contracts["http.auth.login.v1"].Dir = "contracts/http/auth/login/v1"
-	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] =
-		metadata.HTTPResponseMeta{Description: "bad", SchemaRef: "../../../../../../outside.schema.json"}
+	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] = metadata.HTTPResponseMeta{
+		Description: "bad",
+		SchemaRef:   "../../../../../../outside.schema.json",
+	}
 
 	gen := NewGenerator(p, "github.com/ghbvf/gocell", root)
 	_, err := gen.GenerateBoundary("ssobff")
@@ -402,8 +407,7 @@ func TestSourceFingerprint_ResponseDescriptionIgnored(t *testing.T) {
 	baseline := computeFingerprint(t, fingerprintProject())
 
 	p := fingerprintProject()
-	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] =
-		metadata.HTTPResponseMeta{Description: "changed description"}
+	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] = metadata.HTTPResponseMeta{Description: "changed description"}
 	got := computeFingerprint(t, p)
 	assert.Equal(t, baseline, got, "changing response description must not change fingerprint")
 }
@@ -418,8 +422,10 @@ func TestSourceFingerprint_ResponseSchemaRefChange(t *testing.T) {
 	p.Contracts["http.auth.login.v1"].Dir = filepath.ToSlash(filepath.Join("contracts", "http", "auth", "login", "v1"))
 	baseline := computeFingerprintWithRoot(t, p, root)
 
-	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] =
-		metadata.HTTPResponseMeta{Description: "bad", SchemaRef: "error.schema.json"}
+	p.Contracts["http.auth.login.v1"].Endpoints.HTTP.Responses[400] = metadata.HTTPResponseMeta{
+		Description: "bad",
+		SchemaRef:   "error.schema.json",
+	}
 	got := computeFingerprintWithRoot(t, p, root)
 	assert.NotEqual(t, baseline, got, "adding response schemaRef must change fingerprint")
 }

--- a/kernel/assembly/hook_dispatcher_test.go
+++ b/kernel/assembly/hook_dispatcher_test.go
@@ -122,7 +122,8 @@ func TestHookDispatcher_SlowSinkDoesNotBlockEmit(t *testing.T) {
 	// The dispatcher must return immediately; only the observer goroutine
 	// is blocked.
 	bo := newBlockingObserver()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D10ms,
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 8, SinkTimeout: testtime.D10ms,
 		Clock: clock.Real(),
 	})
 	t.Cleanup(func() {
@@ -145,7 +146,8 @@ func TestHookDispatcher_OverflowDropsAndCounts(t *testing.T) {
 	// one DropReasonQueueFull is certain regardless of scheduler jitter.
 	bo := newBlockingObserver()
 	cv := newSpyCounterVec()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 2, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 2, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
 		Clock: clock.Real(),
 	})
 	t.Cleanup(func() {
@@ -173,7 +175,8 @@ func TestHookDispatcher_OverflowDropsAndCounts(t *testing.T) {
 func TestHookDispatcher_PerSinkTimeoutCountsAndContinues(t *testing.T) {
 	bo := newBlockingObserver()
 	cv := newSpyCounterVec()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D20ms, Provider: &spyProvider{cv: cv},
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 8, SinkTimeout: testtime.D20ms, Provider: &spyProvider{cv: cv},
 		Clock: clock.Real(),
 	})
 	t.Cleanup(func() {
@@ -238,7 +241,8 @@ func (c *collectObserver) len() int {
 
 func TestHookDispatcher_StopDrainsPending(t *testing.T) {
 	obs := &collectObserver{}
-	d := newHookDispatcher(dispatcherConfig{Observer: obs, QueueSize: 32, SinkTimeout: testtime.D1s,
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: obs, QueueSize: 32, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
 
@@ -251,7 +255,8 @@ func TestHookDispatcher_StopDrainsPending(t *testing.T) {
 }
 
 func TestHookDispatcher_StopIsIdempotent(t *testing.T) {
-	d := newHookDispatcher(dispatcherConfig{Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
 	d.stop(testtime.D200ms)
@@ -259,7 +264,8 @@ func TestHookDispatcher_StopIsIdempotent(t *testing.T) {
 }
 
 func TestHookDispatcher_FlushOnIdleReturnsTrue(t *testing.T) {
-	d := newHookDispatcher(dispatcherConfig{Observer: cell.NopHookObserver{}, QueueSize: 8, SinkTimeout: testtime.D1s,
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: cell.NopHookObserver{}, QueueSize: 8, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
 	t.Cleanup(func() { d.stop(testtime.D200ms) })
@@ -296,7 +302,8 @@ func TestHookDispatcher_EmitAfterStopCountsQueueFull(t *testing.T) {
 // for). Returning false here would make clean-shutdown callers block or
 // retry for no gain.
 func TestHookDispatcher_FlushAfterStopReturnsTrue(t *testing.T) {
-	d := newHookDispatcher(dispatcherConfig{Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
 	d.stop(testtime.D200ms)
@@ -311,7 +318,8 @@ func TestHookDispatcher_FlushAfterStopReturnsTrue(t *testing.T) {
 // shared-timer behavior documented in flush().
 func TestHookDispatcher_FlushTimeoutThenSuccess(t *testing.T) {
 	bo := newBlockingObserver()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 2, SinkTimeout: testtime.D1s,
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 2, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
 	t.Cleanup(func() {

--- a/kernel/assembly/observer_test.go
+++ b/kernel/assembly/observer_test.go
@@ -239,6 +239,8 @@ func (errorPanicObserver) OnHookEvent(cell.HookEvent) {
 }
 
 // Compile-time interface conformance check.
-var _ cell.LifecycleHookObserver = (*captureObserver)(nil)
-var _ cell.LifecycleHookObserver = badObserver{}
-var _ cell.LifecycleHookObserver = errorPanicObserver{}
+var (
+	_ cell.LifecycleHookObserver = (*captureObserver)(nil)
+	_ cell.LifecycleHookObserver = badObserver{}
+	_ cell.LifecycleHookObserver = errorPanicObserver{}
+)

--- a/kernel/assembly/timeout_test.go
+++ b/kernel/assembly/timeout_test.go
@@ -44,12 +44,15 @@ func (c *slowHookCell) block(ctx context.Context, phase string) error {
 func (c *slowHookCell) BeforeStart(ctx context.Context) error {
 	return c.block(ctx, "BeforeStart")
 }
+
 func (c *slowHookCell) AfterStart(ctx context.Context) error {
 	return c.block(ctx, "AfterStart")
 }
+
 func (c *slowHookCell) BeforeStop(ctx context.Context) error {
 	return c.block(ctx, "BeforeStop")
 }
+
 func (c *slowHookCell) AfterStop(ctx context.Context) error {
 	return c.block(ctx, "AfterStop")
 }

--- a/kernel/cell/auth_plan_test.go
+++ b/kernel/cell/auth_plan_test.go
@@ -11,19 +11,23 @@ import (
 // ─── Compile-time interface assertions ────────────────────────────────────────
 
 // AuthPlan sealed interface assertions.
-var _ cell.AuthPlan = cell.AuthNone{}
-var _ cell.AuthPlan = cell.AuthJWT{}
-var _ cell.AuthPlan = cell.AuthJWTFromAssembly{}
-var _ cell.AuthPlan = cell.AuthMTLS{}
-var _ cell.AuthPlan = cell.AuthServiceToken{}
+var (
+	_ cell.AuthPlan = cell.AuthNone{}
+	_ cell.AuthPlan = cell.AuthJWT{}
+	_ cell.AuthPlan = cell.AuthJWTFromAssembly{}
+	_ cell.AuthPlan = cell.AuthMTLS{}
+	_ cell.AuthPlan = cell.AuthServiceToken{}
+)
 
 // ListenerAuth assertions: every AuthPlan in the closed enumeration must
 // satisfy ListenerAuth. Auth scheme is a listener-scope concern.
-var _ cell.ListenerAuth = cell.AuthNone{}
-var _ cell.ListenerAuth = cell.AuthJWT{}
-var _ cell.ListenerAuth = cell.AuthJWTFromAssembly{}
-var _ cell.ListenerAuth = cell.AuthMTLS{}
-var _ cell.ListenerAuth = cell.AuthServiceToken{}
+var (
+	_ cell.ListenerAuth = cell.AuthNone{}
+	_ cell.ListenerAuth = cell.AuthJWT{}
+	_ cell.ListenerAuth = cell.AuthJWTFromAssembly{}
+	_ cell.ListenerAuth = cell.AuthMTLS{}
+	_ cell.ListenerAuth = cell.AuthServiceToken{}
+)
 
 // ─── Describe() golden values ─────────────────────────────────────────────────
 

--- a/kernel/cell/celltest/mux.go
+++ b/kernel/cell/celltest/mux.go
@@ -23,9 +23,11 @@ import (
 )
 
 // Compile-time checks.
-var _ cell.RouteMux = (*TestMux)(nil)
-var _ cell.AuthRouteDeclarer = (*TestMux)(nil)
-var _ cell.Prefixer = (*TestMux)(nil)
+var (
+	_ cell.RouteMux          = (*TestMux)(nil)
+	_ cell.AuthRouteDeclarer = (*TestMux)(nil)
+	_ cell.Prefixer          = (*TestMux)(nil)
+)
 
 // TestMux adapts http.ServeMux to cell.RouteMux for testing.
 // It uses Go 1.22+ ServeMux pattern matching ("GET /path/{param}").

--- a/kernel/cell/init_contract_test.go
+++ b/kernel/cell/init_contract_test.go
@@ -22,7 +22,7 @@ import (
 // still uses Dependencies.
 func compileCellInitSignature() {
 	// A function literal that satisfies the Cell.Init shape.
-	var _ = func(_ context.Context, _ Registry) error {
+	_ = func(_ context.Context, _ Registry) error {
 		return nil
 	}
 }

--- a/kernel/cell/observer_test.go
+++ b/kernel/cell/observer_test.go
@@ -74,9 +74,11 @@ func (r *recordingObserver) OnHookEvent(e HookEvent) {
 }
 
 // compile-time interface check.
-var _ LifecycleHookObserver = (*recordingObserver)(nil)
-var _ LifecycleHookObserver = (*NopHookObserver)(nil)
-var _ LifecycleHookObserver = NopHookObserver{}
+var (
+	_ LifecycleHookObserver = (*recordingObserver)(nil)
+	_ LifecycleHookObserver = (*NopHookObserver)(nil)
+	_ LifecycleHookObserver = NopHookObserver{}
+)
 
 func TestNopHookObserver_DoesNotPanic(t *testing.T) {
 	// NopHookObserver must accept any HookEvent without panicking or doing work.

--- a/kernel/command/ports_test.go
+++ b/kernel/command/ports_test.go
@@ -20,6 +20,7 @@ type mockActiveScanner struct{}
 func (m *mockActiveScanner) ScanActive(_ context.Context, _ ScanFilter) ([]Entry, error) {
 	return nil, nil
 }
+
 func (m *mockActiveScanner) GetCommand(_ context.Context, _ string) (*Entry, error) {
 	return &Entry{}, nil
 }

--- a/kernel/command/sweeper_test.go
+++ b/kernel/command/sweeper_test.go
@@ -242,6 +242,7 @@ func (a *mockAckQueue) Ack(_ context.Context, id string, reason command.AckReaso
 func (a *mockAckQueue) Enqueue(context.Context, command.Entry, command.EnqueueOptions) error {
 	return errors.New("unused")
 }
+
 func (a *mockAckQueue) Dequeue(context.Context, string, int, time.Duration) ([]command.Entry, error) {
 	return nil, errors.New("unused")
 }
@@ -249,6 +250,7 @@ func (a *mockAckQueue) Report(context.Context, string, time.Time) error { return
 func (a *mockAckQueue) ExtendLease(context.Context, string, time.Duration, time.Time) error {
 	return errors.New("unused")
 }
+
 func (a *mockAckQueue) Cancel(context.Context, string, time.Time) error {
 	return errors.New("unused")
 }

--- a/kernel/crypto/key_provider_test.go
+++ b/kernel/crypto/key_provider_test.go
@@ -31,8 +31,10 @@ func (fakeHandle) Decrypt(_ context.Context, _, _, _, _ []byte) ([]byte, error) 
 
 // Compile-time contract checks — these fail at build time if the interfaces
 // are not satisfied, mirroring the kernel/lifecycle and kernel/worker pattern.
-var _ kcrypto.KeyProvider = fakeProvider{}
-var _ kcrypto.KeyHandle = fakeHandle{}
+var (
+	_ kcrypto.KeyProvider = fakeProvider{}
+	_ kcrypto.KeyHandle   = fakeHandle{}
+)
 
 // ---------------------------------------------------------------------------
 // Method-call tests (verifying interface shape at runtime)

--- a/kernel/crypto/value_transformer_test.go
+++ b/kernel/crypto/value_transformer_test.go
@@ -18,6 +18,7 @@ type fakeTransformer struct{}
 func (fakeTransformer) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, string, []byte, []byte, error) {
 	return plaintext, "fake-key-v1", nil, nil, nil
 }
+
 func (fakeTransformer) Decrypt(_ context.Context, ciphertext []byte, _ string, _, _, _ []byte) ([]byte, error) {
 	return ciphertext, nil
 }
@@ -29,8 +30,10 @@ func (fakeCurrentKeyIDProvider) CurrentKeyID(_ context.Context) (string, error) 
 	return "fake-key-v1", nil
 }
 
-var _ kcrypto.ValueTransformer = fakeTransformer{}
-var _ kcrypto.CurrentKeyIDProvider = fakeCurrentKeyIDProvider{}
+var (
+	_ kcrypto.ValueTransformer     = fakeTransformer{}
+	_ kcrypto.CurrentKeyIDProvider = fakeCurrentKeyIDProvider{}
+)
 
 // ---------------------------------------------------------------------------
 // ValueTransformer interface method tests

--- a/kernel/governance/location_integration_test.go
+++ b/kernel/governance/location_integration_test.go
@@ -3,14 +3,16 @@
 package governance_test
 
 import (
-	"github.com/ghbvf/gocell/kernel/clock"
 	"testing"
 	"testing/fstest"
 
-	"github.com/ghbvf/gocell/kernel/governance"
-	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/clock"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/governance"
+	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
 // TestLocation_REF01_SliceBelongsToCell verifies that a REF-01 finding
@@ -226,10 +228,14 @@ func TestLocation_DEP02_ScopeNotFile(t *testing.T) {
 			}},
 		},
 		Contracts: map[string]*metadata.ContractMeta{
-			"http.ab.v1": {ID: "http.ab.v1", Kind: "http", OwnerCell: "a",
-				Endpoints: metadata.EndpointsMeta{Server: "a", Clients: []string{"b"}}},
-			"http.ba.v1": {ID: "http.ba.v1", Kind: "http", OwnerCell: "b",
-				Endpoints: metadata.EndpointsMeta{Server: "b", Clients: []string{"a"}}},
+			"http.ab.v1": {
+				ID: "http.ab.v1", Kind: "http", OwnerCell: "a",
+				Endpoints: metadata.EndpointsMeta{Server: "a", Clients: []string{"b"}},
+			},
+			"http.ba.v1": {
+				ID: "http.ba.v1", Kind: "http", OwnerCell: "b",
+				Endpoints: metadata.EndpointsMeta{Server: "b", Clients: []string{"a"}},
+			},
 		},
 	}
 

--- a/kernel/outbox/emitter_test.go
+++ b/kernel/outbox/emitter_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-var _ Emitter = (*WriterEmitter)(nil)
-var _ Emitter = (*DirectEmitter)(nil)
+var (
+	_ Emitter = (*WriterEmitter)(nil)
+	_ Emitter = (*DirectEmitter)(nil)
+)
 
 func TestWriterEmitter_ConstructRejectsNilWriter(t *testing.T) {
 	_, err := NewWriterEmitter(nil)

--- a/kernel/outbox/observability_test.go
+++ b/kernel/outbox/observability_test.go
@@ -429,6 +429,7 @@ func (c *captureSubscriber) Ready(Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (c *captureSubscriber) Subscribe(_ context.Context, _ Subscription, h SubscriberHandler) error {
 	c.handler = h
 	return nil

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -97,9 +97,11 @@ func (m *mockSubscriberCtx) Ready(_ Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (m *mockSubscriberCtx) Subscribe(_ context.Context, _ Subscription, _ SubscriberHandler) error {
 	return nil
 }
+
 func (m *mockSubscriberCtx) Close(ctx context.Context) error {
 	if m.closeFn != nil {
 		return m.closeFn(ctx)
@@ -153,6 +155,7 @@ func (m *plainSubscriber) Ready(_ Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (m *plainSubscriber) Subscribe(_ context.Context, _ Subscription, _ SubscriberHandler) error {
 	return nil
 }
@@ -209,6 +212,7 @@ func (m *mockSubscriber) Ready(_ Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (m *mockSubscriber) Subscribe(_ context.Context, _ Subscription, _ SubscriberHandler) error {
 	return nil
 }
@@ -266,6 +270,7 @@ func (r *recordingSubscriber) Ready(_ Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (r *recordingSubscriber) Subscribe(_ context.Context, sub Subscription, handler SubscriberHandler) error {
 	r.subscribeCalled = true
 	r.subscribeTopic = sub.Topic
@@ -982,6 +987,7 @@ func (r *recordingSubscriberFull) Ready(_ Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (r *recordingSubscriberFull) Subscribe(_ context.Context, sub Subscription, _ SubscriberHandler) error {
 	r.subscribedSub = sub
 	return nil
@@ -1001,8 +1007,10 @@ func (s *intakeStopperSubscriber) StopIntake(_ context.Context) error {
 	return nil
 }
 
-var _ Subscriber = (*intakeStopperSubscriber)(nil)
-var _ SubscriberIntakeStopper = (*intakeStopperSubscriber)(nil)
+var (
+	_ Subscriber              = (*intakeStopperSubscriber)(nil)
+	_ SubscriberIntakeStopper = (*intakeStopperSubscriber)(nil)
+)
 
 func TestSubscriberWithMiddleware_ForwardsStopIntake(t *testing.T) {
 	inner := &intakeStopperSubscriber{}

--- a/kernel/wrapper/spec_test.go
+++ b/kernel/wrapper/spec_test.go
@@ -15,7 +15,8 @@ func TestContractSpec_HTTPSpec_Validate(t *testing.T) {
 	}{
 		{"happy — full http spec", wrapper.ContractSpec{
 			ID: "http.auth.login.v1", Kind: "http", Transport: "http",
-			Method: "POST", Path: "/api/v1/auth/login"}, false},
+			Method: "POST", Path: "/api/v1/auth/login",
+		}, false},
 		{"empty id rejected", wrapper.ContractSpec{Kind: "http", Transport: "http", Method: "POST", Path: "/x"}, true},
 		{"empty kind rejected", wrapper.ContractSpec{ID: "a", Transport: "http", Method: "POST", Path: "/x"}, true},
 		{"empty transport rejected", wrapper.ContractSpec{ID: "a", Kind: "http", Method: "POST", Path: "/x"}, true},
@@ -68,10 +69,12 @@ func TestContractSpec_EventSpec_Validate(t *testing.T) {
 	}{
 		{"happy — event spec", wrapper.ContractSpec{
 			ID: "event.session.revoked.v1", Kind: "event", Transport: "amqp",
-			Topic: "session.revoked.v1"}, false},
+			Topic: "session.revoked.v1",
+		}, false},
 		{"event kind requires topic", wrapper.ContractSpec{ID: "a", Kind: "event", Transport: "amqp"}, true},
 		{"event spec with http fields rejected", wrapper.ContractSpec{
-			ID: "a", Kind: "event", Transport: "amqp", Topic: "t", Method: "POST"}, true},
+			ID: "a", Kind: "event", Transport: "amqp", Topic: "t", Method: "POST",
+		}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/runtime/auth/jwt_test.go
+++ b/runtime/auth/jwt_test.go
@@ -419,8 +419,10 @@ func TestJWTVerifier_AcceptsVerificationOnlyKey(t *testing.T) {
 // --- Interface abstraction tests (WM-2-F1) ---
 
 // Compile-time checks: *KeySet satisfies both interfaces.
-var _ SigningKeyProvider = (*KeySet)(nil)
-var _ VerificationKeyStore = (*KeySet)(nil)
+var (
+	_ SigningKeyProvider   = (*KeySet)(nil)
+	_ VerificationKeyStore = (*KeySet)(nil)
+)
 
 // stubSigningKeyProvider is a minimal test double for SigningKeyProvider.
 type stubSigningKeyProvider struct {

--- a/runtime/auth/provider_test.go
+++ b/runtime/auth/provider_test.go
@@ -15,8 +15,10 @@ import (
 )
 
 // Compile-time interface checks.
-var _ KeyProvider = (*EnvKeyProvider)(nil)
-var _ KeyProvider = (*StaticKeyProvider)(nil)
+var (
+	_ KeyProvider = (*EnvKeyProvider)(nil)
+	_ KeyProvider = (*StaticKeyProvider)(nil)
+)
 
 // --- EnvKeyProvider tests ---
 

--- a/runtime/auth/refresh/gc_worker_test.go
+++ b/runtime/auth/refresh/gc_worker_test.go
@@ -26,12 +26,15 @@ func (c staticClock) Until(t time.Time) time.Duration { return t.Sub(c.now) }
 func (c staticClock) NewTimerAt(_ time.Time) clock.Timer {
 	panic("staticClock.NewTimerAt not implemented")
 }
+
 func (c staticClock) NewTicker(d time.Duration) clock.Ticker {
 	return clock.Real().NewTicker(d)
 }
+
 func (c staticClock) AfterFunc(_ time.Time, _ func()) clock.Timer {
 	panic("staticClock.AfterFunc not implemented")
 }
+
 func (c staticClock) Sleep(_ context.Context, _ time.Time) error {
 	panic("staticClock.Sleep not implemented")
 }

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -27,12 +27,15 @@ func (*typedNilClock) Until(t time.Time) time.Duration { return t.Sub(baseTime) 
 func (*typedNilClock) NewTimerAt(_ time.Time) clock.Timer {
 	panic("typedNilClock.NewTimerAt not implemented")
 }
+
 func (*typedNilClock) NewTicker(_ time.Duration) clock.Ticker {
 	panic("typedNilClock.NewTicker not implemented")
 }
+
 func (*typedNilClock) AfterFunc(_ time.Time, _ func()) clock.Timer {
 	panic("typedNilClock.AfterFunc not implemented")
 }
+
 func (*typedNilClock) Sleep(_ context.Context, _ time.Time) error {
 	panic("typedNilClock.Sleep not implemented")
 }

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -429,6 +429,7 @@ func (s *invokeOnceSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *invokeOnceSubscriber) Subscribe(ctx context.Context, _ outbox.Subscription, handler outbox.SubscriberHandler) error {
 	s.once.Do(func() {
 		handler(ctx, s.entry)

--- a/runtime/bootstrap/consumer_tracing_integration_test.go
+++ b/runtime/bootstrap/consumer_tracing_integration_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -17,8 +20,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/eventbus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // F3 round-4 integration test: verifies the end-to-end path

--- a/runtime/bootstrap/lifecycle_integration_test.go
+++ b/runtime/bootstrap/lifecycle_integration_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghbvf/gocell/kernel/cell"
-	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 
 	"github.com/ghbvf/gocell/kernel/clock"
 )

--- a/runtime/bootstrap/metrics_provider_test.go
+++ b/runtime/bootstrap/metrics_provider_test.go
@@ -41,6 +41,7 @@ type recordingProvider struct{}
 func (recordingProvider) CounterVec(_ kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
 	return kernelmetrics.NopProvider{}.CounterVec(kernelmetrics.CounterOpts{})
 }
+
 func (recordingProvider) HistogramVec(_ kernelmetrics.HistogramOpts) (kernelmetrics.HistogramVec, error) {
 	return kernelmetrics.NopProvider{}.HistogramVec(kernelmetrics.HistogramOpts{})
 }

--- a/runtime/bootstrap/phases_test.go
+++ b/runtime/bootstrap/phases_test.go
@@ -957,6 +957,7 @@ func (s *phaseTestSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *phaseTestSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	return nil
 }
@@ -971,14 +972,17 @@ type phaseTestSubscriberCloser struct {
 func (s *phaseTestSubscriberCloser) Setup(_ context.Context, _ outbox.Subscription) error {
 	return nil
 }
+
 func (s *phaseTestSubscriberCloser) Ready(_ outbox.Subscription) <-chan struct{} {
 	ch := make(chan struct{})
 	close(ch)
 	return ch
 }
+
 func (s *phaseTestSubscriberCloser) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	return nil
 }
+
 func (s *phaseTestSubscriberCloser) Close(_ context.Context) error {
 	*s.log = append(*s.log, s.name)
 	return nil
@@ -997,9 +1001,11 @@ func (b *phaseTestSharedBus) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (b *phaseTestSharedBus) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	return nil
 }
+
 func (b *phaseTestSharedBus) Close(_ context.Context) error {
 	*b.closeCount++
 	return nil
@@ -1023,9 +1029,11 @@ func (s *pubSubCtxSpy) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *pubSubCtxSpy) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	return nil
 }
+
 func (s *pubSubCtxSpy) Close(ctx context.Context) error {
 	return s.closeFn(ctx)
 }
@@ -1038,11 +1046,13 @@ func (b nonComparablePubSub) Publish(_ context.Context, _ string, _ []byte) erro
 func (b nonComparablePubSub) Setup(_ context.Context, _ outbox.Subscription) error {
 	return nil
 }
+
 func (b nonComparablePubSub) Ready(_ outbox.Subscription) <-chan struct{} {
 	ch := make(chan struct{})
 	close(ch)
 	return ch
 }
+
 func (b nonComparablePubSub) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	return nil
 }

--- a/runtime/bootstrap/shutdown_metrics_test.go
+++ b/runtime/bootstrap/shutdown_metrics_test.go
@@ -40,6 +40,7 @@ func (v *fakeCounterVec) With(l kernelmetrics.Labels) kernelmetrics.Counter {
 	kernelmetrics.MustValidateLabels(v.labels, l)
 	return &fakeCounter{vec: v, labels: l}
 }
+
 func (v *fakeCounterVec) totalForLabel(key, value string) float64 {
 	v.mu.Lock()
 	defer v.mu.Unlock()
@@ -81,6 +82,7 @@ func (v *fakeHistogramVec) With(l kernelmetrics.Labels) kernelmetrics.Histogram 
 	kernelmetrics.MustValidateLabels(v.labels, l)
 	return &fakeHistogram{vec: v, labels: l}
 }
+
 func (v *fakeHistogramVec) observationsForLabel(key, value string) []float64 {
 	v.mu.Lock()
 	defer v.mu.Unlock()

--- a/runtime/distlock/locker_test.go
+++ b/runtime/distlock/locker_test.go
@@ -28,8 +28,10 @@ const lockerSmallTTL = testtime.D500ms
 
 // lockerExpiredTTLFrac is the fractional nanosecond below 1ms used to verify
 // boundary conditions in expiry tests.
-const lockerExpiredTTL500us = 500 * time.Microsecond
-const lockerExpiredTTL999us = 999_999 * time.Nanosecond
+const (
+	lockerExpiredTTL500us = 500 * time.Microsecond
+	lockerExpiredTTL999us = 999_999 * time.Nanosecond
+)
 
 // lockerTTLHalf is exactly half of the default 10s test TTL, used when
 // computing the renewal trigger point (ttl * 0.5 = 5s) without introducing

--- a/runtime/distlock/manager.go
+++ b/runtime/distlock/manager.go
@@ -41,11 +41,13 @@ func (h renewHeap) Swap(i, j int) {
 	h[i].index = i
 	h[j].index = j
 }
+
 func (h *renewHeap) Push(x any) {
 	item := x.(*heapItem)
 	item.index = len(*h)
 	*h = append(*h, item)
 }
+
 func (h *renewHeap) Pop() any {
 	old := *h
 	n := len(old)

--- a/runtime/eventrouter/add_contract_handler_test.go
+++ b/runtime/eventrouter/add_contract_handler_test.go
@@ -34,11 +34,13 @@ func (s *contractSpySpan) SetStatus(code wrapper.StatusCode, _ string) {
 	defer s.mu.Unlock()
 	s.status = code
 }
+
 func (s *contractSpySpan) End() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ended = true
 }
+
 func (s *contractSpySpan) attrMap() map[string]any {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/runtime/eventrouter/router_close_test.go
+++ b/runtime/eventrouter/router_close_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
-const routerCloseHandlerDuration = testtime.D200ms
-const routerCloseDrainLong = testtime.D5s
-const routerCloseElapsedMax = 600 * time.Millisecond
-const routerCloseDeadlineExtraLong = 6 * time.Second
+const (
+	routerCloseHandlerDuration   = testtime.D200ms
+	routerCloseDrainLong         = testtime.D5s
+	routerCloseElapsedMax        = 600 * time.Millisecond
+	routerCloseDeadlineExtraLong = 6 * time.Second
+)
 
 // ---------------------------------------------------------------------------
 // Three-phase Close tests (Phase 2: drain barrier)
@@ -75,9 +77,11 @@ func newCancelTimeRecorder(inner outbox.Subscriber) *cancelTimeRecorder {
 func (r *cancelTimeRecorder) Setup(ctx context.Context, sub outbox.Subscription) error {
 	return r.inner.Setup(ctx, sub)
 }
+
 func (r *cancelTimeRecorder) Ready(sub outbox.Subscription) <-chan struct{} {
 	return r.inner.Ready(sub)
 }
+
 func (r *cancelTimeRecorder) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.SubscriberHandler) error {
 	// Signal that we are inside Subscribe.
 	select {
@@ -129,15 +133,19 @@ func newCompositeStopIntakeSubscriber() *compositeStopIntakeSubscriber {
 func (c *compositeStopIntakeSubscriber) Setup(ctx context.Context, sub outbox.Subscription) error {
 	return c.cancelRec.Setup(ctx, sub)
 }
+
 func (c *compositeStopIntakeSubscriber) Ready(sub outbox.Subscription) <-chan struct{} {
 	return c.cancelRec.Ready(sub)
 }
+
 func (c *compositeStopIntakeSubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, handler outbox.SubscriberHandler) error {
 	return c.cancelRec.Subscribe(ctx, sub, handler)
 }
+
 func (c *compositeStopIntakeSubscriber) Close(ctx context.Context) error {
 	return c.cancelRec.Close(ctx)
 }
+
 func (c *compositeStopIntakeSubscriber) StopIntake(ctx context.Context) error {
 	return c.stopRecorder.StopIntake(ctx)
 }

--- a/runtime/eventrouter/router_test.go
+++ b/runtime/eventrouter/router_test.go
@@ -43,6 +43,7 @@ func (s *blockingSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *blockingSubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, _ outbox.SubscriberHandler) error {
 	s.mu.Lock()
 	s.topics = append(s.topics, sub.Topic)
@@ -72,6 +73,7 @@ func (s *failingSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *failingSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	return s.err
 }
@@ -90,6 +92,7 @@ func (s *delayedFailSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *delayedFailSubscriber) Subscribe(ctx context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	select {
 	case <-time.After(s.delay):
@@ -487,6 +490,7 @@ func (s *stuckSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *stuckSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	<-s.block // ignores ctx -- simulates unresponsive subscriber
 	return nil
@@ -502,6 +506,7 @@ func (s *panickingSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *panickingSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	panic("boom")
 }
@@ -691,6 +696,7 @@ func (s *recordingGroupSubscriber) Ready(_ outbox.Subscription) <-chan struct{} 
 	close(ch)
 	return ch
 }
+
 func (s *recordingGroupSubscriber) Subscribe(ctx context.Context, sub outbox.Subscription, _ outbox.SubscriberHandler) error {
 	s.mu.Lock()
 	s.calls = append(s.calls, groupSubscribeCall{
@@ -864,6 +870,7 @@ func (s *setupFailSubscriber) Ready(_ outbox.Subscription) <-chan struct{} {
 	close(ch)
 	return ch
 }
+
 func (s *setupFailSubscriber) Subscribe(_ context.Context, _ outbox.Subscription, _ outbox.SubscriberHandler) error {
 	s.subscribeCnt.Add(1)
 	return nil

--- a/runtime/http/middleware/csrf_test.go
+++ b/runtime/http/middleware/csrf_test.go
@@ -116,12 +116,21 @@ func TestCSRF_SecFetchSite(t *testing.T) {
 		{"bogus value rejects", "unknown-value", true, nil, "", 403},
 		{"same-site rejects when not allowed", "same-site", false, nil, "", 403},
 		// P0 fix: same-site + AllowSameSite=true falls through to Origin check.
-		{"same-site with trusted origin allowed", "same-site", true,
-			[]string{"https://example.com"}, "https://example.com", 200},
-		{"same-site with untrusted origin rejected", "same-site", true,
-			[]string{"https://example.com"}, "https://evil.example.com", 403},
-		{"same-site without origin signal rejected (fail-closed)", "same-site", true,
-			[]string{"https://example.com"}, "", 403},
+		{
+			"same-site with trusted origin allowed", "same-site", true,
+			[]string{"https://example.com"},
+			"https://example.com", 200,
+		},
+		{
+			"same-site with untrusted origin rejected", "same-site", true,
+			[]string{"https://example.com"},
+			"https://evil.example.com", 403,
+		},
+		{
+			"same-site without origin signal rejected (fail-closed)", "same-site", true,
+			[]string{"https://example.com"},
+			"", 403,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -108,9 +108,11 @@ func (r *Router) patternRecorderMiddleware(next http.Handler) http.Handler {
 }
 
 // Compile-time checks.
-var _ kcell.RouteMux = (*Router)(nil)
-var _ kcell.AuthRouteDeclarer = (*Router)(nil)
-var _ kcell.HTTPContractDeclarer = (*Router)(nil)
+var (
+	_ kcell.RouteMux             = (*Router)(nil)
+	_ kcell.AuthRouteDeclarer    = (*Router)(nil)
+	_ kcell.HTTPContractDeclarer = (*Router)(nil)
+)
 
 // Option configures a Router.
 type Option func(*Router)
@@ -1529,9 +1531,11 @@ type nativeMuxAdapter struct {
 // Compile-time checks: nativeMuxAdapter forwards AuthRouteMeta + declares its
 // mount prefix so auth.Mount can derive ServeMux-relative registration paths
 // from fully-qualified Contract.Path literals.
-var _ kcell.AuthRouteDeclarer = (*nativeMuxAdapter)(nil)
-var _ kcell.Prefixer = (*nativeMuxAdapter)(nil)
-var _ kcell.HTTPContractDeclarer = (*nativeMuxAdapter)(nil)
+var (
+	_ kcell.AuthRouteDeclarer    = (*nativeMuxAdapter)(nil)
+	_ kcell.Prefixer             = (*nativeMuxAdapter)(nil)
+	_ kcell.HTTPContractDeclarer = (*nativeMuxAdapter)(nil)
+)
 
 // Prefix returns the sub-route mount prefix this adapter inherited from its
 // parent Route. An empty prefix means the adapter sits directly under the

--- a/runtime/outbox/metrics_safe_test.go
+++ b/runtime/outbox/metrics_safe_test.go
@@ -34,6 +34,7 @@ func (m *mockCollector) RecordBatchSize(size int) { m.batchSizes = append(m.batc
 func (m *mockCollector) RecordReclaim(count int64) {
 	m.reclaimCounts = append(m.reclaimCounts, count)
 }
+
 func (m *mockCollector) RecordCleanup(p, d int64) {
 	m.cleanupCalls = append(m.cleanupCalls, mockCleanupEntry{p, d})
 }

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -19,9 +19,11 @@ import (
 )
 
 // Compile-time interface checks.
-var _ kout.Relay = (*Relay)(nil)
-var _ worker.Worker = (*Relay)(nil)
-var _ kernellifecycle.ManagedResource = (*Relay)(nil)
+var (
+	_ kout.Relay                      = (*Relay)(nil)
+	_ worker.Worker                   = (*Relay)(nil)
+	_ kernellifecycle.ManagedResource = (*Relay)(nil)
+)
 
 // ---------------------------------------------------------------------------
 // Relay lifecycle state machine

--- a/runtime/shutdown/shutdown_interrupt_windows_test.go
+++ b/runtime/shutdown/shutdown_interrupt_windows_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 // TestSignalsToWatch_Windows asserts the Windows signal set is exactly

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -795,6 +795,7 @@ func (s *stuckConn) Ping(_ context.Context) error {
 	}
 	return nil
 }
+
 func (s *stuckConn) Read(_ context.Context) ([]byte, error) {
 	<-s.closeCh
 	return nil, errors.New("closed")
@@ -1001,5 +1002,7 @@ func TestHub_IsRunning_Contract(t *testing.T) {
 }
 
 // Compile-time interface checks.
-var _ Conn = (*fakeConn)(nil)
-var _ Conn = (*stuckConn)(nil)
+var (
+	_ Conn = (*fakeConn)(nil)
+	_ Conn = (*stuckConn)(nil)
+)

--- a/tests/integration/internal_rpc_caller_cell_test.go
+++ b/tests/integration/internal_rpc_caller_cell_test.go
@@ -30,6 +30,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	accesscore "github.com/ghbvf/gocell/cells/accesscore"
 	auditcore "github.com/ghbvf/gocell/cells/auditcore"
 	configcore "github.com/ghbvf/gocell/cells/configcore"
@@ -44,8 +47,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // callerCellHTTPClient is a shared HTTP client for caller-cell integration tests.

--- a/tests/integration/outbox_failure_paths_test.go
+++ b/tests/integration/outbox_failure_paths_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -8,6 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
+	"github.com/testcontainers/testcontainers-go/wait"
+
 	"github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/adapters/rabbitmq"
 	"github.com/ghbvf/gocell/adapters/redis"
@@ -18,14 +27,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/google/uuid"
-	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
-	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 const (

--- a/tests/integration/postgres_helpers_test.go
+++ b/tests/integration/postgres_helpers_test.go
@@ -6,8 +6,9 @@ import (
 	"io/fs"
 	"testing"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 )
 
 func testPostgresMigrationsFS(t testing.TB) fs.FS {

--- a/tests/integration/shutdown_e2e_test.go
+++ b/tests/integration/shutdown_e2e_test.go
@@ -31,15 +31,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
+
 	"github.com/ghbvf/gocell/adapters/rabbitmq"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/tests/testutil"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tcrabbitmq "github.com/testcontainers/testcontainers-go/modules/rabbitmq"
 )
 
 const (

--- a/tools/archtest/error_first_test.go
+++ b/tools/archtest/error_first_test.go
@@ -71,8 +71,10 @@ import (
 	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
 )
 
-const ruleErrorFirstAPI01 = "ERROR-FIRST-API-01"
-const ruleErrorFirstTypedNil01 = "ERROR-FIRST-TYPED-NIL-01"
+const (
+	ruleErrorFirstAPI01      = "ERROR-FIRST-API-01"
+	ruleErrorFirstTypedNil01 = "ERROR-FIRST-TYPED-NIL-01"
+)
 
 // errorFirstEnforcedFiles are the relative paths (from module root) of files
 // whose declarations must satisfy ERROR-FIRST-API-01. Slash-separated for

--- a/tools/archtest/role_admin_literal_test.go
+++ b/tools/archtest/role_admin_literal_test.go
@@ -33,8 +33,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const ruleRoleAdminLiteral01 = "ROLE-ADMIN-LITERAL-01"
-const ruleRoleAdminLiteral02 = "ROLE-ADMIN-LITERAL-02"
+const (
+	ruleRoleAdminLiteral01 = "ROLE-ADMIN-LITERAL-01"
+	ruleRoleAdminLiteral02 = "ROLE-ADMIN-LITERAL-02"
+)
 
 // roleAdminAllowlist contains the files that are explicitly permitted to declare
 // a const whose name contains "Admin"/"admin" with the value "admin".

--- a/tools/codegen/markergen/merge_test.go
+++ b/tools/codegen/markergen/merge_test.go
@@ -544,7 +544,7 @@ func copyFile(t *testing.T, src, dst string) {
 	if err != nil {
 		t.Fatalf("copyFile: read %s: %v", src, err)
 	}
-	if err := os.WriteFile(dst, data, 0600); err != nil { //nolint:gosec // test helper writes to t.TempDir()
+	if err := os.WriteFile(dst, data, 0o600); err != nil { //nolint:gosec // test helper writes to t.TempDir()
 		t.Fatalf("copyFile: write %s: %v", dst, err)
 	}
 }

--- a/tools/generatedcatalog/catalog_test.go
+++ b/tools/generatedcatalog/catalog_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	kerneldepgraph "github.com/ghbvf/gocell/kernel/depgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	kerneldepgraph "github.com/ghbvf/gocell/kernel/depgraph"
 )
 
 func TestEmitFileDeterministicGo(t *testing.T) {

--- a/tools/generatedverify/generatedverify_test.go
+++ b/tools/generatedverify/generatedverify_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
 const fixtureModule = "example.com/generatedfixture"


### PR DESCRIPTION
## Summary

- `.golangci.yml` `formatters.enable += gofumpt`（v2 内置 formatter，无需新依赖）
- `golangci-lint fmt` 一次性全仓 reformat 98 文件：
  - 合并连续 `var _ X = (*T)(nil)` / `type Foo func(...)` 为分组块
  - 跨行 `lhs =\n\trhs` 单语句收为一行
- 4 处合并后超 `lll` 140 字符的 struct literal 改用多行字面量（`kernel/assembly/generator_fingerprint_test.go`）
- CI 端 `golangci-lint run` (v2.11.4) 自动校验 formatter，无需修改 workflow

无逻辑改动，纯格式化。完成 Track G G8 残余。

Refs: `docs/plans/202605011500-029-master-roadmap.md` G8（`PR-V11-CI-LINT-BATCH-4`）

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`（159 packages 全部 ok）
- [x] `golangci-lint run ./...`（0 issues）
- [x] roadmap G8 行回灌为 ✅
- [ ] CI 全绿