### PR TITLE
fix(scaffold): bundle variant dedup + cell cross-stage single-plan merge (Lane D #5+#7)

### DIFF
--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -8,9 +8,22 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// stdoutCaptureMu / stderrCaptureMu serialize os.Stdout / os.Stderr
+// redirection. captureStdout/captureStderr mutate process-global file
+// descriptors; without serialization two t.Parallel() tests racing on the
+// same stream clobber each other's pipe (one test's restore reverts the
+// fd while another is still printing → empty capture). Independent mutexes
+// per stream avoid cross-stream deadlock; same-stream nested capture is not
+// a pattern any test uses.
+var (
+	stdoutCaptureMu sync.Mutex
+	stderrCaptureMu sync.Mutex
 )
 
 func TestPrintUsage(t *testing.T) {
@@ -538,6 +551,8 @@ func TestPrintTargetList(t *testing.T) {
 // captureStdout runs fn with os.Stdout redirected into a string.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
+	stdoutCaptureMu.Lock()
+	defer stdoutCaptureMu.Unlock()
 	orig := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -561,6 +576,8 @@ func captureStdout(t *testing.T, fn func()) string {
 
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
+	stderrCaptureMu.Lock()
+	defer stderrCaptureMu.Unlock()
 	orig := os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -21,6 +21,12 @@ import (
 // fd while another is still printing → empty capture). Independent mutexes
 // per stream avoid cross-stream deadlock; same-stream nested capture is not
 // a pattern any test uses.
+//
+// WARNING: nested same-stream capture DEADLOCKS — sync.Mutex is not
+// re-entrant. Calling captureStdout inside a captureStdout callback (or
+// captureStderr inside captureStderr) will block forever waiting for a lock
+// the outer call already holds. Cross-stream nesting (captureStdout inside
+// captureStderr or vice-versa) is safe because they use independent mutexes.
 var (
 	stdoutCaptureMu sync.Mutex
 	stderrCaptureMu sync.Mutex

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -508,7 +508,7 @@ func validateSliceScaffoldFlags(id, cellID, level string) error {
 // scaffoldSlice produces an empty slice skeleton (slice.yaml only) under
 // cells/{cellID}/slices/{sliceID}/. K#09 inline-template path replaces the
 // deleted kernel/scaffold package; the bundle path used by `scaffold cell`
-// produces a richer slice via cellgen.ScaffoldCellBundle. For a complete
+// produces a richer slice via cellgen.PlanCellBundleScaffold. For a complete
 // slice with service.go + service_test.go skeleton, prefer
 // `gocell scaffold cell --id=<cell> --with-http`.
 //

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -11,12 +11,10 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/pathsafe"
 	"github.com/ghbvf/gocell/pkg/yamlsafe"
 	"github.com/ghbvf/gocell/tools/codegen/cellgen"
-	"github.com/ghbvf/gocell/tools/codegen/contractgen"
 )
 
 // ErrScaffoldInvalidOpts is the public error code surfaced when scaffold
@@ -330,37 +328,48 @@ func buildScaffoldCellSpec(in scaffoldCellInputs) cellgen.ScaffoldSpec {
 	}
 }
 
-// printScaffoldCellDryRunPlan resolves the output plan and prints the paths
-// that would be created. Falls back to a minimal summary when plan derivation
-// fails (e.g. symlink resolution error in a restricted environment).
-func printScaffoldCellDryRunPlan(root string, spec cellgen.ScaffoldSpec) error {
-	realRoot, err := pathsafe.ResolveRoot(root)
-	if err == nil {
-		plan, planErr := cellgen.PlanCellBundleForDryRun(realRoot, spec)
-		if planErr == nil {
-			for _, absPath := range pathsafe.PlannedPaths(plan) {
-				rel, _ := filepath.Rel(root, absPath)
-				fmt.Printf(dryRunCreatePathFmt, filepath.ToSlash(rel))
-			}
-			return nil
-		}
+// validateScaffoldCellFlags enforces required-field, control-char, and no-dash
+// constraints on the parsed scaffold cell flags. Extracted from scaffoldCell to
+// keep the latter's cognitive complexity within the project budget (≤15).
+func validateScaffoldCellFlags(id, team, role string) error {
+	if id == "" {
+		return errors.New(errMsgIDRequired)
 	}
-	// Fallback: print minimal info when plan cannot be derived.
-	fmt.Printf(dryRunCreatePathFmt, filepath.ToSlash(filepath.Join("cells", spec.CellID, "cell.yaml")))
-	fmt.Printf(dryRunCreatePathFmt, filepath.ToSlash(filepath.Join("cells", spec.CellID, "cell.go")))
-	fmt.Printf("(dry-run) Would create cell bundle (slice + contract) under %s\n",
-		filepath.ToSlash(filepath.Join("cells", spec.CellID)))
+	if team == "" {
+		return fmt.Errorf("--team is required")
+	}
+	if role == "" {
+		return fmt.Errorf("--role is required")
+	}
+	// Round-7: control-char + path-traversal guard.
+	if err := validateScaffoldID(id, "--id"); err != nil {
+		return err
+	}
+	if err := validateScaffoldText(team, "--team"); err != nil {
+		return err
+	}
+	if err := validateScaffoldText(role, "--role"); err != nil {
+		return err
+	}
+	// F11: reject kebab-case cell IDs (aligned with scaffoldSlice behavior).
+	if strings.Contains(id, "-") {
+		return errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+			"scaffold cell: --id must not contain '-'; use no-dash identifier",
+			errcode.WithInternal(fmt.Sprintf("id=%q suggestion=%q", id, strings.ReplaceAll(id, "-", ""))))
+	}
 	return nil
 }
 
-// scaffoldCell implements the K#09 SCAFFOLD-ONE-CMD bundle: a one-shot
-// command that produces cell + 1 example slice + 1 example contract +
-// JSON schemas, then auto-invokes cell + contract codegen so the bundle
-// is compilable and the example slice's unit test passes immediately.
+// scaffoldCell implements the K#09 SCAFFOLD-ONE-CMD bundle: a one-shot command
+// that produces cell + 1 example slice + 1 example contract + JSON schemas in
+// a single atomic pathsafe.WritePlannedFiles call. When --skip-generate is
+// false (default), derived codegen files (cell_gen.go, types_gen.go,
+// iface_gen.go, handler_gen.go) are merged into the same plan so the bundle is
+// compilable immediately on success, and the entire write is rolled back on any
+// conflict or error.
 //
-// --skip-generate skips the codegen step (useful for dry-run sanity checks
-// or pre-commit scaffold invocations); the resulting bundle is still a
-// compilable cell skeleton but lacks the generated handler glue.
+// Mirrors scaffold_assembly.go (assembly cross-stage pattern): ResolveRoot →
+// PlanCellBundleScaffold → WritePlannedFiles → dry-run print → reportScaffold.
 func scaffoldCell(root string, args []string) error {
 	fs := flag.NewFlagSet("scaffold cell", flag.ContinueOnError)
 	id := fs.String("id", "", "cell ID (required)")
@@ -377,43 +386,14 @@ func scaffoldCell(root string, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-
-	if *id == "" {
-		return errors.New(errMsgIDRequired)
-	}
-	if *team == "" {
-		return fmt.Errorf("--team is required")
-	}
-	if *role == "" {
-		return fmt.Errorf("--role is required")
-	}
-
-	// Round-7: control-char + path-traversal guard. Round-2 added these guards
-	// to scaffoldSlice/Contract/Journey/Assembly but missed scaffold cell;
-	// closing the chain so `--id="evil\nextra: pwned"` cannot inject YAML keys.
-	if err := validateScaffoldID(*id, "--id"); err != nil {
-		return err
-	}
-	if err := validateScaffoldText(*team, "--team"); err != nil {
-		return err
-	}
-	if err := validateScaffoldText(*role, "--role"); err != nil {
+	if err := validateScaffoldCellFlags(*id, *team, *role); err != nil {
 		return err
 	}
 
-	// F11: reject kebab-case cell IDs (aligned with scaffoldSlice behavior).
-	if strings.Contains(*id, "-") {
-		return errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
-			"scaffold cell: --id must not contain '-'; use no-dash identifier",
-			errcode.WithInternal(fmt.Sprintf("id=%q suggestion=%q", *id, strings.ReplaceAll(*id, "-", ""))))
-	}
-
-	// Resolve Go identifiers shared by both dry-run and live paths.
 	resolvedStruct := *structName
 	if resolvedStruct == "" {
 		resolvedStruct = cellIDToPascalCase(*id)
 	}
-	pkg := *id
 
 	mod, err := readModule(root)
 	if err != nil {
@@ -423,7 +403,7 @@ func scaffoldCell(root string, args []string) error {
 	spec := buildScaffoldCellSpec(scaffoldCellInputs{
 		ID:             *id,
 		ResolvedStruct: resolvedStruct,
-		Package:        pkg,
+		Package:        *id,
 		ModulePath:     mod,
 		OwnerTeam:      *team,
 		OwnerRole:      *role,
@@ -433,19 +413,28 @@ func scaffoldCell(root string, args []string) error {
 		WithEvents:     *withEvents,
 		WithBoth:       *withBoth,
 	})
+	spec.SkipGenerate = *skipGenerate
 
-	bundleSpec := spec
-	bundleSpec.DryRun = *dryRun
-	if err := cellgen.ScaffoldCellBundle(root, bundleSpec); err != nil {
+	realRoot, err := pathsafe.ResolveRoot(root)
+	if err != nil {
+		return fmt.Errorf("scaffold cell: resolve project root: %w", err)
+	}
+
+	plan, err := cellgen.PlanCellBundleScaffold(realRoot, spec)
+	if err != nil {
+		return err
+	}
+
+	if err := pathsafe.WritePlannedFiles(realRoot, plan, *dryRun); err != nil {
 		return err
 	}
 
 	if *dryRun {
-		// F8: list the full plan so callers can see all paths that would be written.
-		// ScaffoldCellBundle already called WritePlannedFiles(dryRun=true) which
-		// validates and returns nil without writing. Re-derive paths from the spec
-		// for display purposes using root (already resolved by the caller).
-		return printScaffoldCellDryRunPlan(root, spec)
+		for _, p := range pathsafe.PlannedPaths(plan) {
+			rel, _ := filepath.Rel(realRoot, p)
+			fmt.Printf(dryRunCreatePathFmt, filepath.ToSlash(rel))
+		}
+		return nil
 	}
 
 	reportScaffold(scaffoldReport{
@@ -458,29 +447,6 @@ func scaffoldCell(root string, args []string) error {
 		fmt.Printf("scaffold cell: skipped auto-generate (--skip-generate). "+
 			"Run `gocell generate cell %s` and `gocell generate contract --all` to materialize codegen output.\n",
 			*id)
-		return nil
-	}
-	return autoGenerateCellBundleArtifacts(root, *id)
-}
-
-// autoGenerateCellBundleArtifacts runs cellgen + contractgen for a freshly
-// scaffolded bundle. The just-written cell + contract yaml files are not in
-// the parser's in-memory state; re-parse from disk before generating.
-func autoGenerateCellBundleArtifacts(root, cellID string) error {
-	project, err := metadata.NewParser(root).Parse()
-	if err != nil {
-		return fmt.Errorf("scaffold cell: re-parse project for codegen: %w", err)
-	}
-	// Generate contracts first so generated DTO types are available when
-	// cell_gen.go is rendered. Restrict to contracts owned by the new cell
-	// so we don't re-scan the entire project on every scaffold invocation.
-	if _, err := contractgen.Generate(root, project, contractgen.Options{
-		Scope: contractgen.ScopeCell(cellID),
-	}); err != nil {
-		return fmt.Errorf("scaffold cell: generate contracts: %w", err)
-	}
-	if _, err := cellgen.Generate(root, project, cellgen.Options{OnlyCell: cellID}); err != nil {
-		return fmt.Errorf("scaffold cell: generate cell: %w", err)
 	}
 	return nil
 }

--- a/cmd/gocell/app/scaffold_bundle_test.go
+++ b/cmd/gocell/app/scaffold_bundle_test.go
@@ -54,10 +54,10 @@ func TestRunScaffoldCell_BundleProducesSliceAndContract(t *testing.T) {
 	}
 }
 
-// TestRunScaffoldCell_BundleWithAutoGenerate covers the autoGenerateCellBundleArtifacts
-// path: scaffold cell without --skip-generate must produce both cellgen and
-// contractgen output (cell_gen.go + types_gen.go) so the bundle is buildable
-// + testable end-to-end.
+// TestRunScaffoldCell_BundleWithAutoGenerate covers the PlanCellBundleScaffold
+// derived-codegen path: scaffold cell without --skip-generate must produce both
+// cellgen and contractgen output (cell_gen.go + types_gen.go) so the bundle is
+// buildable + testable end-to-end.
 func TestRunScaffoldCell_BundleWithAutoGenerate(t *testing.T) {
 	t.Parallel()
 
@@ -94,6 +94,23 @@ func setupBundleTestProject(t *testing.T) string {
 		[]byte("module github.com/ghbvf/gocell\n\ngo 1.23\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+
+	// Copy the shared error schema so contractgen (invoked by --skip-generate=false
+	// paths) can resolve relative SchemaRef links in scaffolded contract.yaml files.
+	schemaDir := filepath.Join(root, "contracts", "shared", "errors")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realSchemaPath := filepath.Join("..", "..", "..", "..", "contracts", "shared", "errors", "error-response-v1.schema.json")
+	schemaContent, err := os.ReadFile(realSchemaPath) //nolint:gosec // test fixture from known path
+	if err != nil {
+		t.Skipf("cannot read shared error schema (not in expected location): %v", err)
+	}
+	schemaOut := filepath.Join(schemaDir, "error-response-v1.schema.json")
+	if err := os.WriteFile(schemaOut, schemaContent, 0o644); err != nil { //nolint:gosec // tempdir test fixture
+		t.Fatal(err)
+	}
+
 	return root
 }
 
@@ -105,8 +122,8 @@ func setupBundleTestProject(t *testing.T) string {
 // BOTH skeleton paths AND derived codegen paths (cell_gen.go, types_gen.go,
 // iface_gen.go, handler_gen.go), and writes ZERO files to disk.
 //
-// RED: current scaffoldCell returns early before autoGenerateCellBundleArtifacts,
-// so dry-run only prints skeleton paths and misses derived files.
+// GREEN: PlanCellBundleScaffold (via appendDerivedCodegenStaged) merges skeleton
+// and derived files into a single plan; dry-run prints the full merged plan.
 func TestRunScaffoldCell_DryRun_PrintsDerivedPaths(t *testing.T) {
 	t.Parallel()
 
@@ -143,7 +160,8 @@ func TestRunScaffoldCell_DryRun_PrintsDerivedPaths(t *testing.T) {
 		}
 	}
 
-	// Derived codegen paths must also appear.
+	// Derived codegen paths must also appear — fatal so test doesn't silently
+	// pass vacuously when contractgen skips rendering.
 	derivedPaths := []string{
 		"cells/drycell/cell_gen.go",
 		"generated/contracts/http/drycell/example/v1/types_gen.go",
@@ -153,7 +171,7 @@ func TestRunScaffoldCell_DryRun_PrintsDerivedPaths(t *testing.T) {
 	for _, rel := range derivedPaths {
 		wantLine := fmt.Sprintf("(dry-run) Would create %s", rel)
 		if !strings.Contains(out, wantLine) {
-			t.Errorf("dry-run output missing derived path %q\nfull output:\n%s", wantLine, out)
+			t.Fatalf("dry-run output missing derived path %q\nfull output:\n%s", wantLine, out)
 		}
 	}
 

--- a/cmd/gocell/app/scaffold_bundle_test.go
+++ b/cmd/gocell/app/scaffold_bundle_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,4 +95,169 @@ func setupBundleTestProject(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return root
+}
+
+// ---------------------------------------------------------------------------
+// D7 RED tests — SCAFFOLD-CELL-BUNDLE-CROSS-STAGE-PLAN-MERGE-01
+// ---------------------------------------------------------------------------
+
+// TestRunScaffoldCell_DryRun_PrintsDerivedPaths verifies that --dry-run prints
+// BOTH skeleton paths AND derived codegen paths (cell_gen.go, types_gen.go,
+// iface_gen.go, handler_gen.go), and writes ZERO files to disk.
+//
+// RED: current scaffoldCell returns early before autoGenerateCellBundleArtifacts,
+// so dry-run only prints skeleton paths and misses derived files.
+func TestRunScaffoldCell_DryRun_PrintsDerivedPaths(t *testing.T) {
+	t.Parallel()
+
+	root := setupBundleTestProject(t)
+
+	args := []string{
+		"--id=drycell",
+		"--type=core",
+		"--level=L2",
+		"--team=platform",
+		"--role=cell-owner",
+		"--with-http",
+		"--dry-run",
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = scaffoldCell(root, args)
+	})
+	if runErr != nil {
+		t.Fatalf("scaffoldCell dry-run: %v", runErr)
+	}
+
+	// Skeleton paths must appear.
+	skeletonPaths := []string{
+		"cells/drycell/cell.yaml",
+		"cells/drycell/cell.go",
+		"cells/drycell/slices/drycellexample/slice.yaml",
+	}
+	for _, rel := range skeletonPaths {
+		wantLine := fmt.Sprintf("(dry-run) Would create %s", rel)
+		if !strings.Contains(out, wantLine) {
+			t.Errorf("dry-run output missing skeleton path %q\nfull output:\n%s", wantLine, out)
+		}
+	}
+
+	// Derived codegen paths must also appear.
+	derivedPaths := []string{
+		"cells/drycell/cell_gen.go",
+		"generated/contracts/http/drycell/example/v1/types_gen.go",
+		"generated/contracts/http/drycell/example/v1/iface_gen.go",
+		"generated/contracts/http/drycell/example/v1/handler_gen.go",
+	}
+	for _, rel := range derivedPaths {
+		wantLine := fmt.Sprintf("(dry-run) Would create %s", rel)
+		if !strings.Contains(out, wantLine) {
+			t.Errorf("dry-run output missing derived path %q\nfull output:\n%s", wantLine, out)
+		}
+	}
+
+	// ZERO files written to disk — including no leftover staging dir.
+	if _, err := os.Stat(filepath.Join(root, "cells", "drycell")); err == nil {
+		t.Error("dry-run: cells/drycell must not exist on disk")
+	}
+	if _, err := os.Stat(filepath.Join(root, "generated")); err == nil {
+		t.Error("dry-run: generated/ must not exist on disk")
+	}
+}
+
+// TestRunScaffoldCell_LiveRollback_OnDerivedConflict verifies that when a derived
+// path pre-exists as a conflicting non-overwritable obstacle, the ENTIRE plan
+// (skeleton + derived) rolls back: both skeleton files and derived files are absent.
+//
+// RED: current code writes skeleton first then derived in a separate call;
+// derived failure leaves skeleton half-written.
+func TestRunScaffoldCell_LiveRollback_OnDerivedConflict(t *testing.T) {
+	t.Parallel()
+
+	root := setupBundleTestProject(t)
+
+	// Pre-place a non-ForceOverwrite conflicting directory at the types_gen.go path
+	// that will cause WritePlannedFiles to fail on the derived slot.
+	conflictDir := filepath.Join(root, "generated", "contracts", "http", "rollbackcell", "example", "v1", "types_gen.go")
+	if err := os.MkdirAll(conflictDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Now types_gen.go is a directory — writing a file at that path will fail.
+
+	args := []string{
+		"--id=rollbackcell",
+		"--type=core",
+		"--level=L2",
+		"--team=platform",
+		"--role=cell-owner",
+		"--with-http",
+	}
+	err := scaffoldCell(root, args)
+	if err == nil {
+		t.Fatal("scaffoldCell with conflicting derived path: want error, got nil")
+	}
+
+	// Skeleton files must not exist after rollback.
+	for _, rel := range []string{
+		"cells/rollbackcell/cell.yaml",
+		"cells/rollbackcell/cell.go",
+		"cells/rollbackcell/slices/rollbackcellexample/slice.yaml",
+	} {
+		if _, statErr := os.Stat(filepath.Join(root, rel)); statErr == nil {
+			t.Errorf("rollback: file must not exist: %s", rel)
+		}
+	}
+	// Derived files must not exist after rollback (except the pre-placed obstacle).
+	for _, rel := range []string{
+		"cells/rollbackcell/cell_gen.go",
+	} {
+		if _, statErr := os.Stat(filepath.Join(root, rel)); statErr == nil {
+			t.Errorf("rollback: derived file must not exist: %s", rel)
+		}
+	}
+}
+
+// TestRunScaffoldCell_SkipGenerate_NoDerived verifies that --skip-generate
+// produces only skeleton files and no derived codegen (*_gen.go) files.
+//
+// This tests the new SkipGenerate path in PlanCellBundleScaffold.
+func TestRunScaffoldCell_SkipGenerate_NoDerived(t *testing.T) {
+	t.Parallel()
+
+	root := setupBundleTestProject(t)
+
+	args := []string{
+		"--id=skipgencell",
+		"--type=core",
+		"--level=L2",
+		"--team=platform",
+		"--role=cell-owner",
+		"--with-http",
+		"--skip-generate",
+	}
+	if err := scaffoldCell(root, args); err != nil {
+		t.Fatalf("scaffoldCell --skip-generate: %v", err)
+	}
+
+	// Skeleton files must exist.
+	for _, rel := range []string{
+		"cells/skipgencell/cell.yaml",
+		"cells/skipgencell/cell.go",
+		"cells/skipgencell/slices/skipgencellexample/slice.yaml",
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Errorf("skip-generate: skeleton file missing %s: %v", rel, err)
+		}
+	}
+
+	// Derived codegen files must NOT exist.
+	for _, rel := range []string{
+		"cells/skipgencell/cell_gen.go",
+		"generated/contracts/http/skipgencell/example/v1/types_gen.go",
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err == nil {
+			t.Errorf("skip-generate: derived file must not exist: %s", rel)
+		}
+	}
 }

--- a/pkg/pathsafe/pathsafe.go
+++ b/pkg/pathsafe/pathsafe.go
@@ -233,7 +233,9 @@ func PlannedPaths(plan []PlannedFile) []string {
 //     rejection happens at writePass via the fd-anchored openat(O_NOFOLLOW)
 //     chain (unix) or O_EXCL leaf write (windows advisory).
 //  2. Each AbsPath must not already exist (conflict detection over the
-//     FULL plan — no partial-write semantics).
+//     FULL plan — no partial-write semantics). ForceOverwrite entries are
+//     exempt here but still pass the forceOverwritePreflightPass inode-kind
+//     gate so dry-run rejects exactly what live would (F2 parity).
 //  3. dryRun returns nil after steps 1-2 succeed (validation only, no write).
 //  4. Otherwise: mkdir all required directories, write all files, then
 //     on the FIRST failure remove every file and directory created during
@@ -256,6 +258,9 @@ func WritePlannedFiles(realRoot string, plan []PlannedFile, dryRun bool) error {
 		return err
 	}
 	if err := conflictPass(plan); err != nil {
+		return err
+	}
+	if err := forceOverwritePreflightPass(plan); err != nil {
 		return err
 	}
 	if dryRun {
@@ -401,8 +406,12 @@ func captureOriginal(path string) (writeRecord, error) {
 			errcode.WithInternal(fmt.Sprintf("path=%s", path)))
 	}
 	mode := info.Mode()
-	switch {
-	case mode.IsRegular():
+	if !forceOverwriteRestorable(mode) {
+		return writeRecord{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"pathsafe: ForceOverwrite supports regular files and symlinks only",
+			errcode.WithDetails(slog.String("path", path)))
+	}
+	if mode.IsRegular() {
 		// path already passed planContainmentPass + caller-side ContainPath;
 		// this read is the capture-for-rollback step (path-based; rollback
 		// is not a TOCTOU boundary — see rollbackWrites godoc).
@@ -418,23 +427,68 @@ func captureOriginal(path string) (writeRecord, error) {
 			originalBytes: content,
 			originalMode:  mode.Perm(),
 		}, nil
-	case mode&os.ModeSymlink != 0:
-		target, readErr := os.Readlink(path)
-		if readErr != nil {
-			return writeRecord{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
-				"pathsafe: readlink original for ForceOverwrite capture", readErr,
-				errcode.WithInternal(fmt.Sprintf("path=%s", path)))
-		}
-		return writeRecord{
-			path:           path,
-			originalKind:   kindSymlink,
-			originalTarget: target,
-		}, nil
-	default:
-		return writeRecord{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"pathsafe: ForceOverwrite supports regular files and symlinks only",
-			errcode.WithDetails(slog.String("path", path)))
 	}
+	// Guaranteed symlink: forceOverwriteRestorable already rejected every
+	// other inode kind above (single source for the kind gate).
+	target, readErr := os.Readlink(path)
+	if readErr != nil {
+		return writeRecord{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"pathsafe: readlink original for ForceOverwrite capture", readErr,
+			errcode.WithInternal(fmt.Sprintf("path=%s", path)))
+	}
+	return writeRecord{
+		path:           path,
+		originalKind:   kindSymlink,
+		originalTarget: target,
+	}, nil
+}
+
+// forceOverwriteRestorable reports whether an existing inode of the given
+// mode at a ForceOverwrite target can be coherently captured and rolled back
+// (regular file or symlink). Directories / devices / pipes / sockets cannot
+// and must be rejected pre-write. This is the SINGLE source for the
+// ForceOverwrite inode-kind gate: captureOriginal (live writePass) and
+// forceOverwritePreflightPass (dry-run + pre-write) both consult it, so
+// dry-run can never accept a target that live would reject (F2 parity).
+func forceOverwriteRestorable(mode os.FileMode) bool {
+	return mode.IsRegular() || mode&os.ModeSymlink != 0
+}
+
+// forceOverwritePreflightPass runs the captureOriginal inode-kind gate over
+// every ForceOverwrite entry WITHOUT the destructive capture. It runs for
+// both dry-run and live (before any write), so:
+//
+//   - dry-run rejects exactly the ForceOverwrite targets live would reject
+//     (closes the pre-PR#544 gap where dry-run returned after conflictPass —
+//     which skips ForceOverwrite entries — and never reached the
+//     captureOriginal kind check, so a dir/device squatting a generated path
+//     passed dry-run but failed live);
+//   - live fails before the FIRST write instead of mid-plan, preserving the
+//     all-or-nothing contract symmetrically with conflictPass.
+//
+// Absent target → ok (writePass records kindNone). Lstat (not Stat) so a
+// leaf symlink is classified as symlink, not its (possibly absent) target.
+func forceOverwritePreflightPass(plan []PlannedFile) error {
+	for _, f := range plan {
+		if !f.ForceOverwrite {
+			continue
+		}
+		info, err := os.Lstat(f.AbsPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+				"pathsafe: lstat ForceOverwrite target (preflight)", err,
+				errcode.WithInternal(fmt.Sprintf("path=%s", f.AbsPath)))
+		}
+		if !forceOverwriteRestorable(info.Mode()) {
+			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				"pathsafe: ForceOverwrite supports regular files and symlinks only",
+				errcode.WithDetails(slog.String("path", f.AbsPath)))
+		}
+	}
+	return nil
 }
 
 // writePass executes the plan via the platform-specific secureMkdirAllAndWrite

--- a/pkg/pathsafe/pathsafe_lane_a_test.go
+++ b/pkg/pathsafe/pathsafe_lane_a_test.go
@@ -604,3 +604,90 @@ func TestWritePlannedFiles_PlanContainmentPass_EscapesRoot(t *testing.T) {
 		t.Fatal("WritePlannedFiles(AbsPath escapes root): want error, got nil")
 	}
 }
+
+// TestWritePlannedFiles_ForceOverwrite_DryRunLiveParity is the F2
+// conformance lock: for every ForceOverwrite target inode kind, dry-run and
+// live must agree on accept/reject. Before the forceOverwritePreflightPass
+// single-source gate, dry-run returned after conflictPass (which skips
+// ForceOverwrite entries) and never reached the captureOriginal kind check,
+// so a directory/device squatting a generated path passed dry-run but failed
+// live. The shared forceOverwriteRestorable predicate makes drift
+// unrepresentable; this test pins the observable contract.
+func TestWritePlannedFiles_ForceOverwrite_DryRunLiveParity(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("inode-kind / symlink semantics differ on windows")
+	}
+
+	cases := []struct {
+		name       string
+		setup      func(t *testing.T, abs string)
+		wantReject bool
+	}{
+		{
+			name:       "absent",
+			setup:      func(t *testing.T, abs string) {},
+			wantReject: false,
+		},
+		{
+			name: "regular_file",
+			setup: func(t *testing.T, abs string) {
+				if err := os.WriteFile(abs, []byte("// old\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReject: false,
+		},
+		{
+			name: "symlink",
+			setup: func(t *testing.T, abs string) {
+				if err := os.Symlink(filepath.Join(t.TempDir(), "x"), abs); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReject: false,
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T, abs string) {
+				if err := os.Mkdir(abs, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReject: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Two independent roots so the live write of one case cannot
+			// perturb the dry-run of another.
+			dryRoot := resolveRealRoot(t)
+			liveRoot := resolveRealRoot(t)
+
+			mk := func(root string) []pathsafe.PlannedFile {
+				abs := filepath.Join(root, "generated", "stamp.go")
+				if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				tc.setup(t, abs)
+				return []pathsafe.PlannedFile{
+					{AbsPath: abs, Content: []byte("// regenerated\n"), ForceOverwrite: true},
+				}
+			}
+
+			dryErr := pathsafe.WritePlannedFiles(dryRoot, mk(dryRoot), true /* dryRun */)
+			liveErr := pathsafe.WritePlannedFiles(liveRoot, mk(liveRoot), false)
+
+			if (dryErr != nil) != (liveErr != nil) {
+				t.Fatalf("dry-run/live parity broken for %s: dryErr=%v liveErr=%v",
+					tc.name, dryErr, liveErr)
+			}
+			if (dryErr != nil) != tc.wantReject {
+				t.Fatalf("%s: wantReject=%v but dryErr=%v", tc.name, tc.wantReject, dryErr)
+			}
+		})
+	}
+}

--- a/tools/archtest/scaffold_bundle_invariants_test.go
+++ b/tools/archtest/scaffold_bundle_invariants_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/ghbvf/gocell/pkg/pathsafe"
 	"github.com/ghbvf/gocell/tools/codegen/cellgen"
 )
 
@@ -53,7 +54,24 @@ var scaffoldSmokeSpec = cellgen.ScaffoldSpec{
 	ConsistencyLevel: "L1",
 }
 
-// TestScaffoldBundle_CellMarkerEmbedded asserts that ScaffoldCellBundle
+// scaffoldSmokeBundle writes the skeleton bundle for scaffoldSmokeSpec into root
+// using PlanCellBundleScaffold (SkipGenerate=true) + WritePlannedFiles.
+func scaffoldSmokeBundle(t *testing.T, root string) error {
+	t.Helper()
+	realRoot, err := pathsafe.ResolveRoot(root)
+	if err != nil {
+		return err
+	}
+	spec := scaffoldSmokeSpec
+	spec.SkipGenerate = true
+	plan, err := cellgen.PlanCellBundleScaffold(realRoot, spec)
+	if err != nil {
+		return err
+	}
+	return pathsafe.WritePlannedFiles(realRoot, plan, false)
+}
+
+// TestScaffoldBundle_CellMarkerEmbedded asserts that PlanCellBundleScaffold
 // produces a cell.go that contains the K#05 +cell:listener: marker.
 //
 // INVARIANT: SCAFFOLD-BUNDLE-MARKER-01
@@ -61,8 +79,8 @@ var scaffoldSmokeSpec = cellgen.ScaffoldSpec{
 func TestScaffoldBundle_CellMarkerEmbedded(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := cellgen.ScaffoldCellBundle(dir, scaffoldSmokeSpec); err != nil {
-		t.Fatalf("ScaffoldCellBundle: %v", err)
+	if err := scaffoldSmokeBundle(t, dir); err != nil {
+		t.Fatalf("scaffoldSmokeBundle: %v", err)
 	}
 	cellGoPath := filepath.Join(dir, "cells", "smokecell", "cell.go")
 	content, err := os.ReadFile(cellGoPath) //nolint:gosec // tempdir test fixture
@@ -175,7 +193,7 @@ func TestScaffoldBundle_ListenerMarkerTypedConst(t *testing.T) {
 	}
 }
 
-// TestScaffoldBundle_ContractYAMLOmitsCodegenKey asserts that ScaffoldCellBundle
+// TestScaffoldBundle_ContractYAMLOmitsCodegenKey asserts that PlanCellBundleScaffold
 // produces a contract.yaml without a top-level `codegen:` key.
 //
 // INVARIANT: SCAFFOLD-BUNDLE-NO-CODEGEN-LITERAL-01
@@ -183,7 +201,7 @@ func TestScaffoldBundle_ListenerMarkerTypedConst(t *testing.T) {
 func TestScaffoldBundle_ContractYAMLOmitsCodegenKey(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	require.NoError(t, cellgen.ScaffoldCellBundle(dir, scaffoldSmokeSpec))
+	require.NoError(t, scaffoldSmokeBundle(t, dir))
 	contractPath := filepath.Join(dir, "contracts", "http", "smokecell", "example", "v1", "contract.yaml")
 	raw, err := os.ReadFile(contractPath) //nolint:gosec // tempdir test fixture
 	require.NoError(t, err)

--- a/tools/archtest/scaffold_derived_forceoverwrite_test.go
+++ b/tools/archtest/scaffold_derived_forceoverwrite_test.go
@@ -1,0 +1,222 @@
+// INVARIANT: SCAFFOLD-DERIVED-FORCEOVERWRITE-01
+//
+// Every derived-codegen pathsafe.PlannedFile carrying ForceOverwrite=true in
+// tools/codegen/cellgen MUST be constructed by planDerivedArtifact
+// (stage_render.go). planDerivedArtifact is the sole site that restores the
+// governance.IsGoCellGenerated overwrite gate which the legacy codegen.Write
+// enforced before PR #544 routed derived writes through the pathsafe
+// single-plan funnel. A direct pathsafe.PlannedFile{...ForceOverwrite:true}
+// composite literal anywhere else in cellgen would silently overwrite a
+// hand-written (non-generated) file on the project tree — exactly the F1
+// regression this rule locks shut.
+//
+// AI-rebust: Medium (downstream caller-allowlist, type-aware via go/types —
+// the literal's type is resolved to pkg/pathsafe.PlannedFile, not matched by
+// name). Upstream is Soft: pathsafe.PlannedFile.ForceOverwrite is an exported
+// field that pathsafe's cross-package callers set directly, so "skip the
+// constructor" cannot be made unrepresentable at the type level here.
+// Upstream Hard-ization is tracked by backlog
+// PATHSAFE-FORCEOVERWRITE-TYPED-CTOR-01 (cap-14), same Lane E typed-scaffold
+// single-source收编 as PATHSAFE-PLANSET-TYPED-HARD-01.
+//
+// # Recognition: type-aware
+//
+// A CompositeLit matches only when info.Types[lit.Type] resolves to the
+// *types.Named (github.com/ghbvf/gocell/pkg/pathsafe).PlannedFile. Alias
+// imports / dot-imports of pathsafe therefore cannot evade the rule.
+//
+// # Blind spots (declared per ai-collab §载体决策原则)
+//
+// EachInSubtree[ast.CompositeLit] + KeyValueExpr value inspection does NOT
+// reason about:
+//
+//  1. ForceOverwrite set to a non-literal expression that evaluates true at
+//     runtime (e.g. `ForceOverwrite: someBoolVar`). The main rule keys on the
+//     `true` *ast.Ident literal only.
+//  2. The benign propagation form `ForceOverwrite: f.ForceOverwrite` in
+//     materializeSkeletonStage (skeleton plan entries never set force=true
+//     themselves — they originate in scaffold.go / scaffold_bundle.go which
+//     never set the field — so copying the field is a no-op-true).
+//
+// TestScaffoldDerivedForceOverwrite_NoNonLiteralForms is the reverse
+// self-check: it asserts the production cellgen AST contains ONLY the two
+// expected ForceOverwrite value forms (literal `true` inside
+// planDerivedArtifact; selector `f.ForceOverwrite` inside
+// materializeSkeletonStage). Any third form — including a bool variable used
+// to sneak true past blind spot #1 — fails the self-check.
+package archtest
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+const (
+	pathsafePkgPath       = "github.com/ghbvf/gocell/pkg/pathsafe"
+	plannedFileTypeName   = "PlannedFile"
+	forceOverwriteField   = "ForceOverwrite"
+	derivedCtorFuncName   = "planDerivedArtifact"
+	skeletonStageFuncName = "materializeSkeletonStage"
+	cellgenRelPrefix      = "tools/codegen/cellgen/"
+)
+
+// isPlannedFileType reports whether expr resolves to pathsafe.PlannedFile.
+func isPlannedFileType(info *types.Info, expr ast.Expr) bool {
+	if info == nil || expr == nil {
+		return false
+	}
+	tv, ok := info.Types[expr]
+	if !ok || tv.Type == nil {
+		return false
+	}
+	named, ok := tv.Type.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == pathsafePkgPath && obj.Name() == plannedFileTypeName
+}
+
+// forceOverwriteValue returns the value expression of a ForceOverwrite
+// KeyValueExpr in lit, or nil if the field is not explicitly set.
+func forceOverwriteValue(lit *ast.CompositeLit) ast.Expr {
+	var val ast.Expr
+	EachInChildren[ast.KeyValueExpr](lit, func(kv *ast.KeyValueExpr) {
+		if val != nil {
+			return
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != forceOverwriteField {
+			return
+		}
+		val = kv.Value
+	})
+	return val
+}
+
+func isLiteralTrue(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == "true"
+}
+
+// TestScaffoldDerivedForceOverwrite_OnlyInConstructor enforces
+// SCAFFOLD-DERIVED-FORCEOVERWRITE-01: a pathsafe.PlannedFile composite literal
+// with `ForceOverwrite: true` in tools/codegen/cellgen is allowed only inside
+// func planDerivedArtifact.
+func TestScaffoldDerivedForceOverwrite_OnlyInConstructor(t *testing.T) {
+	t.Parallel()
+
+	diags := RunTyped(t, TypedOpts{}, []string{
+		"./tools/codegen/cellgen/...",
+	}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil || p.Fset == nil {
+			return nil
+		}
+		var out []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if !strings.HasPrefix(rel, cellgenRelPrefix) ||
+				strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+				if fn.Body == nil {
+					return
+				}
+				EachInSubtree[ast.CompositeLit](fn.Body, func(lit *ast.CompositeLit) {
+					if !isPlannedFileType(p.TypesInfo, lit.Type) {
+						return
+					}
+					v := forceOverwriteValue(lit)
+					if v == nil || !isLiteralTrue(v) {
+						return
+					}
+					if fn.Name != nil && fn.Name.Name == derivedCtorFuncName {
+						return
+					}
+					out = append(out, Diagnostic{
+						Rel:  rel,
+						Line: p.Fset.Position(lit.Pos()).Line,
+						Message: "SCAFFOLD-DERIVED-FORCEOVERWRITE-01: pathsafe.PlannedFile{ForceOverwrite:true} " +
+							"outside planDerivedArtifact — derived writes must go through the " +
+							"governance.IsGoCellGenerated overwrite gate (stage_render.go)",
+					})
+				})
+			})
+		}
+		return out
+	})
+	Report(t, "SCAFFOLD-DERIVED-FORCEOVERWRITE-01", diags)
+}
+
+// TestScaffoldDerivedForceOverwrite_NoNonLiteralForms is the declared
+// blind-spot reverse self-check (see file godoc): the ONLY ForceOverwrite
+// value forms permitted in production cellgen AST are
+//
+//   - literal `true` inside planDerivedArtifact
+//   - selector `f.ForceOverwrite` inside materializeSkeletonStage
+//
+// Anything else (a bool variable, a function call, a literal true outside the
+// constructor) fails — closing the "sneak true via non-literal" blind spot.
+func TestScaffoldDerivedForceOverwrite_NoNonLiteralForms(t *testing.T) {
+	t.Parallel()
+
+	diags := RunTyped(t, TypedOpts{}, []string{
+		"./tools/codegen/cellgen/...",
+	}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil || p.Fset == nil {
+			return nil
+		}
+		var out []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if !strings.HasPrefix(rel, cellgenRelPrefix) ||
+				strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+				if fn.Body == nil {
+					return
+				}
+				fnName := ""
+				if fn.Name != nil {
+					fnName = fn.Name.Name
+				}
+				EachInSubtree[ast.CompositeLit](fn.Body, func(lit *ast.CompositeLit) {
+					if !isPlannedFileType(p.TypesInfo, lit.Type) {
+						return
+					}
+					v := forceOverwriteValue(lit)
+					if v == nil {
+						return // field omitted → zero value false, fine
+					}
+					if isLiteralTrue(v) && fnName == derivedCtorFuncName {
+						return
+					}
+					if sel, ok := v.(*ast.SelectorExpr); ok &&
+						sel.Sel != nil && sel.Sel.Name == forceOverwriteField &&
+						fnName == skeletonStageFuncName {
+						return // benign skeleton propagation
+					}
+					if id, ok := v.(*ast.Ident); ok && id.Name == "false" {
+						return // explicit false → harmless
+					}
+					out = append(out, Diagnostic{
+						Rel:  rel,
+						Line: p.Fset.Position(v.Pos()).Line,
+						Message: "SCAFFOLD-DERIVED-FORCEOVERWRITE-01: unexpected ForceOverwrite value form in " +
+							fnName + " — only literal true (planDerivedArtifact) or f.ForceOverwrite " +
+							"propagation (materializeSkeletonStage) are permitted",
+					})
+				})
+			})
+		}
+		return out
+	})
+	Report(t, "SCAFFOLD-DERIVED-FORCEOVERWRITE-01", diags)
+}

--- a/tools/archtest/scaffold_write_funnel_test.go
+++ b/tools/archtest/scaffold_write_funnel_test.go
@@ -35,6 +35,9 @@
 //     including paths intentionally excluded from the depguard ban list
 //     because they have legitimate non-write os.* calls:
 //   - tools/codegen/cellgen/scaffold.go  (no os import today; future guard)
+//   - tools/codegen/cellgen/stage_render.go (os.MkdirTemp/RemoveAll/ReadFile
+//     for temp-dir lifecycle — NOT banned; any future MkdirAll/WriteFile/
+//     Mkdir/Create/OpenFile addition here WILL trip this archtest)
 //   - tools/codegen/writer.go            (os.ReadFile for drift detection)
 //   - kernel/assembly/generator.go       (os.ReadFile/Stat for go.mod metadata)
 //   - cmd/gocell/app/scaffold.go         (os.Stat for target dir checks)
@@ -87,7 +90,10 @@ var bannedOSWriteSelectors = map[string]bool{
 // scaffoldFunnelPred limits which files inside the loaded packages are
 // scanned. cmd/gocell/app/ may only match scaffold*.go (generate_catalog.go
 // and export.go are exempt — see file-level Out-of-scope godoc).
-// tools/codegen/cellgen/ may match scaffold*.go and generate_*.go.
+// tools/codegen/cellgen/ may match scaffold*.go, generate_*.go, and
+// stage_render.go (the ephemeral-staging helper that orchestrates the
+// cross-stage merge — os.MkdirTemp/RemoveAll/ReadFile are NOT banned, only
+// write-side ops MkdirAll/WriteFile/Mkdir/Create/OpenFile).
 // Everywhere else (tools/codegen/contractgen, tools/codegen top-level,
 // kernel/assembly): all non-test .go files.
 func scaffoldFunnelPred(rel string) bool {
@@ -100,7 +106,9 @@ func scaffoldFunnelPred(rel string) bool {
 		return strings.HasPrefix(base, "scaffold")
 	}
 	if strings.HasPrefix(rel, "tools/codegen/cellgen/") {
-		return strings.HasPrefix(base, "scaffold") || strings.HasPrefix(base, "generate_")
+		return strings.HasPrefix(base, "scaffold") ||
+			strings.HasPrefix(base, "generate_") ||
+			base == "stage_render.go"
 	}
 	return true
 }
@@ -143,11 +151,16 @@ func canonicalOSWriteCall(info *types.Info, call *ast.CallExpr) string {
 // calls in scaffold paths outside pkg/pathsafe.
 //
 // Scanned paths (predicate-filtered after package load):
-//   - tools/codegen/cellgen/         (ScaffoldCell, ScaffoldCellBundle, generate_*)
+//   - tools/codegen/cellgen/         (PlanCellBundleScaffold, generate_*, stage_render.go)
 //   - tools/codegen/contractgen/     (generator + writer)
 //   - tools/codegen/writer.go        (codegen.Write — top-level only)
 //   - kernel/assembly/               (Generator.PlanAssemblyScaffold)
 //   - cmd/gocell/app/scaffold*.go    (scaffoldSlice, scaffoldContract, scaffoldJourney)
+//
+// stage_render.go blind-spot: os.MkdirTemp/RemoveAll/ReadFile are NOT in
+// bannedOSWriteSelectors (they manage temp-dir lifetime, not project-tree writes).
+// Only write-side ops (MkdirAll/WriteFile/Mkdir/Create/OpenFile) are banned.
+// The file IS scanned — any future project-tree write call added there trips this test.
 //
 // Allowlist (only these files may call banned os selectors):
 //   - pkg/pathsafe/pathsafe.go (not loaded by this test; out of scope by construction)

--- a/tools/codegen/cellgen/scaffold.go
+++ b/tools/codegen/cellgen/scaffold.go
@@ -59,9 +59,10 @@ type ScaffoldSpec struct {
 	// ConsistencyLevel is the cell consistency level. Must be one of validConsistencyLevels.
 	// Defaults to "L1" when empty.
 	ConsistencyLevel string
-	// DryRun, when true, renders all templates (validating their output) and
-	// performs conflict detection but does not write any files to disk.
-	DryRun bool
+	// SkipGenerate, when true, skips the appended cellgen/contractgen derived
+	// artifacts from PlanCellBundleScaffold. The resulting plan contains only
+	// skeleton files. Mirrors assembly.AssemblyScaffoldSpec.SkipGenerate semantics.
+	SkipGenerate bool
 	// WithHTTP, WithEvents, WithBoth control K#09 ScaffoldCellBundle's contract
 	// variant. WithHTTP produces an HTTP request/response contract (default
 	// when none of the three flags are set). WithEvents produces an event
@@ -99,11 +100,6 @@ l0Dependencies: []
 // ScaffoldCell renders a new cell skeleton at root/<targetDir> with stub
 // markers, cell.yaml, and the K#05 marker conventions in place. Returns an
 // error if any output file already exists (caller must remove first).
-//
-// When spec.DryRun is true, templates are rendered (validating output) and
-// conflict detection is performed, but no files are written. This allows
-// callers to validate inputs and detect path conflicts in CI without mutating
-// the filesystem, while still catching template/input errors early.
 //
 // Generated files:
 //   - <root>/<targetDir>/cell.go  — struct + stub markers + initInternal hook
@@ -157,7 +153,7 @@ func ScaffoldCell(root, targetDir string, spec ScaffoldSpec) error {
 	// structured *errcode.Error (ErrConflict for file-exists, ErrInternal for
 	// OS errors) so re-wrapping would clobber the Code and lose the caller's
 	// ability to errors.As to ErrConflict.
-	return pathsafe.WritePlannedFiles(realRoot, plan, spec.DryRun)
+	return pathsafe.WritePlannedFiles(realRoot, plan, false)
 }
 
 // validateScaffoldSpec returns an error if any required field is missing or

--- a/tools/codegen/cellgen/scaffold_bundle.go
+++ b/tools/codegen/cellgen/scaffold_bundle.go
@@ -202,7 +202,7 @@ func planCellBundle(realRoot string, spec ScaffoldSpec) ([]pathsafe.PlannedFile,
 		plan = append(plan, items...)
 	}
 	if withEvents {
-		items, err := planEventExampleArtifacts(realRoot, spec, cellNoDash, sliceID)
+		items, err := planEventExampleArtifacts(realRoot, spec, cellNoDash, sliceID, withHTTP)
 		if err != nil {
 			return nil, err
 		}
@@ -279,10 +279,13 @@ func planHTTPExampleArtifacts(realRoot string, spec ScaffoldSpec, cellNoDash, sl
 }
 
 // planEventExampleArtifacts renders the event slice + contract pair and returns
-// them as PlannedFiles. When spec.WithBoth, uses a separate event slice ID.
-func planEventExampleArtifacts(realRoot string, spec ScaffoldSpec, cellNoDash, sliceID string) ([]pathsafe.PlannedFile, error) {
+// them as PlannedFiles. When withHTTP is true (an HTTP slice is also present),
+// uses a distinct event sliceID (cellNoDash+"eventexample") to avoid duplicate
+// AbsPath collisions — gating on withHTTP rather than spec.WithBoth unifies the
+// WithBoth path and the WithHTTP&&WithEvents path under one rule.
+func planEventExampleArtifacts(realRoot string, spec ScaffoldSpec, cellNoDash, sliceID string, withHTTP bool) ([]pathsafe.PlannedFile, error) {
 	eventSliceID := sliceID
-	if spec.WithBoth {
+	if withHTTP {
 		eventSliceID = cellNoDash + "eventexample"
 	}
 	bd := bundleData{

--- a/tools/codegen/cellgen/scaffold_bundle.go
+++ b/tools/codegen/cellgen/scaffold_bundle.go
@@ -1,8 +1,9 @@
-// scaffold_bundle.go implements K#09 ScaffoldCellBundle: a one-shot scaffold
-// orchestrator that produces a compilable + testable cell skeleton in a
-// single call. Composes ScaffoldCell (cell.yaml + cell.go) with
-// ScaffoldExampleSlice (slice.yaml + service.go + service_test.go) and
-// ScaffoldExampleContract (contract.yaml + JSON schemas).
+// scaffold_bundle.go implements K#09 PlanCellBundleScaffold: a one-shot scaffold
+// planner that returns a merged []pathsafe.PlannedFile covering a compilable +
+// testable cell skeleton. Composes planCell (cell.yaml + cell.go) with
+// planHTTPExampleArtifacts / planEventExampleArtifacts (slice.yaml + service.go +
+// service_test.go + contract.yaml + JSON schemas). When SkipGenerate is false,
+// appendDerivedCodegenStaged (stage_render.go) appends derived codegen files.
 //
 // The resulting bundle layout (HTTP variant):
 //
@@ -55,7 +56,7 @@ var contractBundleTemplate = template.Must(template.New("scaffold-contract.tmpl"
 	ParseFS(templateFS, "templates/scaffold-contract.tmpl"))
 
 // bundleData is the shared template context for slice + contract bundle
-// templates. Computed once in ScaffoldCellBundle from a ScaffoldSpec.
+// templates. Computed once in planCellBundle from a ScaffoldSpec.
 type bundleData struct {
 	CellID         string
 	SlicePackage   string // SliceID with no dashes (Go package name)

--- a/tools/codegen/cellgen/scaffold_bundle.go
+++ b/tools/codegen/cellgen/scaffold_bundle.go
@@ -65,45 +65,42 @@ type bundleData struct {
 	ListenerMarker string // K#05 cell:listener marker; sourced from ListenerMarker const
 }
 
-// ScaffoldCellBundle is the K#09 one-shot scaffold orchestrator. It composes
-// ScaffoldCell + ScaffoldExampleSlice + ScaffoldExampleContract; on dry-run
-// every template renders (catching errors) and conflict detection runs but
-// no files are written.
+// PlanCellBundleScaffold is the K#09 one-shot scaffold planner. It produces a
+// merged []pathsafe.PlannedFile covering:
+//   - skeleton files (cell.go, cell.yaml, slice artifacts, contract artifacts)
+//     with ForceOverwrite=false — conflict detection rejects pre-existing files.
+//   - when spec.SkipGenerate is false: derived codegen files (cell_gen.go,
+//     generated/contracts/.../types_gen.go, iface_gen.go, handler_gen.go)
+//     with ForceOverwrite=true — always regenerated without conflict.
 //
 // Defaults: when neither WithHTTP nor WithEvents is set, WithHTTP applies.
 // WithBoth produces both an HTTP contract and an event contract.
 //
-// Writes are atomic: all files are planned first, then written in a single
-// pathsafe.WritePlannedFiles call. On failure the entire bundle is rolled back.
-func ScaffoldCellBundle(root string, spec ScaffoldSpec) error {
-	if err := validateScaffoldSpec(spec); err != nil {
-		return err
-	}
-
-	realRoot, err := pathsafe.ResolveRoot(root)
-	if err != nil {
-		return errcode.Wrap(errcode.KindInternal, errcode.ErrInternal, "scaffold bundle: validation failed", err)
-	}
-
-	plan, err := planCellBundle(realRoot, spec)
-	if err != nil {
-		return err
-	}
-
-	// Return WritePlannedFiles error directly: pathsafe already returns a
-	// structured *errcode.Error (ErrConflict for file-exists, ErrInternal for
-	// OS errors) so re-wrapping would clobber the Code.
-	return pathsafe.WritePlannedFiles(realRoot, plan, spec.DryRun)
-}
-
-// PlanCellBundleForDryRun is the exported equivalent of planCellBundle,
-// allowing callers (e.g. scaffoldCell dry-run in cmd/gocell/app) to enumerate
-// the full file list without writing anything. realRoot must be the output of
-// pathsafe.ResolveRoot.
+// realRoot must be the output of pathsafe.ResolveRoot. The returned plan is
+// written by the caller via a single pathsafe.WritePlannedFiles call, ensuring
+// all-or-nothing atomicity across skeleton + derived files.
 //
-// Applies the same default + consistency-level validation as ScaffoldCellBundle.
-func PlanCellBundleForDryRun(realRoot string, spec ScaffoldSpec) ([]pathsafe.PlannedFile, error) {
-	return planCellBundle(realRoot, spec)
+// Mirrors kernel/assembly.Generator.PlanAssemblyScaffold + appendGeneratedFiles.
+func PlanCellBundleScaffold(realRoot string, spec ScaffoldSpec) ([]pathsafe.PlannedFile, error) {
+	if err := validateScaffoldSpec(spec); err != nil {
+		return nil, err
+	}
+
+	skeletonPlan, err := planCellBundle(realRoot, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	if spec.SkipGenerate {
+		return skeletonPlan, nil
+	}
+
+	// Ephemeral staging: write skeleton into a temp dir (via pathsafe funnel),
+	// parse metadata, render derived artifacts in-memory, rebase to realRoot.
+	// The staging lifecycle (MkdirTemp + RemoveAll) is encapsulated in
+	// appendDerivedCodegenStaged (stage_render.go) — os calls are not in
+	// scaffold_bundle.go which is in the depguard scaffold-os-ban list.
+	return appendDerivedCodegenStaged(realRoot, spec.CellID, skeletonPlan)
 }
 
 // minCellConsistencyLevel returns the minimum cell consistency level required
@@ -283,7 +280,9 @@ func planHTTPExampleArtifacts(realRoot string, spec ScaffoldSpec, cellNoDash, sl
 // uses a distinct event sliceID (cellNoDash+"eventexample") to avoid duplicate
 // AbsPath collisions — gating on withHTTP rather than spec.WithBoth unifies the
 // WithBoth path and the WithHTTP&&WithEvents path under one rule.
-func planEventExampleArtifacts(realRoot string, spec ScaffoldSpec, cellNoDash, sliceID string, withHTTP bool) ([]pathsafe.PlannedFile, error) {
+func planEventExampleArtifacts(
+	realRoot string, spec ScaffoldSpec, cellNoDash, sliceID string, withHTTP bool,
+) ([]pathsafe.PlannedFile, error) {
 	eventSliceID := sliceID
 	if withHTTP {
 		eventSliceID = cellNoDash + "eventexample"

--- a/tools/codegen/cellgen/scaffold_bundle_test.go
+++ b/tools/codegen/cellgen/scaffold_bundle_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/pathsafe"
 )
 
 // TestScaffoldCellBundle_HTTP is a RED test for K#09 cellgen.ScaffoldCellBundle:
@@ -582,6 +583,70 @@ func TestScaffoldSpec_Validate_AcceptsL2WithEvents(t *testing.T) {
 	}
 	if err := ScaffoldCellBundle(dir, spec); err != nil {
 		t.Fatalf("expected no error for L2+WithEvents, got: %v", err)
+	}
+}
+
+// TestPlanEventExampleArtifacts_HTTPAndEvents_DistinctSliceID is a RED test for
+// SCAFFOLD-BUNDLE-VARIANT-DUPLICATE-PATH-01. When WithHTTP=true and
+// WithEvents=true (WithBoth=false), the event slice must use a distinct sliceID
+// (cellNoDash+"eventexample") instead of the same sliceID as the HTTP slice.
+// The old code only assigned the distinct ID when WithBoth=true, causing both
+// HTTP and event slices to write under the same directory → duplicate AbsPath.
+func TestPlanEventExampleArtifacts_HTTPAndEvents_DistinctSliceID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	spec := ScaffoldSpec{
+		CellID:           "myhttpcell",
+		StructName:       "MyHTTPCell",
+		Package:          "myhttpcell",
+		ModulePath:       "github.com/ghbvf/gocell",
+		OwnerTeam:        "platform",
+		OwnerRole:        "cell-owner",
+		Type:             "core",
+		ConsistencyLevel: "L2", // events require >= L2
+		WithHTTP:         true,
+		WithEvents:       true,
+		// WithBoth intentionally false — this is the degenerate "both flags" path
+	}
+
+	realRoot, err := pathsafe.ResolveRoot(dir)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+	plan, err := planCellBundle(realRoot, spec)
+	if err != nil {
+		t.Fatalf("planCellBundle: %v", err)
+	}
+
+	// Assert no duplicate AbsPath entries.
+	seen := make(map[string]int)
+	for _, f := range plan {
+		seen[f.AbsPath]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate AbsPath in plan: %s (count=%d)", path, count)
+		}
+	}
+
+	// Assert that the HTTP and event slices have distinct directories.
+	var httpSliceDir, eventSliceDir string
+	for _, f := range plan {
+		rel, _ := filepath.Rel(realRoot, f.AbsPath)
+		rel = filepath.ToSlash(rel)
+		if strings.HasPrefix(rel, "cells/myhttpcell/slices/myhttpcellexample/") {
+			httpSliceDir = "cells/myhttpcell/slices/myhttpcellexample"
+		}
+		if strings.HasPrefix(rel, "cells/myhttpcell/slices/myhttpcelleventexample/") {
+			eventSliceDir = "cells/myhttpcell/slices/myhttpcelleventexample"
+		}
+	}
+	if httpSliceDir == "" {
+		t.Errorf("HTTP slice dir cells/myhttpcell/slices/myhttpcellexample not found in plan")
+	}
+	if eventSliceDir == "" {
+		t.Errorf("event slice dir cells/myhttpcell/slices/myhttpcelleventexample not found in plan")
 	}
 }
 

--- a/tools/codegen/cellgen/scaffold_bundle_test.go
+++ b/tools/codegen/cellgen/scaffold_bundle_test.go
@@ -1,6 +1,7 @@
 package cellgen
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -803,13 +804,18 @@ func TestPlanCellBundleScaffold_MergedPlan(t *testing.T) {
 // remains in os.TempDir(). This locks the F2 fix: named return + deferred
 // cleanup inside materializeSkeletonStage.
 func TestMaterializeSkeletonStage_NoLeakOnInnerFailure(t *testing.T) {
-	t.Parallel()
+	// Not parallel: mutates package-level stageTempParent via
+	// isolateStageParent. Confining it to the sequential test phase means no
+	// concurrent materializeSkeletonStage reader can race the var, and the
+	// leak scan is over a private dir so a sibling test's staging dir can
+	// never be misattributed as a leak.
 	if runtime.GOOS == "windows" {
-		t.Skip("os.TempDir() listing semantics differ on windows")
+		t.Skip("temp-dir listing semantics differ on windows")
 	}
 
-	// Snapshot existing stage dirs before the test.
-	stageBefore := listStageDirs(t)
+	stageParent := isolateStageParent(t)
+	// Private parent starts empty; snapshot for symmetry/robustness.
+	stageBefore := listStageDirs(t, stageParent)
 
 	// Feed a skeleton plan that rebases from a realRoot that does NOT match
 	// the AbsPath prefix — filepath.Rel will produce a relative path with ".."
@@ -842,7 +848,7 @@ func TestMaterializeSkeletonStage_NoLeakOnInnerFailure(t *testing.T) {
 	}
 
 	// No new stage dirs should remain after the failure.
-	stageAfter := listStageDirs(t)
+	stageAfter := listStageDirs(t, stageParent)
 	leaked := setDiff(stageAfter, stageBefore)
 	if len(leaked) > 0 {
 		t.Errorf("temp-dir leak: %d gocell-scaffold-stage-* dir(s) remain after inner failure: %v",
@@ -850,20 +856,36 @@ func TestMaterializeSkeletonStage_NoLeakOnInnerFailure(t *testing.T) {
 	}
 }
 
-// listStageDirs returns the set of gocell-scaffold-stage-* entries in os.TempDir().
-func listStageDirs(t *testing.T) map[string]struct{} {
+// listStageDirs returns the set of gocell-scaffold-stage-* entries under
+// parent (the isolated per-test staging parent set by isolateStageParent).
+func listStageDirs(t *testing.T, parent string) map[string]struct{} {
 	t.Helper()
-	entries, err := os.ReadDir(os.TempDir())
+	entries, err := os.ReadDir(parent)
 	if err != nil {
-		t.Fatalf("ReadDir(TempDir): %v", err)
+		t.Fatalf("ReadDir(%s): %v", parent, err)
 	}
 	out := make(map[string]struct{})
 	for _, e := range entries {
 		if e.IsDir() && strings.HasPrefix(e.Name(), "gocell-scaffold-stage-") {
-			out[filepath.Join(os.TempDir(), e.Name())] = struct{}{}
+			out[filepath.Join(parent, e.Name())] = struct{}{}
 		}
 	}
 	return out
+}
+
+// isolateStageParent points materializeSkeletonStage at a private per-test
+// temp parent (via package-level stageTempParent) so leak assertions scan
+// only this test's staging dirs and cannot misattribute a sibling parallel
+// test's gocell-scaffold-stage-* dir as a leak. Callers must NOT be
+// t.Parallel(): the var mutation is confined to the sequential test phase so
+// no concurrent materializeSkeletonStage reader races it. Restored on cleanup.
+func isolateStageParent(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev := stageTempParent
+	stageTempParent = dir
+	t.Cleanup(func() { stageTempParent = prev })
+	return dir
 }
 
 // setDiff returns elements in a that are not in b.
@@ -947,15 +969,22 @@ func TestPlanCellBundle_WithBothFlags_DupGuardIsBackstop(t *testing.T) {
 	}
 }
 
-// TestPlanCellBundleScaffold_CrossStageRollback_NoStagingDir asserts that when
-// a derived-file write failure (e.g. ForceOverwrite target is a directory)
-// rolls back skeleton files AND leaves no gocell-scaffold-stage-* dir in TempDir.
-func TestPlanCellBundleScaffold_CrossStageRollback_NoStagingDir(t *testing.T) {
-	t.Parallel()
+// TestPlanCellBundleScaffold_DirAtDerivedPath_PlanTimeReject asserts that a
+// pre-existing directory at a derived ForceOverwrite path is rejected at PLAN
+// time (planDerivedArtifact's governance-gate read fails fast: a directory is
+// neither absent nor a generated file), not deferred to writePass. This is
+// the cellgen-side half of F2's dry-run/live parity: the conflict surfaces
+// from PlanCellBundleScaffold itself, before any plan executes, so dry-run
+// and live agree. Nothing is written to the project tree and no
+// gocell-scaffold-stage-* dir leaks (F3).
+func TestPlanCellBundleScaffold_DirAtDerivedPath_PlanTimeReject(t *testing.T) {
+	// Not parallel: mutates package-level stageTempParent (see
+	// isolateStageParent godoc).
 	if runtime.GOOS == "windows" {
 		t.Skip("MkdirAll on conflict path semantics differ on windows")
 	}
 
+	stageParent := isolateStageParent(t)
 	root := t.TempDir()
 	// Must have go.mod for metadata.NewParser to work inside appendDerivedCodegen.
 	if err := os.WriteFile(filepath.Join(root, "go.mod"),
@@ -977,14 +1006,14 @@ func TestPlanCellBundleScaffold_CrossStageRollback_NoStagingDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Pre-place a directory at the types_gen.go path to cause WritePlannedFiles
-	// to fail when writing the ForceOverwrite derived file.
+	// Pre-place a directory at the derived types_gen.go path. planDerivedArtifact
+	// must reject it at plan-construction time (read → "is a directory").
 	conflictDir := filepath.Join(root, "generated", "contracts", "http", "rollbackstage", "example", "v1", "types_gen.go")
 	if err := os.MkdirAll(conflictDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	stageBefore := listStageDirs(t)
+	stageBefore := listStageDirs(t, stageParent)
 
 	realRoot, err := pathsafe.ResolveRoot(root)
 	if err != nil {
@@ -1003,31 +1032,107 @@ func TestPlanCellBundleScaffold_CrossStageRollback_NoStagingDir(t *testing.T) {
 		WithHTTP:         true,
 	}
 
-	plan, planErr := PlanCellBundleScaffold(realRoot, spec)
-	if planErr != nil {
-		t.Fatalf("PlanCellBundleScaffold: %v", planErr)
-	}
-	writeErr := pathsafe.WritePlannedFiles(realRoot, plan, false)
-	if writeErr == nil {
-		t.Fatal("WritePlannedFiles with conflicting derived path: want error, got nil")
+	_, planErr := PlanCellBundleScaffold(realRoot, spec)
+	if planErr == nil {
+		t.Fatal("PlanCellBundleScaffold with a directory at the derived path: want plan-time error, got nil")
 	}
 
-	// Skeleton files must not exist after rollback.
+	// PlanCellBundleScaffold only stages + plans; it must never write the
+	// skeleton onto the project tree (the plan is never executed here).
 	for _, rel := range []string{
 		"cells/rollbackstage/cell.yaml",
 		"cells/rollbackstage/cell.go",
 		"cells/rollbackstage/slices/rollbackstageexample/slice.yaml",
 	} {
 		if _, statErr := os.Stat(filepath.Join(root, rel)); statErr == nil {
-			t.Errorf("cross-stage rollback: skeleton file must not exist: %s", rel)
+			t.Errorf("plan-time reject must not pollute project tree: %s", rel)
 		}
 	}
 
 	// No staging temp dir must remain.
-	stageAfter := listStageDirs(t)
+	stageAfter := listStageDirs(t, stageParent)
 	leaked := setDiff(stageAfter, stageBefore)
 	if len(leaked) > 0 {
 		t.Errorf("staging temp dir leaked after write failure: %v", leaked)
+	}
+}
+
+// TestPlanCellBundleScaffold_RefusesNonGeneratedDerivedFile is the F1
+// regression lock: a hand-written (non gocell-generated) file pre-placed at a
+// derived-artifact path must NOT be silently overwritten. PR #544 routed
+// derived writes through pathsafe with unconditional ForceOverwrite=true,
+// dropping the governance.IsGoCellGenerated gate the legacy codegen.Write
+// enforced. planDerivedArtifact restores it: PlanCellBundleScaffold must
+// return an error and the pre-existing file content must be untouched.
+func TestPlanCellBundleScaffold_RefusesNonGeneratedDerivedFile(t *testing.T) {
+	// Not parallel: isolateStageParent mutates package-level stageTempParent.
+	if runtime.GOOS == "windows" {
+		t.Skip("temp-dir listing semantics differ on windows")
+	}
+	_ = isolateStageParent(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module github.com/ghbvf/gocell\n\ngo 1.23\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	schemaDir := filepath.Join(root, "contracts", "shared", "errors")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realSchemaPath := filepath.Join("..", "..", "..", "contracts", "shared", "errors", "error-response-v1.schema.json")
+	schemaContent, schemaErr := os.ReadFile(realSchemaPath) //nolint:gosec // test fixture
+	if schemaErr != nil {
+		t.Skipf("cannot read shared error schema: %v", schemaErr)
+	}
+	schemaOut := filepath.Join(schemaDir, "error-response-v1.schema.json")
+	if err := os.WriteFile(schemaOut, schemaContent, 0o644); err != nil { //nolint:gosec // tempdir test fixture
+		t.Fatal(err)
+	}
+
+	// Pre-place a HAND-WRITTEN (no gocell header) regular file at a derived
+	// contract artifact path.
+	derivedRel := filepath.Join("generated", "contracts", "http", "guardstage", "example", "v1", "types_gen.go")
+	derivedAbs := filepath.Join(root, derivedRel)
+	if err := os.MkdirAll(filepath.Dir(derivedAbs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	handwritten := []byte("package handwritten\n\n// human-authored, NOT generated\n")
+	if err := os.WriteFile(derivedAbs, handwritten, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	realRoot, err := pathsafe.ResolveRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+	spec := ScaffoldSpec{
+		CellID:           "guardstage",
+		StructName:       "GuardStage",
+		Package:          "guardstage",
+		ModulePath:       "github.com/ghbvf/gocell",
+		OwnerTeam:        "platform",
+		OwnerRole:        "cell-owner",
+		Type:             "core",
+		ConsistencyLevel: "L2",
+		WithHTTP:         true,
+	}
+
+	_, planErr := PlanCellBundleScaffold(realRoot, spec)
+	if planErr == nil {
+		t.Fatal("PlanCellBundleScaffold over a non-generated derived file: want error, got nil")
+	}
+	if !strings.Contains(planErr.Error(), "non-generated") {
+		t.Errorf("error must name the non-generated overwrite refusal; got: %v", planErr)
+	}
+
+	// The hand-written file must be byte-identical (never overwritten).
+	got, readErr := os.ReadFile(derivedAbs) //nolint:gosec // tempdir test fixture, path constructed in-test
+	if readErr != nil {
+		t.Fatalf("read pre-placed file: %v", readErr)
+	}
+	if !bytes.Equal(got, handwritten) {
+		t.Errorf("hand-written file was modified: got %q want %q", got, handwritten)
 	}
 }
 

--- a/tools/codegen/cellgen/scaffold_bundle_test.go
+++ b/tools/codegen/cellgen/scaffold_bundle_test.go
@@ -682,7 +682,8 @@ func TestPlanEventExampleArtifacts_HTTPAndEvents_DistinctSliceID(t *testing.T) {
 // and derived codegen files (ForceOverwrite=true), with no duplicate AbsPath.
 // Nothing is written to the project tree.
 //
-// RED: PlanCellBundleScaffold does not exist yet.
+// GREEN: PlanCellBundleScaffold delegates to appendDerivedCodegenStaged which
+// merges skeleton + derived into a single plan in-memory.
 func TestPlanCellBundleScaffold_MergedPlan(t *testing.T) {
 	t.Parallel()
 
@@ -789,6 +790,244 @@ func TestPlanCellBundleScaffold_MergedPlan(t *testing.T) {
 	// Nothing written to project tree (plan is in-memory only).
 	if _, statErr := os.Stat(filepath.Join(realRoot, "cells", "plantestcell")); statErr == nil {
 		t.Error("PlanCellBundleScaffold must not write to project tree")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// F2 / F10: temp-dir cleanup + dup-guard backstop + cross-stage rollback
+// ---------------------------------------------------------------------------
+
+// TestMaterializeSkeletonStage_NoLeakOnInnerFailure asserts that when
+// materializeSkeletonStage fails after creating the temp dir (e.g. the
+// WritePlannedFiles step returns an error), no gocell-scaffold-stage-* entry
+// remains in os.TempDir(). This locks the F2 fix: named return + deferred
+// cleanup inside materializeSkeletonStage.
+func TestMaterializeSkeletonStage_NoLeakOnInnerFailure(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("os.TempDir() listing semantics differ on windows")
+	}
+
+	// Snapshot existing stage dirs before the test.
+	stageBefore := listStageDirs(t)
+
+	// Feed a skeleton plan that rebases from a realRoot that does NOT match
+	// the AbsPath prefix — filepath.Rel will produce a relative path with ".."
+	// segments if we pass a totally different root, but actually to trigger the
+	// WritePlannedFiles failure we can use a containment-escape path.
+	// Simplest reliable failure: pass an AbsPath whose Rel(...) call succeeds
+	// but then pathsafe.WritePlannedFiles fails because the plan contains an
+	// absolute path outside stageRoot (symlink-escape).
+	//
+	// Even simpler: use a plan with a file whose content triggers an OS-level
+	// write error by making the stageRoot read-only after MkdirTemp — but that
+	// is fragile as root. Instead, just make realRoot → AbsPath relationship
+	// inconsistent so filepath.Rel returns a "../../..." path, causing
+	// pathsafe.WritePlannedFiles to reject it (containment check).
+	realRoot := t.TempDir()
+	resolved, err := pathsafe.ResolveRoot(realRoot)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+	// Craft a plan entry whose AbsPath is NOT under resolved — triggers
+	// pathsafe containment rejection inside materializeSkeletonStage.
+	outsideDir := t.TempDir()
+	badPlan := []pathsafe.PlannedFile{
+		{AbsPath: filepath.Join(outsideDir, "evil.txt"), Content: []byte("bad")},
+	}
+
+	_, stageErr := materializeSkeletonStage(resolved, badPlan)
+	if stageErr == nil {
+		t.Fatal("materializeSkeletonStage with outside AbsPath: want error, got nil")
+	}
+
+	// No new stage dirs should remain after the failure.
+	stageAfter := listStageDirs(t)
+	leaked := setDiff(stageAfter, stageBefore)
+	if len(leaked) > 0 {
+		t.Errorf("temp-dir leak: %d gocell-scaffold-stage-* dir(s) remain after inner failure: %v",
+			len(leaked), leaked)
+	}
+}
+
+// listStageDirs returns the set of gocell-scaffold-stage-* entries in os.TempDir().
+func listStageDirs(t *testing.T) map[string]struct{} {
+	t.Helper()
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		t.Fatalf("ReadDir(TempDir): %v", err)
+	}
+	out := make(map[string]struct{})
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "gocell-scaffold-stage-") {
+			out[filepath.Join(os.TempDir(), e.Name())] = struct{}{}
+		}
+	}
+	return out
+}
+
+// setDiff returns elements in a that are not in b.
+func setDiff(a, b map[string]struct{}) []string {
+	var out []string
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// TestPlanCellBundle_WithBothFlags_DupGuardIsBackstop asserts that the OLD
+// behavior (event reuses HTTP sliceID when withHTTP=true) would produce
+// duplicate AbsPath entries that pathsafe's duplicate-detection pass rejects.
+// This proves the dup-guard is the actual backstop and that planCellBundle's
+// distinct-sliceID fix closed the primary window.
+//
+// The test reconstructs the old behavior by calling planEventExampleArtifacts
+// with withHTTP=false (forcing same sliceID as HTTP) and then confirming that
+// when merged with HTTP artifacts, duplicates appear.
+func TestPlanCellBundle_WithBothFlags_DupGuardIsBackstop(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	realRoot, err := pathsafe.ResolveRoot(dir)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+
+	spec := ScaffoldSpec{
+		CellID:           "dupguardcell",
+		StructName:       "DupGuardCell",
+		Package:          "dupguardcell",
+		ModulePath:       "github.com/ghbvf/gocell",
+		OwnerTeam:        "platform",
+		OwnerRole:        "cell-owner",
+		Type:             "core",
+		ConsistencyLevel: "L2",
+	}
+	cellNoDash := strings.ReplaceAll(spec.CellID, "-", "")
+	sliceID := cellNoDash + "example"
+
+	// HTTP artifacts.
+	httpItems, err := planHTTPExampleArtifacts(realRoot, spec, cellNoDash, sliceID)
+	if err != nil {
+		t.Fatalf("planHTTPExampleArtifacts: %v", err)
+	}
+
+	// OLD behavior: event artifacts with same sliceID (withHTTP=false in old code).
+	// We simulate by calling planEventExampleArtifacts with withHTTP=false,
+	// which keeps the same sliceID instead of appending "eventexample".
+	oldEventItems, err := planEventExampleArtifacts(realRoot, spec, cellNoDash, sliceID, false /* withHTTP=false → same sliceID */)
+	if err != nil {
+		t.Fatalf("planEventExampleArtifacts (old behavior): %v", err)
+	}
+
+	combined := make([]pathsafe.PlannedFile, 0, len(httpItems)+len(oldEventItems))
+	combined = append(combined, httpItems...)
+	combined = append(combined, oldEventItems...)
+
+	// Detect duplicates — the dup-guard backstop must fire.
+	seen := make(map[string]int)
+	for _, f := range combined {
+		seen[f.AbsPath]++
+	}
+	var dups []string
+	for path, count := range seen {
+		if count > 1 {
+			rel, _ := filepath.Rel(realRoot, path)
+			dups = append(dups, rel)
+		}
+	}
+	if len(dups) == 0 {
+		t.Fatal("expected duplicate AbsPath entries with old same-sliceID behavior; got none — dup-guard backstop not exercised")
+	}
+	// Verify WritePlannedFiles rejects the duplicate plan (dup-guard backstop).
+	if err := pathsafe.WritePlannedFiles(realRoot, combined, true /* dryRun */); err == nil {
+		t.Error("WritePlannedFiles must reject duplicate AbsPath plan; got nil error")
+	}
+}
+
+// TestPlanCellBundleScaffold_CrossStageRollback_NoStagingDir asserts that when
+// a derived-file write failure (e.g. ForceOverwrite target is a directory)
+// rolls back skeleton files AND leaves no gocell-scaffold-stage-* dir in TempDir.
+func TestPlanCellBundleScaffold_CrossStageRollback_NoStagingDir(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("MkdirAll on conflict path semantics differ on windows")
+	}
+
+	root := t.TempDir()
+	// Must have go.mod for metadata.NewParser to work inside appendDerivedCodegen.
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module github.com/ghbvf/gocell\n\ngo 1.23\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Include shared error schema so contractgen can render.
+	schemaDir := filepath.Join(root, "contracts", "shared", "errors")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realSchemaPath := filepath.Join("..", "..", "..", "contracts", "shared", "errors", "error-response-v1.schema.json")
+	schemaContent, schemaErr := os.ReadFile(realSchemaPath) //nolint:gosec // test fixture
+	if schemaErr != nil {
+		t.Skipf("cannot read shared error schema: %v", schemaErr)
+	}
+	schemaOut := filepath.Join(schemaDir, "error-response-v1.schema.json")
+	if err := os.WriteFile(schemaOut, schemaContent, 0o644); err != nil { //nolint:gosec // tempdir test fixture
+		t.Fatal(err)
+	}
+
+	// Pre-place a directory at the types_gen.go path to cause WritePlannedFiles
+	// to fail when writing the ForceOverwrite derived file.
+	conflictDir := filepath.Join(root, "generated", "contracts", "http", "rollbackstage", "example", "v1", "types_gen.go")
+	if err := os.MkdirAll(conflictDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stageBefore := listStageDirs(t)
+
+	realRoot, err := pathsafe.ResolveRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+
+	spec := ScaffoldSpec{
+		CellID:           "rollbackstage",
+		StructName:       "RollbackStage",
+		Package:          "rollbackstage",
+		ModulePath:       "github.com/ghbvf/gocell",
+		OwnerTeam:        "platform",
+		OwnerRole:        "cell-owner",
+		Type:             "core",
+		ConsistencyLevel: "L2",
+		WithHTTP:         true,
+	}
+
+	plan, planErr := PlanCellBundleScaffold(realRoot, spec)
+	if planErr != nil {
+		t.Fatalf("PlanCellBundleScaffold: %v", planErr)
+	}
+	writeErr := pathsafe.WritePlannedFiles(realRoot, plan, false)
+	if writeErr == nil {
+		t.Fatal("WritePlannedFiles with conflicting derived path: want error, got nil")
+	}
+
+	// Skeleton files must not exist after rollback.
+	for _, rel := range []string{
+		"cells/rollbackstage/cell.yaml",
+		"cells/rollbackstage/cell.go",
+		"cells/rollbackstage/slices/rollbackstageexample/slice.yaml",
+	} {
+		if _, statErr := os.Stat(filepath.Join(root, rel)); statErr == nil {
+			t.Errorf("cross-stage rollback: skeleton file must not exist: %s", rel)
+		}
+	}
+
+	// No staging temp dir must remain.
+	stageAfter := listStageDirs(t)
+	leaked := setDiff(stageAfter, stageBefore)
+	if len(leaked) > 0 {
+		t.Errorf("staging temp dir leaked after write failure: %v", leaked)
 	}
 }
 

--- a/tools/codegen/cellgen/scaffold_bundle_test.go
+++ b/tools/codegen/cellgen/scaffold_bundle_test.go
@@ -12,6 +12,24 @@ import (
 	"github.com/ghbvf/gocell/pkg/pathsafe"
 )
 
+// scaffoldBundleSkip is a test helper that calls PlanCellBundleScaffold
+// (with SkipGenerate forced true so no metadata parse is needed) and then
+// WritePlannedFiles(dryRun=false) to write skeleton files. Returns the first
+// error encountered (plan or write).
+func scaffoldBundleSkip(t *testing.T, root string, spec ScaffoldSpec) error {
+	t.Helper()
+	realRoot, err := pathsafe.ResolveRoot(root)
+	if err != nil {
+		return err
+	}
+	spec.SkipGenerate = true
+	plan, err := PlanCellBundleScaffold(realRoot, spec)
+	if err != nil {
+		return err
+	}
+	return pathsafe.WritePlannedFiles(realRoot, plan, false)
+}
+
 // TestScaffoldCellBundle_HTTP is a RED test for K#09 cellgen.ScaffoldCellBundle:
 // produces cell + 1 example slice + 1 HTTP contract bundle in one shot.
 //
@@ -41,8 +59,8 @@ func TestScaffoldCellBundle_HTTP(t *testing.T) {
 		WithHTTP:         true,
 	}
 
-	if err := ScaffoldCellBundle(dir, spec); err != nil {
-		t.Fatalf("ScaffoldCellBundle: %v", err)
+	if err := scaffoldBundleSkip(t, dir, spec); err != nil {
+		t.Fatalf("scaffoldBundleSkip: %v", err)
 	}
 
 	// Verify bundle file inventory.
@@ -95,8 +113,8 @@ func TestScaffoldCellBundle_Events(t *testing.T) {
 		WithEvents:       true,
 	}
 
-	if err := ScaffoldCellBundle(dir, spec); err != nil {
-		t.Fatalf("ScaffoldCellBundle: %v", err)
+	if err := scaffoldBundleSkip(t, dir, spec); err != nil {
+		t.Fatalf("scaffoldBundleSkip: %v", err)
 	}
 
 	wantFiles := []string{
@@ -117,7 +135,8 @@ func TestScaffoldCellBundle_Events(t *testing.T) {
 	}
 }
 
-// TestScaffoldCellBundle_DryRun verifies dry-run produces no files.
+// TestScaffoldCellBundle_DryRun verifies that PlanCellBundleScaffold (skeleton only)
+// followed by WritePlannedFiles(dryRun=true) produces no files.
 func TestScaffoldCellBundle_DryRun(t *testing.T) {
 	t.Parallel()
 
@@ -132,10 +151,18 @@ func TestScaffoldCellBundle_DryRun(t *testing.T) {
 		Type:             "core",
 		ConsistencyLevel: "L2",
 		WithHTTP:         true,
-		DryRun:           true,
+		SkipGenerate:     true, // skip codegen stage so no metadata parse needed
 	}
-	if err := ScaffoldCellBundle(dir, spec); err != nil {
-		t.Fatalf("dry-run ScaffoldCellBundle: %v", err)
+	realRoot, err := pathsafe.ResolveRoot(dir)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+	plan, err := PlanCellBundleScaffold(realRoot, spec)
+	if err != nil {
+		t.Fatalf("PlanCellBundleScaffold: %v", err)
+	}
+	if err := pathsafe.WritePlannedFiles(realRoot, plan, true); err != nil {
+		t.Fatalf("WritePlannedFiles dry-run: %v", err)
 	}
 	// In dry-run, the cell directory must not exist.
 	if _, err := os.Stat(filepath.Join(dir, "cells", "drycell")); err == nil {
@@ -162,8 +189,8 @@ func TestScaffoldCellBundle_WithBoth(t *testing.T) {
 		WithBoth:         true,
 	}
 
-	if err := ScaffoldCellBundle(dir, spec); err != nil {
-		t.Fatalf("ScaffoldCellBundle WithBoth: %v", err)
+	if err := scaffoldBundleSkip(t, dir, spec); err != nil {
+		t.Fatalf("scaffoldBundleSkip WithBoth: %v", err)
 	}
 
 	// HTTP slice and contract must exist.
@@ -254,9 +281,9 @@ func TestScaffoldCellBundle_SymlinkEscape_Slice(t *testing.T) {
 		WithHTTP:         true,
 	}
 
-	err := ScaffoldCellBundle(root, spec)
+	err := scaffoldBundleSkip(t, root, spec)
 	if err == nil {
-		t.Fatal("ScaffoldCellBundle(slices symlink escape): want error, got nil")
+		t.Fatal("scaffoldBundleSkip(slices symlink escape): want error, got nil")
 	}
 	var ec *errcode.Error
 	if !errors.As(err, &ec) {
@@ -311,9 +338,9 @@ func TestScaffoldCellBundle_SymlinkEscape_Contract(t *testing.T) {
 		WithHTTP:         true,
 	}
 
-	err := ScaffoldCellBundle(root, spec)
+	err := scaffoldBundleSkip(t, root, spec)
 	if err == nil {
-		t.Fatal("ScaffoldCellBundle(contract symlink escape): want error, got nil")
+		t.Fatal("scaffoldBundleSkip(contract symlink escape): want error, got nil")
 	}
 
 	// outside 内不应有任何文件
@@ -351,9 +378,9 @@ func TestScaffoldCellBundle_AtomicRollback_OnContractConflict(t *testing.T) {
 		WithHTTP:         true,
 	}
 
-	err := ScaffoldCellBundle(root, spec)
+	err := scaffoldBundleSkip(t, root, spec)
 	if err == nil {
-		t.Fatal("ScaffoldCellBundle(contract conflict): want error, got nil")
+		t.Fatal("scaffoldBundleSkip(contract conflict): want error, got nil")
 	}
 
 	// atomic：cells/myhttpcell/cell.yaml、cell.go、slices/.../slice.yaml 全不存在
@@ -402,9 +429,9 @@ func TestScaffoldCellBundle_AtomicRollback_OnContainmentFail(t *testing.T) {
 		WithHTTP:         true,
 	}
 
-	err := ScaffoldCellBundle(root, spec)
+	err := scaffoldBundleSkip(t, root, spec)
 	if err == nil {
-		t.Fatal("ScaffoldCellBundle(containment fail): want error, got nil")
+		t.Fatal("scaffoldBundleSkip(containment fail): want error, got nil")
 	}
 
 	// atomic：cell.yaml 和 cell.go 均未写入
@@ -439,9 +466,9 @@ func TestScaffoldCellBundle_RejectKebabCellID(t *testing.T) {
 		ConsistencyLevel: "L1",
 		WithHTTP:         true,
 	}
-	err := ScaffoldCellBundle(dir, spec)
+	err := scaffoldBundleSkip(t, dir, spec)
 	if err == nil {
-		t.Fatal("ScaffoldCellBundle(kebab CellID): want error, got nil")
+		t.Fatal("scaffoldBundleSkip(kebab CellID): want error, got nil")
 	}
 	// Error must mention kebab or dash so the message is actionable.
 	msg := err.Error()
@@ -474,8 +501,8 @@ func TestScaffoldCellBundle_BundleDefaultIsHTTP(t *testing.T) {
 		Type:             "core",
 		ConsistencyLevel: "L2",
 	}
-	if err := ScaffoldCellBundle(dir, spec); err != nil {
-		t.Fatalf("ScaffoldCellBundle: %v", err)
+	if err := scaffoldBundleSkip(t, dir, spec); err != nil {
+		t.Fatalf("scaffoldBundleSkip: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "contracts", "http", "defcell", "example", "v1", "contract.yaml")); err != nil {
 		t.Errorf("default bundle should produce HTTP contract; got: %v", err)
@@ -554,7 +581,7 @@ func TestScaffoldSpec_Validate_RejectsL1WithEvents(t *testing.T) {
 		ConsistencyLevel: "L1",
 		WithEvents:       true,
 	}
-	err := ScaffoldCellBundle(dir, spec)
+	err := scaffoldBundleSkip(t, dir, spec)
 	if err == nil {
 		t.Fatal("expected validation error for L1+WithEvents, got nil")
 	}
@@ -581,7 +608,7 @@ func TestScaffoldSpec_Validate_AcceptsL2WithEvents(t *testing.T) {
 		ConsistencyLevel: "L2",
 		WithEvents:       true,
 	}
-	if err := ScaffoldCellBundle(dir, spec); err != nil {
+	if err := scaffoldBundleSkip(t, dir, spec); err != nil {
 		t.Fatalf("expected no error for L2+WithEvents, got: %v", err)
 	}
 }
@@ -650,6 +677,121 @@ func TestPlanEventExampleArtifacts_HTTPAndEvents_DistinctSliceID(t *testing.T) {
 	}
 }
 
+// TestPlanCellBundleScaffold_MergedPlan verifies that PlanCellBundleScaffold
+// returns a merged plan containing both skeleton files (ForceOverwrite=false)
+// and derived codegen files (ForceOverwrite=true), with no duplicate AbsPath.
+// Nothing is written to the project tree.
+//
+// RED: PlanCellBundleScaffold does not exist yet.
+func TestPlanCellBundleScaffold_MergedPlan(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Must have go.mod for metadata.NewParser to work.
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module github.com/ghbvf/gocell\n\ngo 1.23\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Must have the shared error schema for contractgen to work.
+	schemaDir := filepath.Join(dir, "contracts", "shared", "errors")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Read from real repo and write to staging root.
+	realSchemaPath := filepath.Join("..", "..", "..", "contracts", "shared", "errors", "error-response-v1.schema.json")
+	schemaContent, err := os.ReadFile(realSchemaPath) //nolint:gosec // test fixture from known path
+	if err != nil {
+		t.Skipf("cannot read shared error schema (not in expected location): %v", err)
+	}
+	schemaOut := filepath.Join(schemaDir, "error-response-v1.schema.json")
+	//nolint:gosec // tempdir test fixture
+	if err := os.WriteFile(schemaOut, schemaContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	realRoot, err := pathsafe.ResolveRoot(dir)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+
+	spec := ScaffoldSpec{
+		CellID:           "plantestcell",
+		StructName:       "PlanTestCell",
+		Package:          "plantestcell",
+		ModulePath:       "github.com/ghbvf/gocell",
+		OwnerTeam:        "platform",
+		OwnerRole:        "cell-owner",
+		Type:             "core",
+		ConsistencyLevel: "L2",
+		WithHTTP:         true,
+	}
+
+	plan, err := PlanCellBundleScaffold(realRoot, spec)
+	if err != nil {
+		t.Fatalf("PlanCellBundleScaffold: %v", err)
+	}
+
+	// No duplicate AbsPath.
+	seen := make(map[string]int)
+	for _, f := range plan {
+		seen[f.AbsPath]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate AbsPath in merged plan: %s (count=%d)", path, count)
+		}
+	}
+
+	// Skeleton files must exist with ForceOverwrite=false.
+	skeletonRels := []string{
+		"cells/plantestcell/cell.yaml",
+		"cells/plantestcell/cell.go",
+	}
+	for _, rel := range skeletonRels {
+		abs := filepath.Join(realRoot, filepath.FromSlash(rel))
+		found := false
+		for _, f := range plan {
+			if f.AbsPath == abs {
+				if f.ForceOverwrite {
+					t.Errorf("skeleton file %s must have ForceOverwrite=false", rel)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("skeleton file missing from merged plan: %s", rel)
+		}
+	}
+
+	// Derived files must exist with ForceOverwrite=true.
+	derivedRels := []string{
+		"cells/plantestcell/cell_gen.go",
+		"generated/contracts/http/plantestcell/example/v1/types_gen.go",
+	}
+	for _, rel := range derivedRels {
+		abs := filepath.Join(realRoot, filepath.FromSlash(rel))
+		found := false
+		for _, f := range plan {
+			if f.AbsPath == abs {
+				if !f.ForceOverwrite {
+					t.Errorf("derived file %s must have ForceOverwrite=true", rel)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("derived file missing from merged plan: %s", rel)
+		}
+	}
+
+	// Nothing written to project tree (plan is in-memory only).
+	if _, statErr := os.Stat(filepath.Join(realRoot, "cells", "plantestcell")); statErr == nil {
+		t.Error("PlanCellBundleScaffold must not write to project tree")
+	}
+}
+
 // TestScaffoldSpec_DefaultsToL2 asserts that an empty ConsistencyLevel is
 // defaulted to "L2" before validation, and that a bundle scaffold succeeds.
 func TestScaffoldSpec_DefaultsToL2(t *testing.T) {
@@ -667,7 +809,7 @@ func TestScaffoldSpec_DefaultsToL2(t *testing.T) {
 		// ConsistencyLevel intentionally empty — should default to L2
 		WithHTTP: true,
 	}
-	if err := ScaffoldCellBundle(dir, spec); err != nil {
+	if err := scaffoldBundleSkip(t, dir, spec); err != nil {
 		t.Fatalf("default ConsistencyLevel scaffold failed: %v", err)
 	}
 	// Verify the generated cell.yaml contains consistencyLevel: L2

--- a/tools/codegen/cellgen/scaffold_test.go
+++ b/tools/codegen/cellgen/scaffold_test.go
@@ -373,30 +373,32 @@ func TestScaffoldCell_ConflictError(t *testing.T) {
 	}
 }
 
-// TestScaffoldCell_DryRun verifies that ScaffoldCell with DryRun=true renders
-// templates (catching template/input errors) but does not write any files.
-func TestScaffoldCell_DryRun(t *testing.T) {
-	t.Run("no files written when no conflict", func(t *testing.T) {
+// TestScaffoldCell_WritesFiles verifies that ScaffoldCell writes cell.go and
+// cell.yaml to disk, and that a second call with the same target returns a
+// conflict error. (Dry-run semantics were removed from ScaffoldCell in D7 —
+// dry-run is now a CLI + WritePlannedFiles concern via PlanCellBundleScaffold.)
+func TestScaffoldCell_WritesFiles(t *testing.T) {
+	t.Run("writes cell.go and cell.yaml", func(t *testing.T) {
 		dir := t.TempDir()
 		spec := ScaffoldSpec{
-			CellID:     "drycell",
-			StructName: "DryCell",
-			Package:    "drycell",
+			CellID:     "writecell",
+			StructName: "WriteCell",
+			Package:    "writecell",
 			ModulePath: "github.com/example/app",
 			OwnerTeam:  "platform",
 			OwnerRole:  "cell-owner",
-			DryRun:     true,
 		}
-		if err := ScaffoldCell(dir, "cells/drycell", spec); err != nil {
-			t.Fatalf("ScaffoldCell DryRun: %v", err)
+		if err := ScaffoldCell(dir, "cells/writecell", spec); err != nil {
+			t.Fatalf("ScaffoldCell: %v", err)
 		}
-		cellGoPath := filepath.Join(dir, "cells", "drycell", "cell.go")
-		if _, err := os.Stat(cellGoPath); err == nil {
-			t.Error("DryRun=true must not write cell.go")
+		for _, rel := range []string{"cells/writecell/cell.go", "cells/writecell/cell.yaml"} {
+			if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+				t.Errorf("ScaffoldCell must write %s: %v", rel, err)
+			}
 		}
 	})
 
-	t.Run("conflict detected in dry-run", func(t *testing.T) {
+	t.Run("conflict detected on second call", func(t *testing.T) {
 		dir := t.TempDir()
 		spec := ScaffoldSpec{
 			CellID:     "conflictcell",
@@ -406,42 +408,17 @@ func TestScaffoldCell_DryRun(t *testing.T) {
 			OwnerTeam:  "platform",
 			OwnerRole:  "cell-owner",
 		}
-		// First live call creates files.
+		// First call creates files.
 		if err := ScaffoldCell(dir, "cells/conflictcell", spec); err != nil {
 			t.Fatalf("first ScaffoldCell: %v", err)
 		}
-		// Second call with DryRun must still detect conflict.
-		spec.DryRun = true
+		// Second call must detect conflict.
 		err := ScaffoldCell(dir, "cells/conflictcell", spec)
 		if err == nil {
-			t.Fatal("expected conflict error in dry-run, got nil")
+			t.Fatal("expected conflict error on second call, got nil")
 		}
 		if !strings.Contains(err.Error(), "already exists") {
 			t.Errorf("expected 'already exists' in error, got: %v", err)
-		}
-	})
-
-	t.Run("dry-run renders templates and validates cell.go syntax", func(t *testing.T) {
-		dir := t.TempDir()
-		spec := ScaffoldSpec{
-			CellID:     "rendercell",
-			StructName: "RenderCell",
-			Package:    "rendercell",
-			ModulePath: "github.com/example/app",
-			OwnerTeam:  "platform",
-			OwnerRole:  "cell-owner",
-			DryRun:     true,
-		}
-		// Dry-run must succeed (templates are valid).
-		if err := ScaffoldCell(dir, "cells/rendercell", spec); err != nil {
-			t.Fatalf("DryRun render validation failed: %v", err)
-		}
-		// No files must be written.
-		if _, err := os.Stat(filepath.Join(dir, "cells", "rendercell", "cell.go")); err == nil {
-			t.Error("DryRun=true must not write cell.go")
-		}
-		if _, err := os.Stat(filepath.Join(dir, "cells", "rendercell", "cell.yaml")); err == nil {
-			t.Error("DryRun=true must not write cell.yaml")
 		}
 	})
 }

--- a/tools/codegen/cellgen/stage_render.go
+++ b/tools/codegen/cellgen/stage_render.go
@@ -15,7 +15,11 @@
 //   - The shared error-response schema is copied into staging as a PlannedFile
 //     so contractgen's relative SchemaRef resolution can find it.
 //   - Derived artifacts are rendered in-memory against the staging tree and
-//     rebased onto realRoot with ForceOverwrite=true before merging.
+//     rebased onto realRoot via planDerivedArtifact, which restores the
+//     governance.IsGoCellGenerated overwrite gate (a pre-existing
+//     non-generated file on realRoot is refused, not silently replaced) and
+//     is the sole ForceOverwrite=true PlannedFile constructor for the derived
+//     path (archtest SCAFFOLD-DERIVED-FORCEOVERWRITE-01).
 //
 // The depguard scaffold-os-ban rule covers files starting with "scaffold" or
 // "generate_" in tools/codegen/cellgen/; stage_render.go IS also scanned by
@@ -36,11 +40,69 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ghbvf/gocell/kernel/governance"
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/pathsafe"
 	"github.com/ghbvf/gocell/tools/codegen/contractgen"
 )
+
+// stageTempParent is the parent directory passed to os.MkdirTemp when
+// materializing the skeleton staging tree. Empty (the default) means
+// os.TempDir() — production behavior is unchanged. Tests override it with an
+// isolated per-test directory so concurrent leak assertions
+// (TestMaterializeSkeletonStage_NoLeakOnInnerFailure / cross-stage rollback)
+// scan only their own staging parent and cannot misattribute a sibling
+// parallel test's gocell-scaffold-stage-* dir as a leak.
+var stageTempParent = ""
+
+// planDerivedArtifact is the SINGLE constructor for a ForceOverwrite derived
+// codegen PlannedFile. It restores the governance gate that the legacy
+// codegen.Write (tools/codegen/writer.go) enforced before PR #544 routed
+// derived writes through the pathsafe single-plan funnel: a file that already
+// exists on realRoot and does NOT carry the gocell generator header
+// (governance.IsGoCellGenerated) is refused, never silently overwritten.
+//
+// relSlashPath is a stageRoot-relative slash path (artifact.Path / RelPath);
+// it is rebased onto realRoot via pathsafe.ContainPath (defense-in-depth
+// parent-symlink walk). ForceOverwrite is set true only when the target is
+// absent or a prior gocell-generated artifact — exactly the codegen-regenerate
+// case. Direct construction of pathsafe.PlannedFile{ForceOverwrite:true} in
+// the derived-append path is statically forbidden by archtest
+// SCAFFOLD-DERIVED-FORCEOVERWRITE-01, which keeps this gate unbypassable
+// (Medium downstream; upstream Hard tracked by backlog
+// PATHSAFE-FORCEOVERWRITE-TYPED-CTOR-01).
+func planDerivedArtifact(realRoot, relSlashPath string, content []byte) (pathsafe.PlannedFile, error) {
+	absReal, err := pathsafe.ContainPath(realRoot, filepath.FromSlash(relSlashPath))
+	if err != nil {
+		return pathsafe.PlannedFile{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: rebase derived artifact", err,
+			errcode.WithDetails(slog.String("artifactPath", relSlashPath)))
+	}
+	existing, readErr := os.ReadFile(absReal) //nolint:gosec // contained path under realRoot (ContainPath above); governance-gate read
+	switch {
+	case readErr == nil:
+		if !governance.IsGoCellGenerated(existing) {
+			return pathsafe.PlannedFile{}, errcode.New(errcode.KindConflict, errcode.ErrConflict,
+				"scaffold stage: refusing to overwrite non-generated file "+
+					"(remove the file or move hand-written code to a sibling location, then re-run scaffold)",
+				errcode.WithDetails(slog.String("artifactPath", relSlashPath)))
+		}
+	case os.IsNotExist(readErr):
+		// Absent → fresh write. ForceOverwrite is still set (uniform plan
+		// entry); pathsafe conflictPass skips it and writePass captureOriginal
+		// records kindNone, identical to a plain create.
+	default:
+		return pathsafe.PlannedFile{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: stat derived artifact target", readErr,
+			errcode.WithDetails(slog.String("artifactPath", relSlashPath)))
+	}
+	return pathsafe.PlannedFile{
+		AbsPath:        absReal,
+		Content:        content,
+		ForceOverwrite: true,
+	}, nil
+}
 
 // sharedErrorSchemaRelPath is the repo-relative path of the shared error
 // response schema. contractgen BuildContractSpec follows SchemaRef links that
@@ -65,7 +127,7 @@ const sharedErrorSchemaRelPath = "contracts/shared/errors/error-response-v1.sche
 //
 // Returns the resolved staging root path or an error.
 func materializeSkeletonStage(realRoot string, skeletonPlan []pathsafe.PlannedFile) (_ string, err error) {
-	rawStage, mkErr := os.MkdirTemp("", "gocell-scaffold-stage-*")
+	rawStage, mkErr := os.MkdirTemp(stageTempParent, "gocell-scaffold-stage-*")
 	if mkErr != nil {
 		return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 			"scaffold stage: create temp dir", mkErr)
@@ -175,19 +237,14 @@ func appendDerivedCodegen(realRoot, stageRoot, cellID string, mergedPlan []paths
 				errcode.WithInternal(fmt.Sprintf("stageRoot=%s", stageRoot)))
 		}
 		for _, a := range artifacts {
-			// a.Path is stageRoot-relative (slash-separated). Route through
-			// pathsafe.ContainPath for defense-in-depth symlink walk on realRoot.
-			absReal, cerr := pathsafe.ContainPath(realRoot, filepath.FromSlash(a.Path))
-			if cerr != nil {
-				return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
-					"scaffold stage: rebase contract artifact", cerr,
-					errcode.WithDetails(slog.String("artifactPath", a.Path)))
+			// a.Path is stageRoot-relative (slash-separated). planDerivedArtifact
+			// rebases onto realRoot (ContainPath defense-in-depth symlink walk)
+			// and enforces the IsGoCellGenerated overwrite gate.
+			pf, perr := planDerivedArtifact(realRoot, a.Path, a.Content)
+			if perr != nil {
+				return nil, perr
 			}
-			mergedPlan = append(mergedPlan, pathsafe.PlannedFile{
-				AbsPath:        absReal,
-				Content:        a.Content,
-				ForceOverwrite: true,
-			})
+			mergedPlan = append(mergedPlan, pf)
 		}
 	}
 
@@ -200,19 +257,14 @@ func appendDerivedCodegen(realRoot, stageRoot, cellID string, mergedPlan []paths
 			errcode.WithInternal(fmt.Sprintf("stageRoot=%s", stageRoot)))
 	}
 	for _, a := range cellArtifacts {
-		// a.RelPath is stageRoot-relative. Route through ContainPath on realRoot
-		// for defense-in-depth symlink walk.
-		absReal, cerr := pathsafe.ContainPath(realRoot, filepath.FromSlash(a.RelPath))
-		if cerr != nil {
-			return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
-				"scaffold stage: rebase cell artifact", cerr,
-				errcode.WithDetails(slog.String("relPath", a.RelPath)))
+		// a.RelPath is stageRoot-relative. planDerivedArtifact rebases onto
+		// realRoot (ContainPath defense-in-depth symlink walk) and enforces
+		// the IsGoCellGenerated overwrite gate.
+		pf, perr := planDerivedArtifact(realRoot, a.RelPath, a.Content)
+		if perr != nil {
+			return nil, perr
 		}
-		mergedPlan = append(mergedPlan, pathsafe.PlannedFile{
-			AbsPath:        absReal,
-			Content:        a.Content,
-			ForceOverwrite: true,
-		})
+		mergedPlan = append(mergedPlan, pf)
 	}
 
 	return mergedPlan, nil

--- a/tools/codegen/cellgen/stage_render.go
+++ b/tools/codegen/cellgen/stage_render.go
@@ -1,0 +1,172 @@
+// stage_render.go — ephemeral staging dir helpers for cross-stage scaffold.
+//
+// INVARIANT: SCAFFOLD-CELL-BUNDLE-CROSS-STAGE-PLAN-MERGE-01
+//
+// materializeSkeletonStage and appendDerivedCodegen together implement the
+// ephemeral-staging pattern that merges skeleton + codegen-derived artifacts
+// into a single pathsafe.WritePlannedFiles plan for PlanCellBundleScaffold.
+//
+// Staging strategy (zero new OS-ban exemptions):
+//   - os.MkdirTemp / os.RemoveAll are NOT in the SCAFFOLD-WRITE-FUNNEL-01
+//     banned set (MkdirAll / WriteFile / Mkdir / Create / OpenFile); they only
+//     manage the temporary directory lifetime.
+//   - Skeleton files are written into the staging root via
+//     pathsafe.WritePlannedFiles itself — staging USES the funnel, not bypass.
+//   - The shared error-response schema is copied into staging as a PlannedFile
+//     so contractgen's relative SchemaRef resolution can find it.
+//   - Derived artifacts are rendered in-memory against the staging tree and
+//     rebased onto realRoot with ForceOverwrite=true before merging.
+//
+// The depguard scaffold-os-ban rule covers files starting with "scaffold" or
+// "generate_" in tools/codegen/cellgen/; this file does not match either
+// prefix and is therefore not in scope. Direct os.MkdirTemp / os.RemoveAll
+// calls here are intentional and reviewed.
+package cellgen
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/pathsafe"
+	"github.com/ghbvf/gocell/tools/codegen/contractgen"
+)
+
+// sharedErrorSchemaRelPath is the repo-relative path of the shared error
+// response schema. contractgen BuildContractSpec follows SchemaRef links that
+// point to this file; it must be present in the staging tree for renders to
+// succeed.
+const sharedErrorSchemaRelPath = "contracts/shared/errors/error-response-v1.schema.json"
+
+// materializeSkeletonStage writes the skeleton plan into a temporary staging
+// directory via pathsafe.WritePlannedFiles (funnel reuse, not bypass) and
+// returns the staging root path. The caller must defer os.RemoveAll(stageRoot).
+//
+// The shared error schema is copied from realRoot into the staging plan so
+// contractgen can resolve relative SchemaRef links in scaffolded contract.yaml
+// files without requiring the schema to be present in the real project tree.
+//
+// Returns the staging root path or an error.
+func materializeSkeletonStage(realRoot string, skeletonPlan []pathsafe.PlannedFile) (stageRoot string, err error) {
+	stageRoot, err = os.MkdirTemp("", "gocell-scaffold-stage-*")
+	if err != nil {
+		return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: create temp dir", err)
+	}
+
+	// Build the staging plan by rebasing skeleton AbsPaths from realRoot → stageRoot.
+	stagePlan := make([]pathsafe.PlannedFile, 0, len(skeletonPlan)+1)
+	for _, f := range skeletonPlan {
+		rel, relErr := filepath.Rel(realRoot, f.AbsPath)
+		if relErr != nil {
+			return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+				"scaffold stage: rebase skeleton path", relErr,
+				errcode.WithDetails(slog.String("path", f.AbsPath)))
+		}
+		stagePlan = append(stagePlan, pathsafe.PlannedFile{
+			AbsPath:        filepath.Join(stageRoot, rel),
+			Content:        f.Content,
+			ForceOverwrite: f.ForceOverwrite,
+		})
+	}
+
+	// Copy the shared error schema from realRoot so contractgen can resolve
+	// relative SchemaRef paths in the scaffolded contract.yaml.
+	schemaAbs := filepath.Join(realRoot, filepath.FromSlash(sharedErrorSchemaRelPath))
+	schemaContent, readErr := os.ReadFile(schemaAbs) //nolint:gosec // known fixed path under project root
+	if readErr == nil {
+		// Only include when present — projects may not have the shared schema yet.
+		stagePlan = append(stagePlan, pathsafe.PlannedFile{
+			AbsPath: filepath.Join(stageRoot, filepath.FromSlash(sharedErrorSchemaRelPath)),
+			Content: schemaContent,
+		})
+	}
+
+	// Write skeleton + schema into the staging root via the funnel.
+	if writeErr := pathsafe.WritePlannedFiles(stageRoot, stagePlan, false); writeErr != nil {
+		return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: materialize skeleton", writeErr)
+	}
+	return stageRoot, nil
+}
+
+// appendDerivedCodegenStaged is the top-level entry point for the ephemeral
+// staging lifecycle. It creates a temp staging dir, materializes the skeleton
+// via the pathsafe funnel, renders derived artifacts, rebases them to realRoot,
+// appends to skeletonPlan with ForceOverwrite=true, and removes the staging dir.
+// Called from scaffold_bundle.go (which is in the depguard scaffold-os-ban list
+// and therefore cannot import "os" directly).
+func appendDerivedCodegenStaged(realRoot, cellID string, skeletonPlan []pathsafe.PlannedFile) ([]pathsafe.PlannedFile, error) {
+	stageRoot, err := materializeSkeletonStage(realRoot, skeletonPlan)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(stageRoot) }()
+
+	return appendDerivedCodegen(realRoot, stageRoot, cellID, skeletonPlan)
+}
+
+// appendDerivedCodegen parses the staging root, renders contractgen and cellgen
+// artifacts in-memory (contract first, then cell so DTO types are available),
+// and appends them to mergedPlan with AbsPaths rebased to realRoot and
+// ForceOverwrite=true. The staging root is ephemeral and must be cleaned up by
+// the caller.
+func appendDerivedCodegen(realRoot, stageRoot, cellID string, mergedPlan []pathsafe.PlannedFile) ([]pathsafe.PlannedFile, error) {
+	project, err := metadata.NewParser(stageRoot).Parse()
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: parse staged metadata", err,
+			errcode.WithDetails(slog.String("cellID", cellID)))
+	}
+
+	// Contract artifacts first so generated DTO types are available for cellgen.
+	contractIDs, err := contractgen.ContractIDsForCell(project, cellID)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: list contracts for cell", err,
+			errcode.WithDetails(slog.String("cellID", cellID)))
+	}
+	for _, cid := range contractIDs {
+		artifacts, artErr := contractgen.RenderContractArtifacts(stageRoot, project, cid)
+		if artErr != nil {
+			return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+				"scaffold stage: render contract artifacts", artErr,
+				errcode.WithDetails(slog.String("contractID", cid)))
+		}
+		for _, a := range artifacts {
+			// a.Path is stageRoot-relative (slash-separated).
+			absStage := filepath.Join(stageRoot, filepath.FromSlash(a.Path))
+			rel, relErr := filepath.Rel(stageRoot, absStage)
+			if relErr != nil {
+				return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+					"scaffold stage: rebase contract artifact", relErr,
+					errcode.WithDetails(slog.String("artifactPath", a.Path)))
+			}
+			mergedPlan = append(mergedPlan, pathsafe.PlannedFile{
+				AbsPath:        filepath.Join(realRoot, rel),
+				Content:        a.Content,
+				ForceOverwrite: true,
+			})
+		}
+	}
+
+	// Cell artifacts (cell_gen.go + slice_gen.go).
+	cellArtifacts, err := RenderCellArtifacts(stageRoot, project, cellID)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: render cell artifacts", err,
+			errcode.WithDetails(slog.String("cellID", cellID)))
+	}
+	for _, a := range cellArtifacts {
+		// a.RelPath is stageRoot-relative.
+		mergedPlan = append(mergedPlan, pathsafe.PlannedFile{
+			AbsPath:        filepath.Join(realRoot, filepath.FromSlash(a.RelPath)),
+			Content:        a.Content,
+			ForceOverwrite: true,
+		})
+	}
+
+	return mergedPlan, nil
+}

--- a/tools/codegen/cellgen/stage_render.go
+++ b/tools/codegen/cellgen/stage_render.go
@@ -18,12 +18,20 @@
 //     rebased onto realRoot with ForceOverwrite=true before merging.
 //
 // The depguard scaffold-os-ban rule covers files starting with "scaffold" or
-// "generate_" in tools/codegen/cellgen/; this file does not match either
-// prefix and is therefore not in scope. Direct os.MkdirTemp / os.RemoveAll
-// calls here are intentional and reviewed.
+// "generate_" in tools/codegen/cellgen/; stage_render.go IS also scanned by
+// archtest SCAFFOLD-WRITE-FUNNEL-01 (scaffoldFunnelPred accepts base=="stage_render.go").
+// Direct os.MkdirTemp / os.RemoveAll / os.ReadFile calls here are intentional
+// and reviewed; write-side ops (MkdirAll/WriteFile/Mkdir/Create/OpenFile) remain
+// banned and would trip the archtest.
+//
+// Temp-dir cleanup: materializeSkeletonStage uses a named-return + deferred
+// cleanup so that any inner failure (filepath.Rel / WritePlannedFiles) removes
+// the staging dir before returning. appendDerivedCodegenStaged additionally
+// defers RemoveAll for the success path.
 package cellgen
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -42,28 +50,56 @@ const sharedErrorSchemaRelPath = "contracts/shared/errors/error-response-v1.sche
 
 // materializeSkeletonStage writes the skeleton plan into a temporary staging
 // directory via pathsafe.WritePlannedFiles (funnel reuse, not bypass) and
-// returns the staging root path. The caller must defer os.RemoveAll(stageRoot).
+// returns the resolved staging root path. Cleanup of the staging dir is
+// internal: if any step after MkdirTemp fails, the dir is removed before
+// returning. On success, the caller (appendDerivedCodegenStaged) defers the
+// final RemoveAll.
+//
+// realRoot must already be the output of pathsafe.ResolveRoot.
 //
 // The shared error schema is copied from realRoot into the staging plan so
 // contractgen can resolve relative SchemaRef links in scaffolded contract.yaml
 // files without requiring the schema to be present in the real project tree.
+// If the schema is absent in realRoot, a Warn is logged and the file is omitted
+// from staging (contractgen will fail gracefully if it actually requires it).
 //
-// Returns the staging root path or an error.
-func materializeSkeletonStage(realRoot string, skeletonPlan []pathsafe.PlannedFile) (stageRoot string, err error) {
-	stageRoot, err = os.MkdirTemp("", "gocell-scaffold-stage-*")
-	if err != nil {
+// Returns the resolved staging root path or an error.
+func materializeSkeletonStage(realRoot string, skeletonPlan []pathsafe.PlannedFile) (_ string, err error) {
+	rawStage, mkErr := os.MkdirTemp("", "gocell-scaffold-stage-*")
+	if mkErr != nil {
 		return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
-			"scaffold stage: create temp dir", err)
+			"scaffold stage: create temp dir", mkErr)
 	}
+
+	// Resolve symlinks on the staging root (e.g. macOS /var→/private/var) so
+	// pathsafe.WritePlannedFiles ContainPath checks work correctly.
+	stageRoot, resolveErr := pathsafe.ResolveRoot(rawStage)
+	if resolveErr != nil {
+		_ = os.RemoveAll(rawStage)
+		return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: resolve temp dir", resolveErr,
+			errcode.WithInternal(fmt.Sprintf("stageRoot=%s", rawStage)))
+	}
+
+	// If any step below fails, remove the staging dir before returning.
+	// stageRoot is captured by closure — not overwritten on error return path —
+	// so RemoveAll always targets the correct directory.
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(stageRoot)
+		}
+	}()
 
 	// Build the staging plan by rebasing skeleton AbsPaths from realRoot → stageRoot.
 	stagePlan := make([]pathsafe.PlannedFile, 0, len(skeletonPlan)+1)
 	for _, f := range skeletonPlan {
 		rel, relErr := filepath.Rel(realRoot, f.AbsPath)
 		if relErr != nil {
-			return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			err = errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 				"scaffold stage: rebase skeleton path", relErr,
-				errcode.WithDetails(slog.String("path", f.AbsPath)))
+				errcode.WithDetails(slog.String("path", f.AbsPath)),
+				errcode.WithInternal(fmt.Sprintf("stageRoot=%s", stageRoot)))
+			return "", err
 		}
 		stagePlan = append(stagePlan, pathsafe.PlannedFile{
 			AbsPath:        filepath.Join(stageRoot, rel),
@@ -74,20 +110,26 @@ func materializeSkeletonStage(realRoot string, skeletonPlan []pathsafe.PlannedFi
 
 	// Copy the shared error schema from realRoot so contractgen can resolve
 	// relative SchemaRef paths in the scaffolded contract.yaml.
+	// If absent, log a warning — projects may not have the shared schema yet.
 	schemaAbs := filepath.Join(realRoot, filepath.FromSlash(sharedErrorSchemaRelPath))
 	schemaContent, readErr := os.ReadFile(schemaAbs) //nolint:gosec // known fixed path under project root
 	if readErr == nil {
-		// Only include when present — projects may not have the shared schema yet.
+		// Only include when present.
 		stagePlan = append(stagePlan, pathsafe.PlannedFile{
 			AbsPath: filepath.Join(stageRoot, filepath.FromSlash(sharedErrorSchemaRelPath)),
 			Content: schemaContent,
 		})
+	} else {
+		slog.Warn("scaffold stage: shared error schema not found; derived codegen may be incomplete",
+			slog.String("path", schemaAbs))
 	}
 
 	// Write skeleton + schema into the staging root via the funnel.
 	if writeErr := pathsafe.WritePlannedFiles(stageRoot, stagePlan, false); writeErr != nil {
-		return "", errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
-			"scaffold stage: materialize skeleton", writeErr)
+		err = errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"scaffold stage: materialize skeleton", writeErr,
+			errcode.WithInternal(fmt.Sprintf("stageRoot=%s", stageRoot)))
+		return "", err
 	}
 	return stageRoot, nil
 }
@@ -111,41 +153,38 @@ func appendDerivedCodegenStaged(realRoot, cellID string, skeletonPlan []pathsafe
 // appendDerivedCodegen parses the staging root, renders contractgen and cellgen
 // artifacts in-memory (contract first, then cell so DTO types are available),
 // and appends them to mergedPlan with AbsPaths rebased to realRoot and
-// ForceOverwrite=true. The staging root is ephemeral and must be cleaned up by
-// the caller.
+// ForceOverwrite=true. The staging root is managed by the caller
+// (appendDerivedCodegenStaged), which defers RemoveAll.
 func appendDerivedCodegen(realRoot, stageRoot, cellID string, mergedPlan []pathsafe.PlannedFile) ([]pathsafe.PlannedFile, error) {
 	project, err := metadata.NewParser(stageRoot).Parse()
 	if err != nil {
 		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 			"scaffold stage: parse staged metadata", err,
-			errcode.WithDetails(slog.String("cellID", cellID)))
+			errcode.WithDetails(slog.String("cellID", cellID)),
+			errcode.WithInternal(fmt.Sprintf("stageRoot=%s", stageRoot)))
 	}
 
 	// Contract artifacts first so generated DTO types are available for cellgen.
-	contractIDs, err := contractgen.ContractIDsForCell(project, cellID)
-	if err != nil {
-		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
-			"scaffold stage: list contracts for cell", err,
-			errcode.WithDetails(slog.String("cellID", cellID)))
-	}
+	contractIDs := contractgen.ContractIDsForCell(project, cellID)
 	for _, cid := range contractIDs {
 		artifacts, artErr := contractgen.RenderContractArtifacts(stageRoot, project, cid)
 		if artErr != nil {
 			return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 				"scaffold stage: render contract artifacts", artErr,
-				errcode.WithDetails(slog.String("contractID", cid)))
+				errcode.WithDetails(slog.String("contractID", cid)),
+				errcode.WithInternal(fmt.Sprintf("stageRoot=%s", stageRoot)))
 		}
 		for _, a := range artifacts {
-			// a.Path is stageRoot-relative (slash-separated).
-			absStage := filepath.Join(stageRoot, filepath.FromSlash(a.Path))
-			rel, relErr := filepath.Rel(stageRoot, absStage)
-			if relErr != nil {
+			// a.Path is stageRoot-relative (slash-separated). Route through
+			// pathsafe.ContainPath for defense-in-depth symlink walk on realRoot.
+			absReal, cerr := pathsafe.ContainPath(realRoot, filepath.FromSlash(a.Path))
+			if cerr != nil {
 				return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
-					"scaffold stage: rebase contract artifact", relErr,
+					"scaffold stage: rebase contract artifact", cerr,
 					errcode.WithDetails(slog.String("artifactPath", a.Path)))
 			}
 			mergedPlan = append(mergedPlan, pathsafe.PlannedFile{
-				AbsPath:        filepath.Join(realRoot, rel),
+				AbsPath:        absReal,
 				Content:        a.Content,
 				ForceOverwrite: true,
 			})
@@ -157,12 +196,20 @@ func appendDerivedCodegen(realRoot, stageRoot, cellID string, mergedPlan []paths
 	if err != nil {
 		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 			"scaffold stage: render cell artifacts", err,
-			errcode.WithDetails(slog.String("cellID", cellID)))
+			errcode.WithDetails(slog.String("cellID", cellID)),
+			errcode.WithInternal(fmt.Sprintf("stageRoot=%s", stageRoot)))
 	}
 	for _, a := range cellArtifacts {
-		// a.RelPath is stageRoot-relative.
+		// a.RelPath is stageRoot-relative. Route through ContainPath on realRoot
+		// for defense-in-depth symlink walk.
+		absReal, cerr := pathsafe.ContainPath(realRoot, filepath.FromSlash(a.RelPath))
+		if cerr != nil {
+			return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+				"scaffold stage: rebase cell artifact", cerr,
+				errcode.WithDetails(slog.String("relPath", a.RelPath)))
+		}
 		mergedPlan = append(mergedPlan, pathsafe.PlannedFile{
-			AbsPath:        filepath.Join(realRoot, filepath.FromSlash(a.RelPath)),
+			AbsPath:        absReal,
 			Content:        a.Content,
 			ForceOverwrite: true,
 		})

--- a/tools/codegen/contractgen/generator.go
+++ b/tools/codegen/contractgen/generator.go
@@ -317,7 +317,7 @@ func selectContractIDsByScope(p *metadata.ProjectMeta, opts Options) ([]string, 
 	case ScopeContracts:
 		return selectByContractList(p, []string(s))
 	case ScopeCell:
-		return selectByCellID(p, string(s))
+		return selectByCellID(p, string(s)), nil
 	default:
 		// Unknown Scope implementation — treat as ScopeAll.
 		return selectAllCodegenContracts(p)
@@ -358,13 +358,14 @@ func selectByContractList(p *metadata.ProjectMeta, ids []string) ([]string, erro
 // (server or publisher). The returned slice is sorted for deterministic output.
 // Thin exported wrapper around selectByCellID for cross-package callers
 // (notably cellgen stage_render.go). No OS calls — safe in depguard scaffold-os-ban scope.
-func ContractIDsForCell(p *metadata.ProjectMeta, cellID string) ([]string, error) {
+// Has no fallible path; returns a plain slice.
+func ContractIDsForCell(p *metadata.ProjectMeta, cellID string) []string {
 	return selectByCellID(p, cellID)
 }
 
 // selectByCellID returns all Codegen=true contracts whose server/publisher
-// cell matches cellID.
-func selectByCellID(p *metadata.ProjectMeta, cellID string) ([]string, error) {
+// cell matches cellID. Has no fallible path; returns a plain slice.
+func selectByCellID(p *metadata.ProjectMeta, cellID string) []string {
 	var ids []string
 	for id, c := range p.Contracts {
 		if !c.Codegen {
@@ -379,7 +380,7 @@ func selectByCellID(p *metadata.ProjectMeta, cellID string) ([]string, error) {
 		}
 	}
 	sort.Strings(ids)
-	return ids, nil
+	return ids
 }
 
 // relFromRoot converts an absolute path under root into a slash-separated

--- a/tools/codegen/contractgen/generator.go
+++ b/tools/codegen/contractgen/generator.go
@@ -354,6 +354,14 @@ func selectByContractList(p *metadata.ProjectMeta, ids []string) ([]string, erro
 	return out, nil
 }
 
+// ContractIDsForCell returns all Codegen=true contract IDs owned by cellID
+// (server or publisher). The returned slice is sorted for deterministic output.
+// Thin exported wrapper around selectByCellID for cross-package callers
+// (notably cellgen stage_render.go). No OS calls — safe in depguard scaffold-os-ban scope.
+func ContractIDsForCell(p *metadata.ProjectMeta, cellID string) ([]string, error) {
+	return selectByCellID(p, cellID)
+}
+
 // selectByCellID returns all Codegen=true contracts whose server/publisher
 // cell matches cellID.
 func selectByCellID(p *metadata.ProjectMeta, cellID string) ([]string, error) {


### PR DESCRIPTION
## Summary

Lane D of plan `docs/plans/202605161800-041-pr442-leftover-cleanup-plan.md` — closes the two remaining scaffold cell/bundle gaps from PR #442 root-cause triage.

- **#5 SCAFFOLD-BUNDLE-VARIANT-DUPLICATE-PATH-01 (P2/Cx1)** — `planEventExampleArtifacts` now assigns a distinct event sliceID whenever an HTTP slice is *also* produced (gate on resolved `withHTTP`, not `spec.WithBoth`), collapsing the `WithHTTP&&WithEvents` and `WithBoth` paths into one rule. No more duplicate AbsPath in a single plan.
- **#7 SCAFFOLD-CELL-BUNDLE-CROSS-STAGE-PLAN-MERGE-01 (P2/Cx3)** — contractgen/cellgen-derived artifacts are merged into the **same single `pathsafe.WritePlannedFiles` plan** as the scaffold skeleton. `--dry-run` now prints the full plan including derived files; a stage-2 failure rolls back skeleton **and** derived (cross-stage all-or-nothing). Mirrors the already-closed assembly cross-stage pattern.

### Design: zero-exemption funnel reuse
The cellgen/contractgen render chain reads the skeleton from disk, so assembly's pure in-memory synth doesn't transfer. New `tools/codegen/cellgen/stage_render.go` materializes the skeleton into an `os.MkdirTemp` dir **via `pathsafe.WritePlannedFiles` itself** (the funnel, not a bypass), parses it, renders derived content with the existing `RenderContractArtifacts`/`RenderCellArtifacts` APIs, re-bases AbsPath onto the real root with `ForceOverwrite:true`, and appends to one plan. Only `os.MkdirTemp`/`os.RemoveAll`/`os.ReadFile` are direct os calls (temp-dir lifecycle; none in the SCAFFOLD-WRITE-FUNNEL-01 banned set). **`.golangci.yml` unchanged, no archtest exemption — SCAFFOLD-WRITE-FUNNEL-01 stays fully Hard with zero carve-out.**

Deleted (no compat shim, per CLAUDE.md 不向后兼容): `ScaffoldCellBundle`, `PlanCellBundleForDryRun`, `autoGenerateCellBundleArtifacts`, `printScaffoldCellDryRunPlan`, `ScaffoldSpec.DryRun`. Added: `PlanCellBundleScaffold`, `ScaffoldSpec.SkipGenerate`, `contractgen.ContractIDsForCell`.

A pre-existing test-infra flake (`captureStdout` mutates global `os.Stdout` without a lock — raced under `t.Parallel()`) was root-caused and fixed with per-stream mutexes.

Refs: SCAFFOLD-BUNDLE-VARIANT-DUPLICATE-PATH-01, SCAFFOLD-CELL-BUNDLE-CROSS-STAGE-PLAN-MERGE-01
ref: kernel/assembly PlanAssemblyScaffold (cross-stage merge template); ADR docs/architecture/202605111400-adr-scaffold-assembly-cross-stage-plan-merge.md

### Implementation matrix (scaffold codegen API; internal tooling, no contract.yaml/DB/errcode change)
```
Contract: cellgen scaffold/plan API (internal codegen tooling)
Change: ScaffoldCellBundle/PlanCellBundleForDryRun → PlanCellBundleScaffold; +SkipGenerate; -DryRun; +contractgen.ContractIDsForCell
Implementations: [x] cellgen.PlanCellBundleScaffold  [x] cmd/gocell scaffoldCell  [x] contractgen.ContractIDsForCell
Conformance test: cellgen.TestPlanCellBundleScaffold_MergedPlan; app.TestRunScaffoldCell_DryRun_PrintsDerivedPaths / _LiveRollback_OnDerivedConflict / _SkipGenerate_NoDerived
Repro: go test ./tools/codegen/cellgen/ -run 'PlanCellBundleScaffold|HTTPAndEvents'; go test ./cmd/gocell/app/ -run TestRunScaffoldCell
Dependent contracts (governance scan): none (no contract.yaml / DB schema / errcode Kind change)
```

## Test plan
- [x] `go build ./...` + `go build -tags=integration ./...`
- [x] `go test ./tools/codegen/... ./cmd/gocell/... ./pkg/pathsafe/...`
- [x] `go test ./cmd/gocell/app/ -count=2` (flake fix verified)
- [x] `go test ./tools/archtest/...` (SCAFFOLD-WRITE-FUNNEL-01 green, zero new exemption)
- [x] `hack/verify-scaffold-bundle.sh` (sandbox smoke: scaffold → compile → test)
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
