### PR TITLE
perf(adapters/postgres): shared PG test container, 237s→28s

### DIFF
--- a/adapters/postgres/audit_ledger_store_test.go
+++ b/adapters/postgres/audit_ledger_store_test.go
@@ -4,8 +4,6 @@ package postgres
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -19,16 +17,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/runtime/audit/ledger/storetest"
 )
-
-// migrationsTableName builds a per-test migrations tracking table name that
-// fits PostgreSQL's 63-char identifier limit and contains only [a-zA-Z0-9_]
-// (passed through validateIdentifier). t.Name() may include "/" for sub-tests
-// and grow well beyond 63 chars, so we hash it to an 8-char hex suffix.
-func migrationsTableName(t *testing.T, prefix string) string {
-	t.Helper()
-	h := sha256.Sum256([]byte(t.Name()))
-	return prefix + hex.EncodeToString(h[:4]) // 8 hex chars
-}
 
 // newTestLedgerProtocol constructs a Protocol for the "auditcore" namespace used
 // throughout these integration tests. Fails the test immediately if construction fails.
@@ -48,23 +36,17 @@ func newTestLedgerProtocol(t *testing.T, ns ledger.NamespaceID) *ledger.Protocol
 	return p
 }
 
-// newIsolatedLedgerStore creates an isolated schema, runs all migrations, and
+// newIsolatedLedgerStore creates a fresh per-test DB (migratedPool) and
 // returns a *LedgerStore plus its cleanup function. The factory is reusable
 // across all sub-tests in this file.
 func newIsolatedLedgerStore(
 	t *testing.T,
-	ctx context.Context,
-	base *Pool,
 	protocol *ledger.Protocol,
 	fc *clockmock.FakeClock,
 ) (*LedgerStore, func()) {
 	t.Helper()
 
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), migrationsTableName(t, "schema_migrations_ledger_"))
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
+	p := migratedPool(t)
 	txm := NewTxManager(p)
 
 	store, err := NewLedgerStore(p.DB(), txm, protocol, fc)
@@ -81,21 +63,13 @@ func newIsolatedLedgerStore(
 // against a real PostgreSQL backend. All cases defined in storetest.Run must
 // pass on the PG store to confirm protocol-level contract parity with MemStore.
 func TestAuditLedgerStore_StoretestSuite(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
-	ctx := context.Background()
 	protocol := storetest.NewTestProtocol(t)
 
 	factory := storetest.Factory(func(t *testing.T) (ledger.Store, *clockmock.FakeClock, func()) {
 		t.Helper()
 		fc := clockmock.New(storetest.EpochAnchor())
 
-		p := isolatedSchemaPool(t, ctx, base)
-		migrator, err := NewMigrator(p, testMigrationsFS(t), migrationsTableName(t, "schema_migrations_suite_"))
-		require.NoError(t, err)
-		require.NoError(t, migrator.Up(ctx))
-
+		p := migratedPool(t)
 		txm := NewTxManager(p)
 		store, err := NewLedgerStore(p.DB(), txm, protocol, fc)
 		require.NoError(t, err)
@@ -117,27 +91,19 @@ func TestAuditLedgerStore_StoretestSuite(t *testing.T) {
 // connection pool to the same DB.
 //
 // F26: Current limitation — both pool A and pool B share the same *pgxpool.Pool
-// from setupPostgres. This simulates application restart by constructing a fresh
+// from migratedPool. This simulates application restart by constructing a fresh
 // TxManager + Store on the same DB; true cross-pool restart (separate pgxpool.New
 // calls to the same DSN) needs testcontainer-level DSN access which is not exposed
-// by the current setupPostgres helper. The Tail-consistency invariant is verified
+// by the current migratedPool helper. The Tail-consistency invariant is verified
 // by constructing a second LedgerStore on the same underlying pool.
 func TestAuditLedgerStore_RestartRecovery_AcrossPool(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)
 	protocol := newTestLedgerProtocol(t, ns)
 
 	// Pool A: write 5 entries.
-	pA := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = pA.Close(context.Background()) })
-
-	migratorA, err := NewMigrator(pA, testMigrationsFS(t), "schema_migrations_restart_a")
-	require.NoError(t, err)
-	require.NoError(t, migratorA.Up(ctx))
+	pA := migratedPool(t)
 
 	fcA := clockmock.New(storetest.EpochAnchor())
 	txmA := NewTxManager(pA)
@@ -155,10 +121,6 @@ func TestAuditLedgerStore_RestartRecovery_AcrossPool(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(nFirst), tailA.SeqNo)
 	assert.Equal(t, int64(nFirst), tailA.EntryCount)
-
-	// Simulate restart: pool B is a fresh handle to the same schema.
-	// Since isolatedSchemaPool embeds the search_path in the connection config,
-	// we open a second pgxpool against the same schema by reusing pA's config.
 
 	// Simulate restart: construct storeB from the same pool (same DB state)
 	fcB := clockmock.New(storetest.EpochAnchor())
@@ -197,15 +159,12 @@ func TestAuditLedgerStore_RestartRecovery_AcrossPool(t *testing.T) {
 // fix: without the fix, Verify would compare e[2].PrevHash against "" (the zero
 // value) and incorrectly report corruption even for a valid chain.
 func TestPGVerify_SubRange_Valid(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)
 	protocol := newTestLedgerProtocol(t, ns)
 
-	store, storeCleanup := newIsolatedLedgerStore(t, ctx, base, protocol, clockmock.New(storetest.EpochAnchor()))
+	store, storeCleanup := newIsolatedLedgerStore(t, protocol, clockmock.New(storetest.EpochAnchor()))
 	t.Cleanup(storeCleanup)
 
 	fc := clockmock.New(storetest.EpochAnchor())
@@ -228,20 +187,12 @@ func TestPGVerify_SubRange_Valid(t *testing.T) {
 // returns valid=false at seq 3 when entry seq=3's hash is tampered via direct
 // SQL UPDATE (PG store; MemStore internal helpers are not available).
 func TestPGVerify_SubRange_Tampered(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)
 	protocol := newTestLedgerProtocol(t, ns)
 
-	p := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = p.Close(context.Background()) })
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_subrange_tampered")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
+	p := migratedPool(t)
 	fc := clockmock.New(storetest.EpochAnchor())
 	txm := NewTxManager(p)
 	store, err := NewLedgerStore(p.DB(), txm, protocol, fc)
@@ -278,20 +229,12 @@ func TestPGVerify_SubRange_Tampered(t *testing.T) {
 // that the final hash chain is intact. This proves pg_advisory_xact_lock
 // serializes Append within the namespace.
 func TestAuditLedgerStore_AdvisoryLockSerializesAppend(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)
 	protocol := newTestLedgerProtocol(t, ns)
 
-	p := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = p.Close(context.Background()) })
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_advlock")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
+	p := migratedPool(t)
 	fc := clockmock.New(storetest.EpochAnchor())
 	txm := NewTxManager(p)
 	store, err := NewLedgerStore(p.DB(), txm, protocol, fc)
@@ -344,20 +287,12 @@ func TestAuditLedgerStore_AdvisoryLockSerializesAppend(t *testing.T) {
 // the outbox writer deliberately returns an error, causing RunInTx to rollback
 // the whole transaction. We then assert audit_entries has no new rows.
 func TestAuditLedgerStore_OutboxAtomicityFailureProof(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)
 	protocol := newTestLedgerProtocol(t, ns)
 
-	p := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = p.Close(context.Background()) })
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_atomicity")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
+	p := migratedPool(t)
 	fc := clockmock.New(storetest.EpochAnchor())
 	txm := NewTxManager(p)
 	store, err := NewLedgerStore(p.DB(), txm, protocol, fc)
@@ -399,16 +334,9 @@ func TestAuditLedgerStore_OutboxAtomicityFailureProof(t *testing.T) {
 // same physical table but different namespace IDs do not pollute each other's
 // entries, and that their advisory locks are independent (different hash inputs).
 func TestAuditLedgerStore_NamespaceIsolation(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 
-	p := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = p.Close(context.Background()) })
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_nsiso")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	nsA, err := ledger.ParseNamespaceID("audit_a")
 	require.NoError(t, err)
@@ -484,27 +412,18 @@ func TestAuditLedgerStore_NamespaceIsolation(t *testing.T) {
 //   - broken: RepoReady returns a non-nil error when audit_entries is dropped,
 //     exercising a failure domain that a pool-level ping cannot detect.
 func TestAuditLedgerStore_RepoReadiness_Conformance(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)
 	protocol := newTestLedgerProtocol(t, ns)
 	fc := clockmock.New(storetest.EpochAnchor())
 
-	// healthy: standard isolated schema with migrations applied.
-	healthyStore, healthyCleanup := newIsolatedLedgerStore(t, ctx, base, protocol, fc)
+	// healthy: per-test DB with migrations applied.
+	healthyStore, healthyCleanup := newIsolatedLedgerStore(t, protocol, fc)
 	t.Cleanup(healthyCleanup)
 
-	// broken: isolated schema with audit_entries table dropped after migration.
-	brokenPool := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = brokenPool.Close(context.Background()) })
-	migrator, err := NewMigrator(brokenPool, testMigrationsFS(t), migrationsTableName(t, "schema_migrations_readyz_broken_"))
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
-	// Drop audit_entries to simulate schema drift / missing migration.
+	// broken: per-test DB with audit_entries table dropped after migration.
+	brokenPool := migratedPool(t)
 	_, execErr := brokenPool.DB().Exec(ctx, `DROP TABLE IF EXISTS audit_entries CASCADE`)
 	require.NoError(t, execErr, "drop audit_entries for broken scenario")
 
@@ -532,20 +451,12 @@ var errRollbackSentinel = errors.New("intentional rollback")
 // invisible after a rollback. A committed control proves the in-tx read is not
 // an artifact and the persisted path still works.
 func TestAuditLedgerStore_ReadWithinAmbientTx(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)
 	protocol := newTestLedgerProtocol(t, ns)
 
-	p := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = p.Close(context.Background()) })
-	migrator, err := NewMigrator(p, testMigrationsFS(t), migrationsTableName(t, "schema_migrations_ambient_read_"))
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
-
+	p := migratedPool(t)
 	fc := clockmock.New(storetest.EpochAnchor())
 	txm := NewTxManager(p)
 	store, err := NewLedgerStore(p.DB(), txm, protocol, fc)

--- a/adapters/postgres/command_queue_conformance_integration_test.go
+++ b/adapters/postgres/command_queue_conformance_integration_test.go
@@ -21,24 +21,23 @@ import (
 // suite drives the InMemQueue implementation in kernel/command/commandtest;
 // both must pass identically.
 //
-// One PG testcontainer is shared across all sub-tests; each sub-test factory
-// call TRUNCATEs `commands` and re-seeds the device FK targets to give a
-// pristine schema view without paying the ~1.5s container-start cost per
-// sub-test (33 sub-tests × ~1.5s = 50s + Docker daemon contention → flaky on
-// constrained CI runners).
+// One shared per-test DB (migratedPool) is reused across all sub-tests; each
+// sub-test factory call TRUNCATEs `commands` and re-seeds the device FK
+// targets to give a pristine schema view without paying per-sub-test DB
+// creation overhead (33 sub-tests × DB cost → flaky on constrained CI runners).
 //
 // ref: docs/plans/202605082145-034-pg-corecell-b-route-plan.md §B2.B
 func TestPGCommandQueue_Conformance(t *testing.T) {
 	testutil.RequireDocker(t)
-	pool, txMgr, terminate := setupSharedCommandQueuePG(t)
-	t.Cleanup(terminate)
+	pool := migratedPool(t)
+	txMgr := NewTxManager(pool)
 
 	factory := func(t *testing.T) (command.Queue, command.ActiveScanner, commandtest.TxRunner, func() time.Time, func()) {
 		t.Helper()
 		resetCommandQueueSchema(t, pool)
 		q, err := NewCommandQueue(pool.DB(), txMgr, clock.Real())
 		require.NoError(t, err)
-		return q, q, txMgr, time.Now, func() {} // shared container — no per-sub-test teardown
+		return q, q, txMgr, time.Now, func() {} // shared pool — no per-sub-test teardown
 	}
 
 	commandtest.RunQueueConformance(t, factory, commandtest.Features{
@@ -47,21 +46,6 @@ func TestPGCommandQueue_Conformance(t *testing.T) {
 		RequiresAmbientTx:    false,
 		SupportsLeaseRenewal: true,
 	})
-}
-
-// setupSharedCommandQueuePG spins ONE testcontainer + migrates schema +
-// creates a TxManager that the whole conformance suite reuses. terminate
-// closes the pool and stops the container in t.Cleanup.
-func setupSharedCommandQueuePG(t *testing.T) (*Pool, *TxManager, func()) {
-	t.Helper()
-	pool, basicCleanup := setupPostgres(t)
-
-	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
-
-	return pool, NewTxManager(pool), basicCleanup
 }
 
 // resetCommandQueueSchema truncates the commands table and re-seeds the
@@ -88,32 +72,21 @@ func resetCommandQueueSchema(t *testing.T, pool *Pool) {
 //   - healthy: a fully migrated queue returns nil from RepoReady.
 //   - broken: a queue whose commands table has been dropped returns non-nil.
 //
-// Each instance uses an isolated schema pool so the DROP TABLE for the broken
-// scenario does not affect the healthy pool's commands table.
+// Each instance uses an isolated per-test DB (migratedPool) so the DROP TABLE
+// for the broken scenario does not affect the healthy pool's commands table.
 func TestPGCommandQueue_RepoReadinessConformance(t *testing.T) {
 	testutil.RequireDocker(t)
-	base, baseTeardown := setupPostgres(t)
-	t.Cleanup(baseTeardown)
-
 	ctx := context.Background()
 
-	// healthy: isolated schema with full migrations — commands table intact.
-	healthyPool := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = healthyPool.Close(context.Background()) })
-	healthyMigrator, err := NewMigrator(healthyPool, testMigrationsFS(t), "schema_migrations_readyz_cq_healthy")
-	require.NoError(t, err)
-	require.NoError(t, healthyMigrator.Up(ctx))
+	// healthy: per-test DB with full migrations — commands table intact.
+	healthyPool := migratedPool(t)
 	healthyTxm := NewTxManager(healthyPool)
 	healthy, err := NewCommandQueue(healthyPool.DB(), healthyTxm, clock.Real())
 	require.NoError(t, err)
 
-	// broken: isolated schema with migrations applied, then commands table dropped
+	// broken: per-test DB with migrations applied, then commands table dropped
 	// to simulate schema drift / missing migration.
-	brokenPool := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = brokenPool.Close(context.Background()) })
-	brokenMigrator, err := NewMigrator(brokenPool, testMigrationsFS(t), "schema_migrations_readyz_cq_broken")
-	require.NoError(t, err)
-	require.NoError(t, brokenMigrator.Up(ctx))
+	brokenPool := migratedPool(t)
 	_, dropErr := brokenPool.DB().Exec(ctx, "DROP TABLE IF EXISTS commands CASCADE")
 	require.NoError(t, dropErr, "drop commands table for broken scenario")
 	brokenTxm := NewTxManager(brokenPool)

--- a/adapters/postgres/integration_test.go
+++ b/adapters/postgres/integration_test.go
@@ -17,13 +17,11 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/tests/testutil"
 )
 
 func mustAllowDestructiveDown(t testing.TB, reason string) DestructiveDownPermit {
@@ -61,39 +59,6 @@ func migrationsUpToFS(t testing.TB, maxVersion int64) fstest.MapFS {
 	return out
 }
 
-// setupPostgres starts a PostgreSQL container via testcontainers and returns a
-// connected Pool along with a cleanup function. The caller must invoke cleanup
-// (or use t.Cleanup) to terminate the container.
-func setupPostgres(t *testing.T) (*Pool, func()) {
-	t.Helper()
-	testutil.RequireDocker(t)
-
-	ctx := context.Background()
-
-	container, err := tcpostgres.Run(ctx, testutil.PostgresImage,
-		tcpostgres.WithDatabase("test"),
-		tcpostgres.WithUsername("test"),
-		tcpostgres.WithPassword("test"),
-		tcpostgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err, "failed to start postgres container")
-
-	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err, "failed to get connection string")
-
-	pool, err := NewPool(ctx, Config{DSN: connStr})
-	require.NoError(t, err, "failed to create pool")
-
-	cleanup := func() {
-		_ = pool.Close(ctx)
-		if err := container.Terminate(ctx); err != nil {
-			t.Logf("WARN: failed to terminate container: %v", err)
-		}
-	}
-
-	return pool, cleanup
-}
-
 // ---------------------------------------------------------------------------
 // T19: TestIntegration_Pool
 // ---------------------------------------------------------------------------
@@ -101,13 +66,12 @@ func setupPostgres(t *testing.T) (*Pool, func()) {
 // TestIntegration_Pool verifies that Pool can connect to a real PostgreSQL
 // instance, pass the Health() probe, and shut down cleanly.
 func TestIntegration_Pool(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
 	t.Run("connect_and_health", func(t *testing.T) {
-		// Pool was already successfully created by setupPostgres.
+		// Pool was already successfully created by emptyPool.
 		// Health() should return nil on a healthy connection.
 		err := pool.Health(ctx)
 		assert.NoError(t, err, "Health() should return nil on a connected pool")
@@ -135,8 +99,7 @@ func TestIntegration_Pool(t *testing.T) {
 // TestIntegration_TxManager tests commit, rollback, and panic-recovery
 // semantics of TxManager.RunInTx against a real PostgreSQL instance.
 func TestIntegration_TxManager(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -219,8 +182,7 @@ func TestIntegration_TxManager(t *testing.T) {
 // TestIntegration_Migrator tests Up, Status, and Down against a real
 // PostgreSQL instance using the embedded migration files.
 func TestIntegration_Migrator(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -301,8 +263,7 @@ func TestIntegration_Migrator(t *testing.T) {
 }
 
 func TestMigration012Down_SQLGuardRejectsDirectProviderBypass(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 	mfs := migrationsUpToFS(t, 12)
@@ -344,15 +305,9 @@ SELECT EXISTS (
 // TestIntegration_OutboxWriter tests writing outbox entries inside and outside
 // a transaction context.
 func TestIntegration_OutboxWriter(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := migratedPool(t)
 
 	ctx := context.Background()
-
-	// Apply migrations so the outbox_entries table exists.
-	migrator, mErr := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
-	require.NoError(t, mErr, "NewMigrator should succeed")
-	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
 	txm := NewTxManager(pool)
 	writer := NewOutboxWriter(clock.Real())
@@ -445,8 +400,7 @@ func TestIntegration_OutboxWriter(t *testing.T) {
 // idempotent (no duplicate-table error).
 // ref: pressly/goose -- +goose no transaction + CREATE INDEX CONCURRENTLY.
 func TestMigrator_Applies004_WithConcurrentlyIndexes(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -497,8 +451,7 @@ func TestMigrator_Applies004_WithConcurrentlyIndexes(t *testing.T) {
 // (F-D-3 / RL-MIG-01 evidence). Also asserts idx_outbox_pending_v2 existence
 // (introduced by migration 005).
 func TestMigration004_StructuralAssertions(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -557,8 +510,7 @@ func TestMigration004_StructuralAssertions(t *testing.T) {
 // creates idx_config_versions_config_id and that an eq-lookup on config_id
 // uses an Index Scan (not a Seq Scan).
 func TestMigration006_ConfigVersionsConfigIDIndex(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -609,8 +561,7 @@ func TestMigration006_ConfigVersionsConfigIDIndex(t *testing.T) {
 // catalog, then construct a fresh migrator with a different tracking table and
 // attempt Up() — it must refuse.
 func TestMigrator_Up_RefusesIfInvalidIndexExists(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -694,8 +645,7 @@ func concurrentUpFixtureFS() fstest.MapFS {
 // INSERT can run multiple times (sentinel row count > 1) or two providers
 // can race the schema_migrations write (per-row uniqueness violation).
 func TestMigrator_ConcurrentUp_NoRaceWithSessionLocker(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 	ctx := context.Background()
 
 	const (
@@ -769,8 +719,7 @@ func sequenceFixtureFS_910() fstest.MapFS {
 // places 009 before 010 (string sort would too, but only because of the
 // zero-padded prefix). Down(1) rolls back exactly 010, leaving 009 applied.
 func TestMigrator_NineBeforeTen_OrderRegression(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 	ctx := context.Background()
 
 	const tableName = "schema_migrations_seq910"
@@ -819,10 +768,9 @@ func TestMigrator_NineBeforeTen_OrderRegression(t *testing.T) {
 // ref: pressly/goose provider_run_test.go TestProviderRun/up_and_down_by_one
 // — confirms ErrNoNextVersion is goose's canonical v=0 signal.
 func TestMigrator_Down_AtVersionZero_Idempotent(t *testing.T) {
-	// setupPostgres starts a fresh testcontainer per test, so a fixed table
+	// emptyPool gives each test its own isolated database, so a fixed table
 	// name does not collide with sibling tests that pick the same string.
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 	ctx := context.Background()
 
 	// Single noop migration — decouples regression from production schema churn.
@@ -859,8 +807,7 @@ func TestMigrator_Down_AtVersionZero_Idempotent(t *testing.T) {
 // rejected by the SQL fail-closed guard in destructive migration Down sections.
 // The guard raises EXCEPTION P0001 unless gocell.allow_destructive_down = 'true'.
 func TestMigrator_Down_RequiresGUC_DirectGooseProviderRejected(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 	ctx := context.Background()
 
 	// Apply only up to migration 019 (includes the destructive users/sessions/roles tables).
@@ -887,8 +834,7 @@ func TestMigrator_Down_RequiresGUC_DirectGooseProviderRejected(t *testing.T) {
 // GUC-blocked error, the destructiveDownSessionLocker is not wiring the GUC
 // correctly.
 func TestMigrator_Down_WithPermit_SetsGUC(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 	ctx := context.Background()
 
 	// Apply migrations up to 019 so there is a destructive migration to roll back.

--- a/adapters/postgres/outbox_store_integration_test.go
+++ b/adapters/postgres/outbox_store_integration_test.go
@@ -33,14 +33,9 @@ const defaultReclaimBatchTest = 1000
 // This test requires a running PostgreSQL container (Docker).
 // Build tag: //go:build integration — excluded from `go test -short` runs.
 func TestPGOutboxStore_ConformanceSuite(t *testing.T) {
-	// setupPostgres is defined in integration_test.go (same package, integration build tag).
-	pool, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
+	pool := migratedPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_store_conformance")
-	require.NoError(t, err, "NewMigrator should succeed")
-	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
 	factory := func(t *testing.T, seed []rout.ClaimedEntry) rout.Store {
 		t.Helper()
@@ -58,13 +53,9 @@ func TestPGOutboxStore_ConformanceSuite(t *testing.T) {
 }
 
 func TestPGOutboxStore_RelayPublishesRollbackStateBeforeAudit(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
+	pool := migratedPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_store_order")
-	require.NoError(t, err, "NewMigrator should succeed")
-	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
 	base := time.Now().UTC()
 	insertSeedRow(t, pool, rout.ClaimedEntry{Entry: kout.Entry{
@@ -150,13 +141,9 @@ func (p *recordingPublisher) Topics() []string {
 // UPDATE that holds locks blocking VACUUM and replication. ReclaimStale caps
 // at defaultReclaimBatchTest per call; relay's tick loop drains residual.
 func TestPGOutboxStore_ReclaimStale_RespectsBatchLimit(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
+	pool := migratedPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_reclaim_limit")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
 	const seedCount = defaultReclaimBatchTest + 500 // 1500 stale claiming rows
 
@@ -199,13 +186,9 @@ func TestPGOutboxStore_ReclaimStale_RespectsBatchLimit(t *testing.T) {
 // fencing CAS end-to-end: worker A claims, reclaim fires, worker A's stale
 // MarkPublished must miss while worker B's lease is preserved. (B2-A-01)
 func TestPGOutboxStore_Fencing_ReclaimedRowSurvivesStaleMark(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
+	pool := migratedPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_fencing")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
 	insertSeedRow(t, pool, rout.ClaimedEntry{Entry: kout.Entry{
 		ID:            "evt-fencing-race",
@@ -320,13 +303,9 @@ func TestPGOutboxStore_Reclaim_DoesNotRegressTerminalRow(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			pool, cleanup := setupPostgres(t)
-			t.Cleanup(cleanup)
+			pool := migratedPool(t)
 
 			ctx := context.Background()
-			migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_reclaim_noregress_"+tc.name)
-			require.NoError(t, err)
-			require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
 			insertSeedRow(t, pool, rout.ClaimedEntry{Entry: kout.Entry{
 				ID:            "evt-reclaim-noregress",
@@ -383,13 +362,9 @@ func TestPGOutboxStore_Reclaim_DoesNotRegressTerminalRow(t *testing.T) {
 // from a terminal state. Complements the deterministic subtests above by
 // stressing the timing window directly.
 func TestPGOutboxStore_Reclaim_RaceWithMarkPublished(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
+	pool := migratedPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_reclaim_race")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
 	store := NewOutboxStore(pool.DB(), clock.Real())
 

--- a/adapters/postgres/refresh_outer_tx_atomicity_integration_test.go
+++ b/adapters/postgres/refresh_outer_tx_atomicity_integration_test.go
@@ -56,7 +56,7 @@ const (
 var errInjectedRollback = errors.New("b5 test: injected rollback after refresh-store mutation")
 
 // b5Fixture wires PG TxManager + PGRefreshStore and is reused across the
-// three subtests. Each subtest gets an isolated PG schema so refresh_tokens
+// three subtests. Each subtest gets its own migratedPool so refresh_tokens
 // rows from one subtest never leak into another.
 type b5Fixture struct {
 	store    *PGRefreshStore
@@ -66,14 +66,10 @@ type b5Fixture struct {
 	policyOK refresh.Policy
 }
 
-func newB5Fixture(t *testing.T, base *Pool) *b5Fixture {
+func newB5Fixture(t *testing.T) *b5Fixture {
 	t.Helper()
-	ctx := context.Background()
 
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clk := storetest.NewFakeClock(time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC))
 	policy := refresh.Policy{
@@ -101,9 +97,7 @@ func newB5Fixture(t *testing.T, base *Pool) *b5Fixture {
 // pre-Issue state. The wire token returned by Issue must be unpeekable
 // after the outer tx rolls back.
 func TestB5_OuterTxRollback_IssueRolledBack(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-	fx := newB5Fixture(t, base)
+	fx := newB5Fixture(t)
 	ctx := context.Background()
 
 	const sessionID = "sess-b5-issue"
@@ -139,9 +133,7 @@ func TestB5_OuterTxRollback_IssueRolledBack(t *testing.T) {
 // injected error). With the cross-store wrap in place, the entire outer tx
 // rolls back and Rotate's effect is undone.
 func TestB5_OuterTxRollback_RotateRolledBack(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-	fx := newB5Fixture(t, base)
+	fx := newB5Fixture(t)
 	ctx := context.Background()
 
 	const sessionID = "sess-b5-rotate"
@@ -186,9 +178,7 @@ func TestB5_OuterTxRollback_RotateRolledBack(t *testing.T) {
 // RevokeSessionDetached and then injects an error. Outer rollback fires.
 // Afterwards Peek on the original wire MUST reject (revoke persisted).
 func TestB5_RevokeSessionDetachedSurvivesOuterRollback(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-	fx := newB5Fixture(t, base)
+	fx := newB5Fixture(t)
 	ctx := context.Background()
 
 	const sessionID = "sess-b5-cascade"

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -6,11 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,21 +38,15 @@ const (
 //     Peek (memstore did not), halving the effective GraceMaxReuses for the
 //     real sessionrefresh.Refresh() call shape (Peek + Rotate per request).
 func TestPGRefreshStore_ContractSuite(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
-	ctx := context.Background()
 	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	// Each factory call gets its own PG schema so parallel subtests are fully
-	// isolated. GC (T13) only sees rows it inserted — no shared-table pollution.
+	// Each factory call gets its own per-test DB (migratedPool) so parallel
+	// subtests are fully isolated. GC (T13) only sees rows it inserted — no
+	// shared-table pollution.
 	factory := func(t *testing.T, policy refresh.Policy) (refresh.Store, *storetest.FakeClock) {
 		t.Helper()
 
-		p := isolatedSchemaPool(t, ctx, base)
-		migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations")
-		require.NoError(t, err)
-		require.NoError(t, migrator.Up(ctx))
+		p := migratedPool(t)
 
 		clock := storetest.NewFakeClock(baseTime)
 		txm := NewTxManager(p)
@@ -67,33 +59,6 @@ func TestPGRefreshStore_ContractSuite(t *testing.T) {
 	storetest.RunIdleExpireContractSuite(t, factory)
 }
 
-// isolatedSchemaPool creates a fresh PG schema and returns a Pool whose
-// search_path is scoped to that schema. t.Cleanup drops the schema and closes
-// the pool after the subtest finishes.
-func isolatedSchemaPool(t *testing.T, ctx context.Context, base *Pool) *Pool {
-	t.Helper()
-
-	schema := fmt.Sprintf("ts%016x", rand.Int63())
-	_, err := base.DB().Exec(ctx, "CREATE SCHEMA "+schema)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_, _ = base.DB().Exec(context.Background(), "DROP SCHEMA "+schema+" CASCADE")
-	})
-
-	cfg := base.DB().Config()
-	if cfg.ConnConfig.RuntimeParams == nil {
-		cfg.ConnConfig.RuntimeParams = make(map[string]string)
-	}
-	cfg.ConnConfig.RuntimeParams["search_path"] = schema
-
-	inner, err := pgxpool.NewWithConfig(ctx, cfg)
-	require.NoError(t, err)
-
-	p := &Pool{inner: inner, config: base.config}
-	t.Cleanup(func() { _ = p.Close(context.Background()) })
-	return p
-}
-
 // ---------------------------------------------------------------------------
 // TestMigration012_StructuralAssertions
 // ---------------------------------------------------------------------------
@@ -102,8 +67,7 @@ func isolatedSchemaPool(t *testing.T, ctx context.Context, base *Pool) *Pool {
 // set of the refresh_tokens table after migration 012 rebuilds it for the
 // append-only selector/verifier model.
 func TestMigration012_StructuralAssertions(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -204,14 +168,8 @@ func TestMigration012_StructuralAssertions(t *testing.T) {
 // TestPGRefreshStore_DMLState asserts the append-only row state after each
 // mutating operation: Issue, Rotate, and RevokeSession.
 func TestPGRefreshStore_DMLState(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_dml_state")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	policy := refresh.Policy{
@@ -309,14 +267,8 @@ func TestPGRefreshStore_DMLState(t *testing.T) {
 // same invariant on every backend); this PG-named test exists so a grep for
 // "Peek" + "Grace" in adapters/postgres/ finds an explicit regression gate.
 func TestPGRefreshStore_PeekPlusRotate_RespectsGraceBudget(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_peek_grace")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
@@ -355,14 +307,8 @@ func TestPGRefreshStore_PeekPlusRotate_RespectsGraceBudget(t *testing.T) {
 }
 
 func TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_reuse_ambient")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
@@ -394,14 +340,8 @@ func TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback(t *testing.T) {
 }
 
 func TestPGRefreshStore_SessionLockRejectsChildValidatedBeforeCascade(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_reuse_lock")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm2 := NewTxManager(p)
@@ -450,14 +390,8 @@ func TestPGRefreshStore_SessionLockRejectsChildValidatedBeforeCascade(t *testing
 // clock beyond Policy.MaxIdle, and asserts that Rotate returns ErrRejected.
 // RED in Wave 1 (migration 016 not applied yet; idle_expires_at column absent).
 func TestPGRefreshStore_T19_IdleExpireBlocksRotate(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_t19")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
@@ -488,14 +422,8 @@ func TestPGRefreshStore_T19_IdleExpireBlocksRotate(t *testing.T) {
 // the original parent token one more time triggers cascade revoke (ErrRejected).
 // RED in Wave 1.
 func TestPGRefreshStore_T20_GraceCounterCapTriggersReuse(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_t20")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
@@ -541,14 +469,8 @@ func TestPGRefreshStore_T20_GraceCounterCapTriggersReuse(t *testing.T) {
 // This is a behavioral contract test — the specific slog output is
 // implementation-detail; we assert the wire-error sentinel only.
 func TestPGRefreshStore_T21_RejectPathsHaveUniformLogging(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_t21")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
@@ -602,20 +524,14 @@ func TestPGRefreshStore_T21_RejectPathsHaveUniformLogging(t *testing.T) {
 // invalid indexes are a schema fault, so runtime/http/health.runOneProbe must
 // classify the probe as unhealthy and /readyz must fail closed with HTTP 503.
 func TestPGRefreshStore_T22_ReadyzReportsInvalidIndex(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_t22")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	// Create a table and then manually mark an index as invalid via pg_index.
 	// We cannot use CREATE INDEX CONCURRENTLY (not in transaction), so we
 	// insert a fake invalid index entry by creating a real index and then
 	// flipping its indisvalid flag.
-	_, err = p.DB().Exec(ctx, `CREATE TABLE IF NOT EXISTS _t22_probe (id serial primary key, val text)`)
+	_, err := p.DB().Exec(ctx, `CREATE TABLE IF NOT EXISTS _t22_probe (id serial primary key, val text)`)
 	require.NoError(t, err)
 	_, err = p.DB().Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_t22_probe_val ON _t22_probe (val)`)
 	require.NoError(t, err)
@@ -656,14 +572,8 @@ func TestPGRefreshStore_T22_ReadyzReportsInvalidIndex(t *testing.T) {
 // hold its own internal transaction that commits independently of the caller.
 // RED in Wave 1 (store still has internal pool.Begin/Commit).
 func TestPGRefreshStore_T23_AmbientTxRollback(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_t23")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
@@ -700,14 +610,8 @@ func TestPGRefreshStore_T23_AmbientTxRollback(t *testing.T) {
 }
 
 func TestPGRefreshStore_RevokeSessionDetachedSurvivesAmbientRollback(t *testing.T) {
-	base, cleanup := setupPostgres(t)
-	t.Cleanup(cleanup)
-
 	ctx := context.Background()
-	p := isolatedSchemaPool(t, ctx, base)
-	migrator, err := NewMigrator(p, testMigrationsFS(t), "schema_migrations_detached_revoke")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	p := migratedPool(t)
 
 	clock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	txm := NewTxManager(p)
@@ -757,19 +661,19 @@ func TestPGRefreshStore_RevokeSessionDetachedSurvivesAmbientRollback(t *testing.
 // pgxpool (boxing the behavior into a mock) or timing-sensitive orchestration.
 // The maintained coverage is intentionally narrower and executable:
 //
-//   1. pkg/ctxutil/detach_test.go asserts that WithDetachedTimeout's returned
-//      ctx is unaffected by parent cancel and carries an independent deadline.
-//   2. cells/accesscore/slices/sessionrefresh/service_test.go::
-//      TestService_CascadeRevoke_UsesDetachedStoreMethod asserts that the
-//      service-level cascade path routes to RevokeSessionDetached rather than
-//      the ambient business revoke.
-//   3. refresh_store.go handleRotatedRow and RevokeSessionDetached use
-//      ctxutil.WithDetachedTimeout for the cascade pool.Exec — verified by code
-//      inspection and the helper test (#1) which proves the wrapped ctx behaves
-//      as required.
-//   4. TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback (above) verifies
-//      the orthogonal property that cascade SQL bypasses the ambient tx — i.e.
-//      survives caller-driven outer rollback.
+//  1. pkg/ctxutil/detach_test.go asserts that WithDetachedTimeout's returned
+//     ctx is unaffected by parent cancel and carries an independent deadline.
+//  2. cells/accesscore/slices/sessionrefresh/service_test.go::
+//     TestService_CascadeRevoke_UsesDetachedStoreMethod asserts that the
+//     service-level cascade path routes to RevokeSessionDetached rather than
+//     the ambient business revoke.
+//  3. refresh_store.go handleRotatedRow and RevokeSessionDetached use
+//     ctxutil.WithDetachedTimeout for the cascade pool.Exec — verified by code
+//     inspection and the helper test (#1) which proves the wrapped ctx behaves
+//     as required.
+//  4. TestPGRefreshStore_ReuseCascadeSurvivesAmbientRollback (above) verifies
+//     the orthogonal property that cascade SQL bypasses the ambient tx — i.e.
+//     survives caller-driven outer rollback.
 //
 // Together these cover the chosen boundary: once execution reaches the store's
 // detached revoke path, the final revoke write is detached from caller cancel

--- a/adapters/postgres/schema_guard_integration_test.go
+++ b/adapters/postgres/schema_guard_integration_test.go
@@ -17,8 +17,7 @@ import (
 // TestVerifyExpectedVersion_Integration verifies that after applying all
 // migrations, VerifyExpectedVersion returns nil (versions match).
 func TestVerifyExpectedVersion_Integration(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -37,8 +36,7 @@ func TestVerifyExpectedVersion_Integration(t *testing.T) {
 // a direct UPDATE on pg_index. This requires superuser (testcontainers PG
 // default user is superuser).
 func TestDetectInvalidIndexes_WithInjectedInvalid(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -88,8 +86,7 @@ func TestDetectInvalidIndexes_WithInjectedInvalid(t *testing.T) {
 // returns an error containing "schema version mismatch". This simulates a
 // binary rollback without a corresponding migration rollback.
 func TestVerifyExpectedVersion_DBAhead_Integration(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -131,8 +128,7 @@ func TestVerifyExpectedVersion_DBAhead_Integration(t *testing.T) {
 // ref: riverqueue/river migration 004_pending_and_more.up.sql — DB-level
 // invariants on state machine transitions are the canonical pattern.
 func TestOutboxClaimingLeaseCheckConstraint_RejectsNullLeaseInsert(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_lease_check")
@@ -169,8 +165,7 @@ func TestOutboxClaimingLeaseCheckConstraint_RejectsNullLeaseInsert(t *testing.T)
 //
 // ref: docs/architecture/202605051600-adr-pg-outbox-fencing.md cutover §
 func TestOutboxMigration014_AbortsOnClaimingResidue(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_014_residue")
@@ -213,8 +208,7 @@ func TestOutboxMigration014_AbortsOnClaimingResidue(t *testing.T) {
 //     a stale pre-014 binary writing through the post-014 schema.
 //   - Attempt migration 015 → must error with check_violation on the constraint.
 func TestOutboxMigration015_RejectsExistingClaimingNullLeaseRow(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_015_existing_bad")
@@ -250,8 +244,7 @@ func TestOutboxMigration015_RejectsExistingClaimingNullLeaseRow(t *testing.T) {
 // (which covers the INSERT path) — both are required to lock the
 // invariant against the two write paths a pre-014 binary could exercise.
 func TestOutboxMigration015_RejectsUpdateIntoClaimingNullLease(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_015_update_path")
@@ -282,8 +275,7 @@ func TestOutboxMigration015_RejectsUpdateIntoClaimingNullLease(t *testing.T) {
 // schema is behind the binary (DB version < FS max), VerifyExpectedVersion
 // returns an error containing "schema version mismatch".
 func TestVerifyExpectedVersion_DBLagged_Integration(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -328,8 +320,7 @@ func attrsContainKV(attrs []slog.Attr, key, value string) bool {
 // TestVerifyExpectedShape_AllColumnsPresent verifies that after all migrations
 // are applied, VerifyExpectedShape returns nil (no shape drift).
 func TestVerifyExpectedShape_AllColumnsPresent(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -345,8 +336,7 @@ func TestVerifyExpectedShape_AllColumnsPresent(t *testing.T) {
 // required column causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with details naming the missing table and column.
 func TestVerifyExpectedShape_MissingRequiredColumn(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -377,8 +367,7 @@ func TestVerifyExpectedShape_MissingRequiredColumn(t *testing.T) {
 // forbidden legacy column causes VerifyExpectedShape to return
 // ErrAdapterPGSchemaShape with details naming the offending table and column.
 func TestVerifyExpectedShape_ForbiddenColumnPresent(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -412,8 +401,7 @@ func TestVerifyExpectedShape_ForbiddenColumnPresent(t *testing.T) {
 // TestVerifyNoInvalidIndexes_NoneInvalid verifies that after applying all
 // migrations, VerifyNoInvalidIndexes returns nil (no invalid indexes).
 func TestVerifyNoInvalidIndexes_NoneInvalid(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -428,8 +416,7 @@ func TestVerifyNoInvalidIndexes_NoneInvalid(t *testing.T) {
 // TestVerifyNoInvalidIndexes_DetectInvalid verifies that VerifyNoInvalidIndexes
 // returns ErrAdapterPGInvalidIndex when at least one index is marked invalid.
 func TestVerifyNoInvalidIndexes_DetectInvalid(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -477,8 +464,7 @@ func TestVerifyNoInvalidIndexes_DetectInvalid(t *testing.T) {
 // TestDetectInvalidIndexes_Empty verifies that after applying all migrations,
 // DetectInvalidIndexes returns an empty slice.
 func TestDetectInvalidIndexes_Empty(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -495,8 +481,7 @@ func TestDetectInvalidIndexes_Empty(t *testing.T) {
 // returns the schema-qualified name when an index is marked invalid via
 // pg_index. Requires superuser (testcontainers default postgres image).
 func TestDetectInvalidIndexes_WithInvalidIndex(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -541,8 +526,7 @@ func TestDetectInvalidIndexes_WithInvalidIndex(t *testing.T) {
 // TestInvalidIndexCheck_NoInvalidIndexes verifies that InvalidIndexCheck (the
 // /readyz probe wrapper) returns nil when no invalid indexes are present.
 func TestInvalidIndexCheck_NoInvalidIndexes(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -573,8 +557,7 @@ func extractDimensionDetail(ec *errcode.Error) string {
 // are applied (including migration 023 adding CHECK constraints), VerifyExpectedShape
 // returns nil.
 func TestVerifyExpectedShape_AllDimensionsHappy(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -590,8 +573,7 @@ func TestVerifyExpectedShape_AllDimensionsHappy(t *testing.T) {
 // foreign key constraint causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="foreign_key".
 func TestVerifyExpectedShape_DetectsMissingForeignKey(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -616,8 +598,7 @@ func TestVerifyExpectedShape_DetectsMissingForeignKey(t *testing.T) {
 // recreating a FK with a different ON DELETE action causes VerifyExpectedShape
 // to surface the on-delete mismatch (covers verifyOneForeignKey OnDelete branch).
 func TestVerifyExpectedShape_DetectsWrongFKOnDeleteAction(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -645,8 +626,7 @@ func TestVerifyExpectedShape_DetectsWrongFKOnDeleteAction(t *testing.T) {
 // unique index causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="index".
 func TestVerifyExpectedShape_DetectsMissingUniqueIndex(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -671,8 +651,7 @@ func TestVerifyExpectedShape_DetectsMissingUniqueIndex(t *testing.T) {
 // trigger causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="trigger".
 func TestVerifyExpectedShape_DetectsMissingTrigger(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -700,8 +679,7 @@ func TestVerifyExpectedShape_DetectsMissingTrigger(t *testing.T) {
 // independently or a partial drop would silently disable the users-side
 // invariant safety net.
 func TestVerifyExpectedShape_DetectsMissingUsersTrigger(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -726,8 +704,7 @@ func TestVerifyExpectedShape_DetectsMissingUsersTrigger(t *testing.T) {
 // trigger causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="trigger_enabled".
 func TestVerifyExpectedShape_DetectsDisabledTrigger(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -752,8 +729,7 @@ func TestVerifyExpectedShape_DetectsDisabledTrigger(t *testing.T) {
 // column's type causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="column_type".
 func TestVerifyExpectedShape_DetectsWrongColumnType(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -779,8 +755,7 @@ func TestVerifyExpectedShape_DetectsWrongColumnType(t *testing.T) {
 // from a column causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="column_nullability".
 func TestVerifyExpectedShape_DetectsNullableColumn(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -805,8 +780,7 @@ func TestVerifyExpectedShape_DetectsNullableColumn(t *testing.T) {
 // a CHECK constraint causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="check".
 func TestVerifyExpectedShape_DetectsMissingCheckConstraint(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -831,8 +805,7 @@ func TestVerifyExpectedShape_DetectsMissingCheckConstraint(t *testing.T) {
 // primary key causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="primary_key".
 func TestVerifyExpectedShape_DetectsMissingPrimaryKey(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -861,8 +834,7 @@ func TestVerifyExpectedShape_DetectsMissingPrimaryKey(t *testing.T) {
 // PL/pgSQL function causes VerifyExpectedShape to return ErrAdapterPGSchemaShape
 // with dimension="function".
 func TestVerifyExpectedShape_DetectsMissingFunction(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 
@@ -894,8 +866,7 @@ func TestVerifyExpectedShape_DetectsMissingFunction(t *testing.T) {
 // This is a live integration test: it injects an invalid index into a real
 // container and asserts the index is still returned.
 func TestDetectInvalidIndexes_StillReportsOrphanWithProgressFilterAdded(t *testing.T) {
-	pool, cleanup := setupPostgres(t)
-	defer cleanup()
+	pool := emptyPool(t)
 
 	ctx := context.Background()
 

--- a/adapters/postgres/session_store_bench_test.go
+++ b/adapters/postgres/session_store_bench_test.go
@@ -14,8 +14,12 @@ import (
 
 // pgBenchFactory is the storetest.BenchFactory for the PG session store.
 //
-// Each call uses migratedPool(b) to get a fresh per-test DB (production
-// schema already present). The cleanup func truncates sessions + users.
+// storetest.Bench's benchRevokeForSubject calls the factory inside the b.N
+// loop, so each call mints a fresh per-test DB and the returned cleanup must
+// release it per-iteration. It uses sharedPG.CloneManaged (NOT migratedPool):
+// migratedPool registers a t.Cleanup(drop) that defers to benchmark end, which
+// would accumulate b.N databases + connection pools and exhaust PG. CloneManaged
+// returns a manual release that cleanup invokes each iteration.
 //
 // The pgSessionStoreWrapper (defined in session_store_integration_test.go)
 // bridges storetest's TEXT subjectIDs to the UUID FK in the sessions table.
@@ -23,13 +27,20 @@ func pgBenchFactory(b *testing.B) (session.Store, *clockmock.FakeClock, func()) 
 	b.Helper()
 	testutil.RequireDocker(b)
 
-	pool := migratedPool(b)
+	dsn, releaseDB := sharedPG.CloneManaged(b)
+	pool, err := NewPool(context.Background(), Config{DSN: dsn})
+	if err != nil {
+		releaseDB()
+		b.Fatalf("pgBenchFactory: open pool: %v", err)
+	}
 
 	fc := clockmock.New(storetest.EpochAnchor())
 	txm := NewTxManager(pool)
 	proto := storetest.NewBenchProtocol(b)
 	store, err := NewSessionStore(pool.DB(), txm, proto, fc)
 	if err != nil {
+		_ = pool.Close(context.Background())
+		releaseDB()
 		b.Fatalf("pgBenchFactory: NewSessionStore: %v", err)
 	}
 
@@ -38,8 +49,8 @@ func pgBenchFactory(b *testing.B) (session.Store, *clockmock.FakeClock, func()) 
 	wrapper := &pgSessionStoreWrapper{inner: store, pool: pool, t: b}
 
 	cleanup := func() {
-		_, _ = pool.DB().Exec(context.Background(),
-			"TRUNCATE sessions, users RESTART IDENTITY CASCADE")
+		_ = pool.Close(context.Background())
+		releaseDB()
 	}
 	return wrapper, fc, cleanup
 }

--- a/adapters/postgres/session_store_bench_test.go
+++ b/adapters/postgres/session_store_bench_test.go
@@ -6,88 +6,30 @@ import (
 	"context"
 	"testing"
 
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
-
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 	"github.com/ghbvf/gocell/runtime/auth/session/storetest"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
-// setupPostgresForBench starts a PostgreSQL testcontainer for use in benchmark
-// tests. It mirrors setupPostgres but bridges *testing.B to the container
-// setup by wrapping the call inside a synthetic *testing.T obtained via
-// b.Run (avoids the *testing.T vs *testing.B interface mismatch in
-// testutil.RequireDocker which requires *testing.T).
-//
-// The returned cleanup func terminates the container and closes the pool.
-func setupPostgresForBench(b *testing.B) (*Pool, func()) {
-	b.Helper()
-	testutil.RequireDocker(b)
-
-	ctx := context.Background()
-
-	container, err := tcpostgres.Run(ctx, testutil.PostgresImage,
-		tcpostgres.WithDatabase("test"),
-		tcpostgres.WithUsername("test"),
-		tcpostgres.WithPassword("test"),
-		tcpostgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		b.Fatalf("setupPostgresForBench: failed to start postgres container: %v", err)
-	}
-
-	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		_ = container.Terminate(ctx)
-		b.Fatalf("setupPostgresForBench: connection string: %v", err)
-	}
-
-	pool, err := NewPool(ctx, Config{DSN: connStr})
-	if err != nil {
-		_ = container.Terminate(ctx)
-		b.Fatalf("setupPostgresForBench: NewPool: %v", err)
-	}
-
-	cleanup := func() {
-		_ = pool.Close(ctx)
-		if err := container.Terminate(ctx); err != nil {
-			b.Logf("WARN: failed to terminate container: %v", err)
-		}
-	}
-	return pool, cleanup
-}
-
 // pgBenchFactory is the storetest.BenchFactory for the PG session store.
 //
-// Each call starts a fresh testcontainer, applies migrations, and returns a
-// PGSessionStore wired with a FakeClock anchored at storetest.EpochAnchor().
-// The cleanup func truncates sessions + users and terminates the container.
+// Each call uses migratedPool(b) to get a fresh per-test DB (production
+// schema already present). The cleanup func truncates sessions + users.
 //
 // The pgSessionStoreWrapper (defined in session_store_integration_test.go)
 // bridges storetest's TEXT subjectIDs to the UUID FK in the sessions table.
 func pgBenchFactory(b *testing.B) (session.Store, *clockmock.FakeClock, func()) {
 	b.Helper()
+	testutil.RequireDocker(b)
 
-	pool, teardown := setupPostgresForBench(b)
-
-	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(b), "schema_migrations")
-	if err != nil {
-		teardown()
-		b.Fatalf("pgBenchFactory: NewMigrator: %v", err)
-	}
-	if err := migrator.Up(ctx); err != nil {
-		teardown()
-		b.Fatalf("pgBenchFactory: migrator.Up: %v", err)
-	}
+	pool := migratedPool(b)
 
 	fc := clockmock.New(storetest.EpochAnchor())
 	txm := NewTxManager(pool)
 	proto := storetest.NewBenchProtocol(b)
 	store, err := NewSessionStore(pool.DB(), txm, proto, fc)
 	if err != nil {
-		teardown()
 		b.Fatalf("pgBenchFactory: NewSessionStore: %v", err)
 	}
 
@@ -98,7 +40,6 @@ func pgBenchFactory(b *testing.B) (session.Store, *clockmock.FakeClock, func()) 
 	cleanup := func() {
 		_, _ = pool.DB().Exec(context.Background(),
 			"TRUNCATE sessions, users RESTART IDENTITY CASCADE")
-		teardown()
 	}
 	return wrapper, fc, cleanup
 }

--- a/adapters/postgres/session_store_integration_test.go
+++ b/adapters/postgres/session_store_integration_test.go
@@ -133,30 +133,15 @@ func (w *pgSessionStoreWrapper) resolveSubjectName(uuidStr string) string {
 	return uuidStr
 }
 
-// resetSessionsTable truncates sessions (and users) between subtests so each
-// factory call gets a clean slate. RESTART IDENTITY resets sequences.
-func resetSessionsTable(t *testing.T, pool *Pool) {
-	t.Helper()
-	_, err := pool.DB().Exec(context.Background(),
-		"TRUNCATE sessions, users RESTART IDENTITY CASCADE")
-	require.NoError(t, err, "resetSessionsTable: truncate failed")
-}
-
 // pgFactory is the storetest.Factory for the PG session store.
 //
-// Each call returns a fresh PGSessionStore (via wrapper) wired with a
-// FakeClock anchored at storetest.EpochAnchor(). The cleanup func truncates
-// the sessions + users tables so subsequent factory calls start clean.
+// Each call returns a fresh PGSessionStore (via wrapper) backed by its own
+// per-test database (migratedPool). The cleanup func is a no-op since the
+// per-test DB is dropped automatically via tb.Cleanup in migratedPool.
 func pgFactory(t *testing.T) (session.Store, *clockmock.FakeClock, func()) {
 	t.Helper()
 
-	pool, teardown := setupPostgres(t)
-	t.Cleanup(teardown)
-
-	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx))
+	pool := migratedPool(t)
 
 	fc := clockmock.New(storetest.EpochAnchor())
 	txm := NewTxManager(pool)
@@ -166,10 +151,7 @@ func pgFactory(t *testing.T) (session.Store, *clockmock.FakeClock, func()) {
 
 	wrapper := &pgSessionStoreWrapper{inner: store, pool: pool, t: t}
 
-	cleanup := func() {
-		resetSessionsTable(t, pool)
-	}
-	return wrapper, fc, cleanup
+	return wrapper, fc, func() {}
 }
 
 // ---------------------------------------------------------------------------
@@ -267,38 +249,25 @@ func TestNewSessionStore_NilClock_Rejected(t *testing.T) {
 //   - healthy: a fully migrated store returns nil from RepoReady.
 //   - broken: a store whose sessions table has been dropped returns non-nil.
 //
-// Each store uses an isolated schema pool so the DROP TABLE for the broken
+// Each store uses its own migratedPool so the DROP TABLE for the broken
 // scenario does not affect the healthy store's sessions table. The real
 // *PGSessionStore (not the pgSessionStoreWrapper) is passed to
 // RunRepoReadinessConformance so the archtest type-resolution still detects
 // coverage.
 func TestPGSessionStore_RepoReadinessConformance(t *testing.T) {
-	base, baseTeardown := setupPostgres(t)
-	t.Cleanup(baseTeardown)
-
 	ctx := context.Background()
 	proto := storetest.NewTestProtocol(t)
 	fc := clockmock.New(storetest.EpochAnchor())
 
-	// healthy: isolated schema with full migrations — sessions table intact.
-	healthyPool := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = healthyPool.Close(context.Background()) })
-	healthyMigrator, err := NewMigrator(healthyPool, testMigrationsFS(t), "schema_migrations_readyz_healthy")
-	require.NoError(t, err)
-	require.NoError(t, healthyMigrator.Up(ctx))
-
+	// healthy: per-test DB with full migrations — sessions table intact.
+	healthyPool := migratedPool(t)
 	healthyTxm := NewTxManager(healthyPool)
 	healthy, err := NewSessionStore(healthyPool.DB(), healthyTxm, proto, fc)
 	require.NoError(t, err)
 
-	// broken: isolated schema with migrations applied, then sessions table dropped
+	// broken: per-test DB with migrations applied, then sessions table dropped
 	// to simulate schema drift / missing migration.
-	brokenPool := isolatedSchemaPool(t, ctx, base)
-	t.Cleanup(func() { _ = brokenPool.Close(context.Background()) })
-	brokenMigrator, err := NewMigrator(brokenPool, testMigrationsFS(t), "schema_migrations_readyz_broken")
-	require.NoError(t, err)
-	require.NoError(t, brokenMigrator.Up(ctx))
-
+	brokenPool := migratedPool(t)
 	_, dropErr := brokenPool.DB().Exec(ctx, "DROP TABLE IF EXISTS sessions CASCADE")
 	require.NoError(t, dropErr, "drop sessions table for broken scenario")
 

--- a/adapters/postgres/testmain_integration_test.go
+++ b/adapters/postgres/testmain_integration_test.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -21,21 +22,31 @@ import (
 // use pgclone directly with this in-package migration callback. pgclone is the
 // single sanctioned holder of tcpostgres.Run (PG-TESTCONTAINER-FUNNEL-01).
 var sharedPG = pgclone.New("gocell_adapters_postgres_test_template",
-	func(ctx context.Context, dsn string) error {
+	func(ctx context.Context, dsn string) (err error) {
 		pool, err := NewPool(ctx, Config{DSN: dsn})
 		if err != nil {
-			return err
+			return fmt.Errorf("open template pool: %w", err)
 		}
-		defer func() { _ = pool.Close(ctx) }()
+		defer func() {
+			// Close error matters: a lingering connection on the template blocks
+			// the first CREATE DATABASE ... TEMPLATE clone. Surface it (when the
+			// migration itself succeeded) so boot fails fast with a clear cause.
+			if cerr := pool.Close(ctx); cerr != nil && err == nil {
+				err = fmt.Errorf("close migration pool: %w", cerr)
+			}
+		}()
 		fsys, err := MigrationsFS()
 		if err != nil {
-			return err
+			return fmt.Errorf("load migrations fs: %w", err)
 		}
 		migrator, err := NewMigrator(pool, fsys, "schema_migrations")
 		if err != nil {
-			return err
+			return fmt.Errorf("new migrator: %w", err)
 		}
-		return migrator.Up(ctx)
+		if err := migrator.Up(ctx); err != nil {
+			return fmt.Errorf("migrate up: %w", err)
+		}
+		return nil
 	})
 
 // TestMain owns shared-container teardown. Runs once per test binary after all

--- a/adapters/postgres/testmain_integration_test.go
+++ b/adapters/postgres/testmain_integration_test.go
@@ -57,7 +57,8 @@ func migratedPool(tb testing.TB) *Pool {
 
 // emptyPool returns a Pool to a fresh empty per-test database (template1, no
 // schema). For migration/schema tests that run their own Up/UpTo/provider.Down
-// against a clean database. Cleanup is registered via tb.Cleanup.
+// against a clean database. Cleanup is registered via tb.Cleanup — callers
+// must not Close manually.
 func emptyPool(tb testing.TB) *Pool {
 	tb.Helper()
 	return openPerTestPool(tb, sharedPG.EmptyDSN(tb))

--- a/adapters/postgres/testmain_integration_test.go
+++ b/adapters/postgres/testmain_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/ghbvf/gocell/tests/testutil/pgclone"
+)
+
+// sharedPG owns one PostgreSQL container for the whole adapters/postgres test
+// binary. The migrated template carries the production migration set; per-test
+// databases are cloned (migratedPool) or created empty (emptyPool) at
+// ~10-200ms each, replacing the historic ~2.5s-per-test container spin-up
+// (~93 spin-ups, ~237s) that dominated CI.
+//
+// adapters/postgres integration tests are white-box `package postgres`, so
+// they cannot import pgshare (pgshare imports adapterpg → import cycle). They
+// use pgclone directly with this in-package migration callback. pgclone is the
+// single sanctioned holder of tcpostgres.Run (PG-TESTCONTAINER-FUNNEL-01).
+var sharedPG = pgclone.New("gocell_adapters_postgres_test_template",
+	func(ctx context.Context, dsn string) error {
+		pool, err := NewPool(ctx, Config{DSN: dsn})
+		if err != nil {
+			return err
+		}
+		defer func() { _ = pool.Close(ctx) }()
+		fsys, err := MigrationsFS()
+		if err != nil {
+			return err
+		}
+		migrator, err := NewMigrator(pool, fsys, "schema_migrations")
+		if err != nil {
+			return err
+		}
+		return migrator.Up(ctx)
+	})
+
+// TestMain owns shared-container teardown. Runs once per test binary after all
+// tests complete.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	sharedPG.Shutdown()
+	os.Exit(code)
+}
+
+// migratedPool returns a Pool to a fresh per-test database cloned from the
+// pre-migrated template (production schema present). For tests that need the
+// schema and do NOT run their own migrations. Cleanup is registered via
+// tb.Cleanup — callers must not Close manually.
+func migratedPool(tb testing.TB) *Pool {
+	tb.Helper()
+	return openPerTestPool(tb, sharedPG.CloneDSN(tb))
+}
+
+// emptyPool returns a Pool to a fresh empty per-test database (template1, no
+// schema). For migration/schema tests that run their own Up/UpTo/provider.Down
+// against a clean database. Cleanup is registered via tb.Cleanup.
+func emptyPool(tb testing.TB) *Pool {
+	tb.Helper()
+	return openPerTestPool(tb, sharedPG.EmptyDSN(tb))
+}
+
+func openPerTestPool(tb testing.TB, dsn string) *Pool {
+	tb.Helper()
+	pool, err := NewPool(context.Background(), Config{DSN: dsn})
+	if err != nil {
+		tb.Fatalf("open per-test pool: %v", err)
+	}
+	tb.Cleanup(func() {
+		if err := pool.Close(context.Background()); err != nil {
+			tb.Logf("WARN: per-test pool close: %v", err)
+		}
+	})
+	return pool
+}

--- a/tests/testutil/pgclone/pgclone.go
+++ b/tests/testutil/pgclone/pgclone.go
@@ -120,6 +120,27 @@ func (s *Shared) EmptyDSN(tb testing.TB) string {
 
 func (s *Shared) perTestDSN(tb testing.TB, migrated bool) string {
 	tb.Helper()
+	dsn, drop := s.mint(tb, migrated)
+	tb.Cleanup(drop)
+	return dsn
+}
+
+// CloneManaged is like CloneDSN but returns a manual release func instead of
+// registering t.Cleanup(drop). For per-iteration lifecycles — e.g. a benchmark
+// that clones inside the b.N loop, where deferring every drop to b.Cleanup
+// would accumulate b.N databases until the benchmark ends. The caller MUST
+// call release exactly once (typically alongside its own pool.Close).
+func (s *Shared) CloneManaged(tb testing.TB) (dsn string, release func()) {
+	tb.Helper()
+	return s.mint(tb, true)
+}
+
+// mint boots the shared container on first call, creates a fresh per-test
+// database (cloned from the migrated template when migrated, else empty), and
+// returns its DSN plus a drop func. It does NOT register cleanup — perTestDSN
+// wires t.Cleanup(drop); CloneManaged hands the drop to the caller.
+func (s *Shared) mint(tb testing.TB, migrated bool) (dsn string, drop func()) {
+	tb.Helper()
 	// Per-call skip-or-fatal gate. RequireDocker either skips (local dev,
 	// Docker absent) or fatals (CI with GOCELL_TEST_DOCKER_REQUIRED=1). Called
 	// outside sync.Once so the gate fires for every caller even after init ran
@@ -145,13 +166,12 @@ func (s *Shared) perTestDSN(tb testing.TB, migrated bool) string {
 		tb.Fatalf("mint per-test DB %s (migrated=%v): %v", dbName, migrated, err)
 	}
 
-	tb.Cleanup(func() {
+	drop = func() {
 		if derr := dropDatabase(context.Background(), s.adminDSN, dbName); derr != nil {
 			tb.Logf("WARN: drop per-test DB %s: %v", dbName, derr)
 		}
-	})
-
-	return swapDatabaseInDSN(s.adminDSN, dbName)
+	}
+	return swapDatabaseInDSN(s.adminDSN, dbName), drop
 }
 
 // Shutdown terminates the shared container if it was booted. Safe to call even
@@ -177,6 +197,10 @@ func (s *Shared) boot(tb testing.TB) {
 
 	if err := validateTemplateDB(s.templateDB); err != nil {
 		s.initErr = err
+		return
+	}
+	if s.migrate == nil {
+		s.initErr = fmt.Errorf("pgclone: migrate func must not be nil")
 		return
 	}
 

--- a/tests/testutil/pgclone/pgclone.go
+++ b/tests/testutil/pgclone/pgclone.go
@@ -27,13 +27,15 @@
 // helpers across multiple _test.go files collapse onto one container + one
 // migration.
 //
-// AI-rebust funnel rating (see .claude/rules/gocell/ai-collab.md): the
-// PG-TESTCONTAINER-FUNNEL guard (depguard import ban + typed archtest
-// callsite identity) is Medium/Medium. Hard is structurally unreachable for
-// "ban a third-party symbol outside an allowlist" — Go has no import
-// visibility modifier, so the compiler cannot forbid importing a public
-// package. Lint-time import-ban + type-resolved callee archtest is the
-// highest tier this rule shape can reach in Go.
+// The PG-TESTCONTAINER-FUNNEL guard (a pure-AST archtest — the callsites are
+// //go:build integration files invisible to golangci-lint/typed tooling) keeps
+// tcpostgres.Run out of every other package. Its AI-rebust rating and
+// blind-spot inventory live in tools/archtest/pg_testcontainer_funnel_test.go.
+//
+// Most callers outside adapters/postgres should use tests/testutil/pgshare,
+// which wraps pgclone with a typed *adapterpg.Pool return. Only white-box
+// `package postgres` tests (which cannot import pgshare without an import
+// cycle) use pgclone directly.
 package pgclone
 
 import (
@@ -52,11 +54,14 @@ import (
 )
 
 // MigrateFunc applies the caller's migration set to the template database at
-// templateDSN. The implementation MUST close any pool/connection it opens
-// before returning: CREATE DATABASE ... TEMPLATE rejects a source DB with
-// active connections, so a lingering connection blocks every subsequent
-// CloneDSN. Callers typically use adapterpg.NewPool + NewMigrator + Up with a
-// deferred pool.Close.
+// templateDSN. Callers typically use adapterpg.NewPool + NewMigrator + Up with
+// a deferred pool.Close.
+//
+// WARNING: the implementation MUST close every pool/connection it opens before
+// returning. CREATE DATABASE ... TEMPLATE rejects a source DB with active
+// connections, so a single lingering connection silently breaks EVERY
+// subsequent CloneDSN call. Use a deferred Close (see pgshare.applyMigrations
+// for the canonical pattern).
 type MigrateFunc func(ctx context.Context, templateDSN string) error
 
 // Shared owns the per-package container + template DB lifecycle. Create one
@@ -137,7 +142,7 @@ func (s *Shared) perTestDSN(tb testing.TB, migrated bool) string {
 		err = createDatabase(ctx, s.adminDSN, dbName)
 	}
 	if err != nil {
-		tb.Fatalf("mint per-test DB %s: %v", dbName, err)
+		tb.Fatalf("mint per-test DB %s (migrated=%v): %v", dbName, migrated, err)
 	}
 
 	tb.Cleanup(func() {
@@ -275,7 +280,11 @@ func execAdmin(ctx context.Context, adminDSN, sql string) error {
 	if err != nil {
 		return fmt.Errorf("connect admin: %w", err)
 	}
-	defer func() { _ = conn.Close(ctx) }()
+	defer func() {
+		if cerr := conn.Close(ctx); cerr != nil {
+			slog.Default().Warn("pgclone: admin conn close failed", "error", cerr)
+		}
+	}()
 	if _, err := conn.Exec(ctx, sql); err != nil {
 		return fmt.Errorf("exec admin sql: %w", err)
 	}

--- a/tests/testutil/pgclone/pgclone.go
+++ b/tests/testutil/pgclone/pgclone.go
@@ -1,0 +1,324 @@
+//go:build integration
+
+// Package pgclone owns the process-wide shared PostgreSQL container lifecycle
+// and per-test database minting for integration test packages. It is the
+// single sanctioned holder of tcpostgres.Run in the repo (PG-TESTCONTAINER-
+// FUNNEL): tests/testutil/pgshare and adapters/postgres's in-package test
+// helper both delegate here, so no other package needs to import the
+// testcontainers postgres module.
+//
+// pgclone deliberately does NOT import adapters/postgres. The migration step
+// (which needs adapterpg.NewMigrator) is supplied by the caller as a
+// MigrateFunc callback. This dependency inversion is what lets
+// adapters/postgres's own white-box (`package postgres`) tests share one
+// container without an import cycle: pgshare imports adapterpg, so
+// adapters/postgres tests cannot import pgshare; they import pgclone, which
+// has no adapterpg edge.
+//
+// Two per-test paths share one container:
+//   - CloneDSN: a per-test DB cloned from a pre-migrated template
+//     (CREATE DATABASE ... TEMPLATE, file-level copy ~50-200ms). For tests
+//     that need the production schema already present.
+//   - EmptyDSN: a per-test empty DB (plain CREATE DATABASE = template1). For
+//     migration/schema tests that run their own Up/UpTo against a clean DB.
+//
+// Package-test binaries run in independent processes, so a *Shared is scoped
+// to one Go test binary; the value is intra-package sharing — multiple setup
+// helpers across multiple _test.go files collapse onto one container + one
+// migration.
+//
+// AI-rebust funnel rating (see .claude/rules/gocell/ai-collab.md): the
+// PG-TESTCONTAINER-FUNNEL guard (depguard import ban + typed archtest
+// callsite identity) is Medium/Medium. Hard is structurally unreachable for
+// "ban a third-party symbol outside an allowlist" — Go has no import
+// visibility modifier, so the compiler cannot forbid importing a public
+// package. Lint-time import-ban + type-resolved callee archtest is the
+// highest tier this rule shape can reach in Go.
+package pgclone
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"github.com/ghbvf/gocell/tests/testutil"
+)
+
+// MigrateFunc applies the caller's migration set to the template database at
+// templateDSN. The implementation MUST close any pool/connection it opens
+// before returning: CREATE DATABASE ... TEMPLATE rejects a source DB with
+// active connections, so a lingering connection blocks every subsequent
+// CloneDSN. Callers typically use adapterpg.NewPool + NewMigrator + Up with a
+// deferred pool.Close.
+type MigrateFunc func(ctx context.Context, templateDSN string) error
+
+// Shared owns the per-package container + template DB lifecycle. Create one
+// in a package-scope var and call Shutdown from TestMain.
+//
+// The zero value is invalid; callers must use New.
+type Shared struct {
+	templateDB string
+	migrate    MigrateFunc
+
+	once     sync.Once
+	initErr  error
+	adminDSN string
+	shutdown func()
+}
+
+// New returns a *Shared bound to templateDB and the caller's MigrateFunc.
+//
+// templateDB must satisfy PostgreSQL identifier rules (see validateTemplateDB):
+// non-empty, ≤ 63 chars, starts with [a-z_], only lowercase ascii letters /
+// digits / underscores, no NUL or double-quote. Use a unique name per Go test
+// binary (`gocell_<pkg>_test_template` is the convention).
+//
+// Validation + container boot are lazy (first CloneDSN/EmptyDSN call): an
+// invalid name surfaces as t.Fatalf there, not a constructor panic. This keeps
+// pgclone panic-free (PANIC-REGISTERED-01 forbids unwrapped panic in this
+// build-tag-gated non-_test.go file). The instance is dormant until the first
+// CloneDSN/EmptyDSN call.
+func New(templateDB string, migrate MigrateFunc) *Shared {
+	return &Shared{templateDB: templateDB, migrate: migrate}
+}
+
+// CloneDSN boots the shared container on first call (one-shot per test
+// binary), clones the pre-migrated template into a fresh per-test database,
+// and returns a DSN pointing at it. The per-test DB is dropped via t.Cleanup
+// (DROP DATABASE ... WITH (FORCE)).
+//
+// The caller opens its own pool against the returned DSN and registers
+// pool.Close via t.Cleanup AFTER this call — t.Cleanup is LIFO, so the pool
+// closes before the DB is dropped (and WITH (FORCE) is a belt-and-suspenders
+// safeguard if ordering is ever wrong).
+func (s *Shared) CloneDSN(tb testing.TB) string {
+	tb.Helper()
+	return s.perTestDSN(tb, true)
+}
+
+// EmptyDSN is like CloneDSN but the per-test database is empty (plain CREATE
+// DATABASE = template1, no production schema). For migration/schema tests
+// that run their own Up/UpTo against a clean database. The shared container's
+// migrated template is still built once on boot (the adopting package uses
+// both paths); empty DBs simply skip the clone.
+func (s *Shared) EmptyDSN(tb testing.TB) string {
+	tb.Helper()
+	return s.perTestDSN(tb, false)
+}
+
+func (s *Shared) perTestDSN(tb testing.TB, migrated bool) string {
+	tb.Helper()
+	// Per-call skip-or-fatal gate. RequireDocker either skips (local dev,
+	// Docker absent) or fatals (CI with GOCELL_TEST_DOCKER_REQUIRED=1). Called
+	// outside sync.Once so the gate fires for every caller even after init ran
+	// once — keeps test-binary semantics consistent when Docker disappears
+	// mid-suite.
+	testutil.RequireDocker(tb)
+
+	s.once.Do(func() { s.boot(tb) })
+	if s.initErr != nil {
+		tb.Fatalf("shared postgres unavailable: %v", s.initErr)
+	}
+
+	ctx := context.Background()
+	dbName := newDBName()
+
+	var err error
+	if migrated {
+		err = cloneDatabase(ctx, s.adminDSN, s.templateDB, dbName)
+	} else {
+		err = createDatabase(ctx, s.adminDSN, dbName)
+	}
+	if err != nil {
+		tb.Fatalf("mint per-test DB %s: %v", dbName, err)
+	}
+
+	tb.Cleanup(func() {
+		if derr := dropDatabase(context.Background(), s.adminDSN, dbName); derr != nil {
+			tb.Logf("WARN: drop per-test DB %s: %v", dbName, derr)
+		}
+	})
+
+	return swapDatabaseInDSN(s.adminDSN, dbName)
+}
+
+// Shutdown terminates the shared container if it was booted. Safe to call even
+// when the singleton was never initialized (s.shutdown nil → no-op). Call from
+// TestMain after m.Run.
+func (s *Shared) Shutdown() {
+	if s.shutdown != nil {
+		s.shutdown()
+	}
+}
+
+// boot validates the template name, starts the container, creates the template
+// DB, applies the caller's migrations, and stores the admin DSN. Runs exactly
+// once per *Shared (guarded by sync.Once in perTestDSN).
+//
+// boot takes testing.TB because the testcontainer archtest
+// TestTestcontainerHelpersRequireDockerBeforeRun requires the function that
+// calls tcpostgres.Run to also call testutil.RequireDocker first. Errors set
+// s.initErr (no t.Fatal inside boot) so the sync.Once gate cannot leave the
+// singleton half-initialized — perTestDSN reads s.initErr and surfaces it.
+func (s *Shared) boot(tb testing.TB) {
+	tb.Helper()
+
+	if err := validateTemplateDB(s.templateDB); err != nil {
+		s.initErr = err
+		return
+	}
+
+	// RequireDocker inside the function with tcpostgres.Run — see boot godoc
+	// for the archtest rationale.
+	testutil.RequireDocker(tb)
+
+	ctx := context.Background()
+	// password/user/db are container-internal credentials — the container
+	// lives only within this test binary's process and never accepts external
+	// traffic; the reused literal across pgclone callers is intentional.
+	container, err := tcpostgres.Run(
+		ctx, testutil.PostgresImage,
+		tcpostgres.WithDatabase("test"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		s.initErr = fmt.Errorf("start shared postgres: %w", err)
+		return
+	}
+
+	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		s.terminateAfterInitFailure(ctx, container, fmt.Errorf("admin DSN: %w", err))
+		return
+	}
+	if err := createDatabase(ctx, adminDSN, s.templateDB); err != nil {
+		s.terminateAfterInitFailure(ctx, container, fmt.Errorf("create template DB: %w", err))
+		return
+	}
+	templateDSN := swapDatabaseInDSN(adminDSN, s.templateDB)
+	if err := s.migrate(ctx, templateDSN); err != nil {
+		s.terminateAfterInitFailure(ctx, container, fmt.Errorf("apply migrations to template: %w", err))
+		return
+	}
+
+	s.adminDSN = adminDSN
+	s.shutdown = func() {
+		if err := container.Terminate(ctx); err != nil {
+			// TestMain runs outside any test context, so *testing.T is
+			// unavailable. Emit to slog so CI log scrapers pick up cleanup
+			// failures; Ryuk fallback handles the actual reap.
+			slog.Default().Error("pgclone: shared container terminate failed",
+				"templateDB", s.templateDB, "error", err)
+		}
+	}
+}
+
+// terminateAfterInitFailure tears down the container after a boot-step failure
+// and records cause in s.initErr. A terminate failure is logged (Ryuk reaps
+// the leak) but does not mask the original cause.
+func (s *Shared) terminateAfterInitFailure(ctx context.Context, container *tcpostgres.PostgresContainer, cause error) {
+	if termErr := container.Terminate(ctx); termErr != nil {
+		slog.Default().Error("pgclone: terminate after init failure also failed",
+			"templateDB", s.templateDB, "init_err", cause, "terminate_err", termErr)
+	}
+	s.initErr = cause
+}
+
+// validateTemplateDB returns nil if name is a legal Postgres identifier under
+// the rules documented on New.
+func validateTemplateDB(templateDB string) error {
+	switch {
+	case templateDB == "":
+		return fmt.Errorf("pgclone: templateDB must not be empty")
+	case len(templateDB) > 63:
+		return fmt.Errorf("pgclone: templateDB exceeds Postgres NAMEDATALEN limit of 63 chars, got %q", templateDB)
+	case strings.ContainsRune(templateDB, '\x00'):
+		return fmt.Errorf("pgclone: templateDB must not contain NUL bytes, got %q", templateDB)
+	case strings.ContainsRune(templateDB, '"'):
+		return fmt.Errorf("pgclone: templateDB must not contain double-quote characters, got %q", templateDB)
+	}
+	for i, ch := range templateDB {
+		if i == 0 {
+			if (ch < 'a' || ch > 'z') && ch != '_' {
+				return fmt.Errorf("pgclone: templateDB must start with [a-z_], got %q", templateDB)
+			}
+			continue
+		}
+		if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '_' {
+			return fmt.Errorf(
+				"pgclone: templateDB must contain only lowercase ascii letters, digits, and underscores (no uppercase), got %q",
+				templateDB)
+		}
+	}
+	return nil
+}
+
+func newDBName() string {
+	return "test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
+// execAdmin opens a throwaway admin connection, runs sql, and closes the
+// connection before return. Closing matters for CREATE DATABASE ... TEMPLATE:
+// Postgres rejects cloning a source DB that has active connections, so a
+// lingering admin connection here would block subsequent clones.
+func execAdmin(ctx context.Context, adminDSN, sql string) error {
+	conn, err := pgx.Connect(ctx, adminDSN)
+	if err != nil {
+		return fmt.Errorf("connect admin: %w", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+	if _, err := conn.Exec(ctx, sql); err != nil {
+		return fmt.Errorf("exec admin sql: %w", err)
+	}
+	return nil
+}
+
+// createDatabase creates an empty database (template1 default). Used both for
+// the shared template DB (boot, before migration) and for EmptyDSN per-test
+// databases.
+func createDatabase(ctx context.Context, adminDSN, name string) error {
+	return execAdmin(ctx, adminDSN, "CREATE DATABASE "+pgQuoteIdent(name))
+}
+
+// cloneDatabase creates newDB as a file-level copy of templateDB.
+func cloneDatabase(ctx context.Context, adminDSN, templateDB, newDB string) error {
+	return execAdmin(ctx, adminDSN, fmt.Sprintf(
+		"CREATE DATABASE %s TEMPLATE %s", pgQuoteIdent(newDB), pgQuoteIdent(templateDB)))
+}
+
+// dropDatabase removes a per-test database via WITH (FORCE) to terminate any
+// straggling connections (the per-test pool should already be Closed; FORCE is
+// a belt-and-suspenders safeguard against test cleanup ordering bugs).
+func dropDatabase(ctx context.Context, adminDSN, name string) error {
+	return execAdmin(ctx, adminDSN, "DROP DATABASE IF EXISTS "+pgQuoteIdent(name)+" WITH (FORCE)")
+}
+
+// swapDatabaseInDSN rewrites the database segment of a postgres DSN.
+// testcontainers-go modules/postgres always emits the canonical form
+// `scheme://user:pass@host:port/<db>?<query>` so a last-`/` + first-`?` split
+// is sufficient.
+func swapDatabaseInDSN(dsn, newDB string) string {
+	idx := strings.LastIndex(dsn, "/")
+	if idx < 0 {
+		return dsn
+	}
+	before := dsn[:idx+1]
+	rest := dsn[idx+1:]
+	if q := strings.IndexByte(rest, '?'); q >= 0 {
+		return before + newDB + rest[q:]
+	}
+	return before + newDB
+}
+
+func pgQuoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}

--- a/tests/testutil/pgclone/pgclone_test.go
+++ b/tests/testutil/pgclone/pgclone_test.go
@@ -1,0 +1,298 @@
+//go:build integration
+
+package pgclone
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// TestValidateTemplateDB exhaustively exercises each rejection branch of
+// validateTemplateDB plus the happy path. Validation is the only pgclone
+// surface reachable without Docker.
+func TestValidateTemplateDB(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantMatch string
+	}{
+		{name: "valid_lowercase", input: "gocell_test_template", wantErr: false},
+		{name: "valid_underscore_prefix", input: "_template", wantErr: false},
+		{name: "valid_with_digits", input: "test_2025", wantErr: false},
+		{name: "valid_single_letter", input: "x", wantErr: false},
+		{name: "valid_max_length", input: strings.Repeat("a", 63), wantErr: false},
+
+		{name: "empty", input: "", wantErr: true, wantMatch: "must not be empty"},
+		{name: "too_long", input: strings.Repeat("a", 64), wantErr: true, wantMatch: "NAMEDATALEN"},
+		{name: "contains_null_byte", input: "test\x00drop", wantErr: true, wantMatch: "NUL bytes"},
+		{name: "contains_double_quote", input: `test"db`, wantErr: true, wantMatch: "double-quote"},
+		{name: "digit_prefix", input: "1test", wantErr: true, wantMatch: "must start with [a-z_]"},
+		{name: "uppercase_prefix", input: "Test", wantErr: true, wantMatch: "must start with [a-z_]"},
+		{name: "uppercase_middle", input: "testDB", wantErr: true, wantMatch: "only lowercase ascii"},
+		{name: "hyphen_invalid", input: "test-db", wantErr: true, wantMatch: "only lowercase ascii"},
+		{name: "dot_invalid", input: "test.db", wantErr: true, wantMatch: "only lowercase ascii"},
+		{name: "space_invalid", input: "test db", wantErr: true, wantMatch: "only lowercase ascii"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateTemplateDB(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validateTemplateDB(%q): want error, got nil", tc.input)
+				}
+				if !strings.Contains(err.Error(), tc.wantMatch) {
+					t.Fatalf("validateTemplateDB(%q): error %q must contain %q",
+						tc.input, err.Error(), tc.wantMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateTemplateDB(%q): want nil, got %v", tc.input, err)
+			}
+		})
+	}
+}
+
+// TestSwapDatabaseInDSN covers every branch of the DSN rewrite helper.
+func TestSwapDatabaseInDSN(t *testing.T) {
+	cases := []struct {
+		name  string
+		dsn   string
+		newDB string
+		want  string
+	}{
+		{
+			name:  "canonical_with_query",
+			dsn:   "postgres://test:test@localhost:5432/test?sslmode=disable",
+			newDB: "fresh",
+			want:  "postgres://test:test@localhost:5432/fresh?sslmode=disable",
+		},
+		{
+			name:  "no_query",
+			dsn:   "postgres://u:p@h:5432/admin",
+			newDB: "newdb",
+			want:  "postgres://u:p@h:5432/newdb",
+		},
+		{
+			name:  "complex_query_preserved",
+			dsn:   "postgres://u:p@h/old?sslmode=disable&pool_max_conns=10",
+			newDB: "isolated_42",
+			want:  "postgres://u:p@h/isolated_42?sslmode=disable&pool_max_conns=10",
+		},
+		{
+			name:  "no_slash_returns_input",
+			dsn:   "not-a-dsn",
+			newDB: "ignored",
+			want:  "not-a-dsn",
+		},
+		{
+			name:  "trailing_slash_only",
+			dsn:   "postgres://h/",
+			newDB: "x",
+			want:  "postgres://h/x",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := swapDatabaseInDSN(tc.dsn, tc.newDB)
+			if got != tc.want {
+				t.Fatalf("swapDatabaseInDSN(%q, %q) = %q, want %q",
+					tc.dsn, tc.newDB, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPgQuoteIdent verifies identifier double-quoting (SQL-injection defense
+// for caller-supplied templateDB names).
+func TestPgQuoteIdent(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain", in: "mydb", want: `"mydb"`},
+		{name: "empty", in: "", want: `""`},
+		{name: "contains_double_quote", in: `bad"name`, want: `"bad""name"`},
+		{name: "multiple_quotes", in: `"a"b"`, want: `"""a""b"""`},
+		{name: "uppercase_preserved", in: "MyDB", want: `"MyDB"`},
+		{name: "whitespace_preserved", in: "my db", want: `"my db"`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pgQuoteIdent(tc.in)
+			if got != tc.want {
+				t.Fatalf("pgQuoteIdent(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNew_StoresFieldsVerbatim asserts New is a thin constructor — it must NOT
+// validate or transform templateDB (validation is lazy at first perTestDSN).
+func TestNew_StoresFieldsVerbatim(t *testing.T) {
+	t.Parallel()
+	bad := "1invalid-name"
+	s := New(bad, nil)
+	if s == nil {
+		t.Fatal("New returned nil for syntactically bad templateDB; expected non-nil with lazy validation")
+	}
+	if s.templateDB != bad {
+		t.Fatalf("templateDB stored as %q, want verbatim %q", s.templateDB, bad)
+	}
+}
+
+// TestShared_Shutdown_NoOpWhenUninitialized asserts Shutdown before any
+// perTestDSN call (s.shutdown nil) does not panic and does not touch state.
+func TestShared_Shutdown_NoOpWhenUninitialized(t *testing.T) {
+	t.Parallel()
+	s := New("never_initialized", nil)
+	s.Shutdown()
+	if s.shutdown != nil {
+		t.Fatalf("Shutdown on uninitialized *Shared must not populate shutdown closure; got non-nil")
+	}
+	if s.initErr != nil {
+		t.Fatalf("Shutdown must not trigger init; got initErr = %v", s.initErr)
+	}
+}
+
+// TestShared_boot_RejectsInvalidTemplateDB asserts boot catches invalid names
+// at the validation gate (before RequireDocker / migrate), so this does NOT
+// require Docker. nil migrate is fine — validation short-circuits first.
+func TestShared_boot_RejectsInvalidTemplateDB(t *testing.T) {
+	t.Parallel()
+	s := New("Bad_Name", nil) // uppercase → rejected by validateTemplateDB
+	s.boot(t)
+	if s.initErr == nil {
+		t.Fatal("boot() must populate initErr for invalid templateDB")
+	}
+	if !strings.Contains(s.initErr.Error(), "must start with") {
+		t.Fatalf("initErr %q must reference the validation rule", s.initErr.Error())
+	}
+}
+
+// TestShared_zeroValueIsInvalid pins the godoc-stated contract that the zero
+// value is not usable: boot with empty templateDB errors before RequireDocker.
+func TestShared_zeroValueIsInvalid(t *testing.T) {
+	t.Parallel()
+	var s Shared // zero value
+	s.boot(t)
+	if s.initErr == nil {
+		t.Fatal("zero-value *Shared must yield validation error on boot()")
+	}
+	if !strings.Contains(s.initErr.Error(), "must not be empty") {
+		t.Fatalf("zero-value initErr %q must mention empty-name rule", s.initErr.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Docker-bound self-tests. Use a pgx-only seed migration so pgclone's own
+// tests stay free of any adapters/postgres dependency (the full adapterpg
+// migration path is exercised by pgshare's own integration tests).
+// ---------------------------------------------------------------------------
+
+const seedTable = "pgclone_seed"
+
+// seedMigrate creates one marker table in the template DB. It MUST close its
+// connection before returning per the MigrateFunc contract (CREATE DATABASE
+// TEMPLATE rejects a source DB with active connections).
+func seedMigrate(ctx context.Context, dsn string) error {
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close(ctx) }()
+	_, err = conn.Exec(ctx, "CREATE TABLE "+seedTable+" (x int)")
+	return err
+}
+
+var pgcloneSelfTest = New("gocell_pgclone_selftest_template", seedMigrate)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	pgcloneSelfTest.Shutdown()
+	os.Exit(code)
+}
+
+func tableExists(ctx context.Context, t *testing.T, dsn, table string) bool {
+	t.Helper()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect %s: %v", dsn, err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+	var exists bool
+	if err := conn.QueryRow(ctx,
+		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1)",
+		table).Scan(&exists); err != nil {
+		t.Fatalf("table-exists probe %s: %v", table, err)
+	}
+	return exists
+}
+
+// TestCloneDSN_IsolatesAndInheritsTemplate boots the shared container (first
+// call), clones two per-test DBs, and asserts: (a) both inherit the seed table
+// from the migrated template, (b) a write into one is invisible from the other.
+func TestCloneDSN_IsolatesAndInheritsTemplate(t *testing.T) {
+	ctx := context.Background()
+	dsnA := pgcloneSelfTest.CloneDSN(t)
+	dsnB := pgcloneSelfTest.CloneDSN(t)
+
+	if !tableExists(ctx, t, dsnA, seedTable) {
+		t.Fatalf("clone A did not inherit template seed table %q", seedTable)
+	}
+	if !tableExists(ctx, t, dsnB, seedTable) {
+		t.Fatalf("clone B did not inherit template seed table %q", seedTable)
+	}
+
+	connA, err := pgx.Connect(ctx, dsnA)
+	if err != nil {
+		t.Fatalf("connect A: %v", err)
+	}
+	defer func() { _ = connA.Close(ctx) }()
+
+	uniq := "iso_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	if _, err := connA.Exec(ctx, "CREATE TABLE "+uniq+" (x int)"); err != nil {
+		t.Fatalf("create table in A: %v", err)
+	}
+	if tableExists(ctx, t, dsnB, uniq) {
+		t.Fatalf("isolation broken: table %s created in clone A is visible from clone B", uniq)
+	}
+}
+
+// TestEmptyDSN_HasNoTemplateSchema asserts EmptyDSN returns a clean database
+// that does NOT inherit the migrated template (template1, not the seed).
+func TestEmptyDSN_HasNoTemplateSchema(t *testing.T) {
+	ctx := context.Background()
+	dsn := pgcloneSelfTest.EmptyDSN(t)
+	if tableExists(ctx, t, dsn, seedTable) {
+		t.Fatalf("EmptyDSN must be empty; seed table %q must not exist", seedTable)
+	}
+}
+
+// TestSharedSingleton_ContainerStartsOnce verifies CloneDSN and EmptyDSN share
+// the same container — adminDSN is stable across calls and both paths.
+func TestSharedSingleton_ContainerStartsOnce(t *testing.T) {
+	_ = pgcloneSelfTest.CloneDSN(t)
+	dsn1 := pgcloneSelfTest.adminDSN
+	if dsn1 == "" {
+		t.Fatal("adminDSN empty after first CloneDSN; boot did not populate")
+	}
+	_ = pgcloneSelfTest.EmptyDSN(t)
+	dsn2 := pgcloneSelfTest.adminDSN
+	if dsn1 != dsn2 {
+		t.Fatalf("adminDSN changed across calls; container re-spawned (dsn1=%q dsn2=%q)", dsn1, dsn2)
+	}
+}

--- a/tests/testutil/pgclone/pgclone_test.go
+++ b/tests/testutil/pgclone/pgclone_test.go
@@ -310,6 +310,32 @@ func TestSharedSingleton_ContainerStartsOnce(t *testing.T) {
 	_ = pgcloneSelfTest.EmptyDSN(t)
 	dsn2 := pgcloneSelfTest.adminDSN
 	if dsn1 != dsn2 {
-		t.Fatalf("adminDSN changed across calls; container re-spawned (dsn1=%q dsn2=%q)", dsn1, dsn2)
+		// adminDSN carries the (test) PG password — assert equality without
+		// logging either value.
+		t.Fatal("adminDSN changed across calls; container was re-spawned (singleton broken)")
+	}
+}
+
+// TestCloneManaged_ReleaseDropsDB verifies CloneManaged returns a usable DSN
+// (migrated template inherited) and that release() drops the per-test DB. This
+// is the manual-lifecycle path for callers that mint inside a loop (e.g. a
+// benchmark's b.N loop); unlike CloneDSN it registers no t.Cleanup, so the
+// caller owns the drop and the DB must not linger after release.
+func TestCloneManaged_ReleaseDropsDB(t *testing.T) {
+	ctx := context.Background()
+	dsn, release := pgcloneSelfTest.CloneManaged(t)
+
+	if !tableExists(ctx, t, dsn, seedTable) {
+		release()
+		t.Fatalf("CloneManaged DSN did not inherit template seed table %q", seedTable)
+	}
+
+	release()
+
+	// After release the per-test DB is dropped; a fresh connect must fail.
+	conn, err := pgx.Connect(ctx, dsn)
+	if err == nil {
+		_ = conn.Close(ctx)
+		t.Fatal("CloneManaged release() must drop the per-test DB; connect to it unexpectedly succeeded")
 	}
 }

--- a/tests/testutil/pgclone/pgclone_test.go
+++ b/tests/testutil/pgclone/pgclone_test.go
@@ -197,6 +197,22 @@ func TestShared_zeroValueIsInvalid(t *testing.T) {
 	}
 }
 
+// TestShared_boot_RejectsNilMigrate pins the fail-fast for a nil MigrateFunc:
+// boot must surface it via initErr (after name validation, before RequireDocker
+// / container start) rather than panicking when it later calls s.migrate. The
+// template name is valid so validation passes and the nil check is reached.
+func TestShared_boot_RejectsNilMigrate(t *testing.T) {
+	t.Parallel()
+	s := New("valid_template_name", nil) // nil migrate
+	s.boot(t)
+	if s.initErr == nil {
+		t.Fatal("boot() must populate initErr when migrate func is nil (not panic later)")
+	}
+	if !strings.Contains(s.initErr.Error(), "migrate func must not be nil") {
+		t.Fatalf("initErr %q must mention nil migrate", s.initErr.Error())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Docker-bound self-tests. Use a pgx-only seed migration so pgclone's own
 // tests stay free of any adapters/postgres dependency (the full adapterpg
@@ -230,7 +246,8 @@ func tableExists(ctx context.Context, t *testing.T, dsn, table string) bool {
 	t.Helper()
 	conn, err := pgx.Connect(ctx, dsn)
 	if err != nil {
-		t.Fatalf("connect %s: %v", dsn, err)
+		// DSN omitted from the message — it carries the (test) PG password.
+		t.Fatalf("connect to per-test DB %q: %v", table, err)
 	}
 	defer func() { _ = conn.Close(ctx) }()
 	var exists bool

--- a/tests/testutil/pgshare/pgshare.go
+++ b/tests/testutil/pgshare/pgshare.go
@@ -1,355 +1,99 @@
 //go:build integration
 
 // Package pgshare provides a process-wide shared PostgreSQL container with
-// pre-migrated template-DB clone semantics for integration test packages.
+// pre-migrated template-DB clone semantics for integration test packages that
+// can import adapters/postgres.
 //
-// Each package that needs an isolated per-test PostgreSQL database creates
-// one *Shared instance (typically in TestMain) bound to a unique template
-// database name. The first NewPerTestPool call boots the container and
-// applies migrations once into the template; subsequent calls clone the
-// template via `CREATE DATABASE ... TEMPLATE <template>` — file-level
-// copy at ~50-200ms, dramatically cheaper than the ~7-10s container cold
-// start the historic per-test setup helpers paid.
+// pgshare is a thin adapterpg-typed wrapper over tests/testutil/pgclone:
+// pgclone owns the container + template + clone lifecycle (and is the single
+// sanctioned holder of tcpostgres.Run); pgshare supplies the adapters/postgres
+// migration callback and returns a typed *adapterpg.Pool. The public API
+// (New / NewPerTestPool / Shutdown) is unchanged from the pre-pgclone form, so
+// the cells packages that adopted pgshare need no edits.
 //
-// Package-test binaries run in independent processes, so the *Shared
-// instance is scoped to one Go test binary. Sharing across packages is
-// not possible (Go's test runner forbids cross-binary state) — the value
-// is intra-package: multiple setup helpers across multiple _test.go files
-// in the same package collapse onto one container + one migration.
-//
-// Mirrors the pattern in adapters/rabbitmq/testmain_integration_test.go
-// (lazy singleton + TestMain teardown), generalized for PG's TEMPLATE
-// clone capability.
+// Packages whose tests are white-box `package postgres` — i.e. adapters/postgres
+// itself — cannot import pgshare: it imports adapterpg, which would form an
+// import cycle. Those packages import pgclone directly with their own
+// in-package migration callback. See pgclone's package doc.
 package pgshare
 
 import (
 	"context"
-	"fmt"
-	"io/fs"
-	"log/slog"
-	"strings"
-	"sync"
 	"testing"
 
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
-
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
-	"github.com/ghbvf/gocell/tests/testutil"
+	"github.com/ghbvf/gocell/tests/testutil/pgclone"
 )
 
-// Shared owns the per-package container + template DB lifecycle. Create
-// one in a package-scope `var` and call Shutdown from TestMain.
+// Shared owns the per-package container + template DB lifecycle via an
+// embedded *pgclone.Shared. Create one in a package-scope var and call
+// Shutdown from TestMain.
 //
 // The zero value is invalid; callers must use New.
 type Shared struct {
-	templateDB string
-
-	once     sync.Once
-	initErr  error
-	adminDSN string
-	shutdown func()
+	inner *pgclone.Shared
 }
 
-// New returns a *Shared bound to the given template database name. The
-// name must satisfy PostgreSQL identifier rules:
-//   - non-empty
-//   - ≤ 63 characters (Postgres NAMEDATALEN limit)
-//   - starts with [a-z_] (no uppercase, no digit-prefix)
-//   - contains only lowercase ASCII letters, digits, and underscores
-//   - must not contain NUL bytes (\x00) or double-quote characters (")
+// New returns a *Shared bound to templateDB (Postgres identifier rules — see
+// pgclone.New). Use a unique name per Go test binary
+// (`gocell_<pkg>_test_template` is the convention).
 //
-// Validation runs at first NewPerTestPool call (lazy): an invalid name
-// produces a `t.Fatalf` rather than panicking at binary start. This keeps
-// pgshare panic-free (PANIC-REGISTERED-01 archtest forbids unwrapped
-// panic in non-test production code, and pgshare.go is build-tag-gated
-// but not a `_test.go` file).
-//
-// Use a unique name per Go test binary (`gocell_<pkg>_test_template` is
-// the convention) so a future caller that opens multiple Shared instances
-// in one process cannot accidentally collide.
-//
-// The instance is dormant until the first NewPerTestPool call.
+// The instance is dormant until the first NewPerTestPool call, which boots the
+// container and applies the adapters/postgres migration set to the template
+// once.
 func New(templateDB string) *Shared {
-	return &Shared{templateDB: templateDB}
+	return &Shared{inner: pgclone.New(templateDB, applyMigrations)}
 }
 
-// validateTemplateDB returns nil if the name is a legal Postgres identifier
-// under the rules documented on New. Called from boot() so violations
-// surface as a `t.Fatalf` at first NewPerTestPool — see New godoc for
-// why this is lazy and not enforced in the constructor.
-func validateTemplateDB(templateDB string) error {
-	switch {
-	case templateDB == "":
-		return fmt.Errorf("pgshare: templateDB must not be empty")
-	case len(templateDB) > 63:
-		return fmt.Errorf("pgshare: templateDB exceeds Postgres NAMEDATALEN limit of 63 chars, got %q", templateDB)
-	case strings.ContainsRune(templateDB, '\x00'):
-		return fmt.Errorf("pgshare: templateDB must not contain NUL bytes, got %q", templateDB)
-	case strings.ContainsRune(templateDB, '"'):
-		return fmt.Errorf("pgshare: templateDB must not contain double-quote characters, got %q", templateDB)
+// applyMigrations runs the production adapters/postgres migration set against
+// the template DSN. It closes the pool before returning per the
+// pgclone.MigrateFunc contract: CREATE DATABASE ... TEMPLATE rejects a source
+// DB with active connections, so the pool MUST be closed before the first
+// clone (the goose *sql.DB opened by NewMigrator is released transitively by
+// pool.Close — the historic applyMigrationsToTemplate behaviour this preserves).
+func applyMigrations(ctx context.Context, templateDSN string) error {
+	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: templateDSN})
+	if err != nil {
+		return err
 	}
-	for i, ch := range templateDB {
-		if i == 0 {
-			if (ch < 'a' || ch > 'z') && ch != '_' {
-				return fmt.Errorf("pgshare: templateDB must start with [a-z_], got %q", templateDB)
-			}
-			continue
-		}
-		if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '_' {
-			return fmt.Errorf(
-				"pgshare: templateDB must contain only lowercase ascii letters, digits, and underscores (no uppercase), got %q",
-				templateDB)
-		}
+	defer func() { _ = pool.Close(ctx) }()
+
+	migrationsFS, err := adapterpg.MigrationsFS()
+	if err != nil {
+		return err
 	}
-	return nil
+	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
+	if err != nil {
+		return err
+	}
+	return migrator.Up(ctx)
 }
 
-// NewPerTestPool clones the shared template database into a fresh
-// per-test database, opens a Pool against it, and registers cleanup via
-// t.Cleanup. The returned pool's lifetime is bound to the test; callers
-// must NOT call pool.Close manually.
+// NewPerTestPool clones the shared template database into a fresh per-test
+// database, opens a Pool against it, and registers cleanup via t.Cleanup. The
+// returned pool's lifetime is bound to the test; callers must NOT call
+// pool.Close manually.
 //
-// First call also boots the container and applies migrations (one-shot
-// for the test binary). Subsequent calls pay only the file-clone cost.
+// First call also boots the container and applies migrations (one-shot for the
+// test binary). Subsequent calls pay only the file-clone cost (~50-200ms).
 func (s *Shared) NewPerTestPool(t *testing.T) *adapterpg.Pool {
 	t.Helper()
-	// Per-call skip-or-fatal gate. RequireDocker either skips (local dev,
-	// Docker absent) or fatals (CI with GOCELL_TEST_DOCKER_REQUIRED=1).
-	// Called outside sync.Once so the gate fires for every caller even
-	// after init has run once — keeps test-binary semantics consistent
-	// when Docker disappears mid-suite.
-	testutil.RequireDocker(t)
-
-	// sync.Once cannot accept arguments; wrap to plumb t into boot so the
-	// archtest TestTestcontainerHelpersRequireDockerBeforeRun (function
-	// containing tcpostgres.Run must call RequireDocker first) is satisfied
-	// by boot itself, not solely by the outer NewPerTestPool. The wrapper
-	// closure captures the first caller's t — failure paths set s.initErr
-	// (no t.Fatal inside boot) so subsequent callers observe the same error
-	// via the read below.
-	s.once.Do(func() { s.boot(t) })
-	if s.initErr != nil {
-		t.Fatalf("shared postgres unavailable: %v", s.initErr)
-	}
-
-	ctx := context.Background()
-	dbName := "test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
-
-	if err := cloneTemplateDB(ctx, s.adminDSN, s.templateDB, dbName); err != nil {
-		t.Fatalf("clone template DB: %v", err)
-	}
-
-	perTestDSN := swapDatabaseInDSN(s.adminDSN, dbName)
-	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: perTestDSN})
+	dsn := s.inner.CloneDSN(t)
+	pool, err := adapterpg.NewPool(context.Background(), adapterpg.Config{DSN: dsn})
 	if err != nil {
-		t.Fatalf("open pool to per-test DB %s: %v", dbName, err)
+		t.Fatalf("open pool to per-test DB: %v", err)
 	}
-
 	t.Cleanup(func() {
-		if err := pool.Close(ctx); err != nil {
-			t.Logf("WARN: per-test pool close (%s): %v", dbName, err)
-		}
-		if err := dropDB(ctx, s.adminDSN, dbName); err != nil {
-			t.Logf("WARN: drop per-test DB %s: %v", dbName, err)
+		if err := pool.Close(context.Background()); err != nil {
+			t.Logf("WARN: per-test pool close: %v", err)
 		}
 	})
-
 	return pool
 }
 
-// Shutdown terminates the shared container if it was booted. Safe to call
-// even when the singleton was never initialized; mirrors
-// rabbitmq.testmain_integration_test.go pattern.
-// If init() failed (Docker unavailable, migration error, etc.), s.shutdown
-// remains nil and this method is a no-op — there is no container to terminate.
+// Shutdown terminates the shared container if it was booted. Safe to call even
+// when the singleton was never initialized (no-op). Call from TestMain after
+// m.Run.
 func (s *Shared) Shutdown() {
-	if s.shutdown != nil {
-		s.shutdown()
-	}
-}
-
-// boot validates the template name, starts the container, applies
-// migrations to the template DB, and stores the admin DSN. Runs exactly
-// once per *Shared (guarded by sync.Once in NewPerTestPool).
-//
-// boot takes *testing.T because the testcontainer archtest
-// TestTestcontainerHelpersRequireDockerBeforeRun requires the function
-// that calls tcpostgres.Run to also call testutil.RequireDocker first
-// (same-function check). The outer NewPerTestPool already calls
-// RequireDocker for the per-call skip gate; the second call here is
-// mildly redundant but satisfies the archtest and is defensive if
-// Docker disappears between the two checks.
-//
-// Errors set s.initErr; no t.Fatal is invoked inside boot so that the
-// sync.Once gate cannot leave the singleton in a half-initialized
-// state — the outer NewPerTestPool reads s.initErr and surfaces it.
-func (s *Shared) boot(t *testing.T) {
-	t.Helper()
-
-	if err := validateTemplateDB(s.templateDB); err != nil {
-		s.initErr = err
-		return
-	}
-	migrationsFS, err := adapterpg.MigrationsFS()
-	if err != nil {
-		s.initErr = fmt.Errorf("migrations fs: %w", err)
-		return
-	}
-
-	// RequireDocker inside the function with tcpostgres.Run — see boot
-	// godoc for the archtest rationale.
-	testutil.RequireDocker(t)
-
-	ctx := context.Background()
-	// password/user/db are container-internal credentials — the container
-	// lives only within this test binary's process and never accepts external
-	// traffic; reused literal across pgshare-using packages is intentional.
-	container, err := tcpostgres.Run(
-		ctx, testutil.PostgresImage,
-		tcpostgres.WithDatabase("test"),
-		tcpostgres.WithUsername("test"),
-		tcpostgres.WithPassword("test"),
-		tcpostgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		s.initErr = fmt.Errorf("start shared postgres: %w", err)
-		return
-	}
-	adminDSN, err := container.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		if termErr := container.Terminate(ctx); termErr != nil {
-			slog.Default().Error("pgshare: terminate after init failure also failed",
-				"templateDB", s.templateDB, "init_err", err, "terminate_err", termErr)
-		}
-		s.initErr = fmt.Errorf("admin DSN: %w", err)
-		return
-	}
-
-	if err := createTemplateDB(ctx, adminDSN, s.templateDB); err != nil {
-		if termErr := container.Terminate(ctx); termErr != nil {
-			slog.Default().Error("pgshare: terminate after init failure also failed",
-				"templateDB", s.templateDB, "init_err", err, "terminate_err", termErr)
-		}
-		s.initErr = fmt.Errorf("create template DB: %w", err)
-		return
-	}
-
-	templateDSN := swapDatabaseInDSN(adminDSN, s.templateDB)
-	if err := applyMigrationsToTemplate(ctx, templateDSN, migrationsFS); err != nil {
-		if termErr := container.Terminate(ctx); termErr != nil {
-			slog.Default().Error("pgshare: terminate after init failure also failed",
-				"templateDB", s.templateDB, "init_err", err, "terminate_err", termErr)
-		}
-		s.initErr = fmt.Errorf("apply migrations to template: %w", err)
-		return
-	}
-
-	s.adminDSN = adminDSN
-	s.shutdown = func() {
-		if err := container.Terminate(ctx); err != nil {
-			// TestMain runs outside any test context, so *testing.T is
-			// unavailable. Emit to slog so CI log scrapers pick up
-			// cleanup failures; Ryuk fallback handles the actual reap.
-			// Error level: container leak impacts ops; Ryuk fallback
-			// eventually reaps, but operators should see the failure
-			// during normal runs.
-			slog.Default().Error("pgshare: shared container terminate failed",
-				"templateDB", s.templateDB, "error", err)
-		}
-	}
-}
-
-// createTemplateDB opens a throwaway admin connection, issues CREATE
-// DATABASE, and closes the connection before return — Postgres rejects
-// CREATE DATABASE ... TEMPLATE <db> while <db> has any active connections,
-// so leaving the admin connection open here would block the migration
-// step that follows.
-func createTemplateDB(ctx context.Context, adminDSN, templateDB string) error {
-	conn, err := pgx.Connect(ctx, adminDSN)
-	if err != nil {
-		return fmt.Errorf("connect admin: %w", err)
-	}
-	defer func() { _ = conn.Close(ctx) }()
-	if _, err := conn.Exec(ctx, "CREATE DATABASE "+pgQuoteIdent(templateDB)); err != nil {
-		return fmt.Errorf("create database: %w", err)
-	}
-	return nil
-}
-
-// applyMigrationsToTemplate opens a dedicated pool to the template DB,
-// runs the full migration set, and closes the pool. The pool MUST be
-// closed before return: per the CREATE DATABASE TEMPLATE constraint
-// (see createTemplateDB), any lingering connection on the source DB
-// blocks subsequent clones.
-func applyMigrationsToTemplate(ctx context.Context, templateDSN string, migrationsFS fs.FS) error {
-	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: templateDSN})
-	if err != nil {
-		return fmt.Errorf("open pool: %w", err)
-	}
-	defer func() {
-		_ = pool.Close(ctx)
-	}()
-
-	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
-	if err != nil {
-		return fmt.Errorf("new migrator: %w", err)
-	}
-	if err := migrator.Up(ctx); err != nil {
-		return fmt.Errorf("migrate up: %w", err)
-	}
-	return nil
-}
-
-func cloneTemplateDB(ctx context.Context, adminDSN, templateDB, newDB string) error {
-	conn, err := pgx.Connect(ctx, adminDSN)
-	if err != nil {
-		return fmt.Errorf("connect admin: %w", err)
-	}
-	defer func() { _ = conn.Close(ctx) }()
-	q := fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s",
-		pgQuoteIdent(newDB), pgQuoteIdent(templateDB))
-	if _, err := conn.Exec(ctx, q); err != nil {
-		return fmt.Errorf("clone: %w", err)
-	}
-	return nil
-}
-
-// dropDB removes a per-test database via WITH (FORCE) to terminate any
-// straggling connections (the per-test pool should already be Closed at
-// this point; FORCE is a belt-and-suspenders safeguard against test
-// cleanup ordering bugs).
-func dropDB(ctx context.Context, adminDSN, dbName string) error {
-	conn, err := pgx.Connect(ctx, adminDSN)
-	if err != nil {
-		return fmt.Errorf("connect admin: %w", err)
-	}
-	defer func() { _ = conn.Close(ctx) }()
-	q := "DROP DATABASE IF EXISTS " + pgQuoteIdent(dbName) + " WITH (FORCE)"
-	if _, err := conn.Exec(ctx, q); err != nil {
-		return fmt.Errorf("drop: %w", err)
-	}
-	return nil
-}
-
-// swapDatabaseInDSN rewrites the database segment of a postgres DSN.
-// testcontainers-go modules/postgres always emits the canonical form
-// `scheme://user:pass@host:port/<db>?<query>` so a last-`/` + first-`?`
-// split is sufficient.
-func swapDatabaseInDSN(dsn, newDB string) string {
-	idx := strings.LastIndex(dsn, "/")
-	if idx < 0 {
-		return dsn
-	}
-	before := dsn[:idx+1]
-	rest := dsn[idx+1:]
-	if q := strings.IndexByte(rest, '?'); q >= 0 {
-		return before + newDB + rest[q:]
-	}
-	return before + newDB
-}
-
-func pgQuoteIdent(name string) string {
-	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+	s.inner.Shutdown()
 }

--- a/tests/testutil/pgshare/pgshare.go
+++ b/tests/testutil/pgshare/pgshare.go
@@ -55,7 +55,7 @@ func New(templateDB string) *Shared {
 func applyMigrations(ctx context.Context, templateDSN string) (err error) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: templateDSN})
 	if err != nil {
-		return err
+		return fmt.Errorf("open template pool: %w", err)
 	}
 	defer func() {
 		// A close error matters here: a lingering connection on the template
@@ -69,13 +69,16 @@ func applyMigrations(ctx context.Context, templateDSN string) (err error) {
 
 	migrationsFS, err := adapterpg.MigrationsFS()
 	if err != nil {
-		return err
+		return fmt.Errorf("load migrations fs: %w", err)
 	}
 	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
 	if err != nil {
-		return err
+		return fmt.Errorf("new migrator: %w", err)
 	}
-	return migrator.Up(ctx)
+	if err := migrator.Up(ctx); err != nil {
+		return fmt.Errorf("migrate up: %w", err)
+	}
+	return nil
 }
 
 // NewPerTestPool clones the shared template database into a fresh per-test

--- a/tests/testutil/pgshare/pgshare.go
+++ b/tests/testutil/pgshare/pgshare.go
@@ -19,6 +19,7 @@ package pgshare
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
@@ -51,12 +52,20 @@ func New(templateDB string) *Shared {
 // DB with active connections, so the pool MUST be closed before the first
 // clone (the goose *sql.DB opened by NewMigrator is released transitively by
 // pool.Close — the historic applyMigrationsToTemplate behaviour this preserves).
-func applyMigrations(ctx context.Context, templateDSN string) error {
+func applyMigrations(ctx context.Context, templateDSN string) (err error) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: templateDSN})
 	if err != nil {
 		return err
 	}
-	defer func() { _ = pool.Close(ctx) }()
+	defer func() {
+		// A close error matters here: a lingering connection on the template
+		// blocks the first CREATE DATABASE ... TEMPLATE clone. Surface it (when
+		// migration itself succeeded) so boot fails fast with a clear cause
+		// instead of the first CloneDSN failing opaquely with "source DB in use".
+		if cerr := pool.Close(ctx); cerr != nil && err == nil {
+			err = fmt.Errorf("close migration pool: %w", cerr)
+		}
+	}()
 
 	migrationsFS, err := adapterpg.MigrationsFS()
 	if err != nil {

--- a/tests/testutil/pgshare/pgshare_test.go
+++ b/tests/testutil/pgshare/pgshare_test.go
@@ -11,251 +11,47 @@ import (
 	"github.com/google/uuid"
 )
 
-// TestValidateTemplateDB exhaustively exercises each rejection branch of
-// validateTemplateDB plus the happy path. Validation is the only pgshare
-// surface that's reachable without Docker — every other function path
-// either connects to PG or calls testcontainers, and is covered by the
-// adopting packages' integration tests (configcore/accesscore PG repos,
-// configwrite/configpublish slices).
-func TestValidateTemplateDB(t *testing.T) {
-	cases := []struct {
-		name      string
-		input     string
-		wantErr   bool
-		wantMatch string // substring of the error message
-	}{
-		{name: "valid_lowercase", input: "gocell_test_template", wantErr: false},
-		{name: "valid_underscore_prefix", input: "_template", wantErr: false},
-		{name: "valid_with_digits", input: "test_2025", wantErr: false},
-		{name: "valid_single_letter", input: "x", wantErr: false},
-		{name: "valid_max_length", input: strings.Repeat("a", 63), wantErr: false},
-
-		{name: "empty", input: "", wantErr: true, wantMatch: "must not be empty"},
-		{name: "too_long", input: strings.Repeat("a", 64), wantErr: true, wantMatch: "NAMEDATALEN"},
-		{name: "contains_null_byte", input: "test\x00drop", wantErr: true, wantMatch: "NUL bytes"},
-		{name: "contains_double_quote", input: `test"db`, wantErr: true, wantMatch: "double-quote"},
-		{name: "digit_prefix", input: "1test", wantErr: true, wantMatch: "must start with [a-z_]"},
-		{name: "uppercase_prefix", input: "Test", wantErr: true, wantMatch: "must start with [a-z_]"},
-		{name: "uppercase_middle", input: "testDB", wantErr: true, wantMatch: "only lowercase ascii"},
-		{name: "hyphen_invalid", input: "test-db", wantErr: true, wantMatch: "only lowercase ascii"},
-		{name: "dot_invalid", input: "test.db", wantErr: true, wantMatch: "only lowercase ascii"},
-		{name: "space_invalid", input: "test db", wantErr: true, wantMatch: "only lowercase ascii"},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			err := validateTemplateDB(tc.input)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("validateTemplateDB(%q): want error, got nil", tc.input)
-				}
-				if !strings.Contains(err.Error(), tc.wantMatch) {
-					t.Fatalf("validateTemplateDB(%q): error %q must contain %q",
-						tc.input, err.Error(), tc.wantMatch)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("validateTemplateDB(%q): want nil, got %v", tc.input, err)
-			}
-		})
-	}
-}
-
-// TestSwapDatabaseInDSN covers every branch of the DSN rewrite helper:
-// canonical testcontainers form (with query), no-query form, malformed
-// input without `/`, and edge cases around path/query boundaries.
-func TestSwapDatabaseInDSN(t *testing.T) {
-	cases := []struct {
-		name  string
-		dsn   string
-		newDB string
-		want  string
-	}{
-		{
-			name:  "canonical_with_query",
-			dsn:   "postgres://test:test@localhost:5432/test?sslmode=disable",
-			newDB: "fresh",
-			want:  "postgres://test:test@localhost:5432/fresh?sslmode=disable",
-		},
-		{
-			name:  "no_query",
-			dsn:   "postgres://u:p@h:5432/admin",
-			newDB: "newdb",
-			want:  "postgres://u:p@h:5432/newdb",
-		},
-		{
-			name:  "complex_query_preserved",
-			dsn:   "postgres://u:p@h/old?sslmode=disable&pool_max_conns=10",
-			newDB: "isolated_42",
-			want:  "postgres://u:p@h/isolated_42?sslmode=disable&pool_max_conns=10",
-		},
-		{
-			name:  "no_slash_returns_input",
-			dsn:   "not-a-dsn",
-			newDB: "ignored",
-			want:  "not-a-dsn",
-		},
-		{
-			name:  "trailing_slash_only",
-			dsn:   "postgres://h/",
-			newDB: "x",
-			want:  "postgres://h/x",
-		},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got := swapDatabaseInDSN(tc.dsn, tc.newDB)
-			if got != tc.want {
-				t.Fatalf("swapDatabaseInDSN(%q, %q) = %q, want %q",
-					tc.dsn, tc.newDB, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestPgQuoteIdent verifies identifier double-quoting: plain identifiers
-// are wrapped in `"`, and embedded `"` characters are escaped by doubling.
-// This is the SQL-injection defense for caller-supplied templateDB names
-// (the canonical pgQuoteIdent contract per PostgreSQL docs).
-func TestPgQuoteIdent(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{name: "plain", in: "mydb", want: `"mydb"`},
-		{name: "empty", in: "", want: `""`},
-		{name: "contains_double_quote", in: `bad"name`, want: `"bad""name"`},
-		{name: "multiple_quotes", in: `"a"b"`, want: `"""a""b"""`},
-		{name: "uppercase_preserved", in: "MyDB", want: `"MyDB"`},
-		{name: "whitespace_preserved", in: "my db", want: `"my db"`},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got := pgQuoteIdent(tc.in)
-			if got != tc.want {
-				t.Fatalf("pgQuoteIdent(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestNew_StoresTemplateDBVerbatim asserts that New is a thin
-// constructor — it must NOT validate or transform templateDB (validation
-// is lazy, runs at first init() — see New godoc for the rationale).
-// Storing a name that would later fail validation must succeed here;
-// the error only surfaces from NewPerTestPool via t.Fatalf.
-func TestNew_StoresTemplateDBVerbatim(t *testing.T) {
+// TestNew_ReturnsNonNil asserts New is a thin constructor returning a usable
+// *Shared. Name validation is lazy (delegated to pgclone at first
+// NewPerTestPool), so even a syntactically bad name constructs without error.
+func TestNew_ReturnsNonNil(t *testing.T) {
 	t.Parallel()
-	// A name that validateTemplateDB rejects; New must still return a
-	// non-nil *Shared with the bad name stored verbatim.
-	bad := "1invalid-name"
-	s := New(bad)
-	if s == nil {
-		t.Fatal("New returned nil for syntactically bad templateDB; expected non-nil with lazy validation")
-	}
-	if s.templateDB != bad {
-		t.Fatalf("templateDB stored as %q, want verbatim %q", s.templateDB, bad)
+	s := New("1invalid-name")
+	if s == nil || s.inner == nil {
+		t.Fatal("New must return a non-nil *Shared with non-nil inner")
 	}
 }
 
-// TestShared_Shutdown_NoOpWhenUninitialized asserts the no-op promise
-// documented on Shutdown: calling Shutdown before any NewPerTestPool
-// (i.e. when init never ran, so s.shutdown is nil) must not panic and
-// must not touch the shared singleton.
+// TestShared_Shutdown_NoOpWhenUninitialized asserts Shutdown before any
+// NewPerTestPool call does not panic (delegates to pgclone, whose shutdown
+// closure is nil until boot).
 func TestShared_Shutdown_NoOpWhenUninitialized(t *testing.T) {
 	t.Parallel()
 	s := New("never_initialized")
-	// Must not panic.
 	s.Shutdown()
-	// init still hasn't run.
-	if s.shutdown != nil {
-		t.Fatalf("Shutdown on uninitialized *Shared must not populate shutdown closure; got non-nil")
-	}
-	if s.initErr != nil {
-		t.Fatalf("Shutdown must not trigger init; got initErr = %v", s.initErr)
-	}
 }
 
-// TestShared_boot_RejectsInvalidTemplateDB asserts that boot() catches
-// invalid template names at the validation gate and surfaces them via
-// s.initErr — the lazy validation path that replaced the constructor
-// panic (PANIC-REGISTERED-01 fix). Validation runs at the top of boot,
-// before RequireDocker, so this test does NOT require Docker.
-func TestShared_boot_RejectsInvalidTemplateDB(t *testing.T) {
-	t.Parallel()
-	s := New("Bad_Name") // uppercase → rejected by validateTemplateDB
-	s.boot(t)
-	if s.initErr == nil {
-		t.Fatal("boot() must populate initErr for invalid templateDB")
-	}
-	if !strings.Contains(s.initErr.Error(), "must start with") {
-		t.Fatalf("initErr %q must reference the validation rule", s.initErr.Error())
-	}
-	// Subsequent boots via sync.Once would also short-circuit — verify
-	// the once gate is consistent with the manual call above.
-	s2 := New("Bad_Name")
-	s2.once.Do(func() { s2.boot(t) })
-	if s2.initErr == nil {
-		t.Fatal("boot() through sync.Once must populate initErr")
-	}
-}
-
-// TestShared_zeroValueIsInvalid pins the godoc-stated contract that the
-// zero value is not usable. Calling boot() with an empty templateDB
-// (the zero-value field) must produce a validation error at the top of
-// boot, before RequireDocker is reached.
-func TestShared_zeroValueIsInvalid(t *testing.T) {
-	t.Parallel()
-	var s Shared // zero value
-	s.boot(t)
-	if s.initErr == nil {
-		t.Fatal("zero-value *Shared must yield validation error on boot()")
-	}
-	if !strings.Contains(s.initErr.Error(), "must not be empty") {
-		t.Fatalf("zero-value initErr %q must mention empty-name rule", s.initErr.Error())
-	}
-}
-
-// Package-level shared instance used by the Docker-bound integration
-// tests below. A single container serves the whole pgshare self-test
-// suite — the same pattern the package exposes to its callers.
+// Package-level shared instance used by the Docker-bound integration tests
+// below — the same pattern pgshare exposes to its callers.
 var pgshareSelfTest = New("gocell_pgshare_selftest_template")
 
-// TestMain owns shared-container teardown for the Docker-bound tests
-// below. Runs once per test binary after all tests complete.
+// TestMain owns shared-container teardown for the Docker-bound tests below.
 func TestMain(m *testing.M) {
 	code := m.Run()
 	pgshareSelfTest.Shutdown()
 	os.Exit(code)
 }
 
-// TestNewPerTestPool_IsolatesPerTestDatabases is the headline integration
-// test: it boots the shared container (first call), clones two per-test
-// databases from the template, and asserts the two databases are fully
-// isolated — a write into one is invisible from the other. This exercises
-// the full Docker path: tcpostgres.Run → createTemplateDB →
-// applyMigrationsToTemplate → cloneTemplateDB → adapterpg.NewPool.
-//
-// The two subtests share one container via the package-level
-// pgshareSelfTest singleton; cleanup of each per-test DB is owned by
-// t.Cleanup inside NewPerTestPool, not by these test bodies.
+// TestNewPerTestPool_IsolatesPerTestDatabases boots the shared container (first
+// call), clones two per-test databases, and asserts they are fully isolated —
+// a write into one is invisible from the other. Exercises the full Docker path
+// including the real adapters/postgres migration callback.
 func TestNewPerTestPool_IsolatesPerTestDatabases(t *testing.T) {
 	poolA := pgshareSelfTest.NewPerTestPool(t)
 	poolB := pgshareSelfTest.NewPerTestPool(t)
 
 	ctx := context.Background()
 
-	// Both pools must be alive and pointing at distinct databases.
-	// Use a transient throwaway table since the template migration set
-	// is the production adapters/postgres schema — we don't want to
-	// depend on schema details here, just on per-DB isolation.
 	tableA := "pgshare_iso_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	if _, err := poolA.DB().Exec(ctx, "CREATE TABLE "+tableA+" (x int)"); err != nil {
 		t.Fatalf("create table in pool A: %v", err)
@@ -264,7 +60,6 @@ func TestNewPerTestPool_IsolatesPerTestDatabases(t *testing.T) {
 		t.Fatalf("insert into pool A: %v", err)
 	}
 
-	// Pool B must NOT see the table — different database.
 	var exists bool
 	row := poolB.DB().QueryRow(ctx,
 		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1)",
@@ -276,7 +71,6 @@ func TestNewPerTestPool_IsolatesPerTestDatabases(t *testing.T) {
 		t.Fatalf("isolation broken: table %s created in pool A is visible from pool B", tableA)
 	}
 
-	// Pool A still sees the row — its own DB persisted across the probe.
 	var count int
 	if err := poolA.DB().QueryRow(ctx, "SELECT COUNT(*) FROM "+tableA).Scan(&count); err != nil {
 		t.Fatalf("recount on pool A: %v", err)
@@ -286,17 +80,14 @@ func TestNewPerTestPool_IsolatesPerTestDatabases(t *testing.T) {
 	}
 }
 
-// TestNewPerTestPool_TemplateSchemaApplied verifies that the migrations
-// embedded in adapters/postgres are applied to the template DB and
-// inherited by every clone — a clone should already have the
-// schema_migrations row set and the production tables present. If the
-// template-init path silently skipped migrations, this would fail.
+// TestNewPerTestPool_TemplateSchemaApplied verifies the adapters/postgres
+// migrations are applied to the template DB and inherited by every clone. This
+// is the adapterpg-specific path that pgclone's own (pgx-only seed) self-tests
+// do not cover.
 func TestNewPerTestPool_TemplateSchemaApplied(t *testing.T) {
 	pool := pgshareSelfTest.NewPerTestPool(t)
 	ctx := context.Background()
 
-	// schema_migrations is the goose/migrator bookkeeping table populated
-	// by applyMigrationsToTemplate. Any cloned DB inherits it.
 	var migrationCount int
 	row := pool.DB().QueryRow(ctx, "SELECT COUNT(*) FROM schema_migrations")
 	if err := row.Scan(&migrationCount); err != nil {
@@ -304,26 +95,5 @@ func TestNewPerTestPool_TemplateSchemaApplied(t *testing.T) {
 	}
 	if migrationCount == 0 {
 		t.Fatal("schema_migrations is empty in cloned DB; template did not receive migrations")
-	}
-}
-
-// TestSharedSingleton_ContainerStartsOnce verifies that two
-// NewPerTestPool calls share the same container — observable via
-// adminDSN being non-empty after first call and stable across subsequent
-// calls. (Direct container-id check would couple to testcontainers
-// internals; adminDSN is the public observable that proves singleton
-// reuse.)
-func TestSharedSingleton_ContainerStartsOnce(t *testing.T) {
-	_ = pgshareSelfTest.NewPerTestPool(t)
-	dsn1 := pgshareSelfTest.adminDSN
-	if dsn1 == "" {
-		t.Fatal("adminDSN empty after first NewPerTestPool; init did not populate")
-	}
-
-	_ = pgshareSelfTest.NewPerTestPool(t)
-	dsn2 := pgshareSelfTest.adminDSN
-	if dsn1 != dsn2 {
-		t.Fatalf("adminDSN changed across calls; container was re-spawned (dsn1=%q dsn2=%q)",
-			dsn1, dsn2)
 	}
 }

--- a/tools/archtest/internal/pgcontainerredfixture/fixture.go
+++ b/tools/archtest/internal/pgcontainerredfixture/fixture.go
@@ -1,0 +1,21 @@
+//go:build archtest_fixture
+
+// Package pgcontainerredfixture is the RED fixture for PG-TESTCONTAINER-FUNNEL-01.
+// It deliberately starts a per-test container via tcpostgres.Run OUTSIDE the
+// pgclone funnel so the funnel detector has a known-positive to fire on.
+//
+// Built only under the archtest_fixture tag. The funnel scan reaches it via
+// parser.ParseFile (which ignores build constraints); the production scan
+// skips tools/archtest/internal/ so this fixture is never itself reported.
+package pgcontainerredfixture
+
+import (
+	"context"
+
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+// Boot is the forbidden shape: a direct tcpostgres.Run outside pgclone.
+func Boot(ctx context.Context) (*tcpostgres.PostgresContainer, error) {
+	return tcpostgres.Run(ctx, "postgres:15-alpine")
+}

--- a/tools/archtest/internal/pgcontainerredfixture/indirect_ref.go
+++ b/tools/archtest/internal/pgcontainerredfixture/indirect_ref.go
@@ -1,0 +1,14 @@
+//go:build archtest_fixture
+
+package pgcontainerredfixture
+
+import (
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+// indirectRun is the forbidden function-value form of the funnel violation:
+// assigning tcpostgres.Run to a variable evades a CallExpr-only scan (the call
+// happens later through `indirectRun`, whose Fun is a bare *ast.Ident).
+// PG-TESTCONTAINER-FUNNEL-01's SelectorExpr scan must still catch the
+// tcpostgres.Run reference on the assignment RHS here.
+var indirectRun = tcpostgres.Run

--- a/tools/archtest/pg_testcontainer_funnel_test.go
+++ b/tools/archtest/pg_testcontainer_funnel_test.go
@@ -38,10 +38,12 @@
 //     globally banned by revive dot-imports).
 //   - Reflection-based construction: out of scope, treated as theoretical.
 //
-// Carve-outs (allowlisted, backlog: migrate to pgclone): cmd/corebundle,
+// Carve-outs (allowlisted, backlog #890: migrate to pgclone): cmd/corebundle,
 // tests/integration, examples/iotdevice, cells/accesscore/slices/identitymanage —
 // each has a distinct container need (full-app e2e harness / independent
 // migration set / full-chain). They are NOT the adapters/postgres bottleneck.
+// Per ai-collab.md §Funnel 双向锁评级, this Medium-upstream transition form is
+// tracked for closure by backlog #890.
 package archtest
 
 import (
@@ -66,7 +68,7 @@ const pgTestcontainerModulePath = "github.com/testcontainers/testcontainers-go/m
 // the sanctioned funnel; the rest are backlogged carve-outs.
 var pgTestcontainerFunnelAllowlist = []string{
 	"tests/testutil/pgclone/", // the sanctioned holder
-	// Backlog: migrate these to pgclone. Each has a distinct container need:
+	// Backlog #890: migrate these to pgclone. Each has a distinct container need:
 	"cmd/corebundle/",                         // full-app e2e + outbox wiring harness
 	"tests/integration/",                      // full-chain L2 atomicity / outbox harness
 	"examples/iotdevice/",                     // example with its own PG migration set

--- a/tools/archtest/pg_testcontainer_funnel_test.go
+++ b/tools/archtest/pg_testcontainer_funnel_test.go
@@ -31,11 +31,15 @@
 // tier this rule shape reaches for integration-tagged code.
 //
 // Blind-spot inventory (per ai-collab.md §"工具选定后强制盲区自检"):
+//   - Function-value reference `run := tcpostgres.Run; run(...)`: COVERED — the
+//     scan walks every <alias>.Run *ast.SelectorExpr (assignment RHS, arg pass,
+//     or CallExpr.Fun alike), not just call targets. RED fixture
+//     internal/pgcontainerredfixture/indirect_ref.go pins this form.
 //   - Dot-import `import . ".../modules/postgres"; Run(...)`: `Run` would be a
-//     bare *ast.Ident, not a SelectorExpr, so isPostgresModuleRun misses it.
-//     Closed by the reverse self-test TestPG_TESTCONTAINER_FUNNEL_01_NoDotImportBlindSpot
-//     which asserts no dot-import of the module exists in the repo (it is also
-//     globally banned by revive dot-imports).
+//     bare *ast.Ident, not a SelectorExpr, so the scan misses it. Closed by the
+//     reverse self-test TestPG_TESTCONTAINER_FUNNEL_01_NoDotImportBlindSpot which
+//     asserts no dot-import of the module exists in the repo (also globally
+//     banned by revive dot-imports).
 //   - Reflection-based construction: out of scope, treated as theoretical.
 //
 // Carve-outs (allowlisted, backlog #890: migrate to pgclone): cmd/corebundle,
@@ -139,12 +143,15 @@ func firstPostgresRunLine(path string) (int, bool, error) {
 		return 0, false, nil
 	}
 	var pos token.Pos
-	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+	// Scan every <alias>.Run SelectorExpr, not just CallExpr.Fun — this also
+	// catches indirect references like `run := tcpostgres.Run` (function-value
+	// assignment) and `pass(tcpostgres.Run)`, which a CallExpr-only scan misses.
+	scanner.EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
 		if pos.IsValid() {
 			return
 		}
-		if isPostgresModuleRun(call.Fun, alias) {
-			pos = call.Pos()
+		if isPostgresModuleRun(sel, alias) {
+			pos = sel.Pos()
 		}
 	})
 	if pos.IsValid() {
@@ -197,6 +204,24 @@ func TestPG_TESTCONTAINER_FUNNEL_01_RedFixture(t *testing.T) {
 		return
 	}
 	t.Logf("RED fixture hit at fixture.go:%d", line)
+}
+
+// TestPG_TESTCONTAINER_FUNNEL_01_RedFixture_IndirectRef pins the F3 fix: the
+// SelectorExpr scan must catch the function-value form `var indirectRun =
+// tcpostgres.Run` in internal/pgcontainerredfixture/indirect_ref.go. A
+// CallExpr-only scan (the original bug) would miss it.
+func TestPG_TESTCONTAINER_FUNNEL_01_RedFixture_IndirectRef(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	fixturePath := filepath.Join(root, "tools", "archtest", "internal", "pgcontainerredfixture", "indirect_ref.go")
+	line, ok, err := firstPostgresRunLine(fixturePath)
+	require.NoError(t, err, "parse indirect-ref RED fixture")
+	if !ok {
+		t.Error("PG-TESTCONTAINER-FUNNEL-01 indirect-ref RED fixture: scan found no tcpostgres.Run " +
+			"function-value reference; the SelectorExpr scan may have regressed to CallExpr-only")
+		return
+	}
+	t.Logf("indirect-ref RED fixture hit at indirect_ref.go:%d", line)
 }
 
 // TestPG_TESTCONTAINER_FUNNEL_01_NoDotImportBlindSpot closes the dot-import

--- a/tools/archtest/pg_testcontainer_funnel_test.go
+++ b/tools/archtest/pg_testcontainer_funnel_test.go
@@ -84,9 +84,9 @@ var pgTestcontainerFunnelAllowlist = []string{
 const archtestInternalPrefix = "tools/archtest/internal/"
 
 // TestPG_TESTCONTAINER_FUNNEL_01 fails if any file outside the allowlist calls
-// tcpostgres.Run. Until adapters/postgres migrates to pgclone this is RED
-// (its setupPostgres + setupPostgresForBench helpers still call it) — the
-// intended pin for the refactor.
+// tcpostgres.Run. adapters/postgres now mints per-test DBs via pgclone, so the
+// sole sanctioned holder is tests/testutil/pgclone; this scan keeps it that way
+// (the backlogged carve-outs are the only other allowed callers).
 func TestPG_TESTCONTAINER_FUNNEL_01(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)

--- a/tools/archtest/pg_testcontainer_funnel_test.go
+++ b/tools/archtest/pg_testcontainer_funnel_test.go
@@ -1,0 +1,241 @@
+// INVARIANT: PG-TESTCONTAINER-FUNNEL-01
+//
+// # PG-TESTCONTAINER-FUNNEL-01
+//
+// tests/testutil/pgclone is the single sanctioned holder of
+// `tcpostgres.Run` (testcontainers postgres module). Every PG integration
+// test must obtain a per-test database via pgclone (directly, or via the
+// pgshare wrapper for packages that can import adapters/postgres) — never by
+// starting its own per-test container. This is the recurrence guard for the
+// adapters/postgres test-perf refactor: ~93 per-test container spin-ups
+// (~237s) collapsed onto one shared container + template clones.
+//
+// # Why a pure-AST scan (not typed, not depguard)
+//
+// Every tcpostgres.Run call and every testcontainers import lives in a
+// `//go:build integration` file. Neither golangci-lint (depguard) nor the
+// archtest typed façade (RunTypedProduction) loads integration-tagged files
+// by default — both would need a global `integration` build tag, which would
+// drag every other linter across all integration files (funlen / gocognit /
+// dupl / gosec) for no benefit. So this guard parses files with
+// parser.ParseFile (which ignores build constraints) and matches the call by
+// import-path + alias + selector — the same mechanism as the sibling
+// TestTestcontainerHelpersRequireDockerBeforeRun in integration_guard_test.go.
+//
+// AI-rebust grade: Medium. The callsite identity (import path
+// "...modules/postgres" + alias-resolved `.Run` selector + file allowlist) is
+// stronger than a string anchor but is archtest-bound, not compile-time. Hard
+// is structurally unreachable for "ban a third-party symbol outside an
+// allowlist" — Go has no import-visibility modifier, so the compiler cannot
+// forbid importing a public package; pure-AST file-allowlist is the highest
+// tier this rule shape reaches for integration-tagged code.
+//
+// Blind-spot inventory (per ai-collab.md §"工具选定后强制盲区自检"):
+//   - Dot-import `import . ".../modules/postgres"; Run(...)`: `Run` would be a
+//     bare *ast.Ident, not a SelectorExpr, so isPostgresModuleRun misses it.
+//     Closed by the reverse self-test TestPG_TESTCONTAINER_FUNNEL_01_NoDotImportBlindSpot
+//     which asserts no dot-import of the module exists in the repo (it is also
+//     globally banned by revive dot-imports).
+//   - Reflection-based construction: out of scope, treated as theoretical.
+//
+// Carve-outs (allowlisted, backlog: migrate to pgclone): cmd/corebundle,
+// tests/integration, examples/iotdevice, cells/accesscore/slices/identitymanage —
+// each has a distinct container need (full-app e2e harness / independent
+// migration set / full-chain). They are NOT the adapters/postgres bottleneck.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+const pgTestcontainerModulePath = "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+// pgTestcontainerFunnelAllowlist holds module-relative path prefixes (slash
+// form) permitted to call tcpostgres.Run directly. tests/testutil/pgclone is
+// the sanctioned funnel; the rest are backlogged carve-outs.
+var pgTestcontainerFunnelAllowlist = []string{
+	"tests/testutil/pgclone/", // the sanctioned holder
+	// Backlog: migrate these to pgclone. Each has a distinct container need:
+	"cmd/corebundle/",                         // full-app e2e + outbox wiring harness
+	"tests/integration/",                      // full-chain L2 atomicity / outbox harness
+	"examples/iotdevice/",                     // example with its own PG migration set
+	"cells/accesscore/slices/identitymanage/", // single-service PG adapter test
+}
+
+// archtestInternalPrefix is archtest's own fixture area (including this rule's
+// RED fixture). Not a governed target — skipped by the production scan.
+const archtestInternalPrefix = "tools/archtest/internal/"
+
+// TestPG_TESTCONTAINER_FUNNEL_01 fails if any file outside the allowlist calls
+// tcpostgres.Run. Until adapters/postgres migrates to pgclone this is RED
+// (its setupPostgres + setupPostgresForBench helpers still call it) — the
+// intended pin for the refactor.
+func TestPG_TESTCONTAINER_FUNNEL_01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	findings := collectPGTestcontainerRunFindings(t, root)
+	assert.Empty(t, findings,
+		"tcpostgres.Run must appear only in tests/testutil/pgclone (or the backlogged carve-outs); "+
+			"use pgclone.CloneDSN/EmptyDSN (or pgshare.NewPerTestPool) instead of starting a per-test container")
+}
+
+func collectPGTestcontainerRunFindings(t *testing.T, root string) []string {
+	t.Helper()
+	files, err := scanner.ModuleScope(root, scanner.IncludeTests()).Files()
+	require.NoError(t, err)
+
+	var findings []string
+	for _, path := range files {
+		rel := relSlash(root, path)
+		if strings.HasPrefix(rel, archtestInternalPrefix) {
+			continue // archtest fixtures are not governed targets
+		}
+		if pgFunnelAllowed(rel) {
+			continue
+		}
+		line, ok, perr := firstPostgresRunLine(path)
+		require.NoError(t, perr)
+		if ok {
+			findings = append(findings, fmt.Sprintf(
+				"%s:%d: forbidden tcpostgres.Run outside tests/testutil/pgclone", rel, line))
+		}
+	}
+	return findings
+}
+
+func pgFunnelAllowed(rel string) bool {
+	for _, prefix := range pgTestcontainerFunnelAllowlist {
+		if strings.HasPrefix(rel, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// firstPostgresRunLine parses path and returns the line of the first
+// `<alias>.Run` call where <alias> is the postgres testcontainers module's
+// import name (handles named/aliased imports via importSelectorName).
+func firstPostgresRunLine(path string) (int, bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return 0, false, err
+	}
+	alias, ok := postgresModuleAlias(file)
+	if !ok {
+		return 0, false, nil
+	}
+	var pos token.Pos
+	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if pos.IsValid() {
+			return
+		}
+		if isPostgresModuleRun(call.Fun, alias) {
+			pos = call.Pos()
+		}
+	})
+	if pos.IsValid() {
+		return fset.Position(pos).Line, true, nil
+	}
+	return 0, false, nil
+}
+
+// postgresModuleAlias returns the local import name bound to the testcontainers
+// postgres module in file, or ("", false) if the module is not imported. A
+// dot-import (name ".") returns ("", false) — that blind spot is closed by the
+// dedicated reverse self-test below.
+func postgresModuleAlias(file *ast.File) (string, bool) {
+	for _, imp := range file.Imports {
+		if archStringLiteralValue(imp.Path) != pgTestcontainerModulePath {
+			continue
+		}
+		if name := importSelectorName(imp, "postgres"); name != "" {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func isPostgresModuleRun(expr ast.Expr, alias string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return id.Name == alias && sel.Sel.Name == "Run"
+}
+
+// TestPG_TESTCONTAINER_FUNNEL_01_RedFixture asserts the detector fires on a
+// known-positive: tools/archtest/internal/pgcontainerredfixture/fixture.go
+// deliberately calls tcpostgres.Run. Without this, a broken detector would
+// silently pass the production scan.
+func TestPG_TESTCONTAINER_FUNNEL_01_RedFixture(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	fixturePath := filepath.Join(root, "tools", "archtest", "internal", "pgcontainerredfixture", "fixture.go")
+	line, ok, err := firstPostgresRunLine(fixturePath)
+	require.NoError(t, err, "parse RED fixture")
+	if !ok {
+		t.Error("PG-TESTCONTAINER-FUNNEL-01 RED fixture: detector found no tcpostgres.Run in fixture.go; " +
+			"firstPostgresRunLine / isPostgresModuleRun may be broken")
+		return
+	}
+	t.Logf("RED fixture hit at fixture.go:%d", line)
+}
+
+// TestPG_TESTCONTAINER_FUNNEL_01_NoDotImportBlindSpot closes the dot-import
+// blind spot: `import . ".../modules/postgres"` would make Run a bare ident
+// that isPostgresModuleRun (SelectorExpr-only) misses. Asserts no file
+// dot-imports the module (also globally banned by revive dot-imports).
+func TestPG_TESTCONTAINER_FUNNEL_01_NoDotImportBlindSpot(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	files, err := scanner.ModuleScope(root, scanner.IncludeTests()).Files()
+	require.NoError(t, err)
+
+	var findings []string
+	for _, path := range files {
+		rel := relSlash(root, path)
+		if strings.HasPrefix(rel, archtestInternalPrefix) {
+			continue
+		}
+		dot, perr := fileDotImportsPostgresModule(path)
+		require.NoError(t, perr)
+		if dot {
+			findings = append(findings, rel+": dot-import of testcontainers postgres module evades PG-TESTCONTAINER-FUNNEL-01")
+		}
+	}
+	assert.Empty(t, findings,
+		"dot-import of the testcontainers postgres module would make Run a bare ident and evade the funnel; forbidden")
+}
+
+func fileDotImportsPostgresModule(path string) (bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return false, err
+	}
+	for _, imp := range file.Imports {
+		if archStringLiteralValue(imp.Path) != pgTestcontainerModulePath {
+			continue
+		}
+		if imp.Name != nil && imp.Name.Name == "." {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
## Summary

消除 `adapters/postgres` 集成测试 per-test 容器 churn——CI integration shard 的主导瓶颈（~93 次 testcontainers spin-up × ~2.5s ≈ 237s）。引入共享容器 + per-test template-DB 克隆，集成测试 **237s → 28s**。

- **`tests/testutil/pgclone`**（新叶子包）：进程级共享 PG 容器单例 + per-test DB minting（`CloneDSN` 克隆已迁移 template / `EmptyDSN` 空库），全仓唯一 `tcpostgres.Run` 持有者；migration 经回调注入，**不依赖 adapters/postgres**（避免白盒 `package postgres` 测试的 import cycle）。
- **`pgshare`** 重构为 pgclone 薄包装，公共 API（`New`/`NewPerTestPool`/`Shutdown`）不变 → 4 个 cells 调用方零改动。
- **`adapters/postgres`** 9 个集成测试文件采用共享容器：`migratedPool`（Bucket A：conformance/DML）/ `emptyPool`（Bucket B：migration/schema 测试自跑 Up/UpTo/provider.Down）。删除全部 per-test 容器死代码（`setupPostgres` / `isolatedSchemaPool` / `setupSharedCommandQueuePG` / `setupPostgresForBench` / `migrationsTableName`）。
- **防复发 funnel**：archtest `PG-TESTCONTAINER-FUNNEL-01` 禁止 `tcpostgres.Run` 出现在 pgclone 之外（+ 4 个 backlog carve-out）。

## 偏离说明

- **depguard 上游锁作废**：所有 `tcpostgres.Run` callsite 在 `//go:build integration` 文件，golangci-lint 默认不带该 tag → 不可见。改用纯 AST archtest（评级 Medium；对"第三方 symbol 在 allowlist 外 import-ban"这一规则形状，Hard 在 Go 结构性不可达——无 import 可见性修饰符）。
- carve-out（cmd/corebundle、tests/integration、examples/iotdevice、cells/accesscore/identitymanage）迁移到 pgclone 列 backlog。

## Refs

`Refs:` PR #887 CI 性能跟进
`ref:` testcontainers-go modules/postgres — TEMPLATE clone（CREATE DATABASE ... TEMPLATE）

## Test plan

- [x] `go build ./...` / `go vet -tags=integration`
- [x] 循环依赖核验：`go list -tags=integration -deps ./tests/testutil/pgclone` 不含 adapters/postgres
- [x] funnel archtest GREEN（PG-TESTCONTAINER-FUNNEL-01 + RED fixture + dot-import 盲区反向自检）
- [x] `GOCELL_TEST_DOCKER_REQUIRED=1 go test -tags=integration ./adapters/postgres/` PASS（237s→28s）
- [x] cells 零回归（configcore PG adapter）
- [x] golangci-lint 0 issues（--new-from-merge-base）

🤖 Generated with [Claude Code](https://claude.com/claude-code)