### PR TITLE
fix(accesscore,errcode,postgres): FU-2 PR #501 review followup — errcode split + migration idempotency + params reorder

### DIFF
--- a/adapters/postgres/migrations/028_authz_epoch_positive_constraints.sql
+++ b/adapters/postgres/migrations/028_authz_epoch_positive_constraints.sql
@@ -70,6 +70,9 @@ BEGIN
     END IF;
 END $$;
 -- +goose StatementEnd
+-- lock_timeout is set AFTER the GUC gate by design: the fail-closed path
+-- (RAISE EXCEPTION above) does not reach any DDL, so a timeout is only
+-- needed once we know the rollback is authorized.
 SET LOCAL lock_timeout = '5s';
 ALTER TABLE users DROP CONSTRAINT IF EXISTS users_authz_epoch_positive;
 ALTER TABLE users ALTER COLUMN authz_epoch SET DEFAULT 0;

--- a/adapters/postgres/migrations/028_authz_epoch_positive_constraints.sql
+++ b/adapters/postgres/migrations/028_authz_epoch_positive_constraints.sql
@@ -32,6 +32,14 @@
 -- constraint name in expectedChecks (verifyChecks path). Both this migration
 -- and schema_guard.expectedChecks are authoritative — they must remain in sync.
 --
+-- Idempotency note (FU-2 R1, 2026-05-16): the Up section is structured as
+-- "DROP CONSTRAINT IF EXISTS; ADD CONSTRAINT" so the migration can be safely
+-- re-run by operators in manual recovery scenarios (e.g. partial apply, replay
+-- on staging). PostgreSQL does not support "ADD CONSTRAINT IF NOT EXISTS"
+-- directly; the DROP+ADD idiom is the canonical equivalent (cf. migration 023
+-- Down section). Constraint names are unchanged, so schema_guard.expectedChecks
+-- stays in sync without modification.
+--
 -- ref: ADR docs/architecture/202605101400-adr-credential-session-protocol.md §A8
 
 -- +goose Up
@@ -39,14 +47,17 @@ SET LOCAL lock_timeout = '5s';
 
 -- users.authz_epoch
 ALTER TABLE users ALTER COLUMN authz_epoch DROP DEFAULT;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_authz_epoch_positive;
 ALTER TABLE users ADD CONSTRAINT users_authz_epoch_positive CHECK (authz_epoch > 0);
 
 -- sessions.authz_epoch_at_issue
 ALTER TABLE sessions ALTER COLUMN authz_epoch_at_issue DROP DEFAULT;
+ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_authz_epoch_at_issue_positive;
 ALTER TABLE sessions ADD CONSTRAINT sessions_authz_epoch_at_issue_positive CHECK (authz_epoch_at_issue > 0);
 
 -- refresh_tokens.authz_epoch_at_issue
 ALTER TABLE refresh_tokens ALTER COLUMN authz_epoch_at_issue DROP DEFAULT;
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS refresh_tokens_authz_epoch_at_issue_positive;
 ALTER TABLE refresh_tokens ADD CONSTRAINT refresh_tokens_authz_epoch_at_issue_positive CHECK (authz_epoch_at_issue > 0);
 
 -- +goose Down

--- a/cells/accesscore/internal/domain/user.go
+++ b/cells/accesscore/internal/domain/user.go
@@ -164,11 +164,12 @@ func NewUser(username, email, passwordHash string, now time.Time) (*User, error)
 // Using a params struct avoids the 11-positional-argument footgun and allows
 // callers to name each field explicitly.
 //
-// Field order: identity / credentials / lifecycle metadata first, then the
-// three authz-controlled fields grouped at the end. The authz subgroup
-// (Status / PasswordResetRequired / AuthzEpoch) mirrors User's private field
-// order (status → passwordResetRequired → authzEpoch) so that the storage
-// boundary and the aggregate read in the same direction.
+// Field order: identity + credentials + lifecycle timestamps first
+// (ID, Username, Email, PasswordHash, PasswordVersion, Source, CreatedAt,
+// UpdatedAt), then the three authz-controlled fields grouped at the end
+// (Status, PasswordResetRequired, AuthzEpoch). The authz subgroup mirrors
+// User's private field order (status → passwordResetRequired → authzEpoch)
+// so the storage boundary and the aggregate read in the same direction.
 type ReconstituteUserParams struct {
 	ID              string
 	Username        string

--- a/cells/accesscore/internal/domain/user.go
+++ b/cells/accesscore/internal/domain/user.go
@@ -163,18 +163,28 @@ func NewUser(username, email, passwordHash string, now time.Time) (*User, error)
 // ReconstituteUserParams holds all fields required by ReconstituteUser.
 // Using a params struct avoids the 11-positional-argument footgun and allows
 // callers to name each field explicitly.
+//
+// Field order: identity / credentials / lifecycle metadata first, then the
+// three authz-controlled fields grouped at the end. The authz subgroup
+// (Status / PasswordResetRequired / AuthzEpoch) mirrors User's private field
+// order (status → passwordResetRequired → authzEpoch) so that the storage
+// boundary and the aggregate read in the same direction.
 type ReconstituteUserParams struct {
-	ID                    string
-	Username              string
-	Email                 string
-	PasswordHash          string
-	PasswordVersion       int64
-	PasswordResetRequired bool
+	ID              string
+	Username        string
+	Email           string
+	PasswordHash    string
+	PasswordVersion int64
+	Source          UserSource
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+
+	// Authz-controlled fields. Mutating these on a live User must go through
+	// the authzmutate funnel; ReconstituteUser is the storage-boundary
+	// rehydration path and is allowlisted for direct assignment.
 	Status                UserStatus
-	Source                UserSource
+	PasswordResetRequired bool
 	AuthzEpoch            int64
-	CreatedAt             time.Time
-	UpdatedAt             time.Time
 }
 
 // ReconstituteUser is the DDD rehydration constructor for the persistence
@@ -213,16 +223,17 @@ func ReconstituteUser(p ReconstituteUserParams) (*User, error) {
 			"ReconstituteUser: authzEpoch must be > 0")
 	}
 	return &User{
-		ID:                    p.ID,
-		Username:              p.Username,
-		Email:                 p.Email,
-		PasswordHash:          p.PasswordHash,
-		PasswordVersion:       p.PasswordVersion,
-		passwordResetRequired: p.PasswordResetRequired,
+		ID:              p.ID,
+		Username:        p.Username,
+		Email:           p.Email,
+		PasswordHash:    p.PasswordHash,
+		PasswordVersion: p.PasswordVersion,
+		CreationSource:  p.Source,
+		CreatedAt:       p.CreatedAt,
+		UpdatedAt:       p.UpdatedAt,
+
 		status:                p.Status,
-		CreationSource:        p.Source,
+		passwordResetRequired: p.PasswordResetRequired,
 		authzEpoch:            p.AuthzEpoch,
-		CreatedAt:             p.CreatedAt,
-		UpdatedAt:             p.UpdatedAt,
 	}, nil
 }

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -329,5 +329,5 @@ func TestChangePassword_RejectsBadOldPassword(t *testing.T) {
 	f.mux.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Contains(t, w.Body.String(), string(errcode.ErrAuthLoginFailed))
+	assert.Contains(t, w.Body.String(), string(errcode.ErrAuthOldPasswordIncorrect))
 }

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -861,7 +861,7 @@ func (s *Service) changePasswordInTx(txCtx context.Context, input ChangePassword
 
 	// Step 3: Verify old password (expensive — inside tx by design, see ChangePassword godoc).
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(input.OldPassword)); err != nil {
-		return "", errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthLoginFailed, "old password incorrect")
+		return "", errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthOldPasswordIncorrect, "old password incorrect")
 	}
 
 	newHash, err := bcrypt.GenerateFromPassword([]byte(input.NewPassword), domain.BcryptCost)

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -902,8 +902,8 @@ func TestChangePassword_ConcurrentRequests_ExactlyOneSucceeds(t *testing.T) {
 	// CAS semantics: exactly one goroutine must succeed and the other must
 	// receive ErrVersionConflict. Any loginFailure indicates a test defect
 	// (unexpected error classification — the race path should always resolve
-	// to ErrVersionConflict, not ErrAuthLoginFailed, when reads are interleaved
-	// after the CAS guard is in place).
+	// to ErrVersionConflict, not ErrAuthOldPasswordIncorrect, when reads are
+	// interleaved after the CAS guard is in place).
 	if loginFailures > 0 {
 		t.Fatalf("unexpected loginFailure(s) in concurrent ChangePassword test: successes=%d versionConflicts=%d loginFailures=%d",
 			successes, versionConflicts, loginFailures)

--- a/contracts/http/auth/user/change-password/v1/contract.yaml
+++ b/contracts/http/auth/user/change-password/v1/contract.yaml
@@ -25,7 +25,7 @@ endpoints:
         description: "Bad request — path parameter id is not a valid UUID (ERR_VALIDATION_INVALID_UUID), request body decode failure, or new password equals old password"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       401:
-        description: "Unauthorized — missing or invalid bearer token, or old password incorrect (ErrAuthLoginFailed)"
+        description: "Unauthorized — missing or invalid bearer token, or old password incorrect (ErrAuthOldPasswordIncorrect)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
         description: "Forbidden — authenticated subject is neither self nor admin"

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -122,6 +122,15 @@ const (
 	ErrAuthIdentityInvalidInput Code = "ERR_AUTH_IDENTITY_INVALID_INPUT"
 	ErrAuthLoginInvalidInput    Code = "ERR_AUTH_LOGIN_INVALID_INPUT"
 	ErrAuthLoginFailed          Code = "ERR_AUTH_LOGIN_FAILED"
+	// ErrAuthOldPasswordIncorrect signals the supplied old password did not
+	// match the stored credential during a ChangePassword flow. Distinct from
+	// ErrAuthLoginFailed: login paths collapse missing-user / wrong-password /
+	// inactive-account into a single opaque 401 to prevent enumeration of
+	// account state; the ChangePassword caller is an already-authenticated
+	// subject mutating their own credential, so the precise reason
+	// ("old password incorrect") is safe to surface and useful for UX. Both
+	// codes map to KindUnauthenticated → HTTP 401.
+	ErrAuthOldPasswordIncorrect Code = "ERR_AUTH_OLD_PASSWORD_INCORRECT"
 	ErrAuthLogoutInvalidInput   Code = "ERR_AUTH_LOGOUT_INVALID_INPUT"
 	ErrAuthLogoutUnavailable    Code = "ERR_AUTH_LOGOUT_UNAVAILABLE"
 	ErrAuthRefreshInvalidInput  Code = "ERR_AUTH_REFRESH_INVALID_INPUT"


### PR DESCRIPTION
## Summary

S4-FU **FU-2** review-closure batch from PR #501 review, three small in-scope changes (no scope churn):

- **F-001 (Cx2)** — `changePasswordInTx` returns new `ErrAuthOldPasswordIncorrect` instead of the opaque login-path `ErrAuthLoginFailed`. ChangePassword caller is already authenticated mutating their own credential, so the precise reason is safe to surface. Login paths still collapse missing-user/wrong-password/inactive into the opaque 401 for enumeration defense — 10 sessionlogin callsites unchanged.
- **R1 (Cx1)** — migration 028 `+goose Up` made idempotent via `DROP CONSTRAINT IF EXISTS; ADD CONSTRAINT` (canonical PG idiom; same as migration 023 Down section). Manual-rerun robustness. No production deploys + tables provably empty + 028 already amended twice post-merge ⇒ in-place edit is safe and aligned with plan §FU-2 R1 authorization.
- **F-008 (Cx1)** — `ReconstituteUserParams` field reorder: authz-subgroup (Status / PasswordResetRequired / AuthzEpoch) grouped at the end, mirroring `User` private field order. All production callers (4 sites across mem/postgres user_repo) + every test caller (8 files across cells/accesscore + integration) use named-field struct literals ⇒ binary-compatible reorder.

Total diff: 42 insertions / 20 deletions across 4 files (Wave 2) + 12 insertions / 3 deletions across 3 files (Wave 1 RED) + 6 insertions / 5 deletions across 1 file (Review #6 godoc nit) = 8 files / ~58 net changes.

## Wave order (TDD strict red→green)

- **Wave 1 RED** (`test(accesscore,errcode): RED — ChangePassword old-password errcode dedicated`): declares `ErrAuthOldPasswordIncorrect` const + flips the e2e assertion. The test FAILS against unchanged production. Confirms the assertion design before the fix lands.
- **Wave 2 GREEN** (`fix(accesscore,postgres,domain): FU-2 GREEN — errcode split + migration idempotency + ReconstituteUserParams reorder`): the three Cx-graded fixes that flip the assertion green and close FU-2.
- **Review #6 nit** (`docs(domain): clarify ReconstituteUserParams godoc field grouping`): godoc wording precision after reviewer feedback (no code change).

## Implementation matrix (contract-fanout.md trigger: new errcode Sentinel)

```
Contract: errcode sentinel + change-password v1 HTTP contract
Change: add ErrAuthOldPasswordIncorrect; switch identitymanage callsite +
  contract description; F-008 is a struct field reorder (no contract impact)
Implementations: not applicable — sentinel is a Code const, no interface
  with multiple implementations
  - errcode declaration:           pkg/errcode/errcode.go            ✓
  - service callsite:              identitymanage/service.go         ✓
  - contract description:          contracts/.../change-password/    ✓
  - integration test assertion:    changepassword_e2e_test.go        ✓
  - test comment reference:        identitymanage/service_test.go    ✓
Conformance test: TestChangePassword_RejectsBadOldPassword (integration tag)
Repro: go test -tags=integration ./cells/accesscore/slices/identitymanage/...
  -run TestChangePassword_RejectsBadOldPassword
Dependent contracts (governance scan): none — ErrAuthOldPasswordIncorrect is
  emitted only from identitymanage changePasswordInTx; no other contracts
  reference ErrAuthLoginFailed for old-password rejection
```

## Self-audit (彻底 / 不向后兼容 / 优雅简洁 / AI-HARD)

- **彻底**: F-001 唯一 production callsite (`service.go:864`) 全覆盖；test 断言 + test 注释引用同步；contract description 同步。R1 schema_guard 名称不变，无联动。F-008 4 production caller (mem/postgres user_repo) + 全部 test caller 使用 named fields，ReconstituteUser 函数 body 同步重排。
- **不向后兼容**: 新 ErrCode 直接替换无 alias；struct 字段直接重排无双路径；migration 直接改不新建 029 桥接（用户已 confirm）。
- **优雅简洁**: 无新抽象、无新文件、无新 helper；总 ~80 line。SQL 用 `DROP IF EXISTS; ADD` idiom（与 023 同形态，无 DO $$ 块过度防御）。
- **AI-HARD**: FU-2 三项均落"日常实施 / refactor / 修 bug"分类，不在 `ai-collab.md` 章程"新增/修改约束 enforcement 机制"适用范围；F-008 概念关联的 Hard funnel `RECONSTITUTE-USER-CALLER-01` 已在 plan §FU-3 K-A 显式登记（非 silent backlog）。无新 Soft 立项。

## Refs

- `docs/plans/202605082145-034-pg-corecell-b-route-plan.md` §S4-FU §FU-2
- ADR `docs/architecture/202605101400-adr-credential-session-protocol.md` §A8 (migration 028 idempotency rationale stays)

## Test plan

- [x] `go build ./...` (0 errors)
- [x] `go test ./...` (all packages PASS)
- [x] `hack/verify-archtest.sh` (PASS SHARD_COUNT=16 TOTAL=421)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go run ./cmd/gocell validate` (0 error / 0 warn)
- [x] `go test -tags=integration ./cells/accesscore/slices/identitymanage/... -run TestChangePassword_RejectsBadOldPassword` — RED before Wave 2, GREEN after
- [x] CI gate: 主体已 PASS（unit / lint / archtest shards 0-9, 11-15 / verify-codegen / examples-smoke / os-smoke / e2e）；少量 shard / integration / make verify 仍在 pending（push 后会重跑）
- [ ] Manual review: contract.yaml description change reads naturally; migration 028 header note is self-explanatory

🤖 Generated with [Claude Code](https://claude.com/claude-code)