### PR TITLE
fix(archtest): replace equalStringSlices with stdlib slices.Equal to silence gosec G602

### DIFF
--- a/kernel/depgraph/closure_test.go
+++ b/kernel/depgraph/closure_test.go
@@ -1,6 +1,7 @@
 package depgraph_test
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -57,7 +58,7 @@ func TestTransitiveImports_DAG(t *testing.T) {
 	gotSlice := mapKeys(got)
 	sort.Strings(gotSlice)
 	sort.Strings(want)
-	if !equalStringSlices(gotSlice, want) {
+	if !slices.Equal(gotSlice, want) {
 		t.Errorf("TransitiveImports(a) = %v, want %v", gotSlice, want)
 	}
 }
@@ -149,7 +150,7 @@ func TestTransitiveImports_FreshCopy(t *testing.T) {
 	second := g.TransitiveImports(synthModClosure + "/a")
 	gotSlice := mapKeys(second)
 	sort.Strings(gotSlice)
-	if !equalStringSlices(gotSlice, snapshot) {
+	if !slices.Equal(gotSlice, snapshot) {
 		t.Errorf("second call returned %v, want %v (mutation of first leaked)", gotSlice, snapshot)
 	}
 	if second["bogus"] {
@@ -241,16 +242,4 @@ func mapKeys(m map[string]bool) []string {
 		out = append(out, k)
 	}
 	return out
-}
-
-func equalStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/tools/archtest/cell_iface_isp_invariants_test.go
+++ b/tools/archtest/cell_iface_isp_invariants_test.go
@@ -25,6 +25,7 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -76,7 +77,7 @@ func TestCellIfaceISP01_CellComposesFourSubInterfaces(t *testing.T) {
 	sort.Strings(want)
 	gotSorted := append([]string(nil), got...)
 	sort.Strings(gotSorted)
-	if !equalStringSlices(gotSorted, want) {
+	if !slices.Equal(gotSorted, want) {
 		t.Errorf("CELL-IFACE-ISP-COMPOSITE-01: Cell embedded sub-interfaces = %v, want exactly %v",
 			gotSorted, want)
 	}
@@ -102,7 +103,7 @@ func TestCellIfaceISP02_SubInterfaceMethodSets(t *testing.T) {
 			want := append([]string(nil), expectedSubInterfaceMethods[name]...)
 			sort.Strings(want)
 
-			if !equalStringSlices(gotMethods, want) {
+			if !slices.Equal(gotMethods, want) {
 				t.Errorf("CELL-IFACE-ISP-METHODSETS-01: %s methods = %v, want exactly %v",
 					name, gotMethods, want)
 			}
@@ -286,19 +287,6 @@ func targetsBaseCellNilPtr(values []ast.Expr) bool {
 		return false
 	}
 	return ident.Name == "BaseCell"
-}
-
-// equalStringSlices compares two sorted string slices for exact equality.
-func equalStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // expectedMethodSetsSHA256 freezes the (sub-interface → method-set) contract

--- a/tools/archtest/codegen_http_handler_funnel_test.go
+++ b/tools/archtest/codegen_http_handler_funnel_test.go
@@ -59,6 +59,7 @@ import (
 	"go/token"
 	"go/types"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -271,7 +272,7 @@ func TestCodegenBuildHTTPEndpointSpecSoleCaller_A2_HandlerEmitTemplateUniqueness
 	sort.Strings(emitFiles)
 
 	want := []string{codegenHandlerTmplRel}
-	if !equalStringSlices(emitFiles, want) {
+	if !slices.Equal(emitFiles, want) {
 		t.Errorf("CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01 (A2): files emitting an http.Handler "+
 			"(ServeHTTP method) under tools/codegen/** = %v; want exactly %v. A new HTTP-handler-emitting "+
 			"generator path must route through buildHTTPEndpointSpec (contractgen handler.tmpl), not a "+

--- a/tools/archtest/userrepo_method_set_frozen_test.go
+++ b/tools/archtest/userrepo_method_set_frozen_test.go
@@ -34,6 +34,7 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -97,7 +98,7 @@ func TestUserRepoMethodSetFrozen(t *testing.T) {
 	}
 	sort.Strings(wantNames)
 
-	if !equalStringSlices(gotNames, wantNames) {
+	if !slices.Equal(gotNames, wantNames) {
 		t.Errorf("USERREPO-METHOD-SET-FROZEN-01: method names = %v, want exactly %v",
 			gotNames, wantNames)
 		return
@@ -137,7 +138,7 @@ func TestUserRepoMethodSetFrozen_BlindSpotReverseSelfTest(t *testing.T) {
 	}
 	sort.Strings(want)
 
-	if equalStringSlices(siblingMethods, want) {
+	if slices.Equal(siblingMethods, want) {
 		t.Errorf("USERREPO-METHOD-SET-FROZEN-01 blind-spot reverse self-test: "+
 			"RoleRepository has the same method set as expectedUserRepoMethodSignatures (%v); "+
 			"loadInterfaceType cannot distinguish UserRepository from RoleRepository — "+


### PR DESCRIPTION
## Summary

- `equalStringSlices(a, b)` 先判 `len(a) != len(b)`, gosec G602 不跨控制流追踪该前置, 机械报 `a[i] != b[i]` 中 b[i] 越界 (false-positive)
- 改用 stdlib `slices.Equal` (Go 1.21+, 本仓 Go 1.25.10), 同语义、消除 hand-rolled helper + gosec 误报
- 3 个 archtest 文件、4 处 callsite + 删 helper 定义, 纯测试侧改动, 不动 production / 公开签名

## 背景

`equalStringSlices` 在仓里已久, 但 develop CI 直到 PR #904 / #905 才暴露 gosec G602 (`tools/archtest/cell_iface_isp_invariants_test.go:297`)。根因是 `golangci-lint-action` 命中持久化缓存 (PR #909 日志: `Cache hit ... a3f9e709f5cea...`), 之前的 push 全部走 cache hit 跳过实际扫描; PR #904 引入新文件触发缓存 invalidation, gosec 实际重跑暴露了旧 finding。属"触发显示"而非"引入"。

## Test plan

- [x] `golangci-lint run ./...` → 0 issues
- [x] `go vet ./...` clean
- [x] 受影响 archtest 全 PASS:
  - `TestCellIfaceISP00_MethodSetsHashGuard`
  - `TestCellIfaceISP01_CellComposesFourSubInterfaces`
  - `TestCellIfaceISP02_SubInterfaceMethodSets`
  - `TestCellIfaceISP03_BaseCellFourSegmentCheck`
  - `TestUserRepoMethodSetFrozen` + `_BlindSpotReverseSelfTest`
  - `TestCodegenBuildHTTPEndpointSpecSoleCaller_A1a/A1b/A2/A3/A4`

ref: pkg.go.dev/slices#Equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)