### PR TITLE
Refactor ContractSpec funnel validation and test coverage

### DIFF
--- a/kernel/contractspec/doc.go
+++ b/kernel/contractspec/doc.go
@@ -26,8 +26,11 @@
 //     endpoints (health probes, devtools catalog, etc.); the only legitimate
 //     construction path for ContractSpec values in runtime/ HTTP infra code.
 //  3. kernel/contractspec.NewEventDerivation — tracing/observability projections
-//     of already-validated event metadata; the canonical path for eventrouter
-//     contract tracing decorators.
+//     of already-validated event metadata; returns (ContractSpec, error) with
+//     Validate() embedded inside the funnel. Closed to a single caller
+//     (runtime/eventrouter/contract_tracing_subscriber.go) by archtest
+//     NO-MANUAL-CONTRACTSPEC-LITERAL-01; no other production file may invoke
+//     this funnel.
 //
 // Three archtest gates enforce this invariant:
 //

--- a/kernel/contractspec/doc.go
+++ b/kernel/contractspec/doc.go
@@ -27,10 +27,12 @@
 //     construction path for ContractSpec values in runtime/ HTTP infra code.
 //  3. kernel/contractspec.NewEventDerivation — tracing/observability projections
 //     of already-validated event metadata; returns (ContractSpec, error) with
-//     Validate() embedded inside the funnel. Closed to a single caller
-//     (runtime/eventrouter/contract_tracing_subscriber.go) by archtest
-//     NO-MANUAL-CONTRACTSPEC-LITERAL-01; no other production file may invoke
-//     this funnel.
+//     Validate() embedded inside the funnel (content invariant: Hard). Closed
+//     to a single caller (runtime/eventrouter/contract_tracing_subscriber.go)
+//     via path-string allowlist in archtest NO-MANUAL-CONTRACTSPEC-LITERAL-01
+//     plus a drift-guard test verifying the allowlisted file still exists
+//     (caller invariant: Medium per ai-collab.md taxonomy). No other production
+//     file may invoke this funnel.
 //
 // Three archtest gates enforce this invariant:
 //

--- a/kernel/contractspec/framework.go
+++ b/kernel/contractspec/framework.go
@@ -1,6 +1,7 @@
 package contractspec
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/ghbvf/gocell/kernel/cellvocab"
@@ -53,14 +54,24 @@ func NewFrameworkHTTP(id, method, path string) ContractSpec {
 // new specs through this path; the source metadata must already pass
 // upstream validation (typically outbox.Subscription.Validate()).
 //
+// Validation is enforced at construction time: the funnel runs
+// ContractSpec.Validate() before returning and wraps any failure as a
+// derivation error. Callers MUST handle the returned error — content
+// invariants are funnel-owned, not caller discipline.
+//
 // Inputs are primitives (not outbox.Subscription) so kernel/contractspec
 // stays independent of kernel/outbox; the eventrouter tracing decorator is
-// the canonical caller.
-func NewEventDerivation(id string, kind cellvocab.ContractKind, transport, topic string) ContractSpec {
-	return ContractSpec{
+// the canonical caller, enforced by archtest
+// NO-MANUAL-CONTRACTSPEC-LITERAL-01 (single-file caller allowlist).
+func NewEventDerivation(id string, kind cellvocab.ContractKind, transport, topic string) (ContractSpec, error) {
+	spec := ContractSpec{
 		ID:        id,
 		Kind:      kind,
 		Transport: transport,
 		Topic:     topic,
 	}
+	if err := spec.Validate(); err != nil {
+		return ContractSpec{}, fmt.Errorf("contractspec: NewEventDerivation: %w", err)
+	}
+	return spec, nil
 }

--- a/kernel/contractspec/framework_test.go
+++ b/kernel/contractspec/framework_test.go
@@ -1,6 +1,7 @@
 package contractspec_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -8,77 +9,112 @@ import (
 	"github.com/ghbvf/gocell/kernel/contractspec"
 )
 
+// assertSpecEqual reports whether got and want match on every public
+// ContractSpec field. Per-field comparison preserves "which field drifted"
+// readability when a test fails; the helper exists so callers stay below the
+// cognitive-complexity ceiling enforced by go-standards.md (≤15).
+//
+// Sonar / gocyclo accounts for the inline ifs against this helper rather
+// than the caller test function — keeping table-driven test bodies trivial.
+func assertSpecEqual(t *testing.T, got, want contractspec.ContractSpec) {
+	t.Helper()
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.Kind != want.Kind {
+		t.Errorf("Kind = %q, want %q", got.Kind, want.Kind)
+	}
+	if got.Transport != want.Transport {
+		t.Errorf("Transport = %q, want %q", got.Transport, want.Transport)
+	}
+	if got.Method != want.Method {
+		t.Errorf("Method = %q, want %q", got.Method, want.Method)
+	}
+	if got.Path != want.Path {
+		t.Errorf("Path = %q, want %q", got.Path, want.Path)
+	}
+	if got.Topic != want.Topic {
+		t.Errorf("Topic = %q, want %q", got.Topic, want.Topic)
+	}
+	if len(got.Clients) != len(want.Clients) {
+		t.Errorf("Clients length = %d, want %d", len(got.Clients), len(want.Clients))
+	}
+}
+
 // TestNewFrameworkHTTP verifies that NewFrameworkHTTP produces a ContractSpec
 // with the correct field values for each input combination, and that the
-// resulting spec passes Validate() for the valid case.
+// resulting spec passes Validate(). The bad-prefix panic path is covered
+// separately by TestNewFrameworkHTTP_BadPrefixPanics.
 func TestNewFrameworkHTTP(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name      string
-		id        string
-		method    string
-		path      string
-		wantValid bool
+		name   string
+		id     string
+		method string
+		path   string
+		want   contractspec.ContractSpec
 	}{
 		{
-			name:      "valid health livez",
-			id:        "http.framework.health.livez.v1",
-			method:    "GET",
-			path:      "/healthz",
-			wantValid: true,
+			name:   "valid health livez",
+			id:     "http.framework.health.livez.v1",
+			method: "GET",
+			path:   "/healthz",
+			want: contractspec.ContractSpec{
+				ID:        "http.framework.health.livez.v1",
+				Kind:      cellvocab.ContractHTTP,
+				Transport: "http",
+				Method:    "GET",
+				Path:      "/healthz",
+			},
 		},
 		{
-			name:      "valid metrics endpoint",
-			id:        "http.framework.health.metrics.v1",
-			method:    "GET",
-			path:      "/metrics",
-			wantValid: true,
+			name:   "valid metrics endpoint",
+			id:     "http.framework.health.metrics.v1",
+			method: "GET",
+			path:   "/metrics",
+			want: contractspec.ContractSpec{
+				ID:        "http.framework.health.metrics.v1",
+				Kind:      cellvocab.ContractHTTP,
+				Transport: "http",
+				Method:    "GET",
+				Path:      "/metrics",
+			},
 		},
 		{
-			name:      "valid devtools catalog",
-			id:        "http.framework.devtools.catalog.v1",
-			method:    "GET",
-			path:      "/api/v1/devtools/catalog",
-			wantValid: true,
+			name:   "valid devtools catalog",
+			id:     "http.framework.devtools.catalog.v1",
+			method: "GET",
+			path:   "/api/v1/devtools/catalog",
+			want: contractspec.ContractSpec{
+				ID:        "http.framework.devtools.catalog.v1",
+				Kind:      cellvocab.ContractHTTP,
+				Transport: "http",
+				Method:    "GET",
+				Path:      "/api/v1/devtools/catalog",
+			},
 		},
 		{
-			name:      "POST method",
-			id:        "http.framework.test.post.v1",
-			method:    "POST",
-			path:      "/api/v1/test",
-			wantValid: true,
+			name:   "POST method",
+			id:     "http.framework.test.post.v1",
+			method: "POST",
+			path:   "/api/v1/test",
+			want: contractspec.ContractSpec{
+				ID:        "http.framework.test.post.v1",
+				Kind:      cellvocab.ContractHTTP,
+				Transport: "http",
+				Method:    "POST",
+				Path:      "/api/v1/test",
+			},
 		},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			spec := contractspec.NewFrameworkHTTP(tc.id, tc.method, tc.path)
-
-			if spec.ID != tc.id {
-				t.Errorf("ID = %q, want %q", spec.ID, tc.id)
-			}
-			if spec.Kind != cellvocab.ContractHTTP {
-				t.Errorf("Kind = %q, want %q", spec.Kind, cellvocab.ContractHTTP)
-			}
-			if spec.Transport != "http" {
-				t.Errorf("Transport = %q, want %q", spec.Transport, "http")
-			}
-			if spec.Method != tc.method {
-				t.Errorf("Method = %q, want %q", spec.Method, tc.method)
-			}
-			if spec.Path != tc.path {
-				t.Errorf("Path = %q, want %q", spec.Path, tc.path)
-			}
-			// Topic must be zero for HTTP specs.
-			if spec.Topic != "" {
-				t.Errorf("Topic = %q, want empty for http kind", spec.Topic)
-			}
-
-			if tc.wantValid {
-				if err := spec.Validate(); err != nil {
-					t.Errorf("Validate() unexpected error: %v", err)
-				}
+			got := contractspec.NewFrameworkHTTP(tc.id, tc.method, tc.path)
+			assertSpecEqual(t, got, tc.want)
+			if err := got.Validate(); err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
 			}
 		})
 	}
@@ -120,9 +156,9 @@ func TestNewFrameworkHTTP_BadPrefixPanics(t *testing.T) {
 	}
 }
 
-// TestNewEventDerivation verifies that NewEventDerivation produces a
-// ContractSpec with the correct field values for each input combination, and
-// that the resulting spec passes Validate() for a valid event kind + topic.
+// TestNewEventDerivation covers the funnel's success path: a valid event /
+// projection spec should be returned with no error and match the expected
+// shape. The bad-input path is covered by TestNewEventDerivation_InvalidPanics.
 func TestNewEventDerivation(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -131,7 +167,7 @@ func TestNewEventDerivation(t *testing.T) {
 		kind      cellvocab.ContractKind
 		transport string
 		topic     string
-		wantValid bool
+		want      contractspec.ContractSpec
 	}{
 		{
 			name:      "valid amqp event",
@@ -139,7 +175,12 @@ func TestNewEventDerivation(t *testing.T) {
 			kind:      cellvocab.ContractEvent,
 			transport: "amqp",
 			topic:     "session.created.v1",
-			wantValid: true,
+			want: contractspec.ContractSpec{
+				ID:        "event.session.created.v1",
+				Kind:      cellvocab.ContractEvent,
+				Transport: "amqp",
+				Topic:     "session.created.v1",
+			},
 		},
 		{
 			name:      "valid internal event",
@@ -147,51 +188,102 @@ func TestNewEventDerivation(t *testing.T) {
 			kind:      cellvocab.ContractEvent,
 			transport: "internal",
 			topic:     "config.entry-upserted.v1",
-			wantValid: true,
+			want: contractspec.ContractSpec{
+				ID:        "event.config.entry-upserted.v1",
+				Kind:      cellvocab.ContractEvent,
+				Transport: "internal",
+				Topic:     "config.entry-upserted.v1",
+			},
 		},
 		{
-			name:      "projection kind — no method or path",
+			name:      "valid projection — no topic required by validator",
 			id:        "projection.session.view.v1",
 			kind:      cellvocab.ContractProjection,
 			transport: "internal",
 			topic:     "",
-			wantValid: false, // projection kind skips event validation; topic empty is fine
+			want: contractspec.ContractSpec{
+				ID:        "projection.session.view.v1",
+				Kind:      cellvocab.ContractProjection,
+				Transport: "internal",
+				Topic:     "",
+			},
 		},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			spec := contractspec.NewEventDerivation(tc.id, tc.kind, tc.transport, tc.topic)
+			got, err := contractspec.NewEventDerivation(tc.id, tc.kind, tc.transport, tc.topic)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertSpecEqual(t, got, tc.want)
+		})
+	}
+}
 
-			if spec.ID != tc.id {
-				t.Errorf("ID = %q, want %q", spec.ID, tc.id)
+// TestNewEventDerivation_InvalidPanics verifies the funnel rejects malformed
+// inputs by returning a wrapped error (NOT panic — content invariant lives
+// in spec.Validate(), not in a panic guard). Each case targets a distinct
+// validation path.
+func TestNewEventDerivation_Invalid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		id        string
+		kind      cellvocab.ContractKind
+		transport string
+		topic     string
+		wantMsg   string
+	}{
+		{
+			name:      "empty id",
+			id:        "",
+			kind:      cellvocab.ContractEvent,
+			transport: "amqp",
+			topic:     "session.created.v1",
+			wantMsg:   "ID must not be empty",
+		},
+		{
+			name:      "event kind missing topic",
+			id:        "event.session.created.v1",
+			kind:      cellvocab.ContractEvent,
+			transport: "amqp",
+			topic:     "",
+			wantMsg:   "event kind requires Topic",
+		},
+		{
+			name:      "unrecognized kind",
+			id:        "garbage.kind.v1",
+			kind:      cellvocab.ContractKind("garbage"),
+			transport: "amqp",
+			topic:     "garbage.topic",
+			wantMsg:   "not recognized",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := contractspec.NewEventDerivation(tc.id, tc.kind, tc.transport, tc.topic)
+			if err == nil {
+				t.Fatalf("expected error, got nil (spec=%+v)", got)
 			}
-			if spec.Kind != tc.kind {
-				t.Errorf("Kind = %q, want %q", spec.Kind, tc.kind)
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error message = %q, want substring %q", err.Error(), tc.wantMsg)
 			}
-			if spec.Transport != tc.transport {
-				t.Errorf("Transport = %q, want %q", spec.Transport, tc.transport)
+			if !strings.Contains(err.Error(), "NewEventDerivation") {
+				t.Errorf("error message = %q, want funnel context %q", err.Error(), "NewEventDerivation")
 			}
-			if spec.Topic != tc.topic {
-				t.Errorf("Topic = %q, want %q", spec.Topic, tc.topic)
+			// Returned spec must be zero on error (fail-closed contract).
+			// ContractSpec contains a slice so == is not available; check ID
+			// emptiness as the canonical zero-value witness.
+			if got.ID != "" || got.Kind != "" || got.Transport != "" || got.Topic != "" {
+				t.Errorf("spec on error = %+v, want zero value", got)
 			}
-			// Method and Path must be zero for event derivations.
-			if spec.Method != "" {
-				t.Errorf("Method = %q, want empty for event derivation", spec.Method)
-			}
-			if spec.Path != "" {
-				t.Errorf("Path = %q, want empty for event derivation", spec.Path)
-			}
-			// Clients must be nil for event derivations.
-			if len(spec.Clients) != 0 {
-				t.Errorf("Clients = %v, want empty for event derivation", spec.Clients)
-			}
-
-			if tc.wantValid {
-				if err := spec.Validate(); err != nil {
-					t.Errorf("Validate() unexpected error: %v", err)
-				}
+			// errors.Is contract: underlying validator error is wrapped via %w.
+			if errors.Unwrap(err) == nil {
+				t.Errorf("error is not wrapping a cause; expected %%w chain")
 			}
 		})
 	}

--- a/kernel/contractspec/framework_test.go
+++ b/kernel/contractspec/framework_test.go
@@ -158,7 +158,7 @@ func TestNewFrameworkHTTP_BadPrefixPanics(t *testing.T) {
 
 // TestNewEventDerivation covers the funnel's success path: a valid event /
 // projection spec should be returned with no error and match the expected
-// shape. The bad-input path is covered by TestNewEventDerivation_InvalidPanics.
+// shape. The bad-input path is covered by TestNewEventDerivation_Invalid.
 func TestNewEventDerivation(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -222,7 +222,7 @@ func TestNewEventDerivation(t *testing.T) {
 	}
 }
 
-// TestNewEventDerivation_InvalidPanics verifies the funnel rejects malformed
+// TestNewEventDerivation_Invalid verifies the funnel rejects malformed
 // inputs by returning a wrapped error (NOT panic — content invariant lives
 // in spec.Validate(), not in a panic guard). Each case targets a distinct
 // validation path.
@@ -276,11 +276,9 @@ func TestNewEventDerivation_Invalid(t *testing.T) {
 				t.Errorf("error message = %q, want funnel context %q", err.Error(), "NewEventDerivation")
 			}
 			// Returned spec must be zero on error (fail-closed contract).
-			// ContractSpec contains a slice so == is not available; check ID
-			// emptiness as the canonical zero-value witness.
-			if got.ID != "" || got.Kind != "" || got.Transport != "" || got.Topic != "" {
-				t.Errorf("spec on error = %+v, want zero value", got)
-			}
+			// assertSpecEqual checks every field including Method/Path/Clients,
+			// guarding against future leaks on the error path.
+			assertSpecEqual(t, got, contractspec.ContractSpec{})
 			// errors.Is contract: underlying validator error is wrapped via %w.
 			if errors.Unwrap(err) == nil {
 				t.Errorf("error is not wrapping a cause; expected %%w chain")

--- a/kernel/contractspec/spec.go
+++ b/kernel/contractspec/spec.go
@@ -13,27 +13,14 @@ import (
 //   - runtime/eventbus / kernel/cell.Registry.Subscribe (event subscription)
 //   - tracing span attributes (gocell.contract.id / kind / transport)
 //
-// Cells MUST NOT construct ContractSpec literals. The valid construction
-// sites are:
-//   - generated/contracts/**/spec_gen.go (private `var spec`) — business contracts
-//   - kernel/contractspec.NewFrameworkHTTP — runtime-owned HTTP infra
-//     (health probes, devtools catalog); see framework.go
-//   - kernel/contractspec.NewEventDerivation — tracing/observability
-//     projections of already-validated event metadata; see framework.go
-//
-// Subscription / route mounting for business contracts goes through the
-// generated NewSubscription / NewHandler adapters in generated/contracts/**.
-// Composite literal under cells/, examples/*/cells/, and runtime/ is
-// forbidden by archtest NO-MANUAL-CONTRACTSPEC-LITERAL-01.
-//
-// Three archtest gates enforce this invariant:
-//   - CELLS-NO-CONTRACTSPEC-IMPORT-01
-//   - NO-MANUAL-CONTRACTSPEC-LITERAL-01
-//   - EVENT-SUBSCRIPTION-CONTRACTGEN-COVERAGE-01
-//
 // The zero value is invalid — callers must populate ID / Kind / Transport
 // and the kind-specific fields, then rely on auth.Mount / wrapper.HTTPHandler
 // to Validate() before registration.
+//
+// Construction-site catalog and archtest enforcement gates are documented
+// in this package's doc.go (single source). Composite literal under cells/,
+// examples/*/cells/, and runtime/ is forbidden by archtest
+// NO-MANUAL-CONTRACTSPEC-LITERAL-01.
 //
 // ref: k8s.io/apimachinery — lightweight value types shared across layers
 // without runtime parsing dependencies.

--- a/runtime/eventrouter/contract_tracing_subscriber.go
+++ b/runtime/eventrouter/contract_tracing_subscriber.go
@@ -66,14 +66,16 @@ func (s *contractTracingSubscriber) Subscribe(
 	// Derivation funnel — projects already-validated Subscription metadata
 	// into ContractSpec shape for the tracer; not a declaration. The only
 	// legitimate runtime/ derivation path per NO-MANUAL-CONTRACTSPEC-LITERAL-01.
-	spec := contractspec.NewEventDerivation(
+	// Validate() runs inside the funnel, so a derived-spec error surfaces here
+	// with a wrapped context.
+	spec, err := contractspec.NewEventDerivation(
 		sub.ContractID,
 		cellvocab.ContractKind(sub.ContractKind),
 		sub.ContractTransport,
 		sub.Topic,
 	)
-	if err := spec.Validate(); err != nil {
-		return fmt.Errorf("eventrouter: contract tracing subscriber: derived spec invalid: %w", err)
+	if err != nil {
+		return fmt.Errorf("eventrouter: contract tracing subscriber: %w", err)
 	}
 	wrapped, err := wrapper.WrapSubscriber(s.tracer, spec, handler)
 	if err != nil {

--- a/tools/archtest/no_manual_contractspec_literal_test.go
+++ b/tools/archtest/no_manual_contractspec_literal_test.go
@@ -12,8 +12,16 @@
 // Hand-written production code under cells/, examples/**/cells/, and runtime/
 // must NOT define ContractSpec literals. Framework-owned HTTP infra (health
 // probes, devtools catalog) and event-tracing derivations use the typed
-// funnels in kernel/contractspec/framework.go — these are the only legitimate
-// runtime-side construction paths and have no allowlist exception.
+// funnels in kernel/contractspec/framework.go.
+//
+// The two funnels enforce different invariants matched to their semantics:
+//
+//   - NewFrameworkHTTP — open caller (any runtime/ HTTP infra may construct
+//     a framework spec) but closed content (FrameworkHTTPIDPrefix panic at
+//     construction time).
+//   - NewEventDerivation — closed caller (single-file allowlist enforced by
+//     this archtest: only runtime/eventrouter/contract_tracing_subscriber.go)
+//     and closed content (Validate() embedded inside the funnel).
 //
 // Exclusions:
 //   - generated/contracts/**/*_gen.go  — the authoritative home for business contracts
@@ -24,8 +32,9 @@
 //
 // AI-rebust: Hard — composite literal under cells/ + examples/ + runtime/
 // is unrepresentable (archtest fails CI); the typed funnels are the only
-// form that survives. Aligns with the "typed function call as Hard funnel
-// for unbounded operations" charter pattern (PANIC-REGISTERED-01 same path).
+// form that survives, and NewEventDerivation is further locked to a single
+// caller. Aligns with the "typed function call as Hard funnel for unbounded
+// operations" charter pattern (PANIC-REGISTERED-01 same path).
 //
 // ref: docs/plans/202605011500-029-master-roadmap.md K#PR4 W3 + G-04
 // ref: kernel/contractspec/spec.go construction-site catalog
@@ -38,6 +47,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -46,6 +56,12 @@ import (
 	"github.com/ghbvf/gocell/kernel/contractspec"
 	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
+
+// eventDerivationAllowedCaller is the single legitimate caller of
+// contractspec.NewEventDerivation. Any other production file invoking the
+// funnel fails NO-MANUAL-CONTRACTSPEC-LITERAL-01; renaming or relocating the
+// caller requires updating this constant in lockstep.
+const eventDerivationAllowedCaller = "runtime/eventrouter/contract_tracing_subscriber.go"
 
 // TestNO_MANUAL_CONTRACTSPEC_LITERAL_01 scans production .go files under
 // cells/, examples/*/cells/, and runtime/ for contractspec.ContractSpec{…}
@@ -72,14 +88,15 @@ func TestNO_MANUAL_CONTRACTSPEC_LITERAL_01(t *testing.T) {
 }
 
 // TestCONTRACTSPEC_FRAMEWORK_BUILDERS_EXIST_01 locks the typed funnel API.
-// If kernel/contractspec.NewFrameworkHTTP or NewEventDerivation are renamed
-// or removed, this test fails to compile — signaling that the Hard gate has
-// lost its only legitimate runtime-side construction path and must be
-// revisited (either redirect callers to a new funnel or update this archtest).
+// If kernel/contractspec.NewFrameworkHTTP or NewEventDerivation are renamed,
+// removed, or their signatures change, this test fails to compile — signaling
+// that the Hard gate has lost its only legitimate runtime-side construction
+// path and must be revisited (either redirect callers to a new funnel or
+// update this archtest).
 func TestCONTRACTSPEC_FRAMEWORK_BUILDERS_EXIST_01(t *testing.T) {
 	t.Parallel()
 	_ = contractspec.NewFrameworkHTTP("http.framework.test.v1", "GET", "/test")
-	_ = contractspec.NewEventDerivation("event.test.v1", cellvocab.ContractEvent, "amqp", "test.topic")
+	_, _ = contractspec.NewEventDerivation("event.test.v1", cellvocab.ContractEvent, "amqp", "test.topic")
 }
 
 // collectContractSpecScanFiles returns production .go files to scan.
@@ -101,7 +118,7 @@ func collectContractSpecScanFiles(t *testing.T, root string) []string {
 	}
 	seen := make(map[string]struct{}, len(cellFiles)+len(runtimeFiles))
 	out := make([]string, 0, len(cellFiles)+len(runtimeFiles))
-	for _, f := range append(append([]string{}, cellFiles...), runtimeFiles...) {
+	for _, f := range slices.Concat(cellFiles, runtimeFiles) {
 		if strings.HasSuffix(f, "_gen.go") {
 			continue
 		}
@@ -136,6 +153,75 @@ func TestNO_MANUAL_CONTRACTSPEC_LITERAL_01_NegativeFixture(t *testing.T) {
 		if !strings.Contains(v, "ContractSpec") {
 			t.Errorf("violation message should mention ContractSpec: %q", v)
 		}
+	}
+}
+
+// TestNO_MANUAL_CONTRACTSPEC_LITERAL_01_NegativeFixture_NewEventDerivation
+// verifies that the scanner reports a violation when a file outside the
+// single-caller allowlist invokes contractspec.NewEventDerivation. A symmetric
+// positive case verifies the allowlist file (rel ==
+// eventDerivationAllowedCaller) is silent.
+func TestNO_MANUAL_CONTRACTSPEC_LITERAL_01_NegativeFixture_NewEventDerivation(t *testing.T) {
+	t.Parallel()
+	src := `package p
+import (
+	"github.com/ghbvf/gocell/kernel/cellvocab"
+	"github.com/ghbvf/gocell/kernel/contractspec"
+)
+func init() {
+	_, _ = contractspec.NewEventDerivation("event.bad.v1", cellvocab.ContractEvent, "amqp", "bad.topic")
+}
+`
+	tmp, err := os.CreateTemp(t.TempDir(), "newevent_test_*.go")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := tmp.WriteString(src); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp: %v", err)
+	}
+
+	// Forbidden caller — simulated path outside the allowlist.
+	forbiddenRel := "runtime/fake/handler.go"
+	violations := scanForContractSpecLiterals(token.NewFileSet(), tmp.Name(), forbiddenRel)
+	if len(violations) == 0 {
+		t.Errorf("expected at least 1 violation for non-allowlist caller of NewEventDerivation, got 0")
+	}
+	for _, v := range violations {
+		if !strings.Contains(v, "NewEventDerivation") {
+			t.Errorf("violation message should mention NewEventDerivation: %q", v)
+		}
+		if !strings.Contains(v, eventDerivationAllowedCaller) {
+			t.Errorf("violation message should mention allowed caller %q: %q",
+				eventDerivationAllowedCaller, v)
+		}
+	}
+
+	// Allowed caller — simulated path matching the allowlist constant.
+	allowedViolations := scanForContractSpecLiterals(token.NewFileSet(), tmp.Name(), eventDerivationAllowedCaller)
+	if len(allowedViolations) != 0 {
+		t.Errorf("expected 0 violations for allowlist caller, got %d: %v",
+			len(allowedViolations), allowedViolations)
+	}
+}
+
+// TestEventDerivationAllowedCallerFileExists guards the caller-allowlist
+// constant against drift. If runtime/eventrouter/contract_tracing_subscriber.go
+// is renamed or moved without updating eventDerivationAllowedCaller, every
+// future production caller silently becomes allowed (the allowlist matches
+// nothing). This test fails fast so the constant must be updated in lockstep.
+func TestEventDerivationAllowedCallerFileExists(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	target := filepath.Join(root, filepath.FromSlash(eventDerivationAllowedCaller))
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("eventDerivationAllowedCaller %q not found: %v", eventDerivationAllowedCaller, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("eventDerivationAllowedCaller %q is a directory, want file", eventDerivationAllowedCaller)
 	}
 }
 
@@ -182,6 +268,8 @@ func init() {
 // scanForContractSpecLiterals AST-scans f for:
 //  1. contractspec.ContractSpec{…} composite literals
 //  2. contractspec.EventSpec(…) call expressions
+//  3. contractspec.NewEventDerivation(…) call expressions outside the
+//     single-file allowlist (eventDerivationAllowedCaller)
 //
 // where "contractspec" is the local alias for kernel/contractspec.
 func scanForContractSpecLiterals(fset *token.FileSet, path, rel string) []string {
@@ -216,21 +304,36 @@ func scanForContractSpecLiterals(fset *token.FileSet, path, rel string) []string
 			rel, pos.Line, alias,
 		))
 	})
-	// Match contractspec.EventSpec(…) call expressions.
+	// Match contractspec.EventSpec(…) and contractspec.NewEventDerivation(…)
+	// call expressions. EventSpec is forbidden globally outside generated/;
+	// NewEventDerivation is forbidden outside eventDerivationAllowedCaller.
 	scanner.EachInSubtree[ast.CallExpr](f, func(node *ast.CallExpr) {
 		sel, ok := node.Fun.(*ast.SelectorExpr)
 		if !ok {
 			return
 		}
 		ident, ok2 := sel.X.(*ast.Ident)
-		if !ok2 || ident.Name != alias || sel.Sel.Name != "EventSpec" {
+		if !ok2 || ident.Name != alias {
 			return
 		}
-		pos := fset.Position(node.Pos())
-		violations = append(violations, fmt.Sprintf(
-			"%s:%d: manual %s.EventSpec() call — must be in generated/contracts/**/*_gen.go only",
-			rel, pos.Line, alias,
-		))
+		switch sel.Sel.Name {
+		case "EventSpec":
+			pos := fset.Position(node.Pos())
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: manual %s.EventSpec() call — must be in generated/contracts/**/*_gen.go only",
+				rel, pos.Line, alias,
+			))
+		case "NewEventDerivation":
+			if rel == eventDerivationAllowedCaller {
+				return
+			}
+			pos := fset.Position(node.Pos())
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: %s.NewEventDerivation() call — only %s may invoke this funnel "+
+					"(derivation funnel is closed by caller-allowlist; see archtest doc)",
+				rel, pos.Line, alias, eventDerivationAllowedCaller,
+			))
+		}
 	})
 	return violations
 }

--- a/tools/archtest/no_manual_contractspec_literal_test.go
+++ b/tools/archtest/no_manual_contractspec_literal_test.go
@@ -30,10 +30,20 @@
 //   - kernel/contractspec/** itself    — defines ContractSpec and the typed funnels
 //   - *_test.go                        — test helpers may reference specs for assertions
 //
-// AI-rebust: Hard — composite literal under cells/ + examples/ + runtime/
-// is unrepresentable (archtest fails CI); the typed funnels are the only
-// form that survives, and NewEventDerivation is further locked to a single
-// caller. Aligns with the "typed function call as Hard funnel for unbounded
+// AI-rebust:
+//   - Composite-literal ban: Hard — `contractspec.ContractSpec{…}` under
+//     cells/ + examples/ + runtime/ is unrepresentable (archtest fails CI),
+//     the typed funnels are the only surviving form.
+//   - NewEventDerivation content invariant: Hard — Validate() is embedded
+//     inside the funnel, so a malformed spec cannot be returned.
+//   - NewEventDerivation caller allowlist: Medium — enforced by path-string
+//     match against eventDerivationAllowedCaller. The drift guard
+//     TestEventDerivationAllowedCallerFileExists upgrades safety by failing
+//     CI if the constant goes stale, but the gate remains string-anchored
+//     per ai-collab.md taxonomy. Upgrade path to Hard would be a typed
+//     authority token only the eventrouter package can mint.
+//
+// Aligns with the "typed function call as Hard funnel for unbounded
 // operations" charter pattern (PANIC-REGISTERED-01 same path).
 //
 // ref: docs/plans/202605011500-029-master-roadmap.md K#PR4 W3 + G-04
@@ -272,6 +282,11 @@ func init() {
 //     single-file allowlist (eventDerivationAllowedCaller)
 //
 // where "contractspec" is the local alias for kernel/contractspec.
+//
+// rel MUST be slash-separated (apply filepath.ToSlash at the caller). The
+// NewEventDerivation allowlist compares rel against eventDerivationAllowedCaller
+// by exact string match; an OS-native path on Windows would silently miss the
+// allowlist and report false violations.
 func scanForContractSpecLiterals(fset *token.FileSet, path, rel string) []string {
 	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR refactors the `ContractSpec` construction funnels to enforce validation at construction time rather than deferring to callers, and significantly expands test coverage for error paths. The changes strengthen the fail-closed contract for event derivation specs while improving test maintainability through helper functions.

## Key Changes

- **NewEventDerivation signature change**: Changed return type from `ContractSpec` to `(ContractSpec, error)`. The funnel now runs `Validate()` internally and wraps validation failures, making content invariants funnel-owned rather than caller-owned.

- **Validation enforcement**: `NewEventDerivation` now returns a zero-valued `ContractSpec` on any error, implementing a fail-closed contract. Callers must handle the returned error.

- **Test helper extraction**: Added `assertSpecEqual()` helper function to reduce cognitive complexity in table-driven tests and improve readability when field mismatches occur.

- **Expanded test coverage**: 
  - Refactored `TestNewFrameworkHTTP` to use expected `ContractSpec` values in test cases instead of boolean flags
  - Added new `TestNewEventDerivation_Invalid` test covering three distinct validation failure paths (empty ID, missing topic for event kind, unrecognized kind)
  - Tests now verify error wrapping via `errors.Unwrap()` and funnel context in error messages

- **Archtest enhancements**:
  - Added single-file caller allowlist for `NewEventDerivation` (only `runtime/eventrouter/contract_tracing_subscriber.go` may invoke)
  - Added `TestNO_MANUAL_CONTRACTSPEC_LITERAL_01_NegativeFixture_NewEventDerivation` to verify the allowlist is enforced
  - Added `TestEventDerivationAllowedCallerFileExists` to guard against drift in the allowlist constant
  - Updated `scanForContractSpecLiterals` to detect and report `NewEventDerivation` calls outside the allowlist

- **Caller updates**: Updated `contract_tracing_subscriber.go` to handle the new `(ContractSpec, error)` return and removed redundant `Validate()` call (now inside the funnel).

- **Documentation**: Updated `doc.go` and code comments to clarify that `NewEventDerivation` is closed to a single caller and that validation is embedded in the funnel.

## Notable Implementation Details

- The fail-closed contract (returning zero `ContractSpec` on error) ensures callers cannot accidentally use partially-constructed specs
- Error messages include funnel context ("NewEventDerivation") to aid debugging
- The archtest allowlist uses a constant (`eventDerivationAllowedCaller`) that is verified to exist, preventing silent allowlist drift
- Test cases now express expected output as concrete `ContractSpec` values rather than boolean flags, making test intent clearer

https://claude.ai/code/session_01Ewgd6scqQryZuCCq6pcdPw