### PR TITLE
test(rbacassign): L2 PG outbox atomicity failure proof (#655)

### DIFF
--- a/tests/integration/l2atomicity/helpers_test.go
+++ b/tests/integration/l2atomicity/helpers_test.go
@@ -450,16 +450,16 @@ func countLiveRefreshTokensForSubject(t *testing.T, h *l2Harness, subjectID stri
 }
 
 // assignRole calls POST /internal/v1/access/roles/assign with a service token
-// signed for the "accesscore" caller cell. Inlined literal is required by the
-// SVCTOKEN-CALLER-CELL-REQUIRED-01 archtest: every GenerateServiceToken call
-// must pass a string literal in the callerCell position so the caller-cell
-// allowlist can be statically verified.
+// signed for the "accesscore" caller cell. The "accesscore" callerCell literal
+// is required by the SVCTOKEN-CALLER-CELL-REQUIRED-01 archtest: every
+// GenerateServiceToken call must pass a string literal in the callerCell
+// position so the caller-cell allowlist can be statically verified.
 func assignRole(t *testing.T, h *l2Harness, userID, roleID string) {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{"userId": userID, "roleId": roleID})
 	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost,
-		"/internal/v1/access/roles/assign", "", time.Now())
-	req, _ := http.NewRequest(http.MethodPost, h.internalBase+"/internal/v1/access/roles/assign",
+		internalPathRolesAssign, "", time.Now())
+	req, _ := http.NewRequest(http.MethodPost, h.internalBase+internalPathRolesAssign,
 		bytes.NewReader(body))
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -478,8 +478,8 @@ func revokeRole(t *testing.T, h *l2Harness, userID, roleID string) {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{"userId": userID, "roleId": roleID})
 	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost,
-		"/internal/v1/access/roles/revoke", "", time.Now())
-	req, _ := http.NewRequest(http.MethodPost, h.internalBase+"/internal/v1/access/roles/revoke",
+		internalPathRolesRevoke, "", time.Now())
+	req, _ := http.NewRequest(http.MethodPost, h.internalBase+internalPathRolesRevoke,
 		bytes.NewReader(body))
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	req.Header.Set("Content-Type", "application/json")

--- a/tests/integration/l2atomicity/helpers_test.go
+++ b/tests/integration/l2atomicity/helpers_test.go
@@ -20,6 +20,19 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
+// Internal API paths for rbacassign endpoints. Shared by assignRole /
+// revokeRole and the failure-injection variants in
+// rbacassign_atomicity_failureproof_e2e_test.go. Lives here (helpers_test.go)
+// so the helpers' compile dependency does not point at a test file that may
+// be deleted/renamed when an atomicity test pattern shifts. The
+// SVCTOKEN-CALLER-CELL-REQUIRED-01 archtest only constrains the callerCell
+// argument of GenerateServiceToken (must be a string literal), not the path
+// argument — so promoting the path to a const is safe.
+const (
+	internalPathRolesAssign = "/internal/v1/access/roles/assign"
+	internalPathRolesRevoke = "/internal/v1/access/roles/revoke"
+)
+
 // loginResult holds the parsed login/refresh response fields.
 type loginResult struct {
 	AccessToken  string

--- a/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+
+package l2atomicity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// Topic literals are kept inlined (not imported from
+// cells/accesscore/internal/dto) because the tests/integration/l2atomicity
+// package cannot import internal/. Same "expected duplication" rationale as
+// eventRoleRevokedV1 in revoke_cascade_e2e_test.go: if the producer-side
+// constant changes, this test must be updated in lockstep — and will visibly
+// fail when the new event type fails to be intercepted by selectiveFailWriter.
+const (
+	topicRoleAssignedV1 = "event.role.assigned.v1"
+	topicRoleRevokedV1  = "event.role.revoked.v1"
+)
+
+// simulatedOutboxErr is the sentinel returned by selectiveFailWriter when it
+// chooses to fail. The contents are observable only in slog (the framework
+// span recorder redacts before reaching the wire); we only assert that the
+// HTTP layer surfaces a 5xx envelope.
+var simulatedOutboxErr = errors.New("simulated outbox write failure (RBACASSIGN-L2-PG-ATOMICITY-01)")
+
+// selectiveFailWriter wraps a real outbox.Writer and returns simulatedOutboxErr
+// when an entry's EventType matches failType.Load().(string). Atomic store
+// allows tests to flip behavior mid-run without rebuilding the harness:
+// "setup phase passes through → trigger window fails on specific event class".
+//
+// The inner writer is the real adapterpg.NewOutboxWriter so the pass-through
+// path exercises full PG outbox semantics; only the fail path short-circuits.
+type selectiveFailWriter struct {
+	inner    outbox.Writer
+	failType atomic.Value // string
+}
+
+func (w *selectiveFailWriter) Write(ctx context.Context, entry outbox.Entry) error {
+	if t, _ := w.failType.Load().(string); t != "" && entry.EventType == t {
+		return simulatedOutboxErr
+	}
+	return w.inner.Write(ctx, entry)
+}
+
+// newSelectiveFailWriter constructs a selectiveFailWriter that delegates to a
+// fresh adapterpg.NewOutboxWriter and starts in pass-through mode.
+func newSelectiveFailWriter() *selectiveFailWriter {
+	w := &selectiveFailWriter{inner: adapterpg.NewOutboxWriter(clock.Real())}
+	w.failType.Store("")
+	return w
+}
+
+// roleAssignmentCount returns the number of role_assignments rows for
+// (userID, roleID). Inlined rather than added to helpers_test.go so the
+// helper remains scoped to the only test that needs it; if a future test
+// adopts the same query, hoist then.
+func roleAssignmentCount(t *testing.T, h *l2Harness, userID, roleID string) int {
+	t.Helper()
+	var n int
+	err := h.pool.DB().QueryRow(context.Background(),
+		`SELECT count(*) FROM role_assignments WHERE user_id = $1 AND role_id = $2`,
+		userID, roleID).Scan(&n)
+	require.NoError(t, err)
+	return n
+}
+
+// postRoleEndpoint posts to /internal/v1/access/roles/{action} with a service
+// token signed for "accesscore" and returns the status code. Inlined rather
+// than parameterized into assignRole/revokeRole because the failure path
+// requires a non-201/200 response which the existing helpers reject via
+// require.Equal — modifying the helpers would loosen guarantees relied on by
+// happy-path tests.
+//
+// Caller-cell literal "accesscore" is required by SVCTOKEN-CALLER-CELL-REQUIRED-01
+// archtest (string literal at GenerateServiceToken callsite).
+func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string) int {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"userId": userID, "roleId": roleID})
+	path := "/internal/v1/access/roles/" + action
+	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, path, "", time.Now())
+	req, _ := http.NewRequest(http.MethodPost, h.internalBase+path, bytes.NewReader(body))
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode
+}
+
+// ---------------------------------------------------------------------------
+// TestL2_RbacAssign_OutboxWriteFailure_RollsBack (RBACASSIGN-L2-PG-ATOMICITY-01)
+// ---------------------------------------------------------------------------
+
+// TestL2_RbacAssign_OutboxWriteFailure_RollsBack proves that when the outbox
+// writer fails inside rbacassign.Service.Assign's transaction, the domain
+// write (role_assignments INSERT via PGRoleRepo.AssignToUser) rolls back
+// atomically and no row persists.
+//
+// Mirrors TestAuditLedgerStore_OutboxAtomicityFailureProof
+// (adapters/postgres/audit_ledger_store_test.go AUDITAPPEND-L2-FAILURE-PROOF-01)
+// but injects failure at the writer layer (where issue #655 specifies — "故意
+// fail writer") rather than the txRunner closure. Drives the full HTTP →
+// service-token-auth → handler → service → persistChange → emitter →
+// writer.Write chain so the rollback proof covers the L2 production path
+// rather than the slice service in isolation.
+//
+// ref: adapters/postgres/audit_ledger_store_test.go:335-392
+// ref: Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
+func TestL2_RbacAssign_OutboxWriteFailure_RollsBack(t *testing.T) {
+	sw := newSelectiveFailWriter()
+	h := newL2HarnessWithWriter(t, sw)
+
+	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
+	const victimUsername = "l2-rbac-atomicity-assign-user"
+	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
+		victimUsername, "rbac-atomicity-assign@l2.local", "VictimPass!99")
+
+	require.Equal(t, 0, roleAssignmentCount(t, h, victimID, "editor"),
+		"baseline: victim must not yet hold editor role")
+
+	// Trigger window: only event.role.assigned.v1 will fail at the writer.
+	sw.failType.Store(topicRoleAssignedV1)
+
+	status := postRoleEndpoint(t, h, "assign", victimID, "editor")
+	require.GreaterOrEqual(t, status, 500,
+		"role assign must surface 5xx when outbox writer fails (got %d)", status)
+	require.Less(t, status, 600,
+		"role assign must surface 5xx (not pass through 2xx) when outbox writer fails (got %d)", status)
+
+	// Rollback proof: domain write did NOT persist despite RoleRepo.AssignToUser
+	// returning success — the TxManager rolled back when the writer failed.
+	assert.Equal(t, 0, roleAssignmentCount(t, h, victimID, "editor"),
+		"role_assignments row MUST NOT persist after outbox-write failure rollback")
+
+	// Negative control: with the trigger cleared, the same call path must
+	// succeed and the row must appear. Guards against the false-positive
+	// where setup itself is broken and the prior assertion would trivially
+	// hold regardless of rollback semantics.
+	sw.failType.Store("")
+	assignRole(t, h, victimID, "editor") // existing helper requires 201
+	assert.Equal(t, 1, roleAssignmentCount(t, h, victimID, "editor"),
+		"control: role_assignments row MUST persist on happy path")
+}
+
+// ---------------------------------------------------------------------------
+// TestL2_RbacRevoke_OutboxWriteFailure_RollsBack (RBACASSIGN-L2-PG-ATOMICITY-01)
+// ---------------------------------------------------------------------------
+
+// TestL2_RbacRevoke_OutboxWriteFailure_RollsBack proves the stronger L2
+// invariant for the Revoke path: when the outbox writer fails, the
+// credentialinvalidate.Invalidator cascade
+// (BumpAuthzEpoch + RevokeForSubject + RevokeUser) rolls back atomically
+// alongside the role deletion. Verifies four DB columns are restored to
+// their pre-call values, proving funnel co-rollback at L2.
+//
+// Setup is driven through the pass-through writer path so role assignment +
+// login + session/refresh chain creation all succeed normally. The failure
+// window is opened only for event.role.revoked.v1 immediately before the
+// revoke call.
+func TestL2_RbacRevoke_OutboxWriteFailure_RollsBack(t *testing.T) {
+	sw := newSelectiveFailWriter()
+	h := newL2HarnessWithWriter(t, sw)
+
+	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
+	const victimUsername = "l2-rbac-atomicity-revoke-user"
+	const victimPassword = "VictimPass!99"
+	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
+		victimUsername, "rbac-atomicity-revoke@l2.local", victimPassword)
+
+	// Setup phase: pass-through writer. Assign role + create 2 live sessions
+	// (each session issues 1 refresh chain → 2 live refresh chains for the
+	// subject).
+	assignRole(t, h, victimID, "editor")
+	_ = httpLogin(t, h.base, victimUsername, victimPassword)
+	_ = httpLogin(t, h.base, victimUsername, victimPassword)
+
+	require.Equal(t, 1, roleAssignmentCount(t, h, victimID, "editor"),
+		"setup: editor role must be assigned before revoke attempt")
+	require.Equal(t, 2, countLiveSessions(t, h, victimID),
+		"setup: victim must have 2 live sessions before revoke attempt")
+	require.Equal(t, 2, countLiveRefreshTokensForSubject(t, h, victimID),
+		"setup: victim must have 2 live refresh chains before revoke attempt")
+	epochBefore := queryUserAuthzEpoch(t, h, victimID)
+
+	// Trigger window: only event.role.revoked.v1 will fail at the writer.
+	sw.failType.Store(topicRoleRevokedV1)
+
+	status := postRoleEndpoint(t, h, "revoke", victimID, "editor")
+	require.GreaterOrEqual(t, status, 500,
+		"role revoke must surface 5xx when outbox writer fails (got %d)", status)
+	require.Less(t, status, 600,
+		"role revoke must surface 5xx (not pass through 2xx) when outbox writer fails (got %d)", status)
+
+	// Funnel co-rollback proof: all four mutations must be undone atomically
+	// with the outbox failure. The credentialinvalidate.Invalidator funnel
+	// (BumpAuthzEpoch + RevokeForSubject + RevokeUser) is wired into the same
+	// txCtx as the role-repo mutation; the writer failure short-circuits the
+	// closure before commit, and the TxManager rolls back every PG mutation.
+	assert.Equal(t, 1, roleAssignmentCount(t, h, victimID, "editor"),
+		"role_assignments row MUST NOT be removed after outbox-write failure rollback")
+	assert.Equal(t, epochBefore, queryUserAuthzEpoch(t, h, victimID),
+		"users.authz_epoch MUST NOT advance after outbox-write failure rollback")
+	assert.Equal(t, 2, countLiveSessions(t, h, victimID),
+		"sessions MUST NOT be revoked after outbox-write failure rollback")
+	assert.Equal(t, 2, countLiveRefreshTokensForSubject(t, h, victimID),
+		"refresh chains MUST NOT be revoked after outbox-write failure rollback")
+
+	// Negative control: with the trigger cleared, the revoke must succeed
+	// and all four state fields must flip — proving the funnel is wired
+	// (without this control, the prior assertions could trivially hold even
+	// if BumpAuthzEpoch / RevokeForSubject / RevokeUser were no-ops).
+	sw.failType.Store("")
+	revokeRole(t, h, victimID, "editor") // existing helper requires 200
+
+	assert.Equal(t, 0, roleAssignmentCount(t, h, victimID, "editor"),
+		"control: role_assignments row MUST be removed on happy revoke")
+	assert.Greater(t, queryUserAuthzEpoch(t, h, victimID), epochBefore,
+		"control: users.authz_epoch MUST advance on happy revoke")
+	assert.Equal(t, 0, countLiveSessions(t, h, victimID),
+		"control: sessions MUST be revoked on happy revoke")
+	assert.Equal(t, 0, countLiveRefreshTokensForSubject(t, h, victimID),
+		"control: refresh chains MUST be revoked on happy revoke")
+}

--- a/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
@@ -34,15 +34,6 @@ const (
 	eventRoleAssignedV1 = "event.role.assigned.v1"
 )
 
-// Internal API path constants used by postRoleEndpoint. Extracted here so the
-// construction point is a single string operation; assignRole/revokeRole in
-// helpers_test.go retain their literal strings because the SVCTOKEN-CALLER-CELL-REQUIRED-01
-// archtest only constrains the callerCell argument, not the path argument.
-const (
-	internalPathRolesAssign = "/internal/v1/access/roles/assign"
-	internalPathRolesRevoke = "/internal/v1/access/roles/revoke"
-)
-
 // victimPassword is the test fixture password used in both atomicity tests.
 // Test fixture; ephemeral integration env.
 const victimPassword = "VictimPass!99"
@@ -116,8 +107,10 @@ func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string)
 	switch action {
 	case "assign":
 		path = internalPathRolesAssign
-	default:
+	case "revoke":
 		path = internalPathRolesRevoke
+	default:
+		t.Fatalf("postRoleEndpoint: unknown action %q (expected \"assign\" or \"revoke\")", action)
 	}
 	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, path, "", time.Now())
 	req, _ := http.NewRequest(http.MethodPost, h.internalBase+path, bytes.NewReader(body))

--- a/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
@@ -27,16 +27,30 @@ import (
 // package cannot import internal/. Same "expected duplication" rationale as
 // eventRoleRevokedV1 in revoke_cascade_e2e_test.go: if the producer-side
 // constant changes, this test must be updated in lockstep — and will visibly
-// fail when the new event type fails to be intercepted by selectiveFailWriter.
+// fail in the inject-failure window when the new event type fails to be
+// intercepted. The negative-control path clears failType and is topic-agnostic
+// by design.
 const (
-	topicRoleAssignedV1 = "event.role.assigned.v1"
-	topicRoleRevokedV1  = "event.role.revoked.v1"
+	eventRoleAssignedV1 = "event.role.assigned.v1"
 )
+
+// Internal API path constants used by postRoleEndpoint. Extracted here so the
+// construction point is a single string operation; assignRole/revokeRole in
+// helpers_test.go retain their literal strings because the SVCTOKEN-CALLER-CELL-REQUIRED-01
+// archtest only constrains the callerCell argument, not the path argument.
+const (
+	internalPathRolesAssign = "/internal/v1/access/roles/assign"
+	internalPathRolesRevoke = "/internal/v1/access/roles/revoke"
+)
+
+// victimPassword is the test fixture password used in both atomicity tests.
+// Test fixture; ephemeral integration env.
+const victimPassword = "VictimPass!99"
 
 // simulatedOutboxErr is the sentinel returned by selectiveFailWriter when it
 // chooses to fail. The contents are observable only in slog (the framework
 // span recorder redacts before reaching the wire); we only assert that the
-// HTTP layer surfaces a 5xx envelope.
+// HTTP layer surfaces a 500 envelope.
 var simulatedOutboxErr = errors.New("simulated outbox write failure (RBACASSIGN-L2-PG-ATOMICITY-01)")
 
 // selectiveFailWriter wraps a real outbox.Writer and returns simulatedOutboxErr
@@ -47,21 +61,25 @@ var simulatedOutboxErr = errors.New("simulated outbox write failure (RBACASSIGN-
 // The inner writer is the real adapterpg.NewOutboxWriter so the pass-through
 // path exercises full PG outbox semantics; only the fail path short-circuits.
 type selectiveFailWriter struct {
-	inner    outbox.Writer
-	failType atomic.Value // string
+	inner     outbox.Writer
+	failType  atomic.Value // string
+	failCount atomic.Int64
 }
 
 func (w *selectiveFailWriter) Write(ctx context.Context, entry outbox.Entry) error {
 	if t, _ := w.failType.Load().(string); t != "" && entry.EventType == t {
+		w.failCount.Add(1)
 		return simulatedOutboxErr
 	}
 	return w.inner.Write(ctx, entry)
 }
 
-// newSelectiveFailWriter constructs a selectiveFailWriter that delegates to a
-// fresh adapterpg.NewOutboxWriter and starts in pass-through mode.
-func newSelectiveFailWriter() *selectiveFailWriter {
-	w := &selectiveFailWriter{inner: adapterpg.NewOutboxWriter(clock.Real())}
+// newSelectiveFailWriter constructs a selectiveFailWriter that delegates to the
+// provided inner writer and starts in pass-through mode. The caller supplies
+// inner explicitly so the injected writer and the cell-wired writer are
+// provably the same instance.
+func newSelectiveFailWriter(inner outbox.Writer) *selectiveFailWriter {
+	w := &selectiveFailWriter{inner: inner}
 	w.failType.Store("")
 	return w
 }
@@ -89,10 +107,18 @@ func roleAssignmentCount(t *testing.T, h *l2Harness, userID, roleID string) int 
 //
 // Caller-cell literal "accesscore" is required by SVCTOKEN-CALLER-CELL-REQUIRED-01
 // archtest (string literal at GenerateServiceToken callsite).
+//
+// The caller owns all status-code assertions; this helper does not require any specific status.
 func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string) int {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{"userId": userID, "roleId": roleID})
-	path := "/internal/v1/access/roles/" + action
+	var path string
+	switch action {
+	case "assign":
+		path = internalPathRolesAssign
+	default:
+		path = internalPathRolesRevoke
+	}
 	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, path, "", time.Now())
 	req, _ := http.NewRequest(http.MethodPost, h.internalBase+path, bytes.NewReader(body))
 	req.Header.Set("Authorization", "ServiceToken "+token)
@@ -124,30 +150,38 @@ func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string)
 // ref: adapters/postgres/audit_ledger_store_test.go:335-392
 // ref: Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
 func TestL2_RbacAssign_OutboxWriteFailure_RollsBack(t *testing.T) {
-	sw := newSelectiveFailWriter()
+	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
 	h := newL2HarnessWithWriter(t, sw)
+	ctx := context.Background()
 
 	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
 	const victimUsername = "l2-rbac-atomicity-assign-user"
 	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
-		victimUsername, "rbac-atomicity-assign@l2.local", "VictimPass!99")
+		victimUsername, "rbac-atomicity-assign@l2.local", victimPassword)
 
 	require.Equal(t, 0, roleAssignmentCount(t, h, victimID, "editor"),
 		"baseline: victim must not yet hold editor role")
 
+	auditBefore := countAuditEntries(t, ctx, h, eventRoleAssignedV1)
+
 	// Trigger window: only event.role.assigned.v1 will fail at the writer.
-	sw.failType.Store(topicRoleAssignedV1)
+	sw.failType.Store(eventRoleAssignedV1)
 
 	status := postRoleEndpoint(t, h, "assign", victimID, "editor")
-	require.GreaterOrEqual(t, status, 500,
-		"role assign must surface 5xx when outbox writer fails (got %d)", status)
-	require.Less(t, status, 600,
-		"role assign must surface 5xx (not pass through 2xx) when outbox writer fails (got %d)", status)
+	require.Equal(t, http.StatusInternalServerError, status,
+		"role assign must surface 500 when outbox writer fails")
+
+	require.Equal(t, int64(1), sw.failCount.Load(),
+		"writer.Write must have been invoked exactly once before transaction rollback")
 
 	// Rollback proof: domain write did NOT persist despite RoleRepo.AssignToUser
 	// returning success — the TxManager rolled back when the writer failed.
-	assert.Equal(t, 0, roleAssignmentCount(t, h, victimID, "editor"),
+	require.Equal(t, 0, roleAssignmentCount(t, h, victimID, "editor"),
 		"role_assignments row MUST NOT persist after outbox-write failure rollback")
+
+	// Audit-silence proof: no audit entry must appear for the aborted assign.
+	require.Equal(t, auditBefore, countAuditEntries(t, ctx, h, eventRoleAssignedV1),
+		"rollback: no audit entry must appear for aborted assign")
 
 	// Negative control: with the trigger cleared, the same call path must
 	// succeed and the row must appear. Guards against the false-positive
@@ -175,12 +209,12 @@ func TestL2_RbacAssign_OutboxWriteFailure_RollsBack(t *testing.T) {
 // window is opened only for event.role.revoked.v1 immediately before the
 // revoke call.
 func TestL2_RbacRevoke_OutboxWriteFailure_RollsBack(t *testing.T) {
-	sw := newSelectiveFailWriter()
+	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
 	h := newL2HarnessWithWriter(t, sw)
+	ctx := context.Background()
 
 	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
 	const victimUsername = "l2-rbac-atomicity-revoke-user"
-	const victimPassword = "VictimPass!99"
 	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
 		victimUsername, "rbac-atomicity-revoke@l2.local", victimPassword)
 
@@ -199,28 +233,35 @@ func TestL2_RbacRevoke_OutboxWriteFailure_RollsBack(t *testing.T) {
 		"setup: victim must have 2 live refresh chains before revoke attempt")
 	epochBefore := queryUserAuthzEpoch(t, h, victimID)
 
+	auditBefore := countAuditEntries(t, ctx, h, eventRoleRevokedV1)
+
 	// Trigger window: only event.role.revoked.v1 will fail at the writer.
-	sw.failType.Store(topicRoleRevokedV1)
+	sw.failType.Store(eventRoleRevokedV1)
 
 	status := postRoleEndpoint(t, h, "revoke", victimID, "editor")
-	require.GreaterOrEqual(t, status, 500,
-		"role revoke must surface 5xx when outbox writer fails (got %d)", status)
-	require.Less(t, status, 600,
-		"role revoke must surface 5xx (not pass through 2xx) when outbox writer fails (got %d)", status)
+	require.Equal(t, http.StatusInternalServerError, status,
+		"role revoke must surface 500 when outbox writer fails")
+
+	require.Equal(t, int64(1), sw.failCount.Load(),
+		"writer.Write must have been invoked exactly once before transaction rollback")
 
 	// Funnel co-rollback proof: all four mutations must be undone atomically
 	// with the outbox failure. The credentialinvalidate.Invalidator funnel
 	// (BumpAuthzEpoch + RevokeForSubject + RevokeUser) is wired into the same
 	// txCtx as the role-repo mutation; the writer failure short-circuits the
 	// closure before commit, and the TxManager rolls back every PG mutation.
-	assert.Equal(t, 1, roleAssignmentCount(t, h, victimID, "editor"),
+	require.Equal(t, 1, roleAssignmentCount(t, h, victimID, "editor"),
 		"role_assignments row MUST NOT be removed after outbox-write failure rollback")
-	assert.Equal(t, epochBefore, queryUserAuthzEpoch(t, h, victimID),
+	require.Equal(t, epochBefore, queryUserAuthzEpoch(t, h, victimID),
 		"users.authz_epoch MUST NOT advance after outbox-write failure rollback")
-	assert.Equal(t, 2, countLiveSessions(t, h, victimID),
+	require.Equal(t, 2, countLiveSessions(t, h, victimID),
 		"sessions MUST NOT be revoked after outbox-write failure rollback")
-	assert.Equal(t, 2, countLiveRefreshTokensForSubject(t, h, victimID),
+	require.Equal(t, 2, countLiveRefreshTokensForSubject(t, h, victimID),
 		"refresh chains MUST NOT be revoked after outbox-write failure rollback")
+
+	// Audit-silence proof: no audit entry must appear for the aborted revoke.
+	require.Equal(t, auditBefore, countAuditEntries(t, ctx, h, eventRoleRevokedV1),
+		"rollback: no audit entry must appear for aborted revoke")
 
 	// Negative control: with the trigger cleared, the revoke must succeed
 	// and all four state fields must flip — proving the funnel is wired


### PR DESCRIPTION
## Summary

Adds two integration tests proving rbacassign's L2 atomicity invariant: when
the outbox writer fails inside `Service.Assign` / `Service.Revoke`'s
transaction, the entire transaction rolls back and no domain state persists.

Closes #655 (RBACASSIGN-L2-PG-ATOMICITY-01).

## What

- `TestL2_RbacAssign_OutboxWriteFailure_RollsBack` — drives the full HTTP →
  internal-listener service-token auth → handler → service → emitter →
  PG outbox writer chain; fails the writer on `event.role.assigned.v1`,
  asserts no `role_assignments` row persists, then clears the trigger and
  asserts the happy path re-populates the row (negative-control against the
  false positive where setup itself is broken).
- `TestL2_RbacRevoke_OutboxWriteFailure_RollsBack` — same shape, fails the
  writer on `event.role.revoked.v1`, asserts the **full
  `credentialinvalidate` funnel co-rollback**: `role_assignments` row
  retained, `users.authz_epoch` unchanged, all victim sessions still live,
  all victim refresh chains still live. Happy-path negative-control flips
  every column.

## Implementation seam

Reuses `tests/integration/l2atomicity/harness_test.go:244`
`newL2HarnessWithWriter(t *testing.T, pgOutboxOverride outbox.Writer)` — a
previously zero-caller seam that boots the full PG-backed
accesscore+configcore+auditcore assembly with three listeners and exposes
exactly one `outbox.Writer` injection point. Built for this kind of failure
injection.

Inline `selectiveFailWriter` (~12 LOC) delegates to the real
`adapterpg.NewOutboxWriter` and only short-circuits when entry.EventType
matches an `atomic.Value`-stored trigger. Lets setup phase (assign role,
create sessions, refresh chains) run through the real PG outbox writer
before flipping to the failure window for the SUT call.

## Test plan

- [x] `go test -tags=integration -count=1 -timeout 5m ./tests/integration/l2atomicity/ -run 'TestL2_RbacAssign_OutboxWriteFailure_RollsBack|TestL2_RbacRevoke_OutboxWriteFailure_RollsBack' -v` — both tests PASS (10.2s, two PG containers)
- [x] `go test -tags=integration -count=1 -timeout 15m ./tests/integration/l2atomicity/...` — full package PASS (26.8s, 11 tests, sibling tests unaffected)
- [x] `go build -tags=integration ./...` — clean
- [x] `go vet -tags=integration ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI integration-test job green (post-push)

## Scope decisions surfaced

`go-standards.md` L2 row requires "outbox 原子性测试" for every L2 slice.
Survey during plan: **12 L2 units in the codebase, only 1 had atomicity
test today** (auditcore at the store level). rbacassign becomes #2 with
this PR. A backlog issue
`L2-OUTBOX-ATOMICITY-COVERAGE-HARD-01` will be filed after merge to
drive the remaining ~10 backfill + a Hard archtest enforcing
"every L2 slice has its atomicity test" (requires prior ADR work to
classify producer vs consumer-only L2 slices since auditappend* have a
different L2 invariant from rbacassign).

This PR deliberately does **not** introduce a new archtest constraint —
ai-collab.md "carry-over Soft" applies (this PR doesn't introduce a new
constraint, the Soft state pre-existed and is not made worse).

## Refs

- `adapters/postgres/audit_ledger_store_test.go:335-392` (AUDITAPPEND-L2-FAILURE-PROOF-01) — pattern template
- `tests/integration/l2atomicity/harness_test.go:244` — zero-caller seam now in use
- `cells/accesscore/slices/rbacassign/service.go:141-165` — SUT (`persistChange`)
- Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
- ThreeDotsLabs/watermill-sql subscriber atomicity test pattern