### PR TITLE
build(deps): 锁定 gofumpt 防自动升级 + 抢救 #910 的 aws credentials 补丁

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,13 @@ updates:
           - "github.com/testcontainers/testcontainers-go*"
           - "go.opentelemetry.io/*"
           - "golang.org/x/*"
+    ignore:
+      # gofumpt 必须锁定在 pinned golangci-lint release 内 vendor 的版本
+      # （golangci-lint v2.11.4 vendors gofumpt v0.9.2）。go.mod 的 gofumpt
+      # 与 golangci-lint 内 vendor 的 gofumpt 版本一旦分裂，producer 侧
+      # （tools/codegen 调用 gofumpt.Source）与 CI formatter gate
+      # （golangci-lint 内 vendor 的同包）会对同一 diff 应用不同格式化规则
+      # → CI 必红 / codegen drift。仅当同步升级 golangci-lint 时才解锁
+      # （见 hack/lib/golangci-lint.sh 的 SYNC 契约）。PR #534 / #910 均因
+      # 自动升级到 v0.10.0 被回滚。
+      - dependency-name: "mvdan.cc/gofumpt"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.10
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.17
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/aws/smithy-go v1.25.1
 	github.com/coder/websocket v1.8.14

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6t
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
-github.com/aws/aws-sdk-go-v2/credentials v1.19.16 h1:r3RJBuU7X9ibt8RHbMjWE6y60QbKBiII6wSrXnapxSU=
-github.com/aws/aws-sdk-go-v2/credentials v1.19.16/go.mod h1:6cx7zqDENJDbBIIWX6P8s0h6hqHC8Avbjh9Dseo27ug=
+github.com/aws/aws-sdk-go-v2/credentials v1.19.17 h1:gP2nkGsS+KMvF/jfFz2Vv2qiiOqWKyPACSzPsqHgoW8=
+github.com/aws/aws-sdk-go-v2/credentials v1.19.17/go.mod h1:Bsew3S/moG5iT77giPj1q8wb/s0RE5/QfH+ASjYtuQc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=


### PR DESCRIPTION
## 背景

dependabot #910（go-other-modules group）打包了两个升级：

1. `mvdan.cc/gofumpt` v0.9.2 → **v0.10.0** ❌ — 必须丢弃
2. `aws-sdk-go-v2/credentials` v1.19.16 → v1.19.17 ✅ — 安全，本 PR 抢救落地

## 为什么 gofumpt 不能升

`hack/lib/golangci-lint.sh` 明确写了版本绑定契约：golangci-lint **v2.11.4 内部 vendor 的是 gofumpt v0.9.2**，`go.mod` 的 gofumpt 必须与之一致。一旦分裂：

- producer 侧 `tools/codegen` 调 `gofumpt.Source`（走 go.mod 的 v0.10.0）
- CI formatter gate 走 golangci-lint 内 vendor 的 v0.9.2

两者对同一 diff 应用**不同格式化规则** → `make verify` 的 gofumpt gate 必红 / codegen drift。`gofumpt` **不在** governance.yml 的 skip list，每次 PR 都会跑。

**PR #534 已经因为同样原因（go.mod 漂到 v0.10.0）回滚过一次**——这是已知陷阱的重演。要升 gofumpt 必须同步升级 golangci-lint 到 vendor v0.10.0 的版本，并在同 PR 内改 `GOLANGCI_LINT_VERSION` + `_build-lint.yml` 的 `version:` + 全仓库 `gofumpt -w`。

## 本 PR 改动

1. **`.github/dependabot.yml`**: gomod ecosystem 加 `ignore: mvdan.cc/gofumpt`，堵住自动升级缺口（这是 Soft enforcement 漏洞，dependabot 反复触发）。注释指向 golangci-lint.sh 的 SYNC 契约。
2. **`go.mod` / `go.sum`**: aws credentials v1.19.16 → v1.19.17（reviewer 确认仅 `adapters/s3/s3.go` 使用，patch 无 breaking change）。

> 注：diff 中 `go.sum` 的 crypto v0.52.0 是 develop 已合并的 #908 带入，非本 PR 改动。

## 验证

- `go mod verify` → all modules verified
- `go build ./...` → OK
- gofumpt 保持 v0.9.2（grep 确认）

## 后续

合并后关闭 **#910**（gofumpt 部分无法采纳，aws 部分已在此 PR 落地）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)