### PR TITLE
feat(configcoretest): add public testutil package

### DIFF
--- a/cells/configcore/configcoretest/builders.go
+++ b/cells/configcore/configcoretest/builders.go
@@ -1,0 +1,140 @@
+package configcoretest
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/ghbvf/gocell/cells/configcore/slices/configsubscribe"
+	"github.com/ghbvf/gocell/cells/configcore/slices/configwrite"
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox/outboxtest"
+)
+
+// BuildWriteOption configures BuildWriteService.
+type BuildWriteOption func(*buildWriteConfig)
+
+type buildWriteConfig struct {
+	repo   *FakeConfigRepository
+	clk    clock.Clock
+	logger *slog.Logger
+}
+
+// WithWriteRepository injects a custom FakeConfigRepository.
+// Use this when a test needs direct access to the repository for seeding or
+// assertions after service operations.
+func WithWriteRepository(r *FakeConfigRepository) BuildWriteOption {
+	return func(c *buildWriteConfig) {
+		if r != nil {
+			c.repo = r
+		}
+	}
+}
+
+// WithWriteClock injects a custom clock into both the repository and the service.
+// Use clockmock.New(t) for time-sensitive assertions.
+func WithWriteClock(clk clock.Clock) BuildWriteOption {
+	return func(c *buildWriteConfig) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// WithWriteLogger injects a custom logger. Defaults to slog.DiscardHandler.
+func WithWriteLogger(l *slog.Logger) BuildWriteOption {
+	return func(c *buildWriteConfig) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
+// BuildWriteService constructs a configwrite.Service wired with an in-memory
+// repository and an outboxtest.Recorder as the event emitter. The Recorder is
+// returned alongside the service for post-operation assertions.
+//
+// Defaults:
+//   - repo: NewFakeConfigRepository(clock.Real())
+//   - tx: cell.DemoCellTxManager()
+//   - emitter: outboxtest.NewRecorder()
+//   - logger: slog.New(slog.DiscardHandler)
+//   - clock: clock.Real()
+func BuildWriteService(t *testing.T, opts ...BuildWriteOption) (*configwrite.Service, *outboxtest.Recorder) {
+	t.Helper()
+
+	cfg := &buildWriteConfig{
+		clk:    clock.Real(),
+		logger: slog.New(slog.DiscardHandler),
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+	// Build repo after options so clock override takes effect.
+	if cfg.repo == nil {
+		cfg.repo = NewFakeConfigRepository(cfg.clk)
+	}
+
+	rec := outboxtest.NewRecorder()
+	svc, err := configwrite.NewService(
+		cfg.repo,
+		cfg.logger,
+		cfg.clk,
+		configwrite.WithTxManager(cell.DemoCellTxManager()),
+		configwrite.WithEmitter(rec),
+	)
+	if err != nil {
+		t.Fatalf("configcoretest.BuildWriteService: %v", err)
+	}
+	return svc, rec
+}
+
+// BuildSubscribeOption configures BuildSubscribeService.
+type BuildSubscribeOption func(*buildSubscribeConfig)
+
+type buildSubscribeConfig struct {
+	clk    clock.Clock
+	logger *slog.Logger
+}
+
+// WithSubscribeClock injects a custom clock.
+// Required by configsubscribe.NewService; defaults to clock.Real().
+func WithSubscribeClock(clk clock.Clock) BuildSubscribeOption {
+	return func(c *buildSubscribeConfig) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// WithSubscribeLogger injects a custom logger. Defaults to slog.DiscardHandler.
+func WithSubscribeLogger(l *slog.Logger) BuildSubscribeOption {
+	return func(c *buildSubscribeConfig) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
+// BuildSubscribeService constructs a configsubscribe.Service wired with default
+// settings suitable for unit tests.
+//
+// Defaults:
+//   - logger: slog.New(slog.DiscardHandler)
+//   - clock: clock.Real()
+func BuildSubscribeService(t *testing.T, opts ...BuildSubscribeOption) *configsubscribe.Service {
+	t.Helper()
+
+	cfg := &buildSubscribeConfig{
+		clk:    clock.Real(),
+		logger: slog.New(slog.DiscardHandler),
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	return configsubscribe.NewService(
+		cfg.logger,
+		configsubscribe.WithClock(cfg.clk),
+	)
+}

--- a/cells/configcore/configcoretest/builders.go
+++ b/cells/configcore/configcoretest/builders.go
@@ -15,23 +15,13 @@ import (
 type BuildWriteOption func(*buildWriteConfig)
 
 type buildWriteConfig struct {
-	repo   *FakeConfigRepository
 	clk    clock.Clock
 	logger *slog.Logger
 }
 
-// WithWriteRepository injects a custom FakeConfigRepository.
-// Use this when a test needs direct access to the repository for seeding or
-// assertions after service operations.
-func WithWriteRepository(r *FakeConfigRepository) BuildWriteOption {
-	return func(c *buildWriteConfig) {
-		if r != nil {
-			c.repo = r
-		}
-	}
-}
-
-// WithWriteClock injects a custom clock into both the repository and the service.
+// WithWriteClock injects a custom clock. The same clock instance is wired into
+// both the FakeConfigRepository and the configwrite.Service, so Create-stamped
+// CreatedAt/UpdatedAt and Update-stamped UpdatedAt come from a single source.
 // Use clockmock.New(t) for time-sensitive assertions.
 func WithWriteClock(clk clock.Clock) BuildWriteOption {
 	return func(c *buildWriteConfig) {
@@ -50,17 +40,22 @@ func WithWriteLogger(l *slog.Logger) BuildWriteOption {
 	}
 }
 
-// BuildWriteService constructs a configwrite.Service wired with an in-memory
-// repository and an outboxtest.Recorder as the event emitter. The Recorder is
-// returned alongside the service for post-operation assertions.
+// BuildWriteService constructs a configwrite.Service wired with a fresh
+// in-memory repository and an outboxtest.Recorder as the event emitter. Both
+// the repository and the Recorder are returned so the test can Seed/Snapshot
+// state and assert on captured outbox entries.
+//
+// The repository is always constructed internally with the configured clock —
+// callers cannot inject a pre-built repository, which removes the clock-fork
+// foot-gun where the repo's clock (Update path) would diverge from the
+// service's clock (Create path).
 //
 // Defaults:
-//   - repo: NewFakeConfigRepository(clock.Real())
 //   - tx: cell.DemoCellTxManager()
 //   - emitter: outboxtest.NewRecorder()
 //   - logger: slog.New(slog.DiscardHandler)
 //   - clock: clock.Real()
-func BuildWriteService(t *testing.T, opts ...BuildWriteOption) (*configwrite.Service, *outboxtest.Recorder) {
+func BuildWriteService(t *testing.T, opts ...BuildWriteOption) (*configwrite.Service, *FakeConfigRepository, *outboxtest.Recorder) {
 	t.Helper()
 
 	cfg := &buildWriteConfig{
@@ -70,14 +65,11 @@ func BuildWriteService(t *testing.T, opts ...BuildWriteOption) (*configwrite.Ser
 	for _, o := range opts {
 		o(cfg)
 	}
-	// Build repo after options so clock override takes effect.
-	if cfg.repo == nil {
-		cfg.repo = NewFakeConfigRepository(cfg.clk)
-	}
+	repo := NewFakeConfigRepository(cfg.clk)
 
 	rec := outboxtest.NewRecorder()
 	svc, err := configwrite.NewService(
-		cfg.repo,
+		repo,
 		cfg.logger,
 		cfg.clk,
 		configwrite.WithTxManager(cell.DemoCellTxManager()),
@@ -86,7 +78,7 @@ func BuildWriteService(t *testing.T, opts ...BuildWriteOption) (*configwrite.Ser
 	if err != nil {
 		t.Fatalf("configcoretest.BuildWriteService: %v", err)
 	}
-	return svc, rec
+	return svc, repo, rec
 }
 
 // BuildSubscribeOption configures BuildSubscribeService.

--- a/cells/configcore/configcoretest/builders.go
+++ b/cells/configcore/configcoretest/builders.go
@@ -119,6 +119,11 @@ func WithSubscribeLogger(l *slog.Logger) BuildSubscribeOption {
 // BuildSubscribeService constructs a configsubscribe.Service wired with default
 // settings suitable for unit tests.
 //
+// No Recorder is returned because configsubscribe is a pure event consumer: it
+// drives a local version-tracking cache but never emits outbox events of its
+// own. Use svc.Cache() to assert cache state after calling HandleEntryUpserted
+// or HandleEntryDeleted.
+//
 // Defaults:
 //   - logger: slog.New(slog.DiscardHandler)
 //   - clock: clock.Real()

--- a/cells/configcore/configcoretest/builders_test.go
+++ b/cells/configcore/configcoretest/builders_test.go
@@ -2,6 +2,7 @@ package configcoretest
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,13 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	configevents "github.com/ghbvf/gocell/cells/configcore/internal/events"
 	"github.com/ghbvf/gocell/cells/configcore/slices/configwrite"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
-var testTime = time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+// testFixedTime is a fixed point-in-time used for clock-sensitive assertions.
+// Named testFixedTime (not testTime) to make the read-only intent explicit:
+// time.Time is a value type and cannot be declared const.
+var testFixedTime = time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
 
 func TestBuildWriteServiceSmoke(t *testing.T) {
 	t.Run("build with defaults and create an entry", func(t *testing.T) {
@@ -39,13 +46,35 @@ func TestBuildWriteServiceSmoke(t *testing.T) {
 }
 
 func TestBuildSubscribeServiceSmoke(t *testing.T) {
-	t.Run("build with defaults returns non-nil service", func(t *testing.T) {
+	t.Run("HandleEntryUpserted drives the wired pipeline end-to-end", func(t *testing.T) {
 		svc := BuildSubscribeService(t)
 		require.NotNil(t, svc)
 
 		cache := svc.Cache()
 		require.NotNil(t, cache)
 		assert.Equal(t, 0, cache.Len())
+
+		// Build an outbox.Entry carrying an EntryUpserted payload.
+		payload, err := json.Marshal(configevents.EntryUpserted{
+			Key:     "smoke-k",
+			Version: 1,
+			ActorID: "test-actor",
+		})
+		require.NoError(t, err)
+
+		entry := outbox.Entry{
+			ID:        "test-entry-001",
+			EventType: domain.TopicConfigEntryUpserted,
+			Payload:   payload,
+		}
+
+		result := svc.HandleEntryUpserted(context.Background(), entry)
+		assert.Equal(t, outbox.DispositionAck, result.Disposition)
+
+		version, present := cache.GetVersion("smoke-k")
+		assert.True(t, present, "key should be present in cache after upsert")
+		assert.Equal(t, 1, version)
+		assert.Equal(t, 1, cache.Len())
 	})
 }
 
@@ -54,16 +83,10 @@ func TestNewFakeConfigRepositoryRoundtrip(t *testing.T) {
 		repo := NewFakeConfigRepository(clock.Real())
 		ctx := context.Background()
 
-		entry := &domain.ConfigEntry{
-			ID:        "cfg-test-001",
-			Key:       "roundtrip-key",
-			Value:     "roundtrip-value",
-			Version:   1,
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		}
-
-		err := repo.Seed(ctx, entry)
+		err := repo.Seed(ctx, SeededEntry{
+			Key:   "roundtrip-key",
+			Value: "roundtrip-value",
+		})
 		require.NoError(t, err)
 
 		snapshot, err := repo.Snapshot(ctx)
@@ -77,9 +100,9 @@ func TestNewFakeConfigRepositoryRoundtrip(t *testing.T) {
 		repo := NewFakeConfigRepository(clock.Real())
 		ctx := context.Background()
 
-		entries := []*domain.ConfigEntry{
-			{ID: "cfg-001", Key: "key-a", Value: "val-a", Version: 1},
-			{ID: "cfg-002", Key: "key-b", Value: "val-b", Version: 1},
+		entries := []SeededEntry{
+			{Key: "key-a", Value: "val-a"},
+			{Key: "key-b", Value: "val-b"},
 		}
 		for _, e := range entries {
 			require.NoError(t, repo.Seed(ctx, e))
@@ -89,11 +112,20 @@ func TestNewFakeConfigRepositoryRoundtrip(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, snapshot, 2)
 	})
+
+	t.Run("seed duplicate key returns error", func(t *testing.T) {
+		repo := NewFakeConfigRepository(clock.Real())
+		ctx := context.Background()
+
+		require.NoError(t, repo.Seed(ctx, SeededEntry{Key: "dup-key", Value: "v1"}))
+		err := repo.Seed(ctx, SeededEntry{Key: "dup-key", Value: "v2"})
+		require.Error(t, err, "seeding a duplicate key must return an error")
+	})
 }
 
 func TestBuildWriteServiceWithCustomClock(t *testing.T) {
 	t.Run("custom clock propagates to created entry timestamps", func(t *testing.T) {
-		clk := clockmock.New(testTime)
+		clk := clockmock.New(testFixedTime)
 		svc, rec := BuildWriteService(t, WithWriteClock(clk))
 		require.NotNil(t, svc)
 
@@ -103,8 +135,8 @@ func TestBuildWriteServiceWithCustomClock(t *testing.T) {
 			Value: "clock-value",
 		})
 		require.NoError(t, err)
-		assert.Equal(t, testTime, entry.CreatedAt)
-		assert.Equal(t, testTime, entry.UpdatedAt)
+		assert.Equal(t, testFixedTime, entry.CreatedAt)
+		assert.Equal(t, testFixedTime, entry.UpdatedAt)
 
 		// emitter also captured the event
 		require.Len(t, rec.Entries(), 1)
@@ -128,4 +160,14 @@ func TestBuildWriteServiceWithCustomRepo(t *testing.T) {
 		require.Len(t, snapshot, 1)
 		assert.Equal(t, "repo-key", snapshot[0].Key)
 	})
+}
+
+// TestFakeConfigRepositoryRepoReadiness satisfies CELL-REPO-READYZ-PROBE-01/P1:
+// every kernel/cell.RepoHealthProber implementation must be wired through
+// celltest.RunRepoReadinessConformance. FakeConfigRepository delegates to an
+// in-memory backend that is always ready, so broken=nil (skip the failure-
+// domain sub-test per conformance harness convention).
+func TestFakeConfigRepositoryRepoReadiness(t *testing.T) {
+	repo := NewFakeConfigRepository(clock.Real())
+	celltest.RunRepoReadinessConformance(t, "fake_config_repo_ready", repo, nil)
 }

--- a/cells/configcore/configcoretest/builders_test.go
+++ b/cells/configcore/configcoretest/builders_test.go
@@ -1,0 +1,131 @@
+package configcoretest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	"github.com/ghbvf/gocell/cells/configcore/slices/configwrite"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+var testTime = time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+func TestBuildWriteServiceSmoke(t *testing.T) {
+	t.Run("build with defaults and create an entry", func(t *testing.T) {
+		svc, rec := BuildWriteService(t)
+		require.NotNil(t, svc)
+		require.NotNil(t, rec)
+
+		ctx := auth.TestContext("test-admin", []string{"admin"})
+		entry, err := svc.Create(ctx, configwrite.CreateInput{
+			Key:   "smoke-key",
+			Value: "smoke-value",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "smoke-key", entry.Key)
+		assert.Equal(t, "smoke-value", entry.Value)
+
+		entries := rec.Entries()
+		require.Len(t, entries, 1)
+		assert.Equal(t, domain.TopicConfigEntryUpserted, entries[0].EventType)
+	})
+}
+
+func TestBuildSubscribeServiceSmoke(t *testing.T) {
+	t.Run("build with defaults returns non-nil service", func(t *testing.T) {
+		svc := BuildSubscribeService(t)
+		require.NotNil(t, svc)
+
+		cache := svc.Cache()
+		require.NotNil(t, cache)
+		assert.Equal(t, 0, cache.Len())
+	})
+}
+
+func TestNewFakeConfigRepositoryRoundtrip(t *testing.T) {
+	t.Run("seed and snapshot returns seeded entries", func(t *testing.T) {
+		repo := NewFakeConfigRepository(clock.Real())
+		ctx := context.Background()
+
+		entry := &domain.ConfigEntry{
+			ID:        "cfg-test-001",
+			Key:       "roundtrip-key",
+			Value:     "roundtrip-value",
+			Version:   1,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+
+		err := repo.Seed(ctx, entry)
+		require.NoError(t, err)
+
+		snapshot, err := repo.Snapshot(ctx)
+		require.NoError(t, err)
+		require.Len(t, snapshot, 1)
+		assert.Equal(t, "roundtrip-key", snapshot[0].Key)
+		assert.Equal(t, "roundtrip-value", snapshot[0].Value)
+	})
+
+	t.Run("seed multiple entries", func(t *testing.T) {
+		repo := NewFakeConfigRepository(clock.Real())
+		ctx := context.Background()
+
+		entries := []*domain.ConfigEntry{
+			{ID: "cfg-001", Key: "key-a", Value: "val-a", Version: 1},
+			{ID: "cfg-002", Key: "key-b", Value: "val-b", Version: 1},
+		}
+		for _, e := range entries {
+			require.NoError(t, repo.Seed(ctx, e))
+		}
+
+		snapshot, err := repo.Snapshot(ctx)
+		require.NoError(t, err)
+		assert.Len(t, snapshot, 2)
+	})
+}
+
+func TestBuildWriteServiceWithCustomClock(t *testing.T) {
+	t.Run("custom clock propagates to created entry timestamps", func(t *testing.T) {
+		clk := clockmock.New(testTime)
+		svc, rec := BuildWriteService(t, WithWriteClock(clk))
+		require.NotNil(t, svc)
+
+		ctx := auth.TestContext("test-admin", []string{"admin"})
+		entry, err := svc.Create(ctx, configwrite.CreateInput{
+			Key:   "clock-key",
+			Value: "clock-value",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, testTime, entry.CreatedAt)
+		assert.Equal(t, testTime, entry.UpdatedAt)
+
+		// emitter also captured the event
+		require.Len(t, rec.Entries(), 1)
+	})
+}
+
+func TestBuildWriteServiceWithCustomRepo(t *testing.T) {
+	t.Run("injected fake repo is used by service", func(t *testing.T) {
+		repo := NewFakeConfigRepository(clock.Real())
+		svc, _ := BuildWriteService(t, WithWriteRepository(repo))
+
+		ctx := auth.TestContext("test-admin", []string{"admin"})
+		_, err := svc.Create(ctx, configwrite.CreateInput{
+			Key:   "repo-key",
+			Value: "repo-value",
+		})
+		require.NoError(t, err)
+
+		snapshot, err := repo.Snapshot(context.Background())
+		require.NoError(t, err)
+		require.Len(t, snapshot, 1)
+		assert.Equal(t, "repo-key", snapshot[0].Key)
+	})
+}

--- a/cells/configcore/configcoretest/builders_test.go
+++ b/cells/configcore/configcoretest/builders_test.go
@@ -24,10 +24,17 @@ import (
 // time.Time is a value type and cannot be declared const.
 var testFixedTime = time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
 
+// testClockAdvance is the duration the mock clock is advanced between Create
+// and Update in TestBuildWriteServiceClockSingleSource — any non-zero value
+// works; 2h is a humanly obvious gap that cannot be confused with default
+// timestamps. Extracted per archtest TEST-TIME-LITERAL-01.
+const testClockAdvance = 2 * time.Hour
+
 func TestBuildWriteServiceSmoke(t *testing.T) {
 	t.Run("build with defaults and create an entry", func(t *testing.T) {
-		svc, rec := BuildWriteService(t)
+		svc, repo, rec := BuildWriteService(t)
 		require.NotNil(t, svc)
+		require.NotNil(t, repo)
 		require.NotNil(t, rec)
 
 		ctx := auth.TestContext("test-admin", []string{"admin"})
@@ -42,6 +49,12 @@ func TestBuildWriteServiceSmoke(t *testing.T) {
 		entries := rec.Entries()
 		require.Len(t, entries, 1)
 		assert.Equal(t, domain.TopicConfigEntryUpserted, entries[0].EventType)
+
+		// returned repo handle observes the same state.
+		snap, err := repo.Snapshot(context.Background())
+		require.NoError(t, err)
+		require.Len(t, snap, 1)
+		assert.Equal(t, "smoke-key", snap[0].Key)
 	})
 }
 
@@ -126,7 +139,7 @@ func TestNewFakeConfigRepositoryRoundtrip(t *testing.T) {
 func TestBuildWriteServiceWithCustomClock(t *testing.T) {
 	t.Run("custom clock propagates to created entry timestamps", func(t *testing.T) {
 		clk := clockmock.New(testFixedTime)
-		svc, rec := BuildWriteService(t, WithWriteClock(clk))
+		svc, _, rec := BuildWriteService(t, WithWriteClock(clk))
 		require.NotNil(t, svc)
 
 		ctx := auth.TestContext("test-admin", []string{"admin"})
@@ -143,23 +156,40 @@ func TestBuildWriteServiceWithCustomClock(t *testing.T) {
 	})
 }
 
-func TestBuildWriteServiceWithCustomRepo(t *testing.T) {
-	t.Run("injected fake repo is used by service", func(t *testing.T) {
-		repo := NewFakeConfigRepository(clock.Real())
-		svc, _ := BuildWriteService(t, WithWriteRepository(repo))
+// TestBuildWriteServiceClockSingleSource is the regression guard for the
+// service↔repo clock-fork bug: Create stamps CreatedAt/UpdatedAt via the
+// service's clock, while Update stamps UpdatedAt via the repository's clock
+// (mem.ConfigRepository.Update writes existing.UpdatedAt = r.clock.Now()).
+//
+// If anyone reintroduces a builder option that lets the caller inject a
+// pre-built repository alongside WithWriteClock, the two clocks will diverge
+// silently. This test pins down the contract: a single clock fed to
+// BuildWriteService is the only time source for both Create- and Update-stamped
+// timestamps, so advancing it between the two calls produces matching reads.
+func TestBuildWriteServiceClockSingleSource(t *testing.T) {
+	clk := clockmock.New(testFixedTime)
+	svc, _, _ := BuildWriteService(t, WithWriteClock(clk))
 
-		ctx := auth.TestContext("test-admin", []string{"admin"})
-		_, err := svc.Create(ctx, configwrite.CreateInput{
-			Key:   "repo-key",
-			Value: "repo-value",
-		})
-		require.NoError(t, err)
-
-		snapshot, err := repo.Snapshot(context.Background())
-		require.NoError(t, err)
-		require.Len(t, snapshot, 1)
-		assert.Equal(t, "repo-key", snapshot[0].Key)
+	ctx := auth.TestContext("test-admin", []string{"admin"})
+	created, err := svc.Create(ctx, configwrite.CreateInput{
+		Key:   "clock-source-key",
+		Value: "v1",
 	})
+	require.NoError(t, err)
+	require.Equal(t, testFixedTime, created.CreatedAt)
+	require.Equal(t, testFixedTime, created.UpdatedAt)
+
+	advanced := testFixedTime.Add(testClockAdvance)
+	clk.Set(advanced)
+
+	updated, err := svc.Update(ctx, configwrite.UpdateInput{
+		Key:             "clock-source-key",
+		Value:           "v2",
+		ExpectedVersion: created.Version,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, testFixedTime, updated.CreatedAt, "CreatedAt must remain at t0")
+	assert.Equal(t, advanced, updated.UpdatedAt, "Update must observe the same advanced clock as the service")
 }
 
 // TestFakeConfigRepositoryRepoReadiness satisfies CELL-REPO-READYZ-PROBE-01/P1:

--- a/cells/configcore/configcoretest/doc.go
+++ b/cells/configcore/configcoretest/doc.go
@@ -1,0 +1,30 @@
+// Package configcoretest provides testutil builders and fakes for the configcore
+// cell. It exposes constructors for the configwrite and configsubscribe slices
+// without requiring Docker or real infrastructure, enabling fast, docker-free
+// unit and journey-criterion tests.
+//
+// # Import scope
+//
+// This package must only be imported from test code: *_test.go files or other
+// test-infrastructure packages (paths containing a "testutil" segment or a
+// segment ending in "test"). Production binaries must never import it.
+// Enforcement: archtest CELLTEST-IMPORT-SCOPE-01 (tools/archtest/celltest_import_scope_test.go)
+// auto-discovers this package via the cells/{X}/{X}test$ naming pattern.
+//
+// # Relationship to production wiring
+//
+// Production wiring for configcore lives in cells/configcore/cell.go (Init,
+// AfterStart, etc.) and is assembled in cmd/corebundle. This package replicates
+// the same wiring decisions in a test-friendly way:
+//   - Real service implementations (configwrite.NewService, configsubscribe.NewService).
+//   - In-memory repository (cells/configcore/internal/mem.NewConfigRepository).
+//   - kernel/cell.DemoCellTxManager() as a pass-through TxRunner.
+//   - kernel/outbox/outboxtest.NewRecorder() as the event emitter.
+//
+// # Usage
+//
+//	svc, rec := configcoretest.BuildWriteService(t)
+//	entry, err := svc.Create(ctx, configwrite.CreateInput{Key: "k", Value: "v"})
+//	require.NoError(t, err)
+//	require.Len(t, rec.Entries(), 1)
+package configcoretest

--- a/cells/configcore/configcoretest/doc.go
+++ b/cells/configcore/configcoretest/doc.go
@@ -17,9 +17,25 @@
 // AfterStart, etc.) and is assembled in cmd/corebundle. This package replicates
 // the same wiring decisions in a test-friendly way:
 //   - Real service implementations (configwrite.NewService, configsubscribe.NewService).
-//   - In-memory repository (cells/configcore/internal/mem.NewConfigRepository).
+//   - An in-memory repository (backed by the mem package — always zero-latency,
+//     no external dependencies).
 //   - kernel/cell.DemoCellTxManager() as a pass-through TxRunner.
 //   - kernel/outbox/outboxtest.NewRecorder() as the event emitter.
+//
+// # Relationship to internal/testutil
+//
+// cells/configcore/internal/testutil provides low-level raw doubles (fake
+// repositories, stub ports) intended for in-package unit tests within the
+// configcore subtree. Import it only from test files inside cells/configcore/.
+//
+// configcoretest (this package) provides higher-level Service builders for
+// cross-package tests and Journey-criterion tests outside cells/configcore. It
+// wires full service graphs so callers interact with the same service API that
+// production code uses — no knowledge of internal types or ports required.
+//
+// Rule of thumb: if your test file lives inside cells/configcore/ and needs a
+// raw double, use internal/testutil. If your test lives outside cells/configcore/
+// (e.g. tests/integration/, journeys/, or a sibling cell), use configcoretest.
 //
 // # Usage
 //
@@ -27,4 +43,13 @@
 //	entry, err := svc.Create(ctx, configwrite.CreateInput{Key: "k", Value: "v"})
 //	require.NoError(t, err)
 //	require.Len(t, rec.Entries(), 1)
+//
+// # Debug logging
+//
+// By default builders discard all logs. To surface slog output during
+// debugging, inject a real handler:
+//
+//	svc, rec := configcoretest.BuildWriteService(t,
+//	    configcoretest.WithWriteLogger(slog.New(slog.NewTextHandler(os.Stderr, nil))),
+//	)
 package configcoretest

--- a/cells/configcore/configcoretest/doc.go
+++ b/cells/configcore/configcoretest/doc.go
@@ -39,17 +39,28 @@
 //
 // # Usage
 //
-//	svc, rec := configcoretest.BuildWriteService(t)
+//	svc, repo, rec := configcoretest.BuildWriteService(t)
 //	entry, err := svc.Create(ctx, configwrite.CreateInput{Key: "k", Value: "v"})
 //	require.NoError(t, err)
 //	require.Len(t, rec.Entries(), 1)
+//	snap, _ := repo.Snapshot(ctx) // direct repo handle for state assertions
+//
+// # Clock single-source contract
+//
+// BuildWriteService always constructs the repository internally using the
+// configured clock (WithWriteClock, defaults to clock.Real()). There is no
+// option to inject a pre-built repository: the service and repository must
+// share one clock so that Create-stamped CreatedAt/UpdatedAt and
+// Update-stamped UpdatedAt come from the same time source.
 //
 // # Debug logging
 //
 // By default builders discard all logs. To surface slog output during
 // debugging, inject a real handler:
 //
-//	svc, rec := configcoretest.BuildWriteService(t,
+//	svc, repo, rec := configcoretest.BuildWriteService(t,
 //	    configcoretest.WithWriteLogger(slog.New(slog.NewTextHandler(os.Stderr, nil))),
 //	)
+//	_ = repo
+//	_ = rec
 package configcoretest

--- a/cells/configcore/configcoretest/fakes.go
+++ b/cells/configcore/configcoretest/fakes.go
@@ -10,11 +10,26 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
-// FakeConfigRepository wraps cells/configcore/internal/mem.ConfigRepository
-// and adds Seed and Snapshot helpers for journey assertions.
+// SeededEntry is a configcoretest-local view of a config entry suitable for
+// public test code outside the cells/configcore subtree. It mirrors the
+// fields callers need without leaking internal/domain types.
+//
+// Version defaults to 1 when passed to Seed and Version == 0.
+type SeededEntry struct {
+	Key       string
+	Value     string
+	Sensitive bool
+	Version   int // optional; defaults to 1 on Seed when zero
+}
+
+// FakeConfigRepository wraps an in-memory ConfigRepository and adds Seed and
+// Snapshot helpers for test scenario setup and assertion.
 //
 // FakeConfigRepository implements ports.ConfigRepository via the embedded
 // *mem.ConfigRepository, so it can be passed directly to BuildWriteService.
+//
+// Spy methods (CallsOf/Reset) are deferred until a test needs them; add via
+// Seed + Snapshot if you need state assertions without a Recorder.
 type FakeConfigRepository struct {
 	*mem.ConfigRepository
 }
@@ -28,13 +43,26 @@ func NewFakeConfigRepository(clk clock.Clock) *FakeConfigRepository {
 	}
 }
 
-// Seed inserts entry into the repository directly, bypassing service-layer
-// validation. Use this to pre-populate the repository before a test scenario.
+// Seed inserts a single entry into the repository directly, bypassing
+// service-layer validation. Use this to pre-populate the repository before a
+// test scenario.
 //
-// If an entry with the same Key already exists, Seed returns an error wrapping
-// the underlying conflict from the mem store.
-func (r *FakeConfigRepository) Seed(ctx context.Context, entry *domain.ConfigEntry) error {
-	if err := r.Create(ctx, entry); err != nil {
+// If entry.Version is 0 it is treated as 1.
+//
+// Seed does NOT support upsert; calling Seed twice with the same Key returns
+// ErrConfigDuplicate. Construct a fresh repo via NewFakeConfigRepository
+// between scenarios.
+func (r *FakeConfigRepository) Seed(ctx context.Context, entry SeededEntry) error {
+	v := entry.Version
+	if v == 0 {
+		v = 1
+	}
+	if err := r.Create(ctx, &domain.ConfigEntry{
+		Key:       entry.Key,
+		Value:     entry.Value,
+		Sensitive: entry.Sensitive,
+		Version:   v,
+	}); err != nil {
 		return fmt.Errorf("configcoretest.FakeConfigRepository.Seed: %w", err)
 	}
 	return nil
@@ -43,7 +71,14 @@ func (r *FakeConfigRepository) Seed(ctx context.Context, entry *domain.ConfigEnt
 // Snapshot returns a point-in-time copy of all config entries currently stored,
 // sorted by key for deterministic ordering in assertions. It does not modify
 // the repository.
-func (r *FakeConfigRepository) Snapshot(ctx context.Context) ([]*domain.ConfigEntry, error) {
+//
+// Snapshot returns up to 500 entries (query.MaxPageSize). Tests seeding more
+// entries than this limit will receive a truncated result — the returned slice
+// will contain exactly 500 entries in that case.
+//
+// WARNING: entries with Sensitive=true contain the plaintext Value as stored in
+// the in-memory backend. Tests should not log entry.Value when Sensitive=true.
+func (r *FakeConfigRepository) Snapshot(ctx context.Context) ([]SeededEntry, error) {
 	entries, err := r.List(ctx, query.ListParams{
 		Limit: query.MaxPageSize,
 		Sort:  []query.SortColumn{{Name: "key", Direction: query.SortASC}},
@@ -51,5 +86,14 @@ func (r *FakeConfigRepository) Snapshot(ctx context.Context) ([]*domain.ConfigEn
 	if err != nil {
 		return nil, fmt.Errorf("configcoretest.FakeConfigRepository.Snapshot: %w", err)
 	}
-	return entries, nil
+	out := make([]SeededEntry, len(entries))
+	for i, e := range entries {
+		out[i] = SeededEntry{
+			Key:       e.Key,
+			Value:     e.Value,
+			Sensitive: e.Sensitive,
+			Version:   e.Version,
+		}
+	}
+	return out, nil
 }

--- a/cells/configcore/configcoretest/fakes.go
+++ b/cells/configcore/configcoretest/fakes.go
@@ -26,7 +26,9 @@ type SeededEntry struct {
 // Snapshot helpers for test scenario setup and assertion.
 //
 // FakeConfigRepository implements ports.ConfigRepository via the embedded
-// *mem.ConfigRepository, so it can be passed directly to BuildWriteService.
+// *mem.ConfigRepository. Tests obtain a wired instance from BuildWriteService
+// (which returns the repo as its second value); direct construction via
+// NewFakeConfigRepository is for repo-only tests that do not need a service.
 //
 // Spy methods (CallsOf/Reset) are deferred until a test needs them; add via
 // Seed + Snapshot if you need state assertions without a Recorder.

--- a/cells/configcore/configcoretest/fakes.go
+++ b/cells/configcore/configcoretest/fakes.go
@@ -1,0 +1,55 @@
+package configcoretest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ghbvf/gocell/cells/configcore/internal/domain"
+	"github.com/ghbvf/gocell/cells/configcore/internal/mem"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/query"
+)
+
+// FakeConfigRepository wraps cells/configcore/internal/mem.ConfigRepository
+// and adds Seed and Snapshot helpers for journey assertions.
+//
+// FakeConfigRepository implements ports.ConfigRepository via the embedded
+// *mem.ConfigRepository, so it can be passed directly to BuildWriteService.
+type FakeConfigRepository struct {
+	*mem.ConfigRepository
+}
+
+// NewFakeConfigRepository creates an empty FakeConfigRepository backed by the
+// in-memory implementation.
+// clk must be non-nil; pass clock.Real() or clockmock.New(...) in tests.
+func NewFakeConfigRepository(clk clock.Clock) *FakeConfigRepository {
+	return &FakeConfigRepository{
+		ConfigRepository: mem.NewConfigRepository(clk),
+	}
+}
+
+// Seed inserts entry into the repository directly, bypassing service-layer
+// validation. Use this to pre-populate the repository before a test scenario.
+//
+// If an entry with the same Key already exists, Seed returns an error wrapping
+// the underlying conflict from the mem store.
+func (r *FakeConfigRepository) Seed(ctx context.Context, entry *domain.ConfigEntry) error {
+	if err := r.Create(ctx, entry); err != nil {
+		return fmt.Errorf("configcoretest.FakeConfigRepository.Seed: %w", err)
+	}
+	return nil
+}
+
+// Snapshot returns a point-in-time copy of all config entries currently stored,
+// sorted by key for deterministic ordering in assertions. It does not modify
+// the repository.
+func (r *FakeConfigRepository) Snapshot(ctx context.Context) ([]*domain.ConfigEntry, error) {
+	entries, err := r.List(ctx, query.ListParams{
+		Limit: query.MaxPageSize,
+		Sort:  []query.SortColumn{{Name: "key", Direction: query.SortASC}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configcoretest.FakeConfigRepository.Snapshot: %w", err)
+	}
+	return entries, nil
+}

--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -653,6 +653,7 @@ var allowedRealCallerPaths = []string{
 	// don't repeat it. They are imported only by *_test.go files; the
 	// CLOCK-INJECTION-TEST-CALLSITE-01 archtest enforces that boundary.
 	"cells/accesscore/internal/testutil/", // SessionRepoForTest / RealSessionRepo
+	"cells/configcore/configcoretest/",    // BuildWriteService / BuildSubscribeService default clock
 }
 
 // INVARIANT: KERNEL-CLOCK-LEAF-FALLBACK-01


### PR DESCRIPTION
## Summary

- Adds `cells/configcore/configcoretest/` — public testutil package exposing `BuildWriteService` / `BuildSubscribeService` builders + `FakeConfigRepository` (wraps `internal/mem.ConfigRepository` with `Seed` + `Snapshot` helpers).
- Enables docker-free producer-side journey criterion tests that were structurally unreachable from `tests/integration/` due to the Go internal-package barrier (root cause of J-confighotreload roadblock).
- Boundary protection inherited from PR0-shipped `CELLTEST-IMPORT-SCOPE-01` archtest (auto-discovers `cells/{X}/{X}test/` form — zero rule edits).

Refs: `docs/plans/202605191943-044-journey-backlog-realignment.md` §2 task 1 (PR-A of 3-PR parallel ship: A=configcore, B=accesscore, C=auditcore).

ref: `kernel/outbox/outboxtest/recorder.go` (PR0 sibling)
ref: `cells/auditcore/auditcoretest/` (PR-C sibling, same plan)

## Test plan

- [x] \`go test ./cells/configcore/configcoretest/... -race\` — 5 tests / 9 subtests GREEN
- [x] \`go test ./tools/archtest/ -run='^TestCelltestImportScope\$|^TestLayerTestutil\$'\` — pass
- [x] \`go build ./...\` — 0 errors
- [x] \`golangci-lint run ./...\` — 0 issues