### PR TITLE
feat(outboxtest): add Recorder + realign plan 044 task 1 scope (PR0)

### DIFF
--- a/docs/plans/202605191943-044-journey-backlog-realignment.md
+++ b/docs/plans/202605191943-044-journey-backlog-realignment.md
@@ -216,26 +216,43 @@ func BuildAuditcoreChain(t *testing.T, opts ...BuildChainOption) (handler outbox
 func CanonicalSessionCreatedEntry(sessionID, userID string) outbox.Entry
 ```
 
-### 2.5 archtest 边界守卫（既有 TESTUTIL-BOUNDARY-01 已 cover）
+### 2.5 archtest 边界守卫（TESTUTIL-BOUNDARY-01 + CELLTEST-IMPORT-SCOPE-01）
 
-> **修订记录（PR0）**：原计划新建 `CELLTEST-IMPORT-SCOPE-01` archtest，PR0 实施前勘察发现既有 `tools/archtest/testutil_boundary_test.go` 的 `TESTUTIL-BOUNDARY-01` 已 cover 同一下游 ban — 其 `isTestInfraPath` 自动发现含 `testutil` 段或长度 > 4 的 `*test` 段的路径，`cells/{X}/{X}test/` 自动落入发现集，production 文件 import 立即失败。新建规则纯属重复造轮子，撤销。
+`CELLTEST-IMPORT-SCOPE-01` archtest 已在 PR0（feat/647-testutil-build-tag）落地，文件为
+`tools/archtest/celltest_import_scope_test.go`。
 
-既有规则形态摘要（供 review 核对，源在 `tools/archtest/testutil_boundary_test.go`）：
+**规则设计**：
 
-- discovery-based：扫描 module 内全部 .go 文件，按路径段匹配自动聚合 testutil/test-infra 包集合
-- 下游 ban：production .go 文件（非 `_test.go` 且非 test-infra 路径）import 该集合中任意包即 fail
-- 上游评级 path-pattern Medium：archtest 自动发现 + 路径段匹配，不依赖 hand-crafted allowlist
+- 扫描 module 内所有 production .go 文件（非 `_test.go` 且非 test-infra 路径）
+- 对每个 import 声明，检查是否匹配正则 `^github\.com/[^/]+/[^/]+/cells/[a-z]+/[a-z]+test$`
+- 命中即 fail，diagnostic 指向违规文件 + import 路径
 
-**与 plan 044 §0 软处理批评的关系**：build tag 全栈迁移（`//go:build testutil` + archtest 守 header consistency）能把上游从 path-pattern Medium 升到编译期 Hard，但代价是 50+ 既有 testutil 包统一改造 + 所有 `go test ./...` → `-tags=testutil` + CI/IDE 配置同步。任务 1 scope 内不做该迁移；若未来真要升级，作为独立 plan 处理而非 backlog 软处理。
+**与 TESTUTIL-BOUNDARY-01 的互补关系**：
+
+| 规则 | 覆盖形态 | 守卫路径举例 |
+|------|---------|------------|
+| TESTUTIL-BOUNDARY-01 | 含 `testutil` 段的路径 | `cells/{X}/internal/testutil/`、`pkg/testutil/` |
+| CELLTEST-IMPORT-SCOPE-01 | `cells/{X}/{X}test$` 命名形态 | `cells/configcore/configcoretest`、`cells/accesscore/accesscoretest` |
+
+TESTUTIL-BOUNDARY-01 的 `isTestInfraPath` 识别含 `testutil` 段或长度 > 4 的 `*test` 后缀段路径，
+但 `extractTestutilRoot` 严格按 `testutil` 段字面匹配，**不**识别 `*test` 后缀段 —— 因此
+`cells/{X}/{X}test/` 的 import ban 依赖本规则独立补充。
+
+**AI-rebust 评级**：
+
+- **下游 Hard**：archtest path-pattern match（正则锁 import 路径字面值，无字符串锚点，violation 形态唯一）
+- **上游 Medium**：archtest 自动发现 production 文件，路径段匹配，未达 codegen funnel Hard（生产代码无法编译期阻止 import ——需 sealed interface 才能升 Hard）
+- **整体 Medium**：满足 ai-collab.md §"立项硬门槛" ≥ Medium 要求
 
 ### 2.6 验证
 
 ```
-go test ./kernel/outbox/outboxtest/... -run='^TestRecorder'    # PR0
-go test ./cells/configcore/configcoretest/...                  # PR A
-go test ./cells/accesscore/accesscoretest/...                  # PR B
-go test ./cells/auditcore/auditcoretest/...                    # PR C
-go test ./tools/archtest/ -run='^TestLayerTestutil$'           # 既有规则回归覆盖新增 *test/ 包
+go test ./kernel/outbox/outboxtest/... -race -run='^TestRecorder'   # PR0 recorder + 并发安全
+go test ./cells/configcore/configcoretest/...                       # PR A
+go test ./cells/accesscore/accesscoretest/...                       # PR B
+go test ./cells/auditcore/auditcoretest/...                         # PR C
+go test ./tools/archtest/ -run='^TestLayerTestutil$'                # 既有规则回归覆盖新增 *test/ 包
+go test ./tools/archtest/ -run='^TestCelltestImportScope$'          # PR0 新增规则
 ```
 
 解锁的后续工作：

--- a/docs/plans/202605191943-044-journey-backlog-realignment.md
+++ b/docs/plans/202605191943-044-journey-backlog-realignment.md
@@ -111,17 +111,18 @@ cells/configcore/configcoretest/
 ├── doc.go                  # 包级 godoc：用途 + 与 production wiring 的关系 + import 范围约束
 ├── builders.go             # BuildWriteService / BuildSubscribeService
 ├── fakes.go                # FakeConfigRepository
-├── outbox_recorder.go      # OutboxRecorder（捕获 emitter.Emit 调用）
 └── builders_test.go        # testutil 自身的单元测试
 ```
+
+> OutboxRecorder 不在本包内重复实现。复用 PR0 提供的 `kernel/outbox/outboxtest.Recorder`（路径含 `*test` 段，已被 `TESTUTIL-BOUNDARY-01` 自动 cover production-import 边界）。
 
 公开 API：
 
 ```go
-// BuildWriteService 构造 docker-free 的 configwrite.Service + 关联 OutboxRecorder。
-// 默认装配：FakeConfigRepository（in-memory map） + DemoCellTxManager + OutboxRecorder 替代 NoopEmitter + DiscardHandler logger + clock.Real。
+// BuildWriteService 构造 docker-free 的 configwrite.Service + 关联 Recorder。
+// 默认装配：FakeConfigRepository（in-memory map） + DemoCellTxManager + outboxtest.NewRecorder() 替代 NoopEmitter + DiscardHandler logger + clock.Real。
 // opts 允许覆盖任一组件，但不暴露 internal/ports 类型 — 走 testutil 包自定义 BuildWriteOption 类型。
-func BuildWriteService(t *testing.T, opts ...BuildWriteOption) (*configwrite.Service, *OutboxRecorder)
+func BuildWriteService(t *testing.T, opts ...BuildWriteOption) (*configwrite.Service, *outboxtest.Recorder)
 
 // BuildSubscribeService 构造 docker-free 的 configsubscribe.Service。
 // 默认装配：clockmock.New(testAnchor) + DiscardHandler logger + NopMetrics + TombstoneTTL=defaultTombstoneTTL。
@@ -140,15 +141,6 @@ func NewFakeConfigRepository() *FakeConfigRepository
 func (r *FakeConfigRepository) Snapshot() []domain.ConfigEntry        // 当前所有 entries 拷贝
 func (r *FakeConfigRepository) CallsOf(method string) []FakeCall      // 方法调用记录（含参数）
 func (r *FakeConfigRepository) Reset()                                // 清空状态 + 调用记录
-
-// OutboxRecorder 实现 outbox.Emitter 接口，捕获所有 Emit 调用供断言。
-type OutboxRecorder struct { /* ... */ }
-func NewOutboxRecorder() *OutboxRecorder
-func (r *OutboxRecorder) Entries() []outbox.Entry                     // 按 Emit 顺序返回
-func (r *OutboxRecorder) EntriesByType(eventType string) []outbox.Entry
-func (r *OutboxRecorder) Reset()
-// 实现 outbox.Emitter
-func (r *OutboxRecorder) Emit(ctx context.Context, entry outbox.Entry) error
 ```
 
 ### 2.3 `cells/accesscore/accesscoretest/` 包设计
@@ -157,12 +149,15 @@ func (r *OutboxRecorder) Emit(ctx context.Context, entry outbox.Entry) error
 ```
 cells/accesscore/accesscoretest/
 ├── doc.go
-├── builders.go             # BuildConfigReceiveService / BuildIdentityManageService
-├── fake_config_getter.go   # FakeConfigGetter
-├── fake_user_repo.go       # FakeUserRepo
-├── fake_rbac_assign.go     # FakeRbacAssign
+├── builders.go                  # BuildConfigReceiveService / BuildIdentityManageService
+├── fake_config_getter.go        # FakeConfigGetter
+├── fake_user_repo.go            # FakeUserRepo
+├── fake_role_repo.go            # FakeRoleRepo
+├── credential_invalidator.go    # 真 *credentialinvalidate.Invalidator 构造 helper（不 Fake，详见下方说明）
 └── ...
 ```
+
+> Ports lock（PR A 实施前已勘察 lock）：accesscore `internal/ports/` 实际暴露的 interface 是 `ConfigGetter` / `UserRepository` / `RoleRepository`；**不存在** `RbacAssign` / `CredentialInvalidator` 名字。`identitymanage.NewService` 第二参数是 concrete `*credentialinvalidate.Invalidator`（非 interface），不可 Fake — testutil 构造真实例，其内部依赖（如有）才 Fake。
 
 公开 API：
 
@@ -188,9 +183,20 @@ func (r *FakeUserRepo) SeedUser(u domain.User)
 func (r *FakeUserRepo) Snapshot() []domain.User
 func (r *FakeUserRepo) CallsOf(method string) []FakeCall
 
-// BuildIdentityManageService 构造 identitymanage.Service + 关联 FakeUserRepo + FakeRbacAssign + OutboxRecorder。
-// 默认装配能让 identitymanage.Service.Create 端到端跑通（DemoCellTxManager + FakeUserRepo + FakeCredentialInvalidator + OutboxRecorder）。
-func BuildIdentityManageService(t *testing.T, opts ...BuildIdentityManageOption) (*identitymanage.Service, *FakeUserRepo, *OutboxRecorder)
+// FakeRoleRepo 实现 internal/ports.RoleRepository（identitymanage / rbacassign 依赖）。
+type FakeRoleRepo struct { /* ... */ }
+func NewFakeRoleRepo() *FakeRoleRepo
+func (r *FakeRoleRepo) SeedAssignment(userID, roleID string)
+func (r *FakeRoleRepo) Snapshot() map[string][]string                 // userID → roleIDs
+func (r *FakeRoleRepo) CallsOf(method string) []FakeCall
+
+// NewCredentialInvalidator 构造真 *credentialinvalidate.Invalidator 实例（不 Fake）。
+// 默认依赖装配：clockmock.New(testAnchor) + DiscardHandler logger + Fake 子依赖（按实际签名 PR B day 1 lock）。
+func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption) *credentialinvalidate.Invalidator
+
+// BuildIdentityManageService 构造 identitymanage.Service + 关联 FakeUserRepo + FakeRoleRepo + Recorder。
+// 默认装配能让 identitymanage.Service.Create 端到端跑通（DemoCellTxManager + FakeUserRepo + 真 Invalidator + outboxtest.NewRecorder()）。
+func BuildIdentityManageService(t *testing.T, opts ...BuildIdentityManageOption) (*identitymanage.Service, *FakeUserRepo, *FakeRoleRepo, *outboxtest.Recorder)
 ```
 
 ### 2.4 `cells/auditcore/auditcoretest/` 包设计
@@ -210,31 +216,26 @@ func BuildAuditcoreChain(t *testing.T, opts ...BuildChainOption) (handler outbox
 func CanonicalSessionCreatedEntry(sessionID, userID string) outbox.Entry
 ```
 
-### 2.5 archtest `CELLTEST-IMPORT-SCOPE-01`
+### 2.5 archtest 边界守卫（既有 TESTUTIL-BOUNDARY-01 已 cover）
 
-新文件 `tools/archtest/celltest_import_scope_test.go`，包级 godoc 写 `// INVARIANT: CELLTEST-IMPORT-SCOPE-01`。
+> **修订记录（PR0）**：原计划新建 `CELLTEST-IMPORT-SCOPE-01` archtest，PR0 实施前勘察发现既有 `tools/archtest/testutil_boundary_test.go` 的 `TESTUTIL-BOUNDARY-01` 已 cover 同一下游 ban — 其 `isTestInfraPath` 自动发现含 `testutil` 段或长度 > 4 的 `*test` 段的路径，`cells/{X}/{X}test/` 自动落入发现集，production 文件 import 立即失败。新建规则纯属重复造轮子，撤销。
 
-规则形态（typed-aware，使用 `archtest.RunTyped` + `internal/typeseval.ResolvePackageRef`）：
+既有规则形态摘要（供 review 核对，源在 `tools/archtest/testutil_boundary_test.go`）：
 
-```
-扫所有 production .go 文件（!_test.go，排除 *test/ 包自身的 _test.go）的 import 声明，
-若 import path 匹配 `cells/[a-z]+/[a-z]+test` → fail。
-扫所有 _test.go 文件无约束（允许 import {X}test）。
-```
+- discovery-based：扫描 module 内全部 .go 文件，按路径段匹配自动聚合 testutil/test-infra 包集合
+- 下游 ban：production .go 文件（非 `_test.go` 且非 test-infra 路径）import 该集合中任意包即 fail
+- 上游评级 path-pattern Medium：archtest 自动发现 + 路径段匹配，不依赖 hand-crafted allowlist
 
-funnel 双向锁评级：
-- **下游 Hard**：archtest type-aware import scope 校验，production code import {X}test 不可表达（编译期不阻挡，archtest CI 阻挡）
-- **上游 Medium**：{X}test 包内可调 internal/ports 是 Go 屏障语法允许的（cell 子树内自包），没有更强约束让"production 包不可调 {X}test"在编译期阻挡。未来升级路径 = build tag 隔离（`//go:build testutil` 标 {X}test 文件，production build 不编译），登记触发型 backlog（不在本 plan 范围）
-
-RED fixture：`tools/archtest/internal/celltestimportscopefixture/`，包含两个 .go 文件：
-- `production_violator.go` — `import "github.com/ghbvf/gocell/cells/configcore/configcoretest"`，期望被规则识别
-- `test_legitimate_test.go` — 同 import，期望放过
+**与 plan 044 §0 软处理批评的关系**：build tag 全栈迁移（`//go:build testutil` + archtest 守 header consistency）能把上游从 path-pattern Medium 升到编译期 Hard，但代价是 50+ 既有 testutil 包统一改造 + 所有 `go test ./...` → `-tags=testutil` + CI/IDE 配置同步。任务 1 scope 内不做该迁移；若未来真要升级，作为独立 plan 处理而非 backlog 软处理。
 
 ### 2.6 验证
 
 ```
-go test ./cells/configcore/configcoretest/... ./cells/accesscore/accesscoretest/... ./cells/auditcore/auditcoretest/...
-go test ./tools/archtest/ -run='^TestCelltestImportScope$'
+go test ./kernel/outbox/outboxtest/... -run='^TestRecorder'    # PR0
+go test ./cells/configcore/configcoretest/...                  # PR A
+go test ./cells/accesscore/accesscoretest/...                  # PR B
+go test ./cells/auditcore/auditcoretest/...                    # PR C
+go test ./tools/archtest/ -run='^TestLayerTestutil$'           # 既有规则回归覆盖新增 *test/ 包
 ```
 
 解锁的后续工作：

--- a/kernel/outbox/outboxtest/recorder.go
+++ b/kernel/outbox/outboxtest/recorder.go
@@ -1,0 +1,73 @@
+package outboxtest
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// Recorder is an in-memory outbox.Emitter that captures every entry passed to
+// Emit for later assertion.
+//
+// Use Recorder in cell-level unit tests as a drop-in for the production
+// transactional / direct emitter when the test cares about *what* was emitted
+// rather than *how* it is delivered. It is concurrency-safe — production
+// Emitter implementations are invoked from multiple goroutines (transactional
+// writer + direct publishers), and tests that exercise those code paths must
+// not race on the recorder.
+//
+// Plan 044 task 1 (PR0): Recorder is the canonical producer-side seam for
+// `semanticForm: producer-side` journey criteria. See
+// docs/plans/202605191943-044-journey-backlog-realignment.md §2.
+//
+// ref: ThreeDotsLabs/watermill pubsub/gochannel — in-memory implementation
+// used by upstream conformance tests for producer-side assertions.
+type Recorder struct {
+	mu      sync.Mutex
+	entries []outbox.Entry
+}
+
+// NewRecorder returns an empty Recorder.
+func NewRecorder() *Recorder { return &Recorder{} }
+
+// Emit captures entry. Always returns nil — Recorder does not simulate
+// emit-time failures; tests that need fail-injection should compose a custom
+// outbox.Emitter that wraps Recorder.
+func (r *Recorder) Emit(_ context.Context, entry outbox.Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, entry)
+	return nil
+}
+
+// Entries returns a defensive copy of the captured entries in Emit order.
+// Mutating the returned slice does not affect the Recorder's internal state.
+func (r *Recorder) Entries() []outbox.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]outbox.Entry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
+
+// EntriesByType returns entries whose EventType equals the given value, in
+// Emit order. Returns a defensive copy.
+func (r *Recorder) EntriesByType(eventType string) []outbox.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]outbox.Entry, 0, len(r.entries))
+	for _, e := range r.entries {
+		if e.EventType == eventType {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Reset clears all captured entries.
+func (r *Recorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = nil
+}

--- a/kernel/outbox/outboxtest/recorder.go
+++ b/kernel/outbox/outboxtest/recorder.go
@@ -1,3 +1,10 @@
+// Package outboxtest provides an in-memory outbox.Emitter for use in cell-level
+// unit tests.
+//
+// Use in tests only — package name follows the "*test" test-infrastructure
+// convention; production code must not import this package (enforced by
+// tools/archtest/celltest_import_scope_test.go for the cells/*/*test/ naming
+// pattern and by tools/archtest/testutil_boundary_test.go for *testutil paths).
 package outboxtest
 
 import (
@@ -17,6 +24,12 @@ import (
 // writer + direct publishers), and tests that exercise those code paths must
 // not race on the recorder.
 //
+// Recorder does NOT implement outbox.DurabilityReporter. Its durability
+// semantics are equivalent to outbox.NoopEmitter — entries are captured
+// in-memory with no persistence guarantee. Tests that need to validate L2
+// outbox durability paths (transactional write + relay confirmation) should use
+// outbox.NewWriterEmitter backed by a mem writer instead of Recorder.
+//
 // Plan 044 task 1 (PR0): Recorder is the canonical producer-side seam for
 // `semanticForm: producer-side` journey criteria. See
 // docs/plans/202605191943-044-journey-backlog-realignment.md §2.
@@ -34,32 +47,41 @@ func NewRecorder() *Recorder { return &Recorder{} }
 // Emit captures entry. Always returns nil — Recorder does not simulate
 // emit-time failures; tests that need fail-injection should compose a custom
 // outbox.Emitter that wraps Recorder.
+//
+// Context is accepted but not inspected. Recorder captures entries as-is
+// without injecting observability fields from ctx; tests that assert
+// ctx-derived metadata (trace_id, span_id) must use a real emitter with a
+// test Publisher.
 func (r *Recorder) Emit(_ context.Context, entry outbox.Entry) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.entries = append(r.entries, entry)
+	r.entries = append(r.entries, deepCopyEntry(entry))
 	return nil
 }
 
-// Entries returns a defensive copy of the captured entries in Emit order.
-// Mutating the returned slice does not affect the Recorder's internal state.
+// Entries returns a deep copy of captured entries in Emit order; mutating the
+// returned slice, including each entry's Payload and Metadata fields, does not
+// affect the Recorder.
 func (r *Recorder) Entries() []outbox.Entry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	out := make([]outbox.Entry, len(r.entries))
-	copy(out, r.entries)
+	for i, e := range r.entries {
+		out[i] = deepCopyEntry(e)
+	}
 	return out
 }
 
 // EntriesByType returns entries whose EventType equals the given value, in
-// Emit order. Returns a defensive copy.
+// Emit order. Returns a deep copy; mutating the returned slice, including each
+// entry's Payload and Metadata fields, does not affect the Recorder.
 func (r *Recorder) EntriesByType(eventType string) []outbox.Entry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	out := make([]outbox.Entry, 0, len(r.entries))
 	for _, e := range r.entries {
 		if e.EventType == eventType {
-			out = append(out, e)
+			out = append(out, deepCopyEntry(e))
 		}
 	}
 	return out
@@ -70,4 +92,22 @@ func (r *Recorder) Reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.entries = nil
+}
+
+// deepCopyEntry returns a copy of e where the Payload and Metadata reference
+// fields are independently allocated. nil Payload and nil Metadata are
+// preserved as nil.
+func deepCopyEntry(e outbox.Entry) outbox.Entry {
+	out := e
+	if e.Payload != nil {
+		out.Payload = make([]byte, len(e.Payload))
+		copy(out.Payload, e.Payload)
+	}
+	if e.Metadata != nil {
+		out.Metadata = make(map[string]string, len(e.Metadata))
+		for k, v := range e.Metadata {
+			out.Metadata[k] = v
+		}
+	}
+	return out
 }

--- a/kernel/outbox/outboxtest/recorder_test.go
+++ b/kernel/outbox/outboxtest/recorder_test.go
@@ -1,0 +1,96 @@
+package outboxtest_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/outbox/outboxtest"
+)
+
+func TestRecorderImplementsEmitter(t *testing.T) {
+	var _ outbox.Emitter = outboxtest.NewRecorder()
+}
+
+func TestRecorderEmitCapturesEntries(t *testing.T) {
+	r := outboxtest.NewRecorder()
+	ctx := context.Background()
+
+	e1 := outbox.Entry{ID: "id-1", EventType: "user.created.v1", Payload: []byte(`{"u":1}`)}
+	e2 := outbox.Entry{ID: "id-2", EventType: "session.created.v1", Payload: []byte(`{"s":1}`)}
+
+	require.NoError(t, r.Emit(ctx, e1))
+	require.NoError(t, r.Emit(ctx, e2))
+
+	entries := r.Entries()
+	require.Len(t, entries, 2)
+	assert.Equal(t, "id-1", entries[0].ID)
+	assert.Equal(t, "id-2", entries[1].ID)
+}
+
+func TestRecorderEntriesReturnsCopy(t *testing.T) {
+	r := outboxtest.NewRecorder()
+	require.NoError(t, r.Emit(context.Background(), outbox.Entry{ID: "x"}))
+
+	snapshot := r.Entries()
+	snapshot[0].ID = "MUTATED"
+
+	assert.Equal(t, "x", r.Entries()[0].ID,
+		"Entries() must return a defensive copy so callers cannot mutate internal state")
+}
+
+func TestRecorderEntriesByTypeFilters(t *testing.T) {
+	r := outboxtest.NewRecorder()
+	ctx := context.Background()
+	for _, e := range []outbox.Entry{
+		{ID: "a", EventType: "user.created.v1"},
+		{ID: "b", EventType: "session.created.v1"},
+		{ID: "c", EventType: "user.created.v1"},
+	} {
+		require.NoError(t, r.Emit(ctx, e))
+	}
+
+	users := r.EntriesByType("user.created.v1")
+	require.Len(t, users, 2)
+	assert.Equal(t, "a", users[0].ID)
+	assert.Equal(t, "c", users[1].ID)
+
+	assert.Empty(t, r.EntriesByType("nonexistent.v1"))
+}
+
+func TestRecorderReset(t *testing.T) {
+	r := outboxtest.NewRecorder()
+	require.NoError(t, r.Emit(context.Background(), outbox.Entry{ID: "x"}))
+	require.Len(t, r.Entries(), 1)
+
+	r.Reset()
+	assert.Empty(t, r.Entries())
+}
+
+// TestRecorderConcurrentEmit asserts the Recorder is safe for concurrent Emit
+// calls — required because production Emitter implementations are called from
+// multiple goroutines (transactional outbox writer + direct publishers).
+func TestRecorderConcurrentEmit(t *testing.T) {
+	r := outboxtest.NewRecorder()
+	ctx := context.Background()
+
+	const writers = 8
+	const perWriter = 100
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				_ = r.Emit(ctx, outbox.Entry{ID: "x"})
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, r.Entries(), writers*perWriter)
+}

--- a/kernel/outbox/outboxtest/recorder_test.go
+++ b/kernel/outbox/outboxtest/recorder_test.go
@@ -94,3 +94,92 @@ func TestRecorderConcurrentEmit(t *testing.T) {
 
 	assert.Len(t, r.Entries(), writers*perWriter)
 }
+
+// TestRecorderConcurrentMixedReadWrite asserts the Recorder is race-free under
+// concurrent Emit, Entries/EntriesByType reads, and Reset calls — mirroring the
+// real usage pattern where a transactional service emits while test goroutines
+// poll for captured entries.
+func TestRecorderConcurrentMixedReadWrite(t *testing.T) {
+	r := outboxtest.NewRecorder()
+	ctx := context.Background()
+
+	const (
+		writers   = 8
+		readers   = 4
+		resetters = 2
+		perOp     = 50
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers + resetters)
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perOp; j++ {
+				_ = r.Emit(ctx, outbox.Entry{
+					ID:        "w",
+					EventType: "user.created.v1",
+					Payload:   []byte(`{"id":1}`),
+					Metadata:  map[string]string{"k": "v"},
+				})
+			}
+		}()
+	}
+
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perOp; j++ {
+				_ = r.Entries()
+				_ = r.EntriesByType("user.created.v1")
+			}
+		}()
+	}
+
+	for i := 0; i < resetters; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perOp; j++ {
+				r.Reset()
+			}
+		}()
+	}
+
+	wg.Wait()
+	// No assertion on final count — Reset may have cleared entries. The race
+	// detector is the actual verification target; PASS without -race is trivial.
+}
+
+// TestRecorderEntriesByTypeDefensiveCopy asserts that mutating the slice
+// returned by EntriesByType — including Payload bytes and Metadata map entries
+// — does not affect the Recorder's internal state.
+func TestRecorderEntriesByTypeDefensiveCopy(t *testing.T) {
+	r := outboxtest.NewRecorder()
+	ctx := context.Background()
+
+	original := outbox.Entry{
+		ID:        "orig",
+		EventType: "user.created.v1",
+		Payload:   []byte(`{"u":1}`),
+		Metadata:  map[string]string{"key": "original"},
+	}
+	require.NoError(t, r.Emit(ctx, original))
+
+	// First call — mutate the returned copy aggressively.
+	snap := r.EntriesByType("user.created.v1")
+	require.Len(t, snap, 1)
+
+	snap[0].ID = "MUTATED_ID"
+	snap[0].Payload[0] = 0xFF
+	snap[0].Metadata["key"] = "mutated"
+	snap[0].Metadata["newkey"] = "extra"
+
+	// Second call — Recorder internal state must be pristine.
+	clean := r.EntriesByType("user.created.v1")
+	require.Len(t, clean, 1, "internal entries must not be removed by mutation")
+	assert.Equal(t, "orig", clean[0].ID, "ID must not be mutated via returned copy")
+	assert.Equal(t, []byte(`{"u":1}`), clean[0].Payload, "Payload must not be mutated via returned copy")
+	assert.Equal(t, map[string]string{"key": "original"}, clean[0].Metadata,
+		"Metadata must not be mutated via returned copy")
+}

--- a/tools/archtest/celltest_import_scope_test.go
+++ b/tools/archtest/celltest_import_scope_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// celltestImportPathPattern matches module-relative import paths of the form
-// cells/[a-z]+/[a-z]+test (e.g. cells/configcore/configcoretest). The pattern
-// anchors at the full path tail so that nested sub-packages
-// (cells/configcore/configcoretest/sub) are also caught.
+// celltestImportPathPattern matches module-relative import paths whose final
+// segment is `[a-z]+test` under cells/{X}/ (e.g. cells/configcore/configcoretest).
+// The trailing `$` anchors the match to the top-level testutil package — nested
+// sub-packages (cells/configcore/configcoretest/sub) are intentionally NOT
+// matched here; they should be ban-covered by their parent package's
+// boundary, which an importer must traverse through the matched root first.
 var celltestImportPathPattern = regexp.MustCompile(`^github\.com/[^/]+/[^/]+/cells/[a-z]+/[a-z]+test$`)
 
 // isCellTestImportPath reports whether an absolute import path matches the

--- a/tools/archtest/celltest_import_scope_test.go
+++ b/tools/archtest/celltest_import_scope_test.go
@@ -1,0 +1,191 @@
+// INVARIANT: CELLTEST-IMPORT-SCOPE-01: production Go files must not import
+// packages matching cells/[a-z]+/[a-z]+test$ — the cells/{X}/{X}test/
+// naming pattern designates test-infrastructure packages (cell-level testutil
+// with a "*test" suffix segment). This rule is complementary to
+// TESTUTIL-BOUNDARY-01 (tools/archtest/testutil_boundary_test.go) which
+// guards paths containing a "testutil" segment; CELLTEST-IMPORT-SCOPE-01
+// precisely guards the cells/*/*test/ naming form.
+package archtest
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// celltestImportPathPattern matches module-relative import paths of the form
+// cells/[a-z]+/[a-z]+test (e.g. cells/configcore/configcoretest). The pattern
+// anchors at the full path tail so that nested sub-packages
+// (cells/configcore/configcoretest/sub) are also caught.
+var celltestImportPathPattern = regexp.MustCompile(`^github\.com/[^/]+/[^/]+/cells/[a-z]+/[a-z]+test$`)
+
+// isCellTestImportPath reports whether an absolute import path matches the
+// cells/{X}/{X}test naming convention.
+//
+// Blind spots: the pattern matches the full path literal from the import
+// declaration; it does not follow type aliases or build-tag-gated imports.
+// Both of those forms are effectively impossible to use as a production import
+// without also triggering a Go compilation error, so they are acceptable
+// non-coverage.
+func isCellTestImportPath(importPath string) bool {
+	return celltestImportPathPattern.MatchString(importPath)
+}
+
+// TestCelltestImportScope enforces CELLTEST-IMPORT-SCOPE-01:
+//
+// No production Go file (i.e. NOT *_test.go and NOT in a test-infrastructure
+// directory) may import a package whose import path matches
+// cells/[a-z]+/[a-z]+test$. Those packages are cell-level testutil packages
+// and importing them from production code would embed test fixtures and
+// t-bound helpers in a release binary, signaling a layering mistake.
+//
+// Complementary rules:
+//   - TESTUTIL-BOUNDARY-01 (testutil_boundary_test.go): guards "testutil" segment paths.
+//   - This rule: guards the cells/*/*test/ naming form (e.g. cells/configcore/configcoretest).
+//
+// The check is discovery-based: any new cells/{X}/{X}test/ package is
+// automatically covered without further edits to this file.
+//
+// Blind spots (non-coverage outside declared rule scope):
+//   - Import aliases that rename the package after import: these require type
+//     resolution and are already an extremely rare pattern. If introduced, the
+//     rule file itself would need to evolve to typed analysis.
+//   - Build-tag-gated imports (//go:build ignore) that never compile: these
+//     are not production imports in practice and do not reach a release binary.
+func TestCelltestImportScope(t *testing.T) {
+	root := findModuleRoot(t)
+	modPath := readModulePath(t, root)
+
+	allGoFiles, err := collectGoFiles(root)
+	require.NoError(t, err, "failed to collect .go files")
+	require.NotEmpty(t, allGoFiles, "no .go files found — module root may be wrong")
+
+	var violations []string
+	for _, f := range allGoFiles {
+		// Skip _test.go — they are permitted to import test-infra packages.
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		rel, err := filepath.Rel(root, f)
+		require.NoError(t, err)
+		rel = filepath.ToSlash(rel)
+		// Skip test-infrastructure paths (outboxtest/, configcoretest/, etc.)
+		// — they may import sibling test packages.
+		if isTestInfraPath(rel) {
+			continue
+		}
+
+		imports, err := parseImports(f)
+		require.NoError(t, err, "failed to parse %s", f)
+		for _, imp := range imports {
+			if !strings.HasPrefix(imp, modPath+"/") {
+				continue
+			}
+			if isCellTestImportPath(imp) {
+				violations = append(violations,
+					fmt.Sprintf("CELLTEST-IMPORT-SCOPE-01: %s (production file) imports %s "+
+						"(cells/*/*test packages are test-infrastructure; only *_test.go or "+
+						"test-infra packages may import them)", rel, imp))
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		for _, v := range violations {
+			t.Logf("%s", v)
+		}
+	}
+	assert.Empty(t, violations,
+		"production (non-_test.go, non-test-infra) files must not import cells/*/*test packages; "+
+			"these packages embed test fixtures — import them only from *_test.go or test-infrastructure files")
+}
+
+// TestCelltestImportPath_PatternTable is a table-driven unit test for the
+// isCellTestImportPath helper. It also acts as the blind-spot self-check test
+// required by the AI-rebust chapter: each "outside declared scope" case is
+// explicitly listed and asserted to return false (non-matching), confirming the
+// rule does NOT attempt to cover those forms.
+func TestCelltestImportPath_PatternTable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		path      string
+		wantMatch bool
+	}{
+		// Positive: should match (violation)
+		{
+			name:      "configcoretest direct",
+			path:      "github.com/ghbvf/gocell/cells/configcore/configcoretest",
+			wantMatch: true,
+		},
+		{
+			name:      "accesscoretest direct",
+			path:      "github.com/ghbvf/gocell/cells/accesscore/accesscoretest",
+			wantMatch: true,
+		},
+		{
+			name:      "auditcoretest direct",
+			path:      "github.com/ghbvf/gocell/cells/auditcore/auditcoretest",
+			wantMatch: true,
+		},
+		// Negative: should NOT match (compliant / out-of-scope)
+		{
+			name:      "production cell package",
+			path:      "github.com/ghbvf/gocell/cells/configcore/slices/flagread",
+			wantMatch: false,
+		},
+		{
+			name:      "kernel package",
+			path:      "github.com/ghbvf/gocell/kernel/outbox",
+			wantMatch: false,
+		},
+		{
+			name:      "outboxtest (kernel, not cells)",
+			path:      "github.com/ghbvf/gocell/kernel/outbox/outboxtest",
+			wantMatch: false,
+		},
+		{
+			name:      "testutil path (covered by TESTUTIL-BOUNDARY-01)",
+			path:      "github.com/ghbvf/gocell/cells/configcore/internal/testutil",
+			wantMatch: false,
+		},
+		{
+			name:      "sub-package of celltest (blind spot — outside declared scope)",
+			path:      "github.com/ghbvf/gocell/cells/configcore/configcoretest/sub",
+			wantMatch: false,
+		},
+		{
+			name:      "runtime package",
+			path:      "github.com/ghbvf/gocell/runtime/auth",
+			wantMatch: false,
+		},
+		{
+			name:      "examples cell package",
+			path:      "github.com/ghbvf/gocell/examples/todoorder/cells/ordercore",
+			wantMatch: false,
+		},
+		{
+			name:      "std library",
+			path:      "context",
+			wantMatch: false,
+		},
+		{
+			name:      "third party",
+			path:      "github.com/stretchr/testify/assert",
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isCellTestImportPath(tc.path)
+			assert.Equal(t, tc.wantMatch, got, "isCellTestImportPath(%q)", tc.path)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `kernel/outbox/outboxtest.Recorder`：in-memory `outbox.Emitter`，捕获 Emit 调用供 producer-side journey criterion 测试断言（并发安全 + race-test 覆盖）
- 新增 archtest `CELLTEST-IMPORT-SCOPE-01`：禁止 production 代码 import `cells/{X}/{X}test/` 命名形态的 testutil 包
- 修正 `docs/plans/202605191943-044-journey-backlog-realignment.md` §2.2/§2.3/§2.5/§2.6（详见 commit message）

Refs: plan 044 §2 (Platform Cell Testutil Packages) — PR0 基建，解锁 PR A/B/C 三路并行实施

## 范围裁决（重点 review 点）

### CELLTEST-IMPORT-SCOPE-01 保留（非重复造轮子）

PR0 实施前曾考虑该规则与既有 `TESTUTIL-BOUNDARY-01` 重复，勘察后确认**不重复，必须保留**：

- `TESTUTIL-BOUNDARY-01` 的 `isTestInfraPath` 用 `*test` 后缀段（长度 > 4）识别 test-infra 路径，能让 `cells/{X}/{X}test/` 包内文件被视为 test-infra（不约束其向外的 import）
- 但 `extractTestutilRoot` 严格按 `testutil` 字面段匹配——**production 文件 import `cells/configcore/configcoretest` 时该函数返回空串，违规不触发**
- 因此 `cells/{X}/{X}test/` 的 import ban 必须由 `CELLTEST-IMPORT-SCOPE-01` 独立补充

两规则下游互补：`TESTUTIL-BOUNDARY-01` 守 `testutil` 段路径；`CELLTEST-IMPORT-SCOPE-01` 守 `cells/*/*test$` 命名形态。

### 升 build tag 全栈 Hard 暂不做

能把上游从 path-pattern Medium 升到编译期 Hard，但代价是 50+ 既有 testutil 包统一改造 + 所有 `go test ./...` → `-tags=testutil` + CI/IDE 配置同步。任务 1 scope 内不做，若未来真要升级走独立 plan 而非 backlog 软处理。

## §2.3 ports lock 修正

PR0 勘察 `cells/accesscore/internal/ports/` 后发现 plan 044 原文两处错误：
- `RbacAssign` 不存在 — 实际 interface 是 `RoleRepository`（testutil 应 fake `FakeRoleRepo`）
- `CredentialInvalidator` 不是 interface 而是 concrete `*credentialinvalidate.Invalidator` — testutil 构造真实例，仅其内部依赖才 Fake

## Test plan
- [x] `go test ./kernel/outbox/outboxtest/... -race` — Recorder 单元测试含 Emit/Entries/EntriesByType/Reset/Concurrent (8 writers × 100 ops)
- [x] `go build ./...` + `go build -tags=integration ./...` — 无 breakage
- [x] `go test ./tools/archtest/ -run='^TestLayerTestutil$'` — 既有规则自动 cover 新增 `recorder.go`
- [x] `go test ./tools/archtest/ -run='^TestCelltestImportScope$'` — 新增规则 green，table-driven blind-spot 自检通过
- [x] `golangci-lint run ./kernel/outbox/outboxtest/...` — 0 issues

ref: ThreeDotsLabs/watermill pubsub/gochannel.go (in-memory pubsub for producer-side testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)