### PR TITLE
feat(skills): add /pr-review auto-graded reviewer dispatch

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -35,6 +35,39 @@ gh pr view <N> --json additions,deletions --jq '.additions + .deletions'
 
 ---
 
+## 阶段 2.5：定位本地 worktree（决定 Read/Grep 上下文）
+
+reviewer agent 需要在某个工作目录下做 Read/Grep。先尝试找到该 PR 分支对应的本地 worktree：
+
+```bash
+BRANCH=$(gh pr view <N> --json headRefName --jq .headRefName)
+WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^worktree /{w=$2} $0=="branch "b{print w; exit}')
+```
+
+### 情况 A：找到 worktree（`$WORKTREE` 非空）
+
+- 把 `$WORKTREE` 绝对路径传给每个 sub-agent prompt
+- sub-agent 在该 worktree 内 Read/Grep（所有路径前缀 `$WORKTREE/`）
+- 上下文最完整：能 Read PR 改动后的全文件、Grep 仓库整体状态、追溯调用链
+- 主 agent 阶段 5 汇总时 Read/Grep 也走同一 worktree
+
+### 情况 B：没有 worktree
+
+**不要** `gh pr checkout`（污染当前分支）。两种回退：
+
+1. **快速路径（默认，无需用户介入）**：sub-agent 工作目录回退到主仓库根，但必须明确告知：
+   - 主要审查依据 = `gh pr diff <N>` 的 patch 内容
+   - `Read` 主仓库文件 = develop 状态（**不含** PR 改动），仅供查"PR 改动周边的已有代码"
+   - `Grep` 反映 develop，不反映 PR 后状态
+   - **超出 patch 范围的判断（如"PR 改动后某函数其他调用方"）必须标 `[需确认]`，不强判 P0**
+2. **完整路径（用户可选）**：当 PR 大或需要深度审查时，提示用户：
+   ```bash
+   git fetch origin && git worktree add worktrees/<NNN>-pr<N> -b pr-<N> origin/<PR-branch>
+   ```
+   建好 worktree 后重跑 `/pr-review <N>` 自动进入情况 A。
+
+---
+
 ## 阶段 3：分级表
 
 区间左闭右开，边界归更高档：
@@ -59,8 +92,11 @@ gh pr view <N> --json additions,deletions --jq '.additions + .deletions'
   gh pr diff <N>                                  # 完整 patch
   gh pr view <N> --json title,body,files,headRefOid  # 元数据
   ```
+- **工作目录上下文**（来自阶段 2.5）：
+  - 情况 A：`$WORKTREE` 绝对路径 + 提示"所有 Read/Grep 路径前缀 `$WORKTREE/`"
+  - 情况 B：主仓库根路径 + 提示"只能基于 patch 审查，Read/Grep 仅反映 develop；超出 patch 范围的判断标 `[需确认]`"
 - 分配的维度子集（来自阶段 3 表格）
-- 必读：CLAUDE.md + `.claude/rules/gocell/*.md` 关键约束
+- 必读：CLAUDE.md + `.claude/rules/gocell/*.md` 关键约束（路径相对工作目录）
 - Finding 格式（沿用 `.claude/agents/reviewer.md`）：
   ```
   [P0/P1/P2] [Cx1-Cx4] [维度] 文件:行号

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -15,8 +15,8 @@ allowed-tools: [Read, Glob, Grep, Bash, Agent]
 
 参数必须是 PR 编号：纯数字（`838`）或带井号（`#838`）。
 
-- 缺参 → 立即报错退出，提示用法 `/pr-review <PR 编号>`
-- 非法格式（含字母、空格、其他符号）→ 立即报错退出
+- 缺参 → 立即输出 `错误：缺少 PR 编号；用法：/pr-review <PR 编号>`，不执行后续阶段
+- 非法格式（含字母、空格、其他符号）→ 立即输出 `错误：参数 "<原值>" 不是合法 PR 编号`，不执行后续阶段
 - **不进入交互**确认，保持调用简单
 
 ---
@@ -35,36 +35,48 @@ gh pr view <N> --json additions,deletions --jq '.additions + .deletions'
 
 ---
 
-## 阶段 2.5：定位本地 worktree（决定 Read/Grep 上下文）
+## 阶段 2.5：定位或自动创建 review worktree
 
-reviewer agent 需要在某个工作目录下做 Read/Grep。先尝试找到该 PR 分支对应的本地 worktree：
+reviewer agent 需要在某个 worktree 内做 Read/Grep（拿到 PR 改动后的全文件 + 追溯调用链）。流程：
 
 ```bash
 BRANCH=$(gh pr view <N> --json headRefName --jq .headRefName)
 WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^worktree /{w=$2} $0=="branch "b{print w; exit}')
 ```
 
-### 情况 A：找到 worktree（`$WORKTREE` 非空）
+### 情况 A：找到既有 worktree（`$WORKTREE` 非空）
 
-- 把 `$WORKTREE` 绝对路径传给每个 sub-agent prompt
-- sub-agent 在该 worktree 内 Read/Grep（所有路径前缀 `$WORKTREE/`）
-- 上下文最完整：能 Read PR 改动后的全文件、Grep 仓库整体状态、追溯调用链
-- 主 agent 阶段 5 汇总时 Read/Grep 也走同一 worktree
+- 直接使用 `$WORKTREE` 绝对路径
+- **不动用户的 worktree 状态**（可能有 work in progress），假定当前 HEAD 即 PR head
+- 若需要校准到最新 PR head，提示用户手动 `git -C $WORKTREE pull --ff-only origin <BRANCH>`，不自动执行
 
-### 情况 B：没有 worktree
+### 情况 B：无既有 worktree → 自动创建 review-only worktree
 
-**不要** `gh pr checkout`（污染当前分支）。两种回退：
+```bash
+git fetch origin <BRANCH>                                          # dangerouslyDisableSandbox: true
+git worktree add --detach worktrees/review-pr<N> origin/<BRANCH>   # detached，不创建本地分支
+WORKTREE="$(git rev-parse --show-toplevel)/worktrees/review-pr<N>"
+```
 
-1. **快速路径（默认，无需用户介入）**：sub-agent 工作目录回退到主仓库根，但必须明确告知：
-   - 主要审查依据 = `gh pr diff <N>` 的 patch 内容
-   - `Read` 主仓库文件 = develop 状态（**不含** PR 改动），仅供查"PR 改动周边的已有代码"
-   - `Grep` 反映 develop，不反映 PR 后状态
-   - **超出 patch 范围的判断（如"PR 改动后某函数其他调用方"）必须标 `[需确认]`，不强判 P0**
-2. **完整路径（用户可选）**：当 PR 大或需要深度审查时，提示用户：
-   ```bash
-   git fetch origin && git worktree add worktrees/<NNN>-pr<N> -b pr-<N> origin/<PR-branch>
-   ```
-   建好 worktree 后重跑 `/pr-review <N>` 自动进入情况 A。
+- 用 `--detach` 避免创建本地分支（review 只读不写）
+- 路径命名 `worktrees/review-pr<N>` 显式标记为 review 用途，与编号 worktree（`<NNN>-<name>`）的命名空间分离，不冲突
+- **复用已存在的 review worktree**：若 `worktrees/review-pr<N>` 已存在，先刷新到最新：
+  ```bash
+  git -C worktrees/review-pr<N> fetch origin <BRANCH>
+  git -C worktrees/review-pr<N> reset --hard origin/<BRANCH>       # 安全：detached + review-only
+  ```
+- **创建失败**（网络 / 权限 / origin 无该分支）→ 报错退出，提示具体失败原因，不静默回退
+
+### 输出末尾追加清理提示（仅情况 B）
+
+在阶段 5 总结输出末尾追加：
+
+```
+🧹 本次自动创建了 review worktree：worktrees/review-pr<N>
+   清理命令：git worktree remove worktrees/review-pr<N>
+```
+
+情况 A 不提示清理（不动用户既有 worktree）。
 
 ---
 
@@ -77,7 +89,7 @@ WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^work
 | `diff < 200` | 1 | 单 agent 跑全六维度 |
 | `200 ≤ diff < 600` | 2 | A：架构合规 + 测试 + 产品；B：安全 + 运维可观测 + DX |
 | `600 ≤ diff < 1500` | 3 | A：架构合规 + 测试；B：安全 + 产品；C：运维可观测 + DX |
-| `diff ≥ 1500` | 6 | 六维度各 1 agent（架构合规 / 安全 / 测试 / 运维 / DX / 产品） |
+| `diff ≥ 1500` | 6 | 六维度各 1 agent（架构合规 / 安全 / 测试 / 运维可观测 / DX / 产品） |
 
 ---
 
@@ -87,14 +99,12 @@ WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^work
 
 每个 sub-agent prompt **必须自包含**：
 
-- PR 编号 + 取 diff 命令：
+- PR 编号 + 取 diff 命令（**全部 `gh` 命令须 `dangerouslyDisableSandbox: true`**）：
   ```bash
   gh pr diff <N>                                  # 完整 patch
   gh pr view <N> --json title,body,files,headRefOid  # 元数据
   ```
-- **工作目录上下文**（来自阶段 2.5）：
-  - 情况 A：`$WORKTREE` 绝对路径 + 提示"所有 Read/Grep 路径前缀 `$WORKTREE/`"
-  - 情况 B：主仓库根路径 + 提示"只能基于 patch 审查，Read/Grep 仅反映 develop；超出 patch 范围的判断标 `[需确认]`"
+- **工作目录上下文**（来自阶段 2.5，恒有 worktree）：`$WORKTREE` 绝对路径 + 明确提示"所有 Read/Grep 路径前缀 `$WORKTREE/`"
 - 分配的维度子集（来自阶段 3 表格）
 - 必读：CLAUDE.md + `.claude/rules/gocell/*.md` 关键约束（路径相对工作目录）
 - Finding 格式（沿用 `.claude/agents/reviewer.md`）：
@@ -115,7 +125,9 @@ WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^work
 ### 5.1 去重 / 冲突裁决
 
 - 同 `文件:行号` + 同问题描述视为重复，保留证据/建议更详细的一条
-- 不同 reviewer 对同一处给出**冲突结论** → 主 agent `Read` 该处代码亲自裁决
+- 同 `文件:行号` 不同 P 级 → **保留更高 P 级**（更保守），主 agent `Read` 代码裁定是否降级
+- 同 `文件:行号` 不同 Cx → **重新评估整簇 Cx**（基于阶段 5.2 根因聚类后的整簇改动量），不简单取大
+- 不同 reviewer 对同一处给出**冲突结论**（一个标 P0 一个标 LGTM）→ 主 agent `Read` 该处代码亲自裁决
 
 ### 5.2 根因归类（不允许跳过）
 
@@ -188,7 +200,22 @@ WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^work
 
 ## 约束
 
-- 不调用 `/fix`，不写代码，不评 CI（沿用 ship Stage 7："禁止自动循环等待 CI 结束"）
+- 不调用 `/fix`，不写代码，不评 CI（禁止自动循环等待 CI 结束）
 - `gh` 命令用 `dangerouslyDisableSandbox: true`
 - 单 reviewer 路径（`diff < 200`）也走 Agent 派发，保持汇总逻辑单源
 - 主 agent **不允许**把 sub-agent Finding 原样转发——根因聚类、系统性判定、整簇 Cx 重评由主 agent 用 `Read`/`Grep` 亲自完成
+
+---
+
+## 验证清单（acceptance criteria）
+
+每次实质修改本 SKILL 后，按下列清单走一遍：
+
+1. **缺参 / 非法参数**：`/pr-review`、`/pr-review abc` → 立即输出错误并不执行后续阶段
+2. **小 PR（diff < 200）**：`/pr-review <小 PR 号>` → 派 1 个 reviewer agent，输出含根因簇视图
+3. **中 PR（600 ≤ diff < 1500）**：`/pr-review <中 PR 号>` → 派 3 个 reviewer agent 并行，主 agent 输出根因簇按主题聚类而非按维度
+4. **大 PR（diff ≥ 1500）**：派 6 个 reviewer agent 并行，六维度各一
+5. **无 worktree 自动创建**：执行前 `git worktree list` 不含 PR 分支 → 执行后 `worktrees/review-pr<N>` 存在
+6. **既有 worktree 复用**：执行前 PR 分支已有 worktree → 直接使用，不创建 `review-pr<N>`
+7. **主 agent 真做根因分析**：输出含 `Read`/`Grep` 证据；根因簇视图先于 Finding 详表
+8. **维度名内部一致**：本 SKILL 内分级表、阶段 4 派发 prompt、阶段 5 输出模板使用同一组六维度名称

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: pr-review
+description: "对指定 PR 跑一次自动分级六维度 review。按 diff 净增删行数自动分配 1/2/3/6 reviewer agent 并行；主 agent 做根因聚类 + Cx 分级 + 修复分流建议，不自动 fix。"
+argument-hint: "<PR 编号>"
+allowed-tools: [Read, Glob, Grep, Bash, Agent]
+---
+
+# GoCell PR Review — 自动分级六维度审查
+
+按 PR diff 净增删行数自动分配 1/2/3/6 个 `reviewer` agent 并行做六维度审查，主 agent 做根因聚类与修复分流建议。**只 review，不自动 fix**——Cx1/Cx2 簇仅给出 `/fix` 建议命令，由用户决定。
+
+---
+
+## 阶段 1：输入解析
+
+参数必须是 PR 编号：纯数字（`838`）或带井号（`#838`）。
+
+- 缺参 → 立即报错退出，提示用法 `/pr-review <PR 编号>`
+- 非法格式（含字母、空格、其他符号）→ 立即报错退出
+- **不进入交互**确认，保持调用简单
+
+---
+
+## 阶段 2：取 diff 行数
+
+主路径（GitHub 已计算好，无需本地 checkout）：
+
+```bash
+gh pr view <N> --json additions,deletions --jq '.additions + .deletions'
+```
+
+`gh` 命令用 `dangerouslyDisableSandbox: true`（沿用 CLAUDE.md 约定）。
+
+取不到 PR（404 / 权限） → 报错退出，提示用户检查 PR 编号与 `gh auth status`。
+
+---
+
+## 阶段 3：分级表
+
+区间左闭右开，边界归更高档：
+
+| diff 行数 | reviewer 数 | 维度切分 |
+|-----------|------------|---------|
+| `diff < 200` | 1 | 单 agent 跑全六维度 |
+| `200 ≤ diff < 600` | 2 | A：架构合规 + 测试 + 产品；B：安全 + 运维可观测 + DX |
+| `600 ≤ diff < 1500` | 3 | A：架构合规 + 测试；B：安全 + 产品；C：运维可观测 + DX |
+| `diff ≥ 1500` | 6 | 六维度各 1 agent（架构合规 / 安全 / 测试 / 运维 / DX / 产品） |
+
+---
+
+## 阶段 4：并行派发 reviewer agent
+
+单消息内多 `Agent` tool call 并行启动 `subagent_type: reviewer`（即使 `diff < 200` 单 reviewer 路径也走 Agent 派发，保持调用形态一致）。
+
+每个 sub-agent prompt **必须自包含**：
+
+- PR 编号 + 取 diff 命令：
+  ```bash
+  gh pr diff <N>                                  # 完整 patch
+  gh pr view <N> --json title,body,files,headRefOid  # 元数据
+  ```
+- 分配的维度子集（来自阶段 3 表格）
+- 必读：CLAUDE.md + `.claude/rules/gocell/*.md` 关键约束
+- Finding 格式（沿用 `.claude/agents/reviewer.md`）：
+  ```
+  [P0/P1/P2] [Cx1-Cx4] [维度] 文件:行号
+  问题: ...
+  证据: `具体代码片段`
+  建议: ...
+  ```
+- 输出要求：Finding 清单（P0→P2，同级 Cx1→Cx4）+ 复杂度汇总 + 维度内的初步判断
+
+---
+
+## 阶段 5：主 agent 分析与汇总（核心职责）
+
+收到所有 sub-agent raw Finding 后，主 agent **必须自己读关键文件、做根因分析**，不允许原样转发 sub-agent 输出。
+
+### 5.1 去重 / 冲突裁决
+
+- 同 `文件:行号` + 同问题描述视为重复，保留证据/建议更详细的一条
+- 不同 reviewer 对同一处给出**冲突结论** → 主 agent `Read` 该处代码亲自裁决
+
+### 5.2 根因归类（不允许跳过）
+
+把所有 Finding 按**共同根因**聚类，而非按文件或维度。
+
+典型根因示例（一个根因可能跨多个维度）：
+
+- "缺少 ctx 取消传播" → 运维（goroutine 泄漏）+ 测试（race）+ DX（API 不一致）
+- "errcode 未走 funnel" → 架构（违反 errcode 规约）+ 安全（PII 泄漏）+ DX（错误格式不统一）
+- "consumer 未声明 disposition" → 架构（违反 eventbus 规约）+ 运维（DLX 路由失效）+ 测试（缺失幂等测试）
+
+主 agent 用 `Grep` 验证根因是否系统性：**同一模式 ≥ 3 处 = 架构缺陷**，1-2 处 = 局部 bug。
+
+每个根因簇标注：
+
+- 涉及维度（可多个）
+- Finding 数（按 P 级拆分）
+- 系统性（是/否 + Grep 数）
+- 整簇 Cx（按修复整簇改动量重新评估，可能高于单条 Finding 的 Cx）
+
+### 5.3 输出固定 5 块（顺序固定）
+
+**1. 根因簇视图**（主输出）：
+
+```
+根因 1：<一句话描述根本问题>
+- 涉及维度：架构 + 安全
+- Finding 数：4（P0×1, P1×3）
+- 系统性：是（Grep 同模式 5 处：cells/foo/bar.go:23, cells/baz/qux.go:45, ...）
+- 整簇 Cx：Cx3（跨 3 包，需改 interface）
+- 子 Finding：F-001, F-003, F-007, F-012
+- 建议：先改 kernel/X 接口，再传播到 cells/Y, cells/Z
+```
+
+**2. 原始 Finding 清单**（详表，按 P0→P2、同级内 Cx1→Cx4 排序）：
+
+| # | 维度 | P | Cx | 文件:行号 | 问题摘要 | 所属根因簇 |
+|---|------|---|----|----------|---------|----------|
+
+**3. 复杂度汇总**（两套统计）：
+
+```
+按根因簇：Cx1: N / Cx2: N / Cx3: N / Cx4: N
+按 Finding：Cx1: N / Cx2: N / Cx3: N / Cx4: N
+```
+
+**4. 修复分流建议**（优先按根因簇，避免逐条改同文件）：
+
+- Cx1/Cx2 簇 → `/fix <PR>` 或 `/fix <根因描述>`
+- Cx3/Cx4 簇 → 标"需人工决策"，给出三级方案种子（最小 / 彻底 / 重构）
+
+**5. 总体结论**：
+
+```
+结论：LGTM / 需修复 / 需讨论
+理由：<一句话>
+```
+
+### 5.4 主 agent 反思自检（输出前强制）
+
+逐条自查：
+
+1. **是否真的读过涉及的代码？** → 至少 `Read` 每个根因簇的代表文件 1 次；没读 = 没做根因分析
+2. **根因归类是否真到了根因层？** → 问"为什么会出现这个症状"直到不能再问；停留在症状层 = 不合格
+3. **系统性判定是否有 Grep 证据？** → 没有 Grep 结果不能标"系统性 = 是"
+
+任一条不通过 → 补做再输出。
+
+---
+
+## 约束
+
+- 不调用 `/fix`，不写代码，不评 CI（沿用 ship Stage 7："禁止自动循环等待 CI 结束"）
+- `gh` 命令用 `dangerouslyDisableSandbox: true`
+- 单 reviewer 路径（`diff < 200`）也走 Agent 派发，保持汇总逻辑单源
+- 主 agent **不允许**把 sub-agent Finding 原样转发——根因聚类、系统性判定、整簇 Cx 重评由主 agent 用 `Read`/`Grep` 亲自完成

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -3,80 +3,52 @@ name: pr-review
 description: "对指定 PR 跑一次自动分级六维度 review。按 diff 净增删行数自动分配 1/2/3/6 reviewer agent 并行；主 agent 做根因聚类 + Cx 分级 + 修复分流建议，不自动 fix。"
 argument-hint: "<PR 编号>"
 allowed-tools: [Read, Glob, Grep, Bash, Agent]
+disable-model-invocation: true
 ---
 
 # GoCell PR Review — 自动分级六维度审查
 
-按 PR diff 净增删行数自动分配 1/2/3/6 个 `reviewer` agent 并行做六维度审查，主 agent 做根因聚类与修复分流建议。**只 review，不自动 fix**——Cx1/Cx2 簇仅给出 `/fix` 建议命令，由用户决定。
+按 PR diff 净增删行数自动分配 1/2/3/6 个 `reviewer` agent 并行做六维度审查，主 agent 做根因聚类与修复分流建议。**只 review，不自动 fix**。
 
 ---
 
 ## 阶段 1：输入解析
 
-参数必须是 PR 编号：纯数字（`838`）或带井号（`#838`）。
+参数必须是 PR 编号（纯数字或 `#NNN`）。
 
-- 缺参 → 立即输出 `错误：缺少 PR 编号；用法：/pr-review <PR 编号>`，不执行后续阶段
-- 非法格式（含字母、空格、其他符号）→ 立即输出 `错误：参数 "<原值>" 不是合法 PR 编号`，不执行后续阶段
-- **不进入交互**确认，保持调用简单
+- 缺参 → 输出 `错误：缺少 PR 编号；用法：/pr-review <PR 编号>`，不执行后续
+- 非法格式 → 输出 `错误：参数 "<原值>" 不是合法 PR 编号`，不执行后续
 
 ---
 
 ## 阶段 2：取 diff 行数
 
-主路径（GitHub 已计算好，无需本地 checkout）：
-
 ```bash
 gh pr view <N> --json additions,deletions --jq '.additions + .deletions'
 ```
 
-`gh` 命令用 `dangerouslyDisableSandbox: true`（沿用 CLAUDE.md 约定）。
-
-取不到 PR（404 / 权限） → 报错退出，提示用户检查 PR 编号与 `gh auth status`。
+`gh` 命令须 `dangerouslyDisableSandbox: true`。取不到 PR → 报错退出。
 
 ---
 
 ## 阶段 2.5：定位或自动创建 review worktree
-
-reviewer agent 需要在某个 worktree 内做 Read/Grep（拿到 PR 改动后的全文件 + 追溯调用链）。流程：
 
 ```bash
 BRANCH=$(gh pr view <N> --json headRefName --jq .headRefName)
 WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^worktree /{w=$2} $0=="branch "b{print w; exit}')
 ```
 
-### 情况 A：找到既有 worktree（`$WORKTREE` 非空）
+**情况 A：找到既有 worktree** → 直接用 `$WORKTREE`，不动其状态。
 
-- 直接使用 `$WORKTREE` 绝对路径
-- **不动用户的 worktree 状态**（可能有 work in progress），假定当前 HEAD 即 PR head
-- 若需要校准到最新 PR head，提示用户手动 `git -C $WORKTREE pull --ff-only origin <BRANCH>`，不自动执行
-
-### 情况 B：无既有 worktree → 自动创建 review-only worktree
+**情况 B：无既有 worktree** → 自动创建 review-only worktree：
 
 ```bash
-git fetch origin <BRANCH>                                          # dangerouslyDisableSandbox: true
-git worktree add --detach worktrees/review-pr<N> origin/<BRANCH>   # detached，不创建本地分支
+git fetch origin <BRANCH>
+git worktree add --detach worktrees/review-pr<N> origin/<BRANCH>   # 已存在则改用 git -C ... reset --hard origin/<BRANCH> 刷新
 WORKTREE="$(git rev-parse --show-toplevel)/worktrees/review-pr<N>"
 ```
 
-- 用 `--detach` 避免创建本地分支（review 只读不写）
-- 路径命名 `worktrees/review-pr<N>` 显式标记为 review 用途，与编号 worktree（`<NNN>-<name>`）的命名空间分离，不冲突
-- **复用已存在的 review worktree**：若 `worktrees/review-pr<N>` 已存在，先刷新到最新：
-  ```bash
-  git -C worktrees/review-pr<N> fetch origin <BRANCH>
-  git -C worktrees/review-pr<N> reset --hard origin/<BRANCH>       # 安全：detached + review-only
-  ```
-- **创建失败**（网络 / 权限 / origin 无该分支）→ 报错退出，提示具体失败原因，不静默回退
-
-### 输出末尾追加清理提示（仅情况 B）
-
-在阶段 5 总结输出末尾追加：
-
-```
-🧹 本次自动创建了 review worktree：worktrees/review-pr<N>
-   清理命令：git worktree remove worktrees/review-pr<N>
-```
-
-情况 A 不提示清理（不动用户既有 worktree）。
+创建失败 → 报错退出，不静默回退。情况 B 在阶段 5 末尾追加：`🧹 清理：git worktree remove worktrees/review-pr<N>`。
 
 ---
 
@@ -89,133 +61,67 @@ WORKTREE="$(git rev-parse --show-toplevel)/worktrees/review-pr<N>"
 | `diff < 200` | 1 | 单 agent 跑全六维度 |
 | `200 ≤ diff < 600` | 2 | A：架构合规 + 测试 + 产品；B：安全 + 运维可观测 + DX |
 | `600 ≤ diff < 1500` | 3 | A：架构合规 + 测试；B：安全 + 产品；C：运维可观测 + DX |
-| `diff ≥ 1500` | 6 | 六维度各 1 agent（架构合规 / 安全 / 测试 / 运维可观测 / DX / 产品） |
+| `diff ≥ 1500` | 6 | 六维度各 1 agent |
 
 ---
 
 ## 阶段 4：并行派发 reviewer agent
 
-单消息内多 `Agent` tool call 并行启动 `subagent_type: reviewer`（即使 `diff < 200` 单 reviewer 路径也走 Agent 派发，保持调用形态一致）。
+单消息内多 `Agent` tool call 并行启动 `subagent_type: reviewer`（即使 1 个也走 Agent 派发）。
 
-每个 sub-agent prompt **必须自包含**：
+每个 sub-agent prompt 必须自包含：
 
-- PR 编号 + 取 diff 命令（**全部 `gh` 命令须 `dangerouslyDisableSandbox: true`**）：
-  ```bash
-  gh pr diff <N>                                  # 完整 patch
-  gh pr view <N> --json title,body,files,headRefOid  # 元数据
-  ```
-- **工作目录上下文**（来自阶段 2.5，恒有 worktree）：`$WORKTREE` 绝对路径 + 明确提示"所有 Read/Grep 路径前缀 `$WORKTREE/`"
-- 分配的维度子集（来自阶段 3 表格）
-- 必读：CLAUDE.md + `.claude/rules/gocell/*.md` 关键约束（路径相对工作目录）
-- Finding 格式（沿用 `.claude/agents/reviewer.md`）：
-  ```
-  [P0/P1/P2] [Cx1-Cx4] [维度] 文件:行号
-  问题: ...
-  证据: `具体代码片段`
-  建议: ...
-  ```
-- 输出要求：Finding 清单（P0→P2，同级 Cx1→Cx4）+ 复杂度汇总 + 维度内的初步判断
+- PR 编号 + 取 diff 命令 `gh pr diff <N>` / `gh pr view <N> --json title,body,files,headRefOid`（**`gh` 须 `dangerouslyDisableSandbox: true`**）
+- 工作目录 `$WORKTREE` 绝对路径，所有 Read/Grep 路径前缀 `$WORKTREE/`
+- 分配的维度子集（阶段 3 表格）
+- 必读：CLAUDE.md + `.claude/rules/gocell/*.md`
+- Finding 格式、Cx 分级、输出契约 → 沿用 `.claude/agents/reviewer.md`
 
 ---
 
-## 阶段 5：主 agent 分析与汇总（核心职责）
+## 阶段 5：主 agent 分析与汇总
 
-收到所有 sub-agent raw Finding 后，主 agent **必须自己读关键文件、做根因分析**，不允许原样转发 sub-agent 输出。
+收到所有 sub-agent raw Finding 后，主 agent **必须自己读关键文件、做根因分析**，不允许原样转发。
 
 ### 5.1 去重 / 冲突裁决
 
-- 同 `文件:行号` + 同问题描述视为重复，保留证据/建议更详细的一条
-- 同 `文件:行号` 不同 P 级 → **保留更高 P 级**（更保守），主 agent `Read` 代码裁定是否降级
-- 同 `文件:行号` 不同 Cx → **重新评估整簇 Cx**（基于阶段 5.2 根因聚类后的整簇改动量），不简单取大
-- 不同 reviewer 对同一处给出**冲突结论**（一个标 P0 一个标 LGTM）→ 主 agent `Read` 该处代码亲自裁决
+- 同 `文件:行号` + 同描述 → 重复，保留更详细一条
+- 同 `文件:行号` 不同 P 级 → 保留更高 P 级，Read 代码裁定是否降级
+- 同 `文件:行号` 不同 Cx → 按 5.2 整簇重评，不简单取大
+- 冲突结论（P0 vs LGTM）→ Read 代码亲自裁决
 
 ### 5.2 根因归类（不允许跳过）
 
-把所有 Finding 按**共同根因**聚类，而非按文件或维度。
+按**共同根因**聚类（不按文件 / 不按维度）。例：`errcode 未走 funnel` → 架构 + 安全 + DX 三维度同时被命中。
 
-典型根因示例（一个根因可能跨多个维度）：
+`Grep` 验证系统性：≥ 3 处 = 架构缺陷，1-2 处 = 局部 bug。
 
-- "缺少 ctx 取消传播" → 运维（goroutine 泄漏）+ 测试（race）+ DX（API 不一致）
-- "errcode 未走 funnel" → 架构（违反 errcode 规约）+ 安全（PII 泄漏）+ DX（错误格式不统一）
-- "consumer 未声明 disposition" → 架构（违反 eventbus 规约）+ 运维（DLX 路由失效）+ 测试（缺失幂等测试）
+每簇标注：涉及维度 / Finding 数（按 P 级拆分）/ 系统性（Grep 数）/ 整簇 Cx（按整簇改动量重评）。
 
-主 agent 用 `Grep` 验证根因是否系统性：**同一模式 ≥ 3 处 = 架构缺陷**，1-2 处 = 局部 bug。
+### 5.3 输出 5 块（顺序固定）
 
-每个根因簇标注：
+**输出语言**：中文。
 
-- 涉及维度（可多个）
-- Finding 数（按 P 级拆分）
-- 系统性（是/否 + Grep 数）
-- 整簇 Cx（按修复整簇改动量重新评估，可能高于单条 Finding 的 Cx）
+1. **根因簇视图**（主输出）— 每簇：根因一句 / 维度 / Finding 数 / 系统性 / 整簇 Cx / 子 Finding ID / 修复顺序建议
+2. **Finding 详表** — 列：`# | 维度 | P | Cx | 文件:行号 | 摘要 | 所属簇`，按 P0→P2、同级 Cx1→Cx4 排序
+3. **复杂度汇总** — 按根因簇 + 按 Finding 两套：`Cx1: N / Cx2: N / Cx3: N / Cx4: N`
+4. **修复分流** — Cx1/Cx2 簇 → `/fix`；Cx3/Cx4 簇 → "需人工决策" + 三级方案种子（最小/彻底/重构）
+5. **总体结论** — `通过 / 需修复 / 需讨论` + 一句话理由
 
-### 5.3 输出固定 5 块（顺序固定）
-
-**1. 根因簇视图**（主输出）：
-
-```
-根因 1：<一句话描述根本问题>
-- 涉及维度：架构 + 安全
-- Finding 数：4（P0×1, P1×3）
-- 系统性：是（Grep 同模式 5 处：cells/foo/bar.go:23, cells/baz/qux.go:45, ...）
-- 整簇 Cx：Cx3（跨 3 包，需改 interface）
-- 子 Finding：F-001, F-003, F-007, F-012
-- 建议：先改 kernel/X 接口，再传播到 cells/Y, cells/Z
-```
-
-**2. 原始 Finding 清单**（详表，按 P0→P2、同级内 Cx1→Cx4 排序）：
-
-| # | 维度 | P | Cx | 文件:行号 | 问题摘要 | 所属根因簇 |
-|---|------|---|----|----------|---------|----------|
-
-**3. 复杂度汇总**（两套统计）：
-
-```
-按根因簇：Cx1: N / Cx2: N / Cx3: N / Cx4: N
-按 Finding：Cx1: N / Cx2: N / Cx3: N / Cx4: N
-```
-
-**4. 修复分流建议**（优先按根因簇，避免逐条改同文件）：
-
-- Cx1/Cx2 簇 → `/fix <PR>` 或 `/fix <根因描述>`
-- Cx3/Cx4 簇 → 标"需人工决策"，给出三级方案种子（最小 / 彻底 / 重构）
-
-**5. 总体结论**：
-
-```
-结论：LGTM / 需修复 / 需讨论
-理由：<一句话>
-```
-
-### 5.4 主 agent 反思自检（输出前强制）
-
-逐条自查：
-
-1. **是否真的读过涉及的代码？** → 至少 `Read` 每个根因簇的代表文件 1 次；没读 = 没做根因分析
-2. **根因归类是否真到了根因层？** → 问"为什么会出现这个症状"直到不能再问；停留在症状层 = 不合格
-3. **系统性判定是否有 Grep 证据？** → 没有 Grep 结果不能标"系统性 = 是"
-
-任一条不通过 → 补做再输出。
+输出前自检：① 每个根因簇都 Read 过代表文件？② 根因到了根本层（不停在症状）？③ 系统性判定有 Grep 证据？— 任一不通过 → 补做。
 
 ---
 
 ## 约束
 
-- 不调用 `/fix`，不写代码，不评 CI（禁止自动循环等待 CI 结束）
-- `gh` 命令用 `dangerouslyDisableSandbox: true`
-- 单 reviewer 路径（`diff < 200`）也走 Agent 派发，保持汇总逻辑单源
-- 主 agent **不允许**把 sub-agent Finding 原样转发——根因聚类、系统性判定、整簇 Cx 重评由主 agent 用 `Read`/`Grep` 亲自完成
+- 不调用 `/fix`，不写代码，不评 CI
+- `gh` 命令 `dangerouslyDisableSandbox: true`
 
 ---
 
-## 验证清单（acceptance criteria）
+## 验证清单
 
-每次实质修改本 SKILL 后，按下列清单走一遍：
-
-1. **缺参 / 非法参数**：`/pr-review`、`/pr-review abc` → 立即输出错误并不执行后续阶段
-2. **小 PR（diff < 200）**：`/pr-review <小 PR 号>` → 派 1 个 reviewer agent，输出含根因簇视图
-3. **中 PR（600 ≤ diff < 1500）**：`/pr-review <中 PR 号>` → 派 3 个 reviewer agent 并行，主 agent 输出根因簇按主题聚类而非按维度
-4. **大 PR（diff ≥ 1500）**：派 6 个 reviewer agent 并行，六维度各一
-5. **无 worktree 自动创建**：执行前 `git worktree list` 不含 PR 分支 → 执行后 `worktrees/review-pr<N>` 存在
-6. **既有 worktree 复用**：执行前 PR 分支已有 worktree → 直接使用，不创建 `review-pr<N>`
-7. **主 agent 真做根因分析**：输出含 `Read`/`Grep` 证据；根因簇视图先于 Finding 详表
-8. **维度名内部一致**：本 SKILL 内分级表、阶段 4 派发 prompt、阶段 5 输出模板使用同一组六维度名称
+1. 缺参 / 非法参数 → 立即输出错误，不执行后续
+2. 分级派发：按 diff 行数派 1/2/3/6 个 reviewer agent（覆盖四档）
+3. 无 worktree 自动创建 `worktrees/review-pr<N>`；既有 worktree 复用，不重建
+4. 主 agent 输出含 Read/Grep 证据 + 根因簇视图先于 Finding 详表；维度名内部一致


### PR DESCRIPTION
## Summary

- 新增 `.claude/skills/pr-review/SKILL.md`：从 ship Stage 7 抽出"按 diff 行数 1/2/3/6 自动分配 reviewer"逻辑，独立成 `/pr-review <PR 编号>` 技能
- 输入 PR 编号 → `gh pr view --json additions,deletions` 取行数 → 分级表派发 1/2/3/6 个 `reviewer` agent 并行 → 主 agent 做根因聚类 + Cx 分级 + 修复分流建议
- **只 review，不自动 fix**：Cx1/Cx2 簇只给出 `/fix` 建议命令，由用户决定
- 命名避开系统内置 `review` / `code-review` / `security-review` 与项目 agent 名 `reviewer`
- 主 agent 必须 `Read`/`Grep` 亲自做根因分析，不允许原样转发 sub-agent 输出

## 与 ship Stage 7 的关系

- 分级表（< 200 / 200-600 / 600-1500 / ≥ 1500 → 1/2/3/6 reviewer）规则一致
- 维度切分一致（六维度切分到不同 agent）
- ship 内部 Stage 7 保持不变，两个技能独立演进，避免互相影响

## Test plan

- [ ] `/pr-review` 在可用 skills 列表中可见
- [ ] `/pr-review <小 PR 号（< 200 行）>` → 启动 1 个 reviewer agent
- [ ] `/pr-review <中 PR 号（≥ 600 行）>` → 启动 3 个 reviewer agent 并行
- [ ] `/pr-review`（缺参）/ `/pr-review abc`（非数字）→ 立即报错退出
- [ ] 主 agent 输出含根因簇视图（每簇标注涉及维度 + 系统性 Grep 数 + 整簇 Cx），而非简单合并

Refs: ship skill Stage 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)