### PR TITLE
fix(repo): rm stray root gocell binary + gitignore re-add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .venv/
 bin/
 dist/
+/gocell
 /ssobff
 
 # Test


### PR DESCRIPTION
## Summary

- 删除 PR #502 (commit `d5f8661a`) 误提交的根目录 18MB `gocell` 二进制
- `.gitignore` 增 `/gocell` 兜底，防止再次 `go build ./cmd/gocell` 在仓库根直接 `git add` 进版本库（与现有 `/ssobff` 同形态）

## 背景

构建管线本来就把 CLI 输出到 `bin/`：
- `Makefile:25` `go build -tags=catalog_gen -o bin/ ./cmd/... ./examples/...`
- `.gitignore:8` 忽略 `bin/`

PR #502 作者在 repo root 直接跑了 `go build ./cmd/gocell`（默认产物名 = 包目录名 `gocell`，输出到当前目录），随后误 `git add gocell` 并随业务变更一起 push。`.gitignore` 缺 `/gocell` 行没拦下来。

## Test plan

- [x] `git rm gocell` 后仓库工作树不再包含该二进制
- [x] `.gitignore` 新增 `/gocell` 行，与既有 `/ssobff` 并列
- [ ] CI 通过（build / lint / archtest）

🤖 Generated with [Claude Code](https://claude.com/claude-code)