### PR TITLE
fix(cmd/corebundle): wrap raw infra deps in setup_pg_integration_test (PR #441 sealed-marker follow-up)

### DIFF
--- a/cmd/corebundle/setup_pg_integration_test.go
+++ b/cmd/corebundle/setup_pg_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -114,27 +115,27 @@ func TestSetupEndpoints_FirstRunFlow_PG(t *testing.T) {
 		accesscore.WithInMemoryDefaults(),
 		accesscore.WithUserRepository(pgUserRepo),
 		accesscore.WithRoleRepository(pgRoleRepo),
-		accesscore.WithOutboxDeps(eb, nw),
+		accesscore.WithOutboxDeps(outbox.WrapPublisherForCell(eb), outbox.WrapWriterForCell(nw)),
 		accesscore.WithJWTIssuer(jwtIssuer),
 		accesscore.WithJWTVerifier(jwtVerifier),
-		accesscore.WithTxManager(txMgr),
+		accesscore.WithTxManager(persistence.WrapForCell(txMgr)),
 		accesscore.WithMetricsProvider(metrics.NopProvider{}),
 		accesscore.WithBootstrapAuth(bootstrapMW),
 	)
 	cc := configcore.NewConfigCore(
 		configcore.WithClock(clock.Real()),
 		configcore.WithInMemoryDefaults(),
-		configcore.WithOutboxDeps(eb, nw),
-		configcore.WithTxManager(noopTxRunner{}),
+		configcore.WithOutboxDeps(outbox.WrapPublisherForCell(eb), outbox.WrapWriterForCell(nw)),
+		configcore.WithTxManager(persistence.WrapForCell(noopTxRunner{})),
 		configcore.WithCursorCodec(configCursorCodec),
 		configcore.WithMetricsProvider(metrics.NopProvider{}),
 	)
 	auc := auditcore.NewAuditCore(
 		auditcore.WithClock(clock.Real()),
 		auditcore.WithInMemoryDefaults(),
-		auditcore.WithOutboxDeps(eb, nw),
+		auditcore.WithOutboxDeps(outbox.WrapPublisherForCell(eb), outbox.WrapWriterForCell(nw)),
 		auditcore.WithHMACKey([]byte("test-hmac-key-32-bytes-long!!!!!")),
-		auditcore.WithTxManager(noopTxRunner{}),
+		auditcore.WithTxManager(persistence.WrapForCell(noopTxRunner{})),
 		auditcore.WithCursorCodec(auditCursorCodec),
 		auditcore.WithMetricsProvider(metrics.NopProvider{}),
 	)


### PR DESCRIPTION
## Summary

`cmd/corebundle/setup_pg_integration_test.go` is `//go:build integration` and so was not type-checked during PR #441's sealed-marker rollout (round-3 commit `973691d4` changed cell public option signatures from raw infra interfaces to sealed `CellPublisher` / `CellWriter` / `CellTxManager` markers). The default `go build` / `go test ./...` path skips the integration tag, hiding the type errors at landing time.

`cmd/gocell/app::TestCheckUnconditionalSkipCI` (and 4 sibling tests) does \`packages.Load(\"./...\")\` across all build tags, so type errors in integration-tagged files surface as \`package load errors:\` and fail the unconditional-skip invariant.

This commit mirrors the wrap pattern already used in the sibling `cmd/corebundle/setup_integration_test.go` (lines 102-122 / 335-355, the non-integration variant landed during the PR #441 main rollout):

```go
// before
accesscore.WithOutboxDeps(eb, nw)
accesscore.WithTxManager(txMgr)

// after
accesscore.WithOutboxDeps(
    outbox.WrapPublisherForCell(eb), outbox.WrapWriterForCell(nw))
accesscore.WithTxManager(persistence.WrapForCell(txMgr))
```

Six call sites total (3× `WithOutboxDeps`, 3× `WithTxManager` — accesscore / configcore / auditcore × {outbox, tx}). Both wrap helpers are in the archtest `CELL-RAW-INFRA-WRAPPER-LOCATION-01` allowlist for `*_test.go` under any layer; `cmd/corebundle/*_test.go` matches.

## Why this is split out from PR #305

PR #305 originally tried to be a CI hotfix for the tools-shard SIGTERM observed across 15+ runs since 2026-05-10. Five iterations of CI changes failed to address the root cause; investigation eventually triangulated the SIGTERM to PR #445 (PR-Φ EachNode funnel) creating OOM pressure on the GHA 2-core 7GB ubuntu-latest runner — unrelated to this sealed-marker bug. The structural fix is documented in \`docs/plans/202605110830-305-archtest-verify-process-isolation.md\` (D path, K8s-style \`make verify-archtest\` process isolation).

This file's sealed-marker bug is independent and deserves its own clean PR.

## Verified locally

- [x] \`go build -tags=integration ./cmd/corebundle/...\` OK
- [x] \`go vet -tags=integration ./cmd/corebundle/...\` OK
- [x] \`go run ./cmd/gocell check unconditional-skip\` → PASS: no unconditional skips found

## Test plan

- [ ] PR Check passes (note: tools shard may still SIGTERM due to PR #445 OOM — that's the separate D-path issue, not introduced by this PR)
- [ ] \`make verify\` → unconditional-skip check passes

## ref

PR #441 round-3 sealed-marker introduction (commit \`973691d4\`); sibling test \`cmd/corebundle/setup_integration_test.go\` for canonical wrap pattern; archtest \`CELL-RAW-INFRA-WRAPPER-LOCATION-01\` allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)