### PR TITLE
fix(test): stabilize flaky CI tests

### DIFF
--- a/docs/plans/202605011500-029-master-roadmap.md
+++ b/docs/plans/202605011500-029-master-roadmap.md
@@ -14,7 +14,7 @@
 |---|---|---|---|
 | **K** Critical | 关键路径 #01-#12 | `tools/depgraph/` + `kernel/cell/*` + `kernel/outbox/*` + `cmd/gocell/*` + `generated/*` + 全 cells/* 迁移（#02/#04-#06） | 1（章节内串行）|
 | **A** 安全 | Track A (A1-A5) | `runtime/auth/*` + `runtime/http/middleware/*` + `kernel/wrapper/*` + `adapters/rabbitmq/classifier.go` + `adapters/websocket/*` | 1 |
-| **B** 数据层 | Track B (B1-B11) | `adapters/postgres/*` + `adapters/redis/*` + `db/migrations/*` + `runtime/storage/*` | 1 |
+| **B** 数据层 | Track B (B1-B12) | `adapters/postgres/*` + `adapters/redis/*` + `adapters/rabbitmq/*` + `db/migrations/*` + `runtime/storage/*` + `kernel/outbox/outboxtest/*` | 1 |
 | **C** Cells 业务 | Track C (C1-C5) | `cells/auditcore/*` + `cells/accesscore/*` + `tests/integration/*` + `kernel/governance/*`（C5）| 1 |
 | **D** Runtime/Observability | Track D (D1-D5) | `runtime/observability/*` + `runtime/bootstrap/*` + `cmd/corebundle/shared_deps.go` | 1 |
 | **G** CI/lint/治理 | Track G + F | `.golangci.yml` + `.github/workflows/*` + `.claude/rules/*` + `docs/architecture/*` + `docs/plans/*` | 1 |
@@ -104,7 +104,7 @@
 | A4 | ✅ PR-V1-RMQ-TERMINAL | B2-A-02 / 027#4 | RMQ 永久错误（403/404/530）无限重试，凭证撤销后 Pod 永不自愈（P0） | ✅ shipped: **soft permanent classification** — runtime reconnect 复用 `classifyDialError`（双层 sentinel：inferred `ErrCredentials/ErrVhost` 需 N=2 确认 + definitive 协议级 sentinel + broker `Server=true && !Recover` + url.Error/net.Error/字符串 fallback），命中即 `markPermanent` 设 `permanentErr` 唤醒 WaitConnected，**reconnect goroutine 持续 retry 不退**；下次 dial 成功 → `markRecovered` 自动清 `permanentErr` → `/readyz` 自愈 200。范式对齐 watermill-amqp 上游。删整套 hard-terminal 脚手架（`StateTerminal` phase + `terminalCh` chan + WaitConnected `<-terminalCh` 分支 + Health StateTerminal 分支），删 dead code（`Config.MaxReconnectAttempts` 字段 + `ErrAdapterAMQPReconnectExhausted` errcode + `isTerminalConnectionError` 简化只检 ConnectPermanent + 5 处 A.1 NOTE + WaitConnected/Health godoc）；同步 `sanitizeURL` fail-closed 丢 RawQuery+Fragment（RabbitMQ URI query 含 password / TLS 文件路径）；吸收 030 A-06 `RMQ-WAITCONNECTED-DOC-FIX`；ADR `docs/architecture/202605051700-adr-rmq-runtime-permanent-classification.md` + `docs/guides/adapter-config-reference.md` migration note | ✅ done | 8h + 4h |
 | A5 | ✅ PR#362（04b63b1f）PR-V1-SVCTOKEN-CALLER-IDENTITY | B2-T-07（13分）/ 027#33 | service token 共享 `RoleInternalAdmin`，缺 caller_cell 最小权限 | ✅ shipped: claims 加 `caller_cell` + AuthMiddleware 强制 `caller_cell ∈ contract.clients`；`BuiltinServiceRoles` 派生 scope；同时关闭 PR266-CONTRACT-CLIENTS-RUNTIME-ENFORCE-01 + B2-T-06 CONTRACT-CLIENTS-NOT-COMPILED-INTO-RUNTIME 一并落地 | ✅ done | 16h + 8h |
 
-### Track B · PG/RMQ/Redis 加固（11 PR / ~111h + ~57h）
+### Track B · PG/RMQ/Redis 加固（12 PR / ~113h + ~58h）
 
 | # | PR | 来源 | 问题 | 方案 | ship | 工时 |
 |---|---|---|---|---|:-:|---|
@@ -119,6 +119,7 @@
 | B9 | PR-V1-REFRESH-IDLE-GRACE | X12/X14 / 027#17 | REFRESH-IDLE-EXPIRE + REFRESH-GRACE-COUNTER 缺（X13 分区延后） | IDLE-EXPIRE + GRACE-COUNTER（不含分区） | L2 | 5h + 3h |
 | B10 | PR-V1-REDIS-CLUSTER | B2-A-03 / 027#18 | Redis 缺 Cluster 模式支持，AWS/Azure Cluster 无法接入（P0） | ModeCluster + DistLock/Idempotency 算法 cluster slot 评估（hashtag） | L3 | 8h + 4h |
 | B11 | PR-V1-REDIS-KEYNS | B2-A-27（10分）/ 027#34 | Redis Idempotency / Nonce / Cache / DistLock 缺 cell 级 namespace prefix，多租户冲突 | 构造期注入 `KeyNamespace`（cell ID）自动 prefix；archtest 守 cell 级隔离 | L2 | 8h + 4h |
+| B12 | PR-V1-RMQ-CONFORMANCE-READINESS | 2026-05-05 PR#385 CI flaky | `TestRabbitMQ_Conformance/Batch6_Concurrency/SubscriberWithMiddleware` 偶发 10s timeout；`SubscribeEntry` 使用 `ConsumerGroup=conformance-cg`，但 readiness wait 走空 consumer group，可能预声明/等待错误队列后提前 publish | conformance harness 等待与实际 `Subscription` 完全一致的 topic + consumerGroup；补 testcontainers stress 或诊断日志锁定 queue/consumer tag，避免首条消息发到未绑定队列 | L1 | 2h + 1h |
 
 ### Track C · cells 业务（6 PR / 56h + 27h）
 

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -465,9 +465,23 @@ func TestServiceTokenAuthenticator_InvalidMAC_Error(t *testing.T) {
 		WithServiceTokenClock(clockmock.New(now)),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
-	// Construct a token with wrong HMAC (last byte flipped).
+	// Construct a token with wrong HMAC. Do not replace with a fixed suffix:
+	// the generated MAC is random and may already end with that value.
 	goodToken := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
-	badToken := goodToken[:len(goodToken)-2] + "ff"
+	parts := strings.Split(goodToken, ":")
+	if len(parts) != 4 {
+		t.Fatalf("expected generated service token to have 4 parts, got %d: %q", len(parts), goodToken)
+	}
+	lastMACByte := parts[3][len(parts[3])-2:]
+	if lastMACByte == "00" {
+		parts[3] = parts[3][:len(parts[3])-2] + "ff"
+	} else {
+		parts[3] = parts[3][:len(parts[3])-2] + "00"
+	}
+	badToken := strings.Join(parts, ":")
+	if badToken == goodToken {
+		t.Fatal("test setup failed: bad token must differ from good token")
+	}
 	req.Header.Set("Authorization", "ServiceToken "+badToken)
 	p, ok, err := a.Authenticate(req)
 	if err == nil {

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -156,6 +156,13 @@ func startHub(t *testing.T, cfg HubConfig, handler MessageHandler) *Hub {
 	return hub
 }
 
+func waitForHubPingTicker(t *testing.T, fc *clockmock.FakeClock) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return fc.PendingTickers() == 1
+	}, testtime.EventuallyShort, testtime.D1ms)
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle Tests
 // ---------------------------------------------------------------------------
@@ -1081,6 +1088,7 @@ func TestHub_TokenExpiry_EvictsOnPing(t *testing.T) {
 	require.Equal(t, 1, hub.ConnCount())
 
 	// Advance clock past expiry; next ping tick must evict.
+	waitForHubPingTicker(t, fc)
 	fc.Advance(testtime.D2h)
 
 	require.Eventually(t, func() bool {
@@ -1113,6 +1121,7 @@ func TestHub_TokenExpiry_AtBoundaryEvicts(t *testing.T) {
 	// Advance clock to *exactly* ExpiresAt — boundary case.
 	// Before(exp) at exp: false (not strictly before). !After(exp) at exp: true.
 	// pingLoop fires at this tick because PingInterval == 10ms == advance.
+	waitForHubPingTicker(t, fc)
 	fc.Advance(testtime.D10ms)
 
 	require.Eventually(t, func() bool {
@@ -1140,6 +1149,7 @@ func TestHub_TokenExpiry_ZeroExpiryNeverEvicts(t *testing.T) {
 	// ExpiresAt is zero ("no expiry"). Use a bounded advance that clockmock can
 	// replay without exhausting the test timeout (avoids O(advance/interval)
 	// ticker iterations in clockmock).
+	waitForHubPingTicker(t, fc)
 	fc.Advance(testtime.D2h)
 
 	assert.Never(t, func() bool { return hub.ConnCount() == 0 || conn.isClosed() }, testtime.D100ms, testtime.D10ms)
@@ -1229,6 +1239,7 @@ func TestHub_SubjectIdx_EmptyAfterTokenExpiry(t *testing.T) {
 	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
+	waitForHubPingTicker(t, fc)
 	fc.Advance(testtime.D2h)
 
 	require.Eventually(t, func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)


### PR DESCRIPTION
## Summary
- Make the service-token invalid-MAC test deterministically mutate the generated HMAC instead of replacing it with a fixed suffix.
- Wait for the websocket hub fake-clock ping ticker before advancing fake time in token-expiry tests.
- Register the RabbitMQ conformance readiness follow-up in the master roadmap.

## Context
- PR #387 race CI failure: https://github.com/ghbvf/gocell/actions/runs/25369114434/job/74387655950?pr=387
- PR #385 integration CI flaky: https://github.com/ghbvf/gocell/actions/runs/25366877855/job/74379906927?pr=385

## Test plan
- [x] go -C worktrees/226-ci-flaky-tests test -race ./runtime/auth -run TestServiceTokenAuthenticator_InvalidMAC_Error -count=1000
- [x] go -C worktrees/226-ci-flaky-tests test ./runtime/websocket -run TestHub_SubjectIdx_EmptyAfterTokenExpiry -count=1000
- [x] go -C worktrees/226-ci-flaky-tests test ./runtime/websocket -run 'TestHub_(TokenExpiry|SubjectIdx)' -count=50
- [x] go -C worktrees/226-ci-flaky-tests test ./runtime/auth ./runtime/websocket
- [x] go -C worktrees/226-ci-flaky-tests build ./...
- [x] go -C worktrees/226-ci-flaky-tests test ./...
- [x] golangci-lint run ./...
- [x] git diff --check origin/develop...HEAD