### PR TITLE
fix(crypto): harden encrypt result contract

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -84,7 +84,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       # Static checks (Build, Vet, golangci-lint, validate/check commands, layering
@@ -271,7 +271,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Integration tests (testcontainers)
@@ -472,7 +472,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: Build e2egate
         run: go build -o "$RUNNER_TEMP/e2egate" ./tools/e2egate/cmd/e2egate
@@ -552,7 +552,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: Vet (cross-platform unit subset)
         run: go vet ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/...
@@ -589,7 +589,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: ssobff startup smoke
         # `examples_smoke` build tag isolates this from the `integration` tag
@@ -691,7 +691,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       # Generated-artifact gate (PR-CFG-M follow-up):

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: make verify

--- a/.github/workflows/otel-collector-nightly.yml
+++ b/.github/workflows/otel-collector-nightly.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: OTLP collector compatibility

--- a/adapters/vault/integration_test.go
+++ b/adapters/vault/integration_test.go
@@ -104,16 +104,16 @@ func TestTransitEnvelope_RoundTrip(t *testing.T) {
 	plaintext := []byte("prod-api-secret")
 	aad := []byte("cell:configcore/key:api_key")
 
-	ct, nonce, edk, keyID, err := handle.Encrypt(ctx, plaintext, aad)
+	result, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
-	assert.NotEmpty(t, ct, "ciphertext must be non-empty")
-	assert.NotNil(t, nonce, "nonce must be present for envelope AES-GCM")
-	assert.NotEmpty(t, nonce, "nonce must be non-empty")
-	assert.NotNil(t, edk, "edk (wrapped DEK) must be present for envelope mode")
-	assert.NotEmpty(t, edk, "edk must be non-empty")
-	assert.Contains(t, keyID, "vault-transit:v", "keyID must reflect vault key version")
+	assert.NotEmpty(t, result.Ciphertext, "ciphertext must be non-empty")
+	assert.NotNil(t, result.Nonce, "nonce must be present for envelope AES-GCM")
+	assert.NotEmpty(t, result.Nonce, "nonce must be non-empty")
+	assert.NotNil(t, result.EDK, "edk (wrapped DEK) must be present for envelope mode")
+	assert.NotEmpty(t, result.EDK, "edk must be non-empty")
+	assert.Contains(t, result.KeyID, "vault-transit:v", "keyID must reflect vault key version")
 
-	recovered, err := handle.Decrypt(ctx, ct, nonce, edk, aad)
+	recovered, err := handle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered, "round-trip must recover original plaintext")
 }
@@ -199,10 +199,10 @@ path "transit/keys/gocell-config/rotate"       { capabilities = ["create","updat
 	plaintext := []byte("approle-encrypted-secret")
 	aad := []byte("cell:configcore/key:approle_test")
 
-	ct, nonce, edk, _, err := handle.Encrypt(ctx, plaintext, aad)
+	result, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	recovered, err := handle.Decrypt(ctx, ct, nonce, edk, aad)
+	recovered, err := handle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered, "AppRole auth: round-trip must recover original plaintext")
 }
@@ -261,12 +261,12 @@ func TestTransitEnvelope_AADMismatch_FailsClosed(t *testing.T) {
 	plaintext := []byte("secret-value")
 	encryptAAD := []byte("cell:configcore/key:row_a")
 
-	ct, nonce, edk, _, err := handle.Encrypt(ctx, plaintext, encryptAAD)
+	result, err := handle.Encrypt(ctx, plaintext, encryptAAD)
 	require.NoError(t, err)
 
 	// Attempt cross-row replay: decrypt with a different AAD.
 	wrongAAD := []byte("cell:configcore/key:row_b")
-	_, err = handle.Decrypt(ctx, ct, nonce, edk, wrongAAD)
+	_, err = handle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, wrongAAD)
 	require.Error(t, err, "decrypting with mismatched AAD must fail-closed (cross-row replay blocked)")
 
 	var ec *errcode.Error
@@ -300,9 +300,9 @@ func TestTransitEnvelope_RotateThenDecryptOldCiphertext(t *testing.T) {
 	plaintext := []byte("pre-rotation-value")
 	aad := []byte("cell:configcore/key:old_key")
 
-	ct1, nonce1, edk1, keyID1, err := handle1.Encrypt(ctx, plaintext, aad)
+	result1, err := handle1.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
-	assert.Contains(t, keyID1, "vault-transit:v1", "keyID must reflect v1 at encrypt time")
+	assert.Contains(t, result1.KeyID, "vault-transit:v1", "keyID must reflect v1 at encrypt time")
 
 	// Rotate to v2.
 	newID, err := p.Rotate(ctx)
@@ -318,7 +318,7 @@ func TestTransitEnvelope_RotateThenDecryptOldCiphertext(t *testing.T) {
 	handle1b, err := p.ByID(ctx, handle1.ID())
 	require.NoError(t, err)
 
-	recovered, err := handle1b.Decrypt(ctx, ct1, nonce1, edk1, aad)
+	recovered, err := handle1b.Decrypt(ctx, result1.Ciphertext, result1.Nonce, result1.EDK, aad)
 	require.NoError(t, err, "historical ciphertext encrypted with v1 must still be decryptable")
 	assert.Equal(t, plaintext, recovered)
 }
@@ -445,7 +445,7 @@ func TestTransitEnvelope_VaultNeverSeesBusinessPlaintext(t *testing.T) {
 	handle, err := p.Current(ctx)
 	require.NoError(t, err)
 
-	_, _, _, _, err = handle.Encrypt(ctx, plaintext, aad)
+	_, err = handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
 	// Inspect the captured encrypt request.
@@ -513,21 +513,21 @@ func TestTransitEnvelope_KeyIDFromEncryptResponse(t *testing.T) {
 	plaintext := []byte("key-id-check-value")
 	aad := []byte("cell:configcore/key:key_id_test")
 
-	_, _, edk, keyID, err := handle.Encrypt(ctx, plaintext, aad)
+	result, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
 	// keyID must have the "vault-transit:v" prefix.
-	assert.True(t, strings.HasPrefix(keyID, "vault-transit:v"),
-		"keyID from Encrypt must start with 'vault-transit:v', got: %q", keyID)
+	assert.True(t, strings.HasPrefix(result.KeyID, "vault-transit:v"),
+		"keyID from Encrypt must start with 'vault-transit:v', got: %q", result.KeyID)
 
 	// keyID from Encrypt must match handle.ID() (no rotation happened).
-	assert.Equal(t, handleID, keyID,
+	assert.Equal(t, handleID, result.KeyID,
 		"keyID from Encrypt() must equal handle.ID() when no rotation occurred")
 
 	// The edk must start with the Vault ciphertext prefix "vault:v".
 	// This is the raw wrapped DEK ciphertext; the "vault:vN:" prefix is how
 	// we extract the key version.
-	edkStr := string(edk)
+	edkStr := string(result.EDK)
 	assert.True(t, strings.HasPrefix(edkStr, "vault:v"),
 		"edk (wrapped DEK) must start with Vault ciphertext prefix 'vault:v', got: %q", edkStr)
 
@@ -536,6 +536,6 @@ func TestTransitEnvelope_KeyIDFromEncryptResponse(t *testing.T) {
 	edkParts := strings.SplitN(edkStr, ":", 3)
 	require.Len(t, edkParts, 3, "edk must have format 'vault:vN:...'")
 	versionFromEDK := edkParts[1] // e.g. "v1"
-	assert.Equal(t, "vault-transit:"+versionFromEDK, keyID,
+	assert.Equal(t, "vault-transit:"+versionFromEDK, result.KeyID,
 		"keyID must be 'vault-transit:' + version extracted from edk prefix")
 }

--- a/adapters/vault/transit_datakey_test.go
+++ b/adapters/vault/transit_datakey_test.go
@@ -24,7 +24,7 @@ func TestEncrypt_UsesDataKeyPath(t *testing.T) {
 	p := newTestProvider(t, fake)
 	h := mustCurrent(t, p)
 
-	_, _, edk, keyID, err := h.Encrypt(context.Background(), []byte("payload"), []byte("aad"))
+	result, err := h.Encrypt(context.Background(), []byte("payload"), []byte("aad"))
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
@@ -41,11 +41,11 @@ func TestEncrypt_UsesDataKeyPath(t *testing.T) {
 	if bits := fake.lastWriteData["bits"]; bits != 256 {
 		t.Errorf("datakey body bits = %v, want 256", bits)
 	}
-	if keyID != "vault-transit:v3" {
-		t.Errorf("keyID = %q, want vault-transit:v3", keyID)
+	if result.KeyID != "vault-transit:v3" {
+		t.Errorf("keyID = %q, want vault-transit:v3", result.KeyID)
 	}
-	if !strings.HasPrefix(string(edk), "vault:v3:") {
-		t.Errorf("edk prefix = %q, want vault:v3:", string(edk))
+	if !strings.HasPrefix(string(result.EDK), "vault:v3:") {
+		t.Errorf("edk prefix = %q, want vault:v3:", string(result.EDK))
 	}
 }
 
@@ -62,11 +62,11 @@ func TestEncryptDecrypt_DataKeyRoundTrip(t *testing.T) {
 	plaintext := []byte("hello world")
 	aad := []byte("row:42")
 
-	ct, nonce, edk, _, err := h.Encrypt(context.Background(), plaintext, aad)
+	result, err := h.Encrypt(context.Background(), plaintext, aad)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
-	got, err := h.Decrypt(context.Background(), ct, nonce, edk, aad)
+	got, err := h.Decrypt(context.Background(), result.Ciphertext, result.Nonce, result.EDK, aad)
 	if err != nil {
 		t.Fatalf("Decrypt: %v", err)
 	}
@@ -75,11 +75,33 @@ func TestEncryptDecrypt_DataKeyRoundTrip(t *testing.T) {
 	}
 }
 
+func TestEncrypt_NonceUnique(t *testing.T) {
+	fake := &fakeVaultClient{latestVersion: 5}
+	p := newTestProvider(t, fake)
+	h := mustCurrent(t, p)
+
+	plaintext := []byte("same payload")
+	aad := []byte("same aad")
+
+	result1, err := h.Encrypt(context.Background(), plaintext, aad)
+	if err != nil {
+		t.Fatalf("Encrypt #1: %v", err)
+	}
+	result2, err := h.Encrypt(context.Background(), plaintext, aad)
+	if err != nil {
+		t.Fatalf("Encrypt #2: %v", err)
+	}
+
+	if bytes.Equal(result1.Nonce, result2.Nonce) {
+		t.Fatalf("consecutive Encrypt calls must produce unique nonces; got %x", result1.Nonce)
+	}
+}
+
 func TestEncrypt_MalformedDatakeyResponse(t *testing.T) {
 	for _, tc := range malformedDatakeyResponseCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			fake, h := newMalformedDatakeyHandle(t, tc.response)
-			_, _, _, _, err := h.Encrypt(context.Background(), []byte("payload"), []byte("aad"))
+			_, err := h.Encrypt(context.Background(), []byte("payload"), []byte("aad"))
 			assertMalformedDatakeyError(t, err)
 			assertDatakeyRequestOnly(t, fake)
 		})

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -500,42 +500,47 @@ func (h *vaultTransitHandle) ID() string { return h.id }
 //
 // ref: hashicorp/vault api-docs/secret/transit POST /transit/datakey/plaintext/:name
 // ref: kubernetes/kubernetes kmsv2/envelope.go@master (EncryptResponse.KeyID)
-func (h *vaultTransitHandle) Encrypt(ctx context.Context, plaintext, aad []byte) (ciphertext, nonce, edk []byte, keyID string, err error) {
+func (h *vaultTransitHandle) Encrypt(ctx context.Context, plaintext, aad []byte) (kcrypto.EncryptResult, error) {
 	dkPath := h.mountPath + "/datakey/plaintext/" + h.keyName
 	result, err := h.client.Write(ctx, dkPath, map[string]any{"bits": 256})
 	if err != nil {
-		return nil, nil, nil, "", classifyVaultEncryptError(err)
+		return kcrypto.EncryptResult{}, classifyVaultEncryptError(err)
 	}
 
 	plaintextB64, ok := result["plaintext"].(string)
 	if !ok {
-		return nil, nil, nil, "", errcode.New(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
+		return kcrypto.EncryptResult{}, errcode.New(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
 			"vault-transit: datakey response missing string 'plaintext' field")
 	}
 	dek, err := base64.StdEncoding.DecodeString(plaintextB64)
 	if err != nil {
-		return nil, nil, nil, "", errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
+		return kcrypto.EncryptResult{}, errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
 			"vault-transit: base64 decode DEK from datakey response", err)
 	}
 	defer clear(dek)
 
 	ciphertextStr, ok := result["ciphertext"].(string)
 	if !ok {
-		return nil, nil, nil, "", errcode.New(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
+		return kcrypto.EncryptResult{}, errcode.New(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
 			"vault-transit: datakey response missing string 'ciphertext' field")
 	}
-	keyID, err = parseVaultKeyID(ciphertextStr, errcode.ErrKeyProviderEncryptFailed)
+	keyID, err := parseVaultKeyID(ciphertextStr, errcode.ErrKeyProviderEncryptFailed)
 	if err != nil {
-		return nil, nil, nil, "", err
+		return kcrypto.EncryptResult{}, err
 	}
 
-	ciphertext, nonce, err = aeadutil.EncryptGCM(dek, plaintext, aad)
+	ciphertext, nonce, err := aeadutil.EncryptGCM(dek, plaintext, aad)
 	if err != nil {
-		return nil, nil, nil, "", errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
+		return kcrypto.EncryptResult{}, errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
 			"vault-transit: local AES-GCM encrypt", err)
 	}
 
-	return ciphertext, nonce, []byte(ciphertextStr), keyID, nil
+	return kcrypto.EncryptResult{
+		Ciphertext: ciphertext,
+		Nonce:      nonce,
+		EDK:        []byte(ciphertextStr),
+		KeyID:      keyID,
+	}, nil
 }
 
 // Decrypt decrypts ciphertext using envelope decryption.

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1096,7 +1097,7 @@ func isTransientHTTPStatus(code int) bool {
 func parseVaultKeyID(ciphertext string, errCode errcode.Code) (string, error) {
 	// Expected format: "vault:vN:base64payload"
 	parts := strings.SplitN(ciphertext, ":", 3)
-	if len(parts) != 3 || parts[0] != "vault" || !strings.HasPrefix(parts[1], "v") {
+	if len(parts) != 3 || parts[0] != "vault" || !validVaultKeyVersion(parts[1]) {
 		// Do NOT include the full ciphertext in the error message — it contains
 		// the wrapped DEK and would leak to server-side logs via the 5xx error chain.
 		prefix := ciphertext
@@ -1109,6 +1110,20 @@ func parseVaultKeyID(ciphertext string, errCode errcode.Code) (string, error) {
 			errcode.WithInternal(fmt.Sprintf("prefix=%q", prefix)))
 	}
 	return vaultKeyIDPrefix + parts[1], nil
+}
+
+func validVaultKeyVersion(version string) bool {
+	digits, ok := strings.CutPrefix(version, "v")
+	if !ok || digits == "" || digits[0] == '0' {
+		return false
+	}
+	for _, ch := range digits {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	_, err := strconv.Atoi(digits)
+	return err == nil
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -890,6 +890,26 @@ func TestParseVaultKeyID(t *testing.T) {
 			ciphertext: "vault:notv:data",
 			wantErr:    true,
 		},
+		{
+			name:       "empty version after v → error",
+			ciphertext: "vault:v:data",
+			wantErr:    true,
+		},
+		{
+			name:       "non-numeric version → error",
+			ciphertext: "vault:vx:data",
+			wantErr:    true,
+		},
+		{
+			name:       "signed version → error",
+			ciphertext: "vault:v-1:data",
+			wantErr:    true,
+		},
+		{
+			name:       "zero version → error",
+			ciphertext: "vault:v0:data",
+			wantErr:    true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1349,51 +1369,91 @@ func TestTransitKeyProvider_ConcurrentEncryptRotate(t *testing.T) {
 
 	ctx := context.Background()
 	const encryptWorkers = 8
+	const encryptIterations = 20
 	const rotations = 5
 
 	var wg sync.WaitGroup
+	errCh := make(chan error, encryptWorkers+1)
+	var encryptSuccesses atomic.Int64
+	var rotateSuccesses atomic.Int64
 
 	// 8 goroutines concurrently encrypting.
 	for range encryptWorkers {
-		wg.Go(func() { runConcurrentEncryptLoop(ctx, p, 20) })
+		wg.Go(func() {
+			successes, err := runConcurrentEncryptLoop(ctx, p, encryptIterations)
+			encryptSuccesses.Add(int64(successes))
+			if err != nil {
+				errCh <- err
+			}
+		})
 	}
 
 	// 1 goroutine doing periodic rotations.
-	wg.Go(func() { runConcurrentRotateLoop(ctx, p, rotations) })
+	wg.Go(func() {
+		successes, err := runConcurrentRotateLoop(ctx, p, rotations)
+		rotateSuccesses.Add(int64(successes))
+		if err != nil {
+			errCh <- err
+		}
+	})
 
 	wg.Wait()
-	// No race detector report = pass. The test itself needs -race to be meaningful.
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("concurrent encrypt/rotate produced errors: %v", errors.Join(errs...))
+	}
+
+	wantEncrypts := int64(encryptWorkers * encryptIterations)
+	if got := encryptSuccesses.Load(); got != wantEncrypts {
+		t.Fatalf("encrypt successes = %d, want %d", got, wantEncrypts)
+	}
+	if got := rotateSuccesses.Load(); got != rotations {
+		t.Fatalf("rotate successes = %d, want %d", got, rotations)
+	}
+
+	if got := p.cachedLatestVersion.Load(); got != int64(1+rotations) {
+		t.Fatalf("cached latest version = %d, want %d", got, 1+rotations)
+	}
 }
 
 // runConcurrentEncryptLoop is the per-worker body of
 // TestTransitKeyProvider_ConcurrentEncryptRotate. Pulled out so the test
-// itself stays under the cognitive-complexity threshold; transient errors
-// from a parallel Rotate are expected and silently terminate the loop.
-func runConcurrentEncryptLoop(ctx context.Context, p *TransitKeyProvider, iterations int) {
-	for range iterations {
+// itself stays under the cognitive-complexity threshold.
+func runConcurrentEncryptLoop(ctx context.Context, p *TransitKeyProvider, iterations int) (int, error) {
+	successes := 0
+	for i := range iterations {
 		h, err := p.Current(ctx)
 		if err != nil {
-			return
+			return successes, fmt.Errorf("Current iteration %d: %w", i, err)
 		}
 		vh, ok := h.(*vaultTransitHandle)
 		if !ok {
-			return
+			return successes, fmt.Errorf("Current iteration %d returned %T, want *vaultTransitHandle", i, h)
 		}
 		if _, err := vh.Encrypt(ctx, []byte("payload"), []byte("aad")); err != nil {
-			return // transient error during concurrent rotation is expected
+			return successes, fmt.Errorf("Encrypt iteration %d: %w", i, err)
 		}
+		successes++
 	}
+	return successes, nil
 }
 
 // runConcurrentRotateLoop is the rotator body of
-// TestTransitKeyProvider_ConcurrentEncryptRotate. Transient rotate errors
-// are acceptable in this race test and silently terminate the loop.
-func runConcurrentRotateLoop(ctx context.Context, p *TransitKeyProvider, iterations int) {
-	for range iterations {
+// TestTransitKeyProvider_ConcurrentEncryptRotate.
+func runConcurrentRotateLoop(ctx context.Context, p *TransitKeyProvider, iterations int) (int, error) {
+	successes := 0
+	for i := range iterations {
 		if _, err := p.Rotate(ctx); err != nil {
-			return
+			return successes, fmt.Errorf("Rotate iteration %d: %w", i, err)
 		}
+		successes++
 	}
+	return successes, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -271,13 +271,14 @@ func mustCurrent(t *testing.T, p *TransitKeyProvider) *vaultTransitHandle {
 	return handle
 }
 
-// callEncrypt is a typed facade over h.Encrypt that returns the five-tuple
-// directly — keeps the assertion surface in tests concise.
+// callEncrypt is a typed facade over h.Encrypt that unpacks EncryptResult so
+// older assertion-heavy tests stay concise.
 func callEncrypt(
 	t *testing.T, h *vaultTransitHandle, ctx context.Context, plaintext, aad []byte,
 ) (ct, nonce, edk []byte, keyID string, err error) {
 	t.Helper()
-	return h.Encrypt(ctx, plaintext, aad)
+	result, err := h.Encrypt(ctx, plaintext, aad)
+	return result.Ciphertext, result.Nonce, result.EDK, result.KeyID, err
 }
 
 // callDecrypt is a typed facade over h.Decrypt.
@@ -1378,7 +1379,7 @@ func runConcurrentEncryptLoop(ctx context.Context, p *TransitKeyProvider, iterat
 		if !ok {
 			return
 		}
-		if _, _, _, _, err := vh.Encrypt(ctx, []byte("payload"), []byte("aad")); err != nil {
+		if _, err := vh.Encrypt(ctx, []byte("payload"), []byte("aad")); err != nil {
 			return // transient error during concurrent rotation is expected
 		}
 	}

--- a/cells/configcore/internal/adapters/postgres/config_repo.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo.go
@@ -96,6 +96,13 @@ const cellID = "configcore"
 
 const configRepoQueryFailedMessage = "config repo query failed"
 
+type encryptedPayload struct {
+	Ciphertext []byte
+	KeyID      string
+	Nonce      []byte
+	EDK        []byte
+}
+
 // Compile-time interface check.
 var _ ports.ConfigRepository = (*ConfigRepository)(nil)
 
@@ -178,18 +185,22 @@ func (r *ConfigRepository) resolveWriteDB(ctx context.Context) (DBTX, error) {
 }
 
 // encryptValue encrypts value for a sensitive entry using the transformer.
-// Returns (ciphertext, keyID, nonce, edk) or error.
-func (r *ConfigRepository) encryptValue(ctx context.Context, key, value string) (ct []byte, keyID string, nonce, edk []byte, err error) {
+func (r *ConfigRepository) encryptValue(ctx context.Context, key, value string) (encryptedPayload, error) {
 	if r.transformer == nil {
-		return nil, "", nil, nil, errcode.New(errcode.KindInternal, errcode.ErrConfigKeyMissing,
+		return encryptedPayload{}, errcode.New(errcode.KindInternal, errcode.ErrConfigKeyMissing,
 			"config repo: no ValueTransformer configured for sensitive entry")
 	}
 	aad := configcrypto.AADForConfig(cellID, key)
 	result, err := r.transformer.Encrypt(ctx, []byte(value), aad)
 	if err != nil {
-		return nil, "", nil, nil, r.cryptoOpError(errcode.ErrConfigEncryptFailed, "Encrypt", "key="+key, err)
+		return encryptedPayload{}, r.cryptoOpError(errcode.ErrConfigEncryptFailed, "Encrypt", "key="+key, err)
 	}
-	return result.Ciphertext, result.KeyID, result.Nonce, result.EDK, nil
+	return encryptedPayload{
+		Ciphertext: result.Ciphertext,
+		KeyID:      result.KeyID,
+		Nonce:      result.Nonce,
+		EDK:        result.EDK,
+	}, nil
 }
 
 // decryptValue decrypts a cipher-column tuple for a sensitive entry.
@@ -213,17 +224,22 @@ func (r *ConfigRepository) decryptValue(ctx context.Context, key string, ct []by
 // configID is the UUID primary key from config_entries.
 func (r *ConfigRepository) encryptVersionValue(
 	ctx context.Context, configID, value string,
-) (ct []byte, keyID string, nonce, edk []byte, err error) {
+) (encryptedPayload, error) {
 	if r.transformer == nil {
-		return nil, "", nil, nil, errcode.New(errcode.KindInternal, errcode.ErrConfigKeyMissing,
+		return encryptedPayload{}, errcode.New(errcode.KindInternal, errcode.ErrConfigKeyMissing,
 			"config repo: no ValueTransformer configured for sensitive version")
 	}
 	aad := configcrypto.AADForVersion(cellID, configID)
 	result, err := r.transformer.Encrypt(ctx, []byte(value), aad)
 	if err != nil {
-		return nil, "", nil, nil, r.cryptoOpError(errcode.ErrConfigEncryptFailed, "EncryptVersion", "config_id="+configID, err)
+		return encryptedPayload{}, r.cryptoOpError(errcode.ErrConfigEncryptFailed, "EncryptVersion", "config_id="+configID, err)
 	}
-	return result.Ciphertext, result.KeyID, result.Nonce, result.EDK, nil
+	return encryptedPayload{
+		Ciphertext: result.Ciphertext,
+		KeyID:      result.KeyID,
+		Nonce:      result.Nonce,
+		EDK:        result.EDK,
+	}, nil
 }
 
 // decryptVersionValue decrypts a cipher-column tuple for a sensitive config version.
@@ -262,12 +278,10 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 	}
 
 	if entry.Sensitive {
-		ct, keyID, nonce, edk, encErr := r.encryptValue(ctx, entry.Key, entry.Value)
+		payload, encErr := r.encryptValue(ctx, entry.Key, entry.Value)
 		if encErr != nil {
 			return encErr
 		}
-		// NOTE: SQL param order (edk, nonce) differs from encryptValue return
-		// order (nonce, edk). Matches column order: value_edk=$10, value_nonce=$11.
 		const q = `INSERT INTO config_entries
 			(id, key, value, sensitive, version, created_at, updated_at,
 			 value_cipher, value_key_id, value_edk, value_nonce)
@@ -275,7 +289,7 @@ func (r *ConfigRepository) Create(ctx context.Context, entry *domain.ConfigEntry
 		_, err = db.Exec(ctx, q,
 			entry.ID, entry.Key, "", entry.Sensitive, entry.Version,
 			entry.CreatedAt, entry.UpdatedAt,
-			ct, keyID, edk, nonce,
+			payload.Ciphertext, payload.KeyID, payload.EDK, payload.Nonce,
 		)
 	} else {
 		const q = `INSERT INTO config_entries
@@ -499,18 +513,16 @@ func (r *ConfigRepository) doUpdate(
 ) (*domain.ConfigEntry, error) {
 	var row Row
 	if sensitive {
-		ct, keyID, nonce, edk, encErr := r.encryptValue(ctx, key, value)
+		payload, encErr := r.encryptValue(ctx, key, value)
 		if encErr != nil {
 			return nil, encErr
 		}
-		// NOTE: SQL param order (edk, nonce) differs from encryptValue return
-		// order (nonce, edk). Matches the column order: value_edk=$3, value_nonce=$4.
 		const q = `UPDATE config_entries
 			SET value = '', sensitive = true, version = version+1, updated_at = now(),
 			    value_cipher = $1, value_key_id = $2, value_edk = $3, value_nonce = $4
 			WHERE key = $5
 			RETURNING ` + configEntryColumns
-		row = db.QueryRow(ctx, q, ct, keyID, edk, nonce, key)
+		row = db.QueryRow(ctx, q, payload.Ciphertext, payload.KeyID, payload.EDK, payload.Nonce, key)
 	} else {
 		const q = `UPDATE config_entries
 			SET value = $1, sensitive = false, version = version+1, updated_at = now(),
@@ -657,7 +669,7 @@ func (r *ConfigRepository) PublishVersion(ctx context.Context, version *domain.C
 	}
 
 	if version.Sensitive {
-		ct, keyID, nonce, edk, encErr := r.encryptVersionValue(ctx, version.ConfigID, version.Value)
+		payload, encErr := r.encryptVersionValue(ctx, version.ConfigID, version.Value)
 		if encErr != nil {
 			return encErr
 		}
@@ -668,7 +680,7 @@ func (r *ConfigRepository) PublishVersion(ctx context.Context, version *domain.C
 		_, err = db.Exec(ctx, q,
 			version.ID, version.ConfigID, version.Version,
 			"", version.Sensitive, version.PublishedAt,
-			ct, keyID, edk, nonce,
+			payload.Ciphertext, payload.KeyID, payload.EDK, payload.Nonce,
 		)
 	} else {
 		const q = `INSERT INTO config_versions

--- a/cells/configcore/internal/adapters/postgres/config_repo.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo.go
@@ -185,11 +185,11 @@ func (r *ConfigRepository) encryptValue(ctx context.Context, key, value string) 
 			"config repo: no ValueTransformer configured for sensitive entry")
 	}
 	aad := configcrypto.AADForConfig(cellID, key)
-	ct, keyID, nonce, edk, err = r.transformer.Encrypt(ctx, []byte(value), aad)
+	result, err := r.transformer.Encrypt(ctx, []byte(value), aad)
 	if err != nil {
 		return nil, "", nil, nil, r.cryptoOpError(errcode.ErrConfigEncryptFailed, "Encrypt", "key="+key, err)
 	}
-	return ct, keyID, nonce, edk, nil
+	return result.Ciphertext, result.KeyID, result.Nonce, result.EDK, nil
 }
 
 // decryptValue decrypts a cipher-column tuple for a sensitive entry.
@@ -219,11 +219,11 @@ func (r *ConfigRepository) encryptVersionValue(
 			"config repo: no ValueTransformer configured for sensitive version")
 	}
 	aad := configcrypto.AADForVersion(cellID, configID)
-	ct, keyID, nonce, edk, err = r.transformer.Encrypt(ctx, []byte(value), aad)
+	result, err := r.transformer.Encrypt(ctx, []byte(value), aad)
 	if err != nil {
 		return nil, "", nil, nil, r.cryptoOpError(errcode.ErrConfigEncryptFailed, "EncryptVersion", "config_id="+configID, err)
 	}
-	return ct, keyID, nonce, edk, nil
+	return result.Ciphertext, result.KeyID, result.Nonce, result.EDK, nil
 }
 
 // decryptVersionValue decrypts a cipher-column tuple for a sensitive config version.

--- a/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -1043,7 +1043,7 @@ func TestEncrypt_FailEncrypt_RoutesToErrConfigEncryptFailed(t *testing.T) {
 	t.Run("encryptValue direct call (covers Update sensitive write path)", func(t *testing.T) {
 		tr := &fakeValueTransformer{currentKeyID: "v1", failEncrypt: true}
 		repo := newEncryptedRepoFromDBTX(&mockDB{}, tr)
-		_, _, _, _, err := repo.encryptValue(ctx, "update_key", "new_value")
+		_, err := repo.encryptValue(ctx, "update_key", "new_value")
 		require.Error(t, err)
 		var ec *errcode.Error
 		require.True(t, errors.As(err, &ec), "error must be *errcode.Error")

--- a/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -59,9 +59,9 @@ func (f *fakeValueTransformer) CurrentKeyID(_ context.Context) (string, error) {
 
 const fakeNonce = "FAKENC123456" // 12 bytes
 
-func (f *fakeValueTransformer) Encrypt(_ context.Context, plaintext, aad []byte) ([]byte, string, []byte, []byte, error) {
+func (f *fakeValueTransformer) Encrypt(_ context.Context, plaintext, aad []byte) (crypto.EncryptResult, error) {
 	if f.failEncrypt {
-		return nil, "", nil, nil, errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "fake: forced encrypt failure")
+		return crypto.EncryptResult{}, errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "fake: forced encrypt failure")
 	}
 	// Fake cipher: XOR each byte with 0x55.
 	ct := make([]byte, len(plaintext))
@@ -70,7 +70,12 @@ func (f *fakeValueTransformer) Encrypt(_ context.Context, plaintext, aad []byte)
 	}
 	// Encode AAD into edk so Decrypt can verify binding without mutable state.
 	edk := append([]byte("edk-"+f.currentKeyID+":aad:"), aad...)
-	return ct, f.currentKeyID, []byte(fakeNonce), edk, nil
+	return crypto.EncryptResult{
+		Ciphertext: ct,
+		Nonce:      []byte(fakeNonce),
+		EDK:        edk,
+		KeyID:      f.currentKeyID,
+	}, nil
 }
 
 func (f *fakeValueTransformer) Decrypt(_ context.Context, ciphertext []byte, keyID string, _, edk, aad []byte) ([]byte, error) {
@@ -181,7 +186,7 @@ func TestEncrypt_GetByKey_SensitiveDecryptsValue(t *testing.T) {
 
 	// Build what the DB row looks like after encryption.
 	original := "s3cr3t"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "db_password"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "db_password"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -191,7 +196,7 @@ func TestEncrypt_GetByKey_SensitiveDecryptsValue(t *testing.T) {
 			//             value_cipher, value_key_id, value_edk, value_nonce
 			values: []any{
 				"cfg-1", "db_password", "", true, 1, now, now,
-				ct, keyID, edk, nonce,
+				result.Ciphertext, result.KeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -236,7 +241,7 @@ func TestEncrypt_GetByKey_SensitiveStaleKey(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	original := "stale-value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "old_key"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "old_key"))
 	require.NoError(t, err)
 
 	// Simulate key rotation: current is now v2, but the row was encrypted with v1.
@@ -248,7 +253,7 @@ func TestEncrypt_GetByKey_SensitiveStaleKey(t *testing.T) {
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "old_key", "", true, 1, now, now,
-				ct, oldKeyID, edk, nonce,
+				result.Ciphertext, oldKeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -292,13 +297,13 @@ func TestEncrypt_UpdateForRollback_SensitiveWritesCipherColumns(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	// Build what the DB RETURNING row looks like after encryption.
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte("new-secret"), configcrypto.AADForConfig("configcore", "api_key"))
+	result, err := tr.Encrypt(ctx, []byte("new-secret"), configcrypto.AADForConfig("configcore", "api_key"))
 	require.NoError(t, err)
 
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
-			values: []any{"cfg-1", "api_key", "", true, 2, now, now, ct, keyID, edk, nonce},
+			values: []any{"cfg-1", "api_key", "", true, 2, now, now, result.Ciphertext, result.KeyID, result.EDK, result.Nonce},
 		},
 	}
 	repo := newEncryptedRepoFromDBTX(db, tr)
@@ -347,7 +352,7 @@ func TestEncrypt_GetVersion_SensitiveDecryptsValue(t *testing.T) {
 
 	original := "published-secret"
 	// Use AADForVersion — matches decryptVersionValue called by GetVersion.
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForVersion("configcore", "cfg-1"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForVersion("configcore", "cfg-1"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -357,7 +362,7 @@ func TestEncrypt_GetVersion_SensitiveDecryptsValue(t *testing.T) {
 			// value_cipher, value_key_id, value_edk, value_nonce
 			values: []any{
 				"cv-1", "cfg-1", 1, "", true, &now,
-				ct, keyID, edk, nonce,
+				result.Ciphertext, result.KeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -408,20 +413,20 @@ func TestConfigRepo_Decrypt_AADMismatch_FailsClosed(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	// Encrypt value for "other_key" — edk embeds "other_key" AAD.
-	ct, keyID, nonce, _, err := tr.Encrypt(ctx, []byte("secret"), configcrypto.AADForConfig("configcore", "other_key"))
+	result, err := tr.Encrypt(ctx, []byte("secret"), configcrypto.AADForConfig("configcore", "other_key"))
 	require.NoError(t, err)
 
 	// Construct an edk that binds to "other_key" AAD (cross-row replay).
 	// When GetByKey reads "db_password", the repo passes "db_password" AAD to
 	// Decrypt, which won't match this edk → ErrConfigDecryptFailed.
-	wrongEDK := append([]byte("edk-"+keyID+":aad:"), configcrypto.AADForConfig("configcore", "other_key")...)
+	wrongEDK := append([]byte("edk-"+result.KeyID+":aad:"), configcrypto.AADForConfig("configcore", "other_key")...)
 
 	now := time.Now()
 	db := &mockDB{
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "db_password", "", true, 1, now, now,
-				ct, keyID, wrongEDK, nonce,
+				result.Ciphertext, result.KeyID, wrongEDK, result.Nonce,
 			},
 		},
 	}
@@ -487,7 +492,7 @@ func TestCurrentKeyID_ProviderReturnsError(t *testing.T) {
 	}
 
 	original := "some-secret"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "my_key"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "my_key"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -495,7 +500,7 @@ func TestCurrentKeyID_ProviderReturnsError(t *testing.T) {
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "my_key", "", true, 1, now, now,
-				ct, keyID, edk, nonce,
+				result.Ciphertext, result.KeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -515,7 +520,7 @@ func TestGetByKey_Sensitive_StaleKey_DifferentStoredAndCurrentKeyID(t *testing.T
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"} // encrypt with v1 first
 
 	original := "stale-value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "cfg_key"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "cfg_key"))
 	require.NoError(t, err)
 
 	// Now simulate key rotation: current is v2, but stored row has v1.
@@ -527,7 +532,7 @@ func TestGetByKey_Sensitive_StaleKey_DifferentStoredAndCurrentKeyID(t *testing.T
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "cfg_key", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce,
+				result.Ciphertext, storedKeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -574,7 +579,7 @@ func TestGetByKey_StaleKey_EmitsWarn(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	original := "sensitive-value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "api_secret"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "api_secret"))
 	require.NoError(t, err)
 
 	storedKeyID := "local-aes-v1"
@@ -585,7 +590,7 @@ func TestGetByKey_StaleKey_EmitsWarn(t *testing.T) {
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "api_secret", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce,
+				result.Ciphertext, storedKeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -619,7 +624,7 @@ func TestGetByKey_FreshKey_NoWarn(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	original := "fresh-value"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "fresh_key"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "fresh_key"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -627,7 +632,7 @@ func TestGetByKey_FreshKey_NoWarn(t *testing.T) {
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "fresh_key", "", true, 1, now, now,
-				ct, keyID, edk, nonce,
+				result.Ciphertext, result.KeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -696,7 +701,7 @@ func TestGetByKey_StaleKey_OnStaleCipherCallback(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	original := "value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "cb_key"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "cb_key"))
 	require.NoError(t, err)
 
 	storedKeyID := "local-aes-v1"
@@ -707,7 +712,7 @@ func TestGetByKey_StaleKey_OnStaleCipherCallback(t *testing.T) {
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "cb_key", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce,
+				result.Ciphertext, storedKeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -896,7 +901,7 @@ func TestWithOnStaleCipher_Option(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	original := "value"
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "opt_key"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "opt_key"))
 	require.NoError(t, err)
 
 	storedKeyID := "local-aes-v1"
@@ -907,7 +912,7 @@ func TestWithOnStaleCipher_Option(t *testing.T) {
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "opt_key", "", true, 1, now, now,
-				ct, storedKeyID, edk, nonce,
+				result.Ciphertext, storedKeyID, result.EDK, result.Nonce,
 			},
 		},
 	}
@@ -1056,7 +1061,7 @@ func TestGetByKey_FreshKey_OnStaleCipherCallback_NotCalled(t *testing.T) {
 	tr := &fakeValueTransformer{currentKeyID: "local-aes-v1"}
 
 	original := "value"
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "fresh_cb_key"))
+	result, err := tr.Encrypt(ctx, []byte(original), configcrypto.AADForConfig("configcore", "fresh_cb_key"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -1064,7 +1069,7 @@ func TestGetByKey_FreshKey_OnStaleCipherCallback_NotCalled(t *testing.T) {
 		queryRowResult: &mockRow{
 			values: []any{
 				"cfg-1", "fresh_cb_key", "", true, 1, now, now,
-				ct, keyID, edk, nonce,
+				result.Ciphertext, result.KeyID, result.EDK, result.Nonce,
 			},
 		},
 	}

--- a/cells/configcore/internal/adapters/postgres/config_repo_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_test.go
@@ -569,8 +569,13 @@ type mockTransformerForTest struct {
 
 var _ crypto.ValueTransformer = (*mockTransformerForTest)(nil)
 
-func (m *mockTransformerForTest) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, string, []byte, []byte, error) {
-	return plaintext, m.keyID, []byte("nonce1234567"), []byte("edk"), nil
+func (m *mockTransformerForTest) Encrypt(_ context.Context, plaintext, _ []byte) (crypto.EncryptResult, error) {
+	return crypto.EncryptResult{
+		Ciphertext: plaintext,
+		Nonce:      []byte("nonce1234567"),
+		EDK:        []byte("edk"),
+		KeyID:      m.keyID,
+	}, nil
 }
 
 func (m *mockTransformerForTest) Decrypt(_ context.Context, ciphertext []byte, _ string, _, _, _ []byte) ([]byte, error) {

--- a/cells/configcore/internal/adapters/postgres/plaintext_migration.go
+++ b/cells/configcore/internal/adapters/postgres/plaintext_migration.go
@@ -207,11 +207,11 @@ func (m *plaintextMigrator) encryptBatch(
 ) error {
 	for _, row := range batch {
 		aad := computeAAD(table, row.aadIdentity)
-		ct, keyID, nonce, edk, encErr := m.transformer.Encrypt(ctx, []byte(row.value), aad)
+		encResult, encErr := m.transformer.Encrypt(ctx, []byte(row.value), aad)
 		if encErr != nil {
 			return fmt.Errorf("plaintext-migrator: encrypt aad_identity=%s: %w", row.aadIdentity, encErr)
 		}
-		skipped, err := m.updateRow(ctx, updateQ, row.id, ct, keyID, nonce, edk)
+		skipped, err := m.updateRow(ctx, updateQ, row.id, encResult.Ciphertext, encResult.KeyID, encResult.Nonce, encResult.EDK)
 		if err != nil {
 			return fmt.Errorf("plaintext-migrator: update aad_identity=%s: %w", row.aadIdentity, err)
 		}

--- a/cells/configcore/internal/adapters/postgres/plaintext_migration_test.go
+++ b/cells/configcore/internal/adapters/postgres/plaintext_migration_test.go
@@ -13,6 +13,7 @@ import (
 
 	configcrypto "github.com/ghbvf/gocell/cells/configcore/internal/crypto"
 	"github.com/ghbvf/gocell/kernel/clock"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
@@ -127,9 +128,14 @@ func (r *fakeEmptyRow) Scan(_ ...any) error { return errors.New("no rows") }
 
 type noopTransformerForMigTest struct{}
 
-func (noopTransformerForMigTest) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, string, []byte, []byte, error) {
+func (noopTransformerForMigTest) Encrypt(_ context.Context, plaintext, _ []byte) (kcrypto.EncryptResult, error) {
 	ct := append([]byte("enc:"), plaintext...)
-	return ct, "test-key-v1", []byte("nonce"), []byte("edk"), nil
+	return kcrypto.EncryptResult{
+		Ciphertext: ct,
+		Nonce:      []byte("nonce"),
+		EDK:        []byte("edk"),
+		KeyID:      "test-key-v1",
+	}, nil
 }
 
 func (noopTransformerForMigTest) Decrypt(_ context.Context, ciphertext []byte, _ string, _, _, _ []byte) ([]byte, error) {
@@ -345,14 +351,14 @@ type aadAwareTransformer struct {
 	keyID string
 }
 
-func (t *aadAwareTransformer) Encrypt(_ context.Context, pt, aad []byte) ([]byte, string, []byte, []byte, error) {
+func (t *aadAwareTransformer) Encrypt(_ context.Context, pt, aad []byte) (kcrypto.EncryptResult, error) {
 	var lenBuf [4]byte
 	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(aad)&0xffffffff))
 	ct := make([]byte, 0, 4+len(aad)+len(pt))
 	ct = append(ct, lenBuf[:]...)
 	ct = append(ct, aad...)
 	ct = append(ct, pt...)
-	return ct, t.keyID, nil, nil, nil
+	return kcrypto.EncryptResult{Ciphertext: ct, KeyID: t.keyID}, nil
 }
 
 func (t *aadAwareTransformer) Decrypt(_ context.Context, ct []byte, _ string, _, _, aad []byte) ([]byte, error) {

--- a/cmd/corebundle/key_provider_test.go
+++ b/cmd/corebundle/key_provider_test.go
@@ -181,10 +181,10 @@ func TestKeyProviderToTransformer_NilReturnsNoop(t *testing.T) {
 	vt := keyProviderToTransformer(nil)
 	require.NotNil(t, vt)
 	// Ensure it's actually a no-op: encrypt returns plaintext unchanged.
-	ct, keyID, nonce, edk, err := vt.Encrypt(context.Background(), []byte("plain"), nil)
+	result, err := vt.Encrypt(context.Background(), []byte("plain"), nil)
 	require.NoError(t, err)
-	assert.Equal(t, "plain", string(ct))
-	assert.Empty(t, keyID)
-	assert.Nil(t, nonce)
-	assert.Nil(t, edk)
+	assert.Equal(t, "plain", string(result.Ciphertext))
+	assert.Empty(t, result.KeyID)
+	assert.Nil(t, result.Nonce)
+	assert.Nil(t, result.EDK)
 }

--- a/cmd/corebundle/vault_readiness_wiring_test.go
+++ b/cmd/corebundle/vault_readiness_wiring_test.go
@@ -63,8 +63,8 @@ type fakeKeyHandle struct{}
 
 func (fakeKeyHandle) ID() string { return "fake-v1" }
 
-func (fakeKeyHandle) Encrypt(_ context.Context, _, _ []byte) ([]byte, []byte, []byte, string, error) {
-	return nil, nil, nil, "", errors.New("fakeKeyHandle.Encrypt must not be called in readiness tests")
+func (fakeKeyHandle) Encrypt(_ context.Context, _, _ []byte) (kcrypto.EncryptResult, error) {
+	return kcrypto.EncryptResult{}, errors.New("fakeKeyHandle.Encrypt must not be called in readiness tests")
 }
 
 func (fakeKeyHandle) Decrypt(_ context.Context, _, _, _, _ []byte) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ghbvf/gocell
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7

--- a/kernel/crypto/key_provider.go
+++ b/kernel/crypto/key_provider.go
@@ -25,6 +25,25 @@ type KeyProvider interface {
 	Rotate(ctx context.Context) (newKeyID string, err error)
 }
 
+// EncryptResult is the named output of an encryption operation.
+//
+// Returning a struct instead of positional values keeps KeyHandle and
+// ValueTransformer aligned and prevents nonce/keyID/EDK tuple swaps at storage
+// boundaries.
+type EncryptResult struct {
+	// Ciphertext is the encrypted payload.
+	Ciphertext []byte
+	// Nonce is the per-encryption AEAD nonce. Crypto-active KeyHandle
+	// implementations MUST generate fresh nonce material for every successful
+	// Encrypt call.
+	Nonce []byte
+	// EDK is the encrypted data key or provider-specific wrapped key material.
+	EDK []byte
+	// KeyID is the encrypt-time key version identifier actually used to protect
+	// the payload. Callers MUST persist this value alongside Ciphertext.
+	KeyID string
+}
+
 // KeyHandle is a thin handle for a specific key version. It provides the
 // cryptographic primitives needed by ValueTransformer.
 //
@@ -49,20 +68,11 @@ type KeyHandle interface {
 	ID() string
 
 	// Encrypt encrypts plaintext under this key using the provided aad as
-	// Additional Authenticated Data.  Returns:
-	//   - ciphertext: the encrypted payload (opaque bytes; may embed nonce for
-	//     some backends like VaultTransit).
-	//   - nonce:      random IV used for AES-GCM (nil for backends that embed it).
-	//   - edk:        encrypted DEK for envelope encryption (nil for backends
-	//     like VaultTransit that manage keys server-side).
-	//   - keyID:      the KEK version identifier actually used at encrypt-time.
-	//     Callers MUST persist this value alongside the ciphertext so that the
-	//     correct key can be resolved during decryption.  Returning keyID from
-	//     Encrypt (rather than reading handle.ID() after the call) eliminates
-	//     the race between a Current() call and a key rotation in VaultTransit.
-	//     Mirrors k8s KMS v2 EncryptResponse.KeyID semantics.
-	//   - err:        non-nil on any encryption failure (fail-closed).
-	Encrypt(ctx context.Context, plaintext, aad []byte) (ciphertext, nonce, edk []byte, keyID string, err error)
+	// Additional Authenticated Data. Callers MUST persist the returned
+	// EncryptResult.KeyID rather than reading handle.ID() after the call; this
+	// eliminates the race between Current() and key rotation in backends like
+	// VaultTransit. Mirrors k8s KMS v2 EncryptResponse.KeyID semantics.
+	Encrypt(ctx context.Context, plaintext, aad []byte) (EncryptResult, error)
 
 	// Decrypt decrypts ciphertext encrypted by this key. The aad must match
 	// exactly what was provided to Encrypt; mismatched aad returns ErrDecryptFailed.

--- a/kernel/crypto/key_provider_test.go
+++ b/kernel/crypto/key_provider_test.go
@@ -24,8 +24,13 @@ func (fakeProvider) Rotate(_ context.Context) (string, error) { return "", nil }
 type fakeHandle struct{}
 
 func (fakeHandle) ID() string { return "fake-v1" }
-func (fakeHandle) Encrypt(_ context.Context, _, _ []byte) ([]byte, []byte, []byte, string, error) {
-	return nil, nil, nil, "fake-v1", nil
+func (fakeHandle) Encrypt(_ context.Context, _, _ []byte) (kcrypto.EncryptResult, error) {
+	return kcrypto.EncryptResult{
+		Ciphertext: []byte("ciphertext"),
+		Nonce:      []byte("nonce"),
+		EDK:        []byte("edk"),
+		KeyID:      "fake-v1",
+	}, nil
 }
 func (fakeHandle) Decrypt(_ context.Context, _, _, _, _ []byte) ([]byte, error) { return nil, nil }
 
@@ -69,12 +74,15 @@ func TestKeyHandle_InterfaceMethods(t *testing.T) {
 		t.Fatalf("ID: expected fake-v1, got %s", h.ID())
 	}
 
-	_, _, _, keyID, err := h.Encrypt(ctx, []byte("plain"), []byte("aad"))
+	result, err := h.Encrypt(ctx, []byte("plain"), []byte("aad"))
 	if err != nil {
 		t.Fatalf("Encrypt: unexpected error: %v", err)
 	}
-	if keyID == "" {
+	if result.KeyID == "" {
 		t.Fatal("Encrypt: keyID must not be empty")
+	}
+	if len(result.Ciphertext) == 0 {
+		t.Fatal("Encrypt: ciphertext must not be empty")
 	}
 
 	_, err = h.Decrypt(ctx, nil, nil, nil, []byte("aad"))

--- a/kernel/crypto/value_transformer.go
+++ b/kernel/crypto/value_transformer.go
@@ -20,10 +20,9 @@ import (
 // ref: kubernetes/kubernetes staging/.../storage/value/transformer.go@master
 type ValueTransformer interface {
 	// Encrypt encrypts plaintext under the current key.
-	// Returns (ciphertext, keyID, nonce, edk, error).
-	// keyID identifies the key version; store alongside the ciphertext so that
-	// Decrypt can resolve the correct historical key on read.
-	Encrypt(ctx context.Context, plaintext, aad []byte) (ciphertext []byte, keyID string, nonce, edk []byte, err error)
+	// EncryptResult.KeyID identifies the key version; store it alongside the
+	// ciphertext so Decrypt can resolve the correct historical key on read.
+	Encrypt(ctx context.Context, plaintext, aad []byte) (EncryptResult, error)
 
 	// Decrypt decrypts ciphertext using the key identified by keyID.
 	// Fail-closed: returns an error on any decryption failure; never returns

--- a/kernel/crypto/value_transformer_test.go
+++ b/kernel/crypto/value_transformer_test.go
@@ -15,8 +15,13 @@ import (
 // fakeTransformer satisfies ValueTransformer.
 type fakeTransformer struct{}
 
-func (fakeTransformer) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, string, []byte, []byte, error) {
-	return plaintext, "fake-key-v1", nil, nil, nil
+func (fakeTransformer) Encrypt(_ context.Context, plaintext, _ []byte) (kcrypto.EncryptResult, error) {
+	return kcrypto.EncryptResult{
+		Ciphertext: plaintext,
+		Nonce:      []byte("nonce"),
+		EDK:        []byte("edk"),
+		KeyID:      "fake-key-v1",
+	}, nil
 }
 
 func (fakeTransformer) Decrypt(_ context.Context, ciphertext []byte, _ string, _, _, _ []byte) ([]byte, error) {
@@ -46,15 +51,15 @@ func TestValueTransformer_InterfaceMethods(t *testing.T) {
 	plaintext := []byte("secret-value")
 	aad := []byte("cell:test-cell/key:test-key") // AADForConfig moved to cells/configcore/internal/crypto
 
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
+	result, err := tr.Encrypt(ctx, plaintext, aad)
 	if err != nil {
 		t.Fatalf("Encrypt: unexpected error: %v", err)
 	}
-	if keyID == "" {
+	if result.KeyID == "" {
 		t.Fatal("Encrypt: keyID must not be empty")
 	}
 
-	recovered, err := tr.Decrypt(ctx, ct, keyID, nonce, edk, aad)
+	recovered, err := tr.Decrypt(ctx, result.Ciphertext, result.KeyID, result.Nonce, result.EDK, aad)
 	if err != nil {
 		t.Fatalf("Decrypt: unexpected error: %v", err)
 	}

--- a/kernel/crypto/verifykeyid.go
+++ b/kernel/crypto/verifykeyid.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"strconv"
 	"strings"
@@ -73,6 +74,10 @@ func tryParseVersionSuffix(keyID, sep string) (provider string, version int, fou
 	return provider, v, true, nil
 }
 
+func canonicalKeyID(provider string, version int) string {
+	return provider + ":v" + strconv.Itoa(version)
+}
+
 // MatchKeyID verifies that handleID and edkKeyID refer to the same provider
 // and key version. Returns nil when they match, or a descriptive
 // ErrKeyProviderDecryptFailed error when they do not.
@@ -93,7 +98,9 @@ func MatchKeyID(handleID, edkKeyID string) error {
 		return err
 	}
 
-	if hp != ep || hv != ev {
+	handleCanonical := canonicalKeyID(hp, hv)
+	edkCanonical := canonicalKeyID(ep, ev)
+	if subtle.ConstantTimeCompare([]byte(handleCanonical), []byte(edkCanonical)) != 1 {
 		return errcode.New(errcode.KindInternal, errcode.ErrKeyProviderDecryptFailed,
 			"keyID mismatch: handle does not match edk",
 			errcode.WithInternal(fmt.Sprintf("handle=%q edk=%q", handleID, edkKeyID)))

--- a/kernel/crypto/verifykeyid_test.go
+++ b/kernel/crypto/verifykeyid_test.go
@@ -3,6 +3,9 @@ package crypto_test
 import (
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"strings"
 	"testing"
 
@@ -202,5 +205,37 @@ func TestMatchKeyID(t *testing.T) {
 				t.Fatalf("MatchKeyID(%q, %q): unexpected error: %v", tc.handleID, tc.edkKeyID, err)
 			}
 		})
+	}
+}
+
+func TestMatchKeyIDUsesConstantTimeCompare(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "verifykeyid.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse verifykeyid.go: %v", err)
+	}
+
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "ConstantTimeCompare" {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if ok && pkg.Name == "subtle" {
+			found = true
+			return false
+		}
+		return true
+	})
+
+	if !found {
+		t.Fatal("MatchKeyID must use crypto/subtle.ConstantTimeCompare for keyID comparisons")
 	}
 }

--- a/runtime/crypto/key_provider.go
+++ b/runtime/crypto/key_provider.go
@@ -35,3 +35,7 @@ type KeyProvider = kcrypto.KeyProvider
 //
 // See KeyProvider alias comment for guidance on import choices.
 type KeyHandle = kcrypto.KeyHandle
+
+// EncryptResult is a type alias for the kernel encryption result contract.
+// The authoritative definition lives in kernel/crypto.
+type EncryptResult = kcrypto.EncryptResult

--- a/runtime/crypto/key_provider_test.go
+++ b/runtime/crypto/key_provider_test.go
@@ -29,13 +29,13 @@ func (h *fakeKeyHandle) ID() string { return h.id }
 // Encrypt XORs plaintext with 0x42 (dummy cipher), produces a unique nonce
 // via counter, and binds aad by prepending it to the "ciphertext" for
 // round-trip verification.
-func (h *fakeKeyHandle) Encrypt(_ context.Context, plaintext, aad []byte) (ciphertext, nonce, edk []byte, keyID string, err error) {
+func (h *fakeKeyHandle) Encrypt(_ context.Context, plaintext, aad []byte) (crypto.EncryptResult, error) {
 	h.counter++
 	// nonce = 12-byte counter value
-	nonce = make([]byte, 12)
+	nonce := make([]byte, 12)
 	nonce[11] = byte(h.counter & 0xff)
 	// edk = key id bytes (stand-in for wrapped DEK)
-	edk = []byte(h.id)
+	edk := []byte(h.id)
 
 	ct := make([]byte, 1+len(aad)+len(plaintext))
 	ct[0] = byte(len(aad) & 0xff)
@@ -43,7 +43,12 @@ func (h *fakeKeyHandle) Encrypt(_ context.Context, plaintext, aad []byte) (ciphe
 	for i, b := range plaintext {
 		ct[1+len(aad)+i] = b ^ 0x42
 	}
-	return ct, nonce, edk, h.id, nil
+	return crypto.EncryptResult{
+		Ciphertext: ct,
+		Nonce:      nonce,
+		EDK:        edk,
+		KeyID:      h.id,
+	}, nil
 }
 
 // Decrypt reverses fakeKeyHandle.Encrypt; returns ErrDecryptFailed if the
@@ -185,15 +190,15 @@ func TestKeyHandle_EncryptDecrypt_AADConsistent(t *testing.T) {
 	aad := []byte("cell:configcore/key:api_key")
 
 	// Round-trip with matching AAD should succeed.
-	cipher, nonce, edk, _, err := h.Encrypt(ctx, plaintext, aad)
+	result, err := h.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	recovered, err := h.Decrypt(ctx, cipher, nonce, edk, aad)
+	recovered, err := h.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered)
 
 	// Different AAD must fail.
-	_, err = h.Decrypt(ctx, cipher, nonce, edk, []byte("cell:configcore/key:other_key"))
+	_, err = h.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, []byte("cell:configcore/key:other_key"))
 	require.Error(t, err, "different AAD should produce a decrypt error")
 }
 
@@ -207,12 +212,12 @@ func TestKeyHandle_EncryptDecrypt_NonceUnique(t *testing.T) {
 	plaintext := []byte("value")
 	aad := []byte("aad")
 
-	_, nonce1, _, _, err := h.Encrypt(ctx, plaintext, aad)
+	result1, err := h.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
-	_, nonce2, _, _, err := h.Encrypt(ctx, plaintext, aad)
+	result2, err := h.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	assert.NotEqual(t, nonce1, nonce2, "consecutive Encrypt calls must produce different nonces")
+	assert.NotEqual(t, result1.Nonce, result2.Nonce, "consecutive Encrypt calls must produce different nonces")
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/crypto/local_aes_provider.go
+++ b/runtime/crypto/local_aes_provider.go
@@ -49,30 +49,35 @@ func (h *localAESHandle) ID() string { return h.id }
 // Note: DEK uses defer clear() to zeroize on function exit; defense-in-depth over Go GC.
 //
 // ref: kubernetes/kubernetes staging/.../kmsv2/envelope.go EncryptResponse.KeyID semantics
-func (h *localAESHandle) Encrypt(_ context.Context, plaintext, aad []byte) (ciphertext, nonce, edk []byte, keyID string, err error) {
+func (h *localAESHandle) Encrypt(_ context.Context, plaintext, aad []byte) (EncryptResult, error) {
 	// 1. Generate a fresh 32-byte DEK.
 	dek := make([]byte, 32)
-	if _, err = io.ReadFull(rand.Reader, dek); err != nil {
-		return nil, nil, nil, "", errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
+	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+		return EncryptResult{}, errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
 			"local-aes: generate DEK", err)
 	}
 	defer clear(dek) // zeroize DEK on function exit; defense-in-depth over Go GC
 
 	// 2. Encrypt plaintext with DEK. Returns raw ciphertext + nonce separately.
-	ciphertext, nonce, err = aeadutil.EncryptGCM(dek, plaintext, aad)
+	ciphertext, nonce, err := aeadutil.EncryptGCM(dek, plaintext, aad)
 	if err != nil {
-		return nil, nil, nil, "", errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
+		return EncryptResult{}, errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
 			"local-aes: encrypt value", err)
 	}
 
 	// 3. Encrypt DEK with KEK (no AAD). edk is a self-contained nonce-prefixed blob.
-	edk, err = aeadutil.EncryptGCMSelfContained(h.kek, dek, nil)
+	edk, err := aeadutil.EncryptGCMSelfContained(h.kek, dek, nil)
 	if err != nil {
-		return nil, nil, nil, "", errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
+		return EncryptResult{}, errcode.Wrap(errcode.KindInternal, errcode.ErrKeyProviderEncryptFailed,
 			"local-aes: wrap DEK", err)
 	}
 
-	return ciphertext, nonce, edk, h.id, nil
+	return EncryptResult{
+		Ciphertext: ciphertext,
+		Nonce:      nonce,
+		EDK:        edk,
+		KeyID:      h.id,
+	}, nil
 }
 
 // Decrypt reverses AES-GCM envelope encryption.

--- a/runtime/crypto/local_aes_provider_test.go
+++ b/runtime/crypto/local_aes_provider_test.go
@@ -65,14 +65,14 @@ func TestLocalAESKeyProvider_ByID_OldKeyStillDecrypts(t *testing.T) {
 	plaintext := []byte("secret value")
 	aad := []byte("cell:configcore/key:db_password")
 
-	cipher, nonce, edk, _, err := current.Encrypt(ctx, plaintext, aad)
+	result, err := current.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
 	// Retrieve the same key by ID and decrypt.
 	handle, err := p.ByID(ctx, currentID)
 	require.NoError(t, err)
 
-	recovered, err := handle.Decrypt(ctx, cipher, nonce, edk, aad)
+	recovered, err := handle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered)
 }
@@ -91,11 +91,11 @@ func TestLocalAESKeyProvider_ByID_PreviousKeyDecrypts(t *testing.T) {
 
 	plaintext := []byte("old secret")
 	aad := []byte("cell:configcore/key:legacy_key")
-	cipher, nonce, edk, _, err := prevHandle.Encrypt(ctx, plaintext, aad)
+	result, err := prevHandle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
 	// Decrypt using the same previous handle.
-	recovered, err := prevHandle.Decrypt(ctx, cipher, nonce, edk, aad)
+	recovered, err := prevHandle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered)
 }
@@ -148,14 +148,14 @@ func TestLocalAESKeyProvider_EnvelopeRoundTrip(t *testing.T) {
 			plaintext := []byte(tc.plaintext)
 			aad := []byte(tc.aad)
 
-			ct, nonce, edk, _, err := handle.Encrypt(ctx, plaintext, aad)
+			result, err := handle.Encrypt(ctx, plaintext, aad)
 			require.NoError(t, err)
 			// AES-GCM produces at least the 16-byte tag even for empty plaintext.
-			assert.NotEmpty(t, ct)
-			assert.NotEmpty(t, nonce)
-			assert.NotEmpty(t, edk)
+			assert.NotEmpty(t, result.Ciphertext)
+			assert.NotEmpty(t, result.Nonce)
+			assert.NotEmpty(t, result.EDK)
 
-			recovered, err := handle.Decrypt(ctx, ct, nonce, edk, aad)
+			recovered, err := handle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, aad)
 			require.NoError(t, err)
 			// AES-GCM Open on empty plaintext returns nil; normalise both to empty.
 			if len(recovered) == 0 {
@@ -207,10 +207,10 @@ func TestLocalAESKeyProvider_DecryptAADMismatch_FailClosed(t *testing.T) {
 	aad := []byte("cell:configcore/key:my_key")
 	wrongAAD := []byte("cell:configcore/key:other_key")
 
-	cipher, nonce, edk, _, err := handle.Encrypt(ctx, plaintext, aad)
+	result, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	_, err = handle.Decrypt(ctx, cipher, nonce, edk, wrongAAD)
+	_, err = handle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, wrongAAD)
 	require.Error(t, err, "mismatched AAD must cause decrypt failure")
 
 	var ec *errcode.Error
@@ -232,12 +232,12 @@ func TestLocalAESKeyProvider_NonceUnique(t *testing.T) {
 	plaintext := []byte("same value")
 	aad := []byte("same aad")
 
-	_, nonce1, _, _, err := handle.Encrypt(ctx, plaintext, aad)
+	result1, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
-	_, nonce2, _, _, err := handle.Encrypt(ctx, plaintext, aad)
+	result2, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	assert.NotEqual(t, nonce1, nonce2, "consecutive Encrypt calls must produce different nonces")
+	assert.NotEqual(t, result1.Nonce, result2.Nonce, "consecutive Encrypt calls must produce different nonces")
 }
 
 // ---------------------------------------------------------------------------
@@ -251,11 +251,11 @@ func TestLocalAESHandle_Decrypt_MissingNonce(t *testing.T) {
 	require.NoError(t, err)
 
 	// Encrypt to get a valid ciphertext + edk.
-	ct, _, edk, _, err := handle.Encrypt(ctx, []byte("value"), []byte("aad"))
+	result, err := handle.Encrypt(ctx, []byte("value"), []byte("aad"))
 	require.NoError(t, err)
 
 	// Pass empty nonce — must fail.
-	_, err = handle.Decrypt(ctx, ct, nil, edk, []byte("aad"))
+	_, err = handle.Decrypt(ctx, result.Ciphertext, nil, result.EDK, []byte("aad"))
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -273,11 +273,11 @@ func TestLocalAESHandle_Decrypt_MissingEDK(t *testing.T) {
 	handle, err := p.Current(ctx)
 	require.NoError(t, err)
 
-	ct, nonce, _, _, err := handle.Encrypt(ctx, []byte("value"), []byte("aad"))
+	result, err := handle.Encrypt(ctx, []byte("value"), []byte("aad"))
 	require.NoError(t, err)
 
 	// Pass empty edk — must fail.
-	_, err = handle.Decrypt(ctx, ct, nonce, nil, []byte("aad"))
+	_, err = handle.Decrypt(ctx, result.Ciphertext, result.Nonce, nil, []byte("aad"))
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -295,15 +295,15 @@ func TestLocalAESHandle_Decrypt_TamperedEDK(t *testing.T) {
 	handle, err := p.Current(ctx)
 	require.NoError(t, err)
 
-	ct, nonce, edk, _, err := handle.Encrypt(ctx, []byte("value"), []byte("aad"))
+	result, err := handle.Encrypt(ctx, []byte("value"), []byte("aad"))
 	require.NoError(t, err)
 
 	// Flip the last byte of edk to simulate tampering.
-	tampered := make([]byte, len(edk))
-	copy(tampered, edk)
+	tampered := make([]byte, len(result.EDK))
+	copy(tampered, result.EDK)
 	tampered[len(tampered)-1] ^= 0xFF
 
-	_, err = handle.Decrypt(ctx, ct, nonce, tampered, []byte("aad"))
+	_, err = handle.Decrypt(ctx, result.Ciphertext, result.Nonce, tampered, []byte("aad"))
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -375,17 +375,15 @@ func TestLocalAESHandle_Encrypt_ReturnsKeyIDEqualsHandleID(t *testing.T) {
 	plaintext := []byte("sensitive config value")
 	aad := []byte("cell:configcore/key:api_key")
 
-	// Five-return-value Encrypt (Phase 0-b kernel interface).
-	// Compile error here is expected until Phase 2-c updates localAESHandle.Encrypt.
-	ct, nonce, edk, keyID, err := handle.Encrypt(ctx, plaintext, aad)
+	result, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
-	assert.NotEmpty(t, ct)
-	assert.NotEmpty(t, nonce)
-	assert.NotEmpty(t, edk)
+	assert.NotEmpty(t, result.Ciphertext)
+	assert.NotEmpty(t, result.Nonce)
+	assert.NotEmpty(t, result.EDK)
 
 	// Core assertion: keyID returned from Encrypt must equal handle.ID().
-	assert.Equal(t, handle.ID(), keyID, "Encrypt must return the handle's key ID")
-	assert.Equal(t, crypto.LocalAESCurrentKeyID, keyID,
+	assert.Equal(t, handle.ID(), result.KeyID, "Encrypt must return the handle's key ID")
+	assert.Equal(t, crypto.LocalAESCurrentKeyID, result.KeyID,
 		"LocalAES current handle keyID must be %q", crypto.LocalAESCurrentKeyID)
 }
 
@@ -422,23 +420,22 @@ func TestLocalAESHandle_Encrypt_ByIDReturnedKeyIDMatches(t *testing.T) {
 	plaintext := []byte("old secret value")
 	aad := []byte("cell:configcore/key:legacy_db_password")
 
-	// Five-return-value Encrypt (Phase 0-b kernel interface).
-	ct, nonce, edk, keyID, err := prevHandle.Encrypt(ctx, plaintext, aad)
+	result, err := prevHandle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
 	// keyID from Encrypt must equal the handle's own ID.
-	assert.Equal(t, crypto.LocalAESPreviousKeyID, keyID,
+	assert.Equal(t, crypto.LocalAESPreviousKeyID, result.KeyID,
 		"Encrypt on previous handle must return previous key ID")
-	assert.Equal(t, prevHandle.ID(), keyID,
+	assert.Equal(t, prevHandle.ID(), result.KeyID,
 		"Encrypt-returned keyID must equal handle.ID()")
 
 	// Round-trip: resolve via ByID(keyID) and decrypt — proving keyID is the
 	// correct binding between ciphertext and the KEK version.
-	resolvedHandle, err := p.ByID(ctx, keyID)
+	resolvedHandle, err := p.ByID(ctx, result.KeyID)
 	require.NoError(t, err)
-	assert.Equal(t, keyID, resolvedHandle.ID())
+	assert.Equal(t, result.KeyID, resolvedHandle.ID())
 
-	recovered, err := resolvedHandle.Decrypt(ctx, ct, nonce, edk, aad)
+	recovered, err := resolvedHandle.Decrypt(ctx, result.Ciphertext, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered,
 		"Decrypt via ByID(keyID) must recover original plaintext")
@@ -478,37 +475,36 @@ func TestLocalAESHandle_Encrypt_DoesNotReuseBuffers(t *testing.T) {
 	plaintext := []byte("same plaintext for both calls")
 	aad := []byte("cell:configcore/key:test_key")
 
-	// Five-return-value Encrypt (Phase 0-b kernel interface).
-	ct1, nonce1, edk1, keyID1, err := handle.Encrypt(ctx, plaintext, aad)
+	result1, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	ct2, nonce2, edk2, keyID2, err := handle.Encrypt(ctx, plaintext, aad)
+	result2, err := handle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
 	// keyID must be stable (same handle, same KEK version).
-	assert.Equal(t, keyID1, keyID2, "keyID must be stable across calls on the same handle")
+	assert.Equal(t, result1.KeyID, result2.KeyID, "keyID must be stable across calls on the same handle")
 
 	// Nonces must differ (random per-call).
-	assert.NotEqual(t, nonce1, nonce2, "consecutive Encrypt calls must produce different nonces")
+	assert.NotEqual(t, result1.Nonce, result2.Nonce, "consecutive Encrypt calls must produce different nonces")
 
 	// edk must differ (each call wraps a fresh random DEK).
 	// If the same DEK were reused, the edk blobs would be identical (GCM is
 	// deterministic given the same key + nonce, and the edk nonce is also random).
 	// In practice two independent random DEKs will produce different edks with
 	// overwhelming probability.
-	assert.NotEqual(t, edk1, edk2,
+	assert.NotEqual(t, result1.EDK, result2.EDK,
 		"consecutive Encrypt calls must wrap independent DEKs (edk must differ)")
 
 	// Ciphertext must differ (different DEK -> different ciphertext even for same plaintext).
-	assert.NotEqual(t, ct1, ct2,
+	assert.NotEqual(t, result1.Ciphertext, result2.Ciphertext,
 		"consecutive Encrypt calls must produce different ciphertexts (different DEK)")
 
 	// Both must decrypt correctly — independence does not break correctness.
-	recovered1, err := handle.Decrypt(ctx, ct1, nonce1, edk1, aad)
+	recovered1, err := handle.Decrypt(ctx, result1.Ciphertext, result1.Nonce, result1.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered1)
 
-	recovered2, err := handle.Decrypt(ctx, ct2, nonce2, edk2, aad)
+	recovered2, err := handle.Decrypt(ctx, result2.Ciphertext, result2.Nonce, result2.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered2)
 }

--- a/runtime/crypto/value_transformer.go
+++ b/runtime/crypto/value_transformer.go
@@ -37,18 +37,18 @@ func NewValueTransformer(p KeyProvider) ValueTransformer {
 }
 
 // Encrypt encrypts plaintext using the current KeyHandle.
-func (t *keyProviderTransformer) Encrypt(ctx context.Context, plaintext, aad []byte) ([]byte, string, []byte, []byte, error) {
+func (t *keyProviderTransformer) Encrypt(ctx context.Context, plaintext, aad []byte) (EncryptResult, error) {
 	handle, err := t.provider.Current(ctx)
 	if err != nil {
-		return nil, "", nil, nil, fmt.Errorf("value-transformer: get current key: %w", err)
+		return EncryptResult{}, fmt.Errorf("value-transformer: get current key: %w", err)
 	}
 
-	ct, nonce, edk, keyID, err := handle.Encrypt(ctx, plaintext, aad)
+	result, err := handle.Encrypt(ctx, plaintext, aad)
 	if err != nil {
-		return nil, "", nil, nil, fmt.Errorf("value-transformer: encrypt: %w", err)
+		return EncryptResult{}, fmt.Errorf("value-transformer: encrypt: %w", err)
 	}
 
-	return ct, keyID, nonce, edk, nil
+	return result, nil
 }
 
 // CurrentKeyID returns the ID of the currently active key. Used by the config
@@ -72,9 +72,9 @@ func (t *keyProviderTransformer) Decrypt(ctx context.Context, ciphertext []byte,
 	// Defense-in-depth: verify that the provider returned a handle whose ID
 	// matches the requested keyID. A mismatch indicates a buggy KeyProvider
 	// implementation that routed the lookup to the wrong key — permanent error.
-	if handle.ID() != keyID {
-		return nil, fmt.Errorf("value-transformer: provider returned handle id %q for requested keyID %q",
-			handle.ID(), keyID)
+	if err := kcrypto.MatchKeyID(handle.ID(), keyID); err != nil {
+		return nil, fmt.Errorf("value-transformer: provider returned handle id %q for requested keyID %q: %w",
+			handle.ID(), keyID, err)
 	}
 
 	plaintext, err := handle.Decrypt(ctx, ciphertext, nonce, edk, aad)
@@ -95,8 +95,8 @@ func (t *keyProviderTransformer) Decrypt(ctx context.Context, ciphertext []byte,
 type NoopTransformer struct{}
 
 // Encrypt returns plaintext as-is with empty keyID, nonce, and edk.
-func (NoopTransformer) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, string, []byte, []byte, error) {
-	return plaintext, "", nil, nil, nil
+func (NoopTransformer) Encrypt(_ context.Context, plaintext, _ []byte) (EncryptResult, error) {
+	return EncryptResult{Ciphertext: plaintext}, nil
 }
 
 // Decrypt returns ciphertext as-is.

--- a/runtime/crypto/value_transformer_test.go
+++ b/runtime/crypto/value_transformer_test.go
@@ -54,13 +54,13 @@ func TestValueTransformer_EncryptDecrypt_RoundTrip(t *testing.T) {
 			plaintext := []byte(tc.value)
 			aad := testAAD(tc.configKey)
 
-			ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
+			result, err := tr.Encrypt(ctx, plaintext, aad)
 			require.NoError(t, err)
-			assert.NotEmpty(t, keyID)
-			assert.NotEmpty(t, nonce)
-			assert.NotEmpty(t, edk)
+			assert.NotEmpty(t, result.KeyID)
+			assert.NotEmpty(t, result.Nonce)
+			assert.NotEmpty(t, result.EDK)
 
-			recovered, err := tr.Decrypt(ctx, ct, keyID, nonce, edk, aad)
+			recovered, err := tr.Decrypt(ctx, result.Ciphertext, result.KeyID, result.Nonce, result.EDK, aad)
 			require.NoError(t, err)
 			// AES-GCM Open on empty plaintext returns nil; normalise both.
 			if len(recovered) == 0 {
@@ -102,12 +102,12 @@ func TestValueTransformer_DecryptByHistoricalKeyID(t *testing.T) {
 	plaintext := []byte("old-secret")
 	aad := testAAD("legacy_key")
 
-	ct, nonce, edk, _, err := previousHandle.Encrypt(ctx, plaintext, aad)
+	result, err := previousHandle.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
 	// The transformer should decrypt using the historical keyID.
 	tr := crypto.NewValueTransformer(p)
-	recovered, err := tr.Decrypt(ctx, ct, crypto.LocalAESPreviousKeyID, nonce, edk, aad)
+	recovered, err := tr.Decrypt(ctx, result.Ciphertext, crypto.LocalAESPreviousKeyID, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered)
 }
@@ -124,10 +124,10 @@ func TestValueTransformer_DecryptWrongAAD_FailClosed(t *testing.T) {
 	aad := testAAD("my_key")
 	wrongAAD := testAAD("other_key")
 
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
+	result, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	_, err = tr.Decrypt(ctx, ct, keyID, nonce, edk, wrongAAD)
+	_, err = tr.Decrypt(ctx, result.Ciphertext, result.KeyID, result.Nonce, result.EDK, wrongAAD)
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -145,10 +145,10 @@ func TestValueTransformer_UnknownKeyID_FailClosed(t *testing.T) {
 
 	plaintext := []byte("value")
 	aad := testAAD("my_key")
-	ct, _, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
+	result, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
 
-	_, err = tr.Decrypt(ctx, ct, "nonexistent-key-id", nonce, edk, aad)
+	_, err = tr.Decrypt(ctx, result.Ciphertext, "nonexistent-key-id", result.Nonce, result.EDK, aad)
 	require.Error(t, err, "unknown keyID must return an error (fail-closed)")
 }
 
@@ -163,14 +163,14 @@ func TestNoopTransformer_Passthrough(t *testing.T) {
 	plaintext := []byte("public-config-value")
 	aad := testAAD("public_key")
 
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
+	result, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
-	assert.Equal(t, plaintext, ct)
-	assert.Empty(t, keyID)
-	assert.Nil(t, nonce)
-	assert.Nil(t, edk)
+	assert.Equal(t, plaintext, result.Ciphertext)
+	assert.Empty(t, result.KeyID)
+	assert.Nil(t, result.Nonce)
+	assert.Nil(t, result.EDK)
 
-	recovered, err := tr.Decrypt(ctx, ct, keyID, nonce, edk, aad)
+	recovered, err := tr.Decrypt(ctx, result.Ciphertext, result.KeyID, result.Nonce, result.EDK, aad)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, recovered)
 }
@@ -217,8 +217,8 @@ type errorKeyHandle struct {
 
 func (h *errorKeyHandle) ID() string { return "error-key" }
 
-func (h *errorKeyHandle) Encrypt(_ context.Context, _, _ []byte) ([]byte, []byte, []byte, string, error) {
-	return nil, nil, nil, "", h.encryptErr
+func (h *errorKeyHandle) Encrypt(_ context.Context, _, _ []byte) (crypto.EncryptResult, error) {
+	return crypto.EncryptResult{}, h.encryptErr
 }
 
 func (h *errorKeyHandle) Decrypt(_ context.Context, _, _, _, _ []byte) ([]byte, error) {
@@ -252,7 +252,7 @@ func TestValueTransformer_Encrypt_CurrentKeyError(t *testing.T) {
 	p := &errorKeyProvider{currentErr: errors.New("current key unavailable")}
 	tr := crypto.NewValueTransformer(p)
 
-	_, _, _, _, err := tr.Encrypt(ctx, []byte("value"), nil)
+	_, err := tr.Encrypt(ctx, []byte("value"), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get current key")
 }
@@ -265,7 +265,7 @@ func TestValueTransformer_Encrypt_HandleEncryptError(t *testing.T) {
 	p := &singleHandleProvider{handle: &errorKeyHandle{encryptErr: encErr}}
 	tr := crypto.NewValueTransformer(p)
 
-	_, _, _, _, err := tr.Encrypt(ctx, []byte("value"), nil)
+	_, err := tr.Encrypt(ctx, []byte("value"), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "encrypt")
 }
@@ -283,7 +283,7 @@ func TestValueTransformer_Decrypt_ByIDError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Fake KeyHandle/KeyProvider for Phase 1-d tests (5-return-value interface)
+// Fake KeyHandle/KeyProvider for EncryptResult interface tests
 // ---------------------------------------------------------------------------
 
 // fixedKeyIDHandle implements kernel/crypto.KeyHandle for TC-VT-1.
@@ -300,14 +300,18 @@ func (h *fixedKeyIDHandle) ID() string { return h.handleID }
 // Encrypt returns a trivial ciphertext with encryptKeyID as keyID.
 // The ciphertext is just plaintext XOR'd with 0x55 (dummy cipher — correctness
 // is not the concern of TC-VT-1; keyID routing is).
-// Implements kernel/crypto.KeyHandle with the Phase 0-b 5-return-value signature.
-func (h *fixedKeyIDHandle) Encrypt(_ context.Context, plaintext, _ []byte) (ciphertext, nonce, edk []byte, keyID string, err error) {
+func (h *fixedKeyIDHandle) Encrypt(_ context.Context, plaintext, _ []byte) (crypto.EncryptResult, error) {
 	ct := make([]byte, len(plaintext))
 	for i, b := range plaintext {
 		ct[i] = b ^ 0x55
 	}
 	// Return encryptKeyID as the authoritative keyID (may differ from h.handleID).
-	return ct, []byte("nonce"), []byte("edk"), h.encryptKeyID, nil
+	return crypto.EncryptResult{
+		Ciphertext: ct,
+		Nonce:      []byte("nonce"),
+		EDK:        []byte("edk"),
+		KeyID:      h.encryptKeyID,
+	}, nil
 }
 
 // Decrypt reverses fixedKeyIDHandle.Encrypt.
@@ -326,9 +330,8 @@ type transientErrorHandle struct{}
 func (h *transientErrorHandle) ID() string { return "transient-key" }
 
 // Encrypt returns ErrKeyProviderTransient — simulating a Vault 503 or network timeout.
-// Implements kernel/crypto.KeyHandle with the Phase 0-b 5-return-value signature.
-func (h *transientErrorHandle) Encrypt(_ context.Context, _, _ []byte) ([]byte, []byte, []byte, string, error) {
-	return nil, nil, nil, "", errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient,
+func (h *transientErrorHandle) Encrypt(_ context.Context, _, _ []byte) (crypto.EncryptResult, error) {
+	return crypto.EncryptResult{}, errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient,
 		"vault: service unavailable (503)")
 }
 
@@ -390,18 +393,18 @@ func TestKeyProviderTransformer_UsesEncryptReturnedKeyID_NotHandleID(t *testing.
 	plaintext := []byte("sensitive value")
 	aad := testAAD("tc_vt1_key")
 
-	ct, keyID, nonce, edk, err := tr.Encrypt(ctx, plaintext, aad)
+	result, err := tr.Encrypt(ctx, plaintext, aad)
 	require.NoError(t, err)
-	assert.NotEmpty(t, ct)
-	assert.NotEmpty(t, nonce)
-	assert.NotEmpty(t, edk)
+	assert.NotEmpty(t, result.Ciphertext)
+	assert.NotEmpty(t, result.Nonce)
+	assert.NotEmpty(t, result.EDK)
 
 	// Core assertion: transformer must persist the keyID returned by Encrypt.
-	assert.Equal(t, "actual-used-keyID", keyID,
+	assert.Equal(t, "actual-used-keyID", result.KeyID,
 		"transformer must use keyID returned by handle.Encrypt, not handle.ID()")
 
 	// Negative assertion: must NOT use handle.ID() ("fake-handle-id").
-	assert.NotEqual(t, "fake-handle-id", keyID,
+	assert.NotEqual(t, "fake-handle-id", result.KeyID,
 		"transformer must NOT use handle.ID() as the stored keyID")
 }
 
@@ -430,7 +433,7 @@ func TestKeyProviderTransformer_EncryptErrorPropagates(t *testing.T) {
 	p := &fixedHandleProvider{handle: h}
 	tr := crypto.NewValueTransformer(p)
 
-	_, _, _, _, err := tr.Encrypt(ctx, []byte("value"), testAAD("tc_vt2_key"))
+	_, err := tr.Encrypt(ctx, []byte("value"), testAAD("tc_vt2_key"))
 	require.Error(t, err, "transient handle.Encrypt error must propagate")
 
 	// errcode.IsTransient traverses the error chain via errors.As.
@@ -469,8 +472,8 @@ type mismatchedIDHandle struct{}
 
 func (h *mismatchedIDHandle) ID() string { return "wrong-key-id" }
 
-func (h *mismatchedIDHandle) Encrypt(_ context.Context, plaintext, _ []byte) ([]byte, []byte, []byte, string, error) {
-	return plaintext, nil, nil, "wrong-key-id", nil
+func (h *mismatchedIDHandle) Encrypt(_ context.Context, plaintext, _ []byte) (crypto.EncryptResult, error) {
+	return crypto.EncryptResult{Ciphertext: plaintext, KeyID: "wrong-key-id"}, nil
 }
 
 func (h *mismatchedIDHandle) Decrypt(_ context.Context, ct, _, _, _ []byte) ([]byte, error) {

--- a/tools/archtest/testdata/clock_leaf_fallback_fixtures/compliant/go.mod
+++ b/tools/archtest/testdata/clock_leaf_fallback_fixtures/compliant/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_leaf_fallback/compliant
 
-go 1.25.9
+go 1.25.10
 
 // Pin to the worktree's kernel/clock so the fixture compiles against the same
 // API the gate guards. The compliant fixture only consumes types/values it

--- a/tools/archtest/testdata/clock_leaf_fallback_fixtures/violates/go.mod
+++ b/tools/archtest/testdata/clock_leaf_fallback_fixtures/violates/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_leaf_fallback/violates
 
-go 1.25.9
+go 1.25.10
 
 // Pin to the worktree's kernel/clock so the fixture can resolve
 // kernel/clock.Real() and exercise the type-aware leaf-fallback gate.


### PR DESCRIPTION
## Summary
- Add `crypto.EncryptResult` and switch `KeyHandle.Encrypt` / `ValueTransformer.Encrypt` away from positional tuples.
- Harden `MatchKeyID` with parsed canonical IDs plus `crypto/subtle.ConstantTimeCompare`.
- Update LocalAES, Vault Transit, configcore PG encryption boundaries, and test fakes to use field-based result mapping.
- Add contract coverage for constant-time comparison and Vault nonce uniqueness.

Refs: G-12 CRYPTO-INTERFACE-HARDENING
ref: kubernetes/kubernetes `staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go`
ref: Go `crypto/subtle.ConstantTimeCompare`

## Test plan
- [x] `go test ./kernel/crypto ./runtime/crypto ./pkg/aeadutil`
- [x] `go test ./adapters/vault`
- [x] `go test ./cells/configcore/internal/adapters/postgres`
- [x] `go test ./cmd/corebundle -run 'Test.*(KeyProvider|ValueTransformer|Vault|ConfigCore)'`
- [x] `go test -cover ./kernel/crypto ./runtime/crypto`
- [x] `go test -tags=integration -run '^$' ./adapters/vault ./cells/configcore/internal/adapters/postgres ./cells/configcore/slices/configwrite ./cells/configcore/slices/configpublish`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `golangci-lint run ./...` (0 issues)
