### PR TITLE
test(archtest): freeze HandleResult field set + literal allowlist

### DIFF
--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -34,7 +34,7 @@ func handleEvent(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 }
 ```
 
-> **回落字面量**：`outbox.HandleResult.ProcessReason` / `SettlementObservers` 字段无法用 factory 表达，需要时直接构造 `outbox.HandleResult{...}` 字面量（典型场景：kernel internal retry plumbing、middleware-handler 协议）。
+> **回落字面量**：`outbox.HandleResult.ProcessReason` / `SettlementObservers` 字段无法用 factory 表达，需要时直接构造 `outbox.HandleResult{...}` 字面量（典型场景：kernel internal retry plumbing、middleware-handler 协议）。`OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01` archtest 把字面量构造限定在 `kernel/outbox/result.go` / `consumer_base.go` / `outboxtest/conformance.go` 三处 allowlist；业务路径必须用 `outbox.Ack()` / `Requeue(err)` / `Reject(err)`。`HandleResult` 字段集本身由 `OUTBOX-HANDLERESULT-FIELDS-FROZEN-01` 冻结。
 
 ### Disposition 语义
 

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1756,3 +1756,222 @@ func repoRootFromTestPath(t *testing.T) string {
 		dir = parent
 	}
 }
+
+// ---------------------------------------------------------------------------
+// OUTBOX-HANDLERESULT-FIELDS-FROZEN-01
+// ---------------------------------------------------------------------------
+
+// handleResultAllowedFields is the verbatim field set of kernel/outbox.HandleResult.
+// Adding a fifth field requires extending this allowlist deliberately, which
+// is the moment to (a) re-read ADR 202605031900-adr-handler-vocabulary-collapse.md,
+// (b) decide whether the new field belongs on the EntryHandler return contract
+// or in ConsumerBase internal state, and (c) extend the Ack/Requeue/Reject
+// factories in kernel/outbox/result.go if the field can be carried by them.
+var handleResultAllowedFields = map[string]struct{}{
+	"Disposition":         {},
+	"Err":                 {},
+	"ProcessReason":       {},
+	"SettlementObservers": {},
+}
+
+// INVARIANT: OUTBOX-HANDLERESULT-FIELDS-FROZEN-01
+//
+// TestOutboxHandleResultFieldsFrozen enforces OUTBOX-HANDLERESULT-FIELDS-FROZEN-01:
+// kernel/outbox.HandleResult must declare exactly the four fields listed in
+// handleResultAllowedFields. The factories Ack/Requeue/Reject cover the two
+// stable axes (Disposition, Err); ProcessReason and SettlementObservers are
+// intentional fallback-literal escape hatches for kernel internal retry
+// plumbing and middleware-handler protocol (see eventbus.md "回落字面量").
+//
+// Drift in this field set silently changes what every cell handler can/must
+// produce, so freezing the set keeps the fallback intentional.
+func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "kernel", "outbox", "outbox.go")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var (
+		found   bool
+		seen    = make(map[string]struct{})
+		unknown []string
+	)
+	ast.Inspect(f, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok || ts.Name == nil || ts.Name.Name != "HandleResult" {
+			return true
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok || st.Fields == nil {
+			return false
+		}
+		found = true
+		for _, field := range st.Fields.List {
+			for _, name := range field.Names {
+				seen[name.Name] = struct{}{}
+				if _, ok := handleResultAllowedFields[name.Name]; !ok {
+					line := fset.Position(name.Pos()).Line
+					unknown = append(unknown, fmt.Sprintf("kernel/outbox/outbox.go:%d: %s", line, name.Name))
+				}
+			}
+		}
+		return false
+	})
+
+	if !found {
+		t.Fatal("HandleResult struct definition not found in kernel/outbox/outbox.go")
+	}
+
+	var missing []string
+	for k := range handleResultAllowedFields {
+		if _, ok := seen[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+
+	sort.Strings(unknown)
+	sort.Strings(missing)
+	for _, u := range unknown {
+		t.Errorf("OUTBOX-HANDLERESULT-FIELDS-FROZEN-01: %s — field not in allowlist; "+
+			"to add a field, update handleResultAllowedFields and review "+
+			"ADR 202605031900-adr-handler-vocabulary-collapse.md plus the "+
+			"Ack/Requeue/Reject factories in kernel/outbox/result.go", u)
+	}
+	for _, m := range missing {
+		t.Errorf("OUTBOX-HANDLERESULT-FIELDS-FROZEN-01: required field %s missing from "+
+			"kernel/outbox.HandleResult — removing a field changes the EntryHandler return "+
+			"contract; review ADR 202605031900 and update handleResultAllowedFields "+
+			"deliberately if the removal is intentional", m)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01
+// ---------------------------------------------------------------------------
+
+// handleResultLiteralAllowlist lists the production (non-_test.go) files that
+// may construct outbox.HandleResult{...} composite literals. Every other
+// production file must use the Ack/Requeue/Reject factories from
+// kernel/outbox/result.go.
+//
+// Why these three:
+//   - kernel/outbox/result.go         — defines the factories themselves.
+//   - kernel/outbox/consumer_base.go  — kernel internal retry/settle plumbing
+//     constructs HandleResult with ProcessReason / SettlementObservers, which
+//     the factories do not expose (see eventbus.md "回落字面量").
+//   - kernel/outbox/outboxtest/conformance.go — shared conformance harness;
+//     non-_test.go by package convention but used only from test binaries.
+//
+// Adding a new entry requires a code-comment justification: the goal of
+// FACTORY-PREFERRED-01 is to keep the fallback-literal surface intentionally
+// small. New kernel/outbox files writing HandleResult literals are rare —
+// extend the list deliberately.
+var handleResultLiteralAllowlist = map[string]struct{}{
+	"kernel/outbox/result.go":                 {},
+	"kernel/outbox/consumer_base.go":          {},
+	"kernel/outbox/outboxtest/conformance.go": {},
+}
+
+// INVARIANT: OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01
+//
+// TestOutboxHandleResultFactoryPreferred enforces
+// OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01: production code (non-_test.go)
+// must use kernel/outbox factories Ack/Requeue/Reject instead of constructing
+// outbox.HandleResult{...} composite literals, except for the three files in
+// handleResultLiteralAllowlist (factories themselves, kernel internal
+// plumbing, shared conformance harness).
+//
+// Test files (_test.go) are excluded by default (scanner.ModuleScope skips
+// them unless IncludeTests is set); generated/, vendor/, testdata/, and
+// worktrees/ are also skipped by default.
+//
+// The scanner detects two literal forms:
+//  1. <alias>.HandleResult{...} where <alias> is the local name binding the
+//     kernel/outbox import (default: "outbox", but explicit aliases are
+//     honored via scanner.PackageAliases).
+//  2. Bare HandleResult{...} when the file's package is "outbox" itself
+//     (covers any future kernel/outbox/*.go file outside the allowlist).
+func TestOutboxHandleResultFactoryPreferred(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	files, err := scanner.ModuleScope(root).Files()
+	if err != nil {
+		t.Fatalf("ModuleScope.Files: %v", err)
+	}
+
+	const outboxImportPath = "github.com/ghbvf/gocell/kernel/outbox"
+
+	var violations []string
+	for _, abs := range files {
+		rel, err := filepath.Rel(root, abs)
+		if err != nil {
+			continue
+		}
+		rel = filepath.ToSlash(rel)
+		if _, ok := handleResultLiteralAllowlist[rel]; ok {
+			continue
+		}
+		hits := scanForHandleResultLiterals(abs, rel, outboxImportPath)
+		violations = append(violations, hits...)
+	}
+
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Errorf("OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01: %s — use outbox.Ack() / "+
+			"outbox.Requeue(err) / outbox.Reject(err) instead of constructing the "+
+			"struct literal; if you genuinely need ProcessReason or SettlementObservers, "+
+			"extend handleResultLiteralAllowlist with a code-comment justification", v)
+	}
+}
+
+// scanForHandleResultLiterals AST-scans the file at path for HandleResult
+// composite literals. Returns "<rel>:<line>" diagnostics. Files that neither
+// import kernel/outbox nor declare package outbox produce no hits.
+func scanForHandleResultLiterals(path, rel, outboxImportPath string) []string {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
+	if err != nil {
+		return nil
+	}
+
+	aliases := scanner.PackageAliases(f, outboxImportPath)
+	inPackageOutbox := f.Name != nil && f.Name.Name == "outbox"
+	if len(aliases) == 0 && !inPackageOutbox {
+		return nil
+	}
+
+	var hits []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		switch tn := cl.Type.(type) {
+		case *ast.SelectorExpr:
+			ident, ok := tn.X.(*ast.Ident)
+			if !ok || tn.Sel == nil || tn.Sel.Name != "HandleResult" {
+				return true
+			}
+			if _, ok := aliases[ident.Name]; !ok {
+				return true
+			}
+			pos := fset.Position(cl.Pos())
+			hits = append(hits, fmt.Sprintf("%s:%d: %s.HandleResult{} literal", rel, pos.Line, ident.Name))
+		case *ast.Ident:
+			if !inPackageOutbox || tn.Name != "HandleResult" {
+				return true
+			}
+			pos := fset.Position(cl.Pos())
+			hits = append(hits, fmt.Sprintf("%s:%d: HandleResult{} literal in package outbox", rel, pos.Line))
+		}
+		return true
+	})
+	return hits
+}

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1785,6 +1785,14 @@ var handleResultAllowedFields = map[string]struct{}{
 //
 // Drift in this field set silently changes what every cell handler can/must
 // produce, so freezing the set keeps the fallback intentional.
+//
+// Cannot funnel: HandleResult is a kernel-owned type whose literal construction
+// is required by consumer_base.go internal plumbing — making fields unexported
+// to force factory-only access would break that intra-package construction and
+// the typed-test conformance harness. No schema/marker source can express
+// "exactly these field names" as a Go compile-time constraint without
+// regenerating the type itself, which loses hand-tuned tags and comments.
+// Archtest is the minimum-friction gate.
 func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 	root := findModuleRoot(t)
 	path := filepath.Join(root, "kernel", "outbox", "outbox.go")
@@ -1810,6 +1818,14 @@ func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 		}
 		found = true
 		for _, field := range st.Fields.List {
+			// Embedded / anonymous field: field.Names is nil. Treat the embedded
+			// type as a virtual field — it adds API surface that Ack/Requeue/Reject
+			// cannot express, so it must go through allowlist review.
+			if len(field.Names) == 0 {
+				line := fset.Position(field.Type.Pos()).Line
+				unknown = append(unknown, fmt.Sprintf("kernel/outbox/outbox.go:%d: <embedded field>", line))
+				continue
+			}
 			for _, name := range field.Names {
 				seen[name.Name] = struct{}{}
 				if _, ok := handleResultAllowedFields[name.Name]; !ok {
@@ -1822,7 +1838,9 @@ func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 	})
 
 	if !found {
-		t.Fatal("HandleResult struct definition not found in kernel/outbox/outbox.go")
+		t.Fatalf("HandleResult struct definition not found in kernel/outbox/outbox.go " +
+			"— if the type was relocated to another file in package outbox, update " +
+			"this test's hardcoded path along with the move")
 	}
 
 	var missing []string
@@ -1865,10 +1883,12 @@ func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 //   - kernel/outbox/outboxtest/conformance.go — shared conformance harness;
 //     non-_test.go by package convention but used only from test binaries.
 //
-// Adding a new entry requires a code-comment justification: the goal of
-// FACTORY-PREFERRED-01 is to keep the fallback-literal surface intentionally
-// small. New kernel/outbox files writing HandleResult literals are rare —
-// extend the list deliberately.
+// Adding a new entry requires the justification to live **next to the map
+// entry below as a Go comment** (not in the file being scanned, since that
+// file is the subject of the rule). The goal of FACTORY-PREFERRED-01 is to
+// keep the fallback-literal surface intentionally small. New kernel/outbox
+// files writing HandleResult literals are rare — extend this list
+// deliberately.
 var handleResultLiteralAllowlist = map[string]struct{}{
 	"kernel/outbox/result.go":                 {},
 	"kernel/outbox/consumer_base.go":          {},
@@ -1894,6 +1914,18 @@ var handleResultLiteralAllowlist = map[string]struct{}{
 //     honored via scanner.PackageAliases).
 //  2. Bare HandleResult{...} when the file's package is "outbox" itself
 //     (covers any future kernel/outbox/*.go file outside the allowlist).
+//
+// Cannot funnel: ProcessReason and SettlementObservers are runtime-determined
+// fields populated by handler code paths and middleware, with no schema /
+// marker source from which a literal-vs-factory choice can be derived. Type
+// system cannot express "callers in cells/ must use these three function
+// names" without unexporting HandleResult itself, which would break the
+// kernel-internal literal construction the allowlist exists to permit.
+// Archtest enforces the path discipline that no other layer can.
+//
+// t.Parallel: this rule walks the entire module (ModuleScope), unlike the
+// single-file FROZEN-01 sibling. Parallelism is intentional here and absent
+// there to keep the cheap test serial.
 func TestOutboxHandleResultFactoryPreferred(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)


### PR DESCRIPTION
## Summary

防御性 archtest，锁定 `outbox.HandleResult` 当前 vocabulary，不推动 backlog 条目 `OUTBOX-HANDLERESULT-SLIM-01` 的收敛迁移。

新增两条静态守卫：

- **OUTBOX-HANDLERESULT-FIELDS-FROZEN-01** — `kernel/outbox.HandleResult` 字段集冻结为 `{Disposition, Err, ProcessReason, SettlementObservers}`。新增第 5 字段必须显式扩展 allowlist，触发对 ADR 202605031900 与 `Ack/Requeue/Reject` factory 的再评估。
- **OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01** — 生产代码（非 `_test.go`）禁止裸 `HandleResult{...}` 字面量构造。allowlist 仅 3 个文件：`kernel/outbox/result.go`（factory 自身）/ `consumer_base.go`（内核 retry plumbing）/ `outboxtest/conformance.go`（共享 conformance harness）。其余 `cells/` `runtime/` `adapters/` `examples/` 必须走 `outbox.Ack()` / `Requeue(err)` / `Reject(err)`。

两条规则均与 develop 基线 0 冲突，并各自做了 sentinel 注入回归验证（在合规文件外加 5th 字段 / 加裸字面量 → archtest 报错并给出明确诊断 → 还原）。

eventbus.md 「回落字面量」段附加一句 archtest ID 引用，提升可发现性。

## Why this PR (而不是直接做 SLIM-01)

backlog 触发条件 (1)(2)(3) 全未达：业务 handler 当前 100% 走 factory，0 处显式 ProcessReason / SettlementObservers 字面量。SLIM-01 全做约 ~1500 LOC 含 194 处 test sweep，且会把 SettlementObservers 从 per-invocation 降为 per-subscription（表达力下降），收益主要为纸面纯洁性。本 PR 用约 220 行 archtest 把现状锁住，让未来违规自动报错，等 backlog 触发条件真正发生时再做 SLIM-01 迁移。

## Refs

- backlog: `OUTBOX-HANDLERESULT-SLIM-01`（守卫现状，不动触发条件文本）
- ADR: `docs/architecture/202605031900-adr-handler-vocabulary-collapse.md`
- ref: `tools/archtest/no_manual_contractspec_literal_test.go` (literal walker 模板)
- ref: `tools/archtest/outbox_invariants_test.go:603 TestOutboxHandleResultNoReceiptField` (TypeSpec 模板)

## Test plan

- [x] `go build ./...` PASS
- [x] `go test ./tools/archtest/` PASS（含两条新规则）
- [x] FIELDS-FROZEN-01 sentinel 注入回归（加 5th 字段 → 期望 fail）
- [x] FACTORY-PREFERRED-01 sentinel 注入回归（在 `cells/internal/testoutbox/emitter.go` 加裸字面量 → 期望 fail）
- [x] `golangci-lint run ./tools/archtest/...` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)