### PR TITLE
refactor(archtest): Pass-Driver migration — PR-3 contract/codegen (#040 stage 2)

### DIFF
--- a/tools/archtest/accesscore_facade_test.go
+++ b/tools/archtest/accesscore_facade_test.go
@@ -3,7 +3,6 @@ package archtest
 
 import (
 	"go/ast"
-	"go/parser"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -11,8 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // TestAccessCoreFacadePolishA61Guard locks A61's no-shim decision: the
@@ -37,13 +34,16 @@ func TestAccessCoreFacadePolishA61Guard(t *testing.T) {
 func scanAccesscoreFacadeDeclarations(t *testing.T, root string) []string {
 	t.Helper()
 	var violations []string
-	scope := scanner.DirsScope(root, []string{"cells/accesscore"})
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc scanner.FileContext) {
-		scanner.EachInSubtree[ast.FuncDecl](fc.File, func(fn *ast.FuncDecl) {
-			if fn.Recv == nil && fn.Name.Name == "ResolveBootstrapCredentialPath" {
-				violations = append(violations, fc.Rel+": exported facade ResolveBootstrapCredentialPath must be deleted")
-			}
-		})
+	scope := DirsScope(root, []string{"cells/accesscore"})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+				if fn.Recv == nil && fn.Name.Name == "ResolveBootstrapCredentialPath" {
+					violations = append(violations, p.Rel(file)+": exported facade ResolveBootstrapCredentialPath must be deleted")
+				}
+			})
+		}
+		return nil
 	})
 	return violations
 }
@@ -52,17 +52,20 @@ func scanResolveBootstrapCredentialPathCalls(t *testing.T, root, dir string) []s
 	t.Helper()
 	rel, err := filepath.Rel(root, dir)
 	require.NoError(t, err)
-	scope := scanner.DirsScope(root, []string{filepath.ToSlash(rel)})
+	scope := DirsScope(root, []string{filepath.ToSlash(rel)})
 	var violations []string
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
-		scanner.EachInSubtree[ast.SelectorExpr](fc.File, func(sel *ast.SelectorExpr) {
-			if sel.Sel.Name != "ResolveBootstrapCredentialPath" {
-				return
-			}
-			pos := fc.Fset.Position(sel.Sel.Pos())
-			violations = append(violations,
-				fc.Rel+":"+strconv.Itoa(pos.Line)+": call initialadmin.ResolveCredentialPath directly")
-		})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+				if sel.Sel.Name != "ResolveBootstrapCredentialPath" {
+					return
+				}
+				pos := p.Fset.Position(sel.Sel.Pos())
+				violations = append(violations,
+					p.Rel(file)+":"+strconv.Itoa(pos.Line)+": call initialadmin.ResolveCredentialPath directly")
+			})
+		}
+		return nil
 	})
 	return violations
 }

--- a/tools/archtest/assembly_invariants_test.go
+++ b/tools/archtest/assembly_invariants_test.go
@@ -34,8 +34,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-
-	archscanner "github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // ---- ASSEMBLY-MODULES-GEN-01 / ASSEMBLY-MODULES-SWITCH-FORBIDDEN-02 /
@@ -72,8 +70,8 @@ func loadKnownCellIDs(t *testing.T) []string {
 	// filepath.Base check would also match nested fixtures (e.g.
 	// cells/<id>/sub/cell.yaml), letting future test scaffolding silently
 	// inflate the cell ID set.
-	scope := archscanner.DirsScope(root, []string{"cells"},
-		archscanner.MatchRels(func(rel string) bool {
+	scope := DirsScope(root, []string{"cells"},
+		MatchRels(func(rel string) bool {
 			rel = filepath.ToSlash(rel)
 			return strings.HasPrefix(rel, "cells/") &&
 				strings.Count(rel, "/") == depth2SlashCount &&
@@ -82,7 +80,7 @@ func loadKnownCellIDs(t *testing.T) []string {
 	)
 
 	var ids []string
-	archscanner.EachContentFile(t, scope, []string{".yaml"}, func(_ *testing.T, fc archscanner.ContentContext) {
+	EachContentFile(t, scope, []string{".yaml"}, func(_ *testing.T, fc ContentContext) {
 		var doc struct {
 			ID string `yaml:"id"`
 		}
@@ -116,21 +114,25 @@ func loadKnownCellIDs(t *testing.T) []string {
 func TestAssemblyModulesGen_HasGeneratedMarker(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
-	scope := archscanner.DirsScope(root, []string{"cmd"},
-		archscanner.MatchRels(func(rel string) bool {
+	scope := DirsScope(root, []string{"cmd"},
+		MatchRels(func(rel string) bool {
 			rel = filepath.ToSlash(rel)
 			return filepath.Base(rel) == "modules_gen.go" && strings.Count(rel, "/") == depth2SlashCount
 		}),
 	)
 
 	hits := 0
-	archscanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc archscanner.FileContext) {
-		hits++
-		path, rel := fc.AbsPath, fc.Rel
-		t.Run(rel, func(t *testing.T) {
-			t.Parallel()
-			checkModulesGenFile(t, path, rel)
-		})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			hits++
+			path := p.Fset.Position(file.Pos()).Filename
+			rel := p.Rel(file)
+			t.Run(rel, func(t *testing.T) {
+				t.Parallel()
+				checkModulesGenFile(t, path, rel)
+			})
+		}
+		return nil
 	})
 	if hits == 0 {
 		t.Logf("%s: no cmd/*/modules_gen.go files found — nothing to enforce", ruleAssemblyModulesGen01)
@@ -176,7 +178,7 @@ func checkModulesGenFile(t *testing.T, path, rel string) {
 // function declaration `func generatedCellModules() []CellModule`.
 func hasGeneratedCellModulesFunc(af *ast.File) bool {
 	found := false
-	archscanner.EachInSubtree[ast.FuncDecl](af, func(fn *ast.FuncDecl) {
+	EachInSubtree[ast.FuncDecl](af, func(fn *ast.FuncDecl) {
 		if found {
 			return
 		}
@@ -226,7 +228,7 @@ func TestRunGoNoCellIDSwitch(t *testing.T) {
 		knownIDSet[id] = struct{}{}
 	}
 
-	scope := archscanner.DirsScope(root, []string{"cmd"})
+	scope := DirsScope(root, []string{"cmd"})
 
 	type violation struct {
 		file   string
@@ -235,29 +237,32 @@ func TestRunGoNoCellIDSwitch(t *testing.T) {
 	}
 	var violations []violation
 
-	archscanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc archscanner.FileContext) {
-		archscanner.EachInSubtree[ast.SwitchStmt](fc.File, func(sw *ast.SwitchStmt) {
-			archscanner.EachInChildren[ast.CaseClause](sw.Body, func(cc *ast.CaseClause) {
-				for _, expr := range cc.List {
-					archscanner.EachInSubtree[ast.BasicLit](expr, func(lit *ast.BasicLit) {
-						if lit.Kind != token.STRING {
-							return
-						}
-						unquoted, err := strconv.Unquote(lit.Value)
-						if err != nil {
-							return
-						}
-						if _, found := knownIDSet[unquoted]; found {
-							violations = append(violations, violation{
-								file:   fc.Rel,
-								line:   fc.Fset.Position(lit.Pos()).Line,
-								cellID: unquoted,
-							})
-						}
-					})
-				}
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			EachInSubtree[ast.SwitchStmt](file, func(sw *ast.SwitchStmt) {
+				EachInChildren[ast.CaseClause](sw.Body, func(cc *ast.CaseClause) {
+					for _, expr := range cc.List {
+						EachInSubtree[ast.BasicLit](expr, func(lit *ast.BasicLit) {
+							if lit.Kind != token.STRING {
+								return
+							}
+							unquoted, err := strconv.Unquote(lit.Value)
+							if err != nil {
+								return
+							}
+							if _, found := knownIDSet[unquoted]; found {
+								violations = append(violations, violation{
+									file:   p.Rel(file),
+									line:   p.Fset.Position(lit.Pos()).Line,
+									cellID: unquoted,
+								})
+							}
+						})
+					}
+				})
 			})
-		})
+		}
+		return nil
 	})
 
 	for _, v := range violations {
@@ -353,7 +358,7 @@ func containsYAMLDashTag(rawTag string) bool {
 // af, or nil if not found.
 func findStructDecl(af *ast.File, name string) *ast.StructType {
 	var result *ast.StructType
-	archscanner.EachInSubtree[ast.TypeSpec](af, func(ts *ast.TypeSpec) {
+	EachInSubtree[ast.TypeSpec](af, func(ts *ast.TypeSpec) {
 		if result != nil {
 			return
 		}
@@ -388,22 +393,25 @@ func findStructDecl(af *ast.File, name string) *ast.StructType {
 func TestAssemblyCellModuleTypePresent(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
-	scope := archscanner.DirsScope(root, []string{"cmd"},
-		archscanner.MatchRels(func(rel string) bool {
+	scope := DirsScope(root, []string{"cmd"},
+		MatchRels(func(rel string) bool {
 			rel = filepath.ToSlash(rel)
 			return filepath.Base(rel) == "modules_gen.go" && strings.Count(rel, "/") == depth2SlashCount
 		}),
 	)
 
 	hits := 0
-	archscanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc archscanner.FileContext) {
-		hits++
-		cmdDir := filepath.Dir(fc.AbsPath)
-		cmdRel := filepath.ToSlash(filepath.Dir(fc.Rel))
-		t.Run(cmdRel, func(t *testing.T) {
-			t.Parallel()
-			checkCellModuleTypePresentInDir(t, root, cmdDir)
-		})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			hits++
+			cmdDir := filepath.Dir(p.Fset.Position(file.Pos()).Filename)
+			cmdRel := filepath.ToSlash(filepath.Dir(p.Rel(file)))
+			t.Run(cmdRel, func(t *testing.T) {
+				t.Parallel()
+				checkCellModuleTypePresentInDir(t, root, cmdDir)
+			})
+		}
+		return nil
 	})
 	if hits == 0 {
 		t.Logf("%s: no cmd/*/modules_gen.go files found — nothing to enforce", ruleAssemblyCellModuleType04)
@@ -420,20 +428,23 @@ func checkCellModuleTypePresentInDir(t *testing.T, root, cmdDir string) {
 	require.NoError(t, err, "%s: rel %s", ruleAssemblyCellModuleType04, cmdDir)
 	cmdDirRel = filepath.ToSlash(cmdDirRel)
 
-	scope := archscanner.DirsScope(root, []string{cmdDirRel},
-		archscanner.MatchRels(func(rel string) bool {
+	scope := DirsScope(root, []string{cmdDirRel},
+		MatchRels(func(rel string) bool {
 			return filepath.ToSlash(filepath.Dir(rel)) == cmdDirRel
 		}),
 	)
 
 	found := false
-	archscanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc archscanner.FileContext) {
-		if found {
-			return
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			if found {
+				return nil
+			}
+			if hasTopLevelTypeDecl(file, "CellModule") {
+				found = true
+			}
 		}
-		if hasTopLevelTypeDecl(fc.File, "CellModule") {
-			found = true
-		}
+		return nil
 	})
 	if found {
 		return
@@ -453,7 +464,7 @@ func checkCellModuleTypePresentInDir(t *testing.T, root, cmdDir string) {
 // any other type kind.
 func hasTopLevelTypeDecl(af *ast.File, name string) bool {
 	found := false
-	archscanner.EachInSubtree[ast.TypeSpec](af, func(ts *ast.TypeSpec) {
+	EachInSubtree[ast.TypeSpec](af, func(ts *ast.TypeSpec) {
 		if !found && ts.Name.Name == name {
 			found = true
 		}
@@ -810,7 +821,7 @@ func asnCheckSource(label, src string) ([]string, error) {
 
 func asnCheckAST(fset *token.FileSet, f *ast.File, label string) []string {
 	var violations []string
-	archscanner.EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
+	EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
 		if fn.Body == nil {
 			return
 		}
@@ -821,7 +832,7 @@ func asnCheckAST(fset *token.FileSet, f *ast.File, label string) []string {
 	// not inherit the caller's lockDepth, so each starts fresh at 0. The
 	// outer EachInSubtree[ast.FuncLit] catches FuncLits anywhere in the file
 	// (top-level decls, nested calls, struct field initializers, ...).
-	archscanner.EachInSubtree[ast.FuncLit](f, func(fl *ast.FuncLit) {
+	EachInSubtree[ast.FuncLit](f, func(fl *ast.FuncLit) {
 		if fl.Body == nil {
 			return
 		}
@@ -1035,7 +1046,7 @@ func asnViolation(file string, line int) string {
 // asnFindAssemblyProductionGoFiles returns all non-test .go files under
 // kernel/assembly/.
 func asnFindAssemblyProductionGoFiles(root string) ([]string, error) {
-	scope := archscanner.DirsScope(root, []string{"kernel/assembly"})
+	scope := DirsScope(root, []string{"kernel/assembly"})
 	files, err := scope.Files()
 	if err != nil {
 		return nil, err
@@ -1113,7 +1124,7 @@ func TestAssemblyRefMethodSet(t *testing.T) {
 // interface { … }` in af, or nil if not found.
 func findInterfaceDecl(af *ast.File, name string) *ast.InterfaceType {
 	var result *ast.InterfaceType
-	archscanner.EachInSubtree[ast.TypeSpec](af, func(ts *ast.TypeSpec) {
+	EachInSubtree[ast.TypeSpec](af, func(ts *ast.TypeSpec) {
 		if result != nil {
 			return
 		}

--- a/tools/archtest/assembly_invariants_test.go
+++ b/tools/archtest/assembly_invariants_test.go
@@ -490,6 +490,7 @@ func hasTopLevelTypeDecl(af *ast.File, name string) bool {
 const ruleAssemblySnapshotsLocked01 = "ASSEMBLY-SNAPSHOTS-LOCKED-01"
 
 func TestAssemblySnapshotsLocked(t *testing.T) {
+	t.Parallel()
 	root := findModuleRoot(t)
 	files, err := asnFindAssemblyProductionGoFiles(root)
 	if err != nil {
@@ -1093,6 +1094,7 @@ var expectedAssemblyRefMethods = map[string]string{
 }
 
 func TestAssemblyRefMethodSet(t *testing.T) {
+	t.Parallel()
 	root := findModuleRoot(t)
 	srcPath := filepath.Join(root, "kernel", "cell", "auth_plan.go")
 

--- a/tools/archtest/auditcore_appender_single_source_test.go
+++ b/tools/archtest/auditcore_appender_single_source_test.go
@@ -4,15 +4,13 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
-	"go/parser"
+	"go/token"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // auditcoreAppenderSlicePackages is the closed set of slice packages that
@@ -65,8 +63,8 @@ const allowedTypeAlias = "type Service = appender.Service"
 func TestAuditcoreAppenderSliceFacadesAreThin(t *testing.T) {
 	root := findModuleRoot(t)
 
-	scope := scanner.DirsScope(root, auditcoreAppenderSlicePackages,
-		scanner.MatchRels(func(rel string) bool {
+	scope := DirsScope(root, auditcoreAppenderSlicePackages,
+		MatchRels(func(rel string) bool {
 			base := filepath.Base(rel)
 			// Skip generated files (own DO NOT EDIT guard) and tests.
 			if strings.HasSuffix(base, "_gen.go") || strings.HasSuffix(base, "_test.go") {
@@ -77,8 +75,11 @@ func TestAuditcoreAppenderSliceFacadesAreThin(t *testing.T) {
 	)
 
 	var violations []string
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc scanner.FileContext) {
-		violations = append(violations, scanAuditcoreAppenderSliceFile(fc)...)
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			violations = append(violations, scanAuditcoreAppenderSliceFile(p.Rel(file), p.Fset, file)...)
+		}
+		return nil
 	})
 
 	sort.Strings(violations)
@@ -95,19 +96,19 @@ func TestAuditcoreAppenderSliceFacadesAreThin(t *testing.T) {
 	assert.Empty(t, violations, failMsg)
 }
 
-func scanAuditcoreAppenderSliceFile(fc scanner.FileContext) []string {
+func scanAuditcoreAppenderSliceFile(rel string, fset *token.FileSet, file *ast.File) []string {
 	var violations []string
 
 	// type Service must be a type alias (Assign valid), never a fresh struct
 	// or interface. ImportSpec / ValueSpec (var Spec = ...) are allowed and
 	// not inspected here (Spec's whitelist enforcement lives in
 	// appender.MustNewSpec).
-	scanner.EachInSubtree[ast.TypeSpec](fc.File, func(ts *ast.TypeSpec) {
+	EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
 		if ts.Name.Name == "Service" && !ts.Assign.IsValid() {
 			violations = append(violations, fmt.Sprintf(
 				"%s:%d: AUDITCORE-APPENDER-SINGLE-SOURCE-01: "+
 					"forbidden `type Service` definition (must be `%s`)",
-				fc.Rel, fc.Fset.Position(ts.Pos()).Line, allowedTypeAlias))
+				rel, fset.Position(ts.Pos()).Line, allowedTypeAlias))
 		}
 	})
 
@@ -116,15 +117,15 @@ func scanAuditcoreAppenderSliceFile(fc scanner.FileContext) []string {
 	// NewService / With* / extractActorID re-fork behavior the appender
 	// package owns. EachInSubtree walks the whole file; slice packages have no
 	// nested function literals so every FuncDecl returned is top-level.
-	scanner.EachInSubtree[ast.FuncDecl](fc.File, func(fd *ast.FuncDecl) {
-		violations = append(violations, scanAppenderFuncDecl(fc, fd)...)
+	EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+		violations = append(violations, scanAppenderFuncDecl(rel, fset, fd)...)
 	})
 
 	return violations
 }
 
-func scanAppenderFuncDecl(fc scanner.FileContext, d *ast.FuncDecl) []string {
-	pos := fc.Fset.Position(d.Pos()).Line
+func scanAppenderFuncDecl(rel string, fset *token.FileSet, d *ast.FuncDecl) []string {
+	pos := fset.Position(d.Pos()).Line
 
 	// Methods: any receiver named *Service or Service is forbidden — slice
 	// packages must not attach behavior to the (aliased) Service type. Go's
@@ -138,7 +139,7 @@ func scanAppenderFuncDecl(fc scanner.FileContext, d *ast.FuncDecl) []string {
 				"%s:%d: AUDITCORE-APPENDER-SINGLE-SOURCE-01: "+
 					"forbidden method on Service "+
 					"(slice must not extend the appender.Service alias)",
-				fc.Rel, pos)}
+				rel, pos)}
 		}
 		// Methods on other types are allowed (none expected today, but
 		// not banned).
@@ -152,13 +153,13 @@ func scanAppenderFuncDecl(fc scanner.FileContext, d *ast.FuncDecl) []string {
 			"%s:%d: AUDITCORE-APPENDER-SINGLE-SOURCE-01: "+
 				"forbidden `func NewService` "+
 				"(call appender.NewService directly from cell.go)",
-			fc.Rel, pos)}
+			rel, pos)}
 	case strings.HasPrefix(d.Name.Name, "With"):
 		return []string{fmt.Sprintf(
 			"%s:%d: AUDITCORE-APPENDER-SINGLE-SOURCE-01: "+
 				"forbidden `func %s` "+
 				"(call appender.%s directly from cell.go)",
-			fc.Rel, pos, d.Name.Name, d.Name.Name)}
+			rel, pos, d.Name.Name, d.Name.Name)}
 	}
 	// Other top-level functions are flagged so the next reviewer notices —
 	// slice packages are metadata holders only.
@@ -166,7 +167,7 @@ func scanAppenderFuncDecl(fc scanner.FileContext, d *ast.FuncDecl) []string {
 		"%s:%d: AUDITCORE-APPENDER-SINGLE-SOURCE-01: unexpected top-level "+
 			"func %s; slice packages should hold only `type Service = "+
 			"appender.Service` + `var Spec = ...`",
-		fc.Rel, pos, d.Name.Name)}
+		rel, pos, d.Name.Name)}
 }
 
 // appenderReceiverTypeName extracts the named receiver type, unwrapping pointer

--- a/tools/archtest/cas_protocol_composition_root_test.go
+++ b/tools/archtest/cas_protocol_composition_root_test.go
@@ -3,14 +3,11 @@ package archtest
 
 import (
 	"go/ast"
-	"go/parser"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // CAS-PROTOCOL-COMPOSITION-ROOT-01: cas.NewProtocol /
@@ -34,8 +31,8 @@ func TestCASProtocol_CompositionRootOnly(t *testing.T) {
 	root := findModuleRoot(t)
 	casPrefix := "runtime/state/cas/"
 
-	scope := scanner.DirsScope(root, []string{"cells", "runtime", "adapters"},
-		scanner.MatchRels(func(rel string) bool {
+	scope := DirsScope(root, []string{"cells", "runtime", "adapters"},
+		MatchRels(func(rel string) bool {
 			rel = filepath.ToSlash(rel)
 			if !strings.HasSuffix(rel, ".go") {
 				return false
@@ -61,24 +58,27 @@ func TestCASProtocol_CompositionRootOnly(t *testing.T) {
 	}
 	var hits []hit
 
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc scanner.FileContext) {
-		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return
-			}
-			pkg, ok := sel.X.(*ast.Ident)
-			if !ok || pkg.Name != "cas" {
-				return
-			}
-			if forbidden[sel.Sel.Name] {
-				hits = append(hits, hit{
-					file: fc.Rel,
-					line: fc.Fset.Position(call.Pos()).Line,
-					name: sel.Sel.Name,
-				})
-			}
-		})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "cas" {
+					return
+				}
+				if forbidden[sel.Sel.Name] {
+					hits = append(hits, hit{
+						file: p.Rel(file),
+						line: p.Fset.Position(call.Pos()).Line,
+						name: sel.Sel.Name,
+					})
+				}
+			})
+		}
+		return nil
 	})
 
 	for _, h := range hits {

--- a/tools/archtest/cellgen_errcode_funnel_test.go
+++ b/tools/archtest/cellgen_errcode_funnel_test.go
@@ -16,13 +16,10 @@ package archtest
 
 import (
 	"go/ast"
-	"go/parser"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // TestCellgenScaffoldErrcodeFunnel enforces CELLGEN-SCAFFOLD-ERRCODE-FUNNEL-01:
@@ -39,7 +36,7 @@ func TestCellgenScaffoldErrcodeFunnel(t *testing.T) {
 
 	repoRoot := repoRootFromTestPath(t)
 
-	cellgenAllPred := scanner.MatchRels(func(rel string) bool {
+	cellgenAllPred := MatchRels(func(rel string) bool {
 		base := filepath.Base(rel)
 		// Exclude test files.
 		if strings.HasSuffix(base, "_test.go") {
@@ -49,28 +46,31 @@ func TestCellgenScaffoldErrcodeFunnel(t *testing.T) {
 		return strings.HasSuffix(base, ".go")
 	})
 
-	scope := scanner.DirsScope(repoRoot, []string{
+	scope := DirsScope(repoRoot, []string{
 		"tools/codegen/cellgen",
 	}, cellgenAllPred)
 
 	var violations []string
 
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
-		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return
-			}
-			ident, ok := sel.X.(*ast.Ident)
-			if !ok {
-				return
-			}
-			if ident.Name == "fmt" && sel.Sel.Name == "Errorf" {
-				pos := fc.Fset.Position(call.Lparen)
-				violations = append(violations,
-					fc.Rel+":"+strconv.Itoa(pos.Line)+": fmt.Errorf(...)")
-			}
-		})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
+				ident, ok := sel.X.(*ast.Ident)
+				if !ok {
+					return
+				}
+				if ident.Name == "fmt" && sel.Sel.Name == "Errorf" {
+					pos := p.Fset.Position(call.Lparen)
+					violations = append(violations,
+						p.Rel(file)+":"+strconv.Itoa(pos.Line)+": fmt.Errorf(...)")
+				}
+			})
+		}
+		return nil
 	})
 
 	if len(violations) > 0 {

--- a/tools/archtest/cellmeta_single_source_test.go
+++ b/tools/archtest/cellmeta_single_source_test.go
@@ -40,8 +40,6 @@ import (
 	"go/token"
 	"path/filepath"
 	"testing"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // TestCellmetaSingleSource01_NoForbiddenTypes verifies CELLMETA-SINGLE-SOURCE-01.
@@ -56,18 +54,21 @@ func TestCellmetaSingleSource01_NoForbiddenTypes(t *testing.T) {
 		"CellVerify":   true,
 		"L0Dep":        true,
 	}
-	scope := scanner.DirsScope(root, []string{"kernel/cell"})
-	scanner.EachFile(t, scope, 0, func(_ *testing.T, fc scanner.FileContext) {
-		scanner.EachInSubtree[ast.TypeSpec](fc.File, func(ts *ast.TypeSpec) {
-			if forbidden[ts.Name.Name] {
-				t.Errorf(
-					"CELLMETA-SINGLE-SOURCE-01: %s declares type %s — "+
-						"moved to kernel/metadata (CellMeta / OwnerMeta / SchemaMeta / "+
-						"CellVerifyMeta / L0DepMeta); remove duplicate type",
-					fc.Rel, ts.Name.Name,
-				)
-			}
-		})
+	scope := DirsScope(root, []string{"kernel/cell"})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
+				if forbidden[ts.Name.Name] {
+					t.Errorf(
+						"CELLMETA-SINGLE-SOURCE-01: %s declares type %s — "+
+							"moved to kernel/metadata (CellMeta / OwnerMeta / SchemaMeta / "+
+							"CellVerifyMeta / L0DepMeta); remove duplicate type",
+						p.Rel(file), ts.Name.Name,
+					)
+				}
+			})
+		}
+		return nil
 	})
 }
 
@@ -83,7 +84,7 @@ func TestCellmetaSingleSource02_NewBaseCellSignature(t *testing.T) {
 		t.Fatalf("parse %s: %v", path, perr)
 	}
 	var found *ast.FuncDecl
-	scanner.EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+	EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
 		if found != nil || fd.Recv != nil || fd.Name == nil {
 			return
 		}
@@ -119,7 +120,7 @@ func TestCellmetaSingleSource03_MetadataInterfaceReturn(t *testing.T) {
 		t.Fatalf("parse %s: %v", path, perr)
 	}
 	var inventoryIface *ast.InterfaceType
-	scanner.EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+	EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
 		if inventoryIface != nil || ts.Name.Name != "CellInventory" {
 			return
 		}

--- a/tools/archtest/codegen_invariants_test.go
+++ b/tools/archtest/codegen_invariants_test.go
@@ -1289,12 +1289,13 @@ func findAllCellInitFiles(t *testing.T, root string) []string {
 				return name == "cell.go" || strings.HasPrefix(name, "cell_")
 			}),
 		)
-		Run(t, scope, func(p *Pass) []Diagnostic {
-			for _, file := range p.Files {
-				files = append(files, p.Fset.Position(file.Pos()).Filename)
-			}
-			return nil
-		})
+		// scope.Files() returns absolute paths without parsing — no AST work
+		// needed here, just path enumeration.
+		paths, err := scope.Files()
+		if err != nil {
+			t.Fatalf("findAllCellInitFiles: scope.Files: %v", err)
+		}
+		files = append(files, paths...)
 	}
 	sort.Strings(files)
 	return files

--- a/tools/archtest/codegen_invariants_test.go
+++ b/tools/archtest/codegen_invariants_test.go
@@ -44,7 +44,6 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/testutil/fileutil"
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 	"github.com/ghbvf/gocell/tools/codegen/markergen"
 )
 
@@ -141,19 +140,23 @@ func TestCodegenUserFileOverlap01(t *testing.T) {
 			continue
 		}
 		structName := cell.GoStructName.String()
-		scope := scanner.DirsScope(root, []string{dirRel},
-			scanner.MatchRels(func(rel string) bool {
+		scope := DirsScope(root, []string{dirRel},
+			MatchRels(func(rel string) bool {
 				if filepath.ToSlash(filepath.Dir(rel)) != dirRel {
 					return false
 				}
 				return filepath.Base(rel) != "cell_gen.go"
 			}),
 		)
-		scanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc scanner.FileContext) {
-			if hasInitMethod(t, fc.AbsPath, structName) {
-				t.Errorf("CODEGEN-USER-FILE-OVERLAP-01: %s defines func (c *%s) Init — Init is owned by cell_gen.go; "+
-					"move business init logic into func (c *%s) initInternal", fc.Rel, structName, structName)
+		Run(t, scope, func(p *Pass) []Diagnostic {
+			for _, file := range p.Files {
+				abs := p.Fset.Position(file.Pos()).Filename
+				if hasInitMethod(t, abs, structName) {
+					t.Errorf("CODEGEN-USER-FILE-OVERLAP-01: %s defines func (c *%s) Init — Init is owned by cell_gen.go; "+
+						"move business init logic into func (c *%s) initInternal", p.Rel(file), structName, structName)
+				}
 			}
+			return nil
 		})
 	}
 }
@@ -223,13 +226,13 @@ func TestCodegenGates_NegativeFixtures(t *testing.T) {
 	t.Run("marker_present", func(t *testing.T) {
 		t.Parallel()
 		root := findModuleRoot(t)
-		scope := scanner.DirsScope(root,
+		scope := DirsScope(root,
 			[]string{"tools/archtest/testdata/codegen_cell_gen_fixtures/marker_present"},
-			scanner.IncludeTestdata(),
+			IncludeTestdata(),
 		)
 
 		var hits []string
-		scanner.EachContentFile(t, scope, []string{".go"}, func(_ *testing.T, fc scanner.ContentContext) {
+		EachContentFile(t, scope, []string{".go"}, func(_ *testing.T, fc ContentContext) {
 			for i, line := range strings.Split(string(fc.Bytes), "\n") {
 				trim := strings.TrimSpace(line)
 				if strings.HasPrefix(trim, codegenMarkerCellPrefix) ||
@@ -371,13 +374,17 @@ func TestCodegenContractUserOverlap01(t *testing.T) {
 // production would leave the fixture green and the ratchet would be a no-op.
 func detectUserFilesUnderGeneratedContracts(t *testing.T, root, dirRel string) []string {
 	t.Helper()
-	scope := scanner.DirsScope(root, []string{dirRel}, scanner.IncludeTests())
+	scope := DirsScope(root, []string{dirRel}, IncludeTests())
 	var userFiles []string
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc scanner.FileContext) {
-		if strings.HasSuffix(fc.AbsPath, "_gen.go") {
-			return
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			abs := p.Fset.Position(file.Pos()).Filename
+			if strings.HasSuffix(abs, "_gen.go") {
+				continue
+			}
+			userFiles = append(userFiles, abs)
 		}
-		userFiles = append(userFiles, fc.AbsPath)
+		return nil
 	})
 	return userFiles
 }
@@ -428,7 +435,7 @@ func TestCodegenContractGates_NegativeFixtures(t *testing.T) {
 		// directory as root. The detector is the single source of the
 		// IncludeTests() option — if production removes IncludeTests(), this
 		// fixture's helper_test.go disappears from userFiles and hasTest stays
-		// false, so the test turns red. Reusing scanner.DirsScope locally
+		// false, so the test turns red. Reusing DirsScope locally
 		// would re-introduce the no-op ratchet that the deep review caught.
 		userFiles := detectUserFilesUnderGeneratedContracts(t, fixtureRoot, filepath.Join("generated", "contracts"))
 		require.NotEmpty(t, userFiles,
@@ -620,7 +627,7 @@ func TestNoMetadataLiteralInCellGo01(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		scanner.EachInSubtree[ast.CompositeLit](f, func(lit *ast.CompositeLit) {
+		EachInSubtree[ast.CompositeLit](f, func(lit *ast.CompositeLit) {
 			if lit.Type == nil {
 				return
 			}
@@ -878,14 +885,14 @@ func hasInitMethod(t *testing.T, path string, structName string) bool {
 		return false
 	}
 	found := false
-	scanner.EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+	EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
 		if found || fd.Recv == nil || len(fd.Recv.List) == 0 || fd.Name == nil {
 			return
 		}
 		if fd.Name.Name != "Init" {
 			return
 		}
-		if scanner.ReceiverTypeName(fd.Recv.List[0].Type) == structName {
+		if ReceiverTypeName(fd.Recv.List[0].Type) == structName {
 			found = true
 		}
 	})
@@ -897,7 +904,7 @@ func findGeneratedCellFilesIn(t *testing.T, roots []string) []string {
 	t.Helper()
 	var found []string
 	for _, scanRoot := range roots {
-		scope := scanner.DirsScope(scanRoot, []string{"."})
+		scope := DirsScope(scanRoot, []string{"."})
 		allFiles, err := scope.Files()
 		require.NoError(t, err, "findGeneratedCellFilesIn: scanning %s", scanRoot)
 		for _, path := range allFiles {
@@ -919,41 +926,42 @@ func findGeneratedCellFilesIn(t *testing.T, roots []string) []string {
 func checkInitInternalHook(t *testing.T, root, dirRel, structName string) []string {
 	t.Helper()
 	dirRelSlash := filepath.ToSlash(dirRel)
-	matchRel := scanner.MatchRels(func(rel string) bool {
+	matchRel := MatchRels(func(rel string) bool {
 		if filepath.ToSlash(filepath.Dir(rel)) != dirRelSlash {
 			return false
 		}
 		return filepath.Base(rel) != "cell_gen.go"
 	})
-	var scope scanner.Scope
+	var scope Scope
 	if pathContainsSegment(dirRelSlash, "testdata") {
-		scope = scanner.DirsScope(root, []string{dirRel}, matchRel, scanner.IncludeTestdata())
+		scope = DirsScope(root, []string{dirRel}, matchRel, IncludeTestdata())
 	} else {
-		scope = scanner.DirsScope(root, []string{dirRel}, matchRel)
+		scope = DirsScope(root, []string{dirRel}, matchRel)
 	}
 
 	found := false
 	var violations []string
 
-	scanner.EachFile(t, scope, 0, func(_ *testing.T, fc scanner.FileContext) {
-		f := fc.File
-		path := fc.Rel
-		_ = path
-		scanner.EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
-			if fd.Recv == nil || len(fd.Recv.List) == 0 || fd.Name == nil {
-				return
-			}
-			if fd.Name.Name != "initInternal" {
-				return
-			}
-			if scanner.ReceiverTypeName(fd.Recv.List[0].Type) != structName {
-				return
-			}
-			found = true
-			if sig := initInternalSignatureViolation(fd, structName, path); sig != "" {
-				violations = append(violations, sig)
-			}
-		})
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			path := p.Rel(file)
+			EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+				if fd.Recv == nil || len(fd.Recv.List) == 0 || fd.Name == nil {
+					return
+				}
+				if fd.Name.Name != "initInternal" {
+					return
+				}
+				if ReceiverTypeName(fd.Recv.List[0].Type) != structName {
+					return
+				}
+				found = true
+				if sig := initInternalSignatureViolation(fd, structName, path); sig != "" {
+					violations = append(violations, sig)
+				}
+			})
+		}
+		return nil
 	})
 
 	if !found && len(violations) == 0 {
@@ -1083,7 +1091,7 @@ func findGeneratedContractFilesIn(t *testing.T, roots []string) []string {
 	t.Helper()
 	var found []string
 	for _, scanRoot := range roots {
-		scope := scanner.DirsScope(scanRoot, []string{"."})
+		scope := DirsScope(scanRoot, []string{"."})
 		allFiles, err := scope.Files()
 		require.NoError(t, err, "findGeneratedContractFilesIn: scanning %s", scanRoot)
 		for _, path := range allFiles {
@@ -1110,7 +1118,7 @@ func extractSpecGenIDTopic(src string) (id, topic string, ok bool) {
 	}
 	var foundID, foundTopic string
 	found := false
-	scanner.EachInSubtree[ast.CompositeLit](f, func(cl *ast.CompositeLit) {
+	EachInSubtree[ast.CompositeLit](f, func(cl *ast.CompositeLit) {
 		if found {
 			return
 		}
@@ -1118,7 +1126,7 @@ func extractSpecGenIDTopic(src string) (id, topic string, ok bool) {
 		if !isSel || sel.Sel.Name != "ContractSpec" {
 			return
 		}
-		scanner.EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
+		EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
 			key, isIdent := kv.Key.(*ast.Ident)
 			if !isIdent {
 				return
@@ -1167,7 +1175,7 @@ func extractSpecGenIDTopic(src string) (id, topic string, ok bool) {
 // dir is a fixture root (not module root); see "Note on fixture-local DirsScope
 // usage" above.
 func findSpecGenFiles(dir string) ([]string, error) {
-	scope := scanner.DirsScope(dir, []string{"."})
+	scope := DirsScope(dir, []string{"."})
 	allFiles, err := scope.Files()
 	if err != nil {
 		return nil, err
@@ -1193,12 +1201,12 @@ func parseContractSpecFields(t *testing.T, path string) (id, topic string, ok bo
 	}
 
 	var foundID, foundTopic string
-	scanner.EachInSubtree[ast.CompositeLit](f, func(cl *ast.CompositeLit) {
+	EachInSubtree[ast.CompositeLit](f, func(cl *ast.CompositeLit) {
 		sel, ok := cl.Type.(*ast.SelectorExpr)
 		if !ok || sel.Sel.Name != "ContractSpec" {
 			return
 		}
-		scanner.EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
+		EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
 			key, ok := kv.Key.(*ast.Ident)
 			if !ok {
 				return
@@ -1269,8 +1277,8 @@ func findAllCellInitFiles(t *testing.T, root string) []string {
 	var files []string
 	for _, c := range project.Cells {
 		cellDirRel := filepath.ToSlash(filepath.Dir(c.File))
-		scope := scanner.DirsScope(root, []string{cellDirRel},
-			scanner.MatchRels(func(rel string) bool {
+		scope := DirsScope(root, []string{cellDirRel},
+			MatchRels(func(rel string) bool {
 				if filepath.ToSlash(filepath.Dir(rel)) != cellDirRel {
 					return false
 				}
@@ -1281,8 +1289,11 @@ func findAllCellInitFiles(t *testing.T, root string) []string {
 				return name == "cell.go" || strings.HasPrefix(name, "cell_")
 			}),
 		)
-		scanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc scanner.FileContext) {
-			files = append(files, fc.AbsPath)
+		Run(t, scope, func(p *Pass) []Diagnostic {
+			for _, file := range p.Files {
+				files = append(files, p.Fset.Position(file.Pos()).Filename)
+			}
+			return nil
 		})
 	}
 	sort.Strings(files)
@@ -1341,7 +1352,7 @@ func forbiddenWireCall(path string) (found string, line int, err error) {
 	if err != nil {
 		return "", 0, err
 	}
-	scanner.EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
 		if found != "" {
 			return
 		}
@@ -1371,7 +1382,7 @@ func cellGenHasRouteGroup(genPath string) bool {
 	}
 	_ = fset
 	found := false
-	scanner.EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
 		if found {
 			return
 		}

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -59,7 +59,6 @@ const FixtureBuildTag = "archtest_fixture"
 
 // Lookup is by module-relative slash path (e.g. "tools/archtest/foo_test.go").
 var LegacyAllowlist = map[string]bool{
-	"tools/archtest/accesscore_facade_test.go":                       true,
 	"tools/archtest/archtest_test.go":                                true,
 	"tools/archtest/archtest_verify_coverage_test.go":                true,
 	"tools/archtest/assembly_invariants_test.go":                     true,

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -67,7 +67,6 @@ var LegacyAllowlist = map[string]bool{
 	"tools/archtest/cell_init_test.go":                               true,
 	"tools/archtest/cell_public_option_param_test.go":                true,
 	"tools/archtest/clock_invariants_test.go":                        true,
-	"tools/archtest/codegen_invariants_test.go":                      true,
 	"tools/archtest/credential_invalidate_funnel_invariants_test.go": true,
 	"tools/archtest/errcode_invariants_test.go":                      true,
 	"tools/archtest/errcode_message_const_fixtures_test.go":          true,

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -69,7 +69,6 @@ var LegacyAllowlist = map[string]bool{
 	"tools/archtest/cell_id_pattern_single_source_test.go":           true,
 	"tools/archtest/cell_init_test.go":                               true,
 	"tools/archtest/cell_public_option_param_test.go":                true,
-	"tools/archtest/cellmeta_single_source_test.go":                  true,
 	"tools/archtest/clock_invariants_test.go":                        true,
 	"tools/archtest/codegen_invariants_test.go":                      true,
 	"tools/archtest/credential_invalidate_funnel_invariants_test.go": true,

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -66,7 +66,6 @@ var LegacyAllowlist = map[string]bool{
 	"tools/archtest/audit_ledger_composition_root_test.go":           true,
 	"tools/archtest/auditcore_appender_single_source_test.go":        true,
 	"tools/archtest/auth_bootstrap_invariants_test.go":               true,
-	"tools/archtest/cas_protocol_composition_root_test.go":           true,
 	"tools/archtest/cell_id_pattern_single_source_test.go":           true,
 	"tools/archtest/cell_init_test.go":                               true,
 	"tools/archtest/cell_public_option_param_test.go":                true,

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -63,7 +63,6 @@ var LegacyAllowlist = map[string]bool{
 	"tools/archtest/archtest_verify_coverage_test.go":                true,
 	"tools/archtest/assembly_invariants_test.go":                     true,
 	"tools/archtest/audit_ledger_composition_root_test.go":           true,
-	"tools/archtest/auditcore_appender_single_source_test.go":        true,
 	"tools/archtest/auth_bootstrap_invariants_test.go":               true,
 	"tools/archtest/cell_id_pattern_single_source_test.go":           true,
 	"tools/archtest/cell_init_test.go":                               true,

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -91,7 +91,6 @@ var LegacyAllowlist = map[string]bool{
 	"tools/archtest/outbox_invariants_test.go":                       true,
 	"tools/archtest/panic_invariants_test.go":                        true,
 	"tools/archtest/pg_repo_ambient_tx_test.go":                      true,
-	"tools/archtest/postgres_constructor_error_first_test.go":        true,
 	"tools/archtest/prod_clock_injection_fixtures_test.go":           true,
 	"tools/archtest/prod_duration_fixtures_test.go":                  true,
 	"tools/archtest/prod_invariants_test.go":                         true,

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -70,7 +70,6 @@ var LegacyAllowlist = map[string]bool{
 	"tools/archtest/cell_id_pattern_single_source_test.go":           true,
 	"tools/archtest/cell_init_test.go":                               true,
 	"tools/archtest/cell_public_option_param_test.go":                true,
-	"tools/archtest/cellgen_errcode_funnel_test.go":                  true,
 	"tools/archtest/cellmeta_single_source_test.go":                  true,
 	"tools/archtest/clock_invariants_test.go":                        true,
 	"tools/archtest/codegen_invariants_test.go":                      true,

--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -61,7 +61,6 @@ const FixtureBuildTag = "archtest_fixture"
 var LegacyAllowlist = map[string]bool{
 	"tools/archtest/archtest_test.go":                                true,
 	"tools/archtest/archtest_verify_coverage_test.go":                true,
-	"tools/archtest/assembly_invariants_test.go":                     true,
 	"tools/archtest/audit_ledger_composition_root_test.go":           true,
 	"tools/archtest/auth_bootstrap_invariants_test.go":               true,
 	"tools/archtest/cell_id_pattern_single_source_test.go":           true,

--- a/tools/archtest/postgres_constructor_error_first_test.go
+++ b/tools/archtest/postgres_constructor_error_first_test.go
@@ -34,12 +34,9 @@ func TestPGConstructorMustFree01(t *testing.T) {
 	}
 	var violations []violation
 
+	// DirsScope without IncludeTests() already excludes *_test.go files.
 	Run(t, scope, func(p *Pass) []Diagnostic {
 		for _, file := range p.Files {
-			abs := p.Fset.Position(file.Pos()).Filename
-			if strings.HasSuffix(abs, "_test.go") {
-				continue
-			}
 			EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
 				name := fd.Name.Name
 				// exported MustNew* at package level (no receiver)

--- a/tools/archtest/postgres_constructor_error_first_test.go
+++ b/tools/archtest/postgres_constructor_error_first_test.go
@@ -13,13 +13,10 @@ package archtest
 
 import (
 	"go/ast"
-	"go/parser"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 const rulePGConstructorMustFree01 = "PG-CONSTRUCTOR-MUST-FREE-01"
@@ -28,7 +25,7 @@ const rulePGConstructorMustFree01 = "PG-CONSTRUCTOR-MUST-FREE-01"
 // reports any exported MustNew* function declaration.
 func TestPGConstructorMustFree01(t *testing.T) {
 	root := findModuleRoot(t)
-	scope := scanner.DirsScope(root, []string{"adapters/postgres"})
+	scope := DirsScope(root, []string{"adapters/postgres"})
 
 	type violation struct {
 		file string
@@ -37,26 +34,30 @@ func TestPGConstructorMustFree01(t *testing.T) {
 	}
 	var violations []violation
 
-	scanner.EachFile(t, scope, parser.SkipObjectResolution|parser.ParseComments, func(t *testing.T, fc scanner.FileContext) {
-		if strings.HasSuffix(fc.AbsPath, "_test.go") {
-			return
-		}
-		scanner.EachInSubtree[ast.FuncDecl](fc.File, func(fd *ast.FuncDecl) {
-			name := fd.Name.Name
-			// exported MustNew* at package level (no receiver)
-			if fd.Recv != nil {
-				return
+	Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			abs := p.Fset.Position(file.Pos()).Filename
+			if strings.HasSuffix(abs, "_test.go") {
+				continue
 			}
-			if !strings.HasPrefix(name, "MustNew") {
-				return
-			}
-			pos := fc.Fset.Position(fd.Pos())
-			violations = append(violations, violation{
-				file: fc.Rel,
-				line: pos.Line,
-				name: name,
+			EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+				name := fd.Name.Name
+				// exported MustNew* at package level (no receiver)
+				if fd.Recv != nil {
+					return
+				}
+				if !strings.HasPrefix(name, "MustNew") {
+					return
+				}
+				pos := p.Fset.Position(fd.Pos())
+				violations = append(violations, violation{
+					file: p.Rel(file),
+					line: pos.Line,
+					name: name,
+				})
 			})
-		})
+		}
+		return nil
 	})
 
 	if len(violations) > 0 {


### PR DESCRIPTION
## Summary

PR-3 of #040 stage 2 — migrates 8 contract/codegen archtest files from `scanner.EachFile` to the Pass-Driver framework shipped in PR #492. All 8 files are pure-EachFile (zero mixed-mode), zero `.golangci.yml` change, zero new abstractions.

**Files migrated (8 / 15 EachFile call sites):**
- `tools/archtest/codegen_invariants_test.go` (4)
- `tools/archtest/assembly_invariants_test.go` (4)
- `tools/archtest/accesscore_facade_test.go` (2)
- `tools/archtest/cellgen_errcode_funnel_test.go` (1)
- `tools/archtest/cas_protocol_composition_root_test.go` (1)
- `tools/archtest/cellmeta_single_source_test.go` (1)
- `tools/archtest/postgres_constructor_error_first_test.go` (1)
- `tools/archtest/auditcore_appender_single_source_test.go` (1)

**Recipe per file** (each is the file's first + only Pass-Driver rewrite — "0 二次返工"):
1. Drop `tools/archtest/internal/scanner` import
2. `scanner.EachFile(...)` → `Run(t, scope, func(p *Pass) []Diagnostic { for _, file := range p.Files { ... } })`
3. `fc.File` → loop variable `file`, `fc.Rel` → `p.Rel(file)`, `fc.Fset` → `p.Fset`, `fc.AbsPath` → `p.Fset.Position(file.Pos()).Filename`
4. `scanner.EachInSubtree`/`EachInChildren`/`MatchRels`/`DirsScope`/`IncludeTests`/`IncludeTestdata`/`ReceiverTypeName`/`Scope`/`EachContentFile`/`ContentContext` → unqualified (test files live in package `archtest`)
5. Remove file's entry from `tools/archtest/internal/archtestmeta/legacy_allowlist.go`

**LegacyAllowlist**: 56 → 48 entries (8 removed).

**`.golangci.yml` unchanged** — none of the 8 files imported `golang.org/x/tools/go/packages` directly. `TestPassFunnelGuardListSync` three-way invariant validates this in CI.

**Pre-shipped Pass framework only** — no Pass-related framework changes; only consumers migrated.

Refs: #040, plan `docs/plans/202605141519-040-archtest-pass-funnel-plan.md` 阶段 2 PR-3
ref: golang/tools go/analysis/internal/checker/checker.go (Pass-Driver pattern source)

## Test plan
- [x] `go build ./...`
- [x] `go build -tags=integration ./...`
- [x] `go test ./tools/archtest/...` (incl. TestPassFunnelGuardListSync three-way sync)
- [x] `go test ./...` (all packages green outside sandbox)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `hack/verify-archtest.sh` (16 shards, 361 tests, all PASS)

## Out of scope (explicit)
- PR-2 / PR-4 / PR-5 (other thematic batches) — separate ship sessions
- Phase 3 LoadPackages → RunTyped (this PR is 0 mixed-mode)
- Phase 4 LegacyAllowlist deletion + scanner deep-internalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)