### PR TITLE
refactor: PR#538 leftover cleanup + #544 new-code coverage

### DIFF
--- a/cmd/gocell/app/scaffold_cell_flags_test.go
+++ b/cmd/gocell/app/scaffold_cell_flags_test.go
@@ -1,0 +1,121 @@
+package app
+
+// Unit coverage for validateScaffoldCellFlags (#544 new code). The flag
+// table-driven cases drive the required-field, free-text control-char, and
+// no-dash rejection branches that the higher-level scaffoldCell integration
+// tests do not exercise individually (they stop at the first guard).
+//
+// The pathsafe.ResolveRoot error wrap in scaffoldCell is intentionally not
+// covered: readModule(root) runs before ResolveRoot on the same root, so a
+// root that fails EvalSymlinks would already have failed the earlier go.mod
+// read. The branch is an unreachable-via-CLI defensive wrap with no logic.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+func TestValidateScaffoldCellFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		id         string
+		team       string
+		role       string
+		wantErr    bool
+		wantSubstr string // substring expected in err.Error() when wantErr
+	}{
+		{
+			name: "valid no-dash id",
+			id:   "billingcell", team: "squad", role: "cell-owner",
+			wantErr: false,
+		},
+		{
+			name: "missing id",
+			id:   "", team: "squad", role: "cell-owner",
+			wantErr: true, wantSubstr: "--id is required",
+		},
+		{
+			name: "missing team",
+			id:   "billingcell", team: "", role: "cell-owner",
+			wantErr: true, wantSubstr: "--team is required",
+		},
+		{
+			name: "missing role",
+			id:   "billingcell", team: "squad", role: "",
+			wantErr: true, wantSubstr: "--role is required",
+		},
+		{
+			name: "id with control char rejected by validateScaffoldID",
+			id:   "bill\ncell", team: "squad", role: "cell-owner",
+			wantErr: true, wantSubstr: "control characters",
+		},
+		{
+			// 341-343: free-text --team with a newline must be rejected by
+			// validateScaffoldText (YAML-injection guard).
+			name: "team with newline rejected by validateScaffoldText",
+			id:   "billingcell", team: "squad\nowner: attacker", role: "cell-owner",
+			wantErr: true, wantSubstr: "control characters",
+		},
+		{
+			// 355-358: kebab-case cell IDs are rejected (no-dash identifier
+			// convention, aligned with scaffoldSlice).
+			name: "kebab-case id rejected",
+			id:   "billing-cell", team: "squad", role: "cell-owner",
+			wantErr: true, wantSubstr: "must not contain '-'",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateScaffoldCellFlags(tc.id, tc.team, tc.role)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validateScaffoldCellFlags(%q,%q,%q): want error, got nil",
+						tc.id, tc.team, tc.role)
+				}
+				// errcode.Error.Error() prefers InternalMessage (which carries
+				// field=/id= debug context, not the human message), so match
+				// against the const-literal Message for structured errors and
+				// fall back to Error() for plain fmt.Errorf required-field errors.
+				msg := err.Error()
+				var ec *errcode.Error
+				if errors.As(err, &ec) {
+					msg = ec.Message
+				}
+				if !strings.Contains(msg, tc.wantSubstr) {
+					t.Errorf("err message = %q, want substring %q", msg, tc.wantSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateScaffoldCellFlags(%q,%q,%q): unexpected error: %v",
+					tc.id, tc.team, tc.role, err)
+			}
+		})
+	}
+}
+
+// The kebab rejection must be a structured errcode.Error carrying
+// ErrScaffoldInvalidOpts so the CLI surfaces a stable code, not a bare
+// fmt.Errorf string.
+func TestValidateScaffoldCellFlags_KebabIsStructured(t *testing.T) {
+	t.Parallel()
+	err := validateScaffoldCellFlags("billing-cell", "squad", "cell-owner")
+	if err == nil {
+		t.Fatal("kebab id: want error, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("kebab id error must be *errcode.Error, got %T (%v)", err, err)
+	}
+	if ec.Code != ErrScaffoldInvalidOpts {
+		t.Errorf("kebab id error code = %q, want %q", ec.Code, ErrScaffoldInvalidOpts)
+	}
+}

--- a/cmd/gocell/app/scaffold_cell_flags_test.go
+++ b/cmd/gocell/app/scaffold_cell_flags_test.go
@@ -27,7 +27,8 @@ func TestValidateScaffoldCellFlags(t *testing.T) {
 		team       string
 		role       string
 		wantErr    bool
-		wantSubstr string // substring expected in err.Error() when wantErr
+		wantSubstr string       // substring expected in err.Error() when wantErr
+		wantCode   errcode.Code // zero value means: do not check code
 	}{
 		{
 			name: "valid no-dash id",
@@ -62,11 +63,21 @@ func TestValidateScaffoldCellFlags(t *testing.T) {
 			wantErr: true, wantSubstr: "control characters",
 		},
 		{
+			// Symmetric to the --team newline case: --role is also a free-text
+			// field validated by validateScaffoldText (YAML-injection guard).
+			name: "role with newline rejected by validateScaffoldText",
+			id:   "billingcell", team: "squad", role: "cell-owner\ninjected: field",
+			wantErr: true, wantSubstr: "control characters",
+		},
+		{
 			// 355-358: kebab-case cell IDs are rejected (no-dash identifier
-			// convention, aligned with scaffoldSlice).
+			// convention, aligned with scaffoldSlice). The error must be a
+			// structured *errcode.Error carrying ErrScaffoldInvalidOpts so the
+			// CLI surfaces a stable code rather than a bare fmt.Errorf string.
 			name: "kebab-case id rejected",
 			id:   "billing-cell", team: "squad", role: "cell-owner",
 			wantErr: true, wantSubstr: "must not contain '-'",
+			wantCode: ErrScaffoldInvalidOpts,
 		},
 	}
 
@@ -80,10 +91,12 @@ func TestValidateScaffoldCellFlags(t *testing.T) {
 					t.Fatalf("validateScaffoldCellFlags(%q,%q,%q): want error, got nil",
 						tc.id, tc.team, tc.role)
 				}
-				// errcode.Error.Error() prefers InternalMessage (which carries
-				// field=/id= debug context, not the human message), so match
-				// against the const-literal Message for structured errors and
-				// fall back to Error() for plain fmt.Errorf required-field errors.
+				// errcode.Error.Error() returns InternalMessage when WithInternal
+				// was used (it carries field=/id= debug context, not the human-
+				// readable Message). validateScaffoldText errors carry WithInternal,
+				// so we must read ec.Message to match the const-literal human text.
+				// Plain fmt.Errorf required-field errors have no *errcode.Error, so
+				// err.Error() is used as the fallback.
 				msg := err.Error()
 				var ec *errcode.Error
 				if errors.As(err, &ec) {
@@ -92,6 +105,14 @@ func TestValidateScaffoldCellFlags(t *testing.T) {
 				if !strings.Contains(msg, tc.wantSubstr) {
 					t.Errorf("err message = %q, want substring %q", msg, tc.wantSubstr)
 				}
+				if tc.wantCode != "" {
+					if ec == nil {
+						t.Fatalf("expected *errcode.Error for code check, got %T (%v)", err, err)
+					}
+					if ec.Code != tc.wantCode {
+						t.Errorf("err code = %q, want %q", ec.Code, tc.wantCode)
+					}
+				}
 				return
 			}
 			if err != nil {
@@ -99,23 +120,5 @@ func TestValidateScaffoldCellFlags(t *testing.T) {
 					tc.id, tc.team, tc.role, err)
 			}
 		})
-	}
-}
-
-// The kebab rejection must be a structured errcode.Error carrying
-// ErrScaffoldInvalidOpts so the CLI surfaces a stable code, not a bare
-// fmt.Errorf string.
-func TestValidateScaffoldCellFlags_KebabIsStructured(t *testing.T) {
-	t.Parallel()
-	err := validateScaffoldCellFlags("billing-cell", "squad", "cell-owner")
-	if err == nil {
-		t.Fatal("kebab id: want error, got nil")
-	}
-	var ec *errcode.Error
-	if !errors.As(err, &ec) {
-		t.Fatalf("kebab id error must be *errcode.Error, got %T (%v)", err, err)
-	}
-	if ec.Code != ErrScaffoldInvalidOpts {
-		t.Errorf("kebab id error code = %q, want %q", ec.Code, ErrScaffoldInvalidOpts)
 	}
 }

--- a/cmd/gocell/app/scaffold_cell_flags_test.go
+++ b/cmd/gocell/app/scaffold_cell_flags_test.go
@@ -18,18 +18,20 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+type scaffoldCellFlagsCase struct {
+	name       string
+	id         string
+	team       string
+	role       string
+	wantErr    bool
+	wantSubstr string       // substring expected in the human message when wantErr
+	wantCode   errcode.Code // zero value means: do not check code
+}
+
 func TestValidateScaffoldCellFlags(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		id         string
-		team       string
-		role       string
-		wantErr    bool
-		wantSubstr string       // substring expected in err.Error() when wantErr
-		wantCode   errcode.Code // zero value means: do not check code
-	}{
+	tests := []scaffoldCellFlagsCase{
 		{
 			name: "valid no-dash id",
 			id:   "billingcell", team: "squad", role: "cell-owner",
@@ -85,40 +87,55 @@ func TestValidateScaffoldCellFlags(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateScaffoldCellFlags(tc.id, tc.team, tc.role)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("validateScaffoldCellFlags(%q,%q,%q): want error, got nil",
-						tc.id, tc.team, tc.role)
-				}
-				// errcode.Error.Error() returns InternalMessage when WithInternal
-				// was used (it carries field=/id= debug context, not the human-
-				// readable Message). validateScaffoldText errors carry WithInternal,
-				// so we must read ec.Message to match the const-literal human text.
-				// Plain fmt.Errorf required-field errors have no *errcode.Error, so
-				// err.Error() is used as the fallback.
-				msg := err.Error()
-				var ec *errcode.Error
-				if errors.As(err, &ec) {
-					msg = ec.Message
-				}
-				if !strings.Contains(msg, tc.wantSubstr) {
-					t.Errorf("err message = %q, want substring %q", msg, tc.wantSubstr)
-				}
-				if tc.wantCode != "" {
-					if ec == nil {
-						t.Fatalf("expected *errcode.Error for code check, got %T (%v)", err, err)
-					}
-					if ec.Code != tc.wantCode {
-						t.Errorf("err code = %q, want %q", ec.Code, tc.wantCode)
-					}
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("validateScaffoldCellFlags(%q,%q,%q): unexpected error: %v",
-					tc.id, tc.team, tc.role, err)
-			}
+			runScaffoldCellFlagsCase(t, tc)
 		})
+	}
+}
+
+// runScaffoldCellFlagsCase dispatches a single table case to keep the test
+// loop body flat (cognitive complexity guard, CLAUDE.md ≤ 15).
+func runScaffoldCellFlagsCase(t *testing.T, tc scaffoldCellFlagsCase) {
+	t.Helper()
+	err := validateScaffoldCellFlags(tc.id, tc.team, tc.role)
+	if !tc.wantErr {
+		if err != nil {
+			t.Fatalf("validateScaffoldCellFlags(%q,%q,%q): unexpected error: %v",
+				tc.id, tc.team, tc.role, err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("validateScaffoldCellFlags(%q,%q,%q): want error, got nil",
+			tc.id, tc.team, tc.role)
+	}
+	assertScaffoldCellFlagsError(t, tc, err)
+}
+
+// assertScaffoldCellFlagsError checks the human message and (optionally) the
+// structured error code of a rejection.
+//
+// errcode.Error.Error() returns InternalMessage when WithInternal was used
+// (it carries field=/id= debug context, not the human-readable Message).
+// validateScaffoldText errors carry WithInternal, so we must read ec.Message
+// to match the const-literal human text. Plain fmt.Errorf required-field
+// errors have no *errcode.Error, so err.Error() is the fallback.
+func assertScaffoldCellFlagsError(t *testing.T, tc scaffoldCellFlagsCase, err error) {
+	t.Helper()
+	msg := err.Error()
+	var ec *errcode.Error
+	if errors.As(err, &ec) {
+		msg = ec.Message
+	}
+	if !strings.Contains(msg, tc.wantSubstr) {
+		t.Errorf("err message = %q, want substring %q", msg, tc.wantSubstr)
+	}
+	if tc.wantCode == "" {
+		return
+	}
+	if ec == nil {
+		t.Fatalf("expected *errcode.Error for code check, got %T (%v)", err, err)
+	}
+	if ec.Code != tc.wantCode {
+		t.Errorf("err code = %q, want %q", ec.Code, tc.wantCode)
 	}
 }

--- a/pkg/pathsafe/pathsafe.go
+++ b/pkg/pathsafe/pathsafe.go
@@ -368,6 +368,13 @@ const (
 	kindSymlink
 )
 
+// errMsgForceOverwriteKindGate is the human-readable message used by both
+// captureOriginal (live writePass) and forceOverwritePreflightPass (dry-run +
+// pre-write) when they reject a non-restorable inode kind (directories,
+// devices, pipes, sockets). Single source keeps the two rejection paths
+// consistent and avoids the MESSAGE-CONST-LITERAL-01 string-duplication smell.
+const errMsgForceOverwriteKindGate = "pathsafe: ForceOverwrite supports regular files and symlinks only"
+
 // writeRecord pairs the written path with the captured original-inode state
 // needed to make ForceOverwrite plans transactional. The default zero value
 // is {kindNone}, matching the non-ForceOverwrite case where rollback only
@@ -408,7 +415,7 @@ func captureOriginal(path string) (writeRecord, error) {
 	mode := info.Mode()
 	if !forceOverwriteRestorable(mode) {
 		return writeRecord{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"pathsafe: ForceOverwrite supports regular files and symlinks only",
+			errMsgForceOverwriteKindGate,
 			errcode.WithDetails(slog.String("path", path)))
 	}
 	if mode.IsRegular() {
@@ -484,7 +491,7 @@ func forceOverwritePreflightPass(plan []PlannedFile) error {
 		}
 		if !forceOverwriteRestorable(info.Mode()) {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-				"pathsafe: ForceOverwrite supports regular files and symlinks only",
+				errMsgForceOverwriteKindGate,
 				errcode.WithDetails(slog.String("path", f.AbsPath)))
 		}
 	}

--- a/pkg/pathsafe/pathsafe_internal_test.go
+++ b/pkg/pathsafe/pathsafe_internal_test.go
@@ -3,6 +3,10 @@ package pathsafe
 // Internal (package pathsafe) tests for Lane A unexported helpers:
 //   - collectMissingDirs (A9): EACCES on intermediate parent must propagate
 //     as a non-nil error, not be swallowed as "directory exists / break".
+//   - captureOriginal / forceOverwritePreflightPass (#544 ForceOverwrite
+//     inode-kind gate): error/rejection branches the public-API tests cannot
+//     reach (lstat ENOTDIR, non-restorable inode kind, unreadable regular
+//     file).
 //
 // Skip windows + root: chmod 0o000 not reliable on windows; ineffective as
 // root. Sequential (not Parallel) because chmod is process-global state.
@@ -13,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -90,5 +95,138 @@ func TestCollectMissingDirs_EACCESReturnsError(t *testing.T) {
 	}
 	if !errors.Is(err, fs.ErrPermission) {
 		t.Errorf("expected fs.ErrPermission, got err=%v", err)
+	}
+}
+
+// --- #544 ForceOverwrite inode-kind gate: error/rejection branches ---
+//
+// These exercise captureOriginal (live writePass capture) and
+// forceOverwritePreflightPass (dry-run + pre-write) failure paths that the
+// public WritePlannedFiles tests cannot deterministically drive, lifting the
+// #544 new-code coverage of pkg/pathsafe over the 80% gate.
+//
+// The Readlink failure branch in captureOriginal is intentionally not
+// exercised: once Lstat classified the inode as a symlink, os.Readlink only
+// fails under a concurrent inode-swap (TOCTOU) which cannot be forced
+// deterministically. It is a defensive Wrap with no behavioral logic.
+
+const errMsgKindGate = "regular files and symlinks only"
+
+// captureOriginal must reject a non-restorable inode kind (directory) so that
+// live writePass fails before the destructive write — covers the
+// forceOverwriteRestorable gate inside captureOriginal.
+func TestCaptureOriginal_RejectsNonRestorableKind(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "squatting-dir")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := captureOriginal(dir)
+	if err == nil {
+		t.Fatal("captureOriginal(directory): want rejection error, got nil")
+	}
+	if !strings.Contains(err.Error(), errMsgKindGate) {
+		t.Errorf("captureOriginal(directory): err = %v, want kind-gate rejection", err)
+	}
+}
+
+// captureOriginal must Wrap an lstat failure that is NOT os.IsNotExist
+// (here ENOTDIR: a path component is a regular file, not a directory).
+func TestCaptureOriginal_LstatNonNotExist(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	parentFile := filepath.Join(root, "afile")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// "afile" is a regular file → lstat of "afile/child" returns ENOTDIR.
+	_, err := captureOriginal(filepath.Join(parentFile, "child"))
+	if err == nil {
+		t.Fatal("captureOriginal(path under non-dir parent): want error, got nil")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ENOTDIR misclassified as not-exist: err=%v", err)
+	}
+}
+
+// captureOriginal must Wrap a ReadFile failure on a regular file whose read
+// permission was removed after the lstat kind check.
+func TestCaptureOriginal_ReadFileError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics differ on windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("chmod 0o000 ineffective as root")
+	}
+	f := filepath.Join(t.TempDir(), "unreadable")
+	if err := os.WriteFile(f, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(f, 0o000); err != nil {
+		t.Fatalf("Chmod 0o000: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(f, 0o644) })
+
+	_, err := captureOriginal(f)
+	if err == nil {
+		t.Fatal("captureOriginal(unreadable regular file): want error, got nil")
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("expected fs.ErrPermission, got err=%v", err)
+	}
+}
+
+// forceOverwritePreflightPass must reject a ForceOverwrite entry whose target
+// is a non-restorable inode kind (directory) so dry-run rejects exactly what
+// live would (F2 parity).
+func TestForceOverwritePreflightPass_RejectsDirectory(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "gen-target-is-dir")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := forceOverwritePreflightPass([]PlannedFile{
+		{AbsPath: dir, Content: []byte("x"), ForceOverwrite: true},
+	})
+	if err == nil {
+		t.Fatal("forceOverwritePreflightPass(dir target): want rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), errMsgKindGate) {
+		t.Errorf("forceOverwritePreflightPass(dir target): err = %v, want kind-gate rejection", err)
+	}
+}
+
+// forceOverwritePreflightPass must Wrap an lstat failure that is NOT
+// os.IsNotExist (ENOTDIR: a path component is a regular file).
+func TestForceOverwritePreflightPass_LstatNonNotExist(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	parentFile := filepath.Join(root, "afile")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := forceOverwritePreflightPass([]PlannedFile{
+		{AbsPath: filepath.Join(parentFile, "child"), ForceOverwrite: true},
+	})
+	if err == nil {
+		t.Fatal("forceOverwritePreflightPass(path under non-dir parent): want error, got nil")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ENOTDIR misclassified as not-exist: err=%v", err)
+	}
+}
+
+// Non-ForceOverwrite entries must be skipped by the preflight pass even when
+// their target is a directory (covers the `continue` guard).
+func TestForceOverwritePreflightPass_SkipsNonForceEntries(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "dir-but-not-force")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := forceOverwritePreflightPass([]PlannedFile{
+		{AbsPath: dir, Content: []byte("x"), ForceOverwrite: false},
+	}); err != nil {
+		t.Fatalf("forceOverwritePreflightPass(non-force dir): want nil, got %v", err)
 	}
 }

--- a/pkg/pathsafe/pathsafe_internal_test.go
+++ b/pkg/pathsafe/pathsafe_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -110,8 +111,6 @@ func TestCollectMissingDirs_EACCESReturnsError(t *testing.T) {
 // fails under a concurrent inode-swap (TOCTOU) which cannot be forced
 // deterministically. It is a defensive Wrap with no behavioral logic.
 
-const errMsgKindGate = "regular files and symlinks only"
-
 // captureOriginal must reject a non-restorable inode kind (directory) so that
 // live writePass fails before the destructive write — covers the
 // forceOverwriteRestorable gate inside captureOriginal.
@@ -125,14 +124,19 @@ func TestCaptureOriginal_RejectsNonRestorableKind(t *testing.T) {
 	if err == nil {
 		t.Fatal("captureOriginal(directory): want rejection error, got nil")
 	}
-	if !strings.Contains(err.Error(), errMsgKindGate) {
+	if !strings.Contains(err.Error(), errMsgForceOverwriteKindGate) {
 		t.Errorf("captureOriginal(directory): err = %v, want kind-gate rejection", err)
 	}
 }
 
 // captureOriginal must Wrap an lstat failure that is NOT os.IsNotExist
 // (here ENOTDIR: a path component is a regular file, not a directory).
+// errcode.Error.Unwrap() returns the Cause, so errors.Is can chain through to
+// syscall.ENOTDIR on unix. The syscall constant is unix-only — skip on Windows.
 func TestCaptureOriginal_LstatNonNotExist(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("syscall.ENOTDIR is a unix-only sentinel")
+	}
 	t.Parallel()
 	root := t.TempDir()
 	parentFile := filepath.Join(root, "afile")
@@ -146,6 +150,11 @@ func TestCaptureOriginal_LstatNonNotExist(t *testing.T) {
 	}
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("ENOTDIR misclassified as not-exist: err=%v", err)
+	}
+	// Positive assertion: errcode.Error.Unwrap() chains to the underlying
+	// syscall error; ENOTDIR must be reachable via errors.Is.
+	if !errors.Is(err, syscall.ENOTDIR) {
+		t.Errorf("expected syscall.ENOTDIR in error chain, got err=%v", err)
 	}
 }
 
@@ -191,14 +200,19 @@ func TestForceOverwritePreflightPass_RejectsDirectory(t *testing.T) {
 	if err == nil {
 		t.Fatal("forceOverwritePreflightPass(dir target): want rejection, got nil")
 	}
-	if !strings.Contains(err.Error(), errMsgKindGate) {
+	if !strings.Contains(err.Error(), errMsgForceOverwriteKindGate) {
 		t.Errorf("forceOverwritePreflightPass(dir target): err = %v, want kind-gate rejection", err)
 	}
 }
 
 // forceOverwritePreflightPass must Wrap an lstat failure that is NOT
 // os.IsNotExist (ENOTDIR: a path component is a regular file).
+// errcode.Error.Unwrap() returns the Cause, so errors.Is can chain through to
+// syscall.ENOTDIR on unix. The syscall constant is unix-only — skip on Windows.
 func TestForceOverwritePreflightPass_LstatNonNotExist(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("syscall.ENOTDIR is a unix-only sentinel")
+	}
 	t.Parallel()
 	root := t.TempDir()
 	parentFile := filepath.Join(root, "afile")
@@ -213,6 +227,11 @@ func TestForceOverwritePreflightPass_LstatNonNotExist(t *testing.T) {
 	}
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("ENOTDIR misclassified as not-exist: err=%v", err)
+	}
+	// Positive assertion: errcode.Error.Unwrap() chains to the underlying
+	// syscall error; ENOTDIR must be reachable via errors.Is.
+	if !errors.Is(err, syscall.ENOTDIR) {
+		t.Errorf("expected syscall.ENOTDIR in error chain, got err=%v", err)
 	}
 }
 

--- a/tests/testutil/minio_integration.go
+++ b/tests/testutil/minio_integration.go
@@ -51,12 +51,6 @@ func WithMinIOVolume(name, target string) MinIORunOption {
 	}
 }
 
-// WithMinIOContainerOption passes an arbitrary ContainerCustomizer through to
-// tcminio.Run. Reserve for cases not covered by typed options.
-func WithMinIOContainerOption(opt testcontainers.ContainerCustomizer) MinIORunOption {
-	return func(c *minioRunConfig) { c.containerOpts = append(c.containerOpts, opt) }
-}
-
 // MinIORunOptions returns the resolved []testcontainers.ContainerCustomizer
 // (shared image readiness wait strategy plus any caller-supplied opts).
 // It does NOT call tcminio.Run — caller invokes tcminio.Run themselves with


### PR DESCRIPTION
## Summary

两件相关的收尾工作（均为 PR merge 后残留/质量门未达标）：

1. **PR #538 残留死代码清理** — PR #538（MinIO testcontainer 故障注入）squash-merge 进 develop 后，其 worktree 里残留一处从未进入任何 commit/PR 的未提交改动：删除 `tests/testutil/minio_integration.go` 的 `WithMinIOContainerOption`。该函数是透传任意 `ContainerCustomizer` 的 escape hatch，全仓零调用方（仅定义点）。`testcontainers` import 仍被 `WithMinIOVolume` 使用，删除不产生 unused import。

2. **#544 新代码测试覆盖率补齐** — SonarCloud Coverage on New Code 标记：
   - `pkg/pathsafe/pathsafe.go` 72.7% → **93.1%**：补 `captureOriginal` / `forceOverwritePreflightPass` 的 lstat-ENOTDIR、非可恢复 inode kind、不可读常规文件等公开 API 不可达的错误/拒绝分支（package-internal table-driven test）。
   - `cmd/gocell/app/scaffold.go` 83.3% → **94.7%**：补 `validateScaffoldCellFlags` 的 free-text 控制字符 + no-dash 拒绝分支。

   剩余未覆盖均为已文档化的防御分支：pathsafe Readlink TOCTOU re-wrap（无法确定性触发）、scaffold `ResolveRoot` wrap（被同 root 上更早的 `readModule` 短路，CLI 不可达）。

Refs: #538, #544

## Test plan

- [x] `go build -tags=integration ./...`
- [x] `go test ./pkg/pathsafe/`（全包）
- [x] `go test ./cmd/gocell/app/`（全包，115s）
- [x] `go test ./tools/archtest/...`（全绿，503s）
- [x] `golangci-lint run`（0 issues）
- [x] 新代码覆盖率 pathsafe 93.1% / scaffold 94.7%（均 > 80% 门槛）

🤖 Generated with [Claude Code](https://claude.com/claude-code)