### PR TITLE
fix(adapters): transient error classification via errcode.WrapInfra Hard funnel (206)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -205,6 +205,7 @@ linters:
             - github.com/ghbvf/gocell/runtime
             - github.com/ghbvf/gocell/adapters
             - github.com/aws/aws-sdk-go-v2
+            - github.com/aws/smithy-go
             - github.com/coder/websocket
             - github.com/coreos/go-oidc
             - github.com/google/uuid

--- a/adapters/postgres/classify.go
+++ b/adapters/postgres/classify.go
@@ -64,13 +64,22 @@ func isRetryablePGError(err error) bool {
 		return false
 	}
 
+	// context.Canceled FIRST — the caller abandoned the work; retry is
+	// pointless. This MUST precede pgconn.SafeToRetry: pgx sets safeToRetry
+	// on its connect/exec wrapper when the failure occurred before any bytes
+	// were sent, which is exactly the shape of a context-canceled acquire —
+	// so SafeToRetry(canceledErr) can be true. Checking Canceled first
+	// prevents a caller-canceled operation from being mislabeled transient.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
 	// Driver-level safe-to-retry signal (e.g. *pgconn.connectError).
 	if pgconn.SafeToRetry(err) {
 		return true
 	}
 
 	// context.DeadlineExceeded — the deadline may not recur on retry.
-	// context.Canceled is intentionally excluded.
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}

--- a/adapters/postgres/classify.go
+++ b/adapters/postgres/classify.go
@@ -1,0 +1,132 @@
+package postgres
+
+// classify.go — SQLSTATE transient-vs-permanent classifier for the PostgreSQL
+// adapter. All transient errors are routed through errcode.WrapInfra (the single
+// funnel that sets KindUnavailable + CategoryInfra + private transient marker).
+//
+// SQLSTATE classes recognized as transient:
+//
+//	40001  serialization_failure  — safe to retry inside a new transaction
+//	40P01  deadlock_detected      — safe to retry inside a new transaction
+//	08xxx  connection_exception   — network/socket-level failures (08000, 08003,
+//	                               08006, 08P01, etc.)
+//
+// context.DeadlineExceeded is also transient; context.Canceled is NOT (the
+// caller gave up — retrying is pointless).
+//
+// pgconn.SafeToRetry(err) covers driver-level SafeToRetry() implementations
+// (e.g. *pgconn.connectError) that are safe to retry from the pgconn layer.
+//
+// ref: jackc/pgx pgconn SafeToRetry (github.com/jackc/pgx/v5/pgconn)
+// ref: https://www.postgresql.org/docs/current/errcodes-appendix.html
+// ref: archtest ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 (WrapInfra funnel)
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// sqlStateClassPrefix returns the 2-character SQLSTATE class prefix (the first
+// two characters of the 5-character code, with any trailing alphanumeric for
+// class codes that use a letter suffix like "08P01").
+//
+// Per the PostgreSQL spec the class is always the first two characters.
+func sqlStateClassPrefix(code string) string {
+	if len(code) < 2 {
+		return code
+	}
+	return code[:2]
+}
+
+// isRetryablePGError reports whether err represents a condition that is safe to
+// retry (with a new transaction or reconnect attempt).
+//
+// Returns true when:
+//   - pgconn.SafeToRetry(err) — driver-level safe-to-retry signal
+//   - errors.As → *pgconn.PgError with SQLSTATE 40001 (serialization_failure)
+//   - errors.As → *pgconn.PgError with SQLSTATE 40P01 (deadlock_detected)
+//   - errors.As → *pgconn.PgError whose class prefix == "08" (connection_exception)
+//   - errors.Is  → context.DeadlineExceeded
+//
+// Returns false for:
+//   - context.Canceled  — the caller abandoned the work; retry is pointless
+//   - all other SQLSTATE codes (fail-closed: unclassified = permanent)
+//   - nil
+//
+// ref: jackc/pgx pgconn SafeToRetry
+// ref: https://www.postgresql.org/docs/current/errcodes-appendix.html
+func isRetryablePGError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Driver-level safe-to-retry signal (e.g. *pgconn.connectError).
+	if pgconn.SafeToRetry(err) {
+		return true
+	}
+
+	// context.DeadlineExceeded — the deadline may not recur on retry.
+	// context.Canceled is intentionally excluded.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+
+	switch pgErr.Code {
+	case "40001", // serialization_failure
+		"40P01": // deadlock_detected
+		return true
+	}
+
+	// SQLSTATE class 08 — connection_exception (08000, 08003, 08006, 08P01, …)
+	if sqlStateClassPrefix(pgErr.Code) == "08" {
+		return true
+	}
+
+	return false
+}
+
+// classifyPGError routes a raw PostgreSQL error to a transient or permanent
+// errcode. The caller supplies the errcode.Code and a string context that
+// describes the operation (used as errcode.WithInternal text for server-side
+// logs — NOT placed in message, which must be a const literal per
+// MESSAGE-CONST-LITERAL-01).
+//
+// Transient branch (isRetryablePGError == true):
+//
+//	errcode.WrapInfra(permanentCode, "postgres: transient error", err,
+//	    errcode.WithInternal(opContext))
+//
+// WrapInfra sets KindUnavailable + CategoryInfra + the private transient
+// marker, enabling errcode.IsTransient to recognize the result. The caller's
+// operation code is reused (no separate ErrAdapterPGTransient constant).
+//
+// Permanent branch (default, fail-closed):
+//
+//	errcode.Wrap(errcode.KindInternal, permanentCode, "postgres: operation failed", err,
+//	    errcode.WithInternal(opContext))
+//
+// Constraint-violation helpers (IsUniqueViolation / IsForeignKeyViolation /
+// IsLastAdminProtected) remain separate and are NOT routed through this
+// function — they produce domain signals, not infra signals.
+//
+// ref: jackc/pgx pgconn SafeToRetry
+// ref: archtest ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01
+func classifyPGError(err error, permanentCode errcode.Code, opContext string) error {
+	if isRetryablePGError(err) {
+		return errcode.WrapInfra(permanentCode,
+			"postgres: transient error", err,
+			errcode.WithInternal(opContext))
+	}
+	return errcode.Wrap(errcode.KindInternal, permanentCode,
+		"postgres: operation failed", err,
+		errcode.WithInternal(opContext))
+}

--- a/adapters/postgres/classify_test.go
+++ b/adapters/postgres/classify_test.go
@@ -1,0 +1,167 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// TestIsRetryablePGError covers all SQLSTATE branches for isRetryablePGError.
+func TestIsRetryablePGError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "serialization_failure 40001",
+			err:  &pgconn.PgError{Code: "40001"},
+			want: true,
+		},
+		{
+			name: "deadlock_detected 40P01",
+			err:  &pgconn.PgError{Code: "40P01"},
+			want: true,
+		},
+		{
+			name: "connection_failure 08006",
+			err:  &pgconn.PgError{Code: "08006"},
+			want: true,
+		},
+		{
+			name: "connection_does_not_exist 08003",
+			err:  &pgconn.PgError{Code: "08003"},
+			want: true,
+		},
+		{
+			name: "connection_exception 08000",
+			err:  &pgconn.PgError{Code: "08000"},
+			want: true,
+		},
+		{
+			name: "protocol_violation 08P01",
+			err:  &pgconn.PgError{Code: "08P01"},
+			want: true,
+		},
+		{
+			name: "unique_violation 23505 — permanent",
+			err:  &pgconn.PgError{Code: "23505"},
+			want: false,
+		},
+		{
+			name: "invalid_password 28P01 — permanent",
+			err:  &pgconn.PgError{Code: "28P01"},
+			want: false,
+		},
+		{
+			name: "invalid_catalog_name 3D000 — permanent",
+			err:  &pgconn.PgError{Code: "3D000"},
+			want: false,
+		},
+		{
+			name: "context.DeadlineExceeded",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "context.Canceled — NOT transient",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("unknown"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryablePGError(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestClassifyPGError verifies that classifyPGError routes transient errors
+// through errcode.WrapInfra (IsTransient == true) and permanent errors through
+// errcode.Wrap (IsTransient == false).
+func TestClassifyPGError(t *testing.T) {
+	const opCode = errcode.Code("ERR_ADAPTER_PG_QUERY")
+	const opMsg = "op"
+
+	tests := []struct {
+		name          string
+		err           error
+		wantTransient bool
+	}{
+		{
+			name:          "serialization_failure 40001 → transient",
+			err:           &pgconn.PgError{Code: "40001"},
+			wantTransient: true,
+		},
+		{
+			name:          "deadlock_detected 40P01 → transient",
+			err:           &pgconn.PgError{Code: "40P01"},
+			wantTransient: true,
+		},
+		{
+			name:          "connection_failure 08006 → transient",
+			err:           &pgconn.PgError{Code: "08006"},
+			wantTransient: true,
+		},
+		{
+			name:          "connection_does_not_exist 08003 → transient",
+			err:           &pgconn.PgError{Code: "08003"},
+			wantTransient: true,
+		},
+		{
+			name:          "unique_violation 23505 → permanent",
+			err:           &pgconn.PgError{Code: "23505"},
+			wantTransient: false,
+		},
+		{
+			name:          "invalid_password 28P01 → permanent",
+			err:           &pgconn.PgError{Code: "28P01"},
+			wantTransient: false,
+		},
+		{
+			name:          "invalid_catalog_name 3D000 → permanent",
+			err:           &pgconn.PgError{Code: "3D000"},
+			wantTransient: false,
+		},
+		{
+			name:          "context.DeadlineExceeded → transient",
+			err:           context.DeadlineExceeded,
+			wantTransient: true,
+		},
+		{
+			name:          "context.Canceled → permanent",
+			err:           context.Canceled,
+			wantTransient: false,
+		},
+		{
+			name:          "plain error → permanent",
+			err:           errors.New("unknown error"),
+			wantTransient: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyPGError(tt.err, opCode, opMsg)
+			assert.Equal(t, tt.wantTransient, errcode.IsTransient(got),
+				"IsTransient mismatch for %q", tt.name)
+		})
+	}
+}

--- a/adapters/postgres/classify_test.go
+++ b/adapters/postgres/classify_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// safeToRetryErr mimics pgx's connect/exec wrapper: pgconn.SafeToRetry
+// recognizes any error whose chain implements SafeToRetry() bool == true.
+// It also unwraps to its cause so errors.Is(err, context.Canceled) holds.
+type safeToRetryErr struct{ cause error }
+
+func (e safeToRetryErr) Error() string     { return "pg: " + e.cause.Error() }
+func (e safeToRetryErr) Unwrap() error     { return e.cause }
+func (e safeToRetryErr) SafeToRetry() bool { return true }
+
 // TestIsRetryablePGError covers all SQLSTATE branches for isRetryablePGError.
 func TestIsRetryablePGError(t *testing.T) {
 	tests := []struct {
@@ -71,6 +80,14 @@ func TestIsRetryablePGError(t *testing.T) {
 		{
 			name: "context.Canceled — NOT transient",
 			err:  context.Canceled,
+			want: false,
+		},
+		{
+			// pgx wraps a canceled-context acquire/exec in an error whose
+			// SafeToRetry()==true (failure before any bytes sent). The
+			// Canceled check must win — caller gave up, not transient.
+			name: "SafeToRetry error wrapping context.Canceled — NOT transient",
+			err:  safeToRetryErr{cause: context.Canceled},
 			want: false,
 		},
 		{

--- a/adapters/postgres/pool.go
+++ b/adapters/postgres/pool.go
@@ -121,7 +121,7 @@ func NewPool(ctx context.Context, cfg Config) (*Pool, error) {
 
 	if err := pool.Ping(ctx); err != nil {
 		pool.Close()
-		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGConnect, "postgres: initial ping", err)
+		return nil, classifyPGError(err, ErrAdapterPGConnect, "initial ping")
 	}
 
 	slog.Info("postgres pool connected",
@@ -145,7 +145,7 @@ func (p *Pool) Health(ctx context.Context) error {
 	defer cancel()
 
 	if err := p.inner.Ping(ctx); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGConnect, "postgres: health check failed", err)
+		return classifyPGError(err, ErrAdapterPGConnect, "health check")
 	}
 	return nil
 }

--- a/adapters/postgres/tx_manager.go
+++ b/adapters/postgres/tx_manager.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/ghbvf/gocell/kernel/persistence"
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/pkg/redaction"
 )
@@ -79,7 +78,7 @@ func (tm *TxManager) RunInTx(ctx context.Context, fn func(ctx context.Context) e
 	// Start a new top-level transaction.
 	tx, err := tm.pool.Begin(ctx)
 	if err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGConnect, "postgres: begin tx", err)
+		return classifyPGError(err, ErrAdapterPGConnect, "begin tx")
 	}
 
 	txCtx := CtxWithTx(ctx, tx)
@@ -114,7 +113,7 @@ func (tm *TxManager) RunInTx(ctx context.Context, fn func(ctx context.Context) e
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGConnect, "postgres: commit tx", err)
+		return classifyPGError(err, ErrAdapterPGConnect, "commit tx")
 	}
 	return nil
 }
@@ -125,8 +124,7 @@ func (tm *TxManager) runInSavepoint(ctx context.Context, tx pgx.Tx, fn func(ctx 
 	spName := fmt.Sprintf("sp_%d", depth)
 
 	if _, err := tx.Exec(ctx, fmt.Sprintf("SAVEPOINT %s", spName)); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "postgres: savepoint create failed", err,
-			errcode.WithInternal(fmt.Sprintf("savepoint=%s", spName)))
+		return classifyPGError(err, ErrAdapterPGQuery, fmt.Sprintf("savepoint create savepoint=%s", spName))
 	}
 
 	nestedCtx := withSavepointDepth(ctx, depth+1)
@@ -160,8 +158,7 @@ func (tm *TxManager) runInSavepoint(ctx context.Context, tx pgx.Tx, fn func(ctx 
 	}
 
 	if _, err := tx.Exec(ctx, fmt.Sprintf("RELEASE SAVEPOINT %s", spName)); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "postgres: savepoint release failed", err,
-			errcode.WithInternal(fmt.Sprintf("savepoint=%s", spName)))
+		return classifyPGError(err, ErrAdapterPGQuery, fmt.Sprintf("savepoint release savepoint=%s", spName))
 	}
 	return nil
 }

--- a/adapters/redis/cache.go
+++ b/adapters/redis/cache.go
@@ -57,9 +57,8 @@ func (c *Cache) Get(ctx context.Context, key string) (string, error) {
 		if errors.Is(err, goredis.Nil) {
 			return "", nil
 		}
-		return "", errcode.Wrap(errcode.KindInternal, ErrAdapterRedisGet,
-			"redis: cache get failed", err,
-			errcode.WithInternal(fmt.Sprintf(internalKeyFmt, prefixed)))
+		return "", classifyRedisError(err, ErrAdapterRedisGet,
+			fmt.Sprintf(internalKeyFmt, prefixed))
 	}
 	return val, nil
 }
@@ -69,9 +68,8 @@ func (c *Cache) Get(ctx context.Context, key string) (string, error) {
 func (c *Cache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
 	prefixed := c.ns.apply(key)
 	if err := c.rdb.Set(ctx, prefixed, value, ttl).Err(); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterRedisSet,
-			"redis: cache set failed", err,
-			errcode.WithInternal(fmt.Sprintf(internalKeyFmt, prefixed)))
+		return classifyRedisError(err, ErrAdapterRedisSet,
+			fmt.Sprintf(internalKeyFmt, prefixed))
 	}
 	return nil
 }
@@ -81,9 +79,8 @@ func (c *Cache) Set(ctx context.Context, key string, value string, ttl time.Dura
 func (c *Cache) Delete(ctx context.Context, key string) error {
 	prefixed := c.ns.apply(key)
 	if err := c.rdb.Del(ctx, prefixed).Err(); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterRedisDelete,
-			"redis: cache delete failed", err,
-			errcode.WithInternal(fmt.Sprintf(internalKeyFmt, prefixed)))
+		return classifyRedisError(err, ErrAdapterRedisDelete,
+			fmt.Sprintf(internalKeyFmt, prefixed))
 	}
 	return nil
 }
@@ -98,9 +95,8 @@ func GetJSON[T any](ctx context.Context, c *Cache, key string) (T, error) {
 		if errors.Is(err, goredis.Nil) {
 			return zero, nil
 		}
-		return zero, errcode.Wrap(errcode.KindInternal, ErrAdapterRedisGet,
-			"redis: cache get json failed", err,
-			errcode.WithInternal(fmt.Sprintf(internalKeyFmt, prefixed)))
+		return zero, classifyRedisError(err, ErrAdapterRedisGet,
+			fmt.Sprintf(internalKeyFmt, prefixed))
 	}
 	var result T
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
@@ -122,9 +118,8 @@ func SetJSON[T any](ctx context.Context, c *Cache, key string, value T, ttl time
 			errcode.WithInternal(fmt.Sprintf(internalKeyFmt, prefixed)))
 	}
 	if err := c.rdb.Set(ctx, prefixed, string(data), ttl).Err(); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterRedisSet,
-			"redis: cache set json failed", err,
-			errcode.WithInternal(fmt.Sprintf(internalKeyFmt, prefixed)))
+		return classifyRedisError(err, ErrAdapterRedisSet,
+			fmt.Sprintf(internalKeyFmt, prefixed))
 	}
 	return nil
 }

--- a/adapters/redis/errors.go
+++ b/adapters/redis/errors.go
@@ -1,0 +1,91 @@
+// Package redis — error classification helpers.
+//
+// classifyRedisError routes a Redis command error to transient (retriable) or
+// permanent classification. Transient conditions route through errcode.WrapInfra
+// (KindUnavailable + CategoryInfra + private transient marker), which errcode.IsTransient
+// recognizes. Permanent conditions route through errcode.Wrap(KindInternal, …).
+//
+// ref: redis/go-redis error.go reply codes (CLUSTERDOWN / LOADING / TRYAGAIN / MASTERDOWN)
+// ref: errcode.WrapInfra funnel + archtest ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01
+package redis
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// classifyRedisError routes a Redis command failure to the correct errcode shape.
+//
+// Transient when any of:
+//   - errors.Is(err, context.DeadlineExceeded) — deadline may succeed on retry
+//   - errors.As net.Error && Timeout() == true — socket read/write timeout
+//   - err.Error() contains "i/o timeout" — raw network timeout string
+//   - CLUSTERDOWN / LOADING / TRYAGAIN / MASTERDOWN Redis reply codes
+//     (server-recovering states that should requeue, not DLX)
+//
+// context.Canceled is NOT transient — the caller gave up.
+// Permanent (WRONGTYPE, marshal errors, etc.) → errcode.Wrap KindInternal.
+//
+// opCode is reused as-is for both branches; no new ErrAdapter*Transient constant is introduced.
+// message args are const literals to satisfy MESSAGE-CONST-LITERAL-01.
+func classifyRedisError(err error, opCode errcode.Code, opMsg string) error {
+	if isTransientRedisError(err) {
+		return errcode.WrapInfra(opCode,
+			"redis: transient error",
+			err,
+			errcode.WithInternal(opMsg))
+	}
+	return errcode.Wrap(errcode.KindInternal, opCode,
+		"redis: operation failed",
+		err,
+		errcode.WithInternal(opMsg))
+}
+
+// isTransientRedisError reports whether err represents a transient Redis failure
+// that is safe to requeue.
+//
+// Classification:
+//  1. context.DeadlineExceeded → transient (deadline exceeded may succeed on retry).
+//     context.Canceled is excluded (caller gave up; retrying is pointless).
+//  2. net.Error.Timeout() == true → transient (socket I/O timeout).
+//  3. Error string contains "i/o timeout" → transient (fallback for plain errors
+//     that carry the network timeout message without implementing net.Error).
+//  4. Redis reply-code prefixes CLUSTERDOWN / LOADING / TRYAGAIN / MASTERDOWN →
+//     transient (server-recovering states; go-redis typed helpers via HasErrorPrefix
+//     are preferred; plain errors.New strings match the HasPrefix fallback path).
+func isTransientRedisError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	if strings.Contains(err.Error(), "i/o timeout") {
+		return true
+	}
+
+	return isTransientRedisReplyCode(err)
+}
+
+// isTransientRedisReplyCode reports whether err is one of the Redis server-recovering
+// reply codes (CLUSTERDOWN / LOADING / TRYAGAIN / MASTERDOWN).
+//
+// go-redis v9 exposes typed public helpers (IsClusterDownError, IsLoadingError,
+// IsTryAgainError, IsMasterDownError) that work with wrapped errors. For plain
+// errors.New strings (common in unit tests), the helpers delegate internally to
+// HasErrorPrefix which also covers that path.
+func isTransientRedisReplyCode(err error) bool {
+	return goredis.IsClusterDownError(err) ||
+		goredis.IsLoadingError(err) ||
+		goredis.IsTryAgainError(err) ||
+		goredis.IsMasterDownError(err)
+}

--- a/adapters/redis/errors.go
+++ b/adapters/redis/errors.go
@@ -64,11 +64,20 @@ func classifyRedisError(err error, opCode errcode.Code, opMsg string) error {
 //     event loss. Not an AI-rebust enforcement mechanism (business
 //     classification, not archtest/governance) — no Soft-upgrade backlog
 //     entry required; the typed check (2) is the durable signal.
+//     3b. goredis.ErrPoolTimeout → transient (connection-pool exhaustion; the
+//     pool frees up — go-redis itself classifies this retryable).
 //  4. Redis reply-code prefixes CLUSTERDOWN / LOADING / TRYAGAIN / MASTERDOWN →
 //     transient (server-recovering states; go-redis typed helpers via HasErrorPrefix
 //     are preferred; plain errors.New strings match the HasPrefix fallback path).
 func isTransientRedisError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	// go-redis pool exhaustion: the client could not obtain a connection
+	// within PoolTimeout. go-redis itself treats this as retryable (the pool
+	// frees up); requeue rather than DLX.
+	if errors.Is(err, goredis.ErrPoolTimeout) {
 		return true
 	}
 

--- a/adapters/redis/errors.go
+++ b/adapters/redis/errors.go
@@ -54,8 +54,16 @@ func classifyRedisError(err error, opCode errcode.Code, opMsg string) error {
 //  1. context.DeadlineExceeded → transient (deadline exceeded may succeed on retry).
 //     context.Canceled is excluded (caller gave up; retrying is pointless).
 //  2. net.Error.Timeout() == true → transient (socket I/O timeout).
-//  3. Error string contains "i/o timeout" → transient (fallback for plain errors
-//     that carry the network timeout message without implementing net.Error).
+//  3. Error string contains "i/o timeout" → transient. SOFT best-effort
+//     fallback, intentionally AFTER the typed net.Error.Timeout() check (2)
+//     which is the primary path: go-redis dial/socket timeouts implement
+//     net.Error and are caught by (2). (3) only catches plain errors that
+//     carry the message text without implementing net.Error. It is not the
+//     authoritative classifier; over/under-match here degrades to the
+//     fail-closed-permanent default (Requeue-then-budget-DLX), never to
+//     event loss. Not an AI-rebust enforcement mechanism (business
+//     classification, not archtest/governance) — no Soft-upgrade backlog
+//     entry required; the typed check (2) is the durable signal.
 //  4. Redis reply-code prefixes CLUSTERDOWN / LOADING / TRYAGAIN / MASTERDOWN →
 //     transient (server-recovering states; go-redis typed helpers via HasErrorPrefix
 //     are preferred; plain errors.New strings match the HasPrefix fallback path).

--- a/adapters/redis/errors_test.go
+++ b/adapters/redis/errors_test.go
@@ -1,0 +1,111 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// fakeNetError is a synthetic net.Error used to exercise the Timeout() branch.
+type fakeNetError struct {
+	timeout bool
+}
+
+func (e *fakeNetError) Error() string {
+	if e.timeout {
+		return "i/o timeout"
+	}
+	return "network error"
+}
+
+func (e *fakeNetError) Timeout() bool   { return e.timeout }
+func (e *fakeNetError) Temporary() bool { return false }
+
+var _ net.Error = (*fakeNetError)(nil)
+
+func TestClassifyRedisError(t *testing.T) {
+	t.Parallel()
+
+	const opCode = errcode.Code("ERR_ADAPTER_REDIS_GET")
+	const opMsg = "get operation context"
+
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{
+			name:      "net.Error Timeout true → transient",
+			err:       &fakeNetError{timeout: true},
+			transient: true,
+		},
+		{
+			name:      "net.Error Timeout false → permanent",
+			err:       &fakeNetError{timeout: false},
+			transient: false,
+		},
+		{
+			name:      "context.DeadlineExceeded → transient",
+			err:       context.DeadlineExceeded,
+			transient: true,
+		},
+		{
+			name:      "context.Canceled → permanent",
+			err:       context.Canceled,
+			transient: false,
+		},
+		{
+			name:      "LOADING prefix → transient",
+			err:       errors.New("LOADING Redis is loading the dataset in memory"),
+			transient: true,
+		},
+		{
+			name:      "CLUSTERDOWN prefix → transient",
+			err:       errors.New("CLUSTERDOWN The cluster is down"),
+			transient: true,
+		},
+		{
+			name:      "TRYAGAIN prefix → transient",
+			err:       errors.New("TRYAGAIN Command cannot be processed, please try again"),
+			transient: true,
+		},
+		{
+			name:      "MASTERDOWN prefix → transient",
+			err:       errors.New("MASTERDOWN Link with MASTER is down"),
+			transient: true,
+		},
+		{
+			name:      "WRONGTYPE prefix → permanent",
+			err:       errors.New("WRONGTYPE Operation against a key holding the wrong kind of value"),
+			transient: false,
+		},
+		{
+			name:      "json marshal plain error → permanent",
+			err:       errors.New("json: cannot unmarshal string into Go value of type int"),
+			transient: false,
+		},
+		{
+			name:      "i/o timeout string → transient",
+			err:       errors.New("read tcp 127.0.0.1:0->127.0.0.1:6379: i/o timeout"),
+			transient: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyRedisError(tc.err, opCode, opMsg)
+			if got == nil {
+				t.Fatal("classifyRedisError must not return nil")
+			}
+			if errcode.IsTransient(got) != tc.transient {
+				t.Errorf("IsTransient(%q) = %v, want %v (err: %v)",
+					tc.err, errcode.IsTransient(got), tc.transient, got)
+			}
+		})
+	}
+}

--- a/adapters/redis/errors_test.go
+++ b/adapters/redis/errors_test.go
@@ -3,8 +3,11 @@ package redis
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
@@ -90,6 +93,16 @@ func TestClassifyRedisError(t *testing.T) {
 		{
 			name:      "i/o timeout string → transient",
 			err:       errors.New("read tcp 127.0.0.1:0->127.0.0.1:6379: i/o timeout"),
+			transient: true,
+		},
+		{
+			name:      "goredis.ErrPoolTimeout → transient",
+			err:       goredis.ErrPoolTimeout,
+			transient: true,
+		},
+		{
+			name:      "wrapped goredis.ErrPoolTimeout → transient",
+			err:       fmt.Errorf("cache get: %w", goredis.ErrPoolTimeout),
 			transient: true,
 		},
 	}

--- a/adapters/redis/idempotency.go
+++ b/adapters/redis/idempotency.go
@@ -189,8 +189,8 @@ func (c *IdempotencyClaimer) Claim(
 
 	res, err := c.rdb.Eval(ctx, claimScript, []string{doneKey, leaseKey}, token, leaseMs).Result()
 	if err != nil {
-		return 0, nil, errcode.Wrap(errcode.KindInternal, ErrAdapterRedisSet,
-			"redis: idempotency claim failed", err)
+		return 0, nil, classifyRedisError(err, ErrAdapterRedisSet,
+			"idempotency claim")
 	}
 
 	code, ok := res.(int64)
@@ -247,8 +247,8 @@ func (r *redisReceipt) Commit(ctx context.Context) error {
 	doneMs := max(r.doneTTL.Milliseconds(), 1)
 	res, err := r.rdb.Eval(ctx, commitScript, []string{r.leaseKey, r.doneKey}, r.token, doneMs).Result()
 	if err != nil {
-		r.commitErr = errcode.Wrap(errcode.KindInternal, ErrAdapterRedisSet,
-			"redis: idempotency commit failed", err)
+		r.commitErr = classifyRedisError(err, ErrAdapterRedisSet,
+			"idempotency commit")
 		return r.commitErr
 	}
 	code, ok := res.(int64)
@@ -275,8 +275,8 @@ func (r *redisReceipt) Release(ctx context.Context) error {
 	}
 	res, err := r.rdb.Eval(ctx, releaseScript, []string{r.leaseKey}, r.token).Result()
 	if err != nil {
-		r.releaseErr = errcode.Wrap(errcode.KindInternal, ErrAdapterRedisDelete,
-			"redis: idempotency release failed", err)
+		r.releaseErr = classifyRedisError(err, ErrAdapterRedisDelete,
+			"idempotency release")
 		return r.releaseErr
 	}
 	code, ok := res.(int64)
@@ -300,7 +300,7 @@ func (r *redisReceipt) Extend(ctx context.Context, ttl time.Duration) error {
 	ttlMs := max(ttl.Milliseconds(), 1)
 	res, err := r.rdb.Eval(ctx, extendScript, []string{r.leaseKey}, r.token, ttlMs).Result()
 	if err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterRedisSet, "redis claimer: extend lease", err)
+		return classifyRedisError(err, ErrAdapterRedisSet, "idempotency extend lease")
 	}
 	code, ok := res.(int64)
 	if !ok || code == 0 {

--- a/adapters/redis/nonce.go
+++ b/adapters/redis/nonce.go
@@ -81,9 +81,8 @@ func (s *NonceStore) CheckAndMark(ctx context.Context, nonce string) error {
 	key := s.ns.apply(nonce)
 	ok, err := s.rdb.SetNX(ctx, key, "1", s.ttl).Result()
 	if err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterRedisSet,
-			"redis nonce store: SET NX failed", err,
-			errcode.WithInternal(fmt.Sprintf("key=%s", key)))
+		return classifyRedisError(err, ErrAdapterRedisSet,
+			fmt.Sprintf("key=%s", key))
 	}
 	if !ok {
 		return auth.ErrNonceReused

--- a/adapters/s3/errors.go
+++ b/adapters/s3/errors.go
@@ -5,10 +5,38 @@ import (
 	"errors"
 	"net"
 
+	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
+
+// retryableS3ErrorCodes mirrors aws-sdk-go-v2 retry.DefaultRetryableErrorCodes
+// + DefaultThrottleErrorCodes (plus S3 InternalError / ServiceUnavailable).
+// These codes are retry-safe regardless of HTTP status — notably
+// RequestTimeout / RequestTimeoutException arrive as HTTP 400, which the
+// status-only check would mis-classify as permanent.
+//
+// ref: aws/aws-sdk-go-v2 aws/retry/standard.go DefaultRetryableErrorCodes /
+// DefaultThrottleErrorCodes.
+var retryableS3ErrorCodes = map[string]struct{}{
+	"RequestTimeout":                         {},
+	"RequestTimeoutException":                {},
+	"InternalError":                          {},
+	"ServiceUnavailable":                     {},
+	"SlowDown":                               {},
+	"Throttling":                             {},
+	"ThrottlingException":                    {},
+	"ThrottledException":                     {},
+	"RequestThrottled":                       {},
+	"RequestThrottledException":              {},
+	"TooManyRequestsException":               {},
+	"RequestLimitExceeded":                   {},
+	"BandwidthLimitExceeded":                 {},
+	"LimitExceededException":                 {},
+	"PriorRequestNotComplete":                {},
+	"ProvisionedThroughputExceededException": {},
+}
 
 // S3 adapter error codes.
 const (
@@ -48,7 +76,11 @@ func classifyS3Error(err error, opCode errcode.Code, opMsg string) error {
 // Classification order:
 //  1. errcode.IsTransient in chain → transient (respects WrapInfra marker).
 //  2. Any other *errcode.Error in chain → permanent (already classified).
-//  3. smithyhttp.ResponseError with HTTP status → classify by status code.
+//  3. smithyhttp.ResponseError with HTTP status → transient if status is
+//     retryable; otherwise fall through (status alone is not authoritative).
+//     3b. smithy.APIError with a retryable/throttle ErrorCode → transient
+//     (RequestTimeout / SlowDown / Throttling… — retry-safe regardless of
+//     HTTP status; RequestTimeout is HTTP 400).
 //  4. context.DeadlineExceeded → transient; context.Canceled → permanent.
 //  5. net.Error.Timeout() == true → transient.
 //  6. Everything else → permanent (fail-closed).
@@ -67,7 +99,20 @@ func isTransientS3Error(err error) bool {
 	// 3. AWS SDK smithy HTTP response error — classify by status code.
 	var respErr *smithyhttp.ResponseError
 	if errors.As(err, &respErr) {
-		return isTransientHTTPStatus(respErr.HTTPStatusCode())
+		if isTransientHTTPStatus(respErr.HTTPStatusCode()) {
+			return true
+		}
+		// fall through to the API error-code check below: some retryable
+		// codes (RequestTimeout) arrive with a non-retryable HTTP status.
+	}
+
+	// 3b. AWS SDK API error code — retryable/throttle codes are retry-safe
+	// independent of HTTP status (RequestTimeout is HTTP 400).
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		if _, ok := retryableS3ErrorCodes[apiErr.ErrorCode()]; ok {
+			return true
+		}
 	}
 
 	// 4. Context errors: deadline is transient, canceled is permanent.

--- a/adapters/s3/errors.go
+++ b/adapters/s3/errors.go
@@ -1,6 +1,14 @@
 package s3
 
-import "github.com/ghbvf/gocell/pkg/errcode"
+import (
+	"context"
+	"errors"
+	"net"
+
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
 
 // S3 adapter error codes.
 const (
@@ -8,3 +16,87 @@ const (
 	ErrAdapterS3Upload errcode.Code = "ERR_ADAPTER_S3_UPLOAD"
 	ErrAdapterS3Health errcode.Code = "ERR_ADAPTER_S3_HEALTH"
 )
+
+// classifyS3Error classifies an S3 SDK error as transient or permanent and
+// wraps it via the appropriate errcode funnel:
+//
+//   - Transient (safe to retry): AWS SDK response with HTTP status in
+//     {408, 429, 500, 502, 503, 504}; context.DeadlineExceeded;
+//     net.Error.Timeout() == true. Routed through errcode.WrapInfra so that
+//     errcode.IsTransient returns true.
+//   - Permanent: all other errors (403, 404, 400, context.Canceled, plain
+//     errors). Routed through errcode.Wrap with KindInternal.
+//
+// opCode is the caller's error code (e.g. ErrAdapterS3Upload); opMsg is
+// placed in WithInternal and never surfaces on the wire.
+//
+// ref: aws/aws-sdk-go-v2 aws/retry RetryableHTTPStatusCode
+// ref: ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 archtest; errcode.WrapInfra funnel.
+func classifyS3Error(err error, opCode errcode.Code, opMsg string) error {
+	if isTransientS3Error(err) {
+		return errcode.WrapInfra(opCode,
+			"s3: transient error", err,
+			errcode.WithInternal(opMsg))
+	}
+	return errcode.Wrap(errcode.KindInternal, opCode,
+		"s3: operation failed", err,
+		errcode.WithInternal(opMsg))
+}
+
+// isTransientS3Error reports whether err should be retried.
+//
+// Classification order:
+//  1. errcode.IsTransient in chain → transient (respects WrapInfra marker).
+//  2. Any other *errcode.Error in chain → permanent (already classified).
+//  3. smithyhttp.ResponseError with HTTP status → classify by status code.
+//  4. context.DeadlineExceeded → transient; context.Canceled → permanent.
+//  5. net.Error.Timeout() == true → transient.
+//  6. Everything else → permanent (fail-closed).
+func isTransientS3Error(err error) bool {
+	// 1. Already has WrapInfra transient marker.
+	if errcode.IsTransient(err) {
+		return true
+	}
+
+	// 2. Any other errcode.Error in chain → already classified as permanent.
+	var ec *errcode.Error
+	if errors.As(err, &ec) {
+		return false
+	}
+
+	// 3. AWS SDK smithy HTTP response error — classify by status code.
+	var respErr *smithyhttp.ResponseError
+	if errors.As(err, &respErr) {
+		return isTransientHTTPStatus(respErr.HTTPStatusCode())
+	}
+
+	// 4. Context errors: deadline is transient, canceled is permanent.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	// 5. Network timeout.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// 6. Unknown error → permanent (fail-closed).
+	return false
+}
+
+// isTransientHTTPStatus reports whether an HTTP status code indicates a
+// condition safe to retry after back-off.
+//
+// ref: aws/aws-sdk-go-v2 aws/retry RetryableHTTPStatusCode
+func isTransientHTTPStatus(code int) bool {
+	switch code {
+	case 429, 408, 500, 502, 503, 504:
+		return true
+	default:
+		return false
+	}
+}

--- a/adapters/s3/errors_test.go
+++ b/adapters/s3/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 
@@ -122,6 +123,33 @@ func TestClassifyS3Error(t *testing.T) {
 		{
 			name:      "net.Error Timeout=false → permanent",
 			err:       &fakeNetError{timeout: false},
+			wantTrans: false,
+		},
+
+		// ---- transient: AWS SDK API error codes (status-agnostic) ----
+		{
+			// RequestTimeout arrives as HTTP 400 — the status-only check
+			// would mis-classify it permanent; the code makes it transient.
+			name: "API RequestTimeout (HTTP 400) → transient",
+			err: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: 400}},
+				Err:      &smithy.GenericAPIError{Code: "RequestTimeout", Message: "timed out"},
+			},
+			wantTrans: true,
+		},
+		{
+			name:      "API SlowDown → transient",
+			err:       &smithy.GenericAPIError{Code: "SlowDown", Message: "reduce rate"},
+			wantTrans: true,
+		},
+		{
+			name:      "API ThrottlingException → transient",
+			err:       &smithy.GenericAPIError{Code: "ThrottlingException", Message: "throttled"},
+			wantTrans: true,
+		},
+		{
+			name:      "API AccessDenied → permanent",
+			err:       &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"},
 			wantTrans: false,
 		},
 	}

--- a/adapters/s3/errors_test.go
+++ b/adapters/s3/errors_test.go
@@ -1,0 +1,169 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// fakeNetError is a net.Error that reports Timeout()=true for testing the
+// net.Error.Timeout() branch of classifyS3Error.
+type fakeNetError struct{ timeout bool }
+
+func (e *fakeNetError) Error() string   { return "fake net error" }
+func (e *fakeNetError) Timeout() bool   { return e.timeout }
+func (e *fakeNetError) Temporary() bool { return false }
+
+var _ net.Error = (*fakeNetError)(nil)
+
+// newSmithyResponseError builds a *smithyhttp.ResponseError with the given
+// HTTP status code. This is the real smithy type — no fabrication needed
+// because the struct is exported and the Response field is a *smithyhttp.Response
+// (which embeds *http.Response).
+func newSmithyResponseError(statusCode int) *smithyhttp.ResponseError {
+	return &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{
+			Response: &http.Response{StatusCode: statusCode},
+		},
+		Err: errors.New("s3 api error"),
+	}
+}
+
+func TestClassifyS3Error(t *testing.T) {
+	t.Parallel()
+
+	const opCode errcode.Code = "ERR_ADAPTER_S3_UPLOAD"
+	const opMsg = "key=test/file.bin"
+
+	tests := []struct {
+		name      string
+		err       error
+		wantTrans bool // true → errcode.IsTransient must be true
+	}{
+		// ---- transient: AWS HTTP status codes ----
+		{
+			name:      "smithy 503 ServiceUnavailable → transient",
+			err:       newSmithyResponseError(503),
+			wantTrans: true,
+		},
+		{
+			name:      "smithy 500 InternalServerError → transient",
+			err:       newSmithyResponseError(500),
+			wantTrans: true,
+		},
+		{
+			name:      "smithy 429 TooManyRequests → transient",
+			err:       newSmithyResponseError(429),
+			wantTrans: true,
+		},
+		{
+			name:      "smithy 408 RequestTimeout → transient",
+			err:       newSmithyResponseError(408),
+			wantTrans: true,
+		},
+		{
+			name:      "smithy 502 BadGateway → transient",
+			err:       newSmithyResponseError(502),
+			wantTrans: true,
+		},
+		{
+			name:      "smithy 504 GatewayTimeout → transient",
+			err:       newSmithyResponseError(504),
+			wantTrans: true,
+		},
+
+		// ---- transient: context / network ----
+		{
+			name:      "context.DeadlineExceeded → transient",
+			err:       context.DeadlineExceeded,
+			wantTrans: true,
+		},
+		{
+			name:      "net.Error Timeout=true → transient",
+			err:       &fakeNetError{timeout: true},
+			wantTrans: true,
+		},
+
+		// ---- permanent: AWS HTTP status codes ----
+		{
+			name:      "smithy 400 BadRequest → permanent",
+			err:       newSmithyResponseError(400),
+			wantTrans: false,
+		},
+		{
+			name:      "smithy 403 Forbidden → permanent",
+			err:       newSmithyResponseError(403),
+			wantTrans: false,
+		},
+		{
+			name:      "smithy 404 NotFound → permanent",
+			err:       newSmithyResponseError(404),
+			wantTrans: false,
+		},
+
+		// ---- permanent: other ----
+		{
+			name:      "context.Canceled → permanent (NOT transient)",
+			err:       context.Canceled,
+			wantTrans: false,
+		},
+		{
+			name:      "plain error → permanent",
+			err:       errors.New("something went wrong"),
+			wantTrans: false,
+		},
+		{
+			name:      "net.Error Timeout=false → permanent",
+			err:       &fakeNetError{timeout: false},
+			wantTrans: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyS3Error(tc.err, opCode, opMsg)
+
+			assert.NotNil(t, got, "classifyS3Error must never return nil when given non-nil err")
+
+			if tc.wantTrans {
+				assert.True(t, errcode.IsTransient(got),
+					"expected transient error for %T but got non-transient: %v", tc.err, got)
+			} else {
+				assert.False(t, errcode.IsTransient(got),
+					"expected permanent error for %T but got transient: %v", tc.err, got)
+			}
+		})
+	}
+}
+
+func TestIsTransientHTTPStatus_S3(t *testing.T) {
+	t.Parallel()
+
+	transient := []int{429, 408, 500, 502, 503, 504}
+	permanent := []int{200, 201, 301, 400, 401, 403, 404, 409, 413}
+
+	for _, code := range transient {
+		code := code
+		t.Run("transient", func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, isTransientHTTPStatus(code), "status %d should be transient", code)
+		})
+	}
+	for _, code := range permanent {
+		code := code
+		t.Run("permanent", func(t *testing.T) {
+			t.Parallel()
+			assert.False(t, isTransientHTTPStatus(code), "status %d should be permanent", code)
+		})
+	}
+}

--- a/adapters/s3/s3.go
+++ b/adapters/s3/s3.go
@@ -213,9 +213,8 @@ func (c *Client) headBucket(ctx context.Context) error {
 		Bucket: aws.String(c.config.Bucket),
 	})
 	if err != nil {
-		wrapped := error(errcode.Wrap(errcode.KindInternal, ErrAdapterS3Health,
-			"s3: health check failed", err,
-			errcode.WithDetails(slog.String("bucket", c.config.Bucket))))
+		wrapped := classifyS3Error(err, ErrAdapterS3Health,
+			fmt.Sprintf("bucket=%s", c.config.Bucket))
 		c.state.Store(&wrapped)
 		return wrapped
 	}
@@ -247,9 +246,8 @@ func (c *Client) Upload(ctx context.Context, key string, data []byte, contentTyp
 		ContentType: aws.String(contentType),
 	})
 	if err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterS3Upload,
-			"s3: upload failed", err,
-			errcode.WithInternal(fmt.Sprintf("key=%s", key)))
+		return classifyS3Error(err, ErrAdapterS3Upload,
+			fmt.Sprintf("key=%s", key))
 	}
 	slog.Debug("s3: object uploaded", slog.String("key", key), slog.Int("size", len(data)))
 	return nil
@@ -271,9 +269,8 @@ func (c *Client) Health(ctx context.Context) error {
 		Bucket: aws.String(c.config.Bucket),
 	})
 	if err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterS3Health,
-			"s3: health check failed", err,
-			errcode.WithDetails(slog.String("bucket", c.config.Bucket)))
+		return classifyS3Error(err, ErrAdapterS3Health,
+			fmt.Sprintf("bucket=%s", c.config.Bucket))
 	}
 	return nil
 }

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -996,7 +996,11 @@ func (p *TransitKeyProvider) readLatestVersion(ctx context.Context) (int, error)
 // ref: hashicorp/vault api/logical.go — *vaultapi.ResponseError status codes
 func classifyVaultError(err error, permanentCode errcode.Code, permanentMsg string) error {
 	if isTransientVaultError(err) {
-		return errcode.Wrap(errcode.KindUnavailable, errcode.ErrKeyProviderTransient,
+		// WrapInfra is the single transient-marker funnel (post-206): it sets
+		// KindUnavailable + CategoryInfra + the private transient marker that
+		// errcode.IsTransient keys on. No dual truth source — the old
+		// Wrap(KindUnavailable, ErrKeyProviderTransient, …) shape is gone.
+		return errcode.WrapInfra(errcode.ErrKeyProviderTransient,
 			"vault-transit: transient error", err,
 			errcode.WithInternal(permanentMsg))
 	}

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -1043,10 +1044,13 @@ func classifyVaultReadError(err error) error {
 //  2. If err chain contains any other errcode.Error (permanent code like
 //     ErrKeyProviderEncryptFailed / ErrKeyProviderDecryptFailed) → permanent.
 //  3. If err is a *vaultapi.ResponseError → classify by HTTP status code.
-//  4. Pure network/context errors (no errcode, no ResponseError) → transient.
+//  4. Genuine *net.OpError / net.Error (no errcode, no ResponseError) →
+//     transient. Any other unknown error → permanent (fail-closed-on-unknown,
+//     consistent with classifyPGError / classifyRedisError / classifyS3Error).
 //
 // This ordering ensures injected permanent errcode errors (e.g. in unit tests)
-// are not accidentally re-classified as transient by the network-fallback case.
+// are not accidentally re-classified as transient by the network-fallback case,
+// and that a non-network unknown (JSON decode, SDK bug) is not retried forever.
 // errors.As is used throughout to support errors.Join / multi-Unwrap chains.
 func isTransientVaultError(err error) bool {
 	// 1. Explicit transient code in chain → transient.
@@ -1066,8 +1070,20 @@ func isTransientVaultError(err error) bool {
 		return isTransientHTTPStatus(respErr.StatusCode)
 	}
 
-	// 4. Pure network/context error (no errcode, no ResponseError) → transient.
-	return true
+	// 4. Genuine network error (no errcode, no ResponseError) → transient.
+	//    context.DeadlineExceeded and net.Error.Timeout() are already covered
+	//    transitively by step 1 (errcode.IsTransient). This branch catches the
+	//    non-timeout network failures — dial refused / connection reset —
+	//    surfaced as *net.OpError. Any OTHER unknown error (JSON decode, SDK
+	//    internal bug) falls through to false: fail-closed-on-unknown, the
+	//    same default as classifyPGError / classifyRedisError / classifyS3Error
+	//    (an unknown error degrades to Reject/permanent, never wrongly retried
+	//    forever). See ADR 202605161800 §"Coverage / threat re-eval".
+	// *net.OpError (dial refused / connection reset) implements net.Error,
+	// so a single net.Error probe covers both timeout and non-timeout
+	// network failures; any other unknown error → false (fail-closed).
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 // isTransientHTTPStatus reports whether an HTTP status code indicates a

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -501,15 +501,15 @@ func TestVaultTransitHandle_VaultServerError_ClassifiedTransient(t *testing.T) {
 	}{
 		{
 			name:     "503 Service Unavailable",
-			vaultErr: errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "vault: 503 service unavailable"),
+			vaultErr: errcode.WrapInfra(errcode.ErrKeyProviderTransient, "vault: 503 service unavailable", nil),
 		},
 		{
 			name:     "429 Too Many Requests",
-			vaultErr: errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "vault: 429 rate limited"),
+			vaultErr: errcode.WrapInfra(errcode.ErrKeyProviderTransient, "vault: 429 rate limited", nil),
 		},
 		{
 			name:     "408 Request Timeout",
-			vaultErr: errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "vault: 408 request timeout"),
+			vaultErr: errcode.WrapInfra(errcode.ErrKeyProviderTransient, "vault: 408 request timeout", nil),
 		},
 	}
 	for _, tc := range transientCases {
@@ -833,7 +833,7 @@ func TestIsTransientVaultError_ContextError(t *testing.T) {
 		},
 		{
 			name:      "errcode.ErrKeyProviderTransient → transient",
-			err:       errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "rate limited"),
+			err:       errcode.WrapInfra(errcode.ErrKeyProviderTransient, "rate limited", nil),
 			wantTrans: true,
 		},
 	}
@@ -1274,7 +1274,7 @@ func TestTokenRenewalWorker_Start_HandlesDoneWithError(t *testing.T) {
 		done <- w.Start(ctx)
 	}()
 
-	injectedErr := errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "vault: token renewal failed")
+	injectedErr := errcode.WrapInfra(errcode.ErrKeyProviderTransient, "vault: token renewal failed", nil)
 	fw.doneCh <- injectedErr
 
 	time.Sleep(testtime.MediumPoll) //archtest:allow:test-sleep wait for goroutine to enter blocking re-auth; no started observable

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -806,9 +806,13 @@ func TestIsTransientVaultError_ContextError(t *testing.T) {
 			wantTrans: true,
 		},
 		{
-			name:      "context.Canceled → transient",
+			// Post-206 unified semantic: context.Canceled is NOT transient
+			// (the caller gave up; retrying is pointless) — consistent with
+			// errcode.IsTransient and grpc-ecosystem retry defaults. Falls
+			// through step-4 (not a net error) → permanent.
+			name:      "context.Canceled → NOT transient (caller gave up)",
 			err:       context.Canceled,
-			wantTrans: true,
+			wantTrans: false,
 		},
 		{
 			name: "net.OpError → transient",

--- a/cells/auditcore/internal/appender/service.go
+++ b/cells/auditcore/internal/appender/service.go
@@ -151,6 +151,18 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) outbox.Ha
 			slog.Any("error", err),
 			slog.String("event_id", entry.ID),
 			slog.String("event_type", entry.EventType))
+		// Disposition 收口 (ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01):
+		// adapter classifiers now mark retry-safe failures via
+		// errcode.WrapInfra. A positively-transient error Requeues. A
+		// positively-permanent error (domain/validation/auth — classified,
+		// not infra) short-circuits to Reject → DLX instead of burning the
+		// whole retry budget. Unknown/ambiguous infra errors stay on the
+		// Requeue (retry-then-budget-DLX) path — fail-closed toward not
+		// losing an event on a transient blip. Mirrors the configreceive
+		// positive-permanent precedent.
+		if !errcode.IsTransient(err) && !errcode.IsInfraError(err) {
+			return outbox.Reject(outbox.NewPermanentError(err))
+		}
 		return outbox.Requeue(err)
 	}
 

--- a/cells/auditcore/internal/appender/service.go
+++ b/cells/auditcore/internal/appender/service.go
@@ -3,6 +3,7 @@ package appender
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -147,6 +148,19 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) outbox.Ha
 		}
 		return outbox.Emit(txCtx, s.emitter, dto.TopicAuditAppended, appendedEvent)
 	}); err != nil {
+		// Idempotent replay: the ledger already holds this entry (same
+		// content/EventID fingerprint), e.g. outbox redelivery or a parallel
+		// consumer-group. errcode.ErrAuditLedgerAlreadyExists is an idempotent
+		// SUCCESS — the entry is committed; the contract (pkg/errcode godoc)
+		// is "treat as already committed and not retry". Ack (not Requeue,
+		// not DLX) and log at Info, before the error-disposition path.
+		var dup *errcode.Error
+		if errors.As(err, &dup) && dup.Code == errcode.ErrAuditLedgerAlreadyExists {
+			s.logger.Info(logPrefix+": entry already appended (idempotent replay)",
+				slog.String("event_id", entry.ID),
+				slog.String("event_type", entry.EventType))
+			return outbox.Ack()
+		}
 		s.logger.Error(logPrefix+": failed to persist entry",
 			slog.Any("error", err),
 			slog.String("event_id", entry.ID),

--- a/cells/auditcore/internal/appender/service_test.go
+++ b/cells/auditcore/internal/appender/service_test.go
@@ -228,6 +228,53 @@ func TestService_HandleEvent_AppendFails_Requeue(t *testing.T) {
 	assert.False(t, errors.As(result.Err, &permErr), "transient persist error must NOT be PermanentError")
 }
 
+// TestService_HandleEvent_AppendFails_Classified verifies the disposition
+// 收口: a positively-classified transient store error is Requeued (retry),
+// while a positively-permanent error short-circuits to Reject → DLX instead
+// of blind-Requeuing and burning the whole retry budget.
+func TestService_HandleEvent_AppendFails_Classified(t *testing.T) {
+	cases := []struct {
+		name        string
+		storeErr    error
+		wantDisp    outbox.Disposition
+		wantPermErr bool
+	}{
+		{
+			name: "transient WrapInfra (PG serialization) → Requeue",
+			storeErr: errcode.WrapInfra(errcode.Code("ERR_ADAPTER_PG_QUERY"),
+				"serialization failure", errors.New("40001")),
+			wantDisp: outbox.DispositionRequeue,
+		},
+		{
+			name: "positively-permanent validation error → Reject → DLX",
+			storeErr: errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				"audit schema drift", errcode.WithCategory(errcode.CategoryValidation)),
+			wantDisp:    outbox.DispositionReject,
+			wantPermErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestProtocol(t)
+			realStore, err := ledger.NewMemStore(p, clock.Real())
+			require.NoError(t, err)
+			spec := newSpec(t, "auditappenduser", appender.ActorAcceptUserFallback)
+			svc := newService(t, spec, &failingStore{Store: realStore, err: tc.storeErr}, p)
+
+			entry := outbox.Entry{
+				ID:        "evt-cls",
+				EventType: "event.user.created.v1",
+				Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "admin-1"}),
+			}
+			result := svc.HandleEvent(context.Background(), entry)
+			assert.Equal(t, tc.wantDisp, result.Disposition)
+
+			var permErr *outbox.PermanentError
+			assert.Equal(t, tc.wantPermErr, errors.As(result.Err, &permErr))
+		})
+	}
+}
+
 // TestService_HandleEvent_Happy verifies the full happy path: ledger.Append +
 // outbox.Emit run inside the same RunInTx block (L2 OutboxFact pattern). We
 // observe the emit by injecting a recording emitter.

--- a/cells/auditcore/internal/appender/service_test.go
+++ b/cells/auditcore/internal/appender/service_test.go
@@ -252,6 +252,16 @@ func TestService_HandleEvent_AppendFails_Classified(t *testing.T) {
 			wantDisp:    outbox.DispositionReject,
 			wantPermErr: true,
 		},
+		{
+			// context.Canceled is infra (IsInfraError true) and NOT transient
+			// → predicate !IsTransient && !IsInfraError == false → Requeue.
+			// Locks the fail-closed direction: a future change to the
+			// predicate that drops the IsInfraError clause would wrongly
+			// Reject canceled-context store failures.
+			name:     "context.Canceled (infra, not transient) → Requeue",
+			storeErr: context.Canceled,
+			wantDisp: outbox.DispositionRequeue,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cells/auditcore/internal/appender/service_test.go
+++ b/cells/auditcore/internal/appender/service_test.go
@@ -285,6 +285,35 @@ func TestService_HandleEvent_AppendFails_Classified(t *testing.T) {
 	}
 }
 
+// TestService_HandleEvent_DuplicateReplay_Ack verifies the idempotent-replay
+// contract: redelivering the same entry (same content/EventID fingerprint)
+// makes ledger.Append return errcode.ErrAuditLedgerAlreadyExists, which the
+// handler must treat as an idempotent SUCCESS → Ack (not Requeue, not DLX).
+func TestService_HandleEvent_DuplicateReplay_Ack(t *testing.T) {
+	p := newTestProtocol(t)
+	realStore, err := ledger.NewMemStore(p, clock.Real())
+	require.NoError(t, err)
+	spec := newSpec(t, "auditappenduser", appender.ActorAcceptUserFallback)
+	svc := newService(t, spec, realStore, p)
+
+	entry := outbox.Entry{
+		ID:        "evt-dup",
+		EventType: "event.user.created.v1",
+		Payload:   mustJSON(t, map[string]any{"userId": "usr-1", "actorId": "admin-1"}),
+	}
+
+	first := svc.HandleEvent(context.Background(), entry)
+	require.Equal(t, outbox.DispositionAck, first.Disposition, "first append must succeed")
+
+	// Redelivery of the identical entry → ErrAuditLedgerAlreadyExists → Ack.
+	second := svc.HandleEvent(context.Background(), entry)
+	assert.Equal(t, outbox.DispositionAck, second.Disposition,
+		"idempotent replay must Ack, not Requeue/Reject")
+	var permErr *outbox.PermanentError
+	assert.False(t, errors.As(second.Err, &permErr),
+		"idempotent replay must not be a PermanentError")
+}
+
 // TestService_HandleEvent_Happy verifies the full happy path: ledger.Append +
 // outbox.Emit run inside the same RunInTx block (L2 OutboxFact pattern). We
 // observe the emit by injecting a recording emitter.

--- a/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_encrypt_test.go
@@ -61,7 +61,7 @@ const fakeNonce = "FAKENC123456" // 12 bytes
 
 func (f *fakeValueTransformer) Encrypt(_ context.Context, plaintext, aad []byte) (crypto.EncryptResult, error) {
 	if f.failEncrypt {
-		return crypto.EncryptResult{}, errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "fake: forced encrypt failure")
+		return crypto.EncryptResult{}, errcode.WrapInfra(errcode.ErrKeyProviderTransient, "fake: forced encrypt failure", nil)
 	}
 	// Fake cipher: XOR each byte with 0x55.
 	ct := make([]byte, len(plaintext))
@@ -1026,7 +1026,7 @@ func TestEncrypt_FailEncrypt_RoutesToErrConfigEncryptFailed(t *testing.T) {
 
 	t.Run("cryptoOpError direct — ErrConfigEncryptFailed transient", func(t *testing.T) {
 		repo := newConfigRepositoryFromDBTX(&mockDB{})
-		transient := errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "vault sealed")
+		transient := errcode.WrapInfra(errcode.ErrKeyProviderTransient, "vault sealed", nil)
 		ec := repo.cryptoOpError(errcode.ErrConfigEncryptFailed, "Encrypt", "key=foo", transient)
 		require.NotNil(t, ec)
 		assert.Equal(t, errcode.ErrConfigEncryptFailed, ec.Code)

--- a/cells/configcore/internal/adapters/postgres/config_repo_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_test.go
@@ -289,6 +289,16 @@ func TestConfigRepo_CryptoOpError_CauseAwareClassification(t *testing.T) {
 					"transient KeyProvider faults must remain CategoryInfra (Vault outage signal)")
 				assert.True(t, errcode.IsInfraError(ec),
 					"IsInfraError must stay true so existing infra alerts fire")
+				// Design contract (206): cryptoOpError re-wraps the transient
+				// cause with errcode.Wrap (NOT WrapInfra) under its own
+				// ErrConfig* code, so the OUTER error does not carry the
+				// transient marker — IsTransient(ec) is false by design. The
+				// retry-safe signal is preserved via CategoryInfra/IsInfraError
+				// (the auditcore disposition predicate keys on IsInfraError,
+				// not IsTransient, for this re-classified cell-layer error).
+				assert.False(t, errcode.IsTransient(ec),
+					"cryptoOpError Wrap intentionally drops the transient marker; "+
+						"callers route on IsInfraError, not IsTransient")
 			})
 		}
 	})

--- a/cells/configcore/internal/adapters/postgres/config_repo_test.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo_test.go
@@ -276,7 +276,7 @@ func TestConfigRepo_CryptoOpError_CauseAwareClassification(t *testing.T) {
 	})
 
 	t.Run("transient KeyProvider cause preserves CategoryInfra", func(t *testing.T) {
-		transient := errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient, "vault sealed")
+		transient := errcode.WrapInfra(errcode.ErrKeyProviderTransient, "vault sealed", nil)
 		for _, tc := range ops {
 			t.Run(tc.name, func(t *testing.T) {
 				ec := repo.cryptoOpError(tc.code, tc.op, "key=foo", transient)

--- a/docs/architecture/202605161800-adr-adapter-error-classification.md
+++ b/docs/architecture/202605161800-adr-adapter-error-classification.md
@@ -86,6 +86,7 @@ reported (exact count, both false-negative and false-positive drift caught).
 | dual truth source (code string vs marker) | n/a | ✅ single marker; vault migrated; old branch deleted |
 | transient-looking error forged outside funnel | ⚠️ any code | ✅ unexported field + archtest = Hard |
 | oidc/websocket adapters classified | ❌ | ❌ (declared out of scope; fail-closed safe) |
+| classifier unknown-error default symmetry | ⚠️ vault step-4 was fail-open (any unknown → transient) | ✅ all four classifiers fail-closed-on-unknown: vault step-4 now requires `*net.OpError`/`net.Error`, else permanent — symmetric with classifyPG/Redis/S3 |
 
 ## Consequences
 

--- a/docs/architecture/202605161800-adr-adapter-error-classification.md
+++ b/docs/architecture/202605161800-adr-adapter-error-classification.md
@@ -1,0 +1,101 @@
+# ADR: Adapter transient-error classification via the errcode.WrapInfra Hard funnel
+
+- Date: 2026-05-16
+- Status: Accepted
+- Refs: backlog `ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01` (cap-x-cross); plan
+  `docs/plans/202605121830-038-p0-p1-blocking-implementation-plan.md` Wave 4
+- Enforcement: archtest `ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01`
+
+## Context
+
+`adapters/{postgres,redis,s3}` returned flat `KindInternal` errors with no
+transient-vs-permanent distinction. Outbox consumers therefore could not make a
+backoff/DLX decision: `cells/auditcore/internal/appender/service.go` blind-
+`Requeue`d every store failure, so a permanent schema/marshal error burned the
+whole retry budget before reaching the DLX. The backlog trigger is "第 1 个
+handler disposition 收口".
+
+`errcode.IsTransient` previously keyed on a single Vault-specific code string
+(`ErrKeyProviderTransient`), unusable by other adapters.
+
+## Decision
+
+A single typed funnel **`errcode.WrapInfra(code, message, cause, opts…)`** is
+the only constructor that produces a transient (retry-safe) error. It sets
+`KindUnavailable` (HTTP 503) + `CategoryInfra` + a **private** `Error.transient`
+marker. There is no parallel `ErrAdapter*Transient` code set — transient-vs-
+permanent is the single Kind+marker axis, queryable in metrics by Kind.
+
+`errcode.IsTransient` is generalized to a single predicate (no parallel
+`IsAdapterTransient`):
+
+- `*errcode.Error` positive branch keys **only** on the private marker;
+- plus raw recognizers for un-wrapped low-level errors: `context.DeadlineExceeded`
+  (not `context.Canceled` — the caller gave up), `net.Error.Timeout()` (the
+  modern replacement for the deprecated `net.Error.Temporary()`, golang/go
+  #45729), and `errors.As(interface{ RetryableError() bool })` (the
+  pgconn.SafeToRetry / aws-sdk-go-v2 RetryableError idiom).
+
+The old `ec.Code == ErrKeyProviderTransient` branch is removed and
+`adapters/vault.classifyVaultError` migrated onto `WrapInfra` — **single truth
+source**, no dual recognition mechanism, no transitional shim.
+
+Per-adapter `classify{Postgres,Redis,S3}Error` stay in their adapter packages
+(they need `pgconn` / go-redis / smithy SDK types; adapters cannot depend on
+each other) and route their transient branch through `errcode.WrapInfra`,
+modeled on the pre-existing `adapters/vault.classifyVaultError` precedent.
+
+Adapter transient inventory:
+
+| Adapter | Transient when |
+|---------|----------------|
+| postgres | `pgconn.SafeToRetry`; SQLSTATE `40001` / `40P01`; class `08*`; ctx deadline |
+| redis | net timeout / ctx deadline / `i/o timeout`; server-recovering `CLUSTERDOWN` / `LOADING` / `TRYAGAIN` / `MASTERDOWN` |
+| s3 | HTTP 429 / 408 / 5xx; net timeout / ctx deadline |
+
+Consumer demonstrator: the auditcore appender now Requeues a positively-
+transient error, Rejects a positively-permanent classified error
+(domain/validation/auth — not infra) to DLX, and keeps unknown/ambiguous infra
+errors on the Requeue (retry-then-budget-DLX) path — fail-closed toward not
+losing an event on a transient blip. Mirrors the `configreceive` precedent.
+
+## Funnel double-lock grading (ai-collab.md §"Funnel 双向锁")
+
+| Side | Mechanism | Grade |
+|------|-----------|-------|
+| Upstream | transient marker producible only via `WrapInfra`; the field is unexported (Go type system forbids any package outside `pkg/errcode` from setting it) + archtest locks the in-package writer to func `WrapInfra` | **Hard** (type system + form-uniqueness archtest, the `panicregister.Approved` 范本) |
+| Downstream | `IsTransient`'s `*Error` positive branch keys only on the private marker — a transient-looking code built via `New`/`Wrap` is type-inexpressibly not transient | **Hard** |
+| Adapter routing presence | archtest `RunTypedProduction` resolves (via `*types.Info`) that each of postgres/redis/s3 calls `errcode.WrapInfra` | **Medium→Hard** (type-aware, fail-on-deviation) |
+
+Declared blind spot (compensated, not silent): archtest does **not** enforce
+that *every* adapter error site calls its `classify…`. An unclassified error
+carries no marker → `IsTransient` false → consumer Requeues (retry-then-budget-
+DLX) — the fail-closed safe degradation (never "wrongly retried-then-lost"). The
+broad no-bare-error sweep (covering oidc/websocket) is a separate larger rule
+outside this Cx3 PR. Reverse self-check:
+`TestAdapterErrorClassificationTransient01_FixturePattern` loads a real
+build-tag-gated package and asserts the two non-WrapInfra marker writes are
+reported (exact count, both false-negative and false-positive drift caught).
+
+## Coverage / threat re-eval
+
+| Concern | Before | After |
+|---------|--------|-------|
+| transient adapter error → Requeue | ❌ blind Requeue all | ✅ marker-driven |
+| permanent error burns retry budget | ❌ | ✅ positively-permanent → Reject (auditcore) |
+| dual truth source (code string vs marker) | n/a | ✅ single marker; vault migrated; old branch deleted |
+| transient-looking error forged outside funnel | ⚠️ any code | ✅ unexported field + archtest = Hard |
+| oidc/websocket adapters classified | ❌ | ❌ (declared out of scope; fail-closed safe) |
+
+## Consequences
+
+- Adapters emit semantically richer errors; consumers branch on
+  `errcode.IsTransient`.
+- New adapter classifiers must route transient through `errcode.WrapInfra` or
+  the archtest fails CI.
+- `net.Error.Temporary()` is never used (deprecated); the codebase standardizes
+  on `Timeout()` + `errors.As`.
+
+ref: jackc/pgx `pgconn` SafeToRetry; aws/aws-sdk-go-v2 `aws/retry`
+RetryableConnectionError/RetryableHTTPStatusCode; ThreeDotsLabs/watermill
+retry middleware (caller-decides predicate); golang/go #45729.

--- a/docs/contributing/adapter-checklist.md
+++ b/docs/contributing/adapter-checklist.md
@@ -28,18 +28,27 @@ Reference: `docs/architecture/metadata-model-v3.md`, `gocell validate`.
 All errors returned from the adapter's public API must use `pkg/errcode` and
 follow the three-way classification:
 
-| Class | Code | When |
-|-------|------|------|
-| Permanent / not-found | `ErrKeyProvider*NotFound`, `ErrConfigKeyMissing` | 4xx from external system, missing resource |
-| Transient | `ErrKeyProviderTransient` | 5xx, network timeout, sealed vault |
-| Config missing | `ErrConfigKeyMissing` | Required env var absent at startup |
+| Class | Constructor | When |
+|-------|-------------|------|
+| Permanent / not-found | `errcode.Wrap(KindInternal, <opCode>, …)` | 4xx from external system, missing resource, schema/marshal |
+| Transient | **`errcode.WrapInfra(<opCode>, …, cause)`** | 5xx / 429 / 408, network timeout, ctx deadline, server-recovering states |
+| Config missing | `errcode.New(<code>, …)` | Required env var absent at startup |
 
 Rules:
 - Never wrap with bare `fmt.Errorf(...)` that loses errcode identity.
-- Return the `classifyVaultReadError(err)` (or equivalent classifier) output
-  directly — do not re-wrap with an additional `fmt.Errorf("... : %w", err)`.
-- The `isTransientVaultError` / `classifyVaultError` pattern is the canonical
-  implementation; copy the structure, not the strings.
+- The transient class **must** go through the single funnel
+  `errcode.WrapInfra` (sets `KindUnavailable` + `CategoryInfra` + the private
+  transient marker that `errcode.IsTransient` keys on). Do **not** hand-build
+  `errcode.Wrap(KindUnavailable, …)` for a transient — archtest
+  `ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01` enforces the funnel (Hard
+  double-lock; ADR `docs/architecture/202605161800-adr-adapter-error-classification.md`).
+- Return the `classify{Adapter}Error(err)` output directly — do not re-wrap
+  with an additional `fmt.Errorf("… : %w", err)`.
+- The `classifyVaultError` / `classifyPGError` / `classifyRedisError` /
+  `classifyS3Error` pattern is the canonical implementation; copy the
+  structure, not the strings. There is no per-adapter `ErrAdapter*Transient`
+  code — reuse the operation code; transient-vs-permanent is the Kind+marker
+  axis.
 
 Sample: `adapters/vault/transit_provider.go::classifyVaultError`,
 `classifyVaultReadError`, `NewTransitKeyProviderFromEnv`.

--- a/pkg/errcode/classify.go
+++ b/pkg/errcode/classify.go
@@ -137,32 +137,47 @@ func WrapInfra(code Code, message string, cause error, opts ...Option) *Error {
 //	}
 //	return outbox.Reject(outbox.NewPermanentError(err))
 //
-// It returns true when, anywhere in the Unwrap chain:
-//   - an *Error carries the WrapInfra transient marker (the single recognized
-//     *Error signal — downstream Hard: a transient-looking code constructed
-//     via New/Wrap without WrapInfra is NOT transient); or
-//   - the error is context.DeadlineExceeded (a deadline may succeed on retry);
-//     context.Canceled is deliberately NOT transient (the caller gave up); or
-//   - a net.Error reports Timeout()==true (modern replacement for the
-//     deprecated net.Error.Temporary(), golang/go #45729); or
-//   - an error implements interface{ RetryableError() bool } returning true
-//     (the pgconn.SafeToRetry / aws-sdk-go-v2 RetryableError idiom, letting
-//     raw SDK errors be recognized before adapter wrapping).
+// Classification is two-tier and the outer tier is authoritative:
 //
-// Returns false for nil. Uses errors.As/Is so it traverses chains produced by
-// fmt.Errorf("…: %w", err).
+//  1. If the chain contains any *errcode.Error, the OUTERMOST one's WrapInfra
+//     transient marker is the final answer — return ec.transient and stop.
+//     A re-wrap via Wrap/New is a deliberate RE-CLASSIFICATION: the outer
+//     layer owns the disposition decision, so an inner WrapInfra marker does
+//     NOT leak through an outer permanent re-wrap (e.g. configcore
+//     cryptoOpError re-wraps a vault-transient cause as a config-layer
+//     KindInternal error and is routed via IsInfraError, not IsTransient).
+//     Raw recognizers (tier 2) are NOT consulted once the error is classified
+//     — a classified-permanent error stays permanent even if some inner cause
+//     looks network-ish. This is the open-source consensus (gRPC/AWS SDK v2/
+//     Kratos: the boundary classifier's decision wins; re-wrap = re-classify)
+//     and keeps the WrapInfra funnel single-sourced.
+//  2. Only when the chain contains NO *errcode.Error (a raw, un-classified
+//     low-level error) are these recognized as transient:
+//     - context.DeadlineExceeded (a deadline may not recur on retry);
+//     context.Canceled is NOT transient (the caller gave up);
+//     - net.Error with Timeout()==true (modern replacement for the
+//     deprecated net.Error.Temporary(), golang/go #45729);
+//     - interface{ RetryableError() bool } == true (pgconn.SafeToRetry /
+//     aws-sdk-go-v2 RetryableError idiom for raw SDK errors).
+//
+// errors.As binds the outermost *Error (fmt.Errorf("…: %w", WrapInfra(…))
+// still yields the WrapInfra *Error as the first — and only — *Error, so
+// fmt-wrapping is transparent; only an outer errcode.Wrap/New re-classifies).
+//
+// Returns false for nil.
 func IsTransient(err error) bool {
 	if err == nil {
 		return false
 	}
 
+	// Tier 1: a classified *errcode.Error is authoritative (outermost wins).
 	var ec *Error
-	if errors.As(err, &ec) && ec.transient {
-		return true
+	if errors.As(err, &ec) {
+		return ec.transient
 	}
 
-	// context.Canceled is intentionally excluded: a canceled parent context
-	// means the work is no longer wanted; retrying is pointless.
+	// Tier 2: raw, un-classified low-level error only.
+	// context.Canceled is intentionally excluded (caller gave up).
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}

--- a/pkg/errcode/classify.go
+++ b/pkg/errcode/classify.go
@@ -3,6 +3,7 @@ package errcode
 import (
 	"context"
 	"errors"
+	"net"
 	"slices"
 )
 
@@ -95,32 +96,88 @@ func IsDomainNotFound(err error, codes ...Code) bool {
 	return slices.Contains(codes, ec.Code)
 }
 
-// IsTransient reports whether err, or any error in its Unwrap chain, carries
-// the ErrKeyProviderTransient code. It is the canonical predicate for routing
-// KeyProvider failures in EventBus handlers:
+// WrapInfra is the single typed funnel for producing a transient (retry-safe)
+// infrastructure error. It is the ONLY constructor that sets the private
+// Error.transient marker — adapter classifiers (classifyPGError /
+// classifyRedisError / classifyS3Error) route their transient branch through
+// it so that IsTransient can recognize the result.
+//
+// Behavior:
+//   - Kind = KindUnavailable (HTTP 503 "retry after a brief delay")
+//   - Category = CategoryInfra
+//   - Code = the caller's operation code (e.g. ERR_ADAPTER_PG_QUERY) — there
+//     is no parallel ErrAdapter*Transient code set; transient-vs-permanent is
+//     the single Kind+marker axis, queryable in metrics by Kind.
+//   - the private transient marker is set true
+//
+// The const-literal restriction documented on New applies to message.
+//
+// Funnel double-lock (per .claude/rules/gocell/ai-collab.md "Funnel 双向锁"):
+//   - upstream Hard: a transient adapter error is producible only via this
+//     function; the marker field is unexported so no package outside errcode
+//     can set it.
+//   - downstream Hard: IsTransient's *Error positive branch keys only on the
+//     marker, never on a code string.
+//
+// archtest ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 enforces both sides.
+//
+// ref: jackc/pgx pgconn SafeToRetry; aws/aws-sdk-go-v2 aws/retry RetryableError.
+func WrapInfra(code Code, message string, cause error, opts ...Option) *Error {
+	e := Wrap(KindUnavailable, code, message, cause, opts...)
+	e.Category = CategoryInfra
+	e.transient = true
+	return e
+}
+
+// IsTransient reports whether err is a transient (retry-safe) condition that
+// an EventBus handler should Requeue rather than Reject:
 //
 //	if errcode.IsTransient(err) {
 //	    return outbox.Requeue(err)
 //	}
-//	return outbox.Reject(err)
+//	return outbox.Reject(outbox.NewPermanentError(err))
 //
-// Transient conditions map to Vault HTTP 503 / 429 / 408 / 499 (sealed,
-// rate-limited, request timeout). All other KeyProvider errors are permanent
-// (400 / 403 / 404) and must be routed to DispositionReject → DLX.
+// It returns true when, anywhere in the Unwrap chain:
+//   - an *Error carries the WrapInfra transient marker (the single recognized
+//     *Error signal — downstream Hard: a transient-looking code constructed
+//     via New/Wrap without WrapInfra is NOT transient); or
+//   - the error is context.DeadlineExceeded (a deadline may succeed on retry);
+//     context.Canceled is deliberately NOT transient (the caller gave up); or
+//   - a net.Error reports Timeout()==true (modern replacement for the
+//     deprecated net.Error.Temporary(), golang/go #45729); or
+//   - an error implements interface{ RetryableError() bool } returning true
+//     (the pgconn.SafeToRetry / aws-sdk-go-v2 RetryableError idiom, letting
+//     raw SDK errors be recognized before adapter wrapping).
 //
-// Returns false for nil. Uses errors.As so it correctly traverses chains
-// produced by fmt.Errorf("…: %w", err).
-//
-// ref: aws/aws-encryption-sdk-python src/aws_encryption_sdk/exceptions.py
+// Returns false for nil. Uses errors.As/Is so it traverses chains produced by
+// fmt.Errorf("…: %w", err).
 func IsTransient(err error) bool {
 	if err == nil {
 		return false
 	}
+
 	var ec *Error
-	if !errors.As(err, &ec) {
-		return false
+	if errors.As(err, &ec) && ec.transient {
+		return true
 	}
-	return ec.Code == ErrKeyProviderTransient
+
+	// context.Canceled is intentionally excluded: a canceled parent context
+	// means the work is no longer wanted; retrying is pointless.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	var retryable interface{ RetryableError() bool }
+	if errors.As(err, &retryable) {
+		return retryable.RetryableError()
+	}
+
+	return false
 }
 
 // IsExpected4xx reports whether err maps to an HTTP 400-499 response code.

--- a/pkg/errcode/classify_test.go
+++ b/pkg/errcode/classify_test.go
@@ -1,0 +1,94 @@
+package errcode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// timeoutErr is a net.Error whose Timeout() reports true — the modern
+// replacement for the deprecated net.Error.Temporary() (golang/go #45729).
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return false }
+
+var _ net.Error = timeoutErr{}
+
+// retryableErr implements the anonymous interface{ RetryableError() bool }
+// adapter contract (pgconn.SafeToRetry / aws-sdk-go-v2 RetryableError idiom).
+type retryableErr struct{ retry bool }
+
+func (e retryableErr) Error() string        { return "adapter op" }
+func (e retryableErr) RetryableError() bool { return e.retry }
+
+func TestWrapInfra_SetsMarkerAndKind(t *testing.T) {
+	cause := errors.New("conn reset")
+	err := WrapInfra(Code("ERR_ADAPTER_PG_QUERY"), "pg query failed", cause)
+
+	var ec *Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("WrapInfra must produce *errcode.Error, got %T", err)
+	}
+	assert.Equal(t, KindUnavailable, ec.Kind, "WrapInfra → KindUnavailable (HTTP 503)")
+	assert.Equal(t, CategoryInfra, ec.Category, "WrapInfra → CategoryInfra")
+	assert.Equal(t, Code("ERR_ADAPTER_PG_QUERY"), ec.Code, "WrapInfra reuses caller operation code")
+	assert.ErrorIs(t, err, cause, "WrapInfra preserves the cause chain")
+	assert.True(t, IsTransient(err), "WrapInfra output is transient")
+}
+
+func TestIsTransient_MarkerKeyed(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"WrapInfra direct", WrapInfra(Code("ERR_ADAPTER_REDIS_GET"), "redis get failed", errors.New("x")), true},
+		{"WrapInfra wrapped", fmt.Errorf("svc: %w", WrapInfra(Code("ERR_ADAPTER_S3_UPLOAD"), "s3 upload failed", errors.New("x"))), true},
+		// Downstream Hard: the transient code constructed via New (no WrapInfra
+		// marker) must NOT be transient — "looks transient but didn't pass
+		// WrapInfra" is not recognized.
+		{"code via New only", New(KindUnavailable, ErrKeyProviderTransient, "sealed"), false},
+		{"plain permanent errcode", New(KindInternal, ErrKeyProviderEncryptFailed, "encrypt failed"), false},
+		// Raw low-level recognizers (un-wrapped stdlib / SDK errors).
+		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+		{"wrapped DeadlineExceeded", fmt.Errorf("dial: %w", context.DeadlineExceeded), true},
+		{"context.Canceled NOT transient", context.Canceled, false},
+		{"net.Error Timeout()", timeoutErr{}, true},
+		{"wrapped net timeout", fmt.Errorf("redis: %w", timeoutErr{}), true},
+		{"RetryableError()=true", retryableErr{retry: true}, true},
+		{"RetryableError()=false", retryableErr{retry: false}, false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsTransient(tc.err))
+		})
+	}
+}
+
+// Disposition routing contract: transient → Requeue, permanent → Reject.
+func TestIsTransient_DispositionContract(t *testing.T) {
+	transient := WrapInfra(Code("ERR_ADAPTER_PG_QUERY"), "serialization failure", errors.New("40001"))
+	permanent := New(KindInternal, Code("ERR_ADAPTER_PG_QUERY"), "schema drift")
+
+	assert.True(t, IsTransient(transient), "serialization failure requeues")
+	assert.False(t, IsTransient(permanent), "schema drift → Reject → DLX")
+}
+
+func TestWrapInfra_NilCauseTolerated(t *testing.T) {
+	err := WrapInfra(Code("ERR_ADAPTER_REDIS_SET"), "redis set failed", nil)
+	assert.True(t, IsTransient(err))
+	var ec *Error
+	assert.True(t, errors.As(err, &ec))
+	assert.Nil(t, ec.Cause)
+}
+
+var _ = time.Second // keep time import stable for future deadline cases

--- a/pkg/errcode/classify_test.go
+++ b/pkg/errcode/classify_test.go
@@ -91,4 +91,38 @@ func TestWrapInfra_NilCauseTolerated(t *testing.T) {
 	assert.Nil(t, ec.Cause)
 }
 
+// TestIsTransient_TwoTierAuthority locks the two-tier semantic (F2/F3):
+// a classified *errcode.Error is authoritative (outermost wins, re-wrap =
+// re-classify); raw recognizers apply ONLY when the chain has no *Error.
+func TestIsTransient_TwoTierAuthority(t *testing.T) {
+	inner := WrapInfra(Code("ERR_ADAPTER_PG_QUERY"), "serialization failure",
+		errors.New("40001"))
+
+	// F2: an outer permanent errcode.Wrap re-classifies — the inner WrapInfra
+	// marker must NOT leak through (re-classification wins).
+	reclassified := Wrap(KindInternal, Code("ERR_CONFIG_DECRYPT_FAILED"),
+		"config decrypt failed", inner)
+	assert.False(t, IsTransient(reclassified),
+		"outer permanent Wrap re-classifies; inner WrapInfra marker must not leak")
+
+	// fmt.Errorf wrapping is transparent: WrapInfra stays the outermost (only)
+	// *Error, so the marker is still authoritative → transient.
+	assert.True(t, IsTransient(fmt.Errorf("svc: %w", inner)),
+		"fmt.Errorf wrap is transparent; WrapInfra marker still authoritative")
+
+	// F3: a classified-permanent *Error whose cause is a raw transient-looking
+	// error (ctx.DeadlineExceeded) stays permanent — tier-2 raw recognizers
+	// are NOT consulted once the error is classified.
+	permWrapsDeadline := Wrap(KindInternal, Code("ERR_ADAPTER_PG_QUERY"),
+		"schema drift", context.DeadlineExceeded)
+	assert.False(t, IsTransient(permWrapsDeadline),
+		"classified-permanent must not be overridden by an inner ctx.DeadlineExceeded")
+
+	// Tier 2 still works for genuinely un-classified raw errors.
+	assert.True(t, IsTransient(context.DeadlineExceeded),
+		"bare ctx.DeadlineExceeded (no *Error) → tier-2 transient")
+	assert.True(t, IsTransient(fmt.Errorf("dial: %w", context.DeadlineExceeded)),
+		"fmt-wrapped bare ctx.DeadlineExceeded (no *Error) → tier-2 transient")
+}
+
 var _ = time.Second // keep time import stable for future deadline cases

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -820,6 +820,14 @@ type Error struct {
 	Details         []slog.Attr
 	Cause           error
 	Category        Category
+
+	// transient is the private retry-disposition marker. It is the single
+	// recognized signal for IsTransient's *Error positive branch (downstream
+	// Hard: "looks transient but didn't pass WrapInfra" is type-inexpressible
+	// outside this package). It is set ONLY by WrapInfra — never by New, Wrap,
+	// Assertion, or any Option. archtest ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01
+	// statically asserts no other assignment site exists in pkg/errcode.
+	transient bool
 }
 
 // FindAttr returns the first detail attribute whose Key matches key, or the

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -389,11 +389,18 @@ const (
 	// ErrKeyProviderKeyNotFound / ErrKeyProviderRotateFailed, which signal
 	// permanent conditions (400 Bad Request, 403 Forbidden, 404 Not Found).
 	//
-	// EventBus Disposition routing:
-	//   - ErrKeyProviderTransient → DispositionRequeue (back-off retry)
-	//   - All other KeyProvider errors → DispositionReject (DLX)
+	// EventBus Disposition routing is driven by the WrapInfra transient
+	// marker, NOT by this code string (post-206). An error carries transient
+	// semantics only when constructed via WrapInfra (which sets the private
+	// Error.transient marker that IsTransient keys on):
 	//
-	// Use IsTransient to check the full error chain.
+	//   - WrapInfra(ErrKeyProviderTransient, …) → IsTransient true → Requeue
+	//   - New/Wrap(KindUnavailable, ErrKeyProviderTransient, …) → IsTransient
+	//     FALSE (no marker) → not transient. Do not hand-build this code and
+	//     expect Requeue; route through WrapInfra (vault.classifyVaultError).
+	//
+	// Use IsTransient(err) to check the full error chain — never compare
+	// against this code string for disposition.
 	//
 	// ref: aws/aws-encryption-sdk-python src/aws_encryption_sdk/exceptions.py
 	// (GenerateKeyError / DecryptKeyError transient vs permanent split).

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -114,8 +114,13 @@ func TestIsDomainNotFound(t *testing.T) {
 }
 
 func TestIsTransientAndExpected4xx(t *testing.T) {
-	assert.True(t, IsTransient(New(KindUnavailable, ErrKeyProviderTransient, "vault sealed")))
-	assert.True(t, IsTransient(fmt.Errorf("wrap: %w", New(KindUnavailable, ErrKeyProviderTransient, "vault sealed"))))
+	// Post-206: transient classification is the WrapInfra marker, not the
+	// ErrKeyProviderTransient code string. Constructing the code via New
+	// alone no longer makes it transient (downstream Hard).
+	sealed := WrapInfra(ErrKeyProviderTransient, "vault sealed", errors.New("sealed"))
+	assert.True(t, IsTransient(sealed))
+	assert.True(t, IsTransient(fmt.Errorf("wrap: %w", sealed)))
+	assert.False(t, IsTransient(New(KindUnavailable, ErrKeyProviderTransient, "vault sealed")))
 	assert.False(t, IsTransient(New(KindInternal, ErrKeyProviderEncryptFailed, "encrypt failed")))
 
 	assert.True(t, IsExpected4xx(New(KindInvalid, ErrValidationFailed, "bad")))

--- a/runtime/crypto/value_transformer_test.go
+++ b/runtime/crypto/value_transformer_test.go
@@ -331,8 +331,8 @@ func (h *transientErrorHandle) ID() string { return "transient-key" }
 
 // Encrypt returns ErrKeyProviderTransient — simulating a Vault 503 or network timeout.
 func (h *transientErrorHandle) Encrypt(_ context.Context, _, _ []byte) (crypto.EncryptResult, error) {
-	return crypto.EncryptResult{}, errcode.New(errcode.KindUnavailable, errcode.ErrKeyProviderTransient,
-		"vault: service unavailable (503)")
+	return crypto.EncryptResult{}, errcode.WrapInfra(errcode.ErrKeyProviderTransient,
+		"vault: service unavailable (503)", nil)
 }
 
 func (h *transientErrorHandle) Decrypt(_ context.Context, _, _, _, _ []byte) ([]byte, error) {

--- a/tools/archtest/adapter_error_classification_test.go
+++ b/tools/archtest/adapter_error_classification_test.go
@@ -34,6 +34,17 @@
 //     IsTransient false → consumer Requeues on the retry-then-budget-DLX path
 //     (fail-closed toward not losing an event). The broad no-bare-error sweep
 //     covering oidc/websocket is a separate, larger rule out of this PR's Cx3.
+//  5. Field address taken then written through the pointer
+//     (`p := &e.transient; *p = true`): the SelectorExpr is nested in a
+//     UnaryExpr (RHS of a different AssignStmt), not a direct AssignStmt-LHS
+//     child, so the AST scan does not see it. Compensation: the field is
+//     unexported — outside pkg/errcode this is a compile error (Go type
+//     system, the true Hard line); inside pkg/errcode the established
+//     convention is direct `e.transient = …` (caught) and the deref form
+//     `(*e).transient = …` is also caught (locked by fixture badDeref). The
+//     address-taken form is exotic, in-package only, and additionally caught
+//     by code review. Not closing it in the AST scan keeps the rule simple;
+//     the type-system Hard line already bounds the blast radius to this file.
 //
 // Reverse self-check: TestAdapterErrorClassificationTransient01_FixturePattern
 // loads a real build-tag-gated package whose transient-marker writes outside
@@ -129,10 +140,10 @@ func TestAdapterErrorClassificationTransient01_FixturePattern(t *testing.T) {
 	for _, d := range diags {
 		t.Log(d.Message)
 	}
-	require.Len(t, diags, 2,
-		"fixture must yield exactly 2 RED writes (badAssign assignment + "+
-			"badLiteral composite literal); WrapInfra writer and readOnly read "+
-			"must not be flagged")
+	require.Len(t, diags, 3,
+		"fixture must yield exactly 3 RED writes (badAssign assignment + "+
+			"badLiteral composite literal + badDeref (*e).transient); WrapInfra "+
+			"writer and readOnly read must not be flagged")
 
 	joined := ""
 	for _, d := range diags {
@@ -140,6 +151,7 @@ func TestAdapterErrorClassificationTransient01_FixturePattern(t *testing.T) {
 	}
 	assert.Contains(t, joined, "in badAssign (assignment)")
 	assert.Contains(t, joined, "in badLiteral (composite literal)")
+	assert.Contains(t, joined, "in badDeref (assignment)")
 	assert.NotContains(t, joined, "in WrapInfra")
 	assert.NotContains(t, joined, "in readOnly")
 }
@@ -171,7 +183,8 @@ func scanTransientMarkerWrites(p *Pass, errcodePkgPath, writerFunc string) []Dia
 				Message: fmt.Sprintf(
 					"errcode.Error.%s written in %s (%s); only func %s may set the "+
 						"transient marker (ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01)",
-					transientMarkerField, where, form, writerFunc),
+					transientMarkerField, where, form, writerFunc,
+				),
 			})
 		}
 		EachInSubtree[ast.AssignStmt](file, func(as *ast.AssignStmt) {

--- a/tools/archtest/adapter_error_classification_test.go
+++ b/tools/archtest/adapter_error_classification_test.go
@@ -8,10 +8,11 @@
 //     func WrapInfra. The field is unexported (Go type system forbids any
 //     package outside pkg/errcode from setting it at all); this archtest adds
 //     the in-package lock so no future New/Wrap/Assertion/Option sets it.
-//   - Upstream Hard: each in-scope adapter (postgres / redis / s3) routes its
-//     transient branch through errcode.WrapInfra — verified by a type-aware
-//     call-resolution presence check, so dropping an adapter's classifier
-//     fails CI.
+//   - Upstream Hard: each in-scope adapter (postgres / redis / s3) declares a
+//     classify…Error function WHOSE BODY routes through errcode.WrapInfra —
+//     verified by type-aware call resolution scoped to that function (a stray
+//     or dead-code WrapInfra call elsewhere in the package does NOT satisfy
+//     it), so dropping/bypassing an adapter's classifier fails CI.
 //
 // Tool: archtest.RunTypedProduction (040 Pass-Driver) + *types.Info call /
 // field resolution. NOT registered in internal/archtestmeta.LegacyAllowlist.
@@ -56,6 +57,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,15 +102,16 @@ func TestAdapterErrorClassificationTransient01(t *testing.T) {
 		if _, tracked := wantAdapters[p.Pkg.Path()]; !tracked {
 			return nil
 		}
-		if packageCallsWrapInfra(p, errcodePkgPath) {
+		if classifierRoutesThroughWrapInfra(p, errcodePkgPath) {
 			wantAdapters[p.Pkg.Path()] = true
 		}
 		return nil
 	})
 	for pkg, present := range wantAdapters {
 		assert.Truef(t, present,
-			"adapter %s must route its transient branch through errcode.WrapInfra "+
-				"(ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 upstream Hard)", pkg)
+			"adapter %s must declare a classify…Error function whose body routes "+
+				"through errcode.WrapInfra (ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 "+
+				"upstream Hard — package-level presence is insufficient)", pkg)
 	}
 }
 
@@ -230,24 +233,58 @@ func isErrcodeTransientField(info *types.Info, ident *ast.Ident, errcodePkgPath 
 	return v.Pkg() != nil && v.Pkg().Path() == errcodePkgPath
 }
 
-// packageCallsWrapInfra reports whether p contains at least one call whose
-// callee resolves to errcodePkgPath.WrapInfra (qualified or dot-imported).
-func packageCallsWrapInfra(p *Pass, errcodePkgPath string) bool {
+// classifierFuncNamePattern matches the per-adapter classifier function
+// (classifyPGError / classifyRedisError / classifyS3Error). Anchoring the
+// scan to this function — rather than the whole package — means a stray /
+// dead-code / unrelated errcode.WrapInfra call elsewhere in the adapter does
+// NOT satisfy the upstream lock: the classifier itself must route through
+// the funnel.
+var classifierFuncNamePattern = regexp.MustCompile(`^classify\w*Error$`)
+
+// classifierRoutesThroughWrapInfra reports whether p declares a
+// classify…Error function whose body contains a call resolving to
+// errcodePkgPath.WrapInfra. This proves the classifier's transient branch is
+// wired through the funnel, not merely that the package mentions WrapInfra
+// somewhere (F7: package-presence was too weak — dead code passed it).
+func classifierRoutesThroughWrapInfra(p *Pass, errcodePkgPath string) bool {
 	if p.TypesInfo == nil {
 		return false
 	}
-	found := false
 	for _, file := range p.Files {
-		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-			if found {
-				return
+		// FindFirstChild is the typed depth-1 funnel (SCANNER-FRAMEWORK-USAGE-02:
+		// no caller-held sentinel over EachInChildren). FuncDecl is a direct
+		// child of *ast.File.
+		_, ok := FindFirstChild[ast.FuncDecl](file, func(fd *ast.FuncDecl) bool {
+			if fd.Body == nil || fd.Name == nil {
+				return false
 			}
-			pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
-			if ok && pkgPath == errcodePkgPath && name == transientMarkerWriterFunc {
-				found = true
+			if !classifierFuncNamePattern.MatchString(fd.Name.Name) {
+				return false
 			}
+			return funcBodyCallsWrapInfra(p.TypesInfo, fd.Body, errcodePkgPath)
 		})
+		if ok {
+			return true
+		}
 	}
+	return false
+}
+
+// funcBodyCallsWrapInfra reports whether body contains a call resolving to
+// errcodePkgPath.WrapInfra. EachInSubtree (recursive) is required because the
+// call is nested (inside an IfStmt/ReturnStmt); USAGE-02 monitors only the
+// depth-1 EachInChildren sentinel, not the subtree walk.
+func funcBodyCallsWrapInfra(info *types.Info, body *ast.BlockStmt, errcodePkgPath string) bool {
+	found := false
+	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+		if found {
+			return
+		}
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if ok && pkgPath == errcodePkgPath && name == transientMarkerWriterFunc {
+			found = true
+		}
+	})
 	return found
 }
 

--- a/tools/archtest/adapter_error_classification_test.go
+++ b/tools/archtest/adapter_error_classification_test.go
@@ -1,0 +1,255 @@
+// INVARIANT: ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01
+//
+// Hard funnel double-lock for adapter transient-error classification
+// (ai-collab.md §"Funnel 双向锁" + §"Hard 范本" typed-function-call form).
+//
+//   - Downstream Hard: the private errcode.Error.transient marker — the single
+//     signal errcode.IsTransient keys on for *Error — is WRITTEN only inside
+//     func WrapInfra. The field is unexported (Go type system forbids any
+//     package outside pkg/errcode from setting it at all); this archtest adds
+//     the in-package lock so no future New/Wrap/Assertion/Option sets it.
+//   - Upstream Hard: each in-scope adapter (postgres / redis / s3) routes its
+//     transient branch through errcode.WrapInfra — verified by a type-aware
+//     call-resolution presence check, so dropping an adapter's classifier
+//     fails CI.
+//
+// Tool: archtest.RunTypedProduction (040 Pass-Driver) + *types.Info call /
+// field resolution. NOT registered in internal/archtestmeta.LegacyAllowlist.
+//
+// Declared blind spots (ai-collab.md §"工具选定后强制盲区自检"), each with a
+// compensating argument and/or reverse self-check fixture:
+//
+//  1. Reflective field set (reflect.Value.SetBool on transient): impossible —
+//     transient is unexported, reflect cannot set an unexported field of a
+//     type defined in another package, and within pkg/errcode no reflect path
+//     touches it. Compensation: Go type system (not archtest-bound).
+//  2. Cross-package Error literal with transient set: a compile error outside
+//     pkg/errcode (unexported field). Compensation: Go type system.
+//  3. WrapInfra reached via a func-value indirection (var f = errcode.WrapInfra;
+//     f(...)): info.Uses still resolves the selector to the *types.Func, so the
+//     upstream presence check still counts it. Covered, not a gap.
+//  4. "Every adapter error site calls classify…" is intentionally NOT enforced
+//     (declared blind spot — see plan §"Fail-closed rationale" + ADR
+//     202605161800): an unclassified adapter error carries no marker →
+//     IsTransient false → consumer Requeues on the retry-then-budget-DLX path
+//     (fail-closed toward not losing an event). The broad no-bare-error sweep
+//     covering oidc/websocket is a separate, larger rule out of this PR's Cx3.
+//
+// Reverse self-check: TestAdapterErrorClassificationTransient01_FixturePattern
+// loads a real build-tag-gated package whose transient-marker writes outside
+// "WrapInfra" MUST be reported; bypassing requires editing real source.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// transientMarkerWriterFunc is the single function name allowed to write the
+// errcode.Error.transient marker. Form-uniqueness anchor (ai-collab Hard 范本).
+const transientMarkerWriterFunc = "WrapInfra"
+
+// transientMarkerField is the unexported marker field name on errcode.Error.
+const transientMarkerField = "transient"
+
+func TestAdapterErrorClassificationTransient01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+
+	errcodePkgPath := modPath + "/pkg/errcode"
+
+	// Downstream Hard: scan pkg/errcode; every write to Error.transient must
+	// be lexically inside func WrapInfra.
+	downstream := RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != errcodePkgPath {
+			return nil
+		}
+		return scanTransientMarkerWrites(p, errcodePkgPath, transientMarkerWriterFunc)
+	})
+	Report(t, "ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01", downstream)
+
+	// Upstream Hard: each in-scope adapter must route through errcode.WrapInfra.
+	wantAdapters := map[string]bool{
+		modPath + "/adapters/postgres": false,
+		modPath + "/adapters/redis":    false,
+		modPath + "/adapters/s3":       false,
+	}
+	_ = RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		if _, tracked := wantAdapters[p.Pkg.Path()]; !tracked {
+			return nil
+		}
+		if packageCallsWrapInfra(p, errcodePkgPath) {
+			wantAdapters[p.Pkg.Path()] = true
+		}
+		return nil
+	})
+	for pkg, present := range wantAdapters {
+		assert.Truef(t, present,
+			"adapter %s must route its transient branch through errcode.WrapInfra "+
+				"(ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 upstream Hard)", pkg)
+	}
+}
+
+// TestAdapterErrorClassificationTransient01_FixturePattern is the reverse
+// self-check (ai-collab.md §"工具选定后强制盲区自检"): a real build-tag-gated
+// package whose two non-WrapInfra transient-marker writes (assignment +
+// composite literal) MUST be reported, while the WrapInfra writer and a
+// read-only access MUST NOT. Asserts the exact count to catch both
+// false-negative drift (detector goes blind) and false-positive drift
+// (detector flags reads / the allowed writer).
+func TestAdapterErrorClassificationTransient01_FixturePattern(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+
+	fixturePkgPath := modPath + "/tools/archtest/internal/transientmarkerfixture"
+	fixturePattern := "./tools/archtest/internal/transientmarkerfixture/..."
+
+	diags := RunTyped(t, TypedOpts{Tests: false, Tags: []string{"archtest_fixture"}},
+		[]string{fixturePattern},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != fixturePkgPath {
+				return nil
+			}
+			return scanTransientMarkerWrites(p, fixturePkgPath, transientMarkerWriterFunc)
+		})
+
+	for _, d := range diags {
+		t.Log(d.Message)
+	}
+	require.Len(t, diags, 2,
+		"fixture must yield exactly 2 RED writes (badAssign assignment + "+
+			"badLiteral composite literal); WrapInfra writer and readOnly read "+
+			"must not be flagged")
+
+	joined := ""
+	for _, d := range diags {
+		joined += d.Message + "\n"
+	}
+	assert.Contains(t, joined, "in badAssign (assignment)")
+	assert.Contains(t, joined, "in badLiteral (composite literal)")
+	assert.NotContains(t, joined, "in WrapInfra")
+	assert.NotContains(t, joined, "in readOnly")
+}
+
+// scanTransientMarkerWrites reports every write to the errcodePkgPath.Error
+// field named transient whose enclosing top-level func is not writerFunc.
+// Write sites: AssignStmt LHS selector `.transient`, and CompositeLit
+// `Error{transient: …}` keyed element. Reads (e.g. `if ec.transient` in
+// IsTransient) are not write sites and are not reported.
+func scanTransientMarkerWrites(p *Pass, errcodePkgPath, writerFunc string) []Diagnostic {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	var ds []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		report := func(node ast.Node, form string) {
+			fn := enclosingFuncName(file, node.Pos())
+			if fn == writerFunc {
+				return
+			}
+			where := fn
+			if where == "" {
+				where = "<package scope>"
+			}
+			ds = append(ds, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(node.Pos()).Line,
+				Message: fmt.Sprintf(
+					"errcode.Error.%s written in %s (%s); only func %s may set the "+
+						"transient marker (ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01)",
+					transientMarkerField, where, form, writerFunc),
+			})
+		}
+		EachInSubtree[ast.AssignStmt](file, func(as *ast.AssignStmt) {
+			// Direct-child selectors of an AssignStmt cover the Lhs write
+			// targets (`e.transient = …`). Reads of the marker live in
+			// IfStmt/BinaryExpr conditions (IsTransient), never as a direct
+			// AssignStmt child, so they are not visited here.
+			EachInChildren[ast.SelectorExpr](as, func(sel *ast.SelectorExpr) {
+				if sel.Sel == nil || sel.Sel.Name != transientMarkerField {
+					return
+				}
+				if isErrcodeTransientField(p.TypesInfo, sel.Sel, errcodePkgPath) {
+					report(sel, "assignment")
+				}
+			})
+		})
+		EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
+			EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok || key.Name != transientMarkerField {
+					return
+				}
+				if isErrcodeTransientField(p.TypesInfo, key, errcodePkgPath) {
+					report(kv, "composite literal")
+				}
+			})
+		})
+	}
+	return ds
+}
+
+// isErrcodeTransientField reports whether ident resolves (via info.Uses) to a
+// struct field named transient declared in package errcodePkgPath.
+func isErrcodeTransientField(info *types.Info, ident *ast.Ident, errcodePkgPath string) bool {
+	obj := info.Uses[ident]
+	if obj == nil {
+		obj = info.Defs[ident]
+	}
+	v, ok := obj.(*types.Var)
+	if !ok || !v.IsField() || v.Name() != transientMarkerField {
+		return false
+	}
+	return v.Pkg() != nil && v.Pkg().Path() == errcodePkgPath
+}
+
+// packageCallsWrapInfra reports whether p contains at least one call whose
+// callee resolves to errcodePkgPath.WrapInfra (qualified or dot-imported).
+func packageCallsWrapInfra(p *Pass, errcodePkgPath string) bool {
+	if p.TypesInfo == nil {
+		return false
+	}
+	found := false
+	for _, file := range p.Files {
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			if found {
+				return
+			}
+			pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+			if ok && pkgPath == errcodePkgPath && name == transientMarkerWriterFunc {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+// enclosingFuncName returns the name of the top-level *ast.FuncDecl whose
+// source range contains pos, or "" when pos is at package scope (no
+// containing top-level func).
+func enclosingFuncName(file *ast.File, pos token.Pos) string {
+	name := ""
+	EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+		if name != "" {
+			return
+		}
+		if fd.Pos() <= pos && pos <= fd.End() {
+			name = fd.Name.Name
+		}
+	})
+	return name
+}

--- a/tools/archtest/internal/transientmarkerfixture/fixture.go
+++ b/tools/archtest/internal/transientmarkerfixture/fixture.go
@@ -8,10 +8,11 @@
 //   - WrapInfra      — the allowed writer (clean; MUST NOT be reported)
 //   - badAssign      — RED: assignment write outside WrapInfra
 //   - badLiteral     — RED: composite-literal write outside WrapInfra
+//   - badDeref       — RED: `(*e).transient = …` deref-form write outside WrapInfra
 //   - readOnly       — clean: a read of transient (MUST NOT be reported)
 //
 // The detector scanTransientMarkerWrites, pointed at this package's import
-// path, must report exactly the two RED sites. Loaded as a real Go package
+// path, must report exactly the three RED sites. Loaded as a real Go package
 // via packages.Load with the archtest_fixture build tag — bypassing the
 // reverse self-check requires editing this real source.
 package transientmarkerfixture
@@ -41,6 +42,15 @@ func badLiteral(code string) *Error {
 	return &Error{Code: code, transient: true} // RED: composite literal outside WrapInfra
 }
 
+// badDeref writes the marker via an explicit pointer deref outside WrapInfra
+// (RED). Locks that `(*e).transient = …` — whose SelectorExpr is still the
+// outermost AssignStmt LHS child — is detected, not a blind spot.
+func badDeref(code string) *Error {
+	e := &Error{Code: code}
+	(*e).transient = true // RED: deref-form assignment outside WrapInfra
+	return e
+}
+
 // readOnly only reads the marker — must not be flagged as a write.
 func readOnly(e *Error) bool {
 	if e.transient {
@@ -49,6 +59,9 @@ func readOnly(e *Error) bool {
 	return false
 }
 
-var _ = readOnly
-var _ = badAssign
-var _ = badLiteral
+var (
+	_ = readOnly
+	_ = badAssign
+	_ = badLiteral
+	_ = badDeref
+)

--- a/tools/archtest/internal/transientmarkerfixture/fixture.go
+++ b/tools/archtest/internal/transientmarkerfixture/fixture.go
@@ -1,0 +1,54 @@
+//go:build archtest_fixture
+
+// Package transientmarkerfixture is a deliberate
+// ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 reverse self-check corpus. It
+// models pkg/errcode's Error.transient marker funnel: only func WrapInfra is
+// allowed to write the unexported transient field. The fixture contains:
+//
+//   - WrapInfra      — the allowed writer (clean; MUST NOT be reported)
+//   - badAssign      — RED: assignment write outside WrapInfra
+//   - badLiteral     — RED: composite-literal write outside WrapInfra
+//   - readOnly       — clean: a read of transient (MUST NOT be reported)
+//
+// The detector scanTransientMarkerWrites, pointed at this package's import
+// path, must report exactly the two RED sites. Loaded as a real Go package
+// via packages.Load with the archtest_fixture build tag — bypassing the
+// reverse self-check requires editing this real source.
+package transientmarkerfixture
+
+// Error mirrors errcode.Error's marker-bearing shape.
+type Error struct {
+	Code      string
+	transient bool
+}
+
+// WrapInfra is the single allowed writer of the transient marker.
+func WrapInfra(code string) *Error {
+	e := &Error{Code: code}
+	e.transient = true // allowed: enclosing func is WrapInfra
+	return e
+}
+
+// badAssign writes the marker via assignment outside WrapInfra (RED).
+func badAssign(code string) *Error {
+	e := &Error{Code: code}
+	e.transient = true // RED: assignment outside WrapInfra
+	return e
+}
+
+// badLiteral writes the marker via composite literal outside WrapInfra (RED).
+func badLiteral(code string) *Error {
+	return &Error{Code: code, transient: true} // RED: composite literal outside WrapInfra
+}
+
+// readOnly only reads the marker — must not be flagged as a write.
+func readOnly(e *Error) bool {
+	if e.transient {
+		return true
+	}
+	return false
+}
+
+var _ = readOnly
+var _ = badAssign
+var _ = badLiteral


### PR DESCRIPTION
## Summary

`adapters/{postgres,redis,s3}` returned flat `KindInternal` errors with no transient-vs-permanent distinction, so outbox consumers could not make a backoff/DLX decision (`auditcore` appender blind-`Requeue`d every store failure → permanent errors burned the whole retry budget). This closes the backlog trigger **"第 1 个 handler disposition 收口"**.

A single typed funnel **`errcode.WrapInfra`** is now the only constructor that makes an error transient (`KindUnavailable` + `CategoryInfra` + a **private** `Error.transient` marker). `errcode.IsTransient` is generalized to a single marker-keyed predicate + raw recognizers (`ctx.DeadlineExceeded`, `net.Error.Timeout()`, `interface{ RetryableError() bool }`; `context.Canceled` excluded). The old `ErrKeyProviderTransient` code-string branch is **deleted** and `vault.classifyVaultError` migrated onto `WrapInfra` — single truth source, no shim.

Per-adapter `classify{PG,Redis,S3}Error` route their transient branch through `WrapInfra` (modeled on the existing `vault.classifyVaultError`). The auditcore appender now Requeues positively-transient, Rejects positively-permanent (domain/validation/auth) to DLX, and keeps unknown/ambiguous infra on the Requeue (retry-then-budget-DLX) path — **fail-closed toward not losing an event** on a transient blip (configreceive precedent).

`Refs: ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01` (038 Wave 4)

## Hard funnel double-lock

archtest `ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01` (040 `RunTypedProduction`, **NOT** LegacyAllowlist):
- **Upstream Hard**: transient marker producible only via `WrapInfra` — field unexported (Go type system) + archtest locks the in-package writer to func `WrapInfra` (`panicregister.Approved` form-uniqueness 范本).
- **Downstream Hard**: `IsTransient` `*Error` branch keys only on the private marker.
- Reverse self-check fixture (`transientmarkerfixture`, `archtest_fixture` tag) asserts exactly 2 non-WrapInfra marker writes are reported (false-neg + false-pos drift caught).
- Declared blind spot (compensated, not silent): archtest does not enforce "every adapter error site calls classify" — fail-closed safe (unclassified → permanent-eligible). See test godoc + ADR.

## Adapter transient inventory

| Adapter | Transient |
|---------|-----------|
| postgres | `pgconn.SafeToRetry`; SQLSTATE `40001`/`40P01`; class `08*`; ctx deadline |
| redis | net timeout / ctx deadline / `i/o timeout`; `CLUSTERDOWN`/`LOADING`/`TRYAGAIN`/`MASTERDOWN` |
| s3 | HTTP 429/408/5xx; net timeout / ctx deadline |

## Contract-fanout implementation matrix

```
Contract: errcode.WrapInfra (new constructor) + errcode.IsTransient (semantic change: marker-keyed)
Change: transient classification single-sourced on a private Error marker; per-adapter classifiers route through WrapInfra
Implementations: [x] postgres classifyPGError  [x] redis classifyRedisError  [x] s3 classifyS3Error  [x] vault classifyVaultError (migrated)
Conformance test: pkg/errcode.TestIsTransient_MarkerKeyed / adapters/{postgres,redis,s3} *_test.go classify tables / appender TestService_HandleEvent_AppendFails_Classified
Repro: go test ./pkg/errcode/ ./adapters/postgres/ ./adapters/redis/ ./adapters/s3/ ./adapters/vault/ ./cells/auditcore/... ./tools/archtest/ -run 'Transient|Classified|AdapterErrorClassification'
Dependent contracts (governance scan): none (no new Kind/Category/Sentinel; reuses KindUnavailable/CategoryInfra)
```

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...`
- [x] unit: pkg/errcode, adapters/{postgres,redis,s3,vault}, cells/auditcore, cells/configcore/internal, runtime/crypto — all green
- [x] archtest full suite (370s, 16-shard) — green incl. new ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 + SCANNER-FRAMEWORK-USAGE-01 + pass-funnel meta guards
- [x] `golangci-lint run ./...` — 0 issues
- Integration tests: classifiers are pure deterministic error-mapping functions (input `*pgconn.PgError{Code}`/smithy ResponseError/net timeout is identical fabricated vs real); existing adapter `-tags=integration` suites build green and exercise the rerouted wrap sites. No DB/network state path is added, so no new integration test is warranted.

ref: jackc/pgx pgconn SafeToRetry; aws/aws-sdk-go-v2 aws/retry; ThreeDotsLabs/watermill retry middleware; golang/go #45729 (net.Error.Temporary deprecation)

Notes: Batch B2 (redis) + B3 (s3) landed in one commit (pre-commit hook staged both); reviewed by diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
