### PR TITLE
refactor(refresh): close PR#388 leftover findings P1+P2 (cascade detach + idle/grace tightening + panic redact)

### DIFF
--- a/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
+++ b/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
@@ -32,8 +32,8 @@
 
 -- ADD COLUMN statements run outside a transaction (NO TRANSACTION mode) so
 -- they can be paired with CREATE INDEX CONCURRENTLY below. CREATE INDEX
--- CONCURRENTLY cannot run inside a transaction block; the +goose NO
--- TRANSACTION directive lifts that constraint for the whole migration.
+-- CONCURRENTLY cannot run inside a transaction block; the goose NO TRANSACTION
+-- directive at the top of this file lifts that constraint for the whole migration.
 -- idle_expires_at is NOT NULL with no DEFAULT (PR#528 dropped the
 -- migration-time DEFAULT) — this only succeeds against an empty table.
 -- See DEV NOTE at the top of this file for upgrade flow.

--- a/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
+++ b/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
@@ -5,9 +5,8 @@
 --   Policy.MaxIdle. Rotate updates the child row's idle_expires_at to
 --   now + Policy.MaxIdle (sliding window). Tokens whose idle_expires_at <
 --   now are rejected as idle-expired even if expires_at > now.
---   Zero Policy.MaxIdle (old stores before this migration is applied)
---   disables the idle check; the column default (created_at + 30d) ensures
---   pre-migration rows have a sensible idle deadline.
+--   Policy.MaxIdle is required (must be positive); the application layer
+--   writes idle_expires_at explicitly on every Issue and Rotate.
 --
 -- X14 (REFRESH-GRACE-COUNTER): first_used_at + used_times
 --   first_used_at TIMESTAMPTZ NULL: set on the first Rotate of each token.
@@ -15,10 +14,6 @@
 --   the parent token is re-presented within the grace window. When used_times
 --   reaches Policy.GraceMaxReuses, the next re-present triggers cascade revoke
 --   even if the re-present is within the ReuseInterval window.
---
--- These columns are additive and backward-compatible with pods that have not
--- yet been updated: the NOT NULL defaults ensure pre-migration rows continue
--- to be read and written by old binaries without errors.
 --
 -- ref: ory/hydra persistence/sql/persister_oauth2.go (refresh_token_rotated column pattern)
 -- ref: zitadel/zitadel internal/api/oidc/token_refresh.go (idle TTL per-request reset)
@@ -32,8 +27,7 @@
 -- with a non-volatile DEFAULT is a metadata-only change in PostgreSQL ≥ 11 and
 -- does not rewrite the table, so it completes instantly even on large tables.
 ALTER TABLE refresh_tokens
-    ADD COLUMN IF NOT EXISTS idle_expires_at TIMESTAMPTZ NOT NULL
-        DEFAULT now() + INTERVAL '30 days';
+    ADD COLUMN IF NOT EXISTS idle_expires_at TIMESTAMPTZ NOT NULL;
 
 ALTER TABLE refresh_tokens
     ADD COLUMN IF NOT EXISTS first_used_at TIMESTAMPTZ NULL;

--- a/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
+++ b/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
@@ -9,7 +9,8 @@
 --   writes idle_expires_at explicitly on every Issue and Rotate.
 --
 -- X14 (REFRESH-GRACE-COUNTER): first_used_at + used_times
---   first_used_at TIMESTAMPTZ NULL: set on the first Rotate of each token.
+--   first_used_at TIMESTAMPTZ NULL: set on the first grace re-use of a
+--   rotated parent token.
 --   used_times     INT          NOT NULL DEFAULT 0: incremented every time
 --   the parent token is re-presented within the grace window. When used_times
 --   reaches Policy.GraceMaxReuses, the next re-present triggers cascade revoke

--- a/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
+++ b/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
@@ -17,15 +17,26 @@
 --
 -- ref: ory/hydra persistence/sql/persister_oauth2.go (refresh_token_rotated column pattern)
 -- ref: zitadel/zitadel internal/api/oidc/token_refresh.go (idle TTL per-request reset)
+--
+-- DEV NOTE: this migration was modified in place by PR#528 to drop the
+-- idle_expires_at DEFAULT clause. goose v3 stores version_id+tstamp (not
+-- file hash), so dev environments that already applied the PR#388 version
+-- of 016 must run `goose down -count 1` then `goose up` to pick up the new
+-- DDL — otherwise goose treats 016 as already applied and the change is a
+-- silent no-op (ADD COLUMN IF NOT EXISTS makes it inert too). CI is
+-- ephemeral; project undeployed; no production schema migration concern.
 
 -- +goose NO TRANSACTION
 
 -- +goose Up
 
--- ADD COLUMN statements run outside a transaction (NO TRANSACTION mode) so they
--- can be paired with CREATE INDEX CONCURRENTLY below.  ALTER TABLE ADD COLUMN
--- with a non-volatile DEFAULT is a metadata-only change in PostgreSQL ≥ 11 and
--- does not rewrite the table, so it completes instantly even on large tables.
+-- ADD COLUMN statements run outside a transaction (NO TRANSACTION mode) so
+-- they can be paired with CREATE INDEX CONCURRENTLY below. CREATE INDEX
+-- CONCURRENTLY cannot run inside a transaction block; the +goose NO
+-- TRANSACTION directive lifts that constraint for the whole migration.
+-- idle_expires_at is NOT NULL with no DEFAULT (PR#528 dropped the
+-- migration-time DEFAULT) — this only succeeds against an empty table.
+-- See DEV NOTE at the top of this file for upgrade flow.
 ALTER TABLE refresh_tokens
     ADD COLUMN IF NOT EXISTS idle_expires_at TIMESTAMPTZ NOT NULL;
 

--- a/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
+++ b/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
@@ -30,6 +30,54 @@
 
 -- +goose Up
 
+-- Preflight: PR#528 intentionally removed the idle_expires_at DEFAULT. That
+-- means 016 is valid only for an empty refresh_tokens table unless an operator
+-- writes an explicit backfill migration. Fail with a clear message before the
+-- NOT NULL ADD COLUMN rather than surfacing PostgreSQL's generic null-column
+-- error. Also catch manual reruns against the old PR#388 column definition.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    row_count BIGINT;
+    existing_default TEXT;
+BEGIN
+    IF to_regclass('refresh_tokens') IS NULL THEN
+        RETURN;
+    END IF;
+
+    SELECT pg_get_expr(d.adbin, d.adrelid)
+      INTO existing_default
+      FROM pg_attribute a
+      JOIN pg_class c ON c.oid = a.attrelid
+      LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+     WHERE c.oid = to_regclass('refresh_tokens')
+       AND a.attname = 'idle_expires_at'
+       AND NOT a.attisdropped;
+
+    IF existing_default IS NOT NULL THEN
+        RAISE EXCEPTION
+            'migration 016 refused: idle_expires_at already exists with default %; environments that applied the old PR#388 016 must goose down -count 1 then goose up, or use an explicit follow-up migration',
+            existing_default;
+    END IF;
+
+    IF existing_default IS NULL
+       AND NOT EXISTS (
+           SELECT 1
+             FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = 'refresh_tokens'
+              AND column_name = 'idle_expires_at'
+       ) THEN
+        SELECT count(*) INTO row_count FROM refresh_tokens;
+        IF row_count > 0 THEN
+            RAISE EXCEPTION
+                'migration 016 refused: refresh_tokens has % rows; idle_expires_at is NOT NULL with no DEFAULT/backfill because the project is undeployed',
+                row_count;
+        END IF;
+    END IF;
+END $$;
+-- +goose StatementEnd
+
 -- ADD COLUMN statements run outside a transaction (NO TRANSACTION mode) so
 -- they can be paired with CREATE INDEX CONCURRENTLY below. CREATE INDEX
 -- CONCURRENTLY cannot run inside a transaction block; the goose NO TRANSACTION

--- a/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
+++ b/adapters/postgres/migrations/016_refresh_tokens_idle_grace.sql
@@ -38,19 +38,20 @@
 -- +goose StatementBegin
 DO $$
 DECLARE
+    refresh_table_name CONSTANT TEXT := 'refresh_tokens';
     row_count BIGINT;
     existing_default TEXT;
 BEGIN
-    IF to_regclass('refresh_tokens') IS NULL THEN
+    IF to_regclass(refresh_table_name) IS NULL THEN
         RETURN;
     END IF;
 
     SELECT pg_get_expr(d.adbin, d.adrelid)
       INTO existing_default
       FROM pg_attribute a
-      JOIN pg_class c ON c.oid = a.attrelid
-      LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
-     WHERE c.oid = to_regclass('refresh_tokens')
+     JOIN pg_class c ON c.oid = a.attrelid
+     LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+     WHERE c.oid = to_regclass(refresh_table_name)
        AND a.attname = 'idle_expires_at'
        AND NOT a.attisdropped;
 
@@ -65,7 +66,7 @@ BEGIN
            SELECT 1
              FROM information_schema.columns
             WHERE table_schema = current_schema()
-              AND table_name = 'refresh_tokens'
+              AND table_name = refresh_table_name
               AND column_name = 'idle_expires_at'
        ) THEN
         SELECT count(*) INTO row_count FROM refresh_tokens;

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/ctxutil"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
@@ -475,21 +476,26 @@ func (s *PGRefreshStore) checkBasicValidity(row refreshRow, ver []byte) error {
 func (s *PGRefreshStore) handleRotatedRow(ctx context.Context, row refreshRow, mutate bool) error {
 	now := s.clock.Now()
 
-	// X14: grace counter cap. If the grace cap is configured and this parent
-	// has already been re-presented GraceMaxReuses times, treat this as a
-	// reuse attack regardless of ReuseInterval.
-	if s.policy.GraceMaxReuses > 0 && row.usedTimes >= s.policy.GraceMaxReuses {
+	// X14: grace counter cap. If this parent has already been re-presented
+	// GraceMaxReuses times, treat this as a reuse attack regardless of ReuseInterval.
+	// Policy.GraceMaxReuses is required (must be positive) — no zero-check needed.
+	if row.usedTimes >= s.policy.GraceMaxReuses {
 		slog.Error("refresh token grace counter exhausted",
 			slog.String("session_id", row.sessionID),
 			slog.String("subject_id", row.subjectID),
 			slog.String("reason", "reuse_detected"),
 			slog.Int("used_times", row.usedTimes),
 		)
-		// Bypass the ambient transaction for the cascade revoke: a reuse-attack
-		// response MUST persist even when the caller's tx rolls back. We use the
-		// underlying pool directly, not execCtx, so the revoke commits on its
-		// own connection regardless of the outer RunInTx outcome.
-		if _, execErr := s.pool.Exec(ctx, revokeSessionSQL, now, row.sessionID); execErr != nil {
+		// Detach from the caller's cancellation context: a reuse-attack response
+		// MUST persist even when the HTTP request is canceled or times out.
+		// The detached context gets a bounded 5-second deadline so the write does
+		// not run indefinitely. The ambient tx is bypassed via s.pool.Exec so the
+		// revoke commits on its own connection regardless of the outer RunInTx outcome.
+		// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
+		// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+		cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
+		defer cancelCascade()
+		if _, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID); execErr != nil {
 			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: grace exhausted cascade", execErr)
 		}
 		return rejectWithReason("reuse_detected", row.sessionID)
@@ -507,10 +513,14 @@ func (s *PGRefreshStore) handleRotatedRow(ctx context.Context, row refreshRow, m
 			slog.String("subject_id", row.subjectID),
 			slog.String("reason", "reuse_detected"),
 		)
-		// Bypass the ambient transaction (see grace-exhausted branch above): the
-		// cascade revoke must commit on its own connection so that an outer
-		// caller rollback does not undo the attack response.
-		if _, execErr := s.pool.Exec(ctx, revokeSessionSQL, now, row.sessionID); execErr != nil {
+		// Detach from the caller's cancellation context (see grace-exhausted
+		// branch above): the cascade revoke must commit even when the caller's
+		// request is canceled. 5-second bounded timeout prevents indefinite wait.
+		// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
+		// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+		cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
+		defer cancelCascade()
+		if _, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID); execErr != nil {
 			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: reuse cascade", execErr)
 		}
 		return rejectWithReason("reuse_detected", row.sessionID)

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -494,8 +494,9 @@ func (s *PGRefreshStore) handleRotatedRow(ctx context.Context, row refreshRow, m
 		// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
 		// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
 		cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
-		defer cancelCascade()
-		if _, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID); execErr != nil {
+		_, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID)
+		cancelCascade()
+		if execErr != nil {
 			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: grace exhausted cascade", execErr)
 		}
 		return rejectWithReason("reuse_detected", row.sessionID)
@@ -519,8 +520,9 @@ func (s *PGRefreshStore) handleRotatedRow(ctx context.Context, row refreshRow, m
 		// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
 		// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
 		cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
-		defer cancelCascade()
-		if _, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID); execErr != nil {
+		_, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID)
+		cancelCascade()
+		if execErr != nil {
 			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: reuse cascade", execErr)
 		}
 		return rejectWithReason("reuse_detected", row.sessionID)

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -28,13 +28,6 @@ var _ refresh.Store = (*PGRefreshStore)(nil)
 // gcBatchSize is the number of rows deleted per GC batch iteration.
 const gcBatchSize = 1000
 
-// idleFarFuture is the sentinel used when Policy.MaxIdle is zero (disabled);
-// prevents idle-GC from sweeping rows that have no configured idle window.
-// Any store that has not applied migration 016 or has explicitly set MaxIdle=0
-// will write this sentinel, ensuring the column satisfies the NOT NULL constraint
-// while effectively disabling idle expiry for that row.
-const idleFarFuture = 10 * 365 * 24 * time.Hour
-
 // Append-only SQL statements.
 //
 // Design: Issue and Rotate only INSERT rows; rotated_at and revoked_at are
@@ -42,7 +35,8 @@ const idleFarFuture = 10 * 365 * 24 * time.Hour
 // revoke_session for the entire session_id lineage.
 //
 // Columns idle_expires_at, first_used_at, used_times are added by migration 016
-// (X12 + X14). Pre-016 rows have idle_expires_at defaulted to created_at + 30d.
+// (X12 + X14). idle_expires_at is written explicitly on every Issue and Rotate;
+// Policy.MaxIdle is required (must be positive).
 const (
 	insertRowSQL = `
 INSERT INTO refresh_tokens (id, parent_id, session_id, subject_id, selector, verifier_hash, created_at, expires_at, idle_expires_at)
@@ -86,8 +80,8 @@ WHERE subject_id = $2
 
 	// gcBatchSQL deletes expired rows: a row is eligible when either its
 	// absolute expires_at or its idle_expires_at has passed the olderThan
-	// threshold. idle_expires_at defaults to now()+30d for pre-016 rows so
-	// they are only swept by expires_at.
+	// threshold. LEAST(expires_at, idle_expires_at) determines the effective
+	// expiry deadline for each row.
 	gcBatchSQL = `
 DELETE FROM refresh_tokens
 WHERE id IN (
@@ -244,14 +238,10 @@ func (s *PGRefreshStore) Issue(ctx context.Context, sessionID, subjectID string)
 	}, nil
 }
 
-// idleDeadline returns now + MaxIdle when MaxIdle is configured, or a far-future
-// sentinel when MaxIdle is zero (pre-016 migration stores that have not yet
-// been configured with an idle expiry window).
+// idleDeadline returns now + MaxIdle. Policy.MaxIdle is guaranteed positive by
+// Validate(), so no zero-check is needed.
 func (s *PGRefreshStore) idleDeadline(now time.Time) time.Time {
-	if s.policy.MaxIdle > 0 {
-		return now.Add(s.policy.MaxIdle)
-	}
-	return now.Add(idleFarFuture)
+	return now.Add(s.policy.MaxIdle)
 }
 
 // Peek validates the presented wire token without advancing the lineage.
@@ -463,11 +453,9 @@ func (s *PGRefreshStore) checkBasicValidity(row refreshRow, ver []byte) error {
 	if !row.expiresAt.After(now) {
 		return rejectWithReason("expired", row.sessionID)
 	}
-	// X12: idle-expiry check. migration 016 ensures idle_expires_at is always
-	// non-zero (NOT NULL with a 30-day default for pre-016 rows). When
-	// Policy.MaxIdle is zero, idle-expiry is disabled (stores that have not yet
-	// applied migration 016 set MaxIdle=0 at the application layer).
-	if s.policy.MaxIdle > 0 && !row.idleExpiresAt.After(now) {
+	// X12: idle-expiry check. Policy.MaxIdle is required (must be positive),
+	// and idle_expires_at is written explicitly on every Issue/Rotate.
+	if !row.idleExpiresAt.After(now) {
 		return rejectWithReason("idle_expired", row.sessionID)
 	}
 	return nil

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -101,11 +101,13 @@ WHERE id IN (
 // Consistency: L1 LocalTx — Rotate is atomic within a single transaction;
 // Issue and revoke paths are single-statement writes.
 //
-// Transaction contract (B2-A-08): PGRefreshStore never acquires its own
-// transactions. All multi-statement operations (Peek, Rotate) delegate to the
-// injected TxRunner. When the caller already holds an ambient transaction,
-// TxManager creates a savepoint instead of a new top-level transaction, so
-// refresh operations are fully nesting-safe.
+// Transaction contract (B2-A-08): PGRefreshStore uses the ambient transaction
+// for business operations. Multi-statement operations (Peek, Rotate) delegate
+// to the injected TxRunner. When the caller already holds an ambient
+// transaction, TxManager creates a savepoint instead of a new top-level
+// transaction, so refresh operations are fully nesting-safe. The only explicit
+// bypass is RevokeSessionDetached and reuse-detection cascade revoke, which
+// commit independently as security/compensation responses.
 //
 // ref: ory/fosite token/hmac/hmacsha.go (base64url nopad + constant-time compare)
 // ref: ory/hydra persistence/sql/persister_oauth2.go (CAS chain + reuse cascade)
@@ -486,18 +488,8 @@ func (s *PGRefreshStore) handleRotatedRow(ctx context.Context, row refreshRow, m
 			slog.String("reason", "reuse_detected"),
 			slog.Int("used_times", row.usedTimes),
 		)
-		// Detach from the caller's cancellation context: a reuse-attack response
-		// MUST persist even when the HTTP request is canceled or times out.
-		// The detached context gets a bounded 5-second deadline so the write does
-		// not run indefinitely. The ambient tx is bypassed via s.pool.Exec so the
-		// revoke commits on its own connection regardless of the outer RunInTx outcome.
-		// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
-		// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
-		cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
-		_, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID)
-		cancelCascade()
-		if execErr != nil {
-			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: grace exhausted cascade", execErr)
+		if err := s.revokeSessionDetachedAt(ctx, row.sessionID, now); err != nil {
+			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: grace exhausted cascade", err)
 		}
 		return rejectWithReason("reuse_detected", row.sessionID)
 	}
@@ -514,16 +506,8 @@ func (s *PGRefreshStore) handleRotatedRow(ctx context.Context, row refreshRow, m
 			slog.String("subject_id", row.subjectID),
 			slog.String("reason", "reuse_detected"),
 		)
-		// Detach from the caller's cancellation context (see grace-exhausted
-		// branch above): the cascade revoke must commit even when the caller's
-		// request is canceled. 5-second bounded timeout prevents indefinite wait.
-		// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
-		// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
-		cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
-		_, execErr := s.pool.Exec(cascadeCtx, revokeSessionSQL, now, row.sessionID)
-		cancelCascade()
-		if execErr != nil {
-			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: reuse cascade", execErr)
+		if err := s.revokeSessionDetachedAt(ctx, row.sessionID, now); err != nil {
+			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: reuse cascade", err)
 		}
 		return rejectWithReason("reuse_detected", row.sessionID)
 	}
@@ -550,6 +534,31 @@ func (s *PGRefreshStore) RevokeSession(ctx context.Context, sessionID string) er
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: revoke session", err)
 	}
 	return nil
+}
+
+// RevokeSessionDetached marks every row in the session_id lineage as revoked,
+// bypassing any ambient transaction and caller cancellation. It is used only
+// for security cascade/compensation paths that must commit independently of
+// the surrounding business transaction.
+func (s *PGRefreshStore) RevokeSessionDetached(ctx context.Context, sessionID string) error {
+	if err := s.revokeSessionDetachedAt(ctx, sessionID, s.clock.Now()); err != nil {
+		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: revoke session detached", err)
+	}
+	return nil
+}
+
+func (s *PGRefreshStore) revokeSessionDetachedAt(ctx context.Context, sessionID string, revokedAt time.Time) error {
+	// Detach from the caller's cancellation context: a security/compensation
+	// revoke MUST persist even when the HTTP request is canceled or times out.
+	// The detached context gets a bounded 5-second deadline so the write does
+	// not run indefinitely. The ambient tx is bypassed via s.pool.Exec so the
+	// revoke commits on its own connection regardless of the outer RunInTx outcome.
+	// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
+	// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+	cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
+	defer cancelCascade()
+	_, err := s.pool.Exec(cascadeCtx, revokeSessionSQL, revokedAt, sessionID)
+	return err
 }
 
 // RevokeUser marks every row owned by subjectID as revoked.

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -686,124 +686,30 @@ func TestPGRefreshStore_T23_AmbientTxRollback(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// T24: reuse cascade survives caller context cancel
+// PR#388 Finding 1 — caller-ctx-cancel cascade detach coverage
 // ---------------------------------------------------------------------------
-
-// TestPGRefreshStore_ReuseCascadeSurvivesCallerCancel verifies that when a
-// reuse_detected cascade revoke is triggered, the revoke SQL commits to the
-// database even if the caller's context is already cancelled at the time
-// Rotate returns. This is the integration-level gate for the detached ctx
-// fix (adapters/postgres/refresh_store.go cascade revoke uses
-// ctxutil.WithDetachedTimeout instead of the caller ctx).
 //
-// RED in Wave 0: cascade revoke still uses caller ctx; this test will fail
-// because the revoked rows may not be committed when the caller ctx is already
-// cancelled. Wave 2 implements detached ctx; test turns GREEN.
-func TestPGRefreshStore_ReuseCascadeSurvivesCallerCancel(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
-	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_cascade_cancel")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
-	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
-	txm := NewTxManager(p)
-	policy := refresh.Policy{
-		ReuseInterval:  testtime.D2s,
-		MaxAge:         time.Hour,
-		MaxIdle:        refreshTest30Days,
-		GraceMaxReuses: 2,
-	}
-	store, err := NewRefreshStore(p.DB(), txm, policy, clock, nil)
-	require.NoError(t, err)
-
-	// Issue parent and Rotate once to open the grace window.
-	parentWire, _, err := store.Issue(ctx, "sess-cascade-cancel", "usr-cascade-cancel")
-	require.NoError(t, err)
-	childWire, _, err := store.Rotate(ctx, parentWire)
-	require.NoError(t, err)
-
-	// Advance past ReuseInterval so the next parentWire Rotate triggers reuse_detected.
-	clock.Advance(testtime.D3s)
-
-	// Cancel the caller context before issuing the reuse-detected Rotate.
-	callerCtx, callerCancel := context.WithCancel(ctx)
-	callerCancel() // immediately cancel
-
-	// Rotate with an already-cancelled ctx: the store should detect reuse and
-	// attempt cascade revoke. The cascade revoke must commit even with a
-	// cancelled caller ctx (detached ctx path).
-	_, _, rotErr := store.Rotate(callerCtx, parentWire)
-	require.ErrorIs(t, rotErr, refresh.ErrRejected,
-		"reuse_detected must return ErrRejected regardless of caller ctx cancel")
-
-	// Verify cascade: attempt to Rotate the child with a fresh context.
-	// If cascade committed, child should also be rejected.
-	freshCtx := context.Background()
-	_, _, childErr := store.Rotate(freshCtx, childWire)
-	require.ErrorIs(t, childErr, refresh.ErrRejected,
-		"cascade revoke must have committed; child token must be rejected with ErrRejected")
-}
-
-// ---------------------------------------------------------------------------
-// T25: grace-exhausted cascade survives caller context cancel
-// ---------------------------------------------------------------------------
-
-// TestPGRefreshStore_GraceExhaustedCascadeSurvivesCallerCancel verifies that
-// when GraceMaxReuses is exhausted, the cascade revoke commits even if the
-// caller's context is already cancelled at the time the exhausting Rotate call
-// is made.
+// Finding 1 asks for an "integration test that cancels the caller ctx during
+// reuse_detected and grace-exhausted handling". The literal shape — call
+// store.Rotate with an already-cancelled ctx — does not reach the cascade SQL:
+// txRunner.RunInTx fails at pool.Begin(ctx) with context.Canceled before the
+// reuse check runs. Inserting the cancel mid-call requires either a mock
+// pgxpool (boxes a real-world bug into pure mock theatre) or non-deterministic
+// timing (flaky under load). Both are worse than the layered coverage we have:
 //
-// RED in Wave 0: same root cause as T24. Wave 2 turns GREEN.
-func TestPGRefreshStore_GraceExhaustedCascadeSurvivesCallerCancel(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
-	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_grace_exhaust_cancel")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
-	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
-	txm := NewTxManager(p)
-	policy := refresh.Policy{
-		ReuseInterval:  testtime.D5s,
-		MaxAge:         time.Hour,
-		MaxIdle:        refreshTest30Days,
-		GraceMaxReuses: 2,
-	}
-	store, err := NewRefreshStore(p.DB(), txm, policy, clock, nil)
-	require.NoError(t, err)
-
-	// Issue and do the first Rotate to open the grace window.
-	parentWire, _, err := store.Issue(ctx, "sess-grace-exhaust-cancel", "usr-grace-exhaust-cancel")
-	require.NoError(t, err)
-	childWire, _, err := store.Rotate(ctx, parentWire)
-	require.NoError(t, err)
-
-	// Drain GraceMaxReuses-1 grace slots (each is within ReuseInterval).
-	// After this, used_times == GraceMaxReuses-1 == 1.
-	for i := 0; i < policy.GraceMaxReuses-1; i++ {
-		_, _, graceErr := store.Rotate(ctx, parentWire)
-		require.NoError(t, graceErr, "grace Rotate %d must succeed", i+1)
-	}
-
-	// The next Rotate of parentWire exhausts GraceMaxReuses and triggers cascade revoke.
-	// Cancel the caller ctx before making this call.
-	callerCtx, callerCancel := context.WithCancel(ctx)
-	callerCancel() // immediately cancel
-
-	_, _, exhaustErr := store.Rotate(callerCtx, parentWire)
-	require.ErrorIs(t, exhaustErr, refresh.ErrRejected,
-		"grace exhausted must return ErrRejected regardless of caller ctx cancel")
-
-	// Verify cascade: the child token must be rejected with a fresh ctx.
-	freshCtx := context.Background()
-	_, _, childErr := store.Rotate(freshCtx, childWire)
-	require.ErrorIs(t, childErr, refresh.ErrRejected,
-		"cascade from grace exhausted must have committed; child token must be rejected")
-}
+//   1. pkg/ctxutil/detach_test.go asserts that WithDetachedTimeout's returned
+//      ctx is unaffected by parent cancel and carries an independent deadline.
+//   2. cells/accesscore/slices/sessionrefresh/service_test.go::
+//      TestService_CascadeRevoke_DetachesFromCallerCtx asserts that the
+//      service-level cascadeRevoke calls store.RevokeSession with a ctx whose
+//      Err() is nil even when the caller ctx is already cancelled.
+//   3. refresh_store.go handleRotatedRow uses ctxutil.WithDetachedTimeout for
+//      the cascade pool.Exec — verified by code inspection and the helper test
+//      (#1) which proves the wrapped ctx behaves as required.
+//   4. TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback (above) verifies
+//      the orthogonal property that cascade SQL bypasses the ambient tx — i.e.
+//      survives caller-driven outer rollback.
+//
+// Together these cover the security property (cascade must commit despite
+// caller-side disruption) without the false confidence of a flaky black-box
+// integration test.

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -26,10 +26,10 @@ const (
 	refreshTest2Hours  = 2 * time.Hour
 )
 
-// TestPGRefreshStore_ContractSuite runs the shared storetest.RunContractSuite
+// TestPGRefreshStore_ContractSuite runs the shared storetest contract suites
 // against a real PostgreSQL backend. This is the regression gate for backend
-// parity with memstore — every Tn subtest enforces the Store contract on
-// both implementations. Notable subtests for PR#388 review findings:
+// parity with memstore — every Tn subtest enforces the Store contract on both
+// implementations. Notable subtests for PR#388 review findings:
 //
 //   - T20_Peek_RejectionParityAndReuseCascade — Peek must reject identically
 //     to Rotate and still cascade-revoke on reuse_detected.
@@ -46,7 +46,7 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 
 	// Each factory call gets its own PG schema so parallel subtests are fully
 	// isolated. GC (T13) only sees rows it inserted — no shared-table pollution.
-	storetest.RunContractSuite(t, func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
+	factory := func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
 		t.Helper()
 
 		p := isolatedSchemaPool(t, ctx, base)
@@ -59,7 +59,10 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 		store, err := NewRefreshStore(p.DB(), txm, policy, clock, nil)
 		require.NoError(t, err)
 		return store, clock
-	})
+	}
+
+	storetest.RunContractSuite(t, factory)
+	storetest.RunIdleExpireContractSuite(t, factory)
 }
 
 // isolatedSchemaPool creates a fresh PG schema and returns a Pool whose
@@ -739,30 +742,32 @@ func TestPGRefreshStore_RevokeSessionDetachedSurvivesAmbientRollback(t *testing.
 }
 
 // ---------------------------------------------------------------------------
-// PR#388 Finding 1 — caller-ctx-cancel cascade detach coverage
+// PR#388 Finding 1 — detached revoke coverage boundaries
 // ---------------------------------------------------------------------------
 //
-// Finding 1 asks for an "integration test that cancels the caller ctx during
+// Finding 1 asked for an "integration test that cancels the caller ctx during
 // reuse_detected and grace-exhausted handling". The literal shape — call
 // store.Rotate with an already-cancelled ctx — does not reach the cascade SQL:
 // txRunner.RunInTx fails at pool.Begin(ctx) with context.Canceled before the
-// reuse check runs. Inserting the cancel mid-call requires either a mock
-// pgxpool (boxes a real-world bug into pure mock theatre) or non-deterministic
-// timing (flaky under load). Both are worse than the layered coverage we have:
+// reuse check runs. Inserting the cancel mid-call would require either a mock
+// pgxpool (boxing the behavior into a mock) or timing-sensitive orchestration.
+// The maintained coverage is intentionally narrower and executable:
 //
 //   1. pkg/ctxutil/detach_test.go asserts that WithDetachedTimeout's returned
 //      ctx is unaffected by parent cancel and carries an independent deadline.
 //   2. cells/accesscore/slices/sessionrefresh/service_test.go::
-//      TestService_CascadeRevoke_DetachesFromCallerCtx asserts that the
-//      service-level cascadeRevoke calls store.RevokeSession with a ctx whose
-//      Err() is nil even when the caller ctx is already cancelled.
-//   3. refresh_store.go handleRotatedRow uses ctxutil.WithDetachedTimeout for
-//      the cascade pool.Exec — verified by code inspection and the helper test
-//      (#1) which proves the wrapped ctx behaves as required.
+//      TestService_CascadeRevoke_UsesDetachedStoreMethod asserts that the
+//      service-level cascade path routes to RevokeSessionDetached rather than
+//      the ambient business revoke.
+//   3. refresh_store.go handleRotatedRow and RevokeSessionDetached use
+//      ctxutil.WithDetachedTimeout for the cascade pool.Exec — verified by code
+//      inspection and the helper test (#1) which proves the wrapped ctx behaves
+//      as required.
 //   4. TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback (above) verifies
 //      the orthogonal property that cascade SQL bypasses the ambient tx — i.e.
 //      survives caller-driven outer rollback.
 //
-// Together these cover the security property (cascade must commit despite
-// caller-side disruption) without the false confidence of a flaky black-box
-// integration test.
+// Together these cover the chosen boundary: once execution reaches the store's
+// detached revoke path, the final revoke write is detached from caller cancel
+// and ambient rollback. They do not claim that every Refresh entry path
+// continues after an already-canceled caller context.

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -692,6 +692,52 @@ func TestPGRefreshStore_T23_AmbientTxRollback(t *testing.T) {
 		"ambient tx rollback must revert Rotate INSERT: no new row should persist")
 }
 
+func TestPGRefreshStore_RevokeSessionDetachedSurvivesAmbientRollback(t *testing.T) {
+	base, cleanup := setupPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	p := isolatedSchemaPool(t, ctx, base)
+	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_detached_revoke")
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx))
+
+	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	txm := NewTxManager(p)
+	store, err := NewRefreshStore(p.DB(), txm, refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         testtime.D1h,
+		MaxIdle:        refreshTest30Days,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clock, nil)
+	require.NoError(t, err)
+
+	detachedWire, _, err := store.Issue(ctx, "sess-detached-revoke", "usr-detached-revoke")
+	require.NoError(t, err)
+	businessWire, _, err := store.Issue(ctx, "sess-business-revoke", "usr-business-revoke")
+	require.NoError(t, err)
+
+	runErr := txm.RunInTx(ctx, func(txCtx context.Context) error {
+		require.NoError(t, store.RevokeSessionDetached(txCtx, "sess-detached-revoke"))
+		return fmt.Errorf("force outer rollback")
+	})
+	require.Error(t, runErr)
+
+	_, _, err = store.Rotate(ctx, detachedWire)
+	require.ErrorIs(t, err, refresh.ErrRejected,
+		"detached session revoke must commit independently of the caller rollback")
+
+	runErr = txm.RunInTx(ctx, func(txCtx context.Context) error {
+		require.NoError(t, store.RevokeSession(txCtx, "sess-business-revoke"))
+		return fmt.Errorf("force outer rollback")
+	})
+	require.Error(t, runErr)
+
+	_, _, err = store.Rotate(ctx, businessWire)
+	require.NoError(t, err,
+		"business RevokeSession must participate in ambient tx and roll back with it")
+}
+
 // ---------------------------------------------------------------------------
 // PR#388 Finding 1 — caller-ctx-cancel cascade detach coverage
 // ---------------------------------------------------------------------------

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -669,3 +669,126 @@ func TestPGRefreshStore_T23_AmbientTxRollback(t *testing.T) {
 	require.Equal(t, countBefore, countAfter,
 		"ambient tx rollback must revert Rotate INSERT: no new row should persist")
 }
+
+// ---------------------------------------------------------------------------
+// T24: reuse cascade survives caller context cancel
+// ---------------------------------------------------------------------------
+
+// TestPGRefreshStore_ReuseCascadeSurvivesCallerCancel verifies that when a
+// reuse_detected cascade revoke is triggered, the revoke SQL commits to the
+// database even if the caller's context is already cancelled at the time
+// Rotate returns. This is the integration-level gate for the detached ctx
+// fix (adapters/postgres/refresh_store.go cascade revoke uses
+// ctxutil.WithDetachedTimeout instead of the caller ctx).
+//
+// RED in Wave 0: cascade revoke still uses caller ctx; this test will fail
+// because the revoked rows may not be committed when the caller ctx is already
+// cancelled. Wave 2 implements detached ctx; test turns GREEN.
+func TestPGRefreshStore_ReuseCascadeSurvivesCallerCancel(t *testing.T) {
+	base, cleanup := setupPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	p := isolatedSchemaPool(t, ctx, base)
+	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_cascade_cancel")
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx))
+
+	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	txm := NewTxManager(p)
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refreshTest30Days,
+		GraceMaxReuses: 2,
+	}
+	store, err := NewRefreshStore(p.DB(), txm, policy, clock, nil)
+	require.NoError(t, err)
+
+	// Issue parent and Rotate once to open the grace window.
+	parentWire, _, err := store.Issue(ctx, "sess-cascade-cancel", "usr-cascade-cancel")
+	require.NoError(t, err)
+	childWire, _, err := store.Rotate(ctx, parentWire)
+	require.NoError(t, err)
+
+	// Advance past ReuseInterval so the next parentWire Rotate triggers reuse_detected.
+	clock.Advance(testtime.D3s)
+
+	// Cancel the caller context before issuing the reuse-detected Rotate.
+	callerCtx, callerCancel := context.WithCancel(ctx)
+	callerCancel() // immediately cancel
+
+	// Rotate with an already-cancelled ctx: the store should detect reuse and
+	// attempt cascade revoke. The cascade revoke must commit even with a
+	// cancelled caller ctx (detached ctx path).
+	_, _, rotErr := store.Rotate(callerCtx, parentWire)
+	require.ErrorIs(t, rotErr, refresh.ErrRejected,
+		"reuse_detected must return ErrRejected regardless of caller ctx cancel")
+
+	// Verify cascade: attempt to Rotate the child with a fresh context.
+	// If cascade committed, child should also be rejected.
+	freshCtx := context.Background()
+	_, _, childErr := store.Rotate(freshCtx, childWire)
+	require.ErrorIs(t, childErr, refresh.ErrRejected,
+		"cascade revoke must have committed; child token must be rejected with ErrRejected")
+}
+
+// ---------------------------------------------------------------------------
+// T25: grace-exhausted cascade survives caller context cancel
+// ---------------------------------------------------------------------------
+
+// TestPGRefreshStore_GraceExhaustedCascadeSurvivesCallerCancel verifies that
+// when GraceMaxReuses is exhausted, the cascade revoke commits even if the
+// caller's context is already cancelled at the time the exhausting Rotate call
+// is made.
+//
+// RED in Wave 0: same root cause as T24. Wave 2 turns GREEN.
+func TestPGRefreshStore_GraceExhaustedCascadeSurvivesCallerCancel(t *testing.T) {
+	base, cleanup := setupPostgres(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	p := isolatedSchemaPool(t, ctx, base)
+	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_grace_exhaust_cancel")
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx))
+
+	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	txm := NewTxManager(p)
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D5s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refreshTest30Days,
+		GraceMaxReuses: 2,
+	}
+	store, err := NewRefreshStore(p.DB(), txm, policy, clock, nil)
+	require.NoError(t, err)
+
+	// Issue and do the first Rotate to open the grace window.
+	parentWire, _, err := store.Issue(ctx, "sess-grace-exhaust-cancel", "usr-grace-exhaust-cancel")
+	require.NoError(t, err)
+	childWire, _, err := store.Rotate(ctx, parentWire)
+	require.NoError(t, err)
+
+	// Drain GraceMaxReuses-1 grace slots (each is within ReuseInterval).
+	// After this, used_times == GraceMaxReuses-1 == 1.
+	for i := 0; i < policy.GraceMaxReuses-1; i++ {
+		_, _, graceErr := store.Rotate(ctx, parentWire)
+		require.NoError(t, graceErr, "grace Rotate %d must succeed", i+1)
+	}
+
+	// The next Rotate of parentWire exhausts GraceMaxReuses and triggers cascade revoke.
+	// Cancel the caller ctx before making this call.
+	callerCtx, callerCancel := context.WithCancel(ctx)
+	callerCancel() // immediately cancel
+
+	_, _, exhaustErr := store.Rotate(callerCtx, parentWire)
+	require.ErrorIs(t, exhaustErr, refresh.ErrRejected,
+		"grace exhausted must return ErrRejected regardless of caller ctx cancel")
+
+	// Verify cascade: the child token must be rejected with a fresh ctx.
+	freshCtx := context.Background()
+	_, _, childErr := store.Rotate(freshCtx, childWire)
+	require.ErrorIs(t, childErr, refresh.ErrRejected,
+		"cascade from grace exhausted must have committed; child token must be rejected")
+}

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
@@ -592,12 +594,10 @@ func TestPGRefreshStore_T21_RejectPathsHaveUniformLogging(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestPGRefreshStore_T22_ReadyzReportsInvalidIndex verifies that the
-// postgres_indexes_valid_ready checker in PGResource.Checkers wraps
-// cell.ErrDegraded when invalid indexes exist. The wrap is load-bearing:
-// runtime/http/health.runOneProbe classifies cell.ErrDegraded as "degraded"
-// (HTTP 200, fail-open) rather than "unhealthy" (HTTP 503, pod evict). Invalid
-// indexes are a maintenance signal — CREATE INDEX CONCURRENTLY in-progress or
-// aborted leftover — not a runtime fault that should evict pods.
+// postgres_indexes_valid_ready checker in PGResource.Checkers returns a normal
+// errcode error when invalid indexes exist. It must not wrap cell.ErrDegraded:
+// invalid indexes are a schema fault, so runtime/http/health.runOneProbe must
+// classify the probe as unhealthy and /readyz must fail closed with HTTP 503.
 func TestPGRefreshStore_T22_ReadyzReportsInvalidIndex(t *testing.T) {
 	base, cleanup := setupPostgres(t)
 	t.Cleanup(cleanup)
@@ -631,10 +631,14 @@ func TestPGRefreshStore_T22_ReadyzReportsInvalidIndex(t *testing.T) {
 	require.True(t, ok, "postgres_indexes_valid_ready checker must be present in Checkers()")
 
 	err = invalidIdxChecker(ctx)
-	require.ErrorIs(t, err, cell.ErrDegraded,
-		"postgres_indexes_valid_ready must wrap cell.ErrDegraded so runtime/http/health.runOneProbe classifies as degraded (HTTP 200), not unhealthy (HTTP 503)")
+	require.Error(t, err, "invalid indexes must make postgres_indexes_valid_ready fail")
+	assert.False(t, errors.Is(err, cell.ErrDegraded),
+		"invalid indexes must not be treated as fail-open degraded readiness")
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec, "invalid index checker must return an errcode error")
+	assert.Equal(t, ErrAdapterPGQuery, ec.Code)
 	require.Contains(t, err.Error(), "idx_t22_probe_val",
-		"degraded error must list invalid index names for /readyz?verbose body")
+		"error must list invalid index names for /readyz?verbose diagnostics")
 
 	t.Cleanup(func() {
 		_, _ = p.DB().Exec(context.Background(), `DROP INDEX IF EXISTS idx_t22_probe_val`)

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
@@ -588,9 +589,12 @@ func TestPGRefreshStore_T21_RejectPathsHaveUniformLogging(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestPGRefreshStore_T22_ReadyzReportsInvalidIndex verifies that the
-// postgres_indexes_valid_ready checker in PGResource.Checkers returns a
-// non-nil error when an invalid index exists in the schema.
-// RED in Wave 1 (checker not yet added to pool_resource.go).
+// postgres_indexes_valid_ready checker in PGResource.Checkers wraps
+// cell.ErrDegraded when invalid indexes exist. The wrap is load-bearing:
+// runtime/http/health.runOneProbe classifies cell.ErrDegraded as "degraded"
+// (HTTP 200, fail-open) rather than "unhealthy" (HTTP 503, pod evict). Invalid
+// indexes are a maintenance signal — CREATE INDEX CONCURRENTLY in-progress or
+// aborted leftover — not a runtime fault that should evict pods.
 func TestPGRefreshStore_T22_ReadyzReportsInvalidIndex(t *testing.T) {
 	base, cleanup := setupPostgres(t)
 	t.Cleanup(cleanup)
@@ -624,7 +628,10 @@ func TestPGRefreshStore_T22_ReadyzReportsInvalidIndex(t *testing.T) {
 	require.True(t, ok, "postgres_indexes_valid_ready checker must be present in Checkers()")
 
 	err = invalidIdxChecker(ctx)
-	require.Error(t, err, "postgres_indexes_valid_ready must return error when invalid indexes exist")
+	require.ErrorIs(t, err, cell.ErrDegraded,
+		"postgres_indexes_valid_ready must wrap cell.ErrDegraded so runtime/http/health.runOneProbe classifies as degraded (HTTP 200), not unhealthy (HTTP 503)")
+	require.Contains(t, err.Error(), "idx_t22_probe_val",
+		"degraded error must list invalid index names for /readyz?verbose body")
 
 	t.Cleanup(func() {
 		_, _ = p.DB().Exec(context.Background(), `DROP INDEX IF EXISTS idx_t22_probe_val`)

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -208,7 +208,12 @@ func TestPGRefreshStore_DMLState(t *testing.T) {
 	require.NoError(t, migrator.Up(ctx))
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
-	policy := refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: refreshTestOneWeek, MaxIdle: refreshTest2Hours}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         refreshTestOneWeek,
+		MaxIdle:        refreshTest2Hours,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	txm := NewTxManager(p)
 	store, err := NewRefreshStore(p.DB(), txm, policy, clock, nil)
 	require.NoError(t, err)
@@ -355,7 +360,12 @@ func TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback(t *testing.T) {
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
-	store, err := NewRefreshStore(p.DB(), txm, refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clock, nil)
+	store, err := NewRefreshStore(p.DB(), txm, refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clock, nil)
 	require.NoError(t, err)
 
 	parentWire, _, err := store.Issue(ctx, "sess-reuse-ambient", "usr-reuse-ambient")
@@ -387,7 +397,12 @@ func TestPGRefreshStore_SessionLockRejectsChildValidatedBeforeCascade(t *testing
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm2 := NewTxManager(p)
-	store, err := NewRefreshStore(p.DB(), txm2, refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clock, nil)
+	store, err := NewRefreshStore(p.DB(), txm2, refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clock, nil)
 	require.NoError(t, err)
 
 	parentWire, _, err := store.Issue(ctx, "sess-reuse-lock", "usr-reuse-lock")

--- a/adapters/postgres/refresh_store_test.go
+++ b/adapters/postgres/refresh_store_test.go
@@ -62,7 +62,12 @@ func (dummyTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error
 
 func TestNewRefreshStore_ReturnsErrorOnInvalidArgs(t *testing.T) {
 	validClock := storetest.NewFakeClock(time.Now())
-	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
+	validPolicy := refresh.Policy{
+		ReuseInterval:  time.Second,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	validTxRunner := dummyTxRunner{}
 
 	// dummyPool is a non-nil *pgxpool.Pool used only to pass the nil check
@@ -112,7 +117,12 @@ func TestNewRefreshStore_ReturnsErrorOnInvalidArgs(t *testing.T) {
 func TestNewRefreshStore_NilRandReader_UsesDefault(t *testing.T) {
 	dummyPool := new(pgxpool.Pool)
 	validClock := storetest.NewFakeClock(time.Now())
-	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
+	validPolicy := refresh.Policy{
+		ReuseInterval:  time.Second,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	validTxRunner := dummyTxRunner{}
 
 	// nil randReader must not error — constructor falls back to crypto/rand.Reader.
@@ -124,7 +134,12 @@ func TestNewRefreshStore_NilRandReader_UsesDefault(t *testing.T) {
 func TestNewRefreshStore_TypedNilRandReader_UsesDefault(t *testing.T) {
 	dummyPool := new(pgxpool.Pool)
 	validClock := storetest.NewFakeClock(time.Now())
-	validPolicy := refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour}
+	validPolicy := refresh.Policy{
+		ReuseInterval:  time.Second,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	validTxRunner := dummyTxRunner{}
 	var reader *typedNilRefreshReader
 

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
 
-	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
@@ -137,15 +136,12 @@ type InvalidIndex struct {
 //   - nil when no invalid indexes exist
 //   - the underlying query error (KindInternal) when DetectInvalidIndexes fails
 //     — this is a real fault (connection, SQL error) and maps to "unhealthy"
-//   - an error wrapping cell.ErrDegraded when indisvalid=false rows are present
-//     — this is a maintenance/degradation signal (CREATE INDEX CONCURRENTLY
-//     in-progress or aborted leftover), not a runtime fault. runtime/http/health.runOneProbe
-//     classifies cell.ErrDegraded as "degraded" → HTTP 200 (fail-open, no pod
-//     eviction); operators see the invalid-index list in /readyz?verbose body
-//     and DROP the index manually.
+//   - an errcode error when indisvalid=false rows are present. Invalid indexes
+//     are a schema fault, so runtime/http/health.runOneProbe classifies this as
+//     "unhealthy" and /readyz returns HTTP 503. Operators see the invalid-index
+//     list in /readyz?verbose diagnostics and DROP the index manually.
 //
 // ref: kubernetes/kubernetes pkg/util/healthz — named health checkers return error.
-// ref: kernel/outbox/emitter.go — same fmt.Errorf wrap cell.ErrDegraded pattern for drop-ratio
 func InvalidIndexCheck(ctx context.Context, pool *Pool) error {
 	indexes, err := DetectInvalidIndexes(ctx, pool)
 	if err != nil {
@@ -158,8 +154,10 @@ func InvalidIndexCheck(ctx context.Context, pool *Pool) error {
 	for _, idx := range indexes {
 		names = append(names, idx.Index)
 	}
-	return fmt.Errorf("schema_guard: %d invalid index(es) [%s]: %w",
-		len(indexes), strings.Join(names, ", "), cell.ErrDegraded)
+	return errcode.New(errcode.KindInternal, ErrAdapterPGQuery,
+		"schema_guard: invalid indexes detected",
+		errcode.WithInternal(fmt.Sprintf("%d invalid index(es): %s", len(indexes), strings.Join(names, ", "))),
+		errcode.WithDetails(slog.Int("invalidCount", len(indexes))))
 }
 
 // DetectInvalidIndexes queries pg_index for any indexes marked as invalid

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
 
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
@@ -131,10 +132,20 @@ type InvalidIndex struct {
 }
 
 // InvalidIndexCheck wraps DetectInvalidIndexes for use as a readyz probe
-// (func(context.Context) error signature). Returns nil when no invalid indexes
-// exist; returns an errcode error listing the invalid indexes otherwise.
+// (func(context.Context) error signature). Returns:
+//
+//   - nil when no invalid indexes exist
+//   - the underlying query error (KindInternal) when DetectInvalidIndexes fails
+//     — this is a real fault (connection, SQL error) and maps to "unhealthy"
+//   - an error wrapping cell.ErrDegraded when indisvalid=false rows are present
+//     — this is a maintenance/degradation signal (CREATE INDEX CONCURRENTLY
+//     in-progress or aborted leftover), not a runtime fault. runtime/http/health.runOneProbe
+//     classifies cell.ErrDegraded as "degraded" → HTTP 200 (fail-open, no pod
+//     eviction); operators see the invalid-index list in /readyz?verbose body
+//     and DROP the index manually.
 //
 // ref: kubernetes/kubernetes pkg/util/healthz — named health checkers return error.
+// ref: kernel/outbox/emitter.go — same fmt.Errorf wrap cell.ErrDegraded pattern for drop-ratio
 func InvalidIndexCheck(ctx context.Context, pool *Pool) error {
 	indexes, err := DetectInvalidIndexes(ctx, pool)
 	if err != nil {
@@ -147,10 +158,8 @@ func InvalidIndexCheck(ctx context.Context, pool *Pool) error {
 	for _, idx := range indexes {
 		names = append(names, idx.Index)
 	}
-	return errcode.New(errcode.KindInternal, ErrAdapterPGQuery,
-		"schema_guard: invalid indexes detected",
-		errcode.WithInternal(fmt.Sprintf("%d invalid index(es): %s", len(indexes), strings.Join(names, ", "))),
-		errcode.WithDetails(slog.Int("invalidCount", len(indexes))))
+	return fmt.Errorf("schema_guard: %d invalid index(es) [%s]: %w",
+		len(indexes), strings.Join(names, ", "), cell.ErrDegraded)
 }
 
 // DetectInvalidIndexes queries pg_index for any indexes marked as invalid

--- a/adapters/postgres/tx_manager.go
+++ b/adapters/postgres/tx_manager.go
@@ -93,7 +93,7 @@ func (tm *TxManager) RunInTx(ctx context.Context, fn func(ctx context.Context) e
 			rbErr := tx.Rollback(context.WithoutCancel(ctx))
 			if rbErr != nil {
 				slog.Error("postgres: rollback after panic failed",
-					slog.Any("panic", r),
+					slog.Any("panic", redaction.RedactAny(r)),
 					slog.String("rollback_error", redaction.RedactError(rbErr).Error()),
 				)
 			}
@@ -138,7 +138,7 @@ func (tm *TxManager) runInSavepoint(ctx context.Context, tx pgx.Tx, fn func(ctx 
 			if rbErr != nil {
 				slog.Error("postgres: rollback savepoint after panic failed",
 					slog.String("savepoint", spName),
-					slog.Any("panic", r),
+					slog.Any("panic", redaction.RedactAny(r)),
 					slog.String("rollback_error", redaction.RedactError(rbErr).Error()),
 				)
 			}

--- a/cells/accesscore/auth_integration_test.go
+++ b/cells/accesscore/auth_integration_test.go
@@ -129,7 +129,12 @@ func loginAndGetPair(t *testing.T, opts ...loginOption) loginResult {
 	require.NoError(t, err)
 
 	intClock := storetest.NewFakeClock(time.Now())
-	intRefreshStore, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, intClock, nil)
+	intRefreshStore, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, intClock, nil)
 	require.NoError(t, err)
 
 	ks, _, _ := auth.MustNewTestKeySet(clock.Real())

--- a/cells/accesscore/cell.go
+++ b/cells/accesscore/cell.go
@@ -43,8 +43,10 @@ const (
 // defaultRefreshPolicy is used only by WithInMemoryDefaults for demo/testing.
 // Durable mode must inject an explicit store via WithRefreshStore.
 var defaultRefreshPolicy = refresh.Policy{
-	ReuseInterval: defaultAccessCoreRefreshReuseInterval,
-	MaxAge:        defaultAccessCoreRefreshMaxAge,
+	ReuseInterval:  defaultAccessCoreRefreshReuseInterval,
+	MaxAge:         defaultAccessCoreRefreshMaxAge,
+	MaxIdle:        refresh.DefaultMaxIdle,
+	GraceMaxReuses: refresh.DefaultGraceMaxReuses,
 }
 
 // Compile-time interface check lives in cell_gen.go (DO NOT EDIT).

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -89,7 +89,12 @@ func mustCursorCodec() *query.CursorCodec {
 
 func newTestRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -98,7 +98,12 @@ func newE2EFixture() *e2eFixture {
 	sessionRepo := mem.NewSessionRepository(clock.Real())
 	roleRepo := mem.NewRoleRepository()
 	refreshStore, err := refreshmem.New(
-		refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour},
+		refresh.Policy{
+			ReuseInterval:  testtime.D2s,
+			MaxAge:         time.Hour,
+			MaxIdle:        refresh.DefaultMaxIdle,
+			GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+		},
 		clock.Real(), nil,
 	)
 	if err != nil {

--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -31,7 +31,12 @@ import (
 
 func newIdentityRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/identitymanage/handler_test.go
+++ b/cells/accesscore/slices/identitymanage/handler_test.go
@@ -34,7 +34,12 @@ const invalidUUID = "not-a-uuid-string"
 
 func newHandlerIdentityRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/identitymanage/refresh_cascade_test.go
+++ b/cells/accesscore/slices/identitymanage/refresh_cascade_test.go
@@ -28,7 +28,12 @@ import (
 func newCascadeStore(t *testing.T) refresh.Store {
 	t.Helper()
 	clk := storetest.NewFakeClock(time.Now())
-	policy := refresh.Policy{ReuseInterval: testtime.SlowPoll, MaxAge: time.Hour}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.SlowPoll,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	store, err := refreshmem.New(policy, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())

--- a/cells/accesscore/slices/sessionlogin/handler_test.go
+++ b/cells/accesscore/slices/sessionlogin/handler_test.go
@@ -33,7 +33,12 @@ const loginPath = "/api/v1/access/sessions/login"
 
 func newHandlerRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogin/outbox_test.go
@@ -40,6 +40,22 @@ func newOutboxRefreshStore() refresh.Store {
 	return store
 }
 
+type cleanupRefreshStoreSpy struct {
+	refresh.Store
+	revokeSessionN         int
+	revokeSessionDetachedN int
+}
+
+func (s *cleanupRefreshStoreSpy) RevokeSession(ctx context.Context, sessionID string) error {
+	s.revokeSessionN++
+	return s.Store.RevokeSession(ctx, sessionID)
+}
+
+func (s *cleanupRefreshStoreSpy) RevokeSessionDetached(ctx context.Context, sessionID string) error {
+	s.revokeSessionDetachedN++
+	return s.Store.RevokeSessionDetached(ctx, sessionID)
+}
+
 // --- stubs ---
 
 type stubOutboxWriter struct{ entries []outbox.Entry }
@@ -169,7 +185,8 @@ func TestPersistSessionWithRefresh_NoopTxRunner_EmitFails_CleanupRuns(t *testing
 	emitter := &failingEmitter{err: fmt.Errorf("broker down")}
 	// noopTxRunner implements cell.Nooper (Noop()==true) → isNoopTx returns true,
 	// so the service runs explicit session cleanup on emit failure.
-	svc := MustNewService(userRepo, sessionRepo, roleRepo, newOutboxRefreshStore(), testIssuer, slog.Default(),
+	refreshStore := &cleanupRefreshStoreSpy{Store: newOutboxRefreshStore()}
+	svc := MustNewService(userRepo, sessionRepo, roleRepo, refreshStore, testIssuer, slog.Default(),
 		WithEmitter(emitter), WithTxManager(noopTxRunner{}), WithClock(clock.Real()))
 
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
@@ -181,4 +198,8 @@ func TestPersistSessionWithRefresh_NoopTxRunner_EmitFails_CleanupRuns(t *testing
 	// In noop tx mode, cleanupIssuedSession must compensate the session write.
 	assert.Len(t, sessionRepo.deleted, 1,
 		"noop tx (demo mode): explicit Delete must run to compensate the already-written session")
+	assert.Equal(t, 1, refreshStore.revokeSessionDetachedN,
+		"cleanupIssuedSession must use RevokeSessionDetached for refresh cleanup")
+	assert.Zero(t, refreshStore.revokeSessionN,
+		"cleanupIssuedSession must not use business RevokeSession")
 }

--- a/cells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogin/outbox_test.go
@@ -28,7 +28,12 @@ import (
 
 func newOutboxRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/sessionlogin/service.go
+++ b/cells/accesscore/slices/sessionlogin/service.go
@@ -257,7 +257,7 @@ func isNoopTx(r persistence.TxRunner) bool {
 
 func (s *Service) cleanupIssuedSession(ctx context.Context, sessionID string) {
 	cleanupCtx := context.WithoutCancel(ctx)
-	if err := s.refreshStore.RevokeSession(cleanupCtx, sessionID); err != nil {
+	if err := s.refreshStore.RevokeSessionDetached(ctx, sessionID); err != nil {
 		s.logger.Error("session-login: cleanup refresh chain failed",
 			slog.Any("error", err), slog.String("session_id", sessionID))
 	}

--- a/cells/accesscore/slices/sessionlogin/service_test.go
+++ b/cells/accesscore/slices/sessionlogin/service_test.go
@@ -30,7 +30,12 @@ import (
 
 func newTestRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/sessionlogout/contract_test.go
+++ b/cells/accesscore/slices/sessionlogout/contract_test.go
@@ -29,7 +29,12 @@ import (
 
 func newContractRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/sessionlogout/handler_test.go
+++ b/cells/accesscore/slices/sessionlogout/handler_test.go
@@ -30,7 +30,12 @@ const (
 
 func newHandlerLogoutRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/sessionlogout/refresh_cascade_test.go
+++ b/cells/accesscore/slices/sessionlogout/refresh_cascade_test.go
@@ -25,7 +25,12 @@ import (
 func newCascadeStore(t *testing.T) refresh.Store {
 	t.Helper()
 	clock := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.SlowPoll, MaxAge: time.Hour}, clock, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.SlowPoll,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clock, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/sessionlogout/service_test.go
+++ b/cells/accesscore/slices/sessionlogout/service_test.go
@@ -26,7 +26,12 @@ import (
 
 func newLogoutRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/sessionmint"
 	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/pkg/ctxutil"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -263,19 +262,17 @@ func (s *Service) verifySession(ctx context.Context, sessionID string) (*domain.
 	return session, nil
 }
 
-// cascadeRevoke calls RevokeSession detached from the caller's cancellation
-// context. Cascade revoke is a security response (reuse-attack or subject-
-// mismatch) that MUST persist even when the HTTP request is canceled or times
-// out. A 5-second bounded timeout prevents indefinite waits.
+// cascadeRevoke calls RevokeSessionDetached. Cascade revoke is a security
+// response (reuse-attack or subject-mismatch) that MUST persist even when the
+// HTTP request is canceled or times out. The store owns the detached,
+// 5-second bounded write policy.
 //
 // reason is log-only and never exposed to callers.
 //
 // ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
 // ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
 func (s *Service) cascadeRevoke(ctx context.Context, sessionID, reason string) error {
-	cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
-	defer cancelCascade()
-	if err := s.refreshStore.RevokeSession(cascadeCtx, sessionID); err != nil {
+	if err := s.refreshStore.RevokeSessionDetached(ctx, sessionID); err != nil {
 		s.logger.Error("session-refresh: cascade revoke failed",
 			slog.String("reason", reason),
 			slog.Any("error", err),

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/sessionmint"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/ctxutil"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -262,10 +263,19 @@ func (s *Service) verifySession(ctx context.Context, sessionID string) (*domain.
 	return session, nil
 }
 
-// cascadeRevoke calls RevokeSession and returns infra errors distinctly from
-// auth rejection. reason is log-only and never exposed to callers.
+// cascadeRevoke calls RevokeSession detached from the caller's cancellation
+// context. Cascade revoke is a security response (reuse-attack or subject-
+// mismatch) that MUST persist even when the HTTP request is canceled or times
+// out. A 5-second bounded timeout prevents indefinite waits.
+//
+// reason is log-only and never exposed to callers.
+//
+// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
+// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
 func (s *Service) cascadeRevoke(ctx context.Context, sessionID, reason string) error {
-	if err := s.refreshStore.RevokeSession(ctx, sessionID); err != nil {
+	cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
+	defer cancelCascade()
+	if err := s.refreshStore.RevokeSession(cascadeCtx, sessionID); err != nil {
 		s.logger.Error("session-refresh: cascade revoke failed",
 			slog.String("reason", reason),
 			slog.Any("error", err),

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -262,10 +262,11 @@ func (s *Service) verifySession(ctx context.Context, sessionID string) (*domain.
 	return session, nil
 }
 
-// cascadeRevoke calls RevokeSessionDetached. Cascade revoke is a security
-// response (reuse-attack or subject-mismatch) that MUST persist even when the
-// HTTP request is canceled or times out. The store owns the detached,
-// 5-second bounded write policy.
+// cascadeRevoke routes security-response revokes (reuse attack,
+// session-not-found, or subject mismatch) through RevokeSessionDetached. Once a
+// cascade path is reached, the store owns the detached, 5-second bounded write
+// policy that lets durable implementations persist the revoke outside the
+// caller's cancellation and ambient transaction boundary.
 //
 // reason is log-only and never exposed to callers.
 //

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -1149,9 +1149,9 @@ func TestService_CascadeRevoke_UsesDetachedStoreMethod(t *testing.T) {
 	sessionRepo := &sessionNotFoundRepo{notFoundErr: notFoundErr}
 	svc := MustNewService(sessionRepo, roleRepo, userRepo, spy, testIssuer, slog.Default(), WithClock(clock.Real()))
 
-	// Cancel the caller ctx before calling Refresh. This simulates an HTTP
-	// request that times out or is canceled by the client while the server
-	// is processing.
+	// Cancel the caller ctx before calling Refresh. This service-level test
+	// only asserts method routing; durable cancellation behavior is owned by
+	// the store-level RevokeSessionDetached contract.
 	callerCtx, callerCancel := context.WithCancel(context.Background())
 	callerCancel() // cancel immediately
 

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -1081,3 +1081,74 @@ func TestRefresh_RotateMismatch_CascadeRevokeFails_PropagatesErr(t *testing.T) {
 	require.ErrorAs(t, err, &ec)
 	assert.Equal(t, errcode.ErrAuthRefreshUnavailable, ec.Code)
 }
+
+// ---------------------------------------------------------------------------
+// Detached ctx tests (Wave 0 RED baseline)
+// ---------------------------------------------------------------------------
+
+// detachSpyRefreshStore wraps a real refresh.Store and records whether the
+// ctx passed to RevokeSession is already done (cancelled/deadline exceeded)
+// at the time of the call. After Wave 2 lands ctxutil.WithDetachedTimeout,
+// the ctx must NOT be done at entry; before Wave 2 it will be done because
+// the caller ctx is passed directly.
+type detachSpyRefreshStore struct {
+	refresh.Store
+	mu             sync.Mutex
+	revokeCalledN  int
+	ctxErrAtRevoke error // ctx.Err() captured inside RevokeSession
+}
+
+func (s *detachSpyRefreshStore) RevokeSession(ctx context.Context, sessionID string) error {
+	s.mu.Lock()
+	s.revokeCalledN++
+	s.ctxErrAtRevoke = ctx.Err()
+	s.mu.Unlock()
+	return s.Store.RevokeSession(ctx, sessionID)
+}
+
+// TestService_CascadeRevoke_DetachesFromCallerCtx verifies that when
+// cascadeRevoke is triggered by a session-not-found condition, the ctx
+// forwarded to RevokeSession is NOT the caller's already-cancelled ctx.
+//
+// Mechanism: cancel the caller ctx before calling Refresh; a triggered
+// cascade should still deliver a live (non-done) ctx to RevokeSession
+// because service.cascadeRevoke must use ctxutil.WithDetachedTimeout.
+//
+// RED in Wave 0: cascadeRevoke currently passes the caller ctx directly;
+// ctx.Err() will be non-nil (context.Canceled) inside RevokeSession.
+// Wave 2 fixes cascadeRevoke to use detached ctx; test turns GREEN.
+func TestService_CascadeRevoke_DetachesFromCallerCtx(t *testing.T) {
+	notFoundErr := domainSessionNotFoundError()
+	roleRepo := mem.NewRoleRepository()
+	userRepo := mem.NewUserRepository()
+
+	_, _, innerStore, wireToken := issueTestWireToken(t, "usr-detach-cancel", "sess-detach-cancel")
+
+	spy := &detachSpyRefreshStore{Store: innerStore}
+	sessionRepo := &sessionNotFoundRepo{notFoundErr: notFoundErr}
+	svc := MustNewService(sessionRepo, roleRepo, userRepo, spy, testIssuer, slog.Default(), WithClock(clock.Real()))
+
+	// Cancel the caller ctx before calling Refresh. This simulates an HTTP
+	// request that times out or is cancelled by the client while the server
+	// is processing.
+	callerCtx, callerCancel := context.WithCancel(context.Background())
+	callerCancel() // cancel immediately
+
+	_, _ = svc.Refresh(callerCtx, wireToken)
+
+	spy.mu.Lock()
+	calledN := spy.revokeCalledN
+	ctxErrAtCall := spy.ctxErrAtRevoke
+	spy.mu.Unlock()
+
+	require.Equal(t, 1, calledN, "RevokeSession must be called exactly once on session-not-found")
+
+	// After Wave 2: ctxErrAtCall must be nil (detached ctx is still live).
+	// In Wave 0 (RED): ctxErrAtCall will be context.Canceled because the
+	// current code passes the caller ctx directly — this assertion fails.
+	if ctxErrAtCall != nil {
+		t.Errorf("RevokeSession received a done ctx (ctx.Err() = %v); "+
+			"cascadeRevoke must use ctxutil.WithDetachedTimeout to detach from caller cancel",
+			ctxErrAtCall)
+	}
+}

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -628,13 +628,15 @@ func (r *infraGetByIDRepo) GetByID(_ context.Context, _ string) (*domain.Session
 	return nil, r.infraErr
 }
 
-// spyRefreshStore wraps a real refresh.Store and records RevokeSession calls.
+// spyRefreshStore wraps a real refresh.Store and records revoke calls.
 // Used by F14 to assert cascade-revoke is triggered on session-not-found.
 type spyRefreshStore struct {
 	refresh.Store
-	mu             sync.Mutex
-	revokeSessionN int
-	lastSessionID  string
+	mu                     sync.Mutex
+	revokeSessionN         int
+	revokeSessionDetachedN int
+	lastSessionID          string
+	lastDetachedSessionID  string
 }
 
 func (s *spyRefreshStore) RevokeSession(ctx context.Context, sessionID string) error {
@@ -645,19 +647,27 @@ func (s *spyRefreshStore) RevokeSession(ctx context.Context, sessionID string) e
 	return s.Store.RevokeSession(ctx, sessionID)
 }
 
+func (s *spyRefreshStore) RevokeSessionDetached(ctx context.Context, sessionID string) error {
+	s.mu.Lock()
+	s.revokeSessionDetachedN++
+	s.lastDetachedSessionID = sessionID
+	s.mu.Unlock()
+	return s.Store.RevokeSessionDetached(ctx, sessionID)
+}
+
 type revokeFailingRefreshStore struct {
 	refresh.Store
 	err error
 }
 
-func (s revokeFailingRefreshStore) RevokeSession(context.Context, string) error {
+func (s revokeFailingRefreshStore) RevokeSessionDetached(context.Context, string) error {
 	return s.err
 }
 
 // TestService_Refresh_SessionNotFound_CascadeRevokes verifies that when
 // sessionRepo.GetByID returns a domain ErrSessionNotFound (not an infra error),
-// Refresh returns ErrAuthRefreshFailed AND calls RevokeSession on the rotated
-// token so the newly-issued child cannot be used by an attacker (F14).
+// Refresh returns ErrAuthRefreshFailed AND calls RevokeSessionDetached on the
+// rotated token so the newly-issued child cannot be used by an attacker (F14).
 func TestService_Refresh_SessionNotFound_CascadeRevokes(t *testing.T) {
 	notFoundErr := domainSessionNotFoundError()
 	roleRepo := mem.NewRoleRepository()
@@ -677,9 +687,11 @@ func TestService_Refresh_SessionNotFound_CascadeRevokes(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_AUTH_REFRESH_FAILED")
 
 	spy.mu.Lock()
-	n := spy.revokeSessionN
+	detachedN := spy.revokeSessionDetachedN
+	businessN := spy.revokeSessionN
 	spy.mu.Unlock()
-	assert.Equal(t, 1, n, "RevokeSession must be called once on session-not-found")
+	assert.Equal(t, 1, detachedN, "RevokeSessionDetached must be called once on session-not-found")
+	assert.Zero(t, businessN, "session-refresh cascade must not use business RevokeSession")
 }
 
 func TestService_Refresh_CascadeRevokeFailure_ReturnsRefreshUnavailable(t *testing.T) {
@@ -775,9 +787,11 @@ func TestService_Refresh_SessionUpdateNotFound_CascadeRevokesAndRejects(t *testi
 	assert.Equal(t, "invalid refresh token", ec.Message)
 
 	spy.mu.Lock()
-	n := spy.revokeSessionN
+	detachedN := spy.revokeSessionDetachedN
+	businessN := spy.revokeSessionN
 	spy.mu.Unlock()
-	assert.Equal(t, 1, n, "session update not-found must cascade revoke the refresh chain")
+	assert.Equal(t, 1, detachedN, "session update not-found must cascade revoke the refresh chain")
+	assert.Zero(t, businessN, "session update cascade must not use business RevokeSession")
 }
 
 func TestService_Refresh_RejectionMessagesAreUniform(t *testing.T) {
@@ -1049,7 +1063,7 @@ func TestRefresh_RotateMismatch_CascadeRevoke_ReturnsRejected(t *testing.T) {
 }
 
 // TestRefresh_RotateMismatch_CascadeRevokeFails_PropagatesErr verifies that when
-// Rotate returns a mismatched token AND cascadeRevoke (RevokeSession) fails,
+// Rotate returns a mismatched token AND cascadeRevoke (RevokeSessionDetached) fails,
 // the infra error is propagated rather than swallowed.
 func TestRefresh_RotateMismatch_CascadeRevokeFails_PropagatesErr(t *testing.T) {
 	_, sessionRepo, innerStore := newTestServiceWithRefreshStore(t, "usr-mismatch-revoke-fail")
@@ -1068,15 +1082,15 @@ func TestRefresh_RotateMismatch_CascadeRevokeFails_PropagatesErr(t *testing.T) {
 	u.ID = "usr-mismatch-revoke-fail"
 	require.NoError(t, userRepo.Create(context.Background(), u))
 
-	// revokeFailingRefreshStore already covers RevokeSession failure; wrap it
+	// revokeFailingRefreshStore already covers RevokeSessionDetached failure; wrap it
 	// with rotateMismatchRefreshStore on top so Rotate returns mismatch and then
-	// cascadeRevoke calls through to a RevokeSession that errors.
+	// cascadeRevoke calls through to a detached revoke that errors.
 	revokeErrStore := revokeFailingRefreshStore{
 		Store: innerStore,
 		err:   errcode.New(errcode.KindInternal, errcode.ErrInternal, "revoke store down"),
 	}
 	// rotateMismatchRefreshStore wraps revokeErrStore so Rotate returns mismatch
-	// but RevokeSession delegates to revokeErrStore and fails.
+	// but RevokeSessionDetached delegates to revokeErrStore and fails.
 	mismatchStore := rotateMismatchRefreshStore{
 		Store:            revokeErrStore,
 		rotatedSessionID: "tampered-session",
@@ -1093,41 +1107,38 @@ func TestRefresh_RotateMismatch_CascadeRevokeFails_PropagatesErr(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Detached ctx tests (Wave 0 RED baseline)
+// Detached revoke routing tests
 // ---------------------------------------------------------------------------
 
 // detachSpyRefreshStore wraps a real refresh.Store and records whether the
-// ctx passed to RevokeSession is already done (canceled/deadline exceeded)
-// at the time of the call. After Wave 2 lands ctxutil.WithDetachedTimeout,
-// the ctx must NOT be done at entry; before Wave 2 it will be done because
-// the caller ctx is passed directly.
+// session-refresh service uses the detached revoke method for cascade paths.
+// The durable store implementation owns the actual cancellation/ambient-tx
+// detach behavior; this service-level test only locks down method routing.
 type detachSpyRefreshStore struct {
 	refresh.Store
-	mu             sync.Mutex
-	revokeCalledN  int
-	ctxErrAtRevoke error // ctx.Err() captured inside RevokeSession
+	mu              sync.Mutex
+	detachedCalledN int
+	businessCalledN int
 }
 
 func (s *detachSpyRefreshStore) RevokeSession(ctx context.Context, sessionID string) error {
 	s.mu.Lock()
-	s.revokeCalledN++
-	s.ctxErrAtRevoke = ctx.Err()
+	s.businessCalledN++
 	s.mu.Unlock()
 	return s.Store.RevokeSession(ctx, sessionID)
 }
 
-// TestService_CascadeRevoke_DetachesFromCallerCtx verifies that when
-// cascadeRevoke is triggered by a session-not-found condition, the ctx
-// forwarded to RevokeSession is NOT the caller's already-canceled ctx.
-//
-// Mechanism: cancel the caller ctx before calling Refresh; a triggered
-// cascade should still deliver a live (non-done) ctx to RevokeSession
-// because service.cascadeRevoke must use ctxutil.WithDetachedTimeout.
-//
-// RED in Wave 0: cascadeRevoke currently passes the caller ctx directly;
-// ctx.Err() will be non-nil (context.Canceled) inside RevokeSession.
-// Wave 2 fixes cascadeRevoke to use detached ctx; test turns GREEN.
-func TestService_CascadeRevoke_DetachesFromCallerCtx(t *testing.T) {
+func (s *detachSpyRefreshStore) RevokeSessionDetached(ctx context.Context, sessionID string) error {
+	s.mu.Lock()
+	s.detachedCalledN++
+	s.mu.Unlock()
+	return s.Store.RevokeSessionDetached(ctx, sessionID)
+}
+
+// TestService_CascadeRevoke_UsesDetachedStoreMethod verifies that when
+// cascadeRevoke is triggered by a session-not-found condition, sessionrefresh
+// calls the explicit detached store method instead of the business revoke.
+func TestService_CascadeRevoke_UsesDetachedStoreMethod(t *testing.T) {
 	notFoundErr := domainSessionNotFoundError()
 	roleRepo := mem.NewRoleRepository()
 	userRepo := mem.NewUserRepository()
@@ -1147,18 +1158,10 @@ func TestService_CascadeRevoke_DetachesFromCallerCtx(t *testing.T) {
 	_, _ = svc.Refresh(callerCtx, wireToken)
 
 	spy.mu.Lock()
-	calledN := spy.revokeCalledN
-	ctxErrAtCall := spy.ctxErrAtRevoke
+	detachedN := spy.detachedCalledN
+	businessN := spy.businessCalledN
 	spy.mu.Unlock()
 
-	require.Equal(t, 1, calledN, "RevokeSession must be called exactly once on session-not-found")
-
-	// After Wave 2: ctxErrAtCall must be nil (detached ctx is still live).
-	// In Wave 0 (RED): ctxErrAtCall will be context.Canceled because the
-	// current code passes the caller ctx directly — this assertion fails.
-	if ctxErrAtCall != nil {
-		t.Errorf("RevokeSession received a done ctx (ctx.Err() = %v); "+
-			"cascadeRevoke must use ctxutil.WithDetachedTimeout to detach from caller cancel",
-			ctxErrAtCall)
-	}
+	require.Equal(t, 1, detachedN, "RevokeSessionDetached must be called exactly once on session-not-found")
+	assert.Zero(t, businessN, "cascadeRevoke must not call business RevokeSession")
 }

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -48,7 +48,12 @@ func init() {
 
 func newTestRefreshStore() refresh.Store {
 	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, clk, nil)
+	store, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, clk, nil)
 	if err != nil {
 		panic("test setup: " + err.Error())
 	}
@@ -115,7 +120,12 @@ func newTestServiceWithClock(t testing.TB, seedUsers ...string) (*Service, ports
 		_ = userRepo.Create(context.Background(), u)
 	}
 	fakeClock := storetest.NewFakeClock(time.Now())
-	refreshStore, err := refreshmem.New(refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: time.Hour}, fakeClock, nil)
+	refreshStore, err := refreshmem.New(refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}, fakeClock, nil)
 	if err != nil {
 		t.Fatalf("test setup: %v", err)
 	}
@@ -1087,7 +1097,7 @@ func TestRefresh_RotateMismatch_CascadeRevokeFails_PropagatesErr(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // detachSpyRefreshStore wraps a real refresh.Store and records whether the
-// ctx passed to RevokeSession is already done (cancelled/deadline exceeded)
+// ctx passed to RevokeSession is already done (canceled/deadline exceeded)
 // at the time of the call. After Wave 2 lands ctxutil.WithDetachedTimeout,
 // the ctx must NOT be done at entry; before Wave 2 it will be done because
 // the caller ctx is passed directly.
@@ -1108,7 +1118,7 @@ func (s *detachSpyRefreshStore) RevokeSession(ctx context.Context, sessionID str
 
 // TestService_CascadeRevoke_DetachesFromCallerCtx verifies that when
 // cascadeRevoke is triggered by a session-not-found condition, the ctx
-// forwarded to RevokeSession is NOT the caller's already-cancelled ctx.
+// forwarded to RevokeSession is NOT the caller's already-canceled ctx.
 //
 // Mechanism: cancel the caller ctx before calling Refresh; a triggered
 // cascade should still deliver a live (non-done) ctx to RevokeSession
@@ -1129,7 +1139,7 @@ func TestService_CascadeRevoke_DetachesFromCallerCtx(t *testing.T) {
 	svc := MustNewService(sessionRepo, roleRepo, userRepo, spy, testIssuer, slog.Default(), WithClock(clock.Real()))
 
 	// Cancel the caller ctx before calling Refresh. This simulates an HTTP
-	// request that times out or is cancelled by the client while the server
+	// request that times out or is canceled by the client while the server
 	// is processing.
 	callerCtx, callerCancel := context.WithCancel(context.Background())
 	callerCancel() // cancel immediately

--- a/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+++ b/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
@@ -152,6 +152,18 @@ uniform.
   `DetectInvalidIndexes` and returns a non-nil error when any `indisvalid=false`
   row exists
 
+**Update (PR#528 follow-up)**: `InvalidIndexCheck` wraps `cell.ErrDegraded`
+when invalid indexes are present (using the same `fmt.Errorf("...: %w", cell.ErrDegraded)`
+pattern as `kernel/outbox/emitter.go` for drop-ratio degradation). This causes
+`runtime/http/health.runOneProbe` to classify the result as **degraded** (HTTP
+200, fail-open) rather than **unhealthy** (HTTP 503, pod evict). Invalid indexes
+are a maintenance signal — CREATE INDEX CONCURRENTLY in-progress or aborted
+leftover — not a runtime fault. Operators see the invalid-index list in the
+`/readyz?verbose` body's `dependencies.postgres_indexes_valid_ready` entry and
+DROP the index manually. The underlying query error path (connection failure,
+SQL error inside `DetectInvalidIndexes`) still returns the raw query error and
+maps to **unhealthy** — that is a real fault.
+
 **Archtest**: `REFRESH-INVALID-INDEX-SINGLE-SOURCE-01` (AST scan for
 `DetectInvalidIndexes` FuncDecl — asserts exactly one definition).
 

--- a/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+++ b/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
@@ -65,6 +65,32 @@ caller `RunInTx(ctx, fn)` where `fn` triggers reuse Peek then returns an
 error; after the outer rollback, a subsequent `Rotate(child)` must still
 return `ErrRejected`.
 
+### Session revoke API split
+
+The `refresh.Store` interface now names the transaction semantics explicitly:
+
+- `RevokeSession(ctx, sessionID)` is the business revoke path. It joins the
+  ambient transaction when one exists and is used by logout flows so session
+  state, refresh-chain revoke, and outbox writes commit or roll back together.
+- `RevokeSessionDetached(ctx, sessionID)` is the security/compensation path.
+  Durable implementations bypass the ambient transaction and detach from
+  caller cancellation with `ctxutil.WithDetachedTimeout(...,
+  refresh.CascadeRevokeTimeout)`.
+
+The split is intentionally **session-only**. `RevokeUser` remains unsplit
+because user-lock, user-delete, change-password, and logout-all are business
+state transitions; refresh-chain revocation must stay atomic with user/session
+mutations and related outbox writes. Adding `RevokeUserDetached` would make it
+too easy for a caller to turn a business operation into a partially committed
+cross-store side effect.
+
+**Tests**:
+- `storetest T22_RevokeSessionDetached_CascadeIgnoresCallerCancel`
+- `TestPGRefreshStore_RevokeSessionDetachedSurvivesAmbientRollback`
+- `sessionrefresh` and `sessionlogin` spy tests assert cascade/cleanup callers
+  use `RevokeSessionDetached`, while logout and identity management keep using
+  `RevokeSession` / `RevokeUser`.
+
 ### X15 — Cascade revoke detaches from caller cancellation
 
 PR#388 closed the ambient-tx boundary but left cascade revoke bound to the
@@ -211,6 +237,10 @@ not a historical backfill. PR#528 collapses the model:
 
 - The DDL DEFAULT is **removed**. `idle_expires_at` is `NOT NULL` with no
   default; every row must be written explicitly by Issue or Rotate.
+- Migration 016 now includes a preflight `DO` block that refuses to add the
+  no-default `idle_expires_at` column to a non-empty `refresh_tokens` table.
+  The project is undeployed, so the accepted migration shape is "empty table
+  only" rather than a backfill branch for historical refresh rows.
 - `Issue`: sets `idle_expires_at = now + Policy.MaxIdle`
 - `Rotate`: child row's `idle_expires_at = now + Policy.MaxIdle` (sliding
   window reset on every successful rotation)
@@ -223,6 +253,13 @@ The migration is modified in place (project undeployed; goose
 `goose_db_version` records `version_id`+`tstamp`, not file hash; CI is
 ephemeral; dev `goose reset` is acceptable). No new 017 migration is created
 to avoid carrying meaningless schema history as a permanent artifact.
+
+Limitation: environments that already applied the old PR#388 version of 016
+will not automatically receive the in-place DDL change because goose will
+consider version 016 applied. Those environments must run `goose down -count 1`
+then `goose up`, reset the dev database, or carry an explicit local follow-up
+migration. That is accepted because GoCell is not deployed to production yet;
+there are no external schemas that need a forward-only compatibility path.
 
 ### X14 — GraceMaxReuses grace counter cap (REFRESH-GRACE-COUNTER) — revised by PR#528
 

--- a/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+++ b/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
@@ -113,31 +113,35 @@ s.pool.Exec(cascadeCtx, revokeSessionSQL, ...)
 proposal #40221) with `context.WithTimeout`: the returned context inherits
 all Values from the parent (trace IDs, auth principal, request id) but is
 **not** canceled when parent is canceled, and carries its own absolute
-deadline (`refresh.CascadeRevokeTimeout = 5 * time.Second`). The same helper
-is used at the service layer (`sessionrefresh.Service.cascadeRevoke`) for
-non-store cascade paths (subject-mismatch, session-not-found, revoked-session,
-rotated-subject-mismatch, session-update-not-found) so all cascade revoke
-sites share a single detach + timeout policy.
+deadline (`refresh.CascadeRevokeTimeout = 5 * time.Second`). The service layer
+routes non-store cascade paths (subject-mismatch, session-not-found,
+revoked-session, rotated-subject-mismatch, session-update-not-found) through
+`Store.RevokeSessionDetached` so cascade revoke sites share the store-owned
+detach + timeout policy.
 
 This pattern is the per-call analogue of HashiCorp Vault's process-level
 `core.activeContext` / `quitContext` (used by `vault/token_store.go`
-`revokeInternal`). Vault detaches token revocation from request lifetime to
-guarantee revocation completes despite client disconnect; GoCell adopts the
-same property using `WithoutCancel + WithTimeout` instead of a manager-owned
-process-level context (simpler; no global lifecycle to plumb).
+`revokeInternal`). Vault detaches token revocation from request lifetime;
+GoCell adopts that boundary for explicit detached revoke calls using
+`WithoutCancel + WithTimeout` instead of a manager-owned process-level context
+(simpler; no global lifecycle to plumb).
 
 **Tests**:
 - `pkg/ctxutil/detach_test.go` — helper boundary (parent cancel does not
   propagate; timeout fires; values preserved; cancel func releases)
-- `cells/accesscore/slices/sessionrefresh/service_test.go::TestService_CascadeRevoke_DetachesFromCallerCtx` —
-  service-level cascade with mock store, asserts `ctx.Err() == nil` at
-  `RevokeSession` entry under canceled caller ctx
-- Black-box PG store-level "caller cancel mid-cascade" tests are intentionally
+- `runtime/auth/refresh/storetest.RunContractSuite::T22_RevokeSessionDetached_CascadeIgnoresCallerCancel` —
+  store-level contract for calling `RevokeSessionDetached` with an already
+  canceled caller ctx
+- `cells/accesscore/slices/sessionrefresh/service_test.go::TestService_CascadeRevoke_UsesDetachedStoreMethod` —
+  service-level cascade routing with a spy store; it asserts cascade paths call
+  `RevokeSessionDetached` rather than ambient `RevokeSession`
+- Black-box refresh-entry "caller cancel mid-cascade" tests are intentionally
   not provided: the literal shape (Rotate with already-canceled ctx) cannot
   reach cascade SQL because `RunInTx` fails at `pool.Begin(ctx)` first.
-  Inserting cancel mid-call requires either a mocked pgxpool (mock theatre)
-  or non-deterministic timing (flaky). Coverage is layered through the helper
-  test, the service-level test, and `TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback`.
+  Inserting cancel mid-call requires either a mocked pgxpool or
+  non-deterministic timing. Coverage is layered through the helper test, the
+  service-level routing test, the store contract, and
+  `TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback`.
 
 ref: golang/go context.WithoutCancel proposal#40221
 ref: hashicorp/vault vault/token_store.go (quitContext detached pattern)
@@ -333,8 +337,9 @@ are **not** implicit defaults applied by `Validate`.
   that would forever carry the original mismatch in schema history.
 - Cascade revoke takes a hard 5-second timeout (`CascadeRevokeTimeout`). If
   PG cascade SQL exceeds 5s under load, the cascade fails with
-  `context.DeadlineExceeded` and the revoke is logged + retried by upstream
-  (no automatic retry from store; security event still surfaces).
+  `context.DeadlineExceeded`; the revoke failure is logged and surfaced to the
+  caller as unavailable. Neither the store nor the service performs an
+  automatic retry.
 
 ---
 

--- a/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+++ b/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
@@ -178,21 +178,18 @@ uniform.
 
 `PGResource.Checkers()` returns two named probes:
 - `postgres_ready`: existing pool ping (no change)
-- `postgres_indexes_valid_ready`: calls `InvalidIndexCheck(ctx, pool)` which wraps
-  `DetectInvalidIndexes` and returns a non-nil error when any `indisvalid=false`
+- `postgres_indexes_valid_ready`: calls `InvalidIndexCheck(ctx, pool)`, which
+  calls `DetectInvalidIndexes` and returns a non-nil error when any `indisvalid=false`
   row exists
 
-**Update (PR#528 follow-up)**: `InvalidIndexCheck` wraps `cell.ErrDegraded`
-when invalid indexes are present (using the same `fmt.Errorf("...: %w", cell.ErrDegraded)`
-pattern as `kernel/outbox/emitter.go` for drop-ratio degradation). This causes
-`runtime/http/health.runOneProbe` to classify the result as **degraded** (HTTP
-200, fail-open) rather than **unhealthy** (HTTP 503, pod evict). Invalid indexes
-are a maintenance signal — CREATE INDEX CONCURRENTLY in-progress or aborted
-leftover — not a runtime fault. Operators see the invalid-index list in the
-`/readyz?verbose` body's `dependencies.postgres_indexes_valid_ready` entry and
-DROP the index manually. The underlying query error path (connection failure,
-SQL error inside `DetectInvalidIndexes`) still returns the raw query error and
-maps to **unhealthy** — that is a real fault.
+**Update (PR#528 follow-up)**: `InvalidIndexCheck` returns a normal
+`KindInternal` errcode error when invalid indexes are present. It deliberately
+does **not** wrap `cell.ErrDegraded`: `/readyz` is the binary traffic gate, so
+schema faults must classify as **unhealthy** (HTTP 503) rather than fail-open
+**degraded** (HTTP 200). Operators still see the invalid-index list in
+`/readyz?verbose` diagnostics and logs, then DROP the index manually. The
+underlying query error path (connection failure, SQL error inside
+`DetectInvalidIndexes`) also maps to **unhealthy**.
 
 **Archtest**: `REFRESH-INVALID-INDEX-SINGLE-SOURCE-01` (AST scan for
 `DetectInvalidIndexes` FuncDecl — asserts exactly one definition).
@@ -320,8 +317,8 @@ are **not** implicit defaults applied by `Validate`.
    attacker defers use.
 3. **Grace counter cap**: prevents indefinite token reuse by concurrent or malicious
    clients within the grace window. After 3 re-uses the chain is cascade-revoked.
-4. **Dual readyz**: invalid indexes (CONCURRENTLY-failed) now surface in the health
-   endpoint before they cause query failures.
+4. **Dual readyz**: invalid indexes (CONCURRENTLY-failed) now surface as a
+   readiness blocker before they cause query failures.
 5. **Redacted rollback logs**: DSN strings from Postgres rollback errors cannot
    leak to log sinks.
 

--- a/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+++ b/docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
@@ -1,9 +1,9 @@
 # ADR: Refresh Store — Ambient-Only TX + Idle/Grace Extension
 
-**Date**: 2026-05-05  
+**Date**: 2026-05-05 (revised 2026-05-06 by PR#528 follow-up — finding 1+2)
 **Status**: Accepted  
-**Implements**: B2-A-08, B2-A-09, B2-A-10, B2-A-11, B2-A-13, X12, X14  
-**PR**: PR-V1-PG-REFRESH-HARDEN-AND-IDLE-GRACE
+**Implements**: B2-A-08, B2-A-09, B2-A-10, B2-A-11, B2-A-13, X12, X14, X15
+**PR**: PR-V1-PG-REFRESH-HARDEN-AND-IDLE-GRACE → PR#528 follow-up
 
 ---
 
@@ -54,7 +54,8 @@ business-level rollback by the caller (e.g. an unrelated handler error after
 the refresh check) would undo the revocation and leave the stolen chain live.
 
 Implementation: `handleRotatedRow` runs the cascade `revokeSessionSQL`
-through `s.pool.Exec(ctx, ...)` directly, bypassing `execCtx`. The revoke
+through `s.pool.Exec(cascadeCtx, ...)` directly, bypassing `execCtx`. The
+cascadeCtx is a **detached, bounded** context (see X15 below). The revoke
 commits on its own connection regardless of the surrounding `RunInTx`
 outcome. The reject error itself is still captured via the outer `rejectErr`
 variable so that `RunInTx` commits cleanly (timing oracle defense intact).
@@ -63,6 +64,57 @@ variable so that `RunInTx` commits cleanly (timing oracle defense intact).
 caller `RunInTx(ctx, fn)` where `fn` triggers reuse Peek then returns an
 error; after the outer rollback, a subsequent `Rotate(child)` must still
 return `ErrRejected`.
+
+### X15 — Cascade revoke detaches from caller cancellation
+
+PR#388 closed the ambient-tx boundary but left cascade revoke bound to the
+caller's request `context.Context`. If a client disconnects (HTTP/2 RST,
+client timeout) **after** reuse_detected but **before** the cascade SQL
+commits, the cascade write fails with `context canceled` and the offending
+refresh chain stays live — re-creating the very vulnerability the bypass was
+meant to close, just shifted from "ambient rollback" to "request lifecycle".
+
+PR#528 fixes this by wrapping the cascade pool.Exec call in a detached,
+bounded context:
+
+```go
+cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
+defer cancelCascade()
+s.pool.Exec(cascadeCtx, revokeSessionSQL, ...)
+```
+
+`pkg/ctxutil.WithDetachedTimeout` composes `context.WithoutCancel` (Go 1.21+,
+proposal #40221) with `context.WithTimeout`: the returned context inherits
+all Values from the parent (trace IDs, auth principal, request id) but is
+**not** canceled when parent is canceled, and carries its own absolute
+deadline (`refresh.CascadeRevokeTimeout = 5 * time.Second`). The same helper
+is used at the service layer (`sessionrefresh.Service.cascadeRevoke`) for
+non-store cascade paths (subject-mismatch, session-not-found, revoked-session,
+rotated-subject-mismatch, session-update-not-found) so all cascade revoke
+sites share a single detach + timeout policy.
+
+This pattern is the per-call analogue of HashiCorp Vault's process-level
+`core.activeContext` / `quitContext` (used by `vault/token_store.go`
+`revokeInternal`). Vault detaches token revocation from request lifetime to
+guarantee revocation completes despite client disconnect; GoCell adopts the
+same property using `WithoutCancel + WithTimeout` instead of a manager-owned
+process-level context (simpler; no global lifecycle to plumb).
+
+**Tests**:
+- `pkg/ctxutil/detach_test.go` — helper boundary (parent cancel does not
+  propagate; timeout fires; values preserved; cancel func releases)
+- `cells/accesscore/slices/sessionrefresh/service_test.go::TestService_CascadeRevoke_DetachesFromCallerCtx` —
+  service-level cascade with mock store, asserts `ctx.Err() == nil` at
+  `RevokeSession` entry under canceled caller ctx
+- Black-box PG store-level "caller cancel mid-cascade" tests are intentionally
+  not provided: the literal shape (Rotate with already-canceled ctx) cannot
+  reach cascade SQL because `RunInTx` fails at `pool.Begin(ctx)` first.
+  Inserting cancel mid-call requires either a mocked pgxpool (mock theatre)
+  or non-deterministic timing (flaky). Coverage is layered through the helper
+  test, the service-level test, and `TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback`.
+
+ref: golang/go context.WithoutCancel proposal#40221
+ref: hashicorp/vault vault/token_store.go (quitContext detached pattern)
 
 ### Accepted timing leak: malformed wire format
 
@@ -114,42 +166,92 @@ uniform.
 **Archtest**: `PG-CONSTRUCTOR-MUST-FREE-01` (AST scan for exported `MustNew*`
 FuncDecl in adapters/postgres non-test files).
 
-### B2-A-13 — RedactError in tx_manager rollback slog
+### B2-A-13 — RedactError in tx_manager rollback slog (broadened by PR#528)
 
 All four `slog.Error` calls in `adapters/postgres/tx_manager.go` for rollback
-failures now wrap the error string with `pkg/redaction.RedactError(err).Error()`
-before logging, ensuring DSN/token strings in rollback errors do not leak to logs.
+failures wrap the error string with `pkg/redaction.RedactError(err).Error()`
+before logging.
 
-### X12 — MaxIdle sliding-window idle-expiry (REFRESH-IDLE-EXPIRE)
+PR#528 broadens the same fail-closed treatment to **panic payloads**:
+`slog.Any("panic", r)` was originally raw `r` (an `any` returned from
+`recover()`) which can carry DSN/token-shaped strings if a panic bubbled out
+of a connection establishment or token-mint path. PR#528 introduces
+`pkg/redaction.RedactAny(v any) any` (`nil → nil`, `error → RedactError`,
+`string → RedactString`, other `→ RedactString(fmt.Sprint(v))`) and rewrites
+all 11 `slog.Any("panic", X)` sites in the repo to wrap X. An archtest
+`TestPanicLogMustUseRedactAny` (AST scan in `tools/archtest`) prevents
+regression: any future `slog.Any("panic", X)` where X is not
+`redaction.RedactAny(...)` fails CI.
 
-Migration 016 adds `idle_expires_at TIMESTAMPTZ NOT NULL DEFAULT now()+30d`.
+Sites: `adapters/postgres/tx_manager.go` ×2 (top-level recover + savepoint
+recover), `kernel/outbox/outbox.go`, `runtime/config/watcher.go`,
+`runtime/http/health/health.go`, `runtime/http/health/wrap.go` ×2,
+`runtime/http/middleware/recovery.go`, `runtime/http/middleware/safe_observe.go`,
+`runtime/outbox/metrics_safe.go`, `runtime/worker/periodic.go`.
 
+### X12 — MaxIdle sliding-window idle-expiry (REFRESH-IDLE-EXPIRE) — revised by PR#528
+
+Migration 016 adds `idle_expires_at TIMESTAMPTZ NOT NULL`. PR#388's original
+SQL also wrote `DEFAULT now() + INTERVAL '30 days'` and the prose claimed
+pre-016 rows would receive a `created_at + 30d` semantics — neither was true.
+The migration default was a metadata-only `now()+30d` (migration-time reset),
+not a historical backfill. PR#528 collapses the model:
+
+- The DDL DEFAULT is **removed**. `idle_expires_at` is `NOT NULL` with no
+  default; every row must be written explicitly by Issue or Rotate.
 - `Issue`: sets `idle_expires_at = now + Policy.MaxIdle`
-- `Rotate`: child row's `idle_expires_at = now + Policy.MaxIdle` (sliding window
-  reset on every successful rotation)
-- `validateRow`: rejects with `idle_expired` when `idle_expires_at ≤ now` and
-  `Policy.MaxIdle > 0`
+- `Rotate`: child row's `idle_expires_at = now + Policy.MaxIdle` (sliding
+  window reset on every successful rotation)
+- `validateRow`: rejects with `idle_expired` when `idle_expires_at ≤ now`
+  (no zero-`MaxIdle` branch — Policy.Validate now rejects zero `MaxIdle`)
 - `gcBatchSQL`: uses `LEAST(expires_at, idle_expires_at) < $1` so idle-expired
   rows are GC'd even when their absolute `expires_at` is still in the future
-- Pre-016 rows have the column defaulted to `created_at + 30d`; stores that have
-  not applied the migration set `MaxIdle = 0` to disable the idle check
 
-### X14 — GraceMaxReuses grace counter cap (REFRESH-GRACE-COUNTER)
+The migration is modified in place (project undeployed; goose
+`goose_db_version` records `version_id`+`tstamp`, not file hash; CI is
+ephemeral; dev `goose reset` is acceptable). No new 017 migration is created
+to avoid carrying meaningless schema history as a permanent artifact.
 
-Migration 016 adds `first_used_at TIMESTAMPTZ NULL` and `used_times INT NOT NULL DEFAULT 0`.
+### X14 — GraceMaxReuses grace counter cap (REFRESH-GRACE-COUNTER) — revised by PR#528
+
+Migration 016 adds `first_used_at TIMESTAMPTZ NULL` and `used_times INT NOT NULL DEFAULT 0`
+(unchanged by PR#528 — these are data columns; `used_times DEFAULT 0` is a
+data initial value, not an "off switch").
 
 - `Rotate` / `validatePresentedLocked`: when the presented token is within the
-  ReuseInterval grace window AND `Policy.GraceMaxReuses > 0` AND
-  `used_times >= GraceMaxReuses` → cascade revoke + ErrRejected (same path as
-  out-of-window reuse detection)
+  ReuseInterval grace window AND `used_times >= Policy.GraceMaxReuses` →
+  cascade revoke + ErrRejected (same path as out-of-window reuse detection).
+  No zero-`GraceMaxReuses` branch — Policy.Validate rejects zero.
 - On each in-grace re-present, `markGraceUsedSQL` increments `used_times` and sets
   `first_used_at = COALESCE(first_used_at, now)` so the first grace re-use time is
-  preserved for auditing
-- Zero `GraceMaxReuses` (default for pre-016 stores) disables the counter cap
+  preserved for auditing.
+
+### Policy zero-value semantics (PR#528 tightening)
+
+PR#388's `Policy.Validate` accepted `MaxIdle == 0` and `GraceMaxReuses == 0`
+as "feature disabled" so pre-016 stores could opt out. With the migration
+collapsed and the project unconstrained by external consumers, PR#528
+collapses the dual semantics:
+
+- `Validate` now requires `MaxIdle > 0` and `GraceMaxReuses > 0` (along with
+  the existing `MaxAge > 0` and `ReuseInterval >= 0` rules). Zero is invalid.
+- `runtime/auth/refresh/types.go`'s `idleFarFuture` 10-year sentinel is removed.
+  `idleDeadline()` is unconditionally `now + Policy.MaxIdle`.
+- `refresh_store.go` `if MaxIdle > 0 &&` / `if GraceMaxReuses > 0 &&` guards
+  are removed. The store always enforces both.
+- All `refresh.Policy{}` construction sites in production and tests are
+  updated to provide `MaxIdle: refresh.DefaultMaxIdle` and
+  `GraceMaxReuses: refresh.DefaultGraceMaxReuses` (or per-test values when
+  the test asserts the corresponding behavior).
 
 **Default values** (in `runtime/auth/refresh/types.go`):
 - `DefaultMaxIdle = 30 * 24 * time.Hour` (30 days, matching Zitadel session TTL)
 - `DefaultGraceMaxReuses = 3` (tolerates SPA double-submit + network retry)
+- `CascadeRevokeTimeout = 5 * time.Second` (per-call detached deadline for
+  cascade revoke; see X15)
+
+These constants are exported so callers can use them as named values; they
+are **not** implicit defaults applied by `Validate`.
 
 ---
 
@@ -175,15 +277,23 @@ Migration 016 adds `first_used_at TIMESTAMPTZ NULL` and `used_times INT NOT NULL
 - The grace counter means T10 (100 concurrent Rotate) uses `GraceMaxReuses=200` in
   the storetest contract so the concurrent-CAS property is preserved for this test.
   Production deployments with `GraceMaxReuses=3` cap concurrent grace retries to 3.
-- Migration 016 is additive (ALTER TABLE ADD COLUMN IF NOT EXISTS + nullable/default
-  columns). No data migration needed; old rows get the 30-day idle default.
-- Stores that have not applied migration 016 must set `Policy.MaxIdle=0` and
-  `Policy.GraceMaxReuses=0` to disable the new checks at the application layer.
+- PR#528 modifies migration 016 in place (drops the `idle_expires_at`
+  `DEFAULT`). The project is undeployed and goose stores `version_id`+`tstamp`,
+  not file hash; CI is ephemeral; dev environments need `goose reset` once.
+  This is the simpler alternative to a one-line 017 "DROP DEFAULT" migration
+  that would forever carry the original mismatch in schema history.
+- Cascade revoke takes a hard 5-second timeout (`CascadeRevokeTimeout`). If
+  PG cascade SQL exceeds 5s under load, the cascade fails with
+  `context.DeadlineExceeded` and the revoke is logged + retried by upstream
+  (no automatic retry from store; security event still surfaces).
 
 ---
 
 ## References
 
+- golang/go `context.WithoutCancel` proposal #40221 — detach helper precedent
+- hashicorp/vault `vault/token_store.go` `revokeInternal` — process-level
+  detached `quitContext` pattern
 - ory/hydra `persistence/sql/persister_oauth2.go` — reuse-detection + grace window
 - zitadel `internal/api/oidc/token_refresh.go` — idle TTL per-request reset
 - ory/fosite `handler/oauth2/refresh.go` — COALESCE grace guard

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
 // ---------------------------------------------------------------------------
@@ -583,7 +584,7 @@ func NotifySettlement(
 					slog.LogAttrs(ctx, slog.LevelError, "outbox: settlement observer panicked",
 						slog.String("topic", entry.Topic),
 						slog.String("entry_id", entry.ID),
-						slog.Any("panic", r))
+						slog.Any("panic", redaction.RedactAny(r)))
 				}
 			}()
 			observer.ObserveSettlement(ctx, obs)

--- a/pkg/ctxutil/detach.go
+++ b/pkg/ctxutil/detach.go
@@ -1,0 +1,36 @@
+// Package ctxutil provides small context.Context helpers for crossing
+// cancellation boundaries that the standard library does not directly model.
+//
+// Scope: critical-write paths (security cascade revoke, compensating cleanup,
+// audit flush) where caller cancellation must NOT abort the write. dev/debug
+// scenarios that just want "ignore cancel" should use stdlib
+// context.WithoutCancel directly; this package layers a bounded timeout on
+// top so detached writes cannot leak goroutines.
+//
+// ref: golang/go context.WithoutCancel proposal#40221
+// ref: hashicorp/vault vault/token_store.go (quitContext detached pattern)
+package ctxutil
+
+import (
+	"context"
+	"time"
+)
+
+// WithDetachedTimeout returns a context that inherits all Values from parent
+// (trace IDs, auth principal, request id) but is NOT canceled when parent is
+// canceled, and carries its own absolute deadline.
+//
+// Use this for critical writes that must complete regardless of caller
+// cancellation: cascade revoke on reuse detection, compensating cleanup,
+// audit log flush. Do NOT use for happy-path reads/writes — caller
+// cancellation usually carries useful "stop wasting work" signal.
+//
+// The returned cancel must always be called (typically via defer) to release
+// the timer regardless of which way the context is finished.
+//
+// Implementation: context.WithoutCancel breaks the cancel chain (Done() is
+// nil-channel, Err() is nil) while preserving Value lookup; WithTimeout adds
+// a fresh deadline on top.
+func WithDetachedTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), timeout)
+}

--- a/pkg/ctxutil/detach_test.go
+++ b/pkg/ctxutil/detach_test.go
@@ -7,13 +7,29 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/ctxutil"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+)
+
+const (
+	// detachLongTimeout is generous enough that no test path should ever hit
+	// it; used as the parent timeout in cases where the test only observes
+	// short waits.
+	detachLongTimeout = testtime.D5s
+	// detachWaitObserve is a short wait used to verify a Done channel does
+	// NOT fire (i.e. detach succeeded).
+	detachWaitObserve = testtime.D50ms
+	// detachShortDeadline forces the timeout to fire within the test budget.
+	detachShortDeadline = testtime.D30ms
+	// detachWaitForFire is the maximum wait before declaring the timeout did
+	// not fire.
+	detachWaitForFire = testtime.D200ms
 )
 
 func TestWithDetachedTimeout_ParentCancelDoesNotPropagate(t *testing.T) {
 	t.Parallel()
 
 	parent, parentCancel := context.WithCancel(context.Background())
-	detached, cancel := ctxutil.WithDetachedTimeout(parent, 5*time.Second)
+	detached, cancel := ctxutil.WithDetachedTimeout(parent, detachLongTimeout)
 	defer cancel()
 
 	parentCancel()
@@ -21,7 +37,7 @@ func TestWithDetachedTimeout_ParentCancelDoesNotPropagate(t *testing.T) {
 	select {
 	case <-detached.Done():
 		t.Error("expected detached ctx to remain live after parent cancel")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(detachWaitObserve):
 		// expected: detached is not canceled by parent
 	}
 
@@ -33,14 +49,14 @@ func TestWithDetachedTimeout_ParentCancelDoesNotPropagate(t *testing.T) {
 func TestWithDetachedTimeout_TimeoutFires(t *testing.T) {
 	t.Parallel()
 
-	detached, cancel := ctxutil.WithDetachedTimeout(context.Background(), 30*time.Millisecond)
+	detached, cancel := ctxutil.WithDetachedTimeout(context.Background(), detachShortDeadline)
 	defer cancel()
 
 	select {
 	case <-detached.Done():
 		// expected
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("expected detached ctx timeout to fire within 200ms")
+	case <-time.After(detachWaitForFire):
+		t.Fatal("expected detached ctx timeout to fire within wait budget")
 	}
 
 	if !errors.Is(detached.Err(), context.DeadlineExceeded) {
@@ -54,7 +70,7 @@ func TestWithDetachedTimeout_PreservesParentValues(t *testing.T) {
 	type ctxKey struct{}
 
 	parent := context.WithValue(context.Background(), ctxKey{}, "trace-123")
-	detached, cancel := ctxutil.WithDetachedTimeout(parent, time.Second)
+	detached, cancel := ctxutil.WithDetachedTimeout(parent, detachLongTimeout)
 	defer cancel()
 
 	if got := detached.Value(ctxKey{}); got != "trace-123" {
@@ -65,14 +81,14 @@ func TestWithDetachedTimeout_PreservesParentValues(t *testing.T) {
 func TestWithDetachedTimeout_CancelFuncReleasesResources(t *testing.T) {
 	t.Parallel()
 
-	detached, cancel := ctxutil.WithDetachedTimeout(context.Background(), 5*time.Second)
+	detached, cancel := ctxutil.WithDetachedTimeout(context.Background(), detachLongTimeout)
 
 	cancel()
 
 	select {
 	case <-detached.Done():
 		// expected: cancel() closes Done channel
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(detachWaitObserve):
 		t.Fatal("expected Done to be closed after cancel()")
 	}
 
@@ -87,13 +103,13 @@ func TestWithDetachedTimeout_AlreadyCanceledParent(t *testing.T) {
 	parent, parentCancel := context.WithCancel(context.Background())
 	parentCancel() // cancel before creating detached
 
-	detached, cancel := ctxutil.WithDetachedTimeout(parent, time.Second)
+	detached, cancel := ctxutil.WithDetachedTimeout(parent, detachLongTimeout)
 	defer cancel()
 
 	select {
 	case <-detached.Done():
 		t.Error("expected detached ctx to remain live even when parent was already canceled")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(detachWaitObserve):
 		// expected: detach cuts the already-canceled parent
 	}
 }

--- a/pkg/ctxutil/detach_test.go
+++ b/pkg/ctxutil/detach_test.go
@@ -22,7 +22,7 @@ func TestWithDetachedTimeout_ParentCancelDoesNotPropagate(t *testing.T) {
 	case <-detached.Done():
 		t.Error("expected detached ctx to remain live after parent cancel")
 	case <-time.After(50 * time.Millisecond):
-		// expected: detached is not cancelled by parent
+		// expected: detached is not canceled by parent
 	}
 
 	if detached.Err() != nil {
@@ -81,7 +81,7 @@ func TestWithDetachedTimeout_CancelFuncReleasesResources(t *testing.T) {
 	}
 }
 
-func TestWithDetachedTimeout_AlreadyCancelledParent(t *testing.T) {
+func TestWithDetachedTimeout_AlreadyCanceledParent(t *testing.T) {
 	t.Parallel()
 
 	parent, parentCancel := context.WithCancel(context.Background())
@@ -92,8 +92,8 @@ func TestWithDetachedTimeout_AlreadyCancelledParent(t *testing.T) {
 
 	select {
 	case <-detached.Done():
-		t.Error("expected detached ctx to remain live even when parent was already cancelled")
+		t.Error("expected detached ctx to remain live even when parent was already canceled")
 	case <-time.After(50 * time.Millisecond):
-		// expected: detach cuts the already-cancelled parent
+		// expected: detach cuts the already-canceled parent
 	}
 }

--- a/pkg/ctxutil/detach_test.go
+++ b/pkg/ctxutil/detach_test.go
@@ -1,0 +1,99 @@
+package ctxutil_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/ctxutil"
+)
+
+func TestWithDetachedTimeout_ParentCancelDoesNotPropagate(t *testing.T) {
+	t.Parallel()
+
+	parent, parentCancel := context.WithCancel(context.Background())
+	detached, cancel := ctxutil.WithDetachedTimeout(parent, 5*time.Second)
+	defer cancel()
+
+	parentCancel()
+
+	select {
+	case <-detached.Done():
+		t.Error("expected detached ctx to remain live after parent cancel")
+	case <-time.After(50 * time.Millisecond):
+		// expected: detached is not cancelled by parent
+	}
+
+	if detached.Err() != nil {
+		t.Errorf("detached.Err() = %v, want nil (timeout not yet reached)", detached.Err())
+	}
+}
+
+func TestWithDetachedTimeout_TimeoutFires(t *testing.T) {
+	t.Parallel()
+
+	detached, cancel := ctxutil.WithDetachedTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	select {
+	case <-detached.Done():
+		// expected
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected detached ctx timeout to fire within 200ms")
+	}
+
+	if !errors.Is(detached.Err(), context.DeadlineExceeded) {
+		t.Errorf("detached.Err() = %v, want context.DeadlineExceeded", detached.Err())
+	}
+}
+
+func TestWithDetachedTimeout_PreservesParentValues(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+
+	parent := context.WithValue(context.Background(), ctxKey{}, "trace-123")
+	detached, cancel := ctxutil.WithDetachedTimeout(parent, time.Second)
+	defer cancel()
+
+	if got := detached.Value(ctxKey{}); got != "trace-123" {
+		t.Errorf("detached.Value(ctxKey{}) = %v, want %q", got, "trace-123")
+	}
+}
+
+func TestWithDetachedTimeout_CancelFuncReleasesResources(t *testing.T) {
+	t.Parallel()
+
+	detached, cancel := ctxutil.WithDetachedTimeout(context.Background(), 5*time.Second)
+
+	cancel()
+
+	select {
+	case <-detached.Done():
+		// expected: cancel() closes Done channel
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("expected Done to be closed after cancel()")
+	}
+
+	if !errors.Is(detached.Err(), context.Canceled) {
+		t.Errorf("detached.Err() after cancel() = %v, want context.Canceled", detached.Err())
+	}
+}
+
+func TestWithDetachedTimeout_AlreadyCancelledParent(t *testing.T) {
+	t.Parallel()
+
+	parent, parentCancel := context.WithCancel(context.Background())
+	parentCancel() // cancel before creating detached
+
+	detached, cancel := ctxutil.WithDetachedTimeout(parent, time.Second)
+	defer cancel()
+
+	select {
+	case <-detached.Done():
+		t.Error("expected detached ctx to remain live even when parent was already cancelled")
+	case <-time.After(50 * time.Millisecond):
+		// expected: detach cuts the already-cancelled parent
+	}
+}

--- a/pkg/redaction/redaction.go
+++ b/pkg/redaction/redaction.go
@@ -187,14 +187,42 @@ func RedactError(err error) error {
 // ref: hashicorp/vault audit log_raw=false default; ADR
 // docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md §8.
 func RedactPanic(v any) string {
-	switch x := v.(type) {
-	case nil:
+	if v == nil {
 		return "<nil>"
+	}
+	switch x := RedactAny(v).(type) {
 	case error:
-		return RedactString(x.Error())
+		return x.Error()
+	case string:
+		return x
+	default:
+		return fmt.Sprint(x)
+	}
+}
+
+// RedactAny scrubs sensitive substrings from arbitrary panic-style payloads
+// before they reach observability backends. Three branches:
+//
+//   - nil → nil
+//   - error → RedactError(e)
+//   - string → RedactString(s)
+//   - other → RedactString(fmt.Sprint(v)) (covers fmt.Stringer, structs,
+//     primitive types; fail-closed: stringify and mask, never echo raw).
+//
+// Intended for `slog.Any("panic", redaction.RedactAny(r))` in panic recovery
+// blocks where r is `any` returned from recover(). The same regex pipeline as
+// RedactString applies, so the field-set and over-mask trade-offs documented
+// at package level apply uniformly.
+func RedactAny(v any) any {
+	if v == nil {
+		return nil
+	}
+	switch x := v.(type) {
+	case error:
+		return RedactError(x)
 	case string:
 		return RedactString(x)
 	default:
-		return RedactString(fmt.Sprintf("%v", v))
+		return RedactString(fmt.Sprint(x))
 	}
 }

--- a/pkg/redaction/redaction.go
+++ b/pkg/redaction/redaction.go
@@ -48,11 +48,20 @@ var connectionStringPattern = regexp.MustCompile(
 	`(?i)(connection[_ ]?string)\s*[:=]\s*\S+`,
 )
 
+// sensitiveKeyPattern is the single source for key names masked by both
+// defaultPattern and quotedJSONPattern. Keep specific token aliases before the
+// generic `token` entry so JSON and key=value coverage evolves together.
+const sensitiveKeyPattern = `password|passwd|pwd|secret|` +
+	`access[_-]?token|refresh[_-]?token|id[_-]?token|token|` +
+	`authorization|connection[_ ]?string|api[_-]?key|bearer|` +
+	`private[_-]?key|signing[_-]?key|dsn`
+
 // defaultPattern matches single-token `key=value` / `key: value` forms.
 //
-// 字段集 = outbox 历史集 (password/passwd/secret/token/dsn) + wrapper attack
-// surface (api[_-]?key / bearer / private[_-]?key / signing[_-]?key) + pwd
-// (SQL Server / ODBC 连接字符串 password 缩写).
+// 字段集 = outbox 历史集 (password/passwd/secret/token/dsn) + OAuth/OIDC token
+// aliases (accessToken/refreshToken/id_token) + wrapper attack surface
+// (authorization / connection string / api[_-]?key / bearer / private[_-]?key
+// / signing[_-]?key) + pwd (SQL Server / ODBC 连接字符串 password 缩写).
 //
 // dsn 保留：PG 连接错误 message 常含完整 DSN（含明文密码 postgres://u:pwd@host），
 // 是真实泄漏面。
@@ -61,15 +70,13 @@ var connectionStringPattern = regexp.MustCompile(
 // 会被 mask。这是 fail-closed 的代价 — 取舍偏向「宁可掩盖目录也不泄漏 SQL
 // Server `Pwd=secret`」。dev 调试需要原始 working directory 时走 slog 结构化字段
 // (e.g. `slog.String("workdir", v)`)，不靠 trace span。
-var defaultPattern = regexp.MustCompile(
-	`(?i)(password|passwd|pwd|secret|token|api[_-]?key|bearer|private[_-]?key|signing[_-]?key|dsn)\s*[:=]\s*\S+`,
-)
+var defaultPattern = regexp.MustCompile(`(?i)(` + sensitiveKeyPattern + `)\s*[:=]\s*\S+`)
 
 // quotedJSONPattern handles common JSON-in-error fragments such as
 // `{"password":"..."}`. It is separate from defaultPattern because the quote
 // between the key and `:` is valid JSON but not a key=value separator.
 var quotedJSONPattern = regexp.MustCompile(
-	`(?i)("(?:password|passwd|pwd|secret|token|api[_-]?key|bearer|private[_-]?key|signing[_-]?key|dsn)"\s*:\s*)"(?:\\.|[^"\\])*"`,
+	`(?i)("(?:` + sensitiveKeyPattern + `)"\s*:\s*)"(?:\\.|[^"\\])*"`,
 )
 
 // allPatterns runs in order. ORDER IS A CORRECTNESS CONSTRAINT, not a

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -340,62 +340,68 @@ func TestMask_ConstantValue(t *testing.T) {
 func TestRedactAny(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil_in_nil_out", func(t *testing.T) {
-		t.Parallel()
-		got := redaction.RedactAny(nil)
-		if got != nil {
-			t.Errorf("RedactAny(nil) = %v, want nil", got)
-		}
-	})
+	t.Run("nil_in_nil_out", assertRedactAnyNil)
+	t.Run("error_branch_redacts", assertRedactAnyErrorRedacts)
+	t.Run("string_branch_redacts", assertRedactAnyStringRedacts)
+	t.Run("panic_value_struct_stringified_redacts", assertRedactAnyStructStringifiedRedacts)
+	t.Run("int_passthrough_no_secret", assertRedactAnyIntPassthrough)
+}
 
-	t.Run("error_branch_redacts", func(t *testing.T) {
-		t.Parallel()
-		err := errors.New("password=hunter2")
-		got := redaction.RedactAny(err)
-		gotErr, ok := got.(error)
-		if !ok {
-			t.Fatalf("RedactAny(error) returned %T, want error", got)
-		}
-		if gotErr.Error() != "password=<REDACTED>" {
-			t.Errorf("RedactAny(error).Error() = %q, want %q", gotErr.Error(), "password=<REDACTED>")
-		}
-	})
+func assertRedactAnyNil(t *testing.T) {
+	t.Parallel()
+	got := redaction.RedactAny(nil)
+	if got != nil {
+		t.Errorf("RedactAny(nil) = %v, want nil", got)
+	}
+}
 
-	t.Run("string_branch_redacts", func(t *testing.T) {
-		t.Parallel()
-		got := redaction.RedactAny("token=abc.def")
-		gotStr, ok := got.(string)
-		if !ok {
-			t.Fatalf("RedactAny(string) returned %T, want string", got)
-		}
-		if gotStr != "token=<REDACTED>" {
-			t.Errorf("RedactAny(string) = %q, want %q", gotStr, "token=<REDACTED>")
-		}
-	})
+func assertRedactAnyErrorRedacts(t *testing.T) {
+	t.Parallel()
+	err := errors.New("password=hunter2")
+	got := redaction.RedactAny(err)
+	gotErr, ok := got.(error)
+	if !ok {
+		t.Fatalf("RedactAny(error) returned %T, want error", got)
+	}
+	if gotErr.Error() != "password=<REDACTED>" {
+		t.Errorf("RedactAny(error).Error() = %q, want %q", gotErr.Error(), "password=<REDACTED>")
+	}
+}
 
-	t.Run("panic_value_struct_stringified_redacts", func(t *testing.T) {
-		t.Parallel()
-		type panicVal struct{ msg string }
-		v := panicVal{msg: "secret=hunter2"}
-		got := redaction.RedactAny(v)
-		s := fmt.Sprint(got)
-		if strings.Contains(s, "hunter2") {
-			t.Errorf("RedactAny(struct) still contains sensitive value in %q", s)
-		}
-		if !strings.Contains(s, "<REDACTED>") {
-			t.Errorf("RedactAny(struct) = %q, want it to contain <REDACTED>", s)
-		}
-	})
+func assertRedactAnyStringRedacts(t *testing.T) {
+	t.Parallel()
+	got := redaction.RedactAny("token=abc.def")
+	gotStr, ok := got.(string)
+	if !ok {
+		t.Fatalf("RedactAny(string) returned %T, want string", got)
+	}
+	if gotStr != "token=<REDACTED>" {
+		t.Errorf("RedactAny(string) = %q, want %q", gotStr, "token=<REDACTED>")
+	}
+}
 
-	t.Run("int_passthrough_no_secret", func(t *testing.T) {
-		t.Parallel()
-		got := redaction.RedactAny(42)
-		s := fmt.Sprint(got)
-		if strings.Contains(s, "<REDACTED>") {
-			t.Errorf("RedactAny(42) = %q, unexpectedly contains <REDACTED>", s)
-		}
-		if s != "42" {
-			t.Errorf("RedactAny(42) = %q, want %q", s, "42")
-		}
-	})
+func assertRedactAnyStructStringifiedRedacts(t *testing.T) {
+	t.Parallel()
+	type panicVal struct{ msg string }
+	v := panicVal{msg: "secret=hunter2"}
+	got := redaction.RedactAny(v)
+	s := fmt.Sprint(got)
+	if strings.Contains(s, "hunter2") {
+		t.Errorf("RedactAny(struct) still contains sensitive value in %q", s)
+	}
+	if !strings.Contains(s, "<REDACTED>") {
+		t.Errorf("RedactAny(struct) = %q, want it to contain <REDACTED>", s)
+	}
+}
+
+func assertRedactAnyIntPassthrough(t *testing.T) {
+	t.Parallel()
+	got := redaction.RedactAny(42)
+	s := fmt.Sprint(got)
+	if strings.Contains(s, "<REDACTED>") {
+		t.Errorf("RedactAny(42) = %q, unexpectedly contains <REDACTED>", s)
+	}
+	if s != "42" {
+		t.Errorf("RedactAny(42) = %q, want %q", s, "42")
+	}
 }

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -2,6 +2,7 @@ package redaction_test
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -334,4 +335,67 @@ func TestMask_ConstantValue(t *testing.T) {
 	if redaction.Mask != "<REDACTED>" {
 		t.Errorf("Mask = %q, want %q", redaction.Mask, "<REDACTED>")
 	}
+}
+
+func TestRedactAny(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_in_nil_out", func(t *testing.T) {
+		t.Parallel()
+		got := redaction.RedactAny(nil)
+		if got != nil {
+			t.Errorf("RedactAny(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("error_branch_redacts", func(t *testing.T) {
+		t.Parallel()
+		err := errors.New("password=hunter2")
+		got := redaction.RedactAny(err)
+		gotErr, ok := got.(error)
+		if !ok {
+			t.Fatalf("RedactAny(error) returned %T, want error", got)
+		}
+		if gotErr.Error() != "password=<REDACTED>" {
+			t.Errorf("RedactAny(error).Error() = %q, want %q", gotErr.Error(), "password=<REDACTED>")
+		}
+	})
+
+	t.Run("string_branch_redacts", func(t *testing.T) {
+		t.Parallel()
+		got := redaction.RedactAny("token=abc.def")
+		gotStr, ok := got.(string)
+		if !ok {
+			t.Fatalf("RedactAny(string) returned %T, want string", got)
+		}
+		if gotStr != "token=<REDACTED>" {
+			t.Errorf("RedactAny(string) = %q, want %q", gotStr, "token=<REDACTED>")
+		}
+	})
+
+	t.Run("panic_value_struct_stringified_redacts", func(t *testing.T) {
+		t.Parallel()
+		type panicVal struct{ msg string }
+		v := panicVal{msg: "secret=hunter2"}
+		got := redaction.RedactAny(v)
+		s := fmt.Sprint(got)
+		if strings.Contains(s, "hunter2") {
+			t.Errorf("RedactAny(struct) still contains sensitive value in %q", s)
+		}
+		if !strings.Contains(s, "<REDACTED>") {
+			t.Errorf("RedactAny(struct) = %q, want it to contain <REDACTED>", s)
+		}
+	})
+
+	t.Run("int_passthrough_no_secret", func(t *testing.T) {
+		t.Parallel()
+		got := redaction.RedactAny(42)
+		s := fmt.Sprint(got)
+		if strings.Contains(s, "<REDACTED>") {
+			t.Errorf("RedactAny(42) = %q, unexpectedly contains <REDACTED>", s)
+		}
+		if s != "42" {
+			t.Errorf("RedactAny(42) = %q, want %q", s, "42")
+		}
+	})
 }

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -44,6 +44,31 @@ func TestRedactString(t *testing.T) {
 			want: "upstream 401: token=<REDACTED>",
 		},
 		{
+			name: "accessToken_camel",
+			in:   "oauth exchange failed: accessToken=access-value",
+			want: "oauth exchange failed: accessToken=<REDACTED>",
+		},
+		{
+			name: "refreshToken_camel",
+			in:   "oauth exchange failed: refreshToken=1//0g",
+			want: "oauth exchange failed: refreshToken=<REDACTED>",
+		},
+		{
+			name: "access_token_snake",
+			in:   "oauth exchange failed: access_token=access-value",
+			want: "oauth exchange failed: access_token=<REDACTED>",
+		},
+		{
+			name: "refresh_token_snake",
+			in:   "oauth exchange failed: refresh_token=1//0g",
+			want: "oauth exchange failed: refresh_token=<REDACTED>",
+		},
+		{
+			name: "id_token_snake",
+			in:   "oauth exchange failed: id_token=eyJhbGc",
+			want: "oauth exchange failed: id_token=<REDACTED>",
+		},
+		{
 			name: "authorization_colonSpace",
 			in:   "Authorization: Bearer abc.def.ghi",
 			want: "Authorization: <REDACTED>",
@@ -180,6 +205,41 @@ func TestRedactString(t *testing.T) {
 			name: "json_token_quoted_with_spaces",
 			in:   `{"token" : "abc.def.ghi","ok":true}`,
 			want: `{"token" : "<REDACTED>","ok":true}`,
+		},
+		{
+			name: "json_accessToken_quoted",
+			in:   `{"accessToken":"access-value","user":"alice"}`,
+			want: `{"accessToken":"<REDACTED>","user":"alice"}`,
+		},
+		{
+			name: "json_refreshToken_quoted",
+			in:   `{"refreshToken":"1//0g","user":"alice"}`,
+			want: `{"refreshToken":"<REDACTED>","user":"alice"}`,
+		},
+		{
+			name: "json_access_token_quoted",
+			in:   `{"access_token":"access-value","user":"alice"}`,
+			want: `{"access_token":"<REDACTED>","user":"alice"}`,
+		},
+		{
+			name: "json_refresh_token_quoted",
+			in:   `{"refresh_token":"1//0g","user":"alice"}`,
+			want: `{"refresh_token":"<REDACTED>","user":"alice"}`,
+		},
+		{
+			name: "json_id_token_quoted",
+			in:   `{"id_token":"eyJhbGc","user":"alice"}`,
+			want: `{"id_token":"<REDACTED>","user":"alice"}`,
+		},
+		{
+			name: "json_authorization_quoted",
+			in:   `{"authorization":"Bearer abc.def.ghi","user":"alice"}`,
+			want: `{"authorization":"<REDACTED>","user":"alice"}`,
+		},
+		{
+			name: "json_connection_string_quoted",
+			in:   `{"connection_string":"Server=foo;Pwd=bar","ok":true}`,
+			want: `{"connection_string":"<REDACTED>","ok":true}`,
 		},
 		{
 			name: "json_secret_escaped_quote",

--- a/runtime/auth/refresh/gc_worker_test.go
+++ b/runtime/auth/refresh/gc_worker_test.go
@@ -67,6 +67,10 @@ func (s *gcStoreSpy) RevokeSession(context.Context, string) error {
 	return errors.New("not implemented")
 }
 
+func (s *gcStoreSpy) RevokeSessionDetached(context.Context, string) error {
+	return errors.New("not implemented")
+}
+
 func (s *gcStoreSpy) RevokeUser(context.Context, string) error {
 	return errors.New("not implemented")
 }

--- a/runtime/auth/refresh/memstore/store.go
+++ b/runtime/auth/refresh/memstore/store.go
@@ -252,6 +252,13 @@ func (s *store) RevokeSession(_ context.Context, sessionID string) error {
 	return nil
 }
 
+// RevokeSessionDetached marks every row in the session_id lineage as revoked.
+// Memstore has no ambient transaction/cancellation boundary, so it shares the
+// same locked critical section as RevokeSession.
+func (s *store) RevokeSessionDetached(ctx context.Context, sessionID string) error {
+	return s.RevokeSession(ctx, sessionID)
+}
+
 // RevokeUser marks every row owned by subjectID as revoked.
 func (s *store) RevokeUser(_ context.Context, subjectID string) error {
 	now := s.clock.Now()

--- a/runtime/auth/refresh/memstore/store.go
+++ b/runtime/auth/refresh/memstore/store.go
@@ -40,7 +40,7 @@ type tokenRecord struct {
 	verifierHash  [sha256.Size]byte
 	createdAt     time.Time
 	expiresAt     time.Time
-	idleExpiresAt time.Time // sliding window; zero disables idle check
+	idleExpiresAt time.Time // sliding window; always set (Policy.MaxIdle required positive)
 	rotatedAt     time.Time // zero means live-latest
 	revokedAt     time.Time // zero means not revoked
 	firstUsedAt   time.Time // zero until first grace re-use
@@ -120,13 +120,10 @@ func (s *store) Issue(_ context.Context, sessionID, subjectID string) (string, *
 	return refresh.EncodeOpaque(sel, ver), rec.toToken(), nil
 }
 
-// idleDeadline returns now + MaxIdle when configured, or a zero time when
-// MaxIdle is zero (idle check disabled).
+// idleDeadline returns now + MaxIdle. Policy.MaxIdle is guaranteed positive by
+// Validate(), so no zero-check is needed.
 func (s *store) idleDeadline(now time.Time) time.Time {
-	if s.policy.MaxIdle > 0 {
-		return now.Add(s.policy.MaxIdle)
-	}
-	return time.Time{}
+	return now.Add(s.policy.MaxIdle)
 }
 
 // Peek validates the presented wire token without advancing the lineage.
@@ -213,14 +210,16 @@ func (s *store) validatePresentedLocked(sel, ver []byte) (*tokenRecord, error) {
 	if !rec.expiresAt.After(now) {
 		return nil, rejectWithReason("expired")
 	}
-	// X12: idle-expiry check (zero idleExpiresAt means idle check disabled).
-	if !rec.idleExpiresAt.IsZero() && s.policy.MaxIdle > 0 && !rec.idleExpiresAt.After(now) {
+	// X12: idle-expiry check. Policy.MaxIdle is required (must be positive),
+	// so idleExpiresAt is always set to a meaningful future time.
+	if !rec.idleExpiresAt.After(now) {
 		return nil, rejectWithReason("idle_expired")
 	}
 
 	if rec.isRotated() {
-		// X14: grace counter cap check.
-		if s.policy.GraceMaxReuses > 0 && rec.usedTimes >= s.policy.GraceMaxReuses {
+		// X14: grace counter cap check. Policy.GraceMaxReuses is required (must
+		// be positive) — no zero-check needed.
+		if rec.usedTimes >= s.policy.GraceMaxReuses {
 			s.revokeSessionLocked(rec.sessionID, now)
 			slog.Error("refresh token grace counter exhausted",
 				slog.String("session_id", rec.sessionID),
@@ -267,9 +266,7 @@ func (s *store) RevokeUser(_ context.Context, subjectID string) error {
 }
 
 // GC removes rows whose effective expiry is before olderThan. The effective
-// expiry is LEAST(expiresAt, idleExpiresAt) when idleExpiresAt is non-zero,
-// or just expiresAt when idle_expires_at is zero (pre-016 / disabled).
-// L0 best-effort.
+// expiry is LEAST(expiresAt, idleExpiresAt). L0 best-effort.
 func (s *store) GC(_ context.Context, olderThan time.Time) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -277,7 +274,7 @@ func (s *store) GC(_ context.Context, olderThan time.Time) (int, error) {
 	removed := 0
 	for _, rec := range s.rows {
 		effectiveExpiry := rec.expiresAt
-		if !rec.idleExpiresAt.IsZero() && rec.idleExpiresAt.Before(effectiveExpiry) {
+		if rec.idleExpiresAt.Before(effectiveExpiry) {
 			effectiveExpiry = rec.idleExpiresAt
 		}
 		if effectiveExpiry.Before(olderThan) {

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -88,8 +88,8 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 		{
 			name: "zero_MaxIdle",
 			policy: refresh.Policy{
-				ReuseInterval:  time.Second,
-				MaxAge:         time.Hour,
+				ReuseInterval: time.Second,
+				MaxAge:        time.Hour,
 				// MaxIdle intentionally zero
 				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
 			},

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -46,15 +46,18 @@ func (*typedNilReader) Read([]byte) (int, error) {
 	return 0, errTypedNilReaderUsed
 }
 
-// TestMemStoreContract runs the full C1-C7 contract test suite (T1-T12) against
+// TestMemStoreContract runs the shared refresh store contract suites against
 // the in-memory store.
 func TestMemStoreContract(t *testing.T) {
-	storetest.RunContractSuite(t, func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
+	factory := func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
 		clk := storetest.NewFakeClock(baseTime)
 		store, err := memstore.New(policy, clk, nil)
 		require.NoError(t, err)
 		return store, clk
-	})
+	}
+
+	storetest.RunContractSuite(t, factory)
+	storetest.RunIdleExpireContractSuite(t, factory)
 }
 
 func TestNewRejectsInvalidConfig(t *testing.T) {

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -85,6 +85,26 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 			policy: refresh.Policy{ReuseInterval: -time.Second, MaxAge: time.Hour},
 			clock:  clk,
 		},
+		{
+			name: "zero_MaxIdle",
+			policy: refresh.Policy{
+				ReuseInterval:  time.Second,
+				MaxAge:         time.Hour,
+				// MaxIdle intentionally zero
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+			},
+			clock: clk,
+		},
+		{
+			name: "zero_GraceMaxReuses",
+			policy: refresh.Policy{
+				ReuseInterval: time.Second,
+				MaxAge:        time.Hour,
+				MaxIdle:       refresh.DefaultMaxIdle,
+				// GraceMaxReuses intentionally zero
+			},
+			clock: clk,
+		},
 	}
 
 	for _, tc := range tests {
@@ -133,8 +153,21 @@ func TestNewDefaultsTypedNilRandReader(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewRejectsInvalidPolicyAndNilClock(t *testing.T) {
-	// empty policy (zero MaxAge, zero ReuseInterval) with nil clock
-	_, err := memstore.New(refresh.Policy{}, nil, nil)
-	require.Error(t, err, "New with invalid policy and nil clock must return error")
+func TestNewRejectsNilClock(t *testing.T) {
+	t.Parallel()
+	validPolicy := refresh.Policy{
+		ReuseInterval:  time.Second,
+		MaxAge:         time.Hour,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
+	_, err := memstore.New(validPolicy, nil, nil)
+	require.Error(t, err, "New with nil clock must return error")
+}
+
+func TestNewRejectsEmptyPolicy(t *testing.T) {
+	t.Parallel()
+	fakeClock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	_, err := memstore.New(refresh.Policy{}, fakeClock, nil)
+	require.Error(t, err, "New with empty Policy must return error")
 }

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -66,9 +66,14 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 		clock  clock.Clock
 	}{
 		{
-			name:   "nil clock",
-			policy: refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour},
-			clock:  nil,
+			name: "nil clock",
+			policy: refresh.Policy{
+				ReuseInterval:  time.Second,
+				MaxAge:         time.Hour,
+				MaxIdle:        refresh.DefaultMaxIdle,
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+			},
+			clock: nil,
 		},
 		{
 			name:   "non-positive max age",
@@ -94,7 +99,12 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 func TestNewRejectsTypedNilClock(t *testing.T) {
 	var clock *typedNilClock
 	store, err := memstore.New(
-		refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour},
+		refresh.Policy{
+			ReuseInterval:  time.Second,
+			MaxAge:         time.Hour,
+			MaxIdle:        refresh.DefaultMaxIdle,
+			GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+		},
 		clock,
 		nil,
 	)
@@ -107,7 +117,12 @@ func TestNewDefaultsTypedNilRandReader(t *testing.T) {
 	var reader *typedNilReader
 
 	store, err := memstore.New(
-		refresh.Policy{ReuseInterval: time.Second, MaxAge: time.Hour},
+		refresh.Policy{
+			ReuseInterval:  time.Second,
+			MaxAge:         time.Hour,
+			MaxIdle:        refresh.DefaultMaxIdle,
+			GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+		},
 		clock,
 		reader,
 	)

--- a/runtime/auth/refresh/store.go
+++ b/runtime/auth/refresh/store.go
@@ -64,16 +64,32 @@ type Store interface {
 	Rotate(ctx context.Context, presentedWire string) (wire string, tok *Token, err error)
 
 	// RevokeSession marks every row in the session_id lineage as revoked.
-	// Idempotent — 0 rows affected is not an error. Called by logout and
-	// reuse-detection cascade.
+	// Idempotent — 0 rows affected is not an error. Called by business flows
+	// such as logout, where refresh-chain revoke must share the caller's
+	// transaction boundary with session state and outbox writes.
 	//
 	// Consistency: L1 LocalTx — single UPDATE.
 	RevokeSession(ctx context.Context, sessionID string) error
 
+	// RevokeSessionDetached marks every row in the session_id lineage as
+	// revoked outside the caller's ambient transaction/cancellation boundary.
+	// It is reserved for security/compensation paths where the revoke must
+	// persist even if the triggering request is canceled or the surrounding
+	// business transaction rolls back.
+	//
+	// Consistency: L1 LocalTx — single UPDATE committed independently by
+	// durable implementations. In-memory implementations may share the same
+	// critical section as RevokeSession.
+	RevokeSessionDetached(ctx context.Context, sessionID string) error
+
 	// RevokeUser marks every row belonging to subjectID as revoked.
 	// Called by user-delete, user-lock, and change-password flows to
 	// invalidate every refresh chain owned by the subject in one atomic
-	// statement. Idempotent.
+	// statement. Idempotent. There is intentionally no detached RevokeUser:
+	// these user-level revokes are business state transitions that must remain
+	// atomic with user/session mutations and related outbox writes. Session-
+	// level cascade revoke is split because it also serves security responses
+	// to token reuse and compensating cleanup.
 	//
 	// Consistency: L1 LocalTx — single UPDATE.
 	RevokeUser(ctx context.Context, subjectID string) error

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -176,7 +176,12 @@ func runT3RotateHappyPath(t *testing.T, factory Factory) {
 // yields a distinct sibling child wire (not a replay of the first child).
 // The append-only model preserves idempotency without leaking tokens.
 func runT4GracePeriod(t *testing.T, factory Factory) {
-	policy := refresh.Policy{ReuseInterval: testtime.D5s, MaxAge: storeMaxAge7d}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D5s,
+		MaxAge:         storeMaxAge7d,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	store, clock := factory(t, policy)
 
 	parentWire, _ := mustIssue(t, store, "sess-4", "user-4")
@@ -193,7 +198,12 @@ func runT4GracePeriod(t *testing.T, factory Factory) {
 // runT5ReuseDetection: parent presented beyond ReuseInterval triggers cascade
 // revocation and ErrRejected; subsequent Rotates on the chain also fail.
 func runT5ReuseDetection(t *testing.T, factory Factory) {
-	policy := refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: storeMaxAge7d}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         storeMaxAge7d,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	store, clock := factory(t, policy)
 	ctx := context.Background()
 
@@ -237,7 +247,12 @@ func runT7RevokedToken(t *testing.T, factory Factory) {
 
 // runT8ExpiredToken: clock past MaxAge → ErrRejected.
 func runT8ExpiredToken(t *testing.T, factory Factory) {
-	policy := refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: testtime.D1h}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         testtime.D1h,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	store, clock := factory(t, policy)
 
 	wire, _ := mustIssue(t, store, "sess-8", "user-8")
@@ -325,7 +340,12 @@ func runT10ConcurrentCAS(t *testing.T, factory Factory) {
 
 // runT11ExpiresAtCalc: ExpiresAt == now + MaxAge at Issue time.
 func runT11ExpiresAtCalc(t *testing.T, factory Factory) {
-	policy := refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: storeMaxAge48h}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         storeMaxAge48h,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	store, clock := factory(t, policy)
 
 	now := clock.Now()
@@ -346,7 +366,12 @@ func runT12ErrcodeCategory(t *testing.T) {
 
 // runT13GCRemovesExpired: GC drops rows past expiresAt.
 func runT13GCRemovesExpired(t *testing.T, factory Factory) {
-	policy := refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: testtime.D1h}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         testtime.D1h,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	store, clock := factory(t, policy)
 
 	activeWire, _ := mustIssue(t, store, "sess-13a", "user-13a")
@@ -417,7 +442,12 @@ func runT15AfterRevokeUser(t *testing.T, factory Factory) {
 // yield two distinct child wires (see T4 — this is a stricter assertion
 // on the append-only sibling semantics).
 func runT16GraceInside(t *testing.T, factory Factory) {
-	policy := refresh.Policy{ReuseInterval: testtime.D10s, MaxAge: storeMaxAge7d}
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D10s,
+		MaxAge:         storeMaxAge7d,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
 	store, _ := factory(t, policy)
 
 	parent, _ := mustIssue(t, store, "sess-16", "user-16")
@@ -499,7 +529,12 @@ func runT19PeekDoesNotAdvance(t *testing.T, factory Factory) {
 }
 
 func runT20PeekRejectionParityAndReuseCascade(t *testing.T, factory Factory) {
-	store, clock := factory(t, refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: testtime.D1h})
+	store, clock := factory(t, refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         testtime.D1h,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	})
 	ctx := context.Background()
 
 	_, err := store.Peek(ctx, "malformed")
@@ -515,7 +550,12 @@ func runT20PeekRejectionParityAndReuseCascade(t *testing.T, factory Factory) {
 	_, err = store.Peek(ctx, expiredWire)
 	assert.ErrorIs(t, err, refresh.ErrRejected, "expired Peek must reject like Rotate")
 
-	store, clock = factory(t, refresh.Policy{ReuseInterval: testtime.D2s, MaxAge: testtime.D1h})
+	store, clock = factory(t, refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         testtime.D1h,
+		MaxIdle:        refresh.DefaultMaxIdle,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	})
 	parentWire, _ := mustIssue(t, store, "sess-20-reuse", t20Subject)
 	childWire, _ := mustRotate(t, store, parentWire)
 	clock.Advance(testtime.D3s)

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -580,3 +580,43 @@ func runT21PeekDoesNotConsumeGraceBudget(t *testing.T, factory Factory) {
 
 // Silence unused-imports guard when errcode isn't needed (defensive).
 var _ = errors.Is
+
+// RunIdleExpireContractSuite runs the idle-expiry sub-test against the given
+// factory. It is separate from RunContractSuite so backends can opt in once they
+// support the MaxIdle field (Wave 2 policy enforcement). Both memstore and PG
+// must pass this suite after Wave 2.
+//
+// Test identifiers Tn_IdleExpire_* are the contract for MaxIdle enforcement:
+// a token that has not been rotated within MaxIdle of creation must be rejected
+// with ErrRejected; the rejection reason is idle_expired.
+func RunIdleExpireContractSuite(t *testing.T, factory Factory) {
+	t.Helper()
+	t.Run("Tn_IdleExpire_RejectsAfterMaxIdle", func(t *testing.T) {
+		t.Parallel()
+		runTnIdleExpireRejectsAfterMaxIdle(t, factory)
+	})
+}
+
+// runTnIdleExpireRejectsAfterMaxIdle constructs a store with MaxIdle=1h, issues
+// a token, advances the clock past 1 hour, then calls Rotate and asserts
+// ErrRejected is returned (idle_expired path).
+func runTnIdleExpireRejectsAfterMaxIdle(t *testing.T, factory Factory) {
+	policy := refresh.Policy{
+		ReuseInterval:  testtime.D2s,
+		MaxAge:         storeMaxAge7d,
+		MaxIdle:        1 * time.Hour,
+		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+	}
+	store, clock := factory(t, policy)
+	ctx := context.Background()
+
+	wire, _ := mustIssue(t, store, "sess-idle", "user-idle")
+
+	// Advance past MaxIdle (1 hour + 1 second).
+	clock.Advance(1*time.Hour + time.Second)
+
+	_, _, err := store.Rotate(ctx, wire)
+	if !errors.Is(err, refresh.ErrRejected) {
+		t.Errorf("Rotate after MaxIdle exceeded: got %v, want ErrRejected (idle_expired)", err)
+	}
+}

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -637,14 +637,19 @@ func RunIdleExpireContractSuite(t *testing.T, factory Factory) {
 	})
 }
 
-// runTnIdleExpireRejectsAfterMaxIdle constructs a store with MaxIdle=1h, issues
-// a token, advances the clock past 1 hour, then calls Rotate and asserts
+// idleExpireMaxIdleWindow is the per-test MaxIdle deadline used by the
+// idle-expire contract subtest; one hour is short enough to fit comfortably
+// in the test envelope yet long enough to differ from MaxAge.
+const idleExpireMaxIdleWindow = testtime.D1h
+
+// runTnIdleExpireRejectsAfterMaxIdle constructs a store with the per-test MaxIdle,
+// issues a token, advances the clock past it, then calls Rotate and asserts
 // ErrRejected is returned (idle_expired path).
 func runTnIdleExpireRejectsAfterMaxIdle(t *testing.T, factory Factory) {
 	policy := refresh.Policy{
 		ReuseInterval:  testtime.D2s,
 		MaxAge:         storeMaxAge7d,
-		MaxIdle:        1 * time.Hour,
+		MaxIdle:        idleExpireMaxIdleWindow,
 		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
 	}
 	store, clock := factory(t, policy)
@@ -652,8 +657,8 @@ func runTnIdleExpireRejectsAfterMaxIdle(t *testing.T, factory Factory) {
 
 	wire, _ := mustIssue(t, store, "sess-idle", "user-idle")
 
-	// Advance past MaxIdle (1 hour + 1 second).
-	clock.Advance(1*time.Hour + time.Second)
+	// Advance past MaxIdle.
+	clock.Advance(idleExpireMaxIdleWindow + time.Second)
 
 	_, _, err := store.Rotate(ctx, wire)
 	if !errors.Is(err, refresh.ErrRejected) {

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -632,9 +632,9 @@ func runT22RevokeSessionDetachedIgnoresCallerCancel(t *testing.T, factory Factor
 var _ = errors.Is
 
 // RunIdleExpireContractSuite runs the idle-expiry sub-test against the given
-// factory. It is separate from RunContractSuite so backends can opt in once they
-// support the MaxIdle field (Wave 2 policy enforcement). Both memstore and PG
-// must pass this suite after Wave 2.
+// factory. It stays separate from RunContractSuite so backend contract runners
+// can name the MaxIdle policy coverage explicitly. Both memstore and PG invoke
+// this suite from their main contract tests.
 //
 // Test identifiers Tn_IdleExpire_* are the contract for MaxIdle enforcement:
 // a token that has not been rotated within MaxIdle of creation must be rejected

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -60,14 +60,6 @@ var defaultPolicy = refresh.Policy{
 	GraceMaxReuses: refresh.DefaultGraceMaxReuses,
 }
 
-// disabledIdleGracePolicy documents the intent of inline Policy literals that
-// omit MaxIdle and GraceMaxReuses throughout this suite.  Zero MaxIdle disables
-// idle expiry; zero GraceMaxReuses disables the grace counter cap.  Tests that
-// inline Policy{ReuseInterval, MaxAge} are exercising only the core reuse-window
-// and lifetime logic — not X12 idle-expiry (T19) or X14 grace counter (T20),
-// which have dedicated integration tests.  Using zero values here keeps the
-// test setup minimal and avoids coupling unrelated tests to migration 016 state.
-
 const (
 	t15TargetSubject = "user-A"
 	t15OtherSubject  = "user-B"

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -2,13 +2,14 @@
 // implementations. Backends (memstore, postgres) each run RunContractSuite
 // to prove they honor the same append-only + single-sentinel semantics.
 //
-// Test identifiers T1-T18 map to Store invariants: T1-T2 Issue, T3 Rotate
+// Test identifiers T1-T22 map to Store invariants: T1-T2 Issue, T3 Rotate
 // happy path, T4 grace window, T5 reuse-after-grace, T6-T8 fail-closed
 // rejection paths, T9 RevokeSession cascade, T10 concurrent Rotate CAS,
 // T11 ExpiresAt calculation, T12 errcode sentinel category, T13 GC cleanup,
 // T14 concurrent goroutine race model, T15 reuse-after-grace cascade,
 // T16 grace-inside-interval, T17 parse-failure uniformity, T18 RevokeUser,
-// T19-T20 Peek preflight/rejection, T21 Peek does not consume grace budget.
+// T19-T20 Peek preflight/rejection, T21 Peek does not consume grace budget,
+// T22 detached session revoke.
 package storetest
 
 import (
@@ -125,6 +126,10 @@ func RunContractSuite(t *testing.T, factory Factory) {
 	t.Run("T21_Peek_DoesNotConsumeGraceBudget", func(t *testing.T) {
 		t.Parallel()
 		runT21PeekDoesNotConsumeGraceBudget(t, factory)
+	})
+	t.Run("T22_RevokeSessionDetached_CascadeIgnoresCallerCancel", func(t *testing.T) {
+		t.Parallel()
+		runT22RevokeSessionDetachedIgnoresCallerCancel(t, factory)
 	})
 }
 
@@ -608,6 +613,19 @@ func runT21PeekDoesNotConsumeGraceBudget(t *testing.T, factory Factory) {
 	// Now used_times == GraceMaxReuses. Next Rotate trips the cap.
 	_, _, err := store.Rotate(ctx, parentWire)
 	assert.ErrorIs(t, err, refresh.ErrRejected, "Rotate at used_times == GraceMaxReuses must trigger reuse_detected")
+}
+
+func runT22RevokeSessionDetachedIgnoresCallerCancel(t *testing.T, factory Factory) {
+	store, _ := factory(t, defaultPolicy)
+
+	wire, _ := mustIssue(t, store, "sess-22", "user-22")
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, store.RevokeSessionDetached(canceledCtx, "sess-22"))
+
+	_, _, err := store.Rotate(context.Background(), wire)
+	assert.ErrorIs(t, err, refresh.ErrRejected, "detached revoke must kill the session chain")
 }
 
 // Silence unused-imports guard when errcode isn't needed (defensive).

--- a/runtime/auth/refresh/types.go
+++ b/runtime/auth/refresh/types.go
@@ -71,9 +71,9 @@ const (
 //
 // MaxAge bounds Token.ExpiresAt - Token.CreatedAt.
 //
-// MaxIdle is the sliding-window idle-expiry duration. Every Rotate call
-// resets the idle clock on the parent row. A token that is not rotated within
-// MaxIdle of its last rotation (or creation) is rejected as idle-expired.
+// MaxIdle is the sliding-window idle-expiry duration. Issue and Rotate write
+// the newly issued row's idle deadline as now + MaxIdle. A token row that is
+// not rotated before its idle deadline is rejected as idle-expired.
 // Must be positive; use DefaultMaxIdle for the standard 30-day window.
 //
 // GraceMaxReuses caps how many times a parent token may be re-presented within

--- a/runtime/auth/refresh/types.go
+++ b/runtime/auth/refresh/types.go
@@ -32,24 +32,34 @@ type Token struct {
 	ExpiresAt time.Time
 }
 
-// Default policy values used when the caller does not configure optional fields.
-//
-// Zero values for MaxIdle and GraceMaxReuses are accepted by NewRefreshStore /
-// memstore.New (via Policy.Validate) and mean "feature disabled" — pre-016
-// stores or deployments that intentionally opt out of idle expiry / grace
-// counter cap. Callers that want the standard behavior set these constants.
-// MaxAge and ReuseInterval are still strictly validated (positive / non-negative).
+// Default policy values. Callers must set these explicitly — Validate does not
+// apply implicit defaults (must be set explicitly by callers; no implicit defaults
+// applied by Validate).
 const (
-	// DefaultMaxIdle is the default idle-expiry window (30 days).
+	// DefaultMaxIdle is the standard idle-expiry window (30 days).
 	// Matches Zitadel auth-token default retention period.
 	// ref: zitadel/zitadel internal/repository/session expire.go
 	DefaultMaxIdle = 30 * 24 * time.Hour
 
-	// DefaultGraceMaxReuses is the default grace reuse counter cap (3 re-uses).
+	// DefaultGraceMaxReuses is the standard grace reuse counter cap (3 re-uses).
 	// Tolerates SPA double-submit + network retry within a grace window without
 	// treating them as reuse attacks. Exceeding the cap triggers cascade revoke.
 	// ref: ory/fosite handler/oauth2/refresh.go (COALESCE reuse guard)
 	DefaultGraceMaxReuses = 3
+
+	// CascadeRevokeTimeout is the maximum time allowed for a cascade-revoke DB
+	// write that runs detached from the caller's cancellation context.
+	//
+	// Cascade revoke is a security response (reuse-attack or subject-mismatch)
+	// that MUST persist even when the HTTP request that triggered it is canceled
+	// or times out. The detached context is constructed via
+	// pkg/ctxutil.WithDetachedTimeout so the write gets its own 5-second budget
+	// independent of the caller's deadline.
+	//
+	// ref: golang/go context.WithoutCancel (proposal#40221)
+	// ref: hashicorp/vault vault/token_store.go quitContext (detached critical write)
+	// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
+	CascadeRevokeTimeout = 5 * time.Second
 )
 
 // Policy controls Rotate semantics and token lifetime.
@@ -64,24 +74,15 @@ const (
 // MaxIdle is the sliding-window idle-expiry duration. Every Rotate call
 // resets the idle clock on the parent row. A token that is not rotated within
 // MaxIdle of its last rotation (or creation) is rejected as idle-expired.
-// Zero value disables idle-expiry check (stores that have not migrated yet).
+// Must be positive; use DefaultMaxIdle for the standard 30-day window.
 //
 // GraceMaxReuses caps how many times a parent token may be re-presented within
 // the ReuseInterval grace window. Once the cap is reached, the next re-present
-// triggers a cascade revoke (same as an out-of-window reuse attack). Zero value
-// disables the counter cap.
+// triggers a cascade revoke (same as an out-of-window reuse attack).
+// Must be positive; use DefaultGraceMaxReuses for the standard cap of 3.
 //
-// Defaults (not enforced; zero values are accepted for backward compat in
-// stores that have not yet applied migration 016):
-//
-//	ReuseInterval  = 2 * time.Second  (matches Ory Hydra grace_period)
-//	MaxAge         = 7 * 24 * time.Hour
-//	MaxIdle        = DefaultMaxIdle   (30 days)
-//	GraceMaxReuses = DefaultGraceMaxReuses (3)
-//
-// Validate() returns an error if MaxAge is non-positive, ReuseInterval is negative,
-// MaxIdle is negative, or GraceMaxReuses is negative. Zero values for MaxIdle and
-// GraceMaxReuses are accepted and mean "disabled".
+// All four fields are required; Validate returns an error for any non-positive
+// or negative value.
 type Policy struct {
 	ReuseInterval  time.Duration
 	MaxAge         time.Duration
@@ -92,11 +93,7 @@ type Policy struct {
 // Validate returns an error if the Policy contains invalid field values.
 //
 // MaxAge must be positive. ReuseInterval must not be negative.
-// MaxIdle and GraceMaxReuses may be zero (zero = disabled): zero MaxIdle disables
-// idle-expiry checks (stores that have not applied migration 016 set MaxIdle=0);
-// zero GraceMaxReuses disables the grace counter cap. This aligns with
-// NewRefreshStore and memstore.New which treat zero values as disabled rather than
-// invalid, and with the far-future sentinel used when MaxIdle is zero.
+// MaxIdle must be positive. GraceMaxReuses must be positive.
 func (p Policy) Validate() error {
 	if p.MaxAge <= 0 {
 		return errorf("Policy.MaxAge must be positive")
@@ -104,13 +101,11 @@ func (p Policy) Validate() error {
 	if p.ReuseInterval < 0 {
 		return errorf("Policy.ReuseInterval must not be negative")
 	}
-	// MaxIdle == 0 means idle-expiry disabled; negative is invalid.
-	if p.MaxIdle < 0 {
-		return errorf("Policy.MaxIdle must not be negative (use zero to disable idle expiry)")
+	if p.MaxIdle <= 0 {
+		return errorf("Policy.MaxIdle must be positive")
 	}
-	// GraceMaxReuses == 0 means grace counter cap disabled; negative is invalid.
-	if p.GraceMaxReuses < 0 {
-		return errorf("Policy.GraceMaxReuses must not be negative (use zero to disable grace cap)")
+	if p.GraceMaxReuses <= 0 {
+		return errorf("Policy.GraceMaxReuses must be positive")
 	}
 	return nil
 }

--- a/runtime/auth/refresh/types_test.go
+++ b/runtime/auth/refresh/types_test.go
@@ -76,7 +76,7 @@ func TestPolicy_Validate(t *testing.T) {
 			policy: refresh.Policy{
 				ReuseInterval: time.Second,
 				MaxAge:        time.Hour,
-				MaxIdle:       30 * 24 * time.Hour,
+				MaxIdle:       refresh.DefaultMaxIdle,
 				// GraceMaxReuses intentionally zero
 			},
 			wantErr: true,

--- a/runtime/auth/refresh/types_test.go
+++ b/runtime/auth/refresh/types_test.go
@@ -1,0 +1,114 @@
+package refresh_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/runtime/auth/refresh"
+)
+
+func TestPolicy_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		policy  refresh.Policy
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid_policy",
+			policy: refresh.Policy{
+				ReuseInterval:  time.Second,
+				MaxAge:         time.Hour,
+				MaxIdle:        refresh.DefaultMaxIdle,
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+			},
+			wantErr: false,
+		},
+		{
+			name: "MaxAge_zero_isError",
+			policy: refresh.Policy{
+				ReuseInterval:  time.Second,
+				MaxAge:         0,
+				MaxIdle:        refresh.DefaultMaxIdle,
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+			},
+			wantErr: true,
+			errMsg:  "MaxAge",
+		},
+		{
+			name: "MaxAge_negative_isError",
+			policy: refresh.Policy{
+				ReuseInterval:  time.Second,
+				MaxAge:         -time.Hour,
+				MaxIdle:        refresh.DefaultMaxIdle,
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+			},
+			wantErr: true,
+			errMsg:  "MaxAge",
+		},
+		{
+			name: "ReuseInterval_negative_isError",
+			policy: refresh.Policy{
+				ReuseInterval:  -time.Second,
+				MaxAge:         time.Hour,
+				MaxIdle:        refresh.DefaultMaxIdle,
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+			},
+			wantErr: true,
+			errMsg:  "ReuseInterval",
+		},
+		{
+			name: "MaxIdle_zero_isError",
+			policy: refresh.Policy{
+				ReuseInterval:  time.Second,
+				MaxAge:         time.Hour,
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+				// MaxIdle intentionally zero
+			},
+			wantErr: true,
+			errMsg:  "must be positive",
+		},
+		{
+			name: "GraceMaxReuses_zero_isError",
+			policy: refresh.Policy{
+				ReuseInterval: time.Second,
+				MaxAge:        time.Hour,
+				MaxIdle:       30 * 24 * time.Hour,
+				// GraceMaxReuses intentionally zero
+			},
+			wantErr: true,
+			errMsg:  "must be positive",
+		},
+		{
+			name: "ReuseInterval_zero_isValid",
+			policy: refresh.Policy{
+				ReuseInterval:  0,
+				MaxAge:         time.Hour,
+				MaxIdle:        refresh.DefaultMaxIdle,
+				GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.policy.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("Policy.Validate() = nil, want error")
+				return
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Policy.Validate() = %v, want nil", err)
+				return
+			}
+			if tc.wantErr && tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("Policy.Validate() error = %q, want it to contain %q", err.Error(), tc.errMsg)
+			}
+		})
+	}
+}

--- a/runtime/config/watcher.go
+++ b/runtime/config/watcher.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
+	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
 // Compile-time assertion: Watcher implements lifecycle.ContextCloser.
@@ -480,7 +481,7 @@ func (w *Watcher) fireCallbacks(symPivot bool) {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error("config watcher callback panic", slog.Any("panic", r))
+					slog.Error("config watcher callback panic", slog.Any("panic", redaction.RedactAny(r)))
 				}
 			}()
 			fn(evt)

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -422,7 +422,7 @@ func (h *Handler) aggregateProbeResults(results map[string]ProbeResult, verbose 
 				"duration_ms": pr.Duration.Milliseconds(),
 			}
 			if pr.Err != nil {
-				entry["error"] = truncateErrMsg(pr.Err.Error(), maxVerboseErrLen)
+				entry["error"] = truncateErrMsg(redaction.RedactString(pr.Err.Error()), maxVerboseErrLen)
 			}
 			dependencies[name] = entry
 		}

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -330,7 +330,7 @@ func (h *Handler) computeReadyzSafe(verbose bool) (result readyzResult) {
 		if r := recover(); r != nil {
 			slog.Error("readyz: recovered panic during readiness computation",
 				slog.String("internal_reason", "readiness_computation_failed"),
-				slog.String("panic", redaction.RedactPanic(r)))
+				slog.Any("panic", redaction.RedactAny(r)))
 			result = readyzResult{overall: "unhealthy", reason: readyzReasonReadinessFailed}
 		}
 	}()

--- a/runtime/http/health/health_test.go
+++ b/runtime/http/health/health_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1101,6 +1102,39 @@ func TestReadyz_VerboseError_LongErrTruncated(t *testing.T) {
 		"error field must be at most %d bytes; got %d", maxWithEllipsis, len(errField))
 	assert.True(t, len(errField) >= 3 && errField[len(errField)-3:] == "...",
 		"truncated error must end with '...'; got %q", errField)
+}
+
+func TestReadyz_VerboseError_RedactsBeforeTruncating(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-redact-verbose", DurabilityMode: cell.DurabilityDemo, Clock: clock.Real()})
+	require.NoError(t, asm.Start(context.Background()))
+	defer func() { _ = asm.Stop(context.Background()) }()
+
+	const leakSentinel = "health-verbose-leak-sentinel-8f2b"
+	h := New(asm, clock.Real())
+	h.SetVerboseToken(testVerboseToken)
+	require.NoError(t, h.RegisterChecker("sensitive", func(_ context.Context) error {
+		return fmt.Errorf("postgres probe failed: password=%s token=%s", leakSentinel, leakSentinel)
+	}))
+
+	capture := withSlogCapture(t)
+	rec := httptest.NewRecorder()
+	req := newVerboseRequest("/readyz?verbose=true")
+	h.ReadyzHandler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.False(t, strings.Contains(rec.Body.String(), leakSentinel),
+		"verbose readyz body must not leak raw probe secrets")
+
+	errObj := errorBody(t, rec)
+	assertReadyzServiceUnavailable(t, errObj)
+
+	deps := readyzUnhealthyDeps(t, capture)
+	sensitiveEntry, ok := deps["sensitive"]
+	require.True(t, ok, "sensitive entry must be present")
+	errField, ok := sensitiveEntry["error"].(string)
+	require.True(t, ok, "error field must be a string")
+	assert.Contains(t, errField, "<REDACTED>")
+	assert.NotContains(t, errField, leakSentinel)
 }
 
 // TestReadyz_UncooperativeChecker_WrapperReturnsOnDeadline verifies the

--- a/runtime/http/health/wrap.go
+++ b/runtime/http/health/wrap.go
@@ -97,7 +97,7 @@ func wrapCtxSafe(fn Checker, clk clock.Clock) Checker {
 
 func probePanicError(panicV any) error {
 	slog.Warn("health: probe panicked",
-		slog.String("panic", redaction.RedactPanic(panicV)),
+		slog.Any("panic", redaction.RedactAny(panicV)),
 	)
 	return fmt.Errorf("panic: %v", panicV)
 }
@@ -136,7 +136,7 @@ func watchLateProbeOutcome(ctxErr error, start, cancelAt time.Time, done <-chan 
 	switch {
 	case o.panicV != nil:
 		slog.Warn("health: probe panicked after ctx cancellation; result discarded",
-			slog.String("panic", redaction.RedactPanic(o.panicV)),
+			slog.Any("panic", redaction.RedactAny(o.panicV)),
 			slog.Any("ctx_err", ctxErr),
 			slog.Duration("cancel_lag", cancelLag),
 			slog.Duration("probe_total", probeTotal),

--- a/runtime/http/health/wrap_test.go
+++ b/runtime/http/health/wrap_test.go
@@ -108,14 +108,16 @@ func TestWrapCtxSafe_PanicBecomesErrorAndLogs(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
+	const leakSentinel = "wrap-panic-leak-sentinel-4ad"
 	wrapped := wrapCtxSafe(func(_ context.Context) error {
-		panic("boom")
+		panic("secret=" + leakSentinel)
 	}, clock.Real())
 	err := wrapped(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "panic: boom")
+	assert.Contains(t, err.Error(), "panic: secret=")
 	assert.Contains(t, logs.String(), "health: probe panicked")
-	assert.Contains(t, logs.String(), "boom")
+	assert.NotContains(t, logs.String(), leakSentinel)
+	assert.Contains(t, logs.String(), "REDACTED")
 }
 
 // TestWrapCtxSafe_NilInput ensures defensive wrapping of nil returns a

--- a/runtime/http/middleware/recovery.go
+++ b/runtime/http/middleware/recovery.go
@@ -46,7 +46,7 @@ func Recovery(next http.Handler) http.Handler {
 				// (PR #391 round-2 F2). Trace span sanitization runs in
 				// recordPanicOnActiveSpan; slog needs the same treatment.
 				attrs := []any{
-					slog.String("panic", redaction.RedactPanic(v)),
+					slog.Any("panic", redaction.RedactAny(v)),
 					slog.String("stack", stack),
 					slog.String("method", r.Method),
 					slog.String("path", r.URL.Path),

--- a/runtime/http/middleware/recovery_test.go
+++ b/runtime/http/middleware/recovery_test.go
@@ -1,9 +1,12 @@
 package middleware
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,6 +49,42 @@ func TestRecovery_PanicString(t *testing.T) {
 	assert.Equal(t, "ERR_INTERNAL", errObj["code"])
 	assert.Equal(t, "internal server error", errObj["message"])
 	assert.Equal(t, []any{}, errObj["details"], "canonical envelope must include empty details object")
+}
+
+func TestRecovery_PanicBodyDoesNotLeakPanicValue(t *testing.T) {
+	const leakSentinel = "recovery-body-leak-sentinel-7c1"
+	handler := Recorder(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("password=" + leakSentinel)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.False(t, strings.Contains(rec.Body.String(), leakSentinel),
+		"500 body must remain generic and never include panic payload")
+	assert.Contains(t, rec.Body.String(), "internal server error")
+}
+
+func TestRecovery_PanicLogRedactsPanicValue(t *testing.T) {
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	const leakSentinel = "recovery-log-leak-sentinel-2b8"
+	handler := Recorder(Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("token=" + leakSentinel)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.NotContains(t, logs.String(), leakSentinel)
+	assert.Contains(t, logs.String(), "REDACTED")
 }
 
 func TestRecovery_PanicError(t *testing.T) {

--- a/runtime/http/middleware/safe_observe.go
+++ b/runtime/http/middleware/safe_observe.go
@@ -3,6 +3,8 @@ package middleware
 import (
 	"log/slog"
 	"runtime/debug"
+
+	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
 // safeObserve runs fn and recovers from any panic, logging it via the
@@ -37,7 +39,7 @@ func safeObserve(logger *slog.Logger, fn func()) {
 			func() {
 				defer func() { _ = recover() }()
 				logger.Error("observability middleware panic",
-					slog.Any("panic", v),
+					slog.Any("panic", redaction.RedactAny(v)),
 					slog.String("stack", string(debug.Stack())),
 				)
 			}()

--- a/runtime/outbox/metrics_safe.go
+++ b/runtime/outbox/metrics_safe.go
@@ -5,6 +5,7 @@ import (
 	"runtime/debug"
 
 	kout "github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
 // safeRelayCollector wraps a kout.RelayCollector and recovers from any
@@ -45,7 +46,7 @@ func (s *safeRelayCollector) safeCall(fn func()) {
 	defer func() {
 		if v := recover(); v != nil {
 			slog.Error("outbox relay: metrics collector panic (dropped observation)",
-				slog.Any("panic", v),
+				slog.Any("panic", redaction.RedactAny(v)),
 				slog.String("stack", string(debug.Stack())),
 			)
 		}

--- a/runtime/worker/periodic.go
+++ b/runtime/worker/periodic.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
 // Compile-time interface check.
@@ -73,7 +74,7 @@ func (p *PeriodicWorker) Stop(_ context.Context) error {
 func (p *PeriodicWorker) runSafe(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("periodic worker panic", slog.Any("panic", r))
+			slog.Error("periodic worker panic", slog.Any("panic", redaction.RedactAny(r)))
 		}
 	}()
 	p.fn(ctx)

--- a/tools/archtest/panic_redaction_test.go
+++ b/tools/archtest/panic_redaction_test.go
@@ -1,0 +1,113 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPanicLogMustUseRedactAny enforces that every slog.Any("panic", X) call
+// in production code wraps X with redaction.RedactAny(...). This prevents
+// panic values containing DSNs, tokens, or credentials from reaching log sinks
+// un-redacted.
+//
+// Rule ID: PANIC-REDACT-01
+// Wave 0: fails against the current codebase (11 violations in Wave 0).
+// Wave 3: all violations remediated; white-list stays empty permanently.
+func TestPanicLogMustUseRedactAny(t *testing.T) {
+	repoRoot := findRepoRootPanicRedact(t)
+	fset := token.NewFileSet()
+	var violations []string
+
+	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == "vendor" || base == "node_modules" || base == ".git" || base == "worktrees" || base == "generated" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return nil // skip files that don't parse; not our concern
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Any" {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != "slog" {
+				return true
+			}
+			if len(call.Args) < 2 {
+				return true
+			}
+			// First arg must be string literal "panic".
+			lit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING || lit.Value != `"panic"` {
+				return true
+			}
+			// Second arg must be a call to redaction.RedactAny(...).
+			arg := call.Args[1]
+			argCall, ok := arg.(*ast.CallExpr)
+			if !ok {
+				violations = append(violations, panicRedactPosStr(fset, call.Pos()))
+				return true
+			}
+			argSel, ok := argCall.Fun.(*ast.SelectorExpr)
+			if !ok || argSel.Sel.Name != "RedactAny" {
+				violations = append(violations, panicRedactPosStr(fset, call.Pos()))
+				return true
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(violations) > 0 {
+		t.Errorf("slog.Any(\"panic\", X) must wrap X with redaction.RedactAny(...). %d violation(s):\n%s",
+			len(violations), strings.Join(violations, "\n"))
+	}
+}
+
+func panicRedactPosStr(fset *token.FileSet, pos token.Pos) string {
+	p := fset.Position(pos)
+	return p.String()
+}
+
+func findRepoRootPanicRedact(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		fi, e := os.Stat(filepath.Join(dir, "go.mod"))
+		if e == nil && !fi.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found — cannot determine repo root")
+		}
+		dir = parent
+	}
+}

--- a/tools/archtest/panic_redaction_test.go
+++ b/tools/archtest/panic_redaction_test.go
@@ -40,7 +40,8 @@ func TestPanicLogMustUseRedactAny(t *testing.T) {
 		}
 		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 		if perr != nil {
-			return nil // skip files that don't parse; not our concern
+			//nolint:nilerr // unparseable files (generated, vendored 3p, broken WIP) are not the archtest's concern
+			return nil
 		}
 		ast.Inspect(f, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)


### PR DESCRIPTION
## Summary

Close all three leftover findings from external multi-role review of PR#388 (refresh-store harden + idle-grace, merged in #388 / commit 19ed2b52). Operates under "no backward compatibility, project undeployed" constraint.

### Finding 1 (P1) — cascade revoke detached from caller ctx
PR#388 decoupled cascade revoke from the **ambient transaction** but left it bound to the **caller request ctx**. If the HTTP client disconnects after reuse_detected but before the cascade SQL commits, the security response fails with `context canceled`.

Fix: `pkg/ctxutil.WithDetachedTimeout` (`context.WithoutCancel` + `context.WithTimeout`, Go 1.21 proposal #40221). Applied at both:
- `adapters/postgres/refresh_store.go` line 504 + 525 (`s.pool.Exec(cascadeCtx, ...)`)
- `cells/accesscore/slices/sessionrefresh/service.go::cascadeRevoke`

Single-source timeout: `runtime/auth/refresh.CascadeRevokeTimeout = 5 * time.Second`. Pattern aligns with HashiCorp Vault `vault/token_store.go` `quitContext`.

### Finding 2 (P1) — idle_expires_at semantics collapse
PR#388 wrote `DEFAULT now() + INTERVAL '30 days'` but ADR + comments claimed `created_at + 30d` historical semantics. Project undeployed; goose stores `version_id`+`tstamp` (not file hash); CI ephemeral; dev `goose reset` acceptable.

Fix: modify migration 016 in place to drop the DEFAULT; `idle_expires_at` is `NOT NULL` with no default, written explicitly by Issue/Rotate. ADR §X12 rewritten.

### Finding 3 (P2) — panic-payload redaction broadened
PR#388 redacted explicit error fields in tx_manager rollback logs but left `slog.Any("panic", r)` raw. Same risk in 10 other sites across kernel/runtime/adapters.

Fix: `pkg/redaction.RedactAny(v any) any` (`nil` / `error` / `string` / `other` switch). All 11 `slog.Any("panic", X)` sites updated. `tools/archtest/panic_redaction_test.go` AST guard prevents regression.

### Bonus — Policy zero-value semantics tightening
`Policy.Validate` now requires `MaxIdle > 0` and `GraceMaxReuses > 0` (was: zero == "feature disabled"). Removed:
- `refresh_store.go` `idleFarFuture` 10-year sentinel
- All `if MaxIdle > 0 &&` / `if GraceMaxReuses > 0 &&` guards
- "pre-016 stores" / "backward compat" prose in types.go

All `refresh.Policy{}` construction sites (production + 30+ test files) updated to provide both fields explicitly.

### Coverage
- `pkg/ctxutil/detach_test.go` — helper boundary (5 sub-tests)
- `pkg/redaction/redaction_test.go::TestRedactAny` — three-branch coverage
- `runtime/auth/refresh/types_test.go::TestPolicy_Validate` — zero-value rejection
- `runtime/auth/refresh/storetest/suite.go::runTnIdleExpireRejectsAfterMaxIdle` — shared contract subtest, runs against PG + memstore
- `cells/accesscore/slices/sessionrefresh/service_test.go::TestService_CascadeRevoke_DetachesFromCallerCtx` — service-level cascade detach with mock store
- `tools/archtest/panic_redaction_test.go::TestPanicLogMustUseRedactAny` — static AST scan
- Black-box PG store-level "caller cancel mid-cascade" test deliberately not added — Rotate with already-canceled ctx fails at `pool.Begin(ctx)` before reaching cascade SQL; layered coverage above gates the property.

ref: golang/go context.WithoutCancel proposal#40221
ref: hashicorp/vault vault/token_store.go (quitContext detached pattern)
ref: ory/fosite handler/oauth2/flow_refresh.go (caller-ctx baseline)
ref: zitadel/zitadel internal/api/oidc/token_refresh.go (caller-ctx baseline)

Refs: PR#388 leftover findings P1+P2

## Test plan

- [x] `go build ./...` — passes
- [x] `go test -race ./pkg/... ./runtime/... ./kernel/... ./cells/... ./tools/archtest/...` — passes
- [x] `go test -tags integration -race ./adapters/postgres/...` — passes (PG contract suite + idle-expire shared subtest + cascade ambient-rollback retained)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `tools/archtest/panic_redaction_test.go::TestPanicLogMustUseRedactAny` — 0 violations
- [x] `tools/archtest/test_time_literal_test.go::TestTestTimeLiteralConst` — 0 violations
- [ ] CI green