### PR TITLE
refactor(outbox): K B6 PR-V1-PG-OUTBOX-RELAY-HARDEN — payload cap + lost metric + reclaim cfg loop

### DIFF
--- a/adapters/postgres/outbox_mock_test.go
+++ b/adapters/postgres/outbox_mock_test.go
@@ -143,6 +143,7 @@ func (t *mockRelayTx) Rollback(_ context.Context) error { return nil }
 func (t *mockRelayTx) CopyFrom(_ context.Context, _ pgx.Identifier, _ []string, _ pgx.CopyFromSource) (int64, error) {
 	return 0, nil
 }
+
 func (t *mockRelayTx) SendBatch(_ context.Context, _ *pgx.Batch) pgx.BatchResults {
 	return nil
 }

--- a/adapters/postgres/outbox_store.go
+++ b/adapters/postgres/outbox_store.go
@@ -22,13 +22,6 @@ import (
 // or maliciously-crafted row at ~4 KB.
 const maxObservabilityJSONBytes = 4 * kout.MaxObservabilityTotalSize
 
-// reclaimBatchSize caps reclaimStaleQuery so a backlog of stale claiming rows
-// cannot create a multi-second UPDATE that holds locks blocking VACUUM and
-// streaming replication. The relay's reclaim loop wakes on its own schedule —
-// a single LIMITed batch per tick is sufficient; backlog drains over a few
-// ticks. Mirrors graphile/worker's get_job LIMIT 1 + repeat-on-tick model.
-const reclaimBatchSize = 1000
-
 // PGOutboxStore implements runtime/outbox.Store over PostgreSQL using pgx.
 //
 // Each method opens its own short transaction; methods do not compose into a
@@ -124,15 +117,15 @@ const markDeadQuery = `UPDATE outbox_entries SET status = $1, attempts = $2,
 // lease_id is cleared on the back-to-pending branch so the next ClaimPending
 // mints a fresh lease; the dead branch keeps the value as audit trail.
 //
-// LIMIT (reclaimBatchSize) caps a single sweep so a backlog of stale rows
-// cannot produce a multi-second UPDATE that blocks VACUUM/replication; the
-// relay's reclaim loop tick re-runs to drain residual.
+// LIMIT ($8 batchSize) caps a single sweep so a backlog of stale rows cannot
+// produce a multi-second UPDATE that blocks VACUUM/replication; the relay's
+// reclaim loop drains residual by re-invoking until count < batchSize.
 //
 // ref: graphile/worker resetLockedAt.ts — outer UPDATE re-asserts locked_by
 // ref: river_job.sql / pgxjob — CTE + SKIP LOCKED batched reclaim
 //
 // $1 claimTTL interval text, $2 maxAttempts, $3 statusDead, $4 statusPending,
-// $5 baseDelayMicros, $6 statusClaiming, $7 maxDelayMicros, $8 reclaimBatchSize.
+// $5 baseDelayMicros, $6 statusClaiming, $7 maxDelayMicros, $8 batchSize.
 const reclaimStaleQuery = `WITH picked AS (
 		SELECT id, lease_id, attempts FROM outbox_entries
 		WHERE status = $6 AND claimed_at < now() - $1::interval
@@ -262,13 +255,17 @@ func (s *PGOutboxStore) MarkDead(ctx context.Context, id, leaseID string, attemp
 	return ct.RowsAffected() == 1, nil
 }
 
-// ReclaimStale transitions up to reclaimBatchSize claiming rows whose
-// claimed_at is older than claimTTL back to pending (with attempts+1 and
-// next_retry_at = backoff) or to dead (when attempts+1 >= maxAttempts).
-// Returns count of rows recovered. The relay's reclaim loop re-runs on its
-// own tick to drain residual when the backlog exceeds reclaimBatchSize.
+// ReclaimStale transitions up to batchSize claiming rows whose claimed_at is
+// older than claimTTL back to pending (with attempts+1 and next_retry_at =
+// backoff) or to dead (when attempts+1 >= maxAttempts). Returns count of rows
+// recovered. The caller's reclaim loop re-runs to drain residual when the
+// backlog exceeds batchSize (`count < batchSize` signals "no more").
 func (s *PGOutboxStore) ReclaimStale(
-	ctx context.Context, claimTTL time.Duration, maxAttempts int, baseDelay, maxDelay time.Duration,
+	ctx context.Context,
+	claimTTL time.Duration,
+	maxAttempts int,
+	baseDelay, maxDelay time.Duration,
+	batchSize int,
 ) (int, error) {
 	// pgx serializes time.Duration as int64 nanoseconds which PostgreSQL cannot
 	// cast to interval (SQLSTATE 42846). Pass claimTTL as "N microseconds" text;
@@ -279,7 +276,7 @@ func (s *PGOutboxStore) ReclaimStale(
 		claimTTLInterval, maxAttempts,
 		statusDead, statusPending,
 		baseDelay.Microseconds(), statusClaiming,
-		maxDelay.Microseconds(), reclaimBatchSize)
+		maxDelay.Microseconds(), batchSize)
 	if err != nil {
 		return 0, errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "outbox store: ReclaimStale failed", err)
 	}

--- a/adapters/postgres/outbox_store_integration_test.go
+++ b/adapters/postgres/outbox_store_integration_test.go
@@ -20,6 +20,12 @@ import (
 	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
 )
 
+// defaultReclaimBatchTest is the batchSize this integration suite passes to
+// Store.ReclaimStale. Pinned to runtime/outbox.DefaultRelayConfig().ReclaimBatchSize
+// (1000) so the cap behavior the test asserts mirrors what the relay will
+// actually request in production.
+const defaultReclaimBatchTest = 1000
+
 // TestPGOutboxStore_ConformanceSuite verifies that PGOutboxStore satisfies the
 // full Store conformance suite defined in runtime/outbox/outboxtest.
 //
@@ -141,7 +147,7 @@ func (p *recordingPublisher) Topics() []string {
 // TestPGOutboxStore_ReclaimStale_RespectsBatchLimit verifies B2-A-06: a
 // backlog of stale claiming rows must not produce a single multi-second
 // UPDATE that holds locks blocking VACUUM and replication. ReclaimStale caps
-// at reclaimBatchSize per call; relay's tick loop drains residual.
+// at defaultReclaimBatchTest per call; relay's tick loop drains residual.
 func TestPGOutboxStore_ReclaimStale_RespectsBatchLimit(t *testing.T) {
 	pool, cleanup := setupPostgres(t)
 	t.Cleanup(cleanup)
@@ -151,7 +157,7 @@ func TestPGOutboxStore_ReclaimStale_RespectsBatchLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
-	const seedCount = reclaimBatchSize + 500 // 1500 stale claiming rows
+	const seedCount = defaultReclaimBatchTest + 500 // 1500 stale claiming rows
 
 	// Seed `seedCount` rows in claiming state with claimed_at far in the past.
 	// Batched INSERT keeps the test under a couple seconds even at 1500 rows.
@@ -170,20 +176,20 @@ func TestPGOutboxStore_ReclaimStale_RespectsBatchLimit(t *testing.T) {
 
 	store := NewOutboxStore(pool.DB(), clock.Real())
 
-	// First ReclaimStale must reclaim exactly reclaimBatchSize.
-	count, err := store.ReclaimStale(ctx, time.Minute, 99, time.Millisecond, time.Second)
+	// First ReclaimStale must reclaim exactly defaultReclaimBatchTest.
+	count, err := store.ReclaimStale(ctx, time.Minute, 99, time.Millisecond, time.Second, defaultReclaimBatchTest)
 	require.NoError(t, err)
-	assert.Equal(t, reclaimBatchSize, count,
-		"first reclaim must cap at reclaimBatchSize, not full backlog")
+	assert.Equal(t, defaultReclaimBatchTest, count,
+		"first reclaim must cap at defaultReclaimBatchTest, not full backlog")
 
 	// Second call drains the residual.
-	count2, err := store.ReclaimStale(ctx, time.Minute, 99, time.Millisecond, time.Second)
+	count2, err := store.ReclaimStale(ctx, time.Minute, 99, time.Millisecond, time.Second, defaultReclaimBatchTest)
 	require.NoError(t, err)
-	assert.Equal(t, seedCount-reclaimBatchSize, count2,
+	assert.Equal(t, seedCount-defaultReclaimBatchTest, count2,
 		"second reclaim drains residual")
 
 	// Third call is a no-op.
-	count3, err := store.ReclaimStale(ctx, time.Minute, 99, time.Millisecond, time.Second)
+	count3, err := store.ReclaimStale(ctx, time.Minute, 99, time.Millisecond, time.Second, defaultReclaimBatchTest)
 	require.NoError(t, err)
 	assert.Zero(t, count3, "third call has nothing to reclaim")
 }
@@ -226,7 +232,7 @@ func TestPGOutboxStore_Fencing_ReclaimedRowSurvivesStaleMark(t *testing.T) {
 
 	// Reclaim sweep: TTL=1s vs claimed_at 1h ago → stale → back to pending,
 	// lease cleared.
-	count, err := store.ReclaimStale(ctx, time.Second, 99, time.Millisecond, time.Second)
+	count, err := store.ReclaimStale(ctx, time.Second, 99, time.Millisecond, time.Second, defaultReclaimBatchTest)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 
@@ -352,7 +358,7 @@ func TestPGOutboxStore_Reclaim_DoesNotRegressTerminalRow(t *testing.T) {
 			// after a markRetry that cleared it). Pre-fix, the row would be
 			// regressed to pending. The query selectively updates only rows
 			// whose state remains consistent with the CTE snapshot.
-			count, err := store.ReclaimStale(ctx, time.Second, 99, time.Millisecond, time.Second)
+			count, err := store.ReclaimStale(ctx, time.Second, 99, time.Millisecond, time.Second, defaultReclaimBatchTest)
 			require.NoError(t, err)
 			assert.Zero(t, count,
 				"reclaim must not touch a row whose state changed between SELECT and UPDATE")
@@ -436,7 +442,7 @@ func TestPGOutboxStore_Reclaim_RaceWithMarkPublished(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 20; i++ {
-			_, _ = store.ReclaimStale(ctx, time.Second, 99, time.Millisecond, time.Second)
+			_, _ = store.ReclaimStale(ctx, time.Second, 99, time.Millisecond, time.Second, defaultReclaimBatchTest)
 		}
 	}()
 

--- a/adapters/postgres/outbox_store_test.go
+++ b/adapters/postgres/outbox_store_test.go
@@ -238,8 +238,10 @@ func TestPGOutboxStore_ReclaimStale_ReturnsCount(t *testing.T) {
 	}
 	store := NewOutboxStore(db, clock.Real())
 
+	const callerBatch = 1234
+
 	count, err := store.ReclaimStale(context.Background(),
-		testtime.D60s, 5, testtime.D5s, testtime.D5min)
+		testtime.D60s, 5, testtime.D5s, testtime.D5min, callerBatch)
 	require.NoError(t, err)
 	assert.Equal(t, 3, count)
 
@@ -259,12 +261,12 @@ func TestPGOutboxStore_ReclaimStale_ReturnsCount(t *testing.T) {
 		"outer UPDATE must re-assert lease_id matches the picked snapshot (write-time fencing)")
 
 	// args: $1=claimTTLInterval, $2=maxAttempts, $3=dead, $4=pending,
-	//       $5=baseDelayMicros, $6=claiming, $7=maxDelayMicros, $8=reclaimBatchSize
+	//       $5=baseDelayMicros, $6=claiming, $7=maxDelayMicros, $8=callerBatchSize
 	assert.Equal(t, 5, ec.args[1], "maxAttempts")
 	assert.Equal(t, statusDead, ec.args[2], "dead status")
 	assert.Equal(t, statusPending, ec.args[3], "pending status")
 	assert.Equal(t, statusClaiming, ec.args[5], "claiming status for WHERE clause")
-	assert.Equal(t, reclaimBatchSize, ec.args[7], "reclaim batch size")
+	assert.Equal(t, callerBatch, ec.args[7], "ReclaimStale must pass through the caller's batchSize")
 
 	// claimTTL interval text
 	ttlArg, ok := ec.args[0].(string)
@@ -279,7 +281,7 @@ func TestPGOutboxStore_ReclaimStale_ExecError(t *testing.T) {
 	store := NewOutboxStore(db, clock.Real())
 
 	_, err := store.ReclaimStale(context.Background(),
-		testtime.D60s, 5, testtime.D5s, testtime.D5min)
+		testtime.D60s, 5, testtime.D5s, testtime.D5min, 1000)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ReclaimStale failed")
 }
@@ -291,7 +293,7 @@ func TestPGOutboxStore_ReclaimStale_ZeroCount(t *testing.T) {
 	store := NewOutboxStore(db, clock.Real())
 
 	count, err := store.ReclaimStale(context.Background(),
-		testtime.D60s, 5, testtime.D5s, testtime.D5min)
+		testtime.D60s, 5, testtime.D5s, testtime.D5min, 1000)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
 }

--- a/assemblies/corebundle/generated/metrics-schema.yaml
+++ b/assemblies/corebundle/generated/metrics-schema.yaml
@@ -298,7 +298,7 @@ metrics:
       fqName: gocell_outbox_relayed_total
       namespace: gocell
       type: counter
-      help: Total number of outbox entries processed by the relay, by outcome.
+      help: Total number of outbox entries processed by the relay, by outcome. outcome=published|retried|dead are canonical writebacks; outcome=skipped covers MarkPublished updated=false (success path lost lease) and outcome=lost covers Mark{Retry,Dead} updated=false (failure path lost lease) — the canonical outcome for both is owned by the reclaimer (see outbox_reclaimed_total).
       labels:
         - cell
         - outcome

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -47,6 +47,15 @@ const (
 	// MaxMetadataTotalSize is the maximum total byte size of all metadata
 	// key-value pairs combined (sum of len(k)+len(v) for each pair).
 	MaxMetadataTotalSize = 65536
+
+	// MaxPayloadBytes caps Entry.Payload length. A bug or malicious producer
+	// that emits multi-MB JSON would otherwise inflate relay batch memory
+	// (BatchSize × payload bytes) and PG TOAST / replication overhead. 1 MiB
+	// matches Apache Kafka's default `message.max.bytes` and gives audit
+	// snapshots / large business events comfortable headroom while keeping a
+	// single relay batch under tens of MB at the default BatchSize=100.
+	// ref: Apache Kafka message.max.bytes default 1 MiB.
+	MaxPayloadBytes = 1 << 20
 )
 
 // ReservedMetadataKeys lists keys that the kernel observability bridge owns
@@ -228,6 +237,10 @@ func (e Entry) Validate() error {
 	}
 	if len(e.Payload) == 0 {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed, "outbox: entry missing payload")
+	}
+	if len(e.Payload) > MaxPayloadBytes {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			fmt.Sprintf("outbox: payload size %d exceeds max %d", len(e.Payload), MaxPayloadBytes))
 	}
 	if err := validateMetadata(e.Metadata); err != nil {
 		return err

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -912,6 +912,36 @@ func TestEntry_Validate_MetadataMultiByteUTF8(t *testing.T) {
 	assert.NoError(t, e.Validate(), "multi-byte key within byte limit should pass")
 }
 
+// --- Payload Validation Tests (PAYLOAD-SIZE-01) ---
+
+func TestEntry_Validate_PayloadByteLimit_Exceeds(t *testing.T) {
+	e := Entry{
+		ID:        "test",
+		EventType: "test.event",
+		Payload:   make([]byte, MaxPayloadBytes+1),
+	}
+	err := e.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payload size")
+	assert.Contains(t, err.Error(), "exceeds max")
+}
+
+func TestEntry_Validate_PayloadAtExactBoundary(t *testing.T) {
+	e := Entry{
+		ID:        "test",
+		EventType: "test.event",
+		Payload:   make([]byte, MaxPayloadBytes),
+	}
+	assert.NoError(t, e.Validate(), "payload at exactly MaxPayloadBytes must be valid")
+}
+
+func TestPayloadConstantsAlign(t *testing.T) {
+	// Sentinel that locks the documented value: 1 MiB. Bumping this constant
+	// is a deliberate design call (PG TOAST overhead, relay batch memory) and
+	// must update this assertion together with operator-facing release notes.
+	assert.Equal(t, 1<<20, MaxPayloadBytes)
+}
+
 func TestEntry_Validate_MetadataAtExactBoundary(t *testing.T) {
 	// Exactly MaxMetadataKeys keys should pass.
 	e := Entry{ID: "test", EventType: "test.event", Payload: []byte(`{}`)}

--- a/kernel/outbox/relay_collector.go
+++ b/kernel/outbox/relay_collector.go
@@ -117,8 +117,12 @@ func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCo
 	}
 
 	relayed, err := p.CounterVec(metrics.CounterOpts{
-		Name:       "outbox_relayed_total",
-		Help:       "Total number of outbox entries processed by the relay, by outcome.",
+		Name: "outbox_relayed_total",
+		Help: "Total number of outbox entries processed by the relay, by outcome. " +
+			"outcome=published|retried|dead are canonical writebacks; " +
+			"outcome=skipped covers MarkPublished updated=false (success path lost lease) " +
+			"and outcome=lost covers Mark{Retry,Dead} updated=false (failure path lost lease) — " +
+			"the canonical outcome for both is owned by the reclaimer (see outbox_reclaimed_total).",
 		LabelNames: []string{"cell", "outcome"},
 	})
 	if err := register(relayed, err, "outbox_relayed_total"); err != nil {

--- a/kernel/outbox/relay_collector.go
+++ b/kernel/outbox/relay_collector.go
@@ -191,6 +191,9 @@ func (c *providerRelayCollector) RecordPollCycle(r PollCycleResult) {
 	if r.Skipped > 0 {
 		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "skipped"}).Add(float64(r.Skipped))
 	}
+	if r.Lost > 0 {
+		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "lost"}).Add(float64(r.Lost))
+	}
 
 	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "claim"}).Observe(r.ClaimDur.Seconds())
 	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "publish"}).Observe(r.PublishDur.Seconds())

--- a/kernel/outbox/relay_metrics.go
+++ b/kernel/outbox/relay_metrics.go
@@ -38,7 +38,11 @@ type RelayCollector interface {
 	RecordBatchSize(size int)
 
 	// RecordReclaim records the number of stale entries reclaimed back to
-	// pending (or dead-lettered). Called once per reclaimStale invocation.
+	// pending (or dead-lettered). Called once per reclaimStale tick **only
+	// when count > 0** — idle reclaim sweeps are not observed (the metric
+	// is a recovery counter, not a tick frequency gauge). This contrasts
+	// with RecordBatchSize which is also called on size==0 cycles so
+	// dashboards can detect a totally idle relay.
 	RecordReclaim(count int64)
 
 	// RecordCleanup records the number of entries removed during periodic

--- a/kernel/outbox/relay_metrics.go
+++ b/kernel/outbox/relay_metrics.go
@@ -6,8 +6,15 @@ import "time"
 // Used by RelayCollector.RecordPollCycle to avoid a long parameter list
 // and to support future extensions without breaking the interface.
 type PollCycleResult struct {
-	Published, Retried, Dead, Skipped  int
-	ClaimDur, PublishDur, WriteBackDur time.Duration
+	// Published / Retried / Dead are the canonical outcomes from the publish
+	// and writeback phases. Skipped covers `MarkPublished updated=false`
+	// (the entry was reclaimed mid-flight before MarkPublished could win).
+	// Lost covers the same condition for failure writebacks (Mark{Retry,Dead}
+	// updated=false): the lease lost mid-flight while the publisher was
+	// reporting an error, so the failure must NOT be counted as retried/dead
+	// — the new lease owner will report the canonical outcome.
+	Published, Retried, Dead, Skipped, Lost int
+	ClaimDur, PublishDur, WriteBackDur      time.Duration
 }
 
 // RelayCollector records outbox relay operational metrics.

--- a/runtime/outbox/config.go
+++ b/runtime/outbox/config.go
@@ -28,6 +28,17 @@ const (
 	defaultRelayReclaimInterval = 30 * time.Second
 	// defaultRelayDeadRetentionPeriod is how long dead-lettered entries are kept.
 	defaultRelayDeadRetentionPeriod = 30 * 24 * time.Hour
+	// defaultRelayReclaimBatchSize caps a single ReclaimStale UPDATE so a
+	// backlog of stale claiming rows cannot produce a multi-second statement
+	// that blocks VACUUM/replication. The reclaim loop tick re-runs to drain
+	// residual when the backlog exceeds the cap. 1000 sits between
+	// ThreeDotsLabs/watermill-sql's 100 (small batch SELECT default) and
+	// riverqueue/river's 10000 (high-throughput job rescuer): outbox reclaim
+	// is a recovery sweep, not a hot path, and a 1000-row UPDATE on the
+	// fencing CTE typically completes well under 100 ms on commodity PG.
+	// ref: ThreeDotsLabs/watermill-sql pkg/sql/schema_adapter_postgresql.go
+	// ref: riverqueue/river internal/maintenance/job_rescuer.go
+	defaultRelayReclaimBatchSize = 1000
 )
 
 // RelayConfig configures the outbox relay behavior.
@@ -55,6 +66,11 @@ type RelayConfig struct {
 	// ReclaimInterval controls the independent ReclaimStale goroutine
 	// frequency, decoupled from cleanup interval. Default 30s.
 	ReclaimInterval time.Duration
+	// ReclaimBatchSize caps a single ReclaimStale UPDATE; the relay's reclaim
+	// loop drains residual on its own tick when the stale backlog exceeds
+	// this cap. Default 1000 (see defaultRelayReclaimBatchSize for the
+	// industry-comparison rationale).
+	ReclaimBatchSize int
 	// DeadRetentionPeriod is how long dead-lettered entries are kept before
 	// cleanup. Separate from RetentionPeriod to give operators more time
 	// to investigate and manually retry failed entries. Default 30 days.
@@ -99,6 +115,7 @@ func DefaultRelayConfig() RelayConfig {
 		ClaimTTL:             defaultRelayClaimTTL,
 		MaxRetryDelay:        defaultRelayMaxRetryDelay,
 		ReclaimInterval:      defaultRelayReclaimInterval,
+		ReclaimBatchSize:     defaultRelayReclaimBatchSize,
 		DeadRetentionPeriod:  defaultRelayDeadRetentionPeriod, // 30 days
 		PollFailureBudget:    5,
 		ReclaimFailureBudget: 5,
@@ -134,6 +151,9 @@ func (c RelayConfig) WithDefaults() RelayConfig {
 	}
 	if c.ReclaimInterval <= 0 {
 		c.ReclaimInterval = d.ReclaimInterval
+	}
+	if c.ReclaimBatchSize <= 0 {
+		c.ReclaimBatchSize = d.ReclaimBatchSize
 	}
 	if c.DeadRetentionPeriod <= 0 {
 		c.DeadRetentionPeriod = d.DeadRetentionPeriod

--- a/runtime/outbox/outboxtest/fake_store.go
+++ b/runtime/outbox/outboxtest/fake_store.go
@@ -265,11 +265,17 @@ func (s *FakeStore) MarkDead(_ context.Context, id, leaseID string, attempts int
 	return true, nil
 }
 
-// ReclaimStale transitions claiming rows whose claimed_at is older than claimTTL
-// back to pending or to dead (when attempts+1 >= maxAttempts).
-// Returns count of rows recovered across both destinations.
+// ReclaimStale transitions up to batchSize claiming rows whose claimed_at is
+// older than claimTTL back to pending or to dead (when attempts+1 >= maxAttempts).
+// Returns count of rows recovered across both destinations. Rows are visited
+// in stable map iteration order capped at batchSize so a backlog larger than
+// the cap is split across loop iterations on the caller side.
 func (s *FakeStore) ReclaimStale(
-	_ context.Context, claimTTL time.Duration, maxAttempts int, baseDelay, maxDelay time.Duration,
+	_ context.Context,
+	claimTTL time.Duration,
+	maxAttempts int,
+	baseDelay, maxDelay time.Duration,
+	batchSize int,
 ) (count int, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -278,6 +284,9 @@ func (s *FakeStore) ReclaimStale(
 	cutoff := now.Add(-claimTTL)
 
 	for _, r := range s.rows {
+		if count >= batchSize {
+			break
+		}
 		if r.status != statusClaiming {
 			continue
 		}

--- a/runtime/outbox/outboxtest/fake_store_test.go
+++ b/runtime/outbox/outboxtest/fake_store_test.go
@@ -116,7 +116,7 @@ func TestFakeStore_WithClock(t *testing.T) {
 	advanced := base.Add(testtime.D2min)
 	s.WithClock(func() time.Time { return advanced })
 
-	count, err := s.ReclaimStale(ctx, fakeStoreClaimTTL, 5, fakeStoreBaseDelay, fakeStoreMaxDelay)
+	count, err := s.ReclaimStale(ctx, fakeStoreClaimTTL, 5, fakeStoreBaseDelay, fakeStoreMaxDelay, 1000)
 	if err != nil {
 		t.Fatalf("ReclaimStale: %v", err)
 	}

--- a/runtime/outbox/outboxtest/store_conformance.go
+++ b/runtime/outbox/outboxtest/store_conformance.go
@@ -287,7 +287,7 @@ func conformFencingRace(t *testing.T, factory StoreFactory) {
 	// Reclaim sweep: TTL = -1h so the just-set claim is "expired" and the
 	// row goes back to pending with lease cleared. Zero baseDelay so the
 	// recovered row is immediately claimable.
-	count, err := store.ReclaimStale(ctx, -time.Hour, 99, 0, 0)
+	count, err := store.ReclaimStale(ctx, -time.Hour, 99, 0, 0, 1000)
 	if err != nil {
 		t.Fatalf(msgReclaimStale, err)
 	}
@@ -488,7 +488,7 @@ func conformReclaimStaleRecovers(t *testing.T, factory StoreFactory) {
 	// Negative TTL → every claiming entry is immediately stale.
 	// Zero baseDelay + maxDelay so the recovered entry gets next_retry_at = now()
 	// and is immediately claimable in the next ClaimPending call.
-	count, err := store.ReclaimStale(ctx, -time.Hour, 99, 0, 0)
+	count, err := store.ReclaimStale(ctx, -time.Hour, 99, 0, 0, 1000)
 	if err != nil {
 		t.Fatalf(msgReclaimStale, err)
 	}
@@ -522,7 +522,7 @@ func conformReclaimStaleFresh(t *testing.T, factory StoreFactory) {
 	}
 
 	// 1-hour TTL: claimed_at (set just above) is well within TTL.
-	count, err := store.ReclaimStale(ctx, time.Hour, 99, conformReclaimBaseDelay, conformReclaimMaxDelay)
+	count, err := store.ReclaimStale(ctx, time.Hour, 99, conformReclaimBaseDelay, conformReclaimMaxDelay, 1000)
 	if err != nil {
 		t.Fatalf(msgReclaimStale, err)
 	}
@@ -548,7 +548,7 @@ func conformReclaimStaleEscalates(t *testing.T, factory StoreFactory) {
 		t.Fatalf(msgClaimPendingWithLen, err, len(claimed))
 	}
 
-	count, err := store.ReclaimStale(ctx, -time.Hour, 5, conformReclaimBaseDelay, conformReclaimMaxDelay)
+	count, err := store.ReclaimStale(ctx, -time.Hour, 5, conformReclaimBaseDelay, conformReclaimMaxDelay, 1000)
 	if err != nil {
 		t.Fatalf(msgReclaimStale, err)
 	}

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -633,11 +633,17 @@ func (r *Relay) handleFailedEntry(ctx context.Context, res publishResult, stats 
 // large backlog promptly inside the same tick rather than waiting up to
 // ReclaimInterval per cap-sized chunk. Loop also breaks on ctx cancel.
 //
+// reclaimMaxIterations bounds the loop so a producer that keeps pushing
+// stale claiming rows faster than we can drain them cannot starve the
+// reclaim goroutine inside one tick. Hitting the cap is a backlog
+// indicator, not a correctness issue — the next reclaim tick will pick
+// up where this one left off.
+//
 // ref: riverqueue/river internal/maintenance/job_rescuer.go (batch loop break)
 func (r *Relay) reclaimStale(ctx context.Context) error {
 	batch := r.cfg.ReclaimBatchSize
 	var total int
-	for {
+	for i := 0; i < reclaimMaxIterations; i++ {
 		if err := ctx.Err(); err != nil {
 			break
 		}
@@ -662,6 +668,14 @@ func (r *Relay) reclaimStale(ctx context.Context) error {
 	}
 	return nil
 }
+
+// reclaimMaxIterations is the per-tick safety cap for the reclaim drain
+// loop. With the default batch=1000, each tick can recover up to 16,000
+// rows; deeper backlogs spill into the next ReclaimInterval tick. The
+// constant is small enough that pathological behavior (Store bug
+// returning count==batch forever) cannot block a relay shutdown by
+// more than a handful of ReclaimStale round-trips.
+const reclaimMaxIterations = 16
 
 // cleanup removes old published and dead entries.
 // Loops CleanupPublished / CleanupDead until each returns deleted < batchSize.

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -643,6 +643,20 @@ func (r *Relay) handleFailedEntry(ctx context.Context, res publishResult, stats 
 func (r *Relay) reclaimStale(ctx context.Context) error {
 	batch := r.cfg.ReclaimBatchSize
 	var total int
+	// Defer the metric/log emit so a partial-success sweep (some batches
+	// committed, then a later batch errors) still reports the rows already
+	// recovered. Reporting only on full success would silently undercount
+	// outbox_reclaimed_total during DB blips, exactly the scenario where
+	// operators correlate it against outbox_relayed_total{outcome="lost"}.
+	defer func() {
+		if total > 0 {
+			slog.Warn(
+				"outbox relay: reclaimed stale entries",
+				slog.Int("count", total),
+			)
+			r.metrics.RecordReclaim(int64(total))
+		}
+	}()
 	for i := 0; i < reclaimMaxIterations; i++ {
 		if err := ctx.Err(); err != nil {
 			break
@@ -658,13 +672,6 @@ func (r *Relay) reclaimStale(ctx context.Context) error {
 		if count < batch {
 			break
 		}
-	}
-	if total > 0 {
-		slog.Warn(
-			"outbox relay: reclaimed stale entries",
-			slog.Int("count", total),
-		)
-		r.metrics.RecordReclaim(int64(total))
 	}
 	return nil
 }

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -62,6 +62,11 @@ type pollStats struct {
 	retried   int
 	dead      int
 	skipped   int
+	// lost counts failure writebacks that lost their lease mid-flight
+	// (Mark{Retry,Dead} returned updated=false). The new lease owner — the
+	// reclaimer or a peer — reports the canonical outcome, so this writeback
+	// must NOT be counted as retried/dead. ref: backlog2 B2-A-05.
+	lost int
 }
 
 // ---------------------------------------------------------------------------
@@ -477,6 +482,7 @@ func (r *Relay) pollOnce(ctx context.Context) error {
 			slog.Int("retried", stats.retried),
 			slog.Int("dead_lettered", stats.dead),
 			slog.Int("skipped", stats.skipped),
+			slog.Int("lost", stats.lost),
 			slog.Duration("claim_dur", claimDur),
 			slog.Duration("publish_dur", pubDur),
 		)
@@ -485,6 +491,7 @@ func (r *Relay) pollOnce(ctx context.Context) error {
 			Retried:      stats.retried,
 			Dead:         stats.dead,
 			Skipped:      stats.skipped,
+			Lost:         stats.lost,
 			ClaimDur:     claimDur,
 			PublishDur:   pubDur,
 			WriteBackDur: wbDur,
@@ -571,6 +578,7 @@ func (r *Relay) handleFailedEntry(ctx context.Context, res publishResult, stats 
 			return err
 		}
 		if !updated {
+			stats.lost++
 			slog.Warn(
 				"outbox relay: stale lease lost fail-write",
 				slog.String("entry_id", res.entry.ID),
@@ -600,6 +608,7 @@ func (r *Relay) handleFailedEntry(ctx context.Context, res publishResult, stats 
 		return err
 	}
 	if !updated {
+		stats.lost++
 		slog.Warn(
 			"outbox relay: stale lease lost fail-write",
 			slog.String("entry_id", res.entry.ID),
@@ -617,17 +626,39 @@ func (r *Relay) handleFailedEntry(ctx context.Context, res publishResult, stats 
 // ---------------------------------------------------------------------------
 
 // reclaimStale recovers entries stuck in 'claiming' past ClaimTTL.
+//
+// Each ReclaimStale call caps at cfg.ReclaimBatchSize so the underlying
+// UPDATE never produces a multi-second statement that blocks VACUUM /
+// replication. We loop until a sweep returns < batchSize, draining a
+// large backlog promptly inside the same tick rather than waiting up to
+// ReclaimInterval per cap-sized chunk. Loop also breaks on ctx cancel.
+//
+// ref: riverqueue/river internal/maintenance/job_rescuer.go (batch loop break)
 func (r *Relay) reclaimStale(ctx context.Context) error {
-	count, err := r.store.ReclaimStale(ctx, r.cfg.ClaimTTL, r.cfg.MaxAttempts, r.cfg.BaseRetryDelay, r.cfg.MaxRetryDelay)
-	if err != nil {
-		return err
+	batch := r.cfg.ReclaimBatchSize
+	var total int
+	for {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		count, err := r.store.ReclaimStale(
+			ctx, r.cfg.ClaimTTL, r.cfg.MaxAttempts,
+			r.cfg.BaseRetryDelay, r.cfg.MaxRetryDelay, batch,
+		)
+		if err != nil {
+			return err
+		}
+		total += count
+		if count < batch {
+			break
+		}
 	}
-	if count > 0 {
+	if total > 0 {
 		slog.Warn(
 			"outbox relay: reclaimed stale entries",
-			slog.Int("count", count),
+			slog.Int("count", total),
 		)
-		r.metrics.RecordReclaim(int64(count))
+		r.metrics.RecordReclaim(int64(total))
 	}
 	return nil
 }

--- a/runtime/outbox/relay_internal_test.go
+++ b/runtime/outbox/relay_internal_test.go
@@ -360,6 +360,9 @@ func TestRelay_HandleFailedEntry_StaleLease_RetryNotCounted(t *testing.T) {
 	assert.Equal(t, 1, store.markRetryCalls, "MarkRetry must be invoked once")
 	assert.Zero(t, stats.retried, "stats.retried must NOT be incremented when lease was lost")
 	assert.Zero(t, stats.dead, "stats.dead must NOT be incremented")
+	assert.Equal(t, 1, stats.lost,
+		"stats.lost must record the lease-lost writeback so providerRelayCollector "+
+			"emits outbox_relayed_total{outcome=\"lost\"}")
 }
 
 // stalePublishStore returns (false, nil) from MarkPublished — the fencing
@@ -436,6 +439,95 @@ func TestRelay_HandleFailedEntry_StaleLease_DeadNotCounted(t *testing.T) {
 	assert.Equal(t, 1, store.markDeadCalls, "MarkDead must be invoked once")
 	assert.Zero(t, stats.dead, "stats.dead must NOT be incremented when lease was lost")
 	assert.Zero(t, stats.retried)
+	assert.Equal(t, 1, stats.lost,
+		"stats.lost must record the lease-lost dead writeback so providerRelayCollector "+
+			"emits outbox_relayed_total{outcome=\"lost\"}")
+}
+
+// countingReclaimStore wraps minimalStore to count ReclaimStale invocations
+// and stage a return-count sequence. Each Pop returns the next configured
+// count; if the slice is exhausted, returns 0 (drained).
+type countingReclaimStore struct {
+	*minimalStore
+	mu        sync.Mutex
+	calls     int
+	plan      []int // staged return values, popped front-to-back
+	batchSeen []int // batchSize values observed per call
+}
+
+func newCountingReclaimStore(plan ...int) *countingReclaimStore {
+	return &countingReclaimStore{minimalStore: newMinimalStore(), plan: plan}
+}
+
+func (s *countingReclaimStore) ReclaimStale(
+	_ context.Context, _ time.Duration, _ int, _, _ time.Duration, batchSize int,
+) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.batchSeen = append(s.batchSeen, batchSize)
+	if len(s.plan) == 0 {
+		return 0, nil
+	}
+	next := s.plan[0]
+	s.plan = s.plan[1:]
+	return next, nil
+}
+
+// TestRelay_ReclaimStale_DrainsBacklogWithinSingleTick verifies B2-A-06: when
+// the store reports `count == batchSize` (i.e. there is more residual), the
+// reclaim helper loops until a sweep returns `< batchSize`, draining a backlog
+// of N×batchSize rows inside one tick instead of N ReclaimInterval ticks.
+func TestRelay_ReclaimStale_DrainsBacklogWithinSingleTick(t *testing.T) {
+	// Plan: 1000 (full), 1000 (full), 500 (residual) — should make 3 calls
+	// and stop on the third because 500 < 1000.
+	store := newCountingReclaimStore(1000, 1000, 500)
+	relay := &Relay{
+		store:   store,
+		cfg:     RelayConfig{ReclaimBatchSize: 1000}.WithDefaults(),
+		metrics: &safeRelayCollector{inner: kout.NoopRelayCollector{}},
+		clock:   clock.Real(),
+	}
+
+	require.NoError(t, relay.reclaimStale(context.Background()))
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Equal(t, 3, store.calls,
+		"reclaimStale must loop until ReclaimStale returns < batchSize "+
+			"(plan was 1000,1000,500 → 3 calls)")
+	for i, b := range store.batchSeen {
+		assert.Equal(t, 1000, b,
+			"call %d must request the configured ReclaimBatchSize=1000", i)
+	}
+}
+
+// TestRelay_ReclaimStale_HitsMaxIterationsCap verifies the safety bound: a
+// pathological store that always returns count==batch must not spin
+// forever inside one tick. After reclaimMaxIterations sweeps the loop
+// breaks, leaving the residual for the next tick.
+func TestRelay_ReclaimStale_HitsMaxIterationsCap(t *testing.T) {
+	plan := make([]int, reclaimMaxIterations+8) // more than enough
+	for i := range plan {
+		plan[i] = 1000 // always full
+	}
+	store := newCountingReclaimStore(plan...)
+	relay := &Relay{
+		store:   store,
+		cfg:     RelayConfig{ReclaimBatchSize: 1000}.WithDefaults(),
+		metrics: &safeRelayCollector{inner: kout.NoopRelayCollector{}},
+		clock:   clock.Real(),
+	}
+
+	require.NoError(t, relay.reclaimStale(context.Background()))
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Equal(t, reclaimMaxIterations, store.calls,
+		"reclaimStale must stop at reclaimMaxIterations (%d) and let the next "+
+			"tick continue draining; otherwise a runaway store/Producer pair "+
+			"could starve the reclaim goroutine inside one tick.",
+		reclaimMaxIterations)
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/outbox/relay_internal_test.go
+++ b/runtime/outbox/relay_internal_test.go
@@ -163,7 +163,7 @@ func (s *minimalStore) MarkDead(_ context.Context, id, leaseID string, attempts 
 	return true, nil
 }
 
-func (s *minimalStore) ReclaimStale(_ context.Context, claimTTL time.Duration, maxAttempts int, _, _ time.Duration) (int, error) {
+func (s *minimalStore) ReclaimStale(_ context.Context, claimTTL time.Duration, maxAttempts int, _, _ time.Duration, _ int) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	cutoff := time.Now().Add(-claimTTL)

--- a/runtime/outbox/relay_internal_test.go
+++ b/runtime/outbox/relay_internal_test.go
@@ -444,18 +444,35 @@ func TestRelay_HandleFailedEntry_StaleLease_DeadNotCounted(t *testing.T) {
 			"emits outbox_relayed_total{outcome=\"lost\"}")
 }
 
+// reclaimStep stages one ReclaimStale return value. Either count (success)
+// or err (failure) is set; never both.
+type reclaimStep struct {
+	count int
+	err   error
+}
+
 // countingReclaimStore wraps minimalStore to count ReclaimStale invocations
-// and stage a return-count sequence. Each Pop returns the next configured
-// count; if the slice is exhausted, returns 0 (drained).
+// and stage a return sequence. Each call pops the next reclaimStep; if the
+// slice is exhausted, returns (0, nil) (drained).
 type countingReclaimStore struct {
 	*minimalStore
 	mu        sync.Mutex
 	calls     int
-	plan      []int // staged return values, popped front-to-back
+	plan      []reclaimStep
 	batchSeen []int // batchSize values observed per call
 }
 
+// newCountingReclaimStore stages a sequence of success counts. Use
+// newCountingReclaimStoreSteps for failure sequences.
 func newCountingReclaimStore(plan ...int) *countingReclaimStore {
+	steps := make([]reclaimStep, len(plan))
+	for i, n := range plan {
+		steps[i] = reclaimStep{count: n}
+	}
+	return &countingReclaimStore{minimalStore: newMinimalStore(), plan: steps}
+}
+
+func newCountingReclaimStoreSteps(plan ...reclaimStep) *countingReclaimStore {
 	return &countingReclaimStore{minimalStore: newMinimalStore(), plan: plan}
 }
 
@@ -471,7 +488,30 @@ func (s *countingReclaimStore) ReclaimStale(
 	}
 	next := s.plan[0]
 	s.plan = s.plan[1:]
-	return next, nil
+	return next.count, next.err
+}
+
+// reclaimRecordingCollector captures RecordReclaim calls so partial-success
+// emits can be asserted directly. The other RelayCollector methods are
+// inherited as no-ops from NoopRelayCollector.
+type reclaimRecordingCollector struct {
+	kout.NoopRelayCollector
+	mu     sync.Mutex
+	counts []int64
+}
+
+func (c *reclaimRecordingCollector) RecordReclaim(n int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.counts = append(c.counts, n)
+}
+
+func (c *reclaimRecordingCollector) snapshot() []int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]int64, len(c.counts))
+	copy(out, c.counts)
+	return out
 }
 
 // TestRelay_ReclaimStale_DrainsBacklogWithinSingleTick verifies B2-A-06: when
@@ -500,6 +540,35 @@ func TestRelay_ReclaimStale_DrainsBacklogWithinSingleTick(t *testing.T) {
 		assert.Equal(t, 1000, b,
 			"call %d must request the configured ReclaimBatchSize=1000", i)
 	}
+}
+
+// TestRelay_ReclaimStale_PartialSuccessRecordsBeforeError verifies that when
+// the loop has already drained N rows and a later batch errors, the metric
+// emit still fires for those N rows. Without the deferred emit the tick
+// would silently undercount outbox_reclaimed_total during DB blips,
+// undermining the lost↔reclaim correlation operators rely on.
+func TestRelay_ReclaimStale_PartialSuccessRecordsBeforeError(t *testing.T) {
+	transientErr := fmt.Errorf("transient DB failure")
+	store := newCountingReclaimStoreSteps(
+		reclaimStep{count: 1000},       // first batch succeeds (full)
+		reclaimStep{err: transientErr}, // second batch fails
+	)
+	rc := &reclaimRecordingCollector{}
+	relay := &Relay{
+		store:   store,
+		cfg:     RelayConfig{ReclaimBatchSize: 1000}.WithDefaults(),
+		metrics: &safeRelayCollector{inner: rc},
+		clock:   clock.Real(),
+	}
+
+	err := relay.reclaimStale(context.Background())
+	require.ErrorIs(t, err, transientErr,
+		"the underlying error must still propagate so the reclaim loop's "+
+			"failure budget can trip /readyz unhealthy")
+
+	assert.Equal(t, []int64{1000}, rc.snapshot(),
+		"RecordReclaim must observe the 1000 rows the first batch already "+
+			"committed, even though a later batch errored")
 }
 
 // TestRelay_ReclaimStale_HitsMaxIterationsCap verifies the safety bound: a

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -695,7 +695,7 @@ func (s *failingStore) ClaimPending(ctx context.Context, batchSize int) ([]outbo
 }
 
 func (s *failingStore) ReclaimStale(
-	ctx context.Context, claimTTL time.Duration, maxAttempts int, base, maxDelay time.Duration,
+	ctx context.Context, claimTTL time.Duration, maxAttempts int, base, maxDelay time.Duration, batchSize int,
 ) (int, error) {
 	s.mu.Lock()
 	err := s.reclaimErr
@@ -703,7 +703,7 @@ func (s *failingStore) ReclaimStale(
 	if err != nil {
 		return 0, err
 	}
-	return s.FakeStore.ReclaimStale(ctx, claimTTL, maxAttempts, base, maxDelay)
+	return s.FakeStore.ReclaimStale(ctx, claimTTL, maxAttempts, base, maxDelay, batchSize)
 }
 
 func (s *failingStore) CleanupPublished(ctx context.Context, cutoff time.Time, batchSize int) (int, error) {
@@ -784,8 +784,14 @@ func TestRelay_HandleFailedEntry_LostStat(t *testing.T) {
 	cfg.Metrics = mc
 
 	relay := outbox.NewRelay(store, pub, cfg)
-	require.NoError(t, relay.Start(t.Context()))
-	defer func() { _ = relay.Stop(t.Context()) }()
+	startCtx, startCancel := context.WithTimeout(t.Context(), testtime.D2s)
+	defer startCancel()
+	require.NoError(t, relay.Start(startCtx))
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), testtime.D2s)
+		defer stopCancel()
+		_ = relay.Stop(stopCtx)
+	}()
 
 	require.Eventually(t, func() bool {
 		mc.mu.Lock()

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -730,6 +730,87 @@ func (s *failingStore) OldestEligibleAt(ctx context.Context, status string) (tim
 	return s.FakeStore.OldestEligibleAt(ctx, status)
 }
 
+// leaseLostStore wraps FakeStore and forces MarkRetry / MarkDead to report
+// updated=false so handleFailedEntry exercises the "lease was lost" branch
+// (B2-A-05 / OUTBOX-RELAY-LOST-METRIC). The publisher is simultaneously made
+// to fail so the relay enters handleFailedEntry rather than MarkPublished.
+type leaseLostStore struct {
+	*outboxtest.FakeStore
+}
+
+func newLeaseLostStore() *leaseLostStore {
+	return &leaseLostStore{FakeStore: outboxtest.NewFakeStore()}
+}
+
+func (s *leaseLostStore) MarkRetry(
+	_ context.Context, _, _ string, _ int, _ time.Time, _ string,
+) (bool, error) {
+	return false, nil
+}
+
+func (s *leaseLostStore) MarkDead(
+	_ context.Context, _, _ string, _ int, _ string,
+) (bool, error) {
+	return false, nil
+}
+
+// TestRelay_HandleFailedEntry_LostStat verifies PR-V1-PG-OUTBOX-RELAY-HARDEN
+// B2-A-05 follow-up: when MarkRetry / MarkDead report updated=false (lease was
+// reclaimed mid-flight), handleFailedEntry MUST count the result into a new
+// "lost" stat and surface it through PollCycleResult.Lost so the
+// `outbox_relayed_total{outcome="lost"}` time-series fires. Without this, a
+// stale-lease writeback is invisible to operators despite stats divergence.
+func TestRelay_HandleFailedEntry_LostStat(t *testing.T) {
+	store := newLeaseLostStore()
+	pub := newFakePublisher().WithError(errors.New("transient publish failure"))
+
+	// Seed one pending entry so a single poll cycle:
+	//   1. ClaimPending mints a lease and returns the row,
+	//   2. fakePublisher fails the publish,
+	//   3. handleFailedEntry routes to MarkRetry,
+	//   4. our wrapper returns updated=false → must count as lost, not retried.
+	store.Seed(outbox.ClaimedEntry{
+		Entry: kout.Entry{
+			ID:        "00000000-0000-4000-8000-000000000001",
+			EventType: "test.event",
+			Topic:     "t",
+			Payload:   []byte(`{}`),
+		},
+	})
+
+	mc := &testCollector{}
+	cfg := fastCfg()
+	cfg.MaxAttempts = 5
+	cfg.Metrics = mc
+
+	relay := outbox.NewRelay(store, pub, cfg)
+	require.NoError(t, relay.Start(t.Context()))
+	defer func() { _ = relay.Stop(t.Context()) }()
+
+	require.Eventually(t, func() bool {
+		mc.mu.Lock()
+		defer mc.mu.Unlock()
+		for _, c := range mc.pollCycles {
+			if c.Lost >= 1 {
+				return true
+			}
+		}
+		return false
+	}, testtime.D1s, testtime.D1ms, "PollCycleResult.Lost must record stale-lease writeback")
+
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	var lostTotal, retriedTotal, deadTotal int
+	for _, c := range mc.pollCycles {
+		lostTotal += c.Lost
+		retriedTotal += c.Retried
+		deadTotal += c.Dead
+	}
+	assert.GreaterOrEqual(t, lostTotal, 1, "Lost must record stale-lease writeback")
+	assert.Equal(t, 0, retriedTotal, "stale-lease writeback must NOT count as retried")
+	assert.Equal(t, 0, deadTotal, "stale-lease writeback must NOT count as dead")
+}
+
 func budgetCfg() outbox.RelayConfig {
 	cfg := fastCfg()
 	cfg.PollFailureBudget = 3

--- a/runtime/outbox/store.go
+++ b/runtime/outbox/store.go
@@ -52,11 +52,20 @@ type Store interface {
 	// updated=false same as above.
 	MarkDead(ctx context.Context, id, leaseID string, attempts int, lastError string) (updated bool, err error)
 
-	// ReclaimStale transitions claiming rows whose claimed_at is older than
-	// claimTTL back to pending (with attempts+1 and next_retry_at = backoff)
-	// or to dead (when attempts+1 >= maxAttempts). Returns count of rows
-	// recovered across both destinations.
-	ReclaimStale(ctx context.Context, claimTTL time.Duration, maxAttempts int, baseDelay, maxDelay time.Duration) (count int, err error)
+	// ReclaimStale transitions up to batchSize claiming rows whose claimed_at
+	// is older than claimTTL back to pending (with attempts+1 and
+	// next_retry_at = backoff) or to dead (when attempts+1 >= maxAttempts).
+	// Returns count of rows recovered across both destinations. Callers MUST
+	// loop until count < batchSize so a backlog larger than one sweep drains
+	// promptly without producing a multi-second UPDATE that blocks
+	// VACUUM/replication.
+	ReclaimStale(
+		ctx context.Context,
+		claimTTL time.Duration,
+		maxAttempts int,
+		baseDelay, maxDelay time.Duration,
+		batchSize int,
+	) (count int, err error)
 
 	// CleanupPublished deletes a batch of published rows older than cutoff.
 	// Caller is responsible for looping until deleted < batchSize.

--- a/templates/grafana-dashboard.json
+++ b/templates/grafana-dashboard.json
@@ -66,7 +66,7 @@
     },
     {
       "title": "Outbox Relay Throughput",
-      "description": "Relay processing rates by outcome. Shows published, retried, and dead-lettered message rates.",
+      "description": "Relay processing rates by outcome — published / retried / dead are canonical writebacks; skipped covers MarkPublished updated=false (success path lost lease) and lost covers Mark{Retry,Dead} updated=false (failure path lost lease). The canonical outcome for skipped/lost rows is owned by the reclaimer (see Outbox Reclaim panel).",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -94,6 +94,16 @@
           "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"dead\"}[5m])",
           "legendFormat": "dead (msg/s)",
           "refId": "C"
+        },
+        {
+          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"skipped\"}[5m])",
+          "legendFormat": "skipped — success path lost lease (msg/s)",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(gocell_outbox_relayed_total{cell=\"${cell_id}\", outcome=\"lost\"}[5m])",
+          "legendFormat": "lost — failure path lost lease (msg/s)",
+          "refId": "E"
         }
       ],
       "fieldConfig": {

--- a/tools/archtest/outbox_payload_size_test.go
+++ b/tools/archtest/outbox_payload_size_test.go
@@ -88,20 +88,45 @@ func TestOutboxPayloadSize01_ConstantDeclaredAndUsedByValidate(t *testing.T) {
 	if validate == nil {
 		t.Fatalf("OUTBOX-PAYLOAD-SIZE-01-B: cannot locate (Entry).Validate in %s", src)
 	}
-	var referenced bool
+	// Look specifically for a `len(e.Payload) > MaxPayloadBytes` (or `>=`)
+	// comparison. Merely importing / shadowing the const is not enough — it
+	// must drive an actual size check, otherwise the cap is decorative
+	// ("`_ = MaxPayloadBytes`" would have passed an ident-only scan).
+	var compared bool
 	ast.Inspect(validate.Body, func(n ast.Node) bool {
-		id, ok := n.(*ast.Ident)
-		if ok && id.Name == constName {
-			referenced = true
-			return false
+		bin, ok := n.(*ast.BinaryExpr)
+		if !ok {
+			return true
 		}
-		return true
+		if bin.Op != token.GTR && bin.Op != token.GEQ {
+			return true
+		}
+		// LHS must be `len(e.Payload)` (or `len(<recv>.Payload)`).
+		lenCall, ok := bin.X.(*ast.CallExpr)
+		if !ok || len(lenCall.Args) != 1 {
+			return true
+		}
+		lenIdent, ok := lenCall.Fun.(*ast.Ident)
+		if !ok || lenIdent.Name != "len" {
+			return true
+		}
+		sel, ok := lenCall.Args[0].(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Payload" {
+			return true
+		}
+		// RHS must reference MaxPayloadBytes by name.
+		rhs, ok := bin.Y.(*ast.Ident)
+		if !ok || rhs.Name != constName {
+			return true
+		}
+		compared = true
+		return false
 	})
-	if !referenced {
+	if !compared {
 		t.Errorf(
-			"OUTBOX-PAYLOAD-SIZE-01-B: (Entry).Validate body must reference %s "+
-				"(otherwise the cap is decorative). Insert "+
-				"`if len(e.Payload) > %s { return errcode.New(...) }`.",
+			"OUTBOX-PAYLOAD-SIZE-01-B: (Entry).Validate body must contain a "+
+				"`len(<recv>.Payload) > %s` comparison (or >=). A bare reference "+
+				"such as `_ = %s` is not sufficient — the comparison is the cap.",
 			constName, constName,
 		)
 	}

--- a/tools/archtest/outbox_payload_size_test.go
+++ b/tools/archtest/outbox_payload_size_test.go
@@ -15,7 +15,8 @@
 //
 // ref: docs/plans/202605011500-029-master-roadmap.md B6 PR-V1-PG-OUTBOX-RELAY-HARDEN
 // ref: backlog2.md B2-A-07 (repurposed: metadata cap shipped, payload cap was the
-//      true unguarded vector).
+//
+//	true unguarded vector).
 package archtest
 
 import (

--- a/tools/archtest/outbox_payload_size_test.go
+++ b/tools/archtest/outbox_payload_size_test.go
@@ -1,0 +1,115 @@
+// OUTBOX-PAYLOAD-SIZE-01 — kernel/outbox payload byte cap invariant.
+//
+// kernel/outbox.MaxPayloadBytes is the canonical upper bound on
+// `Entry.Payload` length. A buggy or malicious producer that writes multi-MB
+// JSON would otherwise inflate relay batch memory and PostgreSQL replication
+// delay. The invariant has two parts:
+//
+//	OUTBOX-PAYLOAD-SIZE-01-A  kernel/outbox/outbox.go declares MaxPayloadBytes
+//	OUTBOX-PAYLOAD-SIZE-01-B  kernel/outbox/outbox.go references MaxPayloadBytes
+//	                          inside Entry.Validate (so the cap actually fires)
+//
+// We assert both parts with an AST scan rather than a runtime test so the
+// gate fails CI with a clear message even when the production code never
+// reaches a sized payload.
+//
+// ref: docs/plans/202605011500-029-master-roadmap.md B6 PR-V1-PG-OUTBOX-RELAY-HARDEN
+// ref: backlog2.md B2-A-07 (repurposed: metadata cap shipped, payload cap was the
+//      true unguarded vector).
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOutboxPayloadSize01_ConstantDeclaredAndUsedByValidate(t *testing.T) {
+	t.Parallel()
+
+	root := findModuleRoot(t)
+	src := filepath.Join(root, "kernel", "outbox", "outbox.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, src, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse %s: %v", src, err)
+	}
+
+	const constName = "MaxPayloadBytes"
+	var declared bool
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, name := range vs.Names {
+				if name.Name == constName {
+					declared = true
+				}
+			}
+		}
+	}
+	if !declared {
+		t.Errorf(
+			"OUTBOX-PAYLOAD-SIZE-01-A: kernel/outbox/outbox.go must declare const %s "+
+				"(payload byte cap; see roadmap B6, backlog2 B2-A-07 repurposed scope).",
+			constName,
+		)
+	}
+
+	// Walk Entry.Validate body for any reference to MaxPayloadBytes.
+	var validate *ast.FuncDecl
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name.Name != "Validate" || fd.Recv == nil || len(fd.Recv.List) != 1 {
+			continue
+		}
+		// Recv must be `e Entry` (value receiver, type Entry).
+		ident, ok := fd.Recv.List[0].Type.(*ast.Ident)
+		if !ok || ident.Name != "Entry" {
+			continue
+		}
+		validate = fd
+		break
+	}
+	if validate == nil {
+		t.Fatalf("OUTBOX-PAYLOAD-SIZE-01-B: cannot locate (Entry).Validate in %s", src)
+	}
+	var referenced bool
+	ast.Inspect(validate.Body, func(n ast.Node) bool {
+		id, ok := n.(*ast.Ident)
+		if ok && id.Name == constName {
+			referenced = true
+			return false
+		}
+		return true
+	})
+	if !referenced {
+		t.Errorf(
+			"OUTBOX-PAYLOAD-SIZE-01-B: (Entry).Validate body must reference %s "+
+				"(otherwise the cap is decorative). Insert "+
+				"`if len(e.Payload) > %s { return errcode.New(...) }`.",
+			constName, constName,
+		)
+	}
+
+	// Sanity: ensure the file's package import path is what we expect, so a
+	// future reorganization that moves the file does not silently bypass the
+	// gate. (`outbox` is the package name.)
+	if f.Name.Name != "outbox" {
+		t.Errorf("expected package outbox, got %s", f.Name.Name)
+	}
+	_ = strings.TrimSpace
+}

--- a/tools/archtest/outbox_relay_lost_metric_test.go
+++ b/tools/archtest/outbox_relay_lost_metric_test.go
@@ -134,9 +134,9 @@ func TestOutboxRelayLostMetric01_PollCycleResultHasLostField(t *testing.T) {
 	}
 	if !hasLost {
 		t.Errorf(
-			"OUTBOX-RELAY-LOST-METRIC-01-B: PollCycleResult must declare a Lost int field "+
-				"(roadmap B6, backlog2 B2-A-05). It travels alongside Published/Retried/"+
-				"Dead/Skipped so providerRelayCollector.RecordPollCycle can fire "+
+			"OUTBOX-RELAY-LOST-METRIC-01-B: PollCycleResult must declare a Lost int field " +
+				"(roadmap B6, backlog2 B2-A-05). It travels alongside Published/Retried/" +
+				"Dead/Skipped so providerRelayCollector.RecordPollCycle can fire " +
 				"`outbox_relayed_total{outcome=\"lost\"}`.",
 		)
 	}

--- a/tools/archtest/outbox_relay_lost_metric_test.go
+++ b/tools/archtest/outbox_relay_lost_metric_test.go
@@ -1,0 +1,143 @@
+// OUTBOX-RELAY-LOST-METRIC-01 — handleFailedEntry must observe Mark*'s updated
+// return value and route stale-lease writebacks into the lost stat / metric.
+//
+// The PG outbox uses lease_id fencing: when a worker's lease is rotated by
+// ReclaimStale (or a peer-replaced claim), MarkRetry / MarkDead return
+// (updated=false, nil). Discarding that bool with `_, err :=` makes stale-lease
+// writebacks invisible — they silently inflate stats.dead / stats.retried,
+// hiding the real reclaim activity.
+//
+// Gate IDs:
+//
+//	OUTBOX-RELAY-LOST-METRIC-01-A  runtime/outbox/relay.go handleFailedEntry must
+//	                                read Mark{Retry,Dead}'s first return into a
+//	                                named bool (no `_` discard).
+//	OUTBOX-RELAY-LOST-METRIC-01-B  PollCycleResult must declare a Lost field, so
+//	                                a "lost" outcome is reportable end-to-end.
+//
+// ref: docs/plans/202605011500-029-master-roadmap.md B6 PR-V1-PG-OUTBOX-RELAY-HARDEN
+// ref: backlog2.md B2-A-05 PG-RELAY-FAIL-WRITE-UNHANDLED-ROWS
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+func TestOutboxRelayLostMetric01_HandleFailedEntryReadsUpdated(t *testing.T) {
+	t.Parallel()
+
+	root := findModuleRoot(t)
+	src := filepath.Join(root, "runtime", "outbox", "relay.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, src, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", src, err)
+	}
+
+	var handle *ast.FuncDecl
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name.Name == "handleFailedEntry" && fd.Recv != nil {
+			handle = fd
+			break
+		}
+	}
+	if handle == nil {
+		t.Fatalf("OUTBOX-RELAY-LOST-METRIC-01-A: handleFailedEntry not found in %s", src)
+	}
+
+	// Inspect every assignment whose RHS is a call ending in MarkRetry or
+	// MarkDead. The LHS first ident MUST NOT be `_` — discarding the updated
+	// bool collapses the lost-lease branch into an uncounted writeback.
+	var violations []token.Pos
+	ast.Inspect(handle.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "MarkRetry", "MarkDead":
+		default:
+			return true
+		}
+		if len(assign.Lhs) < 1 {
+			return true
+		}
+		first, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok || first.Name == "_" {
+			violations = append(violations, assign.Pos())
+		}
+		return true
+	})
+
+	for _, p := range violations {
+		t.Errorf(
+			"OUTBOX-RELAY-LOST-METRIC-01-A: %s discards Mark{Retry,Dead}'s `updated bool` "+
+				"(LHS is `_`); read it as `updated, err := r.store.Mark...(...)` and "+
+				"route updated=false to stats.lost so stale leases stay observable.",
+			fset.Position(p),
+		)
+	}
+}
+
+func TestOutboxRelayLostMetric01_PollCycleResultHasLostField(t *testing.T) {
+	t.Parallel()
+
+	root := findModuleRoot(t)
+	src := filepath.Join(root, "kernel", "outbox", "relay_metrics.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, src, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", src, err)
+	}
+
+	var hasLost bool
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != "PollCycleResult" {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			for _, field := range st.Fields.List {
+				for _, name := range field.Names {
+					if name.Name == "Lost" {
+						hasLost = true
+					}
+				}
+			}
+		}
+	}
+	if !hasLost {
+		t.Errorf(
+			"OUTBOX-RELAY-LOST-METRIC-01-B: PollCycleResult must declare a Lost int field "+
+				"(roadmap B6, backlog2 B2-A-05). It travels alongside Published/Retried/"+
+				"Dead/Skipped so providerRelayCollector.RecordPollCycle can fire "+
+				"`outbox_relayed_total{outcome=\"lost\"}`.",
+		)
+	}
+}

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -706,8 +706,12 @@ func (sp *scanPackage) providerRelayCollectorEntries(call *ast.CallExpr, rel str
 		sp.entryFromOpts("counter", opts{
 			name:      "outbox_relayed_total",
 			namespace: sp.namespace,
-			help:      "Total number of outbox entries processed by the relay, by outcome.",
-			labels:    []string{"cell", "outcome"},
+			help: "Total number of outbox entries processed by the relay, by outcome. " +
+				"outcome=published|retried|dead are canonical writebacks; " +
+				"outcome=skipped covers MarkPublished updated=false (success path lost lease) " +
+				"and outcome=lost covers Mark{Retry,Dead} updated=false (failure path lost lease) — " +
+				"the canonical outcome for both is owned by the reclaimer (see outbox_reclaimed_total).",
+			labels: []string{"cell", "outcome"},
 		}, rel, call.Pos()),
 		sp.entryFromOpts("histogram", opts{
 			name:      "outbox_poll_duration_seconds",


### PR DESCRIPTION
## Summary

Closes the three remaining PR-V1-PG-OUTBOX-RELAY-HARDEN punch-list items left
open after PR#373's fencing landing. The five backlog2 entries (B2-A-04..07,
B2-A-12) had already been struck through there; this PR closes the **deeper
follow-ups** the reviewer flagged when those went in:

- **B2-A-07 → payload cap (repurposed)** — backlog wording was \"metadata\"
  but \`MaxMetadataTotalSize=64 KiB\` already lives in \`kernel/outbox/outbox.go\`.
  The truly unguarded vector is **payload**: a buggy/malicious producer can
  ship multi-MB JSON, blowing up relay batch memory (\`BatchSize × payload\`)
  and amplifying PG TOAST + replication delay. This PR adds
  \`MaxPayloadBytes = 1 MiB\` (Apache Kafka \`message.max.bytes\` default) and
  enforces it in \`Entry.Validate\`.
- **B2-A-05 → \`updated bool\` reaches metrics** — \`handleFailedEntry\` already
  observed \`updated=false\` from MarkRetry/MarkDead and emitted a slog.Warn,
  but the lease-lost outcome had no time-series. Operators couldn't correlate
  reclaim activity with stats divergence. New \`PollCycleResult.Lost\` flows
  through the same channel as Published/Retried/Dead/Skipped;
  \`providerRelayCollector.RecordPollCycle\` fires
  \`outbox_relayed_total{outcome=\"lost\"}\` with the existing zero-skip discipline.
- **B2-A-06 → caller-controlled batchSize + drain loop** — the previous fix
  hard-coded \`reclaimBatchSize = 1000\` as a package-private const and relied
  on \`ReclaimInterval\` ticks to drain residual. A backlog larger than 1000
  rows took multiple ticks (each potentially 30 s apart) to clear. This PR
  promotes the cap into \`runtime/outbox.RelayConfig.ReclaimBatchSize\`
  (default still 1000), pipes it through \`Store.ReclaimStale(...,batchSize)\`,
  and loops \`relay.reclaimStale\` while \`count >= batchSize\` (or ctx is
  cancelled) — the river/job_rescuer pattern.

## Out of scope

- B2-A-04, B2-A-12 (and the metadata half of B2-A-07) shipped in PR#373 —
  not re-touched.
- \`WithReclaimBatchSize\` functional option intentionally NOT added; default
  1000 covers all known scenarios. Adding the option is one line if a tuning
  need ever surfaces.

## Refs

- \`docs/plans/202605011500-029-master-roadmap.md\` Track B B6
- \`docs/backlog2.md\` B2-A-05 / B2-A-06 / B2-A-07 (this PR closes the
  follow-up gaps after the original ~~strikes~~)
- \`ref: ThreeDotsLabs/watermill-sql pkg/sql/schema_adapter_postgresql.go\` —
  100-row baseline informed the 1000 chosen here
- \`ref: riverqueue/river internal/maintenance/job_rescuer.go\` —
  \`count<batch break\` loop pattern
- \`ref: Apache Kafka message.max.bytes default 1 MiB\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` (unit)
- [x] \`go test -tags=integration ./adapters/postgres/...\` covered by the
      existing CI integration job; \`TestPGOutboxStore_ReclaimStale_RespectsBatchLimit\`
      now uses the new caller-supplied \`batchSize\` parameter
- [x] \`golangci-lint run ./...\` (0 issues)
- [x] New archtest gates pass:
      \`OUTBOX-PAYLOAD-SIZE-01-A/B\`, \`OUTBOX-RELAY-LOST-METRIC-01-A/B\`
- [x] Wave A RED commit \`d226be78\` shows tests failing on develop;
      Wave B GREEN commit \`b7014635\` flips them green

🤖 Generated with [Claude Code](https://claude.com/claude-code)