### PR TITLE
fix(eventbus): R-02 escalate drop to Error + contextual fields

### DIFF
--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -87,7 +87,13 @@ func validateMetadata(m map[string]string) error {
 type Entry struct {
 	// ID is the canonical idempotency identifier. Consumers SHOULD use this
 	// field to construct idempotency keys.
-	ID            string
+	ID string
+	// AggregateID identifies the domain entity that owns this event (e.g. a
+	// session UUID or a config-entry slug). It MUST be a domain entity
+	// identifier (UUID or opaque slug validated by SafeID); it MUST NOT carry
+	// user PII (email, phone number, username, or display name). AggregateID
+	// is emitted verbatim in structured logs, including Error-level drop and
+	// dead-letter records, and is NOT redacted by pkg/redaction.
 	AggregateID   string
 	AggregateType string
 	EventType     string

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -180,8 +180,11 @@ func (b *InMemoryEventBus) broadcast(topic string, gs *groupState, entry outbox.
 		select {
 		case sub.ch <- entry:
 		default:
-			slog.Warn("eventbus: subscriber buffer full, message dropped",
+			slog.Error("eventbus: subscriber buffer full, message dropped",
 				slog.String("topic", topic),
+				slog.String("entry_id", entry.ID),
+				slog.String("aggregate_id", entry.AggregateID),
+				slog.String("event_type", entry.EventType),
 			)
 		}
 	}
@@ -195,9 +198,12 @@ func (b *InMemoryEventBus) roundRobin(topic, group string, gs *groupState, entry
 	select {
 	case sub.ch <- entry:
 	default:
-		slog.Warn("eventbus: subscriber buffer full, message dropped",
+		slog.Error("eventbus: subscriber buffer full, message dropped",
 			slog.String("topic", topic),
 			slog.String("consumer_group", group),
+			slog.String("entry_id", entry.ID),
+			slog.String("aggregate_id", entry.AggregateID),
+			slog.String("event_type", entry.EventType),
 		)
 	}
 }

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -123,7 +123,7 @@ func New(opts ...Option) *InMemoryEventBus {
 //   - For the empty-group ("") bucket: send to ALL subscribers (broadcast)
 //
 // Non-blocking: if a subscriber's buffer is full, the message is dropped
-// (logged as warning).
+// (logged at Error level — indicates message loss and impacts correctness).
 //
 // The bus unwraps the envelope so subscribers always see the business payload
 // in Entry.Payload, matching the semantics of the RabbitMQ subscriber path.
@@ -445,6 +445,8 @@ func (b *InMemoryEventBus) notifyRetryExhausted(
 	slog.Error("eventbus: retries exhausted, routing to dead letter",
 		slog.String("topic", topic),
 		slog.String("entry_id", entry.ID),
+		slog.String("aggregate_id", entry.AggregateID),
+		slog.String("event_type", entry.EventType),
 		slog.Any("error", err),
 	)
 }
@@ -550,6 +552,8 @@ func (b *InMemoryEventBus) handleInvalidDisposition(
 		slog.Error("eventbus: invalid disposition, retry budget exhausted",
 			slog.String("topic", topic),
 			slog.String("entry_id", entry.ID),
+			slog.String("aggregate_id", entry.AggregateID),
+			slog.String("event_type", entry.EventType),
 			slog.String("disposition", res.Disposition.String()),
 			slog.Int("attempt", attempt+1),
 		)
@@ -559,6 +563,8 @@ func (b *InMemoryEventBus) handleInvalidDisposition(
 	slog.Error("eventbus: invalid disposition, treating as requeue",
 		slog.String("topic", topic),
 		slog.String("entry_id", entry.ID),
+		slog.String("aggregate_id", entry.AggregateID),
+		slog.String("event_type", entry.EventType),
 		slog.String("disposition", res.Disposition.String()),
 		slog.Int("attempt", attempt+1),
 		slog.Duration("retry_delay", delay),

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -1510,6 +1510,43 @@ func (r *failingReleaseReceipt) Extend(_ context.Context, _ time.Duration) error
 // R-02: drop-path log level + contextual fields
 // ---------------------------------------------------------------------------
 
+// assertNoPayloadLeak asserts that the given slog.Record does not contain
+// payloadMarker anywhere in its Message or attribute values. This is the
+// negative regression guard for R-02: the drop-path log must never include
+// business payload bytes, preventing accidental PII exposure.
+//
+// Rationale: a future refactor could accidentally add slog.Any("entry", entry)
+// or slog.Any("payload", entry.Payload) to the drop log. This helper catches
+// that regression by asserting on a recognizable sentinel string embedded in
+// the payload at publish time.
+func assertNoPayloadLeak(t *testing.T, r slog.Record, payloadMarker string) {
+	t.Helper()
+
+	if strings.Contains(r.Message, payloadMarker) {
+		t.Errorf("drop log Message must not contain payload marker %q; message=%q",
+			payloadMarker, r.Message)
+	}
+
+	r.Attrs(func(a slog.Attr) bool {
+		// Render the attribute value to its string representation and scan for
+		// the marker. This catches:
+		//   slog.String("payload", string(entry.Payload))
+		//   slog.Any("payload", entry.Payload)
+		//   slog.Any("entry", entry) — whole Entry serialized
+		rendered := fmt.Sprintf("%v", a.Value.Any())
+		if strings.Contains(rendered, payloadMarker) {
+			t.Errorf("drop log attr %q value must not contain payload marker %q; rendered=%q",
+				a.Key, payloadMarker, rendered)
+		}
+		// Also check the raw string value.
+		if strings.Contains(a.Value.String(), payloadMarker) {
+			t.Errorf("drop log attr %q string value must not contain payload marker %q; value=%q",
+				a.Key, payloadMarker, a.Value.String())
+		}
+		return true
+	})
+}
+
 // findLogAttr returns the first slog.Attr with the given key from a Record.
 func findLogAttr(r slog.Record, key string) (slog.Attr, bool) {
 	var found slog.Attr
@@ -1546,6 +1583,11 @@ func findDropRecord(records []slog.Record, msgSubstr string) *slog.Record {
 //
 // Strategy: inject a subscription directly into groupSubs with a pre-filled
 // channel (no goroutine draining it) so the drop is deterministic.
+//
+// Negative regression guard (R-02): the drop log must NOT contain the business
+// payload — assertNoPayloadLeak verifies this using a unique sentinel marker
+// embedded in the published entry's Payload. Any future change that accidentally
+// adds slog.Any("payload", ...) or slog.Any("entry", ...) will fail this test.
 func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	cap := healthtest.NewCapture(t)
 
@@ -1571,13 +1613,16 @@ func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	}
 	bus.mu.Unlock()
 
+	// Sentinel marker embedded in the payload — must NOT appear in any log attr.
+	const payloadMarker = "SECRET_PAYLOAD_MARKER_DO_NOT_LOG"
+
 	// Build and publish the entry-under-test.
 	entry := outbox.Entry{
 		ID:          "evt-broadcast-drop-2",
 		AggregateID: "agg-bcast-002",
 		EventType:   "drop.broadcast.v1",
 		Topic:       "drop.broadcast.v1",
-		Payload:     []byte(`{"x":2}`),
+		Payload:     []byte(`{"sentinel":"` + payloadMarker + `"}`),
 	}
 	env, err := outbox.MarshalEnvelope(entry)
 	require.NoError(t, err)
@@ -1602,6 +1647,9 @@ func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	evtTypeAttr, ok := findLogAttr(*dropRecord, "event_type")
 	require.True(t, ok, "drop record must carry 'event_type'")
 	assert.Equal(t, "drop.broadcast.v1", evtTypeAttr.Value.String())
+
+	// Negative regression: payload bytes must not appear in the drop log record.
+	assertNoPayloadLeak(t, *dropRecord, payloadMarker)
 }
 
 // TestRoundRobin_BufferFull_LogsErrorWithContextualFields verifies R-02:
@@ -1609,6 +1657,10 @@ func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 // and carry entry_id, aggregate_id, event_type, and consumer_group attributes.
 //
 // Strategy: same as broadcast test — inject pre-filled subscription directly.
+//
+// Negative regression guard (R-02): the drop log must NOT contain the business
+// payload — assertNoPayloadLeak verifies this using a unique sentinel marker
+// embedded in the published entry's Payload.
 func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	cap := healthtest.NewCapture(t)
 
@@ -1631,12 +1683,15 @@ func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	}
 	bus.mu.Unlock()
 
+	// Sentinel marker embedded in the payload — must NOT appear in any log attr.
+	const payloadMarker = "SECRET_PAYLOAD_MARKER_DO_NOT_LOG"
+
 	entry := outbox.Entry{
 		ID:          "evt-rr-drop-2",
 		AggregateID: "agg-rr-002",
 		EventType:   "drop.roundrobin.v1",
 		Topic:       "drop.roundrobin.v1",
-		Payload:     []byte(`{"x":2}`),
+		Payload:     []byte(`{"sentinel":"` + payloadMarker + `"}`),
 	}
 	env, err := outbox.MarshalEnvelope(entry)
 	require.NoError(t, err)
@@ -1664,6 +1719,9 @@ func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	evtTypeAttr, ok := findLogAttr(*dropRecord, "event_type")
 	require.True(t, ok, "drop record must carry 'event_type'")
 	assert.Equal(t, "drop.roundrobin.v1", evtTypeAttr.Value.String())
+
+	// Negative regression: payload bytes must not appear in the drop log record.
+	assertNoPayloadLeak(t, *dropRecord, payloadMarker)
 }
 
 // TestNotifyRetryExhausted_LogsErrorWithContextualFields verifies F1:
@@ -1672,6 +1730,10 @@ func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 //
 // Strategy: publish to a subscriber that always returns Requeue; wait for
 // the retry budget to exhaust and the dead-letter path to fire.
+//
+// Negative regression guard (R-02): the retries-exhausted log must NOT contain
+// the business payload — assertNoPayloadLeak verifies this using a unique
+// sentinel marker embedded in the published entry's Payload.
 func TestNotifyRetryExhausted_LogsErrorWithContextualFields(t *testing.T) {
 	cap := healthtest.NewCapture(t)
 
@@ -1689,12 +1751,15 @@ func TestNotifyRetryExhausted_LogsErrorWithContextualFields(t *testing.T) {
 	}()
 	<-bus.Ready(outbox.Subscription{Topic: topic})
 
+	// Sentinel marker embedded in the payload — must NOT appear in any log attr.
+	const payloadMarker = "SECRET_PAYLOAD_MARKER_DO_NOT_LOG"
+
 	entry := outbox.Entry{
 		ID:          "evt-exhaust-1",
 		AggregateID: "agg-exhaust-001",
 		EventType:   topic,
 		Topic:       topic,
-		Payload:     []byte(`{"x":1}`),
+		Payload:     []byte(`{"sentinel":"` + payloadMarker + `"}`),
 	}
 	env, err := outbox.MarshalEnvelope(entry)
 	require.NoError(t, err)
@@ -1723,6 +1788,9 @@ func TestNotifyRetryExhausted_LogsErrorWithContextualFields(t *testing.T) {
 	evtTypeAttr, ok := findLogAttr(*exhaustedRecord, "event_type")
 	require.True(t, ok, "retries-exhausted record must carry 'event_type'")
 	assert.Equal(t, topic, evtTypeAttr.Value.String())
+
+	// Negative regression: payload bytes must not appear in the retries-exhausted log.
+	assertNoPayloadLeak(t, *exhaustedRecord, payloadMarker)
 
 	cancel()
 	<-done

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1502,6 +1504,196 @@ func (r *failingReleaseReceipt) Release(_ context.Context) error {
 	return r.err
 }
 func (r *failingReleaseReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
+
+// ---------------------------------------------------------------------------
+// R-02: drop-path log level + contextual fields
+// ---------------------------------------------------------------------------
+
+// captureSlogHandler is a test-only slog.Handler that captures every Record.
+// Mirrors the pattern used in cells/configcore/slogtest_helper_test.go.
+type captureSlogHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureSlogHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *captureSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+func (h *captureSlogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureSlogHandler) WithGroup(string) slog.Handler      { return h }
+
+// findLogAttr returns the first slog.Attr with the given key from a Record.
+func findLogAttr(r slog.Record, key string) (slog.Attr, bool) {
+	var found slog.Attr
+	var ok bool
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			found = a
+			ok = true
+			return false
+		}
+		return true
+	})
+	return found, ok
+}
+
+// TestBroadcast_BufferFull_LogsErrorWithContextualFields verifies R-02:
+// when the broadcast drop path fires, the log record must be at slog.LevelError
+// and carry entry_id, aggregate_id, and event_type attributes.
+//
+// Strategy: inject a subscription directly into groupSubs with a pre-filled
+// channel (no goroutine draining it) so the drop is deterministic.
+func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
+	cap := &captureSlogHandler{}
+	logger := slog.New(cap)
+	prev := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	bus := New(WithClock(clock.Real()), WithBufferSize(1))
+	defer func() { _ = bus.Close(context.Background()) }()
+
+	// Inject a subscription with a pre-filled channel directly.
+	// The subscriber channel has capacity 1 and is already full, so any Publish
+	// must take the default (drop) branch. No goroutine is draining it.
+	_, cancelSub := context.WithCancel(context.Background())
+	t.Cleanup(cancelSub)
+	sub := &subscription{
+		ch:     make(chan outbox.Entry, 1),
+		cancel: cancelSub,
+		done:   make(chan struct{}),
+	}
+	filler := outbox.Entry{ID: "filler", EventType: "drop.broadcast.v1", Topic: "drop.broadcast.v1"}
+	sub.ch <- filler // pre-fill to capacity
+
+	bus.mu.Lock()
+	bus.groupSubs["drop.broadcast.v1"] = map[string]*groupState{
+		"": {subs: []*subscription{sub}},
+	}
+	bus.mu.Unlock()
+
+	// Build and publish the entry-under-test.
+	entry := outbox.Entry{
+		ID:          "evt-broadcast-drop-2",
+		AggregateID: "agg-bcast-002",
+		EventType:   "drop.broadcast.v1",
+		Topic:       "drop.broadcast.v1",
+		Payload:     []byte(`{"x":2}`),
+	}
+	env, err := outbox.MarshalEnvelope(entry)
+	require.NoError(t, err)
+	require.NoError(t, bus.Publish(context.Background(), "drop.broadcast.v1", env))
+
+	// Drop fires synchronously inside Publish, so the record is already captured.
+	cap.mu.Lock()
+	var dropRecord *slog.Record
+	for i := range cap.records {
+		if cap.records[i].Level == slog.LevelError &&
+			strings.Contains(cap.records[i].Message, "dropped") {
+			r := cap.records[i]
+			dropRecord = &r
+			break
+		}
+	}
+	cap.mu.Unlock()
+	require.NotNil(t, dropRecord, "slog.Error drop record must be captured synchronously")
+
+	topicAttr, ok := findLogAttr(*dropRecord, "topic")
+	require.True(t, ok, "drop record must carry 'topic'")
+	assert.Equal(t, "drop.broadcast.v1", topicAttr.Value.String())
+
+	entryIDAttr, ok := findLogAttr(*dropRecord, "entry_id")
+	require.True(t, ok, "drop record must carry 'entry_id'")
+	assert.Equal(t, "evt-broadcast-drop-2", entryIDAttr.Value.String())
+
+	aggIDAttr, ok := findLogAttr(*dropRecord, "aggregate_id")
+	require.True(t, ok, "drop record must carry 'aggregate_id'")
+	assert.Equal(t, "agg-bcast-002", aggIDAttr.Value.String())
+
+	evtTypeAttr, ok := findLogAttr(*dropRecord, "event_type")
+	require.True(t, ok, "drop record must carry 'event_type'")
+	assert.Equal(t, "drop.broadcast.v1", evtTypeAttr.Value.String())
+}
+
+// TestRoundRobin_BufferFull_LogsErrorWithContextualFields verifies R-02:
+// when the roundRobin drop path fires, the log record must be at slog.LevelError
+// and carry entry_id, aggregate_id, event_type, and consumer_group attributes.
+//
+// Strategy: same as broadcast test — inject pre-filled subscription directly.
+func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
+	cap := &captureSlogHandler{}
+	logger := slog.New(cap)
+	prev := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	bus := New(WithClock(clock.Real()), WithBufferSize(1))
+	defer func() { _ = bus.Close(context.Background()) }()
+
+	_, cancelSub := context.WithCancel(context.Background())
+	t.Cleanup(cancelSub)
+	sub := &subscription{
+		ch:     make(chan outbox.Entry, 1),
+		cancel: cancelSub,
+		done:   make(chan struct{}),
+	}
+	filler := outbox.Entry{ID: "filler", EventType: "drop.roundrobin.v1", Topic: "drop.roundrobin.v1"}
+	sub.ch <- filler
+
+	bus.mu.Lock()
+	bus.groupSubs["drop.roundrobin.v1"] = map[string]*groupState{
+		"drop-cg": {subs: []*subscription{sub}},
+	}
+	bus.mu.Unlock()
+
+	entry := outbox.Entry{
+		ID:          "evt-rr-drop-2",
+		AggregateID: "agg-rr-002",
+		EventType:   "drop.roundrobin.v1",
+		Topic:       "drop.roundrobin.v1",
+		Payload:     []byte(`{"x":2}`),
+	}
+	env, err := outbox.MarshalEnvelope(entry)
+	require.NoError(t, err)
+	require.NoError(t, bus.Publish(context.Background(), "drop.roundrobin.v1", env))
+
+	cap.mu.Lock()
+	var dropRecord *slog.Record
+	for i := range cap.records {
+		if cap.records[i].Level == slog.LevelError &&
+			strings.Contains(cap.records[i].Message, "dropped") {
+			r := cap.records[i]
+			dropRecord = &r
+			break
+		}
+	}
+	cap.mu.Unlock()
+	require.NotNil(t, dropRecord, "slog.Error drop record must be captured synchronously")
+
+	topicAttr, ok := findLogAttr(*dropRecord, "topic")
+	require.True(t, ok, "drop record must carry 'topic'")
+	assert.Equal(t, "drop.roundrobin.v1", topicAttr.Value.String())
+
+	cgAttr, ok := findLogAttr(*dropRecord, "consumer_group")
+	require.True(t, ok, "drop record must carry 'consumer_group'")
+	assert.Equal(t, "drop-cg", cgAttr.Value.String())
+
+	entryIDAttr, ok := findLogAttr(*dropRecord, "entry_id")
+	require.True(t, ok, "drop record must carry 'entry_id'")
+	assert.Equal(t, "evt-rr-drop-2", entryIDAttr.Value.String())
+
+	aggIDAttr, ok := findLogAttr(*dropRecord, "aggregate_id")
+	require.True(t, ok, "drop record must carry 'aggregate_id'")
+	assert.Equal(t, "agg-rr-002", aggIDAttr.Value.String())
+
+	evtTypeAttr, ok := findLogAttr(*dropRecord, "event_type")
+	require.True(t, ok, "drop record must carry 'event_type'")
+	assert.Equal(t, "drop.roundrobin.v1", evtTypeAttr.Value.String())
+}
 
 // Verify interface compliance at compile time.
 var (

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/runtime/http/health/healthtest"
 )
 
 // busEventually2x is testtime.EventuallyShort × 2 for standard eventually timeouts.
@@ -1509,23 +1510,6 @@ func (r *failingReleaseReceipt) Extend(_ context.Context, _ time.Duration) error
 // R-02: drop-path log level + contextual fields
 // ---------------------------------------------------------------------------
 
-// captureSlogHandler is a test-only slog.Handler that captures every Record.
-// Mirrors the pattern used in cells/configcore/slogtest_helper_test.go.
-type captureSlogHandler struct {
-	mu      sync.Mutex
-	records []slog.Record
-}
-
-func (h *captureSlogHandler) Enabled(context.Context, slog.Level) bool { return true }
-func (h *captureSlogHandler) Handle(_ context.Context, r slog.Record) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.records = append(h.records, r.Clone())
-	return nil
-}
-func (h *captureSlogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h *captureSlogHandler) WithGroup(string) slog.Handler      { return h }
-
 // findLogAttr returns the first slog.Attr with the given key from a Record.
 func findLogAttr(r slog.Record, key string) (slog.Attr, bool) {
 	var found slog.Attr
@@ -1541,18 +1525,29 @@ func findLogAttr(r slog.Record, key string) (slog.Attr, bool) {
 	return found, ok
 }
 
+// findDropRecord scans records captured by healthtest.CaptureHandler and
+// returns the first Error-level record whose message contains msgSubstr.
+func findDropRecord(records []slog.Record, msgSubstr string) *slog.Record {
+	for i := range records {
+		if records[i].Level == slog.LevelError && strings.Contains(records[i].Message, msgSubstr) {
+			r := records[i]
+			return &r
+		}
+	}
+	return nil
+}
+
 // TestBroadcast_BufferFull_LogsErrorWithContextualFields verifies R-02:
 // when the broadcast drop path fires, the log record must be at slog.LevelError
 // and carry entry_id, aggregate_id, and event_type attributes.
 //
+// Uses healthtest.NewCapture (pkg/testutil/sloghelper-safe layer; no import
+// cycle: runtime/http/health/healthtest does not import runtime/eventbus).
+//
 // Strategy: inject a subscription directly into groupSubs with a pre-filled
 // channel (no goroutine draining it) so the drop is deterministic.
 func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
-	cap := &captureSlogHandler{}
-	logger := slog.New(cap)
-	prev := slog.Default()
-	slog.SetDefault(logger)
-	t.Cleanup(func() { slog.SetDefault(prev) })
+	cap := healthtest.NewCapture(t)
 
 	bus := New(WithClock(clock.Real()), WithBufferSize(1))
 	defer func() { _ = bus.Close(context.Background()) }()
@@ -1589,17 +1584,7 @@ func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	require.NoError(t, bus.Publish(context.Background(), "drop.broadcast.v1", env))
 
 	// Drop fires synchronously inside Publish, so the record is already captured.
-	cap.mu.Lock()
-	var dropRecord *slog.Record
-	for i := range cap.records {
-		if cap.records[i].Level == slog.LevelError &&
-			strings.Contains(cap.records[i].Message, "dropped") {
-			r := cap.records[i]
-			dropRecord = &r
-			break
-		}
-	}
-	cap.mu.Unlock()
+	dropRecord := findDropRecord(cap.Snapshot(), "dropped")
 	require.NotNil(t, dropRecord, "slog.Error drop record must be captured synchronously")
 
 	topicAttr, ok := findLogAttr(*dropRecord, "topic")
@@ -1625,11 +1610,7 @@ func TestBroadcast_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 //
 // Strategy: same as broadcast test — inject pre-filled subscription directly.
 func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
-	cap := &captureSlogHandler{}
-	logger := slog.New(cap)
-	prev := slog.Default()
-	slog.SetDefault(logger)
-	t.Cleanup(func() { slog.SetDefault(prev) })
+	cap := healthtest.NewCapture(t)
 
 	bus := New(WithClock(clock.Real()), WithBufferSize(1))
 	defer func() { _ = bus.Close(context.Background()) }()
@@ -1661,17 +1642,7 @@ func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, bus.Publish(context.Background(), "drop.roundrobin.v1", env))
 
-	cap.mu.Lock()
-	var dropRecord *slog.Record
-	for i := range cap.records {
-		if cap.records[i].Level == slog.LevelError &&
-			strings.Contains(cap.records[i].Message, "dropped") {
-			r := cap.records[i]
-			dropRecord = &r
-			break
-		}
-	}
-	cap.mu.Unlock()
+	dropRecord := findDropRecord(cap.Snapshot(), "dropped")
 	require.NotNil(t, dropRecord, "slog.Error drop record must be captured synchronously")
 
 	topicAttr, ok := findLogAttr(*dropRecord, "topic")
@@ -1693,6 +1664,68 @@ func TestRoundRobin_BufferFull_LogsErrorWithContextualFields(t *testing.T) {
 	evtTypeAttr, ok := findLogAttr(*dropRecord, "event_type")
 	require.True(t, ok, "drop record must carry 'event_type'")
 	assert.Equal(t, "drop.roundrobin.v1", evtTypeAttr.Value.String())
+}
+
+// TestNotifyRetryExhausted_LogsErrorWithContextualFields verifies F1:
+// notifyRetryExhausted must log at Error level and carry aggregate_id and
+// event_type (aligned with R-02 contextual field standard).
+//
+// Strategy: publish to a subscriber that always returns Requeue; wait for
+// the retry budget to exhaust and the dead-letter path to fire.
+func TestNotifyRetryExhausted_LogsErrorWithContextualFields(t *testing.T) {
+	cap := healthtest.NewCapture(t)
+
+	bus := New(WithClock(clock.Real()), WithBufferSize(16))
+	defer func() { _ = bus.Close(context.Background()) }()
+
+	const topic = "retry.exhaust.fields.v1"
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: topic},
+			entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+				return outbox.Requeue(errors.New("always-transient"))
+			}))
+	}()
+	<-bus.Ready(outbox.Subscription{Topic: topic})
+
+	entry := outbox.Entry{
+		ID:          "evt-exhaust-1",
+		AggregateID: "agg-exhaust-001",
+		EventType:   topic,
+		Topic:       topic,
+		Payload:     []byte(`{"x":1}`),
+	}
+	env, err := outbox.MarshalEnvelope(entry)
+	require.NoError(t, err)
+	require.NoError(t, bus.Publish(context.Background(), topic, env))
+
+	// Wait for the retry budget to exhaust and the dead-letter record to appear.
+	require.Eventually(t, func() bool {
+		return bus.DeadLetterLen() > 0
+	}, busEventually10x, testtime.MediumPoll, "dead letter must be populated after retries exhausted")
+
+	// Find the Error-level "retries exhausted" record.
+	var exhaustedRecord *slog.Record
+	for _, r := range cap.Snapshot() {
+		if r.Level == slog.LevelError && strings.Contains(r.Message, "retries exhausted") {
+			rc := r
+			exhaustedRecord = &rc
+			break
+		}
+	}
+	require.NotNil(t, exhaustedRecord, "slog.Error 'retries exhausted' record must be captured")
+
+	aggIDAttr, ok := findLogAttr(*exhaustedRecord, "aggregate_id")
+	require.True(t, ok, "retries-exhausted record must carry 'aggregate_id'")
+	assert.Equal(t, "agg-exhaust-001", aggIDAttr.Value.String())
+
+	evtTypeAttr, ok := findLogAttr(*exhaustedRecord, "event_type")
+	require.True(t, ok, "retries-exhausted record must carry 'event_type'")
+	assert.Equal(t, topic, evtTypeAttr.Value.String())
+
+	cancel()
+	<-done
 }
 
 // Verify interface compliance at compile time.


### PR DESCRIPTION
## Summary

- Upgrade `broadcast()` and `roundRobin()` drop-path logs from `slog.Warn` → `slog.Error` per observability.md rule: dropped message affects correctness → Error level
- Add three structured fields extracted from the dropped `outbox.Entry`: `entry_id`, `aggregate_id`, `event_type` (via `slog.String`)
- Keep existing `topic` (and `consumer_group` for roundRobin); no payload dump

## Test plan

- [x] `TestBroadcast_BufferFull_LogsErrorWithContextualFields` — injects a pre-filled subscription, verifies drop record is `slog.LevelError` with `entry_id`, `aggregate_id`, `event_type`, `topic`
- [x] `TestRoundRobin_BufferFull_LogsErrorWithContextualFields` — same for named consumer group, also verifies `consumer_group` field
- [x] All existing `runtime/eventbus` tests pass (`go test ./runtime/eventbus/...`)
- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues

`Refs: R-02-EVENTBUS-DROP-CONTEXTUAL-LOG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)