### PR TITLE
feat(ws): PR-V1-SEC-WS-AUTH-ACL — Authenticator + Broadcast filter + token expiry + slow-client evict (B2-W-01/02/06)

### DIFF
--- a/adapters/postgres/outbox_mock_test.go
+++ b/adapters/postgres/outbox_mock_test.go
@@ -143,6 +143,7 @@ func (t *mockRelayTx) Rollback(_ context.Context) error { return nil }
 func (t *mockRelayTx) CopyFrom(_ context.Context, _ pgx.Identifier, _ []string, _ pgx.CopyFromSource) (int64, error) {
 	return 0, nil
 }
+
 func (t *mockRelayTx) SendBatch(_ context.Context, _ *pgx.Batch) pgx.BatchResults {
 	return nil
 }

--- a/adapters/websocket/conn.go
+++ b/adapters/websocket/conn.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coder/websocket"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
 	rtws "github.com/ghbvf/gocell/runtime/websocket"
 )
 
@@ -23,16 +24,26 @@ var _ rtws.Conn = (*Conn)(nil)
 // so it can interrupt an in-flight Write immediately by closing the underlying
 // TCP connection. Write uses mu only to serialize concurrent writes.
 type Conn struct {
-	id   string
-	conn *websocket.Conn
+	id        string
+	principal *auth.Principal
+	conn      *websocket.Conn
 
 	closed atomic.Bool // set once by Close; checked by Write
 	mu     sync.Mutex  // serializes Write calls only
 }
 
-// NewConn creates a Conn wrapping a github.com/coder/websocket connection.
-func NewConn(id string, conn *websocket.Conn) *Conn {
-	return &Conn{id: id, conn: conn}
+// NewConn creates a Conn wrapping a github.com/coder/websocket connection
+// with an authenticated principal bound at handshake time.
+func NewConn(id string, principal *auth.Principal, conn *websocket.Conn) *Conn {
+	return &Conn{id: id, principal: principal, conn: conn}
+}
+
+// Principal returns the authenticated principal bound at handshake time.
+// May be nil only when the adapter is misconstructed; production wiring
+// always supplies a non-nil principal (anonymous endpoints use
+// auth.NewAnonymousAuthenticator which returns PrincipalAnonymous).
+func (c *Conn) Principal() *auth.Principal {
+	return c.principal
 }
 
 func (c *Conn) ID() string { return c.id }

--- a/adapters/websocket/export_test.go
+++ b/adapters/websocket/export_test.go
@@ -1,0 +1,5 @@
+package websocket
+
+// IsClientUpgradeError exposes the unexported isClientUpgradeError function
+// for use in external (package websocket_test) tests.
+var IsClientUpgradeError = isClientUpgradeError

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -19,6 +19,14 @@ import (
 	rtws "github.com/ghbvf/gocell/runtime/websocket"
 )
 
+// upgradeFailedBody is the public response body for any non-401 upgrade
+// failure (hijack-not-supported, websocket.Accept errors). Browser
+// WebSocket APIs cannot read the response body, so the constant is
+// intentionally short — operators rely on slog (logUpgradeFailure) for
+// the structured error / errcode / remote_addr context. 401 paths
+// surface http.StatusText(...) per status code instead of this constant.
+const upgradeFailedBody = "websocket upgrade failed"
+
 // UpgradeConfig configures the WebSocket upgrade handler.
 type UpgradeConfig struct {
 	// AllowedOrigins lists the origin patterns authorized for the upgrade.
@@ -115,7 +123,7 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 		if _, ok := w.(http.Hijacker); !ok {
 			logUpgradeFailure(r, errcode.New(errcode.KindInternal, ErrAdapterWSUpgrade,
 				"websocket: response writer does not support hijack"))
-			http.Error(w, "websocket upgrade failed", http.StatusInternalServerError)
+			http.Error(w, upgradeFailedBody, http.StatusInternalServerError)
 			return
 		}
 		acceptUpgradeAndRegister(w, r, hub, cfg, principal)
@@ -178,9 +186,9 @@ func acceptUpgradeAndRegister(w http.ResponseWriter, r *http.Request, hub *rtws.
 	if err != nil {
 		logUpgradeFailure(r, err)
 		if isClientUpgradeError(err) {
-			http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
+			http.Error(w, upgradeFailedBody, http.StatusBadRequest)
 		} else {
-			http.Error(w, "websocket upgrade failed", http.StatusInternalServerError)
+			http.Error(w, upgradeFailedBody, http.StatusInternalServerError)
 		}
 		return
 	}

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/logutil"
+	"github.com/ghbvf/gocell/runtime/auth"
 	rtws "github.com/ghbvf/gocell/runtime/websocket"
 )
 
@@ -35,6 +36,22 @@ type UpgradeConfig struct {
 	// the slice handed to coder/websocket is the exact one that passed
 	// validation (no trim drift between check and runtime).
 	AllowedOrigins []string
+
+	// Authenticator validates the HTTP request before WebSocket upgrade.
+	// Required (nil → ErrWebsocketAuthenticatorMissing at construction).
+	//
+	// The Authenticator runs BEFORE websocket.Accept; rejection writes a
+	// plain-text 401 directly to the response writer (browser WebSocket APIs
+	// cannot read the response body, so envelope JSON is meaningless).
+	//
+	// Composition root selects one of:
+	//   - auth.NewJWTAuthenticator(verifier)        — token-via-Authorization-header
+	//   - auth.NewContextAuthenticator()            — already authenticated by listener middleware
+	//   - auth.NewAnonymousAuthenticator()          — explicit unauthenticated channel
+	//   - custom auth.AuthenticatorFunc             — query-param / cookie / subprotocol token
+	//
+	// ref: coder/websocket accept.go — http.Error(w, err.Error(), code) before Accept
+	Authenticator auth.Authenticator
 }
 
 // Validate checks that the UpgradeConfig is well-formed and rewrites
@@ -77,12 +94,36 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrWebsocketHubMissing,
 			"websocket: UpgradeHandler hub must not be nil (fail-fast at wire time)")
 	}
+	if cfg.Authenticator == nil {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrWebsocketAuthenticatorMissing,
+			"websocket: UpgradeHandler Authenticator must not be nil (SEC-FAIL-CLOSED); "+
+				"use auth.NewAnonymousAuthenticator() for explicit unauthenticated endpoints")
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !hub.IsRunning() {
 			http.Error(w, "websocket hub not ready", http.StatusServiceUnavailable)
+			return
+		}
+
+		// Authenticate before upgrade (cf. coder/websocket accept.go pattern:
+		// HTTP errors are returned before Accept consumes the handshake bytes).
+		principal, ok, err := cfg.Authenticator.Authenticate(r)
+		if err != nil {
+			slog.Warn("websocket: upgrade rejected — invalid credential",
+				slog.Any("error", err),
+				slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
+			)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if !ok || principal == nil {
+			slog.Warn("websocket: upgrade rejected — credential absent",
+				slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
+			)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
@@ -108,7 +149,7 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 		wsConn.SetReadLimit(hub.Config().ReadLimit)
 
 		connID := "ws-" + uuid.NewString()
-		conn := NewConn(connID, wsConn)
+		conn := NewConn(connID, principal, wsConn)
 
 		remoteAddr := logutil.SafeAddr(r.RemoteAddr)
 		if regErr := hub.Register(r.Context(), conn); regErr != nil {
@@ -122,6 +163,8 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 		slog.Info("websocket: client connected",
 			slog.String("conn_id", connID),
 			slog.String("remote_addr", remoteAddr),
+			slog.String("subject", principal.Subject),
+			slog.String("kind", principal.Kind.String()),
 		)
 	}), nil
 }

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -132,6 +132,8 @@ func authenticateForUpgrade(w http.ResponseWriter, r *http.Request, a auth.Authe
 		slog.Warn("websocket: upgrade rejected — invalid credential",
 			slog.Any("error", err),
 			slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
+			slog.String("path", r.URL.Path),
+			slog.String("error_code", string(errcode.ErrWebsocketUpgradeUnauthenticated)),
 		)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return nil, false
@@ -139,6 +141,8 @@ func authenticateForUpgrade(w http.ResponseWriter, r *http.Request, a auth.Authe
 	if !ok || principal == nil {
 		slog.Warn("websocket: upgrade rejected — credential absent",
 			slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
+			slog.String("path", r.URL.Path),
+			slog.String("error_code", string(errcode.ErrWebsocketUpgradeUnauthenticated)),
 		)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return nil, false
@@ -191,10 +195,41 @@ func MustUpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) http.Handler {
 
 func logUpgradeFailure(r *http.Request, err error) {
 	addr := logutil.SafeAddr(r.RemoteAddr)
-	slog.Error("websocket: upgrade failed",
+	msg := "websocket: upgrade failed"
+	fields := []any{
 		slog.Any("error", err),
 		slog.String("remote_addr", addr),
-	)
+	}
+	if isClientUpgradeError(err) {
+		slog.Warn(msg, fields...)
+		return
+	}
+	slog.Error(msg, fields...)
+}
+
+// isClientUpgradeError reports whether the upgrade failure originated from
+// the client (bad handshake, missing headers, protocol violation). Server-side
+// failures (hijack not supported, internal write errors) stay at Error level.
+func isClientUpgradeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	// coder/websocket Accept returns errors with these substrings for client-side issues.
+	for _, marker := range []string{
+		"websocket protocol violation",
+		"Sec-WebSocket-Key",
+		"Sec-WebSocket-Version",
+		"expected GET method",
+		"request must contain",
+		"request method must be",
+		"Origin",
+	} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 type upgradeAcceptWriter struct {

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -107,66 +107,77 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 			http.Error(w, "websocket hub not ready", http.StatusServiceUnavailable)
 			return
 		}
-
-		// Authenticate before upgrade (cf. coder/websocket accept.go pattern:
-		// HTTP errors are returned before Accept consumes the handshake bytes).
-		principal, ok, err := cfg.Authenticator.Authenticate(r)
-		if err != nil {
-			slog.Warn("websocket: upgrade rejected — invalid credential",
-				slog.Any("error", err),
-				slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
-			)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		principal, ok := authenticateForUpgrade(w, r, cfg.Authenticator)
+		if !ok {
 			return
 		}
-		if !ok || principal == nil {
-			slog.Warn("websocket: upgrade rejected — credential absent",
-				slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
-			)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		opts := &websocket.AcceptOptions{
-			OriginPatterns: cfg.AllowedOrigins,
-		}
-
 		if _, ok := w.(http.Hijacker); !ok {
 			logUpgradeFailure(r, errcode.New(errcode.KindInternal, ErrAdapterWSUpgrade,
 				"websocket: response writer does not support hijack"))
 			http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
 			return
 		}
-
-		acceptWriter := newUpgradeAcceptWriter(w)
-		wsConn, err := websocket.Accept(acceptWriter, r, opts)
-		if err != nil {
-			logUpgradeFailure(r, err)
-			http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
-			return
-		}
-
-		wsConn.SetReadLimit(hub.Config().ReadLimit)
-
-		connID := "ws-" + uuid.NewString()
-		conn := NewConn(connID, principal, wsConn)
-
-		remoteAddr := logutil.SafeAddr(r.RemoteAddr)
-		if regErr := hub.Register(r.Context(), conn); regErr != nil {
-			_ = wsConn.Close(websocket.StatusNormalClosure, "registration rejected")
-			slog.Warn("websocket: register rejected",
-				slog.Any("error", regErr),
-				slog.String("remote_addr", remoteAddr),
-			)
-			return
-		}
-		slog.Info("websocket: client connected",
-			slog.String("conn_id", connID),
-			slog.String("remote_addr", remoteAddr),
-			slog.String("subject", principal.Subject),
-			slog.String("kind", principal.Kind.String()),
-		)
+		acceptUpgradeAndRegister(w, r, hub, cfg, principal)
 	}), nil
+}
+
+// authenticateForUpgrade runs cfg.Authenticator on the request. On absent or
+// invalid credentials it writes a plain-text 401 response and returns false;
+// the caller (UpgradeHandler) then short-circuits without calling
+// websocket.Accept. cf. coder/websocket accept.go: HTTP errors are returned
+// before Accept consumes the handshake bytes.
+func authenticateForUpgrade(w http.ResponseWriter, r *http.Request, a auth.Authenticator) (*auth.Principal, bool) {
+	principal, ok, err := a.Authenticate(r)
+	if err != nil {
+		slog.Warn("websocket: upgrade rejected — invalid credential",
+			slog.Any("error", err),
+			slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
+		)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return nil, false
+	}
+	if !ok || principal == nil {
+		slog.Warn("websocket: upgrade rejected — credential absent",
+			slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
+		)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return nil, false
+	}
+	return principal, true
+}
+
+// acceptUpgradeAndRegister performs the WebSocket upgrade and hub registration
+// after authentication has already succeeded. principal is bound to the
+// resulting Conn.
+func acceptUpgradeAndRegister(w http.ResponseWriter, r *http.Request, hub *rtws.Hub, cfg UpgradeConfig, principal *auth.Principal) {
+	opts := &websocket.AcceptOptions{OriginPatterns: cfg.AllowedOrigins}
+	acceptWriter := newUpgradeAcceptWriter(w)
+	wsConn, err := websocket.Accept(acceptWriter, r, opts)
+	if err != nil {
+		logUpgradeFailure(r, err)
+		http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
+		return
+	}
+	wsConn.SetReadLimit(hub.Config().ReadLimit)
+
+	connID := "ws-" + uuid.NewString()
+	conn := NewConn(connID, principal, wsConn)
+
+	remoteAddr := logutil.SafeAddr(r.RemoteAddr)
+	if regErr := hub.Register(r.Context(), conn); regErr != nil {
+		_ = wsConn.Close(websocket.StatusNormalClosure, "registration rejected")
+		slog.Warn("websocket: register rejected",
+			slog.Any("error", regErr),
+			slog.String("remote_addr", remoteAddr),
+		)
+		return
+	}
+	slog.Info("websocket: client connected",
+		slog.String("conn_id", connID),
+		slog.String("remote_addr", remoteAddr),
+		slog.String("subject", principal.Subject),
+		slog.String("kind", principal.Kind.String()),
+	)
 }
 
 // MustUpgradeHandler is the static-wiring variant of UpgradeHandler.

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -114,7 +114,7 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 		if _, ok := w.(http.Hijacker); !ok {
 			logUpgradeFailure(r, errcode.New(errcode.KindInternal, ErrAdapterWSUpgrade,
 				"websocket: response writer does not support hijack"))
-			http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
+			http.Error(w, "websocket upgrade failed", http.StatusInternalServerError)
 			return
 		}
 		acceptUpgradeAndRegister(w, r, hub, cfg, principal)
@@ -159,7 +159,11 @@ func acceptUpgradeAndRegister(w http.ResponseWriter, r *http.Request, hub *rtws.
 	wsConn, err := websocket.Accept(acceptWriter, r, opts)
 	if err != nil {
 		logUpgradeFailure(r, err)
-		http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
+		if isClientUpgradeError(err) {
+			http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
+		} else {
+			http.Error(w, "websocket upgrade failed", http.StatusInternalServerError)
+		}
 		return
 	}
 	wsConn.SetReadLimit(hub.Config().ReadLimit)

--- a/adapters/websocket/handler.go
+++ b/adapters/websocket/handler.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"bufio"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -121,21 +122,38 @@ func UpgradeHandler(hub *rtws.Hub, cfg UpgradeConfig) (http.Handler, error) {
 	}), nil
 }
 
-// authenticateForUpgrade runs cfg.Authenticator on the request. On absent or
-// invalid credentials it writes a plain-text 401 response and returns false;
-// the caller (UpgradeHandler) then short-circuits without calling
-// websocket.Accept. cf. coder/websocket accept.go: HTTP errors are returned
-// before Accept consumes the handshake bytes.
+// authenticateForUpgrade runs cfg.Authenticator on the request. On rejection
+// it writes a plain-text HTTP error and returns false; the caller
+// (UpgradeHandler) then short-circuits without calling websocket.Accept. cf.
+// coder/websocket accept.go: HTTP errors are returned before Accept consumes
+// the handshake bytes.
+//
+// Status code derivation (RFC 9110):
+//
+//   - absent credential (ok=false, err=nil)                              → 401
+//   - invalid credential, errcode.Kind=Unauthenticated (default for auth) → 401
+//   - invalid credential, errcode.Kind=PermissionDenied                  → 403
+//   - other errcode.Kind                                                  → derived via Kind.Status()
+//
+// errcode.Kind is the single source for HTTP status (Kind.Status()); body is
+// always plain text because browser WebSocket APIs cannot read the response
+// body, so envelope JSON would be unobservable to clients.
 func authenticateForUpgrade(w http.ResponseWriter, r *http.Request, a auth.Authenticator) (*auth.Principal, bool) {
 	principal, ok, err := a.Authenticate(r)
 	if err != nil {
+		status := http.StatusUnauthorized
+		var ec *errcode.Error
+		if errors.As(err, &ec) {
+			status = ec.Kind.Status()
+		}
 		slog.Warn("websocket: upgrade rejected — invalid credential",
 			slog.Any("error", err),
 			slog.String("remote_addr", logutil.SafeAddr(r.RemoteAddr)),
 			slog.String("path", r.URL.Path),
 			slog.String("error_code", string(errcode.ErrWebsocketUpgradeUnauthenticated)),
+			slog.Int("status", status),
 		)
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		http.Error(w, http.StatusText(status), status)
 		return nil, false
 	}
 	if !ok || principal == nil {
@@ -144,7 +162,7 @@ func authenticateForUpgrade(w http.ResponseWriter, r *http.Request, a auth.Authe
 			slog.String("path", r.URL.Path),
 			slog.String("error_code", string(errcode.ErrWebsocketUpgradeUnauthenticated)),
 		)
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return nil, false
 	}
 	return principal, true

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -411,7 +411,10 @@ func TestUpgradeHandler_RejectsEmptyOrigins(t *testing.T) {
 	t.Run("empty origins — expect construction error with *errcode.Error", func(t *testing.T) {
 		hub := rtws.NewHub(cfg, nil)
 
-		handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{AllowedOrigins: nil})
+		handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+			AllowedOrigins: nil,
+			Authenticator:  testAuth(),
+		})
 		require.Error(t, err)
 		assert.Nil(t, handler)
 		var ec *errcode.Error
@@ -493,6 +496,7 @@ func TestUpgradeHandler_RejectsWildcardOrigin(t *testing.T) {
 
 	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"*"},
+		Authenticator:  testAuth(),
 	})
 	require.Error(t, err)
 	assert.Nil(t, handler)
@@ -507,6 +511,7 @@ func TestMustUpgradeHandler_PanicsOnInvalidConfig(t *testing.T) {
 	require.Panics(t, func() {
 		_ = adapterws.MustUpgradeHandler(hub, adapterws.UpgradeConfig{
 			AllowedOrigins: []string{"*"},
+			Authenticator:  testAuth(),
 		})
 	})
 }
@@ -522,6 +527,7 @@ func TestUpgradeHandler_RejectsBareHostOrigin(t *testing.T) {
 
 	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"example.com"},
+		Authenticator:  testAuth(),
 	})
 	require.Error(t, err)
 	assert.Nil(t, handler)

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -2,6 +2,7 @@ package websocket_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -141,7 +142,7 @@ func TestUpgradeHandler_UpgradeFailureResponseIsPublic(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 	assert.Equal(t, "websocket upgrade failed\n", string(body))
 	assert.NotContains(t, string(body), "ERR_ADAPTER_WS_UPGRADE")
 	assert.NotContains(t, string(body), "websocket: the client is not using the websocket protocol")
@@ -175,7 +176,7 @@ func TestUpgradeHandler_NonHijackerFailsBeforeAccept(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Equal(t, "websocket upgrade failed\n", rr.Body.String())
 	assert.NotEqual(t, http.StatusSwitchingProtocols, rr.Code)
 }
@@ -741,4 +742,64 @@ func TestUpgradeHandler_401_ResponseIsPlainText(t *testing.T) {
 	body := rr.Body.String()
 	assert.NotContains(t, body, "{")
 	assert.NotContains(t, body, "ERR_")
+}
+
+// TestUpgradeHandler_HijackerNotSupported_Returns500 locks server-side
+// error semantics: a response writer without Hijacker support is a
+// runtime/server-side misconfiguration, not a client protocol violation,
+// so it must surface as 500 rather than 400. (PR-V1-SEC-WS-AUTH-ACL review
+// round 2 #P2-2.)
+func TestUpgradeHandler_HijackerNotSupported_Returns500(t *testing.T) {
+	cfg := rtws.DefaultHubConfig(clock.Real())
+	cfg.PingInterval = testtime.SlowPoll
+	hub := rtws.NewHub(cfg, nil)
+
+	startErr := make(chan error, 1)
+	go func() { startErr <- hub.Start(context.Background()) }()
+	require.Eventually(t, hub.IsRunning, testtime.D2s, time.Millisecond)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
+		defer cancel()
+		_ = hub.Stop(ctx)
+		<-startErr
+	})
+
+	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		Authenticator:  testAuth(),
+	})
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "websocket upgrade failed\n", rr.Body.String())
+}
+
+// TestIsClientUpgradeError_Classification table-drives the heuristic that
+// drives 4xx vs 5xx response branching. (PR-V1-SEC-WS-AUTH-ACL review
+// round 2 #P2-2.)
+func TestIsClientUpgradeError_Classification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"protocol violation", errors.New("websocket protocol violation: bad opcode"), true},
+		{"missing Sec-WebSocket-Key", errors.New("Sec-WebSocket-Key header missing"), true},
+		{"unexpected method", errors.New("expected GET method, got POST"), true},
+		{"origin denied", errors.New("Origin header not in allow-list"), true},
+		{"server transient", errors.New("write tcp: broken pipe"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := adapterws.IsClientUpgradeError(tc.err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -22,8 +22,21 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	authpkg "github.com/ghbvf/gocell/runtime/auth"
 	rtws "github.com/ghbvf/gocell/runtime/websocket"
 )
+
+// stubAlwaysAllowAuth returns the supplied principal unconditionally.
+type stubAlwaysAllowAuth struct{ p *authpkg.Principal }
+
+func (s *stubAlwaysAllowAuth) Authenticate(_ *http.Request) (*authpkg.Principal, bool, error) {
+	return s.p, true, nil
+}
+
+// testAuth is a convenience helper that returns a stubAlwaysAllowAuth for tests.
+func testAuth() *stubAlwaysAllowAuth {
+	return &stubAlwaysAllowAuth{p: &authpkg.Principal{Kind: authpkg.PrincipalUser, Subject: "test"}}
+}
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
@@ -62,6 +75,7 @@ func setupTestHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, *httpte
 	// Use explicit AllowedOrigins; empty origins will be rejected after SEC-FAIL-CLOSED-04.
 	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"http://*"},
+		Authenticator:  testAuth(),
 	}))
 
 	server := httptest.NewServer(mux)
@@ -150,6 +164,7 @@ func TestUpgradeHandler_NonHijackerFailsBeforeAccept(t *testing.T) {
 
 	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"http://*"},
+		Authenticator:  testAuth(),
 	})
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
 	req.Header.Set("Connection", "Upgrade")
@@ -177,53 +192,6 @@ func TestHub_RegisterUnregister(t *testing.T) {
 	}, testtime.D2s, testtime.D10ms)
 }
 
-func TestHub_Broadcast(t *testing.T) {
-	var (
-		mu       sync.Mutex
-		received []string
-	)
-
-	hub, server := setupTestHub(t, nil)
-	defer server.Close()
-
-	conn1 := dialWS(t, server.URL)
-	conn2 := dialWS(t, server.URL)
-
-	require.Eventually(t, func() bool {
-		return hub.ConnCount() == 2
-	}, testtime.D2s, testtime.D10ms)
-
-	hub.Broadcast(context.Background(), []byte("hello all"))
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	readMsg := func(c *websocket.Conn) {
-		defer wg.Done()
-		ctx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
-		defer cancel()
-
-		_, data, err := c.Read(ctx)
-		if err != nil {
-			t.Logf("read error: %v", err)
-			return
-		}
-		mu.Lock()
-		received = append(received, string(data))
-		mu.Unlock()
-	}
-
-	go readMsg(conn1)
-	go readMsg(conn2)
-	wg.Wait()
-
-	mu.Lock()
-	assert.Len(t, received, 2)
-	for _, msg := range received {
-		assert.Equal(t, "hello all", msg)
-	}
-	mu.Unlock()
-}
 
 func TestHub_MessageHandler(t *testing.T) {
 	var (
@@ -355,6 +323,7 @@ func TestUpgradeHandler_AllowedOrigins(t *testing.T) {
 
 	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"http://*"},
+		Authenticator:  testAuth(),
 	})
 
 	assert.NotNil(t, handler)
@@ -371,7 +340,7 @@ func TestHub_FullLifecycle(t *testing.T) {
 	}, testtime.D2s, testtime.D10ms)
 
 	// Broadcast.
-	hub.Broadcast(context.Background(), []byte("lifecycle"))
+	require.NoError(t, hub.BroadcastFilter(context.Background(), []byte("lifecycle"), func(rtws.Conn) bool { return true }))
 	readCtx, readCancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer readCancel()
 	_, data, err := conn.Read(readCtx)
@@ -420,6 +389,7 @@ func TestUpgradeHandler_HubNotRunning_503(t *testing.T) {
 	// AllowedOrigins is required post-SEC-FAIL-CLOSED-04; use a valid value.
 	handler := requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"http://*"},
+		Authenticator:  testAuth(),
 	})
 
 	// Use ResponseRecorder — no TCP needed, no sandbox issue.
@@ -456,6 +426,7 @@ func TestUpgradeHandler_RejectsEmptyOrigins(t *testing.T) {
 
 		handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
 			AllowedOrigins: []string{"http://*"},
+			Authenticator:  testAuth(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, handler)
@@ -469,6 +440,7 @@ func TestUpgradeHandler_RejectsEmptyOrigins(t *testing.T) {
 func TestUpgradeHandler_RejectsNilHub(t *testing.T) {
 	handler, err := adapterws.UpgradeHandler(nil, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"http://*"},
+		Authenticator:  testAuth(),
 	})
 
 	require.Error(t, err)
@@ -494,6 +466,7 @@ func TestMustUpgradeHandler_PanicsOnNilHub(t *testing.T) {
 	}()
 	_ = adapterws.MustUpgradeHandler(nil, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"http://*"},
+		Authenticator:  testAuth(),
 	})
 	t.Fatal("expected MustUpgradeHandler to panic, got none")
 }
@@ -623,6 +596,7 @@ func TestUpgradeHandler_DisallowedOrigin_HandshakeRejected(t *testing.T) {
 	// Narrow allow-list: only http://*.allowed.test is permitted.
 	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
 		AllowedOrigins: []string{"http://*.allowed.test"},
+		Authenticator:  testAuth(),
 	}))
 	server := httptest.NewServer(mux)
 	defer server.Close()
@@ -636,4 +610,128 @@ func TestUpgradeHandler_DisallowedOrigin_HandshakeRejected(t *testing.T) {
 	}
 	assert.Equal(t, 0, hub.ConnCount(),
 		"hub must not register a connection rejected at handshake")
+}
+
+// TestUpgradeHandler_RejectsNilAuthenticator locks fail-fast at composition.
+func TestUpgradeHandler_RejectsNilAuthenticator(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
+	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		// Authenticator: nil — explicit
+	})
+	require.Error(t, err)
+	assert.Nil(t, handler)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrWebsocketAuthenticatorMissing, ec.Code)
+}
+
+func TestMustUpgradeHandler_PanicsOnNilAuthenticator(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
+	require.Panics(t, func() {
+		_ = adapterws.MustUpgradeHandler(hub, adapterws.UpgradeConfig{
+			AllowedOrigins: []string{"http://*"},
+		})
+	})
+}
+
+// stubDenyingAuth returns absent (no credential).
+type stubDenyingAuth struct{}
+
+func (stubDenyingAuth) Authenticate(_ *http.Request) (*authpkg.Principal, bool, error) {
+	return nil, false, nil
+}
+
+// stubFailingAuth returns invalid credential error.
+type stubFailingAuth struct{}
+
+func (stubFailingAuth) Authenticate(_ *http.Request) (*authpkg.Principal, bool, error) {
+	return nil, false, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "bad token")
+}
+
+func TestUpgradeHandler_AbsentCredential_Returns401(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
+	startErr := make(chan error, 1)
+	go func() { startErr <- hub.Start(context.Background()) }()
+	require.Eventually(t, hub.IsRunning, testtime.D2s, time.Millisecond)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
+		defer cancel()
+		_ = hub.Stop(ctx)
+		<-startErr
+	})
+
+	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		Authenticator:  stubDenyingAuth{},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, 0, hub.ConnCount(), "hub must not register unauthenticated conn")
+}
+
+func TestUpgradeHandler_InvalidCredential_Returns401(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
+	startErr := make(chan error, 1)
+	go func() { startErr <- hub.Start(context.Background()) }()
+	require.Eventually(t, hub.IsRunning, testtime.D2s, time.Millisecond)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
+		defer cancel()
+		_ = hub.Stop(ctx)
+		<-startErr
+	})
+
+	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		Authenticator:  stubFailingAuth{},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, 0, hub.ConnCount())
+}
+
+// 401 response body should be plain text (browser WS API can't read body anyway).
+func TestUpgradeHandler_401_ResponseIsPlainText(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
+	startErr := make(chan error, 1)
+	go func() { startErr <- hub.Start(context.Background()) }()
+	require.Eventually(t, hub.IsRunning, testtime.D2s, time.Millisecond)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
+		defer cancel()
+		_ = hub.Stop(ctx)
+		<-startErr
+	})
+
+	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		Authenticator:  stubDenyingAuth{},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	body := rr.Body.String()
+	assert.NotContains(t, body, "{")
+	assert.NotContains(t, body, "ERR_")
 }

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -717,6 +717,46 @@ func TestUpgradeHandler_InvalidCredential_Returns401(t *testing.T) {
 	assert.Equal(t, 0, hub.ConnCount())
 }
 
+// stubForbiddenAuth returns a credential whose errcode.Kind is PermissionDenied,
+// representing "credential present and valid but caller is not authorized" —
+// must surface as 403, not 401 (RFC 9110 §15.5.4).
+type stubForbiddenAuth struct{}
+
+func (stubForbiddenAuth) Authenticate(_ *http.Request) (*authpkg.Principal, bool, error) {
+	return nil, false, errcode.New(errcode.KindPermissionDenied, errcode.ErrAuthForbidden,
+		"caller cell not in allowlist")
+}
+
+// TestUpgradeHandler_ForbiddenCredential_Returns403 locks the kind-driven
+// status: an Authenticator returning errcode.KindPermissionDenied must surface
+// as 403, distinct from the 401 path used for absent or invalid credentials.
+// Status is derived via errcode.Kind.Status() — single source.
+func TestUpgradeHandler_ForbiddenCredential_Returns403(t *testing.T) {
+	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
+	startErr := make(chan error, 1)
+	go func() { startErr <- hub.Start(context.Background()) }()
+	require.Eventually(t, hub.IsRunning, testtime.D2s, time.Millisecond)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
+		defer cancel()
+		_ = hub.Stop(ctx)
+		<-startErr
+	})
+
+	handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		Authenticator:  stubForbiddenAuth{},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Equal(t, 0, hub.ConnCount())
+}
+
 // 401 response body should be plain text (browser WS API can't read body anyway).
 func TestUpgradeHandler_401_ResponseIsPlainText(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -192,7 +192,6 @@ func TestHub_RegisterUnregister(t *testing.T) {
 	}, testtime.D2s, testtime.D10ms)
 }
 
-
 func TestHub_MessageHandler(t *testing.T) {
 	var (
 		mu         sync.Mutex
@@ -641,11 +640,13 @@ func TestMustUpgradeHandler_PanicsOnNilAuthenticator(t *testing.T) {
 	})
 }
 
-// stubDenyingAuth returns absent (no credential).
+// stubDenyingAuth returns absent (no credential). The (nil, false, nil) shape
+// is the documented "absent credential" outcome of the Authenticator contract;
+// the linter complaint is a false positive for this stub.
 type stubDenyingAuth struct{}
 
 func (stubDenyingAuth) Authenticate(_ *http.Request) (*authpkg.Principal, bool, error) {
-	return nil, false, nil
+	return nil, false, nil //nolint:nilnil // Authenticator absent-credential contract
 }
 
 // stubFailingAuth returns invalid credential error.

--- a/adapters/websocket/integration_test.go
+++ b/adapters/websocket/integration_test.go
@@ -16,11 +16,18 @@ import (
 	adapterws "github.com/ghbvf/gocell/adapters/websocket"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	authpkg "github.com/ghbvf/gocell/runtime/auth"
 	rtws "github.com/ghbvf/gocell/runtime/websocket"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type stubIntegrationAuth struct{ p *authpkg.Principal }
+
+func (s *stubIntegrationAuth) Authenticate(_ *http.Request) (*authpkg.Principal, bool, error) {
+	return s.p, true, nil
+}
 
 // setupIntegrationHub creates a running Hub + httptest server for integration tests.
 func setupIntegrationHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, *httptest.Server) {
@@ -41,6 +48,7 @@ func setupIntegrationHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, 
 		// suite exercises coder/websocket's OriginPatterns matcher; bare host
 		// would never match the Origin header that dialIntegrationWS sends.
 		AllowedOrigins: []string{"http://*"},
+		Authenticator:  &stubIntegrationAuth{p: &authpkg.Principal{Kind: authpkg.PrincipalUser, Subject: "integration-user"}},
 	}))
 	server := httptest.NewServer(mux)
 
@@ -140,7 +148,7 @@ func TestIntegration_BroadcastMultipleClients(t *testing.T) {
 		return hub.ConnCount() == numClients
 	}, testtime.D2s, testtime.D10ms)
 
-	hub.Broadcast(context.Background(), []byte("broadcast msg"))
+	require.NoError(t, hub.BroadcastFilter(context.Background(), []byte("broadcast msg"), func(rtws.Conn) bool { return true }))
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex

--- a/docs/backlog2.md
+++ b/docs/backlog2.md
@@ -39,8 +39,8 @@
 |---|---|---|---|---|---|
 | ~~**B2-A-01**~~ | ~~POSTGRES-OUTBOX-CLAIM-FENCING-MISSING~~ | ✅ **closed fix/221-pg-outbox-fencing** — `lease_id UUID` 列 + 五个 CAS SQL 全部 `AND lease_id = $N`；ClaimedEntry.LeaseID 透传；archtest OUTBOX-LEASE-ID-CAS-01 静态守卫；ADR `docs/architecture/202605051600-adr-pg-outbox-fencing.md` | — | — |
 | **B2-C-01** | **AUDITCORE-HASHCHAIN-RESTART-RECOVERY-MISSING** | `cells/auditcore/internal/domain/hashchain.go:31` + `cells/auditcore/cell.go` | `NewHashChain` 启动从空链开始，`initSlices` 未从 repo 恢复尾节点；多实例或重启后尾哈希不连续，链完整性无法验证；合规审计致命。**修复**：cell 启动时从 repo `SELECT last hash` 注入；考虑 leader 单写或全局 advisory lock。 | Cx4 | MD-02 |
-| **B2-W-01** | **WEBSOCKET-UPGRADE-NO-AUTH-FAIL-OPEN** | `adapters/websocket/handler.go:51-65` | `UpgradeHandler` 升级后无 token / credential 校验，任意客户端可建立 WS 连接 → hub。**修复**：升级前必填 `auth.AuthMiddleware` 等价校验；构造期注入 Authenticator 接口；空 Authenticator fail-fast。 | Cx4 | MD-03 |
-| **B2-W-02** | **WEBSOCKET-BROADCAST-NO-ACL** | `runtime/websocket/hub.go:405-420` | `Broadcast` 无 filter 参数；所有连接均可收到广播；多租户场景下信息越界。**修复**：Broadcast 接受 `func(conn) bool` filter 或 topic-scoped Send；hub 维护 `principal -> conn[]` 映射。 | Cx4 | MD-04 |
+| ~~**B2-W-01**~~ | ~~WEBSOCKET-UPGRADE-NO-AUTH-FAIL-OPEN~~ | ✅ **closed PR-V1-SEC-WS-AUTH-ACL** — UpgradeConfig.Authenticator 必填（nil → ErrWebsocketAuthenticatorMissing）；构造期 fail-fast；archtest SEC-07 静态守卫所有 UpgradeConfig 字面量必须声明 Authenticator | — | — |
+| ~~**B2-W-02**~~ | ~~WEBSOCKET-BROADCAST-NO-ACL~~ | ✅ **closed PR-V1-SEC-WS-AUTH-ACL** — 删除无参 Broadcast；新增 BroadcastFilter（filter 必填，O(N)）+ BroadcastToSubject（O(1) subject index）；Hub 维护 subjectIdx；archtest SEC-08/09 静态守卫 | — | — |
 | **B2-A-02** | **RMQ-RECONNECT-PERMANENT-ERROR-NO-TERMINAL** | `adapters/rabbitmq/connection.go:436-670` | `reconnectLoop` 注释承认"keep trying"，认证失败 / Vhost not found 等永久错误也无限重试，readiness 持续挂起；凭证撤销后 pod 永不退出。**修复**：分类 amqp.Error code（403/404/530 等永久），permanent 时关 conn → readyz 503 → 容器重启拉新凭证。 | Cx4 | MD-05 |
 | **B2-A-03** | **REDIS-CLUSTER-MODE-MISSING** | `adapters/redis/client.go:30-45` | `Config.Mode` 只支持 `standalone` / `sentinel`，无法接入 AWS ElastiCache Cluster / Azure Cache Cluster；生产部署受限。**修复**：新增 `ModeCluster`，使用 `redis.NewClusterClient`；DistLock / Idempotency 算法需重新评估 cluster slot 影响（hashtag）。 | Cx4 | MD-37 |
 | **B2-C-02** | **SETUP-ADMIN-PUBLIC-ROUTE-PERMANENT** | `cells/accesscore/cell_routes.go:73` + `slices/setup/handler.go:46-58` + `contracts/http/auth/setup/admin/v1/contract.yaml:5` | setup 端点常驻 `Public: true`；contract 标 `lifecycle: active`；410 Gone 仅在 admin 已存在时返回，未初始化窗口仍可被匿名首管抢注；多视角共识根因。**修复**：移到 `/internal/v1/setup/`（service-token only）+ contract `lifecycle: bootstrap`，或一次性 bootstrap token（env 注入消费）。`A26-R2` 限速只是缓解。 | Cx3 | CL-06 / LY-06 / PR-01 / PR-02 / PR-07 |
@@ -148,12 +148,12 @@
 
 | # | 标题 | 严重度 | 文件:行 | 描述 | Cx |
 |---|---|---|---|---|---|
-| **B2-W-01** | (P0) UPGRADE-NO-AUTH | — | — | 见 §1 B2-W-01 | — |
-| **B2-W-02** | (P0) BROADCAST-NO-ACL | — | — | 见 §1 B2-W-02 | — |
+| ~~**B2-W-01**~~ | ~~(P0) UPGRADE-NO-AUTH~~ | — | ✅ closed PR-V1-SEC-WS-AUTH-ACL — 见 §1 B2-W-01 | — | — |
+| ~~**B2-W-02**~~ | ~~(P0) BROADCAST-NO-ACL~~ | — | ✅ closed PR-V1-SEC-WS-AUTH-ACL — 见 §1 B2-W-02 | — | — |
 | **B2-W-03** | WS-OBSERVABILITY-MISSING | P1 | `runtime/websocket/hub.go` | 无 Prometheus 指标 / 连接生命周期追踪；连接数 / 消息率 / 错误 / 慢 client 全黑盒。**修复**：注入 metrics provider，暴露 `ws_connections{cell}` `ws_messages_total{direction,outcome}` `ws_send_duration_seconds`。 | Cx2 |
 | **B2-W-04** | WS-MESSAGE-BUFFER-UNBOUNDED | P1 | `runtime/websocket/hub.go:510` | 慢连接导致 Broadcast 发送端 channel 缓冲无上限；OOM 风险。**修复**：每连接 sendCh 加 cap（默认 64），满则 drop oldest 或断连接 + slog.Warn。 | Cx2 |
 | **B2-W-05** | WS-STOP-SYNC-CLOSE-ALL-CONNS | P1 | `runtime/websocket/hub.go:280-293` | Stop 时逐连接同步 Close；千连接场景下 Pod terminationGracePeriod 容易超时。**修复**：广播 close frame 后 fan-out goroutine 池 + 总 deadline；超时强制 conn.Close(）。 | Cx2 |
-| **B2-W-06** | WS-DOC-MISSING | P1 | `docs/guides/`（缺失） | 无入门文档 / 协议规范 / 常见陷阱（origin / 心跳 / 重连）；外部接入者全靠读源码。**修复**：`docs/guides/websocket-integration.md`，含 origin 配置 / 心跳协议 / 重连退避 / 故障注入。 | Cx2 |
+| ~~**B2-W-06**~~ | ~~WS-DOC-MISSING~~ | ✅ closed PR-V1-SEC-WS-AUTH-ACL | `docs/guides/websocket-integration.md` 新增（9节：架构/Origin配置/认证/心跳/重连/广播/驱逐/故障注入/运维参数表） | — | — |
 
 ---
 

--- a/docs/guides/websocket-integration.md
+++ b/docs/guides/websocket-integration.md
@@ -109,7 +109,13 @@ authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, 
     if err != nil {
         return nil, false, err
     }
-    return claims.Principal(), true, nil
+    return &auth.Principal{
+        Kind:       auth.PrincipalUser,
+        Subject:    claims.Subject,
+        Roles:      claims.Roles,
+        AuthMethod: "jwt",
+        ExpiresAt:  claims.ExpiresAt,
+    }, true, nil
 })
 ```
 
@@ -127,7 +133,13 @@ authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, 
     if err != nil {
         return nil, false, err
     }
-    return claims.Principal(), true, nil
+    return &auth.Principal{
+        Kind:       auth.PrincipalUser,
+        Subject:    claims.Subject,
+        Roles:      claims.Roles,
+        AuthMethod: "jwt",
+        ExpiresAt:  claims.ExpiresAt,
+    }, true, nil
 })
 ```
 
@@ -349,14 +361,14 @@ func broadcastToCell(hub *rtws.Hub, cellID string, event []byte) error {
 `runtime/websocket/hub_test.go` 提供 `fakeConn` 参考实现：
 
 ```go
-// 正常连接
-conn := newFakeConn("conn-1", &auth.Principal{Subject: "user-1"})
+// 正常连接（principal 在握手时快照到 connEntry.subject/expiresAt）
+conn := newFakeConnWithPrincipal("conn-1", &auth.Principal{Kind: auth.PrincipalUser, Subject: "user-1"})
 require.NoError(t, hub.Register(ctx, conn))
 
-// 阻塞连接（模拟慢客户端）
-conn := newBlockingFakeConn("slow-1", &auth.Principal{Subject: "slow"})
-require.NoError(t, hub.Register(ctx, conn))
-// 触发 BroadcastFilter 后，conn 的 send buffer 满 → 驱逐
+// 阻塞连接（模拟慢客户端，writeLoop 永远阻塞 → send buffer 满后驱逐）
+slow := newBlockingFakeConn("slow-1", &auth.Principal{Kind: auth.PrincipalUser, Subject: "slow"})
+require.NoError(t, hub.Register(ctx, slow))
+// 触发 BroadcastFilter 后，conn 的 send buffer 满 → 驱逐（reason="send_buffer_full"）
 ```
 
 ### clockmock 推进 token 过期
@@ -368,10 +380,11 @@ clk := clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 hub := rtws.NewHub(rtws.DefaultHubConfig(clk), nil)
 
 p := &auth.Principal{
+    Kind:      auth.PrincipalUser,
     Subject:   "user-1",
     ExpiresAt: clk.Now().Add(5 * time.Minute),
 }
-conn := newFakeConn("conn-1", p)
+conn := newFakeConnWithPrincipal("conn-1", p)
 require.NoError(t, hub.Register(ctx, conn))
 
 // 推进时钟，超过 token 过期时间

--- a/docs/guides/websocket-integration.md
+++ b/docs/guides/websocket-integration.md
@@ -1,0 +1,357 @@
+# WebSocket 集成指南
+
+> 适用版本：GoCell v1.0（PR-V1-SEC-WS-AUTH-ACL）
+
+---
+
+## 1. 架构概览
+
+```
+HTTP 请求
+    │
+    ▼
+adapters/websocket.UpgradeHandler   — transport 层
+    ├─ Authenticate (before Accept)
+    ├─ websocket.Accept (coder/websocket)
+    └─ hub.Register(conn)
+            │
+            ▼
+    runtime/websocket.Hub            — 应用层
+        ├─ connMu + conns map
+        ├─ subjectIdx (O(1) subject → conns)
+        ├─ pingLoop (goroutine)
+        └─ per-conn readLoop + writeLoop (goroutines)
+```
+
+**职责边界**：
+
+| 层 | 包 | 职责 |
+|---|---|---|
+| Transport | `adapters/websocket` | HTTP 升级、Origin 校验、认证、conn 封装 |
+| 应用层 | `runtime/websocket` | 连接生命周期、心跳驱逐、广播路由 |
+
+`adapters/websocket` 依赖 `coder/websocket` 处理帧协议；`runtime/websocket.Hub` 不了解 transport 细节，只与 `Conn` 接口交互。
+
+---
+
+## 2. Origin 配置
+
+`UpgradeConfig.AllowedOrigins` 是安全关键字段：
+
+```go
+cfg := adapterws.UpgradeConfig{
+    AllowedOrigins: []string{
+        "https://app.example.com",
+        "https://*.example.com",   // wildcard 仅限 host 一段
+    },
+    Authenticator: auth.NewContextAuthenticator(),
+}
+handler, err := adapterws.UpgradeHandler(hub, cfg)
+```
+
+规则：
+
+- **必填非空**：空 slice → `errcode.ErrWebsocketOriginsMissing`，构造时失败。
+- **scheme 必填**：`"example.com"` 无 scheme 被拒（`errcode.ErrWebsocketOriginsInvalid`）；浏览器 Origin header 始终含 scheme，裸 host 永远不会匹配。
+- **禁止全通配符 `"*"`**：明确拒绝，拒绝路由到 `errcode.ErrWebsocketOriginsInvalid`。
+- **Wildcard 只作 host 一段**：`"https://*.example.com"` 合法；`"https://**"` 语义不明，避免使用。
+
+---
+
+## 3. 认证集成
+
+`UpgradeConfig.Authenticator` 必填（nil → `errcode.ErrWebsocketAuthenticatorMissing`）。认证在 `websocket.Accept` 之前执行；认证失败直接写 `401 Unauthorized` 明文响应（浏览器 WebSocket API 无法读响应 body，JSON envelope 无意义）。
+
+### 3.1 三种内置方式
+
+#### Bearer token via Authorization header
+
+```go
+// 适合：服务端直连（curl、native app、后端 worker）
+// 限制：浏览器 JS WebSocket API 无法设置 Authorization header
+authenticator := auth.NewJWTAuthenticator(verifier)
+```
+
+#### listener middleware 已鉴权后透传（推荐 `/api/v1/*`）
+
+```go
+// 适合：WebSocket 路由挂载在已有 JWT listener 上
+// Principal 由 listener JWT middleware 写入 ctx，Authenticator 读出
+authenticator := auth.NewContextAuthenticator()
+```
+
+WebSocket handler 注册在 PrimaryListener 时优先选此方式：listener 已做 JWT 校验，避免重复验签。
+
+#### 显式无认证（broadcast-only 频道）
+
+```go
+// 适合：只推送公开数据（公告频道、行情推送）的 hub
+// 必须显式声明，不可用 nil 代替
+authenticator := auth.NewAnonymousAuthenticator()
+```
+
+### 3.2 自定义 AuthenticatorFunc
+
+浏览器 JS `WebSocket` API 不支持设置 `Authorization` header，常见替代方式：
+
+#### a. Query-param token
+
+```go
+authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, bool, error) {
+    token := r.URL.Query().Get("token")
+    if token == "" {
+        return nil, false, nil
+    }
+    p, err := verifier.Verify(r.Context(), token)
+    if err != nil {
+        return nil, false, err
+    }
+    return p, true, nil
+})
+```
+
+**安全权衡**：token 出现在 URL，会落入服务器访问日志、浏览器历史、代理日志。仅在无法使用 Cookie 的场景使用，并设置极短 TTL（≤ 60s 一次性 token）。
+
+#### b. Cookie（推荐浏览器场景）
+
+```go
+authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, bool, error) {
+    cookie, err := r.Cookie("session_token")
+    if err != nil {
+        return nil, false, nil
+    }
+    p, err := verifier.Verify(r.Context(), cookie.Value)
+    if err != nil {
+        return nil, false, err
+    }
+    return p, true, nil
+})
+```
+
+**安全权衡**：Cookie 不出现在 URL；需设置 `SameSite=Strict`（或 `Lax`）+ `HttpOnly` + `Secure` 防止 CSRF 和 XSS。
+
+#### c. Sec-WebSocket-Protocol 子协议携带 token
+
+```go
+authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, bool, error) {
+    // 浏览器可通过 new WebSocket(url, ["v1", "<token>"]) 传递子协议
+    protos := r.Header.Get("Sec-WebSocket-Protocol")
+    // 解析出 token 部分...
+    ...
+})
+```
+
+**安全权衡**：token 明文出现在握手 header，不在 URL 日志中，但需服务端在 Accept 时回传选中的子协议，实现略复杂。
+
+### 3.3 composition root 示例
+
+```go
+// 选一：ContextAuthenticator（/api/v1/* JWT listener 上的推荐方式）
+handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+    AllowedOrigins: []string{"https://app.example.com"},
+    Authenticator:  auth.NewContextAuthenticator(),
+})
+
+// 选二：JWTAuthenticator（独立端口，需 Bearer token）
+handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+    AllowedOrigins: []string{"https://app.example.com"},
+    Authenticator:  auth.NewJWTAuthenticator(verifier),
+})
+
+// 选三：AnonymousAuthenticator（广播频道，无认证）
+handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
+    AllowedOrigins: []string{"https://app.example.com"},
+    Authenticator:  auth.NewAnonymousAuthenticator(),
+})
+```
+
+---
+
+## 4. 心跳与 token 续期
+
+Hub 内置 ping-pong 循环：
+
+- **PingInterval**（默认 30s）：每轮向所有连接发 ping。
+- **PingMissMax**（默认 2）：连续 miss 达到阈值则驱逐连接。
+- **PingTimeout**（默认 5s）：单次 ping 的 deadline。
+
+**Token 过期驱逐**：ping loop 每轮先于发 ping 检查 `Principal.ExpiresAt`。若当前时间已超过 `ExpiresAt`，连接被驱逐，无需等待下一次 miss。`ExpiresAt.IsZero()` 时不检查（Anonymous principal 不过期）。
+
+**v1.0 不支持服务端 push refresh**：token 续期必须由客户端主动操作：
+
+1. 客户端检测到 token 临近过期（推荐提前 60s）。
+2. 客户端通过原认证 API 获取新 token。
+3. 客户端主动断开 WS 连接，用新 token 重新握手建立连接。
+
+---
+
+## 5. 重连策略
+
+客户端实现指数退避重连（推荐参数）：
+
+```
+初始延迟: 1s
+倍增系数: 2
+最大延迟: 30s
+抖动:     ±500ms（防止 thundering herd）
+```
+
+示例序列：`1s → 2s → 4s → 8s → 16s → 30s → 30s → ...`
+
+服务端关系：
+
+- `hub.IsRunning() == false` 时，`UpgradeHandler` 返回 `503 Service Unavailable`。客户端收到 503 应继续退避重连。
+- hub 停止（`Stop` 调用或 `Start` ctx cancel）时，所有连接被关闭。客户端重连请求在 hub 重新就绪前会持续得到 503。
+- 正常停机顺序：先停止 hub（关闭连接），readyz 返回 503 防止 LB 继续路由新请求。
+
+---
+
+## 6. 广播：BroadcastFilter vs BroadcastToSubject
+
+### BroadcastFilter — 通用过滤广播
+
+```go
+// filter 必填，nil 返回 errcode.ErrWebsocketBroadcastFilterMissing
+err := hub.BroadcastFilter(ctx, data, func(c rtws.Conn) bool {
+    p := c.Principal()
+    return p != nil && p.CallerCellID == "accesscore"
+})
+
+// 全广播（显式）
+err := hub.BroadcastFilter(ctx, data, func(rtws.Conn) bool { return true })
+```
+
+特性：
+
+- O(N) 迭代所有连接。
+- filter 在调用方 goroutine 执行（不持有 connMu）。
+- **filter 必须是 O(1) cheap 操作**：读 `Conn.Principal()` 字段合法；发起 DB 查询或远程 RPC 是性能反模式（N 连接 × RPC 延迟 = 广播延迟）。
+
+### BroadcastToSubject — subject 索引广播
+
+```go
+// O(1) 索引 lookup，通过 subjectIdx 直接定位
+// subject == "" 返回 errcode.ErrWebsocketBroadcastSubjectMissing
+// subject 不存在（无连接）→ noop，返回 nil
+err := hub.BroadcastToSubject(ctx, userID, data)
+```
+
+特性：
+
+- `subjectIdx` 由 Hub 在 Register/Unregister 时维护，与 `conns` 严格同步。
+- Subject 来自 `conn.Principal().Subject`（JWT sub claim / service token callerCell）。
+- Anonymous principal（Subject == ""）不进入 subjectIdx。
+
+### 多租户 ACL 示例
+
+```go
+// 按 subject 精准推送（用户数据变更通知）
+func notifyUser(hub *rtws.Hub, userID string, event []byte) error {
+    return hub.BroadcastToSubject(ctx, userID, event)
+}
+
+// 按 Cell 过滤广播（仅推送给特定 cell 的连接）
+func broadcastToCell(hub *rtws.Hub, cellID string, event []byte) error {
+    return hub.BroadcastFilter(ctx, event, func(c rtws.Conn) bool {
+        p := c.Principal()
+        return p != nil && p.CallerCellID == cellID
+    })
+}
+```
+
+---
+
+## 7. 慢客户端驱逐
+
+每个连接有独立的 send channel，容量由 `HubConfig.SendBufferSize`（默认 32）控制。
+
+**驱逐触发条件**：
+
+- `BroadcastFilter` / `BroadcastToSubject` fanout 时，`send` channel 满 → 立即驱逐（select default-drop）。
+- `Send(connID)` 时，channel 满 → 驱逐 + 返回 `errcode.ErrWebsocketSlowClient`。
+- `writeLoop` 内 `conn.Write` 失败（网络错误） → 同路径驱逐。
+
+客户端必须容忍服务端主动断开连接。收到 `1001 Going Away` 或 EOF 后执行重连退避逻辑。
+
+驱逐会记录 `slog.Warn("websocket hub: slow client evicted, send buffer full", ...)` 包含 `conn_id` 和 `subject`。
+
+---
+
+## 8. 故障注入与压测
+
+### fakeConn 模式
+
+`runtime/websocket/hub_test.go` 提供 `fakeConn` 参考实现：
+
+```go
+// 正常连接
+conn := newFakeConn("conn-1", &auth.Principal{Subject: "user-1"})
+require.NoError(t, hub.Register(ctx, conn))
+
+// 阻塞连接（模拟慢客户端）
+conn := newBlockingFakeConn("slow-1", &auth.Principal{Subject: "slow"})
+require.NoError(t, hub.Register(ctx, conn))
+// 触发 BroadcastFilter 后，conn 的 send buffer 满 → 驱逐
+```
+
+### clockmock 推进 token 过期
+
+```go
+clk := clockmock.New(time.Now())
+hub := rtws.NewHub(rtws.DefaultHubConfig(clk), nil)
+
+p := &auth.Principal{
+    Subject:   "user-1",
+    ExpiresAt: clk.Now().Add(5 * time.Minute),
+}
+conn := newFakeConn("conn-1", p)
+require.NoError(t, hub.Register(ctx, conn))
+
+// 推进时钟，超过 token 过期时间
+clk.Advance(6 * time.Minute)
+
+// 下一个 ping tick 触发过期驱逐
+clk.Advance(hub.Config().PingInterval)
+
+require.Eventually(t, func() bool {
+    return hub.ConnCount() == 0
+}, time.Second, 10*time.Millisecond)
+```
+
+### BroadcastToSubject 异步断言
+
+`BroadcastToSubject` 将数据投入 writeLoop goroutine 的 channel，断言需要等待异步完成：
+
+```go
+err := hub.BroadcastToSubject(ctx, "user-1", []byte("hello"))
+require.NoError(t, err)
+
+// 等待 writeLoop 实际投递
+require.Eventually(t, func() bool {
+    return conn.ReceivedCount() == 1
+}, time.Second, time.Millisecond)
+```
+
+---
+
+## 9. 运维参数表
+
+| 字段 | DefaultHubConfig 值 | 调优触发条件 |
+|---|---|---|
+| `PingInterval` | `30s` | 网络不稳定时减小（10s）；连接数大时增大（60s）减少 ping 开销 |
+| `PingTimeout` | `5s` | 高延迟网络（如跨大洲）适当增大；需要快速检测死连接时减小 |
+| `ReadLimit` | `64KB` | 消息 payload 超限时按业务需求增大；安全边界低于默认值可减小 |
+| `PingMissMax` | `2` | 对抖动容忍高时增大（3-5）；严格活跃性检测时设为 1 |
+| `MaxConnections` | `0`（无限制） | 防止 OOM 时设置上限（如 10000）；与 CPU/内存容量匹配 |
+| `SendBufferSize` | `32` | 高吞吐推送时增大（64-256）；严格 fail-closed 时设 0（无缓冲，立即驱逐） |
+| `Clock` | 无默认，必须传入 | `clock.Real()` for production；`clockmock.New(t)` for tests |
+
+---
+
+## 更多
+
+- 架构决策：`docs/architecture/202605011500-adr-ws-auth-acl.md`（SEC-FAIL-CLOSED 设计）
+- 错误码参考：`pkg/errcode/errcode.go`（`ErrWebsocket*` 系列）
+- archtest 规则：`tools/archtest/security_defaults_test.go`（SEC-07/08/09）
+
+ref: coder/websocket accept.go; centrifugal/centrifuge hub.go; olahol/melody hub.go

--- a/docs/guides/websocket-integration.md
+++ b/docs/guides/websocket-integration.md
@@ -183,6 +183,8 @@ Hub 内置 ping-pong 循环：
 2. 客户端通过原认证 API 获取新 token。
 3. 客户端主动断开 WS 连接，用新 token 重新握手建立连接。
 
+**最坏情况**下，token 过期后**最多 `PingInterval`（默认 30s）**才被驱逐；对敏感场景缩短 `PingInterval`。
+
 ---
 
 ## 5. 重连策略

--- a/docs/guides/websocket-integration.md
+++ b/docs/guides/websocket-integration.md
@@ -56,6 +56,8 @@ handler, err := adapterws.UpgradeHandler(hub, cfg)
 - **禁止全通配符 `"*"`**：明确拒绝，拒绝路由到 `errcode.ErrWebsocketOriginsInvalid`。
 - **Wildcard 只作 host 一段**：`"https://*.example.com"` 合法；`"https://**"` 语义不明，避免使用。
 
+> **生产环境警告**：`"http://*"` 与 `"https://*"` 全 host 通配仅用于本地开发或内网调试；生产环境必须使用具体 host pattern，例如 `"https://app.example.com"` 或 `"https://*.app.example.com"`。全 host 通配会绕过 Origin 安全边界，导致任意跨域访问。
+
 ---
 
 ## 3. 认证集成
@@ -69,6 +71,7 @@ handler, err := adapterws.UpgradeHandler(hub, cfg)
 ```go
 // 适合：服务端直连（curl、native app、后端 worker）
 // 限制：浏览器 JS WebSocket API 无法设置 Authorization header
+// verifier 类型为 auth.IntentTokenVerifier，实现 VerifyIntent(ctx, token, expected TokenIntent) (Claims, error)
 authenticator := auth.NewJWTAuthenticator(verifier)
 ```
 
@@ -102,11 +105,11 @@ authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, 
     if token == "" {
         return nil, false, nil
     }
-    p, err := verifier.Verify(r.Context(), token)
+    claims, err := verifier.VerifyIntent(r.Context(), token, auth.TokenIntentAccess)
     if err != nil {
         return nil, false, err
     }
-    return p, true, nil
+    return claims.Principal(), true, nil
 })
 ```
 
@@ -120,11 +123,11 @@ authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, 
     if err != nil {
         return nil, false, nil
     }
-    p, err := verifier.Verify(r.Context(), cookie.Value)
+    claims, err := verifier.VerifyIntent(r.Context(), cookie.Value, auth.TokenIntentAccess)
     if err != nil {
         return nil, false, err
     }
-    return p, true, nil
+    return claims.Principal(), true, nil
 })
 ```
 
@@ -143,7 +146,29 @@ authenticator := auth.AuthenticatorFunc(func(r *http.Request) (*auth.Principal, 
 
 **安全权衡**：token 明文出现在握手 header，不在 URL 日志中，但需服务端在 Accept 时回传选中的子协议，实现略复杂。
 
-### 3.3 composition root 示例
+### 3.3 MessageHandler 读取 Principal（P1-3）
+
+Hub 在 Register 时把 Principal 注入 per-connection context（`auth.WithPrincipal(connCtx, p)`）。MessageHandler 收到的 `ctx` 可直接通过 `auth.FromContext(ctx)` 取 principal，无需经过 Conn 对象：
+
+```go
+hub := rtws.NewHub(cfg, func(ctx context.Context, connID string, data []byte) {
+    p, ok := auth.FromContext(ctx)
+    if !ok || p == nil {
+        slog.Warn("ws: message from unauthenticated conn", slog.String("conn_id", connID))
+        return
+    }
+    // p.Subject / p.Roles / p.ExpiresAt 是握手时快照的只读字段，禁止修改。
+    _ = p.Subject
+    _ = p.Roles
+    // 业务处理...
+})
+```
+
+### 3.4 Principal immutability 约定（P2-1）
+
+Authenticator 返回 `*auth.Principal` 后，调用方**禁止修改**其任何字段（`Subject` / `Roles` / `ExpiresAt` / `Claims`）。Hub 在握手时从 `conn.Principal()` 快照 `subject` 和 `expiresAt` 到 `connEntry`，注册完成后 hub 内部不再回读 `conn.Principal()`。`Conn.Principal()` 字段在整个连接生命周期内必须保持不变；如需更新身份，客户端应重新握手。
+
+### 3.5 composition root 示例
 
 ```go
 // 选一：ContextAuthenticator（/api/v1/* JWT listener 上的推荐方式）
@@ -153,6 +178,7 @@ handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
 })
 
 // 选二：JWTAuthenticator（独立端口，需 Bearer token）
+// verifier 实现 auth.IntentTokenVerifier 接口
 handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
     AllowedOrigins: []string{"https://app.example.com"},
     Authenticator:  auth.NewJWTAuthenticator(verifier),
@@ -162,6 +188,18 @@ handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
 handler, err := adapterws.UpgradeHandler(hub, adapterws.UpgradeConfig{
     AllowedOrigins: []string{"https://app.example.com"},
     Authenticator:  auth.NewAnonymousAuthenticator(),
+})
+```
+
+### 3.6 service principal
+
+service token 的身份通过 `CallerCellID` 表达，**不是** `Subject`（service principal 的 `Subject` 一律为空）。过滤 service 连接时应读 `p.CallerCellID`：
+
+```go
+// 按 CallerCellID 过滤特定 cell 的 service 连接
+err := hub.BroadcastFilter(ctx, data, func(c rtws.Conn) bool {
+    p := c.Principal()
+    return p != nil && p.CallerCellID == "accesscore"
 })
 ```
 
@@ -175,7 +213,7 @@ Hub 内置 ping-pong 循环：
 - **PingMissMax**（默认 2）：连续 miss 达到阈值则驱逐连接。
 - **PingTimeout**（默认 5s）：单次 ping 的 deadline。
 
-**Token 过期驱逐**：ping loop 每轮先于发 ping 检查 `Principal.ExpiresAt`。若当前时间已超过 `ExpiresAt`，连接被驱逐，无需等待下一次 miss。`ExpiresAt.IsZero()` 时不检查（Anonymous principal 不过期）。
+**Token 过期驱逐**：ping loop 每轮先于发 ping 检查 `Principal.ExpiresAt`。若当前时间已超过 `ExpiresAt`，连接被驱逐，无需等待下一次 miss。`ExpiresAt.IsZero()` 时不检查（Anonymous principal 不过期）。token 过期驱逐在 slog 中带 `reason="token_expired"` 结构化字段（P2-3）。
 
 **v1.0 不支持服务端 push refresh**：token 续期必须由客户端主动操作：
 
@@ -199,6 +237,16 @@ Hub 内置 ping-pong 循环：
 ```
 
 示例序列：`1s → 2s → 4s → 8s → 16s → 30s → 30s → ...`
+
+### HTTP 状态码对照表（P2-2）
+
+| 状态码 | 触发条件 | 客户端动作 |
+|---|---|---|
+| 101 | 升级成功 | — |
+| 400 | 客户端握手协议违规（无 `Sec-WebSocket-Key`、Origin 拒绝、非 GET 等） | 修正客户端实现，不重试 |
+| 401 | 凭证缺失或无效 | 重新获取 token / 跳认证 |
+| 500 | 服务端错误（hijack 不支持、Accept I/O 失败） | 指数退避重试 |
+| 503 | hub 未启动或停机中 | 指数退避重试，等 readyz 通过 |
 
 服务端关系：
 
@@ -226,8 +274,8 @@ err := hub.BroadcastFilter(ctx, data, func(rtws.Conn) bool { return true })
 特性：
 
 - O(N) 迭代所有连接。
-- filter 在调用方 goroutine 执行（不持有 connMu）。
-- **filter 必须是 O(1) cheap 操作**：读 `Conn.Principal()` 字段合法；发起 DB 查询或远程 RPC 是性能反模式（N 连接 × RPC 延迟 = 广播延迟）。
+- **filter 在锁外执行**（P1-2）：Hub 在 connMu 下 snapshot 连接列表后释放锁，再逐个调用 filter。因此 filter 慢不会阻塞 `Register` / `Stop`，filter 内可以**安全**调用 `hub.Send(...)` / `hub.BroadcastToSubject(...)` 而不会死锁。
+- **仍建议 filter O(1) cheap**：filter 变慢只会拖慢该次广播延迟（snapshot 完成后才迭代），但不影响连接管理；禁止在 filter 内发起 DB 查询或远程 RPC（N 连接 × RPC 延迟 = 广播延迟放大反模式）。
 
 ### BroadcastToSubject — subject 索引广播
 
@@ -241,8 +289,16 @@ err := hub.BroadcastToSubject(ctx, userID, data)
 特性：
 
 - `subjectIdx` 由 Hub 在 Register/Unregister 时维护，与 `conns` 严格同步。
-- Subject 来自 `conn.Principal().Subject`（JWT sub claim / service token callerCell）。
+- Subject 来自 `conn.Principal().Subject`（JWT sub claim）。service principal 的 Subject 为空，不进入 subjectIdx；service 连接应通过 `BroadcastFilter` + `CallerCellID` 路由。
 - Anonymous principal（Subject == ""）不进入 subjectIdx。
+
+### ctx 行为说明（P1-5）
+
+`Send` / `BroadcastFilter` / `BroadcastToSubject` 在入队前检查调用方 ctx：
+
+- 若调用方 ctx 已 canceled，立即返回 `ctx.Err()`，不向 send channel 投递任何消息（short-circuit）。
+- **ctx 仅控制入队 timeout**；writeLoop 写 socket 使用内部 per-connection connCtx，调用方 ctx canceled 后已成功入队的消息**仍会**被 writeLoop 送达。
+- 调用方 ctx 不会污染 send channel（canceled ctx 永远不会把消息写入 channel）。
 
 ### 多租户 ACL 示例
 
@@ -252,7 +308,7 @@ func notifyUser(hub *rtws.Hub, userID string, event []byte) error {
     return hub.BroadcastToSubject(ctx, userID, event)
 }
 
-// 按 Cell 过滤广播（仅推送给特定 cell 的连接）
+// 按 Cell 过滤广播（仅推送给特定 cell 的 service 连接）
 func broadcastToCell(hub *rtws.Hub, cellID string, event []byte) error {
     return hub.BroadcastFilter(ctx, event, func(c rtws.Conn) bool {
         p := c.Principal()
@@ -265,7 +321,7 @@ func broadcastToCell(hub *rtws.Hub, cellID string, event []byte) error {
 
 ## 7. 慢客户端驱逐
 
-每个连接有独立的 send channel，容量由 `HubConfig.SendBufferSize`（默认 32）控制。
+每个连接有独立的 send channel，容量由 `HubConfig.SendBufferSize`（默认 32）控制。**零值自动 fallback 到默认值 32**（与 `PingInterval`、`PingMissMax` 等字段同模式），不存在"0 = unbuffered"语义。
 
 **驱逐触发条件**：
 
@@ -275,7 +331,14 @@ func broadcastToCell(hub *rtws.Hub, cellID string, event []byte) error {
 
 客户端必须容忍服务端主动断开连接。收到 `1001 Going Away` 或 EOF 后执行重连退避逻辑。
 
-驱逐会记录 `slog.Warn("websocket hub: slow client evicted, send buffer full", ...)` 包含 `conn_id` 和 `subject`。
+**evict slog reason 字段**（P2-3）：所有驱逐路径在 slog 输出中均包含 `reason` 结构化字段，运维可按 label 区分驱逐原因：
+
+| `reason` 值 | 触发路径 |
+|---|---|
+| `send_buffer_full` | 慢客户端：send channel 满，fanout 或 Send 触发 |
+| `connection_write_failed` | writeLoop 写 socket 失败（网络中断） |
+| `token_expired` | ping loop 检测到 Principal.ExpiresAt 超期 |
+| `duplicate_conn_id` | Register 时发现同 ID 的旧连接，旧连接被驱逐 |
 
 ---
 
@@ -298,8 +361,10 @@ require.NoError(t, hub.Register(ctx, conn))
 
 ### clockmock 推进 token 过期
 
+`clockmock.New(initial time.Time)` 返回 `*FakeClock`，参数为初始时刻（`time.Time`），**不是** `*testing.T`：
+
 ```go
-clk := clockmock.New(time.Now())
+clk := clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 hub := rtws.NewHub(rtws.DefaultHubConfig(clk), nil)
 
 p := &auth.Principal{
@@ -345,8 +410,10 @@ require.Eventually(t, func() bool {
 | `ReadLimit` | `64KB` | 消息 payload 超限时按业务需求增大；安全边界低于默认值可减小 |
 | `PingMissMax` | `2` | 对抖动容忍高时增大（3-5）；严格活跃性检测时设为 1 |
 | `MaxConnections` | `0`（无限制） | 防止 OOM 时设置上限（如 10000）；与 CPU/内存容量匹配 |
-| `SendBufferSize` | `32` | 高吞吐推送时增大（64-256）；严格 fail-closed 时设 0（无缓冲，立即驱逐） |
-| `Clock` | 无默认，必须传入 | `clock.Real()` for production；`clockmock.New(t)` for tests |
+| `SendBufferSize` | `32`；**零值自动取默认值 32** | 高吞吐推送时增大（64-256）；严格 fail-closed 时减小 |
+| `Clock` | 无默认，必须传入 | `clock.Real()` for production；`clockmock.New(time.Now())` for tests |
+
+**evict slog `reason` 字段**：所有连接驱逐均在 slog 中附带 `reason` 字段，可用于告警分类：`send_buffer_full`（慢客户端）、`token_expired`（token 超期）、`connection_write_failed`（写失败/网络中断）、`duplicate_conn_id`（重复连接 ID）。
 
 ---
 

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -204,6 +204,30 @@ const (
 	//	var ec *errcode.Error
 	//	if errors.As(err, &ec) && ec.Code == errcode.ErrWebsocketHubMissing { /* misconfig */ }
 	ErrWebsocketHubMissing Code = "ERR_WEBSOCKET_HUB_MISSING"
+	// ErrWebsocketAuthenticatorMissing signals that an UpgradeHandler was
+	// constructed without an Authenticator. The error is returned by the
+	// error-form constructor and panicked by the static-wiring twin.
+	//
+	// SEC-FAIL-CLOSED (PR-V1-SEC-WS-AUTH-ACL): nil Authenticator must surface
+	// at composition root, not at the first HTTP request.
+	ErrWebsocketAuthenticatorMissing Code = "ERR_WEBSOCKET_AUTHENTICATOR_MISSING"
+	// ErrWebsocketBroadcastFilterMissing signals that Hub.BroadcastFilter was
+	// called with a nil filter function. fail-closed: full-broadcast must be
+	// expressed explicitly via `func(Conn) bool { return true }`.
+	ErrWebsocketBroadcastFilterMissing Code = "ERR_WEBSOCKET_BROADCAST_FILTER_MISSING"
+	// ErrWebsocketBroadcastSubjectMissing signals that Hub.BroadcastToSubject
+	// was called with an empty subject string.
+	ErrWebsocketBroadcastSubjectMissing Code = "ERR_WEBSOCKET_BROADCAST_SUBJECT_MISSING"
+	// ErrWebsocketUpgradeUnauthenticated signals that the UpgradeHandler
+	// rejected an incoming HTTP request because the Authenticator returned
+	// either absent (no credential) or a present-but-invalid credential. The
+	// HTTP response status is 401 and the body is plain text; this code is
+	// only used in server-side slog records.
+	ErrWebsocketUpgradeUnauthenticated Code = "ERR_WEBSOCKET_UPGRADE_UNAUTHENTICATED"
+	// ErrWebsocketSlowClient signals that the Hub evicted a connection because
+	// its send buffer filled (gorilla/websocket select-default-drop pattern).
+	// Emitted from BroadcastFilter / BroadcastToSubject / Send.
+	ErrWebsocketSlowClient Code = "ERR_WEBSOCKET_SLOW_CLIENT"
 
 	// Outbox envelope error codes.
 	// ErrEnvelopeSchema signals that an inbound wire message does not conform

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -291,6 +291,11 @@ func validateCallerCell(callerCell string) error {
 // fail-closed mode should compose with a guard that rejects (false, nil)
 // outcomes (the typical /api/v1/* listener already does this via JWT
 // short-circuit).
+//
+// 警告：当挂载在已有 JWT listener 上时，ContextAuthenticator 应是 chain 中
+// 唯一的 authenticator（不通过 UnionAuthenticator 组合）；absent-credential
+// 结果（false, nil）不会阻止 Union 继续尝试下一个 authenticator，可能造成
+// 意料之外的 fall-through 路径。
 func NewContextAuthenticator() Authenticator {
 	return AuthenticatorFunc(func(r *http.Request) (*Principal, bool, error) {
 		if p, ok := FromContext(r.Context()); ok {

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -125,6 +125,7 @@ func jwtClaimsToPrincipal(c Claims) *Principal {
 			"iss":       c.Issuer,
 			"token_use": string(c.TokenUse),
 		},
+		ExpiresAt: c.ExpiresAt,
 	}
 }
 
@@ -273,4 +274,44 @@ func validateCallerCell(callerCell string) error {
 			fmt.Sprintf("caller cell id %q invalid (must match ^[a-z][a-z0-9-]*$)", callerCell))
 	}
 	return nil
+}
+
+// NewContextAuthenticator returns an Authenticator that extracts a Principal
+// from the request context. It is used by adapters that mount behind an
+// already-authenticated listener (e.g. WebSocket upgrade routes mounted on a
+// JWT listener); the listener middleware writes the Principal via
+// WithPrincipal, and the adapter's Authenticator simply reads it back.
+//
+// Outcomes:
+//
+//	(p, true, nil)                 — Principal found in ctx, Kind != PrincipalUnknown.
+//	(absentPrincipal(), false, nil) — no Principal in ctx (chain may continue).
+//
+// This Authenticator never returns an error; callers that want a strict
+// fail-closed mode should compose with a guard that rejects (false, nil)
+// outcomes (the typical /api/v1/* listener already does this via JWT
+// short-circuit).
+func NewContextAuthenticator() Authenticator {
+	return AuthenticatorFunc(func(r *http.Request) (*Principal, bool, error) {
+		if p, ok := FromContext(r.Context()); ok {
+			return p, true, nil
+		}
+		return absentPrincipal(), false, nil
+	})
+}
+
+// NewAnonymousAuthenticator returns an Authenticator that always succeeds
+// with a fresh PrincipalAnonymous principal. It is the explicit, type-safe
+// way to declare "this WebSocket endpoint accepts unauthenticated traffic"
+// at the composition root — paired with UpgradeConfig.Authenticator's
+// non-nil requirement to keep fail-closed semantics intact.
+//
+// The returned Principal carries Kind=PrincipalAnonymous and zero ExpiresAt
+// (anonymous principals never expire). Subject and Roles are intentionally
+// empty; downstream authorization (auth.RequireSelfOrRole etc.) treats the
+// anonymous Principal as having no privileges.
+func NewAnonymousAuthenticator() Authenticator {
+	return AuthenticatorFunc(func(_ *http.Request) (*Principal, bool, error) {
+		return &Principal{Kind: PrincipalAnonymous}, true, nil
+	})
 }

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -924,3 +924,93 @@ func TestValidateCallerCell(t *testing.T) {
 		})
 	}
 }
+
+func TestNewAnonymousAuthenticator(t *testing.T) {
+	a := NewAnonymousAuthenticator()
+	p, ok, err := a.Authenticate(newRequest(t))
+	if err != nil {
+		t.Fatalf("anonymous authenticator should not error: %v", err)
+	}
+	if !ok {
+		t.Fatal("anonymous authenticator must always return ok=true")
+	}
+	if p == nil {
+		t.Fatal("anonymous authenticator must return non-nil principal")
+	}
+	if p.Kind != PrincipalAnonymous {
+		t.Errorf("expected PrincipalAnonymous, got %v", p.Kind)
+	}
+	if !p.ExpiresAt.IsZero() {
+		t.Error("anonymous principal must have zero ExpiresAt (no expiry)")
+	}
+}
+
+func TestNewContextAuthenticator_PrincipalInCtx(t *testing.T) {
+	want := &Principal{Kind: PrincipalUser, Subject: "u1"}
+	a := NewContextAuthenticator()
+
+	req := newRequest(t)
+	req = req.WithContext(WithPrincipal(req.Context(), want))
+
+	got, ok, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true when principal is in ctx")
+	}
+	if got != want {
+		t.Errorf("expected same pointer, got %v want %v", got, want)
+	}
+}
+
+func TestNewContextAuthenticator_NoPrincipalInCtx(t *testing.T) {
+	a := NewContextAuthenticator()
+	p, ok, err := a.Authenticate(newRequest(t))
+	if err != nil {
+		t.Fatalf("absent ctx principal must not error, got %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false when principal not in ctx")
+	}
+	if p == nil || p.Kind != PrincipalUnknown {
+		t.Errorf("expected absentPrincipal, got %v", p)
+	}
+}
+
+// JWT authenticator must plumb Claims.ExpiresAt to Principal.ExpiresAt.
+func TestJWTAuthenticator_PlumbsExpiresAt(t *testing.T) {
+	exp := time.Date(2030, 6, 1, 0, 0, 0, 0, time.UTC)
+	v := &stubVerifierForExp{
+		claims: Claims{
+			Subject:   "u1",
+			Issuer:    "iss",
+			ExpiresAt: exp,
+			TokenUse:  TokenIntentAccess,
+		},
+	}
+	a := NewJWTAuthenticator(v)
+	req := newRequest(t)
+	req.Header.Set("Authorization", "Bearer x")
+
+	p, ok, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if !p.ExpiresAt.Equal(exp) {
+		t.Errorf("ExpiresAt not plumbed: got %v want %v", p.ExpiresAt, exp)
+	}
+}
+
+// stubVerifierForExp helps TestJWTAuthenticator_PlumbsExpiresAt; minimal implementation.
+type stubVerifierForExp struct {
+	claims Claims
+	err    error
+}
+
+func (s *stubVerifierForExp) VerifyIntent(_ context.Context, _ string, _ TokenIntent) (Claims, error) {
+	return s.claims, s.err
+}

--- a/runtime/auth/principal.go
+++ b/runtime/auth/principal.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"slices"
+	"time"
 )
 
 type PrincipalKind int
@@ -57,6 +58,15 @@ type Principal struct {
 	// mutating it has no effect on authentication decisions and may corrupt
 	// shared state.
 	Claims map[string]string
+	// ExpiresAt is the absolute expiration time of the credential that
+	// produced this Principal. Zero value means "no expiry" (anonymous
+	// and service principals never expire). For JWT principals this is
+	// copied from Claims.ExpiresAt by jwtClaimsToPrincipal.
+	//
+	// Consumers (e.g. runtime/websocket.Hub) check ExpiresAt against the
+	// current clock to decide eviction; long-lived WebSocket connections
+	// are evicted on the next ping tick after token expiry.
+	ExpiresAt time.Time
 }
 
 // HasRole is nil-safe: a nil receiver always returns false.

--- a/runtime/auth/principal.go
+++ b/runtime/auth/principal.go
@@ -42,6 +42,14 @@ func (k PrincipalKind) String() string {
 // CallerCellID (the originating cell id extracted from the 4-part service
 // token). Subject is always empty; Roles is always nil. Use RequireCallerCell
 // to authorize internal endpoints by caller allowlist.
+//
+// Immutability contract: After an Authenticator returns a Principal, callers
+// must not modify any field for the lifetime of the request/connection.
+// runtime/websocket.Hub snapshots Subject and ExpiresAt at handshake time and
+// treats the principal as immutable; mutating Subject/Roles/ExpiresAt/Claims
+// after Authenticate has undefined effects on hub subjectIdx and expiry
+// eviction. Slices (Roles) and maps (Claims) are read-only by convention; do
+// not append or mutate. This mirrors the existing Claims map convention.
 type Principal struct {
 	Kind                  PrincipalKind
 	Subject               string

--- a/runtime/auth/principal_test.go
+++ b/runtime/auth/principal_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestPrincipalKind_String(t *testing.T) {
@@ -142,5 +143,25 @@ func TestPrincipal_ServiceKindCallerCellID(t *testing.T) {
 	// Spec: Roles must be nil for a service principal (no role-based authz for services)
 	if p.Roles != nil {
 		t.Errorf("service kind Roles must be nil, got %v", p.Roles)
+	}
+}
+
+func TestPrincipal_ExpiresAt_ZeroValueMeansNoExpiry(t *testing.T) {
+	var p Principal
+	if !p.ExpiresAt.IsZero() {
+		t.Error("zero-value Principal.ExpiresAt must be zero time (no expiry)")
+	}
+}
+
+func TestPrincipal_ExpiresAt_RoundTrip(t *testing.T) {
+	exp := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	original := &Principal{Kind: PrincipalUser, ExpiresAt: exp}
+	ctx := WithPrincipal(context.Background(), original)
+	got, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("FromContext should retrieve principal")
+	}
+	if !got.ExpiresAt.Equal(exp) {
+		t.Errorf("ExpiresAt round-trip failed: got %v want %v", got.ExpiresAt, exp)
 	}
 }

--- a/runtime/websocket/conn.go
+++ b/runtime/websocket/conn.go
@@ -1,6 +1,10 @@
 package websocket
 
-import "context"
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/runtime/auth"
+)
 
 // Conn abstracts a WebSocket connection. Implementations live in
 // adapters/ (e.g., adapters/websocket for github.com/coder/websocket).
@@ -25,4 +29,13 @@ type Conn interface {
 	//   - Must not block longer than necessary (no long mutex waits).
 	// If a graceful close is needed in the future, add CloseGracefully(ctx).
 	Close() error
+
+	// Principal returns the authenticated principal bound at handshake time.
+	// It may return nil if the adapter did not bind a principal (e.g. test
+	// fakes); the Hub treats nil as "no subject indexing, no expiry tracked"
+	// and behaves as if the connection has Kind=PrincipalUnknown.
+	//
+	// The returned pointer is owned by the Conn implementation; consumers
+	// must not mutate the Principal struct.
+	Principal() *auth.Principal
 }

--- a/runtime/websocket/errors.go
+++ b/runtime/websocket/errors.go
@@ -1,19 +1,1 @@
 package websocket
-
-import "github.com/ghbvf/gocell/pkg/errcode"
-
-// Hub error codes — aliases to centralized errcode constants for local readability.
-var (
-	ErrWSConnNotFound   = errcode.ErrWSConnNotFound
-	ErrWSAlreadyStarted = errcode.ErrWSAlreadyStarted
-	ErrWSAlreadyStopped = errcode.ErrWSAlreadyStopped
-	ErrWSHubStopping    = errcode.ErrWSHubStopping
-	ErrWSHubNotRunning  = errcode.ErrWSHubNotRunning
-	ErrWSMaxConns       = errcode.ErrWSMaxConns
-
-	ErrWebsocketAuthenticatorMissing    = errcode.ErrWebsocketAuthenticatorMissing
-	ErrWebsocketBroadcastFilterMissing  = errcode.ErrWebsocketBroadcastFilterMissing
-	ErrWebsocketBroadcastSubjectMissing = errcode.ErrWebsocketBroadcastSubjectMissing
-	ErrWebsocketUpgradeUnauthenticated  = errcode.ErrWebsocketUpgradeUnauthenticated
-	ErrWebsocketSlowClient              = errcode.ErrWebsocketSlowClient
-)

--- a/runtime/websocket/errors.go
+++ b/runtime/websocket/errors.go
@@ -10,4 +10,10 @@ var (
 	ErrWSHubStopping    = errcode.ErrWSHubStopping
 	ErrWSHubNotRunning  = errcode.ErrWSHubNotRunning
 	ErrWSMaxConns       = errcode.ErrWSMaxConns
+
+	ErrWebsocketAuthenticatorMissing    = errcode.ErrWebsocketAuthenticatorMissing
+	ErrWebsocketBroadcastFilterMissing  = errcode.ErrWebsocketBroadcastFilterMissing
+	ErrWebsocketBroadcastSubjectMissing = errcode.ErrWebsocketBroadcastSubjectMissing
+	ErrWebsocketUpgradeUnauthenticated  = errcode.ErrWebsocketUpgradeUnauthenticated
+	ErrWebsocketSlowClient              = errcode.ErrWebsocketSlowClient
 )

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -76,8 +76,8 @@ type connEntry struct {
 	conn          Conn
 	cancel        context.CancelFunc
 	pingMisses    int
-	send          chan []byte    // buffered, sized by HubConfig.SendBufferSize
-	closeSendOnce sync.Once     // guards close(send) for idempotent close
+	send          chan []byte // buffered, sized by HubConfig.SendBufferSize
+	closeSendOnce sync.Once   // guards close(send) for idempotent close
 }
 
 // Hub manages WebSocket connections and provides signal-first broadcasting.
@@ -552,36 +552,9 @@ func (h *Hub) fanout(ctx context.Context, entries []*connEntry, data []byte) {
 // evictSlow removes a slow client whose send buffer is full. Idempotent;
 // safe to call from fanout, writeLoop, or pingLoop.
 func (h *Hub) evictSlow(e *connEntry) {
-	connID := e.conn.ID()
-	h.connMu.Lock()
-	current, ok := h.conns[connID]
-	if ok && current == e {
-		delete(h.conns, connID)
-		h.removeFromSubjectIdxLocked(e)
-	} else {
-		ok = false
-	}
-	h.connMu.Unlock()
-
-	if !ok {
-		return
-	}
-	e.cancel()
-	e.closeSendOnce.Do(func() { close(e.send) })
-	if err := e.conn.Close(); err != nil {
-		slog.Debug("websocket hub: close on slow-client evict",
-			slog.String("conn_id", connID),
-			slog.Any("error", err),
-		)
-	}
-	var subject string
-	if p := e.conn.Principal(); p != nil {
-		subject = p.Subject
-	}
-	slog.Warn("websocket hub: slow client evicted, send buffer full",
-		slog.String("conn_id", connID),
-		slog.String("subject", subject),
-	)
+	h.evictEntry(e, slog.LevelWarn,
+		"websocket hub: slow client evicted, send buffer full",
+		"websocket hub: close on slow-client evict")
 }
 
 // Send sends a text message to a specific connection.
@@ -712,6 +685,17 @@ func (h *Hub) isExpired(entry *connEntry, now time.Time) bool {
 
 // evictExpired removes a connection whose principal token has expired.
 func (h *Hub) evictExpired(entry *connEntry) {
+	h.evictEntry(entry, slog.LevelInfo,
+		"websocket hub: connection evicted on token expiry",
+		"websocket hub: close on expiry evict")
+}
+
+// evictEntry removes an entry from conns + subjectIdx and tears down its
+// goroutines. Idempotent: safe to call from any path (slow-client,
+// token-expiry, or future eviction reasons). evictMsg is logged at the
+// supplied level on success; closeMsg is logged at Debug if conn.Close
+// returns an error.
+func (h *Hub) evictEntry(entry *connEntry, level slog.Level, evictMsg, closeMsg string) {
 	connID := entry.conn.ID()
 	h.connMu.Lock()
 	current, ok := h.conns[connID]
@@ -729,7 +713,7 @@ func (h *Hub) evictExpired(entry *connEntry) {
 	entry.cancel()
 	entry.closeSendOnce.Do(func() { close(entry.send) })
 	if err := entry.conn.Close(); err != nil {
-		slog.Debug("websocket hub: close on expiry evict",
+		slog.Debug(closeMsg,
 			slog.String("conn_id", connID),
 			slog.Any("error", err),
 		)
@@ -738,7 +722,7 @@ func (h *Hub) evictExpired(entry *connEntry) {
 	if p := entry.conn.Principal(); p != nil {
 		subject = p.Subject
 	}
-	slog.Info("websocket hub: connection evicted on token expiry",
+	slog.LogAttrs(context.Background(), level, evictMsg,
 		slog.String("conn_id", connID),
 		slog.String("subject", subject),
 	)
@@ -781,4 +765,3 @@ func (h *Hub) handlePingResult(connID string, pingErr error) {
 		slog.Int("misses", current.pingMisses),
 	)
 }
-

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -82,7 +82,7 @@ type connEntry struct {
 	cancel     context.CancelFunc
 	pingMisses int
 	send       chan []byte   // buffered, sized by HubConfig.SendBufferSize
-	done       chan struct{}  // closed when entry is evicted; writeLoop exit signal
+	done       chan struct{} // closed when entry is evicted; writeLoop exit signal
 	closeOnce  sync.Once     // guards close(done) for idempotent eviction
 
 	// subject and expiresAt are frozen at Register time from conn.Principal().

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -174,9 +174,9 @@ func (h *Hub) Start(ctx context.Context) error {
 		cancel()
 		s := h.state.Load()
 		if s == stateRunning {
-			return errcode.New(errcode.KindInternal, ErrWSAlreadyStarted, "websocket: hub already started")
+			return errcode.New(errcode.KindInternal, errcode.ErrWSAlreadyStarted, "websocket: hub already started")
 		}
-		return errcode.New(errcode.KindInternal, ErrWSAlreadyStopped, "websocket: hub already stopped")
+		return errcode.New(errcode.KindInternal, errcode.ErrWSAlreadyStopped, "websocket: hub already stopped")
 	}
 	h.runCancel = cancel
 	h.wg.Add(1)
@@ -240,7 +240,7 @@ func (h *Hub) shutdown(ctx context.Context) error {
 			}
 		}
 		// Already stopped.
-		return errcode.New(errcode.KindInternal, ErrWSAlreadyStopped, "websocket: hub already stopped")
+		return errcode.New(errcode.KindInternal, errcode.ErrWSAlreadyStopped, "websocket: hub already stopped")
 	}
 
 	// We won the CAS — we own the shutdown.
@@ -321,18 +321,18 @@ func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	if s == stateStopping {
 		h.connMu.Unlock()
 		_ = conn.Close()
-		return errcode.New(errcode.KindUnavailable, ErrWSHubStopping, "websocket: hub is stopping, connection rejected")
+		return errcode.New(errcode.KindUnavailable, errcode.ErrWSHubStopping, "websocket: hub is stopping, connection rejected")
 	}
 	if s != stateRunning {
 		h.connMu.Unlock()
 		_ = conn.Close()
-		return errcode.New(errcode.KindUnavailable, ErrWSHubNotRunning, "websocket: hub is not running, connection rejected")
+		return errcode.New(errcode.KindUnavailable, errcode.ErrWSHubNotRunning, "websocket: hub is not running, connection rejected")
 	}
 
 	if h.config.MaxConnections > 0 && len(h.conns) >= h.config.MaxConnections {
 		h.connMu.Unlock()
 		_ = conn.Close()
-		return errcode.New(errcode.KindUnavailable, ErrWSMaxConns, "websocket: max connections reached")
+		return errcode.New(errcode.KindUnavailable, errcode.ErrWSMaxConns, "websocket: max connections reached")
 	}
 
 	// Evict existing entry with same ID to prevent context leak.
@@ -490,7 +490,7 @@ func (h *Hub) Unregister(connID string) {
 // ref: olahol/melody melody.go BroadcastFilter
 func (h *Hub) BroadcastFilter(ctx context.Context, data []byte, filter func(Conn) bool) error {
 	if filter == nil {
-		return errcode.New(errcode.KindInternal, ErrWebsocketBroadcastFilterMissing,
+		return errcode.New(errcode.KindInternal, errcode.ErrWebsocketBroadcastFilterMissing,
 			"websocket: BroadcastFilter requires a non-nil filter; "+
 				"use func(Conn) bool { return true } for full broadcast")
 	}
@@ -518,7 +518,7 @@ func (h *Hub) BroadcastFilter(ctx context.Context, data []byte, filter func(Conn
 // ref: centrifugal/centrifuge hub.go connShard.users
 func (h *Hub) BroadcastToSubject(ctx context.Context, subject string, data []byte) error {
 	if subject == "" {
-		return errcode.New(errcode.KindInternal, ErrWebsocketBroadcastSubjectMissing,
+		return errcode.New(errcode.KindInternal, errcode.ErrWebsocketBroadcastSubjectMissing,
 			"websocket: BroadcastToSubject requires a non-empty subject")
 	}
 	h.connMu.Lock()
@@ -566,7 +566,7 @@ func (h *Hub) Send(ctx context.Context, connID string, data []byte) error {
 	h.connMu.Unlock()
 
 	if !ok {
-		return errcode.New(errcode.KindNotFound, ErrWSConnNotFound,
+		return errcode.New(errcode.KindNotFound, errcode.ErrWSConnNotFound,
 			"websocket: connection not found: "+connID)
 	}
 
@@ -575,7 +575,7 @@ func (h *Hub) Send(ctx context.Context, connID string, data []byte) error {
 		return nil
 	default:
 		h.evictSlow(entry)
-		return errcode.New(errcode.KindUnavailable, ErrWebsocketSlowClient,
+		return errcode.New(errcode.KindUnavailable, errcode.ErrWebsocketSlowClient,
 			"websocket: connection "+connID+" send buffer full, evicted")
 	}
 }

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -26,6 +26,7 @@ const (
 	defaultReadLimit       = 64 * 1024 // 64KB
 	defaultPingMissMax     = 2
 	defaultShutdownTimeout = 10 * time.Second
+	defaultSendBufferSize  = 32
 )
 
 // HubConfig configures the Hub.
@@ -45,28 +46,38 @@ type HubConfig struct {
 	MaxConnections int
 	// Clock is the time source. Required; NewHub panics if nil.
 	Clock clock.Clock
+
+	// SendBufferSize is the per-connection send channel capacity used by the
+	// writeLoop. When the channel is full the connection is evicted (slow
+	// client; gorilla/websocket select-default-drop). Default 32; 0 means
+	// unbuffered (any send that doesn't immediately match a receive triggers
+	// eviction — extreme fail-closed mode for low-latency scenarios).
+	SendBufferSize int
 }
 
 // DefaultHubConfig returns a HubConfig with sensible defaults. A clock must be
 // provided; pass clock.Real() at the composition root or a clockmock for tests.
 func DefaultHubConfig(clk clock.Clock) HubConfig {
 	return HubConfig{
-		PingInterval: defaultPingInterval,
-		PingTimeout:  defaultPingTimeout,
-		ReadLimit:    defaultReadLimit,
-		PingMissMax:  defaultPingMissMax,
-		Clock:        clk,
+		PingInterval:   defaultPingInterval,
+		PingTimeout:    defaultPingTimeout,
+		ReadLimit:      defaultReadLimit,
+		PingMissMax:    defaultPingMissMax,
+		SendBufferSize: defaultSendBufferSize,
+		Clock:          clk,
 	}
 }
 
 // MessageHandler is called when a message is received from a client.
 type MessageHandler func(ctx context.Context, connID string, data []byte)
 
-// connEntry wraps a Conn with its per-connection context and ping state.
+// connEntry wraps a Conn with its per-connection context, ping state, and send channel.
 type connEntry struct {
-	conn       Conn
-	cancel     context.CancelFunc
-	pingMisses int
+	conn          Conn
+	cancel        context.CancelFunc
+	pingMisses    int
+	send          chan []byte    // buffered, sized by HubConfig.SendBufferSize
+	closeSendOnce sync.Once     // guards close(send) for idempotent close
 }
 
 // Hub manages WebSocket connections and provides signal-first broadcasting.
@@ -100,7 +111,12 @@ type Hub struct {
 	// wg.Add MUST happen under connMu to prevent a race with wg.Wait.
 	connMu sync.Mutex
 	conns  map[string]*connEntry
-	wg     sync.WaitGroup // tracks readLoop + pingLoop goroutines
+	// subjectIdx[subject][connID] = entry. Maintained in lockstep with conns.
+	// Only populated for entries whose Conn.Principal().Subject is non-empty.
+	// Synced at: Register / unregisterEntry / Unregister / pingLoop expiry-evict
+	// / slow-client evict / shutdown drain.
+	subjectIdx map[string]map[string]*connEntry
+	wg         sync.WaitGroup // tracks readLoop + writeLoop + pingLoop goroutines
 
 	// cancelMu protects runCancel from concurrent Start/Stop access.
 	cancelMu  sync.Mutex
@@ -136,6 +152,7 @@ func NewHub(cfg HubConfig, handler MessageHandler) *Hub {
 		clk:          cfg.Clock,
 		handler:      handler,
 		conns:        make(map[string]*connEntry),
+		subjectIdx:   make(map[string]map[string]*connEntry),
 		shutdownDone: make(chan struct{}),
 	}
 }
@@ -246,6 +263,7 @@ func (h *Hub) shutdown(ctx context.Context) error {
 		entries = append(entries, e)
 	}
 	clear(h.conns)
+	clear(h.subjectIdx)
 	h.connMu.Unlock()
 
 	// Close all connections synchronously. cancel() unblocks Read via
@@ -259,6 +277,7 @@ func (h *Hub) shutdown(ctx context.Context) error {
 	// + closeWg (see WS-OPS-02 in tech-debt-registry).
 	for _, e := range entries {
 		e.cancel()
+		e.closeSendOnce.Do(func() { close(e.send) })
 		if err := e.conn.Close(); err != nil {
 			slog.Warn("websocket hub: close connection failed",
 				slog.String("conn_id", e.conn.ID()),
@@ -267,7 +286,7 @@ func (h *Hub) shutdown(ctx context.Context) error {
 		}
 	}
 
-	// Wait for all goroutines (readLoops + pingLoop), bounded by ctx.
+	// Wait for all goroutines (readLoops + writeLoops + pingLoop), bounded by ctx.
 	done := make(chan struct{})
 	go func() {
 		h.wg.Wait()
@@ -320,18 +339,25 @@ func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	var evicted *connEntry
 	if old, ok := h.conns[conn.ID()]; ok {
 		delete(h.conns, conn.ID())
+		h.removeFromSubjectIdxLocked(old)
 		evicted = old
 	}
 
 	connCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	entry := &connEntry{conn: conn, cancel: cancel}
+	entry := &connEntry{
+		conn:   conn,
+		cancel: cancel,
+		send:   make(chan []byte, h.config.SendBufferSize),
+	}
 	h.conns[conn.ID()] = entry
-	h.wg.Add(1)
+	h.addToSubjectIdxLocked(entry)
+	h.wg.Add(2) // readLoop + writeLoop
 	h.connMu.Unlock()
 
 	// Close evicted conn outside lock.
 	if evicted != nil {
 		evicted.cancel()
+		evicted.closeSendOnce.Do(func() { close(evicted.send) })
 		_ = evicted.conn.Close()
 		slog.Warn("websocket hub: evicted duplicate conn",
 			slog.String("conn_id", conn.ID()),
@@ -345,11 +371,47 @@ func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	go func() {
 		defer h.wg.Done()
 		defer cancel() // ensures cancel is called when the goroutine exits
-		h.readLoop(connCtx, entry.conn)
+		h.readLoop(connCtx, conn)
 		h.unregisterEntry(entry)
 	}()
 
+	go func() {
+		defer h.wg.Done()
+		h.writeLoop(connCtx, entry)
+	}()
+
 	return nil
+}
+
+// addToSubjectIdxLocked must be called with connMu held. Skips entries whose
+// principal Subject is empty (anonymous, service, missing principal).
+func (h *Hub) addToSubjectIdxLocked(entry *connEntry) {
+	p := entry.conn.Principal()
+	if p == nil || p.Subject == "" {
+		return
+	}
+	bucket, ok := h.subjectIdx[p.Subject]
+	if !ok {
+		bucket = make(map[string]*connEntry)
+		h.subjectIdx[p.Subject] = bucket
+	}
+	bucket[entry.conn.ID()] = entry
+}
+
+// removeFromSubjectIdxLocked must be called with connMu held.
+func (h *Hub) removeFromSubjectIdxLocked(entry *connEntry) {
+	p := entry.conn.Principal()
+	if p == nil || p.Subject == "" {
+		return
+	}
+	bucket, ok := h.subjectIdx[p.Subject]
+	if !ok {
+		return
+	}
+	delete(bucket, entry.conn.ID())
+	if len(bucket) == 0 {
+		delete(h.subjectIdx, p.Subject)
+	}
 }
 
 // unregisterEntry is called by the readLoop goroutine. It only removes the
@@ -363,6 +425,7 @@ func (h *Hub) unregisterEntry(entry *connEntry) {
 	current, ok := h.conns[connID]
 	if ok && current == entry {
 		delete(h.conns, connID)
+		h.removeFromSubjectIdxLocked(entry)
 	} else {
 		ok = false
 	}
@@ -370,6 +433,9 @@ func (h *Hub) unregisterEntry(entry *connEntry) {
 
 	if ok {
 		entry.cancel()
+		// close send AFTER state cleared; writeLoop exits.
+		// unregisterEntry is called exactly once from readLoop's defer.
+		entry.closeSendOnce.Do(func() { close(entry.send) })
 		if err := entry.conn.Close(); err != nil {
 			slog.Debug("websocket hub: close on unregister",
 				slog.String("conn_id", connID),
@@ -390,11 +456,13 @@ func (h *Hub) Unregister(connID string) {
 	entry, ok := h.conns[connID]
 	if ok {
 		delete(h.conns, connID)
+		h.removeFromSubjectIdxLocked(entry)
 	}
 	h.connMu.Unlock()
 
 	if ok {
 		entry.cancel()
+		entry.closeSendOnce.Do(func() { close(entry.send) })
 		if err := entry.conn.Close(); err != nil {
 			slog.Debug("websocket hub: close on unregister",
 				slog.String("conn_id", connID),
@@ -407,33 +475,118 @@ func (h *Hub) Unregister(connID string) {
 	}
 }
 
-// Broadcast sends a text message to all connected clients concurrently.
-// A slow connection does not block delivery to other connections.
-func (h *Hub) Broadcast(ctx context.Context, data []byte) {
+// BroadcastFilter sends data to every connection for which filter returns true.
+// filter must be non-nil; passing nil returns ErrWebsocketBroadcastFilterMissing
+// (fail-closed: full-broadcast must be expressed as `func(Conn) bool { return true }`).
+//
+// filter is invoked under no lock; implementations must be O(1) (a closure that
+// reads Conn.Principal() is fine; database queries are an anti-pattern). filter
+// may be invoked from a single goroutine (the caller's goroutine).
+//
+// A connection whose send buffer is full is evicted (slow client; the broadcast
+// continues to other connections). Returns nil on success even if some
+// connections were evicted; the eviction is logged and counted via slog.
+//
+// ref: olahol/melody melody.go BroadcastFilter
+func (h *Hub) BroadcastFilter(ctx context.Context, data []byte, filter func(Conn) bool) error {
+	if filter == nil {
+		return errcode.New(errcode.KindInternal, ErrWebsocketBroadcastFilterMissing,
+			"websocket: BroadcastFilter requires a non-nil filter; "+
+				"use func(Conn) bool { return true } for full broadcast")
+	}
 	h.connMu.Lock()
-	entries := make([]*connEntry, 0, len(h.conns))
+	selected := make([]*connEntry, 0, len(h.conns))
 	for _, e := range h.conns {
-		entries = append(entries, e)
+		if filter(e.conn) {
+			selected = append(selected, e)
+		}
 	}
 	h.connMu.Unlock()
 
-	var wg sync.WaitGroup
-	for _, e := range entries {
-		wg.Add(1)
-		go func(e *connEntry) {
-			defer wg.Done()
-			if err := e.conn.Write(ctx, data); err != nil {
-				slog.Warn("websocket hub: broadcast write failed",
-					slog.String("conn_id", e.conn.ID()),
-					slog.Any("error", err),
-				)
-			}
-		}(e)
+	h.fanout(ctx, selected, data)
+	return nil
+}
+
+// BroadcastToSubject sends data to every connection whose Principal.Subject
+// matches the supplied subject. Subject "" returns ErrWebsocketBroadcastSubjectMissing
+// (fail-closed: callers must declare an explicit identity). An unknown subject
+// (no matching connections) is a no-op and returns nil.
+//
+// O(1) lookup via the hub's subject index (centrifuge-style). Connection
+// eviction on full send buffer is the same as BroadcastFilter.
+//
+// ref: centrifugal/centrifuge hub.go connShard.users
+func (h *Hub) BroadcastToSubject(ctx context.Context, subject string, data []byte) error {
+	if subject == "" {
+		return errcode.New(errcode.KindInternal, ErrWebsocketBroadcastSubjectMissing,
+			"websocket: BroadcastToSubject requires a non-empty subject")
 	}
-	wg.Wait()
+	h.connMu.Lock()
+	bucket := h.subjectIdx[subject]
+	selected := make([]*connEntry, 0, len(bucket))
+	for _, e := range bucket {
+		selected = append(selected, e)
+	}
+	h.connMu.Unlock()
+
+	h.fanout(ctx, selected, data)
+	return nil
+}
+
+// fanout enqueues data on each entry's send chan; full-buffer triggers eviction.
+// Caller must NOT hold connMu (fanout acquires it for evictions).
+func (h *Hub) fanout(ctx context.Context, entries []*connEntry, data []byte) {
+	for _, e := range entries {
+		select {
+		case e.send <- data:
+			// queued
+		default:
+			h.evictSlow(e)
+		}
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+// evictSlow removes a slow client whose send buffer is full. Idempotent;
+// safe to call from fanout, writeLoop, or pingLoop.
+func (h *Hub) evictSlow(e *connEntry) {
+	connID := e.conn.ID()
+	h.connMu.Lock()
+	current, ok := h.conns[connID]
+	if ok && current == e {
+		delete(h.conns, connID)
+		h.removeFromSubjectIdxLocked(e)
+	} else {
+		ok = false
+	}
+	h.connMu.Unlock()
+
+	if !ok {
+		return
+	}
+	e.cancel()
+	e.closeSendOnce.Do(func() { close(e.send) })
+	if err := e.conn.Close(); err != nil {
+		slog.Debug("websocket hub: close on slow-client evict",
+			slog.String("conn_id", connID),
+			slog.Any("error", err),
+		)
+	}
+	var subject string
+	if p := e.conn.Principal(); p != nil {
+		subject = p.Subject
+	}
+	slog.Warn("websocket hub: slow client evicted, send buffer full",
+		slog.String("conn_id", connID),
+		slog.String("subject", subject),
+	)
 }
 
 // Send sends a text message to a specific connection.
+// If the connection's send buffer is full, the connection is evicted and
+// ErrWebsocketSlowClient is returned.
 func (h *Hub) Send(ctx context.Context, connID string, data []byte) error {
 	h.connMu.Lock()
 	entry, ok := h.conns[connID]
@@ -444,7 +597,14 @@ func (h *Hub) Send(ctx context.Context, connID string, data []byte) error {
 			"websocket: connection not found: "+connID)
 	}
 
-	return entry.conn.Write(ctx, data)
+	select {
+	case entry.send <- data:
+		return nil
+	default:
+		h.evictSlow(entry)
+		return errcode.New(errcode.KindUnavailable, ErrWebsocketSlowClient,
+			"websocket: connection "+connID+" send buffer full, evicted")
+	}
 }
 
 // Config returns the Hub's configuration.
@@ -477,6 +637,33 @@ func (h *Hub) readLoop(ctx context.Context, conn Conn) {
 	}
 }
 
+// writeLoop drains the entry's send channel and writes each message to conn.
+// Exits when the send channel is closed (connection removed) or context is
+// canceled. On write failure, evicts the connection.
+//
+// ref: gorilla/websocket examples/chat/hub.go — select-default-drop pattern
+func (h *Hub) writeLoop(ctx context.Context, entry *connEntry) {
+	for {
+		select {
+		case data, ok := <-entry.send:
+			if !ok {
+				return // chan closed → exit
+			}
+			if err := entry.conn.Write(ctx, data); err != nil {
+				slog.Debug("websocket hub: write failed in writeLoop",
+					slog.String("conn_id", entry.conn.ID()),
+					slog.Any("error", err),
+				)
+				// Write fail also evicts (network error, conn dead)
+				h.evictSlow(entry)
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func (h *Hub) pingLoop(ctx context.Context) {
 	ticker := h.clk.NewTicker(h.config.PingInterval)
 	defer ticker.Stop()
@@ -497,12 +684,64 @@ func (h *Hub) pingAll(ctx context.Context) {
 	maps.Copy(snapshot, h.conns)
 	h.connMu.Unlock()
 
+	now := h.clk.Now()
 	for connID, entry := range snapshot {
+		// Token expiry check first (before paying the network round-trip).
+		if h.isExpired(entry, now) {
+			h.evictExpired(entry)
+			continue
+		}
 		pingCtx, cancel := context.WithTimeout(ctx, h.config.PingTimeout)
 		err := entry.conn.Ping(pingCtx)
 		cancel()
 		h.handlePingResult(connID, err)
 	}
+}
+
+// isExpired reports whether the entry's principal token has expired.
+func (h *Hub) isExpired(entry *connEntry, now time.Time) bool {
+	p := entry.conn.Principal()
+	if p == nil {
+		return false
+	}
+	if p.ExpiresAt.IsZero() {
+		return false
+	}
+	return p.ExpiresAt.Before(now)
+}
+
+// evictExpired removes a connection whose principal token has expired.
+func (h *Hub) evictExpired(entry *connEntry) {
+	connID := entry.conn.ID()
+	h.connMu.Lock()
+	current, ok := h.conns[connID]
+	if ok && current == entry {
+		delete(h.conns, connID)
+		h.removeFromSubjectIdxLocked(entry)
+	} else {
+		ok = false
+	}
+	h.connMu.Unlock()
+
+	if !ok {
+		return
+	}
+	entry.cancel()
+	entry.closeSendOnce.Do(func() { close(entry.send) })
+	if err := entry.conn.Close(); err != nil {
+		slog.Debug("websocket hub: close on expiry evict",
+			slog.String("conn_id", connID),
+			slog.Any("error", err),
+		)
+	}
+	var subject string
+	if p := entry.conn.Principal(); p != nil {
+		subject = p.Subject
+	}
+	slog.Info("websocket hub: connection evicted on token expiry",
+		slog.String("conn_id", connID),
+		slog.String("subject", subject),
+	)
 }
 
 // handlePingResult records a successful ping or increments the miss counter.
@@ -525,12 +764,14 @@ func (h *Hub) handlePingResult(connID string, pingErr error) {
 	current.pingMisses++
 	if current.pingMisses >= h.config.PingMissMax {
 		delete(h.conns, connID)
+		h.removeFromSubjectIdxLocked(current)
 		h.connMu.Unlock()
 		slog.Warn("websocket hub: ping threshold exceeded, removing connection",
 			slog.String("conn_id", connID),
 			slog.Int("misses", current.pingMisses),
 		)
 		current.cancel()
+		current.closeSendOnce.Do(func() { close(current.send) })
 		_ = current.conn.Close()
 		return
 	}
@@ -540,3 +781,4 @@ func (h *Hub) handlePingResult(connID string, pingErr error) {
 		slog.Int("misses", current.pingMisses),
 	)
 }
+

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -746,11 +746,16 @@ func (h *Hub) pingAll(ctx context.Context) {
 
 // isExpired reports whether the entry's principal token has expired.
 // Uses the expiresAt snapshot captured at Register time.
+//
+// Boundary semantics: expiresAt == now is treated as expired (RFC 7519 §4.1.4:
+// "the current date/time MUST be before the expiration date/time listed in the
+// exp claim"; on-or-after exp means rejection). Implementation uses
+// !After(now) rather than Before(now) so the exact-tick case evicts.
 func (h *Hub) isExpired(entry *connEntry, now time.Time) bool {
 	if entry.expiresAt.IsZero() {
 		return false
 	}
-	return entry.expiresAt.Before(now)
+	return !entry.expiresAt.After(now)
 }
 
 // evictWith removes an entry from conns + subjectIdx and tears down its

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
 
 // Hub lifecycle states (atomic.Int32 transitions).
@@ -49,9 +50,9 @@ type HubConfig struct {
 
 	// SendBufferSize is the per-connection send channel capacity used by the
 	// writeLoop. When the channel is full the connection is evicted (slow
-	// client; gorilla/websocket select-default-drop). Default 32; 0 means
-	// unbuffered (any send that doesn't immediately match a receive triggers
-	// eviction — extreme fail-closed mode for low-latency scenarios).
+	// client; gorilla/websocket select-default-drop). Default 32; zero value
+	// is replaced with the default at construction time. Must be > 0 if
+	// explicitly set.
 	SendBufferSize int
 }
 
@@ -71,13 +72,24 @@ func DefaultHubConfig(clk clock.Clock) HubConfig {
 // MessageHandler is called when a message is received from a client.
 type MessageHandler func(ctx context.Context, connID string, data []byte)
 
-// connEntry wraps a Conn with its per-connection context, ping state, and send channel.
+// connEntry wraps a Conn with its per-connection context, ping state, send
+// channel, and a snapshot of the principal fields captured at Register time.
+//
+// ref: centrifugal/centrifuge client.go — c.user / c.exp value snapshot at
+// handshake; hub never re-reads conn.Principal() after registration.
 type connEntry struct {
-	conn          Conn
-	cancel        context.CancelFunc
-	pingMisses    int
-	send          chan []byte // buffered, sized by HubConfig.SendBufferSize
-	closeSendOnce sync.Once   // guards close(send) for idempotent close
+	conn       Conn
+	cancel     context.CancelFunc
+	pingMisses int
+	send       chan []byte   // buffered, sized by HubConfig.SendBufferSize
+	done       chan struct{}  // closed when entry is evicted; writeLoop exit signal
+	closeOnce  sync.Once     // guards close(done) for idempotent eviction
+
+	// subject and expiresAt are frozen at Register time from conn.Principal().
+	// Hub does not call conn.Principal() after registration — the principal is
+	// treated as immutable for the lifetime of the connection.
+	subject   string    // conn.Principal().Subject; empty for anonymous/service
+	expiresAt time.Time // conn.Principal().ExpiresAt; zero = no expiry
 }
 
 // Hub manages WebSocket connections and provides signal-first broadcasting.
@@ -112,9 +124,10 @@ type Hub struct {
 	connMu sync.Mutex
 	conns  map[string]*connEntry
 	// subjectIdx[subject][connID] = entry. Maintained in lockstep with conns.
-	// Only populated for entries whose Conn.Principal().Subject is non-empty.
+	// Only populated for entries whose subject snapshot is non-empty.
 	// Synced at: Register / unregisterEntry / Unregister / pingLoop expiry-evict
 	// / slow-client evict / shutdown drain.
+	// All writes to conns and subjectIdx MUST go through removeConnLocked.
 	subjectIdx map[string]map[string]*connEntry
 	wg         sync.WaitGroup // tracks readLoop + writeLoop + pingLoop goroutines
 
@@ -142,6 +155,9 @@ func NewHub(cfg HubConfig, handler MessageHandler) *Hub {
 	}
 	if cfg.PingMissMax == 0 {
 		cfg.PingMissMax = defaultPingMissMax
+	}
+	if cfg.SendBufferSize == 0 {
+		cfg.SendBufferSize = defaultSendBufferSize
 	}
 	if handler == nil {
 		handler = func(context.Context, string, []byte) {}
@@ -262,6 +278,9 @@ func (h *Hub) shutdown(ctx context.Context) error {
 	for _, e := range h.conns {
 		entries = append(entries, e)
 	}
+	// Bulk drain: clear both maps together. This is the only place that
+	// bypasses removeConnLocked — bulk shutdown must clear both atomically.
+	// All non-shutdown write paths must use removeConnLocked.
 	clear(h.conns)
 	clear(h.subjectIdx)
 	h.connMu.Unlock()
@@ -277,7 +296,7 @@ func (h *Hub) shutdown(ctx context.Context) error {
 	// + closeWg (see WS-OPS-02 in tech-debt-registry).
 	for _, e := range entries {
 		e.cancel()
-		e.closeSendOnce.Do(func() { close(e.send) })
+		e.closeOnce.Do(func() { close(e.done) })
 		if err := e.conn.Close(); err != nil {
 			slog.Warn("websocket hub: close connection failed",
 				slog.String("conn_id", e.conn.ID()),
@@ -315,6 +334,9 @@ func (h *Hub) shutdown(ctx context.Context) error {
 //
 // The Hub must be in the running state (Start called). Register on an
 // idle, stopping, or stopped Hub returns an error and closes the conn.
+//
+// The per-connection context carries the connection's Principal (if present)
+// so that MessageHandler can call auth.FromContext(ctx) for inbound ACL.
 func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	h.connMu.Lock()
 	s := h.state.Load()
@@ -338,16 +360,34 @@ func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	// Evict existing entry with same ID to prevent context leak.
 	var evicted *connEntry
 	if old, ok := h.conns[conn.ID()]; ok {
-		delete(h.conns, conn.ID())
-		h.removeFromSubjectIdxLocked(old)
+		h.removeConnLocked(old)
 		evicted = old
 	}
 
+	// Snapshot principal fields once at handshake time.
+	// Hub never re-reads conn.Principal() after this point.
+	// ref: centrifugal/centrifuge client.go — c.user / c.exp frozen at connect.
+	var subject string
+	var expiresAt time.Time
+	if p := conn.Principal(); p != nil {
+		subject = p.Subject
+		expiresAt = p.ExpiresAt
+	}
+
 	connCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	// Inject principal into per-conn context so MessageHandler can do ACL
+	// via auth.FromContext(ctx).
+	if p := conn.Principal(); p != nil {
+		connCtx = auth.WithPrincipal(connCtx, p)
+	}
+
 	entry := &connEntry{
-		conn:   conn,
-		cancel: cancel,
-		send:   make(chan []byte, h.config.SendBufferSize),
+		conn:      conn,
+		cancel:    cancel,
+		send:      make(chan []byte, h.config.SendBufferSize),
+		done:      make(chan struct{}),
+		subject:   subject,
+		expiresAt: expiresAt,
 	}
 	h.conns[conn.ID()] = entry
 	h.addToSubjectIdxLocked(entry)
@@ -357,10 +397,11 @@ func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	// Close evicted conn outside lock.
 	if evicted != nil {
 		evicted.cancel()
-		evicted.closeSendOnce.Do(func() { close(evicted.send) })
+		evicted.closeOnce.Do(func() { close(evicted.done) })
 		_ = evicted.conn.Close()
 		slog.Warn("websocket hub: evicted duplicate conn",
 			slog.String("conn_id", conn.ID()),
+			slog.String("reason", "duplicate_conn_id"),
 		)
 	}
 
@@ -383,34 +424,41 @@ func (h *Hub) Register(ctx context.Context, conn Conn) error {
 	return nil
 }
 
+// removeConnLocked deletes entry from h.conns and h.subjectIdx atomically.
+// Caller must hold connMu. This is the single allowed mutation site for
+// h.conns outside of shutdown's bulk drain; SEC-FAIL-CLOSED-09 archtest
+// forbids raw delete(h.conns,) / clear(h.conns) elsewhere in hub.go.
+func (h *Hub) removeConnLocked(entry *connEntry) {
+	delete(h.conns, entry.conn.ID())
+	h.removeFromSubjectIdxLocked(entry)
+}
+
 // addToSubjectIdxLocked must be called with connMu held. Skips entries whose
-// principal Subject is empty (anonymous, service, missing principal).
+// subject snapshot is empty (anonymous, service, missing principal).
 func (h *Hub) addToSubjectIdxLocked(entry *connEntry) {
-	p := entry.conn.Principal()
-	if p == nil || p.Subject == "" {
+	if entry.subject == "" {
 		return
 	}
-	bucket, ok := h.subjectIdx[p.Subject]
+	bucket, ok := h.subjectIdx[entry.subject]
 	if !ok {
 		bucket = make(map[string]*connEntry)
-		h.subjectIdx[p.Subject] = bucket
+		h.subjectIdx[entry.subject] = bucket
 	}
 	bucket[entry.conn.ID()] = entry
 }
 
 // removeFromSubjectIdxLocked must be called with connMu held.
 func (h *Hub) removeFromSubjectIdxLocked(entry *connEntry) {
-	p := entry.conn.Principal()
-	if p == nil || p.Subject == "" {
+	if entry.subject == "" {
 		return
 	}
-	bucket, ok := h.subjectIdx[p.Subject]
+	bucket, ok := h.subjectIdx[entry.subject]
 	if !ok {
 		return
 	}
 	delete(bucket, entry.conn.ID())
 	if len(bucket) == 0 {
-		delete(h.subjectIdx, p.Subject)
+		delete(h.subjectIdx, entry.subject)
 	}
 }
 
@@ -424,8 +472,7 @@ func (h *Hub) unregisterEntry(entry *connEntry) {
 	h.connMu.Lock()
 	current, ok := h.conns[connID]
 	if ok && current == entry {
-		delete(h.conns, connID)
-		h.removeFromSubjectIdxLocked(entry)
+		h.removeConnLocked(entry)
 	} else {
 		ok = false
 	}
@@ -433,9 +480,10 @@ func (h *Hub) unregisterEntry(entry *connEntry) {
 
 	if ok {
 		entry.cancel()
-		// close send AFTER state cleared; writeLoop exits.
-		// unregisterEntry is called exactly once from readLoop's defer.
-		entry.closeSendOnce.Do(func() { close(entry.send) })
+		// Signal writeLoop to exit via done channel (not by closing send).
+		// ref: centrifugal/centrifuge internal/queue/queue.go — never close the
+		// producer-facing channel to avoid send-on-closed-channel panics.
+		entry.closeOnce.Do(func() { close(entry.done) })
 		if err := entry.conn.Close(); err != nil {
 			slog.Debug("websocket hub: close on unregister",
 				slog.String("conn_id", connID),
@@ -455,14 +503,13 @@ func (h *Hub) Unregister(connID string) {
 	h.connMu.Lock()
 	entry, ok := h.conns[connID]
 	if ok {
-		delete(h.conns, connID)
-		h.removeFromSubjectIdxLocked(entry)
+		h.removeConnLocked(entry)
 	}
 	h.connMu.Unlock()
 
 	if ok {
 		entry.cancel()
-		entry.closeSendOnce.Do(func() { close(entry.send) })
+		entry.closeOnce.Do(func() { close(entry.done) })
 		if err := entry.conn.Close(); err != nil {
 			slog.Debug("websocket hub: close on unregister",
 				slog.String("conn_id", connID),
@@ -494,15 +541,23 @@ func (h *Hub) BroadcastFilter(ctx context.Context, data []byte, filter func(Conn
 			"websocket: BroadcastFilter requires a non-nil filter; "+
 				"use func(Conn) bool { return true } for full broadcast")
 	}
+
+	// Snapshot entries under lock; run filter outside lock to avoid
+	// deadlock if filter calls hub.Send (which also acquires connMu).
+	// ref: olahol/melody melody.go — filter runs outside session lock.
 	h.connMu.Lock()
-	selected := make([]*connEntry, 0, len(h.conns))
+	snapshot := make([]*connEntry, 0, len(h.conns))
 	for _, e := range h.conns {
+		snapshot = append(snapshot, e)
+	}
+	h.connMu.Unlock()
+
+	selected := make([]*connEntry, 0, len(snapshot))
+	for _, e := range snapshot {
 		if filter(e.conn) {
 			selected = append(selected, e)
 		}
 	}
-	h.connMu.Unlock()
-
 	h.fanout(ctx, selected, data)
 	return nil
 }
@@ -535,32 +590,39 @@ func (h *Hub) BroadcastToSubject(ctx context.Context, subject string, data []byt
 
 // fanout enqueues data on each entry's send chan; full-buffer triggers eviction.
 // Caller must NOT hold connMu (fanout acquires it for evictions).
+// ctx cancellation causes fanout to return early without enqueuing remaining entries.
 func (h *Hub) fanout(ctx context.Context, entries []*connEntry, data []byte) {
 	for _, e := range entries {
-		select {
-		case e.send <- data:
-			// queued
-		default:
-			h.evictSlow(e)
-		}
 		if ctx.Err() != nil {
 			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case e.send <- data:
+			// queued
+		case <-e.done:
+			// already evicted, skip silently
+		default:
+			h.evictWith(e, "send_buffer_full", slog.LevelWarn,
+				"websocket hub: slow client evicted, send buffer full",
+				"websocket hub: close on slow-client evict")
 		}
 	}
 }
 
-// evictSlow removes a slow client whose send buffer is full. Idempotent;
-// safe to call from fanout, writeLoop, or pingLoop.
-func (h *Hub) evictSlow(e *connEntry) {
-	h.evictEntry(e, slog.LevelWarn,
-		"websocket hub: slow client evicted, send buffer full",
-		"websocket hub: close on slow-client evict")
-}
-
 // Send sends a text message to a specific connection.
 // If the connection's send buffer is full, the connection is evicted and
-// ErrWebsocketSlowClient is returned.
+// ErrWebsocketSlowClient is returned. If ctx is already canceled, returns
+// ctx.Err() without enqueuing.
 func (h *Hub) Send(ctx context.Context, connID string, data []byte) error {
+	// Pre-check: if ctx is already done, return immediately without touching
+	// the send channel. This gives ctx.Done() priority over the send case
+	// (Go select does not guarantee ordering when multiple cases are ready).
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	h.connMu.Lock()
 	entry, ok := h.conns[connID]
 	h.connMu.Unlock()
@@ -571,10 +633,17 @@ func (h *Hub) Send(ctx context.Context, connID string, data []byte) error {
 	}
 
 	select {
+	case <-ctx.Done():
+		return ctx.Err()
 	case entry.send <- data:
 		return nil
+	case <-entry.done:
+		return errcode.New(errcode.KindUnavailable, errcode.ErrWSConnNotFound,
+			"websocket: connection "+connID+" already evicted")
 	default:
-		h.evictSlow(entry)
+		h.evictWith(entry, "send_buffer_full", slog.LevelWarn,
+			"websocket hub: slow client evicted, send buffer full",
+			"websocket hub: close on slow-client evict")
 		return errcode.New(errcode.KindUnavailable, errcode.ErrWebsocketSlowClient,
 			"websocket: connection "+connID+" send buffer full, evicted")
 	}
@@ -611,28 +680,30 @@ func (h *Hub) readLoop(ctx context.Context, conn Conn) {
 }
 
 // writeLoop drains the entry's send channel and writes each message to conn.
-// Exits when the send channel is closed (connection removed) or context is
-// canceled. On write failure, evicts the connection.
+// Exits when entry.done is closed (connection evicted/removed) or the
+// per-conn context is canceled. On write failure, evicts the connection.
 //
-// ref: gorilla/websocket examples/chat/hub.go — select-default-drop pattern
+// ref: centrifugal/centrifuge internal/queue/queue.go — select on done chan
+// rather than closing the send channel to avoid send-on-closed-channel panics
+// in concurrent producers (fanout, Send).
 func (h *Hub) writeLoop(ctx context.Context, entry *connEntry) {
 	for {
 		select {
-		case data, ok := <-entry.send:
-			if !ok {
-				return // chan closed → exit
-			}
+		case <-entry.done:
+			return
+		case <-ctx.Done():
+			return
+		case data := <-entry.send:
 			if err := entry.conn.Write(ctx, data); err != nil {
 				slog.Debug("websocket hub: write failed in writeLoop",
 					slog.String("conn_id", entry.conn.ID()),
 					slog.Any("error", err),
 				)
-				// Write fail also evicts (network error, conn dead)
-				h.evictSlow(entry)
+				h.evictWith(entry, "connection_write_failed", slog.LevelWarn,
+					"websocket hub: connection evicted on write failure",
+					"websocket hub: close on write-failure evict")
 				return
 			}
-		case <-ctx.Done():
-			return
 		}
 	}
 }
@@ -661,7 +732,9 @@ func (h *Hub) pingAll(ctx context.Context) {
 	for connID, entry := range snapshot {
 		// Token expiry check first (before paying the network round-trip).
 		if h.isExpired(entry, now) {
-			h.evictExpired(entry)
+			h.evictWith(entry, "token_expired", slog.LevelInfo,
+				"websocket hub: connection evicted on token expiry",
+				"websocket hub: close on expiry evict")
 			continue
 		}
 		pingCtx, cancel := context.WithTimeout(ctx, h.config.PingTimeout)
@@ -672,36 +745,26 @@ func (h *Hub) pingAll(ctx context.Context) {
 }
 
 // isExpired reports whether the entry's principal token has expired.
+// Uses the expiresAt snapshot captured at Register time.
 func (h *Hub) isExpired(entry *connEntry, now time.Time) bool {
-	p := entry.conn.Principal()
-	if p == nil {
+	if entry.expiresAt.IsZero() {
 		return false
 	}
-	if p.ExpiresAt.IsZero() {
-		return false
-	}
-	return p.ExpiresAt.Before(now)
+	return entry.expiresAt.Before(now)
 }
 
-// evictExpired removes a connection whose principal token has expired.
-func (h *Hub) evictExpired(entry *connEntry) {
-	h.evictEntry(entry, slog.LevelInfo,
-		"websocket hub: connection evicted on token expiry",
-		"websocket hub: close on expiry evict")
-}
-
-// evictEntry removes an entry from conns + subjectIdx and tears down its
+// evictWith removes an entry from conns + subjectIdx and tears down its
 // goroutines. Idempotent: safe to call from any path (slow-client,
-// token-expiry, or future eviction reasons). evictMsg is logged at the
-// supplied level on success; closeMsg is logged at Debug if conn.Close
+// token-expiry, write-failure, or future eviction reasons). reason is
+// included in structured log fields for observability. evictMsg is logged at
+// the supplied level on success; closeMsg is logged at Debug if conn.Close
 // returns an error.
-func (h *Hub) evictEntry(entry *connEntry, level slog.Level, evictMsg, closeMsg string) {
+func (h *Hub) evictWith(entry *connEntry, reason string, level slog.Level, evictMsg, closeMsg string) {
 	connID := entry.conn.ID()
 	h.connMu.Lock()
 	current, ok := h.conns[connID]
 	if ok && current == entry {
-		delete(h.conns, connID)
-		h.removeFromSubjectIdxLocked(entry)
+		h.removeConnLocked(entry)
 	} else {
 		ok = false
 	}
@@ -711,20 +774,18 @@ func (h *Hub) evictEntry(entry *connEntry, level slog.Level, evictMsg, closeMsg 
 		return
 	}
 	entry.cancel()
-	entry.closeSendOnce.Do(func() { close(entry.send) })
+	entry.closeOnce.Do(func() { close(entry.done) })
 	if err := entry.conn.Close(); err != nil {
 		slog.Debug(closeMsg,
 			slog.String("conn_id", connID),
+			slog.String("reason", reason),
 			slog.Any("error", err),
 		)
 	}
-	var subject string
-	if p := entry.conn.Principal(); p != nil {
-		subject = p.Subject
-	}
 	slog.LogAttrs(context.Background(), level, evictMsg,
 		slog.String("conn_id", connID),
-		slog.String("subject", subject),
+		slog.String("subject", entry.subject),
+		slog.String("reason", reason),
 	)
 }
 
@@ -747,15 +808,14 @@ func (h *Hub) handlePingResult(connID string, pingErr error) {
 	}
 	current.pingMisses++
 	if current.pingMisses >= h.config.PingMissMax {
-		delete(h.conns, connID)
-		h.removeFromSubjectIdxLocked(current)
+		h.removeConnLocked(current)
 		h.connMu.Unlock()
 		slog.Warn("websocket hub: ping threshold exceeded, removing connection",
 			slog.String("conn_id", connID),
 			slog.Int("misses", current.pingMisses),
 		)
 		current.cancel()
-		current.closeSendOnce.Do(func() { close(current.send) })
+		current.closeOnce.Do(func() { close(current.done) })
 		_ = current.conn.Close()
 		return
 	}

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -13,10 +13,10 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/runtime/auth"
 )
-
-const hubBroadcastConcurrentDeadline = 400 * time.Millisecond
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
@@ -38,6 +38,7 @@ type fakeConn struct {
 	readyOnce  sync.Once
 	pingErr    error         // configurable: non-nil makes Ping fail
 	writeDelay time.Duration // configurable: simulates slow writes
+	principal  *auth.Principal
 }
 
 func newFakeConn(id string) *fakeConn {
@@ -109,6 +110,18 @@ func (f *fakeConn) Close() error {
 	f.closed = true
 	close(f.closeCh)
 	return nil
+}
+
+func (f *fakeConn) Principal() *auth.Principal {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.principal
+}
+
+func newFakeConnWithPrincipal(id string, p *auth.Principal) *fakeConn {
+	c := newFakeConn(id)
+	c.principal = p
+	return c
 }
 
 func (f *fakeConn) isClosed() bool {
@@ -492,70 +505,9 @@ func TestHub_RegisterStopRace(t *testing.T) {
 	// goleak.VerifyTestMain catches any leaked goroutines.
 }
 
-func TestHub_ConcurrentBroadcast(t *testing.T) {
-	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
-
-	conns := make([]*fakeConn, 5)
-	for i := range conns {
-		c := newFakeConn("bc" + string(rune('0'+i)))
-		conns[i] = c
-		require.NoError(t, hub.Register(context.Background(), c))
-		<-c.readyCh
-	}
-
-	var wg sync.WaitGroup
-	for range 10 {
-		wg.Go(func() {
-			hub.Broadcast(context.Background(), []byte("msg"))
-		})
-	}
-	wg.Wait()
-
-	for _, c := range conns {
-		assert.NotEmpty(t, c.getWrites())
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Functional Tests
 // ---------------------------------------------------------------------------
-
-func TestHub_Broadcast(t *testing.T) {
-	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
-
-	c1 := newFakeConn("c1")
-	c2 := newFakeConn("c2")
-	require.NoError(t, hub.Register(context.Background(), c1))
-	require.NoError(t, hub.Register(context.Background(), c2))
-	<-c1.readyCh
-	<-c2.readyCh
-
-	hub.Broadcast(context.Background(), []byte("hello all"))
-
-	assert.Equal(t, [][]byte{[]byte("hello all")}, c1.getWrites())
-	assert.Equal(t, [][]byte{[]byte("hello all")}, c2.getWrites())
-}
-
-func TestHub_BroadcastSlowConn(t *testing.T) {
-	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
-
-	fast := newFakeConn("fast")
-	slow := newFakeConn("slow")
-	slow.writeDelay = testtime.D200ms
-
-	require.NoError(t, hub.Register(context.Background(), fast))
-	require.NoError(t, hub.Register(context.Background(), slow))
-	<-fast.readyCh
-	<-slow.readyCh
-
-	start := time.Now()
-	hub.Broadcast(context.Background(), []byte("data"))
-	elapsed := time.Since(start)
-
-	assert.Equal(t, [][]byte{[]byte("data")}, fast.getWrites())
-	assert.Equal(t, [][]byte{[]byte("data")}, slow.getWrites())
-	assert.Less(t, elapsed, hubBroadcastConcurrentDeadline, "broadcast should be concurrent")
-}
 
 func TestHub_Send(t *testing.T) {
 	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
@@ -800,7 +752,8 @@ func (s *stuckConn) Read(_ context.Context) ([]byte, error) {
 	<-s.closeCh
 	return nil, errors.New("closed")
 }
-func (s *stuckConn) Write(_ context.Context, _ []byte) error { return nil }
+func (s *stuckConn) Write(_ context.Context, _ []byte) error    { return nil }
+func (s *stuckConn) Principal() *auth.Principal                 { return nil }
 func (s *stuckConn) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1006,3 +959,248 @@ var (
 	_ Conn = (*fakeConn)(nil)
 	_ Conn = (*stuckConn)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// BroadcastFilter / BroadcastToSubject Tests
+// ---------------------------------------------------------------------------
+
+func TestHub_BroadcastFilter_NilFilterFails(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+	err := hub.BroadcastFilter(context.Background(), []byte("x"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "filter")
+}
+
+func TestHub_BroadcastFilter_AllConns(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+	pa := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice"}
+	pb := &auth.Principal{Kind: auth.PrincipalUser, Subject: "bob"}
+	a := newFakeConnWithPrincipal("a", pa)
+	b := newFakeConnWithPrincipal("b", pb)
+	require.NoError(t, hub.Register(context.Background(), a))
+	require.NoError(t, hub.Register(context.Background(), b))
+	<-a.readyCh
+	<-b.readyCh
+
+	require.NoError(t, hub.BroadcastFilter(context.Background(), []byte("hi"),
+		func(c Conn) bool { return true }))
+
+	require.Eventually(t, func() bool {
+		return len(a.getWrites()) == 1 && len(b.getWrites()) == 1
+	}, testtime.D2s, testtime.D10ms)
+}
+
+func TestHub_BroadcastFilter_SelectiveBySubject(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+	pa := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice"}
+	pb := &auth.Principal{Kind: auth.PrincipalUser, Subject: "bob"}
+	a := newFakeConnWithPrincipal("a", pa)
+	b := newFakeConnWithPrincipal("b", pb)
+	require.NoError(t, hub.Register(context.Background(), a))
+	require.NoError(t, hub.Register(context.Background(), b))
+	<-a.readyCh
+	<-b.readyCh
+
+	require.NoError(t, hub.BroadcastFilter(context.Background(), []byte("only-alice"),
+		func(c Conn) bool { return c.Principal() != nil && c.Principal().Subject == "alice" }))
+
+	require.Eventually(t, func() bool {
+		return len(a.getWrites()) == 1
+	}, testtime.D2s, testtime.D10ms)
+
+	// Negative wait — bob must NOT receive.
+	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative test: bob must not receive within window
+	assert.Empty(t, b.getWrites())
+}
+
+func TestHub_BroadcastToSubject_EmptySubjectFails(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+	err := hub.BroadcastToSubject(context.Background(), "", []byte("x"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject")
+}
+
+func TestHub_BroadcastToSubject_HitsAllConnsForSubject(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+	pa := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice"}
+	pb := &auth.Principal{Kind: auth.PrincipalUser, Subject: "bob"}
+	a1 := newFakeConnWithPrincipal("a1", pa)
+	a2 := newFakeConnWithPrincipal("a2", pa)
+	b := newFakeConnWithPrincipal("b", pb)
+	require.NoError(t, hub.Register(context.Background(), a1))
+	require.NoError(t, hub.Register(context.Background(), a2))
+	require.NoError(t, hub.Register(context.Background(), b))
+	<-a1.readyCh
+	<-a2.readyCh
+	<-b.readyCh
+
+	require.NoError(t, hub.BroadcastToSubject(context.Background(), "alice", []byte("ping-alice")))
+
+	require.Eventually(t, func() bool {
+		return len(a1.getWrites()) == 1 && len(a2.getWrites()) == 1
+	}, testtime.D2s, testtime.D10ms)
+	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative window
+	assert.Empty(t, b.getWrites())
+}
+
+func TestHub_BroadcastToSubject_UnknownSubjectIsNoop(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+	// No conns at all. Subject not present → returns nil, no error.
+	err := hub.BroadcastToSubject(context.Background(), "ghost", []byte("x"))
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Token Expiry Eviction Tests
+// ---------------------------------------------------------------------------
+
+func TestHub_TokenExpiry_EvictsOnPing(t *testing.T) {
+	fc := clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	cfg := DefaultHubConfig(fc)
+	cfg.PingInterval = testtime.D10ms
+	cfg.PingTimeout = testtime.FastPoll
+
+	hub := startHub(t, cfg, nil)
+
+	p := &auth.Principal{
+		Kind:      auth.PrincipalUser,
+		Subject:   "expiring",
+		ExpiresAt: fc.Now().Add(time.Hour), // 1h from now
+	}
+	conn := newFakeConnWithPrincipal("expiring", p)
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+	require.Equal(t, 1, hub.ConnCount())
+
+	// Advance clock past expiry; next ping tick must evict.
+	fc.Advance(2 * time.Hour)
+
+	require.Eventually(t, func() bool {
+		return hub.ConnCount() == 0 && conn.isClosed()
+	}, testtime.D2s, testtime.D10ms)
+}
+
+func TestHub_TokenExpiry_ZeroExpiryNeverEvicts(t *testing.T) {
+	fc := clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	cfg := DefaultHubConfig(fc)
+	cfg.PingInterval = testtime.D10ms
+	cfg.PingTimeout = testtime.FastPoll
+
+	hub := startHub(t, cfg, nil)
+
+	// Anonymous principal: zero ExpiresAt = never expires.
+	p := &auth.Principal{Kind: auth.PrincipalAnonymous}
+	conn := newFakeConnWithPrincipal("perm", p)
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	// Advance clock far into future. Conn must remain.
+	fc.Advance(100 * 365 * 24 * time.Hour)
+
+	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative test: must NOT evict
+	assert.Equal(t, 1, hub.ConnCount())
+	assert.False(t, conn.isClosed())
+}
+
+// ---------------------------------------------------------------------------
+// Slow Client Eviction Tests
+// ---------------------------------------------------------------------------
+
+// blockingFakeConn never completes Write — used to simulate a slow/dead client
+// whose send chan fills.
+type blockingFakeConn struct {
+	*fakeConn
+	blockUntil chan struct{}
+}
+
+func newBlockingFakeConn(id string, p *auth.Principal) *blockingFakeConn {
+	return &blockingFakeConn{
+		fakeConn:   newFakeConnWithPrincipal(id, p),
+		blockUntil: make(chan struct{}),
+	}
+}
+
+func (b *blockingFakeConn) Write(ctx context.Context, data []byte) error {
+	select {
+	case <-b.blockUntil:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return b.fakeConn.Write(ctx, data)
+}
+
+func TestHub_SlowClient_EvictedWhenSendBufferFull(t *testing.T) {
+	cfg := DefaultHubConfig(clock.Real())
+	cfg.SendBufferSize = 2 // tiny buffer
+	hub := startHub(t, cfg, nil)
+
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "slow"}
+	slow := newBlockingFakeConn("slow", p)
+	defer close(slow.blockUntil) // unblock at test end so writeLoop can exit
+
+	require.NoError(t, hub.Register(context.Background(), slow))
+	<-slow.readyCh
+
+	// Pump enough messages to overflow send buffer (2) + writeLoop slot.
+	// BroadcastToSubject runs the slow path; writeLoop is stuck on Write so
+	// chan fills after a few sends.
+	for range 10 {
+		_ = hub.BroadcastToSubject(context.Background(), "slow", []byte("burst"))
+	}
+
+	require.Eventually(t, func() bool {
+		return hub.ConnCount() == 0
+	}, testtime.D2s, testtime.D10ms,
+		"slow client must be evicted once send buffer fills")
+}
+
+// ---------------------------------------------------------------------------
+// Subject Index Consistency Tests
+// ---------------------------------------------------------------------------
+
+func TestHub_SubjectIdx_EmptyAfterRegisterUnregister(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice"}
+	conn := newFakeConnWithPrincipal("a", p)
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	hub.Unregister("a")
+	require.Eventually(t, func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)
+
+	// Idx must be empty so a future BroadcastToSubject is a no-op.
+	err := hub.BroadcastToSubject(context.Background(), "alice", []byte("x"))
+	assert.NoError(t, err)
+	assert.Empty(t, conn.getWrites())
+}
+
+func TestHub_SubjectIdx_EmptyAfterTokenExpiry(t *testing.T) {
+	fc := clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	cfg := DefaultHubConfig(fc)
+	cfg.PingInterval = testtime.D10ms
+	cfg.PingTimeout = testtime.FastPoll
+	hub := startHub(t, cfg, nil)
+
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice", ExpiresAt: fc.Now().Add(time.Hour)}
+	conn := newFakeConnWithPrincipal("a", p)
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	fc.Advance(2 * time.Hour)
+
+	require.Eventually(t, func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)
+
+	err := hub.BroadcastToSubject(context.Background(), "alice", []byte("x"))
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// SendBufferSize Default Test
+// ---------------------------------------------------------------------------
+
+func TestDefaultHubConfig_SendBufferSize(t *testing.T) {
+	cfg := DefaultHubConfig(clock.Real())
+	assert.Equal(t, 32, cfg.SendBufferSize, "default SendBufferSize must be 32")
+}

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -1017,8 +1017,7 @@ func TestHub_BroadcastFilter_SelectiveBySubject(t *testing.T) {
 	}, testtime.D2s, testtime.D10ms)
 
 	// Negative wait — bob must NOT receive.
-	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative test: bob must not receive within window
-	assert.Empty(t, b.getWrites())
+	assert.Never(t, func() bool { return len(b.getWrites()) > 0 }, testtime.D100ms, testtime.D10ms)
 }
 
 func TestHub_BroadcastToSubject_EmptySubjectFails(t *testing.T) {
@@ -1047,8 +1046,7 @@ func TestHub_BroadcastToSubject_HitsAllConnsForSubject(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(a1.getWrites()) == 1 && len(a2.getWrites()) == 1
 	}, testtime.D2s, testtime.D10ms)
-	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative window
-	assert.Empty(t, b.getWrites())
+	assert.Never(t, func() bool { return len(b.getWrites()) > 0 }, testtime.D100ms, testtime.D10ms)
 }
 
 func TestHub_BroadcastToSubject_UnknownSubjectIsNoop(t *testing.T) {
@@ -1110,9 +1108,7 @@ func TestHub_TokenExpiry_ZeroExpiryNeverEvicts(t *testing.T) {
 	// ticker iterations in clockmock).
 	fc.Advance(testtime.D2h)
 
-	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative test: must NOT evict
-	assert.Equal(t, 1, hub.ConnCount())
-	assert.False(t, conn.isClosed())
+	assert.Never(t, func() bool { return hub.ConnCount() == 0 || conn.isClosed() }, testtime.D100ms, testtime.D10ms)
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -1088,6 +1088,39 @@ func TestHub_TokenExpiry_EvictsOnPing(t *testing.T) {
 	}, testtime.D2s, testtime.D10ms)
 }
 
+// TestHub_TokenExpiry_AtBoundaryEvicts locks RFC 7519 §4.1.4 boundary: the
+// token MUST NOT be accepted on or after the exp instant. Setup advances
+// the clock to *exactly* expiresAt — Before(now) would return false (still
+// alive); !After(now) returns true (evicted). This is the bug-or-not edge.
+func TestHub_TokenExpiry_AtBoundaryEvicts(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fc := clockmock.New(start)
+
+	cfg := DefaultHubConfig(fc)
+	cfg.PingInterval = testtime.D10ms
+	cfg.PingTimeout = testtime.FastPoll
+
+	hub := startHub(t, cfg, nil)
+
+	// Register at clock=start with ExpiresAt = start + 10ms.
+	exp := start.Add(testtime.D10ms)
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "boundary", ExpiresAt: exp}
+	conn := newFakeConnWithPrincipal("boundary", p)
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+	require.Equal(t, 1, hub.ConnCount())
+
+	// Advance clock to *exactly* ExpiresAt — boundary case.
+	// Before(exp) at exp: false (not strictly before). !After(exp) at exp: true.
+	// pingLoop fires at this tick because PingInterval == 10ms == advance.
+	fc.Advance(testtime.D10ms)
+
+	require.Eventually(t, func() bool {
+		return hub.ConnCount() == 0 && conn.isClosed()
+	}, testtime.D2s, testtime.D10ms,
+		"ExpiresAt == clock.Now() must evict (RFC 7519: on-or-after exp = expired)")
+}
+
 func TestHub_TokenExpiry_ZeroExpiryNeverEvicts(t *testing.T) {
 	fc := clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -444,7 +444,11 @@ func TestHub_RegisterDuplicateID(t *testing.T) {
 	assert.True(t, connA.isClosed(), "old conn should be closed")
 
 	// Send to "dup" should reach connB, not connA.
+	// Send enqueues on the per-conn channel; writeLoop delivers asynchronously.
 	require.NoError(t, hub.Send(context.Background(), "dup", []byte("hello")))
+	require.Eventually(t, func() bool {
+		return len(connB.getWrites()) == 1
+	}, testtime.D2s, testtime.D10ms)
 	assert.Equal(t, [][]byte{[]byte("hello")}, connB.getWrites())
 	assert.Empty(t, connA.getWrites())
 }
@@ -517,6 +521,10 @@ func TestHub_Send(t *testing.T) {
 	<-conn.readyCh
 
 	require.NoError(t, hub.Send(context.Background(), "target", []byte("direct")))
+	// Send enqueues on the per-conn channel; writeLoop delivers asynchronously.
+	require.Eventually(t, func() bool {
+		return len(conn.getWrites()) == 1
+	}, testtime.D2s, testtime.D10ms)
 	assert.Equal(t, [][]byte{[]byte("direct")}, conn.getWrites())
 }
 
@@ -1096,8 +1104,11 @@ func TestHub_TokenExpiry_ZeroExpiryNeverEvicts(t *testing.T) {
 	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
-	// Advance clock far into future. Conn must remain.
-	fc.Advance(100 * 365 * 24 * time.Hour)
+	// Advance clock well past any plausible expiry. Conn must remain because
+	// ExpiresAt is zero ("no expiry"). Use a bounded advance that clockmock can
+	// replay without exhausting the test timeout (avoids O(advance/interval)
+	// ticker iterations in clockmock).
+	fc.Advance(2 * time.Hour)
 
 	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative test: must NOT evict
 	assert.Equal(t, 1, hub.ConnCount())

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -760,8 +760,8 @@ func (s *stuckConn) Read(_ context.Context) ([]byte, error) {
 	<-s.closeCh
 	return nil, errors.New("closed")
 }
-func (s *stuckConn) Write(_ context.Context, _ []byte) error    { return nil }
-func (s *stuckConn) Principal() *auth.Principal                 { return nil }
+func (s *stuckConn) Write(_ context.Context, _ []byte) error { return nil }
+func (s *stuckConn) Principal() *auth.Principal              { return nil }
 func (s *stuckConn) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -674,6 +674,7 @@ func TestNewHub_PreservesExplicitConfig(t *testing.T) {
 		ReadLimit:      1024,
 		PingMissMax:    5,
 		MaxConnections: 9,
+		SendBufferSize: 16, // explicit non-zero; must be preserved as-is
 		Clock:          clock.Real(),
 	}
 	handler := func(context.Context, string, []byte) {}
@@ -1210,4 +1211,269 @@ func TestHub_SubjectIdx_EmptyAfterTokenExpiry(t *testing.T) {
 func TestDefaultHubConfig_SendBufferSize(t *testing.T) {
 	cfg := DefaultHubConfig(clock.Real())
 	assert.Equal(t, 32, cfg.SendBufferSize, "default SendBufferSize must be 32")
+}
+
+// ---------------------------------------------------------------------------
+// P1-4: SendBufferSize zero-value fallback
+// ---------------------------------------------------------------------------
+
+func TestHub_NewHub_ZeroSendBufferSize_GetsDefault(t *testing.T) {
+	hub := NewHub(HubConfig{Clock: clock.Real()}, nil)
+	assert.Equal(t, defaultSendBufferSize, hub.Config().SendBufferSize,
+		"zero SendBufferSize must be replaced with defaultSendBufferSize at construction")
+}
+
+// ---------------------------------------------------------------------------
+// P1-2: BroadcastFilter runs filter outside lock (no deadlock when filter calls Send)
+// ---------------------------------------------------------------------------
+
+func TestHub_BroadcastFilter_FilterRunsWithoutLock(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+
+	conn := newFakeConn("target")
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	// filter calls hub.Send — if filter ran under connMu this would deadlock.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = hub.BroadcastFilter(context.Background(), []byte("broadcast"),
+			func(c Conn) bool {
+				// Calling Send inside filter must not deadlock.
+				_ = hub.Send(context.Background(), c.ID(), []byte("direct"))
+				return false // broadcast itself sends nothing; direct send above suffices
+			})
+	}()
+
+	select {
+	case <-done:
+		// no deadlock
+	case <-time.After(testtime.EventuallyShort):
+		t.Fatal("BroadcastFilter deadlocked — filter likely ran under connMu")
+	}
+
+	// The direct Send inside the filter should have enqueued one message.
+	require.Eventually(t, func() bool {
+		return len(conn.getWrites()) >= 1
+	}, testtime.D2s, testtime.D10ms)
+}
+
+// ---------------------------------------------------------------------------
+// P1-5: Canceled ctx in Send/BroadcastFilter short-circuits immediately
+// ---------------------------------------------------------------------------
+
+func TestHub_Send_CanceledCtx_DoesNotEnqueue(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+
+	conn := newFakeConn("target")
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+
+	err := hub.Send(canceledCtx, "target", []byte("should not arrive"))
+	// Send must return ctx.Err() immediately.
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// Conn must receive nothing (canceled ctx short-circuits enqueue).
+	assert.Never(t, func() bool {
+		return len(conn.getWrites()) > 0
+	}, testtime.D100ms, testtime.D10ms)
+}
+
+func TestHub_BroadcastFilter_CanceledCtx_StopsEarly(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+
+	// Register multiple conns to have something to iterate.
+	conns := make([]*fakeConn, 5)
+	for i := range conns {
+		conns[i] = newFakeConn(fmt.Sprintf("c%d", i))
+		require.NoError(t, hub.Register(context.Background(), conns[i]))
+	}
+	for _, c := range conns {
+		<-c.readyCh
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+
+	// BroadcastFilter with canceled ctx must not enqueue on any conn.
+	err := hub.BroadcastFilter(canceledCtx, []byte("no-deliver"),
+		func(Conn) bool { return true })
+	require.NoError(t, err) // BroadcastFilter itself returns nil regardless
+
+	// No conn should have received a message.
+	assert.Never(t, func() bool {
+		for _, c := range conns {
+			if len(c.getWrites()) > 0 {
+				return true
+			}
+		}
+		return false
+	}, testtime.D100ms, testtime.D10ms)
+}
+
+// ---------------------------------------------------------------------------
+// P1-3: Register injects principal into per-conn context for MessageHandler
+// ---------------------------------------------------------------------------
+
+func TestHub_Register_PrincipalInjectedToHandlerCtx(t *testing.T) {
+	gotPrincipal := make(chan *auth.Principal, 1)
+	handler := func(ctx context.Context, _ string, _ []byte) {
+		p, _ := auth.FromContext(ctx)
+		gotPrincipal <- p
+	}
+
+	hub := startHub(t, DefaultHubConfig(clock.Real()), handler)
+
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice"}
+	conn := newFakeConnWithPrincipal("conn-with-principal", p)
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	conn.readCh <- []byte("hello")
+
+	select {
+	case received := <-gotPrincipal:
+		require.NotNil(t, received, "principal must be present in handler ctx")
+		assert.Equal(t, "alice", received.Subject)
+	case <-time.After(testtime.EventuallyShort):
+		t.Fatal("handler did not receive message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// P2-1: Principal snapshot stability — mutation after Register doesn't affect subjectIdx
+// ---------------------------------------------------------------------------
+
+func TestHub_PrincipalSnapshot_StableAfterMutation(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "original"}
+	conn := newFakeConnWithPrincipal("conn-snapshot", p)
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	// Mutate the principal subject after registration.
+	// Hub snapshots subject at Register time; subjectIdx must still use "original".
+	conn.mu.Lock()
+	conn.principal = &auth.Principal{Kind: auth.PrincipalUser, Subject: "mutated"}
+	conn.mu.Unlock()
+
+	// BroadcastToSubject with the original subject must still reach the conn.
+	require.NoError(t, hub.BroadcastToSubject(context.Background(), "original", []byte("ping")))
+	require.Eventually(t, func() bool {
+		return len(conn.getWrites()) == 1
+	}, testtime.D2s, testtime.D10ms,
+		"subjectIdx must use snapshotted subject, not the mutated one")
+
+	// BroadcastToSubject with the mutated subject must be a no-op.
+	require.NoError(t, hub.BroadcastToSubject(context.Background(), "mutated", []byte("should not arrive")))
+	assert.Never(t, func() bool {
+		return len(conn.getWrites()) > 1
+	}, testtime.D100ms, testtime.D10ms,
+		"mutated subject must not appear in subjectIdx")
+}
+
+// ---------------------------------------------------------------------------
+// P1-1 + P2-3: Write failure evicts connection via evictWith (no panic)
+// ---------------------------------------------------------------------------
+
+// writeFailConn returns an error on first Write, then succeeds.
+type writeFailConn struct {
+	*fakeConn
+	failOnce sync.Once
+	failed   chan struct{}
+}
+
+func newWriteFailConn(id string) *writeFailConn {
+	return &writeFailConn{
+		fakeConn: newFakeConn(id),
+		failed:   make(chan struct{}),
+	}
+}
+
+func (w *writeFailConn) Write(ctx context.Context, data []byte) error {
+	var firstFail bool
+	w.failOnce.Do(func() { firstFail = true })
+	if firstFail {
+		close(w.failed)
+		return errors.New("simulated write failure")
+	}
+	return w.fakeConn.Write(ctx, data)
+}
+
+func TestHub_WriteFailureEvictsConnection(t *testing.T) {
+	hub := startHub(t, DefaultHubConfig(clock.Real()), nil)
+
+	conn := newWriteFailConn("write-fail")
+	require.NoError(t, hub.Register(context.Background(), conn))
+	<-conn.readyCh
+
+	// Trigger a write to cause the failure.
+	require.NoError(t, hub.Send(context.Background(), "write-fail", []byte("trigger")))
+
+	// Wait for the write failure signal.
+	select {
+	case <-conn.failed:
+	case <-time.After(testtime.EventuallyShort):
+		t.Fatal("Write was never called")
+	}
+
+	// After write failure, writeLoop should have evicted the connection.
+	require.Eventually(t, func() bool {
+		return hub.ConnCount() == 0
+	}, testtime.D2s, testtime.D10ms,
+		"write failure must evict connection")
+}
+
+// ---------------------------------------------------------------------------
+// P1-1: No send-on-closed-channel panic under concurrent broadcast + evict
+// ---------------------------------------------------------------------------
+
+func TestHub_PanicSafe_NoSendOnClosedChannel(t *testing.T) {
+	cfg := DefaultHubConfig(clock.Real())
+	cfg.SendBufferSize = 1 // tiny buffer to trigger evictions quickly
+	hub := startHub(t, cfg, nil)
+
+	const n = 50
+	for i := range n {
+		conn := newFakeConn(fmt.Sprintf("p%d", i))
+		require.NoError(t, hub.Register(context.Background(), conn))
+	}
+
+	// Wait for all readLoops to be active.
+	require.Eventually(t, func() bool {
+		return hub.ConnCount() == n
+	}, testtime.EventuallyShort, testtime.D1ms)
+
+	var wg sync.WaitGroup
+
+	// Concurrent broadcasters.
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				_ = hub.BroadcastFilter(context.Background(), []byte("burst"),
+					func(Conn) bool { return true })
+			}
+		}()
+	}
+
+	// Concurrent unregisters.
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			hub.Unregister(fmt.Sprintf("p%d", idx))
+		}(i)
+	}
+
+	wg.Wait()
+	// goleak in TestMain will catch leaked goroutines.
+	// race detector catches data races.
+	// No panic = test passes.
 }

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -1074,7 +1074,7 @@ func TestHub_TokenExpiry_EvictsOnPing(t *testing.T) {
 	p := &auth.Principal{
 		Kind:      auth.PrincipalUser,
 		Subject:   "expiring",
-		ExpiresAt: fc.Now().Add(time.Hour), // 1h from now
+		ExpiresAt: fc.Now().Add(testtime.D1h),
 	}
 	conn := newFakeConnWithPrincipal("expiring", p)
 	require.NoError(t, hub.Register(context.Background(), conn))
@@ -1082,7 +1082,7 @@ func TestHub_TokenExpiry_EvictsOnPing(t *testing.T) {
 	require.Equal(t, 1, hub.ConnCount())
 
 	// Advance clock past expiry; next ping tick must evict.
-	fc.Advance(2 * time.Hour)
+	fc.Advance(testtime.D2h)
 
 	require.Eventually(t, func() bool {
 		return hub.ConnCount() == 0 && conn.isClosed()
@@ -1108,7 +1108,7 @@ func TestHub_TokenExpiry_ZeroExpiryNeverEvicts(t *testing.T) {
 	// ExpiresAt is zero ("no expiry"). Use a bounded advance that clockmock can
 	// replay without exhausting the test timeout (avoids O(advance/interval)
 	// ticker iterations in clockmock).
-	fc.Advance(2 * time.Hour)
+	fc.Advance(testtime.D2h)
 
 	time.Sleep(testtime.D50ms) //archtest:allow:test-sleep negative test: must NOT evict
 	assert.Equal(t, 1, hub.ConnCount())
@@ -1194,12 +1194,12 @@ func TestHub_SubjectIdx_EmptyAfterTokenExpiry(t *testing.T) {
 	cfg.PingTimeout = testtime.FastPoll
 	hub := startHub(t, cfg, nil)
 
-	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice", ExpiresAt: fc.Now().Add(time.Hour)}
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "alice", ExpiresAt: fc.Now().Add(testtime.D1h)}
 	conn := newFakeConnWithPrincipal("a", p)
 	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
-	fc.Advance(2 * time.Hour)
+	fc.Advance(testtime.D2h)
 
 	require.Eventually(t, func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)
 

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -23,6 +23,7 @@ package archtest
 // ref: tools/archtest/auth_authtest_boundary_test.go — 4 sub-test pattern
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -666,17 +667,229 @@ func isRequiredComposeEnvInterpolation(value string) bool {
 	return true
 }
 
-func testSEC07WebsocketAuthenticatorRequired(t *testing.T, _ string) {
+func testSEC07WebsocketAuthenticatorRequired(t *testing.T, root string) {
 	t.Helper()
-	t.Fatalf("%s: not yet implemented (Wave 1 D)", secFailClosed07)
+	files, err := findAllProductionGoFiles(root)
+	require.NoError(t, err)
+
+	var violations []string
+	for _, f := range files {
+		hits, err := findUpgradeConfigWithoutAuthenticator(f)
+		require.NoErrorf(t, err, "scanning %s", f)
+		rel, _ := filepath.Rel(root, f)
+		rel = filepath.ToSlash(rel)
+		for _, line := range hits {
+			violations = append(violations, fmt.Sprintf("%s:%d: UpgradeConfig literal missing Authenticator field (%s)",
+				rel, line, secFailClosed07))
+		}
+	}
+	if len(violations) > 0 {
+		for _, v := range violations {
+			t.Logf("%s violation: %s", secFailClosed07, v)
+		}
+	}
+	assert.Empty(t, violations,
+		"adapters/websocket UpgradeConfig literals must explicitly set Authenticator "+
+			"(use auth.NewAnonymousAuthenticator() for explicit unauthenticated channels)")
 }
 
-func testSEC08NoLegacyBroadcastCall(t *testing.T, _ string) {
-	t.Helper()
-	t.Fatalf("%s: not yet implemented (Wave 1 D)", secFailClosed08)
+func findUpgradeConfigWithoutAuthenticator(path string) ([]int, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	var lines []int
+	ast.Inspect(f, func(n ast.Node) bool {
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if !isUpgradeConfigType(cl.Type) {
+			return true
+		}
+		if hasKey(cl, "Authenticator") {
+			return true
+		}
+		lines = append(lines, fset.Position(cl.Pos()).Line)
+		return true
+	})
+	return lines, nil
 }
 
-func testSEC09HubSubjectIdxSync(t *testing.T, _ string) {
+func isUpgradeConfigType(expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name == "UpgradeConfig"
+	case *ast.SelectorExpr:
+		return t.Sel != nil && t.Sel.Name == "UpgradeConfig"
+	}
+	return false
+}
+
+func hasKey(cl *ast.CompositeLit, key string) bool {
+	for _, el := range cl.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		ident, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if ident.Name == key {
+			return true
+		}
+	}
+	return false
+}
+
+func testSEC08NoLegacyBroadcastCall(t *testing.T, root string) {
 	t.Helper()
-	t.Fatalf("%s: not yet implemented (Wave 1 D)", secFailClosed09)
+	files, err := findAllProductionGoFiles(root)
+	require.NoError(t, err)
+
+	var violations []string
+	for _, f := range files {
+		hits, err := findLegacyBroadcastCalls(f)
+		require.NoErrorf(t, err, "scanning %s", f)
+		rel, _ := filepath.Rel(root, f)
+		rel = filepath.ToSlash(rel)
+		for _, line := range hits {
+			violations = append(violations, fmt.Sprintf("%s:%d: legacy Hub.Broadcast call (use BroadcastFilter or BroadcastToSubject; %s)",
+				rel, line, secFailClosed08))
+		}
+	}
+	if len(violations) > 0 {
+		for _, v := range violations {
+			t.Logf("%s violation: %s", secFailClosed08, v)
+		}
+	}
+	assert.Empty(t, violations,
+		"runtime/websocket.Hub.Broadcast was deleted by PR-V1-SEC-WS-AUTH-ACL; "+
+			"use BroadcastFilter (filter required) or BroadcastToSubject (O(1) subject index)")
+}
+
+func findLegacyBroadcastCalls(path string) ([]int, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	// Skip files that don't import runtime/websocket (no chance of a Hub.Broadcast call).
+	if !bytes.Contains(data, []byte(`"github.com/ghbvf/gocell/runtime/websocket"`)) {
+		return nil, nil
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	var lines []int
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel == nil || sel.Sel.Name != "Broadcast" {
+			return true
+		}
+		// BroadcastFilter / BroadcastToSubject have different Sel.Name, so they pass.
+		lines = append(lines, fset.Position(call.Pos()).Line)
+		return true
+	})
+	return lines, nil
+}
+
+func testSEC09HubSubjectIdxSync(t *testing.T, root string) {
+	t.Helper()
+	path := filepath.Join(root, "runtime", "websocket", "hub.go")
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
+	require.NoError(t, err)
+
+	var violations []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
+		}
+		if !funcBodyDeletesConns(fn.Body) {
+			return true
+		}
+		if funcBodyTouchesSubjectIdx(fn.Body) {
+			return true
+		}
+		line := fset.Position(fn.Pos()).Line
+		violations = append(violations, fmt.Sprintf("hub.go:%d: %s deletes h.conns without touching h.subjectIdx (%s)",
+			line, fn.Name.Name, secFailClosed09))
+		return true
+	})
+
+	if len(violations) > 0 {
+		for _, v := range violations {
+			t.Logf("%s violation: %s", secFailClosed09, v)
+		}
+	}
+	assert.Empty(t, violations,
+		"every site that removes from h.conns must also remove from h.subjectIdx "+
+			"(or clear it). 5-write-point invariant: Register evict-dup / unregisterEntry / "+
+			"Unregister / handlePingResult miss-evict / evictSlow / evictExpired / shutdown drain")
+}
+
+func funcBodyDeletesConns(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok || ident.Name != "delete" {
+			return true
+		}
+		if len(call.Args) < 1 {
+			return true
+		}
+		// First arg should look like h.conns or similar selector.
+		sel, ok := call.Args[0].(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "conns" {
+			return true
+		}
+		found = true
+		return false
+	})
+	return found
+}
+
+func funcBodyTouchesSubjectIdx(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		// Match any reference to subjectIdx (delete / clear / removeFromSubjectIdxLocked).
+		switch v := n.(type) {
+		case *ast.SelectorExpr:
+			if v.Sel != nil && v.Sel.Name == "subjectIdx" {
+				found = true
+				return false
+			}
+		case *ast.Ident:
+			if v.Name == "removeFromSubjectIdxLocked" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -890,6 +890,23 @@ func findLegacyBroadcastCalls(path string) ([]int, error) {
 	return lines, nil
 }
 
+// allowedConnsMutationFuncs lists hub.go function names where direct mutation
+// of h.conns (delete / clear) is permitted. Every other function must route
+// through removeConnLocked. shutdown is allowed because its bulk drain pairs
+// clear(h.conns) with clear(h.subjectIdx) in adjacent statements; this
+// colocation cannot be enforced via a per-function boolean check, hence the
+// function-name allowlist.
+var allowedConnsMutationFuncs = map[string]bool{
+	"removeConnLocked": true,
+	"shutdown":         true,
+}
+
+// testSEC09HubSubjectIdxSync enforces that every call site mutating h.conns
+// (delete or clear) in hub.go resides in either the centralized
+// removeConnLocked helper or the shutdown bulk-drain path. This replaces the
+// previous per-function boolean ("function deletes h.conns AND touches
+// subjectIdx") which silently passed when a function had multiple delete sites
+// with only one paired subjectIdx update.
 func testSEC09HubSubjectIdxSync(t *testing.T, root string) {
 	t.Helper()
 	path := filepath.Join(root, "runtime", "websocket", "hub.go")
@@ -907,15 +924,32 @@ func testSEC09HubSubjectIdxSync(t *testing.T, root string) {
 		if !ok || fn.Body == nil {
 			return true
 		}
-		if !funcBodyDeletesConns(fn.Body) {
+		if allowedConnsMutationFuncs[fn.Name.Name] {
 			return true
 		}
-		if funcBodyTouchesSubjectIdx(fn.Body) {
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || (ident.Name != "delete" && ident.Name != "clear") {
+				return true
+			}
+			if len(call.Args) < 1 {
+				return true
+			}
+			sel, ok := call.Args[0].(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "conns" {
+				return true
+			}
+			line := fset.Position(call.Pos()).Line
+			violations = append(violations,
+				fmt.Sprintf("hub.go:%d: %s() must not call %s(h.conns,...) directly; "+
+					"use removeConnLocked() helper (or, for bulk drain, place inside shutdown). [%s]",
+					line, fn.Name.Name, ident.Name, secFailClosed09))
 			return true
-		}
-		line := fset.Position(fn.Pos()).Line
-		violations = append(violations, fmt.Sprintf("hub.go:%d: %s deletes h.conns without touching h.subjectIdx (%s)",
-			line, fn.Name.Name, secFailClosed09))
+		})
 		return true
 	})
 
@@ -925,53 +959,131 @@ func testSEC09HubSubjectIdxSync(t *testing.T, root string) {
 		}
 	}
 	assert.Empty(t, violations,
-		"every site that removes from h.conns must also remove from h.subjectIdx "+
-			"(or clear it). 5-write-point invariant: Register evict-dup / unregisterEntry / "+
-			"Unregister / handlePingResult miss-evict / evictSlow / evictExpired / shutdown drain")
+		"every h.conns mutation site (delete or clear) must reside in the "+
+			"centralized removeConnLocked helper or the shutdown bulk-drain path. "+
+			"All other call sites must route through removeConnLocked() to keep "+
+			"subjectIdx in lockstep with conns.")
 }
 
-func funcBodyDeletesConns(body *ast.BlockStmt) bool {
-	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		ident, ok := call.Fun.(*ast.Ident)
-		if !ok || (ident.Name != "delete" && ident.Name != "clear") {
-			return true
-		}
-		if len(call.Args) < 1 {
-			return true
-		}
-		// First arg should look like h.conns or similar selector.
-		sel, ok := call.Args[0].(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil || sel.Sel.Name != "conns" {
-			return true
-		}
-		found = true
-		return false
-	})
-	return found
+// TestSEC09_SyntheticDirectDeleteViolates verifies that the SEC-09 archtest
+// flags a direct delete(h.conns, ...) call outside the allowed function set.
+func TestSEC09_SyntheticDirectDeleteViolates(t *testing.T) {
+	t.Parallel()
+	src := `package websocket
+
+import "sync"
+
+type Hub struct {
+	connMu sync.Mutex
+	conns  map[string]int
 }
 
-func funcBodyTouchesSubjectIdx(body *ast.BlockStmt) bool {
-	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		// Match any reference to subjectIdx (delete / clear / removeFromSubjectIdxLocked).
-		switch v := n.(type) {
-		case *ast.SelectorExpr:
-			if v.Sel != nil && v.Sel.Name == "subjectIdx" {
-				found = true
-				return false
-			}
-		case *ast.Ident:
-			if v.Name == "removeFromSubjectIdxLocked" {
-				found = true
-				return false
-			}
+func (h *Hub) badRemove(id string) {
+	h.connMu.Lock()
+	delete(h.conns, id) // VIOLATION: not in allowedConnsMutationFuncs
+	h.connMu.Unlock()
+}
+
+func (h *Hub) removeConnLocked(id string) {
+	delete(h.conns, id) // OK: allowed
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "synthetic.go", src, parser.SkipObjectResolution)
+	require.NoError(t, err)
+
+	var found []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
 		}
+		if allowedConnsMutationFuncs[fn.Name.Name] {
+			return true
+		}
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || (ident.Name != "delete" && ident.Name != "clear") {
+				return true
+			}
+			if len(call.Args) < 1 {
+				return true
+			}
+			sel, ok := call.Args[0].(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "conns" {
+				return true
+			}
+			found = append(found, fn.Name.Name)
+			return true
+		})
 		return true
 	})
-	return found
+
+	require.Len(t, found, 1, "exactly one violation expected (badRemove)")
+	assert.Equal(t, "badRemove", found[0])
+}
+
+// TestSEC09_SyntheticAllowedFunctionsPass verifies the allowlist works:
+// removeConnLocked and shutdown can call raw delete/clear without violation.
+func TestSEC09_SyntheticAllowedFunctionsPass(t *testing.T) {
+	t.Parallel()
+	src := `package websocket
+
+import "sync"
+
+type Hub struct {
+	connMu sync.Mutex
+	conns  map[string]int
+}
+
+func (h *Hub) removeConnLocked(id string) {
+	delete(h.conns, id)
+}
+
+func (h *Hub) shutdown() {
+	h.connMu.Lock()
+	clear(h.conns)
+	h.connMu.Unlock()
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "synthetic.go", src, parser.SkipObjectResolution)
+	require.NoError(t, err)
+
+	var found []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
+		}
+		if allowedConnsMutationFuncs[fn.Name.Name] {
+			return true
+		}
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || (ident.Name != "delete" && ident.Name != "clear") {
+				return true
+			}
+			if len(call.Args) < 1 {
+				return true
+			}
+			sel, ok := call.Args[0].(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "conns" {
+				return true
+			}
+			found = append(found, fn.Name.Name)
+			return true
+		})
+		return true
+	})
+
+	assert.Empty(t, found, "removeConnLocked and shutdown should be allowed and produce no violations")
 }

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -2,7 +2,7 @@ package archtest
 
 // security_defaults_test.go — static archtest rules for PR-MODE-1 SEC-FAIL-CLOSED.
 //
-// Five sub-tests mirror the SEC-FAIL-CLOSED-01..05 rule IDs:
+// Sub-tests mirror the SEC-FAIL-CLOSED-01..09 rule IDs:
 //
 //   01  addr-driven gate: bundle.go must not wrap WithListener in IfStmt guarded
 //       by PrimaryHTTPAddr / InternalHTTPAddr / HealthHTTPAddr != "".
@@ -16,6 +16,9 @@ package archtest
 //       interpolation, not committed literal values.
 //   06  internal listener guard: production WithListener calls must not wire
 //       cell.InternalListener with a literal AuthNone chain.
+//   07  websocket UpgradeConfig literals must include Authenticator field
+//   08  no production code may call runtime/websocket.Hub.Broadcast (deleted API)
+//   09  hub.go conns and subjectIdx delete points must stay in sync
 //
 // ref: tools/archtest/auth_authtest_boundary_test.go — 4 sub-test pattern
 
@@ -41,6 +44,9 @@ const (
 	secFailClosed04 = "SEC-FAIL-CLOSED-04"
 	secFailClosed05 = "SEC-FAIL-CLOSED-05"
 	secFailClosed06 = "SEC-FAIL-CLOSED-06"
+	secFailClosed07 = "SEC-FAIL-CLOSED-07"
+	secFailClosed08 = "SEC-FAIL-CLOSED-08"
+	secFailClosed09 = "SEC-FAIL-CLOSED-09"
 )
 
 func TestSecurityDefaults(t *testing.T) {
@@ -68,6 +74,18 @@ func TestSecurityDefaults(t *testing.T) {
 
 	t.Run(secFailClosed06+"_internal_listener_must_not_use_authnone", func(t *testing.T) {
 		testSEC06InternalListenerMustNotUseAuthNone(t, root)
+	})
+
+	t.Run(secFailClosed07+"_websocket_upgrade_config_must_set_authenticator", func(t *testing.T) {
+		testSEC07WebsocketAuthenticatorRequired(t, root)
+	})
+
+	t.Run(secFailClosed08+"_no_legacy_broadcast_call", func(t *testing.T) {
+		testSEC08NoLegacyBroadcastCall(t, root)
+	})
+
+	t.Run(secFailClosed09+"_hub_subjectidx_sync", func(t *testing.T) {
+		testSEC09HubSubjectIdxSync(t, root)
 	})
 }
 
@@ -646,4 +664,19 @@ func isRequiredComposeEnvInterpolation(value string) bool {
 		}
 	}
 	return true
+}
+
+func testSEC07WebsocketAuthenticatorRequired(t *testing.T, _ string) {
+	t.Helper()
+	t.Fatalf("%s: not yet implemented (Wave 1 D)", secFailClosed07)
+}
+
+func testSEC08NoLegacyBroadcastCall(t *testing.T, _ string) {
+	t.Helper()
+	t.Fatalf("%s: not yet implemented (Wave 1 D)", secFailClosed08)
+}
+
+func testSEC09HubSubjectIdxSync(t *testing.T, _ string) {
+	t.Helper()
+	t.Fatalf("%s: not yet implemented (Wave 1 D)", secFailClosed09)
 }

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -667,6 +667,88 @@ func isRequiredComposeEnvInterpolation(value string) bool {
 	return true
 }
 
+func TestFindUpgradeConfigWithoutAuthenticator_DetectsLiteralWithMissingField(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Case 1: same-package UpgradeConfig literal (ast.Ident) — no Authenticator field.
+	path1 := filepath.Join(dir, "nauth_ident.go")
+	src1 := `package main
+
+import "github.com/ghbvf/gocell/adapters/websocket"
+
+func main() {
+	_ = websocket.UpgradeConfig{AllowedOrigins: []string{"http://*"}}
+}
+`
+	require.NoError(t, os.WriteFile(path1, []byte(src1), 0o644))
+
+	lines1, err := findUpgradeConfigWithoutAuthenticator(path1)
+	require.NoError(t, err)
+	assert.NotEmpty(t, lines1, "should detect ident-form UpgradeConfig missing Authenticator")
+
+	// Case 2: qualified SelectorExpr (pkgname.UpgradeConfig) — no Authenticator field.
+	path2 := filepath.Join(dir, "nauth_sel.go")
+	src2 := `package main
+
+import adapterws "github.com/ghbvf/gocell/adapters/websocket"
+
+func main() {
+	_ = adapterws.UpgradeConfig{AllowedOrigins: []string{"http://*"}}
+}
+`
+	require.NoError(t, os.WriteFile(path2, []byte(src2), 0o644))
+
+	lines2, err := findUpgradeConfigWithoutAuthenticator(path2)
+	require.NoError(t, err)
+	assert.NotEmpty(t, lines2, "should detect selector-form UpgradeConfig missing Authenticator")
+}
+
+func TestFindUpgradeConfigWithoutAuthenticator_AcceptsLiteralWithAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Case 1: same-package UpgradeConfig with Authenticator field present (ast.Ident).
+	path1 := filepath.Join(dir, "withauth_ident.go")
+	src1 := `package main
+
+import "github.com/ghbvf/gocell/adapters/websocket"
+
+func main() {
+	_ = websocket.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		Authenticator:  nil,
+	}
+}
+`
+	require.NoError(t, os.WriteFile(path1, []byte(src1), 0o644))
+
+	lines1, err := findUpgradeConfigWithoutAuthenticator(path1)
+	require.NoError(t, err)
+	assert.Empty(t, lines1, "should not flag UpgradeConfig that has Authenticator field")
+
+	// Case 2: qualified SelectorExpr with Authenticator field present.
+	path2 := filepath.Join(dir, "withauth_sel.go")
+	src2 := `package main
+
+import adapterws "github.com/ghbvf/gocell/adapters/websocket"
+
+func main() {
+	_ = adapterws.UpgradeConfig{
+		AllowedOrigins: []string{"http://*"},
+		Authenticator:  nil,
+	}
+}
+`
+	require.NoError(t, os.WriteFile(path2, []byte(src2), 0o644))
+
+	lines2, err := findUpgradeConfigWithoutAuthenticator(path2)
+	require.NoError(t, err)
+	assert.Empty(t, lines2, "should not flag UpgradeConfig that has Authenticator field (selector form)")
+}
+
 func testSEC07WebsocketAuthenticatorRequired(t *testing.T, root string) {
 	t.Helper()
 	files, err := findAllProductionGoFiles(root)
@@ -856,7 +938,7 @@ func funcBodyDeletesConns(body *ast.BlockStmt) bool {
 			return true
 		}
 		ident, ok := call.Fun.(*ast.Ident)
-		if !ok || ident.Name != "delete" {
+		if !ok || (ident.Name != "delete" && ident.Name != "clear") {
 			return true
 		}
 		if len(call.Args) < 1 {


### PR DESCRIPTION
## Summary

Closes B2-W-01 / B2-W-02 / B2-W-06 (P0 backlog) by reworking the WebSocket layer:

- **Upgrade authentication**: `UpgradeConfig.Authenticator auth.Authenticator` 必填 + fail-fast at composition (`ErrWebsocketAuthenticatorMissing`). Authenticate runs **before** `websocket.Accept`; absent or invalid credentials get a plain-text 401.
- **Broadcast ACL**: removed `Hub.Broadcast(ctx, data)`; only `Hub.BroadcastFilter(ctx, data, filter)` (filter required) and `Hub.BroadcastToSubject(ctx, subject, data)` (O(1) subject index, centrifuge `connShard.users` pattern) remain.
- **Principal binding**: `runtime/websocket.Conn` interface adds `Principal()`; adapter `Conn` carries the principal from handshake; hub uses it for `subjectIdx` (5 write points kept in lockstep) and token-expiry eviction.
- **Token expiry / revalidation**: `auth.Principal.ExpiresAt` plumbed from JWT `Claims.ExpiresAt`; `pingLoop` evicts expired conns on the next tick (centrifuge `checkExpired`). Zero `ExpiresAt` = no-expiry domain semantic for anonymous/service principals.
- **Slow-client backpressure**: per-conn `send` chan + `writeLoop` goroutine; `BroadcastFilter`/`BroadcastToSubject`/`Send` use select-default-drop (gorilla `examples/chat/hub.go` pattern); slow clients are evicted with `ErrWebsocketSlowClient`.
- **Authenticator helpers**: `auth.NewContextAuthenticator()` (transparent passthrough when listener middleware already authenticated) + `auth.NewAnonymousAuthenticator()` (explicit unauthenticated channel).
- **Documentation**: new `docs/guides/websocket-integration.md` (9 sections: architecture boundary, origin config, authenticator selection, heartbeat + token expiry, reconnect strategy, broadcast API guidance, slow-client eviction, failure injection, runtime parameter table).
- **Static guards**: archtest `SEC-FAIL-CLOSED-07` (UpgradeConfig literals must declare `Authenticator`), `SEC-FAIL-CLOSED-08` (production code may not call deleted `Hub.Broadcast`), `SEC-FAIL-CLOSED-09` (`hub.go` `conns`/`subjectIdx` delete sites stay in sync).

**Zero v1.1 backlog tail**: WS-AUTH-REVALIDATE, WS-BROADCAST-BACKPRESSURE, WS-USER-INDEX-OPTIMIZATION, ContextAuthenticator/AnonymousAuthenticator helpers — **all closed in this PR**.

## Open-source references

```
ref: coder/websocket accept.go@master                       — Accept 前 http.Error(401) 模式
ref: olahol/melody melody.go@master                         — BroadcastFilter(data, fn) 签名形状
ref: centrifugal/centrifuge hub.go@master                   — connShard.users 索引 + checkExpired
ref: gorilla/websocket examples/chat/hub.go@main            — per-conn send chan + select-default 驱逐
```

## Test plan

- [x] `go test -race ./runtime/auth/... ./runtime/websocket/... ./adapters/websocket/...` 全绿
- [x] `go test ./tools/archtest/...` 全绿（含新增 SEC-07/08/09 + 既有 TEST-TIME-LITERAL-01 / SEC-FAIL-CLOSED-04 守护）
- [x] `golangci-lint run ./...` 0 issues
- [x] Wave 0 RED 红灯测试 commit (`41e110a6`) 单独存证
- [x] 5 写点 subjectIdx 一致性测试覆盖（注册 / 取消 / pingLoop expiry / slow-client / shutdown）
- [x] 401 absent / 401 invalid / success-with-principal 端到端断言
- [x] `BroadcastFilter` filter==nil → error；`BroadcastToSubject` subject=="" → error；unknown subject → noop
- [x] FakeClock 推进 token expiry → conn 在下一 ping tick 被驱逐 + idx 同步清
- [ ] CI（push 后由 GitHub Actions 验证）

Refs: B2-W-01 B2-W-02 B2-W-06