### PR TITLE
build(hooks): pre-push fast-gate — gofumpt/build/vet/codegen staleness (214)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: build check-build test fmt verify validate generate cover clean \
+        install-hooks \
         up down \
         test-integration \
         test-integration-cluster \
@@ -49,6 +50,14 @@ fmt:
 # ref: kubernetes/kubernetes hack/make-rules/verify.sh
 verify:
 	bash hack/make-rules/verify.sh
+
+# install-hooks points git at the tracked hack/githooks/ dir (per-repo
+# config, shared across all worktrees of this repo). Run once after clone
+# and after `git worktree add`. The pre-push hook runs the fast CI subset
+# (gofumpt / build+vet / codegen staleness) AI co-authors most often skip.
+install-hooks:
+	git config core.hooksPath hack/githooks
+	@echo "core.hooksPath -> hack/githooks (pre-push active)"
 
 validate:
 	go run ./cmd/gocell validate

--- a/hack/README.md
+++ b/hack/README.md
@@ -13,6 +13,25 @@ change to the driver.
   `gocell::log::error`).
 - `verify-*.sh` — individual gates. Each script is independently runnable
   (`bash hack/verify-X.sh`) and exits non-zero on failure.
+- `githooks/pre-push` — local fast-feedback hook (see below). Not part of
+  the `make verify` gate set; it runs at `git push` time, not in CI.
+
+## Local pre-push hook
+
+`make install-hooks` points `core.hooksPath` at `hack/githooks/` (per-repo
+config, shared across all worktrees of this repo). **Run it once after a
+fresh clone and after every `git worktree add`** — without it the hook is
+inert and there is no local protection.
+
+`hack/githooks/pre-push` runs the fast, deterministic, offline subset of CI
+that fresh-instance AI co-authors most often skip — gofumpt (scoped to the
+pushed `.go` files), `go build`/`vet` (incl. integration/e2e tags), and
+codegen staleness (`gocell verify generated`). Each tier only fires when
+the push actually touches the files it protects, so a docs-only push pays
+~0s. Honest scope: it checks the working tree (not the pushed commit) and
+`git push --no-verify` bypasses it — a fast feedback loop, not an
+unbypassable gate. See the header comment in `githooks/pre-push` for the
+full rationale and the deliberate CI-mirror deviations.
 
 ## Adding a new gate
 

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# hack/githooks/pre-push — fast local mirror of the CI gates that AI
+# co-authors most often forget to run before pushing (fresh-instance, no
+# memory: ai-collab.md §1). It is NOT a full `make verify` — only the
+# subset that is (a) deterministic offline, (b) sub-10s on a warm build
+# cache, (c) high "forgot to run" rate. Slow / infra-bound gates (full
+# golangci-lint, go test, archtest, integration testcontainers) stay in CI.
+#
+# Cost control: every tier is gated on whether this push actually touches
+# the files that tier protects. A docs-only push pays ~0; a .go push pays
+# ~6-8s (build/vet run in parallel on warm cache); a schema/contract push
+# additionally pays the codegen staleness probe.
+#
+# Honest scope (ai-collab grading): this is Medium AI-rebust — `git push
+# --no-verify` bypasses it and a fresh clone/worktree without
+# `make install-hooks` has no protection. It is a fast feedback loop, not
+# an unbypassable funnel.
+#
+# Bypass (humans, real emergencies only): git push --no-verify
+# Install / re-point after clone or new worktree: make install-hooks
+#
+# stdin protocol (githooks(5)): one line per pushed ref —
+#   <local ref> <local oid> <remote ref> <remote oid>
+# Deleted ref => local oid all-zero. New branch => remote oid all-zero.
+#
+# ref: kubernetes/kubernetes hack/verify-*.sh diff-mode pattern;
+#      git githooks(5) pre-push sample.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && cd .. && pwd)"
+cd "${ROOT}"
+
+ZERO="0000000000000000000000000000000000000000"
+BASE_BRANCH="origin/develop"
+
+# ---------------------------------------------------------------------------
+# Collect the changed-file set across every pushed ref.
+# ---------------------------------------------------------------------------
+ranges=()
+while read -r _local_ref local_oid _remote_ref remote_oid; do
+    [[ -z "${local_oid:-}" ]] && continue
+    [[ "${local_oid}" == "${ZERO}" ]] && continue   # branch deletion
+    if [[ "${remote_oid}" == "${ZERO}" ]]; then
+        # New branch on the remote: diff against the merge-base with the
+        # integration branch so we only inspect this branch's own work,
+        # not every commit since it forked.
+        if base="$(git merge-base "${BASE_BRANCH}" "${local_oid}" 2>/dev/null)"; then
+            ranges+=("${base}..${local_oid}")
+        else
+            # Can't resolve a base (no fetched develop): fall back to
+            # checking the whole tree — correctness over speed.
+            ranges+=("__ALL__")
+        fi
+    else
+        ranges+=("${remote_oid}..${local_oid}")
+    fi
+done
+
+# Nothing to push (e.g. delete-only) → let git proceed.
+[[ ${#ranges[@]} -eq 0 ]] && exit 0
+
+changed=""
+force_all=0
+for r in "${ranges[@]}"; do
+    if [[ "${r}" == "__ALL__" ]]; then
+        force_all=1
+        break
+    fi
+    changed+=$'\n'"$(git diff --name-only --diff-filter=ACMR "${r}" 2>/dev/null || true)"
+done
+
+if [[ ${force_all} -eq 1 ]]; then
+    go_files="$(git ls-files '*.go')"
+    go_changed=1
+    codegen_changed=1
+else
+    go_files="$(printf '%s\n' "${changed}" | grep -E '\.go$' || true)"
+    [[ -n "${go_files}" ]] && go_changed=1 || go_changed=0
+    if printf '%s\n' "${changed}" | grep -qE '(\.schema\.json|/(cell|slice|assembly|contract)\.yaml|\.tmpl|tools/codegen/.*\.go|cmd/gocell/.*\.go)$'; then
+        codegen_changed=1
+    else
+        codegen_changed=0
+    fi
+fi
+
+start=$(date +%s)
+fail=0
+note() { printf '  pre-push: %s\n' "$1" >&2; }
+
+# ---------------------------------------------------------------------------
+# Tier 1 — gofumpt, scoped to the changed .go files. ~ms. Always when .go
+# changed. This is the exact gate that failed CI #525.
+# ---------------------------------------------------------------------------
+if [[ ${go_changed} -eq 1 ]]; then
+    fmt_targets=()
+    while IFS= read -r f; do
+        [[ -n "${f}" && -f "${f}" ]] && fmt_targets+=("${f}")
+    done < <(printf '%s\n' "${go_files}" | grep -E '\.go$' || true)
+    if [[ ${#fmt_targets[@]} -gt 0 ]]; then
+        if drift="$(gofumpt -l "${fmt_targets[@]}" 2>/dev/null)" && [[ -n "${drift}" ]]; then
+            note "formatter drift (run: make fmt):"
+            printf '%s\n' "${drift}" | sed 's/^/    /' >&2
+            fail=1
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Tier 2 — compile + vet, incl. the integration / e2e build tags that are
+# the single most-forgotten step (see memory: integration-tag build).
+# Whole-module (Go type-checks transitively), so run the four in parallel.
+# ---------------------------------------------------------------------------
+if [[ ${go_changed} -eq 1 ]]; then
+    pids=() ; names=() ; logs=()
+    run_bg() {
+        local name="$1"; shift
+        local log; log="$(mktemp "${TMPDIR:-/tmp}/prepush.XXXXXX")"
+        ( "$@" ) >"${log}" 2>&1 &
+        pids+=($!) ; names+=("${name}") ; logs+=("${log}")
+    }
+    run_bg "go build ./..."                        go build ./...
+    run_bg "go build -tags=integration ./..."      go build -tags=integration ./...
+    run_bg "go vet ./..."                          go vet ./...
+    run_bg "go vet -tags=e2e ./tests/e2e/..."      go vet -tags=e2e ./tests/e2e/...
+    for i in "${!pids[@]}"; do
+        if ! wait "${pids[$i]}"; then
+            note "FAIL: ${names[$i]}"
+            sed 's/^/    /' "${logs[$i]}" >&2
+            fail=1
+        fi
+        rm -f "${logs[$i]}"
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Tier 3 — codegen staleness. Only when a codegen *source* changed
+# (schema/contract/cell/slice/assembly/tmpl/generator). "schema changed,
+# forgot make generate" class.
+# ---------------------------------------------------------------------------
+if [[ ${codegen_changed} -eq 1 ]]; then
+    if ! out="$(go run ./cmd/gocell verify generated 2>&1)"; then
+        note "stale codegen artifacts (run: make generate):"
+        printf '%s\n' "${out}" | sed 's/^/    /' >&2
+        fail=1
+    fi
+fi
+
+elapsed=$(( $(date +%s) - start ))
+if [[ ${fail} -ne 0 ]]; then
+    note "blocked (${elapsed}s). Fix above, or 'git push --no-verify' for a true emergency (human only)."
+    exit 1
+fi
+note "ok (${elapsed}s)"
+exit 0

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -1,14 +1,30 @@
 #!/usr/bin/env bash
-# hack/githooks/pre-push — fast local mirror of the CI gates that AI
+# hack/githooks/pre-push — fast local approximation of the CI gates that AI
 # co-authors most often forget to run before pushing (fresh-instance, no
 # memory: ai-collab.md §1). It is NOT a full `make verify` — only the
 # subset that is (a) deterministic offline, (b) sub-10s on a warm build
 # cache, (c) high "forgot to run" rate. Slow / infra-bound gates (full
 # golangci-lint, go test, archtest, integration testcontainers) stay in CI.
 #
+# Not a 1:1 CI mirror — two deliberate deviations:
+#   - It checks the WORKING TREE, not the pushed commit snapshot. Git does
+#     not check out the push range; every tier (gofumpt / build / vet /
+#     verify-generated) inspects whatever is on disk now. Un-staged
+#     generated/ edits can therefore pass here but fail CI (which runs from
+#     a clean checkout). This is inherent to pre-push hooks, not a bug —
+#     stage your work before relying on the result.
+#   - `go build -tags=integration ./...` has no standalone CI step; CI
+#     compiles the integration tag transitively inside `go test
+#     -tags=integration` (integration-test job). It is added here as an
+#     extra local guard because the integration-tag build break is a
+#     repeatedly-forgotten failure mode (project memory: integration-tag
+#     build). The other three commands do mirror real CI steps
+#     (_build-lint.yml: go build ./... / go vet ./... / go vet -tags=e2e
+#     ./tests/e2e/...).
+#
 # Cost control: every tier is gated on whether this push actually touches
 # the files that tier protects. A docs-only push pays ~0; a .go push pays
-# ~6-8s (build/vet run in parallel on warm cache); a schema/contract push
+# ~6-9s (build/vet run in parallel on warm cache); a schema/contract push
 # additionally pays the codegen staleness probe.
 #
 # Honest scope (ai-collab grading): this is Medium AI-rebust — `git push
@@ -28,11 +44,24 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && cd .. && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT}"
 
 ZERO="0000000000000000000000000000000000000000"
 BASE_BRANCH="origin/develop"
+
+note() { printf '  pre-push: %s\n' "$1" >&2; }
+
+# run_bg launches a command detached, capturing combined output to a temp
+# file; wait/collect happens in Tier 2. Defined at top level (not inside
+# the tier `if`) so it is declared once, alongside note().
+pids=() ; names=() ; logs=()
+run_bg() {
+    local name="$1"; shift
+    local log; log="$(mktemp "${TMPDIR:-/tmp}/prepush.XXXXXX")"
+    ( "$@" ) >"${log}" 2>&1 &
+    pids+=($!) ; names+=("${name}") ; logs+=("${log}")
+}
 
 # ---------------------------------------------------------------------------
 # Collect the changed-file set across every pushed ref.
@@ -77,7 +106,11 @@ if [[ ${force_all} -eq 1 ]]; then
 else
     go_files="$(printf '%s\n' "${changed}" | grep -E '\.go$' || true)"
     [[ -n "${go_files}" ]] && go_changed=1 || go_changed=0
-    if printf '%s\n' "${changed}" | grep -qE '(\.schema\.json|/(cell|slice|assembly|contract)\.yaml|\.tmpl|tools/codegen/.*\.go|cmd/gocell/.*\.go)$'; then
+    # Codegen sources: schema / contract|cell|slice|assembly yaml / any
+    # template, plus the generators and the staleness verifier themselves
+    # (tools/codegen, tools/generatedverify, cmd/gocell). A miss here only
+    # degrades to "CI catches it" — the hook is an aid, not the SoT.
+    if printf '%s\n' "${changed}" | grep -qE '(\.schema\.json|/(cell|slice|assembly|contract)\.yaml|\.tmpl|tools/codegen/.*\.go|tools/generatedverify/.*\.go|cmd/gocell/.*\.go)$'; then
         codegen_changed=1
     else
         codegen_changed=0
@@ -86,7 +119,6 @@ fi
 
 start=$(date +%s)
 fail=0
-note() { printf '  pre-push: %s\n' "$1" >&2; }
 
 # ---------------------------------------------------------------------------
 # Tier 1 — gofumpt, scoped to the changed .go files. ~ms. Always when .go
@@ -98,7 +130,13 @@ if [[ ${go_changed} -eq 1 ]]; then
         [[ -n "${f}" && -f "${f}" ]] && fmt_targets+=("${f}")
     done < <(printf '%s\n' "${go_files}" | grep -E '\.go$' || true)
     if [[ ${#fmt_targets[@]} -gt 0 ]]; then
-        if drift="$(gofumpt -l "${fmt_targets[@]}" 2>/dev/null)" && [[ -n "${drift}" ]]; then
+        # Fail-closed if gofumpt is absent: a missing formatter must not
+        # silently skip the gate (no-soft-fallback). `2>/dev/null` would
+        # swallow "command not found" into an empty drift string and pass.
+        if ! command -v gofumpt >/dev/null 2>&1; then
+            note "gofumpt not found — install: go install mvdan.cc/gofumpt@latest"
+            fail=1
+        elif drift="$(gofumpt -l "${fmt_targets[@]}")" && [[ -n "${drift}" ]]; then
             note "formatter drift (run: make fmt):"
             printf '%s\n' "${drift}" | sed 's/^/    /' >&2
             fail=1
@@ -107,18 +145,11 @@ if [[ ${go_changed} -eq 1 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Tier 2 — compile + vet, incl. the integration / e2e build tags that are
-# the single most-forgotten step (see memory: integration-tag build).
-# Whole-module (Go type-checks transitively), so run the four in parallel.
+# Tier 2 — compile + vet. Whole-module (Go type-checks transitively), so
+# run the four in parallel. integration/e2e tags: see header note on the
+# deliberate deviation from CI step structure.
 # ---------------------------------------------------------------------------
 if [[ ${go_changed} -eq 1 ]]; then
-    pids=() ; names=() ; logs=()
-    run_bg() {
-        local name="$1"; shift
-        local log; log="$(mktemp "${TMPDIR:-/tmp}/prepush.XXXXXX")"
-        ( "$@" ) >"${log}" 2>&1 &
-        pids+=($!) ; names+=("${name}") ; logs+=("${log}")
-    }
     run_bg "go build ./..."                        go build ./...
     run_bg "go build -tags=integration ./..."      go build -tags=integration ./...
     run_bg "go vet ./..."                          go vet ./...
@@ -136,7 +167,7 @@ fi
 # ---------------------------------------------------------------------------
 # Tier 3 — codegen staleness. Only when a codegen *source* changed
 # (schema/contract/cell/slice/assembly/tmpl/generator). "schema changed,
-# forgot make generate" class.
+# forgot make generate" class. Verifies the working tree (see header).
 # ---------------------------------------------------------------------------
 if [[ ${codegen_changed} -eq 1 ]]; then
     if ! out="$(go run ./cmd/gocell verify generated 2>&1)"; then
@@ -148,7 +179,9 @@ fi
 
 elapsed=$(( $(date +%s) - start ))
 if [[ ${fail} -ne 0 ]]; then
-    note "blocked (${elapsed}s). Fix above, or 'git push --no-verify' for a true emergency (human only)."
+    note "blocked (${elapsed}s). Fix above, then re-push."
+    note "AI agents: fix the cause — do NOT use 'git push --no-verify'; escalate to the human owner if blocked."
+    note "Humans, real emergencies only: git push --no-verify"
     exit 1
 fi
 note "ok (${elapsed}s)"


### PR DESCRIPTION
## Summary

Fresh-instance AI co-authors repeatedly `git push` without running the cheap CI subset (`ai-collab.md` §1: no memory, no learned feedback — memory `feedback_lint_before_push` already exists but instruction-level reminders don't hold). CI #525 failed on `verify-gofumpt.sh` for exactly this reason.

Adds a tracked git `pre-push` hook (`hack/githooks/pre-push`) mirroring the fast / deterministic / offline CI gates, **gated per-tier on whether the push actually touches the files that tier protects** so cost stays near-zero for the common push:

| Tier | Check | Trigger | Cost (warm) |
|---|---|---|---|
| 1 | `gofumpt` scoped to pushed `.go` files | any `.go` changed | ~40ms |
| 2 | `go build`/`vet` ×4 (incl. `-tags=integration` / `-tags=e2e`), parallel | any `.go` changed | ~6–9s |
| 3 | `gocell verify generated` | codegen source changed (schema/contract/cell/slice/assembly/tmpl/generator) | ~1–7s |

- **docs-only / no-.go push → ~0s** (verified: 192ms, all tiers skipped).
- `make install-hooks` points `core.hooksPath` at the tracked dir (per-repo, shared across worktrees; run once after clone / `git worktree add`).
- Slow/infra-bound gates (full golangci-lint, go test, archtest, integration testcontainers) deliberately stay in CI only.

## AI-rebust grade (ai-collab.md)

**Medium** — honest scope: `git push --no-verify` bypasses it, and a fresh worktree without `make install-hooks` has no protection. It is a fast local feedback loop, **not** an unbypassable funnel. The Hard layer (harness `PreToolUse` hook, agent-uncircumventable, no bootstrap) was explicitly scoped out by the requester for this iteration.

## Test plan

No Go code added (bash hook + Makefile target) — verification is shellcheck + functional smoke, run in-worktree:

- [x] `shellcheck hack/githooks/pre-push` — clean (repo has `verify-shellcheck` gate)
- [x] bash 3.2 compatible (removed `mapfile`; macOS default shell)
- [x] no-op range → `ok (0s)`
- [x] new-branch realistic range (merge-base `origin/develop`..HEAD, only Makefile+hook) → `ok (0s)`, 192ms, tiers correctly skipped
- [x] `.go`-bearing range → Tier 1+2 fire, drift detected, exit 1 with `make fmt` recipe
- [x] codegen-source-bearing range → Tier 3 `gocell verify generated` fires
- [x] `make install-hooks` → `core.hooksPath -> hack/githooks`

Refs: 214
ref: kubernetes/kubernetes hack/verify-gofmt.sh (diff-mode pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)