### PR TITLE
docs(pr441): close F5 sealed-marker doc residuals

### DIFF
--- a/examples/todoorder/cells/ordercell/cell.go
+++ b/examples/todoorder/cells/ordercell/cell.go
@@ -65,7 +65,7 @@ func WithRepository(r domain.OrderRepository) Option {
 // AI-HARD per ADR cell-raw-infra-sealed-marker: the option signature
 // rejects raw outbox.Writer at compile time.
 //
-// ref: docs/architecture/<adr-cell-raw-infra-sealed-marker>.md
+// ref: docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md §D1
 func WithOutboxWriter(writer outbox.CellWriter) Option {
 	return func(c *OrderCell) {
 		if writer != nil {

--- a/tools/archtest/wrapper_location_test.go
+++ b/tools/archtest/wrapper_location_test.go
@@ -11,14 +11,14 @@
 // kernel/outbox.CellPublisher / CellWriter) eliminated.
 //
 // AI-rebust 评级：Medium (archtest type-aware via typeseval.SharedResolver
-// caller-package check). The sealed marker is the AI-HARD primary defense
-// (违反不可表达 — cells can no longer declare With* Options that accept raw
-// types because the type system rejects raw → CellXxx assignment without
-// the wrapper). This archtest is belt-and-suspenders that additionally pins
-// the authorized wrap-call locations, preventing a cell from importing
-// kernel/persistence and calling WrapForCell internally.
+// caller-package check). The sealed marker is the AI-HARD field/assignment
+// defense; public With* raw-parameter signatures remain syntactically
+// expressible and are guarded by CELL-RAW-INFRA-PUBLIC-OPTION-PARAM-01.
+// This archtest is the required Medium companion for wrapper call locations,
+// preventing a cell from importing kernel/persistence and calling WrapForCell
+// internally.
 //
-// ref: docs/architecture/<adr-cell-raw-infra-sealed-marker>.md §D2
+// ref: docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md §D2
 // ref: ADR 202605101800 §D6 (history; archtest scanner predecessor deleted)
 package archtest
 


### PR DESCRIPTION
Summary
- Replace remaining sealed-marker ADR placeholder refs with the concrete ADR path.
- Reword wrapper-location archtest AI-rebust note to match Hard field/assignment + Medium signature/location enforcement.

Refs: PR441-F5
ref: docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md

Test plan
- [x] rg "<adr-cell-raw-infra-sealed-marker>|belt-and-suspenders" tools/archtest/wrapper_location_test.go examples/todoorder/cells/ordercell/cell.go
- [x] go test ./examples/todoorder/cells/ordercell -count=1
- [x] go test ./tools/archtest -run TestCellRawInfraWrapperLocation01 -count=1 -timeout 2m
- [x] go -C worktrees/805-pr441-f5-residuals build ./...
- [x] go -C worktrees/805-pr441-f5-residuals test ./...
- [x] golangci-lint run ./...