### PR TITLE
fix(test): bootstrap dual_listener no-close-race shutdown budget D2s→D5s

### DIFF
--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -855,7 +855,13 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
 		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
-		WithShutdownTimeout(testtime.D2s),
+		// D5s shutdown budget (matches the dual-listener slow-reload test at
+		// bootstrap_test.go:1815). 4 in-flight requests drain in parallel with
+		// dual-listener http.Server.Shutdown + LIFO teardown sharing a single
+		// shutCtx; -race scheduling on slow CI runners can push the tail past
+		// D2s. The test asserts race-free shutdown — the budget value is
+		// incidental and must only be wide enough to avoid an artificial timeout.
+		WithShutdownTimeout(testtime.D5s),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -892,7 +898,9 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 	select {
 	case err := <-done:
 		assert.NoError(t, err)
-	case <-time.After(testtime.SelectShutdown):
+	// D10s outer guard keeps `outer > inner` so a clean shutdown that consumes
+	// most of the D5s shutCtx still wins this fallback in the select race.
+	case <-time.After(testtime.D10s):
 		t.Fatal("bootstrap did not shut down in time")
 	}
 

--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -28,6 +28,18 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
+// File-local timeouts for TestPhase7ServeAll_DualListener_NoCloseRace —
+// the only test in this file that fires concurrent in-flight requests during
+// cancel(). See testtime/testtime.go for the convention: per-site unique
+// deadlines should be declared file-local so the project-wide constants stay
+// semantic. testtime.SelectShutdown (5s) cannot be used here because the
+// shutdown budget itself is 5s — the outer select fallback must be strictly
+// greater than the inner shutCtx for the assertion path to win the race.
+const (
+	noCloseRaceShutdownBudget = testtime.D5s
+	noCloseRaceShutdownGuard  = testtime.D10s
+)
+
 // dualListenerCell registers one /api/v1/* and one /internal/v1/* route so
 // tests can verify dual-listener dispatch end-to-end.
 type dualListenerCell struct {
@@ -855,13 +867,14 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 		WithAssembly(asm),
 		WithListener(cell.PrimaryListener, primaryLn.Addr().String(), []cell.ListenerAuth{cell.AuthNone{}}, WithListenerNet(primaryLn)),
 		WithListener(cell.InternalListener, internalLn.Addr().String(), internalAuthChain, WithListenerNet(internalLn)),
-		// D5s shutdown budget (matches the dual-listener slow-reload test at
-		// bootstrap_test.go:1815). 4 in-flight requests drain in parallel with
-		// dual-listener http.Server.Shutdown + LIFO teardown sharing a single
-		// shutCtx; -race scheduling on slow CI runners can push the tail past
-		// D2s. The test asserts race-free shutdown — the budget value is
-		// incidental and must only be wide enough to avoid an artificial timeout.
-		WithShutdownTimeout(testtime.D5s),
+		// noCloseRaceShutdownBudget matches TestBootstrap_ShutdownDrainsInflightReload
+		// (the other dual-listener test that drains real in-flight work). 4 in-flight
+		// requests drain in parallel with dual-listener http.Server.Shutdown + LIFO
+		// teardown sharing a single shutCtx; -race scheduling on slow CI runners can
+		// push the tail past testtime.D2s. The test asserts race-free shutdown —
+		// the budget value is incidental and only needs to be wide enough to avoid
+		// an artificial timeout.
+		WithShutdownTimeout(noCloseRaceShutdownBudget),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -898,9 +911,10 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 	select {
 	case err := <-done:
 		assert.NoError(t, err)
-	// D10s outer guard keeps `outer > inner` so a clean shutdown that consumes
-	// most of the D5s shutCtx still wins this fallback in the select race.
-	case <-time.After(testtime.D10s):
+	// noCloseRaceShutdownGuard preserves the `outer > inner` invariant so a
+	// clean shutdown that consumes most of noCloseRaceShutdownBudget still wins
+	// this fallback in the select race.
+	case <-time.After(noCloseRaceShutdownGuard):
 		t.Fatal("bootstrap did not shut down in time")
 	}
 


### PR DESCRIPTION
## Summary

CI run [25453182848](https://github.com/ghbvf/gocell/actions/runs/25453182848/job/74675581991) (Test · Race Detector on develop @ c5a67e5b) failed in `runtime/bootstrap.TestPhase7ServeAll_DualListener_NoCloseRace`:

```
--- FAIL: TestPhase7ServeAll_DualListener_NoCloseRace (2.00s)
    dual_listener_test.go:894:
    Error: teardown[teardown_http_drain]: listener "primary" shutdown: context deadline exceeded
```

Root cause is CI tail latency, not a regression. PR #402 scope was `adapters/rabbitmq/` + `tools/archtest/` only — no `runtime/bootstrap/` changes. The test fires 4 in-flight requests then immediately `cancel()`s; dual-listener `http.Server.Shutdown` + LIFO teardown share a single `D2s` shutCtx. Under `-race` scheduling on a slow GH Actions runner, the combined budget can be exhausted before the parallel drains finish.

## Fix

`runtime/bootstrap/dual_listener_test.go` (single test only):

- `WithShutdownTimeout(testtime.D2s)` → `D5s` — matches `bootstrap_test.go:1815` (the dual-listener slow-reload test).
- Outer `time.After(testtime.SelectShutdown)` (5s) → `time.After(testtime.D10s)` — keeps `outer > inner` so a clean shutdown that consumes most of the D5s budget still wins the select race.

Other dual/triple listener shutdown tests in the file (`D2s`) are unchanged — none of them fire concurrent in-flight requests during cancel; the tight budget there is still a useful regression signal.

The race-free property under test is verified by `-race`; the timeout value is incidental and only needs to be wide enough to avoid an artificial timeout.

`Refs:` PR #402 develop CI flake (no backlog ID; behavior fix is the test budget itself).
`ref:` golang/go `net/http.Server.Shutdown` — `shutdownPollIntervalMax = 500ms`

## Test plan

- [x] `go test -race -run NoCloseRace -count=50 -timeout 10m ./runtime/bootstrap/` — green
- [x] `go test -race -timeout 10m ./runtime/bootstrap/...` — green
- [x] `golangci-lint run ./runtime/bootstrap/...` — 0 issues
- [ ] CI Test · Race Detector — re-run on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)