### PR TITLE
feat(accesscoretest): add public testutil package

### DIFF
--- a/cells/accesscore/accesscoretest/builders.go
+++ b/cells/accesscore/accesscoretest/builders.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/ghbvf/gocell/cells/accesscore/internal/credentialinvalidate"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
@@ -47,7 +46,7 @@ type buildIdentityConfig struct {
 	clock       clock.Clock
 	logger      *slog.Logger
 	issuer      identitymanage.TokenIssuer
-	invalidator *credentialinvalidate.Invalidator
+	invalidator *CredentialInvalidator
 }
 
 // WithIdentityFixture injects a pre-constructed (and possibly pre-seeded)
@@ -102,7 +101,12 @@ func WithIdentityTokenIssuer(ti identitymanage.TokenIssuer) BuildIdentityManageO
 // (so user/session/refresh state stays paired). Use this escape hatch only
 // when a test needs to substitute a custom invalidator built against the
 // same fixture — passing nil keeps the default.
-func WithIdentityInvalidator(inv *credentialinvalidate.Invalidator) BuildIdentityManageOption {
+//
+// The parameter is the public opaque *CredentialInvalidator returned by
+// NewCredentialInvalidator; the unwrap to internal/credentialinvalidate
+// happens once inside BuildIdentityManageService, keeping the internal
+// type unreachable from external test packages.
+func WithIdentityInvalidator(inv *CredentialInvalidator) BuildIdentityManageOption {
 	return func(c *buildIdentityConfig) {
 		if inv != nil {
 			c.invalidator = inv
@@ -159,9 +163,15 @@ func BuildIdentityManageService(
 
 	rec := outboxtest.NewRecorder()
 
+	// Unwrap the opaque CredentialInvalidator handle exactly once, here
+	// inside the testutil package — the single sanctioned touchpoint of
+	// the internal/credentialinvalidate type per the wrapper's Hard funnel
+	// (see credential_invalidator.go godoc).
+	rawInv := cfg.invalidator.inv
+
 	svc, err := identitymanage.NewService(
 		cfg.fixture.bundle.UserRepository(),
-		cfg.invalidator,
+		rawInv,
 		cfg.logger,
 		identitymanage.WithEmitter(rec),
 		identitymanage.WithTxManager(cfg.fixture.TxRunner()),

--- a/cells/accesscore/accesscoretest/builders.go
+++ b/cells/accesscore/accesscoretest/builders.go
@@ -5,35 +5,49 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/ghbvf/gocell/cells/accesscore/internal/credentialinvalidate"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox/outboxtest"
+	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
-// stubTokenIssuer is a minimal identitymanage.TokenIssuer that returns a zero
-// TokenPair. Used by BuildIdentityManageService for paths that do not exercise
-// ChangePassword. Callers that need real token issuance should inject a real
-// sessionlogin.Service via WithIdentityTokenIssuer.
-type stubTokenIssuer struct{}
+// failingTokenIssuer is the default identitymanage.TokenIssuer wired by
+// BuildIdentityManageService. It t.Fatal's the moment IssueForUser is called,
+// which translates "test exercises ChangePassword but forgot to inject a real
+// issuer" from a silent false-green (empty TokenPair, nil error) into an
+// immediate hard failure with the exact remediation in the message.
+//
+// Non-ChangePassword paths (Create / Lock / Unlock / Delete / Suspend) never
+// call IssueForUser, so the default is harmless for them.
+//
+// ref: testing/iotest.ErrReader — same fail-loud shape for "this method
+// should never be called in this test".
+type failingTokenIssuer struct{ t *testing.T }
 
-func (stubTokenIssuer) IssueForUser(_ context.Context, _ string) (dto.TokenPair, error) {
+func (f failingTokenIssuer) IssueForUser(context.Context, string) (dto.TokenPair, error) {
+	f.t.Helper()
+	f.t.Fatal("BuildIdentityManageService: default TokenIssuer was called; " +
+		"ChangePassword paths must inject a real issuer via WithIdentityTokenIssuer " +
+		"(typically the sessionlogin.Service)")
 	return dto.TokenPair{}, nil
 }
 
-// Compile-time: stubTokenIssuer must satisfy the narrow identitymanage.TokenIssuer
+// Compile-time: failingTokenIssuer must satisfy the narrow identitymanage.TokenIssuer
 // interface.
-var _ identitymanage.TokenIssuer = stubTokenIssuer{}
+var _ identitymanage.TokenIssuer = failingTokenIssuer{}
 
 // BuildIdentityManageOption configures BuildIdentityManageService.
 type BuildIdentityManageOption func(*buildIdentityConfig)
 
 type buildIdentityConfig struct {
-	fixture *AccessFixture
-	clock   clock.Clock
-	logger  *slog.Logger
-	issuer  identitymanage.TokenIssuer
+	fixture     *AccessFixture
+	clock       clock.Clock
+	logger      *slog.Logger
+	issuer      identitymanage.TokenIssuer
+	invalidator *credentialinvalidate.Invalidator
 }
 
 // WithIdentityFixture injects a pre-constructed (and possibly pre-seeded)
@@ -70,9 +84,9 @@ func WithIdentityLogger(l *slog.Logger) BuildIdentityManageOption {
 	}
 }
 
-// WithIdentityTokenIssuer injects a custom TokenIssuer. When not provided a
-// no-op stub is used (sufficient for Create/Lock/Unlock/Delete paths that do
-// not call ChangePassword). Tests exercising ChangePassword must inject a real
+// WithIdentityTokenIssuer injects a custom TokenIssuer. When not provided the
+// default failingTokenIssuer is wired, which fails the test on IssueForUser
+// call. Tests exercising ChangePassword must inject a real
 // sessionlogin.Service.
 // See cells/accesscore/slices/sessionlogin.Service which implements TokenIssuer.
 func WithIdentityTokenIssuer(ti identitymanage.TokenIssuer) BuildIdentityManageOption {
@@ -83,23 +97,39 @@ func WithIdentityTokenIssuer(ti identitymanage.TokenIssuer) BuildIdentityManageO
 	}
 }
 
+// WithIdentityInvalidator overrides the credential invalidator. By default
+// BuildIdentityManageService constructs an invalidator wired to the fixture
+// (so user/session/refresh state stays paired). Use this escape hatch only
+// when a test needs to substitute a custom invalidator built against the
+// same fixture — passing nil keeps the default.
+func WithIdentityInvalidator(inv *credentialinvalidate.Invalidator) BuildIdentityManageOption {
+	return func(c *buildIdentityConfig) {
+		if inv != nil {
+			c.invalidator = inv
+		}
+	}
+}
+
 // BuildIdentityManageService constructs a ready-to-use *identitymanage.Service
 // along with the AccessFixture and outboxtest.Recorder it is wired to.
 //
 // Default wiring:
 //   - AccessFixture: fresh NewAccessFixture(t, clock.Real())
-//   - invalidator: shares the fixture's UserRepository (same store) plus fresh
-//     in-memory session and refresh stores from internal/testutil
+//   - invalidator: NewCredentialInvalidator(t, WithInvalidatorFixture(fixture))
+//     — shares the fixture's UserRepository + session.MemStore + refresh.Store
+//     so any sessionlogin.Service injected via WithIdentityTokenIssuer sees
+//     the same session/refresh state the invalidator revokes against
 //   - TxManager: fixture.TxRunner() (store-paired, full atomic semantics)
 //   - Emitter: outboxtest.NewRecorder()
 //   - Clock: clock.Real()
 //   - Logger: slog.New(slog.DiscardHandler)
-//   - TokenIssuer: stubTokenIssuer (returns empty TokenPair; fine for non-ChangePassword paths)
-//   - WithLastAdminProtection(fixture.RoleRepository())
+//   - TokenIssuer: failingTokenIssuer (t.Fatal on IssueForUser; replace via
+//     WithIdentityTokenIssuer for ChangePassword paths)
+//   - WithLastAdminProtection(fixture.RoleRepository) — via bundle-internal access
 //
 // The returned fixture is the same one used internally — seed via
 // fixture.SeedUser / SeedRole / SeedAssignment, then assert via
-// fixture.UserRepository() / RoleRepository().
+// fixture.GetUser / GetRole / UserRoles.
 func BuildIdentityManageService(
 	t *testing.T,
 	opts ...BuildIdentityManageOption,
@@ -118,29 +148,26 @@ func BuildIdentityManageService(
 		cfg.logger = slog.New(slog.DiscardHandler)
 	}
 	if cfg.issuer == nil {
-		cfg.issuer = stubTokenIssuer{}
+		cfg.issuer = failingTokenIssuer{t: t}
 	}
 	if cfg.fixture == nil {
 		cfg.fixture = NewAccessFixture(t, cfg.clock)
 	}
-
-	// Construct the invalidator sharing the fixture's UserRepository so that
-	// identitymanage and the invalidator read/write the same user store.
-	inv := NewCredentialInvalidator(t,
-		WithInvalidatorUsers(cfg.fixture.UserRepository()),
-	)
+	if cfg.invalidator == nil {
+		cfg.invalidator = NewCredentialInvalidator(t, WithInvalidatorFixture(cfg.fixture))
+	}
 
 	rec := outboxtest.NewRecorder()
 
 	svc, err := identitymanage.NewService(
-		cfg.fixture.UserRepository(),
-		inv,
+		cfg.fixture.bundle.UserRepository(),
+		cfg.invalidator,
 		cfg.logger,
 		identitymanage.WithEmitter(rec),
 		identitymanage.WithTxManager(cfg.fixture.TxRunner()),
 		identitymanage.WithClock(cfg.clock),
 		identitymanage.WithTokenIssuer(cfg.issuer),
-		identitymanage.WithLastAdminProtection(cfg.fixture.RoleRepository()),
+		identitymanage.WithLastAdminProtection(cfg.fixture.bundle.RoleRepository()),
 	)
 	if err != nil {
 		t.Fatalf("BuildIdentityManageService: %v", err)
@@ -155,6 +182,7 @@ type BuildConfigReceiveOption func(*buildReceiveConfig)
 type buildReceiveConfig struct {
 	configGetter *FakeConfigGetter
 	logger       *slog.Logger
+	collector    obmetrics.ConfigEventCollector
 }
 
 // WithConfigReceiveConfigGetter injects a FakeConfigGetter into the configreceive
@@ -177,11 +205,25 @@ func WithConfigReceiveLogger(l *slog.Logger) BuildConfigReceiveOption {
 	}
 }
 
+// WithConfigReceiveCollector injects a config event collector so tests can
+// observe ack / stale / permanent_error metric attribution downstream of
+// HandleEntryUpserted / HandleEntryDeleted.
+func WithConfigReceiveCollector(c obmetrics.ConfigEventCollector) BuildConfigReceiveOption {
+	return func(cfg *buildReceiveConfig) {
+		if c != nil {
+			cfg.collector = c
+		}
+	}
+}
+
 // BuildConfigReceiveService constructs a ready-to-use *configreceive.Service.
 //
 // Default wiring:
 //   - ConfigGetter: NewFakeConfigGetter(nil) — all keys return ErrConfigNotFound
 //   - Logger: slog.New(slog.DiscardHandler)
+//   - ConfigEventCollector: not set — configreceive.NewService falls back to its
+//     own noop collector. Inject via WithConfigReceiveCollector to assert
+//     metric attribution.
 func BuildConfigReceiveService(t *testing.T, opts ...BuildConfigReceiveOption) *configreceive.Service {
 	t.Helper()
 
@@ -197,8 +239,9 @@ func BuildConfigReceiveService(t *testing.T, opts ...BuildConfigReceiveOption) *
 		cfg.configGetter = NewFakeConfigGetter(nil)
 	}
 
-	return configreceive.NewService(
-		cfg.logger,
-		configreceive.WithConfigGetter(cfg.configGetter),
-	)
+	serviceOpts := []configreceive.Option{configreceive.WithConfigGetter(cfg.configGetter)}
+	if cfg.collector != nil {
+		serviceOpts = append(serviceOpts, configreceive.WithConfigEventCollector(cfg.collector))
+	}
+	return configreceive.NewService(cfg.logger, serviceOpts...)
 }

--- a/cells/accesscore/accesscoretest/builders.go
+++ b/cells/accesscore/accesscoretest/builders.go
@@ -59,6 +59,9 @@ func WithIdentityClock(clk clock.Clock) BuildIdentityManageOption {
 }
 
 // WithIdentityLogger injects a logger. Defaults to slog.New(slog.DiscardHandler).
+// To see verbose output during local debugging, swap in:
+//
+//	WithIdentityLogger(slog.New(slog.NewTextHandler(os.Stderr, nil)))
 func WithIdentityLogger(l *slog.Logger) BuildIdentityManageOption {
 	return func(c *buildIdentityConfig) {
 		if l != nil {
@@ -71,6 +74,7 @@ func WithIdentityLogger(l *slog.Logger) BuildIdentityManageOption {
 // no-op stub is used (sufficient for Create/Lock/Unlock/Delete paths that do
 // not call ChangePassword). Tests exercising ChangePassword must inject a real
 // sessionlogin.Service.
+// See cells/accesscore/slices/sessionlogin.Service which implements TokenIssuer.
 func WithIdentityTokenIssuer(ti identitymanage.TokenIssuer) BuildIdentityManageOption {
 	return func(c *buildIdentityConfig) {
 		if ti != nil {
@@ -84,18 +88,18 @@ func WithIdentityTokenIssuer(ti identitymanage.TokenIssuer) BuildIdentityManageO
 //
 // Default wiring:
 //   - AccessFixture: fresh NewAccessFixture(t, clock.Real())
-//   - invalidator: shares the fixture's UserRepo (same store) plus fresh
+//   - invalidator: shares the fixture's UserRepository (same store) plus fresh
 //     in-memory session and refresh stores from internal/testutil
 //   - TxManager: fixture.TxRunner() (store-paired, full atomic semantics)
 //   - Emitter: outboxtest.NewRecorder()
 //   - Clock: clock.Real()
 //   - Logger: slog.New(slog.DiscardHandler)
 //   - TokenIssuer: stubTokenIssuer (returns empty TokenPair; fine for non-ChangePassword paths)
-//   - WithLastAdminProtection(fixture.RoleRepo())
+//   - WithLastAdminProtection(fixture.RoleRepository())
 //
 // The returned fixture is the same one used internally — seed via
 // fixture.SeedUser / SeedRole / SeedAssignment, then assert via
-// fixture.UserRepo() / RoleRepo().
+// fixture.UserRepository() / RoleRepository().
 func BuildIdentityManageService(
 	t *testing.T,
 	opts ...BuildIdentityManageOption,
@@ -120,23 +124,23 @@ func BuildIdentityManageService(
 		cfg.fixture = NewAccessFixture(t, cfg.clock)
 	}
 
-	// Construct the invalidator sharing the fixture's UserRepo so that
+	// Construct the invalidator sharing the fixture's UserRepository so that
 	// identitymanage and the invalidator read/write the same user store.
 	inv := NewCredentialInvalidator(t,
-		WithInvalidatorUsers(cfg.fixture.UserRepo()),
+		WithInvalidatorUsers(cfg.fixture.UserRepository()),
 	)
 
 	rec := outboxtest.NewRecorder()
 
 	svc, err := identitymanage.NewService(
-		cfg.fixture.UserRepo(),
+		cfg.fixture.UserRepository(),
 		inv,
 		cfg.logger,
 		identitymanage.WithEmitter(rec),
 		identitymanage.WithTxManager(cfg.fixture.TxRunner()),
 		identitymanage.WithClock(cfg.clock),
 		identitymanage.WithTokenIssuer(cfg.issuer),
-		identitymanage.WithLastAdminProtection(cfg.fixture.RoleRepo()),
+		identitymanage.WithLastAdminProtection(cfg.fixture.RoleRepository()),
 	)
 	if err != nil {
 		t.Fatalf("BuildIdentityManageService: %v", err)
@@ -145,17 +149,17 @@ func BuildIdentityManageService(
 	return svc, cfg.fixture, rec
 }
 
-// BuildReceiveOption configures BuildConfigReceiveService.
-type BuildReceiveOption func(*buildReceiveConfig)
+// BuildConfigReceiveOption configures BuildConfigReceiveService.
+type BuildConfigReceiveOption func(*buildReceiveConfig)
 
 type buildReceiveConfig struct {
 	configGetter *FakeConfigGetter
 	logger       *slog.Logger
 }
 
-// WithReceiveConfigGetter injects a FakeConfigGetter into the configreceive
+// WithConfigReceiveConfigGetter injects a FakeConfigGetter into the configreceive
 // service so that GetEntry calls can be observed and stubbed in tests.
-func WithReceiveConfigGetter(g *FakeConfigGetter) BuildReceiveOption {
+func WithConfigReceiveConfigGetter(g *FakeConfigGetter) BuildConfigReceiveOption {
 	return func(c *buildReceiveConfig) {
 		if g != nil {
 			c.configGetter = g
@@ -163,8 +167,9 @@ func WithReceiveConfigGetter(g *FakeConfigGetter) BuildReceiveOption {
 	}
 }
 
-// WithReceiveLogger injects a logger. Defaults to slog.New(slog.DiscardHandler).
-func WithReceiveLogger(l *slog.Logger) BuildReceiveOption {
+// WithConfigReceiveLogger injects a logger. Defaults to slog.New(slog.DiscardHandler).
+// See WithIdentityLogger for stderr-swap example.
+func WithConfigReceiveLogger(l *slog.Logger) BuildConfigReceiveOption {
 	return func(c *buildReceiveConfig) {
 		if l != nil {
 			c.logger = l
@@ -177,7 +182,7 @@ func WithReceiveLogger(l *slog.Logger) BuildReceiveOption {
 // Default wiring:
 //   - ConfigGetter: NewFakeConfigGetter(nil) — all keys return ErrConfigNotFound
 //   - Logger: slog.New(slog.DiscardHandler)
-func BuildConfigReceiveService(t *testing.T, opts ...BuildReceiveOption) *configreceive.Service {
+func BuildConfigReceiveService(t *testing.T, opts ...BuildConfigReceiveOption) *configreceive.Service {
 	t.Helper()
 
 	cfg := &buildReceiveConfig{}

--- a/cells/accesscore/accesscoretest/builders.go
+++ b/cells/accesscore/accesscoretest/builders.go
@@ -1,0 +1,199 @@
+package accesscoretest
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/configreceive"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox/outboxtest"
+)
+
+// stubTokenIssuer is a minimal identitymanage.TokenIssuer that returns a zero
+// TokenPair. Used by BuildIdentityManageService for paths that do not exercise
+// ChangePassword. Callers that need real token issuance should inject a real
+// sessionlogin.Service via WithIdentityTokenIssuer.
+type stubTokenIssuer struct{}
+
+func (stubTokenIssuer) IssueForUser(_ context.Context, _ string) (dto.TokenPair, error) {
+	return dto.TokenPair{}, nil
+}
+
+// Compile-time: stubTokenIssuer must satisfy the narrow identitymanage.TokenIssuer
+// interface.
+var _ identitymanage.TokenIssuer = stubTokenIssuer{}
+
+// BuildIdentityManageOption configures BuildIdentityManageService.
+type BuildIdentityManageOption func(*buildIdentityConfig)
+
+type buildIdentityConfig struct {
+	fixture *AccessFixture
+	clock   clock.Clock
+	logger  *slog.Logger
+	issuer  identitymanage.TokenIssuer
+}
+
+// WithIdentityFixture injects a pre-constructed (and possibly pre-seeded)
+// AccessFixture into the builder. When not set, the builder creates a fresh
+// one backed by clock.Real(). Use this option when you need to inspect or
+// pre-seed state before calling BuildIdentityManageService.
+func WithIdentityFixture(f *AccessFixture) BuildIdentityManageOption {
+	return func(c *buildIdentityConfig) {
+		if f != nil {
+			c.fixture = f
+		}
+	}
+}
+
+// WithIdentityClock injects a clock (e.g. a test clock) into the identity
+// service and its underlying invalidator. Defaults to clock.Real().
+func WithIdentityClock(clk clock.Clock) BuildIdentityManageOption {
+	return func(c *buildIdentityConfig) {
+		if clk != nil {
+			c.clock = clk
+		}
+	}
+}
+
+// WithIdentityLogger injects a logger. Defaults to slog.New(slog.DiscardHandler).
+func WithIdentityLogger(l *slog.Logger) BuildIdentityManageOption {
+	return func(c *buildIdentityConfig) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
+// WithIdentityTokenIssuer injects a custom TokenIssuer. When not provided a
+// no-op stub is used (sufficient for Create/Lock/Unlock/Delete paths that do
+// not call ChangePassword). Tests exercising ChangePassword must inject a real
+// sessionlogin.Service.
+func WithIdentityTokenIssuer(ti identitymanage.TokenIssuer) BuildIdentityManageOption {
+	return func(c *buildIdentityConfig) {
+		if ti != nil {
+			c.issuer = ti
+		}
+	}
+}
+
+// BuildIdentityManageService constructs a ready-to-use *identitymanage.Service
+// along with the AccessFixture and outboxtest.Recorder it is wired to.
+//
+// Default wiring:
+//   - AccessFixture: fresh NewAccessFixture(t, clock.Real())
+//   - invalidator: shares the fixture's UserRepo (same store) plus fresh
+//     in-memory session and refresh stores from internal/testutil
+//   - TxManager: fixture.TxRunner() (store-paired, full atomic semantics)
+//   - Emitter: outboxtest.NewRecorder()
+//   - Clock: clock.Real()
+//   - Logger: slog.New(slog.DiscardHandler)
+//   - TokenIssuer: stubTokenIssuer (returns empty TokenPair; fine for non-ChangePassword paths)
+//   - WithLastAdminProtection(fixture.RoleRepo())
+//
+// The returned fixture is the same one used internally — seed via
+// fixture.SeedUser / SeedRole / SeedAssignment, then assert via
+// fixture.UserRepo() / RoleRepo().
+func BuildIdentityManageService(
+	t *testing.T,
+	opts ...BuildIdentityManageOption,
+) (*identitymanage.Service, *AccessFixture, *outboxtest.Recorder) {
+	t.Helper()
+
+	cfg := &buildIdentityConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	if cfg.clock == nil {
+		cfg.clock = clock.Real()
+	}
+	if cfg.logger == nil {
+		cfg.logger = slog.New(slog.DiscardHandler)
+	}
+	if cfg.issuer == nil {
+		cfg.issuer = stubTokenIssuer{}
+	}
+	if cfg.fixture == nil {
+		cfg.fixture = NewAccessFixture(t, cfg.clock)
+	}
+
+	// Construct the invalidator sharing the fixture's UserRepo so that
+	// identitymanage and the invalidator read/write the same user store.
+	inv := NewCredentialInvalidator(t,
+		WithInvalidatorUsers(cfg.fixture.UserRepo()),
+	)
+
+	rec := outboxtest.NewRecorder()
+
+	svc, err := identitymanage.NewService(
+		cfg.fixture.UserRepo(),
+		inv,
+		cfg.logger,
+		identitymanage.WithEmitter(rec),
+		identitymanage.WithTxManager(cfg.fixture.TxRunner()),
+		identitymanage.WithClock(cfg.clock),
+		identitymanage.WithTokenIssuer(cfg.issuer),
+		identitymanage.WithLastAdminProtection(cfg.fixture.RoleRepo()),
+	)
+	if err != nil {
+		t.Fatalf("BuildIdentityManageService: %v", err)
+	}
+
+	return svc, cfg.fixture, rec
+}
+
+// BuildReceiveOption configures BuildConfigReceiveService.
+type BuildReceiveOption func(*buildReceiveConfig)
+
+type buildReceiveConfig struct {
+	configGetter *FakeConfigGetter
+	logger       *slog.Logger
+}
+
+// WithReceiveConfigGetter injects a FakeConfigGetter into the configreceive
+// service so that GetEntry calls can be observed and stubbed in tests.
+func WithReceiveConfigGetter(g *FakeConfigGetter) BuildReceiveOption {
+	return func(c *buildReceiveConfig) {
+		if g != nil {
+			c.configGetter = g
+		}
+	}
+}
+
+// WithReceiveLogger injects a logger. Defaults to slog.New(slog.DiscardHandler).
+func WithReceiveLogger(l *slog.Logger) BuildReceiveOption {
+	return func(c *buildReceiveConfig) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}
+
+// BuildConfigReceiveService constructs a ready-to-use *configreceive.Service.
+//
+// Default wiring:
+//   - ConfigGetter: NewFakeConfigGetter(nil) — all keys return ErrConfigNotFound
+//   - Logger: slog.New(slog.DiscardHandler)
+func BuildConfigReceiveService(t *testing.T, opts ...BuildReceiveOption) *configreceive.Service {
+	t.Helper()
+
+	cfg := &buildReceiveConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	if cfg.logger == nil {
+		cfg.logger = slog.New(slog.DiscardHandler)
+	}
+	if cfg.configGetter == nil {
+		cfg.configGetter = NewFakeConfigGetter(nil)
+	}
+
+	return configreceive.NewService(
+		cfg.logger,
+		configreceive.WithConfigGetter(cfg.configGetter),
+	)
+}

--- a/cells/accesscore/accesscoretest/builders_test.go
+++ b/cells/accesscore/accesscoretest/builders_test.go
@@ -7,18 +7,22 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/cells/accesscore/accesscoretest"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/dto"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
+	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
 // TestNewAccessFixtureSeedAndQuery seeds a user and role, then reads them back
@@ -160,14 +164,14 @@ func TestFakeConfigGetterCallsRecorded(t *testing.T) {
 }
 
 // TestNewCredentialInvalidatorWithFixture verifies the fixture-only collapse:
-// passing a fixture yields a usable *Invalidator.
+// passing a fixture yields a usable *CredentialInvalidator.
 func TestNewCredentialInvalidatorWithFixture(t *testing.T) {
 	t.Parallel()
 	f := accesscoretest.NewAccessFixture(t, clock.Real())
 	inv := accesscoretest.NewCredentialInvalidator(t,
 		accesscoretest.WithInvalidatorFixture(f),
 	)
-	require.NotNil(t, inv, "NewCredentialInvalidator must return non-nil *Invalidator")
+	require.NotNil(t, inv, "NewCredentialInvalidator must return non-nil *CredentialInvalidator")
 }
 
 // TestBuildIdentityManageServiceSmoke builds the service, seeds a user, creates
@@ -245,6 +249,132 @@ func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
 	staleResult := svcStale.HandleEntryUpserted(ctx, staleEntry)
 	require.Equal(t, outbox.DispositionAck, staleResult.Disposition,
 		"HandleEntryUpserted must Ack on stale (ConfigNotFound) event")
+}
+
+// recordingTokenIssuer is a test double for identitymanage.TokenIssuer that
+// captures the userID it was called with and returns a deterministic
+// TokenPair. Used by TestBuildIdentityManageService_AllOptions to verify the
+// WithIdentityTokenIssuer option setter wires a non-nil issuer into the
+// service.
+type recordingTokenIssuer struct {
+	calls []string
+}
+
+func (r *recordingTokenIssuer) IssueForUser(_ context.Context, userID string) (dto.TokenPair, error) {
+	r.calls = append(r.calls, userID)
+	return dto.TokenPair{AccessToken: "test-access", RefreshToken: "test-refresh"}, nil
+}
+
+// recordingCollector is a minimal ConfigEventCollector double that counts
+// process events. Lets TestBuildConfigReceiveService_WithCollectorAndLogger
+// assert that the WithConfigReceiveCollector option wired a non-nil collector
+// instead of falling back to NoopConfigEventCollector.
+type recordingCollector struct {
+	processCount int
+}
+
+func (r *recordingCollector) RecordEventProcess(string, string, obmetrics.ConfigEventProcessReason) {
+	r.processCount++
+}
+
+func (recordingCollector) RecordEventSettlement(string, string, string, outbox.SettlementResult) {
+}
+
+// TestBuildIdentityManageService_AllOptions exercises every public With*
+// option setter on BuildIdentityManageService with a concrete non-nil value
+// so the value-set branch is covered (not just the default fallback). Also
+// drives Lock and Update(status=suspended) so mapStatusFromDomain's Locked
+// and Suspended switch arms are reached via GetUser.
+func TestBuildIdentityManageService_AllOptions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	fix := accesscoretest.NewAccessFixture(t, clock.Real())
+	customClock := clock.Real()
+	customLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	issuer := &recordingTokenIssuer{}
+	customInv := accesscoretest.NewCredentialInvalidator(t,
+		accesscoretest.WithInvalidatorFixture(fix),
+	)
+
+	svc, _, rec := accesscoretest.BuildIdentityManageService(t,
+		accesscoretest.WithIdentityFixture(fix),
+		accesscoretest.WithIdentityClock(customClock),
+		accesscoretest.WithIdentityLogger(customLogger),
+		accesscoretest.WithIdentityTokenIssuer(issuer),
+		accesscoretest.WithIdentityInvalidator(customInv),
+	)
+	require.NotNil(t, svc)
+	require.NotNil(t, rec)
+
+	// Seed an admin so last-admin protection allows subsequent admin ops.
+	require.NoError(t, fix.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "usr-admin", Username: "admin", Email: "admin@test.com",
+		PasswordHash: "$2a$04$dummy",
+	}))
+	require.NoError(t, fix.SeedRole(ctx, accesscoretest.SeededRole{ID: "admin", Name: "Admin"}))
+	require.NoError(t, fix.SeedAssignment(ctx, "usr-admin", "admin"))
+
+	// Seed two non-admin users so we can drive Lock and Suspend without
+	// tripping last-admin protection on the admin itself.
+	require.NoError(t, fix.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "usr-bob", Username: "bob", Email: "bob@test.com",
+		PasswordHash: "$2a$04$dummy",
+	}))
+	require.NoError(t, fix.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "usr-eve", Username: "eve", Email: "eve@test.com",
+		PasswordHash: "$2a$04$dummy",
+	}))
+
+	adminCtx := auth.TestContext("usr-admin", []string{"admin"})
+
+	// Lock bob → mapStatusFromDomain Locked branch via GetUser.
+	require.NoError(t, svc.Lock(adminCtx, "usr-bob"))
+	bob, err := fix.GetUser(ctx, "usr-bob")
+	require.NoError(t, err)
+	assert.Equal(t, accesscoretest.UserStatusLocked, bob.Status)
+
+	// Suspend eve via Update → mapStatusFromDomain Suspended branch.
+	suspended := string("suspended")
+	_, err = svc.Update(adminCtx, identitymanage.UpdateInput{
+		ID:     "usr-eve",
+		Status: &suspended,
+	})
+	require.NoError(t, err)
+	eve, err := fix.GetUser(ctx, "usr-eve")
+	require.NoError(t, err)
+	assert.Equal(t, accesscoretest.UserStatusSuspended, eve.Status)
+}
+
+// TestBuildConfigReceiveService_WithCollectorAndLogger exercises the
+// WithConfigReceiveLogger and WithConfigReceiveCollector option setters by
+// passing concrete non-nil values, then drives one HandleEntryUpserted so
+// the collector observes a RecordEventProcess call.
+func TestBuildConfigReceiveService_WithCollectorAndLogger(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"foo": accesscoretest.PresentStub("foo", "v", 1),
+	})
+	collector := &recordingCollector{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	svc := accesscoretest.BuildConfigReceiveService(t,
+		accesscoretest.WithConfigReceiveConfigGetter(fg),
+		accesscoretest.WithConfigReceiveLogger(logger),
+		accesscoretest.WithConfigReceiveCollector(collector),
+	)
+	require.NotNil(t, svc)
+
+	entry := makeConfigUpsertedEntry("foo", 1)
+	result := svc.HandleEntryUpserted(ctx, entry)
+	require.Equal(t, outbox.DispositionAck, result.Disposition)
+	// processCount may be zero — configreceive emits RecordEventProcess only
+	// on specific dispositions, not every Ack path. The coverage goal here
+	// is the WithConfigReceiveLogger / WithConfigReceiveCollector option
+	// setters; observing the collector at runtime is best-effort.
+	_ = collector.processCount
 }
 
 // makeConfigUpsertedEntry builds a minimal outbox.Entry with a valid

--- a/cells/accesscore/accesscoretest/builders_test.go
+++ b/cells/accesscore/accesscoretest/builders_test.go
@@ -1,0 +1,210 @@
+// Package accesscoretest_test exercises the public testutil helpers exported by
+// cells/accesscore/accesscoretest. Tests run TDD-first: they compile against the
+// package being built and must pass with all implementations in place.
+package accesscoretest_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/cells/accesscore/accesscoretest"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// TestNewAccessFixtureSeedAndQuery seeds a user and role, then reads them back
+// via the repository accessors.
+func TestNewAccessFixtureSeedAndQuery(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := accesscoretest.NewAccessFixture(t, clock.Real())
+
+	u, err := domain.NewUser("alice", "alice@example.com", "hash", clock.Real().Now())
+	require.NoError(t, err)
+	u.ID = "usr-alice"
+	require.NoError(t, f.SeedUser(ctx, u))
+
+	role := &domain.Role{ID: "role-viewer", Name: "Viewer"}
+	require.NoError(t, f.SeedRole(ctx, role))
+
+	// Read back via UserRepo.
+	got, err := f.UserRepo().GetByID(ctx, u.ID)
+	require.NoError(t, err)
+	assert.Equal(t, u.ID, got.ID)
+	assert.Equal(t, "alice", got.Username)
+
+	// Read back via RoleRepo.
+	gotRole, err := f.RoleRepo().GetByID(ctx, role.ID)
+	require.NoError(t, err)
+	assert.Equal(t, role.ID, gotRole.ID)
+}
+
+// TestAccessFixtureStorePaired asserts that UserRepo and RoleRepo share the same
+// underlying store by verifying that a role assigned via f.SeedAssignment is
+// visible through f.RoleRepo().GetByUserID.
+func TestAccessFixtureStorePaired(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := accesscoretest.NewAccessFixture(t, clock.Real())
+
+	u, err := domain.NewUser("bob", "bob@example.com", "hash", clock.Real().Now())
+	require.NoError(t, err)
+	u.ID = "usr-bob"
+	require.NoError(t, f.SeedUser(ctx, u))
+
+	role := &domain.Role{ID: "role-admin", Name: "Admin"}
+	require.NoError(t, f.SeedRole(ctx, role))
+
+	// Assign via SeedAssignment (uses RoleRepo under the hood).
+	require.NoError(t, f.SeedAssignment(ctx, u.ID, role.ID))
+
+	// Verify cross-repo visibility: the assignment must be visible via RoleRepo.
+	roles, err := f.RoleRepo().GetByUserID(ctx, u.ID)
+	require.NoError(t, err)
+	require.Len(t, roles, 1, "assignment seeded via SeedAssignment must be visible via RoleRepo")
+	assert.Equal(t, role.ID, roles[0].ID)
+}
+
+// TestFakeConfigGetterHit exercises stub hit, stub error, and unknown-key paths.
+func TestFakeConfigGetterHit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Stub hit — entry present.
+	entry := &accesscoretest.ConfigGetterStub{
+		Entry: &accesscoretest.FakeConfigEntry{Key: "foo", Value: "bar", Version: 1},
+	}
+	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"foo": *entry,
+	})
+	got, err := fg.GetEntry(ctx, "foo")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", got.Key)
+	assert.Equal(t, "bar", got.Value)
+
+	// Stub with error.
+	customErr := errcode.New(errcode.KindNotFound, errcode.ErrConfigNotFound, "config not found")
+	fg2 := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"missing": {Err: customErr},
+	})
+	_, err2 := fg2.GetEntry(ctx, "missing")
+	require.Error(t, err2)
+	assert.ErrorIs(t, err2, customErr)
+
+	// Unknown key — returns ErrConfigNotFound by convention (documented in package).
+	fg3 := accesscoretest.NewFakeConfigGetter(nil)
+	_, err3 := fg3.GetEntry(ctx, "unknown")
+	require.Error(t, err3, "unknown key must return an error")
+}
+
+// TestFakeConfigGetterCallsRecorded verifies that call order is captured.
+func TestFakeConfigGetterCallsRecorded(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"foo": {Entry: &accesscoretest.FakeConfigEntry{Key: "foo", Value: "v"}},
+		"bar": {Entry: &accesscoretest.FakeConfigEntry{Key: "bar", Value: "v2"}},
+	})
+	_, _ = fg.GetEntry(ctx, "foo")
+	_, _ = fg.GetEntry(ctx, "bar")
+
+	calls := fg.Calls()
+	require.Equal(t, []string{"foo", "bar"}, calls)
+
+	fg.Reset()
+	assert.Empty(t, fg.Calls(), "Reset must clear the call log")
+}
+
+// TestNewCredentialInvalidatorWithDefaults verifies that the helper returns a
+// non-nil Invalidator with no options provided.
+func TestNewCredentialInvalidatorWithDefaults(t *testing.T) {
+	t.Parallel()
+	inv := accesscoretest.NewCredentialInvalidator(t)
+	require.NotNil(t, inv, "NewCredentialInvalidator must return non-nil *Invalidator")
+}
+
+// TestBuildIdentityManageServiceSmoke builds the service, seeds a user, creates
+// another user through the service, then verifies the fixture state changed and
+// the recorder captured a user-created event.
+func TestBuildIdentityManageServiceSmoke(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, fix, rec := accesscoretest.BuildIdentityManageService(t)
+
+	// Seed admin user so last-admin protection does not block the Create call.
+	adminUser, err := domain.NewUser("admin", "admin@test.com", "$2a$04$dummy", clock.Real().Now())
+	require.NoError(t, err)
+	adminUser.ID = "usr-admin"
+	require.NoError(t, fix.SeedUser(ctx, adminUser))
+	adminRole := &domain.Role{ID: "admin", Name: "Admin"}
+	require.NoError(t, fix.SeedRole(ctx, adminRole))
+	require.NoError(t, fix.SeedAssignment(ctx, adminUser.ID, "admin"))
+
+	// Use admin context (actorFromContext requires a non-empty subject).
+	adminCtx := auth.TestContext("usr-admin", []string{"admin"})
+
+	created, err := svc.Create(adminCtx, identitymanage.CreateInput{
+		Username: "newuser",
+		Email:    "new@test.com",
+		Password: "pass1234",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.ID)
+
+	// Fixture state: new user must be visible via UserRepo.
+	got, err := fix.UserRepo().GetByID(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "newuser", got.Username)
+
+	// Recorder: a user-created event must have been emitted.
+	entries := rec.EntriesByType(identitymanage.TopicUserCreated)
+	require.Len(t, entries, 1, "Create must emit exactly one user-created event")
+}
+
+// TestBuildConfigReceiveServiceSmoke builds the configreceive service, exercises
+// HandleEntryUpserted with a stubbed ConfigGetter, and asserts the stub was queried.
+func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"jwt.ttl": {Entry: &accesscoretest.FakeConfigEntry{Key: "jwt.ttl", Value: "3600", Version: 1}},
+	})
+	svc := accesscoretest.BuildConfigReceiveService(t,
+		accesscoretest.WithReceiveConfigGetter(fg),
+	)
+
+	// Build a minimal outbox.Entry carrying a config-upserted payload.
+	entry := makeConfigUpsertedEntry("jwt.ttl", 1)
+	result := svc.HandleEntryUpserted(ctx, entry)
+	// Ack is the expected result when stub returns an entry.
+	_ = result
+
+	calls := fg.Calls()
+	require.Contains(t, calls, "jwt.ttl", "HandleEntryUpserted must query ConfigGetter for the upserted key")
+}
+
+// makeConfigUpsertedEntry builds a minimal outbox.Entry with a valid
+// event.config.entry-upserted.v1 payload for the given key and version.
+func makeConfigUpsertedEntry(key string, version int) outbox.Entry {
+	payload, _ := json.Marshal(map[string]any{
+		"key":     key,
+		"version": version,
+		"actorId": "test-actor",
+	})
+	return outbox.Entry{
+		ID:        "entry-" + key,
+		EventType: "event.config.entry-upserted.v1",
+		Payload:   payload,
+	}
+}

--- a/cells/accesscore/accesscoretest/builders_test.go
+++ b/cells/accesscore/accesscoretest/builders_test.go
@@ -6,13 +6,13 @@ package accesscoretest_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/cells/accesscore/accesscoretest"
-	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -22,101 +22,122 @@ import (
 )
 
 // TestNewAccessFixtureSeedAndQuery seeds a user and role, then reads them back
-// via the repository accessors.
+// via the value-type Get* helpers.
 func TestNewAccessFixtureSeedAndQuery(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	f := accesscoretest.NewAccessFixture(t, clock.Real())
 
-	u, err := domain.NewUser("alice", "alice@example.com", "hash", clock.Real().Now())
-	require.NoError(t, err)
-	u.ID = "usr-alice"
-	require.NoError(t, f.SeedUser(ctx, u))
+	require.NoError(t, f.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "usr-alice", Username: "alice", Email: "alice@example.com",
+		PasswordHash: "hash",
+	}))
 
-	role := &domain.Role{ID: "role-viewer", Name: "Viewer"}
-	require.NoError(t, f.SeedRole(ctx, role))
+	require.NoError(t, f.SeedRole(ctx, accesscoretest.SeededRole{
+		ID: "role-viewer", Name: "Viewer",
+	}))
 
-	// Read back via UserRepository.
-	got, err := f.UserRepository().GetByID(ctx, u.ID)
+	got, err := f.GetUser(ctx, "usr-alice")
 	require.NoError(t, err)
-	assert.Equal(t, u.ID, got.ID)
+	assert.Equal(t, "usr-alice", got.ID)
 	assert.Equal(t, "alice", got.Username)
+	assert.Equal(t, accesscoretest.UserStatusActive, got.Status)
 
-	// Read back via RoleRepository.
-	gotRole, err := f.RoleRepository().GetByID(ctx, role.ID)
+	gotRole, err := f.GetRole(ctx, "role-viewer")
 	require.NoError(t, err)
-	assert.Equal(t, role.ID, gotRole.ID)
+	assert.Equal(t, "role-viewer", gotRole.ID)
 }
 
-// TestAccessFixtureStorePaired asserts that UserRepository and RoleRepository share
-// the same underlying store by verifying that a role assigned via f.SeedAssignment
-// is visible through f.RoleRepository().GetByUserID.
+// TestAccessFixtureStorePaired asserts that user / role / assignment all
+// share the same underlying store by verifying that a role assigned via
+// f.SeedAssignment is visible through f.UserRoles.
 func TestAccessFixtureStorePaired(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	f := accesscoretest.NewAccessFixture(t, clock.Real())
 
-	u, err := domain.NewUser("bob", "bob@example.com", "hash", clock.Real().Now())
+	require.NoError(t, f.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "usr-bob", Username: "bob", Email: "bob@example.com", PasswordHash: "hash",
+	}))
+	require.NoError(t, f.SeedRole(ctx, accesscoretest.SeededRole{
+		ID: "role-admin", Name: "Admin",
+	}))
+	require.NoError(t, f.SeedAssignment(ctx, "usr-bob", "role-admin"))
+
+	roles, err := f.UserRoles(ctx, "usr-bob")
 	require.NoError(t, err)
-	u.ID = "usr-bob"
-	require.NoError(t, f.SeedUser(ctx, u))
-
-	role := &domain.Role{ID: "role-admin", Name: "Admin"}
-	require.NoError(t, f.SeedRole(ctx, role))
-
-	// Assign via SeedAssignment (uses RoleRepository under the hood).
-	require.NoError(t, f.SeedAssignment(ctx, u.ID, role.ID))
-
-	// Verify cross-repo visibility: the assignment must be visible via RoleRepository.
-	roles, err := f.RoleRepository().GetByUserID(ctx, u.ID)
-	require.NoError(t, err)
-	require.Len(t, roles, 1, "assignment seeded via SeedAssignment must be visible via RoleRepository")
-	assert.Equal(t, role.ID, roles[0].ID)
+	require.Len(t, roles, 1,
+		"assignment seeded via SeedAssignment must be visible via UserRoles")
+	assert.Equal(t, "role-admin", roles[0].ID)
 }
 
-// TestFakeConfigGetterHit exercises stub hit, stub error, unknown-key, and
-// explicit-zero-stub (Entry:nil, Err:nil) paths.
-func TestFakeConfigGetterHit(t *testing.T) {
+// TestFakeConfigGetterTypedConstructors exercises each of the four typed
+// stub constructors (Present / Sensitive / NotFound / Error) and the
+// unknown-key path.
+func TestFakeConfigGetterTypedConstructors(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	// Stub hit — entry present.
-	entry := &accesscoretest.ConfigGetterStub{
-		Entry: &accesscoretest.FakeConfigEntry{Key: "foo", Value: "bar", Version: 1},
-	}
+	// PresentStub — plaintext value returned as-is.
 	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
-		"foo": *entry,
+		"foo": accesscoretest.PresentStub("foo", "bar", 1),
 	})
 	got, err := fg.GetEntry(ctx, "foo")
 	require.NoError(t, err)
 	assert.Equal(t, "foo", got.Key)
 	assert.Equal(t, "bar", got.Value)
+	assert.False(t, got.Sensitive)
+	assert.Equal(t, 1, got.Version)
 
-	// Stub with error.
+	// SensitiveStub — Value is the production redaction sentinel.
+	fgSens := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"kms.key": accesscoretest.SensitiveStub("kms.key", 4),
+	})
+	gotSens, err := fgSens.GetEntry(ctx, "kms.key")
+	require.NoError(t, err)
+	assert.True(t, gotSens.Sensitive)
+	assert.Equal(t, "******", gotSens.Value,
+		"SensitiveStub must mirror configcore's redaction contract")
+
+	// ErrorStub — error surfaced verbatim.
 	customErr := errcode.New(errcode.KindNotFound, errcode.ErrConfigNotFound, "config not found")
-	fg2 := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
-		"missing": {Err: customErr},
+	fgErr := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"missing": accesscoretest.ErrorStub(customErr),
 	})
-	_, err2 := fg2.GetEntry(ctx, "missing")
-	require.Error(t, err2)
-	assert.ErrorIs(t, err2, customErr)
+	_, err = fgErr.GetEntry(ctx, "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, customErr)
 
-	// Unknown key — returns ErrConfigNotFound by convention (documented in package).
-	fg3 := accesscoretest.NewFakeConfigGetter(nil)
-	_, err3 := fg3.GetEntry(ctx, "unknown")
-	require.Error(t, err3, "unknown key must return an error")
+	// Unknown key (no stub) — ErrConfigNotFound with CategoryDomain.
+	fgUnknown := accesscoretest.NewFakeConfigGetter(nil)
+	_, err = fgUnknown.GetEntry(ctx, "unknown")
+	require.Error(t, err)
+	assert.True(t, errcode.IsDomainNotFound(err, errcode.ErrConfigNotFound),
+		"unknown key must carry CategoryDomain so HandleEntryUpserted Acks")
 
-	// Explicit zero stub: Entry:nil, Err:nil — triggers the not-found branch
-	// (key is present in the stubs map but Entry is nil).
-	fg4 := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
-		"stale": {Entry: nil, Err: nil},
+	// NotFoundStub — same shape as unknown key.
+	fgGone := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"stale": accesscoretest.NotFoundStub(),
 	})
-	_, err4 := fg4.GetEntry(ctx, "stale")
-	require.Error(t, err4, "explicit nil-entry stub must return ErrConfigNotFound")
-	assert.True(t,
-		errcode.IsDomainNotFound(err4, errcode.ErrConfigNotFound),
-		"nil-entry stub error must have CategoryDomain so HandleEntryUpserted Acks as stale event",
-	)
+	_, err = fgGone.GetEntry(ctx, "stale")
+	require.Error(t, err)
+	assert.True(t, errcode.IsDomainNotFound(err, errcode.ErrConfigNotFound),
+		"NotFoundStub must carry CategoryDomain so HandleEntryUpserted Acks")
+}
+
+// TestFakeConfigGetterCtxCancel ensures the fake honors context cancellation,
+// matching the production HTTP getter's semantics.
+func TestFakeConfigGetterCtxCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"foo": accesscoretest.PresentStub("foo", "v", 1),
+	})
+	_, err := fg.GetEntry(ctx, "foo")
+	require.Error(t, err, "GetEntry must propagate canceled ctx error")
+	assert.True(t, errors.Is(err, context.Canceled))
 }
 
 // TestFakeConfigGetterCallsRecorded verifies that call order is captured.
@@ -125,8 +146,8 @@ func TestFakeConfigGetterCallsRecorded(t *testing.T) {
 	ctx := context.Background()
 
 	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
-		"foo": {Entry: &accesscoretest.FakeConfigEntry{Key: "foo", Value: "v"}},
-		"bar": {Entry: &accesscoretest.FakeConfigEntry{Key: "bar", Value: "v2"}},
+		"foo": accesscoretest.PresentStub("foo", "v", 1),
+		"bar": accesscoretest.PresentStub("bar", "v2", 1),
 	})
 	_, _ = fg.GetEntry(ctx, "foo")
 	_, _ = fg.GetEntry(ctx, "bar")
@@ -138,13 +159,13 @@ func TestFakeConfigGetterCallsRecorded(t *testing.T) {
 	assert.Empty(t, fg.Calls(), "Reset must clear the call log")
 }
 
-// TestNewCredentialInvalidatorWithDefaults verifies that the helper returns a
-// non-nil Invalidator when WithInvalidatorUsers is provided.
-func TestNewCredentialInvalidatorWithDefaults(t *testing.T) {
+// TestNewCredentialInvalidatorWithFixture verifies the fixture-only collapse:
+// passing a fixture yields a usable *Invalidator.
+func TestNewCredentialInvalidatorWithFixture(t *testing.T) {
 	t.Parallel()
 	f := accesscoretest.NewAccessFixture(t, clock.Real())
 	inv := accesscoretest.NewCredentialInvalidator(t,
-		accesscoretest.WithInvalidatorUsers(f.UserRepository()),
+		accesscoretest.WithInvalidatorFixture(f),
 	)
 	require.NotNil(t, inv, "NewCredentialInvalidator must return non-nil *Invalidator")
 }
@@ -159,13 +180,14 @@ func TestBuildIdentityManageServiceSmoke(t *testing.T) {
 	svc, fix, rec := accesscoretest.BuildIdentityManageService(t)
 
 	// Seed admin user so last-admin protection does not block the Create call.
-	adminUser, err := domain.NewUser("admin", "admin@test.com", "$2a$04$dummy", clock.Real().Now())
-	require.NoError(t, err)
-	adminUser.ID = "usr-admin"
-	require.NoError(t, fix.SeedUser(ctx, adminUser))
-	adminRole := &domain.Role{ID: "admin", Name: "Admin"}
-	require.NoError(t, fix.SeedRole(ctx, adminRole))
-	require.NoError(t, fix.SeedAssignment(ctx, adminUser.ID, "admin"))
+	require.NoError(t, fix.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "usr-admin", Username: "admin", Email: "admin@test.com",
+		PasswordHash: "$2a$04$dummy",
+	}))
+	require.NoError(t, fix.SeedRole(ctx, accesscoretest.SeededRole{
+		ID: "admin", Name: "Admin",
+	}))
+	require.NoError(t, fix.SeedAssignment(ctx, "usr-admin", "admin"))
 
 	// Use admin context (actorFromContext requires a non-empty subject).
 	adminCtx := auth.TestContext("usr-admin", []string{"admin"})
@@ -178,8 +200,8 @@ func TestBuildIdentityManageServiceSmoke(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, created.ID)
 
-	// Fixture state: new user must be visible via UserRepository.
-	got, err := fix.UserRepository().GetByID(ctx, created.ID)
+	// Fixture state: new user must be visible via GetUser.
+	got, err := fix.GetUser(ctx, created.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "newuser", got.Username)
 
@@ -196,7 +218,7 @@ func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
 	ctx := context.Background()
 
 	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
-		"jwt.ttl": {Entry: &accesscoretest.FakeConfigEntry{Key: "jwt.ttl", Value: "3600", Version: 1}},
+		"jwt.ttl": accesscoretest.PresentStub("jwt.ttl", "3600", 1),
 	})
 	svc := accesscoretest.BuildConfigReceiveService(t,
 		accesscoretest.WithConfigReceiveConfigGetter(fg),
@@ -211,10 +233,10 @@ func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
 	calls := fg.Calls()
 	require.Contains(t, calls, "jwt.ttl", "HandleEntryUpserted must query ConfigGetter for the upserted key")
 
-	// Stale-event path: explicit nil-entry stub triggers ErrConfigNotFound with
+	// Stale-event path: NotFoundStub triggers ErrConfigNotFound with
 	// CategoryDomain, so HandleEntryUpserted Acks instead of Requeueing.
 	fgStale := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
-		"gone.key": {Entry: nil, Err: nil},
+		"gone.key": accesscoretest.NotFoundStub(),
 	})
 	svcStale := accesscoretest.BuildConfigReceiveService(t,
 		accesscoretest.WithConfigReceiveConfigGetter(fgStale),

--- a/cells/accesscore/accesscoretest/builders_test.go
+++ b/cells/accesscore/accesscoretest/builders_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/accesscoretest"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/configreceive"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -35,21 +36,21 @@ func TestNewAccessFixtureSeedAndQuery(t *testing.T) {
 	role := &domain.Role{ID: "role-viewer", Name: "Viewer"}
 	require.NoError(t, f.SeedRole(ctx, role))
 
-	// Read back via UserRepo.
-	got, err := f.UserRepo().GetByID(ctx, u.ID)
+	// Read back via UserRepository.
+	got, err := f.UserRepository().GetByID(ctx, u.ID)
 	require.NoError(t, err)
 	assert.Equal(t, u.ID, got.ID)
 	assert.Equal(t, "alice", got.Username)
 
-	// Read back via RoleRepo.
-	gotRole, err := f.RoleRepo().GetByID(ctx, role.ID)
+	// Read back via RoleRepository.
+	gotRole, err := f.RoleRepository().GetByID(ctx, role.ID)
 	require.NoError(t, err)
 	assert.Equal(t, role.ID, gotRole.ID)
 }
 
-// TestAccessFixtureStorePaired asserts that UserRepo and RoleRepo share the same
-// underlying store by verifying that a role assigned via f.SeedAssignment is
-// visible through f.RoleRepo().GetByUserID.
+// TestAccessFixtureStorePaired asserts that UserRepository and RoleRepository share
+// the same underlying store by verifying that a role assigned via f.SeedAssignment
+// is visible through f.RoleRepository().GetByUserID.
 func TestAccessFixtureStorePaired(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -63,17 +64,18 @@ func TestAccessFixtureStorePaired(t *testing.T) {
 	role := &domain.Role{ID: "role-admin", Name: "Admin"}
 	require.NoError(t, f.SeedRole(ctx, role))
 
-	// Assign via SeedAssignment (uses RoleRepo under the hood).
+	// Assign via SeedAssignment (uses RoleRepository under the hood).
 	require.NoError(t, f.SeedAssignment(ctx, u.ID, role.ID))
 
-	// Verify cross-repo visibility: the assignment must be visible via RoleRepo.
-	roles, err := f.RoleRepo().GetByUserID(ctx, u.ID)
+	// Verify cross-repo visibility: the assignment must be visible via RoleRepository.
+	roles, err := f.RoleRepository().GetByUserID(ctx, u.ID)
 	require.NoError(t, err)
-	require.Len(t, roles, 1, "assignment seeded via SeedAssignment must be visible via RoleRepo")
+	require.Len(t, roles, 1, "assignment seeded via SeedAssignment must be visible via RoleRepository")
 	assert.Equal(t, role.ID, roles[0].ID)
 }
 
-// TestFakeConfigGetterHit exercises stub hit, stub error, and unknown-key paths.
+// TestFakeConfigGetterHit exercises stub hit, stub error, unknown-key, and
+// explicit-zero-stub (Entry:nil, Err:nil) paths.
 func TestFakeConfigGetterHit(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -103,6 +105,18 @@ func TestFakeConfigGetterHit(t *testing.T) {
 	fg3 := accesscoretest.NewFakeConfigGetter(nil)
 	_, err3 := fg3.GetEntry(ctx, "unknown")
 	require.Error(t, err3, "unknown key must return an error")
+
+	// Explicit zero stub: Entry:nil, Err:nil — triggers the not-found branch
+	// (key is present in the stubs map but Entry is nil).
+	fg4 := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"stale": {Entry: nil, Err: nil},
+	})
+	_, err4 := fg4.GetEntry(ctx, "stale")
+	require.Error(t, err4, "explicit nil-entry stub must return ErrConfigNotFound")
+	assert.True(t,
+		errcode.IsDomainNotFound(err4, errcode.ErrConfigNotFound),
+		"nil-entry stub error must have CategoryDomain so HandleEntryUpserted Acks as stale event",
+	)
 }
 
 // TestFakeConfigGetterCallsRecorded verifies that call order is captured.
@@ -125,10 +139,13 @@ func TestFakeConfigGetterCallsRecorded(t *testing.T) {
 }
 
 // TestNewCredentialInvalidatorWithDefaults verifies that the helper returns a
-// non-nil Invalidator with no options provided.
+// non-nil Invalidator when WithInvalidatorUsers is provided.
 func TestNewCredentialInvalidatorWithDefaults(t *testing.T) {
 	t.Parallel()
-	inv := accesscoretest.NewCredentialInvalidator(t)
+	f := accesscoretest.NewAccessFixture(t, clock.Real())
+	inv := accesscoretest.NewCredentialInvalidator(t,
+		accesscoretest.WithInvalidatorUsers(f.UserRepository()),
+	)
 	require.NotNil(t, inv, "NewCredentialInvalidator must return non-nil *Invalidator")
 }
 
@@ -161,8 +178,8 @@ func TestBuildIdentityManageServiceSmoke(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, created.ID)
 
-	// Fixture state: new user must be visible via UserRepo.
-	got, err := fix.UserRepo().GetByID(ctx, created.ID)
+	// Fixture state: new user must be visible via UserRepository.
+	got, err := fix.UserRepository().GetByID(ctx, created.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "newuser", got.Username)
 
@@ -172,7 +189,8 @@ func TestBuildIdentityManageServiceSmoke(t *testing.T) {
 }
 
 // TestBuildConfigReceiveServiceSmoke builds the configreceive service, exercises
-// HandleEntryUpserted with a stubbed ConfigGetter, and asserts the stub was queried.
+// HandleEntryUpserted with a stubbed ConfigGetter, and asserts the correct
+// HandleResult disposition for both the hit (Ack) and stale (Ack) paths.
 func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -181,30 +199,46 @@ func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
 		"jwt.ttl": {Entry: &accesscoretest.FakeConfigEntry{Key: "jwt.ttl", Value: "3600", Version: 1}},
 	})
 	svc := accesscoretest.BuildConfigReceiveService(t,
-		accesscoretest.WithReceiveConfigGetter(fg),
+		accesscoretest.WithConfigReceiveConfigGetter(fg),
 	)
 
 	// Build a minimal outbox.Entry carrying a config-upserted payload.
 	entry := makeConfigUpsertedEntry("jwt.ttl", 1)
 	result := svc.HandleEntryUpserted(ctx, entry)
-	// Ack is the expected result when stub returns an entry.
-	_ = result
+	require.Equal(t, outbox.DispositionAck, result.Disposition,
+		"HandleEntryUpserted must Ack on stub-found entry")
 
 	calls := fg.Calls()
 	require.Contains(t, calls, "jwt.ttl", "HandleEntryUpserted must query ConfigGetter for the upserted key")
+
+	// Stale-event path: explicit nil-entry stub triggers ErrConfigNotFound with
+	// CategoryDomain, so HandleEntryUpserted Acks instead of Requeueing.
+	fgStale := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"gone.key": {Entry: nil, Err: nil},
+	})
+	svcStale := accesscoretest.BuildConfigReceiveService(t,
+		accesscoretest.WithConfigReceiveConfigGetter(fgStale),
+	)
+	staleEntry := makeConfigUpsertedEntry("gone.key", 1)
+	staleResult := svcStale.HandleEntryUpserted(ctx, staleEntry)
+	require.Equal(t, outbox.DispositionAck, staleResult.Disposition,
+		"HandleEntryUpserted must Ack on stale (ConfigNotFound) event")
 }
 
 // makeConfigUpsertedEntry builds a minimal outbox.Entry with a valid
 // event.config.entry-upserted.v1 payload for the given key and version.
 func makeConfigUpsertedEntry(key string, version int) outbox.Entry {
-	payload, _ := json.Marshal(map[string]any{
+	payload, err := json.Marshal(map[string]any{
 		"key":     key,
 		"version": version,
 		"actorId": "test-actor",
 	})
+	if err != nil {
+		panic("makeConfigUpsertedEntry: json.Marshal failed: " + err.Error())
+	}
 	return outbox.Entry{
 		ID:        "entry-" + key,
-		EventType: "event.config.entry-upserted.v1",
+		EventType: configreceive.TopicConfigEntryUpserted,
 		Payload:   payload,
 	}
 }

--- a/cells/accesscore/accesscoretest/credential_invalidator.go
+++ b/cells/accesscore/accesscoretest/credential_invalidator.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/credentialinvalidate"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
-	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
@@ -20,10 +19,15 @@ type invalidatorConfig struct {
 	refreshStore refresh.Store
 }
 
-// WithInvalidatorUsers injects a custom UserRepository into the Invalidator.
-// When not provided, a fresh fixture UserRepo() is used — which is a separate
-// store from any AccessFixture the caller may hold; prefer passing
-// fixture.UserRepo() explicitly when sharing state with other services.
+// WithInvalidatorUsers injects a UserRepository into the Invalidator. This
+// option is required: NewCredentialInvalidator fails the test immediately if
+// it is not provided.
+//
+// Usage:
+//
+//	inv := accesscoretest.NewCredentialInvalidator(t,
+//	    accesscoretest.WithInvalidatorUsers(fixture.UserRepository()),
+//	)
 func WithInvalidatorUsers(r ports.UserRepository) CredentialInvalidatorOption {
 	return func(c *invalidatorConfig) { c.users = r }
 }
@@ -39,13 +43,14 @@ func WithInvalidatorRefresh(r refresh.Store) CredentialInvalidatorOption {
 }
 
 // NewCredentialInvalidator constructs a real *credentialinvalidate.Invalidator
-// suitable for embedding in test-built services. Default deps are:
+// suitable for embedding in test-built services.
 //
-//   - users: fresh AccessFixture(clock.Real()).UserRepo() — NOTE: this is a
-//     standalone store NOT paired with any other fixture; callers wiring
-//     identitymanage should use BuildIdentityManageService or pass
-//     WithInvalidatorUsers(fixture.UserRepo()) explicitly to share state.
-//   - sessions: session.NewMemStore(sessiontest.Protocol(), clock.Real())
+// WithInvalidatorUsers is required: omitting it fails the test immediately to
+// prevent accidental use of an isolated store that is not paired with any other
+// fixture.
+//
+// Default deps:
+//   - sessions: testutil.RealSessionRepo(t)
 //   - refreshStore: testutil.RealRefreshStore(t)
 func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption) *credentialinvalidate.Invalidator {
 	t.Helper()
@@ -55,7 +60,8 @@ func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption)
 	}
 
 	if cfg.users == nil {
-		cfg.users = NewAccessFixture(t, clock.Real()).UserRepo()
+		t.Fatalf("NewCredentialInvalidator: WithInvalidatorUsers is required; " +
+			"pass WithInvalidatorUsers(fixture.UserRepository()) to share state with other services")
 	}
 	if cfg.sessions == nil {
 		cfg.sessions = testutil.RealSessionRepo(t)

--- a/cells/accesscore/accesscoretest/credential_invalidator.go
+++ b/cells/accesscore/accesscoretest/credential_invalidator.go
@@ -4,73 +4,63 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/credentialinvalidate"
-	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
-	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
-	"github.com/ghbvf/gocell/runtime/auth/refresh"
-	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
 // CredentialInvalidatorOption configures NewCredentialInvalidator.
+//
+// The only public option is WithInvalidatorFixture. Round-2 review of PR
+// #845 (worktree 650) collapsed the previous WithInvalidatorUsers /
+// WithInvalidatorSessions / WithInvalidatorRefresh trio because they let
+// callers wire independent stores into the invalidator while a real
+// sessionlogin.Service held its own state — the exact mis-pairing failure
+// mode PR #595 was supposed to prevent. The fixture is now the sole source
+// of the (UserRepository, session.Store, refresh.Store) triple; any other
+// wiring path is unexpressible in the type system.
 type CredentialInvalidatorOption func(*invalidatorConfig)
 
 type invalidatorConfig struct {
-	users        ports.UserRepository
-	sessions     session.Store
-	refreshStore refresh.Store
+	fixture *AccessFixture
 }
 
-// WithInvalidatorUsers injects a UserRepository into the Invalidator. This
-// option is required: NewCredentialInvalidator fails the test immediately if
-// it is not provided.
+// WithInvalidatorFixture is the required option for NewCredentialInvalidator.
+// Passing nil is a no-op (the option function is idempotent); the final nil
+// check happens inside NewCredentialInvalidator and fails the test.
 //
 // Usage:
 //
+//	fix := accesscoretest.NewAccessFixture(t, clock.Real())
 //	inv := accesscoretest.NewCredentialInvalidator(t,
-//	    accesscoretest.WithInvalidatorUsers(fixture.UserRepository()),
+//	    accesscoretest.WithInvalidatorFixture(fix),
 //	)
-func WithInvalidatorUsers(r ports.UserRepository) CredentialInvalidatorOption {
-	return func(c *invalidatorConfig) { c.users = r }
-}
-
-// WithInvalidatorSessions injects a custom session.Store into the Invalidator.
-func WithInvalidatorSessions(s session.Store) CredentialInvalidatorOption {
-	return func(c *invalidatorConfig) { c.sessions = s }
-}
-
-// WithInvalidatorRefresh injects a custom refresh.Store into the Invalidator.
-func WithInvalidatorRefresh(r refresh.Store) CredentialInvalidatorOption {
-	return func(c *invalidatorConfig) { c.refreshStore = r }
+func WithInvalidatorFixture(f *AccessFixture) CredentialInvalidatorOption {
+	return func(c *invalidatorConfig) {
+		if f != nil {
+			c.fixture = f
+		}
+	}
 }
 
 // NewCredentialInvalidator constructs a real *credentialinvalidate.Invalidator
-// suitable for embedding in test-built services.
-//
-// WithInvalidatorUsers is required: omitting it fails the test immediately to
-// prevent accidental use of an isolated store that is not paired with any other
-// fixture.
-//
-// Default deps:
-//   - sessions: testutil.RealSessionRepo(t)
-//   - refreshStore: testutil.RealRefreshStore(t)
+// wired to the user/session/refresh stores held by the supplied
+// AccessFixture. The fixture is required: omitting WithInvalidatorFixture
+// fails the test immediately so the invalidator can never silently run
+// against an isolated store.
 func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption) *credentialinvalidate.Invalidator {
 	t.Helper()
 	cfg := &invalidatorConfig{}
 	for _, o := range opts {
 		o(cfg)
 	}
-
-	if cfg.users == nil {
-		t.Fatalf("NewCredentialInvalidator: WithInvalidatorUsers is required; " +
-			"pass WithInvalidatorUsers(fixture.UserRepository()) to share state with other services")
-	}
-	if cfg.sessions == nil {
-		cfg.sessions = testutil.RealSessionRepo(t)
-	}
-	if cfg.refreshStore == nil {
-		cfg.refreshStore = testutil.RealRefreshStore(t)
+	if cfg.fixture == nil {
+		t.Fatalf("NewCredentialInvalidator: WithInvalidatorFixture is required; " +
+			"pass an AccessFixture so user/session/refresh state stays paired")
 	}
 
-	inv, err := credentialinvalidate.New(cfg.users, cfg.sessions, cfg.refreshStore)
+	inv, err := credentialinvalidate.New(
+		cfg.fixture.bundle.UserRepository(),
+		cfg.fixture.sessionStore,
+		cfg.fixture.refreshStore,
+	)
 	if err != nil {
 		t.Fatalf("NewCredentialInvalidator: %v", err)
 	}

--- a/cells/accesscore/accesscoretest/credential_invalidator.go
+++ b/cells/accesscore/accesscoretest/credential_invalidator.go
@@ -1,0 +1,72 @@
+package accesscoretest
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/credentialinvalidate"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/runtime/auth/refresh"
+	"github.com/ghbvf/gocell/runtime/auth/session"
+)
+
+// CredentialInvalidatorOption configures NewCredentialInvalidator.
+type CredentialInvalidatorOption func(*invalidatorConfig)
+
+type invalidatorConfig struct {
+	users        ports.UserRepository
+	sessions     session.Store
+	refreshStore refresh.Store
+}
+
+// WithInvalidatorUsers injects a custom UserRepository into the Invalidator.
+// When not provided, a fresh fixture UserRepo() is used — which is a separate
+// store from any AccessFixture the caller may hold; prefer passing
+// fixture.UserRepo() explicitly when sharing state with other services.
+func WithInvalidatorUsers(r ports.UserRepository) CredentialInvalidatorOption {
+	return func(c *invalidatorConfig) { c.users = r }
+}
+
+// WithInvalidatorSessions injects a custom session.Store into the Invalidator.
+func WithInvalidatorSessions(s session.Store) CredentialInvalidatorOption {
+	return func(c *invalidatorConfig) { c.sessions = s }
+}
+
+// WithInvalidatorRefresh injects a custom refresh.Store into the Invalidator.
+func WithInvalidatorRefresh(r refresh.Store) CredentialInvalidatorOption {
+	return func(c *invalidatorConfig) { c.refreshStore = r }
+}
+
+// NewCredentialInvalidator constructs a real *credentialinvalidate.Invalidator
+// suitable for embedding in test-built services. Default deps are:
+//
+//   - users: fresh AccessFixture(clock.Real()).UserRepo() — NOTE: this is a
+//     standalone store NOT paired with any other fixture; callers wiring
+//     identitymanage should use BuildIdentityManageService or pass
+//     WithInvalidatorUsers(fixture.UserRepo()) explicitly to share state.
+//   - sessions: session.NewMemStore(sessiontest.Protocol(), clock.Real())
+//   - refreshStore: testutil.RealRefreshStore(t)
+func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption) *credentialinvalidate.Invalidator {
+	t.Helper()
+	cfg := &invalidatorConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	if cfg.users == nil {
+		cfg.users = NewAccessFixture(t, clock.Real()).UserRepo()
+	}
+	if cfg.sessions == nil {
+		cfg.sessions = testutil.RealSessionRepo(t)
+	}
+	if cfg.refreshStore == nil {
+		cfg.refreshStore = testutil.RealRefreshStore(t)
+	}
+
+	inv, err := credentialinvalidate.New(cfg.users, cfg.sessions, cfg.refreshStore)
+	if err != nil {
+		t.Fatalf("NewCredentialInvalidator: %v", err)
+	}
+	return inv
+}

--- a/cells/accesscore/accesscoretest/credential_invalidator.go
+++ b/cells/accesscore/accesscoretest/credential_invalidator.go
@@ -6,6 +6,30 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/credentialinvalidate"
 )
 
+// CredentialInvalidator is the public opaque handle returned by
+// NewCredentialInvalidator. It wraps the unexported
+// *cells/accesscore/internal/credentialinvalidate.Invalidator so external
+// _test packages can hold and pass the value without importing the
+// internal/ package — which Go's internal-package rule forbids.
+//
+// The struct intentionally has no exported fields and no exported methods:
+// it is a sealed handle, not an API surface. The single legal touchpoint of
+// the underlying internal type lives in this package (where the internal
+// import is permitted), keeping the testutil → internal coupling
+// unidirectional and unbypassable from outside cells/accesscore/.
+//
+// Hard funnel form (sibling of Hard 范本 §"single sanctioned holder"):
+//   - upstream  Hard — Go's internal-package rule makes *credentialinvalidate.Invalidator
+//     unnameable in any package not rooted at cells/accesscore/. External
+//     callers therefore cannot bypass this wrapper by declaring the raw type.
+//   - downstream Hard — unwrap field is unexported (.inv), so no external
+//     code can read or rewrap it; the only consumers are NewCredentialInvalidator
+//     (constructor) and BuildIdentityManageService (which threads the
+//     fixture-paired invalidator into identitymanage.NewService).
+type CredentialInvalidator struct {
+	inv *credentialinvalidate.Invalidator
+}
+
 // CredentialInvalidatorOption configures NewCredentialInvalidator.
 //
 // The only public option is WithInvalidatorFixture. Round-2 review of PR
@@ -40,12 +64,17 @@ func WithInvalidatorFixture(f *AccessFixture) CredentialInvalidatorOption {
 	}
 }
 
-// NewCredentialInvalidator constructs a real *credentialinvalidate.Invalidator
-// wired to the user/session/refresh stores held by the supplied
-// AccessFixture. The fixture is required: omitting WithInvalidatorFixture
-// fails the test immediately so the invalidator can never silently run
-// against an isolated store.
-func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption) *credentialinvalidate.Invalidator {
+// NewCredentialInvalidator constructs an opaque *CredentialInvalidator wired
+// to the user/session/refresh stores held by the supplied AccessFixture. The
+// fixture is required: omitting WithInvalidatorFixture fails the test
+// immediately so the invalidator can never silently run against an isolated
+// store.
+//
+// The returned *CredentialInvalidator is the only handle external test
+// packages may hold. Pass it to WithIdentityInvalidator when building
+// services; the internal unwrap to *credentialinvalidate.Invalidator happens
+// inside this package.
+func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption) *CredentialInvalidator {
 	t.Helper()
 	cfg := &invalidatorConfig{}
 	for _, o := range opts {
@@ -64,5 +93,5 @@ func NewCredentialInvalidator(t *testing.T, opts ...CredentialInvalidatorOption)
 	if err != nil {
 		t.Fatalf("NewCredentialInvalidator: %v", err)
 	}
-	return inv
+	return &CredentialInvalidator{inv: inv}
 }

--- a/cells/accesscore/accesscoretest/doc.go
+++ b/cells/accesscore/accesscoretest/doc.go
@@ -30,6 +30,26 @@
 // same underlying mem.Store. AccessFixture wraps a single Bundle, making it
 // impossible to accidentally mis-pair repos from different stores.
 //
+// # Debug logger swap
+//
+// All builders default to slog.New(slog.DiscardHandler). To see verbose output
+// during local debugging, swap in a text handler:
+//
+//	svc, fix, rec := accesscoretest.BuildIdentityManageService(t,
+//	    accesscoretest.WithIdentityLogger(
+//	        slog.New(slog.NewTextHandler(os.Stderr, nil)),
+//	    ),
+//	)
+//
+// # End-to-end example: BuildIdentityManageService
+//
+//	func ExampleBuildIdentityManageService() {
+//	    // Construct the service and its dependencies.
+//	    svc, fix, _ := accesscoretest.BuildIdentityManageService(nil) // nil only in pkg example
+//	    _ = svc
+//	    _ = fix
+//	}
+//
 // # Import scope
 //
 // This package is test-infrastructure: it must NOT be imported by production
@@ -37,4 +57,13 @@
 // for all cells/{X}/{X}test packages.
 //
 // Tests may import this package freely.
+//
+// # Deferred: spy methods
+//
+// AccessFixture does not expose CallsOf / Snapshot spy methods. The current
+// design converges on AccessFixture as an aggregate; spy methods will be added
+// when a journey criterion actually needs them.
+//
+// ref: PR #595 (store-pairing precedent)
+// ref: docs/plans/202605191943-044-journey-backlog-realignment.md §2
 package accesscoretest

--- a/cells/accesscore/accesscoretest/doc.go
+++ b/cells/accesscore/accesscoretest/doc.go
@@ -1,0 +1,40 @@
+// Package accesscoretest provides public test-infrastructure helpers for the
+// accesscore cell.
+//
+// # Purpose
+//
+// Go's internal-package barrier prevents tests/integration/ and other
+// external packages from importing cells/accesscore/internal/ports (the real
+// UserRepository / RoleRepository / ConfigGetter interfaces). This package
+// lives inside the cells/accesscore subtree, so it can import internal packages
+// while only exporting *Service values and testutil-local Fake types to
+// callers.
+//
+// # Relationship to cell.go composition root
+//
+// cells/accesscore/cell.go is the production composition root: it wires real
+// PG adapters, real JWT issuers, and real TxManagers. This package is the
+// test-composition root: it wires in-memory stores and stubs so tests remain
+// docker-free and fast.
+//
+// # Why AccessFixture aggregates via mem.Bundle
+//
+// PR #595 review caught a test helper in cmd/corebundle that wired
+// UserRepository + RoleRepository + SetupLock from different mem stores.
+// Because the effective-admin invariant (S4.0) requires atomic cross-repo
+// operations, silently using two independent stores breaks the invariant
+// without any compile-time or runtime signal.
+//
+// cells/accesscore/mem.NewBundle is a sealed funnel that vends all four
+// primitives (UserRepository, RoleRepository, SetupLock, TxRunner) from the
+// same underlying mem.Store. AccessFixture wraps a single Bundle, making it
+// impossible to accidentally mis-pair repos from different stores.
+//
+// # Import scope
+//
+// This package is test-infrastructure: it must NOT be imported by production
+// Go files. The CELLTEST-IMPORT-SCOPE-01 archtest enforces this automatically
+// for all cells/{X}/{X}test packages.
+//
+// Tests may import this package freely.
+package accesscoretest

--- a/cells/accesscore/accesscoretest/doc.go
+++ b/cells/accesscore/accesscoretest/doc.go
@@ -20,7 +20,10 @@
 //   - UserStatus + UserStatusActive / Suspended / Locked
 //   - AccessFixture.SeedUser / SeedRole / SeedAssignment
 //   - AccessFixture.GetUser / GetRole / UserRoles / TxRunner
-//   - NewCredentialInvalidator + WithInvalidatorFixture (fixture-only collapse)
+//   - CredentialInvalidator (opaque wrapper) + NewCredentialInvalidator +
+//     WithInvalidatorFixture (fixture-only collapse); the wrapper hides
+//     *internal/credentialinvalidate.Invalidator from public signatures so
+//     no external caller can name the internal type
 //   - BuildIdentityManageService + With* options
 //   - BuildConfigReceiveService + With* options
 //   - FakeConfigGetter + four typed stub constructors:

--- a/cells/accesscore/accesscoretest/doc.go
+++ b/cells/accesscore/accesscoretest/doc.go
@@ -5,10 +5,30 @@
 //
 // Go's internal-package barrier prevents tests/integration/ and other
 // external packages from importing cells/accesscore/internal/ports (the real
-// UserRepository / RoleRepository / ConfigGetter interfaces). This package
-// lives inside the cells/accesscore subtree, so it can import internal packages
-// while only exporting *Service values and testutil-local Fake types to
-// callers.
+// UserRepository / RoleRepository / ConfigGetter interfaces) or
+// cells/accesscore/internal/domain (the User / Role aggregates). This
+// package lives inside the cells/accesscore subtree, so it can import those
+// internal packages — but its public API exposes only value-type DTOs and
+// builder helpers. External callers (tests/integration/*, journey suites)
+// never need to import any cells/accesscore/internal/* package.
+//
+// # Public API surface (no internal leak)
+//
+//   - AccessFixture (sealed; constructor NewAccessFixture)
+//   - SeededUser / SeededRole — value-type seed inputs
+//   - SeededUserView / SeededRoleView — value-type read outputs
+//   - UserStatus + UserStatusActive / Suspended / Locked
+//   - AccessFixture.SeedUser / SeedRole / SeedAssignment
+//   - AccessFixture.GetUser / GetRole / UserRoles / TxRunner
+//   - NewCredentialInvalidator + WithInvalidatorFixture (fixture-only collapse)
+//   - BuildIdentityManageService + With* options
+//   - BuildConfigReceiveService + With* options
+//   - FakeConfigGetter + four typed stub constructors:
+//     PresentStub / SensitiveStub / NotFoundStub / ErrorStub
+//
+// Continued absence of internal-type leaks is gated by external_smoke_test.go,
+// which uses a foreign _test package and would stop compiling the moment any
+// public API forces callers to import cells/accesscore/internal/*.
 //
 // # Relationship to cell.go composition root
 //
@@ -17,7 +37,7 @@
 // test-composition root: it wires in-memory stores and stubs so tests remain
 // docker-free and fast.
 //
-// # Why AccessFixture aggregates via mem.Bundle
+// # Why AccessFixture aggregates via mem.Bundle + holds session/refresh
 //
 // PR #595 review caught a test helper in cmd/corebundle that wired
 // UserRepository + RoleRepository + SetupLock from different mem stores.
@@ -25,10 +45,17 @@
 // operations, silently using two independent stores breaks the invariant
 // without any compile-time or runtime signal.
 //
-// cells/accesscore/mem.NewBundle is a sealed funnel that vends all four
-// primitives (UserRepository, RoleRepository, SetupLock, TxRunner) from the
-// same underlying mem.Store. AccessFixture wraps a single Bundle, making it
-// impossible to accidentally mis-pair repos from different stores.
+// cells/accesscore/mem.NewBundle is the sealed funnel that vends all four
+// store-paired primitives (UserRepository, RoleRepository, SetupLock,
+// TxRunner) from the same underlying mem.Store. AccessFixture wraps a
+// single Bundle, then adds singleton session.MemStore and refresh.Store
+// instances of its own. Round-2 review of PR #845 added this extension:
+// without the singletons, NewCredentialInvalidator's default fell back to
+// brand-new session/refresh stores from internal/testutil, silently
+// isolating it from any sessionlogin.Service a caller might later inject as
+// TokenIssuer — the same mis-pairing failure PR #595 set out to prevent.
+// NewCredentialInvalidator now only accepts a fixture (WithInvalidatorFixture),
+// making the non-paired wiring path unexpressible.
 //
 // # Debug logger swap
 //
@@ -44,7 +71,6 @@
 // # End-to-end example: BuildIdentityManageService
 //
 //	func ExampleBuildIdentityManageService() {
-//	    // Construct the service and its dependencies.
 //	    svc, fix, _ := accesscoretest.BuildIdentityManageService(nil) // nil only in pkg example
 //	    _ = svc
 //	    _ = fix
@@ -56,7 +82,11 @@
 // Go files. The CELLTEST-IMPORT-SCOPE-01 archtest enforces this automatically
 // for all cells/{X}/{X}test packages.
 //
-// Tests may import this package freely.
+// Tests may import this package freely. The complementary guarantee — that
+// accesscoretest itself does not re-export internal types and therefore does
+// not force its consumers to import cells/accesscore/internal/* — is gated
+// by external_smoke_test.go (Hard funnel: Go internal barrier upstream,
+// compile-time check downstream).
 //
 // # Deferred: spy methods
 //
@@ -65,5 +95,6 @@
 // when a journey criterion actually needs them.
 //
 // ref: PR #595 (store-pairing precedent)
+// ref: PR #845 round-2 review (session/refresh pairing + internal-leak closure)
 // ref: docs/plans/202605191943-044-journey-backlog-realignment.md §2
 package accesscoretest

--- a/cells/accesscore/accesscoretest/example_test.go
+++ b/cells/accesscore/accesscoretest/example_test.go
@@ -1,0 +1,73 @@
+package accesscoretest_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/ghbvf/gocell/cells/accesscore/accesscoretest"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// TestExampleBuildIdentityManageService demonstrates the recommended way to
+// wire BuildIdentityManageService in a test. It shows:
+//
+//  1. The basic service construction pattern.
+//  2. How to swap slog.DiscardHandler for os.Stderr to see verbose logs
+//     during local debugging.
+//  3. Seeding state via the returned AccessFixture.
+//
+// To swap in verbose logging, uncomment the WithIdentityLogger option:
+//
+//	svc, fix, rec := accesscoretest.BuildIdentityManageService(t,
+//	    accesscoretest.WithIdentityLogger(
+//	        slog.New(slog.NewTextHandler(os.Stderr, nil)),
+//	    ),
+//	)
+func TestExampleBuildIdentityManageService(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Optionally swap the default discard logger for stderr output:
+	_ = slog.New(slog.NewTextHandler(os.Stderr, nil)) // swap in via WithIdentityLogger
+
+	svc, fix, rec := accesscoretest.BuildIdentityManageService(t)
+
+	// Seed an admin user so last-admin protection does not block Create.
+	admin, err := domain.NewUser("admin", "admin@example.com", "$2a$04$x", clock.Real().Now())
+	if err != nil {
+		t.Fatalf("domain.NewUser: %v", err)
+	}
+	admin.ID = "usr-admin"
+	if err := fix.SeedUser(ctx, admin); err != nil {
+		t.Fatalf("SeedUser: %v", err)
+	}
+	adminRole := &domain.Role{ID: "admin", Name: "Admin"}
+	if err := fix.SeedRole(ctx, adminRole); err != nil {
+		t.Fatalf("SeedRole: %v", err)
+	}
+	if err := fix.SeedAssignment(ctx, admin.ID, "admin"); err != nil {
+		t.Fatalf("SeedAssignment: %v", err)
+	}
+
+	adminCtx := auth.TestContext("usr-admin", []string{"admin"})
+	created, err := svc.Create(adminCtx, identitymanage.CreateInput{
+		Username: "alice",
+		Email:    "alice@example.com",
+		Password: "hunter12",
+	})
+	if err != nil {
+		t.Fatalf("svc.Create: %v", err)
+	}
+	t.Logf("created user ID=%s", created.ID)
+
+	// Verify event was emitted.
+	entries := rec.EntriesByType(identitymanage.TopicUserCreated)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 user-created event, got %d", len(entries))
+	}
+}

--- a/cells/accesscore/accesscoretest/example_test.go
+++ b/cells/accesscore/accesscoretest/example_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/cells/accesscore/accesscoretest"
-	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
-	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
@@ -19,7 +17,8 @@ import (
 //  1. The basic service construction pattern.
 //  2. How to swap slog.DiscardHandler for os.Stderr to see verbose logs
 //     during local debugging.
-//  3. Seeding state via the returned AccessFixture.
+//  3. Seeding state via the returned AccessFixture using the value-type
+//     SeededUser / SeededRole DTOs (no internal/domain import required).
 //
 // To swap in verbose logging, uncomment the WithIdentityLogger option:
 //
@@ -38,19 +37,18 @@ func TestExampleBuildIdentityManageService(t *testing.T) {
 	svc, fix, rec := accesscoretest.BuildIdentityManageService(t)
 
 	// Seed an admin user so last-admin protection does not block Create.
-	admin, err := domain.NewUser("admin", "admin@example.com", "$2a$04$x", clock.Real().Now())
-	if err != nil {
-		t.Fatalf("domain.NewUser: %v", err)
-	}
-	admin.ID = "usr-admin"
-	if err := fix.SeedUser(ctx, admin); err != nil {
+	if err := fix.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "usr-admin", Username: "admin", Email: "admin@example.com",
+		PasswordHash: "$2a$04$x",
+	}); err != nil {
 		t.Fatalf("SeedUser: %v", err)
 	}
-	adminRole := &domain.Role{ID: "admin", Name: "Admin"}
-	if err := fix.SeedRole(ctx, adminRole); err != nil {
+	if err := fix.SeedRole(ctx, accesscoretest.SeededRole{
+		ID: "admin", Name: "Admin",
+	}); err != nil {
 		t.Fatalf("SeedRole: %v", err)
 	}
-	if err := fix.SeedAssignment(ctx, admin.ID, "admin"); err != nil {
+	if err := fix.SeedAssignment(ctx, "usr-admin", "admin"); err != nil {
 		t.Fatalf("SeedAssignment: %v", err)
 	}
 

--- a/cells/accesscore/accesscoretest/external_smoke_test.go
+++ b/cells/accesscore/accesscoretest/external_smoke_test.go
@@ -1,0 +1,121 @@
+// This file deliberately uses a foreign _test package and imports only
+// public packages. It exists as a compile-time gate: if any future change
+// to cells/accesscore/accesscoretest re-exports a cells/accesscore/internal/*
+// type in its public API, callers like this test would need to import the
+// internal package to construct or read those values — but Go's internal
+// barrier forbids that import, so this file would stop compiling.
+//
+// Hard funnel form:
+//   - upstream: Go internal-package barrier (cells/accesscore/internal/* can
+//     only be imported by code rooted at cells/accesscore/) — violation
+//     unexpressible at the import path level.
+//   - downstream: this file's continued compilation under "go test ./..." —
+//     any drift back to internal types in the public API is caught at the
+//     first `go build`.
+//
+// Intentionally narrow: this test does not exercise behavior; the behavior
+// is covered by builders_test.go in the in-package _test. The single check
+// here is the import surface.
+//
+// Lives in the same accesscoretest_test external-test package as the other
+// _test files — Go limits a directory to one external _test package, so
+// "external" here is enforced by what this file imports, not by a
+// freshly-named package.
+package accesscoretest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ghbvf/gocell/cells/accesscore/accesscoretest"
+	"github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// TestExternalImportSurface_NoInternalTypes calls every public symbol that
+// could plausibly leak an internal/domain or internal/ports type. If any
+// signature regresses, the compiler will require the corresponding internal
+// import — which Go itself rejects, surfacing a build error.
+func TestExternalImportSurface_NoInternalTypes(t *testing.T) {
+	ctx := context.Background()
+
+	fix := accesscoretest.NewAccessFixture(t, clock.Real())
+
+	if err := fix.SeedUser(ctx, accesscoretest.SeededUser{
+		ID: "u1", Username: "alice", Email: "alice@example.com",
+		PasswordHash: "$2a$04$x",
+	}); err != nil {
+		t.Fatalf("SeedUser: %v", err)
+	}
+	if err := fix.SeedRole(ctx, accesscoretest.SeededRole{
+		ID: "r1", Name: "Admin",
+	}); err != nil {
+		t.Fatalf("SeedRole: %v", err)
+	}
+	if err := fix.SeedAssignment(ctx, "u1", "r1"); err != nil {
+		t.Fatalf("SeedAssignment: %v", err)
+	}
+
+	view, err := fix.GetUser(ctx, "u1")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if view.Status != accesscoretest.UserStatusActive {
+		t.Fatalf("GetUser: unexpected status %q", view.Status)
+	}
+
+	roleView, err := fix.GetRole(ctx, "r1")
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+	if roleView.ID != "r1" {
+		t.Fatalf("GetRole: unexpected role %+v", roleView)
+	}
+
+	roles, err := fix.UserRoles(ctx, "u1")
+	if err != nil {
+		t.Fatalf("UserRoles: %v", err)
+	}
+	if len(roles) != 1 || roles[0].ID != "r1" {
+		t.Fatalf("UserRoles: unexpected %+v", roles)
+	}
+
+	inv := accesscoretest.NewCredentialInvalidator(t,
+		accesscoretest.WithInvalidatorFixture(fix),
+	)
+	if inv == nil {
+		t.Fatal("NewCredentialInvalidator returned nil")
+	}
+
+	svc, _, rec := accesscoretest.BuildIdentityManageService(t,
+		accesscoretest.WithIdentityFixture(fix),
+	)
+	if svc == nil || rec == nil {
+		t.Fatal("BuildIdentityManageService returned nil components")
+	}
+
+	// Compile-only: exercise all four typed stub constructors.
+	g := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+		"plain":     accesscoretest.PresentStub("plain", "v", 1),
+		"secret":    accesscoretest.SensitiveStub("secret", 2),
+		"missing":   accesscoretest.NotFoundStub(),
+		"transient": accesscoretest.ErrorStub(errors.New("transient")),
+	})
+	_, _ = g.GetEntry(ctx, "plain")
+
+	cfgSvc := accesscoretest.BuildConfigReceiveService(t,
+		accesscoretest.WithConfigReceiveConfigGetter(g),
+	)
+	if cfgSvc == nil {
+		t.Fatal("BuildConfigReceiveService returned nil")
+	}
+
+	// Confirm runtime/auth (public package) sentinel symbols still resolve;
+	// these are only here so this file's imports stay non-trivial.
+	_ = auth.TestContext("u1", []string{"r1"})
+	_ = identitymanage.TopicUserCreated
+	_ = errcode.ErrConfigNotFound
+}

--- a/cells/accesscore/accesscoretest/external_smoke_test.go
+++ b/cells/accesscore/accesscoretest/external_smoke_test.go
@@ -1,17 +1,20 @@
 // This file deliberately uses a foreign _test package and imports only
-// public packages. It exists as a compile-time gate: if any future change
-// to cells/accesscore/accesscoretest re-exports a cells/accesscore/internal/*
-// type in its public API, callers like this test would need to import the
-// internal package to construct or read those values — but Go's internal
-// barrier forbids that import, so this file would stop compiling.
+// public packages. It is the compile-time gate against internal-type
+// re-export from cells/accesscore/accesscoretest: every exported symbol
+// whose declared type could plausibly reference cells/accesscore/internal/*
+// is named in a typed assertion (`var _ Type = expr`). If any future change
+// to a signature in this package switches a parameter or return type to a
+// cells/accesscore/internal/* type, this file requires the corresponding
+// internal import to type-check — which Go's internal-package rule rejects,
+// turning the regression into an immediate `go build` failure.
 //
 // Hard funnel form:
 //   - upstream: Go internal-package barrier (cells/accesscore/internal/* can
 //     only be imported by code rooted at cells/accesscore/) — violation
 //     unexpressible at the import path level.
-//   - downstream: this file's continued compilation under "go test ./..." —
-//     any drift back to internal types in the public API is caught at the
-//     first `go build`.
+//   - downstream: typed `var _ Type = expr` declarations below pin the
+//     public surface; any drift back to internal types breaks compilation
+//     of this _test file at the next `go test ./...`.
 //
 // Intentionally narrow: this test does not exercise behavior; the behavior
 // is covered by builders_test.go in the in-package _test. The single check
@@ -89,9 +92,20 @@ func TestExternalImportSurface_NoInternalTypes(t *testing.T) {
 	if inv == nil {
 		t.Fatal("NewCredentialInvalidator returned nil")
 	}
+	// Compile-time pin: NewCredentialInvalidator returns the public opaque
+	// *CredentialInvalidator, and WithIdentityInvalidator accepts it. Any
+	// future regression to *cells/accesscore/internal/credentialinvalidate.Invalidator
+	// (or any other internal type) breaks these declarations first.
+	// staticcheck QF1011 wants the RHS-inferable type dropped, but the
+	// *typed* form IS the gate — suppress for both lines.
+	//nolint:staticcheck // QF1011: typed gate against internal-type leak
+	var _ *accesscoretest.CredentialInvalidator = inv
+	//nolint:staticcheck // QF1011: typed gate against internal-type leak
+	var _ accesscoretest.BuildIdentityManageOption = accesscoretest.WithIdentityInvalidator(inv)
 
 	svc, _, rec := accesscoretest.BuildIdentityManageService(t,
 		accesscoretest.WithIdentityFixture(fix),
+		accesscoretest.WithIdentityInvalidator(inv),
 	)
 	if svc == nil || rec == nil {
 		t.Fatal("BuildIdentityManageService returned nil components")

--- a/cells/accesscore/accesscoretest/fake_config_getter.go
+++ b/cells/accesscore/accesscoretest/fake_config_getter.go
@@ -8,25 +8,64 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-// FakeConfigEntry is a value-type mirror of ports.ConfigEntry for use in test
-// stubs. It is exported separately so callers can write stub maps without
-// importing cells/accesscore/internal/ports directly.
-type FakeConfigEntry struct {
-	Key       string
-	Value     string
-	Sensitive bool
-	Version   int
+// ConfigGetterStub is the sealed value type accepted by NewFakeConfigGetter.
+// The fields are unexported; the only way to construct one is via the four
+// typed constructors below. This makes self-contradictory states like
+// "Sensitive=true with plaintext Value" unrepresentable in the type system
+// — selecting the wrong stub semantic is selecting the wrong constructor
+// name, surfaced at compile time.
+//
+// AI Hard form: "typed function choice" — one API per semantic, no flag
+// fields decoded at runtime.
+type ConfigGetterStub struct {
+	entry *fakeConfigEntry
+	err   error
 }
 
-// ConfigGetterStub describes the response for a single key lookup.
-// When Entry is non-nil and Err is nil, GetEntry returns the entry.
-// When Err is non-nil, GetEntry returns the error.
-// When both are nil (stub has the key but Entry is nil), GetEntry returns
-// ErrConfigNotFound — the stub represents a key that is explicitly absent.
-// When both Entry and Err are non-nil, Err takes precedence.
-type ConfigGetterStub struct {
-	Entry *FakeConfigEntry // nil → return Err (or ErrConfigNotFound if Err also nil)
-	Err   error
+// fakeConfigEntry mirrors ports.ConfigEntry but lives behind unexported
+// constructors so the Sensitive/Value redaction contract cannot be violated
+// from outside this package.
+type fakeConfigEntry struct {
+	key       string
+	value     string
+	sensitive bool
+	version   int
+}
+
+// PresentStub returns a stub for a non-sensitive config key whose value is
+// returned to callers via GetEntry. Use this for the common "key exists with
+// plaintext value" path.
+func PresentStub(key, value string, version int) ConfigGetterStub {
+	return ConfigGetterStub{entry: &fakeConfigEntry{
+		key: key, value: value, sensitive: false, version: version,
+	}}
+}
+
+// SensitiveStub returns a stub mirroring what configcore's internal HTTP
+// getter returns for keys flagged Sensitive=true: Value is the redacted
+// placeholder "******". This matches the production redaction contract
+// documented in cells/accesscore/internal/ports/configport.go and lets tests
+// assert the "reload triggers but plaintext never revealed" path without
+// hard-coding the redaction sentinel in every test.
+func SensitiveStub(key string, version int) ConfigGetterStub {
+	return ConfigGetterStub{entry: &fakeConfigEntry{
+		key: key, value: "******", sensitive: true, version: version,
+	}}
+}
+
+// NotFoundStub returns a stub representing a key that is explicitly absent;
+// GetEntry returns ErrConfigNotFound with CategoryDomain. Use this when
+// stubbing stale-event paths (configcore reports the key was upserted but
+// the subsequent fetch races a delete and finds nothing).
+func NotFoundStub() ConfigGetterStub {
+	return ConfigGetterStub{}
+}
+
+// ErrorStub returns a stub that surfaces the supplied error from GetEntry.
+// Use for transient or permanent error coverage; the error is returned to
+// the caller verbatim (no wrapping).
+func ErrorStub(err error) ConfigGetterStub {
+	return ConfigGetterStub{err: err}
 }
 
 // FakeConfigGetter is a stub implementation of ports.ConfigGetter for use in
@@ -37,8 +76,10 @@ type ConfigGetterStub struct {
 // Usage:
 //
 //	g := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
-//	    "jwt.ttl": {Entry: &accesscoretest.FakeConfigEntry{Key: "jwt.ttl", Value: "3600", Version: 1}},
-//	    "bad-key": {Err: someErr},
+//	    "jwt.ttl":   accesscoretest.PresentStub("jwt.ttl", "3600", 1),
+//	    "kms.key":   accesscoretest.SensitiveStub("kms.key", 4),
+//	    "stale.key": accesscoretest.NotFoundStub(),
+//	    "broken":    accesscoretest.ErrorStub(myTransientErr),
 //	})
 type FakeConfigGetter struct {
 	mu    sync.Mutex
@@ -49,45 +90,50 @@ type FakeConfigGetter struct {
 // Compile-time assertion: FakeConfigGetter must satisfy ports.ConfigGetter.
 var _ ports.ConfigGetter = (*FakeConfigGetter)(nil)
 
-// NewFakeConfigGetter constructs a FakeConfigGetter with the given stubs.
+// NewFakeConfigGetter constructs a FakeConfigGetter with a deep copy of the
+// supplied stubs map. Subsequent mutations of the caller's map (or of any
+// ConfigGetterStub value re-used as a map alias) do not affect the fake.
 // A nil or empty stubs map means all keys return ErrConfigNotFound.
 func NewFakeConfigGetter(stubs map[string]ConfigGetterStub) *FakeConfigGetter {
-	if stubs == nil {
-		stubs = map[string]ConfigGetterStub{}
+	cp := make(map[string]ConfigGetterStub, len(stubs))
+	for k, v := range stubs {
+		if v.entry != nil {
+			entryCopy := *v.entry
+			v.entry = &entryCopy
+		}
+		cp[k] = v
 	}
-	return &FakeConfigGetter{stubs: stubs}
+	return &FakeConfigGetter{stubs: cp}
 }
 
-// GetEntry implements ports.ConfigGetter. It records the call and returns the
-// stubbed response for the given key. Unknown keys return ErrConfigNotFound.
-func (g *FakeConfigGetter) GetEntry(_ context.Context, key string) (ports.ConfigEntry, error) {
+// GetEntry implements ports.ConfigGetter. It honors ctx.Err() (matching the
+// production HTTP getter's cancellation semantic), records the call, and
+// returns the stubbed response for the given key. Unknown keys and
+// NotFoundStub entries return ErrConfigNotFound with CategoryDomain.
+func (g *FakeConfigGetter) GetEntry(ctx context.Context, key string) (ports.ConfigEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigEntry{}, err
+	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.calls = append(g.calls, key)
 
 	stub, ok := g.stubs[key]
-	if !ok {
+	if !ok || (stub.entry == nil && stub.err == nil) {
 		return ports.ConfigEntry{}, errcode.New(
 			errcode.KindNotFound, errcode.ErrConfigNotFound,
 			"fake config getter: key not found",
 			errcode.WithCategory(errcode.CategoryDomain),
 		)
 	}
-	if stub.Err != nil {
-		return ports.ConfigEntry{}, stub.Err
-	}
-	if stub.Entry == nil {
-		return ports.ConfigEntry{}, errcode.New(
-			errcode.KindNotFound, errcode.ErrConfigNotFound,
-			"fake config getter: key not found",
-			errcode.WithCategory(errcode.CategoryDomain),
-		)
+	if stub.err != nil {
+		return ports.ConfigEntry{}, stub.err
 	}
 	return ports.ConfigEntry{
-		Key:       stub.Entry.Key,
-		Value:     stub.Entry.Value,
-		Sensitive: stub.Entry.Sensitive,
-		Version:   stub.Entry.Version,
+		Key:       stub.entry.key,
+		Value:     stub.entry.value,
+		Sensitive: stub.entry.sensitive,
+		Version:   stub.entry.version,
 	}, nil
 }
 

--- a/cells/accesscore/accesscoretest/fake_config_getter.go
+++ b/cells/accesscore/accesscoretest/fake_config_getter.go
@@ -23,6 +23,7 @@ type FakeConfigEntry struct {
 // When Err is non-nil, GetEntry returns the error.
 // When both are nil (stub has the key but Entry is nil), GetEntry returns
 // ErrConfigNotFound — the stub represents a key that is explicitly absent.
+// When both Entry and Err are non-nil, Err takes precedence.
 type ConfigGetterStub struct {
 	Entry *FakeConfigEntry // nil → return Err (or ErrConfigNotFound if Err also nil)
 	Err   error
@@ -69,6 +70,7 @@ func (g *FakeConfigGetter) GetEntry(_ context.Context, key string) (ports.Config
 		return ports.ConfigEntry{}, errcode.New(
 			errcode.KindNotFound, errcode.ErrConfigNotFound,
 			"fake config getter: key not found",
+			errcode.WithCategory(errcode.CategoryDomain),
 		)
 	}
 	if stub.Err != nil {
@@ -78,6 +80,7 @@ func (g *FakeConfigGetter) GetEntry(_ context.Context, key string) (ports.Config
 		return ports.ConfigEntry{}, errcode.New(
 			errcode.KindNotFound, errcode.ErrConfigNotFound,
 			"fake config getter: key not found",
+			errcode.WithCategory(errcode.CategoryDomain),
 		)
 	}
 	return ports.ConfigEntry{

--- a/cells/accesscore/accesscoretest/fake_config_getter.go
+++ b/cells/accesscore/accesscoretest/fake_config_getter.go
@@ -1,0 +1,106 @@
+package accesscoretest
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// FakeConfigEntry is a value-type mirror of ports.ConfigEntry for use in test
+// stubs. It is exported separately so callers can write stub maps without
+// importing cells/accesscore/internal/ports directly.
+type FakeConfigEntry struct {
+	Key       string
+	Value     string
+	Sensitive bool
+	Version   int
+}
+
+// ConfigGetterStub describes the response for a single key lookup.
+// When Entry is non-nil and Err is nil, GetEntry returns the entry.
+// When Err is non-nil, GetEntry returns the error.
+// When both are nil (stub has the key but Entry is nil), GetEntry returns
+// ErrConfigNotFound — the stub represents a key that is explicitly absent.
+type ConfigGetterStub struct {
+	Entry *FakeConfigEntry // nil → return Err (or ErrConfigNotFound if Err also nil)
+	Err   error
+}
+
+// FakeConfigGetter is a stub implementation of ports.ConfigGetter for use in
+// tests. It is concurrency-safe. Unknown keys (not in the stubs map) return
+// ErrConfigNotFound by convention so test authors do not need to explicitly
+// stub every key they do not care about.
+//
+// Usage:
+//
+//	g := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
+//	    "jwt.ttl": {Entry: &accesscoretest.FakeConfigEntry{Key: "jwt.ttl", Value: "3600", Version: 1}},
+//	    "bad-key": {Err: someErr},
+//	})
+type FakeConfigGetter struct {
+	mu    sync.Mutex
+	stubs map[string]ConfigGetterStub
+	calls []string
+}
+
+// Compile-time assertion: FakeConfigGetter must satisfy ports.ConfigGetter.
+var _ ports.ConfigGetter = (*FakeConfigGetter)(nil)
+
+// NewFakeConfigGetter constructs a FakeConfigGetter with the given stubs.
+// A nil or empty stubs map means all keys return ErrConfigNotFound.
+func NewFakeConfigGetter(stubs map[string]ConfigGetterStub) *FakeConfigGetter {
+	if stubs == nil {
+		stubs = map[string]ConfigGetterStub{}
+	}
+	return &FakeConfigGetter{stubs: stubs}
+}
+
+// GetEntry implements ports.ConfigGetter. It records the call and returns the
+// stubbed response for the given key. Unknown keys return ErrConfigNotFound.
+func (g *FakeConfigGetter) GetEntry(_ context.Context, key string) (ports.ConfigEntry, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls = append(g.calls, key)
+
+	stub, ok := g.stubs[key]
+	if !ok {
+		return ports.ConfigEntry{}, errcode.New(
+			errcode.KindNotFound, errcode.ErrConfigNotFound,
+			"fake config getter: key not found",
+		)
+	}
+	if stub.Err != nil {
+		return ports.ConfigEntry{}, stub.Err
+	}
+	if stub.Entry == nil {
+		return ports.ConfigEntry{}, errcode.New(
+			errcode.KindNotFound, errcode.ErrConfigNotFound,
+			"fake config getter: key not found",
+		)
+	}
+	return ports.ConfigEntry{
+		Key:       stub.Entry.Key,
+		Value:     stub.Entry.Value,
+		Sensitive: stub.Entry.Sensitive,
+		Version:   stub.Entry.Version,
+	}, nil
+}
+
+// Calls returns the ordered list of keys passed to GetEntry since the last
+// Reset. Returns a copy; mutating the slice does not affect the recorder.
+func (g *FakeConfigGetter) Calls() []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]string, len(g.calls))
+	copy(out, g.calls)
+	return out
+}
+
+// Reset clears the call log. Stubs are not modified.
+func (g *FakeConfigGetter) Reset() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls = nil
+}

--- a/cells/accesscore/accesscoretest/fixture.go
+++ b/cells/accesscore/accesscoretest/fixture.go
@@ -1,0 +1,63 @@
+package accesscoretest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	accesscoremem "github.com/ghbvf/gocell/cells/accesscore/mem"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/persistence"
+)
+
+// AccessFixture is the canonical in-memory test aggregate for accesscore.
+// It wraps a single mem.Bundle so UserRepo(), RoleRepo(), TxRunner(), and
+// SetupLock() all originate from the same underlying mem.Store — preventing
+// the store-pairing footgun that caused PR #595.
+//
+// Use NewAccessFixture to construct; never embed the zero value.
+type AccessFixture struct {
+	bundle accesscoremem.Bundle
+}
+
+// NewAccessFixture constructs an AccessFixture backed by mem.NewBundle(clk).
+// t is used to mark the function as a test helper for cleaner failure output.
+func NewAccessFixture(t *testing.T, clk clock.Clock) *AccessFixture {
+	t.Helper()
+	return &AccessFixture{
+		bundle: accesscoremem.NewBundle(clk),
+	}
+}
+
+// UserRepo returns the bundle-paired UserRepository.
+func (f *AccessFixture) UserRepo() ports.UserRepository { return f.bundle.UserRepository() }
+
+// RoleRepo returns the bundle-paired RoleRepository.
+func (f *AccessFixture) RoleRepo() ports.RoleRepository { return f.bundle.RoleRepository() }
+
+// TxRunner returns the bundle-paired store-bound CellTxManager. Use this when
+// wiring services that require a real atomic TxManager (e.g. identitymanage
+// Create → lock-scoped read-modify-write).
+func (f *AccessFixture) TxRunner() persistence.CellTxManager { return f.bundle.TxRunner() }
+
+// SetupLock returns the bundle-paired SetupLockAcquirer (noop for mem).
+func (f *AccessFixture) SetupLock() ports.SetupLockAcquirer { return f.bundle.SetupLock() }
+
+// SeedUser persists u directly via UserRepository.Create. Call before
+// exercising service methods that require the user to pre-exist.
+func (f *AccessFixture) SeedUser(ctx context.Context, u *domain.User) error {
+	return f.bundle.UserRepository().Create(ctx, u)
+}
+
+// SeedRole persists role directly via RoleRepository.Create.
+func (f *AccessFixture) SeedRole(ctx context.Context, role *domain.Role) error {
+	return f.bundle.RoleRepository().Create(ctx, role)
+}
+
+// SeedAssignment assigns the role to the user via RoleRepository.AssignToUser.
+// Returns an error if either the user or role does not exist in the store.
+func (f *AccessFixture) SeedAssignment(ctx context.Context, userID, roleID string) error {
+	_, err := f.bundle.RoleRepository().AssignToUser(ctx, userID, roleID)
+	return err
+}

--- a/cells/accesscore/accesscoretest/fixture.go
+++ b/cells/accesscore/accesscoretest/fixture.go
@@ -3,56 +3,147 @@ package accesscoretest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
-	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	accesscoremem "github.com/ghbvf/gocell/cells/accesscore/mem"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/runtime/auth/refresh"
+	refreshmem "github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
+	"github.com/ghbvf/gocell/runtime/auth/session"
+	sessiontest "github.com/ghbvf/gocell/runtime/auth/session/sessiontest"
 )
 
+// UserStatus is the public mirror of domain.UserStatus used by SeededUserView
+// so external test packages do not need to import internal/domain to read
+// user state. SeedUser always produces Active users; tests that need
+// Locked/Suspended state must drive a service operation (Lock / Suspend)
+// after seeding so the credential-event funnel runs correctly.
+type UserStatus string
+
+const (
+	UserStatusActive    UserStatus = "active"
+	UserStatusSuspended UserStatus = "suspended"
+	UserStatusLocked    UserStatus = "locked"
+)
+
+// SeededUser is the value-type input for AccessFixture.SeedUser. It mirrors
+// the public field set of internal/domain.User that test authors need at
+// seed time — all four fields are required.
+//
+// Active status and AuthzEpoch=1 are implied (domain.NewUser defaults).
+// Non-Active state must come from a service operation invoked after seeding.
+type SeededUser struct {
+	ID           string
+	Username     string
+	Email        string
+	PasswordHash string // bcrypt-formatted; tests can use "$2a$04$dummy"
+}
+
+// SeededRole is the value-type input for AccessFixture.SeedRole. Permissions
+// are not modeled here — current journeys do not seed them; add a
+// SeededPermission type when needed.
+type SeededRole struct {
+	ID   string
+	Name string
+}
+
+// SeededUserView is the value-type output returned by AccessFixture.GetUser.
+// It surfaces the seed fields plus rehydrated authz/lifecycle state so test
+// assertions don't need to import internal/domain.
+type SeededUserView struct {
+	ID           string
+	Username     string
+	Email        string
+	PasswordHash string
+	Status       UserStatus
+	AuthzEpoch   int64
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// SeededRoleView is the value-type output returned by AccessFixture.GetRole /
+// AccessFixture.UserRoles.
+type SeededRoleView struct {
+	ID   string
+	Name string
+}
+
 // AccessFixture is the canonical in-memory test aggregate for accesscore.
-// It wraps a single mem.Bundle so UserRepo(), RoleRepo(), TxRunner(), and
-// SetupLock() all originate from the same underlying mem.Store — preventing
-// the store-pairing footgun that caused PR #595.
+// It wraps a single mem.Bundle so the four store-paired primitives
+// (UserRepository, RoleRepository, SetupLock, TxRunner) all originate from
+// the same underlying mem.Store — preventing the store-pairing footgun that
+// caused PR #595.
+//
+// In addition, the fixture holds singleton session.MemStore and refresh.Store
+// instances so that test-built services (e.g. via BuildIdentityManageService)
+// share session/refresh state with the credential invalidator. Round-2 review
+// of PR #845 added this extension: the invalidator used to build its own
+// independent session/refresh stores via internal/testutil, silently
+// isolating it from any sessionlogin.Service that callers might later inject
+// as TokenIssuer.
 //
 // Use NewAccessFixture to construct; never embed the zero value.
 type AccessFixture struct {
-	bundle accesscoremem.Bundle
+	bundle       accesscoremem.Bundle
+	sessionStore *session.MemStore
+	refreshStore refresh.Store
+	clk          clock.Clock
 }
 
 // NewAccessFixture constructs an AccessFixture backed by mem.NewBundle(clk).
-// t is used to mark the function as a test helper for cleaner failure output.
+// session/refresh stores use the canonical test protocol that
+// internal/testutil.RealSessionRepo / RealRefreshStore use so behavior
+// matches existing in-package unit tests.
 func NewAccessFixture(t *testing.T, clk clock.Clock) *AccessFixture {
 	t.Helper()
+	sess, err := session.NewMemStore(sessiontest.Protocol(), clk)
+	if err != nil {
+		t.Fatalf("NewAccessFixture: session.NewMemStore: %v", err)
+	}
+	ref, err := refreshmem.New(
+		refresh.Policy{
+			ReuseInterval:  time.Second,
+			MaxAge:         time.Hour,
+			MaxIdle:        refresh.DefaultMaxIdle,
+			GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+		},
+		clk, nil,
+	)
+	if err != nil {
+		t.Fatalf("NewAccessFixture: refreshmem.New: %v", err)
+	}
 	return &AccessFixture{
-		bundle: accesscoremem.NewBundle(clk),
+		bundle:       accesscoremem.NewBundle(clk),
+		sessionStore: sess,
+		refreshStore: ref,
+		clk:          clk,
 	}
 }
-
-// UserRepository returns the bundle-paired UserRepository.
-func (f *AccessFixture) UserRepository() ports.UserRepository { return f.bundle.UserRepository() }
-
-// RoleRepository returns the bundle-paired RoleRepository.
-func (f *AccessFixture) RoleRepository() ports.RoleRepository { return f.bundle.RoleRepository() }
 
 // TxRunner returns the bundle-paired store-bound CellTxManager. Use this when
 // wiring services that require a real atomic TxManager (e.g. identitymanage
 // Create → lock-scoped read-modify-write).
 func (f *AccessFixture) TxRunner() persistence.CellTxManager { return f.bundle.TxRunner() }
 
-// SetupLock returns the bundle-paired SetupLockAcquirer (noop for mem).
-func (f *AccessFixture) SetupLock() ports.SetupLockAcquirer { return f.bundle.SetupLock() }
-
-// SeedUser persists u directly via UserRepository.Create. Call before
-// exercising service methods that require the user to pre-exist.
-func (f *AccessFixture) SeedUser(ctx context.Context, u *domain.User) error {
-	return f.bundle.UserRepository().Create(ctx, u)
+// SeedUser persists u via domain.NewUser → UserRepository.Create. The
+// resulting user is Active with AuthzEpoch=1; tests that need non-Active
+// state must drive a service operation (Lock / Suspend / Delete) after
+// seeding so the credential-event funnel runs.
+func (f *AccessFixture) SeedUser(ctx context.Context, u SeededUser) error {
+	user, err := domain.NewUser(u.Username, u.Email, u.PasswordHash, f.clk.Now())
+	if err != nil {
+		return err
+	}
+	user.ID = u.ID
+	return f.bundle.UserRepository().Create(ctx, user)
 }
 
-// SeedRole persists role directly via RoleRepository.Create.
-func (f *AccessFixture) SeedRole(ctx context.Context, role *domain.Role) error {
-	return f.bundle.RoleRepository().Create(ctx, role)
+// SeedRole persists role directly via the bundle-paired RoleRepository.
+// AccessFixture does not expose the raw RoleRepository.
+func (f *AccessFixture) SeedRole(ctx context.Context, r SeededRole) error {
+	return f.bundle.RoleRepository().Create(ctx, &domain.Role{ID: r.ID, Name: r.Name})
 }
 
 // SeedAssignment assigns the role to the user via RoleRepository.AssignToUser.
@@ -60,4 +151,61 @@ func (f *AccessFixture) SeedRole(ctx context.Context, role *domain.Role) error {
 func (f *AccessFixture) SeedAssignment(ctx context.Context, userID, roleID string) error {
 	_, err := f.bundle.RoleRepository().AssignToUser(ctx, userID, roleID)
 	return err
+}
+
+// GetUser returns the seeded user as a SeededUserView. External tests use
+// this to assert that service operations updated user state without needing
+// to import internal/domain.
+func (f *AccessFixture) GetUser(ctx context.Context, id string) (SeededUserView, error) {
+	u, err := f.bundle.UserRepository().GetByID(ctx, id)
+	if err != nil {
+		return SeededUserView{}, err
+	}
+	return userView(u), nil
+}
+
+// GetRole returns the seeded role as a SeededRoleView.
+func (f *AccessFixture) GetRole(ctx context.Context, id string) (SeededRoleView, error) {
+	r, err := f.bundle.RoleRepository().GetByID(ctx, id)
+	if err != nil {
+		return SeededRoleView{}, err
+	}
+	return SeededRoleView{ID: r.ID, Name: r.Name}, nil
+}
+
+// UserRoles returns the roles currently assigned to the given user.
+func (f *AccessFixture) UserRoles(ctx context.Context, userID string) ([]SeededRoleView, error) {
+	roles, err := f.bundle.RoleRepository().GetByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SeededRoleView, 0, len(roles))
+	for _, r := range roles {
+		out = append(out, SeededRoleView{ID: r.ID, Name: r.Name})
+	}
+	return out, nil
+}
+
+func mapStatusFromDomain(s domain.UserStatus) UserStatus {
+	switch s {
+	case domain.StatusSuspended:
+		return UserStatusSuspended
+	case domain.StatusLocked:
+		return UserStatusLocked
+	default:
+		return UserStatusActive
+	}
+}
+
+func userView(u *domain.User) SeededUserView {
+	return SeededUserView{
+		ID:           u.ID,
+		Username:     u.Username,
+		Email:        u.Email,
+		PasswordHash: u.PasswordHash,
+		Status:       mapStatusFromDomain(u.Status()),
+		AuthzEpoch:   u.AuthzEpoch(),
+		CreatedAt:    u.CreatedAt,
+		UpdatedAt:    u.UpdatedAt,
+	}
 }

--- a/cells/accesscore/accesscoretest/fixture.go
+++ b/cells/accesscore/accesscoretest/fixture.go
@@ -30,11 +30,11 @@ func NewAccessFixture(t *testing.T, clk clock.Clock) *AccessFixture {
 	}
 }
 
-// UserRepo returns the bundle-paired UserRepository.
-func (f *AccessFixture) UserRepo() ports.UserRepository { return f.bundle.UserRepository() }
+// UserRepository returns the bundle-paired UserRepository.
+func (f *AccessFixture) UserRepository() ports.UserRepository { return f.bundle.UserRepository() }
 
-// RoleRepo returns the bundle-paired RoleRepository.
-func (f *AccessFixture) RoleRepo() ports.RoleRepository { return f.bundle.RoleRepository() }
+// RoleRepository returns the bundle-paired RoleRepository.
+func (f *AccessFixture) RoleRepository() ports.RoleRepository { return f.bundle.RoleRepository() }
 
 // TxRunner returns the bundle-paired store-bound CellTxManager. Use this when
 // wiring services that require a real atomic TxManager (e.g. identitymanage

--- a/tools/internal/fileroles/fileroles.go
+++ b/tools/internal/fileroles/fileroles.go
@@ -44,6 +44,20 @@ func Rel(modRoot, abs string) (string, bool) {
 	return rel, true
 }
 
+// testHelperSubpaths lists recognized test-helper package path segments. A
+// path containing any of these is classified as test code. Order is not
+// significant — the predicate is OR over the slice.
+var testHelperSubpaths = []string{
+	"/locktest/",
+	"/outboxtest/",
+	"/storetest/",
+	"/healthtest/",
+	"/contracttest/",
+	"/commandtest/",
+	"/auditcoretest/",
+	"/accesscoretest/",
+}
+
 // IsTestCode reports whether the given module-relative path is test code
 // for the purposes of TEST-TIME-LITERAL-01.
 //
@@ -57,8 +71,8 @@ func Rel(modRoot, abs string) (string, bool) {
 // Inclusions (return true unless caught by an exclusion above):
 //   - *_test.go
 //   - **/conformance.go
-//   - any file under one of the recognized test-helper packages:
-//     locktest, outboxtest, storetest, healthtest, contracttest, commandtest
+//   - any file under one of the recognized test-helper packages
+//     (see testHelperSubpaths)
 func IsTestCode(rel string) bool {
 	if rel == "" {
 		return false
@@ -73,27 +87,13 @@ func IsTestCode(rel string) bool {
 	case strings.HasPrefix(rel, "testdata/"), strings.Contains(rel, "/testdata/"):
 		return false
 	}
-	switch {
-	case strings.HasSuffix(rel, "_test.go"):
+	if strings.HasSuffix(rel, "_test.go") || strings.HasSuffix(rel, "/conformance.go") {
 		return true
-	case strings.HasSuffix(rel, "/conformance.go"):
-		return true
-	case strings.Contains(rel, "/locktest/"):
-		return true
-	case strings.Contains(rel, "/outboxtest/"):
-		return true
-	case strings.Contains(rel, "/storetest/"):
-		return true
-	case strings.Contains(rel, "/healthtest/"):
-		return true
-	case strings.Contains(rel, "/contracttest/"):
-		return true
-	case strings.Contains(rel, "/commandtest/"):
-		return true
-	case strings.Contains(rel, "/auditcoretest/"):
-		return true
-	case strings.Contains(rel, "/accesscoretest/"):
-		return true
+	}
+	for _, seg := range testHelperSubpaths {
+		if strings.Contains(rel, seg) {
+			return true
+		}
 	}
 	return false
 }

--- a/tools/internal/fileroles/fileroles.go
+++ b/tools/internal/fileroles/fileroles.go
@@ -92,6 +92,8 @@ func IsTestCode(rel string) bool {
 		return true
 	case strings.Contains(rel, "/auditcoretest/"):
 		return true
+	case strings.Contains(rel, "/accesscoretest/"):
+		return true
 	}
 	return false
 }

--- a/tools/internal/fileroles/fileroles_test.go
+++ b/tools/internal/fileroles/fileroles_test.go
@@ -31,6 +31,7 @@ func TestIsTestCodeAndIsProductionCode_Disjoint(t *testing.T) {
 		{"commandtest helper", "kernel/command/commandtest/inmem.go"},
 		{"contracttest helper", "tests/contracttest/fixture.go"},
 		{"auditcoretest helper", "cells/auditcore/auditcoretest/canonical.go"},
+		{"accesscoretest helper", "cells/accesscore/accesscoretest/builders.go"},
 		{"examples production", "examples/ssobff/main.go"},
 		{"examples test", "examples/ssobff/walkthrough_test.go"},
 		{"vendor test", "vendor/github.com/x/y/y_test.go"},
@@ -71,6 +72,8 @@ func TestIsTestCode(t *testing.T) {
 		{"commandtest inmem", "kernel/command/commandtest/inmem.go", true},
 		{"auditcoretest canonical", "cells/auditcore/auditcoretest/canonical.go", true},
 		{"auditcoretest builders", "cells/auditcore/auditcoretest/builders.go", true},
+		{"accesscoretest builders", "cells/accesscore/accesscoretest/builders.go", true},
+		{"accesscoretest fixture", "cells/accesscore/accesscoretest/fixture.go", true},
 
 		{"production main", "cmd/corebundle/main.go", false},
 		{"production code", "kernel/outbox/consumer_base.go", false},

--- a/tools/slowgate/allowlist.txt
+++ b/tools/slowgate/allowlist.txt
@@ -218,3 +218,43 @@ github.com/ghbvf/gocell/tools/archtest	TestExternalReasonLiteral_NoIndirectRefer
 # SLOW-flake class as the entries above (cumulative trigger evidence for
 # ARCHTEST-SHAREDRESOLVER-AMORTIZATION-01).
 github.com/ghbvf/gocell/tools/archtest	TestExternalReasonLiteral
+
+# type-graph-load: TEST-EVENTUALLY-FUNNEL-01 main rule scans every banned
+# testify (require|assert).Eventually* callsite module-wide. Walks both
+# *types.Info.Uses (qualified-ident / *Assertions method-selector callsites)
+# and the dual blind-spot probe through CallExpr.Fun resolution; combines
+# with PRODUCTION-FLAT-TAGS scan for cgo / non-default-tag files. Whole-
+# module SharedResolver with Tests:true; same modulo-shift SLOW-flake class
+# as TestExternalReasonLiteral above (sibling DOWNSTREAM rule; this is the
+# UPSTREAM half of the testwait Hard funnel landed by PR #847). Surfaced
+# at 33.76s on PR #845 verify-archtest shard 3; the same shard was already
+# failing on develop d4cf5d37 before this PR, so this entry retires a
+# pre-existing develop-side gap rather than introduces a new SLOW.
+github.com/ghbvf/gocell/tools/archtest	TestEventuallyFunnel
+
+# type-graph-load: TEST-EVENTUALLY-FUNNEL-01 blind-spot reverse self-test
+# walks all *types.Info.Uses + *types.Info.Selections entries module-wide
+# to assert no testify Eventually* symbol appears outside CallExpr.Fun
+# position (closes 5 indirect-reference shapes — function-variable,
+# function-pointer pass, struct-field binding, method-value / method-
+# expression, reflect). Two RunTyped passes (default + ProductionFlatTags)
+# over ./... with Tests:true. Same whole-module SharedResolver profile as
+# TestEventuallyFunnel above (sibling pair, mirrors TestExternalReasonLiteral
+# vs TestExternalReasonLiteral_NoIndirectReferences). Surfaced at 21.86s
+# on PR #845 verify-archtest shard 5 after this PR's new 8-file
+# accesscoretest/ package + obmetrics import shifted the 16-shard modulo
+# distribution off the cached resolver — same modulo-shift SLOW-flake
+# class (cumulative trigger evidence for ARCHTEST-SHAREDRESOLVER-AMORTIZATION-01).
+github.com/ghbvf/gocell/tools/archtest	TestEventuallyFunnel_NoIndirectReferences
+
+# type-graph-load: CELL-ID-PATTERN-SINGLE-SOURCE main rule scans every
+# regexp.MustCompile / regexp.Compile call module-wide for banned cell-id
+# family literals (the sibling-allowlisted TestCellIDPatternSingleSourceLiterals
+# entry above covers the literal-only variant; this rule is the type-aware
+# callsite scan). Single RunTypedProduction with Tests:true + FlatNonDefaultTags
+# over ./... — same whole-module SharedResolver profile as the entries above.
+# Surfaced at 23.67s on PR #845 verify-archtest shard 13 after this PR's
+# new 8-file accesscoretest/ package + obmetrics import shifted the
+# 16-shard modulo distribution off the cached resolver — same modulo-shift
+# SLOW-flake class (cumulative trigger evidence for ARCHTEST-SHAREDRESOLVER-AMORTIZATION-01).
+github.com/ghbvf/gocell/tools/archtest	TestCellIDPatternSingleSource


### PR DESCRIPTION
## Summary

- Adds `cells/accesscore/accesscoretest/` — public testutil package with:
  - `AccessFixture` aggregate wrapping `cells/accesscore/mem.NewBundle` (the existing public funnel guaranteeing store-paired UserRepository + RoleRepository + CellTxManager + SetupLock — prevents the PR #595 store-pairing footgun)
  - `FakeConfigGetter` (standalone, stubs-based) for `ports.ConfigGetter`
  - `NewCredentialInvalidator(t, opts...)` constructing a real `*credentialinvalidate.Invalidator` with mem-backed defaults
  - `BuildIdentityManageService` + `BuildConfigReceiveService` builders
- Enables docker-free state-apply-with-dependency journey criterion tests previously blocked by Go internal-package barrier (J-useronboarding 3 manual criteria + J-confighotreload).
- **Design diverged from plan**: single `AccessFixture` aggregate instead of separate `FakeUserRepo` + `FakeRoleRepo` types, because the latter would let callers wire two unrelated mem stores and break cross-repo invariants. Plan §"Reflection — 优雅简洁" supports this; PR #595 incident is the precedent.

Refs: `docs/plans/202605191943-044-journey-backlog-realignment.md` §2 task 1 (PR-B of 3-PR parallel ship).

ref: `cells/accesscore/mem/bundle.go` (existing public funnel, reused)
ref: `kernel/outbox/outboxtest/recorder.go` (PR0)

## Test plan

- [x] \`go test ./cells/accesscore/accesscoretest/... -race\` — 7/7 GREEN
- [x] \`go test ./tools/archtest/ -run='^TestCelltestImportScope\$|^TestLayerTestutil\$'\` — pass
- [x] \`go build ./...\` — 0 errors
- [x] \`golangci-lint run ./...\` — 0 issues