### PR TITLE
docs(cli),ci(pathsafe): align generate-help codegen default + os-smoke coverage

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -680,7 +680,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: Vet (cross-platform unit subset)
-        run: go vet ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/...
+        run: go vet ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/pathsafe/...
         shell: bash
 
       - name: Cross-platform unit smoke
@@ -688,9 +688,9 @@ jobs:
         # Enable -race on macOS to maximise race-detector coverage.
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            go test -race -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/...
+            go test -race -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/pathsafe/...
           else
-            go test -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/...
+            go test -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/pathsafe/...
           fi
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ kind: http
 ownerCell: mycell
 consistencyLevel: L0
 lifecycle: active
-codegen: true
 endpoints:
   server: mycell
   clients: []          # external callers (cell ids or actor ids); empty = open API

--- a/cmd/gocell/app/generate.go
+++ b/cmd/gocell/app/generate.go
@@ -70,7 +70,7 @@ var generateSubcommands = []subcommand[func(ctx context.Context, args []string) 
 			"+ JSON schemas. <contractID> | --all [--dry-run | --verify].",
 			"--verify reports drift without writing; --dry-run prints",
 			"would-write paths without writing.",
-			"Prerequisite: set codegen: true in the contract.yaml.",
+			"Default: codegen on; set codegen: false to opt out.",
 			"CI: commit *_gen.go files and run with --verify.",
 		},
 		run: func(_ context.Context, a []string) error { return generateContract(a) },

--- a/docs/guides/codegen-new-endpoint.md
+++ b/docs/guides/codegen-new-endpoint.md
@@ -199,7 +199,7 @@ takes a standard `outbox.EntryHandler` — no custom interface to implement.
 | Mistake | Effect | Fix |
 |---------|--------|-----|
 | `wrapper.ContractSpec{}` literal in cells/ | archtest CELLS-NO-WRAPPER-CONTRACTSPEC-IMPORT-01 fail | Use generated `NewHandler` / `NewSubscription` |
-| Stale `codegen: false` left in contract.yaml | Generator skips the contract (codegen defaults to on) | Remove the `codegen: false` line |
+| Stale `codegen: false` left in contract.yaml | Generator skips the contract (explicit false overrides the default-on) | Remove the `codegen: false` line |
 | Editing files in `generated/` | Overwritten on next generate | Implement the `Service` interface instead |
 | Wrong `contractUsages` role | `gocell validate` ADV-06 fail | Set `role: serve` for HTTP server, `role: subscribe` for event subscriber |
 | `return nil, err` for business 4xx | Generated handler falls through to `httputil.WriteError` 5xx path; business error loses its intended status code | Return typed struct: `return createg.Create404ErrorResponse{Body: *errcode.New(...)}, nil` |

--- a/docs/guides/codegen-new-endpoint.md
+++ b/docs/guides/codegen-new-endpoint.md
@@ -34,7 +34,6 @@ kind: http
 ownerCell: myapp
 consistencyLevel: L1
 lifecycle: active
-codegen: true
 endpoints:
   server: myapp
   http:
@@ -200,7 +199,7 @@ takes a standard `outbox.EntryHandler` — no custom interface to implement.
 | Mistake | Effect | Fix |
 |---------|--------|-----|
 | `wrapper.ContractSpec{}` literal in cells/ | archtest CELLS-NO-WRAPPER-CONTRACTSPEC-IMPORT-01 fail | Use generated `NewHandler` / `NewSubscription` |
-| Forgetting `codegen: true` in contract.yaml | Generator skips the contract | Add `codegen: true` |
+| Stale `codegen: false` left in contract.yaml | Generator skips the contract (codegen defaults to on) | Remove the `codegen: false` line |
 | Editing files in `generated/` | Overwritten on next generate | Implement the `Service` interface instead |
 | Wrong `contractUsages` role | `gocell validate` ADV-06 fail | Set `role: serve` for HTTP server, `role: subscribe` for event subscriber |
 | `return nil, err` for business 4xx | Generated handler falls through to `httputil.WriteError` 5xx path; business error loses its intended status code | Return typed struct: `return createg.Create404ErrorResponse{Body: *errcode.New(...)}, nil` |

--- a/pkg/pathsafe/pathsafe_test.go
+++ b/pkg/pathsafe/pathsafe_test.go
@@ -137,8 +137,18 @@ func containPathCases() []containPathCase {
 			wantErr: true,
 		},
 		{
-			name:    "abs_path",
-			setup:   func(t *testing.T) (string, string) { return resolved(t), "/etc/passwd" },
+			name: "abs_path",
+			setup: func(t *testing.T) (string, string) {
+				abs := "/etc/passwd"
+				if runtime.GOOS == "windows" {
+					// Windows absolute paths require a volume; POSIX-style
+					// "/etc/passwd" is treated as relative by filepath.IsAbs
+					// on Windows, so use a volume-rooted path to exercise the
+					// same "caller passed an absolute path" rejection branch.
+					abs = `C:\Windows\System32\drivers\etc\hosts`
+				}
+				return resolved(t), abs
+			},
 			wantErr: true,
 		},
 		{

--- a/tools/archtest/codegen_invariants_test.go
+++ b/tools/archtest/codegen_invariants_test.go
@@ -265,12 +265,14 @@ func TestCodegenGates_NegativeFixtures(t *testing.T) {
 // ============================================================
 //
 // Gates protect the generator's contract on contracts that have opted into
-// codegen (codegen: true in contract.yaml).
+// codegen. Contracts opt in by default; declare `codegen: false` in
+// contract.yaml to opt out.
 //
 // ref: docs/plans/202605011500-029-master-roadmap.md K#06
 
 // TestCodegenContractGen01_OptedInHasGen verifies CODEGEN-CONTRACT-GEN-01.
-// A contract opts into codegen by setting `codegen: true` in contract.yaml.
+// Contracts are opted into codegen by default; `codegen: false` in
+// contract.yaml is the only way to opt out.
 // For every opted-in contract:
 //   - generated/<kind>/<...>/v<N>/types_gen.go must exist
 //   - generated/<kind>/<...>/v<N>/iface_gen.go must exist

--- a/tools/archtest/codegen_invariants_test.go
+++ b/tools/archtest/codegen_invariants_test.go
@@ -310,7 +310,7 @@ func requireRealGeneratedFile(t *testing.T, root, path, contractID string) {
 	info, err := os.Lstat(path)
 	switch {
 	case err != nil && os.IsNotExist(err):
-		t.Errorf("CODEGEN-CONTRACT-GEN-01: contract %q has codegen=true but missing %s; run `gocell generate contract %s`",
+		t.Errorf("CODEGEN-CONTRACT-GEN-01: contract %q is codegen-enabled but missing %s; run `gocell generate contract %s`",
 			contractID, rel, contractID)
 	case err != nil:
 		t.Errorf("CODEGEN-CONTRACT-GEN-01: lstat %s: %v", rel, err)

--- a/tools/generatedverify/generatedverify.go
+++ b/tools/generatedverify/generatedverify.go
@@ -246,10 +246,10 @@ func ExpectedArtifacts(ctx context.Context, root, module string, project *metada
 
 	// K#06 contractgen outputs: types_gen.go / iface_gen.go (always) +
 	// handler_gen.go (kind=http only) under generated/contracts/<kind>/<...>/v<N>/
-	// for every contract that opted into codegen by setting `codegen: true`
-	// in contract.yaml. Reuse contractgen.RenderContractArtifacts so the
-	// manifest stays byte-identical to what `gocell generate contract --all`
-	// would write.
+	// for every contract that opted into codegen (the default — declare
+	// `codegen: false` in contract.yaml to opt out). Reuse
+	// contractgen.RenderContractArtifacts so the manifest stays byte-identical
+	// to what `gocell generate contract --all` would write.
 	contractgenArtifacts, err := expectedContractgenArtifacts(root, project)
 	if err != nil {
 		return nil, fmt.Errorf("expected contractgen artifacts: %w", err)


### PR DESCRIPTION
## Summary

Lane C of `docs/plans/202605161800-041-pr442-leftover-cleanup-plan.md` — two Cx1 leftovers from PR #442 (K#09 SCAFFOLD-ONE-CMD). File domains disjoint, no archtest/enforcement added, no Go logic changed.

### C1 — GENERATE-HELP-CODEGEN-DEFAULT-DRIFT-01 (docs/Cx1)

K#09 funnel at `kernel/metadata/parser.go:296` defaults `contract.yaml::codegen` to `true` when the key is absent; `codegen: false` is the only opt-out. User-facing docs/help still described the inverse. Aligned five active docs:

- **`cmd/gocell/app/generate.go:73`** — contract help line: `Prerequisite: set codegen: true in the contract.yaml.` → `Default: codegen on; set codegen: false to opt out.`
- **`README.md:114`** — quick-start example contract.yaml drops the `codegen: true` row; example now relies on the default.
- **`docs/guides/codegen-new-endpoint.md:37`** — same drop in the guide's example.
- **`docs/guides/codegen-new-endpoint.md:203`** — pitfall row flipped from `Forgetting codegen: true ⇒ skipped ⇒ Add codegen: true` to `Stale codegen: false left in contract.yaml ⇒ Generator skips the contract (codegen defaults to on) ⇒ Remove the codegen: false line`.
- **`tools/generatedverify/generatedverify.go:247-252`** — K#06 contractgen godoc reworded to match the funnel default (no behaviour change).
- **`tools/archtest/codegen_invariants_test.go:267-273`** — CODEGEN-CONTRACT-GEN-01 invariant doc reworded; `if !contract.Codegen { continue }` logic untouched (Codegen field value is `true` whether from default or explicit declaration, so the test still picks up the same opted-in set).

#### Deliberate carve-outs (no follow-up)

- `.claude/rules/gocell/{cell-patterns,error-handling}.md` — describe explicit-true scenarios; no factual error.
- `docs/architecture/`, `docs/archive/`, `docs/plans/archive/`, `docs/reviews/` — frozen historical records.
- `tools/codegen/contractgen/testdata/synth/**` and `tools/archtest/testdata/adapter_returns/**` — fixtures cover the explicit-true parse path; removing them would shrink coverage.

### C6 — PATHSAFE-OS-SMOKE-COVERAGE-01 (test/Cx1)

`pkg/pathsafe/` ships `nofollow_unix.go` + `nofollow_windows.go` (`O_NOFOLLOW` vs `O_EXCL` fallback) but the cross-platform unit subset in the os-smoke job (`.github/workflows/_build-lint.yml:683/691/693`) covered only `runtime/{shutdown,config}` and `kernel/governance`. Added `./pkg/pathsafe/...` to the vet step plus both macOS and Windows test branches. Job remains `continue-on-error: true` (line 670) so any Windows nofollow-fallback divergence surfaces as advisory signal without blocking PRs.

## Test plan

- [x] `go -C worktrees/219-c-pr442-docs-ci build ./...`
- [x] `go -C worktrees/219-c-pr442-docs-ci test ./cmd/gocell/... ./pkg/pathsafe/... ./tools/generatedverify/...` — green
- [x] `go -C worktrees/219-c-pr442-docs-ci test ./tools/archtest/...` — green (no archtest broken)
- [x] `golangci-lint run --new-from-merge-base=origin/develop ./...` — 0 new issues
- [x] `go run ./cmd/gocell generate --help` — verified `contract` block renders the new line and no longer contains `Prerequisite: set codegen: true`
- [ ] CI os-smoke (macOS + Windows) covers `./pkg/pathsafe/...` for the first time — advisory; will surface any platform divergence in PR checks UI without blocking

## Notes

- `Refs:` plan file `docs/plans/202605161800-041-pr442-leftover-cleanup-plan.md` Lane C
- Lane A/B/D/E from the same plan are independent and not part of this PR
- No new archtest / enforcement / interface / contract / schema / migration in this PR