### PR TITLE
test(outbox): B2-X-01 replace fixed sleep with deterministic subscribe-ready wait

### DIFF
--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -163,8 +163,9 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 
 	subCtx, subCancel := context.WithCancel(ctx)
 	defer subCancel()
+	e2eSub := outbox.Subscription{Topic: topic, ConsumerGroup: "e2e-test", CellID: "e2e-test"}
 	go func() {
-		_ = eb.Subscribe(subCtx, outbox.Subscription{Topic: topic, ConsumerGroup: "e2e-test", CellID: "e2e-test"}, entryToSubHandler(func(_ context.Context, e outbox.Entry) outbox.HandleResult {
+		_ = eb.Subscribe(subCtx, e2eSub, entryToSubHandler(func(_ context.Context, e outbox.Entry) outbox.HandleResult {
 			var p configEntryUpsertedBusinessPayload
 			err := json.Unmarshal(e.Payload, &p)
 			recvMu.Lock()
@@ -173,8 +174,15 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 			return outbox.Ack()
 		}))
 	}()
-	// Give subscriber goroutine a moment to register before first publish.
-	time.Sleep(testtime.MediumPoll) //archtest:allow:test-sleep wait for goroutine to enter blocking Subscribe; no started observable
+	// Wait until the subscriber goroutine has registered in the eventbus before
+	// publishing. eb.Ready returns a channel that eb.Subscribe closes once the
+	// subscription is registered and ready to receive messages, providing a
+	// deterministic synchronisation point instead of a fixed sleep.
+	select {
+	case <-eb.Ready(e2eSub):
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for e2e-test subscription to be ready")
+	}
 
 	// --- Step 5: Assemble cells ---
 	hmacKey := []byte("test-hmac-key-32-bytes-long!!!!!")


### PR DESCRIPTION
## Summary

- Replaced `time.Sleep(testtime.MediumPoll)` in `TestOutboxE2E_PGMode_WriteToSubscribe` with `<-eb.Ready(e2eSub)` — a deterministic synchronisation point provided by the existing `InMemoryEventBus.Ready` API.
- `eb.Ready(sub)` returns a `<-chan struct{}` that `eb.Subscribe` closes once the subscription is registered in the internal map, eliminating the publish-before-subscribe race on slow CI nodes.
- Removed the now-dead `//archtest:allow:test-sleep` anchor (no residual sleep remains).

**Readiness approach chosen**: `InMemoryEventBus.Ready(outbox.Subscription) <-chan struct{}` — already present in `runtime/eventbus/eventbus.go` (lines 218–229) and already used by `outbox_wiring_test.go` for the same pattern. No new primitives introduced.

Refs: B2-X-01

## Test plan

- [x] `go -C worktrees/633-b2x01-outbox-e2e-ready build -tags=integration ./cmd/corebundle/...` — clean
- [x] `go -C worktrees/633-b2x01-outbox-e2e-ready build ./...` — clean
- [x] `go -C worktrees/633-b2x01-outbox-e2e-ready vet -tags=integration ./cmd/corebundle/...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -run TestTestSleepDiscipline ./tools/archtest/...` — passes (archtest confirms no unannotated sleeps remain)
- [x] Integration test requires PG testcontainer (Docker). Verified compiles cleanly under `-tags=integration`. CI integration job command: `go test -tags=integration -covermode=atomic -coverprofile=coverage-integration.out <discovered-pkgs> -count=1 -timeout 15m` (auto-discovered via `comm -13` of bare vs tagged `go list`).
- [x] Pre-existing `TestBuildBootstrap_*` failures in sandbox are identical on `develop` (`listen tcp 127.0.0.1:0: bind: operation not permitted`) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)