### PR TITLE
refactor(kernel/cell): promote Cell(id) onto AssemblyRef interface — close C5 残余 B2-K-03

### DIFF
--- a/kernel/cell/auth_plan.go
+++ b/kernel/cell/auth_plan.go
@@ -135,18 +135,28 @@ var _ ListenerAuth = AuthJWT{}
 
 // ─── AuthJWTFromAssembly ──────────────────────────────────────────────────────
 
-// AssemblyRef exposes the minimum contract kernel needs: ID() for identity
-// comparison and CellIDs() for authProvider discovery. Using a named interface
-// instead of any preserves type safety at composition boundaries.
+// AssemblyRef is the contract kernel needs from an assembly: identity
+// (ID), the registered cell list (CellIDs), and by-ID cell lookup (Cell).
+// Using a named interface preserves type safety at composition boundaries
+// and lets callers in runtime/bootstrap iterate authProvider discovery
+// without an implicit type assertion to a private sub-interface.
 //
 // Bootstrap passes the concrete *assembly.CoreAssembly which satisfies this
 // interface structurally; identity checks (same pointer) are done in
 // runtime/bootstrap, not in kernel.
+//
+// ASSEMBLYREF-METHOD-SET-01 (tools/archtest/assemblyref_method_set_test.go)
+// locks this method set against accidental drift.
 type AssemblyRef interface {
 	// ID returns the assembly's unique identifier.
 	ID() string
 	// CellIDs returns the ordered list of registered cell identifiers.
 	CellIDs() []string
+	// Cell returns the registered Cell with the given ID, or nil if no
+	// cell with that ID is registered. Callers are responsible for type-
+	// asserting the returned Cell to the role-specific interface they
+	// require (e.g. AuthProvider).
+	Cell(id string) Cell
 }
 
 // AuthJWTFromAssembly is a lazy JWT plan that resolves its verifier from an

--- a/kernel/cell/auth_plan.go
+++ b/kernel/cell/auth_plan.go
@@ -170,10 +170,10 @@ type AssemblyRef interface {
 //
 // Lifecycle constraint: the Assembly value must be the same instance later
 // passed to bootstrap.WithAssembly. Bootstrap phase0
-// (validateAuthPlanAssemblyMatch in runtime/bootstrap/auth_plan_validate.go)
-// performs a same-pointer identity check and rejects wrappers, copies, or
-// fakes — even when they share the same ID. Construct AuthJWTFromAssembly
-// from the canonical *assembly.CoreAssembly.
+// (validateAuthJWTFromAssemblyPlans in runtime/bootstrap/auth_plan_validate.go)
+// rejects direct struct literals, nil assemblies, wrappers, copies, or fakes
+// even when they share the same ID. Construct AuthJWTFromAssembly from the
+// canonical *assembly.CoreAssembly.
 type AuthJWTFromAssembly struct {
 	// Assembly must be the same *assembly.CoreAssembly instance later
 	// supplied to bootstrap.WithAssembly. Constructors only reject
@@ -210,6 +210,14 @@ func MustNewAuthJWTFromAssembly(asm AssemblyRef) AuthJWTFromAssembly {
 		panic(err.Error())
 	}
 	return plan
+}
+
+// IsConstructed reports whether the plan was built through
+// NewAuthJWTFromAssembly or MustNewAuthJWTFromAssembly. Direct struct literals
+// do not initialize the shared resolver pointer and are rejected by bootstrap
+// phase0 before phase4 can silently skip SetResolved.
+func (p AuthJWTFromAssembly) IsConstructed() bool {
+	return p.resolved != nil
 }
 
 func (AuthJWTFromAssembly) authPlanKind() AuthKind { return AuthKindJWTFromAssembly }

--- a/kernel/cell/auth_plan.go
+++ b/kernel/cell/auth_plan.go
@@ -167,10 +167,18 @@ type AssemblyRef interface {
 // reads from the router are safe without locking.
 //
 // AuthJWTFromAssembly implements only ListenerAuth (same rationale as AuthJWT).
+//
+// Lifecycle constraint: the Assembly value must be the same instance later
+// passed to bootstrap.WithAssembly. Bootstrap phase0
+// (validateAuthPlanAssemblyMatch in runtime/bootstrap/auth_plan_validate.go)
+// performs a same-pointer identity check and rejects wrappers, copies, or
+// fakes — even when they share the same ID. Construct AuthJWTFromAssembly
+// from the canonical *assembly.CoreAssembly.
 type AuthJWTFromAssembly struct {
-	// Assembly is the AssemblyRef to scan for an AuthProvider cell at phase4.
-	// Required; nil is rejected by NewAuthJWTFromAssembly with a panic.
-	// In practice this is always *assembly.CoreAssembly from kernel/assembly.
+	// Assembly must be the same *assembly.CoreAssembly instance later
+	// supplied to bootstrap.WithAssembly. Constructors only reject
+	// nil/typed-nil; wrong-instance values pass construction and are
+	// caught at bootstrap phase0.
 	Assembly AssemblyRef
 
 	// resolved holds the verifier once phase4 has run. Bootstrap writes via
@@ -179,8 +187,9 @@ type AuthJWTFromAssembly struct {
 }
 
 // NewAuthJWTFromAssembly constructs an AuthJWTFromAssembly plan. Returns an
-// error when asm is nil; use MustNewAuthJWTFromAssembly for fail-fast static
-// wiring.
+// error when asm is nil or a typed-nil interface value; the same input passed
+// to MustNewAuthJWTFromAssembly panics instead. The same-instance constraint
+// (see AuthJWTFromAssembly type doc) is checked later, at bootstrap phase0.
 func NewAuthJWTFromAssembly(asm AssemblyRef) (AuthJWTFromAssembly, error) {
 	if validation.IsNilInterface(asm) {
 		return AuthJWTFromAssembly{}, fmt.Errorf("cell: NewAuthJWTFromAssembly assembly must not be nil")
@@ -192,7 +201,9 @@ func NewAuthJWTFromAssembly(asm AssemblyRef) (AuthJWTFromAssembly, error) {
 }
 
 // MustNewAuthJWTFromAssembly is the composition-root convenience wrapper around
-// NewAuthJWTFromAssembly that panics on misconfiguration.
+// NewAuthJWTFromAssembly that panics on nil/typed-nil input. It does not
+// validate the same-instance constraint (see AuthJWTFromAssembly type doc),
+// which bootstrap phase0 enforces with a fail-fast error.
 func MustNewAuthJWTFromAssembly(asm AssemblyRef) AuthJWTFromAssembly {
 	plan, err := NewAuthJWTFromAssembly(asm)
 	if err != nil {

--- a/kernel/cell/auth_plan_test.go
+++ b/kernel/cell/auth_plan_test.go
@@ -252,6 +252,26 @@ func TestAuthJWTFromAssembly_ResolvedVerifier(t *testing.T) {
 	}
 }
 
+func TestAuthJWTFromAssembly_IsConstructed(t *testing.T) {
+	t.Parallel()
+
+	asm := &stubAssemblyRef{id: "constructed"}
+	p, err := cell.NewAuthJWTFromAssembly(asm)
+	if err != nil {
+		t.Fatalf("NewAuthJWTFromAssembly returned unexpected error: %v", err)
+	}
+	if !p.IsConstructed() {
+		t.Fatal("constructor-built AuthJWTFromAssembly should report constructed")
+	}
+
+	if (cell.AuthJWTFromAssembly{}).IsConstructed() {
+		t.Fatal("struct-literal AuthJWTFromAssembly should report not constructed")
+	}
+	if (cell.AuthJWTFromAssembly{Assembly: asm}).IsConstructed() {
+		t.Fatal("literal with Assembly but no resolver should report not constructed")
+	}
+}
+
 // ─── TokenIntent ──────────────────────────────────────────────────────────────
 
 func TestTokenIntent_IsValid(t *testing.T) {

--- a/kernel/cell/auth_plan_test.go
+++ b/kernel/cell/auth_plan_test.go
@@ -276,11 +276,14 @@ func TestTokenIntent_IsValid(t *testing.T) {
 
 // ─── Test stubs ───────────────────────────────────────────────────────────────
 
-// stubAssemblyRef satisfies cell.AssemblyRef.
+// stubAssemblyRef satisfies cell.AssemblyRef. Cell returns nil because the
+// kernel/cell tests validate construction-time invariants only; cell lookup
+// is exercised end-to-end by runtime/bootstrap tests.
 type stubAssemblyRef struct{ id string }
 
-func (s *stubAssemblyRef) ID() string        { return s.id }
-func (s *stubAssemblyRef) CellIDs() []string { return nil }
+func (s *stubAssemblyRef) ID() string              { return s.id }
+func (s *stubAssemblyRef) CellIDs() []string       { return nil }
+func (s *stubAssemblyRef) Cell(_ string) cell.Cell { return nil }
 
 // stubVerifier satisfies cell.IntentTokenVerifier.
 type stubVerifier struct{}

--- a/kernel/cell/auth_types.go
+++ b/kernel/cell/auth_types.go
@@ -105,9 +105,10 @@ type HMACKeyring interface {
 }
 
 // AuthProvider is an optional cell-level interface that exposes an
-// IntentTokenVerifier for runtime authentication. AuthJWTFromAssembly scans
-// the assembly for cells implementing this interface during phase4.
-// This is the kernel projection of the bootstrap-private authProvider interface.
+// IntentTokenVerifier for runtime authentication. AuthJWTFromAssembly walks
+// the assembly's CellIDs in deterministic order during bootstrap phase4 and
+// promotes the unique implementer's verifier; zero, multiple, or nil
+// verifiers are rejected with a startup error.
 type AuthProvider interface {
 	TokenVerifier() IntentTokenVerifier
 }

--- a/runtime/bootstrap/auth_plan_apply.go
+++ b/runtime/bootstrap/auth_plan_apply.go
@@ -138,8 +138,9 @@ func discoverAuthVerifierFromAssembly(asm cell.AssemblyRef) (auth.IntentTokenVer
 			continue
 		}
 		// cell.AuthProvider.TokenVerifier() returns cell.IntentTokenVerifier.
-		// auth.IntentTokenVerifier is a type alias of cell.IntentTokenVerifier
-		// (F6), so the assignment is direct with no runtime conversion needed.
+		// auth.IntentTokenVerifier is a Go type alias of cell.IntentTokenVerifier
+		// (runtime/auth/auth.go:56, F6), so the assignment is direct with no
+		// runtime conversion needed.
 		v := ap.TokenVerifier()
 		if v == nil {
 			return nil, fmt.Errorf(

--- a/runtime/bootstrap/auth_plan_apply.go
+++ b/runtime/bootstrap/auth_plan_apply.go
@@ -123,7 +123,7 @@ func (b *Bootstrap) runAuthPlanValidateHooks() error {
 //
 // Moved from policy_jwt_from_assembly.go; kept bootstrap-private.
 func discoverAuthVerifierFromAssembly(asm cell.AssemblyRef) (auth.IntentTokenVerifier, error) {
-	if asm == nil {
+	if validation.IsNilInterface(asm) {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 			"bootstrap: AuthJWTFromAssembly.Assembly is nil; use cell.NewAuthJWTFromAssembly(asm)")
 	}

--- a/runtime/bootstrap/auth_plan_apply.go
+++ b/runtime/bootstrap/auth_plan_apply.go
@@ -131,9 +131,9 @@ func discoverAuthVerifierFromAssembly(asm cell.AssemblyRef) (auth.IntentTokenVer
 		foundID string
 	)
 	for _, id := range asm.CellIDs() {
-		// AssemblyRef is a minimal interface; assemblyWithCell adds Cell(id).
-		// Bootstrap bridges the gap via asmCellLookup.
-		ap, ok := asmCellLookup(asm, id)
+		// asm.Cell returns nil for unknown IDs; the AuthProvider type
+		// assertion then yields ok=false and the cell is skipped.
+		ap, ok := asm.Cell(id).(cell.AuthProvider)
 		if !ok {
 			continue
 		}
@@ -161,25 +161,6 @@ func discoverAuthVerifierFromAssembly(asm cell.AssemblyRef) (auth.IntentTokenVer
 				"or wire the verifier explicitly via cell.NewAuthJWT(verifier)")
 	}
 	return found, nil
-}
-
-// assemblyWithCell is the internal interface needed by discoverAuthVerifierFromAssembly
-// to look up cells by ID. *assembly.CoreAssembly satisfies this.
-type assemblyWithCell interface {
-	cell.AssemblyRef
-	Cell(id string) cell.Cell
-}
-
-// asmCellLookup type-asserts asm to assemblyWithCell and looks up a cell.AuthProvider.
-// Returns (nil, false) if asm doesn't have the Cell(id) method or the cell doesn't
-// implement cell.AuthProvider.
-func asmCellLookup(asm cell.AssemblyRef, id string) (cell.AuthProvider, bool) {
-	awc, ok := asm.(assemblyWithCell)
-	if !ok {
-		return nil, false
-	}
-	ap, ok := awc.Cell(id).(cell.AuthProvider)
-	return ap, ok
 }
 
 // ─── Middleware factories ─────────────────────────────────────────────────────

--- a/runtime/bootstrap/auth_plan_apply.go
+++ b/runtime/bootstrap/auth_plan_apply.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/http/router"
 )
@@ -140,25 +141,27 @@ func discoverAuthVerifierFromAssembly(asm cell.AssemblyRef) (auth.IntentTokenVer
 		// cell.AuthProvider.TokenVerifier() returns cell.IntentTokenVerifier.
 		// auth.IntentTokenVerifier is a Go type alias of cell.IntentTokenVerifier
 		// (runtime/auth/auth.go:56, F6), so the assignment is direct with no
-		// runtime conversion needed.
+		// runtime conversion needed. validation.IsNilInterface catches both
+		// untyped nil and typed-nil verifiers (e.g. `var v *MyVerifier`)
+		// before they propagate into router wiring.
 		v := ap.TokenVerifier()
-		if v == nil {
-			return nil, fmt.Errorf(
-				"bootstrap: cell %q implements authProvider (cell.AuthProvider) but TokenVerifier() returned nil", id)
+		if validation.IsNilInterface(v) {
+			return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+				fmt.Sprintf("bootstrap: cell %q implements authProvider (cell.AuthProvider) but TokenVerifier() returned nil", id))
 		}
 		if found != nil {
-			return nil, fmt.Errorf(
-				"bootstrap: multiple authProvider cells discovered: %q and %q; "+
+			return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+				fmt.Sprintf("bootstrap: multiple authProvider cells discovered: %q and %q; "+
 					"keep only one or supply the verifier explicitly via cell.NewAuthJWT(verifier)",
-				foundID, id)
+					foundID, id))
 		}
 		found = v
 		foundID = id
 	}
 	if found == nil {
-		return nil, fmt.Errorf(
-			"bootstrap: AuthJWTFromAssembly found no authProvider cell in the assembly; " +
-				"register a cell implementing cell.AuthProvider whose TokenVerifier() returns a non-nil auth.IntentTokenVerifier, " +
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"bootstrap: AuthJWTFromAssembly found no authProvider cell in the assembly; "+
+				"register a cell implementing cell.AuthProvider whose TokenVerifier() returns a non-nil auth.IntentTokenVerifier, "+
 				"or wire the verifier explicitly via cell.NewAuthJWT(verifier)")
 	}
 	return found, nil

--- a/runtime/bootstrap/auth_plan_apply_test.go
+++ b/runtime/bootstrap/auth_plan_apply_test.go
@@ -48,6 +48,15 @@ type applyStubHMACKeyring struct{}
 func (k *applyStubHMACKeyring) Current() []byte   { return []byte("secret-32-bytes-padding-here----") }
 func (k *applyStubHMACKeyring) Secrets() [][]byte { return [][]byte{k.Current()} }
 
+// Compile-time guard: cell.AssemblyRef must expose Cell(id string) cell.Cell
+// so that runtime/bootstrap can resolve registered cells by ID without an
+// implicit type assertion to a private sub-interface. The canonical guard
+// is the AST-level ASSEMBLYREF-METHOD-SET-01 archtest
+// (tools/archtest/assemblyref_method_set_test.go); this method-expression
+// reference adds a typecheck-time tripwire that fails this test binary's
+// build immediately if Cell is removed from AssemblyRef.
+var _ func(cell.AssemblyRef, string) cell.Cell = cell.AssemblyRef.Cell
+
 // applyStubAssemblyRef satisfies cell.AssemblyRef.
 type applyStubAssemblyRef struct {
 	id      string

--- a/runtime/bootstrap/auth_plan_apply_test.go
+++ b/runtime/bootstrap/auth_plan_apply_test.go
@@ -57,14 +57,18 @@ func (k *applyStubHMACKeyring) Secrets() [][]byte { return [][]byte{k.Current()}
 // build immediately if Cell is removed from AssemblyRef.
 var _ func(cell.AssemblyRef, string) cell.Cell = cell.AssemblyRef.Cell
 
-// applyStubAssemblyRef satisfies cell.AssemblyRef.
+// applyStubAssemblyRef satisfies cell.AssemblyRef. Cell always returns nil
+// because the tests using this stub validate auth-chain placement and
+// singleton invariants — they do not exercise authProvider discovery, which
+// has dedicated coverage via fakeAssemblyWithCells below.
 type applyStubAssemblyRef struct {
 	id      string
 	cellIDs []string
 }
 
-func (a *applyStubAssemblyRef) ID() string        { return a.id }
-func (a *applyStubAssemblyRef) CellIDs() []string { return a.cellIDs }
+func (a *applyStubAssemblyRef) ID() string              { return a.id }
+func (a *applyStubAssemblyRef) CellIDs() []string       { return a.cellIDs }
+func (a *applyStubAssemblyRef) Cell(_ string) cell.Cell { return nil }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -249,7 +253,8 @@ func (c *fakeAuthProviderCell) TokenVerifier() cell.IntentTokenVerifier { return
 // Ensure fakeAuthProviderCell satisfies cell.AuthProvider at compile time.
 var _ cell.AuthProvider = (*fakeAuthProviderCell)(nil)
 
-// fakeAssemblyWithCells satisfies both cell.AssemblyRef and assemblyWithCell.
+// fakeAssemblyWithCells satisfies cell.AssemblyRef with an in-memory cell map,
+// providing the by-ID lookup that authProvider discovery exercises.
 type fakeAssemblyWithCells struct {
 	id    string
 	cells map[string]cell.Cell

--- a/runtime/bootstrap/auth_plan_apply_test.go
+++ b/runtime/bootstrap/auth_plan_apply_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -266,6 +267,9 @@ func (a *fakeAssemblyWithCells) CellIDs() []string {
 	for id := range a.cells {
 		ids = append(ids, id)
 	}
+	// Sort to match production CoreAssembly.CellIDs ordering, so that
+	// discovery-error messages naming foundID/id are deterministic.
+	sort.Strings(ids)
 	return ids
 }
 func (a *fakeAssemblyWithCells) Cell(id string) cell.Cell { return a.cells[id] }

--- a/runtime/bootstrap/auth_plan_apply_test.go
+++ b/runtime/bootstrap/auth_plan_apply_test.go
@@ -81,11 +81,36 @@ func newMinimalBootstrap() *Bootstrap {
 	}
 }
 
-// hasAuthMiddlewareOpt returns true if opts contains ≥1 router option.
-// applyListenerAuthChain only populates routerOpts for JWT plans (AuthJWT/AuthJWTFromAssembly);
-// non-JWT plans add to mws instead. A non-empty routerOpts slice signals a JWT plan.
-func hasAuthMiddlewareOpt(opts []routerpkg.Option) bool {
-	return len(opts) > 0
+// routerInstallsAuthMiddleware applies router options to a real Router and
+// observes request behavior. A protected route returns 401 without an
+// Authorization header only when router.WithAuthMiddleware is actually wired.
+func routerInstallsAuthMiddleware(t *testing.T, opts []routerpkg.Option) bool {
+	t.Helper()
+
+	allOpts := append([]routerpkg.Option{routerpkg.WithRouterClock(clock.Real())}, opts...)
+	rtr, err := routerpkg.NewForListener(cell.PrimaryListener, allOpts...)
+	require.NoError(t, err)
+
+	auth.MustMount(rtr, auth.Route{
+		Contract: testHTTPContract(http.MethodGet, "/auth-plan/protected"),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	})
+	require.NoError(t, rtr.FinalizeAuth())
+
+	rec := httptest.NewRecorder()
+	rtr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/auth-plan/protected", nil))
+
+	switch rec.Code {
+	case http.StatusUnauthorized:
+		return true
+	case http.StatusOK:
+		return false
+	default:
+		t.Fatalf("protected route returned status %d, want 401 with auth middleware or 200 without it", rec.Code)
+		return false
+	}
 }
 
 // ─── TestApplyListenerAuthChain_EachKind ──────────────────────────────────────
@@ -104,33 +129,33 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 	ref := cell.PrimaryListener
 
 	tests := []struct {
-		name          string
-		chain         []cell.ListenerAuth
-		wantMWCount   int
-		wantRouterOpt bool // whether a WithAuthMiddleware router option is included
-		wantDescribe  string
-		wantErr       bool
+		name              string
+		chain             []cell.ListenerAuth
+		wantMWCount       int
+		wantAuthInstalled bool
+		wantDescribe      string
+		wantErr           bool
 	}{
 		{
-			name:          "AuthNone",
-			chain:         []cell.ListenerAuth{cell.AuthNone{}},
-			wantMWCount:   0,
-			wantRouterOpt: false,
-			wantDescribe:  "none",
+			name:              "AuthNone",
+			chain:             []cell.ListenerAuth{cell.AuthNone{}},
+			wantMWCount:       0,
+			wantAuthInstalled: false,
+			wantDescribe:      "none",
 		},
 		{
-			name:          "AuthJWT",
-			chain:         []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)},
-			wantMWCount:   0,
-			wantRouterOpt: true,
-			wantDescribe:  "jwt",
+			name:              "AuthJWT",
+			chain:             []cell.ListenerAuth{cell.MustNewAuthJWT(verifier)},
+			wantMWCount:       0,
+			wantAuthInstalled: true,
+			wantDescribe:      "jwt",
 		},
 		{
-			name:          "AuthJWTFromAssembly_resolved",
-			chain:         []cell.ListenerAuth{resolvedPlan},
-			wantMWCount:   0,
-			wantRouterOpt: true,
-			wantDescribe:  "jwt",
+			name:              "AuthJWTFromAssembly_resolved",
+			chain:             []cell.ListenerAuth{resolvedPlan},
+			wantMWCount:       0,
+			wantAuthInstalled: true,
+			wantDescribe:      "jwt",
 		},
 		{
 			name: "AuthJWTFromAssembly_unresolved",
@@ -140,18 +165,18 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:          "AuthMTLS",
-			chain:         []cell.ListenerAuth{cell.AuthMTLS{}},
-			wantMWCount:   1,
-			wantRouterOpt: false,
-			wantDescribe:  "mtls",
+			name:              "AuthMTLS",
+			chain:             []cell.ListenerAuth{cell.AuthMTLS{}},
+			wantMWCount:       1,
+			wantAuthInstalled: false,
+			wantDescribe:      "mtls",
 		},
 		{
-			name:          "AuthServiceToken",
-			chain:         []cell.ListenerAuth{cell.MustNewAuthServiceToken(store, ring)},
-			wantMWCount:   1,
-			wantRouterOpt: false,
-			wantDescribe:  "service-token",
+			name:              "AuthServiceToken",
+			chain:             []cell.ListenerAuth{cell.MustNewAuthServiceToken(store, ring)},
+			wantMWCount:       1,
+			wantAuthInstalled: false,
+			wantDescribe:      "service-token",
 		},
 		{
 			name: "MultiPlan_MTLSAndServiceToken",
@@ -159,9 +184,9 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 				cell.AuthMTLS{},
 				cell.MustNewAuthServiceToken(store, ring),
 			},
-			wantMWCount:   2,
-			wantRouterOpt: false,
-			wantDescribe:  "mtls+service-token",
+			wantMWCount:       2,
+			wantAuthInstalled: false,
+			wantDescribe:      "mtls+service-token",
 		},
 	}
 
@@ -177,13 +202,8 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, mws, tc.wantMWCount, "middleware count")
 			assert.Equal(t, tc.wantDescribe, describe, "describe")
-			if tc.wantRouterOpt {
-				assert.True(t, hasAuthMiddlewareOpt(routerOpts),
-					"expected WithAuthMiddleware router option but none found")
-			} else {
-				assert.False(t, hasAuthMiddlewareOpt(routerOpts),
-					"expected no WithAuthMiddleware router option but found one")
-			}
+			assert.Equal(t, tc.wantAuthInstalled, routerInstallsAuthMiddleware(t, routerOpts),
+				"auth middleware installation")
 		})
 	}
 }
@@ -278,6 +298,18 @@ func TestRunAuthPlanValidateHooks_DiscoverScenarios(t *testing.T) {
 	t.Parallel()
 
 	verifier := &applyStubVerifier{}
+
+	t.Run("typed_nil_assembly_returns_error", func(t *testing.T) {
+		t.Parallel()
+		var asm *applyStubAssemblyRef
+		var err error
+
+		require.NotPanics(t, func() {
+			_, err = discoverAuthVerifierFromAssembly(asm)
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Assembly is nil")
+	})
 
 	t.Run("zero_providers_returns_error", func(t *testing.T) {
 		t.Parallel()

--- a/runtime/bootstrap/auth_plan_validate.go
+++ b/runtime/bootstrap/auth_plan_validate.go
@@ -4,8 +4,9 @@ package bootstrap
 //
 // Four validation functions are used by bootstrap_phases.go:
 //
-//   validateAuthPlanAssemblyMatch  — phase0: AuthJWTFromAssembly.Assembly must be
-//                                    the same instance as WithAssembly's assembly.
+//   validateAuthJWTFromAssemblyPlans — phase0: AuthJWTFromAssembly must be
+//                                      constructor-built with a non-nil Assembly
+//                                      matching WithAssembly when registered.
 //   validateAuthPlanMTLSBindings   — phase0: any listener with AuthMTLS must
 //                                    have ClientAuth + ClientCAs set on tls.Config.
 //   validateAuthChainJWTSingleton  — phase0: at most 1 JWT plan in a listener chain,
@@ -25,32 +26,54 @@ import (
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
-// validateAuthPlanAssemblyMatch enforces the single-assembly invariant:
-// any AuthJWTFromAssembly in a listener chain must carry the same AssemblyRef
-// instance that was passed to WithAssembly. This prevents the silent bug where
-// PolicyJWTFromAssembly(asmA) + WithAssembly(asmB) would discover auth in asmA
-// while running the rest of bootstrap against asmB.
-//
-// Replaces: validateListenerPolicyAssemblyMatch (bootstrap_phases.go).
-func (b *Bootstrap) validateAuthPlanAssemblyMatch() error {
-	if b.assemblyCore == nil {
-		return nil
-	}
+// validateAuthJWTFromAssemblyPlans catches malformed AuthJWTFromAssembly
+// literals at phase0, then enforces the single-assembly invariant when
+// WithAssembly is present. This prevents nil/typed-nil panics, rejected
+// constructor bypass, and the silent bug where AuthJWTFromAssembly(asmA) +
+// WithAssembly(asmB) would discover auth in asmA while running the rest of
+// bootstrap against asmB.
+func (b *Bootstrap) validateAuthJWTFromAssemblyPlans() error {
 	for ref, cfg := range b.listenerConfigs {
-		for _, plan := range cfg.authChain {
+		for i, plan := range cfg.authChain {
 			p, ok := plan.(cell.AuthJWTFromAssembly)
 			if !ok {
 				continue
 			}
-			// Identity check: same pointer, not just same ID.
-			if p.Assembly != b.assemblyCore {
-				return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
-					fmt.Sprintf(
-						"bootstrap: listener %q AuthJWTFromAssembly carries assembly %q but WithAssembly registered %q; "+
-							"the composition root must wire the same *assembly.CoreAssembly instance everywhere",
-						ref.String(), p.Assembly.ID(), b.assemblyCore.ID()))
+			if err := b.validateAuthJWTFromAssemblyPlan(ref.String(), i, p); err != nil {
+				return err
 			}
 		}
+	}
+	return nil
+}
+
+func (b *Bootstrap) validateAuthJWTFromAssemblyPlan(
+	listener string,
+	position int,
+	p cell.AuthJWTFromAssembly,
+) error {
+	if validation.IsNilInterface(p.Assembly) {
+		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			fmt.Sprintf("listener %q: AuthJWTFromAssembly at position %d Assembly must not be nil; "+
+				"construct it with cell.MustNewAuthJWTFromAssembly(asm)",
+				listener, position))
+	}
+	if !p.IsConstructed() {
+		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			fmt.Sprintf("listener %q: AuthJWTFromAssembly at position %d was constructed as a struct literal; "+
+				"use cell.NewAuthJWTFromAssembly(asm) or cell.MustNewAuthJWTFromAssembly(asm) "+
+				"so the resolver pointer is initialized",
+				listener, position))
+	}
+	if b.assemblyCore == nil {
+		return nil
+	}
+	if p.Assembly != b.assemblyCore {
+		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			fmt.Sprintf(
+				"bootstrap: listener %q AuthJWTFromAssembly carries assembly %q but WithAssembly registered %q; "+
+					"the composition root must wire the same *assembly.CoreAssembly instance everywhere",
+				listener, p.Assembly.ID(), b.assemblyCore.ID()))
 	}
 	return nil
 }

--- a/runtime/bootstrap/auth_plan_validate_test.go
+++ b/runtime/bootstrap/auth_plan_validate_test.go
@@ -1,7 +1,7 @@
 package bootstrap
 
 // auth_plan_validate_test.go — white-box table-driven tests for
-// validateAuthChainJWTSingleton, validateAuthPlanAssemblyMatch, and
+// validateAuthChainJWTSingleton, validateAuthJWTFromAssemblyPlans, and
 // validateAuthPlanMTLSBindings. Uses package bootstrap for white-box access.
 
 import (
@@ -117,9 +117,9 @@ func TestValidateAuthChainJWTSingleton(t *testing.T) {
 	}
 }
 
-// ─── TestValidateAuthPlanAssemblyMatch ────────────────────────────────────────
+// ─── TestValidateAuthJWTFromAssemblyPlans ─────────────────────────────────────
 
-func TestValidateAuthPlanAssemblyMatch(t *testing.T) {
+func TestValidateAuthJWTFromAssemblyPlans(t *testing.T) {
 	t.Parallel()
 
 	asmA := assembly.New(assembly.Config{ID: "asm-match-a", DurabilityMode: cell.DurabilityDemo, Clock: clock.Real()})
@@ -133,7 +133,7 @@ func TestValidateAuthPlanAssemblyMatch(t *testing.T) {
 			WithListener(cell.PrimaryListener, "127.0.0.1:0",
 				[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asmA)}),
 		)
-		err := b.validateAuthPlanAssemblyMatch()
+		err := b.validateAuthJWTFromAssemblyPlans()
 		require.NoError(t, err)
 	})
 
@@ -145,7 +145,7 @@ func TestValidateAuthPlanAssemblyMatch(t *testing.T) {
 			WithListener(cell.PrimaryListener, "127.0.0.1:0",
 				[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asmB)}),
 		)
-		err := b.validateAuthPlanAssemblyMatch()
+		err := b.validateAuthJWTFromAssemblyPlans()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "AuthJWTFromAssembly")
 		assert.Contains(t, err.Error(), "asm-match-a")
@@ -155,7 +155,7 @@ func TestValidateAuthPlanAssemblyMatch(t *testing.T) {
 
 	t.Run("NilAssembly_NoError", func(t *testing.T) {
 		t.Parallel()
-		// No WithAssembly — b.assembly is nil; validateAuthPlanAssemblyMatch
+		// No WithAssembly — b.assembly is nil; validateAuthJWTFromAssemblyPlans
 		// should return nil immediately.
 		b := &Bootstrap{
 			listenerConfigs: map[cell.ListenerRef]listenerConfig{
@@ -164,8 +164,68 @@ func TestValidateAuthPlanAssemblyMatch(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, b.validateAuthPlanAssemblyMatch())
+		require.NoError(t, b.validateAuthJWTFromAssemblyPlans())
 	})
+
+	t.Run("ConstructedPlanWithoutWithAssembly_NoError", func(t *testing.T) {
+		t.Parallel()
+		asm := &applyStubAssemblyRef{id: "valid-no-withassembly"}
+		b := bootstrapWithListener(
+			cell.PrimaryListener,
+			[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(asm)},
+			nil,
+		)
+		require.NoError(t, b.validateAuthJWTFromAssemblyPlans())
+	})
+}
+
+func TestValidateAuthJWTFromAssemblyPlans_RejectsConstructorBypass(t *testing.T) {
+	t.Parallel()
+
+	asm := &applyStubAssemblyRef{id: "literal-asm"}
+	var typedNil *applyStubAssemblyRef
+
+	tests := []struct {
+		name    string
+		plan    cell.AuthJWTFromAssembly
+		wantErr string
+	}{
+		{
+			name:    "zero literal",
+			plan:    cell.AuthJWTFromAssembly{},
+			wantErr: "Assembly must not be nil",
+		},
+		{
+			name:    "nil Assembly literal",
+			plan:    cell.AuthJWTFromAssembly{Assembly: nil},
+			wantErr: "Assembly must not be nil",
+		},
+		{
+			name:    "typed nil Assembly literal",
+			plan:    cell.AuthJWTFromAssembly{Assembly: typedNil},
+			wantErr: "Assembly must not be nil",
+		},
+		{
+			name:    "real Assembly literal without resolver",
+			plan:    cell.AuthJWTFromAssembly{Assembly: asm},
+			wantErr: "constructed as a struct literal",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := bootstrapWithListener(cell.PrimaryListener, []cell.ListenerAuth{tc.plan}, nil)
+
+			var err error
+			require.NotPanics(t, func() {
+				err = b.validateAuthJWTFromAssemblyPlans()
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Contains(t, err.Error(), cell.PrimaryListener.String())
+		})
+	}
 }
 
 // ─── TestValidateAuthPlanMTLSBindings ─────────────────────────────────────────

--- a/runtime/bootstrap/auth_plan_validate_test.go
+++ b/runtime/bootstrap/auth_plan_validate_test.go
@@ -153,6 +153,24 @@ func TestValidateAuthJWTFromAssemblyPlans(t *testing.T) {
 		assert.Contains(t, err.Error(), cell.PrimaryListener.String())
 	})
 
+	t.Run("Mismatch_SameIDDifferentInstances", func(t *testing.T) {
+		t.Parallel()
+		asmWithID := assembly.New(assembly.Config{ID: "asm-match-same-id", DurabilityMode: cell.DurabilityDemo, Clock: clock.Real()})
+		otherWithSameID := assembly.New(assembly.Config{ID: "asm-match-same-id", DurabilityMode: cell.DurabilityDemo, Clock: clock.Real()})
+		b := New(
+			WithClock(clock.Real()),
+			WithAssembly(asmWithID),
+			WithListener(cell.PrimaryListener, "127.0.0.1:0",
+				[]cell.ListenerAuth{cell.MustNewAuthJWTFromAssembly(otherWithSameID)}),
+		)
+
+		err := b.validateAuthJWTFromAssemblyPlans()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AuthJWTFromAssembly")
+		assert.Contains(t, err.Error(), "same *assembly.CoreAssembly instance")
+		assert.Contains(t, err.Error(), cell.PrimaryListener.String())
+	})
+
 	t.Run("NilAssembly_NoError", func(t *testing.T) {
 		t.Parallel()
 		// No WithAssembly — b.assembly is nil; validateAuthJWTFromAssemblyPlans

--- a/runtime/bootstrap/phases_assembly.go
+++ b/runtime/bootstrap/phases_assembly.go
@@ -36,7 +36,7 @@ func (b *Bootstrap) phase0ValidateOptions() error {
 	if b.managedResourceNil {
 		return fmt.Errorf("bootstrap: managed resource must not be nil in WithManagedResource")
 	}
-	if err := b.validateAuthPlanAssemblyMatch(); err != nil {
+	if err := b.validateAuthJWTFromAssemblyPlans(); err != nil {
 		return err
 	}
 	if err := b.validateAuthPlanMTLSBindings(); err != nil {

--- a/tools/archtest/assemblyref_method_set_test.go
+++ b/tools/archtest/assemblyref_method_set_test.go
@@ -1,0 +1,180 @@
+package archtest
+
+// assemblyref_method_set_test.go — AST guard for cell.AssemblyRef method set.
+//
+// Rule:
+//
+//   ASSEMBLYREF-METHOD-SET-01  cell.AssemblyRef interface (kernel/cell/auth_plan.go)
+//                              must declare exactly three methods:
+//                                ID() string
+//                                CellIDs() []string
+//                                Cell(id string) Cell
+//                              No additions, no removals. Reverse narrowing
+//                              (e.g. dropping Cell(id) and re-introducing the
+//                              implicit type-assertion bridge in
+//                              runtime/bootstrap/auth_plan_apply.go) is the
+//                              regression we are guarding against.
+//
+// Background: prior to refactor/529 the bootstrap layer carried a private
+// assemblyWithCell sub-interface and an asmCellLookup helper that did
+// asm.(assemblyWithCell) — a silent-skip type assertion when the assembly
+// implementation lacked Cell(id). Promoting Cell(id) onto AssemblyRef makes
+// the contract complete and lets the compiler enforce it; this test prevents
+// a future refactor from re-narrowing the interface back to the two-method
+// form.
+//
+// ref: kubernetes-sigs/controller-runtime pkg/cluster/cluster.go@main
+//      — explicit interface seam, no implicit type narrowing in callers.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const assemblyRefRule01 = "ASSEMBLYREF-METHOD-SET-01"
+
+// expectedAssemblyRefMethods is the canonical method set for cell.AssemblyRef.
+// Each entry is "<name>(<params>) <results>" with go/printer-equivalent
+// formatting (single space between groups, no trailing space).
+var expectedAssemblyRefMethods = map[string]string{
+	"ID":      "() string",
+	"CellIDs": "() []string",
+	"Cell":    "(id string) Cell",
+}
+
+// TestAssemblyRefMethodSet enforces ASSEMBLYREF-METHOD-SET-01: the
+// cell.AssemblyRef interface must carry exactly the three methods listed in
+// expectedAssemblyRefMethods. Adding, removing, or renaming a method without
+// updating this test indicates either a deliberate contract change (update
+// the test in the same PR) or an accidental narrowing (revert the change).
+func TestAssemblyRefMethodSet(t *testing.T) {
+	root := findModuleRoot(t)
+	srcPath := filepath.Join(root, "kernel", "cell", "auth_plan.go")
+
+	fset := token.NewFileSet()
+	af, err := parser.ParseFile(fset, srcPath, nil, parser.SkipObjectResolution)
+	require.NoError(t, err, "parse %s", srcPath)
+
+	iface := findInterfaceDecl(af, "AssemblyRef")
+	require.NotNil(t, iface, "%s: type AssemblyRef interface not found in %s", assemblyRefRule01, srcPath)
+
+	got := make(map[string]string, len(iface.Methods.List))
+	for _, m := range iface.Methods.List {
+		require.Len(t, m.Names, 1,
+			"%s: AssemblyRef methods must be named (no embedded interfaces)", assemblyRefRule01)
+		name := m.Names[0].Name
+		ft, ok := m.Type.(*ast.FuncType)
+		require.True(t, ok, "%s: method %s must be a FuncType", assemblyRefRule01, name)
+		got[name] = formatFuncSignature(ft)
+	}
+
+	assert.Equal(t, expectedAssemblyRefMethods, got,
+		"%s: cell.AssemblyRef method set drift detected. "+
+			"If this is a deliberate contract change, update expectedAssemblyRefMethods "+
+			"in the same PR; otherwise revert the interface narrowing/widening.",
+		assemblyRefRule01)
+}
+
+// findInterfaceDecl returns the *ast.InterfaceType declared as `type <name>
+// interface { … }` in af, or nil if not found.
+func findInterfaceDecl(af *ast.File, name string) *ast.InterfaceType {
+	for _, decl := range af.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != name {
+				continue
+			}
+			if iface, ok := ts.Type.(*ast.InterfaceType); ok {
+				return iface
+			}
+		}
+	}
+	return nil
+}
+
+// formatFuncSignature renders an *ast.FuncType as "(<params>) <results>"
+// matching the canonical Go fmt-equivalent form used in
+// expectedAssemblyRefMethods. Single-result types are not parenthesized;
+// multi-result types are.
+func formatFuncSignature(ft *ast.FuncType) string {
+	out := "(" + formatFieldList(ft.Params, false) + ")"
+	if ft.Results == nil || len(ft.Results.List) == 0 {
+		return out
+	}
+	results := formatFieldList(ft.Results, false)
+	if len(ft.Results.List) > 1 || len(ft.Results.List[0].Names) > 0 {
+		results = "(" + results + ")"
+	}
+	return out + " " + results
+}
+
+// formatFieldList renders an *ast.FieldList as a comma-joined string of
+// "<names> <type>" segments (or just "<type>" when the field is anonymous).
+// Embedded names within a single field share one type expression.
+func formatFieldList(fl *ast.FieldList, _ bool) string {
+	if fl == nil {
+		return ""
+	}
+	var parts []string
+	for _, f := range fl.List {
+		typeStr := formatExpr(f.Type)
+		if len(f.Names) == 0 {
+			parts = append(parts, typeStr)
+			continue
+		}
+		names := ""
+		for i, n := range f.Names {
+			if i > 0 {
+				names += ", "
+			}
+			names += n.Name
+		}
+		parts = append(parts, names+" "+typeStr)
+	}
+	return joinComma(parts)
+}
+
+func joinComma(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+// formatExpr renders the small subset of ast.Expr shapes that appear in the
+// AssemblyRef method set: identifiers, qualified identifiers, slice types,
+// and pointer types. Anything outside this set falls back to ast.Expr's
+// best-effort string form via a panic — extending the interface should
+// prompt extending this helper too.
+func formatExpr(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return formatExpr(v.X) + "." + v.Sel.Name
+	case *ast.ArrayType:
+		if v.Len == nil {
+			return "[]" + formatExpr(v.Elt)
+		}
+	case *ast.StarExpr:
+		return "*" + formatExpr(v.X)
+	}
+	// Defensive: ASSEMBLYREF-METHOD-SET-01 should fail loudly on a method
+	// signature that uses an expression shape this helper does not yet
+	// handle, prompting a same-PR extension rather than silent acceptance.
+	panic("assemblyref_method_set_test: unsupported ast.Expr shape; extend formatExpr when AssemblyRef gains a new signature kind")
+}

--- a/tools/archtest/assemblyref_method_set_test.go
+++ b/tools/archtest/assemblyref_method_set_test.go
@@ -40,12 +40,16 @@ import (
 const assemblyRefRule01 = "ASSEMBLYREF-METHOD-SET-01"
 
 // expectedAssemblyRefMethods is the canonical method set for cell.AssemblyRef.
-// Each entry is "<name>(<params>) <results>" with go/printer-equivalent
-// formatting (single space between groups, no trailing space).
+// Each entry is "(<param-types>) <result-types>" — parameter and result
+// names are intentionally elided so that this guard locks the capability
+// (which methods exist with which types) rather than the source-level
+// spelling (which is documentation). A pure parameter rename like
+// `Cell(id string) Cell` → `Cell(cellID string) Cell` is intentionally
+// allowed; adding/removing/retyping a method must update this map.
 var expectedAssemblyRefMethods = map[string]string{
 	"ID":      "() string",
 	"CellIDs": "() []string",
-	"Cell":    "(id string) Cell",
+	"Cell":    "(string) Cell",
 }
 
 // TestAssemblyRefMethodSet enforces ASSEMBLYREF-METHOD-SET-01: the
@@ -102,46 +106,46 @@ func findInterfaceDecl(af *ast.File, name string) *ast.InterfaceType {
 	return nil
 }
 
-// formatFuncSignature renders an *ast.FuncType as "(<params>) <results>"
-// matching the canonical Go fmt-equivalent form used in
-// expectedAssemblyRefMethods. A single anonymous result is rendered without
-// parentheses; multiple results, or a single named result (e.g.
-// "(c Cell)"), are parenthesized — matching `gofmt` output. When extending
-// AssemblyRef, write the expected entry in the same form.
+// formatFuncSignature renders an *ast.FuncType as "(<param-types>) <results>"
+// matching the canonical types-only form used in expectedAssemblyRefMethods.
+// A single result is rendered without parentheses regardless of whether the
+// AST carries a name; two or more results are parenthesized. Names of both
+// parameters and results are deliberately discarded — see
+// expectedAssemblyRefMethods doc.
 func formatFuncSignature(ft *ast.FuncType) string {
-	out := "(" + formatFieldList(ft.Params) + ")"
+	out := "(" + formatFieldTypes(ft.Params) + ")"
 	if ft.Results == nil || len(ft.Results.List) == 0 {
 		return out
 	}
-	results := formatFieldList(ft.Results)
-	if len(ft.Results.List) > 1 || len(ft.Results.List[0].Names) > 0 {
+	results := formatFieldTypes(ft.Results)
+	if len(ft.Results.List) > 1 {
 		results = "(" + results + ")"
 	}
 	return out + " " + results
 }
 
-// formatFieldList renders an *ast.FieldList as a comma-joined string of
-// "<names> <type>" segments (or just "<type>" when the field is anonymous).
-// Embedded names within a single field share one type expression.
-func formatFieldList(fl *ast.FieldList) string {
+// formatFieldTypes renders an *ast.FieldList as a comma-joined sequence of
+// type expressions, ignoring all parameter / result names. A field that
+// declares N names with a single type expression contributes N type
+// segments (so `func(a, b string)` and `func(string, string)` both render
+// as "string, string").
+func formatFieldTypes(fl *ast.FieldList) string {
 	if fl == nil {
 		return ""
 	}
 	var parts []string
 	for _, f := range fl.List {
 		typeStr := formatExpr(f.Type)
-		if len(f.Names) == 0 {
+		// One field may declare multiple names sharing the same type; one
+		// type segment per name keeps the rendering equivalent to the
+		// fully-spelled form `func(a string, b string)`.
+		count := len(f.Names)
+		if count == 0 {
+			count = 1
+		}
+		for i := 0; i < count; i++ {
 			parts = append(parts, typeStr)
-			continue
 		}
-		names := ""
-		for i, n := range f.Names {
-			if i > 0 {
-				names += ", "
-			}
-			names += n.Name
-		}
-		parts = append(parts, names+" "+typeStr)
 	}
 	return joinComma(parts)
 }

--- a/tools/archtest/assemblyref_method_set_test.go
+++ b/tools/archtest/assemblyref_method_set_test.go
@@ -104,14 +104,16 @@ func findInterfaceDecl(af *ast.File, name string) *ast.InterfaceType {
 
 // formatFuncSignature renders an *ast.FuncType as "(<params>) <results>"
 // matching the canonical Go fmt-equivalent form used in
-// expectedAssemblyRefMethods. Single-result types are not parenthesized;
-// multi-result types are.
+// expectedAssemblyRefMethods. A single anonymous result is rendered without
+// parentheses; multiple results, or a single named result (e.g.
+// "(c Cell)"), are parenthesized — matching `gofmt` output. When extending
+// AssemblyRef, write the expected entry in the same form.
 func formatFuncSignature(ft *ast.FuncType) string {
-	out := "(" + formatFieldList(ft.Params, false) + ")"
+	out := "(" + formatFieldList(ft.Params) + ")"
 	if ft.Results == nil || len(ft.Results.List) == 0 {
 		return out
 	}
-	results := formatFieldList(ft.Results, false)
+	results := formatFieldList(ft.Results)
 	if len(ft.Results.List) > 1 || len(ft.Results.List[0].Names) > 0 {
 		results = "(" + results + ")"
 	}
@@ -121,7 +123,7 @@ func formatFuncSignature(ft *ast.FuncType) string {
 // formatFieldList renders an *ast.FieldList as a comma-joined string of
 // "<names> <type>" segments (or just "<type>" when the field is anonymous).
 // Embedded names within a single field share one type expression.
-func formatFieldList(fl *ast.FieldList, _ bool) string {
+func formatFieldList(fl *ast.FieldList) string {
 	if fl == nil {
 		return ""
 	}
@@ -156,10 +158,11 @@ func joinComma(parts []string) string {
 }
 
 // formatExpr renders the small subset of ast.Expr shapes that appear in the
-// AssemblyRef method set: identifiers, qualified identifiers, slice types,
-// and pointer types. Anything outside this set falls back to ast.Expr's
-// best-effort string form via a panic — extending the interface should
-// prompt extending this helper too.
+// AssemblyRef method set: identifiers, qualified identifiers, slice and
+// fixed-size array types, and pointer types. Anything outside this set
+// trips a panic — extending the interface should prompt extending this
+// helper in the same change so that the archtest stays expressive instead
+// of silently accepting an unfamiliar shape.
 func formatExpr(e ast.Expr) string {
 	switch v := e.(type) {
 	case *ast.Ident:
@@ -170,8 +173,11 @@ func formatExpr(e ast.Expr) string {
 		if v.Len == nil {
 			return "[]" + formatExpr(v.Elt)
 		}
+		return "[" + formatExpr(v.Len) + "]" + formatExpr(v.Elt)
 	case *ast.StarExpr:
 		return "*" + formatExpr(v.X)
+	case *ast.BasicLit:
+		return v.Value
 	}
 	// Defensive: ASSEMBLYREF-METHOD-SET-01 should fail loudly on a method
 	// signature that uses an expression shape this helper does not yet


### PR DESCRIPTION
## Summary

- 把 `Cell(id string) cell.Cell` 直接挂到 `kernel/cell.AssemblyRef` 接口上，删除 `runtime/bootstrap/auth_plan_apply.go` 内私有 `assemblyWithCell` 子接口和 `asmCellLookup` helper（共 ~20 行样板）；在 `discoverAuthVerifierFromAssembly` 内联为 `ap, ok := asm.Cell(id).(cell.AuthProvider)`。
- 编译期保证调用方不再走 silent-skip — 此前 `asm.(assemblyWithCell)` 类型断言失败时返回 `(nil, false)` → continue，是隐式 fallback；现在 Cell(id) 是接口契约的一部分，断言失败语义被消除（仍允许 cell 为 nil → skip，但路径明确）。
- 新增 `tools/archtest/assemblyref_method_set_test.go` (`ASSEMBLYREF-METHOD-SET-01`) AST 守护接口签名（要求且仅要求 ID/CellIDs/Cell 三方法），防未来反向收窄。
- TDD 流程严格红→绿：Batch A commit 写 archtest + 编译期 method-expression tripwire 双双 RED；Batch B commit 扩展接口 + 删 helper + 补 stub 方法转 GREEN。

Closes **B2-K-03**（W1 C5 残余 — PR-V1-KERNEL-IFACE-EXPLICIT 收尾）。

Refs: `docs/plans/202605011500-029-master-roadmap.md` W1 C5 残余 B2-K-03

ref: kubernetes-sigs/controller-runtime pkg/manager/manager.go — minimal interface seam（业界惯例：最小接口 + DI 扩展，不在主接口暴露 by-name lookup）。本 PR 的偏离理由：GoCell 是单进程框架无 RPC 边界，且 `Cell(id)` 早已存在于 `*kernel/assembly.CoreAssembly`（`kernel/assembly/assembly.go:738`），本次属"接口收窄遗漏的修正"而非"新增能力"；同侧加 archtest 锁定方法集，防 capability 漂移。

## 改动文件

| 文件 | 说明 |
|------|------|
| `kernel/cell/auth_plan.go` | `AssemblyRef` 加 `Cell(id string) Cell` 方法；godoc 改写为三方法完整契约描述 |
| `runtime/bootstrap/auth_plan_apply.go` | 删 `assemblyWithCell` 私有接口（4 行）+ `asmCellLookup` 函数（11 行）；inline 调用 |
| `runtime/bootstrap/auth_plan_apply_test.go` | `applyStubAssemblyRef` 补 `Cell` 返回 nil；`fakeAssemblyWithCells` godoc 去掉对 `assemblyWithCell` 的引用 |
| `kernel/cell/auth_plan_test.go` | `stubAssemblyRef` 补 `Cell` 返回 nil |
| `tools/archtest/assemblyref_method_set_test.go` | 新增 `ASSEMBLYREF-METHOD-SET-01` AST archtest |

## 不做清单（按"不预设未来需求"）

- 不加 `Cells() []cell.Cell` 全量返回方法
- 不加 `HasCell(id) bool` 便利方法（nil 返回即 miss）
- 不改 `CellIDs()` 返回顺序语义
- 不动 `runtime/command/bootstrap_phase.go` 等已直接用 `*CoreAssembly` 具体类型的路径
- 不做 deprecation alias / 兼容 shim（项目无外部消费方）

## Test plan

- [x] Batch A：`go test ./tools/archtest/... -run TestAssemblyRefMethodSet` 在扩展接口前 FAIL（确认 RED）；`go test ./runtime/bootstrap/... -run='^$'` 在扩展接口前 build fail（确认 method-expression RED tripwire）
- [x] Batch B：`go build ./...` GREEN
- [x] Batch B：`go test ./... -count=1 -race` 全 GREEN（包括 archtest 64s 全套 + bootstrap discover 三场景）
- [x] Batch B：`golangci-lint run ./...` 0 issues
- [x] Batch B：`go vet ./...` 0 issues
- [x] 反向验证：archtest 在缺失 Cell 方法时 FAIL — 由 Batch A RED commit 直接证实

🤖 Generated with [Claude Code](https://claude.com/claude-code)