### PR TITLE
docs(architecture): add framework capability analysis (DDD scope / inventory / interactions / gaps)

### DIFF
--- a/docs/architecture/202605131500-001-ddd-scope-analysis.md
+++ b/docs/architecture/202605131500-001-ddd-scope-analysis.md
@@ -1,0 +1,62 @@
+# DDD API 设计在 GoCell 分层中的适用范围
+
+> 系列文档 1/4 · 配套文档：[002 能力盘点](./202605131500-002-framework-capability-inventory.md) · [003 交互模式](./202605131500-003-capability-interaction-patterns.md) · [004 缺口分析](./202605131500-004-capability-gap-analysis.md)
+
+## 结论
+
+DDD 核心建模（限界上下文 / 聚合 / 实体 / 领域服务 / 仓储 / 领域事件）**只适用于 `cells/`**。其他分层各有自己的设计语汇，强套 DDD 反而会引入伪领域抽象。
+
+## 分层定性
+
+| 分层 | DDD 适用性 | 主导设计语汇 |
+|------|------------|--------------|
+| **`cells/`** | 主战场 | Bounded Context = Cell；Slice = Use Case / 应用服务；Aggregate / Entity / Repository / Domain Event 都在 slice 内 |
+| **`contracts/`** | 周边概念 | 是 DDD 的 **Published Language**，但不需要"再做 DDD 设计"——它本身是 schema-first 的边界协议（OpenAPI / JSON Schema / event payload），关注点是版本演化、向后兼容（见 `api-versioning.md`） |
+| **`adapters/`** | 周边概念 | 是 DDD 的 **Anti-Corruption Layer** 物化（postgres / rabbitmq / oidc / vault 等），职责是"翻译外部协议到 kernel/runtime 接口"，禁止塞业务规则 |
+| **`kernel/`** | 不适用 | 框架底座 / 元模型；对标 K8s + fx，设计语汇是 declarative resource + lifecycle + sealed registry，不是领域模型 |
+| **`runtime/`** | 不适用 | 横切技术能力（http / auth / worker / observability / outbox）；设计语汇是中间件链 + 可组合 hook + readyz/metrics |
+| **`pkg/`** | 不适用 | 纯库（errcode / httputil / redaction），无状态 utility |
+| **`cmd/` `tools/`** | 不适用 | CLI / 治理工具，过程式脚本 |
+
+## 关键边界
+
+DDD 不是越多越好。GoCell 的分层规则明确隔离了"业务领域"与"框架能力"：
+
+1. **kernel / runtime / adapters 中出现"领域服务""聚合"是 smell** — 这些层只承载技术能力。例如 `runtime/audit/ledger` 不是"审计聚合"，它是 hash chain 存储 primitive；真正的"审计领域"在 `cells/auditcore/`。
+2. **contracts/ 的 DDD-ness 已经下沉为 governance 规则** — 例如 v1 schema 演化、`additionalProperties` 策略、event payload 版本化（见 `eventbus.md` §事件负载），不需要再叠 DDD 词汇。
+3. **adapters/ 的 ACL 是承诺而非建模** — 通过"adapter 只实现 kernel/runtime 接口、不依赖 cells/"这条依赖规则强制（CLAUDE.md §依赖规则），不靠 DDD 文档约束。
+
+## Cell 内部的 DDD-ish 结构（按 GoCell 词汇）
+
+```
+cells/<cell>/
+├── cell.yaml                 # 元数据（id/type/consistencyLevel/owner/schema.primary/verify.smoke）
+├── cell.go / cell_init.go    # Cell 实例 + Init(reg) 注册
+├── cell_providers.go         # 选项 / 依赖装配
+├── cell_gen.go               # codegen 派生（禁手改）
+├── slices/<slice>/
+│   ├── slice.yaml            # 元数据（contractUsages / verify.unit / verify.contract / allowedFiles）
+│   ├── handler.go            # HTTP / event handler（薄层）
+│   ├── service.go            # 应用服务（NewXxx(...) (*X, error)，TxRunner nil 检查）
+│   └── *_test.go             # unit / contract / oracle / intent / outbox
+├── internal/
+│   ├── dto/                  # 跨 slice 数据载体
+│   ├── ports/                # 仓储 / 外部依赖接口
+│   ├── adapters/postgres/    # 仓储 PG 实现
+│   ├── mem/                  # 仓储内存实现（test）
+│   └── <domain>mint/         # 领域计算（如 sessionmint、ledgermint）
+├── postgres/                 # cell 级 PG schema / migrations / driver wiring
+└── mem/                      # cell 级 mem store
+```
+
+## DDD 适用性的设计风险
+
+如果对非 `cells/` 层强行套 DDD：
+
+- **kernel/ 里建"聚合"** → 与 K8s declarative model 冲突，破坏元模型一致性
+- **runtime/ 中间件做"领域决策"** → 横切关注点泄漏到业务路径，违反 cell metric label `cell="_runtime"` 设计前提
+- **adapter 里加"领域服务"** → 等于在 ACL 里塞业务规则，破坏分层依赖（adapters/ 不依赖 cells/）
+
+## 一句话总结
+
+**DDD 收敛到 `cells/`，其他层按各自的元模型 / 中间件 / ACL 语汇设计**，这正是 GoCell 分层依赖规则的初衷。

--- a/docs/architecture/202605131500-002-framework-capability-inventory.md
+++ b/docs/architecture/202605131500-002-framework-capability-inventory.md
@@ -1,0 +1,225 @@
+# GoCell 框架能力盘点
+
+> 系列文档 2/4 · 配套文档：[001 DDD 适用范围](./202605131500-001-ddd-scope-analysis.md) · [003 交互模式](./202605131500-003-capability-interaction-patterns.md) · [004 缺口分析](./202605131500-004-capability-gap-analysis.md)
+
+按"能力域"组织（而非目录），每条注明承载层与关键 API。
+
+## A. 应用模型 / Cell 框架（kernel/）
+
+| 能力 | 承载 | 说明 |
+|---|---|---|
+| **Cell / Slice 声明模型** | `cell.yaml` / `slice.yaml` + `kernel/metadata` | 必填 id / type / consistencyLevel / owner / verify；对标 K8s declarative |
+| **Cell 生命周期** | `kernel/cell.{Cell, BaseCell, Init, Start, Stop}` + `lifecycle.go` | Init/Stop 对称契约；phase 化启动（bootstrap phase 0–7） |
+| **Registry builder** | `kernel/cell.Registry`：`MountRouteGroup` / `Subscribe` / `RegisterContract` | Init 期声明意图，bootstrap drain 到 router |
+| **Outbox / EventBus** | `kernel/outbox.{Entry, EntryHandler, HandleResult, Ack/Requeue/Reject, ConsumerBase, Emit, Subscription}` | L2 事件 emit + consume；不用碰 idempotency.Claimer，Settlement 由 transport 注入 |
+| **Contract Spec** | `kernel/contractspec.ContractSpec{ID, Kind, Transport, Topic}` | 描述订阅 / 发布契约 |
+| **Persistence** | `kernel/persistence.TxRunner` / `TxManager` | service 必填 `TxRunner`（nil → `NewXxx` fail-fast） |
+| **Clock** | `kernel/clock.Clock` | 测试用 `clockmock` 注入 |
+| **Crypto** | `kernel/crypto` | KeyProvider 接口 / envelope 加密原语 |
+| **Observability** | `kernel/observability/metrics` | 注册业务 metric（cell label 自动） |
+| **State machine vocab** | `kernel/cellvocab` | 一致性等级 L0–L4、disposition 词汇 |
+| **Metadata** | `kernel/metadata` | cell.yaml / slice.yaml 元数据访问 |
+| **Verify** | `kernel/verify` | smoke / contract / unit verify hook |
+| **Idempotency** | `kernel/idempotency.Claimer`（透明） | 由 ConsumerBase 内部使用，handler 不接触 |
+
+## B. 事件 / 消息（kernel/outbox + runtime/eventbus + runtime/outbox）
+
+- **Outbox emit**：`outbox.Emit` 在 service 事务内写入，relay 异步发布
+- **PG outbox fencing**：lease_id CAS（`OUTBOX-LEASE-ID-CAS-01`，ADR 202605051600）
+- **ConsumerBase**：两阶段 Claim/Commit/Release 幂等 + 退避重试 + DLX 路由
+- **HandleResult vocabulary**：`Ack()` / `Requeue(err)` / `Reject(err)`；PermanentError 标签
+- **Subscription**：`reg.Subscribe(spec, handler, consumerGroup, cellID, opts...)`，4 参 cellID 位置必填
+- **Settlement / Receipt**：transport 层独立注入，handler 无感知
+- **EventRouter**：bootstrap 接管所有订阅 goroutine 生命周期
+- **Relay collector + metrics**：outbox 发布观测
+- **失败开放 tracker**（`failopen_tracker`）：consumer 退化保护
+
+## C. HTTP / API（runtime/http + contracts/http + codegen）
+
+- **Router** (`runtime/http/router`)：`RouteGroup`、`MountRouteGroup`、`MountCodegen`、auth.Mount
+- **CellAttribution middleware**：listener-root 注入 `ctxkeys.CellID`，metrics/log/trace 一致
+- **Middleware 链**：Recovery、Metrics、Tracing、AccessLog、Auth、RateLimit、CircuitBreaker、BodyLimit、CORS
+- **codegen handler**：contract.yaml → typed `Get200JSONResponse` / `*ErrorResponse` 信封（ADR 202605061500）
+- **错误兜底**：`pkg/httputil.WriteError` + 共享 `error-response-v1.schema.json`
+- **API 版本策略**：`/api/v1/` 前缀；response 只增不删；request strict（FMT-20）
+
+## D. 认证 / 授权（runtime/auth）
+
+| 子能力 | API |
+|---|---|
+| JWT 签发/校验 | `auth.JWT` + audience/issuer 校验 + intent claim |
+| Session | `runtime/auth/session.Store`（mem / redis / pg） |
+| Refresh token | `runtime/auth/refresh.Plan` + GC + storetest |
+| Service Token | `auth.ServiceToken` + Nonce（NonceStore Redis） |
+| Principal / Guard | 角色 / 权限 / Exempt list |
+| Authz middleware | `auth.Middleware` + RBAC 校验（rbacassign / rbaccheck slice） |
+| Auth Plan | `kernel/cell.AuthPlan` + bootstrap apply/validate/describe |
+
+## E. 数据 / 持久化（adapters/postgres + kernel/persistence）
+
+- **TxManager**：savepoint / nested tx / repanic（C-class panic）
+- **adapters/postgres**：driver、迁移、错误映射、tx_manager
+- **CAS / 乐观锁**：`runtime/state/cas`
+- **ValueTransformer**：`runtime/crypto` envelope 加密落库（DEK/KEK）
+- **pg-migrate 工具**：`tools/pg-migrate`
+- **Cell-local repo 模式**：`cells/<c>/internal/adapters/postgres/`
+
+## F. 缓存 / 状态（adapters/redis）
+
+- **Cache primitive**（per-cell namespace）
+- **IdempotencyClaimer**（`_runtime` sentinel）
+- **NonceStore**（role-named namespace）
+- **RedisDriver** + KeyNamespace 校验（`REDIS-KEY-NAMESPACE-01`）
+- **DistLock**：`runtime/distlock`（leader-elect）
+
+## G. 加密 / 密钥（kernel/crypto + runtime/crypto + adapters/vault）
+
+- **KeyProvider 接口**（local AES / Vault Transit）
+- **AEAD utility**（`pkg/aeadutil`）
+- **SecureCookie**（`pkg/securecookie`）
+- **HMAC key 管理**（bootstrap hmac_key）
+- **Vault Transit adapter** + readyz probe `vault_transit_ready`
+
+## H. 可观测性（runtime/observability + kernel/observability）
+
+| 维度 | 能力 |
+|---|---|
+| **Metrics** | Prometheus provider；`cell` label（业务）/ `_runtime` 哨兵；HTTP/outbox/auth/worker 指标 |
+| **Logging** | `slog` 结构化；error/warn/info/debug 级别约束；禁止 Debug dump body |
+| **Tracing** | OTEL provider；trace propagation；span error redaction（fail-closed） |
+| **Audit Ledger** | `runtime/audit/ledger` hash chain + payload redaction 出站 |
+| **Redaction 单源** | `pkg/redaction` (RedactError / RedactPayload) |
+| **Readyz probes** | snake_case `_ready` 后缀（rabbitmq_ready / vault_transit_ready） |
+
+## I. 配置 / Feature Flag（cells/configcore + runtime/config）
+
+- **Config publish/read/subscribe/write** slice
+- **Feature flag write**（configcore/slices/flagwrite）
+- **Config event metrics wiring**（per-cell adapter）
+- **热更新**：configsubscribe slice
+
+## J. 外部适配（adapters/）
+
+| 适配 | 用途 |
+|---|---|
+| postgres | PG driver + tx |
+| redis | 4 primitives（Cache / Idempotency / Nonce / Driver） |
+| rabbitmq | event bus（AMQP） |
+| oidc | OIDC provider 集成 |
+| vault | KMS / Transit |
+| s3 | 对象存储 |
+| websocket | WS adapter |
+| otel | OTEL exporter |
+| prometheus | metrics exporter |
+| circuitbreaker | HTTP 熔断 |
+| ratelimit | HTTP / token bucket |
+
+**约束**：cells 不直接 import adapters/，由 `cmd/corebundle` 注入接口实现。
+
+## K. 装配 / 启动（runtime/bootstrap + cmd/corebundle）
+
+- **Bootstrap phases**（phase 0–7）：grace period / managed resource / assembly / events / workers / http / shutdown
+- **Shutdown barrier + grace**：metrics 化的 shutdown ordering
+- **Dual listener**（business + internal port）
+- **Managed resource lifecycle**（reload gate）
+- **Module wiring**（access_module / audit_module / config_module / cell_module）
+- **Per-cell adapter binding**
+- **Assembly.yaml** → 物理拓扑
+
+## L. CLI 工具（cmd/gocell）
+
+| 子命令 | 功能 |
+|---|---|
+| `gocell validate` | governance 规则全集（FMT / ADV / VERIFY / TOPO / HTTP / REF / strict） |
+| `gocell scaffold` | cell / slice / contract / assembly / journey 脚手架 |
+| `gocell generate` | codegen 入口（contract / cell / catalog / assembly） |
+| `gocell check` | 静态检查聚合 |
+| `gocell verify` | 验证 codegen 产物 / drift |
+| `gocell export` | 元数据导出 |
+| `gocell graph` | 依赖图 |
+
+## M. Codegen funnel（tools/codegen + generated/）
+
+- **contractgen**：HTTP contract → typed handler + Subscription helper
+- **cellgen**：cell.yaml + slice.yaml → cell_gen.go（meta / providers）
+- **markergen**：marker 派生
+- **generatedcatalog**：cell/slice/contract 索引
+- **golden test**：scaffold/codegen 输出 byte-equal 校验
+- **gofumpt render**：统一格式化
+
+## N. Governance（kernel/governance + tools/archtest + .golangci.yml）
+
+| 工具 | 职责 |
+|---|---|
+| `kernel/governance` rules | FMT-20 strict request / ADV-06 subscribers / VERIFY-01 contract usage / TOPO / HTTP / REF |
+| `tools/archtest` (16-shard process-isolated) | PANIC-REGISTERED / MESSAGE-CONST-LITERAL / DETAILS-SLOG-ATTR / OUTBOX-* / REDIS-KEY-NAMESPACE / EXPORTED-ERROR-NEW / REGISTRY-SUBSCRIBE-CELLID 等 50+ invariant |
+| `tools/depgraph` | 跨包依赖闭包 |
+| `tools/metricschema` | metric schema drift |
+| `tools/generatedverify` | 派生产物 drift |
+| `tools/nogo` | go-only lint |
+| `tools/e2egate` / `tools/slowgate` | E2E / 慢测分流 |
+| `.golangci.yml` | depguard 路径级 import 禁令 |
+
+## O. 错误 / Panic / Redaction 单源（pkg/）
+
+- `pkg/errcode`：三层 redaction（Message const / Details slog.Attr / Internal）
+- `pkg/panicregister.Approved(reason, value)`：production panic 唯一形态
+- `pkg/redaction`：err + payload 单源
+- `pkg/httputil.WriteError`：HTTP 兜底
+
+## P. 测试基础设施（pkg/testutil + */celltest + */authtest + */sessiontest）
+
+- **Clock mock**（`clockmock`）
+- **Slog capture**（`sloghelper`）
+- **Cell test harness**（`kernel/cell/celltest`）
+- **Outbox conformance**（`kernel/outbox/outboxtest`）
+- **Auth/Session test helpers**
+- **Postgres test container helpers**
+- **Codegen golden test framework**
+
+## Cells 可消费的能力清单（按 import 实际统计）
+
+```
+kernel/cell, cellvocab, clock, contractspec, crypto, idempotency(透明),
+metadata, observability/metrics, outbox, persistence, verify
+
+runtime/audit/ledger, auth, auth/refresh, auth/session, crypto, eventbus,
+http/router, observability/metrics, state/cas
+
+pkg/ctxcancel, ctxkeys, errcode, panicregister, pgquery, query, redaction,
+testutil/sloghelper, testutil/testtime, validation
+
+adapters/postgres   ← 仅 cell 自有 repo 实现，且仅引用 driver / Tx 类型，不跨 cell
+```
+
+## 一致性等级 → 可用结构对照
+
+| 级别 | 典型 import | 结构特征 |
+|---|---|---|
+| **L0** LocalOnly | `pkg/*`、`kernel/crypto` | 纯函数，无 Tx / 无 outbox |
+| **L1** LocalTx | + `kernel/persistence` | 单 cell 事务，handler→service→repo |
+| **L2** OutboxFact | + `kernel/outbox` / `runtime/eventbus` | service 在同事务内 `outbox.Emit`，relay 异步发布 |
+| **L3** WorkflowEventual | + ConsumerBase + `runtime/state/cas` | 订阅事件投影，幂等 Claim/Commit |
+| **L4** DeviceLatent | + `runtime/distlock` + scheduler | 长延迟回执，去重窗口 |
+
+## 强制 invariant（review / archtest 守护，开发者必须知晓）
+
+- **panic** 必走 `panicregister.Approved(...)`（`PANIC-REGISTERED-01`）
+- **`errcode.New` message 必须 const literal**（`MESSAGE-CONST-LITERAL-01`）
+- **`WithDetails` 只接 `slog.Attr`**（`DETAILS-SLOG-ATTR-01`）
+- **service nil TxRunner fail-fast**（`OUTBOX-SERVICE-01`）
+- **`reg.Subscribe` 第 4 参数 cellID 位置必填**（`REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01`）
+- **HandleResult 字面量构造**仅限 kernel allowlist，业务路径用 `Ack/Requeue/Reject` factory（`OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01`）
+- **L2 consumer 必须配 DLX exchange**
+- **export 包级 `var Err* = errors.New(...)` 禁用**，必须 `errcode.New`（`EXPORTED-ERROR-NEW-01`）
+- **outbox lease CAS** 由 store 透传（`OUTBOX-LEASE-ID-CAS-01`），handler 无感知
+- **Redis key namespace** 由构造期 `KeyNamespace.Validate()` 守护（`REDIS-KEY-NAMESPACE-01`）
+
+## 显式范围外（当前未实现）
+
+- 多租户隔离（tenant 维度的 namespace）
+- 服务网格 / gRPC adapter（目前 HTTP/AMQP only）
+- 分布式追踪 sampling 策略管理
+- 多 region / failover 拓扑
+
+详细未实现项 → [004 缺口分析](./202605131500-004-capability-gap-analysis.md)

--- a/docs/architecture/202605131500-003-capability-interaction-patterns.md
+++ b/docs/architecture/202605131500-003-capability-interaction-patterns.md
@@ -1,0 +1,356 @@
+# 框架能力的交互模式
+
+> 系列文档 3/4 · 配套文档：[001 DDD 适用范围](./202605131500-001-ddd-scope-analysis.md) · [002 能力盘点](./202605131500-002-framework-capability-inventory.md) · [004 缺口分析](./202605131500-004-capability-gap-analysis.md)
+
+按"典型场景"展示能力如何串联，产生什么效果。
+
+---
+
+## 场景 1：L2 业务请求生命周期（HTTP → 事务 → 事件 → 消费）
+
+最核心的组合：
+
+```
+Client
+  │  POST /api/v1/sessions
+  ▼
+[runtime/http listener]
+  └─ CellAttribution mw      ← 注入 ctxkeys.CellID="accesscore"（看 RouteGroup ownership）
+      └─ Tracing mw          ← span 起点，绑 cell label
+          └─ Metrics mw       ← http_requests_total{cell="accesscore"}
+              └─ AccessLog mw ← 结构化 slog，含 cell 字段
+                  └─ Auth mw (JWT)  ← runtime/auth.Authenticator + JWKS + intent claim
+                      └─ Guard mw   ← Principal + RBAC（rbaccheck slice）
+                          └─ RateLimit / CircuitBreaker / BodyLimit
+                              ▼
+              [codegen handler] (Get200JSONResponse / Post201ErrorResponse)
+                  ▼
+        ┌──────────────────────────────────────────────────────┐
+        │  service.go: sessionlogin.Service.Login(ctx, dto)    │
+        │    ├─ validation.Struct(dto)                          │
+        │    ├─ kernel/persistence.TxRunner.RunTx(ctx, func){   │
+        │    │     ├─ ports.UserRepo.FindByEmail(tx, ...)       │
+        │    │     ├─ sessionmint.Mint(...)                     │
+        │    │     ├─ session.Store.Put(tx, ...)                │
+        │    │     └─ outbox.Emit(tx, "session.created.v1",     │
+        │    │                    eventID, payload)             │
+        │    │           ← 同事务写入 outbox 表（B 类：lease_id) │
+        │    └─ 返回 dto                                        │
+        └──────────────────────────────────────────────────────┘
+                  ▼
+              [codegen handler 返回 typed Response]
+                  ▼
+              Tracing span 关闭（错误经 pkg/redaction.RedactError 后写入）
+
+[runtime/outbox.Relay]（后台 goroutine，独立于请求）
+  ├─ ClaimPending(lease_id CAS) → adapters/rabbitmq.Publisher
+  ├─ 成功 → MarkPublished(lease_id CAS)
+  └─ 失败 → MarkRetry / 退避 → 预算耗尽 → MarkDead → DLX
+
+[Subscriber] auditcore-auditappendsession
+  └─ ConsumerBase.Wrap：
+      ├─ kernel/idempotency.Claimer.Claim(eventID)  ← Redis IdempotencyClaimer
+      │     ↳ KeyNamespace="_runtime"（sentinel）
+      ├─ handler(ctx, entry) → outbox.HandleResult
+      │     ├─ Ack() → broker Ack → Claimer.Commit
+      │     ├─ Requeue(err) → 退避 → Claimer.Release
+      │     └─ Reject(err) → Nack(requeue=false) → DLX
+      └─ Settlement 由 Subscriber transport 注入（handler 不接触）
+```
+
+**产生的作用**：
+
+- **业务原子性**：DB 状态 + 事件发布同事务（outbox pattern），不丢、不重
+- **消费幂等**：Claimer 两阶段 + lease CAS，consumer 崩溃/重投不重复处理
+- **完整可观测**：同一 trace 跨 HTTP → tx → relay → consumer；metrics 标 cell；error 经 redaction
+- **失败兜底**：瞬态走重试，永久走 DLX，预算耗尽自动转 Reject
+
+---
+
+## 场景 2：启动装配（bootstrap 把所有 phase 串起来）
+
+```
+cmd/corebundle/main.go
+  └─ bundle_options.go → bundle_assembly.go
+      ▼
+runtime/bootstrap.Run(ctx, opts):
+
+  Phase 0: Grace period               ← 给依赖一个稳定时间窗
+  Phase 1: Managed resources          ← Vault/Redis/PG/RabbitMQ 连接 + readyz 接线
+            ├─ KeyProvider (Vault Transit 或 local AES)
+            ├─ HMAC key 加载
+            ├─ ValueTransformer 装配
+            └─ adapter readyz probe (vault_transit_ready, rabbitmq_ready ...)
+  Phase 2: Assembly → 解析 assembly.yaml
+            └─ Topology：cell → listener → namespace 归属
+  Phase 3: Cell.Init(ctx, registry)
+            ├─ 各 Cell 在 Init 内调用 reg.MountRouteGroup / reg.Subscribe
+            ├─ Registry 收集 RegistrySnapshot
+            └─ 校验 cellID positional / contract spec / cell.yaml 一致
+  Phase 3b: AuthPlan apply              ← 各 cell 声明 auth 要求 → 编译为 middleware
+  Phase 4: Events
+            └─ drainCellSubscriptions：snapshot → EventRouter
+                ↳ EventRouter 起 goroutine + ConsumerBase 包装
+  Phase 5: Workers (runtime/worker)
+            └─ outbox.Relay / refresh GC / audit verify 等后台 worker
+  Phase 6: HTTP listeners
+            ├─ business listener (8080)：业务 RouteGroup
+            ├─ internal listener (8090)：/metrics /healthz /readyz /debug
+            └─ CellAttribution middleware 安装
+  Phase 7: Health aggregation
+            └─ 聚合 cell.Health + adapter readyz → /readyz
+
+Shutdown：逆序 + shutdown barrier + grace + metrics 化（shutdown_duration_seconds）
+```
+
+**产生的作用**：
+
+- **确定性启动**：每 phase 有 fail-fast 校验（cellID positional / TxRunner nil / KeyNamespace.Validate 都在构造期触发）
+- **声明对齐闭环**：slice.yaml.contractUsages ↔ contract.yaml.endpoints ↔ Init 期 reg.Subscribe，运行前已检查
+- **依赖可观测**：readyz 把 adapter 故障映射到 K8s probe，运维直接消费
+
+---
+
+## 场景 3：错误传播 / Redaction 单源（错误流水线）
+
+```
+domain service 抛错
+  └─ errcode.New(ErrXxx, "const literal msg",
+        WithDetails(slog.String("userId", id), slog.Int("attempts", n)),
+        WithInternal(fmt.Sprintf("sql=%q stack=%s", q, stack)))
+        │
+        ▼
+codegen handler
+  ├─ 4xx → typed *ErrorResponse{Body: errcode.Error{...}}（details 下发）
+  └─ 未声明 5xx → return nil, err → httputil.WriteError 兜底
+        │
+        ▼
+HTTP middleware (Recovery / response writer)
+  ├─ 检查 status：5xx → strip details；internal 永不下发
+  └─ 序列化 wire JSON ↘
+        │              到客户端
+        ▼
+slog (server side)
+  └─ 记录完整 Message + Details + Internal（含 stack / sql）
+        │
+        ▼
+Tracing span.RecordError
+  └─ kernel/wrapper.WrapConsumer 与 runtime/http/middleware.Recovery
+       无条件经 pkg/redaction.RedactError →
+         mask password/secret/token/api_key/authorization/private_key/signing_key/dsn
+         value boundary 到下一空白（fail-closed）
+        │
+        ▼
+adapters/otel exporter → backend
+        ↑
+Audit Ledger 同源
+  └─ runtime/outbox.SanitizeError 也走 pkg/redaction（单源治理）
+
+业务 cell 出站 audit payload
+  └─ pkg/redaction.RedactPayload（递归剔除同源 key 列表）
+```
+
+**产生的作用**：
+
+- **三层隔离**：客户端只看 Message（4xx 加 Details）；服务端 slog 看全；trace backend 看 redact 版
+- **PII 不外泄**：trace 经 fail-closed value boundary，过度 mask 是接受代价
+- **单源治理**：所有 redaction 走 `pkg/redaction`，避免多处规则漂移
+
+---
+
+## 场景 4：Cell 作为隔离单位（owner 维度横切）
+
+cell 不仅是代码组织，**`cell` 是所有横切维度的 owner key**：
+
+```
+                 cell="accesscore"
+                       │
+        ┌──────────────┼──────────────┬──────────────┬──────────────┐
+        ▼              ▼              ▼              ▼              ▼
+  HTTP metrics    slog field    trace span    Redis namespace   Audit owner
+  http_*{cell=}   {cell:...}    cell.id=...   accesscore:<k>    entry.cell
+        │              │              │              │              │
+        └──────────────┴──────────────┴──────────────┴──────────────┘
+                              │
+                       由 ctxkeys.CellID 串联
+                       由 CellAttribution mw 注入
+                       由 RouteGroup ownership 派生
+```
+
+**产生的作用**：
+
+- **运维语义统一**：dashboard 用 `cell` 一个维度过滤就能切出业务/框架（业务 `cell != "_runtime"`，运行时探针 `cell="_runtime"`）
+- **故障隔离单位**：accesscore 故障 → Redis key、metrics、日志、trace 全部能定向
+- **多租户雏形**：未来 tenant 可作为 cell 之上正交维度（当前未实现）
+
+---
+
+## 场景 5：Codegen funnel — 单源驱动多产物
+
+```
+contracts/http/access/v1/sessions.contract.yaml
+  ├─ openapi schema (request/response)
+  ├─ endpoints.subscribers / publishers
+  └─ codegen: true
+        │
+        ▼ tools/codegen/contractgen
+        ├─ generated typed handler interface（业务实现）
+        ├─ generated Get200JSONResponse / Post201ErrorResponse structs
+        ├─ generated Subscription helpers (NewSubscription with cellID)
+        └─ generated catalog 索引
+
+cells/accesscore/cell.yaml + slices/*/slice.yaml
+        │
+        ▼ tools/codegen/cellgen
+        ├─ cell_gen.go (meta / providers)
+        └─ providers wired with contractgen artifacts
+
+并行验证：
+  ├─ kernel/governance.validate
+  │     ├─ FMT-20 strict request
+  │     ├─ ADV-06 endpoints.subscribers ↔ contractUsages 双向
+  │     ├─ VERIFY-01 contract usage ↔ verify.contract 闭环
+  │     ├─ TOPO 依赖规则
+  │     └─ HTTP /api/v1 前缀 / response 只增不删
+  ├─ tools/archtest (50+ invariants, 16 shard)
+  │     ├─ PANIC-REGISTERED-01 typed wrap
+  │     ├─ MESSAGE-CONST-LITERAL-01
+  │     ├─ DETAILS-SLOG-ATTR-01
+  │     ├─ OUTBOX-* (lease CAS / service nil-check / HandleResult factory)
+  │     ├─ REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01
+  │     ├─ REDIS-KEY-NAMESPACE-01
+  │     └─ ROUTER-ATTRIBUTION / RUNTIME-SENTINEL
+  ├─ tools/generatedverify (golden drift)
+  └─ tools/depgraph (跨包闭包)
+```
+
+**产生的作用**：
+
+- **单源**：一份 contract.yaml 决定 handler 类型、订阅声明、verify 闭环、catalog 索引
+- **改不漏**：删字段 → openapi 校验失败；缺 subscriber → ADV-06；忘 verify.contract → VERIFY-01
+- **AI-rebust**：违反不可表达（typed struct）或运行时拒绝（archtest），不靠注释/命名 convention
+
+---
+
+## 场景 6：事务 + outbox + 幂等的三角
+
+L2/L3 最关键的组合：
+
+```
+        Producer 侧                  │     Consumer 侧
+                                     │
+PG Tx (kernel/persistence)           │  Subscriber + ConsumerBase
+  ├─ business state mutation         │  ├─ recv from broker
+  └─ outbox.Emit(tx, evt)            │  ├─ kernel/idempotency.Claimer
+        ↓ same row                   │  │   .Claim("{cg}:{entry.ID}")
+        ↓ lease_id=NULL              │  │   ↓ Redis SET NX EX
+        ↓                            │  │   ← 已 claim → skip + Ack
+        ▼                            │  ├─ handler(ctx, entry)
+PG outbox table                      │  │   → HandleResult
+        ▼                            │  ├─ broker Ack / Nack
+runtime/outbox.Relay                 │  │   ├─ Ack → Claimer.Commit
+  ├─ ClaimPending → lease_id CAS     │  │   ├─ Reject → Nack(no requeue) → DLX
+  ├─ adapters/rabbitmq.Publish       │  │   └─ Requeue → 退避 → Claimer.Release
+  ├─ MarkPublished (lease CAS)       │  │
+  ├─ MarkRetry / MarkDead            │  └─ Settlement 由 Subscriber 注入
+  └─ ReclaimStale (lease CAS)        │      （handler 无感知）
+```
+
+两个独立的"防重"机制叠加：
+
+- **producer 侧 lease_id**：防多 relay worker 抢同一行（旧 worker CAS 必失败，ADR 202605051600）
+- **consumer 侧 Claimer**：防同事件多次投递（broker at-least-once 语义补偿）
+
+**产生的作用**：
+
+- end-to-end exactly-once-effect（不是 exactly-once delivery）
+- relay 横向扩展安全（多 worker 不重复发布）
+- consumer 横向扩展安全（同 cg 多实例不重复处理；不同 cg fanout）
+
+---
+
+## 场景 7：观测三件套 + 业务语义对齐
+
+```
+                请求进入
+                   │
+   ┌───────────────┼───────────────┐
+   ▼               ▼               ▼
+Metrics         Logging         Tracing
+   │               │               │
+   ├ http_*       ├ slog          ├ span
+   │  {cell,       │  {cell,       │  {cell,
+   │   route,      │   trace_id,   │   trace_id,
+   │   status}     │   span_id,    │   ...}
+   │               │   error}      │
+   │               │               │
+   │               │               ├ RecordError → redaction
+   │               │               │
+   ▼               ▼               ▼
+prometheus     stdout(JSON)    OTEL exporter
+
+业务事件：
+   audit ledger（hash chain，append-only）
+      ├─ 订阅业务事件作为 audit 源
+      ├─ payload 出站经 RedactPayload
+      └─ verify 端点：Append/Verify chain integrity
+```
+
+**产生的作用**：
+
+- 同 trace_id 跨 HTTP → tx → outbox relay → consumer 链路追踪
+- 同 cell label 跨 metrics/log/span 三栈对齐
+- audit ledger 独立保留完整业务事件流（合规 / 排障）
+
+---
+
+## 场景 8：CLI + Governance + archtest 形成的开发者闭环
+
+```
+开发新 cell：
+  1. gocell scaffold cell <name>     ← 生成 cell.yaml + 目录
+  2. gocell scaffold slice <c>/<s>   ← 生成 slice.yaml + handler/service 骨架
+  3. 写 contract.yaml
+  4. gocell generate contract        ← codegen 派生 typed handler
+  5. gocell generate cell            ← 派生 cell_gen.go
+  6. 实现 service.go（TxRunner / repository）
+  7. gocell validate                 ← FMT/ADV/VERIFY/TOPO/HTTP/REF 规则
+  8. go test ./...                   ← unit + contract + intent + outbox
+  9. hack/verify-archtest.sh         ← 16-shard archtest 全集
+ 10. make verify                     ← 总入口
+
+CI（每个 PR）：
+  ├─ golangci-lint (depguard 路径级)
+  ├─ archtest 16-shard 矩阵
+  ├─ generated drift verify
+  ├─ governance validate
+  ├─ unit + integration test
+  ├─ codegen golden
+  └─ journey runner（J-*.yaml 验收剧本）
+```
+
+**产生的作用**：
+
+- 开发者只写 contract.yaml + service.go，其他派生 + 校验自动化
+- AI co-author（fresh session 无记忆）也能通过 archtest 在 CI 被拒，约束不可绕过
+
+---
+
+## 组合产生的"涌现能力"
+
+| 组合 | 涌现 |
+|---|---|
+| **PG outbox + Claimer + ConsumerBase** | End-to-end exactly-once-effect 事件驱动 |
+| **CellAttribution + ctxkeys.CellID + redaction** | 单一 owner 维度贯穿三栈观测 |
+| **codegen + governance + archtest** | 单源 contract → 多产物 + 闭环校验，违反不可表达 |
+| **errcode 三层 + middleware strip + redaction** | PII fail-closed，开发者写一次错误 4xx/5xx 自动分级 |
+| **Cell.Init 声明 + Registry drain + bootstrap phase** | 声明式装配，启动期 fail-fast，无 runtime 漂移 |
+| **per-cell adapter + KeyNamespace + readyz** | 故障隔离 + 运维定向 + 单 cell 灰度可行 |
+| **AuthPlan + Mount + Guard + JWT/Session/Refresh** | 声明式 auth，cell 只声明意图，编译为 middleware |
+| **TxRunner nil fail-fast + lease CAS + panicregister.Approved** | 构造期 + 静态 + 运行时三层防误用 |
+
+## 核心设计哲学
+
+每个能力都是**接口 + 单源 + 治理守卫**三件套。能力之间通过 `ctxkeys.CellID` / `kernel.Registry` / `outbox.Entry` / `errcode.Error` 这几个**公共信封**串联，避免点对点耦合。
+
+组合产生的力量不是能力总和，而是 **"声明一次，全栈生效"** 的杠杆。

--- a/docs/architecture/202605131500-004-capability-gap-analysis.md
+++ b/docs/architecture/202605131500-004-capability-gap-analysis.md
@@ -1,0 +1,418 @@
+# 框架能力交互缺口分析（35 项）
+
+> 系列文档 4/4 · 配套文档：[001 DDD 适用范围](./202605131500-001-ddd-scope-analysis.md) · [002 能力盘点](./202605131500-002-framework-capability-inventory.md) · [003 交互模式](./202605131500-003-capability-interaction-patterns.md)
+
+本文盘点 GoCell 框架现有能力之间"**没接通**"的缺口——单看每个能力都能用，组合起来要业务自己拼胶水。
+
+按三批组织：第一批为抽象缺失（framework 没做），第二批为组合断点（做了没串），第三批为运维/演进/外部边界。
+
+---
+
+## 第一批：抽象缺失（P0/P1 必须做）
+
+### 缺口 1：HTTP 幂等无框架支持
+
+| 维度 | 当前 |
+|---|---|
+| consumer 侧事件幂等 | ✅ `kernel/idempotency.Claimer` 透明 |
+| HTTP 请求幂等（Idempotency-Key header） | ❌ 框架无，每个 cell 自己处理 |
+| 跨 cell call 幂等 | ❌ |
+
+**设计张力**：
+- 存储窗口：consumer 全局唯一 event_id；HTTP 客户端任意 key 需 (userID, key) 命名空间
+- 响应回放：consumer 幂等可 skip+Ack；HTTP "已处理"必须回放原始 status + body + headers
+- 进行中并发：客户端同 key 并发重试策略
+- 范围：单 cell / 跨 cell / 全 assembly 三种语义
+
+**设计骨架**：`runtime/http/idempotency.Store` 接口 + `RecordedResponse` + middleware 装载在 Auth 之后、handler 之前；Store 实现复用 Redis namespace。
+
+**依赖前置**：缺口 5（after-commit hook）。
+
+### 缺口 2：L3 Saga / Workflow 运行时
+
+**当前状态**：`cellvocab.L3` 词汇存在，`runtime/workflow` 不存在；现有 L3 场景全手撕。
+
+**设计张力**：framework vs cell 边界 / 声明式 vs 编程式 / 与 outbox 的关系 / 补偿原语 / 超时语义。
+
+**设计骨架**：`kernel/workflow` 提供 `Step{Run, Compensate, Timeout, Retries}`，framework 提供 state journal 持久化 + leader-elect engine。
+
+**依赖前置**：缺口 5（after-commit）+ distlock leader。
+
+### 缺口 3：跨 Cell In-Process Contract
+
+**当前状态**：同 assembly 内 cell-A 想调 cell-B 只有 HTTP / event / import 三条路，都有问题。
+
+**设计骨架**：codegen 同一份 contract.yaml 派生 server handler + client invoker；assembly.yaml 拓扑决定 inproc vs http transport，业务无感知。
+
+### 缺口 4：Command Bus 半空壳
+
+**当前状态**：`runtime/command` 只有 lifecycle，无 dispatcher / handler registry / idempotency / 与 outbox 桥。
+
+**设计骨架**：`Dispatcher.Dispatch[C, R]`（同步）+ `DispatchAsync[C]`（异步，写 command outbox）；contracts/command codegen 派生 typed Command + Handler 接口。
+
+**依赖前置**：缺口 1（HTTP idempotency-key ↔ command_id 映射）。
+
+### 缺口 5：Tx After-Commit Hook
+
+**当前状态**：`TxRunner.RunTx` 提交后无 hook；业务想"事务成功后清缓存"无路径。
+
+**设计张力**：诱惑陷阱（复活 outbox 想消灭的反模式）；正当用途窄（cache invalidation / metric / log / WS broadcast）；不允许扩展到 stateful 副作用。
+
+**设计骨架**：克制版 `RunTxWithBestEffortAfterCommit(ctx, fn, hooks...)`；Hook 签名无返回值；archtest 限制只允许 transient 副作用。
+
+### 缺口 6：Schema Registry Runtime
+
+**当前状态**：api-versioning.md 是约定，运行时无版本协商 / payload 兼容性检查 / 自动 routing。
+
+**设计骨架**：build-time codegen 生成 schema hash 嵌入 binary；runtime 在 outbox.Entry header 带 hash；consumer 按 hash + CompatPolicy 决策 decode。
+
+### 缺口 7：Health Dependency 感知
+
+**当前状态**：cell.Health 是 boolean Up/Down/Degraded，依赖图扁平，无部分失败映射。
+
+**设计骨架**：cell.yaml 声明 `dependencies: [{target, severity}]`；runtime 计算 `cell.HealthStatus = my-status × dependencies-status`；assembly.yaml 派生启动顺序。
+
+---
+
+## 第二批：组合断点（P1/P2 应做）
+
+### 缺口 8：失败模式预算未共享
+
+五个失败感知点（HTTP Circuit / Rate Limit / Outbox Consumer / Retry Budget / HTTP Client Circuit）各算各的，没有共享口径。
+
+**设计骨架**：`kernel/failurebudget` 共享观测口径 + 声明式 action map（degrade-mode / shed / throttle）。
+
+### 缺口 9：Backpressure 反压通道
+
+下游 outbox 堆积 / consumer lag 增大时，无反压到上游 HTTP 入口。
+
+**设计骨架**：`runtime/backpressure.Observer` 接口；HTTP middleware 装载 Observer，按 Pressure Level 走 throttle / shed。
+
+### 缺口 10：跨 Transport 的 Principal 传播
+
+Principal 是 transport-coupled——HTTP 路径才有，进入事件 / Worker / WS 后丢失。
+
+**设计骨架**：`PrincipalEnvelope`（含 OnBehalfOf 链）；outbox.Entry.Headers 自动注入 envelope；consumer 端 ConsumerBase 自动 unmarshal 写回 ctx。
+
+### 缺口 11：观测三栈反查链路断裂
+
+cell label 对齐了，但 trace_id → audit / metric exemplar / alert → cell.yaml owner 反查链路缺失。
+
+**设计骨架**：`kernel/observability/correlation.Correlation` envelope；outbox + audit ledger 自动注入 trace_id；提供 `/internal/v1/correlate?trace_id=` 反查 API。
+
+### 缺口 12：Large Payload / Stream
+
+outbox.Payload 无 size 限制 / 无 streaming；audit ledger JSONB 列超大撑爆；S3 adapter 与 outbox 无桥。
+
+**设计骨架**：`runtime/blobref.BlobRef`（Storage / SHA256 / Size / Codec）；outbox.Emit 自动判断 size 走 inline 或 externalize。
+
+### 缺口 13：数据生命周期 / GDPR
+
+audit append-only 无 retention；outbox 无清理 worker；PII 无 right-to-be-forgotten 路径。
+
+**设计骨架**：cell.yaml 声明 `dataClasses` + retention + onExpire；framework 提供 ErasureHandler 跨 cell 协调。
+
+### 缺口 14：周期任务 / 定时调度
+
+`worker.periodic` + `distlock` 要业务手动组合；缺统一 ScheduledTask 抽象。
+
+**设计骨架**：`kernel/scheduler.ScheduledTask{Schedule, LeaderOnly, Idempotent, Run}`；framework 自动 leader-elect + fencing + 缺勤补跑策略 + run history。
+
+### 缺口 15：版本偏移 / 滚动部署
+
+部署窗口期间 mixed-version 行为不可控；api-versioning 约定无运行时检查。
+
+**设计骨架**：`kernel/version.CompatMatrix`；启动期实例向 cluster registry 注册版本；检测混合版本时启用 compat mode。
+
+### 缺口 16：故障注入 / Chaos / 回放
+
+celltest / outboxtest 单元 OK，但故障注入 / 时间快进 / 网络分区 / 流量录制回放缺。
+
+**设计骨架**：`pkg/testutil/chaos.FaultInjector`（build tag `chaos` 隔离）；adapter 接口埋 fault point。
+
+### 缺口 17：Graceful Degradation
+
+依赖部分失败 → readyz 红 → K8s 摘流量 → 整体不可用；缺降级运行模式。
+
+**设计骨架**：cell.yaml 声明 `fallbacks: [{dependency, mode, fallbackImpl, alert}]`。
+
+### 缺口 18：Cache 一致性
+
+`adapters/redis Cache` 是单纯 KV；无 write-through / 失效广播 / Principal scope / negative cache 协议。
+
+**设计骨架**：`runtime/cache.Region{Name, Scope, TTL, Invalidate}`；与 outbox event 桥接自动 invalidate。
+
+### 缺口 19：Stream / Pagination / WS
+
+列表 cursor 语义未标准化；WS 无 topic 抽象 / 无 EventBus 桥接；SSE 完全没有。
+
+**设计骨架**：`runtime/stream.Cursor`（keyset + SnapshotID）；WS topic 抽象 + 自动 EventBus fanout；SSE codegen 支持。
+
+### 缺口 20：Secret Rotation 跨能力路径
+
+KeyProvider rotation 由 Vault 侧，但 JWT / HMAC / ValueTransformer KEK / ServiceToken / Refresh signing key 的 rotation 协议未明。
+
+**设计骨架**：`kernel/crypto/rotation.Rotatable` 接口；所有签名/加密 key 必经 Rotatable；wire token 自带 kid 选 key。
+
+### 缺口 21：Resource Sizing
+
+连接池 / goroutine / 内存预算各 adapter 独立配置；缺统一 sizing 协议 + 资源耗尽行为契约。
+
+**设计骨架**：`kernel/resource.Budget{Owner, Type, Limit, OnSaturation}`；saturation 触发 Backpressure。
+
+### 缺口 22：AuthZ 策略 ↔ Contract 反向联动
+
+contract.yaml 不声明权限；策略与 endpoint 是两套独立声明，靠 cell 内 wire 手动绑定。
+
+**设计骨架**：contract.yaml 加 `authz.required` + `authz.resource`；codegen 派生 handler 签名要求 Principal 必带相应权限。
+
+---
+
+## 第三批：时间维度 / 外部边界 / DX 工具链
+
+### 缺口 23：Time / Clock / Causality 统一模型
+
+分布式时间维度缺：跨实例 wall clock 漂移 / monotonic vs wall / causality vs absolute time / 三种时刻（发生 / 落库 / 消费）。
+
+**设计骨架**：`kernel/clock.Instant{Wall, Mono, Logical, CauseOf}`；outbox.Entry.Headers 自动注入 emitted_wall / emitted_logical / caused_by。
+
+### 缺口 24：Event Ordering / Partition / FIFO
+
+outbox 跨事务无序；relay 多 worker 并行；RabbitMQ 默认不保 FIFO；业务"同 user 状态变更按序消费"无声明式表达。
+
+**设计骨架**：`outbox.Emit(... PartitionKey(userID), CausalAfter(prevEntryID))`；contract.yaml 声明 `ordering.partitionKey` + `guarantee: per-key-fifo`。
+
+### 缺口 25：Migration ↔ Deploy 协同
+
+`tools/pg-migrate` 有；但 migration 与 code 版本兼容矩阵 / rolling deploy 期间 mixed schema 行为 / 回滚协议缺。
+
+**设计骨架**：`kernel/migration.Migration{Version, PreCodeMin, PreCodeMax, CompatPhases}`；CI 守 migration ↔ code 兼容交集非空。
+
+### 缺口 26：Drain / Graceful Shutdown of In-Flight
+
+shutdown_barrier 有 grace；但 in-flight HTTP / consumer / long-running workflow / WebSocket 的优雅完成协议未明。
+
+**设计骨架**：`kernel/lifecycle/drain.Drainer` 接口；各 transport 注册 Drainer；ConsumerBase 检测 shutdown 后完成手头 + Release lease。
+
+### 缺口 27：Outbound HTTP / Webhook
+
+cells 调外部 API 无标准框架：无 retry / circuit / observability / idempotency / signing。L4 DeviceLatent 场景全是 outbound，但无支撑。
+
+**设计骨架**：`contracts/http-outbound/` codegen client + outbound consumer 模式；service 写"调用三方"意图到 outbox（kind=outbound-call）；outbound worker 消费 + circuit。
+
+### 缺口 28：Tenant Capacity / Quota / Cost Attribution
+
+多租户维度缺；即便不做完整租户，资源归属维度本身缺。
+
+**设计骨架**：`kernel/attribution.Attribution{Cell, Tenant, Contract}`；ctxkeys.AttributionFrom 在 listener-root 注入；metric 自动切片；Quota 同步检查。
+
+### 缺口 29：Client SDK 生成
+
+codegen 只生成 server-side；client SDK（Go 内部 / TS 前端 / Python 脚本）业务自己写。
+
+**设计骨架**：`tools/codegen/sdkgen/{go-client, typescript, python}`；SDK 自带 errcode unmarshal / retry / trace propagation。
+
+### 缺口 30：Contract Test / Consumer-Driven
+
+跨服务实际兼容性靠 e2e；缺 consumer pact 收集 + producer "对所有已知 consumer 兼容" 自动验证。
+
+**设计骨架**：`expectations.yaml` 声明 consumer 期望；producer CI 跑 generated consumer expectation suite。
+
+### 缺口 31：Audit / Forensic Query API
+
+auditquery slice 存在但能力薄；跨事件因果链 / 重放 / 反向查 / PIT 重建均缺。
+
+**设计骨架**：扩 auditquery API：`/audit/causal-chain` `/audit/timeline?trace_id=` `/audit/replay` `/audit/state-at`。
+
+### 缺口 32：Idempotent Restart / State Recovery
+
+进程重启后各能力部分有恢复，缺统一 restart-safe 协议。
+
+**设计骨架**：`kernel/recovery.Recoverable` 接口；bootstrap 启动期扫所有 Recoverable 注册 → 从 store 拉 unfinished tokens → Resume。
+
+### 缺口 33：Local Dev / Replay / Time Travel
+
+docker-compose + 单 cell run/test 有；但录制重放 / 跨 cell 联调 / 状态快照回滚 / 时间快进 / hot reload 缺。
+
+**设计骨架**：`tools/devloop/` 提供 record / replay / snapshot / fast-forward 子命令。
+
+### 缺口 34：Policy as Code（CORS / CSP / Cookies / Rate Limit）
+
+HTTP 安全策略 / Cookie 标志 / Rate Limit 都是 global 配置或业务手撕；cell 不可声明。
+
+**设计骨架**：cell.yaml / contract.yaml 加 `httpPolicy` 字段；framework 派生 middleware 统一应用。
+
+### 缺口 35：Feature Flag ↔ Code Path 协同
+
+flag 名是字符串硬编码；与代码路径关联靠 `if` check；rollout / sticky bucketing / audit 联动缺。
+
+**设计骨架**：`contracts/featureflag/*.flag.yaml` codegen 派生 typed flag：`flags.NewLoginFlow.Enabled(ctx) bool`；自动 metric + audit 决策。
+
+---
+
+## 缺口性质分类矩阵
+
+```
+              抽象缺失          维度共享           生命周期            声明面窄
+              ─────────────    ─────────────     ─────────────       ─────────────
+长链路        [1] HTTP idem    [10] Principal    [15] Version skew   [22] AuthZ↔contract
+              [2] Saga         [11] Correlation  [25] Migration      [29] SDK gen
+              [3] InProc RPC                     [26] Drain          [30] Contract test
+              [4] Command bus                    [32] Restart-safe   [35] Feature flag
+              [5] AfterCommit                                        [34] HTTP policy
+
+横切治理       [7] Health dep   [21] Resource     [13] Data lifecycle [23] Time/clock
+              [8] Failure bud  [28] Attribution  [20] Secret rot     [24] Event order
+              [9] Backpressure                   [17] Degradation
+              [27] Outbound
+
+观测/数据      [16] Chaos       [12] Large pay    [33] Local dev      [31] Forensic
+              [18] Cache       [19] Stream/WS    [14] Scheduled
+                                                  [6] Schema reg
+```
+
+---
+
+## 强枢纽节点（Wire Envelope）
+
+35 缺口中近半数依赖**同一份扩展信封**（outbox.Entry.Headers + ctx envelope）：
+
+```
+                     [10] Principal Envelope
+                     [11] Correlation
+                     [23] Time / Causality
+                              │
+                              ▼
+                       共享 envelope
+                              │
+                ┌─────────────┼─────────────┐
+                ▼             ▼             ▼
+         outbox.Headers   audit.Entry   trace span
+                │
+                ▼
+   一个 wire 信封解锁：[1][2][3][4][5][22][24][27][30][31][32][35]
+```
+
+**核心识别**：把 wire envelope 做对，下游缺口的 interaction 半径自动变小。
+
+---
+
+## 缺口依赖图（顶层）
+
+```
+                ┌──────────────────────────────────┐
+                ▼                                  │
+   [5] After-Commit Hook ──┐                       │
+                           │                       │
+                           ▼                       │
+                  [1] HTTP Idempotency             │
+                           │                       │
+                           ▼                       │
+                  [4] Command Bus                  │
+                           │                       │
+                           ▼                       │
+                  [2] L3 Workflow / Saga ←─────────┘
+                           │
+                           ▼
+                  [Projection / Replay] (P3)
+
+
+   [3] In-Process Contract ←─ codegen 扩展
+                           │
+                           ▼
+                  跨 cell typed RPC
+
+   [6] Schema Registry ←─ codegen 扩展（独立线）
+
+   [7] Health Dependency ←─ cell.yaml 字段（独立线）
+                           │
+                           └→ 启动依赖编排
+```
+
+**核心串联线**：**After-Commit Hook → HTTP Idempotency → Command Bus → Saga** 是递进，前面是后面的基础设施。
+
+---
+
+## 落地优先级建议
+
+| Wave | 内容 | 周期估 | 收益 |
+|---|---|---|---|
+| **W0** | 扩 outbox.Entry.Headers + 定义 envelope schema（[10][11][23]） | 短 | 解锁后续多个缺口 |
+| **W1** | After-Commit Hook（含 archtest 白名单） + Health Dependency 声明 + 观测反查 | 短 | 立即受益 |
+| **W2** | HTTP Idempotency middleware + RecordedResponse Store | 中 | 缓解最高频痛点 |
+| **W3** | Command Bus + codegen + 与 outbox / idempotency 协同 | 中 | 打通 CQRS 写侧 |
+| **W4** | In-Process Contract + assembly 拓扑感知 transport bind | 中 | 解决跨 cell 调用合规缺口 |
+| **W5** | Schema Registry（codegen hash + runtime check） + Version Skew | 短 | 把约定升机制，AI-rebust 升级 |
+| **W6** | L3 Saga / Workflow Engine（基于 W1–W4） | 长 | L3 consistencyLevel 名实相符 |
+| **W7** | Auth → Audit middleware + observability 反查链路 + AuthZ↔contract | 短 | 合规 + 排障基础 |
+| **W8** | Outbound HTTP / Webhook + Drain / Restart-safe | 中 | 外部边界标准化 |
+| **W9** | Migration ↔ Deploy + Secret Rotation 协议 | 中 | 生产演进基础 |
+| **W10** | Projection / Replay runtime（基于 W5+W6） | 长 | L3 投影场景体系化 |
+| **后置** | EventBus → WS bridge / 多租户 / 全套 DX 工具链 | — | 等业务驱动 |
+
+---
+
+## 缺口性质判断
+
+### 三批缺口的本质差异
+
+| 批次 | 数量 | 性质 |
+|---|---|---|
+| 第一批（1–7） | 7 | **抽象缺失**：framework 没做的 framework 范畴必填项 |
+| 第二批（8–22） | 15 | **组合断点**：能力做了但没串起来（envelope / 共享口径 / 共有协议） |
+| 第三批（23–35） | 13 | **时间维度 / 外部边界 / DX 工具链** |
+
+### 三批的根本问题归约
+
+35 个缺口的本质可归到 **3 个核心问题**：
+
+1. **协议层不够薄**：wire envelope 字段集没收敛，导致每个能力各搞各的
+2. **时间维度系统性缺位**：所有抽象假设静态
+3. **声明面收口不全**：cell.yaml / contract.yaml 还能装更多事
+
+### 缺口的"难度分布"
+
+| 难度 | 缺口数 | 例子 |
+|---|---|---|
+| **改 wire envelope** | ~8 | [10][11][23] 等 |
+| **加 codegen 字段** | ~10 | [6][22][24][29][34][35] |
+| **新建 framework 抽象** | ~10 | [1][2][4][27] |
+| **新建协议** | ~5 | [13][20][25][32] |
+| **DX 工具链** | ~3 | [29][30][33] |
+
+**改 wire envelope** 是最高 ROI 区——动 1 处接管多缺口。
+**新建 framework 抽象** 是最大投入区——长周期。
+**DX 工具链** 是最易拖延区——直到团队规模驱动。
+
+---
+
+## 边际收益递减说明
+
+- **第一批（1–7）是必填项**——没做这些，L3+ 不可用
+- **第二批（8–22）是应做项**——做了大幅减少业务 boilerplate，不做能撑住但脆弱
+- **第三批（23–35）是可做项**——做了优雅，不做大多数业务团队也能挺过去
+
+继续找缺口会越来越多变成"细化 / scope 决定 / 业务团队偏好"——不是 framework 设计问题。如：
+
+- GraphQL 支持（业务偏好）
+- gRPC adapter（部署形态偏好）
+- Notification email/SMS/push（更像 outbound 子集）
+- A/B testing platform（更像 feature flag 子集）
+- BFF / API gateway（更像 cross-cell composition 子集）
+- 文件上传 / 直传 S3（更像 large payload 子集）
+
+这些是真实需求，但**不是 framework 必须答的问题**——是 framework 已有能力的业务侧组合应用。
+
+---
+
+## 总判断
+
+1. **GoCell framework 当前阶段**：**单元精度高、组合精度低**的典型早期状态。每个独立能力（Cell / Outbox / Auth / Errcode / Codegen / Archtest）做得相当精致，但能力之间的 wire envelope / 共享口径 / 共有协议远没成型。
+
+2. **修复优先序的杠杆点**在 **W0–W2**：扩 envelope + after-commit + idempotency 三件套，解锁后续多个缺口。
+
+3. **AI-rebust 视角下的系统性升级机会**：当前 archtest 重点守"形态唯一"（panic / errcode / outbox 字面量等），下一阶段应该升级到守"**关系唯一**"（wire envelope 字段集 / contract.yaml ↔ 实现 ↔ test 三方一致）。这要求 archtest 工具能跨多文件做关系验证——`tools/archtest/internal/typeseval` 已有基础，但跨 yaml ↔ code 的双向关系测试尚未普及。
+
+4. **真正的战略选择**：framework 接下来是"**做深现有能力的精度**"，还是"**做广能力的组合**"？两者投入截然不同。后者收益更高——前者已经处于 marginal returns，后者直接决定 L3+ 能否落地。
+
+**简言之：第一批缺口是 "framework 没做的事"，第二批缺口是 "framework 做了但没串起来的事"。串起来的代价远小于重做的代价，应当优先。**


### PR DESCRIPTION
四份配套文档：001 DDD 适用范围（cells 主战场，其他层各自语汇）；
002 能力盘点（A–P 16 域 + cells 消费清单 + L0–L4 对照 + 强制 invariant）；
003 交互模式（8 个典型场景 + 涌现能力 + 设计哲学）；
004 缺口分析（35 项三批分级 + 性质矩阵 + 枢纽节点 + 依赖图 + 落地优先级）。

四份文档交叉引用，可独立阅读也可串联通读，为后续 framework 演进的范围决策提供依据。