### PR TITLE
fix(schemas,governance,metadata): unify auth bool semantics via single oracle (PR-C)

### DIFF
--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -1025,11 +1025,11 @@ func (v *Validator) validateFMT27() []ValidationResult {
 			contractFile(c),
 			"endpoints.http.auth",
 			fmt.Sprintf(
-				"contract %q declares incompatible auth mode flags; auth.public, "+
-					"auth.bootstrap, auth.passwordResetExempt, auth.clientsOnly, and "+
-					"auth.serviceOwned have distinct route-auth semantics. "+
-					"Only auth.serviceOwned may combine with auth.passwordResetExempt",
-				c.ID,
+				"contract %q has incompatible auth mode combination: %s set to true. "+
+					"Set at most one of {auth.public, auth.bootstrap, "+
+					"auth.passwordResetExempt, auth.clientsOnly}; "+
+					"only auth.serviceOwned may pair with auth.passwordResetExempt",
+				c.ID, formatTrueAuthFields(auth),
 			),
 		))
 	}
@@ -1042,6 +1042,29 @@ func (v *Validator) validateFMT27() []ValidationResult {
 // IterateAuthBoolCombos; no FMT-27 changes needed.
 func hasFMT27AuthModeConflict(auth metadata.HTTPAuthMeta) bool {
 	return !metadata.AuthComboLegal(auth)
+}
+
+// formatTrueAuthFields lists the auth bool fields currently set to true, in
+// the canonical P-R-S-B-C order, so FMT-27 diagnostics pinpoint the offending
+// flags rather than only naming the contract. Used by validateFMT27.
+func formatTrueAuthFields(auth metadata.HTTPAuthMeta) string {
+	var fields []string
+	if auth.Public {
+		fields = append(fields, "auth.public")
+	}
+	if auth.PasswordResetExempt {
+		fields = append(fields, "auth.passwordResetExempt")
+	}
+	if auth.ServiceOwned {
+		fields = append(fields, "auth.serviceOwned")
+	}
+	if auth.Bootstrap {
+		fields = append(fields, "auth.bootstrap")
+	}
+	if auth.ClientsOnly {
+		fields = append(fields, "auth.clientsOnly")
+	}
+	return strings.Join(fields, ", ")
 }
 
 // validateFMT30 enforces that every assembly's build.deployTemplate is one of

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -1036,24 +1036,12 @@ func (v *Validator) validateFMT27() []ValidationResult {
 	return results
 }
 
+// hasFMT27AuthModeConflict delegates to metadata.AuthComboLegal so the schema
+// (contract.schema.json if/then) and governance share a single oracle. Adding
+// a new auth bool field requires updating only AuthComboLegal +
+// IterateAuthBoolCombos; no FMT-27 changes needed.
 func hasFMT27AuthModeConflict(auth metadata.HTTPAuthMeta) bool {
-	coreModes := 0
-	if auth.Public {
-		coreModes++
-	}
-	if auth.Bootstrap {
-		coreModes++
-	}
-	if auth.PasswordResetExempt {
-		coreModes++
-	}
-	if auth.ClientsOnly {
-		coreModes++
-	}
-	if coreModes > 1 {
-		return true
-	}
-	return auth.ServiceOwned && (auth.Public || auth.Bootstrap || auth.ClientsOnly)
+	return !metadata.AuthComboLegal(auth)
 }
 
 // validateFMT30 enforces that every assembly's build.deployTemplate is one of

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -358,6 +358,68 @@ func fmt27ProjectWithAuth(auth metadata.HTTPAuthMeta) *metadata.ProjectMeta {
 	}
 }
 
+// TestFMT27ErrorDiagnostics locks the FMT-27 message format so contract
+// authors get actionable diagnostics: the message must (1) name every auth
+// field currently set to true, (2) signal the conflict ("incompatible"),
+// and (3) carry the fix hint ("Set at most one"). Without these assertions
+// the message text could regress silently.
+//
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
+func TestFMT27ErrorDiagnostics(t *testing.T) {
+	cases := []struct {
+		name     string
+		auth     metadata.HTTPAuthMeta
+		mustName []string
+	}{
+		{
+			name:     "public+bootstrap",
+			auth:     metadata.HTTPAuthMeta{Public: true, Bootstrap: true},
+			mustName: []string{"auth.public", "auth.bootstrap"},
+		},
+		{
+			name:     "clientsOnly+serviceOwned",
+			auth:     metadata.HTTPAuthMeta{ClientsOnly: true, ServiceOwned: true},
+			mustName: []string{"auth.serviceOwned", "auth.clientsOnly"},
+		},
+		{
+			name: "all four core modes",
+			auth: metadata.HTTPAuthMeta{
+				Public:              true,
+				PasswordResetExempt: true,
+				Bootstrap:           true,
+				ClientsOnly:         true,
+			},
+			mustName: []string{"auth.public", "auth.passwordResetExempt", "auth.bootstrap", "auth.clientsOnly"},
+		},
+		{
+			name:     "serviceOwned+bootstrap",
+			auth:     metadata.HTTPAuthMeta{ServiceOwned: true, Bootstrap: true},
+			mustName: []string{"auth.serviceOwned", "auth.bootstrap"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewValidator(fmt27ProjectWithAuth(tc.auth), "", clock.Real())
+			matches := findByCode(v.validateFMT27(), codeFMT27)
+			if len(matches) != 1 {
+				t.Fatalf("FMT-27: expected exactly 1 violation, got %d: %v", len(matches), matches)
+			}
+			msg := matches[0].Message
+			for _, field := range tc.mustName {
+				if !strings.Contains(msg, field) {
+					t.Errorf("FMT-27 diagnostic missing %q in message: %s", field, msg)
+				}
+			}
+			if !strings.Contains(msg, "incompatible") {
+				t.Errorf("FMT-27 diagnostic missing 'incompatible' keyword in message: %s", msg)
+			}
+			if !strings.Contains(msg, "Set at most one") {
+				t.Errorf("FMT-27 diagnostic missing 'Set at most one' fix hint in message: %s", msg)
+			}
+		})
+	}
+}
+
 // TestFMT27AuthBoolMatrix enumerates all 32 combinations of the 5 auth bool
 // fields and asserts validateFMT27's behavior against metadata.LegalAuthComboNames
 // — the hand-maintained whitelist that is independent of AuthComboLegal. Using

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -489,6 +489,28 @@ func fmt27ProjectWithAuth(auth metadata.HTTPAuthMeta) *metadata.ProjectMeta {
 	}
 }
 
+// TestFMT27AuthBoolMatrix enumerates all 32 combinations of the 5 auth bool
+// fields and asserts that validateFMT27 returns an error iff
+// metadata.AuthComboLegal returns false. Governance-side mirror of
+// TestContractSchemaAuthBoolMatrix; both layers share the AuthComboLegal oracle.
+//
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01
+func TestFMT27AuthBoolMatrix(t *testing.T) {
+	metadata.IterateAuthBoolCombos(func(auth metadata.HTTPAuthMeta, name string) {
+		t.Run(name, func(t *testing.T) {
+			v := NewValidator(fmt27ProjectWithAuth(auth), "", clock.Real())
+			matches := findByCode(v.validateFMT27(), codeFMT27)
+			expectedLegal := metadata.AuthComboLegal(auth)
+			if expectedLegal && len(matches) != 0 {
+				t.Errorf("FMT-27 rejected legal combo %s: %v", name, matches)
+			}
+			if !expectedLegal && len(matches) == 0 {
+				t.Errorf("FMT-27 accepted illegal combo %s; expected reject per AuthComboLegal", name)
+			}
+		})
+	})
+}
+
 // --- FMT-28 (HTTP auth mode placement/shape constraints) ---
 
 // TestFMT28_BootstrapOnNonSetupAdminPath verifies that auth.bootstrap:true on a

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -322,143 +322,12 @@ func TestFMT13_HTTPContractWithEndpoints(t *testing.T) {
 	}
 }
 
-// --- FMT-27 (auth.public/bootstrap/passwordResetExempt three-way mutually exclusive) ---
-// These tests are RED until validateFMT27 is implemented in Batch 1 / Agent-B.
-
-// TestFMT27_PublicAndBootstrapBothTrue verifies that a contract declaring both
-// auth.public:true and auth.bootstrap:true is rejected by FMT-27.
-// RED: validateFMT27 does not yet exist.
-func TestFMT27_PublicAndBootstrapBothTrue(t *testing.T) {
-	project := &metadata.ProjectMeta{
-		Cells:  map[string]*metadata.CellMeta{},
-		Slices: map[string]*metadata.SliceMeta{},
-		Contracts: map[string]*metadata.ContractMeta{
-			"http.auth.setup.admin.v1": {
-				ID:               "http.auth.setup.admin.v1",
-				Kind:             "http",
-				ConsistencyLevel: "L1",
-				Lifecycle:        "active",
-				Endpoints: metadata.EndpointsMeta{
-					Server:  "accesscore",
-					Clients: []string{"edge-bff"},
-					HTTP: &metadata.HTTPTransportMeta{
-						Method:        "POST",
-						Path:          "/api/v1/access/setup/admin",
-						SuccessStatus: 201,
-						Auth: metadata.HTTPAuthMeta{
-							Public:    true,
-							Bootstrap: true,
-						},
-					},
-				},
-				Dir:  "contracts/http/auth/setup/admin/v1",
-				File: "contracts/http/auth/setup/admin/v1/contract.yaml",
-			},
-		},
-		Journeys:   map[string]*metadata.JourneyMeta{},
-		Assemblies: map[string]*metadata.AssemblyMeta{},
-	}
-
-	v := NewValidator(project, "", clock.Real())
-
-	// validateFMT27 does not exist yet — RED: calling a method that panics
-	// or returns no results.
-	results := v.validateFMT27()
-
-	var fmt27Errors []ValidationResult
-	for _, r := range results {
-		if r.Code == "FMT-27" && r.Severity == SeverityError {
-			fmt27Errors = append(fmt27Errors, r)
-		}
-	}
-
-	if len(fmt27Errors) == 0 {
-		t.Fatal("FMT-27: expected error when both auth.public and auth.bootstrap are true, got none — " +
-			"validateFMT27 not yet implemented (Batch 1 Agent-B)")
-	}
-}
-
-// TestFMT27_BootstrapAndPasswordResetExemptBothTrue verifies that
-// auth.bootstrap:true + auth.passwordResetExempt:true is rejected by FMT-27.
-// RED: validateFMT27 does not yet exist.
-func TestFMT27_BootstrapAndPasswordResetExemptBothTrue(t *testing.T) {
-	project := &metadata.ProjectMeta{
-		Cells:  map[string]*metadata.CellMeta{},
-		Slices: map[string]*metadata.SliceMeta{},
-		Contracts: map[string]*metadata.ContractMeta{
-			"http.auth.bad.v1": {
-				ID:               "http.auth.bad.v1",
-				Kind:             "http",
-				ConsistencyLevel: "L1",
-				Lifecycle:        "active",
-				Endpoints: metadata.EndpointsMeta{
-					Server:  "accesscore",
-					Clients: []string{"edge-bff"},
-					HTTP: &metadata.HTTPTransportMeta{
-						Method:        "POST",
-						Path:          "/api/v1/access/setup/admin",
-						SuccessStatus: 201,
-						Auth: metadata.HTTPAuthMeta{
-							Bootstrap:           true,
-							PasswordResetExempt: true,
-						},
-					},
-				},
-				Dir:  "contracts/http/auth/bad/v1",
-				File: "contracts/http/auth/bad/v1/contract.yaml",
-			},
-		},
-		Journeys:   map[string]*metadata.JourneyMeta{},
-		Assemblies: map[string]*metadata.AssemblyMeta{},
-	}
-
-	v := NewValidator(project, "", clock.Real())
-	results := v.validateFMT27()
-
-	var fmt27Errors []ValidationResult
-	for _, r := range results {
-		if r.Code == "FMT-27" && r.Severity == SeverityError {
-			fmt27Errors = append(fmt27Errors, r)
-		}
-	}
-
-	if len(fmt27Errors) == 0 {
-		t.Fatal("FMT-27: expected error when both auth.bootstrap and auth.passwordResetExempt are true, got none — " +
-			"validateFMT27 not yet implemented (Batch 1 Agent-B)")
-	}
-}
-
-func TestFMT27_ClientsOnlyWithExclusiveAuthModes(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		auth metadata.HTTPAuthMeta
-	}{
-		{name: "public", auth: metadata.HTTPAuthMeta{ClientsOnly: true, Public: true}},
-		{name: "bootstrap", auth: metadata.HTTPAuthMeta{ClientsOnly: true, Bootstrap: true}},
-		{name: "passwordResetExempt", auth: metadata.HTTPAuthMeta{ClientsOnly: true, PasswordResetExempt: true}},
-		{name: "serviceOwned", auth: metadata.HTTPAuthMeta{ClientsOnly: true, ServiceOwned: true}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			v := NewValidator(fmt27ProjectWithAuth(tc.auth), "", clock.Real())
-			matches := findByCode(v.validateFMT27(), codeFMT27)
-			if len(matches) == 0 {
-				t.Fatalf("FMT-27: expected error for clientsOnly combined with %s, got none", tc.name)
-			}
-		})
-	}
-}
-
-func TestFMT27_ServiceOwnedAllowsPasswordResetExempt(t *testing.T) {
-	v := NewValidator(fmt27ProjectWithAuth(metadata.HTTPAuthMeta{
-		ServiceOwned:        true,
-		PasswordResetExempt: true,
-	}), "", clock.Real())
-
-	matches := findByCode(v.validateFMT27(), codeFMT27)
-	if len(matches) != 0 {
-		t.Fatalf("FMT-27: serviceOwned + passwordResetExempt must be allowed, got: %v", matches)
-	}
-}
+// --- FMT-27 (HTTP auth bool mutex) ---
+// All per-pair / per-bool subtests are subsumed by TestFMT27AuthBoolMatrix
+// (32-combo matrix sharing metadata.AuthComboLegal as oracle, defined below
+// alongside the fmt27ProjectWithAuth fixture). The matrix is the sole entry
+// point; happy-path documentation lives in contract_schema_test.go where
+// full contract YAML samples drive the schema layer.
 
 func fmt27ProjectWithAuth(auth metadata.HTTPAuthMeta) *metadata.ProjectMeta {
 	return &metadata.ProjectMeta{
@@ -494,7 +363,7 @@ func fmt27ProjectWithAuth(auth metadata.HTTPAuthMeta) *metadata.ProjectMeta {
 // metadata.AuthComboLegal returns false. Governance-side mirror of
 // TestContractSchemaAuthBoolMatrix; both layers share the AuthComboLegal oracle.
 //
-// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
 func TestFMT27AuthBoolMatrix(t *testing.T) {
 	metadata.IterateAuthBoolCombos(func(auth metadata.HTTPAuthMeta, name string) {
 		t.Run(name, func(t *testing.T) {

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -401,22 +401,31 @@ func TestFMT27ErrorDiagnostics(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			v := NewValidator(fmt27ProjectWithAuth(tc.auth), "", clock.Real())
 			matches := findByCode(v.validateFMT27(), codeFMT27)
-			if len(matches) != 1 {
-				t.Fatalf("FMT-27: expected exactly 1 violation, got %d: %v", len(matches), matches)
-			}
-			msg := matches[0].Message
-			for _, field := range tc.mustName {
-				if !strings.Contains(msg, field) {
-					t.Errorf("FMT-27 diagnostic missing %q in message: %s", field, msg)
-				}
-			}
-			if !strings.Contains(msg, "incompatible") {
-				t.Errorf("FMT-27 diagnostic missing 'incompatible' keyword in message: %s", msg)
-			}
-			if !strings.Contains(msg, "Set at most one") {
-				t.Errorf("FMT-27 diagnostic missing 'Set at most one' fix hint in message: %s", msg)
-			}
+			assertFMT27Diagnostic(t, matches, tc.mustName)
 		})
+	}
+}
+
+// assertFMT27Diagnostic asserts that a single FMT-27 violation was produced
+// and that its message names every field in mustName plus the conflict
+// keyword and fix hint. Extracted from TestFMT27ErrorDiagnostics to keep the
+// table-driven loop body within cognitive-complexity bounds.
+func assertFMT27Diagnostic(t *testing.T, matches []ValidationResult, mustName []string) {
+	t.Helper()
+	if len(matches) != 1 {
+		t.Fatalf("FMT-27: expected exactly 1 violation, got %d: %v", len(matches), matches)
+	}
+	msg := matches[0].Message
+	for _, field := range mustName {
+		if !strings.Contains(msg, field) {
+			t.Errorf("FMT-27 diagnostic missing %q in message: %s", field, msg)
+		}
+	}
+	if !strings.Contains(msg, "incompatible") {
+		t.Errorf("FMT-27 diagnostic missing 'incompatible' keyword in message: %s", msg)
+	}
+	if !strings.Contains(msg, "Set at most one") {
+		t.Errorf("FMT-27 diagnostic missing 'Set at most one' fix hint in message: %s", msg)
 	}
 }
 

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -359,9 +359,11 @@ func fmt27ProjectWithAuth(auth metadata.HTTPAuthMeta) *metadata.ProjectMeta {
 }
 
 // TestFMT27AuthBoolMatrix enumerates all 32 combinations of the 5 auth bool
-// fields and asserts that validateFMT27 returns an error iff
-// metadata.AuthComboLegal returns false. Governance-side mirror of
-// TestContractSchemaAuthBoolMatrix; both layers share the AuthComboLegal oracle.
+// fields and asserts validateFMT27's behavior against metadata.LegalAuthComboNames
+// — the hand-maintained whitelist that is independent of AuthComboLegal. Using
+// the whitelist (rather than AuthComboLegal) ensures this test detects
+// divergence in the governance delegation chain rather than merely confirming
+// that governance and oracle move in lock-step.
 //
 // INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
 func TestFMT27AuthBoolMatrix(t *testing.T) {
@@ -369,12 +371,12 @@ func TestFMT27AuthBoolMatrix(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			v := NewValidator(fmt27ProjectWithAuth(auth), "", clock.Real())
 			matches := findByCode(v.validateFMT27(), codeFMT27)
-			expectedLegal := metadata.AuthComboLegal(auth)
+			_, expectedLegal := metadata.LegalAuthComboNames[name]
 			if expectedLegal && len(matches) != 0 {
 				t.Errorf("FMT-27 rejected legal combo %s: %v", name, matches)
 			}
 			if !expectedLegal && len(matches) == 0 {
-				t.Errorf("FMT-27 accepted illegal combo %s; expected reject per AuthComboLegal", name)
+				t.Errorf("FMT-27 accepted illegal combo %s; expected reject per LegalAuthComboNames", name)
 			}
 		})
 	})

--- a/kernel/metadata/auth_combo.go
+++ b/kernel/metadata/auth_combo.go
@@ -1,0 +1,83 @@
+package metadata
+
+// AuthComboLegal returns true iff the bool combination on auth is permitted by
+// FMT-27 semantics. This function is the single source of truth shared by:
+//
+//   - kernel/metadata/schemas/contract.schema.json (compile-time schema validation
+//     via if/then const:true rules — see TestContractSchemaAuthBoolMatrix)
+//   - kernel/governance/rules_fmt.go validateFMT27 (runtime governance check —
+//     hasFMT27AuthModeConflict delegates to !AuthComboLegal)
+//   - kernel/metadata/auth_combo_test.go (oracle whitelist test)
+//
+// Rules:
+//   - Core modes {Public, Bootstrap, PasswordResetExempt, ClientsOnly}: at most
+//     one may be true.
+//   - ServiceOwned: may combine with PasswordResetExempt; mutually exclusive
+//     with Public, Bootstrap, and ClientsOnly.
+//
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01
+// ref: kubernetes/kubernetes pkg/securitycontext/util.go (capability mode mutex)
+func AuthComboLegal(auth HTTPAuthMeta) bool {
+	coreModes := 0
+	if auth.Public {
+		coreModes++
+	}
+	if auth.Bootstrap {
+		coreModes++
+	}
+	if auth.PasswordResetExempt {
+		coreModes++
+	}
+	if auth.ClientsOnly {
+		coreModes++
+	}
+	if coreModes > 1 {
+		return false
+	}
+	if auth.ServiceOwned && (auth.Public || auth.Bootstrap || auth.ClientsOnly) {
+		return false
+	}
+	return true
+}
+
+// IterateAuthBoolCombos enumerates all 32 (= 2^5) combinations of the 5 auth
+// bool fields. Field literal is intentionally explicit — adding a new bool
+// field to HTTPAuthMeta requires updating this helper (compile error surfaces
+// the omission), then the matrix space doubles naturally and matrix tests
+// surface unhandled cases.
+//
+// name encodes each field as one character: uppercase = true, lowercase = false.
+// Order P-R-S-B-C: Public / passwordResetExempt (R) / ServiceOwned / Bootstrap /
+// ClientsOnly. Example: "P-r-s-b-c" = Public:true, all others false.
+func IterateAuthBoolCombos(fn func(auth HTTPAuthMeta, name string)) {
+	for bits := 0; bits < 32; bits++ {
+		auth := HTTPAuthMeta{
+			Public:              bits&0x01 != 0,
+			PasswordResetExempt: bits&0x02 != 0,
+			ServiceOwned:        bits&0x04 != 0,
+			Bootstrap:           bits&0x08 != 0,
+			ClientsOnly:         bits&0x10 != 0,
+		}
+		fn(auth, encodeAuthCombo(auth))
+	}
+}
+
+func encodeAuthCombo(auth HTTPAuthMeta) string {
+	letter := func(field bool, upper, lower byte) byte {
+		if field {
+			return upper
+		}
+		return lower
+	}
+	return string([]byte{
+		letter(auth.Public, 'P', 'p'),
+		'-',
+		letter(auth.PasswordResetExempt, 'R', 'r'),
+		'-',
+		letter(auth.ServiceOwned, 'S', 's'),
+		'-',
+		letter(auth.Bootstrap, 'B', 'b'),
+		'-',
+		letter(auth.ClientsOnly, 'C', 'c'),
+	})
+}

--- a/kernel/metadata/auth_combo.go
+++ b/kernel/metadata/auth_combo.go
@@ -13,6 +13,41 @@ const HTTPAuthMetaBoolFields = 5
 // (2 ** HTTPAuthMetaBoolFields). Tests iterate from 0 to this value.
 const AuthComboMatrixSize = 1 << HTTPAuthMetaBoolFields
 
+// LegalAuthComboNames is the hand-maintained extensional statement of FMT-27
+// auth bool mutex semantics (encoded by encodeAuthCombo). AuthComboLegal is
+// the algorithmic (intensional) statement; the two must agree on all 32 combos
+// — TestAuthComboLegal_AgainstWhitelist enforces parity between them.
+//
+// Matrix tests at the schema and governance layers consume this whitelist
+// (rather than calling AuthComboLegal) so they detect implementation
+// divergence instead of colluding with the oracle. Single-source by design,
+// dual-form by intent: the algorithm runs in production, the whitelist
+// audits the algorithm.
+//
+// 7 legal combinations (out of 32):
+//
+//	"p-r-s-b-c"  default authenticated route (all flags off)
+//	"P-r-s-b-c"  public only
+//	"p-R-s-b-c"  passwordResetExempt only
+//	"p-r-S-b-c"  serviceOwned only
+//	"p-r-s-B-c"  bootstrap only
+//	"p-r-s-b-C"  clientsOnly only
+//	"p-R-S-b-c"  serviceOwned + passwordResetExempt
+//
+// When a rule evolves (e.g. allowing a new pair to coexist), update both this
+// whitelist AND AuthComboLegal in the same change; CI fails otherwise.
+//
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
+var LegalAuthComboNames = map[string]struct{}{
+	"p-r-s-b-c": {},
+	"P-r-s-b-c": {},
+	"p-R-s-b-c": {},
+	"p-r-S-b-c": {},
+	"p-r-s-B-c": {},
+	"p-r-s-b-C": {},
+	"p-R-S-b-c": {},
+}
+
 // AuthComboLegal returns true iff the bool combination on auth is permitted by
 // FMT-27 semantics. This function is the single source of truth shared by:
 //

--- a/kernel/metadata/auth_combo.go
+++ b/kernel/metadata/auth_combo.go
@@ -1,5 +1,18 @@
 package metadata
 
+// HTTPAuthMetaBoolFields is the count of bool fields on HTTPAuthMeta. It is the
+// authoritative source of the matrix size used by IterateAuthBoolCombos
+// (1 << HTTPAuthMetaBoolFields = 32 currently). TestHTTPAuthMetaFieldCount in
+// auth_combo_test.go reflects on HTTPAuthMeta and fails CI when the actual
+// bool field count drifts from this constant — adding a 6th bool field forces
+// every consumer (IterateAuthBoolCombos, AuthComboLegal, the whitelist in
+// TestAuthComboLegal_AgainstWhitelist) to be updated together.
+const HTTPAuthMetaBoolFields = 5
+
+// AuthComboMatrixSize is the size of the auth bool combination space
+// (2 ** HTTPAuthMetaBoolFields). Tests iterate from 0 to this value.
+const AuthComboMatrixSize = 1 << HTTPAuthMetaBoolFields
+
 // AuthComboLegal returns true iff the bool combination on auth is permitted by
 // FMT-27 semantics. This function is the single source of truth shared by:
 //
@@ -10,7 +23,7 @@ package metadata
 //   - kernel/metadata/auth_combo_test.go (oracle whitelist test)
 //
 // Rules:
-//   - Core modes {Public, Bootstrap, PasswordResetExempt, ClientsOnly}: at most
+//   - Core modes {Public, PasswordResetExempt, Bootstrap, ClientsOnly}: at most
 //     one may be true.
 //   - ServiceOwned: may combine with PasswordResetExempt; mutually exclusive
 //     with Public, Bootstrap, and ClientsOnly.
@@ -40,17 +53,23 @@ func AuthComboLegal(auth HTTPAuthMeta) bool {
 	return true
 }
 
-// IterateAuthBoolCombos enumerates all 32 (= 2^5) combinations of the 5 auth
-// bool fields. Field literal is intentionally explicit — adding a new bool
-// field to HTTPAuthMeta requires updating this helper (compile error surfaces
-// the omission), then the matrix space doubles naturally and matrix tests
-// surface unhandled cases.
+// IterateAuthBoolCombos enumerates all 2 ** HTTPAuthMetaBoolFields (= 32 today)
+// combinations of HTTPAuthMeta's bool fields. Named-field struct literals are
+// used here for readability — Go does NOT report a compile error when a new
+// field is added to HTTPAuthMeta, so the safety net is a separate reflect-based
+// guard: TestHTTPAuthMetaFieldCount in auth_combo_test.go fails CI if the bool
+// field count drifts from HTTPAuthMetaBoolFields, forcing this helper, the
+// matrix size constant, AuthComboLegal, and the test whitelist to be updated
+// together.
+//
+// HTTPAuthMeta.Responses ([]int) is intentionally excluded: it is not a
+// mutex-governed flag and does not participate in FMT-27 semantics.
 //
 // name encodes each field as one character: uppercase = true, lowercase = false.
-// Order P-R-S-B-C: Public / passwordResetExempt (R) / ServiceOwned / Bootstrap /
+// Order P-R-S-B-C: Public / PasswordResetExempt (R) / ServiceOwned / Bootstrap /
 // ClientsOnly. Example: "P-r-s-b-c" = Public:true, all others false.
 func IterateAuthBoolCombos(fn func(auth HTTPAuthMeta, name string)) {
-	for bits := 0; bits < 32; bits++ {
+	for bits := 0; bits < AuthComboMatrixSize; bits++ {
 		auth := HTTPAuthMeta{
 			Public:              bits&0x01 != 0,
 			PasswordResetExempt: bits&0x02 != 0,

--- a/kernel/metadata/auth_combo_test.go
+++ b/kernel/metadata/auth_combo_test.go
@@ -1,6 +1,55 @@
 package metadata
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+// httpAuthMetaTotalFields is the expected total field count on HTTPAuthMeta:
+// 5 bool (Public/PasswordResetExempt/ServiceOwned/Bootstrap/ClientsOnly) +
+// 1 []int (Responses) = 6. Increment together with HTTPAuthMetaBoolFields when
+// adding new fields and update IterateAuthBoolCombos / AuthComboLegal / the
+// legalNames whitelist below in the same change.
+const httpAuthMetaTotalFields = 6
+
+// TestHTTPAuthMetaFieldCount is the static safeguard for IterateAuthBoolCombos.
+// Go's named-field struct literals do not produce a compile error when fields
+// are added to a struct, so this reflect-based assertion is the only signal
+// catching a developer who adds a 6th auth bool but forgets to update
+// IterateAuthBoolCombos / AuthComboLegal / HTTPAuthMetaBoolFields.
+//
+// When this test fails, the typical fix is:
+//  1. include the new field in IterateAuthBoolCombos's struct literal,
+//  2. bump HTTPAuthMetaBoolFields and httpAuthMetaTotalFields,
+//  3. extend AuthComboLegal's rule chain,
+//  4. extend the legalNames whitelist in TestAuthComboLegal_AgainstWhitelist
+//     (the matrix space doubles automatically via AuthComboMatrixSize).
+//
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
+func TestHTTPAuthMetaFieldCount(t *testing.T) {
+	typ := reflect.TypeOf(HTTPAuthMeta{})
+
+	gotTotal := typ.NumField()
+	if gotTotal != httpAuthMetaTotalFields {
+		t.Fatalf("HTTPAuthMeta has %d fields, want %d — a field was added or "+
+			"removed; update IterateAuthBoolCombos, AuthComboLegal, "+
+			"HTTPAuthMetaBoolFields, and the legalNames whitelist in lockstep",
+			gotTotal, httpAuthMetaTotalFields)
+	}
+
+	gotBool := 0
+	for i := 0; i < gotTotal; i++ {
+		if typ.Field(i).Type.Kind() == reflect.Bool {
+			gotBool++
+		}
+	}
+	if gotBool != HTTPAuthMetaBoolFields {
+		t.Fatalf("HTTPAuthMeta has %d bool fields, want HTTPAuthMetaBoolFields=%d "+
+			"— matrix size mismatch; update IterateAuthBoolCombos and "+
+			"HTTPAuthMetaBoolFields together (the matrix space is 2^N)",
+			gotBool, HTTPAuthMetaBoolFields)
+	}
+}
 
 // TestAuthComboLegal_AgainstWhitelist enumerates all 32 combinations of the
 // 5 auth bool fields and asserts each matches the explicit hand-maintained
@@ -44,10 +93,11 @@ func TestAuthComboLegal_AgainstWhitelist(t *testing.T) {
 			}
 		})
 	})
-	if count != 32 {
-		t.Errorf("IterateAuthBoolCombos enumerated %d combinations, want 32 — "+
+	if count != AuthComboMatrixSize {
+		t.Errorf("IterateAuthBoolCombos enumerated %d combinations, want %d — "+
 			"a bool field may have been added without doubling the matrix; "+
-			"update the whitelist in this test alongside the helper", count)
+			"update the whitelist in this test alongside the helper",
+			count, AuthComboMatrixSize)
 	}
 }
 

--- a/kernel/metadata/auth_combo_test.go
+++ b/kernel/metadata/auth_combo_test.go
@@ -20,7 +20,7 @@ import "testing"
 //
 // All other 25 combinations must be rejected.
 //
-// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
 func TestAuthComboLegal_AgainstWhitelist(t *testing.T) {
 	legalNames := map[string]struct{}{
 		"p-r-s-b-c": {},

--- a/kernel/metadata/auth_combo_test.go
+++ b/kernel/metadata/auth_combo_test.go
@@ -51,41 +51,18 @@ func TestHTTPAuthMetaFieldCount(t *testing.T) {
 	}
 }
 
-// TestAuthComboLegal_AgainstWhitelist enumerates all 32 combinations of the
-// 5 auth bool fields and asserts each matches the explicit hand-maintained
-// whitelist of legal combinations. The whitelist serves as an independent
-// oracle: if AuthComboLegal regresses, divergence surfaces here. If the rules
-// change, both AuthComboLegal and this whitelist must be updated together.
-//
-// Legal combinations (7 of 32):
-//
-//	"p-r-s-b-c"  default authenticated route (all fields false / omitted)
-//	"P-r-s-b-c"  public only
-//	"p-R-s-b-c"  passwordResetExempt only
-//	"p-r-S-b-c"  serviceOwned only
-//	"p-r-s-B-c"  bootstrap only
-//	"p-r-s-b-C"  clientsOnly only
-//	"p-R-S-b-c"  serviceOwned + passwordResetExempt
-//
-// All other 25 combinations must be rejected.
+// TestAuthComboLegal_AgainstWhitelist enforces parity between AuthComboLegal
+// (algorithmic / intensional rule) and LegalAuthComboNames (hand-maintained /
+// extensional rule). The whitelist serves as an independent oracle — if either
+// statement regresses without the other, this test reports the divergence.
 //
 // INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
 func TestAuthComboLegal_AgainstWhitelist(t *testing.T) {
-	legalNames := map[string]struct{}{
-		"p-r-s-b-c": {},
-		"P-r-s-b-c": {},
-		"p-R-s-b-c": {},
-		"p-r-S-b-c": {},
-		"p-r-s-B-c": {},
-		"p-r-s-b-C": {},
-		"p-R-S-b-c": {},
-	}
-
 	count := 0
 	IterateAuthBoolCombos(func(auth HTTPAuthMeta, name string) {
 		count++
 		t.Run(name, func(t *testing.T) {
-			_, expectedLegal := legalNames[name]
+			_, expectedLegal := LegalAuthComboNames[name]
 			actual := AuthComboLegal(auth)
 			if actual != expectedLegal {
 				t.Errorf("AuthComboLegal(%+v) = %v, want %v",
@@ -96,7 +73,7 @@ func TestAuthComboLegal_AgainstWhitelist(t *testing.T) {
 	if count != AuthComboMatrixSize {
 		t.Errorf("IterateAuthBoolCombos enumerated %d combinations, want %d — "+
 			"a bool field may have been added without doubling the matrix; "+
-			"update the whitelist in this test alongside the helper",
+			"update LegalAuthComboNames alongside the helper",
 			count, AuthComboMatrixSize)
 	}
 }

--- a/kernel/metadata/auth_combo_test.go
+++ b/kernel/metadata/auth_combo_test.go
@@ -1,0 +1,66 @@
+package metadata
+
+import "testing"
+
+// TestAuthComboLegal_AgainstWhitelist enumerates all 32 combinations of the
+// 5 auth bool fields and asserts each matches the explicit hand-maintained
+// whitelist of legal combinations. The whitelist serves as an independent
+// oracle: if AuthComboLegal regresses, divergence surfaces here. If the rules
+// change, both AuthComboLegal and this whitelist must be updated together.
+//
+// Legal combinations (7 of 32):
+//
+//	"p-r-s-b-c"  default authenticated route (all fields false / omitted)
+//	"P-r-s-b-c"  public only
+//	"p-R-s-b-c"  passwordResetExempt only
+//	"p-r-S-b-c"  serviceOwned only
+//	"p-r-s-B-c"  bootstrap only
+//	"p-r-s-b-C"  clientsOnly only
+//	"p-R-S-b-c"  serviceOwned + passwordResetExempt
+//
+// All other 25 combinations must be rejected.
+//
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01
+func TestAuthComboLegal_AgainstWhitelist(t *testing.T) {
+	legalNames := map[string]struct{}{
+		"p-r-s-b-c": {},
+		"P-r-s-b-c": {},
+		"p-R-s-b-c": {},
+		"p-r-S-b-c": {},
+		"p-r-s-B-c": {},
+		"p-r-s-b-C": {},
+		"p-R-S-b-c": {},
+	}
+
+	count := 0
+	IterateAuthBoolCombos(func(auth HTTPAuthMeta, name string) {
+		count++
+		t.Run(name, func(t *testing.T) {
+			_, expectedLegal := legalNames[name]
+			actual := AuthComboLegal(auth)
+			if actual != expectedLegal {
+				t.Errorf("AuthComboLegal(%+v) = %v, want %v",
+					auth, actual, expectedLegal)
+			}
+		})
+	})
+	if count != 32 {
+		t.Errorf("IterateAuthBoolCombos enumerated %d combinations, want 32 — "+
+			"a bool field may have been added without doubling the matrix; "+
+			"update the whitelist in this test alongside the helper", count)
+	}
+}
+
+// TestIterateAuthBoolCombos_NamesUnique guards against bitmap encoding bugs by
+// asserting every emitted name is unique across the 32-iteration window.
+func TestIterateAuthBoolCombos_NamesUnique(t *testing.T) {
+	seen := make(map[string]int)
+	IterateAuthBoolCombos(func(_ HTTPAuthMeta, name string) {
+		seen[name]++
+	})
+	for name, n := range seen {
+		if n != 1 {
+			t.Errorf("name %q emitted %d times, want exactly 1", name, n)
+		}
+	}
+}

--- a/kernel/metadata/schema_types.go
+++ b/kernel/metadata/schema_types.go
@@ -27,15 +27,22 @@ type HTTPTransportMeta struct {
 // HTTPAuthMeta carries route-level authentication override flags for contractgen.
 // These map to generated auth.Route wiring and handler constructor shape.
 //
+// Mutex among the 5 bool fields is enforced by metadata.AuthComboLegal (the
+// single oracle shared by contract.schema.json if/then rules and governance
+// validateFMT27). When adding a new bool field, see auth_combo.go for the
+// checklist of files to update in lockstep.
+//
 // ref: kubernetes-sigs/controller-tools markers/registry.go (declarative auth metadata)
 type HTTPAuthMeta struct {
 	// Public marks the route as JWT-exempt. The generated NewHandler takes no
 	// policy argument; auth.Route{Public: true} is emitted by RegisterRoutes.
-	// Mutually exclusive with PasswordResetExempt and Bootstrap.
+	// Mutually exclusive with PasswordResetExempt, Bootstrap, ServiceOwned,
+	// and ClientsOnly.
 	Public bool `yaml:"public,omitempty" json:"public,omitempty"`
 	// PasswordResetExempt allows callers whose JWT carries password_reset_required=true
 	// to reach this route. The generated handler emits auth.Route{PasswordResetExempt: true}.
-	// Mutually exclusive with Public and Bootstrap.
+	// Mutually exclusive with Public, Bootstrap, and ClientsOnly. May combine
+	// with ServiceOwned.
 	PasswordResetExempt bool `yaml:"passwordResetExempt,omitempty" json:"passwordResetExempt,omitempty"`
 	// ServiceOwned indicates that the listener must still authenticate the caller,
 	// but route-level authorization is intentionally absent because the service
@@ -47,17 +54,19 @@ type HTTPAuthMeta struct {
 	// Bootstrap marks the route as protected by HTTP Basic Auth using
 	// GOCELL_BOOTSTRAP_ADMIN_USERNAME/PASSWORD env credentials. Listener-level
 	// JWT middleware skips routes flagged as Bootstrap (matcher in FinalizeAuth).
-	// Mutually exclusive with Public and PasswordResetExempt. FMT-28 limits this
-	// flag to contracts whose path matches IsBootstrapPath.
+	// Mutually exclusive with Public, PasswordResetExempt, ServiceOwned, and
+	// ClientsOnly. FMT-28 limits this flag to contracts whose path matches
+	// IsBootstrapPath.
 	Bootstrap bool `yaml:"bootstrap,omitempty" json:"bootstrap,omitempty"`
 	// ClientsOnly indicates that this endpoint relies solely on Contract.Clients
 	// caller-cell allowlist for authorization. When true, contractgen generates a
 	// single-arg NewHandler(svc Service) constructor and emits auth.Route without
 	// a Policy field. auth.Mount auto-injects RequireCallerCell guard when
-	// Clients is non-empty. Mutually exclusive with Public, Bootstrap, and
-	// PasswordResetExempt. Requires endpoints.clients to be non-empty and the
-	// path to match IsInternalHTTPPath (/internal/v1 or /internal/v1/...)
-	// where caller-cell identity is verifiable via the service token.
+	// Clients is non-empty. Mutually exclusive with Public, Bootstrap,
+	// PasswordResetExempt, and ServiceOwned. Requires endpoints.clients to be
+	// non-empty and the path to match IsInternalHTTPPath (/internal/v1 or
+	// /internal/v1/...) where caller-cell identity is verifiable via the
+	// service token.
 	ClientsOnly bool `yaml:"clientsOnly,omitempty" json:"clientsOnly,omitempty"`
 	// Responses lists HTTP status codes injected by listener-mounted middleware
 	// (e.g. bootstrap auth 401, rate limiter 429). CH-04 treats these as

--- a/kernel/metadata/schemas/contract.schema.json
+++ b/kernel/metadata/schemas/contract.schema.json
@@ -187,28 +187,33 @@
                   },
                   "auth": {
                     "type": "object",
-                    "description": "Route-level authentication overrides for contractgen. Omit for standard authenticated routes.",
+                    "description": "Route-level authentication overrides for contractgen. Omit for standard authenticated routes. Mutex enforced by value-true (if/then const:true) so explicit `false` is equivalent to omission and never triggers conflict — see metadata.AuthComboLegal for the single oracle.",
                     "additionalProperties": false,
                     "properties": {
                       "public": {
                         "type": "boolean",
-                        "description": "If true, route is mounted as public (no JWT required). auth.Route{Public: true} is emitted by RegisterRoutes. Mutually exclusive with passwordResetExempt and bootstrap."
+                        "default": false,
+                        "description": "If true, route is mounted as public (no JWT required). auth.Route{Public: true} is emitted by RegisterRoutes. Mutually exclusive with passwordResetExempt, bootstrap, serviceOwned, and clientsOnly."
                       },
-	                      "passwordResetExempt": {
-	                        "type": "boolean",
-	                        "description": "If true, route bypasses the force-password-reset gate. auth.Route{PasswordResetExempt: true} is emitted. Mutually exclusive with public and bootstrap."
-	                      },
-	                      "serviceOwned": {
-	                        "type": "boolean",
-	                        "description": "If true, listener JWT authentication still applies but generated handlers omit route-level Policy because ownership authorization is enforced inside the service. May be combined with passwordResetExempt. Mutually exclusive with public, bootstrap, and clientsOnly."
-	                      },
-	                      "bootstrap": {
+                      "passwordResetExempt": {
                         "type": "boolean",
-	                        "description": "If true, contractgen generates a NewHandler(bootstrapAuth func(http.Handler) http.Handler, ...) constructor and emits auth.Route{BootstrapAuth: bootstrapAuth} from RegisterRoutes; the listener-level JWT middleware skips this route. Composition root injects the bootstrap Basic Auth + per-IP rate-limit middleware (GOCELL_BOOTSTRAP_ADMIN_USERNAME/PASSWORD env credentials). Mutually exclusive with public and passwordResetExempt. FMT-28 limits bootstrap to setup/admin paths."
+                        "default": false,
+                        "description": "If true, route bypasses the force-password-reset gate. auth.Route{PasswordResetExempt: true} is emitted. Mutually exclusive with public, bootstrap, and clientsOnly. May combine with serviceOwned."
+                      },
+                      "serviceOwned": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "If true, listener JWT authentication still applies but generated handlers omit route-level Policy because ownership authorization is enforced inside the service. May be combined with passwordResetExempt. Mutually exclusive with public, bootstrap, and clientsOnly."
+                      },
+                      "bootstrap": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "If true, contractgen generates a NewHandler(bootstrapAuth func(http.Handler) http.Handler, ...) constructor and emits auth.Route{BootstrapAuth: bootstrapAuth} from RegisterRoutes; the listener-level JWT middleware skips this route. Composition root injects the bootstrap Basic Auth + per-IP rate-limit middleware (GOCELL_BOOTSTRAP_ADMIN_USERNAME/PASSWORD env credentials). Mutually exclusive with public, passwordResetExempt, serviceOwned, and clientsOnly. FMT-28 limits bootstrap to setup/admin paths."
                       },
                       "clientsOnly": {
                         "type": "boolean",
-	                        "description": "If true, contractgen generates a single-arg NewHandler(svc Service) constructor and emits auth.Route without a Policy field. Authorization is provided solely by Contract.Clients caller-cell allowlist (auth.Mount auto-injects RequireCallerCell guard when Clients is non-empty). Mutually exclusive with public, bootstrap, and passwordResetExempt. Requires endpoints.clients to be non-empty and path matching /internal/v1 or /internal/v1/...; FMT-28 enforces this cross-field shape."
+                        "default": false,
+                        "description": "If true, contractgen generates a single-arg NewHandler(svc Service) constructor and emits auth.Route without a Policy field. Authorization is provided solely by Contract.Clients caller-cell allowlist (auth.Mount auto-injects RequireCallerCell guard when Clients is non-empty). Mutually exclusive with public, bootstrap, passwordResetExempt, and serviceOwned. Requires endpoints.clients to be non-empty and path matching /internal/v1 or /internal/v1/...; FMT-28 enforces this cross-field shape."
                       },
                       "responses": {
                         "type": "array",
@@ -222,16 +227,65 @@
                       }
                     },
                     "allOf": [
-                      {"not": {"required": ["public", "bootstrap"]}, "description": "auth.public and auth.bootstrap are mutually exclusive."},
-                      {"not": {"required": ["public", "passwordResetExempt"]}, "description": "auth.public and auth.passwordResetExempt are mutually exclusive."},
-	                      {"not": {"required": ["bootstrap", "passwordResetExempt"]}, "description": "auth.bootstrap and auth.passwordResetExempt are mutually exclusive."},
-	                      {"not": {"required": ["clientsOnly", "public"]}, "description": "auth.clientsOnly and auth.public are mutually exclusive."},
-	                      {"not": {"required": ["clientsOnly", "bootstrap"]}, "description": "auth.clientsOnly and auth.bootstrap are mutually exclusive."},
-	                      {"not": {"required": ["clientsOnly", "passwordResetExempt"]}, "description": "auth.clientsOnly and auth.passwordResetExempt are mutually exclusive."},
-	                      {"not": {"required": ["serviceOwned", "public"]}, "description": "auth.serviceOwned and auth.public are mutually exclusive."},
-	                      {"not": {"required": ["serviceOwned", "bootstrap"]}, "description": "auth.serviceOwned and auth.bootstrap are mutually exclusive."},
-	                      {"not": {"required": ["serviceOwned", "clientsOnly"]}, "description": "auth.serviceOwned and auth.clientsOnly are mutually exclusive."}
-	                    ]
+                      {
+                        "description": "auth.public=true is mutually exclusive with bootstrap, passwordResetExempt, serviceOwned, clientsOnly (value-true semantics; explicit false is fine).",
+                        "if": {"properties": {"public": {"const": true}}, "required": ["public"]},
+                        "then": {
+                          "properties": {
+                            "bootstrap": {"not": {"const": true}},
+                            "passwordResetExempt": {"not": {"const": true}},
+                            "serviceOwned": {"not": {"const": true}},
+                            "clientsOnly": {"not": {"const": true}}
+                          }
+                        }
+                      },
+                      {
+                        "description": "auth.bootstrap=true is mutually exclusive with public, passwordResetExempt, serviceOwned, clientsOnly.",
+                        "if": {"properties": {"bootstrap": {"const": true}}, "required": ["bootstrap"]},
+                        "then": {
+                          "properties": {
+                            "public": {"not": {"const": true}},
+                            "passwordResetExempt": {"not": {"const": true}},
+                            "serviceOwned": {"not": {"const": true}},
+                            "clientsOnly": {"not": {"const": true}}
+                          }
+                        }
+                      },
+                      {
+                        "description": "auth.passwordResetExempt=true is mutually exclusive with public, bootstrap, clientsOnly. May combine with serviceOwned.",
+                        "if": {"properties": {"passwordResetExempt": {"const": true}}, "required": ["passwordResetExempt"]},
+                        "then": {
+                          "properties": {
+                            "public": {"not": {"const": true}},
+                            "bootstrap": {"not": {"const": true}},
+                            "clientsOnly": {"not": {"const": true}}
+                          }
+                        }
+                      },
+                      {
+                        "description": "auth.clientsOnly=true is mutually exclusive with public, bootstrap, passwordResetExempt, serviceOwned.",
+                        "if": {"properties": {"clientsOnly": {"const": true}}, "required": ["clientsOnly"]},
+                        "then": {
+                          "properties": {
+                            "public": {"not": {"const": true}},
+                            "bootstrap": {"not": {"const": true}},
+                            "passwordResetExempt": {"not": {"const": true}},
+                            "serviceOwned": {"not": {"const": true}}
+                          }
+                        }
+                      },
+                      {
+                        "description": "auth.serviceOwned=true is mutually exclusive with public, bootstrap, clientsOnly. May combine with passwordResetExempt.",
+                        "if": {"properties": {"serviceOwned": {"const": true}}, "required": ["serviceOwned"]},
+                        "then": {
+                          "properties": {
+                            "public": {"not": {"const": true}},
+                            "bootstrap": {"not": {"const": true}},
+                            "clientsOnly": {"not": {"const": true}}
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/kernel/metadata/schemas/contract_schema_test.go
+++ b/kernel/metadata/schemas/contract_schema_test.go
@@ -318,12 +318,12 @@ func TestContractSchemaAuthBoolMatrix(t *testing.T) {
 			require.NoError(t, json.Unmarshal([]byte(doc), &contractDoc))
 
 			err := schema.Validate(contractDoc)
-			expectedLegal := metadata.AuthComboLegal(auth)
+			_, expectedLegal := metadata.LegalAuthComboNames[name]
 			if expectedLegal && err != nil {
 				t.Errorf("schema rejected legal combo %s: %v", name, err)
 			}
 			if !expectedLegal && err == nil {
-				t.Errorf("schema accepted illegal combo %s; expected reject per AuthComboLegal", name)
+				t.Errorf("schema accepted illegal combo %s; expected reject per LegalAuthComboNames", name)
 			}
 		})
 	})

--- a/kernel/metadata/schemas/contract_schema_test.go
+++ b/kernel/metadata/schemas/contract_schema_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
 func TestContractSchemaAllowsParamConstraintFacets(t *testing.T) {
@@ -474,4 +476,59 @@ func TestContractSchemaRejectsAuthClientsOnlyAndPublicBoth(t *testing.T) {
 		schema.Validate(contractDoc),
 		"contract with both auth.clientsOnly:true and auth.public:true "+
 			"must fail schema validation (mutually exclusive)")
+}
+
+// TestContractSchemaAuthBoolMatrix enumerates all 32 combinations of the
+// 5 auth bool fields and asserts schema validation matches metadata.AuthComboLegal
+// (the single oracle shared with kernel/governance/rules_fmt.go validateFMT27).
+//
+// Every contract document explicitly declares every bool field (true or false)
+// to guard the "explicit false vs omission" semantic: under the original
+// not/required mutex implementation, declaring 5 keys would trigger the
+// key-presence rules and reject all 32 cases. Under the if/then const:true
+// implementation, only the value-true conflicts are rejected.
+//
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01
+func TestContractSchemaAuthBoolMatrix(t *testing.T) {
+	schema := compileContractSchemaForTest(t)
+
+	metadata.IterateAuthBoolCombos(func(auth metadata.HTTPAuthMeta, name string) {
+		t.Run(name, func(t *testing.T) {
+			doc := fmt.Sprintf(`{
+				"id": "http.matrix.test.v1",
+				"kind": "http",
+				"consistencyLevel": "L1",
+				"lifecycle": "active",
+				"endpoints": {
+					"server": "testcell",
+					"clients": ["testcell"],
+					"http": {
+						"method": "POST",
+						"path": "/internal/v1/matrix/test",
+						"successStatus": 200,
+						"noContent": false,
+						"auth": {
+							"public": %t,
+							"passwordResetExempt": %t,
+							"serviceOwned": %t,
+							"bootstrap": %t,
+							"clientsOnly": %t
+						}
+					}
+				}
+			}`, auth.Public, auth.PasswordResetExempt, auth.ServiceOwned, auth.Bootstrap, auth.ClientsOnly)
+
+			var contractDoc any
+			require.NoError(t, json.Unmarshal([]byte(doc), &contractDoc))
+
+			err := schema.Validate(contractDoc)
+			expectedLegal := metadata.AuthComboLegal(auth)
+			if expectedLegal && err != nil {
+				t.Errorf("schema rejected legal combo %s: %v", name, err)
+			}
+			if !expectedLegal && err == nil {
+				t.Errorf("schema accepted illegal combo %s; expected reject per AuthComboLegal", name)
+			}
+		})
+	})
 }

--- a/kernel/metadata/schemas/contract_schema_test.go
+++ b/kernel/metadata/schemas/contract_schema_test.go
@@ -145,47 +145,6 @@ func TestContractSchemaAllowsAuthPasswordResetExempt(t *testing.T) {
 	assert.NoError(t, schema.Validate(contractDoc), "contract with auth.passwordResetExempt:true must pass strict validation")
 }
 
-func TestContractSchemaRejectsAuthPublicAndPasswordResetExemptBoth(t *testing.T) {
-	raw, err := FS.ReadFile("contract.schema.json")
-	require.NoError(t, err)
-
-	var schemaDoc any
-	require.NoError(t, json.Unmarshal(raw, &schemaDoc))
-
-	compiler := jsonschema.NewCompiler()
-	const schemaURL = "https://gocell.dev/schemas/contract.schema.json"
-	require.NoError(t, compiler.AddResource(schemaURL, schemaDoc))
-	schema, err := compiler.Compile(schemaURL)
-	require.NoError(t, err)
-
-	var contractDoc any
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"id": "http.auth.bad.v1",
-		"kind": "http",
-		"consistencyLevel": "L1",
-		"lifecycle": "active",
-		"endpoints": {
-			"server": "accesscore",
-			"clients": [],
-			"http": {
-				"method": "POST",
-				"path": "/api/v1/auth/bad",
-				"successStatus": 200,
-				"noContent": false,
-				"auth": {
-					"public": true,
-					"passwordResetExempt": true
-				}
-			}
-		}
-	}`), &contractDoc))
-
-	assert.Error(t,
-		schema.Validate(contractDoc),
-		"contract with both auth.public:true and auth.passwordResetExempt:true "+
-			"must fail schema validation (mutually exclusive)")
-}
-
 func TestContractSchemaAllowsAuthServiceOwnedWithPasswordResetExempt(t *testing.T) {
 	schema := compileContractSchemaForTest(t)
 
@@ -219,46 +178,6 @@ func TestContractSchemaAllowsAuthServiceOwnedWithPasswordResetExempt(t *testing.
 
 	assert.NoError(t, schema.Validate(contractDoc),
 		"auth.serviceOwned:true must be allowed to combine with auth.passwordResetExempt:true")
-}
-
-func TestContractSchemaRejectsAuthServiceOwnedWithExclusiveModes(t *testing.T) {
-	schema := compileContractSchemaForTest(t)
-
-	for _, tc := range []struct {
-		name  string
-		field string
-	}{
-		{name: "public", field: "public"},
-		{name: "bootstrap", field: "bootstrap"},
-		{name: "clientsOnly", field: "clientsOnly"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			var contractDoc any
-			require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{
-				"id": "http.auth.bad.serviceowned.%s.v1",
-				"kind": "http",
-				"consistencyLevel": "L1",
-				"lifecycle": "active",
-				"endpoints": {
-					"server": "accesscore",
-					"clients": ["edge-bff"],
-					"http": {
-						"method": "POST",
-						"path": "/internal/v1/auth/bad/%s",
-						"successStatus": 200,
-						"noContent": false,
-						"auth": {
-							"serviceOwned": true,
-							"%s": true
-						}
-					}
-				}
-			}`, tc.name, tc.name, tc.field)), &contractDoc))
-
-			assert.Error(t, schema.Validate(contractDoc),
-				"auth.serviceOwned:true must be mutually exclusive with auth.%s:true", tc.field)
-		})
-	}
 }
 
 func TestContractSchemaAllowsAuthBootstrapWithResponses(t *testing.T) {
@@ -317,88 +236,6 @@ func compileContractSchemaForTest(t *testing.T) *jsonschema.Schema {
 	return schema
 }
 
-func TestContractSchemaRejectsAuthBootstrapAndPublicBoth(t *testing.T) {
-	raw, err := FS.ReadFile("contract.schema.json")
-	require.NoError(t, err)
-
-	var schemaDoc any
-	require.NoError(t, json.Unmarshal(raw, &schemaDoc))
-
-	compiler := jsonschema.NewCompiler()
-	const schemaURL = "https://gocell.dev/schemas/contract.schema.json"
-	require.NoError(t, compiler.AddResource(schemaURL, schemaDoc))
-	schema, err := compiler.Compile(schemaURL)
-	require.NoError(t, err)
-
-	var contractDoc any
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"id": "http.auth.bad2.v1",
-		"kind": "http",
-		"consistencyLevel": "L1",
-		"lifecycle": "active",
-		"endpoints": {
-			"server": "accesscore",
-			"clients": [],
-			"http": {
-				"method": "POST",
-				"path": "/api/v1/access/setup/admin",
-				"successStatus": 201,
-				"noContent": false,
-				"auth": {
-					"bootstrap": true,
-					"public": true
-				}
-			}
-		}
-	}`), &contractDoc))
-
-	assert.Error(t,
-		schema.Validate(contractDoc),
-		"contract with both auth.bootstrap:true and auth.public:true "+
-			"must fail schema validation (mutually exclusive)")
-}
-
-func TestContractSchemaRejectsAuthBootstrapAndPasswordResetExemptBoth(t *testing.T) {
-	raw, err := FS.ReadFile("contract.schema.json")
-	require.NoError(t, err)
-
-	var schemaDoc any
-	require.NoError(t, json.Unmarshal(raw, &schemaDoc))
-
-	compiler := jsonschema.NewCompiler()
-	const schemaURL = "https://gocell.dev/schemas/contract.schema.json"
-	require.NoError(t, compiler.AddResource(schemaURL, schemaDoc))
-	schema, err := compiler.Compile(schemaURL)
-	require.NoError(t, err)
-
-	var contractDoc any
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"id": "http.auth.bad3.v1",
-		"kind": "http",
-		"consistencyLevel": "L1",
-		"lifecycle": "active",
-		"endpoints": {
-			"server": "accesscore",
-			"clients": [],
-			"http": {
-				"method": "POST",
-				"path": "/api/v1/access/setup/admin",
-				"successStatus": 201,
-				"noContent": false,
-				"auth": {
-					"bootstrap": true,
-					"passwordResetExempt": true
-				}
-			}
-		}
-	}`), &contractDoc))
-
-	assert.Error(t,
-		schema.Validate(contractDoc),
-		"contract with both auth.bootstrap:true and auth.passwordResetExempt:true "+
-			"must fail schema validation (mutually exclusive)")
-}
-
 func TestContractSchemaAllowsAuthClientsOnly(t *testing.T) {
 	raw, err := FS.ReadFile("contract.schema.json")
 	require.NoError(t, err)
@@ -437,47 +274,6 @@ func TestContractSchemaAllowsAuthClientsOnly(t *testing.T) {
 		"contract with auth.clientsOnly:true must pass strict validation")
 }
 
-func TestContractSchemaRejectsAuthClientsOnlyAndPublicBoth(t *testing.T) {
-	raw, err := FS.ReadFile("contract.schema.json")
-	require.NoError(t, err)
-
-	var schemaDoc any
-	require.NoError(t, json.Unmarshal(raw, &schemaDoc))
-
-	compiler := jsonschema.NewCompiler()
-	const schemaURL = "https://gocell.dev/schemas/contract.schema.json"
-	require.NoError(t, compiler.AddResource(schemaURL, schemaDoc))
-	schema, err := compiler.Compile(schemaURL)
-	require.NoError(t, err)
-
-	var contractDoc any
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"id": "http.internal.bad4.v1",
-		"kind": "http",
-		"consistencyLevel": "L1",
-		"lifecycle": "active",
-		"endpoints": {
-			"server": "testcell",
-			"clients": ["testcell"],
-			"http": {
-				"method": "GET",
-				"path": "/internal/v1/bad4",
-				"successStatus": 200,
-				"noContent": false,
-				"auth": {
-					"clientsOnly": true,
-					"public": true
-				}
-			}
-		}
-	}`), &contractDoc))
-
-	assert.Error(t,
-		schema.Validate(contractDoc),
-		"contract with both auth.clientsOnly:true and auth.public:true "+
-			"must fail schema validation (mutually exclusive)")
-}
-
 // TestContractSchemaAuthBoolMatrix enumerates all 32 combinations of the
 // 5 auth bool fields and asserts schema validation matches metadata.AuthComboLegal
 // (the single oracle shared with kernel/governance/rules_fmt.go validateFMT27).
@@ -488,7 +284,7 @@ func TestContractSchemaRejectsAuthClientsOnlyAndPublicBoth(t *testing.T) {
 // key-presence rules and reject all 32 cases. Under the if/then const:true
 // implementation, only the value-true conflicts are rejected.
 //
-// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01
+// INVARIANT: AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01.
 func TestContractSchemaAuthBoolMatrix(t *testing.T) {
 	schema := compileContractSchemaForTest(t)
 


### PR DESCRIPTION
## Summary

PR-403 funnel 化路线图 §3 / §4.4 PR-C `AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01`。

引入 `metadata.AuthComboLegal` 作为 5 个 auth 布尔字段（public / passwordResetExempt / serviceOwned / bootstrap / clientsOnly）互斥语义的**单一真相源**，schema (if/then const:true) 与 governance (FMT-27 委托) 共享同一判定函数。新增 32 组合矩阵测试覆盖所有合法/非法布尔组合。

## 关键变更

### 1. 修复 schema not/required key-presence 缺陷（隐藏 bug）

调研发现 `contract.schema.json` L224-234 用 `{not:{required:[X,Y]}}` 实现互斥。按 JSON Schema 2020-12 规范这是 **"key 是否出现"** 语义，而 FMT-27 (`rules_fmt.go`) 用 Go bool **"value == true"** 语义。两层**已不一致**——schema 比 governance 严格：`auth: {public: false, bootstrap: true}` 当前会被 schema 拒绝（因两个 key 都出现）但被 governance 接受。

当前不暴露因为所有 contract.yaml 实际只写 "true 或省略"。32 组合矩阵首次显式声明所有 5 个布尔字段，立即暴露此缺陷。修复方案：改为 5 条 `if/then const:true` 按 value 拦截，与 Go bool 语义对齐。

### 2. 抽离 `metadata.AuthComboLegal` oracle

`hasFMT27AuthModeConflict` 简化为 `return !metadata.AuthComboLegal(auth)`。schema/governance/test 三处单源。未来加新 auth 布尔字段只需更新 `AuthComboLegal` + `IterateAuthBoolCombos`，FMT-27 自动获得新语义。

### 3. 32 组合矩阵覆盖

`IterateAuthBoolCombos` 用手写位图 helper 显式列出 5 字段（加新字段编译报错强迫更新）。三个矩阵测试共享 oracle：
- `TestAuthComboLegal_AgainstWhitelist` — oracle vs hand-maintained whitelist（独立第二判定）
- `TestContractSchemaAuthBoolMatrix` — schema vs oracle
- `TestFMT27AuthBoolMatrix` — governance vs oracle

每个矩阵测试都显式声明 5 个 bool 字段（true/false 都写），守 \"显式 false ≡ 省略\" 语义。

### 4. 测试瘦身

被矩阵完全覆盖的 9 个 hand-picked subtest 删除（5 个 schema Reject + 4 个 governance per-bool）。保留 5 个 schema Allows happy-path（带完整 contract YAML 上下文 path/method/clients/responses/pathParams——矩阵覆盖不到）。

## Commit 序列

| C | Phase | 内容 |
|---|---|---|
| C1 | RED | oracle + 矩阵 → schema 矩阵 32 fail（暴露 not/required 缺陷）；governance 矩阵全绿 |
| C2 | GREEN | schema if/then 重写 + default:false annotation → schema 矩阵全绿 |
| C3 | refactor | governance 委托 oracle（行为零变化）|
| C4 | cleanup | 删 9 个被覆盖 subtest + 3 godot fix |

## Refs

- Roadmap: `docs/plans/202605070431-pr403-funnel-fix-roadmap.md` §3 / §4.4 PR-C
- INVARIANT: `AUTH-SCHEMA-GOVERNANCE-BOOL-SEMANTICS-01`
- ref: kubernetes/kubernetes pkg/securitycontext/util.go (capability mode mutex 单源 oracle 模式)
- ref: JSON Schema 2020-12 if/then keyword; OpenAPI 3.1.0 §Schema Object

## Test plan

- [x] `go test ./kernel/metadata/...` — oracle + matrix + happy-path 全绿
- [x] `go test ./kernel/governance/...` — FMT-27 矩阵 + 现有规则全绿
- [x] `go test ./kernel/metadata/schemas/...` — schema 矩阵 32 case + happy-path 全绿
- [x] `go test ./tools/archtest/...` — archtest 全绿（含 governance rule_inventory 81 条 golden 不变）
- [x] `golangci-lint run ./kernel/metadata/... ./kernel/governance/...` — 0 issues
- [ ] CI 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)