### PR TITLE
fix(assembly): drain hook dispatcher observer sinks

### DIFF
--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -96,10 +96,15 @@ type Config struct {
 	// Zero uses DefaultHookObserverSinkTimeout (5s).
 	HookObserverSinkTimeout time.Duration
 
-	// HookObserverDrainTimeout bounds Stop()'s wait for the dispatcher to
-	// drain remaining events after the channel is closed. Zero uses
-	// DefaultHookObserverDrainTimeout (5s). After drain completion or
-	// timeout, any further emit() calls are counted as queue_full.
+	// HookObserverDrainTimeout bounds Stop()'s shared hook-dispatcher
+	// shutdown budget after event intake is closed. The same budget covers
+	// both queue drain (worker processing already-emitted events) and sink
+	// drain (observer goroutines that exceeded HookObserverSinkTimeout but
+	// later exit). Zero uses DefaultHookObserverDrainTimeout (5s). Stop(ctx)
+	// also returns early when ctx is canceled; Shutdown uses
+	// context.Background() and is bounded only by this timeout. After drain
+	// completion, timeout, or cancellation, any further emit() calls are
+	// counted as queue_full.
 	HookObserverDrainTimeout time.Duration
 
 	// MetricsProvider receives the dispatcher's internal drop / queue-depth

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -254,10 +254,10 @@ func (a *CoreAssembly) Stop(ctx context.Context) error {
 
 	// Drain the async hook dispatcher after all cells have reported their
 	// AfterStop events so shutdown telemetry lands before the process
-	// exits. The drain is bounded by HookObserverDrainTimeout; a broken
-	// observer does not indefinitely block Stop().
+	// exits. The drain is bounded by ctx and HookObserverDrainTimeout; a
+	// broken observer does not indefinitely block Stop().
 	if a.dispatcher != nil {
-		a.dispatcher.stop(a.cfg.HookObserverDrainTimeout)
+		a.dispatcher.stop(ctx, a.cfg.HookObserverDrainTimeout)
 	}
 	return errors.Join(errs...)
 }
@@ -271,7 +271,7 @@ func (a *CoreAssembly) Stop(ctx context.Context) error {
 // as the final step of Stop().
 func (a *CoreAssembly) Shutdown() {
 	if a.dispatcher != nil {
-		a.dispatcher.stop(a.cfg.HookObserverDrainTimeout)
+		a.dispatcher.stop(context.Background(), a.cfg.HookObserverDrainTimeout)
 	}
 }
 

--- a/kernel/assembly/assembly.go
+++ b/kernel/assembly/assembly.go
@@ -577,16 +577,10 @@ func (a *CoreAssembly) emitHookEvent(e cell.HookEvent) {
 	// Defensive fallback — should not happen when New() is used.
 	defer func() {
 		if r := recover(); r != nil {
-			var recoveredErr error
-			if asErr, ok := r.(error); ok {
-				recoveredErr = asErr
-			} else {
-				recoveredErr = fmt.Errorf("observer panicked: %v", r)
-			}
 			slog.Error("lifecycle: hook observer panicked",
 				slog.String("cell", e.CellID),
 				slog.String("hook", string(e.Hook)),
-				slog.Any("error", recoveredErr))
+				slog.String("panic", sanitizeHookObserverPanicValue(r)))
 		}
 	}()
 	a.cfg.HookObserver.OnHookEvent(e)

--- a/kernel/assembly/hook_dispatcher.go
+++ b/kernel/assembly/hook_dispatcher.go
@@ -1,6 +1,7 @@
 package assembly
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -284,15 +285,18 @@ func (d *hookDispatcher) dispatchOne(e cell.HookEvent) {
 }
 
 // stop closes the channel, then waits for the worker to drain remaining
-// events or for drainTimeout to elapse — whichever comes first. After stop
-// returns, the dispatcher is no longer usable; emit() will see a full
-// (actually closed) channel via the default branch and count the event as
+// events, drainTimeout to elapse, or ctx cancellation — whichever comes first.
+// After stop returns, the dispatcher is no longer usable; emit() will see a
+// full (actually closed) channel via the default branch and count the event as
 // queue_full.
 //
 // stop is safe to call multiple times; only the first invocation closes the
 // channel.
-func (d *hookDispatcher) stop(drainTimeout time.Duration) {
+func (d *hookDispatcher) stop(ctx context.Context, drainTimeout time.Duration) {
 	d.stopOnce.Do(func() {
+		if ctx == nil {
+			ctx = context.Background()
+		}
 		close(d.ch)
 		if drainTimeout <= 0 {
 			drainTimeout = DefaultHookObserverDrainTimeout
@@ -306,6 +310,10 @@ func (d *hookDispatcher) stop(drainTimeout time.Duration) {
 			slog.Warn("assembly: hook dispatcher drain timed out; abandoning worker",
 				slog.Duration("timeout", drainTimeout))
 			return
+		case <-ctx.Done():
+			slog.Warn("assembly: hook dispatcher drain canceled; abandoning worker",
+				slog.Any("error", ctx.Err()))
+			return
 		}
 
 		select {
@@ -314,6 +322,9 @@ func (d *hookDispatcher) stop(drainTimeout time.Duration) {
 		case <-t.C():
 			slog.Warn("assembly: hook dispatcher sink drain timed out; abandoning observer sinks",
 				slog.Duration("timeout", drainTimeout))
+		case <-ctx.Done():
+			slog.Warn("assembly: hook dispatcher sink drain canceled; abandoning observer sinks",
+				slog.Any("error", ctx.Err()))
 		}
 	})
 }

--- a/kernel/assembly/hook_dispatcher.go
+++ b/kernel/assembly/hook_dispatcher.go
@@ -193,9 +193,11 @@ func (d *hookDispatcher) emit(e cell.HookEvent) {
 func (d *hookDispatcher) flush(timeout time.Duration) (ok bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			// Same recovery as emit: sending on closed channel means the
-			// dispatcher has already stopped, which implicitly means the
-			// buffer was drained. Treat flush as successful.
+			// Same recovery as emit: sending on a closed channel means the
+			// dispatcher has already stopped accepting events. A post-stop
+			// flush is therefore a no-op success for callers that only need
+			// a stable "not accepting fences" state; it does not prove a
+			// timed-out stop drained observer sinks.
 			ok = true
 		}
 	}()

--- a/kernel/assembly/hook_dispatcher.go
+++ b/kernel/assembly/hook_dispatcher.go
@@ -1,13 +1,16 @@
 package assembly
 
 import (
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
 // Default queue / timeout settings for hookDispatcher. Tuned for GoCell's
@@ -19,6 +22,8 @@ const (
 	DefaultHookObserverSinkTimeout  = 5 * time.Second
 	DefaultHookObserverDrainTimeout = 5 * time.Second
 )
+
+const maxHookObserverPanicLogBytes = 256
 
 // Drop reason label values emitted on hook_observer_dropped_total (bare name;
 // the Provider's Namespace field adds the "gocell_" prefix to produce the
@@ -41,10 +46,10 @@ const (
 //     reported via `hook_observer_dropped_total{reason="queue_full"}`.
 //   - **Per-sink timeout** via goroutine+channel race (mirroring
 //     go.uber.org/fx app.go withTimeout); a slow sink is abandoned to its
-//     own goroutine and counted `reason="sink_timeout"`. A broken observer
-//     that blocks forever leaks one goroutine per emission; that is the
-//     observer's bug, not ours, and is materially safer than blocking the
-//     assembly.
+//     own tracked goroutine and counted `reason="sink_timeout"`. Stop()
+//     waits for timed-out sinks within the existing drain budget so normal
+//     shutdowns do not leave observer goroutines behind, while permanently
+//     stuck observers still cannot block assembly shutdown forever.
 //   - **Eager lifecycle**: `newHookDispatcher` starts the worker
 //     immediately; `stop(timeout)` closes the channel, waits for drain up
 //     to timeout, then returns. `sync.Once` protects idempotent stop.
@@ -69,7 +74,12 @@ type hookDispatcher struct {
 	dropped     metrics.CounterVec // labeled by reason
 	clock       clock.Clock
 	wg          sync.WaitGroup
+	sinkWg      sync.WaitGroup
+	sinkMu      sync.Mutex
+	sinkActive  int
+	sinkIdle    chan struct{}
 	stopOnce    sync.Once
+	queueWarn   sync.Once
 	done        chan struct{} // closed when the worker loop exits
 }
 
@@ -134,6 +144,7 @@ func newHookDispatcher(cfg dispatcherConfig) *hookDispatcher {
 		sinkTimeout: cfg.SinkTimeout,
 		dropped:     dropped,
 		clock:       cfg.Clock,
+		sinkIdle:    closedChannel(),
 		done:        make(chan struct{}),
 	}
 	d.wg.Add(1)
@@ -158,14 +169,14 @@ func (d *hookDispatcher) emit(e cell.HookEvent) {
 			// Send on closed channel after stop(). Count as queue_full
 			// because from the emitter's perspective the queue is
 			// unavailable.
-			d.dropped.With(metrics.Labels{"reason": DropReasonQueueFull}).Inc()
+			d.dropQueueFull(e)
 		}
 	}()
 	evt := e
 	select {
 	case d.ch <- hookItem{evt: &evt}:
 	default:
-		d.dropped.With(metrics.Labels{"reason": DropReasonQueueFull}).Inc()
+		d.dropQueueFull(e)
 	}
 }
 
@@ -238,14 +249,16 @@ func (d *hookDispatcher) run() {
 // advances to the next event so a stuck observer cannot halt delivery.
 func (d *hookDispatcher) dispatchOne(e cell.HookEvent) {
 	result := make(chan struct{}, 1)
+	d.beginSink()
 	go func() {
 		defer func() {
+			defer d.finishSink()
 			if r := recover(); r != nil {
 				d.dropped.With(metrics.Labels{"reason": DropReasonObserverPanic}).Inc()
 				slog.Error("lifecycle: hook observer panicked",
 					slog.String("cell", e.CellID),
 					slog.String("hook", string(e.Hook)),
-					slog.Any("panic", r))
+					slog.String("panic", sanitizeHookObserverPanicValue(r)))
 			}
 			select {
 			case result <- struct{}{}:
@@ -285,14 +298,82 @@ func (d *hookDispatcher) stop(drainTimeout time.Duration) {
 			drainTimeout = DefaultHookObserverDrainTimeout
 		}
 		t := d.clock.NewTimerAt(d.clock.Now().Add(drainTimeout))
+		defer t.Stop()
 		select {
 		case <-d.done:
-			// Drained cleanly.
-			t.Stop()
+			// Worker drained cleanly; no future sinkWg.Add calls can occur.
 		case <-t.C():
-			t.Stop()
 			slog.Warn("assembly: hook dispatcher drain timed out; abandoning worker",
+				slog.Duration("timeout", drainTimeout))
+			return
+		}
+
+		select {
+		case <-d.currentSinkIdle():
+			d.sinkWg.Wait()
+		case <-t.C():
+			slog.Warn("assembly: hook dispatcher sink drain timed out; abandoning observer sinks",
 				slog.Duration("timeout", drainTimeout))
 		}
 	})
+}
+
+func (d *hookDispatcher) dropQueueFull(e cell.HookEvent) {
+	d.dropped.With(metrics.Labels{"reason": DropReasonQueueFull}).Inc()
+	d.queueWarn.Do(func() {
+		slog.Warn("assembly: hook dispatcher queue full; dropping hook event",
+			slog.String("reason", DropReasonQueueFull),
+			slog.String("cell", e.CellID),
+			slog.String("hook", string(e.Hook)))
+	})
+}
+
+func (d *hookDispatcher) beginSink() {
+	d.sinkWg.Add(1)
+	d.sinkMu.Lock()
+	if d.sinkActive == 0 {
+		d.sinkIdle = make(chan struct{})
+	}
+	d.sinkActive++
+	d.sinkMu.Unlock()
+}
+
+func (d *hookDispatcher) finishSink() {
+	d.sinkMu.Lock()
+	d.sinkActive--
+	if d.sinkActive == 0 {
+		close(d.sinkIdle)
+	}
+	d.sinkMu.Unlock()
+	d.sinkWg.Done()
+}
+
+func (d *hookDispatcher) currentSinkIdle() <-chan struct{} {
+	d.sinkMu.Lock()
+	defer d.sinkMu.Unlock()
+	return d.sinkIdle
+}
+
+func closedChannel() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func sanitizeHookObserverPanicValue(r any) string {
+	return truncateUTF8Bytes(redaction.RedactString(fmt.Sprintf("%v", r)), maxHookObserverPanicLogBytes)
+}
+
+func truncateUTF8Bytes(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	truncated := s[:maxBytes]
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
 }

--- a/kernel/assembly/hook_dispatcher_test.go
+++ b/kernel/assembly/hook_dispatcher_test.go
@@ -1,7 +1,11 @@
 package assembly
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,7 +17,9 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/redaction"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
@@ -117,6 +123,31 @@ func (b *blockingObserver) release() {
 	b.releaseOnce.Do(func() { close(b.gate) })
 }
 
+func captureDefaultSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	oldDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(oldDefault) })
+	return &buf
+}
+
+func requireLogRecord(t *testing.T, buf *bytes.Buffer, msg string) map[string]any {
+	t.Helper()
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		require.NoError(t, json.Unmarshal(line, &rec), "bad log line %q", line)
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	t.Fatalf("log record %q not found in logs:\n%s", msg, buf.String())
+	return nil
+}
+
 func TestHookDispatcher_SlowSinkDoesNotBlockEmit(t *testing.T) {
 	// A sink that hangs for 10s must not delay emit() more than a few ms.
 	// The dispatcher must return immediately; only the observer goroutine
@@ -172,6 +203,35 @@ func TestHookDispatcher_OverflowDropsAndCounts(t *testing.T) {
 		"overflow must surface as queue_full drops")
 }
 
+func TestHookDispatcher_QueueFullDropLogsWarnFallback(t *testing.T) {
+	buf := captureDefaultSlog(t)
+	bo := newBlockingObserver()
+	cv := newSpyCounterVec()
+	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 2, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+		Clock: clock.Real(),
+	})
+	t.Cleanup(func() {
+		bo.release()
+		d.stop(testtime.D2s)
+	})
+
+	d.emit(cell.HookEvent{CellID: "prime", Hook: cell.HookBeforeStart})
+	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "primer event should reach observer")
+
+	for range 100 {
+		d.emit(cell.HookEvent{CellID: "overflow", Hook: cell.HookBeforeStart})
+	}
+	require.GreaterOrEqual(t, cv.count(DropReasonQueueFull), 1,
+		"overflow must surface as queue_full drops")
+
+	rec := requireLogRecord(t, buf, "assembly: hook dispatcher queue full; dropping hook event")
+	assert.Equal(t, "WARN", rec["level"])
+	assert.Equal(t, DropReasonQueueFull, rec["reason"])
+	assert.Equal(t, "overflow", rec["cell"])
+	assert.Equal(t, string(cell.HookBeforeStart), rec["hook"])
+}
+
 func TestHookDispatcher_PerSinkTimeoutCountsAndContinues(t *testing.T) {
 	bo := newBlockingObserver()
 	cv := newSpyCounterVec()
@@ -194,6 +254,12 @@ func TestHookDispatcher_PerSinkTimeoutCountsAndContinues(t *testing.T) {
 type panicObserver struct{}
 
 func (panicObserver) OnHookEvent(cell.HookEvent) { panic("sink crashed") }
+
+type panicValueObserver struct {
+	value any
+}
+
+func (p panicValueObserver) OnHookEvent(cell.HookEvent) { panic(p.value) }
 
 func TestHookDispatcher_PanicIsCountedAndIsolated(t *testing.T) {
 	cv := newSpyCounterVec()
@@ -219,6 +285,36 @@ func TestHookDispatcher_PanicIsCountedAndIsolated(t *testing.T) {
 	require.True(t, d.flush(testtime.D500ms))
 	assert.Equal(t, 2, cv.count(DropReasonObserverPanic),
 		"subsequent events continue to be dispatched (and continue to panic)")
+}
+
+func TestHookDispatcher_ObserverPanicLogValueIsRedactedAndTruncated(t *testing.T) {
+	buf := captureDefaultSlog(t)
+	cv := newSpyCounterVec()
+	secret := "super-secret-token-value"
+	tail := "panic-tail-must-not-appear"
+	panicValue := "observer panic token=" + secret + " " + strings.Repeat("x", 300) + tail
+	d := newHookDispatcher(dispatcherConfig{
+		Observer:    panicValueObserver{value: panicValue},
+		QueueSize:   8,
+		SinkTimeout: testtime.D1s,
+		Provider:    &spyProvider{cv: cv},
+
+		Clock: clock.Real(),
+	})
+	t.Cleanup(func() { d.stop(testtime.D500ms) })
+
+	d.emit(cell.HookEvent{CellID: "panic-redaction", Hook: cell.HookAfterStop})
+	require.True(t, d.flush(testtime.D500ms), "flush should succeed after sink panic")
+	require.Equal(t, 1, cv.count(DropReasonObserverPanic),
+		"observer panic should still be counted")
+
+	rec := requireLogRecord(t, buf, "lifecycle: hook observer panicked")
+	got, ok := rec["panic"].(string)
+	require.Truef(t, ok, "panic log field must be a string, got %T", rec["panic"])
+	assert.LessOrEqual(t, len(got), maxHookObserverPanicLogBytes)
+	assert.Contains(t, got, redaction.Mask)
+	assert.NotContains(t, got, secret)
+	assert.NotContains(t, got, tail)
 }
 
 // collectObserver records events for drain-on-stop verification.
@@ -254,6 +350,91 @@ func TestHookDispatcher_StopDrainsPending(t *testing.T) {
 	assert.Equal(t, 10, obs.len(), "stop(drainTimeout) must drain all in-flight events")
 }
 
+func TestHookDispatcher_StopWaitsForTimedOutSinkBeforeReturning(t *testing.T) {
+	clk := clockmock.New(time.Time{})
+	bo := newBlockingObserver()
+	cv := newSpyCounterVec()
+	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+		Clock: clk,
+	})
+	t.Cleanup(func() {
+		bo.release()
+		d.stop(testtime.D10s)
+	})
+
+	d.emit(cell.HookEvent{CellID: "slow-drain", Hook: cell.HookBeforeStart})
+	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "event should reach observer")
+	clk.Advance(testtime.D1s)
+	require.Eventually(t, func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "sink timeout must be counted")
+
+	stopDone := make(chan struct{})
+	go func() {
+		d.stop(testtime.D10s)
+		close(stopDone)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-d.done:
+			return true
+		default:
+			return false
+		}
+	}, testtime.EventuallyDefault, testtime.FastPoll, "worker should drain before sink wait assertion")
+
+	select {
+	case <-stopDone:
+		t.Fatal("stop returned before the timed-out observer sink exited")
+	case <-time.After(testtime.ShortSleep):
+	}
+
+	bo.release()
+	select {
+	case <-stopDone:
+	case <-time.After(testtime.SelectShutdown):
+		t.Fatal("stop did not return after observer sink exited")
+	}
+}
+
+func TestHookDispatcher_StopDoesNotHangForeverOnStuckSink(t *testing.T) {
+	clk := clockmock.New(time.Time{})
+	bo := newBlockingObserver()
+	cv := newSpyCounterVec()
+	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+		Clock: clk,
+	})
+	t.Cleanup(bo.release)
+
+	d.emit(cell.HookEvent{CellID: "stuck-drain", Hook: cell.HookBeforeStart})
+	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "event should reach observer")
+	clk.Advance(testtime.D1s)
+	require.Eventually(t, func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "sink timeout must be counted")
+
+	stopDone := make(chan struct{})
+	go func() {
+		d.stop(testtime.D2s)
+		close(stopDone)
+	}()
+	require.Eventually(t, func() bool { return clk.PendingTimers() >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "stop should wait on the remaining drain budget")
+
+	select {
+	case <-stopDone:
+		t.Fatal("stop returned before the drain budget elapsed")
+	default:
+	}
+	clk.Advance(testtime.D2s)
+	select {
+	case <-stopDone:
+	case <-time.After(testtime.SelectShutdown):
+		t.Fatal("stop did not return after drain budget elapsed")
+	}
+	bo.release()
+}
+
 func TestHookDispatcher_StopIsIdempotent(t *testing.T) {
 	d := newHookDispatcher(dispatcherConfig{
 		Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
@@ -279,6 +460,7 @@ func TestHookDispatcher_FlushOnIdleReturnsTrue(t *testing.T) {
 // selected), and that panic must be converted into a queue_full drop so
 // a post-Stop caller never crashes the assembly.
 func TestHookDispatcher_EmitAfterStopCountsQueueFull(t *testing.T) {
+	buf := captureDefaultSlog(t)
 	cv := newSpyCounterVec()
 	d := newHookDispatcher(dispatcherConfig{
 		Observer: cell.NopHookObserver{}, QueueSize: 4,
@@ -293,6 +475,11 @@ func TestHookDispatcher_EmitAfterStopCountsQueueFull(t *testing.T) {
 
 	assert.GreaterOrEqual(t, cv.count(DropReasonQueueFull), 1,
 		"emit after stop must land in queue_full drop counter")
+	rec := requireLogRecord(t, buf, "assembly: hook dispatcher queue full; dropping hook event")
+	assert.Equal(t, "WARN", rec["level"])
+	assert.Equal(t, DropReasonQueueFull, rec["reason"])
+	assert.Equal(t, "after-stop", rec["cell"])
+	assert.Equal(t, string(cell.HookBeforeStart), rec["hook"])
 }
 
 // TestHookDispatcher_FlushAfterStopReturnsTrue locks in the

--- a/kernel/assembly/hook_dispatcher_test.go
+++ b/kernel/assembly/hook_dispatcher_test.go
@@ -159,7 +159,7 @@ func TestHookDispatcher_SlowSinkDoesNotBlockEmit(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		bo.release()
-		d.stop(testtime.D500ms)
+		d.stop(context.Background(), testtime.D500ms)
 	})
 
 	start := time.Now()
@@ -183,7 +183,7 @@ func TestHookDispatcher_OverflowDropsAndCounts(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		bo.release()
-		d.stop(testtime.D2s)
+		d.stop(context.Background(), testtime.D2s)
 	})
 
 	// Prime the pipeline: emit one event and wait until the worker has
@@ -212,7 +212,7 @@ func TestHookDispatcher_QueueFullDropLogsWarnFallback(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		bo.release()
-		d.stop(testtime.D2s)
+		d.stop(context.Background(), testtime.D2s)
 	})
 
 	d.emit(cell.HookEvent{CellID: "prime", Hook: cell.HookBeforeStart})
@@ -241,7 +241,7 @@ func TestHookDispatcher_PerSinkTimeoutCountsAndContinues(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		bo.release()
-		d.stop(testtime.D500ms)
+		d.stop(context.Background(), testtime.D500ms)
 	})
 
 	d.emit(cell.HookEvent{CellID: "slow-sink", Hook: cell.HookBeforeStart})
@@ -271,7 +271,7 @@ func TestHookDispatcher_PanicIsCountedAndIsolated(t *testing.T) {
 
 		Clock: clock.Real(),
 	})
-	t.Cleanup(func() { d.stop(testtime.D500ms) })
+	t.Cleanup(func() { d.stop(context.Background(), testtime.D500ms) })
 
 	d.emit(cell.HookEvent{CellID: "crash", Hook: cell.HookBeforeStart})
 	require.True(t, d.flush(testtime.D500ms), "flush should succeed even after sink panic")
@@ -301,7 +301,7 @@ func TestHookDispatcher_ObserverPanicLogValueIsRedactedAndTruncated(t *testing.T
 
 		Clock: clock.Real(),
 	})
-	t.Cleanup(func() { d.stop(testtime.D500ms) })
+	t.Cleanup(func() { d.stop(context.Background(), testtime.D500ms) })
 
 	d.emit(cell.HookEvent{CellID: "panic-redaction", Hook: cell.HookAfterStop})
 	require.True(t, d.flush(testtime.D500ms), "flush should succeed after sink panic")
@@ -345,7 +345,7 @@ func TestHookDispatcher_StopDrainsPending(t *testing.T) {
 	for i := range 10 {
 		d.emit(cell.HookEvent{CellID: "drain", Hook: cell.HookBeforeStart, Duration: time.Duration(i)})
 	}
-	d.stop(testtime.D2s)
+	d.stop(context.Background(), testtime.D2s)
 
 	assert.Equal(t, 10, obs.len(), "stop(drainTimeout) must drain all in-flight events")
 }
@@ -359,7 +359,7 @@ func TestHookDispatcher_StopWaitsForTimedOutSinkBeforeReturning(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		bo.release()
-		d.stop(testtime.D10s)
+		d.stop(context.Background(), testtime.D10s)
 	})
 
 	d.emit(cell.HookEvent{CellID: "slow-drain", Hook: cell.HookBeforeStart})
@@ -371,7 +371,7 @@ func TestHookDispatcher_StopWaitsForTimedOutSinkBeforeReturning(t *testing.T) {
 
 	stopDone := make(chan struct{})
 	go func() {
-		d.stop(testtime.D10s)
+		d.stop(context.Background(), testtime.D10s)
 		close(stopDone)
 	}()
 	require.Eventually(t, func() bool {
@@ -415,7 +415,7 @@ func TestHookDispatcher_StopDoesNotHangForeverOnStuckSink(t *testing.T) {
 
 	stopDone := make(chan struct{})
 	go func() {
-		d.stop(testtime.D2s)
+		d.stop(context.Background(), testtime.D2s)
 		close(stopDone)
 	}()
 	require.Eventually(t, func() bool { return clk.PendingTimers() >= 1 },
@@ -435,13 +435,67 @@ func TestHookDispatcher_StopDoesNotHangForeverOnStuckSink(t *testing.T) {
 	bo.release()
 }
 
+func TestHookDispatcher_StopReturnsWhenContextCanceledDuringSinkDrain(t *testing.T) {
+	clk := clockmock.New(time.Time{})
+	bo := newBlockingObserver()
+	cv := newSpyCounterVec()
+	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+		Clock: clk,
+	})
+	t.Cleanup(bo.release)
+
+	d.emit(cell.HookEvent{CellID: "ctx-drain", Hook: cell.HookBeforeStart})
+	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "event should reach observer")
+	clk.Advance(testtime.D1s)
+	require.Eventually(t, func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "sink timeout must be counted")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopDone := make(chan struct{})
+	go func() {
+		d.stop(ctx, testtime.D10s)
+		close(stopDone)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-d.done:
+			return true
+		default:
+			return false
+		}
+	}, testtime.EventuallyDefault, testtime.FastPoll, "worker should drain before sink wait assertion")
+
+	select {
+	case <-stopDone:
+		t.Fatal("stop returned before sink completion or context cancellation")
+	default:
+	}
+	cancel()
+	select {
+	case <-stopDone:
+	case <-time.After(testtime.SelectShutdown):
+		t.Fatal("stop did not return after context cancellation")
+	}
+
+	bo.release()
+	require.Eventually(t, func() bool {
+		select {
+		case <-d.currentSinkIdle():
+			return true
+		default:
+			return false
+		}
+	}, testtime.EventuallyDefault, testtime.FastPoll, "observer sink should exit after release")
+}
+
 func TestHookDispatcher_StopIsIdempotent(t *testing.T) {
 	d := newHookDispatcher(dispatcherConfig{
 		Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
-	d.stop(testtime.D200ms)
-	d.stop(testtime.D200ms) // second call must be a no-op, no panic
+	d.stop(context.Background(), testtime.D200ms)
+	d.stop(context.Background(), testtime.D200ms) // second call must be a no-op, no panic
 }
 
 func TestHookDispatcher_FlushOnIdleReturnsTrue(t *testing.T) {
@@ -449,7 +503,7 @@ func TestHookDispatcher_FlushOnIdleReturnsTrue(t *testing.T) {
 		Observer: cell.NopHookObserver{}, QueueSize: 8, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
-	t.Cleanup(func() { d.stop(testtime.D200ms) })
+	t.Cleanup(func() { d.stop(context.Background(), testtime.D200ms) })
 
 	require.True(t, d.flush(testtime.D500ms), "flush on idle dispatcher must succeed")
 }
@@ -469,7 +523,7 @@ func TestHookDispatcher_EmitAfterStopCountsQueueFull(t *testing.T) {
 		Clock: clock.Real(),
 	})
 
-	d.stop(testtime.D200ms)
+	d.stop(context.Background(), testtime.D200ms)
 	// At least one emit after stop must still not panic; drop is counted.
 	d.emit(cell.HookEvent{CellID: "after-stop", Hook: cell.HookBeforeStart})
 
@@ -493,7 +547,7 @@ func TestHookDispatcher_FlushAfterStopReturnsTrue(t *testing.T) {
 		Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
 	})
-	d.stop(testtime.D200ms)
+	d.stop(context.Background(), testtime.D200ms)
 
 	require.True(t, d.flush(testtime.D200ms),
 		"flush after stop must return true (channel drained, fence is trivially satisfied)")
@@ -511,7 +565,7 @@ func TestHookDispatcher_FlushTimeoutThenSuccess(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		bo.release()
-		d.stop(testtime.D500ms)
+		d.stop(context.Background(), testtime.D500ms)
 	})
 
 	d.emit(cell.HookEvent{CellID: "slow", Hook: cell.HookBeforeStart})
@@ -548,4 +602,45 @@ func TestCoreAssembly_StopDrainsDispatcher(t *testing.T) {
 	// No extra flush needed: Stop() must drain internally.
 	assert.GreaterOrEqual(t, obs.len(), 4,
 		"Stop must drain before returning (4 hook events minimum: BeforeStart, AfterStart, BeforeStop, AfterStop)")
+}
+
+func TestCoreAssembly_StopContextCancelsDispatcherDrain(t *testing.T) {
+	clk := clockmock.New(time.Time{})
+	obs := newBlockingObserver()
+	a := newTestAssembly(t, Config{
+		ID:                       "ctx-drain-test",
+		DurabilityMode:           cell.DurabilityDemo,
+		HookObserver:             obs,
+		HookObserverSinkTimeout:  testtime.D10s,
+		HookObserverDrainTimeout: testtime.D10s,
+		Clock:                    clk,
+	})
+	var calls []string
+	require.NoError(t, a.Register(newHookOrderCell("A", &calls, "")))
+	require.NoError(t, a.Start(context.Background()))
+	require.Eventually(t, func() bool { return obs.received.Load() >= 1 },
+		testtime.EventuallyDefault, testtime.FastPoll, "start hook event should reach observer")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- a.Stop(ctx)
+	}()
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(testtime.SelectShutdown):
+		t.Fatal("Stop(ctx) waited for HookObserverDrainTimeout despite canceled context")
+	}
+
+	obs.release()
+	require.Eventually(t, func() bool {
+		select {
+		case <-a.dispatcher.done:
+			return true
+		default:
+			return false
+		}
+	}, testtime.EventuallyDefault, testtime.FastPoll, "dispatcher worker should exit after observer release")
 }

--- a/kernel/assembly/hook_dispatcher_test.go
+++ b/kernel/assembly/hook_dispatcher_test.go
@@ -32,7 +32,8 @@ import (
 // ref: go.uber.org/goleak README@main — VerifyTestMain is the canonical
 // last-resort guard against goroutine leaks in Go.
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
+	goleak.VerifyTestMain(
+		m,
 		// stdlib http keep-alive loops that adapter tests spin up can linger
 		// briefly on fast shutdown; explicit allowlist keeps the main assembly
 		// coverage strict.
@@ -207,7 +208,8 @@ func TestHookDispatcher_QueueFullDropLogsWarnFallback(t *testing.T) {
 	buf := captureDefaultSlog(t)
 	bo := newBlockingObserver()
 	cv := newSpyCounterVec()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 2, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 2, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
 		Clock: clock.Real(),
 	})
 	t.Cleanup(func() {
@@ -354,7 +356,8 @@ func TestHookDispatcher_StopWaitsForTimedOutSinkBeforeReturning(t *testing.T) {
 	clk := clockmock.New(time.Time{})
 	bo := newBlockingObserver()
 	cv := newSpyCounterVec()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
 		Clock: clk,
 	})
 	t.Cleanup(func() {
@@ -401,7 +404,8 @@ func TestHookDispatcher_StopDoesNotHangForeverOnStuckSink(t *testing.T) {
 	clk := clockmock.New(time.Time{})
 	bo := newBlockingObserver()
 	cv := newSpyCounterVec()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
 		Clock: clk,
 	})
 	t.Cleanup(bo.release)
@@ -439,7 +443,8 @@ func TestHookDispatcher_StopReturnsWhenContextCanceledDuringSinkDrain(t *testing
 	clk := clockmock.New(time.Time{})
 	bo := newBlockingObserver()
 	cv := newSpyCounterVec()
-	d := newHookDispatcher(dispatcherConfig{Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
+	d := newHookDispatcher(dispatcherConfig{
+		Observer: bo, QueueSize: 8, SinkTimeout: testtime.D1s, Provider: &spyProvider{cv: cv},
 		Clock: clk,
 	})
 	t.Cleanup(bo.release)
@@ -536,13 +541,13 @@ func TestHookDispatcher_EmitAfterStopCountsQueueFull(t *testing.T) {
 	assert.Equal(t, string(cell.HookBeforeStart), rec["hook"])
 }
 
-// TestHookDispatcher_FlushAfterStopReturnsTrue locks in the
+// TestHookDispatcher_FlushAfterStopIsNoOpSuccess locks in the
 // "send-on-closed treated as flush success" branch of flush(). Intent:
-// once the dispatcher has been stopped, the channel is fully drained, so
-// any further fence is semantically satisfied (there is nothing to wait
-// for). Returning false here would make clean-shutdown callers block or
-// retry for no gain.
-func TestHookDispatcher_FlushAfterStopReturnsTrue(t *testing.T) {
+// once the dispatcher has stopped accepting events, any further fence is
+// a no-op for callers that only need a stable stopped state. This does
+// not assert that a timed-out stop drained observer sinks; sink drain is
+// covered by the dedicated stop tests above.
+func TestHookDispatcher_FlushAfterStopIsNoOpSuccess(t *testing.T) {
 	d := newHookDispatcher(dispatcherConfig{
 		Observer: cell.NopHookObserver{}, QueueSize: 4, SinkTimeout: testtime.D1s,
 		Clock: clock.Real(),
@@ -550,7 +555,7 @@ func TestHookDispatcher_FlushAfterStopReturnsTrue(t *testing.T) {
 	d.stop(context.Background(), testtime.D200ms)
 
 	require.True(t, d.flush(testtime.D200ms),
-		"flush after stop must return true (channel drained, fence is trivially satisfied)")
+		"flush after stop must return true (dispatcher stopped accepting fences)")
 }
 
 // TestHookDispatcher_FlushTimeoutThenSuccess exercises the subtle case


### PR DESCRIPTION
## Summary
- Track timed-out hook observer sink goroutines and wait for them during dispatcher shutdown within the existing drain budget.
- Bound dispatcher drain by both `Stop(ctx)` cancellation and `HookObserverDrainTimeout`.
- Sanitize observer panic log values with redaction and a UTF-8-safe 256-byte cap.
- Add a once-per-dispatcher `queue_full` `slog.Warn` fallback while preserving the existing reason-only drop metric.
- Clarify the public drain contract: the observer drain timeout is a shared queue-drain + sink-drain budget, and flush-after-stop is only a no-op stopped-state helper, not proof of full sink drain after timeout.

Refs: docs/plans/202605011500-029-master-roadmap.md N2 / PR-V1-030-G01-HOOK-DISPATCHER-LIFECYCLE

## Root Cause
`hookDispatcher.dispatchOne` abandoned timed-out observer goroutines without ownership tracking, so `stop()` only waited for the worker loop and could return while observer goroutines remained alive. The same path logged raw panic values and queue-full drops were metric-only, which made drops silent without a real metrics provider.

## Ref
- ref: uber-go/fx app.go / internal/lifecycle/lifecycle.go
- ref: kubernetes/client-go tools/record/event.go

## Review Follow-up
- Addressed Cx3: `CoreAssembly.Stop(ctx)` now passes ctx into dispatcher drain; cancellation can end drain before the full observer drain timeout.
- Addressed P2 review notes: exported `HookObserverDrainTimeout` docs now describe the two-stage shared budget, and `FlushAfterStop` wording no longer equates stopped intake with full sink drain.

## Test Plan
- [x] `go test ./kernel/assembly -run 'TestHookDispatcher_(QueueFullDropLogsWarnFallback|ObserverPanicLogValueIsRedactedAndTruncated|StopWaitsForTimedOutSinkBeforeReturning|StopDoesNotHangForeverOnStuckSink|StopReturnsWhenContextCanceledDuringSinkDrain|EmitAfterStopCountsQueueFull)|TestCoreAssembly_StopContextCancelsDispatcherDrain'`
- [x] `go test ./kernel/assembly`
- [x] `go test -race ./kernel/assembly`
- [x] `go test ./runtime/bootstrap -run 'TestBootstrap_DefaultAssembly_WiresMetricsProvider|TestAssembly_FailedStartDrainsDispatcher'`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] follow-up docs-only check: `go test ./kernel/assembly`, `go test -race ./kernel/assembly`, `golangci-lint run ./kernel/assembly/...`
