### PR TITLE
refactor(slowgate): raise default threshold 15s → 20s

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -171,7 +171,7 @@ jobs:
       # it by default, and without it a non-zero `go test` exit code would
       # be masked by `tee`/`slowgate` success. Do not remove this line.
       #
-      # `--threshold=15s` matches `defaultThreshold` in tools/slowgate/main.go;
+      # `--threshold=20s` matches `defaultThreshold` in tools/slowgate/main.go;
       # the literal is duplicated to keep the workflow self-documenting at
       # the call site. Calibrated for GHA ubuntu-latest 2-CPU runners where
       # packages.Load-bound tests run 5–15× slower than developer laptops.
@@ -195,7 +195,7 @@ jobs:
             $PKGS \
             -count=1 -timeout 5m \
             | tee "$RUNNER_TEMP/test-${{ matrix.shard }}.json" \
-            | "$RUNNER_TEMP/slowgate" --threshold=15s --allowlist=tools/slowgate/allowlist.txt
+            | "$RUNNER_TEMP/slowgate" --threshold=20s --allowlist=tools/slowgate/allowlist.txt
 
       # Upload the raw `go test -json` event stream only on Test step
       # failure. Restored as a P1 review fix: without it, a non-slowgate
@@ -306,7 +306,7 @@ jobs:
           SHARD_TARGET: ${{ matrix.shard }}
           TIMEOUT: 5m
           SLOWGATE_BIN: ${{ runner.temp }}/slowgate
-          SLOWGATE_THRESHOLD: 15s
+          SLOWGATE_THRESHOLD: 20s
           SLOWGATE_ALLOWLIST: tools/slowgate/allowlist.txt
         run: bash hack/verify-archtest.sh
 

--- a/cells/auditcore/cell_test.go
+++ b/cells/auditcore/cell_test.go
@@ -552,7 +552,7 @@ func TestAuditCore_HealthCheckers_WithDirectEmitter(t *testing.T) {
 // supplied a context with a deadline (strictTailVerifyOnStartup must wrap ctx
 // with WithTimeout). It does NOT actually wait for the deadline to fire —
 // it returns ctx.DeadlineExceeded immediately so the test runs in milliseconds
-// rather than paying 30 s of wall-clock cost (slowgate cap 15 s).
+// rather than paying 30 s of wall-clock cost (slowgate cap 20 s).
 type deadlineProbeStore struct {
 	ledger.Store
 	gotDeadline bool
@@ -581,7 +581,7 @@ func (b *deadlineProbeStore) Verify(ctx context.Context, from, to int64) (bool, 
 // wraps the caller context with a deadline before calling ledger.Store.Verify,
 // so a hung store cannot stall k8s readiness indefinitely.
 //
-// F-04: rather than block on the production 30 s timeout (slowgate cap 15 s),
+// F-04: rather than block on the production 30 s timeout (slowgate cap 20 s),
 // the probe store inspects ctx.Deadline() at call time and returns
 // DeadlineExceeded immediately — testing the deadline-injection contract
 // without paying wall-clock cost.

--- a/hack/verify-archtest.sh
+++ b/hack/verify-archtest.sh
@@ -46,7 +46,7 @@ readonly ARCHTEST_PKG="./tools/archtest"
 readonly SHARD_COUNT="${SHARD_COUNT:-16}"
 readonly TIMEOUT="${TIMEOUT:-5m}"
 readonly SLOWGATE_BIN="${SLOWGATE_BIN:-}"
-readonly SLOWGATE_THRESHOLD="${SLOWGATE_THRESHOLD:-15s}"
+readonly SLOWGATE_THRESHOLD="${SLOWGATE_THRESHOLD:-20s}"
 readonly SLOWGATE_ALLOWLIST="${SLOWGATE_ALLOWLIST:-tools/slowgate/allowlist.txt}"
 
 # Validate SHARD_COUNT before doing any work.

--- a/tools/slowgate/allowlist.txt
+++ b/tools/slowgate/allowlist.txt
@@ -1,4 +1,4 @@
-# slowgate allowlist — tests permitted to exceed the default 15s budget.
+# slowgate allowlist — tests permitted to exceed the default 20s budget.
 #
 # Format: each data line is `Package<TAB>TestName`. Every data line MUST
 # be preceded by a `# <reason>` comment explaining why the wall-clock cost
@@ -7,13 +7,13 @@
 # top-level test func. Independent table-driven negative cases for the
 # parser live in TestLoadSlowgateAllowlist_ParseRules (same file).
 #
-# Threshold rationale (15s, see tools/slowgate/main.go defaultThreshold):
+# Threshold rationale (20s, see tools/slowgate/main.go defaultThreshold):
 # packages.Load-bound and subprocess-go-toolchain tests run 5–15× slower
 # on GHA ubuntu-latest 2-CPU runners than on developer laptops. 2s and 5s
 # thresholds both produced perpetual allowlist churn driven by hardware
-# mismatch, not real regression. 15s lets the slow-by-design population
+# mismatch, not real regression. 20s lets the slow-by-design population
 # pass while still catching meaningful regressions (a 100ms sleep drifting
-# to 16s+ still fires).
+# to 21s+ still fires).
 #
 # Adding entries: only when CI has empirically failed the gate. The
 # failing slowgate step prints `SLOW <Package> <TestName> <Elapsed>` lines

--- a/tools/slowgate/main.go
+++ b/tools/slowgate/main.go
@@ -61,19 +61,19 @@ const (
 	// value is shown instead so the message stays accurate.
 	defaultAllowlistPath = "tools/slowgate/allowlist.txt"
 
-	// defaultThreshold is the default per-test wall-clock budget. 15s is
+	// defaultThreshold is the default per-test wall-clock budget. 20s is
 	// calibrated for GHA ubuntu-latest runner hardware: packages.Load-bound
 	// tests (archtest / typeseval / metricschema / generatedverify) and
 	// subprocess-go-toolchain tests (kernel/verify) run 5–15× slower on
 	// CI's 2-CPU shared runners than on a developer laptop, so locally
 	// "fast" 2–7s tests routinely show 5–43s on CI. 2s and 5s thresholds
 	// both produced perpetual allowlist churn from this hardware mismatch;
-	// 15s preserves real signal (a sleep regression from 100ms to 16s+ is
+	// 20s preserves real signal (a sleep regression from 100ms to 21s+ is
 	// still caught) while letting the slow-by-design population pass
-	// without per-PR allowlist edits. A handful of tests genuinely > 15s
+	// without per-PR allowlist edits. A handful of tests genuinely > 20s
 	// (large packages.Load scans, subprocess go invocations, long YAML
 	// fixtures) live in tools/slowgate/allowlist.txt.
-	defaultThreshold = 15 * time.Second
+	defaultThreshold = 20 * time.Second
 )
 
 func main() {


### PR DESCRIPTION
## Summary

将 slowgate 默认 wall-clock 预算从 **15s → 20s**，给 GHA ubuntu-latest 2-CPU runner 上的 `packages.Load`-bound archtest 扫描类测试 ~5s headroom，降低硬件方差驱动的 allowlist churn，同时保留显著回归信号（100ms sleep 漂到 21s+ 仍能被捕获）。

触发证据：PR #504 在 verify-archtest shard 14 上观测到 `TestCredentialInvalidateFunnel_BumpAuthzEpoch_01` 走到 15.94s——刚好越过 15s 预算。提高到 20s 让这类临界 type-graph-load 测试在不进入 allowlist 的前提下通过。

## 改动范围

四处生效点 + 三处注释，全部同步：

| 位置 | 类型 | 改动 |
|------|------|------|
| `tools/slowgate/main.go` `defaultThreshold` | 生效值 | `15 * time.Second` → `20 * time.Second` |
| `tools/slowgate/main.go` godoc rationale | 注释 | 15s → 20s（"a sleep regression from 100ms to 21s+ is still caught"） |
| `tools/slowgate/allowlist.txt` 头行 | 注释 | "default 15s budget" → "default 20s budget" |
| `tools/slowgate/allowlist.txt` rationale 段 | 注释 | "16s+ still fires" → "21s+ still fires" |
| `hack/verify-archtest.sh` `SLOWGATE_THRESHOLD` 默认值 | 生效值 | `15s` → `20s` |
| `.github/workflows/_build-lint.yml` build-test `--threshold` flag | 生效值 | `--threshold=15s` → `--threshold=20s` |
| `.github/workflows/_build-lint.yml` build-test self-documenting 注释 | 注释 | `` `--threshold=15s` matches `` → `` `--threshold=20s` matches `` |
| `.github/workflows/_build-lint.yml` verify-archtest `SLOWGATE_THRESHOLD` env | 生效值 | `15s` → `20s` |

> `tools/slowgate/allowlist.txt:113` 的 PR #504 incident-record 注释保留 verbatim（`15.94s > 15s budget`），它记录的是历史观测时刻，不该 back-edit 篡改历史。

> `tools/slowgate/main_test.go` 的 `testThreshold = 2 * time.Second` 与生效默认值解耦（fixture-only），无需改动。

ref: tools/slowgate/main.go defaultThreshold

## Test plan

- [x] `go build ./...`（worktree 全量）
- [x] `go test ./tools/slowgate/... -count=1`
- [x] `go test -run TestSlowgateAllowlist ./tools/archtest/... -count=1`
- [x] `golangci-lint run ./tools/slowgate/...` → 0 issues
- [x] Smoke: `go test -json ./tools/slowgate/... | slowgate --threshold=20s --allowlist=tools/slowgate/allowlist.txt` exit=0
- [ ] CI build-test 矩阵全绿（包括 archtest 16-shard）