### PR TITLE
feat(archtest): TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01 Hard funnel (Phase 3.5 PR-EP1)

### DIFF
--- a/tools/archtest/build_constraint_test.go
+++ b/tools/archtest/build_constraint_test.go
@@ -36,7 +36,7 @@ func findIntegrationTagViolations(rootDir string) ([]string, error) {
 		if relErr != nil {
 			rel = path
 		}
-		ok, checkErr := fileHasIntegrationTag(path)
+		ok, checkErr := fileHasExclusivelyTag(path, "integration")
 		if checkErr != nil || !ok {
 			violations = append(violations, rel)
 		}
@@ -111,33 +111,6 @@ func fileHasStricterThanIntegrationTag(path string) (bool, error) {
 	withoutAny := expr.Eval(func(_ string) bool { return false })
 	withDefaultCtx := expr.Eval(typeseval.BuildContextPredicate())
 	return !withIntegrationCtx && !withoutAny && !withDefaultCtx, nil
-}
-
-// fileHasIntegrationTag returns true iff the file carries, in its header
-// section (before the package clause and following only blank lines and other
-// comments — the only zone the Go toolchain recognizes for build constraints),
-// a //go:build line whose constraint expression:
-//  1. evaluates to true when the "integration" tag is active, AND
-//  2. evaluates to false when no tags are active (i.e., the file is not built
-//     unconditionally — it must actually be gated on the integration tag).
-//
-// A //go:build line that appears after the package clause (or after any other
-// non-comment, non-blank line) is invisible to the toolchain and therefore
-// counted as a violation, matching the semantics of `go build` / `go test`.
-//
-// Returns (false, nil) when the file lacks a //go:build line in the header.
-// Returns (false, err) when the line cannot be parsed.
-func fileHasIntegrationTag(path string) (bool, error) {
-	expr, err := typeseval.ParseBuildConstraint(path)
-	if err != nil {
-		return false, err
-	}
-	if expr == nil {
-		return false, nil
-	}
-	withIntegration := expr.Eval(func(tag string) bool { return tag == "integration" })
-	withoutAny := expr.Eval(func(_ string) bool { return false })
-	return withIntegration && !withoutAny, nil
 }
 
 // TestArchtest_AllIntegrationTestFiles_HaveIntegrationBuildTag walks the entire

--- a/tools/archtest/build_constraint_test.go
+++ b/tools/archtest/build_constraint_test.go
@@ -17,7 +17,13 @@ import (
 // findIntegrationTagViolations walks rootDir and returns the relative paths (from
 // rootDir) of every *_integration_test.go file that does NOT carry a //go:build
 // constraint expression that evaluates to true when the "integration" tag is set
-// and false when no tags are set.
+// AND false under the default toolchain context (no extra tags).
+//
+// Delegates to fileHasExclusivelyTag(path, "integration") for the per-file gate
+// — the same helper drives CI-INTEGRATION-DISCOVERY-01. PR #472 (PR-BT1) routed
+// fileHasExclusivelyTag through typeseval.BuildContextPredicate so toolchain
+// defaults (GOOS/GOARCH/cgo/unix/gc/go1.X) are honored; this avoids a latent
+// false-negative on compound directives like `//go:build integration && linux`.
 //
 // Parse failures are treated as violations (conservative / fail-closed strategy).
 func findIntegrationTagViolations(rootDir string) ([]string, error) {

--- a/tools/archtest/eval_predicate_centralization_test.go
+++ b/tools/archtest/eval_predicate_centralization_test.go
@@ -99,8 +99,14 @@ func TestEvalPredicateCentralization01(t *testing.T) {
 
 	var violations []evalPredicateViolation
 	for _, pkg := range resolver.Packages() {
-		if pkg == nil || pkg.TypesInfo == nil || pkg.Fset == nil {
-			continue
+		if pkg == nil {
+			t.Fatalf("typeseval.SharedResolver returned nil package " +
+				"(SharedResolver invariant broken)")
+		}
+		if pkg.TypesInfo == nil || pkg.Fset == nil {
+			t.Fatalf("package %q loaded without TypesInfo/Fset "+
+				"(SharedResolver misconfigured — full type info is required "+
+				"to resolve constraint.Expr.Eval callsites)", pkg.PkgPath)
 		}
 		for _, file := range pkg.Syntax {
 			rel := pkgFileRel(root, pkg, file)

--- a/tools/archtest/eval_predicate_centralization_test.go
+++ b/tools/archtest/eval_predicate_centralization_test.go
@@ -22,10 +22,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+	"github.com/ghbvf/gocell/tools/internal/fileroles"
 )
 
 const (
@@ -261,6 +263,11 @@ func isBuildContextPredicateCallee(funExpr ast.Expr, info *types.Info) bool {
 		if pkgPath, name, ok := typeseval.ResolvePackageRef(info, sel); ok {
 			return pkgPath == buildContextPredicatePkg && name == buildContextPredicateFunc
 		}
+		// info is non-nil but ResolvePackageRef declined: sel.X is not a
+		// package qualifier (e.g. method-position selector on a value with
+		// a `BuildContextPredicate` method). Decline rather than falling
+		// through to the AST-only path — that path matches any Ident named
+		// "typeseval" and would over-accept under method-position shadowing.
 		return false
 	}
 	// AST-only fallback (no info): match `typeseval.BuildContextPredicate`.
@@ -284,6 +291,13 @@ func isBuildContextPredicateCallee(funExpr ast.Expr, info *types.Info) bool {
 // (`var f = func(...) bool { return false }; expr.Eval(f)`) are NOT
 // accepted. The inline-literal-with-`false`-ident shape is the Hard
 // surface — anything else fails archtest.
+//
+// Note on `false` shadowing: Go permits redefining the predeclared
+// `false` identifier via assignment (e.g. `false := true`), but only
+// across multiple statements. The single-statement body check
+// (len(fl.Body.List) == 1) structurally rules out a shadowing pattern,
+// so `id.Name == "false"` is a complete check — there is no
+// `{ false := true; return false }` form that fits in 1 statement.
 func isAllFalseSentinelFuncLit(fl *ast.FuncLit) bool {
 	if fl == nil || fl.Body == nil {
 		return false
@@ -303,6 +317,88 @@ func isAllFalseSentinelFuncLit(fl *ast.FuncLit) bool {
 		return false
 	}
 	return id.Name == "false"
+}
+
+// TestEvalPredicateCentralizationFixtures is the "test the test" meta-test
+// for TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01 detection helpers. Each fixture
+// package under
+//
+//	tools/archtest/testdata/eval_predicate_centralization_fixtures/<case>/
+//
+// is a synthetic single-file Go package that demonstrates one canonical
+// shape (GREEN, 0 violations expected) or one violation shape (RED, the
+// expected violation line(s) listed in the table below). Loading goes
+// through typeseval.LoadPackages with full types.Info so the type-aware
+// detection paths (isConstraintExprEvalCall via ResolveMethodCall;
+// isBuildContextPredicateCallee via ResolvePackageRef) are exercised the
+// same way as the main test.
+//
+// Adding a new fixture: drop a `<case>/usage.go` file with the demonstration
+// shape and add a row to `cases` below. testdata/ is skipped by the Go
+// toolchain so fixtures never run in default builds.
+func TestEvalPredicateCentralizationFixtures(t *testing.T) {
+	t.Parallel()
+
+	root := findModuleRoot(t)
+	fixtureBase := filepath.Join(root, "tools", "archtest", "testdata",
+		"eval_predicate_centralization_fixtures")
+
+	cases := []struct {
+		dir       string
+		wantLines []int // empty / nil = GREEN; non-empty = RED with these line numbers
+	}{
+		// GREEN — Form A and Form B canonical shapes accepted.
+		{"form_a_good", nil},
+		{"form_b_good", nil},
+		// RED — hand-rolled predicate (most common drift form).
+		{"inline_predicate_red", []int{10}},
+		// RED — var binding indirection (arg is Ident, not CallExpr / FuncLit).
+		{"var_binding_red", []int{10}},
+		// RED — FuncLit body has multi-statement, fails sentinel single-stmt check.
+		{"funclit_multi_stmt_red", []int{9}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.dir, func(t *testing.T) {
+			t.Parallel()
+
+			fixtureDir := filepath.Join(fixtureBase, tc.dir)
+			pkgs, errs, err := typeseval.LoadPackages(root, false, nil,
+				"./tools/archtest/testdata/eval_predicate_centralization_fixtures/"+tc.dir)
+			require.NoError(t, err, "LoadPackages failed for fixture %s", tc.dir)
+			require.Empty(t, errs, "package load errors for fixture %s: %v", tc.dir, errs)
+			require.NotEmpty(t, pkgs, "no packages loaded for fixture %s", tc.dir)
+
+			var violations []evalPredicateViolation
+			for _, p := range pkgs {
+				for i, file := range p.Syntax {
+					if i >= len(p.GoFiles) {
+						continue
+					}
+					abs := p.GoFiles[i]
+					rel, ok := fileroles.Rel(fixtureDir, abs)
+					if !ok {
+						continue
+					}
+					violations = append(violations,
+						scanFileForEvalPredicateViolations(p.Fset, file, p.TypesInfo, rel)...)
+				}
+			}
+
+			var gotLines []int
+			for _, v := range violations {
+				gotLines = append(gotLines, v.Line)
+			}
+			sort.Ints(gotLines)
+
+			wantLines := append([]int(nil), tc.wantLines...)
+			sort.Ints(wantLines)
+
+			assert.Equal(t, wantLines, gotLines,
+				"fixture %s: violation lines mismatch (got: %+v)", tc.dir, violations)
+		})
+	}
 }
 
 // formatEvalCallee returns a short human-readable callee for violation

--- a/tools/archtest/eval_predicate_centralization_test.go
+++ b/tools/archtest/eval_predicate_centralization_test.go
@@ -1,0 +1,324 @@
+package archtest
+
+// INVARIANT: TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01
+//
+// eval_predicate_centralization_test.go — every go/build/constraint.Expr.Eval
+// callsite in tools/archtest/*_test.go (top-level package, excluding
+// internal/ subpackages) must pass either typeseval.BuildContextPredicate(...)
+// or an inline `func(_ string) bool { return false }` sentinel. Hand-written
+// tag predicates drift past go-toolchain default tag additions; this funnel
+// makes the wrong shape archtest-detectable.
+//
+// Single-rule file per ai-collab.md "archtest 文件命名" branch (single rule →
+// {rule}_test.go). Promote to {theme}_invariants_test.go if related TYPESEVAL-*
+// invariants accumulate to ≥ 3.
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+)
+
+const (
+	buildContextPredicatePkg  = "github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+	buildContextPredicateFunc = "BuildContextPredicate"
+	constraintExprPkgPath     = "go/build/constraint"
+	constraintExprEvalMethod  = "Eval"
+)
+
+// INVARIANT: TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01
+//
+// Every constraint.Expr.Eval(arg) callsite in tools/archtest/*_test.go (top-
+// level package, excluding internal/ subpackages) MUST pass either:
+//
+//	Form A — a *ast.CallExpr whose callee resolves to
+//	         tools/archtest/internal/typeseval.BuildContextPredicate
+//	         (any extraTags arguments are fine; the funnel is the call form).
+//	Form B — an inline *ast.FuncLit of shape  func(_ string) bool { return false }
+//	         — the all-false sentinel — body must be exactly one ReturnStmt
+//	         whose single result is the identifier `false`. Indirection via a
+//	         var binding (`var fn = func(...) { return false }; expr.Eval(fn)`)
+//	         is NOT accepted: the inline FuncLit shape is the Hard surface.
+//
+// Any other predicate shape — `func(tag string) bool { return tag == "X" }`,
+// a named helper, a variable identifier, a method reference, a composite
+// return expression — fails this rule.
+//
+// Why a static funnel (Hard) and not a doc convention (Soft):
+//
+//   - The toolchain-default tag set (GOOS/GOARCH/cgo/unix/gc/go1.X) drifts
+//     every release. A hand-written predicate that hard-codes "linux ||
+//     darwin || amd64 || ..." silently misses additions. BuildContextPredicate
+//     sources implicitDefaults from build.Default.ReleaseTags + a single
+//     mirror of internal/syslist, so go.mod floor bumps propagate
+//     automatically. Forcing every consumer through the call form makes the
+//     drift unreachable.
+//
+//   - The all-false sentinel is the canonical "evaluate under empty tag
+//     set" form; allowing it explicitly avoids forcing a contrived
+//     BuildContextPredicate() call where the intent is to deny every tag.
+//
+// Implementation parallels PRODUCTION-LOADER-FUNNEL-01 (ban one shape,
+// allowlist by structural exclusion) and PANIC-REGISTERED-01 (form
+// uniqueness at panic() callsite).
+//
+// AI-rebust rating: Hard. Per .claude/rules/gocell/ai-collab.md "Hard 范本"
+// — "typed function call as Hard funnel for unbounded operations": form
+// uniqueness + archtest fail-on-deviation is the highest grade reachable in
+// Go for this rule shape. The Go type system does not prevent passing
+// arbitrary func(string)bool to constraint.Expr.Eval at compile time;
+// static archtest at CI is the canonical Hard enforcement.
+//
+// Internal scope note: tools/archtest/internal/typeseval/buildtags_test.go
+// is the implementor's coverage self-test for BuildContextPredicate's flat
+// load semantics; it uses derived per-slice predicates by design and is
+// outside this rule's scope (mirroring panic_invariants excluding
+// pkg/panicregister/*_test.go from PANIC-REGISTERED-01).
+func TestEvalPredicateCentralization01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	// SharedResolver with tests=true loads *_test.go files so the rule can
+	// inspect archtest tests themselves. Pattern is scoped to ./tools/archtest/...
+	// — not the real-repo "./..." that PRODUCTION-LOADER-FUNNEL-01 polices —
+	// so this is the canonical narrow-scope archtest-self load shape, same
+	// as scanner_framework_usage_test.go.
+	resolver, err := typeseval.SharedResolver(root, true, nil, "./tools/archtest/...")
+	require.NoError(t, err, "typeseval.SharedResolver")
+
+	var violations []evalPredicateViolation
+	for _, pkg := range resolver.Packages() {
+		if pkg == nil || pkg.TypesInfo == nil || pkg.Fset == nil {
+			continue
+		}
+		for _, file := range pkg.Syntax {
+			rel := pkgFileRel(root, pkg, file)
+			// Scope: tools/archtest/*_test.go only (subpackages under
+			// tools/archtest/internal/ are out of scope — see header doc).
+			if filepath.ToSlash(filepath.Dir(rel)) != "tools/archtest" {
+				continue
+			}
+			if !strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			violations = append(violations,
+				scanFileForEvalPredicateViolations(pkg.Fset, file, pkg.TypesInfo, rel)...)
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].Rel != violations[j].Rel {
+			return violations[i].Rel < violations[j].Rel
+		}
+		return violations[i].Line < violations[j].Line
+	})
+	for _, v := range violations {
+		t.Errorf("TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01: %s:%d: "+
+			"constraint.Expr.Eval predicate must be typeseval.BuildContextPredicate(...) "+
+			"or inline func(_ string) bool { return false }; got %s. "+
+			"Reason: the toolchain-default tag set (GOOS/GOARCH/cgo/unix/gc/go1.X) "+
+			"drifts every release; hand-written predicates miss additions. Use "+
+			"typeseval.BuildContextPredicate(extraTags...) to inherit defaults.",
+			v.Rel, v.Line, v.Form)
+	}
+}
+
+// evalPredicateViolation records one TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01
+// hit for batched reporting.
+type evalPredicateViolation struct {
+	Rel  string
+	Line int
+	Form string // human-readable description of the offending shape
+}
+
+// scanFileForEvalPredicateViolations walks file's AST for calls shaped
+// `<expr>.Eval(arg)` whose receiver static type is go/build/constraint.Expr,
+// and records a violation for each call whose first argument matches neither
+// Form A (typeseval.BuildContextPredicate(...) CallExpr) nor Form B (inline
+// all-false sentinel FuncLit).
+func scanFileForEvalPredicateViolations(
+	fset *token.FileSet,
+	file *ast.File,
+	info *types.Info,
+	rel string,
+) []evalPredicateViolation {
+	var violations []evalPredicateViolation
+
+	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if !isConstraintExprEvalCall(call, info) {
+			return
+		}
+		if len(call.Args) == 0 {
+			violations = append(violations, evalPredicateViolation{
+				Rel:  rel,
+				Line: fset.Position(call.Pos()).Line,
+				Form: "<no arguments>",
+			})
+			return
+		}
+		arg := call.Args[0]
+
+		// Form A: arg is a CallExpr whose callee resolves to
+		// typeseval.BuildContextPredicate.
+		if argCall, ok := arg.(*ast.CallExpr); ok {
+			if isBuildContextPredicateCallee(argCall.Fun, info) {
+				return
+			}
+			violations = append(violations, evalPredicateViolation{
+				Rel:  rel,
+				Line: fset.Position(call.Pos()).Line,
+				Form: "CallExpr with non-canonical callee " + formatEvalCallee(argCall.Fun),
+			})
+			return
+		}
+
+		// Form B: arg is an inline FuncLit shaped func(_ string) bool { return false }.
+		if fl, ok := arg.(*ast.FuncLit); ok {
+			if isAllFalseSentinelFuncLit(fl) {
+				return
+			}
+			violations = append(violations, evalPredicateViolation{
+				Rel:  rel,
+				Line: fset.Position(call.Pos()).Line,
+				Form: "FuncLit with non-canonical body (not `return false` single-stmt)",
+			})
+			return
+		}
+
+		// Any other shape (Ident, SelectorExpr, etc.) — including indirection
+		// through a var-bound predicate — is a violation. The inline FuncLit
+		// requirement is what makes Form B Hard.
+		violations = append(violations, evalPredicateViolation{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Form: "non-CallExpr/non-FuncLit predicate argument (var binding / Ident / SelectorExpr not allowed)",
+		})
+	})
+
+	return violations
+}
+
+// isConstraintExprEvalCall reports whether call is `<expr>.Eval(...)` where
+// the resolved method is go/build/constraint.Expr.Eval. Uses types.Info
+// Selections (via typeseval.ResolveMethodCall) to recover the method's owning
+// package and name. When info is nil (fixture / partial type info) the
+// detection falls through to false — this is fail-closed for the
+// caller-visible direction (we never over-flag a non-constraint Eval; the
+// archtest may under-detect on missing type info, which manifests as the
+// load failing earlier via require.NoError).
+func isConstraintExprEvalCall(call *ast.CallExpr, info *types.Info) bool {
+	if info == nil {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil {
+		return false
+	}
+	if sel.Sel.Name != constraintExprEvalMethod {
+		return false
+	}
+	fn, ok := typeseval.ResolveMethodCall(info, sel)
+	if !ok {
+		return false
+	}
+	if fn.Pkg() == nil {
+		return false
+	}
+	return fn.Pkg().Path() == constraintExprPkgPath && fn.Name() == constraintExprEvalMethod
+}
+
+// isBuildContextPredicateCallee reports whether funExpr refers to
+// typeseval.BuildContextPredicate. Uses types.Info via
+// typeseval.ResolvePackageRef (handles both qualified `typeseval.X` and
+// dot-imported bare `X` forms); falls back to AST-only `typeseval.X`
+// selector matching when info is nil. Mirrors panic_invariants_test.go::
+// isApprovedCallee structure.
+func isBuildContextPredicateCallee(funExpr ast.Expr, info *types.Info) bool {
+	sel, ok := funExpr.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil {
+		// Bare Ident is also possible under dot-import; ResolvePackageRef
+		// handles both *ast.SelectorExpr and *ast.Ident.
+		if info != nil {
+			if pkgPath, name, ok := typeseval.ResolvePackageRef(info, funExpr); ok {
+				return pkgPath == buildContextPredicatePkg && name == buildContextPredicateFunc
+			}
+		}
+		return false
+	}
+	if sel.Sel.Name != buildContextPredicateFunc {
+		return false
+	}
+	if info != nil {
+		if pkgPath, name, ok := typeseval.ResolvePackageRef(info, sel); ok {
+			return pkgPath == buildContextPredicatePkg && name == buildContextPredicateFunc
+		}
+		return false
+	}
+	// AST-only fallback (no info): match `typeseval.BuildContextPredicate`.
+	xIdent, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return xIdent.Name == "typeseval"
+}
+
+// isAllFalseSentinelFuncLit reports whether fl is exactly:
+//
+//	func(<any-ident>) bool { return false }
+//
+// — body has exactly 1 statement, that statement is a ReturnStmt with
+// exactly 1 result, and the result is the *ast.Ident `false`. Parameter
+// and result types are not re-checked: the constraint.Expr.Eval signature
+// already constrains them to func(string)bool at the type system.
+//
+// Equivalent forms like `return !true`, `return 0 == 1`, or a var binding
+// (`var f = func(...) bool { return false }; expr.Eval(f)`) are NOT
+// accepted. The inline-literal-with-`false`-ident shape is the Hard
+// surface — anything else fails archtest.
+func isAllFalseSentinelFuncLit(fl *ast.FuncLit) bool {
+	if fl == nil || fl.Body == nil {
+		return false
+	}
+	if len(fl.Body.List) != 1 {
+		return false
+	}
+	ret, ok := fl.Body.List[0].(*ast.ReturnStmt)
+	if !ok {
+		return false
+	}
+	if len(ret.Results) != 1 {
+		return false
+	}
+	id, ok := ret.Results[0].(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return id.Name == "false"
+}
+
+// formatEvalCallee returns a short human-readable callee for violation
+// messages. Mirrors panic_invariants_test.go::formatCallee.
+func formatEvalCallee(funExpr ast.Expr) string {
+	switch fun := funExpr.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		if fun.Sel == nil {
+			return "<unknown>"
+		}
+		if xIdent, ok := fun.X.(*ast.Ident); ok {
+			return xIdent.Name + "." + fun.Sel.Name
+		}
+		return "?." + fun.Sel.Name
+	}
+	return "<unknown>"
+}

--- a/tools/archtest/scanner_framework_usage_test.go
+++ b/tools/archtest/scanner_framework_usage_test.go
@@ -108,8 +108,14 @@ func TestScannerFrameworkUsage01(t *testing.T) {
 
 	var diags []scanner.Diagnostic
 	for _, pkg := range resolver.Packages() {
+		if pkg == nil {
+			t.Fatalf("typeseval.SharedResolver returned nil package " +
+				"(SharedResolver invariant broken)")
+		}
 		if pkg.TypesInfo == nil || pkg.Fset == nil {
-			continue
+			t.Fatalf("package %q loaded without TypesInfo/Fset "+
+				"(SharedResolver misconfigured — full type info is required "+
+				"for forbiddenWalkRefs/forbiddenAstListTypeAssertions)", pkg.PkgPath)
 		}
 		for _, file := range pkg.Syntax {
 			rel := pkgFileRel(root, pkg, file)

--- a/tools/archtest/testdata/eval_predicate_centralization_fixtures/form_a_good/usage.go
+++ b/tools/archtest/testdata/eval_predicate_centralization_fixtures/form_a_good/usage.go
@@ -1,0 +1,14 @@
+// Package form_a_good — Form A (typeseval.BuildContextPredicate CallExpr) is
+// the canonical accepted shape; 0 violations expected.
+package form_a_good
+
+import (
+	"go/build/constraint"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+)
+
+func _example(e constraint.Expr) {
+	_ = e.Eval(typeseval.BuildContextPredicate())
+	_ = e.Eval(typeseval.BuildContextPredicate("integration"))
+}

--- a/tools/archtest/testdata/eval_predicate_centralization_fixtures/form_b_good/usage.go
+++ b/tools/archtest/testdata/eval_predicate_centralization_fixtures/form_b_good/usage.go
@@ -1,0 +1,9 @@
+// Package form_b_good — Form B (inline `func(_ string) bool { return false }`
+// all-false sentinel) is the canonical accepted shape; 0 violations expected.
+package form_b_good
+
+import "go/build/constraint"
+
+func _example(e constraint.Expr) {
+	_ = e.Eval(func(_ string) bool { return false })
+}

--- a/tools/archtest/testdata/eval_predicate_centralization_fixtures/funclit_multi_stmt_red/usage.go
+++ b/tools/archtest/testdata/eval_predicate_centralization_fixtures/funclit_multi_stmt_red/usage.go
@@ -1,0 +1,13 @@
+// Package funclit_multi_stmt_red — FuncLit body has more than 1 statement,
+// failing the isAllFalseSentinelFuncLit single-ReturnStmt check;
+// 1 violation expected at line 9.
+package funclit_multi_stmt_red
+
+import "go/build/constraint"
+
+func _example(e constraint.Expr) {
+	_ = e.Eval(func(_ string) bool {
+		_ = 0
+		return false
+	})
+}

--- a/tools/archtest/testdata/eval_predicate_centralization_fixtures/inline_predicate_red/usage.go
+++ b/tools/archtest/testdata/eval_predicate_centralization_fixtures/inline_predicate_red/usage.go
@@ -1,0 +1,11 @@
+// Package inline_predicate_red — inline hand-rolled `func(tag string) bool
+// { return tag == "X" }` predicate; 1 violation expected at line 9.
+package inline_predicate_red
+
+import "go/build/constraint"
+
+func _example(e constraint.Expr) {
+	// Hand-rolled predicate hard-codes a single tag; drifts when toolchain
+	// adds defaults. Detection must flag.
+	_ = e.Eval(func(tag string) bool { return tag == "X" })
+}

--- a/tools/archtest/testdata/eval_predicate_centralization_fixtures/inline_predicate_red/usage.go
+++ b/tools/archtest/testdata/eval_predicate_centralization_fixtures/inline_predicate_red/usage.go
@@ -1,5 +1,5 @@
 // Package inline_predicate_red — inline hand-rolled `func(tag string) bool
-// { return tag == "X" }` predicate; 1 violation expected at line 9.
+// { return tag == "X" }` predicate; 1 violation expected at line 10.
 package inline_predicate_red
 
 import "go/build/constraint"

--- a/tools/archtest/testdata/eval_predicate_centralization_fixtures/var_binding_red/usage.go
+++ b/tools/archtest/testdata/eval_predicate_centralization_fixtures/var_binding_red/usage.go
@@ -1,0 +1,11 @@
+// Package var_binding_red — var binding indirection (`var p = func(...) { ... };
+// expr.Eval(p)`) bypasses inline-FuncLit requirement; 1 violation expected at
+// the call site (Eval arg is *ast.Ident, not CallExpr or FuncLit).
+package var_binding_red
+
+import "go/build/constraint"
+
+func _example(e constraint.Expr) {
+	p := func(_ string) bool { return false }
+	_ = e.Eval(p)
+}


### PR DESCRIPTION
## Summary

- Adds `tools/archtest/eval_predicate_centralization_test.go` — static archtest enforcing **TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01**: every `go/build/constraint.Expr.Eval(arg)` callsite in `tools/archtest/*_test.go` must use either `typeseval.BuildContextPredicate(...)` (Form A) or inline `func(_ string) bool { return false }` (Form B); any other shape fails archtest.
- Closes a PR #472 (PR-BT1) refactor drift in `build_constraint_test.go`: the `fileHasIntegrationTag` inline predicate `func(tag string) bool { return tag == "integration" }` was missed when its twin `fileHasExclusivelyTag(path, tag)` upgraded to `BuildContextPredicate`. Latent bug: `//go:build integration && linux` was mis-reported as not-integration. Resolved by collapsing `fileHasIntegrationTag` into `fileHasExclusivelyTag(path, "integration")` (net −25 LOC).
- **AI-rebust: Hard** — form uniqueness + archtest fail-on-deviation, per `.claude/rules/gocell/ai-collab.md` "Hard 范本". Lifts the helper from near-Hard (PR #472 baseline) to Hard.

## Why a static funnel (Hard) vs. doc convention (Soft)

- Toolchain default tag set (`GOOS / GOARCH / cgo / unix / gc / go1.X`) drifts every release. A hand-written predicate that hard-codes `linux || darwin || amd64 || ...` silently misses additions.
- `typeseval.BuildContextPredicate` sources `implicitDefaults` from `build.Default.ReleaseTags` + a single `internal/syslist` mirror; `go.mod` floor bumps propagate automatically. Routing every consumer through the call form makes the drift surface unreachable.
- The all-false sentinel `func(_ string) bool { return false }` is the canonical "evaluate under empty tag set" form — allowing it avoids forcing a contrived `BuildContextPredicate()` call where the intent is to deny every tag.

## Detection design

- `scanner.EachInSubtree[ast.CallExpr]` + `types.Info`-based receiver type resolution.
- `typeseval.ResolveMethodCall(info, sel)` resolves the `Eval` method's owning package to `go/build/constraint` (interface method via `info.Selections.Obj()`).
- `typeseval.ResolvePackageRef(info, expr)` resolves the `BuildContextPredicate` callee (handles qualified `typeseval.X` and dot-imported bare `X`).
- Form B requires inline `*ast.FuncLit` with exactly 1 `ReturnStmt` whose single result is `*ast.Ident{Name: "false"}`. Var-binding indirection (`var fn = func(...) bool { return false }; expr.Eval(fn)`) is rejected — inline-literal-with-`false`-ident is the Hard surface, mirroring `PANIC-REGISTERED-01`.
- Scope: `tools/archtest/*_test.go` top-level only. `tools/archtest/internal/typeseval/buildtags_test.go` is the implementor's own coverage self-test and intentionally uses derived per-slice predicates (mirror of `panic_invariants` excluding `pkg/panicregister/*_test.go` from `PANIC-REGISTERED-01`).

## Compatibility

No production code changes. Two archtest source files touched. Functions removed: `fileHasIntegrationTag` (twin of `fileHasExclusivelyTag(path, "integration")`).

## Test plan

- [x] `go build ./...` — green
- [x] `go build -tags=integration ./...` — green
- [x] `go test ./tools/archtest/...` — green (all 315 tests across 16 shards)
- [x] `bash hack/verify-archtest.sh` — green (16-shard process-isolated)
- [x] `golangci-lint run ./tools/archtest/...` — 0 issues
- [x] **TDD RED phase verified**: archtest correctly catches `build_constraint_test.go:138` before the drift fix
- [x] **GREEN phase**: archtest + `BUILD-CONSTRAINT-INTEGRATION-TAG-01` + `CI-INTEGRATION-DISCOVERY-01` all pass after fix

## Refs

- `TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01` (cap-02 line 85, docs/backlog.md)
- Phase 3.5 PR-EP1 in `docs/plans/202605112000-036-archtest-governance-rollout-plan.md`
- ref: `golang/go src/go/build/build.go` `(*Context).eval` (centralization parallel)
- ref: `tools/archtest/panic_invariants_test.go::isApprovedCallee` (Hard funnel pattern)
- ref: `tools/archtest/production_loader_funnel_test.go` (meta-archtest structure)