### PR TITLE
fix(sonar): kernel/{governance,metadata} constants + test CC split

### DIFF
--- a/kernel/governance/rules_contract_test_mapping.go
+++ b/kernel/governance/rules_contract_test_mapping.go
@@ -64,6 +64,8 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
+const examplesPathPrefix = "examples/"
+
 // validateCONTRACTENDPOINTTESTMAPPING01 runs the bidirectional check:
 //   - Direction A (contract → slice): every active HTTP contract has at least
 //     one slice in its server cell declaring "contract.<id>.serve".
@@ -231,7 +233,7 @@ func (v *Validator) ctmCheckExamplesArrow(
 	s *metadata.SliceMeta, c *metadata.ContractMeta,
 	fieldPath, entry, contractID string,
 ) *ValidationResult {
-	if !strings.HasPrefix(c.File, "examples/") || strings.HasPrefix(sliceFile(s), "examples/") {
+	if !strings.HasPrefix(c.File, examplesPathPrefix) || strings.HasPrefix(sliceFile(s), examplesPathPrefix) {
 		return nil
 	}
 	r := v.newResult(
@@ -306,7 +308,7 @@ func isActiveHTTPPlatformContract(c *metadata.ContractMeta) bool {
 	return c != nil &&
 		c.Kind == "http" &&
 		c.Lifecycle == "active" &&
-		!strings.HasPrefix(c.File, "examples/")
+		!strings.HasPrefix(c.File, examplesPathPrefix)
 }
 
 // buildCellServeIndex maps each cell ID to the set of contract IDs that any of

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -944,18 +944,25 @@ func (v *Validator) checkFMT15Contract(c *metadata.ContractMeta) []ValidationRes
 	return results
 }
 
+// responseSchemaDataInfo holds the JSON Schema "data" property subset.
+type responseSchemaDataInfo struct {
+	Type string `json:"type"`
+}
+
+// responseSchemaPropertiesInfo holds the JSON Schema "properties" subset needed
+// for list-lint checks.
+type responseSchemaPropertiesInfo struct {
+	Data responseSchemaDataInfo `json:"data"`
+	// NextCursor is non-nil when the "nextCursor" property is declared in the schema.
+	NextCursor *json.RawMessage `json:"nextCursor"`
+	// HasMore is non-nil when the "hasMore" property is declared in the schema.
+	HasMore *json.RawMessage `json:"hasMore"`
+}
+
 // responseSchemaInfo holds the subset of JSON Schema fields needed for list-lint checks.
 type responseSchemaInfo struct {
-	Properties struct {
-		Data struct {
-			Type string `json:"type"`
-		} `json:"data"`
-		// NextCursor is non-nil when the "nextCursor" property is declared in the schema.
-		NextCursor *json.RawMessage `json:"nextCursor"`
-		// HasMore is non-nil when the "hasMore" property is declared in the schema.
-		HasMore *json.RawMessage `json:"hasMore"`
-	} `json:"properties"`
-	Required []string `json:"required"`
+	Properties responseSchemaPropertiesInfo `json:"properties"`
+	Required   []string                     `json:"required"`
 	// Combinator fields: non-nil when the schema uses oneOf/anyOf/allOf at the root level.
 	OneOf *json.RawMessage `json:"oneOf"`
 	AnyOf *json.RawMessage `json:"anyOf"`

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -1074,21 +1074,29 @@ func TestFMT32_OwnershipDeclarationRequired(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			v := NewValidator(tc.project, "", clock.Real())
 			matches := findByCode(v.validateFMT32(), codeFMT32)
-			if len(matches) != tc.wantCount {
-				t.Fatalf("FMT-32 %s: expected %d findings, got %d: %v", tc.name, tc.wantCount, len(matches), matches)
-			}
-			if tc.wantCount == 1 {
-				if matches[0].IssueType != tc.wantIssue {
-					t.Errorf("FMT-32: expected IssueType=%v, got %v", tc.wantIssue, matches[0].IssueType)
-				}
-				if matches[0].Field != tc.wantField {
-					t.Errorf("FMT-32: expected Field=%q, got %q", tc.wantField, matches[0].Field)
-				}
-				if matches[0].Severity != SeverityError {
-					t.Errorf("FMT-32: expected SeverityError, got %v", matches[0].Severity)
-				}
-			}
+			assertFMT32Result(t, tc.name, matches, tc.wantCount, tc.wantIssue, tc.wantField)
 		})
+	}
+}
+
+// assertFMT32Result checks the FMT-32 finding count and, when exactly one
+// finding is expected, validates its IssueType, Field, and Severity.
+func assertFMT32Result(t *testing.T, caseName string, matches []ValidationResult, wantCount int, wantIssue IssueType, wantField string) {
+	t.Helper()
+	if len(matches) != wantCount {
+		t.Fatalf("FMT-32 %s: expected %d findings, got %d: %v", caseName, wantCount, len(matches), matches)
+	}
+	if wantCount != 1 {
+		return
+	}
+	if matches[0].IssueType != wantIssue {
+		t.Errorf("FMT-32: expected IssueType=%v, got %v", wantIssue, matches[0].IssueType)
+	}
+	if matches[0].Field != wantField {
+		t.Errorf("FMT-32: expected Field=%q, got %q", wantField, matches[0].Field)
+	}
+	if matches[0].Severity != SeverityError {
+		t.Errorf("FMT-32: expected SeverityError, got %v", matches[0].Severity)
 	}
 }
 

--- a/kernel/governance/rules_http.go
+++ b/kernel/governance/rules_http.go
@@ -36,6 +36,11 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+const (
+	fieldHTTPPath         = "endpoints.http.path"
+	fieldHTTPResponsesFmt = "endpoints.http.responses[%d]"
+)
+
 // =============================================================================
 // CH-04 — HTTP response alignment
 // =============================================================================
@@ -170,7 +175,7 @@ func (v *Validator) checkResponseAlignmentForContract(
 		if errors.Is(err, errCorrelationMissing) {
 			return []ValidationResult{v.newResult(
 				codeCH04, SeverityError, IssueRequired,
-				c.File, "endpoints.http.path",
+				c.File, fieldHTTPPath,
 				fmt.Sprintf(advHintCH04CorrelationFailed, c.ID, handlerFile),
 			)}
 		}
@@ -216,7 +221,7 @@ func buildAlignmentFindings(v *Validator, c *metadata.ContractMeta, observed, de
 	for _, status := range diffStatuses(observed, declared) {
 		results = append(results, v.newResult(
 			codeCH04, SeverityError, IssueRequired,
-			c.File, fmt.Sprintf("endpoints.http.responses[%d]", status),
+			c.File, fmt.Sprintf(fieldHTTPResponsesFmt, status),
 			fmt.Sprintf("%s: handler returns %d but contract does not declare it;"+
 				" fix: add responses[%d] to the contract or remove the handler return path", c.ID, status, status),
 		))
@@ -833,7 +838,7 @@ func (v *Validator) checkPathParamUUIDForContract(
 	if !ok {
 		return []ValidationResult{v.newResult(
 			codeCH05, SeverityError, IssueRequired,
-			c.File, "endpoints.http.path",
+			c.File, fieldHTTPPath,
 			fmt.Sprintf(advHintCH05CorrelationFailed, c.ID),
 		)}
 	}
@@ -842,7 +847,7 @@ func (v *Validator) checkPathParamUUIDForContract(
 	if !ok {
 		return []ValidationResult{v.newResult(
 			codeCH05, SeverityError, IssueRequired,
-			c.File, "endpoints.http.path",
+			c.File, fieldHTTPPath,
 			fmt.Sprintf(advHintCH05CorrelationFailed, c.ID),
 		)}
 	}
@@ -1004,7 +1009,7 @@ func (v *Validator) checkTypedEnvelopeForContract(
 	for _, status := range diffStatuses(declared, implemented) {
 		results = append(results, v.newResult(
 			codeCH06, SeverityError, IssueRequired,
-			c.File, fmt.Sprintf("endpoints.http.responses[%d]", status),
+			c.File, fmt.Sprintf(fieldHTTPResponsesFmt, status),
 			fmt.Sprintf("%s: contract declares status %d but generated types_gen.go has no matching typed"+
 				" response struct; fix: run `gocell generate contract --all` to regenerate typed response structs", c.ID, status),
 		))
@@ -1012,7 +1017,7 @@ func (v *Validator) checkTypedEnvelopeForContract(
 	for _, status := range diffStatuses(implemented, declared) {
 		results = append(results, v.newResult(
 			codeCH06, SeverityError, IssueRequired,
-			c.File, fmt.Sprintf("endpoints.http.responses[%d]", status),
+			c.File, fmt.Sprintf(fieldHTTPResponsesFmt, status),
 			fmt.Sprintf("%s: generated types_gen.go has typed response struct for status %d but contract.yaml"+
 				" does not declare it (orphan struct); fix: add responses[%d] to contract.yaml or rerun `gocell generate contract --all`",
 				c.ID, status, status),

--- a/kernel/governance/rules_http_test.go
+++ b/kernel/governance/rules_http_test.go
@@ -275,62 +275,86 @@ func handleSomething(w http.ResponseWriter, r *http.Request) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			root := t.TempDir()
-			const contractID = "http.test.v1"
-			sliceRelDir := "cells/testcell/slices/testslice"
-
-			// Write slice directory and handler file unless the test wants no handler.
-			sliceAbsDir := filepath.Join(root, sliceRelDir)
-			require.NoError(t, os.MkdirAll(sliceAbsDir, 0o755))
-			if !tc.noHandler && tc.handlerSrc != "" {
-				if tc.noAuthMount {
-					// Write handler src without auth.Mount boilerplate to test fail-closed.
-					path := filepath.Join(sliceAbsDir, "handler.go")
-					content := "package x\n\nimport \"net/http\"\nimport \"github.com/ghbvf/gocell/pkg/errcode\"\n\n" + tc.handlerSrc
-					require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
-				} else {
-					writeHandlerFile(t, sliceAbsDir, contractID, tc.handlerSrc)
-				}
-			}
-
-			project := makeProject(contractID, sliceRelDir)
-			if tc.noHandler {
-				// No slice registered → findHandlerFile returns "".
-				project = &metadata.ProjectMeta{
-					Cells:      map[string]*metadata.CellMeta{},
-					Slices:     map[string]*metadata.SliceMeta{},
-					Contracts:  map[string]*metadata.ContractMeta{},
-					Journeys:   map[string]*metadata.JourneyMeta{},
-					Assemblies: map[string]*metadata.AssemblyMeta{},
-				}
-			}
-
-			c := makeContract(contractID, "contracts/http/test/v1/contract.yaml", tc.responses)
-			if tc.name == "non-http contract is skipped" {
-				c.Kind = "event"
-			}
-
-			validator := NewValidator(project, root, clock.Real())
-			results := validator.CheckHTTPResponseAlignment([]*metadata.ContractMeta{c}, root)
-
-			var errs []ValidationResult
-			for _, r := range results {
-				if r.Severity == SeverityError {
-					errs = append(errs, r)
-				}
-			}
-			// CH-04 only emits SeverityError findings; extra declarations are
-			// intentionally not reported (see CodeContractHealthResponseAlignment doc).
-			require.Len(t, errs, len(tc.wantErrors), "error count mismatch")
-			for i, want := range tc.wantErrors {
-				assert.Contains(t, errs[i].Message, want)
-			}
-
-			if tc.noHandler {
-				assert.Empty(t, results, "expected no findings when no handler exists")
-			}
+			runCheckHTTPResponseAlignmentCase(t, tc.name, tc.handlerSrc, tc.responses, tc.wantErrors, tc.noHandler, tc.noAuthMount)
 		})
 	}
+}
+
+// runCheckHTTPResponseAlignmentCase exercises a single TestCheckHTTPResponseAlignment
+// table entry. Extracted to keep the parent test within cognitive complexity limits.
+func runCheckHTTPResponseAlignmentCase(
+	t *testing.T,
+	caseName, handlerSrc string,
+	responses map[int]metadata.HTTPResponseMeta,
+	wantErrors []string,
+	noHandler, noAuthMount bool,
+) {
+	t.Helper()
+	root := t.TempDir()
+	const contractID = "http.test.v1"
+	sliceRelDir := "cells/testcell/slices/testslice"
+
+	// Write slice directory and handler file unless the test wants no handler.
+	sliceAbsDir := filepath.Join(root, sliceRelDir)
+	require.NoError(t, os.MkdirAll(sliceAbsDir, 0o755))
+	writeHTTPAlignmentHandlerFile(t, sliceAbsDir, contractID, handlerSrc, noHandler, noAuthMount)
+
+	project := buildHTTPAlignmentProject(contractID, sliceRelDir, noHandler)
+
+	c := makeContract(contractID, "contracts/http/test/v1/contract.yaml", responses)
+	if caseName == "non-http contract is skipped" {
+		c.Kind = "event"
+	}
+
+	validator := NewValidator(project, root, clock.Real())
+	results := validator.CheckHTTPResponseAlignment([]*metadata.ContractMeta{c}, root)
+
+	var errs []ValidationResult
+	for _, r := range results {
+		if r.Severity == SeverityError {
+			errs = append(errs, r)
+		}
+	}
+	// CH-04 only emits SeverityError findings; extra declarations are
+	// intentionally not reported (see CodeContractHealthResponseAlignment doc).
+	require.Len(t, errs, len(wantErrors), "error count mismatch")
+	for i, want := range wantErrors {
+		assert.Contains(t, errs[i].Message, want)
+	}
+	if noHandler {
+		assert.Empty(t, results, "expected no findings when no handler exists")
+	}
+}
+
+// writeHTTPAlignmentHandlerFile writes the handler file for a CH-04 test case.
+func writeHTTPAlignmentHandlerFile(t *testing.T, sliceAbsDir, contractID, handlerSrc string, noHandler, noAuthMount bool) {
+	t.Helper()
+	if noHandler || handlerSrc == "" {
+		return
+	}
+	if noAuthMount {
+		// Write handler src without auth.Mount boilerplate to test fail-closed.
+		path := filepath.Join(sliceAbsDir, "handler.go")
+		content := "package x\n\nimport \"net/http\"\nimport \"github.com/ghbvf/gocell/pkg/errcode\"\n\n" + handlerSrc
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+		return
+	}
+	writeHandlerFile(t, sliceAbsDir, contractID, handlerSrc)
+}
+
+// buildHTTPAlignmentProject builds the project metadata for a CH-04 test case.
+func buildHTTPAlignmentProject(contractID, sliceRelDir string, noHandler bool) *metadata.ProjectMeta {
+	if noHandler {
+		// No slice registered → findHandlerFile returns "".
+		return &metadata.ProjectMeta{
+			Cells:      map[string]*metadata.CellMeta{},
+			Slices:     map[string]*metadata.SliceMeta{},
+			Contracts:  map[string]*metadata.ContractMeta{},
+			Journeys:   map[string]*metadata.JourneyMeta{},
+			Assemblies: map[string]*metadata.AssemblyMeta{},
+		}
+	}
+	return makeProject(contractID, sliceRelDir)
 }
 
 // writeGeneratedHandlerFile writes a minimal handler_gen.go under

--- a/kernel/governance/rules_misc_advisory.go
+++ b/kernel/governance/rules_misc_advisory.go
@@ -703,7 +703,12 @@ func formatVarSpecNames(vs *ast.ValueSpec) string {
 // =============================================================================
 
 const (
-	docNamingGuardRelPath    = "docs/architecture/naming-guard.yaml"
+	// docNamingGuardRelPath is the repo-relative path to the naming-guard config
+	// consumed by DOC-NAME-01.
+	docNamingGuardRelPath = "docs/architecture/naming-guard.yaml"
+
+	// durabilityModeHintSuffix is user-facing guidance appended to OUTGUARD-01
+	// error messages to steer authors toward the correct durabilityMode value.
 	durabilityModeHintSuffix = "(use demo for examples/tests, durable for production assemblies)"
 )
 

--- a/kernel/governance/rules_misc_advisory.go
+++ b/kernel/governance/rules_misc_advisory.go
@@ -302,7 +302,7 @@ func (v *Validator) validateOUTGUARD01() []ValidationResult {
 					fmt.Sprintf(
 						"cell %q has invalid durabilityMode %q; must be \"demo\" or \"durable\"; "+
 							"fix: set durabilityMode to demo or durable in the cell.yaml "+
-							"(use demo for examples/tests, durable for production assemblies)",
+							durabilityModeHintSuffix,
 						c.ID, c.DurabilityMode),
 				))
 			}
@@ -317,7 +317,7 @@ func (v *Validator) validateOUTGUARD01() []ValidationResult {
 					"cell %q declares %s consistency but has no durabilityMode; "+
 						"L2+ cells must declare durabilityMode: demo or durable; "+
 						"fix: add durabilityMode: demo or durabilityMode: durable to the cell.yaml "+
-						"(use demo for examples/tests, durable for production assemblies)",
+						durabilityModeHintSuffix,
 					c.ID, c.ConsistencyLevel),
 			))
 			continue
@@ -330,7 +330,7 @@ func (v *Validator) validateOUTGUARD01() []ValidationResult {
 				fmt.Sprintf(
 					"cell %q has invalid durabilityMode %q; must be \"demo\" or \"durable\"; "+
 						"fix: set durabilityMode to demo or durable in the cell.yaml "+
-						"(use demo for examples/tests, durable for production assemblies)",
+						durabilityModeHintSuffix,
 					c.ID, c.DurabilityMode),
 			))
 		}
@@ -702,7 +702,10 @@ func formatVarSpecNames(vs *ast.ValueSpec) string {
 // DOC-NAME-01 implementation (formerly rules_docs.go)
 // =============================================================================
 
-const docNamingGuardRelPath = "docs/architecture/naming-guard.yaml"
+const (
+	docNamingGuardRelPath    = "docs/architecture/naming-guard.yaml"
+	durabilityModeHintSuffix = "(use demo for examples/tests, durable for production assemblies)"
+)
 
 type docNamingGuardConfig struct {
 	Include      []string               `yaml:"include"`

--- a/kernel/governance/rules_ref.go
+++ b/kernel/governance/rules_ref.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
+const fieldBuildEntrypoint = "build.entrypoint"
+
 // validateREF01 checks that slice.belongsToCell references an existing cell.
 func (v *Validator) validateREF01() []ValidationResult {
 	var results []ValidationResult
@@ -185,7 +187,7 @@ func (v *Validator) validateREF10() []ValidationResult {
 			results = append(results, v.newResult(
 				codeREF10, SeverityError, IssueRequired,
 				assemblyFile(a),
-				"build.entrypoint",
+				fieldBuildEntrypoint,
 				fmt.Sprintf("assembly %q must have build.entrypoint; fix: set build.entrypoint to the main package path", a.ID),
 			))
 		}
@@ -211,7 +213,7 @@ func (v *Validator) validateREF11() []ValidationResult {
 			results = append(results, v.newResult(
 				codeREF11, SeverityError, IssueInvalid,
 				assemblyFile(a),
-				"build.entrypoint",
+				fieldBuildEntrypoint,
 				fmt.Sprintf("assembly %q build.entrypoint %q: path escapes project root;"+
 					" fix: use a path relative to the repository root", a.ID, a.Build.Entrypoint),
 			))
@@ -221,7 +223,7 @@ func (v *Validator) validateREF11() []ValidationResult {
 			results = append(results, v.newResult(
 				codeREF11, SeverityError, IssueRefNotFound,
 				assemblyFile(a),
-				"build.entrypoint",
+				fieldBuildEntrypoint,
 				fmt.Sprintf("assembly %q build.entrypoint %q does not exist;"+
 					" fix: create the entrypoint file or correct the path", a.ID, a.Build.Entrypoint),
 			))

--- a/kernel/governance/rules_topo.go
+++ b/kernel/governance/rules_topo.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
+const fieldContractUsagesRoleFmt = "contractUsages[%d].role"
+
 // validateTOPO01 checks that contractUsages[].role is valid for the contract's kind.
 func (v *Validator) validateTOPO01() []ValidationResult {
 	var results []ValidationResult
@@ -22,7 +24,7 @@ func (v *Validator) validateTOPO01() []ValidationResult {
 				results = append(results, v.newResult(
 					codeTOPO01, SeverityError, IssueInvalid,
 					sliceFile(s),
-					fmt.Sprintf("contractUsages[%d].role", i),
+					fmt.Sprintf(fieldContractUsagesRoleFmt, i),
 					fmt.Sprintf("role %q is not valid for contract kind %q (contract %q);"+
 						" fix: use a valid role for this contract kind", cu.Role, c.Kind, cu.Contract),
 				))
@@ -49,7 +51,7 @@ func (v *Validator) validateTOPO02() []ValidationResult {
 				results = append(results, v.newResult(
 					codeTOPO02, SeverityError, IssueMismatch,
 					sliceFile(s),
-					fmt.Sprintf("contractUsages[%d].role", i),
+					fmt.Sprintf(fieldContractUsagesRoleFmt, i),
 					fmt.Sprintf(
 						"slice %q (cell %q) has provider role %q but contract %q provider is %q;"+
 							" fix: move this slice to the owning cell or remove the provider role",
@@ -79,7 +81,7 @@ func (v *Validator) validateTOPO03() []ValidationResult {
 				results = append(results, v.newResult(
 					codeTOPO03, SeverityError, IssueMismatch,
 					sliceFile(s),
-					fmt.Sprintf("contractUsages[%d].role", i),
+					fmt.Sprintf(fieldContractUsagesRoleFmt, i),
 					fmt.Sprintf(
 						"slice %q (cell %q) has consumer role %q but is not in contract %q consumers %v;"+
 							" fix: add this cell to the contract's consumers or remove the consumer role from the slice",

--- a/kernel/governance/rules_verify.go
+++ b/kernel/governance/rules_verify.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	fieldCritCheckRefTmpl = "passCriteria[%d].checkRef"
+	fieldCritCheckRefTmpl    = "passCriteria[%d].checkRef"
+	fieldWaiversExpiresAtFmt = "verify.waivers[%d].expiresAt"
 
 	// defaultWaiverExpiryTruncation is the granularity used when comparing a
 	// waiver's expiresAt date against the current time. Day-level truncation
@@ -124,7 +125,7 @@ func (v *Validator) validateWaiverVERIFY02(file string, i int, w metadata.Waiver
 		results = append(results, v.newResult(
 			codeVERIFY02, SeverityError, IssueRequired,
 			file,
-			fmt.Sprintf("verify.waivers[%d].expiresAt", i),
+			fmt.Sprintf(fieldWaiversExpiresAtFmt, i),
 			fmt.Sprintf("waiver.expiresAt is required for contract %q; fix: add an expiresAt field (YYYY-MM-DD) to this waiver entry", w.Contract),
 		))
 		return results
@@ -134,7 +135,7 @@ func (v *Validator) validateWaiverVERIFY02(file string, i int, w metadata.Waiver
 		results = append(results, v.newResult(
 			codeVERIFY02, SeverityError, IssueInvalid,
 			file,
-			fmt.Sprintf("verify.waivers[%d].expiresAt", i),
+			fmt.Sprintf(fieldWaiversExpiresAtFmt, i),
 			fmt.Sprintf("waiver expiresAt %q is not a valid date (expected YYYY-MM-DD); fix: use a YYYY-MM-DD formatted date", w.ExpiresAt),
 		))
 		return results
@@ -143,7 +144,7 @@ func (v *Validator) validateWaiverVERIFY02(file string, i int, w metadata.Waiver
 		results = append(results, v.newResult(
 			codeVERIFY02, SeverityError, IssueInvalid,
 			file,
-			fmt.Sprintf("verify.waivers[%d].expiresAt", i),
+			fmt.Sprintf(fieldWaiversExpiresAtFmt, i),
 			fmt.Sprintf("waiver for contract %q expired on %s;"+
 				" fix: extend the waiver expiresAt or add a proper verify.contract entry", w.Contract, w.ExpiresAt),
 		))

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -4858,6 +4858,7 @@ func TestOUTGUARD01_InvalidDurabilityMode(t *testing.T) {
 	assert.Equal(t, SeverityError, got[0].Severity)
 	assert.Equal(t, IssueInvalid, got[0].IssueType)
 	assert.Contains(t, got[0].Message, "banana")
+	assert.Contains(t, got[0].Message, "use demo for examples/tests", "durabilityModeHintSuffix must appear in OUTGUARD-01 message")
 }
 
 // TestOUTGUARD01_InvalidDurabilityMode_L0L1 covers the L0/L1 branch: the field

--- a/kernel/metadata/meta_struct_guard_test.go
+++ b/kernel/metadata/meta_struct_guard_test.go
@@ -86,35 +86,41 @@ func checkStruct(t *testing.T, typ reflect.Type, path string, depth, maxDepth in
 	for i := range typ.NumField() {
 		f := typ.Field(i)
 		fieldPath := path + "." + f.Name
+		checkStructField(t, f, fieldPath)
+		// Recurse into struct fields (and slices/maps whose elements are structs).
+		recurseType(t, f.Type, fieldPath, depth+1, maxDepth)
+	}
+}
 
-		// Check for map[string]any / map[string]interface{} — these bypass
-		// KnownFields because all unknown keys are silently absorbed.
-		if isCatchallMap(f.Type) {
+// checkStructField asserts that a single struct field does not carry a
+// catch-all map type or a yaml:",inline" tag unless explicitly allowed.
+func checkStructField(t *testing.T, f reflect.StructField, fieldPath string) {
+	t.Helper()
+
+	// Check for map[string]any / map[string]interface{} — these bypass
+	// KnownFields because all unknown keys are silently absorbed.
+	if isCatchallMap(f.Type) {
+		if !allowedInlineFields[shortPath(fieldPath)] {
+			t.Errorf(
+				"field %s has type %s which acts as a catch-all and may bypass KnownFields(true); "+
+					"add to allowedInlineFields with justification if intentional",
+				fieldPath, f.Type,
+			)
+		}
+	}
+
+	// Check for yaml:",inline" — when combined with a map type (even
+	// map[string]string) it absorbs unknown YAML keys.
+	if tag, ok := f.Tag.Lookup("yaml"); ok {
+		if strings.Contains(tag, ",inline") {
 			if !allowedInlineFields[shortPath(fieldPath)] {
 				t.Errorf(
-					"field %s has type %s which acts as a catch-all and may bypass KnownFields(true); "+
+					"field %s has yaml:\",inline\" tag which absorbs unknown YAML keys and may bypass KnownFields(true); "+
 						"add to allowedInlineFields with justification if intentional",
-					fieldPath, f.Type,
+					fieldPath,
 				)
 			}
 		}
-
-		// Check for yaml:",inline" — when combined with a map type (even
-		// map[string]string) it absorbs unknown YAML keys.
-		if tag, ok := f.Tag.Lookup("yaml"); ok {
-			if strings.Contains(tag, ",inline") {
-				if !allowedInlineFields[shortPath(fieldPath)] {
-					t.Errorf(
-						"field %s has yaml:\",inline\" tag which absorbs unknown YAML keys and may bypass KnownFields(true); "+
-							"add to allowedInlineFields with justification if intentional",
-						fieldPath,
-					)
-				}
-			}
-		}
-
-		// Recurse into struct fields (and slices/maps whose elements are structs).
-		recurseType(t, f.Type, fieldPath, depth+1, maxDepth)
 	}
 }
 


### PR DESCRIPTION
## Summary

SonarCloud actionable findings cleanup for **kernel/governance + kernel/metadata** (Agent A1 of 6).

Fresh snapshot 2026-05-20 baseline (Quality Gate **OK**, 133 OPEN). This PR is one of 6 parallel cleanup PRs.

- Fixed: 11 findings
- STALE: 5 (S1135 TODO comments not present in current code)

## Findings 处理表

| # | Path | Line | Rule | Action |
|---|------|------|------|--------|
| 1 | `kernel/governance/rules_contract_test_mapping.go` | 234 | go:S1192 | `examplesPathPrefix` const |
| 2 | `kernel/governance/rules_fmt.go` | 950 | godre:S8205 | `responseSchemaDataInfo` + `responseSchemaPropertiesInfo` named types |
| 3 | `kernel/governance/rules_fmt_test.go` | 948 | go:S3776 CC=19 | `assertFMT32Result` helper extracted |
| 4 | `kernel/governance/rules_http.go` | 173 | go:S1192 | `fieldHTTPPath` const |
| 5 | `kernel/governance/rules_http.go` | 219 | go:S1192 | `fieldHTTPResponsesFmt` const |
| 6 | `kernel/governance/rules_http_test.go` | 120 | go:S3776 CC=29 | `runCheckHTTPResponseAlignmentCase` + 2 helpers (skip :837 CC=31 per H8) |
| 7-11 | `kernel/governance/rules_journey*.go` | various | go:S1135 | STALE (no TODO at listed lines) |
| 12 | `kernel/governance/rules_misc_advisory.go` | 305 | go:S1192 | `durabilityModeHintSuffix` const |
| 13 | `kernel/governance/rules_ref.go` | 188 | go:S1192 | `fieldBuildEntrypoint` const |
| 14 | `kernel/governance/rules_topo.go` | 25 | go:S1192 | `fieldContractUsagesRoleFmt` const |
| 15 | `kernel/governance/rules_verify.go` | 127 | go:S1192 | `fieldWaiversExpiresAtFmt` const |
| 16 | `kernel/metadata/meta_struct_guard_test.go` | 73 | go:S3776 CC=18 | `checkStructField` helper extracted |

ref: SonarCloud snapshot 2026-05-20T03:25Z (project ghbvf_gocell)

## Test plan

- [x] `go build ./...` pass
- [x] `go test ./kernel/governance/... ./kernel/metadata/...` pass
- [x] `go test ./tools/archtest/...` pass (153s)
- [x] `golangci-lint run ./...` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>