### PR TITLE
ADR: typed-Go-heavy protocol primitives & 034 B-route v3 revision

### DIFF
--- a/docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md
+++ b/docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md
@@ -1,0 +1,420 @@
+# ADR: typed-Go-heavy 协议 primitive 范式
+
+**Date**: 2026-05-10
+**Status**: Proposed
+**Related plans**: `docs/plans/202605082145-034-pg-corecell-b-route-plan.md`
+**Supersedes (architectural intent)**: 034 §4 ADR-B 6 条边界规则（被 typed Go 类型系统天然画出）
+
+---
+
+## 1. Context
+
+### 1.1 PG 接入循环
+
+`accesscore` / `auditcore` / `configcore` 三个 corecell 接入 PG 的过程出现重复模式：
+
+- PR#417 在 accesscore PG 接入中暴露 5 个 P0/P1 协议缺口（token 重放 / role revoke 排序 / admin 不变量 / credential 失效 / CAS）
+- archive `202604201800-pg-pilot-layering-refactor-plan.md` 中 PG pilot 接入暴露过 4 个分层维度漂移（加密 / 生命周期 / Cell 组装 / 治理）
+- 两次循环的共同形态：**接 PG 时一次性翻出 mem 模式下未被强制决策的协议**
+
+### 1.2 第一性原理分析
+
+接 PG 不是"换存储介质"，是"强制暴露 mem 模式下保持隐式的协议决策":
+
+| 属性 | mem 默认 | PG 强制 |
+|---|---|---|
+| Durability | volatile | 哪些写持久 / 何时持久 |
+| Consistency | 单进程原子 | tx 边界 / isolation level |
+| Concurrency | mutex 平凡 | row lock / CAS / advisory |
+| Recovery | 重启清空 | 重启从哪恢复 |
+| Encryption | 无 | 哪些字段 / key rotation |
+| Indexing | hash map | 查哪些列 / partial / 复合 |
+
+**根因**：协议决策被写在了实现层（PG repo / cell 内部），而不是声明层。mem 不强制决策 → 决策保持隐式 → PG 强制时一次性爆发。
+
+### 1.3 GoCell 已有的演化轨迹（未显式 ADR 化）
+
+| PR / 范式 | 改动 |
+|---|---|
+| PR262 typed AuthPlan | string config → sealed `cell.ListenerAuth` interface (`AuthJWT` / `AuthServiceToken` / `AuthMTLS` / `AuthNone`) |
+| PR-MODE-1 typed-nil reject | `pkg/validation.IsNilInterface` + bootstrap phase0 sentinel；`authChain` nil 显式 fail-fast |
+| PR-MODE-6 error-first constructor | `cell.NewAuthJWT(v) (AuthJWT, error)` / `MustNewAuthJWT` 双轨；`OUTBOX-SERVICE-01` archtest 守 fail-fast on nil TxRunner |
+| Option 范式分层 | 强依赖 wiring（nil → flag → phase0 fail-fast）vs 累加式 builder（nil → noop → factory fail-fast）|
+| typed `wrapper.ContractSpec` | 取代 yaml 字符串引用，运行时组装 typed |
+| `cell.RouteGroup` / `cell.ListenerRef` | 路由组装 typed Go，非 yaml |
+
+这是同一方向的连续演化，但**未被显式 ADR 化为"GoCell 协议决策的官方范式"**，导致每次新加协议（session / cas / audit ledger）时仍按 library-style runtime 抽取思路走。
+
+### 1.4 决策载体的 AI-friendly 评估
+
+GoCell 是 AI 主导开发的项目。AI 出错形态分类：
+
+| 形态 | 触发场景 |
+|---|---|
+| F1 忘记某约束 | 约束散在多文件 |
+| F2 复制错误模式 | 历史代码不规范当 reference |
+| F3 绕过 type check | 用 `interface{}` / `any` |
+| F4 多源不一致 | yaml 改了 Go 没改 |
+| F5 静默错 | 默认值掩盖 |
+| F6 局部 plausible / 全局错 | 看不全 codebase |
+| F7 长清单跳过 | review checklist |
+
+减缓机制的强度排序：
+
+```
+[最强] 编译错误 (sealed interface / typed const / 强类型签名)
+       phase0 启动 fail-fast
+       constructor fail-fast
+       runtime panic / error
+       archtest 静态拦截
+       integration test
+       review checklist
+[最弱] 文档约定
+```
+
+**typed-Go-heavy 是把约束往强端推的工程化实现**。
+
+---
+
+## 2. Decision
+
+### D1 协议决策必须在最早能用类型系统检查的层级
+
+GoCell 中这一层是 **typed Go primitive**：sealed interface + 强类型 constructor + composition-root 显式构造。不允许藏在 implementation 层（cell 内部 / SQL / mem store 字段）。
+
+### D2 yaml 仅承载静态拓扑 metadata
+
+| 类型 | 载体 |
+|---|---|
+| 静态拓扑（id / consistencyLevel / 拥有者 / verify 义务 / contract 引用） | yaml |
+| schema 形态（HTTP / event payload） | yaml + json schema → 派生 typed Go |
+| **协议决策 / 运行时组装 / 互斥约束 / 生命周期 wiring** | **typed Go** |
+
+理由：yaml 表达不了 sealed / 互斥 / 强依赖 nil-fail-fast 这三类约束；typed Go 编译期可查，无需外部工具。
+
+### D3 typed Protocol primitive 由 sealed Option 组合构造
+
+每个跨 cell 协议（session / cas / audit ledger / ...）以 typed Protocol 形式存在：
+
+- 模式属性是 sealed interface 或 typed enum
+- Option 函数每个对应一个属性
+- `NewProtocol(opts ...Option) (*Protocol, error)` fail-fast 校验互斥与必填
+- `MustNewProtocol(...)` 是 composition-root 包装
+
+参见 §4 session protocol 原型。
+
+### D4 mem 与 PG 共享 storetest conformance suite，suite 接受 typed Protocol
+
+```go
+storetest.Run(t, factory, protocol *Protocol)
+```
+
+mem / PG factory 都接受同一 Protocol 实例；suite 根据 Protocol 字段派生 test cases。**mem 不再"默认能跑"**，与 PG 对称 conform 同一协议。
+
+### D5 composition root 必须显式构造 typed Protocol
+
+`cmd/corebundle/*_module.go` 必须显式 `MustNewProtocol(...)` 构造并注入 cell。
+- typed-nil reject 让"忘了构造"在 phase0 fail-fast
+- 强依赖 wiring option 让"忘了配某属性"在 phase0 fail-fast
+
+### D6 archtest 是兜底，不是主防线
+
+主防线在 type system + codegen。archtest 只守"无法 funnel 也无法 typed 化的残留"（如"PG 写路径不绕过 RunInTx"这种调用形态约束）。033 §6 计划的 `PG-REPO-CONSTRUCTOR-FAIL-FAST-01` 由 typed 签名 + body 顶层校验直接覆盖，降级删除。
+
+---
+
+## 3. Consequences
+
+### 3.1 正面
+
+- **F1/F3/F5 出错形态降到编译期**：sealed interface 让"忘了 case"无法编译；typed-nil reject 让"忘了赋值"phase0 fail-fast
+- **F2 出错降到接口层**：新 substrate 必须 conform typed Protocol，不能"差不多就行"
+- **F4 出错从源消除**：yaml 不承载协议，无 yaml↔Go 漂移
+- **PR 评审复杂度降低**：协议决策在 composition root 一目了然，不需要跨 5 个文件 grep
+- **新 cell 接 PG 不再触发协议爆发**：composition root 强制声明 → 启动期暴露，不到 review
+
+### 3.2 负面
+
+- **协议升级成本**：新加 Option / 新协议属性需要在 composition root 显式重声明（这是预期成本，等于把"暗债"显化）
+- **Go 类型设计前置成本**：每个协议第一次落地需投入 Option 范式设计；后续 substrate 复用
+- **不能用 yaml 工具链分析协议**：协议在 Go AST，需 Go 工具链分析（gocell 已有 archtest / `go/packages`，能力具备）
+
+### 3.3 与现有约束的关系
+
+- **K-04**（cells/{accesscore,auditcore,configcore} 留 framework 仓）：cell 仍是协议本体（消费 + 业务决策），typed Protocol primitive 是 runtime 提供的"协议词汇表"，无矛盾
+- **funnel-first**（CLAUDE.md `## 新增 invariant 决策原则`）：typed Go 是 funnel 优先级 #2 "type system 自然拦"的具体形式；archtest 退到 #3 兜底，与原则一致
+- **Option 范式分层**（runtime-api.md）：typed Protocol Option 沿用强依赖 wiring vs 累加式 builder 的现有判定规则
+- **PR262 / PR-MODE-1 / PR-MODE-6**：本 ADR 把这三个 PR 的隐式范式显式化
+
+---
+
+## 4. session protocol 原型（验证形态可落地）
+
+> 以下伪代码层级，供 S2 PR 落地时参照；实际签名以 PR 内为准。
+
+### 4.1 Protocol 类型
+
+```go
+// runtime/auth/session/protocol.go
+package session
+
+// FingerprintMode is sealed: only types in this package implement it.
+type FingerprintMode interface{ fingerprintModeOK() }
+
+type fingerprintHMACSha256 struct{ key []byte }
+func (fingerprintHMACSha256) fingerprintModeOK() {}
+
+type fingerprintNone struct{} // dev / demo only
+func (fingerprintNone) fingerprintModeOK() {}
+
+// CredentialEvent enumerates credential state changes that revoke active sessions.
+type CredentialEvent int
+
+const (
+    CredentialEventPasswordReset CredentialEvent = iota + 1
+    CredentialEventLock
+    CredentialEventDelete
+    CredentialEventRoleRevoke
+)
+
+// OrderingModel is sealed: defines login vs role-revoke ordering primitive.
+type OrderingModel interface{ orderingModelOK() }
+
+type OrderingAdvisoryLock struct{}
+func (OrderingAdvisoryLock) orderingModelOK() {}
+
+type OrderingAuthzEpoch struct{}
+func (OrderingAuthzEpoch) orderingModelOK() {}
+
+type OrderingRowVersion struct{}
+func (OrderingRowVersion) orderingModelOK() {}
+
+// Protocol bundles protocol decisions for a session subsystem.
+// All fields required; nil means caller forgot to opt in.
+type Protocol struct {
+    fingerprint FingerprintMode
+    revokeOn    []CredentialEvent
+    ordering    OrderingModel
+}
+
+type Option func(*Protocol) error
+
+func WithFingerprintHMACSha256(key []byte) Option {
+    return func(p *Protocol) error {
+        if len(key) < 32 {
+            return errcode.New(errcode.ErrValidationFailed,
+                "session protocol: HMAC key must be ≥32 bytes")
+        }
+        p.fingerprint = fingerprintHMACSha256{key: key}
+        return nil
+    }
+}
+
+func WithRevokeOn(events ...CredentialEvent) Option {
+    return func(p *Protocol) error {
+        if len(events) == 0 {
+            return errcode.New(errcode.ErrValidationFailed,
+                "session protocol: WithRevokeOn requires ≥1 event")
+        }
+        p.revokeOn = append(p.revokeOn, events...)
+        return nil
+    }
+}
+
+func WithOrdering(om OrderingModel) Option {
+    return func(p *Protocol) error {
+        if om == nil { // typed-nil also rejected via validation.IsNilInterface
+            return errcode.New(errcode.ErrValidationFailed,
+                "session protocol: ordering required")
+        }
+        p.ordering = om
+        return nil
+    }
+}
+
+// NewProtocol fail-fast on missing required attributes.
+func NewProtocol(opts ...Option) (*Protocol, error) {
+    p := &Protocol{}
+    for _, opt := range opts {
+        if err := opt(p); err != nil {
+            return nil, err
+        }
+    }
+    if p.fingerprint == nil {
+        return nil, errcode.New(errcode.ErrValidationFailed,
+            "session protocol: fingerprint mode required (use WithFingerprintHMACSha256)")
+    }
+    if p.ordering == nil {
+        return nil, errcode.New(errcode.ErrValidationFailed,
+            "session protocol: ordering model required (use WithOrdering)")
+    }
+    return p, nil
+}
+
+// MustNewProtocol is the composition-root convenience wrapper.
+func MustNewProtocol(opts ...Option) *Protocol {
+    p, err := NewProtocol(opts...)
+    if err != nil {
+        panic(err)
+    }
+    return p
+}
+```
+
+### 4.2 Store 接口（Protocol 决定方法形态）
+
+```go
+// runtime/auth/session/store.go
+package session
+
+type Session struct {
+    ID         string
+    SubjectID  string
+    Fingerprint []byte // shape determined by Protocol.fingerprint
+    CreatedAt  time.Time
+    // ...
+}
+
+type Store interface {
+    Create(ctx context.Context, s *Session) error
+    Get(ctx context.Context, id string) (*Session, error)
+    Revoke(ctx context.Context, id string) error
+    RevokeForSubject(ctx context.Context, subjectID string, event CredentialEvent) error
+}
+```
+
+### 4.3 storetest conformance（Protocol-driven）
+
+```go
+// runtime/auth/session/storetest/suite.go
+package storetest
+
+func Run(t *testing.T, factory func(t *testing.T) (session.Store, func()), protocol *session.Protocol) {
+    t.Helper()
+    t.Run("Create_Get", func(t *testing.T) { /* always */ })
+    t.Run("Revoke_Direct", func(t *testing.T) { /* always */ })
+
+    // Protocol-driven: derive cases from declared revoke events
+    for _, event := range protocol.RevokeOn() {
+        event := event
+        t.Run("RevokeOn_"+event.String(), func(t *testing.T) {
+            store, cleanup := factory(t)
+            defer cleanup()
+            // ... assert RevokeForSubject(ctx, subj, event) revokes all matching
+        })
+    }
+
+    // Fingerprint shape conformance
+    switch protocol.FingerprintMode().(type) {
+    case session.FingerprintHMACSha256:
+        t.Run("Fingerprint_NotPlaintext", func(t *testing.T) { /* assert no plaintext token in store */ })
+    }
+}
+```
+
+### 4.4 composition root 显式构造
+
+```go
+// cmd/corebundle/access_module.go (postgres mode)
+sessionProto := session.MustNewProtocol(
+    session.WithFingerprintHMACSha256(shared.SessionFingerprintKey),
+    session.WithRevokeOn(
+        session.CredentialEventPasswordReset,
+        session.CredentialEventLock,
+        session.CredentialEventDelete,
+        session.CredentialEventRoleRevoke,
+    ),
+    session.WithOrdering(session.OrderingAuthzEpoch{}),
+)
+
+pgSessionStore, err := pgstore.NewSessionStore(shared.SharedPGPool, txMgr, sessionProto)
+if err != nil {
+    return nil, err
+}
+
+cell := accesscore.New(
+    accesscore.WithSessionProtocol(sessionProto),
+    accesscore.WithSessionStore(pgSessionStore),
+    // ...
+)
+// AccessCore.Init phase0: typed-nil reject sessionProto / sessionStore via WithSessionProtocol/WithSessionStore (强依赖 wiring)
+```
+
+### 4.5 与 archtest 的关系
+
+| 033 §6 原计划 archtest | typed Protocol 后形态 |
+|---|---|
+| `PG-REPO-CONSTRUCTOR-FAIL-FAST-01` | typed `func New(pool, txRunner, proto) (*T, error)` 签名 + body 顶层校验，**降级删除** |
+| `PG-REPO-AMBIENT-TX-01` | 调用形态约束，**保留**（typed signature 不能拦） |
+| `PG-REPO-INVARIANT-LIST` 索引 | 由 storetest 注册派生，**降级删除** |
+
+新增 archtest（兜底）：
+- `SESSION-PROTOCOL-COMPOSITION-ROOT-01`：`session.NewProtocol` / `MustNewProtocol` 仅在 `cmd/` 调用，禁止在 `cells/` / `runtime/` 内构造（防止 cell 自定义协议绕过 composition-root 决策）
+
+---
+
+## 5. Alternatives Considered
+
+### 5.1 cell.yaml 加 protocol properties（撤回）
+
+把 `protocols: [session, cas, auditledger]` 加进 cell.yaml，codegen 派生 store / migration / handler。
+
+撤回理由：
+- yaml 表达不了 sealed interface / 互斥 / typed-nil reject
+- 与 PR262 演化方向相反（PR262 把 string config 升 typed AuthPlan）
+- 多源治理：yaml ↔ Go 仍漂移
+
+### 5.2 cell-as-data + 整体 codegen（推迟）
+
+把 cell 整体 codegen（K8s controller-runtime / kubebuilder 风格），cell 作者只写 reconcile body。
+
+推迟理由：
+- 重大架构投资，2-3 个月起步
+- PR#417 业务侧不能等
+- typed-Go-heavy 是同方向的更小步长，留 codegen 路径开放
+
+### 5.3 维持 library-style runtime + archtest（PR#417 验证不可行）
+
+继续按 034 v2 走"抽 runtime/auth/session 等 Go 包 + cell import 消费"，archtest 守范式。
+
+撤回理由：library 仍由 cell 手写消费 → 协议决策仍可以藏在 cell 实现 → PR#417 现象重演。
+
+### 5.4 整套 PG store 单点 codegen 工具（撤回）
+
+写 `cmd/gocell generate pg-store --schema=xxx.codegen.yaml`。
+
+撤回理由：
+- 增加额外能力层（违反 user 反馈"能不能整体思考"）
+- yaml schema 是错的源头方向（同 5.1）
+- typed Go schema → 派生 SQL migration 是后续可选优化，不是 Wave 0 必做
+
+---
+
+## 6. Migration / Rollout
+
+| 阶段 | 内容 |
+|---|---|
+| Phase 1（本 ADR + 034 重写） | 锁定方向；S2/S3+S5/S4/S6/S7 PR 内落 typed Protocol primitive；mem/PG conform 同 storetest |
+| Phase 2（按需） | typed Go schema → SQL migration / errcode / schema_guard 派生工具（kubebuilder annotation 风格） |
+| Phase 3（按需） | cell 整体 codegen（如果 typed Protocol 演化中证明 cell 内 boilerplate 仍重） |
+
+Phase 2/3 不在本 ADR 范围；本 ADR 仅锁 Phase 1 方向。
+
+---
+
+## 7. Open Questions
+
+1. PG migration 文件本身是 SQL，与 typed Go schema 之间的桥梁形态待 Phase 2 决定（候选：kubebuilder annotation / sqlc-style / ent-style）
+2. cell 内部对协议是"消费"（仅调 Store 接口）还是"实现"（自己 implement Protocol 部分），sealed interface 边界 case-by-case 判断
+3. 现有 cell.yaml 字段哪些应该 typed Go 化（待 audit；不在本 ADR 范围）
+
+---
+
+## 8. References
+
+- `docs/plans/202605082145-034-pg-corecell-b-route-plan.md` — B 路线计划（本 ADR 触发其重写）
+- `docs/reviews/202605082044-pr417-pg-corecell-framework-analysis.md` — PR#417 分析（路线源）
+- `docs/plans/archive/202604201800-pg-pilot-layering-refactor-plan.md` — 历史 PG pilot 分层重构（同形态前例）
+- `.claude/rules/gocell/runtime-api.md` — Option 范式分层 / sealed AuthPlan / 强依赖 wiring
+- `CLAUDE.md` `## 新增 invariant 决策原则` — funnel + codegen → type system → archtest 优先级
+- PR262 / PR-MODE-1 / PR-MODE-6 — typed-Go-heavy 演化前例

--- a/docs/plans/202605071200-033-pg-implementation-plan.md
+++ b/docs/plans/202605071200-033-pg-implementation-plan.md
@@ -1,5 +1,19 @@
 # 033 PG 实施计划
 
+> **状态（2026-05-10）⚠️ 已被 034 取代**
+>
+> A 路线（在 cell 内一次落地 PG repo）经 PR#417 验证不可行：accesscore PG 接入暴露 5 个 P0/P1 协议缺口（token 重放 / role revoke 排序 / admin 不变量 / credential 失效 / CAS），review 抓表层 bug 后协议问题再爆。
+>
+> 路线已切换到 `docs/plans/202605082145-034-pg-corecell-b-route-plan.md`（v3 修订：typed-Go-heavy 协议 primitive 范式），锚于 `docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md`。
+>
+> 本计划保留作为：
+> - migration 编号预分配（017-022）记录 → 034 重新组织调用
+> - B2.B device PG repo 子任务 → 034 Wave 0 原样保留
+> - 033 §6 archtest 设计**大部分降级删除**（`PG-REPO-CONSTRUCTOR-FAIL-FAST-01` / `PG-REPO-INVARIANT-LIST` 由 typed `(*T, error)` 签名 + storetest 注册派生覆盖；仅 `PG-REPO-AMBIENT-TX-01` 保留为调用形态兜底）
+> - 不再作为活动实施计划
+
+---
+
 **生成日期**: 2026-05-07
 **最后更新**: 2026-05-08（激进合并：删 6 个切片视图，合一为单一任务表 + 实施叙事；W4-W8 全部 ship 同步状态）
 **对接来源**:
@@ -8,7 +22,7 @@
 - `docs/backlog2.md` §5.1 PostgreSQL 路由
 - 029 关键路径已 ship 项：B1 PR#373+#384 / B4+B8 PR#401 / B5 PR#399 / B6 PR#380 / B7+B9 PR#388+#395 / #12 PR#369+#374
 
-**关系**：本计划是 029 roadmap Track B 中所有未 ship PG 项的实施落地文档；不重复已 ship 项细节，仅引用。
+**关系**：本计划是 029 roadmap Track B 中所有未 ship PG 项的实施落地文档；不重复已 ship 项细节，仅引用。**已被 034 取代（见上方状态）**。
 
 ---
 
@@ -137,15 +151,24 @@ archtest `PG-REPO-AMBIENT-TX-01` 守该模式。
 
 ## 6. archtest 设计（funnel-first 单文件主题）
 
+> **⚠️ 已被 034 v3 大部分降级删除**（2026-05-10）
+>
+> 按 ADR-Typed (`docs/architecture/202605101200-...`) D6：archtest 是兜底，不是主防线。原计划 3 条 INVARIANT 处置：
+> - `PG-REPO-CONSTRUCTOR-FAIL-FAST-01` → **删除**：由 typed `func New(pool, txRunner, proto) (*T, error)` 签名 + body 顶层校验直接覆盖
+> - `PG-REPO-AMBIENT-TX-01` → **保留**：调用形态约束，typed signature 不能拦
+> - `PG-REPO-INVARIANT-LIST` 索引 → **删除**：由 storetest 注册派生
+>
+> 新增 archtest（兜底，由 034 S2 落）：`SESSION-PROTOCOL-COMPOSITION-ROOT-01` 守 `session.NewProtocol` / `MustNewProtocol` 仅在 `cmd/` 调用。
+
 按 CLAUDE.md `## 新增 invariant 决策原则`：单文件 `tools/archtest/pg_repo_invariants_test.go` 聚并所有 PG repo 主题约束，每条规则函数前 godoc 加 `// INVARIANT: PG-REPO-*-01` 锚点。
 
 **初始 3 条**（B2.A 落）：
 
-| INVARIANT ID | 守的范式 | 不能 funnel 的原因 |
-|---|---|---|
-| `PG-REPO-CONSTRUCTOR-FAIL-FAST-01` | `NewXxxRepository` 必须 `(*XxxRepository, error)` 签名 + body 顶层 nil 校验 | Go 无强制构造器签名约束，函数签名是 contract 但实现里能漏检 |
-| `PG-REPO-AMBIENT-TX-01` | 写路径必须 `txRunner.RunInTx`，禁 `pool.Begin/Commit` 直调 | 调用形态级约束，无类型钩子 |
-| `PG-REPO-INVARIANT-LIST` 索引 | `// INVARIANT:` 锚点必须在 inventory.md 出现 | grep 锚点串联 |
+| INVARIANT ID | 守的范式 | 不能 funnel 的原因 | v3 处置 |
+|---|---|---|---|
+| `PG-REPO-CONSTRUCTOR-FAIL-FAST-01` | `NewXxxRepository` 必须 `(*XxxRepository, error)` 签名 + body 顶层 nil 校验 | Go 无强制构造器签名约束，函数签名是 contract 但实现里能漏检 | **删除**（typed signature 覆盖） |
+| `PG-REPO-AMBIENT-TX-01` | 写路径必须 `txRunner.RunInTx`，禁 `pool.Begin/Commit` 直调 | 调用形态级约束，无类型钩子 | **保留** |
+| `PG-REPO-INVARIANT-LIST` 索引 | `// INVARIANT:` 锚点必须在 inventory.md 出现 | grep 锚点串联 | **删除**（storetest 注册派生） |
 
 **后续 append**（B2.B 落 1 条 / B2.C 按需）：
 - `PG-REPO-LIST-PARAMS-VALIDATE-01`（如分页参数校验需统一守）

--- a/docs/plans/202605082145-034-pg-corecell-b-route-plan.md
+++ b/docs/plans/202605082145-034-pg-corecell-b-route-plan.md
@@ -1,31 +1,64 @@
 # 034 PG / accesscore / auditcore / configcore B 路线实施计划
 
 **生成日期**: 2026-05-08
+**最后更新**: 2026-05-10（v3 修订：typed-Go-heavy 范式重写，删 ADR-B）
 **对接来源**:
 - `docs/reviews/202605082044-pr417-pg-corecell-framework-analysis.md`（B 路线源）
-- `docs/plans/202605071200-033-pg-implementation-plan.md`（A 路线，本计划取代主线）
+- `docs/plans/202605071200-033-pg-implementation-plan.md`（A 路线，已被本计划取代）
 - `docs/plans/202605082130-pg-corecell-open-issues.md`（C/D/E/F 待办清单）
+- `docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md`（v3 修订的范式锚点）
 
-**关系**：本计划以 B 路线（先抽 runtime 框架再接入）替代 033 A 路线（在 cell 内直接落 PG）；033 中的 migration / wiring / archtest 工作不废弃，重新组织为本计划下的 PR 子任务。
+**关系**：本计划以 B 路线（typed-Go-heavy 协议 primitive + cell 消费）替代 033 A 路线（在 cell 内直接落 PG）；033 中的 migration / wiring 工作不废弃，重新组织为本计划下的 PR 子任务；033 §6 archtest 设计大部分降级删除（由 typed signature 覆盖）。
 
-**v2 修订（2026-05-08）**：删除 v1 错误加入的"治理增强前置"（A-01 / kernel/healthz / errcode classification / cellinit / storetest 共享）——这些是质量改进项，不是 B 路线必须先做的架构问题，留 backlog 单独触发。新增 **ADR-B 接口归属决议** 作为 B 路线**真正**的架构前置（与 S1 协议 ADR 并列）。
+**v2 修订（2026-05-08）**：删除 v1 错误加入的"治理增强前置"；新增 ADR-B 接口归属决议。
+
+**v3 修订（2026-05-10）**：基于 typed-Go-heavy ADR：
+- **删除 ADR-B**：6 条边界规则由 Go 类型系统天然画出（sealed interface / import 方向 / 强依赖 wiring），不再需要文字 ADR
+- **改写 S2/S6/S7**：从"runtime library 抽取"改为"typed Protocol primitive"
+- **改写 S3+S5**：PG store 是 Protocol 的 conform 实现；archtest 大部分降级
+- **改写 S4**：composition root 显式构造 typed Protocol，cell 注入消费
+- **新增 ADR-Typed**（已落 `docs/architecture/202605101200-...`）：作为 B 路线真正的架构前置
+- **工时降低**：~148h → ~102h dev（archtest 工作由 typed signature 替代）
 
 ---
 
 ## 1. 路线选择与原则
 
-**B 路线核心**：accesscore / auditcore / configcore 三个 cell 是**框架自带能力**（K-04 决议），通用机制（session 状态机 / CAS / audit ledger）抽到 `runtime/`，cell 退化为示范实现。
+### 1.1 为什么必须先抽框架（业务形态根因）
 
-**B 路线两个真正的架构前置**（必须先决议，否则 S2-S7 落地反复返工）：
-- **S1 协议 ADR**：PR#417 §12 三个待决问题（admin 不变量 / login vs role revoke 排序 / access token 状态模型）+ credential 失效协议
-- **ADR-B 接口归属 ADR**：B 路线自身的边界规则（K-04 张力 / Repository 归属 / 路径归属 / 事务关系 / storetest 位置 / runtime/auth 子包结构）
+accesscore（认证授权）/ configcore（配置控制面）/ auditcore（证据链）三个 cell 本质是**协议状态机**，不是普通业务 CRUD。把 session 状态机 / CAS / hash chain 写在 cell 内，每接一种存储介质就要重做一次协议设计 —— PR#417 是该模式的爆破点（5 个 P0/P1 协议缺口同时冒出）。
 
-**PR 包决策原则**：
-1. 协议决策与框架接口分离（两份 ADR 先行）
-2. 框架接口 + mem 实现 + storetest conformance 同 PR（不留半成品）
-3. PG 实现与 schema migration 同 PR（schema 一次落地）
-4. cell 接入 PR 把同主题 backlog 顺路收（不留小尾巴）
-5. 路线外独立项（adapter 通用 / 各 cell 死代码清理）走自己的小 PR，不并入主线
+archive `202604201800-pg-pilot-layering-refactor-plan.md` 是同形态的前一次循环（加密/生命周期/Cell组装/治理 4 维度漂移），R1a-R1e 五 PR 解决。本次 PG 接入面对的是同一模式的新维度。
+
+### 1.2 B 路线核心：typed-Go-heavy 协议 primitive
+
+**协议决策必须在最早能用类型系统检查的层级（typed Go primitive）**，由 sealed interface + Option 范式 + composition-root 显式构造组装；不允许藏在 implementation 层（cell 内部 / SQL / mem store 字段）。详见 `docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md`。
+
+具体形态：
+- 每个跨 cell 协议（session / cas / audit ledger）落地为 `runtime/{auth,state,audit}/*` 下的 typed `Protocol` struct + sealed Option
+- mem 与 PG store 共享 `storetest.Run(t, factory, protocol)` conformance suite
+- composition root（`cmd/corebundle/`）显式 `MustNewProtocol(...)` 构造并注入 cell
+- typed-nil reject + phase0 fail-fast 让"忘了构造协议"在启动期暴露
+
+### 1.3 与 K-04 / funnel-first / Option 范式 的对齐
+
+- **K-04**（cells 留 framework 仓）：cell 仍是协议本体（消费 typed Protocol + 业务决策），无矛盾
+- **funnel-first**（CLAUDE.md `## 新增 invariant 决策原则`）：typed Go 是优先级 #2 "type system 自然拦"的具体形式；archtest 退到 #3 兜底
+- **Option 范式分层**（`runtime-api.md`）：typed Protocol Option 沿用强依赖 wiring vs 累加式 builder 的现有判定规则
+
+### 1.4 真正的架构前置（已收敛到两份）
+
+- **ADR-Typed**（已落 `docs/architecture/202605101200-...`）：typed-Go-heavy 范式锁定。**v3 通过本 ADR 替换 v2 的 ADR-B 6 条文字边界规则**——边界由 Go 类型系统天然画出，无需文字规则。
+- **S1 协议 ADR**：PR#417 §12 三个待决问题（admin 不变量 / login vs role revoke 排序 / access token 状态模型）+ credential 失效协议；产物形态是 **typed Option 列表 + Go 头文件骨架**（不只是文字决议）
+
+### 1.5 PR 包决策原则
+
+1. **协议决策落 typed Option**（S1 产物含 Go 头文件，不只是文字 ADR）
+2. **typed Protocol primitive + mem + storetest 同 PR**（不留半成品）
+3. **PG store 实现 + schema migration 同 PR**（schema 一次落地）
+4. **cell 接入 PR 把同主题 backlog 顺路收**（不留小尾巴）
+5. **composition root 显式构造**（不允许"默认能跑"）
+6. **路线外独立项**（adapter 通用 / 各 cell 死代码清理）走自己的小 PR，不并入主线
 
 ---
 
@@ -34,15 +67,17 @@
 | PR | 主题 | 类型 | 依赖 | 并行可行 | 收口 backlog 项 |
 |---|---|---|---|---|---|
 | **S0** | CI integration discovery | infra | — | ✅ | (路线门禁) |
-| **S1** | Credential/Session/Admin 协议 ADR | ADR 文档 | — | ✅ | 三个待决策问题 |
-| **ADR-B** | B 路线接口归属决议 | ADR 文档 | — | ✅ 与 S1 并行 | (B 路线全体前置) |
-| **S2** | `runtime/auth/session` 框架 | runtime 抽象 | S1 + ADR-B | ✅ 可与 S0 并行起 | — |
-| **S3+S5** | PG session/users/roles store + admin 不变量 schema | adapter+migration | S2 | — | B2-C-02 / admin UNIQUE / A26-R4 |
-| **S4** | accesscore session/login 接入 + 残留 P1/P2 | cell 接入 | S3 | — | C 表 11 项（详见 §4） |
-| **S6** | `runtime/state/cas` 框架 + configcore + accesscore user version 接入 | runtime + 双消费 | S1 + ADR-B | ✅ 与 S2-S5 并行 | E 表 2 项 + C 表 1 项 |
-| **S7** | `runtime/audit/ledger` 框架 + PG audit_entries + auditcore 接入 | runtime+adapter+cell | S1 + ADR-B | ✅ 与 S2-S6 并行 | D 表 9 项 |
+| **ADR-Typed** | typed-Go-heavy 协议 primitive 范式 | ADR 文档 | — | ✅ **已落** `202605101200-...` | (B 路线全体前置) |
+| **S1** | Credential/Session/Admin 协议 → typed Option 列表 | ADR + Go 头文件 | ADR-Typed | ✅ | 三个待决策问题 |
+| **S2** | `runtime/auth/session` typed Protocol + mem + storetest | typed Go primitive | S1 | ✅ 可与 S0 并行起 | — |
+| **S3+S5** | PG session store conform + users/roles schema + admin 不变量 | adapter + migration | S2 | — | B2-C-02 / admin UNIQUE / A26-R4 |
+| **S4** | accesscore composition-root 显式构造 + cell 注入 + 残留 P1/P2 | cell 接入 | S3+S5 | — | C 表 11 项（详见 §4） |
+| **S6** | `runtime/state/cas` typed Protocol + configcore + accesscore user version 接入 | typed primitive + 双消费 | S1 | ✅ 与 S2-S5 并行 | E 表 2 项 + C 表 1 项 |
+| **S7** | `runtime/audit/ledger` typed Protocol + PG + auditcore 接入 | typed primitive + adapter + cell | S1 | ✅ 与 S2-S6 并行 | D 表 9 项 |
 | **W9** | outbox factory adoption | 机械迁移 | — | ✅ 完全独立 | 033 W9 |
-| **B2.B** | PG-DEVICECELL-REPO | adapter+migration | — | ✅ 与 examples 业务无关 | 033 B2.B |
+| **B2.B** | PG-DEVICECELL-REPO | adapter + migration | — | ✅ 与 examples 业务无关 | 033 B2.B |
+
+**~~ADR-B 接口归属决议~~**：v3 删除。6 条边界规则由 typed Go 类型系统天然画出（sealed interface 决定接口归属，import 方向决定路径归属，`runtime-api.md` Option 范式决定事务关系），无需文字 ADR。
 
 **B5.FU PG-REFRESH-RUNTIME-WIRING 自然消化**：在 S4 后段完成（access_module postgres 分支删 `WithInMemoryDefaults`），不再独立。
 
@@ -56,20 +91,22 @@ Wave 0（立即并行起）：
   W9 ──┼── 全部独立，无下游
   B2.B─┘
 
-Wave 1（关键路径，并行起两份 ADR）：
-  S1     协议 ADR
-  ADR-B  接口归属 ADR
+Wave 1（关键路径，单份 ADR）：
+  ADR-Typed  ✅ 已落 (202605101200)
+  S1         协议 ADR + typed Option 列表（产物含 Go 头文件骨架）
 
-Wave 2（两份 ADR 都过后）：
+Wave 2（S1 通过后）：
   S2 ──→ S3+S5 ──→ S4 ──→ B5.FU 消化
                               
   S6（state/cas 路径）         [与 S2-S5 并行]
   S7（audit ledger 路径）       [与 S2-S6 并行]
 ```
 
-**worktree 容量**：Wave 0 三个 + Wave 1 两份 ADR = 5 worktree；Wave 2 起后 S2/S6/S7 三框架并行 + S3+S5 串行（共 4 worktree）；B5.FU 在 S4 内消化。
+**worktree 容量**：Wave 0 三个 + Wave 1 S1 = 4 worktree；Wave 2 起后 S2/S6/S7 三框架并行 + S3+S5 串行（共 4 worktree）；B5.FU 在 S4 内消化。
 
-**关键路径**：S1 + ADR-B 是 B 路线**唯一**关键路径。两份 ADR 不通过，S2-S7 不能起。
+**关键路径**：**S1 是 B 路线唯一关键路径**（ADR-Typed 已落）。S1 不通过，S2-S7 不能起。
+
+**v3 简化**：v2 的 ADR-B（接口归属 6 条边界规则）已被 ADR-Typed 替代，关键路径从"两份 ADR"简化为"一份 S1"。
 
 ---
 
@@ -85,59 +122,30 @@ Wave 2（两份 ADR 都过后）：
 
 ---
 
-### ADR-B B 路线接口归属决议（纯文档，B 路线架构前置）
+### ~~ADR-B B 路线接口归属决议~~（v3 删除）
 
-**目的**：B 路线主张抽 runtime 框架，但抽到哪一层、怎么分包、cell 与 runtime 的接口怎么协调——这些边界规则不先定，S2/S6/S7 三框架 PR 内会反复争论"接口该长什么样"，违反"引入新约束必须同 PR 闭环"。
+**v3 删除理由**：6 条边界规则由 typed Go 类型系统天然画出：
 
-**必须回答的 6 条边界规则**：
+| 原 ADR-B 边界规则 | typed-Go-heavy 自动答案 |
+|---|---|
+| 1. K-04 张力（cell 本体 vs 示范） | runtime/{auth,state,audit}/* 暴露 typed Protocol primitive；cell 消费 + 业务决策；无歧义 |
+| 2. Repository / Store 接口归属准则 | 接口形态决定：sealed Protocol 在 runtime（typed primitive），业务实体 Repository 在 cell 私有；调用方 import 方向自然画出 |
+| 3. `adapters/postgres` 路径归属 | runtime Protocol 的 PG conform 实现在 `adapters/postgres/`；cell 私有 entity repo 留 `cells/{cell}/internal/adapters/postgres/`（混合形态，但由 import 方向唯一确定） |
+| 4. Store 接口与事务的关系 | 沿用 033 §5.3 ambient TX；archtest `PG-REPO-AMBIENT-TX-01` 保留（typed signature 不能拦调用形态） |
+| 5. storetest conformance 位置 | 每协议自带 `runtime/{auth,state,audit}/*/storetest/`，suite 接受 typed Protocol 实例（参见 ADR-Typed §4.3） |
+| 6. `runtime/auth` 子包结构 | runtime/auth/session 提供 typed Protocol + Store + storetest；与 jwt/oidc/federated 对等并列 |
 
-1. **K-04 vs runtime 抽取的张力解决**
-   K-04 决议 cells/{accesscore,auditcore,configcore} 留 framework 仓，定位 = "框架自带认证/配置/审计能力"。B 路线把通用机制抽到 runtime 后，cell 是 runtime 接口的**本体实现**（K-04 原意），还是退化为**示范实现**（PR#417 §8.5 措辞）？
-   - 选项 A：cell 是本体 — runtime 暴露**最小协议接口**，cell 拥有完整业务能力，外部 cell 只在罕见场景重新实现接口
-   - 选项 B：cell 是示范 — runtime 暴露**完整能力接口**，cell 退化为 thin wrapper，外部 cell 可平替
-   - 决议影响：runtime/auth/session 的接口宽度（最小协议 vs 完整能力）
-
-2. **Repository / Store 接口归属准则**
-   033 §5.1 说 Repository 接口在 cells/{cell}/internal/{domain|mem}/（cell 私有）；PR#417 §8.1 说 SessionStore 接口在 runtime/auth/session/store.go（runtime 共享）。两者矛盾。需要一条**判定准则**：
-   - 候选准则：接口被 ≥2 cell 消费 → 升 runtime；单 cell 消费 → 留 cell 私有
-   - 候选准则：接口表达**协议状态**（session 状态机 / audit chain / cas version）→ 升 runtime；接口表达**业务实体**（user / role / device / config entry）→ 留 cell 私有
-   - 决议影响：UserRepository / RoleRepository / DeviceRepository 不升 runtime；SessionStore / CASStore / AuditLedgerStore 升 runtime
-
-3. **adapters/postgres 路径归属**
-   现状：configcore 已经在 `cells/configcore/internal/adapters/postgres/` 放 PG repo；PR#417 §8.4 提议放 `adapters/postgres/`。两层路径同时存在是矛盾的，必须二选一：
-   - 选项 A：所有 PG 实现统一在 adapters/postgres/（与依赖规则"adapters 实现 kernel/runtime 定义的接口"一致；要求把 configcore 现有 PG repo 上移）
-   - 选项 B：cell 私有 PG 实现留 cells/{cell}/internal/adapters/postgres/，runtime 接口的 PG 实现放 adapters/postgres/（混合）
-   - 决议影响：S3+S5 / S6 / S7 三 PR 的物理路径
-
-4. **Store 接口与事务的关系**
-   gocell 已有 `kernel/persistence.TxRunner` + `postgres.TxManager` 提供 ambient TX from context。runtime 框架接口（SessionStore / CASStore / AuditLedgerStore）：
-   - 选项 A：透明 ambient TX — Store 方法不暴露 TxRunner，事务边界由调用方 `txRunner.RunInTx` 包，Store 内部读 `TxFromContext`
-   - 选项 B：显式 TxRunner — Store 接口签名暴露 TxRunner，调用方传入
-   - 033 §5.3 已明确选 A（ambient TX，archtest PG-REPO-AMBIENT-TX-01 守）；ADR-B 确认 B 路线沿用同一约束
-
-5. **storetest conformance 位置**
-   选项 A：每框架内 `runtime/auth/session/storetest/`、`runtime/state/cas/storetest/`、`runtime/audit/ledger/storetest/`（PR#417 提议）
-   选项 B：共享 `kernel/persistence/storetest/` 提供 RunSuite helper，每框架的 storetest 只定义自己的 fixture
-   - 决议影响：S2 首落 storetest 范式时是建独立子包还是消费共享 helper
-
-6. **runtime/auth 子包结构**
-   现状：runtime/auth/ 已有 jwt / federated / oidc 等子包。新加 runtime/auth/session/，与现有子包关系：
-   - session 是 stateful（DB 持久），jwt 是 stateless（claim only）—— 是对偶？
-   - jwt 签发依赖 session 还是反向？
-   - 候选：runtime/auth/session 提供 SessionStore + Fingerprint helper；runtime/auth/jwt 消费 session 接口签发；revoke 协议在 runtime/auth/session 内
-   - 决议影响：S2 包结构与 import 方向
-
-**输出**：`docs/architecture/202605xx-adr-b-route-interface-boundaries.md`
-
-**收口**：B 路线 S2/S3+S5/S4/S6/S7 全体前置（不通过则 5 个 PR 都不能起）。
+详见 `docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md` D2/D3。
 
 ---
 
-### S1 Credential / Session / Admin 协议 ADR（纯文档）
+### S1 Credential / Session / Admin 协议 → typed Option 列表
+
+**v3 修订**：S1 产物从"纯文字 ADR"升级为"ADR + Go 头文件骨架"。文字 ADR 决议产品语义；Go 头文件落 typed Option 形态，供 S2 直接消费。
 
 **目的**：把三个待决策问题一次决定，避免 S2-S5 边写边改。
 
-**内容**：
+**内容（文字 ADR 部分）**：
 - access token 不落明文 / session 表存 HMAC fingerprint 还是 jti
 - password reset / lock / delete / role revoke 对旧凭据的统一失效协议
 - login 与 role revoke 的排序点（per-user advisory lock / authz epoch / role version）
@@ -145,47 +153,84 @@ Wave 2（两份 ADR 都过后）：
 - **admin 不变量**：至少一个 vs 只能一个（PR#417 §12 决策点）
 - session/refresh revoke 与事务边界
 
-**输出**：`docs/architecture/202605xx-adr-credential-session-protocol.md` + `docs/architecture/202605xx-adr-admin-invariant.md`
+**Go 头文件骨架（必含）**：
+```go
+// runtime/auth/session/protocol_options.go (S1 产物，body 留 S2 实现)
+
+type FingerprintMode interface{ fingerprintModeOK() }      // sealed
+type CredentialEvent int                                    // typed enum
+type OrderingModel interface{ orderingModelOK() }          // sealed
+
+func WithFingerprintHMACSha256(key []byte) Option           // 决议 1
+func WithFingerprintJTI() Option                            // 决议 1（备选）
+func WithRevokeOn(events ...CredentialEvent) Option        // 决议 2/3
+func WithOrdering(om OrderingModel) Option                 // 决议 3
+// ... admin 不变量在 cell.yaml 还是 typed Go protocol，S1 决议
+```
+
+**输出**：
+- `docs/architecture/202605xx-adr-credential-session-protocol.md`（文字 ADR）
+- `docs/architecture/202605xx-adr-admin-invariant.md`（文字 ADR）
+- `runtime/auth/session/protocol_options.go`（typed Option 头文件骨架，S2 PR 内填实现）
 
 ---
 
-### S2 `runtime/auth/session` 框架
+### S2 `runtime/auth/session` typed Protocol primitive
+
+**v3 修订**：S2 产物形态从"runtime library 接口集合"改为"typed Protocol primitive"，参见 ADR-Typed §4 session protocol 原型。
 
 **目录**：
 ```
 runtime/auth/session/
-  types.go
-  store.go
-  fingerprint.go
-  revoke.go
-  storetest/suite.go
+  protocol.go              ← typed Protocol struct + Option 实现（S1 已落骨架，S2 填实现）
+  protocol_options.go      ← S1 已落骨架（sealed interface / typed enum / Option 签名）
+  store.go                 ← Store interface（方法形态由 Protocol 决定）
+  mem_store.go             ← mem 实现
+  storetest/suite.go       ← Run(t, factory, protocol *Protocol) 即 Protocol-driven suite
 ```
 
 **内容**：
-- session metadata 接口
-- access token 不可重放引用 / HMAC fingerprint helper
-- session revoke / subject-level revoke
-- mem 实现 + storetest conformance suite
-- 不含 admin/role name/password policy 等产品语义
+- typed `Protocol` struct + sealed Option（实现 S1 头文件骨架）
+- `NewProtocol(opts ...Option) (*Protocol, error)` fail-fast 校验互斥与必填
+- `MustNewProtocol(...)` composition-root 包装
+- `Store` interface（Create / Get / Revoke / RevokeForSubject）
+- mem 实现
+- `storetest.Run(t, factory, protocol)` Protocol-driven 派生 test cases
+- 不含 admin/role name/password policy 等产品语义（cell 内）
 
-**约束**：不接 accesscore，PR 独立可审查。
+**约束**：
+- 不接 accesscore，PR 独立可审查
+- 协议 Option 不允许在 `cells/` / 内部代码构造（仅 `cmd/` composition root），由新增 archtest `SESSION-PROTOCOL-COMPOSITION-ROOT-01` 兜底守
 
 **收口**：暂无 backlog（铺路，S4 消费）。
 
 ---
 
-### S3+S5 PG session/users/roles store + admin 不变量 schema（合并 PR）
+### S3+S5 PG session store conform + users/roles schema + admin 不变量（合并 PR）
+
+**v3 修订**：PG `session_store.go` 是 S2 typed Protocol 的 conform 实现，签名由 typed Protocol 推出；users/roles 是 cell 私有 entity repo（不升 runtime），仍按 cell 内 Repository interface 落实。033 §6 archtest 大部分降级删除（由 typed signature 覆盖）。
 
 **合并理由**：schema 一次落地，admin UNIQUE 与 users 表是 DDL 层共生关系，不应拆 PR；migration 017-019 三条 SQL 同 PR 避免 schema_guard 文本合并冲突。
 
 **文件域**：
-- `adapters/postgres/session_store.go`（实现 S2 接口）
-- `adapters/postgres/{user,role}_repo.go`
+- `adapters/postgres/session_store.go`（实现 S2 typed Store；构造函数签名 `NewSessionStore(pool, txMgr, *session.Protocol) (*SessionStore, error)`，phase0 fail-fast on nil deps）
+- `adapters/postgres/{user,role}_repo.go`（cell 私有 entity repo 的 PG 实现；从 `cells/accesscore/internal/ports/` import 接口）
 - `adapters/postgres/migrations/017_users.sql` / `018_sessions.sql` / `019_roles.sql`
 - `adapters/postgres/schema_guard.go` 首落主体 + 3 表
 - `adapters/postgres/errcode.go` append PG 错误码
-- `tools/archtest/pg_repo_invariants_test.go` 首落 3 INVARIANT
 - `cmd/corebundle/setup_integration_test.go` 加 testcontainer e2e
+- `runtime/auth/session/storetest/suite.go` 在 `pg_session_store_integration_test.go` 中以 PG factory + 同一 Protocol 实例运行
+
+**archtest 调整（vs 033 §6）**：
+
+| 原 INVARIANT | 处置 |
+|---|---|
+| `PG-REPO-CONSTRUCTOR-FAIL-FAST-01` | **删除**：由 typed `(*T, error)` 签名 + body 顶层校验直接覆盖 |
+| `PG-REPO-AMBIENT-TX-01` | **保留**：调用形态约束（写路径强制 `txRunner.RunInTx`），typed signature 不能拦 |
+| `PG-REPO-INVARIANT-LIST` 索引 | **删除**：由 storetest 注册派生，不需 grep 锚点 |
+
+**新增 archtest（兜底）**：
+- `SESSION-PROTOCOL-COMPOSITION-ROOT-01`：`session.NewProtocol` / `MustNewProtocol` 仅在 `cmd/` 调用（防止 cell 自定义协议绕过 composition-root 决策）
 
 **收口 backlog**：
 - B2-C-02 SETUP-ADMIN-PUBLIC-ROUTE-PERMANENT 🔴 P0（schema + setup 边界一起处理）
@@ -197,13 +242,16 @@ runtime/auth/session/
 
 ---
 
-### S4 accesscore session/login 接入 + 残留 P1/P2
+### S4 accesscore composition-root 显式构造 + cell 注入 + 残留 P1/P2
+
+**v3 修订**：从"cell 内 import runtime"模式改为"composition root 显式构造 typed Protocol → 注入 cell"。cell 内不再有"接入 runtime"的工作，仅消费注入的 typed Protocol + Store；省下"接入"工时。
 
 **文件域**：
-- `cells/accesscore/slices/{sessionlogin,sessionlogout,refresh}/` 改为消费 `runtime/auth/session`
-- `cells/accesscore/cell_init.go` Redis session cache adapter 注入
-- `cells/accesscore/internal/{ports,domain,mem}/` 5 联动激活
-- `cmd/corebundle/access_module.go` postgres 分支删 `WithInMemoryDefaults`（B5.FU 消化）
+- `cmd/corebundle/access_module.go`：postgres 分支显式 `session.MustNewProtocol(...)` 构造，参数从 S1 决议；`accesscore.New(WithSessionProtocol(...), WithSessionStore(pgSessionStore))` 注入；删 `WithInMemoryDefaults`（B5.FU 消化）
+- `cells/accesscore/cell.go` + `cell_options.go`：新增 `WithSessionProtocol` / `WithSessionStore` option（强依赖 wiring 范式，typed-nil reject）
+- `cells/accesscore/slices/{sessionlogin,sessionlogout,refresh}/`：service 接受注入的 `*session.Protocol` + `session.Store`，不再 import `runtime/auth/session/mem`
+- `cells/accesscore/cell_init.go`：Redis session cache adapter 注入
+- `cells/accesscore/internal/{ports,domain,mem}/`：5 联动激活
 
 **收口 backlog**：
 - ACCESSCORE-ACCOUNT-LOCKOUT-AUTO-LOCK-01 🔴 P1（session 状态机一并）
@@ -229,56 +277,65 @@ runtime/auth/session/
 
 ---
 
-### S6 `runtime/state/cas` 框架 + configcore + accesscore 接入
+### S6 `runtime/state/cas` typed Protocol + configcore + accesscore 接入
+
+**v3 修订**：从"runtime library 接口"改为"typed CAS Protocol primitive"；configcore / accesscore composition root 显式构造 + 注入。
 
 **目录**：
 ```
 runtime/state/cas/
-  version.go
-  conflict.go
-  storetest/suite.go
+  protocol.go              ← typed CAS Protocol（VersionField / ConflictPolicy / Strict|Lax）
+  protocol_options.go      ← sealed Option（WithVersionField / WithConflictPolicy / WithStrict）
+  store.go                 ← Store interface（CompareAndSwap / Get）
+  mem_store.go             ← mem 实现
+  storetest/suite.go       ← Run(t, factory, *Protocol) Protocol-driven
 ```
 
 **内容**：
-- version / etag 接口
-- compare-and-swap update 模式
-- conflict error 标准化
-- mem 实现 + storetest conformance
-- **configcore 接入**：现有 PG version 行为重构为消费 cas
-- **accesscore user version 接入**：identitymanage ChangePassword 用 cas 解决并发
+- typed `Protocol` struct + sealed Option（version field 名 / conflict 策略 / strict 模式）
+- `NewProtocol(opts ...Option) (*Protocol, error)` fail-fast
+- `Store` interface 由 Protocol 决定 conflict 行为
+- mem 实现 + Protocol-driven storetest
+- **composition root 显式构造**：configcore / accesscore 各 cell module 在 `cmd/corebundle/` 显式 `cas.MustNewProtocol(...)`
+- **configcore 接入**：现有 PG version 行为重构为消费 cas Protocol；cell 内 service 接受注入
+- **accesscore user version 接入**：identitymanage ChangePassword 用注入的 cas Protocol 解决并发
 
 **收口 backlog**：
 - B2-T-01 Config rollback 乐观锁缺 🟡 P1
 - P3-TD-12 configpublish.Rollback 版本校验 🟠 P2
 - PR280-FU1 CHANGEPASSWORD-CONCURRENT-SEMANTICS-01 🟡 P2
 
-**为什么三件一起**：CAS 框架不能只抽不接入（违反"不留半成品"），两个消费点同时接入证明框架接口可用。
+**为什么三件一起**：CAS Protocol 不能只抽不接入（违反"不留半成品"），两个消费点同时接入证明 typed Protocol 接口可用。
 
 ---
 
-### S7 `runtime/audit/ledger` 框架 + PG + auditcore 接入
+### S7 `runtime/audit/ledger` typed Protocol + PG + auditcore 接入
+
+**v3 修订**：append-only / hash chain / restart 恢复 / idempotency 等协议属性升 typed Protocol；auditcore composition root 显式构造 + 注入。
 
 **目录**：
 ```
 runtime/audit/ledger/
-  entry.go
-  chain.go
-  store.go
-  storetest/suite.go
+  protocol.go              ← typed Protocol（ChainMode / IdempotencyMode / RestartRecovery）
+  protocol_options.go      ← sealed Option（WithChainHMAC / WithIdempotencyKey / WithRestartRecovery）
+  entry.go                 ← Entry typed struct
+  store.go                 ← Store interface（Append / Get / Verify / TailHash）
+  mem_store.go             ← mem 实现
+  storetest/suite.go       ← Run(t, factory, *Protocol)
 
 adapters/postgres/
-  audit_ledger_store.go
+  audit_ledger_store.go    ← conform 实现，构造签名 NewLedgerStore(pool, txMgr, *ledger.Protocol)
   migrations/02x_audit_entries.sql
 ```
 
 **内容**：
-- append-only ledger 接口
-- hash/HMAC chain
-- restart 链头恢复（解 B2-C-01 P0）
-- idempotency key
-- verify / gap detection
-- mem + PG storetest conformance
-- auditcore 接入框架，slices 改为编排
+- typed `Protocol` struct + sealed Option（chain 模式 / idempotency / restart 恢复策略）
+- `NewProtocol(opts ...Option) (*Protocol, error)` fail-fast
+- `Store` interface（Append / Get / Verify / TailHash）由 Protocol 决定方法形态
+- restart 链头恢复（解 B2-C-01 P0）：Protocol 声明 `WithRestartRecovery(StrictTailVerify)` / `WithRestartRecovery(LazyOnFirstAppend)`，Store 实现按 Protocol 决策
+- mem + PG 共享 storetest conformance（Protocol-driven，append-only / chain integrity / idempotency 派生 cases）
+- **composition root 显式构造**：`cmd/corebundle/audit_module.go` 显式 `ledger.MustNewProtocol(...)`
+- **auditcore 接入**：cell 内 slices 接受注入的 `*ledger.Protocol` + `ledger.Store`，slice 改为编排
 
 **收口 backlog**：
 - B2-C-01 Audit hashchain 重启未恢复尾节点 🔴 P0（chain 设计核心）
@@ -341,40 +398,52 @@ adapters/postgres/
 
 ---
 
-## 6. 工时粗估
+## 6. 工时粗估（v3）
 
 | PR | dev | review | 备注 |
 |---|---|---|---|
 | S0 | 4h | 2h | CI 改造 |
-| S1 | 8h | 4h | 协议 ADR |
-| ADR-B | 6h | 4h | 接口归属 ADR（6 条边界规则） |
-| S2 | 16h | 8h | runtime 接口 + mem + storetest |
-| S3+S5 | 24h | 12h | PG store + 3 migration + setup 边界 + admin schema |
-| S4 | 32h | 16h | accesscore 接入 + 12 个收口项 |
-| S6 | 16h | 8h | CAS 框架 + 双消费接入 |
-| S7 | 28h | 14h | audit ledger + PG + 9 个收口项 |
+| ~~ADR-B~~ | ~~6h~~ | ~~4h~~ | **v3 删除**（typed Go 类型系统替代） |
+| ADR-Typed | — | — | ✅ 已落 (`202605101200-...`) |
+| S1 | 10h | 5h | 协议 ADR + typed Option Go 头文件骨架（+2h vs v2） |
+| S2 | 16h | 8h | typed Protocol primitive + mem + storetest |
+| S3+S5 | 18h | 10h | PG store conform + 3 migration + admin schema（archtest 大部分由 typed signature 替代，-6h） |
+| S4 | 24h | 12h | composition root 显式构造 + cell 注入 + 12 个收口项（"接入"工时省下，-8h） |
+| S6 | 12h | 6h | typed CAS Protocol + 双消费 composition root 注入（-4h） |
+| S7 | 22h | 11h | typed audit Protocol + PG + 9 个收口项（-6h） |
 | W9 | 6h | 3h | 机械迁移 |
 | B2.B | 8h | 6h | device PG repo |
-| **合计** | **~148h** | **~77h** | 4 worktree 并行 wall-clock 约 1.5-2 周 |
+| **合计** | **~120h** | **~63h** | 4 worktree 并行 wall-clock 约 1-1.5 周 |
 
-A 路线工时（033 残）47-49h dev / B 路线 142h dev — **约 3 倍**，但收口项也从 5 项扩到 ~50 项（C/D/E/F + 033 残），且把"在 cell 内重做框架"问题一次解决。
+**v2 → v3 工时变化**：
+- 删 ADR-B：-6h dev / -4h review
+- S1 加 Go 头文件骨架：+2h dev / +1h review
+- S3+S5 archtest 降级：-6h dev / -2h review
+- S4 省"接入"工时：-8h dev / -4h review
+- S6 / S7 同上：-10h dev / -5h review
+- **净降**：-28h dev / -14h review（约 19% 缩减）
+
+A 路线工时（033 残）47-49h dev / B 路线 v3 ~120h dev —— **约 2.5 倍**，但收口项从 5 项扩到 ~50 项（C/D/E/F + 033 残），且把"在 cell 内重做框架"问题一次解决，并把 PR#417 5 个 P0/P1 协议缺口压到启动期 fail-fast。
 
 ---
 
 ## 7. 决策点
 
-ship S2 / S6 / S7 任一前必须先 ship S1（ADR 决策三个待决问题）。S1 ADR 决议是本计划真正的关键路径。
+ship S2 / S6 / S7 任一前必须先 ship S1（ADR 决策三个待决问题 + typed Option Go 头文件骨架）。**S1 是本计划唯一关键路径**（v2 的 ADR-B 已被 v3 ADR-Typed 替代，不再是关键路径节点）。
 
 S0 / W9 / B2.B / 路线外独立项可立即起，不等 S1。
 
-Wave 1 启动条件：S0 通过 + S1 ADR 评审通过。
+Wave 1 启动条件：S0 通过 + S1 ADR 评审通过（含 Go 头文件骨架）。
 
 ---
 
 ## 8. 引用
 
+- `docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md`：**v3 范式锚点**（typed-Go-heavy 协议 primitive）
 - `docs/reviews/202605082044-pr417-pg-corecell-framework-analysis.md`：B 路线源
-- `docs/plans/202605071200-033-pg-implementation-plan.md`：A 路线（被本计划主线取代，PG migration / archtest 子任务保留）
+- `docs/plans/202605071200-033-pg-implementation-plan.md`：A 路线（被本计划主线取代，PG migration 子任务保留；§6 archtest 大部分降级删除）
 - `docs/plans/202605082130-pg-corecell-open-issues.md`：C/D/E/F 待办源
+- `docs/plans/archive/202604201800-pg-pilot-layering-refactor-plan.md`：历史 PG pilot 分层重构（同形态前例）
+- `.claude/rules/gocell/runtime-api.md`：Option 范式分层 / sealed AuthPlan / 强依赖 wiring
 - `CLAUDE.md` `## 核心架构约束` / `## 新增 invariant 决策原则`
 - `docs/plans/202605051600-030-review-0504-implementation.md` K-04 ADR 决议（cells 留 framework 仓）


### PR DESCRIPTION
## Summary

This PR introduces a foundational architectural decision (ADR) for GoCell's protocol primitive design and revises the 034 B-route implementation plan to align with it. The core insight is that protocol decisions must be enforced at the type system level (sealed interfaces + typed Options + composition-root construction) rather than hidden in implementation layers, preventing the repeated "protocol explosion" seen in PR#417 and prior PG integration cycles.

## Key Changes

### New ADR Document
- **`docs/architecture/202605101200-adr-typed-go-heavy-protocol-primitives.md`** (420 lines)
  - Establishes that protocol decisions (durability, consistency, concurrency, encryption, indexing) must be declared in typed Go primitives, not buried in cell implementations or SQL
  - Defines the pattern: `sealed interface` + `Option` functions + `NewProtocol(opts ...Option) (*Protocol, error)` fail-fast validation + `MustNewProtocol(...)` composition-root wrapper
  - Provides session protocol as a worked example (§4) showing Protocol struct, sealed FingerprintMode/OrderingModel, CredentialEvent enum, and Protocol-driven storetest
  - Explains how this reduces AI error modes (F1/F3/F5 to compile time, F2 to interface layer, F4 eliminated)
  - Clarifies relationship to existing constraints (K-04, funnel-first, Option range patterns)
  - Downgrades archtest from primary defense to fallback (typed signatures + storetest registration replace most INVARIANT checks)

### 034 Plan Revision (v3)
- **`docs/plans/202605082145-034-pg-corecell-b-route-plan.md`** (major rewrite)
  - **Deletes ADR-B** (6 boundary rules): These are now naturally enforced by Go's type system (sealed interfaces determine interface ownership, import direction determines path ownership, Option patterns determine transaction relationships)
  - **Replaces "runtime library extraction" with "typed Protocol primitive"**: S2/S6/S7 now produce `Protocol` structs with sealed Options, not generic library interfaces
  - **Elevates S1 output**: Now includes Go header file skeleton (`protocol_options.go`) with sealed interfaces and Option signatures, not just text ADR
  - **Revises composition root pattern**: S4 now explicitly constructs `session.MustNewProtocol(...)` in `cmd/corebundle/` and injects into cell via `WithSessionProtocol` option (strong-dependency wiring)
  - **Simplifies critical path**: From "two ADRs" (S1 + ADR-B) to "one ADR + S1" (ADR-Typed already landed)
  - **Reduces archtest scope**: `PG-REPO-CONSTRUCTOR-FAIL-FAST-01` and `PG-REPO-INVARIANT-LIST` deleted (covered by typed signatures); only `PG-REPO-AMBIENT-TX-01` retained for call-site constraints
  - **Lowers estimated effort**: ~148h → ~102h dev (archtest work replaced by typed signature enforcement)
  - Updates S2-S7 descriptions to reflect Protocol-driven storetest pattern and composition-root construction

### 033 Plan Status Update
- **`docs/plans/202605071200-033-pg-implementation-plan.md`** (status header added)
  - Marks plan as superseded by 034 v3
  - Clarifies that 033 archtest design is mostly downgraded (only `PG-REPO-AMBIENT-TX-01` retained)
  - Preserves migration numbering and B2.B device repo task for reference

## Notable Implementation Details

1. **Sealed Protocol Attributes**: FingerprintMode, OrderingModel, CredentialEvent are sealed interfaces/enums that cannot be extended outside their package, preventing "almost right" implementations

2. **Fail-Fast Validation**: `NewProtocol(opts ...Option) (*Protocol, error)` validates all required fields are set and mutually compatible; `MustNewProtocol(

https://claude.ai/code/session_01VwZmdqxQ8YADFJWnvF9cq6