### PR TITLE
feat(cellgen): CELLGEN-LITERAL-FUNNEL-02 type-system Hard funnel

### DIFF
--- a/tools/codegen/cellgen/builder.go
+++ b/tools/codegen/cellgen/builder.go
@@ -82,7 +82,7 @@ func BuildCellSpec(p *metadata.ProjectMeta, cellID string, bundle markergen.Wire
 		CellID:               cell.ID,
 		ConsumerGroupDefault: cell.ID,
 		SourceFile:           cell.File,
-		MetadataLiteral:      cell,
+		RenderedMetaLiteral:  renderCellMetaLiteral(cell),
 	}
 
 	listenerPrefix := make(map[string]string, len(bundle.Listeners))

--- a/tools/codegen/cellgen/builder_test.go
+++ b/tools/codegen/cellgen/builder_test.go
@@ -601,3 +601,42 @@ func TestBuildCellSpec_SubscribeValidExportedIdentAccepted(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildCellSpec_RenderedMetaLiteralPopulated locks CELLGEN-LITERAL-FUNNEL-02:
+// CellGenSpec exposes a pre-rendered Go literal string (RenderedMetaLiteral), not
+// the live *metadata.CellMeta pointer. The Hard property — cell.tmpl cannot
+// hand-enumerate CellMeta fields because the struct is not reachable from the
+// spec — depends on BuildCellSpec populating this field deterministically from
+// renderCellMetaLiteral(cell). A regression that re-exposes *CellMeta or leaves
+// the field blank breaks this test before reaching the template.
+func TestBuildCellSpec_RenderedMetaLiteralPopulated(t *testing.T) {
+	t.Parallel()
+	cell := &metadata.CellMeta{
+		ID:               "demo",
+		Type:             "core",
+		ConsistencyLevel: "L1",
+		Dir:              "demo",
+		File:             "cells/demo/cell.yaml",
+		GoStructName:     metadata.MustNewGoIdentifier("Demo"),
+	}
+	p := fixtureProject(cell, nil, nil)
+
+	spec, err := BuildCellSpec(p, "demo", markergen.WireBundle{})
+	if err != nil {
+		t.Fatalf("BuildCellSpec: %v", err)
+	}
+	got := spec.RenderedMetaLiteral
+	if got == "" {
+		t.Fatalf("RenderedMetaLiteral is empty; BuildCellSpec must pre-render the literal")
+	}
+	if !strings.HasPrefix(got, "&metadata.CellMeta{") {
+		t.Errorf("RenderedMetaLiteral should start with '&metadata.CellMeta{', got: %q", got)
+	}
+	// Equivalence with renderCellMetaLiteral(cell) — locks BuildCellSpec to
+	// the canonical renderer (not a hand-built string), which is the Hard
+	// guarantee: any divergence here means BuildCellSpec stopped using the
+	// reflect-driven funnel.
+	if want := renderCellMetaLiteral(cell); got != want {
+		t.Errorf("RenderedMetaLiteral diverges from renderCellMetaLiteral output\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/tools/codegen/cellgen/generator.go
+++ b/tools/codegen/cellgen/generator.go
@@ -25,14 +25,12 @@ var templateFS embed.FS
 // tools/codegen/templates/header.tmpl without embedding it in the
 // cellgen subpackage (which would break future sibling subpackages
 // contractgen / markergen that also need the shared header).
-var templates = func() *template.Template {
-	t := template.Must(codegen.SharedTemplates.Clone())
-	// Register renderCellMetaLiteral before ParseFS so cell.tmpl can use it.
-	// The FuncMap must be registered before template parsing or ParseFS will
-	// return an error for unknown function references.
-	t = t.Funcs(template.FuncMap{"renderCellMetaLiteral": RenderCellMetaLiteral})
-	return template.Must(t.ParseFS(templateFS, "templates/*.tmpl"))
-}()
+//
+// CELLGEN-LITERAL-FUNNEL-02: no FuncMap. The CellMeta literal is pre-rendered
+// into CellGenSpec.RenderedMetaLiteral at build time so cell.tmpl emits the
+// string directly without invoking any template function (and therefore
+// cannot reach the *metadata.CellMeta struct to hand-enumerate fields).
+var templates = template.Must(template.Must(codegen.SharedTemplates.Clone()).ParseFS(templateFS, "templates/*.tmpl"))
 
 // Options controls a Generate run.
 type Options struct {

--- a/tools/codegen/cellgen/generator.go
+++ b/tools/codegen/cellgen/generator.go
@@ -30,7 +30,12 @@ var templateFS embed.FS
 // into CellGenSpec.RenderedMetaLiteral at build time so cell.tmpl emits the
 // string directly without invoking any template function (and therefore
 // cannot reach the *metadata.CellMeta struct to hand-enumerate fields).
-var templates = template.Must(template.Must(codegen.SharedTemplates.Clone()).ParseFS(templateFS, "templates/*.tmpl"))
+var templates = mustParseTemplates()
+
+func mustParseTemplates() *template.Template {
+	cloned := template.Must(codegen.SharedTemplates.Clone())
+	return template.Must(cloned.ParseFS(templateFS, "templates/*.tmpl"))
+}
 
 // Options controls a Generate run.
 type Options struct {

--- a/tools/codegen/cellgen/generator_test.go
+++ b/tools/codegen/cellgen/generator_test.go
@@ -26,12 +26,21 @@ var updateGolden = flag.Bool("update", false, "regenerate golden files")
 // initInternal hook, captureErr closure, mux.Route subPath block).
 func TestRenderCell_HappyPath_OneListenerOneSubRoute(t *testing.T) {
 	t.Parallel()
+	// Exercise the full builder → renderer integration on the happy path so
+	// that any drift in renderCellMetaLiteral's output format (e.g. gofumpt
+	// alignment changes) surfaces here as a template-render failure rather
+	// than being silently masked by a "&metadata.CellMeta{}" stub.
 	spec := &CellGenSpec{
 		Package:              "demo",
 		StructName:           "Demo",
 		CellID:               "demo",
 		ConsumerGroupDefault: "demo",
-		RenderedMetaLiteral:  "&metadata.CellMeta{}",
+		RenderedMetaLiteral: renderCellMetaLiteral(&metadata.CellMeta{
+			ID:               "demo",
+			Type:             "core",
+			ConsistencyLevel: "L1",
+			GoStructName:     metadata.MustNewGoIdentifier("Demo"),
+		}),
 		RouteGroups: []RouteGroupGenSpec{{
 			ListenerConst: "cell.PrimaryListener",
 			Prefix:        "/api/v1",

--- a/tools/codegen/cellgen/generator_test.go
+++ b/tools/codegen/cellgen/generator_test.go
@@ -31,6 +31,7 @@ func TestRenderCell_HappyPath_OneListenerOneSubRoute(t *testing.T) {
 		StructName:           "Demo",
 		CellID:               "demo",
 		ConsumerGroupDefault: "demo",
+		RenderedMetaLiteral:  "&metadata.CellMeta{}",
 		RouteGroups: []RouteGroupGenSpec{{
 			ListenerConst: "cell.PrimaryListener",
 			Prefix:        "/api/v1",
@@ -77,7 +78,7 @@ func TestRenderCell_HappyPath_OneListenerOneSubRoute(t *testing.T) {
 func TestRenderCell_WithSubscriptionsAddsImportsAndNewSubscription(t *testing.T) {
 	t.Parallel()
 	spec := &CellGenSpec{
-		Package: "demo", StructName: "Demo", CellID: "demo", ConsumerGroupDefault: "demo",
+		Package: "demo", StructName: "Demo", CellID: "demo", ConsumerGroupDefault: "demo", RenderedMetaLiteral: "&metadata.CellMeta{}",
 		Subscriptions: []SubscriptionGenSpec{{
 			ContractID:          "event.foo.bar.v1",
 			Transport:           "amqp",
@@ -115,7 +116,7 @@ func TestRenderCell_WithSubscriptionsAddsImportsAndNewSubscription(t *testing.T)
 func TestRenderCell_EmptySubPathDirectMount(t *testing.T) {
 	t.Parallel()
 	spec := &CellGenSpec{
-		Package: "demo", StructName: "Demo", CellID: "demo", ConsumerGroupDefault: "demo",
+		Package: "demo", StructName: "Demo", CellID: "demo", ConsumerGroupDefault: "demo", RenderedMetaLiteral: "&metadata.CellMeta{}",
 		RouteGroups: []RouteGroupGenSpec{{
 			ListenerConst: "cell.InternalListener",
 			Prefix:        "/internal/v1/admin",
@@ -448,7 +449,7 @@ func mustContain(t *testing.T, haystack, needle string) {
 func TestCellGen_SubscribeBlockUsesGeneratedPackage(t *testing.T) {
 	t.Parallel()
 	spec := &CellGenSpec{
-		Package: "demo", StructName: "Demo", CellID: "demo", ConsumerGroupDefault: "demo",
+		Package: "demo", StructName: "Demo", CellID: "demo", ConsumerGroupDefault: "demo", RenderedMetaLiteral: "&metadata.CellMeta{}",
 		Subscriptions: []SubscriptionGenSpec{{
 			ContractID:          "event.order-created.v1",
 			SliceID:             "ordercreate",

--- a/tools/codegen/cellgen/literal_printer.go
+++ b/tools/codegen/cellgen/literal_printer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/panicregister"
 )
 
-// RenderCellMetaLiteral renders a *metadata.CellMeta value as a Go source
+// renderCellMetaLiteral renders a *metadata.CellMeta value as a Go source
 // literal string of the form `&metadata.CellMeta{...}`. The output is valid
 // Go that survives goimports+gofumpt without structural change.
 //
@@ -28,7 +28,12 @@ import (
 //
 // Unknown reflect.Kind panics with panicregister.Approved (fail-loud so future
 // CellMeta field additions surface immediately at development time).
-func RenderCellMetaLiteral(cell *metadata.CellMeta) string {
+//
+// CELLGEN-LITERAL-FUNNEL-02: unexported. The sole caller is BuildCellSpec,
+// which pre-renders this string into CellGenSpec.RenderedMetaLiteral so the
+// template never accesses *metadata.CellMeta. Out-of-package callers cannot
+// re-introduce a funcMap path that would let cell.tmpl hand-enumerate fields.
+func renderCellMetaLiteral(cell *metadata.CellMeta) string {
 	if cell == nil {
 		return "&metadata.CellMeta{}"
 	}

--- a/tools/codegen/cellgen/literal_printer_test.go
+++ b/tools/codegen/cellgen/literal_printer_test.go
@@ -76,13 +76,13 @@ func TestRenderCellMetaLiteral_AccesscoreGreenBaseline(t *testing.T) {
 		// Dir and File have yaml:"-" — must be omitted
 	}
 
-	raw := RenderCellMetaLiteral(cell)
+	raw := renderCellMetaLiteral(cell)
 	got := fmtLiteral(t, raw)
 	// Normalize the golden through fmtLiteral as well so test expectations
 	// do not depend on hand-crafted gofumpt alignment.
 	want := fmtLiteral(t, accesscoreGolden)
 	if got != want {
-		t.Errorf("RenderCellMetaLiteral() GREEN baseline mismatch")
+		t.Errorf("renderCellMetaLiteral() GREEN baseline mismatch")
 		gotLines := strings.Split(got, "\n")
 		wantLines := strings.Split(want, "\n")
 		for i := 0; i < len(gotLines) || i < len(wantLines); i++ {
@@ -243,13 +243,13 @@ func TestRenderCellMetaLiteral_TableDriven(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			raw := RenderCellMetaLiteral(tc.input)
+			raw := renderCellMetaLiteral(tc.input)
 			got := fmtLiteral(t, raw)
 			// Normalize tc.want through fmtLiteral as well so test expectations
 			// don't need hand-crafted alignment.
 			want := fmtLiteral(t, tc.want)
 			if got != want {
-				t.Errorf("RenderCellMetaLiteral(%s) mismatch\ngot:\n%s\nwant:\n%s", tc.name, got, want)
+				t.Errorf("renderCellMetaLiteral(%s) mismatch\ngot:\n%s\nwant:\n%s", tc.name, got, want)
 				gotLines := strings.Split(got, "\n")
 				wantLines := strings.Split(want, "\n")
 				for i := 0; i < len(gotLines) || i < len(wantLines); i++ {

--- a/tools/codegen/cellgen/literal_printer_test.go
+++ b/tools/codegen/cellgen/literal_printer_test.go
@@ -109,6 +109,14 @@ func TestRenderCellMetaLiteral_TableDriven(t *testing.T) {
 		want string
 	}{
 		{
+			// nil guard is part of the public contract documented on
+			// renderCellMetaLiteral; defending it here prevents a regression
+			// that would surface only at code generation time.
+			name:  "nil cell returns empty literal",
+			input: nil,
+			want:  "&metadata.CellMeta{}",
+		},
+		{
 			name: "empty verify smoke slice omitted",
 			input: &metadata.CellMeta{
 				ID:               "testcell",

--- a/tools/codegen/cellgen/spec.go
+++ b/tools/codegen/cellgen/spec.go
@@ -12,8 +12,6 @@
 // should use Generate.
 package cellgen
 
-import "github.com/ghbvf/gocell/kernel/metadata"
-
 // CellGenSpec is the rendering input for cell.tmpl. It is the projection of
 // CellMeta + child slices that the template needs to emit cell_gen.go.
 //
@@ -34,14 +32,17 @@ type CellGenSpec struct {
 	// Rendered into the file header as "// Source: <SourceFile>" so that
 	// readers of the generated file can locate the authoritative YAML.
 	SourceFile string
-	// MetadataLiteral is the parsed CellMeta passed directly to cell.tmpl.
-	// The template renders it via the renderCellMetaLiteral template func
-	// (reflect-driven literal printer) into the package-scope
-	// `var cellMeta = &metadata.CellMeta{...}` block. Using *CellMeta
-	// directly — instead of a hand-written projection struct — closes the
-	// pipeline field-coverage gap: CellMeta yaml-tag field additions are
-	// automatically emitted by the reflect renderer without any builder change.
-	MetadataLiteral *metadata.CellMeta
+	// RenderedMetaLiteral is the pre-rendered Go source literal for the cell's
+	// metadata, of the form "&metadata.CellMeta{...}". BuildCellSpec calls
+	// renderCellMetaLiteral(cell) at spec build time and assigns the result;
+	// cell.tmpl emits the string verbatim into
+	// `var cellMeta = {{ .RenderedMetaLiteral }}`.
+	//
+	// CELLGEN-LITERAL-FUNNEL-02 Hard 来源（type system 最高档）：cell.tmpl
+	// 拿不到 *metadata.CellMeta（CellGenSpec 不暴露），手写字段枚举
+	// **不可表达** — 没有数据源可访问。任何想绕过 reflect-driven renderer
+	// 的尝试必须修改此字段类型（公开 API 变更，review 必然可见）。
+	RenderedMetaLiteral string
 	// RouteGroups holds the listener-aggregated route mounts. Each entry
 	// emits one reg.RouteGroup() call.
 	RouteGroups []RouteGroupGenSpec

--- a/tools/codegen/cellgen/spec.go
+++ b/tools/codegen/cellgen/spec.go
@@ -38,10 +38,12 @@ type CellGenSpec struct {
 	// cell.tmpl emits the string verbatim into
 	// `var cellMeta = {{ .RenderedMetaLiteral }}`.
 	//
-	// CELLGEN-LITERAL-FUNNEL-02 Hard 来源（type system 最高档）：cell.tmpl
-	// 拿不到 *metadata.CellMeta（CellGenSpec 不暴露），手写字段枚举
-	// **不可表达** — 没有数据源可访问。任何想绕过 reflect-driven renderer
-	// 的尝试必须修改此字段类型（公开 API 变更，review 必然可见）。
+	// CELLGEN-LITERAL-FUNNEL-02 Hard source (highest type-system grade):
+	// cell.tmpl cannot reach *metadata.CellMeta because CellGenSpec does not
+	// expose it. Hand-enumeration of CellMeta fields in the template is
+	// structurally unreachable — there is no data source to access. Any
+	// attempt to bypass the reflect-driven renderer must change the type of
+	// this field, which is a public API change and therefore review-visible.
 	RenderedMetaLiteral string
 	// RouteGroups holds the listener-aggregated route mounts. Each entry
 	// emits one reg.RouteGroup() call.

--- a/tools/codegen/cellgen/templates/cell.tmpl
+++ b/tools/codegen/cellgen/templates/cell.tmpl
@@ -19,7 +19,7 @@ var _ cell.Cell = (*{{.StructName}})(nil)
 // loadCellMetadata returns the package-scope pointer; cell.go's constructor
 // passes it to cell.MustNewBaseCell which deep-copies the value so callers
 // cannot mutate the generated literal.
-var cellMeta = {{ renderCellMetaLiteral .MetadataLiteral }}
+var cellMeta = {{ .RenderedMetaLiteral }}
 
 func loadCellMetadata() *metadata.CellMeta { return cellMeta }
 


### PR DESCRIPTION
## Summary

- `CellGenSpec.MetadataLiteral *metadata.CellMeta` → `RenderedMetaLiteral string` — the template now receives a pre-rendered Go literal string instead of the live struct pointer
- `BuildCellSpec` calls `renderCellMetaLiteral(cell)` at spec build time; `cell.tmpl` simplifies to `var cellMeta = {{ .RenderedMetaLiteral }}` (no funcMap)
- `RenderCellMetaLiteral` → `renderCellMetaLiteral` (unexported; zero out-of-package callers per repo grep)

## Hard 来源 (type system 最高档)

`cell.tmpl` cannot reach `*metadata.CellMeta` because `CellGenSpec` does not expose it. Hand-enumeration of CellMeta fields in the template becomes **structurally unreachable** — no data source exists to access. Any attempt to re-introduce funcMap-based field access requires modifying `CellGenSpec`'s public field type — a change that is **review-visible** and cannot be silently introduced.

This is one rung above the typed-funnel pattern (`PANIC-REGISTERED-01` / `NO-MANUAL-CONTRACTSPEC-LITERAL-01`), which depend on archtest enforcement; here the Hard property comes from the type system directly, so no archtest is added (per backlog spec).

## Refs

- `CELLGEN-LITERAL-FUNNEL-02` (PR-MD1 follow-up, closes silent-drift loophole left by PR #477)
- Plan: `docs/plans/202605112000-036-archtest-governance-rollout-plan.md` §3.8

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./tools/codegen/cellgen/...\` (incl. new \`TestBuildCellSpec_RenderedMetaLiteralPopulated\`)
- [x] \`go test ./tools/archtest/...\` (all archtest invariants GREEN, ~118s)
- [x] \`bash hack/verify-codegen-cell.sh\` → 0-diff regeneration
- [x] \`golangci-lint run ./...\` → 0 issues
- [x] \`go build -tags=integration ./...\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)