### PR TITLE
feat(codegen): seal httpEndpointSpec + CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 archtest (close #690)

### DIFF
--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -1467,8 +1467,14 @@ func (v *Validator) validateFMT33() []ValidationResult {
 //
 // Funnel pair (ai-robust.md §Funnel 双向锁评级):
 //
-//	upstream Hard: tools/codegen/contractgen/builder.go::validateAuthOnInternalPath
-//	               (single funnel via buildHTTPEndpointSpec — sole HTTP codegen entry)
+//	upstream Hard: tools/codegen/contractgen/builder.go::validateAuthOnInternalPath,
+//	               called unconditionally inside buildHTTPEndpointSpec. The "sole
+//	               HTTP codegen entry" premise is enforced — not grep-asserted — by
+//	               the sealed (unexported) httpEndpointSpec type (cross-package
+//	               bypass not expressible) + archtest
+//	               CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (intra-package sole
+//	               constructor/caller + http.Handler emit-uniqueness across
+//	               tools/codegen/**).
 //	downstream:    this rule (Medium — receiver-type + RuleCode const + fix suffix archtest)
 //
 // Orthogonal to FMT-26 (two-bypass mutex, path-agnostic) and

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -1470,11 +1470,14 @@ func (v *Validator) validateFMT33() []ValidationResult {
 //	upstream Hard: tools/codegen/contractgen/builder.go::validateAuthOnInternalPath,
 //	               called unconditionally inside buildHTTPEndpointSpec. The "sole
 //	               HTTP codegen entry" premise is enforced — not grep-asserted — by
-//	               the sealed (unexported) httpEndpointSpec type (cross-package
-//	               bypass not expressible) + archtest
+//	               the sealed (unexported) httpEndpointSpec type AND the
+//	               package-private build/render surface: no out-of-package code
+//	               can construct a non-nil Endpoint (A1a) nor obtain a mutable
+//	               spec to flip Path/AuthPublic/Clients after FMT-34 ran (A4) —
+//	               cross-package bypass not expressible. Locked by archtest
 //	               CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (intra-package sole
 //	               constructor/caller + http.Handler emit-uniqueness across
-//	               tools/codegen/**).
+//	               tools/codegen/** + no exported spec leak).
 //	downstream:    this rule (Medium — receiver-type + RuleCode const + fix suffix archtest)
 //
 // Orthogonal to FMT-26 (two-bypass mutex, path-agnostic) and

--- a/tools/archtest/codegen_http_handler_funnel_test.go
+++ b/tools/archtest/codegen_http_handler_funnel_test.go
@@ -11,13 +11,18 @@ package archtest
 // future one) emitted an http.Handler without going through that funnel,
 // FMT-34's "sole HTTP codegen entry" premise would silently degrade.
 //
-// Hard收口 + archtest closure (three legs; see the per-test godoc for ratings):
+// Hard收口 + archtest closure (four legs; see the per-test godoc for ratings):
 //
 //	type seal (compile-time Hard): contractgen.httpEndpointSpec is unexported.
 //	  ContractGenSpec.Endpoint is *httpEndpointSpec, so no out-of-package code
-//	  can construct a non-nil Endpoint → cannot drive handler.tmpl with a
-//	  hand-built (FMT-34-unvalidated) spec. This is the load-bearing Hard
-//	  upgrade #690 calls the "sealed interface / 单一抽象函数" path.
+//	  can construct a non-nil Endpoint. The spec is also never handed to
+//	  another package as a mutable value: its sole constructor buildContractSpec
+//	  and every render wrapper are package-private, and the exported surface
+//	  (Generate / RenderContractArtifacts) returns rendered []byte, never the
+//	  spec. So neither constructing nor post-construction mutating (an exported
+//	  field flipped to AuthPublic:true after FMT-34 ran) an unvalidated Endpoint
+//	  to drive handler.tmpl is expressible cross-package. This is the
+//	  load-bearing Hard upgrade #690 calls the "sealed interface / 单一抽象函数" path.
 //
 //	A1a — the seal is locked: ContractGenSpec.Endpoint's base type is the
 //	      unexported sealed name, and no exported alias re-exports it.
@@ -25,22 +30,34 @@ package archtest
 //	      type is constructed only inside buildHTTPEndpointSpec, and
 //	      buildHTTPEndpointSpec is called only from the allowlisted funnel.
 //	A2  — across all of tools/codegen/**, the only source file emitting an
-//	      http.Handler implementation (ServeHTTP method) is handler.tmpl.
+//	      http.Handler implementation (ServeHTTP method / HandlerFunc adapter,
+//	      any import alias) is handler.tmpl.
 //	A3  — handler.tmpl is rendered only inside the contractgen package, whose
 //	      only HTTP-spec construction path is buildHTTPEndpointSpec.
+//	A4  — no exported contractgen function signature names ContractGenSpec or
+//	      httpEndpointSpec (param or result), so no out-of-package code can
+//	      obtain a mutable spec to flip Endpoint.Path/AuthPublic/Clients. This
+//	      is the cross-package "cannot mutate" reverse proof complementing A1a's
+//	      "cannot construct"; it locks buildContractSpec + render wrappers
+//	      staying package-private (re-exporting either re-introduces a spec in
+//	      an exported signature → A4 RED).
 //
-// AI-robust ceiling (honest): the type seal is Hard for the cross-package
-// bypass. A1b/A2/A3 cover what the Go type system fundamentally cannot — a
-// second intra-package constructor (no package-internal visibility) and text
-// emission of an http.Handler (a generated string is not type-checkable). No
-// lower-cost Hard path exists for those, so there is no follow-up Hard-ization
-// backlog; the archtest is the ceiling. (ai-robust.md §Review checklist:
-// "Medium 且无低成本升 Hard 路径 → 保留".)
+// AI-robust ceiling (honest): the type seal + the package-private build/render
+// surface make BOTH cross-package construction (A1a) and cross-package mutation
+// (A4) unexpressible — these are compile-time/visibility Hard facts, archtest-
+// locked against regression. A1b/A2/A3 cover what the Go type system
+// fundamentally cannot — a second intra-package constructor (no package-internal
+// visibility) and text emission of an http.Handler (a generated string is not
+// type-checkable). No lower-cost Hard path exists for those, so there is no
+// follow-up Hard-ization backlog; the archtest is the ceiling. (ai-robust.md
+// §Review checklist: "Medium 且无低成本升 Hard 路径 → 保留".)
 
 import (
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"regexp"
 	"sort"
 	"strconv"
@@ -63,7 +80,24 @@ const (
 	codegenHandlerTmplRel = "tools/codegen/contractgen/templates/handler.tmpl"
 	// codegenContractgenPrefix is the contractgen package subtree.
 	codegenContractgenPrefix = "tools/codegen/contractgen/"
+	// codegenSpecHolderType is the exported outer IR struct whose Endpoint field
+	// holds the sealed *httpEndpointSpec. An exported function naming it (A4)
+	// would hand a mutable spec to another package, re-opening the
+	// post-construction mutation bypass.
+	codegenSpecHolderType = "ContractGenSpec"
 )
+
+// codegenLeakedSpecTypes are the package-local IR types whose exported fields
+// reach FMT-34-validated endpoint state. A4 bans any EXPORTED contractgen
+// function from naming them in a parameter or result: doing so would hand a
+// mutable spec (or its sealed Endpoint) to another package, letting a holder
+// flip Path / AuthPublic / Clients after buildHTTPEndpointSpec already ran
+// validateAuthOnInternalPath. The only sanctioned exported surface (Generate /
+// RenderContractArtifacts) trades in rendered []byte, never these types.
+var codegenLeakedSpecTypes = map[string]bool{
+	codegenSpecHolderType: true, // "ContractGenSpec" — has the mutable Endpoint field
+	codegenSealedSpecType: true, // "httpEndpointSpec" — the sealed endpoint itself
+}
 
 // codegenSpecCtorCallerAllowlist names the production functions permitted to
 // CALL buildHTTPEndpointSpec (A1b ②). buildHTTPSpec is the single funnel that
@@ -76,17 +110,25 @@ var codegenSpecCtorCallerAllowlist = map[string]string{
 // codegenHandlerEmitMarker matches the two language-mandated shapes by which
 // Go source produces an http.Handler:
 //
-//   - a ServeHTTP method `func (h *Handler) ServeHTTP(<param> http.ResponseWriter, ...)`
+//   - a ServeHTTP method `func (h *Handler) ServeHTTP(<param> <q.>ResponseWriter, ...)`
 //     (the http.Handler interface method), and
-//   - the http.HandlerFunc(<fn>) adapter (an http.Handler without a ServeHTTP
+//   - the <q.>HandlerFunc(<fn>) adapter (an http.Handler without a ServeHTTP
 //     method of its own).
 //
 // Both appear in handler.tmpl today; a new generator could emit a handler via
 // EITHER form, so A2 must cover both — the ServeHTTP-only marker would miss a
 // HandlerFunc-only emitter (reviewer B-1). These are structural shapes of the
-// regulated artifact, not arbitrary string conventions. ServeHTTP's param name
-// is matched as \w+ so it is not pinned to the literal "w".
-var codegenHandlerEmitMarker = regexp.MustCompile(`ServeHTTP\(\s*\w+\s+http\.ResponseWriter|http\.HandlerFunc\(`)
+// regulated artifact, not arbitrary string conventions.
+//
+// Alias / unnamed-param tolerant (PR #904 review F2): the net/http import
+// qualifier is matched as an optional `(?:\w+\.)?` so an alias import
+// (`stdhttp.ResponseWriter`, `nethttp.HandlerFunc(`) or a dot-import (bare
+// `ResponseWriter` / `HandlerFunc(`) cannot slip a handler past the scan; and
+// the ServeHTTP param name is optional `(?:\w+\s+)?` so an unnamed-param method
+// (`ServeHTTP(http.ResponseWriter, ...)`) is still caught. The `ServeHTTP\(`
+// literal prefix is retained so it does not over-match the non-handler
+// `visitXxxResponse(ctx, w http.ResponseWriter)` methods emitted by types.tmpl.
+var codegenHandlerEmitMarker = regexp.MustCompile(`ServeHTTP\(\s*(?:\w+\s+)?(?:\w+\.)?ResponseWriter|(?:\w+\.)?HandlerFunc\(`)
 
 // ---------------------------------------------------------------------------
 // A1a — the type seal is in place and locked (no re-export).
@@ -243,62 +285,109 @@ func TestCodegenBuildHTTPEndpointSpecSoleCaller_A2_HandlerEmitTemplateUniqueness
 // AI-robust: Medium. Complements A2's emit-side check with the render side:
 // even though A2 guarantees handler.tmpl is the only http.Handler emitter, an
 // out-of-package generator could re-render it (by path) with a hand-built,
-// FMT-34-unvalidated spec. Banning the "handler.tmpl" template-name literal
-// outside contractgen closes that. A positive sanity (≥1 occurrence inside
-// contractgen) prevents a vacuous pass if the template were renamed/removed.
+// FMT-34-unvalidated spec. Banning a reference to the "handler.tmpl"
+// template-name constant outside contractgen closes that. A positive sanity
+// (≥1 occurrence inside contractgen) prevents a vacuous pass if the template
+// were renamed/removed.
 //
-// Blind spot (documented): the template name reached via a const/variable
-// rather than a string literal, or a computed path.
+// Typed const evaluation (PR #904 review F3): the scan resolves each
+// BasicLit / Ident / SelectorExpr / BinaryExpr through go/types constant
+// folding (EvaluateConstString), so a const indirection
+// (`const tmpl = "handler.tmpl"`) or string concatenation
+// (`"handler" + ".tmpl"`) folds to the same value and is caught — the prior
+// BasicLit-only scan missed both. RunTyped (not the AST-only Run) supplies the
+// types.Info the folding needs.
+//
+// Blind spot (documented, not detected): the template name assembled from
+// runtime-only data (e.g. filepath.Join of a value read from disk) — no
+// compile-time constant exists to fold. A computed-but-const path still folds
+// and is caught.
 // ---------------------------------------------------------------------------
 func TestCodegenBuildHTTPEndpointSpecSoleCaller_A3_HandlerTmplRenderedOnlyInContractgen(t *testing.T) {
 	t.Parallel()
-	root := findModuleRoot(t)
 
-	outsideScope := DirsScope(root, []string{"tools/codegen"},
-		MatchRels(func(rel string) bool {
-			if strings.Contains(rel, "/testdata/") || strings.HasSuffix(rel, "_test.go") {
-				return false
-			}
-			if !strings.HasSuffix(rel, ".go") {
-				return false
-			}
-			return !strings.HasPrefix(rel, codegenContractgenPrefix)
-		}),
-	)
 	var outside []string
-	_ = Run(t, outsideScope, func(p *Pass) []Diagnostic {
+	var insideCount int
+	_ = RunTyped(t, TypedOpts{}, []string{"./tools/codegen/..."}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil || p.Fset == nil {
+			return nil
+		}
 		for _, f := range p.Files {
-			for _, line := range scanHandlerTmplLiteralLines(f, p.Fset) {
-				outside = append(outside, p.Rel(f)+":"+line)
+			rel := p.Rel(f)
+			if strings.Contains(rel, "/testdata/") || strings.HasSuffix(rel, "_test.go") || !strings.HasSuffix(rel, ".go") {
+				continue
+			}
+			lines := scanHandlerTmplConstExprLines(f, p.TypesInfo, p.Fset)
+			if strings.HasPrefix(rel, codegenContractgenPrefix) {
+				insideCount += len(lines)
+				continue
+			}
+			for _, ln := range lines {
+				outside = append(outside, rel+":"+strconv.Itoa(ln))
 			}
 		}
 		return nil
 	})
+	sort.Strings(outside)
 	for _, v := range outside {
 		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A3): %s references template %q outside "+
 			"the contractgen package — handler.tmpl must be rendered only by the buildHTTPEndpointSpec funnel.",
 			v, codegenHandlerTemplate)
 	}
 
-	// Positive sanity: the funnel target must exist inside contractgen, else
-	// the guard above passes vacuously.
-	insideScope := DirsScope(root, []string{"tools/codegen/contractgen"},
+	if insideCount == 0 {
+		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A3): template %q is never referenced inside "+
+			"contractgen — A3 would pass vacuously; update the rule if the template was renamed/removed.",
+			codegenHandlerTemplate)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A4 — no exported contractgen API hands out the mutable spec.
+//
+// AI-robust: Hard (compile-time/visibility fact, archtest-locked against
+// regression). A1a proves out-of-package code cannot CONSTRUCT a non-nil
+// Endpoint (httpEndpointSpec unexported). But exported fields on a held
+// *httpEndpointSpec / *ContractGenSpec are mutable, so a holder could flip
+// Path / AuthPublic / Clients AFTER buildHTTPEndpointSpec ran FMT-34 and then
+// drive handler.tmpl with the mutated spec. That mutation path is closed by
+// the holder being unreachable cross-package: the only producer
+// (buildContractSpec) and consumers (render wrappers) are package-private, and
+// the exported surface returns rendered []byte. A4 locks that — it fails if
+// any EXPORTED contractgen function names ContractGenSpec or httpEndpointSpec
+// in a parameter or result (re-exporting buildContractSpec or a render wrapper
+// is exactly such a signature). This is the cross-package "cannot mutate"
+// reverse proof the #690 review asked for.
+//
+// Scope notes:
+//   - Receiver types are NOT scanned (a method ON the sealed type, e.g.
+//     httpEndpointSpec.IsPagination, is in-package and fine); only Params +
+//     Results are walked, recursively, so []*ContractGenSpec / map / func-typed
+//     nestings are caught too.
+//   - Production-only walk (non-_test.go): white-box tests legitimately hold
+//     the spec.
+//
+// Blind spot (documented, not detected): an exported method whose RECEIVER is
+// an exported type and that returns the spec via an interface the caller can
+// type-assert. No exported contractgen type carries the spec today; adding one
+// would itself be an unusual API change. Asserted clean by the production walk.
+// ---------------------------------------------------------------------------
+func TestCodegenBuildHTTPEndpointSpecSoleCaller_A4_NoExportedSpecLeak(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	scope := DirsScope(root, []string{"tools/codegen/contractgen"},
 		MatchRels(func(rel string) bool {
 			return strings.HasSuffix(rel, ".go") && !strings.HasSuffix(rel, "_test.go")
 		}),
 	)
-	var insideCount int
-	_ = Run(t, insideScope, func(p *Pass) []Diagnostic {
+	var violations []string
+	_ = Run(t, scope, func(p *Pass) []Diagnostic {
 		for _, f := range p.Files {
-			insideCount += len(scanHandlerTmplLiteralLines(f, p.Fset))
+			violations = append(violations, scanExportedSpecLeak(f, p.Rel(f))...)
 		}
 		return nil
 	})
-	if insideCount == 0 {
-		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A3): template %q is never rendered inside "+
-			"contractgen — A3 would pass vacuously; update the rule if the template was renamed/removed.",
-			codegenHandlerTemplate)
-	}
+	reportCodegenFunnel(t, violations)
 }
 
 // ===========================================================================
@@ -343,6 +432,49 @@ func scanExportedSealedAlias(f *ast.File) []string {
 		if id := exprToIdent(ts.Type); id != nil && id.Name == codegenSealedSpecType {
 			out = append(out, "exported alias "+ts.Name.Name+" = "+codegenSealedSpecType+
 				" re-exports the sealed spec type — drop it (it re-opens cross-package construction)")
+		}
+	})
+	return out
+}
+
+// scanExportedSpecLeak flags an EXPORTED package-level function (A4) whose
+// parameter or result type names a codegenLeakedSpecTypes member. Receiver
+// types are deliberately NOT scanned — a method on the sealed type
+// (httpEndpointSpec.IsPagination) is in-package and harmless. The Params /
+// Results field types are walked recursively, so nested forms
+// ([]*ContractGenSpec, func() *httpEndpointSpec, …) are caught too.
+func scanExportedSpecLeak(f *ast.File, rel string) []string {
+	var out []string
+	EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+		if fd.Name == nil || !fd.Name.IsExported() || fd.Type == nil {
+			return
+		}
+		for _, grp := range []*ast.FieldList{fd.Type.Params, fd.Type.Results} {
+			if grp == nil {
+				continue
+			}
+			for _, field := range grp.List {
+				for _, name := range leakedSpecIdentsIn(field.Type) {
+					out = append(out, rel+": exported func "+fd.Name.Name+
+						" names IR type "+name+" in its signature — the build product must not "+
+						"escape contractgen (hands out a mutable spec → re-opens post-construction "+
+						"Endpoint mutation); keep buildContractSpec / render wrappers package-private")
+				}
+			}
+		}
+	})
+	return out
+}
+
+// leakedSpecIdentsIn returns the distinct codegenLeakedSpecTypes identifiers
+// appearing anywhere in the type expression expr (root included).
+func leakedSpecIdentsIn(expr ast.Expr) []string {
+	seen := map[string]bool{}
+	var out []string
+	EachInSubtree[ast.Ident](expr, func(id *ast.Ident) {
+		if codegenLeakedSpecTypes[id.Name] && !seen[id.Name] {
+			seen[id.Name] = true
+			out = append(out, id.Name)
 		}
 	})
 	return out
@@ -429,18 +561,29 @@ func isCallTo(call *ast.CallExpr, name string) bool {
 	return id != nil && id.Name == name
 }
 
-// scanHandlerTmplLiteralLines returns the line numbers in f where a string
-// literal equal to "handler.tmpl" appears.
-func scanHandlerTmplLiteralLines(f *ast.File, fset *token.FileSet) []string {
-	var lines []string
-	EachInSubtree[ast.BasicLit](f, func(lit *ast.BasicLit) {
-		if lit.Kind != token.STRING {
-			return
+// scanHandlerTmplConstExprLines returns the (deduped, sorted) line numbers in f
+// where a compile-time constant string expression folds to "handler.tmpl". It
+// walks BasicLit / Ident / SelectorExpr / BinaryExpr and resolves each via
+// go/types constant folding (EvaluateConstString), so a literal, a const-ident
+// reference, a package-qualified const, and a "+" concatenation are all caught
+// (A3, PR #904 F3). info MUST come from the same typed load that produced f.
+func scanHandlerTmplConstExprLines(f *ast.File, info *types.Info, fset *token.FileSet) []int {
+	seen := map[int]bool{}
+	var lines []int
+	record := func(expr ast.Expr) {
+		if v, ok := EvaluateConstString(info, expr); ok && v == codegenHandlerTemplate {
+			ln := fset.Position(expr.Pos()).Line
+			if !seen[ln] {
+				seen[ln] = true
+				lines = append(lines, ln)
+			}
 		}
-		if v, ok := StringLitValue(lit); ok && v == codegenHandlerTemplate {
-			lines = append(lines, strconv.Itoa(fset.Position(lit.Pos()).Line))
-		}
-	})
+	}
+	EachInSubtree[ast.BasicLit](f, func(n *ast.BasicLit) { record(n) })
+	EachInSubtree[ast.Ident](f, func(n *ast.Ident) { record(n) })
+	EachInSubtree[ast.SelectorExpr](f, func(n *ast.SelectorExpr) { record(n) })
+	EachInSubtree[ast.BinaryExpr](f, func(n *ast.BinaryExpr) { record(n) })
+	sort.Ints(lines)
 	return lines
 }
 
@@ -501,20 +644,43 @@ func reportCodegenFunnel(t *testing.T, violations []string) {
 // assumed). Inline-parsed fixtures keep the proofs hermetic.
 // ===========================================================================
 
-func parseCodegenFixtureSrc(t *testing.T, src string) (*ast.File, *token.FileSet) {
+func parseCodegenFixtureSrc(t *testing.T, src string) *ast.File {
 	t.Helper()
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "fixture.go", src, parser.ParseComments)
 	if err != nil {
 		t.Fatalf("parse fixture: %v", err)
 	}
-	return f, fset
+	return f
+}
+
+// typeCheckCodegenFixture parses + type-checks an inline (import-free) fixture
+// so EvaluateConstString can fold const idents / concatenations in the A3
+// reverse self-check. The fixtures need no imports, so importer.Default is
+// never actually invoked.
+func typeCheckCodegenFixture(t *testing.T, src string) (*ast.File, *types.Info, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	info := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{},
+		Defs:  map[*ast.Ident]types.Object{},
+		Uses:  map[*ast.Ident]types.Object{},
+	}
+	conf := types.Config{Importer: importer.Default()}
+	if _, err := conf.Check("codegenfixture", fset, []*ast.File{f}, info); err != nil {
+		t.Fatalf("type-check fixture: %v", err)
+	}
+	return f, info, fset
 }
 
 func TestCodegenFunnel_A1a_DetectsExportedEndpointType(t *testing.T) {
 	t.Parallel()
 	// RED fixture: Endpoint typed with an EXPORTED spec type.
-	f, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+	f := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type HTTPEndpointSpec struct{}\n"+
 		"type ContractGenSpec struct { Endpoint *HTTPEndpointSpec }\n")
 	base, ok := contractGenSpecEndpointBaseType(f)
@@ -528,7 +694,7 @@ func TestCodegenFunnel_A1a_DetectsExportedEndpointType(t *testing.T) {
 		t.Fatal("exported type must not equal the sealed unexported name (would mask the violation)")
 	}
 	// GREEN fixture: sealed unexported type passes.
-	g, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+	g := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type httpEndpointSpec struct{}\n"+
 		"type ContractGenSpec struct { Endpoint *httpEndpointSpec }\n")
 	gb, _ := contractGenSpecEndpointBaseType(g)
@@ -539,18 +705,54 @@ func TestCodegenFunnel_A1a_DetectsExportedEndpointType(t *testing.T) {
 
 func TestCodegenFunnel_A1a_DetectsExportedReExportAlias(t *testing.T) {
 	t.Parallel()
-	f, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+	f := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type httpEndpointSpec struct{}\n"+
 		"type PublicEndpointSpec = httpEndpointSpec\n")
 	if got := scanExportedSealedAlias(f); len(got) == 0 {
 		t.Fatal("detector missed exported alias re-export of the sealed type")
 	}
 	// Negative: an unexported alias is harmless (not a cross-package re-export).
-	g, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+	g := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type httpEndpointSpec struct{}\n"+
 		"type localAlias = httpEndpointSpec\n")
 	if got := scanExportedSealedAlias(g); len(got) != 0 {
 		t.Fatalf("detector over-flagged unexported alias: %v", got)
+	}
+}
+
+func TestCodegenFunnel_A4_DetectsExportedSpecLeak(t *testing.T) {
+	t.Parallel()
+	// RED: exported funcs that hand out the mutable spec — by result, by param,
+	// the sealed endpoint directly, and a nested []*ContractGenSpec form.
+	f := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type ContractGenSpec struct{}\n"+
+		"type httpEndpointSpec struct{}\n"+
+		"func BuildLeak() *ContractGenSpec { return nil }\n"+
+		"func RenderLeak(s *ContractGenSpec) {}\n"+
+		"func EndpointLeak() *httpEndpointSpec { return nil }\n"+
+		"func SliceLeak() []*ContractGenSpec { return nil }\n")
+	got := scanExportedSpecLeak(f, "fixture.go")
+	for _, want := range []string{
+		"exported func BuildLeak names IR type ContractGenSpec",
+		"exported func RenderLeak names IR type ContractGenSpec",
+		"exported func EndpointLeak names IR type httpEndpointSpec",
+		"exported func SliceLeak names IR type ContractGenSpec",
+	} {
+		if !strings.Contains(strings.Join(got, "\n"), want) {
+			t.Errorf("A4 detector missed %q; got %v", want, got)
+		}
+	}
+	// GREEN: unexported producer/consumers, an exported method ON the sealed
+	// type (receiver not scanned), and an exported func trading in []byte only.
+	g := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type ContractGenSpec struct{}\n"+
+		"type httpEndpointSpec struct{}\n"+
+		"func buildContractSpec() *ContractGenSpec { return nil }\n"+
+		"func renderHandler(s *ContractGenSpec) ([]byte, error) { return nil, nil }\n"+
+		"func (e *httpEndpointSpec) IsPagination() bool { return false }\n"+
+		"func Generate() ([]byte, error) { return nil, nil }\n")
+	if got := scanExportedSpecLeak(g, "fixture.go"); len(got) != 0 {
+		t.Fatalf("A4 over-flagged sanctioned package-private / []byte surface: %v", got)
 	}
 }
 
@@ -564,7 +766,7 @@ func TestCodegenFunnel_A1b_DetectsRogueConstructionAndCaller(t *testing.T) {
 	// RED: rogue composite-literal + new() construction + a package-level var
 	// function literal calling the ctor outside the funnel (the position-based
 	// scan catches the func-literal that an enclosing-FuncDecl walk would miss).
-	f, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+	f := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type httpEndpointSpec struct{}\n"+
 		"func buildHTTPEndpointSpec() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
 		"func rogueLit() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
@@ -583,7 +785,7 @@ func TestCodegenFunnel_A1b_DetectsRogueConstructionAndCaller(t *testing.T) {
 	}
 	// GREEN: composite literal + new() inside the ctor, ctor call inside the
 	// allowlisted funnel (incl. a nested func literal still within buildHTTPSpec).
-	g, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+	g := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type httpEndpointSpec struct{}\n"+
 		"func buildHTTPEndpointSpec() *httpEndpointSpec { _ = new(httpEndpointSpec); return &httpEndpointSpec{} }\n"+
 		"func buildHTTPSpec() { run := func() { _, _ = buildHTTPEndpointSpec(), 0 }; run() }\n")
@@ -631,22 +833,35 @@ func TestCodegenFunnel_A1b_NoMethodValueIndirectionInProduction(t *testing.T) {
 func TestCodegenFunnel_A2_MarkerDiscriminates(t *testing.T) {
 	t.Parallel()
 	// Positive: both http.Handler emission shapes (ServeHTTP method, any param
-	// name; and the http.HandlerFunc adapter — the B-1 HandlerFunc-only path).
+	// name; and the http.HandlerFunc adapter — the B-1 HandlerFunc-only path),
+	// across the stdlib qualifier, an import alias, a dot-import (no qualifier),
+	// and an unnamed ServeHTTP param (PR #904 F2 — alias/unnamed tolerance).
 	for _, s := range []string{
 		"func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {",
 		"func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {",
 		"Handler: http.HandlerFunc(h.handle),",
 		"mux.Handle(p, http.HandlerFunc(generatedHandler))",
+		// alias import (the F2 bypass)
+		"func (h *Handler) ServeHTTP(w stdhttp.ResponseWriter, r *stdhttp.Request) {",
+		"Handler: stdhttp.HandlerFunc(h.handle),",
+		"mux.Handle(p, nethttp.HandlerFunc(generatedHandler))",
+		// unnamed ServeHTTP param
+		"func (h *Handler) ServeHTTP(stdhttp.ResponseWriter, *stdhttp.Request) {",
+		// dot-import (no qualifier)
+		"func (h *Handler) ServeHTTP(w ResponseWriter, r *Request) {",
 	} {
 		if !codegenHandlerEmitMarker.MatchString(s) {
 			t.Errorf("marker missed http.Handler emission: %q", s)
 		}
 	}
-	// Negative: prose / type references that produce no http.Handler.
+	// Negative: prose / type references that produce no http.Handler, plus the
+	// types.tmpl visit method which carries http.ResponseWriter but is NOT a
+	// ServeHTTP (the ServeHTTP\( prefix guards against that over-match).
 	for _, s := range []string{
 		"// Renders the http.Handler that decodes the request",
 		"bootstrapAuth func(http.Handler) http.Handler",
 		"var h http.Handler = next",
+		"func (r Get200JSONResponse) visitGetResponse(ctx context.Context, w http.ResponseWriter) error {",
 	} {
 		if codegenHandlerEmitMarker.MatchString(s) {
 			t.Errorf("marker over-matched non-emission text: %q", s)
@@ -654,16 +869,24 @@ func TestCodegenFunnel_A2_MarkerDiscriminates(t *testing.T) {
 	}
 }
 
-func TestCodegenFunnel_A3_DetectsHandlerTmplLiteral(t *testing.T) {
+func TestCodegenFunnel_A3_DetectsHandlerTmplConstExpr(t *testing.T) {
 	t.Parallel()
-	f, fset := parseCodegenFixtureSrc(t, "package cellgen\n"+
-		"func render() { _ = \"handler.tmpl\" }\n")
-	if got := scanHandlerTmplLiteralLines(f, fset); len(got) != 1 {
-		t.Fatalf("detector found %d handler.tmpl literals, want 1", len(got))
+	// Positive: a bare literal, a const-ident reference, and a "+" concatenation
+	// all fold to "handler.tmpl" (PR #904 F3 — typed const eval closes the
+	// const/concat blind spot the prior BasicLit-only scan missed).
+	for _, src := range []string{
+		"package cellgen\nfunc render() { _ = \"handler.tmpl\" }\n",
+		"package cellgen\nconst tmpl = \"handler.tmpl\"\nfunc render() { _ = tmpl }\n",
+		"package cellgen\nfunc render() { _ = \"handler\" + \".tmpl\" }\n",
+	} {
+		f, info, fset := typeCheckCodegenFixture(t, src)
+		if got := scanHandlerTmplConstExprLines(f, info, fset); len(got) == 0 {
+			t.Errorf("detector missed handler.tmpl const expr in:\n%s", src)
+		}
 	}
-	// Negative: a different template name is not flagged.
-	g, gfset := parseCodegenFixtureSrc(t, "package cellgen\nfunc render() { _ = \"cell.tmpl\" }\n")
-	if got := scanHandlerTmplLiteralLines(g, gfset); len(got) != 0 {
+	// Negative: a different template name (const-folded) is not flagged.
+	f, info, fset := typeCheckCodegenFixture(t, "package cellgen\nconst tmpl = \"cell.tmpl\"\nfunc render() { _ = tmpl }\n")
+	if got := scanHandlerTmplConstExprLines(f, info, fset); len(got) != 0 {
 		t.Fatalf("detector over-flagged non-handler template: %v", got)
 	}
 }

--- a/tools/archtest/codegen_http_handler_funnel_test.go
+++ b/tools/archtest/codegen_http_handler_funnel_test.go
@@ -95,6 +95,7 @@ var codegenHandlerEmitMarker = regexp.MustCompile(`ServeHTTP\(\s*\w+\s+http\.Res
 //     does not re-open THIS funnel; only the alias form is banned.
 //   - Reflection-built endpoint values are AST-invisible — irrelevant for a
 //     codegen package that constructs structs literally.
+//
 // ---------------------------------------------------------------------------
 func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1a_SpecTypeSealed(t *testing.T) {
 	t.Parallel()
@@ -143,6 +144,7 @@ func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1a_SpecTypeSealed(t *testing.T)
 //     EndpointSpec is an unexported package func returning (*T, error); the
 //     only realistic form is a direct call inside a function body.
 //   - reflect-built values: AST-invisible; irrelevant for literal codegen.
+//
 // ---------------------------------------------------------------------------
 func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1b_SoleConstructorAndCaller(t *testing.T) {
 	t.Parallel()

--- a/tools/archtest/codegen_http_handler_funnel_test.go
+++ b/tools/archtest/codegen_http_handler_funnel_test.go
@@ -43,6 +43,7 @@ import (
 	"go/token"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -72,13 +73,20 @@ var codegenSpecCtorCallerAllowlist = map[string]string{
 	"buildHTTPSpec": "sole funnel: assigns buildHTTPEndpointSpec result to ContractGenSpec.Endpoint",
 }
 
-// codegenHandlerEmitMarker matches the http.Handler interface-method emission
-// `func (h *Handler) ServeHTTP(<param> http.ResponseWriter, ...)` as it appears
-// in handler.tmpl. The marker is the language-mandated shape of an http.Handler
-// implementation (a ServeHTTP method taking http.ResponseWriter is required by
-// the http.Handler interface) — not an arbitrary string convention. Param name
+// codegenHandlerEmitMarker matches the two language-mandated shapes by which
+// Go source produces an http.Handler:
+//
+//   - a ServeHTTP method `func (h *Handler) ServeHTTP(<param> http.ResponseWriter, ...)`
+//     (the http.Handler interface method), and
+//   - the http.HandlerFunc(<fn>) adapter (an http.Handler without a ServeHTTP
+//     method of its own).
+//
+// Both appear in handler.tmpl today; a new generator could emit a handler via
+// EITHER form, so A2 must cover both — the ServeHTTP-only marker would miss a
+// HandlerFunc-only emitter (reviewer B-1). These are structural shapes of the
+// regulated artifact, not arbitrary string conventions. ServeHTTP's param name
 // is matched as \w+ so it is not pinned to the literal "w".
-var codegenHandlerEmitMarker = regexp.MustCompile(`ServeHTTP\(\s*\w+\s+http\.ResponseWriter`)
+var codegenHandlerEmitMarker = regexp.MustCompile(`ServeHTTP\(\s*\w+\s+http\.ResponseWriter|http\.HandlerFunc\(`)
 
 // ---------------------------------------------------------------------------
 // A1a — the type seal is in place and locked (no re-export).
@@ -138,11 +146,18 @@ func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1a_SpecTypeSealed(t *testing.T)
 // (Tests=false) so unit tests that call buildHTTPEndpointSpec directly are out
 // of scope by construction.
 //
+// Detection is by token-position containment (not enclosing-FuncDecl name), so
+// constructions / calls inside function literals, package-level var
+// initializers, or init() — not just top-level FuncDecls — are all covered
+// (reviewer B-2). Both construction forms are detected: httpEndpointSpec{}
+// composite literals AND new(httpEndpointSpec) (reviewer A-1).
+//
 // Blind spots (documented, not detected):
-//   - Method-value / variable indirection: `f := buildHTTPEndpointSpec; f()`
-//     or a package-scope construction/call outside any FuncDecl. buildHTTP-
-//     EndpointSpec is an unexported package func returning (*T, error); the
-//     only realistic form is a direct call inside a function body.
+//   - Method-value indirection: `f := buildHTTPEndpointSpec; f()` — the call
+//     site spells the variable, not the func name. buildHTTPEndpointSpec is an
+//     unexported package func returning (*T, error); a direct call is the only
+//     realistic form. Asserted absent in production by
+//     TestCodegenFunnel_A1b_NoMethodValueIndirectionInProduction.
 //   - reflect-built values: AST-invisible; irrelevant for literal codegen.
 //
 // ---------------------------------------------------------------------------
@@ -153,16 +168,7 @@ func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1b_SoleConstructorAndCaller(t *
 
 	var violations []string
 	_ = Run(t, scope, func(p *Pass) []Diagnostic {
-		var typeFound, ctorFound bool
-		for _, f := range p.Files {
-			if hasTypeSpecNamed(f, codegenSealedSpecType) {
-				typeFound = true
-			}
-			if hasFuncDeclNamed(f, codegenSpecCtorFunc) {
-				ctorFound = true
-			}
-			violations = append(violations, scanSealedSpecConstructionAndCaller(f, p.Rel(f))...)
-		}
+		ctorBody, callerBodies, typeFound, ctorFound := collectA1bRanges(p.Files)
 		if !typeFound {
 			violations = append(violations,
 				"sealed spec type "+codegenSealedSpecType+" not found in contractgen — renamed without updating this lock?")
@@ -170,6 +176,10 @@ func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1b_SoleConstructorAndCaller(t *
 		if !ctorFound {
 			violations = append(violations,
 				"constructor "+codegenSpecCtorFunc+" not found in contractgen — renamed without updating this lock?")
+			return nil // cannot range-check constructions without the constructor body
+		}
+		for _, f := range p.Files {
+			violations = append(violations, scanSealedSpecViolations(f, p.Rel(f), ctorBody, callerBodies)...)
 		}
 		return nil
 	})
@@ -181,15 +191,19 @@ func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1b_SoleConstructorAndCaller(t *
 // A2 — http.Handler emit-template uniqueness across all of tools/codegen/**.
 //
 // AI-robust: Medium (deny-by-default content scan). Text emission of an
-// http.Handler is not type-checkable, so a content scan for the
-// language-mandated ServeHTTP signature is the ceiling tool — not a Soft
-// string-anchor convention. The found-set == {handler.tmpl} assertion also
-// proves .tmpl files are walked (handler.tmpl is itself a .tmpl).
+// http.Handler is not type-checkable, so a content scan for the two
+// language-mandated handler shapes (ServeHTTP method + http.HandlerFunc
+// adapter) is the ceiling tool — not a Soft string-anchor convention. The
+// found-set == {handler.tmpl} assertion also proves .tmpl files are walked
+// (handler.tmpl is itself a .tmpl).
 //
-// Blind spots (documented): a handler emitted with a split / printf-built
-// ServeHTTP signature, an http.HandlerFunc-only handler with no ServeHTTP
-// method, a template in a non-(.tmpl|.go) extension, or re-rendering
-// handler.tmpl by os.ReadFile path (caught instead by A3).
+// Blind spots (documented): a ServeHTTP signature split / printf-built so the
+// contiguous marker text never appears; a template in a non-(.tmpl|.go)
+// extension; or re-rendering handler.tmpl by an os.ReadFile path (that form is
+// caught by A3, which bans the "handler.tmpl" literal outside contractgen).
+// A handler emitted as a raw struct implementing http.Handler without ever
+// writing the ServeHTTP-with-http.ResponseWriter signature contiguously is the
+// residual text-emission ceiling.
 // ---------------------------------------------------------------------------
 func TestCodegenBuildHTTPEndpointSpecSoleCaller_A2_HandlerEmitTemplateUniqueness(t *testing.T) {
 	t.Parallel()
@@ -334,39 +348,85 @@ func scanExportedSealedAlias(f *ast.File) []string {
 	return out
 }
 
-// scanSealedSpecConstructionAndCaller flags, in file f:
-//   - a composite literal of the sealed type outside buildHTTPEndpointSpec, and
-//   - a call to buildHTTPEndpointSpec from a function not in the allowlist.
-func scanSealedSpecConstructionAndCaller(f *ast.File, rel string) []string {
-	var out []string
-	EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
-		if fd.Body == nil || fd.Name == nil {
-			return
+// posRange is a half-open-inclusive token.Pos span [lo, hi] of a function body.
+type posRange struct{ lo, hi token.Pos }
+
+func (r posRange) contains(p token.Pos) bool { return r.lo <= p && p <= r.hi }
+
+func anyContains(rs []posRange, p token.Pos) bool {
+	for _, r := range rs {
+		if r.contains(p) {
+			return true
 		}
-		fn := fd.Name.Name
-		EachInSubtree[ast.CompositeLit](fd.Body, func(cl *ast.CompositeLit) {
-			if id := exprToIdent(cl.Type); id != nil && id.Name == codegenSealedSpecType &&
-				fn != codegenSpecCtorFunc {
-				out = append(out, rel+": "+fn+" constructs "+codegenSealedSpecType+
-					" outside "+codegenSpecCtorFunc+" — the sealed spec has a single sanctioned constructor")
-			}
-		})
-		EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
-			id := exprToIdent(call.Fun)
-			if id == nil || id.Name != codegenSpecCtorFunc {
+	}
+	return false
+}
+
+// collectA1bRanges scans every file for the sole-constructor body
+// (buildHTTPEndpointSpec) and the allowlisted-caller bodies, returning their
+// token.Pos spans plus whether the sealed type and the constructor were found.
+// Position spans (not enclosing-FuncDecl name) let scanSealedSpecViolations
+// catch constructions/calls inside function literals, var initializers, and
+// init() — anywhere the FuncDecl-name approach would miss.
+func collectA1bRanges(files []*ast.File) (ctor posRange, callers []posRange, typeFound, ctorFound bool) {
+	for _, f := range files {
+		if hasTypeSpecNamed(f, codegenSealedSpecType) {
+			typeFound = true
+		}
+		EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+			if fd.Recv != nil || fd.Name == nil || fd.Body == nil {
 				return
 			}
-			if fn == codegenSpecCtorFunc {
-				return // self (no recursion in production, defensive)
+			if fd.Name.Name == codegenSpecCtorFunc {
+				ctorFound = true
+				ctor = posRange{fd.Body.Pos(), fd.Body.End()}
 			}
-			if _, allow := codegenSpecCtorCallerAllowlist[fn]; allow {
-				return
+			if _, ok := codegenSpecCtorCallerAllowlist[fd.Name.Name]; ok {
+				callers = append(callers, posRange{fd.Body.Pos(), fd.Body.End()})
 			}
-			out = append(out, rel+": "+fn+" calls "+codegenSpecCtorFunc+
-				" outside the funnel — only "+allowlistKeys(codegenSpecCtorCallerAllowlist)+" may call it")
 		})
+	}
+	return ctor, callers, typeFound, ctorFound
+}
+
+// scanSealedSpecViolations flags, anywhere in f (by token position):
+//   - a httpEndpointSpec{} composite literal or new(httpEndpointSpec) outside
+//     the sole constructor body, and
+//   - a call to buildHTTPEndpointSpec outside every allowlisted caller body.
+func scanSealedSpecViolations(f *ast.File, rel string, ctor posRange, callers []posRange) []string {
+	var out []string
+	EachInSubtree[ast.CompositeLit](f, func(cl *ast.CompositeLit) {
+		if id := exprToIdent(cl.Type); id != nil && id.Name == codegenSealedSpecType && !ctor.contains(cl.Pos()) {
+			out = append(out, rel+": "+codegenSealedSpecType+
+				"{} constructed outside "+codegenSpecCtorFunc+" — single sanctioned constructor")
+		}
+	})
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+		switch {
+		case isNewOfSealedSpec(call) && !ctor.contains(call.Pos()):
+			out = append(out, rel+": new("+codegenSealedSpecType+
+				") outside "+codegenSpecCtorFunc+" — single sanctioned constructor")
+		case isCallTo(call, codegenSpecCtorFunc) && !anyContains(callers, call.Pos()):
+			out = append(out, rel+": "+codegenSpecCtorFunc+
+				" called outside the funnel — only "+allowlistKeys(codegenSpecCtorCallerAllowlist)+" may call it")
+		}
 	})
 	return out
+}
+
+// isNewOfSealedSpec reports whether call is new(httpEndpointSpec).
+func isNewOfSealedSpec(call *ast.CallExpr) bool {
+	if id := exprToIdent(call.Fun); id == nil || id.Name != "new" || len(call.Args) != 1 {
+		return false
+	}
+	arg := exprToIdent(call.Args[0])
+	return arg != nil && arg.Name == codegenSealedSpecType
+}
+
+// isCallTo reports whether call invokes the bare package-level function name.
+func isCallTo(call *ast.CallExpr, name string) bool {
+	id := exprToIdent(call.Fun)
+	return id != nil && id.Name == name
 }
 
 // scanHandlerTmplLiteralLines returns the line numbers in f where a string
@@ -378,7 +438,7 @@ func scanHandlerTmplLiteralLines(f *ast.File, fset *token.FileSet) []string {
 			return
 		}
 		if v, ok := StringLitValue(lit); ok && v == codegenHandlerTemplate {
-			lines = append(lines, itoa(fset.Position(lit.Pos()).Line))
+			lines = append(lines, strconv.Itoa(fset.Position(lit.Pos()).Line))
 		}
 	})
 	return lines
@@ -418,16 +478,6 @@ func hasTypeSpecNamed(f *ast.File, name string) bool {
 	return found
 }
 
-func hasFuncDeclNamed(f *ast.File, name string) bool {
-	found := false
-	EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
-		if fd.Recv == nil && fd.Name != nil && fd.Name.Name == name {
-			found = true
-		}
-	})
-	return found
-}
-
 func allowlistKeys(m map[string]string) string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -435,21 +485,6 @@ func allowlistKeys(m map[string]string) string {
 	}
 	sort.Strings(keys)
 	return strings.Join(keys, ", ")
-}
-
-// itoa avoids importing strconv solely for line numbers in diagnostics.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var b [20]byte
-	i := len(b)
-	for n > 0 {
-		i--
-		b[i] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(b[i:])
 }
 
 func reportCodegenFunnel(t *testing.T, violations []string) {
@@ -519,47 +554,99 @@ func TestCodegenFunnel_A1a_DetectsExportedReExportAlias(t *testing.T) {
 	}
 }
 
+func scanA1bFixture(f *ast.File) []string {
+	ctor, callers, _, _ := collectA1bRanges([]*ast.File{f})
+	return scanSealedSpecViolations(f, "fixture.go", ctor, callers)
+}
+
 func TestCodegenFunnel_A1b_DetectsRogueConstructionAndCaller(t *testing.T) {
 	t.Parallel()
-	// RED: construction outside the constructor + a call from a non-funnel func.
+	// RED: rogue composite-literal + new() construction + a package-level var
+	// function literal calling the ctor outside the funnel (the position-based
+	// scan catches the func-literal that an enclosing-FuncDecl walk would miss).
 	f, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type httpEndpointSpec struct{}\n"+
 		"func buildHTTPEndpointSpec() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
-		"func rogue() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
-		"func notTheFunnel() { _, _ = buildHTTPEndpointSpec(), 0 }\n")
-	got := scanSealedSpecConstructionAndCaller(f, "fixture.go")
-	if !containsSubstr(got, "rogue constructs httpEndpointSpec") {
-		t.Errorf("missed rogue construction; got %v", got)
+		"func rogueLit() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
+		"func rogueNew() *httpEndpointSpec { return new(httpEndpointSpec) }\n"+
+		"var rogueVar = func() { _, _ = buildHTTPEndpointSpec(), 0 }\n")
+	got := scanA1bFixture(f)
+	joined := strings.Join(got, "\n")
+	for _, want := range []string{
+		codegenSealedSpecType + "{} constructed outside",
+		"new(" + codegenSealedSpecType + ") outside",
+		codegenSpecCtorFunc + " called outside the funnel",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("A1b detector missed %q; got %v", want, got)
+		}
 	}
-	if !containsSubstr(got, "notTheFunnel calls buildHTTPEndpointSpec") {
-		t.Errorf("missed rogue caller; got %v", got)
-	}
-	// GREEN: construction inside the constructor + call from the allowlisted funnel.
+	// GREEN: composite literal + new() inside the ctor, ctor call inside the
+	// allowlisted funnel (incl. a nested func literal still within buildHTTPSpec).
 	g, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
 		"type httpEndpointSpec struct{}\n"+
-		"func buildHTTPEndpointSpec() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
-		"func buildHTTPSpec() { _, _ = buildHTTPEndpointSpec(), 0 }\n")
-	if got := scanSealedSpecConstructionAndCaller(g, "fixture.go"); len(got) != 0 {
-		t.Errorf("over-flagged sanctioned construction/caller: %v", got)
+		"func buildHTTPEndpointSpec() *httpEndpointSpec { _ = new(httpEndpointSpec); return &httpEndpointSpec{} }\n"+
+		"func buildHTTPSpec() { run := func() { _, _ = buildHTTPEndpointSpec(), 0 }; run() }\n")
+	if got := scanA1bFixture(g); len(got) != 0 {
+		t.Errorf("A1b over-flagged sanctioned construction/caller: %v", got)
+	}
+}
+
+// TestCodegenFunnel_A1b_NoMethodValueIndirectionInProduction asserts the one
+// documented A1b blind spot — method-value indirection `f := buildHTTPEndpointSpec`
+// — does not occur in contractgen production source, so the gap is documented
+// AND verified empty (ai-robust.md §盲区自检).
+func TestCodegenFunnel_A1b_NoMethodValueIndirectionInProduction(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	scope := DirsScope(root, []string{"tools/codegen/contractgen"})
+	var hits []string
+	_ = Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			// A value reference to buildHTTPEndpointSpec that is NOT the callee of
+			// a CallExpr (i.e. the func used as a value: assignment, arg, return).
+			calleeIdents := map[*ast.Ident]bool{}
+			EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+				if id := exprToIdent(call.Fun); id != nil {
+					calleeIdents[id] = true
+				}
+			})
+			EachInSubtree[ast.Ident](f, func(id *ast.Ident) {
+				if id.Name == codegenSpecCtorFunc && !calleeIdents[id] {
+					hits = append(hits, rel+": value reference to "+codegenSpecCtorFunc)
+				}
+			})
+		}
+		return nil
+	})
+	// The decl of buildHTTPEndpointSpec is itself an Ident occurrence that is not
+	// a callee; tolerate exactly the declaration, flag any additional value ref.
+	if len(hits) > 1 {
+		t.Errorf("A1b blind spot exploited: method-value reference(s) to %s in production: %v",
+			codegenSpecCtorFunc, hits)
 	}
 }
 
 func TestCodegenFunnel_A2_MarkerDiscriminates(t *testing.T) {
 	t.Parallel()
-	// Positive: the canonical http.Handler emission (any param name).
+	// Positive: both http.Handler emission shapes (ServeHTTP method, any param
+	// name; and the http.HandlerFunc adapter — the B-1 HandlerFunc-only path).
 	for _, s := range []string{
 		"func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {",
 		"func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {",
+		"Handler: http.HandlerFunc(h.handle),",
+		"mux.Handle(p, http.HandlerFunc(generatedHandler))",
 	} {
 		if !codegenHandlerEmitMarker.MatchString(s) {
 			t.Errorf("marker missed http.Handler emission: %q", s)
 		}
 	}
-	// Negative: prose / type references that are NOT a ServeHTTP method def.
+	// Negative: prose / type references that produce no http.Handler.
 	for _, s := range []string{
 		"// Renders the http.Handler that decodes the request",
 		"bootstrapAuth func(http.Handler) http.Handler",
-		"Handler: http.HandlerFunc(h.handle),",
+		"var h http.Handler = next",
 	} {
 		if codegenHandlerEmitMarker.MatchString(s) {
 			t.Errorf("marker over-matched non-emission text: %q", s)
@@ -579,13 +666,4 @@ func TestCodegenFunnel_A3_DetectsHandlerTmplLiteral(t *testing.T) {
 	if got := scanHandlerTmplLiteralLines(g, gfset); len(got) != 0 {
 		t.Fatalf("detector over-flagged non-handler template: %v", got)
 	}
-}
-
-func containsSubstr(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if strings.Contains(h, needle) {
-			return true
-		}
-	}
-	return false
 }

--- a/tools/archtest/codegen_http_handler_funnel_test.go
+++ b/tools/archtest/codegen_http_handler_funnel_test.go
@@ -1,0 +1,589 @@
+package archtest
+
+// INVARIANT: CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01
+//
+// Every HTTP-handler-emitting codegen path under tools/codegen/** MUST flow
+// through the contractgen funnel buildHTTPEndpointSpec → handler.tmpl. This
+// archtest is the downstream/breadth half of the FMT-34 upstream funnel
+// (kernel/governance/rules_fmt.go::validateFMT34): FMT-34's auth-on-internal
+// guard validateAuthOnInternalPath runs unconditionally inside
+// buildHTTPEndpointSpec, so if a second generator (cellgen / markergen / a
+// future one) emitted an http.Handler without going through that funnel,
+// FMT-34's "sole HTTP codegen entry" premise would silently degrade.
+//
+// Hard收口 + archtest closure (three legs; see the per-test godoc for ratings):
+//
+//	type seal (compile-time Hard): contractgen.httpEndpointSpec is unexported.
+//	  ContractGenSpec.Endpoint is *httpEndpointSpec, so no out-of-package code
+//	  can construct a non-nil Endpoint → cannot drive handler.tmpl with a
+//	  hand-built (FMT-34-unvalidated) spec. This is the load-bearing Hard
+//	  upgrade #690 calls the "sealed interface / 单一抽象函数" path.
+//
+//	A1a — the seal is locked: ContractGenSpec.Endpoint's base type is the
+//	      unexported sealed name, and no exported alias re-exports it.
+//	A1b — within contractgen (Go has no intra-package visibility), the sealed
+//	      type is constructed only inside buildHTTPEndpointSpec, and
+//	      buildHTTPEndpointSpec is called only from the allowlisted funnel.
+//	A2  — across all of tools/codegen/**, the only source file emitting an
+//	      http.Handler implementation (ServeHTTP method) is handler.tmpl.
+//	A3  — handler.tmpl is rendered only inside the contractgen package, whose
+//	      only HTTP-spec construction path is buildHTTPEndpointSpec.
+//
+// AI-robust ceiling (honest): the type seal is Hard for the cross-package
+// bypass. A1b/A2/A3 cover what the Go type system fundamentally cannot — a
+// second intra-package constructor (no package-internal visibility) and text
+// emission of an http.Handler (a generated string is not type-checkable). No
+// lower-cost Hard path exists for those, so there is no follow-up Hard-ization
+// backlog; the archtest is the ceiling. (ai-robust.md §Review checklist:
+// "Medium 且无低成本升 Hard 路径 → 保留".)
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	// codegenSealedSpecType is the unexported name of the HTTP endpoint spec
+	// struct in package contractgen. Renaming the sealed holder must update
+	// this constant together with A1a's re-export check — the name is the lock.
+	codegenSealedSpecType = "httpEndpointSpec"
+	// codegenSpecCtorFunc is the sole constructor of codegenSealedSpecType and
+	// the FMT-34 funnel entry; "SOLE-CALLER" in the rule ID refers to it.
+	codegenSpecCtorFunc = "buildHTTPEndpointSpec"
+	// codegenHandlerTemplate is the only template that emits an http.Handler.
+	codegenHandlerTemplate = "handler.tmpl"
+	// codegenHandlerTmplRel is the one allowlisted file permitted to carry the
+	// http.Handler-emit marker (A2).
+	codegenHandlerTmplRel = "tools/codegen/contractgen/templates/handler.tmpl"
+	// codegenContractgenPrefix is the contractgen package subtree.
+	codegenContractgenPrefix = "tools/codegen/contractgen/"
+)
+
+// codegenSpecCtorCallerAllowlist names the production functions permitted to
+// CALL buildHTTPEndpointSpec (A1b ②). buildHTTPSpec is the single funnel that
+// assigns the result to ContractGenSpec.Endpoint. (Test files call it directly
+// for unit assertions; they are out of scope — production-only walk.)
+var codegenSpecCtorCallerAllowlist = map[string]string{
+	"buildHTTPSpec": "sole funnel: assigns buildHTTPEndpointSpec result to ContractGenSpec.Endpoint",
+}
+
+// codegenHandlerEmitMarker matches the http.Handler interface-method emission
+// `func (h *Handler) ServeHTTP(<param> http.ResponseWriter, ...)` as it appears
+// in handler.tmpl. The marker is the language-mandated shape of an http.Handler
+// implementation (a ServeHTTP method taking http.ResponseWriter is required by
+// the http.Handler interface) — not an arbitrary string convention. Param name
+// is matched as \w+ so it is not pinned to the literal "w".
+var codegenHandlerEmitMarker = regexp.MustCompile(`ServeHTTP\(\s*\w+\s+http\.ResponseWriter`)
+
+// ---------------------------------------------------------------------------
+// A1a — the type seal is in place and locked (no re-export).
+//
+// AI-robust: this test asserts the compile-time Hard fact (sealed unexported
+// type as the Endpoint field type) plus the re-export must-check
+// (ai-robust.md §"JSON-wire-decode struct sealing": 任意名 re-export 必查点).
+// Before the seal lands this test is RED — ContractGenSpec.Endpoint is the
+// exported *HTTPEndpointSpec — which drives the Wave-1 RED → Wave-2 GREEN flip.
+//
+// Blind spots (Go type system / AST ceiling; documented, not detected here):
+//   - A definition `type Exported httpEndpointSpec` (NOT an alias) creates a
+//     distinct type that is NOT assignable to ContractGenSpec.Endpoint, so it
+//     does not re-open THIS funnel; only the alias form is banned.
+//   - Reflection-built endpoint values are AST-invisible — irrelevant for a
+//     codegen package that constructs structs literally.
+// ---------------------------------------------------------------------------
+func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1a_SpecTypeSealed(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	scope := DirsScope(root, []string{"tools/codegen/contractgen"})
+
+	var violations []string
+	_ = Run(t, scope, func(p *Pass) []Diagnostic {
+		var endpointFound bool
+		var endpointBase string
+		for _, f := range p.Files {
+			if base, ok := contractGenSpecEndpointBaseType(f); ok {
+				endpointFound = true
+				endpointBase = base
+			}
+			violations = append(violations, scanExportedSealedAlias(f)...)
+		}
+		if !endpointFound {
+			violations = append(violations,
+				"ContractGenSpec.Endpoint field not found in contractgen — has the spec type been renamed?")
+			return nil
+		}
+		if endpointBase != codegenSealedSpecType {
+			violations = append(violations, "ContractGenSpec.Endpoint base type is "+endpointBase+
+				"; must be the sealed unexported type "+codegenSealedSpecType+
+				" (exported spec types let any package hand-build an FMT-34-unvalidated Endpoint)")
+		}
+		return nil
+	})
+
+	reportCodegenFunnel(t, violations)
+}
+
+// ---------------------------------------------------------------------------
+// A1b — sole constructor + sole caller, within the contractgen package.
+//
+// AI-robust: Medium. Go has no intra-package visibility, so a second
+// constructor of the (unexported) sealed type or a non-funnel caller is not
+// compile-rejectable; this archtest is the ceiling. Production-only walk
+// (Tests=false) so unit tests that call buildHTTPEndpointSpec directly are out
+// of scope by construction.
+//
+// Blind spots (documented, not detected):
+//   - Method-value / variable indirection: `f := buildHTTPEndpointSpec; f()`
+//     or a package-scope construction/call outside any FuncDecl. buildHTTP-
+//     EndpointSpec is an unexported package func returning (*T, error); the
+//     only realistic form is a direct call inside a function body.
+//   - reflect-built values: AST-invisible; irrelevant for literal codegen.
+// ---------------------------------------------------------------------------
+func TestCodegenBuildHTTPEndpointSpecSoleCaller_A1b_SoleConstructorAndCaller(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	scope := DirsScope(root, []string{"tools/codegen/contractgen"})
+
+	var violations []string
+	_ = Run(t, scope, func(p *Pass) []Diagnostic {
+		var typeFound, ctorFound bool
+		for _, f := range p.Files {
+			if hasTypeSpecNamed(f, codegenSealedSpecType) {
+				typeFound = true
+			}
+			if hasFuncDeclNamed(f, codegenSpecCtorFunc) {
+				ctorFound = true
+			}
+			violations = append(violations, scanSealedSpecConstructionAndCaller(f, p.Rel(f))...)
+		}
+		if !typeFound {
+			violations = append(violations,
+				"sealed spec type "+codegenSealedSpecType+" not found in contractgen — renamed without updating this lock?")
+		}
+		if !ctorFound {
+			violations = append(violations,
+				"constructor "+codegenSpecCtorFunc+" not found in contractgen — renamed without updating this lock?")
+		}
+		return nil
+	})
+
+	reportCodegenFunnel(t, violations)
+}
+
+// ---------------------------------------------------------------------------
+// A2 — http.Handler emit-template uniqueness across all of tools/codegen/**.
+//
+// AI-robust: Medium (deny-by-default content scan). Text emission of an
+// http.Handler is not type-checkable, so a content scan for the
+// language-mandated ServeHTTP signature is the ceiling tool — not a Soft
+// string-anchor convention. The found-set == {handler.tmpl} assertion also
+// proves .tmpl files are walked (handler.tmpl is itself a .tmpl).
+//
+// Blind spots (documented): a handler emitted with a split / printf-built
+// ServeHTTP signature, an http.HandlerFunc-only handler with no ServeHTTP
+// method, a template in a non-(.tmpl|.go) extension, or re-rendering
+// handler.tmpl by os.ReadFile path (caught instead by A3).
+// ---------------------------------------------------------------------------
+func TestCodegenBuildHTTPEndpointSpecSoleCaller_A2_HandlerEmitTemplateUniqueness(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	scope := DirsScope(root, []string{"tools/codegen"},
+		MatchRels(func(rel string) bool {
+			if strings.Contains(rel, "/testdata/") {
+				return false // golden snapshots are codegen output, not generator source
+			}
+			if strings.HasSuffix(rel, "_test.go") {
+				return false
+			}
+			return strings.HasSuffix(rel, ".tmpl") || strings.HasSuffix(rel, ".go")
+		}),
+	)
+
+	var emitFiles []string
+	EachContentFile(t, scope, []string{".tmpl", ".go"}, func(_ *testing.T, fc ContentContext) {
+		if codegenHandlerEmitMarker.Match(fc.Bytes) {
+			emitFiles = append(emitFiles, fc.Rel)
+		}
+	})
+	sort.Strings(emitFiles)
+
+	want := []string{codegenHandlerTmplRel}
+	if !equalStringSlices(emitFiles, want) {
+		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A2): files emitting an http.Handler "+
+			"(ServeHTTP method) under tools/codegen/** = %v; want exactly %v. A new HTTP-handler-emitting "+
+			"generator path must route through buildHTTPEndpointSpec (contractgen handler.tmpl), not a "+
+			"second template/string.", emitFiles, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A3 — handler.tmpl is rendered only inside the contractgen package.
+//
+// AI-robust: Medium. Complements A2's emit-side check with the render side:
+// even though A2 guarantees handler.tmpl is the only http.Handler emitter, an
+// out-of-package generator could re-render it (by path) with a hand-built,
+// FMT-34-unvalidated spec. Banning the "handler.tmpl" template-name literal
+// outside contractgen closes that. A positive sanity (≥1 occurrence inside
+// contractgen) prevents a vacuous pass if the template were renamed/removed.
+//
+// Blind spot (documented): the template name reached via a const/variable
+// rather than a string literal, or a computed path.
+// ---------------------------------------------------------------------------
+func TestCodegenBuildHTTPEndpointSpecSoleCaller_A3_HandlerTmplRenderedOnlyInContractgen(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	outsideScope := DirsScope(root, []string{"tools/codegen"},
+		MatchRels(func(rel string) bool {
+			if strings.Contains(rel, "/testdata/") || strings.HasSuffix(rel, "_test.go") {
+				return false
+			}
+			if !strings.HasSuffix(rel, ".go") {
+				return false
+			}
+			return !strings.HasPrefix(rel, codegenContractgenPrefix)
+		}),
+	)
+	var outside []string
+	_ = Run(t, outsideScope, func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			for _, line := range scanHandlerTmplLiteralLines(f, p.Fset) {
+				outside = append(outside, p.Rel(f)+":"+line)
+			}
+		}
+		return nil
+	})
+	for _, v := range outside {
+		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A3): %s references template %q outside "+
+			"the contractgen package — handler.tmpl must be rendered only by the buildHTTPEndpointSpec funnel.",
+			v, codegenHandlerTemplate)
+	}
+
+	// Positive sanity: the funnel target must exist inside contractgen, else
+	// the guard above passes vacuously.
+	insideScope := DirsScope(root, []string{"tools/codegen/contractgen"},
+		MatchRels(func(rel string) bool {
+			return strings.HasSuffix(rel, ".go") && !strings.HasSuffix(rel, "_test.go")
+		}),
+	)
+	var insideCount int
+	_ = Run(t, insideScope, func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			insideCount += len(scanHandlerTmplLiteralLines(f, p.Fset))
+		}
+		return nil
+	})
+	if insideCount == 0 {
+		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A3): template %q is never rendered inside "+
+			"contractgen — A3 would pass vacuously; update the rule if the template was renamed/removed.",
+			codegenHandlerTemplate)
+	}
+}
+
+// ===========================================================================
+// Detection helpers (shared by production scans above and the reverse
+// self-checks below). Each operates on a single *ast.File so the same logic
+// runs over Pass.Files and over inline-parsed fixture sources.
+// ===========================================================================
+
+// contractGenSpecEndpointBaseType returns the base type name of the Endpoint
+// field of the ContractGenSpec struct in f (dereferencing one *), and ok=true
+// if that struct/field is present in f.
+func contractGenSpecEndpointBaseType(f *ast.File) (string, bool) {
+	var base string
+	var ok bool
+	EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+		if ts.Name == nil || ts.Name.Name != "ContractGenSpec" {
+			return
+		}
+		st, isStruct := ts.Type.(*ast.StructType)
+		if !isStruct || st.Fields == nil {
+			return
+		}
+		for _, field := range st.Fields.List {
+			if !fieldHasName(field, "Endpoint") {
+				continue
+			}
+			base = starExprBaseIdentName(field.Type)
+			ok = true
+		}
+	})
+	return base, ok
+}
+
+// scanExportedSealedAlias flags an exported type alias `type X = httpEndpointSpec`
+// (the re-export form that re-opens cross-package construction).
+func scanExportedSealedAlias(f *ast.File) []string {
+	var out []string
+	EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+		if ts.Name == nil || !ts.Assign.IsValid() || !ts.Name.IsExported() {
+			return
+		}
+		if id := exprToIdent(ts.Type); id != nil && id.Name == codegenSealedSpecType {
+			out = append(out, "exported alias "+ts.Name.Name+" = "+codegenSealedSpecType+
+				" re-exports the sealed spec type — drop it (it re-opens cross-package construction)")
+		}
+	})
+	return out
+}
+
+// scanSealedSpecConstructionAndCaller flags, in file f:
+//   - a composite literal of the sealed type outside buildHTTPEndpointSpec, and
+//   - a call to buildHTTPEndpointSpec from a function not in the allowlist.
+func scanSealedSpecConstructionAndCaller(f *ast.File, rel string) []string {
+	var out []string
+	EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+		if fd.Body == nil || fd.Name == nil {
+			return
+		}
+		fn := fd.Name.Name
+		EachInSubtree[ast.CompositeLit](fd.Body, func(cl *ast.CompositeLit) {
+			if id := exprToIdent(cl.Type); id != nil && id.Name == codegenSealedSpecType &&
+				fn != codegenSpecCtorFunc {
+				out = append(out, rel+": "+fn+" constructs "+codegenSealedSpecType+
+					" outside "+codegenSpecCtorFunc+" — the sealed spec has a single sanctioned constructor")
+			}
+		})
+		EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
+			id := exprToIdent(call.Fun)
+			if id == nil || id.Name != codegenSpecCtorFunc {
+				return
+			}
+			if fn == codegenSpecCtorFunc {
+				return // self (no recursion in production, defensive)
+			}
+			if _, allow := codegenSpecCtorCallerAllowlist[fn]; allow {
+				return
+			}
+			out = append(out, rel+": "+fn+" calls "+codegenSpecCtorFunc+
+				" outside the funnel — only "+allowlistKeys(codegenSpecCtorCallerAllowlist)+" may call it")
+		})
+	})
+	return out
+}
+
+// scanHandlerTmplLiteralLines returns the line numbers in f where a string
+// literal equal to "handler.tmpl" appears.
+func scanHandlerTmplLiteralLines(f *ast.File, fset *token.FileSet) []string {
+	var lines []string
+	EachInSubtree[ast.BasicLit](f, func(lit *ast.BasicLit) {
+		if lit.Kind != token.STRING {
+			return
+		}
+		if v, ok := StringLitValue(lit); ok && v == codegenHandlerTemplate {
+			lines = append(lines, itoa(fset.Position(lit.Pos()).Line))
+		}
+	})
+	return lines
+}
+
+// ---- small AST utilities (single type assertions, no range-over-AST-slice) --
+
+func fieldHasName(field *ast.Field, name string) bool {
+	for _, n := range field.Names {
+		if n != nil && n.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func starExprBaseIdentName(expr ast.Expr) string {
+	if se, ok := expr.(*ast.StarExpr); ok {
+		if id := exprToIdent(se.X); id != nil {
+			return id.Name
+		}
+		return ""
+	}
+	if id := exprToIdent(expr); id != nil {
+		return id.Name
+	}
+	return ""
+}
+
+func hasTypeSpecNamed(f *ast.File, name string) bool {
+	found := false
+	EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+		if ts.Name != nil && ts.Name.Name == name {
+			found = true
+		}
+	})
+	return found
+}
+
+func hasFuncDeclNamed(f *ast.File, name string) bool {
+	found := false
+	EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+		if fd.Recv == nil && fd.Name != nil && fd.Name.Name == name {
+			found = true
+		}
+	})
+	return found
+}
+
+func allowlistKeys(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+// itoa avoids importing strconv solely for line numbers in diagnostics.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+func reportCodegenFunnel(t *testing.T, violations []string) {
+	t.Helper()
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01: %s", v)
+	}
+}
+
+// ===========================================================================
+// Reverse self-checks — prove the detectors fire on planted violations
+// (ai-robust.md §"工具选定后强制盲区自检": detection must be demonstrated, not
+// assumed). Inline-parsed fixtures keep the proofs hermetic.
+// ===========================================================================
+
+func parseCodegenFixtureSrc(t *testing.T, src string) (*ast.File, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return f, fset
+}
+
+func TestCodegenFunnel_A1a_DetectsExportedEndpointType(t *testing.T) {
+	t.Parallel()
+	// RED fixture: Endpoint typed with an EXPORTED spec type.
+	f, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type HTTPEndpointSpec struct{}\n"+
+		"type ContractGenSpec struct { Endpoint *HTTPEndpointSpec }\n")
+	base, ok := contractGenSpecEndpointBaseType(f)
+	if !ok {
+		t.Fatal("detector failed to locate ContractGenSpec.Endpoint")
+	}
+	if base != "HTTPEndpointSpec" {
+		t.Fatalf("base type = %q, want HTTPEndpointSpec", base)
+	}
+	if base == codegenSealedSpecType {
+		t.Fatal("exported type must not equal the sealed unexported name (would mask the violation)")
+	}
+	// GREEN fixture: sealed unexported type passes.
+	g, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type httpEndpointSpec struct{}\n"+
+		"type ContractGenSpec struct { Endpoint *httpEndpointSpec }\n")
+	gb, _ := contractGenSpecEndpointBaseType(g)
+	if gb != codegenSealedSpecType {
+		t.Fatalf("sealed fixture base = %q, want %q", gb, codegenSealedSpecType)
+	}
+}
+
+func TestCodegenFunnel_A1a_DetectsExportedReExportAlias(t *testing.T) {
+	t.Parallel()
+	f, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type httpEndpointSpec struct{}\n"+
+		"type PublicEndpointSpec = httpEndpointSpec\n")
+	if got := scanExportedSealedAlias(f); len(got) == 0 {
+		t.Fatal("detector missed exported alias re-export of the sealed type")
+	}
+	// Negative: an unexported alias is harmless (not a cross-package re-export).
+	g, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type httpEndpointSpec struct{}\n"+
+		"type localAlias = httpEndpointSpec\n")
+	if got := scanExportedSealedAlias(g); len(got) != 0 {
+		t.Fatalf("detector over-flagged unexported alias: %v", got)
+	}
+}
+
+func TestCodegenFunnel_A1b_DetectsRogueConstructionAndCaller(t *testing.T) {
+	t.Parallel()
+	// RED: construction outside the constructor + a call from a non-funnel func.
+	f, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type httpEndpointSpec struct{}\n"+
+		"func buildHTTPEndpointSpec() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
+		"func rogue() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
+		"func notTheFunnel() { _, _ = buildHTTPEndpointSpec(), 0 }\n")
+	got := scanSealedSpecConstructionAndCaller(f, "fixture.go")
+	if !containsSubstr(got, "rogue constructs httpEndpointSpec") {
+		t.Errorf("missed rogue construction; got %v", got)
+	}
+	if !containsSubstr(got, "notTheFunnel calls buildHTTPEndpointSpec") {
+		t.Errorf("missed rogue caller; got %v", got)
+	}
+	// GREEN: construction inside the constructor + call from the allowlisted funnel.
+	g, _ := parseCodegenFixtureSrc(t, "package contractgen\n"+
+		"type httpEndpointSpec struct{}\n"+
+		"func buildHTTPEndpointSpec() *httpEndpointSpec { return &httpEndpointSpec{} }\n"+
+		"func buildHTTPSpec() { _, _ = buildHTTPEndpointSpec(), 0 }\n")
+	if got := scanSealedSpecConstructionAndCaller(g, "fixture.go"); len(got) != 0 {
+		t.Errorf("over-flagged sanctioned construction/caller: %v", got)
+	}
+}
+
+func TestCodegenFunnel_A2_MarkerDiscriminates(t *testing.T) {
+	t.Parallel()
+	// Positive: the canonical http.Handler emission (any param name).
+	for _, s := range []string{
+		"func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {",
+		"func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {",
+	} {
+		if !codegenHandlerEmitMarker.MatchString(s) {
+			t.Errorf("marker missed http.Handler emission: %q", s)
+		}
+	}
+	// Negative: prose / type references that are NOT a ServeHTTP method def.
+	for _, s := range []string{
+		"// Renders the http.Handler that decodes the request",
+		"bootstrapAuth func(http.Handler) http.Handler",
+		"Handler: http.HandlerFunc(h.handle),",
+	} {
+		if codegenHandlerEmitMarker.MatchString(s) {
+			t.Errorf("marker over-matched non-emission text: %q", s)
+		}
+	}
+}
+
+func TestCodegenFunnel_A3_DetectsHandlerTmplLiteral(t *testing.T) {
+	t.Parallel()
+	f, fset := parseCodegenFixtureSrc(t, "package cellgen\n"+
+		"func render() { _ = \"handler.tmpl\" }\n")
+	if got := scanHandlerTmplLiteralLines(f, fset); len(got) != 1 {
+		t.Fatalf("detector found %d handler.tmpl literals, want 1", len(got))
+	}
+	// Negative: a different template name is not flagged.
+	g, gfset := parseCodegenFixtureSrc(t, "package cellgen\nfunc render() { _ = \"cell.tmpl\" }\n")
+	if got := scanHandlerTmplLiteralLines(g, gfset); len(got) != 0 {
+		t.Fatalf("detector over-flagged non-handler template: %v", got)
+	}
+}
+
+func containsSubstr(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.Contains(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/codegen/contractgen/builder.go
+++ b/tools/codegen/contractgen/builder.go
@@ -16,14 +16,14 @@ import (
 	"github.com/ghbvf/gocell/tools/codegen/internal/pathx"
 )
 
-// BuildContractSpec projects a single contract.yaml + its schemaRefs into a
+// buildContractSpec projects a single contract.yaml + its schemaRefs into a
 // ContractGenSpec. Returns error when:
 //   - contract not found in project
 //   - Codegen flag is false
 //   - schemaRef parsing fails
 //   - kind=http but http endpoint missing
 //   - kind=event but payload schemaRef missing
-func BuildContractSpec(rootDir string, p *metadata.ProjectMeta, contractID string) (*ContractGenSpec, error) {
+func buildContractSpec(rootDir string, p *metadata.ProjectMeta, contractID string) (*ContractGenSpec, error) {
 	if p == nil {
 		return nil, fmt.Errorf("contractgen build: project is nil")
 	}
@@ -67,7 +67,7 @@ func BuildContractSpec(rootDir string, p *metadata.ProjectMeta, contractID strin
 		}
 	case "command", "projection":
 		// These kinds are in the closed set (CONTRACT-KINDS-CLOSED-SET-01) but do
-		// not yet have dedicated generators. BuildContractSpec accepts them so that
+		// not yet have dedicated generators. buildContractSpec accepts them so that
 		// generateOneContract can emit types_gen.go + iface_gen.go (shared scaffolding)
 		// without hard-failing. No spec/handler/subscription file is emitted.
 		// When a full generator is added, add the corresponding case here.

--- a/tools/codegen/contractgen/builder.go
+++ b/tools/codegen/contractgen/builder.go
@@ -213,7 +213,14 @@ func hasDTONamed(dtos []DTOSpec, name string) bool {
 	return false
 }
 
-// buildHTTPEndpointSpec constructs the HTTPEndpointSpec including pagination detection.
+// buildHTTPEndpointSpec is the SOLE constructor of the sealed httpEndpointSpec
+// and the FMT-34 funnel entry (it calls validateAuthOnInternalPath). It is
+// called only from buildHTTPSpec, which assigns the result to
+// ContractGenSpec.Endpoint. The "sole constructor / sole caller" invariant is
+// locked by archtest CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A1b); the
+// cross-package bypass is sealed by httpEndpointSpec being unexported.
+//
+// It constructs the httpEndpointSpec including pagination detection.
 // HasBody is true only when the HTTP method is POST/PUT/PATCH AND the contract declares
 // a schemaRefs.request — POST/PATCH endpoints that accept only path params (no request
 // body schema) must not call DecodeJSONStrict (an empty body would be rejected).
@@ -222,7 +229,7 @@ func buildHTTPEndpointSpec(
 	contract *metadata.ContractMeta,
 	http *metadata.HTTPTransportMeta,
 	pathParams, queryParams []ParamSpec,
-) (*HTTPEndpointSpec, error) {
+) (*httpEndpointSpec, error) {
 	handlerMethod := goPascalCase(domainLastSegment(contract.ID))
 	methodHasBody := http.Method == "POST" || http.Method == "PUT" || http.Method == "PATCH"
 	hasBody := methodHasBody && contract.SchemaRefs.Request != ""
@@ -249,7 +256,7 @@ func buildHTTPEndpointSpec(
 		return nil, err
 	}
 
-	spec := &HTTPEndpointSpec{
+	spec := &httpEndpointSpec{
 		Method:                  http.Method,
 		Path:                    http.Path,
 		SuccessCode:             http.SuccessStatus,
@@ -309,7 +316,11 @@ func validateAuthServiceOwned(contractID string, auth metadata.HTTPAuthMeta) err
 // FMT-34 (kernel/governance/rules_fmt.go::validateFMT34 is the downstream
 // Medium half). validateAuthOnInternalPath is called unconditionally inside
 // buildHTTPEndpointSpec — the sole production HTTP codegen entry — so any
-// HTTP contract generation path triggers this funnel automatically.
+// HTTP contract generation path triggers this funnel automatically. That
+// "sole entry" premise is no longer grep-only: it is enforced by the sealed
+// (unexported) httpEndpointSpec type plus archtest
+// CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (sole constructor/caller +
+// http.Handler emit-uniqueness across tools/codegen/**).
 //
 // Uses metadata.IsInternalHTTPPath as the single oracle for the /internal/v1
 // predicate (shared with governance + runtime), preventing prefix-string
@@ -380,7 +391,7 @@ func validateAuthClientsOnly(
 // Any non-cursor/non-limit query params land in ExtraQueryParams so the
 // handler template can route them through per-param parsing while
 // cursor/limit always go through pkg/httputil.ParsePageParams.
-func detectPagination(spec *HTTPEndpointSpec) error {
+func detectPagination(spec *httpEndpointSpec) error {
 	hasCursor, hasLimit := false, false
 	var extras []ParamSpec
 	for _, q := range spec.QueryParams {

--- a/tools/codegen/contractgen/builder_test.go
+++ b/tools/codegen/contractgen/builder_test.go
@@ -475,10 +475,10 @@ func TestBuildQueryParams_BoundaryValues(t *testing.T) {
 	}
 }
 
-// --- BuildContractSpec tests ---
+// --- buildContractSpec tests ---
 
 // TestBuildContractSpec_CommandKind_Skips documents the graceful-skip path for
-// kind=command (and kind=projection): BuildContractSpec returns a valid spec with
+// kind=command (and kind=projection): buildContractSpec returns a valid spec with
 // no error and no HTTP/event-specific fields populated. generateOneContract will
 // only emit types_gen.go + iface_gen.go for these kinds.
 func TestBuildContractSpec_CommandKind_Skips(t *testing.T) {
@@ -493,9 +493,9 @@ func TestBuildContractSpec_CommandKind_Skips(t *testing.T) {
 			},
 		},
 	}
-	spec, err := BuildContractSpec("", p, "command.device.provision.v1")
+	spec, err := buildContractSpec("", p, "command.device.provision.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec should not error for kind=command, got: %v", err)
+		t.Fatalf("buildContractSpec should not error for kind=command, got: %v", err)
 	}
 	if spec == nil {
 		t.Fatal("expected non-nil spec")
@@ -526,9 +526,9 @@ func TestBuildContractSpec_ProjectionKind_Skips(t *testing.T) {
 			},
 		},
 	}
-	spec, err := BuildContractSpec("", p, "projection.device.inventory.v1")
+	spec, err := buildContractSpec("", p, "projection.device.inventory.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec should not error for kind=projection, got: %v", err)
+		t.Fatalf("buildContractSpec should not error for kind=projection, got: %v", err)
 	}
 	if spec == nil {
 		t.Fatal("expected non-nil spec")
@@ -604,7 +604,7 @@ func TestBuildHTTPEndpointSpec_HasBody_PostWithRequestSchema(t *testing.T) {
 	}
 }
 
-// TestBuildContractSpec_Event_TopicAndHandlerMethod verifies that BuildContractSpec
+// TestBuildContractSpec_Event_TopicAndHandlerMethod verifies that buildContractSpec
 // correctly populates the EventEndpointSpec.Topic and HandlerMethod fields for an
 // event contract. Topic == ContractID after PR-CODEGEN-FULL-MIGRATION-FU,
 // HandlerMethod is "Handle" + PascalCase(domainLastSegment).
@@ -612,9 +612,9 @@ func TestBuildContractSpec_Event_TopicAndHandlerMethod(t *testing.T) {
 	t.Parallel()
 	root, p := setupEventRoot(t)
 
-	spec, err := BuildContractSpec(root, p, "event.item-created.v1")
+	spec, err := buildContractSpec(root, p, "event.item-created.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Event == nil {
 		t.Fatal("expected Event spec to be populated for kind=event")
@@ -673,9 +673,9 @@ func TestBuildHTTPEndpointSpec_AuthBootstrap_FieldPropagated(t *testing.T) {
 		File: "contracts/http/auth/setup/admin/v1/contract.yaml",
 	}
 
-	spec, err := BuildContractSpec(root, p, bootstrapContractID)
+	spec, err := buildContractSpec(root, p, bootstrapContractID)
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Endpoint == nil {
 		t.Fatal("expected Endpoint spec to be populated for kind=http")
@@ -1199,7 +1199,7 @@ func TestCollectAndValidateStatuses(t *testing.T) {
 
 // TestContractIDToKebab verifies that contractIDToKebab converts contract IDs to
 // kebab-case by replacing all dots with dashes. The function is the single source
-// used by BuildContractSpec to pre-compute all panicregister.Approved reason literals.
+// used by buildContractSpec to pre-compute all panicregister.Approved reason literals.
 func TestContractIDToKebab(t *testing.T) {
 	cases := []struct {
 		name string

--- a/tools/codegen/contractgen/builder_test.go
+++ b/tools/codegen/contractgen/builder_test.go
@@ -635,7 +635,7 @@ func TestBuildContractSpec_Event_TopicAndHandlerMethod(t *testing.T) {
 // --- Auth.Bootstrap closed-set extension tests (Batch 0 RED, SEC-SETUP-CLOSURE) ---
 
 // TestBuildHTTPEndpointSpec_AuthBootstrap_FieldPropagated verifies that
-// contract.yaml auth.bootstrap:true is correctly propagated to HTTPEndpointSpec.AuthBootstrap.
+// contract.yaml auth.bootstrap:true is correctly propagated to httpEndpointSpec.AuthBootstrap.
 // This test is RED until Batch 1 / Agent-A integrates auth.bootstrap into the real setup
 // contract and the template renders it. The field propagation through buildHTTPEndpointSpec
 // is already GREEN from the schema extension in Batch 0.

--- a/tools/codegen/contractgen/doc.go
+++ b/tools/codegen/contractgen/doc.go
@@ -135,6 +135,10 @@
 //     the codegen.Render plumbing).
 //   - tools/archtest/handler_inline_limit_parse_test.go — HANDLER-NO-INLINE-
 //     LIMIT-PARSE-01, regression gate against per-param limit parsing.
+//   - tools/archtest/codegen_http_handler_funnel_test.go —
+//     CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01: HTTP codegen funnel
+//     integrity (sealed httpEndpointSpec type + sole constructor/caller +
+//     handler.tmpl http.Handler emit-uniqueness across tools/codegen/**).
 //   - kernel/governance/rules_http.go — CH-04 (handler-emitted status ⊂
 //     contract.yaml.responses[] ∪ auth.responses), CH-05 (uuid path-param
 //     parse-call presence), CH-06 (contract.yaml.responses[] ∪ successStatus

--- a/tools/codegen/contractgen/doc.go
+++ b/tools/codegen/contractgen/doc.go
@@ -4,7 +4,7 @@
 //
 // # Pipeline
 //
-// BuildContractSpec parses the contract metadata + schemaRefs into a
+// buildContractSpec parses the contract metadata + schemaRefs into a
 // *ContractGenSpec (spec.go); the spec is then handed to one or more
 // templates registered in templates/ via render.go. Each output file lives
 // under generated/contracts/<segments>/ where the segments mirror the

--- a/tools/codegen/contractgen/generator.go
+++ b/tools/codegen/contractgen/generator.go
@@ -51,7 +51,7 @@ type CodegenArtifact struct {
 	Content []byte
 }
 
-// Generate orchestrates BuildContractSpec → render → write for one or all
+// Generate orchestrates buildContractSpec → render → write for one or all
 // opted-in metadata.
 // root is the repository root (absolute path; from which go.mod is read for
 // module path).
@@ -98,7 +98,7 @@ func generateOneContract(root string, p *metadata.ProjectMeta, contractID string
 		return fmt.Errorf("contract %q: id contains illegal path characters", contractID)
 	}
 
-	spec, err := BuildContractSpec(root, p, contractID)
+	spec, err := buildContractSpec(root, p, contractID)
 	if err != nil {
 		// B.6: wrap error with contract ID context.
 		return fmt.Errorf("contract %q: %w", contractID, err)
@@ -208,7 +208,7 @@ func RenderContractArtifacts(root string, p *metadata.ProjectMeta, contractID st
 		return nil, nil
 	}
 
-	spec, err := BuildContractSpec(root, p, contractID)
+	spec, err := buildContractSpec(root, p, contractID)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/codegen/contractgen/generator_test.go
+++ b/tools/codegen/contractgen/generator_test.go
@@ -79,7 +79,7 @@ func synthEventFixture(t *testing.T) string {
 
 // setupHTTPMinimalRoot copies the synth_http_minimal fixture into a fresh
 // t.TempDir(), adds a go.mod, parses it, and returns (root, project).
-// Schema paths in the ProjectMeta are relative to root, so BuildContractSpec
+// Schema paths in the ProjectMeta are relative to root, so buildContractSpec
 // and codegen.Write both use the same root. Generated files land in
 // root/generated/... and do not pollute committed testdata.
 func setupHTTPMinimalRoot(t *testing.T) (string, *metadata.ProjectMeta) {
@@ -433,10 +433,10 @@ func TestGenerate_EmptyRoot(t *testing.T) {
 	}
 }
 
-// TestGenerate_BuildSpecError verifies that BuildContractSpec errors propagate.
+// TestGenerate_BuildSpecError verifies that buildContractSpec errors propagate.
 func TestGenerate_BuildSpecError(t *testing.T) {
 	t.Parallel()
-	// kind=event with missing payload schemaRef will fail BuildContractSpec.
+	// kind=event with missing payload schemaRef will fail buildContractSpec.
 	p := &metadata.ProjectMeta{
 		Contracts: map[string]*metadata.ContractMeta{
 			"event.broken.v1": {
@@ -449,7 +449,7 @@ func TestGenerate_BuildSpecError(t *testing.T) {
 	}
 	_, err := Generate(t.TempDir(), p, Options{Scope: ScopeAll{}})
 	if err == nil {
-		t.Fatal("expected error propagated from BuildContractSpec")
+		t.Fatal("expected error propagated from buildContractSpec")
 	}
 }
 
@@ -715,9 +715,9 @@ func TestGenerate_PackageNameKeywordSanitize(t *testing.T) {
 	root, p := setupKeywordConflictRoot(t)
 
 	// Verify the package name is "configdelete" and not the keyword "delete".
-	spec, err := BuildContractSpec(root, p, "http.config.delete.v1")
+	spec, err := buildContractSpec(root, p, "http.config.delete.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.PackageName != "configdelete" {
 		t.Errorf("PackageName = %q, want configdelete", spec.PackageName)

--- a/tools/codegen/contractgen/render.go
+++ b/tools/codegen/contractgen/render.go
@@ -2,7 +2,6 @@ package contractgen
 
 import (
 	"embed"
-	"fmt"
 	"strconv"
 	"text/template"
 
@@ -115,86 +114,8 @@ func needsStrconv(spec *ContractGenSpec) bool {
 	return false
 }
 
-// RenderTypes renders types_gen.go content for the given spec.
-// Returns formatted, goimports-processed bytes.
-func RenderTypes(spec *ContractGenSpec, filename string) ([]byte, error) {
-	b, err := codegen.Render(codegen.RenderOptions{
-		TemplateName: "types.tmpl",
-		Templates:    templates,
-		Data:         spec,
-		Filename:     filename,
-	})
-	if err != nil {
-		return b, fmt.Errorf("contractgen render types: %w", err)
-	}
-	return b, nil
-}
-
-// RenderIface renders iface_gen.go content for the given spec.
-// Returns formatted, goimports-processed bytes.
-func RenderIface(spec *ContractGenSpec, filename string) ([]byte, error) {
-	b, err := codegen.Render(codegen.RenderOptions{
-		TemplateName: "iface.tmpl",
-		Templates:    templates,
-		Data:         spec,
-		Filename:     filename,
-	})
-	if err != nil {
-		return b, fmt.Errorf("contractgen render iface: %w", err)
-	}
-	return b, nil
-}
-
-// RenderHandler renders handler_gen.go content for the given spec.
-// Only valid for kind=http metadata. Returns an error for event metadata.
-func RenderHandler(spec *ContractGenSpec, filename string) ([]byte, error) {
-	if spec.Kind != "http" {
-		return nil, fmt.Errorf("contractgen render handler: contract %q is kind=%q, not http", spec.ContractID, spec.Kind)
-	}
-	b, err := codegen.Render(codegen.RenderOptions{
-		TemplateName: "handler.tmpl",
-		Templates:    templates,
-		Data:         spec,
-		Filename:     filename,
-	})
-	if err != nil {
-		return b, fmt.Errorf("contractgen render handler: %w", err)
-	}
-	return b, nil
-}
-
-// RenderSpec renders spec_gen.go content for the given spec.
-// Only valid for kind=event contracts. Returns an error for non-event contracts.
-func RenderSpec(spec *ContractGenSpec, filename string) ([]byte, error) {
-	if spec.Kind != "event" {
-		return nil, fmt.Errorf("contractgen render spec: contract %q is kind=%q, not event", spec.ContractID, spec.Kind)
-	}
-	b, err := codegen.Render(codegen.RenderOptions{
-		TemplateName: "spec.tmpl",
-		Templates:    templates,
-		Data:         spec,
-		Filename:     filename,
-	})
-	if err != nil {
-		return b, fmt.Errorf("contractgen render spec: %w", err)
-	}
-	return b, nil
-}
-
-// RenderSubscription renders subscription_gen.go content for the given spec.
-// Only valid for kind=event contracts. Returns an error for non-event contracts.
-func RenderSubscription(spec *ContractGenSpec, filename string) ([]byte, error) {
-	if spec.Kind != "event" {
-		return nil, fmt.Errorf("contractgen render subscription: contract %q is kind=%q, not event", spec.ContractID, spec.Kind)
-	}
-	b, err := codegen.Render(codegen.RenderOptions{
-		TemplateName: "subscription.tmpl",
-		Templates:    templates,
-		Data:         spec,
-		Filename:     filename,
-	})
-	if err != nil {
-		return b, fmt.Errorf("contractgen render subscription: %w", err)
-	}
-	return b, nil
-}
+// Per-template rendering for production goes through Generate /
+// RenderContractArtifacts (generator.go), which call codegen.Render directly.
+// The per-artifact render wrappers used to live here but were only ever called
+// from tests; they now live in render_test.go as test helpers (their sole
+// remaining use), so render.go carries no test-only surface.

--- a/tools/codegen/contractgen/render.go
+++ b/tools/codegen/contractgen/render.go
@@ -23,7 +23,7 @@ var templates = func() *template.Template {
 		// Used to embed the request schema JSON constant safely.
 		"quoteGoString": strconv.Quote,
 		// hasPathParams reports whether the endpoint has path parameters.
-		"hasPathParams": func(ep *HTTPEndpointSpec) bool {
+		"hasPathParams": func(ep *httpEndpointSpec) bool {
 			return ep != nil && len(ep.PathParams) > 0
 		},
 		// hasQueryNumeric reports whether any query param requires strconv parsing.

--- a/tools/codegen/contractgen/render_test.go
+++ b/tools/codegen/contractgen/render_test.go
@@ -993,28 +993,28 @@ func TestNeedsStrconv(t *testing.T) {
 	}{
 		{"nil spec", nil, false},
 		{"nil endpoint", &ContractGenSpec{}, false},
-		{"non-pagination string-only", &ContractGenSpec{Endpoint: &HTTPEndpointSpec{
+		{"non-pagination string-only", &ContractGenSpec{Endpoint: &httpEndpointSpec{
 			QueryParams: []ParamSpec{{Name: "name", GoType: "string"}},
 		}}, false},
-		{"non-pagination int64", &ContractGenSpec{Endpoint: &HTTPEndpointSpec{
+		{"non-pagination int64", &ContractGenSpec{Endpoint: &httpEndpointSpec{
 			QueryParams: []ParamSpec{{Name: "page", GoType: "int64"}},
 		}}, true},
-		{"pagination no extras", &ContractGenSpec{Endpoint: &HTTPEndpointSpec{
+		{"pagination no extras", &ContractGenSpec{Endpoint: &httpEndpointSpec{
 			Pagination: &PaginationShape{HasCursor: true, HasLimit: true},
 		}}, false},
-		{"pagination with int64 extra", &ContractGenSpec{Endpoint: &HTTPEndpointSpec{
+		{"pagination with int64 extra", &ContractGenSpec{Endpoint: &httpEndpointSpec{
 			Pagination: &PaginationShape{
 				HasCursor: true, HasLimit: true,
 				ExtraQueryParams: []ParamSpec{{Name: "since", GoType: "int64"}},
 			},
 		}}, true},
-		{"pagination with bool extra", &ContractGenSpec{Endpoint: &HTTPEndpointSpec{
+		{"pagination with bool extra", &ContractGenSpec{Endpoint: &httpEndpointSpec{
 			Pagination: &PaginationShape{
 				HasCursor: true, HasLimit: true,
 				ExtraQueryParams: []ParamSpec{{Name: "active", GoType: "bool"}},
 			},
 		}}, true},
-		{"pagination with string-only extras", &ContractGenSpec{Endpoint: &HTTPEndpointSpec{
+		{"pagination with string-only extras", &ContractGenSpec{Endpoint: &httpEndpointSpec{
 			Pagination: &PaginationShape{
 				HasCursor: true, HasLimit: true,
 				ExtraQueryParams: []ParamSpec{{Name: "tag", GoType: "string"}},

--- a/tools/codegen/contractgen/render_test.go
+++ b/tools/codegen/contractgen/render_test.go
@@ -11,7 +11,75 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/testutil/fileutil"
+	"github.com/ghbvf/gocell/tools/codegen"
 )
+
+// renderTypes / renderIface / renderHandler / renderSpec / renderSubscription
+// are test-only wrappers over codegen.Render for one contractgen artifact.
+// Production rendering goes through Generate / RenderContractArtifacts
+// (generator.go), which call codegen.Render directly; these helpers let the
+// per-template unit + golden tests render a single artifact in isolation and
+// exercise the kind-gating guards. Filename is fixed to "/dev/null" (rendering
+// to memory — goimports path-aware import resolution disabled), matching the
+// committed goldens.
+func renderTypes(spec *ContractGenSpec) ([]byte, error) {
+	b, err := codegen.Render(codegen.RenderOptions{
+		TemplateName: "types.tmpl", Templates: templates, Data: spec, Filename: "/dev/null",
+	})
+	if err != nil {
+		return b, fmt.Errorf("contractgen render types: %w", err)
+	}
+	return b, nil
+}
+
+func renderIface(spec *ContractGenSpec) ([]byte, error) {
+	b, err := codegen.Render(codegen.RenderOptions{
+		TemplateName: "iface.tmpl", Templates: templates, Data: spec, Filename: "/dev/null",
+	})
+	if err != nil {
+		return b, fmt.Errorf("contractgen render iface: %w", err)
+	}
+	return b, nil
+}
+
+func renderHandler(spec *ContractGenSpec) ([]byte, error) {
+	if spec.Kind != "http" {
+		return nil, fmt.Errorf("contractgen render handler: contract %q is kind=%q, not http", spec.ContractID, spec.Kind)
+	}
+	b, err := codegen.Render(codegen.RenderOptions{
+		TemplateName: "handler.tmpl", Templates: templates, Data: spec, Filename: "/dev/null",
+	})
+	if err != nil {
+		return b, fmt.Errorf("contractgen render handler: %w", err)
+	}
+	return b, nil
+}
+
+func renderSpec(spec *ContractGenSpec) ([]byte, error) {
+	if spec.Kind != "event" {
+		return nil, fmt.Errorf("contractgen render spec: contract %q is kind=%q, not event", spec.ContractID, spec.Kind)
+	}
+	b, err := codegen.Render(codegen.RenderOptions{
+		TemplateName: "spec.tmpl", Templates: templates, Data: spec, Filename: "/dev/null",
+	})
+	if err != nil {
+		return b, fmt.Errorf("contractgen render spec: %w", err)
+	}
+	return b, nil
+}
+
+func renderSubscription(spec *ContractGenSpec) ([]byte, error) {
+	if spec.Kind != "event" {
+		return nil, fmt.Errorf("contractgen render subscription: contract %q is kind=%q, not event", spec.ContractID, spec.Kind)
+	}
+	b, err := codegen.Render(codegen.RenderOptions{
+		TemplateName: "subscription.tmpl", Templates: templates, Data: spec, Filename: "/dev/null",
+	})
+	if err != nil {
+		return b, fmt.Errorf("contractgen render subscription: %w", err)
+	}
+	return b, nil
+}
 
 // update flag: run with -update to regenerate golden files.
 var updateGolden = flag.Bool("update", false, "update golden files")
@@ -40,7 +108,7 @@ func repoRoot(t *testing.T) string {
 // goldenDir is the path to the golden files relative to the package.
 const goldenDir = "testdata/golden"
 
-// TestBuildContractSpec_HTTP_OrderCreate tests BuildContractSpec for the
+// TestBuildContractSpec_HTTP_OrderCreate tests buildContractSpec for the
 // todoorder ordercreate HTTP contract (POST, body, no path/query params).
 func TestBuildContractSpec_HTTP_OrderCreate(t *testing.T) {
 	root := repoRoot(t)
@@ -48,9 +116,9 @@ func TestBuildContractSpec_HTTP_OrderCreate(t *testing.T) {
 	// Set codegen=true for this contract.
 	p.Contracts["http.order.create.v1"].Codegen = true
 
-	spec, err := BuildContractSpec(root, p, "http.order.create.v1")
+	spec, err := buildContractSpec(root, p, "http.order.create.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Kind != "http" {
 		t.Errorf("Kind = %q, want http", spec.Kind)
@@ -88,9 +156,9 @@ func TestBuildContractSpec_HTTP_OrderGet(t *testing.T) {
 	p := loadTodoorderProject(t, root)
 	p.Contracts["http.order.get.v1"].Codegen = true
 
-	spec, err := BuildContractSpec(root, p, "http.order.get.v1")
+	spec, err := buildContractSpec(root, p, "http.order.get.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Endpoint.Method != "GET" {
 		t.Errorf("Method = %q, want GET", spec.Endpoint.Method)
@@ -123,9 +191,9 @@ func TestBuildContractSpec_HTTP_OrderList(t *testing.T) {
 	p := loadTodoorderProject(t, root)
 	p.Contracts["http.order.list.v1"].Codegen = true
 
-	spec, err := BuildContractSpec(root, p, "http.order.list.v1")
+	spec, err := buildContractSpec(root, p, "http.order.list.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Endpoint.HandlerMethod != "List" {
 		t.Errorf("HandlerMethod = %q, want List", spec.Endpoint.HandlerMethod)
@@ -163,9 +231,9 @@ func TestBuildContractSpec_Event_OrderCreated(t *testing.T) {
 	p := loadTodoorderProject(t, root)
 	p.Contracts["event.order-created.v1"].Codegen = true
 
-	spec, err := BuildContractSpec(root, p, "event.order-created.v1")
+	spec, err := buildContractSpec(root, p, "event.order-created.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Kind != "event" {
 		t.Errorf("Kind = %q, want event", spec.Kind)
@@ -198,7 +266,7 @@ func TestBuildContractSpec_Event_OrderCreated(t *testing.T) {
 func TestBuildContractSpec_ContractNotFound(t *testing.T) {
 	root := repoRoot(t)
 	p := loadTodoorderProject(t, root)
-	_, err := BuildContractSpec(root, p, "http.does.not.exist.v1")
+	_, err := buildContractSpec(root, p, "http.does.not.exist.v1")
 	if err == nil {
 		t.Fatal("expected error for missing contract")
 	}
@@ -220,7 +288,7 @@ func TestBuildContractSpec_CodegenFalse(t *testing.T) {
 		},
 	}
 	root := findRepoRoot()
-	_, err := BuildContractSpec(root, p, "http.synth.nocodegen.v1")
+	_, err := buildContractSpec(root, p, "http.synth.nocodegen.v1")
 	if err == nil {
 		t.Fatal("expected error for codegen=false")
 	}
@@ -242,7 +310,7 @@ func TestBuildContractSpec_MissingHTTPEndpoint(t *testing.T) {
 		},
 	}
 	root := findRepoRoot()
-	_, err := BuildContractSpec(root, p, "http.foo.bar.v1")
+	_, err := buildContractSpec(root, p, "http.foo.bar.v1")
 	if err == nil {
 		t.Fatal("expected error for missing http endpoint")
 	}
@@ -261,7 +329,7 @@ func TestBuildContractSpec_MissingPayloadRef(t *testing.T) {
 		},
 	}
 	root := findRepoRoot()
-	_, err := BuildContractSpec(root, p, "event.foo.bar.v1")
+	_, err := buildContractSpec(root, p, "event.foo.bar.v1")
 	if err == nil {
 		t.Fatal("expected error for missing payload schemaRef")
 	}
@@ -281,9 +349,9 @@ func TestBuildContractSpec_CommandKind_GracefulSkip(t *testing.T) {
 		},
 	}
 	root := findRepoRoot()
-	spec, err := BuildContractSpec(root, p, "command.foo.bar.v1")
+	spec, err := buildContractSpec(root, p, "command.foo.bar.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec should not error for kind=command (graceful skip), got: %v", err)
+		t.Fatalf("buildContractSpec should not error for kind=command (graceful skip), got: %v", err)
 	}
 	if spec == nil || spec.Kind != "command" {
 		t.Errorf("expected spec with Kind=command, got: %v", spec)
@@ -310,7 +378,7 @@ func TestBuildContractSpec_TrulyUnsupportedKind(t *testing.T) {
 		},
 	}
 	root := findRepoRoot()
-	_, err := BuildContractSpec(root, p, "workflow.foo.bar.v1")
+	_, err := buildContractSpec(root, p, "workflow.foo.bar.v1")
 	if err == nil {
 		t.Fatal("expected error for truly unsupported kind")
 	}
@@ -318,7 +386,7 @@ func TestBuildContractSpec_TrulyUnsupportedKind(t *testing.T) {
 
 // --- Golden file tests ---
 
-// TestRender_Golden runs BuildContractSpec + render for the 4 real todoorder
+// TestRender_Golden runs buildContractSpec + render for the 4 real todoorder
 // contracts and compares the output to golden files.
 // Run with -update to regenerate golden files.
 func TestRender_Golden(t *testing.T) {
@@ -346,9 +414,9 @@ func TestRender_Golden(t *testing.T) {
 			contract.Codegen = true
 			defer func() { contract.Codegen = false }()
 
-			spec, err := BuildContractSpec(root, p, tc.contractID)
+			spec, err := buildContractSpec(root, p, tc.contractID)
 			if err != nil {
-				t.Fatalf("BuildContractSpec(%q): %v", tc.contractID, err)
+				t.Fatalf("buildContractSpec(%q): %v", tc.contractID, err)
 			}
 
 			for _, outFile := range tc.outputs {
@@ -388,9 +456,9 @@ func TestRender_Golden_Synth_HTTPMinimal(t *testing.T) {
 	outputs := []string{"types_gen.go", "iface_gen.go", "handler_gen.go"}
 	for _, outFile := range outputs {
 		t.Run(outFile, func(t *testing.T) {
-			spec, err := BuildContractSpec(absTestDir, p, "http.order.ping.v1")
+			spec, err := buildContractSpec(absTestDir, p, "http.order.ping.v1")
 			if err != nil {
-				t.Fatalf("BuildContractSpec: %v", err)
+				t.Fatalf("buildContractSpec: %v", err)
 			}
 			content := renderFile(t, spec, outFile)
 			goldenFile := goldenFilePath("synth_http_minimal", outFile)
@@ -425,9 +493,9 @@ func TestRender_Golden_Synth_HTTPFull(t *testing.T) {
 	outputs := []string{"types_gen.go", "iface_gen.go", "handler_gen.go"}
 	for _, outFile := range outputs {
 		t.Run(outFile, func(t *testing.T) {
-			spec, err := BuildContractSpec(absTestDir, p, "http.item.details.v1")
+			spec, err := buildContractSpec(absTestDir, p, "http.item.details.v1")
 			if err != nil {
-				t.Fatalf("BuildContractSpec: %v", err)
+				t.Fatalf("buildContractSpec: %v", err)
 			}
 			content := renderFile(t, spec, outFile)
 			goldenFile := goldenFilePath("synth_http_full", outFile)
@@ -484,9 +552,9 @@ func TestRender_Golden_Synth_HTTPAuthModes(t *testing.T) {
 			if contract == nil {
 				t.Fatalf("%s not found in synth fixture", tc.contractID)
 			}
-			spec, err := BuildContractSpec(absTestDir, p, tc.contractID)
+			spec, err := buildContractSpec(absTestDir, p, tc.contractID)
 			if err != nil {
-				t.Fatalf("BuildContractSpec: %v", err)
+				t.Fatalf("buildContractSpec: %v", err)
 			}
 			for _, outFile := range outputs {
 				t.Run(outFile, func(t *testing.T) {
@@ -525,9 +593,9 @@ func TestRender_Golden_Synth_Event(t *testing.T) {
 	outputs := []string{"types_gen.go", "iface_gen.go", "spec_gen.go", "subscription_gen.go"}
 	for _, outFile := range outputs {
 		t.Run(outFile, func(t *testing.T) {
-			spec, err := BuildContractSpec(absTestDir, p, "event.item-created.v1")
+			spec, err := buildContractSpec(absTestDir, p, "event.item-created.v1")
 			if err != nil {
-				t.Fatalf("BuildContractSpec: %v", err)
+				t.Fatalf("buildContractSpec: %v", err)
 			}
 			content := renderFile(t, spec, outFile)
 			goldenFile := goldenFilePath("synth_event", outFile)
@@ -581,15 +649,15 @@ func renderFile(t *testing.T, spec *ContractGenSpec, outFile string) []byte {
 	)
 	switch outFile {
 	case "types_gen.go":
-		content, err = RenderTypes(spec, "/dev/null")
+		content, err = renderTypes(spec)
 	case "iface_gen.go":
-		content, err = RenderIface(spec, "/dev/null")
+		content, err = renderIface(spec)
 	case "handler_gen.go":
-		content, err = RenderHandler(spec, "/dev/null")
+		content, err = renderHandler(spec)
 	case "spec_gen.go":
-		content, err = RenderSpec(spec, "/dev/null")
+		content, err = renderSpec(spec)
 	case "subscription_gen.go":
-		content, err = RenderSubscription(spec, "/dev/null")
+		content, err = renderSubscription(spec)
 	default:
 		t.Fatalf("unknown output file: %s", outFile)
 	}
@@ -674,9 +742,9 @@ func TestRender_Golden_Synth_KeywordConflict(t *testing.T) {
 	outputs := []string{"types_gen.go", "iface_gen.go", "handler_gen.go"}
 	for _, outFile := range outputs {
 		t.Run(outFile, func(t *testing.T) {
-			spec, err := BuildContractSpec(absTestDir, p, "http.config.delete.v1")
+			spec, err := buildContractSpec(absTestDir, p, "http.config.delete.v1")
 			if err != nil {
-				t.Fatalf("BuildContractSpec: %v", err)
+				t.Fatalf("buildContractSpec: %v", err)
 			}
 			// Verify keyword sanitization.
 			if spec.PackageName != "configdelete" {
@@ -694,7 +762,7 @@ func TestRender_Golden_Synth_KeywordConflict(t *testing.T) {
 	}
 }
 
-// --- A.9: BuildContractSpec integration tests using synth fixtures ---
+// --- A.9: buildContractSpec integration tests using synth fixtures ---
 
 // TestBuildContractSpec_HTTP uses the synth_http_full fixture to verify
 // Endpoint.Method, SuccessCode, path params, and DTOs.
@@ -710,9 +778,9 @@ func TestBuildContractSpec_HTTP(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	spec, err := BuildContractSpec(absTestDir, p, "http.item.details.v1")
+	spec, err := buildContractSpec(absTestDir, p, "http.item.details.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Endpoint == nil {
 		t.Fatal("Endpoint is nil")
@@ -754,9 +822,9 @@ func TestBuildContractSpec_Event(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	spec, err := BuildContractSpec(absTestDir, p, "event.item-created.v1")
+	spec, err := buildContractSpec(absTestDir, p, "event.item-created.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 	if spec.Event == nil {
 		t.Fatal("Event is nil")
@@ -808,14 +876,14 @@ func TestSpecGenIsPackagePrivate(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	spec, err := BuildContractSpec(absTestDir, p, "event.item-created.v1")
+	spec, err := buildContractSpec(absTestDir, p, "event.item-created.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 
-	content, err := RenderSpec(spec, "/dev/null")
+	content, err := renderSpec(spec)
 	if err != nil {
-		t.Fatalf("RenderSpec: %v", err)
+		t.Fatalf("renderSpec: %v", err)
 	}
 	got := string(content)
 
@@ -842,14 +910,14 @@ func TestSubscriptionMountCallsRegistrySubscribe(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	spec, err := BuildContractSpec(absTestDir, p, "event.item-created.v1")
+	spec, err := buildContractSpec(absTestDir, p, "event.item-created.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 
-	content, err := RenderSubscription(spec, "/dev/null")
+	content, err := renderSubscription(spec)
 	if err != nil {
-		t.Fatalf("RenderSubscription: %v", err)
+		t.Fatalf("renderSubscription: %v", err)
 	}
 	got := string(content)
 
@@ -883,14 +951,14 @@ func TestNewSubscriptionFourArgSignature(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	spec, err := BuildContractSpec(absTestDir, p, "event.item-created.v1")
+	spec, err := buildContractSpec(absTestDir, p, "event.item-created.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 
-	content, err := RenderSubscription(spec, "/dev/null")
+	content, err := renderSubscription(spec)
 	if err != nil {
-		t.Fatalf("RenderSubscription: %v", err)
+		t.Fatalf("renderSubscription: %v", err)
 	}
 	got := string(content)
 
@@ -906,7 +974,7 @@ func TestNewSubscriptionFourArgSignature(t *testing.T) {
 	}
 }
 
-// TestRenderSpec_RejectsHTTPContract verifies that RenderSpec returns an error
+// TestRenderSpec_RejectsHTTPContract verifies that renderSpec returns an error
 // when the contract is kind=http.
 func TestRenderSpec_RejectsHTTPContract(t *testing.T) {
 	t.Parallel()
@@ -914,22 +982,22 @@ func TestRenderSpec_RejectsHTTPContract(t *testing.T) {
 	p := loadTodoorderProject(t, root)
 	p.Contracts["http.order.create.v1"].Codegen = true
 
-	spec, err := BuildContractSpec(root, p, "http.order.create.v1")
+	spec, err := buildContractSpec(root, p, "http.order.create.v1")
 	if err != nil {
-		t.Fatalf("BuildContractSpec: %v", err)
+		t.Fatalf("buildContractSpec: %v", err)
 	}
 
-	_, err = RenderSpec(spec, "/dev/null")
+	_, err = renderSpec(spec)
 	if err == nil {
-		t.Fatal("RenderSpec should reject kind=http contract")
+		t.Fatal("renderSpec should reject kind=http contract")
 	}
 	if !strings.Contains(err.Error(), "not event") {
 		t.Errorf("error should mention 'not event', got: %v", err)
 	}
 
-	_, err = RenderSubscription(spec, "/dev/null")
+	_, err = renderSubscription(spec)
 	if err == nil {
-		t.Fatal("RenderSubscription should reject kind=http contract")
+		t.Fatal("renderSubscription should reject kind=http contract")
 	}
 	if !strings.Contains(err.Error(), "not event") {
 		t.Errorf("error should mention 'not event', got: %v", err)

--- a/tools/codegen/contractgen/spec.go
+++ b/tools/codegen/contractgen/spec.go
@@ -18,8 +18,11 @@ type ContractGenSpec struct {
 	// DTOs holds the flattened list of Go struct definitions (nested types
 	// expanded to top-level entries). Template iterates this slice directly.
 	DTOs []DTOSpec
-	// Endpoint is non-nil when Kind == "http".
-	Endpoint *HTTPEndpointSpec
+	// Endpoint is non-nil when Kind == "http". Its type is the unexported
+	// httpEndpointSpec (sealed): no out-of-package code can construct a non-nil
+	// Endpoint, so a hand-built (FMT-34-unvalidated) HTTP spec cannot drive
+	// handler.tmpl from another package. See httpEndpointSpec's godoc.
+	Endpoint *httpEndpointSpec
 	// Event is non-nil when Kind == "event".
 	Event *EventEndpointSpec
 	// RequestSchemaJSON is the raw JSON content of the request schema file,
@@ -111,8 +114,18 @@ type DTOField struct {
 	Maximum *int64
 }
 
-// HTTPEndpointSpec holds HTTP-specific endpoint information.
-type HTTPEndpointSpec struct {
+// httpEndpointSpec holds HTTP-specific endpoint information.
+//
+// The type is unexported on purpose (sealed): its sole constructor is
+// buildHTTPEndpointSpec, which runs validateAuthOnInternalPath (the FMT-34
+// upstream guard) unconditionally. Because ContractGenSpec.Endpoint is
+// *httpEndpointSpec, no out-of-package code can build a non-nil Endpoint and
+// drive handler.tmpl with an FMT-34-unvalidated spec — the cross-package
+// bypass is not expressible. Fields stay exported because text/template reads
+// them via reflection. The intra-package "sole constructor / sole caller"
+// and the cross-generator emit-uniqueness invariants are locked by archtest
+// CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01.
+type httpEndpointSpec struct {
 	// Method is the HTTP method in upper-case, e.g. "POST".
 	Method string
 	// Path is the full URL path including chi-style placeholders, e.g. "/api/v1/orders/{id}".
@@ -186,7 +199,7 @@ type HTTPEndpointSpec struct {
 // pagination pattern. It is implemented as a method (not a field) so handler
 // templates can keep their existing `{{- if .Endpoint.IsPagination}}` form
 // while builder-side state moves to the structured *PaginationShape value.
-func (e *HTTPEndpointSpec) IsPagination() bool {
+func (e *httpEndpointSpec) IsPagination() bool {
 	return e != nil && e.Pagination != nil
 }
 

--- a/tools/codegen/contractgen/spec.go
+++ b/tools/codegen/contractgen/spec.go
@@ -20,8 +20,13 @@ type ContractGenSpec struct {
 	DTOs []DTOSpec
 	// Endpoint is non-nil when Kind == "http". Its type is the unexported
 	// httpEndpointSpec (sealed): no out-of-package code can construct a non-nil
-	// Endpoint, so a hand-built (FMT-34-unvalidated) HTTP spec cannot drive
-	// handler.tmpl from another package. See httpEndpointSpec's godoc.
+	// Endpoint. The whole ContractGenSpec is also never handed to another
+	// package as a mutable value — its sole constructor buildContractSpec and
+	// every render wrapper are package-private (only Generate /
+	// RenderContractArtifacts are exported, and those return rendered []byte,
+	// never the spec). So neither constructing nor mutating an
+	// FMT-34-unvalidated Endpoint to drive handler.tmpl is expressible from
+	// another package. See httpEndpointSpec's godoc.
 	Endpoint *httpEndpointSpec
 	// Event is non-nil when Kind == "event".
 	Event *EventEndpointSpec
@@ -83,7 +88,7 @@ type DTOSpec struct {
 	// Fields lists the struct fields in source-declared order.
 	Fields []DTOField
 	// Nested holds intermediate nested-object types discovered during schema
-	// traversal. Callers of BuildContractSpec see an empty slice — the builder
+	// traversal. Callers of buildContractSpec see an empty slice — the builder
 	// promotes nested types to ContractGenSpec.DTOs and clears this field.
 	Nested []DTOSpec
 }
@@ -119,12 +124,23 @@ type DTOField struct {
 // The type is unexported on purpose (sealed): its sole constructor is
 // buildHTTPEndpointSpec, which runs validateAuthOnInternalPath (the FMT-34
 // upstream guard) unconditionally. Because ContractGenSpec.Endpoint is
-// *httpEndpointSpec, no out-of-package code can build a non-nil Endpoint and
-// drive handler.tmpl with an FMT-34-unvalidated spec — the cross-package
-// bypass is not expressible. Fields stay exported because text/template reads
-// them via reflection. The intra-package "sole constructor / sole caller"
-// and the cross-generator emit-uniqueness invariants are locked by archtest
-// CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01.
+// *httpEndpointSpec, no out-of-package code can build a non-nil Endpoint.
+//
+// Fields stay exported because text/template reads them via reflection, so a
+// holder of a *httpEndpointSpec could otherwise mutate Path / AuthPublic /
+// Clients after construction (after FMT-34 already ran) and drive handler.tmpl
+// with the mutated, unvalidated spec. That mutation path is closed not by the
+// field visibility but by the holder being unreachable cross-package: the spec
+// is produced only by the package-private buildContractSpec and consumed only
+// by the package-private render wrappers; the exported surface (Generate /
+// RenderContractArtifacts) returns rendered []byte and never the spec. So
+// neither construction nor post-construction mutation of an
+// FMT-34-unvalidated Endpoint is expressible from another package.
+//
+// The intra-package "sole constructor / sole caller", the cross-generator
+// emit-uniqueness, and the "no exported API leaks the mutable spec" invariants
+// are locked by archtest CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01
+// (A1b / A2 / A3 / A4 respectively).
 type httpEndpointSpec struct {
 	// Method is the HTTP method in upper-case, e.g. "POST".
 	Method string


### PR DESCRIPTION
## Summary

锁定「所有 HTTP-handler-emitting codegen 路径必经 `buildHTTPEndpointSpec` funnel」，使 FMT-34 上游 Hard 论证不再依赖 grep 断言。用户裁定：现在就做 Hard 收口 + A1+A2+A3 全闭环。

**Hard 收口（编译期，跨包）**：`HTTPEndpointSpec` → unexport `httpEndpointSpec`。`ContractGenSpec.Endpoint` 字段类型变私有 → 外部包无法构造非 nil Endpoint → 无法用 FMT-34-未校验的 spec 驱动 `handler.tmpl`。已反证：外部引用 `cg.HTTPEndpointSpec` 编译失败 `undefined`。字段保持 exported（template reflection），**生成产物 byte-identical**（goldens + generatedverify 不变）。

**archtest 闭环（类型系统天花板兜底）**：新建 `CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01`
- **A1a**：`ContractGenSpec.Endpoint` 基类型必为 sealed 未导出名 + 无 exported alias re-export（锁住密封本身）。
- **A1b**：包内 `httpEndpointSpec{}` 仅在 `buildHTTPEndpointSpec` 构造；ctor 仅被 `buildHTTPSpec` 调用。
- **A2**：扫 `tools/codegen/**` 所有 `.tmpl`+`.go`，含 `ServeHTTP(_ http.ResponseWriter` 标记的文件集 == `{handler.tmpl}`（deny-by-default）。
- **A3**：`"handler.tmpl"` 渲染引用仅在 contractgen 包内。
- 5 个 inline-parse 反向自检证明每个 detector 的检出/不误判。

## AI-robust 分档

| 项 | 形态 | 档位 | 天花板 |
|----|------|------|--------|
| 类型密封 | `httpEndpointSpec` unexport（跨包编译期不可表达） | **Hard** | — |
| A1a re-export 锁 | AST：基类型未导出 + 无 exported alias | Hard-adjacent | 锁住密封 |
| A1b 包内 sole ctor/caller | AST funcdecl-walk + 名匹配 | Medium | Go 无包内可见性 |
| A2 emit-uniqueness | `EachContentFile` + 语言强制 ServeHTTP 签名标记 | Medium | 文本发射不可类型密封 |
| A3 render-tie | AST 字符串字面量 | Medium | 同 A2 |

A1b/A2/A3 覆盖的残留是 Go 类型系统**固有天花板**（无更低成本 Hard 路径）→ **无遗留 Hard 化 backlog**，理由写进 archtest godoc（ai-robust.md §Review checklist「Medium 且无低成本升 Hard 路径 → 保留」）。

## Implementation matrix

```
Contract: contractgen.HTTPEndpointSpec (codegen 内部 spec 类型) — unexport 密封
Change: HTTPEndpointSpec → httpEndpointSpec; ContractGenSpec.Endpoint 字段类型私有化
Implementations: [x] contractgen (唯一持有者，零外部代码调用方)
Conformance test: archtest CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A1a/A1b/A2/A3)
Repro: go test ./tools/archtest/ -run 'TestCodegenBuildHTTPEndpointSpecSoleCaller|TestCodegenFunnel'
Dependent contracts (governance scan): FMT-34 (godoc 同步升级); 无 wire/schema 变更
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./tools/codegen/contractgen/` — golden 不变（密封不改生成文本）
- [x] `go test ./tools/codegen/... ./cmd/gocell/... ./tools/generatedverify/...` — 全部 importer + regenerate-verify 通过
- [x] `go test ./tools/archtest/` — 全量套件（含 meta-archtest）PASS（548s）
- [x] `go test ./kernel/governance/ -run FMT34` — FMT-34 不变
- [x] `golangci-lint run --new-from-merge-base=origin/develop` — 0 new issues
- [x] Wave 1 RED → Wave 2 GREEN（A1a/A1b 先红后绿）
- [x] Hard 密封反证：外部包引用 `cg.HTTPEndpointSpec` → 编译失败 `undefined`

ref: TNG/ArchUnit OnlyBeCalledSpecification（onlyBeCalled caller-allowlist 语义）
ref: zeromicro/go-zero tools/goctl/api/gogen/genhandlers.go（单入口纯靠约定——#690 要防的退化形态）

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)