### PR TITLE
docs(metadata): C-06 document L0 cell as future extension point

### DIFF
--- a/docs/architecture/consistency.md
+++ b/docs/architecture/consistency.md
@@ -19,6 +19,13 @@
 
 **示例**：输入校验、纯计算、本地格式化。
 
+> **当前状态（C-06-L0-CELL-DECISION）**：L0 Cell 是已建模的未来扩展点，
+> 平台三个 cell（accesscore / auditcore / configcore）当前均无 L0 实例。
+> 所有平台 cell.yaml 的 `l0Dependencies: []` 为空是**预期行为**，不是 schema 缺陷。
+> 未来如需将共享纯计算逻辑（如哈希、编码工具）提升为独立 L0 Cell，
+> 消费方在 `l0Dependencies` 中声明依赖即可。
+> 详见 `kernel/metadata.L0DepMeta` godoc。
+
 ---
 
 ## L1 — LocalTx

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -14,7 +14,7 @@
 L0 Cell 是特殊模型：
 - 纯计算分区（无状态机、无契约）
 - 同 Assembly 内直接导入
-- 必须通过 `l0Dependencies` 显式声明
+- 消费方 Cell 通过 `l0Dependencies` 声明对此 L0 Cell 的直接依赖（L0 Cell 自身由 `consistencyLevel: L0` 标识）
 
 ### Slice
 

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -68,6 +68,29 @@ type CellVerifyMeta struct {
 }
 
 // L0DepMeta declares a direct dependency on an L0 (LocalOnly) Cell.
+//
+// L0 Cell status: sanctioned future extension point
+//
+// L0 (LocalOnly, pure-compute library cell) is a first-class member of the
+// consistency-level model (L0-L4). An L0 Cell has no state machine, no
+// outbox, and no contracts; it exposes shared pure-computation logic (e.g.
+// hashing, validation algorithms, encoding helpers) that other cells in the
+// same Assembly may import directly.
+//
+// As of this writing there is no L0 Cell instance in the platform cells
+// (accesscore / auditcore / configcore). Every platform cell.yaml therefore
+// carries `l0Dependencies: []` — this empty slice is expected and correct;
+// it is not a schema defect or dead-code path.
+//
+// When a future L0 Cell is created (e.g. a shared pure-compute package
+// elevated to a first-class Cell), consuming cells would add an entry here:
+//
+//	l0Dependencies:
+//	  - cell: sharedcrypto
+//	    reason: deterministic hashing for cursor tokens
+//
+// Decision record: C-06-L0-CELL-DECISION — user chose doc-only (option b)
+// over elevating an existing package to a concrete L0 instance (option a).
 type L0DepMeta struct {
 	Cell   string `yaml:"cell"`
 	Reason string `yaml:"reason"`


### PR DESCRIPTION
## Summary

- Add godoc to `kernel/metadata.L0DepMeta` documenting that L0 Cell is a sanctioned future extension point; no platform L0 instance currently exists; `l0Dependencies: []` is expected, not a defect.
- Add a matching callout note in `docs/architecture/consistency.md` (the canonical L0-L4 reference) so the decision is discoverable.
- No runtime behavior changed; no `cells/` or `pkg/query` files touched.

User chose **option (b) doc-only** over option (a) elevating `pkg/query.CursorCodec` to a concrete L0 Cell instance.

Refs: C-06-L0-CELL-DECISION

🤖 Generated with [Claude Code](https://claude.com/claude-code)