### PR TITLE
docs(kernel/observability): add umbrella package doc.go (plan-030 K-03)

### DIFF
--- a/kernel/observability/doc.go
+++ b/kernel/observability/doc.go
@@ -1,0 +1,32 @@
+// Package observability is the namespace root for GoCell's
+// provider-neutral observability abstractions. The root package itself
+// declares no symbols; consumers always import a sub-package.
+//
+// Layer split — what lives where:
+//
+//   - kernel/observability/...    — provider-neutral interfaces only.
+//     Counter / Histogram / Provider (metrics), Snapshot / Statter
+//     (poolstats). No backend types (prometheus, otel, …) appear in
+//     these signatures, so kernel modules and cells can emit telemetry
+//     without taking a transitive dependency on any exporter.
+//
+//   - runtime/observability/...   — wiring + in-memory implementations.
+//     HTTP middleware (logging context enrichment, request collector,
+//     tracing propagation) and ProviderCollector adapters that bridge
+//     kernel interfaces to a chosen Provider at composition time.
+//
+//   - adapters/{prometheus,otel,…} — concrete exporters. These import
+//     kernel/observability/metrics and implement Provider against a
+//     real registry. Kernel and cells never import them directly; the
+//     composition root (cmd/) selects one and threads it through
+//     bootstrap.WithMetricsProvider.
+//
+// The boundary is one-directional: adapters depend on kernel; kernel
+// does not know about adapters. A NopProvider in the kernel package
+// keeps unit tests and dev wire-ups runnable without a backend, while
+// still validating label-set contracts so drift surfaces early.
+//
+// ref: docs/architecture/202604252235-001-metrics-provider-abstraction-in-kernel.md
+// ref: opentelemetry-go metric/meter.go — API/SDK split that motivates
+// this layering.
+package observability

--- a/kernel/observability/doc.go
+++ b/kernel/observability/doc.go
@@ -1,6 +1,12 @@
 // Package observability is the namespace root for GoCell's
-// provider-neutral observability abstractions. The root package itself
-// declares no symbols; consumers always import a sub-package.
+// provider-neutral metrics and pool-stats abstractions. The root
+// package itself declares no symbols; consumers always import a
+// sub-package.
+//
+// Tracing abstractions (Tracer / Span / Attr) live in kernel/wrapper,
+// not under this tree, because tracing is consumed by wrapper-level
+// middleware that pre-dates this namespace. runtime/observability/tracing
+// re-exports them as type aliases for HTTP-side callers.
 //
 // Layer split — what lives where:
 //
@@ -11,22 +17,28 @@
 //     without taking a transitive dependency on any exporter.
 //
 //   - runtime/observability/...   — wiring + in-memory implementations.
-//     HTTP middleware (logging context enrichment, request collector,
-//     tracing propagation) and ProviderCollector adapters that bridge
-//     kernel interfaces to a chosen Provider at composition time.
+//     HTTP middleware for logging context enrichment and the in-memory
+//     request collector; a stdlib-only Tracer stub re-exporting the
+//     kernel/wrapper interfaces; ProviderCollector adapters that bridge
+//     kernel metrics interfaces to a chosen Provider at composition
+//     time. No external propagation logic — that lives in adapters.
 //
-//   - adapters/{prometheus,otel,…} — concrete exporters. These import
-//     kernel/observability/metrics and implement Provider against a
-//     real registry. Kernel and cells never import them directly; the
-//     composition root (cmd/) selects one and threads it through
-//     bootstrap.WithMetricsProvider.
+//   - adapters/{prometheus,otel,…} — concrete exporters. prometheus
+//     implements kernel/observability/metrics.Provider; otel implements
+//     both kernel/wrapper.Tracer (with W3C TraceContext propagation)
+//     and a metrics Provider, plus pool/messaging collectors. Kernel
+//     and cells never import them directly; the composition root
+//     (cmd/) selects one and threads it through
+//     bootstrap.WithMetricsProvider, which auto-wires an HTTP
+//     ProviderCollector into the router.
 //
 // The boundary is one-directional: adapters depend on kernel; kernel
-// does not know about adapters. A NopProvider in the kernel package
-// keeps unit tests and dev wire-ups runnable without a backend, while
-// still validating label-set contracts so drift surfaces early.
+// does not know about adapters. A NopProvider in
+// kernel/observability/metrics keeps unit tests and dev wire-ups
+// runnable without a backend, while still validating label-set
+// contracts so drift surfaces early.
 //
 // ref: docs/architecture/202604252235-001-metrics-provider-abstraction-in-kernel.md
-// ref: opentelemetry-go metric/meter.go — API/SDK split that motivates
-// this layering.
+// ref: open-telemetry/opentelemetry-go metric/meter.go — API/SDK split
+// that motivates this layering.
 package observability


### PR DESCRIPTION
## Summary

补 `kernel/observability/doc.go`（32 行，包级 godoc only），明确 kernel/observability 与 runtime/observability、adapters/{prometheus,otel} 的职责切分：

- **kernel/observability/...** — provider-neutral interfaces only（Counter/Histogram/Provider/Snapshot/Statter）
- **runtime/observability/...** — wiring + 内存实现（HTTP middleware、ProviderCollector adapters）
- **adapters/{prometheus,otel,…}** — 具体 exporter，由 composition root 经 `bootstrap.WithMetricsProvider` 注入

**问题来源**：`docs/reviews/20260504-systems-layer-01-kernel.md` §P1#2 — kernel 子包多有 doc.go，唯独 `kernel/observability/` 根目录无包文档，读者必须从子包或 ADR 反推架构意图。

**范围**：纯文档，0 行代码改动；不影响任何调用方，无需测试改动。

Refs: PR-V1-030-K03-OBSERVABILITY-PKGDOC
ref: docs/architecture/202604252235-001-metrics-provider-abstraction-in-kernel.md
ref: opentelemetry-go metric/meter.go API/SDK split

## Test plan

- [x] `go build ./...` 通过
- [x] `go vet ./kernel/observability/...` 通过
- [x] `golangci-lint run ./kernel/observability/...` 0 issues
- [x] `go doc ./kernel/observability` 渲染正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)