### PR TITLE
feat(observability): PR-2 PR-PROM-HARDEN-3 (B2-A-22/23/24 + Hard funnel)

### DIFF
--- a/.github/workflows/test-race.yml
+++ b/.github/workflows/test-race.yml
@@ -58,11 +58,15 @@ jobs:
         #   - kernel/ ... runtime/ ... pkg/ ... — repository's own goroutines
         #   - tools/archtest/internal/typeseval/ — process-wide SharedResolver
         #     cache (sync.Mutex + map) covered by TestSharedResolver_ConcurrentInit
+        #   - adapters/prometheus/ — MetricProvider RWMutex + HookObserver
+        #     concurrent OnHookEvent (B2-A-24 unit-level race coverage; no
+        #     Docker dependency, fits the fast lane budget)
         run: |
           go test -race -count=1 -timeout 10m \
             ./kernel/... \
             ./runtime/... \
             ./pkg/... \
+            ./adapters/prometheus/... \
             ./tools/archtest/internal/typeseval/...
 
   race-pg-integration:

--- a/adapters/prometheus/cell_label.go
+++ b/adapters/prometheus/cell_label.go
@@ -1,0 +1,33 @@
+// INVARIANT: PROM-CELL-LABEL-FUNNEL-01 — every CounterVec/HistogramVec
+// WithLabelValues call in this package that emits a cell_id must route the
+// cell id through promCellLabel.
+
+package prometheus
+
+import (
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/panicregister"
+)
+
+// promCellLabel is the single typed-function funnel for writing a cell id
+// into a Prometheus label. Upstream invariants (schemas/cell.schema.json
+// id.pattern, governance rule FMT-C1) already guarantee every cell id in
+// flight matches metadata.CellIDPattern; this function is an A-class
+// unreachable defense in the sense of the panic taxonomy
+// (docs/architecture/202604270030-architectural-panic-whitelist.md §4.1).
+// The archtest PROM-CELL-LABEL-FUNNEL-01 enforces form uniqueness so a
+// future caller cannot bypass the funnel and silently introduce a
+// non-conforming cell_id series — Bypass `WithLabelValues(...string)`'s
+// unbounded-string operation is closed at CI time, matching the panic
+// funnel pattern (PANIC-REGISTERED-01) charter §4 Wave 2.
+//
+// ref: pkg/panicregister.Approved — typed marker funnel for panic
+// ref: tools/archtest/panic_invariants_test.go — Hard form-uniqueness pattern
+func promCellLabel(id string) string {
+	if !metadata.MatchCellID(id) {
+		panic(panicregister.Approved("prom-cell-label-invalid",
+			errcode.Assertion("prom adapter received cell id violating CellIDPattern")))
+	}
+	return id
+}

--- a/adapters/prometheus/cell_label.go
+++ b/adapters/prometheus/cell_label.go
@@ -1,6 +1,10 @@
-// INVARIANT: PROM-CELL-LABEL-FUNNEL-01 — every CounterVec/HistogramVec
-// WithLabelValues call in this package that emits a cell_id must route the
-// cell id through promCellLabel.
+// cell_label.go — single typed-function funnel for emitting cell_id labels.
+//
+// PROM-CELL-LABEL-FUNNEL-01 (defined in tools/archtest/prom_cell_label_funnel_test.go)
+// enforces that every CounterVec/HistogramVec WithLabelValues call inside
+// this package routes its cell_id argument through promCellLabel. The
+// archtest is the authoritative invariant declaration; this file holds the
+// implementation.
 
 package prometheus
 

--- a/adapters/prometheus/hook_observer.go
+++ b/adapters/prometheus/hook_observer.go
@@ -107,7 +107,14 @@ func NewHookObserver(cfg HookObserverConfig) (*HookObserver, error) {
 
 // OnHookEvent records the event. Safe for concurrent use (Prometheus vec
 // types are goroutine-safe).
+//
+// cell_id is routed through promCellLabel — the single typed-function
+// funnel that enforces metadata.CellIDPattern. Upstream invariants
+// (schemas/cell.schema.json + FMT-C1) already guarantee every event in
+// flight has a valid cell id; promCellLabel is the A-class unreachable
+// defense backstop required by PROM-CELL-LABEL-FUNNEL-01.
 func (o *HookObserver) OnHookEvent(e cell.HookEvent) {
-	o.hookTotal.WithLabelValues(e.CellID, string(e.Hook), string(e.Outcome)).Inc()
-	o.hookDuration.WithLabelValues(e.CellID, string(e.Hook)).Observe(e.Duration.Seconds())
+	cellID := promCellLabel(e.CellID)
+	o.hookTotal.WithLabelValues(cellID, string(e.Hook), string(e.Outcome)).Inc()
+	o.hookDuration.WithLabelValues(cellID, string(e.Hook)).Observe(e.Duration.Seconds())
 }

--- a/adapters/prometheus/hook_observer_test.go
+++ b/adapters/prometheus/hook_observer_test.go
@@ -2,6 +2,8 @@ package prometheus
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,7 +31,7 @@ func TestNewHookObserver_RegistersMetrics(t *testing.T) {
 	// Prometheus only exposes a metric family after the first observation —
 	// verify registration by making one observation and then gathering.
 	obs.OnHookEvent(cell.HookEvent{
-		CellID: "c", Hook: cell.HookBeforeStart, Outcome: cell.OutcomeSuccess,
+		CellID: "cc", Hook: cell.HookBeforeStart, Outcome: cell.OutcomeSuccess,
 		Duration: time.Millisecond,
 	})
 	gathered, err := reg.Gather()
@@ -57,11 +59,11 @@ func TestHookObserver_CounterIncrementsPerOutcome(t *testing.T) {
 		phase   cell.HookPhase
 		outcome cell.HookOutcome
 	}{
-		{"a", cell.HookBeforeStart, cell.OutcomeSuccess},
-		{"a", cell.HookBeforeStart, cell.OutcomeSuccess},
-		{"a", cell.HookBeforeStart, cell.OutcomeFailure},
-		{"b", cell.HookAfterStart, cell.OutcomeTimeout},
-		{"b", cell.HookAfterStop, cell.OutcomePanic},
+		{"aa", cell.HookBeforeStart, cell.OutcomeSuccess},
+		{"aa", cell.HookBeforeStart, cell.OutcomeSuccess},
+		{"aa", cell.HookBeforeStart, cell.OutcomeFailure},
+		{"bb", cell.HookAfterStart, cell.OutcomeTimeout},
+		{"bb", cell.HookAfterStop, cell.OutcomePanic},
 	}
 	for _, tc := range tests {
 		obs.OnHookEvent(cell.HookEvent{
@@ -72,19 +74,19 @@ func TestHookObserver_CounterIncrementsPerOutcome(t *testing.T) {
 		})
 	}
 
-	counter, err := obs.hookTotal.GetMetricWithLabelValues("a", "before_start", "success")
+	counter, err := obs.hookTotal.GetMetricWithLabelValues("aa", "before_start", "success")
 	require.NoError(t, err)
 	assert.Equal(t, 2.0, testutil.ToFloat64(counter))
 
-	counter, err = obs.hookTotal.GetMetricWithLabelValues("a", "before_start", "failure")
+	counter, err = obs.hookTotal.GetMetricWithLabelValues("aa", "before_start", "failure")
 	require.NoError(t, err)
 	assert.Equal(t, 1.0, testutil.ToFloat64(counter))
 
-	counter, err = obs.hookTotal.GetMetricWithLabelValues("b", "after_start", "timeout")
+	counter, err = obs.hookTotal.GetMetricWithLabelValues("bb", "after_start", "timeout")
 	require.NoError(t, err)
 	assert.Equal(t, 1.0, testutil.ToFloat64(counter))
 
-	counter, err = obs.hookTotal.GetMetricWithLabelValues("b", "after_stop", "panic")
+	counter, err = obs.hookTotal.GetMetricWithLabelValues("bb", "after_stop", "panic")
 	require.NoError(t, err)
 	assert.Equal(t, 1.0, testutil.ToFloat64(counter))
 }
@@ -96,7 +98,7 @@ func TestHookObserver_HistogramRecordsDuration(t *testing.T) {
 
 	for range 3 {
 		obs.OnHookEvent(cell.HookEvent{
-			CellID:   "c",
+			CellID:   "cc",
 			Hook:     cell.HookBeforeStart,
 			Outcome:  cell.OutcomeSuccess,
 			Duration: hookObserverD15ms,
@@ -131,7 +133,7 @@ func TestHookObserver_CustomNamespace(t *testing.T) {
 	reg := prom.NewRegistry()
 	obs, err := NewHookObserver(HookObserverConfig{Registry: reg, Namespace: "myapp"})
 	require.NoError(t, err)
-	obs.OnHookEvent(cell.HookEvent{CellID: "c", Hook: cell.HookBeforeStart, Outcome: cell.OutcomeSuccess, Duration: time.Millisecond})
+	obs.OnHookEvent(cell.HookEvent{CellID: "cc", Hook: cell.HookBeforeStart, Outcome: cell.OutcomeSuccess, Duration: time.Millisecond})
 
 	gathered, err := reg.Gather()
 	require.NoError(t, err)
@@ -190,4 +192,115 @@ func TestHookObserver_DuplicateRegistrationReturnsError(t *testing.T) {
 	var ec *errcode.Error
 	require.True(t, errors.As(err, &ec), "expected errcode.Error in chain")
 	assert.Equal(t, ErrAdapterPromRegister, ec.Code)
+}
+
+// TestPromCellLabel_Valid verifies that a cell id satisfying CellIDPattern
+// passes through promCellLabel unchanged. This locks in the funnel's
+// happy-path contract: zero overhead transformation for upstream-validated
+// ids.
+func TestPromCellLabel_Valid(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{"accesscore", "auditcore", "configcore", "aa", "a0"} {
+		id := id
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			got := promCellLabel(id)
+			if got != id {
+				t.Fatalf("promCellLabel(%q) = %q, want %q", id, got, id)
+			}
+		})
+	}
+}
+
+// TestPromCellLabel_PanicsOnInvalid verifies that an invalid cell id triggers
+// the A-class panic via panicregister.Approved. Upstream invariants
+// (schemas + FMT-C1) should make this branch unreachable; this test locks
+// in the fail-fast contract for bypass-detection paths.
+func TestPromCellLabel_PanicsOnInvalid(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"", "a", "Foo", "foo-bar", "foo_bar", "1foo", "foo bar"}
+	for _, id := range cases {
+		id := id
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("promCellLabel(%q) did not panic on invalid input", id)
+				}
+				// The panic value is *errcode.Error (A-class) wrapped by
+				// panicregister.Approved — verify the payload type.
+				ec, ok := r.(*errcode.Error)
+				if !ok {
+					t.Fatalf("panic value type = %T, want *errcode.Error (A-class assertion)", r)
+				}
+				if ec.Code != errcode.ErrInternal {
+					t.Fatalf("panic ec.Code = %q, want ErrInternal", ec.Code)
+				}
+			}()
+			_ = promCellLabel(id)
+		})
+	}
+}
+
+// raceConcurrency is the goroutine count for race tests. Matches the
+// adapters/redis/race_stress_integration_test.go golden reference (50).
+const raceConcurrency = 50
+
+// TestHookObserver_ConcurrentOnHookEvent_RaceDetector verifies that the
+// Prometheus HookObserver is safe for concurrent OnHookEvent invocations.
+// Runs raceConcurrency goroutines that emit hook events with varying
+// (cell_id, hook, outcome) tuples. Asserts the race detector observes no
+// data race and the final counter sum equals the expected total.
+//
+// Run with `go test -race`. Does NOT use t.Parallel() because race detector
+// behavior under parallel tests is non-deterministic (golden reference:
+// adapters/redis/race_stress_integration_test.go).
+func TestHookObserver_ConcurrentOnHookEvent_RaceDetector(t *testing.T) {
+	reg := prom.NewRegistry()
+	obs, err := NewHookObserver(HookObserverConfig{Registry: reg})
+	require.NoError(t, err)
+
+	// Three distinct valid cell ids; combined with two hook phases and one
+	// outcome that yields six label tuples — enough to exercise the
+	// CounterVec dispatch table under concurrent writers.
+	cellIDs := []string{"accesscore", "auditcore", "configcore"}
+	hooks := []cell.HookPhase{cell.HookBeforeStart, cell.HookAfterStart}
+
+	var emitted atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(raceConcurrency)
+	for i := 0; i < raceConcurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			obs.OnHookEvent(cell.HookEvent{
+				CellID:   cellIDs[idx%len(cellIDs)],
+				Hook:     hooks[idx%len(hooks)],
+				Outcome:  cell.OutcomeSuccess,
+				Duration: time.Millisecond,
+			})
+			emitted.Add(1)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(raceConcurrency), emitted.Load(),
+		"all goroutines must complete; missing emissions indicate a deadlock or panic")
+
+	// Verify the sum across all label tuples equals the emission count.
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	var total float64
+	for _, mf := range gathered {
+		if mf.GetName() != "gocell_cell_hook_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			total += m.GetCounter().GetValue()
+		}
+	}
+	require.Equal(t, float64(raceConcurrency), total,
+		"counter total must equal goroutine count; mismatch indicates dropped events")
 }

--- a/adapters/prometheus/hook_observer_test.go
+++ b/adapters/prometheus/hook_observer_test.go
@@ -230,8 +230,12 @@ func TestPromCellLabel_PanicsOnInvalid(t *testing.T) {
 				if r == nil {
 					t.Fatalf("promCellLabel(%q) did not panic on invalid input", id)
 				}
-				// The panic value is *errcode.Error (A-class) wrapped by
-				// panicregister.Approved — verify the payload type.
+				// The panic value is *errcode.Error directly:
+				// panicregister.Approved is a pass-through source-level marker
+				// (returns its value arg unchanged), so recover() observes the
+				// inner errcode.Assertion *errcode.Error. The reason kebab
+				// string is statically validated by archtest
+				// PANIC-REGISTERED-01 at compile/CI time, not at runtime.
 				ec, ok := r.(*errcode.Error)
 				if !ok {
 					t.Fatalf("panic value type = %T, want *errcode.Error (A-class assertion)", r)

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -589,10 +589,31 @@ func TestMetricProvider_ConcurrentCounterVec_RaceDetector(t *testing.T) {
 	}
 
 	// The N concurrent .Inc() calls share the same underlying *prom.CounterVec
-	// (registerOrReuse idempotent path), so the sum is exactly N.
+	// (registerOrReuse idempotent path): exactly 1 series, sum = N.
 	got := testutil.CollectAndCount(reg, "gocelltest_race_total")
 	if got != 1 {
 		t.Fatalf("expected exactly 1 series after concurrent register, got %d", got)
+	}
+	// Verify sum so a regression where Inc dropped writes (e.g. a future
+	// per-call register/unregister bug) does not pass with series-count
+	// alone. Gather() walks the registry directly — the abstracted
+	// metrics.Counter does not implement prom.Collector so testutil.ToFloat64
+	// is not directly applicable here.
+	gathered, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	var sum float64
+	for _, mf := range gathered {
+		if mf.GetName() != "gocelltest_race_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			sum += m.GetCounter().GetValue()
+		}
+	}
+	if sum != float64(raceConcurrency) {
+		t.Fatalf("counter sum = %v, want %d", sum, raceConcurrency)
 	}
 }
 

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -2,7 +2,10 @@ package prometheus_test
 
 import (
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -11,6 +14,11 @@ import (
 	gcprom "github.com/ghbvf/gocell/adapters/prometheus"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 )
+
+// raceConcurrency mirrors the constant in hook_observer_test (50). Kept as
+// a separate const here because the two test files live in different
+// packages (prometheus_test vs prometheus).
+const raceConcurrency = 50
 
 func newTestProvider(t *testing.T) (metrics.Provider, *prom.Registry) {
 	t.Helper()
@@ -541,4 +549,101 @@ func (s singletonCounter) Describe(ch chan<- *prom.Desc) {
 
 func (s singletonCounter) Collect(ch chan<- prom.Metric) {
 	ch <- prom.MustNewConstMetric(prom.NewDesc("singleton", "test helper", nil, nil), prom.CounterValue, s.val)
+}
+
+// TestMetricProvider_ConcurrentCounterVec_RaceDetector verifies that N
+// goroutines concurrently calling CounterVec with the same opts is safe.
+// Exercises registerOrReuse's AlreadyRegisteredError branch under contention:
+// only the first call actually registers a new collector; subsequent calls
+// return the existing one. Both paths must be race-free.
+//
+// Run with `go test -race`. No t.Parallel() — see golden reference
+// adapters/redis/race_stress_integration_test.go.
+func TestMetricProvider_ConcurrentCounterVec_RaceDetector(t *testing.T) {
+	p, reg := newTestProvider(t)
+
+	opts := metrics.CounterOpts{
+		Name:       "race_total",
+		Help:       "race test counter",
+		LabelNames: []string{"k"},
+	}
+
+	var wg sync.WaitGroup
+	var firstErr atomic.Value // error
+	wg.Add(raceConcurrency)
+	for i := 0; i < raceConcurrency; i++ {
+		go func() {
+			defer wg.Done()
+			cv, err := p.CounterVec(opts)
+			if err != nil {
+				firstErr.CompareAndSwap(nil, err)
+				return
+			}
+			cv.With(metrics.Labels{"k": "v"}).Inc()
+		}()
+	}
+	wg.Wait()
+
+	if err := firstErr.Load(); err != nil {
+		t.Fatalf("concurrent CounterVec returned error: %v", err)
+	}
+
+	// The N concurrent .Inc() calls share the same underlying *prom.CounterVec
+	// (registerOrReuse idempotent path), so the sum is exactly N.
+	got := testutil.CollectAndCount(reg, "gocelltest_race_total")
+	if got != 1 {
+		t.Fatalf("expected exactly 1 series after concurrent register, got %d", got)
+	}
+}
+
+// TestMetricProvider_ConcurrentRegisterAndUnregister_RaceDetector verifies
+// that interleaved CounterVec / Unregister calls do not race on the
+// provider's internal vecs map (the RWMutex contract). Each goroutine
+// registers a uniquely-named CounterVec and then unregisters it, with N
+// goroutines running concurrently. The race detector must observe no data
+// race on the vecs map's read/write boundary.
+//
+// Run with `go test -race`.
+func TestMetricProvider_ConcurrentRegisterAndUnregister_RaceDetector(t *testing.T) {
+	p, reg := newTestProvider(t)
+
+	var wg sync.WaitGroup
+	var firstErr atomic.Value // error
+	wg.Add(raceConcurrency)
+	for i := 0; i < raceConcurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("unique_total_%d", idx)
+			cv, err := p.CounterVec(metrics.CounterOpts{
+				Name:       name,
+				Help:       "h",
+				LabelNames: []string{"k"},
+			})
+			if err != nil {
+				firstErr.CompareAndSwap(nil, err)
+				return
+			}
+			cv.With(metrics.Labels{"k": "v"}).Inc()
+			if err := p.Unregister(cv); err != nil {
+				firstErr.CompareAndSwap(nil, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if err := firstErr.Load(); err != nil {
+		t.Fatalf("concurrent register/unregister returned error: %v", err)
+	}
+
+	// After all unregisters complete, Gather must succeed without panicking.
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather after concurrent unregister: %v", err)
+	}
+	// All unique_total_* series should be gone.
+	for _, mf := range families {
+		if strings.HasPrefix(mf.GetName(), "gocelltest_unique_total_") {
+			t.Fatalf("unique_total series leaked after unregister: %s", mf.GetName())
+		}
+	}
 }

--- a/cmd/corebundle/metrics.go
+++ b/cmd/corebundle/metrics.go
@@ -29,11 +29,15 @@ const (
 	// can send a clean 503 + "Exceeded configured timeout of {dur}.\n" before
 	// the TCP write deadline kicks in and forcibly closes the connection.
 	//
-	// Caveat: http.TimeoutHandler signals the response writer but does not
-	// cancel the Gather goroutine. All current GoCell collectors are pure
-	// in-memory reads (CounterVec/HistogramVec.Collect), so this is benign;
-	// introducing an IO collector in the future requires plumbing context
-	// through the Gatherer interface (upstream limitation).
+	// Caveat: promhttp's Timeout option implements scrape budget enforcement
+	// by spawning Gather() in a goroutine and racing it against a time.After
+	// channel — the prom.Gatherer interface carries no context, so an
+	// overrunning Gather call keeps executing in the background even after
+	// the 503 has been written. All current GoCell collectors are pure
+	// in-memory reads (CounterVec/HistogramVec.Collect), so a stranded
+	// Gather goroutine is benign; introducing an IO collector later requires
+	// either (a) a custom Gatherer that owns its own context-cancellable
+	// reads, or (b) upstream context plumbing in client_golang.
 	//
 	// ref: prometheus/client_golang prometheus/promhttp/http.go HandlerOpts.Timeout
 	metricsScrapeTimeout = 10 * time.Second

--- a/cmd/corebundle/metrics.go
+++ b/cmd/corebundle/metrics.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -14,11 +15,39 @@ import (
 	adapterprom "github.com/ghbvf/gocell/adapters/prometheus"
 )
 
-// metricsAuthHeader names the request header used to authenticate
-// /metrics scrapers when a bearer token is configured. Mirrors the X-Readyz-Token
-// convention for /readyz?verbose — keeping the same shape for all
-// control-plane endpoints lets operators standardize scraper config.
-const metricsAuthHeader = "X-Metrics-Token"
+const (
+	// metricsAuthHeader names the request header used to authenticate
+	// /metrics scrapers when a bearer token is configured. Mirrors the
+	// X-Readyz-Token convention for /readyz?verbose — keeping the same shape
+	// for all control-plane endpoints lets operators standardize scraper config.
+	metricsAuthHeader = "X-Metrics-Token"
+
+	// metricsScrapeTimeout is the application-level Gather() timeout for the
+	// /metrics handler. Set to 10s following the Prometheus official default
+	// scrape_timeout. Must be strictly less than the bootstrap HTTP
+	// WriteTimeout (30s, runtime/bootstrap/bootstrap_phase7.go) so promhttp
+	// can send a clean 503 + "Exceeded configured timeout of {dur}.\n" before
+	// the TCP write deadline kicks in and forcibly closes the connection.
+	//
+	// Caveat: http.TimeoutHandler signals the response writer but does not
+	// cancel the Gather goroutine. All current GoCell collectors are pure
+	// in-memory reads (CounterVec/HistogramVec.Collect), so this is benign;
+	// introducing an IO collector in the future requires plumbing context
+	// through the Gatherer interface (upstream limitation).
+	//
+	// ref: prometheus/client_golang prometheus/promhttp/http.go HandlerOpts.Timeout
+	metricsScrapeTimeout = 10 * time.Second
+
+	// metricsMaxRequestsInFlight caps concurrent /metrics scrapes. Normal
+	// operation has a single Prometheus server scraping (concurrency 1); HA
+	// dual-Prometheus + an operator running curl tops out at 3. Excess
+	// requests get 503 so the scraper backs off, preventing a slow-scrape
+	// queue from exhausting HealthListener goroutines. Ordering: the outer
+	// withMetricsTokenGuard handles 401 before this limit checks 503, so
+	// unauthenticated traffic cannot exhaust the inflight budget (nginx
+	// auth_request → limit_req parity).
+	metricsMaxRequestsInFlight = 3
+)
 
 // withMetricsTokenGuard wraps h so requests without a matching
 // X-Metrics-Token header are rejected with 401 Unauthorized.
@@ -81,7 +110,11 @@ func buildPromStack() (promStack, error) {
 //
 // ref: Kubernetes metrics/rbac — control-plane endpoints must be guarded.
 func buildMetricsHandler(metricsToken string, registry *prom.Registry) http.Handler {
-	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+		Timeout:             metricsScrapeTimeout,
+		MaxRequestsInFlight: metricsMaxRequestsInFlight,
+		Registry:            registry, // self-instrument: promhttp_metric_handler_errors_total
+	})
 	if metricsToken != "" {
 		return withMetricsTokenGuard(metricsToken, h)
 	}

--- a/cmd/corebundle/metrics_test.go
+++ b/cmd/corebundle/metrics_test.go
@@ -3,8 +3,14 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -100,4 +106,126 @@ func TestBuildPromStack_ProducesIndependentRegistries(t *testing.T) {
 	second, err := buildPromStack()
 	require.NoError(t, err)
 	assert.NotSame(t, first.registry, second.registry)
+}
+
+// Test-time durations extracted to package-level constants to satisfy
+// archtest TEST-TIME-LITERAL-01 (extract test durations to consts).
+const (
+	// bootstrapWriteTimeoutSanity is the bootstrap HTTP WriteTimeout
+	// (runtime/bootstrap/bootstrap_phase7.go defaultBootstrapHTTPWriteTimeout).
+	// The metrics handler scrape timeout must be strictly less to ensure
+	// promhttp can send a clean 503 before TCP write deadline kicks in.
+	bootstrapWriteTimeoutSanity = 30 * time.Second
+	// metricsTestScrapeTimeout is a tiny test-only timeout to avoid waiting
+	// the production 10s value in unit tests.
+	metricsTestScrapeTimeout = 50 * time.Millisecond
+	// metricsTestSlowGatherMultiplier — slow Gather sleeps this many times
+	// the test scrape timeout, guaranteeing the timeout path trips.
+	metricsTestSlowGatherMultiplier = 5
+	// metricsInflightTestGatherTimeout — long enough that
+	// promhttp.Timeout never fires before the test exits, isolating the
+	// MaxRequestsInFlight 503 path.
+	metricsInflightTestGatherTimeout = 5 * time.Second
+	// metricsInflightSettleDelay — short pause to let saturating goroutines
+	// enter Gather() and decrement the inflight semaphore before the test
+	// fires its limit-trip request.
+	metricsInflightSettleDelay = 20 * time.Millisecond
+)
+
+// slowGatherer is a prom.Gatherer that blocks for the configured duration on
+// every Gather() call. Used to exercise promhttp.HandlerFor's Timeout path.
+type slowGatherer struct {
+	sleep time.Duration
+	inner *prom.Registry
+}
+
+func (g *slowGatherer) Gather() ([]*dto.MetricFamily, error) {
+	time.Sleep(g.sleep) //archtest:allow:test-sleep slowGatherer simulates upstream Gather latency for promhttp Timeout 503 path
+	return g.inner.Gather()
+}
+
+// TestBuildMetricsHandler_TimeoutReturns503 verifies that a Gather() call
+// blocking longer than metricsScrapeTimeout (10s) is terminated by
+// promhttp.HandlerFor's Timeout path, returning HTTP 503 + the
+// "Exceeded configured timeout of {dur}." body. The handler-level timeout
+// must fire before the bootstrap-level WriteTimeout (30s) so the client
+// gets a clean response rather than a TCP RST.
+//
+// We construct the handler directly via promhttp.HandlerFor (mirroring
+// buildMetricsHandler's wiring) with a small Timeout to keep the test fast.
+func TestBuildMetricsHandler_TimeoutReturns503(t *testing.T) {
+	t.Parallel()
+
+	// Sanity: the production constant must be < bootstrap WriteTimeout.
+	require.Less(t, metricsScrapeTimeout, bootstrapWriteTimeoutSanity,
+		"metricsScrapeTimeout must be strictly less than bootstrap HTTP WriteTimeout")
+
+	gatherer := &slowGatherer{
+		sleep: metricsTestSlowGatherMultiplier * metricsTestScrapeTimeout,
+		inner: prom.NewRegistry(),
+	}
+
+	h := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
+		Timeout:             metricsTestScrapeTimeout,
+		MaxRequestsInFlight: metricsMaxRequestsInFlight,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Exceeded configured timeout") {
+		t.Fatalf("body does not contain promhttp timeout text: %q", rec.Body.String())
+	}
+}
+
+// TestBuildMetricsHandler_MaxRequestsInFlight verifies that requests
+// exceeding metricsMaxRequestsInFlight receive 503. We hold the configured
+// limit of slow Gather calls in flight and confirm the next request returns
+// 503 immediately.
+func TestBuildMetricsHandler_MaxRequestsInFlight(t *testing.T) {
+	t.Parallel()
+
+	// Each inflight Gather blocks until release is closed.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	gatherer := prom.GathererFunc(func() ([]*dto.MetricFamily, error) {
+		<-release
+		return nil, nil
+	})
+
+	h := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
+		Timeout:             metricsInflightTestGatherTimeout, // longer than test runtime
+		MaxRequestsInFlight: metricsMaxRequestsInFlight,
+	})
+
+	// Saturate the inflight budget.
+	var saturated sync.WaitGroup
+	saturated.Add(metricsMaxRequestsInFlight)
+	for i := 0; i < metricsMaxRequestsInFlight; i++ {
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			rec := httptest.NewRecorder()
+			saturated.Done()
+			h.ServeHTTP(rec, req)
+		}()
+	}
+	saturated.Wait()
+	// Give the goroutines a moment to enter Gather() and decrement the
+	// inflight semaphore. promhttp's limiter is preemptive — without a
+	// small sync delay the limit check can race against goroutine start.
+	time.Sleep(metricsInflightSettleDelay) //archtest:allow:test-sleep inflight semaphore decrement timing
+
+	// One more request must trip the 503 path.
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (inflight limit not enforced); body=%q",
+			rec.Code, rec.Body.String())
+	}
 }

--- a/cmd/corebundle/metrics_test.go
+++ b/cmd/corebundle/metrics_test.go
@@ -13,6 +13,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/runtime/bootstrap"
 )
 
 func TestWithMetricsTokenGuard(t *testing.T) {
@@ -110,12 +112,10 @@ func TestBuildPromStack_ProducesIndependentRegistries(t *testing.T) {
 
 // Test-time durations extracted to package-level constants to satisfy
 // archtest TEST-TIME-LITERAL-01 (extract test durations to consts).
+//
+// Bootstrap WriteTimeout is consumed via bootstrap.DefaultBootstrapHTTPWriteTimeout
+// (single-source) — see TestBuildMetricsHandler_TimeoutReturns503 sanity check.
 const (
-	// bootstrapWriteTimeoutSanity is the bootstrap HTTP WriteTimeout
-	// (runtime/bootstrap/bootstrap_phase7.go defaultBootstrapHTTPWriteTimeout).
-	// The metrics handler scrape timeout must be strictly less to ensure
-	// promhttp can send a clean 503 before TCP write deadline kicks in.
-	bootstrapWriteTimeoutSanity = 30 * time.Second
 	// metricsTestScrapeTimeout is a tiny test-only timeout to avoid waiting
 	// the production 10s value in unit tests.
 	metricsTestScrapeTimeout = 50 * time.Millisecond
@@ -153,7 +153,9 @@ func TestBuildMetricsHandler_TimeoutReturns503(t *testing.T) {
 	t.Parallel()
 
 	// Sanity: the production constant must be < bootstrap WriteTimeout.
-	require.Less(t, metricsScrapeTimeout, bootstrapWriteTimeoutSanity,
+	// Reads the real bootstrap default (no duplicated literal) so a future
+	// bootstrap timeout change is auto-reflected here.
+	require.Less(t, metricsScrapeTimeout, bootstrap.DefaultBootstrapHTTPWriteTimeout,
 		"metricsScrapeTimeout must be strictly less than bootstrap HTTP WriteTimeout")
 
 	gatherer := &slowGatherer{

--- a/cmd/corebundle/metrics_test.go
+++ b/cmd/corebundle/metrics_test.go
@@ -126,10 +126,6 @@ const (
 	// promhttp.Timeout never fires before the test exits, isolating the
 	// MaxRequestsInFlight 503 path.
 	metricsInflightTestGatherTimeout = 5 * time.Second
-	// metricsInflightSettleDelay — short pause to let saturating goroutines
-	// enter Gather() and decrement the inflight semaphore before the test
-	// fires its limit-trip request.
-	metricsInflightSettleDelay = 20 * time.Millisecond
 )
 
 // slowGatherer is a prom.Gatherer that blocks for the configured duration on
@@ -189,11 +185,19 @@ func TestBuildMetricsHandler_TimeoutReturns503(t *testing.T) {
 func TestBuildMetricsHandler_MaxRequestsInFlight(t *testing.T) {
 	t.Parallel()
 
-	// Each inflight Gather blocks until release is closed.
+	// entered.Done() is called inside Gather, so entered.Wait() blocks
+	// until every saturating goroutine is actually inside the inflight
+	// semaphore. Coupling the saturation signal to the Gather body itself
+	// (rather than to goroutine launch) removes the race between
+	// "ServeHTTP started" and "promhttp inflight counter incremented" —
+	// a fixed sleep buffer would be flaky under CI load.
+	var entered sync.WaitGroup
+	entered.Add(metricsMaxRequestsInFlight)
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
 
 	gatherer := prom.GathererFunc(func() ([]*dto.MetricFamily, error) {
+		entered.Done()
 		<-release
 		return nil, nil
 	})
@@ -203,22 +207,16 @@ func TestBuildMetricsHandler_MaxRequestsInFlight(t *testing.T) {
 		MaxRequestsInFlight: metricsMaxRequestsInFlight,
 	})
 
-	// Saturate the inflight budget.
-	var saturated sync.WaitGroup
-	saturated.Add(metricsMaxRequestsInFlight)
 	for i := 0; i < metricsMaxRequestsInFlight; i++ {
 		go func() {
 			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 			rec := httptest.NewRecorder()
-			saturated.Done()
 			h.ServeHTTP(rec, req)
 		}()
 	}
-	saturated.Wait()
-	// Give the goroutines a moment to enter Gather() and decrement the
-	// inflight semaphore. promhttp's limiter is preemptive — without a
-	// small sync delay the limit check can race against goroutine start.
-	time.Sleep(metricsInflightSettleDelay) //archtest:allow:test-sleep inflight semaphore decrement timing
+	// All N goroutines are now blocked inside Gather → inflight semaphore
+	// is saturated. The next request must trip the 503 path immediately.
+	entered.Wait()
 
 	// One more request must trip the 503 path.
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -481,31 +481,47 @@ func TestRunValidate_DetectsKebabAssemblyID(t *testing.T) {
 	assert.Contains(t, out, "FMT-A1", "default-mode output must report FMT-A1 code")
 }
 
+// TestRunValidate_DetectsKebabCellID locks in FMT-C1 under default
+// (non-strict) mode: the rule mirrors schemas/cell.schema.json id.pattern
+// (collapsed in PR-2 PR-PROM-HARDEN-3 alongside the unconditional governance
+// upgrade), so schema-aware tooling and the governance CLI agree without a
+// strict toggle. Mirrors TestRunValidate_DetectsKebabAssemblyID.
+func TestRunValidate_DetectsKebabCellID(t *testing.T) {
+	dir := writeKebabCellID(t)
+
+	var gotErr error
+	out := captureStdout(t, func() {
+		gotErr = runValidate([]string{"--root", dir})
+	})
+	require.Error(t, gotErr, "default validate must return error when FMT-C1 fires on invalid cell id")
+	assert.Contains(t, out, "FMT-C1", "default-mode output must report FMT-C1 code")
+}
+
 // TestRunValidate_Default_IgnoresStrictOnlyRules is the regression guard
-// for the strict gate itself: every fixture that trips FMT-16 / 17 / C1
-// in strict mode must remain silent under default mode. Without this case
+// for the strict gate itself: every fixture that trips FMT-16 / 17 in
+// strict mode must remain silent under default mode. Without this case
 // a refactor that accidentally promoted a strict rule to a base rule
 // would slip through (CI gates would still pass, but `gocell validate`
 // without --strict would no longer be the documented "default-permissive"
 // surface for kebab-style violations).
 //
-// FMT-A1 (assembly id pattern) is intentionally NOT in this list: it
-// mirrors schemas/assembly.schema.json id.pattern and runs unconditionally
-// — see TestRunValidate_DetectsKebabAssemblyID for the positive lock.
+// FMT-A1 and FMT-C1 (assembly/cell id patterns) are intentionally NOT in
+// this list: they mirror schemas/{assembly,cell}.schema.json id.pattern
+// and run unconditionally — see TestRunValidate_DetectsKebabAssemblyID
+// and TestRunValidate_DetectsKebabCellID for the positive locks.
 //
 // The fixtures here may emit unrelated base findings (e.g. REF-16 warning,
 // or REF-* errors stemming from minimal scaffolding); the test deliberately
 // does NOT assert "no error returned" because the contract being verified
-// is narrower: regardless of base findings, no FMT-16/17/C1 line may
-// appear in default output. `out` is logged on failure so a future drift
-// in base rules surfaces the offending code.
+// is narrower: regardless of base findings, no FMT-16/17 line may appear
+// in default output. `out` is logged on failure so a future drift in base
+// rules surfaces the offending code.
 func TestRunValidate_Default_IgnoresStrictOnlyRules(t *testing.T) {
 	cases := []struct {
 		name string
 		fix  func(*testing.T) string
 	}{
 		{"kebabSliceDir_FMT16", writeKebabSlice},
-		{"kebabCellID_FMTC1", writeKebabCellID},
 		{"allowedFilesMismatch_FMT17", writeAllowedFilesMismatch},
 	}
 	for _, tc := range cases {
@@ -515,7 +531,7 @@ func TestRunValidate_Default_IgnoresStrictOnlyRules(t *testing.T) {
 			out := captureStdout(t, func() {
 				_ = runValidate([]string{"--root", dir})
 			})
-			for _, code := range []string{"FMT-16", "FMT-17", "FMT-C1"} {
+			for _, code := range []string{"FMT-16", "FMT-17"} {
 				if assert.NotContains(t, out, code, "%s must stay silent under default mode", code) {
 					continue
 				}

--- a/cmd/gocell/app/mode_test.go
+++ b/cmd/gocell/app/mode_test.go
@@ -418,8 +418,9 @@ func writeAllowedFilesMismatch(t *testing.T) string {
 }
 
 // writeKebabAssemblyID writes a no-dash assembly directory whose declared id
-// contains '-'. Triggers FMT-A1 in strict mode (in addition to whatever
-// base findings the metadata layer surfaces for the dir/id mismatch).
+// contains '-'. Triggers FMT-A1 unconditionally (it mirrors a schema
+// constraint and runs on every validate path; see
+// TestRunValidate_DetectsKebabAssemblyID for the positive lock).
 func writeKebabAssemblyID(t *testing.T) string {
 	t.Helper()
 	// REF-11 verifies build.entrypoint exists; the cmd/myasm stub keeps that
@@ -430,13 +431,13 @@ func writeKebabAssemblyID(t *testing.T) string {
 	return dir
 }
 
-// TestRunValidate_Strict_DetectsKebabCellID locks in FMT-C1 in strict full
-// mode: a kebab-case cell id is rejected only by ValidateStrict(true). The
-// fixture has a kebab directory (necessary because REF-04 enforces id ↔
-// dir match, so an id-only kebab is impossible to construct without a
-// base error pre-empting strict), so FMT-16 fires alongside FMT-C1 — that
-// is the defense-in-depth pair the rule was designed for, and the
-// assertion below verifies both rules light up.
+// TestRunValidate_Strict_DetectsKebabCellID locks in the strict-mode
+// co-trigger: when the fixture has both a kebab id and a kebab directory,
+// FMT-C1 (now unconditional, see TestRunValidate_DetectsKebabCellID for
+// the default-path lock) and FMT-16 (strict-only, kebab dir scan) must
+// both light up. The assertion verifies this defense-in-depth pair under
+// `--strict` so a future refactor that breaks the strict-mode rule chain
+// does not silently disarm FMT-16.
 func TestRunValidate_Strict_DetectsKebabCellID(t *testing.T) {
 	dir := writeKebabCellID(t)
 
@@ -444,9 +445,9 @@ func TestRunValidate_Strict_DetectsKebabCellID(t *testing.T) {
 	out := captureStdout(t, func() {
 		gotErr = runValidate([]string{"--root", dir, "--strict"})
 	})
-	require.Error(t, gotErr, "strict must return error when FMT-C1 fires on kebab cell id")
-	assert.Contains(t, out, "FMT-C1", "full-mode output must report FMT-C1 code")
-	assert.Contains(t, out, "FMT-16", "FMT-16 must also fire — kebab dir is the natural co-trigger")
+	require.Error(t, gotErr, "strict must return error when FMT-C1 + FMT-16 fire on kebab cell id + dir")
+	assert.Contains(t, out, "FMT-C1", "FMT-C1 (unconditional) must report on kebab cell id")
+	assert.Contains(t, out, "FMT-16", "FMT-16 (strict-only) must report on kebab cell dir")
 }
 
 // TestRunValidate_Strict_DetectsAllowedFilesMismatch locks in FMT-17: a

--- a/cmd/gocell/app/validate.go
+++ b/cmd/gocell/app/validate.go
@@ -33,7 +33,7 @@ func runValidate(args []string) error {
 	strict := fs.Bool("strict", false,
 		"enforce strict-only governance rules"+
 			" (VERIFY-06 executable journey auto checks, FMT-16 slice/cell/assembly dirs,"+
-			" FMT-17 allowedFiles, FMT-C1 cell id, FMT-A1 assembly id)")
+			" FMT-17 allowedFiles)")
 	format := fs.String("format", string(printers.FormatText),
 		"output format: text (non-stable, default) | json | sarif")
 	if err := fs.Parse(args); err != nil {

--- a/kernel/governance/depcheck_test.go
+++ b/kernel/governance/depcheck_test.go
@@ -234,11 +234,11 @@ func TestDEP03_SameAssembly(t *testing.T) {
 				ID:               "app-core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "sharedcrypto", Reason: "hashing"},
 				},
 			},
-			"shared-crypto": {
-				ID:               "shared-crypto",
+			"sharedcrypto": {
+				ID:               "sharedcrypto",
 				ConsistencyLevel: "L0",
 			},
 		},
@@ -247,7 +247,7 @@ func TestDEP03_SameAssembly(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"main-bundle": {
 				ID:    "main-bundle",
-				Cells: []string{"app-core", "shared-crypto"},
+				Cells: []string{"app-core", "sharedcrypto"},
 			},
 		},
 	}
@@ -265,11 +265,11 @@ func TestDEP03_DifferentAssembly(t *testing.T) {
 				ID:               "app-core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "sharedcrypto", Reason: "hashing"},
 				},
 			},
-			"shared-crypto": {
-				ID:               "shared-crypto",
+			"sharedcrypto": {
+				ID:               "sharedcrypto",
 				ConsistencyLevel: "L0",
 			},
 		},
@@ -282,7 +282,7 @@ func TestDEP03_DifferentAssembly(t *testing.T) {
 			},
 			"bundle-b": {
 				ID:    "bundle-b",
-				Cells: []string{"shared-crypto"},
+				Cells: []string{"sharedcrypto"},
 			},
 		},
 	}
@@ -302,11 +302,11 @@ func TestDEP03_NoAssemblies(t *testing.T) {
 				ID:               "app-core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "sharedcrypto", Reason: "hashing"},
 				},
 			},
-			"shared-crypto": {
-				ID:               "shared-crypto",
+			"sharedcrypto": {
+				ID:               "sharedcrypto",
 				ConsistencyLevel: "L0",
 			},
 		},
@@ -384,11 +384,11 @@ func TestDEP03_CellNotInAnyAssembly(t *testing.T) {
 				ID:               "app-core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "sharedcrypto", Reason: "hashing"},
 				},
 			},
-			"shared-crypto": {
-				ID:               "shared-crypto",
+			"sharedcrypto": {
+				ID:               "sharedcrypto",
 				ConsistencyLevel: "L0",
 			},
 		},
@@ -397,7 +397,7 @@ func TestDEP03_CellNotInAnyAssembly(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"bundle-a": {
 				ID:    "bundle-a",
-				Cells: []string{"shared-crypto"}, // app-core not in any assembly
+				Cells: []string{"sharedcrypto"}, // app-core not in any assembly
 			},
 		},
 	}

--- a/kernel/governance/rules_misc_strict.go
+++ b/kernel/governance/rules_misc_strict.go
@@ -41,12 +41,12 @@ import (
 //   - FMT-17: slice.yaml allowedFiles first entry does not match the slice directory
 //   - FMT-19: kernel/wrapper/*.go contains forbidden mutable package-level state
 //   - VERIFY-06: active journeys have at least one auto passCriteria checkRef
-//   - FMT-C1: cell.yaml id contains '-' (kebab-case cell id disallowed)
 //   - DOC-NAME-01: active docs contain a forbidden legacy naming literal
 //
-// FMT-A1 (assembly id pattern) is unconditional inside Validate: it
-// mirrors schemas/assembly.schema.json id.pattern and must apply on every
-// validate path so schema-aware tooling and `gocell validate` agree.
+// FMT-A1 (assembly id pattern) and FMT-C1 (cell id pattern) are
+// unconditional inside Validate: they mirror schemas/{assembly,cell}.
+// schema.json properties.id.pattern and must apply on every validate path
+// so schema-aware tooling and `gocell validate` agree.
 //
 // FMT-18 (contractspec.ContractSpec literals in cells/** cross-check) was removed in
 // PR-V1-CODEGEN-FULL-MIGRATION: after W3 cells/** has 0 ContractSpec literals,
@@ -122,9 +122,9 @@ func (v *Validator) strictRules(ctx context.Context, strict bool) []func() []Val
 		// FMT-18 deleted in PR-V1-CODEGEN-FULL-MIGRATION W4 (replaced by archtest
 		// CELLS-NO-WRAPPER-CONTRACTSPEC-IMPORT-01 / NO-MANUAL-CONTRACTSPEC-LITERAL-01).
 		func() []ValidationResult { return v.validateFMT19(strict) },
-		func() []ValidationResult { return v.validateFMTC1(strict) },
-		// FMT-A1 is now registered in the default rules() pipeline (it
-		// mirrors a schema constraint and applies on every validate path).
+		// FMT-A1 and FMT-C1 are now registered in the default rules()
+		// pipeline (they mirror schema constraints and apply on every
+		// validate path).
 		func() []ValidationResult { return v.validateDOCNAME01(strict) },
 	}
 }
@@ -215,20 +215,31 @@ func (v *Validator) validateFMT17(strict bool) []ValidationResult {
 	return results
 }
 
-// validateFMTC1 checks that no cell.yaml declares a kebab-case id (contains '-').
-// In strict mode this is a SeverityError; in non-strict mode it is silent.
+// validateFMTC1 checks that every cell.yaml id satisfies
+// metadata.CellIDPattern (^[a-z][a-z0-9]+$). It runs unconditionally:
+// the rule mirrors a schema-level constraint (schemas/cell.schema.json
+// properties.id.pattern, kept byte-equal by TestSchemaConstantsMatchSchema
+// Literals) and schema-aware tooling rejects the same values without a
+// strict toggle. Gating this check on --strict would leave default
+// `gocell validate` users on a different contract than the schema, mirroring
+// the single-gatekeeper model declared in docs/architecture/202605061800-
+// adr-assembly-yaml-minimal-derivation.md §"Schema 约束单源".
 //
-// This complements FMT-16: FMT-16 catches kebab filesystem directories, while
-// FMT-C1 catches kebab yaml ids even when the directory is already no-dash
-// (e.g. during a migration where id is fixed last). A clean project passes
-// both; a half-migrated project typically trips one of them.
-func (v *Validator) validateFMTC1(strict bool) []ValidationResult {
-	if !strict {
-		return nil
-	}
+// This is the same pattern as validateFMTA1 (assembly id) — both are
+// registered in the rules() pipeline at validate.go and accept the strict
+// param only for signature symmetry inside the strictRules dispatcher
+// (which no longer registers them).
+//
+// FMT-C1 complements FMT-16: FMT-16 catches kebab filesystem directories,
+// while FMT-C1 catches non-conforming yaml ids (kebab, uppercase, single
+// char, leading digit) even when the directory is already no-dash. A clean
+// project passes both.
+//
+// strict is accepted for signature symmetry but no longer changes behavior.
+func (v *Validator) validateFMTC1(_ bool) []ValidationResult {
 	var results []ValidationResult
 	for _, c := range v.project.Cells {
-		if !strings.Contains(c.ID, "-") {
+		if metadata.MatchCellID(c.ID) {
 			continue
 		}
 		results = append(results, v.newResult(
@@ -236,8 +247,8 @@ func (v *Validator) validateFMTC1(strict bool) []ValidationResult {
 			cellFile(c),
 			"id",
 			fmt.Sprintf(
-				"cell id %q contains '-'; kebab-case cell ids are disallowed in strict mode (rename to %q)",
-				c.ID, strings.ReplaceAll(c.ID, "-", ""),
+				"cell id %q does not match %s; use lowercase ASCII letters + digits, ≥2 chars, starting with a letter",
+				c.ID, metadata.CellIDPattern,
 			),
 		))
 	}
@@ -255,9 +266,11 @@ func (v *Validator) validateFMTC1(strict bool) []ValidationResult {
 // declared in docs/architecture/202605061800-adr-assembly-yaml-minimal-
 // derivation.md §"Schema 约束单源".
 //
-// FMT-C1 / FMT-16 / FMT-17 stay strict-only because cell.schema.json id
-// pattern itself permits kebab (different schema design); those rules
-// remain stylistic strict-mode preferences, not schema mirrors.
+// FMT-16 / FMT-17 stay strict-only because they catch stylistic
+// concerns (kebab-case filesystem directories, allowedFiles drift) that
+// schemas do not directly mirror; FMT-C1 was migrated to the rules()
+// pipeline alongside cell.schema.json properties.id.pattern收紧 (PR-2
+// PR-PROM-HARDEN-3).
 //
 // strict is accepted for signature symmetry with the strictRules block but
 // no longer changes behavior.

--- a/kernel/governance/rules_misc_strict_test.go
+++ b/kernel/governance/rules_misc_strict_test.go
@@ -564,51 +564,65 @@ func TestREF05_PathIDSplit_FiresWhenDirAndIDDisagree(t *testing.T) {
 	}
 }
 
-// TestStrictValidator_FMTC1_KebabCellID verifies that FMT-C1 flags cell.yaml
-// ids containing '-' (kebab-case) in strict mode and is silent otherwise.
-// Uses synthetic ids (foo-bar) so later repo-wide sed renames do not erase
-// the kebab fixture.
-func TestStrictValidator_FMTC1_KebabCellID(t *testing.T) {
-	project := &metadata.ProjectMeta{
-		Cells: map[string]*metadata.CellMeta{
-			"foo-bar": {
-				ID:               "foo-bar",
-				Type:             "core",
-				ConsistencyLevel: "L2",
-				Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
-				Schema:           metadata.SchemaMeta{Primary: "cell_foobar"},
-				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.startup"}},
-				Dir:              "foobar", // dir already no-dash, but id still dash
-			},
-		},
-		Slices:     map[string]*metadata.SliceMeta{},
-		Contracts:  map[string]*metadata.ContractMeta{},
-		Journeys:   map[string]*metadata.JourneyMeta{},
-		Assemblies: map[string]*metadata.AssemblyMeta{},
+// TestValidator_FMTC1_CellIDPattern verifies FMT-C1 fires unconditionally
+// for cell ids that violate CellIDPattern (kebab, uppercase, single char,
+// leading digit, etc.). FMT-C1 mirrors a schema constraint
+// (schemas/cell.schema.json id.pattern) so it must trip on both the default
+// and strict validate paths — schema-aware tooling rejects the same value
+// without a strict toggle. Uses synthetic ids so later repo-wide sed renames
+// do not erase the fixture.
+func TestValidator_FMTC1_CellIDPattern(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"kebab_disallowed", "foo-bar"},
+		{"uppercase_disallowed", "FooBar"},
+		{"single_char_disallowed", "a"},
+		{"leading_digit_disallowed", "1foo"},
+		{"underscore_disallowed", "foo_bar"},
 	}
 
-	v := NewValidator(project, "", clock.Real())
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			project := &metadata.ProjectMeta{
+				Cells: map[string]*metadata.CellMeta{
+					tc.id: {
+						ID:               tc.id,
+						Type:             "core",
+						ConsistencyLevel: "L2",
+						Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+						Schema:           metadata.SchemaMeta{Primary: "cell_foobar"},
+						Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.startup"}},
+						Dir:              "foobar",
+					},
+				},
+				Slices:     map[string]*metadata.SliceMeta{},
+				Contracts:  map[string]*metadata.ContractMeta{},
+				Journeys:   map[string]*metadata.JourneyMeta{},
+				Assemblies: map[string]*metadata.AssemblyMeta{},
+			}
 
-	// Non-strict: silent.
-	forRes569, err := v.ValidateStrict(t.Context(), false)
-	require.NoError(t, err)
-	for _, r := range forRes569 {
-		if r.Code == "FMT-C1" {
-			t.Errorf("non-strict mode must not emit FMT-C1: %s", r.Message)
-		}
-	}
+			v := NewValidator(project, "", clock.Real())
 
-	// Strict: must fire FMT-C1.
-	var got bool
-	forRes577, err := v.ValidateStrict(t.Context(), true)
-	require.NoError(t, err)
-	for _, r := range forRes577 {
-		if r.Code == "FMT-C1" && r.Severity == SeverityError {
-			got = true
-		}
-	}
-	if !got {
-		t.Error("strict mode should produce FMT-C1 error for kebab-case cell id")
+			for _, strict := range []bool{false, true} {
+				strict := strict
+				t.Run(fmtBoolName(strict), func(t *testing.T) {
+					results, err := v.ValidateStrict(t.Context(), strict)
+					require.NoError(t, err)
+					var got bool
+					for _, r := range results {
+						if r.Code == "FMT-C1" && r.Severity == SeverityError {
+							got = true
+						}
+					}
+					if !got {
+						t.Errorf("FMT-C1 must fire for invalid cell id %q (strict=%v)", tc.id, strict)
+					}
+				})
+			}
+		})
 	}
 }
 

--- a/kernel/governance/rules_misc_strict_test.go
+++ b/kernel/governance/rules_misc_strict_test.go
@@ -6,6 +6,7 @@ package governance
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -564,6 +565,37 @@ func TestREF05_PathIDSplit_FiresWhenDirAndIDDisagree(t *testing.T) {
 	}
 }
 
+// assertRuleFiresInBothModes runs ValidateStrict in both default and
+// strict modes and fails when the given rule code does not fire as a
+// SeverityError in either pass. Extracted so FMTC1/FMTA1 unconditional-
+// rule tests share the same shape and stay under the cognitive
+// complexity budget.
+func assertRuleFiresInBothModes(t *testing.T, v *Validator, code, fixtureDesc string) {
+	t.Helper()
+	for _, strict := range []bool{false, true} {
+		strict := strict
+		t.Run(fmtBoolName(strict), func(t *testing.T) {
+			results, err := v.ValidateStrict(t.Context(), strict)
+			require.NoError(t, err)
+			if !ruleFiredAsError(results, code) {
+				t.Errorf("%s must fire for %s (strict=%v)", code, fixtureDesc, strict)
+			}
+		})
+	}
+}
+
+// ruleFiredAsError reports whether results contains at least one
+// SeverityError matching code. Side-effect free; used by the
+// assertRuleFires* helpers.
+func ruleFiredAsError(results []ValidationResult, code string) bool {
+	for _, r := range results {
+		if r.Code == code && r.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
 // TestValidator_FMTC1_CellIDPattern verifies FMT-C1 fires unconditionally
 // for cell ids that violate CellIDPattern (kebab, uppercase, single char,
 // leading digit, etc.). FMT-C1 mirrors a schema constraint
@@ -605,23 +637,8 @@ func TestValidator_FMTC1_CellIDPattern(t *testing.T) {
 			}
 
 			v := NewValidator(project, "", clock.Real())
-
-			for _, strict := range []bool{false, true} {
-				strict := strict
-				t.Run(fmtBoolName(strict), func(t *testing.T) {
-					results, err := v.ValidateStrict(t.Context(), strict)
-					require.NoError(t, err)
-					var got bool
-					for _, r := range results {
-						if r.Code == "FMT-C1" && r.Severity == SeverityError {
-							got = true
-						}
-					}
-					if !got {
-						t.Errorf("FMT-C1 must fire for invalid cell id %q (strict=%v)", tc.id, strict)
-					}
-				})
-			}
+			assertRuleFiresInBothModes(t, v, "FMT-C1",
+				fmt.Sprintf("invalid cell id %q", tc.id))
 		})
 	}
 }
@@ -650,23 +667,7 @@ func TestValidator_FMTA1_AssemblyIDPattern(t *testing.T) {
 	}
 
 	v := NewValidator(project, "", clock.Real())
-
-	for _, strict := range []bool{false, true} {
-		strict := strict
-		t.Run(fmtBoolName(strict), func(t *testing.T) {
-			results, err := v.ValidateStrict(t.Context(), strict)
-			require.NoError(t, err)
-			var got bool
-			for _, r := range results {
-				if r.Code == "FMT-A1" && r.Severity == SeverityError {
-					got = true
-				}
-			}
-			if !got {
-				t.Errorf("FMT-A1 must fire for kebab-case assembly id (strict=%v)", strict)
-			}
-		})
-	}
+	assertRuleFiresInBothModes(t, v, "FMT-A1", "kebab-case assembly id")
 }
 
 func fmtBoolName(b bool) string {

--- a/kernel/governance/targets_test.go
+++ b/kernel/governance/targets_test.go
@@ -339,8 +339,8 @@ func l0Project() *metadata.ProjectMeta {
 				Type:             "support",
 				ConsistencyLevel: "L0",
 			},
-			"shared-validate": {
-				ID:               "shared-validate",
+			"sharedvalidate": {
+				ID:               "sharedvalidate",
 				Type:             "support",
 				ConsistencyLevel: "L0",
 				// L0 cell with NO slices — tests propagation for slice-less cells.
@@ -351,7 +351,7 @@ func l0Project() *metadata.ProjectMeta {
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
 					{Cell: "sharedcrypto", Reason: "hashing"},
-					{Cell: "shared-validate", Reason: "input validation"},
+					{Cell: "sharedvalidate", Reason: "input validation"},
 				},
 			},
 			"auditcore": {
@@ -360,8 +360,8 @@ func l0Project() *metadata.ProjectMeta {
 				ConsistencyLevel: "L2",
 				// no L0 dependencies
 			},
-			"billing-core": {
-				ID:               "billing-core",
+			"billingcore": {
+				ID:               "billingcore",
 				Type:             "core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
@@ -376,7 +376,7 @@ func l0Project() *metadata.ProjectMeta {
 				ID:            "hasher",
 				BelongsToCell: "sharedcrypto",
 			},
-			// shared-validate has NO slices (intentional).
+			// sharedvalidate has NO slices (intentional).
 			"accesscore/session-login": {
 				ID:            "session-login",
 				BelongsToCell: "accesscore",
@@ -388,9 +388,9 @@ func l0Project() *metadata.ProjectMeta {
 				ID:            "audit-write",
 				BelongsToCell: "auditcore",
 			},
-			"billing-core/payment": {
+			"billingcore/payment": {
 				ID:            "payment",
-				BelongsToCell: "billing-core",
+				BelongsToCell: "billingcore",
 			},
 		},
 		Contracts: map[string]*metadata.ContractMeta{
@@ -421,10 +421,10 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 			name:  "L0 cell change propagates to all dependent cells",
 			files: []string{"cells/sharedcrypto/slices/hasher/hash.go"},
 			// sharedcrypto/hasher is directly affected;
-			// accesscore AND billing-core both depend on sharedcrypto,
+			// accesscore AND billingcore both depend on sharedcrypto,
 			// so their slices are also selected.
-			wantSlices:    []string{"accesscore/session-login", "billing-core/payment", "sharedcrypto/hasher"},
-			wantCells:     []string{"accesscore", "billing-core", "sharedcrypto"},
+			wantSlices:    []string{"accesscore/session-login", "billingcore/payment", "sharedcrypto/hasher"},
+			wantCells:     []string{"accesscore", "billingcore", "sharedcrypto"},
 			wantContracts: []string{"http.auth.login.v1"},
 		},
 		{
@@ -439,8 +439,8 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 			name:  "journey referencing L0 cell does NOT trigger L0 propagation",
 			files: []string{"journeys/J-l0-test.yaml"},
 			// Journey references sharedcrypto (L0) and accesscore.
-			// billing-core depends on sharedcrypto but is NOT in the journey.
-			// If L0 propagation fired from journey expansion, billing-core/payment
+			// billingcore depends on sharedcrypto but is NOT in the journey.
+			// If L0 propagation fired from journey expansion, billingcore/payment
 			// would appear — its absence proves the guard works.
 			wantSlices:    []string{"accesscore/session-login", "sharedcrypto/hasher"},
 			wantCells:     []string{"accesscore", "sharedcrypto"},
@@ -448,8 +448,8 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 		},
 		{
 			name:  "L0 cell without slices propagates to dependents",
-			files: []string{"cells/shared-validate/cell.yaml"},
-			// shared-validate is L0 with no slices. Changing its cell.yaml
+			files: []string{"cells/sharedvalidate/cell.yaml"},
+			// sharedvalidate is L0 with no slices. Changing its cell.yaml
 			// should still propagate to accesscore (which depends on it).
 			wantSlices:    []string{"accesscore/session-login"},
 			wantCells:     []string{"accesscore"},

--- a/kernel/governance/targets_test.go
+++ b/kernel/governance/targets_test.go
@@ -334,8 +334,8 @@ func TestSelectFromFiles_NonexistentJourney(t *testing.T) {
 func l0Project() *metadata.ProjectMeta {
 	return &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{
-			"shared-crypto": {
-				ID:               "shared-crypto",
+			"sharedcrypto": {
+				ID:               "sharedcrypto",
 				Type:             "support",
 				ConsistencyLevel: "L0",
 			},
@@ -350,7 +350,7 @@ func l0Project() *metadata.ProjectMeta {
 				Type:             "core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "sharedcrypto", Reason: "hashing"},
 					{Cell: "shared-validate", Reason: "input validation"},
 				},
 			},
@@ -365,16 +365,16 @@ func l0Project() *metadata.ProjectMeta {
 				Type:             "core",
 				ConsistencyLevel: "L2",
 				L0Dependencies: []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "signature"},
+					{Cell: "sharedcrypto", Reason: "signature"},
 				},
 				// NOT referenced by J-l0-test journey — used to test
 				// that journey changes don't trigger L0 propagation.
 			},
 		},
 		Slices: map[string]*metadata.SliceMeta{
-			"shared-crypto/hasher": {
+			"sharedcrypto/hasher": {
 				ID:            "hasher",
-				BelongsToCell: "shared-crypto",
+				BelongsToCell: "sharedcrypto",
 			},
 			// shared-validate has NO slices (intentional).
 			"accesscore/session-login": {
@@ -402,7 +402,7 @@ func l0Project() *metadata.ProjectMeta {
 		Journeys: map[string]*metadata.JourneyMeta{
 			"J-l0-test": {
 				ID:    "J-l0-test",
-				Cells: []string{"shared-crypto", "accesscore"},
+				Cells: []string{"sharedcrypto", "accesscore"},
 			},
 		},
 		Assemblies: map[string]*metadata.AssemblyMeta{},
@@ -419,12 +419,12 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 	}{
 		{
 			name:  "L0 cell change propagates to all dependent cells",
-			files: []string{"cells/shared-crypto/slices/hasher/hash.go"},
-			// shared-crypto/hasher is directly affected;
-			// accesscore AND billing-core both depend on shared-crypto,
+			files: []string{"cells/sharedcrypto/slices/hasher/hash.go"},
+			// sharedcrypto/hasher is directly affected;
+			// accesscore AND billing-core both depend on sharedcrypto,
 			// so their slices are also selected.
-			wantSlices:    []string{"accesscore/session-login", "billing-core/payment", "shared-crypto/hasher"},
-			wantCells:     []string{"accesscore", "billing-core", "shared-crypto"},
+			wantSlices:    []string{"accesscore/session-login", "billing-core/payment", "sharedcrypto/hasher"},
+			wantCells:     []string{"accesscore", "billing-core", "sharedcrypto"},
 			wantContracts: []string{"http.auth.login.v1"},
 		},
 		{
@@ -438,12 +438,12 @@ func TestSelectFromFiles_L0DependencyTracking(t *testing.T) {
 		{
 			name:  "journey referencing L0 cell does NOT trigger L0 propagation",
 			files: []string{"journeys/J-l0-test.yaml"},
-			// Journey references shared-crypto (L0) and accesscore.
-			// billing-core depends on shared-crypto but is NOT in the journey.
+			// Journey references sharedcrypto (L0) and accesscore.
+			// billing-core depends on sharedcrypto but is NOT in the journey.
 			// If L0 propagation fired from journey expansion, billing-core/payment
 			// would appear — its absence proves the guard works.
-			wantSlices:    []string{"accesscore/session-login", "shared-crypto/hasher"},
-			wantCells:     []string{"accesscore", "shared-crypto"},
+			wantSlices:    []string{"accesscore/session-login", "sharedcrypto/hasher"},
+			wantCells:     []string{"accesscore", "sharedcrypto"},
 			wantContracts: []string{"http.auth.login.v1"},
 		},
 		{

--- a/kernel/governance/validate.go
+++ b/kernel/governance/validate.go
@@ -192,6 +192,7 @@ func (v *Validator) rules() []func() []ValidationResult {
 		v.validateFMT13, v.validateFMT14, v.validateFMT15, v.validateFMT24, v.validateFMT26,
 		v.validateFMT27, v.validateFMT28, v.validateFMT29, v.validateFMT30, v.validateFMT31,
 		func() []ValidationResult { return v.validateFMTA1(false) },
+		func() []ValidationResult { return v.validateFMTC1(false) },
 		v.validateADV01, v.validateADV03, v.validateADV04, v.validateADV05,
 		v.validateADV06,
 		v.validateOUTGUARD01,

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -50,14 +50,14 @@ func validProject() *metadata.ProjectMeta {
 				Dir:              "auditcore",
 				File:             "cells/auditcore/cell.yaml",
 			},
-			"shared-crypto": {
-				ID:               "shared-crypto",
+			"sharedcrypto": {
+				ID:               "sharedcrypto",
 				Type:             "support",
 				ConsistencyLevel: "L0",
 				Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
-				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.shared-crypto.startup"}},
-				Dir:              "shared-crypto",
-				File:             "cells/shared-crypto/cell.yaml",
+				Verify:           metadata.CellVerifyMeta{Smoke: []string{"smoke.sharedcrypto.startup"}},
+				Dir:              "sharedcrypto",
+				File:             "cells/sharedcrypto/cell.yaml",
 			},
 		},
 		Slices: map[string]*metadata.SliceMeta{
@@ -179,7 +179,7 @@ func validProject() *metadata.ProjectMeta {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"corebundle": {
 				ID:                  "corebundle",
-				Cells:               []string{"accesscore", "auditcore", "shared-crypto"},
+				Cells:               []string{"accesscore", "auditcore", "sharedcrypto"},
 				MaxConsistencyLevel: "L2", // derived: max of L2, L2, L0
 				Owner:               metadata.OwnerMeta{Team: "platform", Role: "assembly-owner"},
 				Build: metadata.BuildMeta{
@@ -538,7 +538,7 @@ func TestREF09(t *testing.T) {
 			name: "valid l0 dependency",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Cells["accesscore"].L0Dependencies = []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "sharedcrypto", Reason: "hashing"},
 				}
 			},
 			wantCount: 0,
@@ -841,7 +841,7 @@ func TestTOPO05(t *testing.T) {
 					ConsistencyLevel: "L0",
 					Lifecycle:        "active",
 					Endpoints: metadata.EndpointsMeta{
-						Server:  "shared-crypto", // L0 cell
+						Server:  "sharedcrypto", // L0 cell
 						Clients: []string{"accesscore"},
 					},
 				}
@@ -859,7 +859,7 @@ func TestTOPO05(t *testing.T) {
 					Lifecycle:        "active",
 					Endpoints: metadata.EndpointsMeta{
 						Server:  "accesscore",
-						Clients: []string{"shared-crypto"}, // L0 cell
+						Clients: []string{"sharedcrypto"}, // L0 cell
 					},
 				}
 			},
@@ -1155,7 +1155,7 @@ func TestVERIFY03(t *testing.T) {
 			name: "l0 dependency targets L0 cell",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Cells["accesscore"].L0Dependencies = []metadata.L0DepMeta{
-					{Cell: "shared-crypto", Reason: "hashing"},
+					{Cell: "sharedcrypto", Reason: "hashing"},
 				}
 			},
 			wantCount: 0,
@@ -1990,7 +1990,7 @@ func TestFMT06(t *testing.T) {
 		{
 			name: "L0 cell without schema.primary is ok",
 			setup: func(pm *metadata.ProjectMeta) {
-				// shared-crypto is L0 with no schema.primary — should be fine
+				// sharedcrypto is L0 with no schema.primary — should be fine
 			},
 			wantCount: 0,
 		},
@@ -4712,10 +4712,10 @@ func TestOUTGUARD01(t *testing.T) {
 		{
 			name: "L0 cell without durabilityMode — no warning",
 			setup: func(pm *metadata.ProjectMeta) {
-				// shared-crypto is L0 — no durability declaration required.
+				// sharedcrypto is L0 — no durability declaration required.
 				pm.Cells["accesscore"].DurabilityMode = "durable"
 				pm.Cells["auditcore"].DurabilityMode = "durable"
-				pm.Cells["shared-crypto"].DurabilityMode = ""
+				pm.Cells["sharedcrypto"].DurabilityMode = ""
 			},
 			wantCount: 0,
 		},
@@ -4723,8 +4723,8 @@ func TestOUTGUARD01(t *testing.T) {
 			name: "mixed — only L2+ without durabilityMode warned",
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Cells["accesscore"].DurabilityMode = "durable"
-				pm.Cells["auditcore"].DurabilityMode = ""     // L2, should warn
-				pm.Cells["shared-crypto"].DurabilityMode = "" // L0, should not warn
+				pm.Cells["auditcore"].DurabilityMode = ""    // L2, should warn
+				pm.Cells["sharedcrypto"].DurabilityMode = "" // L0, should not warn
 			},
 			wantCount: 1,
 		},

--- a/kernel/metadata/contract_constraints.go
+++ b/kernel/metadata/contract_constraints.go
@@ -26,14 +26,17 @@ const (
 	// + digits, ≥2 chars, must start with a letter. Mirrors
 	// schemas/assembly.schema.json properties.id.pattern.
 	AssemblyIDPattern = `^[a-z][a-z0-9]+$`
+	// CellIDPattern restricts cell ids to lowercase ASCII letters + digits,
+	// ≥2 chars, must start with a letter. Mirrors
+	// schemas/cell.schema.json properties.id.pattern. Identical to
+	// AssemblyIDPattern by design — both share the no-dash concatenation
+	// convention enforced by FMT-16 / FMT-C1; single-sourced here so adapter
+	// (e.g. adapters/prometheus.promCellLabel), governance, and codegen
+	// layers consume the same regex.
+	CellIDPattern = `^[a-z][a-z0-9]+$`
 	// GoStructNamePattern restricts cell.GoStructName to a Go-exported
 	// identifier shape (uppercase first letter, ASCII letters + digits).
 	// Mirrors schemas/cell.schema.json properties.goStructName.pattern.
-	//
-	// Note: cell.schema.json id.pattern is intentionally more permissive
-	// than the governance FMT-C1 strict-mode rule; that pre-existing
-	// schema/governance gap is out of scope for this PR (see review
-	// docs/reviews/202605070218-pr404-second-wave-review.md §R-meta).
 	GoStructNamePattern = `^[A-Z][A-Za-z0-9]*$`
 )
 
@@ -44,11 +47,15 @@ var DeployTemplateEnum = []string{"k8s", "compose", "binary"}
 
 var (
 	assemblyIDRe   = regexp.MustCompile(AssemblyIDPattern)
+	cellIDRe       = regexp.MustCompile(CellIDPattern)
 	goStructNameRe = regexp.MustCompile(GoStructNamePattern)
 )
 
 // MatchAssemblyID reports whether s satisfies AssemblyIDPattern.
 func MatchAssemblyID(s string) bool { return assemblyIDRe.MatchString(s) }
+
+// MatchCellID reports whether s satisfies CellIDPattern.
+func MatchCellID(s string) bool { return cellIDRe.MatchString(s) }
 
 // MatchGoStructName reports whether s satisfies GoStructNamePattern.
 func MatchGoStructName(s string) bool { return goStructNameRe.MatchString(s) }

--- a/kernel/metadata/contract_constraints_test.go
+++ b/kernel/metadata/contract_constraints_test.go
@@ -1,0 +1,55 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// TestMatchCellID covers the CellIDPattern regex semantics (^[a-z][a-z0-9]+$):
+// lowercase ASCII letters + digits only, ≥2 chars, must start with a letter.
+// Identical to AssemblyIDPattern by design — the no-dash convention enforced
+// by FMT-16 / FMT-C1.
+func TestMatchCellID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		// Valid cases — real-world cell ids in this repository.
+		{"accesscore", "accesscore", true},
+		{"auditcore", "auditcore", true},
+		{"configcore", "configcore", true},
+		{"two_char_min", "ab", true},
+		{"letter_plus_digit", "a0", true},
+		{"long_concat", "mdmgateway", true},
+		{"trailing_digits", "core1", true},
+
+		// Invalid cases.
+		{"empty", "", false},
+		{"single_char", "a", false},
+		{"leading_dash_disallowed", "-foo", false},
+		{"internal_dash_disallowed", "foo-bar", false},
+		{"trailing_dash_disallowed", "foo-", false},
+		{"uppercase_disallowed", "FooBar", false},
+		{"mixed_case_disallowed", "fooBar", false},
+		{"underscore_disallowed", "foo_bar", false},
+		{"digit_start_disallowed", "1foo", false},
+		{"whitespace_disallowed", "foo bar", false},
+		{"slash_disallowed", "foo/bar", false},
+		{"colon_disallowed", "foo:bar", false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := metadata.MatchCellID(tc.in)
+			if got != tc.want {
+				t.Fatalf("MatchCellID(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/kernel/metadata/schemas/cell.schema.json
+++ b/kernel/metadata/schemas/cell.schema.json
@@ -10,7 +10,7 @@
     "id": {
       "type": "string",
       "description": "Unique cell identifier. Must equal the directory name under cells/.",
-      "pattern": "^[a-z][a-z0-9-]*$"
+      "pattern": "^[a-z][a-z0-9]+$"
     },
     "type": {
       "type": "string",

--- a/kernel/metadata/schemas/schema_const_consistency_test.go
+++ b/kernel/metadata/schemas/schema_const_consistency_test.go
@@ -35,6 +35,11 @@ func TestSchemaConstantsMatchSchemaLiterals(t *testing.T) {
 		},
 		{
 			"cell.schema.json",
+			[]string{"properties", "id", "pattern"},
+			"CellIDPattern", metadata.CellIDPattern,
+		},
+		{
+			"cell.schema.json",
 			[]string{"properties", "goStructName", "pattern"},
 			"GoStructNamePattern", metadata.GoStructNamePattern,
 		},

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -13,20 +13,16 @@ import (
 	"encoding/hex"
 	"log/slog"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
-
-// callerCellPattern validates the caller cell id: must start with a lowercase
-// letter and contain only lowercase letters, digits, and hyphens.
-var callerCellPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 // Authenticator inspects an HTTP request and resolves the caller's identity.
 type Authenticator interface {
@@ -266,12 +262,14 @@ func verifyServiceTokenPayload(ring cell.HMACKeyring, payload string, cfg servic
 }
 
 // validateCallerCell validates the caller cell id extracted from the 4-part
-// service token. The cell id must be non-empty and match [a-z][a-z0-9-]*.
+// service token. The cell id must be non-empty and satisfy
+// metadata.CellIDPattern (^[a-z][a-z0-9]+$). Single source — same regex
+// the schema (cell.schema.json) and governance (FMT-C1) enforce.
 func validateCallerCell(callerCell string) error {
 	if callerCell == "" {
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "caller cell missing")
 	}
-	if !callerCellPattern.MatchString(callerCell) {
+	if !metadata.MatchCellID(callerCell) {
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
 			"caller cell id invalid",
 			errcode.WithDetails(slog.String("callerCell", callerCell)))

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -865,8 +865,11 @@ func TestServiceTokenAuthenticator_PastTimestampAtMaxAge_Error(t *testing.T) {
 	}
 }
 
-// TestValidateCallerCell tests the validateCallerCell function directly with
-// a table-driven set of cases covering empty, uppercase, valid, and invalid IDs.
+// TestValidateCallerCell tests the validateCallerCell function directly.
+// Cases reflect metadata.CellIDPattern (^[a-z][a-z0-9]+$): lowercase ASCII
+// letters + digits, ≥2 chars, must start with a letter — same regex
+// schema/governance enforce. Dash, single char, leading digit, uppercase,
+// underscore are all invalid.
 func TestValidateCallerCell(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -890,9 +893,11 @@ func TestValidateCallerCell(t *testing.T) {
 			wantMsg:    "caller cell id",
 		},
 		{
-			name:       "lowercase access-core — valid",
+			name:       "dash access-core — invalid (no-dash CellIDPattern)",
 			callerCell: "access-core",
-			wantErr:    false,
+			wantErr:    true,
+			wantCode:   errcode.ErrAuthUnauthorized,
+			wantMsg:    "caller cell id",
 		},
 		{
 			name:       "starts with digit — invalid",
@@ -902,13 +907,39 @@ func TestValidateCallerCell(t *testing.T) {
 			wantMsg:    "caller cell id",
 		},
 		{
-			name:       "single letter — valid",
+			name:       "single letter — invalid (≥2 chars required)",
 			callerCell: "a",
+			wantErr:    true,
+			wantCode:   errcode.ErrAuthUnauthorized,
+			wantMsg:    "caller cell id",
+		},
+		{
+			name:       "alphanumeric with hyphens — invalid (no-dash CellIDPattern)",
+			callerCell: "a-b-c-123",
+			wantErr:    true,
+			wantCode:   errcode.ErrAuthUnauthorized,
+			wantMsg:    "caller cell id",
+		},
+		{
+			name:       "underscore foo_bar — invalid",
+			callerCell: "foo_bar",
+			wantErr:    true,
+			wantCode:   errcode.ErrAuthUnauthorized,
+			wantMsg:    "caller cell id",
+		},
+		{
+			name:       "concat accesscore — valid",
+			callerCell: "accesscore",
 			wantErr:    false,
 		},
 		{
-			name:       "alphanumeric with hyphens — valid",
-			callerCell: "a-b-c-123",
+			name:       "two char min ab — valid",
+			callerCell: "ab",
+			wantErr:    false,
+		},
+		{
+			name:       "letter plus digit a0 — valid",
+			callerCell: "a0",
 			wantErr:    false,
 		},
 	}

--- a/runtime/bootstrap/bootstrap_phase7.go
+++ b/runtime/bootstrap/bootstrap_phase7.go
@@ -31,8 +31,11 @@ const (
 	defaultBootstrapHTTPReadHeaderTimeout = 10 * time.Second
 	// defaultBootstrapHTTPReadTimeout is the http.Server ReadTimeout.
 	defaultBootstrapHTTPReadTimeout = 30 * time.Second
-	// defaultBootstrapHTTPWriteTimeout is the http.Server WriteTimeout.
-	defaultBootstrapHTTPWriteTimeout = 30 * time.Second
+	// DefaultBootstrapHTTPWriteTimeout is the http.Server WriteTimeout.
+	// Exported so cross-package consumers (e.g. cmd/corebundle metrics
+	// handler scrape-timeout sanity tests) can pin against the same source
+	// of truth instead of duplicating the literal.
+	DefaultBootstrapHTTPWriteTimeout = 30 * time.Second
 	// defaultBootstrapHTTPIdleTimeout is the http.Server IdleTimeout for keep-alive
 	// connections.
 	defaultBootstrapHTTPIdleTimeout = 60 * time.Second
@@ -132,7 +135,7 @@ func (b *Bootstrap) phase7BindListeners(s *phaseState) ([]boundServer, error) {
 				Handler:           rtr.Handler(),
 				ReadHeaderTimeout: defaultBootstrapHTTPReadHeaderTimeout,
 				ReadTimeout:       defaultBootstrapHTTPReadTimeout,
-				WriteTimeout:      defaultBootstrapHTTPWriteTimeout,
+				WriteTimeout:      DefaultBootstrapHTTPWriteTimeout,
 				IdleTimeout:       defaultBootstrapHTTPIdleTimeout,
 			},
 			ln:        ln,

--- a/tools/archtest/cell_id_pattern_single_source_test.go
+++ b/tools/archtest/cell_id_pattern_single_source_test.go
@@ -1,0 +1,257 @@
+// invariants asserted in this file:
+//   - INVARIANT: CELL-ID-PATTERN-SINGLE-SOURCE-01
+//
+// CELL-ID-PATTERN-SINGLE-SOURCE-01: every regexp.MustCompile / Compile /
+// MustCompilePOSIX call in the module whose first argument is a string
+// literal matching the cell-id family of patterns must live in
+// kernel/metadata/contract_constraints.go (the single source) — anywhere
+// else is a duplicate that drifts away from metadata.{Cell,Assembly}IDPattern
+// and must be replaced with metadata.MatchCellID / metadata.MatchAssemblyID.
+//
+// Banned literal strings (exact match, after string unquoting):
+//   - "^[a-z][a-z0-9]+$" — current Cell/AssemblyIDPattern (≥2 chars, no dash);
+//     defined in kernel/metadata/contract_constraints.go.
+//   - "^[a-z][a-z0-9-]*$" — pre-PR-309 legacy form (allowed dash, allowed
+//     single char); eliminated from runtime/auth and tools/archtest in this
+//     PR and listed here to fail-closed against any re-introduction.
+//
+// Patterns with similar shape but different semantics (e.g.
+// `^[a-z][a-z0-9-]+$` for kebab-case panic-reason ids in
+// panic_invariants_test.go, or `^[a-z][a-z0-9]*(?:_[a-z0-9]+)*_ready$`
+// for adapter ready-probe names) are NOT in the banned set — they are
+// distinct, well-anchored sub-grammars unrelated to cell-id matching.
+//
+// AI-rebust: Medium. Detection uses *types.Info to resolve the callee to
+// regexp.MustCompile (form-independent of `import r "regexp"` aliasing or
+// `re := regexp.MustCompile` indirection) and exact string-content match
+// on the first arg literal. Hard is not reachable in Go for this rule
+// shape: regexp.MustCompile takes a plain string, and Go has no string-
+// literal typing or sealed-by-pattern dispatch. Bypass paths: (a) write
+// the pattern as a non-literal expression (string concat, var ref) — the
+// rule does not chase indirection by design, and review will catch the
+// odd shape; (b) tweak the regex semantics (different anchor, extra
+// character class) — at that point it is a different pattern with
+// different semantics, not a "looks-like cell id" duplicate.
+//
+// ref: kernel/metadata/contract_constraints.go — single source for cell-id family patterns + matchers (MatchCellID, MatchAssemblyID).
+// ref: tools/archtest/prom_cell_label_funnel_test.go — companion typeseval callee-resolution range pattern.
+// ref: .claude/rules/gocell/ai-collab.md — Medium archtest (typed-info + literal allowlist + path allowlist).
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+	"github.com/ghbvf/gocell/tools/internal/fileroles"
+)
+
+const (
+	cellIDPatternRuleID         = "CELL-ID-PATTERN-SINGLE-SOURCE-01"
+	regexpPkgPath               = "regexp"
+	cellIDPatternAllowFile      = "kernel/metadata/contract_constraints.go"
+	cellIDPatternAllowSelfFile  = "tools/archtest/cell_id_pattern_single_source_test.go"
+	legacyCallerCellRegexString = `^[a-z][a-z0-9-]*$`
+)
+
+// regexpCompileFuncs are the regexp package entry points that take a
+// pattern string and produce a *regexp.Regexp. All three are gated by the
+// same rule.
+var regexpCompileFuncs = map[string]struct{}{
+	"MustCompile":      {},
+	"Compile":          {},
+	"MustCompilePOSIX": {},
+	"CompilePOSIX":     {},
+}
+
+// bannedPatterns is the set of literal regex strings that may only be
+// compiled inside kernel/metadata/. Strings are computed once via the
+// metadata constants so this archtest does not itself encode the same
+// literal twice (single-source consistency with metadata.go).
+//
+// CellIDPattern and AssemblyIDPattern currently share the same string
+// (^[a-z][a-z0-9]+$); building the set from a slice tolerates that
+// equality without a map-literal duplicate-key compile error.
+func bannedPatterns() map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, p := range []string{
+		metadata.CellIDPattern,
+		metadata.AssemblyIDPattern,
+		legacyCallerCellRegexString,
+	} {
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+// TestCellIDPatternSingleSource enforces CELL-ID-PATTERN-SINGLE-SOURCE-01.
+//
+// Loads the production package set via the typed funnel
+// typeseval.LoadProductionPackages (PRODUCTION-LOADER-FUNNEL-01 — the
+// raw SharedResolver(_, _, _, "./...") form is banned in archtest test
+// files) and walks every regexp.MustCompile family call. Records a
+// violation when the first arg is a banned string literal and the file
+// is not in the allowlist. Test files are also scanned (tests=true) so
+// stray cell-id regex declared in *_test.go is caught.
+func TestCellIDPatternSingleSource(t *testing.T) {
+	t.Parallel()
+
+	root := findModuleRoot(t)
+	module := readModulePath(t, root)
+
+	resolver, err := typeseval.LoadProductionPackages(
+		root, module, true /* tests */, typeseval.FlatNonDefaultTags())
+	require.NoError(t, err, "LoadProductionPackages failed")
+
+	allowFiles := map[string]struct{}{
+		cellIDPatternAllowFile:     {},
+		cellIDPatternAllowSelfFile: {},
+	}
+	banned := bannedPatterns()
+
+	var violations []string
+	for _, p := range resolver.Production() {
+		if p == nil || p.TypesInfo == nil {
+			continue
+		}
+		for i, file := range p.Syntax {
+			if i >= len(p.GoFiles) {
+				continue
+			}
+			abs := p.GoFiles[i]
+			rel, ok := fileroles.Rel(root, abs)
+			if !ok {
+				continue
+			}
+			if _, ok := allowFiles[rel]; ok {
+				continue
+			}
+			violations = append(violations,
+				scanCellIDPatternCalls(p, file, rel, banned)...)
+		}
+	}
+
+	sort.Strings(violations)
+	violations = dedupSortedStrings(violations)
+	if len(violations) > 0 {
+		t.Fatalf("%s: regexp.MustCompile/Compile of cell-id family pattern "+
+			"must live in %s; use metadata.MatchCellID / "+
+			"metadata.MatchAssemblyID elsewhere.\nViolations (%d):\n  %s",
+			cellIDPatternRuleID, cellIDPatternAllowFile,
+			len(violations), strings.Join(violations, "\n  "))
+	}
+}
+
+// scanCellIDPatternCalls walks file's AST for regexp.MustCompile-family
+// calls and returns one violation per banned-literal first arg.
+func scanCellIDPatternCalls(
+	p *packages.Package, file *ast.File, rel string, banned map[string]struct{},
+) []string {
+	var out []string
+	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if !isRegexpCompileCall(p.TypesInfo, call.Fun) {
+			return
+		}
+		if len(call.Args) == 0 {
+			return
+		}
+		lit := constLiteralValue(p.TypesInfo, call.Args[0])
+		if lit == "" {
+			return
+		}
+		if _, isBanned := banned[lit]; !isBanned {
+			return
+		}
+		pos := p.Fset.Position(call.Pos())
+		out = append(out, fmt.Sprintf(
+			"%s:%d: regexp.MustCompile(%q) — banned cell-id family literal; "+
+				"compile only in %s, callers should use metadata.MatchCellID",
+			rel, pos.Line, lit, cellIDPatternAllowFile,
+		))
+	})
+	return out
+}
+
+// isRegexpCompileCall resolves fun via *types.Info.Uses and reports
+// whether it refers to one of regexp's MustCompile / Compile /
+// MustCompilePOSIX / CompilePOSIX. Resolution through the type checker
+// makes alias imports (`import r "regexp"`) and function-variable
+// indirection (`mc := regexp.MustCompile`) match the same way.
+func isRegexpCompileCall(info *types.Info, fun ast.Expr) bool {
+	if info == nil {
+		return false
+	}
+	var ident *ast.Ident
+	switch v := fun.(type) {
+	case *ast.Ident:
+		ident = v
+	case *ast.SelectorExpr:
+		ident = v.Sel
+	default:
+		return false
+	}
+	obj := info.Uses[ident]
+	if obj == nil {
+		return false
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok || fn.Pkg() == nil {
+		return false
+	}
+	if fn.Pkg().Path() != regexpPkgPath {
+		return false
+	}
+	_, ok = regexpCompileFuncs[fn.Name()]
+	return ok
+}
+
+// constLiteralValue extracts the string content of arg if it is a string
+// literal or a constant string expression (e.g. metadata.CellIDPattern
+// reference). Returns "" if arg is not a const-resolvable string.
+//
+// Const ref resolution uses *types.Info.Types, which carries the const
+// value computed by the type checker; this catches the case where a
+// caller spells the pattern as `metadata.CellIDPattern` rather than the
+// raw `^[a-z][a-z0-9]+$` literal — both compile to the same banned
+// outcome.
+func constLiteralValue(info *types.Info, arg ast.Expr) string {
+	if info == nil {
+		return ""
+	}
+	tv, ok := info.Types[arg]
+	if !ok || tv.Value == nil {
+		return ""
+	}
+	if tv.Value.Kind() != constant.String {
+		return ""
+	}
+	return constant.StringVal(tv.Value)
+}
+
+// dedupSortedStrings deduplicates an already-sorted slice in place. Used
+// to fold duplicate diagnostics from packages.Visit's TestVariant overlap
+// (the same file appears in both the `package x` and `package x_test`
+// load when tests=true).
+func dedupSortedStrings(in []string) []string {
+	if len(in) <= 1 {
+		return in
+	}
+	out := in[:1]
+	for _, s := range in[1:] {
+		if s == out[len(out)-1] {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/tools/archtest/prom_cell_label_funnel_test.go
+++ b/tools/archtest/prom_cell_label_funnel_test.go
@@ -1,0 +1,93 @@
+// invariants asserted in this file:
+//   - INVARIANT: PROM-CELL-LABEL-FUNNEL-01
+//
+// PROM-CELL-LABEL-FUNNEL-01: every read of cell.HookEvent.CellID in
+// adapters/prometheus/*.go (non-test, excluding cell_label.go itself) must
+// be the direct argument of a call to promCellLabel(...). The single
+// typed-function funnel routes the field through metadata.CellIDPattern
+// validation; bypassing it would let a non-conforming cell_id reach
+// Prometheus labels and create high-cardinality series silently.
+//
+// AI-rebust: Hard (typed-function-call funnel + AST form uniqueness,
+// charter §4 Wave 2 same pattern as PANIC-REGISTERED-01).
+//
+// ref: adapters/prometheus/cell_label.go — promCellLabel funnel
+// ref: tools/archtest/panic_invariants_test.go — companion Hard form pattern
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+// TestPromCellLabelFunnel enforces PROM-CELL-LABEL-FUNNEL-01.
+func TestPromCellLabelFunnel(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoRootFromTestPath(t)
+
+	pred := scanner.MatchRels(func(rel string) bool {
+		base := filepath.Base(rel)
+		if strings.HasSuffix(base, "_test.go") {
+			return false
+		}
+		// Exclude the funnel definition file itself — promCellLabel reads
+		// the id string parameter; the rule applies to cell.HookEvent.CellID
+		// field reads, which only occur in caller files.
+		if base == "cell_label.go" {
+			return false
+		}
+		return strings.HasSuffix(base, ".go")
+	})
+
+	scope := scanner.DirsScope(repoRoot, []string{
+		"adapters/prometheus",
+	}, pred)
+
+	var violations []string
+
+	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
+		// Build the set of *ast.SelectorExpr nodes that are direct argument
+		// of a promCellLabel(...) call — these are the approved reads.
+		approved := map[*ast.SelectorExpr]struct{}{}
+		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || ident.Name != "promCellLabel" {
+				return
+			}
+			if len(call.Args) == 0 {
+				return
+			}
+			if sel, ok := call.Args[0].(*ast.SelectorExpr); ok {
+				approved[sel] = struct{}{}
+			}
+		})
+
+		// Walk every SelectorExpr; flag any `.CellID` read that is not in
+		// the approved set.
+		scanner.EachInSubtree[ast.SelectorExpr](fc.File, func(sel *ast.SelectorExpr) {
+			if sel.Sel == nil || sel.Sel.Name != "CellID" {
+				return
+			}
+			if _, ok := approved[sel]; ok {
+				return
+			}
+			pos := fc.Fset.Position(sel.Pos())
+			violations = append(violations,
+				fc.Rel+":"+strconv.Itoa(pos.Line)+
+					": direct .CellID access must route through promCellLabel(...)")
+		})
+	})
+
+	if len(violations) > 0 {
+		t.Fatalf("PROM-CELL-LABEL-FUNNEL-01: cell.HookEvent.CellID reads in adapters/prometheus/ "+
+			"must be the direct argument of promCellLabel(...).\n"+
+			"Violations (%d):\n  %s", len(violations), strings.Join(violations, "\n  "))
+	}
+}

--- a/tools/archtest/prom_cell_label_funnel_test.go
+++ b/tools/archtest/prom_cell_label_funnel_test.go
@@ -3,91 +3,219 @@
 //
 // PROM-CELL-LABEL-FUNNEL-01: every read of cell.HookEvent.CellID in
 // adapters/prometheus/*.go (non-test, excluding cell_label.go itself) must
-// be the direct argument of a call to promCellLabel(...). The single
-// typed-function funnel routes the field through metadata.CellIDPattern
-// validation; bypassing it would let a non-conforming cell_id reach
-// Prometheus labels and create high-cardinality series silently.
+// be the direct argument of a call to adapters/prometheus.promCellLabel(...).
+// The single typed-function funnel routes the field through
+// metadata.CellIDPattern validation; bypassing it would let a non-conforming
+// cell_id reach Prometheus labels and create high-cardinality series
+// silently.
 //
-// AI-rebust: Hard (typed-function-call funnel + AST form uniqueness,
-// charter §4 Wave 2 same pattern as PANIC-REGISTERED-01).
+// AI-rebust: Hard (typed-function-call funnel + types.Info form uniqueness,
+// charter §4 Wave 2 same pattern as PANIC-REGISTERED-01). The funnel call
+// is resolved via *types.Info so a same-name local variable or alias cannot
+// bypass the check; the SelectorExpr's X is also type-checked to be
+// kernel/cell.HookEvent (pointer or value) so unrelated *.CellID fields on
+// future structs do not produce false positives.
 //
-// ref: adapters/prometheus/cell_label.go — promCellLabel funnel
-// ref: tools/archtest/panic_invariants_test.go — companion Hard form pattern
+// ref: adapters/prometheus/cell_label.go — promCellLabel funnel definition
+// ref: tools/archtest/panic_invariants_test.go — companion Hard pattern
 package archtest
 
 import (
+	"fmt"
 	"go/ast"
-	"go/parser"
+	"go/types"
 	"path/filepath"
-	"strconv"
+	"sort"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+
 	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+	"github.com/ghbvf/gocell/tools/internal/fileroles"
+)
+
+const (
+	promAdapterPkgPath = "github.com/ghbvf/gocell/adapters/prometheus"
+	promFunnelFuncName = "promCellLabel"
+	cellPkgPath        = "github.com/ghbvf/gocell/kernel/cell"
+	hookEventTypeName  = "HookEvent"
+	cellLabelDefnFile  = "cell_label.go" // funnel definition; excluded from scan
+	promRuleID         = "PROM-CELL-LABEL-FUNNEL-01"
 )
 
 // TestPromCellLabelFunnel enforces PROM-CELL-LABEL-FUNNEL-01.
 func TestPromCellLabelFunnel(t *testing.T) {
 	t.Parallel()
 
-	repoRoot := repoRootFromTestPath(t)
+	root := findModuleRoot(t)
 
-	pred := scanner.MatchRels(func(rel string) bool {
-		base := filepath.Base(rel)
-		if strings.HasSuffix(base, "_test.go") {
-			return false
-		}
-		// Exclude the funnel definition file itself — promCellLabel reads
-		// the id string parameter; the rule applies to cell.HookEvent.CellID
-		// field reads, which only occur in caller files.
-		if base == "cell_label.go" {
-			return false
-		}
-		return strings.HasSuffix(base, ".go")
-	})
-
-	scope := scanner.DirsScope(repoRoot, []string{
-		"adapters/prometheus",
-	}, pred)
+	pkgs, errs, err := typeseval.LoadPackages(root, false, nil,
+		"./adapters/prometheus/...")
+	require.NoError(t, err, "LoadPackages failed")
+	require.Empty(t, errs, "package load errors must fail-closed: %v", errs)
 
 	var violations []string
 
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
-		// Build the set of *ast.SelectorExpr nodes that are direct argument
-		// of a promCellLabel(...) call — these are the approved reads.
-		approved := map[*ast.SelectorExpr]struct{}{}
-		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
-			ident, ok := call.Fun.(*ast.Ident)
-			if !ok || ident.Name != "promCellLabel" {
-				return
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		// Only scan the production package itself; skip the *_test variant
+		// the test-loader synthesizes (its PkgPath ends with ".test" or has
+		// the `_test` suffix).
+		if p.PkgPath != promAdapterPkgPath {
+			return
+		}
+		for i, file := range p.Syntax {
+			if i >= len(p.GoFiles) {
+				continue
 			}
-			if len(call.Args) == 0 {
-				return
+			abs := p.GoFiles[i]
+			rel, ok := fileroles.Rel(root, abs)
+			if !ok {
+				continue
 			}
-			if sel, ok := call.Args[0].(*ast.SelectorExpr); ok {
-				approved[sel] = struct{}{}
+			// Skip the funnel definition file (it reads its own `id` parameter,
+			// not a HookEvent.CellID) and any test file.
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
 			}
-		})
+			if filepath.Base(rel) == cellLabelDefnFile {
+				continue
+			}
 
-		// Walk every SelectorExpr; flag any `.CellID` read that is not in
-		// the approved set.
-		scanner.EachInSubtree[ast.SelectorExpr](fc.File, func(sel *ast.SelectorExpr) {
-			if sel.Sel == nil || sel.Sel.Name != "CellID" {
-				return
-			}
-			if _, ok := approved[sel]; ok {
-				return
-			}
-			pos := fc.Fset.Position(sel.Pos())
 			violations = append(violations,
-				fc.Rel+":"+strconv.Itoa(pos.Line)+
-					": direct .CellID access must route through promCellLabel(...)")
-		})
+				scanPromCellLabelFunnel(p, file, rel)...)
+		}
 	})
 
+	sort.Strings(violations)
 	if len(violations) > 0 {
-		t.Fatalf("PROM-CELL-LABEL-FUNNEL-01: cell.HookEvent.CellID reads in adapters/prometheus/ "+
+		t.Fatalf("%s: cell.HookEvent.CellID reads in adapters/prometheus/ "+
 			"must be the direct argument of promCellLabel(...).\n"+
-			"Violations (%d):\n  %s", len(violations), strings.Join(violations, "\n  "))
+			"Violations (%d):\n  %s",
+			promRuleID, len(violations), strings.Join(violations, "\n  "))
 	}
+}
+
+// scanPromCellLabelFunnel walks file's AST looking for cell.HookEvent.CellID
+// reads, comparing each against the approved set (direct args of
+// promCellLabel call). The approved set is computed by resolving every
+// CallExpr's callee via *types.Info — string-name matching alone (e.g.
+// `ident.Name == "promCellLabel"`) would let a same-name local variable
+// bypass the funnel, which is why the Hard property requires type
+// resolution (charter §1 form uniqueness).
+func scanPromCellLabelFunnel(p *packages.Package, file *ast.File, rel string) []string {
+	approved := approvedCellIDArgs(p.TypesInfo, file)
+
+	var violations []string
+	for sel := range cellIDSelectorExprs(p.TypesInfo, file) {
+		if _, ok := approved[sel]; ok {
+			continue
+		}
+		pos := p.Fset.Position(sel.Pos())
+		violations = append(violations, fmt.Sprintf(
+			"%s:%d: cell.HookEvent.CellID read must be the direct argument of promCellLabel(...)",
+			rel, pos.Line,
+		))
+	}
+	return violations
+}
+
+// approvedCellIDArgs returns the set of *ast.SelectorExpr nodes that appear
+// as the first positional argument of a call resolving to
+// `adapters/prometheus.promCellLabel` (the funnel). These are the only
+// approved cell.HookEvent.CellID reads under PROM-CELL-LABEL-FUNNEL-01.
+//
+// Callee resolution goes through *types.Info.Uses so a same-name local
+// `promCellLabel` variable does NOT register as an approved call site.
+func approvedCellIDArgs(info *types.Info, file *ast.File) map[*ast.SelectorExpr]struct{} {
+	out := map[*ast.SelectorExpr]struct{}{}
+	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if !isPromFunnelCall(info, call.Fun) {
+			return
+		}
+		if len(call.Args) == 0 {
+			return
+		}
+		sel, ok := call.Args[0].(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+		out[sel] = struct{}{}
+	})
+	return out
+}
+
+// isPromFunnelCall resolves fun via *types.Info.Uses and reports whether
+// it refers to adapters/prometheus.promCellLabel (the funnel). A same-name
+// local variable or function declared in another package fails this check
+// even though its AST form is identical — that is the Hard property.
+func isPromFunnelCall(info *types.Info, fun ast.Expr) bool {
+	if info == nil {
+		return false
+	}
+	var ident *ast.Ident
+	switch v := fun.(type) {
+	case *ast.Ident:
+		ident = v
+	case *ast.SelectorExpr:
+		ident = v.Sel
+	default:
+		return false
+	}
+	obj := info.Uses[ident]
+	if obj == nil {
+		return false
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok || fn.Pkg() == nil {
+		return false
+	}
+	return fn.Pkg().Path() == promAdapterPkgPath && fn.Name() == promFunnelFuncName
+}
+
+// cellIDSelectorExprs returns the set of *ast.SelectorExpr nodes that read
+// the field `CellID` from a value (or pointer) of type kernel/cell.HookEvent.
+// SelectorExpr nodes whose X is some unrelated struct that happens to have
+// a CellID field do not appear in this set — that type discrimination is
+// the precision guard against false positives.
+func cellIDSelectorExprs(info *types.Info, file *ast.File) map[*ast.SelectorExpr]struct{} {
+	out := map[*ast.SelectorExpr]struct{}{}
+	if info == nil {
+		return out
+	}
+	scanner.EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != "CellID" {
+			return
+		}
+		xType := info.TypeOf(sel.X)
+		if xType == nil {
+			return
+		}
+		if !isHookEventType(xType) {
+			return
+		}
+		out[sel] = struct{}{}
+	})
+	return out
+}
+
+// isHookEventType reports whether t is kernel/cell.HookEvent (value or
+// pointer). The check inspects the underlying *types.Named's object and
+// package path so type aliases / renames in callers are tolerated as long
+// as they resolve to the same defined type.
+func isHookEventType(t types.Type) bool {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == cellPkgPath && obj.Name() == hookEventTypeName
 }

--- a/tools/archtest/svctoken_caller_cell_test.go
+++ b/tools/archtest/svctoken_caller_cell_test.go
@@ -24,7 +24,6 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -42,10 +41,6 @@ const ruleSvctokenCallerCellRequired01 = "SVCTOKEN-CALLER-CELL-REQUIRED-01"
 // Shared with role_admin_literal_test.go in the same archtest package; do
 // not duplicate.
 const authRuntimeImportPath = "github.com/ghbvf/gocell/runtime/auth"
-
-// cellIDRegex is the canonical cell-ID pattern: lowercase letter + lowercase
-// alphanumeric/dash, at least 2 chars total.
-var cellIDRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 // TestSVCTOKEN_CALLER_CELL_REQUIRED_01 enforces that every call to
 // auth.GenerateServiceToken passes a valid cell-ID string literal as its
@@ -173,11 +168,13 @@ func collectGenerateServiceTokenDiags(
 					return
 				}
 
-				if !cellIDRegex.MatchString(callerCell) {
+				if !metadata.MatchCellID(callerCell) {
 					add(scanner.Diagnostic{
-						Rel:     rel,
-						Line:    pos.Line,
-						Message: fmt.Sprintf("auth.GenerateServiceToken callerCell %q does not match ^[a-z][a-z0-9-]*$", callerCell),
+						Rel:  rel,
+						Line: pos.Line,
+						Message: fmt.Sprintf(
+							"auth.GenerateServiceToken callerCell %q does not match metadata.CellIDPattern (%s)",
+							callerCell, metadata.CellIDPattern),
 					})
 					return
 				}
@@ -282,12 +279,12 @@ func discoverKnownCells(t *testing.T, root string) map[string]bool {
 		t.Fatalf("metadata.NewParser: %v", err)
 	}
 	for id := range project.Cells {
-		if cellIDRegex.MatchString(id) {
+		if metadata.MatchCellID(id) {
 			known[id] = true
 		}
 	}
 	for _, a := range project.Actors {
-		if cellIDRegex.MatchString(a.ID) {
+		if metadata.MatchCellID(a.ID) {
 			known[a.ID] = true
 		}
 	}


### PR DESCRIPTION
## Summary

PR-2 PR-PROM-HARDEN-3 — Prometheus 出口面 3 项 P1 hardening + cell-id 不变量上提至 Hard。

- **B2-A-22** `/metrics` handler `promhttp.HandlerOpts.Timeout(10s)` + `MaxRequestsInFlight(3)` + self-instrument Registry，scrape 超时返回 503，应用层 timeout 先于 server WriteTimeout 触发（10s < 30s）。
- **B2-A-23** cell-id no-dash invariant 上提：`cell.schema.json` 收紧到 `^[a-z][a-z0-9]+$`，新增 `metadata.CellIDPattern` 单源 + `MatchCellID` helper，`validateFMTC1` unconditional 化（移入 rules() pipeline，对齐 FMT-A1 范式）。+ Hard funnel：新增 `adapters/prometheus/cell_label.go::promCellLabel` typed-function funnel + archtest `PROM-CELL-LABEL-FUNNEL-01` 锁定 form uniqueness。
- **B2-A-24** MetricProvider / HookObserver race tests + `adapters/prometheus` 纳入 `.github/workflows/test-race.yml` race-unit scope。

**AI-rebust: Hard**（typed-function-call funnel + archtest form uniqueness + A class panic.Approved，charter §4 Wave 2 同源范式 PANIC-REGISTERED-01）。立项硬门槛 Medium 达标，本次升 Hard。

## Design 要点

- **invariant 上提，下游零防御**：cell-id 在 schema + governance 双层 unconditional enforce 后，`promCellLabel` 内的 `MatchCellID` 校验是 A class unreachable defense（panic via `panicregister.Approved + errcode.Assertion`）。archtest 锁定任何 `cell.HookEvent.CellID` 读取必须是 `promCellLabel(...)` 的直接参数。
- **dash gap 清理**：旧 cell.schema.json `^[a-z][a-z0-9-]*$` 与 FMT-C1 strict-only 的设计 gap 已知 out-of-scope（contract_constraints.go:36 旧注释）。本 PR 顺手清理，与 AssemblyIDPattern/FMT-A1 单源对齐。实际 7 个 cell.yaml id 全部 no-dash，零破坏。
- **资源复用**：`pkg/panicregister.Approved` / `pkg/errcode.Assertion` / `tools/archtest/internal/{typeseval,scanner}` / `panic_invariants_test.go` 模板 / `hack/verify-archtest.sh` 自动发现 / `// INVARIANT:` godoc 范式全部既有，新增 ~60 行特定 callee 守卫。

## Caveat

`promhttp.HandlerOpts.Timeout` 触发时 `http.TimeoutHandler` 不 cancel `Gather` goroutine。当前所有 collector 内存读取无 IO 无泄漏；引入 IO collector 时需另议（不入 backlog 防 zombie）。

Refs: B2-A-22, B2-A-23, B2-A-24
ref: prometheus/client_golang prometheus/promhttp/http.go `HandlerOpts.Timeout` / `MaxRequestsInFlight`
ref: kernel/governance/rules_misc_strict.go `validateFMTA1`（FMT-C1 升级范式）
ref: tools/archtest/panic_invariants_test.go（PROM-CELL-LABEL-FUNNEL-01 模板）

## Test plan

- [x] go build ./...
- [x] go test ./... （仅 adapters/rabbitmq blackhole timeout 一项 pre-existing 失败，与本 PR 无关）
- [x] go test -race ./adapters/prometheus/... ./kernel/... （pass）
- [x] go build -tags=integration ./... （pass）
- [x] go vet ./... （0 issues）
- [x] golangci-lint run ./... （0 issues）
- [x] go test ./tools/archtest/... （含新 PROM-CELL-LABEL-FUNNEL-01，pass）
- [ ] gocell validate （CI 跑）
- [ ] gocell validate --strict （CI 跑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)