### PR TITLE
fix(sonar): kernel/assembly + cmd/{gocell,corebundle} CC split

### DIFF
--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -140,11 +140,11 @@ func (m AccessCoreModule) Provide(
 		accesscore.WithRefreshGC(time.Hour, defaultRefreshGCRetention),
 		accesscore.WithCASProtocol(casProto),
 	}
-	innerSessionStore, extraOpts, err := resolveAccessStorageOpts(shared, sessionProto, accessOpts)
+	innerSessionStore, storageOpts, err := resolveAccessStorageOpts(shared, sessionProto, accessOpts)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	accessOpts = extraOpts
+	accessOpts = storageOpts
 	// AUTH-CACHE-01 (T5): wrap the session store with a Redis read-through
 	// cache when env knob + Redis client are both present. Default-off — env
 	// unset / empty / non-positive / un-parseable Duration / nil Redis client

--- a/cmd/corebundle/access_module.go
+++ b/cmd/corebundle/access_module.go
@@ -140,36 +140,11 @@ func (m AccessCoreModule) Provide(
 		accesscore.WithRefreshGC(time.Hour, defaultRefreshGCRetention),
 		accesscore.WithCASProtocol(casProto),
 	}
-	var innerSessionStore session.Store
-	if shared.Topology.StorageBackend == "postgres" {
-		pgOpts, pgSessionStore, err := accessPostgresOptions(shared, sessionProto)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		innerSessionStore = pgSessionStore
-		accessOpts = append(accessOpts, pgOpts...)
-	} else {
-		// mem mode: WithMemBundle yields a (UserRepository, RoleRepository,
-		// SetupLock, store-paired TxRunner) quadruple all derived from the
-		// same backing mem.Store. The Bundle funnel makes mis-pairing (e.g.
-		// non-store-paired TxRunner) inexpressible at compile time and
-		// guarantees the cross-repo effective-admin invariant (S4.0) +
-		// store.mu serialization of concurrent first-admin provisioning.
-		sessionMemStore, err := session.NewMemStore(sessionProto, shared.Clock)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("accesscore: session.NewMemStore: %w", err)
-		}
-		refreshMemStore, err := refreshmem.New(accesscore.DefaultRefreshPolicy(), shared.Clock, nil)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("accesscore: refreshmem.New: %w", err)
-		}
-		innerSessionStore = sessionMemStore
-		accessOpts = append(
-			accessOpts,
-			accesscore.WithMemBundle(accessmem.NewBundle(shared.Clock)),
-			accesscore.WithRefreshStore(refreshMemStore),
-		)
+	innerSessionStore, extraOpts, err := resolveAccessStorageOpts(shared, sessionProto, accessOpts)
+	if err != nil {
+		return nil, nil, nil, err
 	}
+	accessOpts = extraOpts
 	// AUTH-CACHE-01 (T5): wrap the session store with a Redis read-through
 	// cache when env knob + Redis client are both present. Default-off — env
 	// unset / empty / non-positive / un-parseable Duration / nil Redis client
@@ -276,6 +251,43 @@ func accessPostgresOptions(shared *SharedDeps, sessionProto *session.Protocol) (
 		)
 	}
 	return accessOpts, pgSessionStore, nil
+}
+
+// resolveAccessStorageOpts selects postgres or memory storage options for
+// accesscore and returns the inner session.Store together with the updated
+// option slice. It is extracted from AccessCoreModule.Provide to keep that
+// function's cognitive complexity within the project limit.
+func resolveAccessStorageOpts(
+	shared *SharedDeps,
+	sessionProto *session.Protocol,
+	base []accesscore.Option,
+) (session.Store, []accesscore.Option, error) {
+	if shared.Topology.StorageBackend == "postgres" {
+		pgOpts, pgSessionStore, err := accessPostgresOptions(shared, sessionProto)
+		if err != nil {
+			return nil, nil, err
+		}
+		return pgSessionStore, append(base, pgOpts...), nil
+	}
+	// mem mode: WithMemBundle yields a (UserRepository, RoleRepository,
+	// SetupLock, store-paired TxRunner) quadruple all derived from the
+	// same backing mem.Store. The Bundle funnel makes mis-pairing (e.g.
+	// non-store-paired TxRunner) inexpressible at compile time and
+	// guarantees the cross-repo effective-admin invariant (S4.0) +
+	// store.mu serialization of concurrent first-admin provisioning.
+	sessionMemStore, err := session.NewMemStore(sessionProto, shared.Clock)
+	if err != nil {
+		return nil, nil, fmt.Errorf("accesscore: session.NewMemStore: %w", err)
+	}
+	refreshMemStore, err := refreshmem.New(accesscore.DefaultRefreshPolicy(), shared.Clock, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("accesscore: refreshmem.New: %w", err)
+	}
+	base = append(base,
+		accesscore.WithMemBundle(accessmem.NewBundle(shared.Clock)),
+		accesscore.WithRefreshStore(refreshMemStore),
+	)
+	return sessionMemStore, base, nil
 }
 
 // wrapSessionStoreWithCache decides whether to wrap inner with the

--- a/cmd/corebundle/config_module.go
+++ b/cmd/corebundle/config_module.go
@@ -50,8 +50,6 @@ var configStaleCipherOpts = prom.CounterOpts{
 // provisional resources that BuildApp must close if a subsequent module's
 // Provide fails. It reads configcore-specific environment variables directly
 // via the LoadPGConfig / LoadCursorKeys / LoadConfigCoreKeyProvider helpers.
-//
-//nolint:gocognit // B2-K-02: 16/15 — 7 linear if-err per-step env / pool / counter setup; split adds no readability gain.
 func (m ConfigCoreModule) Provide(
 	ctx context.Context, shared *SharedDeps,
 ) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
@@ -71,16 +69,9 @@ func (m ConfigCoreModule) Provide(
 	}
 
 	// 2. KeyProvider: read configcore-namespaced env (or use test override).
-	kp := m.KeyProviderOverride
-	if kp == nil {
-		providerName, masterKey, prevMasterKey := LoadConfigCoreKeyProvider()
-		kp, err = buildKeyProvider(
-			shared.Topology.StorageBackend, shared.Topology.AdapterMode,
-			providerName, masterKey, prevMasterKey, shared.Clock,
-		)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("configcore key provider: %w", err)
-		}
+	kp, err := resolveConfigKeyProvider(m.KeyProviderOverride, shared)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	vt := keyProviderToTransformer(kp)
 
@@ -113,23 +104,7 @@ func (m ConfigCoreModule) Provide(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	pgRes := modResult.PoolResource
-	cellOpts := modResult.CellOptions
-	relayOpts := modResult.BootstrapOpts
-	var opts []bootstrap.Option
-	var provisional []kernellifecycle.ManagedResource
-	if pgRes != nil {
-		opts = append(opts, bootstrap.WithManagedResource(pgRes))
-		provisional = append(provisional, pgRes)
-	}
-	rollback := func() {
-		for _, v := range slices.Backward(provisional) {
-			if closeErr := v.Close(ctx); closeErr != nil {
-				slog.Warn("configcore: provisional rollback close failed",
-					slog.Any("error", closeErr))
-			}
-		}
-	}
+
 	// Expose the pool through SharedDeps so AccessCoreModule + AuditCoreModule
 	// can wire their own outbox.Writer + TxManager from the same pool in
 	// postgres mode. In memory mode modResult.PGPool is nil — SharedPGPool
@@ -155,7 +130,52 @@ func (m ConfigCoreModule) Provide(
 		configcore.WithEventbusCacheCollector(shared.EventbusCacheCollector),
 		configcore.WithCASProtocol(casProto),
 	}
-	c := configcore.NewConfigCore(append(baseOpts, cellOpts...)...) //archtest:allow:clock-injection:via-slice WithClock in baseOpts
+	baseOpts = append(baseOpts, modResult.CellOptions...) //archtest:allow:clock-injection:via-slice WithClock in baseOpts
+	c := configcore.NewConfigCore(baseOpts...)
+
+	return buildConfigCoreResult(ctx, c, kp, shared, modResult)
+}
+
+// resolveConfigKeyProvider returns m.KeyProviderOverride when set, otherwise
+// builds the key provider from the environment. Extracted to reduce Provide's
+// cognitive complexity.
+func resolveConfigKeyProvider(override kcrypto.KeyProvider, shared *SharedDeps) (kcrypto.KeyProvider, error) {
+	if override != nil {
+		return override, nil
+	}
+	providerName, masterKey, prevMasterKey := LoadConfigCoreKeyProvider()
+	kp, err := buildKeyProvider(
+		shared.Topology.StorageBackend, shared.Topology.AdapterMode,
+		providerName, masterKey, prevMasterKey, shared.Clock,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("configcore key provider: %w", err)
+	}
+	return kp, nil
+}
+
+// buildConfigCoreResult wires the provisional resources, relay opts, and
+// key-provider managed resource, then registers Vault diagnostics. It is
+// extracted from Provide to keep that function's cognitive complexity within
+// the project limit.
+func buildConfigCoreResult(
+	ctx context.Context,
+	c cell.Cell,
+	kp kcrypto.KeyProvider,
+	shared *SharedDeps,
+	modResult ConfigCoreModuleResult,
+) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
+	var opts []bootstrap.Option
+	var provisional []kernellifecycle.ManagedResource
+
+	if modResult.PoolResource != nil {
+		opts = append(opts, bootstrap.WithManagedResource(modResult.PoolResource))
+		provisional = append(provisional, modResult.PoolResource)
+	}
+
+	rollback := func() {
+		closeProvisional(ctx, provisional)
+	}
 
 	// Register Vault diagnostics when the KeyProvider exposes them.
 	if err := registerKeyProviderMetrics(kp, shared); err != nil {
@@ -166,7 +186,8 @@ func (m ConfigCoreModule) Provide(
 
 	// Relay opts: in postgres mode, relayOpts contains WithManagedResource(relay)
 	// so the relay worker is independently managed by bootstrap (Worker/Close/Checkers).
-	opts = append(opts, relayOpts...)
+	opts = append(opts, modResult.BootstrapOpts...)
+
 	// A19: when the KeyProvider opts into lifecycle.ManagedResource (today:
 	// vault-transit via TransitKeyProvider.Checkers()["vault_transit_ready"]),
 	// register it with bootstrap so its probes flow into /readyz. Local-aes
@@ -178,6 +199,16 @@ func (m ConfigCoreModule) Provide(
 		provisional = append(provisional, kpRes)
 	}
 	return c, opts, provisional, nil
+}
+
+// closeProvisional closes managed resources in LIFO order, logging failures.
+func closeProvisional(ctx context.Context, resources []kernellifecycle.ManagedResource) {
+	for _, v := range slices.Backward(resources) {
+		if closeErr := v.Close(ctx); closeErr != nil {
+			slog.Warn("configcore: provisional rollback close failed",
+				slog.Any("error", closeErr))
+		}
+	}
 }
 
 var _ CellModule = ConfigCoreModule{}

--- a/cmd/corebundle/config_module.go
+++ b/cmd/corebundle/config_module.go
@@ -117,6 +117,7 @@ func (m ConfigCoreModule) Provide(
 	// constructor (CAS-PROTOCOL-COMPOSITION-ROOT-01 archtest enforces this).
 	casProto, err := newConfigCoreCASProtocol()
 	if err != nil {
+		shared.SharedPGPool = nil
 		return nil, nil, nil, err
 	}
 
@@ -173,6 +174,7 @@ func buildConfigCoreResult(
 		provisional = append(provisional, modResult.PoolResource)
 	}
 
+	// rollback is only invoked before kpRes append; if reordered, capture provisional through a function arg.
 	rollback := func() {
 		closeProvisional(ctx, provisional)
 	}

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -228,6 +228,12 @@ func runScaffold(ctx context.Context, args []string) error {
 	return runScaffoldWithRoot(ctx, root, args)
 }
 
+// scaffoldIDNote is the help-text note repeated for every scaffold sub-command
+// that accepts a --id flag subject to the no-dash identifier constraint.
+// Extracted to avoid duplicating the literal (go:S1192).
+const scaffoldIDNote = "Note: --id must match ^[a-z][a-z0-9]+$" +
+	" (lowercase letters and digits only, at least 2 chars; no dashes / underscores / dots)."
+
 // scaffoldSubcommands is the single source of truth for `gocell scaffold`
 // (see subcommand.go / CLI-UNIMPL-HIDE-01). The handler also takes the
 // resolved project root so tests drive a temp dir via runScaffoldWithRoot
@@ -243,7 +249,7 @@ var scaffoldSubcommands = []subcommand[func(ctx context.Context, root string, ar
 			"[--type=core|edge|support] [--level=L0..L4]",
 			"[--with-http] [--with-events] [--with-both]",
 			"[--skip-generate] [--dry-run]",
-			"Note: --id must match ^[a-z][a-z0-9]+$ (lowercase letters and digits only, at least 2 chars; no dashes / underscores / dots).",
+			scaffoldIDNote,
 		},
 		run: func(_ context.Context, root string, a []string) error { return scaffoldCell(root, a) },
 	},
@@ -252,7 +258,7 @@ var scaffoldSubcommands = []subcommand[func(ctx context.Context, root string, ar
 		help: []string{
 			"Create cells/<cellID>/slices/<id>/slice.yaml.",
 			"--id=<id> --cell=<cellID> [--dry-run]",
-			"Note: --id must match ^[a-z][a-z0-9]+$ (lowercase letters and digits only, at least 2 chars; no dashes / underscores / dots).",
+			scaffoldIDNote,
 		},
 		run: func(_ context.Context, root string, a []string) error { return scaffoldSlice(root, a) },
 	},
@@ -279,7 +285,7 @@ var scaffoldSubcommands = []subcommand[func(ctx context.Context, root string, ar
 			"Create assemblies/<id>/assembly.yaml + cmd/<id>/run.go + app.go.",
 			"--id=<id> --cells=<a,b,...> --team=<team> --role=<role>",
 			"[--deploy=k8s|compose|binary] (default: k8s) [--skip-generate] [--dry-run]",
-			"Note: --id must match ^[a-z][a-z0-9]+$ (lowercase letters and digits only, at least 2 chars; no dashes / underscores / dots).",
+			scaffoldIDNote,
 		},
 		run: func(_ context.Context, root string, a []string) error { return scaffoldAssembly(root, a) },
 	},

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -586,29 +586,41 @@ func (g *Generator) computeBoundaryContracts(cellSet map[string]bool) (exported,
 // classifyBoundary categorizes a single contract as exported, imported, or internal
 // relative to the assembly cell set.
 func classifyBoundary(contractID, provider string, consumers []string, cellSet, exportedSet, importedSet map[string]bool) {
-	providerInAssembly := cellSet[provider]
-
-	if providerInAssembly {
-		if len(consumers) == 0 {
+	if cellSet[provider] {
+		if isExportedContract(consumers, cellSet) {
 			exportedSet[contractID] = true
-		} else {
-			for _, c := range consumers {
-				if !cellSet[c] {
-					exportedSet[contractID] = true
-					break
-				}
-			}
+		}
+	} else {
+		if hasInternalConsumer(consumers, cellSet) {
+			importedSet[contractID] = true
 		}
 	}
+}
 
-	if !providerInAssembly {
-		for _, c := range consumers {
-			if cellSet[c] {
-				importedSet[contractID] = true
-				break
-			}
+// isExportedContract reports whether a provider-in-assembly contract is
+// exported: it has no consumers, or at least one consumer is outside the
+// assembly.
+func isExportedContract(consumers []string, cellSet map[string]bool) bool {
+	if len(consumers) == 0 {
+		return true
+	}
+	for _, c := range consumers {
+		if !cellSet[c] {
+			return true
 		}
 	}
+	return false
+}
+
+// hasInternalConsumer reports whether at least one consumer of a
+// provider-outside-assembly contract belongs to the assembly.
+func hasInternalConsumer(consumers []string, cellSet map[string]bool) bool {
+	for _, c := range consumers {
+		if cellSet[c] {
+			return true
+		}
+	}
+	return false
 }
 
 // collectSmokeTargets gathers all verify.smoke entries from cells in the assembly.

--- a/kernel/assembly/generator_scaffold_test.go
+++ b/kernel/assembly/generator_scaffold_test.go
@@ -753,45 +753,60 @@ func TestPlanAssemblyScaffold_ConflictDetection_AllSixSlots(t *testing.T) {
 		slotIdx := slotIdx
 		t.Run(rels[slotIdx], func(t *testing.T) {
 			t.Parallel()
-
-			root, pm := scaffoldTestProject(t)
-			gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
-
-			// 预置第 slotIdx 个文件
-			dir := filepath.Join(root, parentDirs[slotIdx])
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				t.Fatal(err)
-			}
-			name := filepath.Base(rels[slotIdx])
-			if err := os.WriteFile(filepath.Join(root, rels[slotIdx]), []byte("# preexisting\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			_ = name
-
-			plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
-				ID:        mustID(t, "slotasm"),
-				Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
-				OwnerTeam: "platform",
-				OwnerRole: "maintainer",
-			})
-			if err != nil {
-				t.Fatalf("PlanAssemblyScaffold: %v", err)
-			}
-			realRoot, _ := pathsafe.ResolveRoot(root)
-			writeErr := pathsafe.WritePlannedFiles(realRoot, mustPlanSet(t, plan), false)
-			if writeErr == nil {
-				t.Fatal("expected conflict error, got nil")
-			}
-
-			// 其他 5 个 slot 不应存在
-			for otherIdx, otherRel := range rels {
-				if otherIdx == slotIdx {
-					continue // 预置的不检查
-				}
-				if _, statErr := os.Stat(filepath.Join(root, otherRel)); statErr == nil {
-					t.Errorf("slot %d conflict: file must not exist: %s", slotIdx, otherRel)
-				}
-			}
+			runSlotConflictSubtest(t, slotIdx, rels, parentDirs)
 		})
+	}
+}
+
+// runSlotConflictSubtest pre-places the file at rels[slotIdx], asserts that
+// WritePlannedFiles returns a conflict error, and verifies that none of the
+// other slots were written. Extracted from
+// TestPlanAssemblyScaffold_ConflictDetection_AllSixSlots to reduce that
+// function's cognitive complexity.
+func runSlotConflictSubtest(t *testing.T, slotIdx int, rels []string, parentDirs []string) {
+	t.Helper()
+
+	root, pm := scaffoldTestProject(t)
+	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
+
+	// 预置第 slotIdx 个文件
+	dir := filepath.Join(root, parentDirs[slotIdx])
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, rels[slotIdx]), []byte("# preexisting\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
+		ID:        mustID(t, "slotasm"),
+		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		OwnerTeam: "platform",
+		OwnerRole: "maintainer",
+	})
+	if err != nil {
+		t.Fatalf("PlanAssemblyScaffold: %v", err)
+	}
+	realRoot, _ := pathsafe.ResolveRoot(root)
+	writeErr := pathsafe.WritePlannedFiles(realRoot, mustPlanSet(t, plan), false)
+	if writeErr == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+
+	// 其他 5 个 slot 不应存在
+	assertNoOtherSlots(t, root, slotIdx, rels)
+}
+
+// assertNoOtherSlots verifies that none of the slots other than slotIdx exist
+// in root after a failed write.
+func assertNoOtherSlots(t *testing.T, root string, slotIdx int, rels []string) {
+	t.Helper()
+	for otherIdx, otherRel := range rels {
+		if otherIdx == slotIdx {
+			continue // 预置的不检查
+		}
+		if _, statErr := os.Stat(filepath.Join(root, otherRel)); statErr == nil {
+			t.Errorf("slot %d conflict: file must not exist: %s", slotIdx, otherRel)
+		}
 	}
 }

--- a/kernel/assembly/hook_dispatcher.go
+++ b/kernel/assembly/hook_dispatcher.go
@@ -173,7 +173,7 @@ func newHookDispatcher(cfg dispatcherConfig) *hookDispatcher {
 // defer overhead because runtime channel sends never panic in that case.
 func (d *hookDispatcher) emit(e cell.HookEvent) {
 	defer func() {
-		if r := recover(); r != nil {
+		if recover() != nil {
 			// Send on closed channel after stop(). Count as queue_full
 			// because from the emitter's perspective the queue is
 			// unavailable.
@@ -199,7 +199,7 @@ func (d *hookDispatcher) emit(e cell.HookEvent) {
 // observer state.
 func (d *hookDispatcher) flush(timeout time.Duration) (ok bool) {
 	defer func() {
-		if r := recover(); r != nil {
+		if recover() != nil {
 			// Same recovery as emit: sending on a closed channel means the
 			// dispatcher has already stopped accepting events. A post-stop
 			// flush is therefore a no-op success for callers that only need

--- a/kernel/cell/mode_resolver_test.go
+++ b/kernel/cell/mode_resolver_test.go
@@ -228,23 +228,31 @@ func TestResolveEmitter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			outcome, err := cell.ResolveEmitter(tc.cfg)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil (outcome=%+v)", outcome)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if outcome.Emitter == nil {
-				t.Fatal("expected non-nil Emitter")
-			}
-			if outcome.Durable != tc.wantDurable {
-				t.Fatalf("Durable: got %v, want %v", outcome.Durable, tc.wantDurable)
-			}
+			assertResolveEmitter(t, tc.cfg, tc.wantErr, tc.wantDurable)
 		})
+	}
+}
+
+// assertResolveEmitter calls cell.ResolveEmitter and asserts the expected
+// outcome. Extracted from TestResolveEmitter to reduce that function's
+// cognitive complexity.
+func assertResolveEmitter(t *testing.T, cfg cell.EmitterConfig, wantErr bool, wantDurable bool) {
+	t.Helper()
+	outcome, err := cell.ResolveEmitter(cfg)
+	if wantErr {
+		if err == nil {
+			t.Fatalf("expected error, got nil (outcome=%+v)", outcome)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Emitter == nil {
+		t.Fatal("expected non-nil Emitter")
+	}
+	if outcome.Durable != wantDurable {
+		t.Fatalf("Durable: got %v, want %v", outcome.Durable, wantDurable)
 	}
 }
 


### PR DESCRIPTION
## Summary

SonarCloud actionable findings cleanup for **kernel/{cell test, assembly} + cmd/{gocell, corebundle}** (Agent A3 of 6).

Fresh snapshot 2026-05-20 baseline. This PR is one of 6 parallel cleanup PRs.

- Fixed: 8 findings
- STALE: 0
- Skipped (H5/H7 per plan): `kernel/cell/mode_resolver_test.go:266` CC=38, `cmd/gocell/app/signalrun_realsig_test.go:52` CC=33

## Findings 处理表

| # | Path | Line | Rule | Action |
|---|------|------|------|--------|
| 1 | `cmd/corebundle/access_module.go` | 70 | go:S3776 CC=16 | extract `resolveAccessStorageOpts` helper |
| 2 | `cmd/corebundle/config_module.go` | 55 | go:S3776 CC=16 | extract `resolveConfigKeyProvider` + `buildConfigCoreResult` + `closeProvisional` |
| 3 | `cmd/gocell/app/scaffold.go` | 246 | go:S1192 | `scaffoldIDNote` const |
| 4 | `kernel/assembly/generator.go` | 588 | go:S3776 CC=17 | extract `isExportedContract` + `hasInternalConsumer` |
| 5 | `kernel/assembly/generator_scaffold_test.go` | 738 | go:S3776 CC=24 | extract `runSlotConflictSubtest` + `assertNoOtherSlots` |
| 6 | `kernel/assembly/hook_dispatcher.go` | 176 | godre:S8193 | `if recover() != nil` direct expression |
| 7 | `kernel/assembly/hook_dispatcher.go` | 202 | godre:S8193 | same |
| 8 | `kernel/cell/mode_resolver_test.go` | 53 | go:S3776 CC=17 | extract `assertResolveEmitter` helper |

ref: SonarCloud snapshot 2026-05-20T03:25Z (project ghbvf_gocell)

## Test plan

- [x] `go build ./...` pass
- [x] `go test ./kernel/...` pass
- [x] `go test ./cmd/...` pass (sandbox tcp listen failures are pre-existing, ok with sandbox off)
- [x] `go test ./tools/archtest/...` pass
- [x] `golangci-lint run ./...` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>