### PR TITLE
fix(archtest): exclude entire tools/archtest/internal tree at scanner layer

### DIFF
--- a/tools/archtest/codegen_invariants_test.go
+++ b/tools/archtest/codegen_invariants_test.go
@@ -1166,8 +1166,9 @@ func extractSpecGenIDTopic(src string) (id, topic string, ok bool) {
 // scanned root is *not* the module root (e.g. user_file_overlap fixture root,
 // or a per-test scanRoot). For those sites we pass the fixture dir as
 // DirsScope's modRoot and use []string{"."} as dirs. This is intentional:
-//   - selfProtectRel filtering ("tools/archtest/internal/scanner") is harmless
-//     here because fixture trees never contain the scanner package
+//   - archtestInternalRel filtering ("tools/archtest/internal") is harmless
+//     here because rel paths are computed relative to the fixture root, so the
+//     prefix never matches (the filter only bites repo-rooted scopes)
 //   - error-message rel paths are computed relative to the fixture root,
 //     which is the correct frame of reference for fixture diagnostics
 // New rules scanning module-rooted subtrees should still pass findModuleRoot(t)

--- a/tools/archtest/internal/pgcontainerredfixture/fixture.go
+++ b/tools/archtest/internal/pgcontainerredfixture/fixture.go
@@ -4,9 +4,11 @@
 // It deliberately starts a per-test container via tcpostgres.Run OUTSIDE the
 // pgclone funnel so the funnel detector has a known-positive to fire on.
 //
-// Built only under the archtest_fixture tag. The funnel scan reaches it via
-// parser.ParseFile (which ignores build constraints); the production scan
-// skips tools/archtest/internal/ so this fixture is never itself reported.
+// Built only under the archtest_fixture tag. The funnel's RED self-check reaches
+// it by direct path (TestPG_TESTCONTAINER_FUNNEL_01_RedFixture, via
+// parser.ParseFile which ignores build constraints); repo-rooted production
+// scans never report it because the scanner excludes all of
+// tools/archtest/internal/ (see archtestInternalRel in internal/scanner/scope.go).
 package pgcontainerredfixture
 
 import (

--- a/tools/archtest/internal/scanner/content.go
+++ b/tools/archtest/internal/scanner/content.go
@@ -50,7 +50,7 @@ func LoadContentFiles(s Scope, suffixes []string) ([]ContentContext, error) {
 		relSlash := filepath.ToSlash(rel)
 		// #nosec G304 -- absPath is derived from a checked-in module subtree
 		// already filtered through scope.collectFile (path-segment escape
-		// guard + selfProtect + ExcludeRels + MatchRels). archtest reads
+		// guard + archtestInternalRel + ExcludeRels + MatchRels). archtest reads
 		// repo-resident files under module root; treating discovered paths as
 		// "user input" would force every archtest read through an arbitrary
 		// allowlist for no security gain.

--- a/tools/archtest/internal/scanner/scope.go
+++ b/tools/archtest/internal/scanner/scope.go
@@ -270,6 +270,8 @@ func rootsContainTestdataSegment(modRoot string, roots []string) bool {
 // That guard is archtest-bound (Medium); a Hard upstream is structurally
 // unreachable because stdlib filepath.WalkDir is always importable and cannot
 // be sealed — the same Medium ceiling PG-TESTCONTAINER-FUNNEL-01 documents.
+// This is that ceiling, not a Soft→Hard transition form, so no backlog upgrade
+// item is registered (per ai-robust.md §"Funnel 双向锁评级").
 var archtestInternalRel = filepath.Join("tools", "archtest", "internal")
 
 // Files returns the sorted, deduplicated list of absolute file paths in the

--- a/tools/archtest/internal/scanner/scope.go
+++ b/tools/archtest/internal/scanner/scope.go
@@ -247,9 +247,30 @@ func rootsContainTestdataSegment(modRoot string, roots []string) bool {
 	return false
 }
 
-// selfProtectRel is the rel-path prefix of the scanner package itself.
-// Files under this prefix are always excluded to prevent self-scanning.
-var selfProtectRel = filepath.Join("tools", "archtest", "internal", "scanner")
+// archtestInternalRel is the module-relative prefix of archtest's own internal
+// tree: the scanner walker itself, every RED fixture (//go:build
+// archtest_fixture), every typed-load fixture, and helper packages like
+// typeseval. A repo-rooted production scan ([ModuleScope] or a repo-rooted
+// [DirsScope]) always excludes this subtree — none of it is a governance
+// target: the scanner must not scan itself, and fixtures deliberately contain
+// forbidden patterns as known-positives.
+//
+// There is intentionally NO opt-in option to include it (unlike testdata /
+// generated, which have IncludeTestdata / IncludeGenerated): policing
+// archtest's internal tree from a framework walk is inexpressible — the same
+// fail-closed posture as vendor / .git. A rule that must reach a specific
+// fixture names it explicitly, and neither path is affected here:
+//   - [DirsScope] rooted AT the fixture directory — rel paths are then
+//     fixture-root relative (e.g. "redfixture.go"), so this prefix never matches;
+//   - go/packages typed load (RunTypedFixture) — bypasses Scope entirely.
+//
+// Upstream lock: SCANNER-FRAMEWORK-USAGE-01 forbids hand-rolled ast/fs/inspector
+// walks in tools/archtest/*_test.go, forcing every archtest through this
+// framework so the exclusion cannot be sidestepped by a raw filepath.WalkDir.
+// That guard is archtest-bound (Medium); a Hard upstream is structurally
+// unreachable because stdlib filepath.WalkDir is always importable and cannot
+// be sealed — the same Medium ceiling PG-TESTCONTAINER-FUNNEL-01 documents.
+var archtestInternalRel = filepath.Join("tools", "archtest", "internal")
 
 // Files returns the sorted, deduplicated list of absolute file paths in the
 // scope. It returns an error if the scope was not constructed via a constructor
@@ -316,11 +337,11 @@ func (s Scope) collectFile(f string, seen map[string]struct{}, files *[]string) 
 	if _, excluded := s.excludeRels[rel]; excluded {
 		return nil
 	}
-	// Path-segment boundary match (not bare HasPrefix) so "scanner_extra/"
-	// or other prefix-colliding siblings are not falsely excluded.
+	// Path-segment boundary match (not bare HasPrefix) so "internalx/" or other
+	// prefix-colliding siblings are not falsely excluded.
 	// ref: golangci-lint pkg/golinters/depguard — segment-boundary path match
-	if rel == selfProtectRel ||
-		strings.HasPrefix(rel, selfProtectRel+string(filepath.Separator)) {
+	if rel == archtestInternalRel ||
+		strings.HasPrefix(rel, archtestInternalRel+string(filepath.Separator)) {
 		return nil
 	}
 	if s.matchRel != nil && !s.matchRel(filepath.ToSlash(rel)) {

--- a/tools/archtest/internal/scanner/scope_test.go
+++ b/tools/archtest/internal/scanner/scope_test.go
@@ -261,6 +261,43 @@ func TestScope_ArchtestInternalExclusion_PathSegmentBoundary(t *testing.T) {
 	}
 }
 
+func TestScope_ExcludesArchtestInternalTree_ContentFiles(t *testing.T) {
+	// collectFile is the shared backbone of Files() (.go) and contentFiles()
+	// (YAML/SQL/MD via LoadContentFiles/EachContentFile), so the archtest-internal
+	// exclusion must apply to non-Go content files too — not just .go.
+	tmp := t.TempDir()
+	internalYAML := filepath.Join(tmp, "tools", "archtest", "internal", "somefixture", "fixture.yaml")
+	controlYAML := filepath.Join(tmp, "cells", "auth", "cell.yaml")
+	for _, f := range []string{internalYAML, controlYAML} {
+		if err := os.MkdirAll(filepath.Dir(f), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", f, err)
+		}
+		if err := os.WriteFile(f, []byte("id: x\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", f, err)
+		}
+	}
+
+	got, err := scanner.LoadContentFiles(scanner.ModuleScope(tmp), []string{".yaml"})
+	if err != nil {
+		t.Fatalf("LoadContentFiles error: %v", err)
+	}
+	var sawInternal, sawControl bool
+	for _, cc := range got {
+		switch cc.AbsPath {
+		case internalYAML:
+			sawInternal = true
+		case controlYAML:
+			sawControl = true
+		}
+	}
+	if sawInternal {
+		t.Errorf("archtest internal tree must be excluded from content files, but %s was returned", internalYAML)
+	}
+	if !sawControl {
+		t.Errorf("control content file %s must be returned (exclusion must be specific to internal/); got=%v", controlYAML, got)
+	}
+}
+
 func TestDirsScope_DeduplicatesOverlappingRoots(t *testing.T) {
 	tmp := t.TempDir()
 	writeFile(t, filepath.Join(tmp, "src", "a.go"), "package src\n")

--- a/tools/archtest/internal/scanner/scope_test.go
+++ b/tools/archtest/internal/scanner/scope_test.go
@@ -185,50 +185,58 @@ func TestScope_ZeroValueIsRejected(t *testing.T) {
 	}
 }
 
-func TestScope_SelfProtectRel(t *testing.T) {
-	// Create a temp tree that looks like the scanner package location.
-	// ModuleScope must not include files under the self-protect path.
+func TestScope_ExcludesArchtestInternalTree(t *testing.T) {
+	// A repo-rooted ModuleScope walk must exclude every file under
+	// tools/archtest/internal/ — the scanner walker itself plus all RED
+	// fixtures and typed-load helpers. archtest's internal tree is never a
+	// production-governance target (see archtestInternalRel in scope.go).
 	tmp := t.TempDir()
-	scannerDir := filepath.Join(tmp, "tools", "archtest", "internal", "scanner")
-	if err := os.MkdirAll(scannerDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
+	internalFiles := []string{
+		filepath.Join(tmp, "tools", "archtest", "internal", "scanner", "fake.go"),
+		filepath.Join(tmp, "tools", "archtest", "internal", "somefixture", "red.go"),
+		filepath.Join(tmp, "tools", "archtest", "internal", "typeseval", "helper.go"),
 	}
-	fakeFile := filepath.Join(scannerDir, "fake.go")
-	if err := os.WriteFile(fakeFile, []byte("package scanner\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile fake.go: %v", err)
+	for _, f := range internalFiles {
+		if err := os.MkdirAll(filepath.Dir(f), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", f, err)
+		}
+		if err := os.WriteFile(f, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", f, err)
+		}
 	}
 
-	s := scanner.ModuleScope(tmp)
-	files, err := s.Files()
+	files, err := scanner.ModuleScope(tmp).Files()
 	if err != nil {
 		t.Fatalf("Files() error: %v", err)
 	}
 	for _, f := range files {
-		if f == fakeFile {
-			t.Errorf("self-protect should exclude %s but it was returned", fakeFile)
+		for _, excluded := range internalFiles {
+			if f == excluded {
+				t.Errorf("archtest internal tree must be excluded, but %s was returned", excluded)
+			}
 		}
 	}
 }
 
-func TestScope_SelfProtect_PathSegmentBoundary(t *testing.T) {
-	// Self-protect must match path segments, not bare string prefixes.
-	// scanner_extra/ shares the prefix tools/archtest/internal/scanner but
-	// is a sibling directory; it must NOT be excluded.
+func TestScope_ArchtestInternalExclusion_PathSegmentBoundary(t *testing.T) {
+	// The exclusion must match path segments, not bare string prefixes.
+	// internalx/ collides on the "internal" prefix but is a sibling directory
+	// (not under tools/archtest/internal/); it must NOT be excluded.
 	tmp := t.TempDir()
-	scannerDir := filepath.Join(tmp, "tools", "archtest", "internal", "scanner")
-	scannerExtraDir := filepath.Join(tmp, "tools", "archtest", "internal", "scanner_extra")
-	if err := os.MkdirAll(scannerDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll scanner: %v", err)
+	internalDir := filepath.Join(tmp, "tools", "archtest", "internal", "scanner")
+	siblingDir := filepath.Join(tmp, "tools", "archtest", "internalx")
+	if err := os.MkdirAll(internalDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll internal: %v", err)
 	}
-	if err := os.MkdirAll(scannerExtraDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll scanner_extra: %v", err)
+	if err := os.MkdirAll(siblingDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll internalx: %v", err)
 	}
-	selfFile := filepath.Join(scannerDir, "self.go")
-	siblingFile := filepath.Join(scannerExtraDir, "foo.go")
+	selfFile := filepath.Join(internalDir, "self.go")
+	siblingFile := filepath.Join(siblingDir, "foo.go")
 	if err := os.WriteFile(selfFile, []byte("package scanner\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile self.go: %v", err)
 	}
-	if err := os.WriteFile(siblingFile, []byte("package scanner_extra\n"), 0o644); err != nil {
+	if err := os.WriteFile(siblingFile, []byte("package internalx\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile foo.go: %v", err)
 	}
 
@@ -246,10 +254,10 @@ func TestScope_SelfProtect_PathSegmentBoundary(t *testing.T) {
 		}
 	}
 	if seenSelf {
-		t.Errorf("self-protect should exclude %s", selfFile)
+		t.Errorf("archtest internal tree must exclude %s", selfFile)
 	}
 	if !seenSibling {
-		t.Errorf("self-protect must NOT exclude prefix-colliding sibling %s; got files=%v", siblingFile, files)
+		t.Errorf("exclusion must NOT match prefix-colliding sibling %s; got files=%v", siblingFile, files)
 	}
 }
 

--- a/tools/archtest/pg_testcontainer_funnel_test.go
+++ b/tools/archtest/pg_testcontainer_funnel_test.go
@@ -79,10 +79,6 @@ var pgTestcontainerFunnelAllowlist = []string{
 	"cells/accesscore/slices/identitymanage/", // single-service PG adapter test
 }
 
-// archtestInternalPrefix is archtest's own fixture area (including this rule's
-// RED fixture). Not a governed target — skipped by the production scan.
-const archtestInternalPrefix = "tools/archtest/internal/"
-
 // TestPG_TESTCONTAINER_FUNNEL_01 fails if any file outside the allowlist calls
 // tcpostgres.Run. adapters/postgres now mints per-test DBs via pgclone, so the
 // sole sanctioned holder is tests/testutil/pgclone; this scan keeps it that way
@@ -104,9 +100,8 @@ func collectPGTestcontainerRunFindings(t *testing.T, root string) []string {
 	var findings []string
 	for _, path := range files {
 		rel := relSlash(root, path)
-		if strings.HasPrefix(rel, archtestInternalPrefix) {
-			continue // archtest fixtures are not governed targets
-		}
+		// archtest's internal tree (this rule's RED fixture included) is excluded
+		// at the scanner layer; see archtestInternalRel in internal/scanner/scope.go.
 		if pgFunnelAllowed(rel) {
 			continue
 		}
@@ -237,9 +232,6 @@ func TestPG_TESTCONTAINER_FUNNEL_01_NoDotImportBlindSpot(t *testing.T) {
 	var findings []string
 	for _, path := range files {
 		rel := relSlash(root, path)
-		if strings.HasPrefix(rel, archtestInternalPrefix) {
-			continue
-		}
 		dot, perr := fileDotImportsPostgresModule(path)
 		require.NoError(t, perr)
 		if dot {


### PR DESCRIPTION
## Summary

`TestTestcontainerHelpersRequireDockerBeforeRun`（INVARIANT: **INTEGRATION-GUARD-01**）在 develop 上预存 RED。

**根因**：该守卫用裸 `scanner.ModuleScope(root, IncludeTests())` 全模块扫描，断言每个启动 testcontainer 的函数先调 `testutil.RequireDocker(t)`，但**没排除 archtest 自己的内部树** `tools/archtest/internal/`。PR #889 新增的 RED fixture `pgcontainerredfixture/fixture.go::Boot` 故意调 `tcpostgres.Run` 不调 `RequireDocker`（这是 PG-TESTCONTAINER-FUNNEL-01 的 known-positive），被 INTEGRATION-GUARD-01 误判。兄弟守卫 `TestPG_TESTCONTAINER_FUNNEL_01` 用 per-test 常量 `archtestInternalPrefix` 跳过了，INTEGRATION-GUARD-01 漏写——一个 **Soft per-rule 约定**漏了就出 bug（archtest 仅 nightly 跑，RED 带病合入 develop）。

## 修复（单源 / Soft→Hard）

把"排除 internal/"的职责从「每条规则各自记得跳」上移到 **scanner 唯一收口点**：`collectFile` 的自保护前缀从 `tools/archtest/internal/scanner` 拓宽到 `tools/archtest/internal`（`selfProtectRel` → `archtestInternalRel`）。所有 repo-rooted 框架扫描由构造层统一排除整棵内部树，**无 opt-in 选项**（与 vendor/.git 同档 fail-closed）。删 pg 测试里两处冗余跳过。

### AI-robust 评级（属"修改约束 enforcement 机制 / archtest"）
- **下游 Hard**：repo-rooted 框架扫描无法表达"扫 internal/"（无 IncludeXxx 选项）；新增 `scope_test.go` 单测钉死。
- **上游 Medium**：手写 `filepath.WalkDir` 旁路由**已存在的 `SCANNER-FRAMEWORK-USAGE-01`** 拦截；Hard 上游结构不可达（stdlib WalkDir 无法 seal，与 PG-TESTCONTAINER-FUNNEL-01 同天花板）。已在 `scope.go` godoc 点名上游锁。

### Blast radius（rel-frame 是安全根因）
`collectFile` 比较 modRoot-relative 路径，故只作用于 repo-rooted scope：
- **fixture-local DirsScope**（modRoot=fixture 目录）→ rel 形如 `redfixture.go`，前缀永不匹配 → 不受影响
- **RunTypedFixture**（go/packages，绕过 Scope）→ 所有 RED-fixture 探测器不受影响
- **`archtest_verify_coverage_test.go`** 自带 `Dir(rel)=="tools/archtest"` 过滤 → 不受影响
- 其余 bare-ModuleScope 治理规则全 assert-empty → 只减不增 finding，保持绿
- **经验性兜底**：全 `go test ./tools/archtest/...` 全绿（207s，覆盖全部规则）

Refs: INTEGRATION-GUARD-01, PG-TESTCONTAINER-FUNNEL-01, SCANNER-FRAMEWORK-USAGE-01

## Test plan
- [x] `go test ./tools/archtest/internal/scanner/` — scope 排除单测 RED→GREEN
- [x] `TestTestcontainerHelpersRequireDockerBeforeRun` 由 RED 转 PASS
- [x] `TestPG_TESTCONTAINER_FUNNEL_01` (+RedFixture/IndirectRef/NoDotImport) 删跳过后全绿
- [x] `go test ./tools/archtest/...` 全绿（blast-radius 经验证明）
- [x] `go build ./...` + `golangci-lint run ./tools/archtest/...`（0 issues）

🤖 Generated with [Claude Code](https://claude.com/claude-code)