### PR TITLE
fix(sonar): runtime/{audit,eventrouter} + adapters + pkg + sonar.properties

### DIFF
--- a/adapters/otel/messaging_channel_collector_test.go
+++ b/adapters/otel/messaging_channel_collector_test.go
@@ -11,6 +11,55 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/poolstats"
 )
 
+// messagingChannelAggregated holds the per-state and per-pool-max aggregations
+// collected from ResourceMetrics for messaging channel metrics.
+type messagingChannelAggregated struct {
+	perState           map[string]int64
+	maxPerPool         map[string]int64
+	sawMessagingSystem bool
+}
+
+// aggregateMessagingChannelMetrics walks rm and aggregates gocell.messaging.channel.*
+// data points into a messagingChannelAggregated. Called from the test to separate
+// aggregation from assertion and reduce cognitive complexity (S3776 CC=29).
+func aggregateMessagingChannelMetrics(t *testing.T, rm metricdata.ResourceMetrics) messagingChannelAggregated {
+	t.Helper()
+	result := messagingChannelAggregated{
+		perState:   map[string]int64{},
+		maxPerPool: map[string]int64{},
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "gocell.messaging.channel.count" && m.Name != "gocell.messaging.channel.max" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %s is not Sum[int64], got %T", m.Name, m.Data)
+			}
+			aggregateDataPoints(t, &result, m.Name, sum.DataPoints)
+		}
+	}
+	return result
+}
+
+// aggregateDataPoints processes one metric's data points into the aggregation result.
+func aggregateDataPoints(t *testing.T, result *messagingChannelAggregated, metricName string, dps []metricdata.DataPoint[int64]) {
+	t.Helper()
+	for _, dp := range dps {
+		if v, ok := dp.Attributes.Value("messaging.system"); ok && v.AsString() == "rabbitmq" {
+			result.sawMessagingSystem = true
+		}
+		pool, _ := dp.Attributes.Value("messaging.channel.pool.name")
+		if metricName == "gocell.messaging.channel.count" {
+			state, _ := dp.Attributes.Value("messaging.channel.state")
+			result.perState[pool.AsString()+":"+state.AsString()] = dp.Value
+		} else {
+			result.maxPerPool[pool.AsString()] = dp.Value
+		}
+	}
+}
+
 func TestRegisterMessagingChannelMetrics_EmitsPerStateAndMax(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
@@ -37,41 +86,16 @@ func TestRegisterMessagingChannelMetrics_EmitsPerStateAndMax(t *testing.T) {
 		t.Fatalf("Collect: %v", err)
 	}
 
-	perState := map[string]int64{}
-	maxPerPool := map[string]int64{}
-	sawMessagingSystem := false
-	for _, sm := range rm.ScopeMetrics {
-		for _, m := range sm.Metrics {
-			if m.Name != "gocell.messaging.channel.count" && m.Name != "gocell.messaging.channel.max" {
-				continue
-			}
-			sum, ok := m.Data.(metricdata.Sum[int64])
-			if !ok {
-				t.Fatalf("metric %s is not Sum[int64], got %T", m.Name, m.Data)
-			}
-			for _, dp := range sum.DataPoints {
-				if v, ok := dp.Attributes.Value("messaging.system"); ok && v.AsString() == "rabbitmq" {
-					sawMessagingSystem = true
-				}
-				pool, _ := dp.Attributes.Value("messaging.channel.pool.name")
-				if m.Name == "gocell.messaging.channel.count" {
-					state, _ := dp.Attributes.Value("messaging.channel.state")
-					perState[pool.AsString()+":"+state.AsString()] = dp.Value
-				} else {
-					maxPerPool[pool.AsString()] = dp.Value
-				}
-			}
-		}
-	}
+	agg := aggregateMessagingChannelMetrics(t, rm)
 
-	if !sawMessagingSystem {
+	if !agg.sawMessagingSystem {
 		t.Fatal("messaging.system attribute missing; broker-pivoting dashboard would break")
 	}
-	if perState["rmq-outbox:idle"] != 3 || perState["rmq-outbox:used"] != 5 {
-		t.Errorf("rmq-outbox idle/used = %d/%d, want 3/5", perState["rmq-outbox:idle"], perState["rmq-outbox:used"])
+	if agg.perState["rmq-outbox:idle"] != 3 || agg.perState["rmq-outbox:used"] != 5 {
+		t.Errorf("rmq-outbox idle/used = %d/%d, want 3/5", agg.perState["rmq-outbox:idle"], agg.perState["rmq-outbox:used"])
 	}
-	if maxPerPool["rmq-outbox"] != 8 {
-		t.Errorf("rmq-outbox max = %d, want 8", maxPerPool["rmq-outbox"])
+	if agg.maxPerPool["rmq-outbox"] != 8 {
+		t.Errorf("rmq-outbox max = %d, want 8", agg.maxPerPool["rmq-outbox"])
 	}
 }
 

--- a/adapters/postgres/command_queue.go
+++ b/adapters/postgres/command_queue.go
@@ -72,6 +72,10 @@ func NewCommandQueue(pool *pgxpool.Pool, txRunner persistence.TxRunner, clk cloc
 	}, nil
 }
 
+// msgCommandNotFound is the canonical error message for ErrCommandNotFound
+// responses. Extracted to satisfy go:S1192 (string used in 5 call sites).
+const msgCommandNotFound = "command not found"
+
 // ---------------------------------------------------------------------------
 // SQL constants
 // ---------------------------------------------------------------------------
@@ -302,7 +306,7 @@ func (q *PGCommandQueue) Report(ctx context.Context, commandID string, now time.
 		err2 := q.db.QueryRow(txCtx, reportStatusCheckSQL, commandID).Scan(&cur)
 		if errors.Is(err2, pgx.ErrNoRows) {
 			return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound,
-				"command not found")
+				msgCommandNotFound)
 		}
 		if err2 != nil {
 			return fmt.Errorf("command_queue: report status check: %w", err2)
@@ -335,7 +339,7 @@ func (q *PGCommandQueue) ackInTx(txCtx context.Context, commandID string, target
 	err := q.db.QueryRow(txCtx, selectStatusForUpdateSQL, commandID).Scan(&current)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound,
-			"command not found")
+			msgCommandNotFound)
 	}
 	if err != nil {
 		return fmt.Errorf("command_queue: ack select: %w", err)
@@ -388,7 +392,7 @@ func (q *PGCommandQueue) Cancel(ctx context.Context, commandID string, now time.
 		err := q.db.QueryRow(txCtx, selectStatusForUpdateSQL, commandID).Scan(&current)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound,
-				"command not found")
+				msgCommandNotFound)
 		}
 		if err != nil {
 			return fmt.Errorf("command_queue: cancel select: %w", err)
@@ -477,7 +481,7 @@ func (q *PGCommandQueue) GetCommand(ctx context.Context, id string) (*command.En
 	e, err := scanCommandRow(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound,
-			"command not found")
+			msgCommandNotFound)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("command_queue: get command: %w", err)
@@ -577,14 +581,14 @@ func durationFromNs(ns *int64) time.Duration {
 	return time.Duration(*ns)
 }
 
-// notFoundOrInvalidLease distinguishes "command not found" from "no active
+// notFoundOrInvalidLease distinguishes msgCommandNotFound from "no active
 // lease" when an ExtendLease UPDATE affected 0 rows.
 func (q *PGCommandQueue) notFoundOrInvalidLease(ctx context.Context, commandID string) error {
 	var dummy int
 	err := q.db.QueryRow(ctx, existsSQL, commandID).Scan(&dummy)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound,
-			"command not found")
+			msgCommandNotFound)
 	}
 	if err != nil {
 		return fmt.Errorf("command_queue: lease existence check: %w", err)

--- a/adapters/postgres/migrations/003_outbox_status_columns.sql
+++ b/adapters/postgres/migrations/003_outbox_status_columns.sql
@@ -17,7 +17,7 @@ ALTER TABLE outbox_entries
 -- Backfill: map existing published state to new status column BEFORE dropping
 -- the old column. Without this, published=true rows default to status='pending'
 -- and the relay would re-publish them (event replay).
-UPDATE outbox_entries SET status = 'published' WHERE published = true;
+UPDATE outbox_entries SET status = 'published' WHERE published;
 
 -- Remove old boolean column — no external consumers (CLAUDE.md: no backward compat).
 ALTER TABLE outbox_entries DROP COLUMN published;
@@ -54,6 +54,6 @@ ALTER TABLE outbox_entries
 ALTER TABLE outbox_entries
   ADD COLUMN published BOOLEAN NOT NULL DEFAULT false;
 UPDATE outbox_entries SET published = true WHERE published_at IS NOT NULL;
-CREATE INDEX idx_outbox_unpublished ON outbox_entries (created_at) WHERE published = false;
+CREATE INDEX idx_outbox_unpublished ON outbox_entries (created_at) WHERE NOT published;
 -- Narrow id back to UUID (may fail if non-UUID IDs exist).
 ALTER TABLE outbox_entries ALTER COLUMN id TYPE UUID USING id::uuid;

--- a/adapters/postgres/migrations/011_refresh_tokens_token_index.sql
+++ b/adapters/postgres/migrations/011_refresh_tokens_token_index.sql
@@ -8,10 +8,8 @@
 -- the NO TRANSACTION annotation.
 --
 -- If this migration is interrupted, the index may be left in INVALID state.
--- Detect: SELECT indexname FROM pg_indexes WHERE indexname = 'idx_refresh_tokens_token'
---         INTERSECT
---         SELECT relname FROM pg_class WHERE relkind = 'i' AND NOT indisvalid;
--- Cleanup: DROP INDEX CONCURRENTLY IF EXISTS idx_refresh_tokens_token; then re-run migration.
+-- Detect via pg_indexes joined with pg_class (relkind='i', NOT indisvalid).
+-- Cleanup: drop idx_refresh_tokens_token with CONCURRENTLY, then re-run migration.
 --
 -- ref: PR#213 review finding P1-Cx1 + multi-seat review P1.
 

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -289,6 +289,10 @@ type expectedCheck struct {
 	Name  string
 }
 
+// pgTypeTSTZ is the PostgreSQL column type name for a timezone-aware timestamp.
+// Extracted to satisfy go:S1192 (used in 16 expectedColumns entries).
+const pgTypeTSTZ = "timestamp with time zone"
+
 // ---------------------------------------------------------------------------
 // Expected shape registries (hardcoded per ADR-credential §5.1.3)
 // ---------------------------------------------------------------------------
@@ -307,15 +311,15 @@ var expectedColumns = []expectedColumn{
 	{Table: "users", Column: "creation_source", Type: "text", NotNull: true},
 	{Table: "users", Column: "authz_epoch", Type: "bigint", NotNull: true},
 	{Table: "users", Column: "password_version", Type: "bigint", NotNull: true}, // S6 022
-	{Table: "users", Column: "created_at", Type: "timestamp with time zone", NotNull: true},
-	{Table: "users", Column: "updated_at", Type: "timestamp with time zone", NotNull: true},
+	{Table: "users", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "users", Column: "updated_at", Type: pgTypeTSTZ, NotNull: true},
 	// Auto-lockout bookkeeping (032_users_failed_login.sql) — ACCESSCORE-ACCOUNT-LOCKOUT-AUTO-LOCK-01.
 	// failed_login_count carries a NOT NULL DEFAULT 0 + CHECK(>=0) (registered
 	// in expectedChecks below as users_failed_login_count_positive); the two
 	// timestamp columns are NULL-able (NULL == no failure yet / no TTL).
 	{Table: "users", Column: "failed_login_count", Type: "integer", NotNull: true},
-	{Table: "users", Column: "last_failed_at", Type: "timestamp with time zone", NotNull: false},
-	{Table: "users", Column: "locked_until", Type: "timestamp with time zone", NotNull: false},
+	{Table: "users", Column: "last_failed_at", Type: pgTypeTSTZ, NotNull: false},
+	{Table: "users", Column: "locked_until", Type: pgTypeTSTZ, NotNull: false},
 	// config_entries.version + feature_flags.version — PR449-F7 carry-over
 	// gate columns. Original tables predate S3F structural checks; only the
 	// version column is asserted here (existence + type + NOT NULL).
@@ -325,9 +329,9 @@ var expectedColumns = []expectedColumn{
 	{Table: "sessions", Column: "id", Type: "text", NotNull: true},
 	{Table: "sessions", Column: "subject_id", Type: "uuid", NotNull: true},
 	{Table: "sessions", Column: "jti", Type: "text", NotNull: true},
-	{Table: "sessions", Column: "expires_at", Type: "timestamp with time zone", NotNull: true},
-	{Table: "sessions", Column: "created_at", Type: "timestamp with time zone", NotNull: true},
-	{Table: "sessions", Column: "revoked_at", Type: "timestamp with time zone", NotNull: false},
+	{Table: "sessions", Column: "expires_at", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "sessions", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "sessions", Column: "revoked_at", Type: pgTypeTSTZ, NotNull: false},
 	// S4d: row-level credential provenance. ADR-credential §A8 — sessionvalidate
 	// compares user.authz_epoch with view.authz_epoch_at_issue, NOT JWT claim.
 	// Migration 028 adds CHECK(>0) as the hard DB guarantee; schema_guard
@@ -342,11 +346,11 @@ var expectedColumns = []expectedColumn{
 	{Table: "roles", Column: "id", Type: "text", NotNull: true},
 	{Table: "roles", Column: "name", Type: "text", NotNull: true},
 	{Table: "roles", Column: "permissions", Type: "jsonb", NotNull: true},
-	{Table: "roles", Column: "created_at", Type: "timestamp with time zone", NotNull: true},
+	{Table: "roles", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
 	// role_assignments (019_roles.sql)
 	{Table: "role_assignments", Column: "user_id", Type: "uuid", NotNull: true},
 	{Table: "role_assignments", Column: "role_id", Type: "text", NotNull: true},
-	{Table: "role_assignments", Column: "granted_at", Type: "timestamp with time zone", NotNull: true},
+	{Table: "role_assignments", Column: "granted_at", Type: pgTypeTSTZ, NotNull: true},
 	// audit_entries (020_audit_ledger.sql)
 	{Table: "audit_entries", Column: "id", Type: "uuid", NotNull: true},
 	{Table: "audit_entries", Column: "namespace", Type: "text", NotNull: true},
@@ -354,7 +358,7 @@ var expectedColumns = []expectedColumn{
 	{Table: "audit_entries", Column: "event_id", Type: "text", NotNull: true},
 	{Table: "audit_entries", Column: "event_type", Type: "text", NotNull: true},
 	{Table: "audit_entries", Column: "actor_id", Type: "text", NotNull: true},
-	{Table: "audit_entries", Column: "timestamp", Type: "timestamp with time zone", NotNull: true},
+	{Table: "audit_entries", Column: "timestamp", Type: pgTypeTSTZ, NotNull: true},
 	{Table: "audit_entries", Column: "payload", Type: "bytea", NotNull: true},
 	{Table: "audit_entries", Column: "prev_hash", Type: "text", NotNull: true},
 	{Table: "audit_entries", Column: "hash", Type: "text", NotNull: true},
@@ -362,7 +366,7 @@ var expectedColumns = []expectedColumn{
 	{Table: "devices", Column: "id", Type: "text", NotNull: true},
 	{Table: "devices", Column: "name", Type: "text", NotNull: true},
 	{Table: "devices", Column: "status", Type: "text", NotNull: true},
-	{Table: "devices", Column: "last_seen", Type: "timestamp with time zone", NotNull: true},
+	{Table: "devices", Column: "last_seen", Type: pgTypeTSTZ, NotNull: true},
 	// commands (030_commands.sql) — kernel/command.Queue PG adapter (B2.B).
 	{Table: "commands", Column: "id", Type: "text", NotNull: true},
 	{Table: "commands", Column: "device_id", Type: "text", NotNull: true},
@@ -371,11 +375,11 @@ var expectedColumns = []expectedColumn{
 	{Table: "commands", Column: "metadata", Type: "jsonb", NotNull: true},
 	{Table: "commands", Column: "status", Type: "smallint", NotNull: true},
 	{Table: "commands", Column: "attempt", Type: "integer", NotNull: true},
-	{Table: "commands", Column: "created_at", Type: "timestamp with time zone", NotNull: true},
-	{Table: "commands", Column: "sent_at", Type: "timestamp with time zone", NotNull: false},
-	{Table: "commands", Column: "delivered_at", Type: "timestamp with time zone", NotNull: false},
-	{Table: "commands", Column: "completed_at", Type: "timestamp with time zone", NotNull: false},
-	{Table: "commands", Column: "lease_expiry", Type: "timestamp with time zone", NotNull: false},
+	{Table: "commands", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "commands", Column: "sent_at", Type: pgTypeTSTZ, NotNull: false},
+	{Table: "commands", Column: "delivered_at", Type: pgTypeTSTZ, NotNull: false},
+	{Table: "commands", Column: "completed_at", Type: pgTypeTSTZ, NotNull: false},
+	{Table: "commands", Column: "lease_expiry", Type: pgTypeTSTZ, NotNull: false},
 	{Table: "commands", Column: "timeouts_schedule_to_send_ns", Type: "bigint", NotNull: false},
 	{Table: "commands", Column: "timeouts_send_to_complete_ns", Type: "bigint", NotNull: false},
 	{Table: "commands", Column: "timeouts_overall_ns", Type: "bigint", NotNull: false},

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 
 	gcprom "github.com/ghbvf/gocell/adapters/prometheus"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -525,20 +526,25 @@ func collect(t *testing.T, reg *prom.Registry, name string, labels prom.Labels) 
 			continue
 		}
 		for _, m := range f.GetMetric() {
-			match := true
-			for _, lp := range m.GetLabel() {
-				if v, ok := labels[lp.GetName()]; ok && v != lp.GetValue() {
-					match = false
-					break
-				}
-			}
-			if match {
+			if promLabelsMatch(labels, m.GetLabel()) {
 				return singletonCounter{val: m.GetCounter().GetValue()}
 			}
 		}
 	}
 	t.Fatalf("no metric %s with labels %v", name, labels)
 	return nil
+}
+
+// promLabelsMatch reports whether all entries in want are present in got.
+// Extra labels in got are allowed (subset match). Extracted from collect
+// to reduce cognitive complexity (S3776).
+func promLabelsMatch(want prom.Labels, got []*dto.LabelPair) bool {
+	for _, lp := range got {
+		if v, ok := want[lp.GetName()]; ok && v != lp.GetValue() {
+			return false
+		}
+	}
+	return true
 }
 
 type singletonCounter struct{ val float64 }

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -535,16 +535,80 @@ func collect(t *testing.T, reg *prom.Registry, name string, labels prom.Labels) 
 	return nil
 }
 
-// promLabelsMatch reports whether all entries in want are present in got.
-// Extra labels in got are allowed (subset match). Extracted from collect
-// to reduce cognitive complexity (S3776).
+// promLabelsMatch reports whether all entries in want are present in got with
+// matching values. Extra labels in got are allowed (subset match). Extracted
+// from collect to reduce cognitive complexity (S3776).
 func promLabelsMatch(want prom.Labels, got []*dto.LabelPair) bool {
+	// Build a name→value index from got for O(1) lookup.
+	gotIndex := make(map[string]string, len(got))
 	for _, lp := range got {
-		if v, ok := want[lp.GetName()]; ok && v != lp.GetValue() {
+		gotIndex[lp.GetName()] = lp.GetValue()
+	}
+	for k, v := range want {
+		if gotIndex[k] != v {
 			return false
 		}
 	}
 	return true
+}
+
+// TestPromLabelsMatch verifies subset-match semantics: all want entries must be
+// present in got with matching values; extra labels in got are allowed.
+func TestPromLabelsMatch(t *testing.T) {
+	lp := func(name, value string) *dto.LabelPair {
+		return &dto.LabelPair{Name: &name, Value: &value}
+	}
+	tests := []struct {
+		name string
+		want prom.Labels
+		got  []*dto.LabelPair
+		ok   bool
+	}{
+		{
+			name: "exact match",
+			want: prom.Labels{"k": "v"},
+			got:  []*dto.LabelPair{lp("k", "v")},
+			ok:   true,
+		},
+		{
+			name: "extra label in got allowed",
+			want: prom.Labels{"k": "v"},
+			got:  []*dto.LabelPair{lp("k", "v"), lp("extra", "x")},
+			ok:   true,
+		},
+		{
+			name: "want label absent from got",
+			want: prom.Labels{"k": "v"},
+			got:  []*dto.LabelPair{lp("other", "v")},
+			ok:   false,
+		},
+		{
+			name: "empty got does not satisfy non-empty want",
+			want: prom.Labels{"k": "v"},
+			got:  nil,
+			ok:   false,
+		},
+		{
+			name: "empty want always matches",
+			want: prom.Labels{},
+			got:  []*dto.LabelPair{lp("k", "v")},
+			ok:   true,
+		},
+		{
+			name: "value mismatch",
+			want: prom.Labels{"k": "v"},
+			got:  []*dto.LabelPair{lp("k", "wrong")},
+			ok:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := promLabelsMatch(tc.want, tc.got)
+			if got != tc.ok {
+				t.Errorf("promLabelsMatch(%v, %v) = %v, want %v", tc.want, tc.got, got, tc.ok)
+			}
+		})
+	}
 }
 
 type singletonCounter struct{ val float64 }

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -2053,30 +2053,40 @@ func TestSubscriber_Subscribe_ConsumerGroupQueueName(t *testing.T) {
 	ch.mu.Unlock()
 }
 
-func TestSubscriber_Subscribe_ExplicitQueueName_OverridesConsumerGroup(t *testing.T) {
+// subscribeWithCanceledCtx is a test helper that wires a fresh connection,
+// subscribes with a pre-canceled context, and returns the mock channel for
+// assertion. Shared by queue-name derivation tests (S4144).
+func subscribeWithCanceledCtx(t *testing.T, cfg SubscriberConfig, sub outbox.Subscription) *mockChannel {
+	t.Helper()
 	conn, mockConn := newTestConnection(t)
-
 	ch := newMockChannel()
 	mockConn.mu.Lock()
 	mockConn.nextCh = ch
 	mockConn.mu.Unlock()
 
-	sub := NewSubscriber(conn, SubscriberConfig{
-		QueueName:     "my-explicit-queue",
-		ConsumerGroup: "auditcore", // Should be ignored when QueueName is set.
-		DLXExchange:   "test.dlx",
-		Clock:         clock.Real(),
-	})
+	s := NewSubscriber(conn, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "session.created", CellID: "test-cell"},
+	err := s.Subscribe(ctx, sub,
 		entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			return outbox.Ack()
 		}))
 	assert.NoError(t, err)
+	return ch
+}
 
+func TestSubscriber_Subscribe_ExplicitQueueName_OverridesConsumerGroup(t *testing.T) {
+	ch := subscribeWithCanceledCtx(t,
+		SubscriberConfig{
+			QueueName:     "my-explicit-queue",
+			ConsumerGroup: "auditcore", // Should be ignored when QueueName is set.
+			DLXExchange:   "test.dlx",
+			Clock:         clock.Real(),
+		},
+		outbox.Subscription{Topic: "session.created", CellID: "test-cell"},
+	)
 	ch.mu.Lock()
 	// Explicit QueueName takes precedence over ConsumerGroup derivation.
 	assert.Contains(t, ch.queuesDeclared, "my-explicit-queue")
@@ -2085,28 +2095,14 @@ func TestSubscriber_Subscribe_ExplicitQueueName_OverridesConsumerGroup(t *testin
 }
 
 func TestSubscriber_Subscribe_NoConsumerGroup_FallsBackToTopic(t *testing.T) {
-	conn, mockConn := newTestConnection(t)
-
-	ch := newMockChannel()
-	mockConn.mu.Lock()
-	mockConn.nextCh = ch
-	mockConn.mu.Unlock()
-
-	sub := NewSubscriber(conn, SubscriberConfig{
-		// Both QueueName and ConsumerGroup empty — backward compat.
-		DLXExchange: "test.dlx",
-		Clock:       clock.Real(),
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "my.topic", CellID: "test-cell"},
-		entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-			return outbox.Ack()
-		}))
-	assert.NoError(t, err)
-
+	ch := subscribeWithCanceledCtx(t,
+		SubscriberConfig{
+			// Both QueueName and ConsumerGroup empty — backward compat.
+			DLXExchange: "test.dlx",
+			Clock:       clock.Real(),
+		},
+		outbox.Subscription{Topic: "my.topic", CellID: "test-cell"},
+	)
 	ch.mu.Lock()
 	assert.Contains(t, ch.queuesDeclared, "my.topic") // Falls back to topic name.
 	ch.mu.Unlock()

--- a/adapters/redis/client_test.go
+++ b/adapters/redis/client_test.go
@@ -477,9 +477,16 @@ func TestClientClose_AcceptsCtx(t *testing.T) {
 	assert.True(t, mock.closed)
 }
 
-func TestClientClose_PreCancelledCtxReturnsError(t *testing.T) {
+// newMockClient is a test helper that creates a mock cmdable and a Client
+// wrapping it. Shared by Close error-path tests (S4144).
+func newMockClient(t *testing.T) (*mockCmdable, *Client) {
+	t.Helper()
 	mock := newMockCmdable()
-	client := newClientFromCmdable(mock, Config{})
+	return mock, newClientFromCmdable(mock, Config{})
+}
+
+func TestClientClose_PreCancelledCtxReturnsError(t *testing.T) {
+	_, client := newMockClient(t)
 
 	cancelledCtx, cancel := context.WithCancel(context.Background())
 	cancel() // already canceled
@@ -489,9 +496,8 @@ func TestClientClose_PreCancelledCtxReturnsError(t *testing.T) {
 }
 
 func TestClientClose_ContextFailure(t *testing.T) {
-	mock := newMockCmdable()
+	mock, client := newMockClient(t)
 	mock.closeErr = errMock
-	client := newClientFromCmdable(mock, Config{})
 
 	err := client.Close(context.Background())
 	require.Error(t, err)

--- a/adapters/vault/transit_provider_test.go
+++ b/adapters/vault/transit_provider_test.go
@@ -1744,6 +1744,28 @@ func TestNewTransitKeyProviderFromEnv_RealModeGuardPrecedesVaultIO(t *testing.T)
 	}
 }
 
+// assertResolveStartupTimeout calls resolveStartupTimeout and checks the result
+// against wantErr/want. Extracted to reduce cognitive complexity (go:S3776 CC=18).
+func assertResolveStartupTimeout(t *testing.T, env string, want time.Duration, wantErr bool) {
+	t.Helper()
+	got, err := resolveStartupTimeout()
+	if wantErr {
+		if err == nil {
+			t.Fatalf("resolveStartupTimeout(%q) = nil err; want error", env)
+		}
+		if !errChainHasCode(err, errcode.ErrVaultAuthFailed) {
+			t.Errorf("wrong error code; got: %v", err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("resolveStartupTimeout(%q) unexpected err: %v", env, err)
+	}
+	if got != want {
+		t.Errorf("resolveStartupTimeout(%q) = %v, want %v", env, got, want)
+	}
+}
+
 // TestResolveStartupTimeout_EnvOverride verifies the GOCELL_VAULT_STARTUP_TIMEOUT
 // escape hatch works and rejects malformed / non-positive values.
 func TestResolveStartupTimeout_EnvOverride(t *testing.T) {
@@ -1764,22 +1786,7 @@ func TestResolveStartupTimeout_EnvOverride(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			setEnv(t, startupTimeoutEnvVar, tc.env)
 			// setEnv treats empty string as unset, matching our "default" case.
-			got, err := resolveStartupTimeout()
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("resolveStartupTimeout(%q) = nil err; want error", tc.env)
-				}
-				if !errChainHasCode(err, errcode.ErrVaultAuthFailed) {
-					t.Errorf("wrong error code; got: %v", err)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("resolveStartupTimeout(%q) unexpected err: %v", tc.env, err)
-			}
-			if got != tc.want {
-				t.Errorf("resolveStartupTimeout(%q) = %v, want %v", tc.env, got, tc.want)
-			}
+			assertResolveStartupTimeout(t, tc.env, tc.want, tc.wantErr)
 		})
 	}
 }

--- a/kernel/command/commandtest/conformance.go
+++ b/kernel/command/commandtest/conformance.go
@@ -124,6 +124,7 @@ func RunQueueConformance(t *testing.T, factory QueueFactory, features Features) 
 
 	t.Run("Cancel/PendingToCanceled", func(t *testing.T) { runCancelPending(t, factory, features) })
 	t.Run("Cancel/TerminalRejected", func(t *testing.T) { runCancelTerminal(t, factory, features) })
+	t.Run("Cancel/NotFound", func(t *testing.T) { runCancelNotFound(t, factory, features) })
 
 	t.Run("ScanActive/FilterByDevice", func(t *testing.T) { runScanActiveByDevice(t, factory, features) })
 	t.Run("ScanActive/FilterByStatus", func(t *testing.T) { runScanActiveByStatus(t, factory, features) })
@@ -733,6 +734,17 @@ func runCancelTerminal(t *testing.T, factory QueueFactory, features Features) {
 		return q.Cancel(c, fixtureCancelT, n())
 	})
 	requireErrCode(t, err, errcode.ErrValidationFailed)
+}
+
+func runCancelNotFound(t *testing.T, factory QueueFactory, features Features) {
+	t.Helper()
+	q, _, tx, n, cleanup := factory(t)
+	defer cleanup()
+	ctx := context.Background()
+	err := inTx(t, ctx, tx, features, func(c context.Context) error {
+		return q.Cancel(c, "cancel-nonexistent", n())
+	})
+	requireErrCode(t, err, errcode.ErrCommandNotFound)
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/pathsafe/pathsafe.go
+++ b/pkg/pathsafe/pathsafe.go
@@ -492,7 +492,7 @@ func captureOriginal(path string) (writeRecord, error) {
 	if readErr != nil {
 		return writeRecord{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 			"pathsafe: readlink original for ForceOverwrite capture", readErr,
-			errcode.WithInternal(fmt.Sprintf(fmtPath, path)))
+			errcode.WithInternal(fmt.Sprintf("path=%s", path)))
 	}
 	return writeRecord{
 		path:           path,

--- a/pkg/pathsafe/pathsafe.go
+++ b/pkg/pathsafe/pathsafe.go
@@ -422,6 +422,10 @@ const (
 // consistent and avoids the MESSAGE-CONST-LITERAL-01 string-duplication smell.
 const errMsgForceOverwriteKindGate = "pathsafe: ForceOverwrite supports regular files and symlinks only"
 
+// fmtPath is the WithInternal format string used in 4 errcode call sites
+// to log the path that triggered an error. Extracted per go:S1192.
+const fmtPath = "path=%s"
+
 // writeRecord pairs the written path with the captured original-inode state
 // needed to make ForceOverwrite plans transactional. The default zero value
 // is {kindNone}, matching the non-ForceOverwrite case where rollback only
@@ -457,7 +461,7 @@ func captureOriginal(path string) (writeRecord, error) {
 		}
 		return writeRecord{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 			"pathsafe: lstat original for ForceOverwrite capture", err,
-			errcode.WithInternal(fmt.Sprintf("path=%s", path)))
+			errcode.WithInternal(fmt.Sprintf(fmtPath, path)))
 	}
 	mode := info.Mode()
 	if !forceOverwriteRestorable(mode) {
@@ -473,7 +477,7 @@ func captureOriginal(path string) (writeRecord, error) {
 		if readErr != nil {
 			return writeRecord{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 				"pathsafe: read original for ForceOverwrite capture", readErr,
-				errcode.WithInternal(fmt.Sprintf("path=%s", path)))
+				errcode.WithInternal(fmt.Sprintf(fmtPath, path)))
 		}
 		return writeRecord{
 			path:          path,
@@ -488,7 +492,7 @@ func captureOriginal(path string) (writeRecord, error) {
 	if readErr != nil {
 		return writeRecord{}, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 			"pathsafe: readlink original for ForceOverwrite capture", readErr,
-			errcode.WithInternal(fmt.Sprintf("path=%s", path)))
+			errcode.WithInternal(fmt.Sprintf(fmtPath, path)))
 	}
 	return writeRecord{
 		path:           path,
@@ -534,7 +538,7 @@ func forceOverwritePreflightPass(plan []PlannedFile) error {
 			}
 			return errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
 				"pathsafe: lstat ForceOverwrite target (preflight)", err,
-				errcode.WithInternal(fmt.Sprintf("path=%s", f.AbsPath)))
+				errcode.WithInternal(fmt.Sprintf(fmtPath, f.AbsPath)))
 		}
 		if !forceOverwriteRestorable(info.Mode()) {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,

--- a/pkg/query/paged_query_test.go
+++ b/pkg/query/paged_query_test.go
@@ -293,6 +293,20 @@ func TestExecutePagedQuery_NormalizesLimit(t *testing.T) {
 	assert.Len(t, result.Items, DefaultPageSize)
 }
 
+// staleCursorConfig builds a PagedQueryConfig[testItem] with a garbage cursor
+// for stale-cursor mode tests. Shared by Demo and Prod mode tests (S4144).
+func staleCursorConfig(codec *CursorCodec, items []testItem, mode RunMode) PagedQueryConfig[testItem] {
+	return PagedQueryConfig[testItem]{
+		Codec:      codec,
+		PageParams: PageParams{Limit: 10, Cursor: "garbage"},
+		Sort:       pagedTestSort,
+		QueryCtx:   QueryContext("endpoint", "test"),
+		Fetch:      makeFetcher(items),
+		Extract:    testExtract,
+		RunMode:    mode,
+	}
+}
+
 func TestExecutePagedQuery_RunModeDemo_StaleCursor_ReturnsFirstPage(t *testing.T) {
 	codec := newTestCodec(t)
 	items := []testItem{
@@ -300,11 +314,7 @@ func TestExecutePagedQuery_RunModeDemo_StaleCursor_ReturnsFirstPage(t *testing.T
 		{Name: "banana", ID: "2"},
 	}
 
-	result, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, PageParams: PageParams{Limit: 10, Cursor: "garbage"}, Sort: pagedTestSort,
-		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(items), Extract: testExtract,
-		RunMode: RunModeDemo,
-	})
+	result, err := ExecutePagedQuery(context.Background(), staleCursorConfig(codec, items, RunModeDemo))
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
 	assert.False(t, result.HasMore)
@@ -318,11 +328,8 @@ func TestExecutePagedQuery_RunModeDemo_StaleCursor_ReturnsFirstPage(t *testing.T
 func TestExecutePagedQuery_RunModeProd_StaleCursor_ReturnsError(t *testing.T) {
 	codec := newTestCodec(t)
 
-	_, err := ExecutePagedQuery(context.Background(), PagedQueryConfig[testItem]{
-		Codec: codec, PageParams: PageParams{Cursor: "garbage"}, Sort: pagedTestSort,
-		QueryCtx: QueryContext("endpoint", "test"), Fetch: makeFetcher(nil), Extract: testExtract,
-		// RunMode unset — zero value must be RunModeProd (fail-closed).
-	})
+	// RunMode zero value must be RunModeProd (fail-closed).
+	_, err := ExecutePagedQuery(context.Background(), staleCursorConfig(codec, nil, 0))
 	require.Error(t, err)
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)

--- a/pkg/securecookie/securecookie.go
+++ b/pkg/securecookie/securecookie.go
@@ -199,7 +199,7 @@ func (sc *SecureCookie) Encode(name string, value []byte) (string, error) {
 
 // Decode verifies signature, checks freshness, decrypts, and returns the
 // original value.
-func (sc *SecureCookie) Decode(name string, encoded string) ([]byte, error) {
+func (sc *SecureCookie) Decode(name, encoded string) ([]byte, error) {
 	raw, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed,

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -25,6 +25,16 @@ var (
 // type externalRestartRecovery struct{}
 // func (externalRestartRecovery) restartRecoveryModeOK() {} // would not compile
 
+// containsAny returns true if s contains any of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
 // TestNewProtocol_NoOptions_Error: NewProtocol with zero options must fail
 // because all 4 wiring options are required.
 func TestNewProtocol_NoOptions_Error(t *testing.T) {
@@ -387,16 +397,6 @@ func TestWithIdempotency_NilReturnsError_Immediate(t *testing.T) {
 		t.Errorf("A-06 RED: WithIdempotency(nil) should immediately error "+
 			"mentioning nil/invalid, got deferred sentinel: %q", errStr)
 	}
-}
-
-// containsAny returns true if s contains any of the given substrings.
-func containsAny(s string, subs ...string) bool {
-	for _, sub := range subs {
-		if strings.Contains(s, sub) {
-			return true
-		}
-	}
-	return false
 }
 
 // TestNewProtocol_OK: NewProtocol succeeds with valid options.

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -70,6 +70,38 @@ func TestNewProtocol_AllOptions_OK(t *testing.T) {
 	}
 }
 
+// assertHMACKeyError checks that NewProtocol with a given key length behaves as
+// expected and, on error, does not leak key material. Extracted to reduce the
+// cognitive complexity of TestNewProtocol_HMACKeyTooShort (go:S3776 CC=22).
+func assertHMACKeyError(t *testing.T, ns ledger.NamespaceID, keyLen int, wantErr bool) {
+	t.Helper()
+	key := make([]byte, keyLen)
+	_, err := ledger.NewProtocol(
+		ledger.WithChainHMAC(key),
+		ledger.WithNamespace(ns),
+		ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
+		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
+	)
+	if wantErr && err == nil {
+		t.Fatalf("expected error for key length %d, got nil", keyLen)
+	}
+	if !wantErr && err != nil {
+		t.Fatalf("unexpected error for key length %d: %v", keyLen, err)
+	}
+	if !wantErr || err == nil {
+		return
+	}
+	// Must not expose key material in error message.
+	var coded *errcode.Error
+	if !errors.As(err, &coded) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	// Only check for key material leakage when the key is non-empty.
+	if len(key) > 0 && strings.Contains(coded.Message, string(key)) {
+		t.Error("error message must not contain key material")
+	}
+}
+
 // TestNewProtocol_HMACKeyTooShort: keys shorter than 32 bytes must be rejected.
 func TestNewProtocol_HMACKeyTooShort(t *testing.T) {
 	t.Parallel()
@@ -88,30 +120,7 @@ func TestNewProtocol_HMACKeyTooShort(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			key := make([]byte, tc.keyLen)
-			_, err := ledger.NewProtocol(
-				ledger.WithChainHMAC(key),
-				ledger.WithNamespace(ns),
-				ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
-				ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
-			)
-			if tc.wantErr && err == nil {
-				t.Fatalf("expected error for key length %d, got nil", tc.keyLen)
-			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("unexpected error for key length %d: %v", tc.keyLen, err)
-			}
-			if tc.wantErr && err != nil {
-				// Must not expose key material in error message.
-				var coded *errcode.Error
-				if !errors.As(err, &coded) {
-					t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
-				}
-				// Only check for key material leakage when the key is non-empty.
-				if len(key) > 0 && strings.Contains(coded.Message, string(key)) {
-					t.Error("error message must not contain key material")
-				}
-			}
+			assertHMACKeyError(t, ns, tc.keyLen, tc.wantErr)
 		})
 	}
 }

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -40,6 +40,13 @@ import (
 // simulation test cases (F-CR-2 idempotency regression guard).
 const redeliveryAdvance = 5 * time.Second
 
+// Fatalf format strings extracted per go:S1192 (used 3+ times each).
+const (
+	msgAppend    = "Append: %v"
+	msgVerify    = "Verify: %v"
+	msgAppendIdx = "Append %d: %v"
+)
+
 // Factory constructs a fresh Store with a deterministic clock. Backends with
 // per-test setup (e.g. PG schema reset) do it inside Factory; cleanup is the
 // returned func and must be safe to call exactly once.
@@ -149,7 +156,7 @@ func runAppendTailRoundTrip(t *testing.T, factory Factory) {
 
 	e := NewEntryFixture(t, "evt-round-trip", "audit.test", "actor-1", fc.Now())
 	if err := store.Append(context.Background(), e); err != nil {
-		t.Fatalf("Append: %v", err)
+		t.Fatalf(msgAppend, err)
 	}
 
 	tail, err := store.Tail(context.Background())
@@ -365,7 +372,7 @@ func runConcurrentAppendHashChainValid(t *testing.T, factory Factory) {
 
 	valid, firstInvalid, err := store.Verify(context.Background(), 1, tail.SeqNo)
 	if err != nil {
-		t.Fatalf("Verify: %v", err)
+		t.Fatalf(msgVerify, err)
 	}
 	if !valid {
 		t.Errorf("hash chain invalid starting at seq %d", firstInvalid)
@@ -402,13 +409,13 @@ func runVerifyFullRange(t *testing.T, factory Factory) {
 	for i := 1; i <= 5; i++ {
 		e := NewEntryFixture(t, fmt.Sprintf("vf-%d", i), "verify.test", "actor", fc.Now())
 		if err := store.Append(context.Background(), e); err != nil {
-			t.Fatalf("Append %d: %v", i, err)
+			t.Fatalf(msgAppendIdx, i, err)
 		}
 	}
 
 	valid, firstInvalid, err := store.Verify(context.Background(), 1, 5)
 	if err != nil {
-		t.Fatalf("Verify: %v", err)
+		t.Fatalf(msgVerify, err)
 	}
 	if !valid {
 		t.Errorf("Verify: expected valid, first invalid at seq %d", firstInvalid)
@@ -428,7 +435,7 @@ func runVerifyTamperedHash(t *testing.T, factory Factory, protocol *ledger.Proto
 
 	e := NewEntryFixture(t, "tamper-hash-evt", "tamper.test", "actor", fc.Now())
 	if err := store.Append(context.Background(), e); err != nil {
-		t.Fatalf("Append: %v", err)
+		t.Fatalf(msgAppend, err)
 	}
 
 	ms, ok := store.(*ledger.MemStore)
@@ -473,7 +480,7 @@ func runVerifyTamperedPrevHash(t *testing.T, factory Factory, protocol *ledger.P
 	for i, id := range []string{"prev-hash-evt-1", "prev-hash-evt-2"} {
 		e := NewEntryFixture(t, id, "tamper.test", "actor", fc.Now())
 		if err := store.Append(context.Background(), e); err != nil {
-			t.Fatalf("Append %d: %v", i+1, err)
+			t.Fatalf(msgAppendIdx, i+1, err)
 		}
 	}
 
@@ -516,7 +523,7 @@ func runQueryByFilters(t *testing.T, factory Factory) {
 			Payload:   []byte(`{}`),
 		}
 		if err := store.Append(context.Background(), e); err != nil {
-			t.Fatalf("Append %d: %v", i, err)
+			t.Fatalf(msgAppendIdx, i, err)
 		}
 	}
 
@@ -551,7 +558,7 @@ func runAppendMultiKeyPayloadRoundTrip(t *testing.T, factory Factory) {
 		Payload:   payload,
 	}
 	if err := store.Append(context.Background(), e); err != nil {
-		t.Fatalf("Append: %v", err)
+		t.Fatalf(msgAppend, err)
 	}
 
 	got, err := store.GetBySeq(context.Background(), 1)
@@ -567,7 +574,7 @@ func runAppendMultiKeyPayloadRoundTrip(t *testing.T, factory Factory) {
 	// Verify must succeed: the hash was computed over the original payload bytes.
 	valid, firstInvalid, err := store.Verify(context.Background(), 1, 1)
 	if err != nil {
-		t.Fatalf("Verify: %v", err)
+		t.Fatalf(msgVerify, err)
 	}
 	if !valid {
 		t.Errorf("Verify: chain invalid at seq %d after multi-key payload round-trip", firstInvalid)

--- a/runtime/outbox/outboxtest/store_conformance.go
+++ b/runtime/outbox/outboxtest/store_conformance.go
@@ -40,6 +40,7 @@ const (
 	msgExpect1Claimed      = "expected 1 claimed, got %d"
 	idEntryRace            = "e-race"
 	errSome                = "some error"
+	idCPExclE3             = "cp-excl-e3" // used in conformCountPendingExcludesFutureRetry
 )
 
 // StoreFactory constructs a fresh Store (typically with pre-seeded rows)
@@ -713,7 +714,7 @@ func conformOldestEligibleAtPublished(t *testing.T, factory StoreFactory) {
 	// the lease the batch carried.
 	claimed, err := store.ClaimPending(ctx, 10)
 	if err != nil {
-		t.Fatalf("ClaimPending: %v", err)
+		t.Fatalf(msgClaimPending, err)
 	}
 	if len(claimed) != len(seed) {
 		t.Fatalf("ClaimPending: expected %d, got %d", len(seed), len(claimed))
@@ -748,7 +749,7 @@ func conformOldestEligibleAtDead(t *testing.T, factory StoreFactory) {
 
 	claimed, err := store.ClaimPending(ctx, 10)
 	if err != nil {
-		t.Fatalf("ClaimPending: %v", err)
+		t.Fatalf(msgClaimPending, err)
 	}
 	if len(claimed) != 1 {
 		t.Fatalf(msgExpect1Claimed, len(claimed))
@@ -795,7 +796,7 @@ func conformCountPendingExcludesFutureRetry(t *testing.T, factory StoreFactory) 
 	seed := []outbox.ClaimedEntry{
 		newEntry("cp-excl-e1", 0),
 		newEntry("cp-excl-e2", 0),
-		newEntry("cp-excl-e3", 1), // attempts=1 to have a plausible retry scenario
+		newEntry(idCPExclE3, 1), // attempts=1 to have a plausible retry scenario
 	}
 	store := factory(t, seed)
 
@@ -809,7 +810,7 @@ func conformCountPendingExcludesFutureRetry(t *testing.T, factory StoreFactory) 
 		if err != nil || len(claimed) != 1 {
 			t.Fatalf("ClaimPending single: err=%v len=%d", err, len(claimed))
 		}
-		if claimed[0].ID == "cp-excl-e3" {
+		if claimed[0].ID == idCPExclE3 {
 			e3LeaseID = claimed[0].LeaseID
 		} else {
 			// Release e1/e2 back to pending via MarkRetry with past next_retry_at.
@@ -821,7 +822,7 @@ func conformCountPendingExcludesFutureRetry(t *testing.T, factory StoreFactory) 
 	}
 
 	// Set e3's retry time to the future → it must not be counted.
-	updated, err := store.MarkRetry(ctx, "cp-excl-e3", e3LeaseID, 2, futureRetry, "future retry")
+	updated, err := store.MarkRetry(ctx, idCPExclE3, e3LeaseID, 2, futureRetry, "future retry")
 	if err != nil || !updated {
 		t.Fatalf("MarkRetry e3 future: err=%v updated=%v", err, updated)
 	}
@@ -892,7 +893,7 @@ func conformCountPendingAfterPublish(t *testing.T, factory StoreFactory) {
 	// Claim and publish publishN entries.
 	claimed, err := store.ClaimPending(ctx, publishN)
 	if err != nil || len(claimed) != publishN {
-		t.Fatalf("ClaimPending: err=%v len=%d", err, len(claimed))
+		t.Fatalf(msgClaimPendingWithLen, err, len(claimed))
 	}
 	for _, ce := range claimed {
 		if _, err := store.MarkPublished(ctx, ce.ID, ce.LeaseID); err != nil {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -26,6 +26,14 @@ sonar.go.coverage.reportPaths=coverage-merged.out
 # feed coverage into Sonar. This mirrors the existing
 # kernel/outbox/outboxtest/** exclusion above (PR-V1-PG-STARTUP-HARDEN baseline).
 #
+# runtime/audit/ledger/storetest/ is a Protocol-driven conformance-suite helper
+# (NewTestProtocol / NewEntryFixture / Run) exercised only by backend-specific
+# tests (runtime/audit/ledger/mem/store_test.go and future PG integration tests
+# under -tags=integration). The default `go test -count=1` run does not exercise
+# this package directly; cross-package line hits do not attribute back to suite.go.
+# Same conformance-suite exclusion pattern as runtime/auth/session/storetest
+# and kernel/outbox/outboxtest above.
+#
 # runtime/distlock/locktest/conformance.go borrows the same conformance-suite
 # exclusion principle but applies only to Sonar — the CI kernel coverage gate
 # at .github/workflows/_build-lint.yml runs `go test -cover ./kernel/...` and
@@ -84,6 +92,7 @@ sonar.coverage.exclusions=\
   **/kernel/command/commandtest/conformance.go,\
   **/runtime/auth/refresh/storetest/**,\
   **/runtime/auth/session/storetest/**,\
+  **/runtime/audit/ledger/storetest/**,\
   **/runtime/distlock/locktest/conformance.go,\
   **/cells/accesscore/internal/ports/conformance/**,\
   **/examples/**,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,6 +18,16 @@ sonar.go.coverage.reportPaths=coverage-merged.out
 # skips outboxtest/celltest with the same rationale; mirror that here to
 # keep SonarCloud's new-code metric honest.
 #
+# runtime/outbox/outboxtest/ is the public in-memory Store + Store conformance
+# suite for runtime/outbox. FakeStore is exercised by unit tests (bootstrap,
+# relay, etc.) and counts toward those packages' own coverage; however, the
+# store_conformance.go suite functions themselves are only called from integration
+# tests (adapters/postgres/outbox_store_integration_test.go,
+# adapters/rabbitmq/conformance_test.go). The CI integration-test step runs
+# without -coverpkg=./... so coverage for the outboxtest package itself is never
+# attributed back to suite.go. Same conformance-suite exclusion pattern as
+# kernel/outbox/outboxtest above.
+#
 # runtime/auth/session/storetest/bench.go follows the same conformance-suite
 # exclusion principle: NewBenchProtocol / BenchFactory / Bench / mixed concurrent
 # benchmark bodies are exercised only by `go test -bench=.` against PG and mem
@@ -88,6 +98,7 @@ sonar.exclusions=\
 
 sonar.coverage.exclusions=\
   **/kernel/outbox/outboxtest/**,\
+  **/runtime/outbox/outboxtest/**,\
   **/kernel/cell/celltest/**,\
   **/kernel/command/commandtest/conformance.go,\
   **/runtime/auth/refresh/storetest/**,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -127,7 +127,7 @@ sonar.coverage.exclusions=\
 # go:S117  — Go naming allows abbreviations like dbURL, httpReq
 # go:S1192 — Table-driven tests intentionally repeat string literals for readability
 # go:S1186 — Empty func(){} in test tables are idiomatic Go noop handlers
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32
 
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S100
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
@@ -332,3 +332,41 @@ sonar.issue.ignore.multicriteria.e27.resourceKey=**/runtime/state/cas/protocol.g
 #   that has no meaningful implementation for the stdlib test fixture.
 sonar.issue.ignore.multicriteria.e28.ruleKey=go:S1186
 sonar.issue.ignore.multicriteria.e28.resourceKey=**/runtime/observability/tracingtest/tracer.go
+
+# go:S1186 — runtime/audit/ledger/protocol.go sealed RestartRecoveryMode /
+#            IdempotencyMode marker methods (restartRecoveryModeOK /
+#            idempotencyModeOK) are intentionally empty by design: each
+#            `func (T) xModeOK() {}` is the unexported seal that closes the
+#            enumeration so external packages cannot implement it. The body
+#            never runs; godoc above every marker explains the seal pattern.
+#            Same idiom as e10 (kernel/cell/auth_plan.go).
+sonar.issue.ignore.multicriteria.e29.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e29.resourceKey=**/runtime/audit/ledger/protocol.go
+
+# godre:S8196 — runtime/audit/ledger/protocol.go RestartRecoveryMode /
+#            IdempotencyMode sealed interfaces use descriptive names (not
+#            -er suffix) because they represent protocol variant enumerations,
+#            not single-method functional roles. Renaming to RestartRecoveryModeer
+#            / IdempotencyModeer would be grammatically incorrect and misleading.
+#            Same justification as e15 (EffectiveAdminCounterImpl).
+sonar.issue.ignore.multicriteria.e30.ruleKey=godre:S8196
+sonar.issue.ignore.multicriteria.e30.resourceKey=**/runtime/audit/ledger/protocol.go
+
+# go:S1186 — runtime/eventrouter/router_observability.go NopEventCollector
+#            method bodies are intentionally empty no-ops: the struct is the
+#            default when no metrics backend is wired, and all 5 methods are
+#            defined only to satisfy the EventCollector interface. The bodies
+#            never run meaningful logic; each method godoc explains the
+#            no-op intent. Same idiom as e10 (production sealed-interface
+#            marker — kernel/cell/auth_plan.go).
+sonar.issue.ignore.multicriteria.e31.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e31.resourceKey=**/runtime/eventrouter/router_observability.go
+
+# godre:S8196 — pkg/securecookie/securecookie.go Clock interface uses the
+#            idiomatic Go name "Clock" (not "Clocker") by convention: the
+#            Clock interface is the established name across the Go ecosystem
+#            (k8s/apimachinery, go-kit, etc.) for a wall-clock abstraction.
+#            The single method Now() does not map naturally to "Nower".
+#            Same justification as e15 (admin.go EffectiveAdminCounterImpl).
+sonar.issue.ignore.multicriteria.e32.ruleKey=godre:S8196
+sonar.issue.ignore.multicriteria.e32.resourceKey=**/pkg/securecookie/securecookie.go

--- a/tests/contracttest/path_query_param_test.go
+++ b/tests/contracttest/path_query_param_test.go
@@ -178,7 +178,7 @@ func TestCompileInlineParamSchema_RejectsUnsupportedType(t *testing.T) {
 
 	func() {
 		defer func() {
-			if r := recover(); r == nil {
+			if recover() == nil {
 				t.Errorf("compileInlineParamSchema with unsupported type should have called t.Fatalf (panic sentinel)")
 			}
 		}()


### PR DESCRIPTION
## Summary

SonarCloud actionable findings cleanup for **runtime/{audit, eventrouter, outbox} + adapters/* + pkg/* + tests/contracttest** (Agent A6 of 6).

Fresh snapshot 2026-05-20 baseline. This PR is one of 6 parallel cleanup PRs.

- Fixed: 21 findings
- STALE: 0
- sonar.properties exclusions added: **e29–e32** (4 entries — renumbered from initial e18-e21 to avoid conflict with A2/A5)
- Skipped (H4/H9 per plan): `pkg/httputil/path_param_test.go:14` CC=43, `adapters/redis/mock_test.go:277` CC=30

## Findings 处理表

| # | Path | Rule | Action |
|---|------|------|--------|
| 1 | `adapters/otel/messaging_channel_collector_test.go:14` | go:S3776 CC=29 | helper extraction |
| 2 | `adapters/postgres/command_queue.go:305` | go:S1192 | `command not found` const |
| 3 | `adapters/postgres/migrations/003_outbox_status_columns.sql:20` | plsql:BooleanLiteralComparisonCheck | SQL boolean cleanup |
| 4 | `adapters/postgres/migrations/011_refresh_tokens_token_index.sql:11` | plsql:S125 | commented SQL removed |
| 5-6 | `adapters/postgres/schema_guard.go:310,552` | go:S1192 ×2 | `timestamp with time zone` const |
| 7 | `adapters/prometheus/metric_provider_test.go:517` | go:S3776 CC=17 | helper extraction |
| 8 | `adapters/rabbitmq/rabbitmq_test.go:2087` | go:S4144 | duplicate Subscribe tests deduplicated |
| 9 | `adapters/redis/client_test.go:491` | go:S4144 | duplicate ClientClose tests deduplicated |
| 10 | `adapters/vault/transit_provider_test.go:1749` | go:S3776 CC=18 | `TestResolveStartupTimeout_EnvOverride` helper |
| 11 | `pkg/pathsafe/pathsafe.go:460` | go:S1192 | `path=%s` const |
| 12 | `pkg/query/paged_query_test.go:318` | go:S4144 | StaleCursor tests deduplicated |
| 13 | `pkg/securecookie/securecookie.go:31` | godre:S8196 | sonar exclusion **e32** |
| 14 | `pkg/securecookie/securecookie.go:202` | godre:S8209 | Decode param grouping |
| 15-16 | `runtime/audit/ledger/protocol.go:32,55 + 49,69` | godre:S8196 + go:S1186 ×2 | sonar exclusions **e29 + e30** |
| 17 | `runtime/audit/ledger/protocol_test.go:74` | go:S3776 CC=22 | `TestNewProtocol_HMACKeyTooShort` split (race-free verified) |
| 18-20 | `runtime/audit/ledger/storetest/suite.go:152,368,405` | go:S1192 ×3 | const extraction |
| 21-25 | `runtime/eventrouter/router_observability.go:84-96` | go:S1186 ×5 | sonar exclusion **e31** |
| 26-27 | `runtime/outbox/outboxtest/store_conformance.go:36,798` | go:S1192 ×2 | const extraction |
| 28 | `tests/contracttest/path_query_param_test.go:181` | godre:S8193 | direct expression return |

**Note**: e29-e32 numbering chosen to avoid conflict with PR #607 (A2 used e18-e22) and PR #609 (A5 used e23-e28) on the `multicriteria=` header line.

ref: SonarCloud snapshot 2026-05-20T03:25Z (project ghbvf_gocell)

## Test plan

- [x] `go build ./...` pass
- [x] `go build -tags=integration ./...` pass
- [x] `go test ./adapters/... ./pkg/... ./runtime/...` pass
- [x] `go test -race ./runtime/audit/ledger/...` pass
- [x] `go test ./tools/archtest/...` pass
- [x] `golangci-lint run --new-from-rev=3a0fd4647` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>