### PR TITLE
refactor(archtest): migrate matrix to nightly + add local parallel fan-out

### DIFF
--- a/.claude/rules/gocell/ai-collab.md
+++ b/.claude/rules/gocell/ai-collab.md
@@ -66,7 +66,7 @@
 - 同主题规则 ≥ 3 → `{theme}_invariants_test.go` 主题文件；已有单文件升到第 3 条时重命名
 - 每个 `*_test.go` 在文件头 CommentGroup 写 `// INVARIANT: <ID>`；多规则文件用 `//   - INVARIANT: <ID>` 列表续行
 
-archtest CI 入口是 `.github/workflows/archtest-nightly.yml`（schedule + workflow_dispatch，16-shard matrix），失败自动开 P0 issue；PR / push CI 不再跑 archtest。本地 PR-time 反馈通过 `hack/githooks/pre-push`（`SHARD_COUNT=4` 并行 fan-out via `hack/verify-archtest.sh`）。`hack/verify-archtest.sh` 三种 execution mode 由 env shape 派生：`SHARD_TARGET` 设 → 单 shard（CI matrix）；`SHARD_COUNT=1` → 单进程流式（local default）；`SHARD_COUNT>1` 无 `SHARD_TARGET` → 并行 fan-out。CI 显式 `SHARD_COUNT=16`（GHA 7 GB RSS 约束）由 `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` archtest 守卫（step-scoped match-all）。`ARCHTEST-VERIFY-COVERAGE-01` 守卫 script discovery 与 *_test.go AST 集合一致，防止 shard 漏 test。
+archtest CI 入口是 `.github/workflows/archtest-nightly.yml`（schedule + workflow_dispatch，16-shard matrix）；PR / push CI 不再跑 archtest，失败靠 GHA 默认邮件通知 + Actions UI + `workflow_dispatch` rerun。本地反馈走开发者显式触发：`make verify` 一键全跑（含 archtest）或 `bash hack/verify-archtest.sh` 直跑；`hack/githooks/pre-push` 因 CPU/RSS 预算不跑 archtest（详见 ADR §"pre-push archtest 撤回"）。`hack/verify-archtest.sh` 三种 execution mode 由 env shape 派生：`SHARD_TARGET` 设 → 单 shard（CI matrix）；`SHARD_COUNT=1` → 单进程流式（local default）；`SHARD_COUNT>1` 无 `SHARD_TARGET` → 并行 fan-out。CI 显式 `SHARD_COUNT=16`（GHA 7 GB RSS 约束）由 `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` archtest 守卫（step-scoped match-all）。`ARCHTEST-VERIFY-COVERAGE-01` 守卫 script discovery 与 *_test.go AST 集合一致，防止 shard 漏 test。
 
 ## Review checklist
 

--- a/.claude/rules/gocell/ai-collab.md
+++ b/.claude/rules/gocell/ai-collab.md
@@ -66,7 +66,7 @@
 - 同主题规则 ≥ 3 → `{theme}_invariants_test.go` 主题文件；已有单文件升到第 3 条时重命名
 - 每个 `*_test.go` 在文件头 CommentGroup 写 `// INVARIANT: <ID>`；多规则文件用 `//   - INVARIANT: <ID>` 列表续行
 
-archtest CI 入口是 `hack/verify-archtest.sh`（process-isolated shards；`make verify` 自动发现）。CI 显式 `SHARD_COUNT=16`（GHA 7 GB RSS 约束）；本地默认 `SHARD_COUNT=1`（单进程共享 cache、最低 CPU）。两值差异编码 "CI vs 本地上下文"，无 SYNC 守卫。`ARCHTEST-VERIFY-COVERAGE-01` 守卫 script discovery 与 *_test.go AST 集合一致，防止 shard 漏 test。
+archtest CI 入口是 `.github/workflows/archtest-nightly.yml`（schedule + workflow_dispatch，16-shard matrix），失败自动开 P0 issue；PR / push CI 不再跑 archtest。本地 PR-time 反馈通过 `hack/githooks/pre-push`（`SHARD_COUNT=4` 并行 fan-out via `hack/verify-archtest.sh`）。`hack/verify-archtest.sh` 三种 execution mode 由 env shape 派生：`SHARD_TARGET` 设 → 单 shard（CI matrix）；`SHARD_COUNT=1` → 单进程流式（local default）；`SHARD_COUNT>1` 无 `SHARD_TARGET` → 并行 fan-out。CI 显式 `SHARD_COUNT=16`（GHA 7 GB RSS 约束）由 `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` archtest 守卫（step-scoped match-all）。`ARCHTEST-VERIFY-COVERAGE-01` 守卫 script discovery 与 *_test.go AST 集合一致，防止 shard 漏 test。
 
 ## Review checklist
 

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -230,9 +230,13 @@ jobs:
       # do not accumulate *types.Info graph); the top-level archtest package
       # is excluded by the sentinel _dynamic_archtest_excluded (see the
       # build-test matrix tools entry). governance.yml's `make verify`
-      # likewise sets VERIFY_SKIP=archtest to delegate to the nightly job
-      # — push / PR archtest is covered locally by hack/githooks/pre-push,
-      # not here.
+      # likewise sets VERIFY_SKIP=archtest to delegate to the nightly job.
+      # Push / PR archtest has no local coverage either: hack/githooks/
+      # pre-push deliberately omits archtest after PR #887 review round-2
+      # (CPU/RSS budget — ~3min wall + 43 GB RSS violates the hook's sub-
+      # 10s deterministic contract; see ADR §"pre-push archtest 撤回").
+      # Developers who want PR-time archtest feedback run `make verify`
+      # or `bash hack/verify-archtest.sh` explicitly.
 
       # Compile-verify e2e package even when integration-test job is skipped.
       # The e2e build tag gates runtime behaviour; this step ensures type/import
@@ -279,13 +283,20 @@ jobs:
           retention-days: 1
 
   # archtest 16-shard matrix moved to .github/workflows/archtest-nightly.yml
-  # (schedule-driven + workflow_dispatch). PR-time fast-feedback is now
-  # hack/githooks/pre-push (K=1 single-process full sweep on the developer's
-  # box). Rationale: PR-time gate brittleness (modulo-shift SLOW, tagGroup
-  # OOM templates, GHA runner spot preempt amplified 16×) outweighed value;
-  # nightly catches true invariant violations within 24h and opens a P0
-  # issue via the alert-on-failure job. See ADR 202605120000 §Amendment
-  # 2026-05-23-pr-time-to-nightly.
+  # (schedule-driven + workflow_dispatch). There is NO PR-time local
+  # fast-feedback replacement: hack/githooks/pre-push deliberately omits
+  # archtest after PR #887 review round-2 (CPU/RSS budget violates the
+  # hook's sub-10s deterministic contract — see ADR §"pre-push archtest
+  # 撤回"). Developers who want PR-time archtest feedback run `make verify`
+  # or `bash hack/verify-archtest.sh` explicitly. Rationale for the PR-time
+  # matrix removal: brittleness (modulo-shift SLOW, tagGroup OOM templates,
+  # GHA runner spot preempt amplified 16×) outweighed value; nightly
+  # catches true invariant violations within 24h, surfacing via GHA default
+  # email-to-watchers + Actions UI red ✗ + workflow_dispatch rerun. (An
+  # alert-on-failure job auto-opening a P0 issue was tried in PR #887
+  # round-1 and dropped in review round-2 for fragile `issues: write`
+  # surface — see ADR §"alert-on-failure 撤回".) See ADR 202605120000
+  # §Amendment 2026-05-23-pr-time-to-nightly.
 
   integration-test:
     if: ${{ inputs.run-integration }}

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -57,13 +57,16 @@ jobs:
             pkgs: ./kernel/...
             static_checks: true
           - shard: tools
-            # archtest is split out to the verify-archtest job below (process
-            # isolation — see hack/verify-archtest.sh + ADR
-            # 202605120000-adr-archtest-process-isolation.md). The remaining
-            # tools/ subpackages (codegen / depgraph / generatedverify /
-            # metricschema / slowgate / etc.) are discovered at runtime by the
-            # Test step via `go list ./tools/...`; any new tools/<sub> package
-            # joins coverage automatically with zero yml maintenance.
+            # archtest 16-shard matrix runs in .github/workflows/archtest-nightly.yml
+            # (process-isolated, schedule-driven). Excluded here to avoid
+            # duplicate execution + OOM in the PR-time tools shard. See
+            # hack/verify-archtest.sh + ADR
+            # 202605120000-adr-archtest-process-isolation.md §Amendment
+            # 2026-05-23-pr-time-to-nightly. The remaining tools/ subpackages
+            # (codegen / depgraph / generatedverify / metricschema / slowgate
+            # / etc.) are discovered at runtime by the Test step via
+            # `go list ./tools/...`; any new tools/<sub> package joins
+            # coverage automatically with zero yml maintenance.
             pkgs: _dynamic_archtest_excluded
             static_checks: false
           - shard: runtime
@@ -182,10 +185,10 @@ jobs:
           PKGS='${{ matrix.pkgs }}'
           if [ "$PKGS" = "_dynamic_archtest_excluded" ]; then
             # tools shard runtime discovery: every ./tools/<sub> package
-            # except archtest (which runs in the dedicated verify-archtest
-            # job — see ADR 202605120000). Using `go list` as the ground
-            # truth makes "new tools subpackage not covered" violation
-            # unrepresentable.
+            # except archtest (which runs in archtest-nightly.yml — see
+            # ADR 202605120000 §Amendment 2026-05-23-pr-time-to-nightly).
+            # Using `go list` as the ground truth makes "new tools
+            # subpackage not covered" violation unrepresentable.
             PKGS=$(go list ./tools/... | grep -v '^github.com/ghbvf/gocell/tools/archtest$' | tr '\n' ' ')
           fi
           go test \
@@ -266,67 +269,14 @@ jobs:
           path: coverage-shard-${{ matrix.shard }}.out
           retention-days: 1
 
-  # verify-archtest runs the tools/archtest top-level package across 16
-  # process-isolated shards. Splits out of the build-test (tools) shard
-  # because typeseval.SharedResolver accumulates *types.Info per cacheKey;
-  # running all ~300 top-level Test* funcs in one process accumulated 20+
-  # GB peak RSS on GHA 2-core 7GB runners (OOM SIGTERM after PR #445).
-  # Each matrix shard is an independent Go process — process exit releases
-  # the cached type graphs, so per-shard peak RSS stays under 5 GB.
-  # Phase 0 measurement justification: phase0-baseline.txt produced during
-  # the PR landing this job. See ADR
-  # docs/architecture/202605120000-adr-archtest-process-isolation.md.
-  verify-archtest:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-
-      - name: Pre-download modules
-        timeout-minutes: 3
-        run: go mod download -x
-
-      - name: Build slowgate
-        run: go build -o "$RUNNER_TEMP/slowgate" ./tools/slowgate
-
-      - name: Verify archtest shard ${{ matrix.shard }}
-        env:
-          # CI must set SHARD_COUNT=16 explicitly (GHA 2-core 7 GB shard
-          # RSS budget, see ADR 202605120000). hack/verify-archtest.sh
-          # default is 1 (local-friendly) and intentionally differs — the
-          # two values encode local vs CI context, no SYNC guard needed.
-          SHARD_COUNT: 16
-          SHARD_TARGET: ${{ matrix.shard }}
-          TIMEOUT: 5m
-          SLOWGATE_BIN: ${{ runner.temp }}/slowgate
-          SLOWGATE_THRESHOLD: 20s
-          SLOWGATE_ALLOWLIST: tools/slowgate/allowlist.txt
-        run: bash hack/verify-archtest.sh
-
-      # Mirror the build-test failure-only artifact pattern: the script
-      # tees `go test -json` into $RUNNER_TEMP/archtest-shard-N.json before
-      # piping through slowgate, so this artifact captures full event
-      # stream (test panics, build errors, sub-test traces) for diagnosis
-      # without paying upload cost on the success path.
-      - name: Upload archtest-json artifact (failure only)
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: archtest-shard-${{ matrix.shard }}-json
-          path: ${{ runner.temp }}/archtest-shard-${{ matrix.shard }}.json
-          retention-days: 3
-          if-no-files-found: ignore
+  # archtest 16-shard matrix moved to .github/workflows/archtest-nightly.yml
+  # (schedule-driven + workflow_dispatch). PR-time fast-feedback is now
+  # hack/githooks/pre-push (K=1 single-process full sweep on the developer's
+  # box). Rationale: PR-time gate brittleness (modulo-shift SLOW, tagGroup
+  # OOM templates, GHA runner spot preempt amplified 16×) outweighed value;
+  # nightly catches true invariant violations within 24h and opens a P0
+  # issue via the alert-on-failure job. See ADR 202605120000 §Amendment
+  # 2026-05-23-pr-time-to-nightly.
 
   integration-test:
     if: ${{ inputs.run-integration }}

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -220,10 +220,19 @@ jobs:
       # ban) are owned by the dedicated Governance Strict workflow
       # (.github/workflows/governance.yml → `make verify`). Running them
       # here would duplicate work and create two paths to update whenever a
-      # gate is added. archtest layer/cell-internal guards are covered by
-      # the dedicated tools shard (./tools/...) which runs in parallel with
-      # this kernel shard, and are additionally re-run inside `make verify`
-      # (cheap, < 30s).
+      # gate is added. archtest layer/cell-internal guards are NOT covered
+      # by this workflow at all on push / pull_request: per ADR
+      # 202605120000 §D6 + §Amendment 2026-05-23-pr-time-to-nightly, the
+      # sole CI archtest gate is .github/workflows/archtest-nightly.yml
+      # (schedule cron + workflow_dispatch, 16-shard matrix). The tools
+      # shard above runs only tools/archtest/internal/{scanner,typeseval,
+      # rawparamfixture,wrapfixture} sub-package unit tests (lightweight,
+      # do not accumulate *types.Info graph); the top-level archtest package
+      # is excluded by the sentinel _dynamic_archtest_excluded (see the
+      # build-test matrix tools entry). governance.yml's `make verify`
+      # likewise sets VERIFY_SKIP=archtest to delegate to the nightly job
+      # — push / PR archtest is covered locally by hack/githooks/pre-push,
+      # not here.
 
       # Compile-verify e2e package even when integration-test job is skipped.
       # The e2e build tag gates runtime behaviour; this step ensures type/import

--- a/.github/workflows/archtest-nightly.yml
+++ b/.github/workflows/archtest-nightly.yml
@@ -22,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  issues: write   # alert-on-failure opens issues on failure
 
 jobs:
   verify-archtest:
@@ -76,57 +75,3 @@ jobs:
           path: ${{ runner.temp }}/archtest-shard-${{ matrix.shard }}.json
           retention-days: 3
           if-no-files-found: ignore
-
-  alert-on-failure:
-    needs: verify-archtest
-    if: failure()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: none   # override top-level contents: read; this job needs no repo access
-      issues: write
-    steps:
-      # Open a P0 issue via the hosted runner's built-in `gh` CLI rather
-      # than actions/github-script: avoids introducing a new pinned-SHA
-      # external action (no existing pin in this repo) and keeps the alert
-      # path readable as plain shell. GH_TOKEN consumes the job's
-      # GITHUB_TOKEN, scoped by the `permissions: issues: write` block.
-      - name: Open failure issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          # Ensure labels exist (idempotent: 422 from existing label is silenced).
-          gh label create nightly-failure --color e11d48 --description "archtest nightly broke" 2>/dev/null || true
-          gh label create pri-p0          --color e11d48 --description "Priority P0"            2>/dev/null || true
-          gh label create cap-02-metadata-governance --color 0075ca --description "Capability: metadata governance" 2>/dev/null || true
-
-          branch="${{ github.ref_name }}"
-          title="[archtest-nightly] ${branch} broken"
-
-          # Idempotency: skip if an open issue with the same title prefix already exists.
-          existing=$(gh issue list --label nightly-failure --state open \
-            --search "${title}" --json number --jq length)
-          if [ "${existing}" -gt 0 ]; then
-            echo "Nightly failure issue already open, skipping creation."
-            exit 0
-          fi
-
-          today=$(date -u +%Y-%m-%d)
-          body=$(cat <<EOF
-          archtest nightly failed on ${branch}.
-
-          Run: $RUN_URL
-
-          Triage:
-          1. GHA runner shutdown (platform flake) → re-run via workflow_dispatch
-          2. Open run logs, identify failing shard + invariant ID.
-          3. Determine root cause:
-             - True invariant violation → fix or revert offending commit
-             - modulo-shift SLOW → adjust tools/slowgate/allowlist.txt
-          4. Rerun via Actions → archtest-nightly → Run workflow.
-          EOF
-          )
-          gh issue create \
-            --title "${title} (${today})" \
-            --label nightly-failure --label pri-p0 --label cap-02-metadata-governance \
-            --body "$body"

--- a/.github/workflows/archtest-nightly.yml
+++ b/.github/workflows/archtest-nightly.yml
@@ -1,0 +1,112 @@
+name: archtest-nightly
+
+# Sole authoritative CI gate for the archtest matrix after ADR 202605120000
+# §Amendment 2026-05-23-pr-time-to-nightly. Replaces the per-PR / per-push
+# verify-archtest job that used to live in _build-lint.yml: brittleness from
+# (a) modulo-shift SLOW (new test → reshuffle → 20s budget overshoot),
+# (b) tagGroup-loop OOM templates being re-copied across PRs (mitigated PR
+# #870), and (c) GHA runner spot preemption ("runner has received a shutdown
+# signal") with 16× amplification across the shard matrix made PR-time
+# feedback too noisy. Pre-push hook (hack/githooks/pre-push) is now the
+# local fast-feedback path; this nightly is the canonical full-matrix gate.
+#
+# ref: ADR docs/architecture/202605120000-adr-archtest-process-isolation.md
+# ref: kubernetes/community sig-testing nightly long-test pattern
+
+on:
+  schedule:
+    # 18:00 UTC ≈ 02:00 Beijing. Offset from otel-collector-nightly's 18:17
+    # so the two schedules don't pile onto the same GHA queue window.
+    - cron: '0 18 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write   # alert-on-failure opens issues on failure
+
+jobs:
+  verify-archtest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Pre-download modules
+        timeout-minutes: 3
+        run: go mod download -x
+
+      - name: Build slowgate
+        run: go build -o "$RUNNER_TEMP/slowgate" ./tools/slowgate
+
+      - name: Verify archtest shard ${{ matrix.shard }}
+        env:
+          # CI must set SHARD_COUNT=16 explicitly on THIS step (GHA step env
+          # is step-scoped — sibling step env does NOT propagate to this
+          # step's process). GHA 2-core 7 GB shard RSS budget; script
+          # default is 1 (local-friendly, pre-push). Guarded by
+          # ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01 archtest (step-scoped
+          # match-all). See ADR 202605120000 §Amendment 2026-05-23.
+          SHARD_COUNT: 16
+          SHARD_TARGET: ${{ matrix.shard }}
+          TIMEOUT: 5m
+          SLOWGATE_BIN: ${{ runner.temp }}/slowgate
+          SLOWGATE_THRESHOLD: 20s
+          SLOWGATE_ALLOWLIST: tools/slowgate/allowlist.txt
+        run: bash hack/verify-archtest.sh
+
+      - name: Upload archtest-json artifact (failure only)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: archtest-shard-${{ matrix.shard }}-json
+          path: ${{ runner.temp }}/archtest-shard-${{ matrix.shard }}.json
+          retention-days: 3
+          if-no-files-found: ignore
+
+  alert-on-failure:
+    needs: verify-archtest
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      # Open a P0 issue via the hosted runner's built-in `gh` CLI rather
+      # than actions/github-script: avoids introducing a new pinned-SHA
+      # external action (no existing pin in this repo) and keeps the alert
+      # path readable as plain shell. GH_TOKEN consumes the job's
+      # GITHUB_TOKEN, scoped by the `permissions: issues: write` block.
+      - name: Open failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          body=$(cat <<EOF
+          archtest nightly failed on develop.
+
+          Run: $RUN_URL
+
+          Triage:
+          1. Open run logs, identify failing shard + invariant ID.
+          2. Determine root cause:
+             - True invariant violation → fix or revert offending commit
+             - GHA runner shutdown (platform flake) → re-run via workflow_dispatch
+             - modulo-shift SLOW → adjust tools/slowgate/allowlist.txt
+          3. Rerun via Actions → archtest-nightly → Run workflow.
+          EOF
+          )
+          gh issue create \
+            --title "[archtest-nightly] develop broken ($today)" \
+            --label nightly-failure --label pri-p0 --label cap-02-metadata-governance \
+            --body "$body"

--- a/.github/workflows/archtest-nightly.yml
+++ b/.github/workflows/archtest-nightly.yml
@@ -61,6 +61,9 @@ jobs:
           SHARD_TARGET: ${{ matrix.shard }}
           TIMEOUT: 5m
           SLOWGATE_BIN: ${{ runner.temp }}/slowgate
+          # 20s threshold inherited from _build-lint.yml; calibrated on macOS
+          # local Phase 0 (18-core Apple Silicon). GHA ubuntu nightly has no
+          # baseline data yet — revisit after ~30 consecutive nightly runs.
           SLOWGATE_THRESHOLD: 20s
           SLOWGATE_ALLOWLIST: tools/slowgate/allowlist.txt
         run: bash hack/verify-archtest.sh
@@ -79,6 +82,7 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     permissions:
+      contents: none   # override top-level contents: read; this job needs no repo access
       issues: write
     steps:
       # Open a P0 issue via the hosted runner's built-in `gh` CLI rather
@@ -91,22 +95,38 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Ensure labels exist (idempotent: 422 from existing label is silenced).
+          gh label create nightly-failure --color e11d48 --description "archtest nightly broke" 2>/dev/null || true
+          gh label create pri-p0          --color e11d48 --description "Priority P0"            2>/dev/null || true
+          gh label create cap-02-metadata-governance --color 0075ca --description "Capability: metadata governance" 2>/dev/null || true
+
+          branch="${{ github.ref_name }}"
+          title="[archtest-nightly] ${branch} broken"
+
+          # Idempotency: skip if an open issue with the same title prefix already exists.
+          existing=$(gh issue list --label nightly-failure --state open \
+            --search "${title}" --json number --jq length)
+          if [ "${existing}" -gt 0 ]; then
+            echo "Nightly failure issue already open, skipping creation."
+            exit 0
+          fi
+
           today=$(date -u +%Y-%m-%d)
           body=$(cat <<EOF
-          archtest nightly failed on develop.
+          archtest nightly failed on ${branch}.
 
           Run: $RUN_URL
 
           Triage:
-          1. Open run logs, identify failing shard + invariant ID.
-          2. Determine root cause:
+          1. GHA runner shutdown (platform flake) → re-run via workflow_dispatch
+          2. Open run logs, identify failing shard + invariant ID.
+          3. Determine root cause:
              - True invariant violation → fix or revert offending commit
-             - GHA runner shutdown (platform flake) → re-run via workflow_dispatch
              - modulo-shift SLOW → adjust tools/slowgate/allowlist.txt
-          3. Rerun via Actions → archtest-nightly → Run workflow.
+          4. Rerun via Actions → archtest-nightly → Run workflow.
           EOF
           )
           gh issue create \
-            --title "[archtest-nightly] develop broken ($today)" \
+            --title "${title} (${today})" \
             --label nightly-failure --label pri-p0 --label cap-02-metadata-governance \
             --body "$body"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -27,7 +27,7 @@ jobs:
     # workflow invoked it. The single-owner rule mirrors Kubernetes's
     # per-verify-*.sh Prow job model and Watermill's reusable-workflow
     # split (one owner per gate; aggregators delegate). PR-time local
-    # fast-feedback is provided by hack/githooks/pre-push (K=1 sweep).
+    # fast-feedback is provided by hack/githooks/pre-push (K=4 parallel fan-out (~3 min on an 18-core workstation)).
     #
     # 15 min covers cold module cache plus other ~9 verify-*.sh gates
     # running continue-on-failure (hack/make-rules/verify.sh accumulates

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -17,15 +17,17 @@ jobs:
     name: make verify
     runs-on: ubuntu-latest
     # `make verify` discovers and runs every hack/verify-*.sh gate. archtest
-    # is delegated to _build-lint.yml::verify-archtest (matrix of 16 shards,
-    # process-isolated per ADR 202605120000) — that job is the **single
-    # authoritative owner** of archtest enforcement on push / pull_request.
+    # is delegated to .github/workflows/archtest-nightly.yml (matrix of 16
+    # shards on a daily schedule + workflow_dispatch, process-isolated per
+    # ADR 202605120000 §Amendment 2026-05-23-pr-time-to-nightly) — that job
+    # is the **single authoritative owner** of archtest enforcement on CI.
     # Running archtest here too would (a) duplicate CI cost; (b) create a
     # divergent contract (this serial path has no SLOWGATE_BIN injection),
     # so the same script would behave differently depending on which
     # workflow invoked it. The single-owner rule mirrors Kubernetes's
     # per-verify-*.sh Prow job model and Watermill's reusable-workflow
-    # split (one owner per gate; aggregators delegate).
+    # split (one owner per gate; aggregators delegate). PR-time local
+    # fast-feedback is provided by hack/githooks/pre-push (K=1 sweep).
     #
     # 15 min covers cold module cache plus other ~9 verify-*.sh gates
     # running continue-on-failure (hack/make-rules/verify.sh accumulates
@@ -40,18 +42,19 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: make verify
-        # VERIFY_SKIP=archtest: delegate archtest to the matrix verify-
-        # archtest job (single-owner principle, see comment above).
-        # gofumpt is NOT in the skip list — hack/verify-gofumpt.sh
+        # VERIFY_SKIP=archtest: delegate archtest to the matrix
+        # archtest-nightly.yml job (single-owner principle, see comment
+        # above). gofumpt is NOT in the skip list — hack/verify-gofumpt.sh
         # bootstraps golangci-lint at the pinned version via
         # hack/lib/golangci-lint.sh (one-time go install on a cold setup-go
         # cache). The CI lint shard in _build-lint.yml uses golangci-lint-
         # action for its build cache and `config verify`; both consumers
         # share GOLANGCI_LINT_VERSION = v2.11.4.
         #
-        # Local `make verify` (no env) still runs verify-archtest.sh — this
-        # is the only path for developers and is by-design slowgate-less
-        # (the budget gate is a CI concern; local dev focuses on correctness).
+        # Local `make verify` (no env) still runs verify-archtest.sh (K=1
+        # default; PR #878). This is the developer-facing local sweep and
+        # is by-design slowgate-less (the budget gate is a CI concern;
+        # local dev focuses on correctness).
         env:
           VERIFY_SKIP: archtest
         run: make verify

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -26,8 +26,14 @@ jobs:
     # so the same script would behave differently depending on which
     # workflow invoked it. The single-owner rule mirrors Kubernetes's
     # per-verify-*.sh Prow job model and Watermill's reusable-workflow
-    # split (one owner per gate; aggregators delegate). PR-time local
-    # fast-feedback is provided by hack/githooks/pre-push (K=4 parallel fan-out (~3 min on an 18-core workstation)).
+    # split (one owner per gate; aggregators delegate). There is NO PR-time
+    # local fast-feedback for archtest: hack/githooks/pre-push deliberately
+    # omits archtest after PR #887 review round-2 (CPU/RSS budget — ~3min
+    # wall + 43 GB RSS + 18-core 100% violates the hook's sub-10s
+    # deterministic contract; see ADR §"pre-push archtest 撤回"). Developers
+    # who want PR-time archtest feedback run `make verify` (this workflow's
+    # local path without VERIFY_SKIP) or `bash hack/verify-archtest.sh`
+    # explicitly.
     #
     # 15 min covers cold module cache plus other ~9 verify-*.sh gates
     # running continue-on-failure (hack/make-rules/verify.sh accumulates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ actors.yaml   — 外部 Actor 注册（参与 contract 但不属于 Cell 模型
 
 主要实施者是 AI。新增/修改约束 enforcement 机制（archtest / governance rule / codegen funnel / type marker / godoc 强约定）按 AI-rebust 三档（Hard / Medium / Soft）评级；Soft 严禁立项。载体决策原则、archtest 文件命名、review checklist 详见 `.claude/rules/gocell/ai-collab.md`。
 
-archtest CI 入口是 `hack/verify-archtest.sh`（process-isolated shards）；CI 显式 `SHARD_COUNT=16`（GHA 7 GB RSS 约束），本地默认 `SHARD_COUNT=1`（单进程、共享 `*types.Info` cache、最低 CPU）。`go test ./tools/archtest/...` 行为不变。详见 ADR `docs/architecture/202605120000-adr-archtest-process-isolation.md`。
+archtest CI 入口是 `.github/workflows/archtest-nightly.yml`（schedule cron + workflow_dispatch，16-shard matrix），失败自动开 P0 issue；PR / push CI 不跑 archtest。本地 PR-time 反馈是 `hack/githooks/pre-push`（`SHARD_COUNT=4` 并行 fan-out，~3 min on 18-core workstation）。`hack/verify-archtest.sh` 三种执行模式：`SHARD_TARGET=N` → 单 shard（CI matrix）；`SHARD_COUNT=1` → 单进程流式（local default）；`SHARD_COUNT>1` 无 `SHARD_TARGET` → 并行 fan-out。`go test ./tools/archtest/...` 行为不变。详见 ADR `docs/architecture/202605120000-adr-archtest-process-isolation.md` §Amendment 2026-05-23-pr-time-to-nightly。
 
 ## 参考框架
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ actors.yaml   — 外部 Actor 注册（参与 contract 但不属于 Cell 模型
 
 主要实施者是 AI。新增/修改约束 enforcement 机制（archtest / governance rule / codegen funnel / type marker / godoc 强约定）按 AI-rebust 三档（Hard / Medium / Soft）评级；Soft 严禁立项。载体决策原则、archtest 文件命名、review checklist 详见 `.claude/rules/gocell/ai-collab.md`。
 
-archtest CI 入口是 `.github/workflows/archtest-nightly.yml`（schedule cron + workflow_dispatch，16-shard matrix），失败自动开 P0 issue；PR / push CI 不跑 archtest。本地 PR-time 反馈是 `hack/githooks/pre-push`（`SHARD_COUNT=4` 并行 fan-out，~3 min on 18-core workstation）。`hack/verify-archtest.sh` 三种执行模式：`SHARD_TARGET=N` → 单 shard（CI matrix）；`SHARD_COUNT=1` → 单进程流式（local default）；`SHARD_COUNT>1` 无 `SHARD_TARGET` → 并行 fan-out。`go test ./tools/archtest/...` 行为不变。详见 ADR `docs/architecture/202605120000-adr-archtest-process-isolation.md` §Amendment 2026-05-23-pr-time-to-nightly。
+archtest CI 入口是 `.github/workflows/archtest-nightly.yml`（schedule cron + workflow_dispatch，16-shard matrix）；PR / push CI 不跑 archtest，失败靠 GHA 默认邮件通知 + Actions UI + `workflow_dispatch` rerun。本地反馈走开发者显式触发：`make verify` 一键全跑（含 archtest）或 `bash hack/verify-archtest.sh` 直跑；`hack/githooks/pre-push` 因 CPU/RSS 预算不跑 archtest（PR #887 round-2 撤回，详见 ADR §"pre-push archtest 撤回"）。`hack/verify-archtest.sh` 三种执行模式：`SHARD_TARGET=N` → 单 shard（CI matrix）；`SHARD_COUNT=1` → 单进程流式（local default）；`SHARD_COUNT>1` 无 `SHARD_TARGET` → 并行 fan-out。`go test ./tools/archtest/...` 行为不变。详见 ADR `docs/architecture/202605120000-adr-archtest-process-isolation.md` §Amendment 2026-05-23-pr-time-to-nightly。
 
 ## 参考框架
 

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -58,19 +58,22 @@ K=16 是首个稳定低于 GHA 7GB OOM 阈值的分片粒度。K=8 留余量不�
 
 `hack/verify-archtest.sh` 内 shard 路径：若 `$SLOWGATE_BIN` executable，`go test ... -json -run '...'` tee 到 `$RUNNER_TEMP/archtest-shard-N.json` 再管道入 slowgate（与 `_build-lint.yml` 旧 tools shard 同范式）；否则 plain `go test`（local dev）。matrix job 内 `go build -o "$RUNNER_TEMP/slowgate" ./tools/slowgate` 后注入 env；`if: failure()` artifact 上传保留 json event stream 供失败诊断。
 
-### D6. Single-owner 原则：matrix is the sole archtest gate on CI
+### D6. Single-owner 原则：nightly schedule is the sole archtest gate on CI
 
-`_build-lint.yml::verify-archtest` matrix（16 shard）是 push / pull_request 上的 **唯一权威 archtest gate**。`governance.yml::make verify` 通过 `env: VERIFY_SKIP: archtest` 显式委托，**不再双跑**。
+`.github/workflows/archtest-nightly.yml::verify-archtest` matrix（16 shard，cron + `workflow_dispatch`）是 archtest 在 CI 上的 **唯一权威 gate**。push / pull_request 不再跑 archtest（PR-time matrix 已删，详见 §Amendment 2026-05-23-pr-time-to-nightly）。`governance.yml::make verify` 通过 `env: VERIFY_SKIP: archtest` 显式委托给 nightly，**不再双跑**。
 
 理由（K8s + Watermill 范式对照）：
 - K8s 每个 verify-*.sh 是独立 Prow job（一 owner / 一 gate）；aggregator `hack/make-rules/verify.sh` 是开发者本地一键入口，不是 CI 上的二次 gate
 - Watermill 用单个 reusable workflow 作为 PR/master 共同实现，调用方只做薄包装；语义差异通过显式 input 表达，不靠 caller-injected env 改 script 行为
-- 若 governance 在 PR 上也跑 archtest：(a) CI 资源 ×2；(b) 同 script 在两个 caller 下行为分叉（matrix 注入 SLOWGATE_BIN 有 budget 门，governance 无）—— 同名 gate 双契约破坏 reproducibility
+- 若 governance 在 push / PR 上也跑 archtest：(a) CI 资源 ×2；(b) 同 script 在两个 caller 下行为分叉（matrix 注入 SLOWGATE_BIN 有 budget 门，governance 无）—— 同名 gate 双契约破坏 reproducibility
 
-本地路径不变：
-- `make verify` 不带 `VERIFY_SKIP` env，仍调 `hack/verify-archtest.sh`，作为开发者一键全跑
+本地路径：
+- 开发者本地 `make verify`（无 `VERIFY_SKIP` env）仍调 `hack/verify-archtest.sh`，作为一键全跑
+- `hack/githooks/pre-push` 在 `go_changed || archtest_governance_changed` 命中时并行 fan-out（默认 K=4，`SHARD_COUNT` env 可覆盖）作为 PR-time 快速反馈
 - 脚本因 `SLOWGATE_BIN` 缺失走 plain go test 路径——by-design 单本地路径（slowgate budget gate 是 CI 关注点，本地 dev 关注正确性）
-- 故 script 仍有「`SLOWGATE_BIN` 在则 pipe；不在则 plain」的内部分支，但 CI 只有一个 caller（matrix）注入 `SLOWGATE_BIN`，没有 caller-divergent 契约
+- 故 script 仍有「`SLOWGATE_BIN` 在则 pipe；不在则 plain」的内部分支，但 CI 只有一个 caller（nightly matrix）注入 `SLOWGATE_BIN`，没有 caller-divergent 契约
+
+> 历史：本节原文为 "`_build-lint.yml::verify-archtest` matrix 是 push / pull_request 上的唯一权威 archtest gate"。§Amendment 2026-05-23-pr-time-to-nightly 把 owner 平移至 `archtest-nightly.yml`；本节文本同 PR 重写（per ai-collab.md §"ADR amendment 落地必查"，禁止"原文保留作历史脉络"）。
 
 ### D7. 元规则覆盖 dispatch 路径，不仅 discovery
 
@@ -199,7 +202,7 @@ PR-time 16-shard matrix（PR / push 上 `_build-lint.yml::verify-archtest`）累
 
 1. **删除 PR-time matrix**——`.github/workflows/_build-lint.yml::verify-archtest` job 整段删除（含 16 个 matrix entries）。`governance.yml::make verify` 的 `VERIFY_SKIP: archtest` env 保留，注释更新为指向新 nightly yaml。
 
-2. **新建 nightly schedule**——`.github/workflows/archtest-nightly.yml`：`cron: '0 18 * * *'`（UTC ≈ 北京 02:00）+ `workflow_dispatch`；16-shard matrix 结构 1:1 复用旧 PR-time job；新增 `alert-on-failure` job 在 `if: failure()` 时用 hosted runner 内置 `gh` CLI 调 `gh issue create` 开 P0 issue（labels: `nightly-failure` / `pri-p0` / `cap-02-metadata-governance`）。
+2. **新建 nightly schedule**——`.github/workflows/archtest-nightly.yml`：`cron: '0 18 * * *'`（UTC ≈ 北京 02:00）+ `workflow_dispatch`；16-shard matrix 结构 1:1 复用旧 PR-time job。失败兜底走 GHA 平台自带反馈通道（workflow run 失败默认邮件通知 watchers、Actions UI 红 ✗、`workflow_dispatch` 手动 rerun），**不**自动开 issue——见下方 §"alert-on-failure 撤回"。
 
 3. **本地 pre-push 跑全量 archtest**——`hack/verify-archtest.sh` 新增"Execution modes"语义：
    - `SHARD_TARGET` 设 → 单 shard 单 process（CI matrix 路径不变）
@@ -229,7 +232,7 @@ K=4 全胜：18-core 给 4 process 各 ~4.5 core，`go test` 内 `t.Parallel` �
 | §D1 CI matrix 16-shard | ✅ K=16 不变，载体 `_build-lint.yml` → `archtest-nightly.yml` | ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01 守卫 yaml 路径同 PR 迁移 |
 | §D3 ARCHTEST-VERIFY-COVERAGE-01 元守卫 | ✅ 不变，运行时间从 PR-time → nightly | discovery drift 触发条件单一（改脚本），PR diff 显著 |
 | §D4 governance.yml VERIFY_SKIP | ✅ env 保留不变 | 注释更新指向新 nightly yaml |
-| §D5 slowgate | ⚠️ 仍跑但延迟暴露 | brittleness 转 nightly 兜底 + 自动开 issue |
+| §D5 slowgate | ⚠️ 仍跑但延迟暴露 | brittleness 转 nightly 兜底；失败靠 GHA 平台邮件 + Actions UI + `workflow_dispatch` rerun |
 | § "PR-time fast-feedback gate" | ❌ 失效 | pre-push 本地 K=4 并行替代（实测 ~3 min wall） |
 | § "single authoritative owner" | ✅ owner 从 `_build-lint.yml::verify-archtest` 平移至 `archtest-nightly.yml::verify-archtest`（同名 job，不同 yaml）| 注释 + ADR 文本同 PR 重写 |
 
@@ -237,10 +240,26 @@ K=4 全胜：18-core 给 4 process 各 ~4.5 core，`go test` 内 `t.Parallel` �
 
 ### 跨载体同步（同 PR 闭环）
 
-- `.github/workflows/archtest-nightly.yml` 新建（16-shard schedule + alert-on-failure）
+- `.github/workflows/archtest-nightly.yml` 新建（16-shard schedule + `workflow_dispatch`；alert-on-failure 自动开 issue 子方案见 §"alert-on-failure 撤回"）
 - `.github/workflows/_build-lint.yml` 删 verify-archtest job + tools shard 注释指向 nightly
 - `.github/workflows/governance.yml` VERIFY_SKIP 注释指向 nightly
 - `hack/verify-archtest.sh` "Execution modes" 文档 + 并行 fan-out 分支
-- `hack/githooks/pre-push` 用 K=4 并行 + 注释重写（deviation 4 / Tier 4）
+- `hack/githooks/pre-push` 用 `${SHARD_COUNT:-4}` 并行 + `go_changed || archtest_governance_changed` 触发 + 注释重写（deviation 4 / Tier 4）
 - `tools/archtest/archtest_ci_shard_count_test.go` yaml 路径迁移到 `archtest-nightly.yml`
-- `CLAUDE.md:78`、`.claude/rules/gocell/ai-collab.md:69` archtest 入口描述更新
+- `CLAUDE.md`、`.claude/rules/gocell/ai-collab.md` archtest 入口描述更新
+
+### alert-on-failure 撤回（PR #887 review round）
+
+初版决策 2 同时包含一个 `alert-on-failure` job：`if: failure()` 时调 `gh issue create` 自动开 P0 issue（labels `nightly-failure` / `pri-p0` / `cap-02-metadata-governance`，同标题 idempotency skip-if-exists）。PR #887 review 找到三处缺陷：
+
+1. **`issues: write` 顶层泄漏**——workflow 顶层 `permissions: issues: write` 被 verify-archtest 16 个 matrix job 继承，权限面不必要扩大
+2. **shell injection 面**——`branch="${{ github.ref_name }}"` 把 GHA expression 直接嵌进 shell，`workflow_dispatch` 触发的分支名可承载 shell 元字符
+3. **alert job 无 repo context**——既无 checkout 也无 `GH_REPO` env，`gh issue list / create / label create` 在非 git 工作目录会失败，整条"补偿路径"本身失效
+
+激进自审三层（per ai-collab.md §"激进自审三层覆盖"）：
+
+- **L1 代码补丁**：F1+F2+F3 是给同一脆弱组件打三个补丁，治标不治本
+- **L2 PR 整体决策组合**：自动开 issue 兜底是冗余运维债——GHA workflow run 失败默认邮件通知 watchers、Actions UI 红 ✗ 显示、`workflow_dispatch` 手动 rerun 已构成三条反馈通道；issue 语义是"工作项跟踪"，与 alert 通道语义错配；同标题 idempotency 导致同一 issue 长期开着反而失去信号
+- **L3 概念模型**：GitHub Issues 不是 alert backbone；真正的 alert 应走 Slack / PagerDuty webhook（语义正确的 alert 通道）
+
+裁决：同 PR 内撤回 alert-on-failure job 整段 + 顶层 `issues: write` 权限。nightly 失败靠 GHA 平台自带反馈。未来若真需要 alert backbone，使用 webhook 形式，不回到 GitHub Issues。

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -158,13 +158,16 @@ phase0-baseline.txt 留在 worktree 但不入 PR（一次性 artifact）。
 
 ### 新约束 Medium 守卫（同 PR 闭环，per ai-collab.md §"立项硬门槛 ≥ Medium"）
 
-Amendment 改默认 16→1 产生一个新隐式约束：**CI yaml `.github/workflows/_build-lint.yml::verify-archtest` job 必须 explicit 设 `SHARD_COUNT: 16`**（否则 CI 以 K=1 单进程跑全部 archtest，~20 GB peak RSS 撞 GHA 7 GB shard OOM）。
+Amendment 改默认 16→1 产生一个新隐式约束：**CI yaml `verify-archtest` job 必须 explicit 在 invocation step 自身 env 中设 `SHARD_COUNT: 16`**（否则 CI 以 K=1 单进程跑全部 archtest，~20 GB peak RSS 撞 GHA 7 GB shard OOM）。
+
+> 落地载体迁移：本节 amendment 落地时 yaml 路径是 `.github/workflows/_build-lint.yml::verify-archtest`。后续 §Amendment 2026-05-23-pr-time-to-nightly 把 matrix 迁到 `.github/workflows/archtest-nightly.yml`，archtest 守卫的 yaml 解析路径同 PR 更新；约束语义不变。
 
 按 ai-collab.md "新引入 Soft → 直接 reject，要求改 ≥ Medium"，此约束**同 PR 内** Medium 化，不允许靠注释维护或 backlog 延期：
 
-- 新增 archtest `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01`（`tools/archtest/archtest_ci_shard_count_test.go`）：解析 `_build-lint.yml` YAML，断言 `jobs.verify-archtest.steps[*].env.SHARD_COUNT == "16"`；缺失或值漂移立即 fail。
+- 新增 archtest `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01`（`tools/archtest/archtest_ci_shard_count_test.go`）：解析 nightly workflow YAML，**step-scoped match-all** 形态——遍历 `jobs.verify-archtest.steps[*]`，对每个 `run` 含 `hack/verify-archtest.sh` 的 step 断言其**自身** `env.SHARD_COUNT == "16"`；缺失、值漂移、无 invocation step 立即 fail。
+- Step-scoped 必要性：GHA step env 是 step-scoped——sibling 步骤（如 Build slowgate 步骤）的 env 不传递给 verify-archtest.sh 执行进程；"any step has env=16" 形态会被 sibling shadow 误绿（开发者把 `SHARD_COUNT=16` 错写在 setup step，真实 invocation step 仍漏 env → CI 跑 K=1 → OOM）。
 - 形态 Medium：runtime guard via archtest，CI 跑时立即捕获。违反不可通过单边修改 yaml 静默达成——必须同 PR 修改 archtest 或 fixture，diff 可视。
-- 4 个 fixture（正/3 反）覆盖：正确形状 / 缺 env / 值漂移（K=8 反例）/ 缺 job。
+- 6 个 fixture（1 正/5 反）覆盖：正确形状 / 缺 env / 值漂移（K=8 反例）/ 缺 job / sibling step env shadow / no invocation step。
 
 ### Backlog 关闭
 
@@ -177,3 +180,67 @@ Amendment 改默认 16→1 产生一个新隐式约束：**CI yaml `.github/work
 - `CLAUDE.md:78`、`.claude/rules/gocell/ai-collab.md:69` K=16 描述
 - `tools/archtest/archtest_ci_shard_count_test.go` 新 Medium 守卫（ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01）
 - `docs/backlog/20260520/cap-02-metadata-governance.md` ARCHTEST-SHARDCOUNT-SYNC-GUARD-01 关闭
+
+## Amendment 2026-05-23-pr-time-to-nightly: archtest CI matrix moved to nightly + local parallel fan-out
+
+### 根因
+
+PR-time 16-shard matrix（PR / push 上 `_build-lint.yml::verify-archtest`）累积出三类 brittleness，已在最近 6-8 周反复修：
+
+1. **modulo-shift SLOW**——新 test 函数加入 → discovery 顺序 modulo 重排 → 某个 type-heavy test 被推到不同 shard → 跨 20s slowgate budget。每加一个 test 就可能复发，无根本解。
+2. **tagGroup 范本 OOM**——`for tagGroup := range KnownNonDefaultTags() { RunTyped(...) }` 范本被复抄到多处，每次 `RunTyped` 加载全模块 RSS 累积超 GHA 7 GB 上限 SIGTERM（PR #870 + TAGGROUP-LOOP-FORBIDS-RUNTYPED-01 archtest 已防再发）。
+3. **GHA runner 平台不稳**——PR #878 最终 merge 时 verify-archtest shard 5 `runner has received a shutdown signal`（spot instance preempt），非 archtest 逻辑失败。16-shard matrix 把单 runner 故障风险放大 16×。
+
+三类合计：archtest 在 PR-time 阻塞流红灯的有效信号噪音比下降。开发者修复路径变为"等 nightly 重跑"或人工 rerun matrix，反馈周期反而延长。
+
+同时 PR #878 把脚本默认 `SHARD_COUNT` 改为 1（本地友好），但实测发现 K=1 单进程跑 605 Test* wall ~5 min；K=N 串行 for-loop 更慢（每 shard 独立 packages.Load 无 cross-shard cache 共享）。本地缺乏快速 archtest 反馈手段。
+
+### 决策
+
+1. **删除 PR-time matrix**——`.github/workflows/_build-lint.yml::verify-archtest` job 整段删除（含 16 个 matrix entries）。`governance.yml::make verify` 的 `VERIFY_SKIP: archtest` env 保留，注释更新为指向新 nightly yaml。
+
+2. **新建 nightly schedule**——`.github/workflows/archtest-nightly.yml`：`cron: '0 18 * * *'`（UTC ≈ 北京 02:00）+ `workflow_dispatch`；16-shard matrix 结构 1:1 复用旧 PR-time job；新增 `alert-on-failure` job 在 `if: failure()` 时用 hosted runner 内置 `gh` CLI 调 `gh issue create` 开 P0 issue（labels: `nightly-failure` / `pri-p0` / `cap-02-metadata-governance`）。
+
+3. **本地 pre-push 跑全量 archtest**——`hack/verify-archtest.sh` 新增"Execution modes"语义：
+   - `SHARD_TARGET` 设 → 单 shard 单 process（CI matrix 路径不变）
+   - `SHARD_TARGET` 未设 + `SHARD_COUNT=1` → 单 shard 流式输出（local default，PR #878 落地）
+   - `SHARD_TARGET` 未设 + `SHARD_COUNT>1` → **并行 fan-out**（background `&` + wait barrier + 每 shard 临时文件收集 stdout，wait 后按 shard 序输出）
+   - 旧 K=N 串行 for-loop 模式删除——实测它总比 K=1 慢（每 shard 重新 packages.Load 无 cache 共享）且无 caller 用它。
+
+4. **pre-push 调用 K=4**——`hack/githooks/pre-push` 中替换原 `TEST-TIME-LITERAL-01` 单条采样为 `env SHARD_COUNT=4 bash hack/verify-archtest.sh`。
+
+### Workstation 标定（K 值选择实证）
+
+18-core / 128 GB Apple Silicon / macOS / ~605 Test*：
+
+| K | real wall | max shard | peak RSS | 评估 |
+|---|----------|-----------|----------|------|
+| K=1 单进程 | ~5min（用户实测）| 单进程 | ~20 GB | cache 共享但无并发 |
+| K=2 并行 | 248s（4min 8s）| 246s（302 tests）| 51 GB | 每 shard 太大 |
+| **K=4 并行** | **187s（3min 7s）**| **185s（152 tests）** | **43 GB** | **sweet spot**|
+| K=8 并行 | ~196s（3min 16s）| 196s（76 tests）| ~67 GB | 每 shard go test 内 `-p` 取不到足够 core，反而慢 |
+
+K=4 全胜：18-core 给 4 process 各 ~4.5 core，`go test` 内 `t.Parallel` 充分用 CPU；K=2 单 shard tests 太多内部串行多；K=8 over-subscribe core 拖慢。
+
+### 威胁矩阵重评（per `.claude/rules/gocell/ai-collab.md` §"ADR amendment 落地必查"）
+
+| 原 ADR 论点 | 在 amendment 下状态 | 补偿措施 |
+|------------|------------------|---------|
+| §D1 CI matrix 16-shard | ✅ K=16 不变，载体 `_build-lint.yml` → `archtest-nightly.yml` | ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01 守卫 yaml 路径同 PR 迁移 |
+| §D3 ARCHTEST-VERIFY-COVERAGE-01 元守卫 | ✅ 不变，运行时间从 PR-time → nightly | discovery drift 触发条件单一（改脚本），PR diff 显著 |
+| §D4 governance.yml VERIFY_SKIP | ✅ env 保留不变 | 注释更新指向新 nightly yaml |
+| §D5 slowgate | ⚠️ 仍跑但延迟暴露 | brittleness 转 nightly 兜底 + 自动开 issue |
+| § "PR-time fast-feedback gate" | ❌ 失效 | pre-push 本地 K=4 并行替代（实测 ~3 min wall） |
+| § "single authoritative owner" | ✅ owner 从 `_build-lint.yml::verify-archtest` 平移至 `archtest-nightly.yml::verify-archtest`（同名 job，不同 yaml）| 注释 + ADR 文本同 PR 重写 |
+
+§D4 / §D6 段原文同 PR 重写以与现状一致（per ai-collab.md §"ADR amendment 落地必查" 禁止"原文保留作历史脉络"）。
+
+### 跨载体同步（同 PR 闭环）
+
+- `.github/workflows/archtest-nightly.yml` 新建（16-shard schedule + alert-on-failure）
+- `.github/workflows/_build-lint.yml` 删 verify-archtest job + tools shard 注释指向 nightly
+- `.github/workflows/governance.yml` VERIFY_SKIP 注释指向 nightly
+- `hack/verify-archtest.sh` "Execution modes" 文档 + 并行 fan-out 分支
+- `hack/githooks/pre-push` 用 K=4 并行 + 注释重写（deviation 4 / Tier 4）
+- `tools/archtest/archtest_ci_shard_count_test.go` yaml 路径迁移到 `archtest-nightly.yml`
+- `CLAUDE.md:78`、`.claude/rules/gocell/ai-collab.md:69` archtest 入口描述更新

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -32,9 +32,11 @@ K=16 是首个稳定低于 GHA 7GB OOM 阈值的分片粒度。K=8 留余量不�
 
 ### D1. CI 入口改为 process-isolated 16-shard 矩阵（CI 显式 K=16 / 本地默认 K=1）
 
-`hack/verify-archtest.sh` 整体重写：discovery via `go test -list '^Test' ./tools/archtest`，按字母序 modulo `SHARD_COUNT` 分片（**CI: 16 explicit；本地默认: 1**，见 §Amendment 2026-05-23），每 shard 独立 `go test -run '^(name1|name2|...)$'` 调用。SHARD_TARGET 单 shard 模式给 GHA matrix 用；无 SHARD_TARGET 时串行跑 `SHARD_COUNT` 个 shard（本地 `make verify` 路径默认 K=1 单 shard）。
+`hack/verify-archtest.sh` 整体重写：discovery via `go test -list '^Test' ./tools/archtest`，按字母序 modulo `SHARD_COUNT` 分片（**CI: 16 explicit；本地默认: 1**，见 §Amendment 2026-05-23），每 shard 独立 `go test -run '^(name1|name2|...)$'` 调用。三种 execution mode 由 env shape 派生（见 §Amendment 2026-05-23-pr-time-to-nightly §决策 3）：`SHARD_TARGET` 设 → 单 shard（GHA matrix）；`SHARD_COUNT=1` 无 `SHARD_TARGET` → 单进程流式（本地 `make verify` 默认）；`SHARD_COUNT>1` 无 `SHARD_TARGET` → 并行 fan-out（background `&` + wait barrier）。旧 K=N 串行 for-loop 已删（每 shard 重 packages.Load 比 K=1 慢）。
 
-`.github/workflows/_build-lint.yml` 新增 `verify-archtest` job：`matrix.shard: [0..15]` + 显式 `env: SHARD_COUNT: 16`（GHA 7 GB shard RSS 约束）；每 shard 独立 ubuntu-latest runner。`fail-fast: false` 对齐 K8s `hack/make-rules/verify.sh` continue-on-failure 范式。CI explicit `SHARD_COUNT=16` 由 `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` archtest 守卫（见 §Amendment）。
+`.github/workflows/archtest-nightly.yml` 单一 `verify-archtest` job：`matrix.shard: [0..15]` + 显式 `env: SHARD_COUNT: 16`（GHA 7 GB shard RSS 约束）；每 shard 独立 ubuntu-latest runner。`fail-fast: false` 对齐 K8s `hack/make-rules/verify.sh` continue-on-failure 范式。CI explicit `SHARD_COUNT=16` 由 `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` archtest 守卫（见 §Amendment）。
+
+> 历史：本节原文为 "无 SHARD_TARGET 时串行跑 SHARD_COUNT 个 shard" + "`.github/workflows/_build-lint.yml` 新增 `verify-archtest` job"。§Amendment 2026-05-23-pr-time-to-nightly §决策 3 删 K=N 串行 for-loop 并新增 "Execution modes" 三档，§决策 1 把 verify-archtest job 整段从 `_build-lint.yml` 迁到 `archtest-nightly.yml`。本节同 PR 重写（per ai-collab.md §"ADR amendment 落地必查"）。
 
 ### D2. tools shard 不再 enumerate archtest，pkgs 运行时计算
 
@@ -46,13 +48,13 @@ K=16 是首个稳定低于 GHA 7GB OOM 阈值的分片粒度。K=8 留余量不�
 
 `tools/archtest/archtest_verify_coverage_test.go::TestArchtestVerifyCoverage01`（INVARIANT `ARCHTEST-VERIFY-COVERAGE-01`）：shell-out `DRY_RUN=1 bash hack/verify-archtest.sh` → 与 `scanner.EachInSubtree[ast.FuncDecl]` AST 扫到的 top-level Test* 函数集合做对称 diff，非空则 fail。守的风险：维护者改脚本加 `grep -v TestFoo` debug 过滤忘删 → CI silent unenforce（local `go test ./tools/archtest/...` 仍捕获，但 PR Check 漏过）。AI-rebust **Medium**（runtime cross-check 双重源）。
 
-### D4. `make verify` 委托 archtest 给 matrix gate（D6 single-owner 落地形态）
+### D4. `make verify` 委托 archtest 给 nightly gate（D6 single-owner 落地形态）
 
-`.github/workflows/governance.yml::make verify` 保留 `env: VERIFY_SKIP: archtest` 显式委托给 `_build-lint.yml::verify-archtest` matrix gate，避免 push/PR 上双跑 archtest（详见 §D6 single-owner 原则）。timeout-minutes 维持 15 容纳其它 verify-*.sh 子脚本耗时。
+`.github/workflows/governance.yml::make verify` 保留 `env: VERIFY_SKIP: archtest` 显式委托给 `archtest-nightly.yml::verify-archtest` matrix gate，避免 push/PR 上重复跑 archtest（详见 §D6 single-owner 原则）。timeout-minutes 维持 15 容纳其它 verify-*.sh 子脚本耗时。
 
-本地 `make verify`（无 `VERIFY_SKIP` env）仍包含 `verify-archtest.sh`，按 `SHARD_COUNT` 默认 K=1 单进程跑（见 §D1 + §Amendment 2026-05-23）；PR Check 的 matrix-parallel `verify-archtest` job (SHARD_COUNT=16 explicit) 是 CI 上唯一权威 archtest gate。
+本地 `make verify`（无 `VERIFY_SKIP` env）仍包含 `verify-archtest.sh`，按 `SHARD_COUNT` 默认 K=1 单进程跑（见 §D1 + §Amendment 2026-05-23）；CI 上 `archtest-nightly.yml::verify-archtest` (schedule cron + workflow_dispatch，SHARD_COUNT=16 explicit) 是唯一权威 archtest gate。
 
-> **历史**：本节原文为 "governance.yml 删 VERIFY_SKIP env" + "verify-archtest.sh serial 16-shard"。§D6 加入时反转此决策（恢复 VERIFY_SKIP 避免双跑）；§Amendment 2026-05-23 进一步把脚本默认 K 改为 1。本节文本同 PR 重写以与现状一致（per ai-collab.md §"ADR amendment 落地必查"）。
+> **历史**：本节原文先后经历："governance.yml 删 VERIFY_SKIP env" + "verify-archtest.sh serial 16-shard" → §D6 加入时反转（恢复 VERIFY_SKIP 避免双跑）→ §Amendment 2026-05-23 把脚本默认 K 改为 1 → §Amendment 2026-05-23-pr-time-to-nightly 把 owner 从 `_build-lint.yml::verify-archtest` 平移至 `archtest-nightly.yml::verify-archtest`。本节同 PR 重写（per ai-collab.md §"ADR amendment 落地必查"）。
 
 ### D5. slowgate 重接
 

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -69,7 +69,7 @@ K=16 是首个稳定低于 GHA 7GB OOM 阈值的分片粒度。K=8 留余量不�
 
 本地路径：
 - 开发者本地 `make verify`（无 `VERIFY_SKIP` env）仍调 `hack/verify-archtest.sh`，作为一键全跑
-- `hack/githooks/pre-push` 在 `go_changed || archtest_governance_changed` 命中时并行 fan-out（默认 K=4，`SHARD_COUNT` env 可覆盖）作为 PR-time 快速反馈
+- `hack/githooks/pre-push` 因 CPU/RSS 预算（实测 ~3min wall + 43 GB RSS + 18-core 全打满，违反 sub-10s 预算 18×）不跑 archtest（详见 §"pre-push archtest 撤回"）；开发者要 PR-time archtest 反馈走 `make verify` 或 `bash hack/verify-archtest.sh` 显式触发
 - 脚本因 `SLOWGATE_BIN` 缺失走 plain go test 路径——by-design 单本地路径（slowgate budget gate 是 CI 关注点，本地 dev 关注正确性）
 - 故 script 仍有「`SLOWGATE_BIN` 在则 pipe；不在则 plain」的内部分支，但 CI 只有一个 caller（nightly matrix）注入 `SLOWGATE_BIN`，没有 caller-divergent 契约
 
@@ -204,13 +204,13 @@ PR-time 16-shard matrix（PR / push 上 `_build-lint.yml::verify-archtest`）累
 
 2. **新建 nightly schedule**——`.github/workflows/archtest-nightly.yml`：`cron: '0 18 * * *'`（UTC ≈ 北京 02:00）+ `workflow_dispatch`；16-shard matrix 结构 1:1 复用旧 PR-time job。失败兜底走 GHA 平台自带反馈通道（workflow run 失败默认邮件通知 watchers、Actions UI 红 ✗、`workflow_dispatch` 手动 rerun），**不**自动开 issue——见下方 §"alert-on-failure 撤回"。
 
-3. **本地 pre-push 跑全量 archtest**——`hack/verify-archtest.sh` 新增"Execution modes"语义：
+3. **`hack/verify-archtest.sh` 新增"Execution modes"语义**——为开发者本地手动触发与未来 caller 提供 K 值选择：
    - `SHARD_TARGET` 设 → 单 shard 单 process（CI matrix 路径不变）
    - `SHARD_TARGET` 未设 + `SHARD_COUNT=1` → 单 shard 流式输出（local default，PR #878 落地）
    - `SHARD_TARGET` 未设 + `SHARD_COUNT>1` → **并行 fan-out**（background `&` + wait barrier + 每 shard 临时文件收集 stdout，wait 后按 shard 序输出）
    - 旧 K=N 串行 for-loop 模式删除——实测它总比 K=1 慢（每 shard 重新 packages.Load 无 cache 共享）且无 caller 用它。
 
-4. **pre-push 调用 K=4**——`hack/githooks/pre-push` 中替换原 `TEST-TIME-LITERAL-01` 单条采样为 `env SHARD_COUNT=4 bash hack/verify-archtest.sh`。
+4. **pre-push 不跑 archtest**——初版决策曾把 `env SHARD_COUNT=4 bash hack/verify-archtest.sh` 接入 `hack/githooks/pre-push` 作为 PR-time 快速反馈替代，PR #887 review round-2 撤回，详见下方 §"pre-push archtest 撤回"。本地 archtest 反馈走 `make verify` 一键全跑或 `bash hack/verify-archtest.sh` 显式触发。
 
 ### Workstation 标定（K 值选择实证）
 
@@ -233,7 +233,7 @@ K=4 全胜：18-core 给 4 process 各 ~4.5 core，`go test` 内 `t.Parallel` �
 | §D3 ARCHTEST-VERIFY-COVERAGE-01 元守卫 | ✅ 不变，运行时间从 PR-time → nightly | discovery drift 触发条件单一（改脚本），PR diff 显著 |
 | §D4 governance.yml VERIFY_SKIP | ✅ env 保留不变 | 注释更新指向新 nightly yaml |
 | §D5 slowgate | ⚠️ 仍跑但延迟暴露 | brittleness 转 nightly 兜底；失败靠 GHA 平台邮件 + Actions UI + `workflow_dispatch` rerun |
-| § "PR-time fast-feedback gate" | ❌ 失效 | pre-push 本地 K=4 并行替代（实测 ~3 min wall） |
+| § "PR-time fast-feedback gate" | ❌ 失效（无替代） | 开发者本地按需 `make verify` 或 `bash hack/verify-archtest.sh`；nightly ≤24h 兜底。round-1 曾用 pre-push K=4 fan-out 替代，因 ~3min wall + 43 GB RSS + 18-core 全打满破 sub-10s 预算 round-2 撤回 |
 | § "single authoritative owner" | ✅ owner 从 `_build-lint.yml::verify-archtest` 平移至 `archtest-nightly.yml::verify-archtest`（同名 job，不同 yaml）| 注释 + ADR 文本同 PR 重写 |
 
 §D4 / §D6 段原文同 PR 重写以与现状一致（per ai-collab.md §"ADR amendment 落地必查" 禁止"原文保留作历史脉络"）。
@@ -244,7 +244,7 @@ K=4 全胜：18-core 给 4 process 各 ~4.5 core，`go test` 内 `t.Parallel` �
 - `.github/workflows/_build-lint.yml` 删 verify-archtest job + tools shard 注释指向 nightly
 - `.github/workflows/governance.yml` VERIFY_SKIP 注释指向 nightly
 - `hack/verify-archtest.sh` "Execution modes" 文档 + 并行 fan-out 分支
-- `hack/githooks/pre-push` 用 `${SHARD_COUNT:-4}` 并行 + `go_changed || archtest_governance_changed` 触发 + 注释重写（deviation 4 / Tier 4）
+- `hack/githooks/pre-push` 撤回 archtest 调用与 governance trigger（详见 §"pre-push archtest 撤回"），保留 gofumpt / build / vet / golangci-lint / codegen-verify 等 sub-10s 友好 gate；deviation 4 重号为 golangci-lint，Tier 4 同步重号
 - `tools/archtest/archtest_ci_shard_count_test.go` yaml 路径迁移到 `archtest-nightly.yml`
 - `CLAUDE.md`、`.claude/rules/gocell/ai-collab.md` archtest 入口描述更新
 
@@ -263,3 +263,19 @@ K=4 全胜：18-core 给 4 process 各 ~4.5 core，`go test` 内 `t.Parallel` �
 - **L3 概念模型**：GitHub Issues 不是 alert backbone；真正的 alert 应走 Slack / PagerDuty webhook（语义正确的 alert 通道）
 
 裁决：同 PR 内撤回 alert-on-failure job 整段 + 顶层 `issues: write` 权限。nightly 失败靠 GHA 平台自带反馈。未来若真需要 alert backbone，使用 webhook 形式，不回到 GitHub Issues。
+
+### pre-push archtest 撤回（PR #887 review round-2）
+
+初版决策 4 把 `env SHARD_COUNT=4 bash hack/verify-archtest.sh` 接入 `hack/githooks/pre-push` 作为 PR-time 快速反馈替代（18-core / 128 GB workstation 标定 K=4 wall ~3 min / RSS 43 GB）。PR #887 review round-2 复测发现实际开发场景下：
+
+- 18-core 在 archtest 跑期间 100% 打满，与开发者其他并行任务（IDE 索引、其它 build、agent）冲突
+- 43 GB peak RSS 在 64 GB 机器上接近内存上限，触发 swap
+- pre-push 头部注释自承"breaches the sub-10s budget by 18×, but accepted"——一个 sub-10s deterministic hook 不应承载 ~3min 的重 gate
+
+激进自审三层（per ai-collab.md §"激进自审三层覆盖"）：
+
+- **L1 代码补丁**：F4（governance trigger）+ F5（SHARD_COUNT 可配置）是对一个本身不该存在的接入打两个补丁
+- **L2 PR 整体决策组合**：pre-push hook 设计目标是 sub-10s deterministic offline gate（其头部第一段明确）；把 ~3min CPU/RSS 重 gate 隐式塞进每次 `git push` 违反这个设计契约；开发者用 `git push --no-verify` 绕过的代价反向使 pre-push 形成 anti-pattern
+- **L3 概念模型**：archtest 是开发者主动触发的合规体检，不是隐式 push gate；正确语义是 explicit `make verify` / `bash hack/verify-archtest.sh`（开发者承担 CPU/RSS 代价）+ nightly 兜底（≤24h，无开发者代价）
+
+裁决：同 PR 内撤回 pre-push archtest 调用 + `archtest_governance_changed` 触发探测 + 头部 deviation 4 / Tier 4 标号；`hack/verify-archtest.sh` "Execution modes" 与并行 fan-out 能力保留（为 `make verify` 与显式调用提供选择）。未来若 CPU/RSS 代价显著下降（更小 archtest 集 / cross-shard cache）再评估接回 pre-push 的可能性。

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -114,6 +114,10 @@
 
 set -euo pipefail
 
+# $TMPDIR is user-controlled but the git hook threat model is local-only:
+# an attacker who can write $TMPDIR already has local write access and can
+# modify the hook itself. The accepted limitation is documented here rather
+# than treated as a blocker.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT}"
 
@@ -127,6 +131,9 @@ note() { printf '  pre-push: %s\n' "$1" >&2; }
 # at top level (not inside a gate `if`) so it is declared once, alongside
 # note().
 pids=() ; names=() ; logs=()
+# Cleanup tempfiles on exit/interrupt. ${logs[@]:-} is safe under set -u
+# when the array is still empty (Ctrl-C before any run_bg call).
+trap 'rm -f "${logs[@]:-}"' EXIT INT TERM
 run_bg() {
     local name="$1"; shift
     local log; log="$(mktemp "${TMPDIR:-/tmp}/prepush.XXXXXX")"
@@ -341,6 +348,9 @@ if [[ ${go_changed} -eq 1 ]]; then
     # Amendment 2026-05-23-pr-time-to-nightly). Runs on every Go push —
     # archtest guards production code patterns so the gate is tied to
     # go_changed, not test_code_changed. See header deviation 4.
+    # Low-memory machines (< 64 GB): use SHARD_COUNT=2 to cap peak RSS at
+    # ~51 GB at the cost of ~4 min wall (vs K=4 ~3 min / 43 GB). Example:
+    #   SHARD_COUNT=2 git push
     run_bg "archtest sweep (bash hack/verify-archtest.sh, K=4 parallel)" \
         env SHARD_COUNT=4 bash hack/verify-archtest.sh
 fi

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -33,29 +33,41 @@
 #     build). The other three commands do mirror real CI steps
 #     (_build-lint.yml: go build ./... / go vet ./... / go vet -tags=e2e
 #     ./tests/e2e/...).
-#   - `SHARD_COUNT=4 bash hack/verify-archtest.sh` (full archtest sweep,
-#     parallel fan-out across 4 process-isolated shards) runs here as the
-#     sole PR-time gate after ADR 202605120000 §Amendment 2026-05-23-pr-
-#     time-to-nightly moved the 16-shard CI matrix to archtest-nightly.yml.
-#     The script's "Execution modes" header makes SHARD_COUNT>1 (without
-#     SHARD_TARGET) the parallel-fan-out trigger. Workstation calibration
-#     (18-core / 128 GB Apple Silicon, macOS, ~605 Test*): K=2 wall 248s
-#     / RSS 51 GB; K=4 wall 187s / RSS 43 GB; K=8 wall ~196s / RSS ~67 GB.
-#     K=4 is the sweet spot — each shard gets ~4.5 cores for `go test`'s
+#   - `env SHARD_COUNT="${SHARD_COUNT:-4}" bash hack/verify-archtest.sh`
+#     (full archtest sweep, parallel fan-out across 4 process-isolated
+#     shards by default; callers may override e.g. `SHARD_COUNT=2 git
+#     push` on low-memory machines) runs here as the sole PR-time gate
+#     after ADR 202605120000 §Amendment 2026-05-23-pr-time-to-nightly
+#     moved the 16-shard CI matrix to archtest-nightly.yml. The script's
+#     "Execution modes" header makes SHARD_COUNT>1 (without SHARD_TARGET)
+#     the parallel-fan-out trigger. Workstation calibration (18-core /
+#     128 GB Apple Silicon, macOS, ~605 Test*): K=2 wall 248s / RSS
+#     51 GB; K=4 wall 187s / RSS 43 GB; K=8 wall ~196s / RSS ~67 GB. K=4
+#     is the sweet spot — each shard gets ~4.5 cores for `go test`'s
 #     internal t.Parallel; K=1 single-process is ~5min wall (cache shared
-#     but no concurrency); K=N serial for-loop was dropped (it was always
-#     slower than K=1: each shard re-runs packages.Load with no cross-
-#     shard cache). Gated on go_changed (any .go file in push), not
-#     test_code_changed: archtest guards production code patterns
-#     (errcode.New / panic registration / etc.), so a non-test Go change
-#     can violate an invariant just as easily as a test change. Cost: ~3
-#     min warm on the calibrated workstation. This breaches the sub-10s
-#     budget by 18×, but is accepted: the archtest matrix is no longer
-#     running on every PR CI, so push-time is the canonical fast-feedback
-#     path. A non-go push (docs only) pays 0; a Go push pays
-#     ~max(build/vet/lint/archtest) = archtest's wall-time. nightly
-#     catches anything that slips through `--no-verify` and opens a P0
-#     issue within 24h.
+#     but no concurrency); K=N serial for-loop was dropped (it was
+#     always slower than K=1: each shard re-runs packages.Load with no
+#     cross-shard cache). Gated on `go_changed || archtest_governance_
+#     changed`, not test_code_changed: archtest guards production code
+#     patterns (errcode.New / panic registration / etc.), so a non-test
+#     Go change can violate an invariant just as easily as a test
+#     change; AND any push that touches archtest's own governance
+#     surface (`.github/workflows/archtest-nightly.yml`, `hack/verify-
+#     archtest.sh`, this hook) must re-run the sweep because PR / push
+#     CI no longer runs archtest and a broken governance file surfaces
+#     only on the next scheduled nightly (≤24h later). Cost: ~3 min warm
+#     on the calibrated workstation. This breaches the sub-10s budget by
+#     18×, but is accepted: the archtest matrix is no longer running on
+#     every PR CI, so push-time is the canonical fast-feedback path. A
+#     non-go / non-governance push (docs only) pays 0; a Go or
+#     governance push pays ~max(build/vet/lint/archtest) = archtest's
+#     wall-time. nightly catches anything that slips through `--no-
+#     verify`; nightly failures surface via the workflow's default
+#     email-to-watchers and the Actions UI red ✗ (no auto-issue tier —
+#     `gh issue create` was tried in PR #887 first round and dropped on
+#     review for being a fragile `issues: write` surface; if a real
+#     alert channel is wanted later it should be Slack / PagerDuty
+#     webhook, not GitHub Issues).
 #   - golangci-lint runs CI-faithfully —
 #     `golangci-lint run --new-from-merge-base=origin/develop` with the
 #     version pinned by hack/lib/golangci-lint.sh (the project's single
@@ -181,6 +193,7 @@ if [[ ${force_all} -eq 1 ]]; then
     go_files="$(git ls-files '*.go')"
     go_changed=1
     codegen_changed=1
+    archtest_governance_changed=1
 else
     go_files="$(printf '%s\n' "${changed}" | grep -E '\.go$' || true)"
     [[ -n "${go_files}" ]] && go_changed=1 || go_changed=0
@@ -199,6 +212,17 @@ else
     # when there is legitimately no match) and test emptiness.
     codegen_hits="$(printf '%s\n' "${changed}" | grep -E '(\.schema\.json|/(cell|slice|assembly|contract)\.yaml|\.tmpl|tools/codegen/.*\.go|tools/generatedverify/.*\.go|cmd/gocell/.*\.go)$' || true)"
     [[ -n "${codegen_hits}" ]] && codegen_changed=1 || codegen_changed=0
+    # Archtest governance surface: the nightly workflow yaml that owns the
+    # CI gate, the shared shell driver, and this hook itself. A push that
+    # touches only these files has go_changed=0 (no .go diff) yet still
+    # needs the local archtest sweep — PR / push CI no longer runs
+    # archtest after ADR 202605120000 §Amendment 2026-05-23-pr-time-to-
+    # nightly, and a broken nightly yaml / shell driver / hook surfaces
+    # only on the next scheduled run (≤24h later). Use the same anti-
+    # SIGPIPE pattern as codegen_hits above (capture full, test emptiness;
+    # never `grep -q`).
+    archtest_gov_hits="$(printf '%s\n' "${changed}" | grep -E '(\.github/workflows/archtest-nightly\.yml$|hack/verify-archtest\.sh$|hack/githooks/pre-push$)' || true)"
+    [[ -n "${archtest_gov_hits}" ]] && archtest_governance_changed=1 || archtest_governance_changed=0
 fi
 
 start=$(date +%s)
@@ -332,27 +356,34 @@ if [[ ${go_changed} -eq 1 ]]; then
     run_bg "go vet -tags=e2e ./tests/e2e/..."      go vet -tags=e2e ./tests/e2e/...
 
     run_bg "golangci-lint (CI-faithful; run: make fmt / fix lint)" lint_gate
+fi
 
-    # Full archtest sweep, K=4 parallel. Without SHARD_TARGET set,
-    # verify-archtest.sh fans out concurrent shards when SHARD_COUNT>1
-    # (see its "Execution modes" header). K=1 single-process is ~5min on
-    # this codebase (~605 Test*); a K=N serial for-loop is even slower
-    # (each shard re-runs packages.Load with no shared *types.Info
-    # cache). Workstation calibration (18-core / 128 GB Apple Silicon,
-    # macOS): K=2 wall 248s / RSS 51 GB; K=4 wall 187s / RSS 43 GB;
-    # K=8 wall ~196s / RSS ~67 GB. K=4 is the sweet spot — 4 process-
-    # isolated shards each get ~4.5 cores for `go test`'s internal
-    # t.Parallel; K=2 over-loads per shard, K=8 starves go test of
-    # cores. CI 16-shard matrix lives in
-    # .github/workflows/archtest-nightly.yml (ADR 202605120000 §
-    # Amendment 2026-05-23-pr-time-to-nightly). Runs on every Go push —
-    # archtest guards production code patterns so the gate is tied to
-    # go_changed, not test_code_changed. See header deviation 4.
-    # Low-memory machines (< 64 GB): use SHARD_COUNT=2 to cap peak RSS at
-    # ~51 GB at the cost of ~4 min wall (vs K=4 ~3 min / 43 GB). Example:
-    #   SHARD_COUNT=2 git push
-    run_bg "archtest sweep (bash hack/verify-archtest.sh, K=4 parallel)" \
-        env SHARD_COUNT=4 bash hack/verify-archtest.sh
+# Full archtest sweep, default K=4 parallel. Gated on go_changed OR
+# archtest_governance_changed: archtest guards production Go patterns
+# (errcode.New / panic registration / etc.), so any .go push must run it;
+# AND the gate covers archtest's own governance surface (nightly yaml /
+# verify-archtest.sh / this hook) so a yaml-or-script-only push doesn't
+# bypass the local sweep — PR / push CI no longer runs archtest after ADR
+# 202605120000 §Amendment 2026-05-23-pr-time-to-nightly, and a broken
+# governance file surfaces only on the next scheduled nightly (≤24h
+# later). Without SHARD_TARGET set, verify-archtest.sh fans out
+# concurrent shards when SHARD_COUNT>1 (see its "Execution modes"
+# header). K=1 single-process is ~5min on this codebase (~605 Test*); a
+# K=N serial for-loop is even slower (each shard re-runs packages.Load
+# with no shared *types.Info cache). Workstation calibration (18-core /
+# 128 GB Apple Silicon, macOS): K=2 wall 248s / RSS 51 GB; K=4 wall 187s
+# / RSS 43 GB; K=8 wall ~196s / RSS ~67 GB. K=4 is the sweet spot — 4
+# process-isolated shards each get ~4.5 cores for `go test`'s internal
+# t.Parallel; K=2 over-loads per shard, K=8 starves go test of cores. CI
+# 16-shard matrix lives in .github/workflows/archtest-nightly.yml (ADR
+# 202605120000 §Amendment 2026-05-23-pr-time-to-nightly). See header
+# deviation 4. Low-memory machines (< 64 GB): use SHARD_COUNT=2 to cap
+# peak RSS at ~51 GB at the cost of ~4 min wall (vs K=4 ~3 min / 43 GB).
+# The `${SHARD_COUNT:-4}` shape honours caller-supplied K (example:
+# `SHARD_COUNT=2 git push`) while keeping K=4 as the calibrated default.
+if [[ ${go_changed} -eq 1 || ${archtest_governance_changed} -eq 1 ]]; then
+    run_bg "archtest sweep (bash hack/verify-archtest.sh)" \
+        env SHARD_COUNT="${SHARD_COUNT:-4}" bash hack/verify-archtest.sh
 fi
 
 if [[ ${codegen_changed} -eq 1 ]]; then

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -4,15 +4,12 @@
 # memory: ai-collab.md §1). It is NOT a full `make verify` — only the
 # subset that is (a) deterministic offline, (b) sub-10s on a WARM cache,
 # (c) high "forgot to run" rate. Infra-bound gates (go test against
-# testcontainers) stay in CI. One inclusion is structurally larger than
-# the rest: the full archtest sweep (deviation 4) runs here as the sole
-# local PR-time gate after the CI 16-shard matrix moved to
-# archtest-nightly.yml (ADR 202605120000 §Amendment 2026-05-23-pr-time-
-# to-nightly). CI-faithful golangci-lint (deviation 5) also rides the fan-
-# out. Both are ~free when warm because fan-out cost is max(gate), not the
-# sum — see deviations 4/5 for the cold-cache caveat.
+# testcontainers) stay in CI. CI-faithful golangci-lint (deviation 4) is
+# the only inclusion that breaches the sub-10s budget on cold cache; it
+# is accepted because warm steady-state is ~7s alongside build/vet, and
+# the cold cost is unavoidable CI work that the push pays regardless.
 #
-# Not a 1:1 CI mirror — five deliberate deviations:
+# Not a 1:1 CI mirror — four deliberate deviations:
 #   - The gofumpt gate runs `go run mvdan.cc/gofumpt` (version resolved from the repo
 #     go.mod) rather than an ambient $PATH `gofumpt`. A host-installed
 #     gofumpt drifts from the version the CI formatter gate enforces
@@ -33,41 +30,19 @@
 #     build). The other three commands do mirror real CI steps
 #     (_build-lint.yml: go build ./... / go vet ./... / go vet -tags=e2e
 #     ./tests/e2e/...).
-#   - `env SHARD_COUNT="${SHARD_COUNT:-4}" bash hack/verify-archtest.sh`
-#     (full archtest sweep, parallel fan-out across 4 process-isolated
-#     shards by default; callers may override e.g. `SHARD_COUNT=2 git
-#     push` on low-memory machines) runs here as the sole PR-time gate
-#     after ADR 202605120000 §Amendment 2026-05-23-pr-time-to-nightly
-#     moved the 16-shard CI matrix to archtest-nightly.yml. The script's
-#     "Execution modes" header makes SHARD_COUNT>1 (without SHARD_TARGET)
-#     the parallel-fan-out trigger. Workstation calibration (18-core /
-#     128 GB Apple Silicon, macOS, ~605 Test*): K=2 wall 248s / RSS
-#     51 GB; K=4 wall 187s / RSS 43 GB; K=8 wall ~196s / RSS ~67 GB. K=4
-#     is the sweet spot — each shard gets ~4.5 cores for `go test`'s
-#     internal t.Parallel; K=1 single-process is ~5min wall (cache shared
-#     but no concurrency); K=N serial for-loop was dropped (it was
-#     always slower than K=1: each shard re-runs packages.Load with no
-#     cross-shard cache). Gated on `go_changed || archtest_governance_
-#     changed`, not test_code_changed: archtest guards production code
-#     patterns (errcode.New / panic registration / etc.), so a non-test
-#     Go change can violate an invariant just as easily as a test
-#     change; AND any push that touches archtest's own governance
-#     surface (`.github/workflows/archtest-nightly.yml`, `hack/verify-
-#     archtest.sh`, this hook) must re-run the sweep because PR / push
-#     CI no longer runs archtest and a broken governance file surfaces
-#     only on the next scheduled nightly (≤24h later). Cost: ~3 min warm
-#     on the calibrated workstation. This breaches the sub-10s budget by
-#     18×, but is accepted: the archtest matrix is no longer running on
-#     every PR CI, so push-time is the canonical fast-feedback path. A
-#     non-go / non-governance push (docs only) pays 0; a Go or
-#     governance push pays ~max(build/vet/lint/archtest) = archtest's
-#     wall-time. nightly catches anything that slips through `--no-
-#     verify`; nightly failures surface via the workflow's default
-#     email-to-watchers and the Actions UI red ✗ (no auto-issue tier —
-#     `gh issue create` was tried in PR #887 first round and dropped on
-#     review for being a fragile `issues: write` surface; if a real
-#     alert channel is wanted later it should be Slack / PagerDuty
-#     webhook, not GitHub Issues).
+#   - archtest is NOT run here. PR #887 first round wired
+#     `SHARD_COUNT=4 bash hack/verify-archtest.sh` as a PR-time
+#     replacement after ADR 202605120000 §Amendment 2026-05-23-pr-time-
+#     to-nightly removed the matrix from PR CI; review second round
+#     dropped that inclusion. Measured cost was ~3 min wall on the
+#     calibrated 18-core workstation with 43 GB peak RSS — CPU 100% +
+#     43 GB RSS for the duration breaks the hook's sub-10s budget by
+#     18× and competes with other developer work on the machine. archtest
+#     belongs in `make verify` (developer-triggered, opt-in) and the
+#     nightly schedule (≤24h tomato; failures surface via GHA email +
+#     Actions UI + workflow_dispatch rerun) — not in an implicit
+#     pre-push gate. Developers who want PR-time archtest feedback run
+#     `bash hack/verify-archtest.sh` or `make verify` explicitly.
 #   - golangci-lint runs CI-faithfully —
 #     `golangci-lint run --new-from-merge-base=origin/develop` with the
 #     version pinned by hack/lib/golangci-lint.sh (the project's single
@@ -95,19 +70,15 @@
 #
 # Execution: every gate is independent (no shared mutable state; the Go
 # build/test cache is concurrency-safe across parallel `go` invocations),
-# so all of them — gofumpt / build×2 / vet×2 / archtest / golangci-lint /
-# codegen-verify — run in a SINGLE parallel fan-out behind one wait
-# barrier. Wall cost is ~max(slowest gate), not the sum of serial tiers.
-# Each gate is still change-gated: a docs-only push launches nothing
-# (~0s); a .go push on a WARM cache pays ~max(build/vet/lint/archtest);
-# after deviation 4 the archtest sweep is typically the slowest gate
-# (~30s-1min warm) so it dominates wall time on Go pushes. Cold-cache is
-# dominated by golangci-lint (~5min measured, see deviation 5 —
+# so all of them — gofumpt / build×2 / vet×2 / golangci-lint / codegen-
+# verify — run in a SINGLE parallel fan-out behind one wait barrier.
+# Wall cost is ~max(slowest gate), not the sum of serial tiers. Each gate
+# is still change-gated: a docs-only push launches nothing (~0s); a .go
+# push on a WARM cache pays ~max(build/vet/lint) ≈ 7-15s. Cold-cache is
+# dominated by golangci-lint (~5min measured, see deviation 4 —
 # unavoidable CI work, paid once, then warm); a schema/contract push
 # additionally runs the codegen staleness probe in the same fan-out (no
-# extra wall time unless it is the slowest job). The "Tier N" labels
-# below are kept only as stable gate identities for cross-references;
-# they no longer imply serial ordering.
+# extra wall time unless it is the slowest job).
 #
 # Honest scope (ai-collab grading): this is Medium AI-rebust — `git push
 # --no-verify` bypasses it and a fresh clone/worktree without
@@ -193,7 +164,6 @@ if [[ ${force_all} -eq 1 ]]; then
     go_files="$(git ls-files '*.go')"
     go_changed=1
     codegen_changed=1
-    archtest_governance_changed=1
 else
     go_files="$(printf '%s\n' "${changed}" | grep -E '\.go$' || true)"
     [[ -n "${go_files}" ]] && go_changed=1 || go_changed=0
@@ -212,17 +182,6 @@ else
     # when there is legitimately no match) and test emptiness.
     codegen_hits="$(printf '%s\n' "${changed}" | grep -E '(\.schema\.json|/(cell|slice|assembly|contract)\.yaml|\.tmpl|tools/codegen/.*\.go|tools/generatedverify/.*\.go|cmd/gocell/.*\.go)$' || true)"
     [[ -n "${codegen_hits}" ]] && codegen_changed=1 || codegen_changed=0
-    # Archtest governance surface: the nightly workflow yaml that owns the
-    # CI gate, the shared shell driver, and this hook itself. A push that
-    # touches only these files has go_changed=0 (no .go diff) yet still
-    # needs the local archtest sweep — PR / push CI no longer runs
-    # archtest after ADR 202605120000 §Amendment 2026-05-23-pr-time-to-
-    # nightly, and a broken nightly yaml / shell driver / hook surfaces
-    # only on the next scheduled run (≤24h later). Use the same anti-
-    # SIGPIPE pattern as codegen_hits above (capture full, test emptiness;
-    # never `grep -q`).
-    archtest_gov_hits="$(printf '%s\n' "${changed}" | grep -E '(\.github/workflows/archtest-nightly\.yml$|hack/verify-archtest\.sh$|hack/githooks/pre-push$)' || true)"
-    [[ -n "${archtest_gov_hits}" ]] && archtest_governance_changed=1 || archtest_governance_changed=0
 fi
 
 start=$(date +%s)
@@ -313,17 +272,9 @@ lint_gate() {
 #   Tier 2  build/vet ×4      — whole-module compile + vet; integration
 #                               and e2e tags are the header-documented
 #                               deliberate CI-structure deviations.
-#   Tier 5  golangci-lint     — CI-faithful PR-mode lint
+#   Tier 4  golangci-lint     — CI-faithful PR-mode lint
 #                               (--new-from-merge-base=origin/develop);
-#                               warm ~7s, cold ~5min (deviation 5).
-#   Tier 4  archtest sweep    — SHARD_COUNT=4 bash hack/verify-archtest.sh
-#                               (parallel fan-out across 4 process-
-#                               isolated shards, all ~605 Test*), gated
-#                               on go_changed (archtest guards
-#                               production code patterns; see deviation
-#                               4). Typically the slowest gate on a Go
-#                               push (~3min warm on calibrated 18-core
-#                               workstation).
+#                               warm ~7s, cold ~5min (deviation 4).
 #   Tier 3  codegen staleness — only when a codegen *source* changed; can
 #                               fire with go_changed=0 (schema/tmpl-only
 #                               push), so it has its own gate, not nested
@@ -356,34 +307,6 @@ if [[ ${go_changed} -eq 1 ]]; then
     run_bg "go vet -tags=e2e ./tests/e2e/..."      go vet -tags=e2e ./tests/e2e/...
 
     run_bg "golangci-lint (CI-faithful; run: make fmt / fix lint)" lint_gate
-fi
-
-# Full archtest sweep, default K=4 parallel. Gated on go_changed OR
-# archtest_governance_changed: archtest guards production Go patterns
-# (errcode.New / panic registration / etc.), so any .go push must run it;
-# AND the gate covers archtest's own governance surface (nightly yaml /
-# verify-archtest.sh / this hook) so a yaml-or-script-only push doesn't
-# bypass the local sweep — PR / push CI no longer runs archtest after ADR
-# 202605120000 §Amendment 2026-05-23-pr-time-to-nightly, and a broken
-# governance file surfaces only on the next scheduled nightly (≤24h
-# later). Without SHARD_TARGET set, verify-archtest.sh fans out
-# concurrent shards when SHARD_COUNT>1 (see its "Execution modes"
-# header). K=1 single-process is ~5min on this codebase (~605 Test*); a
-# K=N serial for-loop is even slower (each shard re-runs packages.Load
-# with no shared *types.Info cache). Workstation calibration (18-core /
-# 128 GB Apple Silicon, macOS): K=2 wall 248s / RSS 51 GB; K=4 wall 187s
-# / RSS 43 GB; K=8 wall ~196s / RSS ~67 GB. K=4 is the sweet spot — 4
-# process-isolated shards each get ~4.5 cores for `go test`'s internal
-# t.Parallel; K=2 over-loads per shard, K=8 starves go test of cores. CI
-# 16-shard matrix lives in .github/workflows/archtest-nightly.yml (ADR
-# 202605120000 §Amendment 2026-05-23-pr-time-to-nightly). See header
-# deviation 4. Low-memory machines (< 64 GB): use SHARD_COUNT=2 to cap
-# peak RSS at ~51 GB at the cost of ~4 min wall (vs K=4 ~3 min / 43 GB).
-# The `${SHARD_COUNT:-4}` shape honours caller-supplied K (example:
-# `SHARD_COUNT=2 git push`) while keeping K=4 as the calibrated default.
-if [[ ${go_changed} -eq 1 || ${archtest_governance_changed} -eq 1 ]]; then
-    run_bg "archtest sweep (bash hack/verify-archtest.sh)" \
-        env SHARD_COUNT="${SHARD_COUNT:-4}" bash hack/verify-archtest.sh
 fi
 
 if [[ ${codegen_changed} -eq 1 ]]; then

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -4,11 +4,13 @@
 # memory: ai-collab.md §1). It is NOT a full `make verify` — only the
 # subset that is (a) deterministic offline, (b) sub-10s on a WARM cache,
 # (c) high "forgot to run" rate. Infra-bound gates (go test against
-# testcontainers, the full archtest 16-shard matrix) stay in CI. Two
-# carved-out exceptions ride the parallel fan-out: the single archtest
-# rule TEST-TIME-LITERAL-01 (deviation 4) and CI-faithful golangci-lint
-# (deviation 5). Both are ~free when warm because the fan-out cost is
-# max(gate), not the sum — see deviations 4/5 for the cold-cache caveat.
+# testcontainers) stay in CI. One inclusion is structurally larger than
+# the rest: the full archtest sweep (deviation 4) runs here as the sole
+# local PR-time gate after the CI 16-shard matrix moved to
+# archtest-nightly.yml (ADR 202605120000 §Amendment 2026-05-23-pr-time-
+# to-nightly). CI-faithful golangci-lint (deviation 5) also rides the fan-
+# out. Both are ~free when warm because fan-out cost is max(gate), not the
+# sum — see deviations 4/5 for the cold-cache caveat.
 #
 # Not a 1:1 CI mirror — five deliberate deviations:
 #   - The gofumpt gate runs `go run mvdan.cc/gofumpt` (version resolved from the repo
@@ -31,22 +33,29 @@
 #     build). The other three commands do mirror real CI steps
 #     (_build-lint.yml: go build ./... / go vet ./... / go vet -tags=e2e
 #     ./tests/e2e/...).
-#   - One archtest rule — `go test -run ^TestTestTimeLiteralConst$
-#     ./tools/archtest` (TEST-TIME-LITERAL-01) — runs even though the
-#     header otherwise keeps archtest in CI. It qualifies on all three
-#     inclusion criteria: pure offline AST/type analysis (deterministic),
-#     ~6-7s on a warm cache (a `go/packages` typed full-module load — NOT
-#     the ~1-2s the test's own comment claims, which counts only the AST
-#     walk), and a repeatedly-forgotten failure mode for AI co-authors who
-#     add a `time.Duration` literal in a *_test.go without hoisting it to a
-#     package-level const. To stay within the sub-10s budget it rides the
-#     single parallel fan-out (see "Execution" below) and is gated on
-#     test-code file changes (test_code_re), so a non-test push pays ~0
-#     and a test-code push pays ~max(build/vet, archtest) ≈ 7-9s, not the
-#     sum. The rest of the archtest matrix (process-isolated 16-shard,
-#     4GB+ RSS) stays in CI — this is a single ~7s test function, not the
-#     suite. run_bg isolates each job's output to its own logfile, so
-#     parallel execution does not interleave failure logs.
+#   - `SHARD_COUNT=4 bash hack/verify-archtest.sh` (full archtest sweep,
+#     parallel fan-out across 4 process-isolated shards) runs here as the
+#     sole PR-time gate after ADR 202605120000 §Amendment 2026-05-23-pr-
+#     time-to-nightly moved the 16-shard CI matrix to archtest-nightly.yml.
+#     The script's "Execution modes" header makes SHARD_COUNT>1 (without
+#     SHARD_TARGET) the parallel-fan-out trigger. Workstation calibration
+#     (18-core / 128 GB Apple Silicon, macOS, ~605 Test*): K=2 wall 248s
+#     / RSS 51 GB; K=4 wall 187s / RSS 43 GB; K=8 wall ~196s / RSS ~67 GB.
+#     K=4 is the sweet spot — each shard gets ~4.5 cores for `go test`'s
+#     internal t.Parallel; K=1 single-process is ~5min wall (cache shared
+#     but no concurrency); K=N serial for-loop was dropped (it was always
+#     slower than K=1: each shard re-runs packages.Load with no cross-
+#     shard cache). Gated on go_changed (any .go file in push), not
+#     test_code_changed: archtest guards production code patterns
+#     (errcode.New / panic registration / etc.), so a non-test Go change
+#     can violate an invariant just as easily as a test change. Cost: ~3
+#     min warm on the calibrated workstation. This breaches the sub-10s
+#     budget by 18×, but is accepted: the archtest matrix is no longer
+#     running on every PR CI, so push-time is the canonical fast-feedback
+#     path. A non-go push (docs only) pays 0; a Go push pays
+#     ~max(build/vet/lint/archtest) = archtest's wall-time. nightly
+#     catches anything that slips through `--no-verify` and opens a P0
+#     issue within 24h.
 #   - golangci-lint runs CI-faithfully —
 #     `golangci-lint run --new-from-merge-base=origin/develop` with the
 #     version pinned by hack/lib/golangci-lint.sh (the project's single
@@ -78,14 +87,15 @@
 # codegen-verify — run in a SINGLE parallel fan-out behind one wait
 # barrier. Wall cost is ~max(slowest gate), not the sum of serial tiers.
 # Each gate is still change-gated: a docs-only push launches nothing
-# (~0s); a .go push on a WARM cache pays ~max(build/vet/archtest/lint) ≈
-# 7-9s; a .go push on a COLD cache is dominated by golangci-lint
-# (~5min measured, see deviation 5 — unavoidable CI work, paid once,
-# then warm); a schema/contract push additionally runs the codegen
-# staleness probe in the same fan-out (no extra wall time unless it is
-# the slowest job). The "Tier N" labels below are kept only as stable
-# gate identities for cross-references; they no longer imply serial
-# ordering.
+# (~0s); a .go push on a WARM cache pays ~max(build/vet/lint/archtest);
+# after deviation 4 the archtest sweep is typically the slowest gate
+# (~30s-1min warm) so it dominates wall time on Go pushes. Cold-cache is
+# dominated by golangci-lint (~5min measured, see deviation 5 —
+# unavoidable CI work, paid once, then warm); a schema/contract push
+# additionally runs the codegen staleness probe in the same fan-out (no
+# extra wall time unless it is the slowest job). The "Tier N" labels
+# below are kept only as stable gate identities for cross-references;
+# they no longer imply serial ordering.
 #
 # Honest scope (ai-collab grading): this is Medium AI-rebust — `git push
 # --no-verify` bypasses it and a fresh clone/worktree without
@@ -160,43 +170,26 @@ for r in "${ranges[@]}"; do
     changed+=$'\n'"$(git diff --name-only --diff-filter=ACMR "${r}" 2>/dev/null || true)"
 done
 
-# test_code_re mirrors tools/internal/fileroles.IsTestCode (the canonical
-# classifier TEST-TIME-LITERAL-01 scans): *_test.go / **/conformance.go /
-# the six **/<x>test/ helper trees, minus the hard exclusions
-# (tools/archtest/, vendor/, generated/, any testdata/). A bash regex is a
-# deliberate approximation — a miss only degrades to "CI catches it" (header
-# philosophy: the hook is an aid, not the SoT). The gate itself still scans
-# the WHOLE module's test code; this trigger only decides whether *this push*
-# is likely to have introduced a new test-time literal worth the ~2s probe.
-test_code_re='(_test\.go|/conformance\.go|/(locktest|outboxtest|storetest|healthtest|contracttest|commandtest)/)'
-test_code_excl='^(tools/archtest/|vendor/|generated/)|/testdata/|^testdata/'
-
 if [[ ${force_all} -eq 1 ]]; then
     go_files="$(git ls-files '*.go')"
     go_changed=1
     codegen_changed=1
-    test_code_changed=1
 else
     go_files="$(printf '%s\n' "${changed}" | grep -E '\.go$' || true)"
     [[ -n "${go_files}" ]] && go_changed=1 || go_changed=0
-    # NEVER pipe into `grep -q` here. `grep -q` exits on the first match,
-    # closing the pipe; on a large changeset (>~64KB of paths — routine for
-    # a multi-commit merge-base..HEAD range) the upstream producer is still
+    # Codegen sources: schema / contract|cell|slice|assembly yaml / any
+    # template, plus the generators and the staleness verifier themselves
+    # (tools/codegen, tools/generatedverify, cmd/gocell). NEVER pipe into
+    # `grep -q` here. `grep -q` exits on the first match, closing the
+    # pipe; on a large changeset (>~64KB of paths — routine for a multi-
+    # commit merge-base..HEAD range) the upstream producer is still
     # writing and dies with SIGPIPE (exit 141). Under `set -o pipefail`
-    # that makes the whole pipeline non-zero, the `if` false, and the gate
-    # is SILENTLY SKIPPED — a fail-OPEN false-negative that defeats the
-    # gate's purpose and contradicts the hook's fail-closed contract
+    # that makes the whole pipeline non-zero, the `if` false, and the
+    # gate is SILENTLY SKIPPED — a fail-OPEN false-negative that defeats
+    # the gate's purpose and contradicts the hook's fail-closed contract
     # (reproduced: status=141 every trial at ~420KB). Instead capture the
     # full (no -q) match into a var with `|| true` (neutralises pipefail
     # when there is legitimately no match) and test emptiness.
-    test_hits="$(printf '%s\n' "${changed}" | grep -E "${test_code_re}" | grep -vE "${test_code_excl}" || true)"
-    [[ -n "${test_hits}" ]] && test_code_changed=1 || test_code_changed=0
-    # Codegen sources: schema / contract|cell|slice|assembly yaml / any
-    # template, plus the generators and the staleness verifier themselves
-    # (tools/codegen, tools/generatedverify, cmd/gocell). Same no-`grep -q`
-    # rule as above (this site previously used `grep -qE` and had the
-    # identical SIGPIPE false-negative). A miss here only degrades to "CI
-    # catches it" — the hook is an aid, not the SoT.
     codegen_hits="$(printf '%s\n' "${changed}" | grep -E '(\.schema\.json|/(cell|slice|assembly|contract)\.yaml|\.tmpl|tools/codegen/.*\.go|tools/generatedverify/.*\.go|cmd/gocell/.*\.go)$' || true)"
     [[ -n "${codegen_hits}" ]] && codegen_changed=1 || codegen_changed=0
 fi
@@ -292,11 +285,14 @@ lint_gate() {
 #   Tier 5  golangci-lint     — CI-faithful PR-mode lint
 #                               (--new-from-merge-base=origin/develop);
 #                               warm ~7s, cold ~5min (deviation 5).
-#   Tier 4  TEST-TIME-LITERAL-01 — one archtest rule, only when a
-#                               test-code .go file changed (test_code_re
-#                               mirrors fileroles.IsTestCode;
-#                               test_code_changed=1 ⇒ go_changed=1 since
-#                               every test-code path is a .go file).
+#   Tier 4  archtest sweep    — SHARD_COUNT=4 bash hack/verify-archtest.sh
+#                               (parallel fan-out across 4 process-
+#                               isolated shards, all ~605 Test*), gated
+#                               on go_changed (archtest guards
+#                               production code patterns; see deviation
+#                               4). Typically the slowest gate on a Go
+#                               push (~3min warm on calibrated 18-core
+#                               workstation).
 #   Tier 3  codegen staleness — only when a codegen *source* changed; can
 #                               fire with go_changed=0 (schema/tmpl-only
 #                               push), so it has its own gate, not nested
@@ -330,10 +326,23 @@ if [[ ${go_changed} -eq 1 ]]; then
 
     run_bg "golangci-lint (CI-faithful; run: make fmt / fix lint)" lint_gate
 
-    if [[ ${test_code_changed} -eq 1 ]]; then
-        run_bg "TEST-TIME-LITERAL-01 (go test -run ^TestTestTimeLiteralConst\$ ./tools/archtest)" \
-            go test -count=1 -run '^TestTestTimeLiteralConst$' ./tools/archtest
-    fi
+    # Full archtest sweep, K=4 parallel. Without SHARD_TARGET set,
+    # verify-archtest.sh fans out concurrent shards when SHARD_COUNT>1
+    # (see its "Execution modes" header). K=1 single-process is ~5min on
+    # this codebase (~605 Test*); a K=N serial for-loop is even slower
+    # (each shard re-runs packages.Load with no shared *types.Info
+    # cache). Workstation calibration (18-core / 128 GB Apple Silicon,
+    # macOS): K=2 wall 248s / RSS 51 GB; K=4 wall 187s / RSS 43 GB;
+    # K=8 wall ~196s / RSS ~67 GB. K=4 is the sweet spot — 4 process-
+    # isolated shards each get ~4.5 cores for `go test`'s internal
+    # t.Parallel; K=2 over-loads per shard, K=8 starves go test of
+    # cores. CI 16-shard matrix lives in
+    # .github/workflows/archtest-nightly.yml (ADR 202605120000 §
+    # Amendment 2026-05-23-pr-time-to-nightly). Runs on every Go push —
+    # archtest guards production code patterns so the gate is tied to
+    # go_changed, not test_code_changed. See header deviation 4.
+    run_bg "archtest sweep (bash hack/verify-archtest.sh, K=4 parallel)" \
+        env SHARD_COUNT=4 bash hack/verify-archtest.sh
 fi
 
 if [[ ${codegen_changed} -eq 1 ]]; then

--- a/hack/verify-archtest.sh
+++ b/hack/verify-archtest.sh
@@ -19,14 +19,14 @@
 #   SHARD_COUNT       Number of shards to partition Test* functions across.
 #                     Default 1 (local-friendly: single process, ~300 Test*
 #                     share *types.Info cache, lowest CPU). CI explicitly
-#                     sets SHARD_COUNT=16 in .github/workflows/_build-lint.yml
+#                     sets SHARD_COUNT=16 in .github/workflows/archtest-nightly.yml
 #                     verify-archtest job — required by GHA 2-core 7 GB
 #                     shard runner RSS budget (Phase 0 measured max peak RSS
 #                     4.22 GB / shard on macOS for K=16; safe under Linux
 #                     7 GB GHA). See ADR 202605120000.
 #   SHARD_TARGET      If set, run only that shard index [0, SHARD_COUNT).
-#                     Used by CI matrix. If empty, all shards run serially
-#                     in this process invocation.
+#                     Used by CI matrix. If empty, see "Execution modes"
+#                     header for the SHARD_COUNT-derived behavior.
 #   TIMEOUT           Go test timeout per shard. Default 5m.
 #   SLOWGATE_BIN      Path to slowgate binary. If executable, each shard's
 #                     `go test -json` stream is piped through it. If unset/
@@ -68,7 +68,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 readonly ARCHTEST_PKG="./tools/archtest"
 # Default 1 (local). CI sets SHARD_COUNT=16 explicitly in
-# .github/workflows/_build-lint.yml::verify-archtest (GHA 7 GB RSS budget).
+# .github/workflows/archtest-nightly.yml::verify-archtest (GHA 7 GB RSS budget).
 # These two values intentionally differ — they encode "local vs CI context"
 # rather than a single global truth, so no SYNC guard is required.
 readonly SHARD_COUNT="${SHARD_COUNT:-1}"
@@ -185,6 +185,9 @@ else
   # packages.Load with no cross-shard cache) and no caller used it.
   pids=()
   logs=()
+  # Cleanup tempfiles on exit/interrupt. ${logs[@]:-} is safe under set -u
+  # when the array is still empty (Ctrl-C before any mktemp).
+  trap 'rm -f "${logs[@]:-}"' EXIT INT TERM
   for s in $(seq 0 $((SHARD_COUNT - 1))); do
     log=$(mktemp "${TMPDIR:-/tmp}/archtest-shard-XXXXXX")
     ( run_shard "$s" ) > "$log" 2>&1 &

--- a/hack/verify-archtest.sh
+++ b/hack/verify-archtest.sh
@@ -42,6 +42,25 @@
 #                     Goes through the same shard_pattern() function that
 #                     run_shard() uses — single source of truth for the
 #                     modulo assignment algorithm.
+#
+# Execution modes (no opt-in flag — derived from env shape):
+#   SHARD_TARGET set                  → single shard per process (CI matrix).
+#   SHARD_TARGET unset, SHARD_COUNT=1 → single shard, streaming stdout (local default).
+#   SHARD_TARGET unset, SHARD_COUNT>1 → all shards concurrent (background `&` +
+#                                       wait barrier; each shard's combined
+#                                       output buffered to a tempfile and
+#                                       flushed in shard order after wait).
+#                                       For the pre-push hook on a workstation
+#                                       where K=1 single-process ~5min wall is
+#                                       too slow and a K=N serial for-loop is
+#                                       even slower (each shard re-runs
+#                                       packages.Load with no cross-shard
+#                                       cache). RSS scales linearly: K=8 ≈ 33
+#                                       GB peak on macOS — sized for workstation
+#                                       use, not GHA 7 GB runners (which keep
+#                                       using SHARD_TARGET single-shard).
+#                                       See ADR 202605120000 §Amendment
+#                                       2026-05-23-pr-time-to-nightly.
 
 set -euo pipefail
 
@@ -149,11 +168,41 @@ run_shard() {
 }
 
 if [ -n "${SHARD_TARGET:-}" ]; then
+  # CI matrix path: single shard per process (each GHA matrix entry sets
+  # SHARD_TARGET=<s> for true cross-runner parallelism).
   run_shard "$SHARD_TARGET"
+elif [ "$SHARD_COUNT" -le 1 ]; then
+  # Local default (SHARD_COUNT=1): single shard, streaming stdout — gives
+  # the developer live test progress instead of a buffered post-mortem.
+  run_shard 0
 else
+  # Local multi-shard path (SHARD_COUNT>1, no SHARD_TARGET): parallel
+  # fan-out. Each shard is process-isolated (no shared mutable state), so
+  # they run concurrently. Capture per-shard combined output to a tempfile,
+  # join at one wait barrier, then emit logs in shard order so the
+  # interleaved console output remains readable. Serial multi-shard mode
+  # was dropped — it was always slower than K=1 (each shard re-loads
+  # packages.Load with no cross-shard cache) and no caller used it.
+  pids=()
+  logs=()
   for s in $(seq 0 $((SHARD_COUNT - 1))); do
-    run_shard "$s"
+    log=$(mktemp "${TMPDIR:-/tmp}/archtest-shard-XXXXXX")
+    ( run_shard "$s" ) > "$log" 2>&1 &
+    pids+=($!)
+    logs+=("$log")
   done
+  fail=0
+  for i in "${!pids[@]}"; do
+    if ! wait "${pids[$i]}"; then
+      fail=1
+    fi
+    cat "${logs[$i]}"
+    rm -f "${logs[$i]}"
+  done
+  if [ "$fail" -ne 0 ]; then
+    echo "verify-archtest: FAIL (SHARD_COUNT=$SHARD_COUNT parallel, TOTAL=$TOTAL)" >&2
+    exit 1
+  fi
 fi
 
 echo "verify-archtest: PASS (SHARD_COUNT=$SHARD_COUNT, TOTAL=$TOTAL)"

--- a/tools/archtest/archtest_ci_shard_count_test.go
+++ b/tools/archtest/archtest_ci_shard_count_test.go
@@ -23,8 +23,8 @@ import (
 const verifyArchtestScriptMarker = "hack/verify-archtest.sh"
 
 // TestVerifyArchtestCIExplicitShardCount asserts that the verify-archtest
-// CI job in .github/workflows/_build-lint.yml sets SHARD_COUNT=16 explicitly
-// in step env, rather than relying on the script default.
+// CI job in .github/workflows/archtest-nightly.yml sets SHARD_COUNT=16
+// explicitly in step env, rather than relying on the script default.
 //
 // Background: hack/verify-archtest.sh default SHARD_COUNT is 1 (local-friendly:
 // single process, ~300 Test* share *types.Info cache, lowest CPU). CI must set
@@ -37,11 +37,17 @@ const verifyArchtestScriptMarker = "hack/verify-archtest.sh"
 // must explicit SHARD_COUNT=16" cannot be bypassed without modifying this
 // archtest in the same PR. Violation is reviewer-visible diff.
 //
+// History: PR #878 introduced this guard against .github/workflows/_build-
+// lint.yml (the then-only CI gate). Per ADR 202605120000 §Amendment 2026-
+// 05-23-pr-time-to-nightly the matrix moved to archtest-nightly.yml and the
+// PR-time job was deleted; the guard now targets the nightly yaml. Local
+// PR-time fast-feedback is hack/githooks/pre-push (K=1 sweep).
+//
 // ref: ADR docs/architecture/202605120000-adr-archtest-process-isolation.md
-// §Amendment 2026-05-23.
+// §Amendment 2026-05-23 + §Amendment 2026-05-23-pr-time-to-nightly.
 func TestVerifyArchtestCIExplicitShardCount(t *testing.T) {
 	root := findModuleRoot(t)
-	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "_build-lint.yml")))
+	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "archtest-nightly.yml")))
 	require.NoError(t, err)
 	require.NoError(t, validateVerifyArchtestExplicitShardCount(body))
 }
@@ -187,11 +193,11 @@ func validateVerifyArchtestExplicitShardCount(body []byte) error {
 	var cfg archtestWorkflowConfig
 	dec := yaml.NewDecoder(bytes.NewReader(body))
 	if err := dec.Decode(&cfg); err != nil {
-		return fmt.Errorf("parse _build-lint.yml: %w", err)
+		return fmt.Errorf("parse archtest-nightly.yml: %w", err)
 	}
 	job, ok := cfg.Jobs["verify-archtest"]
 	if !ok {
-		return fmt.Errorf("ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01: jobs.verify-archtest missing from _build-lint.yml")
+		return fmt.Errorf("ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01: jobs.verify-archtest missing from archtest-nightly.yml")
 	}
 	invocations := 0
 	for _, step := range job.Steps {

--- a/tools/archtest/archtest_ci_shard_count_test.go
+++ b/tools/archtest/archtest_ci_shard_count_test.go
@@ -37,11 +37,10 @@ const verifyArchtestScriptMarker = "hack/verify-archtest.sh"
 // must explicit SHARD_COUNT=16" cannot be bypassed without modifying this
 // archtest in the same PR. Violation is reviewer-visible diff.
 //
-// History: PR #878 introduced this guard against .github/workflows/_build-
-// lint.yml (the then-only CI gate). Per ADR 202605120000 §Amendment 2026-
-// 05-23-pr-time-to-nightly the matrix moved to archtest-nightly.yml and the
-// PR-time job was deleted; the guard now targets the nightly yaml. Local
-// PR-time fast-feedback is hack/githooks/pre-push (K=1 sweep).
+// The guard targets .github/workflows/archtest-nightly.yml — the sole
+// authoritative CI gate for the archtest matrix (ADR 202605120000
+// §Amendment 2026-05-23-pr-time-to-nightly). Local PR-time fast-feedback
+// is hack/githooks/pre-push (K=4 parallel fan-out).
 //
 // ref: ADR docs/architecture/202605120000-adr-archtest-process-isolation.md
 // §Amendment 2026-05-23 + §Amendment 2026-05-23-pr-time-to-nightly.


### PR DESCRIPTION
## Summary

PR-time archtest 16-shard matrix in `_build-lint.yml` accumulated three classes of brittleness:
1. **modulo-shift SLOW** — new test → discovery reshuffle → slow test crosses 20s slowgate budget
2. **tagGroup template OOM** — fixed in PR #870, but the template's existence taught the lesson
3. **GHA runner spot preempt amplified 16×** — PR #878's final merge had `shard 5` fail with `The runner has received a shutdown signal`, non-archtest fault

This PR moves the matrix to a nightly schedule and replaces PR-time CI feedback with a local parallel pre-push hook.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/archtest-nightly.yml` | **new** — schedule cron `0 18 * * *` + 16-shard matrix + alert-on-failure auto-opens a P0 issue via the hosted runner's `gh` CLI (no new pinned-SHA action dependency) |
| `.github/workflows/_build-lint.yml` | delete `verify-archtest` job (~60 lines); tools shard comments updated to point at nightly |
| `.github/workflows/governance.yml` | `VERIFY_SKIP=archtest` comment updated to point at nightly yaml |
| `hack/verify-archtest.sh` | new "Execution modes" header; `SHARD_COUNT>1` without `SHARD_TARGET` triggers parallel fan-out (background `&` + wait + per-shard tempfile log); drop dead K=N serial for-loop |
| `hack/githooks/pre-push` | archtest sweep `SHARD_COUNT=4` parallel replaces `TEST-TIME-LITERAL-01` single-rule sample; deviation 4 + Tier 4 + header comments rewritten |
| `tools/archtest/archtest_ci_shard_count_test.go` | `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` yaml path → `archtest-nightly.yml`; 6 fixtures preserved (step-scoped match-all from PR #878) |
| `docs/architecture/202605120000-adr-archtest-process-isolation.md` | (a) amend PR 878 §"新约束 Medium 守卫" to match as-shipped step-scoped/6-fixture reality (drift fix); (b) add §Amendment 2026-05-23-pr-time-to-nightly with threat-matrix re-eval + K-value calibration data |
| `CLAUDE.md` + `.claude/rules/gocell/ai-collab.md` | archtest CI entry description updated (nightly + pre-push, not PR matrix) |

## K-value calibration (18-core / 128 GB Apple Silicon, macOS, ~605 Test*)

| K | real wall | max shard | peak RSS | tests/shard | verdict |
|---|----------|-----------|----------|-------------|---------|
| K=1 single-process | ~5min (user-reported) | n/a | ~20 GB | 605 | cache shared but no concurrency |
| K=2 parallel | 248s (4m 8s) | 246s | 51 GB | 302 | per-shard too large |
| **K=4 parallel** | **187s (3m 7s)** | **185s** | **43 GB** | 151 | **sweet spot** |
| K=8 parallel | ~196s (3m 16s) | 196s | ~67 GB | 76 | go test starved of cores |

K=4 chosen: 4 process-isolated shards × ~4.5 cores each = saturated `go test -p` internal parallelism without core oversubscription.

## Test plan

- [x] `go test ./tools/archtest -run TestVerifyArchtestCIExplicitShardCount` → all 6 fixtures PASS against migrated nightly yaml
- [x] `go test ./tools/archtest -run TestArchtestVerifyCoverage01` → PASS (script discovery vs AST scan still aligned)
- [x] `go test ./tools/archtest -run TestWorkflowExternalUsesPinnedToSHA` → PASS (nightly yaml's `gh issue create` shell step replaces `actions/github-script@v7` — no SHA pin needed)
- [x] `SHARD_COUNT=4 bash hack/verify-archtest.sh` locally → PASS in 187-220s, 605 tests
- [x] `go build ./...` clean
- [x] golangci-lint PR mode (new-from-merge-base) → 0 issues
- [x] shellcheck `verify-archtest.sh` → 0 issues (pre-push SC2329 infos are pre-existing false positives — `run_bg` invokes by string)
- [x] `git push` triggered new pre-push hook (266s including build/vet/lint fanout) → ok
- [ ] After merge: `gh workflow run archtest-nightly.yml` to verify the new nightly path end-to-end (16-shard matrix + alert-on-failure)

## OSS ref

- ref: kubernetes/community sig-testing nightly long-test pattern (separate cron jobs for matrix-heavy checks)
- ref: ADR `docs/architecture/202605120000-adr-archtest-process-isolation.md` §Amendment 2026-05-23-pr-time-to-nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)