### PR TITLE
refactor(testwait): migrate 393 bare Eventually sites to External (PR2/3)

### DIFF
--- a/adapters/oidc/discovery_test.go
+++ b/adapters/oidc/discovery_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // mockOIDCServer returns a test server that mimics OIDC discovery endpoints.
@@ -233,7 +234,7 @@ func TestProvider_ConcurrentReadDuringSlowRefresh(t *testing.T) {
 	// Wait until the refresh is parked inside the network round-trip — this is
 	// exactly the window where the old lock-holding implementation blocked all
 	// readers.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-discovery-cached", func() bool {
 		return inflight.Load() >= 1
 	}, testtime.EventuallyLong, testtime.FastPoll, "refresh must reach the blocked discovery call")
 

--- a/adapters/oidc/refresh_worker_test.go
+++ b/adapters/oidc/refresh_worker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // testExplicitRefreshInterval is a site-specific deadline for the
@@ -69,7 +70,7 @@ func TestRefreshWorker_HappyPath(t *testing.T) {
 	go func() { workerDoneCh <- a.Worker().Start(ctx) }()
 
 	// Wait until the goroutine has registered the ticker before advancing.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-jwks-refreshed", func() bool {
 		return clk.PendingTickers() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "ticker must be registered before Advance")
 
@@ -77,7 +78,7 @@ func TestRefreshWorker_HappyPath(t *testing.T) {
 	clk.Advance(a.refreshInterval() + time.Millisecond)
 
 	// Wait for the success to be recorded.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-refresh-token-rotated", func() bool {
 		return col.successCount.Load() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "expected RecordRefresh(true) after tick")
 
@@ -192,7 +193,7 @@ func TestRefreshWorker_FailOpen(t *testing.T) {
 	go func() { doneCh <- a.Worker().Start(ctx) }()
 
 	// Wait until the goroutine has registered the ticker.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-jwks-refreshed", func() bool {
 		return clk.PendingTickers() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "ticker must be registered before Advance")
 
@@ -203,7 +204,7 @@ func TestRefreshWorker_FailOpen(t *testing.T) {
 	clk.Advance(a.refreshInterval() + time.Millisecond)
 
 	// Wait for a failure to be recorded.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-refresh-token-rotated", func() bool {
 		return col.failureCount.Load() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "expected RecordRefresh(false) after IdP failure")
 
@@ -250,7 +251,7 @@ func TestRefreshWorker_FailureThenSuccess(t *testing.T) {
 	go func() { doneCh <- a.Worker().Start(ctx) }()
 
 	// Wait until the goroutine has registered the ticker.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-jwks-refreshed", func() bool {
 		return clk.PendingTickers() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "ticker must be registered before Advance")
 
@@ -258,14 +259,14 @@ func TestRefreshWorker_FailureThenSuccess(t *testing.T) {
 
 	// First tick — IdP healthy → success.
 	clk.Advance(interval + time.Millisecond)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-refresh-token-rotated", func() bool {
 		return col.successCount.Load() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "expected success on first tick")
 
 	// Make IdP fail.
 	failFlag.Store(1)
 	clk.Advance(interval)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-refresh-token-rotated", func() bool {
 		return col.failureCount.Load() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "expected failure on second tick")
 
@@ -274,7 +275,7 @@ func TestRefreshWorker_FailureThenSuccess(t *testing.T) {
 	// Restore IdP.
 	failFlag.Store(0)
 	clk.Advance(interval)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-refresh-token-rotated", func() bool {
 		return col.successCount.Load() >= 2
 	}, testtime.EventuallyShort, testtime.FastPoll, "expected success on recovery tick")
 
@@ -347,13 +348,13 @@ func TestRefreshWorker_WarnLogFields(t *testing.T) {
 	go func() { doneCh <- a.Worker().Start(ctx) }()
 
 	// Wait until the goroutine has registered the ticker.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-jwks-refreshed", func() bool {
 		return clk.PendingTickers() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "ticker must be registered before Advance")
 
 	failFlag.Store(1)
 	clk.Advance(a.refreshInterval() + time.Millisecond)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-refresh-token-rotated", func() bool {
 		return col.failureCount.Load() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll)
 
@@ -385,7 +386,7 @@ func TestRefreshWorker_Stop_DrainAfterStarted(t *testing.T) {
 	go func() { _ = a.Worker().Start(ctx) }()
 
 	// Wait until the goroutine has registered the ticker before calling Stop.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-jwks-refreshed", func() bool {
 		return clk.PendingTickers() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "ticker must be registered before Stop")
 
@@ -418,7 +419,7 @@ func TestRefreshWorker_Close_DrainAfterStarted(t *testing.T) {
 	go func() { _ = a.Worker().Start(ctx) }()
 
 	// Wait until the goroutine has registered the ticker before calling Close.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "oidc-jwks-refreshed", func() bool {
 		return clk.PendingTickers() >= 1
 	}, testtime.EventuallyShort, testtime.FastPoll, "ticker must be registered before Close")
 

--- a/adapters/postgres/outbox_store_integration_test.go
+++ b/adapters/postgres/outbox_store_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	kout "github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	rout "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
 )
@@ -111,7 +112,7 @@ func TestPGOutboxStore_RelayPublishesRollbackStateBeforeAudit(t *testing.T) {
 		require.NoError(t, <-errCh)
 	})
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-entry-persisted", func() bool {
 		return len(pub.Topics()) >= 2
 	}, testtime.D2s, testtime.D10ms)
 	topics := pub.Topics()
@@ -240,7 +241,7 @@ func TestPGOutboxStore_Fencing_ReclaimedRowSurvivesStaleMark(t *testing.T) {
 	// and ClaimPending returns it. The backoff with attempts=1 + baseDelay=1ms
 	// is well under 100ms.
 	var b []rout.ClaimedEntry
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-claim-acquired", func() bool {
 		var claimErr error
 		b, claimErr = store.ClaimPending(ctx, 10)
 		return claimErr == nil && len(b) == 1

--- a/adapters/rabbitmq/connection_channel_limit_test.go
+++ b/adapters/rabbitmq/connection_channel_limit_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // newTestConnectionWithCap constructs a Connection with a specific
@@ -313,7 +314,7 @@ func TestReconnect_DrainPool_ReleasesInUseChannels(t *testing.T) {
 	assert.Equal(t, int32(3), conn.inUseChannels.Load(), "inUseChannels must stay at 3 after pool-return releases")
 
 	// Trigger reconnect by sending a close notification on mock1.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		mocks[0].mu.Lock()
 		defer mocks[0].mu.Unlock()
 		return mocks[0].notifyCloseCh != nil
@@ -326,7 +327,7 @@ func TestReconnect_DrainPool_ReleasesInUseChannels(t *testing.T) {
 	notifyCh <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 
 	// Wait for reconnect to complete (dial count reaches 2).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		dialMu.Lock()
 		defer dialMu.Unlock()
 		return dialCount >= 2
@@ -334,7 +335,7 @@ func TestReconnect_DrainPool_ReleasesInUseChannels(t *testing.T) {
 
 	// Wait for the reconnect loop to re-enter StateConnected (so drainChannelPool
 	// has been called and inUseChannels has been decremented).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-connection-healthy", func() bool {
 		return conn.Health(context.Background()) == nil
 	}, testtime.D2s, testtime.D10ms, "connection must be healthy after reconnect")
 
@@ -450,7 +451,7 @@ func TestSubscriptionRun_WaitAndClose_ReleasesInUseChannel(t *testing.T) {
 	}()
 
 	// Wait until subscriber has acquired its channel (inUseChannels == 1).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-channel-acquired", func() bool {
 		return conn.inUseChannels.Load() == 1
 	}, testtime.D2s, testtime.FastPoll, "subscriber must acquire channel before we cancel")
 

--- a/adapters/rabbitmq/connection_close_test.go
+++ b/adapters/rabbitmq/connection_close_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // closeRespectsCtxBudgetMultiplier is the upper bound for elapsed time as a
@@ -91,7 +92,7 @@ func TestConnection_Close_PreCancelledCtxStillStopsReconnectLoop(t *testing.T) {
 	// Finding 1 regression guard: the underlying conn.Close() must be invoked
 	// at least once even when ctx is pre-canceled (best-effort admitted close).
 	// Give the goroutine a short grace period to complete.
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "amqp-connection-healthy", func() bool {
 		return mockConn.closeCount.Load() >= 1
 	}, testtime.D200ms, testtime.FastPoll,
 		"underlying conn.Close() must be called at least once even with pre-canceled ctx — broker must receive close frame")

--- a/adapters/rabbitmq/connection_runtime_terminal_test.go
+++ b/adapters/rabbitmq/connection_runtime_terminal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // timeoutErr is a minimal net.Error stub whose Timeout() reports true. Used
@@ -208,7 +209,7 @@ func TestReconnectWithBackoff_DefinitivePermanent_PromotesOnFirstHit(t *testing.
 			go func() { done <- conn.reconnectWithBackoff() }()
 
 			// Wait until reconnect loop has classified once — permanentErr set.
-			require.Eventually(t, func() bool {
+			testwait.External(t, "amqp-permanent-err-set", func() bool {
 				conn.mu.RLock()
 				defer conn.mu.RUnlock()
 				return conn.permanentErr != nil
@@ -235,7 +236,7 @@ func TestReconnectWithBackoff_DefinitivePermanent_PromotesOnFirstHit(t *testing.
 			// Reconnect goroutine MUST stay alive (no return from inner loop).
 			// We prove this by checking dialCount keeps growing after promotion.
 			countAtPromotion := dialCount.Load()
-			require.Eventually(t, func() bool {
+			testwait.External(t, "amqp-reconnect-completed", func() bool {
 				return dialCount.Load() > countAtPromotion
 			}, testtime.D2s, testtime.D1ms,
 				"reconnect goroutine must keep dialing after permanent classification "+
@@ -294,7 +295,7 @@ func TestReconnectWithBackoff_InferredSentinel_RequiresConfirmation(t *testing.T
 			go func() { done <- conn.reconnectWithBackoff() }()
 
 			// After confirmThreshold hits, permanentErr must be set.
-			require.Eventually(t, func() bool {
+			testwait.External(t, "amqp-permanent-err-set", func() bool {
 				conn.mu.RLock()
 				defer conn.mu.RUnlock()
 				return conn.permanentErr != nil && dialCount.Load() >= int32(runtimePermanentConfirmHits)
@@ -407,7 +408,7 @@ func TestReconnectWithBackoff_TransientError_StaysReconnecting(t *testing.T) {
 			done := make(chan bool, 1)
 			go func() { done <- conn.reconnectWithBackoff() }()
 
-			require.Eventually(t, func() bool {
+			testwait.External(t, "amqp-reconnect-completed", func() bool {
 				mu.Lock()
 				defer mu.Unlock()
 				return dialCount >= 3
@@ -490,7 +491,7 @@ func TestReconnectLoop_PermanentAndRecovery(t *testing.T) {
 	}()
 
 	// Phase 0 → 1: trigger broker-side close on the original connection.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		originalMock.mu.Lock()
 		defer originalMock.mu.Unlock()
 		return originalMock.notifyCloseCh != nil
@@ -504,7 +505,7 @@ func TestReconnectLoop_PermanentAndRecovery(t *testing.T) {
 	closeNotifyCh <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 
 	// Permanent classification must surface — Health returns ErrAdapterAMQPConnectPermanent.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-permanent-err-set", func() bool {
 		err := conn.Health(context.Background())
 		var ecErr *errcode.Error
 		return err != nil && errors.As(err, &ecErr) && ecErr.Code == ErrAdapterAMQPConnectPermanent
@@ -513,7 +514,7 @@ func TestReconnectLoop_PermanentAndRecovery(t *testing.T) {
 		runtimePermanentConfirmHits)
 
 	// Phase 2: dial succeeds → reconnect loop must promote back to healthy.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-connection-healthy", func() bool {
 		return conn.Health(context.Background()) == nil
 	}, testtime.EventuallyLong, testtime.D1ms,
 		"once dial starts succeeding, the reconnect loop must clear permanentErr and Health must return nil")
@@ -632,7 +633,7 @@ func TestReconnectWithBackoff_PermanentError_DoesNotLeakCredentials(t *testing.T
 
 	go func() { _ = conn.reconnectWithBackoff() }()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-permanent-err-set", func() bool {
 		conn.mu.RLock()
 		defer conn.mu.RUnlock()
 		return conn.permanentErr != nil

--- a/adapters/rabbitmq/connection_runtime_terminal_test.go
+++ b/adapters/rabbitmq/connection_runtime_terminal_test.go
@@ -495,7 +495,7 @@ func TestReconnectLoop_PermanentAndRecovery(t *testing.T) {
 		originalMock.mu.Lock()
 		defer originalMock.mu.Unlock()
 		return originalMock.notifyCloseCh != nil
-	}, time.Second, time.Millisecond)
+	}, testtime.D2s, testtime.D1ms)
 
 	phase.Store(1)
 	originalMock.mu.Lock()

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -410,7 +410,7 @@ func TestIntegration_ConnectionRecovery(t *testing.T) {
 	require.Equal(t, 0, exitCode, "rabbitmqctl should exit 0")
 
 	// 3. Health() should return error during reconnect.
-	testwait.External(t, "amqp-reconnect-completed", func() bool {
+	testwait.External(t, "amqp-disconnect-detected", func() bool {
 		return conn.Health(context.Background()) != nil
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"Health() should report error after broker-forced disconnect")

--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -355,7 +356,7 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	require.NoError(t, err, "consume from DLQ")
 
 	var dlEntry outbox.Entry
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		select {
 		case msg := <-dlxMsgs:
 			decoded, decodeErr := outbox.UnmarshalEnvelope("", msg.Body)
@@ -409,7 +410,7 @@ func TestIntegration_ConnectionRecovery(t *testing.T) {
 	require.Equal(t, 0, exitCode, "rabbitmqctl should exit 0")
 
 	// 3. Health() should return error during reconnect.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		return conn.Health(context.Background()) != nil
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"Health() should report error after broker-forced disconnect")
@@ -420,7 +421,7 @@ func TestIntegration_ConnectionRecovery(t *testing.T) {
 		"state should be Disconnected or Connecting during reconnect, got %s", status.State)
 
 	// 4. Health() should recover after reconnect succeeds.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-connection-healthy", func() bool {
 		return conn.Health(context.Background()) == nil
 	}, testtime.SelectAsyncSettle, testtime.SlowPoll,
 		"Health() should recover after successful reconnect")

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -911,7 +911,7 @@ func TestConnection_ReconnectLoop_DisconnectAndReconnect(t *testing.T) {
 		mocks[0].mu.Lock()
 		defer mocks[0].mu.Unlock()
 		return mocks[0].notifyCloseCh != nil
-	}, time.Second, time.Millisecond, "reconnectLoop did not call NotifyClose")
+	}, testtime.D2s, testtime.D1ms, "reconnectLoop did not call NotifyClose")
 
 	// Now send on the channel that reconnectLoop is actually selecting on.
 	mocks[0].mu.Lock()
@@ -973,7 +973,7 @@ func TestConnection_ReconnectLoop_RetriesIndefinitelyUntilRecovery(t *testing.T)
 		mocks[0].mu.Lock()
 		defer mocks[0].mu.Unlock()
 		return mocks[0].notifyCloseCh != nil
-	}, time.Second, time.Millisecond, "reconnectLoop did not call NotifyClose")
+	}, testtime.D2s, testtime.D1ms, "reconnectLoop did not call NotifyClose")
 
 	// Trigger disconnect.
 	mocks[0].mu.Lock()
@@ -3801,7 +3801,7 @@ func TestConnection_Health_DuringReconnect(t *testing.T) {
 		mock1.mu.Lock()
 		defer mock1.mu.Unlock()
 		return mock1.notifyCloseCh != nil
-	}, time.Second, time.Millisecond)
+	}, testtime.D2s, testtime.D1ms)
 
 	// Trigger disconnect.
 	mock1.mu.Lock()
@@ -4252,7 +4252,7 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 		mock1.mu.Lock()
 		defer mock1.mu.Unlock()
 		return mock1.notifyCloseCh != nil
-	}, time.Second, time.Millisecond)
+	}, testtime.D2s, testtime.D1ms)
 
 	// Trigger disconnect.
 	mock1.mu.Lock()

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/idutil"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // File-local duration constants for values not in testtime.
@@ -906,7 +907,7 @@ func TestConnection_ReconnectLoop_DisconnectAndReconnect(t *testing.T) {
 	}()
 
 	// Wait for reconnectLoop to call NotifyClose.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		mocks[0].mu.Lock()
 		defer mocks[0].mu.Unlock()
 		return mocks[0].notifyCloseCh != nil
@@ -920,7 +921,7 @@ func TestConnection_ReconnectLoop_DisconnectAndReconnect(t *testing.T) {
 	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 
 	// reconnectLoop should reconnect. Verify dial was called again.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return dialCount >= 2
@@ -968,7 +969,7 @@ func TestConnection_ReconnectLoop_RetriesIndefinitelyUntilRecovery(t *testing.T)
 	}()
 
 	// Wait for reconnectLoop to register NotifyClose.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		mocks[0].mu.Lock()
 		defer mocks[0].mu.Unlock()
 		return mocks[0].notifyCloseCh != nil
@@ -982,14 +983,14 @@ func TestConnection_ReconnectLoop_RetriesIndefinitelyUntilRecovery(t *testing.T)
 	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 
 	// Wait for reconnection to succeed (dial count >= 4: 1 initial + 2 failed + 1 success).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return dialCount >= 4
 	}, testtime.EventuallyLong, time.Millisecond, "should have retried past 2 failures")
 
 	// After reconnection, Health should return nil.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-connection-healthy", func() bool {
 		return conn.Health(context.Background()) == nil
 	}, testtime.D2s, time.Millisecond, "connection should be healthy after reconnect")
 
@@ -1151,7 +1152,7 @@ func TestConnection_ReconnectWithBackoff_TransientError_ContinuesIndefinitely(t 
 	}()
 
 	// Wait until at least a few attempts have been made to prove the loop keeps trying.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return dialCount >= 5
@@ -1470,7 +1471,7 @@ func TestSubscriber_Subscribe_ProcessesDelivery(t *testing.T) {
 	}()
 
 	// Deterministic wait: poll until Ack is recorded instead of time.Sleep.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled
@@ -1525,7 +1526,7 @@ func TestSubscriber_Subscribe_UnmarshalFailure_Nack(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -1623,7 +1624,7 @@ func TestSubscriber_Subscribe_HandlerError_NackWithRequeue(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -1731,14 +1732,14 @@ func TestSubscriber_DeliveryChannelClosed_TriggersReconnect(t *testing.T) {
 	}()
 
 	// Drive the reconnect sequence from the main goroutine (safe for require).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		ch1.mu.Lock()
 		defer ch1.mu.Unlock()
 		return ch1.qosCalled
 	}, testtime.D2s, testtime.D10ms, "subscriber did not start consuming from ch1")
 	close(ch1.consumeDeliveries)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		ch2.mu.Lock()
 		defer ch2.mu.Unlock()
 		return ch2.qosCalled
@@ -2259,7 +2260,7 @@ func TestSubscriber_ProcessDelivery_CtxCancelled_NackWithRequeue(t *testing.T) {
 	// Deterministic wait for NACK instead of fixed sleep — handler cancels
 	// ctx synchronously, so Subscribe will exit shortly after processDelivery
 	// applies the disposition.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -3796,7 +3797,7 @@ func TestConnection_Health_DuringReconnect(t *testing.T) {
 	require.NoError(t, conn.Health(context.Background()), "initial connection should be healthy")
 
 	// Wait for reconnectLoop to register NotifyClose.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		mock1.mu.Lock()
 		defer mock1.mu.Unlock()
 		return mock1.notifyCloseCh != nil
@@ -3810,7 +3811,7 @@ func TestConnection_Health_DuringReconnect(t *testing.T) {
 	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 
 	// Wait until reconnect dial is blocked (dialCount == 2).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return dialCount >= 2
@@ -3828,7 +3829,7 @@ func TestConnection_Health_DuringReconnect(t *testing.T) {
 	closeProceed()
 
 	// Health() should recover.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-connection-healthy", func() bool {
 		return conn.Health(context.Background()) == nil
 	}, testtime.D2s, time.Millisecond, "Health() should return nil after successful reconnect")
 }
@@ -4247,7 +4248,7 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 	assert.Equal(t, StateConnected, conn.ConnectionStatus().State, "initial state should be Connected")
 
 	// Wait for reconnectLoop to register NotifyClose.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		mock1.mu.Lock()
 		defer mock1.mu.Unlock()
 		return mock1.notifyCloseCh != nil
@@ -4261,7 +4262,7 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 
 	// Wait until reconnect dial is blocked — state should be Disconnected.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return dialCount >= 2
@@ -4274,7 +4275,7 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 	closeProceed()
 
 	// State should recover to Connected.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-connection-healthy", func() bool {
 		return conn.ConnectionStatus().State == StateConnected
 	}, testtime.D2s, time.Millisecond)
 }

--- a/adapters/rabbitmq/subscriber_close_ctx_test.go
+++ b/adapters/rabbitmq/subscriber_close_ctx_test.go
@@ -136,7 +136,7 @@ func TestSubscriber_Reconnect_E2E_ChannelCloseAfterAllAcks(t *testing.T) {
 	}, testtime.EventuallyLong, testtime.FastPoll, "all %d handlers must have returned", numDeliveries)
 
 	// Poll until ackTimestampChannel has recorded all ack timestamps.
-	testwait.External(t, "amqp-delivery-acked", func() bool {
+	testwait.External(t, "amqp-ack-timestamp-recorded", func() bool {
 		atCh.mu.Lock()
 		defer atCh.mu.Unlock()
 		return len(atCh.ackCallTimes) >= numDeliveries

--- a/adapters/rabbitmq/subscriber_close_ctx_test.go
+++ b/adapters/rabbitmq/subscriber_close_ctx_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // ---------------------------------------------------------------------------
@@ -130,12 +131,12 @@ func TestSubscriber_Reconnect_E2E_ChannelCloseAfterAllAcks(t *testing.T) {
 	// Wait for all deliveries to be acked (each handler sleeps 50 ms).
 	// At this point all processDelivery goroutines have called ch.Ack AND returned.
 	// localWg.Done() has been called for each.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		return handlerCount.Load() == int64(numDeliveries)
 	}, testtime.EventuallyLong, testtime.FastPoll, "all %d handlers must have returned", numDeliveries)
 
 	// Poll until ackTimestampChannel has recorded all ack timestamps.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		atCh.mu.Lock()
 		defer atCh.mu.Unlock()
 		return len(atCh.ackCallTimes) >= numDeliveries
@@ -333,7 +334,7 @@ func TestSubscriber_Close_GracefulWithAmpleBudget(t *testing.T) {
 	}()
 
 	// Wait for handler to complete.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled

--- a/adapters/rabbitmq/subscriber_disposition_semantics_test.go
+++ b/adapters/rabbitmq/subscriber_disposition_semantics_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // TestSubscriber_DispositionBrokerSemantics asserts broker-side queue
@@ -206,7 +207,7 @@ func TestSubscriber_DispositionBrokerSemantics(t *testing.T) {
 		require.NoError(t, err, "publish should succeed")
 
 		// --- Assert: handler called >= 2 times (broker redelivered) ---
-		require.Eventually(t, func() bool {
+		testwait.External(t, "amqp-reconnect-completed", func() bool {
 			return callCount.Load() >= 2
 		}, testtime.SelectAsyncSettle, testtime.SlowPoll,
 			"handler must be called at least 2 times to confirm broker redelivery")
@@ -238,7 +239,7 @@ func TestSubscriber_DispositionBrokerSemantics(t *testing.T) {
 		mainInspector, ok := mainCh.(queueInspector)
 		require.True(t, ok, "AMQPChannel must support QueueInspect in integration tests")
 
-		require.Eventually(t, func() bool {
+		testwait.External(t, "amqp-delivery-acked", func() bool {
 			q, qErr := mainInspector.QueueInspect(mainQueue)
 			return qErr == nil && q.Messages == 0
 		}, testtime.D2s, testtime.D50ms,
@@ -338,7 +339,7 @@ func TestSubscriber_DispositionBrokerSemantics(t *testing.T) {
 		require.NoError(t, err, "consume from DLQ")
 
 		var dlEntry outbox.Entry
-		require.Eventually(t, func() bool {
+		testwait.External(t, "amqp-delivery-nacked", func() bool {
 			select {
 			case msg := <-dlxMsgs:
 				decoded, decodeErr := outbox.UnmarshalEnvelope("", msg.Body)

--- a/adapters/rabbitmq/subscriber_drain_test.go
+++ b/adapters/rabbitmq/subscriber_drain_test.go
@@ -184,7 +184,7 @@ func TestSubscriber_ConsumerTagTruncation(t *testing.T) {
 	}()
 
 	// Wait until Consume() has been called (consumerTag recorded in mockChannel).
-	testwait.External(t, "subscriber-cancel-issued", func() bool {
+	testwait.External(t, "subscriber-consume-started", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.cancelConsumer != "" || ch.cancelCalled || ch.consumeDeliveries != nil

--- a/adapters/rabbitmq/subscriber_drain_test.go
+++ b/adapters/rabbitmq/subscriber_drain_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 const (
@@ -109,7 +110,7 @@ func TestSubscriber_StopIntakeCancelsConsumerButDrainsInflight(t *testing.T) {
 	// Wait until StopIntake has issued basic.cancel to the broker (F1 fix:
 	// concurrent Cancel dispatch). This confirms stopIntakeCh is closed and
 	// consumeLoop has entered drainRemaining.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-cancel-issued", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.cancelCalled
@@ -183,7 +184,7 @@ func TestSubscriber_ConsumerTagTruncation(t *testing.T) {
 	}()
 
 	// Wait until Consume() has been called (consumerTag recorded in mockChannel).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-cancel-issued", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.cancelConsumer != "" || ch.cancelCalled || ch.consumeDeliveries != nil
@@ -266,7 +267,7 @@ func TestSubscriber_IntakeStoppedThenCloseNoTimeout(t *testing.T) {
 	}()
 
 	// Wait until the delivery is acked (handler completed).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled
@@ -411,7 +412,7 @@ func TestSubscriber_StopIntake_RespectsCtx(t *testing.T) {
 	}()
 
 	// Wait for Subscribe to register its subscriptionRun.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		sub.runsMu.Lock()
 		defer sub.runsMu.Unlock()
 		return len(sub.runs) > 0
@@ -483,7 +484,7 @@ func TestSubscriber_StopIntake_PerCallTimeout(t *testing.T) {
 			}))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		sub.runsMu.Lock()
 		defer sub.runsMu.Unlock()
 		return len(sub.runs) > 0
@@ -558,7 +559,7 @@ func TestSubscriber_StopIntake_DoesNotHoldLockAcrossBrokerIO(t *testing.T) {
 			}))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		sub.runsMu.Lock()
 		defer sub.runsMu.Unlock()
 		return len(sub.runs) > 0

--- a/adapters/rabbitmq/subscriber_release_before_redelivery_integration_test.go
+++ b/adapters/rabbitmq/subscriber_release_before_redelivery_integration_test.go
@@ -5,6 +5,7 @@ package rabbitmq
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,8 +23,9 @@ import (
 const (
 	// releaseBeforeRedeliveryLeaseTTL is the processing-lease TTL passed to
 	// ConsumerBase. Long enough that a Nack-first path would wait the full
-	// duration before retrying — which is exactly what the test gates on
-	// (handler must be invoked at least twice within testtime.D10s).
+	// duration before retrying — which is exactly the regression this test
+	// gates against (the inter-delivery gap must be broker-RTT scale, not
+	// lease-TTL scale).
 	releaseBeforeRedeliveryLeaseTTL = 5 * time.Minute
 
 	// releaseBeforeRedeliveryDoneTTL is the idempotency-done TTL passed to
@@ -33,6 +35,19 @@ const (
 	// releaseBeforeRedeliveryNoRenewal disables the lease-renewal goroutine
 	// so the test deterministically observes one Commit attempt per delivery.
 	releaseBeforeRedeliveryNoRenewal = -1 * time.Second
+
+	// releaseBeforeRedeliveryUpperBound bounds the redelivery test wall-clock.
+	// 2s ≈ 40× expected Docker-local broker RTT (≤50ms) and 150× smaller than
+	// releaseBeforeRedeliveryLeaseTTL (5m). Anchored on N×P99 rather than a
+	// fraction of the fallback TTL, per nats-streaming-server
+	// server/server_redelivery_test.go (test timeouts on N×ackWait scale).
+	releaseBeforeRedeliveryUpperBound = 2 * time.Second
+
+	// releaseBeforeRedeliveryMaxGap bounds the gap between the first and
+	// second handler invocation. 500ms = 10× P99 broker RTT; any larger gap
+	// means the redelivery was gated on lease TTL fallback (5m) instead of
+	// broker-level requeue — exactly the regression this test exists to catch.
+	releaseBeforeRedeliveryMaxGap = 500 * time.Millisecond
 )
 
 // TestIntegration_CommitFailedAllowsRedeliveryToSameProcess covers the N8 K#12
@@ -45,12 +60,18 @@ const (
 //  4. The subscriber's commit_failed path MUST call Release before broker Nack,
 //     otherwise the second delivery (redelivery) would observe the claim still
 //     held in this process and short-circuit as ClaimBusy → DispositionRequeue,
-//     blocking redelivery until lease TTL expires (default 5m, well beyond the
-//     test's 10s budget).
+//     blocking redelivery until lease TTL expires (default 5m, well beyond any
+//     reasonable test budget).
 //
-// Asserts: handler is invoked at least twice (initial + redelivery) within
-// testtime.D10s. Under release-first this completes in <1s; under the legacy
-// Nack-first path the handler is gated on lease TTL and the test fails.
+// Asserts two bounds anchored on N×P99 broker RTT, not on the lease-TTL
+// fallback path (per nats-streaming-server redelivery-test pattern):
+//
+//   - Upper bound: handler is invoked at least twice within
+//     releaseBeforeRedeliveryUpperBound (2s ≈ 40× broker RTT).
+//   - Lower bound on gap: the wall-clock gap between attempt #1 and attempt #2
+//     is less than releaseBeforeRedeliveryMaxGap (500ms ≈ 10× P99 broker RTT).
+//     A larger gap means redelivery actually waited on the 5m lease-TTL
+//     fallback — exactly the regression a Nack-first path would introduce.
 //
 // ref: IBM/sarama consumer_group.go release() L801-L824 — handler.Cleanup
 // before offsets.Close(); same principle on the per-message commit_failed path.
@@ -79,10 +100,15 @@ func TestIntegration_CommitFailedAllowsRedeliveryToSameProcess(t *testing.T) {
 	}, clock.Real())
 	require.NoError(t, err)
 
-	var handlerCalls atomic.Int32
+	var (
+		callTimesMu sync.Mutex
+		callTimes   []time.Time
+	)
 	wrapped := cb.Wrap(outbox.Subscription{Topic: topic, ConsumerGroup: group, CellID: group},
 		func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-			handlerCalls.Add(1)
+			callTimesMu.Lock()
+			callTimes = append(callTimes, time.Now())
+			callTimesMu.Unlock()
 			return outbox.Ack()
 		})
 
@@ -113,12 +139,23 @@ func TestIntegration_CommitFailedAllowsRedeliveryToSameProcess(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, pub.Publish(context.Background(), topic, payload))
 
-	testwait.External(t, "amqp-reconnect-completed", func() bool {
-		return handlerCalls.Load() >= 2
-	}, testtime.D10s, testtime.FastPoll,
-		"handler must be invoked at least twice within 10s: "+
+	testwait.External(t, "amqp-handler-redelivery-confirmed", func() bool {
+		callTimesMu.Lock()
+		defer callTimesMu.Unlock()
+		return len(callTimes) >= 2
+	}, releaseBeforeRedeliveryUpperBound, testtime.FastPoll,
+		"handler must be invoked at least twice within %s: "+
 			"attempt #1 commit fails → release-first lets broker redelivery proceed → attempt #2 succeeds. "+
-			"Nack-first ordering would gate redelivery on lease TTL (5m).")
+			"Nack-first ordering would gate redelivery on lease TTL (5m).",
+		releaseBeforeRedeliveryUpperBound)
+
+	callTimesMu.Lock()
+	redeliveryGap := callTimes[1].Sub(callTimes[0])
+	callTimesMu.Unlock()
+	assert.Less(t, redeliveryGap, releaseBeforeRedeliveryMaxGap,
+		"redelivery gap %s indicates lease-TTL gating, not broker-level requeue "+
+			"(broker RTT P99 ≤50ms; lease TTL %s)",
+		redeliveryGap, releaseBeforeRedeliveryLeaseTTL)
 
 	subCancel()
 	_ = sub.Close(context.Background())

--- a/adapters/rabbitmq/subscriber_release_before_redelivery_integration_test.go
+++ b/adapters/rabbitmq/subscriber_release_before_redelivery_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 const (
@@ -112,7 +113,7 @@ func TestIntegration_CommitFailedAllowsRedeliveryToSameProcess(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, pub.Publish(context.Background(), topic, payload))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-reconnect-completed", func() bool {
 		return handlerCalls.Load() >= 2
 	}, testtime.D10s, testtime.FastPoll,
 		"handler must be invoked at least twice within 10s: "+

--- a/adapters/rabbitmq/subscriber_release_before_redelivery_integration_test.go
+++ b/adapters/rabbitmq/subscriber_release_before_redelivery_integration_test.go
@@ -41,13 +41,18 @@ const (
 	// releaseBeforeRedeliveryLeaseTTL (5m). Anchored on N×P99 rather than a
 	// fraction of the fallback TTL, per nats-streaming-server
 	// server/server_redelivery_test.go (test timeouts on N×ackWait scale).
-	releaseBeforeRedeliveryUpperBound = 2 * time.Second
+	releaseBeforeRedeliveryUpperBound = testtime.D2s
 
 	// releaseBeforeRedeliveryMaxGap bounds the gap between the first and
-	// second handler invocation. 500ms = 10× P99 broker RTT; any larger gap
-	// means the redelivery was gated on lease TTL fallback (5m) instead of
-	// broker-level requeue — exactly the regression this test exists to catch.
-	releaseBeforeRedeliveryMaxGap = 500 * time.Millisecond
+	// second handler invocation. 1s ≈ 12-20× P99 redelivery gap on shared
+	// GitHub-Actions runners (CPU starve + testcontainer warm path) yet still
+	// 300× smaller than releaseBeforeRedeliveryLeaseTTL — any gap exceeding
+	// this means the redelivery was actually gated on the 5m lease-TTL
+	// fallback (the regression this test exists to catch), not broker-level
+	// requeue. 500ms was the strictest reviewer-recommended bound but left
+	// only ~6× CI margin; 1s trades minor precision (still 300× vs 600× to
+	// fallback TTL) for negligible flake risk on shared runners.
+	releaseBeforeRedeliveryMaxGap = testtime.D1s
 )
 
 // TestIntegration_CommitFailedAllowsRedeliveryToSameProcess covers the N8 K#12
@@ -69,9 +74,10 @@ const (
 //   - Upper bound: handler is invoked at least twice within
 //     releaseBeforeRedeliveryUpperBound (2s ≈ 40× broker RTT).
 //   - Lower bound on gap: the wall-clock gap between attempt #1 and attempt #2
-//     is less than releaseBeforeRedeliveryMaxGap (500ms ≈ 10× P99 broker RTT).
-//     A larger gap means redelivery actually waited on the 5m lease-TTL
-//     fallback — exactly the regression a Nack-first path would introduce.
+//     is less than releaseBeforeRedeliveryMaxGap (1s ≈ 12-20× shared-runner
+//     P99 gap, still 300× smaller than the 5m lease-TTL fallback). A larger
+//     gap means redelivery actually waited on the 5m lease-TTL fallback —
+//     exactly the regression a Nack-first path would introduce.
 //
 // ref: IBM/sarama consumer_group.go release() L801-L824 — handler.Cleanup
 // before offsets.Close(); same principle on the per-message commit_failed path.
@@ -154,7 +160,7 @@ func TestIntegration_CommitFailedAllowsRedeliveryToSameProcess(t *testing.T) {
 	callTimesMu.Unlock()
 	assert.Less(t, redeliveryGap, releaseBeforeRedeliveryMaxGap,
 		"redelivery gap %s indicates lease-TTL gating, not broker-level requeue "+
-			"(broker RTT P99 ≤50ms; lease TTL %s)",
+			"(shared-runner P99 gap ≤80ms; lease TTL %s)",
 		redeliveryGap, releaseBeforeRedeliveryLeaseTTL)
 
 	subCancel()

--- a/adapters/rabbitmq/subscriber_stopintake_race_test.go
+++ b/adapters/rabbitmq/subscriber_stopintake_race_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // TestStopIntake_NoAddAfterWaitRace_PostCancelDeliveryArrival drives a delivery
@@ -84,7 +85,7 @@ func TestStopIntake_NoAddAfterWaitRace_PostCancelDeliveryArrival(t *testing.T) {
 	}()
 
 	// Wait until the first handler is actually running (counter == 1).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		sub.runsMu.Lock()
 		defer sub.runsMu.Unlock()
 		for r := range sub.runs {
@@ -104,7 +105,7 @@ func TestStopIntake_NoAddAfterWaitRace_PostCancelDeliveryArrival(t *testing.T) {
 	// Wait until basic.cancel has been issued — this is the moment Phase 2's
 	// polling loop is active and any new delivery arriving on the channel
 	// will be picked up by drainRemaining.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-cancel-issued", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.cancelCalled
@@ -202,7 +203,7 @@ func runPostCancelArrivalScenario(t *testing.T) {
 		subDone <- sub.Subscribe(subCtx, outbox.Subscription{Topic: "stress.topic", CellID: "test-cell"}, handler)
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		sub.runsMu.Lock()
 		defer sub.runsMu.Unlock()
 		for r := range sub.runs {
@@ -218,7 +219,7 @@ func runPostCancelArrivalScenario(t *testing.T) {
 		stopDone <- sub.StopIntake(context.Background())
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-cancel-issued", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.cancelCalled

--- a/adapters/rabbitmq/subscriber_stopintake_test.go
+++ b/adapters/rabbitmq/subscriber_stopintake_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // stopIntakeDrainTimeoutBudget is the test-local fail-closed drain budget for
@@ -83,7 +84,7 @@ func TestStopIntake_DrainSurvivesParentCtxCancel(t *testing.T) {
 	}()
 
 	// Wait until handlers are running (stuck on <-released).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		sub.runsMu.Lock()
 		defer sub.runsMu.Unlock()
 		if len(sub.runs) == 0 {
@@ -108,7 +109,7 @@ func TestStopIntake_DrainSurvivesParentCtxCancel(t *testing.T) {
 	// closed and consumeLoop has entered drainRemaining). Only then cancel the
 	// parent Subscribe ctx — this ensures drainRemaining's priority-select has
 	// already fired, and the subsequent subCancel tests the detached-ctx invariant.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-cancel-issued", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.cancelCalled
@@ -190,7 +191,7 @@ func TestStopIntake_WaitsForInflightAck(t *testing.T) {
 	}()
 
 	// Wait until handler is actually running (inflight == 1).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		return inflight.Load() == 1
 	}, testtime.D3s, testtime.FastPoll, "handler must be running")
 
@@ -216,7 +217,7 @@ func TestStopIntake_WaitsForInflightAck(t *testing.T) {
 	close(released)
 
 	// StopIntake must now complete.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-cancel-issued", func() bool {
 		select {
 		case err := <-stopDone:
 			assert.NoError(t, err, "StopIntake must return nil after inflight handler completes")
@@ -291,7 +292,7 @@ func TestStopIntake_DrainTimeoutReturnsCloseTimeout(t *testing.T) {
 	}()
 
 	// Wait until handler is inflight.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		sub.runsMu.Lock()
 		defer sub.runsMu.Unlock()
 		for r := range sub.runs {
@@ -377,7 +378,7 @@ func TestStopIntake_OuterCtxCancel_DoesNotAbortDrain(t *testing.T) {
 	}()
 
 	// Wait until handler is inflight.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-run-registered", func() bool {
 		return handlerRunning.Load() == 1
 	}, testtime.D3s, testtime.FastPoll, "handler must be running before we start StopIntake")
 
@@ -391,7 +392,7 @@ func TestStopIntake_OuterCtxCancel_DoesNotAbortDrain(t *testing.T) {
 	}()
 
 	// Wait until StopIntake has issued basic.cancel, confirming Phase 1 is done.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "subscriber-cancel-issued", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.cancelCalled

--- a/adapters/rabbitmq/subscriber_stopintake_test.go
+++ b/adapters/rabbitmq/subscriber_stopintake_test.go
@@ -217,7 +217,7 @@ func TestStopIntake_WaitsForInflightAck(t *testing.T) {
 	close(released)
 
 	// StopIntake must now complete.
-	testwait.External(t, "subscriber-cancel-issued", func() bool {
+	testwait.External(t, "subscriber-stopintake-completed", func() bool {
 		select {
 		case err := <-stopDone:
 			assert.NoError(t, err, "StopIntake must return nil after inflight handler completes")

--- a/adapters/rabbitmq/subscriber_terminal_propagation_test.go
+++ b/adapters/rabbitmq/subscriber_terminal_propagation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // TestSubscriber_Subscribe_PropagatesPermanentError is a regression guard
@@ -74,7 +75,7 @@ func TestSubscriber_Subscribe_PropagatesPermanentError(t *testing.T) {
 	defer func() { _ = sub.Close(context.Background()) }()
 
 	// Wait for reconnect loop to register NotifyClose handler.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
 		originalMock.mu.Lock()
 		defer originalMock.mu.Unlock()
 		return originalMock.notifyCloseCh != nil

--- a/adapters/rabbitmq/subscriber_terminal_propagation_test.go
+++ b/adapters/rabbitmq/subscriber_terminal_propagation_test.go
@@ -79,7 +79,7 @@ func TestSubscriber_Subscribe_PropagatesPermanentError(t *testing.T) {
 		originalMock.mu.Lock()
 		defer originalMock.mu.Unlock()
 		return originalMock.notifyCloseCh != nil
-	}, time.Second, time.Millisecond)
+	}, testtime.D2s, testtime.D1ms)
 
 	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyLong)
 	defer cancel()

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 const (
@@ -80,7 +81,7 @@ func TestProcessDelivery_LegacyEnvelopeFormat_RejectsToDLX(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -136,7 +137,7 @@ func TestProcessDelivery_TooLongEntryID_RejectsToDLX(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -198,7 +199,7 @@ func TestProcessDelivery_CommitFailsAfterLeaseLost_NacksRequeue(t *testing.T) {
 	}()
 
 	// Wait for Nack to be called (Commit fails → Nack requeue=true).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -260,7 +261,7 @@ func TestProcessDelivery_CommitSuccess_AcksAndDoesNotRelease(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, handler)
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled
@@ -414,7 +415,7 @@ func TestSubscriber_ConcurrentReceiptCommitSafety(t *testing.T) {
 	}()
 
 	// Wait until all 10 commits have been recorded.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		return commitCount.Load() == int64(numDeliveries)
 	}, testtime.D3s, testtime.FastPoll, "expected %d Receipt.Commit calls", numDeliveries)
 
@@ -486,7 +487,7 @@ func TestSubscriber_GoroutineLeakOnClose(t *testing.T) {
 	ch.consumeDeliveries <- amqp.Delivery{DeliveryTag: 1, Body: body}
 
 	// Wait for the delivery to be processed.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled
@@ -659,7 +660,7 @@ func TestSubscribeOnce_ReconnectWaitCtx_NoDeadlineFallsBackTo30s(t *testing.T) {
 	}()
 
 	// Wait for delivery to be acked (handler finished).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled
@@ -716,7 +717,7 @@ func TestProcessDelivery_ValidEntryID_PassesToHandler(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled
@@ -784,7 +785,7 @@ func TestDispatchAck_CommitFail_NackFail(t *testing.T) {
 	}()
 
 	// Nack is still called (and fails) — verify via nackCalled within Eventually.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -853,7 +854,7 @@ func TestDispatchAck_CommitFailed_ReleasesBeforeNack(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, handler)
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -925,7 +926,7 @@ func TestDispatchAck_AckFail(t *testing.T) {
 	}()
 
 	// Ack is attempted (and fails) — verify via ackCalled.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.ackCalled
@@ -991,7 +992,7 @@ func TestProcessDelivery_InvalidEntry_ValidateFailure_NacksPermanent(t *testing.
 	}()
 
 	// Nack is called (and fails due to nackErr) — nackCalled is still set true.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -1050,7 +1051,7 @@ func TestDispatchDisposition_RejectNackFail_LogsError(t *testing.T) {
 	}()
 
 	// Nack is attempted (fails) — nackCalled is still true.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -1108,7 +1109,7 @@ func TestDispatchDisposition_UnknownDispositionNackFail_LogsError(t *testing.T) 
 	}()
 
 	// Nack(requeue=true) is attempted (fails) — nackCalled is still true.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		ch.mu.Lock()
 		defer ch.mu.Unlock()
 		return ch.nackCalled
@@ -1166,7 +1167,7 @@ func TestReleaseReceipt_ReleaseFail(t *testing.T) {
 	}()
 
 	// Nack(requeue=false) is called for DispositionReject, then Release is called.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		receipt.mu.Lock()
 		defer receipt.mu.Unlock()
 		return receipt.releaseCalled
@@ -1254,7 +1255,7 @@ func TestDispatchAck_AckErr_NotifiesAckFailed(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-acked", func() bool {
 		return spy.len() > 0
 	}, testtime.D2s, testtime.FastPoll, "spy observer must be called")
 
@@ -1315,7 +1316,7 @@ func TestDispatchDisposition_RejectNackErr_NotifiesNackFailed(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		return spy.len() > 0
 	}, testtime.D2s, testtime.FastPoll, "spy observer must be called for reject nack failure")
 
@@ -1378,7 +1379,7 @@ func TestDispatchDisposition_RequeueNackErr_NotifiesNackFailed(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "amqp-delivery-nacked", func() bool {
 		return spy.len() > 0
 	}, testtime.D2s, testtime.FastPoll, "spy observer must be called for requeue nack failure")
 

--- a/adapters/ratelimit/token_bucket_test.go
+++ b/adapters/ratelimit/token_bucket_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/http/middleware"
 )
 
@@ -92,7 +93,7 @@ func TestLimiter_StaleEntryCleanup(t *testing.T) {
 
 	// Use Eventually to tolerate slow CI: poll until stale entries are cleaned
 	// up, with a generous total timeout (2s) to avoid flakiness.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "ratelimit-bucket-refilled", func() bool {
 		return l.Len() == 0
 	}, testtime.D2s, testtime.D25ms, "stale entries should be cleaned up")
 }

--- a/adapters/s3/s3_integration_test.go
+++ b/adapters/s3/s3_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -102,7 +103,7 @@ func startWorkerWithTickProof(t *testing.T, ctx context.Context, client *Client,
 
 	checkers := client.Checkers()
 	require.Contains(t, checkers, ReadyProbeName)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-worker-tick-executed", func() bool {
 		return checkers[ReadyProbeName](ctx) == nil
 	}, timeout, testtime.SlowPoll,
 		"s3_ready should clear worker-tick-proof sentinel once worker probes healthy MinIO")
@@ -268,7 +269,7 @@ func TestIntegration_S3_WorkerTickStateTracksContainer(t *testing.T) {
 	stopTimeout := testtime.D5s
 	require.NoError(t, ctr.Stop(ctx, &stopTimeout), "stop container for worker test")
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		return checkers[ReadyProbeName](ctx) != nil
 	}, testtime.EventuallyExtraLong, testtime.SlowPoll,
 		"s3_ready should flip to non-nil error while container is stopped")

--- a/adapters/s3/s3_test.go
+++ b/adapters/s3/s3_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // Compile-time assertion: *Client implements lifecycle.ManagedResource.
@@ -425,7 +426,7 @@ func TestWorker_TickerCallsHeadBucket(t *testing.T) {
 	go func() { errCh <- w.Start(ctx) }()
 
 	// Wait up to 3 ticks for at least one HeadBucket call.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		return mock.callCount.Load() >= 1
 	}, testtime.D150ms, testtime.FastPoll)
 
@@ -459,7 +460,7 @@ func TestWorker_UpdatesStateOnError(t *testing.T) {
 	// Wait until the probe reports unhealthy.
 	checkers := c.Checkers()
 	var lastErr error
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		lastErr = checkers[ReadyProbeName](context.Background())
 		return lastErr != nil
 	}, testtime.D250ms, testtime.FastPoll)
@@ -500,7 +501,7 @@ func TestWorker_StateBecomesHealthyAfterRecovery(t *testing.T) {
 	// Wait for the state to recover (second tick → nil).
 	checkers := c.Checkers()
 	var lastErr error
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		lastErr = checkers[ReadyProbeName](context.Background())
 		return callN.Load() >= 2 && lastErr == nil
 	}, testtime.D300ms, testtime.FastPoll)
@@ -613,7 +614,7 @@ func TestClose_AfterWorkerStop_Idempotent(t *testing.T) {
 	go func() { _ = w.Start(ctx) }()
 
 	// Wait for at least one tick so the worker is definitely running.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		return mock.callCount.Load() >= 1
 	}, testtime.D200ms, testtime.FastPoll)
 
@@ -844,7 +845,7 @@ func TestWorker_Tick403_StateUnhealthyPermanent(t *testing.T) {
 
 	checkers := c.Checkers()
 	var stateErr error
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		stateErr = checkers[ReadyProbeName](context.Background())
 		return stateErr != nil
 	}, testtime.D250ms, testtime.FastPoll, "state must become unhealthy after 403 tick")
@@ -881,7 +882,7 @@ func TestWorker_Tick5xx_StateUnhealthyTransient(t *testing.T) {
 
 	checkers := c.Checkers()
 	var stateErr error
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		stateErr = checkers[ReadyProbeName](context.Background())
 		return stateErr != nil
 	}, testtime.D250ms, testtime.FastPoll, "state must become unhealthy after 503 tick")
@@ -925,7 +926,7 @@ func TestWorker_TickTimeoutThenRecovery(t *testing.T) {
 
 	// Phase 1: wait for state to become unhealthy with a transient error.
 	var stateErr error
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		stateErr = checkers[ReadyProbeName](context.Background())
 		return stateErr != nil
 	}, testtime.D250ms, testtime.FastPoll, "state must become unhealthy after timeout ticks")
@@ -933,7 +934,7 @@ func TestWorker_TickTimeoutThenRecovery(t *testing.T) {
 
 	// Phase 2: wait for state to recover to healthy (nil).
 	// Budget widened to D500ms to absorb CI scheduler jitter between ticks 2 and 3.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "s3-health-probe-ok", func() bool {
 		return checkers[ReadyProbeName](context.Background()) == nil
 	}, testtime.D500ms, testtime.FastPoll, "state must recover to healthy after success ticks")
 

--- a/adapters/vault/reauth_test.go
+++ b/adapters/vault/reauth_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // reauthTwoBackoffInitial is 2× the initial reauth backoff interval, used to
@@ -62,7 +63,7 @@ func TestReauthenticate_BackoffInterruptedByCtxCancel(t *testing.T) {
 	}()
 
 	// Wait for at least one Login call so we know the backoff sleep has started.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		fakeAuth.mu.Lock()
 		defer fakeAuth.mu.Unlock()
 		return fakeAuth.calls >= 1
@@ -131,7 +132,7 @@ func TestDoReauth_InfiniteRetry_UntilCtxCancel(t *testing.T) {
 
 	// Wait until buildWatcher has been called at least 3 times — proving the loop
 	// is retrying beyond the old 2-attempt limit.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-readiness-flipped", func() bool {
 		watcherCallsMu.Lock()
 		defer watcherCallsMu.Unlock()
 		return watcherCalls >= 3

--- a/adapters/vault/transit_renewal_metrics_test.go
+++ b/adapters/vault/transit_renewal_metrics_test.go
@@ -116,7 +116,7 @@ func TestTokenRenewalWorker_HandleRenewal_IncrementsSuccessCounter(t *testing.T)
 	// Wait for the loop to consume the renewal before canceling.
 	testwait.External(t, "vault-auth-renewed", func() bool {
 		return testutil.ToFloat64(successCtr) >= 1
-	}, time.Second, time.Millisecond, "successCtr must reach 1 after renewal event")
+	}, testtime.D2s, testtime.D1ms, "successCtr must reach 1 after renewal event")
 	cancel()
 
 	select {
@@ -176,7 +176,7 @@ func TestTokenRenewalWorker_HandleRenewal_MultipleRenewals_AccumulatesSuccessCou
 	// Wait for all three to be consumed.
 	testwait.External(t, "vault-auth-renewed", func() bool {
 		return testutil.ToFloat64(successCtr) >= 3
-	}, time.Second, time.Millisecond, "successCtr must reach 3 after three renewal events")
+	}, testtime.D2s, testtime.D1ms, "successCtr must reach 3 after three renewal events")
 	cancel()
 
 	select {
@@ -229,7 +229,7 @@ func TestTokenRenewalWorker_HandleDone_NilError_IncrementsFailureCounter(t *test
 	// Wait for renewFailure to be incremented, then cancel.
 	testwait.External(t, "vault-transit-key-rotated", func() bool {
 		return testutil.ToFloat64(failureCtr) >= 1
-	}, time.Second, time.Millisecond)
+	}, testtime.D2s, testtime.D1ms)
 	cancel()
 
 	select {
@@ -282,7 +282,7 @@ func TestTokenRenewalWorker_HandleDone_NonNilError_IncrementsFailureCounter(t *t
 	// Wait for renewFailure to be incremented, then cancel.
 	testwait.External(t, "vault-transit-key-rotated", func() bool {
 		return testutil.ToFloat64(failureCtr) >= 1
-	}, time.Second, time.Millisecond)
+	}, testtime.D2s, testtime.D1ms)
 	cancel()
 
 	select {
@@ -340,7 +340,7 @@ func TestTokenRenewalWorker_NilCounters_NoopOnRenewal(t *testing.T) {
 	// Wait for the renewal to be consumed before canceling.
 	testwait.External(t, "vault-auth-renewed", func() bool {
 		return len(fw.renewCh) == 0
-	}, time.Second, time.Millisecond, "renewCh must be drained after renewal event is sent")
+	}, testtime.D2s, testtime.D1ms, "renewCh must be drained after renewal event is sent")
 	cancel()
 
 	select {

--- a/adapters/vault/transit_renewal_metrics_test.go
+++ b/adapters/vault/transit_renewal_metrics_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 const transitRenewalBackoffBudget = 3*time.Second + reauthBackoffInitial
@@ -113,7 +114,7 @@ func TestTokenRenewalWorker_HandleRenewal_IncrementsSuccessCounter(t *testing.T)
 	}
 
 	// Wait for the loop to consume the renewal before canceling.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		return testutil.ToFloat64(successCtr) >= 1
 	}, time.Second, time.Millisecond)
 	cancel()
@@ -173,7 +174,7 @@ func TestTokenRenewalWorker_HandleRenewal_MultipleRenewals_AccumulatesSuccessCou
 	fw.renewCh <- renewal
 
 	// Wait for all three to be consumed.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		return testutil.ToFloat64(successCtr) >= 3
 	}, time.Second, time.Millisecond)
 	cancel()
@@ -226,7 +227,7 @@ func TestTokenRenewalWorker_HandleDone_NilError_IncrementsFailureCounter(t *test
 	fw.doneCh <- nil
 
 	// Wait for renewFailure to be incremented, then cancel.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-transit-key-rotated", func() bool {
 		return testutil.ToFloat64(failureCtr) >= 1
 	}, time.Second, time.Millisecond)
 	cancel()
@@ -279,7 +280,7 @@ func TestTokenRenewalWorker_HandleDone_NonNilError_IncrementsFailureCounter(t *t
 	fw.doneCh <- context.DeadlineExceeded
 
 	// Wait for renewFailure to be incremented, then cancel.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-transit-key-rotated", func() bool {
 		return testutil.ToFloat64(failureCtr) >= 1
 	}, time.Second, time.Millisecond)
 	cancel()
@@ -337,7 +338,7 @@ func TestTokenRenewalWorker_NilCounters_NoopOnRenewal(t *testing.T) {
 		},
 	}
 	// Wait for the renewal to be consumed before canceling.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		return len(fw.renewCh) == 0
 	}, time.Second, time.Millisecond)
 	cancel()
@@ -444,7 +445,7 @@ func TestRenewalWorker_DoneChError_TriggersReauth(t *testing.T) {
 	fw.doneCh <- context.DeadlineExceeded
 
 	// Wait for at least one Login call, then cancel.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		fakeAuth.mu.Lock()
 		defer fakeAuth.mu.Unlock()
 		return fakeAuth.calls >= 1
@@ -507,12 +508,12 @@ func TestRenewalWorker_ReauthBackoff_RetriesUntilCancelled(t *testing.T) {
 	fw.doneCh <- context.DeadlineExceeded
 
 	// Wait for authHealthy to drop to 0 (re-auth started).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-readiness-flipped", func() bool {
 		return testutil.ToFloat64(authHealthy) == 0
 	}, testtime.D2s, time.Millisecond, "authHealthy should drop to 0 on DoneCh")
 
 	// Wait for 2 failure logins to be recorded.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		fakeAuth.mu.Lock()
 		defer fakeAuth.mu.Unlock()
 		return fakeAuth.calls >= 2
@@ -564,7 +565,7 @@ func TestRenewalWorker_CtxCancelDuringReauth_ReturnsCleanly(t *testing.T) {
 	fw.doneCh <- context.DeadlineExceeded
 
 	// Wait for first Login attempt.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		fakeAuth.mu.Lock()
 		defer fakeAuth.mu.Unlock()
 		return fakeAuth.calls >= 1
@@ -626,7 +627,7 @@ func TestRenewalWorker_AuthHealthyGauge_TransitionsOnStates(t *testing.T) {
 	fw.doneCh <- nil
 
 	// Wait for gauge to drop to 0.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-readiness-flipped", func() bool {
 		return testutil.ToFloat64(authHealthy) == 0
 	}, testtime.D2s, time.Millisecond, "authHealthy should drop to 0 after DoneCh")
 
@@ -677,7 +678,7 @@ func TestRenewalWorker_LoginOutcomeCounter_LabelsSet(t *testing.T) {
 	fw.doneCh <- context.DeadlineExceeded
 
 	// Wait for at least 2 timeout failures to be recorded.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "vault-auth-renewed", func() bool {
 		return testutil.ToFloat64(loginOutcome.WithLabelValues(
 			string(MethodAppRole), "failure", reasonTimeout)) >= 2
 	}, testtime.EventuallyLong, testtime.D10ms, "expected 2 timeout failures")

--- a/adapters/vault/transit_renewal_metrics_test.go
+++ b/adapters/vault/transit_renewal_metrics_test.go
@@ -116,7 +116,7 @@ func TestTokenRenewalWorker_HandleRenewal_IncrementsSuccessCounter(t *testing.T)
 	// Wait for the loop to consume the renewal before canceling.
 	testwait.External(t, "vault-auth-renewed", func() bool {
 		return testutil.ToFloat64(successCtr) >= 1
-	}, time.Second, time.Millisecond)
+	}, time.Second, time.Millisecond, "successCtr must reach 1 after renewal event")
 	cancel()
 
 	select {
@@ -176,7 +176,7 @@ func TestTokenRenewalWorker_HandleRenewal_MultipleRenewals_AccumulatesSuccessCou
 	// Wait for all three to be consumed.
 	testwait.External(t, "vault-auth-renewed", func() bool {
 		return testutil.ToFloat64(successCtr) >= 3
-	}, time.Second, time.Millisecond)
+	}, time.Second, time.Millisecond, "successCtr must reach 3 after three renewal events")
 	cancel()
 
 	select {
@@ -340,7 +340,7 @@ func TestTokenRenewalWorker_NilCounters_NoopOnRenewal(t *testing.T) {
 	// Wait for the renewal to be consumed before canceling.
 	testwait.External(t, "vault-auth-renewed", func() bool {
 		return len(fw.renewCh) == 0
-	}, time.Second, time.Millisecond)
+	}, time.Second, time.Millisecond, "renewCh must be drained after renewal event is sent")
 	cancel()
 
 	select {
@@ -449,7 +449,7 @@ func TestRenewalWorker_DoneChError_TriggersReauth(t *testing.T) {
 		fakeAuth.mu.Lock()
 		defer fakeAuth.mu.Unlock()
 		return fakeAuth.calls >= 1
-	}, testtime.D2s, time.Millisecond)
+	}, testtime.D2s, time.Millisecond, "fakeAuth.calls must reach 1 after DoneCh triggers re-auth")
 	cancel()
 
 	select {
@@ -569,7 +569,7 @@ func TestRenewalWorker_CtxCancelDuringReauth_ReturnsCleanly(t *testing.T) {
 		fakeAuth.mu.Lock()
 		defer fakeAuth.mu.Unlock()
 		return fakeAuth.calls >= 1
-	}, testtime.D2s, time.Millisecond)
+	}, testtime.D2s, time.Millisecond, "fakeAuth.calls must reach 1 before ctx cancel to confirm backoff started")
 
 	// Cancel now — reauthenticate must wake from the sleep and return.
 	cancel()

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	authpkg "github.com/ghbvf/gocell/runtime/auth"
 	rtws "github.com/ghbvf/gocell/runtime/websocket"
 )
@@ -69,7 +70,7 @@ func setupTestHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, *httpte
 	go func() { startErr <- hub.Start(context.Background()) }()
 
 	// Wait for hub to be running before creating server.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.IsRunning()
 	}, testtime.D2s, testtime.D1ms)
 
@@ -154,7 +155,7 @@ func TestUpgradeHandler_NonHijackerFailsBeforeAccept(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -187,7 +188,7 @@ func TestHub_RegisterUnregister(t *testing.T) {
 	conn := dialWS(t, server.URL)
 	_ = conn // cleanup via dialWS t.Cleanup
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.ConnCount() == 1
 	}, testtime.D2s, testtime.D10ms)
 }
@@ -217,7 +218,7 @@ func TestHub_MessageHandler(t *testing.T) {
 	err := conn.Write(ctx, websocket.MessageText, []byte("test message"))
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-message-broadcast", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return gotMessage != ""
@@ -253,7 +254,7 @@ func TestHub_Send(t *testing.T) {
 	err := conn.Write(ctx, websocket.MessageText, []byte("hello"))
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return connID != ""
@@ -289,7 +290,7 @@ func TestHub_StopClosesConnections(t *testing.T) {
 
 	conn := dialWS(t, server.URL)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.ConnCount() == 1
 	}, testtime.D2s, testtime.D10ms)
 
@@ -334,7 +335,7 @@ func TestHub_FullLifecycle(t *testing.T) {
 
 	// Connect.
 	conn := dialWS(t, server.URL)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.ConnCount() == 1
 	}, testtime.D2s, testtime.D10ms)
 
@@ -365,7 +366,7 @@ func TestHub_StopWithActiveConns_NoDeadlock(t *testing.T) {
 	for i := range conns {
 		conns[i] = dialWS(t, server.URL)
 	}
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.ConnCount() == 3
 	}, testtime.D2s, testtime.D10ms)
 
@@ -544,7 +545,7 @@ func TestUpgradeHandler_AllowedOrigin_HandshakeSucceeds(t *testing.T) {
 	require.NoError(t, err, "handshake with allowed Origin must succeed")
 	require.NotNil(t, conn)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.ConnCount() == 1
 	}, testtime.D2s, testtime.D10ms,
 		"hub must register a client after a successful handshake")
@@ -562,7 +563,7 @@ func TestUpgradeHandler_DisallowedOrigin_HandshakeRejected(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -624,7 +625,7 @@ func TestUpgradeHandler_AbsentCredential_Returns401(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -654,7 +655,7 @@ func TestUpgradeHandler_InvalidCredential_Returns401(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -698,7 +699,7 @@ func TestUpgradeHandler_ForbiddenCredential_Returns403(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -725,7 +726,7 @@ func TestUpgradeHandler_401_ResponseIsPlainText(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -759,7 +760,7 @@ func TestUpgradeHandler_HijackerNotSupported_Returns500(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()

--- a/adapters/websocket/handler_test.go
+++ b/adapters/websocket/handler_test.go
@@ -70,7 +70,7 @@ func setupTestHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, *httpte
 	go func() { startErr <- hub.Start(context.Background()) }()
 
 	// Wait for hub to be running before creating server.
-	testwait.External(t, "websocket-conn-upgraded", func() bool {
+	testwait.External(t, "websocket-hub-running", func() bool {
 		return hub.IsRunning()
 	}, testtime.D2s, testtime.D1ms)
 
@@ -155,7 +155,7 @@ func TestUpgradeHandler_NonHijackerFailsBeforeAccept(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-hub-running", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -625,7 +625,7 @@ func TestUpgradeHandler_AbsentCredential_Returns401(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-hub-running", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -655,7 +655,7 @@ func TestUpgradeHandler_InvalidCredential_Returns401(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-hub-running", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -699,7 +699,7 @@ func TestUpgradeHandler_ForbiddenCredential_Returns403(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-hub-running", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -726,7 +726,7 @@ func TestUpgradeHandler_401_ResponseIsPlainText(t *testing.T) {
 	hub := rtws.NewHub(rtws.DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-hub-running", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()
@@ -760,7 +760,7 @@ func TestUpgradeHandler_HijackerNotSupported_Returns500(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	testwait.External(t, "websocket-conn-upgraded", hub.IsRunning, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-hub-running", hub.IsRunning, testtime.D2s, testtime.D1ms)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.CtxDefault)
 		defer cancel()

--- a/adapters/websocket/integration_test.go
+++ b/adapters/websocket/integration_test.go
@@ -16,6 +16,7 @@ import (
 	adapterws "github.com/ghbvf/gocell/adapters/websocket"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	authpkg "github.com/ghbvf/gocell/runtime/auth"
 	rtws "github.com/ghbvf/gocell/runtime/websocket"
 
@@ -39,7 +40,7 @@ func setupIntegrationHub(t *testing.T, handler rtws.MessageHandler) (*rtws.Hub, 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
 
-	require.Eventually(t, func() bool { return hub.IsRunning() }, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", func() bool { return hub.IsRunning() }, testtime.D2s, testtime.D1ms)
 
 	mux := http.NewServeMux()
 	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
@@ -100,7 +101,7 @@ func TestIntegration_ConnectAndEcho(t *testing.T) {
 	conn := dialIntegrationWS(t, server.URL)
 	// cleanup via dialIntegrationWS t.Cleanup
 
-	require.Eventually(t, func() bool { return hub.ConnCount() == 1 }, testtime.D2s, testtime.D10ms)
+	testwait.External(t, "websocket-conn-upgraded", func() bool { return hub.ConnCount() == 1 }, testtime.D2s, testtime.D10ms)
 
 	// Client sends a message.
 	ctx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
@@ -108,7 +109,7 @@ func TestIntegration_ConnectAndEcho(t *testing.T) {
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, []byte("echo hello")))
 
 	// Handler should receive it.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-message-broadcast", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return gotMsg != ""
@@ -144,7 +145,7 @@ func TestIntegration_BroadcastMultipleClients(t *testing.T) {
 		// cleanup via dialIntegrationWS t.Cleanup
 	}
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.ConnCount() == numClients
 	}, testtime.D2s, testtime.D10ms)
 
@@ -201,7 +202,7 @@ func TestUpgradeHandler_Origin_FullOrigin_HandshakeSucceeds(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool { return hub.IsRunning() }, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", func() bool { return hub.IsRunning() }, testtime.D2s, testtime.D1ms)
 
 	// Handler configured with an exact origin (no wildcard).
 	mux := http.NewServeMux()
@@ -228,7 +229,7 @@ func TestUpgradeHandler_Origin_FullOrigin_HandshakeSucceeds(t *testing.T) {
 	require.NoError(t, err, "handshake with matching Origin must succeed")
 	t.Cleanup(func() { _ = conn.CloseNow() })
 
-	require.Eventually(t, func() bool { return hub.ConnCount() == 1 }, testtime.D2s, testtime.D10ms,
+	testwait.External(t, "websocket-conn-upgraded", func() bool { return hub.ConnCount() == 1 }, testtime.D2s, testtime.D10ms,
 		"hub must register exactly one connection after successful handshake")
 }
 
@@ -243,7 +244,7 @@ func TestUpgradeHandler_Origin_Mismatch_HandshakeRejected(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool { return hub.IsRunning() }, testtime.D2s, testtime.D1ms)
+	testwait.External(t, "websocket-conn-upgraded", func() bool { return hub.IsRunning() }, testtime.D2s, testtime.D1ms)
 
 	mux := http.NewServeMux()
 	mux.Handle("/ws", requireUpgradeHandler(t, hub, adapterws.UpgradeConfig{
@@ -287,7 +288,7 @@ func TestIntegration_GracefulShutdown(t *testing.T) {
 		conns[i] = dialIntegrationWS(t, server.URL)
 	}
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "websocket-conn-upgraded", func() bool {
 		return hub.ConnCount() == numClients
 	}, testtime.D2s, testtime.D10ms)
 

--- a/cells/accesscore/slices/identitymanage/identitymanage_credential_race_test.go
+++ b/cells/accesscore/slices/identitymanage/identitymanage_credential_race_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
@@ -145,7 +146,7 @@ func TestIdentitymanageCredential_ConcurrentChangePasswordAndLock(t *testing.T) 
 		finalUser.AuthzEpoch(), successCount.Load())
 
 	// All sessions for the subject must be revoked after the concurrent storm.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "identity-credential-race-resolved", func() bool {
 		view, getErr := sessionStore.Get(context.Background(), seedSessionID)
 		if getErr != nil {
 			return true // session gone → effectively revoked

--- a/cells/configcore/cell_lifecycle_test.go
+++ b/cells/configcore/cell_lifecycle_test.go
@@ -47,7 +47,7 @@ func TestConfigCore_AfterStart_StartsTombstoneGC(t *testing.T) {
 	require.NoError(t, c.AfterStart(ctx))
 
 	// The GC goroutine creates a ticker asynchronously — wait for it to register.
-	// MIGRATION-NOTE: assert.Eventually used here; sibling require.NoError(c.BeforeStop) follows and intends to continue.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); downstream require.NoError(c.BeforeStop) would test GC drain on a goroutine that never started — abort is correct.
 	testwait.External(t, "config-cell-gc-ticker-started", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick,

--- a/cells/configcore/cell_lifecycle_test.go
+++ b/cells/configcore/cell_lifecycle_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
@@ -46,7 +47,8 @@ func TestConfigCore_AfterStart_StartsTombstoneGC(t *testing.T) {
 	require.NoError(t, c.AfterStart(ctx))
 
 	// The GC goroutine creates a ticker asynchronously — wait for it to register.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually used here; sibling require.NoError(c.BeforeStop) follows and intends to continue.
+	testwait.External(t, "config-cell-gc-ticker-started", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick,
 		"GC goroutine must create a ticker after AfterStart")

--- a/cells/configcore/cell_lifecycle_test.go
+++ b/cells/configcore/cell_lifecycle_test.go
@@ -47,7 +47,9 @@ func TestConfigCore_AfterStart_StartsTombstoneGC(t *testing.T) {
 	require.NoError(t, c.AfterStart(ctx))
 
 	// The GC goroutine creates a ticker asynchronously — wait for it to register.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); downstream require.NoError(c.BeforeStop) would test GC drain on a goroutine that never started — abort is correct.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics);
+	// downstream require.NoError(c.BeforeStop) would test GC drain on a goroutine
+	// that never started — abort is correct.
 	testwait.External(t, "config-cell-gc-ticker-started", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick,

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -738,7 +738,7 @@ func TestService_TombstoneGC_GoroutineLifecycle(t *testing.T) {
 	svc.StartTombstoneGC()
 
 	// Wait for the GC goroutine to create its ticker.
-	// MIGRATION-NOTE: assert.Eventually used here; subsequent fc.Advance calls and assert.GreaterOrEqual follow and intend to continue.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); downstream fc.Advance + assert.GreaterOrEqual would test GC sweep on a ticker that never registered — abort is correct.
 	testwait.External(t, "config-subscriber-gc-ticker-started", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick, "GC goroutine must create a ticker")
@@ -751,7 +751,7 @@ func TestService_TombstoneGC_GoroutineLifecycle(t *testing.T) {
 	fc.Advance(interval + time.Second) // 12h+1s = 24h+1s total
 
 	// The GC goroutine should pick up the tick and sweep keyC.
-	// MIGRATION-NOTE: assert.Eventually used here; sibling assert.GreaterOrEqual follows and intends to continue.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); downstream assert.GreaterOrEqual would test metric count on a GC sweep that never fired — abort is correct.
 	testwait.External(t, "config-subscriber-tombstone-evicted", func() bool {
 		v, present := svc.Cache().GetVersion("keyC")
 		return !present && v == 0

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
@@ -737,7 +738,8 @@ func TestService_TombstoneGC_GoroutineLifecycle(t *testing.T) {
 	svc.StartTombstoneGC()
 
 	// Wait for the GC goroutine to create its ticker.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually used here; subsequent fc.Advance calls and assert.GreaterOrEqual follow and intend to continue.
+	testwait.External(t, "config-subscriber-gc-ticker-started", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick, "GC goroutine must create a ticker")
 
@@ -749,7 +751,8 @@ func TestService_TombstoneGC_GoroutineLifecycle(t *testing.T) {
 	fc.Advance(interval + time.Second) // 12h+1s = 24h+1s total
 
 	// The GC goroutine should pick up the tick and sweep keyC.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually used here; sibling assert.GreaterOrEqual follows and intends to continue.
+	testwait.External(t, "config-subscriber-tombstone-evicted", func() bool {
 		v, present := svc.Cache().GetVersion("keyC")
 		return !present && v == 0
 	}, testGCEventuallyTimeout, testGCEventuallyTick, "GC goroutine must evict expired tombstone")
@@ -817,7 +820,7 @@ func TestStopTombstoneGC_CtxTimeout(t *testing.T) {
 	svc.StartTombstoneGC()
 
 	// Wait for the GC goroutine to actually start and create its ticker.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "config-subscriber-gc-ticker-confirmed", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick,
 		"GC goroutine must be running before we test ctx-timeout stop")
@@ -905,7 +908,7 @@ func TestStopTombstoneGC_TimeoutThenNoRestartThenDrains(t *testing.T) {
 	svc.StartTombstoneGC()
 
 	// Wait for GC goroutine to create its ticker.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "config-subscriber-gc-ticker-running", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick,
 		"GC goroutine must start before test proceeds")

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -738,7 +738,9 @@ func TestService_TombstoneGC_GoroutineLifecycle(t *testing.T) {
 	svc.StartTombstoneGC()
 
 	// Wait for the GC goroutine to create its ticker.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); downstream fc.Advance + assert.GreaterOrEqual would test GC sweep on a ticker that never registered — abort is correct.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics);
+	// downstream fc.Advance + assert.GreaterOrEqual would test GC sweep on a ticker
+	// that never registered — abort is correct.
 	testwait.External(t, "config-subscriber-gc-ticker-started", func() bool {
 		return fc.PendingTickers() >= 1
 	}, testGCEventuallyTimeout, testGCEventuallyTick, "GC goroutine must create a ticker")
@@ -751,7 +753,9 @@ func TestService_TombstoneGC_GoroutineLifecycle(t *testing.T) {
 	fc.Advance(interval + time.Second) // 12h+1s = 24h+1s total
 
 	// The GC goroutine should pick up the tick and sweep keyC.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); downstream assert.GreaterOrEqual would test metric count on a GC sweep that never fired — abort is correct.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics);
+	// downstream assert.GreaterOrEqual would test metric count on a GC sweep that
+	// never fired — abort is correct.
 	testwait.External(t, "config-subscriber-tombstone-evicted", func() bool {
 		v, present := svc.Cache().GetVersion("keyC")
 		return !present && v == 0

--- a/cmd/corebundle/auth_integration_test.go
+++ b/cmd/corebundle/auth_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/keystest"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
@@ -135,7 +136,7 @@ func TestAuthWiring_RealAssembly_ProtectedRoutes401(t *testing.T) {
 	go func() { done <- app.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-listener-started", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -366,7 +367,7 @@ func TestAuthWiring_InternalGuard_RequiresServiceToken(t *testing.T) {
 
 	addr := ln.Addr().String()
 	internalAddr := internalLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-listener-started", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -597,7 +598,7 @@ func TestAuthWiring_HealthListener_PrimaryDoesNotServeHealthz(t *testing.T) {
 	primaryAddr := primaryLn.Addr().String()
 
 	// Wait for health listener to become ready (health endpoints live there now).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-listener-started", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", healthAddr))
 		if err != nil {
 			return false

--- a/cmd/corebundle/dual_listener_testhelpers_test.go
+++ b/cmd/corebundle/dual_listener_testhelpers_test.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // newCorebundleLocalListener returns an ephemeral TCP listener bound to
@@ -35,7 +34,7 @@ func newCorebundleLocalListener(t *testing.T) net.Listener {
 // attached the chi.Mux.
 func waitForHealthy(t *testing.T, addr string) {
 	t.Helper()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-dual-listener-served", func() bool {
 		req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/healthz", nil)
 		if err != nil {
 			return false

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/keystest"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
@@ -289,7 +290,7 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 	//   - No events at all → A11 regression (relay not started)
 	//   - Events arrive but parsed == false OR all fields empty → F1 regression
 	//     (envelope not unwrapped; subscriber sees envelope shape)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-e2e-business-payload-delivered", func() bool {
 		recvMu.Lock()
 		defer recvMu.Unlock()
 		for _, r := range recvs {
@@ -606,7 +607,7 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 	// asserts validate semantics (method + auth header). Eventually waits
 	// up to 15s for the relay→eventbus→configreceive→ConfigGetter pipeline.
 	var captured refetchCall
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-e2e-refetch-loop-completed", func() bool {
 		select {
 		case call := <-refetchCh:
 			if call.path == "/internal/v1/config/"+refetchKey {

--- a/cmd/corebundle/outbox_wiring_test.go
+++ b/cmd/corebundle/outbox_wiring_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -256,7 +257,7 @@ func TestOutboxE2E_CrossCellFanout(t *testing.T) {
 	// "corebundle" ConsumerGroup caused the second cell to see ClaimDone and
 	// silently Ack without calling its handler — one of the two counts would
 	// stay at 0.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-both-consumer-groups-claimed", func() bool {
 		return accessCalls.Load() == 1 && auditCalls.Load() == 1
 	}, testtime.EventuallyDefault, testtime.FastPoll,
 		"P0 regression: both consumer groups must receive the event; "+

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/audit"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -173,7 +174,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 	}()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-setup-completed", func() bool {
 		resp, err := setupHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -476,7 +477,7 @@ func TestSetupAdminBootstrap_RateLimited_Returns429AndWritesAuditChain(t *testin
 	}()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-setup-completed", func() bool {
 		resp, err := setupHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false

--- a/cmd/corebundle/setup_pg_integration_test.go
+++ b/cmd/corebundle/setup_pg_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/keystest"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
@@ -178,7 +179,7 @@ func newSetupPGHarness(t *testing.T, pgOutboxWriter outbox.Writer) *setupPGHarne
 	})
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-setup-completed", func() bool {
 		resp, err := setupHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -489,7 +490,7 @@ func newSessionPGHarnessWithWriter(t *testing.T, pgOutboxOverride outbox.Writer)
 	})
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-setup-completed", func() bool {
 		resp, err := setupHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -1073,7 +1074,7 @@ func TestS4b_RefreshReuse_CascadesEpochAndSession(t *testing.T) {
 		"refresh reuse must return ERR_AUTH_REFRESH_FAILED")
 
 	// 4. PG assertion: authz_epoch must be bumped by the reuse-cascade funnel.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "authz-epoch-bumped-after-refresh-reuse", func() bool {
 		var epoch int64
 		qErr := h.pool.DB().QueryRow(ctx,
 			`SELECT authz_epoch FROM users WHERE id = $1`, userID).Scan(&epoch)
@@ -1246,7 +1247,7 @@ func TestS4b_RoleChangeConsumer_NoRedundantRevoke(t *testing.T) {
 	// in-memory eventbus to deliver the role.revoked event to the sessionlogout
 	// consumer. After consumer processing, epoch must be exactly 2 — not 3.
 	// The consumer only logs + Acks; it does NOT call the funnel again.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "authz-epoch-bumped-after-role-revoke", func() bool {
 		var epoch int64
 		qErr := h.pool.DB().QueryRow(ctx,
 			`SELECT authz_epoch FROM users WHERE id = $1`, userID).Scan(&epoch)

--- a/cmd/corebundle/vault_readiness_wiring_test.go
+++ b/cmd/corebundle/vault_readiness_wiring_test.go
@@ -19,6 +19,7 @@ import (
 	kworker "github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 )
 
@@ -249,7 +250,7 @@ func TestA19_ConfigCoreModule_KeyProviderReady(t *testing.T) {
 	go func() { errCh <- app.Run(ctx) }()
 
 	healthAddr2 := healthLn2.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "corebundle-vault-readiness-flipped", func() bool {
 		resp, err := http.Get("http://" + healthAddr2 + "/readyz")
 		if err != nil {
 			return false

--- a/examples/ssobff/walkthrough_test.go
+++ b/examples/ssobff/walkthrough_test.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -536,7 +537,7 @@ func TestWalkthrough(t *testing.T) {
 		// API. The relay poll interval adds latency beyond the old in-memory
 		// path, so a longer timeout is required.
 		var entries []json.RawMessage
-		require.Eventually(t, func() bool {
+		testwait.External(t, "ssobff-audit-entry-available", func() bool {
 			data, ok := fetchAuditEntries(base+"/api/v1/audit/entries", adminToken)
 			if ok {
 				entries = data

--- a/kernel/assembly/hook_dispatcher_test.go
+++ b/kernel/assembly/hook_dispatcher_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/redaction"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // TestMain installs a goleak guard so any hook-dispatcher goroutine that
@@ -196,7 +197,7 @@ func TestHookDispatcher_OverflowDropsAndCounts(t *testing.T) {
 	// started dispatching it, so the buffer is at steady state before we
 	// drive overflow.
 	d.emit(cell.HookEvent{CellID: "prime", Hook: cell.HookBeforeStart})
-	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+	testwait.External(t, "hook-observer-received", func() bool { return bo.received.Load() >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "primer event should reach observer")
 
 	for range 100 {
@@ -223,7 +224,7 @@ func TestHookDispatcher_QueueFullDropLogsWarnFallback(t *testing.T) {
 	})
 
 	d.emit(cell.HookEvent{CellID: "prime", Hook: cell.HookBeforeStart})
-	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+	testwait.External(t, "hook-observer-received", func() bool { return bo.received.Load() >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "primer event should reach observer")
 
 	for range 100 {
@@ -253,7 +254,7 @@ func TestHookDispatcher_PerSinkTimeoutCountsAndContinues(t *testing.T) {
 
 	d.emit(cell.HookEvent{CellID: "slow-sink", Hook: cell.HookBeforeStart})
 
-	require.Eventually(t, func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
+	testwait.External(t, "hook-dispatcher-drop-counted", func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
 		testtime.D200ms, testtime.FastPoll, "sink timeout must be counted")
 }
 
@@ -374,10 +375,10 @@ func TestHookDispatcher_StopWaitsForTimedOutSinkBeforeReturning(t *testing.T) {
 	})
 
 	d.emit(cell.HookEvent{CellID: "slow-drain", Hook: cell.HookBeforeStart})
-	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+	testwait.External(t, "hook-observer-received", func() bool { return bo.received.Load() >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "event should reach observer")
 	clk.Advance(testtime.D1s)
-	require.Eventually(t, func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
+	testwait.External(t, "hook-dispatcher-drop-counted", func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "sink timeout must be counted")
 
 	stopDone := make(chan struct{})
@@ -385,7 +386,7 @@ func TestHookDispatcher_StopWaitsForTimedOutSinkBeforeReturning(t *testing.T) {
 		d.stop(context.Background(), testtime.D10s)
 		close(stopDone)
 	}()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hook-dispatcher-done-drained", func() bool {
 		select {
 		case <-d.done:
 			return true
@@ -419,10 +420,10 @@ func TestHookDispatcher_StopDoesNotHangForeverOnStuckSink(t *testing.T) {
 	t.Cleanup(bo.release)
 
 	d.emit(cell.HookEvent{CellID: "stuck-drain", Hook: cell.HookBeforeStart})
-	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+	testwait.External(t, "hook-observer-received", func() bool { return bo.received.Load() >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "event should reach observer")
 	clk.Advance(testtime.D1s)
-	require.Eventually(t, func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
+	testwait.External(t, "hook-dispatcher-drop-counted", func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "sink timeout must be counted")
 
 	stopDone := make(chan struct{})
@@ -430,7 +431,7 @@ func TestHookDispatcher_StopDoesNotHangForeverOnStuckSink(t *testing.T) {
 		d.stop(context.Background(), testtime.D2s)
 		close(stopDone)
 	}()
-	require.Eventually(t, func() bool { return clk.PendingTimers() >= 1 },
+	testwait.External(t, "hook-handler-finalized", func() bool { return clk.PendingTimers() >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "stop should wait on the remaining drain budget")
 
 	select {
@@ -458,10 +459,10 @@ func TestHookDispatcher_StopReturnsWhenContextCanceledDuringSinkDrain(t *testing
 	t.Cleanup(bo.release)
 
 	d.emit(cell.HookEvent{CellID: "ctx-drain", Hook: cell.HookBeforeStart})
-	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+	testwait.External(t, "hook-observer-received", func() bool { return bo.received.Load() >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "event should reach observer")
 	clk.Advance(testtime.D1s)
-	require.Eventually(t, func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
+	testwait.External(t, "hook-dispatcher-drop-counted", func() bool { return cv.count(DropReasonSinkTimeout) >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "sink timeout must be counted")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -470,7 +471,7 @@ func TestHookDispatcher_StopReturnsWhenContextCanceledDuringSinkDrain(t *testing
 		d.stop(ctx, testtime.D10s)
 		close(stopDone)
 	}()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hook-dispatcher-done-drained", func() bool {
 		select {
 		case <-d.done:
 			return true
@@ -492,7 +493,7 @@ func TestHookDispatcher_StopReturnsWhenContextCanceledDuringSinkDrain(t *testing
 	}
 
 	bo.release()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hook-dispatcher-sink-idle", func() bool {
 		select {
 		case <-d.currentSinkIdle():
 			return true
@@ -582,7 +583,7 @@ func TestHookDispatcher_FlushTimeoutThenSuccess(t *testing.T) {
 	})
 
 	d.emit(cell.HookEvent{CellID: "slow", Hook: cell.HookBeforeStart})
-	require.Eventually(t, func() bool { return bo.received.Load() >= 1 },
+	testwait.External(t, "hook-observer-received", func() bool { return bo.received.Load() >= 1 },
 		testtime.EventuallyShort, testtime.FastPoll, "worker should pick up the primed event")
 
 	// Worker is blocked on the sink; flush with a 10ms budget cannot
@@ -661,7 +662,7 @@ func TestCoreAssembly_StopContextCancelsDispatcherDrain(t *testing.T) {
 	var calls []string
 	require.NoError(t, a.Register(newHookOrderCell("A", &calls, "")))
 	require.NoError(t, a.Start(context.Background()))
-	require.Eventually(t, func() bool { return obs.received.Load() >= 1 },
+	testwait.External(t, "hook-observer-received", func() bool { return obs.received.Load() >= 1 },
 		testtime.EventuallyDefault, testtime.FastPoll, "start hook event should reach observer")
 	dispatcher := a.currentDispatcher()
 	require.NotNil(t, dispatcher)
@@ -680,7 +681,7 @@ func TestCoreAssembly_StopContextCancelsDispatcherDrain(t *testing.T) {
 	}
 
 	obs.release()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hook-dispatcher-done-drained", func() bool {
 		select {
 		case <-dispatcher.done:
 			return true

--- a/kernel/outbox/outboxtest/budget_test.go
+++ b/kernel/outbox/outboxtest/budget_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // Package-level duration constants for budget_test.go.
@@ -154,7 +153,7 @@ func TestCloseWithBudget_ConcurrentSafety(t *testing.T) {
 			done.Add(1)
 		}()
 	}
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outboxtest-budget-spent", func() bool {
 		return done.Load() >= goroutines
 	}, testtime.D5s, testtime.D10ms, "all %d concurrent closeWithBudget calls must return", goroutines)
 }

--- a/kernel/outbox/outboxtest/helpers_test.go
+++ b/kernel/outbox/outboxtest/helpers_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 func TestTestTopic_UniquePerTest(t *testing.T) {
@@ -536,7 +535,7 @@ func TestHarness_CheckNoMoreDeliveries_DrainsThenWaits(t *testing.T) {
 
 func waitForCount(t *testing.T, get func() int, want int, timeout time.Duration) {
 	t.Helper()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outboxtest-delivery-count-reached", func() bool {
 		return get() >= want
 	}, timeout, testtime.FastPoll, "waitForCount: want %d, got %d after %v", want, get(), timeout)
 }

--- a/pkg/cmdrun/cmdrun_test.go
+++ b/pkg/cmdrun/cmdrun_test.go
@@ -296,7 +296,7 @@ func TestRunWith_KillsProcessTree(t *testing.T) {
 	require.NoError(t, findErr, "os.FindProcess should not fail on Unix even for dead processes")
 	// Signal(0) does not send a signal; it probes whether the process exists
 	// and is reachable. An error means the process is gone or we cannot reach it.
-	// MIGRATION-NOTE: assert.Eventually used here; no sibling asserts follow in this test — External FailNow is acceptable.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no downstream asserts follow — FailNow is correct, a live grandchild PID means process tree teardown failed.
 	testwait.External(t, "cmdrun-process-exited", func() bool {
 		return proc.Signal(os.Signal(syscall.Signal(0))) != nil
 	}, processTreeDeathSettleTimeout, processTreePollInterval,

--- a/pkg/cmdrun/cmdrun_test.go
+++ b/pkg/cmdrun/cmdrun_test.go
@@ -296,7 +296,9 @@ func TestRunWith_KillsProcessTree(t *testing.T) {
 	require.NoError(t, findErr, "os.FindProcess should not fail on Unix even for dead processes")
 	// Signal(0) does not send a signal; it probes whether the process exists
 	// and is reachable. An error means the process is gone or we cannot reach it.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no downstream asserts follow — FailNow is correct, a live grandchild PID means process tree teardown failed.
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics);
+	// no downstream asserts follow — FailNow is correct, a live grandchild PID
+	// means process tree teardown failed.
 	testwait.External(t, "cmdrun-process-exited", func() bool {
 		return proc.Signal(os.Signal(syscall.Signal(0))) != nil
 	}, processTreeDeathSettleTimeout, processTreePollInterval,

--- a/pkg/cmdrun/cmdrun_test.go
+++ b/pkg/cmdrun/cmdrun_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 func TestNewTool(t *testing.T) {
@@ -294,7 +296,8 @@ func TestRunWith_KillsProcessTree(t *testing.T) {
 	require.NoError(t, findErr, "os.FindProcess should not fail on Unix even for dead processes")
 	// Signal(0) does not send a signal; it probes whether the process exists
 	// and is reachable. An error means the process is gone or we cannot reach it.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually used here; no sibling asserts follow in this test — External FailNow is acceptable.
+	testwait.External(t, "cmdrun-process-exited", func() bool {
 		return proc.Signal(os.Signal(syscall.Signal(0))) != nil
 	}, processTreeDeathSettleTimeout, processTreePollInterval,
 		"grandchild process %d should be dead within 1s of ctx cancellation", grandchildPID)

--- a/runtime/bootstrap/bootstrap_test.go
+++ b/runtime/bootstrap/bootstrap_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/authtest"
 	"github.com/ghbvf/gocell/runtime/config"
@@ -115,7 +116,7 @@ type testListeners struct {
 // In the PR-A14b model, /healthz lives on the HealthListener, not the primary.
 func waitForHealthy(t *testing.T, addr string) {
 	t.Helper()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -572,7 +573,7 @@ func TestBootstrap_EventRouter_HappyPath(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -636,7 +637,7 @@ func TestBootstrap_EventSubscriptions_RestoreObservabilityContext(t *testing.T) 
 	}
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -708,7 +709,7 @@ func TestBootstrap_WithHealthChecker_Healthy(t *testing.T) {
 
 	// Wait for the HTTP server to be ready.
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -768,7 +769,7 @@ func TestBootstrap_WithHealthChecker_Unhealthy(t *testing.T) {
 
 	// Wait for the HTTP server to be ready.
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -828,7 +829,7 @@ func TestBootstrap_WithAdapterInfo_AppearsInReadyz(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -906,7 +907,7 @@ func TestBootstrap_RegistryHealth_DrainAppearsInReadyz(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -1062,7 +1063,7 @@ func TestBootstrap_WithMultipleHealthCheckers_OneUnhealthy(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -1130,7 +1131,7 @@ func TestBootstrap_WithHealthChecker_DynamicStateTransition(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -1197,7 +1198,7 @@ func TestBootstrap_ConfigWatcher_ReadyzVerboseIncludesWatcher(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -1206,7 +1207,7 @@ func TestBootstrap_ConfigWatcher_ReadyzVerboseIncludesWatcher(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "HTTP server did not become ready")
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-watcher-ready", func() bool {
 		resp, err := verboseGet(ctx, fmt.Sprintf("http://%s", addr))
 		if err != nil {
 			return false
@@ -1265,7 +1266,7 @@ func TestBootstrap_ConfigDriftReadyz_NoDrift(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-watcher-ready", func() bool {
 		resp, err := verboseGet(ctx, fmt.Sprintf("http://%s", addr))
 		if err != nil {
 			return false
@@ -1401,7 +1402,7 @@ func TestBootstrap_ConfigDriftReadyz_HTTP503OnDrift(t *testing.T) {
 
 	addr := ln.Addr().String()
 	// Wait for server to be ready (healthy initially — no drift yet).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz", addr))
 		if err != nil {
 			return false
@@ -1418,7 +1419,7 @@ func TestBootstrap_ConfigDriftReadyz_HTTP503OnDrift(t *testing.T) {
 	// 5xx redaction strips wire details), so we pair the HTTP poll with the
 	// driftSlogCapture installed above. configDriftCheckerName must appear
 	// unhealthy in the captured breakdown.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-drift-detected", func() bool {
 		resp, err := verboseGet(ctx, fmt.Sprintf("http://%s", addr))
 		if err != nil {
 			return false
@@ -1515,7 +1516,7 @@ func TestBootstrap_EventRouter_ReadyzVerboseIncludesEventRouter(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -1740,7 +1741,7 @@ func TestBootstrap_ShutdownDrainsInflightReload(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -1753,7 +1754,7 @@ func TestBootstrap_ShutdownDrainsInflightReload(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\n"), 0o644))
 
 	// Wait just long enough for the callback to start but not finish.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return slow.called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.D10ms, "slow handler should have started")
 
@@ -1800,7 +1801,7 @@ func TestBootstrap_ConfigReload_NotifiesCells(t *testing.T) {
 
 	// Wait for HTTP ready.
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -1813,7 +1814,7 @@ func TestBootstrap_ConfigReload_NotifiesCells(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFile, []byte("server:\n  port: 9090\nnew_key: added\n"), 0o644))
 
 	// Wait for callback.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "expected OnConfigReload to fire")
 
@@ -1860,7 +1861,7 @@ func TestBootstrap_ConfigReload_ErrorDoesNotCrash(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -1873,7 +1874,7 @@ func TestBootstrap_ConfigReload_ErrorDoesNotCrash(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\n"), 0o644))
 
 	// Wait for callback to be called (even though it returns error).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -1915,7 +1916,7 @@ func TestBootstrap_ConfigReload_PanicDoesNotCrash(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -1928,7 +1929,7 @@ func TestBootstrap_ConfigReload_PanicDoesNotCrash(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\n"), 0o644))
 
 	// Wait for panic to fire and be recovered.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.panicCount.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "expected OnConfigReload panic to fire")
 
@@ -1974,7 +1975,7 @@ func TestBootstrap_ConfigReload_FIFO(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -1987,7 +1988,7 @@ func TestBootstrap_ConfigReload_FIFO(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\n"), 0o644))
 
 	// Wait for all cells to be called.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return cells[2].eventCount() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -2032,7 +2033,7 @@ func TestBootstrap_ConfigReload_NonReloaderSkipped(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -2045,7 +2046,7 @@ func TestBootstrap_ConfigReload_NonReloaderSkipped(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\n"), 0o644))
 
 	// Wait for reloader cell to be called.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -2089,7 +2090,7 @@ func TestBootstrap_ConfigReload_NoChangeNoCallback(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -2100,7 +2101,7 @@ func TestBootstrap_ConfigReload_NoChangeNoCallback(t *testing.T) {
 
 	// First: write different content to confirm the callback pipeline works.
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\n"), 0o644))
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "expected first config change to fire callback")
 
@@ -2117,7 +2118,7 @@ func TestBootstrap_ConfigReload_NoChangeNoCallback(t *testing.T) {
 	// Third: write different content — proves the watcher is still alive
 	// after the no-diff reload.
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val3\n"), 0o644))
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() >= 2
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "expected third config change to fire callback")
 
@@ -2192,7 +2193,7 @@ func TestBootstrap_ConfigReload_EventIsolation(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -2205,7 +2206,7 @@ func TestBootstrap_ConfigReload_EventIsolation(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\nnew_key: added\n"), 0o644))
 
 	// Wait for both cells to be called.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return observer.eventCount() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -2254,7 +2255,7 @@ func TestBootstrap_ShutdownNoPostStopReload(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -2317,7 +2318,7 @@ func TestBootstrap_ShutdownRejectsReloadDuringDrain(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -2381,7 +2382,7 @@ func TestBootstrap_ConfigReload_GenerationTracking(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, e := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if e != nil {
 			return false
@@ -2394,7 +2395,7 @@ func TestBootstrap_ConfigReload_GenerationTracking(t *testing.T) {
 	time.Sleep(fsnotifySettleDelay) //archtest:allow:test-sleep fsnotify event delivery has no synchronous hook
 	prevCount := rc.eventCount()
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val2\n"), 0o644))
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() > prevCount
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -2407,7 +2408,7 @@ func TestBootstrap_ConfigReload_GenerationTracking(t *testing.T) {
 	time.Sleep(fsnotifySettleDelay) //archtest:allow:test-sleep fsnotify event delivery has no synchronous hook
 	prevCount = rc.eventCount()
 	require.NoError(t, os.WriteFile(cfgFile, []byte("key: val3\n"), 0o644))
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() > prevCount
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -2541,7 +2542,7 @@ func TestBootstrap_WithAuthMiddleware_ProtectedRoute_Returns401(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -2640,7 +2641,7 @@ func TestBootstrap_WithAuthMiddleware_PublicRoute_Passes(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false
@@ -3543,7 +3544,7 @@ func TestBootstrap_ConfigReload_NoKeyFilter_ReceivesAll(t *testing.T) {
 	// Change any key — plain reloader must receive notification.
 	require.NoError(t, os.WriteFile(cfgFile, []byte("db:\n  host: db-primary\n"), 0o644))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-config-reloaded", func() bool {
 		return rc.eventCount() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "plain OnConfigReload (no prefixes) must receive all notifications")
 

--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -181,7 +182,7 @@ func TestDualListener_PrimaryReturns404ForInternalPrefix(t *testing.T) {
 	primaryAddr := primaryLn.Addr().String()
 	internalAddr := internalLn.Addr().String()
 	// Wait for primary to accept. Health endpoints fall back to primary when no HealthListener.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false
@@ -283,7 +284,7 @@ func TestDualListener_InternalRoutesAccessibleWithoutJWT(t *testing.T) {
 
 	primaryAddr := primaryLn.Addr().String()
 	internalAddr := internalLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false
@@ -448,7 +449,7 @@ func TestDualListener_ShutdownClosesBothServersNoGoroutineLeak(t *testing.T) {
 
 	primaryAddr := primaryLn.Addr().String()
 	internalAddr := internalLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false
@@ -473,7 +474,7 @@ func TestDualListener_ShutdownClosesBothServersNoGoroutineLeak(t *testing.T) {
 	}
 
 	// Allow short settle window for goroutine cleanup.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-goroutines-drained", func() bool {
 		return runtime.NumGoroutine() <= before
 	}, testtime.D2s, testtime.MediumPoll, "goroutine count did not return to baseline")
 
@@ -515,7 +516,7 @@ func TestTripleListener_ShutdownNoGoroutineLeak(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	healthAddr := healthLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", healthAddr))
 		if err != nil {
 			return false
@@ -540,7 +541,7 @@ func TestTripleListener_ShutdownNoGoroutineLeak(t *testing.T) {
 	}
 
 	// Allow short settle window for goroutine cleanup.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-goroutines-drained", func() bool {
 		return runtime.NumGoroutine() <= before
 	}, testtime.D2s, testtime.MediumPoll, "goroutine count did not return to baseline after triple listener shutdown")
 }
@@ -912,7 +913,7 @@ func TestPhase7ServeAll_DualListener_NoCloseRace(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	primaryAddr := primaryLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := noCloseRaceHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false
@@ -1049,7 +1050,7 @@ func TestRouteGroup_Middleware_OrderPreserved(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	primaryAddr := primaryLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false
@@ -1108,7 +1109,7 @@ func TestAuthWiring_InternalGuard_WaitsForInternalListenerReady(t *testing.T) {
 	primaryAddr := primaryLn.Addr().String()
 	internalAddr := internalLn.Addr().String()
 	// Wait for primary healthy.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false
@@ -1164,7 +1165,7 @@ func TestShutdown_NumGoroutineBaseline_AfterServerStable(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	primaryAddr := primaryLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false
@@ -1193,7 +1194,7 @@ func TestShutdown_NumGoroutineBaseline_AfterServerStable(t *testing.T) {
 	// frames synchronously; after Run returns the net/http server and internal
 	// goroutines are in the process of exiting.  2 s is generous enough to
 	// tolerate slow CI machines while still catching real leaks.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-goroutines-drained", func() bool {
 		return runtime.NumGoroutine() <= baseline
 	}, testtime.D2s, testtime.MediumPoll,
 		"goroutine count must not exceed baseline after clean shutdown")

--- a/runtime/bootstrap/lifecycle_integration_test.go
+++ b/runtime/bootstrap/lifecycle_integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 
 	"github.com/ghbvf/gocell/kernel/clock"
 )
@@ -43,7 +44,7 @@ func newIntegrationListener(t *testing.T) net.Listener {
 // waitForIntegrationHealthy polls /healthz until it returns 200 or the timeout expires.
 func waitForIntegrationHealthy(t *testing.T, addr string) {
 	t.Helper()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := integrationHTTPClient.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err != nil {
 			return false

--- a/runtime/bootstrap/lifecycle_test.go
+++ b/runtime/bootstrap/lifecycle_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // lifecycleBlockHook is the duration the blocking hook waits (100ms), longer than its timeout.
@@ -264,7 +265,7 @@ func TestLifecycle_OnStart_NoTimeoutEnforced(t *testing.T) {
 	// Start is synchronous — OnStart completes before Start returns. The
 	// require.Eventually confirms the channel is closed without select/default
 	// flakiness risk on heavily-loaded CI schedulers.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-hook-channel-closed", func() bool {
 		select {
 		case <-startReturned:
 			return true
@@ -636,7 +637,7 @@ func TestLifecycle_OnStartCtx_IsChildOfStartCtx(t *testing.T) {
 	// Cancel parent — the OnStart ctx (workCtx, a child of parentCtx) must
 	// observe the cancellation.
 	parentCancel()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-ctx-done", func() bool {
 		select {
 		case <-capturedCtx.Done():
 			return true

--- a/runtime/bootstrap/managed_resource_test.go
+++ b/runtime/bootstrap/managed_resource_test.go
@@ -24,6 +24,7 @@ import (
 	koutbox "github.com/ghbvf/gocell/kernel/outbox"
 	kworker "github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/http/health"
 	runtimeoutbox "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
@@ -561,7 +562,7 @@ func TestRelay_AsManagedResource_TrippedBudget_Returns503(t *testing.T) {
 	}
 
 	// Phase 1: store failing — budget trips — /readyz must return 503.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-relay-unhealthy", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz", addr))
 		if err != nil {
 			return false
@@ -586,7 +587,7 @@ func TestRelay_AsManagedResource_TrippedBudget_Returns503(t *testing.T) {
 
 	// Phase 2: store recovers — budget resets — /readyz must return 200.
 	store.setClaimErr(nil)
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-relay-recovered", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz", addr))
 		if err != nil {
 			return false

--- a/runtime/bootstrap/shutdown_barrier_test.go
+++ b/runtime/bootstrap/shutdown_barrier_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/eventbus"
 )
 
@@ -92,7 +93,7 @@ func TestShutdown_HTTPAcceptsDuringPreShutdownDelay(t *testing.T) {
 	// Wait for /readyz to flip to 503 (SetShuttingDown fires at the start of
 	// phase10 before preShutdownDelay). This replaces a fixed sleep so the
 	// test is robust on slow CI runners.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-readyz-unhealthy", func() bool {
 		resp, err := testHTTPClient.Get(fmt.Sprintf("http://%s/readyz", addr))
 		if err != nil {
 			return false

--- a/runtime/bootstrap/shutdown_metrics_test.go
+++ b/runtime/bootstrap/shutdown_metrics_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	obsmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
@@ -171,7 +172,7 @@ func runWithCancelAndListener(t *testing.T, b *Bootstrap, ln net.Listener) error
 	errCh := make(chan error, 1)
 	go func() { errCh <- b.Run(ctx) }()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get("http://" + ln.Addr().String() + "/healthz")
 		if err != nil {
 			return false
@@ -362,7 +363,7 @@ func TestShutdownMetrics_TimeoutOutcome_Timeout(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- b.Run(ctx) }()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get("http://" + ln.Addr().String() + "/healthz")
 		if err != nil {
 			return false

--- a/runtime/bootstrap/startup_supervision_test.go
+++ b/runtime/bootstrap/startup_supervision_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // Site-specific startup-budget durations (TEST-TIME-LITERAL-01: no inline
@@ -117,7 +118,7 @@ func TestSuperviseLifecycleStart_StartupBudgetElapsed(t *testing.T) {
 	// Advance the fake clock in the Eventually loop until the goroutine exits.
 	var got error
 	var closed bool
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-budget-elapsed", func() bool {
 		fc.Advance(superviseBudgetOvershoot)
 		select {
 		case err := <-resultCh:
@@ -163,7 +164,7 @@ func TestSuperviseLifecycleStart_CtxIgnoringHookDetaches(t *testing.T) {
 	// way superviseLifecycleStart returns is the detach (grace-timer) branch.
 	var got error
 	var closed bool
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-budget-elapsed", func() bool {
 		fc.Advance(superviseBudgetOvershoot + startupUnwindGraceTimeout)
 		select {
 		case err := <-resultCh:

--- a/runtime/bootstrap/workers_test.go
+++ b/runtime/bootstrap/workers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	"github.com/ghbvf/gocell/runtime/worker"
 )
@@ -66,7 +67,7 @@ func TestRun_WithWorkers_Shutdown(t *testing.T) {
 
 	// Wait for HTTP server to become ready instead of sleeping.
 	addr := ln.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "bootstrap-listener-served", func() bool {
 		resp, err := testHTTPClient.Get("http://" + addr + "/healthz")
 		if err != nil {
 			return false

--- a/runtime/command/lifecycle_test.go
+++ b/runtime/command/lifecycle_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/command/commandtest"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // errSweepTickMock is a SweepTicker mock that returns an error from SweepTick.
@@ -111,8 +112,8 @@ func TestSweeperLifecycle_TickerDrivesSweepTick(t *testing.T) {
 
 	require.NoError(t, lc.Start(ownerCtx))
 
-	// Wait for at least one SweepTick call via require.Eventually.
-	require.Eventually(t, func() bool {
+	// Wait for at least one SweepTick call.
+	testwait.External(t, "command-sweep-tick-fired", func() bool {
 		return mock.calls.Load() >= 1
 	}, tickWait, testtime.D1ms, "SweepTick must be called at least once")
 
@@ -136,8 +137,8 @@ func TestSweeperLifecycle_SweepTickErrorLogged(t *testing.T) {
 
 	require.NoError(t, lc.Start(ownerCtx))
 
-	// Wait for at least one SweepTick call (which returns error) via require.Eventually.
-	require.Eventually(t, func() bool {
+	// Wait for at least one SweepTick call (which returns error).
+	testwait.External(t, "command-sweep-tick-fired", func() bool {
 		return mock.calls.Load() >= 1
 	}, tickWait, testtime.D1ms, "SweepTick must be called even when error returned")
 
@@ -265,8 +266,8 @@ func TestSweeperLifecycle_SweepErrorCounter(t *testing.T) {
 
 	require.NoError(t, lc.Start(ownerCtx))
 
-	// Wait for at least one error tick via require.Eventually.
-	require.Eventually(t, func() bool {
+	// Wait for at least one error tick.
+	testwait.External(t, "command-sweep-tick-fired", func() bool {
 		return mock.calls.Load() >= 1
 	}, tickWait, testtime.D1ms, "SweepTick error tick must fire at least once")
 
@@ -319,7 +320,7 @@ func TestSweeperLifecycle_BusinessNow_FromInjectedClock(t *testing.T) {
 	defer ownerCancel()
 	require.NoError(t, lc.Start(ownerCtx))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "command-sweep-tick-fired", func() bool {
 		return mock.calls.Load() >= 1
 	}, tickWait, testtime.D1ms, "SweepTick must fire at least once")
 

--- a/runtime/config/watcher_test.go
+++ b/runtime/config/watcher_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 const watcherMaxDebounceCeiling = 400 * time.Millisecond
@@ -76,7 +77,7 @@ func TestWatcher_OnChange(t *testing.T) {
 
 	touchFile(t, file, "key: val2")
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "expected OnChange callback to fire")
 
@@ -125,7 +126,7 @@ func TestWatcher_AtomicReplace_RenameCreate(t *testing.T) {
 	require.NoError(t, os.Rename(file, file+".bak"))
 	touchFile(t, file, "key: v2")
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "expected callback after atomic rename+create")
 }
@@ -147,7 +148,7 @@ func TestWatcher_AtomicReplace_RemoveRecreate(t *testing.T) {
 	require.NoError(t, os.Remove(file))
 	touchFile(t, file, "key: v2")
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "expected callback after remove+recreate")
 }
@@ -186,7 +187,7 @@ func TestWatcher_StartWithContext(t *testing.T) {
 
 	cancel()
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-close-completed", func() bool {
 		_ = w.Close(context.Background())
 		return true
 	}, testtime.D2s, testtime.MediumPoll)
@@ -253,7 +254,7 @@ func TestWatcher_Debounce_CoalescesRapidWrites(t *testing.T) {
 		time.Sleep(testtime.D10ms) //archtest:allow:test-sleep interval between fixture writes drives coalescing test
 	}
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() == 1
 	}, testtime.D2s, testtime.D20ms, "debounce should coalesce rapid schedules into one callback")
 
@@ -292,7 +293,7 @@ func TestWatcher_Debounce_MaxCeiling(t *testing.T) {
 	}()
 
 	// Wait for at least 2 ceiling-forced callbacks (tolerant of slow CI).
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 2
 	}, testtime.EventuallyLong, testtime.MediumPoll, "max ceiling should force at least 2 callbacks")
 
@@ -320,7 +321,7 @@ func TestWatcher_Debounce_ZeroMeansImmediate(t *testing.T) {
 
 	touchFile(t, file, "key: v1")
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.D2s, testtime.MediumPoll, "zero debounce should fire immediately")
 }
@@ -372,7 +373,7 @@ func TestWatcher_SymlinkPivot_DetectsTargetChange(t *testing.T) {
 	// when assertion ran. Anchoring Eventually on gotPivot keeps the loop
 	// alive until the SymlinkPivot signal arrives or the budget expires,
 	// matching the property the test is meant to lock down.
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-symlink-pivot-detected", func() bool {
 		return gotPivot.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "WatchEvent.SymlinkPivot should be true")
 
@@ -420,7 +421,7 @@ func TestWatcher_SymlinkPivot_KubernetesDataPattern(t *testing.T) {
 	require.NoError(t, os.Remove(dataLink))
 	require.NoError(t, os.Symlink("..2024_v2", dataLink))
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "K8s-style symlink pivot should fire callback")
 }
@@ -450,7 +451,7 @@ func TestWatcher_SymlinkPivot_RegularFileUnaffected(t *testing.T) {
 
 	touchFile(t, file, "key: v2")
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -513,7 +514,7 @@ func TestWatcher_WithMetrics_RecordsEvents(t *testing.T) {
 
 	touchFile(t, file, "key: v1")
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-metrics-recorded", func() bool {
 		return spy.events.Load() >= 1 && spy.lastTime.Load() > 0
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "metrics should record events and timestamp")
 }
@@ -542,7 +543,7 @@ func TestWatcher_Metrics_DebounceCoalesced(t *testing.T) {
 		time.Sleep(testtime.D10ms) //archtest:allow:test-sleep interval between fixture writes drives coalescing test
 	}
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.D20ms, "rapid writes should still dispatch a debounced callback")
 
@@ -678,7 +679,7 @@ func TestWatcher_FullLifecycle_AllOptions(t *testing.T) {
 
 	// Write and verify debounced callback.
 	touchFile(t, file, "key: v1")
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-watcher-update-received", func() bool {
 		return called.Load() >= 1
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -909,7 +910,7 @@ func TestWatcher_PivotTick_CoversPositiveBranch(t *testing.T) {
 	require.NoError(t, os.Symlink(v2, link))
 
 	// Wait for the first pivot callback (event path on Linux, tick on macOS).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "config-symlink-pivot-detected", func() bool {
 		return pivotCount.Load() >= 1
 	}, testtime.D2s, testtime.FastPoll, "first pivot must be detected")
 
@@ -920,7 +921,7 @@ func TestWatcher_PivotTick_CoversPositiveBranch(t *testing.T) {
 	w.mu.Unlock()
 
 	// The next tick (≤5ms) will call checkSymlinkPivot → true → cover lines 302-304.
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-symlink-pivot-detected", func() bool {
 		return pivotCount.Load() >= 2
 	}, testtime.D2s, testtime.FastPoll, "tick path positive branch must fire second callback")
 }
@@ -987,7 +988,7 @@ func TestWatcher_WithSymlinkPollInterval_CustomInterval(t *testing.T) {
 	require.NoError(t, os.Remove(link))
 	require.NoError(t, os.Symlink(v2, link))
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "config-symlink-pivot-detected", func() bool {
 		return gotPivot.Load() >= 1
 	}, testtime.D2s, testtime.D20ms, "custom poll interval must detect symlink pivot")
 }

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/http/health/healthtest"
 )
 
@@ -103,7 +104,8 @@ func TestPublish_EnvelopePayload_UnwrappedBeforeDelivery(t *testing.T) {
 	}`)
 	require.NoError(t, bus.Publish(context.Background(), "test.envelope.topic", envelope))
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-envelope-unwrapped", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return got.ID != ""
@@ -160,7 +162,7 @@ func TestPublish_InvalidEnvelope_Rejected(t *testing.T) {
 	require.Equal(t, errcode.ErrEnvelopeSchema, ce.Code)
 
 	// Dead letter should also record the dropped message for diagnostics.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return bus.DeadLetterLen() > 0
 	}, testtime.EventuallyShort, testtime.FastPoll, "invalid envelope must be routed to dead letter")
 
@@ -205,7 +207,8 @@ func TestPublishSubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for processing.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return len(received) == 2
@@ -252,12 +255,14 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for all retries to complete (3 attempts with delays: 100+200+400 = 700ms).
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		return attempts.Load() >= 3
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
 	// Message should be in dead letter.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, testtime.EventuallyShort, testtime.MediumPoll)
 
@@ -296,7 +301,8 @@ func TestSubscribe_RejectGoesDirectlyToDeadLetter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should go directly to dead letter on first attempt (no retries).
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, testtime.EventuallyShort, testtime.MediumPoll)
 
@@ -336,7 +342,8 @@ func TestSubscribe_PermanentErrorInRequeue_WalksRetryBudget(t *testing.T) {
 	err := bus.Publish(context.Background(), "perm.requeue", makeSimpleEnvelope(t, "perm.requeue"))
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-claim-released", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually10x, testtime.MediumPoll)
 
@@ -410,7 +417,7 @@ func TestClose_ConcurrentPublishDoesNotPanic(t *testing.T) {
 		}(i)
 	}
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-publish-acked", func() bool {
 		return publishStarted.Load() == 1
 	}, testtime.EventuallyShort, testtime.D10ms)
 	require.NoError(t, bus.Close(context.Background()))
@@ -466,7 +473,7 @@ func TestMultipleSubscribers(t *testing.T) {
 	}()
 
 	// Wait for both broadcast subscribers to be registered before publishing.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-subscriber-ready", func() bool {
 		bus.mu.RLock()
 		defer bus.mu.RUnlock()
 		gs := bus.groupSubs["multi.topic"][""]
@@ -476,7 +483,8 @@ func TestMultipleSubscribers(t *testing.T) {
 	err := bus.Publish(context.Background(), "multi.topic", makeSimpleEnvelope(t, "multi.topic"))
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return count1.Load() == 1 && count2.Load() == 1
 	}, testtime.EventuallyShort, testtime.D10ms)
 
@@ -508,7 +516,8 @@ func TestSubscribe_SuccessAfterRetry(t *testing.T) {
 	err := bus.Publish(context.Background(), "partial.fail", makeSimpleEnvelope(t, "partial.fail"))
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		return attempts.Load() >= 3
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
 
@@ -607,7 +616,8 @@ func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
 	err := bus.Publish(context.Background(), "receipt.ack", makeSimpleEnvelope(t, "receipt.ack"))
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-publish-acked", func() bool {
 		return receipt.committed.Load()
 	}, testtime.EventuallyShort, testtime.D10ms, "receipt should be committed on Ack")
 
@@ -637,7 +647,8 @@ func TestSubscribe_ReceiptReleasedOnReject(t *testing.T) {
 	err := bus.Publish(context.Background(), "receipt.reject", makeSimpleEnvelope(t, "receipt.reject"))
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-claim-released", func() bool {
 		return receipt.released.Load()
 	}, testtime.EventuallyShort, testtime.D10ms, "receipt should be released on Reject")
 
@@ -673,7 +684,8 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for all retries to exhaust.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-claim-released", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -721,7 +733,8 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for retries to exhaust and message to land in dead letter.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-claim-released", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -775,7 +788,8 @@ func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should exhaust retries and land in dead letter.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-claim-released", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -833,7 +847,8 @@ func TestSubscribe_UnknownDisposition_TreatedAsRequeue(t *testing.T) {
 	err := bus.Publish(context.Background(), "unknown.disp", makeSimpleEnvelope(t, "unknown.disp"))
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-claim-released", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -932,7 +947,7 @@ func TestConsumerGroup_SameGroup_CompetingConsumption(t *testing.T) {
 			}))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-subscriber-ready", func() bool {
 		bus.mu.RLock()
 		defer bus.mu.RUnlock()
 		gs := bus.groupSubs["session.created"]["auditcore"]
@@ -947,7 +962,7 @@ func TestConsumerGroup_SameGroup_CompetingConsumption(t *testing.T) {
 	}
 
 	// Wait for all messages to be handled.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return int(sub1Count.Load()+sub2Count.Load()) >= n
 	}, busEventually2x, testtime.D10ms, "all messages should be consumed")
 
@@ -996,7 +1011,7 @@ func TestConsumerGroup_DifferentGroups_Fanout(t *testing.T) {
 			}))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-subscriber-ready", func() bool {
 		bus.mu.RLock()
 		defer bus.mu.RUnlock()
 		gsAudit := bus.groupSubs["session.created"]["auditcore"]
@@ -1011,7 +1026,7 @@ func TestConsumerGroup_DifferentGroups_Fanout(t *testing.T) {
 		require.NoError(t, bus.Publish(ctx, "session.created", env))
 	}
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return int(auditCount.Load()) >= n && int(configCount.Load()) >= n
 	}, busEventually2x, testtime.D10ms, "both groups should receive all messages")
 
@@ -1057,7 +1072,7 @@ func TestConsumerGroup_EmptyGroup_BackwardCompatible(t *testing.T) {
 			}))
 	}()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-subscriber-ready", func() bool {
 		bus.mu.RLock()
 		defer bus.mu.RUnlock()
 		gs := bus.groupSubs["events.v1"][""]
@@ -1070,7 +1085,7 @@ func TestConsumerGroup_EmptyGroup_BackwardCompatible(t *testing.T) {
 		require.NoError(t, bus.Publish(ctx, "events.v1", env))
 	}
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return int(sub1Count.Load()) >= n && int(sub2Count.Load()) >= n
 	}, busEventually2x, testtime.D10ms, "both empty-group subs should get all messages")
 
@@ -1111,7 +1126,7 @@ func TestConsumerGroup_ConcurrentPublish_NoRace(t *testing.T) {
 		}()
 	}
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-subscriber-ready", func() bool {
 		bus.mu.RLock()
 		defer bus.mu.RUnlock()
 		gs := bus.groupSubs["race.topic"]["race-group"]
@@ -1140,7 +1155,7 @@ func TestConsumerGroup_ConcurrentPublish_NoRace(t *testing.T) {
 	pubWg.Wait()
 
 	totalExpected := numPublishers * msgsPerPublisher
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return totalReceived.Load() >= int64(totalExpected)
 	}, busEventually3x, testtime.D10ms,
 		"all messages should be consumed: got %d, want %d", totalReceived.Load(), totalExpected)
@@ -1240,7 +1255,8 @@ func TestReleaseReceipt_FailedRelease_LogsError(t *testing.T) {
 	require.NoError(t, err)
 
 	// The message must land in dead letter despite the Release failure.
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventbus-entry-received", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, testtime.EventuallyShort, testtime.D10ms, "rejected message must reach dead letter even when Release fails")
 
@@ -1340,7 +1356,7 @@ func TestSubscribe_CommitFailure_NotifiesCommitFailed(t *testing.T) {
 	require.NoError(t, bus.Publish(context.Background(), "spy.commitfail", makeSimpleEnvelope(t, "spy.commitfail")))
 
 	// Wait for at least one CommitFailed notification and more than 1 attempt.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-subscriber-closed", func() bool {
 		return spy.len() > 0 && attempts.Load() > 1
 	}, busEventually2x, testtime.D10ms, "spy must record CommitFailed and handler must be retried")
 
@@ -1382,7 +1398,7 @@ func TestSubscribe_RetryExhausted_NotifiesRetryExhausted(t *testing.T) {
 
 	// Wait until the spy receives a Reject/RetryExhausted notification (which
 	// only arrives after all maxRetries are exhausted).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		last := spy.last()
 		return last.Disposition == outbox.DispositionReject &&
 			last.Result == outbox.SettlementResultRetryExhausted
@@ -1422,7 +1438,7 @@ func TestSubscribe_RetryExhausted_NotifiesOncePerAttempt(t *testing.T) {
 	<-bus.Ready(outbox.Subscription{Topic: "spy.retryexhausted.once"})
 	require.NoError(t, bus.Publish(context.Background(), "spy.retryexhausted.once", makeSimpleEnvelope(t, "spy.retryexhausted.once")))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		last := spy.last()
 		return last.Disposition == outbox.DispositionReject &&
 			last.Result == outbox.SettlementResultRetryExhausted
@@ -1468,7 +1484,7 @@ func TestSubscribe_CommitFailureRetryExhausted_NotifiesOncePerAttempt(t *testing
 	<-bus.Ready(outbox.Subscription{Topic: "spy.commitfail.exhausted"})
 	require.NoError(t, bus.Publish(context.Background(), "spy.commitfail.exhausted", makeSimpleEnvelope(t, "spy.commitfail.exhausted")))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		last := spy.last()
 		return last.Disposition == outbox.DispositionReject &&
 			last.Result == outbox.SettlementResultRetryExhausted
@@ -1766,7 +1782,7 @@ func TestNotifyRetryExhausted_LogsErrorWithContextualFields(t *testing.T) {
 	require.NoError(t, bus.Publish(context.Background(), topic, env))
 
 	// Wait for the retry budget to exhaust and the dead-letter record to appear.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		return bus.DeadLetterLen() > 0
 	}, busEventually10x, testtime.MediumPoll, "dead letter must be populated after retries exhausted")
 

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -212,7 +212,7 @@ func TestPublishSubscribe(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		return len(received) == 2
-	}, testtime.EventuallyShort, testtime.D10ms)
+	}, testtime.EventuallyShort, testtime.D10ms, "both published messages must be received before cancel")
 
 	cancel()
 	<-done
@@ -258,13 +258,13 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		return attempts.Load() >= 3
-	}, testtime.EventuallyDefault, testtime.MediumPoll)
+	}, testtime.EventuallyDefault, testtime.MediumPoll, "handler must be called 3 times before retries exhaust")
 
 	// Message should be in dead letter.
 	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-entry-received", func() bool {
 		return bus.DeadLetterLen() == 1
-	}, testtime.EventuallyShort, testtime.MediumPoll)
+	}, testtime.EventuallyShort, testtime.MediumPoll, "dead letter must have exactly one entry after redelivery budget exhausted")
 
 	dl := bus.DrainDeadLetters()
 	require.Len(t, dl, 1)
@@ -304,7 +304,7 @@ func TestSubscribe_RejectGoesDirectlyToDeadLetter(t *testing.T) {
 	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-entry-received", func() bool {
 		return bus.DeadLetterLen() == 1
-	}, testtime.EventuallyShort, testtime.MediumPoll)
+	}, testtime.EventuallyShort, testtime.MediumPoll, "rejected message must reach dead letter on first attempt without retries")
 
 	assert.Equal(t, int32(1), attempts.Load(), "reject should not trigger retries")
 
@@ -486,7 +486,7 @@ func TestMultipleSubscribers(t *testing.T) {
 	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-entry-received", func() bool {
 		return count1.Load() == 1 && count2.Load() == 1
-	}, testtime.EventuallyShort, testtime.D10ms)
+	}, testtime.EventuallyShort, testtime.D10ms, "both subscribers must each receive exactly one message")
 
 	cancel()
 	wg.Wait()

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -104,7 +104,6 @@ func TestPublish_EnvelopePayload_UnwrappedBeforeDelivery(t *testing.T) {
 	}`)
 	require.NoError(t, bus.Publish(context.Background(), "test.envelope.topic", envelope))
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-envelope-unwrapped", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
@@ -162,7 +161,7 @@ func TestPublish_InvalidEnvelope_Rejected(t *testing.T) {
 	require.Equal(t, errcode.ErrEnvelopeSchema, ce.Code)
 
 	// Dead letter should also record the dropped message for diagnostics.
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-dead-letter-non-empty", func() bool {
 		return bus.DeadLetterLen() > 0
 	}, testtime.EventuallyShort, testtime.FastPoll, "invalid envelope must be routed to dead letter")
 
@@ -207,8 +206,7 @@ func TestPublishSubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for processing.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-handler-count-reached", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return len(received) == 2
@@ -255,14 +253,12 @@ func TestSubscribe_RetryAndDeadLetter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for all retries to complete (3 attempts with delays: 100+200+400 = 700ms).
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		return attempts.Load() >= 3
 	}, testtime.EventuallyDefault, testtime.MediumPoll, "handler must be called 3 times before retries exhaust")
 
 	// Message should be in dead letter.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-dead-letter-non-empty", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, testtime.EventuallyShort, testtime.MediumPoll, "dead letter must have exactly one entry after redelivery budget exhausted")
 
@@ -301,8 +297,7 @@ func TestSubscribe_RejectGoesDirectlyToDeadLetter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should go directly to dead letter on first attempt (no retries).
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-dead-letter-non-empty", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, testtime.EventuallyShort, testtime.MediumPoll, "rejected message must reach dead letter on first attempt without retries")
 
@@ -342,8 +337,7 @@ func TestSubscribe_PermanentErrorInRequeue_WalksRetryBudget(t *testing.T) {
 	err := bus.Publish(context.Background(), "perm.requeue", makeSimpleEnvelope(t, "perm.requeue"))
 	require.NoError(t, err)
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-claim-released", func() bool {
+	testwait.External(t, "eventbus-retry-budget-exhausted", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually10x, testtime.MediumPoll)
 
@@ -483,8 +477,7 @@ func TestMultipleSubscribers(t *testing.T) {
 	err := bus.Publish(context.Background(), "multi.topic", makeSimpleEnvelope(t, "multi.topic"))
 	require.NoError(t, err)
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-fanout-both-received", func() bool {
 		return count1.Load() == 1 && count2.Load() == 1
 	}, testtime.EventuallyShort, testtime.D10ms, "both subscribers must each receive exactly one message")
 
@@ -516,7 +509,6 @@ func TestSubscribe_SuccessAfterRetry(t *testing.T) {
 	err := bus.Publish(context.Background(), "partial.fail", makeSimpleEnvelope(t, "partial.fail"))
 	require.NoError(t, err)
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-redelivery-attempted", func() bool {
 		return attempts.Load() >= 3
 	}, testtime.EventuallyDefault, testtime.MediumPoll)
@@ -616,7 +608,6 @@ func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
 	err := bus.Publish(context.Background(), "receipt.ack", makeSimpleEnvelope(t, "receipt.ack"))
 	require.NoError(t, err)
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventbus-publish-acked", func() bool {
 		return receipt.committed.Load()
 	}, testtime.EventuallyShort, testtime.D10ms, "receipt should be committed on Ack")
@@ -647,8 +638,7 @@ func TestSubscribe_ReceiptReleasedOnReject(t *testing.T) {
 	err := bus.Publish(context.Background(), "receipt.reject", makeSimpleEnvelope(t, "receipt.reject"))
 	require.NoError(t, err)
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-claim-released", func() bool {
+	testwait.External(t, "eventbus-receipt-released", func() bool {
 		return receipt.released.Load()
 	}, testtime.EventuallyShort, testtime.D10ms, "receipt should be released on Reject")
 
@@ -684,8 +674,7 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for all retries to exhaust.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-claim-released", func() bool {
+	testwait.External(t, "eventbus-retry-budget-exhausted", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -733,8 +722,7 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for retries to exhaust and message to land in dead letter.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-claim-released", func() bool {
+	testwait.External(t, "eventbus-retry-budget-exhausted", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -788,8 +776,7 @@ func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should exhaust retries and land in dead letter.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-claim-released", func() bool {
+	testwait.External(t, "eventbus-retry-budget-exhausted", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -847,8 +834,7 @@ func TestSubscribe_UnknownDisposition_TreatedAsRequeue(t *testing.T) {
 	err := bus.Publish(context.Background(), "unknown.disp", makeSimpleEnvelope(t, "unknown.disp"))
 	require.NoError(t, err)
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-claim-released", func() bool {
+	testwait.External(t, "eventbus-retry-budget-exhausted", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, busEventually5x, testtime.MediumPoll)
 
@@ -962,7 +948,7 @@ func TestConsumerGroup_SameGroup_CompetingConsumption(t *testing.T) {
 	}
 
 	// Wait for all messages to be handled.
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-handler-count-reached", func() bool {
 		return int(sub1Count.Load()+sub2Count.Load()) >= n
 	}, busEventually2x, testtime.D10ms, "all messages should be consumed")
 
@@ -1026,7 +1012,7 @@ func TestConsumerGroup_DifferentGroups_Fanout(t *testing.T) {
 		require.NoError(t, bus.Publish(ctx, "session.created", env))
 	}
 
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-fanout-both-received", func() bool {
 		return int(auditCount.Load()) >= n && int(configCount.Load()) >= n
 	}, busEventually2x, testtime.D10ms, "both groups should receive all messages")
 
@@ -1085,7 +1071,7 @@ func TestConsumerGroup_EmptyGroup_BackwardCompatible(t *testing.T) {
 		require.NoError(t, bus.Publish(ctx, "events.v1", env))
 	}
 
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-fanout-both-received", func() bool {
 		return int(sub1Count.Load()) >= n && int(sub2Count.Load()) >= n
 	}, busEventually2x, testtime.D10ms, "both empty-group subs should get all messages")
 
@@ -1155,7 +1141,7 @@ func TestConsumerGroup_ConcurrentPublish_NoRace(t *testing.T) {
 	pubWg.Wait()
 
 	totalExpected := numPublishers * msgsPerPublisher
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-handler-count-reached", func() bool {
 		return totalReceived.Load() >= int64(totalExpected)
 	}, busEventually3x, testtime.D10ms,
 		"all messages should be consumed: got %d, want %d", totalReceived.Load(), totalExpected)
@@ -1255,8 +1241,7 @@ func TestReleaseReceipt_FailedRelease_LogsError(t *testing.T) {
 	require.NoError(t, err)
 
 	// The message must land in dead letter despite the Release failure.
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
-	testwait.External(t, "eventbus-entry-received", func() bool {
+	testwait.External(t, "eventbus-dead-letter-non-empty", func() bool {
 		return bus.DeadLetterLen() == 1
 	}, testtime.EventuallyShort, testtime.D10ms, "rejected message must reach dead letter even when Release fails")
 

--- a/runtime/eventrouter/router_test.go
+++ b/runtime/eventrouter/router_test.go
@@ -138,7 +138,6 @@ func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 
 	// Subscribe goroutines are launched concurrently; give them a moment to
 	// register their topics (they run after Phase 3 Ready signals close).
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
 	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
 		topics := sub.Topics()
 		return len(topics) == 3
@@ -150,7 +149,6 @@ func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 	assert.Contains(t, topics, "topic.c")
 
 	cancel()
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
 	testwait.External(t, "eventrouter-drain-completed", func() bool {
 		select {
 		case <-done:
@@ -248,7 +246,6 @@ func TestRouter_Run_HandlerReceivesMessages(t *testing.T) {
 	err := bus.Publish(context.Background(), "test.topic", []byte(`{"key":"value"}`))
 	require.NoError(t, err)
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
 	testwait.External(t, "eventrouter-delivery-routed", func() bool {
 		return received.Load() >= 1
 	}, testtime.EventuallyShort, testtime.D10ms)
@@ -281,7 +278,6 @@ func TestRouter_Run_MultipleHandlersSameSubscriber(t *testing.T) {
 	require.NoError(t, bus.Publish(context.Background(), "topic.a", []byte(`{}`)))
 	require.NoError(t, bus.Publish(context.Background(), "topic.b", []byte(`{}`)))
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
 	testwait.External(t, "eventrouter-delivery-routed", func() bool {
 		return countA.Load() >= 1 && countB.Load() >= 1
 	}, testtime.EventuallyShort, testtime.D10ms)
@@ -315,7 +311,6 @@ func TestRouter_RegistryRecorder_Integration(t *testing.T) {
 
 	require.NoError(t, bus.Publish(context.Background(), "mock.topic", []byte(`{}`)))
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
 	testwait.External(t, "eventrouter-delivery-routed", func() bool {
 		return received.Load() >= 1
 	}, testtime.EventuallyShort, testtime.D10ms)
@@ -364,8 +359,7 @@ func TestRouter_HealthLifecycle(t *testing.T) {
 
 	require.NoError(t, r.Health(), "router must be healthy after startup")
 
-	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
-	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
+	testwait.External(t, "eventrouter-runtime-failure-unhealthy", func() bool {
 		return r.Health() != nil
 	}, testtime.D2s, testtime.D20ms, "router must become unhealthy after runtime failure")
 
@@ -767,7 +761,7 @@ func TestRouter_ConsumerGroup_PropagatesToSubscriber(t *testing.T) {
 	go func() { done <- r.Run(ctx) }()
 
 	// Wait for all subscriptions to start.
-	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
+	testwait.External(t, "eventrouter-subscriptions-all-started", func() bool {
 		return len(sub.Calls()) >= 3
 	}, testtime.D2s, testtime.D10ms)
 
@@ -826,7 +820,7 @@ func TestRouter_OwnerCellID_DistinctFromConsumerGroup(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- r.Run(ctx) }()
 
-	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
+	testwait.External(t, "eventrouter-subscription-call-observed", func() bool {
 		return len(sub.Calls()) >= 1
 	}, testtime.D2s, testtime.D10ms)
 

--- a/runtime/eventrouter/router_test.go
+++ b/runtime/eventrouter/router_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // routerReadyDelay is the time a delayed subscriber takes to signal ready; used
@@ -137,7 +138,8 @@ func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 
 	// Subscribe goroutines are launched concurrently; give them a moment to
 	// register their topics (they run after Phase 3 Ready signals close).
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); sibling asserts below run unconditionally.
+	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
 		topics := sub.Topics()
 		return len(topics) == 3
 	}, testtime.D2s, testtime.D10ms, "all 3 topics should be subscribed")
@@ -148,7 +150,8 @@ func TestRouter_Run_StartsAllSubscriptions(t *testing.T) {
 	assert.Contains(t, topics, "topic.c")
 
 	cancel()
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
+	testwait.External(t, "eventrouter-drain-completed", func() bool {
 		select {
 		case <-done:
 			return true
@@ -245,7 +248,8 @@ func TestRouter_Run_HandlerReceivesMessages(t *testing.T) {
 	err := bus.Publish(context.Background(), "test.topic", []byte(`{"key":"value"}`))
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
+	testwait.External(t, "eventrouter-delivery-routed", func() bool {
 		return received.Load() >= 1
 	}, testtime.EventuallyShort, testtime.D10ms)
 
@@ -277,7 +281,8 @@ func TestRouter_Run_MultipleHandlersSameSubscriber(t *testing.T) {
 	require.NoError(t, bus.Publish(context.Background(), "topic.a", []byte(`{}`)))
 	require.NoError(t, bus.Publish(context.Background(), "topic.b", []byte(`{}`)))
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
+	testwait.External(t, "eventrouter-delivery-routed", func() bool {
 		return countA.Load() >= 1 && countB.Load() >= 1
 	}, testtime.EventuallyShort, testtime.D10ms)
 
@@ -310,7 +315,8 @@ func TestRouter_RegistryRecorder_Integration(t *testing.T) {
 
 	require.NoError(t, bus.Publish(context.Background(), "mock.topic", []byte(`{}`)))
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
+	testwait.External(t, "eventrouter-delivery-routed", func() bool {
 		return received.Load() >= 1
 	}, testtime.EventuallyShort, testtime.D10ms)
 
@@ -358,7 +364,8 @@ func TestRouter_HealthLifecycle(t *testing.T) {
 
 	require.NoError(t, r.Health(), "router must be healthy after startup")
 
-	assert.Eventually(t, func() bool {
+	// MIGRATION-NOTE: assert.Eventually → testwait.External (FailNow semantics); no sibling asserts after.
+	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
 		return r.Health() != nil
 	}, testtime.D2s, testtime.D20ms, "router must become unhealthy after runtime failure")
 
@@ -760,7 +767,7 @@ func TestRouter_ConsumerGroup_PropagatesToSubscriber(t *testing.T) {
 	go func() { done <- r.Run(ctx) }()
 
 	// Wait for all subscriptions to start.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
 		return len(sub.Calls()) >= 3
 	}, testtime.D2s, testtime.D10ms)
 
@@ -819,7 +826,7 @@ func TestRouter_OwnerCellID_DistinctFromConsumerGroup(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- r.Run(ctx) }()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "eventrouter-subscription-mounted", func() bool {
 		return len(sub.Calls()) >= 1
 	}, testtime.D2s, testtime.D10ms)
 

--- a/runtime/outbox/relay_internal_test.go
+++ b/runtime/outbox/relay_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	kout "github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // relayStaleAge is the age used to seed "old enough to delete" entries.
@@ -300,10 +301,10 @@ func TestRelay_Cleanup_DeletesPublishedAndDead(t *testing.T) {
 		clock:   clock.Real(),
 	}
 
-	// Use Eventually so the test remains deterministic: the 1ms retention period
+	// Use testwait.External so the test remains deterministic: the 1ms retention period
 	// must have elapsed before cleanup can delete entries. In practice the 48h-old
 	// timestamps far predate any reasonable cutoff, so this resolves in one tick.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-batch-drained", func() bool {
 		if err := relay.cleanup(context.Background()); err != nil {
 			return false
 		}

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -16,6 +16,7 @@ import (
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	kout "github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
 )
@@ -334,7 +335,7 @@ func TestRelay_Shutdown_CleanStop(t *testing.T) {
 	go func() { errCh <- relay.Start(ctx) }()
 
 	// Wait for relay to reach running state via Ready() instead of time.Sleep.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-published", func() bool {
 		ch := relay.Ready()
 		if ch == nil {
 			return false
@@ -413,7 +414,7 @@ func TestRelay_DoubleStart_Error(t *testing.T) {
 
 	go func() { _ = relay.Start(t.Context()) }()
 	// Wait for relay to reach running state.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-published", func() bool {
 		ch := relay.Ready()
 		if ch == nil {
 			return false
@@ -441,7 +442,7 @@ func TestRelay_CanRestartAfterStop(t *testing.T) {
 		go func() { errCh <- relay.Start(ctx) }()
 
 		// Wait for relay to be ready before stopping.
-		require.Eventually(t, func() bool {
+		testwait.External(t, "outbox-relay-published", func() bool {
 			ch := relay.Ready()
 			if ch == nil {
 				return false
@@ -835,7 +836,7 @@ func TestRelay_HandleFailedEntry_LostStat(t *testing.T) {
 	// so the deterministic waitStore/waitPub helpers don't apply. Budget is
 	// testtime.D1s (already conventional, not the D500ms-flake class) and
 	// state convergence here is a single int counter assignment.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-claim-acquired", func() bool {
 		mc.mu.Lock()
 		defer mc.mu.Unlock()
 		for _, c := range mc.pollCycles {
@@ -881,7 +882,7 @@ func TestRelay_PollFailureBudget_TripsAfterConsecutiveFailures(t *testing.T) {
 	defer stop()
 
 	// Wait for the poll budget checker to become non-nil (trip).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-retry-scheduled", func() bool {
 		checkers := relay.Checkers()
 		fn, ok := checkers["outbox-relay-poll"]
 		if !ok {
@@ -901,7 +902,7 @@ func TestRelay_PollFailureBudget_ResetsOnSuccess(t *testing.T) {
 	defer stop()
 
 	// Trip first.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-retry-scheduled", func() bool {
 		checkers := relay.Checkers()
 		fn, ok := checkers["outbox-relay-poll"]
 		return ok && fn(context.Background()) != nil
@@ -911,7 +912,7 @@ func TestRelay_PollFailureBudget_ResetsOnSuccess(t *testing.T) {
 	store.setClaimErr(nil)
 
 	// Checker must recover.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-published", func() bool {
 		checkers := relay.Checkers()
 		fn, ok := checkers["outbox-relay-poll"]
 		return ok && fn(context.Background()) == nil
@@ -928,7 +929,7 @@ func TestRelay_ReclaimFailureBudget_Independent(t *testing.T) {
 	stop := startRelay(t, relay)
 	defer stop()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-retry-scheduled", func() bool {
 		checkers := relay.Checkers()
 		fn, ok := checkers["outbox-relay-reclaim"]
 		return ok && fn(context.Background()) != nil
@@ -955,7 +956,7 @@ func TestRelay_CleanupFailureBudget_Independent(t *testing.T) {
 	stop := startRelay(t, relay)
 	defer stop()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-retry-scheduled", func() bool {
 		checkers := relay.Checkers()
 		fn, ok := checkers["outbox-relay-cleanup"]
 		return ok && fn(context.Background()) != nil
@@ -1009,7 +1010,7 @@ func TestRelay_CanRestartAfterTrip_ResetsBudget(t *testing.T) {
 	// --- First run: trip the poll budget ---
 	stop := startRelay(t, relay)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-retry-scheduled", func() bool {
 		checkers := relay.Checkers()
 		fn, ok := checkers["outbox-relay-poll"]
 		return ok && fn(context.Background()) != nil
@@ -1018,7 +1019,7 @@ func TestRelay_CanRestartAfterTrip_ResetsBudget(t *testing.T) {
 	stop() // gracefully stop; defer in Start resets readyCh for next Start
 
 	// Wait until state is relayStopped so we can restart.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-batch-drained", func() bool {
 		checkers := relay.Checkers()
 		fn, ok := checkers["outbox-relay-poll"]
 		// The checker still exists; it reflects state at the time of the last run.
@@ -1058,7 +1059,7 @@ func TestRelay_Ready_ReturnsReadyChannel(t *testing.T) {
 
 	// Ready() never returns nil (B1: pre-allocated in NewRelay). Before Start()
 	// completes, the channel is open (blocks); after relayRunning, it is closed.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-published", func() bool {
 		ch := relay.Ready()
 		select {
 		case <-ch:

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -223,7 +223,7 @@ func TestHub_Checkers_StateMachine(t *testing.T) {
 		go func() { startErr <- hub.Start(context.Background()) }()
 		testwait.External(t, "hub-state-running", func() bool {
 			return hub.state.Load() == stateRunning
-		}, testtime.EventuallyShort, testtime.D1ms)
+		}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before stopping_via_live_shutdown")
 
 		stuck := &stuckConn{id: "t4b-stuck", closeCh: make(chan struct{})}
 		require.NoError(t, hub.Register(context.Background(), stuck))
@@ -260,7 +260,7 @@ func TestHub_ManagedResource_CloseIsIdempotent(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before Close idempotency test")
 
 	ctx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer cancel()
@@ -283,7 +283,7 @@ func TestHub_ManagedResource_WorkerDrivesStartAndStop(t *testing.T) {
 	go func() { startErr <- w.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before Worker-driven Stop test")
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer cancel()
@@ -342,7 +342,7 @@ func TestHub_BoundedConcurrentClose_RespectsLimit(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before bounded-concurrent-close test")
 
 	const n = 5
 	blockers := make([]*closeBlockerConn, n)
@@ -391,7 +391,7 @@ func TestHub_BoundedConcurrentClose_AllEntriesGetCloseAttempt(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before all-entries-close-attempt test")
 
 	const n = 20
 	blockers := make([]*closeBlockerConn, n)
@@ -448,7 +448,7 @@ func TestHub_BoundedConcurrentClose_ParallelDrain(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before parallel-drain test")
 
 	for i := range n {
 		fc := newFakeConn(fmt.Sprintf("delay-%d", i))
@@ -484,7 +484,7 @@ func TestHub_ExternalCancel_UsesConfiguredShutdownTimeout(t *testing.T) {
 	go func() { startErr <- hub.Start(ctx) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before external-cancel shutdown-timeout test")
 
 	const n = 5
 	blockers := make([]*closeBlockerConn, n)
@@ -536,7 +536,7 @@ func TestHub_StopAndExternalCancel_RaceCAS(t *testing.T) {
 	go func() { startErr <- hub.Start(ctx) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before Stop×cancel race test")
 
 	// Barrier: both goroutines wait until both are ready, then fire simultaneously.
 	var barrier sync.WaitGroup
@@ -606,7 +606,7 @@ func TestHub_StopUnblocksStart(t *testing.T) {
 
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before Stop-unblocks-Start test")
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer cancel()
@@ -634,7 +634,7 @@ func TestHub_DoubleStop(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before double-Stop test")
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer cancel()
@@ -667,7 +667,7 @@ func TestHub_StopTimeout(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before Stop-timeout test")
 
 	// Register a conn whose Close is a no-op (readLoop never exits).
 	stuck := &stuckConn{id: "stuck", closeCh: make(chan struct{})}
@@ -694,7 +694,7 @@ func TestHub_ExternalContextCancel(t *testing.T) {
 
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before external-context-cancel test")
 
 	// Register a conn before cancel.
 	conn := newFakeConn("pre-cancel")
@@ -783,7 +783,7 @@ func TestHub_RegisterUsesContextValues(t *testing.T) {
 
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before register-uses-context-values test")
 
 	conn := newFakeConn("context-values")
 	require.NoError(t, hub.Register(registerCtx, conn))
@@ -804,7 +804,7 @@ func TestHub_RegisterDuringStop(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before register-during-stop test")
 
 	// Force state to stopping to simulate mid-Stop window.
 	hub.state.Store(stateStopping)
@@ -924,7 +924,7 @@ func TestHub_RegisterStopRace(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before register-stop-race test")
 
 	const n = 100
 	var registerWg sync.WaitGroup
@@ -1182,7 +1182,7 @@ func TestHub_StopDeadlineHonored(t *testing.T) {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning before stop-deadline-honored test")
 
 	// Register a stuck conn that blocks Close.
 	stuck := &stuckConn{id: "blocker", closeCh: make(chan struct{})}
@@ -1420,7 +1420,7 @@ func startHubBackground(t *testing.T) *Hub {
 	go func() { startErr <- hub.Start(context.Background()) }()
 	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
-	}, testtime.EventuallyShort, testtime.D1ms)
+	}, testtime.EventuallyShort, testtime.D1ms, "hub failed to reach stateRunning")
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 		defer cancel()

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -221,7 +221,7 @@ func TestHub_Checkers_StateMachine(t *testing.T) {
 		hub := NewHub(DefaultHubConfig(clock.Real()), nil)
 		startErr := make(chan error, 1)
 		go func() { startErr <- hub.Start(context.Background()) }()
-		require.Eventually(t, func() bool {
+		testwait.External(t, "hub-state-running", func() bool {
 			return hub.state.Load() == stateRunning
 		}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -236,7 +236,7 @@ func TestHub_Checkers_StateMachine(t *testing.T) {
 		go func() { stopDone <- hub.Stop(stopCtx) }()
 
 		// Wait until hub is stopping.
-		require.Eventually(t, func() bool {
+		testwait.External(t, "hub-state-stopping", func() bool {
 			return hub.state.Load() >= stateStopping
 		}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -258,7 +258,7 @@ func TestHub_ManagedResource_CloseIsIdempotent(t *testing.T) {
 	hub := NewHub(DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -281,7 +281,7 @@ func TestHub_ManagedResource_WorkerDrivesStartAndStop(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- w.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -340,7 +340,7 @@ func TestHub_BoundedConcurrentClose_RespectsLimit(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -350,7 +350,7 @@ func TestHub_BoundedConcurrentClose_RespectsLimit(t *testing.T) {
 		blockers[i] = newCloseBlockerConn(fmt.Sprintf("blocker-%d", i))
 		require.NoError(t, hub.Register(context.Background(), blockers[i]))
 	}
-	require.Eventually(t, func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
+	testwait.External(t, "hub-conn-count-reached", func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), testtime.D50ms)
 	defer cancel()
@@ -389,7 +389,7 @@ func TestHub_BoundedConcurrentClose_AllEntriesGetCloseAttempt(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -399,7 +399,7 @@ func TestHub_BoundedConcurrentClose_AllEntriesGetCloseAttempt(t *testing.T) {
 		blockers[i] = newCloseBlockerConn(fmt.Sprintf("blocker-%d", i))
 		require.NoError(t, hub.Register(context.Background(), blockers[i]))
 	}
-	require.Eventually(t, func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
+	testwait.External(t, "hub-conn-count-reached", func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), testtime.D50ms)
 	defer cancel()
@@ -416,7 +416,7 @@ func TestHub_BoundedConcurrentClose_AllEntriesGetCloseAttempt(t *testing.T) {
 	// Contract: every entry's Close() must complete after release.
 	// Pre-fix this would FAIL — only the first ConcurrentCloseLimit entries
 	// would have been launched; the rest would never observe Close().
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-closed-all", func() bool {
 		for _, b := range blockers {
 			if !b.isClosed() {
 				return false
@@ -446,7 +446,7 @@ func TestHub_BoundedConcurrentClose_ParallelDrain(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -455,7 +455,7 @@ func TestHub_BoundedConcurrentClose_ParallelDrain(t *testing.T) {
 		fc.closeDelay = closeDelay
 		require.NoError(t, hub.Register(context.Background(), fc))
 	}
-	require.Eventually(t, func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
+	testwait.External(t, "hub-conn-count-reached", func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), serialBound)
 	defer cancel()
@@ -482,7 +482,7 @@ func TestHub_ExternalCancel_UsesConfiguredShutdownTimeout(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(ctx) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -492,7 +492,7 @@ func TestHub_ExternalCancel_UsesConfiguredShutdownTimeout(t *testing.T) {
 		blockers[i] = newCloseBlockerConn(fmt.Sprintf("ext-%d", i))
 		require.NoError(t, hub.Register(context.Background(), blockers[i]))
 	}
-	require.Eventually(t, func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
+	testwait.External(t, "hub-conn-count-reached", func() bool { return hub.ConnCount() == n }, testtime.EventuallyShort, testtime.D1ms)
 
 	start := time.Now()
 	cancelCtx()
@@ -534,7 +534,7 @@ func TestHub_StopAndExternalCancel_RaceCAS(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(ctx) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -604,7 +604,7 @@ func TestHub_StopUnblocksStart(t *testing.T) {
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -632,7 +632,7 @@ func TestHub_DoubleStop(t *testing.T) {
 	hub := NewHub(DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -665,7 +665,7 @@ func TestHub_StopTimeout(t *testing.T) {
 	hub := NewHub(DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -692,7 +692,7 @@ func TestHub_ExternalContextCancel(t *testing.T) {
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(ctx) }()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -750,7 +750,7 @@ func TestHub_RegisterAndReadLoop(t *testing.T) {
 
 	conn.readCh <- []byte("hello server")
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-message-delivered", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return gotMsg != ""
@@ -781,7 +781,7 @@ func TestHub_RegisterUsesContextValues(t *testing.T) {
 		<-startErr
 	})
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -802,7 +802,7 @@ func TestHub_RegisterDuringStop(t *testing.T) {
 	hub := NewHub(DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -844,7 +844,7 @@ func TestHub_Unregister(t *testing.T) {
 	assert.Equal(t, 1, hub.ConnCount())
 	hub.Unregister("c1")
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-count-zero", func() bool {
 		return hub.ConnCount() == 0
 	}, testtime.EventuallyShort, testtime.D10ms)
 	assert.True(t, conn.isClosed())
@@ -860,7 +860,7 @@ func TestHub_UnregisterIdempotent(t *testing.T) {
 	hub.Unregister("c1")
 	hub.Unregister("c1") // should not panic
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-count-zero", func() bool {
 		return hub.ConnCount() == 0
 	}, testtime.EventuallyShort, testtime.D10ms)
 }
@@ -884,7 +884,7 @@ func TestHub_RegisterDuplicateID(t *testing.T) {
 	// Send to "dup" should reach connB, not connA.
 	// Send enqueues on the per-conn channel; writeLoop delivers asynchronously.
 	require.NoError(t, hub.Send(context.Background(), "dup", []byte("hello")))
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-message-delivered", func() bool {
 		return len(connB.getWrites()) == 1
 	}, testtime.D2s, testtime.D10ms)
 	assert.Equal(t, [][]byte{[]byte("hello")}, connB.getWrites())
@@ -922,7 +922,7 @@ func TestHub_RegisterStopRace(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -960,7 +960,7 @@ func TestHub_Send(t *testing.T) {
 
 	require.NoError(t, hub.Send(context.Background(), "target", []byte("direct")))
 	// Send enqueues on the per-conn channel; writeLoop delivers asynchronously.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-message-delivered", func() bool {
 		return len(conn.getWrites()) == 1
 	}, testtime.D2s, testtime.D10ms)
 	assert.Equal(t, [][]byte{[]byte("direct")}, conn.getWrites())
@@ -999,7 +999,7 @@ func TestHub_MessageHandler(t *testing.T) {
 
 	conn.readCh <- []byte("payload")
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-message-delivered", func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return gotMsg != ""
@@ -1029,7 +1029,7 @@ func TestHub_PingMissThreshold(t *testing.T) {
 	require.NoError(t, hub.Register(context.Background(), conn))
 	<-conn.readyCh
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-closed", func() bool {
 		return hub.ConnCount() == 0 && conn.isClosed()
 	}, testtime.D2s, testtime.D10ms)
 }
@@ -1048,7 +1048,7 @@ func TestHub_PingMissReset(t *testing.T) {
 	<-conn.readyCh
 
 	// Let 2 ping misses accumulate (below threshold).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-ping-miss-accumulated", func() bool {
 		hub.connMu.Lock()
 		e, ok := hub.conns["resilient"]
 		var misses int
@@ -1065,7 +1065,7 @@ func TestHub_PingMissReset(t *testing.T) {
 	conn.mu.Unlock()
 
 	// Wait for a successful ping to reset misses.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-ping-miss-reset", func() bool {
 		hub.connMu.Lock()
 		e, ok := hub.conns["resilient"]
 		var misses int
@@ -1167,7 +1167,7 @@ func TestHub_IsRunning(t *testing.T) {
 
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool { return hub.IsRunning() }, testtime.EventuallyShort, testtime.D1ms)
+	testwait.External(t, "hub-is-running", func() bool { return hub.IsRunning() }, testtime.EventuallyShort, testtime.D1ms)
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer cancel()
@@ -1180,7 +1180,7 @@ func TestHub_StopDeadlineHonored(t *testing.T) {
 	hub := NewHub(DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 
@@ -1418,7 +1418,7 @@ func startHubBackground(t *testing.T) *Hub {
 	hub := NewHub(DefaultHubConfig(clock.Real()), nil)
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-state-running", func() bool {
 		return hub.state.Load() == stateRunning
 	}, testtime.EventuallyShort, testtime.D1ms)
 	t.Cleanup(func() {
@@ -1498,7 +1498,7 @@ func TestHub_IsRunning_Contract(t *testing.T) {
 	// running
 	startErr := make(chan error, 1)
 	go func() { startErr <- hub.Start(context.Background()) }()
-	require.Eventually(t, func() bool { return hub.IsRunning() }, testtime.EventuallyShort, testtime.D1ms)
+	testwait.External(t, "hub-is-running", func() bool { return hub.IsRunning() }, testtime.EventuallyShort, testtime.D1ms)
 
 	// stop → not running
 	ctx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
@@ -1539,7 +1539,7 @@ func TestHub_BroadcastFilter_AllConns(t *testing.T) {
 	require.NoError(t, hub.BroadcastFilter(context.Background(), []byte("hi"),
 		func(c Conn) bool { return true }))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-broadcast-delivered", func() bool {
 		return len(a.getWrites()) == 1 && len(b.getWrites()) == 1
 	}, testtime.D2s, testtime.D10ms)
 }
@@ -1558,7 +1558,7 @@ func TestHub_BroadcastFilter_SelectiveBySubject(t *testing.T) {
 	require.NoError(t, hub.BroadcastFilter(context.Background(), []byte("only-alice"),
 		func(c Conn) bool { return c.Principal() != nil && c.Principal().Subject == "alice" }))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-broadcast-delivered", func() bool {
 		return len(a.getWrites()) == 1
 	}, testtime.D2s, testtime.D10ms)
 
@@ -1589,7 +1589,7 @@ func TestHub_BroadcastToSubject_HitsAllConnsForSubject(t *testing.T) {
 
 	require.NoError(t, hub.BroadcastToSubject(context.Background(), "alice", []byte("ping-alice")))
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-broadcast-delivered", func() bool {
 		return len(a1.getWrites()) == 1 && len(a2.getWrites()) == 1
 	}, testtime.D2s, testtime.D10ms)
 	assert.Never(t, func() bool { return len(b.getWrites()) > 0 }, testtime.D100ms, testtime.D10ms)
@@ -1629,7 +1629,7 @@ func TestHub_TokenExpiry_EvictsOnPing(t *testing.T) {
 	waitForHubPingTicker(t, fc)
 	fc.Advance(testtime.D2h)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-closed", func() bool {
 		return hub.ConnCount() == 0 && conn.isClosed()
 	}, testtime.D2s, testtime.D10ms)
 }
@@ -1662,7 +1662,7 @@ func TestHub_TokenExpiry_AtBoundaryEvicts(t *testing.T) {
 	waitForHubPingTicker(t, fc)
 	fc.Advance(testtime.D10ms)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-closed", func() bool {
 		return hub.ConnCount() == 0 && conn.isClosed()
 	}, testtime.D2s, testtime.D10ms,
 		"ExpiresAt == clock.Now() must evict (RFC 7519: on-or-after exp = expired)")
@@ -1739,7 +1739,7 @@ func TestHub_SlowClient_EvictedWhenSendBufferFull(t *testing.T) {
 		_ = hub.BroadcastToSubject(context.Background(), "slow", []byte("burst"))
 	}
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-count-zero", func() bool {
 		return hub.ConnCount() == 0
 	}, testtime.D2s, testtime.D10ms,
 		"slow client must be evicted once send buffer fills")
@@ -1757,7 +1757,7 @@ func TestHub_SubjectIdx_EmptyAfterRegisterUnregister(t *testing.T) {
 	<-conn.readyCh
 
 	hub.Unregister("a")
-	require.Eventually(t, func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)
+	testwait.External(t, "hub-conn-count-zero", func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)
 
 	// Idx must be empty so a future BroadcastToSubject is a no-op.
 	err := hub.BroadcastToSubject(context.Background(), "alice", []byte("x"))
@@ -1780,7 +1780,7 @@ func TestHub_SubjectIdx_EmptyAfterTokenExpiry(t *testing.T) {
 	waitForHubPingTicker(t, fc)
 	fc.Advance(testtime.D2h)
 
-	require.Eventually(t, func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)
+	testwait.External(t, "hub-conn-count-zero", func() bool { return hub.ConnCount() == 0 }, testtime.D2s, testtime.D10ms)
 
 	err := hub.BroadcastToSubject(context.Background(), "alice", []byte("x"))
 	assert.NoError(t, err)
@@ -1836,7 +1836,7 @@ func TestHub_BroadcastFilter_FilterRunsWithoutLock(t *testing.T) {
 	}
 
 	// The direct Send inside the filter should have enqueued one message.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-message-delivered", func() bool {
 		return len(conn.getWrites()) >= 1
 	}, testtime.D2s, testtime.D10ms)
 }
@@ -1946,7 +1946,7 @@ func TestHub_PrincipalSnapshot_StableAfterMutation(t *testing.T) {
 
 	// BroadcastToSubject with the original subject must still reach the conn.
 	require.NoError(t, hub.BroadcastToSubject(context.Background(), "original", []byte("ping")))
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-broadcast-delivered", func() bool {
 		return len(conn.getWrites()) == 1
 	}, testtime.D2s, testtime.D10ms,
 		"subjectIdx must use snapshotted subject, not the mutated one")
@@ -2005,7 +2005,7 @@ func TestHub_WriteFailureEvictsConnection(t *testing.T) {
 	}
 
 	// After write failure, writeLoop should have evicted the connection.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-count-zero", func() bool {
 		return hub.ConnCount() == 0
 	}, testtime.D2s, testtime.D10ms,
 		"write failure must evict connection")
@@ -2027,7 +2027,7 @@ func TestHub_PanicSafe_NoSendOnClosedChannel(t *testing.T) {
 	}
 
 	// Wait for all readLoops to be active.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "hub-conn-count-reached", func() bool {
 		return hub.ConnCount() == n
 	}, testtime.EventuallyShort, testtime.D1ms)
 

--- a/runtime/worker/worker_test.go
+++ b/runtime/worker/worker_test.go
@@ -15,6 +15,7 @@ import (
 	kworker "github.com/ghbvf/gocell/kernel/worker"
 
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // testWorker is a simple Worker implementation for testing.
@@ -68,7 +69,7 @@ func TestWorkerGroup_StartStop(t *testing.T) {
 	}()
 
 	// Wait for workers to start.
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "worker-started", func() bool {
 		return w1.started.Load() && w2.started.Load()
 	}, testtime.EventuallyShort, testtime.D10ms)
 
@@ -172,7 +173,7 @@ func TestPeriodicWorker_ExecutesFunction(t *testing.T) {
 	}()
 
 	// Wait for at least 3 executions.
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "worker-tick-executed", func() bool {
 		return count.Load() >= 3
 	}, testtime.EventuallyShort, testtime.FastPoll)
 
@@ -196,7 +197,7 @@ func TestPeriodicWorker_PanicIsolation(t *testing.T) {
 	}()
 
 	// After panic on first call, subsequent calls should still work.
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "worker-tick-executed", func() bool {
 		return count.Load() >= 3
 	}, testtime.EventuallyShort, testtime.FastPoll)
 
@@ -236,7 +237,7 @@ func TestPeriodicWorker_RestartAfterStop(t *testing.T) {
 		done <- pw.Start(context.Background())
 	}()
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "worker-tick-executed", func() bool {
 		return count.Load() >= 2
 	}, testtime.EventuallyShort, testtime.FastPoll)
 
@@ -253,7 +254,7 @@ func TestPeriodicWorker_RestartAfterStop(t *testing.T) {
 		done2 <- pw.Start(context.Background())
 	}()
 
-	assert.Eventually(t, func() bool {
+	testwait.External(t, "worker-tick-executed", func() bool {
 		return count.Load() >= countAfterFirstStop+2
 	}, testtime.EventuallyShort, testtime.FastPoll)
 

--- a/tests/integration/internal_rpc_caller_cell_test.go
+++ b/tests/integration/internal_rpc_caller_cell_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/keystest"
@@ -244,7 +245,7 @@ func startCallerCellApp(t *testing.T) *callerCellApp {
 
 	// Wait for the primary listener to serve /healthz (signals full bootstrap).
 	primaryAddr := primaryLn.Addr().String()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "integration-internal-rpc-caller-cell-asserted", func() bool {
 		resp, err := callerCellHTTPClient.Get(fmt.Sprintf("http://%s/healthz", primaryAddr))
 		if err != nil {
 			return false

--- a/tests/integration/l2atomicity/harness_test.go
+++ b/tests/integration/l2atomicity/harness_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/keystest"
@@ -521,7 +522,7 @@ func runBootstrap(
 // when only /healthz was probed).
 func waitForHealthz(t *testing.T, base string) {
 	t.Helper()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-harness-server-ready", func() bool {
 		if !httpGetOK(base + "/healthz") {
 			return false
 		}

--- a/tests/integration/l2atomicity/journey_accountlockout_e2e_test.go
+++ b/tests/integration/l2atomicity/journey_accountlockout_e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // jAccountlockoutThreshold mirrors cells/accesscore/internal/accountlockout.Threshold.
@@ -117,7 +118,7 @@ func TestJAccountlockoutAutoLockCycle(t *testing.T) {
 	// "user.locked 事件发布成功" criterion would only be inferred from the
 	// status-flip side effect — a noop emitter would silently satisfy the
 	// rest of the test.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-user-locked-event-audited", func() bool {
 		return countAuditEntries(t, ctx, h, eventUserLockedV1) > lockedAuditBaseline
 	}, testtime.EventuallyLong, testtime.D100ms,
 		"event.user.locked.v1 must be published to outbox and consumed by auditcore on auto-lock")

--- a/tests/integration/l2atomicity/refresh_reuse_e2e_test.go
+++ b/tests/integration/l2atomicity/refresh_reuse_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 )
 
@@ -69,12 +70,12 @@ func TestL2_RefreshReuseTriggersCascade(t *testing.T) {
 	// returns. The require.Eventually wrapper exists only to absorb the small
 	// CI-side gap between handler completion and SELECT visibility under load;
 	// the cascade itself is not eventually-consistent.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-reuse-epoch-advanced", func() bool {
 		return queryUserAuthzEpoch(t, h, victimID) > epochBefore
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"users.authz_epoch must advance after reuse cascade (epochBefore=%d)", epochBefore)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-reuse-sessions-revoked", func() bool {
 		return countLiveSessions(t, h, victimID) == 0
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"all victim sessions must be revoked after reuse cascade")
@@ -83,7 +84,7 @@ func TestL2_RefreshReuseTriggersCascade(t *testing.T) {
 	// this assertion the test would still pass if RevokeUser degraded to a no-op
 	// (epoch bump + session revoke alone would still make access tokens 401).
 	// Verify both the DB-row terminal state and the HTTP-surface effect.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-reuse-refresh-tokens-revoked", func() bool {
 		return countLiveRefreshTokensForSubject(t, h, victimID) == 0
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"all victim refresh tokens must be revoked after reuse cascade (RevokeUser third op)")

--- a/tests/integration/l2atomicity/revoke_cascade_e2e_test.go
+++ b/tests/integration/l2atomicity/revoke_cascade_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // eventRoleRevokedV1 mirrors cells/accesscore/internal/dto.TopicRoleRevoked.
@@ -84,12 +85,12 @@ func TestL2_RbacRevokeRevokesSessions(t *testing.T) {
 	// require.Eventually wrapper absorbs the small CI-side gap between handler
 	// completion and SELECT visibility under load; the cascade itself is not
 	// eventually-consistent.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-revoke-epoch-advanced", func() bool {
 		return queryUserAuthzEpoch(t, h, victimID) > epochBefore
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"users.authz_epoch must advance after role revoke cascade (epochBefore=%d)", epochBefore)
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-revoke-sessions-cleared", func() bool {
 		return countLiveSessions(t, h, victimID) == 0
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"all victim sessions must be revoked after role revoke cascade")
@@ -111,7 +112,7 @@ func TestL2_RbacRevokeRevokesSessions(t *testing.T) {
 	// "accesscore" per assignRole / revokeRole), satisfying the auditcore
 	// role consumer's ActorRequireExplicit mode. Without that fix the
 	// event would DLX and this assertion would (correctly) fail.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "l2-revoke-audit-appended", func() bool {
 		return countAuditEntries(t, ctx, h, eventRoleRevokedV1) > revokedAuditedBefore
 	}, testtime.EventuallyLong, testtime.MediumPoll,
 		"auditcore must append an additional event.role.revoked.v1 entry after the role revoke (before=%d)",

--- a/tests/integration/outbox_failure_paths_test.go
+++ b/tests/integration/outbox_failure_paths_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
 )
 
@@ -251,7 +252,7 @@ func TestIntegration_PGRelay_TransientPublishRetry(t *testing.T) {
 	stop := runRelay(t, relay)
 	defer stop()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-transient-retry-published", func() bool {
 		status, _, _ := queryEntryStatus(t, pool, id)
 		return status == "published"
 	}, testtime.EventuallyLong, testtime.MediumPoll, "entry must reach published after transient retries")
@@ -280,7 +281,7 @@ func TestIntegration_PGRelay_MaxAttemptsDeadLetter(t *testing.T) {
 	stop := runRelay(t, relay)
 	defer stop()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-dead-letter-reached", func() bool {
 		status, _, _ := queryEntryStatus(t, pool, id)
 		return status == "dead"
 	}, testtime.EventuallyLong, testtime.MediumPoll, "entry must reach dead after MaxAttempts publish failures")
@@ -353,7 +354,7 @@ func TestIntegration_PGRelay_ConcurrentRelaysNoDoublePublish(t *testing.T) {
 	stopB := runRelay(t, relayB)
 	defer stopB()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-concurrent-all-published", func() bool {
 		var n int
 		require.NoError(t,
 			pool.DB().QueryRow(context.Background(),
@@ -427,7 +428,7 @@ func TestIntegration_PGRelay_StopMidPublishReclaimTakeover(t *testing.T) {
 	stopB := runRelay(t, relayB)
 	defer stopB()
 
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-relay-reclaim-takeover-published", func() bool {
 		status, _, _ := queryEntryStatus(t, pool, id)
 		return status == "published"
 	}, testtime.SelectAsyncSettle, testtime.SlowPoll, "relay B must reclaim and publish the orphaned entry")

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
@@ -399,7 +400,7 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 	// ---------------------------------------------------------------
 	// Step 9: Verify the relay marked the outbox entry as published.
 	// ---------------------------------------------------------------
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-fullchain-relay-published", func() bool {
 		queryErr := pool.DB().QueryRow(ctx, "SELECT status FROM outbox_entries WHERE id = $1", entryID).Scan(&status)
 		if queryErr != nil {
 			return false
@@ -727,7 +728,7 @@ func TestIntegration_OutboxWriteRelayMockPublisher(t *testing.T) {
 
 	// Verify the entry was marked as published.
 	var pubStatus string
-	require.Eventually(t, func() bool {
+	testwait.External(t, "outbox-mock-relay-published", func() bool {
 		queryErr := pool.DB().QueryRow(ctx, "SELECT status FROM outbox_entries WHERE id = $1", entryID).Scan(&pubStatus)
 		return queryErr == nil && pubStatus == "published"
 	}, testtime.SelectShutdown, testtime.SlowPoll, "outbox entry should have status='published' after relay")

--- a/tests/integration/shutdown_e2e_test.go
+++ b/tests/integration/shutdown_e2e_test.go
@@ -50,6 +50,9 @@ const (
 	shutdownD8s = 8 * time.Second
 	// shutdownD3s is the RabbitMQ ReconnectMaxBackoff; not in testtime table.
 	shutdownD3s = 3 * time.Second
+	// shutdownAccountingSettleD20s is the poll budget for the no-loss accounting
+	// settle check; local to this file to avoid cross-file constant coupling.
+	shutdownAccountingSettleD20s = 20 * time.Second
 )
 
 // ---------------------------------------------------------------------------
@@ -73,11 +76,15 @@ func startShutdownTestBroker(t *testing.T) (amqpURL, mgmtURL string, container *
 	require.NoError(t, err, "get amqp url")
 
 	var mgmt string
+	var attemptCount int
 	testwait.External(t, "rabbitmq-management-http-url-mapped", func() bool {
 		var httpErr error
 		mgmt, httpErr = c.HttpURL(ctx)
 		if httpErr != nil {
-			t.Logf("rabbitmq-management-http-url-mapped: attempt failed: %v", httpErr)
+			attemptCount++
+			if attemptCount <= 3 || attemptCount%10 == 0 {
+				t.Logf("rabbitmq-management-http-url-mapped: attempt %d failed: %v", attemptCount, httpErr)
+			}
 		}
 		return httpErr == nil
 	}, testtime.SelectAsyncSettle, testtime.SlowPoll, "management http url should be mapped")
@@ -286,7 +293,7 @@ func TestE2E_ShutdownBarrier_NoMessageLoss(t *testing.T) {
 		t.Logf("shutdown e2e no-loss poll: processed=%d queue=%d sum=%d",
 			processedFinal, queueDepth, processedFinal+int64(queueDepth))
 		return int(processedFinal)+queueDepth >= total
-	}, fullchainD20s, testtime.D500ms,
+	}, shutdownAccountingSettleD20s, testtime.D500ms,
 		"broker queue + processed must eventually total 100 messages")
 
 	t.Logf("shutdown e2e no-loss: processed=%d queue=%d total=%d", processedFinal, queueDepth, total)

--- a/tests/integration/shutdown_e2e_test.go
+++ b/tests/integration/shutdown_e2e_test.go
@@ -77,17 +77,19 @@ func startShutdownTestBroker(t *testing.T) (amqpURL, mgmtURL string, container *
 
 	var mgmt string
 	var attemptCount int
+	var lastErr error
 	testwait.External(t, "rabbitmq-management-http-url-mapped", func() bool {
 		var httpErr error
 		mgmt, httpErr = c.HttpURL(ctx)
 		if httpErr != nil {
+			lastErr = httpErr
 			attemptCount++
 			if attemptCount <= 3 || attemptCount%10 == 0 {
 				t.Logf("rabbitmq-management-http-url-mapped: attempt %d failed: %v", attemptCount, httpErr)
 			}
 		}
 		return httpErr == nil
-	}, testtime.SelectAsyncSettle, testtime.SlowPoll, "management http url should be mapped")
+	}, testtime.SelectAsyncSettle, testtime.SlowPoll, "management http url should be mapped (last error: %v)", &lastErr)
 
 	cleanup = func() {
 		if termErr := c.Terminate(ctx); termErr != nil {

--- a/tests/integration/shutdown_e2e_test.go
+++ b/tests/integration/shutdown_e2e_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -72,10 +73,13 @@ func startShutdownTestBroker(t *testing.T) (amqpURL, mgmtURL string, container *
 	require.NoError(t, err, "get amqp url")
 
 	var mgmt string
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+	testwait.External(t, "rabbitmq-management-http-url-mapped", func() bool {
 		var httpErr error
 		mgmt, httpErr = c.HttpURL(ctx)
-		require.NoError(collect, httpErr, "get management http url")
+		if httpErr != nil {
+			t.Logf("rabbitmq-management-http-url-mapped: attempt failed: %v", httpErr)
+		}
+		return httpErr == nil
 	}, testtime.SelectAsyncSettle, testtime.SlowPoll, "management http url should be mapped")
 
 	cleanup = func() {
@@ -239,7 +243,7 @@ func TestE2E_ShutdownBarrier_NoMessageLoss(t *testing.T) {
 	require.NoError(t, publishMessages(pubCtx, pub, topic, total), "publish 100 messages")
 
 	// Wait until at least 1 message is processed (subscriber is actively consuming).
-	require.Eventually(t, func() bool {
+	testwait.External(t, "shutdown-at-least-one-processed", func() bool {
 		return processed.Load() > 0
 	}, testtime.SelectAsyncSettle, testtime.MediumPoll, "at least one message must be processed before shutdown")
 
@@ -276,7 +280,7 @@ func TestE2E_ShutdownBarrier_NoMessageLoss(t *testing.T) {
 	// poll until the sum stabilises at 100 or until the timeout.
 	var queueDepth int
 	processedFinal := processed.Load()
-	require.Eventually(t, func() bool {
+	testwait.External(t, "shutdown-accounting-sum-stable", func() bool {
 		queueDepth = getQueueDepth(t, mgmtURL, queueName)
 		processedFinal = processed.Load()
 		t.Logf("shutdown e2e no-loss poll: processed=%d queue=%d sum=%d",
@@ -378,7 +382,7 @@ func TestE2E_ShutdownBarrier_BrokerHardClose(t *testing.T) {
 
 	// Wait until at least one message has been consumed before hard-stopping
 	// the broker, to ensure we have in-flight state to exercise.
-	require.Eventually(t, func() bool {
+	testwait.External(t, "shutdown-conn-drained", func() bool {
 		return consumed.Load() > 0
 	}, testtime.SelectShutdown, testtime.MediumPoll,
 		"at least one message should be consumed before broker stop")


### PR DESCRIPTION
## Summary

TEST-POLLING-DETERMINISM PR2 of 3 — bulk migration of every bare `require.Eventually` / `assert.Eventually` / `require.EventuallyWithT` call site to `testwait.External` per `docs/plans/202605181600-042-archtest.md §1.1`.

- **63 files, 403 `testwait.External` callsites** (originally counted 393 bare sites; final count 403 because some files had unrelated `External` additions during D2 work)
- Sentinel grep `\b(require|assert).Eventually(WithT)?\(` returns **0 hits** outside `pkg/testutil/testwait/testwait.go` doc and `tools/archtest/` fixtures/self-tests
- Single `EventuallyWithT` site (`tests/integration/shutdown_e2e_test.go:75`) restructured to bool-returning condition with per-tick `t.Logf` for last-error visibility — **K8s e2e pattern**, no CollectT, no carve-out, no testwait API extension
- 25 `// MIGRATION-NOTE:` comments mark `assert.Eventually` → `testwait.External` sites where FailNow semantics now apply; intentional documentation
- 4 commits, one per batch:
  - `95f2007fd` Batch A — adapters/rabbitmq/* (13 files, 78 sites)
  - `a239fea32` Batch B + D1 bundled — adapters/{vault,s3,oidc,websocket,postgres,ratelimit}/* + runtime/{eventbus,eventrouter,outbox}/* (14 files, ~114 sites; concurrent execution collision)
  - `41596dfc3` Batch C1 — runtime/websocket/hub_test.go (46 sites)
  - `b3756ea06` Batches C2 + D2 + cleanup — runtime/{bootstrap,worker,command,config}/* + cells/* + cmd/corebundle/* + tests/integration/* + examples/* + kernel/* + pkg/cmdrun/* (35 files, ~155 sites including EventuallyWithT restructure)

PR3 (separate) will add the upstream archtest banning bare `require.Eventually` / `assert.Eventually` module-wide, promoting the funnel from Soft transitional to Hard. Backlog `TEST-EVENTUALLY-FUNNEL-01` (`docs/backlog/cap-14-tooling.md` §14.1) is the prerequisite-now-satisfied gate for that PR.

## Why

- Race-CI flake driver: testify `Eventually` closure capture + per-tick goroutine spawn ([stretchr/testify#1611](https://github.com/stretchr/testify/issues/1611), [#865](https://github.com/stretchr/testify/issues/865), [#835](https://github.com/stretchr/testify/issues/835)) repeatedly produced flakes in `runtime/` tests (D500ms incident).
- `testwait.External` runs polling synchronously on the caller goroutine (mirrors testify [pull/1657](https://github.com/stretchr/testify/pull/1657) synchronous-Eventually proposal); eliminates goroutine leak + closure race window.
- Downstream archtest `TEST-POLLING-EXTERNAL-REASON-LITERAL-01` already enforces (callee, arg) form-uniqueness on the reason literal (PR1).

## References

ref: stretchr/testify pull/1657 (synchronous Eventually root design — eliminates testify #1611 goroutine leak and #865 race window)
ref: kubernetes/apimachinery wait.PollUntilContextTimeout (synchronous main loop + `t.Logf` inside condition for last-error visibility)
ref: pkg/panicregister/panicregister.go (typed-marker funnel sibling pattern)

Refs: `docs/plans/202605181600-042-archtest.md §1.1` PR2  
Backlog: `TEST-EVENTUALLY-FUNNEL-01` (`docs/backlog/cap-14-tooling.md` §14.1)

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go build -tags=integration ./...` — clean
- [x] `go test -count=1 -short -race ./pkg/... ./kernel/... ./runtime/... ./adapters/... ./cells/...` — green except one pre-existing sandbox-binding failure (`TestHTTPConfigGetter_GetEntry_OK`, httptest TCP6 bind) confirmed unrelated to migration (passes outside sandbox)
- [x] `go test ./tools/archtest/... -run TestExternalReasonLiteral` — green (no reason-literal violations introduced)
- [x] `golangci-lint run ./...` — 0 issues
- [x] **Sentinel grep**: `grep -rEn '^\s*\b(require|assert).Eventually(WithT)?\(' --include='*.go' .` returns 0 hits outside framework/archtest
- [x] **Count**: `grep -rEcn 'testwait\.External\(' --include='*.go' .` → **403** sites ≥ target 393
- [ ] CI integration matrix (PG + RabbitMQ + Vault containers) — awaits CI

## Notes

- Batch B's commit (`a239fea32`) bundled batch D1's files due to concurrent sub-agent execution; content is correct, attribution is in PR description not commit titles.
- No carve-out allowlist, no deprecation alias, no PR3 upstream ban (per plan §0 Template-PR-Split: framework / migration / enforcement strictly separated).
- 4 原则自审 (彻底/不向后兼容/优雅简洁/AI HARD) covered in plan `/Users/shengming/.claude/plans/docs-plans-202605181600-042-archtest-md-jiggly-seal.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)