### PR TITLE
fix(auditcore): reject events with missing actor identity (fail-closed)

### DIFF
--- a/cells/auditcore/slices/auditappend/outbox_test.go
+++ b/cells/auditcore/slices/auditappend/outbox_test.go
@@ -45,7 +45,7 @@ func TestService_WithEmitter(t *testing.T) {
 	entry := outbox.Entry{
 		ID:        "evt-1",
 		EventType: "event.user.created.v1",
-		Payload:   mustJSON(map[string]any{"userId": "usr-1"}),
+		Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "adm-1"}),
 	}
 	assertAck(t, svc.HandleEvent(context.Background(), entry))
 
@@ -62,7 +62,7 @@ func TestService_WithTxManager(t *testing.T) {
 	entry := outbox.Entry{
 		ID:        "evt-1",
 		EventType: "event.user.created.v1",
-		Payload:   mustJSON(map[string]any{"userId": "usr-1"}),
+		Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "adm-1"}),
 	}
 	assertAck(t, svc.HandleEvent(context.Background(), entry))
 
@@ -80,23 +80,11 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 	entry := outbox.Entry{
 		ID:        "evt-1",
 		EventType: "event.session.created.v1",
-		Payload:   mustJSON(map[string]any{"sessionId": "sess-1", "userId": "usr-1"}),
+		Payload:   mustJSON(t, map[string]any{"sessionId": "sess-1", "userId": "usr-1"}),
 	}
 	assertAck(t, svc.HandleEvent(context.Background(), entry))
 
 	assert.Equal(t, 1, tx.calls)
 	require.Len(t, ow.entries, 1)
 	assert.Equal(t, dto.TopicAuditAppended, ow.entries[0].EventType)
-}
-
-func TestService_HandleEvent_SystemActor(t *testing.T) {
-	// Test that entries without userId get "system" as actor.
-	svc, _ := newTestService(t)
-	entry := outbox.Entry{
-		ID:        "evt-sys",
-		EventType: "event.config.entry-upserted.v1",
-		Payload:   mustJSON(map[string]any{"key": "app.name"}), // no userId
-	}
-	assertAck(t, svc.HandleEvent(context.Background(), entry))
-	assert.Equal(t, 1, svc.ChainLen())
 }

--- a/cells/auditcore/slices/auditappend/service.go
+++ b/cells/auditcore/slices/auditappend/service.go
@@ -140,26 +140,26 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) outbox.Ha
 
 	// Extract actor identity from payload.
 	// Priority: actorId (admin-write events) > userId (session.* events).
-	// Producer-side schemas declare actorId/userId as required; reaching the
-	// missing-actor branch indicates upstream contract violation and routes
+	// Producer-side schemas declare actorId/userId as required; payloads that
+	// fail to decode into the actor struct (non-object JSON) or that resolve
+	// to an empty actor both indicate upstream contract violation and route
 	// to DLX (PermanentError) rather than polluting the audit chain.
-	var actorID string
-	{
-		var payload struct {
-			ActorID string `json:"actorId"`
-			UserID  string `json:"userId"`
-		}
-		if err := json.Unmarshal(entry.Payload, &payload); err != nil {
-			s.logger.Warn("audit-append: failed to extract actor from payload",
-				slog.Any("error", err),
-				slog.String("event_id", entry.ID),
-				slog.String("event_type", entry.EventType))
-		} else {
-			actorID = payload.ActorID
-			if actorID == "" {
-				actorID = payload.UserID
-			}
-		}
+	var payload struct {
+		ActorID string `json:"actorId"`
+		UserID  string `json:"userId"`
+	}
+	if err := json.Unmarshal(entry.Payload, &payload); err != nil {
+		s.logger.Warn("audit-append: actor missing — rejecting event",
+			slog.Any("error", err),
+			slog.String("event_id", entry.ID),
+			slog.String("event_type", entry.EventType))
+		return outbox.Reject(outbox.NewPermanentError(
+			errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				"audit-append: event payload missing required actor identity")))
+	}
+	actorID := payload.ActorID
+	if actorID == "" {
+		actorID = payload.UserID
 	}
 	if actorID == "" {
 		s.logger.Warn("audit-append: actor missing — rejecting event",

--- a/cells/auditcore/slices/auditappend/service.go
+++ b/cells/auditcore/slices/auditappend/service.go
@@ -20,9 +20,11 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-// Topics lists the event topics consumed by audit-append. The handler is
-// payload-agnostic — it extracts userId when the payload carries one,
-// otherwise falls back to "system", so adding a topic here is purely additive.
+// Topics lists the event topics consumed by audit-append. The handler extracts
+// actorId (admin-write events) or userId (session.* events) from the payload;
+// events missing both fields are rejected to DLX (see HandleEvent). Adding a
+// topic here is purely additive provided the producer schema declares one of
+// actorId / userId as required.
 // Each topic must also list auditcore as a subscriber in its contract.yaml.
 var Topics = []string{
 	"event.user.created.v1",
@@ -136,13 +138,11 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) outbox.Ha
 		return outbox.Reject(outbox.NewPermanentError(errors.New("audit-append: invalid JSON payload")))
 	}
 
-	// Extract actorId from payload. PR-CFG-G1 G.2 made actorId required for all
-	// admin-write events (config + user.{deleted,updated,unlocked,locked,created}).
-	// session.* events use userId (no actorId — system action attributed to the
-	// session owner). Producer-side decoders (configcore/internal/events,
-	// accesscore/internal/dto) reject empty actorId, so reaching the "system"
-	// fallback here means the producer bypassed validation — record at Error
-	// level so data-quality dashboards surface the regression.
+	// Extract actor identity from payload.
+	// Priority: actorId (admin-write events) > userId (session.* events).
+	// Producer-side schemas declare actorId/userId as required; reaching the
+	// missing-actor branch indicates upstream contract violation and routes
+	// to DLX (PermanentError) rather than polluting the audit chain.
 	var actorID string
 	{
 		var payload struct {
@@ -162,13 +162,12 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) outbox.Ha
 		}
 	}
 	if actorID == "" {
-		s.logger.Error("audit-append: actor extraction fell back to \"system\" — "+
-			"event payload contained neither actorId nor userId; producer-side "+
-			"validation regression suspected",
+		s.logger.Warn("audit-append: actor missing — rejecting event",
 			slog.String("event_id", entry.ID),
 			slog.String("event_type", entry.EventType))
-		// Fail-safe fallback — see ADR Q5 (at-least-once audit > actor traceability).
-		actorID = "system"
+		return outbox.Reject(outbox.NewPermanentError(
+			errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				"audit-append: event payload missing required actor identity")))
 	}
 
 	// Append to hash chain.

--- a/cells/auditcore/slices/auditappend/service_test.go
+++ b/cells/auditcore/slices/auditappend/service_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,10 +108,9 @@ func TestNewService_HMACKeyTooShort(t *testing.T) {
 
 func TestService_HandleEvent(t *testing.T) {
 	tests := []struct {
-		name       string
-		entry      outbox.Entry
-		wantReject bool
-		wantChain  int
+		name      string
+		entry     outbox.Entry
+		wantChain int
 	}{
 		{
 			name: "user created event",
@@ -145,14 +145,9 @@ func TestService_HandleEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			svc, repo := newTestService(t)
 
-			result := svc.HandleEvent(context.Background(), tt.entry)
-			if tt.wantReject {
-				assertReject(t, result)
-			} else {
-				assertAck(t, result)
-				assert.Equal(t, tt.wantChain, svc.ChainLen())
-				assert.Equal(t, tt.wantChain, repo.Len())
-			}
+			assertAck(t, svc.HandleEvent(context.Background(), tt.entry))
+			assert.Equal(t, tt.wantChain, svc.ChainLen())
+			assert.Equal(t, tt.wantChain, repo.Len())
 		})
 	}
 }
@@ -287,36 +282,48 @@ func TestService_HandleEvent_ActorExtraction(t *testing.T) {
 }
 
 // TestService_HandleEvent_ActorMissing_Reject locks the fail-closed contract:
-// when both actorId and userId are absent or empty, HandleEvent must return
-// DispositionReject (DLX path) wrapping a PermanentError, and the audit chain
-// must remain untouched. Producer-side schemas already declare these fields
-// as required; reaching this branch indicates upstream contract violation
-// and routing the event to DLX preserves audit traceability.
+// when the payload cannot resolve to a non-empty actor (object missing the
+// fields, explicit empty values, JSON that is not a struct-shaped object),
+// HandleEvent must return DispositionReject (DLX path) wrapping a
+// PermanentError, and the audit chain must remain untouched. Producer-side
+// schemas already declare actorId/userId as required; reaching this branch
+// indicates upstream contract violation and routing the event to DLX
+// preserves audit traceability.
 func TestService_HandleEvent_ActorMissing_Reject(t *testing.T) {
 	tests := []struct {
 		name      string
 		eventType string
-		payload   map[string]any
+		payload   []byte
 	}{
 		{
 			name:      "config event missing actorId (no userId fallback)",
 			eventType: "event.config.entry-upserted.v1",
-			payload:   map[string]any{"key": "k", "version": 1},
+			payload:   mustJSON(t, map[string]any{"key": "k", "version": 1}),
 		},
 		{
 			name:      "user event missing both actorId and userId",
 			eventType: "event.user.created.v1",
-			payload:   map[string]any{"username": "bob"},
+			payload:   mustJSON(t, map[string]any{"username": "bob"}),
 		},
 		{
 			name:      "explicit empty strings for actorId and userId",
 			eventType: "event.user.locked.v1",
-			payload:   map[string]any{"actorId": "", "userId": ""},
+			payload:   mustJSON(t, map[string]any{"actorId": "", "userId": ""}),
 		},
 		{
 			name:      "snake_case user_id is not a recognized field",
 			eventType: "event.user.created.v1",
-			payload:   map[string]any{"user_id": "usr-2", "username": "bob"},
+			payload:   mustJSON(t, map[string]any{"user_id": "usr-2", "username": "bob"}),
+		},
+		{
+			name:      "valid JSON array is not an object",
+			eventType: "event.user.created.v1",
+			payload:   []byte(`[]`),
+		},
+		{
+			name:      "valid JSON null is not an object",
+			eventType: "event.user.created.v1",
+			payload:   []byte(`null`),
 		},
 	}
 	for _, tt := range tests {
@@ -331,7 +338,7 @@ func TestService_HandleEvent_ActorMissing_Reject(t *testing.T) {
 			entry := outbox.Entry{
 				ID:        "evt-actor-missing",
 				EventType: tt.eventType,
-				Payload:   mustJSON(t, tt.payload),
+				Payload:   tt.payload,
 			}
 
 			result := svc.HandleEvent(context.Background(), entry)
@@ -346,12 +353,16 @@ func TestService_HandleEvent_ActorMissing_Reject(t *testing.T) {
 			assert.Equal(t, 0, repo.Len(), "rejected event must not be persisted")
 
 			// Log line carries event_id / event_type as structured fields and
-			// must NOT contain the literal "system" fallback marker.
+			// must NOT contain the literal "system" fallback marker. Exactly
+			// one Warn line is emitted for the entire reject path (single-Warn
+			// invariant — see service.go HandleEvent actor-extraction block).
 			logEntry := sloghelper.FindLogEntry(logBuf.String(), "audit-append: actor missing")
 			require.NotNil(t, logEntry, "expected Warn log line for missing actor")
 			assert.Equal(t, "WARN", logEntry["level"], "missing actor must emit at WARN level")
 			assert.Equal(t, "evt-actor-missing", logEntry["event_id"], "log line must carry event_id")
 			assert.Equal(t, tt.eventType, logEntry["event_type"], "log line must carry event_type")
+			assert.Equal(t, 1, strings.Count(logBuf.String(), `"audit-append: actor missing`),
+				"reject path must emit exactly one Warn log line, not one per check")
 			assert.NotContains(t, logBuf.String(), `"system"`,
 				`fail-closed reject must not log the legacy "system" fallback marker`)
 		})

--- a/cells/auditcore/slices/auditappend/service_test.go
+++ b/cells/auditcore/slices/auditappend/service_test.go
@@ -117,7 +117,7 @@ func TestService_HandleEvent(t *testing.T) {
 			entry: outbox.Entry{
 				ID:        "evt-1",
 				EventType: "event.user.created.v1",
-				Payload:   mustJSON(map[string]any{"userId": "usr-1"}),
+				Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "adm-1"}),
 			},
 			wantChain: 1,
 		},
@@ -126,25 +126,16 @@ func TestService_HandleEvent(t *testing.T) {
 			entry: outbox.Entry{
 				ID:        "evt-2",
 				EventType: "event.session.created.v1",
-				Payload:   mustJSON(map[string]any{"sessionId": "sess-1", "userId": "usr-1"}),
+				Payload:   mustJSON(t, map[string]any{"sessionId": "sess-1", "userId": "usr-1"}),
 			},
 			wantChain: 1,
 		},
 		{
-			name: "config entry-upserted event (no userId → system actor)",
+			name: "config entry-upserted event with actorId",
 			entry: outbox.Entry{
 				ID:        "evt-3",
 				EventType: "event.config.entry-upserted.v1",
-				Payload:   mustJSON(map[string]any{"key": "app.name", "value": "v", "version": 1}),
-			},
-			wantChain: 1,
-		},
-		{
-			name: "user created event with snake_case user_id (transitional)",
-			entry: outbox.Entry{
-				ID:        "evt-4",
-				EventType: "event.user.created.v1",
-				Payload:   mustJSON(map[string]any{"user_id": "usr-2", "username": "bob"}),
+				Payload:   mustJSON(t, map[string]any{"key": "app.name", "version": 1, "actorId": "adm-1"}),
 			},
 			wantChain: 1,
 		},
@@ -173,7 +164,7 @@ func TestService_HandleEvent_ChainGrows(t *testing.T) {
 		entry := outbox.Entry{
 			ID:        "evt-" + string(rune('0'+i)),
 			EventType: "event.user.created.v1",
-			Payload:   mustJSON(map[string]any{"userId": "usr-1"}),
+			Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "adm-1"}),
 		}
 		assertAck(t, svc.HandleEvent(context.Background(), entry))
 	}
@@ -240,7 +231,7 @@ func TestService_HandleEvent_PublishError_DoesNotFailAppend(t *testing.T) {
 	entry := outbox.Entry{
 		ID:        "evt-pub-err",
 		EventType: "event.user.created.v1",
-		Payload:   mustJSON(map[string]any{"userId": "usr-1"}),
+		Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "adm-1"}),
 	}
 	result := svc.HandleEvent(context.Background(), entry)
 	assertAck(t, result)
@@ -248,9 +239,9 @@ func TestService_HandleEvent_PublishError_DoesNotFailAppend(t *testing.T) {
 }
 
 // TestService_HandleEvent_ActorExtraction covers the actor-id extractor's
-// priority: actorId (preferred) > userId (fallback) > "system" (default).
-// G.6 migrated user events from snake_case user_id to camelCase userId; G.2
-// added required actorId to all admin-write events.
+// priority on the success path: actorId (admin-write events) > userId
+// (session.* events). Missing-actor handling is covered separately in
+// TestService_HandleEvent_ActorMissing_Reject.
 func TestService_HandleEvent_ActorExtraction(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -276,12 +267,6 @@ func TestService_HandleEvent_ActorExtraction(t *testing.T) {
 			payload:     map[string]any{"key": "k", "version": 1, "actorId": "adm-99"},
 			wantActorID: "adm-99",
 		},
-		{
-			name:        "no actor field (legacy config event) → system fallback",
-			eventType:   "event.config.entry-upserted.v1",
-			payload:     map[string]any{"key": "k", "version": 1},
-			wantActorID: "system",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -289,7 +274,7 @@ func TestService_HandleEvent_ActorExtraction(t *testing.T) {
 			entry := outbox.Entry{
 				ID:        "evt-" + tt.name,
 				EventType: tt.eventType,
-				Payload:   mustJSON(tt.payload),
+				Payload:   mustJSON(t, tt.payload),
 			}
 			assertAck(t, svc.HandleEvent(context.Background(), entry))
 
@@ -297,6 +282,78 @@ func TestService_HandleEvent_ActorExtraction(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, entries, 1)
 			assert.Equal(t, tt.wantActorID, entries[0].ActorID)
+		})
+	}
+}
+
+// TestService_HandleEvent_ActorMissing_Reject locks the fail-closed contract:
+// when both actorId and userId are absent or empty, HandleEvent must return
+// DispositionReject (DLX path) wrapping a PermanentError, and the audit chain
+// must remain untouched. Producer-side schemas already declare these fields
+// as required; reaching this branch indicates upstream contract violation
+// and routing the event to DLX preserves audit traceability.
+func TestService_HandleEvent_ActorMissing_Reject(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		payload   map[string]any
+	}{
+		{
+			name:      "config event missing actorId (no userId fallback)",
+			eventType: "event.config.entry-upserted.v1",
+			payload:   map[string]any{"key": "k", "version": 1},
+		},
+		{
+			name:      "user event missing both actorId and userId",
+			eventType: "event.user.created.v1",
+			payload:   map[string]any{"username": "bob"},
+		},
+		{
+			name:      "explicit empty strings for actorId and userId",
+			eventType: "event.user.locked.v1",
+			payload:   map[string]any{"actorId": "", "userId": ""},
+		},
+		{
+			name:      "snake_case user_id is not a recognized field",
+			eventType: "event.user.created.v1",
+			payload:   map[string]any{"user_id": "usr-2", "username": "bob"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := mem.NewAuditRepository()
+			var logBuf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			svc, err := NewService(repo, testHMACKey, logger, clock.Real(),
+				WithClock(clock.Real()), WithTxManager(directRunner{}))
+			require.NoError(t, err)
+
+			entry := outbox.Entry{
+				ID:        "evt-actor-missing",
+				EventType: tt.eventType,
+				Payload:   mustJSON(t, tt.payload),
+			}
+
+			result := svc.HandleEvent(context.Background(), entry)
+			assertReject(t, result)
+
+			var permErr *outbox.PermanentError
+			require.ErrorAs(t, result.Err, &permErr,
+				"Err must wrap a PermanentError so ConsumerBase routes to DLX")
+
+			// Audit chain must NOT be polluted by rejected event.
+			assert.Equal(t, 0, svc.ChainLen(), "rejected event must not be appended to chain")
+			assert.Equal(t, 0, repo.Len(), "rejected event must not be persisted")
+
+			// Log line carries event_id / event_type as structured fields and
+			// must NOT contain the literal "system" fallback marker.
+			logEntry := sloghelper.FindLogEntry(logBuf.String(), "audit-append: actor missing")
+			require.NotNil(t, logEntry, "expected Warn log line for missing actor")
+			assert.Equal(t, "WARN", logEntry["level"], "missing actor must emit at WARN level")
+			assert.Equal(t, "evt-actor-missing", logEntry["event_id"], "log line must carry event_id")
+			assert.Equal(t, tt.eventType, logEntry["event_type"], "log line must carry event_type")
+			assert.NotContains(t, logBuf.String(), `"system"`,
+				`fail-closed reject must not log the legacy "system" fallback marker`)
 		})
 	}
 }
@@ -311,9 +368,9 @@ func (f *failingAppendRepo) Append(_ context.Context, _ *domain.AuditEntry) erro
 	return f.err
 }
 
-// TestService_HandleEvent_RepoAppendFails_Requeue covers the persistFn→repo.Append
-// failure branch (service.go:180-187): a transient persistence error must produce
-// DispositionRequeue so ConsumerBase can back off and retry.
+// TestService_HandleEvent_RepoAppendFails_Requeue covers the persistFn → repo.Append
+// failure branch: a transient persistence error must produce DispositionRequeue
+// so ConsumerBase can back off and retry.
 func TestService_HandleEvent_RepoAppendFails_Requeue(t *testing.T) {
 	sentinel := fmt.Errorf("db unavailable")
 	repo := &failingAppendRepo{AuditRepository: mem.NewAuditRepository(), err: sentinel}
@@ -325,7 +382,7 @@ func TestService_HandleEvent_RepoAppendFails_Requeue(t *testing.T) {
 	entry := outbox.Entry{
 		ID:        "evt-repo-fail",
 		EventType: "event.user.created.v1",
-		Payload:   mustJSON(map[string]any{"userId": "usr-1"}),
+		Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "adm-1"}),
 	}
 
 	result := svc.HandleEvent(context.Background(), entry)
@@ -338,7 +395,9 @@ func TestService_HandleEvent_RepoAppendFails_Requeue(t *testing.T) {
 	assert.False(t, errors.As(result.Err, &permErr), "transient persist error must NOT be PermanentError")
 }
 
-func mustJSON(v any) []byte {
-	b, _ := json.Marshal(v)
+func mustJSON(t testing.TB, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
 	return b
 }

--- a/docs/architecture/202605031900-adr-handler-vocabulary-collapse.md
+++ b/docs/architecture/202605031900-adr-handler-vocabulary-collapse.md
@@ -119,20 +119,6 @@ handler-author vocabulary. The `adapters/rabbitmq` dependency on
 `outbox.Settlement` interface). This closes the time-bounded compromise
 that was explicitly accepted in K#03.
 
-## Trade-off Q5 — actorID system fallback in auditappend
-
-`auditappend.HandleEvent` falls back to `actorID = "system"` when the event
-payload contains neither `actorId` nor `userId`. This is an explicit trade-off:
-
-- **At-least-once audit semantics take priority** — dropping an audit entry
-  because of missing actor metadata is worse than recording it under a sentinel
-- **Producer-side validation already enforces actorId** for admin-write events
-  (PR-CFG-G1 G.2: configcore + accesscore decoders reject empty actorId)
-- **Reaching the fallback path means producer regression** — the handler logs
-  at Error level so data-quality dashboards surface the regression
-
-The fallback is fail-safe, not a routine path; do not rely on it.
-
 ## Consequences
 
 - Public API surface area in `kernel/outbox` + `kernel/persistence`

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -286,7 +286,7 @@
 | B2-R-07 | **OTel tracer shutdown 无 deadline** — 现状: shutdown 无超时上限；修复: 加 ctx deadline | bug | P1/Cx1 | 🟡 | — | `adapters/otel/tracer.go:63,65` | backlog2 §3 B2-R-07 |
 | B2-R-08 | **OTel callback 需手工 unregister** — 现状: callback 注册后无自动 unregister；修复: 接 lifecycle hook | bug | P1/Cx3 | 🟡 | — | `adapters/otel/pool_collector.go:43,110` | backlog2 §3 B2-R-08 |
 | B2-R-09 | **OTel attr cache key 碰撞无上界** — 现状: attr cache 无 LRU/eviction；修复: 加 LRU + max size | bug | P1/Cx3 | 🟡 | — | `adapters/otel/metric_provider.go:84,96,101` | backlog2 §3 B2-R-09 |
-| B2-C-05 | **Auditappend actor 缺失降级不安全** — 现状: actor 缺失时静默降级；修复: fail-closed | bug | P1/Cx2 | 🟡 | 发布前安全收口 | `cells/auditcore/slices/auditappend/service.go:133` | backlog2 §4 B2-C-05 |
+| B2-C-05 | **Auditappend actor 缺失降级不安全** — 现状: actor 缺失时静默降级；修复: fail-closed | bug | P1/Cx2 | ✅ closed by fix/302 | 发布前安全收口 | `cells/auditcore/slices/auditappend/service.go` | backlog2 §4 B2-C-05 |
 | B2-C-09 | **Auditquery raw payload 直接回传** — 现状: handler 直接回传 raw payload 含敏感字段；修复: redact + slog level 区分 | bug | P1/Cx2 | 🟡 | 发布前安全收口 | `cells/auditcore/slices/auditquery/handler.go:35,42` | backlog2 §4 B2-C-09 |
 | B2-C-14 | **Hash-chain 跨重启连续性测试缺** — 现状: 缺重启场景验证；修复: 加 testcontainer 重启回归 | test | P2/Cx2 | 🟡 | — | `cells/auditcore/slices/auditappend/service_test.go:110` | backlog2 §4 B2-C-14 |
 | B2-A-20 | **OTel simple tracer propagation 不对称** — 现状: 解析 vs 注入实现不对称；修复: 统一 propagator | bug | P2/Cx2 | 🟡 | — | `runtime/observability/tracing/tracer.go:77` | backlog2 §5.3 B2-A-20 |


### PR DESCRIPTION
## Summary

- 删除 `auditappend.HandleEvent` 的 actor fallback：actorId / userId 都缺失时不再降级为字面量 `"system"` 后 Ack，改为 `outbox.Reject(NewPermanentError)` 路由到 DLX
- 删除 ADR `202605031900-adr-handler-vocabulary-collapse.md` 的 §Trade-off Q5（前提已不成立：producer schema 已强制 actorId/userId required）
- 顺手修两个 P2：`mustJSON` helper 接收 `testing.TB` 并 `require.NoError`；删 `TestService_HandleEvent_RepoAppendFails_Requeue` 注释里硬编码的 `service.go:180-187` 行号
- backlog `B2-C-05` 状态 🟡 → ✅

## Why

旧 fallback 在 actor 缺失时写入 `"system"` 然后成功 Ack，外部表现为正常但审计链丢失了真实 actor，影响合规追责（OWASP / SOC2 / GDPR 立场反对）。Producer 端 schema 已经全部 fail-closed，fallback 兜底的前提（producer 可能漏发）已经消失。

业界对标：
- Hyperledger Fabric — identity 验证失败 → INVALID，不写入 ledger
- AWS CloudTrail — `userIdentity.type=Unknown` 枚举，不用 sentinel 字符串
- Watermill / Kratos — 语义错误 → permanent error → DLQ

## Test plan

- [x] `go test ./...` 全套通过（含 archtest 65s）
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go run ./cmd/gocell validate` — 0 errors / 0 warnings
- [x] `grep -n '"system"' cells/auditcore/slices/auditappend/service.go` — 无残留
- [x] 新增 `TestService_HandleEvent_ActorMissing_Reject` 锁定 4 个缺失场景（missing / empty / snake_case alias）

ref: hyperledger/fabric — validation failure → INVALID, no ledger write
ref: ThreeDotsLabs/watermill — permanent semantic errors → poison queue
ref: aws/cloudtrail — userIdentity.type=Unknown over "system" sentinel

Refs: B2-C-05

🤖 Generated with [Claude Code](https://claude.com/claude-code)