### PR TITLE
ci(integration-discovery): auto-discover integration packages by build tag

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -277,34 +277,58 @@ jobs:
       - name: Integration tests (testcontainers)
         env:
           GOCELL_TEST_DOCKER_REQUIRED: "1"
-        # cmd/corebundle contains e2e outbox integration tests (outbox_e2e_integration_test.go)
-        # that require PG testcontainers. Include it so A11 + F1 regression guards run in CI.
-        # examples/ssobff carries the end-to-end walkthrough test (AUTH-SETUP-01
-        # regression guard — bootstrap credential flow, password-reset gate,
-        # change-password / refresh / logout contract shape). Without this job
-        # including it, the "integration" build tag was never compiled in CI.
-        # cells/accesscore/slices/identitymanage also has an integration test
-        # (changepassword_e2e_test.go) that exercises the real AuthMiddleware.
-        # runtime/bootstrap carries lifecycle_integration_test.go (HookStartStop
-        # ordering + LIFO rollback precision probes); without this path the
-        # //go:build integration file silently never compiles in CI.
-        # -coverpkg removed to match per-shard unit test profile semantics —
-        # each run only reports coverage for the packages it tested, avoiding
-        # per-file dilution in the merged Sonar view.
-        # tests/e2e/internal/... covers the require+clients helpers (pure
-        # unit tests); the smoke and encryption sub-packages are owned by
-        # the dedicated `e2e` job which runs the docker-compose harness.
-        # Earlier this scope used the broader ./tests/e2e/... — but
-        # require.Docker only skips when no docker socket is reachable, and
-        # GitHub runners always expose one for testcontainers, so smoke
-        # tests under ./tests/e2e ran here and blocked on a corebundle
-        # that never started in this job. Compile-time tag regressions
-        # for the smoke / encryption packages remain covered by the e2e
-        # job's `go test -tags=e2e ./tests/e2e/...`.
-        # tests/testutil owns shared testcontainer startup helpers; include it
-        # so new non-test helper code is covered by its own integration
-        # contract tests instead of relying on downstream packages.
-        run: go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/... ./tests/integration/... ./tests/testutil/... ./tests/e2e/internal/... ./cmd/corebundle/... ./examples/ssobff/... ./cells/accesscore/slices/identitymanage/... ./runtime/bootstrap/... -count=1 -timeout 15m
+        # Auto-discover packages by build tag rather than maintaining a
+        # hardcoded list. Each prior addition to the explicit list (examples/
+        # ssobff, runtime/bootstrap, cells/accesscore/slices/identitymanage,
+        # tests/testutil) was a documented incident where new integration
+        # tests silently never ran in CI because nobody updated this step.
+        # archtest CI-INTEGRATION-DISCOVERY-01 prevents regression to a
+        # hardcoded list.
+        #
+        # Discovery: set-diff (comm -13) between the bare `go list` and
+        # `go list -tags=integration` outputs. A package appears in the diff
+        # iff enabling the tag changed its TestGoFiles / XTestGoFiles set —
+        # i.e., the package has at least one //go:build integration file.
+        # This precisely matches the integration coverage surface and avoids
+        # the over-broad `./...` (which would re-run every unit test under
+        # integration tags) and the under-broad single-tag listing (which
+        # lists all test-bearing packages, integration or not).
+        # comm requires sorted input (both files are sorted) and returns
+        # exit 0 even when files differ — unlike `diff`, which returns 1 on
+        # differences and would abort under `set -e -o pipefail`.
+        #
+        # Carve-outs (intentionally excluded):
+        #   - Compound-tag packages (`integration && otelcollector`,
+        #     `integration_cluster`) — covered by dedicated OTel smoke / vet
+        #     steps below; their constraints evaluate false under
+        #     {integration} alone.
+        #   - `e2e`-tagged files (tests/e2e/...) — owned by the dedicated
+        #     `e2e` job which runs the docker-compose harness. Pure-helper
+        #     unit tests under tests/e2e/internal/clients also run there.
+        #   - `examples_smoke` — covered by the dedicated examples-smoke job.
+        #
+        # Empty-set guard fails fast if discovery returns nothing —
+        # build-context misconfiguration could otherwise silently zero out
+        # the integration job into a no-op pass.
+        #
+        # -coverpkg remains omitted to match per-shard unit test profile
+        # semantics; each run reports coverage only for tested packages.
+        #
+        # ref: kubernetes/kubernetes hack/make-rules/test-integration.sh
+        # (kube::test::find_integration_test_pkgs uses go list -find for discovery)
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          fmt='{{.ImportPath}}|{{join .TestGoFiles ","}}|{{join .XTestGoFiles ","}}'
+          go list -find -f "$fmt" ./... | sort >"$tmp/bare.txt"
+          go list -tags=integration -find -f "$fmt" ./... | sort >"$tmp/tagged.txt"
+          pkgs=$(comm -13 "$tmp/bare.txt" "$tmp/tagged.txt" | awk -F'|' '{print $1}' | sort -u | tr '\n' ' ')
+          test -n "$pkgs" || { echo "FAIL: no integration packages discovered (build context or tag misconfiguration?)" >&2; exit 1; }
+          echo "Integration packages:"
+          echo "$pkgs" | tr ' ' '\n'
+          # shellcheck disable=SC2086
+          go test -tags=integration -covermode=atomic -coverprofile=coverage-integration.out $pkgs -count=1 -timeout 15m
 
       - name: OTel collector smoke
         env:

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -320,15 +320,19 @@ jobs:
           set -euo pipefail
           tmp=$(mktemp -d)
           trap 'rm -rf "$tmp"' EXIT
-          fmt='{{.ImportPath}}|{{join .TestGoFiles ","}}|{{join .XTestGoFiles ","}}'
-          go list -find -f "$fmt" ./... | sort >"$tmp/bare.txt"
-          go list -tags=integration -find -f "$fmt" ./... | sort >"$tmp/tagged.txt"
-          pkgs=$(comm -13 "$tmp/bare.txt" "$tmp/tagged.txt" | awk -F'|' '{print $1}' | sort -u | tr '\n' ' ')
-          test -n "$pkgs" || { echo "FAIL: no integration packages discovered (build context or tag misconfiguration?)" >&2; exit 1; }
-          echo "Integration packages:"
-          echo "$pkgs" | tr ' ' '\n'
-          # shellcheck disable=SC2086
-          go test -tags=integration -covermode=atomic -coverprofile=coverage-integration.out $pkgs -count=1 -timeout 15m
+          # Include .GoFiles alongside .TestGoFiles / .XTestGoFiles so that
+          # packages whose non-test //go:build integration files (e.g.,
+          # tests/testutil/rabbitmq_integration.go) gain visibility under the
+          # tag are also detected — defending against the comm -13 false-
+          # identity case where TestGoFiles alone happens to be unchanged.
+          list_fmt='{{.ImportPath}}|{{join .GoFiles ","}}|{{join .TestGoFiles ","}}|{{join .XTestGoFiles ","}}'
+          go list -find -f "$list_fmt" ./... | sort >"$tmp/bare.txt"
+          go list -tags=integration -find -f "$list_fmt" ./... | sort >"$tmp/tagged.txt"
+          mapfile -t pkgs < <(comm -13 "$tmp/bare.txt" "$tmp/tagged.txt" | awk -F'|' '{print $1}' | sort -u)
+          test "${#pkgs[@]}" -gt 0 || { echo "FAIL: no integration packages discovered (no //go:build integration files visible, or tag misconfiguration)" >&2; exit 1; }
+          printf 'Integration packages (%d):\n' "${#pkgs[@]}"
+          printf '  %s\n' "${pkgs[@]}"
+          go test -tags=integration -covermode=atomic -coverprofile=coverage-integration.out "${pkgs[@]}" -count=1 -timeout 15m
 
       - name: OTel collector smoke
         env:

--- a/docs/audit/archtest-inventory.md
+++ b/docs/audit/archtest-inventory.md
@@ -6,8 +6,8 @@
 
 ## 概览
 
-- archtest 文件总数：74
-- archtest INVARIANT 锚点数：176
+- archtest 文件总数：75
+- archtest INVARIANT 锚点数：177
 - governance `rules_*.go` 文件数：8
 
 ## archtest 规则清单

--- a/docs/audit/archtest-inventory.md
+++ b/docs/audit/archtest-inventory.md
@@ -39,6 +39,7 @@
 | `CELLMETA-SINGLE-SOURCE-03` | `cellmeta_single_source_test.go` | 13 | cellmeta |
 | `CELLS-NO-ROUTEMUX-WRAPPER-01` | `setup_admin_bootstrap_closure_test.go` | 12 | cells |
 | `CELLS-NO-WRAPPER-CONTRACTSPEC-IMPORT-01` | `cells_no_wrapper_contractspec_import_test.go` | 1 | cells |
+| `CI-INTEGRATION-DISCOVERY-01` | `ci_integration_discovery_invariants_test.go` | 1 | ci |
 | `CI-PINNING-WORKFLOW-DIGEST-01` | `ci_pinning_test.go` | 1 | ci |
 | `CLOCK-INJECTION-PROD-CALLSITE-01` | `clock_invariants_test.go` | 446 | clock |
 | `CLOCK-INJECTION-TEST-CALLSITE-01` | `clock_invariants_test.go` | 261 | clock |

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -137,16 +137,31 @@ func readIntegrationTestStep(t *testing.T) workflowStep {
 }
 
 // TestArchtest_CIIntegrationDiscovery_DiscoversIntegrationPackages asserts
-// the static walker finds a non-trivial number of packages with files gated
-// under -tags=integration. The lower bound (15) is calibrated to the live
-// count (~17 in develop after the S0 orphan-package backfill); a count
-// below 15 signals regression past the pre-S0 hardcoded-list state.
+// the walker discovers a non-empty set AND every package in a small
+// sentinel list. Sentinels are foundational integration coverage anchors
+// (PG adapter, integration-test root, shared testcontainer helpers) whose
+// disappearance signals either walker breakage or major refactor — the
+// latter requiring an explicit update of this list rather than a silent
+// numeric-threshold drift. Avoiding a free-floating count threshold (which
+// ages with the codebase) keeps the gate stable across legitimate package
+// reorgs that don't affect integration coverage.
 func TestArchtest_CIIntegrationDiscovery_DiscoversIntegrationPackages(t *testing.T) {
 	root := findModuleRoot(t)
 	pkgs, err := discoverPackagesUnderTag(root, "integration")
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, len(pkgs), 15,
-		"expected ≥15 integration packages discovered, got %d: %v", len(pkgs), pkgs)
+	require.NotEmpty(t, pkgs,
+		"no integration packages discovered — walker likely broken")
+
+	sentinels := []string{
+		"adapters/postgres",
+		"tests/integration",
+		"tests/testutil",
+	}
+	for _, s := range sentinels {
+		assert.Contains(t, pkgs, s,
+			"sentinel integration package %q must be discovered; "+
+				"walker broken or package relocated (update sentinels intentionally)", s)
+	}
 	t.Logf("discovered %d integration packages", len(pkgs))
 }
 
@@ -185,27 +200,30 @@ func TestArchtest_CIIntegrationDiscovery_WorkflowUsesGoList(t *testing.T) {
 }
 
 // TestArchtest_CIIntegrationDiscovery_GuardsEmptyDiscovery asserts that the
-// step fails fast if discovery returns zero packages. Without this guard, a
-// misconfigured build context (e.g., a tag typo) could silently zero out
-// the integration job and turn it into a no-op pass.
+// step fails fast if discovery returns zero packages. The guard must combine
+// (a) a discovery-emptiness check AND (b) an explicit `exit 1` on the empty
+// branch — a bare check without exit path is decorative (`test ... && echo
+// ok` would parse fine but never fail).
 //
-// Accepted forms (string scalar OR bash array):
-//   - test -n "$pkgs" || ...          (string discovery)
-//   - [ -z "$pkgs" ] && ...
-//   - test "${#pkgs[@]}" -gt 0 || ... (bash array discovery — current form)
-//   - [ "${#pkgs[@]}" -eq 0 ] && ...
+// Accepted forms (string scalar OR bash array; positive or negated):
+//   - test -n "$pkgs" || { ...; exit 1; }     (current: bash array form)
+//   - [ -z "$pkgs" ] && { ...; exit 1; }
+//   - test "${#pkgs[@]}" -gt 0 || { ...; exit 1; }
+//   - [ "${#pkgs[@]}" -eq 0 ] && { ...; exit 1; }
 func TestArchtest_CIIntegrationDiscovery_GuardsEmptyDiscovery(t *testing.T) {
 	step := readIntegrationTestStep(t)
 	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
 
 	guardRE := regexp.MustCompile(
-		`(test\s+-n\s+["']?\$\{?pkgs\}?["']?` +
-			`|\[\s+-z\s+["']?\$\{?pkgs\}?["']?\s+\]` +
-			`|test\s+"\$\{#pkgs\[@\]\}"\s+-gt\s+0` +
-			`|\[\s+"\$\{#pkgs\[@\]\}"\s+-eq\s+0\s+\])`)
+		`(test\s+-n\s+["']?\$\{?pkgs\}?["']?\s*\|\|.*\bexit\s+1\b` +
+			`|\[\s+-z\s+["']?\$\{?pkgs\}?["']?\s+\]\s*&&.*\bexit\s+1\b` +
+			`|test\s+"\$\{#pkgs\[@\]\}"\s+-gt\s+0\s*\|\|.*\bexit\s+1\b` +
+			`|\[\s+"\$\{#pkgs\[@\]\}"\s+-eq\s+0\s+\]\s*&&.*\bexit\s+1\b)`,
+	)
 	assert.True(t, guardRE.MatchString(step.Run),
-		"integration-test step must fail fast on empty discovery (e.g., `test -n \"$pkgs\"` "+
-			"or `test \"${#pkgs[@]}\" -gt 0`)")
+		"integration-test step must fail fast on empty discovery — the empty-check "+
+			"must be paired with `|| { ...; exit 1; }` (positive form) or `&& { ...; exit 1; }` "+
+			"(negated form); a check without an exit path is decorative")
 }
 
 // TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs
@@ -223,6 +241,26 @@ func TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs(t
 			"($pkgs or \"${pkgs[@]}\"); got run block:\n%s", step.Run)
 }
 
+// TestArchtest_CIIntegrationDiscovery_WorkflowInvokesExactlyOneGoTest asserts
+// the integration-test step contains exactly one `go test` invocation. A
+// second hardcoded `go test ./somepath/...` co-existing alongside the
+// discovered set would silently dilute the discovery guarantee — the
+// uniqueness constraint forces the discovery output to be the single source
+// of truth for what gets tested.
+//
+// The line-anchored regex `(?m)^\s*go test\s` avoids false positives from
+// `go test` mentioned in shell comments or echo strings.
+func TestArchtest_CIIntegrationDiscovery_WorkflowInvokesExactlyOneGoTest(t *testing.T) {
+	step := readIntegrationTestStep(t)
+	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
+
+	goTestRE := regexp.MustCompile(`(?m)^\s*go test\s`)
+	matches := goTestRE.FindAllString(step.Run, -1)
+	assert.Len(t, matches, 1,
+		"integration-test step must invoke `go test` exactly once on the discovered "+
+			"package set; found %d invocations: %v", len(matches), matches)
+}
+
 // TestArchtest_CIIntegrationDiscovery_FixtureMetaTest verifies the
 // discoverPackagesUnderTag walker classifies synthetic files correctly:
 //
@@ -236,34 +274,54 @@ func TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs(t
 //   - `//go:build integration || e2e`       → discovered under both tags
 //   - pre-Go-1.17 `// +build integration` (no `//go:build` line) → NOT
 //     discovered (intentional; repo Go floor is 1.25)
+//   - production .go (filename != _test.go) with the tag → discovered;
+//     mirrors the workflow set-diff's .GoFiles coverage
+//   - `_test.go` filename with the tag → discovered; mirrors the workflow
+//     set-diff's .TestGoFiles / .XTestGoFiles coverage
 //
 // Each fixture lives in its own subdirectory so the directory-level
 // dedup logic in discoverPackagesUnderTag does not collapse multiple
-// fixtures into one entry.
+// fixtures into one entry. The `filename` field defaults to "f.go" when
+// blank; explicit values document filename-specific intent.
 func TestArchtest_CIIntegrationDiscovery_FixtureMetaTest(t *testing.T) {
 	t.Parallel()
 
 	fixtures := []struct {
-		name    string
-		content string
-		wantInt bool
-		wantE2E bool
+		name     string
+		filename string // defaults to "f.go" when empty
+		content  string
+		wantInt  bool
+		wantE2E  bool
 	}{
-		{"plain_integration", "//go:build integration\n\npackage f\n", true, false},
-		{"plain_e2e", "//go:build e2e\n\npackage f\n", false, true},
-		{"compound_otel", "//go:build integration && otelcollector\n\npackage f\n", false, false},
-		{"no_tag", "package f\n", false, false},
-		{"cluster", "//go:build integration_cluster\n\npackage f\n", false, false},
-		{"or_form", "//go:build integration || e2e\n\npackage f\n", true, true},
+		{name: "plain_integration", content: "//go:build integration\n\npackage f\n", wantInt: true},
+		{name: "plain_e2e", content: "//go:build e2e\n\npackage f\n", wantE2E: true},
+		{name: "compound_otel", content: "//go:build integration && otelcollector\n\npackage f\n"},
+		{name: "no_tag", content: "package f\n"},
+		{name: "cluster", content: "//go:build integration_cluster\n\npackage f\n"},
+		{name: "or_form", content: "//go:build integration || e2e\n\npackage f\n", wantInt: true, wantE2E: true},
 		// Pre-1.17 `// +build` form is silently undetected — documents the limitation.
-		{"old_plus_build", "// +build integration\n\npackage f\n", false, false},
+		{name: "old_plus_build", content: "// +build integration\n\npackage f\n"},
+		// Filename-typed cases: explicit production .go vs _test.go to mirror
+		// workflow set-diff symmetry across .GoFiles / .TestGoFiles axes.
+		{
+			name: "production_only_integration", filename: "production.go",
+			content: "//go:build integration\n\npackage f\n", wantInt: true,
+		},
+		{
+			name: "test_file_integration", filename: "service_integration_test.go",
+			content: "//go:build integration\n\npackage f\n", wantInt: true,
+		},
 	}
 
 	root := t.TempDir()
 	for _, fx := range fixtures {
 		sub := filepath.Join(root, fx.name)
 		require.NoError(t, os.MkdirAll(sub, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(sub, "f.go"), []byte(fx.content), 0o644))
+		fname := fx.filename
+		if fname == "" {
+			fname = "f.go"
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(sub, fname), []byte(fx.content), 0o644))
 	}
 
 	intPkgs, err := discoverPackagesUnderTag(root, "integration")

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -16,43 +16,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
-// discoverPackagesUnderTag walks rootDir and returns relative paths of every
-// directory containing at least one .go file whose //go:build expression
-// evaluates true under {tag} alone AND false under no tags.
+// discoverPackagesUnderTag walks rootDir via the scanner framework and
+// returns relative paths of every directory containing at least one .go
+// file whose //go:build expression evaluates true under {tag} alone AND
+// false under no tags.
 //
 // "{tag} alone" matches the visibility a `go list -tags=<tag>` invocation
-// would produce: a file with `integration && otelcollector` is NOT discovered
-// because that expression is false under {integration} alone. This mirrors
-// the carve-out semantics of the dedicated OTel/race CI steps.
+// would produce: a file with `integration && otelcollector` is NOT
+// discovered because that expression is false under {integration} alone.
+// This mirrors the carve-out semantics of the dedicated OTel/race CI steps.
+//
+// Uses scanner.ModuleScope so the default skip-dir set (vendor, testdata,
+// worktrees, generated, .git, node_modules) is enforced uniformly with
+// every other archtest walk per SCANNER-FRAMEWORK-USAGE-01.
 func discoverPackagesUnderTag(rootDir, tag string) ([]string, error) {
+	files, err := scanner.ModuleScope(rootDir, scanner.IncludeTests()).Files()
+	if err != nil {
+		return nil, err
+	}
+
 	seen := map[string]bool{}
 	var pkgs []string
-
-	err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if skipDirs[d.Name()] {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(d.Name(), ".go") {
-			return nil
-		}
+	for _, path := range files {
 		ok, parseErr := fileHasExclusivelyTag(path, tag)
 		if parseErr != nil {
-			return parseErr
+			return nil, parseErr
 		}
 		if !ok {
-			return nil
+			continue
 		}
 		dir := filepath.Dir(path)
 		if seen[dir] {
-			return nil
+			continue
 		}
 		seen[dir] = true
 		rel, relErr := filepath.Rel(rootDir, dir)
@@ -60,10 +59,6 @@ func discoverPackagesUnderTag(rootDir, tag string) ([]string, error) {
 			rel = dir
 		}
 		pkgs = append(pkgs, rel)
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 	sort.Strings(pkgs)
 	return pkgs, nil

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -78,6 +78,12 @@ func discoverPackagesUnderTag(rootDir, tag string) ([]string, error) {
 // returned for tag="integration". They belong to dedicated CI steps
 // (OTel smoke, integration_cluster vet, etc.) and must not be confused
 // with the main integration-test gate.
+//
+// Pre-Go-1.17 `// +build integration` files (without a paired `//go:build`
+// line) are out of scope: `constraint.IsGoBuild` recognizes only the
+// `//go:build` form, and the repo's Go floor (1.25, declared in go.mod)
+// makes the dual-line form unnecessary. The fixture meta-test documents
+// this exclusion explicitly.
 func fileHasExclusivelyTag(path, tag string) (bool, error) {
 	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
@@ -132,15 +138,15 @@ func readIntegrationTestStep(t *testing.T) workflowStep {
 
 // TestArchtest_CIIntegrationDiscovery_DiscoversIntegrationPackages asserts
 // the static walker finds a non-trivial number of packages with files gated
-// under -tags=integration. The lower bound (10) is a sanity check: the live
-// count is ~17 in develop. A bump-down here without coordinated CI surgery
-// signals the regression class CI-INTEGRATION-DISCOVERY-01 protects against.
+// under -tags=integration. The lower bound (15) is calibrated to the live
+// count (~17 in develop after the S0 orphan-package backfill); a count
+// below 15 signals regression past the pre-S0 hardcoded-list state.
 func TestArchtest_CIIntegrationDiscovery_DiscoversIntegrationPackages(t *testing.T) {
 	root := findModuleRoot(t)
 	pkgs, err := discoverPackagesUnderTag(root, "integration")
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, len(pkgs), 10,
-		"expected ≥10 integration packages discovered, got %d: %v", len(pkgs), pkgs)
+	assert.GreaterOrEqual(t, len(pkgs), 15,
+		"expected ≥15 integration packages discovered, got %d: %v", len(pkgs), pkgs)
 	t.Logf("discovered %d integration packages", len(pkgs))
 }
 
@@ -159,9 +165,10 @@ func TestArchtest_CIIntegrationDiscovery_DiscoversE2EPackages(t *testing.T) {
 
 // TestArchtest_CIIntegrationDiscovery_WorkflowUsesGoList asserts that the
 // integration-test job's main step uses `go list -tags=integration` for
-// package discovery, not a hardcoded glob list. The forbidden snippet is
-// the exact pre-S0 invocation header — its presence indicates a literal
-// revert of the discovery change.
+// package discovery and contains no deeper-than-root package globs (e.g.,
+// `./adapters/...`, `./cells/configcore/...`). The whole-module probe
+// `./...` (used inside the `go list` call itself) is allowed — it's the
+// deeper-segment globs that signal hardcoded-list regression.
 func TestArchtest_CIIntegrationDiscovery_WorkflowUsesGoList(t *testing.T) {
 	step := readIntegrationTestStep(t)
 	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
@@ -170,39 +177,50 @@ func TestArchtest_CIIntegrationDiscovery_WorkflowUsesGoList(t *testing.T) {
 		"integration-test step must auto-discover via `go list -tags=integration ...`; "+
 			"see CI-INTEGRATION-DISCOVERY-01")
 
-	forbidden := "go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/..."
-	assert.NotContains(t, step.Run, forbidden,
-		"integration-test step must not hardcode package globs after `go test`; "+
-			"use $pkgs from `go list` discovery instead")
+	hardcodedGlobRE := regexp.MustCompile(`\./[a-z][a-zA-Z0-9_-]*/\.\.\.`)
+	matches := hardcodedGlobRE.FindAllString(step.Run, -1)
+	assert.Empty(t, matches,
+		"integration-test step must not hardcode package globs (found %v); "+
+			"use the discovered package set from `go list` instead", matches)
 }
 
 // TestArchtest_CIIntegrationDiscovery_GuardsEmptyDiscovery asserts that the
 // step fails fast if discovery returns zero packages. Without this guard, a
 // misconfigured build context (e.g., a tag typo) could silently zero out
 // the integration job and turn it into a no-op pass.
+//
+// Accepted forms (string scalar OR bash array):
+//   - test -n "$pkgs" || ...          (string discovery)
+//   - [ -z "$pkgs" ] && ...
+//   - test "${#pkgs[@]}" -gt 0 || ... (bash array discovery — current form)
+//   - [ "${#pkgs[@]}" -eq 0 ] && ...
 func TestArchtest_CIIntegrationDiscovery_GuardsEmptyDiscovery(t *testing.T) {
 	step := readIntegrationTestStep(t)
 	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
 
-	// Either `test -n "$pkgs"` or `[ -z "$pkgs" ]` form is acceptable.
-	guardRE := regexp.MustCompile(`(test\s+-n\s+["']?\$\{?pkgs\}?["']?|\[\s+-z\s+["']?\$\{?pkgs\}?["']?\s+\])`)
+	guardRE := regexp.MustCompile(
+		`(test\s+-n\s+["']?\$\{?pkgs\}?["']?` +
+			`|\[\s+-z\s+["']?\$\{?pkgs\}?["']?\s+\]` +
+			`|test\s+"\$\{#pkgs\[@\]\}"\s+-gt\s+0` +
+			`|\[\s+"\$\{#pkgs\[@\]\}"\s+-eq\s+0\s+\])`)
 	assert.True(t, guardRE.MatchString(step.Run),
-		"integration-test step must fail fast on empty discovery (e.g., `test -n \"$pkgs\" || exit 1`)")
+		"integration-test step must fail fast on empty discovery (e.g., `test -n \"$pkgs\"` "+
+			"or `test \"${#pkgs[@]}\" -gt 0`)")
 }
 
 // TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs
-// asserts the `go test` invocation passes $pkgs (or ${pkgs}) as the package
-// argument, not a literal glob. This is the symmetric positive check to
-// WorkflowUsesGoList: the discovery output must actually flow into the
-// test invocation.
+// asserts the `go test` invocation passes the discovered package set as
+// arguments — either `$pkgs` (string scalar) or `"${pkgs[@]}"` (bash array,
+// current form). This is the symmetric positive check to WorkflowUsesGoList:
+// discovery output must actually flow into the test invocation.
 func TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs(t *testing.T) {
 	step := readIntegrationTestStep(t)
 	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
 
-	invokeRE := regexp.MustCompile(`go test\s+[^\n]*\$\{?pkgs\}?`)
+	invokeRE := regexp.MustCompile(`go test\s+[^\n]*(\$\{?pkgs\}?|"\$\{pkgs\[@\]\}")`)
 	assert.True(t, invokeRE.MatchString(step.Run),
-		"integration-test step's `go test` must run on $pkgs from discovery; "+
-			"got run block:\n%s", step.Run)
+		"integration-test step's `go test` must run on the discovered package set "+
+			"($pkgs or \"${pkgs[@]}\"); got run block:\n%s", step.Run)
 }
 
 // TestArchtest_CIIntegrationDiscovery_FixtureMetaTest verifies the
@@ -216,6 +234,8 @@ func TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs(t
 //   - `//go:build integration_cluster`      → NOT discovered under "integration"
 //     (different tag name; covered by separate vet step)
 //   - `//go:build integration || e2e`       → discovered under both tags
+//   - pre-Go-1.17 `// +build integration` (no `//go:build` line) → NOT
+//     discovered (intentional; repo Go floor is 1.25)
 //
 // Each fixture lives in its own subdirectory so the directory-level
 // dedup logic in discoverPackagesUnderTag does not collapse multiple
@@ -235,6 +255,8 @@ func TestArchtest_CIIntegrationDiscovery_FixtureMetaTest(t *testing.T) {
 		{"no_tag", "package f\n", false, false},
 		{"cluster", "//go:build integration_cluster\n\npackage f\n", false, false},
 		{"or_form", "//go:build integration || e2e\n\npackage f\n", true, true},
+		// Pre-1.17 `// +build` form is silently undetected — documents the limitation.
+		{"old_plus_build", "// +build integration\n\npackage f\n", false, false},
 	}
 
 	root := t.TempDir()

--- a/tools/archtest/ci_integration_discovery_test.go
+++ b/tools/archtest/ci_integration_discovery_test.go
@@ -1,0 +1,258 @@
+// INVARIANT: CI-INTEGRATION-DISCOVERY-01: integration-test step uses `go list -tags=integration` discovery, not hardcoded globs
+package archtest
+
+import (
+	"bufio"
+	"bytes"
+	"go/build/constraint"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// discoverPackagesUnderTag walks rootDir and returns relative paths of every
+// directory containing at least one .go file whose //go:build expression
+// evaluates true under {tag} alone AND false under no tags.
+//
+// "{tag} alone" matches the visibility a `go list -tags=<tag>` invocation
+// would produce: a file with `integration && otelcollector` is NOT discovered
+// because that expression is false under {integration} alone. This mirrors
+// the carve-out semantics of the dedicated OTel/race CI steps.
+func discoverPackagesUnderTag(rootDir, tag string) ([]string, error) {
+	seen := map[string]bool{}
+	var pkgs []string
+
+	err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") {
+			return nil
+		}
+		ok, parseErr := fileHasExclusivelyTag(path, tag)
+		if parseErr != nil {
+			return parseErr
+		}
+		if !ok {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		if seen[dir] {
+			return nil
+		}
+		seen[dir] = true
+		rel, relErr := filepath.Rel(rootDir, dir)
+		if relErr != nil {
+			rel = dir
+		}
+		pkgs = append(pkgs, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(pkgs)
+	return pkgs, nil
+}
+
+// fileHasExclusivelyTag returns true iff the file's header //go:build line
+// evaluates true under {tag} and false under {} — i.e., the file IS gated on
+// the tag and would be visible to `go list -tags=<tag>`.
+//
+// Compound expressions like `integration && otelcollector` evaluate false
+// under {integration} alone, so files using such constraints are NOT
+// returned for tag="integration". They belong to dedicated CI steps
+// (OTel smoke, integration_cluster vet, etc.) and must not be confused
+// with the main integration-test gate.
+func fileHasExclusivelyTag(path, tag string) (bool, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") {
+			if !constraint.IsGoBuild(line) {
+				continue
+			}
+			expr, parseErr := constraint.Parse(line)
+			if parseErr != nil {
+				return false, parseErr
+			}
+			withTag := expr.Eval(func(t string) bool { return t == tag })
+			withoutAny := expr.Eval(func(_ string) bool { return false })
+			return withTag && !withoutAny, nil
+		}
+		break
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// readIntegrationTestStep reads _build-lint.yml and returns the
+// "Integration tests (testcontainers)" step from the integration-test job.
+// Step / job names are coupled to the workflow file by string; renaming
+// either is a coordinated change with this archtest.
+func readIntegrationTestStep(t *testing.T) workflowStep {
+	t.Helper()
+	root := findModuleRoot(t)
+	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "_build-lint.yml")))
+	require.NoError(t, err)
+
+	var cfg workflowConfig
+	require.NoError(t, yaml.NewDecoder(bytes.NewReader(body)).Decode(&cfg))
+
+	job, ok := cfg.Jobs["integration-test"]
+	require.True(t, ok, "integration-test job missing from _build-lint.yml")
+
+	step, ok := findWorkflowStep(job.Steps, "Integration tests (testcontainers)")
+	require.True(t, ok, "Integration tests (testcontainers) step missing from integration-test job")
+	return step
+}
+
+// TestArchtest_CIIntegrationDiscovery_DiscoversIntegrationPackages asserts
+// the static walker finds a non-trivial number of packages with files gated
+// under -tags=integration. The lower bound (10) is a sanity check: the live
+// count is ~17 in develop. A bump-down here without coordinated CI surgery
+// signals the regression class CI-INTEGRATION-DISCOVERY-01 protects against.
+func TestArchtest_CIIntegrationDiscovery_DiscoversIntegrationPackages(t *testing.T) {
+	root := findModuleRoot(t)
+	pkgs, err := discoverPackagesUnderTag(root, "integration")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(pkgs), 10,
+		"expected ≥10 integration packages discovered, got %d: %v", len(pkgs), pkgs)
+	t.Logf("discovered %d integration packages", len(pkgs))
+}
+
+// TestArchtest_CIIntegrationDiscovery_DiscoversE2EPackages asserts at least
+// one e2e package is found. e2e tag is rarer (mostly tests/e2e/...) but
+// must never be empty — an empty set means the walker is broken or the e2e
+// surface vanished, both of which warrant fail-loud.
+func TestArchtest_CIIntegrationDiscovery_DiscoversE2EPackages(t *testing.T) {
+	root := findModuleRoot(t)
+	pkgs, err := discoverPackagesUnderTag(root, "e2e")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(pkgs), 1,
+		"expected ≥1 e2e package discovered, got %d: %v", len(pkgs), pkgs)
+	t.Logf("discovered %d e2e packages", len(pkgs))
+}
+
+// TestArchtest_CIIntegrationDiscovery_WorkflowUsesGoList asserts that the
+// integration-test job's main step uses `go list -tags=integration` for
+// package discovery, not a hardcoded glob list. The forbidden snippet is
+// the exact pre-S0 invocation header — its presence indicates a literal
+// revert of the discovery change.
+func TestArchtest_CIIntegrationDiscovery_WorkflowUsesGoList(t *testing.T) {
+	step := readIntegrationTestStep(t)
+	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
+
+	assert.Contains(t, step.Run, "go list -tags=integration",
+		"integration-test step must auto-discover via `go list -tags=integration ...`; "+
+			"see CI-INTEGRATION-DISCOVERY-01")
+
+	forbidden := "go test -tags=integration,e2e -covermode=atomic -coverprofile=coverage-integration.out ./adapters/..."
+	assert.NotContains(t, step.Run, forbidden,
+		"integration-test step must not hardcode package globs after `go test`; "+
+			"use $pkgs from `go list` discovery instead")
+}
+
+// TestArchtest_CIIntegrationDiscovery_GuardsEmptyDiscovery asserts that the
+// step fails fast if discovery returns zero packages. Without this guard, a
+// misconfigured build context (e.g., a tag typo) could silently zero out
+// the integration job and turn it into a no-op pass.
+func TestArchtest_CIIntegrationDiscovery_GuardsEmptyDiscovery(t *testing.T) {
+	step := readIntegrationTestStep(t)
+	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
+
+	// Either `test -n "$pkgs"` or `[ -z "$pkgs" ]` form is acceptable.
+	guardRE := regexp.MustCompile(`(test\s+-n\s+["']?\$\{?pkgs\}?["']?|\[\s+-z\s+["']?\$\{?pkgs\}?["']?\s+\])`)
+	assert.True(t, guardRE.MatchString(step.Run),
+		"integration-test step must fail fast on empty discovery (e.g., `test -n \"$pkgs\" || exit 1`)")
+}
+
+// TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs
+// asserts the `go test` invocation passes $pkgs (or ${pkgs}) as the package
+// argument, not a literal glob. This is the symmetric positive check to
+// WorkflowUsesGoList: the discovery output must actually flow into the
+// test invocation.
+func TestArchtest_CIIntegrationDiscovery_WorkflowInvokesGoTestOnDiscoveredPkgs(t *testing.T) {
+	step := readIntegrationTestStep(t)
+	require.NotEmpty(t, step.Run, "integration-test main step run block missing")
+
+	invokeRE := regexp.MustCompile(`go test\s+[^\n]*\$\{?pkgs\}?`)
+	assert.True(t, invokeRE.MatchString(step.Run),
+		"integration-test step's `go test` must run on $pkgs from discovery; "+
+			"got run block:\n%s", step.Run)
+}
+
+// TestArchtest_CIIntegrationDiscovery_FixtureMetaTest verifies the
+// discoverPackagesUnderTag walker classifies synthetic files correctly:
+//
+//   - `//go:build integration`              → discovered under "integration"
+//   - `//go:build e2e`                      → discovered under "e2e", NOT "integration"
+//   - `//go:build integration && otelcollector` → NOT discovered under "integration"
+//     (compound tag; covered by separate CI step)
+//   - no //go:build line                    → NOT discovered
+//   - `//go:build integration_cluster`      → NOT discovered under "integration"
+//     (different tag name; covered by separate vet step)
+//   - `//go:build integration || e2e`       → discovered under both tags
+//
+// Each fixture lives in its own subdirectory so the directory-level
+// dedup logic in discoverPackagesUnderTag does not collapse multiple
+// fixtures into one entry.
+func TestArchtest_CIIntegrationDiscovery_FixtureMetaTest(t *testing.T) {
+	t.Parallel()
+
+	fixtures := []struct {
+		name    string
+		content string
+		wantInt bool
+		wantE2E bool
+	}{
+		{"plain_integration", "//go:build integration\n\npackage f\n", true, false},
+		{"plain_e2e", "//go:build e2e\n\npackage f\n", false, true},
+		{"compound_otel", "//go:build integration && otelcollector\n\npackage f\n", false, false},
+		{"no_tag", "package f\n", false, false},
+		{"cluster", "//go:build integration_cluster\n\npackage f\n", false, false},
+		{"or_form", "//go:build integration || e2e\n\npackage f\n", true, true},
+	}
+
+	root := t.TempDir()
+	for _, fx := range fixtures {
+		sub := filepath.Join(root, fx.name)
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(sub, "f.go"), []byte(fx.content), 0o644))
+	}
+
+	intPkgs, err := discoverPackagesUnderTag(root, "integration")
+	require.NoError(t, err)
+	e2ePkgs, err := discoverPackagesUnderTag(root, "e2e")
+	require.NoError(t, err)
+
+	for _, fx := range fixtures {
+		intHit := slices.Contains(intPkgs, fx.name)
+		e2eHit := slices.Contains(e2ePkgs, fx.name)
+		assert.Equal(t, fx.wantInt, intHit, "integration discovery for fixture %s", fx.name)
+		assert.Equal(t, fx.wantE2E, e2eHit, "e2e discovery for fixture %s", fx.name)
+	}
+}


### PR DESCRIPTION
## Summary

S0 from `docs/plans/202605082145-034-pg-corecell-b-route-plan.md`.

Replace the hardcoded integration-test package list in `.github/workflows/_build-lint.yml` with `go list` set-diff discovery, and add archtest `CI-INTEGRATION-DISCOVERY-01` to lock the pattern in. The previous explicit list silently orphaned every newly-introduced integration package; the workflow comments document 4 such past incidents (examples/ssobff, runtime/bootstrap, cells/accesscore/slices/identitymanage, tests/testutil).

**Auto-fixes 6 currently orphan integration packages** that exist on develop but were never running in CI:
- `kernel/governance/`, `kernel/metadata/`
- `cells/accesscore/` (top-level)
- `cells/configcore/internal/adapters/postgres/`
- `cells/configcore/slices/configwrite/`, `cells/configcore/slices/configpublish/`

## Discovery mechanism

```bash
list_fmt='{{.ImportPath}}|{{join .GoFiles ","}}|{{join .TestGoFiles ","}}|{{join .XTestGoFiles ","}}'
go list -find -f "$list_fmt" ./...                 | sort > bare.txt
go list -tags=integration -find -f "$list_fmt" ./... | sort > tagged.txt
mapfile -t pkgs < <(comm -13 bare.txt tagged.txt | awk -F'|' '{print $1}' | sort -u)
test "${#pkgs[@]}" -gt 0 || { echo "FAIL: no integration packages discovered" >&2; exit 1; }
go test -tags=integration ... "${pkgs[@]}" -count=1 -timeout 15m
```

A package appears in the diff iff enabling `-tags=integration` changed its `.GoFiles / .TestGoFiles / .XTestGoFiles` set — i.e., it has at least one `//go:build integration` file (production or test). `comm -13` is used over `diff` because `diff` returns exit 1 on differences, which `set -euo pipefail` would treat as fatal. Bash array (`mapfile`) keeps `go test` arg tokenization clean and avoids the SC2086 over-suppression that string-scalar form requires.

## Carve-outs (intentionally excluded)

Compound and single-purpose tags evaluate false under `{integration}` alone, so the discovery naturally excludes them. They remain in their dedicated CI steps:
- `integration && otelcollector` → OTel smoke step
- `integration_cluster` → cluster vet step
- `e2e` → dedicated `e2e` job (docker-compose harness)
- `examples_smoke` → dedicated `examples-smoke` job

## archtest CI-INTEGRATION-DISCOVERY-01

`tools/archtest/ci_integration_discovery_invariants_test.go` (NEW) — 7 tests:

| Test | Purpose |
|------|---------|
| `DiscoversIntegrationPackages` | walker finds non-empty set + 3 sentinel packages (`adapters/postgres`, `tests/integration`, `tests/testutil`); avoids brittle numeric threshold |
| `DiscoversE2EPackages` | non-empty set under `e2e` tag |
| `WorkflowUsesGoList` | step contains `go list -tags=integration`; no deeper-than-root globs (`./adapters/...`, `./cells/configcore/...`, etc.) |
| `GuardsEmptyDiscovery` | empty-check is paired with `\|\| { ...; exit 1; }` (positive form) or `&& { ...; exit 1; }` (negated form) — bare check without exit path is decorative |
| `WorkflowInvokesGoTestOnDiscoveredPkgs` | `go test ... $pkgs` (or `"${pkgs[@]}"`) — discovery output flows into invocation |
| `WorkflowInvokesExactlyOneGoTest` | line-anchored count of `go test` invocations == 1 — forbids hardcoded `go test` co-existing with discovered set |
| `FixtureMetaTest` | 9 synthetic fixtures verifying classification: single-tag, compound `&&`, OR, no-tag, different tag, pre-1.17 `// +build`, production-only `.go`, `_test.go` filename |

Uses `tools/archtest/internal/scanner` framework (`scanner.ModuleScope(rootDir, scanner.IncludeTests()).Files()`) per `SCANNER-FRAMEWORK-USAGE-01` — no raw `filepath.WalkDir` in archtest source.

## Commits

| Commit | Purpose |
|---|---|
| `722d47a4` | Initial S0 implementation: workflow auto-discovery + first archtest cut |
| `faa25c11` | Round-1 review fixes (8 Cx1/Cx2 findings: array form, .GoFiles, file rename, broader regex, sentinel docs, etc.) |
| `5f09b4b7` | Round-2 review fixes (5 P2 findings: sentinel-based threshold, guard-bound-to-exit-1, exactly-one-go-test, fixture symmetry, inventory regen) |
| `51457137` | Rebase fallout: migrate to scanner framework after PR #430 (`SCANNER-FRAMEWORK-USAGE-01` enablement removed package-level `skipDirs`); regen inventory after PR-B governance bump (74/176 → 75/177) |

## Test plan

- [x] `make verify` — 21/21 gates pass locally (verify-archtest-inventory, verify-panic-registered, verify-prod-clock-injection, verify-prod-duration, verify-test-time-literal, verify-unconditional-skip, etc.)
- [x] `go test ./tools/archtest/` — 50s PASS
- [x] `go test ./tools/archtest/ -run CIIntegrationDiscovery -v` — 7/7 PASS
- [x] `go vet ./tools/archtest/...` — clean (CI gate)
- [x] `go build -tags=integration ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `bash hack/verify-archtest-inventory.sh` — exit 0
- [x] Local discovery shell snippet returns 17 packages, matches archtest count
- [x] `go vet -tags=integration "${pkgs[@]}"` against all 17 — clean
- [ ] CI integration-test job runs successfully against the auto-discovered set (verifying on PR check now)

## References

- ref: kubernetes/kubernetes `hack/make-rules/test-integration.sh` (`kube::test::find_integration_test_pkgs` uses `go list -find` for discovery)
- ref: hashicorp/consul `Makefile` (`go list -tags=$GOTAGS ./... | grep ...` piped to `go test`)
- ref: etcd-io/etcd `scripts/test_lib.sh` (single-invocation discipline + structured discovery)

Refs: `docs/plans/202605082145-034-pg-corecell-b-route-plan.md` S0

🤖 Generated with [Claude Code](https://claude.com/claude-code)