### PR TITLE
docs(architecture): R2-P5 spike — cellgen errcode funnel Hard 升级机制 ADR

### DIFF
--- a/docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md
+++ b/docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md
@@ -6,11 +6,11 @@
 > ref: docs/plans/202605162000-037r2-wave4-advance-round2.md §R2-P5;
 >      docs/backlog/cap-14-tooling.md L44 `CELLGEN-ERRCODE-FUNNEL-HARDEN`;
 >      .claude/rules/gocell/ai-collab.md §"typed function call as Hard funnel for unbounded operations";
->      tools/archtest/panic_registered_test.go（对偶范本 PANIC-REGISTERED-01）
+>      tools/archtest/panic_invariants_test.go（对偶范本 PANIC-REGISTERED-01；INVARIANT ID 来自旧文件名 panic_registered_test.go，文件按章程 §archtest 文件命名「同主题规则 ≥ 3 → *_invariants_test.go」重命名）
 
 ## Context
 
-`tools/codegen/cellgen/` 包负责生成 cell/slice scaffold 与运行时元数据 literal。PR#557 完成 cellgen 全包 errcode 迁移：50+ 处 error 构造均走 `errcode.New / errcode.Wrap / errcode.Assertion`，0 处 `fmt.Errorf / errors.New / pkg/errors`。
+`tools/codegen/cellgen/` 包负责生成 cell/slice scaffold 与运行时元数据 literal。PR #453（`refactor(cellgen): PR442 follow-up — housekeeping (cellgen errcode + CI + docs)`，merged 2026-05-11）完成 cellgen 全包 errcode 迁移：50+ 处 error 构造均走 `errcode.New / errcode.Wrap / errcode.Assertion`，0 处 `fmt.Errorf / errors.New / pkg/errors`。（备注：backlog `cap-14-tooling.md:44` 原文写「PR#557」是事实错误，本 ADR 以 GitHub merged PR 号为准）
 
 当前 enforcement archtest `CELLGEN-SCAFFOLD-ERRCODE-FUNNEL-01`（`tools/archtest/cellgen_errcode_funnel_test.go` L57-71）用纯 AST identifier 匹配（`SelectorExpr.X.Name == "fmt" && Sel.Name == "Errorf"`）单点禁 `fmt.Errorf`：
 
@@ -45,7 +45,7 @@ backlog `cap-14-tooling.md` L44 提出两个 Hard 升级候选：
 4. **章程 §"typed function call as Hard funnel for unbounded operations"**（`.claude/rules/gocell/ai-collab.md`）：
    > Hard property comes from "form uniqueness": picking any other shape... fails archtest in CI... The charter §1 definition of "typed function call" Hard does not require compile-time blocking, only form uniqueness + archtest fail-on-deviation — which is the highest grade reachable in Go for this rule shape.
 
-5. **PANIC-REGISTERED-01 范本结构**（`tools/archtest/panic_registered_test.go`）：
+5. **PANIC-REGISTERED-01 范本结构**（`tools/archtest/panic_invariants_test.go`）：
    - 扫所有 `panic(arg)` site
    - arg 必须是 `*ast.CallExpr` 且 callee 经 `types.Info.Uses` 解析到 `pkg/panicregister.Approved`
    - 不在白名单内的 panic 形态（bare panic、其他 callee、非字面量 reason）archtest fail
@@ -80,40 +80,74 @@ backlog 原案 2 提出新建 cellgen 专属 typed Error wrapper（如 `func cel
 
 ### D5. 选 (c'') 白名单 form uniqueness（对偶 PANIC-REGISTERED-01）
 
-重写 `tools/archtest/cellgen_errcode_funnel_test.go` 为白名单 form uniqueness archtest，与 PANIC-REGISTERED-01 严格对偶：
+重写 `tools/archtest/cellgen_errcode_funnel_test.go` 为 **types.Info-driven 白名单 form uniqueness archtest**，与 PANIC-REGISTERED-01 严格对偶。**不依赖 callee name pattern 匹配**——name pattern 设计在 v1 草案中曾被使用，被 review 发现漏 dot import / 裸 Ident / function-valued re-export 三类 escape，且容易漏白名单成员（如 `Assertion` 不含 `New/Wrap/Error` 子串），故彻底改为按 callee 解析对象 + result type 双重判定：
 
 ```
-对 cellgen 包内任一 *ast.CallExpr，如果：
-  (1) callee 的 Sel.Name 命中 error-constructor pattern：
-      ^(New|Newf|Wrap|Wrapf|Errorf|Errf|MustNew|.*Error)$
-      （覆盖业界惯例命名 + cellgen 实际使用集 + 常见第三方 lib）
-  AND
-  (2) callee 类型签名（via *types.Info）的 result tuple 至少一个 type
-      assignable to `error` interface
-      （过滤误伤：strings.NewReader / http.NewRequest 等不返 error 的 New）
-THEN 强制：
-  (3) callee 解析到的 *types.Func.Pkg().Path() 必须 ∈
-      {"github.com/ghbvf/gocell/pkg/errcode"}
-ELSE
-  archtest fail("cellgen: error constructor outside errcode funnel: <pos>")
+对 cellgen 包内任一 *ast.CallExpr c：
+
+STEP 1 — callee 解析（覆盖所有 import 形态）：
+  根据 c.Fun 形态用 *types.Info 解析到 callee object：
+    a. SelectorExpr (pkg.Func / x.Method)：types.Info.Uses[sel.Sel] →
+       *types.Func 或 *types.Var
+    b. Ident（裸函数名 / dot import 后的裸函数名）：
+       types.Info.Uses[ident] → *types.Func 或 *types.Var
+    c. 其他形态（FuncLit、ParenExpr、IndexExpr 泛型实例化等）：递归
+       拆解到底层 callee
+
+STEP 2 — 仅看 error 构造点（result type 触发判定）：
+  callee 的 Signature.Results() 含至少一个 type 满足
+  types.Implements(t, errorInterface) — 即可赋值给 `error`
+  若 callee 不返回 error → skip（非 error 构造，无需检查）
+
+STEP 3 — 白名单 form uniqueness 强制：
+  callee 必须是 *types.Func 且 callee.Pkg().Path() ∈
+    {"github.com/ghbvf/gocell/pkg/errcode"}
+  自动覆盖 errcode 包内任何当前/未来公开 callable（New / Wrap /
+  Assertion / 未来新增），无需手动维护白名单成员
+  否则 archtest fail("cellgen: error constructor outside errcode funnel:
+    <pos>: callee=<resolved-name> from <pkg>")
+
+STEP 4 — function-valued re-export 显式拒绝：
+  STEP 1 解析到 *types.Var（如 `var ErrNew = errors.New` 后调用
+  `ErrNew(msg)`，callee 是 var 而非 func）→ archtest fail
+  ("cellgen: error constructor via function-valued variable forbidden:
+  <pos>: var=<name>")
+  rationale: 间接寻址通道是 AI 创新 escape 的主要面，cellgen 包内
+  无此模式（grep 验证），显式 fail-closed
 ```
+
+为什么放弃 name pattern：v1 草案 `^(New|Newf|Wrap|Wrapf|Errorf|Errf|MustNew|.*Error)$` 有三类硬错：
+
+1. **漏白名单成员**：cellgen 现用 `errcode.Assertion`（`literal_printer.go` 4 处），`Assertion` 不含 `New/Wrap/Error/Errorf` 任何子串，pattern 不命中 → 自身白名单成员都被排除
+2. **漏 dot import / 裸 Ident**：`import . "fmt"` 后 `Errorf(msg)` 是 `*ast.Ident` 不是 `*ast.SelectorExpr`，根本不进入 `Sel.Name` 检查路径
+3. **漏 function-valued re-export**：`var ErrNew = errors.New; ErrNew(msg)` callee 是 Ident 解析到 var，绕过 name pattern + types.Info func 检查
+
+types.Info-driven 设计同时解决三类问题：(1) 白名单按 pkg.Path() 检查，errcode 包内所有 callable 自动入白名单；(2) callee 解析覆盖 SelectorExpr/Ident/FuncLit 等所有 ast 形态；(3) STEP 4 显式禁 var 通道。
 
 **反向自检 RED fixture 覆盖面**（章程 §AI-rebust 三档分级 ≥ Hard 必备）：
 
-1. `fmt.Errorf("...")` — 黑名单原型，失败位置 = 调用点 callsite
-2. `fmtx "fmt"` alias import + `fmtx.Errorf("...")` — alias 绕过，失败位置 = 调用点 callsite（types.Info 解析覆盖 alias）
-3. `errors.New("...")` — stdlib 另一 escape route，失败位置 = 调用点 callsite
-4. cellgen 包内自建 wrapper `func newErr(msg string) error { return errors.New(msg) }` — AI 创新 escape。**失败位置 = wrapper 定义体内的 `errors.New` 调用**，不是外层 `newErr(...)` 调用点（外层 callee `newErr` 命中 pattern 但 result type 检查通过；funnel 仍需要 wrapper 定义内的最终构造点命中——`errors.New` 同时满足 name pattern + 返回 error，被覆盖）
+1. `fmt.Errorf("...")` — normal SelectorExpr import，失败位置 = 调用点
+2. `fmtx "fmt"` alias import + `fmtx.Errorf("...")` — alias SelectorExpr，失败位置 = 调用点（types.Info 解析覆盖 alias）
+3. `import . "fmt"` + `Errorf("...")` — dot import，callee 是裸 Ident，失败位置 = 调用点（STEP 1.b 覆盖）
+4. `errors.New("...")` — stdlib 另一 escape route，失败位置 = 调用点
+5. `import . "errors"` + `New("...")` — dot import 第二 lib，失败位置 = 调用点
+6. `var ErrNew = errors.New` + 调用 `ErrNew("...")` — function-valued var re-export，失败位置 = 调用点（STEP 4 显式 fail）
+7. cellgen 包内自建 wrapper `func newErr(msg string) error { return errors.New(msg) }` — AI 创新 escape。**失败位置 = wrapper 定义体内的 `errors.New` 调用**（errors.New result type 含 error，pkg.Path 不在白名单）；外层 `newErr(...)` 调用点 result type 含 error 但 callee.Pkg().Path() == "github.com/.../tools/codegen/cellgen"（也不在白名单）→ 外层调用点同样 fail；任一处先报都构成 Hard 覆盖
 
 每个 fixture 应证明 archtest fail，从而验证白名单覆盖未知形态而非仅已知 escape。
 
-**Hard 覆盖完备性论证**：cellgen 包内任何最终构造 error 的语义（不透传现有 error）必然落入两类：(A) 直接调用 `errcode.{New,Wrap,Assertion}` — 落白名单内 ✅；(B) 调用任何其他 callable 间接构造 — 该 callable 的定义体内必然有最终构造点，最终构造点 callee name 必然命中 pattern（业界惯例：构造 error 必经 `New|Errorf|Wrap|...`），被 archtest 在 callable 定义处拦截。除反射动态构造（盲区清单 §D5 末尾）外无第三类。
+**Hard 覆盖完备性论证**（types.Info-driven 设计）：cellgen 包内任何最终构造 error 的语义（不透传现有 error）必然产生 CallExpr 且 callee 返回类型含 `error`，被 STEP 2 触发。该 CallExpr 的 callee 经 STEP 1 解析后必然落入以下三类：
+- (A) `*types.Func` 且 pkg.Path() == `pkg/errcode` — 白名单内 ✅
+- (B) `*types.Func` 且 pkg.Path() ≠ `pkg/errcode`（含 cellgen 包内自建 helper）— STEP 3 fail
+- (C) `*types.Var`（function-valued 变量）— STEP 4 fail
+
+除反射动态构造（盲区清单见下）外无第四类。
 
 **盲区清单**（章程 §"工具选定后强制盲区自检"，Hard 评级前置举证）：
 
-- **反射动态构造 error**：通过 `reflect.MakeFunc` 等动态生成返回 `error` 的 callable，archtest 无法在 AST 层识别其内部 escape。cellgen 包当前无此模式（grep 验证），接受为已知遗留风险；未来若 cellgen 引入反射 codegen，扩 archtest 加 reflect 包 import ban。
-- **build-tag 隔离的非默认 file**：archtest scope 当前包含 `tools/codegen/cellgen/*.go`（excluding `*_test.go`），若新增 build-tag 文件需同步检查 scope 覆盖。已由 `ARCHTEST-VERIFY-COVERAGE-01` 守护 archtest 注册一致性。
-- **wrapper 名不含 error-constructor pattern 但定义体内的最终构造仍被命中**：见 fixture 4 论证；这不是盲区，是 Hard 覆盖路径。明文澄清避免 P5.1 实施者把此场景误判为遗漏。
+- **反射动态构造 error**：通过 `reflect.MakeFunc` / `reflect.Value.Call` 等动态生成返回 `error` 的 callable，CallExpr 的 callee 类型在静态 AST 层不可解析为具名 `*types.Func`（多解析为 `*types.Var` 走 STEP 4 fail，但 `reflect.Value.Call(...).Interface().(error)` 路径无 CallExpr 直接产 error）。cellgen 包当前无此模式（grep 验证 `reflect.MakeFunc` / `reflect.Value.Call` 均不出现），接受为已知遗留风险；未来若 cellgen 引入反射 codegen，扩 archtest 加 reflect 包 import ban
+- **build-tag 隔离的非默认 file**：archtest scope 当前包含 `tools/codegen/cellgen/*.go`（excluding `*_test.go`），若新增 build-tag 文件需同步检查 scope 覆盖。已由 `ARCHTEST-VERIFY-COVERAGE-01` 守护 archtest 注册一致性
+- **interface method call 返回 error**：如 `var x SomeInterface; x.Method() error`。当前 cellgen 包内无此调用形态返回 error（grep 验证）；若未来出现，STEP 1.a 解析到 `*types.Func`（interface method），pkg.Path 不在白名单则 fail，与 (B) 同处理
 
 ### D6. AI-rebust 评级 = Hard
 

--- a/docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md
+++ b/docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md
@@ -100,12 +100,20 @@ ELSE
 
 **反向自检 RED fixture 覆盖面**（章程 §AI-rebust 三档分级 ≥ Hard 必备）：
 
-1. `fmt.Errorf("...")` — 黑名单原型
-2. `fmtx "fmt"` alias import + `fmtx.Errorf("...")` — alias 绕过
-3. `errors.New("...")` — stdlib 另一 escape route
-4. cellgen 包内自建 wrapper `func newErr(msg string) error { return errors.New(msg) }` 调用点 — AI 创新 escape
+1. `fmt.Errorf("...")` — 黑名单原型，失败位置 = 调用点 callsite
+2. `fmtx "fmt"` alias import + `fmtx.Errorf("...")` — alias 绕过，失败位置 = 调用点 callsite（types.Info 解析覆盖 alias）
+3. `errors.New("...")` — stdlib 另一 escape route，失败位置 = 调用点 callsite
+4. cellgen 包内自建 wrapper `func newErr(msg string) error { return errors.New(msg) }` — AI 创新 escape。**失败位置 = wrapper 定义体内的 `errors.New` 调用**，不是外层 `newErr(...)` 调用点（外层 callee `newErr` 命中 pattern 但 result type 检查通过；funnel 仍需要 wrapper 定义内的最终构造点命中——`errors.New` 同时满足 name pattern + 返回 error，被覆盖）
 
 每个 fixture 应证明 archtest fail，从而验证白名单覆盖未知形态而非仅已知 escape。
+
+**Hard 覆盖完备性论证**：cellgen 包内任何最终构造 error 的语义（不透传现有 error）必然落入两类：(A) 直接调用 `errcode.{New,Wrap,Assertion}` — 落白名单内 ✅；(B) 调用任何其他 callable 间接构造 — 该 callable 的定义体内必然有最终构造点，最终构造点 callee name 必然命中 pattern（业界惯例：构造 error 必经 `New|Errorf|Wrap|...`），被 archtest 在 callable 定义处拦截。除反射动态构造（盲区清单 §D5 末尾）外无第三类。
+
+**盲区清单**（章程 §"工具选定后强制盲区自检"，Hard 评级前置举证）：
+
+- **反射动态构造 error**：通过 `reflect.MakeFunc` 等动态生成返回 `error` 的 callable，archtest 无法在 AST 层识别其内部 escape。cellgen 包当前无此模式（grep 验证），接受为已知遗留风险；未来若 cellgen 引入反射 codegen，扩 archtest 加 reflect 包 import ban。
+- **build-tag 隔离的非默认 file**：archtest scope 当前包含 `tools/codegen/cellgen/*.go`（excluding `*_test.go`），若新增 build-tag 文件需同步检查 scope 覆盖。已由 `ARCHTEST-VERIFY-COVERAGE-01` 守护 archtest 注册一致性。
+- **wrapper 名不含 error-constructor pattern 但定义体内的最终构造仍被命中**：见 fixture 4 论证；这不是盲区，是 Hard 覆盖路径。明文澄清避免 P5.1 实施者把此场景误判为遗漏。
 
 ### D6. AI-rebust 评级 = Hard
 
@@ -114,7 +122,10 @@ ELSE
 - **form uniqueness**：cellgen 包内任何 error constructor callee 必须 ∈ `pkg/errcode`，集合外形态 archtest 全部 fail — 无灰色地带
 - **archtest fail-on-deviation**：任何偏离立即 CI 红
 - **诚实声明**：编译期不可阻止（Go 允许任何包定义任何 callable），enforcement 完全依赖 archtest。这是 Go 语言中 "error 构造点 funnel" 此类规则形态可达到的最高评级
-- **funnel 双向锁评级**（§Funnel 双向锁评级）：上游 Hard（cellgen 包内任何 error construct callsite 必须落入白名单）+ 下游 Hard（pkg/errcode funnel 集合本身已由 ERRCODE-KIND-LITERAL-01 + MESSAGE-CONST-LITERAL-01 + DETAILS-SLOG-ATTR-01 锁定）— 闭环 funnel
+- **funnel 双向锁评级**（§Funnel 双向锁评级）：
+  - **上游 Hard**：cellgen 包内任何 error construct callsite 必须落入白名单。**评级依据章程 §"typed function call as Hard funnel for unbounded operations"**：「form uniqueness + archtest fail-on-deviation 是 Go 语言中此类规则形态可达最高级，不要求编译期阻止」（与 PANIC-REGISTERED-01 同源认定）。本案上游不采用「典型形态 = sealed interface + 字段私有化」（章程 §Funnel 双向锁评级第一项典型形态）——sealed interface 适用于「funnel API 接受任意载荷」（如 panic(any)），cellgen errcode 的 funnel API 是 `errcode.{New,Wrap,Assertion}` 三个 typed function，载荷已被类型签名锁定，无需 sealed interface
+  - **下游 Hard**：`pkg/errcode` funnel 集合本身由 ERRCODE-KIND-LITERAL-01 + MESSAGE-CONST-LITERAL-01 + DETAILS-SLOG-ATTR-01 锁定（三档 archtest 形态锁，与 ADR `202605051730-adr-errcode-message-pii-safety.md` 一致）
+  - **闭环**：上游白名单 + 下游 funnel 内容锁 — 集合外不能进 + 集合内必须经过 funnel 双向 Hard
 
 ## Rejected alternatives
 

--- a/docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md
+++ b/docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md
@@ -1,0 +1,130 @@
+# ADR: cellgen errcode funnel Hard 升级机制选型
+
+> Status: Accepted
+> Date: 2026-05-17
+> Implementation: 待 P5.1 PR（重写 `tools/archtest/cellgen_errcode_funnel_test.go` 到白名单 form uniqueness）
+> ref: docs/plans/202605162000-037r2-wave4-advance-round2.md §R2-P5;
+>      docs/backlog/cap-14-tooling.md L44 `CELLGEN-ERRCODE-FUNNEL-HARDEN`;
+>      .claude/rules/gocell/ai-collab.md §"typed function call as Hard funnel for unbounded operations";
+>      tools/archtest/panic_registered_test.go（对偶范本 PANIC-REGISTERED-01）
+
+## Context
+
+`tools/codegen/cellgen/` 包负责生成 cell/slice scaffold 与运行时元数据 literal。PR#557 完成 cellgen 全包 errcode 迁移：50+ 处 error 构造均走 `errcode.New / errcode.Wrap / errcode.Assertion`，0 处 `fmt.Errorf / errors.New / pkg/errors`。
+
+当前 enforcement archtest `CELLGEN-SCAFFOLD-ERRCODE-FUNNEL-01`（`tools/archtest/cellgen_errcode_funnel_test.go` L57-71）用纯 AST identifier 匹配（`SelectorExpr.X.Name == "fmt" && Sel.Name == "Errorf"`）单点禁 `fmt.Errorf`：
+
+- 未使用 `types.Info`；alias import (`fmtx "fmt"`)、dot import (`. "fmt"`)、re-export 均可绕过
+- 不覆盖 `errors.New` / 第三方 errors lib / cellgen 包内自建 error wrapper（如 `func newErr(msg) error { return errors.New(msg) }`）等其他 escape route
+- 自我评级 Medium（文件头 godoc L11-14 明示「Medium scanner AST + concrete-package allowlist」）
+
+backlog `cap-14-tooling.md` L44 提出两个 Hard 升级候选：
+
+> Hard 升级路径：加 `.golangci.yml` method-level depguard rule 或抽 typed Error return wrapper 让 `fmt.Errorf` 在编译期不可表达
+
+本 ADR 为 R2-P5 spike 的决策产物，评估 backlog 原案 + 衍生方案并选定实施方向。
+
+## Spike key facts
+
+1. **cellgen 包 error 构造现状**（grep `tools/codegen/cellgen/*.go` 非测试代码）：
+   - `errcode.New / errcode.Wrap / errcode.Assertion` = 50+ 处
+   - `fmt.Errorf / errors.New / errors.Wrap / pkg/errors.*` = 0 处
+   - 透传 `return err`（不构造新 error）= 30+ 处
+   - **包已事实上是白名单 form uniqueness 形态**，Hard 升级 = 把该事实形态做成 archtest 强约束
+
+2. **cellgen 包 `fmt` 合法使用**：
+   - `fmt.Sprintf` = 10+ 处合法（subscription alias 拼接、metadata literal printer、`errcode.WithInternal` 上下文格式化）
+   - `fmt.Fprintf` = 12+ 处合法（`literal_printer.go` 给 `strings.Builder` 输出 Go literal）
+   - 禁 `fmt` 整包 import 不现实（破坏 codegen 核心功能）
+
+3. **depguard 工具能力**（核实 OpenPeeDeeP/depguard v2 README + GoCell `.golangci.yml` 现有 rule）：
+   - 仅支持 package import 级 file-glob ban（如 `scaffold-os-ban` 禁 4 文件 import os）
+   - **不支持** method-level caller allowlist
+   - GoCell 现有 0 个 depguard rule 是 method-level 形态
+
+4. **章程 §"typed function call as Hard funnel for unbounded operations"**（`.claude/rules/gocell/ai-collab.md`）：
+   > Hard property comes from "form uniqueness": picking any other shape... fails archtest in CI... The charter §1 definition of "typed function call" Hard does not require compile-time blocking, only form uniqueness + archtest fail-on-deviation — which is the highest grade reachable in Go for this rule shape.
+
+5. **PANIC-REGISTERED-01 范本结构**（`tools/archtest/panic_registered_test.go`）：
+   - 扫所有 `panic(arg)` site
+   - arg 必须是 `*ast.CallExpr` 且 callee 经 `types.Info.Uses` 解析到 `pkg/panicregister.Approved`
+   - 不在白名单内的 panic 形态（bare panic、其他 callee、非字面量 reason）archtest fail
+   - **白名单 form uniqueness**：集合外任何形态均失败
+
+## Decision
+
+### D1. 否决 (a) depguard method-level rule
+
+backlog 原案 1 基于不准确的 depguard 能力假设。depguard v2 不支持 method-level caller allowlist，仅支持 package import 级 ban。无 GoCell 内部或 OSS 上游路径可在不引入新工具的前提下实现 method-level enforcement。
+
+### D2. 否决 (a') depguard package-level 禁 `fmt` import
+
+衍生方案：仿 `scaffold-os-ban` 禁 cellgen 包 import `fmt`。否决理由：cellgen 包内 22+ 处合法 `fmt.Sprintf/Fprintf` 用途（literal printer、alias 拼接、WithInternal 上下文）。禁 `fmt` 等于推倒 `literal_printer.go` 改 `strings.Builder` 替代，代价高且非必要。
+
+### D3. 否决 (b) typed Error return wrapper
+
+backlog 原案 2 提出新建 cellgen 专属 typed Error wrapper（如 `func cellgenError(...) error`），使 `fmt.Errorf` 通过类型不匹配在编译期不可表达。否决理由：
+
+- cellgen 当前已 0 处 `fmt.Errorf`，所有 error 已走 `errcode.New/Wrap`。新建 wrapper 只服务 archtest，无运行时价值
+- 章程 §"string-typed concept funnel" 适用条件不成立：cellgen error 不是独立 string-typed concept（如 rule code / event topic 这类承载独立语义的字符串），是 errcode 通用域；funnel 已经是 errcode 本身
+- 章程 §panicregister.Approved 范本前提是「源 API 接受 `any` 类型，需 typed marker 压缩成形态唯一性」；cellgen errcode 不存在此前提（errcode.New/Wrap 已经是 typed funnel）
+- 新增 thin marker wrapper 违反 §"优雅简洁"
+
+### D4. 否决 (c) 黑名单单点禁的 type-aware 升级
+
+衍生方案：把现有 archtest 升级到 type-aware（用 `types.Info.Uses` 解析 `fmt.Errorf` callee），覆盖 alias/dot import。否决理由：
+
+- 仅防 `fmt.Errorf` 一种已知 escape，AI 创新 escape route（如自建 `newErr` wrapper、引入 pkg/errors、引入第三方 lib）都能绕过
+- 章程 §"Funnel 双向锁评级"要求 funnel 类约束「集合外不能进 / 集合内必须经过」双向 Hard，黑名单只锁单点，上游 Hard 不闭环
+- L3 概念模型与 PANIC-REGISTERED-01 不对偶（PANIC 是白名单 funnel，黑名单单点禁是其退化形态）
+
+### D5. 选 (c'') 白名单 form uniqueness（对偶 PANIC-REGISTERED-01）
+
+重写 `tools/archtest/cellgen_errcode_funnel_test.go` 为白名单 form uniqueness archtest，与 PANIC-REGISTERED-01 严格对偶：
+
+```
+对 cellgen 包内任一 *ast.CallExpr，如果：
+  (1) callee 的 Sel.Name 命中 error-constructor pattern：
+      ^(New|Newf|Wrap|Wrapf|Errorf|Errf|MustNew|.*Error)$
+      （覆盖业界惯例命名 + cellgen 实际使用集 + 常见第三方 lib）
+  AND
+  (2) callee 类型签名（via *types.Info）的 result tuple 至少一个 type
+      assignable to `error` interface
+      （过滤误伤：strings.NewReader / http.NewRequest 等不返 error 的 New）
+THEN 强制：
+  (3) callee 解析到的 *types.Func.Pkg().Path() 必须 ∈
+      {"github.com/ghbvf/gocell/pkg/errcode"}
+ELSE
+  archtest fail("cellgen: error constructor outside errcode funnel: <pos>")
+```
+
+**反向自检 RED fixture 覆盖面**（章程 §AI-rebust 三档分级 ≥ Hard 必备）：
+
+1. `fmt.Errorf("...")` — 黑名单原型
+2. `fmtx "fmt"` alias import + `fmtx.Errorf("...")` — alias 绕过
+3. `errors.New("...")` — stdlib 另一 escape route
+4. cellgen 包内自建 wrapper `func newErr(msg string) error { return errors.New(msg) }` 调用点 — AI 创新 escape
+
+每个 fixture 应证明 archtest fail，从而验证白名单覆盖未知形态而非仅已知 escape。
+
+### D6. AI-rebust 评级 = Hard
+
+按章程 §"typed function call as Hard funnel for unbounded operations"：
+
+- **form uniqueness**：cellgen 包内任何 error constructor callee 必须 ∈ `pkg/errcode`，集合外形态 archtest 全部 fail — 无灰色地带
+- **archtest fail-on-deviation**：任何偏离立即 CI 红
+- **诚实声明**：编译期不可阻止（Go 允许任何包定义任何 callable），enforcement 完全依赖 archtest。这是 Go 语言中 "error 构造点 funnel" 此类规则形态可达到的最高评级
+- **funnel 双向锁评级**（§Funnel 双向锁评级）：上游 Hard（cellgen 包内任何 error construct callsite 必须落入白名单）+ 下游 Hard（pkg/errcode funnel 集合本身已由 ERRCODE-KIND-LITERAL-01 + MESSAGE-CONST-LITERAL-01 + DETAILS-SLOG-ATTR-01 锁定）— 闭环 funnel
+
+## Rejected alternatives
+
+- (a) depguard method-level rule — D1
+- (a') depguard package-level 禁 fmt import — D2
+- (b) typed Error return wrapper — D3
+- (c) 黑名单单点禁 + type-aware 升级 — D4
+
+## Escalation
+
+- **新增 cellgen 包内 error escape route**（如引入第三方 lib 需绕过 funnel）：必须 RETRACT 本 ADR 或扩 D5 (3) 白名单集合，同 PR 修改 archtest + ADR 双侧
+- **name pattern 误伤 / 漏报**：P5.1 实施期跑全仓 dry-run 确认；如有误伤合法 callee（如 cellgen 内合理使用某 stdlib `XxxError` helper），同 PR 调整 pattern 并补反向自检 fixture
+- **章程 §AI-rebust 三档分级 升级路径**：若未来 Go 1.X 支持 method-level visibility（如 export 控制扩展到方法），评估升级到 compile-time Hard，本 ADR 转 Superseded

--- a/docs/plans/202605162000-037r2-wave4-advance-round2.md
+++ b/docs/plans/202605162000-037r2-wave4-advance-round2.md
@@ -44,7 +44,7 @@
 | **R2-P2** IFACE-IMPL-HELPER | PR-a framework+6站点迁移 / PR-b Hard funnel | ~3-4h | ⏳ PR-a 起（branch 599）；PR-b 待 PR-a merge | 无 | P1∥P2∥P4 |
 | **R2-P3** POSTGRES-NOTFOUND-MIXUP | archtest enforcement（±migration） | spike 1h + 1-3h | ✅ ship — PR-a PR #528 (branch 211, merged) + PR-b PR #530 (branch 213) | spike 结论 | 独立 |
 | ~~**R2-P4** OWNER-AST-EXTRACTION~~ | 单维 tooling refactor | — | ❌ subsumed by PR #435 | — | — |
-| **R2-P5** CELLGEN-ERRCODE-FUNNEL-HARDEN | 决策→多维 | spike 2h + TBD | ⏳ spike | P5.0 决策 | 串行其后 |
+| **R2-P5** CELLGEN-ERRCODE-FUNNEL-HARDEN | spike + 单 PR enforcement | spike 2h + 3-4h | ⏳ spike 完结（ADR 202605171200，选 c'' 白名单 form uniqueness）；P5.1 待启动 | 无 | 独立 |
 
 ### R2-P1：PR-TS1-FU-VALIDATIONRESULT-EMITTER-SEALED-MARKER-01 ✅ shipped 2026-05-16
 
@@ -86,13 +86,18 @@
 >
 > **否决「新建独立 tool 加 referenced_by 索引」**：等于重建 PR #435 刻意铲除的「持久化 artifact + drift gate」，是对该架构决策的回归，违反 single-source 原则。原事故类（照 inventory 改错文件）已随 inventory 删除消失。cap-02 对应行同步关闭。
 
-### R2-P5：CELLGEN-ERRCODE-FUNNEL-HARDEN（决策 gate）
+### R2-P5：CELLGEN-ERRCODE-FUNNEL-HARDEN（决策 gate → 单 PR enforcement）
 
-- **P5.0 决策 spike**（任务首步，非外部依赖）：评估 (a) depguard method-level rule vs (b) cellgen typed errcode wrapper 抽出，产出选型结论 + 理由（ADR-lite 段落）。
-- **P5.1+**：按选定机制拆 framework / migration / enforcement N PR（036 单维度规则）。
-- **维度**：决策→多维。排 P1-P3 之后（唯一多维非平凡项，需专注，且决策结论影响后续拆分）。
-- **文件**：`tools/codegen/cellgen/` + （视方案）`.golangci.yml` 或新 typed wrapper。
-- **前置**：P5.0 决策。**关闭 backlog** cap-14 对应行。
+> **P5.0 spike 完结**（2026-05-17）：产出 ADR `docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md`。结论 = **否决 backlog 原案 (a)(b)、否决衍生 (a')(c)，选 (c'') 白名单 form uniqueness**（对偶 PANIC-REGISTERED-01）。
+>
+> **关键事实修正**：spike 实测 cellgen 包当前 `errcode.New/Wrap/Assertion` 50+ 处、`fmt.Errorf/errors.New` 0 处——包已事实上是白名单 form uniqueness 形态。backlog 原案 (a) depguard method-level 不可行（工具能力不支持，已查 OpenPeeDeeP/depguard v2 README）；(b) typed wrapper 是「为 archtest 而 wrapper」无运行时价值（违反 §"优雅简洁"，且 cellgen errcode 非 string-typed concept funnel 适用域）。
+
+- **P5.1 实施**（单 PR、单维 enforcement，~3-4h）：重写 `tools/archtest/cellgen_errcode_funnel_test.go` 到白名单 form uniqueness——扫 cellgen 包内 CallExpr，callee 名字命中 error-constructor pattern `^(New|Newf|Wrap|Wrapf|Errorf|Errf|MustNew|.*Error)$` 且 result type 含 `error`，则 callee 必须 types.Info 解析到 `pkg/errcode` 包；否则 archtest fail。
+- **反向自检 RED fixture**（章程 §AI-rebust ≥ Hard 必备）：覆盖 4 类 escape — fmt.Errorf 原型 / fmtx alias import / errors.New stdlib / cellgen 包内自建 wrapper（AI 创新 escape）。
+- **AI-rebust**：**Hard**（form uniqueness + archtest fail-on-deviation；章程 §"typed function call as Hard funnel for unbounded operations" 明确认可的 Hard 上限）+ **Funnel 双向锁 Hard**（上游：cellgen 包内任何 error construct callsite 必须落白名单；下游：pkg/errcode funnel 集合本身已由 ERRCODE-KIND-LITERAL-01 + MESSAGE-CONST-LITERAL-01 + DETAILS-SLOG-ATTR-01 锁定 — 闭环 funnel）。
+- **维度**：单维 enforcement（archtest 升级 + RED fixture），无业务迁移、无新概念、无新包。
+- **文件**：`tools/archtest/cellgen_errcode_funnel_test.go`（重写）+ `tools/archtest/testdata/cellgen_errcode_funnel_fixtures/`（4 RED fixture）+ 复用 `tools/archtest/internal/typeseval/` helper。
+- **前置**：无（spike 已完结）。**关闭 backlog** `cap-14-tooling.md:44` 🟡 → ✅（同 P5.1 PR）。
 
 ---
 

--- a/docs/plans/202605162000-037r2-wave4-advance-round2.md
+++ b/docs/plans/202605162000-037r2-wave4-advance-round2.md
@@ -44,7 +44,7 @@
 | **R2-P2** IFACE-IMPL-HELPER | PR-a framework+6站点迁移 / PR-b Hard funnel | ~3-4h | ⏳ PR-a 起（branch 599）；PR-b 待 PR-a merge | 无 | P1∥P2∥P4 |
 | **R2-P3** POSTGRES-NOTFOUND-MIXUP | archtest enforcement（±migration） | spike 1h + 1-3h | ✅ ship — PR-a PR #528 (branch 211, merged) + PR-b PR #530 (branch 213) | spike 结论 | 独立 |
 | ~~**R2-P4** OWNER-AST-EXTRACTION~~ | 单维 tooling refactor | — | ❌ subsumed by PR #435 | — | — |
-| **R2-P5** CELLGEN-ERRCODE-FUNNEL-HARDEN | spike + 单 PR enforcement | spike 2h + 3-4h | ⏳ spike 完结（ADR 202605171200，选 c'' 白名单 form uniqueness）；P5.1 待启动 | 无 | 独立 |
+| **R2-P5** CELLGEN-ERRCODE-FUNNEL-HARDEN | spike + 单 PR enforcement | spike 2h + 3-4h | ⏳ spike 完结（spike PR #548，ADR 202605171200，选 c'' 白名单 form uniqueness）；P5.1 待启动 | 无 | 独立 |
 
 ### R2-P1：PR-TS1-FU-VALIDATIONRESULT-EMITTER-SEALED-MARKER-01 ✅ shipped 2026-05-16
 

--- a/docs/plans/202605162000-037r2-wave4-advance-round2.md
+++ b/docs/plans/202605162000-037r2-wave4-advance-round2.md
@@ -92,8 +92,8 @@
 >
 > **关键事实修正**：spike 实测 cellgen 包当前 `errcode.New/Wrap/Assertion` 50+ 处、`fmt.Errorf/errors.New` 0 处——包已事实上是白名单 form uniqueness 形态。backlog 原案 (a) depguard method-level 不可行（工具能力不支持，已查 OpenPeeDeeP/depguard v2 README）；(b) typed wrapper 是「为 archtest 而 wrapper」无运行时价值（违反 §"优雅简洁"，且 cellgen errcode 非 string-typed concept funnel 适用域）。
 
-- **P5.1 实施**（单 PR、单维 enforcement，~3-4h）：重写 `tools/archtest/cellgen_errcode_funnel_test.go` 到白名单 form uniqueness——扫 cellgen 包内 CallExpr，callee 名字命中 error-constructor pattern `^(New|Newf|Wrap|Wrapf|Errorf|Errf|MustNew|.*Error)$` 且 result type 含 `error`，则 callee 必须 types.Info 解析到 `pkg/errcode` 包；否则 archtest fail。
-- **反向自检 RED fixture**（章程 §AI-rebust ≥ Hard 必备）：覆盖 4 类 escape — fmt.Errorf 原型 / fmtx alias import / errors.New stdlib / cellgen 包内自建 wrapper（AI 创新 escape）。
+- **P5.1 实施**（单 PR、单维 enforcement，~3-4h）：重写 `tools/archtest/cellgen_errcode_funnel_test.go` 到 types.Info-driven 白名单 form uniqueness——扫 cellgen 包内 CallExpr，按 *types.Info 解析 callee（覆盖 SelectorExpr/Ident/dot import 所有形态），若 callee 返回类型含 `error`，则 callee 必须是 *types.Func 且 `.Pkg().Path() == "github.com/.../pkg/errcode"`；解析到 *types.Var（function-valued re-export）显式 fail。**不依赖 callee name pattern**（详见 ADR §D5 论证：name pattern 漏 dot import / 裸 Ident / re-export，且漏白名单成员如 Assertion）。
+- **反向自检 RED fixture**（章程 §AI-rebust ≥ Hard 必备）：覆盖 7 类 escape — fmt.Errorf normal / fmtx alias / fmt dot import / errors.New normal / errors dot import / function-valued var re-export / cellgen 包内自建 wrapper。
 - **AI-rebust**：**Hard**（form uniqueness + archtest fail-on-deviation；章程 §"typed function call as Hard funnel for unbounded operations" 明确认可的 Hard 上限）+ **Funnel 双向锁 Hard**（上游：cellgen 包内任何 error construct callsite 必须落白名单；下游：pkg/errcode funnel 集合本身已由 ERRCODE-KIND-LITERAL-01 + MESSAGE-CONST-LITERAL-01 + DETAILS-SLOG-ATTR-01 锁定 — 闭环 funnel）。
 - **维度**：单维 enforcement（archtest 升级 + RED fixture），无业务迁移、无新概念、无新包。
 - **文件**：`tools/archtest/cellgen_errcode_funnel_test.go`（重写）+ `tools/archtest/testdata/cellgen_errcode_funnel_fixtures/`（4 RED fixture）+ 复用 `tools/archtest/internal/typeseval/` helper。


### PR DESCRIPTION
## Summary

- R2-P5 spike 产物：ADR `docs/architecture/202605171200-adr-cellgen-errcode-funnel-mechanism.md`，评估 CELLGEN-ERRCODE-FUNNEL-HARDEN 候选机制并选定 **(c'') 白名单 form uniqueness**（对偶 PANIC-REGISTERED-01）
- 同步更新 037 R2 计划 §R2-P5 段落（spike 完结、P5.1 单 PR enforcement 拆分）
- **本 PR 仅 spike 决策文档**，不动 cellgen 任何 .go / 不动 archtest 任何 .go / 不动 .golangci.yml；P5.1 实施另立 PR

## 双文档紧耦合 — 单 spike 交付物声明

本 PR 同时新建 ADR + 修改 037 R2 计划进度，二者构成**单一 spike 交付物**（决策本身 + 进度状态更新），紧耦合不可拆分。类比 R2-P3 spike 结论也合并 ADR + 037 R2 表格更新于单 PR。符合 036 单 PR=单维度纪律。

## Spike 关键事实

- cellgen 包当前 `errcode.New/Wrap/Assertion` **50+ 处**、`fmt.Errorf/errors.New` **0 处** — 包已事实上是白名单 form uniqueness 形态
- depguard v2 **不支持** method-level caller allowlist（核实 OpenPeeDeeP/depguard v2 README + GoCell 现有 `.golangci.yml`）
- cellgen 包 `fmt` 合法用途 22+ 处（literal printer / alias 拼接 / WithInternal），禁 `fmt` 整包不现实
- 现有 archtest 是纯 AST identifier 匹配，alias/dot import/re-export 均可绕过，自评 Medium

## 候选方案评估表（ADR §Decision）

| 方案 | 评级 | 结论 |
|------|------|------|
| (a) depguard method-level rule（backlog 原案 1） | ❌ 不可行 | 工具能力不支持 |
| (a') depguard package-level 禁 `fmt` | ❌ 不可行 | 22+ 处合法 fmt.Sprintf/Fprintf 用途 |
| (b) typed Error return wrapper（backlog 原案 2） | ⚠️ 低 ROI | cellgen 0 处 fmt.Errorf，wrapper 仅服务 archtest，违反优雅简洁 |
| (c) 黑名单单点禁 type-aware 升级 | ⚠️ 不彻底 | AI 创新 escape route 仍可绕过 |
| **(c'') 白名单 form uniqueness** | ✅ **选定** | 对偶 PANIC-REGISTERED-01，章程 Hard 范本 |

## (c'') 选定方案 archtest 形态（types.Info-driven，不依赖 callee name pattern）

```
对 cellgen 包内任一 *ast.CallExpr c：

STEP 1 — callee 解析（覆盖所有 import 形态）：
  根据 c.Fun 形态用 *types.Info 解析到 callee object：
    a. SelectorExpr (pkg.Func / x.Method)：types.Info.Uses[sel.Sel]
    b. Ident（裸函数名 / dot import 后的裸函数名）：types.Info.Uses[ident]
    c. 其他形态（FuncLit / ParenExpr / IndexExpr 泛型）：递归拆解

STEP 2 — 仅看 error 构造点（result type 触发判定）：
  callee.Signature.Results() 含至少一个 type satisfies error
  若不返回 error → skip

STEP 3 — 白名单 form uniqueness 强制：
  callee 必须是 *types.Func 且 callee.Pkg().Path() ∈
    {"github.com/ghbvf/gocell/pkg/errcode"}
  自动覆盖 errcode 包内任何当前/未来公开 callable（New / Wrap /
  Assertion / 未来新增）

STEP 4 — function-valued re-export 显式拒绝：
  STEP 1 解析到 *types.Var → archtest fail
  rationale: 间接寻址通道是 AI 创新 escape 主面，显式 fail-closed
```

**为什么放弃 name pattern**（v1 草案漏 3 类硬错，详见 ADR §D5）：
1. 漏白名单成员：cellgen 现用 `errcode.Assertion`，pattern `^(New|Wrap|Error...)$` 不命中
2. 漏 dot import / 裸 Ident：`import . "fmt"` + `Errorf(...)` 是 Ident 不进入 SelectorExpr 路径
3. 漏 function-valued re-export：`var ErrNew = errors.New; ErrNew(msg)` 绕过 name pattern + func 检查

**反向自检 RED fixture 覆盖面（P5.1 实施，7 类）**：
1. `fmt.Errorf("...")` — normal SelectorExpr import
2. `fmtx "fmt"` alias import + `fmtx.Errorf(...)`
3. `import . "fmt"` + bare `Errorf("...")` — dot import
4. `errors.New("...")` — stdlib 另一 escape route
5. `import . "errors"` + bare `New("...")` — dot import 第二 lib
6. `var ErrNew = errors.New` + 调用 `ErrNew("...")` — function-valued var re-export
7. cellgen 包内自建 wrapper `func newErr(msg) error { return errors.New(msg) }`

## AI-rebust 评级

- **Hard**（form uniqueness 用 pkg.Path() + archtest fail-on-deviation；章程 §"typed function call as Hard funnel for unbounded operations" 明确认可的 Go 该规则形态最高档）
- **Funnel 双向锁 Hard**（上游：cellgen 包内 error construct 必须落 `pkg/errcode` 白名单；下游：`pkg/errcode` 集合本身由 ERRCODE-KIND-LITERAL-01 / MESSAGE-CONST-LITERAL-01 / DETAILS-SLOG-ATTR-01 锁定 — 闭环 funnel）

## Review 修复历史

| 轮次 | commit | 修复 |
|------|--------|------|
| 1 | `5670ea922` | F1/F2/F4/F5/F6 文档完整性 |
| 2 | `9a630f5ee` | B1 (D5 设计重写为 types.Info-driven，去 name pattern) + B2 (panic_registered_test.go → panic_invariants_test.go) + B3 (PR#557 → PR #453) |

| Finding | Cx | 状态 |
|---------|----|----|
| F1 §D5 RED fixture 4 描述精化 + Hard 覆盖完备性论证 | Cx2 | ✅ |
| F2 §D6 上游 Hard 评级补章程引用 | Cx2 | ✅ |
| F3 ADR 命名格式 | Cx1 | dismiss — 仓库 ADR 普遍 `yyyyMMddHHmm-adr-<name>.md` 既有惯例 |
| F4 §D5 末尾补盲区清单 | Cx1 | ✅ |
| F5 037 R2 进度表 R2-P5 行补 spike PR #548 编号 | Cx1 | ✅ |
| F6 PR 描述补双文档紧耦合声明 | Cx1 | ✅ |
| **B1** §D5 name pattern 漏 dot import / 裸 Ident / re-export + 漏 Assertion 白名单 | P0 | ✅ types.Info-driven 重写 |
| **B2** ref panic_registered_test.go 文件不存在 | P0 | ✅ → panic_invariants_test.go |
| **B3** PR#557 GitHub 不存在 | P0 | ✅ → PR #453 |

## ref

- `tools/archtest/panic_invariants_test.go`（PANIC-REGISTERED-01 对偶范本，INVARIANT ID 来自旧文件名）
- `tools/archtest/scaffold_write_funnel_test.go`（type-aware archtest 技法范本）
- `.claude/rules/gocell/ai-collab.md` §"typed function call as Hard funnel for unbounded operations" + §"Funnel 双向锁评级"
- `docs/backlog/cap-14-tooling.md` L44 `CELLGEN-ERRCODE-FUNNEL-HARDEN`（注：原文写「PR#557」是事实错误，实际 PR #453）

## Test plan

- [x] ADR 论据完整性（5 个 spike 事实 + 5 个候选方案逐条否决/选定理由 + AI-rebust 评级 + escalation 路径 + 盲区清单）
- [x] 037 R2 §1 进度表 R2-P5 行更新（spike PR #548 + ADR 文件名 + 单 PR enforcement 维度）
- [x] 037 R2 §R2-P5 段落重写（spike 完结、P5.1 实施拆分、types.Info-driven 设计、7 类 RED fixture）
- [x] 不动 cellgen 任何 .go / 不动 archtest 任何 .go / 不动 .golangci.yml / 不动 backlog cap-14（backlog 行的关闭跟 P5.1 实施 PR）
- [x] Review F1/F2/F4/F5/F6 + B1/B2/B3 已 fix；F3 经验证为既有惯例 dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)