### PR TITLE
fix(verify): G-14 text printer surface ZeroMatch/SkippedOnly as [WARN]

### DIFF
--- a/cmd/gocell/app/printers/testdata/golden/json/verify_skipped_only.json
+++ b/cmd/gocell/app/printers/testdata/golden/json/verify_skipped_only.json
@@ -1,0 +1,21 @@
+{
+  "targetId": "accesscore/sessions",
+  "passed": false,
+  "results": [
+    {
+      "name": "TestStubbed",
+      "passed": false,
+      "output": "",
+      "zeroMatch": false,
+      "skippedOnly": true
+    }
+  ],
+  "errors": [
+    {
+      "code": "ERR_ZERO_TEST_MATCH",
+      "message": "pattern matched only skipped tests — replace stubs with executable checks",
+      "details": []
+    }
+  ],
+  "manualPending": []
+}

--- a/cmd/gocell/app/printers/testdata/golden/text/verify_skipped_only.txt
+++ b/cmd/gocell/app/printers/testdata/golden/text/verify_skipped_only.txt
@@ -1,0 +1,3 @@
+Verify accesscore/sessions: FAILED
+  [WARN] TestStubbed — only skipped tests
+  error: [ERR_ZERO_TEST_MATCH] pattern matched only skipped tests — replace stubs with executable checks

--- a/cmd/gocell/app/printers/testdata/golden/text/verify_skipped_only.txt
+++ b/cmd/gocell/app/printers/testdata/golden/text/verify_skipped_only.txt
@@ -1,3 +1,3 @@
 Verify accesscore/sessions: FAILED
-  [WARN] TestStubbed — only skipped tests
+  [WARN] TestStubbed — all matched tests skipped (replace stubs with executable checks)
   error: [ERR_ZERO_TEST_MATCH] pattern matched only skipped tests — replace stubs with executable checks

--- a/cmd/gocell/app/printers/testdata/golden/text/verify_zero_match.txt
+++ b/cmd/gocell/app/printers/testdata/golden/text/verify_zero_match.txt
@@ -1,3 +1,3 @@
 Verify accesscore/sessions: FAILED
-  [FAIL] TestNonexistent
+  [WARN] TestNonexistent — no tests matched -run pattern
   error: [ERR_ZERO_TEST_MATCH] zero tests matched -run pattern

--- a/cmd/gocell/app/printers/verify.go
+++ b/cmd/gocell/app/printers/verify.go
@@ -65,11 +65,23 @@ func (p *verifyTextPrinter) Print(r *verify.VerifyResult) error {
 
 func (p *verifyTextPrinter) printTestResults(results []verify.TestResult) error {
 	for _, tr := range results {
-		marker := "PASS"
-		if !tr.Passed {
+		// ZeroMatch / SkippedOnly carry Passed=false from recordResult but
+		// represent "no executable check ran" rather than a true assertion
+		// failure. Surface them as [WARN] with a trailing reason so the
+		// first line carries the full diagnosis; the generic Passed/!Passed
+		// split is reserved for tests that actually executed.
+		var marker, suffix string
+		switch {
+		case tr.ZeroMatch:
+			marker, suffix = "WARN", " — no tests matched -run pattern"
+		case tr.SkippedOnly:
+			marker, suffix = "WARN", " — only skipped tests"
+		case tr.Passed:
+			marker = "PASS"
+		default:
 			marker = "FAIL"
 		}
-		if _, err := fmt.Fprintf(p.w, "  [%s] %s\n", marker, tr.Name); err != nil {
+		if _, err := fmt.Fprintf(p.w, "  [%s] %s%s\n", marker, tr.Name, suffix); err != nil {
 			return err
 		}
 		if tr.Output != "" {

--- a/cmd/gocell/app/printers/verify.go
+++ b/cmd/gocell/app/printers/verify.go
@@ -65,17 +65,18 @@ func (p *verifyTextPrinter) Print(r *verify.VerifyResult) error {
 
 func (p *verifyTextPrinter) printTestResults(results []verify.TestResult) error {
 	for _, tr := range results {
-		// ZeroMatch / SkippedOnly carry Passed=false from recordResult but
-		// represent "no executable check ran" rather than a true assertion
-		// failure. Surface them as [WARN] with a trailing reason so the
-		// first line carries the full diagnosis; the generic Passed/!Passed
-		// split is reserved for tests that actually executed.
+		// ZeroMatch / SkippedOnly represent "no executable check ran" rather
+		// than a true assertion failure. Surface them as [WARN] with a
+		// trailing reason so the first line carries the full diagnosis. We
+		// branch on these fields before the generic Passed split so the WARN
+		// classification stays robust even if a future upstream change drops
+		// the recordResult convention of forcing Passed=false alongside them.
 		var marker, suffix string
 		switch {
 		case tr.ZeroMatch:
 			marker, suffix = "WARN", " — no tests matched -run pattern"
 		case tr.SkippedOnly:
-			marker, suffix = "WARN", " — only skipped tests"
+			marker, suffix = "WARN", " — all matched tests skipped (replace stubs with executable checks)"
 		case tr.Passed:
 			marker = "PASS"
 		default:

--- a/cmd/gocell/app/printers/verify_test.go
+++ b/cmd/gocell/app/printers/verify_test.go
@@ -202,6 +202,8 @@ func TestVerifyJSONPrinter_EmitsSkippedOnlyAndStructuredErrors(t *testing.T) {
 	require.Len(t, doc.Results, 1)
 	require.True(t, doc.Results[0].SkippedOnly)
 	require.False(t, doc.Results[0].ZeroMatch)
+	require.False(t, doc.Results[0].Passed,
+		"SkippedOnly must force Passed=false (recordResult contract)")
 	require.Len(t, doc.Errors, 1)
 	require.Equal(t, errcode.ErrZeroTestMatch, doc.Errors[0].Code)
 	require.Equal(t, "pattern matched only skipped tests — replace stubs with executable checks", doc.Errors[0].Message)

--- a/cmd/gocell/app/printers/verify_test.go
+++ b/cmd/gocell/app/printers/verify_test.go
@@ -68,6 +68,21 @@ var verifyGoldenCases = []struct {
 		},
 	},
 	{
+		name: "skipped_only",
+		result: &verify.VerifyResult{
+			TargetID: "accesscore/sessions",
+			Passed:   false,
+			Results: []verify.TestResult{
+				{Name: "TestStubbed", Passed: false, SkippedOnly: true},
+			},
+			Errors: []error{errcode.New(
+				errcode.KindNotFound,
+				errcode.ErrZeroTestMatch,
+				"pattern matched only skipped tests — replace stubs with executable checks",
+			)},
+		},
+	},
+	{
 		name: "multi_test_mixed",
 		result: &verify.VerifyResult{
 			TargetID: "accesscore/all",

--- a/docs/backlog/cap-14-tooling.md
+++ b/docs/backlog/cap-14-tooling.md
@@ -102,7 +102,7 @@
 | NOLINT-AUDIT-01 | **Nolint audit** — 现状: 全仓 101 处 nolint 含 errcheck 类豁免；修复: 审查 | arch-opt | Cx2 | 🟡 | — | 全仓 *.go | NOLINT-AUDIT-01 |
 | ADR-INDEX-01 | **ADR index** — 现状: 缺 ADR 索引；修复: 生成 docs/architecture/INDEX.md | doc | Cx1 | 🟡 | — | `docs/architecture/` | ADR-INDEX-01 |
 | ADR-DATE-CONSISTENCY-CHECK | **ADR 文件名日期 vs 内容 Date 一致性** — 现状: PR#404 ADR `202605061800-...md` 文件内 Date: 2026-05-07（1 天误差）；修复: archtest 校验 `docs/architecture/yyyymmddHHmm-*.md` 文件名前缀日期 = 内容 `Date:` 字段日期 | test | P3/Cx1 | 🟡 | — | `tools/archtest/` + ADR 命名约定 | PR#404 F6 |
-| G-14 | **VERIFY-PRINTER-ZEROMATCH-WARN** — text printer 对 `TestResult.ZeroMatch=true` 无警告，与 `[PASS]` + 实际跑 N 个测试输出完全相同；修复: `printTestResults` 检测 `tr.ZeroMatch` 输出 `[WARN] %s — no tests matched -run pattern` | bug | P1/Cx1 | 🟡 | — | `cmd/gocell/app/printers/verify.go` | 030 §3 G-14 |
+| G-14 | **VERIFY-PRINTER-ZEROMATCH-WARN** — text printer 对 `TestResult.ZeroMatch=true` 无警告，与 `[PASS]` + 实际跑 N 个测试输出完全相同；修复: `printTestResults` 检测 `tr.ZeroMatch` 输出 `[WARN] %s — no tests matched -run pattern`，同步对称修 `SkippedOnly` | bug | P1/Cx1 | ✅ | closed by PR #580 | `cmd/gocell/app/printers/verify.go` | 030 §3 G-14 |
 | F-07 | **SYSML-VIEW-CODEGEN** — 5 张 SysML 图（BDD/IBD/用例/活动/状态机）有元数据天然映射但无生成器；修复: 新建 `tools/sysmlgen/` → `generated/sysml/<view>.{puml,mermaid}` + CI step `make sysml-verify` | feat | P3/Cx3 | 🟡 | F-06 落地后 | `tools/sysmlgen/` (新) + `generated/sysml/` (新) | 030 §3 F-07 |
 
 ## 14.6 杂项 / PR FU / T-*


### PR DESCRIPTION
## Summary

- `cmd/gocell/app/printers/verify.go::printTestResults` 现在对 `tr.ZeroMatch` / `tr.SkippedOnly` 输出 `[WARN] <name> — <reason>`，与"测试真跑了但失败"的 `[FAIL]` 视觉分离；JSON printer 路径不变（已显式暴露 `zeroMatch` / `skippedOnly` 布尔）。
- `[WARN]` 行的 reason 后缀让首行就承载完整诊断；下面由 `printErrors` 输出的 `error: [ERR_ZERO_TEST_MATCH] ...` 摘要保持不动（单源治理，`recordResult` 上游已注入结构化 `errcode.Error`）。
- 一并修了 `SkippedOnly` 的对称 UX（同函数同上游构造），不留 follow-up。

Refs: `docs/backlog/cap-14-tooling.md` G-14
ref: aquasecurity/kube-bench `cmd/common.go`（PASS/FAIL/WARN/INFO marker 体系）
ref: golang `testing/testing.go` "testing: warning: no tests to run"（warning 一词同源）

## TDD

| Wave | Commit | 状态 |
|------|--------|------|
| 1 (RED) | `test(verify): G-14 RED — expect [WARN] for ZeroMatch/SkippedOnly in text printer` | 更新 zero_match golden 到新预期 + 新增 skipped_only 用例；测试 RED |
| 2 (GREEN) | `fix(verify): G-14 text printer surface ZeroMatch/SkippedOnly as [WARN]` | switch 四态 ZeroMatch / SkippedOnly / Passed / FAIL；GREEN |

## Test plan

- [x] `go -C worktrees/225-verify-printer-zeromatch-warn test ./cmd/gocell/app/printers/...` — text + JSON golden 全过
- [x] `go -C worktrees/225-verify-printer-zeromatch-warn test ./...` — 全量回归零失败
- [x] `golangci-lint run ./...` — 0 issues

## AI-HARD 自评

本任务属"review finding 中的 bug 修复类"——**不**新增/修改 enforcement 机制。保障层：

| 风险 | 保障 | 评级 |
|------|------|------|
| text 形态被静默回滚 | `verify_test.go` `assertGolden` golden file diff | **Hard**（fixture-level regression test，charter §1 范例 `eachnode_test.go` 同型）|
| ZeroMatch / SkippedOnly 状态域穷举 | 上游 `kernel/verify/gotest.go:57-58` 运行时互斥构造 + 新增 golden case 覆盖 SkippedOnly 单元 | **Medium**（bool 平行但运行时唯一构造点保障；不引入 sum-type，代价 >> L1 收益）|
| 文案漂移 | const literal in `verify.go`，由 golden 守 | **Hard** |

不引入新 archtest / 不改 `TestResult` struct / 不抽 sum type。

## 三原则自审

- **彻底**：ZeroMatch + SkippedOnly 同根一并修；上游 `errcode.ErrZeroTestMatch` 错误注入已存在不动；不留 TODO/FIXME。
- **不向后兼容**：直接替换 `[FAIL]` → `[WARN]` for ZeroMatch / SkippedOnly；ZeroMatch 行旧字面量从 golden 删除；不留 deprecation 别名。
- **优雅简洁**：单文件 switch +15 行；不抽 helper（单 callsite，违反 "≥3 次再抽常量"）；不动 struct / 上游 / JSON。