### PR TITLE
fix(accesscore): drop unused gocognit nolint on initSlices

### DIFF
--- a/cells/accesscore/cell_init.go
+++ b/cells/accesscore/cell_init.go
@@ -196,7 +196,7 @@ func (c *AccessCore) initRefreshGC() error {
 // constraints (login before identity, accountlockout before login, etc.) outweigh
 // the funlen / cognitive-complexity budgets.
 //
-//nolint:funlen,gocognit,cyclop // sequential cell composition root; readability and ordering
+//nolint:funlen,cyclop // sequential cell composition root; readability and ordering
 func (c *AccessCore) initSlices() error {
 	// credentialinvalidate: shared invalidator for identity-manage, rbac-assign,
 	// session-refresh, and accountlockout. Atomically bumps authz_epoch, revokes


### PR DESCRIPTION
## Summary

- 删除 `cells/accesscore/cell_init.go:199` `//nolint:funlen,gocognit,cyclop` 中的 `gocognit` — PR #595 把 `Provisioner.mu` 删掉 + `WithSetupLock` Hard-funnel 后 `initSlices` 的认知复杂度已降到 ≤15，`gocognit` 不再触发，`nolintlint allow-unused: false` 抓到了 unused directive。
- 保留 `funlen` 与 `cyclop`（同一函数仍触发）。

## Root cause

CI run `26135130028`（develop HEAD `4bc3b7f96` push）唯一失败步骤是 `build-test (kernel, ./kernel/..., true)` 的 lint：

```
cells/accesscore/cell_init.go:199:1: directive `//nolint:funlen,gocognit,cyclop // sequential cell composition root; readability and ordering` is unused for linter "gocognit" (nolintlint)
```

四条相邻流水线（govulncheck / Static Analysis / Race Detector / Governance Strict）全 success — 单点 lint 治理遗漏，非机制性回归。

## Test plan

- [x] `go build ./...` — 0 errors
- [x] `golangci-lint run ./...` — 0 issues（注：本地 darwin/amd64 v2.11.4 上未复现 CI 报错，但 nolintlint "unused" 与 gocognit > 15 互斥触发，删除指令对 lint 输出不会增加新 issue）
- [ ] CI lint 步骤通过

Refs: develop CI run 26135130028

🤖 Generated with [Claude Code](https://claude.com/claude-code)