### PR TITLE
refactor(archtest): Pass-Driver migration — PR-2 metadata (#040 stage 2)

### DIFF
--- a/tools/archtest/internal/archtestmeta/legacy_allowlist.go
+++ b/tools/archtest/internal/archtestmeta/legacy_allowlist.go
@@ -84,8 +84,6 @@ var LegacyAllowlist = map[string]bool{
 	"tools/archtest/health_aggregation_test.go":                      true,
 	"tools/archtest/httputil_invariants_test.go":                     true,
 	"tools/archtest/identitymanage_last_admin_protection_test.go":    true,
-	"tools/archtest/inventory_anchor_required_test.go":               true,
-	"tools/archtest/kernel_metadata_no_wire_test.go":                 true,
 	"tools/archtest/kernel_poolstats_location_test.go":               true,
 	"tools/archtest/listener_dx_test.go":                             true,
 	"tools/archtest/managed_resource_contract_test.go":               true,

--- a/tools/archtest/inventory_anchor_required_test.go
+++ b/tools/archtest/inventory_anchor_required_test.go
@@ -43,7 +43,6 @@ package archtest
 
 import (
 	"go/ast"
-	"go/parser"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -51,10 +50,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 const (
@@ -75,7 +71,7 @@ var inventoryAnchorIDPattern = regexp.MustCompile(
 )
 
 // anchorRef is one parsed `// INVARIANT: <ID>` (or `// - INVARIANT: <ID>`)
-// occurrence. Line number is recovered separately via `fc.Fset.Position`
+// occurrence. Line number is recovered separately via `p.Fset.Position`
 // because the AST comment carries position via its parent group, not the
 // individual `*ast.Comment`.
 type anchorRef struct {
@@ -91,23 +87,26 @@ func TestInventoryAnchorRequired(t *testing.T) {
 	root := findModuleRoot(t)
 	scope := archtestScope(t, root)
 
-	var violators []string
-	scanner.EachFile(t, scope, parser.ParseComments|parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
-		if !isTopLevelArchtestTestFile(fc) {
-			return
+	diags := Run(t, scope, func(p *Pass) []Diagnostic {
+		var ds []Diagnostic
+		for _, file := range p.Files {
+			if !isTopLevelArchtestTestFileByPath(p.Rel(file), p.Abs(file)) {
+				continue
+			}
+			if !hasValidInventoryAnchorInHeader(file) {
+				ds = append(ds, Diagnostic{
+					Rel:     filepath.Base(p.Rel(file)),
+					Line:    1,
+					Message: "missing or malformed `// INVARIANT: <ID>` in file-header CommentGroup",
+				})
+			}
 		}
-		if !hasValidInventoryAnchorInHeader(fc.File) {
-			violators = append(violators, filepath.Base(fc.Rel))
-		}
+		return ds
 	})
 
-	sort.Strings(violators)
-	assert.Emptyf(t, violators,
-		"%s: every tools/archtest/*_test.go must declare at least one valid "+
-			"`// INVARIANT: <ID>` line in its file-header CommentGroup "+
-			"(the first ast.CommentGroup, regardless of position relative to "+
-			"the package clause). Missing or malformed in:\n  %s",
-		inventoryAnchorRequiredRule, strings.Join(violators, "\n  "))
+	// Sort by Rel for stable output before reporting.
+	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	Report(t, inventoryAnchorRequiredRule, diags)
 }
 
 // TestInventoryAnchorValidID enforces canonical grammar across all anchors —
@@ -122,61 +121,42 @@ func TestInventoryAnchorValidID(t *testing.T) {
 	root := findModuleRoot(t)
 	scope := archtestScope(t, root)
 
-	type violation struct {
-		file  string
-		line  int
-		token string
-	}
-	var violations []violation
-	scanner.EachFile(t, scope, parser.ParseComments|parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
-		if !isTopLevelArchtestTestFile(fc) {
-			return
-		}
-		for _, group := range fc.File.Comments {
-			for _, c := range group.List {
-				ref, ok := parseInventoryAnchor(c.Text)
-				if !ok {
-					continue
-				}
-				if !inventoryAnchorIDPattern.MatchString(ref.id) {
-					line := fc.Fset.Position(c.Pos()).Line
-					violations = append(violations, violation{
-						file:  filepath.Base(fc.Rel),
-						line:  line,
-						token: ref.id,
-					})
+	diags := Run(t, scope, func(p *Pass) []Diagnostic {
+		var ds []Diagnostic
+		for _, file := range p.Files {
+			if !isTopLevelArchtestTestFileByPath(p.Rel(file), p.Abs(file)) {
+				continue
+			}
+			for _, group := range file.Comments {
+				for _, c := range group.List {
+					ref, ok := parseInventoryAnchor(c.Text)
+					if !ok {
+						continue
+					}
+					if !inventoryAnchorIDPattern.MatchString(ref.id) {
+						line := p.Fset.Position(c.Pos()).Line
+						ds = append(ds, Diagnostic{
+							Rel:     filepath.Base(p.Rel(file)),
+							Line:    line,
+							Message: "non-canonical INVARIANT anchor " + ref.id + "; must match grammar " + inventoryAnchorIDPattern.String(),
+						})
+					}
 				}
 			}
 		}
+		return ds
 	})
-
-	sort.Slice(violations, func(i, j int) bool {
-		if violations[i].file != violations[j].file {
-			return violations[i].file < violations[j].file
-		}
-		return violations[i].line < violations[j].line
-	})
-
-	if len(violations) == 0 {
-		return
-	}
-	lines := make([]string, len(violations))
-	for i, v := range violations {
-		lines[i] = v.file + ":" + intToStr(v.line) + ": " + v.token
-	}
-	assert.Failf(t, "non-canonical INVARIANT anchor",
-		"%s: every `// INVARIANT: <ID>` line must match grammar %s. "+
-			"Offending tokens:\n  %s",
-		inventoryAnchorValidIDRule, inventoryAnchorIDPattern, strings.Join(lines, "\n  "))
+	Report(t, inventoryAnchorValidIDRule, diags)
 }
 
-// isTopLevelArchtestTestFile reports whether fc points at a tools/archtest/<name>_test.go
-// file directly (subpackages under tools/archtest/internal/ are out of scope).
-func isTopLevelArchtestTestFile(fc scanner.FileContext) bool {
-	if filepath.ToSlash(filepath.Dir(fc.Rel)) != "tools/archtest" {
+// isTopLevelArchtestTestFileByPath reports whether the given rel/abs paths
+// point at a tools/archtest/<name>_test.go file directly (subpackages under
+// tools/archtest/internal/ are out of scope).
+func isTopLevelArchtestTestFileByPath(rel, absPath string) bool {
+	if filepath.ToSlash(filepath.Dir(rel)) != "tools/archtest" {
 		return false
 	}
-	return strings.HasSuffix(fc.AbsPath, "_test.go")
+	return strings.HasSuffix(absPath, "_test.go")
 }
 
 // archtestScope returns a Scope over tools/archtest/ that **matches the
@@ -190,12 +170,12 @@ func isTopLevelArchtestTestFile(fc scanner.FileContext) bool {
 // builds a string set of slash-paths, and feeds it to `MatchRels`. Local
 // editor swap files (`.foo_test.go.swp`) and other untracked artifacts are
 // silently skipped, matching the script's behavior.
-func archtestScope(t *testing.T, root string) scanner.Scope {
+func archtestScope(t *testing.T, root string) Scope {
 	t.Helper()
 	tracked := loadGitTrackedSet(t, root)
-	return scanner.DirsScope(root, []string{"tools/archtest"},
-		scanner.IncludeTests(),
-		scanner.MatchRels(func(rel string) bool {
+	return DirsScope(root, []string{"tools/archtest"},
+		IncludeTests(),
+		MatchRels(func(rel string) bool {
 			return tracked[filepath.ToSlash(rel)]
 		}),
 	)
@@ -272,28 +252,4 @@ func parseInventoryAnchor(commentText string) (anchorRef, bool) {
 	}
 	tok = strings.TrimSuffix(tok, ":")
 	return anchorRef{id: tok}, true
-}
-
-// intToStr is a tiny helper for diagnostic line numbers; avoids importing fmt
-// for a single Sprintf("%d") call.
-func intToStr(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var buf [20]byte
-	pos := len(buf)
-	negative := n < 0
-	if negative {
-		n = -n
-	}
-	for n > 0 {
-		pos--
-		buf[pos] = byte('0' + n%10)
-		n /= 10
-	}
-	if negative {
-		pos--
-		buf[pos] = '-'
-	}
-	return string(buf[pos:])
 }

--- a/tools/archtest/kernel_metadata_no_wire_test.go
+++ b/tools/archtest/kernel_metadata_no_wire_test.go
@@ -17,13 +17,8 @@ package archtest
 
 import (
 	"go/ast"
-	"go/parser"
 	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 const ruleKernelMetadataNoWire = "KERNEL-METADATA-NO-WIRE-01"
@@ -52,73 +47,57 @@ var kernelMetadataWireSymbols = map[string]bool{
 	// defines contractspec.ContractSpec (a different type entirely).
 }
 
-type wireViolation struct {
-	File   string
-	Line   int
-	Symbol string
-}
-
 // TestKernelMetadataDoesNotContainWireSymbols enforces KERNEL-METADATA-NO-WIRE-01.
 // It parses all non-test .go files in kernel/metadata/ and fails if any of the
 // forbidden wire-format top-level declaration names are found.
 func TestKernelMetadataDoesNotContainWireSymbols(t *testing.T) {
+	t.Parallel()
 	root := findModuleRoot(t)
-	scope := scanner.DirsScope(root, []string{"kernel/metadata"},
-		scanner.MatchRels(func(rel string) bool {
+	scope := DirsScope(root, []string{"kernel/metadata"},
+		MatchRels(func(rel string) bool {
 			// Single-dir semantics: only files directly under kernel/metadata,
 			// no sub-packages.
 			return filepath.ToSlash(filepath.Dir(rel)) == "kernel/metadata"
 		}),
 	)
 
-	var violations []wireViolation
-
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(_ *testing.T, fc scanner.FileContext) {
-		f := fc.File
-		rel := fc.Rel
-
-		scanner.EachInChildren[ast.FuncDecl](f, func(d *ast.FuncDecl) {
-			if kernelMetadataWireSymbols[d.Name.Name] {
-				violations = append(violations, wireViolation{
-					File:   rel,
-					Line:   fc.Fset.Position(d.Pos()).Line,
-					Symbol: d.Name.Name,
-				})
-			}
-		})
-		scanner.EachInChildren[ast.GenDecl](f, func(d *ast.GenDecl) {
-			scanner.EachInChildren[ast.TypeSpec](d, func(s *ast.TypeSpec) {
-				if kernelMetadataWireSymbols[s.Name.Name] {
-					violations = append(violations, wireViolation{
-						File:   rel,
-						Line:   fc.Fset.Position(s.Pos()).Line,
-						Symbol: s.Name.Name,
+	diags := Run(t, scope, func(p *Pass) []Diagnostic {
+		var ds []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInChildren[ast.FuncDecl](file, func(d *ast.FuncDecl) {
+				if kernelMetadataWireSymbols[d.Name.Name] {
+					ds = append(ds, Diagnostic{
+						Rel:     rel,
+						Line:    p.Fset.Position(d.Pos()).Line,
+						Message: "wire-format symbol " + d.Name.Name + " must not be declared in kernel/metadata; move to runtime/devtools/catalog/",
 					})
 				}
 			})
-			scanner.EachInChildren[ast.ValueSpec](d, func(s *ast.ValueSpec) {
-				for _, ident := range s.Names {
-					if kernelMetadataWireSymbols[ident.Name] {
-						violations = append(violations, wireViolation{
-							File:   rel,
-							Line:   fc.Fset.Position(ident.Pos()).Line,
-							Symbol: ident.Name,
+			EachInChildren[ast.GenDecl](file, func(d *ast.GenDecl) {
+				EachInChildren[ast.TypeSpec](d, func(s *ast.TypeSpec) {
+					if kernelMetadataWireSymbols[s.Name.Name] {
+						ds = append(ds, Diagnostic{
+							Rel:     rel,
+							Line:    p.Fset.Position(s.Pos()).Line,
+							Message: "wire-format symbol " + s.Name.Name + " must not be declared in kernel/metadata; move to runtime/devtools/catalog/",
 						})
 					}
-				}
+				})
+				EachInChildren[ast.ValueSpec](d, func(s *ast.ValueSpec) {
+					for _, ident := range s.Names {
+						if kernelMetadataWireSymbols[ident.Name] {
+							ds = append(ds, Diagnostic{
+								Rel:     rel,
+								Line:    p.Fset.Position(ident.Pos()).Line,
+								Message: "wire-format symbol " + ident.Name + " must not be declared in kernel/metadata; move to runtime/devtools/catalog/",
+							})
+						}
+					}
+				})
 			})
-		})
-	})
-
-	if len(violations) > 0 {
-		t.Logf("%s: found %d wire-symbol declaration(s) in kernel/metadata/:",
-			ruleKernelMetadataNoWire, len(violations))
-		for _, v := range violations {
-			t.Logf("  %s:%d  symbol: %s", v.File, v.Line, v.Symbol)
 		}
-	}
-
-	assert.Empty(t, violations,
-		"%s: kernel/metadata must not declare wire-format symbols; "+
-			"move them to runtime/devtools/catalog/", ruleKernelMetadataNoWire)
+		return ds
+	})
+	Report(t, ruleKernelMetadataNoWire, diags)
 }


### PR DESCRIPTION
## Summary

#040 Stage 2 PR-2（metadata 主题）。把 2 个 A 类 archtest 从 `scanner.EachFile` 迁移到 `archtest.Run` Pass-Driver 范式，Rule 返回 `[]Diagnostic` + `archtest.Report`（对齐 plan 阶段 1.5「后续迁移强制约定」），并从 `legacy_allowlist.go` 删除对应两项使其纳入 PASS-FUNNEL-EACHFILE-01 强制 enforcement。

- `tools/archtest/kernel_metadata_no_wire_test.go`：EachFile→Run，inline append+assert.Empty→Diagnostic+Report
- `tools/archtest/inventory_anchor_required_test.go`：2 处 EachFile→Run，archtestScope(git ls-files) 保留，assert.*→Diagnostic+Report
- `tools/archtest/internal/archtestmeta/legacy_allowlist.go`：删 2 项

无 `.golangci.yml` 改动（两文件不直接 import golang.org/x/tools/go/packages）。

Refs: #040
ref: golang.org/x/tools go/analysis (Pass-Driver)

## Test plan

- [x] go build ./... + go build -tags=integration ./...
- [x] go test ./tools/archtest/...（全套 PASS，含 TestPassFunnelEachFile01 脱 allowlist 后强制回归）
- [x] golangci-lint 0 issues

## Contract fanout

Contract: archtest 元治理（无生产契约/schema/DB 变更）
Change: scanner.EachFile → archtest.Run 入口迁移，行为零变化
Dependent contracts (governance scan): none

🤖 Generated with [Claude Code](https://claude.com/claude-code)